### PR TITLE
feat: add disabled prop to AmountSelector

### DIFF
--- a/__tests__/components/atoms/AvatarAvatar.error-handling.test.tsx
+++ b/__tests__/components/atoms/AvatarAvatar.error-handling.test.tsx
@@ -1,15 +1,15 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { ArtistAvatar } from '@/components/atoms/ArtistAvatar';
 
 describe('ArtistAvatar - Basic Functionality', () => {
   it('should render with required props', () => {
     render(
       <ArtistAvatar
-        src="test-image.jpg"
-        alt="Test Artist"
-        name="Test Artist"
-        size="md"
+        src='test-image.jpg'
+        alt='Test Artist'
+        name='Test Artist'
+        size='md'
       />
     );
 
@@ -21,10 +21,10 @@ describe('ArtistAvatar - Basic Functionality', () => {
   it('should have proper accessibility attributes', () => {
     render(
       <ArtistAvatar
-        src="test-image.jpg"
-        alt="Test Artist Avatar"
-        name="Test Artist"
-        size="md"
+        src='test-image.jpg'
+        alt='Test Artist Avatar'
+        name='Test Artist'
+        size='md'
       />
     );
 
@@ -35,10 +35,10 @@ describe('ArtistAvatar - Basic Functionality', () => {
   it('should pass through size prop correctly', () => {
     render(
       <ArtistAvatar
-        src="test-image.jpg"
-        alt="Test Artist"
-        name="Test Artist"
-        size="lg"
+        src='test-image.jpg'
+        alt='Test Artist'
+        name='Test Artist'
+        size='lg'
       />
     );
 

--- a/components/atoms/AmountSelector.stories.tsx
+++ b/components/atoms/AmountSelector.stories.tsx
@@ -16,6 +16,9 @@ const meta: Meta<typeof AmountSelector> = {
     isSelected: {
       control: { type: 'boolean' },
     },
+    disabled: {
+      control: { type: 'boolean' },
+    },
   },
 };
 
@@ -27,6 +30,7 @@ export const Default: Story = {
     amount: 5,
     isSelected: false,
     onClick: () => {},
+    disabled: false,
   },
 };
 
@@ -35,6 +39,7 @@ export const Selected: Story = {
     amount: 10,
     isSelected: true,
     onClick: () => {},
+    disabled: false,
   },
 };
 
@@ -43,6 +48,7 @@ export const SmallAmount: Story = {
     amount: 3,
     isSelected: false,
     onClick: () => {},
+    disabled: false,
   },
 };
 
@@ -51,6 +57,7 @@ export const LargeAmount: Story = {
     amount: 25,
     isSelected: false,
     onClick: () => {},
+    disabled: false,
   },
 };
 
@@ -79,8 +86,18 @@ export const InDarkMode: Story = {
     amount: 7,
     isSelected: true,
     onClick: () => {},
+    disabled: false,
   },
   parameters: {
     backgrounds: { default: 'dark' },
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    amount: 5,
+    isSelected: false,
+    onClick: () => {},
+    disabled: true,
   },
 };

--- a/components/atoms/AmountSelector.tsx
+++ b/components/atoms/AmountSelector.tsx
@@ -5,6 +5,7 @@ interface AmountSelectorProps {
   isSelected: boolean;
   onClick: () => void;
   className?: string;
+  disabled?: boolean;
 }
 
 export function AmountSelector({
@@ -12,6 +13,7 @@ export function AmountSelector({
   isSelected,
   onClick,
   className,
+  disabled,
 }: AmountSelectorProps) {
   return (
     <button
@@ -19,8 +21,11 @@ export function AmountSelector({
       onClick={onClick}
       aria-pressed={isSelected}
       aria-label={`Select $${amount} tip amount`}
+      disabled={disabled}
+      aria-disabled={disabled}
       className={cn(
-        'w-full aspect-square rounded-xl border text-lg font-semibold transition-colors flex items-center justify-center cursor-pointer',
+        'w-full aspect-square rounded-xl border text-lg font-semibold transition-colors flex items-center justify-center',
+        disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
         'bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100',
         isSelected
           ? 'border-purple-500 ring-2 ring-purple-200/60 dark:ring-purple-600/30'
@@ -28,7 +33,7 @@ export function AmountSelector({
         className
       )}
     >
-      ${amount}
+      <span aria-hidden>{'$' + amount}</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- allow AmountSelector to hide visual dollars from screen readers
- add optional disabled prop and accessible button styling
- document disabled state in story and fix unused test import

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Can't find meta/_journal.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc441c790832786353e1153a0abe4