### PR TITLE
fix: resolve SonarCloud S7741 typeof undefined issues

### DIFF
--- a/apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx
+++ b/apps/web/app/[username]/[slug]/sounds/SoundsLandingPage.tsx
@@ -65,7 +65,7 @@ export function SoundsLandingPage({
 }: Readonly<SoundsLandingPageProps>) {
   const [menuOpen, setMenuOpen] = useState(false);
   const resolvedUtmParams = useMemo(() => {
-    if (typeof globalThis.window === 'undefined') {
+    if (globalThis.window === undefined) {
       return utmParams;
     }
 

--- a/apps/web/app/r/[slug]/ReleaseLandingPage.tsx
+++ b/apps/web/app/r/[slug]/ReleaseLandingPage.tsx
@@ -235,7 +235,7 @@ export function ReleaseLandingPage({
     (provider): provider is Provider & { url: string } => Boolean(provider.url)
   );
   const resolvedUtmParams = useMemo(() => {
-    if (typeof globalThis.window === 'undefined') {
+    if (globalThis.window === undefined) {
       return utmParams;
     }
 

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -130,7 +130,7 @@ function unwrapNextImageUrl(url: string | null | undefined): string | null {
 }
 
 function getModeFromLocation(fallbackMode: ProfileMode): ProfileMode {
-  if (typeof globalThis.window === 'undefined') {
+  if (globalThis.window === undefined) {
     return fallbackMode;
   }
 
@@ -215,7 +215,7 @@ export function ProfileCompactTemplate({
   }, [artist.image_url, photoDownloadSizes]);
 
   const initialSource = useMemo(() => {
-    if (typeof globalThis.window === 'undefined') return null;
+    if (globalThis.window === undefined) return null;
     return new URLSearchParams(globalThis.location.search).get('source');
   }, []);
 

--- a/apps/web/components/providers/SentryDashboardProvider.tsx
+++ b/apps/web/components/providers/SentryDashboardProvider.tsx
@@ -221,7 +221,7 @@ export function useSentryDashboardState(): {
   });
 
   useEffect(() => {
-    if (typeof globalThis.window === 'undefined') {
+    if (globalThis.window === undefined) {
       return undefined;
     }
 

--- a/apps/web/lib/distribution/instagram-activation.ts
+++ b/apps/web/lib/distribution/instagram-activation.ts
@@ -175,7 +175,7 @@ export async function postDistributionEvent(
 ): Promise<boolean> {
   // This helper relies on a same-origin relative URL and keepalive semantics,
   // so accidental server-side calls should no-op instead of throwing.
-  if (typeof globalThis.window === 'undefined') {
+  if (globalThis.window === undefined) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
Fixes 6 SonarCloud S7741 issues across 5 files — compare with `undefined` directly instead of `typeof x === 'undefined'`.

All instances are SSR guards of the form `typeof globalThis.window === 'undefined'` becoming `globalThis.window === undefined`. Semantics are identical here because `globalThis.window` is a declared global property — comparing to `undefined` does not risk a `ReferenceError`.

- components/providers/SentryDashboardProvider.tsx
- app/[username]/[slug]/sounds/SoundsLandingPage.tsx
- app/r/[slug]/ReleaseLandingPage.tsx
- lib/distribution/instagram-activation.ts
- components/features/profile/templates/ProfileCompactTemplate.tsx (2 sites)

## SonarCloud Rules Addressed
- **typescript:S7741** — Compare with `undefined` directly instead of using `typeof`

## Test plan
- [x] TypeScript compiles (pre-commit)
- [x] Biome lint passes
- [x] No behavior changes

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to environment detection logic across multiple components with no impact to user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->