### PR TITLE
fix: remove unnecessary non-null assertions (SonarCloud S4325)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/releases/release-actions.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/release-actions.tsx
@@ -111,7 +111,7 @@ function buildShareItems(
       icon: menuIcon('Link2'),
       items: groupTrackedPresetsBySource(ALL_UTM_PRESETS).map(sourceGroup => {
         if (sourceGroup.presets.length === 1) {
-          const preset = sourceGroup.presets[0]!;
+          const preset = sourceGroup.presets[0];
           return {
             id: `tracked-${preset.id}`,
             label: sourceGroup.label,

--- a/apps/web/lib/share/destinations.ts
+++ b/apps/web/lib/share/destinations.ts
@@ -216,7 +216,7 @@ export const PUBLIC_SHARE_DESTINATIONS: readonly PublicShareDestination[] = [
       utm_content: 'story',
     },
     launch: context =>
-      launchInstagramStory(context, PUBLIC_SHARE_DESTINATIONS[1]!),
+      launchInstagramStory(context, PUBLIC_SHARE_DESTINATIONS[1]),
   },
   {
     id: 'twitter',
@@ -230,7 +230,7 @@ export const PUBLIC_SHARE_DESTINATIONS: readonly PublicShareDestination[] = [
       utm_campaign: '{{release_slug}}',
       utm_content: 'post',
     },
-    launch: context => launchTwitter(context, PUBLIC_SHARE_DESTINATIONS[2]!),
+    launch: context => launchTwitter(context, PUBLIC_SHARE_DESTINATIONS[2]),
   },
   {
     id: 'threads',
@@ -244,7 +244,7 @@ export const PUBLIC_SHARE_DESTINATIONS: readonly PublicShareDestination[] = [
       utm_campaign: '{{release_slug}}',
       utm_content: 'post',
     },
-    launch: context => launchThreads(context, PUBLIC_SHARE_DESTINATIONS[3]!),
+    launch: context => launchThreads(context, PUBLIC_SHARE_DESTINATIONS[3]),
   },
   {
     id: 'email',
@@ -258,7 +258,7 @@ export const PUBLIC_SHARE_DESTINATIONS: readonly PublicShareDestination[] = [
       utm_campaign: '{{release_slug}}',
       utm_content: 'friend',
     },
-    launch: context => launchEmail(context, PUBLIC_SHARE_DESTINATIONS[4]!),
+    launch: context => launchEmail(context, PUBLIC_SHARE_DESTINATIONS[4]),
   },
 ] as const;
 

--- a/apps/web/lib/share/tracked-sources.ts
+++ b/apps/web/lib/share/tracked-sources.ts
@@ -228,7 +228,7 @@ export function buildTrackedShareDropdownItems(params: {
     previousGroup = sourceGroup.group;
 
     if (sourceGroup.presets.length === 1) {
-      const preset = sourceGroup.presets[0]!;
+      const preset = sourceGroup.presets[0];
       submenuItems.push({
         type: 'action',
         id: `tracked-${preset.id}`,


### PR DESCRIPTION
## Summary
Resolves 6 SonarCloud **S4325** MINOR issues ("This assertion is unnecessary since it does not change the type of the expression").

- `apps/web/lib/share/destinations.ts` — drop `!` on `PUBLIC_SHARE_DESTINATIONS[1..4]` (4 sites)
- `apps/web/lib/share/tracked-sources.ts:231` — drop `!` on `sourceGroup.presets[0]` inside `length===1` guard
- `apps/web/components/features/dashboard/organisms/releases/release-actions.tsx:114` — same pattern

## SonarCloud Rules Addressed
- **typescript:S4325** — Unnecessary type assertions

## Test plan
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Biome check passes
- [x] Pre-commit hooks (biome, eslint, a11y, typecheck) pass
- [x] No behavior changes — pure assertion removals

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety in share and destination handling by refining null-checking behavior across internal modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->