### PR TITLE
fix: normalize icon name mapping

### DIFF
--- a/components/atoms/Icon.tsx
+++ b/components/atoms/Icon.tsx
@@ -4,12 +4,27 @@ import { cn } from '@/lib/utils';
 
 export type IconName = keyof typeof icons;
 
+// Normalize various icon naming conventions (kebab-case, underscores, "Icon" suffix)
+function resolveIconName(name: string): IconName | undefined {
+  const cleaned = name.endsWith('Icon') ? name.slice(0, -4) : name;
+  if (cleaned in icons) return cleaned as IconName;
+
+  const pascal = cleaned
+    .split(/[^a-zA-Z0-9]/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('') as IconName;
+
+  return pascal in icons ? pascal : undefined;
+}
+
 export interface IconProps extends Omit<LucideProps, 'ref'> {
-  name: IconName;
+  name: IconName | string;
 }
 
 export function Icon({ name, className, ...props }: IconProps) {
-  const LucideIcon = icons[name];
-  if (!LucideIcon) return null;
+  const iconName = resolveIconName(String(name));
+  if (!iconName) return null;
+  const LucideIcon = icons[iconName];
   return <LucideIcon className={cn(className)} {...props} />;
 }

--- a/tests/unit/Icon.test.tsx
+++ b/tests/unit/Icon.test.tsx
@@ -23,6 +23,14 @@ describe('Icon', () => {
     expect(icon).toHaveAttribute('height', '32');
   });
 
+  it('normalizes various icon name formats', () => {
+    render(<Icon name='alarm-clock' data-testid='kebab' />);
+    expect(screen.getByTestId('kebab')).toBeInTheDocument();
+
+    render(<Icon name='ActivityIcon' data-testid='suffix' />);
+    expect(screen.getByTestId('suffix')).toBeInTheDocument();
+  });
+
   it('returns null for unknown icon', () => {
     const { container } = render(
       <Icon name={'NotRealIcon' as any} data-testid='icon' />


### PR DESCRIPTION
## Summary
- resolve kebab-case and `Icon`-suffix icon names to Lucide icons
- cover icon name normalization with new tests

## Testing
- `DATABASE_URL='' pnpm test tests/unit/Icon.test.tsx tests/unit/IconBadge.test.tsx tests/unit/FlyoutItem.test.tsx`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68c0d0136d5483279ff065a3d33c75ac