### PR TITLE
feat(auth): switch to shadcn Clerk elements

### DIFF
--- a/app/(auth)/signin/page.tsx
+++ b/app/(auth)/signin/page.tsx
@@ -1,8 +1,18 @@
 'use client';
 
-import { ClerkLoaded, ClerkLoading, SignIn } from '@clerk/nextjs';
+import {
+  Input as ClerkInput,
+  Field,
+  FieldError,
+  Label,
+} from '@clerk/elements/common';
+import { SignIn } from '@clerk/elements/sign-in';
+import { ClerkLoaded, ClerkLoading } from '@clerk/nextjs';
+import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { AuthLayout } from '@/components/auth';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
 import { AuthFormSkeleton } from '@/components/ui/LoadingSkeleton';
 
 export default function SignInPage() {
@@ -24,33 +34,51 @@ export default function SignInPage() {
           <AuthFormSkeleton />
         </ClerkLoading>
         <ClerkLoaded>
-          <SignIn
-            appearance={{
-              elements: {
-                rootBox: 'mx-auto w-full',
-                card: 'shadow-none border-0 bg-transparent p-0',
-                headerTitle:
-                  'hidden lg:block text-2xl font-bold text-gray-900 dark:text-white mb-6',
-                headerSubtitle:
-                  'hidden lg:block text-gray-600 dark:text-gray-300 mb-8',
-                socialButtonsBlockButton:
-                  'border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors',
-                dividerLine: 'bg-gray-200 dark:bg-gray-700',
-                dividerText: 'text-gray-500 dark:text-gray-400',
-                formFieldInput:
-                  'border-gray-200 dark:border-gray-700 dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500',
-                formButtonPrimary:
-                  'bg-blue-600 hover:bg-blue-500 text-white font-medium py-2.5 rounded-lg transition-colors',
-                footerActionLink:
-                  'text-blue-600 hover:text-blue-500 font-medium',
-              },
-            }}
+          <SignIn.Root
             routing='hash'
             redirectUrl={redirectUrl}
             afterSignInUrl={redirectUrl}
             afterSignUpUrl={redirectUrl}
             signUpUrl='/signup'
-          />
+          >
+            <SignIn.Step name='start'>
+              <div className='space-y-4'>
+                <Field name='identifier'>
+                  <Label>Email</Label>
+                  <ClerkInput asChild>
+                    <Input
+                      type='email'
+                      autoComplete='email'
+                      placeholder='you@example.com'
+                    />
+                  </ClerkInput>
+                  <FieldError />
+                </Field>
+
+                <Field name='password'>
+                  <Label>Password</Label>
+                  <ClerkInput asChild>
+                    <Input type='password' placeholder='Your password' />
+                  </ClerkInput>
+                  <FieldError />
+                </Field>
+
+                <SignIn.Action submit asChild>
+                  <Button className='w-full'>Sign in</Button>
+                </SignIn.Action>
+
+                <p className='text-center text-sm text-gray-600 dark:text-gray-400'>
+                  New to Jovie?{' '}
+                  <Link
+                    href='/signup'
+                    className='text-blue-600 hover:text-blue-500 font-medium'
+                  >
+                    Create an account
+                  </Link>
+                </p>
+              </div>
+            </SignIn.Step>
+          </SignIn.Root>
         </ClerkLoaded>
       </div>
     </AuthLayout>

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,8 +1,18 @@
 'use client';
 
-import { ClerkLoaded, ClerkLoading, SignUp } from '@clerk/nextjs';
+import {
+  Input as ClerkInput,
+  Field,
+  FieldError,
+  Label,
+} from '@clerk/elements/common';
+import { SignUp } from '@clerk/elements/sign-up';
+import { ClerkLoaded, ClerkLoading } from '@clerk/nextjs';
+import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { AuthLayout } from '@/components/auth';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
 import { AuthFormSkeleton } from '@/components/ui/LoadingSkeleton';
 
 export default function SignUpPage() {
@@ -24,32 +34,50 @@ export default function SignUpPage() {
           <AuthFormSkeleton />
         </ClerkLoading>
         <ClerkLoaded>
-          <SignUp
-            appearance={{
-              elements: {
-                rootBox: 'mx-auto w-full',
-                card: 'shadow-none border-0 bg-transparent p-0',
-                headerTitle:
-                  'hidden lg:block text-2xl font-bold text-gray-900 dark:text-white mb-6',
-                headerSubtitle:
-                  'hidden lg:block text-gray-600 dark:text-gray-300 mb-8',
-                socialButtonsBlockButton:
-                  'border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors',
-                dividerLine: 'bg-gray-200 dark:bg-gray-700',
-                dividerText: 'text-gray-500 dark:text-gray-400',
-                formFieldInput:
-                  'border-gray-200 dark:border-gray-700 dark:bg-gray-800 focus:ring-2 focus:ring-purple-500 focus:border-purple-500',
-                formButtonPrimary:
-                  'bg-purple-600 hover:bg-purple-500 text-white font-medium py-2.5 rounded-lg transition-colors',
-                footerActionLink:
-                  'text-purple-600 hover:text-purple-500 font-medium',
-              },
-            }}
+          <SignUp.Root
             routing='hash'
             redirectUrl={redirectUrl}
             afterSignUpUrl={redirectUrl}
             signInUrl='/signin'
-          />
+          >
+            <SignUp.Step name='start'>
+              <div className='space-y-4'>
+                <Field name='emailAddress'>
+                  <Label>Email</Label>
+                  <ClerkInput asChild>
+                    <Input
+                      type='email'
+                      autoComplete='email'
+                      placeholder='you@example.com'
+                    />
+                  </ClerkInput>
+                  <FieldError />
+                </Field>
+
+                <Field name='password'>
+                  <Label>Password</Label>
+                  <ClerkInput asChild>
+                    <Input type='password' placeholder='Create a password' />
+                  </ClerkInput>
+                  <FieldError />
+                </Field>
+
+                <SignUp.Action submit asChild>
+                  <Button className='w-full'>Create account</Button>
+                </SignUp.Action>
+
+                <p className='text-center text-sm text-gray-600 dark:text-gray-400'>
+                  Already have an account?{' '}
+                  <Link
+                    href='/signin'
+                    className='text-purple-600 hover:text-purple-500 font-medium'
+                  >
+                    Sign in
+                  </Link>
+                </p>
+              </div>
+            </SignUp.Step>
+          </SignUp.Root>
         </ClerkLoaded>
       </div>
     </AuthLayout>

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@clerk/elements": "0.23.62",
     "@clerk/nextjs": "^6.31.9",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@clerk/elements':
+    specifier: 0.23.62
+    version: 0.23.62(@types/react-dom@18.3.7)(@types/react@18.3.24)(next@15.5.2)(react-dom@18.3.1)(react@18.3.1)
   '@clerk/nextjs':
     specifier: ^6.31.9
     version: 6.31.9(next@15.5.2)(react-dom@18.3.1)(react@18.3.1)
@@ -968,6 +971,20 @@ packages:
       tslib: 2.8.1
     dev: false
 
+  /@clerk/clerk-react@5.46.2(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-Gk2YVg4k72ZSCJu/fYw5GQuku1vwfHrMmYRt1/2+vyDdotZsFjKA0AcH3cPkzHlVBuCwYonN+7BfQBBq3HzX9g==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+    dependencies:
+      '@clerk/shared': 3.24.2(react-dom@18.3.1)(react@18.3.1)
+      '@clerk/types': 4.85.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+    dev: false
+
   /@clerk/dev-cli@0.0.12:
     resolution: {integrity: sha512-BtBuvwYPzIX15aN3FBhDLOSpMzgaZy9PbGtFwbSG+MX7HBNHpy8ncVQ2F52hQ33FGRb73yE33mthE/fDI7IcNQ==}
     engines: {node: '>=18.17.0'}
@@ -982,6 +999,36 @@ packages:
       - '@babel/preset-env'
       - supports-color
     dev: true
+
+  /@clerk/elements@0.23.62(@types/react-dom@18.3.7)(@types/react@18.3.24)(next@15.5.2)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-aba/dZ+tP3GQOX8vkoqbjECUahm++v+hIvLRh1lbYpjeybDMlsVfUCgbMRxawvIkRiVUoamTbfD5xJ2xRhNcdQ==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      next: ^13.5.4 || ^14.0.3 || ^15
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+    peerDependenciesMeta:
+      next:
+        optional: true
+    dependencies:
+      '@clerk/clerk-react': 5.46.2(react-dom@18.3.1)(react@18.3.1)
+      '@clerk/shared': 3.24.2(react-dom@18.3.1)(react@18.3.1)
+      '@clerk/types': 4.85.0
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-form': 0.1.8(@types/react-dom@18.3.7)(@types/react@18.3.24)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.24)(react@18.3.1)
+      '@xstate/react': 6.0.0(@types/react@18.3.24)(react@18.3.1)(xstate@5.21.0)
+      client-only: 0.0.1
+      next: 15.5.2(@babel/core@7.28.3)(@playwright/test@1.55.0)(react-dom@18.3.1)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+      type-fest: 4.41.0
+      xstate: 5.21.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+    dev: false
 
   /@clerk/localizations@3.24.0:
     resolution: {integrity: sha512-7COjNFcvt+lJk2Kcsa7xS47nM0MfdbcfGSkx0IdMQZX56wZtH4ftKhKJxIfiFfuCUIiyThx+Z9QuUqMM7IL9NQ==}
@@ -2948,6 +2995,31 @@ packages:
       react-dom: 18.3.1(react@18.3.1)
     dev: false
 
+  /@radix-ui/react-form@0.1.8(@types/react-dom@18.3.7)(@types/react@18.3.24)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.24)(react@18.3.1)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.24)(react-dom@18.3.1)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7)(@types/react@18.3.24)(react-dom@18.3.1)(react@18.3.1)
+      '@types/react': 18.3.24
+      '@types/react-dom': 18.3.7(@types/react@18.3.24)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    dev: false
+
   /@radix-ui/react-id@1.1.1(@types/react@18.3.24)(react@18.3.1):
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -2960,6 +3032,26 @@ packages:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.24)(react@18.3.1)
       '@types/react': 18.3.24
       react: 18.3.1
+    dev: false
+
+  /@radix-ui/react-label@2.1.7(@types/react-dom@18.3.7)(@types/react@18.3.24)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7)(@types/react@18.3.24)(react-dom@18.3.1)(react@18.3.1)
+      '@types/react': 18.3.24
+      '@types/react-dom': 18.3.7(@types/react@18.3.24)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     dev: false
 
   /@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.7)(@types/react@18.3.24)(react-dom@18.3.1)(react@18.3.1):
@@ -5083,6 +5175,23 @@ packages:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
     dev: true
+
+  /@xstate/react@6.0.0(@types/react@18.3.24)(react@18.3.1)(xstate@5.21.0):
+    resolution: {integrity: sha512-xXlLpFJxqLhhmecAXclBECgk+B4zYSrDTl8hTfPZBogkn82OHKbm9zJxox3Z/YXoOhAQhKFTRLMYGdlbhc6T9A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      xstate: ^5.20.0
+    peerDependenciesMeta:
+      xstate:
+        optional: true
+    dependencies:
+      react: 18.3.1
+      use-isomorphic-layout-effect: 1.2.1(@types/react@18.3.24)(react@18.3.1)
+      use-sync-external-store: 1.5.0(react@18.3.1)
+      xstate: 5.21.0
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
 
   /@zxcvbn-ts/core@3.0.4:
     resolution: {integrity: sha512-aQeiT0F09FuJaAqNrxynlAwZ2mW/1MdXakKWNmGM1Qp/VaY6CnB/GfnMS2T8gB2231Esp1/maCWd8vTG4OuShw==}
@@ -12058,7 +12167,6 @@ packages:
   /type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
-    dev: true
 
   /type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
@@ -12276,6 +12384,19 @@ packages:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  /use-isomorphic-layout-effect@1.2.1(@types/react@18.3.24)(react@18.3.1):
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 18.3.24
+      react: 18.3.1
+    dev: false
 
   /use-sync-external-store@1.5.0(react@18.3.1):
     resolution: {integrity: sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==}
@@ -12803,6 +12924,10 @@ packages:
 
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  /xstate@5.21.0:
+    resolution: {integrity: sha512-y4wmqxjyAa0tgz4k3m/MgTF1kDOahE5+xLfWt5eh1sk+43DatLhKlI8lQDJZpvihZavjbD3TUgy2PRMphhhqgQ==}
+    dev: false
 
   /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}


### PR DESCRIPTION
## Summary
- replace auto Clerk `<SignIn>` and `<SignUp>` with shadcn-styled Clerk Elements
- add @clerk/elements dependency

## Testing
- `pnpm exec eslint "app/(auth)/signin/page.tsx" "app/(auth)/signup/page.tsx"`
- `pnpm test tests/unit/FormField.test.tsx` *(fails: Can't find meta/_journal.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a0eea9a883278a1d6be4f3d66d5e