### PR TITLE
feat: enhance footer link handling

### DIFF
--- a/components/atoms/FooterLink.README.md
+++ b/components/atoms/FooterLink.README.md
@@ -1,0 +1,18 @@
+# FooterLink Component
+
+A lightweight link optimized for footer navigation with automatic external-link handling.
+
+## Usage
+
+### Internal link
+```tsx
+import { FooterLink } from '@/components/atoms/FooterLink';
+
+<FooterLink href="/about">About</FooterLink>
+```
+
+### External link
+```tsx
+<FooterLink href="https://example.com">Example</FooterLink>
+```
+External links open in a new tab with `rel="noopener noreferrer"` applied.

--- a/components/atoms/FooterLink.tsx
+++ b/components/atoms/FooterLink.tsx
@@ -1,4 +1,16 @@
 import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+const baseStyles = 'transition-colors';
+const variantStyles = {
+  light:
+    'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white',
+  dark: 'text-white/60 hover:text-white',
+} as const;
+
+function isExternal(href: string) {
+  return /^https?:\/\//.test(href);
+}
 
 interface FooterLinkProps {
   href: string;
@@ -13,17 +25,14 @@ export function FooterLink({
   variant = 'dark',
   className = '',
 }: FooterLinkProps) {
-  const baseStyles = 'transition-colors';
-  const variantStyles = {
-    light:
-      'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white',
-    dark: 'text-white/60 hover:text-white',
-  };
+  const external = isExternal(href);
 
   return (
     <Link
       href={href}
-      className={`${baseStyles} ${variantStyles[variant]} ${className}`}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noopener noreferrer' : undefined}
+      className={cn(baseStyles, variantStyles[variant], className)}
     >
       {children}
     </Link>


### PR DESCRIPTION
## Summary
- improve FooterLink style composition using `cn`
- open external footer links in new tabs
- document internal and external FooterLink usage

## Testing
- `pnpm lint` *(fails: __tests__/components/atoms/AvatarAvatar.error-handling.test.tsx 2:32 'vi' is defined but never used)*
- `pnpm test` *(fails: require() of ES Module @vitejs/plugin-react from vitest.config.ts not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc55685cc8327a8d316a83b5cc29f