### PR TITLE
feat: enhance IconBadge accessibility

### DIFF
--- a/components/atoms/IconBadge.tsx
+++ b/components/atoms/IconBadge.tsx
@@ -1,15 +1,25 @@
 import React from 'react';
+import { cn } from '@/lib/utils';
 
 interface IconBadgeProps {
   Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   colorVar: string;
   className?: string;
+  ariaLabel?: string;
 }
 
-export function IconBadge({ Icon, colorVar, className = '' }: IconBadgeProps) {
+export function IconBadge({
+  Icon,
+  colorVar,
+  className,
+  ariaLabel,
+}: IconBadgeProps) {
   return (
     <div
-      className={`relative flex h-8 w-8 items-center justify-center rounded-full ${className}`}
+      className={cn(
+        'relative flex h-8 w-8 items-center justify-center rounded-full',
+        className
+      )}
       style={{
         backgroundColor: `color-mix(in srgb, var(${colorVar}) 12%, transparent)`,
       }}
@@ -19,8 +29,9 @@ export function IconBadge({ Icon, colorVar, className = '' }: IconBadgeProps) {
         style={{
           color: `var(${colorVar})`,
         }}
-        role='img'
-        aria-hidden='true'
+        aria-hidden={ariaLabel ? false : true}
+        role={ariaLabel ? 'img' : undefined}
+        aria-label={ariaLabel}
       />
     </div>
   );

--- a/tests/unit/IconBadge.test.tsx
+++ b/tests/unit/IconBadge.test.tsx
@@ -7,16 +7,19 @@ describe('IconBadge', () => {
   afterEach(cleanup);
 
   it('renders icon with correct styling', () => {
-    render(<IconBadge Icon={BoltIcon} colorVar='--accent-speed' />);
+    const { container } = render(
+      <IconBadge Icon={BoltIcon} colorVar='--accent-speed' />
+    );
 
-    const iconContainer = screen.getByRole('img', {
-      hidden: true,
-    }).parentElement;
+    const icon = container.querySelector('svg');
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+    expect(icon).not.toHaveAttribute('role');
+    const iconContainer = icon?.parentElement;
     expect(iconContainer).toHaveClass('h-8', 'w-8', 'rounded-full');
   });
 
   it('applies custom className', () => {
-    render(
+    const { container } = render(
       <IconBadge
         Icon={BoltIcon}
         colorVar='--accent-speed'
@@ -24,9 +27,21 @@ describe('IconBadge', () => {
       />
     );
 
-    const iconContainer = screen.getByRole('img', {
-      hidden: true,
-    }).parentElement;
+    const iconContainer = container.firstChild as HTMLElement;
     expect(iconContainer).toHaveClass('custom-class');
+  });
+
+  it('uses aria-label when provided', () => {
+    render(
+      <IconBadge
+        Icon={BoltIcon}
+        colorVar='--accent-speed'
+        ariaLabel='Bolt icon'
+      />
+    );
+
+    const icon = screen.getByLabelText('Bolt icon');
+    expect(icon).toHaveAttribute('role', 'img');
+    expect(icon).toHaveAttribute('aria-hidden', 'false');
   });
 });


### PR DESCRIPTION
## Summary
- improve IconBadge accessibility with optional ariaLabel
- apply role only when labeled and default to aria-hidden
- use cn for class merging and update tests

## Testing
- `pnpm exec eslint components/atoms/IconBadge.tsx tests/unit/IconBadge.test.tsx`
- `env -u DATABASE_URL pnpm test tests/unit/IconBadge.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bbc537405c8327b1d736d7d92b90d7