### PR TITLE
[chore]: Playwright style sanity (bg-black text-white)

### DIFF
--- a/tests/e2e/style-sanity.spec.ts
+++ b/tests/e2e/style-sanity.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+// Simple sanity check that Tailwind classes resolve to expected computed styles in the browser
+// We do not rely on specific pages to include elements; instead we inject a transient node.
+
+test.describe('Style sanity', () => {
+  test('bg-black text-white computes correctly', async ({ page }) => {
+    // Use a lightweight route that exists publicly
+    await page.goto('/sandbox');
+
+    // Inject a transient element with tailwind classes and measure computed styles
+    const result = await page.evaluate(() => {
+      const el = document.createElement('div');
+      el.className = 'bg-black text-white';
+      el.textContent = 'style-sanity';
+      el.style.position = 'fixed';
+      el.style.left = '-9999px'; // offscreen
+      document.body.appendChild(el);
+
+      const styles = window.getComputedStyle(el);
+      const bg = styles.backgroundColor;
+      const color = styles.color;
+
+      el.remove();
+      return { bg, color };
+    });
+
+    // Chromium returns rgb values, ensure black/white within tolerance
+    // bg-black -> rgb(0, 0, 0), text-white -> rgb(255, 255, 255)
+    expect(result.bg).toBe('rgb(0, 0, 0)');
+    expect(result.color).toBe('rgb(255, 255, 255)');
+  });
+});


### PR DESCRIPTION
Adds a minimal Playwright E2E test that asserts Tailwind classes map to expected computed styles in the browser.

- New test: `tests/e2e/style-sanity.spec.ts`
- Navigates to `/sandbox`, injects a transient `div` with `bg-black text-white`, reads computed styles, and asserts:
  - backgroundColor === `rgb(0, 0, 0)`
  - color === `rgb(255, 255, 255)`

Why: Lightweight guard to catch regressions where Tailwind CSS isn't applied in the built app even if `next build` passes.

Non-invasive: No app code modified; only adds a test.

DoD: Test passes on CI in both light and dark modes implicitly (computed values are absolute).

Rollback: revert this PR.