### PR TITLE
fix: prefer Number.parseInt over parseInt

### DIFF
--- a/apps/web/app/[username]/opengraph-image.tsx
+++ b/apps/web/app/[username]/opengraph-image.tsx
@@ -31,7 +31,7 @@ async function toDataUrl(imageUrl: string): Promise<string | null> {
 
     // Limit to 2MB to avoid memory pressure in edge runtime
     const contentLength = response.headers.get('content-length');
-    if (contentLength && parseInt(contentLength, 10) > 2 * 1024 * 1024) {
+    if (contentLength && Number.parseInt(contentLength, 10) > 2 * 1024 * 1024) {
       return null;
     }
 

--- a/apps/web/lib/youtube/metadata.ts
+++ b/apps/web/lib/youtube/metadata.ts
@@ -44,9 +44,9 @@ interface YouTubeApiResponse {
 function parseDuration(iso: string): number {
   const match = iso.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
   if (!match) return 0;
-  const hours = parseInt(match[1] || '0', 10);
-  const minutes = parseInt(match[2] || '0', 10);
-  const seconds = parseInt(match[3] || '0', 10);
+  const hours = Number.parseInt(match[1] || '0', 10);
+  const minutes = Number.parseInt(match[2] || '0', 10);
+  const seconds = Number.parseInt(match[3] || '0', 10);
   return hours * 3600 + minutes * 60 + seconds;
 }
 


### PR DESCRIPTION
## Summary
Fixes 4 SonarCloud MINOR issues:
- Qualify 3 `parseInt` calls in `apps/web/lib/youtube/metadata.ts` with `Number.`
- Qualify 1 `parseInt` call in `apps/web/app/[username]/opengraph-image.tsx` with `Number.`

## SonarCloud Rules Addressed
- S7773: Prefer `Number.parseInt` over `parseInt`

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes — pure namespace qualification (identical semantics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal numeric parsing operations for improved code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->