### PR TITLE
refactor: use shadcn button for dashboard nav

### DIFF
--- a/components/dashboard/DashboardNav.tsx
+++ b/components/dashboard/DashboardNav.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Divider } from '@/components/atoms/Divider';
 import { Tooltip } from '@/components/atoms/Tooltip';
+import { Button } from '@/components/ui/Button';
 import { cn } from '@/lib/utils';
 
 // Primary Navigation - Core features
@@ -96,15 +97,17 @@ export function DashboardNav({ collapsed = false }: DashboardNavProps) {
           (pathname === '/dashboard' && item.id === 'overview');
 
         const linkContent = (
-          <Link
+          <Button
+            as={Link}
             href={item.href}
+            variant='ghost'
             className={cn(
               // Apple-style active state - solid pill highlight
               isActive
                 ? 'bg-accent/10 text-primary-token shadow-sm border border-subtle'
                 : 'text-secondary-token hover:text-primary-token hover:bg-surface-2/80',
               // Base styles with perfect alignment
-              'group flex items-center rounded-lg transition-all duration-200 ease-in-out relative',
+              'group w-full justify-start rounded-lg transition-all duration-200 ease-in-out relative',
               // Focus states
               'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2',
               // Responsive padding and spacing
@@ -150,7 +153,7 @@ export function DashboardNav({ collapsed = false }: DashboardNavProps) {
             >
               {item.name}
             </span>
-          </Link>
+          </Button>
         );
 
         return (


### PR DESCRIPTION
## Summary
- refactor dashboard nav items to use shared shadcn/ui Button

## Testing
- `pnpm lint` *(fails: Unable to resolve module '@radix-ui/react-popover', unused vars)*
- `pnpm test` *(fails: Can't find meta/_journal.json file, missing deps, test suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0af95e93883278b737a7f6212e26f