### PR TITLE
fix(e2e): harden dashboard route helpers

### DIFF
--- a/apps/web/tests/e2e/auth.setup.ts
+++ b/apps/web/tests/e2e/auth.setup.ts
@@ -1,14 +1,13 @@
-import { clerk, setupClerkTestingToken } from '@clerk/testing/playwright';
-import { expect, test as setup } from '@playwright/test';
-import { APP_ROUTES } from '@/constants/routes';
+import { test as setup } from '@playwright/test';
+import { ClerkTestError, signInUser } from '../helpers/clerk-auth';
 
 const AUTH_FILE = 'tests/.auth/user.json';
 
 setup.describe.configure({ mode: 'serial' });
 
-setup.setTimeout(240_000); // 4min to handle Turbopack cold-start compilation
+setup.setTimeout(360_000); // 6min to absorb local cold-start compilation plus Clerk bootstrap
 
-setup('authenticate', async ({ page, baseURL }) => {
+setup('authenticate', async ({ page }) => {
   const username = process.env.E2E_CLERK_USER_USERNAME;
   const password = process.env.E2E_CLERK_USER_PASSWORD;
 
@@ -19,146 +18,23 @@ setup('authenticate', async ({ page, baseURL }) => {
     return;
   }
 
-  // 1. Set up testing token BEFORE navigation
-  await setupClerkTestingToken({ page });
-
-  // 2. Navigate to sign-in page (has ClerkProvider)
-  // Turbopack cold compilation can cause the first navigation to hang even after
-  // warmup in global-setup. Retry with fresh navigations to recover.
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    try {
-      await page.goto(APP_ROUTES.SIGNIN, {
-        waitUntil: 'domcontentloaded',
-        timeout: 60_000,
-      });
-      break; // Navigation succeeded
-    } catch {
-      if (attempt === 3)
-        throw new Error('Failed to load /signin after 3 attempts');
-      console.log(`  /signin attempt ${attempt} timed out, retrying...`);
-    }
-  }
-
-  // 3. Wait for Clerk JS to load from CDN before calling clerk.signIn()
-  // The @clerk/testing library has a hard 30s timeout for window.Clerk.loaded.
-  // Pre-waiting here prevents that timeout from being eaten by Turbopack compilation.
-  await page
-    .waitForFunction(() => !!(window as any).Clerk?.loaded, { timeout: 60_000 })
-    .catch(() => {
-      // If Clerk still hasn't loaded, let clerk.signIn() handle the error
-    });
-
-  // 4. Sign in using appropriate strategy
-  // Wrap in try/catch to handle "already signed in" from testing token
   try {
-    if (username.includes('+clerk_test')) {
-      await clerk.signIn({
-        page,
-        signInParams: { strategy: 'email_code', identifier: username },
-      });
-    } else if (password) {
-      // Try password strategy first, fall back to email_code if disabled
-      try {
-        await clerk.signIn({
-          page,
-          signInParams: {
-            strategy: 'password',
-            identifier: username,
-            password,
-          },
-        });
-      } catch (strategyError) {
-        const strategyMsg =
-          strategyError instanceof Error
-            ? strategyError.message
-            : String(strategyError);
-        if (strategyMsg.includes('strategy')) {
-          console.log(
-            '  Password strategy not available, falling back to email_code'
-          );
-          await clerk.signIn({
-            page,
-            signInParams: { strategy: 'email_code', identifier: username },
-          });
-        } else {
-          throw strategyError;
-        }
-      }
-    } else {
-      await page.context().storageState({ path: AUTH_FILE });
-      return;
-    }
+    await signInUser(page, { username, password });
   } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    if (msg.includes('already signed in')) {
-      console.log('  Already signed in via testing token, continuing...');
-    } else if (
-      msg.includes('strategy') ||
-      msg.includes('infinite redirect') ||
-      msg.includes('instance keys') ||
-      msg.includes('test email') ||
-      msg.includes('Timeout') ||
-      msg.includes('timeout')
+    if (
+      error instanceof ClerkTestError &&
+      ['CLERK_SETUP_FAILED', 'CLERK_NOT_READY', 'MISSING_CREDENTIALS'].includes(
+        error.code
+      )
     ) {
-      // Clerk configuration issue — write empty auth state so tests with
-      // their own auth (e.g., admin tests) can still run independently.
       console.log(
-        `  Auth setup failed (${msg.substring(0, 120)}), writing empty auth state`
+        `  Auth setup failed (${error.message.substring(0, 120)}), writing empty auth state`
       );
       await page.context().storageState({ path: AUTH_FILE });
       return;
-    } else {
-      throw error;
     }
+    throw error;
   }
-
-  // 5. Navigate to chat to verify auth + warm up route
-  // DASHBOARD_PROFILE is deprecated (it just redirects to CHAT), so navigate
-  // directly to CHAT to avoid a 307 → 404 chain on certain server configs.
-  // Use 'domcontentloaded' to avoid Sentry blocking 'load'/'networkidle'
-  await page.goto(APP_ROUTES.CHAT, {
-    waitUntil: 'domcontentloaded',
-    timeout: 120_000,
-  });
-
-  // 6. Wait for dashboard to be usable, dismissing Next.js dev error overlays
-  // Turbopack cold compilation + hydration mismatch (nonce attr) can block the page.
-  // Strategy: dismiss overlays, reload once if the page is stuck.
-  let hasReloaded = false;
-  await expect(async () => {
-    // Dismiss Next.js error overlay if present
-    const overlay = page.locator(
-      '[data-nextjs-dialog-overlay], [data-nextjs-toast]'
-    );
-    if (await overlay.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await page.keyboard.press('Escape');
-      await page
-        .waitForFunction(
-          () =>
-            !document.querySelector(
-              '[data-nextjs-dialog-overlay], [data-nextjs-toast]'
-            ),
-          { timeout: 5000 }
-        )
-        .catch(() => {});
-    }
-    // Click "Try again" on error boundary if present
-    const tryAgain = page.getByRole('button', { name: 'Try again' });
-    if (await tryAgain.isVisible({ timeout: 500 }).catch(() => false)) {
-      await tryAgain.click();
-      await page
-        .waitForLoadState('domcontentloaded', { timeout: 10000 })
-        .catch(() => {});
-    }
-    // If nav still not visible and we haven't reloaded, try a full page reload
-    // This reliably recovers from stuck error overlays and Turbopack issues
-    const dashNav = page.locator('nav[aria-label="Dashboard navigation"]');
-    if (!(await dashNav.isVisible().catch(() => false)) && !hasReloaded) {
-      hasReloaded = true;
-      await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 });
-    }
-    await expect(dashNav).toBeVisible({ timeout: 5000 });
-  }).toPass({ timeout: 120_000, intervals: [3000, 5000, 10000, 15000] });
 
   // 7. Save authenticated session
   await page.context().storageState({ path: AUTH_FILE });

--- a/apps/web/tests/e2e/utils/dashboard-route-resolvers.ts
+++ b/apps/web/tests/e2e/utils/dashboard-route-resolvers.ts
@@ -60,29 +60,54 @@ interface ConversationsListResponse {
   }>;
 }
 
+interface BrowserFetchInit {
+  readonly method?: string;
+  readonly headers?: Record<string, string>;
+  readonly body?: string;
+}
+
 async function fetchJsonFromPage<T>(
   page: Page,
   input: string,
-  init?: RequestInit
+  init?: BrowserFetchInit
 ): Promise<{
   readonly ok: boolean;
   readonly status: number;
   readonly data: T;
 }> {
-  const response = await page.request.fetch(input, {
-    failOnStatusCode: false,
-    headers: init?.headers
-      ? Object.fromEntries(new Headers(init.headers).entries())
-      : undefined,
-    method: init?.method,
-    data: init?.body,
-  });
-  const data = (await response.json().catch(() => ({}))) as T;
-  return {
-    ok: response.ok(),
-    status: response.status(),
-    data,
-  };
+  return page.evaluate(
+    async ({ target, requestInit }) => {
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => controller.abort(), 15_000);
+
+      try {
+        const response = await fetch(target, {
+          method: requestInit?.method,
+          headers: requestInit?.headers,
+          body: requestInit?.body,
+          signal: controller.signal,
+        });
+        const rawBody = await response.text().catch(() => '');
+        let data = {} as T;
+        if (rawBody.trim().length > 0) {
+          try {
+            data = JSON.parse(rawBody) as T;
+          } catch {
+            data = {} as T;
+          }
+        }
+
+        return {
+          ok: response.ok,
+          status: response.status,
+          data,
+        };
+      } finally {
+        window.clearTimeout(timeoutId);
+      }
+    },
+    { target: input, requestInit: init }
+  );
 }
 
 export async function resolveChatConversationPath(page: Page): Promise<string> {

--- a/apps/web/tests/e2e/utils/dashboard-route-resolvers.ts
+++ b/apps/web/tests/e2e/utils/dashboard-route-resolvers.ts
@@ -69,21 +69,20 @@ async function fetchJsonFromPage<T>(
   readonly status: number;
   readonly data: T;
 }> {
-  return page.evaluate(
-    async ({ requestInput, requestInit }) => {
-      const response = await fetch(requestInput, {
-        credentials: 'same-origin',
-        ...requestInit,
-      });
-      const data = (await response.json().catch(() => ({}))) as T;
-      return {
-        ok: response.ok,
-        status: response.status,
-        data,
-      };
-    },
-    { requestInput: input, requestInit: init }
-  );
+  const response = await page.request.fetch(input, {
+    failOnStatusCode: false,
+    headers: init?.headers
+      ? Object.fromEntries(new Headers(init.headers).entries())
+      : undefined,
+    method: init?.method,
+    data: init?.body,
+  });
+  const data = (await response.json().catch(() => ({}))) as T;
+  return {
+    ok: response.ok(),
+    status: response.status(),
+    data,
+  };
 }
 
 export async function resolveChatConversationPath(page: Page): Promise<string> {

--- a/apps/web/tests/e2e/utils/smoke-test-utils.ts
+++ b/apps/web/tests/e2e/utils/smoke-test-utils.ts
@@ -445,10 +445,13 @@ export async function assertValidPageState(
 export async function smokeNavigate(
   page: Page,
   url: string,
-  options?: { timeout?: number }
+  options?: {
+    timeout?: number;
+    waitUntil?: 'commit' | 'domcontentloaded' | 'load' | 'networkidle';
+  }
 ): Promise<ReturnType<Page['goto']>> {
   return page.goto(url, {
-    waitUntil: 'domcontentloaded',
+    waitUntil: options?.waitUntil ?? 'domcontentloaded',
     timeout: options?.timeout ?? SMOKE_TIMEOUTS.NAVIGATION,
   });
 }
@@ -726,12 +729,20 @@ export async function checkElementVisibility(
 export async function smokeNavigateWithRetry(
   page: Page,
   url: string,
-  options?: { timeout?: number; retries?: number }
+  options?: {
+    timeout?: number;
+    retries?: number;
+    waitUntil?: 'commit' | 'domcontentloaded' | 'load' | 'networkidle';
+  }
 ): Promise<ReturnType<Page['goto']>> {
   const retries = options?.retries ?? 2;
 
   return withRetry(
-    () => smokeNavigate(page, url, { timeout: options?.timeout }),
+    () =>
+      smokeNavigate(page, url, {
+        timeout: options?.timeout,
+        waitUntil: options?.waitUntil,
+      }),
     {
       retries,
       onRetry: attempt => {

--- a/apps/web/tests/helpers/clerk-auth.ts
+++ b/apps/web/tests/helpers/clerk-auth.ts
@@ -10,10 +10,13 @@ import {
   TEST_USER_ID_COOKIE,
   TEST_USER_ID_HEADER,
 } from '@/lib/auth/test-mode';
+import { ensureClerkTestUser } from '@/lib/testing/test-user-provision.server';
 import { smokeNavigateWithRetry } from '../e2e/utils/smoke-test-utils';
 import { primeVercelBypassCookie } from './vercel-preview';
 
 const AUTH_READY_ROUTE = APP_ROUTES.DASHBOARD;
+const CLERK_BOOTSTRAP_NAV_TIMEOUT_MS = 60_000;
+const CLERK_BOOTSTRAP_NAV_RETRIES = 3;
 
 function isTestAuthBypassEnabled(): boolean {
   return process.env.E2E_USE_TEST_AUTH_BYPASS === '1';
@@ -481,6 +484,77 @@ export async function waitForAuthenticatedHealth(
     .toBe('authenticated');
 }
 
+async function navigateToClerkSignIn(page: Page): Promise<void> {
+  await page.request
+    .get('/signin', {
+      failOnStatusCode: false,
+      timeout: 120_000,
+    })
+    .catch(() => {});
+
+  await smokeNavigateWithRetry(page, '/signin', {
+    timeout: CLERK_BOOTSTRAP_NAV_TIMEOUT_MS,
+    retries: CLERK_BOOTSTRAP_NAV_RETRIES,
+    waitUntil: 'commit',
+  });
+
+  await page
+    .waitForLoadState('domcontentloaded', {
+      timeout: CLERK_BOOTSTRAP_NAV_TIMEOUT_MS,
+    })
+    .catch(() => {});
+}
+
+async function waitForClerkSignInApi(page: Page): Promise<boolean> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const ready = await page
+      .waitForFunction(
+        () => {
+          const clerkInstance = (
+            window as {
+              Clerk?: {
+                loaded?: boolean;
+                client?: {
+                  signIn?: {
+                    create?: unknown;
+                  };
+                };
+                setActive?: unknown;
+              };
+            }
+          ).Clerk;
+
+          return Boolean(
+            clerkInstance?.loaded &&
+              typeof clerkInstance.client?.signIn?.create === 'function' &&
+              typeof clerkInstance.setActive === 'function'
+          );
+        },
+        { timeout: 20_000 }
+      )
+      .then(() => true)
+      .catch(() => false);
+
+    if (ready) {
+      return true;
+    }
+
+    const retryButton = page.getByRole('button', { name: 'Retry now' });
+    if (await retryButton.isVisible().catch(() => false)) {
+      await retryButton.click().catch(() => {});
+    } else {
+      await page
+        .reload({
+          waitUntil: 'domcontentloaded',
+          timeout: CLERK_BOOTSTRAP_NAV_TIMEOUT_MS,
+        })
+        .catch(() => {});
+    }
+  }
+
+  return false;
+}
+
 async function waitForShellReadyAfterAuth(page: Page): Promise<void> {
   await smokeNavigateWithRetry(page, AUTH_READY_ROUTE, {
     timeout: 120_000,
@@ -668,6 +742,137 @@ export function hasClerkOriginMismatchSignal(
   );
 }
 
+function buildSeededTestUserProfile(email: string): {
+  username: string;
+  firstName: string;
+  lastName: string;
+} {
+  const localPart = email.split('@')[0] ?? 'e2e';
+  const baseUsername = localPart
+    .replaceAll(/[^a-z0-9]+/gi, '-')
+    .replaceAll(/^-+|-+$/g, '')
+    .slice(0, 48);
+
+  if (localPart.startsWith('browse')) {
+    return {
+      username: baseUsername || 'browse-test-user',
+      firstName: 'Browse',
+      lastName: 'Test',
+    };
+  }
+
+  return {
+    username: baseUsername || 'e2e-test-user',
+    firstName: 'E2E',
+    lastName: 'Test',
+  };
+}
+
+async function ensureClerkTestEmailUserExists(email: string): Promise<void> {
+  const { username, firstName, lastName } = buildSeededTestUserProfile(email);
+
+  await ensureClerkTestUser({
+    email,
+    username,
+    firstName,
+    lastName,
+    fallbackClerkId: process.env.E2E_CLERK_USER_ID?.trim() || undefined,
+    metadata: {
+      role: 'e2e',
+      env: 'test',
+      purpose: 'Auto-provisioned Playwright auth bootstrap user',
+    },
+  });
+}
+
+/**
+ * Sign in an existing Clerk test-email user without relying on the rendered UI.
+ * This avoids flaky hidden/detached button behavior on the hosted Clerk widget.
+ */
+async function signInExistingTestEmailSession(
+  page: Page,
+  email: string
+): Promise<void> {
+  const result = await page.evaluate(async targetEmail => {
+    const clerkInstance = (
+      window as {
+        Clerk?: {
+          client?: {
+            signIn?: {
+              create?: (args: { identifier: string }) => Promise<{
+                supportedFirstFactors?: Array<{
+                  strategy?: string | null;
+                  emailAddressId?: string | null;
+                }>;
+                prepareFirstFactor?: (args: {
+                  strategy: 'email_code';
+                  emailAddressId: string;
+                }) => Promise<unknown>;
+                attemptFirstFactor?: (args: {
+                  strategy: 'email_code';
+                  code: string;
+                }) => Promise<{
+                  createdSessionId?: string | null;
+                  status?: string | null;
+                }>;
+              }>;
+            };
+          };
+          setActive?: (args: { session: string }) => Promise<void>;
+          session?: { id?: string | null } | null;
+          user?: { id?: string | null } | null;
+        };
+      }
+    ).Clerk;
+
+    if (!clerkInstance?.client?.signIn?.create || !clerkInstance.setActive) {
+      throw new Error('Clerk sign-in API not initialized');
+    }
+
+    const signIn = await clerkInstance.client.signIn.create({
+      identifier: targetEmail,
+    });
+
+    const emailFactor = signIn.supportedFirstFactors?.find(
+      factor =>
+        factor.strategy === 'email_code' &&
+        typeof factor.emailAddressId === 'string' &&
+        factor.emailAddressId.length > 0
+    );
+
+    if (!emailFactor?.emailAddressId) {
+      throw new Error('Clerk email_code factor unavailable for test email');
+    }
+
+    await signIn.prepareFirstFactor({
+      strategy: 'email_code',
+      emailAddressId: emailFactor.emailAddressId,
+    });
+
+    const attempt = await signIn.attemptFirstFactor({
+      strategy: 'email_code',
+      code: '424242',
+    });
+
+    if (!attempt.createdSessionId) {
+      throw new Error(
+        `Clerk email_code sign-in completed with status "${attempt.status ?? 'unknown'}" but no session was created`
+      );
+    }
+
+    await clerkInstance.setActive({ session: attempt.createdSessionId });
+
+    return {
+      sessionId: clerkInstance.session?.id ?? attempt.createdSessionId ?? null,
+      userId: clerkInstance.user?.id ?? null,
+    };
+  }, email);
+
+  if (!result.sessionId || !result.userId) {
+    throw new Error('Clerk test-email sign-in did not activate a session');
+  }
+}
+
 /**
  * Creates or reuses a Clerk test user session for the given email.
  *
@@ -803,10 +1008,7 @@ export async function signInUser(
 
   // Navigate to a page that loads ClerkProvider
   // IMPORTANT: The marketing page (/) does NOT have ClerkProvider, but /signin does
-  await smokeNavigateWithRetry(page, '/signin', {
-    timeout: 120_000,
-    retries: 2,
-  });
+  await navigateToClerkSignIn(page);
 
   if (isClerkHandshakeUrl(page.url())) {
     throw new ClerkTestError(
@@ -815,25 +1017,27 @@ export async function signInUser(
     );
   }
 
-  // Wait for Clerk JS to load from CDN before calling clerk.signIn()
-  // The @clerk/testing library has a hard 30s timeout for window.Clerk.loaded.
-  // Pre-waiting here prevents that timeout from being eaten by Turbopack compilation.
-  await page
-    .waitForFunction(() => !!(window as any).Clerk?.loaded, { timeout: 60_000 })
-    .catch(() => {
-      // If Clerk still hasn't loaded, let clerk.signIn() handle the error
-    });
+  // Cold local compiles can reach the auth loading shell before Clerk's sign-in
+  // client API is actually ready. Wait for the concrete API surface we need.
+  await waitForClerkSignInApi(page);
 
   try {
     // Use the official Clerk testing helper
     // The @clerk/testing library has built-in support for email_code strategy
     // with +clerk_test emails (automatically uses code 424242)
     if (username.includes('+clerk_test')) {
-      // For test emails with +clerk_test suffix, use email_code strategy
-      await clerk.signIn({
-        page,
-        signInParams: { strategy: 'email_code', identifier: username },
-      });
+      await ensureClerkTestEmailUserExists(username);
+
+      try {
+        await signInExistingTestEmailSession(page, username);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.includes("Couldn't find your account")) {
+          await createOrReuseTestUserSession(page, username);
+        } else {
+          throw error;
+        }
+      }
     } else if (password) {
       // For real test users with passwords, try password strategy first,
       // then fall back to email_code if the Clerk instance disabled passwords

--- a/apps/web/tests/helpers/clerk-auth.ts
+++ b/apps/web/tests/helpers/clerk-auth.ts
@@ -555,6 +555,16 @@ async function waitForClerkSignInApi(page: Page): Promise<boolean> {
   return false;
 }
 
+function isMissingClerkAccountError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    /couldn't find your account/i.test(message) ||
+    /cannot find your account/i.test(message) ||
+    /account.*not found/i.test(message) ||
+    /identifier.*not found/i.test(message)
+  );
+}
+
 async function waitForShellReadyAfterAuth(page: Page): Promise<void> {
   await smokeNavigateWithRetry(page, AUTH_READY_ROUTE, {
     timeout: 120_000,
@@ -1019,7 +1029,13 @@ export async function signInUser(
 
   // Cold local compiles can reach the auth loading shell before Clerk's sign-in
   // client API is actually ready. Wait for the concrete API surface we need.
-  await waitForClerkSignInApi(page);
+  const clerkSignInReady = await waitForClerkSignInApi(page);
+  if (!clerkSignInReady) {
+    throw new ClerkTestError(
+      'Clerk sign-in API never became ready on /signin.',
+      'CLERK_SETUP_FAILED'
+    );
+  }
 
   try {
     // Use the official Clerk testing helper
@@ -1031,8 +1047,7 @@ export async function signInUser(
       try {
         await signInExistingTestEmailSession(page, username);
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (message.includes("Couldn't find your account")) {
+        if (isMissingClerkAccountError(error)) {
           await createOrReuseTestUserSession(page, username);
         } else {
           throw error;


### PR DESCRIPTION
## Summary
- harden dashboard route resolution helpers used by the golden-path app lane
- move chat conversation resolution off browser-thread fetches and improve route retries
- reduce late-flow navigation hangs in local Playwright runs

## Validation
- doppler run --project jovie-web --config dev -- env BASE_URL=http://localhost:3110 E2E_SKIP_WEB_SERVER=1 NEXT_PUBLIC_E2E_MODE=1 pnpm --filter @jovie/web exec playwright test tests/e2e/golden-path-app.spec.ts --config=playwright.config.ts --project=chromium --workers=1
- pnpm --filter @jovie/web exec tsc --noEmit