### PR TITLE
chore: add Drizzle Check DATABASE_URL source summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,14 +217,31 @@ jobs:
       - name: Configure DATABASE_URL env
         if: steps.check_changes.outputs.run_full_ci == 'true'
         run: |
+          SOURCE="none"
           if [[ -n "$NEON_URL" ]]; then
             echo "DATABASE_URL=$NEON_URL" >> $GITHUB_ENV
+            SOURCE="NEON_DATABASE_URL secret"
           elif [[ -n "$DB_URL" ]]; then
             echo "DATABASE_URL=$DB_URL" >> $GITHUB_ENV
+            SOURCE="DATABASE_URL secret"
           else
             echo "No DATABASE_URL secret configured." >&2
+            # Keep behavior: fail if Drizzle check is required but no DB URL available
+            echo "RESOLVED_DB_SOURCE=$SOURCE" >> $GITHUB_ENV
+            {
+              echo "### Drizzle Check: DATABASE_URL source"
+              echo ""
+              echo "- No DATABASE_URL resolved (likely fork PR or missing secrets)."
+            } >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
+
+          echo "RESOLVED_DB_SOURCE=$SOURCE" >> $GITHUB_ENV
+          {
+            echo "### Drizzle Check: DATABASE_URL source"
+            echo ""
+            echo "- Resolved from: $SOURCE"
+          } >> $GITHUB_STEP_SUMMARY
 
       - name: Install dependencies
         if: steps.check_changes.outputs.run_full_ci == 'true'


### PR DESCRIPTION
Goal: Improve observability of the Drizzle Check job without changing behavior.

Changes:
- ci.yml (`ci-drizzle-check` job): Enhance "Configure DATABASE_URL env" step to record the source used (NEON_DATABASE_URL vs DATABASE_URL) via an env var `RESOLVED_DB_SOURCE` and append a short non-secret note to `$GITHUB_STEP_SUMMARY`.
- Behavior preserved: still exits with error if required and no DB URL available; path guards and fallbacks unchanged.

Why:
- Clarifies whether DATABASE_URL came from Neon outputs or repository secrets.
- Helps triage fork PRs (no secrets) vs internal PRs quickly.

Test plan:
- Open this PR into `preview` to trigger CI; verify the Drizzle Check step summary shows the resolved source.
- Confirm job still skips when path guards detect no DB/schema changes or runs when relevant.

Rollback plan:
- Revert this PR or remove the summary lines if needed (no functional dependency changes).