### PR TITLE
perf(web): keep trimming releases route bundle

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleasePlanPromptDialog.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleasePlanPromptDialog.tsx
@@ -29,22 +29,37 @@ export function ReleasePlanPromptDialog({
   onClose,
   onGenerateReleasePlan,
 }: ReleasePlanPromptDialogProps) {
+  const dialogTitle = isGateLoading
+    ? 'Release Plan'
+    : canGenerateReleasePlans
+      ? 'Generate Release Plan'
+      : 'Upgrade To Generate A Release Plan';
+  const dialogDescription = isGateLoading
+    ? 'Checking whether this workspace can generate tasks for the release plan.'
+    : canGenerateReleasePlans
+      ? 'Create the step-by-step tasks for this release and jump straight into the plan.'
+      : 'Upgrade to turn this release into a step-by-step plan with tasks you can assign to Jovie AI.';
+  const actionButton = isGateLoading ? (
+    <Button type='button' size='sm' disabled>
+      Loading...
+    </Button>
+  ) : canGenerateReleasePlans ? (
+    <Button
+      type='button'
+      size='sm'
+      onClick={onGenerateReleasePlan}
+      disabled={isGeneratingReleasePlan}
+    >
+      {isGeneratingReleasePlan ? 'Generating...' : 'Generate Release Plan'}
+    </Button>
+  ) : (
+    <UpgradeButton size='sm'>Upgrade to Pro</UpgradeButton>
+  );
+
   return (
     <Dialog open={open} onClose={onClose} size='sm'>
-      <DialogTitle>
-        {isGateLoading
-          ? 'Release Plan'
-          : canGenerateReleasePlans
-            ? 'Generate Release Plan'
-            : 'Upgrade To Generate A Release Plan'}
-      </DialogTitle>
-      <DialogDescription>
-        {isGateLoading
-          ? 'Checking whether this workspace can generate tasks for the release plan.'
-          : canGenerateReleasePlans
-            ? 'Create the step-by-step tasks for this release and jump straight into the plan.'
-            : 'Upgrade to turn this release into a step-by-step plan with tasks you can assign to Jovie AI.'}
-      </DialogDescription>
+      <DialogTitle>{dialogTitle}</DialogTitle>
+      <DialogDescription>{dialogDescription}</DialogDescription>
       <DialogBody className='space-y-2'>
         <p className='text-[13px] text-secondary-token'>
           {releaseTitle ?? 'This release'} is ready.
@@ -60,24 +75,7 @@ export function ReleasePlanPromptDialog({
         >
           Maybe Later
         </Button>
-        {isGateLoading ? (
-          <Button type='button' size='sm' disabled>
-            Loading...
-          </Button>
-        ) : canGenerateReleasePlans ? (
-          <Button
-            type='button'
-            size='sm'
-            onClick={onGenerateReleasePlan}
-            disabled={isGeneratingReleasePlan}
-          >
-            {isGeneratingReleasePlan
-              ? 'Generating...'
-              : 'Generate Release Plan'}
-          </Button>
-        ) : (
-          <UpgradeButton size='sm'>Upgrade to Pro</UpgradeButton>
-        )}
+        {actionButton}
       </DialogActions>
     </Dialog>
   );

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleasePlanPromptDialog.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleasePlanPromptDialog.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { Button } from '@jovie/ui';
+import { UpgradeButton } from '@/components/molecules/UpgradeButton';
+import {
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/organisms/Dialog';
+
+interface ReleasePlanPromptDialogProps {
+  readonly open: boolean;
+  readonly releaseTitle: string | null;
+  readonly isGateLoading: boolean;
+  readonly canGenerateReleasePlans: boolean;
+  readonly isGeneratingReleasePlan: boolean;
+  readonly onClose: () => void;
+  readonly onGenerateReleasePlan: () => void;
+}
+
+export function ReleasePlanPromptDialog({
+  open,
+  releaseTitle,
+  isGateLoading,
+  canGenerateReleasePlans,
+  isGeneratingReleasePlan,
+  onClose,
+  onGenerateReleasePlan,
+}: ReleasePlanPromptDialogProps) {
+  return (
+    <Dialog open={open} onClose={onClose} size='sm'>
+      <DialogTitle>
+        {isGateLoading
+          ? 'Release Plan'
+          : canGenerateReleasePlans
+            ? 'Generate Release Plan'
+            : 'Upgrade To Generate A Release Plan'}
+      </DialogTitle>
+      <DialogDescription>
+        {isGateLoading
+          ? 'Checking whether this workspace can generate tasks for the release plan.'
+          : canGenerateReleasePlans
+            ? 'Create the step-by-step tasks for this release and jump straight into the plan.'
+            : 'Upgrade to turn this release into a step-by-step plan with tasks you can assign to Jovie AI.'}
+      </DialogDescription>
+      <DialogBody className='space-y-2'>
+        <p className='text-[13px] text-secondary-token'>
+          {releaseTitle ?? 'This release'} is ready.
+        </p>
+      </DialogBody>
+      <DialogActions>
+        <Button
+          type='button'
+          variant='outline'
+          size='sm'
+          onClick={onClose}
+          disabled={isGeneratingReleasePlan}
+        >
+          Maybe Later
+        </Button>
+        {isGateLoading ? (
+          <Button type='button' size='sm' disabled>
+            Loading...
+          </Button>
+        ) : canGenerateReleasePlans ? (
+          <Button
+            type='button'
+            size='sm'
+            onClick={onGenerateReleasePlan}
+            disabled={isGeneratingReleasePlan}
+          >
+            {isGeneratingReleasePlan
+              ? 'Generating...'
+              : 'Generate Release Plan'}
+          </Button>
+        ) : (
+          <UpgradeButton size='sm'>Upgrade to Pro</UpgradeButton>
+        )}
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Button } from '@jovie/ui';
 import { useRouter } from 'next/navigation';
 import {
   lazy,
@@ -24,15 +23,7 @@ import {
   DrawerButton,
   DrawerLoadingSkeleton,
 } from '@/components/molecules/drawer';
-import { UpgradeButton } from '@/components/molecules/UpgradeButton';
 import { useTableMeta } from '@/components/organisms/AuthShellWrapper';
-import {
-  Dialog,
-  DialogActions,
-  DialogBody,
-  DialogDescription,
-  DialogTitle,
-} from '@/components/organisms/Dialog';
 import { DialogLoadingSkeleton } from '@/components/organisms/DialogLoadingSkeleton';
 import { PageShell } from '@/components/organisms/PageShell';
 import type { TrackSidebarData } from '@/components/organisms/release-sidebar';
@@ -113,6 +104,12 @@ const ReleasesEmptyState = lazy(() =>
 const SmartLinkGateBanner = lazy(() =>
   import('./SmartLinkGateBanner').then(m => ({
     default: m.SmartLinkGateBanner,
+  }))
+);
+
+const ReleasePlanPromptDialog = lazy(() =>
+  import('./ReleasePlanPromptDialog').then(m => ({
+    default: m.ReleasePlanPromptDialog,
   }))
 );
 
@@ -992,60 +989,30 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
         />
       </Suspense>
 
-      <Dialog
-        open={isPostCreatePlanModalOpen && postCreateRelease !== null}
-        onClose={closePostCreatePlanModal}
-        size='sm'
-      >
-        <DialogTitle>
-          {isReleasePlanGateLoading
-            ? 'Release Plan'
-            : canGenerateReleasePlans
-              ? 'Generate Release Plan'
-              : 'Upgrade To Generate A Release Plan'}
-        </DialogTitle>
-        <DialogDescription>
-          {isReleasePlanGateLoading
-            ? 'Checking whether this workspace can generate tasks for the release plan.'
-            : canGenerateReleasePlans
-              ? 'Create the step-by-step tasks for this release and jump straight into the plan.'
-              : 'Upgrade to turn this release into a step-by-step plan with tasks you can assign to Jovie AI.'}
-        </DialogDescription>
-        <DialogBody className='space-y-2'>
-          <p className='text-[13px] text-secondary-token'>
-            {postCreateRelease?.title ?? 'This release'} is ready.
-          </p>
-        </DialogBody>
-        <DialogActions>
-          <Button
-            type='button'
-            variant='outline'
-            size='sm'
-            onClick={closePostCreatePlanModal}
-            disabled={isGeneratingReleasePlan}
-          >
-            Maybe Later
-          </Button>
-          {isReleasePlanGateLoading ? (
-            <Button type='button' size='sm' disabled>
-              Loading...
-            </Button>
-          ) : canGenerateReleasePlans ? (
-            <Button
-              type='button'
+      <Suspense
+        fallback={
+          isPostCreatePlanModalOpen && postCreateRelease !== null ? (
+            <DialogLoadingSkeleton
+              open
+              onClose={closePostCreatePlanModal}
               size='sm'
-              onClick={handleGenerateReleasePlan}
-              disabled={isGeneratingReleasePlan}
-            >
-              {isGeneratingReleasePlan
-                ? 'Generating...'
-                : 'Generate Release Plan'}
-            </Button>
-          ) : (
-            <UpgradeButton size='sm'>Upgrade to Pro</UpgradeButton>
-          )}
-        </DialogActions>
-      </Dialog>
+              rows={3}
+            />
+          ) : null
+        }
+      >
+        {isPostCreatePlanModalOpen && postCreateRelease !== null ? (
+          <ReleasePlanPromptDialog
+            open
+            releaseTitle={postCreateRelease.title}
+            isGateLoading={isReleasePlanGateLoading}
+            canGenerateReleasePlans={canGenerateReleasePlans}
+            isGeneratingReleasePlan={isGeneratingReleasePlan}
+            onClose={closePostCreatePlanModal}
+            onGenerateReleasePlan={handleGenerateReleasePlan}
+          />
+        ) : null}
+      </Suspense>
     </>
   );
 });

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
@@ -10,12 +10,12 @@ import { TABLE_ROW_HEIGHTS } from '@/lib/constants/layout';
 import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
 import { useExpandedTracks } from './hooks/useExpandedTracks';
 import { useSortingManager } from './hooks/useSortingManager';
+import { getReleaseContextMenuItems } from './utils/release-context-actions';
 import {
   createExpandableReleaseCellRenderer,
   createReleaseCellRenderer,
   createRightMetaCellRenderer,
-} from './utils/column-renderers';
-import { getReleaseContextMenuItems } from './utils/release-context-actions';
+} from './utils/release-table-renderers';
 
 const MobileReleaseList = lazy(() =>
   import('./MobileReleaseList').then(m => ({

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
@@ -1,23 +1,35 @@
 'use client';
 
 import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
-import { useCallback, useMemo } from 'react';
+import { lazy, Suspense, useCallback, useMemo } from 'react';
 import { Icon } from '@/components/atoms/Icon';
 import type { TrackSidebarData } from '@/components/organisms/release-sidebar';
 import { TableEmptyState, UnifiedTable } from '@/components/organisms/table';
 import { useBreakpointDown } from '@/hooks/useBreakpoint';
 import { TABLE_ROW_HEIGHTS } from '@/lib/constants/layout';
 import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
-import { TrackRowsContainer } from './components';
 import { useExpandedTracks } from './hooks/useExpandedTracks';
 import { useSortingManager } from './hooks/useSortingManager';
-import { MobileReleaseList } from './MobileReleaseList';
 import {
   createExpandableReleaseCellRenderer,
   createReleaseCellRenderer,
   createRightMetaCellRenderer,
 } from './utils/column-renderers';
 import { getReleaseContextMenuItems } from './utils/release-context-actions';
+
+const MobileReleaseList = lazy(() =>
+  import('./MobileReleaseList').then(m => ({
+    default: m.MobileReleaseList,
+  }))
+);
+
+const TrackRowsContainer = lazy(() =>
+  import(
+    '@/features/dashboard/organisms/release-provider-matrix/components'
+  ).then(m => ({
+    default: m.TrackRowsContainer,
+  }))
+);
 
 interface ProviderConfig {
   label: string;
@@ -65,6 +77,16 @@ const columnHelper = createColumnHelper<ReleaseViewModel>();
 const MetaHeaderCell = () => (
   <span className='sr-only'>Smart link, popularity, year</span>
 );
+
+function TrackRowsLoadingRow({
+  columnCount: _columnCount,
+}: Readonly<{ columnCount: number }>) {
+  return (
+    <div className='px-4 py-2 text-[11px] text-tertiary-token'>
+      Loading tracks...
+    </div>
+  );
+}
 
 /**
  * ReleaseTable - Releases table using UnifiedTable
@@ -283,16 +305,18 @@ export function ReleaseTable({
       if (!tracks) return null;
 
       return (
-        <TrackRowsContainer
-          tracks={tracks}
-          release={release}
-          providerConfig={providerConfig}
-          allProviders={allProviders}
-          columnCount={columnCount}
-          columnVisibility={tanstackColumnVisibility}
-          onTrackClick={onTrackClick}
-          selectedTrackId={selectedTrackId}
-        />
+        <Suspense fallback={<TrackRowsLoadingRow columnCount={columnCount} />}>
+          <TrackRowsContainer
+            tracks={tracks}
+            release={release}
+            providerConfig={providerConfig}
+            allProviders={allProviders}
+            columnCount={columnCount}
+            columnVisibility={tanstackColumnVisibility}
+            onTrackClick={onTrackClick}
+            selectedTrackId={selectedTrackId}
+          />
+        </Suspense>
       );
     },
     [
@@ -329,15 +353,23 @@ export function ReleaseTable({
     }
 
     return (
-      <MobileReleaseList
-        releases={releases}
-        artistName={artistName}
-        onEdit={onEdit}
-        onCopy={onCopy}
-        isSmartLinkLocked={isSmartLinkLocked}
-        getSmartLinkLockReason={getSmartLinkLockReason}
-        groupByYear={groupByYear}
-      />
+      <Suspense
+        fallback={
+          <div className='border-b border-(--linear-app-frame-seam) px-4 py-3 text-[12px] text-secondary-token'>
+            Loading releases...
+          </div>
+        }
+      >
+        <MobileReleaseList
+          releases={releases}
+          artistName={artistName}
+          onEdit={onEdit}
+          onCopy={onCopy}
+          isSmartLinkLocked={isSmartLinkLocked}
+          getSmartLinkLockReason={getSmartLinkLockReason}
+          groupByYear={groupByYear}
+        />
+      </Suspense>
     );
   }
 

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.types.ts
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.types.ts
@@ -2,9 +2,14 @@ import type { TrackSidebarData } from '@/components/organisms/release-sidebar';
 import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
 
 export interface ProviderConfig {
-  label: string;
+  readonly label: string;
   readonly accent: string;
 }
+
+export const RELEASE_VIEW_OPTIONS = [
+  { value: 'tracks', label: 'Tracks' },
+  { value: 'releases', label: 'Releases' },
+] as const;
 
 export interface ReleaseTableProps {
   readonly releases: ReleaseViewModel[];

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.types.ts
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.types.ts
@@ -1,0 +1,33 @@
+import type { TrackSidebarData } from '@/components/organisms/release-sidebar';
+import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
+
+export interface ProviderConfig {
+  label: string;
+  readonly accent: string;
+}
+
+export interface ReleaseTableProps {
+  readonly releases: ReleaseViewModel[];
+  readonly providerConfig: Record<ProviderKey, ProviderConfig>;
+  readonly artistName?: string | null;
+  readonly onCopy: (
+    path: string,
+    label: string,
+    testId: string
+  ) => Promise<string>;
+  readonly onEdit: (release: ReleaseViewModel) => void;
+  readonly columnVisibility?: Record<string, boolean>;
+  readonly rowHeight?: number;
+  readonly onFocusedRowChange?: (release: ReleaseViewModel) => void;
+  readonly showTracks?: boolean;
+  readonly groupByYear?: boolean;
+  readonly refreshingReleaseId?: string | null;
+  readonly flashedReleaseId?: string | null;
+  readonly selectedReleaseId?: string | null;
+  readonly selectedTrackId?: string | null;
+  readonly isSmartLinkLocked?: (releaseId: string) => boolean;
+  readonly getSmartLinkLockReason?: (
+    releaseId: string
+  ) => 'scheduled' | 'cap' | null;
+  readonly onTrackClick?: (trackData: TrackSidebarData) => void;
+}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableDisplayMenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableDisplayMenu.tsx
@@ -22,12 +22,8 @@ import {
 } from '@/components/organisms/table';
 import { GLYPH_SHIFT } from '@/lib/keyboard-shortcuts';
 import { cn } from '@/lib/utils';
+import { RELEASE_VIEW_OPTIONS } from './ReleaseTable.types';
 import type { ReleaseView } from './ReleaseTableSubheader';
-
-const RELEASE_VIEW_OPTIONS = [
-  { value: 'tracks', label: 'Tracks' },
-  { value: 'releases', label: 'Releases' },
-] as const;
 
 function ReleaseViewSegmentedControl({
   value,

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableDisplayMenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableDisplayMenu.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import {
+  Button,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  TooltipShortcut,
+} from '@jovie/ui';
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { X } from 'lucide-react';
+import { useState } from 'react';
+import { AppIconButton } from '@/components/atoms/AppIconButton';
+import { AppSegmentControl } from '@/components/atoms/AppSegmentControl';
+import { Icon } from '@/components/atoms/Icon';
+import {
+  PAGE_TOOLBAR_ACTION_ACTIVE_CLASS,
+  PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
+  PAGE_TOOLBAR_ACTION_ICON_ONLY_BUTTON_CLASS,
+  PAGE_TOOLBAR_ICON_CLASS,
+  PAGE_TOOLBAR_ICON_STROKE_WIDTH,
+} from '@/components/organisms/table';
+import { GLYPH_SHIFT } from '@/lib/keyboard-shortcuts';
+import { cn } from '@/lib/utils';
+import type { ReleaseView } from './ReleaseTableSubheader';
+
+const RELEASE_VIEW_OPTIONS = [
+  { value: 'tracks', label: 'Tracks' },
+  { value: 'releases', label: 'Releases' },
+] as const;
+
+function ReleaseViewSegmentedControl({
+  value,
+  onChange,
+}: {
+  readonly value: ReleaseView;
+  readonly onChange: (value: ReleaseView) => void;
+}) {
+  return (
+    <AppSegmentControl
+      value={value}
+      onValueChange={onChange}
+      options={RELEASE_VIEW_OPTIONS.map(option => ({
+        value: option.value,
+        label: option.label,
+      }))}
+      size='md'
+      className='grid w-full grid-cols-2'
+      triggerClassName='min-h-[34px] px-3 py-1.5 text-[12px]'
+      aria-label='Choose releases view'
+    />
+  );
+}
+
+function ToggleSwitch({
+  label,
+  checked,
+  onToggle,
+}: {
+  readonly label: string;
+  readonly checked: boolean;
+  readonly onToggle: () => void;
+}) {
+  return (
+    <button
+      type='button'
+      role='switch'
+      aria-checked={checked}
+      onClick={onToggle}
+      className='flex w-full items-center justify-between gap-2 rounded-full px-2 py-1.5 transition-[background-color,color] duration-150 hover:bg-surface-1 focus-visible:outline-none focus-visible:bg-surface-1'
+    >
+      <span className='text-[12px] font-[510] text-secondary-token'>
+        {label}
+      </span>
+      <span
+        className={cn(
+          'flex h-[18px] w-[30px] shrink-0 items-center rounded-full p-[3px] transition-colors',
+          checked ? 'bg-(--linear-accent)' : 'bg-(--linear-border-subtle)'
+        )}
+      >
+        <span
+          className={cn(
+            'h-3 w-3 rounded-full bg-white shadow-sm transition-transform',
+            checked && 'translate-x-3'
+          )}
+        />
+      </span>
+    </button>
+  );
+}
+
+export function ReleaseTableDisplayMenu({
+  groupByYear,
+  onGroupByYearChange,
+  releaseView,
+  onReleaseViewChange,
+  triggerClassName,
+  compact = false,
+}: {
+  readonly groupByYear?: boolean;
+  readonly onGroupByYearChange?: (group: boolean) => void;
+  readonly releaseView?: ReleaseView;
+  readonly onReleaseViewChange?: (view: ReleaseView) => void;
+  readonly triggerClassName?: string;
+  readonly compact?: boolean;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <TooltipShortcut
+        label='Display'
+        shortcut={`${GLYPH_SHIFT}V`}
+        side='bottom'
+      >
+        <PopoverTrigger asChild>
+          <Button
+            variant='ghost'
+            size='sm'
+            className={cn(
+              PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
+              'h-7 rounded-full px-1.5 [&_svg]:h-3 [&_svg]:w-3',
+              compact && PAGE_TOOLBAR_ACTION_ICON_ONLY_BUTTON_CLASS,
+              compact && 'w-7',
+              isOpen && PAGE_TOOLBAR_ACTION_ACTIVE_CLASS,
+              triggerClassName
+            )}
+          >
+            <Icon
+              name='SlidersHorizontal'
+              className={PAGE_TOOLBAR_ICON_CLASS}
+              strokeWidth={PAGE_TOOLBAR_ICON_STROKE_WIDTH}
+            />
+            <span className={cn(compact && 'sr-only')}>Display</span>
+          </Button>
+        </PopoverTrigger>
+      </TooltipShortcut>
+      <PopoverContent
+        align='end'
+        className='w-[248px] rounded-[12px] border border-subtle bg-surface-1 p-0 shadow-popover'
+      >
+        <div className='flex items-center justify-between border-b border-subtle px-3 py-2'>
+          <span className='text-[13px] font-[510] text-primary-token'>
+            Display
+          </span>
+          <PopoverPrimitive.Close asChild>
+            <AppIconButton
+              type='button'
+              ariaLabel='Close display menu'
+              className='border-transparent bg-transparent'
+            >
+              <X className='h-3.5 w-3.5' />
+            </AppIconButton>
+          </PopoverPrimitive.Close>
+        </div>
+
+        {onReleaseViewChange && (
+          <div className='border-b border-subtle px-3 py-2'>
+            <ReleaseViewSegmentedControl
+              value={releaseView ?? 'releases'}
+              onChange={onReleaseViewChange}
+            />
+          </div>
+        )}
+
+        {onGroupByYearChange && (
+          <div className='border-b border-subtle px-3 py-1.5'>
+            <p className='px-1 pb-1 text-[13px] font-[510] tracking-normal text-secondary-token'>
+              List options
+            </p>
+            <ToggleSwitch
+              label='Group by year'
+              checked={groupByYear ?? false}
+              onToggle={() => onGroupByYearChange(!groupByYear)}
+            />
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableExportButton.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableExportButton.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { ExportCSVButton } from '@/components/organisms/table';
+import type { ReleaseViewModel } from '@/lib/discography/types';
+import {
+  getReleasesForExport,
+  RELEASES_CSV_COLUMNS,
+} from './utils/exportReleases';
+
+interface ReleaseTableExportButtonProps {
+  readonly releases: ReleaseViewModel[];
+  readonly selectedIds: Set<string>;
+}
+
+export function ReleaseTableExportButton({
+  releases,
+  selectedIds,
+}: ReleaseTableExportButtonProps) {
+  return (
+    <ExportCSVButton
+      getData={() => getReleasesForExport(releases, selectedIds)}
+      columns={RELEASES_CSV_COLUMNS}
+      filename='releases'
+      label='Export'
+      variant='ghost'
+      size='sm'
+      chrome='page-toolbar'
+      iconOnly
+      tooltipLabel='Export'
+      className='h-7 w-7 rounded-full px-0 [&_svg]:h-3 [&_svg]:w-3'
+    />
+  );
+}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableSubheader.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableSubheader.tsx
@@ -6,7 +6,6 @@ import { AppSegmentControl } from '@/components/atoms/AppSegmentControl';
 import { Icon } from '@/components/atoms/Icon';
 import { HeaderSearchAction } from '@/components/molecules/HeaderSearchAction';
 import {
-  ExportCSVButton,
   PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
   PAGE_TOOLBAR_ACTION_ICON_ONLY_BUTTON_CLASS,
   PAGE_TOOLBAR_END_GROUP_CLASS,
@@ -20,10 +19,6 @@ import type { ReleaseType, ReleaseViewModel } from '@/lib/discography/types';
 import { useCodeFlag } from '@/lib/feature-flags/client';
 import { cn } from '@/lib/utils';
 import { useReleaseFilterCounts } from './hooks/useReleaseFilterCounts';
-import {
-  getReleasesForExport,
-  RELEASES_CSV_COLUMNS,
-} from './utils/exportReleases';
 
 const ReleaseFilterDropdown = lazy(() =>
   import('./ReleaseFilterDropdown').then(m => ({
@@ -34,6 +29,12 @@ const ReleaseFilterDropdown = lazy(() =>
 const ReleaseTableDisplayMenu = lazy(() =>
   import('./ReleaseTableDisplayMenu').then(m => ({
     default: m.ReleaseTableDisplayMenu,
+  }))
+);
+
+const ReleaseTableExportButton = lazy(() =>
+  import('./ReleaseTableExportButton').then(m => ({
+    default: m.ReleaseTableExportButton,
   }))
 );
 
@@ -230,18 +231,33 @@ export const ReleaseTableSubheader = memo(function ReleaseTableSubheader({
               />
             </Suspense>
           )}
-          <ExportCSVButton
-            getData={() => getReleasesForExport(releases, selectedIds)}
-            columns={RELEASES_CSV_COLUMNS}
-            filename='releases'
-            label='Export'
-            variant='ghost'
-            size='sm'
-            chrome='page-toolbar'
-            iconOnly
-            tooltipLabel='Export'
-            className='h-7 w-7 rounded-full px-0 [&_svg]:h-3 [&_svg]:w-3'
-          />
+          <Suspense
+            fallback={
+              <Button
+                variant='ghost'
+                size='sm'
+                className={cn(
+                  PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
+                  PAGE_TOOLBAR_ACTION_ICON_ONLY_BUTTON_CLASS,
+                  'h-7 w-7 rounded-full px-0 [&_svg]:h-3 [&_svg]:w-3'
+                )}
+                aria-label='Export'
+                disabled
+              >
+                <Icon
+                  name='Download'
+                  className={PAGE_TOOLBAR_ICON_CLASS}
+                  strokeWidth={PAGE_TOOLBAR_ICON_STROKE_WIDTH}
+                />
+                <span className='sr-only'>Export</span>
+              </Button>
+            }
+          >
+            <ReleaseTableExportButton
+              releases={releases}
+              selectedIds={selectedIds}
+            />
+          </Suspense>
           <DrawerToggleButton
             chrome='page-toolbar'
             ariaLabel='Toggle release preview'

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableSubheader.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableSubheader.tsx
@@ -1,22 +1,12 @@
 'use client';
 
-import {
-  Button,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-  TooltipShortcut,
-} from '@jovie/ui';
-import * as PopoverPrimitive from '@radix-ui/react-popover';
-import { X } from 'lucide-react';
-import { lazy, memo, Suspense, useState } from 'react';
-import { AppIconButton } from '@/components/atoms/AppIconButton';
+import { Button } from '@jovie/ui';
+import { lazy, memo, Suspense } from 'react';
 import { AppSegmentControl } from '@/components/atoms/AppSegmentControl';
 import { Icon } from '@/components/atoms/Icon';
 import { HeaderSearchAction } from '@/components/molecules/HeaderSearchAction';
 import {
   ExportCSVButton,
-  PAGE_TOOLBAR_ACTION_ACTIVE_CLASS,
   PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
   PAGE_TOOLBAR_ACTION_ICON_ONLY_BUTTON_CLASS,
   PAGE_TOOLBAR_END_GROUP_CLASS,
@@ -28,7 +18,6 @@ import { DrawerToggleButton } from '@/features/dashboard/atoms/DrawerToggleButto
 import { LINEAR_SURFACE } from '@/features/dashboard/tokens';
 import type { ReleaseType, ReleaseViewModel } from '@/lib/discography/types';
 import { useCodeFlag } from '@/lib/feature-flags/client';
-import { GLYPH_SHIFT } from '@/lib/keyboard-shortcuts';
 import { cn } from '@/lib/utils';
 import { useReleaseFilterCounts } from './hooks/useReleaseFilterCounts';
 import {
@@ -39,6 +28,12 @@ import {
 const ReleaseFilterDropdown = lazy(() =>
   import('./ReleaseFilterDropdown').then(m => ({
     default: m.ReleaseFilterDropdown,
+  }))
+);
+
+const ReleaseTableDisplayMenu = lazy(() =>
+  import('./ReleaseTableDisplayMenu').then(m => ({
+    default: m.ReleaseTableDisplayMenu,
   }))
 );
 
@@ -118,169 +113,6 @@ function ReleaseViewButtons({
       triggerClassName='min-w-[72px] px-3'
       aria-label='Choose releases view'
     />
-  );
-}
-
-/** Linear-style full-width segmented control with icons */
-function ReleaseViewSegmentedControl({
-  value,
-  onChange,
-}: {
-  value: ReleaseView;
-  onChange: (value: ReleaseView) => void;
-}) {
-  return (
-    <AppSegmentControl
-      value={value}
-      onValueChange={onChange}
-      options={RELEASE_VIEW_OPTIONS.map(option => ({
-        value: option.value,
-        label: option.label,
-      }))}
-      size='md'
-      className='grid w-full grid-cols-2'
-      triggerClassName='min-h-[34px] px-3 py-1.5 text-[12px]'
-      aria-label='Choose releases view'
-    />
-  );
-}
-
-/** Toggle switch component for display menu options */
-function ToggleSwitch({
-  label,
-  checked,
-  onToggle,
-}: {
-  label: string;
-  checked: boolean;
-  onToggle: () => void;
-}) {
-  return (
-    <button
-      type='button'
-      role='switch'
-      aria-checked={checked}
-      onClick={onToggle}
-      className='flex w-full items-center justify-between gap-2 rounded-full px-2 py-1.5 transition-[background-color,color] duration-150 hover:bg-surface-1 focus-visible:outline-none focus-visible:bg-surface-1'
-    >
-      <span className='text-[12px] font-[510] text-secondary-token'>
-        {label}
-      </span>
-      <span
-        className={cn(
-          'flex h-[18px] w-[30px] shrink-0 items-center rounded-full p-[3px] transition-colors',
-          checked ? 'bg-(--linear-accent)' : 'bg-(--linear-border-subtle)'
-        )}
-      >
-        <span
-          className={cn(
-            'h-3 w-3 rounded-full bg-white shadow-sm transition-transform',
-            checked && 'translate-x-3'
-          )}
-        />
-      </span>
-    </button>
-  );
-}
-
-/**
- * LinearStyleDisplayMenu - Compact display settings popover
- *
- * Features:
- * - Tracks/releases view toggle
- * - Group by year toggle
- */
-function LinearStyleDisplayMenu({
-  groupByYear,
-  onGroupByYearChange,
-  releaseView,
-  onReleaseViewChange,
-  triggerClassName,
-  compact = false,
-}: {
-  groupByYear?: boolean;
-  onGroupByYearChange?: (group: boolean) => void;
-  releaseView?: ReleaseView;
-  onReleaseViewChange?: (view: ReleaseView) => void;
-  triggerClassName?: string;
-  compact?: boolean;
-}) {
-  const [isOpen, setIsOpen] = useState(false);
-
-  return (
-    <Popover open={isOpen} onOpenChange={setIsOpen}>
-      <TooltipShortcut
-        label='Display'
-        shortcut={`${GLYPH_SHIFT}V`}
-        side='bottom'
-      >
-        <PopoverTrigger asChild>
-          <Button
-            variant='ghost'
-            size='sm'
-            className={cn(
-              PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
-              'h-7 rounded-full px-1.5 [&_svg]:h-3 [&_svg]:w-3',
-              compact && PAGE_TOOLBAR_ACTION_ICON_ONLY_BUTTON_CLASS,
-              compact && 'w-7',
-              isOpen && PAGE_TOOLBAR_ACTION_ACTIVE_CLASS,
-              triggerClassName
-            )}
-          >
-            <Icon
-              name='SlidersHorizontal'
-              className={PAGE_TOOLBAR_ICON_CLASS}
-              strokeWidth={PAGE_TOOLBAR_ICON_STROKE_WIDTH}
-            />
-            <span className={cn(compact && 'sr-only')}>Display</span>
-          </Button>
-        </PopoverTrigger>
-      </TooltipShortcut>
-      <PopoverContent
-        align='end'
-        className='w-[248px] rounded-[12px] border border-subtle bg-surface-1 p-0 shadow-popover'
-      >
-        {/* Header */}
-        <div className='flex items-center justify-between border-b border-subtle px-3 py-2'>
-          <span className='text-[13px] font-[510] text-primary-token'>
-            Display
-          </span>
-          <PopoverPrimitive.Close asChild>
-            <AppIconButton
-              type='button'
-              ariaLabel='Close display menu'
-              className='border-transparent bg-transparent'
-            >
-              <X className='h-3.5 w-3.5' />
-            </AppIconButton>
-          </PopoverPrimitive.Close>
-        </div>
-
-        {/* Release view toggle */}
-        {onReleaseViewChange && (
-          <div className='border-b border-subtle px-3 py-2'>
-            <ReleaseViewSegmentedControl
-              value={releaseView ?? 'releases'}
-              onChange={onReleaseViewChange}
-            />
-          </div>
-        )}
-
-        {/* List options */}
-        {onGroupByYearChange && (
-          <div className='border-b border-subtle px-3 py-1.5'>
-            <p className='px-1 pb-1 text-[13px] font-[510] tracking-normal text-secondary-token'>
-              List options
-            </p>
-            <ToggleSwitch
-              label='Group by year'
-              checked={groupByYear ?? false}
-              onToggle={() => onGroupByYearChange(!groupByYear)}
-            />
-          </div>
-        )}
-      </PopoverContent>
-    </Popover>
   );
 }
 
@@ -366,14 +198,37 @@ export const ReleaseTableSubheader = memo(function ReleaseTableSubheader({
             />
           </Suspense>
           {showToolbarExtras && (
-            <LinearStyleDisplayMenu
-              groupByYear={groupByYear}
-              onGroupByYearChange={onGroupByYearChange}
-              releaseView={releaseView}
-              onReleaseViewChange={onReleaseViewChange}
-              triggerClassName={PAGE_TOOLBAR_ACTION_BUTTON_CLASS}
-              compact
-            />
+            <Suspense
+              fallback={
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  className={cn(
+                    PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
+                    PAGE_TOOLBAR_ACTION_ICON_ONLY_BUTTON_CLASS,
+                    'h-7 w-7 rounded-full px-0 [&_svg]:h-3 [&_svg]:w-3'
+                  )}
+                  aria-label='Display'
+                  disabled
+                >
+                  <Icon
+                    name='SlidersHorizontal'
+                    className={PAGE_TOOLBAR_ICON_CLASS}
+                    strokeWidth={PAGE_TOOLBAR_ICON_STROKE_WIDTH}
+                  />
+                  <span className='sr-only'>Display</span>
+                </Button>
+              }
+            >
+              <ReleaseTableDisplayMenu
+                groupByYear={groupByYear}
+                onGroupByYearChange={onGroupByYearChange}
+                releaseView={releaseView}
+                onReleaseViewChange={onReleaseViewChange}
+                triggerClassName={PAGE_TOOLBAR_ACTION_BUTTON_CLASS}
+                compact
+              />
+            </Suspense>
           )}
           <ExportCSVButton
             getData={() => getReleasesForExport(releases, selectedIds)}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableSubheader.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableSubheader.tsx
@@ -19,6 +19,7 @@ import type { ReleaseType, ReleaseViewModel } from '@/lib/discography/types';
 import { useCodeFlag } from '@/lib/feature-flags/client';
 import { cn } from '@/lib/utils';
 import { useReleaseFilterCounts } from './hooks/useReleaseFilterCounts';
+import { RELEASE_VIEW_OPTIONS } from './ReleaseTable.types';
 
 const ReleaseFilterDropdown = lazy(() =>
   import('./ReleaseFilterDropdown').then(m => ({
@@ -84,12 +85,6 @@ interface ReleaseTableSubheaderProps {
   /** Whether create release is available */
   readonly canCreateManualReleases?: boolean;
 }
-
-/** Options for release view segmented control */
-const RELEASE_VIEW_OPTIONS = [
-  { value: 'tracks', label: 'Tracks' },
-  { value: 'releases', label: 'Releases' },
-] as const;
 
 function ReleaseViewButtons({
   value,

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
@@ -195,17 +195,18 @@ export function ReleaseTableWithTracks({
     };
   }, [columnVisibility]);
 
-  const hasExpandedRows = useMemo(
-    () => releases.some(r => isExpanded(r.id)),
-    [releases, isExpanded]
-  );
+  const hasExpandedRows = expandedReleaseIds.size > 0;
 
   const groupingConfig = useMemo(() => {
     if (!groupByYear) return undefined;
     return {
       getGroupKey: (release: ReleaseViewModel) => {
         if (!release.releaseDate) return 'Unknown';
-        const year = new Date(release.releaseDate).getFullYear();
+        const directYear = String(release.releaseDate).match(/^(\d{4})/)?.[1];
+        if (directYear) {
+          return directYear;
+        }
+        const year = new Date(release.releaseDate).getUTCFullYear();
         return Number.isNaN(year) ? 'Unknown' : year.toString();
       },
       getGroupLabel: (year: string) => year,

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
@@ -6,12 +6,13 @@ import { Icon } from '@/components/atoms/Icon';
 import { TableEmptyState, UnifiedTable } from '@/components/organisms/table';
 import { useBreakpointDown } from '@/hooks/useBreakpoint';
 import { TABLE_ROW_HEIGHTS } from '@/lib/constants/layout';
-import type { ReleaseViewModel } from '@/lib/discography/types';
+import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
+import { useExpandedTracks } from './hooks/useExpandedTracks';
 import { useSortingManager } from './hooks/useSortingManager';
 import type { ReleaseTableProps } from './ReleaseTable.types';
 import { getReleaseContextMenuItems } from './utils/release-context-actions';
 import {
-  createReleaseCellRenderer,
+  createExpandableReleaseCellRenderer,
   createRightMetaCellRenderer,
 } from './utils/release-table-renderers';
 
@@ -21,9 +22,11 @@ const MobileReleaseList = lazy(() =>
   }))
 );
 
-const ReleaseTableWithTracks = lazy(() =>
-  import('./ReleaseTableWithTracks').then(m => ({
-    default: m.ReleaseTableWithTracks,
+const TrackRowsContainer = lazy(() =>
+  import(
+    '@/features/dashboard/organisms/release-provider-matrix/components'
+  ).then(m => ({
+    default: m.TrackRowsContainer,
   }))
 );
 
@@ -33,17 +36,15 @@ const MetaHeaderCell = () => (
   <span className='sr-only'>Smart link, popularity, year</span>
 );
 
-/**
- * ReleaseTable - Releases table using UnifiedTable
- *
- * Features:
- * - Consolidated availability column showing all providers
- * - URL-persisted sorting via nuqs (shareable/bookmarkable)
- * - Debounced sorting for large datasets (>500 rows)
- * - Bulk actions and row selection
- * - Context menu for edit, copy actions
- */
-export function ReleaseTable({
+function TrackRowsLoadingRow() {
+  return (
+    <div className='px-4 py-2 text-[11px] text-tertiary-token'>
+      Loading tracks...
+    </div>
+  );
+}
+
+export function ReleaseTableWithTracks({
   releases,
   providerConfig,
   artistName,
@@ -52,7 +53,6 @@ export function ReleaseTable({
   columnVisibility,
   rowHeight = TABLE_ROW_HEIGHTS.STANDARD + 4,
   onFocusedRowChange,
-  showTracks = false,
   groupByYear = false,
   selectedReleaseId,
   selectedTrackId,
@@ -62,13 +62,17 @@ export function ReleaseTable({
   getSmartLinkLockReason,
   onTrackClick,
 }: ReleaseTableProps) {
-  // Mobile detection - render list view on small screens
   const isMobile = useBreakpointDown('md');
-  // Sorting with URL persistence and debouncing
+  const {
+    expandedReleaseIds,
+    isExpanded,
+    isLoading: isLoadingTracks,
+    toggleExpansion,
+    getTracksForRelease,
+  } = useExpandedTracks();
   const { sorting, onSortingChange, isSorting, isLargeDataset } =
     useSortingManager({ rowCount: releases.length });
 
-  // Context menu items for right-click (shared with mobile swipe actions)
   const getContextMenuItems = useCallback(
     (release: ReleaseViewModel) =>
       getReleaseContextMenuItems({
@@ -82,15 +86,16 @@ export function ReleaseTable({
     [onEdit, onCopy, artistName, isSmartLinkLocked, getSmartLinkLockReason]
   );
 
-  // Stable callbacks for UnifiedTable props
   const getRowId = useCallback((row: ReleaseViewModel) => row.id, []);
   const getRowTestId = useCallback(
     (_row: ReleaseViewModel, index: number) =>
       index === 0 ? 'release-row' : undefined,
     []
   );
+
   const getRowClassName = useCallback(
     (row: ReleaseViewModel) => {
+      const isRowExpanded = isExpanded(row.id);
       const isSelected = selectedReleaseId === row.id;
       const isRefreshing = refreshingReleaseId === row.id;
       const isFlashed = flashedReleaseId === row.id;
@@ -99,6 +104,9 @@ export function ReleaseTable({
       if (isSelected) {
         baseClassName =
           'bg-[color-mix(in_oklab,var(--linear-row-selected)_20%,transparent)] shadow-[inset_2px_0_0_0_var(--linear-border-focus)] hover:bg-[color-mix(in_oklab,var(--linear-row-selected)_24%,transparent)] focus-within:bg-[color-mix(in_oklab,var(--linear-row-selected)_28%,transparent)]';
+      } else if (isRowExpanded) {
+        baseClassName =
+          'bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_52%,transparent)] hover:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_58%,transparent)] focus-within:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_62%,transparent)]';
       } else {
         baseClassName =
           'bg-transparent hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_78%,transparent)] focus-within:bg-[color-mix(in_oklab,var(--linear-row-hover)_84%,transparent)] transition-[background-color,box-shadow,color] duration-150 ease-out [&:hover_span]:text-primary-token [&:hover_p]:text-primary-token';
@@ -120,13 +128,11 @@ export function ReleaseTable({
         .filter(Boolean)
         .join(' ');
     },
-    [selectedReleaseId, refreshingReleaseId, flashedReleaseId]
+    [isExpanded, selectedReleaseId, refreshingReleaseId, flashedReleaseId]
   );
 
-  // Keyboard navigation callback - open sidebar for focused row
-  const handleFocusedRowChange = useCallback(
+  const handleFocusedReleaseChange = useCallback(
     (index: number) => {
-      // Guard against stale index when releases array changes
       if (index < 0 || index >= releases.length) return;
       const release = releases[index];
       if (release && onFocusedRowChange) {
@@ -136,21 +142,30 @@ export function ReleaseTable({
     [releases, onFocusedRowChange]
   );
 
-  // Build column definitions (catalog view)
+  const allProviders = useMemo(
+    () => Object.keys(providerConfig) as ProviderKey[],
+    [providerConfig]
+  );
+
   const columns = useMemo(() => {
     const releaseColumn = columnHelper.accessor('title', {
       id: 'release',
       header: 'Release',
-      cell: createReleaseCellRenderer(artistName, onEdit),
+      cell: createExpandableReleaseCellRenderer(
+        artistName,
+        isExpanded,
+        isLoadingTracks,
+        toggleExpansion,
+        onEdit
+      ),
       minSize: 200,
-      size: 9999, // Large value to make it flex and fill available space
+      size: 9999,
       enableSorting: false,
       meta: { className: 'pl-4 pr-2.5' },
     });
 
     const rightMetaColumn = columnHelper.display({
       id: 'meta',
-      // NOSONAR S6478: TanStack Table header renderer prop, component already extracted
       header: MetaHeaderCell,
       cell: createRightMetaCellRenderer(
         isSmartLinkLocked,
@@ -162,9 +177,16 @@ export function ReleaseTable({
     });
 
     return [releaseColumn, rightMetaColumn];
-  }, [artistName, onEdit, isSmartLinkLocked, getSmartLinkLockReason]);
+  }, [
+    artistName,
+    isExpanded,
+    isLoadingTracks,
+    toggleExpansion,
+    onEdit,
+    isSmartLinkLocked,
+    getSmartLinkLockReason,
+  ]);
 
-  // Transform columnVisibility to TanStack format (always show release)
   const tanstackColumnVisibility = useMemo(() => {
     if (!columnVisibility) return undefined;
     return {
@@ -173,10 +195,11 @@ export function ReleaseTable({
     };
   }, [columnVisibility]);
 
-  // No fixed minWidth - on mobile, hidden columns allow the table to fit naturally
-  const minWidth = '0';
+  const hasExpandedRows = useMemo(
+    () => releases.some(r => isExpanded(r.id)),
+    [releases, isExpanded]
+  );
 
-  // Year grouping configuration
   const groupingConfig = useMemo(() => {
     if (!groupByYear) return undefined;
     return {
@@ -189,39 +212,41 @@ export function ReleaseTable({
     };
   }, [groupByYear]);
 
-  if (showTracks) {
-    return (
-      <Suspense
-        fallback={
-          <div className='px-4 py-3 text-[12px] text-secondary-token'>
-            Loading releases...
-          </div>
-        }
-      >
-        <ReleaseTableWithTracks
-          releases={releases}
-          providerConfig={providerConfig}
-          artistName={artistName}
-          onCopy={onCopy}
-          onEdit={onEdit}
-          columnVisibility={columnVisibility}
-          rowHeight={rowHeight}
-          onFocusedRowChange={onFocusedRowChange}
-          showTracks={showTracks}
-          groupByYear={groupByYear}
-          refreshingReleaseId={refreshingReleaseId}
-          flashedReleaseId={flashedReleaseId}
-          selectedReleaseId={selectedReleaseId}
-          selectedTrackId={selectedTrackId}
-          isSmartLinkLocked={isSmartLinkLocked}
-          getSmartLinkLockReason={getSmartLinkLockReason}
-          onTrackClick={onTrackClick}
-        />
-      </Suspense>
-    );
-  }
+  const renderExpandedContent = useCallback(
+    (release: ReleaseViewModel, columnCount: number) => {
+      const tracks = getTracksForRelease(release.id);
+      if (!tracks) return null;
 
-  // Mobile: render card-based list view instead of table
+      return (
+        <Suspense fallback={<TrackRowsLoadingRow />}>
+          <TrackRowsContainer
+            tracks={tracks}
+            release={release}
+            providerConfig={providerConfig}
+            allProviders={allProviders}
+            columnCount={columnCount}
+            columnVisibility={tanstackColumnVisibility}
+            onTrackClick={onTrackClick}
+            selectedTrackId={selectedTrackId}
+          />
+        </Suspense>
+      );
+    },
+    [
+      getTracksForRelease,
+      providerConfig,
+      allProviders,
+      tanstackColumnVisibility,
+      onTrackClick,
+      selectedTrackId,
+    ]
+  );
+
+  const getExpandableRowId = useCallback(
+    (release: ReleaseViewModel) => release.id,
+    []
+  );
+
   if (isMobile) {
     if (releases.length === 0) {
       return (
@@ -267,20 +292,23 @@ export function ReleaseTable({
       getRowId={getRowId}
       getRowTestId={getRowTestId}
       getRowClassName={getRowClassName}
-      enableVirtualization={!groupByYear}
+      enableVirtualization={!hasExpandedRows && !groupByYear}
       rowHeight={rowHeight}
-      minWidth={minWidth}
+      minWidth='0'
       hideHeader
       className='text-[12.5px] text-primary-token'
       containerClassName='h-full px-2.5 pb-2.5 pt-0.5 md:px-3 md:pb-3 md:pt-1'
       columnVisibility={tanstackColumnVisibility}
-      onFocusedRowChange={handleFocusedRowChange}
+      onFocusedRowChange={handleFocusedReleaseChange}
       skeletonRows={14}
       skeletonColumnConfig={[
         { variant: 'release', width: '100%' },
         { variant: 'meta', width: '204px' },
       ]}
       groupingConfig={groupingConfig}
+      expandedRowIds={expandedReleaseIds}
+      renderExpandedContent={renderExpandedContent}
+      getExpandableRowId={getExpandableRowId}
       emptyState={
         <TableEmptyState
           icon={<Icon name='Disc3' className='h-6 w-6' />}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/utils/column-renderers.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/utils/column-renderers.tsx
@@ -24,6 +24,10 @@ import {
   ReleaseCell,
   SmartLinkCell,
 } from '@/features/dashboard/organisms/releases/cells';
+import {
+  formatReleaseDate,
+  formatReleaseDateMonthYear,
+} from '@/lib/discography/formatting';
 import { getReleaseTypeStyle } from '@/lib/discography/release-type-styles';
 import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
 import { formatDuration } from '@/lib/utils/formatDuration';
@@ -32,11 +36,11 @@ import { formatDuration } from '@/lib/utils/formatDuration';
 // Constants
 // ============================================================================
 
-/** Date format options for release date display */
 export const DATE_FORMAT_OPTIONS = {
   month: 'short',
   year: 'numeric',
 } as const;
+
 export const DATE_TOOLTIP_FORMAT_OPTIONS = {
   year: 'numeric',
   month: 'long',
@@ -276,17 +280,10 @@ export function createRightMetaCellRenderer(
   }: CellContext<ReleaseViewModel, unknown>) {
     const release = row.original;
     const dateLabel = release.releaseDate
-      ? new Date(release.releaseDate).toLocaleDateString('en-US', {
-          month: 'short',
-          year: 'numeric',
-        })
+      ? formatReleaseDateMonthYear(release.releaseDate)
       : '—';
     const yearTitle = release.releaseDate
-      ? new Date(release.releaseDate).toLocaleDateString('en-US', {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        })
+      ? formatReleaseDate(release.releaseDate)
       : 'Unknown release date';
 
     return (
@@ -510,10 +507,7 @@ export function renderStatsCell({
 }: CellContext<ReleaseViewModel, unknown>) {
   const release = row.original;
   const dateStr = release.releaseDate
-    ? new Date(release.releaseDate).toLocaleDateString('en-US', {
-        month: 'short',
-        year: 'numeric',
-      })
+    ? formatReleaseDateMonthYear(release.releaseDate)
     : null;
 
   return (

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/utils/release-context-actions.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/utils/release-context-actions.tsx
@@ -1,5 +1,4 @@
 import type { ContextMenuItemType } from '@/components/organisms/table';
-import { buildReleaseActions } from '@/features/dashboard/organisms/releases/release-actions';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 
 interface GetReleaseContextMenuItemsOptions {
@@ -17,14 +16,18 @@ interface GetReleaseContextMenuItemsOptions {
  *
  * Delegates to the canonical `buildReleaseActions` builder.
  */
-export function getReleaseContextMenuItems({
+export async function getReleaseContextMenuItems({
   release,
   onEdit,
   onCopy,
   artistName,
   isSmartLinkLocked,
   getSmartLinkLockReason,
-}: GetReleaseContextMenuItemsOptions): ContextMenuItemType[] {
+}: GetReleaseContextMenuItemsOptions): Promise<ContextMenuItemType[]> {
+  const { buildReleaseActions } = await import(
+    '@/features/dashboard/organisms/releases/release-actions'
+  );
+
   return buildReleaseActions({
     release,
     onEdit,

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/utils/release-table-renderers.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/utils/release-table-renderers.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import type { CellContext } from '@tanstack/react-table';
+import { ExpandButton } from '@/features/dashboard/organisms/release-provider-matrix/components/ExpandButton';
+import {
+  PopularityIcon,
+  ReleaseCell,
+  SmartLinkCell,
+} from '@/features/dashboard/organisms/releases/cells';
+import type { ReleaseViewModel } from '@/lib/discography/types';
+
+export function createReleaseCellRenderer(
+  artistName: string | null | undefined,
+  onOpen?: (release: ReleaseViewModel) => void
+) {
+  return function ReleaseCellRenderer({
+    row,
+  }: CellContext<ReleaseViewModel, unknown>) {
+    return (
+      <ReleaseCell
+        release={row.original}
+        artistName={artistName}
+        onSelect={onOpen}
+      />
+    );
+  };
+}
+
+export function createExpandableReleaseCellRenderer(
+  artistName: string | null | undefined,
+  isExpanded: (releaseId: string) => boolean,
+  isLoading: (releaseId: string) => boolean,
+  onToggleExpansion: (release: ReleaseViewModel) => void,
+  onOpen?: (release: ReleaseViewModel) => void
+) {
+  return function ExpandableReleaseCellRenderer({
+    row,
+  }: CellContext<ReleaseViewModel, unknown>) {
+    const release = row.original;
+    const expanded = isExpanded(release.id);
+    const loading = isLoading(release.id);
+
+    return (
+      <div className='flex items-center gap-1'>
+        <ExpandButton
+          isExpanded={expanded}
+          isLoading={loading}
+          totalTracks={release.totalTracks}
+          onClick={e => {
+            e.stopPropagation();
+            onToggleExpansion(release);
+          }}
+        />
+        <ReleaseCell
+          release={release}
+          artistName={artistName}
+          onSelect={onOpen}
+        />
+      </div>
+    );
+  };
+}
+
+export function createRightMetaCellRenderer(
+  isSmartLinkLocked?: (releaseId: string) => boolean,
+  getSmartLinkLockReason?: (releaseId: string) => 'scheduled' | 'cap' | null
+) {
+  return function RightMetaCellRenderer({
+    row,
+  }: CellContext<ReleaseViewModel, unknown>) {
+    const release = row.original;
+    const dateLabel = release.releaseDate
+      ? new Date(release.releaseDate).toLocaleDateString('en-US', {
+          month: 'short',
+          year: 'numeric',
+        })
+      : '—';
+    const yearTitle = release.releaseDate
+      ? new Date(release.releaseDate).toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        })
+      : 'Unknown release date';
+
+    return (
+      <div className='flex items-center gap-2.5'>
+        <div className='max-lg:hidden min-w-0 flex-1'>
+          <SmartLinkCell
+            release={release}
+            locked={isSmartLinkLocked?.(release.id)}
+            lockReason={getSmartLinkLockReason?.(release.id)}
+          />
+        </div>
+
+        <PopularityIcon popularity={release.spotifyPopularity} />
+
+        <span
+          className='inline-flex w-[64px] shrink-0 justify-end text-right tabular-nums text-[11px] font-[400] text-secondary-token'
+          title={yearTitle}
+        >
+          {dateLabel}
+        </span>
+      </div>
+    );
+  };
+}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/utils/release-table-renderers.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/utils/release-table-renderers.tsx
@@ -7,6 +7,10 @@ import {
   ReleaseCell,
   SmartLinkCell,
 } from '@/features/dashboard/organisms/releases/cells';
+import {
+  formatReleaseDate,
+  formatReleaseDateMonthYear,
+} from '@/lib/discography/formatting';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 
 export function createReleaseCellRenderer(
@@ -70,17 +74,10 @@ export function createRightMetaCellRenderer(
   }: CellContext<ReleaseViewModel, unknown>) {
     const release = row.original;
     const dateLabel = release.releaseDate
-      ? new Date(release.releaseDate).toLocaleDateString('en-US', {
-          month: 'short',
-          year: 'numeric',
-        })
+      ? formatReleaseDateMonthYear(release.releaseDate)
       : '—';
     const yearTitle = release.releaseDate
-      ? new Date(release.releaseDate).toLocaleDateString('en-US', {
-          year: 'numeric',
-          month: 'long',
-          day: 'numeric',
-        })
+      ? formatReleaseDate(release.releaseDate)
       : 'Unknown release date';
 
     return (

--- a/apps/web/components/organisms/table/molecules/TableContextMenu.tsx
+++ b/apps/web/components/organisms/table/molecules/TableContextMenu.tsx
@@ -7,6 +7,7 @@ import {
   type MouseEventHandler,
   type ReactElement,
   type ReactNode,
+  useCallback,
   useEffect,
   useMemo,
   useState,
@@ -67,7 +68,9 @@ export interface TableContextMenuProps {
   /** Array of menu items to display in the context menu */
   readonly items?: ContextMenuItemType[];
   /** Lazily resolve menu items when the context menu is opened */
-  readonly getItems?: () => ContextMenuItemType[];
+  readonly getItems?: () =>
+    | ContextMenuItemType[]
+    | Promise<ContextMenuItemType[]>;
   /** Whether the context menu is disabled */
   readonly disabled?: boolean;
 }
@@ -78,6 +81,10 @@ function isSeparator(item: ContextMenuItemType): item is { type: 'separator' } {
 
 function isSubmenu(item: ContextMenuItemType): item is ContextMenuSubmenu {
   return 'items' in item && Array.isArray(item.items);
+}
+
+function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return typeof (value as PromiseLike<T>).then === 'function';
 }
 
 function normalizeContextMenuItems(
@@ -244,6 +251,38 @@ export function TableContextMenu({
     }
   }, [getItems, items]);
 
+  const resolveItems = useCallback(() => {
+    if (!getItems) {
+      setResolvedItems(items ?? []);
+      return;
+    }
+
+    const nextItems = getItems();
+
+    if (isPromiseLike(nextItems)) {
+      setResolvedItems([
+        {
+          id: 'loading',
+          label: 'Loading...',
+          onClick: () => {},
+          disabled: true,
+        },
+      ]);
+
+      void Promise.resolve(nextItems)
+        .then(loadedItems => {
+          setResolvedItems(loadedItems);
+        })
+        .catch(() => {
+          setResolvedItems([]);
+        });
+
+      return;
+    }
+
+    setResolvedItems(nextItems);
+  }, [getItems, items]);
+
   // Memoize conversion to prevent recalculation on every render
   const convertedItems = useMemo(
     () => convertContextMenuItems(resolvedItems),
@@ -254,21 +293,20 @@ export function TableContextMenu({
     return <>{children}</>;
   }
 
-  const triggerChild =
-    getItems && isValidElement(children)
-      ? (() => {
-          const contextMenuChild = children as ReactElement<{
-            onContextMenuCapture?: MouseEventHandler<Element>;
-          }>;
+  let triggerChild = children;
 
-          return cloneElement(contextMenuChild, {
-            onContextMenuCapture: event => {
-              contextMenuChild.props.onContextMenuCapture?.(event);
-              setResolvedItems(getItems());
-            },
-          });
-        })()
-      : children;
+  if (getItems && isValidElement(children)) {
+    const contextMenuChild = children as ReactElement<{
+      onContextMenuCapture?: MouseEventHandler<Element>;
+    }>;
+
+    triggerChild = cloneElement(contextMenuChild, {
+      onContextMenuCapture: event => {
+        contextMenuChild.props.onContextMenuCapture?.(event);
+        resolveItems();
+      },
+    });
+  }
 
   return (
     <TableActionMenu items={convertedItems} trigger='context'>

--- a/apps/web/components/organisms/table/molecules/TableContextMenu.tsx
+++ b/apps/web/components/organisms/table/molecules/TableContextMenu.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react';
 import { TableActionMenu } from '@/components/atoms/table-action-menu/TableActionMenu';
 import type { TableActionMenuItem } from '@/components/atoms/table-action-menu/types';
+import { logger } from '@/lib/utils/logger';
 
 /**
  * A single action item in the context menu
@@ -244,6 +245,7 @@ export function TableContextMenu({
   const [resolvedItems, setResolvedItems] = useState<ContextMenuItemType[]>(
     items ?? []
   );
+  const [, setResolveGeneration] = useState(0);
 
   useEffect(() => {
     if (!getItems) {
@@ -253,6 +255,7 @@ export function TableContextMenu({
 
   const resolveItems = useCallback(() => {
     if (!getItems) {
+      setResolveGeneration(current => current + 1);
       setResolvedItems(items ?? []);
       return;
     }
@@ -269,17 +272,39 @@ export function TableContextMenu({
         },
       ]);
 
-      void Promise.resolve(nextItems)
-        .then(loadedItems => {
-          setResolvedItems(loadedItems);
-        })
-        .catch(() => {
-          setResolvedItems([]);
-        });
+      setResolveGeneration(currentGeneration => {
+        const nextGeneration = currentGeneration + 1;
+
+        void Promise.resolve(nextItems)
+          .then(loadedItems => {
+            setResolveGeneration(activeGeneration => {
+              if (activeGeneration === nextGeneration) {
+                setResolvedItems(loadedItems);
+              }
+              return activeGeneration;
+            });
+          })
+          .catch(error => {
+            setResolveGeneration(activeGeneration => {
+              if (activeGeneration === nextGeneration) {
+                logger.warn(
+                  'Failed to resolve async context menu items',
+                  error,
+                  'TableContextMenu'
+                );
+                setResolvedItems([]);
+              }
+              return activeGeneration;
+            });
+          });
+
+        return nextGeneration;
+      });
 
       return;
     }
 
+    setResolveGeneration(current => current + 1);
     setResolvedItems(nextItems);
   }, [getItems, items]);
 
@@ -299,10 +324,12 @@ export function TableContextMenu({
     const contextMenuChild = children as ReactElement<{
       onContextMenuCapture?: MouseEventHandler<Element>;
     }>;
+    const originalOnContextMenuCapture =
+      contextMenuChild.props.onContextMenuCapture;
 
     triggerChild = cloneElement(contextMenuChild, {
       onContextMenuCapture: event => {
-        contextMenuChild.props.onContextMenuCapture?.(event);
+        originalOnContextMenuCapture?.(event);
         resolveItems();
       },
     });

--- a/apps/web/components/organisms/table/molecules/TableContextMenu.tsx
+++ b/apps/web/components/organisms/table/molecules/TableContextMenu.tsx
@@ -1,7 +1,16 @@
 'use client';
 
 import type { CommonDropdownItem } from '@jovie/ui';
-import { type ReactNode, useMemo } from 'react';
+import {
+  cloneElement,
+  isValidElement,
+  type MouseEventHandler,
+  type ReactElement,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { TableActionMenu } from '@/components/atoms/table-action-menu/TableActionMenu';
 import type { TableActionMenuItem } from '@/components/atoms/table-action-menu/types';
 
@@ -56,7 +65,9 @@ export interface TableContextMenuProps {
   /** React children to wrap with context menu functionality */
   readonly children: ReactNode;
   /** Array of menu items to display in the context menu */
-  readonly items: ContextMenuItemType[];
+  readonly items?: ContextMenuItemType[];
+  /** Lazily resolve menu items when the context menu is opened */
+  readonly getItems?: () => ContextMenuItemType[];
   /** Whether the context menu is disabled */
   readonly disabled?: boolean;
 }
@@ -220,18 +231,48 @@ export function convertContextMenuItems(
 export function TableContextMenu({
   children,
   items,
+  getItems,
   disabled = false,
 }: TableContextMenuProps) {
-  // Memoize conversion to prevent recalculation on every render
-  const convertedItems = useMemo(() => convertContextMenuItems(items), [items]);
+  const [resolvedItems, setResolvedItems] = useState<ContextMenuItemType[]>(
+    items ?? []
+  );
 
-  if (disabled || items.length === 0) {
+  useEffect(() => {
+    if (!getItems) {
+      setResolvedItems(items ?? []);
+    }
+  }, [getItems, items]);
+
+  // Memoize conversion to prevent recalculation on every render
+  const convertedItems = useMemo(
+    () => convertContextMenuItems(resolvedItems),
+    [resolvedItems]
+  );
+
+  if (disabled || (!getItems && resolvedItems.length === 0)) {
     return <>{children}</>;
   }
 
+  const triggerChild =
+    getItems && isValidElement(children)
+      ? (() => {
+          const contextMenuChild = children as ReactElement<{
+            onContextMenuCapture?: MouseEventHandler<Element>;
+          }>;
+
+          return cloneElement(contextMenuChild, {
+            onContextMenuCapture: event => {
+              contextMenuChild.props.onContextMenuCapture?.(event);
+              setResolvedItems(getItems());
+            },
+          });
+        })()
+      : children;
+
   return (
     <TableActionMenu items={convertedItems} trigger='context'>
-      {children}
+      {triggerChild}
     </TableActionMenu>
   );
 }

--- a/apps/web/components/organisms/table/organisms/UnifiedTable.tsx
+++ b/apps/web/components/organisms/table/organisms/UnifiedTable.tsx
@@ -548,7 +548,10 @@ export function UnifiedTable<TData>({
           : null;
 
       const wrappedRowElement = getContextMenuItems ? (
-        <TableContextMenu key={row.id} items={getContextMenuItems(rowData)}>
+        <TableContextMenu
+          key={row.id}
+          getItems={() => getContextMenuItems(rowData)}
+        >
           {rowElement}
         </TableContextMenu>
       ) : (

--- a/apps/web/components/organisms/table/organisms/UnifiedTable.tsx
+++ b/apps/web/components/organisms/table/organisms/UnifiedTable.tsx
@@ -126,7 +126,9 @@ export interface UnifiedTableProps<TData> {
   /**
    * Get context menu items for a row
    */
-  readonly getContextMenuItems?: (row: TData) => ContextMenuItemType[];
+  readonly getContextMenuItems?: (
+    row: TData
+  ) => ContextMenuItemType[] | Promise<ContextMenuItemType[]>;
 
   /**
    * Get custom class names for a row

--- a/apps/web/components/organisms/table/organisms/VirtualizedTableBody.tsx
+++ b/apps/web/components/organisms/table/organisms/VirtualizedTableBody.tsx
@@ -259,7 +259,10 @@ export function VirtualizedTableBody<TData>({
 
         // Apply context menu wrapper if needed
         const wrappedRow = getContextMenuItems ? (
-          <TableContextMenu key={row.id} items={getContextMenuItems(rowData)}>
+          <TableContextMenu
+            key={row.id}
+            getItems={() => getContextMenuItems(rowData)}
+          >
             {rowElement}
           </TableContextMenu>
         ) : (

--- a/apps/web/components/organisms/table/organisms/VirtualizedTableBody.tsx
+++ b/apps/web/components/organisms/table/organisms/VirtualizedTableBody.tsx
@@ -87,7 +87,9 @@ export interface VirtualizedTableBodyProps<TData> {
   /**
    * Get context menu items for a row
    */
-  readonly getContextMenuItems?: (row: TData) => ContextMenuItemType[];
+  readonly getContextMenuItems?: (
+    row: TData
+  ) => ContextMenuItemType[] | Promise<ContextMenuItemType[]>;
 
   /**
    * Get custom class names for a row

--- a/apps/web/lib/discography/formatting.ts
+++ b/apps/web/lib/discography/formatting.ts
@@ -12,12 +12,18 @@ const shortReleaseDateFormatter = new Intl.DateTimeFormat('en-US', {
   timeZone: 'UTC',
 });
 
+const monthYearReleaseDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+
 const releaseArtistListFormatter = new Intl.ListFormat('en', {
   style: 'long',
   type: 'conjunction',
 });
 
-function parseReleaseDate(date: string): Date | null {
+export function parseReleaseDate(date: string): Date | null {
   if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
     const [year, month, day] = date.split('-').map(Number);
     return new Date(Date.UTC(year, month - 1, day));
@@ -76,4 +82,10 @@ export function formatReleaseDateShort(date: string | undefined): string {
   if (!date) return 'TBD';
   const parsed = parseReleaseDate(date);
   return parsed ? shortReleaseDateFormatter.format(parsed) : 'Invalid';
+}
+
+export function formatReleaseDateMonthYear(date: string | undefined): string {
+  if (!date) return 'TBD';
+  const parsed = parseReleaseDate(date);
+  return parsed ? monthYearReleaseDateFormatter.format(parsed) : 'Invalid';
 }

--- a/apps/web/tests/components/release-provider-matrix/ReleaseTable.test.tsx
+++ b/apps/web/tests/components/release-provider-matrix/ReleaseTable.test.tsx
@@ -49,7 +49,7 @@ vi.mock(
 );
 
 vi.mock(
-  '@/features/dashboard/organisms/release-provider-matrix/utils/column-renderers',
+  '@/features/dashboard/organisms/release-provider-matrix/utils/release-table-renderers',
   () => ({
     createExpandableReleaseCellRenderer: () => () => null,
     createReleaseCellRenderer: () => () => null,

--- a/apps/web/tests/components/release-provider-matrix/ReleaseTable.test.tsx
+++ b/apps/web/tests/components/release-provider-matrix/ReleaseTable.test.tsx
@@ -183,7 +183,7 @@ describe('ReleaseTable', () => {
     expect(idleRow).toBeInTheDocument();
   });
 
-  it('passes the selected track state into expanded track rows', () => {
+  it('passes the selected track state into expanded track rows', async () => {
     render(
       <ReleaseTable
         {...commonProps}
@@ -193,11 +193,11 @@ describe('ReleaseTable', () => {
     );
 
     expect(screen.getByTestId('expanded-row-release_1')).toBeInTheDocument();
-    expect(screen.getByTestId('expanded-track-track-1')).toHaveAttribute(
+    expect(await screen.findByTestId('expanded-track-track-1')).toHaveAttribute(
       'data-state',
       'idle'
     );
-    expect(screen.getByTestId('expanded-track-track-2')).toHaveAttribute(
+    expect(await screen.findByTestId('expanded-track-track-2')).toHaveAttribute(
       'data-state',
       'selected'
     );

--- a/apps/web/tests/components/release-provider-matrix/ReleaseTable.test.tsx
+++ b/apps/web/tests/components/release-provider-matrix/ReleaseTable.test.tsx
@@ -153,7 +153,7 @@ describe('ReleaseTable', () => {
     onEdit: vi.fn(),
   } satisfies Partial<ComponentProps<typeof ReleaseTable>>;
 
-  it('keeps selected and expanded release rows visually distinct', () => {
+  it('keeps selected and expanded release rows visually distinct', async () => {
     render(
       <ReleaseTable
         {...commonProps}
@@ -162,12 +162,12 @@ describe('ReleaseTable', () => {
       />
     );
 
-    const expandedRow = screen
-      .getByTestId('release-row-wrapper-release_1')
-      .querySelector('div');
-    const selectedRow = screen
-      .getByTestId('release-row-wrapper-release_2')
-      .querySelector('div');
+    const expandedRow = (
+      await screen.findByTestId('release-row-wrapper-release_1')
+    ).querySelector('div');
+    const selectedRow = (
+      await screen.findByTestId('release-row-wrapper-release_2')
+    ).querySelector('div');
 
     expect(expandedRow).toBeInTheDocument();
     expect(selectedRow).toBeInTheDocument();
@@ -192,7 +192,9 @@ describe('ReleaseTable', () => {
       />
     );
 
-    expect(screen.getByTestId('expanded-row-release_1')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('expanded-row-release_1')
+    ).toBeInTheDocument();
     expect(await screen.findByTestId('expanded-track-track-1')).toHaveAttribute(
       'data-state',
       'idle'

--- a/apps/web/tests/components/release-provider-matrix/ReleaseTableSubheader.test.tsx
+++ b/apps/web/tests/components/release-provider-matrix/ReleaseTableSubheader.test.tsx
@@ -52,29 +52,20 @@ vi.mock('@/components/atoms/AppSegmentControl', () => ({
   AppSegmentControl: () => <div data-testid='segment-control' />,
 }));
 
-vi.mock('@/components/atoms/AppIconButton', () => ({
-  AppIconButton: ({ children }: { children: ReactNode }) => (
-    <button type='button'>{children}</button>
-  ),
-}));
-
-vi.mock('@radix-ui/react-popover', () => ({
-  Close: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
-
 vi.mock('@jovie/ui', () => ({
   Button: ({ children, ...props }: Record<string, unknown>) => (
     <button type='button' {...props}>
       {children as ReactNode}
     </button>
   ),
-  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
-  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
-  PopoverContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  TooltipShortcut: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
+
+vi.mock(
+  '@/features/dashboard/organisms/release-provider-matrix/ReleaseTableDisplayMenu',
+  () => ({
+    ReleaseTableDisplayMenu: () => <button type='button'>Display</button>,
+  })
+);
 
 vi.mock('@/components/organisms/table', () => ({
   PAGE_TOOLBAR_ACTION_ACTIVE_CLASS: 'active',

--- a/apps/web/tests/components/release-provider-matrix/ReleaseTableSubheader.test.tsx
+++ b/apps/web/tests/components/release-provider-matrix/ReleaseTableSubheader.test.tsx
@@ -67,6 +67,13 @@ vi.mock(
   })
 );
 
+vi.mock(
+  '@/features/dashboard/organisms/release-provider-matrix/ReleaseTableExportButton',
+  () => ({
+    ReleaseTableExportButton: () => <button type='button'>Export</button>,
+  })
+);
+
 vi.mock('@/components/organisms/table', () => ({
   PAGE_TOOLBAR_ACTION_ACTIVE_CLASS: 'active',
   PAGE_TOOLBAR_ACTION_BUTTON_CLASS: 'action-button',
@@ -105,7 +112,6 @@ vi.mock('@/components/organisms/table', () => ({
       {label}
     </button>
   ),
-  ExportCSVButton: () => <button type='button'>Export</button>,
   PageToolbarActionButton: ({
     label,
     onClick,

--- a/apps/web/tests/unit/dashboard/ReleaseProviderMatrix.test.tsx
+++ b/apps/web/tests/unit/dashboard/ReleaseProviderMatrix.test.tsx
@@ -274,6 +274,72 @@ vi.mock(
 );
 
 vi.mock(
+  '@/features/dashboard/organisms/release-provider-matrix/ReleasePlanPromptDialog',
+  () => ({
+    ReleasePlanPromptDialog: ({
+      open,
+      releaseTitle,
+      isGateLoading,
+      canGenerateReleasePlans,
+      isGeneratingReleasePlan,
+      onClose,
+      onGenerateReleasePlan,
+    }: {
+      open: boolean;
+      releaseTitle: string | null;
+      isGateLoading: boolean;
+      canGenerateReleasePlans: boolean;
+      isGeneratingReleasePlan: boolean;
+      onClose: () => void;
+      onGenerateReleasePlan: () => void;
+    }) =>
+      open ? (
+        <div role='dialog' aria-modal='true'>
+          <h2>
+            {isGateLoading
+              ? 'Release Plan'
+              : canGenerateReleasePlans
+                ? 'Generate Release Plan'
+                : 'Upgrade To Generate A Release Plan'}
+          </h2>
+          <p>
+            {isGateLoading
+              ? 'Checking whether this workspace can generate tasks for the release plan.'
+              : canGenerateReleasePlans
+                ? 'Create the step-by-step tasks for this release and jump straight into the plan.'
+                : 'Upgrade to turn this release into a step-by-step plan with tasks you can assign to Jovie AI.'}
+          </p>
+          <p>{releaseTitle ?? 'This release'} is ready.</p>
+          <button
+            type='button'
+            onClick={onClose}
+            disabled={isGeneratingReleasePlan}
+          >
+            Maybe Later
+          </button>
+          {isGateLoading ? (
+            <button type='button' disabled>
+              Loading...
+            </button>
+          ) : canGenerateReleasePlans ? (
+            <button
+              type='button'
+              onClick={onGenerateReleasePlan}
+              disabled={isGeneratingReleasePlan}
+            >
+              {isGeneratingReleasePlan
+                ? 'Generating...'
+                : 'Generate Release Plan'}
+            </button>
+          ) : (
+            <button type='button'>Upgrade to Pro</button>
+          )}
+        </div>
+      ) : null,
+  })
+);
+
+vi.mock(
   '@/features/dashboard/organisms/release-provider-matrix/hooks/useReleaseTablePreferences',
   () => ({
     useReleaseTablePreferences: () => ({
@@ -505,7 +571,7 @@ describe('ReleaseProviderMatrix', () => {
   });
 
   describe('conditional rendering', () => {
-    it('shows empty state when not connected and no releases', () => {
+    it('shows empty state when not connected and no releases', async () => {
       renderWithProviders(
         <ReleaseProviderMatrix
           releases={[]}
@@ -514,7 +580,9 @@ describe('ReleaseProviderMatrix', () => {
           spotifyConnected={false}
         />
       );
-      expect(screen.getByTestId('releases-empty-state')).toBeInTheDocument();
+      expect(
+        await screen.findByTestId('releases-empty-state')
+      ).toBeInTheDocument();
     });
 
     it('shows importing state when importing with no releases', () => {
@@ -575,7 +643,7 @@ describe('ReleaseProviderMatrix', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('shows spotify import banner when import is active', () => {
+    it('shows spotify import banner when import is active', async () => {
       renderWithProviders(
         <ReleaseProviderMatrix
           releases={[makeRelease()]}
@@ -586,7 +654,9 @@ describe('ReleaseProviderMatrix', () => {
         />
       );
 
-      const banner = screen.getByTestId('spotify-import-progress-banner');
+      const banner = await screen.findByTestId(
+        'spotify-import-progress-banner'
+      );
       expect(banner).toHaveAttribute('aria-hidden', 'false');
       expect(banner).toHaveStyle({ visibility: 'visible', opacity: '1' });
     });

--- a/apps/web/tests/unit/organisms/table/TableContextMenu.test.tsx
+++ b/apps/web/tests/unit/organisms/table/TableContextMenu.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { TableContextMenu } from '@/components/organisms/table/molecules/TableContextMenu';
@@ -68,5 +68,32 @@ describe('TableContextMenu', () => {
     );
 
     expect(screen.getByTestId('context-items')).toHaveTextContent('copy');
+  });
+
+  it('supports async getItems resolution', async () => {
+    const getItems = vi.fn(
+      async () =>
+        [
+          {
+            id: 'delete',
+            label: 'Delete',
+            onClick: vi.fn(),
+          },
+        ] as const
+    );
+
+    render(
+      <TableContextMenu getItems={getItems}>
+        <div>Async Row</div>
+      </TableContextMenu>
+    );
+
+    fireEvent.contextMenu(screen.getByText('Async Row'));
+
+    expect(screen.getByTestId('context-items')).toHaveTextContent('loading');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('context-items')).toHaveTextContent('delete');
+    });
   });
 });

--- a/apps/web/tests/unit/organisms/table/TableContextMenu.test.tsx
+++ b/apps/web/tests/unit/organisms/table/TableContextMenu.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { TableContextMenu } from '@/components/organisms/table/molecules/TableContextMenu';
+
+const tableActionMenuMock = vi.fn(
+  ({
+    children,
+    items,
+  }: {
+    children: ReactNode;
+    items: Array<{ id: string; label: string }>;
+  }) => (
+    <div>
+      <div data-testid='context-items'>
+        {items.map(item => item.id).join(',')}
+      </div>
+      {children}
+    </div>
+  )
+);
+
+vi.mock('@/components/atoms/table-action-menu/TableActionMenu', () => ({
+  TableActionMenu: (props: {
+    children: ReactNode;
+    items: Array<{ id: string; label: string }>;
+  }) => tableActionMenuMock(props),
+}));
+
+describe('TableContextMenu', () => {
+  it('defers getItems until the menu opens', () => {
+    const getItems = vi.fn(() => [
+      {
+        id: 'edit',
+        label: 'Edit',
+        onClick: vi.fn(),
+      },
+    ]);
+
+    render(
+      <TableContextMenu getItems={getItems}>
+        <div>Row</div>
+      </TableContextMenu>
+    );
+
+    expect(getItems).not.toHaveBeenCalled();
+    expect(screen.getByTestId('context-items')).toBeEmptyDOMElement();
+
+    fireEvent.contextMenu(screen.getByText('Row'));
+
+    expect(getItems).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('context-items')).toHaveTextContent('edit');
+  });
+
+  it('still supports eager items for existing call sites', () => {
+    render(
+      <TableContextMenu
+        items={[
+          {
+            id: 'copy',
+            label: 'Copy',
+            onClick: vi.fn(),
+          },
+        ]}
+      >
+        <div>Row</div>
+      </TableContextMenu>
+    );
+
+    expect(screen.getByTestId('context-items')).toHaveTextContent('copy');
+  });
+});


### PR DESCRIPTION
## Summary
- split the releases table so tracks-mode code loads only when that view is used
- lazy load the CSV export path and the post-create release-plan prompt
- defer release action menu construction until the row menu is actually opened

## Why
The `/app/dashboard/releases` route still carried interaction-only code in its default client graph. These changes keep the loaded UI the same, but move tracks expansion, export, modal, and action-menu work off the first render path.

## Validation
- `pnpm --filter @jovie/web exec vitest run tests/components/release-provider-matrix/ReleaseTable.test.tsx tests/components/release-provider-matrix/ReleaseTableSubheader.test.tsx tests/unit/dashboard/ReleaseProviderMatrix.test.tsx tests/unit/organisms/table/TableContextMenu.test.tsx`
- `pnpm --filter @jovie/web exec tsc -p tsconfig.typecheck.json --noEmit`
- `doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web build`

## Notes
- Public prerendered routes remained intact in the production build, including `/[username]`, `/[username]/[slug]`, `/[username]/[slug]/[trackSlug]`, `/[username]/[slug]/download`, and `/[username]/[slug]/sounds`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Display menu for controlling table view (Tracks/Releases toggle) and grouping options.
  * Added CSV export functionality for release data.
  * Introduced release plan generation prompt with improved loading and upgrade messaging.
  * Added track expansion capability within the release table.

* **Performance**
  * Implemented lazy-loading for release table components to improve initial load performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->