### PR TITLE
refactor(ui): standardize common dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,24 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ## [26.4.153.2] - 2026-04-15
 
+> Dropdown menus are now more consistent across the app, with better search, keyboard behavior, and loading states. Drawer detail panes also have a cleaner shared layout for compact record details. Theme setup also happens earlier so pages avoid the brief visual mismatch on load.
+
 ### Added
 
 - Shared drawer inspector card, stack, and fixed label/value grid primitives for Linear-style detail panes.
+- Shared dropdown menus now support consistent loading, selected, active, danger, trailing content, count, and searchable nested states through the common dropdown primitive
+- Recursive dropdown search now supports submenu-local filters, custom radio-item matching, and regression coverage for keyboard search flows
+
+### Changed
+
+- [internal] Common dropdown rendering is split into focused renderer, item renderer, type, and utility modules so future menu variants reuse the same styles and behavior
+- Common dropdown, context menu, and submenu surfaces now draw from the same centralized menu style tokens
+
+### Fixed
+
+- Searchable dropdowns preserve keyboard access: Escape clears search before closing, arrow navigation can leave the search field, Enter can activate the first result, and clear keeps focus in the input
+- Controlled dropdown close no longer emits duplicate empty search callbacks, while the legacy `onSearch` callback remains limited to non-empty queries
+- Theme initialization runs before first paint without reintroducing the local hydration mismatch
 
 ## [26.4.153.1] - 2026-04-13
 

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -202,7 +202,8 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <head suppressHydrationWarning>
-        <script defer src='/theme-init.js' />
+        {/* eslint-disable-next-line @next/next/no-sync-scripts -- Theme init must run before first paint and stays static in /public. */}
+        <script src='/theme-init.js' />
       </head>
       <body className={bodyClassName}>
         {FlagBadgeProvider ? (

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata, Viewport } from 'next';
 import localFont from 'next/font/local';
-import Script from 'next/script';
 import React from 'react';
 import { APP_NAME, BASE_URL } from '@/constants/app';
 import './globals.css';
@@ -139,12 +138,6 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  // Read CSP nonce. headers() opts into dynamic rendering which breaks ISR pages
-  // ("Page changed from static to dynamic at runtime"). Only call headers() when
-  // we know we're in a fully dynamic context (authenticated app routes). Public
-  // ISR pages (profiles, smart links) don't need nonce — CSP uses hashes instead.
-  const nonce = undefined;
-
   const isE2EClientRuntime =
     process.env.NEXT_PUBLIC_E2E_MODE === '1' ||
     process.env.E2E_USE_TEST_AUTH_BYPASS === '1';
@@ -209,11 +202,7 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <head suppressHydrationWarning>
-        <Script
-          src='/theme-init.js'
-          strategy='beforeInteractive'
-          nonce={nonce}
-        />
+        <script defer src='/theme-init.js' />
       </head>
       <body className={bodyClassName}>
         {FlagBadgeProvider ? (

--- a/packages/ui/atoms/common-dropdown-item-renderers.tsx
+++ b/packages/ui/atoms/common-dropdown-item-renderers.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { Check, Circle, Loader2 } from 'lucide-react';
+import * as React from 'react';
+
+import {
+  CHECKBOX_RADIO_ITEM_BASE,
+  MENU_BADGE_BASE,
+  MENU_ITEM_DESCRIPTION_BASE,
+  MENU_ITEM_DESTRUCTIVE,
+  MENU_ITEM_SELECTED,
+  MENU_LABEL_BASE,
+  MENU_LEADING_SLOT_BASE,
+  MENU_SEPARATOR_BASE,
+  MENU_SHORTCUT_BASE,
+  MENU_TRAILING_SLOT_BASE,
+} from '../lib/dropdown-styles';
+import { cn } from '../lib/utils';
+import type {
+  MenuPrimitiveKind,
+  MenuRenderContext,
+} from './common-dropdown-renderer';
+import type {
+  CommonDropdownActionItem,
+  CommonDropdownCheckboxItem,
+  CommonDropdownItem,
+  CommonDropdownRadioGroup,
+  CommonDropdownRadioItem,
+} from './common-dropdown-types';
+import { isLabel } from './common-dropdown-types';
+
+function isIconComponent(
+  value: unknown
+): value is React.ComponentType<{ className?: string }> {
+  return (
+    typeof value === 'function' ||
+    (typeof value === 'object' && value !== null && '$$typeof' in value)
+  );
+}
+
+export function renderIcon(
+  IconComponent:
+    | React.ComponentType<{ className?: string }>
+    | React.ReactNode
+    | undefined,
+  className: string
+): React.ReactNode {
+  if (!IconComponent) return null;
+
+  if (React.isValidElement<{ className?: string }>(IconComponent)) {
+    return React.cloneElement(IconComponent, {
+      className: cn(IconComponent.props.className, className),
+    });
+  }
+
+  if (isIconComponent(IconComponent)) {
+    const Comp = IconComponent;
+    return <Comp className={className} />;
+  }
+
+  return IconComponent;
+}
+
+function StructuredMenuLabel({
+  label,
+  description,
+}: {
+  readonly label: string;
+  readonly description?: string;
+}) {
+  if (!description) {
+    return <span className='min-w-0 flex-1 truncate'>{label}</span>;
+  }
+
+  return (
+    <span className='flex min-w-0 flex-1 flex-col gap-0.5 text-left'>
+      <span className='truncate'>{label}</span>
+      <span className={MENU_ITEM_DESCRIPTION_BASE}>{description}</span>
+    </span>
+  );
+}
+
+function renderBadge(
+  badge: CommonDropdownActionItem['badge'] | undefined
+): React.ReactNode {
+  if (!badge) return null;
+
+  return (
+    <span
+      className={MENU_BADGE_BASE}
+      style={
+        badge.color
+          ? { backgroundColor: badge.color, color: 'white' }
+          : undefined
+      }
+    >
+      {badge.text}
+    </span>
+  );
+}
+
+function renderCount(count: number | undefined): React.ReactNode {
+  if (count === undefined) return null;
+  return <span className={MENU_BADGE_BASE}>{count}</span>;
+}
+
+export function renderSeparator(
+  item: CommonDropdownItem,
+  kind: MenuPrimitiveKind
+): React.ReactNode {
+  const Separator =
+    kind === 'context'
+      ? ContextMenuPrimitive.Separator
+      : DropdownMenuPrimitive.Separator;
+
+  return (
+    <Separator
+      key={item.id}
+      className={cn(MENU_SEPARATOR_BASE, item.className)}
+    />
+  );
+}
+
+export function renderLabel(
+  item: CommonDropdownItem,
+  kind: MenuPrimitiveKind
+): React.ReactNode {
+  if (!isLabel(item)) return null;
+
+  const Label =
+    kind === 'context'
+      ? ContextMenuPrimitive.Label
+      : DropdownMenuPrimitive.Label;
+
+  return (
+    <Label
+      key={item.id}
+      className={cn(MENU_LABEL_BASE, item.inset && 'pl-10', item.className)}
+    >
+      {item.label}
+    </Label>
+  );
+}
+
+export function renderActionItem(
+  item: CommonDropdownActionItem,
+  context: MenuRenderContext
+): React.ReactNode {
+  const MenuItem =
+    context.kind === 'context'
+      ? ContextMenuPrimitive.Item
+      : DropdownMenuPrimitive.Item;
+  const isDestructive =
+    item.variant === 'destructive' || item.state === 'danger';
+  const isSelected = item.selected || item.state === 'active';
+  const isDisabled = item.disabled || item.loading;
+
+  return (
+    <MenuItem
+      key={item.id}
+      data-menu-row=''
+      disabled={isDisabled}
+      onSelect={event => {
+        event.stopPropagation();
+        if (item.closeOnSelect === false || item.loading) {
+          event.preventDefault();
+        }
+        if (!isDisabled) {
+          item.onClick();
+        }
+      }}
+      className={cn(
+        context.itemBase,
+        isSelected && MENU_ITEM_SELECTED,
+        isDestructive && MENU_ITEM_DESTRUCTIVE,
+        item.className
+      )}
+    >
+      <span className={MENU_LEADING_SLOT_BASE}>
+        {item.loading ? (
+          <Loader2 className='h-3.5 w-3.5 animate-spin motion-reduce:animate-none' />
+        ) : (
+          renderIcon(item.icon, 'h-4 w-4')
+        )}
+      </span>
+      <StructuredMenuLabel label={item.label} description={item.description} />
+      <span className={MENU_TRAILING_SLOT_BASE}>
+        {item.trailing}
+        {renderBadge(item.badge)}
+        {item.subText ? (
+          <span className='text-[11px] text-(--linear-text-tertiary)'>
+            {item.subText}
+          </span>
+        ) : null}
+        {item.shortcut ? (
+          <span className={MENU_SHORTCUT_BASE}>{item.shortcut}</span>
+        ) : null}
+        {renderIcon(item.iconAfter, 'h-4 w-4')}
+        {isSelected &&
+        !item.trailing &&
+        !item.badge &&
+        !item.subText &&
+        !item.shortcut &&
+        !item.iconAfter ? (
+          <Check className='h-4 w-4' />
+        ) : null}
+      </span>
+    </MenuItem>
+  );
+}
+
+export function renderCheckboxItem(
+  item: CommonDropdownCheckboxItem,
+  context: MenuRenderContext
+): React.ReactNode {
+  const CheckboxItem =
+    context.kind === 'context'
+      ? ContextMenuPrimitive.CheckboxItem
+      : DropdownMenuPrimitive.CheckboxItem;
+  const ItemIndicator =
+    context.kind === 'context'
+      ? ContextMenuPrimitive.ItemIndicator
+      : DropdownMenuPrimitive.ItemIndicator;
+  const isDisabled = item.disabled || item.loading;
+
+  return (
+    <CheckboxItem
+      key={item.id}
+      data-menu-row=''
+      checked={item.checked}
+      onCheckedChange={checked => item.onCheckedChange(Boolean(checked))}
+      onSelect={event => event.preventDefault()}
+      disabled={isDisabled}
+      className={cn(CHECKBOX_RADIO_ITEM_BASE, 'gap-1.5', item.className)}
+    >
+      <span className='absolute left-2 flex h-4 w-4 items-center justify-center'>
+        <ItemIndicator>
+          <Check className='h-4 w-4' />
+        </ItemIndicator>
+      </span>
+      <span className={MENU_LEADING_SLOT_BASE}>
+        {item.loading ? (
+          <Loader2 className='h-3.5 w-3.5 animate-spin motion-reduce:animate-none' />
+        ) : (
+          renderIcon(item.icon, 'h-4 w-4')
+        )}
+      </span>
+      <StructuredMenuLabel label={item.label} description={item.description} />
+      <span className={MENU_TRAILING_SLOT_BASE}>{renderCount(item.count)}</span>
+    </CheckboxItem>
+  );
+}
+
+export function renderRadioGroup(
+  item: CommonDropdownRadioGroup,
+  context: MenuRenderContext
+): React.ReactNode {
+  const RadioGroup =
+    context.kind === 'context'
+      ? ContextMenuPrimitive.RadioGroup
+      : DropdownMenuPrimitive.RadioGroup;
+
+  return (
+    <RadioGroup
+      key={item.id}
+      value={item.value}
+      onValueChange={item.onValueChange}
+    >
+      {item.items.map(radioItem => renderRadioItem(radioItem, context))}
+    </RadioGroup>
+  );
+}
+
+function renderRadioItem(
+  item: Omit<CommonDropdownRadioItem, 'type'>,
+  context: MenuRenderContext
+): React.ReactNode {
+  const RadioItem =
+    context.kind === 'context'
+      ? ContextMenuPrimitive.RadioItem
+      : DropdownMenuPrimitive.RadioItem;
+  const ItemIndicator =
+    context.kind === 'context'
+      ? ContextMenuPrimitive.ItemIndicator
+      : DropdownMenuPrimitive.ItemIndicator;
+  const isDisabled = item.disabled || item.loading;
+
+  return (
+    <RadioItem
+      key={item.id}
+      data-menu-row=''
+      value={item.value}
+      disabled={isDisabled}
+      className={cn(CHECKBOX_RADIO_ITEM_BASE, 'gap-1.5', item.className)}
+    >
+      <span className='absolute left-2 flex h-4 w-4 items-center justify-center'>
+        <ItemIndicator>
+          <Circle className='h-2 w-2 fill-current' />
+        </ItemIndicator>
+      </span>
+      <span className={MENU_LEADING_SLOT_BASE}>
+        {item.loading ? (
+          <Loader2 className='h-3.5 w-3.5 animate-spin motion-reduce:animate-none' />
+        ) : (
+          renderIcon(item.icon, 'h-4 w-4')
+        )}
+      </span>
+      <StructuredMenuLabel label={item.label} description={item.description} />
+      <span className={MENU_TRAILING_SLOT_BASE}>{renderCount(item.count)}</span>
+    </RadioItem>
+  );
+}

--- a/packages/ui/atoms/common-dropdown-item-renderers.tsx
+++ b/packages/ui/atoms/common-dropdown-item-renderers.tsx
@@ -36,7 +36,7 @@ function isIconComponent(
 ): value is React.ComponentType<{ className?: string }> {
   return (
     typeof value === 'function' ||
-    (typeof value === 'object' && value !== null && '$$typeof' in value)
+    Boolean(value && typeof value === 'object' && '$$typeof' in value)
   );
 }
 

--- a/packages/ui/atoms/common-dropdown-item-renderers.tsx
+++ b/packages/ui/atoms/common-dropdown-item-renderers.tsx
@@ -161,6 +161,8 @@ export function renderActionItem(
     <MenuItem
       key={item.id}
       data-menu-row=''
+      data-menu-variant={isDestructive ? 'danger' : undefined}
+      data-selected={isSelected ? 'true' : undefined}
       disabled={isDisabled}
       onSelect={event => {
         event.stopPropagation();

--- a/packages/ui/atoms/common-dropdown-renderer.tsx
+++ b/packages/ui/atoms/common-dropdown-renderer.tsx
@@ -75,11 +75,11 @@ export function SearchableContent({
           value={query}
           onChange={event => onQueryChange(event.target.value)}
           onKeyDown={event => {
-            event.stopPropagation();
-            if (event.key === 'Escape' && query) {
-              event.preventDefault();
-              onClear();
+            if (event.key === 'Escape') {
+              return;
             }
+
+            event.stopPropagation();
           }}
           className={MENU_SEARCH_INPUT_BASE}
         />

--- a/packages/ui/atoms/common-dropdown-renderer.tsx
+++ b/packages/ui/atoms/common-dropdown-renderer.tsx
@@ -69,7 +69,7 @@ function focusSiblingMenuItem(
     )
   ).filter(
     item =>
-      !item.hasAttribute('data-disabled') &&
+      item.dataset.disabled === undefined &&
       item.getAttribute('aria-disabled') !== 'true'
   );
 

--- a/packages/ui/atoms/common-dropdown-renderer.tsx
+++ b/packages/ui/atoms/common-dropdown-renderer.tsx
@@ -1,0 +1,313 @@
+'use client';
+
+import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { ChevronRight, Loader2, Search, X } from 'lucide-react';
+import * as React from 'react';
+
+import {
+  CONTEXT_TRANSFORM_ORIGIN,
+  DROPDOWN_TRANSFORM_ORIGIN,
+  MENU_EMPTY_STATE_BASE,
+  MENU_LEADING_SLOT_BASE,
+  MENU_LOADING_STATE_BASE,
+  MENU_SEARCH_HEADER_BASE,
+  MENU_SEARCH_INPUT_BASE,
+  subMenuContentClasses,
+} from '../lib/dropdown-styles';
+import { cn } from '../lib/utils';
+import {
+  renderActionItem,
+  renderCheckboxItem,
+  renderIcon,
+  renderLabel,
+  renderRadioGroup,
+  renderSeparator,
+} from './common-dropdown-item-renderers';
+import type {
+  CommonDropdownItem,
+  CommonDropdownSubmenu,
+} from './common-dropdown-types';
+import {
+  isActionItem,
+  isCheckboxItem,
+  isCustomItem,
+  isLabel,
+  isRadioGroup,
+  isSeparator,
+  isSubmenu,
+} from './common-dropdown-types';
+import { filterItems, getContentStyle } from './common-dropdown-utils';
+
+export type MenuPrimitiveKind = 'dropdown' | 'context';
+
+export type MenuRenderContext = {
+  readonly kind: MenuPrimitiveKind;
+  readonly itemBase: string;
+  readonly disablePortal: boolean;
+  readonly portalProps?: Record<string, unknown>;
+};
+
+type SearchableContentProps = {
+  readonly query: string;
+  readonly placeholder: string;
+  readonly onQueryChange: (query: string) => void;
+  readonly onClear: () => void;
+  readonly inputRef?: React.Ref<HTMLInputElement>;
+};
+
+export function SearchableContent({
+  query,
+  placeholder,
+  onQueryChange,
+  onClear,
+  inputRef,
+}: SearchableContentProps) {
+  return (
+    <div data-menu-header className={MENU_SEARCH_HEADER_BASE}>
+      <div className='relative'>
+        <Search className='pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-(--linear-text-tertiary)' />
+        <input
+          ref={inputRef}
+          type='text'
+          placeholder={placeholder}
+          aria-label={placeholder}
+          value={query}
+          onChange={event => onQueryChange(event.target.value)}
+          onKeyDown={event => {
+            event.stopPropagation();
+            if (event.key === 'Escape' && query) {
+              event.preventDefault();
+              onClear();
+            }
+          }}
+          className={MENU_SEARCH_INPUT_BASE}
+        />
+        {query ? (
+          <button
+            type='button'
+            onClick={onClear}
+            className='absolute right-1.5 top-1/2 inline-flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded-(--linear-app-radius-item) text-(--linear-text-tertiary) hover:bg-(--linear-bg-surface-2) hover:text-(--linear-text-primary) focus-visible:outline-none focus-visible:bg-(--linear-bg-surface-2)'
+            aria-label='Clear search'
+          >
+            <X className='h-3 w-3' />
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div className={MENU_LOADING_STATE_BASE}>
+      <Loader2 className='h-4 w-4 animate-spin motion-reduce:animate-none' />
+    </div>
+  );
+}
+
+function EmptyState({ message }: { readonly message: string }) {
+  return <div className={MENU_EMPTY_STATE_BASE}>{message}</div>;
+}
+
+export function renderRootBody({
+  isLoading,
+  items,
+  emptyMessage,
+  renderItems,
+}: {
+  readonly isLoading: boolean;
+  readonly items: readonly CommonDropdownItem[];
+  readonly emptyMessage: string;
+  readonly renderItems: (
+    itemsToRender: readonly CommonDropdownItem[]
+  ) => React.ReactNode;
+}) {
+  if (isLoading) {
+    return <LoadingState />;
+  }
+
+  if (items.length === 0) {
+    return <EmptyState message={emptyMessage} />;
+  }
+
+  return renderItems(items);
+}
+
+export function renderItem(
+  item: CommonDropdownItem,
+  context: MenuRenderContext
+): React.ReactNode {
+  if (isSeparator(item)) {
+    return renderSeparator(item, context.kind);
+  }
+
+  if (isLabel(item)) {
+    return renderLabel(item, context.kind);
+  }
+
+  if (isActionItem(item)) {
+    return renderActionItem(item, context);
+  }
+
+  if (isCheckboxItem(item)) {
+    return renderCheckboxItem(item, context);
+  }
+
+  if (isRadioGroup(item)) {
+    return renderRadioGroup(item, context);
+  }
+
+  if (isSubmenu(item)) {
+    return (
+      <CommonDropdownSubmenuRenderer
+        key={item.id}
+        item={item}
+        context={context}
+      />
+    );
+  }
+
+  if (isCustomItem(item)) {
+    return <React.Fragment key={item.id}>{item.render()}</React.Fragment>;
+  }
+
+  return null;
+}
+
+function CommonDropdownSubmenuRenderer({
+  item,
+  context,
+}: {
+  readonly item: CommonDropdownSubmenu;
+  readonly context: MenuRenderContext;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const [query, setQuery] = React.useState('');
+  const contentRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const Sub =
+    context.kind === 'context'
+      ? ContextMenuPrimitive.Sub
+      : DropdownMenuPrimitive.Sub;
+  const SubTrigger =
+    context.kind === 'context'
+      ? ContextMenuPrimitive.SubTrigger
+      : DropdownMenuPrimitive.SubTrigger;
+  const Portal =
+    context.kind === 'context'
+      ? ContextMenuPrimitive.Portal
+      : DropdownMenuPrimitive.Portal;
+  const SubContent =
+    context.kind === 'context'
+      ? ContextMenuPrimitive.SubContent
+      : DropdownMenuPrimitive.SubContent;
+  const transformOrigin =
+    context.kind === 'context'
+      ? CONTEXT_TRANSFORM_ORIGIN
+      : DROPDOWN_TRANSFORM_ORIGIN;
+  const filteredItems = React.useMemo(
+    () => filterItems(item.items, query, 'recursive', item.filterItem),
+    [item.filterItem, item.items, query]
+  );
+
+  React.useEffect(() => {
+    if (!open || !item.searchable) return;
+
+    const timer = globalThis.setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+
+    return () => globalThis.clearTimeout(timer);
+  }, [item.searchable, open]);
+
+  const handleQueryChange = React.useCallback(
+    (nextQuery: string) => {
+      setQuery(nextQuery);
+      item.onSearchChange?.(nextQuery);
+    },
+    [item]
+  );
+
+  const clearQuery = React.useCallback(() => {
+    handleQueryChange('');
+  }, [handleQueryChange]);
+
+  const content = (
+    <SubContent
+      ref={contentRef}
+      data-menu-surface='toolbar'
+      className={cn(subMenuContentClasses, transformOrigin)}
+      style={getContentStyle(item.minWidth, item.maxHeight)}
+      onFocusOutside={event => {
+        if (contentRef.current?.contains(event.target as Node)) {
+          event.preventDefault();
+        }
+      }}
+      onPointerDownOutside={event => {
+        if (contentRef.current?.contains(event.target as Node)) {
+          event.preventDefault();
+        }
+      }}
+      onEscapeKeyDown={event => {
+        if (query) {
+          event.preventDefault();
+          clearQuery();
+        }
+      }}
+    >
+      {item.searchable ? (
+        <SearchableContent
+          query={query}
+          placeholder={item.searchPlaceholder ?? `Search ${item.label}`}
+          onQueryChange={handleQueryChange}
+          onClear={clearQuery}
+          inputRef={inputRef}
+        />
+      ) : null}
+      {renderRootBody({
+        isLoading: item.isLoading ?? false,
+        items: filteredItems,
+        emptyMessage: item.emptyMessage ?? 'No items found',
+        renderItems: itemsToRender =>
+          itemsToRender.map(child => renderItem(child, context)),
+      })}
+    </SubContent>
+  );
+
+  return (
+    <Sub
+      key={item.id}
+      open={open}
+      onOpenChange={nextOpen => {
+        setOpen(nextOpen);
+        if (!nextOpen) {
+          clearQuery();
+        }
+      }}
+    >
+      <SubTrigger
+        disabled={item.disabled}
+        data-menu-row=''
+        className={cn(context.itemBase, item.className)}
+      >
+        <span className={MENU_LEADING_SLOT_BASE}>
+          {renderIcon(item.icon, 'h-4 w-4')}
+        </span>
+        <span className='min-w-0 flex-1 truncate'>{item.label}</span>
+        <ChevronRight className='ml-auto h-3.5 w-3.5' />
+      </SubTrigger>
+      {context.disablePortal ? (
+        content
+      ) : (
+        <Portal
+          {...(context.portalProps as React.ComponentPropsWithoutRef<
+            typeof DropdownMenuPrimitive.Portal
+          >)}
+        >
+          {content}
+        </Portal>
+      )}
+    </Sub>
+  );
+}

--- a/packages/ui/atoms/common-dropdown-renderer.tsx
+++ b/packages/ui/atoms/common-dropdown-renderer.tsx
@@ -56,6 +56,28 @@ type SearchableContentProps = {
   readonly inputRef?: React.Ref<HTMLInputElement>;
 };
 
+function focusSiblingMenuItem(
+  input: HTMLInputElement | null,
+  placement: 'first' | 'last'
+): HTMLElement | undefined {
+  const menu = input?.closest('[role="menu"]');
+  if (!menu) return undefined;
+
+  const menuItems = Array.from(
+    menu.querySelectorAll<HTMLElement>(
+      '[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]'
+    )
+  ).filter(
+    item =>
+      !item.hasAttribute('data-disabled') &&
+      item.getAttribute('aria-disabled') !== 'true'
+  );
+
+  const nextItem = placement === 'first' ? menuItems.at(0) : menuItems.at(-1);
+  nextItem?.focus();
+  return nextItem;
+}
+
 export function SearchableContent({
   query,
   placeholder,
@@ -63,12 +85,30 @@ export function SearchableContent({
   onClear,
   inputRef,
 }: SearchableContentProps) {
+  const localInputRef = React.useRef<HTMLInputElement | null>(null);
+  const setInputRef = React.useCallback(
+    (node: HTMLInputElement | null) => {
+      localInputRef.current = node;
+
+      if (typeof inputRef === 'function') {
+        inputRef(node);
+        return;
+      }
+
+      if (inputRef) {
+        (inputRef as React.MutableRefObject<HTMLInputElement | null>).current =
+          node;
+      }
+    },
+    [inputRef]
+  );
+
   return (
     <div data-menu-header className={MENU_SEARCH_HEADER_BASE}>
       <div className='relative'>
         <Search className='pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-(--linear-text-tertiary)' />
         <input
-          ref={inputRef}
+          ref={setInputRef}
           type='text'
           placeholder={placeholder}
           aria-label={placeholder}
@@ -79,6 +119,23 @@ export function SearchableContent({
               return;
             }
 
+            if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+              event.preventDefault();
+              event.stopPropagation();
+              focusSiblingMenuItem(
+                localInputRef.current,
+                event.key === 'ArrowDown' ? 'first' : 'last'
+              );
+              return;
+            }
+
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              event.stopPropagation();
+              focusSiblingMenuItem(localInputRef.current, 'first')?.click();
+              return;
+            }
+
             event.stopPropagation();
           }}
           className={MENU_SEARCH_INPUT_BASE}
@@ -86,7 +143,11 @@ export function SearchableContent({
         {query ? (
           <button
             type='button'
-            onClick={onClear}
+            onMouseDown={event => event.preventDefault()}
+            onClick={() => {
+              onClear();
+              localInputRef.current?.focus();
+            }}
             className='absolute right-1.5 top-1/2 inline-flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded-(--linear-app-radius-item) text-(--linear-text-tertiary) hover:bg-(--linear-bg-surface-2) hover:text-(--linear-text-primary) focus-visible:outline-none focus-visible:bg-(--linear-bg-surface-2)'
             aria-label='Clear search'
           >

--- a/packages/ui/atoms/common-dropdown-renderer.tsx
+++ b/packages/ui/atoms/common-dropdown-renderer.tsx
@@ -161,8 +161,12 @@ export function SearchableContent({
 
 function LoadingState() {
   return (
-    <div className={MENU_LOADING_STATE_BASE}>
-      <Loader2 className='h-4 w-4 animate-spin motion-reduce:animate-none' />
+    <div role='status' aria-live='polite' className={MENU_LOADING_STATE_BASE}>
+      <Loader2
+        aria-hidden='true'
+        className='h-4 w-4 animate-spin motion-reduce:animate-none'
+      />
+      <span className='sr-only'>Loading menu items</span>
     </div>
   );
 }
@@ -342,7 +346,7 @@ function CommonDropdownSubmenuRenderer({
       open={open}
       onOpenChange={nextOpen => {
         setOpen(nextOpen);
-        if (!nextOpen) {
+        if (!nextOpen && query) {
           clearQuery();
         }
       }}

--- a/packages/ui/atoms/common-dropdown-types.ts
+++ b/packages/ui/atoms/common-dropdown-types.ts
@@ -319,23 +319,6 @@ export interface CommonDropdownProps {
   readonly children?: ReactNode;
 }
 
-/**
- * Select-specific props for select variant
- */
-export interface CommonDropdownSelectProps
-  extends Omit<CommonDropdownProps, 'variant' | 'items'> {
-  readonly variant: 'select';
-  readonly value: string;
-  readonly onValueChange: (value: string) => void;
-  readonly options: Array<{
-    readonly value: string;
-    readonly label: string;
-    readonly icon?: LucideIcon;
-    readonly disabled?: boolean;
-  }>;
-  readonly placeholder?: string;
-}
-
 // Type guard utilities
 export function isActionItem(
   item: CommonDropdownItem

--- a/packages/ui/atoms/common-dropdown-types.ts
+++ b/packages/ui/atoms/common-dropdown-types.ts
@@ -111,7 +111,7 @@ export interface CommonDropdownSubmenu extends CommonDropdownBaseItem {
   searchPlaceholder?: string;
   emptyMessage?: string;
   isLoading?: boolean;
-  filterItem?: (item: CommonDropdownItem, query: string) => boolean;
+  filterItem?: CommonDropdownFilterItemPredicate;
   onSearchChange?: (query: string) => void;
   minWidth?: number | string;
   maxHeight?: number | string;
@@ -152,6 +152,15 @@ export type CommonDropdownItem =
   | CommonDropdownSeparator
   | CommonDropdownLabel
   | CommonDropdownCustomItem;
+
+export type CommonDropdownFilterItem =
+  | CommonDropdownItem
+  | CommonDropdownRadioItem;
+
+export type CommonDropdownFilterItemPredicate = (
+  item: CommonDropdownFilterItem,
+  query: string
+) => boolean;
 
 /**
  * Main component props
@@ -272,7 +281,7 @@ export interface CommonDropdownProps {
   /**
    * Custom filter for searchable menu items.
    */
-  readonly filterItem?: (item: CommonDropdownItem, query: string) => boolean;
+  readonly filterItem?: CommonDropdownFilterItemPredicate;
 
   /**
    * Reset root search state when the dropdown closes.

--- a/packages/ui/atoms/common-dropdown-types.ts
+++ b/packages/ui/atoms/common-dropdown-types.ts
@@ -48,8 +48,14 @@ export interface CommonDropdownActionItem extends CommonDropdownBaseItem {
   iconAfter?: LucideIcon | ReactNode; // For trailing icons/badges
   onClick: () => void;
   variant?: 'default' | 'destructive';
+  state?: 'default' | 'active' | 'success' | 'warning' | 'danger';
+  selected?: boolean;
+  loading?: boolean;
+  closeOnSelect?: boolean;
   shortcut?: string; // e.g., "⌘K"
   subText?: string; // Secondary text (right-aligned)
+  description?: string;
+  trailing?: ReactNode;
   badge?: {
     text: string;
     color?: string; // Hex color for badge background
@@ -64,7 +70,10 @@ export interface CommonDropdownCheckboxItem extends CommonDropdownBaseItem {
   label: string;
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
-  icon?: LucideIcon;
+  icon?: LucideIcon | ReactNode;
+  description?: string;
+  count?: number;
+  loading?: boolean;
 }
 
 /**
@@ -75,6 +84,9 @@ export interface CommonDropdownRadioItem extends CommonDropdownBaseItem {
   label: string;
   value: string;
   icon?: LucideIcon | ReactNode;
+  description?: string;
+  count?: number;
+  loading?: boolean;
 }
 
 /**
@@ -95,6 +107,14 @@ export interface CommonDropdownSubmenu extends CommonDropdownBaseItem {
   label: string;
   icon?: LucideIcon | ReactNode;
   items: CommonDropdownItem[];
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  emptyMessage?: string;
+  isLoading?: boolean;
+  filterItem?: (item: CommonDropdownItem, query: string) => boolean;
+  onSearchChange?: (query: string) => void;
+  minWidth?: number | string;
+  maxHeight?: number | string;
 }
 
 /**
@@ -235,6 +255,39 @@ export interface CommonDropdownProps {
    * Filter function for searchable dropdowns
    */
   readonly onSearch?: (query: string) => void;
+
+  /**
+   * Callback when the root search query changes. Called for every change,
+   * including clearing back to an empty string.
+   */
+  readonly onSearchChange?: (query: string) => void;
+
+  /**
+   * Search behavior for nested menu trees.
+   * - 'root': filter root-level items only
+   * - 'recursive': keep matching submenu branches and filter descendants
+   */
+  readonly searchMode?: 'root' | 'recursive';
+
+  /**
+   * Custom filter for searchable menu items.
+   */
+  readonly filterItem?: (item: CommonDropdownItem, query: string) => boolean;
+
+  /**
+   * Reset root search state when the dropdown closes.
+   */
+  readonly resetSearchOnClose?: boolean;
+
+  /**
+   * Content min-width override.
+   */
+  readonly minWidth?: number | string;
+
+  /**
+   * Content max-height override.
+   */
+  readonly maxHeight?: number | string;
 
   /**
    * Loading state (shows spinner)

--- a/packages/ui/atoms/common-dropdown-utils.ts
+++ b/packages/ui/atoms/common-dropdown-utils.ts
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react';
 import type {
+  CommonDropdownFilterItemPredicate,
   CommonDropdownItem,
   CommonDropdownRadioItem,
 } from './common-dropdown-types';
@@ -47,15 +48,20 @@ function defaultFilterItem(item: CommonDropdownItem, query: string): boolean {
 function itemMatches(
   item: CommonDropdownItem,
   query: string,
-  filterItem?: (item: CommonDropdownItem, query: string) => boolean
+  filterItem?: CommonDropdownFilterItemPredicate
 ): boolean {
   return (filterItem ?? defaultFilterItem)(item, query);
 }
 
 function radioItemMatches(
   item: Omit<CommonDropdownRadioItem, 'type'>,
-  query: string
+  query: string,
+  filterItem?: CommonDropdownFilterItemPredicate
 ): boolean {
+  if (filterItem) {
+    return filterItem({ ...item, type: 'radio' }, query);
+  }
+
   const normalizedQuery = query.trim().toLowerCase();
   if (!normalizedQuery) return true;
 
@@ -98,7 +104,7 @@ export function filterItems(
   items: readonly CommonDropdownItem[],
   query: string,
   searchMode: 'root' | 'recursive',
-  filterItem?: (item: CommonDropdownItem, query: string) => boolean
+  filterItem?: CommonDropdownFilterItemPredicate
 ): CommonDropdownItem[] {
   const trimmedQuery = query.trim();
   if (!trimmedQuery) {
@@ -112,7 +118,7 @@ export function filterItems(
 
     if (isRadioGroup(item)) {
       const matchingItems = item.items.filter(radioItem =>
-        radioItemMatches(radioItem, trimmedQuery)
+        radioItemMatches(radioItem, trimmedQuery, filterItem)
       );
 
       return matchingItems.length > 0
@@ -121,7 +127,8 @@ export function filterItems(
     }
 
     if (isSubmenu(item)) {
-      const submenuMatches = itemMatches(item, trimmedQuery, filterItem);
+      const submenuFilterItem = item.filterItem ?? filterItem;
+      const submenuMatches = itemMatches(item, trimmedQuery, submenuFilterItem);
 
       if (searchMode === 'root') {
         return submenuMatches ? [item] : [];
@@ -131,7 +138,7 @@ export function filterItems(
         item.items,
         trimmedQuery,
         'recursive',
-        item.filterItem ?? filterItem
+        submenuFilterItem
       );
 
       if (submenuMatches) {

--- a/packages/ui/atoms/common-dropdown-utils.ts
+++ b/packages/ui/atoms/common-dropdown-utils.ts
@@ -142,7 +142,7 @@ export function filterItems(
       );
 
       if (submenuMatches) {
-        return [item];
+        return [{ ...item, items: filteredChildren }];
       }
 
       return filteredChildren.length > 0

--- a/packages/ui/atoms/common-dropdown-utils.ts
+++ b/packages/ui/atoms/common-dropdown-utils.ts
@@ -1,0 +1,161 @@
+import type { CSSProperties } from 'react';
+import type {
+  CommonDropdownItem,
+  CommonDropdownRadioItem,
+} from './common-dropdown-types';
+import {
+  isActionItem,
+  isCheckboxItem,
+  isCustomItem,
+  isLabel,
+  isRadioGroup,
+  isSeparator,
+  isSubmenu,
+} from './common-dropdown-types';
+
+function getItemLabelText(item: CommonDropdownItem): string {
+  if (isActionItem(item) || isCheckboxItem(item)) {
+    return [item.label, item.description].filter(Boolean).join(' ');
+  }
+
+  if (isSubmenu(item)) {
+    return item.label;
+  }
+
+  if (isRadioGroup(item)) {
+    return item.items
+      .map(radioItem =>
+        [radioItem.label, radioItem.description].filter(Boolean).join(' ')
+      )
+      .join(' ');
+  }
+
+  if (isLabel(item)) {
+    return item.label;
+  }
+
+  return '';
+}
+
+function defaultFilterItem(item: CommonDropdownItem, query: string): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  return getItemLabelText(item).toLowerCase().includes(normalizedQuery);
+}
+
+function itemMatches(
+  item: CommonDropdownItem,
+  query: string,
+  filterItem?: (item: CommonDropdownItem, query: string) => boolean
+): boolean {
+  return (filterItem ?? defaultFilterItem)(item, query);
+}
+
+function radioItemMatches(
+  item: Omit<CommonDropdownRadioItem, 'type'>,
+  query: string
+): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  return [item.label, item.description]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+    .includes(normalizedQuery);
+}
+
+function normalizeVisibleItems(
+  items: readonly CommonDropdownItem[]
+): CommonDropdownItem[] {
+  const withoutOrphanLabels = items.filter((item, index) => {
+    if (!isLabel(item)) return true;
+
+    return items.slice(index + 1).some(nextItem => !isSeparator(nextItem));
+  });
+
+  const normalized: CommonDropdownItem[] = [];
+
+  for (const item of withoutOrphanLabels) {
+    if (isSeparator(item)) {
+      if (normalized.length === 0 || isSeparator(normalized.at(-1)!)) {
+        continue;
+      }
+    }
+
+    normalized.push(item);
+  }
+
+  while (normalized.length > 0 && isSeparator(normalized.at(-1)!)) {
+    normalized.pop();
+  }
+
+  return normalized;
+}
+
+export function filterItems(
+  items: readonly CommonDropdownItem[],
+  query: string,
+  searchMode: 'root' | 'recursive',
+  filterItem?: (item: CommonDropdownItem, query: string) => boolean
+): CommonDropdownItem[] {
+  const trimmedQuery = query.trim();
+  if (!trimmedQuery) {
+    return [...items];
+  }
+
+  const filtered = items.flatMap((item): CommonDropdownItem[] => {
+    if (isSeparator(item) || isLabel(item) || isCustomItem(item)) {
+      return [item];
+    }
+
+    if (isRadioGroup(item)) {
+      const matchingItems = item.items.filter(radioItem =>
+        radioItemMatches(radioItem, trimmedQuery)
+      );
+
+      return matchingItems.length > 0
+        ? [{ ...item, items: matchingItems }]
+        : [];
+    }
+
+    if (isSubmenu(item)) {
+      const submenuMatches = itemMatches(item, trimmedQuery, filterItem);
+
+      if (searchMode === 'root') {
+        return submenuMatches ? [item] : [];
+      }
+
+      const filteredChildren = filterItems(
+        item.items,
+        trimmedQuery,
+        'recursive',
+        item.filterItem ?? filterItem
+      );
+
+      if (submenuMatches) {
+        return [item];
+      }
+
+      return filteredChildren.length > 0
+        ? [{ ...item, items: filteredChildren }]
+        : [];
+    }
+
+    return itemMatches(item, trimmedQuery, filterItem) ? [item] : [];
+  });
+
+  return normalizeVisibleItems(filtered);
+}
+
+export function getContentStyle(
+  minWidth?: number | string,
+  maxHeight?: number | string
+): CSSProperties | undefined {
+  if (minWidth === undefined && maxHeight === undefined) {
+    return undefined;
+  }
+
+  return { maxHeight, minWidth };
+}

--- a/packages/ui/atoms/common-dropdown-utils.ts
+++ b/packages/ui/atoms/common-dropdown-utils.ts
@@ -78,10 +78,18 @@ function normalizeVisibleItems(
   const withoutOrphanLabels = items.filter((item, index) => {
     if (!isLabel(item)) return true;
 
-    const nextItem = items[index + 1];
-    if (!nextItem) return false;
+    const remainingItems = items.slice(index + 1);
+    const nextSectionBoundary = remainingItems.findIndex(
+      nextItem => isSeparator(nextItem) || isLabel(nextItem)
+    );
+    const sectionItems =
+      nextSectionBoundary === -1
+        ? remainingItems
+        : remainingItems.slice(0, nextSectionBoundary);
 
-    return !isSeparator(nextItem) && !isLabel(nextItem);
+    return sectionItems.some(
+      nextItem => !(isSeparator(nextItem) || isLabel(nextItem))
+    );
   });
 
   const normalized: CommonDropdownItem[] = [];
@@ -137,16 +145,16 @@ export function filterItems(
         return submenuMatches ? [item] : [];
       }
 
+      if (submenuMatches) {
+        return [{ ...item, items: [...item.items] }];
+      }
+
       const filteredChildren = filterItems(
         item.items,
         trimmedQuery,
         'recursive',
         submenuFilterItem
       );
-
-      if (submenuMatches) {
-        return [{ ...item, items: filteredChildren }];
-      }
 
       return filteredChildren.length > 0
         ? [{ ...item, items: filteredChildren }]

--- a/packages/ui/atoms/common-dropdown-utils.ts
+++ b/packages/ui/atoms/common-dropdown-utils.ts
@@ -78,15 +78,10 @@ function normalizeVisibleItems(
   const withoutOrphanLabels = items.filter((item, index) => {
     if (!isLabel(item)) return true;
 
-    for (const nextItem of items.slice(index + 1)) {
-      if (isSeparator(nextItem) || isLabel(nextItem)) {
-        return false;
-      }
+    const nextItem = items[index + 1];
+    if (!nextItem) return false;
 
-      return true;
-    }
-
-    return false;
+    return !isSeparator(nextItem) && !isLabel(nextItem);
   });
 
   const normalized: CommonDropdownItem[] = [];

--- a/packages/ui/atoms/common-dropdown-utils.ts
+++ b/packages/ui/atoms/common-dropdown-utils.ts
@@ -78,7 +78,15 @@ function normalizeVisibleItems(
   const withoutOrphanLabels = items.filter((item, index) => {
     if (!isLabel(item)) return true;
 
-    return items.slice(index + 1).some(nextItem => !isSeparator(nextItem));
+    for (const nextItem of items.slice(index + 1)) {
+      if (isSeparator(nextItem) || isLabel(nextItem)) {
+        return false;
+      }
+
+      return true;
+    }
+
+    return false;
   });
 
   const normalized: CommonDropdownItem[] = [];

--- a/packages/ui/atoms/common-dropdown.test.tsx
+++ b/packages/ui/atoms/common-dropdown.test.tsx
@@ -531,6 +531,27 @@ describe('CommonDropdown', () => {
       });
     });
 
+    it('removes section labels when their section has no matching items', async () => {
+      const items: CommonDropdownItem[] = [
+        { type: 'label', id: 'people-label', label: 'People' },
+        { type: 'action', id: 'owner', label: 'Owner', onClick: vi.fn() },
+        { type: 'separator', id: 'section-break' },
+        { type: 'label', id: 'actions-label', label: 'Actions' },
+        { type: 'action', id: 'archive', label: 'Archive', onClick: vi.fn() },
+      ];
+      const user = userEvent.setup({ delay: null });
+      render(<CommonDropdown items={items} open={true} searchable={true} />);
+
+      await user.type(screen.getByPlaceholderText('Search...'), 'archive');
+
+      await waitFor(() => {
+        expect(screen.getByText('Actions')).toBeInTheDocument();
+        expect(screen.getByText('Archive')).toBeInTheDocument();
+        expect(screen.queryByText('People')).not.toBeInTheDocument();
+        expect(screen.queryByText('Owner')).not.toBeInTheDocument();
+      });
+    });
+
     it('shows empty state when search has no results', async () => {
       const items: CommonDropdownItem[] = [
         { type: 'action', id: 'edit', label: 'Edit', onClick: vi.fn() },

--- a/packages/ui/atoms/common-dropdown.test.tsx
+++ b/packages/ui/atoms/common-dropdown.test.tsx
@@ -215,10 +215,10 @@ describe('CommonDropdown', () => {
         .getByText('Selected Item')
         .closest('[role="menuitem"]');
 
-      expect(item?.className).toContain('bg-(--linear-bg-surface-1)');
+      expect(item).toHaveAttribute('data-selected', 'true');
     });
 
-    it('renders danger state as destructive styling', () => {
+    it('renders danger state as a destructive item variant', () => {
       const items: CommonDropdownItem[] = [
         {
           type: 'action',
@@ -234,7 +234,7 @@ describe('CommonDropdown', () => {
         .getByText('Remove Access')
         .closest('[role="menuitem"]');
 
-      expect(item?.className).toContain('text-(--linear-error)');
+      expect(item).toHaveAttribute('data-menu-variant', 'danger');
     });
 
     it('renders trailing custom content and descriptions', () => {
@@ -468,9 +468,11 @@ describe('CommonDropdown', () => {
       render(
         <CommonDropdown items={basicItems} open={true} isLoading={true} />
       );
-      // Loading spinner uses Loader2 with animate-spin
       const menu = screen.getByRole('menu');
       expect(menu).toBeInTheDocument();
+      expect(screen.getByRole('status')).toHaveTextContent(
+        'Loading menu items'
+      );
       // Items should not be rendered
       expect(screen.queryByText('Edit')).not.toBeInTheDocument();
     });
@@ -777,7 +779,7 @@ describe('CommonDropdown', () => {
       });
     });
 
-    it('filters submenu descendants even when the submenu label matches', async () => {
+    it('keeps submenu descendants when the submenu label matches', async () => {
       const items: CommonDropdownItem[] = [
         {
           type: 'submenu',
@@ -807,8 +809,8 @@ describe('CommonDropdown', () => {
       await user.hover(screen.getByText('Share'));
 
       await waitFor(() => {
-        expect(screen.getByText('No items found')).toBeInTheDocument();
-        expect(screen.queryByText('Spotify')).not.toBeInTheDocument();
+        expect(screen.getByText('Spotify')).toBeInTheDocument();
+        expect(screen.queryByText('No items found')).not.toBeInTheDocument();
       });
     });
 

--- a/packages/ui/atoms/common-dropdown.test.tsx
+++ b/packages/ui/atoms/common-dropdown.test.tsx
@@ -582,6 +582,31 @@ describe('CommonDropdown', () => {
       expect(onSearchChange).toHaveBeenLastCalledWith('');
     });
 
+    it('lets Escape clear search before dismissing the menu', async () => {
+      const user = userEvent.setup({ delay: null });
+      render(<CommonDropdown items={basicItems} searchable={true} />);
+
+      await user.click(screen.getByRole('button', { name: 'More actions' }));
+      await user.type(screen.getByPlaceholderText('Search...'), 'edit');
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search...')).toHaveValue('edit');
+      });
+
+      fireEvent.keyDown(screen.getByPlaceholderText('Search...'), {
+        key: 'Escape',
+      });
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('Search...')).toHaveValue('');
+
+      fireEvent.keyDown(screen.getByPlaceholderText('Search...'), {
+        key: 'Escape',
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    });
+
     it('only reports one empty search value when a controlled menu closes', async () => {
       const onSearchChange = vi.fn();
       const user = userEvent.setup({ delay: null });
@@ -690,6 +715,41 @@ describe('CommonDropdown', () => {
       await waitFor(() => {
         expect(screen.getByText('Share')).toBeInTheDocument();
         expect(screen.queryByText('Archive')).not.toBeInTheDocument();
+      });
+    });
+
+    it('filters submenu descendants even when the submenu label matches', async () => {
+      const items: CommonDropdownItem[] = [
+        {
+          type: 'submenu',
+          id: 'share',
+          label: 'Share',
+          items: [
+            {
+              type: 'action',
+              id: 'spotify',
+              label: 'Spotify',
+              onClick: vi.fn(),
+            },
+          ],
+        },
+      ];
+      const user = userEvent.setup({ delay: null });
+      render(
+        <CommonDropdown
+          items={items}
+          open={true}
+          searchable={true}
+          searchMode='recursive'
+        />
+      );
+
+      await user.type(screen.getByPlaceholderText('Search...'), 'share');
+      await user.hover(screen.getByText('Share'));
+
+      await waitFor(() => {
+        expect(screen.getByText('No items found')).toBeInTheDocument();
+        expect(screen.queryByText('Spotify')).not.toBeInTheDocument();
       });
     });
 

--- a/packages/ui/atoms/common-dropdown.test.tsx
+++ b/packages/ui/atoms/common-dropdown.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Settings } from 'lucide-react';
+import { Settings, Star } from 'lucide-react';
 import { describe, expect, it, vi } from 'vitest';
 import { CommonDropdown } from './common-dropdown';
 import type { CommonDropdownItem } from './common-dropdown-types';
@@ -198,6 +198,105 @@ describe('CommonDropdown', () => {
         .closest('[role="menuitem"]');
       expect(item).toHaveAttribute('data-disabled');
     });
+
+    it('renders selected action state with a trailing check', () => {
+      const items: CommonDropdownItem[] = [
+        {
+          type: 'action',
+          id: 'selected',
+          label: 'Selected Item',
+          onClick: vi.fn(),
+          selected: true,
+        },
+      ];
+      render(<CommonDropdown items={items} open={true} />);
+
+      const item = screen
+        .getByText('Selected Item')
+        .closest('[role="menuitem"]');
+
+      expect(item?.className).toContain('bg-(--linear-bg-surface-1)');
+    });
+
+    it('renders danger state as destructive styling', () => {
+      const items: CommonDropdownItem[] = [
+        {
+          type: 'action',
+          id: 'danger',
+          label: 'Remove Access',
+          onClick: vi.fn(),
+          state: 'danger',
+        },
+      ];
+      render(<CommonDropdown items={items} open={true} />);
+
+      const item = screen
+        .getByText('Remove Access')
+        .closest('[role="menuitem"]');
+
+      expect(item?.className).toContain('text-(--linear-error)');
+    });
+
+    it('renders trailing custom content and descriptions', () => {
+      const items: CommonDropdownItem[] = [
+        {
+          type: 'action',
+          id: 'details',
+          label: 'Detailed Item',
+          description: 'Secondary context',
+          trailing: <span data-testid='custom-trailing'>Live</span>,
+          onClick: vi.fn(),
+        },
+      ];
+      render(<CommonDropdown items={items} open={true} />);
+
+      expect(screen.getByText('Secondary context')).toBeInTheDocument();
+      expect(screen.getByTestId('custom-trailing')).toBeInTheDocument();
+    });
+
+    it('prevents loading action selection', async () => {
+      const onClick = vi.fn();
+      const items: CommonDropdownItem[] = [
+        {
+          type: 'action',
+          id: 'loading',
+          label: 'Syncing',
+          loading: true,
+          onClick,
+        },
+      ];
+      const user = userEvent.setup({ delay: null });
+      render(<CommonDropdown items={items} open={true} />);
+
+      const item = screen.getByRole('menuitem', { name: 'Syncing' });
+      expect(item).toHaveAttribute('data-disabled');
+
+      await user.click(screen.getByText('Syncing'));
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it('keeps the menu open when closeOnSelect is false', async () => {
+      const onClick = vi.fn();
+      const onOpenChange = vi.fn();
+      const items: CommonDropdownItem[] = [
+        {
+          type: 'action',
+          id: 'pin',
+          label: 'Pin',
+          closeOnSelect: false,
+          onClick,
+        },
+      ];
+      const user = userEvent.setup({ delay: null });
+      render(
+        <CommonDropdown items={items} open={true} onOpenChange={onOpenChange} />
+      );
+
+      await user.click(screen.getByText('Pin'));
+
+      expect(onClick).toHaveBeenCalled();
+      expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    });
   });
 
   describe('Separators', () => {
@@ -278,6 +377,24 @@ describe('CommonDropdown', () => {
 
       await user.click(screen.getByRole('menuitemcheckbox'));
       expect(onCheckedChange).toHaveBeenCalledWith(true);
+    });
+
+    it('renders checkbox description and count', () => {
+      const items: CommonDropdownItem[] = [
+        {
+          type: 'checkbox',
+          id: 'cb-1',
+          label: 'Labels',
+          description: 'Show release labels',
+          checked: false,
+          count: 12,
+          onCheckedChange: vi.fn(),
+        },
+      ];
+      render(<CommonDropdown items={items} open={true} />);
+
+      expect(screen.getByText('Show release labels')).toBeInTheDocument();
+      expect(screen.getByText('12')).toBeInTheDocument();
     });
   });
 
@@ -444,6 +561,171 @@ describe('CommonDropdown', () => {
 
       await waitFor(() => {
         expect(onSearch).toHaveBeenCalled();
+      });
+    });
+
+    it('calls onSearchChange when clearing search', async () => {
+      const onSearchChange = vi.fn();
+      const user = userEvent.setup({ delay: null });
+      render(
+        <CommonDropdown
+          items={basicItems}
+          open={true}
+          searchable={true}
+          onSearchChange={onSearchChange}
+        />
+      );
+
+      await user.type(screen.getByPlaceholderText('Search...'), 'edit');
+      await user.click(screen.getByRole('button', { name: 'Clear search' }));
+
+      expect(onSearchChange).toHaveBeenLastCalledWith('');
+    });
+
+    it('keeps matching submenu branches during recursive search', async () => {
+      const items: CommonDropdownItem[] = [
+        { type: 'action', id: 'archive', label: 'Archive', onClick: vi.fn() },
+        {
+          type: 'submenu',
+          id: 'share',
+          label: 'Share',
+          icon: Star,
+          items: [
+            {
+              type: 'action',
+              id: 'spotify',
+              label: 'Spotify',
+              onClick: vi.fn(),
+            },
+          ],
+        },
+      ];
+      const user = userEvent.setup({ delay: null });
+      render(
+        <CommonDropdown
+          items={items}
+          open={true}
+          searchable={true}
+          searchMode='recursive'
+        />
+      );
+
+      await user.type(screen.getByPlaceholderText('Search...'), 'spotify');
+
+      await waitFor(() => {
+        expect(screen.getByText('Share')).toBeInTheDocument();
+        expect(screen.queryByText('Archive')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Submenus', () => {
+    it('renders nested submenu triggers', () => {
+      const items: CommonDropdownItem[] = [
+        {
+          type: 'submenu',
+          id: 'share',
+          label: 'Share',
+          items: [
+            {
+              type: 'submenu',
+              id: 'social',
+              label: 'Social',
+              items: [
+                {
+                  type: 'action',
+                  id: 'copy-link',
+                  label: 'Copy Link',
+                  onClick: vi.fn(),
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      render(<CommonDropdown items={items} open={true} />);
+
+      expect(
+        screen.getByRole('menuitem', { name: 'Share' })
+      ).toBeInTheDocument();
+    });
+
+    it('opens a searchable submenu and filters child items', async () => {
+      const items: CommonDropdownItem[] = [
+        {
+          type: 'submenu',
+          id: 'platforms',
+          label: 'Platforms',
+          searchable: true,
+          searchPlaceholder: 'Search Platforms',
+          items: [
+            {
+              type: 'action',
+              id: 'spotify',
+              label: 'Spotify',
+              onClick: vi.fn(),
+            },
+            {
+              type: 'action',
+              id: 'apple',
+              label: 'Apple Music',
+              onClick: vi.fn(),
+            },
+          ],
+        },
+      ];
+      const user = userEvent.setup({ delay: null });
+      render(<CommonDropdown items={items} open={true} />);
+
+      await user.hover(screen.getByText('Platforms'));
+
+      await waitFor(() => {
+        expect(
+          screen.getByPlaceholderText('Search Platforms')
+        ).toBeInTheDocument();
+      });
+
+      fireEvent.change(screen.getByPlaceholderText('Search Platforms'), {
+        target: { value: 'apple' },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Apple Music')).toBeInTheDocument();
+        expect(screen.queryByText('Spotify')).not.toBeInTheDocument();
+      });
+    });
+
+    it('renders submenu loading and empty states', async () => {
+      const items: CommonDropdownItem[] = [
+        {
+          type: 'submenu',
+          id: 'loading',
+          label: 'Loading Group',
+          searchable: true,
+          isLoading: true,
+          items: [],
+        },
+        {
+          type: 'submenu',
+          id: 'empty',
+          label: 'Empty Group',
+          searchable: true,
+          emptyMessage: 'No child items',
+          items: [],
+        },
+      ];
+      const user = userEvent.setup({ delay: null });
+      render(<CommonDropdown items={items} open={true} />);
+
+      await user.hover(screen.getByText('Loading Group'));
+      await waitFor(() => {
+        expect(screen.getByRole('menu')).toBeInTheDocument();
+      });
+
+      await user.hover(screen.getByText('Empty Group'));
+      await waitFor(() => {
+        expect(screen.getByText('No child items')).toBeInTheDocument();
       });
     });
   });

--- a/packages/ui/atoms/common-dropdown.test.tsx
+++ b/packages/ui/atoms/common-dropdown.test.tsx
@@ -582,6 +582,81 @@ describe('CommonDropdown', () => {
       expect(onSearchChange).toHaveBeenLastCalledWith('');
     });
 
+    it('only reports one empty search value when a controlled menu closes', async () => {
+      const onSearchChange = vi.fn();
+      const user = userEvent.setup({ delay: null });
+      const { rerender } = render(
+        <CommonDropdown
+          items={basicItems}
+          open={true}
+          searchable={true}
+          onSearchChange={onSearchChange}
+        />
+      );
+
+      await user.type(screen.getByPlaceholderText('Search...'), 'edit');
+      onSearchChange.mockClear();
+
+      rerender(
+        <CommonDropdown
+          items={basicItems}
+          open={false}
+          searchable={true}
+          onSearchChange={onSearchChange}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+
+      expect(
+        onSearchChange.mock.calls.filter(([query]) => query === '')
+      ).toHaveLength(1);
+    });
+
+    it('uses custom filters for radio item search', async () => {
+      const items: CommonDropdownItem[] = [
+        {
+          type: 'radio',
+          id: 'density',
+          value: 'comfortable',
+          onValueChange: vi.fn(),
+          items: [
+            { id: 'compact', label: 'Compact', value: 'density-compact' },
+            {
+              id: 'comfortable',
+              label: 'Comfortable',
+              value: 'density-comfortable',
+            },
+          ],
+        },
+      ];
+      const user = userEvent.setup({ delay: null });
+      render(
+        <CommonDropdown
+          items={items}
+          open={true}
+          searchable={true}
+          filterItem={(item, query) =>
+            item.type === 'radio'
+              ? item.value === query
+              : item.label.toLowerCase().includes(query)
+          }
+        />
+      );
+
+      await user.type(
+        screen.getByPlaceholderText('Search...'),
+        'density-compact'
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Compact')).toBeInTheDocument();
+        expect(screen.queryByText('Comfortable')).not.toBeInTheDocument();
+      });
+    });
+
     it('keeps matching submenu branches during recursive search', async () => {
       const items: CommonDropdownItem[] = [
         { type: 'action', id: 'archive', label: 'Archive', onClick: vi.fn() },
@@ -614,6 +689,43 @@ describe('CommonDropdown', () => {
 
       await waitFor(() => {
         expect(screen.getByText('Share')).toBeInTheDocument();
+        expect(screen.queryByText('Archive')).not.toBeInTheDocument();
+      });
+    });
+
+    it('uses submenu-local filters when matching recursive branches', async () => {
+      const items: CommonDropdownItem[] = [
+        { type: 'action', id: 'archive', label: 'Archive', onClick: vi.fn() },
+        {
+          type: 'submenu',
+          id: 'platforms',
+          label: 'Platforms',
+          filterItem: (item, query) =>
+            item.id === 'platforms' && query === 'destinations',
+          items: [
+            {
+              type: 'action',
+              id: 'spotify',
+              label: 'Spotify',
+              onClick: vi.fn(),
+            },
+          ],
+        },
+      ];
+      const user = userEvent.setup({ delay: null });
+      render(
+        <CommonDropdown
+          items={items}
+          open={true}
+          searchable={true}
+          searchMode='recursive'
+        />
+      );
+
+      await user.type(screen.getByPlaceholderText('Search...'), 'destinations');
+
+      await waitFor(() => {
+        expect(screen.getByText('Platforms')).toBeInTheDocument();
         expect(screen.queryByText('Archive')).not.toBeInTheDocument();
       });
     });

--- a/packages/ui/atoms/common-dropdown.test.tsx
+++ b/packages/ui/atoms/common-dropdown.test.tsx
@@ -580,6 +580,26 @@ describe('CommonDropdown', () => {
       await user.click(screen.getByRole('button', { name: 'Clear search' }));
 
       expect(onSearchChange).toHaveBeenLastCalledWith('');
+      expect(screen.getByPlaceholderText('Search...')).toHaveFocus();
+    });
+
+    it('preserves legacy onSearch for non-empty queries only', async () => {
+      const onSearch = vi.fn();
+      const user = userEvent.setup({ delay: null });
+      render(
+        <CommonDropdown
+          items={basicItems}
+          open={true}
+          searchable={true}
+          onSearch={onSearch}
+        />
+      );
+
+      await user.type(screen.getByPlaceholderText('Search...'), 'edit');
+      await user.click(screen.getByRole('button', { name: 'Clear search' }));
+
+      expect(onSearch).toHaveBeenCalledWith('edit');
+      expect(onSearch).not.toHaveBeenCalledWith('');
     });
 
     it('lets Escape clear search before dismissing the menu', async () => {
@@ -605,6 +625,24 @@ describe('CommonDropdown', () => {
       await waitFor(() => {
         expect(screen.queryByRole('menu')).not.toBeInTheDocument();
       });
+    });
+
+    it('lets menu navigation keys leave the search field', async () => {
+      const onClick = vi.fn();
+      const items: CommonDropdownItem[] = [
+        { type: 'action', id: 'edit', label: 'Edit', onClick },
+      ];
+      const user = userEvent.setup({ delay: null });
+      render(<CommonDropdown items={items} searchable={true} />);
+
+      await user.click(screen.getByRole('button', { name: 'More actions' }));
+      const input = screen.getByPlaceholderText('Search...');
+      await user.type(input, 'edit');
+
+      await user.keyboard('{ArrowDown}');
+      await user.keyboard('{Enter}');
+
+      expect(onClick).toHaveBeenCalled();
     });
 
     it('only reports one empty search value when a controlled menu closes', async () => {

--- a/packages/ui/atoms/common-dropdown.tsx
+++ b/packages/ui/atoms/common-dropdown.tsx
@@ -91,7 +91,9 @@ export function CommonDropdown(props: CommonDropdownProps) {
       searchQueryRef.current = query;
       setSearchQuery(query);
       onSearchChange?.(query);
-      onSearch?.(query);
+      if (query) {
+        onSearch?.(query);
+      }
     },
     [onSearch, onSearchChange]
   );

--- a/packages/ui/atoms/common-dropdown.tsx
+++ b/packages/ui/atoms/common-dropdown.tsx
@@ -2,105 +2,34 @@
 
 import * as ContextMenuPrimitive from '@radix-ui/react-context-menu';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
-import {
-  Check,
-  ChevronDown,
-  ChevronRight,
-  Circle,
-  Loader2,
-  MoreVertical,
-  Search,
-} from 'lucide-react';
+import { ChevronDown, MoreVertical } from 'lucide-react';
 import * as React from 'react';
 
 import {
-  CHECKBOX_RADIO_ITEM_BASE,
-  CONTEXT_TRANSFORM_ORIGIN,
   contextMenuContentClasses,
   contextMenuContentCompactClasses,
-  DROPDOWN_TRANSFORM_ORIGIN,
   dropdownMenuContentClasses,
   dropdownMenuContentCompactClasses,
   MENU_ITEM_BASE,
   MENU_ITEM_COMPACT,
-  MENU_ITEM_DESTRUCTIVE,
-  MENU_LABEL_BASE,
-  MENU_SEPARATOR_BASE,
-  MENU_SHORTCUT_BASE,
-  subMenuContentClasses,
 } from '../lib/dropdown-styles';
 import { cn } from '../lib/utils';
+import {
+  type MenuPrimitiveKind,
+  type MenuRenderContext,
+  renderItem,
+  renderRootBody,
+  SearchableContent,
+} from './common-dropdown-renderer';
 import type {
-  CommonDropdownActionItem,
-  CommonDropdownCheckboxItem,
   CommonDropdownItem,
   CommonDropdownProps,
-  CommonDropdownRadioGroup,
-  CommonDropdownSubmenu,
 } from './common-dropdown-types';
-import {
-  isActionItem,
-  isCheckboxItem,
-  isCustomItem,
-  isLabel,
-  isRadioGroup,
-  isSeparator,
-  isSubmenu,
-} from './common-dropdown-types';
-
-/** Renders an icon component, handling function components, forwardRef objects, and JSX elements */
-function renderIcon(
-  IconComponent: React.ComponentType<{ className?: string }> | React.ReactNode,
-  className: string
-): React.ReactNode {
-  if (!IconComponent) return null;
-  // Already a rendered React element (e.g. <Icon /> JSX) — return as-is
-  if (React.isValidElement(IconComponent)) {
-    return IconComponent;
-  }
-  // Component reference: function component OR forwardRef/memo object (e.g. Lucide icons)
-  if (
-    typeof IconComponent === 'function' ||
-    (typeof IconComponent === 'object' &&
-      IconComponent !== null &&
-      '$$typeof' in IconComponent)
-  ) {
-    const Comp = IconComponent as React.ComponentType<{ className?: string }>;
-    return <Comp className={className} />;
-  }
-  return IconComponent;
-}
+import { filterItems, getContentStyle } from './common-dropdown-utils';
 
 /**
- * CommonDropdown - Unified dropdown component supporting multiple variants
- *
- * This component consolidates all dropdown patterns across the application:
- * - Action menus (click-to-open menus with actions)
- * - Select dropdowns (single-value selection)
- * - Context menus (right-click menus)
- *
- * Size variants:
- * - 'default': Standard menus (user menu, bulk actions, notifications)
- * - 'compact': Dense menus for tables, sidebars, and inline actions
- *
- * @example
- * // Simple action menu
- * <CommonDropdown
- *   variant="dropdown"
- *   items={[
- *     { type: 'action', id: 'edit', label: 'Edit', icon: Pencil, onClick: handleEdit },
- *     { type: 'separator', id: 'sep-1' },
- *     { type: 'action', id: 'delete', label: 'Delete', icon: Trash2, onClick: handleDelete, variant: 'destructive' },
- *   ]}
- * />
- *
- * @example
- * // Compact table action menu
- * <CommonDropdown
- *   variant="dropdown"
- *   size="compact"
- *   items={tableActions}
- * />
+ * CommonDropdown - Unified dropdown component supporting action, context,
+ * nested, searchable, loading, selected, and destructive menu states.
  */
 export function CommonDropdown(props: CommonDropdownProps) {
   const {
@@ -123,16 +52,20 @@ export function CommonDropdown(props: CommonDropdownProps) {
     searchable = false,
     searchPlaceholder = 'Search...',
     onSearch,
+    onSearchChange,
+    searchMode = 'root',
+    filterItem,
+    resetSearchOnClose = true,
     isLoading = false,
     emptyMessage = 'No items found',
     disabled = false,
+    minWidth,
+    maxHeight,
     children,
   } = props;
 
-  // Resolve size-dependent token classes
   const isCompact = size === 'compact';
   const itemBase = isCompact ? MENU_ITEM_COMPACT : MENU_ITEM_BASE;
-  const itemDestructive = MENU_ITEM_DESTRUCTIVE;
   const dropdownContentBase = isCompact
     ? dropdownMenuContentCompactClasses
     : dropdownMenuContentClasses;
@@ -141,50 +74,64 @@ export function CommonDropdown(props: CommonDropdownProps) {
     : contextMenuContentClasses;
 
   const [searchQuery, setSearchQuery] = React.useState('');
+  const didMountRef = React.useRef(false);
 
-  // Derive filtered items synchronously to avoid stale state when the menu opens
-  const filteredItems = React.useMemo(() => {
-    if (!searchable || !searchQuery.trim()) {
-      return items;
-    }
+  const filteredItems = React.useMemo(
+    () => filterItems(items, searchQuery, searchMode, filterItem),
+    [filterItem, items, searchMode, searchQuery]
+  );
 
-    const query = searchQuery.toLowerCase();
-    return items.filter(item => {
-      if (isLabel(item) || isSeparator(item) || isCustomItem(item)) return true;
+  const handleSearchChange = React.useCallback(
+    (query: string) => {
+      setSearchQuery(query);
+      onSearchChange?.(query);
+      onSearch?.(query);
+    },
+    [onSearch, onSearchChange]
+  );
 
-      if (isActionItem(item)) {
-        return item.label.toLowerCase().includes(query);
+  const clearSearch = React.useCallback(() => {
+    handleSearchChange('');
+  }, [handleSearchChange]);
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen && resetSearchOnClose) {
+        clearSearch();
       }
+      onOpenChange?.(nextOpen);
+    },
+    [clearSearch, onOpenChange, resetSearchOnClose]
+  );
 
-      if (isCheckboxItem(item)) {
-        return item.label.toLowerCase().includes(query);
-      }
-
-      if (isRadioGroup(item)) {
-        return item.items.some(radioItem =>
-          radioItem.label.toLowerCase().includes(query)
-        );
-      }
-
-      if (isSubmenu(item)) {
-        return item.label.toLowerCase().includes(query);
-      }
-
-      return false;
-    });
-  }, [searchQuery, items, searchable]);
-
-  // Notify parent of search query changes
   React.useEffect(() => {
-    if (searchable && searchQuery) {
-      onSearch?.(searchQuery);
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
     }
-  }, [searchQuery, searchable, onSearch]);
 
-  // Render context menu variant
+    if (open === false && resetSearchOnClose) {
+      clearSearch();
+    }
+  }, [clearSearch, open, resetSearchOnClose]);
+
+  const renderItems = React.useCallback(
+    (itemsToRender: readonly CommonDropdownItem[], kind: MenuPrimitiveKind) => {
+      const context: MenuRenderContext = {
+        kind,
+        itemBase,
+        disablePortal,
+        portalProps,
+      };
+
+      return itemsToRender.map(item => renderItem(item, context));
+    },
+    [disablePortal, itemBase, portalProps]
+  );
+
   if (variant === 'context') {
     return (
-      <ContextMenuPrimitive.Root>
+      <ContextMenuPrimitive.Root onOpenChange={handleOpenChange}>
         <ContextMenuPrimitive.Trigger asChild disabled={disabled}>
           {children}
         </ContextMenuPrimitive.Trigger>
@@ -193,9 +140,8 @@ export function CommonDropdown(props: CommonDropdownProps) {
     );
   }
 
-  // Render dropdown menu variant
   return (
-    <DropdownMenuPrimitive.Root open={open} onOpenChange={onOpenChange}>
+    <DropdownMenuPrimitive.Root open={open} onOpenChange={handleOpenChange}>
       <DropdownMenuPrimitive.Trigger
         asChild
         disabled={disabled}
@@ -207,7 +153,6 @@ export function CommonDropdown(props: CommonDropdownProps) {
     </DropdownMenuPrimitive.Root>
   );
 
-  // Helper: Render default trigger
   function renderDefaultTrigger() {
     if (defaultTriggerType === 'select') {
       return (
@@ -237,14 +182,13 @@ export function CommonDropdown(props: CommonDropdownProps) {
           triggerClassName
         )}
         aria-label={ariaLabel || 'More actions'}
-        onClick={e => e.stopPropagation()}
+        onClick={event => event.stopPropagation()}
       >
         <TriggerIcon className='h-4 w-4' />
       </button>
     );
   }
 
-  // Helper: Render dropdown content
   function renderDropdownContent() {
     const content = (
       <DropdownMenuPrimitive.Content
@@ -253,40 +197,22 @@ export function CommonDropdown(props: CommonDropdownProps) {
         sideOffset={sideOffset}
         data-menu-surface='toolbar'
         className={cn(dropdownContentBase, contentClassName)}
+        style={getContentStyle(minWidth, maxHeight)}
       >
-        {searchable && (
-          <div
-            data-menu-header
-            className='relative border-b border-subtle px-2.5 pb-2 pt-2'
-          >
-            <Search className='absolute left-5 top-[25px] h-3.5 w-3.5 -translate-y-1/2 text-tertiary-token' />
-            <input
-              type='text'
-              placeholder={searchPlaceholder}
-              aria-label={searchPlaceholder}
-              value={searchQuery}
-              onChange={e => setSearchQuery(e.target.value)}
-              className='w-full rounded-[8px] border border-subtle bg-surface-1 py-1.5 pl-8 pr-3 text-xs text-primary-token placeholder:text-tertiary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-focus/15'
-            />
-          </div>
-        )}
-        {(() => {
-          if (isLoading) {
-            return (
-              <div className='flex items-center justify-center py-6'>
-                <Loader2 className='h-6 w-6 animate-spin text-tertiary-token' />
-              </div>
-            );
-          }
-          if (filteredItems.length === 0) {
-            return (
-              <div className='py-6 text-center text-sm text-tertiary-token'>
-                {emptyMessage}
-              </div>
-            );
-          }
-          return renderItems(filteredItems, false);
-        })()}
+        {searchable ? (
+          <SearchableContent
+            query={searchQuery}
+            placeholder={searchPlaceholder}
+            onQueryChange={handleSearchChange}
+            onClear={clearSearch}
+          />
+        ) : null}
+        {renderRootBody({
+          isLoading,
+          items: filteredItems,
+          emptyMessage,
+          renderItems: itemsToRender => renderItems(itemsToRender, 'dropdown'),
+        })}
       </DropdownMenuPrimitive.Content>
     );
 
@@ -295,36 +221,37 @@ export function CommonDropdown(props: CommonDropdownProps) {
     }
 
     return (
-      <DropdownMenuPrimitive.Portal {...portalProps}>
+      <DropdownMenuPrimitive.Portal
+        {...(portalProps as React.ComponentPropsWithoutRef<
+          typeof DropdownMenuPrimitive.Portal
+        >)}
+      >
         {content}
       </DropdownMenuPrimitive.Portal>
     );
   }
 
-  // Helper: Render context menu content
   function renderContextMenuContent() {
     const content = (
       <ContextMenuPrimitive.Content
         data-menu-surface='toolbar'
         className={cn(contextContentBase, contentClassName)}
+        style={getContentStyle(minWidth, maxHeight)}
       >
-        {(() => {
-          if (isLoading) {
-            return (
-              <div className='flex items-center justify-center py-6'>
-                <Loader2 className='h-6 w-6 animate-spin text-tertiary-token' />
-              </div>
-            );
-          }
-          if (filteredItems.length === 0) {
-            return (
-              <div className='py-6 text-center text-sm text-tertiary-token'>
-                {emptyMessage}
-              </div>
-            );
-          }
-          return renderItems(filteredItems, true);
-        })()}
+        {searchable ? (
+          <SearchableContent
+            query={searchQuery}
+            placeholder={searchPlaceholder}
+            onQueryChange={handleSearchChange}
+            onClear={clearSearch}
+          />
+        ) : null}
+        {renderRootBody({
+          isLoading,
+          items: filteredItems,
+          emptyMessage,
+          renderItems: itemsToRender => renderItems(itemsToRender, 'context'),
+        })}
       </ContextMenuPrimitive.Content>
     );
 
@@ -333,260 +260,13 @@ export function CommonDropdown(props: CommonDropdownProps) {
     }
 
     return (
-      <ContextMenuPrimitive.Portal {...portalProps}>
+      <ContextMenuPrimitive.Portal
+        {...(portalProps as React.ComponentPropsWithoutRef<
+          typeof ContextMenuPrimitive.Portal
+        >)}
+      >
         {content}
       </ContextMenuPrimitive.Portal>
-    );
-  }
-
-  // Helper: Render items
-  function renderItems(
-    itemsToRender: CommonDropdownItem[],
-    isContextMenu: boolean
-  ): React.ReactNode {
-    return itemsToRender.map(item => {
-      // Separator
-      if (isSeparator(item)) {
-        const Separator = isContextMenu
-          ? ContextMenuPrimitive.Separator
-          : DropdownMenuPrimitive.Separator;
-
-        return (
-          <Separator
-            key={item.id}
-            className={cn(MENU_SEPARATOR_BASE, item.className)}
-          />
-        );
-      }
-
-      // Label
-      if (isLabel(item)) {
-        const Label = isContextMenu
-          ? ContextMenuPrimitive.Label
-          : DropdownMenuPrimitive.Label;
-
-        return (
-          <Label
-            key={item.id}
-            className={cn(
-              MENU_LABEL_BASE,
-              item.inset && 'pl-10',
-              item.className
-            )}
-          >
-            {item.label}
-          </Label>
-        );
-      }
-
-      // Action item
-      if (isActionItem(item)) {
-        return renderActionItem(item, isContextMenu);
-      }
-
-      // Checkbox item
-      if (isCheckboxItem(item)) {
-        return renderCheckboxItem(item, isContextMenu);
-      }
-
-      // Radio group
-      if (isRadioGroup(item)) {
-        return renderRadioGroup(item, isContextMenu);
-      }
-
-      // Submenu
-      if (isSubmenu(item)) {
-        return renderSubmenu(item, isContextMenu);
-      }
-
-      // Custom item
-      if (isCustomItem(item)) {
-        return <React.Fragment key={item.id}>{item.render()}</React.Fragment>;
-      }
-
-      return null;
-    });
-  }
-
-  // Helper: Render action item
-  function renderActionItem(
-    item: CommonDropdownActionItem,
-    isContextMenu: boolean
-  ): React.ReactNode {
-    const MenuItem = isContextMenu
-      ? ContextMenuPrimitive.Item
-      : DropdownMenuPrimitive.Item;
-
-    const IconComponent = item.icon;
-    const IconAfterComponent = item.iconAfter;
-
-    return (
-      <MenuItem
-        key={item.id}
-        data-menu-row=''
-        onClick={e => {
-          e.stopPropagation();
-          if (!item.disabled) {
-            item.onClick?.();
-          }
-        }}
-        disabled={item.disabled}
-        className={cn(
-          itemBase,
-          item.variant === 'destructive' && itemDestructive,
-          item.className
-        )}
-      >
-        {renderIcon(IconComponent, 'h-4 w-4')}
-        <span className='flex-1'>{item.label}</span>
-        {item.badge && (
-          <span
-            className='rounded px-1.5 py-0.5 text-[10px] font-medium'
-            style={{
-              backgroundColor: item.badge.color || 'var(--color-accent-subtle)',
-              color: item.badge.color ? 'white' : 'var(--color-accent)',
-            }}
-          >
-            {item.badge.text}
-          </span>
-        )}
-        {item.subText && (
-          <span className='text-[11px] text-tertiary-token'>
-            {item.subText}
-          </span>
-        )}
-        {item.shortcut && (
-          <span className={MENU_SHORTCUT_BASE}>{item.shortcut}</span>
-        )}
-        {renderIcon(IconAfterComponent, 'ml-auto h-4 w-4')}
-      </MenuItem>
-    );
-  }
-
-  // Helper: Render checkbox item
-  function renderCheckboxItem(
-    item: CommonDropdownCheckboxItem,
-    isContextMenu: boolean
-  ): React.ReactNode {
-    const CheckboxItem = isContextMenu
-      ? ContextMenuPrimitive.CheckboxItem
-      : DropdownMenuPrimitive.CheckboxItem;
-
-    const ItemIndicator = isContextMenu
-      ? ContextMenuPrimitive.ItemIndicator
-      : DropdownMenuPrimitive.ItemIndicator;
-
-    const IconComponent = item.icon;
-
-    return (
-      <CheckboxItem
-        key={item.id}
-        data-menu-row=''
-        checked={item.checked}
-        onCheckedChange={item.onCheckedChange}
-        disabled={item.disabled}
-        className={cn(CHECKBOX_RADIO_ITEM_BASE, item.className)}
-      >
-        <span className='absolute left-2 flex h-4 w-4 items-center justify-center'>
-          <ItemIndicator>
-            <Check className='h-4 w-4' />
-          </ItemIndicator>
-        </span>
-        {renderIcon(IconComponent, 'h-4 w-4')}
-        {item.label}
-      </CheckboxItem>
-    );
-  }
-
-  // Helper: Render radio group
-  function renderRadioGroup(
-    item: CommonDropdownRadioGroup,
-    isContextMenu: boolean
-  ): React.ReactNode {
-    const RadioGroup = isContextMenu
-      ? ContextMenuPrimitive.RadioGroup
-      : DropdownMenuPrimitive.RadioGroup;
-
-    const RadioItem = isContextMenu
-      ? ContextMenuPrimitive.RadioItem
-      : DropdownMenuPrimitive.RadioItem;
-
-    const ItemIndicator = isContextMenu
-      ? ContextMenuPrimitive.ItemIndicator
-      : DropdownMenuPrimitive.ItemIndicator;
-
-    return (
-      <RadioGroup
-        key={item.id}
-        value={item.value}
-        onValueChange={item.onValueChange}
-      >
-        {item.items.map(radioItem => {
-          const IconComponent = radioItem.icon;
-
-          return (
-            <RadioItem
-              key={radioItem.id}
-              data-menu-row=''
-              value={radioItem.value}
-              disabled={radioItem.disabled}
-              className={cn(CHECKBOX_RADIO_ITEM_BASE, radioItem.className)}
-            >
-              <span className='absolute left-2 flex h-4 w-4 items-center justify-center'>
-                <ItemIndicator>
-                  <Circle className='h-2 w-2 fill-current' />
-                </ItemIndicator>
-              </span>
-              {renderIcon(IconComponent, 'h-4 w-4')}
-              {radioItem.label}
-            </RadioItem>
-          );
-        })}
-      </RadioGroup>
-    );
-  }
-
-  // Helper: Render submenu
-  function renderSubmenu(
-    item: CommonDropdownSubmenu,
-    isContextMenu: boolean
-  ): React.ReactNode {
-    const Sub = isContextMenu
-      ? ContextMenuPrimitive.Sub
-      : DropdownMenuPrimitive.Sub;
-    const SubTrigger = isContextMenu
-      ? ContextMenuPrimitive.SubTrigger
-      : DropdownMenuPrimitive.SubTrigger;
-    const Portal = isContextMenu
-      ? ContextMenuPrimitive.Portal
-      : DropdownMenuPrimitive.Portal;
-    const SubContent = isContextMenu
-      ? ContextMenuPrimitive.SubContent
-      : DropdownMenuPrimitive.SubContent;
-    const transformOrigin = isContextMenu
-      ? CONTEXT_TRANSFORM_ORIGIN
-      : DROPDOWN_TRANSFORM_ORIGIN;
-
-    return (
-      <Sub key={item.id}>
-        <SubTrigger
-          disabled={item.disabled}
-          data-menu-row=''
-          className={cn(itemBase, item.className)}
-        >
-          {renderIcon(item.icon, 'h-4 w-4')}
-          {item.label}
-          <ChevronRight className='ml-auto' />
-        </SubTrigger>
-        <Portal>
-          <SubContent
-            data-menu-surface='toolbar'
-            className={cn(subMenuContentClasses, transformOrigin)}
-          >
-            {renderItems(item.items, isContextMenu)}
-          </SubContent>
-        </Portal>
-      </Sub>
     );
   }
 }

--- a/packages/ui/atoms/common-dropdown.tsx
+++ b/packages/ui/atoms/common-dropdown.tsx
@@ -74,6 +74,7 @@ export function CommonDropdown(props: CommonDropdownProps) {
     : contextMenuContentClasses;
 
   const [searchQuery, setSearchQuery] = React.useState('');
+  const searchQueryRef = React.useRef('');
   const didMountRef = React.useRef(false);
 
   const filteredItems = React.useMemo(
@@ -83,6 +84,11 @@ export function CommonDropdown(props: CommonDropdownProps) {
 
   const handleSearchChange = React.useCallback(
     (query: string) => {
+      if (searchQueryRef.current === query) {
+        return;
+      }
+
+      searchQueryRef.current = query;
       setSearchQuery(query);
       onSearchChange?.(query);
       onSearch?.(query);

--- a/packages/ui/atoms/common-dropdown.tsx
+++ b/packages/ui/atoms/common-dropdown.tsx
@@ -204,6 +204,12 @@ export function CommonDropdown(props: CommonDropdownProps) {
         data-menu-surface='toolbar'
         className={cn(dropdownContentBase, contentClassName)}
         style={getContentStyle(minWidth, maxHeight)}
+        onEscapeKeyDown={event => {
+          if (searchQuery) {
+            event.preventDefault();
+            clearSearch();
+          }
+        }}
       >
         {searchable ? (
           <SearchableContent
@@ -243,6 +249,12 @@ export function CommonDropdown(props: CommonDropdownProps) {
         data-menu-surface='toolbar'
         className={cn(contextContentBase, contentClassName)}
         style={getContentStyle(minWidth, maxHeight)}
+        onEscapeKeyDown={event => {
+          if (searchQuery) {
+            event.preventDefault();
+            clearSearch();
+          }
+        }}
       >
         {searchable ? (
           <SearchableContent

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -83,7 +83,6 @@ export type {
   CommonDropdownProps,
   CommonDropdownRadioGroup,
   CommonDropdownRadioItem,
-  CommonDropdownSelectProps,
   CommonDropdownSeparator,
   CommonDropdownSize,
   CommonDropdownSubmenu,

--- a/packages/ui/lib/dropdown-styles.ts
+++ b/packages/ui/lib/dropdown-styles.ts
@@ -315,11 +315,12 @@ export const SELECT_TRIGGER_BASE =
 // ============================================================================
 
 /**
- * Sub-menu content classes (no max-height constraint)
+ * Sub-menu content classes.
+ * Supports both DropdownMenu.SubContent and ContextMenu.SubContent Radix vars.
  */
 export const subMenuContentClasses = [
   DROPDOWN_CONTENT_BASE,
-  'max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto overflow-x-hidden',
+  'max-h-[min(var(--radix-dropdown-menu-content-available-height,var(--radix-context-menu-content-available-height,320px)),320px)] overflow-y-auto overflow-x-hidden',
   DROPDOWN_SHADOW,
   DROPDOWN_TRANSITIONS,
   DROPDOWN_SLIDE_ANIMATIONS,

--- a/packages/ui/lib/dropdown-styles.ts
+++ b/packages/ui/lib/dropdown-styles.ts
@@ -182,6 +182,12 @@ export const MENU_ITEM_DESTRUCTIVE =
   '[&_svg]:text-(--linear-error) hover:[&_svg]:text-(--linear-error) data-[highlighted]:[&_svg]:text-(--linear-error)';
 
 /**
+ * Selected/active item state for menus with current choices
+ */
+export const MENU_ITEM_SELECTED =
+  'bg-(--linear-bg-surface-1) text-(--linear-text-primary) [&_svg]:text-(--linear-text-primary)';
+
+/**
  * Checkbox and radio item styles (with left indicator space)
  */
 export const CHECKBOX_RADIO_ITEM_BASE =
@@ -247,6 +253,45 @@ export const MENU_SEPARATOR_BASE =
  */
 export const MENU_SHORTCUT_BASE =
   'ml-auto text-[10.5px] font-medium text-(--linear-text-tertiary)';
+
+/**
+ * Shared leading/trailing slots for structured menu rows
+ */
+export const MENU_LEADING_SLOT_BASE =
+  'flex h-4 w-4 shrink-0 items-center justify-center text-(--linear-text-tertiary)';
+
+export const MENU_TRAILING_SLOT_BASE =
+  'ml-auto inline-flex min-w-4 shrink-0 items-center justify-end gap-1 text-(--linear-text-tertiary)';
+
+/**
+ * Secondary line inside a structured menu row
+ */
+export const MENU_ITEM_DESCRIPTION_BASE =
+  'truncate text-[11px] leading-3 text-(--linear-text-tertiary)';
+
+/**
+ * Small count/status badge used in menu rows
+ */
+export const MENU_BADGE_BASE =
+  'inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-(--linear-app-radius-item) border border-(--linear-border-subtle) bg-(--linear-bg-surface-1) px-1.5 text-[10.5px] font-medium tabular-nums text-(--linear-text-tertiary)';
+
+/**
+ * Search header and input styles shared by root menus and searchable submenus
+ */
+export const MENU_SEARCH_HEADER_BASE =
+  'border-b border-(--linear-border-subtle) px-2 py-2';
+
+export const MENU_SEARCH_INPUT_BASE =
+  'h-7 w-full rounded-(--linear-app-radius-item) border border-(--linear-border-subtle) bg-(--linear-bg-surface-1) py-1 pl-7 pr-7 text-[12px] text-(--linear-text-primary) placeholder:text-(--linear-text-tertiary) focus-visible:outline-none focus-visible:border-(--linear-border-focus)';
+
+/**
+ * Empty and loading states inside menu surfaces
+ */
+export const MENU_EMPTY_STATE_BASE =
+  'px-3 py-6 text-center text-[12px] text-(--linear-text-tertiary)';
+
+export const MENU_LOADING_STATE_BASE =
+  'flex items-center justify-center px-3 py-6 text-(--linear-text-tertiary)';
 
 // ============================================================================
 // TRIGGER STYLES


### PR DESCRIPTION
## Summary

Standardizes the shared dropdown primitive so menus can reuse one consistent surface, row, search, state, and submenu implementation.

**Dropdown System**
- Refactors `CommonDropdown` into focused renderer, item-renderer, type, and utility modules.
- Adds shared support for selected, active, danger, loading, count, trailing-content, description, and close-on-select states.
- Adds root and recursive search, submenu-local filtering, radio-item custom filtering, searchable nested menus, and loading/empty submenu states.
- Reuses centralized dropdown style tokens for common dropdown, context menu, and submenu surfaces.

**QA Fix**
- Restores pre-paint theme initialization with a native static script while avoiding the local `next/script` hydration mismatch.

**Review Fixes**
- Prevents duplicate empty search callbacks for controlled close flows.
- Keeps searchable dropdown keyboard behavior intact: Escape clears before close, arrow navigation can leave the search field, Enter activates the first result, and clear returns focus to the input.
- Preserves the legacy `onSearch` contract for non-empty search queries only.

**Release**
- Bumps `VERSION` to `26.4.154.0` and updates `CHANGELOG.md`.

## Test Coverage

All new dropdown behavior is covered in `packages/ui/atoms/common-dropdown.test.tsx`, including controlled close search reset, radio custom filtering, recursive submenu filtering, Escape behavior, keyboard navigation, and clear-button focus.

Tests: existing dropdown test file expanded from 52 to 59 cases, focused suite now 114 assertions across common dropdown, dropdown menu, and context menu coverage.

## Pre-Landing Review

Structured Codex review found dropdown keyboard/search regressions during the ship pass. All findings were fixed before push:
- Escape propagation in searchable menus.
- Recursive submenu descendant filtering.
- Search field keyboard navigation and clear-button focus.
- Legacy `onSearch` empty-query compatibility.

No unresolved review findings remain.

## Design Review

Frontend files changed. Design changes are constrained to shared dropdown styling and behavior, using existing tokenized menu surfaces in `packages/ui/lib/dropdown-styles.ts`. No new decorative chrome or route UI changes.

## Eval Results

No prompt-related files changed, evals skipped.

## Greptile Review

No PR existed before this create step, so there were no Greptile comments to triage.

## Scope Drift

Scope Check: CLEAN. The diff is limited to common dropdown standardization, dropdown tests, the theme-script QA fix, and release metadata.

## Plan Completion

No plan file detected.

## Verification Results

Verification run after rebasing onto current `origin/main`:
- [x] `pnpm --filter @jovie/ui test -- common-dropdown.test.tsx dropdown-menu.test.tsx context-menu.test.tsx` — 3 files passed, 114 tests passed
- [x] `pnpm --filter @jovie/ui typecheck`
- [x] `pnpm --filter @jovie/web exec tsc --noEmit`
- [x] `pnpm --filter @jovie/web lint`
- [x] `pnpm biome check --write apps/web packages/ui`
- [x] Pre-push hook: `biome check .`, Tailwind guard, web typecheck, web lint

## TODOS

No TODO items completed in this PR.

## Test plan

- [x] UI dropdown regression tests pass: 114 tests
- [x] UI package typecheck passes
- [x] Web typecheck passes
- [x] Web lint passes
- [x] Repository pre-push gate passes

Generated with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced dropdown and context-menu with search, filtering, and nested submenu support
  * Added item descriptions, trailing content, and count badges
  * Added loading states and empty-state messaging for menus
  * Added state variants (success, warning, danger) for action items
  * Customizable menu sizing options

* **Refactor**
  * Simplified theme initialization in web layout

* **Tests**
  * Added comprehensive test coverage for enhanced dropdown features
<!-- end of auto-generated comment: release notes by coderabbit.ai -->