### PR TITLE
Refine onboarding step copy

### DIFF
--- a/app/onboarding/README.md
+++ b/app/onboarding/README.md
@@ -32,3 +32,12 @@ Legacy onboarding components have been moved to `/app/legacy/onboarding/componen
 - `OnboardingForm.stories.tsx` (Storybook stories)
 
 These components are no longer used in the application but are preserved for reference.
+
+## Copy Reference
+
+Current step copy for `AppleStyleOnboardingForm`:
+
+1. **welcome** – Title: "Launch your profile in moments." Prompt: "Three quick steps and you're live."
+2. **name** – Title: "Your name, your signature." Prompt: "Displayed on your Jovie profile."
+3. **handle** – Title: "Claim your @handle." Prompt: "This becomes your unique link."
+4. **done** – Title: "You're live." Prompt: "Your link is ready to share."

--- a/components/dashboard/organisms/AppleStyleOnboardingForm.tsx
+++ b/components/dashboard/organisms/AppleStyleOnboardingForm.tsx
@@ -16,26 +16,26 @@ interface OnboardingStep {
   prompt: string;
 }
 
-const ONBOARDING_STEPS: OnboardingStep[] = [
+export const ONBOARDING_STEPS: OnboardingStep[] = [
   {
     id: 'welcome',
-    title: "Let's get you live.",
-    prompt: "We'll set up your profile in 3 quick steps.",
+    title: 'Launch your profile in moments.',
+    prompt: "Three quick steps and you're live.",
   },
   {
     id: 'name',
-    title: "What's your name?",
-    prompt: 'This will be displayed on your Jovie profile.',
+    title: 'Your name, your signature.',
+    prompt: 'Displayed on your Jovie profile.',
   },
   {
     id: 'handle',
-    title: 'Pick your @handle',
-    prompt: 'This will be your link on Jovie.',
+    title: 'Claim your @handle.',
+    prompt: 'This becomes your unique link.',
   },
   {
     id: 'done',
     title: "You're live.",
-    prompt: "Here's your link.",
+    prompt: 'Your link is ready to share.',
   },
 ];
 
@@ -112,9 +112,12 @@ export function AppleStyleOnboardingForm() {
     // Prefill full name from Clerk metadata or user data
     if (user) {
       // Priority: privateMetadata.fullName > firstName + lastName > email fallback
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const privateFullName = ((user as any).privateMetadata as Record<string, unknown> | undefined)
-        ?.fullName as string | undefined;
+      const userWithMetadata = user as
+        | { privateMetadata?: Record<string, unknown> }
+        | undefined;
+      const privateFullName = userWithMetadata?.privateMetadata?.fullName as
+        | string
+        | undefined;
       if (privateFullName) {
         setFullName(privateFullName);
       } else if (user.firstName || user.lastName) {
@@ -141,12 +144,11 @@ export function AppleStyleOnboardingForm() {
       setHandle(urlHandle);
       setHandleInput(urlHandle);
     } else if (
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ((user as any).privateMetadata as Record<string, unknown> | undefined)?.suggestedUsername
+      (user as { privateMetadata?: Record<string, unknown> } | undefined)
+        ?.privateMetadata?.suggestedUsername
     ) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const suggested = ((user as any).privateMetadata as Record<string, unknown>)
-        .suggestedUsername as string;
+      const suggested = (user as { privateMetadata?: Record<string, unknown> })
+        .privateMetadata?.suggestedUsername as string;
       setHandle(suggested);
       setHandleInput(suggested);
     } else {

--- a/tests/unit/AppleStyleOnboardingForm.test.ts
+++ b/tests/unit/AppleStyleOnboardingForm.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { ONBOARDING_STEPS } from '@/components/dashboard/organisms/AppleStyleOnboardingForm';
+
+describe('AppleStyleOnboardingForm copy', () => {
+  it('matches the expected onboarding step copy', () => {
+    expect(ONBOARDING_STEPS).toEqual([
+      {
+        id: 'welcome',
+        title: 'Launch your profile in moments.',
+        prompt: "Three quick steps and you're live.",
+      },
+      {
+        id: 'name',
+        title: 'Your name, your signature.',
+        prompt: 'Displayed on your Jovie profile.',
+      },
+      {
+        id: 'handle',
+        title: 'Claim your @handle.',
+        prompt: 'This becomes your unique link.',
+      },
+      {
+        id: 'done',
+        title: "You're live.",
+        prompt: 'Your link is ready to share.',
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Revise onboarding step titles and prompts with concise, aspirational phrasing
- Document finalized copy in onboarding README
- Add unit test to ensure step copy remains consistent

## Testing
- `pnpm lint` *(fails: Parse errors in components/atoms/SocialIcon.tsx)*
- `pnpm exec eslint components/dashboard/organisms/AppleStyleOnboardingForm.tsx tests/unit/AppleStyleOnboardingForm.test.ts app/onboarding/README.md`
- `pnpm test` *(fails: Can't find meta/_journal.json file)*
- `pnpm exec vitest run tests/unit/AppleStyleOnboardingForm.test.ts` *(fails: Can't find meta/_journal.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc5d5a5bc8327bffebdecabeb18e2