### PR TITLE
fix(onboarding): add loading and error boundaries to checkout route

### DIFF
--- a/apps/web/app/onboarding/checkout/error.tsx
+++ b/apps/web/app/onboarding/checkout/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { PublicPageErrorFallback } from '@/components/providers/PublicPageErrorFallback';
+import type { ErrorProps } from '@/types/common';
+
+export default function OnboardingCheckoutError({ error }: ErrorProps) {
+  return <PublicPageErrorFallback error={error} context='Checkout' />;
+}

--- a/apps/web/app/onboarding/checkout/loading.tsx
+++ b/apps/web/app/onboarding/checkout/loading.tsx
@@ -1,0 +1,11 @@
+import { AuthPageSkeleton } from '@/features/auth';
+
+/**
+ * Loading skeleton for the onboarding checkout page.
+ * Uses AuthLayout-compatible skeleton since the page wraps in AuthLayout.
+ */
+export default function OnboardingCheckoutLoading() {
+  return (
+    <AuthPageSkeleton formTitle='Upgrade your profile' showFormTitle={false} />
+  );
+}


### PR DESCRIPTION
## Summary
- Add `loading.tsx` and `error.tsx` to `app/onboarding/checkout/` route segment
- Without these, the parent onboarding loading skeleton shows "Preparing your setup / Loading your handle step" during checkout page loads — wrong context for a payment flow
- The new loading skeleton uses `AuthPageSkeleton` (matching the checkout page's `AuthLayout` wrapper)
- The new error boundary uses `PublicPageErrorFallback` with 'Checkout' context

## Test plan
- [x] Typecheck passes
- [x] Biome lint passes  
- [x] Pre-commit hooks pass (lint, typecheck, eslint)
- [x] Pre-push hooks pass (biome, typecheck, lint, tailwind)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated error page for the checkout onboarding flow to gracefully handle and display error messages when checkout operations fail.
  * Implemented visual loading indicator with skeleton display during checkout processing to provide users with consistent, real-time feedback during page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->