### PR TITLE
feat: enhance social icon lookup and accessibility

### DIFF
--- a/__tests__/components/atoms/AvatarAvatar.error-handling.test.tsx
+++ b/__tests__/components/atoms/AvatarAvatar.error-handling.test.tsx
@@ -1,15 +1,15 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { ArtistAvatar } from '@/components/atoms/ArtistAvatar';
 
 describe('ArtistAvatar - Basic Functionality', () => {
   it('should render with required props', () => {
     render(
       <ArtistAvatar
-        src="test-image.jpg"
-        alt="Test Artist"
-        name="Test Artist"
-        size="md"
+        src='test-image.jpg'
+        alt='Test Artist'
+        name='Test Artist'
+        size='md'
       />
     );
 
@@ -21,10 +21,10 @@ describe('ArtistAvatar - Basic Functionality', () => {
   it('should have proper accessibility attributes', () => {
     render(
       <ArtistAvatar
-        src="test-image.jpg"
-        alt="Test Artist Avatar"
-        name="Test Artist"
-        size="md"
+        src='test-image.jpg'
+        alt='Test Artist Avatar'
+        name='Test Artist'
+        size='md'
       />
     );
 
@@ -35,10 +35,10 @@ describe('ArtistAvatar - Basic Functionality', () => {
   it('should pass through size prop correctly', () => {
     render(
       <ArtistAvatar
-        src="test-image.jpg"
-        alt="Test Artist"
-        name="Test Artist"
-        size="lg"
+        src='test-image.jpg'
+        alt='Test Artist'
+        name='Test Artist'
+        size='lg'
       />
     );
 

--- a/components/atoms/SocialIcon.tsx
+++ b/components/atoms/SocialIcon.tsx
@@ -20,11 +20,13 @@ import {
   siX,
   siYoutube,
 } from 'simple-icons';
+import { cn } from '@/lib/utils';
 
 interface SocialIconProps {
   platform: string;
   className?: string;
   size?: number;
+  ariaLabel?: string;
 }
 
 // Map platform names to Simple Icons
@@ -57,10 +59,18 @@ export function getPlatformIcon(platform: string): SimpleIcon | undefined {
   return platformMap[platform.toLowerCase()];
 }
 
-export function SocialIcon({ platform, className, size }: SocialIconProps) {
-  const icon = platformMap[platform.toLowerCase()];
-  const iconClass = className || 'h-4 w-4';
+export function SocialIcon({
+  platform,
+  className,
+  size,
+  ariaLabel,
+}: SocialIconProps) {
+  const icon = getPlatformIcon(platform);
+  const iconClass = cn('h-4 w-4', className);
   const sizeStyle = size ? { width: size, height: size } : undefined;
+  const accessibilityProps = ariaLabel
+    ? { 'aria-label': ariaLabel }
+    : { 'aria-hidden': 'true' };
 
   if (icon) {
     return (
@@ -69,7 +79,7 @@ export function SocialIcon({ platform, className, size }: SocialIconProps) {
         style={sizeStyle}
         fill='currentColor'
         viewBox='0 0 24 24'
-        aria-hidden='true'
+        {...accessibilityProps}
       >
         <path d={icon.path} />
       </svg>
@@ -84,7 +94,7 @@ export function SocialIcon({ platform, className, size }: SocialIconProps) {
       fill='none'
       stroke='currentColor'
       viewBox='0 0 24 24'
-      aria-hidden='true'
+      {...accessibilityProps}
     >
       <path
         strokeLinecap='round'


### PR DESCRIPTION
## Summary
- export and reuse `getPlatformIcon` inside `SocialIcon`
- allow callers to extend icon styling via `cn`
- support optional `ariaLabel` for screen readers

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Can't find meta/_journal.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc5328df88327a277f985dc395246