### PR TITLE
fix: reduce cognitive complexity of ChatPageClient (batch 20)

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -99,6 +99,74 @@ function ChatTitleBadge({ title }: { readonly title: string }) {
   );
 }
 
+interface ChatProfileFallbackProps {
+  readonly needsOnboarding: boolean;
+  readonly dashboardLoadError: unknown;
+  readonly isProfileSetupRace: boolean;
+  readonly canAutoRetry: boolean;
+  readonly autoRetryCount: number;
+  readonly onRetry: () => void;
+}
+
+function ChatProfileFallback({
+  needsOnboarding,
+  dashboardLoadError,
+  isProfileSetupRace,
+  canAutoRetry,
+  autoRetryCount,
+  onRetry,
+}: ChatProfileFallbackProps) {
+  if (needsOnboarding && !dashboardLoadError) {
+    return (
+      <ChatWorkspaceSurface>
+        <div className='flex h-full items-center justify-center p-6'>
+          <ContentSurfaceCard className='flex max-w-sm flex-col items-center gap-3 px-6 py-8 text-center'>
+            <LoadingSpinner size='lg' tone='muted' />
+            <p className='text-sm text-secondary-token'>
+              Taking you to onboarding…
+            </p>
+          </ContentSurfaceCard>
+        </div>
+      </ChatWorkspaceSurface>
+    );
+  }
+
+  const profileMessage = isProfileSetupRace
+    ? 'Finishing your dashboard setup…'
+    : 'We hit a problem loading your profile. Please retry in a moment.';
+
+  return (
+    <ChatWorkspaceSurface>
+      <div className='flex h-full items-center justify-center p-6'>
+        <ContentSurfaceCard className='flex max-w-sm flex-col items-center gap-3 px-6 py-8 text-center'>
+          {isProfileSetupRace ? (
+            <LoadingSpinner size='lg' tone='muted' />
+          ) : (
+            <AlertCircle className='h-8 w-8 text-tertiary-token' />
+          )}
+          <p className='text-sm text-secondary-token'>{profileMessage}</p>
+          {isProfileSetupRace && canAutoRetry && (
+            <p className='text-xs text-tertiary-token'>
+              Retrying automatically in 3 seconds ({autoRetryCount + 1}/3)…
+            </p>
+          )}
+          {!isProfileSetupRace && (
+            <Button
+              onClick={onRetry}
+              variant='secondary'
+              size='sm'
+              className='gap-2'
+            >
+              <RefreshCw className='h-4 w-4' />
+              Retry
+            </Button>
+          )}
+        </ContentSurfaceCard>
+      </div>
+    </ChatWorkspaceSurface>
+  );
+}
+
 export function ChatPageClient({
   conversationId,
   isFirstSession = false,
@@ -567,54 +635,15 @@ export function ChatPageClient({
   ]);
 
   if (!activeProfile) {
-    if (needsOnboarding && !dashboardLoadError) {
-      return (
-        <ChatWorkspaceSurface>
-          <div className='flex h-full items-center justify-center p-6'>
-            <ContentSurfaceCard className='flex max-w-sm flex-col items-center gap-3 px-6 py-8 text-center'>
-              <LoadingSpinner size='lg' tone='muted' />
-              <p className='text-sm text-secondary-token'>
-                Taking you to onboarding…
-              </p>
-            </ContentSurfaceCard>
-          </div>
-        </ChatWorkspaceSurface>
-      );
-    }
-
-    const profileMessage = isProfileSetupRace
-      ? 'Finishing your dashboard setup…'
-      : 'We hit a problem loading your profile. Please retry in a moment.';
-
     return (
-      <ChatWorkspaceSurface>
-        <div className='flex h-full items-center justify-center p-6'>
-          <ContentSurfaceCard className='flex max-w-sm flex-col items-center gap-3 px-6 py-8 text-center'>
-            {isProfileSetupRace ? (
-              <LoadingSpinner size='lg' tone='muted' />
-            ) : (
-              <AlertCircle className='h-8 w-8 text-tertiary-token' />
-            )}
-            <p className='text-sm text-secondary-token'>{profileMessage}</p>
-            {isProfileSetupRace && canAutoRetry && (
-              <p className='text-xs text-tertiary-token'>
-                Retrying automatically in 3 seconds ({autoRetryCount + 1}/3)…
-              </p>
-            )}
-            {!isProfileSetupRace && (
-              <Button
-                onClick={() => router.refresh()}
-                variant='secondary'
-                size='sm'
-                className='gap-2'
-              >
-                <RefreshCw className='h-4 w-4' />
-                Retry
-              </Button>
-            )}
-          </ContentSurfaceCard>
-        </div>
-      </ChatWorkspaceSurface>
+      <ChatProfileFallback
+        needsOnboarding={needsOnboarding}
+        dashboardLoadError={dashboardLoadError}
+        isProfileSetupRace={isProfileSetupRace}
+        canAutoRetry={canAutoRetry}
+        autoRetryCount={autoRetryCount}
+        onRetry={() => router.refresh()}
+      />
     );
   }
 


### PR DESCRIPTION
## Summary
Fixes a SonarCloud CRITICAL cognitive-complexity issue:

- `typescript:S3776` — `ChatPageClient` at `apps/web/app/app/(shell)/chat/ChatPageClient.tsx:102` was at complexity 16 (allowed: 15).

The `!activeProfile` fallback render (onboarding redirect spinner, profile-setup-race vs. load-failure messaging, auto-retry copy, and manual retry button) was extracted into a standalone `ChatProfileFallback` component. This removes several nested conditional-JSX branches from the parent, dropping its cognitive complexity below the Sonar threshold. No behavior changes.

## SonarCloud Rules Addressed
- S3776: Cognitive Complexity of functions should not be too high

## Test plan
- [x] TypeScript compiles (`pnpm --filter web typecheck`)
- [x] Biome check passes
- [x] ESLint passes
- [x] No behavior changes (refactor only — extracted the identical JSX sub-tree into a sibling component)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for chat profile handling to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->