### PR TITLE
feat: add skeleton loaders for Clerk components

### DIFF
--- a/app/(auth)/sign-in/[[...rest]]/page.tsx
+++ b/app/(auth)/sign-in/[[...rest]]/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { SignIn } from '@clerk/nextjs';
+import { ClerkLoaded, ClerkLoading, SignIn } from '@clerk/nextjs';
 import { useSearchParams } from 'next/navigation';
+import { AuthFormSkeleton } from '@/components/ui/LoadingSkeleton';
 import { Logo } from '@/components/ui/Logo';
 
 export default function SignInPage() {
@@ -49,11 +50,18 @@ export default function SignInPage() {
             .
           </p>
         </div>
-        <SignIn
-          redirectUrl={destination}
-          afterSignInUrl={destination}
-          afterSignUpUrl={destination}
-        />
+        <div className='min-h-[400px]'>
+          <ClerkLoading>
+            <AuthFormSkeleton />
+          </ClerkLoading>
+          <ClerkLoaded>
+            <SignIn
+              redirectUrl={destination}
+              afterSignInUrl={destination}
+              afterSignUpUrl={destination}
+            />
+          </ClerkLoaded>
+        </div>
       </div>
     </div>
   );

--- a/app/(auth)/sign-up/[[...rest]]/page.tsx
+++ b/app/(auth)/sign-up/[[...rest]]/page.tsx
@@ -2,6 +2,7 @@
 
 import { ClerkLoaded, ClerkLoading, SignUp } from '@clerk/nextjs';
 import { useSearchParams } from 'next/navigation';
+import { AuthFormSkeleton } from '@/components/ui/LoadingSkeleton';
 import { Logo } from '@/components/ui/Logo';
 
 export default function SignUpPage() {
@@ -41,20 +42,20 @@ export default function SignUpPage() {
             .
           </p>
         </div>
-        <ClerkLoading>
-          <div className='text-center text-gray-600 dark:text-white/70'>
-            Loading account form...
-          </div>
-        </ClerkLoading>
-        <ClerkLoaded>
-          <SignUp
-            path='/sign-up'
-            routing='path'
-            signInUrl='/sign-in'
-            redirectUrl={redirect}
-            afterSignUpUrl={redirect}
-          />
-        </ClerkLoaded>
+        <div className='min-h-[500px]'>
+          <ClerkLoading>
+            <AuthFormSkeleton />
+          </ClerkLoading>
+          <ClerkLoaded>
+            <SignUp
+              path='/sign-up'
+              routing='path'
+              signInUrl='/sign-in'
+              redirectUrl={redirect}
+              afterSignUpUrl={redirect}
+            />
+          </ClerkLoaded>
+        </div>
       </div>
     </div>
   );

--- a/app/(auth)/signin/page.tsx
+++ b/app/(auth)/signin/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { SignIn } from '@clerk/nextjs';
+import { ClerkLoaded, ClerkLoading, SignIn } from '@clerk/nextjs';
 import { useSearchParams } from 'next/navigation';
 import { AuthLayout } from '@/components/auth';
+import { AuthFormSkeleton } from '@/components/ui/LoadingSkeleton';
 
 export default function SignInPage() {
   const searchParams = useSearchParams();
@@ -18,29 +19,37 @@ export default function SignInPage() {
       gradientTo='cyan-600'
       textColorClass='text-blue-100'
     >
-      <SignIn
-        appearance={{
-          elements: {
-            rootBox: 'mx-auto w-full',
-            card: 'shadow-none border-0 bg-transparent p-0',
-            headerTitle:
-              'hidden lg:block text-2xl font-bold text-gray-900 dark:text-white mb-6',
-            headerSubtitle:
-              'hidden lg:block text-gray-600 dark:text-gray-300 mb-8',
-            socialButtonsBlockButton:
-              'border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors',
-            dividerLine: 'bg-gray-200 dark:bg-gray-700',
-            dividerText: 'text-gray-500 dark:text-gray-400',
-            formFieldInput:
-              'border-gray-200 dark:border-gray-700 dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500',
-            formButtonPrimary:
-              'bg-blue-600 hover:bg-blue-500 text-white font-medium py-2.5 rounded-lg transition-colors',
-            footerActionLink: 'text-blue-600 hover:text-blue-500 font-medium',
-          },
-        }}
-        redirectUrl={redirectUrl}
-        signUpUrl='/signup'
-      />
+      <div className='min-h-[400px]'>
+        <ClerkLoading>
+          <AuthFormSkeleton />
+        </ClerkLoading>
+        <ClerkLoaded>
+          <SignIn
+            appearance={{
+              elements: {
+                rootBox: 'mx-auto w-full',
+                card: 'shadow-none border-0 bg-transparent p-0',
+                headerTitle:
+                  'hidden lg:block text-2xl font-bold text-gray-900 dark:text-white mb-6',
+                headerSubtitle:
+                  'hidden lg:block text-gray-600 dark:text-gray-300 mb-8',
+                socialButtonsBlockButton:
+                  'border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors',
+                dividerLine: 'bg-gray-200 dark:bg-gray-700',
+                dividerText: 'text-gray-500 dark:text-gray-400',
+                formFieldInput:
+                  'border-gray-200 dark:border-gray-700 dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500',
+                formButtonPrimary:
+                  'bg-blue-600 hover:bg-blue-500 text-white font-medium py-2.5 rounded-lg transition-colors',
+                footerActionLink:
+                  'text-blue-600 hover:text-blue-500 font-medium',
+              },
+            }}
+            redirectUrl={redirectUrl}
+            signUpUrl='/signup'
+          />
+        </ClerkLoaded>
+      </div>
     </AuthLayout>
   );
 }

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { SignUp } from '@clerk/nextjs';
+import { ClerkLoaded, ClerkLoading, SignUp } from '@clerk/nextjs';
 import { useSearchParams } from 'next/navigation';
 import { AuthLayout } from '@/components/auth';
+import { AuthFormSkeleton } from '@/components/ui/LoadingSkeleton';
 
 export default function SignUpPage() {
   const searchParams = useSearchParams();
@@ -18,30 +19,37 @@ export default function SignUpPage() {
       gradientTo='blue-600'
       textColorClass='text-purple-100'
     >
-      <SignUp
-        appearance={{
-          elements: {
-            rootBox: 'mx-auto w-full',
-            card: 'shadow-none border-0 bg-transparent p-0',
-            headerTitle:
-              'hidden lg:block text-2xl font-bold text-gray-900 dark:text-white mb-6',
-            headerSubtitle:
-              'hidden lg:block text-gray-600 dark:text-gray-300 mb-8',
-            socialButtonsBlockButton:
-              'border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors',
-            dividerLine: 'bg-gray-200 dark:bg-gray-700',
-            dividerText: 'text-gray-500 dark:text-gray-400',
-            formFieldInput:
-              'border-gray-200 dark:border-gray-700 dark:bg-gray-800 focus:ring-2 focus:ring-purple-500 focus:border-purple-500',
-            formButtonPrimary:
-              'bg-purple-600 hover:bg-purple-500 text-white font-medium py-2.5 rounded-lg transition-colors',
-            footerActionLink:
-              'text-purple-600 hover:text-purple-500 font-medium',
-          },
-        }}
-        redirectUrl={redirectUrl}
-        signInUrl='/signin'
-      />
+      <div className='min-h-[500px]'>
+        <ClerkLoading>
+          <AuthFormSkeleton />
+        </ClerkLoading>
+        <ClerkLoaded>
+          <SignUp
+            appearance={{
+              elements: {
+                rootBox: 'mx-auto w-full',
+                card: 'shadow-none border-0 bg-transparent p-0',
+                headerTitle:
+                  'hidden lg:block text-2xl font-bold text-gray-900 dark:text-white mb-6',
+                headerSubtitle:
+                  'hidden lg:block text-gray-600 dark:text-gray-300 mb-8',
+                socialButtonsBlockButton:
+                  'border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors',
+                dividerLine: 'bg-gray-200 dark:bg-gray-700',
+                dividerText: 'text-gray-500 dark:text-gray-400',
+                formFieldInput:
+                  'border-gray-200 dark:border-gray-700 dark:bg-gray-800 focus:ring-2 focus:ring-purple-500 focus:border-purple-500',
+                formButtonPrimary:
+                  'bg-purple-600 hover:bg-purple-500 text-white font-medium py-2.5 rounded-lg transition-colors',
+                footerActionLink:
+                  'text-purple-600 hover:text-purple-500 font-medium',
+              },
+            }}
+            redirectUrl={redirectUrl}
+            signInUrl='/signin'
+          />
+        </ClerkLoaded>
+      </div>
     </AuthLayout>
   );
 }

--- a/components/BrandingBadge.tsx
+++ b/components/BrandingBadge.tsx
@@ -9,9 +9,11 @@ import { useUser } from '@clerk/nextjs';
 export default function BrandingBadge() {
   const { user, isLoaded } = useUser();
 
-  // Don't render anything while loading to prevent flash
+  // Show a placeholder while loading to avoid layout shift
   if (!isLoaded) {
-    return null;
+    return (
+      <div className='h-3 w-24 rounded-sm skeleton motion-reduce:animate-none' />
+    );
   }
 
   // Check if user has Pro plan

--- a/components/molecules/UserButton.tsx
+++ b/components/molecules/UserButton.tsx
@@ -83,7 +83,20 @@ export function UserButton({ artist, showUserInfo = false }: UserButtonProps) {
   ]);
 
   if (!isLoaded || !user) {
-    return null;
+    if (showUserInfo) {
+      return (
+        <div className='flex w-full items-center gap-3 p-2'>
+          <div className='h-8 w-8 rounded-full skeleton motion-reduce:animate-none' />
+          <div className='flex-1 space-y-1'>
+            <div className='h-4 w-24 rounded-sm skeleton motion-reduce:animate-none' />
+            <div className='h-3 w-16 rounded-sm skeleton motion-reduce:animate-none' />
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div className='h-8 w-8 rounded-full skeleton motion-reduce:animate-none' />
+    );
   }
 
   const handleSignOut = async () => {

--- a/components/ui/LoadingSkeleton.tsx
+++ b/components/ui/LoadingSkeleton.tsx
@@ -194,6 +194,21 @@ export function SocialBarSkeleton() {
   );
 }
 
+export function AuthFormSkeleton() {
+  return (
+    <div
+      className='space-y-4'
+      aria-label='Loading authentication form'
+      role='status'
+    >
+      <div className='h-10 w-full rounded-md skeleton motion-reduce:animate-none' />
+      <div className='h-10 w-full rounded-md skeleton motion-reduce:animate-none' />
+      <div className='h-10 w-full rounded-md skeleton motion-reduce:animate-none' />
+      <div className='h-12 w-full rounded-md skeleton motion-reduce:animate-none' />
+    </div>
+  );
+}
+
 export function CardSkeleton() {
   return (
     <div className='w-full p-4 border border-gray-200 dark:border-gray-700 rounded-lg'>

--- a/tests/unit/BrandingBadge.test.tsx
+++ b/tests/unit/BrandingBadge.test.tsx
@@ -56,7 +56,7 @@ describe('BrandingBadge', () => {
     expect(screen.getByText('Made with Jovie')).toBeInTheDocument();
   });
 
-  it('shows nothing while loading', () => {
+  it('shows placeholder while loading', () => {
     (useUser as any).mockReturnValue({
       user: null,
       isLoaded: false,
@@ -64,7 +64,7 @@ describe('BrandingBadge', () => {
 
     const { container } = render(<BrandingBadge />);
 
-    expect(container.firstChild).toBeNull();
+    expect(container.firstChild).toHaveClass('skeleton');
   });
 
   it('shows branding for unauthenticated users', () => {


### PR DESCRIPTION
## Summary
- add AuthFormSkeleton and apply to Clerk SignIn/SignUp pages
- render user and branding placeholders while Clerk loads to avoid layout shifts
- update test for branding badge placeholder

## Testing
- `pnpm lint`
- `pnpm test` *(fails: onboarding-rate-limit.test.ts enforceOnboardingRateLimit etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ecba89448327bb81ac2f96989321