### PR TITLE
fix(ui): address dropdown review nits

### DIFF
--- a/packages/ui/atoms/common-dropdown-item-renderers.tsx
+++ b/packages/ui/atoms/common-dropdown-item-renderers.tsx
@@ -31,12 +31,15 @@ import type {
 } from './common-dropdown-types';
 import { isLabel } from './common-dropdown-types';
 
+function isObjectLike(value: unknown): value is object {
+  return Object(value) === value;
+}
+
 function isIconComponent(
   value: unknown
 ): value is React.ComponentType<{ className?: string }> {
   return (
-    typeof value === 'function' ||
-    (typeof value === 'object' && value !== null && '$$typeof' in value)
+    typeof value === 'function' || (isObjectLike(value) && '$$typeof' in value)
   );
 }
 

--- a/packages/ui/atoms/common-dropdown-item-renderers.tsx
+++ b/packages/ui/atoms/common-dropdown-item-renderers.tsx
@@ -36,7 +36,7 @@ function isIconComponent(
 ): value is React.ComponentType<{ className?: string }> {
   return (
     typeof value === 'function' ||
-    Boolean(value && typeof value === 'object' && '$$typeof' in value)
+    (typeof value === 'object' && value !== null && '$$typeof' in value)
   );
 }
 

--- a/packages/ui/atoms/common-dropdown-renderer.tsx
+++ b/packages/ui/atoms/common-dropdown-renderer.tsx
@@ -41,20 +41,20 @@ import { filterItems, getContentStyle } from './common-dropdown-utils';
 
 export type MenuPrimitiveKind = 'dropdown' | 'context';
 
-export type MenuRenderContext = {
+export interface MenuRenderContext {
   readonly kind: MenuPrimitiveKind;
   readonly itemBase: string;
   readonly disablePortal: boolean;
   readonly portalProps?: Record<string, unknown>;
-};
+}
 
-type SearchableContentProps = {
+interface SearchableContentProps {
   readonly query: string;
   readonly placeholder: string;
   readonly onQueryChange: (query: string) => void;
   readonly onClear: () => void;
   readonly inputRef?: React.Ref<HTMLInputElement>;
-};
+}
 
 function focusSiblingMenuItem(
   input: HTMLInputElement | null,


### PR DESCRIPTION
## Summary
- replace the redundant truthiness check in CommonDropdown icon component detection with an explicit object/null guard
- switch dropdown renderer object-shape aliases to interfaces

## Verification
- pnpm --filter @jovie/ui test -- common-dropdown.test.tsx dropdown-menu.test.tsx context-menu.test.tsx
- pnpm --filter @jovie/ui typecheck
- pnpm biome check .
- push preflight: biome check ., next proxy guard, tailwind guard, web typecheck, web lint

Follow-up for review comments left after #7326 was already merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored object detection logic and enhanced component type identification mechanisms throughout the framework.
  * Updated internal type definitions in dropdown and menu rendering systems to improve code structure and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->