### PR TITLE
fix: resolve SonarCloud replaceAll issues (S7781)

### DIFF
--- a/apps/web/app/api/dashboard/audience/source-route-helpers.ts
+++ b/apps/web/app/api/dashboard/audience/source-route-helpers.ts
@@ -157,9 +157,9 @@ function buildAudienceSourceSlugFallback(
 ): string {
   const normalized = value
     .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
+    .replaceAll(/[\u0300-\u036f]/g, '')
     .toLowerCase();
-  const sanitized = normalized.replace(/[^a-z0-9]+/g, '-');
+  const sanitized = normalized.replaceAll(/[^a-z0-9]+/g, '-');
   const trimmed = trimEdgeDashes(sanitized);
 
   if (trimmed) {

--- a/apps/web/lib/profile/featured-playlist-fallback-web.ts
+++ b/apps/web/lib/profile/featured-playlist-fallback-web.ts
@@ -21,7 +21,7 @@ export type FeaturedPlaylistFallbackCandidate = z.infer<
 >;
 
 function decodeHtmlEntities(value: string): string {
-  return value.replace(
+  return value.replaceAll(
     /&(#x?[0-9a-fA-F]+|amp|apos|quot|lt|gt);/g,
     (match, entity: string) => {
       switch (entity) {
@@ -49,7 +49,7 @@ function decodeHtmlEntities(value: string): string {
 }
 
 function normalizeWhitespace(value: string): string {
-  return value.replace(/\s+/g, ' ').trim();
+  return value.replaceAll(/\s+/g, ' ').trim();
 }
 
 function normalizeTitle(value: string): string {


### PR DESCRIPTION
## Summary
Fixes 4 SonarCloud MINOR issues (typescript:S7781 — prefer String#replaceAll over String#replace).

- `source-route-helpers.ts` — 2 occurrences in `buildAudienceSourceSlugFallback`
- `featured-playlist-fallback-web.ts` — 2 occurrences in `decodeHtmlEntities` and `normalizeWhitespace`

All patterns already use the `/g` flag, so semantics are unchanged.

## SonarCloud Rules Addressed
- typescript:S7781 — Prefer String#replaceAll() over String#replace()

## Test plan
- [x] TypeScript compiles
- [x] Biome + ESLint pass (via pre-commit hook)
- [x] No behavior changes — mechanical replacement preserving /g semantics

Auto-merge requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal string processing methods to use modern `replaceAll()` approach instead of `replace()` with global regex patterns for improved code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->