### PR TITLE
fix: resolve SonarCloud S7781 replaceAll issues

### DIFF
--- a/apps/web/app/api/promo-downloads/confirm/route.ts
+++ b/apps/web/app/api/promo-downloads/confirm/route.ts
@@ -32,8 +32,8 @@ const confirmSchema = z.object({
 function slugify(title: string): string {
   return title
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '')
     .slice(0, 80);
 }
 

--- a/apps/web/lib/email/templates/personalization.ts
+++ b/apps/web/lib/email/templates/personalization.ts
@@ -42,7 +42,7 @@ export function resolveSafeFirstName(
     return null;
   }
 
-  const tokens = trimmedName.replace(/\s+/g, ' ').split(' ').filter(Boolean);
+  const tokens = trimmedName.replaceAll(/\s+/g, ' ').split(' ').filter(Boolean);
   // Stay intentionally conservative: only personalize clear two-word names.
   if (tokens.length !== 2) {
     return null;

--- a/apps/web/lib/playlists/generate-cover.ts
+++ b/apps/web/lib/playlists/generate-cover.ts
@@ -128,10 +128,10 @@ async function createGradientBackground(): Promise<Buffer> {
 function createTextOverlay(text: string): Buffer {
   // Escape XML entities
   const escaped = text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
 
   // Calculate font size based on text length
   let fontSize = 100;

--- a/apps/web/lib/submission-agent/monitoring/providers/allmusic.ts
+++ b/apps/web/lib/submission-agent/monitoring/providers/allmusic.ts
@@ -209,9 +209,9 @@ function normalizeComparableValue(
   const normalized = value
     .toLowerCase()
     .replaceAll('&', ' and ')
-    .replace(/[^a-z0-9]+/g, ' ')
+    .replaceAll(/[^a-z0-9]+/g, ' ')
     .trim()
-    .replace(/\s+/g, ' ');
+    .replaceAll(/\s+/g, ' ');
 
   return normalized.length > 0 ? normalized : null;
 }


### PR DESCRIPTION
## Summary
Fixes 9 SonarCloud issues (MINOR priority) across 4 files — use `String#replaceAll()` instead of `String#replace()` for global replacements.

- email/templates/personalization.ts: whitespace token split
- playlists/generate-cover.ts: XML entity escaping (4 sites)
- promo-downloads/confirm/route.ts: slugify helper (2 sites)
- submission-agent/monitoring/providers/allmusic.ts: canonical value normalization (2 sites)

## SonarCloud Rules Addressed
- **typescript:S7781** — Prefer `String#replaceAll()` over `String#replace()`

## Test plan
- [x] TypeScript compiles (pre-commit)
- [x] Biome lint passes
- [x] No behavior changes (semantics of `replaceAll` with global regex / single-char strings are identical)

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal string handling utilities across the application using updated JavaScript methods for improved code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->