### PR TITLE
fix: resolve SonarCloud negated condition issues (batch 6)

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/task-actions.ts
@@ -157,9 +157,9 @@ export async function instantiateReleaseTasks(releaseId: string) {
       releaseId,
       category: item.category,
       dueAt:
-        releaseDate !== null
-          ? computeDueDate(releaseDate, item.dueDaysOffset)
-          : null,
+        releaseDate === null
+          ? null
+          : computeDueDate(releaseDate, item.dueDaysOffset),
       position: startPosition + index,
       sourceTemplateId: null,
       metadata: {

--- a/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
@@ -439,54 +439,54 @@ export async function updateTask(
     .set({
       title: data.title ?? existingTask.title,
       description:
-        data.description !== undefined
-          ? data.description
-          : existingTask.description,
+        data.description === undefined
+          ? existingTask.description
+          : data.description,
       status: nextStatus,
       priority: data.priority ?? existingTask.priority,
       assigneeKind: data.assigneeKind ?? existingTask.assigneeKind,
       assigneeUserId:
-        data.assigneeUserId !== undefined
-          ? data.assigneeUserId
-          : existingTask.assigneeUserId,
+        data.assigneeUserId === undefined
+          ? existingTask.assigneeUserId
+          : data.assigneeUserId,
       agentType:
-        data.agentType !== undefined ? data.agentType : existingTask.agentType,
+        data.agentType === undefined ? existingTask.agentType : data.agentType,
       agentStatus: data.agentStatus ?? existingTask.agentStatus,
       agentInput:
-        data.agentInput !== undefined
-          ? data.agentInput
-          : existingTask.agentInput,
+        data.agentInput === undefined
+          ? existingTask.agentInput
+          : data.agentInput,
       agentOutput:
-        data.agentOutput !== undefined
-          ? data.agentOutput
-          : existingTask.agentOutput,
+        data.agentOutput === undefined
+          ? existingTask.agentOutput
+          : data.agentOutput,
       agentError:
-        data.agentError !== undefined
-          ? data.agentError
-          : existingTask.agentError,
+        data.agentError === undefined
+          ? existingTask.agentError
+          : data.agentError,
       releaseId:
-        data.releaseId !== undefined ? data.releaseId : existingTask.releaseId,
+        data.releaseId === undefined ? existingTask.releaseId : data.releaseId,
       parentTaskId:
-        data.parentTaskId !== undefined
-          ? data.parentTaskId
-          : existingTask.parentTaskId,
+        data.parentTaskId === undefined
+          ? existingTask.parentTaskId
+          : data.parentTaskId,
       category:
-        data.category !== undefined ? data.category : existingTask.category,
-      dueAt: data.dueAt !== undefined ? data.dueAt : existingTask.dueAt,
+        data.category === undefined ? existingTask.category : data.category,
+      dueAt: data.dueAt === undefined ? existingTask.dueAt : data.dueAt,
       scheduledFor:
-        data.scheduledFor !== undefined
-          ? data.scheduledFor
-          : existingTask.scheduledFor,
+        data.scheduledFor === undefined
+          ? existingTask.scheduledFor
+          : data.scheduledFor,
       startedAt:
-        data.startedAt !== undefined ? data.startedAt : existingTask.startedAt,
+        data.startedAt === undefined ? existingTask.startedAt : data.startedAt,
       completedAt,
       position: data.position ?? existingTask.position,
       sourceTemplateId:
-        data.sourceTemplateId !== undefined
-          ? data.sourceTemplateId
-          : existingTask.sourceTemplateId,
+        data.sourceTemplateId === undefined
+          ? existingTask.sourceTemplateId
+          : data.sourceTemplateId,
       metadata:
-        data.metadata !== undefined ? data.metadata : existingTask.metadata,
+        data.metadata === undefined ? existingTask.metadata : data.metadata,
       updatedAt: new Date(),
     })
     .where(eq(tasks.id, taskId))

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -163,7 +163,7 @@ export default async function OnboardingPage({
 
   // Discard the early reservation if a providedHandle is now available (e.g. from
   // existingProfile.username) — otherwise isReservedHandle would incorrectly be true.
-  let reservedHandle = !providedHandle ? earlyReservedHandle.handle : null;
+  let reservedHandle = providedHandle ? null : earlyReservedHandle.handle;
   let isReservedHandle = !providedHandle && earlyReservedHandle.isReserved;
   if (
     shouldLoadExistingProfile &&

--- a/apps/web/components/features/home/ReleaseModeMockCard.tsx
+++ b/apps/web/components/features/home/ReleaseModeMockCard.tsx
@@ -52,9 +52,9 @@ function ReleaseArtwork({
           <p className='text-[14px] font-[560] tracking-[-0.02em] text-white'>
             {title}
           </p>
-          {!compact ? (
+          {compact ? null : (
             <p className='mt-1 text-[10px] leading-4 text-white/72'>{artist}</p>
-          ) : null}
+          )}
         </div>
       </div>
     </div>

--- a/apps/web/lib/playlists/prompts.ts
+++ b/apps/web/lib/playlists/prompts.ts
@@ -48,7 +48,7 @@ Requirements:
 - Mix well-known tracks (60%) with deeper cuts (30%) and emerging artists (10%)
 - Sequence for flow: open strong, build energy, peak in the middle, cool down at end
 ${genreDirective}${categoryDirective}${avoidList}
-${seed !== undefined ? `Variety seed: ${seed} (use this to explore different directions)` : ''}
+${seed === undefined ? '' : `Variety seed: ${seed} (use this to explore different directions)`}
 
 Respond in JSON format:
 {


### PR DESCRIPTION
## Summary
Fixes 17 SonarCloud issues (MINOR priority):
- Flip 14 negated ternary conditions (`!== undefined`) in dashboard task-actions
- Flip negated condition in release task-actions
- Flip negated conditions in playlists prompts, ReleaseModeMockCard, onboarding page

## SonarCloud Rules Addressed
- S7735: Unexpected negated condition — swap condition and branches for positive-first style

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (mechanical condition flip only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed user handle reservation logic during onboarding
  * Corrected task update field preservation to maintain existing values when not explicitly modified
  * Improved release task due date calculations when date is unavailable
  * Refined conditional logic in release artwork display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->