### PR TITLE
fix: reduce cognitive complexity in ChatMessage and playlist fallback

### DIFF
--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -57,6 +57,31 @@ function isSocialLinkRemovalResult(
   );
 }
 
+function renderPitchResultCard(
+  toolInvocation: ToolInvocationPart
+): React.ReactNode {
+  const result = toolInvocation.result as {
+    success: boolean;
+    releaseTitle?: string;
+    pitches?: {
+      spotify: string;
+      appleMusic: string;
+      amazon: string;
+      generic: string;
+    };
+    error?: string;
+  };
+
+  return (
+    <ChatPitchCard
+      state={result.success ? 'success' : 'error'}
+      releaseTitle={result.releaseTitle}
+      pitches={result.pitches}
+      error={result.error}
+    />
+  );
+}
+
 function renderToolCard(
   toolInvocation: ToolInvocationPart,
   profileId?: string
@@ -133,26 +158,7 @@ function renderToolCard(
     toolInvocation.toolName === 'generateReleasePitch' &&
     toolInvocation.state === 'result'
   ) {
-    const result = toolInvocation.result as {
-      success: boolean;
-      releaseTitle?: string;
-      pitches?: {
-        spotify: string;
-        appleMusic: string;
-        amazon: string;
-        generic: string;
-      };
-      error?: string;
-    };
-
-    return (
-      <ChatPitchCard
-        state={result.success ? 'success' : 'error'}
-        releaseTitle={result.releaseTitle}
-        pitches={result.pitches}
-        error={result.error}
-      />
-    );
+    return renderPitchResultCard(toolInvocation);
   }
 
   return null;

--- a/apps/web/lib/profile/featured-playlist-fallback.ts
+++ b/apps/web/lib/profile/featured-playlist-fallback.ts
@@ -102,20 +102,7 @@ export async function refreshFeaturedPlaylistFallbackCandidate(input: {
     }
   } else if (dismissedPlaylistId === discoveredCandidate.playlistId) {
     return;
-  } else if (
-    currentConfirmed &&
-    currentConfirmed.playlistId !== discoveredCandidate.playlistId
-  ) {
-    if (currentCandidate) {
-      nextSettings = {
-        ...currentSettings,
-        featuredPlaylistFallbackCandidate: null,
-      };
-    }
-  } else if (
-    currentConfirmed &&
-    currentConfirmed.playlistId === discoveredCandidate.playlistId
-  ) {
+  } else if (currentConfirmed) {
     if (currentCandidate) {
       nextSettings = {
         ...currentSettings,


### PR DESCRIPTION
## Summary
Reduces SonarCloud S3776 cognitive complexity in 2 files:
- **ChatMessage.tsx** (`renderToolCard`, 16→14): Extract pitch result rendering to `renderPitchResultCard` helper function, removing a nested ternary from the main function
- **featured-playlist-fallback.ts** (`refreshFeaturedPlaylistFallbackCandidate`, 17→~13): Merge two identical `else if` branches that both clear the candidate when a confirmed playlist exists — the playlistId comparison was irrelevant since both branches had the same action

## SonarCloud Rules Addressed
- `S3776`: Refactor this function to reduce its Cognitive Complexity (2 instances)

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] No behavior changes (identical branch merge + extraction only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization in chat message rendering
  * Simplified playlist fallback selection logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->