### PR TITLE
feat: add as prop and refactor GradientText

### DIFF
--- a/components/atoms/GradientText.tsx
+++ b/components/atoms/GradientText.tsx
@@ -1,34 +1,44 @@
+import type { ElementType, ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+const variantClasses = {
+  primary:
+    'from-blue-600 via-purple-600 to-cyan-600 dark:from-blue-400 dark:via-purple-400 dark:to-cyan-400',
+  secondary: 'from-gray-600 to-gray-800 dark:from-gray-300 dark:to-gray-100',
+  success:
+    'from-green-600 to-emerald-600 dark:from-green-400 dark:to-emerald-400',
+  warning:
+    'from-yellow-600 to-orange-600 dark:from-yellow-400 dark:to-orange-400',
+  'purple-cyan':
+    'from-purple-600 to-cyan-600 dark:from-purple-400 dark:to-cyan-400',
+} as const;
+
 export interface GradientTextProps {
   /** Text content to display with gradient */
-  children: React.ReactNode;
+  children: ReactNode;
   /** Gradient color scheme variant */
-  variant?: 'primary' | 'secondary' | 'success' | 'warning' | 'purple-cyan';
+  variant?: keyof typeof variantClasses;
   /** Additional CSS classes */
   className?: string;
+  /** Element type to render */
+  as?: ElementType;
 }
 
 export function GradientText({
   children,
   variant = 'primary',
   className = '',
+  as: Component = 'span',
 }: GradientTextProps) {
-  const variantClasses = {
-    primary:
-      'from-blue-600 via-purple-600 to-cyan-600 dark:from-blue-400 dark:via-purple-400 dark:to-cyan-400',
-    secondary: 'from-gray-600 to-gray-800 dark:from-gray-300 dark:to-gray-100',
-    success:
-      'from-green-600 to-emerald-600 dark:from-green-400 dark:to-emerald-400',
-    warning:
-      'from-yellow-600 to-orange-600 dark:from-yellow-400 dark:to-orange-400',
-    'purple-cyan':
-      'from-purple-600 to-cyan-600 dark:from-purple-400 dark:to-cyan-400',
-  };
-
   return (
-    <span
-      className={`text-transparent bg-gradient-to-r ${variantClasses[variant]} bg-clip-text ${className}`}
+    <Component
+      className={cn(
+        'text-transparent bg-gradient-to-r',
+        variantClasses[variant],
+        className
+      )}
     >
       {children}
-    </span>
+    </Component>
   );
 }


### PR DESCRIPTION
## Summary
- refactor GradientText to reuse variantClasses at module scope
- streamline gradient styling with `cn`
- add optional `as` prop for semantic flexibility

## Testing
- `pnpm lint` *(fails: '__tests__/components/atoms/AvatarAvatar.error-handling.test.tsx:2:32  error  "vi" is defined but never used')*
- `npx eslint components/atoms/GradientText.tsx`
- `pnpm test` *(fails: Can't find meta/_journal.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc5537cf08327aeac502d048f2c0f