### PR TITLE
fix: remove automatic DATABASE_URL stub interfering with health check tests

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -14,9 +14,6 @@ if (process.env.NODE_ENV === 'test') {
 
   if (!databaseUrl) {
     console.warn('DATABASE_URL is not set. Database tests will be skipped.');
-    // Set a stub DATABASE_URL to prevent warnings in test files
-    process.env.DATABASE_URL =
-      'postgresql://stub:stub@localhost:5432/stub_test_db';
   } else {
     const sql = neon(databaseUrl);
     const db = drizzle(sql, { schema });


### PR DESCRIPTION
Fix CI test failure by removing the automatic stub DATABASE_URL from test setup that was interfering with health check tests.

## Problem
The health check test  specifically tests the scenario when DATABASE_URL is missing, expecting the error message 'DATABASE_URL not configured'. However, our test setup was automatically setting a stub DATABASE_URL, causing the test to fail.

## Solution  
Remove the automatic stub DATABASE_URL from global test setup. Individual test files can still set their own stubs if needed, but the health check tests can now properly test the missing DATABASE_URL scenario.

## Changes
- Remove automatic DATABASE_URL stub from 
- Health check tests now pass as expected
- All other tests continue to work (they show warnings but gracefully skip DB operations)

## PostHog Events
N/A - test infrastructure fix

## Rollback Plan
Revert this PR