### PR TITLE
fix: modernize TS idioms flagged by SonarCloud

### DIFF
--- a/apps/web/app/api/share/story/playlist/route.tsx
+++ b/apps/web/app/api/share/story/playlist/route.tsx
@@ -35,7 +35,7 @@ export async function GET(req: NextRequest) {
     .where(eq(joviePlaylists.slug, slug))
     .limit(1);
 
-  if (!playlist || playlist.status !== 'published') {
+  if (playlist?.status !== 'published') {
     return NextResponse.json(
       { error: 'Playlist not found' },
       { status: 404, headers: { 'Cache-Control': 'no-store' } }

--- a/apps/web/app/api/share/story/profile/route.tsx
+++ b/apps/web/app/api/share/story/profile/route.tsx
@@ -21,7 +21,7 @@ export async function GET(req: NextRequest) {
   }
 
   const profile = await getProfileByUsername(username);
-  if (!profile || !profile.isPublic) {
+  if (!profile?.isPublic) {
     return NextResponse.json(
       { error: 'Profile not found' },
       { status: 404, headers: { 'Cache-Control': 'no-store' } }

--- a/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
+++ b/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
@@ -243,9 +243,7 @@ async function buildBioLinkActivation(
 
     for (const eventRow of eventRows) {
       const eventType = eventRow.eventType as BioLinkActivationEventType;
-      if (timestamps[eventType] === null) {
-        timestamps[eventType] = eventRow.createdAt;
-      }
+      timestamps[eventType] ??= eventRow.createdAt;
     }
   }
 

--- a/apps/web/lib/blog/getBlogPosts.ts
+++ b/apps/web/lib/blog/getBlogPosts.ts
@@ -114,7 +114,7 @@ function formatTitleFromSlug(slug: string): string {
 }
 
 function stripHtmlH1Blocks(html: string): string {
-  return html.replace(/<h1\b[^>]*>[\s\S]*?<\/h1>/gi, '');
+  return html.replaceAll(/<h1\b[^>]*>[\s\S]*?<\/h1>/gi, '');
 }
 
 async function readBlogPostFile(slug: string): Promise<{

--- a/apps/web/lib/distribution/instagram-activation.ts
+++ b/apps/web/lib/distribution/instagram-activation.ts
@@ -111,7 +111,7 @@ export function buildDistributionDedupeKey(
 }
 
 export function getBioLinkActivationWindowEnd(
-  onboardingCompletedAt: Date | string | null | undefined
+  onboardingCompletedAt: DateInput
 ): Date | null {
   const onboardingDate = coerceDate(onboardingCompletedAt);
   if (!onboardingDate) {

--- a/apps/web/lib/feature-flags/shared.ts
+++ b/apps/web/lib/feature-flags/shared.ts
@@ -31,9 +31,6 @@ export type StatsigGateKey =
  */
 export const FEATURE_FLAG_KEYS = STATSIG_GATE_KEYS;
 
-/** @deprecated Use StatsigGateKey or CodeFlagName instead. */
-export type FeatureFlagKey = StatsigGateKey;
-
 export type SubscribeCTAVariant = 'two_step' | 'inline';
 
 export interface StatsigFeatureFlagsBootstrap {

--- a/apps/web/lib/share/copy.ts
+++ b/apps/web/lib/share/copy.ts
@@ -116,8 +116,8 @@ export function slugifyShareValue(input: string): string {
   return input
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/gu, '-')
-    .replace(/^-+|-+$/gu, '');
+    .replaceAll(/[^a-z0-9]+/gu, '-')
+    .replaceAll(/^-+|-+$/gu, '');
 }
 
 export function buildPublicShareFallbackText(context: ShareContext): string {

--- a/apps/web/lib/youtube/parse.ts
+++ b/apps/web/lib/youtube/parse.ts
@@ -36,7 +36,7 @@ export function parseYouTubeUrl(url: string): ParsedYouTubeUrl | null {
     let candidate: string | null = null;
 
     if (host === 'youtu.be' || host === 'www.youtu.be') {
-      candidate = parsed.pathname.split('/').filter(Boolean)[0] ?? null;
+      candidate = parsed.pathname.split('/').find(Boolean) ?? null;
     } else {
       candidate = parsed.searchParams.get('v');
       if (!candidate) {


### PR DESCRIPTION
## Summary
Resolves 10 SonarCloud issues via small, semantically equivalent TypeScript modernizations:

- `lib/blog/getBlogPosts.ts:117` — `replace` → `replaceAll` (S7781)
- `lib/share/copy.ts:119-120` — `replace` → `replaceAll` x2 (S7781)
- `lib/youtube/parse.ts:39` — `.filter(Boolean)[0]` → `.find(Boolean)` (S7750)
- `app/app/(shell)/dashboard/actions/dashboard-data.ts:246` — `if (x === null) x = v` → `x ??= v` (type is `Date | null`, equivalent) (S6606)
- `lib/distribution/instagram-activation.ts:114` — inline union → existing `DateInput` alias (S4323)
- `lib/feature-flags/shared.ts:35` — remove unused deprecated `FeatureFlagKey` alias (S6564) (only self-reference in codebase)
- `app/api/share/story/playlist/route.tsx:38` — `!playlist || playlist.status !== 'published'` → `playlist?.status !== 'published'` (S6582)
- `app/api/share/story/profile/route.tsx:24` — `!profile || !profile.isPublic` → `!profile?.isPublic` (S6582)

## SonarCloud Rules Addressed
- S7781, S7750, S6606, S4323, S6564, S6582

## Test plan
- [x] TypeScript compiles
- [x] Biome check passes
- [x] Pre-commit hooks pass
- [x] No behavior changes — all transforms are semantically equivalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null handling in API endpoints to prevent potential crashes and ensure consistent error responses.
  * Enhanced timestamp tracking for event data collection accuracy.

* **Refactor**
  * Optimized string processing logic for improved performance and maintainability.
  * Simplified type definitions and removed deprecated aliases.
  * Updated URL parsing methods for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->