### PR TITLE
[fix]: listen-tracking-through-analytics-wrapper

### DIFF
--- a/components/organisms/ListenSection.tsx
+++ b/components/organisms/ListenSection.tsx
@@ -4,6 +4,7 @@ import React, { useEffect } from 'react';
 import { DSPButtonGroup } from '@/components/molecules/DSPButtonGroup';
 import { LISTEN_COOKIE } from '@/constants/app';
 import { getDSPDeepLinkConfig, openDeepLink } from '@/lib/deep-links';
+import { track } from '@/lib/analytics';
 import type { AvailableDSP } from '@/lib/dsp';
 
 export interface ListenSectionProps {
@@ -67,17 +68,10 @@ export function ListenSection({
       // Fire-and-forget tracking
       if (enableTracking) {
         try {
-          fetch('/api/track', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              handle,
-              linkType: 'listen',
-              target: dspKey,
-            }),
-            keepalive: true,
-          }).catch(() => {
-            // Silent fail for analytics - don't disrupt user experience
+          track('listen_button_click', {
+            handle,
+            linkType: 'listen',
+            target: dspKey,
           });
         } catch {
           // noop

--- a/components/profile/StaticListenInterface.tsx
+++ b/components/profile/StaticListenInterface.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 // Lazy import deep links to avoid loading heavy code upfront
 import { LISTEN_COOKIE } from '@/constants/app';
+import { track } from '@/lib/analytics';
 import { AvailableDSP, getAvailableDSPs } from '@/lib/dsp';
 import { Artist } from '@/types/db';
 
@@ -86,12 +87,13 @@ export const StaticListenInterface = React.memo(function StaticListenInterface({
       } catch {}
 
       // Track click (non-blocking)
-      fetch('/api/track', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ handle, linkType: 'listen', target: dsp.key }),
-        keepalive: true,
-      }).catch(() => {});
+      try {
+        track('listen_button_click', {
+          handle,
+          linkType: 'listen',
+          target: dsp.key,
+        });
+      } catch {};
 
       // Try deep linking with lazy import
       try {


### PR DESCRIPTION
## Goal
Route listen tracking through centralized analytics wrapper instead of direct API calls.

## Changes  
- Replace direct fetch('/api/track') calls in ListenSection.tsx and StaticListenInterface.tsx
- Use track() from @/lib/analytics with proper event structure
- Fire listen_button_click events with handle, linkType: 'listen', and target: dspKey
- Maintain fire-and-forget semantics without blocking UI

## Testing
- Verify analytics events fire correctly
- Ensure no performance regressions  
- Maintain existing listen button functionality

Closes #764

Generated with [Claude Code](https://claude.ai/code)