### PR TITLE
refactor: replace heroicon usage with Icon component

### DIFF
--- a/components/atoms/IconBadge.tsx
+++ b/components/atoms/IconBadge.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
+import { Icon, type IconName } from '@/components/atoms/Icon';
 import { cn } from '@/lib/utils';
 
 interface IconBadgeProps {
-  Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  name: IconName;
   colorVar: string;
   className?: string;
   ariaLabel?: string;
 }
 
 export function IconBadge({
-  Icon,
+  name,
   colorVar,
   className,
   ariaLabel,
@@ -25,6 +26,7 @@ export function IconBadge({
       }}
     >
       <Icon
+        name={name}
         className='h-[18px] w-[18px]'
         style={{
           color: `var(${colorVar})`,

--- a/components/molecules/FlyoutItem.tsx
+++ b/components/molecules/FlyoutItem.tsx
@@ -25,7 +25,7 @@ export const FlyoutItem = React.forwardRef<HTMLAnchorElement, FlyoutItemProps>(
         role='menuitem'
       >
         <div className='flex-shrink-0'>
-          <IconBadge Icon={feature.Icon} colorVar={feature.colorVar} />
+          <IconBadge name={feature.icon} colorVar={feature.colorVar} />
         </div>
         <div className='min-w-0 flex-1'>
           <div className='flex items-center gap-2'>

--- a/lib/features.ts
+++ b/lib/features.ts
@@ -1,19 +1,11 @@
-import {
-  ArrowTrendingUpIcon,
-  BoltIcon,
-  ChartBarIcon,
-  LinkIcon,
-  MagnifyingGlassCircleIcon,
-  RocketLaunchIcon,
-  SparklesIcon,
-} from '@heroicons/react/24/outline';
+import type { IconName } from '@/components/atoms/Icon';
 
 export type Feature = {
   slug: string;
   title: string;
   blurb: string;
   href: string;
-  Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+  icon: IconName;
   colorVar: string; // e.g., '--accent-conv'
   aiPowered?: boolean; // Flag for AI-powered tag
 };
@@ -24,7 +16,7 @@ export const FEATURES: Feature[] = [
     title: 'Smart Conversions',
     blurb: 'AI-optimized CTAs and layouts that adapt in real time.',
     href: '/link-in-bio#smart-conversions',
-    Icon: ArrowTrendingUpIcon,
+    icon: 'TrendingUp',
     colorVar: '--accent-conv',
     aiPowered: true,
   },
@@ -33,7 +25,7 @@ export const FEATURES: Feature[] = [
     title: 'Real-Time Analytics',
     blurb: 'Instant insights, always aligned with your ad platforms.',
     href: '/link-in-bio#analytics',
-    Icon: ChartBarIcon,
+    icon: 'ChartBar',
     colorVar: '--accent-analytics',
   },
   {
@@ -41,7 +33,7 @@ export const FEATURES: Feature[] = [
     title: 'Blazing Fast',
     blurb: 'Sub-100ms loads. 99.99% uptime. Fans never wait.',
     href: '/link-in-bio#performance',
-    Icon: BoltIcon,
+    icon: 'Bolt',
     colorVar: '--accent-speed',
   },
   {
@@ -49,7 +41,7 @@ export const FEATURES: Feature[] = [
     title: 'Pixel-Perfect by Default',
     blurb: "Profiles auto-polished—you can't make them ugly.",
     href: '/link-in-bio#design',
-    Icon: SparklesIcon,
+    icon: 'Sparkles',
     colorVar: '--accent-beauty',
   },
   {
@@ -57,7 +49,7 @@ export const FEATURES: Feature[] = [
     title: 'SEO Boost',
     blurb: 'Structured, discoverable, and lightning-fast by design.',
     href: '/link-in-bio#seo',
-    Icon: MagnifyingGlassCircleIcon,
+    icon: 'Search',
     colorVar: '--accent-seo',
   },
   {
@@ -65,7 +57,7 @@ export const FEATURES: Feature[] = [
     title: 'Deep Links',
     blurb: 'Send fans straight to /listen, /tip, or /subscribe.',
     href: '/link-in-bio#deep-links',
-    Icon: LinkIcon,
+    icon: 'Link',
     colorVar: '--accent-links',
   },
   {
@@ -73,7 +65,7 @@ export const FEATURES: Feature[] = [
     title: 'Pixels & Remarketing',
     blurb: 'Growth integrations that scale with you.',
     href: '/link-in-bio#pro',
-    Icon: RocketLaunchIcon,
+    icon: 'Rocket',
     colorVar: '--accent-pro',
   },
 ];

--- a/tests/unit/FlyoutItem.test.tsx
+++ b/tests/unit/FlyoutItem.test.tsx
@@ -1,4 +1,3 @@
-import { BoltIcon } from '@heroicons/react/24/outline';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { FlyoutItem } from '@/components/molecules/FlyoutItem';
@@ -9,7 +8,7 @@ const mockFeature: Feature = {
   title: 'Blazing Fast',
   blurb: 'Sub-100ms loads and 99.99% uptime—fans never wait.',
   href: '/features/performance',
-  Icon: BoltIcon,
+  icon: 'Bolt',
   colorVar: '--accent-speed',
 };
 

--- a/tests/unit/IconBadge.test.tsx
+++ b/tests/unit/IconBadge.test.tsx
@@ -1,4 +1,3 @@
-import { BoltIcon } from '@heroicons/react/24/outline';
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { IconBadge } from '@/components/atoms/IconBadge';
@@ -8,7 +7,7 @@ describe('IconBadge', () => {
 
   it('renders icon with correct styling', () => {
     const { container } = render(
-      <IconBadge Icon={BoltIcon} colorVar='--accent-speed' />
+      <IconBadge name='Bolt' colorVar='--accent-speed' />
     );
 
     const icon = container.querySelector('svg');
@@ -21,7 +20,7 @@ describe('IconBadge', () => {
   it('applies custom className', () => {
     const { container } = render(
       <IconBadge
-        Icon={BoltIcon}
+        name='Bolt'
         colorVar='--accent-speed'
         className='custom-class'
       />
@@ -33,11 +32,7 @@ describe('IconBadge', () => {
 
   it('uses aria-label when provided', () => {
     render(
-      <IconBadge
-        Icon={BoltIcon}
-        colorVar='--accent-speed'
-        ariaLabel='Bolt icon'
-      />
+      <IconBadge name='Bolt' colorVar='--accent-speed' ariaLabel='Bolt icon' />
     );
 
     const icon = screen.getByLabelText('Bolt icon');


### PR DESCRIPTION
## Summary
- refactor IconBadge to accept lucide icon names
- migrate feature definitions and tests to use new Icon component

## Testing
- `pnpm lint`
- `pnpm test` *(fails: hanging; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c617051c8327b6a0f750357b2acc