### PR TITLE
fix: style cleanup flagged by SonarCloud (S7741, S6582)

### DIFF
--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -226,8 +226,7 @@ function getReleaseSupportingLine(
 
   const [primaryArtist, ...featuredArtists] = artistNames;
   if (
-    primaryArtist &&
-    primaryArtist.toLowerCase() === artistName.toLowerCase() &&
+    primaryArtist?.toLowerCase() === artistName.toLowerCase() &&
     featuredArtists.length > 0
   ) {
     return `w/ ${featuredArtists.join(', ')}`;

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -104,7 +104,7 @@ function unwrapNextImageUrl(url: string | null | undefined): string | null {
 }
 
 function getModeFromLocation(fallbackMode: ProfileMode): ProfileMode {
-  if (typeof globalThis.window === 'undefined') {
+  if (globalThis.window === undefined) {
     return fallbackMode;
   }
 
@@ -173,7 +173,7 @@ export function ProfileCompactTemplate({
   }, []);
 
   useEffect(() => {
-    if (typeof globalThis.window === 'undefined') {
+    if (globalThis.window === undefined) {
       return;
     }
 
@@ -212,7 +212,7 @@ export function ProfileCompactTemplate({
   }, [artist.image_url, photoDownloadSizes]);
 
   const initialSource = useMemo(() => {
-    if (typeof globalThis.window === 'undefined') return null;
+    if (globalThis.window === undefined) return null;
     return new URLSearchParams(globalThis.location.search).get('source');
   }, []);
 


### PR DESCRIPTION
## Summary
Resolves 4 SonarCloud issues with small style cleanups:

- `components/features/profile/templates/ProfileCompactTemplate.tsx` — replace 3× `typeof globalThis.window === 'undefined'` with direct `globalThis.window === undefined` comparisons (S7741). Semantically equivalent since `globalThis` is always defined.
- `components/features/profile/templates/ProfileCompactSurface.tsx:229` — collapse `primaryArtist && primaryArtist.toLowerCase() === artistName.toLowerCase()` to `primaryArtist?.toLowerCase() === artistName.toLowerCase()` (S6582). Caller passes non-empty names, so behavior is preserved.

## SonarCloud Rules Addressed
- typescript:S7741 — Compare with `undefined` directly instead of using `typeof`
- typescript:S6582 — Prefer optional chain expression

## Test plan
- [x] TypeScript compiles
- [x] Biome check passes
- [x] Pre-commit hooks pass
- [x] No behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Code quality improvements to internal logic handling.

---

*Note: This release contains no user-facing changes or new features.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->