### PR TITLE
feat(onboarding): separate success notifications from errors

### DIFF
--- a/__tests__/components/dashboard/AppleStyleOnboardingForm.test.tsx
+++ b/__tests__/components/dashboard/AppleStyleOnboardingForm.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AppleStyleOnboardingForm } from '@/components/dashboard/organisms/AppleStyleOnboardingForm';
+
+vi.mock('@clerk/nextjs', () => ({
+  useUser: () => ({ user: { id: '1', emailAddresses: [] } }),
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: () => {} }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+vi.mock('@/lib/analytics', () => ({ track: () => {}, identify: () => {} }));
+
+describe('AppleStyleOnboardingForm messages', () => {
+  it('shows error message without notification', () => {
+    render(
+      <AppleStyleOnboardingForm
+        initialStepIndex={2}
+        initialState={{ error: 'Something went wrong', notification: null }}
+      />
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Link copied to clipboard!')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows notification without error', () => {
+    render(
+      <AppleStyleOnboardingForm
+        initialStepIndex={3}
+        initialState={{
+          notification: 'Link copied to clipboard!',
+          error: null,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Link copied to clipboard!')).toBeInTheDocument();
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `notification` field to onboarding state
- show success copy notifications independently of errors
- test error and notification rendering in onboarding form

## Testing
- `pnpm exec eslint components/dashboard/organisms/AppleStyleOnboardingForm.tsx __tests__/components/dashboard/AppleStyleOnboardingForm.test.tsx`
- `DATABASE_URL='' pnpm test __tests__/components/dashboard/AppleStyleOnboardingForm.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bdc5c9e69083279ead9d9940dfcc0e