### PR TITLE
test(drawer): add scroll regression coverage

### DIFF
--- a/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
@@ -315,36 +315,38 @@ export function AnalyticsSidebarView({
     >
       <div
         className={cn(
-          'space-y-2 transition-opacity duration-150',
+          'flex min-h-0 flex-1 flex-col space-y-2 transition-opacity duration-150',
           isFetching && !loading && 'opacity-70'
         )}
       >
-        {/* Funnel waterfall — vertical bars show dropoff at a glance */}
-        <FunnelCard stages={stages} loading={loading} />
+        <div className='shrink-0 space-y-2'>
+          {/* Funnel waterfall — vertical bars show dropoff at a glance */}
+          <FunnelCard stages={stages} loading={loading} />
 
-        {/* Engagement — compact 2-col, secondary to the funnel */}
-        <DrawerStatGrid variant='card'>
-          <div className='px-3 py-2'>
-            <StatTile
-              label='Link Clicks'
-              value={formatMetricValue(loading, data?.total_clicks)}
-            />
-          </div>
-          <div className='px-3 py-2'>
-            <StatTile
-              label='Listen Clicks'
-              value={formatMetricValue(loading, data?.listen_clicks)}
-            />
-          </div>
-          {showTipLinkVisits ? (
+          {/* Engagement — compact 2-col, secondary to the funnel */}
+          <DrawerStatGrid variant='card'>
             <div className='px-3 py-2'>
               <StatTile
-                label='Tip Link Visits'
-                value={formatMetricValue(loading, data?.tip_link_visits)}
+                label='Link Clicks'
+                value={formatMetricValue(loading, data?.total_clicks)}
               />
             </div>
-          ) : null}
-        </DrawerStatGrid>
+            <div className='px-3 py-2'>
+              <StatTile
+                label='Listen Clicks'
+                value={formatMetricValue(loading, data?.listen_clicks)}
+              />
+            </div>
+            {showTipLinkVisits ? (
+              <div className='px-3 py-2'>
+                <StatTile
+                  label='Tip Link Visits'
+                  value={formatMetricValue(loading, data?.tip_link_visits)}
+                />
+              </div>
+            ) : null}
+          </DrawerStatGrid>
+        </div>
         <DrawerTabbedCard
           testId={tabbedCardTestId}
           tabs={

--- a/apps/web/tests/e2e/drawer-profile-editing.spec.ts
+++ b/apps/web/tests/e2e/drawer-profile-editing.spec.ts
@@ -28,6 +28,8 @@ import {
 const IS_FAST_ITERATION = process.env.E2E_FAST_ITERATION === '1';
 const TEST_PRESS_PHOTO_PNG_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wn8s6sAAAAASUVORK5CYII=';
+const PROFILE_DRAWER_SCROLL_REGION_TEST_ID =
+  'profile-contact-tabbed-card-scroll-region';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Tab rendering
@@ -96,6 +98,118 @@ test.describe('Profile drawer — tab rendering', () => {
       document.body.innerText.toLowerCase()
     );
     expect(body).not.toMatch(/application error|something went wrong/);
+  });
+
+  test('About tab scrolls to lower settings content on desktop', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+
+    await page.goto(APP_ROUTES.DASHBOARD_PROFILE, {
+      waitUntil: 'domcontentloaded',
+      timeout: 90_000,
+    });
+    await waitForHydration(page);
+
+    await page.getByRole('tab', { name: 'About' }).click();
+    await page.waitForTimeout(500);
+
+    const scrollRegion = page.getByTestId(PROFILE_DRAWER_SCROLL_REGION_TEST_ID);
+    const lowerSettingsControl = page
+      .getByText('Show releases older than 90 days')
+      .first();
+
+    await expect(scrollRegion).toBeVisible({ timeout: 30_000 });
+    await expect(lowerSettingsControl).toBeVisible({ timeout: 30_000 });
+
+    const regionMetrics = await scrollRegion.evaluate(element => ({
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+      scrollTop: element.scrollTop,
+    }));
+    expect(regionMetrics.scrollHeight).toBeGreaterThan(
+      regionMetrics.clientHeight
+    );
+
+    const regionBox = await scrollRegion.boundingBox();
+    const beforeBox = await lowerSettingsControl.boundingBox();
+    expect(regionBox).not.toBeNull();
+    expect(beforeBox).not.toBeNull();
+    expect((beforeBox?.y ?? 0) + (beforeBox?.height ?? 0)).toBeGreaterThan(
+      (regionBox?.y ?? 0) + (regionBox?.height ?? 0)
+    );
+
+    await scrollRegion.evaluate(element => {
+      element.scrollTop = element.scrollHeight;
+    });
+    await page.waitForTimeout(250);
+
+    const afterScrollTop = await scrollRegion.evaluate(
+      element => element.scrollTop
+    );
+    expect(afterScrollTop).toBeGreaterThan(regionMetrics.scrollTop);
+
+    const afterBox = await lowerSettingsControl.boundingBox();
+    expect(afterBox).not.toBeNull();
+    expect((afterBox?.y ?? 0) + (afterBox?.height ?? 0)).toBeLessThanOrEqual(
+      (regionBox?.y ?? 0) + (regionBox?.height ?? 0) + 2
+    );
+  });
+
+  test('About tab scrolls to lower settings content on mobile', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    await page.goto(APP_ROUTES.DASHBOARD_PROFILE, {
+      waitUntil: 'domcontentloaded',
+      timeout: 90_000,
+    });
+    await waitForHydration(page);
+
+    await page.getByRole('tab', { name: 'About' }).click();
+    await page.waitForTimeout(500);
+
+    const scrollRegion = page.getByTestId(PROFILE_DRAWER_SCROLL_REGION_TEST_ID);
+    const lowerSettingsControl = page
+      .getByText('Show releases older than 90 days')
+      .first();
+
+    await expect(scrollRegion).toBeVisible({ timeout: 30_000 });
+    await expect(lowerSettingsControl).toBeVisible({ timeout: 30_000 });
+
+    const regionMetrics = await scrollRegion.evaluate(element => ({
+      clientHeight: element.clientHeight,
+      scrollHeight: element.scrollHeight,
+      scrollTop: element.scrollTop,
+    }));
+    expect(regionMetrics.scrollHeight).toBeGreaterThan(
+      regionMetrics.clientHeight
+    );
+
+    const regionBox = await scrollRegion.boundingBox();
+    const beforeBox = await lowerSettingsControl.boundingBox();
+    expect(regionBox).not.toBeNull();
+    expect(beforeBox).not.toBeNull();
+    expect((beforeBox?.y ?? 0) + (beforeBox?.height ?? 0)).toBeGreaterThan(
+      (regionBox?.y ?? 0) + (regionBox?.height ?? 0)
+    );
+
+    await scrollRegion.evaluate(element => {
+      element.scrollTop = element.scrollHeight;
+    });
+    await page.waitForTimeout(250);
+
+    const afterScrollTop = await scrollRegion.evaluate(
+      element => element.scrollTop
+    );
+    expect(afterScrollTop).toBeGreaterThan(regionMetrics.scrollTop);
+
+    const afterBox = await lowerSettingsControl.boundingBox();
+    expect(afterBox).not.toBeNull();
+    expect((afterBox?.y ?? 0) + (afterBox?.height ?? 0)).toBeLessThanOrEqual(
+      (regionBox?.y ?? 0) + (regionBox?.height ?? 0) + 2
+    );
   });
 
   test('About tab uploads and deletes a press photo', async ({ page }) => {

--- a/apps/web/tests/unit/components/molecules/DrawerTabbedCard.test.tsx
+++ b/apps/web/tests/unit/components/molecules/DrawerTabbedCard.test.tsx
@@ -27,9 +27,19 @@ describe('DrawerTabbedCard', () => {
     const card = screen.getByTestId('drawer-tabbed-card');
     const tablist = screen.getByRole('tablist', { name: 'Drawer card tabs' });
     const content = screen.getByText('Details content');
+    const scrollRegion = screen.getByTestId('drawer-tabbed-card-scroll-region');
 
     expect(card).toBeInTheDocument();
     expect(card).toContainElement(tablist);
     expect(card).toContainElement(content);
+    expect(card).toHaveClass('flex-1', 'min-h-0', 'flex', 'flex-col');
+    expect(card).not.toHaveClass('h-full');
+    expect(scrollRegion).toHaveAttribute('data-scroll-mode', 'internal');
+    expect(scrollRegion).toHaveClass(
+      'min-h-0',
+      'flex-1',
+      'overflow-y-auto',
+      'overscroll-contain'
+    );
   });
 });

--- a/apps/web/tests/unit/components/molecules/EntitySidebarShell.test.tsx
+++ b/apps/web/tests/unit/components/molecules/EntitySidebarShell.test.tsx
@@ -142,4 +142,39 @@ describe('EntitySidebarShell', () => {
     expect(footerContainer).not.toHaveAttribute('data-variant', 'card');
     expect(footerContainer).toHaveClass('px-3', 'py-2.5');
   });
+
+  it('defaults to child-owned scrolling for drawer body content', () => {
+    const { container } = render(
+      <EntitySidebarShell isOpen ariaLabel='Child scroll drawer'>
+        <div>Body content</div>
+      </EntitySidebarShell>
+    );
+
+    const body = container.querySelector('[data-scroll-strategy="child"]');
+
+    expect(body).toBeInTheDocument();
+    expect(body).not.toHaveClass('overflow-y-auto');
+    expect(body).toHaveClass('flex', 'flex-1', 'min-h-0', 'flex-col');
+  });
+
+  it('preserves shell-owned scrolling when explicitly requested', () => {
+    const { container } = render(
+      <EntitySidebarShell
+        isOpen
+        ariaLabel='Shell scroll drawer'
+        scrollStrategy='shell'
+      >
+        <div>Body content</div>
+      </EntitySidebarShell>
+    );
+
+    const body = container.querySelector('[data-scroll-strategy="shell"]');
+
+    expect(body).toBeInTheDocument();
+    expect(body).toHaveClass(
+      'overflow-y-auto',
+      'overflow-x-hidden',
+      'overscroll-contain'
+    );
+  });
 });

--- a/apps/web/tests/unit/dashboard/ProfileContactSidebar.scroll.test.tsx
+++ b/apps/web/tests/unit/dashboard/ProfileContactSidebar.scroll.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ProfileContactSidebar } from '@/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar';
+
+const mockState = vi.hoisted(() => ({
+  close: vi.fn(),
+  push: vi.fn(),
+  replace: vi.fn(),
+  setPreviewData: vi.fn(),
+  previewData: {
+    username: 'tim',
+    displayName: 'Tim White',
+    avatarUrl: null,
+    bio: 'Bio',
+    genres: ['pop'],
+    location: 'Los Angeles, CA',
+    hometown: 'New Brunswick, NJ',
+    activeSinceYear: 2019,
+    links: [],
+    profilePath: '/tim',
+    dspConnections: {
+      spotify: {
+        connected: true,
+        artistName: 'Tim White',
+      },
+      appleMusic: {
+        connected: false,
+        artistName: null,
+      },
+    },
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/app/dashboard/profile',
+  useRouter: () => ({
+    push: mockState.push,
+    replace: mockState.replace,
+  }),
+  useSearchParams: () => ({
+    get: () => null,
+    toString: () => '',
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/DashboardDataContext', () => ({
+  useDashboardData: () => ({
+    selectedProfile: {
+      id: 'profile-1',
+      settings: {},
+    },
+  }),
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/PreviewPanelContext', () => ({
+  usePreviewPanelState: () => ({
+    isOpen: true,
+    close: mockState.close,
+  }),
+  usePreviewPanelData: () => ({
+    previewData: mockState.previewData,
+    setPreviewData: mockState.setPreviewData,
+  }),
+}));
+
+vi.mock('@/components/organisms/profile-sidebar/ProfileSidebarHeader', () => ({
+  useProfileHeaderParts: () => ({
+    overflowActions: [],
+  }),
+}));
+
+vi.mock('@/lib/queries', () => ({
+  useDeletePressPhotoMutation: () => ({
+    mutateAsync: vi.fn(),
+  }),
+  useDashboardAnalyticsQuery: () => ({
+    data: {
+      profile_views: 0,
+      total_clicks: 0,
+    },
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+  }),
+  useDspMatchesQuery: () => ({
+    data: [],
+  }),
+  usePressPhotosQuery: () => ({
+    data: [],
+  }),
+  usePressPhotoUploadMutation: () => ({
+    mutateAsync: vi.fn(),
+  }),
+  useProfileMonetizationSummary: () => ({
+    data: null,
+  }),
+  useProfileSaveMutation: () => ({
+    mutate: vi.fn(),
+  }),
+  useRemoveSocialLinkMutation: () => ({
+    mutate: vi.fn(),
+  }),
+}));
+
+describe('ProfileContactSidebar scroll contract', () => {
+  it('uses child-owned scrolling without the legacy full-height wrapper', () => {
+    const { container } = render(<ProfileContactSidebar />);
+
+    const shellBody = container.querySelector('[data-scroll-strategy="child"]');
+    const tabbedCard = screen.getByTestId('profile-contact-tabbed-card');
+    const scrollRegion = screen.getByTestId(
+      'profile-contact-tabbed-card-scroll-region'
+    );
+
+    expect(shellBody).toBeInTheDocument();
+    expect(shellBody).not.toHaveClass('overflow-y-auto');
+    expect(tabbedCard.closest('.min-h-full')).toBeNull();
+    expect(scrollRegion).toHaveAttribute('data-scroll-mode', 'internal');
+    expect(scrollRegion).toHaveClass('overflow-y-auto');
+  });
+});

--- a/apps/web/tests/unit/dashboard/drawer-chrome.test.tsx
+++ b/apps/web/tests/unit/dashboard/drawer-chrome.test.tsx
@@ -60,6 +60,29 @@ describe('dashboard drawer chrome', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('audience member drawer uses the tabbed card as the scroll region', () => {
+    const { container } = render(
+      <AudienceMemberSidebar
+        member={audienceMember}
+        isOpen={true}
+        onClose={() => undefined}
+        contextMenuItems={[]}
+      />
+    );
+
+    const shellBody = container.querySelector('[data-scroll-strategy="child"]');
+    const tabbedCard = screen.getByTestId('audience-member-tabbed-card');
+    const scrollRegion = screen.getByTestId(
+      'audience-member-tabbed-card-scroll-region'
+    );
+
+    expect(shellBody).toBeInTheDocument();
+    expect(shellBody).not.toHaveClass('overflow-y-auto');
+    expect(tabbedCard.closest('.min-h-full')).toBeNull();
+    expect(scrollRegion).toHaveAttribute('data-scroll-mode', 'internal');
+    expect(scrollRegion).toHaveClass('overflow-y-auto');
+  });
+
   it('presence drawer keeps close inside the overflow menu and drops decorative label', () => {
     render(
       <DspPresenceSidebar


### PR DESCRIPTION
## Summary
- normalize the analytics drawers for the child-owned scroll contract
- add unit coverage for `EntitySidebarShell` and `DrawerTabbedCard` scroll ownership
- add structural regression coverage for the profile and audience sidebars
- add desktop and mobile Playwright coverage for the profile drawer scroll path

## Verification
- `pnpm --filter web exec vitest run tests/unit/components/molecules/DrawerTabbedCard.test.tsx tests/unit/components/molecules/EntitySidebarShell.test.tsx tests/unit/dashboard/drawer-chrome.test.tsx tests/unit/dashboard/ProfileContactSidebar.scroll.test.tsx`
- `pnpm --filter web exec tsc --noEmit`
- pre-push hook passed: `biome check .`, `pnpm --filter=@jovie/web run pre-push`

## Notes
- this PR is stacked on #7356 to keep both PRs under the repo's 10-file limit
- the authenticated Playwright command is present but local execution is still blocked by the existing auth/server harness instability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized dashboard sidebar layout structure for improved flex positioning and container constraints.

* **Tests**
  * Added comprehensive test coverage for dashboard sidebar scrolling behavior across desktop and mobile viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->