### PR TITLE
feat(release-sidebar): collapse secondary sections

### DIFF
--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -26,8 +26,8 @@ import {
   DrawerCardActionBar,
   DrawerFormGridRow,
   DrawerInspectorCard,
-  DrawerInspectorStack,
   DrawerMediaThumb,
+  DrawerSection,
   DrawerSplitButton,
   DrawerSurfaceCard,
   DrawerTabbedCard,
@@ -656,7 +656,7 @@ export function ReleaseSidebar({
       emptyMessage='Select a release in the table to view its details.'
     >
       {release && (
-        <DrawerInspectorStack data-testid='release-inspector-stack'>
+        <div className='space-y-2.5'>
           <DrawerTabbedCard
             testId='release-tabbed-card'
             tabs={
@@ -754,11 +754,13 @@ export function ReleaseSidebar({
             </DrawerInspectorCard>
           ) : null}
 
-          <DrawerInspectorCard
+          <DrawerSection
             title='Lyrics'
+            surface='card'
             defaultOpen={false}
-            data-testid='release-lyrics-card'
-            gridClassName='space-y-2.5'
+            lazyMount
+            testId='release-lyrics-card'
+            contentClassName='p-0'
           >
             <ReleaseLyricsSection
               releaseId={release.id}
@@ -769,13 +771,15 @@ export function ReleaseSidebar({
               onSaveLyrics={onSaveLyrics}
               onFormatLyrics={onFormatLyrics}
             />
-          </DrawerInspectorCard>
+          </DrawerSection>
 
-          <DrawerInspectorCard
-            title='Settings'
+          <DrawerSection
+            title='Extras'
+            surface='card'
             defaultOpen={false}
-            data-testid='release-settings-card-stack'
-            gridClassName='space-y-2.5'
+            lazyMount
+            testId='release-extras-card'
+            contentClassName='space-y-3 p-3'
           >
             {isEditable ? (
               <ReleaseArtworkDownloadsSetting
@@ -789,15 +793,17 @@ export function ReleaseSidebar({
               targetPlaylists={release.targetPlaylists}
               onSave={readOnly ? undefined : onSaveTargetPlaylists}
               readOnly={readOnly}
+              variant='flat'
             />
             {!readOnly ? (
               <ReleasePitchSection
                 releaseId={release.id}
                 existingPitches={release.generatedPitches}
+                variant='flat'
               />
             ) : null}
-          </DrawerInspectorCard>
-        </DrawerInspectorStack>
+          </DrawerSection>
+        </div>
       )}
     </EntitySidebarShell>
   );

--- a/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
@@ -363,10 +363,30 @@ vi.mock(
 );
 
 vi.mock('@/components/organisms/release-sidebar/ReleasePitchSection', () => ({
-  ReleasePitchSection: () => (
-    <div data-testid='pitch-section'>Pitch Section</div>
+  ReleasePitchSection: ({ variant }: { variant?: 'card' | 'flat' }) => (
+    <div data-testid='pitch-section' data-variant={variant ?? 'card'}>
+      Pitch Section
+    </div>
   ),
 }));
+
+vi.mock(
+  '@/components/organisms/release-sidebar/ReleaseTargetPlaylistsSection',
+  () => ({
+    ReleaseTargetPlaylistsSection: ({
+      variant,
+    }: {
+      variant?: 'card' | 'flat';
+    }) => (
+      <div
+        data-testid='target-playlists-section'
+        data-variant={variant ?? 'card'}
+      >
+        Target Playlists
+      </div>
+    ),
+  })
+);
 
 vi.mock('@/components/features/dashboard/release-tasks', () => ({
   ReleaseTaskChecklist: () => <div data-testid='task-checklist'>Tasks</div>,
@@ -471,10 +491,9 @@ describe('ReleaseSidebar inspector cards', () => {
     );
   });
 
-  it('renders the release drawer with a tabbed primary card and a details properties panel', () => {
+  it('renders the release drawer with collapsed secondary sections', () => {
     render(<ReleaseSidebar release={mockRelease} {...defaultProps} />);
 
-    expect(screen.getByTestId('release-inspector-stack')).toBeInTheDocument();
     expect(screen.getByTestId('release-tabbed-card')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-tabs')).toBeInTheDocument();
     expect(screen.getByTestId('release-properties-card')).toBeInTheDocument();
@@ -490,14 +509,15 @@ describe('ReleaseSidebar inspector cards', () => {
     expect(screen.queryByTestId('tracklist')).not.toBeInTheDocument();
     expect(screen.getByTestId('release-tasks-card')).toBeInTheDocument();
     expect(screen.getByTestId('release-lyrics-card')).toBeInTheDocument();
+    expect(screen.getByTestId('release-extras-card')).toBeInTheDocument();
+    expect(screen.getByText('Lyrics')).toBeInTheDocument();
+    expect(screen.getByText('Extras')).toBeInTheDocument();
+    expect(screen.queryByTestId('lyrics')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('async-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pitch-section')).not.toBeInTheDocument();
     expect(
-      screen.getByTestId('release-settings-card-stack')
-    ).toBeInTheDocument();
-    expect(screen.getByTestId('async-toggle')).toBeInTheDocument();
-    expect(screen.getByTestId('lyrics')).toHaveAttribute(
-      'data-variant',
-      'flat'
-    );
+      screen.queryByTestId('target-playlists-section')
+    ).not.toBeInTheDocument();
     expect(screen.getByTestId('task-checklist')).toBeInTheDocument();
   });
 
@@ -547,8 +567,10 @@ describe('ReleaseSidebar inspector cards', () => {
       'card'
     );
     expect(screen.getByTestId('release-properties-card')).toBeInTheDocument();
-    expect(screen.getByTestId('release-inspector-stack')).toBeInTheDocument();
     expect(screen.getByTestId('release-tabbed-card')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('release-inspector-stack')
+    ).not.toBeInTheDocument();
   });
 
   it('resets the active tab to Details when the release changes', async () => {
@@ -602,16 +624,17 @@ describe('ReleaseSidebar inspector cards', () => {
     expect(screen.getByTestId('analytics')).toBeInTheDocument();
   });
 
-  it('renders the release drawer as stacked header, analytics, tabbed primary content, and secondary cards', () => {
+  it('renders the release drawer as header, analytics, primary tabs, and collapsed secondary sections', () => {
     render(<ReleaseSidebar release={mockRelease} {...defaultProps} />);
 
     expect(screen.getByTestId('release-header-card')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-card-action-bar')).toBeInTheDocument();
     expect(screen.getByTestId('analytics')).toBeInTheDocument();
     expect(screen.getByTestId('release-properties-card')).toBeInTheDocument();
-    expect(screen.getByTestId('release-inspector-stack')).toBeInTheDocument();
     expect(screen.getByTestId('drawer-tabs')).toBeInTheDocument();
     expect(screen.getByTestId('release-tabbed-card')).toBeInTheDocument();
+    expect(screen.getByTestId('release-lyrics-card')).toBeInTheDocument();
+    expect(screen.getByTestId('release-extras-card')).toBeInTheDocument();
     expect(
       screen.queryByTestId('release-credits-card-stack')
     ).not.toBeInTheDocument();

--- a/apps/web/tests/e2e/releases-dashboard.spec.ts
+++ b/apps/web/tests/e2e/releases-dashboard.spec.ts
@@ -364,15 +364,11 @@ test.describe('Releases dashboard', () => {
     });
 
     const sidebar = await openFirstReleaseSidebar(page);
+    await expect(sidebar.getByTestId('release-properties-card')).toBeVisible();
     await expect(sidebar.getByTestId('release-tabbed-card')).toBeVisible();
-    await expect(sidebar.getByTestId('drawer-tab-links')).toBeVisible();
-    await sidebar.getByTestId('drawer-tab-links').click();
+    await expect(sidebar.getByTestId('drawer-tab-dsps')).toBeVisible();
+    await sidebar.getByTestId('drawer-tab-dsps').click();
     await expect(sidebar.getByTitle('Copy smart link')).toBeVisible();
-    await sidebar.getByTestId('drawer-tab-tasks').click();
-    await expect(sidebar.getByTestId('drawer-tab-tasks')).toHaveAttribute(
-      'aria-selected',
-      'true'
-    );
   });
 
   test('smart link URLs contain the correct artist handle @nightly', async ({


### PR DESCRIPTION
## Summary
- replace the old inspector stack wrapper with the final hybrid drawer layout
- move Lyrics and Extras into collapsed card sections and flatten nested chrome
- finish the releases dashboard coverage for the always-on Properties card

## Stack
- Depends on: https://github.com/JovieInc/Jovie/pull/7364
- Base branch: \'itstimwhite/release-tabs\'
- Head branch: \'itstimwhite/release-extras\'
- This is the top PR in the stack

## Verification
- pnpm --filter web exec vitest run tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx tests/components/organisms/release-sidebar/ReleaseSidebarLinks.interaction.test.tsx
- commit hook: pnpm turbo typecheck --filter=@jovie/web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Restructured release sidebar with improved spacing and layout consistency.
  * Renamed Settings card to Extras for improved clarity.

* **Refactor**
  * Optimized section initialization and lazy-loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->