### PR TITLE
fix(trust): harden not-found pages and route-qa detection

### DIFF
--- a/apps/web/app/[username]/[slug]/not-found.tsx
+++ b/apps/web/app/[username]/[slug]/not-found.tsx
@@ -2,7 +2,10 @@ import Link from 'next/link';
 
 export default function SmartLinkNotFound() {
   return (
-    <div className='bg-base text-foreground flex min-h-dvh flex-col items-center justify-center px-4'>
+    <div
+      data-testid='not-found'
+      className='bg-base text-foreground flex min-h-dvh flex-col items-center justify-center px-4'
+    >
       <div className='w-full max-w-sm text-center'>
         <div className='mb-6 select-none'>
           <span

--- a/apps/web/app/[username]/not-found.tsx
+++ b/apps/web/app/[username]/not-found.tsx
@@ -6,6 +6,7 @@ export default function NotFound() {
   return (
     <PublicPageShell mainClassName='bg-base'>
       <MarketingContainer
+        data-testid='not-found'
         width='page'
         className='flex min-h-[calc(100vh-var(--public-shell-header-offset))] items-center justify-center py-16'
       >

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -10,6 +10,7 @@ export default function NotFound() {
 
       <main
         id='main-content'
+        data-testid='not-found'
         style={{ paddingTop: 'var(--linear-header-height, 64px)' }}
       >
         <Container className='flex min-h-[calc(100vh-8rem)] items-center justify-center'>

--- a/apps/web/app/out/[id]/page.tsx
+++ b/apps/web/app/out/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle } from 'lucide-react';
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
+import { cache } from 'react';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { StandaloneProductPage } from '@/components/organisms/StandaloneProductPage';
@@ -19,9 +20,24 @@ interface PageProps
     }>;
   }> {}
 
+const getCachedWrappedLink = cache(async (shortId: string) =>
+  getWrappedLink(shortId)
+);
+
 export async function generateMetadata({
-  params: _params,
+  params,
 }: Readonly<PageProps>): Promise<Metadata> {
+  const { id: shortId } = await params;
+
+  if (!shortId || shortId.length > 20) {
+    return { title: 'Not Found' };
+  }
+
+  const wrappedLink = await getCachedWrappedLink(shortId);
+  if (!wrappedLink) {
+    return { title: 'Not Found' };
+  }
+
   return {
     title: 'Link Confirmation Required',
     description: 'This link requires confirmation before proceeding.',
@@ -45,7 +61,7 @@ export default async function InterstitialPage({
     notFound();
   }
 
-  const wrappedLink = await getWrappedLink(shortId);
+  const wrappedLink = await getCachedWrappedLink(shortId);
 
   if (!wrappedLink) {
     notFound();

--- a/apps/web/scripts/route-qa.ts
+++ b/apps/web/scripts/route-qa.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
+import { pathToFileURL } from 'node:url';
 import { type BrowserContext, chromium, type Page } from 'playwright';
 import { APP_ROUTES } from '../constants/routes';
 import { getAlternativeSlugs } from '../content/alternatives';
@@ -86,6 +87,35 @@ const ERROR_SELECTORS = [
   '[data-testid="dashboard-error"]',
   '.next-error-h1',
 ];
+
+interface NotFoundSignalInput {
+  readonly responseStatus: number;
+  readonly finalUrl: string;
+  readonly bodyText: string;
+  readonly title: string;
+  readonly hasNotFoundTestId: boolean;
+}
+
+export function isNotFoundLike({
+  responseStatus,
+  finalUrl,
+  bodyText,
+  title,
+  hasNotFoundTestId,
+}: Readonly<NotFoundSignalInput>) {
+  const loweredTitle = title.toLowerCase();
+
+  return (
+    responseStatus === 404 ||
+    finalUrl.includes('/not-found') ||
+    hasNotFoundTestId ||
+    loweredTitle.includes('not found') ||
+    bodyText.includes('page not found') ||
+    bodyText.includes('content not found') ||
+    bodyText.includes("doesn't exist") ||
+    bodyText.includes("couldn't find")
+  );
+}
 
 function toRouteTemplate(filePath: string): string {
   const relativePath = path.relative(APP_DIR, filePath);
@@ -754,6 +784,11 @@ async function runRouteCase(
         .innerText()
         .catch(() => '')
     ).toLowerCase();
+    const hasNotFoundTestId = await page
+      .locator('[data-testid="not-found"]')
+      .first()
+      .isVisible()
+      .catch(() => false);
     pageErrors = await collectPageErrors(page);
 
     const hasMainContent = await page
@@ -762,12 +797,13 @@ async function runRouteCase(
       .isVisible()
       .catch(() => false);
     const responseStatus = response?.status() ?? 0;
-    const notFoundLike =
-      responseStatus === 404 ||
-      finalUrl.includes('/not-found') ||
-      bodyText.includes('page not found') ||
-      bodyText.includes("doesn't exist") ||
-      bodyText.includes("couldn't find");
+    const notFoundLike = isNotFoundLike({
+      responseStatus,
+      finalUrl,
+      bodyText,
+      title,
+      hasNotFoundTestId,
+    });
 
     const unauthorizedLike = await page
       .locator('text=/unauthorized|sign in as an admin|valid kiosk token/i')
@@ -957,4 +993,7 @@ async function main() {
   }
 }
 
-void main();
+const invokedPath = process.argv[1];
+if (invokedPath && import.meta.url === pathToFileURL(invokedPath).href) {
+  void main();
+}

--- a/apps/web/tests/scripts/route-qa.test.ts
+++ b/apps/web/tests/scripts/route-qa.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { isNotFoundLike } from '../../scripts/route-qa';
+
+describe('route-qa not-found detection', () => {
+  it('accepts explicit not-found copy variants', () => {
+    expect(
+      isNotFoundLike({
+        responseStatus: 200,
+        finalUrl: 'http://127.0.0.1:3100/missing-qa-user/missing-release',
+        bodyText:
+          '404 content not found this page may have been removed or the link may be incorrect',
+        title: 'Not Found | Jovie',
+        hasNotFoundTestId: false,
+      })
+    ).toBe(true);
+  });
+
+  it('accepts pages with the shared not-found test id even on a 200 response', () => {
+    expect(
+      isNotFoundLike({
+        responseStatus: 200,
+        finalUrl: 'http://127.0.0.1:3100/out/invalid-link',
+        bodyText: 'link confirmation required',
+        title: 'Link Confirmation Required | Jovie',
+        hasNotFoundTestId: true,
+      })
+    ).toBe(true);
+  });
+
+  it('rejects normal successful pages', () => {
+    expect(
+      isNotFoundLike({
+        responseStatus: 200,
+        finalUrl: 'http://127.0.0.1:3100/e2e-test-user',
+        bodyText: 'e2e test user stream now latest release',
+        title: 'E2E Test User | Jovie',
+        hasNotFoundTestId: false,
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/app/out-link-page.test.ts
+++ b/apps/web/tests/unit/app/out-link-page.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetWrappedLink } = vi.hoisted(() => ({
+  mockGetWrappedLink: vi.fn(),
+}));
+
+vi.mock('@/lib/services/link-wrapping', () => ({
+  getWrappedLink: mockGetWrappedLink,
+}));
+
+vi.mock('@/components/molecules/ContentSectionHeader', () => ({
+  ContentSectionHeader: () => null,
+}));
+
+vi.mock('@/components/molecules/ContentSurfaceCard', () => ({
+  ContentSurfaceCard: ({ children }: { readonly children: unknown }) =>
+    children,
+}));
+
+vi.mock('@/components/organisms/StandaloneProductPage', () => ({
+  StandaloneProductPage: ({ children }: { readonly children: unknown }) =>
+    children,
+}));
+
+vi.mock('@/app/out/[id]/InterstitialClient', () => ({
+  InterstitialClient: () => null,
+}));
+
+describe('out link metadata', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns not-found metadata when the wrapped link is missing', async () => {
+    mockGetWrappedLink.mockResolvedValue(null);
+
+    const { generateMetadata } = await import('@/app/out/[id]/page');
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ id: 'invalid-link' }),
+    });
+
+    expect(metadata.title).toBe('Not Found');
+  });
+
+  it('returns not-found metadata when the short id is invalid', async () => {
+    const { generateMetadata } = await import('@/app/out/[id]/page');
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ id: 'x'.repeat(21) }),
+    });
+
+    expect(metadata.title).toBe('Not Found');
+    expect(mockGetWrappedLink).not.toHaveBeenCalled();
+  });
+
+  it('keeps confirmation metadata for valid wrapped links', async () => {
+    mockGetWrappedLink.mockResolvedValue({
+      category: 'adult',
+      clickCount: 0,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      domain: 'example.com',
+      id: 'wrapped-link-id',
+      kind: 'sensitive',
+      originalUrl: 'https://example.com',
+      shortId: 'valid-link',
+      titleAlias: 'External Link',
+    });
+
+    const { generateMetadata } = await import('@/app/out/[id]/page');
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ id: 'valid-link' }),
+    });
+
+    expect(metadata.title).toBe('Link Confirmation Required');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `data-testid="not-found"` to all not-found pages for reliable QA detection
- Cache `getWrappedLink` in `/out` page to avoid duplicate fetches between `generateMetadata` and the page component
- Extract `isNotFoundLike` into a testable function in route-qa with a main-guard for test imports
- Add unit tests for `isNotFoundLike` and `/out` link page

## Test plan
- [x] Typecheck passes
- [x] Biome formatting clean
- [x] Pre-commit hooks pass (lint, typecheck, biome)
- [x] Pre-push hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced detection of not-found pages across the application.

* **Bug Fixes**
  * Invalid short links (exceeding 20 characters) now correctly return not-found metadata and handling.

* **Tests**
  * Added test coverage for not-found detection logic and short link validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->