### PR TITLE
fix(qa): correct standalone server path in releases QA loop

### DIFF
--- a/apps/web/scripts/releases-dashboard-qa-loop.ts
+++ b/apps/web/scripts/releases-dashboard-qa-loop.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 
 import { type ChildProcess, spawn } from 'node:child_process';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { APP_ROUTES } from '../constants/routes';
@@ -359,6 +359,17 @@ async function ensureManagedServer() {
     throw new Error('Failed to build @jovie/web for qa:releases:loop');
   }
 
+  const serverEntryPath = resolve(
+    repoRoot,
+    'apps/web/.next/standalone/apps/web/server.js'
+  );
+  if (!existsSync(serverEntryPath)) {
+    throw new Error(
+      `Standalone server not found at ${serverEntryPath}. ` +
+        'Ensure the build completed successfully with output: "standalone".'
+    );
+  }
+
   const server = spawn(
     'doppler',
     [
@@ -369,7 +380,7 @@ async function ensureManagedServer() {
       'dev',
       '--',
       'node',
-      '.next/standalone/apps/web/server.js',
+      'apps/web/.next/standalone/apps/web/server.js',
     ],
     {
       cwd: repoRoot,


### PR DESCRIPTION
## Summary
- Fix standalone server path from `.next/standalone/apps/web/server.js` to `apps/web/.next/standalone/apps/web/server.js` in `releases-dashboard-qa-loop.ts`
- The script runs from repo root but the Next.js standalone build outputs under `apps/web/.next/`, not the repo root `.next/`
- Add existence check with clear error message when the build artifact is missing

## Test plan
- [x] Typecheck passes
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass
- [ ] CI passes
- [ ] Verify with `doppler run -- pnpm --filter @jovie/web run qa:releases:loop -- --max-iterations 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced server startup validation to ensure required build artifacts are present and provide clearer error messages when deployment issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->