### PR TITLE
fix: resolve SonarCloud S3735 and S2004 issues

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
@@ -9,7 +9,7 @@
 
 import { upload } from '@vercel/blob/client';
 import { useParams } from 'next/navigation';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Icon } from '@/components/atoms/Icon';
 
 interface PromoDownloadFile {
@@ -79,9 +79,11 @@ export default function PromoDownloadsPage() {
   }, [releaseId]);
 
   // Load on first render
-  if (!loaded) {
-    void loadFiles();
-  }
+  useEffect(() => {
+    if (!loaded) {
+      loadFiles();
+    }
+  }, [loaded, loadFiles]);
 
   const handleFileSelect = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/web/components/features/dashboard/molecules/universal-link-input/UniversalLinkInput.tsx
+++ b/apps/web/components/features/dashboard/molecules/universal-link-input/UniversalLinkInput.tsx
@@ -156,6 +156,17 @@ const PROCESSING_DELAY_MS = 900;
 const DONE_DELAY_MS = 700;
 const SHORTCUT_MICROPHONE_KEY = 'm';
 
+function computeWaveformBands(data: Uint8Array): number[] {
+  return Array.from({ length: WAVEFORM_BAND_COUNT }, (_, index) => {
+    const start = Math.floor((index / WAVEFORM_BAND_COUNT) * data.length);
+    const end = Math.floor(((index + 1) / WAVEFORM_BAND_COUNT) * data.length);
+    const range = data.slice(start, Math.max(end, start + 1));
+    const total = range.reduce((sum, value) => sum + value, 0);
+    const average = total / range.length / 255;
+    return Math.max(MIN_WAVEFORM_LEVEL, average);
+  });
+}
+
 type DictationState =
   | 'idle'
   | 'listening'
@@ -322,18 +333,6 @@ export const UniversalLinkInput = forwardRef<
       analyserRef.current = analyser;
       frequencyDataRef.current = frequencyData;
 
-      const computeBands = (data: Uint8Array) =>
-        Array.from({ length: WAVEFORM_BAND_COUNT }, (_, index) => {
-          const start = Math.floor((index / WAVEFORM_BAND_COUNT) * data.length);
-          const end = Math.floor(
-            ((index + 1) / WAVEFORM_BAND_COUNT) * data.length
-          );
-          const range = data.slice(start, Math.max(end, start + 1));
-          const total = range.reduce((sum, value) => sum + value, 0);
-          const average = total / range.length / 255;
-          return Math.max(MIN_WAVEFORM_LEVEL, average);
-        });
-
       const animate = () => {
         const activeAnalyser = analyserRef.current;
         const activeFrequencyData = frequencyDataRef.current;
@@ -342,7 +341,7 @@ export const UniversalLinkInput = forwardRef<
         }
 
         activeAnalyser.getByteFrequencyData(activeFrequencyData);
-        setWaveformLevels(computeBands(activeFrequencyData));
+        setWaveformLevels(computeWaveformBands(activeFrequencyData));
         animationFrameRef.current = globalThis.requestAnimationFrame(animate);
       };
 


### PR DESCRIPTION
## Summary
Fixes 2 SonarCloud CRITICAL issues (non-S3776 rules):

- **S3735** (void operator) in `downloads/page.tsx`: Replace render-time `void loadFiles()` with `useEffect` for idiomatic React data loading
- **S2004** (nested functions >4 levels) in `UniversalLinkInput.tsx`: Extract `computeWaveformBands` to module-level function, reducing nesting depth from 5 to 2

## SonarCloud Rules Addressed
- **S3735**: Remove use of the "void" operator
- **S2004**: Functions should not be nested more than 4 levels deep

## Test plan
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Biome lint passes on both changed files
- [x] All pre-commit hooks pass (biome, eslint, a11y, typecheck)
- [x] All pre-push hooks pass (full biome + typecheck + lint)
- [x] No behavior changes — `computeWaveformBands` only uses module-level constants; `useEffect` preserves load-on-mount semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)