### PR TITLE
fix: resolve SonarCloud S3776 cognitive complexity issues (batch 1)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/utils/column-renderers.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/utils/column-renderers.tsx
@@ -277,6 +277,66 @@ export function TouringCityCell({ row }: CellContext<AudienceMember, unknown>) {
   );
 }
 
+type SubtitlePart = { key: string; text: string; className?: string };
+
+function buildUserSubtitleParts(
+  m: AudienceMember,
+  hiddenMetadataColumns: {
+    readonly location: boolean;
+    readonly engagement: boolean;
+    readonly lastSeen: boolean;
+  }
+): SubtitlePart[] {
+  const parts: SubtitlePart[] = [];
+
+  if (hiddenMetadataColumns.engagement) {
+    if (m.intentLevel === 'high') {
+      parts.push({
+        key: 'intent',
+        text: 'High',
+        className: 'font-[510] text-emerald-600 dark:text-emerald-400',
+      });
+    } else if (m.intentLevel === 'medium') {
+      parts.push({
+        key: 'intent',
+        text: 'Medium',
+        className: 'font-[510] text-amber-600 dark:text-amber-400',
+      });
+    }
+
+    if (m.visits > 0) {
+      parts.push({
+        key: 'visits',
+        text: `${m.visits} ${m.visits === 1 ? 'visit' : 'visits'}`,
+      });
+    }
+  }
+
+  if (hiddenMetadataColumns.location) {
+    const locationCity = m.geoCity ?? m.geoCountry ?? null;
+    if (locationCity) {
+      try {
+        parts.push({
+          key: 'location',
+          text: decodeURIComponent(locationCity),
+        });
+      } catch {
+        parts.push({ key: 'location', text: locationCity });
+      }
+    }
+  }
+
+  if (hiddenMetadataColumns.lastSeen && m.lastSeenAt) {
+    parts.push({
+      key: 'last-seen',
+      text: formatTimeAgo(m.lastSeenAt),
+      className: 'tabular-nums',
+    });
+  }
+
+  return parts;
+}
+
 /**
  * Renders the user cell with type dot, inline touring badge,
  * and a metadata subtitle that ensures info density at every breakpoint.
@@ -292,58 +352,7 @@ export function UserCellWithTouring({
     useAudienceTableStableContext();
   const touringInfo = getTouringCity(row.original);
   const m = row.original;
-
-  // Build subtitle tokens for the metadata that is hidden in the current layout.
-  const subtitleParts: {
-    key: string;
-    text: string;
-    className?: string;
-  }[] = [];
-
-  if (hiddenMetadataColumns.engagement) {
-    if (m.intentLevel === 'high') {
-      subtitleParts.push({
-        key: 'intent',
-        text: 'High',
-        className: 'font-[510] text-emerald-600 dark:text-emerald-400',
-      });
-    } else if (m.intentLevel === 'medium') {
-      subtitleParts.push({
-        key: 'intent',
-        text: 'Medium',
-        className: 'font-[510] text-amber-600 dark:text-amber-400',
-      });
-    }
-
-    if (m.visits > 0) {
-      subtitleParts.push({
-        key: 'visits',
-        text: `${m.visits} ${m.visits === 1 ? 'visit' : 'visits'}`,
-      });
-    }
-  }
-
-  if (hiddenMetadataColumns.location) {
-    const locationCity = m.geoCity ?? m.geoCountry ?? null;
-    if (locationCity) {
-      try {
-        subtitleParts.push({
-          key: 'location',
-          text: decodeURIComponent(locationCity),
-        });
-      } catch {
-        subtitleParts.push({ key: 'location', text: locationCity });
-      }
-    }
-  }
-
-  if (hiddenMetadataColumns.lastSeen && m.lastSeenAt) {
-    subtitleParts.push({
-      key: 'last-seen',
-      text: formatTimeAgo(m.lastSeenAt),
-      className: 'tabular-nums',
-    });
-  }
+  const subtitleParts = buildUserSubtitleParts(m, hiddenMetadataColumns);
 
   return (
     <div className='flex items-center gap-2 min-w-0'>

--- a/apps/web/components/features/dashboard/organisms/releases/release-actions.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/release-actions.tsx
@@ -42,6 +42,105 @@ export interface BuildReleaseActionsOptions {
   readonly qrCodeIcon?: ReactNode;
 }
 
+function buildShareItems(
+  opts: Pick<
+    BuildReleaseActionsOptions,
+    'release' | 'onCopy' | 'artistName' | 'onCopyQrCode' | 'qrCodeIcon'
+  > & {
+    locked: boolean;
+    lockReason: 'scheduled' | 'cap' | null;
+    smartLinkUrl: string;
+  }
+): ContextMenuItemType[] {
+  const {
+    release,
+    onCopy,
+    artistName,
+    onCopyQrCode,
+    qrCodeIcon,
+    locked,
+    lockReason,
+    smartLinkUrl,
+  } = opts;
+
+  if (locked) {
+    return [
+      {
+        id: 'copy-smart-link',
+        label:
+          lockReason === 'scheduled'
+            ? 'Scheduled smart link (Pro)'
+            : 'Smart link (Pro)',
+        icon: menuIcon(lockReason === 'scheduled' ? 'Clock' : 'Lock'),
+        disabled: true,
+        onClick: () => {},
+      },
+    ];
+  }
+
+  const items: ContextMenuItemType[] = [
+    {
+      id: 'copy-smart-link',
+      label: 'Copy smart link',
+      icon: menuIcon('Copy'),
+      onClick: () => {
+        void onCopy(
+          release.smartLinkPath,
+          `${release.title} smart link`,
+          `smart-link-copy-${release.id}`
+        );
+      },
+    },
+  ];
+
+  const utmShareItems = getUTMShareContextMenuItems({
+    smartLinkUrl,
+    context: buildUTMContext({
+      smartLinkUrl,
+      releaseSlug: release.slug,
+      releaseTitle: release.title,
+      artistName,
+      releaseDate: release.releaseDate,
+    }),
+  });
+
+  if (utmShareItems.length > 0) {
+    items.push({ type: 'separator' }, ...utmShareItems);
+  }
+
+  if (release.hasVideoLinks) {
+    items.push(
+      { type: 'separator' },
+      {
+        id: 'copy-sounds-link',
+        label: 'Copy Use Sound link',
+        icon: menuIcon('Music'),
+        onClick: () => {
+          void onCopy(
+            `${release.smartLinkPath}/sounds`,
+            `${release.title} sounds link`,
+            `sounds-link-copy-${release.id}`
+          );
+        },
+      }
+    );
+  }
+
+  if (onCopyQrCode) {
+    items.push(
+      { type: 'separator' },
+      {
+        id: 'copy-qr-code',
+        label: 'Copy QR code',
+        icon: qrCodeIcon,
+        onClick: onCopyQrCode,
+      }
+    );
+  }
+
+  return items;
+}
+
 /**
  * Canonical builder for release action menus.
  *
@@ -64,78 +163,16 @@ export function buildReleaseActions({
   const locked = isSmartLinkLocked?.(release.id) ?? false;
   const lockReason = getSmartLinkLockReason?.(release.id) ?? null;
   const smartLinkUrl = `${getBaseUrl()}${release.smartLinkPath}`;
-  const shareItems: ContextMenuItemType[] = [];
-
-  if (locked) {
-    shareItems.push({
-      id: 'copy-smart-link',
-      label:
-        lockReason === 'scheduled'
-          ? 'Scheduled smart link (Pro)'
-          : 'Smart link (Pro)',
-      icon: menuIcon(lockReason === 'scheduled' ? 'Clock' : 'Lock'),
-      disabled: true,
-      onClick: () => {},
-    });
-  } else {
-    shareItems.push({
-      id: 'copy-smart-link',
-      label: 'Copy smart link',
-      icon: menuIcon('Copy'),
-      onClick: () => {
-        void onCopy(
-          release.smartLinkPath,
-          `${release.title} smart link`,
-          `smart-link-copy-${release.id}`
-        );
-      },
-    });
-
-    const utmShareItems = getUTMShareContextMenuItems({
-      smartLinkUrl,
-      context: buildUTMContext({
-        smartLinkUrl,
-        releaseSlug: release.slug,
-        releaseTitle: release.title,
-        artistName,
-        releaseDate: release.releaseDate,
-      }),
-    });
-
-    if (utmShareItems.length > 0) {
-      shareItems.push({ type: 'separator' }, ...utmShareItems);
-    }
-
-    if (release.hasVideoLinks) {
-      shareItems.push(
-        { type: 'separator' },
-        {
-          id: 'copy-sounds-link',
-          label: 'Copy Use Sound link',
-          icon: menuIcon('Music'),
-          onClick: () => {
-            void onCopy(
-              `${release.smartLinkPath}/sounds`,
-              `${release.title} sounds link`,
-              `sounds-link-copy-${release.id}`
-            );
-          },
-        }
-      );
-    }
-
-    if (onCopyQrCode) {
-      shareItems.push(
-        { type: 'separator' },
-        {
-          id: 'copy-qr-code',
-          label: 'Copy QR code',
-          icon: qrCodeIcon,
-          onClick: onCopyQrCode,
-        }
-      );
-    }
-  }
+  const shareItems = buildShareItems({
+    release,
+    onCopy,
+    artistName,
+    onCopyQrCode,
+    qrCodeIcon,
+    locked,
+    lockReason,
+    smartLinkUrl,
+  });
 
   const metadataItems = buildCopyMenuItems([
     { id: 'release-id', label: 'Release ID', value: release.id },

--- a/apps/web/lib/fit-scoring/calculator.ts
+++ b/apps/web/lib/fit-scoring/calculator.ts
@@ -271,6 +271,28 @@ function getFitScoreTotal(breakdown: FitScoreBreakdown) {
   );
 }
 
+function applyPaidSignalScores(
+  input: FitScoreInput,
+  breakdown: FitScoreBreakdown
+) {
+  if (
+    input.paidVerificationPlatforms &&
+    input.paidVerificationPlatforms.length > 0
+  ) {
+    breakdown.paidVerification = SCORE_WEIGHTS.PAID_VERIFICATION;
+    breakdown.meta!.paidVerificationPlatforms = input.paidVerificationPlatforms;
+  }
+  if (input.hasSoundCloudPro) {
+    breakdown.soundcloudPro = SCORE_WEIGHTS.SOUNDCLOUD_PRO;
+  }
+  if (input.hasSoundCloudPro && input.soundCloudProTier) {
+    breakdown.meta!.soundcloudProTier = input.soundCloudProTier;
+  }
+  if (input.hasTrackingPixels) {
+    breakdown.hasTrackingPixels = SCORE_WEIGHTS.HAS_TRACKING_PIXELS;
+  }
+}
+
 /**
  * Calculate the fit score for a creator profile.
  *
@@ -351,28 +373,8 @@ export function calculateFitScore(input: FitScoreInput): FitScoreResult {
     breakdown.hasContactEmail = SCORE_WEIGHTS.HAS_CONTACT_EMAIL;
   }
 
-  // 11. Paid verification on social platforms (+10) - signals willingness/ability to pay
-  // Platforms like Twitter/X, Instagram, Facebook, Threads require paid subscriptions for verification
-  if (
-    input.paidVerificationPlatforms &&
-    input.paidVerificationPlatforms.length > 0
-  ) {
-    breakdown.paidVerification = SCORE_WEIGHTS.PAID_VERIFICATION;
-    breakdown.meta!.paidVerificationPlatforms = input.paidVerificationPlatforms;
-  }
-
-  // 12. SoundCloud Pro subscription (+10) - music-specific paid signal, stronger than social verification
-  if (input.hasSoundCloudPro) {
-    breakdown.soundcloudPro = SCORE_WEIGHTS.SOUNDCLOUD_PRO;
-  }
-  if (input.hasSoundCloudPro && input.soundCloudProTier) {
-    breakdown.meta!.soundcloudProTier = input.soundCloudProTier;
-  }
-
-  // 13. Has tracking pixels on link-in-bio (+5) - signals active ad spend
-  if (input.hasTrackingPixels) {
-    breakdown.hasTrackingPixels = SCORE_WEIGHTS.HAS_TRACKING_PIXELS;
-  }
+  // 11-13. Paid verification, SoundCloud Pro, and tracking pixels
+  applyPaidSignalScores(input, breakdown);
 
   // Calculate total score (capped at 100)
   const score = Math.min(100, getFitScoreTotal(breakdown));

--- a/apps/web/lib/leads/reporting.ts
+++ b/apps/web/lib/leads/reporting.ts
@@ -85,6 +85,15 @@ function isMissingLeadReportingSchemaError(error: unknown): boolean {
   ].some(pattern => message.includes(pattern));
 }
 
+function addToGroup(map: Map<string, LeadRow[]>, key: string, lead: LeadRow) {
+  const group = map.get(key);
+  if (group) {
+    group.push(lead);
+  } else {
+    map.set(key, [lead]);
+  }
+}
+
 function buildLeadGroups(filteredLeads: LeadRow[]) {
   const sourceGroups = new Map<string, LeadRow[]>();
   const pixelGroups = new Map<string, LeadRow[]>();
@@ -94,39 +103,24 @@ function buildLeadGroups(filteredLeads: LeadRow[]) {
   const toolGroups = new Map<string, LeadRow[]>();
 
   for (const lead of filteredLeads) {
-    sourceGroups.set(lead.sourcePlatform, [
-      ...(sourceGroups.get(lead.sourcePlatform) ?? []),
-      lead,
-    ]);
-    pixelGroups.set(lead.hasTrackingPixels ? 'tracking_pixels' : 'no_pixels', [
-      ...(pixelGroups.get(
-        lead.hasTrackingPixels ? 'tracking_pixels' : 'no_pixels'
-      ) ?? []),
-      lead,
-    ]);
-    verifiedGroups.set(lead.isLinktreeVerified ? 'verified' : 'not_verified', [
-      ...(verifiedGroups.get(
-        lead.isLinktreeVerified ? 'verified' : 'not_verified'
-      ) ?? []),
-      lead,
-    ]);
-    paidTierGroups.set(lead.hasPaidTier ? 'paid_tier' : 'free_tier', [
-      ...(paidTierGroups.get(lead.hasPaidTier ? 'paid_tier' : 'free_tier') ??
-        []),
-      lead,
-    ]);
-    keywordGroups.set(lead.discoveryQuery ?? 'unknown', [
-      ...(keywordGroups.get(lead.discoveryQuery ?? 'unknown') ?? []),
-      lead,
-    ]);
+    const pixelKey = lead.hasTrackingPixels ? 'tracking_pixels' : 'no_pixels';
+    const verifiedKey = lead.isLinktreeVerified ? 'verified' : 'not_verified';
+    const paidKey = lead.hasPaidTier ? 'paid_tier' : 'free_tier';
+    const queryKey = lead.discoveryQuery ?? 'unknown';
+
+    addToGroup(sourceGroups, lead.sourcePlatform, lead);
+    addToGroup(pixelGroups, pixelKey, lead);
+    addToGroup(verifiedGroups, verifiedKey, lead);
+    addToGroup(paidTierGroups, paidKey, lead);
+    addToGroup(keywordGroups, queryKey, lead);
 
     if (lead.musicToolsDetected.length === 0) {
-      toolGroups.set('none', [...(toolGroups.get('none') ?? []), lead]);
+      addToGroup(toolGroups, 'none', lead);
       continue;
     }
 
     for (const tool of lead.musicToolsDetected) {
-      toolGroups.set(tool, [...(toolGroups.get(tool) ?? []), lead]);
+      addToGroup(toolGroups, tool, lead);
     }
   }
 

--- a/apps/web/lib/profile-monetization.ts
+++ b/apps/web/lib/profile-monetization.ts
@@ -126,6 +126,17 @@ export function getProfileMonetizationPrimaryActionLabel(
   }
 }
 
+function resolveProvider(
+  stripeReady: boolean,
+  stripeIncomplete: boolean,
+  hasVenmoSetup: boolean,
+  hasProfileUrl: boolean
+): ProfileMonetizationSummaryResponse['provider'] {
+  if (stripeReady || stripeIncomplete) return 'stripe';
+  if (hasVenmoSetup && hasProfileUrl) return 'venmo';
+  return 'none';
+}
+
 export function isProfileMonetizationShareable(
   paymentState: ProfilePaymentState
 ): boolean {
@@ -163,14 +174,12 @@ export function resolveProfileMonetizationSummary(
     paymentState = 'not_setup';
   }
 
-  let provider: ProfileMonetizationSummaryResponse['provider'];
-  if (stripeReady || stripeIncomplete) {
-    provider = 'stripe';
-  } else if (hasVenmoSetup && hasProfileUrl) {
-    provider = 'venmo';
-  } else {
-    provider = 'none';
-  }
+  const provider = resolveProvider(
+    stripeReady,
+    stripeIncomplete,
+    hasVenmoSetup,
+    hasProfileUrl
+  );
 
   const manageHref: AppRoute =
     input.stripeConnectEnabled && paymentState !== 'needs_profile_url'


### PR DESCRIPTION
## Summary
Fixes 5 SonarCloud CRITICAL S3776 cognitive complexity issues by extracting helper functions:

- **`resolveProfileMonetizationSummary`** (16→≤15): Extract `resolveProvider` helper for provider determination logic
- **`calculateFitScore`** (17→≤15): Extract `applyPaidSignalScores` helper for paid verification, SoundCloud Pro, and tracking pixel scoring
- **`buildLeadGroups`** (17→≤15): Extract `addToGroup` helper + pre-compute ternary keys to eliminate duplicate expressions
- **`UserCellWithTouring`** (17→≤15): Extract `buildUserSubtitleParts` helper for subtitle metadata assembly
- **`buildReleaseActions`** (17→≤15): Extract `buildShareItems` helper for share menu construction with early return for locked state

## SonarCloud Rules Addressed
- **S3776**: Cognitive Complexity of functions should not be too high (threshold: 15)

## Test plan
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Biome lint passes on all 5 changed files
- [x] All 121 unit tests pass (profile-monetization + fit-scoring calculator)
- [x] No behavior changes — pure refactoring (extract method only)
- [x] Pre-commit hooks pass (biome, eslint, a11y, typecheck)
- [x] Pre-push hooks pass (full biome + typecheck + lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)