### PR TITLE
refactor(ui): compose icon button atoms

### DIFF
--- a/apps/web/components/atoms/CircleIconButton.tsx
+++ b/apps/web/components/atoms/CircleIconButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Slot } from '@radix-ui/react-slot';
+import { Button } from '@jovie/ui';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
@@ -41,7 +41,10 @@ export type CircleIconButtonVariant =
   | 'pearlQuiet';
 
 export interface CircleIconButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  extends Omit<
+    React.ComponentProps<typeof Button>,
+    'size' | 'variant' | 'asChild'
+  > {
   /** Button content (typically an icon) */
   readonly children: React.ReactNode;
   /** Accessible label for screen readers */
@@ -70,49 +73,76 @@ const iconSizeStyles: Record<CircleIconButtonSize, string> = {
   lg: '[&>svg]:h-5 [&>svg]:w-5',
 };
 
-const variantStyles: Record<CircleIconButtonVariant, string> = {
+const variantStyles: Record<
+  CircleIconButtonVariant,
+  {
+    buttonVariant: React.ComponentProps<typeof Button>['variant'];
+    className: string;
+  }
+> = {
   // Surface - elevated card style with subtle border
-  surface: cn(
-    'border border-subtle bg-surface-1 text-primary-token',
-    'shadow-sm',
-    'hover:bg-surface-2 hover:text-primary-token hover:shadow-md'
-  ),
+  surface: {
+    buttonVariant: 'secondary',
+    className: cn(
+      'border border-subtle bg-surface-1 text-primary-token',
+      'shadow-sm',
+      'hover:bg-surface-2 hover:text-primary-token hover:shadow-md'
+    ),
+  },
   // Frosted - glassmorphic with backdrop blur
-  frosted: cn(
-    'border border-subtle bg-[color-mix(in_srgb,var(--linear-bg-surface-1)_84%,transparent)] text-primary-token backdrop-blur-sm',
-    'shadow-sm',
-    'hover:bg-[color-mix(in_srgb,var(--linear-bg-surface-2)_88%,transparent)]'
-  ),
+  frosted: {
+    buttonVariant: 'frosted-ghost',
+    className: cn(
+      'border border-subtle bg-[color-mix(in_srgb,var(--linear-bg-surface-1)_84%,transparent)] text-primary-token backdrop-blur-sm',
+      'shadow-sm',
+      'hover:bg-[color-mix(in_srgb,var(--linear-bg-surface-2)_88%,transparent)]'
+    ),
+  },
   // Ghost - transparent with hover background
-  ghost: cn(
-    'bg-transparent text-secondary-token',
-    'hover:bg-surface-1 hover:text-primary-token'
-  ),
+  ghost: {
+    buttonVariant: 'ghost',
+    className: cn(
+      'bg-transparent text-secondary-token',
+      'hover:bg-surface-1 hover:text-primary-token'
+    ),
+  },
   // Secondary - subtle background without border
-  secondary: cn(
-    'bg-surface-2 text-secondary-token',
-    'shadow-sm',
-    'hover:bg-surface-3 hover:text-primary-token'
-  ),
+  secondary: {
+    buttonVariant: 'secondary',
+    className: cn(
+      'bg-surface-2 text-secondary-token',
+      'shadow-sm',
+      'hover:bg-surface-3 hover:text-primary-token'
+    ),
+  },
   // Outline - transparent with visible border
-  outline: cn(
-    'border border-subtle bg-transparent text-tertiary-token',
-    'hover:bg-surface-1 hover:text-primary-token'
-  ),
+  outline: {
+    buttonVariant: 'outline',
+    className: cn(
+      'border border-subtle bg-transparent text-tertiary-token',
+      'hover:bg-surface-1 hover:text-primary-token'
+    ),
+  },
   // Pearl - public profile chrome
-  pearl: cn(
-    'border border-[color:var(--profile-pearl-border)] bg-[var(--profile-pearl-bg)] text-primary-token backdrop-blur-xl',
-    'shadow-[var(--profile-pearl-shadow)]',
-    'hover:bg-[var(--profile-pearl-bg-hover)] hover:text-primary-token',
-    'active:bg-[var(--profile-pearl-bg-active)]'
-  ),
-  pearlQuiet: cn(
-    'border border-transparent bg-transparent text-primary-token/78 backdrop-blur-xl',
-    'shadow-none',
-    'hover:border-[color:var(--profile-pearl-border)] hover:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_88%,transparent)] hover:text-primary-token hover:shadow-[0_10px_24px_rgba(10,12,18,0.1)]',
-    'focus-visible:border-[color:var(--profile-pearl-border)] focus-visible:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_92%,transparent)] focus-visible:text-primary-token focus-visible:shadow-[0_10px_24px_rgba(10,12,18,0.12)]',
-    'active:bg-[var(--profile-pearl-bg-active)] active:text-primary-token'
-  ),
+  pearl: {
+    buttonVariant: 'ghost',
+    className: cn(
+      'border border-[color:var(--profile-pearl-border)] bg-[var(--profile-pearl-bg)] text-primary-token backdrop-blur-xl',
+      'shadow-[var(--profile-pearl-shadow)]',
+      'hover:bg-[var(--profile-pearl-bg-hover)] hover:text-primary-token',
+      'active:bg-[var(--profile-pearl-bg-active)]'
+    ),
+  },
+  pearlQuiet: {
+    buttonVariant: 'ghost',
+    className: cn(
+      'border border-transparent bg-transparent text-primary-token/78 backdrop-blur-xl',
+      'shadow-none',
+      'hover:border-[color:var(--profile-pearl-border)] hover:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_88%,transparent)] hover:text-primary-token hover:shadow-[0_10px_24px_rgba(10,12,18,0.1)]',
+      'focus-visible:border-[color:var(--profile-pearl-border)] focus-visible:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_92%,transparent)] focus-visible:text-primary-token focus-visible:shadow-[0_10px_24px_rgba(10,12,18,0.12)]',
+      'active:bg-[var(--profile-pearl-bg-active)] active:text-primary-token'
+    ),
+  },
 };
 
 const baseStyles = cn(
@@ -122,9 +152,6 @@ const baseStyles = cn(
   'transition-all duration-150 ease-out',
   // Active state
   'active:scale-95',
-  // Focus ring using design system utility
-  'focus-ring-themed',
-  'focus-visible:ring-offset-[var(--color-bg-base)]',
   // Required for soft material treatments on profile chrome
   'relative isolate overflow-hidden',
   // Touch optimizations
@@ -150,24 +177,27 @@ export const CircleIconButton = React.forwardRef<
   },
   ref
 ) {
-  const Comp = asChild ? Slot : 'button';
+  const variantConfig = variantStyles[variant];
 
   return (
-    <Comp
+    <Button
       ref={ref}
-      type={asChild ? undefined : type}
+      asChild={asChild}
+      type={type}
+      variant={variantConfig.buttonVariant}
+      size='icon'
       className={cn(
         baseStyles,
         sizeStyles[size],
         iconSizeStyles[size],
-        variantStyles[variant],
+        variantConfig.className,
         className
       )}
       aria-label={ariaLabel}
       {...props}
     >
       {children}
-    </Comp>
+    </Button>
   );
 });
 

--- a/apps/web/components/atoms/CircleIconButton.tsx
+++ b/apps/web/components/atoms/CircleIconButton.tsx
@@ -183,7 +183,7 @@ export const CircleIconButton = React.forwardRef<
     <Button
       ref={ref}
       asChild={asChild}
-      type={type}
+      type={asChild ? undefined : type}
       variant={variantConfig.buttonVariant}
       size='icon'
       className={cn(

--- a/apps/web/components/atoms/InlineIconButton.tsx
+++ b/apps/web/components/atoms/InlineIconButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import type {
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
@@ -9,7 +10,7 @@ import type {
 import { cn } from '@/lib/utils';
 
 export const INLINE_ICON_BUTTON_BASE_CLASSNAME =
-  'inline-flex shrink-0 items-center justify-center rounded-full border border-transparent bg-transparent text-secondary-token leading-none transition-[opacity,background-color,color,box-shadow] duration-150 hover:bg-surface-1 focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus) [&_svg]:block';
+  'h-auto w-auto shrink-0 rounded-full border border-transparent bg-transparent p-0.5 text-secondary-token leading-none shadow-none transition-[opacity,background-color,color,box-shadow] duration-150 hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus) [&_svg]:block';
 
 export const INLINE_ICON_BUTTON_VISIBLE_CLASSNAME =
   'p-0.5 opacity-60 hover:opacity-100 focus-visible:opacity-100';
@@ -56,9 +57,11 @@ export function InlineIconButton(props: InlineIconButtonProps) {
     );
 
     return (
-      <a href={href} className={sharedClassName} {...anchorProps}>
-        {children}
-      </a>
+      <Button asChild variant='ghost' size='icon' className={sharedClassName}>
+        <a href={href} {...anchorProps}>
+          {children}
+        </a>
+      </Button>
     );
   }
 
@@ -79,8 +82,14 @@ export function InlineIconButton(props: InlineIconButtonProps) {
   );
 
   return (
-    <button type={type} className={sharedClassName} {...buttonProps}>
+    <Button
+      type={type}
+      variant='ghost'
+      size='icon'
+      className={sharedClassName}
+      {...buttonProps}
+    >
       {children}
-    </button>
+    </Button>
   );
 }

--- a/apps/web/tests/unit/atoms/CircleIconButton.test.tsx
+++ b/apps/web/tests/unit/atoms/CircleIconButton.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import Link from 'next/link';
 import { createRef } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -78,8 +79,7 @@ describe('CircleIconButton', () => {
   it('renders as child element when asChild is true', () => {
     render(
       <CircleIconButton ariaLabel='Link button' asChild>
-        {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- test only */}
-        <a href='/profile'>Back</a>
+        <Link href='/profile'>Back</Link>
       </CircleIconButton>
     );
     const link = screen.getByRole('link', { name: 'Link button' });

--- a/apps/web/tests/unit/atoms/InlineIconButton.test.tsx
+++ b/apps/web/tests/unit/atoms/InlineIconButton.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  INLINE_ICON_BUTTON_FADE_CLASSNAME,
+  INLINE_ICON_BUTTON_VISIBLE_CLASSNAME,
+  InlineIconButton,
+} from '@/components/atoms/InlineIconButton';
+import { expectNoA11yViolations } from '../../utils/a11y';
+
+describe('InlineIconButton', () => {
+  it('renders a button by default', () => {
+    render(
+      <InlineIconButton aria-label='Edit item'>
+        <svg aria-hidden='true' />
+      </InlineIconButton>
+    );
+
+    expect(screen.getByRole('button', { name: 'Edit item' })).toHaveAttribute(
+      'type',
+      'button'
+    );
+  });
+
+  it('renders an anchor when href is provided', () => {
+    render(
+      <InlineIconButton href='/items/1' aria-label='Open item'>
+        <svg aria-hidden='true' />
+      </InlineIconButton>
+    );
+
+    expect(screen.getByRole('link', { name: 'Open item' })).toHaveAttribute(
+      'href',
+      '/items/1'
+    );
+  });
+
+  it('uses the fade visibility class when fadeOnParentHover is enabled', () => {
+    render(
+      <InlineIconButton fadeOnParentHover aria-label='Remove item'>
+        <svg aria-hidden='true' />
+      </InlineIconButton>
+    );
+
+    expect(screen.getByRole('button', { name: 'Remove item' })).toHaveClass(
+      ...INLINE_ICON_BUTTON_FADE_CLASSNAME.split(' ')
+    );
+  });
+
+  it('uses the visible visibility class by default', () => {
+    render(
+      <InlineIconButton aria-label='Copy item'>
+        <svg aria-hidden='true' />
+      </InlineIconButton>
+    );
+
+    expect(screen.getByRole('button', { name: 'Copy item' })).toHaveClass(
+      ...INLINE_ICON_BUTTON_VISIBLE_CLASSNAME.split(' ')
+    );
+  });
+
+  it('calls onClick when activated', () => {
+    const handleClick = vi.fn();
+
+    render(
+      <InlineIconButton aria-label='Refresh item' onClick={handleClick}>
+        <svg aria-hidden='true' />
+      </InlineIconButton>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh item' }));
+    expect(handleClick).toHaveBeenCalledOnce();
+  });
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(
+      <InlineIconButton aria-label='Accessible inline icon'>
+        <svg aria-hidden='true' />
+      </InlineIconButton>
+    );
+
+    await expectNoA11yViolations(container);
+  });
+});


### PR DESCRIPTION
## Goal

Route the high-drift icon button atoms through the canonical `@jovie/ui` Button without changing their public APIs.

## What changed

- rewired `CircleIconButton` to compose `Button` and preserve its size/variant surface
- rewired `InlineIconButton` to use `Button` for button and anchor modes
- added focused unit coverage for `InlineIconButton`
- updated `CircleIconButton` tests for the new `asChild` path

## Verification

- `pnpm --filter @jovie/web exec vitest run tests/unit/atoms/CircleIconButton.test.tsx tests/unit/atoms/InlineIconButton.test.tsx`
- `pnpm --filter @jovie/web run typecheck`

## Notes

This PR is intentionally small. Badge unification, `LinearButton` removal, and token cleanup are shipping in separate follow-up PRs to stay within repo review limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Refined icon button component styling and focus behavior for improved keyboard navigation and visual consistency
  * Updated styling for icon button variants across the application

* **Tests**
  * Expanded test coverage for icon button components, including accessibility verification and event handling assertions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->