### PR TITLE
fix: resolve SonarCloud S7763 export-from issues

### DIFF
--- a/apps/web/lib/auth/test-mode.ts
+++ b/apps/web/lib/auth/test-mode.ts
@@ -3,7 +3,6 @@ import {
   TEST_AUTH_BYPASS_MODE,
   TEST_MODE_COOKIE,
   TEST_MODE_HEADER,
-  TEST_PERSONA_COOKIE,
   TEST_USER_ID_COOKIE,
   TEST_USER_ID_HEADER,
 } from '@/lib/auth/test-mode-constants';
@@ -15,7 +14,7 @@ export {
   TEST_PERSONA_COOKIE,
   TEST_USER_ID_COOKIE,
   TEST_USER_ID_HEADER,
-};
+} from '@/lib/auth/test-mode-constants';
 
 const TRUSTED_PREVIEW_HOSTS = new Set(['preview.jov.ie']);
 


### PR DESCRIPTION
## Summary
Fixes 5 SonarCloud S7763 issues in `apps/web/lib/auth/test-mode.ts` by using `export … from` for re-exports. Internal consumers still import the constants they use; `TEST_PERSONA_COOKIE` is re-exported only (not used in this file).

## SonarCloud Rules Addressed
- **typescript:S7763** — Use `export…from` to re-export

## Test plan
- [x] TypeScript compiles (pre-commit)
- [x] Biome lint passes
- [x] No behavior changes (pure re-export syntax change)

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements to authentication constant exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->