### PR TITLE
fix: address review comments from sonar-fix #7257

### DIFF
--- a/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ArrowRight, Check } from 'lucide-react';
 import React from 'react';
 import { LoadingSpinner } from '@/components/atoms/LoadingSpinner';
 import { AUTH_SURFACE } from '@/lib/auth/constants';
@@ -46,33 +47,13 @@ function SubmitButtonIcon({
   }
   if (autoSubmitClaimed) {
     return (
-      <svg
-        viewBox='0 0 20 20'
-        fill='none'
+      <Check
         aria-hidden='true'
-        className='h-4 w-4 animate-in zoom-in duration-300'
-      >
-        <path
-          d='M6 10.2l2.6 2.6L14 7.4'
-          stroke='currentColor'
-          strokeWidth='2'
-          strokeLinecap='round'
-          strokeLinejoin='round'
-        />
-      </svg>
+        className='size-4 animate-in zoom-in duration-300'
+      />
     );
   }
-  return (
-    <svg viewBox='0 0 20 20' fill='none' aria-hidden='true' className='h-4 w-4'>
-      <path
-        d='M4 10h12m0 0l-4-4m4 4l-4 4'
-        stroke='currentColor'
-        strokeWidth='2'
-        strokeLinecap='round'
-        strokeLinejoin='round'
-      />
-    </svg>
-  );
+  return <ArrowRight aria-hidden='true' className='size-4' />;
 }
 
 export function OnboardingHandleStep({

--- a/apps/web/components/features/profile/ProfileHeroCard.tsx
+++ b/apps/web/components/features/profile/ProfileHeroCard.tsx
@@ -219,42 +219,52 @@ export function ArtistHero({
           </div>
 
           <div className='flex flex-wrap items-center gap-3'>
-            {primaryAction?.href ? (
-              <a
-                href={primaryAction.href}
-                target={primaryAction.external ? '_blank' : undefined}
-                rel={primaryAction.external ? 'noopener noreferrer' : undefined}
-                onClick={
-                  primaryAction.external ? undefined : primaryAction.onClick
-                }
-                aria-label={primaryAction.ariaLabel ?? primaryAction.label}
-                className={primaryActionClassName}
-              >
-                {primaryActionKind === 'tickets' ? (
-                  <Ticket
-                    className='mr-2 h-[17px] w-[17px]'
-                    aria-hidden='true'
-                  />
-                ) : null}
-                {primaryAction.label}
-              </a>
-            ) : null}
-            {primaryAction && !primaryAction.href ? (
-              <button
-                type='button'
-                onClick={primaryAction.onClick}
-                aria-label={primaryAction.ariaLabel ?? primaryAction.label}
-                className={primaryActionClassName}
-              >
-                {primaryActionKind === 'tickets' ? (
-                  <Ticket
-                    className='mr-2 h-[17px] w-[17px]'
-                    aria-hidden='true'
-                  />
-                ) : null}
-                {primaryAction.label}
-              </button>
-            ) : null}
+            {primaryAction
+              ? (() => {
+                  const content = (
+                    <>
+                      {primaryActionKind === 'tickets' ? (
+                        <Ticket
+                          className='mr-2 h-[17px] w-[17px]'
+                          aria-hidden='true'
+                        />
+                      ) : null}
+                      {primaryAction.label}
+                    </>
+                  );
+                  const label = primaryAction.ariaLabel ?? primaryAction.label;
+
+                  return primaryAction.href ? (
+                    <a
+                      href={primaryAction.href}
+                      target={primaryAction.external ? '_blank' : undefined}
+                      rel={
+                        primaryAction.external
+                          ? 'noopener noreferrer'
+                          : undefined
+                      }
+                      onClick={
+                        primaryAction.external
+                          ? undefined
+                          : primaryAction.onClick
+                      }
+                      aria-label={label}
+                      className={primaryActionClassName}
+                    >
+                      {content}
+                    </a>
+                  ) : (
+                    <button
+                      type='button'
+                      onClick={primaryAction.onClick}
+                      aria-label={label}
+                      className={primaryActionClassName}
+                    >
+                      {content}
+                    </button>
+                  );
+                })()
+              : null}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
Follow-up to #7257, addressing CodeRabbit review comments:
- Replace inline SVGs with lucide-react `Check` and `ArrowRight` in `SubmitButtonIcon`
- Use `size-4` class per repo icon convention
- Extract shared `primaryAction` content to eliminate duplication in `ProfileHeroCard`

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (review feedback only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated icon components in the dashboard onboarding flow to use standardized icon library.
  * Improved code organization in the profile card component's action button rendering logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->