### PR TITLE
fix(trust): add download route expansion to route-qa

### DIFF
--- a/apps/web/scripts/route-qa.ts
+++ b/apps/web/scripts/route-qa.ts
@@ -205,7 +205,7 @@ function buildDynamicCase(
   };
 }
 
-async function expandDynamicRoute(
+export async function expandDynamicRoute(
   route: string,
   source: string
 ): Promise<RouteCase[]> {
@@ -500,6 +500,28 @@ async function expandDynamicRoute(
       buildDynamicCase(
         `/${MISSING_PUBLIC_USERNAME}/missing-release/sounds`,
         `${source} -> missing release sounds`,
+        route,
+        {
+          expectedState: 'not-found',
+        }
+      ),
+    ];
+  }
+
+  if (route === '/[username]/[slug]/download') {
+    const resolvedPath = await resolveSeededPublicReleasePath({
+      path: '/[username]/[slug]',
+      seedProfile: 'e2e-test-user',
+    } as never);
+    return [
+      buildDynamicCase(
+        `${resolvedPath}/download`,
+        `${source} -> seeded release download`,
+        route
+      ),
+      buildDynamicCase(
+        `/${MISSING_PUBLIC_USERNAME}/missing-release/download`,
+        `${source} -> missing release download`,
         route,
         {
           expectedState: 'not-found',


### PR DESCRIPTION
## Summary
- Export `expandDynamicRoute` for testability
- Add `/[username]/[slug]/download` route case with seeded release download and missing release not-found scenarios to route-qa coverage

## Test plan
- [x] Typecheck passes
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for release downloads and missing release error scenarios to strengthen QA validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->