### PR TITLE
fix: resolve SonarCloud code quality issues (batch 1)

### DIFF
--- a/apps/web/app/(dynamic)/playlists/[slug]/page.tsx
+++ b/apps/web/app/(dynamic)/playlists/[slug]/page.tsx
@@ -43,7 +43,7 @@ async function getPlaylist(slug: string) {
     .where(eq(joviePlaylists.slug, slug))
     .limit(1);
 
-  if (!playlist || playlist.status !== 'published') return null;
+  if (playlist?.status !== 'published') return null;
   return playlist;
 }
 

--- a/apps/web/app/app/(shell)/dashboard/releases/actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/actions.ts
@@ -2253,6 +2253,26 @@ export async function revertReleaseArtwork(
   return { artworkUrl: originalArtworkUrl, originalArtworkUrl };
 }
 
+function determineReleaseStatus(
+  releaseDate: Date | null
+): 'draft' | 'scheduled' | 'released' {
+  if (!releaseDate) return 'draft';
+  return releaseDate > new Date() ? 'scheduled' : 'released';
+}
+
+function computeRevealDate(
+  formRevealDate: string | null,
+  releaseDate: Date | null,
+  status: 'draft' | 'scheduled' | 'released'
+): Date | null {
+  if (formRevealDate) return new Date(formRevealDate);
+  if (!releaseDate || status !== 'scheduled') return null;
+  const thirtyDaysBefore = new Date(releaseDate);
+  thirtyDaysBefore.setDate(thirtyDaysBefore.getDate() - 30);
+  const now = new Date();
+  return thirtyDaysBefore > now ? thirtyDaysBefore : now;
+}
+
 export async function createRelease(formData: {
   title: string;
   releaseType: 'single' | 'ep' | 'album' | 'compilation' | 'live';
@@ -2287,26 +2307,12 @@ export async function createRelease(formData: {
     ? new Date(formData.releaseDate)
     : null;
 
-  // Determine status based on release date
-  const now = new Date();
-  let status: 'draft' | 'scheduled' | 'released';
-  if (!releaseDate) {
-    status = 'draft';
-  } else if (releaseDate > now) {
-    status = 'scheduled';
-  } else {
-    status = 'released';
-  }
-
-  // Reveal date: use explicit override if provided, otherwise auto-set for scheduled releases
-  let revealDate: Date | null = null;
-  if (formData.revealDate) {
-    revealDate = new Date(formData.revealDate);
-  } else if (releaseDate && status === 'scheduled') {
-    const thirtyDaysBefore = new Date(releaseDate);
-    thirtyDaysBefore.setDate(thirtyDaysBefore.getDate() - 30);
-    revealDate = thirtyDaysBefore > now ? thirtyDaysBefore : now;
-  }
+  const status = determineReleaseStatus(releaseDate);
+  const revealDate = computeRevealDate(
+    formData.revealDate ?? null,
+    releaseDate,
+    status
+  );
 
   try {
     const [inserted] = await db

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/utils/column-renderers.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/utils/column-renderers.tsx
@@ -279,6 +279,14 @@ export function TouringCityCell({ row }: CellContext<AudienceMember, unknown>) {
 
 type SubtitlePart = { key: string; text: string; className?: string };
 
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 function buildUserSubtitleParts(
   m: AudienceMember,
   hiddenMetadataColumns: {
@@ -289,41 +297,32 @@ function buildUserSubtitleParts(
 ): SubtitlePart[] {
   const parts: SubtitlePart[] = [];
 
-  if (hiddenMetadataColumns.engagement) {
-    if (m.intentLevel === 'high') {
-      parts.push({
-        key: 'intent',
-        text: 'High',
-        className: 'font-[510] text-emerald-600 dark:text-emerald-400',
-      });
-    } else if (m.intentLevel === 'medium') {
-      parts.push({
-        key: 'intent',
-        text: 'Medium',
-        className: 'font-[510] text-amber-600 dark:text-amber-400',
-      });
-    }
-
-    if (m.visits > 0) {
-      parts.push({
-        key: 'visits',
-        text: `${m.visits} ${m.visits === 1 ? 'visit' : 'visits'}`,
-      });
-    }
+  if (hiddenMetadataColumns.engagement && m.intentLevel === 'high') {
+    parts.push({
+      key: 'intent',
+      text: 'High',
+      className: 'font-[510] text-emerald-600 dark:text-emerald-400',
+    });
+  } else if (hiddenMetadataColumns.engagement && m.intentLevel === 'medium') {
+    parts.push({
+      key: 'intent',
+      text: 'Medium',
+      className: 'font-[510] text-amber-600 dark:text-amber-400',
+    });
   }
 
-  if (hiddenMetadataColumns.location) {
-    const locationCity = m.geoCity ?? m.geoCountry ?? null;
-    if (locationCity) {
-      try {
-        parts.push({
-          key: 'location',
-          text: decodeURIComponent(locationCity),
-        });
-      } catch {
-        parts.push({ key: 'location', text: locationCity });
-      }
-    }
+  if (hiddenMetadataColumns.engagement && m.visits > 0) {
+    parts.push({
+      key: 'visits',
+      text: `${m.visits} ${m.visits === 1 ? 'visit' : 'visits'}`,
+    });
+  }
+
+  const locationCity = hiddenMetadataColumns.location
+    ? (m.geoCity ?? m.geoCountry ?? null)
+    : null;
+  if (locationCity) {
+    parts.push({ key: 'location', text: safeDecode(locationCity) });
   }
 
   if (hiddenMetadataColumns.lastSeen && m.lastSeenAt) {

--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceTable.tsx
@@ -155,7 +155,7 @@ export function DspPresenceTable({
   return (
     <UnifiedTable
       data={items}
-      columns={columns as ColumnDef<DspPresenceItem, unknown>[]}
+      columns={columns}
       onRowClick={onRowSelect}
       getRowId={getRowId}
       getRowTestId={getRowTestId}

--- a/apps/web/lib/extensions/fill-preview.ts
+++ b/apps/web/lib/extensions/fill-preview.ts
@@ -141,7 +141,7 @@ export async function buildExtensionFillPreview(
   profileId: string
 ): Promise<ExtensionFillPreviewResponse | null> {
   const release = await getReleaseById(request.entityId);
-  if (!release || release.creatorProfileId !== profileId) return null;
+  if (release?.creatorProfileId !== profileId) return null;
 
   const releaseTitle = release.title.trim();
   const artistName =


### PR DESCRIPTION
## Summary
Fixes 5 SonarCloud issues (CRITICAL + MAJOR priority):
- Extract `determineReleaseStatus`/`computeRevealDate` helpers from `createRelease` to reduce cognitive complexity (S3776)
- Flatten `buildUserSubtitleParts` nesting, extract `safeDecode` helper (S3776)
- Use optional chaining in playlist page and fill-preview (S6582)
- Remove unnecessary type assertion in DspPresenceTable (S4325)

## SonarCloud Rules Addressed
- S3776: Cognitive Complexity — extracted helpers to reduce function complexity
- S6582: Prefer optional chain expressions
- S4325: Unnecessary type assertion

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (code quality fixes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal logic for release status determination and reveal date calculation.
  * Improved data handling for user engagement and location display in the dashboard.
  * Streamlined validation checks and error handling for better code efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->