### PR TITLE
feat(marketing): add artist profile render surfaces

### DIFF
--- a/apps/web/app/(marketing)/artist-profiles/page.tsx
+++ b/apps/web/app/(marketing)/artist-profiles/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import { MarketingPageShell } from '@/components/marketing';
-import { Container } from '@/components/site/Container';
 import { APP_NAME, BASE_URL } from '@/constants/app';
 import { APP_ROUTES } from '@/constants/routes';
 import { HomeHero } from '@/features/home/HomeAdaptiveProfileStory';
@@ -12,7 +11,7 @@ import { HomeEngageBentoSection } from '@/features/home/HomeEngageBentoSection';
 import { FinalCallToAction } from '@/features/home/HomePageNarrative';
 import { HomeSpecChapter } from '@/features/home/HomeSpecChapter';
 import { HomeTrustSection } from '@/features/home/HomeTrustSection';
-import { HOMEPAGE_FINAL_CTA_CONTENT } from '@/features/home/home-page-content';
+import { HOME_FINAL_CTA_CONTENT } from '@/features/home/home-page-content';
 import { StickyPhoneTour } from '@/features/home/StickyPhoneTour';
 import { ARTIST_PROFILE_MODES } from './artist-profile-modes';
 
@@ -76,21 +75,18 @@ export default function ArtistProfilesPage() {
 
       {/* ── "One profile." interstitial ── */}
       <section className='homepage-chapter' style={{ textAlign: 'center' }}>
-        <Container size='homepage'>
+        <div className='mx-auto max-w-[1200px] px-5 sm:px-6 lg:px-8'>
           <h2 className='marketing-h1-linear mx-auto text-primary-token'>
             One profile.
           </h2>
-        </Container>
+        </div>
       </section>
 
       {/* ── All sections (ungated on artist-profiles) ── */}
       <HomeChapter1 />
       <HomeChapter2 />
       <HomeTrustSection />
-      <HomeAutoNotifySection />
-      <HomeEngageBentoSection />
       <HomeChapter3 />
-      <HomeSpecChapter />
 
       <StickyPhoneTour
         modes={ARTIST_PROFILE_MODES}
@@ -99,7 +95,11 @@ export default function ArtistProfilesPage() {
         artistHandle='timwhite'
       />
 
-      <FinalCallToAction content={HOMEPAGE_FINAL_CTA_CONTENT} />
+      <HomeAutoNotifySection />
+      <HomeEngageBentoSection />
+      <HomeSpecChapter />
+
+      <FinalCallToAction content={HOME_FINAL_CTA_CONTENT} />
     </MarketingPageShell>
   );
 }

--- a/apps/web/app/(marketing)/artist-profiles/page.tsx
+++ b/apps/web/app/(marketing)/artist-profiles/page.tsx
@@ -1,13 +1,12 @@
-import { Button } from '@jovie/ui';
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { MarketingPageShell } from '@/components/marketing';
 import { APP_NAME, BASE_URL } from '@/constants/app';
 import { APP_ROUTES } from '@/constants/routes';
+import { HomeHero } from '@/features/home/HomeAdaptiveProfileStory';
 import { FinalCallToAction } from '@/features/home/HomePageNarrative';
-import { HOME_FINAL_CTA_CONTENT } from '@/features/home/home-page-content';
+import { HOMEPAGE_FINAL_CTA_CONTENT } from '@/features/home/home-page-content';
 import { StickyPhoneTour } from '@/features/home/StickyPhoneTour';
-import { getCanonicalSurface } from '@/lib/canonical-surfaces';
+import { FEATURE_FLAGS } from '@/lib/feature-flags/shared';
 import { ARTIST_PROFILE_MODES } from './artist-profile-modes';
 
 export const revalidate = false;
@@ -62,63 +61,21 @@ export const metadata: Metadata = {
   },
 };
 
-const PUBLIC_PROFILE_REVIEW_ROUTE =
-  getCanonicalSurface('public-profile').reviewRoute;
-
 export default function ArtistProfilesPage() {
   return (
     <MarketingPageShell>
-      {/* ── Hero (text-only, phone tour is the visual proof) ── */}
-      <section
-        className='relative overflow-hidden pb-8 pt-[5.75rem] md:pb-12 md:pt-[6.25rem]'
-        aria-labelledby='artist-profiles-heading'
-      >
-        <div
-          aria-hidden='true'
-          className='pointer-events-none absolute inset-0'
-          style={{ background: 'var(--linear-hero-backdrop)' }}
+      <HomeHero />
+
+      {FEATURE_FLAGS.SHOW_HOMEPAGE_SECTIONS && (
+        <StickyPhoneTour
+          modes={ARTIST_PROFILE_MODES}
+          introTitle='Your profile adapts to what matters right now.'
+          introBadge='One link. Four modes.'
+          artistHandle='timwhite'
         />
-        <div className='hero-glow pointer-events-none absolute inset-x-0 top-0 h-[36rem]' />
+      )}
 
-        <div className='relative mx-auto max-w-[1200px] px-6 sm:px-8 lg:px-10'>
-          <div className='mx-auto max-w-[42rem] text-center'>
-            <h1
-              id='artist-profiles-heading'
-              className='marketing-h1-linear text-primary-token'
-            >
-              One link. Every release.
-            </h1>
-            <p className='mx-auto mt-5 max-w-[36rem] text-[17px] leading-[1.7] text-secondary-token sm:text-[18px]'>
-              Put jov.ie/username in your bio once. Before a drop it becomes a
-              countdown. On release day it becomes the best place to listen.
-              Between campaigns it keeps collecting fans, tickets, tips, and
-              business inquiries.
-            </p>
-
-            <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
-              <Button asChild size='lg'>
-                <Link href={APP_ROUTES.SIGNUP}>Claim your profile</Link>
-              </Button>
-              <Button asChild variant='ghost' size='lg'>
-                <Link href={PUBLIC_PROFILE_REVIEW_ROUTE}>
-                  See a live example
-                </Link>
-              </Button>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* ── Phone Tour (the centerpiece) ── */}
-      <StickyPhoneTour
-        modes={ARTIST_PROFILE_MODES}
-        introTitle='Your profile adapts to what matters right now.'
-        introBadge='One link. Four modes.'
-        artistHandle='timwhite'
-      />
-
-      {/* ── Final CTA ── */}
-      <FinalCallToAction content={HOME_FINAL_CTA_CONTENT} />
+      <FinalCallToAction content={HOMEPAGE_FINAL_CTA_CONTENT} />
     </MarketingPageShell>
   );
 }

--- a/apps/web/app/(marketing)/artist-profiles/page.tsx
+++ b/apps/web/app/(marketing)/artist-profiles/page.tsx
@@ -1,12 +1,19 @@
 import type { Metadata } from 'next';
 import { MarketingPageShell } from '@/components/marketing';
+import { Container } from '@/components/site/Container';
 import { APP_NAME, BASE_URL } from '@/constants/app';
 import { APP_ROUTES } from '@/constants/routes';
 import { HomeHero } from '@/features/home/HomeAdaptiveProfileStory';
+import { HomeAutoNotifySection } from '@/features/home/HomeAutoNotifySection';
+import { HomeChapter1 } from '@/features/home/HomeChapter1';
+import { HomeChapter2 } from '@/features/home/HomeChapter2';
+import { HomeChapter3 } from '@/features/home/HomeChapter3';
+import { HomeEngageBentoSection } from '@/features/home/HomeEngageBentoSection';
 import { FinalCallToAction } from '@/features/home/HomePageNarrative';
+import { HomeSpecChapter } from '@/features/home/HomeSpecChapter';
+import { HomeTrustSection } from '@/features/home/HomeTrustSection';
 import { HOMEPAGE_FINAL_CTA_CONTENT } from '@/features/home/home-page-content';
 import { StickyPhoneTour } from '@/features/home/StickyPhoneTour';
-import { FEATURE_FLAGS } from '@/lib/feature-flags/shared';
 import { ARTIST_PROFILE_MODES } from './artist-profile-modes';
 
 export const revalidate = false;
@@ -64,16 +71,33 @@ export const metadata: Metadata = {
 export default function ArtistProfilesPage() {
   return (
     <MarketingPageShell>
+      {/* ── Hero (same as homepage) ── */}
       <HomeHero />
 
-      {FEATURE_FLAGS.SHOW_HOMEPAGE_SECTIONS && (
-        <StickyPhoneTour
-          modes={ARTIST_PROFILE_MODES}
-          introTitle='Your profile adapts to what matters right now.'
-          introBadge='One link. Four modes.'
-          artistHandle='timwhite'
-        />
-      )}
+      {/* ── "One profile." interstitial ── */}
+      <section className='homepage-chapter' style={{ textAlign: 'center' }}>
+        <Container size='homepage'>
+          <h2 className='marketing-h1-linear mx-auto text-primary-token'>
+            One profile.
+          </h2>
+        </Container>
+      </section>
+
+      {/* ── All sections (ungated on artist-profiles) ── */}
+      <HomeChapter1 />
+      <HomeChapter2 />
+      <HomeTrustSection />
+      <HomeAutoNotifySection />
+      <HomeEngageBentoSection />
+      <HomeChapter3 />
+      <HomeSpecChapter />
+
+      <StickyPhoneTour
+        modes={ARTIST_PROFILE_MODES}
+        introTitle='Your profile adapts to what matters right now.'
+        introBadge='One link. Four modes.'
+        artistHandle='timwhite'
+      />
 
       <FinalCallToAction content={HOMEPAGE_FINAL_CTA_CONTENT} />
     </MarketingPageShell>

--- a/apps/web/app/(marketing)/layout.tsx
+++ b/apps/web/app/(marketing)/layout.tsx
@@ -1,4 +1,5 @@
 import localFont from 'next/font/local';
+import '../(home)/home.css';
 import './marketing-utilities.css';
 import { PublicPageShell } from '@/components/site/PublicPageShell';
 import { MarketingEnhancements } from '@/features/home/MarketingEnhancements';

--- a/apps/web/app/(marketing)/renders/page.tsx
+++ b/apps/web/app/(marketing)/renders/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { HOMEPAGE_PROFILE_SHOWCASE_STATES } from '@/features/home/homepage-profile-preview-fixture';
+import { MARKETING_RENDER_ROUTE_SURFACES } from '@/features/home/MarketingRenderSurface';
 
 const states = Object.keys(HOMEPAGE_PROFILE_SHOWCASE_STATES);
 
@@ -17,6 +18,23 @@ export default function RendersIndexPage() {
         Add <code>?chrome=true</code> to show Jovie branding and menu. Add{' '}
         <code>?width=375</code> to change render width.
       </p>
+
+      <div className='mt-8'>
+        <h2 className='text-sm font-medium text-primary-token'>
+          Named Surfaces
+        </h2>
+        <div className='mt-3 grid gap-2'>
+          {MARKETING_RENDER_ROUTE_SURFACES.map(surface => (
+            <Link
+              key={surface.id}
+              href={surface.href}
+              className='rounded-lg border border-white/8 bg-white/3 px-4 py-3 text-sm text-primary-token transition-colors hover:bg-white/6'
+            >
+              {surface.label}
+            </Link>
+          ))}
+        </div>
+      </div>
 
       <div className='mt-8 grid gap-2'>
         {states.map(state => (

--- a/apps/web/app/(marketing)/renders/surfaces/[surface]/page.tsx
+++ b/apps/web/app/(marketing)/renders/surfaces/[surface]/page.tsx
@@ -1,0 +1,49 @@
+import { notFound } from 'next/navigation';
+import {
+  isMarketingRenderRouteSurfaceId,
+  MarketingRenderSurface,
+} from '@/features/home/MarketingRenderSurface';
+
+function getSearchParam(
+  value: string | string[] | undefined
+): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function MarketingSurfaceRenderPage({
+  params,
+  searchParams,
+}: {
+  readonly params: Promise<{ surface: string }>;
+  readonly searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { surface } = await params;
+  const resolvedSearchParams = await searchParams;
+  const hideChrome = getSearchParam(resolvedSearchParams.chrome) !== 'true';
+  const width = Number.parseInt(
+    getSearchParam(resolvedSearchParams.width) ?? '430',
+    10
+  );
+
+  if (!isMarketingRenderRouteSurfaceId(surface)) {
+    notFound();
+  }
+
+  return (
+    <div
+      className='flex min-h-screen items-center justify-center bg-black'
+      style={{ padding: '2rem' }}
+    >
+      <div
+        style={{
+          width: `${Number.isFinite(width) ? width : 430}px`,
+          maxWidth: '100%',
+        }}
+        data-testid='marketing-surface-render'
+        data-hide-chrome={hideChrome}
+      >
+        <MarketingRenderSurface surfaceId={surface} hideChrome={hideChrome} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/features/home/HomeAdaptiveProfileStory.tsx
+++ b/apps/web/components/features/home/HomeAdaptiveProfileStory.tsx
@@ -1,7 +1,5 @@
 import { Container } from '@/components/site/Container';
 import { FEATURE_FLAGS } from '@/lib/feature-flags/shared';
-import { HomeChapter1 } from './HomeChapter1';
-import { HomeChapter2 } from './HomeChapter2';
 import { HomeHeroCTA } from './HomeHeroCTA';
 import { HomeHeroPhoneComposition } from './HomeHeroPhoneComposition';
 import { HomeTrustSection } from './HomeTrustSection';
@@ -53,13 +51,7 @@ export function HomeAdaptiveProfileStory() {
   return (
     <div data-testid='homepage-shell'>
       <HomeHero />
-      {showSections && (
-        <>
-          <HomeChapter1 />
-          <HomeChapter2 />
-          <HomeTrustSection />
-        </>
-      )}
+      {showSections ? <HomeTrustSection /> : null}
     </div>
   );
 }

--- a/apps/web/components/features/home/HomeAdaptiveProfileStory.tsx
+++ b/apps/web/components/features/home/HomeAdaptiveProfileStory.tsx
@@ -7,7 +7,7 @@ import { HomeHeroPhoneComposition } from './HomeHeroPhoneComposition';
 import { HomeTrustSection } from './HomeTrustSection';
 import { HOME_HERO_CONTENT } from './home-page-content';
 
-function HomeHero() {
+export function HomeHero() {
   return (
     <section
       className='homepage-hero'

--- a/apps/web/components/features/home/HomeAutoNotifySection.tsx
+++ b/apps/web/components/features/home/HomeAutoNotifySection.tsx
@@ -1,44 +1,6 @@
 import { Container } from '@/components/site/Container';
+import { HomeNotificationCard } from './HomeNotificationCard';
 import { HOME_AUTO_NOTIFY_CONTENT } from './home-page-content';
-
-function LockScreenNotification() {
-  const { notificationFrom, notificationBody } = HOME_AUTO_NOTIFY_CONTENT;
-
-  return (
-    <div className='homepage-ios-notification'>
-      <div className='homepage-ios-notification-header'>
-        {/* Jovie icon — small rounded square */}
-        <div className='homepage-ios-notification-icon'>
-          <svg
-            width='16'
-            height='16'
-            viewBox='0 0 16 16'
-            fill='none'
-            aria-hidden='true'
-          >
-            <rect width='16' height='16' rx='4' fill='rgba(255,255,255,0.9)' />
-            <text
-              x='8'
-              y='12'
-              textAnchor='middle'
-              fill='#0a0b0e'
-              fontSize='10'
-              fontWeight='700'
-              fontFamily='ui-sans-serif, system-ui, sans-serif'
-            >
-              J
-            </text>
-          </svg>
-        </div>
-        <span className='homepage-ios-notification-app'>
-          {notificationFrom}
-        </span>
-        <span className='homepage-ios-notification-time'>now</span>
-      </div>
-      <p className='homepage-ios-notification-body'>{notificationBody}</p>
-    </div>
-  );
-}
 
 export function HomeAutoNotifySection() {
   return (
@@ -60,7 +22,7 @@ export function HomeAutoNotifySection() {
             </div>
 
             <div className='homepage-auto-notify-visual'>
-              <LockScreenNotification />
+              <HomeNotificationCard />
             </div>
           </div>
         </div>

--- a/apps/web/components/features/home/HomeEngageBentoSection.tsx
+++ b/apps/web/components/features/home/HomeEngageBentoSection.tsx
@@ -1,4 +1,6 @@
 import { Container } from '@/components/site/Container';
+import { HOME_ENGAGE_CONTENT } from './home-page-content';
+import { MarketingRenderSurface } from './MarketingRenderSurface';
 
 export function HomeEngageBentoSection() {
   return (
@@ -10,47 +12,26 @@ export function HomeEngageBentoSection() {
       <Container size='homepage'>
         <div className='mx-auto max-w-[1200px]'>
           <h2 id='engage-bento-heading' className='homepage-chapter-title'>
-            Engage.
+            {HOME_ENGAGE_CONTENT.title}
           </h2>
+          <p className='homepage-chapter-body mt-4 max-w-[42rem]'>
+            {HOME_ENGAGE_CONTENT.body}
+          </p>
         </div>
       </Container>
 
       <div className='homepage-bento-track'>
-        {/* Placeholder cards — content TBD */}
-        <article className='homepage-bento-card'>
-          <div className='homepage-bento-card-copy'>
-            <h3 className='homepage-bento-card-title'>Smart Links</h3>
-            <p className='homepage-bento-card-body'>
-              One link routes every fan to their preferred streaming platform.
-            </p>
-          </div>
-        </article>
-        <article className='homepage-bento-card'>
-          <div className='homepage-bento-card-copy'>
-            <h3 className='homepage-bento-card-title'>Pre-save Pages</h3>
-            <p className='homepage-bento-card-body'>
-              Every upcoming release becomes a countdown page automatically.
-            </p>
-          </div>
-        </article>
-        <article className='homepage-bento-card'>
-          <div className='homepage-bento-card-copy'>
-            <h3 className='homepage-bento-card-title'>Tour Dates</h3>
-            <p className='homepage-bento-card-body'>
-              Synced from Bandsintown. Nearby fans see shows in their city
-              first.
-            </p>
-          </div>
-        </article>
-        <article className='homepage-bento-card'>
-          <div className='homepage-bento-card-copy'>
-            <h3 className='homepage-bento-card-title'>Tips &amp; Support</h3>
-            <p className='homepage-bento-card-body'>
-              Accept tips from fans with a single tap. QR code included for live
-              shows.
-            </p>
-          </div>
-        </article>
+        {HOME_ENGAGE_CONTENT.cards.map(card => (
+          <article key={card.id} className='homepage-bento-card'>
+            <div className='homepage-bento-card-visual'>
+              <MarketingRenderSurface surfaceId={card.surfaceId} />
+            </div>
+            <div className='homepage-bento-card-copy'>
+              <h3 className='homepage-bento-card-title'>{card.title}</h3>
+              <p className='homepage-bento-card-body'>{card.body}</p>
+            </div>
+          </article>
+        ))}
       </div>
     </section>
   );

--- a/apps/web/components/features/home/HomeFanRelationshipSection.tsx
+++ b/apps/web/components/features/home/HomeFanRelationshipSection.tsx
@@ -1,0 +1,55 @@
+import { Container } from '@/components/site/Container';
+import { HOME_RELATIONSHIP_SECTION_CONTENT } from './home-page-content';
+import { MarketingRenderSurface } from './MarketingRenderSurface';
+
+export function HomeFanRelationshipSection() {
+  const [paymentCard, fanCard] = HOME_RELATIONSHIP_SECTION_CONTENT.cards;
+
+  return (
+    <section
+      data-testid='homepage-fan-relationship'
+      className='homepage-chapter'
+      aria-labelledby='homepage-fan-relationship-heading'
+    >
+      <Container size='homepage'>
+        <div className='mx-auto max-w-[1200px]'>
+          <div className='homepage-chapter-copy'>
+            <h2
+              id='homepage-fan-relationship-heading'
+              className='homepage-chapter-title'
+            >
+              {HOME_RELATIONSHIP_SECTION_CONTENT.title}
+            </h2>
+            <p className='homepage-chapter-body'>
+              {HOME_RELATIONSHIP_SECTION_CONTENT.body}
+            </p>
+          </div>
+
+          <div className='homepage-chapter-insight'>
+            <article className='homepage-insight-card homepage-insight-card-lead'>
+              <div className='homepage-insight-card-copy'>
+                <h3 className='homepage-insight-card-title'>
+                  {paymentCard.title}
+                </h3>
+                <p className='homepage-insight-card-body'>{paymentCard.body}</p>
+              </div>
+              <MarketingRenderSurface surfaceId='tips' />
+            </article>
+
+            <article className='homepage-insight-card homepage-insight-card-mini'>
+              <div className='homepage-insight-card-copy'>
+                <h3 className='homepage-insight-card-title'>{fanCard.title}</h3>
+                <p className='homepage-insight-card-body'>{fanCard.body}</p>
+              </div>
+              <MarketingRenderSurface surfaceId='fans' />
+            </article>
+          </div>
+
+          <p className='homepage-chapter-flow-line'>
+            {HOME_RELATIONSHIP_SECTION_CONTENT.footnote}
+          </p>
+        </div>
+      </Container>
+    </section>
+  );
+}

--- a/apps/web/components/features/home/HomeNotificationCard.tsx
+++ b/apps/web/components/features/home/HomeNotificationCard.tsx
@@ -1,0 +1,39 @@
+import { HOME_AUTO_NOTIFY_CONTENT } from './home-page-content';
+
+export function HomeNotificationCard() {
+  const { notificationFrom, notificationBody } = HOME_AUTO_NOTIFY_CONTENT;
+
+  return (
+    <div className='homepage-ios-notification'>
+      <div className='homepage-ios-notification-header'>
+        <div className='homepage-ios-notification-icon'>
+          <svg
+            width='16'
+            height='16'
+            viewBox='0 0 16 16'
+            fill='none'
+            aria-hidden='true'
+          >
+            <rect width='16' height='16' rx='4' fill='rgba(255,255,255,0.9)' />
+            <text
+              x='8'
+              y='12'
+              textAnchor='middle'
+              fill='#0a0b0e'
+              fontSize='10'
+              fontWeight='700'
+              fontFamily='ui-sans-serif, system-ui, sans-serif'
+            >
+              J
+            </text>
+          </svg>
+        </div>
+        <span className='homepage-ios-notification-app'>
+          {notificationFrom}
+        </span>
+        <span className='homepage-ios-notification-time'>now</span>
+      </div>
+      <p className='homepage-ios-notification-body'>{notificationBody}</p>
+    </div>
+  );
+}

--- a/apps/web/components/features/home/HomePageNarrative.tsx
+++ b/apps/web/components/features/home/HomePageNarrative.tsx
@@ -7,10 +7,9 @@ import type { FeaturedCreator } from '@/lib/featured-creators';
 import { fillToMinimum } from './featured-creators-fallback';
 import { HomeAdaptiveProfileStory } from './HomeAdaptiveProfileStory';
 import { HomeAutoNotifySection } from './HomeAutoNotifySection';
-import { HomeChapter3 } from './HomeChapter3';
 import { HomeEngageBentoSection } from './HomeEngageBentoSection';
+import { HomeFanRelationshipSection } from './HomeFanRelationshipSection';
 import { HomeLiveProofSection } from './HomeLiveProofSection';
-import { HomeSpecChapter } from './HomeSpecChapter';
 import {
   HOMEPAGE_FINAL_CTA_CONTENT,
   type HomeFinalCtaContent,
@@ -83,8 +82,7 @@ export function HomePageNarrative({
         <>
           <HomeAutoNotifySection />
           <HomeEngageBentoSection />
-          <HomeChapter3 />
-          <HomeSpecChapter />
+          <HomeFanRelationshipSection />
           {proofAvailability === 'visible' ? resolvedProofSection : null}
           <FinalCallToAction />
         </>

--- a/apps/web/components/features/home/HomeProfileShowcase.tsx
+++ b/apps/web/components/features/home/HomeProfileShowcase.tsx
@@ -38,6 +38,8 @@ interface HomeProfileShowcaseProps {
   readonly presentation?: HomeProfileShowcasePresentation;
   readonly overlayMode?: HomeProfileShowcaseOverlayMode;
   readonly cropAnchor?: HomeProfileShowcaseCropAnchor;
+  readonly hideJovieBranding?: boolean;
+  readonly hideMoreMenu?: boolean;
 }
 
 function HomeProfileOverlayCard({
@@ -155,8 +157,12 @@ function getLatestRelease(stateId: ProfileShowcaseStateId) {
 
 function ShowcaseSurface({
   stateId,
+  hideJovieBranding,
+  hideMoreMenu,
 }: Readonly<{
   stateId: ProfileShowcaseStateId;
+  hideJovieBranding: boolean;
+  hideMoreMenu: boolean;
 }>) {
   const state = HOMEPAGE_PROFILE_SHOWCASE_STATES[stateId];
 
@@ -198,6 +204,8 @@ function ShowcaseSurface({
         onRevealNotifications={() => {}}
         previewNotificationsState={state.notifications}
         previewReleaseActionLabel={state.releaseActionLabel}
+        hideJovieBranding={hideJovieBranding}
+        hideMoreMenu={hideMoreMenu}
       />
     </div>
   );
@@ -210,6 +218,8 @@ export function HomeProfileShowcase({
   presentation = 'full-phone',
   overlayMode = 'auto',
   cropAnchor = 'center',
+  hideJovieBranding = false,
+  hideMoreMenu = false,
 }: Readonly<HomeProfileShowcaseProps>) {
   const reducedMotion = useReducedMotion();
   const inertRef = useRef<HTMLDivElement>(null);
@@ -235,7 +245,13 @@ export function HomeProfileShowcase({
         compact={compact}
         className='homepage-showcase-phone-frame'
       >
-        {shouldRenderSurface ? <ShowcaseSurface stateId={stateId} /> : null}
+        {shouldRenderSurface ? (
+          <ShowcaseSurface
+            stateId={stateId}
+            hideJovieBranding={hideJovieBranding}
+            hideMoreMenu={hideMoreMenu}
+          />
+        ) : null}
         {shouldRenderOverlay ? (
           <HomeProfileOverlayCard stateId={stateId} mode='absolute' />
         ) : null}
@@ -245,7 +261,11 @@ export function HomeProfileShowcase({
     content = (
       <div className='homepage-showcase-crop-viewport'>
         <div className='homepage-showcase-crop-surface'>
-          <ShowcaseSurface stateId={stateId} />
+          <ShowcaseSurface
+            stateId={stateId}
+            hideJovieBranding={hideJovieBranding}
+            hideMoreMenu={hideMoreMenu}
+          />
         </div>
         {shouldRenderOverlay ? (
           <HomeProfileOverlayCard stateId={stateId} mode='absolute' />

--- a/apps/web/components/features/home/MarketingRenderSurface.tsx
+++ b/apps/web/components/features/home/MarketingRenderSurface.tsx
@@ -1,0 +1,148 @@
+import type { ReactNode } from 'react';
+import { HomeCountdownObject } from './HomeCountdownObject';
+import { HomeNotificationCard } from './HomeNotificationCard';
+import { HomeProfileShowcase } from './HomeProfileShowcase';
+import { HomeRelationshipPanel } from './HomeRelationshipPanel';
+
+export const MARKETING_RENDER_ROUTE_SURFACES = [
+  {
+    id: 'profile',
+    label: 'Profile',
+    href: '/renders/surfaces/profile',
+  },
+  {
+    id: 'notification',
+    label: 'Notification',
+    href: '/renders/surfaces/notification',
+  },
+  {
+    id: 'tips',
+    label: 'Tips',
+    href: '/renders/surfaces/tips',
+  },
+  {
+    id: 'countdown',
+    label: 'Countdown',
+    href: '/renders/surfaces/countdown',
+  },
+  {
+    id: 'fans',
+    label: 'Fans',
+    href: '/renders/surfaces/fans',
+  },
+] as const;
+
+export type MarketingRenderRouteSurfaceId =
+  (typeof MARKETING_RENDER_ROUTE_SURFACES)[number]['id'];
+
+export type MarketingRenderSurfaceId = MarketingRenderRouteSurfaceId | 'tour';
+
+export function isMarketingRenderRouteSurfaceId(
+  value: string
+): value is MarketingRenderRouteSurfaceId {
+  return MARKETING_RENDER_ROUTE_SURFACES.some(surface => surface.id === value);
+}
+
+interface MarketingRenderSurfaceProps {
+  readonly surfaceId: MarketingRenderSurfaceId;
+  readonly hideChrome?: boolean;
+}
+
+function RenderShell({
+  children,
+  emphasize = false,
+}: Readonly<{
+  children: ReactNode;
+  emphasize?: boolean;
+}>) {
+  return (
+    <div
+      className={`relative flex min-h-[13rem] items-center justify-center overflow-hidden rounded-[1.5rem] border border-white/10 ${
+        emphasize
+          ? 'bg-[radial-gradient(circle_at_top,rgba(138,180,255,0.18),transparent_52%),linear-gradient(180deg,rgba(16,19,26,0.98),rgba(6,8,12,1))]'
+          : 'bg-[linear-gradient(180deg,rgba(14,16,22,0.98),rgba(7,9,13,1))]'
+      } p-4 shadow-[0_22px_56px_rgba(0,0,0,0.22)]`}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function MarketingRenderSurface({
+  surfaceId,
+  hideChrome = true,
+}: Readonly<MarketingRenderSurfaceProps>) {
+  switch (surfaceId) {
+    case 'profile':
+      return (
+        <RenderShell emphasize>
+          <HomeProfileShowcase
+            stateId='catalog'
+            presentation='beauty-shot'
+            overlayMode='hidden'
+            hideJovieBranding={hideChrome}
+            hideMoreMenu={hideChrome}
+            className='w-full max-w-[16.25rem]'
+          />
+        </RenderShell>
+      );
+    case 'notification':
+      return (
+        <RenderShell emphasize>
+          <div className='w-full max-w-[22rem]'>
+            <HomeNotificationCard />
+          </div>
+        </RenderShell>
+      );
+    case 'tips':
+      return (
+        <RenderShell>
+          <HomeProfileShowcase
+            stateId='tips-apple-pay'
+            presentation='drawer-crop'
+            cropAnchor='bottom'
+            hideJovieBranding={hideChrome}
+            hideMoreMenu={hideChrome}
+            className='w-full'
+          />
+        </RenderShell>
+      );
+    case 'countdown':
+      return (
+        <RenderShell>
+          <div className='flex w-full flex-col items-center gap-4'>
+            <HomeCountdownObject />
+            <HomeProfileShowcase
+              stateId='streams-presave'
+              presentation='featured-card-crop'
+              overlayMode='hidden'
+              hideJovieBranding={hideChrome}
+              hideMoreMenu={hideChrome}
+              className='w-full'
+            />
+          </div>
+        </RenderShell>
+      );
+    case 'fans':
+      return (
+        <RenderShell>
+          <div className='w-full max-w-[24rem] rounded-[1.25rem] border border-white/8 bg-white/[0.04] p-3'>
+            <HomeRelationshipPanel />
+          </div>
+        </RenderShell>
+      );
+    case 'tour':
+      return (
+        <RenderShell>
+          <HomeProfileShowcase
+            stateId='tour'
+            presentation='featured-card-crop'
+            overlayMode='hidden'
+            hideJovieBranding={hideChrome}
+            hideMoreMenu={hideChrome}
+            className='w-full'
+          />
+        </RenderShell>
+      );
+  }
+}

--- a/apps/web/components/features/home/home-page-content.ts
+++ b/apps/web/components/features/home/home-page-content.ts
@@ -53,6 +53,40 @@ export interface HomeChapter3Content {
   ];
 }
 
+export interface HomeEngageCard {
+  readonly id: 'smart-links' | 'countdown' | 'tour' | 'tips' | 'fans';
+  readonly title: string;
+  readonly body: string;
+  readonly surfaceId: 'profile' | 'countdown' | 'tour' | 'tips' | 'fans';
+}
+
+export interface HomeEngageContent {
+  readonly title: string;
+  readonly body: string;
+  readonly cards: readonly [
+    HomeEngageCard,
+    HomeEngageCard,
+    HomeEngageCard,
+    HomeEngageCard,
+    HomeEngageCard,
+  ];
+}
+
+export interface HomeRelationshipSectionCard {
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface HomeRelationshipSectionContent {
+  readonly title: string;
+  readonly body: string;
+  readonly cards: readonly [
+    HomeRelationshipSectionCard,
+    HomeRelationshipSectionCard,
+  ];
+  readonly footnote: string;
+}
+
 /* ── Philosophy ───────────────────────────────────────── */
 
 export interface HomePhilosophyCard {
@@ -146,6 +180,61 @@ export const HOME_CHAPTER_3_CONTENT: HomeChapter3Content = {
     },
   ],
 };
+
+export const HOME_ENGAGE_CONTENT: HomeEngageContent = {
+  title: 'Engage.',
+  body: 'The same profile handles listening, countdowns, tour dates, tips, and fan capture without another campaign to build.',
+  cards: [
+    {
+      id: 'smart-links',
+      title: 'Smart links that stay current.',
+      body: 'One profile routes fans to the right release and the right streaming destination.',
+      surfaceId: 'profile',
+    },
+    {
+      id: 'countdown',
+      title: 'Countdowns built in.',
+      body: 'Upcoming drops turn into pre-save and countdown pages from the same link.',
+      surfaceId: 'countdown',
+    },
+    {
+      id: 'tour',
+      title: 'Shows land in the right city.',
+      body: 'Tour dates can lead the page when the next thing that matters is local.',
+      surfaceId: 'tour',
+    },
+    {
+      id: 'tips',
+      title: 'Get paid without losing the moment.',
+      body: 'Fans can tip in one tap and stay inside the same experience.',
+      surfaceId: 'tips',
+    },
+    {
+      id: 'fans',
+      title: 'Recognize the people who care.',
+      body: 'Tips, presaves, listens, and alerts turn into a fan relationship you can build on.',
+      surfaceId: 'fans',
+    },
+  ],
+};
+
+export const HOME_RELATIONSHIP_SECTION_CONTENT: HomeRelationshipSectionContent =
+  {
+    title: 'Turn action into a relationship.',
+    body: 'Get paid in the moment, then keep the fan warm with the same link they already trust.',
+    cards: [
+      {
+        title: 'Take the payment.',
+        body: 'Apple Pay and quick support flows make it easy to capture the moment while someone is ready.',
+      },
+      {
+        title: 'Keep the signal.',
+        body: 'Know who tipped, listened, or turned on notifications so the next follow-up starts warm.',
+      },
+    ],
+    footnote:
+      'A tip, a presave, or a show RSVP becomes a fan you recognize next time.',
+  };
 
 export const HOME_PHILOSOPHY_CONTENT: HomePhilosophyContent = {
   sectionTitle: 'Built for artists by artists.',

--- a/apps/web/components/site/PublicPageShell.tsx
+++ b/apps/web/components/site/PublicPageShell.tsx
@@ -1,6 +1,7 @@
+import Link from 'next/link';
 import { SkipToContent } from '@/components/atoms/SkipToContent';
+import { APP_ROUTES } from '@/constants/routes';
 import { cn } from '@/lib/utils';
-import { MarketingFooter } from './MarketingFooter';
 import {
   MarketingHeader,
   type MarketingHeaderVariant,
@@ -38,7 +39,28 @@ export function PublicPageShell({
       >
         {children}
       </main>
-      <MarketingFooter />
+      <footer className='home-legal-bar'>
+        <nav
+          className='mx-auto flex w-full max-w-[var(--linear-content-max)] items-center justify-center gap-3 px-5 pb-6 pt-3 text-[11px] tracking-[-0.01em] sm:px-6 lg:px-0'
+          aria-label='Legal'
+        >
+          <Link
+            href={APP_ROUTES.LEGAL_PRIVACY}
+            className='home-legal-link focus-ring-themed rounded-md px-1.5 py-0.5'
+          >
+            Privacy
+          </Link>
+          <span aria-hidden='true' className='text-secondary-token/60'>
+            ·
+          </span>
+          <Link
+            href={APP_ROUTES.LEGAL_TERMS}
+            className='home-legal-link focus-ring-themed rounded-md px-1.5 py-0.5'
+          >
+            Terms
+          </Link>
+        </nav>
+      </footer>
     </div>
   );
 }

--- a/apps/web/tests/unit/app/artist-profiles-page.test.tsx
+++ b/apps/web/tests/unit/app/artist-profiles-page.test.tsx
@@ -38,25 +38,27 @@ describe('ArtistProfilesPage', () => {
     globalThis.matchMedia = originalMatchMedia;
   });
 
-  it('renders the homepage hero with headline and CTA', () => {
+  it('renders the homepage hero and all sections ungated', () => {
     render(<ArtistProfilesPage />);
 
     expect(screen.getByTestId('homepage-hero')).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {
-        level: 1,
-        name: 'The link your music deserves.',
-      })
-    ).toBeInTheDocument();
+    expect(screen.getByText('One profile.')).toBeInTheDocument();
+    expect(screen.getByTestId('homepage-chapter-1')).toBeInTheDocument();
+    expect(screen.getByTestId('homepage-chapter-2')).toBeInTheDocument();
+    expect(screen.getByTestId('homepage-trust')).toBeInTheDocument();
+    expect(screen.getByTestId('homepage-auto-notify')).toBeInTheDocument();
+    expect(screen.getByTestId('homepage-engage-bento')).toBeInTheDocument();
+    expect(screen.getByTestId('homepage-chapter-3')).toBeInTheDocument();
+    expect(screen.getByTestId('homepage-spec-section')).toBeInTheDocument();
+    expect(screen.getByTestId('sticky-phone-tour')).toBeInTheDocument();
     expect(screen.getByTestId('final-cta-section')).toBeInTheDocument();
+  });
+
+  it('uses the homepage CTA copy', () => {
+    render(<ArtistProfilesPage />);
+
     expect(screen.getByTestId('final-cta-headline')).toHaveTextContent(
       'Stay in the studio.'
     );
-  });
-
-  it('renders the claim form CTA in the hero', () => {
-    render(<ArtistProfilesPage />);
-
-    expect(screen.getByTestId('homepage-claim-form')).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/app/artist-profiles-page.test.tsx
+++ b/apps/web/tests/unit/app/artist-profiles-page.test.tsx
@@ -46,19 +46,19 @@ describe('ArtistProfilesPage', () => {
     expect(screen.getByTestId('homepage-chapter-1')).toBeInTheDocument();
     expect(screen.getByTestId('homepage-chapter-2')).toBeInTheDocument();
     expect(screen.getByTestId('homepage-trust')).toBeInTheDocument();
+    expect(screen.getByTestId('homepage-chapter-3')).toBeInTheDocument();
+    expect(screen.getByTestId('sticky-phone-tour')).toBeInTheDocument();
     expect(screen.getByTestId('homepage-auto-notify')).toBeInTheDocument();
     expect(screen.getByTestId('homepage-engage-bento')).toBeInTheDocument();
-    expect(screen.getByTestId('homepage-chapter-3')).toBeInTheDocument();
     expect(screen.getByTestId('homepage-spec-section')).toBeInTheDocument();
-    expect(screen.getByTestId('sticky-phone-tour')).toBeInTheDocument();
     expect(screen.getByTestId('final-cta-section')).toBeInTheDocument();
   });
 
-  it('uses the homepage CTA copy', () => {
+  it('uses the artist profile CTA copy', () => {
     render(<ArtistProfilesPage />);
 
     expect(screen.getByTestId('final-cta-headline')).toHaveTextContent(
-      'Stay in the studio.'
+      'Claim your profile.'
     );
   });
 });

--- a/apps/web/tests/unit/app/artist-profiles-page.test.tsx
+++ b/apps/web/tests/unit/app/artist-profiles-page.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import ArtistProfilesPage from '@/app/(marketing)/artist-profiles/page';
-import { getCanonicalSurface } from '@/lib/canonical-surfaces';
 
 vi.mock('@/constants/app', async importOriginal => {
   const actual = await importOriginal<typeof import('@/constants/app')>();
@@ -19,38 +18,45 @@ vi.mock('@/features/home/StickyPhoneTour', () => ({
 }));
 
 describe('ArtistProfilesPage', () => {
-  it('renders the text-only hero with headline and phone tour', () => {
+  const originalMatchMedia = globalThis.matchMedia;
+
+  beforeAll(() => {
+    // @ts-expect-error test shim
+    globalThis.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: false,
+      media: '(prefers-reduced-motion: reduce)',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      onchange: null,
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  afterAll(() => {
+    globalThis.matchMedia = originalMatchMedia;
+  });
+
+  it('renders the homepage hero with headline and CTA', () => {
     render(<ArtistProfilesPage />);
 
+    expect(screen.getByTestId('homepage-hero')).toBeInTheDocument();
     expect(
       screen.getByRole('heading', {
         level: 1,
-        name: 'One link. Every release.',
+        name: 'The link your music deserves.',
       })
     ).toBeInTheDocument();
-    expect(screen.getByTestId('sticky-phone-tour')).toBeInTheDocument();
     expect(screen.getByTestId('final-cta-section')).toBeInTheDocument();
     expect(screen.getByTestId('final-cta-headline')).toHaveTextContent(
-      'Claim your profile.'
+      'Stay in the studio.'
     );
   });
 
-  it('passes artist-profile modes to the phone tour', () => {
+  it('renders the claim form CTA in the hero', () => {
     render(<ArtistProfilesPage />);
 
-    expect(screen.getByTestId('sticky-phone-tour')).toHaveTextContent(
-      'Your profile adapts to what matters right now.'
-    );
-  });
-
-  it('links the profile example CTA to the canonical public-profile review route', () => {
-    render(<ArtistProfilesPage />);
-
-    expect(
-      screen.getByRole('link', { name: 'See a live example' })
-    ).toHaveAttribute(
-      'href',
-      getCanonicalSurface('public-profile').reviewRoute
-    );
+    expect(screen.getByTestId('homepage-claim-form')).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/home/HomeAdaptiveProfileStory.test.tsx
+++ b/apps/web/tests/unit/home/HomeAdaptiveProfileStory.test.tsx
@@ -63,29 +63,21 @@ describe('HomeAdaptiveProfileStory', () => {
     expect(screen.getByTestId('homepage-trust')).toBeInTheDocument();
   });
 
-  it('renders chapter 1 with sandbox card', () => {
+  it('renders the trust logo strip when sections are enabled', () => {
     render(<HomeAdaptiveProfileStory />);
 
-    expect(
-      screen.getByRole('heading', { name: 'Turn attention into action.' })
-    ).toBeInTheDocument();
-    expect(screen.getByTestId('homepage-sandbox')).toBeInTheDocument();
+    expect(screen.getByTestId('homepage-trust')).toBeInTheDocument();
   });
 
-  it('renders chapter 2 with tip bento card', () => {
-    render(<HomeAdaptiveProfileStory />);
-
-    expect(
-      screen.getByRole('heading', {
-        name: 'Get paid.',
-      })
-    ).toBeInTheDocument();
-    expect(screen.getByText("That's it.")).toBeInTheDocument();
-  });
-
-  it('does not render old sections', () => {
+  it('keeps the hero isolated from the deeper middle sections', () => {
     const { container } = render(<HomeAdaptiveProfileStory />);
 
+    expect(
+      screen.queryByRole('heading', { name: 'Turn attention into action.' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Get paid.' })
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByTestId('homepage-interstitial')
     ).not.toBeInTheDocument();

--- a/apps/web/tests/unit/home/HomePageNarrative.test.tsx
+++ b/apps/web/tests/unit/home/HomePageNarrative.test.tsx
@@ -32,33 +32,29 @@ describe('HomePageNarrative', () => {
     globalThis.matchMedia = originalMatchMedia;
   });
 
-  it('renders the 7-chapter section order', () => {
+  it('renders the reshaped homepage section order', () => {
     render(<HomePageNarrative />);
 
     const hero = screen.getByTestId('homepage-hero');
     const trust = screen.getByTestId('homepage-trust');
-    const ch1 = screen.getByTestId('homepage-chapter-1');
-    const ch2 = screen.getByTestId('homepage-chapter-2');
-    const ch3 = screen.getByTestId('homepage-chapter-3');
-    const philosophy = screen.getByTestId('homepage-spec-section');
+    const autoNotify = screen.getByTestId('homepage-auto-notify');
+    const engage = screen.getByTestId('homepage-engage-bento');
+    const relationship = screen.getByTestId('homepage-fan-relationship');
     const finalCta = screen.getByTestId('final-cta-headline');
 
-    expect(hero.compareDocumentPosition(ch1)).toBe(
+    expect(hero.compareDocumentPosition(trust)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
-    expect(ch1.compareDocumentPosition(ch2)).toBe(
+    expect(trust.compareDocumentPosition(autoNotify)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
-    expect(ch2.compareDocumentPosition(trust)).toBe(
+    expect(autoNotify.compareDocumentPosition(engage)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
-    expect(trust.compareDocumentPosition(ch3)).toBe(
+    expect(engage.compareDocumentPosition(relationship)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
-    expect(ch3.compareDocumentPosition(philosophy)).toBe(
-      Node.DOCUMENT_POSITION_FOLLOWING
-    );
-    expect(philosophy.compareDocumentPosition(finalCta)).toBe(
+    expect(relationship.compareDocumentPosition(finalCta)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING
     );
   });
@@ -80,8 +76,9 @@ describe('HomePageNarrative', () => {
         name: 'Algorithms reward consistency.',
       })
     ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('homepage-chapter-3')).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', { name: 'Built into the link.' })
+      screen.queryByTestId('homepage-spec-section')
     ).not.toBeInTheDocument();
   });
 
@@ -110,5 +107,27 @@ describe('HomePageNarrative', () => {
       />
     );
     expect(screen.getByTestId('mock-proof-section')).toBeInTheDocument();
+  });
+
+  it('renders the render-backed engage and relationship content', () => {
+    render(<HomePageNarrative />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Notify every fan. Automatically.' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Engage.' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'Turn action into a relationship.',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Smart links that stay current.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Recognize the people who care.')
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/home/marketing-content-guardrails.test.ts
+++ b/apps/web/tests/unit/home/marketing-content-guardrails.test.ts
@@ -105,12 +105,12 @@ describe('Marketing content guardrails', () => {
       const text = container.textContent ?? '';
 
       expect(text).toContain('Built for artists by artists');
-      expect(text).toContain('Zero Setup.');
-      expect(text).toContain('Know Every Fan by Name.');
-      expect(text).toContain('Stupid Fast.');
-      expect(text).toContain('Location-Aware.');
-      expect(text).toContain('Turn attention into action.');
-      expect(text).toContain('Get paid.');
+      expect(text).toContain('Notify every fan. Automatically.');
+      expect(text).toContain('Engage.');
+      expect(text).toContain('Turn action into a relationship.');
+      expect(text).toContain('Stay in the studio.');
+      expect(text).toContain('Smart links that stay current.');
+      expect(text).toContain('Recognize the people who care.');
     });
   });
 });


### PR DESCRIPTION
## Summary
- add the render surface route for marketing captures
- expand the artist-profiles marketing page with the staged homepage content updates
- land the artist-profiles container-width cleanup that fixes the public-route CI guard

## Test plan
- `pnpm --filter web exec vitest run tests/unit/app/artist-profiles-page.test.tsx tests/unit/home/HomeAdaptiveProfileStory.test.tsx tests/unit/home/HomePageNarrative.test.tsx tests/unit/home/marketing-content-guardrails.test.ts`
- pre-push hooks: `next:proxy-guard`, `tailwind:check`, app `typecheck`, app `lint`