### PR TITLE
fix(dashboard): add loading/disabled state to SocialsForm submit button

### DIFF
--- a/apps/web/components/features/dashboard/organisms/socials-form/SocialsForm.tsx
+++ b/apps/web/components/features/dashboard/organisms/socials-form/SocialsForm.tsx
@@ -5,6 +5,7 @@ import { Button, CommonDropdown, Input } from '@jovie/ui';
 import { Plus, Trash2 } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { LoadingSpinner } from '@/components/atoms/LoadingSpinner';
 import { SocialIcon } from '@/components/atoms/SocialIcon';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { ALL_PLATFORMS, PLATFORM_METADATA_MAP } from '@/constants/platforms';
@@ -403,10 +404,19 @@ export function SocialsForm({ artist }: Readonly<SocialsFormProps>) {
             </Button>
             <Button
               type='submit'
+              disabled={loading}
               variant='primary'
               className='w-full sm:w-auto'
+              aria-busy={loading}
             >
-              Save Social Links
+              {loading ? (
+                <div className='flex items-center justify-center space-x-2'>
+                  <LoadingSpinner size='sm' tone='inverse' label='Saving' />
+                  <span>Saving...</span>
+                </div>
+              ) : (
+                'Save Social Links'
+              )}
             </Button>
           </div>
         </form>


### PR DESCRIPTION
## Summary
- Add `disabled={loading}` and `aria-busy={loading}` to the Save Social Links button in `SocialsForm`
- Show spinner + "Saving..." text during submission (matching `ProfileForm` pattern)
- Prevents double-click submissions and provides clear visual feedback

## Test plan
- [x] Typecheck passes
- [x] Biome lint passes
- [x] ESLint passes
- [x] A11y staged check passes
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Save Social Links button now displays loading state during submission with visual feedback and becomes disabled while processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->