### PR TITLE
fix: remove unnecessary type assertions (batch 8)

### DIFF
--- a/apps/web/app/[username]/[slug]/[trackSlug]/page.tsx
+++ b/apps/web/app/[username]/[slug]/[trackSlug]/page.tsx
@@ -139,7 +139,7 @@ export default async function TrackDeepLinkPage({
   );
 
   // Add the deeper breadcrumb (4 levels instead of 3)
-  const graph = structuredData['@graph'] as Array<Record<string, unknown>>;
+  const graph = structuredData['@graph'];
   const bcIndex = graph.findIndex(s => s['@type'] === 'BreadcrumbList');
   if (bcIndex >= 0) {
     graph[bcIndex] = buildBreadcrumbObject([

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SuggestedDspMatches.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SuggestedDspMatches.tsx
@@ -11,7 +11,6 @@ import {
   PROVIDER_LABELS,
 } from '@/features/dashboard/atoms/DspProviderIcon';
 import { useDspMatchActions } from '@/features/dashboard/organisms/dsp-matches/hooks';
-import type { DspProviderId } from '@/lib/dsp-enrichment/types';
 import { type DspMatch, useDspMatchesQuery } from '@/lib/queries';
 import { cn } from '@/lib/utils';
 import { isExternalDspImage } from '@/lib/utils/dsp-images';
@@ -156,8 +155,7 @@ function SuggestedMatchRow({
   onReject,
 }: SuggestedMatchRowProps) {
   const isLoading = isConfirming || isRejecting;
-  const label =
-    PROVIDER_LABELS[match.providerId as DspProviderId] ?? match.providerId;
+  const label = PROVIDER_LABELS[match.providerId] ?? match.providerId;
   const [popoverOpen, setPopoverOpen] = useState(false);
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -191,10 +189,7 @@ function SuggestedMatchRow({
       <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
         <PopoverTrigger asChild>
           <span className='contents'>
-            <DspProviderIcon
-              provider={match.providerId as DspProviderId}
-              size='sm'
-            />
+            <DspProviderIcon provider={match.providerId} size='sm' />
             <span className='min-w-0 flex-1 truncate text-[13px] font-[450] text-primary-token'>
               {match.externalArtistName || label}
             </span>
@@ -288,10 +283,7 @@ function MatchPopoverContent({
           </div>
         ) : (
           <div className='flex h-8 w-8 items-center justify-center rounded-full border border-subtle bg-surface-1'>
-            <DspProviderIcon
-              provider={match.providerId as DspProviderId}
-              size='md'
-            />
+            <DspProviderIcon provider={match.providerId} size='md' />
           </div>
         )}
         <div className='min-w-0 flex-1'>


### PR DESCRIPTION
## Summary
Fixes 4 SonarCloud issues (MINOR priority):
- Remove 3 redundant `as DspProviderId` casts in SuggestedDspMatches — `match.providerId` is already `DspProviderId`
- Remove unnecessary `as Array<...>` assertion in track page structured data

## SonarCloud Rules Addressed
- S4325: Unnecessary type assertion — the expression already has the target type

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (type assertion removal only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code quality and maintainability through internal type system refinements in profile and dashboard components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->