### PR TITLE
fix(profile): add loading skeleton for public artist profile route

### DIFF
--- a/apps/web/app/[username]/loading.tsx
+++ b/apps/web/app/[username]/loading.tsx
@@ -1,0 +1,35 @@
+/**
+ * Loading skeleton for public artist profile pages.
+ *
+ * Shows a minimal, themed placeholder while the profile data is fetched
+ * on client-side navigation between profiles.
+ */
+export default function ProfileLoading() {
+  return (
+    <div className='min-h-dvh bg-base'>
+      <div className='mx-auto max-w-2xl px-4 pt-24 pb-16'>
+        {/* Avatar placeholder */}
+        <div className='flex flex-col items-center'>
+          <div className='h-24 w-24 rounded-full bg-surface-raised animate-pulse' />
+          {/* Name placeholder */}
+          <div className='mt-4 h-6 w-40 rounded-lg bg-surface-raised animate-pulse' />
+          {/* Handle placeholder */}
+          <div className='mt-2 h-4 w-24 rounded-md bg-surface-raised animate-pulse' />
+        </div>
+
+        {/* Bio placeholder */}
+        <div className='mt-8 space-y-2'>
+          <div className='mx-auto h-3 w-full max-w-xs rounded bg-surface-raised animate-pulse' />
+          <div className='mx-auto h-3 w-3/4 max-w-xs rounded bg-surface-raised animate-pulse' />
+        </div>
+
+        {/* Link buttons placeholder */}
+        <div className='mt-10 space-y-3'>
+          <div className='mx-auto h-12 w-full max-w-sm rounded-xl bg-surface-raised animate-pulse' />
+          <div className='mx-auto h-12 w-full max-w-sm rounded-xl bg-surface-raised animate-pulse' />
+          <div className='mx-auto h-12 w-full max-w-sm rounded-xl bg-surface-raised animate-pulse' />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `loading.tsx` to the `[username]` route segment for public artist profiles
- The route is `force-dynamic` with multiple DB queries but had no loading state, causing a blank flash during client-side navigation between profiles
- Skeleton shows avatar circle, name bar, handle bar, bio lines, and 3 link button placeholders using design system tokens with pulse animation

## Test plan
- [x] Typecheck passes
- [x] Biome lint passes (no warnings)
- [x] ESLint passes
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading skeleton UI for artist profile pages. Users now see animated placeholders for profile information (avatar, name, bio, and action buttons) while data loads, providing a smoother visual experience during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->