### PR TITLE
refactor: unify site header with atomic components

### DIFF
--- a/app/flyout-demo/page.tsx
+++ b/app/flyout-demo/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { IconBadge } from '@/components/atoms/IconBadge';
-import { HeaderNav } from '@/components/organisms/HeaderNav';
+import { Header } from '@/components/site/Header';
 import { FEATURES } from '@/lib/features';
 
 export default function FlyoutDemoPage() {
@@ -15,8 +15,8 @@ export default function FlyoutDemoPage() {
 
   return (
     <div className={`min-h-screen transition-colors ${isDark ? 'dark' : ''}`}>
-      {/* Use the actual HeaderNav component */}
-      <HeaderNav />
+      {/* Use the shared Header component */}
+      <Header />
 
       {/* Demo Content */}
       <main className='mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8'>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,21 +1,13 @@
 import Link from 'next/link';
 import { Container } from '@/components/site/Container';
 import { Footer } from '@/components/site/Footer';
-import { Logo } from '@/components/ui/Logo';
+import { Header } from '@/components/site/Header';
 
 export default function NotFound() {
   return (
     <div className='min-h-screen bg-white dark:bg-gray-900'>
       {/* Header */}
-      <header className='sticky top-0 z-50 w-full border-b border-gray-200/50 dark:border-white/10 bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm supports-backdrop-filter:bg-white/60 dark:supports-backdrop-filter:bg-gray-900/60'>
-        <Container>
-          <div className='flex h-16 items-center justify-between'>
-            <Link href='/' className='flex items-center space-x-2'>
-              <Logo size='sm' />
-            </Link>
-          </div>
-        </Container>
-      </header>
+      <Header />
 
       {/* Main Content */}
       <main className='flex-1'>

--- a/components/organisms/HeaderNav.tsx
+++ b/components/organisms/HeaderNav.tsx
@@ -2,9 +2,11 @@
 
 import Link from 'next/link';
 import { LogoLink } from '@/components/atoms/LogoLink';
+import { NavLink } from '@/components/atoms/NavLink';
 import { AuthActions } from '@/components/molecules/AuthActions';
 import { FlyoutItem } from '@/components/molecules/FlyoutItem';
 import { Container } from '@/components/site/Container';
+import { Button } from '@/components/ui/Button';
 import {
   Popover,
   PopoverContent,
@@ -27,9 +29,13 @@ export function HeaderNav() {
             <nav className='flex items-center space-x-6'>
               <Popover>
                 <PopoverTrigger asChild>
-                  <button className='text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 rounded px-2 py-1'>
+                  <Button
+                    variant='plain'
+                    size='sm'
+                    className='font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+                  >
                     Product
-                  </button>
+                  </Button>
                 </PopoverTrigger>
                 <PopoverContent
                   align='center'
@@ -59,12 +65,9 @@ export function HeaderNav() {
                   </div>
                 </PopoverContent>
               </Popover>
-              <Link
-                href='/pricing'
-                className='text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors'
-              >
+              <NavLink href='/pricing' className='font-medium'>
                 Pricing
-              </Link>
+              </NavLink>
             </nav>
           </div>
 
@@ -73,9 +76,13 @@ export function HeaderNav() {
             <nav className='flex items-center space-x-4'>
               <Popover>
                 <PopoverTrigger asChild>
-                  <button className='text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 rounded px-2 py-1 min-h-[44px] flex items-center'>
+                  <Button
+                    variant='plain'
+                    size='sm'
+                    className='min-h-[44px] px-2 font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'
+                  >
                     Product
-                  </button>
+                  </Button>
                 </PopoverTrigger>
                 <PopoverContent
                   align='start'
@@ -103,12 +110,12 @@ export function HeaderNav() {
                   </div>
                 </PopoverContent>
               </Popover>
-              <Link
+              <NavLink
                 href='/pricing'
-                className='text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors min-h-[44px] flex items-center px-2'
+                className='min-h-[44px] px-2 font-medium flex items-center'
               >
                 Pricing
-              </Link>
+              </NavLink>
             </nav>
           </div>
 


### PR DESCRIPTION
## Summary
- refactor HeaderNav to use `Button` and `NavLink` from atomic design
- replace direct HeaderNav usage with shared Header component
- apply common header across not-found page

## Testing
- `pnpm eslint app/flyout-demo/page.tsx app/not-found.tsx components/organisms/HeaderNav.tsx`
- `pnpm lint` *(fails: Unable to resolve module '@radix-ui/react-popover')*
- `pnpm test` *(fails: Can't find meta/_journal.json file)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c2b5f96c832781c5dbfe09f3e062