### PR TITLE
refactor: use core Button for primary CTA

### DIFF
--- a/components/ui/PrimaryCTA.tsx
+++ b/components/ui/PrimaryCTA.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { clsx } from 'clsx';
 import React from 'react';
-import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { Button, type ButtonProps } from '@/components/ui/Button';
+import { cn } from '@/lib/utils';
 
 /**
  * PrimaryCTA Component
@@ -15,99 +15,40 @@ import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
  * - Supports light/dark mode with appropriate contrast
  * - Includes subtle hover animations and glow effects
  */
-type PrimaryCTAProps = {
-  children: React.ReactNode;
-  onClick?: React.MouseEventHandler<HTMLButtonElement>;
+interface PrimaryCTAProps
+  extends Omit<ButtonProps, 'variant' | 'size' | 'loading'> {
   ariaLabel: string;
   loadingLabel?: string;
   loading?: boolean;
-  type?: 'button' | 'submit' | 'reset';
-  autoFocus?: boolean;
-  disabled?: boolean;
-  className?: string;
   size?: 'md' | 'lg';
   fullWidth?: boolean;
-  id?: string;
   dataTestId?: string;
-};
+}
 
 export default function PrimaryCTA({
   children,
-  onClick,
   ariaLabel,
   loadingLabel,
   loading = false,
-  type = 'button',
-  autoFocus = false,
-  disabled,
-  className,
   size = 'lg',
   fullWidth = true,
-  id,
+  className,
   dataTestId,
+  ...props
 }: PrimaryCTAProps) {
-  const isLoading = Boolean(loading);
-  const a11yLabel = isLoading && loadingLabel ? loadingLabel : ariaLabel;
-
-  const base =
-    'relative inline-flex items-center justify-center overflow-hidden group rounded-xl font-semibold tracking-tight shadow-lg transition-all duration-200 ease-out focus-ring cursor-pointer';
-  const color =
-    'bg-gray-900 text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-50';
-  const sizing =
-    size === 'lg'
-      ? 'min-h-[56px] px-8 text-base sm:min-h-[60px] sm:px-10 sm:text-lg'
-      : 'min-h-[48px] px-6 text-sm';
-  const width = fullWidth ? 'w-full' : '';
-
-  const handleClick: React.MouseEventHandler<HTMLButtonElement> = e => {
-    if (disabled || isLoading) {
-      e.preventDefault();
-      return;
-    }
-    onClick?.(e);
-  };
+  const a11yLabel = loading && loadingLabel ? loadingLabel : ariaLabel;
 
   return (
-    <button
-      id={id}
-      data-testid={dataTestId}
-      type={type}
-      onClick={handleClick}
+    <Button
+      variant='primary'
+      size={size}
+      loading={loading}
       aria-label={a11yLabel}
-      autoFocus={autoFocus}
-      disabled={disabled || isLoading}
-      aria-disabled={disabled || isLoading ? 'true' : 'false'}
-      className={clsx(
-        base,
-        color,
-        sizing,
-        width,
-        'hover:scale-[1.01] active:scale-[0.98] ring-1 ring-black/10 dark:ring-white/10 hover:ring-black/20 dark:hover:ring-white/20',
-        // luminous subtle glow using before pseudo-element
-        'before:pointer-events-none before:absolute before:inset-0 before:rounded-xl before:opacity-0 before:transition-opacity before:duration-300',
-        'before:bg-[radial-gradient(80%_60%_at_50%_0%,rgba(255,255,255,0.35),transparent_60%)]',
-        'group-hover:before:opacity-100',
-        isLoading && 'opacity-80',
-        className
-      )}
+      data-testid={dataTestId}
+      className={cn(fullWidth ? 'w-full' : '', className)}
+      {...props}
     >
-      <span
-        className={clsx(
-          'transition-opacity duration-200',
-          isLoading ? 'opacity-0' : 'opacity-100'
-        )}
-      >
-        {children}
-      </span>
-
-      {isLoading && (
-        <div
-          className='absolute inset-0 flex items-center justify-center pointer-events-none'
-          aria-hidden='true'
-        >
-          <LoadingSpinner size='sm' variant='light' />
-        </div>
-      )}
-    </button>
+      {children}
+    </Button>
   );
 }


### PR DESCRIPTION
## Summary
- refactor PrimaryCTA to build on shared Button component for consistent button styling

## Testing
- `pnpm lint` *(fails: Unable to resolve module '@radix-ui/react-popover' and other lint errors)*
- `pnpm test` *(fails: 70 test suites failed, unable to resolve '@radix-ui/react-popover')*


------
https://chatgpt.com/codex/tasks/task_e_68c0ad9de0a483278551ab50387f7565