### PR TITLE
fix: extract type aliases for inline union types (batch 13)

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/actions.ts
@@ -256,8 +256,7 @@ function mapReleaseToViewModel(
     title: release.title,
     artistNames: release.artistNames,
     releaseDate: toISOStringOrNull(release.releaseDate) ?? undefined,
-    status:
-      (release.status as 'draft' | 'scheduled' | 'released') ?? 'released',
+    status: (release.status as ReleaseStatusValue) ?? 'released',
     revealDate: toISOStringOrNull(release.revealDate) ?? undefined,
     deletedAt: toISOStringOrNull(release.deletedAt) ?? undefined,
     artworkUrl: release.artworkUrl ?? undefined,
@@ -2253,9 +2252,9 @@ export async function revertReleaseArtwork(
   return { artworkUrl: originalArtworkUrl, originalArtworkUrl };
 }
 
-function determineReleaseStatus(
-  releaseDate: Date | null
-): 'draft' | 'scheduled' | 'released' {
+type ReleaseStatusValue = 'draft' | 'scheduled' | 'released';
+
+function determineReleaseStatus(releaseDate: Date | null): ReleaseStatusValue {
   if (!releaseDate) return 'draft';
   return releaseDate > new Date() ? 'scheduled' : 'released';
 }
@@ -2263,7 +2262,7 @@ function determineReleaseStatus(
 function computeRevealDate(
   formRevealDate: string | null,
   releaseDate: Date | null,
-  status: 'draft' | 'scheduled' | 'released'
+  status: ReleaseStatusValue
 ): Date | null {
   if (formRevealDate) return new Date(formRevealDate);
   if (!releaseDate || status !== 'scheduled') return null;

--- a/apps/web/components/providers/clerkAvailability.ts
+++ b/apps/web/components/providers/clerkAvailability.ts
@@ -8,6 +8,10 @@ const PRIVATE_IPV4_BLOCKS = [
   /^172\.(1[6-9]|2\d|3[0-1])\./,
 ] as const;
 
+type LocationLike =
+  | Pick<Location, 'hostname' | 'protocol'>
+  | Pick<URL, 'hostname' | 'protocol'>;
+
 interface HeaderReader {
   get(name: string): string | null;
 }
@@ -23,10 +27,7 @@ export function isMockPublishableKey(publishableKey: string): boolean {
 export function shouldBypassClerk(
   publishableKey: string | undefined,
   clerkMockFlag: string | undefined,
-  locationLike:
-    | Pick<Location, 'hostname' | 'protocol'>
-    | Pick<URL, 'hostname' | 'protocol'>
-    | undefined = globalThis.window === undefined
+  locationLike: LocationLike | undefined = globalThis.window === undefined
     ? undefined
     : globalThis.location
 ): boolean {
@@ -121,10 +122,7 @@ export function getRequestLocationFromHeaders(
 }
 
 export function shouldDisableClerkProxyForLocation(
-  locationLike:
-    | Pick<Location, 'hostname' | 'protocol'>
-    | Pick<URL, 'hostname' | 'protocol'>
-    | undefined
+  locationLike: LocationLike | undefined
 ): boolean {
   if (!locationLike) return false;
 
@@ -135,10 +133,7 @@ export function shouldDisableClerkProxyForLocation(
 }
 
 export function getClerkProxyUrl(
-  locationLike:
-    | Pick<Location, 'hostname' | 'protocol'>
-    | Pick<URL, 'hostname' | 'protocol'>
-    | undefined = globalThis.window === undefined
+  locationLike: LocationLike | undefined = globalThis.window === undefined
     ? undefined
     : globalThis.location
 ): string | undefined {

--- a/apps/web/lib/distribution/instagram-activation.ts
+++ b/apps/web/lib/distribution/instagram-activation.ts
@@ -52,7 +52,9 @@ interface ActivationSourceParams {
   } | null;
 }
 
-function coerceDate(value: Date | string | null | undefined): Date | null {
+type DateInput = Date | string | null | undefined;
+
+function coerceDate(value: DateInput): Date | null {
   if (!value) return null;
   const date = value instanceof Date ? value : new Date(value);
   return Number.isNaN(date.getTime()) ? null : date;


### PR DESCRIPTION
## Summary
Fixes 3 SonarCloud issues (MINOR priority):
- Add `ReleaseStatusValue` type alias in releases/actions.ts, replacing 3 inline occurrences
- Add `DateInput` type alias in instagram-activation.ts
- Add `LocationLike` type alias in clerkAvailability.ts, replacing 3 inline occurrences

## SonarCloud Rules Addressed
- S4323: Replace inline union type with a type alias

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (type alias extraction only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type consistency and code organization to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->