### PR TITLE
fix: normalize sparse release track numbering

### DIFF
--- a/apps/web/components/features/demo/mock-release-data.ts
+++ b/apps/web/components/features/demo/mock-release-data.ts
@@ -77,6 +77,10 @@ export const DEMO_RELEASE_VIEW_MODELS: ReleaseViewModel[] =
     releaseType: release.releaseType,
     isExplicit: Boolean(release.tracks?.some(track => track.isExplicit)),
     totalTracks: release.totalTracks,
+    totalDiscs: Math.max(
+      1,
+      ...(release.tracks ?? []).map(track => track.discNumber)
+    ),
     totalDurationMs: release.totalDurationMs,
     upc: release.upc,
     label: release.label ?? null,

--- a/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
@@ -26,10 +26,31 @@ interface TrackControlSource {
   readonly artworkUrl?: string | null;
 }
 
-function getTrackLabel(track: ReleaseSidebarTrack): string {
+function getCanonicalTrackLabel(track: ReleaseSidebarTrack): string {
   return track.discNumber > 1
     ? `${track.discNumber}-${track.trackNumber}`
     : String(track.trackNumber);
+}
+
+function getDisplayTrackLabel(params: {
+  track: ReleaseSidebarTrack;
+  index: number;
+  tracks: readonly ReleaseSidebarTrack[];
+  totalTracks: number;
+}): string {
+  const { track, index, tracks, totalTracks } = params;
+  const isPartialSubset = tracks.length < totalTracks;
+  const isSingleDisc = tracks.every(item => item.discNumber === 1);
+
+  if (!isSingleDisc) {
+    return getCanonicalTrackLabel(track);
+  }
+
+  if (isPartialSubset) {
+    return String(index + 1);
+  }
+
+  return getCanonicalTrackLabel(track);
 }
 
 export function ReleaseTrackList({
@@ -113,6 +134,12 @@ export function ReleaseTrackList({
         <TrackListRow
           key={track.id}
           track={track}
+          trackLabel={getDisplayTrackLabel({
+            track,
+            index,
+            tracks,
+            totalTracks: release.totalTracks,
+          })}
           release={release}
           playbackState={playbackState}
           onToggleTrack={toggleTrack}
@@ -125,12 +152,14 @@ export function ReleaseTrackList({
 
 function TrackListRow({
   track,
+  trackLabel,
   release,
   playbackState,
   onToggleTrack,
   isLastRow,
 }: {
   readonly track: ReleaseSidebarTrack;
+  readonly trackLabel: string;
   readonly release: Release;
   readonly playbackState: {
     activeTrackId: string | null;
@@ -140,7 +169,6 @@ function TrackListRow({
   readonly onToggleTrack: (track: TrackControlSource) => Promise<void>;
   readonly isLastRow: boolean;
 }) {
-  const trackLabel = getTrackLabel(track);
   const playableUrl = track.audioUrl ?? track.previewUrl ?? undefined;
   const isActiveTrack = playbackState.activeTrackId === track.id;
   const isTrackPlaying = isActiveTrack && playbackState.isPlaying;

--- a/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
@@ -35,18 +35,10 @@ function getCanonicalTrackLabel(track: ReleaseSidebarTrack): string {
 function getDisplayTrackLabel(params: {
   track: ReleaseSidebarTrack;
   index: number;
-  tracks: readonly ReleaseSidebarTrack[];
-  totalTracks: number;
+  isSingleDiscPartialSubset: boolean;
 }): string {
-  const { track, index, tracks, totalTracks } = params;
-  const isPartialSubset = tracks.length < totalTracks;
-  const isSingleDisc = tracks.every(item => item.discNumber === 1);
-
-  if (!isSingleDisc) {
-    return getCanonicalTrackLabel(track);
-  }
-
-  if (isPartialSubset) {
+  const { track, index, isSingleDiscPartialSubset } = params;
+  if (isSingleDiscPartialSubset) {
     return String(index + 1);
   }
 
@@ -125,6 +117,14 @@ export function ReleaseTrackList({
     );
   }
 
+  const inferredDiscCount = Math.max(
+    1,
+    ...tracks.map(track => track.discNumber)
+  );
+  const isSingleDiscPartialSubset =
+    tracks.length < release.totalTracks &&
+    (release.totalDiscs ?? inferredDiscCount) === 1;
+
   return (
     <div className='space-y-1' data-testid='tracklist'>
       <p className='sr-only' aria-live='polite'>
@@ -137,8 +137,7 @@ export function ReleaseTrackList({
           trackLabel={getDisplayTrackLabel({
             track,
             index,
-            tracks,
-            totalTracks: release.totalTracks,
+            isSingleDiscPartialSubset,
           })}
           release={release}
           playbackState={playbackState}

--- a/apps/web/lib/discography/types.ts
+++ b/apps/web/lib/discography/types.ts
@@ -151,6 +151,7 @@ export interface ReleaseViewModel {
   upc?: string | null;
   label?: string | null;
   totalTracks: number;
+  totalDiscs?: number;
   totalDurationMs?: number | null;
   primaryIsrc?: string | null;
   genres?: string[];

--- a/apps/web/tests/components/organisms/release-sidebar/ReleaseTrackList.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/ReleaseTrackList.test.tsx
@@ -292,7 +292,7 @@ describe('ReleaseTrackList', () => {
   });
 
   it('keeps disc-track labels for multi-disc subsets', () => {
-    const release = { ...createMockRelease(), totalTracks: 10 };
+    const release = { ...createMockRelease(), totalTracks: 10, totalDiscs: 2 };
     const tracks = [
       createTrack(release, { id: 'track_1', trackNumber: 1, discNumber: 1 }),
       createTrack(release, {
@@ -324,6 +324,31 @@ describe('ReleaseTrackList', () => {
     expect(
       screen.getByTestId('release-track-control-track_2_3')
     ).toHaveTextContent('2-3');
+  });
+
+  it('keeps canonical numbering when a multi-disc subset only includes disc one tracks', () => {
+    const release = { ...createMockRelease(), totalTracks: 12, totalDiscs: 2 };
+    const tracks = [
+      createTrack(release, { id: 'track_1', trackNumber: 1, discNumber: 1 }),
+      createTrack(release, { id: 'track_5', trackNumber: 5, discNumber: 1 }),
+      createTrack(release, {
+        id: 'track_10',
+        trackNumber: 10,
+        discNumber: 1,
+      }),
+    ];
+
+    render(<ReleaseTrackList release={release} tracksOverride={tracks} />);
+
+    expect(
+      screen.getByTestId('release-track-control-track_1')
+    ).toHaveTextContent('1');
+    expect(
+      screen.getByTestId('release-track-control-track_5')
+    ).toHaveTextContent('5');
+    expect(
+      screen.getByTestId('release-track-control-track_10')
+    ).toHaveTextContent('10');
   });
 
   it('renders simplified loading, error, and empty states', () => {

--- a/apps/web/tests/components/organisms/release-sidebar/ReleaseTrackList.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/ReleaseTrackList.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ReleaseTrackList } from '@/components/organisms/release-sidebar/ReleaseTrackList';
+import type { ReleaseSidebarTrack } from '@/lib/discography/types';
 import { createMockRelease } from '@/tests/test-utils/factories';
 
 const { mockToggleTrack, mockQueryResult, mockPlaybackState } = vi.hoisted(
@@ -51,6 +52,38 @@ vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
   }),
 }));
 
+function createTrack(
+  release: ReturnType<typeof createMockRelease>,
+  overrides: Partial<ReleaseSidebarTrack> = {}
+): ReleaseSidebarTrack {
+  return {
+    id: 'track_1',
+    releaseId: release.id,
+    releaseSlug: release.slug,
+    title: 'Static Skies',
+    slug: 'static-skies',
+    smartLinkPath: `${release.smartLinkPath}/static-skies`,
+    trackNumber: 1,
+    discNumber: 1,
+    durationMs: 185000,
+    isrc: 'USRC17607839',
+    isExplicit: false,
+    previewUrl: 'https://example.com/preview.mp3',
+    audioUrl: null,
+    audioFormat: null,
+    previewSource: 'spotify',
+    previewVerification: 'verified',
+    providerConfidenceSummary: {
+      canonical: 1,
+      searchFallback: 0,
+      unknown: 0,
+      unresolvedProviders: [],
+    },
+    providers: [],
+    ...overrides,
+  };
+}
+
 describe('ReleaseTrackList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -68,39 +101,16 @@ describe('ReleaseTrackList', () => {
 
   it('renders a flat track list without the old playback summary or card chrome', () => {
     const release = createMockRelease();
+    const track = createTrack(release, {
+      providerConfidenceSummary: {
+        canonical: 1,
+        searchFallback: 1,
+        unknown: 0,
+        unresolvedProviders: [],
+      },
+    });
 
-    render(
-      <ReleaseTrackList
-        release={release}
-        tracksOverride={[
-          {
-            id: 'track_1',
-            releaseId: release.id,
-            releaseSlug: release.slug,
-            title: 'Static Skies',
-            slug: 'static-skies',
-            smartLinkPath: `${release.smartLinkPath}/static-skies`,
-            trackNumber: 1,
-            discNumber: 1,
-            durationMs: 185000,
-            isrc: 'USRC17607839',
-            isExplicit: false,
-            previewUrl: 'https://example.com/preview.mp3',
-            audioUrl: null,
-            audioFormat: null,
-            previewSource: 'spotify',
-            previewVerification: 'verified',
-            providerConfidenceSummary: {
-              canonical: 1,
-              searchFallback: 1,
-              unknown: 0,
-              unresolvedProviders: [],
-            },
-            providers: [],
-          },
-        ]}
-      />
-    );
+    render(<ReleaseTrackList release={release} tracksOverride={[track]} />);
 
     const tracklist = screen.getByTestId('tracklist');
     const row = screen.getByTestId('release-track-row-track_1');
@@ -135,33 +145,7 @@ describe('ReleaseTrackList', () => {
     render(
       <ReleaseTrackList
         release={release}
-        tracksOverride={[
-          {
-            id: 'track_1',
-            releaseId: release.id,
-            releaseSlug: release.slug,
-            title: 'Static Skies',
-            slug: 'static-skies',
-            smartLinkPath: `${release.smartLinkPath}/static-skies`,
-            trackNumber: 1,
-            discNumber: 1,
-            durationMs: 185000,
-            isrc: 'USRC17607839',
-            isExplicit: false,
-            previewUrl: 'https://example.com/preview.mp3',
-            audioUrl: null,
-            audioFormat: null,
-            previewSource: 'spotify',
-            previewVerification: 'verified',
-            providerConfidenceSummary: {
-              canonical: 1,
-              searchFallback: 0,
-              unknown: 0,
-              unresolvedProviders: [],
-            },
-            providers: [],
-          },
-        ]}
+        tracksOverride={[createTrack(release)]}
       />
     );
 
@@ -183,33 +167,7 @@ describe('ReleaseTrackList', () => {
     render(
       <ReleaseTrackList
         release={release}
-        tracksOverride={[
-          {
-            id: 'track_1',
-            releaseId: release.id,
-            releaseSlug: release.slug,
-            title: 'Static Skies',
-            slug: 'static-skies',
-            smartLinkPath: `${release.smartLinkPath}/static-skies`,
-            trackNumber: 1,
-            discNumber: 1,
-            durationMs: 185000,
-            isrc: 'USRC17607839',
-            isExplicit: false,
-            previewUrl: 'https://example.com/preview.mp3',
-            audioUrl: null,
-            audioFormat: null,
-            previewSource: 'spotify',
-            previewVerification: 'verified',
-            providerConfidenceSummary: {
-              canonical: 1,
-              searchFallback: 0,
-              unknown: 0,
-              unresolvedProviders: [],
-            },
-            providers: [],
-          },
-        ]}
+        tracksOverride={[createTrack(release)]}
       />
     );
 
@@ -221,42 +179,18 @@ describe('ReleaseTrackList', () => {
 
   it('starts playback from the left slot with the correct track payload', async () => {
     const user = userEvent.setup();
-    const release = createMockRelease({
-      title: 'Midnight Sun',
+    const release = {
+      ...createMockRelease({
+        title: 'Midnight Sun',
+      }),
       artistNames: ['Test Artist'],
       artworkUrl: 'https://cdn.example.com/cover.png',
-    });
+    };
 
     render(
       <ReleaseTrackList
         release={release}
-        tracksOverride={[
-          {
-            id: 'track_1',
-            releaseId: release.id,
-            releaseSlug: release.slug,
-            title: 'Static Skies',
-            slug: 'static-skies',
-            smartLinkPath: `${release.smartLinkPath}/static-skies`,
-            trackNumber: 1,
-            discNumber: 1,
-            durationMs: 185000,
-            isrc: 'USRC17607839',
-            isExplicit: false,
-            previewUrl: 'https://example.com/preview.mp3',
-            audioUrl: null,
-            audioFormat: null,
-            previewSource: 'spotify',
-            previewVerification: 'verified',
-            providerConfidenceSummary: {
-              canonical: 1,
-              searchFallback: 0,
-              unknown: 0,
-              unresolvedProviders: [],
-            },
-            providers: [],
-          },
-        ]}
+        tracksOverride={[createTrack(release)]}
       />
     );
 
@@ -273,8 +207,127 @@ describe('ReleaseTrackList', () => {
     });
   });
 
+  it('normalizes visible numbering for a sparse single-disc partial subset', () => {
+    const release = { ...createMockRelease(), totalTracks: 18 };
+    const sparseTracks = [
+      createTrack(release, {
+        id: 'track_1',
+        title: 'Free (with Ellie Goulding)',
+        slug: 'free-with-ellie-goulding',
+        smartLinkPath: `${release.smartLinkPath}/free-with-ellie-goulding`,
+        trackNumber: 1,
+      }),
+      createTrack(release, {
+        id: 'track_2',
+        title: 'How Deep Is Your Love',
+        slug: 'how-deep-is-your-love',
+        smartLinkPath: `${release.smartLinkPath}/how-deep-is-your-love`,
+        trackNumber: 2,
+      }),
+      createTrack(release, {
+        id: 'track_3',
+        title: 'This Is What You Came For (with Rihanna)',
+        slug: 'this-is-what-you-came-for',
+        smartLinkPath: `${release.smartLinkPath}/this-is-what-you-came-for`,
+        trackNumber: 3,
+      }),
+      createTrack(release, {
+        id: 'track_9',
+        title: 'Miracle (with Ellie Goulding)',
+        slug: 'miracle-with-ellie-goulding',
+        smartLinkPath: `${release.smartLinkPath}/miracle-with-ellie-goulding`,
+        trackNumber: 9,
+      }),
+      createTrack(release, {
+        id: 'track_11',
+        title: 'Desire (with Sam Smith)',
+        slug: 'desire-with-sam-smith',
+        smartLinkPath: `${release.smartLinkPath}/desire-with-sam-smith`,
+        trackNumber: 11,
+      }),
+      createTrack(release, {
+        id: 'track_13',
+        title: "Lovers In A Past Life (with Rag'n'Bone Man)",
+        slug: 'lovers-in-a-past-life-with-ragnbone-man',
+        smartLinkPath: `${release.smartLinkPath}/lovers-in-a-past-life-with-ragnbone-man`,
+        trackNumber: 13,
+      }),
+    ];
+
+    render(
+      <ReleaseTrackList release={release} tracksOverride={sparseTracks} />
+    );
+
+    const controlLabels = sparseTracks.map(track =>
+      screen
+        .getByTestId(`release-track-control-${track.id}`)
+        .textContent?.trim()
+    );
+
+    expect(controlLabels).toEqual(['1', '2', '3', '4', '5', '6']);
+    expect(
+      screen.getByRole('button', { name: 'Play Miracle (with Ellie Goulding)' })
+    ).toHaveTextContent('4');
+  });
+
+  it('keeps canonical numbering when the rendered list is complete', () => {
+    const release = { ...createMockRelease(), totalTracks: 3 };
+    const tracks = [
+      createTrack(release, { id: 'track_1', trackNumber: 1 }),
+      createTrack(release, { id: 'track_3', trackNumber: 3 }),
+      createTrack(release, { id: 'track_5', trackNumber: 5 }),
+    ];
+
+    render(<ReleaseTrackList release={release} tracksOverride={tracks} />);
+
+    expect(
+      screen.getByTestId('release-track-control-track_1')
+    ).toHaveTextContent('1');
+    expect(
+      screen.getByTestId('release-track-control-track_3')
+    ).toHaveTextContent('3');
+    expect(
+      screen.getByTestId('release-track-control-track_5')
+    ).toHaveTextContent('5');
+  });
+
+  it('keeps disc-track labels for multi-disc subsets', () => {
+    const release = { ...createMockRelease(), totalTracks: 10 };
+    const tracks = [
+      createTrack(release, { id: 'track_1', trackNumber: 1, discNumber: 1 }),
+      createTrack(release, {
+        id: 'track_2_1',
+        trackNumber: 1,
+        discNumber: 2,
+        title: 'Disc Two Intro',
+        slug: 'disc-two-intro',
+        smartLinkPath: `${release.smartLinkPath}/disc-two-intro`,
+      }),
+      createTrack(release, {
+        id: 'track_2_3',
+        trackNumber: 3,
+        discNumber: 2,
+        title: 'Disc Two Finale',
+        slug: 'disc-two-finale',
+        smartLinkPath: `${release.smartLinkPath}/disc-two-finale`,
+      }),
+    ];
+
+    render(<ReleaseTrackList release={release} tracksOverride={tracks} />);
+
+    expect(
+      screen.getByTestId('release-track-control-track_1')
+    ).toHaveTextContent('1');
+    expect(
+      screen.getByTestId('release-track-control-track_2_1')
+    ).toHaveTextContent('2-1');
+    expect(
+      screen.getByTestId('release-track-control-track_2_3')
+    ).toHaveTextContent('2-3');
+  });
+
   it('renders simplified loading, error, and empty states', () => {
-    const release = createMockRelease({ totalTracks: 2 });
+    const release = { ...createMockRelease(), totalTracks: 2 };
 
     mockQueryResult.isLoading = true;
     const { rerender } = render(<ReleaseTrackList release={release} />);

--- a/apps/web/tests/components/release-provider-matrix/TrackRow.test.tsx
+++ b/apps/web/tests/components/release-provider-matrix/TrackRow.test.tsx
@@ -121,4 +121,12 @@ describe('TrackRow', () => {
       audioUrl: 'https://cdn.example.com/track.mp3',
     });
   });
+
+  it('keeps canonical track numbers in the release matrix row', () => {
+    renderTrackRow({
+      track: createTrack({ id: 'track-9', trackNumber: 9 }),
+    });
+
+    expect(screen.getByText('9.')).toBeInTheDocument();
+  });
 });

--- a/apps/web/tests/unit/demo/demo-releases-experience.test.tsx
+++ b/apps/web/tests/unit/demo/demo-releases-experience.test.tsx
@@ -176,7 +176,10 @@ async function openReleasesMatrix() {
   return releasesMatrix;
 }
 
-async function openReleaseDrawer(title: string) {
+async function openReleaseDrawer(
+  title: string,
+  options?: { readonly requireSidebar?: boolean }
+) {
   const releasesMatrix = await openReleasesMatrix();
   const openButton = within(releasesMatrix).getByRole('button', {
     name: `Open ${title}`,
@@ -184,7 +187,21 @@ async function openReleaseDrawer(title: string) {
 
   fireEvent.click(openButton);
 
-  await screen.findByTestId('release-sidebar');
+  if (options?.requireSidebar) {
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('release-sidebar')).toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
+    return;
+  }
+
+  await waitFor(() => {
+    expect(screen.getAllByText(hasTextContent(title)).length).toBeGreaterThan(
+      1
+    );
+  });
 }
 
 describe('DemoReleasesExperience', () => {
@@ -228,8 +245,8 @@ describe('DemoReleasesExperience', () => {
   it('normalizes sparse track numbering in the release drawer tracks tab', async () => {
     renderDemo();
 
-    await openReleaseDrawer('96 Months');
-    fireEvent.click(screen.getByTestId('drawer-tab-tracks'));
+    await openReleaseDrawer('96 Months', { requireSidebar: true });
+    fireEvent.click(await screen.findByTestId('drawer-tab-tracks'));
 
     const tracklist = await screen.findByTestId('tracklist');
     const trackButtons = within(tracklist)

--- a/apps/web/tests/unit/demo/demo-releases-experience.test.tsx
+++ b/apps/web/tests/unit/demo/demo-releases-experience.test.tsx
@@ -161,38 +161,46 @@ function hasTextContent(text: string) {
     node?.textContent?.includes(text) ?? false;
 }
 
+async function openReleasesMatrix() {
+  const releasesNavLabel = screen
+    .getAllByText('Releases')
+    .find(node => node.closest('button'));
+  expect(releasesNavLabel).toBeTruthy();
+  fireEvent.click(releasesNavLabel?.closest('button') as HTMLButtonElement);
+
+  const releasesMatrix = await screen.findByTestId('releases-matrix');
+  fireEvent.click(
+    within(releasesMatrix).getByRole('tab', { name: 'Releases' })
+  );
+
+  return releasesMatrix;
+}
+
+async function openReleaseDrawer(title: string) {
+  const releasesMatrix = await openReleasesMatrix();
+  const openButton = within(releasesMatrix).getByRole('button', {
+    name: `Open ${title}`,
+  });
+
+  fireEvent.click(openButton);
+
+  await screen.findByTestId('release-sidebar');
+}
+
 describe('DemoReleasesExperience', () => {
   it('renders fixture data and opens the selected release in the drawer', async () => {
     renderDemo();
 
     // The sidebar nav has a Releases tab and it appears in the breadcrumb
     expect(screen.getAllByText('Releases').length).toBeGreaterThan(0);
-
-    const releasesNavLabel = screen
-      .getAllByText('Releases')
-      .find(node => node.closest('button'));
-    expect(releasesNavLabel).toBeTruthy();
-    fireEvent.click(releasesNavLabel?.closest('button') as HTMLButtonElement);
-
-    const releasesMatrix = await screen.findByTestId('releases-matrix');
-    fireEvent.click(
-      within(releasesMatrix).getByRole('tab', { name: 'Releases' })
-    );
+    await openReleaseDrawer('Blessings featuring Clementine Douglas');
 
     // Release titles should appear in the list
     expect(
-      within(releasesMatrix).getAllByText(
+      screen.getAllByText(
         hasTextContent('Blessings featuring Clementine Douglas')
       ).length
-    ).toBeGreaterThan(0);
-
-    // Click a release row to open the detail drawer
-    const releaseTitle = within(releasesMatrix).getAllByText(
-      hasTextContent('Blessings featuring Clementine Douglas')
-    )[0];
-    fireEvent.click(
-      releaseTitle.closest('tr') ?? releaseTitle.closest('td') ?? releaseTitle
-    );
+    ).toBeGreaterThan(1);
 
     // Selecting a row should surface the release details alongside the table.
     await waitFor(() => {
@@ -207,16 +215,7 @@ describe('DemoReleasesExperience', () => {
   it('renders release data in the table', async () => {
     renderDemo();
 
-    const releasesNavLabel = screen
-      .getAllByText('Releases')
-      .find(node => node.closest('button'));
-    expect(releasesNavLabel).toBeTruthy();
-    fireEvent.click(releasesNavLabel?.closest('button') as HTMLButtonElement);
-
-    const releasesMatrix = await screen.findByTestId('releases-matrix');
-    fireEvent.click(
-      within(releasesMatrix).getByRole('tab', { name: 'Releases' })
-    );
+    const releasesMatrix = await openReleasesMatrix();
 
     // The table should contain mock release titles
     expect(
@@ -224,5 +223,46 @@ describe('DemoReleasesExperience', () => {
         hasTextContent('Blessings featuring Clementine Douglas')
       ).length
     ).toBeGreaterThan(0);
+  });
+
+  it('normalizes sparse track numbering in the release drawer tracks tab', async () => {
+    renderDemo();
+
+    await openReleaseDrawer('96 Months');
+    fireEvent.click(screen.getByTestId('drawer-tab-tracks'));
+
+    const tracklist = await screen.findByTestId('tracklist');
+    const trackButtons = within(tracklist)
+      .getAllByRole('button')
+      .map(button => button.textContent?.trim());
+
+    expect(trackButtons).toEqual(['1', '2', '3', '4', '5', '6']);
+    expect(
+      screen.getByTestId('release-track-control-calvin-96-months-track-1')
+    ).toHaveTextContent('1');
+    expect(
+      screen.getByTestId('release-track-control-calvin-96-months-track-9')
+    ).toHaveTextContent('4');
+    expect(
+      screen.getByTestId('release-track-control-calvin-96-months-track-11')
+    ).toHaveTextContent('5');
+    expect(
+      screen.getByTestId('release-track-control-calvin-96-months-track-13')
+    ).toHaveTextContent('6');
+    expect(
+      within(tracklist).getByText('Free (with Ellie Goulding)')
+    ).toBeInTheDocument();
+    expect(
+      within(tracklist).getByText('Miracle (with Ellie Goulding)')
+    ).toBeInTheDocument();
+    expect(
+      within(tracklist).getByText('Desire (with Sam Smith)')
+    ).toBeInTheDocument();
+    expect(
+      within(tracklist).getByText("Lovers In A Past Life (with Rag'n'Bone Man)")
+    ).toBeInTheDocument();
+    expect(within(tracklist).queryByText('9')).not.toBeInTheDocument();
+    expect(within(tracklist).queryByText('11')).not.toBeInTheDocument();
+    expect(within(tracklist).queryByText('13')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/demo/mock-release-data.test.ts
+++ b/apps/web/tests/unit/demo/mock-release-data.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEMO_RELEASE_SIDEBAR_FIXTURES,
+  DEMO_RELEASE_VIEW_MODELS,
+} from '@/features/demo/mock-release-data';
+
+describe('mock release data', () => {
+  it('keeps the 96 Months sidebar fixture sparse relative to the full release', () => {
+    const release = DEMO_RELEASE_VIEW_MODELS.find(
+      item => item.id === 'calvin-96-months'
+    );
+    const tracks = DEMO_RELEASE_SIDEBAR_FIXTURES['calvin-96-months']?.tracks;
+
+    expect(release).toBeDefined();
+    expect(release?.totalTracks).toBe(18);
+    expect(tracks).toBeDefined();
+    expect(tracks).toHaveLength(6);
+    expect(tracks?.map(track => track.trackNumber)).toEqual([
+      1, 2, 3, 9, 11, 13,
+    ]);
+    expect(tracks?.length ?? 0).toBeLessThan(release?.totalTracks ?? 0);
+  });
+});


### PR DESCRIPTION
## Summary
- normalize release sidebar track labels only for sparse single-disc partial subsets
- keep sparse demo source data intact and add fixture, component, screen, and matrix regression coverage
- stabilize the demo release drawer test helper found during exhaustive QA

## Review
Pre-Landing Review: No issues found.

## Verification
- `doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web exec vitest run tests/components/organisms/release-sidebar/ReleaseTrackList.test.tsx tests/unit/demo/demo-releases-experience.test.tsx tests/unit/demo/mock-release-data.test.ts tests/components/release-provider-matrix/TrackRow.test.tsx`
- `pnpm --filter @jovie/web run typecheck`
- `pnpm exec eslint components/organisms/release-sidebar/ReleaseTrackList.tsx tests/components/organisms/release-sidebar/ReleaseTrackList.test.tsx tests/components/release-provider-matrix/TrackRow.test.tsx tests/unit/demo/demo-releases-experience.test.tsx tests/unit/demo/mock-release-data.test.ts`
- `git push -u origin itstimwhite/track-qa-ship` pre-push hook, which ran `biome check .`, `pnpm --filter=@jovie/web run next:proxy-guard`, `pnpm --filter=@jovie/web run tailwind:check`, `pnpm --filter=@jovie/web run typecheck`, and `pnpm --filter=@jovie/web run lint`

## Notes
- The targeted Vitest run still emits the existing mocked `next/image` `blurDataURL` warning in `demo-releases-experience.test.tsx`, but the tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes — Version 26.4.157

* **Bug Fixes**
  * Demo release drawers now show renumbered, sequential track lists for sparse single-disc partial subsets in the sidebar while keeping canonical numbers unchanged elsewhere.
  * Added a release-matrix guardrail to prevent unintended canonical renumbering outside the sidebar.

* **Tests**
  * Added regression coverage for sparse demo release fixtures, sidebar numbering, release-drawer flow, and matrix behavior.
  * Stabilized demo drawer test helpers to reduce timing flakiness.

* **Chores**
  * Bumped package/version metadata and updated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->