### PR TITLE
fix: reduce cognitive complexity of lead discovery (batch 20)

### DIFF
--- a/apps/web/lib/leads/discovery.ts
+++ b/apps/web/lib/leads/discovery.ts
@@ -269,6 +269,47 @@ async function shouldSkipSeenSearchResult(
   return false;
 }
 
+async function deduplicateSearchResults(
+  results: Awaited<ReturnType<typeof searchGoogleCSE>>,
+  query: string,
+  currentOffset: number
+): Promise<{ candidates: DiscoveryCandidate[]; duplicatesSkipped: number }> {
+  let duplicatesSkipped = 0;
+  const candidatesByHandle = new Map<string, DiscoveryCandidate>();
+
+  for (const [index, item] of results.entries()) {
+    if (!isLinktreeUrl(item.link)) continue;
+
+    const handle = extractLinktreeHandle(item.link);
+    if (!handle) continue;
+
+    const skipSeen = await shouldSkipSeenSearchResult(
+      query,
+      item.link,
+      currentOffset + index
+    );
+    if (skipSeen) {
+      duplicatesSkipped++;
+      continue;
+    }
+
+    candidatesByHandle.set(handle, {
+      linktreeHandle: handle,
+      linktreeUrl: `https://linktr.ee/${handle}`,
+      discoverySource: 'google_cse',
+      discoveryQuery: query,
+      sourcePlatform: 'linktree',
+      sourceHandle: handle,
+      sourceUrl: `https://linktr.ee/${handle}`,
+    });
+  }
+
+  return {
+    candidates: Array.from(candidatesByHandle.values()),
+    duplicatesSkipped,
+  };
+}
+
 /**
  * Runs one discovery cycle: picks keywords, searches Google CSE, inserts new leads.
  * Respects daily query budget and rotates through keywords via lastDiscoveryQueryIndex.
@@ -347,34 +388,12 @@ export async function runDiscovery(
       const results = await searchGoogleCSE(keyword.query, currentOffset);
       diagnostic.rawResultCount = results.length;
 
-      const candidatesByHandle = new Map<string, DiscoveryCandidate>();
-      for (const [index, item] of results.entries()) {
-        if (!isLinktreeUrl(item.link)) continue;
-
-        const handle = extractLinktreeHandle(item.link);
-        if (!handle) continue;
-
-        const skipSeen = await shouldSkipSeenSearchResult(
-          keyword.query,
-          item.link,
-          currentOffset + index
-        );
-        if (skipSeen) {
-          result.duplicatesSkipped++;
-          continue;
-        }
-
-        candidatesByHandle.set(handle, {
-          linktreeHandle: handle,
-          linktreeUrl: `https://linktr.ee/${handle}`,
-          discoverySource: 'google_cse',
-          discoveryQuery: keyword.query,
-          sourcePlatform: 'linktree',
-          sourceHandle: handle,
-          sourceUrl: `https://linktr.ee/${handle}`,
-        });
-      }
-      const candidates = Array.from(candidatesByHandle.values());
+      const { candidates, duplicatesSkipped } = await deduplicateSearchResults(
+        results,
+        keyword.query,
+        currentOffset
+      );
+      result.duplicatesSkipped += duplicatesSkipped;
       diagnostic.linktreeUrlsFound = candidates.length;
       result.candidatesProcessed += candidates.length;
 


### PR DESCRIPTION
## Summary
Fixes 1 SonarCloud CRITICAL issue:
- Extract `deduplicateSearchResults` helper from `runDiscovery` (S3776, complexity 24→~10)

## SonarCloud Rules Addressed
- S3776: Cognitive Complexity — extracted search result deduplication loop

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (refactoring only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved deduplication logic in the search discovery process to better filter and consolidate results from searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->