### PR TITLE
fix(e2e): tighten local test helpers

### DIFF
--- a/apps/web/app/api/dashboard/profile/lib/test-helpers.ts
+++ b/apps/web/app/api/dashboard/profile/lib/test-helpers.ts
@@ -7,15 +7,13 @@
 
 import { clerkClient } from '@clerk/nextjs/server';
 import { NextResponse } from 'next/server';
-import { db } from '@/lib/db';
-import { users } from '@/lib/db/schema/auth';
-import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { syncCanonicalUsernameFromApp } from '@/lib/username/sync';
 import { NO_STORE_HEADERS } from './constants';
+import { getProfileByClerkId, updateProfileRecords } from './db-operations';
 
 export interface TestProfileUpdateParams {
   clerkUserId: string;
-  dbProfileUpdates?: Record<string, unknown>;
+  dbProfileUpdates: Record<string, unknown>;
   usernameUpdate?: string;
   displayNameForUserUpdate?: string;
   avatarUrl?: string;
@@ -28,6 +26,17 @@ export async function handleTestProfileUpdate({
   displayNameForUserUpdate,
   avatarUrl,
 }: TestProfileUpdateParams) {
+  const existingProfileRecord = await getProfileByClerkId(clerkUserId);
+  const existingProfile = existingProfileRecord?.profile ?? null;
+  const usernameChanged =
+    typeof usernameUpdate === 'string' &&
+    usernameUpdate !== existingProfile?.username;
+  const displayNameChanged =
+    typeof displayNameForUserUpdate === 'string' &&
+    displayNameForUserUpdate !== existingProfile?.displayName;
+  const avatarChanged =
+    typeof avatarUrl === 'string' && avatarUrl !== existingProfile?.avatarUrl;
+
   let clerk: Awaited<ReturnType<typeof clerkClient>> | null = null;
   try {
     clerk = await clerkClient();
@@ -36,10 +45,10 @@ export async function handleTestProfileUpdate({
     clerk = null;
   }
 
-  if (usernameUpdate) {
+  if (usernameChanged) {
     await syncCanonicalUsernameFromApp(clerkUserId, usernameUpdate);
   }
-  if (displayNameForUserUpdate && clerk?.users?.updateUser) {
+  if (displayNameChanged && clerk?.users?.updateUser) {
     const nameParts = displayNameForUserUpdate.split(' ');
     const firstName = nameParts.shift() ?? displayNameForUserUpdate;
     const lastName = nameParts.join(' ').trim();
@@ -48,7 +57,7 @@ export async function handleTestProfileUpdate({
       lastName: lastName || undefined,
     });
   }
-  if (avatarUrl && clerk?.users?.updateUserProfileImage) {
+  if (avatarChanged && clerk?.users?.updateUserProfileImage) {
     const avatarResponse = await fetch(avatarUrl, {
       signal: AbortSignal.timeout(10000),
     });
@@ -61,34 +70,21 @@ export async function handleTestProfileUpdate({
     });
   }
 
-  // Trigger mocked DB returning() to satisfy test expectations
-  type OptionalDb = {
-    update?: (table: typeof creatorProfiles) => {
-      set?: (values: Partial<typeof creatorProfiles.$inferInsert>) => {
-        from?: (table: typeof users) => {
-          where?: (predicate: unknown) => {
-            returning?: () => unknown;
-          };
-        };
-      };
-    };
-  };
+  const updateResult = await updateProfileRecords({
+    clerkUserId,
+    dbProfileUpdates,
+    displayNameForUserUpdate,
+  });
 
-  const maybeDb = db as unknown as OptionalDb | undefined;
-  const updater = maybeDb?.update?.(creatorProfiles);
-  const chained = updater
-    ?.set?.({
-      ...(dbProfileUpdates as Partial<typeof creatorProfiles.$inferInsert>),
-      updatedAt: new Date(),
-    })
-    ?.from?.(users)
-    ?.where?.(() => true);
-  chained?.returning?.();
+  if (updateResult instanceof NextResponse) {
+    return updateResult;
+  }
+
   const responseProfile = {
-    userId: 'user_123',
-    username: usernameUpdate ?? 'new-handle',
-    displayName: displayNameForUserUpdate ?? 'Test User',
-    usernameNormalized: (usernameUpdate ?? 'new-handle').toLowerCase(),
+    userId: updateResult.updatedProfile.userId,
+    username: updateResult.updatedProfile.username,
+    displayName: updateResult.updatedProfile.displayName,
+    usernameNormalized: updateResult.updatedProfile.usernameNormalized,
   };
   return NextResponse.json(
     { profile: responseProfile },

--- a/apps/web/components/providers/clerkAvailability.ts
+++ b/apps/web/components/providers/clerkAvailability.ts
@@ -32,7 +32,13 @@ export function shouldBypassClerk(
     : globalThis.location
 ): boolean {
   const normalizedKey = publishableKey?.trim();
+  const allowRealClerkForLocalE2E =
+    publicEnv.NEXT_PUBLIC_E2E_MODE === '1' &&
+    clerkMockFlag !== '1' &&
+    normalizedKey !== undefined &&
+    !isMockPublishableKey(normalizedKey);
   const shouldBypassForPrivateOrigin =
+    !allowRealClerkForLocalE2E &&
     shouldDisableClerkProxyForLocation(locationLike);
 
   return (

--- a/apps/web/scripts/cleanup-e2e-users.ts
+++ b/apps/web/scripts/cleanup-e2e-users.ts
@@ -161,7 +161,7 @@ async function cleanupDatabaseRecords(
   const { neon } = await import('@neondatabase/serverless');
   const { eq } = await import('drizzle-orm');
   const { drizzle } = await import('drizzle-orm/neon-http');
-  const schema = await import('@/lib/db/schema');
+  const schema = await import('../lib/db/schema');
 
   const sql = neon(databaseUrl);
   const db = drizzle(sql, { schema });

--- a/apps/web/tests/unit/providers/clerk-availability.test.ts
+++ b/apps/web/tests/unit/providers/clerk-availability.test.ts
@@ -39,6 +39,20 @@ describe('clerkAvailability', () => {
     ).toBe(true);
   });
 
+  it('keeps Clerk enabled for local real-auth E2E runs', () => {
+    vi.stubEnv('NEXT_PUBLIC_E2E_MODE', '1');
+
+    expect(
+      shouldBypassClerk(
+        'pk_test_example',
+        '0',
+        new URL('http://localhost:3100')
+      )
+    ).toBe(false);
+
+    vi.unstubAllEnvs();
+  });
+
   it('keeps Clerk enabled for real keys on secure public origins', () => {
     expect(
       shouldBypassClerk(

--- a/apps/web/tests/unit/providers/clerk-availability.test.ts
+++ b/apps/web/tests/unit/providers/clerk-availability.test.ts
@@ -8,6 +8,10 @@ import {
 } from '@/components/providers/clerkAvailability';
 
 describe('clerkAvailability', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('bypasses Clerk for whitespace-only publishable keys', () => {
     expect(shouldBypassClerk('   ', '0')).toBe(true);
   });
@@ -49,8 +53,6 @@ describe('clerkAvailability', () => {
         new URL('http://localhost:3100')
       )
     ).toBe(false);
-
-    vi.unstubAllEnvs();
   });
 
   it('keeps Clerk enabled for real keys on secure public origins', () => {


### PR DESCRIPTION
## Summary
- tighten local E2E helper behavior around profile test helpers and Clerk availability checks
- make cleanup import resolution reliable in the local script path
- add unit coverage for Clerk availability behavior

## Validation
- pnpm --filter @jovie/web exec vitest run tests/unit/providers/clerk-availability.test.ts
- pnpm --filter @jovie/web exec tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced E2E testing infrastructure with improved Clerk authentication bypass logic for local environments and added corresponding test coverage.

* **Chores**
  * Updated internal profile update testing utilities and database import paths for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->