### PR TITLE
Improve homepage load time with lazy sections

### DIFF
--- a/HOMEPAGE_PERFORMANCE_TASKS.md
+++ b/HOMEPAGE_PERFORMANCE_TASKS.md
@@ -1,0 +1,13 @@
+# Homepage Performance Tasks
+
+## Overview
+
+The marketing home page should feel instantaneous. This checklist tracks refinements that keep the experience crisp and light.
+
+## Open Tasks
+
+- [ ] Preload critical fonts to remove first paint flashes
+- [ ] Defer offscreen sections with `IntersectionObserver`
+- [ ] Audit images and enable `loading="lazy"` where possible
+- [ ] Add a Lighthouse performance budget for the `/` route
+- [ ] Explore server components to trim client bundle further

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -1,11 +1,22 @@
 import type { Metadata } from 'next';
-import { NewFeaturedArtists } from '@/components/home/NewFeaturedArtists';
-import { NewFeaturesSection } from '@/components/home/NewFeaturesSection';
+import dynamic from 'next/dynamic';
 import { NewHomeHero } from '@/components/home/NewHomeHero';
-import { NewHowItWorks } from '@/components/home/NewHowItWorks';
-import { NewPreFooterCTA } from '@/components/home/NewPreFooterCTA';
-import { NewUpgradeTeaser } from '@/components/home/NewUpgradeTeaser';
 import { APP_NAME, APP_URL } from '@/constants/app';
+
+const NewFeaturedArtists = dynamic(
+  () => import('@/components/home/NewFeaturedArtists'),
+  { ssr: false }
+);
+const NewFeaturesSection = dynamic(
+  () => import('@/components/home/NewFeaturesSection')
+);
+const NewUpgradeTeaser = dynamic(
+  () => import('@/components/home/NewUpgradeTeaser')
+);
+const NewHowItWorks = dynamic(() => import('@/components/home/NewHowItWorks'));
+const NewPreFooterCTA = dynamic(
+  () => import('@/components/home/NewPreFooterCTA')
+);
 
 // Root layout handles dynamic rendering
 export const revalidate = 3600; // Revalidate every hour


### PR DESCRIPTION
## Summary
- dynamically import below-the-fold marketing components to shrink the initial JS bundle
- add performance checklist for future homepage speed work

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Can't find meta/_journal.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68bde1f38cec8327a27d53c4c5655fd3