### PR TITLE
feat: dashboard-link-ux

### DIFF
--- a/components/dashboard/atoms/UniversalLinkInput.tsx
+++ b/components/dashboard/atoms/UniversalLinkInput.tsx
@@ -14,6 +14,9 @@ interface UniversalLinkInputProps {
   placeholder?: string;
   disabled?: boolean;
   existingPlatforms?: string[]; // Array of existing platform IDs to check for duplicates
+  // Quota indicators (optional)
+  socialVisibleCount?: number;
+  socialVisibleLimit?: number; // default 6
 }
 
 export const UniversalLinkInput: React.FC<UniversalLinkInputProps> = ({
@@ -21,6 +24,8 @@ export const UniversalLinkInput: React.FC<UniversalLinkInputProps> = ({
   placeholder = 'Paste any link (Spotify, Instagram, TikTok, etc.)',
   disabled = false,
   existingPlatforms = [],
+  socialVisibleCount = 0,
+  socialVisibleLimit = 6,
 }) => {
   const [url, setUrl] = useState('');
   const [customTitle, setCustomTitle] = useState('');
@@ -273,33 +278,49 @@ export const UniversalLinkInput: React.FC<UniversalLinkInputProps> = ({
               )}
             </div>
 
-            {/* Add button */}
-            <Button
-              onClick={handleAdd}
-              disabled={
-                disabled ||
-                !detectedLink.isValid ||
-                !displayTitle.trim() ||
-                isPlatformDuplicate
-              }
-              size='sm'
-              style={{
-                backgroundColor:
-                  detectedLink.isValid && !isPlatformDuplicate
-                    ? brandColor
-                    : undefined,
-              }}
-              className={
-                !detectedLink.isValid || isPlatformDuplicate ? 'opacity-50' : ''
-              }
-              aria-label={
-                isPlatformDuplicate
-                  ? `Cannot add duplicate ${detectedLink.platform.name} link`
-                  : `Add ${displayTitle || 'link'}`
-              }
-            >
-              Add
-            </Button>
+            {/* Add button + quota */}
+            <div className='flex flex-col items-end gap-1'>
+              <Button
+                onClick={handleAdd}
+                disabled={
+                  disabled ||
+                  !detectedLink.isValid ||
+                  !displayTitle.trim() ||
+                  isPlatformDuplicate
+                }
+                size='sm'
+                style={{
+                  backgroundColor:
+                    detectedLink.isValid && !isPlatformDuplicate
+                      ? brandColor
+                      : undefined,
+                }}
+                className={
+                  !detectedLink.isValid || isPlatformDuplicate
+                    ? 'opacity-50'
+                    : ''
+                }
+                aria-label={
+                  isPlatformDuplicate
+                    ? `Cannot add duplicate ${detectedLink.platform.name} link`
+                    : `Add ${detectedLink.platform.name}`
+                }
+              >
+                {`Add ${detectedLink.platform.name}`}
+              </Button>
+
+              {/* Quota badge (muted) */}
+              <div className='text-[11px] text-secondary-token'>
+                {detectedLink.platform.category === 'social' ? (
+                  <span>
+                    {Math.min(socialVisibleCount, socialVisibleLimit)}/
+                    {socialVisibleLimit} visible
+                  </span>
+                ) : (
+                  <span> No limit </span>
+                )}
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/components/dashboard/atoms/UniversalLinkInput.tsx
+++ b/components/dashboard/atoms/UniversalLinkInput.tsx
@@ -317,7 +317,7 @@ export const UniversalLinkInput: React.FC<UniversalLinkInputProps> = ({
                     {socialVisibleLimit} visible
                   </span>
                 ) : (
-                  <span> No limit </span>
+                  <span>No limit</span>
                 )}
               </div>
             </div>

--- a/components/dashboard/molecules/UnifiedLinkManager.tsx
+++ b/components/dashboard/molecules/UnifiedLinkManager.tsx
@@ -61,8 +61,7 @@ export const UnifiedLinkManager: React.FC<UnifiedLinkManagerProps> = ({
             ✨ Add Any Link
           </h3>
           <p className='text-sm text-secondary'>
-            Paste any link and we&apos;ll automatically detect the platform and
-            organize it for you
+            Paste a link — we’ll detect and organize it for you.
           </p>
         </div>
 
@@ -78,11 +77,11 @@ export const UnifiedLinkManager: React.FC<UnifiedLinkManagerProps> = ({
         />
       </div>
 
-      {/* Organized Link Groups */}
+      {/* Organized Link Groups (Collapsible) */}
       {(socialLinks.length > 0 ||
         musicLinks.length > 0 ||
         customLinks.length > 0) && (
-        <div className='space-y-6'>
+        <div className='space-y-4'>
           <div className='flex items-center gap-2'>
             <h3 className='text-lg font-semibold text-primary'>Your Links</h3>
             <span className='text-xs text-secondary bg-surface-2 px-2 py-1 rounded-full'>
@@ -91,74 +90,114 @@ export const UnifiedLinkManager: React.FC<UnifiedLinkManagerProps> = ({
             </span>
           </div>
 
-          <div className='grid gap-6 md:grid-cols-2 lg:grid-cols-3'>
+          <div className='space-y-3'>
             {/* Social Links Group */}
             {socialLinks.length > 0 && (
-              <div className='bg-surface-1 border border-subtle rounded-lg p-4'>
-                <div className='flex items-center gap-2 mb-4'>
-                  <div className='w-2 h-2 bg-blue-500 rounded-full'></div>
-                  <h4 className='text-sm font-medium text-primary'>
-                    Social ({socialLinks.length})
-                  </h4>
-                </div>
-                <div className='space-y-2'>
+              <details className='bg-surface-1 border border-subtle rounded-lg'>
+                <summary className='flex items-center justify-between p-3 cursor-pointer select-none'>
+                  <div className='flex items-center gap-2'>
+                    <div className='w-2 h-2 bg-blue-500 rounded-full'></div>
+                    <span className='text-sm font-medium text-primary'>
+                      Social
+                    </span>
+                    <span className='text-xs text-secondary bg-surface-2 px-2 py-0.5 rounded-full'>
+                      {socialLinks.length}
+                    </span>
+                  </div>
+                  {(() => {
+                    const visible = socialLinks.filter(l => l.isVisible).length;
+                    const hidden = socialLinks.length - visible;
+                    return (
+                      <div className='flex items-center gap-2'>
+                        <span className='text-xs text-secondary'>
+                          {visible}/6 visible
+                        </span>
+                        {hidden > 0 && (
+                          <span className='text-[10px] text-secondary bg-surface-2 px-2 py-0.5 rounded-full'>
+                            {hidden} hidden
+                          </span>
+                        )}
+                      </div>
+                    );
+                  })()}
+                </summary>
+                <div className='p-3 pt-0 space-y-2'>
                   {socialLinks.map(link => (
                     <div
                       key={link.id}
                       className='flex items-center gap-2 text-xs text-secondary'
                     >
                       <span className='w-1 h-1 bg-blue-500 rounded-full'></span>
-                      {link.platform.name}
+                      <span className='truncate'>
+                        {link.platform.name}
+                        {!link.isVisible && (
+                          <span className='ml-2 text-[10px] text-secondary'>
+                            (hidden)
+                          </span>
+                        )}
+                      </span>
                     </div>
                   ))}
                 </div>
-              </div>
+              </details>
             )}
 
             {/* Music Links Group */}
             {musicLinks.length > 0 && (
-              <div className='bg-surface-1 border border-subtle rounded-lg p-4'>
-                <div className='flex items-center gap-2 mb-4'>
-                  <div className='w-2 h-2 bg-green-500 rounded-full'></div>
-                  <h4 className='text-sm font-medium text-primary'>
-                    Music ({musicLinks.length})
-                  </h4>
-                </div>
-                <div className='space-y-2'>
+              <details className='bg-surface-1 border border-subtle rounded-lg'>
+                <summary className='flex items-center justify-between p-3 cursor-pointer select-none'>
+                  <div className='flex items-center gap-2'>
+                    <div className='w-2 h-2 bg-green-500 rounded-full'></div>
+                    <span className='text-sm font-medium text-primary'>
+                      Music
+                    </span>
+                    <span className='text-xs text-secondary bg-surface-2 px-2 py-0.5 rounded-full'>
+                      {musicLinks.length}
+                    </span>
+                  </div>
+                </summary>
+                <div className='p-3 pt-0 space-y-2'>
                   {musicLinks.map(link => (
                     <div
                       key={link.id}
                       className='flex items-center gap-2 text-xs text-secondary'
                     >
                       <span className='w-1 h-1 bg-green-500 rounded-full'></span>
-                      {link.platform.name}
+                      <span className='truncate'>{link.platform.name}</span>
                     </div>
                   ))}
                 </div>
-              </div>
+              </details>
             )}
 
             {/* Custom Links Group */}
             {customLinks.length > 0 && (
-              <div className='bg-surface-1 border border-subtle rounded-lg p-4'>
-                <div className='flex items-center gap-2 mb-4'>
-                  <div className='w-2 h-2 bg-purple-500 rounded-full'></div>
-                  <h4 className='text-sm font-medium text-primary'>
-                    Custom ({customLinks.length})
-                  </h4>
-                </div>
-                <div className='space-y-2'>
+              <details className='bg-surface-1 border border-subtle rounded-lg'>
+                <summary className='flex items-center justify-between p-3 cursor-pointer select-none'>
+                  <div className='flex items-center gap-2'>
+                    <div className='w-2 h-2 bg-purple-500 rounded-full'></div>
+                    <span className='text-sm font-medium text-primary'>
+                      Custom
+                    </span>
+                    <span className='text-xs text-secondary bg-surface-2 px-2 py-0.5 rounded-full'>
+                      {customLinks.length}
+                    </span>
+                  </div>
+                </summary>
+                <div className='p-3 pt-0 space-y-2'>
                   {customLinks.map(link => (
                     <div
                       key={link.id}
                       className='flex items-center gap-2 text-xs text-secondary'
                     >
                       <span className='w-1 h-1 bg-purple-500 rounded-full'></span>
-                      {link.title || link.platform.name}
+                      <span className='truncate'>
+                        {link.title || link.platform.name}
+                      </span>
                     </div>
                   ))}
                 </div>
-              </div>
+              </details>
             )}
           </div>
         </div>


### PR DESCRIPTION
Goal: Improve dashboard links UX for faster, clearer link adding and organization.

Changes:
- Copy: “Paste a link — we’ll detect and organize it for you.” (`components/dashboard/molecules/UnifiedLinkManager.tsx`)
- Contextual Add button: “Add <Platform>” + muted quota badge near the button (`components/dashboard/atoms/UniversalLinkInput.tsx`)
- Per-group limits: Social soft-cap of 6 visible (overflow saved as hidden with clarifying toast); Music unlimited (`components/dashboard/molecules/LinkManager.tsx`)
- Link groups restyled as collapsible categories with counts and hidden-badge for overflow (`components/dashboard/molecules/UnifiedLinkManager.tsx`)

Feature flag: Not added – UX-only polish that doesn’t change data model beyond `isVisible`, already present in LinkItem; happy to wrap with flag if required.

PostHog events: None added (no new primary user action beyond existing add/reorder/delete). Can add if we want to track quota interactions.

Rollback plan: Revert this PR.

CI: `pnpm typecheck && pnpm test` passed locally; pre-push hooks clean.
