### PR TITLE
refactor: externalize status badge styles

### DIFF
--- a/components/atoms/StatusBadge.tsx
+++ b/components/atoms/StatusBadge.tsx
@@ -1,14 +1,24 @@
+import { cn } from '@/lib/utils';
+import {
+  type StatusBadgeSize,
+  type StatusBadgeVariant,
+  sizeClasses,
+  variantClasses,
+} from './StatusBadgeStyles';
+
 export interface StatusBadgeProps {
   /** Badge text content */
   children: React.ReactNode;
   /** Color variant for the badge */
-  variant?: 'blue' | 'green' | 'purple' | 'orange' | 'red' | 'gray';
+  variant?: StatusBadgeVariant;
   /** Optional icon to display before text */
   icon?: React.ReactNode;
   /** Size variant */
-  size?: 'sm' | 'md' | 'lg';
+  size?: StatusBadgeSize;
   /** Additional CSS classes */
   className?: string;
+  /** Whether the badge communicates dynamic state */
+  dynamic?: boolean;
 }
 
 export function StatusBadge({
@@ -17,30 +27,17 @@ export function StatusBadge({
   icon,
   size = 'md',
   className = '',
+  dynamic = false,
 }: StatusBadgeProps) {
-  const variantClasses = {
-    blue: 'bg-blue-500/10 border-blue-500/20 text-blue-400',
-    green: 'bg-green-500/10 border-green-500/20 text-green-400',
-    purple: 'bg-purple-500/10 border-purple-500/20 text-purple-400',
-    orange: 'bg-orange-500/10 border-orange-500/20 text-orange-400',
-    red: 'bg-red-500/10 border-red-500/20 text-red-400',
-    gray: 'bg-gray-500/10 border-gray-500/20 text-gray-400',
-  };
-
-  const sizeClasses = {
-    sm: 'px-3 py-1 text-xs',
-    md: 'px-4 py-2 text-sm',
-    lg: 'px-5 py-2.5 text-base',
-  };
-
   return (
     <div
-      className={`
-        inline-flex items-center gap-2 rounded-full border font-medium
-        ${variantClasses[variant]} 
-        ${sizeClasses[size]} 
-        ${className}
-      `}
+      role={dynamic ? 'status' : undefined}
+      className={cn(
+        'inline-flex items-center gap-2 rounded-full border font-medium',
+        variantClasses[variant],
+        sizeClasses[size],
+        className
+      )}
     >
       {icon && <span className='flex-shrink-0'>{icon}</span>}
       <span>{children}</span>

--- a/components/atoms/StatusBadgeStyles.ts
+++ b/components/atoms/StatusBadgeStyles.ts
@@ -1,0 +1,17 @@
+export const variantClasses = {
+  blue: 'bg-blue-500/10 border-blue-500/20 text-blue-400',
+  green: 'bg-green-500/10 border-green-500/20 text-green-400',
+  purple: 'bg-purple-500/10 border-purple-500/20 text-purple-400',
+  orange: 'bg-orange-500/10 border-orange-500/20 text-orange-400',
+  red: 'bg-red-500/10 border-red-500/20 text-red-400',
+  gray: 'bg-gray-500/10 border-gray-500/20 text-gray-400',
+} as const;
+
+export const sizeClasses = {
+  sm: 'px-3 py-1 text-xs',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-5 py-2.5 text-base',
+} as const;
+
+export type StatusBadgeVariant = keyof typeof variantClasses;
+export type StatusBadgeSize = keyof typeof sizeClasses;


### PR DESCRIPTION
## Summary
- extract status badge variant and size maps to reusable module
- use `cn` utility to merge base, variant, size, and custom classes
- add optional `dynamic` flag that applies `role="status"`

## Testing
- `pnpm exec eslint --format json components/atoms/StatusBadge.tsx components/atoms/StatusBadgeStyles.ts`
- `pnpm test` *(fails: Can't find meta/_journal.json file, numerous suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_68bbc53083cc83278f223271de34d384