### PR TITLE
feat: improve icon accessibility and sizing

### DIFF
--- a/components/atoms/IconBadge.tsx
+++ b/components/atoms/IconBadge.tsx
@@ -1,12 +1,25 @@
 import React from 'react';
 
+export const ICON_BADGE_SIZE = 32;
+export const ICON_BADGE_ICON_SIZE = 18;
+
 interface IconBadgeProps {
   Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   colorVar: string;
   className?: string;
+  ariaLabel?: string;
+  title?: string;
 }
 
-export function IconBadge({ Icon, colorVar, className = '' }: IconBadgeProps) {
+export function IconBadge({
+  Icon,
+  colorVar,
+  className = '',
+  ariaLabel,
+  title,
+}: IconBadgeProps) {
+  const labelled = ariaLabel ?? title;
+
   return (
     <div
       className={`relative flex h-8 w-8 items-center justify-center rounded-full ${className}`}
@@ -19,8 +32,10 @@ export function IconBadge({ Icon, colorVar, className = '' }: IconBadgeProps) {
         style={{
           color: `var(${colorVar})`,
         }}
-        role='img'
-        aria-hidden='true'
+        role={labelled ? 'img' : undefined}
+        aria-label={ariaLabel}
+        title={title}
+        aria-hidden={labelled ? undefined : 'true'}
       />
     </div>
   );

--- a/components/atoms/JovieIcon.tsx
+++ b/components/atoms/JovieIcon.tsx
@@ -1,11 +1,22 @@
 import { cn } from '@/lib/utils';
 
+export const JOVIE_ICON_DEFAULT_SIZE = 24;
+
 interface JovieIconProps {
   className?: string;
   size?: number;
+  ariaLabel?: string;
+  title?: string;
 }
 
-export function JovieIcon({ className, size = 24 }: JovieIconProps) {
+export function JovieIcon({
+  className,
+  size = JOVIE_ICON_DEFAULT_SIZE,
+  ariaLabel,
+  title,
+}: JovieIconProps) {
+  const labelled = ariaLabel ?? title;
+
   return (
     <svg
       width={size}
@@ -14,6 +25,10 @@ export function JovieIcon({ className, size = 24 }: JovieIconProps) {
       xmlns='http://www.w3.org/2000/svg'
       className={cn('text-black dark:text-white transition-colors', className)}
       fill='currentColor'
+      role={labelled ? 'img' : undefined}
+      aria-label={ariaLabel}
+      title={title}
+      aria-hidden={labelled ? undefined : 'true'}
     >
       {/* Music note icon */}
       <circle cx='8' cy='24' r='4' />

--- a/components/atoms/SocialIcon.tsx
+++ b/components/atoms/SocialIcon.tsx
@@ -30,10 +30,14 @@ import {
   siYoutube,
 } from 'simple-icons';
 
+export const SOCIAL_ICON_DEFAULT_SIZE = 16;
+
 interface SocialIconProps {
   platform: string;
   className?: string;
   size?: number;
+  ariaLabel?: string;
+  title?: string;
 }
 
 // Map platform names to Simple Icons
@@ -75,10 +79,21 @@ export function getPlatformIcon(platform: string): SimpleIcon | undefined {
   return platformMap[platform.toLowerCase()];
 }
 
-export function SocialIcon({ platform, className, size }: SocialIconProps) {
+export function SocialIcon({
+  platform,
+  className,
+  size,
+  ariaLabel,
+  title,
+}: SocialIconProps) {
   const icon = platformMap[platform.toLowerCase()];
-  const iconClass = className || 'h-4 w-4';
-  const sizeStyle = size ? { width: size, height: size } : undefined;
+  const iconClass = className || 'h-4 w-4'; // matches SOCIAL_ICON_DEFAULT_SIZE
+  const sizeStyle = size
+    ? { width: size, height: size }
+    : className
+      ? undefined
+      : { width: SOCIAL_ICON_DEFAULT_SIZE, height: SOCIAL_ICON_DEFAULT_SIZE };
+  const labelled = ariaLabel ?? title;
 
   if (icon) {
     return (
@@ -87,7 +102,10 @@ export function SocialIcon({ platform, className, size }: SocialIconProps) {
         style={sizeStyle}
         fill='currentColor'
         viewBox='0 0 24 24'
-        aria-hidden='true'
+        role={labelled ? 'img' : undefined}
+        aria-label={ariaLabel}
+        title={title}
+        aria-hidden={labelled ? undefined : 'true'}
       >
         <path d={icon.path} />
       </svg>
@@ -102,7 +120,10 @@ export function SocialIcon({ platform, className, size }: SocialIconProps) {
       fill='none'
       stroke='currentColor'
       viewBox='0 0 24 24'
-      aria-hidden='true'
+      role={labelled ? 'img' : undefined}
+      aria-label={ariaLabel}
+      title={title}
+      aria-hidden={labelled ? undefined : 'true'}
     >
       <path
         strokeLinecap='round'

--- a/components/atoms/index.ts
+++ b/components/atoms/index.ts
@@ -12,6 +12,7 @@ export * from './FeatureCard';
 export * from './FrostedButton';
 export * from './GradientText';
 export * from './IconBadge';
+export * from './JovieIcon';
 export * from './LoadingSpinner';
 export * from './LogoLink';
 export * from './NavLink';

--- a/components/organisms/HeroSection.tsx
+++ b/components/organisms/HeroSection.tsx
@@ -70,7 +70,7 @@ export function HeroSection({
       <Container className='relative flex max-w-4xl flex-col items-center text-center'>
         {/* Icon/Emoji */}
         {icon && (
-          <div className='mb-8 text-6xl' role='img'>
+          <div className='mb-8 text-6xl' aria-hidden='true'>
             {icon}
           </div>
         )}


### PR DESCRIPTION
## Summary
- make icons accessible only when labeled and hide decorative icons
- export default icon sizes for consistent layouts

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Can't find meta/_journal.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc86e8da308327ad373a6fc392f6b2