### PR TITLE
fix: resolve SonarCloud globalThis issues (S7764)

### DIFF
--- a/apps/web/components/jovie/components/ChatAlbumArtCard.tsx
+++ b/apps/web/components/jovie/components/ChatAlbumArtCard.tsx
@@ -40,7 +40,7 @@ function buildCreateReleasePrompt(title: string | null): string {
 }
 
 function submitChatPrompt(prompt: string): void {
-  window.dispatchEvent(
+  globalThis.dispatchEvent(
     new CustomEvent('jovie-chat-submit-prompt', { detail: { prompt } })
   );
 }

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -719,9 +719,12 @@ export function useJovieChat({
       rateLimitedSubmitter.maybeExecute({ text: detail.prompt });
     };
 
-    window.addEventListener('jovie-chat-submit-prompt', handlePromptEvent);
+    globalThis.addEventListener('jovie-chat-submit-prompt', handlePromptEvent);
     return () => {
-      window.removeEventListener('jovie-chat-submit-prompt', handlePromptEvent);
+      globalThis.removeEventListener(
+        'jovie-chat-submit-prompt',
+        handlePromptEvent
+      );
     };
   }, [rateLimitedSubmitter]);
 


### PR DESCRIPTION
## Summary
Fixes 3 SonarCloud MINOR issues (typescript:S7764 — prefer globalThis over window).

- `ChatAlbumArtCard.tsx` — `window.dispatchEvent` → `globalThis.dispatchEvent`
- `useJovieChat.ts` — `window.addEventListener` / `window.removeEventListener` → `globalThis` equivalents

## SonarCloud Rules Addressed
- typescript:S7764 — Prefer \`globalThis\` over \`window\`

## Test plan
- [x] TypeScript compiles
- [x] Biome + ESLint pass (via pre-commit hook)
- [x] No behavior changes — \`globalThis\` === \`window\` in browser contexts

Auto-merge requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal event handling mechanism for enhanced compatibility with the chat system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->