### PR TITLE
refactor: use cn utility in logo and section heading

### DIFF
--- a/components/atoms/LogoLink.tsx
+++ b/components/atoms/LogoLink.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { Logo } from '@/components/ui/Logo';
+import { cn } from '@/lib/utils';
 
 interface LogoLinkProps {
   href?: string;
@@ -15,7 +16,7 @@ export function LogoLink({
   return (
     <Link
       href={href}
-      className={`flex items-center space-x-2 ${className || ''}`}
+      className={cn('flex items-center space-x-2', className)}
       aria-label='Jovie'
     >
       <Logo size={logoSize} />

--- a/components/atoms/SectionHeading.tsx
+++ b/components/atoms/SectionHeading.tsx
@@ -1,3 +1,5 @@
+import { cn } from '@/lib/utils';
+
 export interface SectionHeadingProps {
   level?: 1 | 2 | 3 | 4 | 5 | 6;
   children: React.ReactNode;
@@ -34,7 +36,12 @@ export function SectionHeading({
   return (
     <Tag
       id={id}
-      className={`font-bold tracking-tight text-gray-900 dark:text-white ${sizeClasses[size]} ${alignClasses[align]} ${className}`}
+      className={cn(
+        'font-bold tracking-tight text-gray-900 dark:text-white',
+        sizeClasses[size],
+        alignClasses[align],
+        className
+      )}
       style={{ letterSpacing: '-0.02em' }}
     >
       {children}


### PR DESCRIPTION
## Summary
- import `cn` and clean up class names in `LogoLink`
- import `cn` and refactor classes in `SectionHeading`

## Testing
- `pnpm lint` *(fails: '__tests__/components/atoms/AvatarAvatar.error-handling.test.tsx 2:32  error  "vi" is defined but never used')*
- `pnpm test` *(fails: many suites, e.g. 'Can't find meta/_journal.json file')*


------
https://chatgpt.com/codex/tasks/task_e_68bbc446e0988327bea471c838f7efca