### PR TITLE
fix(a11y): improve sidebar muted text contrast

### DIFF
--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1075,9 +1075,9 @@
   --sidebar-border: 255 255 255 / 0.06;
   /* Linear: --linear-app-sidebar-border-rgb */
   --sidebar-ring: 109 119 230 / 0.55;
-  --sidebar-muted: 107 111 118;
+  --sidebar-muted: 138 143 152;
   /* Linear: --linear-app-sidebar-muted-rgb */
-  --sidebar-muted-foreground: 107 111 118;
+  --sidebar-muted-foreground: 138 143 152;
   --sidebar-surface: var(--linear-app-sidebar-background-rgb);
   /* Matches sidebar background */
   --sidebar-surface-hover: 255 255 255 / 0.04;


### PR DESCRIPTION
## Summary
- Lighten `--sidebar-muted` and `--sidebar-muted-foreground` from `rgb(107,111,118)` to `rgb(138,143,152)` for better readability against dark sidebar backgrounds
- Addresses WCAG 2.1 AA contrast ratio requirements for sidebar navigation text

## Test plan
- [x] Typecheck passes
- [x] Pre-commit/pre-push hooks pass
- [ ] CI passes
- [ ] Visual verification in dark mode sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted dark mode sidebar color scheme to enhance visual clarity of muted elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->