### PR TITLE
fix: resolve SonarCloud typeof, readonly props, push batching (batch 12)

### DIFF
--- a/apps/web/app/(dynamic)/playlists/[slug]/page.tsx
+++ b/apps/web/app/(dynamic)/playlists/[slug]/page.tsx
@@ -129,9 +129,9 @@ export async function generateMetadata({
 
 export default async function PlaylistPage({
   params,
-}: {
+}: Readonly<{
   params: Promise<{ slug: string }>;
-}) {
+}>) {
   const { slug } = await params;
   const playlist = await getPlaylist(slug);
   if (!playlist) notFound();

--- a/apps/web/app/(dynamic)/playlists/_components/PlaylistGrid.tsx
+++ b/apps/web/app/(dynamic)/playlists/_components/PlaylistGrid.tsx
@@ -15,10 +15,10 @@ export interface PlaylistCardData {
 export function PlaylistGrid({
   playlists,
   emptyMessage,
-}: {
+}: Readonly<{
   playlists: PlaylistCardData[];
   emptyMessage: React.ReactNode;
-}) {
+}>) {
   if (playlists.length === 0) {
     return (
       <div className='mt-16 text-center'>

--- a/apps/web/app/(dynamic)/playlists/genre/[genre]/page.tsx
+++ b/apps/web/app/(dynamic)/playlists/genre/[genre]/page.tsx
@@ -51,9 +51,9 @@ async function getPlaylistsByGenre(genre: string) {
 
 export default async function GenreHubPage({
   params,
-}: {
+}: Readonly<{
   params: Promise<{ genre: string }>;
-}) {
+}>) {
   const { genre } = await params;
   const decoded = decodeURIComponent(genre);
   const playlists = await getPlaylistsByGenre(genre);

--- a/apps/web/app/(dynamic)/playlists/mood/[mood]/page.tsx
+++ b/apps/web/app/(dynamic)/playlists/mood/[mood]/page.tsx
@@ -45,9 +45,9 @@ async function getPlaylistsByMood(mood: string) {
 
 export default async function MoodHubPage({
   params,
-}: {
+}: Readonly<{
   params: Promise<{ mood: string }>;
-}) {
+}>) {
   const { mood } = await params;
   const decoded = decodeURIComponent(mood);
   const playlists = await getPlaylistsByMood(mood);

--- a/apps/web/app/app/(shell)/admin/playlists/page.tsx
+++ b/apps/web/app/app/(shell)/admin/playlists/page.tsx
@@ -214,9 +214,9 @@ const TAB_OPTIONS = [
 
 export default async function AdminPlaylistsPage({
   searchParams,
-}: {
+}: Readonly<{
   searchParams: Promise<{ tab?: string }>;
-}) {
+}>) {
   const { tab = 'pending' } = await searchParams;
   const currentTab = (
     ['pending', 'published', 'rejected'].includes(tab) ? tab : 'pending'

--- a/apps/web/components/features/profile/templates/PublicProfileTemplateV2.tsx
+++ b/apps/web/components/features/profile/templates/PublicProfileTemplateV2.tsx
@@ -136,7 +136,7 @@ export function PublicProfileTemplateV2({
     socialLinks.find(link => link.platform === 'venmo')?.url ?? null;
   const venmoUsername = extractVenmoUsername(venmoLink);
   const initialSource = useMemo(() => {
-    if (typeof globalThis.window === 'undefined') {
+    if (globalThis.window === undefined) {
       return null;
     }
 
@@ -164,7 +164,7 @@ export function PublicProfileTemplateV2({
   });
 
   const scrollToTourSection = useCallback(() => {
-    if (typeof globalThis.window === 'undefined') {
+    if (globalThis.window === undefined) {
       return;
     }
 
@@ -199,7 +199,7 @@ export function PublicProfileTemplateV2({
   }, [prefersReducedMotion]);
 
   const scrollToSubscribeSection = useCallback(() => {
-    if (typeof globalThis.window === 'undefined') {
+    if (globalThis.window === undefined) {
       return;
     }
 
@@ -215,7 +215,7 @@ export function PublicProfileTemplateV2({
   }, [prefersReducedMotion]);
 
   const scrollToAboutSection = useCallback(() => {
-    if (typeof globalThis.window === 'undefined') {
+    if (globalThis.window === undefined) {
       return;
     }
 
@@ -282,7 +282,7 @@ export function PublicProfileTemplateV2({
   useEffect(() => applyRequestedMode(mode), [applyRequestedMode, mode]);
 
   useEffect(() => {
-    if (typeof globalThis.window === 'undefined') {
+    if (globalThis.window === undefined) {
       return;
     }
 
@@ -295,7 +295,7 @@ export function PublicProfileTemplateV2({
   }, [applyRequestedMode]);
 
   useEffect(() => {
-    if (typeof globalThis.window === 'undefined') {
+    if (globalThis.window === undefined) {
       return;
     }
 

--- a/apps/web/lib/spotify/scoring.ts
+++ b/apps/web/lib/spotify/scoring.ts
@@ -336,23 +336,17 @@ function buildReadyNextActions(
 
   if (verdict.label === 'Healthy') {
     actions.push(
-      'Use these stronger neighbours as playlist, collab, and audience targeting references.'
-    );
-    actions.push(
+      'Use these stronger neighbours as playlist, collab, and audience targeting references.',
       'Re-check after major releases or marketing spikes to confirm adjacency holds.'
     );
   } else if (verdict.label === 'Mixed') {
     actions.push(
-      'Aim for placement near slightly larger artists in the same genre lane.'
-    );
-    actions.push(
+      'Aim for placement near slightly larger artists in the same genre lane.',
       'Audit recent releases and metadata for sharper genre signaling.'
     );
   } else {
     actions.push(
-      'Prioritize adjacency with slightly larger artists instead of broad genre reach.'
-    );
-    actions.push(
+      'Prioritize adjacency with slightly larger artists instead of broad genre reach.',
       'Treat the current neighbourhood as a warning that discovery quality may be compounding downward.'
     );
   }

--- a/apps/web/lib/tracking/consent.ts
+++ b/apps/web/lib/tracking/consent.ts
@@ -107,7 +107,7 @@ export function isTrackingAllowed(): boolean {
  * marketing: false = blocked.
  */
 export function isMarketingAllowed(): boolean {
-  if (typeof globalThis.window === 'undefined') return false;
+  if (globalThis.window === undefined) return false;
 
   if (isGPCEnabled() || isDNTEnabled()) return false;
 


### PR DESCRIPTION
## Summary
Fixes 15 SonarCloud issues (MINOR priority):
- Replace `typeof globalThis.window === 'undefined'` with `globalThis.window === undefined` (7× S7741)
- Wrap inline component props with `Readonly<>` in 5 playlist pages (5× S6759)
- Batch consecutive `Array#push()` calls into single calls in scoring.ts (3× S7778)

## SonarCloud Rules Addressed
- S7741: Compare with `undefined` directly instead of using `typeof`
- S6759: Mark component props as read-only
- S7778: Do not call `Array#push()` multiple times

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (code quality fixes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced type safety in playlist and admin page components by applying stricter immutability constraints.
  * Streamlined window detection checks across profile and consent modules for consistency.
  * Consolidated repeated code patterns in action-building functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->