### PR TITLE
chore: fast-preview-auto-promote

### DIFF
--- a/.github/rulesets/branch-protection.yml
+++ b/.github/rulesets/branch-protection.yml
@@ -17,6 +17,6 @@ rules:
     parameters:
       strict_required_status_checks_policy: true
       required_status_checks:
-        - context: 'pr-policy'
-        - context: 'ci-fast'
+        - context: 'CI / ci-fast'
+        - context: 'CI / PR Up-to-date with Preview'
 bypass_actors: []

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,7 +6,7 @@ name: Smart Auto-Merge
 on:
   pull_request_target:
     types: [opened, edited, synchronize, labeled, unlabeled, ready_for_review]
-    branches: [preview]
+    branches: [preview, production]
   check_suite:
     types: [completed]
   workflow_run:
@@ -27,11 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    # Only run for preview branch PRs
+    # Run for preview and production PRs; for other events we'll resolve PR and skip if needed
     if: >
-      (github.event.pull_request.base.ref == 'preview' || 
-       (github.event.workflow_run.head_branch != 'preview' && 
-        github.event.workflow_run.head_branch != 'production'))
+      (github.event_name == 'pull_request_target' && (github.event.pull_request.base.ref == 'preview' || github.event.pull_request.base.ref == 'production'))
+      || (github.event_name != 'pull_request_target')
 
     steps:
       - name: Get PR details
@@ -69,8 +68,8 @@ jobs:
               return { skip: true };
             }
 
-            if (pr.base.ref !== 'preview') {
-              core.info('PR is not targeting preview branch, skipping');
+            if (pr.base.ref !== 'preview' && pr.base.ref !== 'production') {
+              core.info('PR is not targeting preview or production branch, skipping');
               return { skip: true };
             }
 
@@ -84,9 +83,38 @@ jobs:
               mergeable_state: pr.mergeable_state,
               head_sha: pr.head.sha,
               head_ref: pr.head.ref,
+              base_ref: pr.base.ref,
               labels: pr.labels.map(l => l.name),
               auto_merge: pr.auto_merge !== null
             };
+
+      - name: Set wait pattern
+        id: set_wait
+        if: steps.get_pr.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = JSON.parse('${{ steps.get_pr.outputs.result }}');
+            const base = pr.base_ref;
+            let re;
+            if (base === 'production') {
+              // Full checks on production PRs
+              re = '^CI \/ (Build|Unit Tests|E2E Tests|Drizzle Check)$';
+            } else {
+              // Fast checks on preview PRs
+              re = '^CI \/ (ci-fast|PR Up-to-date with Preview)$';
+            }
+            core.setOutput('check_re', re);
+
+      - name: Set promotion flag
+        id: is_promotion
+        if: steps.get_pr.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = JSON.parse('${{ steps.get_pr.outputs.result }}');
+            const isPromotion = pr.base_ref === 'production' && pr.head_ref === 'preview';
+            core.setOutput('promotion', isPromotion ? 'true' : 'false');
 
       - name: Check if PR should be auto-merged
         id: should_merge
@@ -133,7 +161,12 @@ jobs:
             let prType = 'regular';
             let eligible = false;
 
-            if (pr.author === 'dependabot[bot]') {
+            // Promotion PR: preview -> production
+            if (pr.base.ref === 'production' && pr.head.ref === 'preview') {
+              prType = 'promotion';
+              // Manual promotion only — do not auto-merge production promotion PRs
+              eligible = false;
+            } else if (pr.author === 'dependabot[bot]') {
               prType = 'dependabot';
               // For dependabot, check if it's patch/minor or security update
               eligible = true; // We'll validate update type in next step
@@ -192,13 +225,13 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 15
           # Wait for all required checks from ruleset
-          check-regexp: (?i)^(CI \/ )?(pr-policy|ci-fast|PR Up-to-date with Preview)$
+          check-regexp: ${{ steps.set_wait.outputs.check_re }}
           allowed-conclusions: success,skipped
           timeout-minutes: 30
 
       - name: Check if branch needs updating
         id: check_branch_status
-        if: steps.wait_for_ci.outputs.status == 'success'
+        if: steps.wait_for_ci.outputs.status == 'success' && steps.is_promotion.outputs.promotion != 'true'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/auto-promote.yml
+++ b/.github/workflows/auto-promote.yml
@@ -1,0 +1,75 @@
+name: Auto Promote to Production
+
+on:
+  push:
+    branches:
+      - preview
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: auto-promote-production
+  cancel-in-progress: false
+
+jobs:
+  open-promotion-pr:
+    name: Open promotion PR (preview -> production)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure not from bot loop
+        if: github.actor == 'github-actions[bot]'
+        run: |
+          echo "Skipping to avoid bot loop"
+          exit 0
+
+      - name: Check for existing promotion PR
+        id: check_pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              base: 'production',
+              head: `${context.repo.owner}:preview`,
+              per_page: 10
+            });
+            if (prs.length > 0) {
+              core.info(`Existing promotion PR #${prs[0].number} found.`);
+              core.setOutput('exists', 'true');
+              core.setOutput('number', String(prs[0].number));
+            } else {
+              core.setOutput('exists', 'false');
+            }
+
+      - name: Open promotion PR
+        if: steps.check_pr.outputs.exists != 'true'
+        id: create_pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = 'chore(release): promote preview to production';
+            const body = [
+              'This PR promotes the latest changes from `preview` to `production`. ',
+              '',
+              '- Auto-created after a successful push to preview.',
+              '- The auto-merge workflow will wait for full checks (Build, Unit Tests, E2E Tests, Drizzle Check).',
+              '',
+              'If anything looks off, close this PR to halt promotion.'
+            ].join('\n');
+
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              head: 'preview',
+              base: 'production',
+              body,
+              maintainer_can_modify: true
+            });
+            core.info(`Opened promotion PR #${pr.number}`);
+            core.setOutput('number', String(pr.number));

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,25 +27,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-policy:
-    name: pr-policy
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            const base = context.payload.pull_request.base.ref;
-            const head = context.payload.pull_request.head.ref;
-            if (base === 'production' && head !== 'preview') {
-              core.setFailed(`Only allow preview -> production. Got ${head} -> ${base}`);
-            } else if (base === 'preview' && head === 'production') {
-              core.setFailed(`Do not merge production -> preview. Use feature/* -> preview`);
-            } else {
-              core.info('PR policy OK');
-            }
-
   up-to-date-with-preview:
     name: PR Up-to-date with Preview
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'preview' }}
@@ -131,7 +112,7 @@ jobs:
   neon-db:
     name: Neon DB
     # Run whenever Drizzle Check would run
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'preview' || contains(github.event.pull_request.labels.*.name, 'full-ci'))) }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'production' || github.event.pull_request.base.ref == 'preview' || contains(github.event.pull_request.labels.*.name, 'full-ci'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -181,7 +162,7 @@ jobs:
   ci-drizzle-check:
     name: Drizzle Check
     needs: [ci-typecheck, ci-lint, neon-db]
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'preview' || contains(github.event.pull_request.labels.*.name, 'full-ci'))) }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'production' || contains(github.event.pull_request.labels.*.name, 'full-ci'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -193,29 +174,38 @@ jobs:
         id: resolve_db
         run: |
           CANDIDATE="${{ needs.neon-db.outputs.db_url }}"
+          SRC=""
           if [ -n "$CANDIDATE" ]; then
             echo "Using Neon DB URL from neon-db job outputs"
             echo "DATABASE_URL=$CANDIDATE" >> $GITHUB_ENV
-            exit 0
-          fi
-          if [ -n "${{ secrets.NEON_DATABASE_URL }}" ]; then
+            SRC="neon-job-output"
+          elif [ -n "${{ secrets.NEON_DATABASE_URL }}" ]; then
             echo "Using NEON_DATABASE_URL secret"
             echo "DATABASE_URL=${{ secrets.NEON_DATABASE_URL }}" >> $GITHUB_ENV
-            exit 0
-          fi
-          if [ -n "${{ secrets.DATABASE_URL_PREVIEW }}" ]; then
+            SRC="secret:NEON_DATABASE_URL"
+          elif [ -n "${{ secrets.DATABASE_URL_PREVIEW }}" ]; then
             echo "Using DATABASE_URL_PREVIEW secret"
             echo "DATABASE_URL=${{ secrets.DATABASE_URL_PREVIEW }}" >> $GITHUB_ENV
-            exit 0
-          fi
-          if [ -n "${{ secrets.DATABASE_URL }}" ]; then
+            SRC="secret:DATABASE_URL_PREVIEW"
+          elif [ -n "${{ secrets.DATABASE_URL }}" ]; then
             echo "Using DATABASE_URL secret"
             echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> $GITHUB_ENV
-            exit 0
+            SRC="secret:DATABASE_URL"
+          else
+            echo "No DATABASE_URL could be resolved (likely a fork PR)."
+            SRC="unresolved"
           fi
-          echo "No DATABASE_URL could be resolved (likely a fork PR)."
 
-      # Path guard: Check if changes affect DB/schema files (only for pushes and non-preview PRs)
+          echo "RESOLVED_DB_SOURCE=$SRC" >> $GITHUB_ENV
+          {
+            echo "### Drizzle Check: DATABASE_URL Resolution"
+            echo "- Source: $SRC"
+            if [ "$SRC" = "unresolved" ]; then
+              echo "- Note: No URL available; downstream steps may skip gracefully."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # Path guard: Check if changes affect DB/schema files (only for pushes and non-production PRs)
       - name: Check for relevant changes
         id: check_changes
         run: |
@@ -233,9 +223,9 @@ jobs:
             exit 0
           fi
 
-          # For PRs to preview, always run Drizzle check (skip path guards)
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.base.ref }}" == "preview" ]]; then
-            echo "Running Drizzle check for PR to preview branch"
+          # For PRs to production, always run Drizzle check (skip path guards)
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.base.ref }}" == "production" ]]; then
+            echo "Running Drizzle check for PR to production branch"
             echo "run_full_ci=true" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -307,19 +297,19 @@ jobs:
   ci-fast:
     name: ci-fast
     # Gate for PRs and merge queue: aggregate fast checks
-    if: ${{ github.event_name == 'pull_request' }}
-    needs: [ci-typecheck, ci-lint, ci-drizzle-check]
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    needs: [ci-typecheck, ci-lint]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: All fast checks passed
         run: |
-          echo "ci-fast passed: Typecheck, Lint, and Drizzle Check succeeded"
+          echo "ci-fast passed: Typecheck and Lint succeeded"
 
   ci-build:
     name: Build
     needs: [ci-typecheck, ci-lint]
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'preview' || contains(github.event.pull_request.labels.*.name, 'full-ci'))) }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'production' || contains(github.event.pull_request.labels.*.name, 'full-ci'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -327,7 +317,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      # Path guard: Check if changes affect critical files (only for pushes and non-preview PRs)
+      # Path guard: Check if changes affect critical files (only for pushes and non-production PRs)
       - name: Check for relevant changes
         id: check_changes
         run: |
@@ -345,9 +335,9 @@ jobs:
             exit 0
           fi
 
-          # For PRs to preview, always run full CI (skip path guards)
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.base.ref }}" == "preview" ]]; then
-            echo "Running full CI for PR to preview branch"
+          # For PRs to production, always run full CI (skip path guards)
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.base.ref }}" == "production" ]]; then
+            echo "Running full CI for PR to production branch"
             echo "run_full_ci=true" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -421,7 +411,7 @@ jobs:
   ci-unit-tests:
     name: Unit Tests
     needs: [ci-typecheck, ci-lint]
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'preview' || contains(github.event.pull_request.labels.*.name, 'full-ci'))) }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'production' || contains(github.event.pull_request.labels.*.name, 'full-ci'))) }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -447,9 +437,9 @@ jobs:
             exit 0
           fi
 
-          # For PRs to preview, always run full CI (skip path guards)
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.base.ref }}" == "preview" ]]; then
-            echo "Running full CI for PR to preview branch"
+          # For PRs to production, always run full CI (skip path guards)
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.base.ref }}" == "production" ]]; then
+            echo "Running full CI for PR to production branch"
             echo "run_full_ci=true" >> $GITHUB_OUTPUT
             exit 0
           fi
@@ -542,7 +532,7 @@ jobs:
   ci-e2e-tests:
     name: E2E Tests
     needs: [ci-build, ci-unit-tests]
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'preview' || contains(github.event.pull_request.labels.*.name, 'full-ci'))) }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'merge_group' || (github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'production' || contains(github.event.pull_request.labels.*.name, 'full-ci'))) }}
     runs-on: ubuntu-latest
     env:
       # Use the Neon database URL from GitHub secrets
@@ -574,12 +564,7 @@ jobs:
             exit 0
           fi
 
-          # For PRs to preview, always run full CI (skip path guards)
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.base.ref }}" == "preview" ]]; then
-            echo "Running full CI for PR to preview branch"
-            echo "run_full_ci=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
+          # PRs to preview do not automatically force full CI here; job-level conditions control execution.
 
           # For merge queue events, always run full CI
           if [[ "${{ github.event_name }}" == "merge_group" ]]; then

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from 'drizzle-kit';
-import { env } from './lib/env';
 
-const databaseUrl = env.DATABASE_URL || '';
+const databaseUrl = process.env.DATABASE_URL || '';
 
 // Clean the URL for Neon (remove the +neon part) — Drizzle Kit expects a standard Postgres URL
 const url = databaseUrl.replace(/^postgres(ql)?\+neon:\/\//, 'postgres$1://');

--- a/scripts/drizzle-migrate.ts
+++ b/scripts/drizzle-migrate.ts
@@ -237,14 +237,7 @@ async function runMigrations() {
 
     db = drizzle(sql);
 
-    // Ensure we operate in the public schema without attempting to create it
-    try {
-      await db.execute(drizzleSql`SET search_path TO public`);
-    } catch (e) {
-      log.warning(
-        `Could not set search_path to public: ${(e as Error).message}`
-      );
-    }
+    // Using default public schema
 
     log.success('Database connection established');
   } catch (error) {
@@ -259,8 +252,7 @@ async function runMigrations() {
     const start = Date.now();
     await migrate(db, {
       migrationsFolder: './drizzle/migrations',
-      // Use default search_path (public) and avoid CREATE SCHEMA by not passing migrationsSchema
-      migrationsTable: 'drizzle__journal',
+      migrationsTable: '__drizzle_migrations',
     });
     const duration = ((Date.now() - start) / 1000).toFixed(2);
 


### PR DESCRIPTION
Goal: Enforce manual promotion to production; keep preview PRs fast-gated. Adds workflow to auto-open promotion PR after preview push.

- Auto-merge disabled for promotion PRs (preview→production)
- CI Drizzle Check writes resolved DB source to step summary
- E2E job logic clarified to not force full CI on preview PRs

Rollback: Revert this commit or disable the new workflow.