### PR TITLE
fix: resolve SonarCloud nested ternary issues (batch 5)

### DIFF
--- a/apps/web/components/features/profile/artist-notifications-cta/ArtistNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ArtistNotificationsCTA.tsx
@@ -464,6 +464,40 @@ export function ArtistNotificationsCTA({
   const handleFormSubmit =
     otpStep === 'verify' ? handleVerifyOtp : handleSubscribe;
 
+  let leftSlot: React.ReactNode;
+  if (otpStep === 'verify') {
+    leftSlot = undefined;
+  } else if (shouldShowCountrySelector) {
+    leftSlot = (
+      <CountrySelector
+        country={country}
+        isOpen={isCountryOpen}
+        onOpenChange={setIsCountryOpen}
+        onSelect={setCountry}
+      />
+    );
+  } else if (smsEnabled) {
+    leftSlot = (
+      <ChannelToggle
+        channel={channel}
+        isSubmitting={isSubmitting}
+        onChannelChange={handleChannelChange}
+      />
+    );
+  }
+
+  const actionClassName =
+    otpStep === 'verify'
+      ? `${subscriptionPrimaryActionClassName} min-w-[7rem]`
+      : subscriptionPrimaryActionClassName;
+
+  let composerClassName: string | undefined;
+  if (otpStep === 'verify') {
+    composerClassName = 'px-3 py-3';
+  } else if (isInputFocused) {
+    composerClassName = subscriptionComposerFocusClassName;
+  }
+
   return (
     <div className='min-h-[180px] space-y-3'>
       <p className={subscriptionHeadingClassName} style={noFontSynthesisStyle}>
@@ -473,22 +507,7 @@ export function ArtistNotificationsCTA({
       <SubscriptionPearlComposer
         dataTestId='subscription-pearl-composer'
         layout={otpStep === 'verify' ? 'stacked' : 'inline'}
-        leftSlot={
-          otpStep === 'verify' ? undefined : shouldShowCountrySelector ? (
-            <CountrySelector
-              country={country}
-              isOpen={isCountryOpen}
-              onOpenChange={setIsCountryOpen}
-              onSelect={setCountry}
-            />
-          ) : smsEnabled ? (
-            <ChannelToggle
-              channel={channel}
-              isSubmitting={isSubmitting}
-              onChannelChange={handleChannelChange}
-            />
-          ) : undefined
-        }
+        leftSlot={leftSlot}
         action={
           <button
             type='button'
@@ -496,23 +515,13 @@ export function ArtistNotificationsCTA({
               handleFormSubmit();
             }}
             disabled={isSubmitting || (otpStep === 'verify' && Boolean(error))}
-            className={
-              otpStep === 'verify'
-                ? `${subscriptionPrimaryActionClassName} min-w-[7rem]`
-                : subscriptionPrimaryActionClassName
-            }
+            className={actionClassName}
             style={noFontSynthesisStyle}
           >
             {getSubmitButtonLabel(isSubmitting, otpStep)}
           </button>
         }
-        className={
-          otpStep === 'verify'
-            ? 'px-3 py-3'
-            : isInputFocused
-              ? subscriptionComposerFocusClassName
-              : undefined
-        }
+        className={composerClassName}
       >
         {otpStep === 'verify' ? (
           <div className='px-2 py-2'>

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -730,7 +730,8 @@ export function ReleaseSidebar({
                     >
                       Loading tasks...
                     </div>
-                  ) : canAccessTasksWorkspace ? (
+                  ) : null}
+                  {!isTasksWorkspaceGateLoading && canAccessTasksWorkspace ? (
                     <ReleaseTaskChecklist
                       releaseId={release.id}
                       variant='compact'
@@ -743,11 +744,12 @@ export function ReleaseSidebar({
                           );
                       }}
                     />
-                  ) : (
+                  ) : null}
+                  {!isTasksWorkspaceGateLoading && !canAccessTasksWorkspace ? (
                     <CompactReleasePlanUpgradeCard
                       onDismiss={() => setActiveTab('details')}
                     />
-                  )}
+                  ) : null}
                 </div>
               )}
 


### PR DESCRIPTION
## Summary
Fixes 4 SonarCloud issues (MAJOR priority):
- Extract `leftSlot`, `actionClassName`, `composerClassName` in ArtistNotificationsCTA (3× S3358)
- Split nested task content ternary in ReleaseSidebar into separate conditionals (S3358)

## SonarCloud Rules Addressed
- S3358: Nested ternary operations — extracted to variables or split into separate conditionals

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (code quality fixes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for artist notification and release task management components to enhance maintainability and reduce rendering complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->