### PR TITLE
feat: add onboarding rate limit

### DIFF
--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -56,9 +56,25 @@ export async function completeOnboarding({
     // Step 3: Rate limiting check
     const headersList = headers();
     const forwarded = headersList.get('x-forwarded-for');
-    const clientIP = forwarded ? forwarded.split(',')[0] : 'unknown';
+    const realIP = headersList.get('x-real-ip');
+    
+    // Extract and validate IP address with fallback chain
+    let clientIP = 'unknown';
+    if (forwarded) {
+      const firstIP = forwarded.split(',')[0].trim();
+      // Basic IP validation (IPv4 and IPv6)
+      if (/^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(firstIP) || 
+          /^(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$/.test(firstIP)) {
+        clientIP = firstIP;
+      }
+    } else if (realIP && /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(realIP)) {
+      clientIP = realIP;
+    }
+    
+    // Skip IP rate limiting for unknown IPs to avoid shared limits
+    const shouldCheckIP = clientIP !== 'unknown';
 
-    await enforceOnboardingRateLimit({ userId, ip: clientIP });
+    await enforceOnboardingRateLimit({ userId, ip: clientIP, checkIP: shouldCheckIP });
 
     // Step 4-6: Parallel operations for performance optimization
     const normalizedUsername = normalizeUsername(username);

--- a/lib/onboarding/rate-limit.ts
+++ b/lib/onboarding/rate-limit.ts
@@ -1,0 +1,55 @@
+import {
+  createOnboardingError,
+  OnboardingErrorCode,
+} from '@/lib/errors/onboarding';
+import { redis } from '@/lib/redis';
+
+/**
+ * Enforce onboarding rate limits keyed by both user ID and IP address.
+ * @param params.userId - Authenticated user's ID
+ * @param params.ip - Client IP address
+ * @param params.limit - Max attempts allowed within the window
+ * @param params.window - Time window in seconds for rate limiting
+ * @throws Error with code OnboardingErrorCode.RATE_LIMITED when limit exceeded
+ */
+export async function enforceOnboardingRateLimit({
+  userId,
+  ip,
+  limit = 5,
+  window = 60,
+}: {
+  userId: string;
+  ip: string;
+  limit?: number;
+  window?: number;
+}): Promise<void> {
+  const userKey = `onboarding:user:${userId}`;
+  const ipKey = `onboarding:ip:${ip}`;
+
+  try {
+    const [userCount, ipCount] = await Promise.all([
+      redis.incr(userKey),
+      redis.incr(ipKey),
+    ]);
+
+    if (userCount === 1) {
+      await redis.expire(userKey, window);
+    }
+    if (ipCount === 1) {
+      await redis.expire(ipKey, window);
+    }
+
+    if (userCount > limit || ipCount > limit) {
+      const error = createOnboardingError(
+        OnboardingErrorCode.RATE_LIMITED,
+        'Too many onboarding attempts. Please wait and try again.'
+      );
+      const err = new Error(error.message);
+      (err as Error & { code?: OnboardingErrorCode }).code = error.code;
+      throw err;
+    }
+  } catch (err) {
+    // Fail open on Redis errors to avoid blocking onboarding if rate limiter fails
+    console.error('Onboarding rate limiter error:', err);
+  }
+}

--- a/lib/onboarding/rate-limit.ts
+++ b/lib/onboarding/rate-limit.ts
@@ -4,52 +4,82 @@ import {
 } from '@/lib/errors/onboarding';
 import { redis } from '@/lib/redis';
 
+// Default rate limiting configuration
+export const ONBOARDING_RATE_LIMIT = {
+  DEFAULT_LIMIT: 5,
+  DEFAULT_WINDOW: 60, // seconds
+} as const;
+
 /**
  * Enforce onboarding rate limits keyed by both user ID and IP address.
  * @param params.userId - Authenticated user's ID
  * @param params.ip - Client IP address
  * @param params.limit - Max attempts allowed within the window
  * @param params.window - Time window in seconds for rate limiting
+ * @param params.checkIP - Whether to check IP rate limiting (default: true)
  * @throws Error with code OnboardingErrorCode.RATE_LIMITED when limit exceeded
  */
 export async function enforceOnboardingRateLimit({
   userId,
   ip,
-  limit = 5,
-  window = 60,
+  limit = ONBOARDING_RATE_LIMIT.DEFAULT_LIMIT,
+  window = ONBOARDING_RATE_LIMIT.DEFAULT_WINDOW,
+  checkIP = true,
 }: {
   userId: string;
   ip: string;
   limit?: number;
   window?: number;
+  checkIP?: boolean;
 }): Promise<void> {
   const userKey = `onboarding:user:${userId}`;
   const ipKey = `onboarding:ip:${ip}`;
 
   try {
-    const [userCount, ipCount] = await Promise.all([
-      redis.incr(userKey),
-      redis.incr(ipKey),
-    ]);
+    // Always check user rate limit
+    const userResult = await redis.set(userKey, 1, 'EX', window, 'NX');
+    let userCount: number;
 
-    if (userCount === 1) {
-      await redis.expire(userKey, window);
-    }
-    if (ipCount === 1) {
-      await redis.expire(ipKey, window);
+    if (userResult === 'OK') {
+      // First request for this user
+      userCount = 1;
+    } else {
+      // Key already exists, increment it
+      userCount = await redis.incr(userKey);
     }
 
-    if (userCount > limit || ipCount > limit) {
+    // Check IP rate limit only if requested and IP is valid
+    let ipCount = 0;
+    if (checkIP && ip !== 'unknown') {
+      const ipResult = await redis.set(ipKey, 1, 'EX', window, 'NX');
+
+      if (ipResult === 'OK') {
+        // First request for this IP
+        ipCount = 1;
+      } else {
+        // Key already exists, increment it
+        ipCount = await redis.incr(ipKey);
+      }
+    }
+
+    if (userCount > limit || (checkIP && ipCount > limit)) {
       const error = createOnboardingError(
         OnboardingErrorCode.RATE_LIMITED,
         'Too many onboarding attempts. Please wait and try again.'
       );
-      const err = new Error(error.message);
-      (err as Error & { code?: OnboardingErrorCode }).code = error.code;
-      throw err;
+      throw error;
     }
   } catch (err) {
-    // Fail open on Redis errors to avoid blocking onboarding if rate limiter fails
+    // Only swallow Redis/infrastructure errors; rethrow intentional rate limit errors
+    if (
+      err &&
+      typeof err === 'object' &&
+      'code' in err &&
+      (err as { code?: OnboardingErrorCode }).code === OnboardingErrorCode.RATE_LIMITED
+    ) {
+      throw err;
+    }
+    // Fail open on Redis infrastructure errors to avoid blocking onboarding
     console.error('Onboarding rate limiter error:', err);
   }
 }

--- a/tests/integration/onboarding-rate-limit.test.ts
+++ b/tests/integration/onboarding-rate-limit.test.ts
@@ -4,14 +4,23 @@ import { enforceOnboardingRateLimit } from '@/lib/onboarding/rate-limit';
 import { redis } from '@/lib/redis';
 
 const TEST_USER = 'test-user';
+const TEST_USER_2 = 'test-user-2';
 const TEST_IP = '203.0.113.1';
+const TEST_IP_2 = '203.0.113.2';
 const USER_KEY = `onboarding:user:${TEST_USER}`;
+const USER_KEY_2 = `onboarding:user:${TEST_USER_2}`;
 const IP_KEY = `onboarding:ip:${TEST_IP}`;
+const IP_KEY_2 = `onboarding:ip:${TEST_IP_2}`;
 
 describe('enforceOnboardingRateLimit', () => {
   beforeEach(async () => {
-    await redis.del(USER_KEY);
-    await redis.del(IP_KEY);
+    // Clean up all test keys
+    await Promise.all([
+      redis.del(USER_KEY),
+      redis.del(USER_KEY_2),
+      redis.del(IP_KEY),
+      redis.del(IP_KEY_2),
+    ]);
   });
 
   it('allows attempts under the limit', async () => {
@@ -33,7 +42,7 @@ describe('enforceOnboardingRateLimit', () => {
     ).resolves.toBeUndefined();
   });
 
-  it('throttles when limit exceeded', async () => {
+  it('throttles when user limit exceeded', async () => {
     await enforceOnboardingRateLimit({
       userId: TEST_USER,
       ip: TEST_IP,
@@ -42,15 +51,147 @@ describe('enforceOnboardingRateLimit', () => {
     });
     await enforceOnboardingRateLimit({
       userId: TEST_USER,
-      ip: TEST_IP,
+      ip: TEST_IP_2, // Different IP to test user limit specifically
       limit: 2,
       window: 10,
     });
     await expect(
       enforceOnboardingRateLimit({
         userId: TEST_USER,
+        ip: TEST_IP_2,
+        limit: 2,
+        window: 10,
+      })
+    ).rejects.toMatchObject({ code: OnboardingErrorCode.RATE_LIMITED });
+  });
+
+  it('throttles when IP limit exceeded', async () => {
+    await enforceOnboardingRateLimit({
+      userId: TEST_USER,
+      ip: TEST_IP,
+      limit: 2,
+      window: 10,
+    });
+    await enforceOnboardingRateLimit({
+      userId: TEST_USER_2, // Different user to test IP limit specifically
+      ip: TEST_IP,
+      limit: 2,
+      window: 10,
+    });
+    await expect(
+      enforceOnboardingRateLimit({
+        userId: TEST_USER_2,
         ip: TEST_IP,
         limit: 2,
+        window: 10,
+      })
+    ).rejects.toMatchObject({ code: OnboardingErrorCode.RATE_LIMITED });
+  });
+
+  it('skips IP rate limiting when checkIP is false', async () => {
+    // Exhaust IP limit first
+    await enforceOnboardingRateLimit({
+      userId: TEST_USER,
+      ip: TEST_IP,
+      limit: 1,
+      window: 10,
+    });
+
+    // Should still allow new user with same IP when checkIP = false
+    await expect(
+      enforceOnboardingRateLimit({
+        userId: TEST_USER_2,
+        ip: TEST_IP,
+        limit: 1,
+        window: 10,
+        checkIP: false,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('skips IP rate limiting for unknown IP', async () => {
+    // Should allow requests with unknown IP
+    await expect(
+      enforceOnboardingRateLimit({
+        userId: TEST_USER,
+        ip: 'unknown',
+        limit: 1,
+        window: 10,
+        checkIP: true,
+      })
+    ).resolves.toBeUndefined();
+
+    // Should allow multiple requests with unknown IP (only user limit applies)
+    await expect(
+      enforceOnboardingRateLimit({
+        userId: TEST_USER,
+        ip: 'unknown',
+        limit: 1,
+        window: 10,
+        checkIP: true,
+      })
+    ).rejects.toMatchObject({ code: OnboardingErrorCode.RATE_LIMITED });
+  });
+
+  it('properly handles race conditions with expiry', async () => {
+    // This test verifies that our atomic SET NX EX approach works
+    const promises = Array.from({ length: 3 }, () =>
+      enforceOnboardingRateLimit({
+        userId: TEST_USER,
+        ip: TEST_IP,
+        limit: 2,
+        window: 10,
+      })
+    );
+
+    const results = await Promise.allSettled(promises);
+    
+    // Should have 2 successful and 1 failed (rate limited)
+    const successful = results.filter(r => r.status === 'fulfilled').length;
+    const failed = results.filter(
+      r => r.status === 'rejected' && 
+      (r.reason as any)?.code === OnboardingErrorCode.RATE_LIMITED
+    ).length;
+
+    expect(successful).toBe(2);
+    expect(failed).toBe(1);
+  });
+
+  it('maintains separate counters for different users and IPs', async () => {
+    // Different users should have independent limits
+    await expect(
+      enforceOnboardingRateLimit({
+        userId: TEST_USER,
+        ip: TEST_IP,
+        limit: 1,
+        window: 10,
+      })
+    ).resolves.toBeUndefined();
+
+    await expect(
+      enforceOnboardingRateLimit({
+        userId: TEST_USER_2,
+        ip: TEST_IP_2,
+        limit: 1,
+        window: 10,
+      })
+    ).resolves.toBeUndefined();
+
+    // Both should be rate limited on their second attempt
+    await expect(
+      enforceOnboardingRateLimit({
+        userId: TEST_USER,
+        ip: TEST_IP,
+        limit: 1,
+        window: 10,
+      })
+    ).rejects.toMatchObject({ code: OnboardingErrorCode.RATE_LIMITED });
+
+    await expect(
+      enforceOnboardingRateLimit({
+        userId: TEST_USER_2,
+        ip: TEST_IP_2,
+        limit: 1,
         window: 10,
       })
     ).rejects.toMatchObject({ code: OnboardingErrorCode.RATE_LIMITED });

--- a/tests/integration/onboarding-rate-limit.test.ts
+++ b/tests/integration/onboarding-rate-limit.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { OnboardingErrorCode } from '@/lib/errors/onboarding';
+import { enforceOnboardingRateLimit } from '@/lib/onboarding/rate-limit';
+import { redis } from '@/lib/redis';
+
+const TEST_USER = 'test-user';
+const TEST_IP = '203.0.113.1';
+const USER_KEY = `onboarding:user:${TEST_USER}`;
+const IP_KEY = `onboarding:ip:${TEST_IP}`;
+
+describe('enforceOnboardingRateLimit', () => {
+  beforeEach(async () => {
+    await redis.del(USER_KEY);
+    await redis.del(IP_KEY);
+  });
+
+  it('allows attempts under the limit', async () => {
+    await expect(
+      enforceOnboardingRateLimit({
+        userId: TEST_USER,
+        ip: TEST_IP,
+        limit: 2,
+        window: 10,
+      })
+    ).resolves.toBeUndefined();
+    await expect(
+      enforceOnboardingRateLimit({
+        userId: TEST_USER,
+        ip: TEST_IP,
+        limit: 2,
+        window: 10,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('throttles when limit exceeded', async () => {
+    await enforceOnboardingRateLimit({
+      userId: TEST_USER,
+      ip: TEST_IP,
+      limit: 2,
+      window: 10,
+    });
+    await enforceOnboardingRateLimit({
+      userId: TEST_USER,
+      ip: TEST_IP,
+      limit: 2,
+      window: 10,
+    });
+    await expect(
+      enforceOnboardingRateLimit({
+        userId: TEST_USER,
+        ip: TEST_IP,
+        limit: 2,
+        window: 10,
+      })
+    ).rejects.toMatchObject({ code: OnboardingErrorCode.RATE_LIMITED });
+  });
+});


### PR DESCRIPTION
## Summary
- add Upstash Redis rate limiter for onboarding
- include helper to enforce user/IP limits
- add integration tests for allowed and throttled onboarding requests

## Testing
- `pnpm lint` *(fails: components/home/ClaimHandleForm.tsx unused var)*
- `DATABASE_URL= pnpm test tests/integration/onboarding-rate-limit.test.ts` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b48ba1cac483278c53fb068c5f8548