### PR TITLE
fix: reduce cognitive complexity of Clerk test user provisioning (batch 18)

### DIFF
--- a/apps/web/lib/testing/test-user-provision.server.ts
+++ b/apps/web/lib/testing/test-user-provision.server.ts
@@ -318,25 +318,39 @@ export async function ensureClerkTestUser({
       throw error;
     }
 
-    let racedUser: { id: string } | undefined;
-    try {
-      const racedUsers = await clerk.users.getUserList({
-        emailAddress: [normalizedEmail],
-      });
-      racedUser = racedUsers.data[0];
-    } catch (raceError) {
-      if (isClerkUnauthorizedError(raceError) && fallbackClerkId) {
-        return fallbackClerkId;
-      }
-      throw raceError;
-    }
-
-    if (!racedUser) {
-      throw error;
-    }
-
-    return racedUser.id;
+    return resolveRacedClerkUser(
+      clerk,
+      normalizedEmail,
+      fallbackClerkId,
+      error
+    );
   }
+}
+
+async function resolveRacedClerkUser(
+  clerk: ReturnType<typeof createClerkClient>,
+  normalizedEmail: string,
+  fallbackClerkId: string | undefined,
+  originalError: unknown
+): Promise<string> {
+  let racedUser: { id: string } | undefined;
+  try {
+    const racedUsers = await clerk.users.getUserList({
+      emailAddress: [normalizedEmail],
+    });
+    racedUser = racedUsers.data[0];
+  } catch (raceError) {
+    if (isClerkUnauthorizedError(raceError) && fallbackClerkId) {
+      return fallbackClerkId;
+    }
+    throw raceError;
+  }
+
+  if (!racedUser) {
+    throw originalError;
+  }
+
+  return racedUser.id;
 }
 
 export async function ensureUserRecord(


### PR DESCRIPTION
## Summary
Fixes 1 SonarCloud CRITICAL issue:
- Extract `resolveRacedClerkUser` helper from `ensureClerkTestUser` (S3776, complexity 21→~12)

## SonarCloud Rules Addressed
- S3776: Cognitive Complexity — extracted deeply nested retry logic into helper

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (refactoring only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal test infrastructure code organization and maintainability through code restructuring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->