### PR TITLE
feat(release-sidebar): tab collection sections

### DIFF
--- a/apps/web/tests/e2e/linear-shell-parity.spec.ts
+++ b/apps/web/tests/e2e/linear-shell-parity.spec.ts
@@ -179,9 +179,17 @@ for (const theme of ['light', 'dark'] as const) {
       drawer.getByText(primaryReleaseTitle, { exact: true }).first()
     ).toBeVisible();
     await expect(drawer.getByTestId('release-header-card')).toBeVisible();
-    const metadataCard = drawer.getByTestId('release-metadata-card');
-    await expect(metadataCard).toBeVisible();
-    await expectCardChrome(metadataCard);
+    await expect(drawer.getByTestId('release-tab-panel-card')).toHaveCount(0);
+
+    const tracksTab = drawer.getByTestId('drawer-tab-tracks');
+    const platformsTab = drawer.getByTestId('drawer-tab-links');
+    const propertiesCard = drawer.getByTestId('release-properties-card');
+    await expect(tracksTab).toBeVisible();
+    await expect(platformsTab).toBeVisible();
+    await expectFlatPillChrome(tracksTab);
+    await expectFlatPillChrome(platformsTab);
+    await expect(propertiesCard).toBeVisible();
+    await expectCardChrome(propertiesCard);
 
     const copySmartLinkButton = drawer.getByRole('button', {
       name: 'Copy smart link',

--- a/apps/web/tests/product-screenshots/releases.spec.ts
+++ b/apps/web/tests/product-screenshots/releases.spec.ts
@@ -87,6 +87,7 @@ test.describe('Product Screenshots – Releases Dashboard', () => {
     });
     console.log('📸 Saved: release-sidebar-detail.png');
 
+    await sidebar.getByTestId('drawer-tab-links').click();
     const platformsCard = sidebar.getByTestId('release-platforms-card');
     await expect(platformsCard).toBeVisible({
       timeout: TIMEOUTS.CONTENT_VISIBLE,
@@ -97,9 +98,9 @@ test.describe('Product Screenshots – Releases Dashboard', () => {
     });
     console.log('📸 Saved: release-sidebar-platforms.png');
 
+    await sidebar.getByTestId('drawer-tab-tasks').click();
     const tasksCard = sidebar.getByTestId('release-tasks-card');
     await expect(tasksCard).toBeVisible({ timeout: TIMEOUTS.CONTENT_VISIBLE });
-    await tasksCard.getByRole('button', { name: 'Tasks' }).click();
     await expect(
       tasksCard.locator(
         '[data-testid="release-task-checklist-scroll-region"], [data-testid="release-task-empty-state-compact"]'


### PR DESCRIPTION
## Summary
- convert Tracks, DSPs, and Tasks into a single tabbed collections card
- keep Lyrics and Settings in the existing inspector stack for this incremental step
- update sidebar interaction coverage plus parity and screenshot fixtures for the tab rail

## Stack
- Depends on: https://github.com/JovieInc/Jovie/pull/7363
- Base branch: \'itstimwhite/release-props\'
- Head branch: \'itstimwhite/release-tabs\'
- Next PR in stack: \'itstimwhite/release-extras\'

## Verification
- pnpm --filter web exec vitest run tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx tests/components/organisms/release-sidebar/ReleaseSidebarLinks.interaction.test.tsx
- commit hook: pnpm turbo typecheck --filter=@jovie/web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite to verify updated UI element structure in the Releases Dashboard.
  * Refined sidebar navigation tests to validate revised interaction patterns for tab switching and card visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->