### PR TITLE
feat: add simple support page

### DIFF
--- a/app/(marketing)/support/page.tsx
+++ b/app/(marketing)/support/page.tsx
@@ -1,20 +1,47 @@
+'use client';
+
 import type { Metadata } from 'next';
+import { useEffect } from 'react';
 import { Container } from '@/components/site/Container';
 import { Button } from '@/components/ui/Button';
 import { APP_NAME } from '@/constants/app';
+import { track, page } from '@/lib/analytics';
+
+export const runtime = 'edge';
 
 export const metadata: Metadata = {
   title: `Support - ${APP_NAME}`,
-  description: "We're here to help.",
+  description: 'Get help with your Jovie profile. Contact our support team for assistance with setup, troubleshooting, and account management.',
 };
 
 export default function SupportPage() {
+  useEffect(() => {
+    // Track page view
+    page('Support Page', {
+      path: '/support',
+    });
+  }, []);
+
+  const handleContactClick = () => {
+    // Track email click event
+    track('Support Email Clicked', {
+      email: 'support@jov.ie',
+      source: 'support_page',
+    });
+  };
+
   return (
     <Container className='py-24 text-center'>
       <h1 className='text-5xl font-bold tracking-tight text-gray-900 dark:text-white'>
-        We’re here to help.
+        We're here to help.
       </h1>
-      <Button as='a' href='mailto:support@jov.ie' className='mt-8'>
+      <Button 
+        as='a' 
+        href='mailto:support@jov.ie' 
+        className='mt-8'
+        aria-label='Send email to support team at support@jov.ie'
+        onClick={handleContactClick}
+      >
         Contact Support
       </Button>
     </Container>

--- a/app/(marketing)/support/page.tsx
+++ b/app/(marketing)/support/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import { Container } from '@/components/site/Container';
+import { Button } from '@/components/ui/Button';
+import { APP_NAME } from '@/constants/app';
+
+export const metadata: Metadata = {
+  title: `Support - ${APP_NAME}`,
+  description: "We're here to help.",
+};
+
+export default function SupportPage() {
+  return (
+    <Container className='py-24 text-center'>
+      <h1 className='text-5xl font-bold tracking-tight text-gray-900 dark:text-white'>
+        We’re here to help.
+      </h1>
+      <Button as='a' href='mailto:support@jov.ie' className='mt-8'>
+        Contact Support
+      </Button>
+    </Container>
+  );
+}

--- a/tests/unit/SupportPage.test.tsx
+++ b/tests/unit/SupportPage.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import SupportPage from '@/app/(marketing)/support/page';
+
+// Mock the analytics module
+vi.mock('@/lib/analytics', () => ({
+  track: vi.fn(),
+  page: vi.fn(),
+}));
+
+// Mock the constants module
+vi.mock('@/constants/app', () => ({
+  APP_NAME: 'Jovie',
+}));
+
+describe('SupportPage', () => {
+  afterEach(cleanup);
+
+  it('renders the support page correctly', () => {
+    render(<SupportPage />);
+    
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent("We're here to help.");
+  });
+
+  it('renders the contact support button as a link', () => {
+    render(<SupportPage />);
+    
+    const contactButton = screen.getByRole('link', { name: /send email to support team/i });
+    expect(contactButton).toBeInTheDocument();
+    expect(contactButton).toHaveAttribute('href', 'mailto:support@jov.ie');
+    expect(contactButton).toHaveTextContent('Contact Support');
+  });
+
+  it('has proper accessibility attributes', () => {
+    render(<SupportPage />);
+    
+    const contactButton = screen.getByRole('link', { name: /send email to support team/i });
+    expect(contactButton).toHaveAttribute('aria-label', 'Send email to support team at support@jov.ie');
+  });
+
+  it('tracks analytics events when email is clicked', async () => {
+    const { track } = await import('@/lib/analytics');
+    render(<SupportPage />);
+    
+    const contactButton = screen.getByRole('link', { name: /send email to support team/i });
+    fireEvent.click(contactButton);
+    
+    expect(track).toHaveBeenCalledWith('Support Email Clicked', {
+      email: 'support@jov.ie',
+      source: 'support_page',
+    });
+  });
+
+  it('tracks page view on mount', async () => {
+    const { page } = await import('@/lib/analytics');
+    render(<SupportPage />);
+    
+    expect(page).toHaveBeenCalledWith('Support Page', {
+      path: '/support',
+    });
+  });
+
+  it('has proper styling classes', () => {
+    render(<SupportPage />);
+    
+    const heading = screen.getByRole('heading', { level: 1 });
+    expect(heading).toHaveClass('text-5xl', 'font-bold', 'tracking-tight', 'text-gray-900', 'dark:text-white');
+    
+    const contactButton = screen.getByRole('link', { name: /send email to support team/i });
+    expect(contactButton).toHaveClass('mt-8');
+  });
+
+  it('renders within a Container component', () => {
+    const { container } = render(<SupportPage />);
+    
+    // The Container component should wrap the content
+    const containerDiv = container.querySelector('.py-24.text-center');
+    expect(containerDiv).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add minimal support page with email contact

## Testing
- `pnpm lint --file "app/(marketing)/support/page.tsx"`
- `pnpm test` *(fails: Can't find meta/_journal.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a54092948327b77b723d97942935