### PR TITLE
fix(onboarding): support seeded signup state

### DIFF
--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -21,6 +21,7 @@ import { extractErrorMessage } from '@/lib/utils/errors';
 interface OnboardingPageProps {
   readonly searchParams?: Promise<{
     readonly handle?: string;
+    readonly username?: string;
     readonly resume?: string;
   }>;
 }
@@ -48,10 +49,12 @@ export default async function OnboardingPage({
   const resolvedSearchParams = await searchParams;
   const pendingClaim = await readPendingClaimContext();
   const targetProfileId = pendingClaim?.creatorProfileId ?? null;
+  const handleQuery =
+    resolvedSearchParams?.handle ?? resolvedSearchParams?.username;
   const shouldSkipDashboardPrefetch =
-    isE2EFastOnboardingEnabled() && Boolean(resolvedSearchParams?.handle);
+    isE2EFastOnboardingEnabled() && Boolean(handleQuery);
   const assumeInitialHandleAvailable =
-    isE2EFastOnboardingEnabled() && Boolean(resolvedSearchParams?.handle);
+    isE2EFastOnboardingEnabled() && Boolean(handleQuery);
 
   const authResult = await resolveUserState();
 
@@ -72,7 +75,7 @@ export default async function OnboardingPage({
 
   const hasResumeSignal = Boolean(resolvedSearchParams?.resume);
   const hasOnboardingContinuationSignal = Boolean(
-    resolvedSearchParams?.handle || resolvedSearchParams?.resume
+    handleQuery || resolvedSearchParams?.resume
   );
   const shouldLoadExistingProfile = Boolean(
     targetProfileId ?? authResult.profileId
@@ -132,9 +135,7 @@ export default async function OnboardingPage({
   // Start handle reservation early with what we know now (display name from Clerk)
   const earlyDisplayName = clerkIdentity.displayName || '';
   const earlyProvidedHandle =
-    resolvedSearchParams?.handle ||
-    pendingClaim?.username ||
-    spotifySuggestedHandle;
+    handleQuery || pendingClaim?.username || spotifySuggestedHandle;
   const reservedHandlePromise =
     !earlyProvidedHandle && earlyDisplayName
       ? reserveOnboardingHandle(earlyDisplayName)
@@ -163,7 +164,7 @@ export default async function OnboardingPage({
     existingProfile?.displayName || clerkIdentity.displayName || '';
 
   const providedHandle =
-    resolvedSearchParams?.handle ||
+    handleQuery ||
     pendingClaim?.username ||
     existingProfile?.username ||
     spotifySuggestedHandle;

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -188,7 +188,7 @@ export default async function OnboardingPage({
 
   const shouldAutoSubmitHandle =
     Boolean(spotifySuggestedHandle) &&
-    !resolvedSearchParams?.handle &&
+    !handleQuery &&
     !existingProfile?.username;
 
   return (

--- a/apps/web/components/features/dashboard/organisms/OnboardingFormWrapper.tsx
+++ b/apps/web/components/features/dashboard/organisms/OnboardingFormWrapper.tsx
@@ -123,6 +123,7 @@ export function OnboardingFormWrapper({
     >
       {isResumeFlow ? (
         <OnboardingV2Form
+          assumeInitialHandleAvailable={assumeInitialHandleAvailable}
           key={formKey}
           initialDisplayName={initialDisplayName}
           initialHandle={resolvedHandle}

--- a/apps/web/components/features/dashboard/organisms/onboarding-v2/OnboardingV2Form.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding-v2/OnboardingV2Form.tsx
@@ -232,6 +232,7 @@ interface LateArrival {
 }
 
 interface OnboardingV2FormProps {
+  readonly assumeInitialHandleAvailable?: boolean;
   readonly existingAvatarUrl?: string | null;
   readonly existingBio?: string | null;
   readonly existingGenres?: string[] | null;
@@ -754,6 +755,7 @@ function OnboardingSidebar({
 }
 
 export function OnboardingV2Form({
+  assumeInitialHandleAvailable = false,
   existingAvatarUrl = null,
   existingBio = null,
   existingGenres = null,
@@ -810,7 +812,8 @@ export function OnboardingV2Form({
 
   const { handleValidation, setHandleValidation, handle, validateHandle } =
     useHandleValidation({
-      assumeInitialHandleAvailable: Boolean(initialProfileId),
+      assumeInitialHandleAvailable:
+        assumeInitialHandleAvailable || Boolean(initialProfileId),
       fullName: initialDisplayName,
       normalizedInitialHandle,
     });

--- a/apps/web/components/features/dashboard/organisms/onboarding-v2/shared/useHandleValidation.ts
+++ b/apps/web/components/features/dashboard/organisms/onboarding-v2/shared/useHandleValidation.ts
@@ -59,12 +59,19 @@ export function useHandleValidation({
   normalizedInitialHandle,
   fullName,
 }: UseHandleValidationOptions): UseHandleValidationReturn {
+  const isTrustedSeededHandle = useCallback(
+    (value: string) =>
+      assumeInitialHandleAvailable &&
+      Boolean(normalizedInitialHandle) &&
+      value === normalizedInitialHandle,
+    [assumeInitialHandleAvailable, normalizedInitialHandle]
+  );
+
   const [handle, setHandle] = useState(normalizedInitialHandle);
   const handleRef = useRef(normalizedInitialHandle);
   const [handleValidation, setHandleValidation] =
     useState<HandleValidationState>({
-      available:
-        assumeInitialHandleAvailable && Boolean(normalizedInitialHandle),
+      available: isTrustedSeededHandle(normalizedInitialHandle),
       checking: false,
       error: null,
       clientValid: Boolean(normalizedInitialHandle),
@@ -113,6 +120,17 @@ export function useHandleValidation({
 
       abortRetryCountRef.current.delete(input);
 
+      if (isTrustedSeededHandle(input)) {
+        setHandleValidation({
+          available: true,
+          checking: false,
+          error: null,
+          clientValid: true,
+          suggestions: [],
+        });
+        return;
+      }
+
       if (result.available) {
         setHandleValidation({
           available: true,
@@ -143,6 +161,19 @@ export function useHandleValidation({
 
       if (isAbortError(error) || isNetworkError(error)) {
         const currentHandle = latestRequestedHandleRef.current;
+
+        if (isTrustedSeededHandle(currentHandle)) {
+          abortRetryCountRef.current.delete(currentHandle);
+          setHandleValidation({
+            available: true,
+            checking: false,
+            clientValid: true,
+            error: null,
+            suggestions: [],
+          });
+          return;
+        }
+
         const currentRetryCount =
           abortRetryCountRef.current.get(currentHandle) ?? 0;
 
@@ -216,6 +247,17 @@ export function useHandleValidation({
     if (combinedChecking) {
       safetyTimerRef.current = setTimeout(() => {
         setHandleValidation(prev => {
+          if (isTrustedSeededHandle(handleRef.current)) {
+            return {
+              ...prev,
+              available: true,
+              checking: false,
+              error: null,
+              clientValid: true,
+              suggestions: [],
+            };
+          }
+
           if (prev.checking) {
             return {
               ...prev,
@@ -237,7 +279,7 @@ export function useHandleValidation({
         safetyTimerRef.current = null;
       }
     };
-  }, [combinedChecking]);
+  }, [combinedChecking, isTrustedSeededHandle]);
 
   const validateHandle = useCallback(
     (input: string) => {
@@ -247,11 +289,7 @@ export function useHandleValidation({
       abortRetryCountRef.current.delete(normalizedInput);
 
       // Fast path: if input matches initial handle, mark as valid immediately
-      if (
-        assumeInitialHandleAvailable &&
-        normalizedInitialHandle &&
-        normalizedInput === normalizedInitialHandle
-      ) {
+      if (isTrustedSeededHandle(normalizedInput)) {
         cancelValidation();
         setHandle(normalizedInput);
         setHandleValidation({
@@ -291,13 +329,11 @@ export function useHandleValidation({
       // Trigger API validation via Pacer (debounced, cached)
       validateApiRef.current(normalizedInput);
     },
-    [assumeInitialHandleAvailable, cancelValidation, normalizedInitialHandle]
+    [cancelValidation, isTrustedSeededHandle]
   );
 
   const isSeededInitialHandleReady =
-    assumeInitialHandleAvailable &&
-    Boolean(normalizedInitialHandle) &&
-    handle === normalizedInitialHandle &&
+    isTrustedSeededHandle(handle) &&
     handleValidation.available &&
     handleValidation.clientValid &&
     !handleValidation.error;

--- a/apps/web/tests/components/dashboard/organisms/onboarding-form-wrapper.test.tsx
+++ b/apps/web/tests/components/dashboard/organisms/onboarding-form-wrapper.test.tsx
@@ -19,7 +19,10 @@ vi.mock('@/features/dashboard/organisms/OnboardingHandleOnlyForm', () => ({
 vi.mock(
   '@/features/dashboard/organisms/onboarding-v2/OnboardingV2Form',
   () => ({
-    OnboardingV2Form: (props: { initialHandle?: string }) => {
+    OnboardingV2Form: (props: {
+      assumeInitialHandleAvailable?: boolean;
+      initialHandle?: string;
+    }) => {
       v2FormPropsSpy(props);
       return <div data-testid='mock-onboarding-v2-form' />;
     },
@@ -81,5 +84,23 @@ describe('OnboardingFormWrapper', () => {
     expect(handleOnlyFormPropsSpy).not.toHaveBeenCalled();
     expect(screen.getByTestId('onboarding-loading-shell')).toBeTruthy();
     expect(await screen.findByTestId('mock-onboarding-v2-form')).toBeTruthy();
+  });
+
+  it('passes seeded-handle fast-path props to the full onboarding form', async () => {
+    render(
+      <OnboardingFormWrapper
+        assumeInitialHandleAvailable
+        initialHandle='existing-handle'
+        initialProfileId='profile_123'
+        userId='user_123'
+      />
+    );
+
+    await screen.findByTestId('mock-onboarding-v2-form');
+
+    expect(v2FormPropsSpy.mock.calls[0]?.[0]).toMatchObject({
+      assumeInitialHandleAvailable: true,
+      initialHandle: 'existing-handle',
+    });
   });
 });

--- a/apps/web/tests/unit/app/onboarding-page.test.tsx
+++ b/apps/web/tests/unit/app/onboarding-page.test.tsx
@@ -268,6 +268,36 @@ describe('onboarding page', () => {
     expect(redirectMock).not.toHaveBeenCalledWith(APP_ROUTES.DASHBOARD);
   });
 
+  it('treats the legacy username query as a continuation signal and prefilled handle', async () => {
+    const { resolveUserState } = await import('@/lib/auth/gate');
+
+    vi.mocked(resolveUserState).mockResolvedValueOnce({
+      state: 'ACTIVE',
+      clerkUserId: 'clerk_123',
+      dbUserId: 'db_123',
+      profileId: 'profile_123',
+      redirectTo: APP_ROUTES.DASHBOARD,
+      context: {
+        isAdmin: false,
+        isPro: false,
+        email: 'artist@example.com',
+      },
+    });
+
+    const page = await OnboardingPage({
+      searchParams: Promise.resolve({ username: 'legacy-artist' }),
+    });
+    render(page);
+
+    expect(page).toBeTruthy();
+    expect(redirectMock).not.toHaveBeenCalledWith(APP_ROUTES.DASHBOARD);
+    expect(onboardingWrapperPropsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialHandle: 'legacy-artist',
+      })
+    );
+  });
+
   it('redirects active users with only a pending claim cookie back to the app shell', async () => {
     const { resolveUserState } = await import('@/lib/auth/gate');
 

--- a/apps/web/tests/unit/components/dashboard/organisms/apple-style-onboarding/useHandleValidation.test.ts
+++ b/apps/web/tests/unit/components/dashboard/organisms/apple-style-onboarding/useHandleValidation.test.ts
@@ -135,6 +135,28 @@ describe('useHandleValidation', () => {
     expect(result.current.handleValidation.available).toBe(true);
   });
 
+  it('keeps a trusted seeded handle available after a transient network failure', async () => {
+    const { result } = renderHook(() =>
+      useHandleValidation({
+        assumeInitialHandleAvailable: true,
+        normalizedInitialHandle: 'claimed-handle',
+        fullName: 'Taylor Swift',
+      })
+    );
+
+    await act(async () => {
+      result.current.validateHandle('claimed-handle');
+    });
+
+    act(() => {
+      validateApiState.callbacks.onError?.(new Error('Failed to fetch'));
+    });
+
+    expect(result.current.handleValidation.available).toBe(true);
+    expect(result.current.handleValidation.error).toBeNull();
+    expect(result.current.handleValidation.checking).toBe(false);
+  });
+
   it('retries transient aborts for the current handle within the retry budget', async () => {
     vi.useFakeTimers();
     const retryValidate = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary
- preserve trusted seeded signup handle state through onboarding v2
- pass the seeded handle assumption through the onboarding wrapper and page entrypoint
- add regression coverage for seeded handle onboarding behavior

## Validation
- pnpm --filter @jovie/web exec vitest run tests/components/dashboard/organisms/onboarding-form-wrapper.test.tsx tests/unit/app/onboarding-page.test.tsx tests/unit/components/dashboard/organisms/apple-style-onboarding/useHandleValidation.test.ts
- pnpm --filter @jovie/web exec tsc --noEmit