### PR TITLE
fix: resolve SonarCloud void-operator issues (S3735)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
@@ -658,8 +658,8 @@ export const DashboardAudienceTableUnified = memo(
           id: 'copy-source-link',
           label: 'Copy Link',
           icon: Copy,
-          onClick: () => {
-            void handleSourceLinkAction('copy');
+          onClick: async () => {
+            await handleSourceLinkAction('copy');
           },
         },
         {
@@ -667,8 +667,8 @@ export const DashboardAudienceTableUnified = memo(
           id: 'open-source-link',
           label: 'Open Link',
           icon: ExternalLink,
-          onClick: () => {
-            void handleSourceLinkAction('open');
+          onClick: async () => {
+            await handleSourceLinkAction('open');
           },
         },
         {
@@ -676,8 +676,8 @@ export const DashboardAudienceTableUnified = memo(
           id: 'download-source-qr',
           label: 'Download QR Code',
           icon: Download,
-          onClick: () => {
-            void handleSourceLinkAction('download');
+          onClick: async () => {
+            await handleSourceLinkAction('download');
           },
         },
       ],


### PR DESCRIPTION
## Summary
Fixes 3 SonarCloud CRITICAL issues (typescript:S3735 — remove use of void operator).

- `DashboardAudienceTableUnified.tsx` — convert 3 onClick handlers from `() => { void handleSourceLinkAction(...) }` to `async () => { await handleSourceLinkAction(...) }`. Matches the async onClick pattern used elsewhere (e.g. `AdminUsersTableUnified.tsx`).

## SonarCloud Rules Addressed
- typescript:S3735 — Remove this use of the "void" operator

## Test plan
- [x] TypeScript compiles
- [x] Biome + ESLint pass (via pre-commit hook)
- [x] No behavior changes — underlying async function `handleSourceLinkAction` already catches its own errors

Auto-merge requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of source link actions ("Copy Link", "Open Link", "Download QR Code") in the dashboard by ensuring they complete properly before marking as finished.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->