### PR TITLE
fix: resolve DashboardOverview SSR event handler error

### DIFF
--- a/components/dashboard/organisms/DashboardOverview.tsx
+++ b/components/dashboard/organisms/DashboardOverview.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import type { DashboardData } from '@/app/dashboard/actions';
 import { CopyToClipboardButton } from '@/components/dashboard/atoms/CopyToClipboardButton';
@@ -66,19 +68,21 @@ export function DashboardOverview({ initialData }: DashboardOverviewProps) {
             {/* Progress indicator */}
             <div className='mb-4'>
               <div className='flex justify-between items-center mb-2'>
-                <span className='text-sm text-secondary-token'>Setup Progress</span>
+                <span className='text-sm text-secondary-token'>
+                  Setup Progress
+                </span>
                 <span className='text-sm text-secondary-token'>{`${completedCount}/${totalSteps}`}</span>
               </div>
-              <div 
-                role='progressbar' 
-                aria-valuenow={completedCount} 
-                aria-valuemin={0} 
+              <div
+                role='progressbar'
+                aria-valuenow={completedCount}
+                aria-valuemin={0}
                 aria-valuemax={totalSteps}
                 aria-label={`Setup progress: ${completedCount} of ${totalSteps} steps completed`}
                 className='w-full bg-surface-2 rounded-full h-2'
               >
-                <div 
-                  className='bg-accent h-2 rounded-full transition-all duration-300 ease-in-out' 
+                <div
+                  className='bg-accent h-2 rounded-full transition-all duration-300 ease-in-out'
                   style={{ width: `${(completedCount / totalSteps) * 100}%` }}
                 />
               </div>

--- a/tests/unit/CopyToClipboardButton.test.tsx
+++ b/tests/unit/CopyToClipboardButton.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { vi, expect } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { expect, vi } from 'vitest';
 import { CopyToClipboardButton } from '@/components/dashboard/atoms/CopyToClipboardButton';
 
 // Mock the analytics module
@@ -30,7 +30,7 @@ const setupClipboardMocks = (
       value: mockClipboard,
       writable: true,
     });
-    
+
     if (clipboardSuccess) {
       mockClipboard.writeText.mockResolvedValue(undefined);
     } else {
@@ -42,68 +42,72 @@ const setupClipboardMocks = (
       writable: true,
     });
   }
-  
+
   Object.defineProperty(document, 'execCommand', {
     value: mockExecCommand,
     writable: true,
   });
-  
+
   mockExecCommand.mockReturnValue(execCommandSuccess);
 };
 
+import { track } from '@/lib/analytics';
+
 describe('CopyToClipboardButton', () => {
-  const { track } = require('@/lib/analytics');
-  
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
   });
-  
+
   afterEach(() => {
     vi.useRealTimers();
   });
 
   it('renders with default labels', () => {
     setupClipboardMocks(true);
-    
-    render(<CopyToClipboardButton relativePath="/test-profile" />);
-    
+
+    render(<CopyToClipboardButton relativePath='/test-profile' />);
+
     expect(screen.getByRole('button')).toHaveTextContent('Copy URL');
   });
 
   it('renders with custom labels', () => {
     setupClipboardMocks(true);
-    
+
     render(
-      <CopyToClipboardButton 
-        relativePath="/test-profile"
-        idleLabel="Copy Link"
-        successLabel="Link Copied!"
-        errorLabel="Copy Failed"
+      <CopyToClipboardButton
+        relativePath='/test-profile'
+        idleLabel='Copy Link'
+        successLabel='Link Copied!'
+        errorLabel='Copy Failed'
       />
     );
-    
+
     expect(screen.getByRole('button')).toHaveTextContent('Copy Link');
   });
 
   it('successfully copies URL using clipboard API', async () => {
     setupClipboardMocks(true, true);
-    
-    render(<CopyToClipboardButton relativePath="/test-profile" />);
-    
+
+    render(<CopyToClipboardButton relativePath='/test-profile' />);
+
     const button = screen.getByRole('button');
     fireEvent.click(button);
-    
+
     await waitFor(() => {
       expect(button).toHaveTextContent('✓ Copied!');
     });
-    
-    expect(mockClipboard.writeText).toHaveBeenCalledWith('https://jov.ie/test-profile');
-    expect(track).toHaveBeenCalledWith('profile_copy_url_click', { status: 'success' });
-    
+
+    expect(mockClipboard.writeText).toHaveBeenCalledWith(
+      'https://jov.ie/test-profile'
+    );
+    expect(track).toHaveBeenCalledWith('profile_copy_url_click', {
+      status: 'success',
+    });
+
     // Check that it returns to idle state after timeout
     vi.runAllTimers();
-    
+
     await waitFor(() => {
       expect(button).toHaveTextContent('Copy URL');
     });
@@ -111,7 +115,7 @@ describe('CopyToClipboardButton', () => {
 
   it('falls back to textarea method when clipboard API unavailable', async () => {
     setupClipboardMocks(false, false, true);
-    
+
     // Mock DOM methods for fallback
     const mockTextarea = {
       focus: vi.fn(),
@@ -119,35 +123,35 @@ describe('CopyToClipboardButton', () => {
       value: '',
       style: {},
     };
-    
+
     const mockAppendChild = vi.fn();
     const mockRemoveChild = vi.fn();
     const mockCreateElement = vi.fn().mockReturnValue(mockTextarea);
-    
+
     Object.defineProperty(document, 'createElement', {
       value: mockCreateElement,
       writable: true,
     });
-    
+
     Object.defineProperty(document.body, 'appendChild', {
       value: mockAppendChild,
       writable: true,
     });
-    
+
     Object.defineProperty(document.body, 'removeChild', {
       value: mockRemoveChild,
       writable: true,
     });
-    
-    render(<CopyToClipboardButton relativePath="/test-profile" />);
-    
+
+    render(<CopyToClipboardButton relativePath='/test-profile' />);
+
     const button = screen.getByRole('button');
     fireEvent.click(button);
-    
+
     await waitFor(() => {
       expect(button).toHaveTextContent('✓ Copied!');
     });
-    
+
     expect(mockCreateElement).toHaveBeenCalledWith('textarea');
     expect(mockTextarea.value).toBe('https://jov.ie/test-profile');
     expect(mockTextarea.focus).toHaveBeenCalled();
@@ -155,12 +159,14 @@ describe('CopyToClipboardButton', () => {
     expect(mockExecCommand).toHaveBeenCalledWith('copy');
     expect(mockAppendChild).toHaveBeenCalledWith(mockTextarea);
     expect(mockRemoveChild).toHaveBeenCalledWith(mockTextarea);
-    expect(track).toHaveBeenCalledWith('profile_copy_url_click', { status: 'success' });
+    expect(track).toHaveBeenCalledWith('profile_copy_url_click', {
+      status: 'success',
+    });
   });
 
   it('tries fallback when clipboard API fails', async () => {
     setupClipboardMocks(true, false, true);
-    
+
     // Mock DOM methods for fallback
     const mockTextarea = {
       focus: vi.fn(),
@@ -168,45 +174,49 @@ describe('CopyToClipboardButton', () => {
       value: '',
       style: {},
     };
-    
+
     const mockAppendChild = vi.fn();
     const mockRemoveChild = vi.fn();
     const mockCreateElement = vi.fn().mockReturnValue(mockTextarea);
-    
+
     Object.defineProperty(document, 'createElement', {
       value: mockCreateElement,
       writable: true,
     });
-    
+
     Object.defineProperty(document.body, 'appendChild', {
       value: mockAppendChild,
       writable: true,
     });
-    
+
     Object.defineProperty(document.body, 'removeChild', {
       value: mockRemoveChild,
       writable: true,
     });
-    
-    render(<CopyToClipboardButton relativePath="/test-profile" />);
-    
+
+    render(<CopyToClipboardButton relativePath='/test-profile' />);
+
     const button = screen.getByRole('button');
     fireEvent.click(button);
-    
+
     await waitFor(() => {
       expect(button).toHaveTextContent('✓ Copied!');
     });
-    
+
     // Should try clipboard first, then fall back
-    expect(mockClipboard.writeText).toHaveBeenCalledWith('https://jov.ie/test-profile');
+    expect(mockClipboard.writeText).toHaveBeenCalledWith(
+      'https://jov.ie/test-profile'
+    );
     expect(mockCreateElement).toHaveBeenCalledWith('textarea');
     expect(mockExecCommand).toHaveBeenCalledWith('copy');
-    expect(track).toHaveBeenCalledWith('profile_copy_url_click', { status: 'success' });
+    expect(track).toHaveBeenCalledWith('profile_copy_url_click', {
+      status: 'success',
+    });
   });
 
   it('shows error when both methods fail', async () => {
     setupClipboardMocks(true, false, false);
-    
+
     // Mock DOM methods for fallback that also fails
     const mockTextarea = {
       focus: vi.fn(),
@@ -214,68 +224,72 @@ describe('CopyToClipboardButton', () => {
       value: '',
       style: {},
     };
-    
+
     const mockAppendChild = vi.fn();
     const mockRemoveChild = vi.fn();
     const mockCreateElement = vi.fn().mockReturnValue(mockTextarea);
-    
+
     Object.defineProperty(document, 'createElement', {
       value: mockCreateElement,
       writable: true,
     });
-    
+
     Object.defineProperty(document.body, 'appendChild', {
       value: mockAppendChild,
       writable: true,
     });
-    
+
     Object.defineProperty(document.body, 'removeChild', {
       value: mockRemoveChild,
       writable: true,
     });
-    
-    render(<CopyToClipboardButton relativePath="/test-profile" />);
-    
+
+    render(<CopyToClipboardButton relativePath='/test-profile' />);
+
     const button = screen.getByRole('button');
     fireEvent.click(button);
-    
+
     await waitFor(() => {
       expect(button).toHaveTextContent('Failed to copy');
     });
-    
-    expect(track).toHaveBeenCalledWith('profile_copy_url_click', { status: 'error' });
+
+    expect(track).toHaveBeenCalledWith('profile_copy_url_click', {
+      status: 'error',
+    });
   });
 
   it('shows error when fallback throws exception', async () => {
     setupClipboardMocks(false, false, false);
-    
+
     // Mock DOM methods that throw errors
     const mockCreateElement = vi.fn().mockImplementation(() => {
       throw new Error('createElement failed');
     });
-    
+
     Object.defineProperty(document, 'createElement', {
       value: mockCreateElement,
       writable: true,
     });
-    
-    render(<CopyToClipboardButton relativePath="/test-profile" />);
-    
+
+    render(<CopyToClipboardButton relativePath='/test-profile' />);
+
     const button = screen.getByRole('button');
     fireEvent.click(button);
-    
+
     await waitFor(() => {
       expect(button).toHaveTextContent('Failed to copy');
     });
-    
-    expect(track).toHaveBeenCalledWith('profile_copy_url_click', { status: 'error' });
+
+    expect(track).toHaveBeenCalledWith('profile_copy_url_click', {
+      status: 'error',
+    });
   });
 
   it('has proper accessibility attributes', () => {
     setupClipboardMocks(true);
-    
-    render(<CopyToClipboardButton relativePath="/test-profile" />);
-    
+
+    render(<CopyToClipboardButton relativePath='/test-profile' />);
+
     const statusElement = screen.getByRole('status');
     expect(statusElement).toHaveAttribute('aria-live', 'polite');
     expect(statusElement).toHaveClass('sr-only');
@@ -283,26 +297,28 @@ describe('CopyToClipboardButton', () => {
 
   it('updates accessibility status on success', async () => {
     setupClipboardMocks(true, true);
-    
-    render(<CopyToClipboardButton relativePath="/test-profile" />);
-    
+
+    render(<CopyToClipboardButton relativePath='/test-profile' />);
+
     const button = screen.getByRole('button');
     fireEvent.click(button);
-    
+
     await waitFor(() => {
       const statusElement = screen.getByRole('status');
-      expect(statusElement).toHaveTextContent('Profile URL copied to clipboard');
+      expect(statusElement).toHaveTextContent(
+        'Profile URL copied to clipboard'
+      );
     });
   });
 
   it('updates accessibility status on error', async () => {
     setupClipboardMocks(true, false, false);
-    
-    render(<CopyToClipboardButton relativePath="/test-profile" />);
-    
+
+    render(<CopyToClipboardButton relativePath='/test-profile' />);
+
     const button = screen.getByRole('button');
     fireEvent.click(button);
-    
+
     await waitFor(() => {
       const statusElement = screen.getByRole('status');
       expect(statusElement).toHaveTextContent('Failed to copy profile URL');


### PR DESCRIPTION
## Goal
Fix runtime error: Event handlers cannot be passed to Client Component props in DashboardOverview.

## Changes
- Added 'use client' directive to DashboardOverview component to handle interactive Button elements
- Fixed require() import to ES6 import in CopyToClipboardButton test file

## Error Fixed
Event handlers cannot be passed to Client Component props

## Testing
- TypeScript compilation passes
- Component can now handle interactive elements properly  
- No more SSR/client boundary violations

## Rollback Plan
Revert this PR

Generated with [Claude Code](https://claude.ai/code)