### PR TITLE
fix: address 4 Sentry production issues

### DIFF
--- a/apps/web/constants/platforms/cdn-domains.ts
+++ b/apps/web/constants/platforms/cdn-domains.ts
@@ -72,7 +72,7 @@ export const PLATFORM_MEDIA_DOMAINS: Record<string, readonly string[]> = {
   // Audio preview CDNs (loaded by HTMLAudioElement in the browser)
   spotify: ['*.scdn.co', '*.spotifycdn.com'],
   apple_music: ['*.mzstatic.com'],
-  deezer: ['*.dzcdn.net'],
+  deezer: ['*.dzcdn.net', 'cdnt-preview.dzcdn.net'],
 };
 
 /**

--- a/apps/web/lib/auth/session.ts
+++ b/apps/web/lib/auth/session.ts
@@ -381,6 +381,21 @@ export async function getSessionContext(options?: {
   }
 
   // Build user context from result
+  // Guard: users.id must be a UUID. If a Clerk ID leaked into the id column
+  // (data issue), fail fast here instead of causing "invalid input syntax for
+  // type uuid" errors in every downstream query (see JOVIE-WEB-HH).
+  const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!UUID_RE.test(result.userId)) {
+    logDbError(
+      'getSessionContext',
+      new Error(
+        `user.id is not a UUID: ${result.userId} (clerkId=${clerkUserId})`
+      )
+    );
+    throw new TypeError(SESSION_ERRORS.USER_NOT_FOUND);
+  }
+
   const user: DbUserContext = {
     id: result.userId,
     clerkId: result.userClerkId,

--- a/apps/web/lib/discography/musicfetch.ts
+++ b/apps/web/lib/discography/musicfetch.ts
@@ -30,8 +30,21 @@ import { musicfetchCircuitBreaker } from './musicfetch-circuit-breaker';
 
 const REQUEST_TIMEOUT_MS = 10_000;
 
+/**
+ * Services the MusicFetch API rejects with a hard 400.
+ * Kept in sync with the comment in lib/dsp-enrichment/providers/musicfetch.ts.
+ */
+const INVALID_MUSICFETCH_SERVICES = new Set([
+  'allMusic',
+  'youtubeShorts',
+  'napster',
+  'telmoreMusik',
+]);
+
 /** The musicfetch service IDs to request (camelCase, as the API expects) */
-const TARGET_SERVICES = MUSICFETCH_ALL_SERVICES;
+const TARGET_SERVICES = MUSICFETCH_ALL_SERVICES.filter(
+  s => !INVALID_MUSICFETCH_SERVICES.has(s)
+);
 
 // ============================================================================
 // Types

--- a/apps/web/lib/utils/color.ts
+++ b/apps/web/lib/utils/color.ts
@@ -155,6 +155,7 @@ export function getContrastSafeIconColor(
   brandHex: string,
   isDarkTheme: boolean
 ): string {
+  if (!brandHex) return isDarkTheme ? '#ffffff' : '#737373';
   if (isDarkTheme && isBrandDark(brandHex)) return '#ffffff';
   const bgHex = isDarkTheme ? '#17171a' : '#fcfcfc';
   return ensureContrast(brandHex, bgHex);

--- a/apps/web/tests/unit/actions/onboarding/complete-onboarding.test.ts
+++ b/apps/web/tests/unit/actions/onboarding/complete-onboarding.test.ts
@@ -386,7 +386,9 @@ describe('completeOnboarding', () => {
   });
 
   it('updates an existing incomplete profile and deactivates orphaned profiles', async () => {
-    mockFetchExistingUser.mockResolvedValueOnce({ id: 'db-user-123' });
+    mockFetchExistingUser.mockResolvedValueOnce({
+      id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    });
     mockUpdateExistingProfile.mockResolvedValueOnce({
       username: 'newartist',
       status: 'updated',
@@ -394,7 +396,7 @@ describe('completeOnboarding', () => {
     });
     mockFetchExistingProfile.mockResolvedValueOnce({
       id: 'profile-123',
-      userId: 'db-user-123',
+      userId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       username: 'old-artist',
       usernameNormalized: 'old-artist',
       displayName: 'Old Artist',
@@ -429,16 +431,18 @@ describe('completeOnboarding', () => {
     );
     expect(mockDeactivateOrphanedProfiles).toHaveBeenCalledWith(
       {},
-      'db-user-123',
+      'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       'profile-123'
     );
   });
 
   it('returns an already-complete profile without rewriting it', async () => {
-    mockFetchExistingUser.mockResolvedValueOnce({ id: 'db-user-123' });
+    mockFetchExistingUser.mockResolvedValueOnce({
+      id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    });
     mockFetchExistingProfile.mockResolvedValueOnce({
       id: 'profile-123',
-      userId: 'db-user-123',
+      userId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       username: 'artist',
       usernameNormalized: 'artist',
       displayName: 'Artist',

--- a/apps/web/tests/unit/dashboard/DashboardOverview.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardOverview.test.tsx
@@ -101,7 +101,7 @@ describe('DashboardOverview', () => {
 
   it('marks tasks complete based on data', () => {
     const profile = makeProfile({
-      userId: 'db-user-123',
+      userId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       spotifyUrl: 'https://open.spotify.com/artist/123',
     });
     renderDashboard(profile, false);
@@ -132,7 +132,7 @@ describe('DashboardOverview', () => {
     (navigator as any).clipboard = { writeText };
 
     const profile = makeProfile({
-      userId: 'db-user-123',
+      userId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       spotifyUrl: 'https://open.spotify.com/artist/123',
     });
     renderDashboard(profile, true);
@@ -181,7 +181,7 @@ describe('DashboardOverview', () => {
 
   it('uses shared compact shell sizing for header action buttons', () => {
     const profile = makeProfile({
-      userId: 'db-user-123',
+      userId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       spotifyUrl: 'https://open.spotify.com/artist/123',
     });
     renderDashboard(profile, true);

--- a/apps/web/tests/unit/dashboard/presence-actions.test.ts
+++ b/apps/web/tests/unit/dashboard/presence-actions.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/lib/auth/session', () => ({
   getSessionContext: vi.fn().mockResolvedValue({
     clerkUserId: 'user_clerk_abc',
     user: {
-      id: 'db-user-123',
+      id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
       clerkId: 'user_clerk_abc',
       email: 'artist@example.com',
       isAdmin: false,

--- a/apps/web/tests/unit/lib/auth/gate.critical.test.ts
+++ b/apps/web/tests/unit/lib/auth/gate.critical.test.ts
@@ -203,7 +203,7 @@ function mockClerkUser(email = 'test@example.com') {
 /** Standard DB result from the JOIN query in resolveUserState */
 function mockDbUserResult(overrides: Record<string, unknown> = {}) {
   return {
-    id: 'db-user-123',
+    id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
     email: 'test@example.com',
     userStatus: 'active',
     isAdmin: false,
@@ -287,7 +287,7 @@ describe('@critical gate.ts', () => {
 
       expect(result.state).toBe(CanonicalUserState.ACTIVE);
       expect(result.clerkUserId).toBe('clerk_123');
-      expect(result.dbUserId).toBe('db-user-123');
+      expect(result.dbUserId).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
       expect(result.profileId).toBe('profile-123');
       expect(result.redirectTo).toBeNull();
     });
@@ -328,7 +328,7 @@ describe('@critical gate.ts', () => {
 
       expect(result.state).toBe(CanonicalUserState.BANNED);
       expect(result.redirectTo).toBe('/unavailable');
-      expect(result.dbUserId).toBe('db-user-123');
+      expect(result.dbUserId).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
     });
 
     it('returns BANNED when user is soft-deleted', async () => {
@@ -487,7 +487,7 @@ describe('@critical gate.ts', () => {
       await resolveUserState();
 
       expect(mockSyncEmailFromClerk).toHaveBeenCalledWith(
-        'db-user-123',
+        'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         'new-email@example.com'
       );
     });

--- a/apps/web/tests/unit/lib/auth/gate.test.ts
+++ b/apps/web/tests/unit/lib/auth/gate.test.ts
@@ -133,7 +133,7 @@ describe('gate.ts', () => {
       mockDbSelect.mockReturnValue(
         createJoinQueryMock([
           {
-            id: 'db-user-123',
+            id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             email: 'test@example.com',
             userStatus: 'active',
             isAdmin: false,
@@ -159,7 +159,7 @@ describe('gate.ts', () => {
       mockDbSelect.mockReturnValue(
         createJoinQueryMock([
           {
-            id: 'db-user-123',
+            id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             email: 'test@example.com',
             userStatus: 'banned',
             isAdmin: false,
@@ -185,7 +185,7 @@ describe('gate.ts', () => {
       mockDbSelect.mockReturnValue(
         createJoinQueryMock([
           {
-            id: 'db-user-123',
+            id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             email: 'test@example.com',
             userStatus: 'suspended',
             isAdmin: false,
@@ -212,7 +212,7 @@ describe('gate.ts', () => {
       mockDbSelect.mockReturnValue(
         createJoinQueryMock([
           {
-            id: 'db-user-123',
+            id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             email: 'test@example.com',
             userStatus: 'active',
             isAdmin: false,
@@ -234,7 +234,7 @@ describe('gate.ts', () => {
 
       expect(result.state).toBe(CanonicalUserState.NEEDS_ONBOARDING);
       expect(result.redirectTo).toBe('/onboarding?fresh_signup=true');
-      expect(result.dbUserId).toBe('db-user-123');
+      expect(result.dbUserId).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
     });
 
     it('returns NEEDS_ONBOARDING when profile is incomplete', async () => {
@@ -247,7 +247,7 @@ describe('gate.ts', () => {
       mockDbSelect.mockReturnValue(
         createJoinQueryMock([
           {
-            id: 'db-user-123',
+            id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             email: 'test@example.com',
             userStatus: 'active',
             isAdmin: false,
@@ -281,7 +281,7 @@ describe('gate.ts', () => {
       mockDbSelect.mockReturnValue(
         createJoinQueryMock([
           {
-            id: 'db-user-123',
+            id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             email: 'test@example.com',
             userStatus: 'active',
             isAdmin: false,
@@ -322,7 +322,7 @@ describe('gate.ts', () => {
       mockDbSelect.mockReturnValue(
         createJoinQueryMock([
           {
-            id: 'db-user-123',
+            id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             email: 'admin@example.com',
             userStatus: 'active',
             isAdmin: true,

--- a/apps/web/tests/unit/lib/auth/proxy-state.test.ts
+++ b/apps/web/tests/unit/lib/auth/proxy-state.test.ts
@@ -131,7 +131,7 @@ describe('proxy-state.ts', () => {
             where: vi.fn().mockReturnValue({
               limit: vi.fn().mockResolvedValue([
                 {
-                  dbUserId: 'db-user-123',
+                  dbUserId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
                   userStatus: 'waitlist_pending',
                   profileId: null,
                   profileComplete: null,
@@ -159,7 +159,7 @@ describe('proxy-state.ts', () => {
             where: vi.fn().mockReturnValue({
               limit: vi.fn().mockResolvedValue([
                 {
-                  dbUserId: 'db-user-123',
+                  dbUserId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
                   userStatus: 'waitlist_approved',
                   profileId: null,
                   profileComplete: null,
@@ -187,7 +187,7 @@ describe('proxy-state.ts', () => {
             where: vi.fn().mockReturnValue({
               limit: vi.fn().mockResolvedValue([
                 {
-                  dbUserId: 'db-user-123',
+                  dbUserId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
                   userStatus: 'profile_claimed',
                   profileId: 'profile-123',
                   profileComplete: null, // onboardingCompletedAt is null
@@ -215,7 +215,7 @@ describe('proxy-state.ts', () => {
             where: vi.fn().mockReturnValue({
               limit: vi.fn().mockResolvedValue([
                 {
-                  dbUserId: 'db-user-123',
+                  dbUserId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
                   userStatus: 'active',
                   profileId: 'profile-123',
                   profileComplete: new Date(),
@@ -248,7 +248,7 @@ describe('proxy-state.ts', () => {
             where: vi.fn().mockReturnValue({
               limit: vi.fn().mockResolvedValue([
                 {
-                  dbUserId: 'db-user-123',
+                  dbUserId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
                   userStatus: 'active',
                   profileId: 'profile-123',
                   profileComplete: new Date(),
@@ -281,7 +281,7 @@ describe('proxy-state.ts', () => {
             where: vi.fn().mockReturnValue({
               limit: vi.fn().mockResolvedValue([
                 {
-                  dbUserId: 'db-user-123',
+                  dbUserId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
                   userStatus: 'waitlist_approved',
                   profileId: 'profile-123',
                   profileComplete: new Date(),
@@ -309,7 +309,7 @@ describe('proxy-state.ts', () => {
             where: vi.fn().mockReturnValue({
               limit: vi.fn().mockResolvedValue([
                 {
-                  dbUserId: 'db-user-123',
+                  dbUserId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
                   userStatus: 'profile_claimed',
                   profileId: 'profile-123',
                   profileComplete: new Date(),
@@ -337,7 +337,7 @@ describe('proxy-state.ts', () => {
             where: vi.fn().mockReturnValue({
               limit: vi.fn().mockResolvedValue([
                 {
-                  dbUserId: 'db-user-123',
+                  dbUserId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
                   userStatus: 'onboarding_incomplete',
                   profileId: 'profile-123',
                   profileComplete: new Date(),
@@ -474,7 +474,7 @@ describe('proxy-state.ts', () => {
             where: vi.fn().mockReturnValue({
               limit: vi.fn().mockResolvedValue([
                 {
-                  dbUserId: 'db-user-123',
+                  dbUserId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
                   userStatus: 'active',
                   profileId: 'profile-123',
                   profileComplete: new Date(),

--- a/apps/web/tests/unit/lib/auth/session.critical.test.ts
+++ b/apps/web/tests/unit/lib/auth/session.critical.test.ts
@@ -269,7 +269,7 @@ describe('@critical session.ts', () => {
       mockCachedAuth.mockResolvedValue({ userId: 'clerk_123' });
 
       const mockUser = {
-        id: 'db-user-123',
+        id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         clerkId: 'clerk_123',
         email: 'test@example.com',
         isAdmin: false,
@@ -359,7 +359,9 @@ describe('@critical session.ts', () => {
       });
 
       const { getProfileByDbUserId } = await import('@/lib/auth/session');
-      const result = await getProfileByDbUserId('db-user-123');
+      const result = await getProfileByDbUserId(
+        'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+      );
 
       expect(result).toEqual({ ...mockQueryResult, isClaimed: true });
     });
@@ -376,7 +378,9 @@ describe('@critical session.ts', () => {
       });
 
       const { getProfileByDbUserId } = await import('@/lib/auth/session');
-      const result = await getProfileByDbUserId('db-user-123');
+      const result = await getProfileByDbUserId(
+        'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+      );
 
       expect(result).toBeNull();
     });
@@ -399,14 +403,14 @@ describe('@critical session.ts', () => {
 
       // The new implementation uses a single JOIN query returning combined data
       const mockJoinResult = {
-        userId: 'db-user-123',
+        userId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         userClerkId: 'clerk_123',
         userEmail: 'test@example.com',
         userIsAdmin: false,
         userIsPro: true,
         userStatus: 'active',
         profileId: 'profile-123',
-        profileUserId: 'db-user-123',
+        profileUserId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         profileUsername: 'testuser',
         profileUsernameNormalized: 'testuser',
         profileDisplayName: 'Test User',
@@ -422,7 +426,7 @@ describe('@critical session.ts', () => {
       const result = await getSessionContext();
 
       expect(result.clerkUserId).toBe('clerk_123');
-      expect(result.user.id).toBe('db-user-123');
+      expect(result.user.id).toBe('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
       expect(result.user.clerkId).toBe('clerk_123');
       expect(result.profile?.id).toBe('profile-123');
     });
@@ -444,7 +448,7 @@ describe('@critical session.ts', () => {
 
       // User exists but no profile (profileId is null from LEFT JOIN)
       const mockJoinResult = {
-        userId: 'db-user-123',
+        userId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         userClerkId: 'clerk_123',
         userEmail: 'test@example.com',
         userIsAdmin: false,
@@ -475,7 +479,7 @@ describe('@critical session.ts', () => {
 
       // User exists but no profile (profileId is null from LEFT JOIN)
       const mockJoinResultNoProfile = {
-        userId: 'db-user-123',
+        userId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         userClerkId: 'clerk_123',
         userEmail: 'test@example.com',
         userIsAdmin: false,
@@ -519,14 +523,14 @@ describe('@critical session.ts', () => {
       mockCachedAuth.mockResolvedValue({ userId: 'clerk_123' });
 
       const mockJoinResult = {
-        userId: 'db-user-123',
+        userId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         userClerkId: 'clerk_123',
         userEmail: 'test@example.com',
         userIsAdmin: false,
         userIsPro: false,
         userStatus: 'active',
         profileId: 'profile-123',
-        profileUserId: 'db-user-123',
+        profileUserId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         profileUsername: 'testuser',
         profileUsernameNormalized: 'testuser',
         profileDisplayName: 'Test User',
@@ -549,7 +553,7 @@ describe('@critical session.ts', () => {
       mockCachedAuth.mockResolvedValue({ userId: 'clerk_123' });
 
       const mockJoinResultNoProfile = {
-        userId: 'db-user-123',
+        userId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         userClerkId: 'clerk_123',
         userEmail: 'test@example.com',
         userIsAdmin: false,
@@ -593,7 +597,7 @@ describe('@critical session.ts', () => {
       mockCachedAuth.mockResolvedValue({ userId: 'clerk_123' });
 
       const mockJoinResult = {
-        userId: 'db-user-123',
+        userId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         userClerkId: 'clerk_123',
         userEmail: 'test@example.com',
         userIsAdmin: false,
@@ -622,7 +626,7 @@ describe('@critical session.ts', () => {
         expect.objectContaining({
           clerkUserId: 'clerk_123',
           user: expect.objectContaining({
-            id: 'db-user-123',
+            id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
             clerkId: 'clerk_123',
           }),
         })
@@ -634,7 +638,7 @@ describe('@critical session.ts', () => {
       mockCachedAuth.mockResolvedValue({ userId: 'clerk_123' });
 
       const mockJoinResult = {
-        userId: 'db-user-123',
+        userId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
         userClerkId: 'clerk_123',
         userEmail: 'test@example.com',
         userIsAdmin: false,


### PR DESCRIPTION
## Summary

Fixes 4 unresolved Sentry issues from the last 7 days:

- **JOVIE-WEB-HH** (98 users, 215 events, escalating): UUID format guard in `getSessionContext()` — prevents Clerk ID strings from reaching UUID columns in downstream queries, failing fast with a clear error
- **JOVIE-WEB-JH** (2 events): Null guard in `getContrastSafeIconColor()` — returns safe default when provider brand color is undefined
- **JOVIE-WEB-HV** (8 events): Filter invalid MusicFetch services (`allMusic`, `youtubeShorts`, `napster`, `telmoreMusik`) from discography ISRC lookups
- **JOVIE-WEB-JD** (1 event): Add `cdnt-preview.dzcdn.net` to CSP `media-src` for Deezer audio preview playback

## Test plan

- [x] `pnpm --filter web typecheck` passes
- [x] `pnpm --filter web lint` passes  
- [x] 9446 tests pass (1 pre-existing failure in `auth-layout.test.tsx` unrelated to changes)
- [x] Test mocks updated to use UUID format for `user.id` fields
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes JOVIE-WEB-HH
Fixes JOVIE-WEB-JH
Fixes JOVIE-WEB-HV
Fixes JOVIE-WEB-JD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Deezer CDN support with additional hostname.

* **Bug Fixes**
  * Improved session validation with UUID format checking.
  * Fixed music service lookups by filtering incompatible services.
  * Enhanced color handling when brand colors are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->