### PR TITLE
feat(profile): refresh playlist fallback on onboarding

### DIFF
--- a/apps/web/app/onboarding/actions/connect-spotify.ts
+++ b/apps/web/app/onboarding/actions/connect-spotify.ts
@@ -33,6 +33,7 @@ import {
 import { isE2EFastOnboardingEnabled } from '@/lib/e2e/runtime';
 import { isSecureEnv } from '@/lib/env-server';
 import { captureError } from '@/lib/error-tracking';
+import { refreshFeaturedPlaylistFallbackCandidate } from '@/lib/profile/featured-playlist-fallback';
 import { trackServerEvent } from '@/lib/server-analytics';
 import { runBackgroundSyncOperations } from './sync';
 
@@ -440,6 +441,13 @@ export async function connectOnboardingSpotifyArtist(
         }
       );
     }
+
+    void refreshFeaturedPlaylistFallbackCandidate({
+      profileId: profile.id,
+      usernameNormalized: profile.handle,
+      artistName: params.artistName,
+      artistSpotifyId: params.spotifyArtistId,
+    });
   };
 
   const runSpotifyImport = async (): Promise<SpotifyImportResult> => {

--- a/apps/web/app/onboarding/actions/enrich-profile.ts
+++ b/apps/web/app/onboarding/actions/enrich-profile.ts
@@ -31,6 +31,7 @@ import {
 } from '@/lib/dsp-enrichment/providers/spotify';
 import { captureError } from '@/lib/error-tracking';
 import { normalizeAndMergeExtraction } from '@/lib/ingestion/merge';
+import { refreshFeaturedPlaylistFallbackCandidate } from '@/lib/profile/featured-playlist-fallback';
 import { logger } from '@/lib/utils/logger';
 import { uploadRemoteAvatar } from './avatar';
 
@@ -402,6 +403,13 @@ export async function enrichProfileFromDsp(
       { profileId: profile.id, spotifyArtistId }
     );
   }
+
+  void refreshFeaturedPlaylistFallbackCandidate({
+    profileId: profile.id,
+    usernameNormalized: profile.usernameNormalized,
+    artistName: result.name ?? profile.displayName ?? profile.username,
+    artistSpotifyId: spotifyArtistId,
+  });
 
   return result;
 }

--- a/apps/web/lib/profile/featured-playlist-fallback.ts
+++ b/apps/web/lib/profile/featured-playlist-fallback.ts
@@ -1,0 +1,159 @@
+import 'server-only';
+
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { invalidateProfileCache } from '@/lib/cache/profile';
+import { db } from '@/lib/db';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { captureError } from '@/lib/error-tracking';
+import { discoverThisIsPlaylistCandidate } from '@/lib/profile/featured-playlist-fallback-discovery';
+import {
+  type FeaturedPlaylistFallbackCandidate,
+  PLAYLIST_SOURCE,
+} from '@/lib/profile/featured-playlist-fallback-web';
+
+const featuredPlaylistFallbackCandidateSchema = z.object({
+  playlistId: z.string().min(1),
+  title: z.string().min(1),
+  url: z.string().url(),
+  imageUrl: z.string().url().nullable(),
+  artistSpotifyId: z.string().min(1),
+  source: z.literal(PLAYLIST_SOURCE),
+  discoveredAt: z.string().datetime(),
+  searchQuery: z.string().min(1),
+});
+
+const confirmedFeaturedPlaylistFallbackSchema =
+  featuredPlaylistFallbackCandidateSchema.extend({
+    confirmedAt: z.string().datetime(),
+  });
+
+export type ConfirmedFeaturedPlaylistFallback = z.infer<
+  typeof confirmedFeaturedPlaylistFallbackSchema
+>;
+
+function getDismissedPlaylistId(
+  settings: Record<string, unknown> | null | undefined
+): string | null {
+  const dismissedId = settings?.featuredPlaylistFallbackDismissedId;
+  return typeof dismissedId === 'string' && dismissedId.trim().length > 0
+    ? dismissedId
+    : null;
+}
+
+export function getFeaturedPlaylistFallbackCandidate(
+  settings: Record<string, unknown> | null | undefined
+): FeaturedPlaylistFallbackCandidate | null {
+  const parsed = featuredPlaylistFallbackCandidateSchema.safeParse(
+    settings?.featuredPlaylistFallbackCandidate
+  );
+  return parsed.success ? parsed.data : null;
+}
+
+export function getConfirmedFeaturedPlaylistFallback(
+  settings: Record<string, unknown> | null | undefined
+): ConfirmedFeaturedPlaylistFallback | null {
+  const parsed = confirmedFeaturedPlaylistFallbackSchema.safeParse(
+    settings?.featuredPlaylistFallback
+  );
+  return parsed.success ? parsed.data : null;
+}
+
+export async function refreshFeaturedPlaylistFallbackCandidate(input: {
+  readonly profileId: string;
+  readonly usernameNormalized: string;
+  readonly artistName: string;
+  readonly artistSpotifyId: string;
+}): Promise<void> {
+  if (!input.artistSpotifyId.trim()) {
+    return;
+  }
+
+  const [profile] = await db
+    .select({ settings: creatorProfiles.settings })
+    .from(creatorProfiles)
+    .where(eq(creatorProfiles.id, input.profileId))
+    .limit(1);
+
+  if (!profile) {
+    return;
+  }
+
+  const currentSettings = (profile.settings ?? {}) as Record<string, unknown>;
+  const currentCandidate =
+    getFeaturedPlaylistFallbackCandidate(currentSettings);
+  const currentConfirmed =
+    getConfirmedFeaturedPlaylistFallback(currentSettings);
+  const dismissedPlaylistId = getDismissedPlaylistId(currentSettings);
+
+  const discoveredCandidate = await discoverThisIsPlaylistCandidate({
+    artistName: input.artistName,
+    artistSpotifyId: input.artistSpotifyId,
+  });
+
+  let nextSettings: Record<string, unknown> | null = null;
+
+  if (!discoveredCandidate) {
+    if (currentCandidate?.source === PLAYLIST_SOURCE) {
+      nextSettings = {
+        ...currentSettings,
+        featuredPlaylistFallbackCandidate: null,
+      };
+    }
+  } else if (dismissedPlaylistId === discoveredCandidate.playlistId) {
+    return;
+  } else if (
+    currentConfirmed &&
+    currentConfirmed.playlistId !== discoveredCandidate.playlistId
+  ) {
+    if (currentCandidate) {
+      nextSettings = {
+        ...currentSettings,
+        featuredPlaylistFallbackCandidate: null,
+      };
+    }
+  } else if (
+    currentConfirmed &&
+    currentConfirmed.playlistId === discoveredCandidate.playlistId
+  ) {
+    if (currentCandidate) {
+      nextSettings = {
+        ...currentSettings,
+        featuredPlaylistFallbackCandidate: null,
+      };
+    }
+  } else {
+    nextSettings = {
+      ...currentSettings,
+      featuredPlaylistFallbackCandidate: discoveredCandidate,
+    };
+  }
+
+  if (
+    !nextSettings ||
+    JSON.stringify(nextSettings) === JSON.stringify(currentSettings)
+  ) {
+    return;
+  }
+
+  try {
+    await db
+      .update(creatorProfiles)
+      .set({
+        settings: nextSettings,
+        updatedAt: new Date(),
+      })
+      .where(eq(creatorProfiles.id, input.profileId));
+    await invalidateProfileCache(input.usernameNormalized);
+  } catch (error) {
+    await captureError(
+      'Failed to refresh featured playlist fallback candidate',
+      error,
+      {
+        profileId: input.profileId,
+        route: 'featured-playlist-fallback',
+        usernameNormalized: input.usernameNormalized,
+      }
+    );
+  }
+}

--- a/apps/web/tests/unit/app/onboarding/actions/connect-spotify.test.ts
+++ b/apps/web/tests/unit/app/onboarding/actions/connect-spotify.test.ts
@@ -10,6 +10,9 @@ const hoisted = vi.hoisted(() => {
   const processMusicFetchEnrichmentJobMock = vi
     .fn()
     .mockResolvedValue(undefined);
+  const refreshFeaturedPlaylistFallbackCandidateMock = vi
+    .fn()
+    .mockResolvedValue(undefined);
   const captureErrorMock = vi.fn();
   const getCachedAuthMock = vi.fn().mockResolvedValue({ userId: 'clerk_123' });
   const trackServerEventMock = vi.fn();
@@ -61,6 +64,7 @@ const hoisted = vi.hoisted(() => {
     noStoreMock,
     processDspArtistDiscoveryJobStandaloneMock,
     processMusicFetchEnrichmentJobMock,
+    refreshFeaturedPlaylistFallbackCandidateMock,
     readPendingClaimContextMock,
     revalidatePathMock,
     revalidateTagMock,
@@ -158,6 +162,11 @@ vi.mock('@/lib/db/schema/profiles', () => ({
 
 vi.mock('@/lib/discography/spotify-import', () => ({
   syncReleasesFromSpotify: hoisted.syncReleasesFromSpotifyMock,
+}));
+
+vi.mock('@/lib/profile/featured-playlist-fallback', () => ({
+  refreshFeaturedPlaylistFallbackCandidate:
+    hoisted.refreshFeaturedPlaylistFallbackCandidateMock,
 }));
 
 vi.mock('@/lib/dsp-enrichment/jobs', () => ({
@@ -258,6 +267,14 @@ describe('connectOnboardingSpotifyArtist', () => {
       hoisted.processDspArtistDiscoveryJobStandaloneMock
     ).toHaveBeenCalledOnce();
     expect(hoisted.processMusicFetchEnrichmentJobMock).toHaveBeenCalledOnce();
+    expect(
+      hoisted.refreshFeaturedPlaylistFallbackCandidateMock
+    ).toHaveBeenCalledWith({
+      artistName: 'Artist Name',
+      artistSpotifyId: 'artist_spotify_id',
+      profileId: 'profile_123',
+      usernameNormalized: 'artist',
+    });
     expect(hoisted.updateSetArgs[1]).toMatchObject({
       settings: expect.objectContaining({
         spotifyArtistName: 'Artist Name',

--- a/apps/web/tests/unit/profile/featured-playlist-fallback.test.ts
+++ b/apps/web/tests/unit/profile/featured-playlist-fallback.test.ts
@@ -56,8 +56,7 @@ vi.mock('@/lib/db/schema/profiles', () => ({
 }));
 
 vi.mock('@/lib/profile/featured-playlist-fallback-discovery', () => ({
-  discoverThisIsPlaylistCandidate:
-    hoisted.discoverThisIsPlaylistCandidateMock,
+  discoverThisIsPlaylistCandidate: hoisted.discoverThisIsPlaylistCandidateMock,
 }));
 
 describe('featured playlist fallback settings helpers', () => {

--- a/apps/web/tests/unit/profile/featured-playlist-fallback.test.ts
+++ b/apps/web/tests/unit/profile/featured-playlist-fallback.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  const invalidateProfileCacheMock = vi.fn().mockResolvedValue(undefined);
+  const captureErrorMock = vi.fn().mockResolvedValue(undefined);
+  const selectResults: unknown[][] = [];
+  const updateSetArgs: Array<Record<string, unknown>> = [];
+  const discoverThisIsPlaylistCandidateMock = vi.fn();
+
+  const selectMock = vi.fn(() => {
+    const result = selectResults.shift() ?? [];
+    const limitMock = vi.fn().mockResolvedValue(result);
+    const whereMock = vi.fn(() => ({ limit: limitMock }));
+    return { from: vi.fn(() => ({ where: whereMock })) };
+  });
+
+  const updateMock = vi.fn(() => ({
+    set: vi.fn((args: Record<string, unknown>) => {
+      updateSetArgs.push(args);
+      return { where: vi.fn().mockResolvedValue(undefined) };
+    }),
+  }));
+
+  return {
+    captureErrorMock,
+    discoverThisIsPlaylistCandidateMock,
+    invalidateProfileCacheMock,
+    selectMock,
+    selectResults,
+    updateMock,
+    updateSetArgs,
+  };
+});
+
+vi.mock('@/lib/cache/profile', () => ({
+  invalidateProfileCache: hoisted.invalidateProfileCacheMock,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: hoisted.captureErrorMock,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: hoisted.selectMock,
+    update: hoisted.updateMock,
+  },
+}));
+
+vi.mock('@/lib/db/schema/profiles', () => ({
+  creatorProfiles: {
+    id: 'id',
+    settings: 'settings',
+    updatedAt: 'updatedAt',
+  },
+}));
+
+vi.mock('@/lib/profile/featured-playlist-fallback-discovery', () => ({
+  discoverThisIsPlaylistCandidate:
+    hoisted.discoverThisIsPlaylistCandidateMock,
+}));
+
+describe('featured playlist fallback settings helpers', () => {
+  beforeEach(() => {
+    hoisted.selectResults.length = 0;
+    hoisted.updateSetArgs.length = 0;
+    hoisted.discoverThisIsPlaylistCandidateMock.mockReset();
+    hoisted.invalidateProfileCacheMock.mockClear();
+  });
+
+  it('writes a pending candidate and invalidates the public profile cache', async () => {
+    hoisted.selectResults.push([{ settings: {} }]);
+    hoisted.discoverThisIsPlaylistCandidateMock.mockResolvedValue({
+      artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+      discoveredAt: '2026-01-01T00:00:00.000Z',
+      imageUrl: null,
+      playlistId: '37i9dQZF1DZ06evO2SKVTu',
+      searchQuery: 'site:open.spotify.com/playlist "This Is Tim White"',
+      source: 'serp_html',
+      title: 'This Is Tim White',
+      url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+    });
+
+    const { refreshFeaturedPlaylistFallbackCandidate } = await import(
+      '@/lib/profile/featured-playlist-fallback'
+    );
+
+    await refreshFeaturedPlaylistFallbackCandidate({
+      artistName: 'Tim White',
+      artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+      profileId: 'profile-1',
+      usernameNormalized: 'timwhite',
+    });
+
+    expect(hoisted.updateSetArgs[0].settings).toEqual(
+      expect.objectContaining({
+        featuredPlaylistFallbackCandidate: expect.objectContaining({
+          playlistId: '37i9dQZF1DZ06evO2SKVTu',
+        }),
+      })
+    );
+    expect(hoisted.invalidateProfileCacheMock).toHaveBeenCalledWith('timwhite');
+  });
+
+  it('does not re-add a dismissed playlist candidate', async () => {
+    hoisted.selectResults.push([
+      {
+        settings: {
+          featuredPlaylistFallbackDismissedId: '37i9dQZF1DZ06evO2SKVTu',
+        },
+      },
+    ]);
+    hoisted.discoverThisIsPlaylistCandidateMock.mockResolvedValue({
+      artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+      discoveredAt: '2026-01-01T00:00:00.000Z',
+      imageUrl: null,
+      playlistId: '37i9dQZF1DZ06evO2SKVTu',
+      searchQuery: 'site:open.spotify.com/playlist "This Is Tim White"',
+      source: 'serp_html',
+      title: 'This Is Tim White',
+      url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+    });
+
+    const { refreshFeaturedPlaylistFallbackCandidate } = await import(
+      '@/lib/profile/featured-playlist-fallback'
+    );
+
+    await refreshFeaturedPlaylistFallbackCandidate({
+      artistName: 'Tim White',
+      artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+      profileId: 'profile-1',
+      usernameNormalized: 'timwhite',
+    });
+
+    expect(hoisted.updateSetArgs).toHaveLength(0);
+  });
+
+  it('reads a confirmed fallback defensively from settings', async () => {
+    const { getConfirmedFeaturedPlaylistFallback } = await import(
+      '@/lib/profile/featured-playlist-fallback'
+    );
+
+    expect(
+      getConfirmedFeaturedPlaylistFallback({
+        featuredPlaylistFallback: {
+          artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+          confirmedAt: '2026-01-01T00:00:00.000Z',
+          discoveredAt: '2026-01-01T00:00:00.000Z',
+          imageUrl: null,
+          playlistId: '37i9dQZF1DZ06evO2SKVTu',
+          searchQuery: 'site:open.spotify.com/playlist "This Is Tim White"',
+          source: 'serp_html',
+          title: 'This Is Tim White',
+          url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+        },
+      })
+    ).toMatchObject({
+      playlistId: '37i9dQZF1DZ06evO2SKVTu',
+      title: 'This Is Tim White',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- store pending and confirmed playlist fallback state in profile settings
- refresh discovery after Spotify connect and enrichment flows
- add formatting cleanup for playlist fallback tests

## Verification
- doppler run --project jovie-web --config dev -- pnpm --filter web exec vitest run tests/unit/profile/featured-playlist-fallback.test.ts tests/unit/app/onboarding/actions/connect-spotify.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Featured playlist fallback system now automatically discovers and stores recommended fallback playlists based on artist information when connecting Spotify accounts during onboarding and profile enrichment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->