### PR TITLE
fix: reduce cognitive complexity of FAL scrape (batch 19)

### DIFF
--- a/apps/web/app/api/spotify/fal-analysis/route.ts
+++ b/apps/web/app/api/spotify/fal-analysis/route.ts
@@ -168,6 +168,49 @@ type FalNameResult =
       warnings: string[];
     };
 
+function extractArtistNamesFromHtml(html: string): string[] {
+  const names: string[] = [];
+
+  // Try extracting from JSON-LD or embedded data
+  const artistNamePattern =
+    /"name"\s*:\s*"([^"]+)"\s*,\s*"@type"\s*:\s*"MusicGroup"/g;
+  let match = artistNamePattern.exec(html);
+  while (match) {
+    names.push(match[1]);
+    match = artistNamePattern.exec(html);
+  }
+
+  // Fallback: extract from embedded script data
+  if (names.length === 0) {
+    const dataPattern = /"artists":\s*\[([^\]]*)\]/g;
+    let dataMatch = dataPattern.exec(html);
+    while (dataMatch) {
+      const nameMatches = dataMatch[1].matchAll(/"name"\s*:\s*"([^"]+)"/g);
+      for (const nm of nameMatches) {
+        if (nm[1] && !names.includes(nm[1])) {
+          names.push(nm[1]);
+        }
+      }
+      dataMatch = dataPattern.exec(html);
+    }
+  }
+
+  // Final fallback: extract from test ID patterns
+  if (names.length === 0) {
+    const simplePattern = /data-testid="artist-link"[^>]*>([^<]+)</g;
+    let simpleMatch = simplePattern.exec(html);
+    while (simpleMatch) {
+      const name = simpleMatch[1].trim();
+      if (name && !names.includes(name)) {
+        names.push(name);
+      }
+      simpleMatch = simplePattern.exec(html);
+    }
+  }
+
+  return names;
+}
+
 async function scrapeFansAlsoLike(artistId: string): Promise<FalNameResult> {
   try {
     const response = await serverFetch(
@@ -210,48 +253,9 @@ async function scrapeFansAlsoLike(artistId: string): Promise<FalNameResult> {
       };
     }
 
-    const names: string[] = [];
-
-    // Try extracting from JSON-LD or embedded data
-    const artistNamePattern =
-      /"name"\s*:\s*"([^"]+)"\s*,\s*"@type"\s*:\s*"MusicGroup"/g;
-    let match = artistNamePattern.exec(html);
-    while (match) {
-      names.push(match[1]);
-      match = artistNamePattern.exec(html);
-    }
-
-    // Fallback: extract from embedded script data
-    if (names.length === 0) {
-      const dataPattern = /"artists":\s*\[([^\]]*)\]/g;
-      let dataMatch = dataPattern.exec(html);
-      while (dataMatch) {
-        const nameMatches = dataMatch[1].matchAll(/"name"\s*:\s*"([^"]+)"/g);
-        for (const nm of nameMatches) {
-          if (nm[1] && !names.includes(nm[1])) {
-            names.push(nm[1]);
-          }
-        }
-        dataMatch = dataPattern.exec(html);
-      }
-    }
-
-    // Final fallback: extract from test ID patterns
-    if (names.length === 0) {
-      const simplePattern = /data-testid="artist-link"[^>]*>([^<]+)</g;
-      let simpleMatch = simplePattern.exec(html);
-      while (simpleMatch) {
-        const name = simpleMatch[1].trim();
-        if (name && !names.includes(name)) {
-          names.push(name);
-        }
-        simpleMatch = simplePattern.exec(html);
-      }
-    }
-
     return {
       status: 'ready',
-      names,
+      names: extractArtistNamesFromHtml(html),
     };
   } catch (error) {
     await captureError('[FAL Scrape] Error', error, {


### PR DESCRIPTION
## Summary
Fixes 1 SonarCloud CRITICAL issue:
- Extract `extractArtistNamesFromHtml` helper from `scrapeFansAlsoLike` (S3776, complexity 22→~6)
- Separates HTML parsing/regex logic from HTTP fetching and error handling

## SonarCloud Rules Addressed
- S3776: Cognitive Complexity — extracted HTML parsing function

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (refactoring only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for better maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->