### PR TITLE
Refine creator profile skeletons and background

### DIFF
--- a/components/profile/ArtistPageShell.tsx
+++ b/components/profile/ArtistPageShell.tsx
@@ -37,7 +37,7 @@ const ArtistPageShell = React.memo(function ArtistPageShell({
       showFooter={showFooter}
       showNotificationButton={process.env.NODE_ENV === 'development'}
       maxWidthClass={maxWidthClass}
-      backgroundPattern='grid'
+      backgroundPattern='gradient'
       showGradientBlurs={true}
     >
       {children}

--- a/components/profile/ProfileSkeleton.tsx
+++ b/components/profile/ProfileSkeleton.tsx
@@ -1,24 +1,27 @@
+import { BackgroundPattern } from '@/components/atoms/BackgroundPattern';
+
 export function ProfileSkeleton() {
   return (
-    <div className='min-h-screen bg-gradient-to-br from-purple-50 via-pink-50 to-orange-50 dark:from-gray-900 dark:via-purple-900/20 dark:to-gray-900 flex items-center justify-center'>
-      <div className='w-full max-w-md mx-auto px-4'>
+    <div className='relative min-h-screen flex items-center justify-center bg-white dark:bg-gray-900'>
+      <BackgroundPattern variant='gradient' />
+      <div className='relative z-10 w-full max-w-md mx-auto px-4'>
         {/* Profile Shell Skeleton */}
-        <div className='bg-white/60 dark:bg-white/5 backdrop-blur-lg border border-gray-200/30 dark:border-white/10 rounded-3xl p-8 shadow-xl shadow-black/5 animate-pulse'>
+        <div className='bg-white/60 dark:bg-white/5 backdrop-blur-lg border border-gray-200/30 dark:border-white/10 rounded-3xl p-8 shadow-xl shadow-black/5'>
           {/* Avatar */}
           <div className='text-center mb-6'>
-            <div className='w-24 h-24 bg-gray-200 dark:bg-gray-700 rounded-full mx-auto mb-4'></div>
+            <div className='w-24 h-24 rounded-full skeleton motion-reduce:animate-none mx-auto mb-4'></div>
             {/* Name */}
-            <div className='h-6 bg-gray-200 dark:bg-gray-700 rounded-lg mb-2 w-32 mx-auto'></div>
+            <div className='h-6 w-32 rounded-lg skeleton motion-reduce:animate-none mx-auto mb-2'></div>
             {/* Bio */}
-            <div className='h-4 bg-gray-200 dark:bg-gray-700 rounded-lg w-48 mx-auto'></div>
+            <div className='h-4 w-48 rounded-lg skeleton motion-reduce:animate-none mx-auto'></div>
           </div>
 
           {/* Action Buttons */}
           <div className='space-y-4'>
             {/* Listen Now Button */}
-            <div className='h-12 bg-gray-200 dark:bg-gray-700 rounded-xl w-full'></div>
+            <div className='h-12 w-full rounded-xl skeleton motion-reduce:animate-none'></div>
             {/* Optional Tip Button */}
-            <div className='h-12 bg-gray-200 dark:bg-gray-700 rounded-xl w-full'></div>
+            <div className='h-12 w-full rounded-xl skeleton motion-reduce:animate-none'></div>
           </div>
         </div>
       </div>

--- a/components/ui/LoadingSkeleton.tsx
+++ b/components/ui/LoadingSkeleton.tsx
@@ -111,8 +111,7 @@ export function LoadingSkeleton({
     return (
       <div
         className={clsx(
-          'animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]',
-          'bg-gray-200 dark:bg-gray-700',
+          'skeleton motion-reduce:animate-none',
           roundedClasses[rounded],
           validatedHeight,
           validatedWidth,
@@ -129,8 +128,7 @@ export function LoadingSkeleton({
         <div
           key={index}
           className={clsx(
-            'animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]',
-            'bg-gray-200 dark:bg-gray-700',
+            'skeleton motion-reduce:animate-none',
             roundedClasses[rounded],
             validatedHeight,
             index === lines - 1 ? 'w-3/4' : validatedWidth,
@@ -147,18 +145,18 @@ export function ProfileSkeleton() {
   return (
     <div className='flex flex-col items-center space-y-4 text-center'>
       <div
-        className='h-32 w-32 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]'
+        className='h-32 w-32 rounded-full skeleton motion-reduce:animate-none'
         aria-label='Loading artist profile image'
         role='img'
       />
       <div className='space-y-2'>
         <div
-          className='h-8 w-48 bg-gray-200 dark:bg-gray-700 rounded-sm animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]'
+          className='h-8 w-48 rounded-sm skeleton motion-reduce:animate-none'
           aria-label='Loading artist name'
           role='text'
         />
         <div
-          className='h-6 w-64 bg-gray-200 dark:bg-gray-700 rounded-sm animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]'
+          className='h-6 w-64 rounded-sm skeleton motion-reduce:animate-none'
           aria-label='Loading artist tagline'
           role='text'
         />
@@ -170,7 +168,7 @@ export function ProfileSkeleton() {
 export function ButtonSkeleton() {
   return (
     <div
-      className='h-12 w-full max-w-sm bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]'
+      className='h-12 w-full max-w-sm rounded-lg skeleton motion-reduce:animate-none'
       aria-label='Loading action button'
       role='button'
     />
@@ -187,7 +185,7 @@ export function SocialBarSkeleton() {
       {Array.from({ length: 4 }).map((_, index) => (
         <div
           key={index}
-          className='h-12 w-12 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]'
+          className='h-12 w-12 rounded-full skeleton motion-reduce:animate-none'
           aria-label={`Loading social link ${index + 1}`}
           role='button'
         />
@@ -201,16 +199,16 @@ export function CardSkeleton() {
     <div className='w-full p-4 border border-gray-200 dark:border-gray-700 rounded-lg'>
       <div className='space-y-3'>
         <div className='flex items-center space-x-3'>
-          <div className='h-10 w-10 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]' />
+          <div className='h-10 w-10 rounded-full skeleton motion-reduce:animate-none' />
           <div className='space-y-1 flex-1'>
-            <div className='h-4 w-1/2 bg-gray-200 dark:bg-gray-700 rounded-sm animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]' />
-            <div className='h-3 w-1/3 bg-gray-200 dark:bg-gray-700 rounded-sm animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]' />
+            <div className='h-4 w-1/2 rounded-sm skeleton motion-reduce:animate-none' />
+            <div className='h-3 w-1/3 rounded-sm skeleton motion-reduce:animate-none' />
           </div>
         </div>
-        <div className='h-24 bg-gray-200 dark:bg-gray-700 rounded-md animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]' />
+        <div className='h-24 rounded-md skeleton motion-reduce:animate-none' />
         <div className='flex justify-between'>
-          <div className='h-8 w-24 bg-gray-200 dark:bg-gray-700 rounded-md animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]' />
-          <div className='h-8 w-24 bg-gray-200 dark:bg-gray-700 rounded-md animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]' />
+          <div className='h-8 w-24 rounded-md skeleton motion-reduce:animate-none' />
+          <div className='h-8 w-24 rounded-md skeleton motion-reduce:animate-none' />
         </div>
       </div>
     </div>
@@ -225,12 +223,12 @@ export function ListSkeleton({ items = 3 }: { items?: number }) {
           key={index}
           className='flex items-center space-x-3 p-3 border border-gray-200 dark:border-gray-700 rounded-md'
         >
-          <div className='h-10 w-10 rounded-full bg-gray-200 dark:bg-gray-700 animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]' />
+          <div className='h-10 w-10 rounded-full skeleton motion-reduce:animate-none' />
           <div className='space-y-1 flex-1'>
-            <div className='h-4 w-1/3 bg-gray-200 dark:bg-gray-700 rounded-sm animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]' />
-            <div className='h-3 w-1/2 bg-gray-200 dark:bg-gray-700 rounded-sm animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]' />
+            <div className='h-4 w-1/3 rounded-sm skeleton motion-reduce:animate-none' />
+            <div className='h-3 w-1/2 rounded-sm skeleton motion-reduce:animate-none' />
           </div>
-          <div className='h-8 w-8 bg-gray-200 dark:bg-gray-700 rounded-md animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]' />
+          <div className='h-8 w-8 rounded-md skeleton motion-reduce:animate-none' />
         </div>
       ))}
     </div>
@@ -250,7 +248,7 @@ export function TableSkeleton({
       <div className='flex border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800'>
         {Array.from({ length: columns }).map((_, index) => (
           <div key={`header-${index}`} className='flex-1 p-3'>
-            <div className='h-5 bg-gray-200 dark:bg-gray-700 rounded-sm animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]' />
+            <div className='h-5 rounded-sm skeleton motion-reduce:animate-none' />
           </div>
         ))}
       </div>
@@ -265,7 +263,7 @@ export function TableSkeleton({
             <div key={`cell-${rowIndex}-${colIndex}`} className='flex-1 p-3'>
               <div
                 className={clsx(
-                  'h-4 bg-gray-200 dark:bg-gray-700 rounded-sm animate-pulse motion-reduce:animate-[pulse_2s_ease-in-out_infinite]',
+                  'h-4 rounded-sm skeleton motion-reduce:animate-none',
                   colIndex === 0 ? 'w-3/4' : 'w-full'
                 )}
               />


### PR DESCRIPTION
## Summary
- unify LoadingSkeleton to use global `skeleton` utility for consistent light/dark modes
- render profile skeleton with gradient background and motion-reduced shimmer
- switch artist page background pattern from grid to gradient for a softer feel

## Testing
- `pnpm lint` *(fails: Unable to resolve path to module '@upstash/redis')*
- `pnpm test` *(fails: Can't find meta/_journal.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a5066e388327845862305ad08371