### PR TITLE
[fix]: button-a11y-semantics

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -32,26 +32,38 @@ export const Button = forwardRef<
       plain = false,
       loading = false,
       disabled,
+      onClick,
       ...props
     },
     ref
   ) => {
     const isDisabled = disabled || loading;
 
+    // Handle click events for link buttons when disabled/loading
+    const handleClick = (event: React.MouseEvent) => {
+      if (Component === 'a' && isDisabled) {
+        event.preventDefault();
+        return;
+      }
+      if (onClick) {
+        onClick(event as any);
+      }
+    };
+
     const baseClasses =
       'relative isolate inline-flex items-center justify-center rounded-lg font-semibold transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900';
 
     const variantClasses = {
       primary:
-        'bg-black text-white hover:bg-gray-800 focus-visible:ring-gray-500 dark:bg-white dark:text-black dark:hover:bg-gray-100',
+        'bg-black text-white hover:bg-gray-800 focus-visible:ring-blue-500 dark:bg-white dark:text-black dark:hover:bg-gray-100 dark:focus-visible:ring-blue-400',
       secondary:
-        'bg-gray-100 text-black hover:bg-gray-200 focus-visible:ring-gray-400 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700',
+        'bg-gray-100 text-black hover:bg-gray-200 focus-visible:ring-blue-500 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:focus-visible:ring-blue-400',
       ghost:
-        'bg-transparent text-black hover:bg-gray-50 focus-visible:ring-gray-400 dark:text-white dark:hover:bg-gray-900',
+        'bg-transparent text-black hover:bg-gray-50 focus-visible:ring-blue-500 dark:text-white dark:hover:bg-gray-900 dark:focus-visible:ring-blue-400',
       outline:
-        'border border-subtle bg-transparent text-primary hover:bg-surface-1 focus-visible:ring-gray-400',
+        'border border-subtle bg-transparent text-primary hover:bg-surface-1 focus-visible:ring-blue-500 dark:focus-visible:ring-blue-400',
       plain:
-        'bg-transparent text-black hover:bg-gray-50 focus-visible:ring-gray-400 dark:text-white dark:hover:bg-gray-900',
+        'bg-transparent text-black hover:bg-gray-50 focus-visible:ring-blue-500 dark:text-white dark:hover:bg-gray-900 dark:focus-visible:ring-blue-400',
     };
 
     const sizeClasses = {
@@ -83,8 +95,9 @@ export const Button = forwardRef<
       const cursorClass = 'cursor-not-allowed';
       const opacityClass = 'opacity-50';
       const hoverDisabled = 'hover:bg-current hover:text-current';
+      const pointerEventsClass = Component === 'a' ? 'pointer-events-none' : '';
 
-      variantClass = `${opacityClass} ${hoverDisabled}`;
+      variantClass = `${opacityClass} ${hoverDisabled} ${pointerEventsClass}`;
 
       if (variant === 'primary') {
         variantClass +=
@@ -104,11 +117,27 @@ export const Button = forwardRef<
     const classes =
       `${baseClasses} ${variantClass} ${sizeClasses[size]} ${className}`.trim();
 
+    // Prepare additional props based on component type and state
+    const additionalProps: Record<string, any> = {};
+    
+    if (Component === 'button') {
+      additionalProps.type = props.type || 'button';
+      additionalProps.disabled = isDisabled;
+    } else if (Component === 'a' && isDisabled) {
+      additionalProps['aria-disabled'] = 'true';
+      additionalProps.tabIndex = -1;
+    }
+    
+    if (loading) {
+      additionalProps['aria-busy'] = 'true';
+    }
+
     return (
       <Component
         ref={ref as React.Ref<HTMLElement>}
         className={classes}
-        disabled={Component === 'button' ? isDisabled : undefined}
+        onClick={handleClick}
+        {...additionalProps}
         {...props}
       >
         {loading && (

--- a/tests/unit/Button.test.tsx
+++ b/tests/unit/Button.test.tsx
@@ -129,4 +129,96 @@ describe('Button', () => {
     const button = screen.getByRole('button');
     expect(button).toHaveClass('cursor-pointer');
   });
+
+  it('has default type="button" for button elements', () => {
+    render(<Button>Button</Button>);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('type', 'button');
+  });
+
+  it('preserves custom type for button elements', () => {
+    render(<Button type='submit'>Submit</Button>);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('type', 'submit');
+  });
+
+  it('adds aria-busy when loading', () => {
+    render(<Button loading>Loading Button</Button>);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('does not have aria-busy when not loading', () => {
+    render(<Button>Normal Button</Button>);
+    const button = screen.getByRole('button');
+    expect(button).not.toHaveAttribute('aria-busy');
+  });
+
+  describe('link button accessibility', () => {
+    it('prevents navigation when disabled as link', () => {
+      const handleClick = vi.fn();
+      render(
+        <Button as='a' href='/test' disabled onClick={handleClick}>
+          Disabled Link
+        </Button>
+      );
+
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('aria-disabled', 'true');
+      expect(link).toHaveAttribute('tabIndex', '-1');
+      expect(link).toHaveClass('pointer-events-none');
+
+      fireEvent.click(link);
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it('prevents navigation when loading as link', () => {
+      const handleClick = vi.fn();
+      render(
+        <Button as='a' href='/test' loading onClick={handleClick}>
+          Loading Link
+        </Button>
+      );
+
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('aria-disabled', 'true');
+      expect(link).toHaveAttribute('tabIndex', '-1');
+      expect(link).toHaveAttribute('aria-busy', 'true');
+      expect(link).toHaveClass('pointer-events-none');
+
+      fireEvent.click(link);
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it('allows normal navigation when enabled as link', () => {
+      const handleClick = vi.fn();
+      render(
+        <Button as='a' href='/test' onClick={handleClick}>
+          Normal Link
+        </Button>
+      );
+
+      const link = screen.getByRole('link');
+      expect(link).not.toHaveAttribute('aria-disabled');
+      expect(link).not.toHaveAttribute('tabIndex');
+      expect(link).not.toHaveClass('pointer-events-none');
+
+      fireEvent.click(link);
+      expect(handleClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('does not trigger click when loading', () => {
+    const handleClick = vi.fn();
+    render(
+      <Button loading onClick={handleClick}>
+        Loading
+      </Button>
+    );
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+
+    expect(handleClick).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Goal
Improve accessibility semantics and interaction guards for Button when rendered as link/anchor, and align focus ring tokens.

## Changes
- Add aria-busy when loading for screen reader announcements
- Guard Link/as='a' on disabled/loading with aria-disabled, tabIndex=-1, preventDefault, and pointer-events-none
- Default type='button' for button elements unless explicitly overridden
- Align focus ring with accent tokens for sufficient contrast
- Add comprehensive tests for all accessibility improvements

## Testing  
- Disabled Link nav guard tests pass
- aria-busy when loading tests pass
- Default type behavior tests pass

## Rollback Plan
Revert this PR

Generated with [Claude Code](https://claude.ai/code)