### PR TITLE
fix(perf): stop creator prefetch leaks

### DIFF
--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
@@ -693,6 +693,7 @@ export const DashboardAudienceTableUnified = memo(
                     description={emptyStateDescription}
                     action={emptyStatePrimaryAction}
                     secondaryAction={emptyStateSecondaryAction}
+                    testId='dashboard-audience-empty-state'
                   />
                 ) : (
                   <>
@@ -722,6 +723,7 @@ export const DashboardAudienceTableUnified = memo(
                             description={emptyStateDescription}
                             action={emptyStatePrimaryAction}
                             secondaryAction={emptyStateSecondaryAction}
+                            testId='dashboard-audience-empty-state'
                           />
                         }
                         getRowId={row => row.id}

--- a/apps/web/components/features/profile/artist-contacts-button/ArtistContactsButton.tsx
+++ b/apps/web/components/features/profile/artist-contacts-button/ArtistContactsButton.tsx
@@ -64,7 +64,7 @@ export function ArtistContactsButton({
       className='border border-subtle/50 bg-transparent text-secondary-token hover:border-subtle hover:bg-surface-1 hover:text-primary-token'
       asChild
     >
-      <Link href={`/${artistHandle}?mode=contact`}>
+      <Link href={`/${artistHandle}?mode=contact`} prefetch={false}>
         <Mail className='h-4 w-4' aria-hidden='true' />
       </Link>
     </CircleIconButton>

--- a/apps/web/components/features/profile/artist-notifications-cta/ArtistNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ArtistNotificationsCTA.tsx
@@ -46,7 +46,7 @@ function ListenNowCTA({
     return (
       <Link
         href={listenHref}
-        prefetch
+        prefetch={false}
         className={subscriptionPrimaryLinkClassName}
       >
         Listen Now
@@ -57,7 +57,7 @@ function ListenNowCTA({
   return (
     <Link
       href={listenHref}
-      prefetch
+      prefetch={false}
       className={subscriptionPrimaryLinkClassName}
     >
       Listen Now

--- a/apps/web/components/features/profile/artist-notifications-cta/shared.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/shared.tsx
@@ -296,7 +296,7 @@ export function SubscriptionSuccess({
         {handle ? (
           <Link
             href={`/${handle}?mode=listen`}
-            prefetch
+            prefetch={false}
             className={subscriptionPrimaryLinkClassName}
           >
             Listen Now
@@ -321,7 +321,7 @@ export function SubscriptionSuccess({
       {handle ? (
         <Link
           href={`/${handle}?mode=listen`}
-          prefetch
+          prefetch={false}
           className={subscriptionPrimaryLinkClassName}
         >
           Listen Now

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -598,6 +598,7 @@ export function ProfileCompactTemplate({
                 >
                   <Link
                     href={APP_ROUTES.ARTIST_PROFILES}
+                    prefetch={false}
                     aria-label='Create your artist profile on Jovie'
                     className='rounded-full opacity-45 drop-shadow-[0_1px_4px_rgba(0,0,0,0.4)] transition-opacity duration-150 hover:opacity-70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
                   >
@@ -629,6 +630,7 @@ export function ProfileCompactTemplate({
                     <Link
                       data-testid='profile-identity-link'
                       href={profileHref}
+                      prefetch={false}
                       aria-label={`Go to ${artist.name}'s profile`}
                       className='inline-flex min-w-0 items-center gap-1.5 rounded-md text-[34px] font-[590] leading-[1.06] tracking-[-0.02em] text-white [text-shadow:0_1px_12px_rgba(0,0,0,0.4)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
                     >

--- a/apps/web/components/organisms/EmptyState.tsx
+++ b/apps/web/components/organisms/EmptyState.tsx
@@ -23,6 +23,7 @@ type PrimaryAction =
       rel?: string;
       variant?: ButtonProps['variant'];
       ariaLabel?: string;
+      prefetch?: boolean;
       /** Keyboard shortcut to display (e.g., "N then I" or "Ctrl+N") */
       shortcut?: string;
     };
@@ -34,6 +35,7 @@ type SecondaryAction =
       target?: React.HTMLAttributeAnchorTarget;
       rel?: string;
       ariaLabel?: string;
+      prefetch?: boolean;
     }
   | {
       label: string;
@@ -138,6 +140,7 @@ export function EmptyState({
         <Button asChild variant={action.variant ?? 'primary'} size={buttonSize}>
           <Link
             href={action.href}
+            prefetch={action.prefetch ?? false}
             target={action.target}
             rel={action.rel}
             aria-label={action.ariaLabel ?? action.label}
@@ -168,6 +171,7 @@ export function EmptyState({
         <Button asChild variant='outline' size={buttonSize}>
           <Link
             href={secondaryAction.href}
+            prefetch={secondaryAction.prefetch ?? false}
             target={secondaryAction.target}
             rel={secondaryAction.rel}
             aria-label={secondaryAction.ariaLabel ?? secondaryAction.label}

--- a/apps/web/scripts/performance-route-manifest.ts
+++ b/apps/web/scripts/performance-route-manifest.ts
@@ -831,7 +831,12 @@ const CREATOR_SHELL_ROUTES = [
     requiresAuth: true,
     warmupStrategy: 'authenticated-route',
     measureMode: 'page-load',
-    readySelectors: { content: ['[data-testid="dashboard-audience-client"]'] },
+    readySelectors: {
+      content: [
+        '[data-testid="dashboard-audience-client"]',
+        '[data-testid="dashboard-audience-empty-state"]',
+      ],
+    },
     timings: [
       { metric: 'first-contentful-paint', budget: 1800 },
       { metric: 'largest-contentful-paint', budget: 3000 },


### PR DESCRIPTION
## Summary
- stop creator dashboard/profile surfaces from prefetching unrelated routes
- expose the audience empty state via a stable perf selector
- tighten the creator-audience perf manifest expectation

## Verification
- doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web exec vitest run scripts/performance-route-manifest.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable link prefetching support in empty state components.

* **Performance Improvements**
  * Disabled automatic link prefetching on artist contacts, notifications, and profile links to reduce unnecessary resource loading.
  * Enhanced performance monitoring to track empty state component loading times.

* **Testing**
  * Added test identifiers for improved monitoring of dashboard audience empty states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->