### PR TITLE
feat(release-sidebar): add properties panel

### DIFF
--- a/apps/web/components/organisms/release-sidebar/ReleasePropertiesPanel.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleasePropertiesPanel.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import { DrawerSection } from '@/components/molecules/drawer';
+import type { CanvasStatus } from '@/lib/services/canvas/types';
+import { ReleaseCreditsSection } from './ReleaseCreditsSection';
+import { ReleaseMetadata } from './ReleaseMetadata';
+import type { Release } from './types';
+
+const PROPERTIES_PANEL_STYLE = {
+  '--drawer-inspector-label-width': '96px',
+} as CSSProperties;
+
+interface ReleasePropertiesPanelProps {
+  readonly release: Release;
+  readonly showCredits?: boolean;
+  readonly isEditable: boolean;
+  readonly onSaveMetadata?: (
+    releaseId: string,
+    values: { upc: string | null; label: string | null }
+  ) => Promise<void>;
+  readonly onSavePrimaryIsrc?: (
+    releaseId: string,
+    isrc: string | null
+  ) => Promise<void>;
+  readonly onCanvasStatusChange?: (status: CanvasStatus) => void;
+}
+
+export function ReleasePropertiesPanel({
+  release,
+  showCredits = true,
+  isEditable,
+  onSaveMetadata,
+  onSavePrimaryIsrc,
+  onCanvasStatusChange,
+}: ReleasePropertiesPanelProps) {
+  return (
+    <DrawerSection
+      title='Properties'
+      surface='card'
+      collapsible={false}
+      testId='release-properties-card'
+      contentClassName='p-0'
+    >
+      <div style={PROPERTIES_PANEL_STYLE}>
+        <ReleaseMetadata
+          release={release}
+          isEditable={isEditable}
+          variant='flat'
+          onSaveMetadata={onSaveMetadata}
+          onSavePrimaryIsrc={onSavePrimaryIsrc}
+          onCanvasStatusChange={onCanvasStatusChange}
+        />
+        {showCredits ? (
+          <ReleaseCreditsSection releaseId={release.id} variant='flat' />
+        ) : null}
+      </div>
+    </DrawerSection>
+  );
+}

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -18,7 +18,6 @@ import {
   useState,
 } from 'react';
 import { toast } from 'sonner';
-import type { SmartLinkCreditGroup as CreditGroup } from '@/app/[username]/[slug]/_lib/data';
 import { updateAllowArtworkDownloads } from '@/app/app/(shell)/dashboard/releases/actions';
 import { Icon } from '@/components/atoms/Icon';
 import { ReleaseTaskChecklist } from '@/components/features/dashboard/release-tasks';
@@ -52,17 +51,15 @@ import { usePlanGate } from '@/lib/queries';
 import type { CanvasStatus } from '@/lib/services/canvas/types';
 import { cn } from '@/lib/utils';
 import { getBaseUrl } from '@/lib/utils/platform-detection';
-import { ReleaseCreditsSection } from './ReleaseCreditsSection';
 import { ReleaseDspLinks } from './ReleaseDspLinks';
 import { ReleaseFields } from './ReleaseFields';
 import { ReleaseLyricsSection } from './ReleaseLyricsSection';
-import { ReleaseMetadata } from './ReleaseMetadata';
 import { ReleasePitchSection } from './ReleasePitchSection';
+import { ReleasePropertiesPanel } from './ReleasePropertiesPanel';
 import { useReleaseHeaderParts } from './ReleaseSidebarHeader';
 import { ReleaseSmartLinkAnalytics } from './ReleaseSmartLinkAnalytics';
 import { ReleaseTargetPlaylistsSection } from './ReleaseTargetPlaylistsSection';
 import { ReleaseTrackList } from './ReleaseTrackList';
-import { fetchReleaseCreditsAction } from './release-credits-action';
 import type { Release, ReleaseSidebarProps } from './types';
 import { useReleaseSidebar } from './useReleaseSidebar';
 import { useTrackAudioPlayer } from './useTrackAudioPlayer';
@@ -267,66 +264,6 @@ function ReleaseArtworkDownloadsSetting({
         density='compact'
       />
     </DrawerFormGridRow>
-  );
-}
-
-function ReleaseCreditsInspectorCard({
-  releaseId,
-}: {
-  readonly releaseId: string;
-}) {
-  const [creditsGroups, setCreditsGroups] = useState<CreditGroup[] | null>(
-    null
-  );
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    let cancelled = false;
-    setCreditsGroups(null);
-    setIsLoading(true);
-
-    fetchReleaseCreditsAction(releaseId)
-      .then(groups => {
-        if (cancelled) return;
-        setCreditsGroups(groups);
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setCreditsGroups(null);
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [releaseId]);
-
-  const hasVisibleCredits =
-    creditsGroups?.some(
-      group => group.role !== 'main_artist' && group.entries.length > 0
-    ) ?? false;
-
-  if (isLoading || !hasVisibleCredits) {
-    return null;
-  }
-
-  return (
-    <DrawerInspectorCard
-      title='Credits'
-      defaultOpen={false}
-      data-testid='release-credits-card-stack'
-    >
-      <ReleaseCreditsSection
-        releaseId={releaseId}
-        variant='flat'
-        creditsGroups={creditsGroups}
-      />
-    </DrawerInspectorCard>
   );
 }
 
@@ -738,10 +675,10 @@ export function ReleaseSidebar({
             contentClassName='pt-2'
           >
             {activeTab === 'details' ? (
-              <ReleaseMetadata
+              <ReleasePropertiesPanel
                 release={release}
+                showCredits={showCredits}
                 isEditable={isEditable}
-                variant='flat'
                 onSaveMetadata={readOnly ? undefined : onSaveMetadata}
                 onSavePrimaryIsrc={readOnly ? undefined : onSavePrimaryIsrc}
                 onCanvasStatusChange={
@@ -777,10 +714,6 @@ export function ReleaseSidebar({
               />
             ) : null}
           </DrawerTabbedCard>
-
-          {showCredits ? (
-            <ReleaseCreditsInspectorCard releaseId={release.id} />
-          ) : null}
 
           {shouldRenderTasks ? (
             <DrawerInspectorCard

--- a/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
@@ -93,9 +93,29 @@ vi.mock('@/components/molecules/drawer', () => ({
   DrawerEmptyState: ({ message }: { message: string }) => (
     <p data-testid='empty-state'>{message}</p>
   ),
-  DrawerSection: ({ children }: { children?: React.ReactNode }) => (
-    <section>{children}</section>
-  ),
+  DrawerSection: ({
+    children,
+    title,
+    testId,
+    defaultOpen = true,
+    collapsible,
+  }: {
+    children?: React.ReactNode;
+    title?: string;
+    testId?: string;
+    defaultOpen?: boolean;
+    collapsible?: boolean;
+  }) => {
+    const isCollapsible = collapsible ?? Boolean(title);
+    const isClosed = isCollapsible && !defaultOpen;
+
+    return (
+      <section data-testid={testId}>
+        {title ? <h3>{title}</h3> : null}
+        {!isClosed ? children : null}
+      </section>
+    );
+  },
   DrawerLinkSection: ({ children }: { children?: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -298,6 +318,14 @@ vi.mock('@/components/organisms/release-sidebar/ReleaseMetadata', () => ({
   ),
 }));
 
+vi.mock('@/components/organisms/release-sidebar/ReleaseCreditsSection', () => ({
+  ReleaseCreditsSection: ({ variant }: { variant?: 'card' | 'flat' }) => (
+    <div data-testid='credits' data-variant={variant ?? 'card'}>
+      Credits
+    </div>
+  ),
+}));
+
 vi.mock('@/app/app/(shell)/dashboard/releases/actions', () => ({
   updateAllowArtworkDownloads: vi.fn().mockResolvedValue(undefined),
 }));
@@ -443,14 +471,18 @@ describe('ReleaseSidebar inspector cards', () => {
     );
   });
 
-  it('renders the release drawer with a tabbed primary card and secondary collapsible cards', () => {
+  it('renders the release drawer with a tabbed primary card and a details properties panel', () => {
     render(<ReleaseSidebar release={mockRelease} {...defaultProps} />);
 
     expect(screen.getByTestId('release-inspector-stack')).toBeInTheDocument();
     expect(screen.getByTestId('release-tabbed-card')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-tabs')).toBeInTheDocument();
-    expect(screen.getByTestId('metadata')).toBeInTheDocument();
+    expect(screen.getByTestId('release-properties-card')).toBeInTheDocument();
     expect(screen.getByTestId('metadata')).toHaveAttribute(
+      'data-variant',
+      'flat'
+    );
+    expect(screen.getByTestId('release-credits')).toHaveAttribute(
       'data-variant',
       'flat'
     );
@@ -462,7 +494,6 @@ describe('ReleaseSidebar inspector cards', () => {
       screen.getByTestId('release-settings-card-stack')
     ).toBeInTheDocument();
     expect(screen.getByTestId('async-toggle')).toBeInTheDocument();
-    expect(screen.getByTestId('lyrics')).toBeInTheDocument();
     expect(screen.getByTestId('lyrics')).toHaveAttribute(
       'data-variant',
       'flat'
@@ -515,6 +546,7 @@ describe('ReleaseSidebar inspector cards', () => {
       'data-surface-variant',
       'card'
     );
+    expect(screen.getByTestId('release-properties-card')).toBeInTheDocument();
     expect(screen.getByTestId('release-inspector-stack')).toBeInTheDocument();
     expect(screen.getByTestId('release-tabbed-card')).toBeInTheDocument();
   });
@@ -527,12 +559,14 @@ describe('ReleaseSidebar inspector cards', () => {
 
     await user.click(screen.getByTestId('drawer-tab-dsps'));
     expect(screen.getByTestId('dsp-links')).toBeInTheDocument();
-    expect(screen.queryByTestId('metadata')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('release-properties-card')
+    ).not.toBeInTheDocument();
 
     const newRelease = { ...mockRelease, id: 'release_2' };
     rerender(<ReleaseSidebar release={newRelease} {...defaultProps} />);
 
-    expect(screen.getByTestId('metadata')).toBeInTheDocument();
+    expect(screen.getByTestId('release-properties-card')).toBeInTheDocument();
     expect(screen.queryByTestId('dsp-links')).not.toBeInTheDocument();
   });
 
@@ -574,6 +608,7 @@ describe('ReleaseSidebar inspector cards', () => {
     expect(screen.getByTestId('release-header-card')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-card-action-bar')).toBeInTheDocument();
     expect(screen.getByTestId('analytics')).toBeInTheDocument();
+    expect(screen.getByTestId('release-properties-card')).toBeInTheDocument();
     expect(screen.getByTestId('release-inspector-stack')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-tabs')).toBeInTheDocument();
     expect(screen.getByTestId('release-tabbed-card')).toBeInTheDocument();
@@ -612,22 +647,9 @@ describe('ReleaseSidebar inspector cards', () => {
     expect(screen.queryByTestId('drawer-tab-tracks')).not.toBeInTheDocument();
   });
 
-  it('renders the Credits card only when credits exist and keeps the inner content flat', async () => {
-    mockFetchReleaseCreditsAction.mockResolvedValue([
-      {
-        role: 'producer',
-        label: 'Producer',
-        entries: [
-          { role: 'producer', artistId: 'artist_1', name: 'A', handle: null },
-        ],
-      },
-    ]);
-
+  it('renders the properties panel with flat metadata and credits content', () => {
     render(<ReleaseSidebar release={mockRelease} {...defaultProps} />);
 
-    expect(
-      await screen.findByTestId('release-credits-card-stack')
-    ).toBeInTheDocument();
     expect(screen.getByTestId('release-credits')).toHaveAttribute(
       'data-variant',
       'flat'


### PR DESCRIPTION
## Summary
- introduce an always-visible Properties card for release metadata and credits
- keep the existing inspector stack below it so this step stays independently mergeable

## Stack
- Depends on: https://github.com/JovieInc/Jovie/pull/7362
- Base branch: \'itstimwhite/flat-sections\'
- Head branch: \'itstimwhite/release-props\'
- Next PR in stack: \'itstimwhite/release-tabs\'

## Verification
- pnpm --filter web exec vitest run tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
- pnpm --filter web exec tsc --noEmit