### PR TITLE
feat(profile): add playlist discovery fetcher

### DIFF
--- a/apps/web/lib/profile/featured-playlist-fallback-discovery.ts
+++ b/apps/web/lib/profile/featured-playlist-fallback-discovery.ts
@@ -1,0 +1,116 @@
+import 'server-only';
+
+import { captureWarning } from '@/lib/error-tracking';
+import { searchGoogleCSE } from '@/lib/leads/google-cse';
+import {
+  type FeaturedPlaylistFallbackCandidate,
+  normalizeSpotifyPlaylistUrl,
+  PLAYLIST_SOURCE,
+  validateThisIsPlaylistPage,
+} from '@/lib/profile/featured-playlist-fallback-web';
+
+const SPOTIFY_WEB_TIMEOUT_MS = 8_000;
+const MAX_PAGE_FETCH_ATTEMPTS = 2;
+const PLAYLIST_QUERY_TEMPLATES = [
+  'site:open.spotify.com/playlist "This Is {artistName}"',
+  'site:open.spotify.com/playlist "This Is {artistName}" "Spotify Playlist"',
+] as const;
+
+async function fetchSpotifyPublicPage(url: string): Promise<string | null> {
+  for (let attempt = 1; attempt <= MAX_PAGE_FETCH_ATTEMPTS; attempt += 1) {
+    try {
+      const response = await fetch(url, {
+        headers: {
+          'user-agent':
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+        },
+        cache: 'no-store',
+        signal: AbortSignal.timeout(SPOTIFY_WEB_TIMEOUT_MS),
+      });
+
+      if (response.ok) {
+        return await response.text();
+      }
+
+      if (response.status >= 500 && attempt < MAX_PAGE_FETCH_ATTEMPTS) {
+        continue;
+      }
+
+      await captureWarning(
+        'Spotify playlist page returned non-ok response',
+        null,
+        {
+          route: 'featured-playlist-fallback-discovery',
+          status: response.status,
+          url,
+        }
+      );
+      return null;
+    } catch (error) {
+      if (attempt < MAX_PAGE_FETCH_ATTEMPTS) {
+        continue;
+      }
+
+      await captureWarning('Spotify playlist page fetch failed', error, {
+        route: 'featured-playlist-fallback-discovery',
+        url,
+      });
+      return null;
+    }
+  }
+
+  return null;
+}
+
+export async function discoverThisIsPlaylistCandidate(input: {
+  readonly artistName: string;
+  readonly artistSpotifyId: string;
+}): Promise<FeaturedPlaylistFallbackCandidate | null> {
+  const artistName = input.artistName.trim();
+  const artistSpotifyId = input.artistSpotifyId.trim();
+
+  if (!artistName || !artistSpotifyId) {
+    return null;
+  }
+
+  const seenPlaylistIds = new Set<string>();
+
+  for (const queryTemplate of PLAYLIST_QUERY_TEMPLATES) {
+    const query = queryTemplate.replace('{artistName}', artistName);
+    const searchResults = await searchGoogleCSE(query, 1);
+
+    for (const result of searchResults) {
+      const normalizedUrl = normalizeSpotifyPlaylistUrl(result.link);
+      if (!normalizedUrl || seenPlaylistIds.has(normalizedUrl.playlistId)) {
+        continue;
+      }
+
+      seenPlaylistIds.add(normalizedUrl.playlistId);
+
+      const html = await fetchSpotifyPublicPage(normalizedUrl.url);
+      if (!html) {
+        continue;
+      }
+
+      const validated = validateThisIsPlaylistPage({
+        artistName,
+        artistSpotifyId,
+        html,
+        playlistId: normalizedUrl.playlistId,
+        url: normalizedUrl.url,
+      });
+
+      if (validated) {
+        return {
+          ...validated,
+          artistSpotifyId,
+          discoveredAt: new Date().toISOString(),
+          searchQuery: query,
+          source: PLAYLIST_SOURCE,
+        };
+      }
+    }
+  }
+
+  return null;
+}

--- a/apps/web/tests/unit/profile/featured-playlist-fallback-discovery.test.ts
+++ b/apps/web/tests/unit/profile/featured-playlist-fallback-discovery.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  return {
+    captureWarningMock: vi.fn().mockResolvedValue(undefined),
+    searchGoogleCSEMock: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureWarning: hoisted.captureWarningMock,
+}));
+
+vi.mock('@/lib/leads/google-cse', () => ({
+  searchGoogleCSE: hoisted.searchGoogleCSEMock,
+}));
+
+const VALID_HTML = `
+<!doctype html>
+<html>
+  <head>
+    <title>This Is Tim White | Spotify Playlist</title>
+    <meta property="og:url" content="https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu" />
+    <meta property="og:image" content="https://i.scdn.co/image/playlist" />
+  </head>
+  <body>
+    <script>
+      window.__DATA__ = {
+        owner: { uri: "spotify:user:spotify", name: "Spotify" },
+        items: ["spotify:artist:4Uwpa6zW3zzCSQvooQNksm"]
+      };
+    </script>
+  </body>
+</html>
+`;
+
+describe('featured playlist fallback discovery', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    hoisted.captureWarningMock.mockClear();
+    hoisted.searchGoogleCSEMock.mockReset();
+  });
+
+  it('discovers a candidate from search results and playlist HTML', async () => {
+    hoisted.searchGoogleCSEMock.mockResolvedValue([
+      {
+        link: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+        title: 'This Is Tim White',
+        snippet: '',
+      },
+    ]);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(VALID_HTML, { status: 200 })
+    );
+
+    const { discoverThisIsPlaylistCandidate } = await import(
+      '@/lib/profile/featured-playlist-fallback-discovery'
+    );
+
+    await expect(
+      discoverThisIsPlaylistCandidate({
+        artistName: 'Tim White',
+        artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+      })
+    ).resolves.toMatchObject({
+      artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+      playlistId: '37i9dQZF1DZ06evO2SKVTu',
+      searchQuery: 'site:open.spotify.com/playlist "This Is Tim White"',
+      source: 'serp_html',
+      title: 'This Is Tim White',
+    });
+  });
+
+  it('returns null when page fetch fails', async () => {
+    hoisted.searchGoogleCSEMock.mockResolvedValue([
+      {
+        link: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+        title: 'This Is Tim White',
+        snippet: '',
+      },
+    ]);
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('timeout'));
+
+    const { discoverThisIsPlaylistCandidate } = await import(
+      '@/lib/profile/featured-playlist-fallback-discovery'
+    );
+
+    await expect(
+      discoverThisIsPlaylistCandidate({
+        artistName: 'Tim White',
+        artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+      })
+    ).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add bounded Google CSE discovery for This Is playlist candidates
- fetch and validate public Spotify playlist pages
- cover discovery success and failure cases with unit tests

## Verification
- doppler run --project jovie-web --config dev -- pnpm --filter web exec vitest run tests/unit/profile/featured-playlist-fallback-discovery.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a fallback discovery mechanism for artist profiles that searches and validates Spotify's "This Is" playlists through alternative sources. Enhances playlist discovery when primary sources are unavailable, with automatic validation, deduplication, and enriched candidate information.

* **Tests**
  * Added unit tests for the new playlist discovery feature to ensure reliability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->