### PR TITLE
[feat]: Grouped Links Manager (single consolidated section) — draft

### DIFF
--- a/components/atoms/QRCode.tsx
+++ b/components/atoms/QRCode.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { useMemo, useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
 
 // Cache with size limit to prevent memory leaks
@@ -8,20 +8,22 @@ const MAX_CACHE_SIZE = 100;
 
 function getQrUrl(data: string, size: number) {
   const key = `${data}-${size}`;
-  
+
   let url = qrCache.get(key);
   if (!url) {
     url = `https://api.qrserver.com/v1/create-qr-code/?size=${size}x${size}&data=${encodeURIComponent(data)}`;
-    
+
     // Implement simple LRU eviction when cache is full
     if (qrCache.size >= MAX_CACHE_SIZE) {
-      const firstKey = qrCache.keys().next().value;
-      qrCache.delete(firstKey);
+      const firstKey = qrCache.keys().next().value as string | undefined;
+      if (firstKey !== undefined) {
+        qrCache.delete(firstKey);
+      }
     }
-    
+
     qrCache.set(key, url);
   }
-  
+
   return url;
 }
 
@@ -49,7 +51,7 @@ export function QRCode({
   if (hasError) {
     return (
       <div
-        role="img"
+        role='img'
         aria-label={`${label} unavailable`}
         className={cn(
           'flex items-center justify-center rounded bg-gray-100 text-gray-500',

--- a/components/atoms/SocialIcon.tsx
+++ b/components/atoms/SocialIcon.tsx
@@ -86,9 +86,8 @@ export function SocialIcon({
   const icon = getPlatformIcon(platform);
   const iconClass = cn('h-4 w-4', className);
   const sizeStyle = size ? { width: size, height: size } : undefined;
-  const accessibilityProps = ariaLabel
-    ? { 'aria-label': ariaLabel }
-    : { 'aria-hidden': 'true' };
+  const accessibilityProps: { 'aria-label'?: string; 'aria-hidden'?: boolean } =
+    ariaLabel ? { 'aria-label': ariaLabel } : { 'aria-hidden': true };
 
   if (icon) {
     return (

--- a/components/dashboard/organisms/GroupedLinksManager.tsx
+++ b/components/dashboard/organisms/GroupedLinksManager.tsx
@@ -68,13 +68,13 @@ function groupLinks(
     else custom.push(l);
   }
 
-  const byOrder = (a: DetectedLink, b: DetectedLink) =>
-    (a.order ?? 0) - (b.order ?? 0);
+  const byStable = (a: DetectedLink, b: DetectedLink) =>
+    (a.normalizedUrl || '').localeCompare(b.normalizedUrl || '');
 
   return {
-    social: social.sort(byOrder),
-    dsp: dsp.sort(byOrder),
-    custom: custom.sort(byOrder),
+    social: social.sort(byStable),
+    dsp: dsp.sort(byStable),
+    custom: custom.sort(byStable),
   };
 }
 

--- a/components/dashboard/organisms/GroupedLinksManager.tsx
+++ b/components/dashboard/organisms/GroupedLinksManager.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+import type { DetectedLink } from '@/lib/utils/platform-detection';
+
+export interface GroupedLinksManagerProps {
+  initialLinks: DetectedLink[];
+  className?: string;
+}
+
+// Server Component scaffold for a single, grouped Links Manager
+// Phase 1: non-interactive layout + grouping only. Interaction wiring will follow.
+export function GroupedLinksManager({
+  initialLinks,
+  className,
+}: GroupedLinksManagerProps) {
+  const groups = groupLinks(initialLinks);
+
+  return (
+    <section className={cn('space-y-6', className)} aria-label='Links Manager'>
+      {(['social', 'dsp', 'custom'] as const).map(section => (
+        <div key={section} className='space-y-3'>
+          <header className='flex items-center justify-between'>
+            <h2 className='text-sm font-semibold capitalize text-primary-token'>
+              {labelFor(section)}
+            </h2>
+            <span className='text-xs text-secondary-token'>
+              {groups[section].length}
+            </span>
+          </header>
+          {/* Phase 1: placeholder list; wiring to existing LinkManager items in Phase 2 */}
+          <ul className='divide-y divide-subtle rounded-lg border border-subtle bg-surface-1'>
+            {groups[section].map(link => (
+              <li
+                key={link.normalizedUrl}
+                className='p-3 text-sm text-secondary-token'
+              >
+                {link.suggestedTitle} —{' '}
+                <span className='font-mono'>{link.normalizedUrl}</span>
+              </li>
+            ))}
+            {groups[section].length === 0 && (
+              <li className='p-3 text-sm text-tertiary italic'>
+                No {labelFor(section)} links yet
+              </li>
+            )}
+          </ul>
+        </div>
+      ))}
+    </section>
+  );
+}
+
+function groupLinks(
+  links: DetectedLink[]
+): Record<'social' | 'dsp' | 'custom', DetectedLink[]> {
+  const social: DetectedLink[] = [];
+  const dsp: DetectedLink[] = [];
+  const custom: DetectedLink[] = [];
+
+  for (const l of links) {
+    // Category comes from platform metadata; fallback to custom
+    const category = (l.platform.category ?? 'custom') as
+      | 'social'
+      | 'dsp'
+      | 'custom';
+    if (category === 'social') social.push(l);
+    else if (category === 'dsp') dsp.push(l);
+    else custom.push(l);
+  }
+
+  const byOrder = (a: DetectedLink, b: DetectedLink) =>
+    (a.order ?? 0) - (b.order ?? 0);
+
+  return {
+    social: social.sort(byOrder),
+    dsp: dsp.sort(byOrder),
+    custom: custom.sort(byOrder),
+  };
+}
+
+function labelFor(section: 'social' | 'dsp' | 'custom'): string {
+  switch (section) {
+    case 'social':
+      return 'Social';
+    case 'dsp':
+      return 'Music';
+    default:
+      return 'Custom';
+  }
+}


### PR DESCRIPTION
Goal
Consolidate the Links Manager into a single grouped section with clear category headers (Social, DSP, Custom), consistent tokens, and reduced duplication between sections. Improve UX and readability while preserving existing functionality, validation, and analytics.

Current State
- Branch created from latest preview.
- Typecheck & lint pass. Scaffold added: `components/dashboard/organisms/GroupedLinksManager.tsx`.

Planned Scope (Phase 1)
- Introduce grouped rendering container with sticky/inline headers.
- Reuse existing `UniversalLinkInput` and items (drag/drop, duplicate detection, quotas).
- Ensure consistent tokens (`border-subtle`, text tokens) and dark/light support.
- Keep analytics routed through `@/lib/analytics` only.
- Add minimal unit tests for grouping and headers.

DoD
- `pnpm typecheck && pnpm lint` pass.
- Visual QA in light/dark.
- Draft PR open for iterative commits.

Rollback
- Revert the PR (UI-only).
