### PR TITLE
refactor(release-sidebar): add flat section variants

### DIFF
--- a/apps/web/components/organisms/release-sidebar/ReleaseCreditsSection.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseCreditsSection.tsx
@@ -17,9 +17,15 @@ const VALUE_CLASSNAME =
   'text-[12px] font-[460] leading-[16px] text-secondary-token';
 const ROW_CLASSNAME = 'rounded-none px-0 py-1 first:pt-0 last:pb-0';
 
+interface ReleaseCreditsSectionProps {
+  readonly releaseId: string;
+  readonly variant?: 'card' | 'flat';
+}
+
 export function ReleaseCreditsSection({
   releaseId,
-}: Readonly<{ releaseId: string }>) {
+  variant = 'card',
+}: ReleaseCreditsSectionProps) {
   const [credits, setCredits] = useState<CreditGroup[] | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -52,19 +58,30 @@ export function ReleaseCreditsSection({
 
   return (
     <DrawerSurfaceCard
-      className={cn(LINEAR_SURFACE.drawerCardSm, 'overflow-hidden')}
+      variant={variant}
+      className={cn(
+        variant === 'card' && LINEAR_SURFACE.drawerCardSm,
+        'overflow-hidden'
+      )}
       testId='release-credits-card'
     >
-      <div className='p-3'>
-        <p className='mb-2 text-[11px] font-[550] uppercase tracking-[0.06em] text-quaternary-token'>
-          Credits
-        </p>
+      <div
+        className={cn(
+          variant === 'card'
+            ? 'p-3'
+            : 'border-t border-(--linear-app-frame-seam) px-3 pb-3 pt-2.5'
+        )}
+      >
+        {variant === 'card' ? (
+          <p className='mb-2 text-[11px] font-[550] uppercase tracking-[0.06em] text-quaternary-token'>
+            Credits
+          </p>
+        ) : null}
         <div className='space-y-0.5'>
           {visibleCredits.map(group => (
             <DrawerPropertyRow
               key={group.role}
               label={group.label}
-              labelWidth={90}
               size='sm'
               className={ROW_CLASSNAME}
               labelClassName={LABEL_CLASSNAME}

--- a/apps/web/components/organisms/release-sidebar/ReleasePitchSection.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleasePitchSection.tsx
@@ -72,6 +72,7 @@ interface ReleasePitchSectionProps {
   readonly releaseId: string;
   readonly existingPitches?: GeneratedPitches | null;
   readonly onPitchesGenerated?: (pitches: GeneratedPitches) => void;
+  readonly variant?: 'card' | 'flat';
 }
 
 function CopyButton({
@@ -118,6 +119,7 @@ export function ReleasePitchSection({
   releaseId,
   existingPitches,
   onPitchesGenerated,
+  variant = 'card',
 }: ReleasePitchSectionProps) {
   const [pitches, setPitches] = useState<GeneratedPitches | null>(
     existingPitches ?? null
@@ -198,7 +200,12 @@ export function ReleasePitchSection({
 
   return (
     <DrawerSurfaceCard
-      className={cn(LINEAR_SURFACE.drawerCardSm, 'space-y-2.5 p-3')}
+      variant={variant}
+      className={cn(
+        variant === 'card' && LINEAR_SURFACE.drawerCardSm,
+        'space-y-2.5',
+        variant === 'card' && 'p-3'
+      )}
       testId='release-pitch-card'
     >
       <div className='flex items-center justify-between'>

--- a/apps/web/components/organisms/release-sidebar/ReleaseTargetPlaylistsSection.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseTargetPlaylistsSection.tsx
@@ -13,6 +13,7 @@ interface ReleaseTargetPlaylistsSectionProps {
   readonly targetPlaylists?: string[];
   readonly onSave?: (releaseId: string, playlists: string[]) => Promise<void>;
   readonly readOnly?: boolean;
+  readonly variant?: 'card' | 'flat';
 }
 
 function parsePlaylistInput(value: string): string[] {
@@ -31,6 +32,7 @@ export function ReleaseTargetPlaylistsSection({
   targetPlaylists,
   onSave,
   readOnly = false,
+  variant = 'card',
 }: ReleaseTargetPlaylistsSectionProps) {
   const initialValue = joinPlaylists(targetPlaylists);
   const [value, setValue] = useState(initialValue);
@@ -60,7 +62,12 @@ export function ReleaseTargetPlaylistsSection({
 
   return (
     <DrawerSurfaceCard
-      className={cn(LINEAR_SURFACE.drawerCardSm, 'space-y-2.5 p-3')}
+      variant={variant}
+      className={cn(
+        variant === 'card' && LINEAR_SURFACE.drawerCardSm,
+        'space-y-2.5',
+        variant === 'card' && 'p-3'
+      )}
       testId='release-target-playlists-card'
     >
       <div className='flex items-center justify-between'>
@@ -68,7 +75,7 @@ export function ReleaseTargetPlaylistsSection({
           htmlFor={`target-playlists-${releaseId}`}
           className='text-[11px] font-medium text-secondary-token'
         >
-          Target playlists
+          Target Playlists
         </label>
         {isSaving && (
           <Loader2 className='h-3 w-3 animate-spin text-tertiary-token' />


### PR DESCRIPTION
## Summary
- add \'flat\' variants for release credits, playlist targets, and pitch sections
- preserve existing card behavior as the default so current callers remain stable

## Stack
- Depends on: https://github.com/JovieInc/Jovie/pull/7361
- Base branch: \'itstimwhite/release-auth\'
- Head branch: \'itstimwhite/flat-sections\'
- Next PR in stack: \'itstimwhite/release-props\'

## Verification
- pnpm --filter web exec vitest run tests/unit/organisms/ReleasePitchSection.test.tsx
- pnpm --filter web exec tsc --noEmit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable display variants for release information sections, supporting both card-based and flat layout modes to provide flexible, context-aware UI presentation options and enhanced customization.

* **Style**
  * Improved label text capitalization and formatting consistency across release section interfaces for better visual clarity and interface uniformity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->