### PR TITLE
fix: resolve SonarCloud nested ternary issues (batch 4)

### DIFF
--- a/apps/web/components/atoms/ImageWithFallback.tsx
+++ b/apps/web/components/atoms/ImageWithFallback.tsx
@@ -114,12 +114,12 @@ export function ImageWithFallback({
   ...rest
 }: ImageWithFallbackProps) {
   const [hasError, setHasError] = useState(false);
-  const sourceUrl =
-    typeof src === 'string'
-      ? src
-      : typeof src === 'object' && src !== null && 'src' in src
-        ? src.src
-        : null;
+  let sourceUrl: string | null = null;
+  if (typeof src === 'string') {
+    sourceUrl = src;
+  } else if (typeof src === 'object' && src !== null && 'src' in src) {
+    sourceUrl = src.src;
+  }
 
   // Reset error state when src changes
   useEffect(() => {

--- a/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
+++ b/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
@@ -177,6 +177,11 @@ function buildFeedbackColumns(deps: {
   ];
 }
 
+function formatDismissedLabel(dismissedAtIso: string | null): string {
+  if (!dismissedAtIso) return 'Dismissed';
+  return `Dismissed ${new Date(dismissedAtIso).toLocaleString()}`;
+}
+
 export function AdminFeedbackTable({
   items,
 }: Readonly<AdminFeedbackTableProps>) {
@@ -368,13 +373,7 @@ export function AdminFeedbackTable({
                     <p className='text-tertiary-token'>
                       {selected.status !== 'dismissed'
                         ? 'Marked as pending'
-                        : `Dismissed ${
-                            selected.dismissedAtIso
-                              ? new Date(
-                                  selected.dismissedAtIso
-                                ).toLocaleString()
-                              : ''
-                          }`}
+                        : formatDismissedLabel(selected.dismissedAtIso)}
                     </p>
                   </div>
                 }

--- a/apps/web/components/features/profile/artist-notifications-cta/TwoStepNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/TwoStepNotificationsCTA.tsx
@@ -204,36 +204,48 @@ function ChannelInputRow({
     }
   };
 
+  let leftSlot: React.ReactNode;
+  if (otpStep === 'verify') {
+    leftSlot = undefined;
+  } else if (shouldShowCountrySelector) {
+    leftSlot = (
+      <CountrySelector
+        country={country}
+        isOpen={isCountryOpen}
+        onOpenChange={setIsCountryOpen}
+        onSelect={setCountry}
+      />
+    );
+  } else if (smsEnabled) {
+    leftSlot = (
+      <button
+        type='button'
+        className='flex h-12 items-center justify-center rounded-full px-3 text-primary-token/68 transition-colors hover:text-primary-token focus-visible:outline-none'
+        aria-label={getChannelToggleLabel(channel)}
+        onClick={() => handleChannelChange(channel === 'sms' ? 'email' : 'sms')}
+        disabled={isSubmitting}
+      >
+        {channel === 'sms' ? (
+          <Phone className='w-4 h-4' aria-hidden='true' />
+        ) : (
+          <Mail className='w-4 h-4' aria-hidden='true' />
+        )}
+      </button>
+    );
+  }
+
+  let composerClassName = '';
+  if (otpStep === 'verify') {
+    composerClassName = 'px-3 py-3';
+  } else if (isInputFocused) {
+    composerClassName = subscriptionComposerFocusClassName;
+  }
+
   return (
     <SubscriptionPearlComposer
       layout={otpStep === 'verify' ? 'stacked' : 'inline'}
       dataTestId='subscription-pearl-composer'
-      leftSlot={
-        otpStep === 'verify' ? undefined : shouldShowCountrySelector ? (
-          <CountrySelector
-            country={country}
-            isOpen={isCountryOpen}
-            onOpenChange={setIsCountryOpen}
-            onSelect={setCountry}
-          />
-        ) : smsEnabled ? (
-          <button
-            type='button'
-            className='flex h-12 items-center justify-center rounded-full px-3 text-primary-token/68 transition-colors hover:text-primary-token focus-visible:outline-none'
-            aria-label={getChannelToggleLabel(channel)}
-            onClick={() =>
-              handleChannelChange(channel === 'sms' ? 'email' : 'sms')
-            }
-            disabled={isSubmitting}
-          >
-            {channel === 'sms' ? (
-              <Phone className='w-4 h-4' aria-hidden='true' />
-            ) : (
-              <Mail className='w-4 h-4' aria-hidden='true' />
-            )}
-          </button>
-        ) : undefined
-      }
+      leftSlot={leftSlot}
       action={
         <button
           type='button'
@@ -245,13 +257,7 @@ function ChannelInputRow({
           {getSubmitLabel(isSubmitting, otpStep)}
         </button>
       }
-      className={
-        otpStep === 'verify'
-          ? 'px-3 py-3'
-          : isInputFocused
-            ? subscriptionComposerFocusClassName
-            : ''
-      }
+      className={composerClassName}
     >
       {otpStep === 'verify' ? (
         <div className='px-2 py-2'>


### PR DESCRIPTION
## Summary
Fixes 5 SonarCloud issues (MAJOR priority):
- Extract sourceUrl computation in ImageWithFallback to if/else (S3358)
- Extract `formatDismissedLabel` helper in AdminFeedbackTable (S3358)
- Extract `leftSlot` and `className` computations in TwoStepNotificationsCTA (3× S3358)

## SonarCloud Rules Addressed
- S3358: Nested ternary operations — extracted to variables, helpers, or if/else blocks

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (code quality fixes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)