### PR TITLE
feat(profile): render confirmed playlist fallback

### DIFF
--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -34,6 +34,7 @@ import type {
 import { getReleasesForProfileLite } from '@/lib/discography/queries';
 import { captureError } from '@/lib/error-tracking';
 import { calculateRequiredProfileCompletion } from '@/lib/profile/completion';
+import { getConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import { isShopEnabled } from '@/lib/profile/shop-settings';
 import { getProfileWithLinks as getCreatorProfileWithLinks } from '@/lib/services/profile';
 import { isDspPlatform } from '@/lib/services/social-links/types';
@@ -642,6 +643,8 @@ export default async function ArtistPage({
   // Read profile photo download settings
   const profileSettings =
     (profile.settings as Record<string, unknown> | null) ?? {};
+  const featuredPlaylistFallback =
+    getConfirmedFeaturedPlaylistFallback(profileSettings);
   const allowPhotoDownloads =
     profileSettings.allowProfilePhotoDownloads === true;
   const photoDownloadSizes = buildAvatarSizes(
@@ -721,6 +724,7 @@ export default async function ArtistPage({
         profileSettings={{
           showOldReleases: profileSettings.showOldReleases === true,
         }}
+        featuredPlaylistFallback={featuredPlaylistFallback}
         releases={releases}
       />
       {isPublicNoAuthSmoke ? null : (

--- a/apps/web/components/features/profile/StaticArtistPage.tsx
+++ b/apps/web/components/features/profile/StaticArtistPage.tsx
@@ -3,6 +3,7 @@ import type { PublicRelease } from '@/features/profile/releases/types';
 import { ProfileCompactTemplate } from '@/features/profile/templates/ProfileCompactTemplate';
 import { buildProfilePublicViewModel } from '@/features/profile/view-models';
 import type { DiscogRelease } from '@/lib/db/schema/content';
+import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import type { AvatarSize } from '@/lib/utils/avatar-sizes';
 import type { PublicContact } from '@/types/contacts';
@@ -36,6 +37,7 @@ export interface StaticArtistPageProps {
   readonly profileSettings?: {
     readonly showOldReleases?: boolean;
   } | null;
+  readonly featuredPlaylistFallback?: ConfirmedFeaturedPlaylistFallback | null;
   readonly viewerCountryCode?: string | null;
   readonly presentation?: StaticArtistPagePresentation;
   readonly releases?: readonly PublicRelease[];
@@ -65,6 +67,7 @@ export function StaticArtistPage({
   showSubscriptionConfirmedBanner = false,
   showShopButton = false,
   profileSettings,
+  featuredPlaylistFallback,
   viewerCountryCode,
   presentation = 'full-public',
   releases,
@@ -93,6 +96,7 @@ export function StaticArtistPage({
     showSubscriptionConfirmedBanner,
     showShopButton,
     profileSettings,
+    featuredPlaylistFallback,
   });
 
   // Live public profiles and compact preview callers intentionally share the
@@ -119,6 +123,7 @@ export function StaticArtistPage({
         viewModel.showSubscriptionConfirmedBanner
       }
       profileSettings={viewModel.profileSettings}
+      featuredPlaylistFallback={viewModel.featuredPlaylistFallback}
       viewerCountryCode={viewerCountryCode}
       releases={releases}
       hideJovieBranding={hideJovieBranding}

--- a/apps/web/components/features/profile/contracts.ts
+++ b/apps/web/components/features/profile/contracts.ts
@@ -1,4 +1,5 @@
 import type { DiscogRelease } from '@/lib/db/schema/content';
+import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import type { AvatarSize } from '@/lib/utils/avatar-sizes';
 import type { PublicContact } from '@/types/contacts';
@@ -143,6 +144,7 @@ export interface ProfilePublicViewModel {
   readonly profileSettings?: {
     readonly showOldReleases?: boolean;
   } | null;
+  readonly featuredPlaylistFallback?: ConfirmedFeaturedPlaylistFallback | null;
   readonly releases?: readonly PublicRelease[];
 }
 

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -31,6 +31,7 @@ import type { DrawerView } from '@/features/profile/ProfileUnifiedDrawer';
 import type { PublicRelease } from '@/features/profile/releases/types';
 import { SubscriptionConfirmedBanner } from '@/features/profile/SubscriptionConfirmedBanner';
 import { sortDSPsByGeoPopularity } from '@/lib/dsp';
+import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import { getProfileReleaseVisibility } from '@/lib/profile/release-visibility';
 import { getCanonicalProfileDSPs } from '@/lib/profile-dsps';
 import { buildProfileShareContext } from '@/lib/share/context';
@@ -95,6 +96,7 @@ interface ProfileCompactSurfaceProps {
   readonly profileSettings?: {
     readonly showOldReleases?: boolean;
   } | null;
+  readonly featuredPlaylistFallback?: ConfirmedFeaturedPlaylistFallback | null;
   readonly enableDynamicEngagement?: boolean;
   readonly subscribeTwoStep?: boolean;
   readonly genres?: string[] | null;
@@ -244,6 +246,7 @@ export function ProfileCompactSurface({
   showPayButton = true,
   latestRelease,
   profileSettings,
+  featuredPlaylistFallback,
   enableDynamicEngagement = false,
   subscribeTwoStep = false,
   genres,
@@ -554,6 +557,37 @@ export function ProfileCompactSurface({
                 </div>
                 <span className='shrink-0 rounded-full bg-white/[0.1] px-3 py-1 text-[11px] font-[510] text-white/80 transition-colors duration-150 group-hover:bg-white/[0.15]'>
                   {nextTourDate.ticketUrl ? 'Tickets' : 'Details'}
+                </span>
+              </a>
+            ) : featuredPlaylistFallback ? (
+              <a
+                href={featuredPlaylistFallback.url}
+                target='_blank'
+                rel='noopener noreferrer'
+                className={actionCardClassName}
+                aria-label={`Open This Is playlist for ${artist.name}`}
+              >
+                {featuredPlaylistFallback.imageUrl ? (
+                  <div className='relative h-11 w-11 shrink-0 overflow-hidden rounded-[12px]'>
+                    <ImageWithFallback
+                      src={featuredPlaylistFallback.imageUrl}
+                      alt={featuredPlaylistFallback.title}
+                      fill
+                      sizes='44px'
+                      className='object-cover'
+                      fallbackVariant='release'
+                    />
+                  </div>
+                ) : (
+                  <Play className='h-4 w-4 shrink-0 fill-current text-white/60' />
+                )}
+                <div className='min-w-0 flex-1'>
+                  <p className='truncate text-[13px] font-[560] text-white/88'>
+                    {featuredPlaylistFallback.title}
+                  </p>
+                </div>
+                <span className='shrink-0 rounded-full bg-white/[0.1] px-3 py-1 text-[11px] font-[510] text-white/80 transition-colors duration-150 group-hover:bg-white/[0.15]'>
+                  Open Playlist
                 </span>
               </a>
             ) : mergedDSPs.length > 0 ? (

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -20,6 +20,7 @@ import {
 import type { PublicRelease } from '@/features/profile/releases/types';
 import { sortDSPsByGeoPopularity } from '@/lib/dsp';
 import { useNotifications } from '@/lib/hooks/useNotifications';
+import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import { getCanonicalProfileDSPs } from '@/lib/profile-dsps';
 import {
   useUnsubscribeNotificationsMutation,
@@ -50,6 +51,7 @@ interface ProfileCompactTemplateProps {
   readonly profileSettings?: {
     readonly showOldReleases?: boolean;
   } | null;
+  readonly featuredPlaylistFallback?: ConfirmedFeaturedPlaylistFallback | null;
   readonly enableDynamicEngagement?: boolean;
   readonly subscribeTwoStep?: boolean;
   readonly genres?: string[] | null;
@@ -148,6 +150,7 @@ export function ProfileCompactTemplate({
   showPayButton = false,
   latestRelease,
   profileSettings,
+  featuredPlaylistFallback,
   enableDynamicEngagement = false,
   subscribeTwoStep = false,
   genres,
@@ -573,6 +576,7 @@ export function ProfileCompactTemplate({
                 showPayButton={showPayButton}
                 latestRelease={latestRelease}
                 profileSettings={profileSettings}
+                featuredPlaylistFallback={featuredPlaylistFallback}
                 enableDynamicEngagement={enableDynamicEngagement}
                 subscribeTwoStep={subscribeTwoStep}
                 genres={genres}

--- a/apps/web/components/features/profile/view-models.ts
+++ b/apps/web/components/features/profile/view-models.ts
@@ -1,4 +1,5 @@
 import type { DiscogRelease } from '@/lib/db/schema/content';
+import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import type { AvatarSize } from '@/lib/utils/avatar-sizes';
 import type { PublicContact } from '@/types/contacts';
@@ -34,6 +35,7 @@ interface BuildProfilePublicViewModelInput {
   readonly profileSettings?: {
     readonly showOldReleases?: boolean;
   } | null;
+  readonly featuredPlaylistFallback?: ConfirmedFeaturedPlaylistFallback | null;
   readonly showFooter?: boolean;
   readonly showBackButton?: boolean;
   readonly showTourButton?: boolean;
@@ -52,6 +54,7 @@ export function buildProfilePublicViewModel({
   enableDynamicEngagement = false,
   latestRelease,
   profileSettings,
+  featuredPlaylistFallback,
   photoDownloadSizes = [],
   allowPhotoDownloads = false,
   pressPhotos = [],
@@ -98,6 +101,7 @@ export function buildProfilePublicViewModel({
     showSubscriptionConfirmedBanner,
     showShopButton,
     profileSettings,
+    featuredPlaylistFallback,
     releases,
   };
 }

--- a/apps/web/tests/unit/profile/profile-compact-template.test.tsx
+++ b/apps/web/tests/unit/profile/profile-compact-template.test.tsx
@@ -471,6 +471,89 @@ describe('ProfileCompactTemplate', () => {
     pushStateSpy.mockRestore();
   });
 
+  it('renders the confirmed playlist fallback when no release is available', async () => {
+    render(
+      <ProfileCompactTemplate
+        mode='profile'
+        artist={mockArtist}
+        socialLinks={[]}
+        contacts={[]}
+        featuredPlaylistFallback={{
+          artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+          confirmedAt: '2026-01-01T00:00:00.000Z',
+          discoveredAt: '2026-01-01T00:00:00.000Z',
+          imageUrl: 'https://example.com/playlist.jpg',
+          playlistId: '37i9dQZF1DZ06evO2SKVTu',
+          searchQuery: 'site:open.spotify.com/playlist "This Is Tim White"',
+          source: 'serp_html',
+          title: 'This Is Tim White',
+          url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole('link', {
+        name: `Open This Is playlist for ${mockArtist.name}`,
+      })
+    ).toHaveAttribute(
+      'href',
+      'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu'
+    );
+    expect(screen.getByText('Open Playlist')).toBeInTheDocument();
+  });
+
+  it('keeps the upcoming show CTA ahead of the playlist fallback', async () => {
+    render(
+      <ProfileCompactTemplate
+        mode='profile'
+        artist={mockArtist}
+        socialLinks={[]}
+        contacts={[]}
+        featuredPlaylistFallback={{
+          artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+          confirmedAt: '2026-01-01T00:00:00.000Z',
+          discoveredAt: '2026-01-01T00:00:00.000Z',
+          imageUrl: 'https://example.com/playlist.jpg',
+          playlistId: '37i9dQZF1DZ06evO2SKVTu',
+          searchQuery: 'site:open.spotify.com/playlist "This Is Tim White"',
+          source: 'serp_html',
+          title: 'This Is Tim White',
+          url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+        }}
+        tourDates={[
+          {
+            id: 'tour-1',
+            profileId: mockArtist.id,
+            title: null,
+            venueName: 'The Ballroom',
+            city: 'Los Angeles',
+            region: 'CA',
+            country: 'US',
+            startDate: '2099-05-01T00:00:00.000Z',
+            endDate: null,
+            ticketUrl: 'https://tickets.example.com/show',
+            ticketStatus: 'onsale',
+            timezone: 'America/Los_Angeles',
+            latitude: null,
+            longitude: null,
+            source: 'manual',
+            sourceEventId: null,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Tickets')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {
+        name: `Open This Is playlist for ${mockArtist.name}`,
+      })
+    ).not.toBeInTheDocument();
+  });
+
   it('clears the mode query and closes the deep-linked drawer', async () => {
     mockCanonicalProfileDSPs.mockReturnValue([{ platform: 'spotify' }]);
     window.history.replaceState(null, '', '/test-artist?mode=listen');

--- a/apps/web/tests/unit/profile/public-profile-page.test.ts
+++ b/apps/web/tests/unit/profile/public-profile-page.test.ts
@@ -108,6 +108,16 @@ describe('Public Profile Page Logic', () => {
         'getPublicTourDates(profile.id)'
       );
     });
+
+    it('reads a confirmed playlist fallback from profile settings without live search', () => {
+      expect(PUBLIC_PROFILE_PAGE_SOURCE).toContain(
+        'getConfirmedFeaturedPlaylistFallback(profileSettings)'
+      );
+      expect(PUBLIC_PROFILE_PAGE_SOURCE).not.toContain('searchGoogleCSE');
+      expect(PUBLIC_PROFILE_PAGE_SOURCE).not.toContain(
+        'discoverThisIsPlaylistCandidate'
+      );
+    });
   });
 
   describe('public claim banner handling', () => {

--- a/apps/web/tests/unit/profile/view-models.test.ts
+++ b/apps/web/tests/unit/profile/view-models.test.ts
@@ -37,6 +37,17 @@ describe('profile view models', () => {
       socialLinks: [],
       contacts: [],
       showPayButton: true,
+      featuredPlaylistFallback: {
+        artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+        confirmedAt: '2026-01-01T00:00:00.000Z',
+        discoveredAt: '2026-01-01T00:00:00.000Z',
+        imageUrl: null,
+        playlistId: '37i9dQZF1DZ06evO2SKVTu',
+        searchQuery: 'site:open.spotify.com/playlist "This Is Tim White"',
+        source: 'serp_html',
+        title: 'This Is Tim White',
+        url: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+      },
     });
 
     expect(viewModel.mode).toBe('tour');
@@ -44,6 +55,7 @@ describe('profile view models', () => {
     expect(viewModel.showBackButton).toBe(true);
     expect(viewModel.showNotificationButton).toBe(true);
     expect(viewModel.isTourModeActive).toBe(true);
+    expect(viewModel.featuredPlaylistFallback?.title).toBe('This Is Tim White');
   });
 
   it('normalizes profile identity fields for editors', () => {


### PR DESCRIPTION
## Summary
- read confirmed playlist fallback state on the public profile route
- propagate the fallback through the profile view model and compact shell
- render the confirmed playlist CTA only when release and tour priorities do not win

## Verification
- doppler run --project jovie-web --config dev -- pnpm --filter web exec vitest run tests/unit/profile/profile-compact-template.test.tsx tests/unit/profile/public-profile-page.test.ts tests/unit/profile/view-models.test.ts
- doppler run --project jovie-web --config dev -- ./node_modules/.bin/tsc --noEmit