### PR TITLE
feat(onboarding): add motion step transitions

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -39,6 +39,34 @@ afterEach(() => {
   cleanup();
 });
 
+// Mock framer-motion to simplify animation testing
+vi.mock('framer-motion', () => {
+  return {
+    __esModule: true,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    motion: new Proxy(
+      {},
+      {
+        get: (_target, element) => {
+          const Component = React.forwardRef(
+            (
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              { children, ...rest }: any,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              ref: any
+            ) =>
+              React.createElement(element as string, { ref, ...rest }, children)
+          );
+          Component.displayName = `motion.${String(element)}`;
+          return Component;
+        },
+      }
+    ),
+    useReducedMotion: () => true,
+  };
+});
+
 // Mock Clerk components and hooks
 vi.mock('@clerk/nextjs', () => ({
   useUser: () => ({


### PR DESCRIPTION
## Summary
- animate onboarding steps with framer-motion for a snappy, Apple-like feel
- drop manual isTransitioning state in favor of library enter/exit animations with reduced-motion support
- mock framer-motion in tests to stabilize animation lifecycle

## Testing
- `npx eslint components/dashboard/organisms/AppleStyleOnboardingForm.tsx app/legacy/onboarding/components/MinimalistOnboardingForm.tsx app/legacy/onboarding/components/ProgressiveOnboardingForm.tsx tests/setup.ts`
- `pnpm test` *(fails: Can't find meta/_journal.json file)*


------
https://chatgpt.com/codex/tasks/task_e_68bdc5d1cd488327a8291200c8303bbb