### PR TITLE
fix(auth): resolve staging Clerk keys from runtime env vars

### DIFF
--- a/apps/web/lib/auth/staging-clerk-keys.ts
+++ b/apps/web/lib/auth/staging-clerk-keys.ts
@@ -21,22 +21,44 @@ interface ClerkKeys {
 }
 
 /**
+ * Read a NEXT_PUBLIC_* env var at runtime, bypassing webpack DefinePlugin.
+ *
+ * Dot-notation access (process.env.NEXT_PUBLIC_X) is replaced at build time
+ * with the production literal. Bracket notation is NOT replaced, so it reads
+ * the actual runtime value from the deployment environment.
+ */
+function runtimePublicEnv(key: string): string | undefined {
+  return (process.env as Record<string, string | undefined>)[key] || undefined;
+}
+
+/**
  * Resolve Clerk keys for a given hostname.
  * Returns staging keys when on a staging host and staging keys are configured.
  * Staging must never silently fall back to production keys.
  */
 export function resolveClerkKeys(hostname: string): ClerkKeys {
   if (isStagingHost(hostname)) {
-    const stagingPk = process.env.CLERK_PUBLISHABLE_KEY_STAGING;
-    const stagingSk = process.env.CLERK_SECRET_KEY_STAGING;
-    if (!stagingPk || !stagingSk) {
-      return {
-        publishableKey: undefined,
-        secretKey: undefined,
-      };
+    const explicitPk = process.env.CLERK_PUBLISHABLE_KEY_STAGING;
+    const explicitSk = process.env.CLERK_SECRET_KEY_STAGING;
+
+    // When explicit _STAGING vars exist, use only those (fail closed on partial).
+    if (explicitPk || explicitSk) {
+      if (!explicitPk || !explicitSk) {
+        return { publishableKey: undefined, secretKey: undefined };
+      }
+      return { publishableKey: explicitPk, secretKey: explicitSk };
     }
 
-    return { publishableKey: stagingPk, secretKey: stagingSk };
+    // No _STAGING vars at all: fall back to the standard env vars read at
+    // runtime. Doppler syncs these directly to Vercel per-environment, so the
+    // staging deployment has staging values even though the build inlined
+    // production values via DefinePlugin.
+    const runtimePk = runtimePublicEnv('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY');
+    const runtimeSk = process.env.CLERK_SECRET_KEY || undefined;
+    if (!runtimePk || !runtimeSk) {
+      return { publishableKey: undefined, secretKey: undefined };
+    }
+    return { publishableKey: runtimePk, secretKey: runtimeSk };
   }
 
   return {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1113,11 +1113,33 @@ const clerkProductionMiddleware = clerkMiddleware(async (auth, req) => {
 // Staging Clerk middleware — lazy-initialized with separate instance keys.
 // The same build is promoted staging → production, so staging keys are
 // stored as server-only runtime env vars (not NEXT_PUBLIC_).
+//
+// Key resolution order:
+// 1. Explicit _STAGING suffixed vars (if either is set, use only those)
+// 2. Standard env vars read at runtime via bracket notation to bypass
+//    webpack DefinePlugin (Doppler syncs staging values per-environment)
 let _clerkStagingMiddleware: NextMiddleware | null = null;
 function getClerkStagingMiddleware() {
   if (_clerkStagingMiddleware === null) {
-    const stagingPk = process.env.CLERK_PUBLISHABLE_KEY_STAGING;
-    const stagingSk = process.env.CLERK_SECRET_KEY_STAGING;
+    const explicitPk = process.env.CLERK_PUBLISHABLE_KEY_STAGING;
+    const explicitSk = process.env.CLERK_SECRET_KEY_STAGING;
+
+    let stagingPk: string | undefined;
+    let stagingSk: string | undefined;
+
+    if (explicitPk || explicitSk) {
+      // Explicit _STAGING vars present — use only those (fail closed on partial)
+      stagingPk = explicitPk;
+      stagingSk = explicitSk;
+    } else {
+      // Fall back to runtime standard vars (bracket notation bypasses DefinePlugin)
+      stagingPk =
+        (process.env as Record<string, string | undefined>)[
+          'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY'
+        ] || undefined;
+      stagingSk = process.env.CLERK_SECRET_KEY || undefined;
+    }
+
     if (stagingPk && stagingSk) {
       _clerkStagingMiddleware = clerkMiddleware(
         async (auth, req) => {

--- a/apps/web/tests/unit/lib/auth/staging-clerk-keys.test.ts
+++ b/apps/web/tests/unit/lib/auth/staging-clerk-keys.test.ts
@@ -106,7 +106,26 @@ describe('staging Clerk key resolution', () => {
     });
   });
 
-  it('returns undefined publishable key on staging headers when staging runtime keys are missing', async () => {
+  it('falls back to runtime standard env vars on staging when no _STAGING vars exist', () => {
+    // beforeEach sets NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY and CLERK_SECRET_KEY
+    // but deletes _STAGING vars — simulates the Doppler/Vercel staging env
+    expect(resolveClerkKeys('staging.jov.ie')).toEqual({
+      publishableKey: 'pk_live_production_example',
+      secretKey: 'sk_live_production_example',
+    });
+  });
+
+  it('returns undefined on staging when no _STAGING vars and no standard vars exist', () => {
+    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    delete process.env.CLERK_SECRET_KEY;
+
+    expect(resolveClerkKeys('staging.jov.ie')).toEqual({
+      publishableKey: undefined,
+      secretKey: undefined,
+    });
+  });
+
+  it('resolves staging PK from headers via runtime fallback', async () => {
     headersMock.mockResolvedValue(
       new Headers({
         host: 'staging.jov.ie',
@@ -115,12 +134,20 @@ describe('staging Clerk key resolution', () => {
       })
     );
 
-    await expect(resolvePublishableKeyFromHeaders()).resolves.toBeUndefined();
+    // No _STAGING vars, but standard vars are set (beforeEach)
+    await expect(resolvePublishableKeyFromHeaders()).resolves.toBe(
+      'pk_live_production_example'
+    );
+  });
+
+  it('returns undefined publishable key on staging when all keys are missing', async () => {
+    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    delete process.env.CLERK_SECRET_KEY;
 
     headersMock.mockResolvedValue(
       new Headers({
-        host: 'main.jov.ie',
-        'x-forwarded-host': 'main.jov.ie',
+        host: 'staging.jov.ie',
+        'x-forwarded-host': 'staging.jov.ie',
         'x-forwarded-proto': 'https',
       })
     );


### PR DESCRIPTION
## Summary
- Staging canary health gate has been failing since April 8 because `staging.jov.ie/signup` returns HTTP 500
- Root cause: code looks for `CLERK_PUBLISHABLE_KEY_STAGING` env var which doesn't exist in Doppler/Vercel. The staging deployment has the standard `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` and `CLERK_SECRET_KEY` set to staging values, but `NEXT_PUBLIC_*` vars are baked in at build time by webpack (always production values)
- Fix: when no `_STAGING` suffixed vars exist, fall back to reading standard env vars at runtime using bracket notation on `process.env`, which bypasses webpack DefinePlugin replacement. Partial `_STAGING` config still fails closed

## Test plan
- [x] `staging-clerk-keys.test.ts` — 9 tests pass (4 new tests for fallback behavior)
- [x] `proxy-behavioral.test.ts` — 34 tests pass
- [x] `proxy-composition.critical.test.ts` — 7 tests pass
- [x] `auth-layout.test.tsx` — 6 tests pass
- [x] Typecheck clean
- [ ] CI canary health gate passes on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved staging environment authentication configuration to intelligently fall back to standard keys when staging-specific keys aren't provided, ensuring reliable deployments.

* **Tests**
  * Added comprehensive test coverage for staging authentication scenarios and fallback configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->