### PR TITLE
fix(ci): re-inject staging Clerk keys at deploy time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2991,7 +2991,10 @@ jobs:
           # Retry up to 3 times for transient Vercel failures
           for attempt in 1 2 3; do
             echo "Deploy attempt $attempt/3"
-            if deploy_output="$(vercel deploy --prebuilt --archive=tgz --token ${{ secrets.VERCEL_TOKEN }} 2>&1)"; then
+            if deploy_output="$(vercel deploy --prebuilt --archive=tgz \
+              --env CLERK_PUBLISHABLE_KEY_STAGING="${CLERK_PUBLISHABLE_KEY_STAGING}" \
+              --env CLERK_SECRET_KEY_STAGING="${CLERK_SECRET_KEY_STAGING}" \
+              --token ${{ secrets.VERCEL_TOKEN }} 2>&1)"; then
               deploy_exit=0
             else
               deploy_exit=$?
@@ -3017,6 +3020,8 @@ jobs:
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          CLERK_PUBLISHABLE_KEY_STAGING: ${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}
+          CLERK_SECRET_KEY_STAGING: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
 
       - name: Alias preview to staging.jov.ie
         run: |


### PR DESCRIPTION
## Summary
- The staging deploy command lost the `--env` flags for Clerk keys when #7126 and #7148 merged with CI changes that overwrote #7186's fix
- Without these flags, staging Vercel deployment has no `CLERK_PUBLISHABLE_KEY_STAGING` or `CLERK_SECRET_KEY_STAGING` at runtime
- All protected routes on staging return 503: `{"error":"Service temporarily unavailable","message":"Authentication service is initializing. Please try again."}`

## Fix
Re-adds `--env CLERK_PUBLISHABLE_KEY_STAGING` and `--env CLERK_SECRET_KEY_STAGING` to the `vercel deploy` command in the staging deploy step, plus explicit env var mapping from GitHub secrets.

## Prerequisites
GitHub secrets must exist:
- `CLERK_PUBLISHABLE_KEY_STAGING` — staging Clerk publishable key
- `CLERK_SECRET_KEY_STAGING` — staging Clerk secret key

If these secrets don't exist yet, they need to be added in Settings → Secrets → Actions.

## Test plan
- [ ] Verify GitHub secrets are configured
- [ ] After merge, staging deploy should inject Clerk keys
- [ ] `staging.jov.ie/signup` should return 200 instead of 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD configuration for staging environment deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->