### PR TITLE
fix: resolve 15 SonarCloud issues (void operator, a11y, code quality)

### DIFF
--- a/apps/web/app/[username]/opengraph-image.tsx
+++ b/apps/web/app/[username]/opengraph-image.tsx
@@ -43,7 +43,7 @@ async function toDataUrl(imageUrl: string): Promise<string | null> {
     const CHUNK = 8192;
     const chunks: string[] = [];
     for (let i = 0; i < bytes.length; i += CHUNK) {
-      chunks.push(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
+      chunks.push(String.fromCodePoint(...bytes.subarray(i, i + CHUNK)));
     }
     return `data:${contentType};base64,${btoa(chunks.join(''))}`;
   } catch {

--- a/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
@@ -79,8 +79,7 @@ export function OnboardingHandleStep({
     isSubmitting || (isPendingSubmit && handleValidation.checking);
   const hasError = Boolean(stateError || handleValidation.error);
 
-  const canSubmit =
-    !Boolean(ctaDisabledReason) && !isTransitioning && !isLoading;
+  const canSubmit = !ctaDisabledReason && !isTransitioning && !isLoading;
 
   return (
     <div className='mx-auto flex w-full max-w-2xl flex-col gap-6'>

--- a/apps/web/components/features/profile/StaticListenInterface.tsx
+++ b/apps/web/components/features/profile/StaticListenInterface.tsx
@@ -190,9 +190,7 @@ export const StaticListenInterface = React.memo(function StaticListenInterface({
       {/* Help text */}
       <div className='mt-6 text-center'>
         <p className='text-xs text-tertiary-token'>
-          {isPreview
-            ? 'Your preferred app opens first next time.'
-            : 'Your preferred app opens first next time.'}
+          Your preferred app opens first next time.
         </p>
       </div>
     </div>

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -413,8 +413,8 @@ export function ProfileInlineNotificationsCTA({
       if (event.key !== 'Enter') return;
       event.preventDefault();
       if (step === 'email') handleEmailSubmit();
-      else if (step === 'name') void handleNameSubmit();
-      else if (step === 'birthday') void handleBirthdaySubmit();
+      else if (step === 'name') handleNameSubmit();
+      else if (step === 'birthday') handleBirthdaySubmit();
     },
     [step, handleEmailSubmit, handleNameSubmit, handleBirthdaySubmit]
   );
@@ -615,7 +615,7 @@ export function ProfileInlineNotificationsCTA({
               value={nameInput}
               onChange={e => setNameInput(e.target.value)}
               onSubmit={() => {
-                void handleNameSubmit();
+                handleNameSubmit();
               }}
               onKeyDown={handleKeyDown}
               onFocus={() => setIsInputFocused(true)}
@@ -649,10 +649,10 @@ export function ProfileInlineNotificationsCTA({
                     if (birthdayHintShown) setBirthdayHintShown(false);
                   }}
                   onComplete={() => {
-                    void handleBirthdaySubmit();
+                    handleBirthdaySubmit();
                   }}
                   onSubmit={() => {
-                    void handleBirthdaySubmit();
+                    handleBirthdaySubmit();
                   }}
                   autoFocus
                   disabled={birthdayMutation.isPending}

--- a/apps/web/components/features/profile/artist-notifications-cta/useSubscriptionForm.ts
+++ b/apps/web/components/features/profile/artist-notifications-cta/useSubscriptionForm.ts
@@ -489,7 +489,7 @@ export function useSubscriptionForm({
       event => {
         if (event.key === 'Enter') {
           event.preventDefault();
-          void (otpStep === 'verify' ? handleVerifyOtp() : handleSubscribe());
+          otpStep === 'verify' ? handleVerifyOtp() : handleSubscribe();
         }
       },
       [handleSubscribe, handleVerifyOtp, otpStep]

--- a/apps/web/components/features/share/PublicShareMenu.tsx
+++ b/apps/web/components/features/share/PublicShareMenu.tsx
@@ -108,7 +108,7 @@ export function PublicShareActionList({
             type='button'
             className={PUBLIC_SHARE_MENU_ITEM_CLASS}
             onClick={() => {
-              void handleAction(destination);
+              handleAction(destination);
             }}
           >
             {renderDestinationIcon(destination.icon)}
@@ -183,7 +183,7 @@ export function PublicShareMenu({
           label: destination.label,
           icon: renderDestinationIcon(destination.icon),
           onClick: () => {
-            void handleDesktopAction(destination);
+            handleDesktopAction(destination);
           },
         })
       ),

--- a/apps/web/components/organisms/table/utils/tableKeyMap.ts
+++ b/apps/web/components/organisms/table/utils/tableKeyMap.ts
@@ -8,7 +8,7 @@
 
 import { isFormElement } from '@/lib/utils/keyboard';
 
-export { isFormElement };
+export { isFormElement } from '@/lib/utils/keyboard';
 
 export type TableNavAction =
   | 'next'

--- a/apps/web/lib/feature-flags/stripe-connect.ts
+++ b/apps/web/lib/feature-flags/stripe-connect.ts
@@ -11,8 +11,7 @@ import { FEATURE_FLAGS } from './shared';
  * @returns true if the feature is enabled
  */
 export function isStripeConnectEnabled(
-  userId: string | null
+  _userId: string | null
 ): Promise<boolean> {
-  void userId;
   return Promise.resolve(FEATURE_FLAGS.STRIPE_CONNECT_ENABLED);
 }

--- a/apps/web/lib/share/image-utils.ts
+++ b/apps/web/lib/share/image-utils.ts
@@ -82,7 +82,7 @@ export async function toDataUrl(
       }
     }
 
-    if (!response || !response.ok) return null;
+    if (!response?.ok) return null;
 
     const ct = response.headers.get('content-type') ?? '';
     if (!ct.startsWith('image/')) return null;
@@ -99,7 +99,7 @@ export async function toDataUrl(
     const CHUNK = 8192;
     const chunks: string[] = [];
     for (let i = 0; i < bytes.length; i += CHUNK) {
-      chunks.push(String.fromCharCode(...bytes.subarray(i, i + CHUNK)));
+      chunks.push(String.fromCodePoint(...bytes.subarray(i, i + CHUNK)));
     }
     return `data:${ct};base64,${btoa(chunks.join(''))}`;
   } catch {


### PR DESCRIPTION
## Summary
Fixes 15 SonarCloud issues across 9 files — all code-quality-only changes with no behavior modifications:

- **S3735** (CRITICAL): Remove `void` operator usage in 4 files (9 issues) — fire-and-forget async calls in event handlers don't need `void` since no `no-floating-promises` rule is configured
- **S7763** (MINOR): Use `export...from` re-export syntax in `tableKeyMap.ts`
- **S3923** (MAJOR): Remove redundant ternary returning same value in `StaticListenInterface.tsx`
- **S6509** (MINOR): Remove redundant `Boolean()` call in `OnboardingHandleStep.tsx`
- **S7758** (MINOR): Prefer `String.fromCodePoint()` over `String.fromCharCode()` in 2 files
- **S6582** (MAJOR): Use optional chaining in `image-utils.ts`

## Test plan
- [x] Biome lint passes on all changed files
- [x] No behavior changes — code quality fixes only
- [x] All changes are minimal and focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined internal code structure for improved maintainability and consistency across components and utilities.
  * Optimized conditional logic and promise handling patterns.
  * Enhanced code clarity through simplified expressions and more direct invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->