### PR TITLE
fix(marketing): address shared hero review notes

### DIFF
--- a/apps/web/components/features/home/HomeHeroSurfaceCluster.tsx
+++ b/apps/web/components/features/home/HomeHeroSurfaceCluster.tsx
@@ -136,7 +136,6 @@ function HeroSmartLinkPanel() {
         glowTone='blue'
         imageClassName='object-cover'
         className='shadow-[0_30px_90px_rgba(0,0,0,0.44)]'
-        priority
       />
     </div>
   );

--- a/apps/web/components/features/home/HomePageNarrative.tsx
+++ b/apps/web/components/features/home/HomePageNarrative.tsx
@@ -39,7 +39,9 @@ function HomeHero() {
     <SharedMarketingHero
       eyebrow='The release system for independent artists'
       headingId='home-hero-heading'
+      sectionTestId='homepage-shell'
       primaryCtaLabel='Get Started'
+      ctaEventName='landing_cta_get_started'
       primaryCtaTestId='homepage-primary-cta'
       secondaryCtaLabel='See Demo'
       secondaryCtaHref={APP_ROUTES.DEMO}

--- a/apps/web/components/features/landing/LandingCTAButton.tsx
+++ b/apps/web/components/features/landing/LandingCTAButton.tsx
@@ -4,12 +4,10 @@ import { Button } from '@jovie/ui';
 import Link from 'next/link';
 import { track } from '@/lib/analytics';
 
-type LandingCTAEventName = 'landing_cta_get_started';
-
 interface LandingCTAButtonProps {
   readonly href: string;
   readonly label: string;
-  readonly eventName: LandingCTAEventName;
+  readonly eventName: string;
   readonly section: 'hero';
   readonly variant?: 'primary' | 'text';
   readonly className?: string;

--- a/apps/web/components/features/landing/SharedMarketingHero.tsx
+++ b/apps/web/components/features/landing/SharedMarketingHero.tsx
@@ -15,6 +15,7 @@ interface SharedMarketingHeroProps {
   readonly sectionTestId?: string;
   readonly primaryCtaLabel?: string;
   readonly primaryCtaHref?: string;
+  readonly ctaEventName?: string;
   readonly primaryCtaTestId?: string;
   readonly secondaryCtaLabel?: string;
   readonly secondaryCtaHref?: string;
@@ -32,9 +33,10 @@ export function SharedMarketingHero({
   media,
   headingId,
   titleTestId = 'hero-heading',
-  sectionTestId = 'homepage-shell',
+  sectionTestId = 'marketing-hero-section',
   primaryCtaLabel = 'Get started',
   primaryCtaHref = APP_ROUTES.SIGNUP,
+  ctaEventName = 'landing_cta_get_started',
   primaryCtaTestId,
   secondaryCtaLabel,
   secondaryCtaHref,
@@ -82,7 +84,7 @@ export function SharedMarketingHero({
                 <LandingCTAButton
                   href={primaryCtaHref}
                   label={primaryCtaLabel}
-                  eventName='landing_cta_get_started'
+                  eventName={ctaEventName}
                   section='hero'
                   testId={primaryCtaTestId}
                 />

--- a/apps/web/tests/unit/landing/SharedMarketingHero.test.tsx
+++ b/apps/web/tests/unit/landing/SharedMarketingHero.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SharedMarketingHero } from '@/features/landing/SharedMarketingHero';
+
+vi.mock('@/features/landing/LandingCTAButton', () => ({
+  LandingCTAButton: ({
+    eventName,
+    label,
+    testId,
+  }: Readonly<{
+    eventName: string;
+    label: string;
+    testId?: string;
+  }>) => (
+    <button
+      type='button'
+      data-event-name={eventName}
+      data-testid={testId ?? 'cta-button'}
+    >
+      {label}
+    </button>
+  ),
+}));
+
+describe('SharedMarketingHero', () => {
+  it('uses a generic default section test id', () => {
+    render(
+      <SharedMarketingHero
+        eyebrow='Eyebrow'
+        headingId='shared-hero-heading'
+        title='Hero title'
+        body='Hero body'
+        media={<div>Media</div>}
+      />
+    );
+
+    expect(screen.getByTestId('marketing-hero-section')).toBeInTheDocument();
+    expect(screen.queryByTestId('homepage-shell')).not.toBeInTheDocument();
+  });
+
+  it('passes an override CTA analytics event to the CTA button', () => {
+    render(
+      <SharedMarketingHero
+        eyebrow='Eyebrow'
+        headingId='shared-hero-heading'
+        title='Hero title'
+        body='Hero body'
+        media={<div>Media</div>}
+        ctaEventName='artist_profiles_cta_get_started'
+        primaryCtaTestId='shared-hero-primary-cta'
+      />
+    );
+
+    expect(screen.getByTestId('shared-hero-primary-cta')).toHaveAttribute(
+      'data-event-name',
+      'artist_profiles_cta_get_started'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- make `SharedMarketingHero` generic by default instead of homepage-specific
- allow CTA analytics event names to be overridden by surfaces using the shared primitive
- remove `priority` from the decorative release phone and add a regression test for the shared hero API

## Verification
- `doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web exec vitest run tests/unit/landing/SharedMarketingHero.test.tsx tests/unit/home/HomePageNarrative.test.tsx`
- `pnpm --filter @jovie/web exec tsc -p tsconfig.typecheck.json --noEmit`
- repo pre-push gate: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced customization of call-to-action event tracking for marketing components.

* **Tests**
  * Added comprehensive unit test coverage for marketing hero component functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->