### PR TITLE
fix: resolve SonarCloud S4624 nested template literals

### DIFF
--- a/apps/web/components/features/dashboard/organisms/SettingsTipsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsTipsSection.tsx
@@ -63,7 +63,8 @@ export function SettingsTipsSection() {
       }
 
       const nextSearch = nextParams.toString();
-      router.replace(`${pathname}${nextSearch ? `?${nextSearch}` : ''}#tips`, {
+      const searchSuffix = nextSearch ? `?${nextSearch}` : '';
+      router.replace(`${pathname}${searchSuffix}#tips`, {
         scroll: false,
       });
     },

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
@@ -467,7 +467,8 @@ export function ProfileContactSidebar() {
       nextParams.set('tab', 'earn');
       nextParams.set('addLink', '1');
       const nextSearch = nextParams.toString();
-      router.replace(`${pathname}${nextSearch ? `?${nextSearch}` : ''}#tips`, {
+      const searchSuffix = nextSearch ? `?${nextSearch}` : '';
+      router.replace(`${pathname}${searchSuffix}#tips`, {
         scroll: false,
       });
     }

--- a/apps/web/components/features/profile/AboutSection.tsx
+++ b/apps/web/components/features/profile/AboutSection.tsx
@@ -158,7 +158,10 @@ export function AboutSection({
                       void downloadPressPhoto(photo, artist, index);
                     }}
                     className='absolute bottom-2 right-2 flex h-8 w-8 items-center justify-center rounded-full text-white/60 transition-colors duration-150 hover:bg-black/40 hover:text-white/90 disabled:cursor-not-allowed disabled:opacity-50'
-                    aria-label={`Download ${photo.originalFilename ?? `press photo ${index + 1}`}`}
+                    aria-label={
+                      'Download ' +
+                      (photo.originalFilename ?? `press photo ${index + 1}`)
+                    }
                   >
                     <Download className='h-4 w-4' />
                   </button>

--- a/apps/web/components/features/profile/templates/PublicProfileTemplateV2.tsx
+++ b/apps/web/components/features/profile/templates/PublicProfileTemplateV2.tsx
@@ -79,7 +79,8 @@ function buildModeHref(mode: ProfileMode): string {
   }
 
   const search = url.searchParams.toString();
-  return `${url.pathname}${search ? `?${search}` : ''}`;
+  const searchSuffix = search ? `?${search}` : '';
+  return `${url.pathname}${searchSuffix}`;
 }
 
 function getModeFromLocation(): ProfileMode {

--- a/apps/web/lib/discography/provider-links.ts
+++ b/apps/web/lib/discography/provider-links.ts
@@ -238,7 +238,7 @@ export async function lookupSpotifyByIsrc(
         }>;
       };
     }>(
-      `/search?q=${encodeURIComponent(`isrc:${isrc}`)}&type=track&limit=1&market=${encodeURIComponent(market)}`
+      `/search?q=${encodeURIComponent('isrc:' + isrc)}&type=track&limit=1&market=${encodeURIComponent(market)}`
     );
 
     const match = payload.tracks?.items?.[0];

--- a/apps/web/lib/email/templates/claim-invite.ts
+++ b/apps/web/lib/email/templates/claim-invite.ts
@@ -70,7 +70,9 @@ export function getClaimInviteText(data: ClaimInviteTemplateData): string {
     ? `\n\nDon't want to receive these emails? Unsubscribe: ${unsubscribeUrl}`
     : '';
 
-  return `${greetingName ? `${greetingName}!` : 'Ayyy!'}
+  const greeting = greetingName ? `${greetingName}!` : 'Ayyy!';
+
+  return `${greeting}
 
 What up. It's Tim White, artist and founder of ${APP_NAME}.
 

--- a/apps/web/lib/email/templates/promo-download-thank-you.ts
+++ b/apps/web/lib/email/templates/promo-download-thank-you.ts
@@ -60,7 +60,8 @@ export function getPromoDownloadThankYouText(
     .map(f => {
       const size = formatFileSize(f.fileSizeBytes);
       const ext = formatExtension(f.fileMimeType);
-      return `- ${f.title} (${ext}${size ? `, ${size}` : ''}): ${f.downloadUrl}`;
+      const sizeInfo = size ? `, ${size}` : '';
+      return `- ${f.title} (${ext}${sizeInfo}): ${f.downloadUrl}`;
     })
     .join('\n');
 

--- a/apps/web/lib/playlists/prompts.ts
+++ b/apps/web/lib/playlists/prompts.ts
@@ -18,9 +18,10 @@ export function buildConceptPrompt(options: {
 }): string {
   const { previousTitles, genreFocus, category = 'general', seed } = options;
 
+  const titleList = previousTitles.map(t => `- ${t}`).join('\n');
   const avoidList =
     previousTitles.length > 0
-      ? `\nPreviously generated titles (DO NOT repeat or closely resemble these):\n${previousTitles.map(t => `- ${t}`).join('\n')}`
+      ? `\nPreviously generated titles (DO NOT repeat or closely resemble these):\n${titleList}`
       : '';
 
   const genreDirective = genreFocus
@@ -89,7 +90,7 @@ export function buildCurationPrompt(options: {
 
   const jovieSection =
     jovieArtistTracks.length > 0
-      ? `\nJovie artist tracks to include (place in positions 3-8, after mood is established):\n${jovieArtistTracks.map(t => `  - [${t.spotifyTrackId}] ${t.artist} - ${t.name}`).join('\n')}`
+      ? `\nJovie artist tracks to include (place in positions 3-8, after mood is established):\n${jovieArtistTracks.map(t => '  - [' + t.spotifyTrackId + '] ' + t.artist + ' - ' + t.name).join('\n')}`
       : '\nNo Jovie artists match this theme.';
 
   return `You are sequencing a ${targetSize}-track playlist called "${concept.title}".


### PR DESCRIPTION
## Summary
Fixes 9 SonarCloud issues (MAJOR priority) across 8 files:
- Extract nested template literals into separate variables
- Use string concatenation where appropriate to avoid nesting
- Common pattern: URL query string construction with ternary inside template

## SonarCloud Rules Addressed
- **S4624**: Refactor this code to not use nested template literals

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (code quality fixes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbHY97KWVAjRpGuEH53zrm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced code maintainability by streamlining variable initialization and string construction patterns across dashboard settings, user profiles, email templates, and playlist management. No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->