### PR TITLE
fix: prevent horizontal scrolling on mobile

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -9,6 +9,7 @@
 html,
 body {
   height: 100%;
+  overflow-x: hidden;
 }
 
 /* Fallback colors before token CSS finishes loading */


### PR DESCRIPTION
## Summary
- hide horizontal overflow globally to stop extra space scrolling

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Can't find meta/_journal.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68bde1a6d74883279839503627893ff3