### PR TITLE
feat(home): focus-aware accent aura around hero search input

### DIFF
--- a/apps/web/components/features/home/HeroSpotifySearch.tsx
+++ b/apps/web/components/features/home/HeroSpotifySearch.tsx
@@ -16,6 +16,7 @@ import { APP_ROUTES } from '@/constants/routes';
 import { type SpotifyArtistResult, useArtistSearchQuery } from '@/lib/queries';
 import { cn } from '@/lib/utils';
 import { handleActivationKeyDown } from '@/lib/utils/keyboard';
+import { InputAuraFrame } from './InputAuraFrame';
 
 const LOADING_SKELETON_KEYS = ['skeleton-1', 'skeleton-2', 'skeleton-3'];
 
@@ -247,72 +248,78 @@ export function HeroSpotifySearch() {
       <label htmlFor='hero-spotify-search' className='sr-only'>
         Search Spotify artists or paste a link
       </label>
-      <div
-        className={cn(
-          'w-full flex items-center gap-3 rounded-xl border px-4 py-3 min-h-12 bg-surface-0',
-          'transition-all duration-slow',
-          shouldShowDropdown
-            ? 'border-focus ring-2 ring-focus/20'
-            : 'border-strong hover:border-focus'
-        )}
-      >
-        <div className='flex items-center justify-center w-6 h-6 rounded-full shrink-0 bg-brand-spotify-subtle'>
-          <SocialIcon
-            platform='spotify'
-            className='w-3.5 h-3.5 text-brand-spotify'
-          />
-        </div>
-        <input
-          ref={inputRef}
-          id='hero-spotify-search'
-          type='text'
-          value={searchQuery}
-          onChange={handleSearchInputChange}
-          onKeyDown={handleKeyDown}
-          onFocus={() => {
-            if (searchQuery.trim().length >= 1 && !isSpotifyUrl(searchQuery)) {
-              setShowResults(true);
+      <InputAuraFrame>
+        <div
+          className={cn(
+            'relative w-full flex items-center gap-3 rounded-xl border px-4 py-3 min-h-12 bg-surface-0',
+            'transition-all duration-200',
+            shouldShowDropdown
+              ? 'border-focus ring-2 ring-focus/20'
+              : 'border-strong hover:border-focus'
+          )}
+        >
+          <div className='flex items-center justify-center w-6 h-6 rounded-full shrink-0 bg-brand-spotify-subtle'>
+            <SocialIcon
+              platform='spotify'
+              className='w-3.5 h-3.5 text-brand-spotify'
+            />
+          </div>
+          <input
+            ref={inputRef}
+            id='hero-spotify-search'
+            type='text'
+            value={searchQuery}
+            onChange={handleSearchInputChange}
+            onKeyDown={handleKeyDown}
+            onFocus={() => {
+              if (
+                searchQuery.trim().length >= 1 &&
+                !isSpotifyUrl(searchQuery)
+              ) {
+                setShowResults(true);
+              }
+            }}
+            onBlur={e => {
+              // Keep dropdown open if focus moves to another element inside the container
+              if (containerRef.current?.contains(e.relatedTarget as Node))
+                return;
+              setShowResults(false);
+              setActiveIndex(-1);
+            }}
+            placeholder='Search your artist name or paste a Spotify link'
+            autoCapitalize='none'
+            autoCorrect='off'
+            autoComplete='off'
+            className='min-w-0 flex-1 bg-transparent text-sm text-primary-token focus-visible:outline-none'
+            role='combobox'
+            aria-expanded={shouldShowDropdown}
+            aria-controls='hero-spotify-results'
+            aria-activedescendant={
+              activeIndex >= 0 ? `hero-result-${activeIndex}` : undefined
             }
-          }}
-          onBlur={e => {
-            // Keep dropdown open if focus moves to another element inside the container
-            if (containerRef.current?.contains(e.relatedTarget as Node)) return;
-            setShowResults(false);
-            setActiveIndex(-1);
-          }}
-          placeholder='Search your artist name or paste a Spotify link'
-          autoCapitalize='none'
-          autoCorrect='off'
-          autoComplete='off'
-          className='min-w-0 flex-1 bg-transparent text-sm text-primary-token focus-visible:outline-none'
-          role='combobox'
-          aria-expanded={shouldShowDropdown}
-          aria-controls='hero-spotify-results'
-          aria-activedescendant={
-            activeIndex >= 0 ? `hero-result-${activeIndex}` : undefined
-          }
-        />
-        {showClaimButton ? (
-          <button
-            type='button'
-            disabled={claimButtonDisabled}
-            onClick={handleClaimArtist}
-            className={cn(
-              'shrink-0 inline-flex items-center justify-center gap-1.5 h-8 px-3 rounded-md text-xs font-semibold transition-colors focus-ring-themed',
-              claimButtonDisabled
-                ? 'bg-btn-primary/50 text-btn-primary-foreground/60 cursor-not-allowed'
-                : 'bg-btn-primary text-btn-primary-foreground'
-            )}
-          >
-            {isLoading && (
-              <div className='w-3 h-3 border-[1.5px] border-current border-t-transparent rounded-full animate-spin motion-reduce:animate-none' />
-            )}
-            Claim Artist
-          </button>
-        ) : (
-          <Search className='w-4 h-4 shrink-0 text-tertiary-token' />
-        )}
-      </div>
+          />
+          {showClaimButton ? (
+            <button
+              type='button'
+              disabled={claimButtonDisabled}
+              onClick={handleClaimArtist}
+              className={cn(
+                'shrink-0 inline-flex items-center justify-center gap-1.5 h-8 px-3 rounded-md text-xs font-semibold transition-colors focus-ring-themed',
+                claimButtonDisabled
+                  ? 'bg-btn-primary/50 text-btn-primary-foreground/60 cursor-not-allowed'
+                  : 'bg-btn-primary text-btn-primary-foreground'
+              )}
+            >
+              {isLoading && (
+                <div className='w-3 h-3 border-[1.5px] border-current border-t-transparent rounded-full animate-spin motion-reduce:animate-none' />
+              )}
+              Claim Artist
+            </button>
+          ) : (
+            <Search className='w-4 h-4 shrink-0 text-tertiary-token' />
+          )}
+        </div>
+      </InputAuraFrame>
 
       {/* Dropdown results */}
       {shouldShowDropdown && (

--- a/apps/web/components/features/home/HeroSpotifySearch.tsx
+++ b/apps/web/components/features/home/HeroSpotifySearch.tsx
@@ -258,7 +258,7 @@ export function HeroSpotifySearch() {
               : 'border-strong hover:border-focus'
           )}
         >
-          <div className='flex items-center justify-center w-6 h-6 rounded-full shrink-0 bg-brand-spotify-subtle'>
+          <div className='flex items-center justify-center size-6 rounded-full shrink-0 bg-brand-spotify-subtle'>
             <SocialIcon
               platform='spotify'
               className='w-3.5 h-3.5 text-brand-spotify'
@@ -319,188 +319,188 @@ export function HeroSpotifySearch() {
             <Search className='w-4 h-4 shrink-0 text-tertiary-token' />
           )}
         </div>
-      </InputAuraFrame>
 
-      {/* Dropdown results */}
-      {shouldShowDropdown && (
-        <div className='absolute z-50 w-full mt-2 rounded-xl border border-default overflow-hidden bg-surface-0 shadow-lg'>
-          <select
-            id='hero-spotify-results'
-            className='sr-only'
-            size={Math.min(totalItems, 6)}
-            aria-label='Spotify artist results'
-            value={
-              activeIndex === pasteUrlIndex
-                ? '__paste__'
-                : (results[activeIndex]?.id ?? '')
-            }
-            onChange={event => {
-              if (event.target.value === '__paste__') {
-                handlePasteUrlClick();
-                return;
+        {/* Dropdown results — inside InputAuraFrame so group-focus-within stays active while interacting */}
+        {shouldShowDropdown && (
+          <div className='absolute z-50 w-full mt-2 rounded-xl border border-default overflow-hidden bg-surface-0 shadow-lg'>
+            <select
+              id='hero-spotify-results'
+              className='sr-only'
+              size={Math.min(totalItems, 6)}
+              aria-label='Spotify artist results'
+              value={
+                activeIndex === pasteUrlIndex
+                  ? '__paste__'
+                  : (results[activeIndex]?.id ?? '')
               }
-              const selectedArtist = results.find(
-                artist => artist.id === event.target.value
-              );
-              if (selectedArtist) {
-                handleArtistSelect(selectedArtist);
-              }
-            }}
-          >
-            <option value='' disabled>
-              Select an artist
-            </option>
-            {results.map((artist, index) => (
-              <option
-                key={artist.id}
-                id={`hero-result-${index}`}
-                value={artist.id}
-              >
-                {artist.name}
-                {artist.followers
-                  ? ` — ${formatFollowers(artist.followers)}`
-                  : ''}
-              </option>
-            ))}
-            <option id={`hero-result-${pasteUrlIndex}`} value='__paste__'>
-              Paste a Spotify URL instead
-            </option>
-          </select>
-
-          {/* Loading skeleton */}
-          {state === 'loading' && results.length === 0 && (
-            <div className='p-3 space-y-2'>
-              {LOADING_SKELETON_KEYS.map(key => (
-                <div
-                  key={key}
-                  className='flex items-center gap-3 animate-pulse'
-                >
-                  <div className='w-10 h-10 rounded-full bg-surface-1' />
-                  <div className='flex-1 space-y-1'>
-                    <div className='h-4 w-32 rounded bg-surface-1' />
-                    <div className='h-3 w-20 rounded bg-surface-1' />
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {/* Empty state */}
-          {state === 'empty' && (
-            <div className='p-4 text-center'>
-              <p className='text-sm text-secondary-token'>No artists found</p>
-            </div>
-          )}
-
-          {/* Error state */}
-          {state === 'error' && (
-            <div className='p-4 text-center'>
-              <p className='text-sm text-error'>Search failed. Try again.</p>
-            </div>
-          )}
-
-          {/* Artist results */}
-          {results.length > 0 && (
-            <div
-              ref={resultsListRef}
-              className='max-h-64 overflow-y-auto'
-              aria-hidden='true'
+              onChange={event => {
+                if (event.target.value === '__paste__') {
+                  handlePasteUrlClick();
+                  return;
+                }
+                const selectedArtist = results.find(
+                  artist => artist.id === event.target.value
+                );
+                if (selectedArtist) {
+                  handleArtistSelect(selectedArtist);
+                }
+              }}
             >
+              <option value='' disabled>
+                Select an artist
+              </option>
               {results.map((artist, index) => (
-                <button
+                <option
                   key={artist.id}
-                  type='button'
-                  tabIndex={0}
-                  className={cn(
-                    'flex items-center gap-3 p-3 cursor-pointer transition-colors border-0 bg-transparent w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/10 dark:focus-visible:ring-white/20 focus-visible:ring-inset',
-                    index === activeIndex && 'bg-surface-1'
-                  )}
-                  onClick={() => handleArtistSelect(artist)}
-                  onKeyDown={event =>
-                    handleActivationKeyDown(event, () =>
-                      handleArtistSelect(artist)
-                    )
-                  }
-                  onMouseEnter={() => setActiveIndex(index)}
+                  id={`hero-result-${index}`}
+                  value={artist.id}
                 >
-                  <div className='w-10 h-10 rounded-full overflow-hidden shrink-0 relative bg-surface-1'>
-                    {artist.imageUrl ? (
-                      <Image
-                        src={artist.imageUrl}
-                        alt={artist.name}
-                        fill
-                        sizes='40px'
-                        className='object-cover'
-                        unoptimized
-                      />
-                    ) : (
-                      <div className='w-full h-full flex items-center justify-center'>
-                        <SocialIcon
-                          platform='spotify'
-                          className='w-5 h-5 text-tertiary-token'
+                  {artist.name}
+                  {artist.followers
+                    ? ` — ${formatFollowers(artist.followers)}`
+                    : ''}
+                </option>
+              ))}
+              <option id={`hero-result-${pasteUrlIndex}`} value='__paste__'>
+                Paste a Spotify URL instead
+              </option>
+            </select>
+
+            {/* Loading skeleton */}
+            {state === 'loading' && results.length === 0 && (
+              <div className='p-3 space-y-2'>
+                {LOADING_SKELETON_KEYS.map(key => (
+                  <div
+                    key={key}
+                    className='flex items-center gap-3 animate-pulse'
+                  >
+                    <div className='w-10 h-10 rounded-full bg-surface-1' />
+                    <div className='flex-1 space-y-1'>
+                      <div className='h-4 w-32 rounded bg-surface-1' />
+                      <div className='h-3 w-20 rounded bg-surface-1' />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Empty state */}
+            {state === 'empty' && (
+              <div className='p-4 text-center'>
+                <p className='text-sm text-secondary-token'>No artists found</p>
+              </div>
+            )}
+
+            {/* Error state */}
+            {state === 'error' && (
+              <div className='p-4 text-center'>
+                <p className='text-sm text-error'>Search failed. Try again.</p>
+              </div>
+            )}
+
+            {/* Artist results */}
+            {results.length > 0 && (
+              <div
+                ref={resultsListRef}
+                className='max-h-64 overflow-y-auto'
+                aria-hidden='true'
+              >
+                {results.map((artist, index) => (
+                  <button
+                    key={artist.id}
+                    type='button'
+                    tabIndex={0}
+                    className={cn(
+                      'flex items-center gap-3 p-3 cursor-pointer transition-colors border-0 bg-transparent w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/10 dark:focus-visible:ring-white/20 focus-visible:ring-inset',
+                      index === activeIndex && 'bg-surface-1'
+                    )}
+                    onClick={() => handleArtistSelect(artist)}
+                    onKeyDown={event =>
+                      handleActivationKeyDown(event, () =>
+                        handleArtistSelect(artist)
+                      )
+                    }
+                    onMouseEnter={() => setActiveIndex(index)}
+                  >
+                    <div className='w-10 h-10 rounded-full overflow-hidden shrink-0 relative bg-surface-1'>
+                      {artist.imageUrl ? (
+                        <Image
+                          src={artist.imageUrl}
+                          alt={artist.name}
+                          fill
+                          sizes='40px'
+                          className='object-cover'
+                          unoptimized
                         />
+                      ) : (
+                        <div className='w-full h-full flex items-center justify-center'>
+                          <SocialIcon
+                            platform='spotify'
+                            className='w-5 h-5 text-tertiary-token'
+                          />
+                        </div>
+                      )}
+                    </div>
+                    <div className='flex-1 min-w-0'>
+                      <div className='font-medium truncate text-sm text-primary-token'>
+                        {artist.name}
+                      </div>
+                      {artist.followers ? (
+                        <div className='text-xs text-tertiary-token'>
+                          {formatFollowers(artist.followers)}
+                        </div>
+                      ) : null}
+                    </div>
+                    {artist.isClaimed && (
+                      <span className='shrink-0 rounded-full bg-brand-spotify-subtle px-2 py-0.5 text-[10px] font-semibold text-brand-spotify'>
+                        On Jovie
+                      </span>
+                    )}
+                    {artist.verified && (
+                      <div
+                        className='shrink-0 text-brand-spotify'
+                        data-testid='verified-badge'
+                      >
+                        <BadgeCheck className='h-4 w-4' aria-hidden='true' />
                       </div>
                     )}
-                  </div>
-                  <div className='flex-1 min-w-0'>
-                    <div className='font-medium truncate text-sm text-primary-token'>
-                      {artist.name}
-                    </div>
-                    {artist.followers ? (
-                      <div className='text-xs text-tertiary-token'>
-                        {formatFollowers(artist.followers)}
-                      </div>
-                    ) : null}
-                  </div>
-                  {artist.isClaimed && (
-                    <span className='shrink-0 rounded-full bg-brand-spotify-subtle px-2 py-0.5 text-[10px] font-semibold text-brand-spotify'>
-                      On Jovie
-                    </span>
-                  )}
-                  {artist.verified && (
-                    <div
-                      className='shrink-0 text-brand-spotify'
-                      data-testid='verified-badge'
-                    >
-                      <BadgeCheck className='h-4 w-4' aria-hidden='true' />
-                    </div>
-                  )}
-                </button>
-              ))}
-            </div>
-          )}
-
-          {/* "Paste URL" option */}
-          <button
-            type='button'
-            tabIndex={0}
-            className={cn(
-              'flex items-center gap-3 p-3 cursor-pointer transition-colors bg-transparent w-full text-left border-t border-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/10 dark:focus-visible:ring-white/20 focus-visible:ring-inset',
-              activeIndex === pasteUrlIndex && 'bg-surface-1'
+                  </button>
+                ))}
+              </div>
             )}
-            onClick={handlePasteUrlClick}
-            onKeyDown={event =>
-              handleActivationKeyDown(event, () => handlePasteUrlClick())
-            }
-            onMouseEnter={() => setActiveIndex(pasteUrlIndex)}
-          >
-            <div className='w-10 h-10 rounded-full flex items-center justify-center bg-surface-1'>
-              <Link2
-                className='h-5 w-5 text-tertiary-token'
-                aria-hidden='true'
-              />
-            </div>
-            <div className='flex-1'>
-              <div className='font-medium text-sm text-primary-token'>
-                Paste a Spotify URL instead
+
+            {/* "Paste URL" option */}
+            <button
+              type='button'
+              tabIndex={0}
+              className={cn(
+                'flex items-center gap-3 p-3 cursor-pointer transition-colors bg-transparent w-full text-left border-t border-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/10 dark:focus-visible:ring-white/20 focus-visible:ring-inset',
+                activeIndex === pasteUrlIndex && 'bg-surface-1'
+              )}
+              onClick={handlePasteUrlClick}
+              onKeyDown={event =>
+                handleActivationKeyDown(event, () => handlePasteUrlClick())
+              }
+              onMouseEnter={() => setActiveIndex(pasteUrlIndex)}
+            >
+              <div className='w-10 h-10 rounded-full flex items-center justify-center bg-surface-1'>
+                <Link2
+                  className='h-5 w-5 text-tertiary-token'
+                  aria-hidden='true'
+                />
               </div>
-              <div className='text-xs text-tertiary-token'>
-                open.spotify.com/artist/...
+              <div className='flex-1'>
+                <div className='font-medium text-sm text-primary-token'>
+                  Paste a Spotify URL instead
+                </div>
+                <div className='text-xs text-tertiary-token'>
+                  open.spotify.com/artist/...
+                </div>
               </div>
-            </div>
-          </button>
-        </div>
-      )}
+            </button>
+          </div>
+        )}
+      </InputAuraFrame>
     </div>
   );
 }

--- a/apps/web/components/features/home/InputAuraFrame.tsx
+++ b/apps/web/components/features/home/InputAuraFrame.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 

--- a/apps/web/components/features/home/InputAuraFrame.tsx
+++ b/apps/web/components/features/home/InputAuraFrame.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+interface InputAuraFrameProps {
+  readonly children: ReactNode;
+  readonly className?: string;
+}
+
+export function InputAuraFrame({
+  children,
+  className,
+}: Readonly<InputAuraFrameProps>) {
+  return (
+    <div className={cn('group/aura relative', className)}>
+      <div
+        aria-hidden='true'
+        className={cn(
+          'pointer-events-none absolute -inset-[6px] overflow-hidden rounded-[1rem] opacity-40 blur-[5px]',
+          'transition-opacity duration-500 group-focus-within/aura:opacity-100',
+          "before:absolute before:left-1/2 before:top-1/2 before:h-[600px] before:w-[600px] before:-translate-x-1/2 before:-translate-y-1/2 before:rotate-[82deg] before:content-['']",
+          'before:bg-[conic-gradient(transparent,var(--color-accent-purple),transparent_10%,transparent_50%,var(--color-accent-pink),transparent_60%)]',
+          'before:transition-transform before:duration-[4000ms] before:ease-out',
+          'group-focus-within/aura:before:rotate-[442deg]',
+          'motion-reduce:before:transition-none motion-reduce:group-focus-within/aura:before:rotate-[82deg]'
+        )}
+      />
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a soft accent-colored glow around the homepage Spotify search input that activates on focus. The aura is purely presentational — dropdown behavior, keyboard flow, and a11y wiring are unchanged.

- New `InputAuraFrame` component (39 lines, no state, no branches) wraps the pill and paints a conic-gradient glow via a `before:` pseudo-element
- Gradient rotates 82° → 442° on focus-within, settles back on blur; `prefers-reduced-motion` holds it in place
- Colors pull from existing accent tokens (`--color-accent-purple`, `--color-accent-pink`); no new design tokens

## Test plan

- [x] 28/28 existing `HeroSpotifySearch` unit tests pass
- [x] Typecheck clean (`pnpm --filter web typecheck`)
- [x] Biome lint clean
- [x] Pre-commit + pre-push hooks green
- [ ] Manual: focus the hero search input at `/` — aura fades in, gradient rotates, dropdown still appears below unaffected
- [ ] Manual: System Settings → Reduce motion ON — aura still visible but no rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Homepage Spotify search input gains a soft, focus-driven accent “aura” with a slowly rotating conic gradient that settles on blur.
  * The aura is decorative and non-interactive, respects reduced-motion preferences (animation is held when requested), and does not change dropdown, keyboard, or accessibility behaviors.
* **Chores**
  * Release version bumped to 26.4.157.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->