### PR TITLE
fix: reduce cognitive complexity in onboarding and task updates (batch 16)

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
@@ -413,6 +413,75 @@ export async function createTask(data: CreateTaskInput): Promise<TaskView> {
   return createTaskForProfile(profileId, data);
 }
 
+function resolveCompletedAt(
+  data: UpdateTaskInput,
+  existingTask: typeof tasks.$inferSelect,
+  nextStatus: string
+): Date | null | undefined {
+  if (data.completedAt !== undefined) return data.completedAt;
+  if (data.status === undefined) return existingTask.completedAt;
+  return nextStatus === 'done'
+    ? (existingTask.completedAt ?? new Date())
+    : null;
+}
+
+function mergeTaskFields(
+  data: UpdateTaskInput,
+  existingTask: typeof tasks.$inferSelect,
+  completedAt: Date | null | undefined,
+  nextStatus: typeof tasks.$inferSelect.status
+) {
+  return {
+    title: data.title ?? existingTask.title,
+    description:
+      data.description === undefined
+        ? existingTask.description
+        : data.description,
+    status: nextStatus,
+    priority: data.priority ?? existingTask.priority,
+    assigneeKind: data.assigneeKind ?? existingTask.assigneeKind,
+    assigneeUserId:
+      data.assigneeUserId === undefined
+        ? existingTask.assigneeUserId
+        : data.assigneeUserId,
+    agentType:
+      data.agentType === undefined ? existingTask.agentType : data.agentType,
+    agentStatus: data.agentStatus ?? existingTask.agentStatus,
+    agentInput:
+      data.agentInput === undefined ? existingTask.agentInput : data.agentInput,
+    agentOutput:
+      data.agentOutput === undefined
+        ? existingTask.agentOutput
+        : data.agentOutput,
+    agentError:
+      data.agentError === undefined ? existingTask.agentError : data.agentError,
+    releaseId:
+      data.releaseId === undefined ? existingTask.releaseId : data.releaseId,
+    parentTaskId:
+      data.parentTaskId === undefined
+        ? existingTask.parentTaskId
+        : data.parentTaskId,
+    category:
+      data.category === undefined ? existingTask.category : data.category,
+    dueAt: data.dueAt === undefined ? existingTask.dueAt : data.dueAt,
+    scheduledFor:
+      data.scheduledFor === undefined
+        ? existingTask.scheduledFor
+        : data.scheduledFor,
+    startedAt:
+      data.startedAt === undefined ? existingTask.startedAt : data.startedAt,
+    completedAt,
+    position: data.position ?? existingTask.position,
+    sourceTemplateId:
+      data.sourceTemplateId === undefined
+        ? existingTask.sourceTemplateId
+        : data.sourceTemplateId,
+    metadata:
+      data.metadata === undefined ? existingTask.metadata : data.metadata,
+    updatedAt: new Date(),
+  };
+}
+
 export async function updateTask(
   taskId: string,
   data: UpdateTaskInput
@@ -424,71 +493,11 @@ export async function updateTask(
   await assertReleaseAccess(profileId, data.releaseId);
 
   const nextStatus = data.status ?? existingTask.status;
-  let completedAt: Date | null | undefined;
-  if (data.completedAt !== undefined) {
-    completedAt = data.completedAt;
-  } else if (data.status === undefined) {
-    completedAt = existingTask.completedAt;
-  } else {
-    completedAt =
-      nextStatus === 'done' ? (existingTask.completedAt ?? new Date()) : null;
-  }
+  const completedAt = resolveCompletedAt(data, existingTask, nextStatus);
 
   const [updated] = await db
     .update(tasks)
-    .set({
-      title: data.title ?? existingTask.title,
-      description:
-        data.description === undefined
-          ? existingTask.description
-          : data.description,
-      status: nextStatus,
-      priority: data.priority ?? existingTask.priority,
-      assigneeKind: data.assigneeKind ?? existingTask.assigneeKind,
-      assigneeUserId:
-        data.assigneeUserId === undefined
-          ? existingTask.assigneeUserId
-          : data.assigneeUserId,
-      agentType:
-        data.agentType === undefined ? existingTask.agentType : data.agentType,
-      agentStatus: data.agentStatus ?? existingTask.agentStatus,
-      agentInput:
-        data.agentInput === undefined
-          ? existingTask.agentInput
-          : data.agentInput,
-      agentOutput:
-        data.agentOutput === undefined
-          ? existingTask.agentOutput
-          : data.agentOutput,
-      agentError:
-        data.agentError === undefined
-          ? existingTask.agentError
-          : data.agentError,
-      releaseId:
-        data.releaseId === undefined ? existingTask.releaseId : data.releaseId,
-      parentTaskId:
-        data.parentTaskId === undefined
-          ? existingTask.parentTaskId
-          : data.parentTaskId,
-      category:
-        data.category === undefined ? existingTask.category : data.category,
-      dueAt: data.dueAt === undefined ? existingTask.dueAt : data.dueAt,
-      scheduledFor:
-        data.scheduledFor === undefined
-          ? existingTask.scheduledFor
-          : data.scheduledFor,
-      startedAt:
-        data.startedAt === undefined ? existingTask.startedAt : data.startedAt,
-      completedAt,
-      position: data.position ?? existingTask.position,
-      sourceTemplateId:
-        data.sourceTemplateId === undefined
-          ? existingTask.sourceTemplateId
-          : data.sourceTemplateId,
-      metadata:
-        data.metadata === undefined ? existingTask.metadata : data.metadata,
-      updatedAt: new Date(),
-    })
+    .set(mergeTaskFields(data, existingTask, completedAt, nextStatus))
     .where(eq(tasks.id, taskId))
     .returning();
 

--- a/apps/web/lib/onboarding/return-to.ts
+++ b/apps/web/lib/onboarding/return-to.ts
@@ -19,6 +19,30 @@ const ALLOWED_POST_CHECKOUT_ROUTES: ReadonlyArray<{
   requiredParams?: Record<string, string>;
 }> = [{ pathname: APP_ROUTES.CHAT, requiredParams: { from: 'onboarding' } }];
 
+function matchPostCheckoutRoute(parsed: URL): string | null {
+  for (const route of ALLOWED_POST_CHECKOUT_ROUTES) {
+    if (parsed.pathname !== route.pathname) continue;
+    if (route.requiredParams) {
+      const allMatch = Object.entries(route.requiredParams).every(
+        ([key, value]) => parsed.searchParams.get(key) === value
+      );
+      if (!allMatch) continue;
+    }
+    // Rebuild from allowlist to prevent injection
+    const url = new URL(route.pathname, 'https://jovie.invalid');
+    if (route.requiredParams) {
+      for (const [key, value] of Object.entries(route.requiredParams)) {
+        url.searchParams.set(key, value);
+      }
+    }
+    // Preserve allowed extra params (panel)
+    const panel = parsed.searchParams.get('panel');
+    if (panel) url.searchParams.set('panel', panel);
+    return `${url.pathname}?${url.searchParams.toString()}`;
+  }
+  return null;
+}
+
 export function normalizeOnboardingReturnTo(raw: unknown): string {
   if (typeof raw !== 'string') {
     return DEFAULT_ONBOARDING_RETURN_TO;
@@ -43,26 +67,5 @@ export function normalizeOnboardingReturnTo(raw: unknown): string {
 
   // Allow post-checkout destinations (e.g. /app/chat?from=onboarding)
   const parsed = new URL(trimmed, 'https://jovie.invalid');
-  for (const route of ALLOWED_POST_CHECKOUT_ROUTES) {
-    if (parsed.pathname !== route.pathname) continue;
-    if (route.requiredParams) {
-      const allMatch = Object.entries(route.requiredParams).every(
-        ([key, value]) => parsed.searchParams.get(key) === value
-      );
-      if (!allMatch) continue;
-    }
-    // Rebuild from allowlist to prevent injection
-    const url = new URL(route.pathname, 'https://jovie.invalid');
-    if (route.requiredParams) {
-      for (const [key, value] of Object.entries(route.requiredParams)) {
-        url.searchParams.set(key, value);
-      }
-    }
-    // Preserve allowed extra params (panel)
-    const panel = parsed.searchParams.get('panel');
-    if (panel) url.searchParams.set('panel', panel);
-    return `${url.pathname}?${url.searchParams.toString()}`;
-  }
-
-  return DEFAULT_ONBOARDING_RETURN_TO;
+  return matchPostCheckoutRoute(parsed) ?? DEFAULT_ONBOARDING_RETURN_TO;
 }


### PR DESCRIPTION
## Summary
Fixes 2 SonarCloud CRITICAL issues:
- Extract `matchPostCheckoutRoute` helper from `normalizeOnboardingReturnTo` (S3776, complexity 21→~7)
- Extract `resolveCompletedAt` and `mergeTaskFields` helpers from `updateTask` (S3776, complexity 19→~2)

## SonarCloud Rules Addressed
- S3776: Cognitive Complexity — extracted helper functions to reduce nesting and conditional density

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (refactoring only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization and maintainability through internal restructuring of task management and checkout flow logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->