### PR TITLE
fix: prefer RegExp.exec over String.match

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
@@ -202,7 +202,7 @@ export function ReleaseTableWithTracks({
     return {
       getGroupKey: (release: ReleaseViewModel) => {
         if (!release.releaseDate) return 'Unknown';
-        const directYear = String(release.releaseDate).match(/^(\d{4})/)?.[1];
+        const directYear = /^(\d{4})/.exec(String(release.releaseDate))?.[1];
         if (directYear) {
           return directYear;
         }

--- a/apps/web/lib/youtube/metadata.ts
+++ b/apps/web/lib/youtube/metadata.ts
@@ -42,7 +42,7 @@ interface YouTubeApiResponse {
  * Parse ISO 8601 duration (e.g., "PT4M33S") to seconds.
  */
 function parseDuration(iso: string): number {
-  const match = iso.match(/PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/);
+  const match = /PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/.exec(iso);
   if (!match) return 0;
   const hours = parseInt(match[1] || '0', 10);
   const minutes = parseInt(match[2] || '0', 10);

--- a/apps/web/lib/youtube/parse.ts
+++ b/apps/web/lib/youtube/parse.ts
@@ -40,8 +40,8 @@ export function parseYouTubeUrl(url: string): ParsedYouTubeUrl | null {
     } else {
       candidate = parsed.searchParams.get('v');
       if (!candidate) {
-        const pathMatch = parsed.pathname.match(
-          /^\/(?:embed|shorts)\/([a-zA-Z0-9_-]{11})\/?$/
+        const pathMatch = /^\/(?:embed|shorts)\/([a-zA-Z0-9_-]{11})\/?$/.exec(
+          parsed.pathname
         );
         candidate = pathMatch?.[1] ?? null;
       }


### PR DESCRIPTION
## Summary
Fixes 3 SonarCloud MINOR issues by switching from `String.prototype.match` to `RegExp.prototype.exec`:
- `apps/web/lib/youtube/metadata.ts` — ISO 8601 duration parsing
- `apps/web/lib/youtube/parse.ts` — YouTube embed/shorts path parsing
- `apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx` — release year extraction

## SonarCloud Rules Addressed
- S6594: Use the `RegExp.exec()` method instead

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes — all affected regexes lack the `/g` flag, so `.match()` and `.exec()` return identical results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal regex matching implementation across release table grouping, YouTube metadata parsing, and video ID extraction for consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->