### PR TITLE
fix: resolve SonarCloud nested ternary issues (batch 10)

### DIFF
--- a/apps/web/app/[username]/[slug]/page.tsx
+++ b/apps/web/app/[username]/[slug]/page.tsx
@@ -517,11 +517,14 @@ export async function generateMetadata({
   const isMystery = metadataPhase === 'mystery';
 
   // In mystery phase, hide release title and artwork from OG tags
-  const title = isMystery
-    ? `New music from ${artistName} - Coming Soon`
-    : isUnreleased
-      ? `${content.title} by ${artistName} - Coming Soon`
-      : `${content.title} by ${artistName} - Stream Now`;
+  let title: string;
+  if (isMystery) {
+    title = `New music from ${artistName} - Coming Soon`;
+  } else if (isUnreleased) {
+    title = `${content.title} by ${artistName} - Coming Soon`;
+  } else {
+    title = `${content.title} by ${artistName} - Stream Now`;
+  }
 
   const description = isMystery
     ? `${artistName} has something new coming. Get notified when it drops.`

--- a/apps/web/components/features/admin/admin-creator-profiles/AdminProfileSidebar.tsx
+++ b/apps/web/components/features/admin/admin-creator-profiles/AdminProfileSidebar.tsx
@@ -174,19 +174,21 @@ export function AdminProfileSidebar({
             allowPhotoDownloads={false}
             showOldReleases={false}
           />
-        ) : selectedCategory === 'algorithm' ? (
+        ) : null}
+        {selectedCategory === 'algorithm' ? (
           <AlgorithmHealthPanel
             profile={profile}
             contact={contact}
             isActive={selectedCategory === 'algorithm'}
           />
-        ) : (
+        ) : null}
+        {selectedCategory !== 'about' && selectedCategory !== 'algorithm' ? (
           <ProfileLinkList
             links={links}
             selectedCategory={selectedCategory as CategoryOption}
             surface='plain'
           />
-        )}
+        ) : null}
       </DrawerTabbedCard>
     </EntitySidebarShell>
   );

--- a/apps/web/components/features/admin/admin-creator-profiles/AlgorithmHealthPanel.tsx
+++ b/apps/web/components/features/admin/admin-creator-profiles/AlgorithmHealthPanel.tsx
@@ -347,12 +347,15 @@ function buildMeaningBullets(report: AlgorithmHealthReport): string[] {
     ];
   }
 
-  const ratioSummary =
-    report.summary.bigger > report.summary.smaller
-      ? 'More resolved neighbours are bigger than the target.'
-      : report.summary.bigger === report.summary.smaller
-        ? 'The resolved neighbour mix is balanced between larger and smaller artists.'
-        : 'More resolved neighbours are smaller than the target.';
+  let ratioSummary: string;
+  if (report.summary.bigger > report.summary.smaller) {
+    ratioSummary = 'More resolved neighbours are bigger than the target.';
+  } else if (report.summary.bigger === report.summary.smaller) {
+    ratioSummary =
+      'The resolved neighbour mix is balanced between larger and smaller artists.';
+  } else {
+    ratioSummary = 'More resolved neighbours are smaller than the target.';
+  }
 
   return [
     ratioSummary,


### PR DESCRIPTION
## Summary
Fixes 3 SonarCloud issues (MAJOR priority):
- Extract `title` computation to if/else in release page (S3358)
- Extract `ratioSummary` computation to if/else in AlgorithmHealthPanel (S3358)
- Split nested category ternary into separate conditionals in AdminProfileSidebar (S3358)

## SonarCloud Rules Addressed
- S3358: Nested ternary operations — extracted to if/else or split into separate conditionals

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (code quality fixes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code maintainability by restructuring conditional logic in metadata generation and component rendering layers.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->