### PR TITLE
feat(profile): add playlist fallback suggestions

### DIFF
--- a/apps/web/app/api/suggestions/playlist-fallback/[id]/approve/route.ts
+++ b/apps/web/app/api/suggestions/playlist-fallback/[id]/approve/route.ts
@@ -1,74 +1,24 @@
 import { eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
-import { z } from 'zod';
-import { getCachedAuth } from '@/lib/auth/cached';
 import { invalidateProfileCache } from '@/lib/cache/profile';
 import { db } from '@/lib/db';
-import { users } from '@/lib/db/schema/auth';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { captureError } from '@/lib/error-tracking';
-import { getFeaturedPlaylistFallbackCandidate } from '@/lib/profile/featured-playlist-fallback';
-
-const requestSchema = z.object({
-  profileId: z.string().uuid(),
-});
+import { getPlaylistFallbackRequestContext } from '../../_shared';
 
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { id: playlistId } = await params;
-    const { userId } = await getCachedAuth();
+    const context = await getPlaylistFallbackRequestContext(request, params);
 
-    if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    if (context instanceof NextResponse) {
+      return context;
     }
 
-    const body = await request.json();
-    const parsed = requestSchema.safeParse(body);
-
-    if (!parsed.success) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: 'Invalid request',
-          details: parsed.error.flatten(),
-        },
-        { status: 400 }
-      );
-    }
-
-    const { profileId } = parsed.data;
-
-    const [profile] = await db
-      .select({
-        id: creatorProfiles.id,
-        clerkId: users.clerkId,
-        settings: creatorProfiles.settings,
-        usernameNormalized: creatorProfiles.usernameNormalized,
-      })
-      .from(creatorProfiles)
-      .innerJoin(users, eq(users.id, creatorProfiles.userId))
-      .where(eq(creatorProfiles.id, profileId))
-      .limit(1);
-
-    if (!profile || profile.clerkId !== userId) {
-      return NextResponse.json(
-        { success: false, error: 'Forbidden' },
-        { status: 403 }
-      );
-    }
-
-    const settings = (profile.settings ?? {}) as Record<string, unknown>;
-    const candidate = getFeaturedPlaylistFallbackCandidate(settings);
-
-    if (!candidate || candidate.playlistId !== playlistId) {
-      return NextResponse.json(
-        { success: false, error: 'Playlist suggestion not found' },
-        { status: 404 }
-      );
-    }
+    const { candidate, playlistId, profileId, settings, usernameNormalized } =
+      context;
 
     const nextSettings = {
       ...settings,
@@ -91,7 +41,7 @@ export async function POST(
       })
       .where(eq(creatorProfiles.id, profileId));
 
-    await invalidateProfileCache(profile.usernameNormalized);
+    await invalidateProfileCache(usernameNormalized);
 
     return NextResponse.json({
       success: true,

--- a/apps/web/app/api/suggestions/playlist-fallback/[id]/approve/route.ts
+++ b/apps/web/app/api/suggestions/playlist-fallback/[id]/approve/route.ts
@@ -1,26 +1,16 @@
-import { eq } from 'drizzle-orm';
-import { NextResponse } from 'next/server';
-import { invalidateProfileCache } from '@/lib/cache/profile';
-import { db } from '@/lib/db';
-import { creatorProfiles } from '@/lib/db/schema/profiles';
-import { captureError } from '@/lib/error-tracking';
-import { getPlaylistFallbackRequestContext } from '../../_shared';
+import { handlePlaylistFallbackMutation } from '../../_shared';
 
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  try {
-    const context = await getPlaylistFallbackRequestContext(request, params);
-
-    if (context instanceof NextResponse) {
-      return context;
-    }
-
-    const { candidate, playlistId, profileId, settings, usernameNormalized } =
-      context;
-
-    const nextSettings = {
+  return handlePlaylistFallbackMutation({
+    request,
+    params,
+    route: '/api/suggestions/playlist-fallback/[id]/approve',
+    errorMessage: 'Playlist fallback approval failed',
+    successMessage: 'Playlist fallback confirmed',
+    buildSettings: ({ candidate, playlistId, settings }) => ({
       ...settings,
       featuredPlaylistFallback: {
         ...candidate,
@@ -31,34 +21,6 @@ export async function POST(
         settings.featuredPlaylistFallbackDismissedId === playlistId
           ? null
           : settings.featuredPlaylistFallbackDismissedId,
-    };
-
-    await db
-      .update(creatorProfiles)
-      .set({
-        settings: nextSettings,
-        updatedAt: new Date(),
-      })
-      .where(eq(creatorProfiles.id, profileId));
-
-    await invalidateProfileCache(usernameNormalized);
-
-    return NextResponse.json({
-      success: true,
-      playlistId,
-      message: 'Playlist fallback confirmed',
-    });
-  } catch (error) {
-    await captureError('Playlist fallback approval failed', error, {
-      route: '/api/suggestions/playlist-fallback/[id]/approve',
-    });
-
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : 'Internal server error',
-      },
-      { status: 500 }
-    );
-  }
+    }),
+  });
 }

--- a/apps/web/app/api/suggestions/playlist-fallback/[id]/approve/route.ts
+++ b/apps/web/app/api/suggestions/playlist-fallback/[id]/approve/route.ts
@@ -1,0 +1,114 @@
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { invalidateProfileCache } from '@/lib/cache/profile';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema/auth';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { captureError } from '@/lib/error-tracking';
+import { getFeaturedPlaylistFallbackCandidate } from '@/lib/profile/featured-playlist-fallback';
+
+const requestSchema = z.object({
+  profileId: z.string().uuid(),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: playlistId } = await params;
+    const { userId } = await getCachedAuth();
+
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const parsed = requestSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Invalid request',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 }
+      );
+    }
+
+    const { profileId } = parsed.data;
+
+    const [profile] = await db
+      .select({
+        id: creatorProfiles.id,
+        clerkId: users.clerkId,
+        settings: creatorProfiles.settings,
+        usernameNormalized: creatorProfiles.usernameNormalized,
+      })
+      .from(creatorProfiles)
+      .innerJoin(users, eq(users.id, creatorProfiles.userId))
+      .where(eq(creatorProfiles.id, profileId))
+      .limit(1);
+
+    if (!profile || profile.clerkId !== userId) {
+      return NextResponse.json(
+        { success: false, error: 'Forbidden' },
+        { status: 403 }
+      );
+    }
+
+    const settings = (profile.settings ?? {}) as Record<string, unknown>;
+    const candidate = getFeaturedPlaylistFallbackCandidate(settings);
+
+    if (!candidate || candidate.playlistId !== playlistId) {
+      return NextResponse.json(
+        { success: false, error: 'Playlist suggestion not found' },
+        { status: 404 }
+      );
+    }
+
+    const nextSettings = {
+      ...settings,
+      featuredPlaylistFallback: {
+        ...candidate,
+        confirmedAt: new Date().toISOString(),
+      },
+      featuredPlaylistFallbackCandidate: null,
+      featuredPlaylistFallbackDismissedId:
+        settings.featuredPlaylistFallbackDismissedId === playlistId
+          ? null
+          : settings.featuredPlaylistFallbackDismissedId,
+    };
+
+    await db
+      .update(creatorProfiles)
+      .set({
+        settings: nextSettings,
+        updatedAt: new Date(),
+      })
+      .where(eq(creatorProfiles.id, profileId));
+
+    await invalidateProfileCache(profile.usernameNormalized);
+
+    return NextResponse.json({
+      success: true,
+      playlistId,
+      message: 'Playlist fallback confirmed',
+    });
+  } catch (error) {
+    await captureError('Playlist fallback approval failed', error, {
+      route: '/api/suggestions/playlist-fallback/[id]/approve',
+    });
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/api/suggestions/playlist-fallback/[id]/reject/route.ts
+++ b/apps/web/app/api/suggestions/playlist-fallback/[id]/reject/route.ts
@@ -1,0 +1,105 @@
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { invalidateProfileCache } from '@/lib/cache/profile';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema/auth';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { captureError } from '@/lib/error-tracking';
+import { getFeaturedPlaylistFallbackCandidate } from '@/lib/profile/featured-playlist-fallback';
+
+const requestSchema = z.object({
+  profileId: z.string().uuid(),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: playlistId } = await params;
+    const { userId } = await getCachedAuth();
+
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const parsed = requestSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Invalid request',
+          details: parsed.error.flatten(),
+        },
+        { status: 400 }
+      );
+    }
+
+    const { profileId } = parsed.data;
+
+    const [profile] = await db
+      .select({
+        id: creatorProfiles.id,
+        clerkId: users.clerkId,
+        settings: creatorProfiles.settings,
+        usernameNormalized: creatorProfiles.usernameNormalized,
+      })
+      .from(creatorProfiles)
+      .innerJoin(users, eq(users.id, creatorProfiles.userId))
+      .where(eq(creatorProfiles.id, profileId))
+      .limit(1);
+
+    if (!profile || profile.clerkId !== userId) {
+      return NextResponse.json(
+        { success: false, error: 'Forbidden' },
+        { status: 403 }
+      );
+    }
+
+    const settings = (profile.settings ?? {}) as Record<string, unknown>;
+    const candidate = getFeaturedPlaylistFallbackCandidate(settings);
+
+    if (!candidate || candidate.playlistId !== playlistId) {
+      return NextResponse.json(
+        { success: false, error: 'Playlist suggestion not found' },
+        { status: 404 }
+      );
+    }
+
+    await db
+      .update(creatorProfiles)
+      .set({
+        settings: {
+          ...settings,
+          featuredPlaylistFallbackCandidate: null,
+          featuredPlaylistFallbackDismissedId: playlistId,
+        },
+        updatedAt: new Date(),
+      })
+      .where(eq(creatorProfiles.id, profileId));
+
+    await invalidateProfileCache(profile.usernameNormalized);
+
+    return NextResponse.json({
+      success: true,
+      playlistId,
+      message: 'Playlist suggestion dismissed',
+    });
+  } catch (error) {
+    await captureError('Playlist fallback rejection failed', error, {
+      route: '/api/suggestions/playlist-fallback/[id]/reject',
+    });
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/api/suggestions/playlist-fallback/[id]/reject/route.ts
+++ b/apps/web/app/api/suggestions/playlist-fallback/[id]/reject/route.ts
@@ -1,54 +1,19 @@
-import { eq } from 'drizzle-orm';
-import { NextResponse } from 'next/server';
-import { invalidateProfileCache } from '@/lib/cache/profile';
-import { db } from '@/lib/db';
-import { creatorProfiles } from '@/lib/db/schema/profiles';
-import { captureError } from '@/lib/error-tracking';
-import { getPlaylistFallbackRequestContext } from '../../_shared';
+import { handlePlaylistFallbackMutation } from '../../_shared';
 
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  try {
-    const context = await getPlaylistFallbackRequestContext(request, params);
-
-    if (context instanceof NextResponse) {
-      return context;
-    }
-
-    const { playlistId, profileId, settings, usernameNormalized } = context;
-
-    await db
-      .update(creatorProfiles)
-      .set({
-        settings: {
-          ...settings,
-          featuredPlaylistFallbackCandidate: null,
-          featuredPlaylistFallbackDismissedId: playlistId,
-        },
-        updatedAt: new Date(),
-      })
-      .where(eq(creatorProfiles.id, profileId));
-
-    await invalidateProfileCache(usernameNormalized);
-
-    return NextResponse.json({
-      success: true,
-      playlistId,
-      message: 'Playlist suggestion dismissed',
-    });
-  } catch (error) {
-    await captureError('Playlist fallback rejection failed', error, {
-      route: '/api/suggestions/playlist-fallback/[id]/reject',
-    });
-
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : 'Internal server error',
-      },
-      { status: 500 }
-    );
-  }
+  return handlePlaylistFallbackMutation({
+    request,
+    params,
+    route: '/api/suggestions/playlist-fallback/[id]/reject',
+    errorMessage: 'Playlist fallback rejection failed',
+    successMessage: 'Playlist suggestion dismissed',
+    buildSettings: ({ playlistId, settings }) => ({
+      ...settings,
+      featuredPlaylistFallbackCandidate: null,
+      featuredPlaylistFallbackDismissedId: playlistId,
+    }),
+  });
 }

--- a/apps/web/app/api/suggestions/playlist-fallback/[id]/reject/route.ts
+++ b/apps/web/app/api/suggestions/playlist-fallback/[id]/reject/route.ts
@@ -1,74 +1,23 @@
 import { eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
-import { z } from 'zod';
-import { getCachedAuth } from '@/lib/auth/cached';
 import { invalidateProfileCache } from '@/lib/cache/profile';
 import { db } from '@/lib/db';
-import { users } from '@/lib/db/schema/auth';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { captureError } from '@/lib/error-tracking';
-import { getFeaturedPlaylistFallbackCandidate } from '@/lib/profile/featured-playlist-fallback';
-
-const requestSchema = z.object({
-  profileId: z.string().uuid(),
-});
+import { getPlaylistFallbackRequestContext } from '../../_shared';
 
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const { id: playlistId } = await params;
-    const { userId } = await getCachedAuth();
+    const context = await getPlaylistFallbackRequestContext(request, params);
 
-    if (!userId) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    if (context instanceof NextResponse) {
+      return context;
     }
 
-    const body = await request.json();
-    const parsed = requestSchema.safeParse(body);
-
-    if (!parsed.success) {
-      return NextResponse.json(
-        {
-          success: false,
-          error: 'Invalid request',
-          details: parsed.error.flatten(),
-        },
-        { status: 400 }
-      );
-    }
-
-    const { profileId } = parsed.data;
-
-    const [profile] = await db
-      .select({
-        id: creatorProfiles.id,
-        clerkId: users.clerkId,
-        settings: creatorProfiles.settings,
-        usernameNormalized: creatorProfiles.usernameNormalized,
-      })
-      .from(creatorProfiles)
-      .innerJoin(users, eq(users.id, creatorProfiles.userId))
-      .where(eq(creatorProfiles.id, profileId))
-      .limit(1);
-
-    if (!profile || profile.clerkId !== userId) {
-      return NextResponse.json(
-        { success: false, error: 'Forbidden' },
-        { status: 403 }
-      );
-    }
-
-    const settings = (profile.settings ?? {}) as Record<string, unknown>;
-    const candidate = getFeaturedPlaylistFallbackCandidate(settings);
-
-    if (!candidate || candidate.playlistId !== playlistId) {
-      return NextResponse.json(
-        { success: false, error: 'Playlist suggestion not found' },
-        { status: 404 }
-      );
-    }
+    const { playlistId, profileId, settings, usernameNormalized } = context;
 
     await db
       .update(creatorProfiles)
@@ -82,7 +31,7 @@ export async function POST(
       })
       .where(eq(creatorProfiles.id, profileId));
 
-    await invalidateProfileCache(profile.usernameNormalized);
+    await invalidateProfileCache(usernameNormalized);
 
     return NextResponse.json({
       success: true,

--- a/apps/web/app/api/suggestions/playlist-fallback/_shared.ts
+++ b/apps/web/app/api/suggestions/playlist-fallback/_shared.ts
@@ -1,0 +1,85 @@
+import { eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema/auth';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { getFeaturedPlaylistFallbackCandidate } from '@/lib/profile/featured-playlist-fallback';
+
+const requestSchema = z.object({
+  profileId: z.string().uuid(),
+});
+
+interface PlaylistFallbackRequestContext {
+  readonly playlistId: string;
+  readonly profileId: string;
+  readonly settings: Record<string, unknown>;
+  readonly candidate: ReturnType<typeof getFeaturedPlaylistFallbackCandidate>;
+  readonly usernameNormalized: string;
+}
+
+export async function getPlaylistFallbackRequestContext(
+  request: Request,
+  params: Promise<{ id: string }>
+): Promise<PlaylistFallbackRequestContext | NextResponse> {
+  const { id: playlistId } = await params;
+  const { userId } = await getCachedAuth();
+
+  if (!userId) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const parsed = requestSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Invalid request',
+        details: parsed.error.flatten(),
+      },
+      { status: 400 }
+    );
+  }
+
+  const { profileId } = parsed.data;
+
+  const [profile] = await db
+    .select({
+      id: creatorProfiles.id,
+      clerkId: users.clerkId,
+      settings: creatorProfiles.settings,
+      usernameNormalized: creatorProfiles.usernameNormalized,
+    })
+    .from(creatorProfiles)
+    .innerJoin(users, eq(users.id, creatorProfiles.userId))
+    .where(eq(creatorProfiles.id, profileId))
+    .limit(1);
+
+  if (!profile || profile.clerkId !== userId) {
+    return NextResponse.json(
+      { success: false, error: 'Forbidden' },
+      { status: 403 }
+    );
+  }
+
+  const settings = (profile.settings ?? {}) as Record<string, unknown>;
+  const candidate = getFeaturedPlaylistFallbackCandidate(settings);
+
+  if (!candidate || candidate.playlistId !== playlistId) {
+    return NextResponse.json(
+      { success: false, error: 'Playlist suggestion not found' },
+      { status: 404 }
+    );
+  }
+
+  return {
+    playlistId,
+    profileId,
+    settings,
+    candidate,
+    usernameNormalized: profile.usernameNormalized,
+  };
+}

--- a/apps/web/app/api/suggestions/playlist-fallback/_shared.ts
+++ b/apps/web/app/api/suggestions/playlist-fallback/_shared.ts
@@ -2,9 +2,11 @@ import { eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getCachedAuth } from '@/lib/auth/cached';
+import { invalidateProfileCache } from '@/lib/cache/profile';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema/auth';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { captureError } from '@/lib/error-tracking';
 import { getFeaturedPlaylistFallbackCandidate } from '@/lib/profile/featured-playlist-fallback';
 
 const requestSchema = z.object({
@@ -15,8 +17,21 @@ interface PlaylistFallbackRequestContext {
   readonly playlistId: string;
   readonly profileId: string;
   readonly settings: Record<string, unknown>;
-  readonly candidate: ReturnType<typeof getFeaturedPlaylistFallbackCandidate>;
+  readonly candidate: NonNullable<
+    ReturnType<typeof getFeaturedPlaylistFallbackCandidate>
+  >;
   readonly usernameNormalized: string;
+}
+
+interface PlaylistFallbackMutationOptions {
+  readonly request: Request;
+  readonly params: Promise<{ id: string }>;
+  readonly route: string;
+  readonly errorMessage: string;
+  readonly successMessage: string;
+  readonly buildSettings: (
+    context: PlaylistFallbackRequestContext
+  ) => Record<string, unknown>;
 }
 
 export async function getPlaylistFallbackRequestContext(
@@ -82,4 +97,47 @@ export async function getPlaylistFallbackRequestContext(
     candidate,
     usernameNormalized: profile.usernameNormalized,
   };
+}
+
+export async function handlePlaylistFallbackMutation({
+  request,
+  params,
+  route,
+  errorMessage,
+  successMessage,
+  buildSettings,
+}: PlaylistFallbackMutationOptions) {
+  try {
+    const context = await getPlaylistFallbackRequestContext(request, params);
+
+    if (context instanceof NextResponse) {
+      return context;
+    }
+
+    await db
+      .update(creatorProfiles)
+      .set({
+        settings: buildSettings(context),
+        updatedAt: new Date(),
+      })
+      .where(eq(creatorProfiles.id, context.profileId));
+
+    await invalidateProfileCache(context.usernameNormalized);
+
+    return NextResponse.json({
+      success: true,
+      playlistId: context.playlistId,
+      message: successMessage,
+    });
+  } catch (error) {
+    await captureError(errorMessage, error, { route });
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Internal server error',
+      },
+      { status: 500 }
+    );
+  }
 }

--- a/apps/web/app/api/suggestions/playlist-fallback/_shared.ts
+++ b/apps/web/app/api/suggestions/playlist-fallback/_shared.ts
@@ -34,32 +34,40 @@ interface PlaylistFallbackMutationOptions {
   ) => Record<string, unknown>;
 }
 
-export async function getPlaylistFallbackRequestContext(
-  request: Request,
-  params: Promise<{ id: string }>
-): Promise<PlaylistFallbackRequestContext | NextResponse> {
-  const { id: playlistId } = await params;
+type OwnedPlaylistFallbackProfile = Pick<
+  PlaylistFallbackRequestContext,
+  'profileId' | 'settings' | 'usernameNormalized'
+>;
+
+type InvalidRequestDetails = ReturnType<
+  z.ZodError<{ profileId: string }>['flatten']
+>;
+
+function invalidRequestResponse(details: InvalidRequestDetails) {
+  return NextResponse.json(
+    {
+      success: false,
+      error: 'Invalid request',
+      details,
+    },
+    { status: 400 }
+  );
+}
+
+async function getOwnedPlaylistFallbackProfile(
+  request: Request
+): Promise<OwnedPlaylistFallbackProfile | NextResponse> {
   const { userId } = await getCachedAuth();
 
   if (!userId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const body = await request.json();
-  const parsed = requestSchema.safeParse(body);
+  const parsed = requestSchema.safeParse(await request.json());
 
   if (!parsed.success) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: 'Invalid request',
-        details: parsed.error.flatten(),
-      },
-      { status: 400 }
-    );
+    return invalidRequestResponse(parsed.error.flatten());
   }
-
-  const { profileId } = parsed.data;
 
   const [profile] = await db
     .select({
@@ -70,7 +78,7 @@ export async function getPlaylistFallbackRequestContext(
     })
     .from(creatorProfiles)
     .innerJoin(users, eq(users.id, creatorProfiles.userId))
-    .where(eq(creatorProfiles.id, profileId))
+    .where(eq(creatorProfiles.id, parsed.data.profileId))
     .limit(1);
 
   if (!profile || profile.clerkId !== userId) {
@@ -80,7 +88,25 @@ export async function getPlaylistFallbackRequestContext(
     );
   }
 
-  const settings = (profile.settings ?? {}) as Record<string, unknown>;
+  return {
+    profileId: profile.id,
+    settings: (profile.settings ?? {}) as Record<string, unknown>,
+    usernameNormalized: profile.usernameNormalized,
+  };
+}
+
+export async function getPlaylistFallbackRequestContext(
+  request: Request,
+  params: Promise<{ id: string }>
+): Promise<PlaylistFallbackRequestContext | NextResponse> {
+  const { id: playlistId } = await params;
+  const profile = await getOwnedPlaylistFallbackProfile(request);
+
+  if (profile instanceof NextResponse) {
+    return profile;
+  }
+
+  const { profileId, settings, usernameNormalized } = profile;
   const candidate = getFeaturedPlaylistFallbackCandidate(settings);
 
   if (!candidate || candidate.playlistId !== playlistId) {
@@ -95,7 +121,7 @@ export async function getPlaylistFallbackRequestContext(
     profileId,
     settings,
     candidate,
-    usernameNormalized: profile.usernameNormalized,
+    usernameNormalized,
   };
 }
 

--- a/apps/web/app/api/suggestions/route.ts
+++ b/apps/web/app/api/suggestions/route.ts
@@ -43,6 +43,10 @@ import {
   creatorProfiles,
 } from '@/lib/db/schema/profiles';
 import { captureError } from '@/lib/error-tracking';
+import {
+  getConfirmedFeaturedPlaylistFallback,
+  getFeaturedPlaylistFallbackCandidate,
+} from '@/lib/profile/featured-playlist-fallback';
 
 // ============================================================================
 // Types
@@ -50,7 +54,12 @@ import { captureError } from '@/lib/error-tracking';
 
 export interface ProfileSuggestion {
   id: string;
-  type: 'dsp_match' | 'social_link' | 'avatar' | 'profile_ready';
+  type:
+    | 'dsp_match'
+    | 'social_link'
+    | 'avatar'
+    | 'playlist_fallback'
+    | 'profile_ready';
   platform: string;
   platformLabel: string;
   title: string;
@@ -100,6 +109,7 @@ export async function GET(request: Request) {
         avatarUrl: creatorProfiles.avatarUrl,
         avatarLockedByUser: creatorProfiles.avatarLockedByUser,
         onboardingCompletedAt: creatorProfiles.onboardingCompletedAt,
+        settings: creatorProfiles.settings,
       })
       .from(creatorProfiles)
       .innerJoin(users, eq(users.id, creatorProfiles.userId))
@@ -226,6 +236,18 @@ export async function GET(request: Request) {
     const filteredAvatars = avatarCandidates.filter(
       c => c.avatarUrl !== profile.avatarUrl
     );
+    const pendingPlaylistFallback = getFeaturedPlaylistFallbackCandidate(
+      profile.settings as Record<string, unknown> | null | undefined
+    );
+    const confirmedPlaylistFallback = getConfirmedFeaturedPlaylistFallback(
+      profile.settings as Record<string, unknown> | null | undefined
+    );
+    const dismissedPlaylistId =
+      typeof (profile.settings as Record<string, unknown> | null | undefined)
+        ?.featuredPlaylistFallbackDismissedId === 'string'
+        ? ((profile.settings as Record<string, unknown>)
+            .featuredPlaylistFallbackDismissedId as string)
+        : null;
 
     // Normalize into unified format
     const suggestions: ProfileSuggestion[] = [
@@ -256,6 +278,25 @@ export async function GET(request: Request) {
         externalUrl: suggestion.url,
         confidence: Number.parseFloat(suggestion.confidenceScore),
       })),
+
+      ...(pendingPlaylistFallback &&
+      confirmedPlaylistFallback?.playlistId !==
+        pendingPlaylistFallback.playlistId &&
+      dismissedPlaylistId !== pendingPlaylistFallback.playlistId
+        ? [
+            {
+              id: pendingPlaylistFallback.playlistId,
+              type: 'playlist_fallback' as const,
+              platform: 'spotify',
+              platformLabel: 'Spotify',
+              title: pendingPlaylistFallback.title,
+              subtitle: 'Official playlist fallback suggestion',
+              imageUrl: pendingPlaylistFallback.imageUrl,
+              externalUrl: pendingPlaylistFallback.url,
+              confidence: null,
+            },
+          ]
+        : []),
 
       // Avatar candidates last
       ...filteredAvatars.map(candidate => ({

--- a/apps/web/components/jovie/components/SuggestedProfilesCarousel.tsx
+++ b/apps/web/components/jovie/components/SuggestedProfilesCarousel.tsx
@@ -302,6 +302,7 @@ function SuggestionCard({
   readonly onNext: () => void;
 }) {
   const isAvatar = suggestion.type === 'avatar';
+  const isPlaylistFallback = suggestion.type === 'playlist_fallback';
   const iconPlatform =
     ICON_PLATFORM_MAP[suggestion.platform] ?? suggestion.platform;
 
@@ -351,7 +352,7 @@ function SuggestionCard({
               target='_blank'
               rel='noopener noreferrer'
               className='shrink-0 rounded-md p-1.5 text-tertiary-token transition-colors hover:bg-surface-2 hover:text-secondary-token'
-              aria-label={`Open ${suggestion.platformLabel} profile`}
+              aria-label={`Open ${suggestion.platformLabel} link`}
             >
               <ExternalLink className='h-3.5 w-3.5' />
             </a>
@@ -413,7 +414,7 @@ function SuggestionCard({
             ) : (
               <X className='h-4 w-4' />
             )}
-            {isAvatar ? 'Skip' : 'Not me'}
+            {isAvatar ? 'Skip' : isPlaylistFallback ? 'Dismiss' : 'Not me'}
           </button>
           <button
             type='button'
@@ -432,7 +433,11 @@ function SuggestionCard({
             ) : (
               <Check className='h-4 w-4' />
             )}
-            {isAvatar ? 'Use photo' : "That's me"}
+            {isAvatar
+              ? 'Use photo'
+              : isPlaylistFallback
+                ? 'Use Playlist'
+                : "That's me"}
           </button>
         </div>
       </div>
@@ -522,6 +527,8 @@ export function SuggestedProfilesCarousel({
     heading = 'Welcome';
   } else if (current.type === 'avatar') {
     heading = 'Choose your profile photo';
+  } else if (current.type === 'playlist_fallback') {
+    heading = 'Playlist suggestion';
   } else {
     heading = 'We found profiles that might be yours';
   }

--- a/apps/web/components/jovie/hooks/useSuggestedProfiles.ts
+++ b/apps/web/components/jovie/hooks/useSuggestedProfiles.ts
@@ -138,6 +138,10 @@ export function useSuggestedProfiles(
           url = `/api/suggestions/avatars/${suggestion.id}/select`;
           body = { profileId };
           break;
+        case 'playlist_fallback':
+          url = `/api/suggestions/playlist-fallback/${suggestion.id}/approve`;
+          body = { profileId };
+          break;
       }
 
       const res = await fetch(url, {
@@ -180,6 +184,10 @@ export function useSuggestedProfiles(
           break;
         case 'avatar':
           url = `/api/suggestions/avatars/${suggestion.id}/dismiss`;
+          body = { profileId };
+          break;
+        case 'playlist_fallback':
+          url = `/api/suggestions/playlist-fallback/${suggestion.id}/reject`;
           body = { profileId };
           break;
       }

--- a/apps/web/tests/unit/chat/useSuggestedProfiles.test.ts
+++ b/apps/web/tests/unit/chat/useSuggestedProfiles.test.ts
@@ -3,6 +3,31 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useSuggestedProfiles } from '@/components/jovie/hooks/useSuggestedProfiles';
 
+const defaultStarterContext = {
+  conversationCount: 2,
+  isRecentlyOnboarded: false,
+  latestReleaseTitle: null,
+};
+
+const playlistFallbackSuggestion = {
+  id: '37i9dQZF1DZ06evO2SKVTu',
+  type: 'playlist_fallback' as const,
+  platform: 'spotify',
+  platformLabel: 'Spotify',
+  title: 'This Is Tim White',
+  subtitle: 'Official playlist fallback suggestion',
+  imageUrl: null,
+  externalUrl: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+  confidence: null,
+};
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
 describe('useSuggestedProfiles', () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -27,33 +52,23 @@ describe('useSuggestedProfiles', () => {
 
   it('fetches suggestions when enabled', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          success: true,
-          suggestions: [
-            {
-              id: 'suggestion_1',
-              type: 'dsp_match',
-              platform: 'spotify',
-              platformLabel: 'Spotify',
-              title: 'Artist Match',
-              subtitle: 'Potential profile',
-              imageUrl: null,
-              externalUrl: null,
-              confidence: 0.96,
-            },
-          ],
-          starterContext: {
-            conversationCount: 2,
-            isRecentlyOnboarded: false,
-            latestReleaseTitle: null,
+      jsonResponse({
+        success: true,
+        suggestions: [
+          {
+            id: 'suggestion_1',
+            type: 'dsp_match',
+            platform: 'spotify',
+            platformLabel: 'Spotify',
+            title: 'Artist Match',
+            subtitle: 'Potential profile',
+            imageUrl: null,
+            externalUrl: null,
+            confidence: 0.96,
           },
-        }),
-        {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      )
+        ],
+        starterContext: defaultStarterContext,
+      })
     );
 
     const { result } = renderHook(() => useSuggestedProfiles('profile_1'));
@@ -73,41 +88,13 @@ describe('useSuggestedProfiles', () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            success: true,
-            suggestions: [
-              {
-                id: '37i9dQZF1DZ06evO2SKVTu',
-                type: 'playlist_fallback',
-                platform: 'spotify',
-                platformLabel: 'Spotify',
-                title: 'This Is Tim White',
-                subtitle: 'Official playlist fallback suggestion',
-                imageUrl: null,
-                externalUrl:
-                  'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
-                confidence: null,
-              },
-            ],
-            starterContext: {
-              conversationCount: 2,
-              isRecentlyOnboarded: false,
-              latestReleaseTitle: null,
-            },
-          }),
-          {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          }
-        )
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ success: true }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
+        jsonResponse({
+          success: true,
+          suggestions: [playlistFallbackSuggestion],
+          starterContext: defaultStarterContext,
         })
-      );
+      )
+      .mockResolvedValueOnce(jsonResponse({ success: true }));
 
     const { result } = renderHook(() => useSuggestedProfiles('profile_1'));
 
@@ -131,41 +118,13 @@ describe('useSuggestedProfiles', () => {
     const fetchSpy = vi
       .spyOn(globalThis, 'fetch')
       .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            success: true,
-            suggestions: [
-              {
-                id: '37i9dQZF1DZ06evO2SKVTu',
-                type: 'playlist_fallback',
-                platform: 'spotify',
-                platformLabel: 'Spotify',
-                title: 'This Is Tim White',
-                subtitle: 'Official playlist fallback suggestion',
-                imageUrl: null,
-                externalUrl:
-                  'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
-                confidence: null,
-              },
-            ],
-            starterContext: {
-              conversationCount: 2,
-              isRecentlyOnboarded: false,
-              latestReleaseTitle: null,
-            },
-          }),
-          {
-            status: 200,
-            headers: { 'Content-Type': 'application/json' },
-          }
-        )
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ success: true }), {
-          status: 200,
-          headers: { 'Content-Type': 'application/json' },
+        jsonResponse({
+          success: true,
+          suggestions: [playlistFallbackSuggestion],
+          starterContext: defaultStarterContext,
         })
-      );
+      )
+      .mockResolvedValueOnce(jsonResponse({ success: true }));
 
     const { result } = renderHook(() => useSuggestedProfiles('profile_1'));
 

--- a/apps/web/tests/unit/chat/useSuggestedProfiles.test.ts
+++ b/apps/web/tests/unit/chat/useSuggestedProfiles.test.ts
@@ -68,4 +68,120 @@ describe('useSuggestedProfiles', () => {
     expect(result.current.total).toBe(1);
     expect(result.current.starterContext?.conversationCount).toBe(2);
   });
+
+  it('routes playlist confirmation to the playlist fallback approve endpoint', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            suggestions: [
+              {
+                id: '37i9dQZF1DZ06evO2SKVTu',
+                type: 'playlist_fallback',
+                platform: 'spotify',
+                platformLabel: 'Spotify',
+                title: 'This Is Tim White',
+                subtitle: 'Official playlist fallback suggestion',
+                imageUrl: null,
+                externalUrl:
+                  'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+                confidence: null,
+              },
+            ],
+            starterContext: {
+              conversationCount: 2,
+              isRecentlyOnboarded: false,
+              latestReleaseTitle: null,
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+    const { result } = renderHook(() => useSuggestedProfiles('profile_1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.total).toBe(1);
+    });
+
+    await result.current.confirm();
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      '/api/suggestions/playlist-fallback/37i9dQZF1DZ06evO2SKVTu/approve',
+      expect.objectContaining({
+        method: 'POST',
+      })
+    );
+  });
+
+  it('routes playlist rejection to the playlist fallback reject endpoint', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            success: true,
+            suggestions: [
+              {
+                id: '37i9dQZF1DZ06evO2SKVTu',
+                type: 'playlist_fallback',
+                platform: 'spotify',
+                platformLabel: 'Spotify',
+                title: 'This Is Tim White',
+                subtitle: 'Official playlist fallback suggestion',
+                imageUrl: null,
+                externalUrl:
+                  'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+                confidence: null,
+              },
+            ],
+            starterContext: {
+              conversationCount: 2,
+              isRecentlyOnboarded: false,
+              latestReleaseTitle: null,
+            },
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+    const { result } = renderHook(() => useSuggestedProfiles('profile_1'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.total).toBe(1);
+    });
+
+    await result.current.reject();
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      '/api/suggestions/playlist-fallback/37i9dQZF1DZ06evO2SKVTu/reject',
+      expect.objectContaining({
+        method: 'POST',
+      })
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- surface pending playlist fallback suggestions in the chat carousel
- add approve and reject endpoints for playlist fallback suggestions
- wire the client suggestion hook to the new playlist actions

## Verification
- doppler run --project jovie-web --config dev -- pnpm --filter web exec vitest run tests/unit/chat/useSuggestedProfiles.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new playlist fallback suggestion type to the profile suggestions carousel, allowing creators to review playlist recommendations.
  * Added dedicated action buttons for approving ("Use Playlist") or dismissing ("Dismiss") playlist suggestions.
  * Playlist suggestions now appear in the carousel with a dedicated "Playlist suggestion" heading, seamlessly integrated with other suggestion types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->