### PR TITLE
fix: resolve SonarCloud negated condition issues (batch 9)

### DIFF
--- a/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
+++ b/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
@@ -371,9 +371,9 @@ export function AdminFeedbackTable({
                       {new Date(selected.createdAtIso).toLocaleString()}
                     </p>
                     <p className='text-tertiary-token'>
-                      {selected.status !== 'dismissed'
-                        ? 'Marked as pending'
-                        : formatDismissedLabel(selected.dismissedAtIso)}
+                      {selected.status === 'dismissed'
+                        ? formatDismissedLabel(selected.dismissedAtIso)
+                        : 'Marked as pending'}
                     </p>
                   </div>
                 }

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
@@ -209,11 +209,11 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
     setIsDeleting(true);
     try {
       const result = await deleteRelease({ releaseId: deleteTarget.id });
-      if (!result.success) {
-        toast.error(result.message ?? 'Failed to delete release.');
-      } else {
+      if (result.success) {
         setRows(prev => prev.filter(r => r.id !== deleteTarget.id));
         toast.success(`"${deleteTarget.title}" deleted.`);
+      } else {
+        toast.error(result.message ?? 'Failed to delete release.');
       }
     } catch {
       toast.error('Failed to delete release.');

--- a/apps/web/components/molecules/drawer/DrawerEditableTextField.tsx
+++ b/apps/web/components/molecules/drawer/DrawerEditableTextField.tsx
@@ -197,7 +197,7 @@ export function DrawerEditableTextField({
             </span>
           </button>
         ) : null}
-        {!editable ? (
+        {editable ? null : (
           <span
             className={cn(
               'block min-w-0 w-full truncate text-[13px] text-primary-token',
@@ -210,7 +210,7 @@ export function DrawerEditableTextField({
           >
             {displayValue}
           </span>
-        ) : null}
+        )}
       </div>
 
       {actionSlotIds.length > 0 ? (
@@ -245,8 +245,9 @@ export function DrawerEditableTextField({
             </DrawerInlineIconButton>
           ) : null}
 
-          {!isEditing
-            ? visibleActions.map(action =>
+          {isEditing
+            ? null
+            : visibleActions.map(action =>
                 action.href ? (
                   <a
                     key={action.id}
@@ -275,8 +276,7 @@ export function DrawerEditableTextField({
                     {action.icon ?? <ExternalLink className='h-3.5 w-3.5' />}
                   </DrawerInlineIconButton>
                 )
-              )
-            : null}
+              )}
         </div>
       ) : null}
     </div>

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -347,11 +347,11 @@ export function TrackSidebar({
                 }
                 meta={
                   <div className='flex flex-wrap items-center gap-2 text-[10.5px] text-tertiary-token'>
-                    {track.durationMs != null ? (
+                    {track.durationMs == null ? null : (
                       <span className='tabular-nums'>
                         {formatDuration(track.durationMs)}
                       </span>
-                    ) : null}
+                    )}
                     {track.isrc ? (
                       <span className='font-mono text-[9.5px] tracking-[0.02em]'>
                         {track.isrc}


### PR DESCRIPTION
## Summary
Fixes 5 SonarCloud issues (MINOR priority):
- Flip 2 negated conditions in DrawerEditableTextField (`!editable`, `!isEditing`) (S7735)
- Flip negated if/else in ReleaseProviderMatrix delete handler (S7735)
- Flip negated condition in AdminFeedbackTable status display (S7735)
- Flip negated null check in TrackSidebar duration (S7735)

## SonarCloud Rules Addressed
- S7735: Unexpected negated condition — swap condition and branches for positive-first style

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (mechanical condition flip only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed status label display in feedback details sidebar.
  * Corrected delete confirmation notifications in the release matrix—success and error toasts now display appropriately.
  * Fixed visibility behavior for editable text field action buttons during edit mode.
  * Improved conditional rendering for track duration display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->