### PR TITLE
fix(drawer): restore child scroll ownership

### DIFF
--- a/apps/web/components/features/admin/admin-users-table/AdminUserDetailDrawer.tsx
+++ b/apps/web/components/features/admin/admin-users-table/AdminUserDetailDrawer.tsx
@@ -132,6 +132,7 @@ export function AdminUserDetailDrawer({
       isOpen={hasUser}
       width={400}
       ariaLabel='User details'
+      scrollStrategy='shell'
       onClose={onClose}
       headerMode='minimal'
       hideMinimalHeaderBar

--- a/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
+++ b/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
@@ -352,6 +352,7 @@ export function AdminFeedbackTable({
         isOpen={Boolean(selected)}
         width={560}
         ariaLabel='Feedback details'
+        scrollStrategy='shell'
         onClose={() => setSelectedId(null)}
         headerMode='minimal'
         hideMinimalHeaderBar

--- a/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberSidebar.tsx
@@ -122,39 +122,36 @@ export function AudienceMemberSidebar({
       emptyMessage='Select a row in the table to view contact details.'
     >
       {member && (
-        <div className='flex min-h-full flex-col gap-2 pt-0.5'>
-          <div className='min-h-0 flex-1'>
-            <DrawerTabbedCard
-              testId='audience-member-tabbed-card'
-              tabs={
-                <DrawerTabs
-                  value={activeTab}
-                  onValueChange={value => setActiveTab(value as AudienceTab)}
-                  options={AUDIENCE_TAB_OPTIONS}
-                  ariaLabel='Audience member tabs'
-                  distribution='intrinsic'
-                />
-              }
-              contentClassName='pt-2'
-            >
-              {activeTab === 'details' && (
-                <div data-testid='audience-details-card'>
-                  <AudienceMemberDetails member={member} />
-                </div>
-              )}
-              {activeTab === 'activity' && (
-                <div data-testid='audience-activity-card'>
-                  <AudienceMemberActivityFeed member={member} />
-                </div>
-              )}
-              {activeTab === 'sources' && (
-                <div data-testid='audience-sources-card'>
-                  <AudienceMemberReferrers member={member} />
-                </div>
-              )}
-            </DrawerTabbedCard>
-          </div>
-        </div>
+        <DrawerTabbedCard
+          testId='audience-member-tabbed-card'
+          className='pt-0.5'
+          tabs={
+            <DrawerTabs
+              value={activeTab}
+              onValueChange={value => setActiveTab(value as AudienceTab)}
+              options={AUDIENCE_TAB_OPTIONS}
+              ariaLabel='Audience member tabs'
+              distribution='intrinsic'
+            />
+          }
+          contentClassName='pt-2'
+        >
+          {activeTab === 'details' && (
+            <div data-testid='audience-details-card'>
+              <AudienceMemberDetails member={member} />
+            </div>
+          )}
+          {activeTab === 'activity' && (
+            <div data-testid='audience-activity-card'>
+              <AudienceMemberActivityFeed member={member} />
+            </div>
+          )}
+          {activeTab === 'sources' && (
+            <div data-testid='audience-sources-card'>
+              <AudienceMemberReferrers member={member} />
+            </div>
+          )}
+        </DrawerTabbedCard>
       )}
     </EntitySidebarShell>
   );

--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceSidebar.tsx
@@ -40,6 +40,7 @@ export function DspPresenceSidebar({ item, onClose }: DspPresenceSidebarProps) {
     <EntitySidebarShell
       isOpen={isOpen}
       ariaLabel={`${label} profile details`}
+      scrollStrategy='shell'
       onClose={onClose}
       headerMode='minimal'
       hideMinimalHeaderBar

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
@@ -648,7 +648,7 @@ export function ProfileContactSidebar() {
         headerMode='minimal'
         hideMinimalHeaderBar
       >
-        <div className='flex min-h-full flex-col gap-2.5 pt-0.5'>
+        <div className='space-y-2.5 pt-0.5'>
           <div className='space-y-2.5 p-3'>
             <div className='grid grid-cols-2 gap-3'>
               <div className='space-y-1'>
@@ -718,101 +718,97 @@ export function ProfileContactSidebar() {
         />
       }
     >
-      <div className='flex min-h-full flex-col'>
-        <div className='min-h-0 flex-1'>
-          <DrawerTabbedCard
-            testId='profile-contact-tabbed-card'
-            className='mt-2.5'
-            tabs={
-              <DrawerTabs
-                value={resolvedCategory}
-                onValueChange={value =>
-                  setSelectedCategory(value as CategoryOption | 'about')
-                }
-                options={tabOptions}
-                ariaLabel='Profile sidebar view'
-                actions={
-                  supportsAddAction ? (
-                    <AppIconButton
-                      type='button'
-                      onClick={() => handleAddLink(resolvedCategory)}
-                      className='h-[26px] w-[26px] rounded-full border-0 bg-transparent text-tertiary-token shadow-none hover:bg-surface-0 hover:text-primary-token'
-                      ariaLabel={`Add ${PROFILE_TAB_OPTIONS_BASE.find(t => t.value === resolvedCategory)?.label ?? ''} link`}
-                    >
-                      <Plus className='h-3.5 w-3.5' />
-                    </AppIconButton>
-                  ) : undefined
-                }
-                actionsClassName='h-[26px] w-[26px]'
-                overflowMode='scroll'
-                distribution='intrinsic'
-              />
+      <DrawerTabbedCard
+        testId='profile-contact-tabbed-card'
+        className='mt-2.5'
+        tabs={
+          <DrawerTabs
+            value={resolvedCategory}
+            onValueChange={value =>
+              setSelectedCategory(value as CategoryOption | 'about')
             }
-            contentClassName='pt-2'
-          >
-            {resolvedCategory === 'about' ? (
-              <ProfileAboutTab
-                bio={bio}
-                genres={genres}
-                location={location}
-                hometown={hometown}
-                activeSinceYear={activeSinceYear}
-                allowPhotoDownloads={allowPhotoDownloads}
-                showOldReleases={showOldReleases}
-                pressPhotos={pressPhotos}
-                onBioChange={handleBioChange}
-                onLocationChange={handleLocationChange}
-                onHometownChange={handleHometownChange}
-                onGenresChange={handleGenresChange}
-                onPressPhotoUpload={handlePressPhotoUpload}
-                onPressPhotoDelete={handlePressPhotoDelete}
-              />
-            ) : (
-              <>
-                {resolvedCategory === 'earnings' && monetizationSummary ? (
-                  <div className='mb-2.5'>
-                    <ProfilePaySurface
-                      summary={monetizationSummary}
-                      variant='drawer'
-                      onSetUsername={handleSetUsername}
-                      onSetUpTips={handleSetUpTips}
-                      onManagePayments={handleManagePayments}
-                      onViewAnalytics={handleViewAnalytics}
-                    />
-                  </div>
-                ) : null}
-                <ProfileLinkList
-                  links={links}
-                  selectedCategory={resolvedCategory as CategoryOption}
-                  onAddLink={handleAddLink}
-                  onRemoveLink={handleRemoveLink}
-                  dspConnections={dspConnections}
-                  profileId={selectedProfile?.id}
-                  surface='plain'
+            options={tabOptions}
+            ariaLabel='Profile sidebar view'
+            actions={
+              supportsAddAction ? (
+                <AppIconButton
+                  type='button'
+                  onClick={() => handleAddLink(resolvedCategory)}
+                  className='h-[26px] w-[26px] rounded-full border-0 bg-transparent text-tertiary-token shadow-none hover:bg-surface-0 hover:text-primary-token'
+                  ariaLabel={`Add ${PROFILE_TAB_OPTIONS_BASE.find(t => t.value === resolvedCategory)?.label ?? ''} link`}
+                >
+                  <Plus className='h-3.5 w-3.5' />
+                </AppIconButton>
+              ) : undefined
+            }
+            actionsClassName='h-[26px] w-[26px]'
+            overflowMode='scroll'
+            distribution='intrinsic'
+          />
+        }
+        contentClassName='pt-2'
+      >
+        {resolvedCategory === 'about' ? (
+          <ProfileAboutTab
+            bio={bio}
+            genres={genres}
+            location={location}
+            hometown={hometown}
+            activeSinceYear={activeSinceYear}
+            allowPhotoDownloads={allowPhotoDownloads}
+            showOldReleases={showOldReleases}
+            pressPhotos={pressPhotos}
+            onBioChange={handleBioChange}
+            onLocationChange={handleLocationChange}
+            onHometownChange={handleHometownChange}
+            onGenresChange={handleGenresChange}
+            onPressPhotoUpload={handlePressPhotoUpload}
+            onPressPhotoDelete={handlePressPhotoDelete}
+          />
+        ) : (
+          <>
+            {resolvedCategory === 'earnings' && monetizationSummary ? (
+              <div className='mb-2.5'>
+                <ProfilePaySurface
+                  summary={monetizationSummary}
+                  variant='drawer'
+                  onSetUsername={handleSetUsername}
+                  onSetUpTips={handleSetUpTips}
+                  onManagePayments={handleManagePayments}
+                  onViewAnalytics={handleViewAnalytics}
                 />
+              </div>
+            ) : null}
+            <ProfileLinkList
+              links={links}
+              selectedCategory={resolvedCategory as CategoryOption}
+              onAddLink={handleAddLink}
+              onRemoveLink={handleRemoveLink}
+              dspConnections={dspConnections}
+              profileId={selectedProfile?.id}
+              surface='plain'
+            />
 
-                {isAddingLink && (
-                  <div className='mt-2.5'>
-                    <SidebarLinkInput
-                      categoryFilter={
-                        resolvedCategory === 'social' ||
-                        resolvedCategory === 'dsp' ||
-                        resolvedCategory === 'earnings'
-                          ? resolvedCategory
-                          : 'social'
-                      }
-                      existingPlatforms={existingPlatformIds}
-                      onAdd={handleSmartAddLink}
-                      onCancel={() => setIsAddingLink(false)}
-                      creatorName={previewData.displayName}
-                    />
-                  </div>
-                )}
-              </>
+            {isAddingLink && (
+              <div className='mt-2.5'>
+                <SidebarLinkInput
+                  categoryFilter={
+                    resolvedCategory === 'social' ||
+                    resolvedCategory === 'dsp' ||
+                    resolvedCategory === 'earnings'
+                      ? resolvedCategory
+                      : 'social'
+                  }
+                  existingPlatforms={existingPlatformIds}
+                  onAdd={handleSmartAddLink}
+                  onCancel={() => setIsAddingLink(false)}
+                  creatorName={previewData.displayName}
+                />
+              </div>
             )}
-          </DrawerTabbedCard>
-        </div>
-      </div>
+          </>
+        )}
+      </DrawerTabbedCard>
     </EntitySidebarShell>
   );
 }

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/AddReleaseSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/AddReleaseSidebar.tsx
@@ -236,6 +236,7 @@ export function AddReleaseSidebar({
       isOpen={isOpen}
       ariaLabel='Add release'
       data-testid='add-release-sidebar'
+      scrollStrategy='shell'
       onClose={handleClose}
       headerMode='minimal'
       hideMinimalHeaderBar

--- a/apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx
@@ -234,6 +234,7 @@ export function TourDateSidebar({
       <EntitySidebarShell
         isOpen={Boolean(tourDate)}
         ariaLabel='Edit tour date'
+        scrollStrategy='shell'
         onClose={onClose}
         headerMode='minimal'
         hideMinimalHeaderBar

--- a/apps/web/components/molecules/drawer/DrawerTabbedCard.tsx
+++ b/apps/web/components/molecules/drawer/DrawerTabbedCard.tsx
@@ -27,7 +27,7 @@ export function DrawerTabbedCard({
     <DrawerSurfaceCard
       variant='card'
       className={cn(
-        'flex h-full min-h-0 flex-col overflow-hidden',
+        'flex min-h-0 flex-1 flex-col overflow-hidden',
         'p-2.5',
         className
       )}
@@ -45,6 +45,8 @@ export function DrawerTabbedCard({
         ) : null}
       </div>
       <div
+        data-scroll-mode='internal'
+        data-testid={testId ? `${testId}-scroll-region` : undefined}
         className={cn(
           'min-h-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain',
           'pb-2 pr-2 pt-2',

--- a/apps/web/components/molecules/drawer/EntitySidebarShell.tsx
+++ b/apps/web/components/molecules/drawer/EntitySidebarShell.tsx
@@ -52,6 +52,8 @@ export interface EntitySidebarShellProps {
 
   /** Main scrollable content */
   readonly children: ReactNode;
+  /** Controls whether scroll is owned by the shell body or a child region. */
+  readonly scrollStrategy?: 'child' | 'shell';
 
   /** Footer slot — pinned to bottom of drawer */
   readonly footer?: ReactNode;
@@ -74,7 +76,8 @@ export interface EntitySidebarShellProps {
  * Standard layout rule: persistent content → tabs → tab content.
  * In minimal mode, the entity header stays pinned above the scrollable region,
  * while callers compose tab controls into the main content card.
- * Only tab-specific children scroll.
+ * Child-owned scroll is the default so tabbed cards can own their own scroll
+ * region. Use shell scroll only for stacked inspector content.
  *
  *  ┌─────────────────────────┐
  *  │ DrawerHeader (title +   │  shrink-0
@@ -106,6 +109,7 @@ export function EntitySidebarShell({
   minimalTabsPlacement = 'card',
   tabsContainerClassName,
   children,
+  scrollStrategy = 'child',
   footer,
   footerSurface = 'card',
   isEmpty = false,
@@ -157,6 +161,15 @@ export function EntitySidebarShell({
         <div className='shrink-0 px-3 py-2.5 lg:mx-0'>{footer}</div>
       );
   }
+  const shellScrollClassName =
+    'flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain lg:px-0 lg:pt-0';
+  const childScrollClassName = 'flex flex-1 min-h-0 flex-col lg:px-0 lg:pt-0';
+  const bodyClassName =
+    scrollStrategy === 'shell' ? shellScrollClassName : childScrollClassName;
+  const bodyChildrenClassName =
+    scrollStrategy === 'shell'
+      ? 'space-y-2.5'
+      : 'flex min-h-0 flex-1 flex-col space-y-2.5';
   return (
     <RightDrawer
       isOpen={isOpen}
@@ -226,15 +239,18 @@ export function EntitySidebarShell({
         ) : null}
 
         {isEmpty ? (
-          <div className='flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain lg:px-0 lg:pt-0'>
+          <div className={bodyClassName} data-scroll-strategy={scrollStrategy}>
             <DrawerSurfaceCard variant='card' className='p-4'>
               <DrawerEmptyState message={emptyMessage} />
             </DrawerSurfaceCard>
           </div>
         ) : (
           <>
-            <div className='flex-1 min-h-0 overflow-y-auto overflow-x-hidden overscroll-contain lg:px-0 lg:pt-0'>
-              <div className='space-y-2.5'>{children}</div>
+            <div
+              className={bodyClassName}
+              data-scroll-strategy={scrollStrategy}
+            >
+              <div className={bodyChildrenClassName}>{children}</div>
             </div>
 
             {footerNode}

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -584,6 +584,7 @@ export function ReleaseSidebar({
       isOpen={isOpen}
       width={width ?? 344}
       ariaLabel='Release details'
+      scrollStrategy='shell'
       onKeyDown={handleKeyDown}
       contextMenuItems={contextMenuItems}
       data-testid='release-sidebar'


### PR DESCRIPTION
## Summary
- move `EntitySidebarShell` to child-owned scrolling by default
- make `DrawerTabbedCard` the canonical internal scroll region
- remove the legacy full-height wrappers from the profile and audience drawers
- explicitly keep stacked non-tabbed drawers on shell-owned scrolling

## Verification
- `pnpm --filter web exec vitest run tests/unit/components/molecules/DrawerTabbedCard.test.tsx tests/unit/components/molecules/EntitySidebarShell.test.tsx tests/components/organisms/RightDrawer.interaction.test.tsx tests/unit/dashboard/drawer-chrome.test.tsx`
- `pnpm --filter web exec tsc --noEmit`
- pre-push hook passed: `biome check .`, `pnpm --filter=@jovie/web run pre-push`

## Follow-up
- analytics drawer normalization and the new regression tests are split into a follow-up branch/PR to stay under the repo's 10-file PR limit
- authenticated Playwright verification is still blocked by the local E2E harness auth/server startup path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved scrolling behavior in admin and dashboard sidebars to ensure proper content display and prevent scrolling conflicts across user detail, feedback, audience member, DSP presence, profile contact, tour dates, and release management panels.

* **Style**
  * Enhanced sidebar layout structure for improved visual consistency and scrolling performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->