### PR TITLE
feat: improve artist avatar error handling

### DIFF
--- a/__tests__/components/atoms/AvatarAvatar.error-handling.test.tsx
+++ b/__tests__/components/atoms/AvatarAvatar.error-handling.test.tsx
@@ -1,15 +1,15 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { ArtistAvatar } from '@/components/atoms/ArtistAvatar';
 
 describe('ArtistAvatar - Basic Functionality', () => {
   it('should render with required props', () => {
     render(
       <ArtistAvatar
-        src="test-image.jpg"
-        alt="Test Artist"
-        name="Test Artist"
-        size="md"
+        src='test-image.jpg'
+        alt='Test Artist'
+        name='Test Artist'
+        size='md'
       />
     );
 
@@ -21,10 +21,10 @@ describe('ArtistAvatar - Basic Functionality', () => {
   it('should have proper accessibility attributes', () => {
     render(
       <ArtistAvatar
-        src="test-image.jpg"
-        alt="Test Artist Avatar"
-        name="Test Artist"
-        size="md"
+        src='test-image.jpg'
+        alt='Test Artist Avatar'
+        name='Test Artist'
+        size='md'
       />
     );
 
@@ -35,10 +35,10 @@ describe('ArtistAvatar - Basic Functionality', () => {
   it('should pass through size prop correctly', () => {
     render(
       <ArtistAvatar
-        src="test-image.jpg"
-        alt="Test Artist"
-        name="Test Artist"
-        size="lg"
+        src='test-image.jpg'
+        alt='Test Artist'
+        name='Test Artist'
+        size='lg'
       />
     );
 

--- a/components/atoms/ArtistAvatar.tsx
+++ b/components/atoms/ArtistAvatar.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import React, { useMemo } from 'react';
-import { OptimizedImage } from '@/components/ui/OptimizedImage';
+import Image from 'next/image';
+import React, { useState } from 'react';
+import { cn } from '@/lib/utils';
 
 export interface ArtistAvatarProps {
   src: string;
-  alt: string;
+  alt?: string;
   name: string;
   size?: 'sm' | 'md' | 'lg' | 'xl';
   priority?: boolean;
@@ -22,35 +23,51 @@ const SIZE_MAP = {
 
 export const ArtistAvatar = React.memo(function ArtistAvatar({
   src,
-  alt,
   name,
+  alt = name,
   size = 'md',
   priority = false,
-  className = '',
+  className,
 }: ArtistAvatarProps) {
-  // Use useMemo to ensure stable props for the OptimizedImage component
-  const sizeProps = useMemo(() => SIZE_MAP[size], [size]);
+  const { width, height, className: sizeClass } = SIZE_MAP[size];
+  const [hasError, setHasError] = useState(false);
 
-  const { width, height, className: sizeClass } = sizeProps;
+  const initials = name
+    .split(' ')
+    .map(part => part[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+  if (hasError || !src) {
+    return (
+      <div
+        className={cn(
+          sizeClass,
+          'flex items-center justify-center rounded-full bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300 ring-1 ring-black/10 dark:ring-white/15 shadow-md group-hover:ring-white/20',
+          className
+        )}
+      >
+        <span className='text-xl font-medium'>{initials}</span>
+      </div>
+    );
+  }
 
   return (
-    <OptimizedImage
+    <Image
       src={src}
       alt={alt}
       width={width}
       height={height}
-      aspectRatio='square'
-      objectFit='cover'
-      objectPosition='center'
       priority={priority}
       quality={85}
-      placeholder='blur'
       sizes={`(max-width: 768px) ${width}px, ${width}px`}
-      className={`${sizeClass} ring-1 ring-black/10 dark:ring-white/15 shadow-md group-hover:ring-white/20 ${className}`}
-      shape='circle'
-      artistName={name}
-      imageType='avatar'
-      enableVersioning={true}
+      className={cn(
+        sizeClass,
+        'rounded-full object-cover object-center ring-1 ring-black/10 dark:ring-white/15 shadow-md group-hover:ring-white/20',
+        className
+      )}
+      onError={() => setHasError(true)}
     />
   );
 });


### PR DESCRIPTION
## Summary
- leverage `cn` to merge avatar classes
- default alt text to artist name
- show placeholder initials when avatar fails to load

## Testing
- `pnpm lint`
- `pnpm test` (fails: Can't find meta/_journal.json file)


------
https://chatgpt.com/codex/tasks/task_e_68bbc524923c83278968d4acb97619cb