### PR TITLE
fix(release-sidebar): avoid release credits auth 500s

### DIFF
--- a/apps/web/components/organisms/release-sidebar/release-credits-action.ts
+++ b/apps/web/components/organisms/release-sidebar/release-credits-action.ts
@@ -1,10 +1,10 @@
 'use server';
 
-import { auth } from '@clerk/nextjs/server';
 import { and, eq } from 'drizzle-orm';
 import type { SmartLinkCreditGroup } from '@/app/[username]/[slug]/_lib/data';
 import { groupReleaseCredits } from '@/app/[username]/[slug]/_lib/data';
 import { getDashboardData } from '@/app/app/(shell)/dashboard/actions';
+import { getOptionalAuth } from '@/lib/auth/cached';
 import { db } from '@/lib/db';
 import {
   artists,
@@ -16,7 +16,7 @@ import { creatorProfiles } from '@/lib/db/schema/profiles';
 export async function fetchReleaseCreditsAction(
   releaseId: string
 ): Promise<SmartLinkCreditGroup[]> {
-  const { userId } = await auth();
+  const { userId } = await getOptionalAuth();
   if (!userId) {
     return [];
   }

--- a/apps/web/tests/unit/organisms/release-credits-action.test.ts
+++ b/apps/web/tests/unit/organisms/release-credits-action.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetOptionalAuth, mockGetDashboardData } = vi.hoisted(() => ({
+  mockGetOptionalAuth: vi.fn(),
+  mockGetDashboardData: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/cached', () => ({
+  getOptionalAuth: mockGetOptionalAuth,
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/actions', () => ({
+  getDashboardData: mockGetDashboardData,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {},
+}));
+
+vi.mock('@/lib/db/schema/content', () => ({
+  artists: {},
+  discogReleases: {},
+  releaseArtists: {},
+}));
+
+vi.mock('@/lib/db/schema/profiles', () => ({
+  creatorProfiles: {},
+}));
+
+vi.mock('@/app/[username]/[slug]/_lib/data', () => ({
+  groupReleaseCredits: vi.fn(),
+}));
+
+import { fetchReleaseCreditsAction } from '@/components/organisms/release-sidebar/release-credits-action';
+
+describe('fetchReleaseCreditsAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns no credits when auth is unavailable', async () => {
+    // Regression: ISSUE-001 - release credits fetch threw 500s when Clerk middleware
+    // was unavailable in demo and dashboard QA flows.
+    // Found by /qa on 2026-04-16
+    // Report: .gstack/qa-reports/qa-report-localhost-2026-04-16.md
+    mockGetOptionalAuth.mockResolvedValue({
+      userId: null,
+      sessionId: null,
+      orgId: null,
+    });
+
+    await expect(fetchReleaseCreditsAction('release_123')).resolves.toEqual([]);
+    expect(mockGetDashboardData).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- switch release credits fetching to optional auth so the drawer no longer 500s when Clerk context is unavailable
- add a regression test for the signed-out fallback path

## Stack
- Base branch: \'main\'
- Head branch: \'itstimwhite/release-auth\'
- Next PR in stack: \'itstimwhite/flat-sections\'

## Verification
- pnpm --filter web exec vitest run tests/unit/organisms/release-credits-action.test.ts
- pnpm --filter web exec tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for release credits functionality to improve code quality and reliability.

* **Refactor**
  * Updated internal authentication handling to use an optional authentication method for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->