### PR TITLE
fix(tracking): handle empty beacon payloads

### DIFF
--- a/apps/web/app/api/audience/click/route.ts
+++ b/apps/web/app/api/audience/click/route.ts
@@ -147,7 +147,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid JSON' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
     const parsed = clickSchema.safeParse(body);
 
     if (!parsed.success) {

--- a/apps/web/app/api/audience/visit/route.ts
+++ b/apps/web/app/api/audience/visit/route.ts
@@ -239,7 +239,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid JSON' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
     const parsed = visitSchema.safeParse(body);
 
     if (!parsed.success) {

--- a/apps/web/app/api/track/route.ts
+++ b/apps/web/app/api/track/route.ts
@@ -352,7 +352,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const body = await request.json();
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid JSON' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
 
     // Validate request using extracted validation module
     const validationResult = validateTrackRequest(body);

--- a/apps/web/tests/unit/api/audience/click.test.ts
+++ b/apps/web/tests/unit/api/audience/click.test.ts
@@ -173,6 +173,19 @@ describe('POST /api/audience/click', () => {
     expect(data.error).toBe('Rate limit exceeded');
   });
 
+  it('returns 400 when the request body is empty', async () => {
+    const request = new NextRequest('http://localhost/api/audience/click', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Invalid JSON');
+  });
+
   it('returns 400 for invalid payload', async () => {
     const request = new NextRequest('http://localhost/api/audience/click', {
       method: 'POST',

--- a/apps/web/tests/unit/api/audience/visit.test.ts
+++ b/apps/web/tests/unit/api/audience/visit.test.ts
@@ -109,6 +109,20 @@ describe('POST /api/audience/visit', () => {
     expect(data.error).toBe('Rate limit exceeded');
   });
 
+  it('returns 400 when the request body is empty', async () => {
+    const request = new NextRequest('http://localhost/api/audience/visit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Invalid JSON');
+    expect(mockWithSystemIngestionSession).not.toHaveBeenCalled();
+  });
+
   it('silently filters bot traffic', async () => {
     mockDetectBot.mockReturnValue({ isBot: true, reason: 'User-Agent match' });
     mockDbSelect.mockReturnValue({

--- a/apps/web/tests/unit/api/track/route.test.ts
+++ b/apps/web/tests/unit/api/track/route.test.ts
@@ -111,6 +111,21 @@ describe('POST /api/track', () => {
     vi.clearAllMocks();
   });
 
+  it('returns 400 when the request body is empty', async () => {
+    const request = new NextRequest('http://localhost/api/track', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+
+    const response = await POST(request as unknown as NextRequest);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe('Invalid JSON');
+  });
+
   it('logs errors when social link click updates fail', async () => {
     const request = new NextRequest('http://localhost/api/track', {
       method: 'POST',


### PR DESCRIPTION
## Summary
- accept empty or malformed beacon payloads on tracking endpoints
- preserve the public profile visit/click/track paths instead of throwing
- add regression coverage for the beacon handlers

## Verification
- doppler run --project jovie-web --config dev -- pnpm --filter web exec vitest run tests/unit/api/audience/visit.test.ts tests/unit/api/audience/click.test.ts tests/unit/api/track/route.test.ts