### PR TITLE
chore: add auto-merge workflow and PR creation helpers

### DIFF
--- a/PR_WORKFLOW_GUIDE.md
+++ b/PR_WORKFLOW_GUIDE.md
@@ -1,0 +1,65 @@
+# PR Workflow Guide
+
+## Creating PRs with Auto-merge
+
+### Option 1: Helper Script (Recommended)
+```bash
+./scripts/create-pr.sh "feat: add user authentication" "Implement OAuth login with Google and GitHub providers"
+```
+
+### Option 2: Manual with gh CLI
+```bash
+# Create PR
+gh pr create --title "feat: add user auth" --body "Implement OAuth login"
+
+# Add auto-merge label
+gh pr edit <PR_NUMBER> --add-label "auto-merge"
+```
+
+## Auto-merge Behavior
+
+The auto-merge workflow will:
+
+✅ **Enable auto-merge for PRs with `auto-merge` label when:**
+- All CI checks pass
+- PR is not draft
+- No blocking labels (`blocked`, `human-review`, `no-auto-merge`, etc.)
+
+⏸️ **Skip auto-merge for PRs with these labels:**
+- `blocked` - PR is blocked
+- `human-review` - Needs human review
+- `no-auto-merge` - Explicitly disable auto-merge
+- `claude:needs-fixes` - Claude detected issues
+- `needs-human` - Requires human intervention
+
+## PR Types
+
+### Regular PRs (like Claude Code creates)
+- ✅ **Auto-merge**: Only if `auto-merge` label is present
+- 🔄 **Merge method**: Squash and merge
+- ⚡ **CI requirements**: Fast checks (lint, typecheck)
+
+### Special PR Types
+- **Dependabot**: Auto-merge for patch/minor updates and security fixes
+- **Codegen**: Auto-merge with `codegen` label
+- **Production promotion**: Manual merge only (no auto-merge)
+
+## Best Practices
+
+1. **Always add `auto-merge` label** when creating PRs via Claude Code
+2. **Use conventional commit format** in PR titles
+3. **Add blocking labels** if PR needs human review
+4. **Monitor CI status** - auto-merge only triggers after green CI
+
+## Troubleshooting
+
+### Auto-merge not triggering?
+- Check if PR has `auto-merge` label
+- Verify CI checks are passing
+- Ensure no blocking labels are present
+- Check workflow logs in GitHub Actions
+
+### Need to disable auto-merge?
+```bash
+gh pr edit <PR_NUMBER> --add-label "no-auto-merge"
+```

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Helper script for creating PRs with auto-merge label
+# Usage: ./scripts/create-pr.sh "PR Title" "PR Body"
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 'PR Title' 'PR Body'"
+  echo "Example: $0 'feat: add user auth' 'Implement OAuth login with Google'"
+  exit 1
+fi
+
+TITLE="$1"
+BODY="$2"
+
+echo "🚀 Creating PR with auto-merge label..."
+echo "Title: $TITLE"
+echo ""
+
+# Create PR and capture the URL
+PR_URL=$(gh pr create --title "$TITLE" --body "$BODY")
+
+if [[ $? -eq 0 ]]; then
+  echo "✅ PR created: $PR_URL"
+  
+  # Extract PR number from URL
+  PR_NUMBER=$(echo "$PR_URL" | grep -o '[0-9]*$')
+  
+  echo "🏷️ Adding auto-merge label..."
+  
+  # Add the auto-merge label
+  gh pr edit "$PR_NUMBER" --add-label "auto-merge"
+  
+  if [[ $? -eq 0 ]]; then
+    echo "✅ auto-merge label added to PR #$PR_NUMBER"
+    echo "🔄 Auto-merge will be enabled when CI passes"
+  else
+    echo "⚠️ Failed to add auto-merge label, you can add it manually"
+  fi
+  
+  echo ""
+  echo "PR URL: $PR_URL"
+else
+  echo "❌ Failed to create PR"
+  exit 1
+fi


### PR DESCRIPTION
Add script to create PRs with auto-merge label automatically and comprehensive guide for the auto-merge workflow. This ensures Claude Code PRs get auto-merged when CI passes without manual GUI interaction.

- Helper script for creating PRs with auto-merge label
- Documentation for PR workflow and auto-merge behavior
- Auto-merge label added to existing PRs #710 and #711

## PostHog Events
N/A - developer tooling improvement

## Rollback Plan
Revert this PR