### PR TITLE
fix(profile): harden playlist discovery fetcher

### DIFF
--- a/apps/web/lib/profile/featured-playlist-fallback-discovery.ts
+++ b/apps/web/lib/profile/featured-playlist-fallback-discovery.ts
@@ -11,10 +11,15 @@ import {
 
 const SPOTIFY_WEB_TIMEOUT_MS = 8_000;
 const MAX_PAGE_FETCH_ATTEMPTS = 2;
+const RETRY_BACKOFF_BASE_MS = 500;
 const PLAYLIST_QUERY_TEMPLATES = [
   'site:open.spotify.com/playlist "This Is {artistName}"',
   'site:open.spotify.com/playlist "This Is {artistName}" "Spotify Playlist"',
 ] as const;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 async function fetchSpotifyPublicPage(url: string): Promise<string | null> {
   for (let attempt = 1; attempt <= MAX_PAGE_FETCH_ATTEMPTS; attempt += 1) {
@@ -33,7 +38,16 @@ async function fetchSpotifyPublicPage(url: string): Promise<string | null> {
       }
 
       if (response.status >= 500 && attempt < MAX_PAGE_FETCH_ATTEMPTS) {
+        await sleep(RETRY_BACKOFF_BASE_MS * attempt);
         continue;
+      }
+
+      if (
+        response.status === 404 ||
+        response.status === 410 ||
+        response.status === 429
+      ) {
+        return null;
       }
 
       await captureWarning(
@@ -48,6 +62,7 @@ async function fetchSpotifyPublicPage(url: string): Promise<string | null> {
       return null;
     } catch (error) {
       if (attempt < MAX_PAGE_FETCH_ATTEMPTS) {
+        await sleep(RETRY_BACKOFF_BASE_MS * attempt);
         continue;
       }
 
@@ -67,6 +82,7 @@ export async function discoverThisIsPlaylistCandidate(input: {
   readonly artistSpotifyId: string;
 }): Promise<FeaturedPlaylistFallbackCandidate | null> {
   const artistName = input.artistName.trim();
+  const safeArtistName = artistName.replaceAll('"', '');
   const artistSpotifyId = input.artistSpotifyId.trim();
 
   if (!artistName || !artistSpotifyId) {
@@ -76,8 +92,18 @@ export async function discoverThisIsPlaylistCandidate(input: {
   const seenPlaylistIds = new Set<string>();
 
   for (const queryTemplate of PLAYLIST_QUERY_TEMPLATES) {
-    const query = queryTemplate.replace('{artistName}', artistName);
-    const searchResults = await searchGoogleCSE(query, 1);
+    const query = queryTemplate.replace('{artistName}', safeArtistName);
+    const searchResults = await searchGoogleCSE(query, 1).catch(async error => {
+      await captureWarning('Google CSE discovery failed', error, {
+        query,
+        route: 'featured-playlist-fallback-discovery',
+      });
+      return null;
+    });
+
+    if (!searchResults) {
+      continue;
+    }
 
     for (const result of searchResults) {
       const normalizedUrl = normalizeSpotifyPlaylistUrl(result.link);

--- a/apps/web/lib/profile/featured-playlist-fallback-discovery.ts
+++ b/apps/web/lib/profile/featured-playlist-fallback-discovery.ts
@@ -37,9 +37,12 @@ async function fetchSpotifyPublicPage(url: string): Promise<string | null> {
         return await response.text();
       }
 
-      if (response.status >= 500 && attempt < MAX_PAGE_FETCH_ATTEMPTS) {
-        await sleep(RETRY_BACKOFF_BASE_MS * attempt);
-        continue;
+      if (response.status >= 500) {
+        if (attempt < MAX_PAGE_FETCH_ATTEMPTS) {
+          await sleep(RETRY_BACKOFF_BASE_MS * attempt);
+          continue;
+        }
+        return null;
       }
 
       if (
@@ -85,7 +88,7 @@ export async function discoverThisIsPlaylistCandidate(input: {
   const safeArtistName = artistName.replaceAll('"', '');
   const artistSpotifyId = input.artistSpotifyId.trim();
 
-  if (!artistName || !artistSpotifyId) {
+  if (!artistName || !safeArtistName || !artistSpotifyId) {
     return null;
   }
 

--- a/apps/web/tests/unit/profile/featured-playlist-fallback-discovery.test.ts
+++ b/apps/web/tests/unit/profile/featured-playlist-fallback-discovery.test.ts
@@ -92,4 +92,74 @@ describe('featured playlist fallback discovery', () => {
       })
     ).resolves.toBeNull();
   });
+
+  it('escapes quotes in artist names before querying Google CSE', async () => {
+    hoisted.searchGoogleCSEMock.mockResolvedValue([]);
+
+    const { discoverThisIsPlaylistCandidate } = await import(
+      '@/lib/profile/featured-playlist-fallback-discovery'
+    );
+
+    await expect(
+      discoverThisIsPlaylistCandidate({
+        artistName: 'Tim "TJ" White',
+        artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+      })
+    ).resolves.toBeNull();
+
+    expect(hoisted.searchGoogleCSEMock).toHaveBeenCalledWith(
+      'site:open.spotify.com/playlist "This Is Tim TJ White"',
+      1
+    );
+  });
+
+  it('returns null and captures a warning when Google CSE throws', async () => {
+    hoisted.searchGoogleCSEMock.mockRejectedValue(new Error('search failed'));
+
+    const { discoverThisIsPlaylistCandidate } = await import(
+      '@/lib/profile/featured-playlist-fallback-discovery'
+    );
+
+    await expect(
+      discoverThisIsPlaylistCandidate({
+        artistName: 'Tim White',
+        artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+      })
+    ).resolves.toBeNull();
+
+    expect(hoisted.captureWarningMock).toHaveBeenCalledWith(
+      'Google CSE discovery failed',
+      expect.any(Error),
+      expect.objectContaining({
+        query: 'site:open.spotify.com/playlist "This Is Tim White"',
+        route: 'featured-playlist-fallback-discovery',
+      })
+    );
+  });
+
+  it('does not capture a warning for expected 404 playlist responses', async () => {
+    hoisted.searchGoogleCSEMock.mockResolvedValue([
+      {
+        link: 'https://open.spotify.com/playlist/37i9dQZF1DZ06evO2SKVTu',
+        title: 'This Is Tim White',
+        snippet: '',
+      },
+    ]);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('', { status: 404 })
+    );
+
+    const { discoverThisIsPlaylistCandidate } = await import(
+      '@/lib/profile/featured-playlist-fallback-discovery'
+    );
+
+    await expect(
+      discoverThisIsPlaylistCandidate({
+        artistName: 'Tim White',
+        artistSpotifyId: '4Uwpa6zW3zzCSQvooQNksm',
+      })
+    ).resolves.toBeNull();
+
+    expect(hoisted.captureWarningMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- add backoff and quieter handling for expected Spotify page failures
- escape quoted artist names before Google CSE queries
- catch Google CSE failures in discovery and cover the hardening paths with tests

## Verification
- doppler run --project jovie-web --config dev -- pnpm --filter web exec vitest run tests/unit/profile/featured-playlist-fallback-discovery.test.ts
- doppler run --project jovie-web --config dev -- ./node_modules/.bin/tsc --noEmit
- pnpm biome check --write apps/web
- git push origin itstimwhite/playlist-fallback-discovery-fetch (pre-push passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced playlist discovery mechanism to identify and validate featured playlists using search and direct validation.

* **Tests**
  * Added comprehensive test coverage for playlist discovery functionality, including success scenarios, error handling, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->