### PR TITLE
feat(profile): add playlist page validation helpers

### DIFF
--- a/apps/web/lib/profile/featured-playlist-fallback-web.ts
+++ b/apps/web/lib/profile/featured-playlist-fallback-web.ts
@@ -1,0 +1,172 @@
+import 'server-only';
+
+import { z } from 'zod';
+import { spotifyPlaylistIdSchema } from '@/lib/validation/schemas/spotify';
+
+export const PLAYLIST_SOURCE = 'serp_html';
+
+const featuredPlaylistFallbackCandidateSchema = z.object({
+  playlistId: spotifyPlaylistIdSchema,
+  title: z.string().min(1),
+  url: z.string().url(),
+  imageUrl: z.string().url().nullable(),
+  artistSpotifyId: z.string().min(1),
+  source: z.literal(PLAYLIST_SOURCE),
+  discoveredAt: z.string().datetime(),
+  searchQuery: z.string().min(1),
+});
+
+export type FeaturedPlaylistFallbackCandidate = z.infer<
+  typeof featuredPlaylistFallbackCandidateSchema
+>;
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(
+    /&(#x?[0-9a-fA-F]+|amp|apos|quot|lt|gt);/g,
+    (match, entity: string) => {
+      switch (entity) {
+        case 'amp':
+          return '&';
+        case 'apos':
+          return "'";
+        case 'quot':
+          return '"';
+        case 'lt':
+          return '<';
+        case 'gt':
+          return '>';
+        default:
+          if (entity.startsWith('#x')) {
+            return String.fromCodePoint(Number.parseInt(entity.slice(2), 16));
+          }
+          if (entity.startsWith('#')) {
+            return String.fromCodePoint(Number.parseInt(entity.slice(1), 10));
+          }
+          return match;
+      }
+    }
+  );
+}
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function normalizeTitle(value: string): string {
+  return normalizeWhitespace(decodeHtmlEntities(value)).toLowerCase();
+}
+
+function getMetaContent(
+  html: string,
+  attribute: 'property' | 'name',
+  key: string
+): string | null {
+  const pattern = new RegExp(
+    `<meta[^>]+${attribute}=["']${key}["'][^>]+content=["']([^"']+)["'][^>]*>`,
+    'i'
+  );
+  const match = html.match(pattern);
+  return match ? decodeHtmlEntities(match[1]) : null;
+}
+
+function getHtmlTitle(html: string): string | null {
+  const match = html.match(/<title>([^<]+)<\/title>/i);
+  return match ? decodeHtmlEntities(match[1]) : null;
+}
+
+export function normalizeSpotifyPlaylistUrl(
+  rawUrl: string
+): { playlistId: string; url: string } | null {
+  try {
+    const parsed = new URL(rawUrl);
+    const hostOk =
+      parsed.hostname === 'open.spotify.com' ||
+      parsed.hostname === 'www.open.spotify.com';
+
+    if (!hostOk) {
+      return null;
+    }
+
+    const pathSegments = parsed.pathname.split('/').filter(Boolean);
+    const playlistSegmentIndex = pathSegments[0] === 'embed' ? 1 : 0;
+
+    if (
+      pathSegments[playlistSegmentIndex] !== 'playlist' ||
+      !pathSegments[playlistSegmentIndex + 1]
+    ) {
+      return null;
+    }
+
+    const playlistIdResult = spotifyPlaylistIdSchema.safeParse(
+      pathSegments[playlistSegmentIndex + 1]
+    );
+    if (!playlistIdResult.success) {
+      return null;
+    }
+
+    return {
+      playlistId: playlistIdResult.data,
+      url: `https://open.spotify.com/playlist/${playlistIdResult.data}`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function validateThisIsPlaylistPage(params: {
+  readonly artistName: string;
+  readonly artistSpotifyId: string;
+  readonly html: string;
+  readonly playlistId: string;
+  readonly url: string;
+}): Omit<
+  FeaturedPlaylistFallbackCandidate,
+  'artistSpotifyId' | 'discoveredAt' | 'searchQuery' | 'source'
+> | null {
+  const title = getHtmlTitle(params.html);
+  const canonicalUrl =
+    getMetaContent(params.html, 'property', 'og:url') ??
+    getMetaContent(params.html, 'name', 'og:url');
+  const imageUrl =
+    getMetaContent(params.html, 'property', 'og:image') ??
+    getMetaContent(params.html, 'name', 'og:image');
+  const ownerLooksLikeSpotify =
+    params.html.includes('spotify:user:spotify') ||
+    params.html.includes('"username":"spotify"') ||
+    params.html.includes('"name":"Spotify"');
+
+  if (
+    !title ||
+    normalizeTitle(title) !==
+      normalizeTitle(`This Is ${params.artistName} | Spotify Playlist`)
+  ) {
+    return null;
+  }
+
+  const normalizedCanonical = canonicalUrl
+    ? normalizeSpotifyPlaylistUrl(canonicalUrl)
+    : null;
+  if (
+    !normalizedCanonical ||
+    normalizedCanonical.playlistId !== params.playlistId
+  ) {
+    return null;
+  }
+
+  if (!ownerLooksLikeSpotify) {
+    return null;
+  }
+
+  if (!params.html.includes(`spotify:artist:${params.artistSpotifyId}`)) {
+    return null;
+  }
+
+  return {
+    playlistId: params.playlistId,
+    title: normalizeWhitespace(
+      decodeHtmlEntities(title.replace(/\|\s*Spotify Playlist$/i, ''))
+    ),
+    url: params.url,
+    imageUrl,
+  };
+}

--- a/apps/web/tests/unit/profile/featured-playlist-fallback-web.test.ts
+++ b/apps/web/tests/unit/profile/featured-playlist-fallback-web.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const VALID_HTML = `
+<!doctype html>
+<html>
+  <head>
+    <title>This Is Tim White | Spotify Playlist</title>
+    <meta property="og:url" content="https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu" />
+    <meta property="og:image" content="https://i.scdn.co/image/playlist" />
+  </head>
+  <body>
+    <script>
+      window.__DATA__ = {
+        owner: { uri: "spotify:user:spotify", name: "Spotify" },
+        items: ["spotify:artist:4Uwpa6zW3zzCSQvooQNksm"]
+      };
+    </script>
+  </body>
+</html>
+`;
+
+describe('featured playlist fallback web helpers', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('normalizes canonical and embed Spotify playlist URLs', async () => {
+    const { normalizeSpotifyPlaylistUrl } = await import(
+      '@/lib/profile/featured-playlist-fallback-web'
+    );
+
+    expect(
+      normalizeSpotifyPlaylistUrl(
+        'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu?si=abc'
+      )
+    ).toEqual({
+      playlistId: '37i9dQZF1DZ06evO2SKVTu',
+      url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+    });
+    expect(
+      normalizeSpotifyPlaylistUrl(
+        'https://open.spotify.com/embed/playlist/37i9dQZF1DZ06evO2SKVTu'
+      )
+    ).toEqual({
+      playlistId: '37i9dQZF1DZ06evO2SKVTu',
+      url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+    });
+    expect(
+      normalizeSpotifyPlaylistUrl('https://example.com/playlist/invalid')
+    ).toBeNull();
+  });
+
+  it('validates a Spotify-owned page with an exact title and matching artist URI', async () => {
+    const { validateThisIsPlaylistPage } = await import(
+      '@/lib/profile/featured-playlist-fallback-web'
+    );
+
+    expect(
+      validateThisIsPlaylistPage({
+        artistName: 'Tim White',
+        artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+        html: VALID_HTML,
+        playlistId: '37i9dQZF1DZ06evO2SKVTu',
+        url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+      })
+    ).toEqual({
+      imageUrl: 'https://i.scdn.co/image/playlist',
+      playlistId: '37i9dQZF1DZ06evO2SKVTu',
+      title: 'This Is Tim White',
+      url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+    });
+  });
+
+  it('rejects near-match titles, non-Spotify owners, and missing artist URIs', async () => {
+    const { validateThisIsPlaylistPage } = await import(
+      '@/lib/profile/featured-playlist-fallback-web'
+    );
+
+    expect(
+      validateThisIsPlaylistPage({
+        artistName: 'Tim White',
+        artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+        html: VALID_HTML.replace(
+          'This Is Tim White | Spotify Playlist',
+          'This Is Tim White Radio | Spotify Playlist'
+        ),
+        playlistId: '37i9dQZF1DZ06evO2SKVTu',
+        url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+      })
+    ).toBeNull();
+    expect(
+      validateThisIsPlaylistPage({
+        artistName: 'Tim White',
+        artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+        html: VALID_HTML.replace(
+          'spotify:user:spotify',
+          'spotify:user:notspotify'
+        ),
+        playlistId: '37i9dQZF1DZ06evO2SKVTu',
+        url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+      })
+    ).toBeNull();
+    expect(
+      validateThisIsPlaylistPage({
+        artistName: 'Tim White',
+        artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+        html: VALID_HTML.replace(
+          'spotify:artist:4Uwpa6zW3zzCSQvooQNksm',
+          'spotify:artist:0000000000000000000000'
+        ),
+        playlistId: '37i9dQZF1DZ06evO2SKVTu',
+        url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+      })
+    ).toBeNull();
+  });
+
+});

--- a/apps/web/tests/unit/profile/featured-playlist-fallback-web.test.ts
+++ b/apps/web/tests/unit/profile/featured-playlist-fallback-web.test.ts
@@ -113,5 +113,4 @@ describe('featured playlist fallback web helpers', () => {
       })
     ).toBeNull();
   });
-
 });


### PR DESCRIPTION
## Summary
- add Spotify playlist URL normalization helpers
- add public-page validation for official This Is playlist candidates
- cover the page-validation heuristics with unit tests

## Verification
- doppler run --project jovie-web --config dev -- pnpm --filter web exec vitest run tests/unit/profile/featured-playlist-fallback-web.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added featured playlist validation and discovery from HTML content
  * Implemented Spotify playlist URL normalization and canonical format conversion

* **Tests**
  * Added comprehensive unit test coverage for playlist URL and validation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->