### PR TITLE
fix: resolve SonarCloud nested ternary issues (batch 2)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/dsp-presence/CatalogHealthSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/CatalogHealthSection.tsx
@@ -50,6 +50,45 @@ function getCatalogScanPollDelayMs(
 }
 
 // ============================================================================
+// Header helpers
+// ============================================================================
+
+function getCatalogHeaderText(opts: {
+  isScanning: boolean;
+  scanFailed: boolean;
+  neverScanned: boolean;
+  allClear: boolean;
+  matchedCount: number;
+  unresolvedCount: number;
+}): string {
+  if (opts.isScanning) return 'Scanning...';
+  if (opts.scanFailed) return 'Scan failed';
+  if (opts.neverScanned) return 'Catalog Health';
+  if (opts.allClear) return `All clear — ${opts.matchedCount} ISRCs matched`;
+  return `Catalog Health — ${opts.unresolvedCount} to review`;
+}
+
+function CatalogStatusIcon({
+  isScanning,
+  scanFailed,
+  allClear,
+  hasResults,
+}: Readonly<{
+  isScanning: boolean;
+  scanFailed: boolean;
+  allClear: boolean;
+  hasResults: boolean;
+}>) {
+  if (isScanning)
+    return <Loader2 className='h-3.5 w-3.5 animate-spin text-primary' />;
+  if (scanFailed) return <XCircle className='h-3.5 w-3.5 text-destructive' />;
+  if (allClear) return <CheckCircle2 className='h-3.5 w-3.5 text-green-500' />;
+  if (hasResults)
+    return <AlertTriangle className='h-3.5 w-3.5 text-amber-500' />;
+  return <ScanSearch className='h-3.5 w-3.5 text-muted-foreground' />;
+}
+
+// ============================================================================
 // Main Component
 // ============================================================================
 
@@ -250,15 +289,14 @@ export function CatalogHealthSection({
     scan?.status === 'completed' && unresolvedNotInCatalog.length === 0;
   const scanFailed = scan?.status === 'failed' || !!scanError;
 
-  const headerText = isScanning
-    ? 'Scanning...'
-    : scanFailed
-      ? 'Scan failed'
-      : neverScanned
-        ? 'Catalog Health'
-        : allClear
-          ? `All clear — ${scan?.matchedCount ?? 0} ISRCs matched`
-          : `Catalog Health — ${unresolvedNotInCatalog.length} to review`;
+  const headerText = getCatalogHeaderText({
+    isScanning,
+    scanFailed,
+    neverScanned,
+    allClear,
+    matchedCount: scan?.matchedCount ?? 0,
+    unresolvedCount: unresolvedNotInCatalog.length,
+  });
 
   return (
     <div className='border-t border-border'>
@@ -269,17 +307,12 @@ export function CatalogHealthSection({
         className='flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-accent/50'
         aria-expanded={isOpen}
       >
-        {isScanning ? (
-          <Loader2 className='h-3.5 w-3.5 animate-spin text-primary' />
-        ) : scanFailed ? (
-          <XCircle className='h-3.5 w-3.5 text-destructive' />
-        ) : allClear ? (
-          <CheckCircle2 className='h-3.5 w-3.5 text-green-500' />
-        ) : hasResults ? (
-          <AlertTriangle className='h-3.5 w-3.5 text-amber-500' />
-        ) : (
-          <ScanSearch className='h-3.5 w-3.5 text-muted-foreground' />
-        )}
+        <CatalogStatusIcon
+          isScanning={isScanning}
+          scanFailed={scanFailed}
+          allClear={allClear}
+          hasResults={hasResults}
+        />
 
         <span className='flex-1 text-xs font-medium'>{headerText}</span>
 

--- a/apps/web/components/molecules/drawer/DrawerCardActionBar.tsx
+++ b/apps/web/components/molecules/drawer/DrawerCardActionBar.tsx
@@ -128,8 +128,10 @@ export function DrawerCardActionBar({
           {overflowTrigger}
           {floatingCloseButton}
         </div>
-      ) : overflowTriggerPlacement === 'card-top-right' &&
-        floatingCloseButton ? (
+      ) : null}
+      {overflowTriggerPlacement === 'card-top-right' &&
+      !overflowTrigger &&
+      floatingCloseButton ? (
         <div className='absolute right-3 top-3 z-10'>{floatingCloseButton}</div>
       ) : null}
       {displayActions.map(action => {

--- a/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
@@ -195,6 +195,17 @@ function TrackListRow({
 
   const controlLabel = getControlLabel();
 
+  let trackButtonContent: React.JSX.Element;
+  if (isActiveTrack && isTrackPlaying) {
+    trackButtonContent = <Pause className='h-3.5 w-3.5' aria-hidden='true' />;
+  } else if (isActiveTrack) {
+    trackButtonContent = (
+      <Play className='h-3.5 w-3.5 translate-x-px' aria-hidden='true' />
+    );
+  } else {
+    trackButtonContent = <span aria-hidden='true'>{trackLabel}</span>;
+  }
+
   return (
     <div
       className={cn(
@@ -220,15 +231,7 @@ function TrackListRow({
         aria-label={controlLabel}
         data-testid={`release-track-control-${track.id}`}
       >
-        {isActiveTrack ? (
-          isTrackPlaying ? (
-            <Pause className='h-3.5 w-3.5' aria-hidden='true' />
-          ) : (
-            <Play className='h-3.5 w-3.5 translate-x-px' aria-hidden='true' />
-          )
-        ) : (
-          <span aria-hidden='true'>{trackLabel}</span>
-        )}
+        {trackButtonContent}
       </button>
 
       <div className='min-w-0 flex-1'>


### PR DESCRIPTION
## Summary
Fixes 9 SonarCloud issues (CRITICAL + MAJOR priority):
- Extract `getCatalogHeaderText` and `CatalogStatusIcon` from CatalogHealthSection (S3776 complexity 28 + 6× S3358)
- Split nested ternary in DrawerCardActionBar into separate conditionals (S3358)
- Extract track button content to variable in ReleaseTrackList (S3358)

## SonarCloud Rules Addressed
- S3776: Cognitive Complexity — extracted helper function and component
- S3358: Nested ternary operations — extracted to variables or split into separate conditionals

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (code quality fixes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)