### PR TITLE
fix: resolve SonarCloud negated condition issues (batch 7)

### DIFF
--- a/apps/web/app/app/(shell)/admin/_components/AdminScoreboardSection.tsx
+++ b/apps/web/app/app/(shell)/admin/_components/AdminScoreboardSection.tsx
@@ -79,7 +79,7 @@ function FunnelStep({
           {count.toLocaleString('en-US')}
         </p>
         <p className='mt-0.5 text-[12px] text-tertiary-token'>
-          {conversionRate !== null ? formatPercent(conversionRate) : '\u2014'}
+          {conversionRate === null ? '\u2014' : formatPercent(conversionRate)}
         </p>
       </li>
     </>
@@ -161,7 +161,7 @@ export async function AdminScoreboardSection() {
             <p
               className={`mt-0.5 text-[13px] font-[450] ${wowGrowth.className}`}
             >
-              {wowGrowth.label !== '\u2014' ? 'vs. prior week' : ''}
+              {wowGrowth.label === '\u2014' ? '' : 'vs. prior week'}
             </p>
           }
         />
@@ -195,9 +195,9 @@ export async function AdminScoreboardSection() {
                   label={step.label}
                   count={step.count}
                   conversionRate={
-                    step.prevCount !== null
-                      ? safeConversionRate(step.count, step.prevCount)
-                      : null
+                    step.prevCount === null
+                      ? null
+                      : safeConversionRate(step.count, step.prevCount)
                   }
                   showArrow={i > 0}
                 />

--- a/apps/web/app/sentry-example-page/SentryExamplePageClient.tsx
+++ b/apps/web/app/sentry-example-page/SentryExamplePageClient.tsx
@@ -106,7 +106,7 @@ export function SentryExamplePageClient() {
             </ContentSurfaceCard>
           ) : null}
 
-          {!isConnected ? (
+          {isConnected ? null : (
             <ContentSurfaceCard
               surface='nested'
               className='border-[color-mix(in_oklab,var(--linear-warning)_30%,var(--linear-app-frame-seam))] bg-[color-mix(in_oklab,var(--linear-warning)_10%,var(--linear-app-content-surface))] p-4'
@@ -122,7 +122,7 @@ export function SentryExamplePageClient() {
                 </p>
               </div>
             </ContentSurfaceCard>
-          ) : null}
+          )}
         </div>
       </ContentSurfaceCard>
     </StandaloneProductPage>

--- a/apps/web/components/features/admin/leads/LeadTable.tsx
+++ b/apps/web/components/features/admin/leads/LeadTable.tsx
@@ -352,7 +352,7 @@ export function LeadTable({
           const count =
             funnelCounts && opt.value ? funnelCounts[opt.value] : undefined;
           const label =
-            count !== undefined ? `${opt.label} (${count})` : opt.label;
+            count === undefined ? opt.label : `${opt.label} (${count})`;
           return (
             <PageToolbarTabButton
               key={opt.value}

--- a/apps/web/components/features/dashboard/release-tasks/MetadataAgentPanel.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/MetadataAgentPanel.tsx
@@ -433,9 +433,9 @@ export function MetadataAgentPanel({
       {error ? (
         <div
           className={`mt-4 rounded-lg border px-3 py-2 text-sm ${
-            !storageAvailable
-              ? 'border-amber-200 bg-amber-50 text-amber-700'
-              : 'border-red-200 bg-red-50 text-red-700'
+            storageAvailable
+              ? 'border-red-200 bg-red-50 text-red-700'
+              : 'border-amber-200 bg-amber-50 text-amber-700'
           }`}
         >
           {error}

--- a/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
@@ -145,7 +145,7 @@ function TrackListRow({
   const isActiveTrack = playbackState.activeTrackId === track.id;
   const isTrackPlaying = isActiveTrack && playbackState.isPlaying;
   const trackDuration =
-    track.durationMs != null ? formatDuration(track.durationMs) : null;
+    track.durationMs == null ? null : formatDuration(track.durationMs);
 
   const handleTogglePlayback = useCallback(() => {
     if (isActiveTrack) {


### PR DESCRIPTION
## Summary
Fixes 7 SonarCloud issues (MINOR priority):
- Flip 3 negated conditions in AdminScoreboardSection (S7735)
- Flip negated condition in MetadataAgentPanel error state (S7735)
- Flip negated conditions in LeadTable, ReleaseTrackList, SentryExamplePageClient (S7735)

## SonarCloud Rules Addressed
- S7735: Unexpected negated condition — swap condition and branches for positive-first style

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (mechanical condition flip only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)