### PR TITLE
fix: prefer globalThis over window (batch 11)

### DIFF
--- a/apps/web/components/atoms/SwipeToReveal.tsx
+++ b/apps/web/components/atoms/SwipeToReveal.tsx
@@ -149,12 +149,12 @@ export const SwipeToReveal = memo(function SwipeToReveal({
       return;
     }
 
-    const timeout = window.setTimeout(() => {
+    const timeout = globalThis.setTimeout(() => {
       setActionsVisible(false);
     }, 350);
 
     return () => {
-      window.clearTimeout(timeout);
+      globalThis.clearTimeout(timeout);
     };
   }, [isDragging, isOpen, offsetX]);
 

--- a/apps/web/components/features/profile/templates/PublicProfileTemplateV2.tsx
+++ b/apps/web/components/features/profile/templates/PublicProfileTemplateV2.tsx
@@ -136,7 +136,7 @@ export function PublicProfileTemplateV2({
     socialLinks.find(link => link.platform === 'venmo')?.url ?? null;
   const venmoUsername = extractVenmoUsername(venmoLink);
   const initialSource = useMemo(() => {
-    if (typeof window === 'undefined') {
+    if (typeof globalThis.window === 'undefined') {
       return null;
     }
 
@@ -164,7 +164,7 @@ export function PublicProfileTemplateV2({
   });
 
   const scrollToTourSection = useCallback(() => {
-    if (typeof window === 'undefined') {
+    if (typeof globalThis.window === 'undefined') {
       return;
     }
 
@@ -199,7 +199,7 @@ export function PublicProfileTemplateV2({
   }, [prefersReducedMotion]);
 
   const scrollToSubscribeSection = useCallback(() => {
-    if (typeof window === 'undefined') {
+    if (typeof globalThis.window === 'undefined') {
       return;
     }
 
@@ -215,7 +215,7 @@ export function PublicProfileTemplateV2({
   }, [prefersReducedMotion]);
 
   const scrollToAboutSection = useCallback(() => {
-    if (typeof window === 'undefined') {
+    if (typeof globalThis.window === 'undefined') {
       return;
     }
 
@@ -282,7 +282,7 @@ export function PublicProfileTemplateV2({
   useEffect(() => applyRequestedMode(mode), [applyRequestedMode, mode]);
 
   useEffect(() => {
-    if (typeof window === 'undefined') {
+    if (typeof globalThis.window === 'undefined') {
       return;
     }
 
@@ -295,7 +295,7 @@ export function PublicProfileTemplateV2({
   }, [applyRequestedMode]);
 
   useEffect(() => {
-    if (typeof window === 'undefined') {
+    if (typeof globalThis.window === 'undefined') {
       return;
     }
 

--- a/apps/web/components/organisms/RightDrawer.tsx
+++ b/apps/web/components/organisms/RightDrawer.tsx
@@ -28,7 +28,7 @@ function hasOpenModalDialog() {
       '[role="dialog"][aria-modal="true"], [role="alertdialog"][aria-modal="true"]'
     )
   ).some(element => {
-    const style = window.getComputedStyle(element);
+    const style = globalThis.getComputedStyle(element);
     return (
       element.getAttribute('aria-hidden') !== 'true' &&
       style.display !== 'none' &&

--- a/apps/web/lib/tracking/consent.ts
+++ b/apps/web/lib/tracking/consent.ts
@@ -107,7 +107,7 @@ export function isTrackingAllowed(): boolean {
  * marketing: false = blocked.
  */
 export function isMarketingAllowed(): boolean {
-  if (typeof window === 'undefined') return false;
+  if (typeof globalThis.window === 'undefined') return false;
 
   if (isGPCEnabled() || isDNTEnabled()) return false;
 


### PR DESCRIPTION
## Summary
Fixes 10 SonarCloud issues (MINOR priority):
- Replace 6 `typeof window === 'undefined'` checks with `typeof globalThis.window === 'undefined'` in PublicProfileTemplateV2 and consent.ts
- Replace `window.setTimeout`/`clearTimeout` with `globalThis` equivalents in SwipeToReveal
- Replace `window.getComputedStyle` with `globalThis.getComputedStyle` in RightDrawer

## SonarCloud Rules Addressed
- S7764: Prefer `globalThis` over `window` — ensures compatibility across environments

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (global reference swap only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)