### PR TITLE
fix: resolve SonarCloud S3776 cognitive complexity issues (batch 2)

### DIFF
--- a/apps/web/app/api/changelog/subscribe/route.ts
+++ b/apps/web/app/api/changelog/subscribe/route.ts
@@ -2,7 +2,10 @@ import crypto from 'node:crypto';
 import { eq } from 'drizzle-orm';
 import { type NextRequest, NextResponse } from 'next/server';
 import { db } from '@/lib/db';
-import { productUpdateSubscribers } from '@/lib/db/schema/product-update-subscribers';
+import {
+  type ProductUpdateSubscriber,
+  productUpdateSubscribers,
+} from '@/lib/db/schema/product-update-subscribers';
 import { sendEmail } from '@/lib/email/send';
 import { getChangelogVerifyEmail } from '@/lib/email/templates/changelog-verify';
 import { captureError } from '@/lib/error-tracking';
@@ -114,6 +117,53 @@ async function sendVerificationEmail(
   });
 }
 
+async function handleExistingSubscriber(
+  existing: ProductUpdateSubscriber,
+  email: string,
+  source: string | undefined
+): Promise<NextResponse> {
+  if (existing.verified && !existing.unsubscribedAt) {
+    return NextResponse.json(
+      { message: 'Already subscribed!' },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  }
+
+  const verificationToken = crypto.randomUUID();
+  const tokenExpiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+  await db
+    .update(productUpdateSubscribers)
+    .set({
+      verified: false,
+      verificationToken,
+      tokenExpiresAt,
+      unsubscribeToken: crypto.randomUUID(),
+      unsubscribedAt: null,
+      source: source ?? 'changelog_page',
+      updatedAt: new Date(),
+    })
+    .where(eq(productUpdateSubscribers.id, existing.id));
+
+  try {
+    await sendVerificationEmail(email, verificationToken);
+  } catch (error) {
+    await captureError('Failed to send changelog verification email', error, {
+      route: '/api/changelog/subscribe',
+      email,
+    });
+    return NextResponse.json(
+      { error: 'Confirmation email unavailable. Please try again.' },
+      { status: 502, headers: NO_STORE_HEADERS }
+    );
+  }
+
+  return NextResponse.json(
+    { message: 'Check your email to confirm your subscription!' },
+    { status: 201, headers: NO_STORE_HEADERS }
+  );
+}
+
 export async function POST(request: NextRequest) {
   const ip = getClientIP(request);
 
@@ -178,46 +228,7 @@ export async function POST(request: NextRequest) {
     .limit(1);
 
   if (existing) {
-    if (existing.verified && !existing.unsubscribedAt) {
-      return NextResponse.json(
-        { message: 'Already subscribed!' },
-        { status: 200, headers: NO_STORE_HEADERS }
-      );
-    }
-
-    const verificationToken = crypto.randomUUID();
-    const tokenExpiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
-
-    await db
-      .update(productUpdateSubscribers)
-      .set({
-        verified: false,
-        verificationToken,
-        tokenExpiresAt,
-        unsubscribeToken: crypto.randomUUID(),
-        unsubscribedAt: null,
-        source: body.source ?? 'changelog_page',
-        updatedAt: new Date(),
-      })
-      .where(eq(productUpdateSubscribers.id, existing.id));
-
-    try {
-      await sendVerificationEmail(email, verificationToken);
-    } catch (error) {
-      await captureError('Failed to send changelog verification email', error, {
-        route: '/api/changelog/subscribe',
-        email,
-      });
-      return NextResponse.json(
-        { error: 'Confirmation email unavailable. Please try again.' },
-        { status: 502, headers: NO_STORE_HEADERS }
-      );
-    }
-
-    return NextResponse.json(
-      { message: 'Check your email to confirm your subscription!' },
-      { status: 201, headers: NO_STORE_HEADERS }
-    );
+    return handleExistingSubscriber(existing, email, body.source);
   }
 
   const verificationToken = crypto.randomUUID();

--- a/apps/web/components/features/admin/ReliabilityCard.tsx
+++ b/apps/web/components/features/admin/ReliabilityCard.tsx
@@ -56,6 +56,20 @@ function getHealthTone(summary: AdminReliabilitySummary): HealthTone {
   };
 }
 
+const DEPLOYMENT_STATE_LABELS: Record<string, string> = {
+  in_progress: 'In progress',
+  failure: 'Failed',
+  success: 'Healthy',
+};
+
+function getDeploymentLabel(summary: AdminReliabilitySummary): string {
+  if (summary.deploymentAvailability === 'not_configured')
+    return 'Not configured';
+  if (summary.deploymentAvailability === 'error') return 'Unavailable';
+  if (summary.deploymentState === null) return 'Unknown';
+  return DEPLOYMENT_STATE_LABELS[summary.deploymentState] ?? 'Unknown';
+}
+
 export function ReliabilityCard({ summary }: Readonly<ReliabilityCardProps>) {
   const tone = getHealthTone(summary);
   const errorRateLabel = `${summary.errorRatePercent.toFixed(2)}%`;
@@ -66,22 +80,7 @@ export function ReliabilityCard({ summary }: Readonly<ReliabilityCardProps>) {
   const incidentsLabel = summary.incidents24h.toLocaleString();
   const sentryIssuesLabel = summary.unresolvedSentryIssues24h.toLocaleString();
   const redisLabel = summary.redisAvailable ? 'Available' : 'Unavailable';
-  let deploymentLabel: string;
-  if (summary.deploymentAvailability === 'not_configured') {
-    deploymentLabel = 'Not configured';
-  } else if (summary.deploymentAvailability === 'error') {
-    deploymentLabel = 'Unavailable';
-  } else {
-    const stateLabels: Record<string, string> = {
-      in_progress: 'In progress',
-      failure: 'Failed',
-      success: 'Healthy',
-    };
-    deploymentLabel =
-      summary.deploymentState === null
-        ? 'Unknown'
-        : (stateLabels[summary.deploymentState] ?? 'Unknown');
-  }
+  const deploymentLabel = getDeploymentLabel(summary);
   const lastIncidentLabel = summary.lastIncidentAt
     ? summary.lastIncidentAt.toISOString().slice(0, 10)
     : '—';

--- a/apps/web/components/features/home/ReleaseModeMockCard.tsx
+++ b/apps/web/components/features/home/ReleaseModeMockCard.tsx
@@ -61,6 +61,12 @@ function ReleaseArtwork({
   );
 }
 
+function getAspectRatio(variant: ReleaseModeMockCardProps['variant']): string {
+  if (variant === 'compact') return '9 / 16';
+  if (variant === 'comparison') return '11 / 13';
+  return '16 / 10';
+}
+
 export function ReleaseModeMockCard({
   release,
   variant,
@@ -76,15 +82,7 @@ export function ReleaseModeMockCard({
   const stateLabel = release.state === 'presave' ? 'Presave' : 'Live';
   const visibleLabels = isCompact ? release.labels.slice(0, 3) : release.labels;
   const stateMetaLabel = release.state === 'presave' ? 'Countdown' : 'Status';
-
-  let aspectRatio: string;
-  if (isCompact) {
-    aspectRatio = '9 / 16';
-  } else if (isComparison) {
-    aspectRatio = '11 / 13';
-  } else {
-    aspectRatio = '16 / 10';
-  }
+  const aspectRatio = getAspectRatio(variant);
 
   return (
     <MarketingSurfaceCard

--- a/apps/web/lib/dsp-enrichment/providers/musicfetch.ts
+++ b/apps/web/lib/dsp-enrichment/providers/musicfetch.ts
@@ -122,6 +122,35 @@ export function isMusicFetchAvailable(): boolean {
  * service list with an invalid-services 400 detected by
  * isMusicfetchInvalidServicesError().
  */
+function handleMusicfetchLookupError(error: unknown, spotifyUrl: string): null {
+  if (error instanceof MusicfetchRequestError) {
+    logger.warn('MusicFetch request failed', {
+      spotifyUrl,
+      statusCode: error.statusCode,
+      retryAfterSeconds: error.retryAfterSeconds,
+      details: error.details,
+      budgetScope:
+        error instanceof MusicfetchBudgetExceededError
+          ? error.budgetScope
+          : undefined,
+      message: error.message,
+    });
+
+    if (error.statusCode === 400 && !isMusicfetchInvalidServicesError(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+
+  logger.warn('MusicFetch request failed', {
+    spotifyUrl,
+    error: error instanceof Error ? error.message : 'Unknown error',
+  });
+
+  throw error instanceof Error ? error : new Error('MusicFetch request failed');
+}
+
 export async function fetchArtistBySpotifyUrl(
   spotifyUrl: string
 ): Promise<MusicFetchArtistResult | null> {
@@ -171,38 +200,7 @@ export async function fetchArtistBySpotifyUrl(
         return data.result;
       } catch (error) {
         span.setStatus({ code: 2, message: 'error' });
-
-        if (error instanceof MusicfetchRequestError) {
-          logger.warn('MusicFetch request failed', {
-            spotifyUrl,
-            statusCode: error.statusCode,
-            retryAfterSeconds: error.retryAfterSeconds,
-            details: error.details,
-            budgetScope:
-              error instanceof MusicfetchBudgetExceededError
-                ? error.budgetScope
-                : undefined,
-            message: error.message,
-          });
-
-          if (error.statusCode === 400) {
-            if (isMusicfetchInvalidServicesError(error)) {
-              throw error;
-            }
-            return null;
-          }
-
-          throw error;
-        }
-
-        logger.warn('MusicFetch request failed', {
-          spotifyUrl,
-          error: error instanceof Error ? error.message : 'Unknown error',
-        });
-
-        throw error instanceof Error
-          ? error
-          : new Error('MusicFetch request failed');
+        return handleMusicfetchLookupError(error, spotifyUrl);
       }
     }
   );


### PR DESCRIPTION
## Summary
Fixes 4 SonarCloud CRITICAL S3776 cognitive complexity issues by extracting helper functions:

- **`ReliabilityCard`** (18→≤15): Extract `getDeploymentLabel` helper and `DEPLOYMENT_STATE_LABELS` constant
- **`POST /api/changelog/subscribe`** (18→≤15): Extract `handleExistingSubscriber` for the re-subscribe flow
- **`fetchArtistBySpotifyUrl`** (18→≤15): Extract `handleMusicfetchLookupError` with merged 400-status condition
- **`ReleaseModeMockCard`** (18→≤15): Extract `getAspectRatio` variant helper

## SonarCloud Rules Addressed
- **S3776**: Cognitive Complexity of functions should not be too high (threshold: 15)

## Test plan
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Biome lint passes on all 4 changed files
- [x] All pre-commit hooks pass (biome, eslint, a11y, typecheck)
- [x] All pre-push hooks pass (full biome + typecheck + lint)
- [x] No behavior changes — pure refactoring (extract method only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal code organization by extracting helper functions for improved maintainability and reduced code duplication across multiple components and utilities
  * No changes to user-facing functionality or behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->