### PR TITLE
fix(chat): migrate tool event contract

### DIFF
--- a/apps/web/app/api/chat/conversations/[id]/messages/route.ts
+++ b/apps/web/app/api/chat/conversations/[id]/messages/route.ts
@@ -2,8 +2,12 @@ import { gateway } from '@ai-sdk/gateway';
 import { generateText } from 'ai';
 import { and, eq, isNull } from 'drizzle-orm';
 import { after, NextResponse } from 'next/server';
-import { z } from 'zod';
 import { getSessionContext } from '@/lib/auth/session';
+import {
+  type ChatPersistenceMessage,
+  chatPersistenceBatchSchema,
+  chatPersistenceMessageSchema,
+} from '@/lib/chat/tool-events';
 import { TITLE_MODEL } from '@/lib/constants/ai-models';
 import { db } from '@/lib/db';
 import { chatConversations, chatMessages } from '@/lib/db/schema/chat';
@@ -13,16 +17,6 @@ import { logger } from '@/lib/utils/logger';
 import { getSessionErrorResponse } from '../../../session-error-response';
 
 export const runtime = 'nodejs';
-
-const messageSchema = z.object({
-  role: z.enum(['user', 'assistant']),
-  content: z.string().min(1).max(50000),
-  toolCalls: z.array(z.record(z.string(), z.unknown())).optional(),
-});
-
-const batchMessageSchema = z.object({
-  messages: z.array(messageSchema).min(1).max(100),
-});
 
 interface RouteParams {
   params: Promise<{ id: string }>;
@@ -35,7 +29,7 @@ interface RouteParams {
  */
 async function maybeGenerateTitle(
   conversationId: string,
-  messages: z.infer<typeof messageSchema>[]
+  messages: ChatPersistenceMessage[]
 ): Promise<void> {
   const userMessage = messages.find(m => m.role === 'user');
   if (!userMessage?.content) return;
@@ -144,18 +138,30 @@ export async function POST(req: Request, { params }: RouteParams) {
     }
 
     // Try to parse as batch first, then as single message
-    const batchResult = batchMessageSchema.safeParse(body);
-    const singleResult = messageSchema.safeParse(body);
+    const batchResult = chatPersistenceBatchSchema.safeParse(body);
+    const singleResult = chatPersistenceMessageSchema.safeParse(body);
 
-    let messagesToInsert: z.infer<typeof messageSchema>[];
+    let messagesToInsert: ChatPersistenceMessage[];
 
     if (batchResult.success) {
       messagesToInsert = batchResult.data.messages;
     } else if (singleResult.success) {
       messagesToInsert = [singleResult.data];
     } else {
+      const validationError =
+        isRecord(body) && Array.isArray(body.messages)
+          ? batchResult.error
+          : singleResult.error;
+      logger.warn(
+        'Rejected invalid chat message payload',
+        {
+          conversationId,
+          issueCount: validationError.issues.length,
+        },
+        'chat-messages'
+      );
       return NextResponse.json(
-        { error: 'Invalid message format', details: singleResult.error.issues },
+        { error: 'Invalid message format', details: validationError.issues },
         { status: 400, headers: NO_CACHE_HEADERS }
       );
     }
@@ -219,4 +225,8 @@ export async function POST(req: Request, { params }: RouteParams) {
       { status: 500, headers: NO_CACHE_HEADERS }
     );
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
 }

--- a/apps/web/app/api/chat/conversations/[id]/route.ts
+++ b/apps/web/app/api/chat/conversations/[id]/route.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, lt } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { getSessionContext } from '@/lib/auth/session';
+import { decodeToolEvents } from '@/lib/chat/tool-events';
 import { db } from '@/lib/db';
 import { chatConversations, chatMessages } from '@/lib/db/schema/chat';
 import { captureError } from '@/lib/error-tracking';
@@ -93,8 +94,26 @@ export async function GET(req: Request, { params }: RouteParams) {
     if (hasMore) rows.pop();
     rows.reverse();
 
+    const messages = rows.map(row => {
+      const decodedToolCalls = decodeToolEvents(row.toolCalls);
+
+      if (decodedToolCalls.source === 'legacy') {
+        logger.warn(
+          'Decoded legacy tool calls while loading conversation',
+          { conversationId: id, messageId: row.id },
+          'chat-conversation'
+        );
+      }
+
+      return {
+        ...row,
+        toolCalls:
+          decodedToolCalls.events.length > 0 ? decodedToolCalls.events : null,
+      };
+    });
+
     return NextResponse.json(
-      { conversation, messages: rows, hasMore },
+      { conversation, messages, hasMore },
       { status: 200, headers: NO_STORE_HEADERS }
     );
   } catch (error) {

--- a/apps/web/components/features/dashboard/organisms/InlineChatArea.tsx
+++ b/apps/web/components/features/dashboard/organisms/InlineChatArea.tsx
@@ -27,30 +27,15 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useMemo,
   useRef,
 } from 'react';
 import { BrandLogo } from '@/components/atoms/BrandLogo';
-import { ChatAlbumArtCard } from '@/components/jovie/components/ChatAlbumArtCard';
-import { ChatAnalyticsCard } from '@/components/jovie/components/ChatAnalyticsCard';
-import { ChatAvatarUploadCard } from '@/components/jovie/components/ChatAvatarUploadCard';
-import { ChatLinkConfirmationCard } from '@/components/jovie/components/ChatLinkConfirmationCard';
 import { useJovieChat } from '@/components/jovie/hooks';
-import {
-  type ArtistContext,
-  type ChatInsightsToolResult,
-  isChatAlbumArtToolResult,
-  isToolInvocationPart,
-  type SocialLinkToolResult,
-  type ToolInvocationPart,
-} from '@/components/jovie/types';
+import { ToolPartsRenderer } from '@/components/jovie/tool-ui';
+import { type ArtistContext, type MessagePart } from '@/components/jovie/types';
 import { getMessageText } from '@/components/jovie/utils';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { cn } from '@/lib/utils';
-import {
-  type ProfileEditPreview,
-  ProfileEditPreviewCard,
-} from './ProfileEditPreviewCard';
 
 interface InlineChatAreaProps {
   /** @deprecated Use profileId instead. Client-provided artist context for backward compatibility. */
@@ -70,26 +55,15 @@ export interface InlineChatAreaRef {
   isLoading: boolean;
 }
 
-// Helper to extract tool invocation parts from message
-function getToolInvocations(
-  parts: Array<{ type: string }>
-): ToolInvocationPart[] {
-  return parts.filter(isToolInvocationPart);
-}
-
 /** Memoized per-message renderer to avoid reprocessing tool invocations on every render. */
 const InlineChatMessage = memo(function InlineChatMessage({
   message,
   profileId,
 }: {
-  message: { id: string; role: string; parts: Array<{ type: string }> };
+  message: { id: string; role: string; parts: MessagePart[] };
   profileId: string;
 }) {
   const textContent = getMessageText(message.parts);
-  const toolInvocations = useMemo(
-    () => getToolInvocations(message.parts),
-    [message.parts]
-  );
 
   return (
     <div className='space-y-3'>
@@ -125,90 +99,14 @@ const InlineChatMessage = memo(function InlineChatMessage({
         </div>
       )}
 
-      {toolInvocations.map(toolInvocation => {
-        const result = toolInvocation.result as
-          | Record<string, unknown>
-          | undefined;
-        if (
-          toolInvocation.toolName === 'proposeProfileEdit' &&
-          toolInvocation.state === 'result' &&
-          result?.success &&
-          result.preview
-        ) {
-          return (
-            <div key={toolInvocation.toolInvocationId} className='ml-10'>
-              <ProfileEditPreviewCard
-                preview={result.preview as ProfileEditPreview}
-                profileId={profileId}
-              />
-            </div>
-          );
-        }
-
-        if (
-          toolInvocation.toolName === 'proposeAvatarUpload' &&
-          toolInvocation.state === 'result' &&
-          toolInvocation.result?.success
-        ) {
-          return (
-            <div key={toolInvocation.toolInvocationId} className='ml-10'>
-              <ChatAvatarUploadCard />
-            </div>
-          );
-        }
-
-        if (
-          toolInvocation.toolName === 'showTopInsights' &&
-          toolInvocation.state === 'result' &&
-          toolInvocation.result?.success
-        ) {
-          return (
-            <div key={toolInvocation.toolInvocationId} className='ml-10'>
-              <ChatAnalyticsCard
-                result={
-                  toolInvocation.result as unknown as ChatInsightsToolResult
-                }
-              />
-            </div>
-          );
-        }
-
-        if (
-          toolInvocation.toolName === 'generateAlbumArt' &&
-          toolInvocation.state === 'result' &&
-          isChatAlbumArtToolResult(toolInvocation.result)
-        ) {
-          return (
-            <div key={toolInvocation.toolInvocationId} className='ml-10'>
-              <ChatAlbumArtCard
-                result={toolInvocation.result}
-                profileId={profileId}
-              />
-            </div>
-          );
-        }
-
-        if (
-          toolInvocation.toolName === 'proposeSocialLink' &&
-          toolInvocation.state === 'result' &&
-          toolInvocation.result?.success
-        ) {
-          const result =
-            toolInvocation.result as unknown as SocialLinkToolResult;
-          return (
-            <div key={toolInvocation.toolInvocationId} className='ml-10'>
-              <ChatLinkConfirmationCard
-                profileId={profileId}
-                platform={result.platform}
-                normalizedUrl={result.normalizedUrl}
-                originalUrl={result.originalUrl}
-              />
-            </div>
-          );
-        }
-
-        return null;
-      })}
+      <div className='ml-10'>
+        <ToolPartsRenderer
+          parts={message.parts}
+          profileId={profileId}
+          variant='inline'
+          hasMessageText={Boolean(textContent)}
+        />
+      </div>
     </div>
   );
 });

--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -5,164 +5,17 @@ import { Check, Copy } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
-import React, { useMemo } from 'react';
 import { BrandLogo } from '@/components/atoms/BrandLogo';
 import { useClipboard } from '@/hooks/useClipboard';
 import { cn } from '@/lib/utils';
-import {
-  type ChatInsightsToolResult,
-  isChatAlbumArtToolResult,
-  isToolInvocationPart,
-  type MessagePart,
-  type SocialLinkRemovalToolResult,
-  type SocialLinkToolResult,
-  type ToolInvocationPart,
-} from '../types';
+import { getRenderableToolEvents, ToolPartsRenderer } from '../tool-ui';
+import type { MessagePart } from '../types';
 import { getMessageText } from '../utils';
-import { ChatAlbumArtCard } from './ChatAlbumArtCard';
-import { ChatAnalyticsCard } from './ChatAnalyticsCard';
-import { ChatAvatarUploadCard } from './ChatAvatarUploadCard';
-import { ChatLinkConfirmationCard } from './ChatLinkConfirmationCard';
-import { ChatLinkRemovalCard } from './ChatLinkRemovalCard';
-import { ChatPitchCard } from './ChatPitchCard';
 
 const ChatMarkdown = dynamic(
   () => import('./ChatMarkdown').then(m => ({ default: m.ChatMarkdown })),
   { ssr: false }
 );
-
-function isInsightsResult(result: unknown): result is ChatInsightsToolResult {
-  return typeof result === 'object' && result !== null && 'success' in result;
-}
-
-function isSocialLinkResult(result: unknown): result is SocialLinkToolResult {
-  return (
-    typeof result === 'object' &&
-    result !== null &&
-    'platform' in result &&
-    'normalizedUrl' in result &&
-    'originalUrl' in result
-  );
-}
-
-function isSocialLinkRemovalResult(
-  result: unknown
-): result is SocialLinkRemovalToolResult {
-  return (
-    typeof result === 'object' &&
-    result !== null &&
-    'linkId' in result &&
-    'platform' in result &&
-    'url' in result
-  );
-}
-
-function renderPitchResultCard(
-  toolInvocation: ToolInvocationPart
-): React.ReactNode {
-  const result = toolInvocation.result as {
-    success: boolean;
-    releaseTitle?: string;
-    pitches?: {
-      spotify: string;
-      appleMusic: string;
-      amazon: string;
-      generic: string;
-    };
-    error?: string;
-  };
-
-  return (
-    <ChatPitchCard
-      state={result.success ? 'success' : 'error'}
-      releaseTitle={result.releaseTitle}
-      pitches={result.pitches}
-      error={result.error}
-    />
-  );
-}
-
-function renderToolCard(
-  toolInvocation: ToolInvocationPart,
-  profileId?: string
-): React.ReactNode {
-  if (
-    toolInvocation.toolName === 'proposeAvatarUpload' &&
-    toolInvocation.state === 'result' &&
-    toolInvocation.result?.success
-  ) {
-    return <ChatAvatarUploadCard />;
-  }
-
-  if (
-    toolInvocation.toolName === 'showTopInsights' &&
-    toolInvocation.state === 'result' &&
-    isInsightsResult(toolInvocation.result)
-  ) {
-    return <ChatAnalyticsCard result={toolInvocation.result} />;
-  }
-
-  if (
-    toolInvocation.toolName === 'proposeSocialLink' &&
-    toolInvocation.state === 'result' &&
-    isSocialLinkResult(toolInvocation.result) &&
-    profileId
-  ) {
-    const result = toolInvocation.result;
-    return (
-      <ChatLinkConfirmationCard
-        profileId={profileId}
-        platform={result.platform}
-        normalizedUrl={result.normalizedUrl}
-        originalUrl={result.originalUrl}
-      />
-    );
-  }
-
-  if (
-    toolInvocation.toolName === 'proposeSocialLinkRemoval' &&
-    toolInvocation.state === 'result' &&
-    isSocialLinkRemovalResult(toolInvocation.result) &&
-    profileId
-  ) {
-    const result = toolInvocation.result;
-    return (
-      <ChatLinkRemovalCard
-        profileId={profileId}
-        linkId={result.linkId}
-        platform={result.platform}
-        url={result.url}
-      />
-    );
-  }
-
-  if (
-    toolInvocation.toolName === 'generateAlbumArt' &&
-    toolInvocation.state === 'result' &&
-    isChatAlbumArtToolResult(toolInvocation.result) &&
-    profileId
-  ) {
-    return (
-      <ChatAlbumArtCard result={toolInvocation.result} profileId={profileId} />
-    );
-  }
-
-  if (
-    toolInvocation.toolName === 'generateReleasePitch' &&
-    toolInvocation.state === 'call'
-  ) {
-    return <ChatPitchCard state='loading' />;
-  }
-
-  if (
-    toolInvocation.toolName === 'generateReleasePitch' &&
-    toolInvocation.state === 'result'
-  ) {
-    return renderPitchResultCard(toolInvocation);
-  }
-
-  return null;
-}
 
 interface ChatMessageProps {
   readonly id: string;
@@ -194,6 +47,7 @@ export function ChatMessage({
   const { copy, isSuccess } = useClipboard();
   const messageText = getMessageText(parts);
   const shouldReduceMotion = useReducedMotion();
+  const toolEvents = getRenderableToolEvents(parts);
   const fileParts = parts.filter(
     (p): p is MessagePart & { url: string; mediaType: string } =>
       p.type === 'file' &&
@@ -201,11 +55,7 @@ export function ChatMessage({
       typeof p.mediaType === 'string' &&
       p.mediaType.startsWith('image/')
   );
-
-  const toolInvocations = useMemo(
-    () => parts.filter(isToolInvocationPart),
-    [parts]
-  );
+  const hasAssistantContent = Boolean(messageText) || toolEvents.length > 0;
 
   return (
     <motion.div
@@ -294,7 +144,7 @@ export function ChatMessage({
             </div>
           )}
 
-          {!isThinking && messageText && (
+          {!isThinking && hasAssistantContent && (
             <div className='space-y-1.5'>
               <div className='flex items-center gap-2 pl-0.5'>
                 <span className='flex h-5.5 w-5.5 items-center justify-center rounded-full border border-subtle bg-surface-0 text-secondary-token'>
@@ -307,33 +157,26 @@ export function ChatMessage({
                   {isStreaming ? 'Writing reply…' : 'Reply'}
                 </span>
               </div>
-              <div
-                data-testid='chat-message-reply-bubble'
-                className='rounded-[18px] border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_70%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,var(--linear-surface))] px-4 py-3.5 text-primary-token shadow-none'
-              >
-                <ChatMarkdown
-                  content={messageText}
-                  isStreaming={Boolean(isStreaming)}
-                />
-              </div>
+              {messageText ? (
+                <div
+                  data-testid='chat-message-reply-bubble'
+                  className='rounded-[18px] border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_70%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,var(--linear-surface))] px-4 py-3.5 text-primary-token shadow-none'
+                >
+                  <ChatMarkdown
+                    content={messageText}
+                    isStreaming={Boolean(isStreaming)}
+                  />
+                </div>
+              ) : null}
             </div>
           )}
 
-          {/* Interactive tool cards */}
-          {toolInvocations.map(toolInvocation => {
-            const card = renderToolCard(toolInvocation, profileId);
-            if (!card) {
-              return null;
-            }
-            return (
-              <div
-                key={toolInvocation.toolInvocationId}
-                className={cn(messageText && 'mt-3')}
-              >
-                {card}
-              </div>
-            );
-          })}
+          <ToolPartsRenderer
+            parts={parts}
+            profileId={profileId}
+            variant='chat'
+            hasMessageText={Boolean(messageText)}
+          />
 
           {!isStreaming && messageText && (
             <div className='mt-1.5 flex items-center justify-end pr-0.5'>

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -8,6 +8,10 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { matchCommand } from '@/lib/chat/command-registry';
 import { consumePendingChatPrompt } from '@/lib/chat/open-chat-with-prompt';
+import type {
+  ChatPersistenceMessage,
+  PendingToolPersistenceEnvelope,
+} from '@/lib/chat/tool-events';
 import { PACER_TIMING } from '@/lib/pacer/hooks/timing';
 import {
   FetchError,
@@ -17,6 +21,7 @@ import {
   useCreateConversationMutation,
 } from '@/lib/queries';
 import { addBreadcrumb, captureException } from '@/lib/sentry/client-lite';
+import { logger } from '@/lib/utils/logger';
 
 import {
   extractPersistableToolCalls,
@@ -91,11 +96,9 @@ export function useJovieChat({
   const [activeConversationId, setActiveConversationId] = useState<
     string | null
   >(conversationId ?? null);
-  const pendingMessagesRef = useRef<{
-    userMessage: string;
-    assistantMessage: string;
-    toolCalls?: Record<string, unknown>[];
-  } | null>(null);
+  const pendingMessagesRef = useRef<PendingToolPersistenceEnvelope | null>(
+    null
+  );
   const pendingInitialSendRef = useRef<{
     text: string;
     files?: FileUIPart[];
@@ -363,27 +366,17 @@ export function useJovieChat({
     }
 
     const assistantText = getMessageText(lastAssistantMessage.parts);
-    if (!assistantText) {
-      // Assistant message exists but has no text yet - leave pending
+    const toolCalls = extractPersistableToolCalls(lastAssistantMessage.parts);
+
+    if (!assistantText && (!toolCalls || toolCalls.length === 0)) {
+      // Assistant message exists but has no persisted text or tool payload yet - leave pending
       return;
     }
-
-    // Extract tool calls for persistence
-    const toolCalls = extractPersistableToolCalls(
-      lastAssistantMessage.parts as Array<{
-        type: string;
-        [key: string]: unknown;
-      }>
-    );
 
     const { userMessage } = pendingMessagesRef.current;
 
     // Build messages to persist - user message may be empty if already persisted during conversation creation
-    const messagesToPersist: Array<{
-      role: 'user' | 'assistant';
-      content: string;
-      toolCalls?: Record<string, unknown>[];
-    }> = [];
+    const messagesToPersist: ChatPersistenceMessage[] = [];
 
     if (userMessage) {
       messagesToPersist.push({ role: 'user', content: userMessage });
@@ -402,6 +395,8 @@ export function useJovieChat({
       },
       {
         onSuccess: data => {
+          pendingMessagesRef.current = null;
+          setIsSubmitting(false);
           queryClient.invalidateQueries({
             queryKey: queryKeys.chat.conversation(activeConversationId),
           });
@@ -413,6 +408,25 @@ export function useJovieChat({
           // start polling so the title auto-updates in sidebar + header.
           if (data?.titlePending) {
             setTitlePollingSince(Date.now());
+          }
+
+          if (!assistantText && toolCalls && toolCalls.length > 0) {
+            addBreadcrumb({
+              category: 'ai-chat',
+              message: 'Persisted tool-only assistant response',
+              level: 'info',
+              data: {
+                conversationId: activeConversationId,
+                toolCount: toolCalls.length,
+              },
+            });
+          }
+
+          if (deferredNavigationRef.current) {
+            const { callback, conversationId: navConversationId } =
+              deferredNavigationRef.current;
+            deferredNavigationRef.current = null;
+            callback(navConversationId);
           }
         },
         onError: err => {
@@ -443,7 +457,7 @@ export function useJovieChat({
               },
             });
           }
-          console.error('[useJovieChat] Failed to save messages:', err);
+          logger.error('[useJovieChat] Failed to save messages:', err);
           setChatError({
             type: 'server',
             message:
@@ -451,22 +465,10 @@ export function useJovieChat({
             errorCode: 'MESSAGE_PERSIST_FAILED',
             failedMessage: lastAttemptedMessageRef.current,
           });
+          setIsSubmitting(false);
         },
       }
     );
-
-    // Successfully extracted and dispatched — clear pending
-    pendingMessagesRef.current = null;
-    setIsSubmitting(false);
-
-    // Fire deferred navigation now that the stream is complete and messages are persisted.
-    // This prevents the route change from killing the in-flight AI response (JOV-1233).
-    if (deferredNavigationRef.current) {
-      const { callback, conversationId: navConversationId } =
-        deferredNavigationRef.current;
-      deferredNavigationRef.current = null;
-      callback(navConversationId);
-    }
   }, [
     status,
     activeConversationId,
@@ -493,7 +495,6 @@ export function useJovieChat({
         // Only store pending ref to persist the assistant response.
         pendingMessagesRef.current = {
           userMessage: '', // Empty - already persisted via initialMessage
-          assistantMessage: '', // Will be filled when response completes
         };
 
         // Store the send payload for the effect that fires after activeConversationId updates.
@@ -540,7 +541,7 @@ export function useJovieChat({
             },
           });
         }
-        console.error('[useJovieChat] Failed to create conversation:', err);
+        logger.error('[useJovieChat] Failed to create conversation:', err);
         setChatError({
           type: 'server',
           message:
@@ -627,7 +628,6 @@ export function useJovieChat({
         // Store pending message for persistence (both user and assistant)
         pendingMessagesRef.current = {
           userMessage: trimmedText,
-          assistantMessage: '', // Will be filled when response completes
         };
       } else {
         // No active conversation — create one first, then return

--- a/apps/web/components/jovie/message-parts.ts
+++ b/apps/web/components/jovie/message-parts.ts
@@ -1,106 +1,28 @@
 import {
-  isToolInvocationPart,
-  type MessagePart,
-  type ToolInvocationPart,
-} from './types';
+  decodeToolEvents,
+  encodeToolEvents,
+  toolEventToMessagePart,
+} from '@/lib/chat/tool-events';
+import type { MessagePart } from './types';
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function normalizeToolInvocationState(
-  value: unknown
-): ToolInvocationPart['state'] {
-  return value === 'call' || value === 'partial-call' ? value : 'result';
-}
-
-function resolveStringField(
-  primary: unknown,
-  fallback: unknown
-): string | null {
-  if (typeof primary === 'string') return primary;
-  if (typeof fallback === 'string') return fallback;
-  return null;
-}
-
-function resolveRecordField(
-  primary: unknown,
-  fallback: unknown
-): Record<string, unknown> | undefined {
-  if (isRecord(primary)) return primary;
-  if (isRecord(fallback)) return fallback;
-  return undefined;
-}
-
-function resolveToolInvocationId(
-  value: Record<string, unknown>,
-  nested: Record<string, unknown> | null,
-  index: number
-): string {
-  if (typeof value.toolInvocationId === 'string') return value.toolInvocationId;
-  if (typeof nested?.toolInvocationId === 'string')
-    return nested.toolInvocationId;
-  if (typeof nested?.toolCallId === 'string') return nested.toolCallId;
-  return `persisted-tool-${index}`;
-}
-
-function hydrateToolInvocationPart(
-  value: unknown,
-  index: number
-): ToolInvocationPart | null {
-  if (!isRecord(value)) return null;
-
-  if (isToolInvocationPart(value)) {
-    return value;
-  }
-
-  const nested = isRecord(value.toolInvocation) ? value.toolInvocation : null;
-  const toolName = resolveStringField(value.toolName, nested?.toolName);
-
-  if (!toolName) {
-    return null;
-  }
-
-  const state = normalizeToolInvocationState(value.state ?? nested?.state);
-  const toolInvocationId = resolveToolInvocationId(value, nested, index);
-
-  return {
-    type: 'tool-invocation',
-    toolInvocationId,
-    toolName,
-    state,
-    args: resolveRecordField(value.args, nested?.args),
-    result: resolveRecordField(value.result, nested?.result),
-    toolInvocation: {
-      toolName,
-      state,
-    },
-  };
-}
-
-export function extractPersistableToolCalls(
-  parts: Array<{ type: string; [key: string]: unknown }>
-) {
-  const toolCalls = parts
-    .filter(part => part.type === 'tool-invocation')
-    .map(part => ({ ...part }));
-
-  return toolCalls.length > 0 ? toolCalls : undefined;
+export function extractPersistableToolCalls(parts: readonly MessagePart[]) {
+  return encodeToolEvents(parts);
 }
 
 export function hydratePersistedMessageParts(
   content: string,
   toolCalls: unknown
 ): MessagePart[] {
-  const parts: MessagePart[] = [{ type: 'text', text: content }];
+  const parts: MessagePart[] = [];
 
-  if (!Array.isArray(toolCalls)) {
+  if (content.length > 0) {
+    parts.push({ type: 'text', text: content });
+  }
+
+  const decoded = decodeToolEvents(toolCalls);
+  if (decoded.events.length === 0) {
     return parts;
   }
 
-  return parts.concat(
-    toolCalls
-      .map((toolCall, index) => hydrateToolInvocationPart(toolCall, index))
-      .filter((toolCall): toolCall is ToolInvocationPart => toolCall !== null)
-  );
+  return parts.concat(decoded.events.map(toolEventToMessagePart));
 }

--- a/apps/web/components/jovie/tool-ui.tsx
+++ b/apps/web/components/jovie/tool-ui.tsx
@@ -1,0 +1,335 @@
+'use client';
+
+import { AlertCircle, CheckCircle2, Loader2 } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useEffect, useRef } from 'react';
+import {
+  type ProfileEditPreview,
+  ProfileEditPreviewCard,
+} from '@/components/features/dashboard/organisms/ProfileEditPreviewCard';
+import {
+  encodeToolEvents,
+  type PersistedToolEvent,
+} from '@/lib/chat/tool-events';
+import { getToolUiConfig } from '@/lib/chat/tool-ui-registry';
+import { addBreadcrumb } from '@/lib/sentry/client-lite';
+import { cn } from '@/lib/utils';
+import { ChatAlbumArtCard } from './components/ChatAlbumArtCard';
+import { ChatAnalyticsCard } from './components/ChatAnalyticsCard';
+import { ChatAvatarUploadCard } from './components/ChatAvatarUploadCard';
+import { ChatLinkConfirmationCard } from './components/ChatLinkConfirmationCard';
+import { ChatLinkRemovalCard } from './components/ChatLinkRemovalCard';
+import { ChatPitchCard } from './components/ChatPitchCard';
+import type {
+  ChatAlbumArtToolResult,
+  ChatInsightsToolResult,
+  MessagePart,
+  SocialLinkRemovalToolResult,
+  SocialLinkToolResult,
+} from './types';
+import { isChatAlbumArtToolResult } from './types';
+
+type ToolRendererVariant = 'chat' | 'inline';
+
+interface ToolPartsRendererProps {
+  readonly parts: readonly MessagePart[];
+  readonly profileId?: string;
+  readonly variant: ToolRendererVariant;
+  readonly hasMessageText?: boolean;
+}
+
+function isInsightsResult(result: unknown): result is ChatInsightsToolResult {
+  return typeof result === 'object' && result !== null && 'success' in result;
+}
+
+function isSocialLinkResult(result: unknown): result is SocialLinkToolResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'platform' in result &&
+    'normalizedUrl' in result &&
+    'originalUrl' in result
+  );
+}
+
+function isSocialLinkRemovalResult(
+  result: unknown
+): result is SocialLinkRemovalToolResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'linkId' in result &&
+    'platform' in result &&
+    'url' in result
+  );
+}
+
+function getToolStatusTitle(event: PersistedToolEvent): string {
+  const config = getToolUiConfig(event.toolName);
+
+  switch (event.state) {
+    case 'running':
+      return config.loadingTitle ?? config.label;
+    case 'failed':
+      return config.errorTitle ?? `${config.label} Failed`;
+    case 'denied':
+      return `${config.label} Denied`;
+    case 'needs-approval':
+      return `${config.label} Needs Approval`;
+    case 'succeeded':
+      return config.label;
+  }
+}
+
+function getToolStatusBody(event: PersistedToolEvent): string | undefined {
+  switch (event.state) {
+    case 'running':
+      return event.summary;
+    case 'failed':
+    case 'denied':
+      return event.errorMessage ?? event.summary;
+    case 'needs-approval':
+      return event.errorMessage ?? 'Approval required before continuing.';
+    case 'succeeded':
+      return event.summary ?? 'Completed';
+  }
+}
+
+function ToolStatusRow({
+  event,
+  variant,
+}: Readonly<{
+  event: PersistedToolEvent;
+  variant: ToolRendererVariant;
+}>) {
+  const body = getToolStatusBody(event);
+  const isInline = variant === 'inline';
+  const isError = event.state === 'failed' || event.state === 'denied';
+  const isRunning = event.state === 'running';
+  const Icon = isRunning ? Loader2 : isError ? AlertCircle : CheckCircle2;
+
+  return (
+    <div
+      data-testid='tool-status-row'
+      data-tool-name={event.toolName}
+      data-tool-state={event.state}
+      role={isError ? 'alert' : 'status'}
+      className={cn(
+        'w-full rounded-xl border bg-surface-1 text-primary-token',
+        isInline ? 'px-3 py-2.5' : 'max-w-[420px] px-3.5 py-3',
+        isError
+          ? 'border-red-500/20 bg-[color-mix(in_oklab,var(--color-error)_8%,var(--linear-app-content-surface))]'
+          : 'border-subtle'
+      )}
+    >
+      <div className='flex items-start gap-2.5'>
+        <span
+          className={cn(
+            'mt-0.5 flex shrink-0 items-center justify-center text-secondary-token',
+            isRunning && 'animate-spin motion-reduce:animate-none',
+            isError && 'text-red-500',
+            !isRunning && !isError && 'text-green-600'
+          )}
+        >
+          <Icon className={isInline ? 'h-3.5 w-3.5' : 'h-4 w-4'} />
+        </span>
+        <div className='min-w-0'>
+          <div
+            className={cn(
+              'truncate font-[560] tracking-[-0.01em]',
+              isInline ? 'text-[12px]' : 'text-[13px]'
+            )}
+          >
+            {getToolStatusTitle(event)}
+          </div>
+          {body ? (
+            <div
+              className={cn(
+                'mt-0.5 text-secondary-token',
+                isInline
+                  ? 'line-clamp-2 text-[11px]'
+                  : 'line-clamp-2 text-[12px]'
+              )}
+            >
+              {body}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function renderArtifactCard(
+  event: PersistedToolEvent,
+  profileId?: string
+): ReactNode {
+  if (event.state !== 'succeeded') {
+    return null;
+  }
+
+  if (
+    event.toolName === 'proposeProfileEdit' &&
+    profileId &&
+    event.output?.success &&
+    event.output.preview
+  ) {
+    return (
+      <ProfileEditPreviewCard
+        preview={event.output.preview as ProfileEditPreview}
+        profileId={profileId}
+      />
+    );
+  }
+
+  if (event.toolName === 'proposeAvatarUpload' && event.output?.success) {
+    return <ChatAvatarUploadCard />;
+  }
+
+  if (event.toolName === 'showTopInsights' && isInsightsResult(event.output)) {
+    return <ChatAnalyticsCard result={event.output} />;
+  }
+
+  if (
+    event.toolName === 'proposeSocialLink' &&
+    profileId &&
+    isSocialLinkResult(event.output)
+  ) {
+    return (
+      <ChatLinkConfirmationCard
+        profileId={profileId}
+        platform={event.output.platform}
+        normalizedUrl={event.output.normalizedUrl}
+        originalUrl={event.output.originalUrl}
+      />
+    );
+  }
+
+  if (
+    event.toolName === 'proposeSocialLinkRemoval' &&
+    profileId &&
+    isSocialLinkRemovalResult(event.output)
+  ) {
+    return (
+      <ChatLinkRemovalCard
+        profileId={profileId}
+        linkId={event.output.linkId}
+        platform={event.output.platform}
+        url={event.output.url}
+      />
+    );
+  }
+
+  if (
+    event.toolName === 'generateAlbumArt' &&
+    profileId &&
+    isChatAlbumArtToolResult(event.output as ChatAlbumArtToolResult)
+  ) {
+    return (
+      <ChatAlbumArtCard
+        result={event.output as ChatAlbumArtToolResult}
+        profileId={profileId}
+      />
+    );
+  }
+
+  if (
+    event.toolName === 'generateReleasePitch' &&
+    isRecord(event.output) &&
+    event.output.success === true &&
+    isRecord(event.output.pitches)
+  ) {
+    return (
+      <ChatPitchCard
+        state='success'
+        releaseTitle={
+          typeof event.output.releaseTitle === 'string'
+            ? event.output.releaseTitle
+            : undefined
+        }
+        pitches={
+          event.output.pitches as {
+            spotify: string;
+            appleMusic: string;
+            amazon: string;
+            generic: string;
+          }
+        }
+      />
+    );
+  }
+
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function getRenderableToolEvents(parts: readonly MessagePart[]) {
+  return encodeToolEvents(parts) ?? [];
+}
+
+export function ToolPartsRenderer({
+  parts,
+  profileId,
+  variant,
+  hasMessageText = false,
+}: ToolPartsRendererProps) {
+  const events = getRenderableToolEvents(parts);
+  const loggedFallbackToolCallsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    for (const event of events) {
+      const config = getToolUiConfig(event.toolName);
+      const shouldLogFallback =
+        config.renderer === 'status' || event.state !== 'succeeded';
+
+      if (
+        shouldLogFallback &&
+        !loggedFallbackToolCallsRef.current.has(event.toolCallId)
+      ) {
+        loggedFallbackToolCallsRef.current.add(event.toolCallId);
+        addBreadcrumb({
+          category: 'ai-chat',
+          message: 'Rendered generic tool fallback',
+          level: 'info',
+          data: {
+            toolCallId: event.toolCallId,
+            toolName: event.toolName,
+            state: event.state,
+            variant,
+          },
+        });
+      }
+    }
+  }, [events, variant]);
+
+  if (events.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {events.map(event => {
+        const config = getToolUiConfig(event.toolName);
+        const artifactCard =
+          config.renderer === 'artifact'
+            ? renderArtifactCard(event, profileId)
+            : null;
+        const content = artifactCard ?? (
+          <ToolStatusRow event={event} variant={variant} />
+        );
+
+        return (
+          <div
+            key={event.toolCallId}
+            className={cn(hasMessageText && variant === 'chat' && 'mt-3')}
+          >
+            {content}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/components/jovie/tool-ui.tsx
+++ b/apps/web/components/jovie/tool-ui.tsx
@@ -2,7 +2,7 @@
 
 import { AlertCircle, CheckCircle2, Loader2 } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
   type ProfileEditPreview,
   ProfileEditPreviewCard,
@@ -21,7 +21,6 @@ import { ChatLinkConfirmationCard } from './components/ChatLinkConfirmationCard'
 import { ChatLinkRemovalCard } from './components/ChatLinkRemovalCard';
 import { ChatPitchCard } from './components/ChatPitchCard';
 import type {
-  ChatAlbumArtToolResult,
   ChatInsightsToolResult,
   MessagePart,
   SocialLinkRemovalToolResult,
@@ -95,6 +94,14 @@ function getToolStatusBody(event: PersistedToolEvent): string | undefined {
   }
 }
 
+const TOOL_STATUS_ICONS: Record<PersistedToolEvent['state'], typeof Loader2> = {
+  running: Loader2,
+  failed: AlertCircle,
+  denied: AlertCircle,
+  succeeded: CheckCircle2,
+  'needs-approval': CheckCircle2,
+};
+
 function ToolStatusRow({
   event,
   variant,
@@ -106,7 +113,7 @@ function ToolStatusRow({
   const isInline = variant === 'inline';
   const isError = event.state === 'failed' || event.state === 'denied';
   const isRunning = event.state === 'running';
-  const Icon = isRunning ? Loader2 : isError ? AlertCircle : CheckCircle2;
+  const Icon = TOOL_STATUS_ICONS[event.state];
 
   return (
     <div
@@ -160,6 +167,140 @@ function ToolStatusRow({
   );
 }
 
+function isPitchOutput(value: unknown): value is {
+  readonly releaseTitle?: string;
+  readonly pitches: {
+    readonly spotify: string;
+    readonly appleMusic: string;
+    readonly amazon: string;
+    readonly generic: string;
+  };
+  readonly success: true;
+} {
+  if (!isRecord(value) || value.success !== true || !isRecord(value.pitches)) {
+    return false;
+  }
+
+  return (
+    (value.releaseTitle === undefined ||
+      typeof value.releaseTitle === 'string') &&
+    typeof value.pitches.spotify === 'string' &&
+    typeof value.pitches.appleMusic === 'string' &&
+    typeof value.pitches.amazon === 'string' &&
+    typeof value.pitches.generic === 'string'
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+type ArtifactRenderer = (
+  event: PersistedToolEvent,
+  profileId?: string
+) => ReactNode;
+
+function renderProfileEditArtifact(
+  event: PersistedToolEvent,
+  profileId?: string
+): ReactNode {
+  if (!profileId || !event.output?.success || !event.output.preview) {
+    return null;
+  }
+
+  return (
+    <ProfileEditPreviewCard
+      preview={event.output.preview as ProfileEditPreview}
+      profileId={profileId}
+    />
+  );
+}
+
+function renderAvatarUploadArtifact(event: PersistedToolEvent): ReactNode {
+  return event.output?.success ? <ChatAvatarUploadCard /> : null;
+}
+
+function renderInsightsArtifact(event: PersistedToolEvent): ReactNode {
+  return isInsightsResult(event.output) ? (
+    <ChatAnalyticsCard result={event.output} />
+  ) : null;
+}
+
+function renderSocialLinkArtifact(
+  event: PersistedToolEvent,
+  profileId?: string
+): ReactNode {
+  if (!profileId || !isSocialLinkResult(event.output)) {
+    return null;
+  }
+
+  return (
+    <ChatLinkConfirmationCard
+      profileId={profileId}
+      platform={event.output.platform}
+      normalizedUrl={event.output.normalizedUrl}
+      originalUrl={event.output.originalUrl}
+    />
+  );
+}
+
+function renderSocialLinkRemovalArtifact(
+  event: PersistedToolEvent,
+  profileId?: string
+): ReactNode {
+  if (!profileId || !isSocialLinkRemovalResult(event.output)) {
+    return null;
+  }
+
+  return (
+    <ChatLinkRemovalCard
+      profileId={profileId}
+      linkId={event.output.linkId}
+      platform={event.output.platform}
+      url={event.output.url}
+    />
+  );
+}
+
+function renderAlbumArtArtifact(
+  event: PersistedToolEvent,
+  profileId?: string
+): ReactNode {
+  if (!profileId || !isChatAlbumArtToolResult(event.output)) {
+    return null;
+  }
+
+  return <ChatAlbumArtCard result={event.output} profileId={profileId} />;
+}
+
+function renderReleasePitchArtifact(event: PersistedToolEvent): ReactNode {
+  if (!isPitchOutput(event.output)) {
+    return null;
+  }
+
+  return (
+    <ChatPitchCard
+      state='success'
+      releaseTitle={event.output.releaseTitle}
+      pitches={event.output.pitches}
+    />
+  );
+}
+
+const ARTIFACT_RENDERERS: Partial<Record<string, ArtifactRenderer>> = {
+  proposeAvatarUpload: event => renderAvatarUploadArtifact(event),
+  proposeProfileEdit: (event, profileId) =>
+    renderProfileEditArtifact(event, profileId),
+  proposeSocialLink: (event, profileId) =>
+    renderSocialLinkArtifact(event, profileId),
+  proposeSocialLinkRemoval: (event, profileId) =>
+    renderSocialLinkRemovalArtifact(event, profileId),
+  showTopInsights: event => renderInsightsArtifact(event),
+  generateAlbumArt: (event, profileId) =>
+    renderAlbumArtArtifact(event, profileId),
+  generateReleasePitch: event => renderReleasePitchArtifact(event),
+};
+
 function renderArtifactCard(
   event: PersistedToolEvent,
   profileId?: string
@@ -168,102 +309,8 @@ function renderArtifactCard(
     return null;
   }
 
-  if (
-    event.toolName === 'proposeProfileEdit' &&
-    profileId &&
-    event.output?.success &&
-    event.output.preview
-  ) {
-    return (
-      <ProfileEditPreviewCard
-        preview={event.output.preview as ProfileEditPreview}
-        profileId={profileId}
-      />
-    );
-  }
-
-  if (event.toolName === 'proposeAvatarUpload' && event.output?.success) {
-    return <ChatAvatarUploadCard />;
-  }
-
-  if (event.toolName === 'showTopInsights' && isInsightsResult(event.output)) {
-    return <ChatAnalyticsCard result={event.output} />;
-  }
-
-  if (
-    event.toolName === 'proposeSocialLink' &&
-    profileId &&
-    isSocialLinkResult(event.output)
-  ) {
-    return (
-      <ChatLinkConfirmationCard
-        profileId={profileId}
-        platform={event.output.platform}
-        normalizedUrl={event.output.normalizedUrl}
-        originalUrl={event.output.originalUrl}
-      />
-    );
-  }
-
-  if (
-    event.toolName === 'proposeSocialLinkRemoval' &&
-    profileId &&
-    isSocialLinkRemovalResult(event.output)
-  ) {
-    return (
-      <ChatLinkRemovalCard
-        profileId={profileId}
-        linkId={event.output.linkId}
-        platform={event.output.platform}
-        url={event.output.url}
-      />
-    );
-  }
-
-  if (
-    event.toolName === 'generateAlbumArt' &&
-    profileId &&
-    isChatAlbumArtToolResult(event.output as ChatAlbumArtToolResult)
-  ) {
-    return (
-      <ChatAlbumArtCard
-        result={event.output as ChatAlbumArtToolResult}
-        profileId={profileId}
-      />
-    );
-  }
-
-  if (
-    event.toolName === 'generateReleasePitch' &&
-    isRecord(event.output) &&
-    event.output.success === true &&
-    isRecord(event.output.pitches)
-  ) {
-    return (
-      <ChatPitchCard
-        state='success'
-        releaseTitle={
-          typeof event.output.releaseTitle === 'string'
-            ? event.output.releaseTitle
-            : undefined
-        }
-        pitches={
-          event.output.pitches as {
-            spotify: string;
-            appleMusic: string;
-            amazon: string;
-            generic: string;
-          }
-        }
-      />
-    );
-  }
-
-  return null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  const renderer = ARTIFACT_RENDERERS[event.toolName];
+  return renderer?.(event, profileId) ?? null;
 }
 
 export function getRenderableToolEvents(parts: readonly MessagePart[]) {
@@ -276,7 +323,7 @@ export function ToolPartsRenderer({
   variant,
   hasMessageText = false,
 }: ToolPartsRendererProps) {
-  const events = getRenderableToolEvents(parts);
+  const events = useMemo(() => getRenderableToolEvents(parts), [parts]);
   const loggedFallbackToolCallsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {

--- a/apps/web/components/jovie/types.ts
+++ b/apps/web/components/jovie/types.ts
@@ -1,3 +1,10 @@
+import {
+  type DynamicToolUIPart,
+  isToolUIPart,
+  type ToolUIPart,
+  type UIMessage,
+} from 'ai';
+import { TOOL_UI_REGISTRY } from '@/lib/chat/tool-ui-registry';
 import type { ChatInsightSummary } from '@/types/insights';
 
 export interface ArtistContext {
@@ -180,50 +187,13 @@ export function isChatAlbumArtToolResult(
   return false;
 }
 
-export interface ToolInvocationPart {
-  type: 'tool-invocation';
-  toolInvocationId: string;
-  toolName: string;
-  state: 'call' | 'result' | 'partial-call';
-  args?: Record<string, unknown>;
-  result?: Record<string, unknown> | ChatAlbumArtToolResult;
-  toolInvocation?: {
-    readonly toolName: string;
-    readonly state: string;
-  };
+export type JovieToolPart = ToolUIPart | DynamicToolUIPart;
+
+export function isJovieToolPart(part: unknown): part is JovieToolPart {
+  return isToolUIPart(part as UIMessage['parts'][number]);
 }
 
-export function isToolInvocationPart(
-  part: unknown
-): part is ToolInvocationPart {
-  if (typeof part !== 'object' || part === null) {
-    return false;
-  }
-  const candidate = part as Partial<ToolInvocationPart>;
-  return (
-    candidate.type === 'tool-invocation' &&
-    typeof candidate.toolInvocationId === 'string' &&
-    candidate.toolInvocationId.length > 0 &&
-    typeof candidate.toolName === 'string' &&
-    candidate.toolName.length > 0 &&
-    (candidate.state === 'call' ||
-      candidate.state === 'result' ||
-      candidate.state === 'partial-call')
-  );
-}
-
-export interface MessagePart {
-  readonly type: string;
-  readonly text?: string;
-  readonly toolInvocation?: {
-    readonly toolName: string;
-    readonly state: string;
-  };
-  /** File attachment URL (data URL or blob URL). Present when type === 'file'. */
-  readonly url?: string;
-  /** MIME type of the file attachment. Present when type === 'file'. */
-  readonly mediaType?: string;
-}
+export type MessagePart = UIMessage['parts'][number];
 
 /** Shape of file attachments passed to AI SDK's sendMessage. */
 export interface FileUIPart {
@@ -233,22 +203,19 @@ export interface FileUIPart {
 }
 
 /** User-friendly labels for AI tool invocations shown during streaming. */
-export const TOOL_LABELS: Record<string, string> = {
-  proposeProfileEdit: 'Editing profile...',
-  proposeAvatarUpload: 'Preparing photo upload...',
-  proposeSocialLink: 'Adding link...',
-  proposeSocialLinkRemoval: 'Removing link...',
-  showTopInsights: 'Checking your signals...',
-  checkCanvasStatus: 'Checking canvas status...',
-  suggestRelatedArtists: 'Finding related artists...',
-  generateAlbumArt: 'Generating album art...',
-  generateCanvasPlan: 'Planning canvas video...',
-  createPromoStrategy: 'Building promo strategy...',
-  markCanvasUploaded: 'Updating canvas status...',
-  createRelease: 'Creating release...',
-  submitFeedback: 'Submitting feedback...',
-  generateReleasePitch: 'Generating pitches...',
-};
+export const TOOL_LABELS: Record<string, string> = (() => {
+  const labels: Record<string, string> = {};
+  const registry = TOOL_UI_REGISTRY as Record<
+    string,
+    { readonly label: string; readonly loadingTitle?: string }
+  >;
+
+  for (const [toolName, config] of Object.entries(registry)) {
+    labels[toolName] = config.loadingTitle ?? config.label;
+  }
+
+  return labels;
+})();
 
 /** A chat suggestion card with icon, label, and prompt */
 export interface ChatSuggestion {

--- a/apps/web/components/jovie/types.ts
+++ b/apps/web/components/jovie/types.ts
@@ -190,6 +190,15 @@ export function isChatAlbumArtToolResult(
 export type JovieToolPart = ToolUIPart | DynamicToolUIPart;
 
 export function isJovieToolPart(part: unknown): part is JovieToolPart {
+  if (
+    typeof part !== 'object' ||
+    part === null ||
+    !('type' in part) ||
+    typeof part.type !== 'string'
+  ) {
+    return false;
+  }
+
   return isToolUIPart(part as UIMessage['parts'][number]);
 }
 

--- a/apps/web/components/marketing/artist-profile/ArtistProfileHowItWorks.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileHowItWorks.tsx
@@ -57,7 +57,7 @@ function ClaimMoment({ accent }: Readonly<{ accent: string }>) {
         <span className='font-medium text-primary-token'>Tim White</span>
       </div>
       <div className='mt-3 overflow-hidden rounded-[1.2rem] border border-white/10 bg-[linear-gradient(180deg,rgba(255,255,255,0.055),rgba(255,255,255,0.02)),#090c10] p-2 shadow-[0_18px_36px_rgba(0,0,0,0.22)]'>
-        <p className='px-2.5 pb-2 text-[10px] font-medium tracking-[0.08em] text-white/36'>
+        <p className='px-2.5 pb-2 text-[10px] font-medium tracking-[0.08em] text-white/64'>
           Top results
         </p>
         <div className='rounded-[1rem] border border-white/8 bg-white/[0.05] px-3 py-3'>
@@ -174,11 +174,11 @@ function BuildMoment({ accent }: Readonly<{ accent: string }>) {
                 className='rounded-full px-3 py-1.5 text-[10px] font-semibold'
                 style={{
                   background: isIngesting
-                    ? `color-mix(in srgb, ${providerAccent} 15%, transparent)`
+                    ? 'rgba(0,0,0,0.34)'
                     : 'rgba(255,255,255,0.05)',
-                  border: `1px solid ${isIngesting ? `color-mix(in srgb, ${providerAccent} 24%, transparent)` : 'rgba(255,255,255,0.08)'}`,
+                  border: `1px solid ${isIngesting ? `color-mix(in srgb, ${providerAccent} 38%, transparent)` : 'rgba(255,255,255,0.08)'}`,
                   color: isIngesting
-                    ? providerAccent
+                    ? `color-mix(in srgb, ${providerAccent} 72%, white)`
                     : 'rgba(255,255,255,0.74)',
                 }}
               >
@@ -311,7 +311,7 @@ export function ArtistProfileHowItWorks({
                 className='relative flex flex-col items-center'
               >
                 <div className='mx-auto flex w-full max-w-[23rem] items-start gap-3 text-left'>
-                  <span className='pt-0.5 text-[13px] font-semibold tracking-[-0.03em] text-white/42'>
+                  <span className='pt-0.5 text-[13px] font-semibold tracking-[-0.03em] text-white/60'>
                     {String(index + 1).padStart(2, '0')}
                   </span>
                   <div className='min-w-0'>

--- a/apps/web/components/marketing/artist-profile/ArtistProfileMonetizationSection.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileMonetizationSection.tsx
@@ -265,6 +265,15 @@ export function ArtistProfileMonetizationSection({
             data-testid='artist-profile-monetization-scroller'
             className='relative flex gap-3.5 overflow-x-auto overflow-y-hidden overscroll-contain scroll-smooth snap-x snap-mandatory pb-2 pl-[max(1.25rem,calc((100vw-var(--linear-content-max))/2+1.25rem))] pr-[9vw] [-ms-overflow-style:none] [scrollbar-width:none] scrollbar-hide sm:gap-4 sm:pl-[max(1.5rem,calc((100vw-var(--linear-content-max))/2+1.5rem))] sm:pr-[10vw] lg:pl-[max(0px,calc((100vw-var(--linear-content-max))/2))] lg:pr-[12vw] [&::-webkit-scrollbar]:hidden'
           >
+            <button
+              type='button'
+              onClick={() => {
+                scrollByDirection('next');
+              }}
+              className='sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-10 focus:rounded-full focus:bg-white focus:px-3 focus:py-2 focus:text-[13px] focus:font-semibold focus:text-black'
+            >
+              Scroll monetization
+            </button>
             {cards.map((card, index) => (
               <MonetizationCard
                 key={card.id}
@@ -372,7 +381,7 @@ function IrlPaymentsVisual({
     <div className='w-[16.75rem] sm:w-[18rem]'>
       <div className='rounded-t-[1.45rem] rounded-b-none bg-[#111214] px-4 pb-5 pt-4 text-white shadow-[0_-18px_40px_rgba(0,0,0,0.18)] sm:px-5'>
         <div className='mx-auto h-1 w-10 rounded-full bg-white/18' />
-        <div className='mt-4 flex items-center gap-2 text-[11px] font-medium tracking-[-0.02em] text-white/52'>
+        <div className='mt-4 flex items-center gap-2 text-[11px] font-medium tracking-[-0.02em] text-white/72'>
           <QrCode className='h-3.5 w-3.5' strokeWidth={1.9} />
           <span>{card.contextLabel}</span>
           <span className='h-1 w-1 rounded-full bg-white/18' />
@@ -415,7 +424,7 @@ function CaptureFanVisual({
           <p className='text-[14px] font-semibold tracking-[-0.03em] text-black'>
             {card.fanName}
           </p>
-          <div className='mt-1 inline-flex items-center gap-1.5 text-[11px] font-medium text-black/56'>
+          <div className='mt-1 inline-flex items-center gap-1.5 text-[11px] font-medium text-black/68'>
             <MapPin className='h-3.5 w-3.5' strokeWidth={1.9} />
             {card.fanLocation}
           </div>
@@ -449,7 +458,7 @@ function SayThanksVisual({
             <p className='text-[12px] font-semibold tracking-[-0.02em] text-black'>
               {card.appName}
             </p>
-            <p className='text-[11px] font-medium text-black/42'>now</p>
+            <p className='text-[11px] font-medium text-black/62'>now</p>
           </div>
           <p className='mt-0.5 text-[11px] font-medium text-black/55'>
             {card.sender}
@@ -457,7 +466,7 @@ function SayThanksVisual({
           <p className='mt-3 text-[13px] font-semibold leading-[1.28] tracking-[-0.03em] text-black'>
             {card.notificationTitle}
           </p>
-          <p className='mt-1.5 text-[12px] leading-[1.45] text-black/58'>
+          <p className='mt-1.5 text-[12px] leading-[1.45] text-black/72'>
             {card.notificationPreview}
           </p>
         </div>

--- a/apps/web/components/marketing/artist-profile/ArtistProfileOutcomesCarousel.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileOutcomesCarousel.tsx
@@ -343,7 +343,7 @@ function DriveStreamsProof({
   return (
     <div className='max-w-[20rem] rounded-[1.25rem] border border-white/7 bg-black/26 p-3.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)] sm:p-4'>
       <div className='border-b border-white/6 pb-3.5'>
-        <p className='text-[11px] font-medium tracking-[-0.01em] text-white/48'>
+        <p className='text-[11px] font-medium tracking-[-0.01em] text-white/68'>
           {proof.floatingCardLabel}
         </p>
         <p className='mt-2.5 text-[1.15rem] font-semibold leading-[1.06] tracking-[-0.04em] text-white'>
@@ -383,21 +383,21 @@ function SellOutProof({
         <p className='text-[12px] font-semibold tracking-[-0.02em] text-white'>
           {proof.drawerTitle}
         </p>
-        <p className='mt-1 text-[11px] text-white/44'>{proof.drawerSubtitle}</p>
+        <p className='mt-1 text-[11px] text-white/68'>{proof.drawerSubtitle}</p>
         <div className='mt-3 divide-y divide-white/6'>
           {proof.drawerRows.map(row => (
             <div
               key={row.id}
               className='grid grid-cols-[3rem_minmax(0,1fr)_auto] items-center gap-2.5 py-2.5'
             >
-              <span className='text-[11px] font-medium tracking-[-0.01em] text-white/52'>
+              <span className='text-[11px] font-medium tracking-[-0.01em] text-white/70'>
                 {row.month} {row.day}
               </span>
               <span className='min-w-0'>
                 <span className='block truncate text-[12.5px] font-semibold text-white'>
                   {row.venue}
                 </span>
-                <span className='block truncate text-[11px] text-white/44'>
+                <span className='block truncate text-[11px] text-white/66'>
                   {row.location}
                 </span>
               </span>
@@ -410,7 +410,7 @@ function SellOutProof({
       </div>
 
       <div className='absolute right-3.5 top-3.5 z-10 w-[11.75rem] rounded-[1.15rem] bg-[#f4f1e8] p-3.5 text-black shadow-[0_20px_42px_rgba(0,0,0,0.3)] sm:right-4 sm:top-4'>
-        <p className='text-[10px] font-semibold tracking-[0.08em] text-black/54'>
+        <p className='text-[10px] font-semibold tracking-[0.08em] text-black/72'>
           {proof.nearbyCardLabel}
         </p>
         <p className='mt-2.5 text-[1.5rem] font-semibold leading-none tracking-[-0.07em]'>
@@ -419,7 +419,7 @@ function SellOutProof({
         <p className='mt-2.5 text-[0.9rem] font-semibold leading-[1.08] tracking-[-0.03em]'>
           {proof.nearbyVenue}
         </p>
-        <p className='mt-1 text-[12px] leading-[1.35] text-black/58'>
+        <p className='mt-1 text-[12px] leading-[1.35] text-black/74'>
           {proof.nearbyLocation}
         </p>
         <span className='mt-3 inline-flex rounded-full bg-black px-2.75 py-1.25 text-[10.5px] font-semibold text-white'>
@@ -448,7 +448,7 @@ function GetPaidProof({
         />
       </div>
       <div className='absolute left-0 bottom-4 rounded-[1.05rem] border border-white/10 bg-black/34 px-3.5 py-2.5 shadow-[inset_0_1px_0_rgba(255,255,255,0.05)]'>
-        <p className='text-[11px] font-medium tracking-[-0.01em] text-white/48'>
+        <p className='text-[11px] font-medium tracking-[-0.01em] text-white/66'>
           {proof.drawerTitle}
         </p>
         <p className='mt-1 text-[12.5px] font-semibold tracking-[-0.03em] text-white'>
@@ -488,7 +488,7 @@ function ShareProof({
       <p className='mt-3.5 font-mono text-[11.5px] font-semibold tracking-[-0.02em] text-black'>
         {proof.url}
       </p>
-      <p className='mt-2 text-[11px] font-medium text-black/56'>
+      <p className='mt-2 text-[11px] font-medium text-black/68'>
         {proof.subtitle}
       </p>
     </div>

--- a/apps/web/lib/chat/tool-events.ts
+++ b/apps/web/lib/chat/tool-events.ts
@@ -16,6 +16,12 @@ export type PersistedToolState =
 
 export type PersistedToolUiHint = 'artifact' | 'status';
 
+export interface PersistedToolApproval {
+  readonly id: string;
+  readonly approved?: boolean;
+  readonly reason?: string;
+}
+
 export interface PersistedToolEvent {
   readonly schemaVersion: 2;
   readonly toolCallId: string;
@@ -26,6 +32,7 @@ export interface PersistedToolEvent {
   readonly errorMessage?: string;
   readonly summary?: string;
   readonly uiHint: PersistedToolUiHint;
+  readonly approval?: PersistedToolApproval;
 }
 
 export interface PendingToolPersistenceEnvelope {
@@ -33,6 +40,11 @@ export interface PendingToolPersistenceEnvelope {
 }
 
 const recordSchema = z.record(z.string(), z.unknown());
+const approvalSchema = z.object({
+  id: z.string().min(1),
+  approved: z.boolean().optional(),
+  reason: z.string().optional(),
+});
 
 export const persistedToolEventSchema = z.object({
   schemaVersion: z.literal(2),
@@ -44,6 +56,7 @@ export const persistedToolEventSchema = z.object({
   errorMessage: z.string().optional(),
   summary: z.string().optional(),
   uiHint: z.enum(['artifact', 'status']),
+  approval: approvalSchema.optional(),
 });
 
 export const persistedToolEventsSchema = z.array(persistedToolEventSchema);
@@ -126,6 +139,19 @@ function extractSummary(value: unknown): string | undefined {
   return undefined;
 }
 
+function extractErrorMessage(value: unknown): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const error = value.error;
+  if (typeof error === 'string' && error.trim().length > 0) {
+    return error.trim();
+  }
+
+  return undefined;
+}
+
 function mapUiStateToPersistedState(
   state: string
 ): PersistedToolState | undefined {
@@ -147,15 +173,16 @@ function mapUiStateToPersistedState(
   }
 }
 
-function mapPersistedStateToUiState(
-  state: PersistedToolState
+function mapPersistedEventToUiState(
+  event: PersistedToolEvent
 ):
+  | 'approval-requested'
+  | 'approval-responded'
   | 'input-available'
   | 'output-available'
-  | 'output-error'
   | 'output-denied'
-  | 'approval-requested' {
-  switch (state) {
+  | 'output-error' {
+  switch (event.state) {
     case 'running':
       return 'input-available';
     case 'succeeded':
@@ -165,8 +192,24 @@ function mapPersistedStateToUiState(
     case 'denied':
       return 'output-denied';
     case 'needs-approval':
-      return 'approval-requested';
+      return typeof event.approval?.approved === 'boolean'
+        ? 'approval-responded'
+        : 'approval-requested';
   }
+}
+
+function normalizeApproval(value: unknown): PersistedToolApproval | undefined {
+  if (!isRecord(value) || typeof value.id !== 'string' || value.id.length < 1) {
+    return undefined;
+  }
+
+  return {
+    id: value.id,
+    ...(typeof value.approved === 'boolean'
+      ? { approved: value.approved }
+      : {}),
+    ...(typeof value.reason === 'string' ? { reason: value.reason } : {}),
+  };
 }
 
 function normalizeToolPart(part: ToolPart): PersistedToolEvent | null {
@@ -192,10 +235,18 @@ function normalizeToolPart(part: ToolPart): PersistedToolEvent | null {
     mappedState === 'succeeded' && output?.success === false
       ? 'failed'
       : mappedState;
+  const approval = normalizeApproval(part.approval);
   const approvalReason =
-    part.approval && typeof part.approval.reason === 'string'
-      ? part.approval.reason
+    approval && typeof approval.reason === 'string'
+      ? approval.reason
       : undefined;
+  const outputError = extractErrorMessage(output);
+  const errorMessage =
+    typeof part.errorText === 'string'
+      ? part.errorText
+      : state === 'failed' || state === 'denied'
+        ? (outputError ?? approvalReason)
+        : undefined;
 
   return {
     schemaVersion: 2,
@@ -204,19 +255,15 @@ function normalizeToolPart(part: ToolPart): PersistedToolEvent | null {
     state,
     input,
     output,
-    errorMessage:
-      typeof part.errorText === 'string'
-        ? part.errorText
-        : state === 'denied'
-          ? approvalReason
-          : undefined,
+    errorMessage,
     summary:
       state === 'succeeded'
         ? extractSummary(output)
         : state === 'failed' || state === 'denied'
-          ? (extractSummary(output) ?? approvalReason)
+          ? (extractSummary(output) ?? outputError ?? approvalReason)
           : undefined,
     uiHint: config.uiHint,
+    approval,
   };
 }
 
@@ -335,7 +382,7 @@ export function decodeToolEvents(toolCalls: unknown): DecodedToolEvents {
 export function toolEventToMessagePart(
   event: PersistedToolEvent
 ): DynamicToolUIPart {
-  const uiState = mapPersistedStateToUiState(event.state);
+  const uiState = mapPersistedEventToUiState(event);
 
   if (uiState === 'input-available') {
     return {
@@ -384,14 +431,29 @@ export function toolEventToMessagePart(
     };
   }
 
+  if (uiState === 'approval-requested') {
+    return {
+      type: 'dynamic-tool',
+      toolName: event.toolName,
+      toolCallId: event.toolCallId,
+      state: uiState,
+      input: event.input ?? {},
+      approval: {
+        id: event.approval?.id ?? `${event.toolCallId}-approval`,
+      },
+    };
+  }
+
   return {
     type: 'dynamic-tool',
     toolName: event.toolName,
     toolCallId: event.toolCallId,
-    state: 'approval-requested',
+    state: uiState,
     input: event.input ?? {},
     approval: {
-      id: `${event.toolCallId}-approval`,
+      id: event.approval?.id ?? `${event.toolCallId}-approval`,
+      approved: event.approval?.approved ?? false,
+      ...(event.approval?.reason ? { reason: event.approval.reason } : {}),
     },
   };
 }

--- a/apps/web/lib/chat/tool-events.ts
+++ b/apps/web/lib/chat/tool-events.ts
@@ -1,0 +1,397 @@
+import {
+  type DynamicToolUIPart,
+  getToolName,
+  isToolUIPart,
+  type UIMessage,
+} from 'ai';
+import { z } from 'zod';
+import { getToolUiConfig } from './tool-ui-registry';
+
+export type PersistedToolState =
+  | 'running'
+  | 'succeeded'
+  | 'failed'
+  | 'denied'
+  | 'needs-approval';
+
+export type PersistedToolUiHint = 'artifact' | 'status';
+
+export interface PersistedToolEvent {
+  readonly schemaVersion: 2;
+  readonly toolCallId: string;
+  readonly toolName: string;
+  readonly state: PersistedToolState;
+  readonly input?: Record<string, unknown>;
+  readonly output?: Record<string, unknown>;
+  readonly errorMessage?: string;
+  readonly summary?: string;
+  readonly uiHint: PersistedToolUiHint;
+}
+
+export interface PendingToolPersistenceEnvelope {
+  readonly userMessage: string;
+}
+
+const recordSchema = z.record(z.string(), z.unknown());
+
+export const persistedToolEventSchema = z.object({
+  schemaVersion: z.literal(2),
+  toolCallId: z.string().min(1),
+  toolName: z.string().min(1),
+  state: z.enum(['running', 'succeeded', 'failed', 'denied', 'needs-approval']),
+  input: recordSchema.optional(),
+  output: recordSchema.optional(),
+  errorMessage: z.string().optional(),
+  summary: z.string().optional(),
+  uiHint: z.enum(['artifact', 'status']),
+});
+
+export const persistedToolEventsSchema = z.array(persistedToolEventSchema);
+
+export const chatPersistenceMessageSchema = z
+  .object({
+    role: z.enum(['user', 'assistant']),
+    content: z.string().max(50_000),
+    toolCalls: persistedToolEventsSchema.optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.role === 'user' && value.content.length < 1) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'User messages must include content.',
+        path: ['content'],
+      });
+    }
+
+    if (
+      value.role === 'assistant' &&
+      value.content.length < 1 &&
+      (!value.toolCalls || value.toolCalls.length === 0)
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        message:
+          'Assistant messages require content unless they include tool calls.',
+        path: ['content'],
+      });
+    }
+  });
+
+export const chatPersistenceBatchSchema = z.object({
+  messages: z.array(chatPersistenceMessageSchema).min(1).max(100),
+});
+
+export type ChatPersistenceMessage = z.infer<
+  typeof chatPersistenceMessageSchema
+>;
+export type ChatPersistenceBatch = z.infer<typeof chatPersistenceBatchSchema>;
+
+type ToolPart = UIMessage['parts'][number] & {
+  readonly toolCallId?: string;
+  readonly input?: unknown;
+  readonly output?: unknown;
+  readonly errorText?: string;
+  readonly state?: string;
+  readonly approval?: {
+    readonly id: string;
+    readonly approved?: boolean;
+    readonly reason?: string;
+  };
+};
+
+export interface DecodedToolEvents {
+  readonly events: PersistedToolEvent[];
+  readonly source: 'empty' | 'v2' | 'legacy' | 'invalid';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function extractSummary(value: unknown): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  for (const key of ['summary', 'title', 'message', 'error']) {
+    if (typeof value[key] === 'string' && value[key].trim().length > 0) {
+      return value[key].trim();
+    }
+  }
+
+  return undefined;
+}
+
+function mapUiStateToPersistedState(
+  state: string
+): PersistedToolState | undefined {
+  switch (state) {
+    case 'input-streaming':
+    case 'input-available':
+      return 'running';
+    case 'approval-requested':
+    case 'approval-responded':
+      return 'needs-approval';
+    case 'output-available':
+      return 'succeeded';
+    case 'output-error':
+      return 'failed';
+    case 'output-denied':
+      return 'denied';
+    default:
+      return undefined;
+  }
+}
+
+function mapPersistedStateToUiState(
+  state: PersistedToolState
+):
+  | 'input-available'
+  | 'output-available'
+  | 'output-error'
+  | 'output-denied'
+  | 'approval-requested' {
+  switch (state) {
+    case 'running':
+      return 'input-available';
+    case 'succeeded':
+      return 'output-available';
+    case 'failed':
+      return 'output-error';
+    case 'denied':
+      return 'output-denied';
+    case 'needs-approval':
+      return 'approval-requested';
+  }
+}
+
+function normalizeToolPart(part: ToolPart): PersistedToolEvent | null {
+  if (!isToolUIPart(part)) {
+    return null;
+  }
+
+  const toolName = getToolName(part);
+  const mappedState = mapUiStateToPersistedState(part.state);
+
+  if (
+    !mappedState ||
+    typeof part.toolCallId !== 'string' ||
+    part.toolCallId.length < 1
+  ) {
+    return null;
+  }
+
+  const config = getToolUiConfig(toolName);
+  const input = asRecord(part.input);
+  const output = asRecord(part.output);
+  const state =
+    mappedState === 'succeeded' && output?.success === false
+      ? 'failed'
+      : mappedState;
+  const approvalReason =
+    part.approval && typeof part.approval.reason === 'string'
+      ? part.approval.reason
+      : undefined;
+
+  return {
+    schemaVersion: 2,
+    toolCallId: part.toolCallId,
+    toolName,
+    state,
+    input,
+    output,
+    errorMessage:
+      typeof part.errorText === 'string'
+        ? part.errorText
+        : state === 'denied'
+          ? approvalReason
+          : undefined,
+    summary:
+      state === 'succeeded'
+        ? extractSummary(output)
+        : state === 'failed' || state === 'denied'
+          ? (extractSummary(output) ?? approvalReason)
+          : undefined,
+    uiHint: config.uiHint,
+  };
+}
+
+function normalizeLegacyState(
+  value: unknown,
+  result: Record<string, unknown> | undefined
+): PersistedToolState {
+  if (value === 'partial-call' || value === 'call') {
+    return 'running';
+  }
+
+  if (result?.success === false) {
+    return 'failed';
+  }
+
+  return 'succeeded';
+}
+
+function decodeLegacyToolEvent(
+  value: unknown,
+  index: number
+): PersistedToolEvent | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const nested = isRecord(value.toolInvocation)
+    ? value.toolInvocation
+    : undefined;
+  const toolNameCandidate = value.toolName ?? nested?.toolName;
+  const toolName =
+    typeof toolNameCandidate === 'string' && toolNameCandidate.length > 0
+      ? toolNameCandidate
+      : null;
+
+  if (!toolName) {
+    return null;
+  }
+
+  const toolCallIdCandidate =
+    value.toolCallId ??
+    value.toolInvocationId ??
+    nested?.toolCallId ??
+    nested?.toolInvocationId;
+  const toolCallId =
+    typeof toolCallIdCandidate === 'string' && toolCallIdCandidate.length > 0
+      ? toolCallIdCandidate
+      : `legacy-tool-${index}`;
+
+  const input = asRecord(value.args ?? nested?.args);
+  const output = asRecord(value.result ?? nested?.result);
+  const state = normalizeLegacyState(value.state ?? nested?.state, output);
+  const config = getToolUiConfig(toolName);
+
+  return {
+    schemaVersion: 2,
+    toolCallId,
+    toolName,
+    state,
+    input,
+    output,
+    errorMessage:
+      state === 'failed'
+        ? (extractSummary(output) ?? 'Tool execution failed.')
+        : undefined,
+    summary: state === 'succeeded' ? extractSummary(output) : undefined,
+    uiHint: config.uiHint,
+  };
+}
+
+function dedupeEvents(events: PersistedToolEvent[]): PersistedToolEvent[] {
+  const byId = new Map<string, PersistedToolEvent>();
+
+  for (const event of events) {
+    byId.set(event.toolCallId, event);
+  }
+
+  return Array.from(byId.values());
+}
+
+export function encodeToolEvents(
+  parts: ReadonlyArray<UIMessage['parts'][number]>
+): PersistedToolEvent[] | undefined {
+  const events = dedupeEvents(
+    parts
+      .map(part => normalizeToolPart(part as ToolPart))
+      .filter((event): event is PersistedToolEvent => event !== null)
+  );
+
+  return events.length > 0 ? events : undefined;
+}
+
+export function decodeToolEvents(toolCalls: unknown): DecodedToolEvents {
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) {
+    return { events: [], source: 'empty' };
+  }
+
+  const v2 = persistedToolEventsSchema.safeParse(toolCalls);
+  if (v2.success) {
+    return { events: dedupeEvents(v2.data), source: 'v2' };
+  }
+
+  const legacyEvents = dedupeEvents(
+    toolCalls
+      .map((toolCall, index) => decodeLegacyToolEvent(toolCall, index))
+      .filter((event): event is PersistedToolEvent => event !== null)
+  );
+
+  if (legacyEvents.length > 0) {
+    return { events: legacyEvents, source: 'legacy' };
+  }
+
+  return { events: [], source: 'invalid' };
+}
+
+export function toolEventToMessagePart(
+  event: PersistedToolEvent
+): DynamicToolUIPart {
+  const uiState = mapPersistedStateToUiState(event.state);
+
+  if (uiState === 'input-available') {
+    return {
+      type: 'dynamic-tool',
+      toolName: event.toolName,
+      toolCallId: event.toolCallId,
+      state: uiState,
+      input: event.input ?? {},
+    };
+  }
+
+  if (uiState === 'output-available') {
+    return {
+      type: 'dynamic-tool',
+      toolName: event.toolName,
+      toolCallId: event.toolCallId,
+      state: uiState,
+      input: event.input ?? {},
+      output: event.output ?? {},
+    };
+  }
+
+  if (uiState === 'output-error') {
+    return {
+      type: 'dynamic-tool',
+      toolName: event.toolName,
+      toolCallId: event.toolCallId,
+      state: uiState,
+      input: event.input,
+      errorText: event.errorMessage ?? 'Tool execution failed.',
+    };
+  }
+
+  if (uiState === 'output-denied') {
+    return {
+      type: 'dynamic-tool',
+      toolName: event.toolName,
+      toolCallId: event.toolCallId,
+      state: uiState,
+      input: event.input ?? {},
+      approval: {
+        id: `${event.toolCallId}-approval`,
+        approved: false,
+        ...(event.errorMessage ? { reason: event.errorMessage } : {}),
+      },
+    };
+  }
+
+  return {
+    type: 'dynamic-tool',
+    toolName: event.toolName,
+    toolCallId: event.toolCallId,
+    state: 'approval-requested',
+    input: event.input ?? {},
+    approval: {
+      id: `${event.toolCallId}-approval`,
+    },
+  };
+}

--- a/apps/web/lib/chat/tool-ui-registry.ts
+++ b/apps/web/lib/chat/tool-ui-registry.ts
@@ -1,0 +1,146 @@
+export type ToolUiRenderer = 'artifact' | 'status';
+export type ToolUiHint = 'artifact' | 'status';
+
+export interface ToolUiConfig {
+  readonly label: string;
+  readonly uiHint: ToolUiHint;
+  readonly renderer: ToolUiRenderer;
+  readonly loadingTitle?: string;
+  readonly errorTitle?: string;
+}
+
+export const TOOL_UI_REGISTRY = {
+  proposeAvatarUpload: {
+    label: 'Avatar Upload',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Preparing Photo Upload...',
+    errorTitle: 'Photo Upload Failed',
+  },
+  proposeSocialLink: {
+    label: 'Social Link',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Adding Link...',
+    errorTitle: 'Link Update Failed',
+  },
+  proposeSocialLinkRemoval: {
+    label: 'Social Link Removal',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Removing Link...',
+    errorTitle: 'Link Removal Failed',
+  },
+  submitFeedback: {
+    label: 'Feedback',
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Submitting Feedback...',
+    errorTitle: 'Feedback Submission Failed',
+  },
+  showTopInsights: {
+    label: 'Top Insights',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Checking Your Signals...',
+    errorTitle: 'Insights Unavailable',
+  },
+  proposeProfileEdit: {
+    label: 'Profile Edit',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Editing Profile...',
+    errorTitle: 'Profile Edit Failed',
+  },
+  checkCanvasStatus: {
+    label: 'Canvas Status',
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Checking Canvas Status...',
+    errorTitle: 'Canvas Check Failed',
+  },
+  suggestRelatedArtists: {
+    label: 'Related Artists',
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Finding Related Artists...',
+    errorTitle: 'Related Artist Search Failed',
+  },
+  writeWorldClassBio: {
+    label: 'Artist Bio',
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Writing Bio...',
+    errorTitle: 'Bio Draft Failed',
+  },
+  generateCanvasPlan: {
+    label: 'Canvas Plan',
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Planning Canvas Video...',
+    errorTitle: 'Canvas Plan Failed',
+  },
+  generateAlbumArt: {
+    label: 'Album Art',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Generating Album Art...',
+    errorTitle: 'Album Art Failed',
+  },
+  createPromoStrategy: {
+    label: 'Promo Strategy',
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Building Promo Strategy...',
+    errorTitle: 'Promo Strategy Failed',
+  },
+  markCanvasUploaded: {
+    label: 'Canvas Upload',
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Updating Canvas Status...',
+    errorTitle: 'Canvas Update Failed',
+  },
+  formatLyrics: {
+    label: 'Lyrics Format',
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Formatting Lyrics...',
+    errorTitle: 'Lyrics Format Failed',
+  },
+  createRelease: {
+    label: 'Create Release',
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Creating Release...',
+    errorTitle: 'Release Creation Failed',
+  },
+  generateReleasePitch: {
+    label: 'Release Pitch',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Generating Pitches...',
+    errorTitle: 'Pitch Generation Failed',
+  },
+} as const satisfies Record<string, ToolUiConfig>;
+
+function startCaseFromCamelCase(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, letter => letter.toUpperCase());
+}
+
+export function getToolUiConfig(toolName: string): ToolUiConfig {
+  return (
+    TOOL_UI_REGISTRY[toolName as keyof typeof TOOL_UI_REGISTRY] ?? {
+      label: startCaseFromCamelCase(toolName),
+      uiHint: 'status',
+      renderer: 'status',
+      loadingTitle: `${startCaseFromCamelCase(toolName)} In Progress...`,
+      errorTitle: `${startCaseFromCamelCase(toolName)} Failed`,
+    }
+  );
+}

--- a/apps/web/lib/db/schema/chat.ts
+++ b/apps/web/lib/db/schema/chat.ts
@@ -7,6 +7,7 @@ import {
   uuid,
 } from 'drizzle-orm/pg-core';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+import type { PersistedToolEvent } from '@/lib/chat/tool-events';
 import { users } from './auth';
 import { chatMessageRoleEnum } from './enums';
 import { creatorProfiles } from './profiles';
@@ -53,7 +54,7 @@ export const chatMessages = pgTable(
       .references(() => chatConversations.id, { onDelete: 'cascade' }),
     role: chatMessageRoleEnum('role').notNull(),
     content: text('content').notNull(),
-    toolCalls: jsonb('tool_calls').$type<Record<string, unknown>[]>(),
+    toolCalls: jsonb('tool_calls').$type<PersistedToolEvent[]>(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
   },
   table => ({

--- a/apps/web/lib/db/schema/chat.ts
+++ b/apps/web/lib/db/schema/chat.ts
@@ -7,7 +7,6 @@ import {
   uuid,
 } from 'drizzle-orm/pg-core';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
-import type { PersistedToolEvent } from '@/lib/chat/tool-events';
 import { users } from './auth';
 import { chatMessageRoleEnum } from './enums';
 import { creatorProfiles } from './profiles';
@@ -54,7 +53,7 @@ export const chatMessages = pgTable(
       .references(() => chatConversations.id, { onDelete: 'cascade' }),
     role: chatMessageRoleEnum('role').notNull(),
     content: text('content').notNull(),
-    toolCalls: jsonb('tool_calls').$type<PersistedToolEvent[]>(),
+    toolCalls: jsonb('tool_calls'),
     createdAt: timestamp('created_at').defaultNow().notNull(),
   },
   table => ({

--- a/apps/web/lib/queries/useChatMutations.ts
+++ b/apps/web/lib/queries/useChatMutations.ts
@@ -1,6 +1,10 @@
 'use client';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type {
+  ChatPersistenceMessage,
+  PersistedToolEvent,
+} from '@/lib/chat/tool-events';
 import { createMutationFn, FetchError, fetchWithTimeout } from './fetch';
 import { queryKeys } from './keys';
 import type { ChatConversation } from './useChatConversationsQuery';
@@ -28,7 +32,7 @@ export interface ChatMessage {
   id: string;
   role: 'user' | 'assistant';
   content: string;
-  toolCalls?: Record<string, unknown>[];
+  toolCalls?: PersistedToolEvent[];
   createdAt: string;
 }
 
@@ -43,11 +47,7 @@ interface CreateConversationResponse {
 
 interface AddMessagesInput {
   conversationId: string;
-  messages: Array<{
-    role: 'user' | 'assistant';
-    content: string;
-    toolCalls?: Record<string, unknown>[];
-  }>;
+  messages: ChatPersistenceMessage[];
 }
 
 interface AddMessagesResponse {

--- a/apps/web/scripts/backfill-chat-tool-events.ts
+++ b/apps/web/scripts/backfill-chat-tool-events.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env tsx
+
+import { pathToFileURL } from 'node:url';
+import { and, eq, gt, isNotNull } from 'drizzle-orm';
+import {
+  decodeToolEvents,
+  type PersistedToolEvent,
+} from '@/lib/chat/tool-events';
+import { db } from '@/lib/db';
+import { chatMessages } from '@/lib/db/schema/chat';
+
+interface BackfillArgs {
+  readonly dryRun: boolean;
+  readonly limit: number;
+  readonly cursor: string | null;
+}
+
+interface BackfillDecision {
+  readonly source: 'empty' | 'v2' | 'legacy' | 'invalid';
+  readonly events: PersistedToolEvent[] | null;
+}
+
+interface BackfillSummary {
+  readonly dryRun: boolean;
+  readonly scanned: number;
+  readonly updated: number;
+  readonly skipped: number;
+  readonly invalid: number;
+  readonly nextCursor: string | null;
+}
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 1_000;
+
+export function parseBackfillArgs(argv: readonly string[]): BackfillArgs {
+  let dryRun = false;
+  let limit = DEFAULT_LIMIT;
+  let cursor: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+
+    if (value === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+
+    if (value === '--limit') {
+      const nextValue = argv[index + 1];
+      const parsed = Number.parseInt(nextValue ?? '', 10);
+
+      if (!Number.isFinite(parsed) || parsed < 1 || parsed > MAX_LIMIT) {
+        throw new Error(
+          `--limit must be an integer between 1 and ${MAX_LIMIT}.`
+        );
+      }
+
+      limit = parsed;
+      index += 1;
+      continue;
+    }
+
+    if (value === '--cursor') {
+      const nextValue = argv[index + 1];
+
+      if (!nextValue) {
+        throw new Error('--cursor requires a message id.');
+      }
+
+      cursor = nextValue;
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${value}`);
+  }
+
+  return { dryRun, limit, cursor };
+}
+
+export function getBackfillDecision(toolCalls: unknown): BackfillDecision {
+  const decoded = decodeToolEvents(toolCalls);
+
+  if (decoded.source === 'legacy') {
+    return {
+      source: decoded.source,
+      events: decoded.events.length > 0 ? decoded.events : null,
+    };
+  }
+
+  return { source: decoded.source, events: null };
+}
+
+export async function backfillChatToolEvents({
+  dryRun,
+  limit,
+  cursor,
+}: BackfillArgs): Promise<BackfillSummary> {
+  const rows = await db
+    .select({
+      id: chatMessages.id,
+      toolCalls: chatMessages.toolCalls,
+    })
+    .from(chatMessages)
+    .where(
+      cursor
+        ? and(isNotNull(chatMessages.toolCalls), gt(chatMessages.id, cursor))
+        : isNotNull(chatMessages.toolCalls)
+    )
+    .orderBy(chatMessages.id)
+    .limit(limit);
+
+  let updated = 0;
+  let skipped = 0;
+  let invalid = 0;
+
+  for (const row of rows) {
+    const decision = getBackfillDecision(row.toolCalls);
+
+    if (decision.source === 'legacy' && decision.events) {
+      if (!dryRun) {
+        await db
+          .update(chatMessages)
+          .set({ toolCalls: decision.events })
+          .where(eq(chatMessages.id, row.id));
+      }
+
+      updated += 1;
+      continue;
+    }
+
+    if (decision.source === 'invalid') {
+      invalid += 1;
+      continue;
+    }
+
+    skipped += 1;
+  }
+
+  return {
+    dryRun,
+    scanned: rows.length,
+    updated,
+    skipped,
+    invalid,
+    nextCursor: rows.at(-1)?.id ?? null,
+  };
+}
+
+async function main() {
+  const args = parseBackfillArgs(process.argv.slice(2));
+  const summary = await backfillChatToolEvents(args);
+
+  console.log(
+    JSON.stringify(
+      {
+        ...summary,
+        mode: summary.dryRun ? 'dry-run' : 'write',
+      },
+      null,
+      2
+    )
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  void main().catch(error => {
+    console.error('Chat tool event backfill failed:', error);
+    process.exit(1);
+  });
+}

--- a/apps/web/tests/e2e/chat-pitch-generation.spec.ts
+++ b/apps/web/tests/e2e/chat-pitch-generation.spec.ts
@@ -70,7 +70,9 @@ test.describe
       // suggested prompts entirely. Check for either the suggestion OR the
       // profile completion card.
       const pitchSuggestion = page.getByText(/generate pitches/i);
-      const profileCard = page.getByText(/your profile is not live/i);
+      const profileCompletionGate = page.getByRole('button', {
+        name: /profile \d+% complete/i,
+      });
       const chatInput = page.getByPlaceholder(/ask jovie|chat message/i);
 
       // At minimum, the chat input should be present
@@ -79,7 +81,7 @@ test.describe
       // If the profile completion card is showing, pitch suggestion is hidden
       // because SuggestedPrompts only renders when profile is 100% complete.
       // This is correct behavior — not a test failure.
-      const isProfileIncomplete = await profileCard
+      const isProfileIncomplete = await profileCompletionGate
         .isVisible()
         .catch(() => false);
       if (!isProfileIncomplete) {
@@ -109,21 +111,12 @@ test.describe
       await expect(sendButton).toBeEnabled({ timeout: 5_000 });
       await sendButton.click();
 
-      // Verify the user message appears in the chat
-      const userMessage = page.getByText(
-        'Generate playlist pitches for my latest release.'
+      // Wait for the actual pitch tool UI, not just "some assistant activity".
+      // The tool can surface either the loading title or the completed card.
+      const pitchToolUi = page.getByText(
+        /Generating pitches|Playlist Pitches/i
       );
-      await expect(userMessage).toBeVisible({ timeout: 10_000 });
-
-      // Wait for the AI to start responding (look for assistant message indicators)
-      // The response may include:
-      // - A "Generating pitches..." tool label
-      // - A ChatPitchCard (loading or success state)
-      // - Or just text if the model decides not to use the tool
-      const assistantResponse = page.locator(
-        '[data-index="1"], [class*="animate-bounce"]'
-      );
-      await expect(assistantResponse.first()).toBeVisible({ timeout: 30_000 });
+      await expect(pitchToolUi.first()).toBeVisible({ timeout: 30_000 });
     });
 
     test('billing status reflects pro plan via API', async ({ page }) => {

--- a/apps/web/tests/unit/api/chat/conversation-message-routes.test.ts
+++ b/apps/web/tests/unit/api/chat/conversation-message-routes.test.ts
@@ -1,0 +1,292 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  const selectLimitMock = vi.fn();
+  const selectOrderByMock = vi.fn().mockReturnValue({ limit: selectLimitMock });
+  const selectWhereMock = vi.fn().mockImplementation(() => ({
+    limit: selectLimitMock,
+    orderBy: selectOrderByMock,
+  }));
+  const selectFromMock = vi.fn().mockReturnValue({ where: selectWhereMock });
+  const selectMock = vi.fn().mockReturnValue({ from: selectFromMock });
+
+  const insertReturningMock = vi.fn();
+  const insertValuesMock = vi
+    .fn()
+    .mockReturnValue({ returning: insertReturningMock });
+  const insertMock = vi.fn().mockReturnValue({ values: insertValuesMock });
+
+  const updateWhereMock = vi.fn().mockResolvedValue(undefined);
+  const updateSetMock = vi.fn().mockReturnValue({ where: updateWhereMock });
+  const updateMock = vi.fn().mockReturnValue({ set: updateSetMock });
+
+  return {
+    getSessionContextMock: vi.fn(),
+    selectMock,
+    selectLimitMock,
+    insertMock,
+    insertValuesMock,
+    insertReturningMock,
+    updateMock,
+    captureErrorMock: vi.fn(),
+    loggerWarnMock: vi.fn(),
+    loggerErrorMock: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionContext: hoisted.getSessionContextMock,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: hoisted.selectMock,
+    insert: hoisted.insertMock,
+    update: hoisted.updateMock,
+  },
+}));
+
+vi.mock('@/lib/db/schema/chat', () => ({
+  chatConversations: {
+    id: 'conversationId',
+    title: 'title',
+    creatorProfileId: 'creatorProfileId',
+    updatedAt: 'updatedAt',
+  },
+  chatMessages: {
+    id: 'messageId',
+    conversationId: 'conversationId',
+    role: 'role',
+    content: 'content',
+    toolCalls: 'toolCalls',
+    createdAt: 'createdAt',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn(),
+  desc: vi.fn(),
+  eq: vi.fn(),
+  isNull: vi.fn(),
+  lt: vi.fn(),
+}));
+
+vi.mock('@ai-sdk/gateway', () => ({
+  gateway: vi.fn(),
+}));
+
+vi.mock('ai', () => ({
+  generateText: vi.fn(),
+}));
+
+vi.mock('next/server', async importOriginal => {
+  const actual = await importOriginal<typeof import('next/server')>();
+  return {
+    ...actual,
+    after: vi.fn(),
+  };
+});
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: hoisted.captureErrorMock,
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: hoisted.loggerWarnMock,
+    error: hoisted.loggerErrorMock,
+  },
+}));
+
+vi.mock('@/app/api/chat/session-error-response', () => ({
+  getSessionErrorResponse: vi.fn().mockReturnValue(null),
+}));
+
+describe('chat conversation message routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.getSessionContextMock.mockResolvedValue({
+      profile: { id: 'profile-1' },
+    });
+  });
+
+  it('accepts assistant tool-only messages on POST', async () => {
+    hoisted.selectLimitMock.mockResolvedValueOnce([
+      {
+        id: 'conv-1',
+        title: 'Existing thread',
+      },
+    ]);
+    hoisted.insertReturningMock.mockResolvedValueOnce([
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          {
+            schemaVersion: 2,
+            toolCallId: 'tool-1',
+            toolName: 'generateAlbumArt',
+            state: 'succeeded',
+            output: { success: true, title: 'Neon Nights' },
+            summary: 'Neon Nights',
+            uiHint: 'artifact',
+          },
+        ],
+      },
+    ]);
+
+    const { POST } = await import(
+      '@/app/api/chat/conversations/[id]/messages/route'
+    );
+    const response = await POST(
+      new Request('http://localhost/api/chat/conversations/conv-1/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          messages: [
+            {
+              role: 'assistant',
+              content: '',
+              toolCalls: [
+                {
+                  schemaVersion: 2,
+                  toolCallId: 'tool-1',
+                  toolName: 'generateAlbumArt',
+                  state: 'succeeded',
+                  output: { success: true, title: 'Neon Nights' },
+                  summary: 'Neon Nights',
+                  uiHint: 'artifact',
+                },
+              ],
+            },
+          ],
+        }),
+      }),
+      { params: Promise.resolve({ id: 'conv-1' }) }
+    );
+
+    expect(response.status).toBe(201);
+    expect(hoisted.insertValuesMock).toHaveBeenCalledWith([
+      {
+        conversationId: 'conv-1',
+        role: 'assistant',
+        content: '',
+        toolCalls: [
+          {
+            schemaVersion: 2,
+            toolCallId: 'tool-1',
+            toolName: 'generateAlbumArt',
+            state: 'succeeded',
+            output: { success: true, title: 'Neon Nights' },
+            summary: 'Neon Nights',
+            uiHint: 'artifact',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects assistant messages with empty content and no tool calls', async () => {
+    hoisted.selectLimitMock.mockResolvedValueOnce([
+      {
+        id: 'conv-1',
+        title: 'Existing thread',
+      },
+    ]);
+
+    const { POST } = await import(
+      '@/app/api/chat/conversations/[id]/messages/route'
+    );
+    const response = await POST(
+      new Request('http://localhost/api/chat/conversations/conv-1/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          role: 'assistant',
+          content: '',
+        }),
+      }),
+      { params: Promise.resolve({ id: 'conv-1' }) }
+    );
+
+    expect(response.status).toBe(400);
+    expect(hoisted.insertMock).not.toHaveBeenCalled();
+    expect(hoisted.loggerWarnMock).toHaveBeenCalled();
+  });
+
+  it('returns normalized tool calls on GET and flags legacy reads', async () => {
+    hoisted.selectLimitMock
+      .mockResolvedValueOnce([
+        {
+          id: 'conv-1',
+          title: 'Existing thread',
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'msg-v2',
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            {
+              schemaVersion: 2,
+              toolCallId: 'tool-v2',
+              toolName: 'showTopInsights',
+              state: 'succeeded',
+              output: { success: true, title: 'Top Signals' },
+              summary: 'Top Signals',
+              uiHint: 'artifact',
+            },
+          ],
+          createdAt: new Date('2026-01-02T00:00:00.000Z'),
+        },
+        {
+          id: 'msg-legacy',
+          role: 'assistant',
+          content: '',
+          toolCalls: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                toolCallId: 'tool-legacy',
+                toolName: 'showTopInsights',
+                state: 'result',
+                result: { success: true, title: 'Legacy Signals' },
+              },
+            },
+          ],
+          createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        },
+      ]);
+
+    const { GET } = await import('@/app/api/chat/conversations/[id]/route');
+    const response = await GET(
+      new Request('http://localhost/api/chat/conversations/conv-1'),
+      { params: Promise.resolve({ id: 'conv-1' }) }
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.messages).toHaveLength(2);
+    expect(body.messages[0].toolCalls).toEqual([
+      expect.objectContaining({
+        toolCallId: 'tool-legacy',
+        toolName: 'showTopInsights',
+        state: 'succeeded',
+      }),
+    ]);
+    expect(body.messages[1].toolCalls).toEqual([
+      expect.objectContaining({
+        toolCallId: 'tool-v2',
+        toolName: 'showTopInsights',
+        state: 'succeeded',
+      }),
+    ]);
+    expect(hoisted.loggerWarnMock).toHaveBeenCalledWith(
+      'Decoded legacy tool calls while loading conversation',
+      { conversationId: 'conv-1', messageId: 'msg-legacy' },
+      'chat-conversation'
+    );
+  });
+});

--- a/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
@@ -25,6 +25,12 @@ vi.mock('@jovie/ui', () => ({
   SimpleTooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
+vi.mock('next/dynamic', () => ({
+  default:
+    () =>
+    ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
 vi.mock('@/components/jovie/components/ChatMarkdown', () => ({
   ChatMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
 }));
@@ -47,11 +53,12 @@ describe('ChatMessage analytics cards', () => {
     const parts = [
       { type: 'text', text: 'Here are the strongest signals I see.' },
       {
-        type: 'tool-invocation',
-        toolInvocationId: 'tool-1',
+        type: 'dynamic-tool',
         toolName: 'showTopInsights',
-        state: 'result',
-        result: {
+        toolCallId: 'tool-1',
+        state: 'output-available',
+        input: { artistId: 'artist-1' },
+        output: {
           success: true,
           title: 'Top signals',
           totalActive: 2,
@@ -74,10 +81,6 @@ describe('ChatMessage analytics cards', () => {
             },
           ],
         },
-        toolInvocation: {
-          toolName: 'showTopInsights',
-          state: 'result',
-        },
       },
     ] as ComponentProps<typeof ChatMessage>['parts'];
     const messageProps = {
@@ -93,5 +96,30 @@ describe('ChatMessage analytics cards', () => {
     expect(
       screen.getByText('Subscribers are picking up in Chicago')
     ).toBeTruthy();
+  });
+
+  it('renders a compact error row for unknown failed tools', () => {
+    const messageProps = {
+      id: 'assistant-3',
+      role: 'assistant' as const,
+      parts: [
+        {
+          type: 'dynamic-tool' as const,
+          toolName: 'unknownTool',
+          toolCallId: 'tool-unknown',
+          state: 'output-error' as const,
+          input: { value: 1 },
+          errorText: 'Something broke',
+        },
+      ],
+    };
+
+    fastRender(<ChatMessage {...messageProps} />);
+
+    const statusRow = screen.getByTestId('tool-status-row');
+    expect(statusRow.getAttribute('role')).toBe('alert');
+    expect(statusRow.getAttribute('data-tool-name')).toBe('unknownTool');
+    expect(screen.getByText('Unknown Tool Failed')).toBeTruthy();
+    expect(screen.getByText('Something broke')).toBeTruthy();
   });
 });

--- a/apps/web/tests/unit/chat/InlineChatArea.tool-rendering.test.tsx
+++ b/apps/web/tests/unit/chat/InlineChatArea.tool-rendering.test.tsx
@@ -107,11 +107,12 @@ describe('InlineChatArea tool invocation rendering', () => {
         parts: [
           { type: 'text', text: "Here's a preview of the change:" },
           {
-            type: 'tool-invocation',
-            toolInvocationId: 'tool-1',
+            type: 'dynamic-tool',
             toolName: 'proposeProfileEdit',
-            state: 'result',
-            result: {
+            toolCallId: 'tool-1',
+            state: 'output-available',
+            input: { field: 'displayName' },
+            output: {
               success: true,
               preview: {
                 field: 'displayName',
@@ -140,11 +141,11 @@ describe('InlineChatArea tool invocation rendering', () => {
         role: 'assistant',
         parts: [
           {
-            type: 'tool-invocation',
-            toolInvocationId: 'tool-1',
+            type: 'dynamic-tool',
             toolName: 'proposeProfileEdit',
-            state: 'call',
-            args: {
+            toolCallId: 'tool-1',
+            state: 'input-available',
+            input: {
               field: 'displayName',
               newValue: 'New Name',
             },
@@ -165,11 +166,11 @@ describe('InlineChatArea tool invocation rendering', () => {
         role: 'assistant',
         parts: [
           {
-            type: 'tool-invocation',
-            toolInvocationId: 'tool-1',
+            type: 'dynamic-tool',
             toolName: 'proposeProfileEdit',
-            state: 'result',
-            result: {
+            toolCallId: 'tool-1',
+            state: 'output-available',
+            output: {
               success: false,
               error: 'Something went wrong',
             },
@@ -190,11 +191,11 @@ describe('InlineChatArea tool invocation rendering', () => {
         role: 'assistant',
         parts: [
           {
-            type: 'tool-invocation',
-            toolInvocationId: 'tool-2',
+            type: 'dynamic-tool',
             toolName: 'proposeAvatarUpload',
-            state: 'result',
-            result: { success: true, action: 'avatar_upload' },
+            toolCallId: 'tool-2',
+            state: 'output-available',
+            output: { success: true, action: 'avatar_upload' },
           },
         ],
       },
@@ -212,11 +213,11 @@ describe('InlineChatArea tool invocation rendering', () => {
         role: 'assistant',
         parts: [
           {
-            type: 'tool-invocation',
-            toolInvocationId: 'tool-3',
+            type: 'dynamic-tool',
             toolName: 'proposeSocialLink',
-            state: 'result',
-            result: {
+            toolCallId: 'tool-3',
+            state: 'output-available',
+            output: {
               success: true,
               platform: {
                 id: 'instagram',
@@ -248,11 +249,11 @@ describe('InlineChatArea tool invocation rendering', () => {
         role: 'assistant',
         parts: [
           {
-            type: 'tool-invocation',
-            toolInvocationId: 'tool-4',
+            type: 'dynamic-tool',
             toolName: 'showTopInsights',
-            state: 'result',
-            result: {
+            toolCallId: 'tool-4',
+            state: 'output-available',
+            output: {
               success: true,
               title: 'Top signals',
               totalActive: 2,
@@ -290,5 +291,32 @@ describe('InlineChatArea tool invocation rendering', () => {
     expect(screen.queryByTestId('avatar-upload-card')).toBeNull();
     expect(screen.queryByTestId('chat-analytics-card')).toBeNull();
     expect(screen.queryByTestId('link-confirmation-card')).toBeNull();
+  });
+
+  it('renders a compact status row for unknown tools', () => {
+    mockMessages = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'dynamic-tool',
+            toolName: 'summarizeAudience',
+            toolCallId: 'tool-5',
+            state: 'output-available',
+            output: {
+              summary: 'Audience summary complete.',
+            },
+          },
+        ],
+      },
+    ];
+
+    renderInlineChat();
+
+    const statusRow = screen.getByTestId('tool-status-row');
+    expect(statusRow.getAttribute('data-tool-name')).toBe('summarizeAudience');
+    expect(screen.getByText('Summarize Audience')).toBeDefined();
+    expect(screen.getByText('Audience summary complete.')).toBeDefined();
   });
 });

--- a/apps/web/tests/unit/chat/message-parts.test.ts
+++ b/apps/web/tests/unit/chat/message-parts.test.ts
@@ -49,7 +49,7 @@ describe('message parts persistence', () => {
         toolCallId: 'tool-2',
         toolName: 'generateReleasePitch',
         state: 'failed',
-        errorMessage: undefined,
+        errorMessage: 'Pitch provider unavailable',
         summary: 'Pitch provider unavailable',
       }),
     ]);

--- a/apps/web/tests/unit/chat/message-parts.test.ts
+++ b/apps/web/tests/unit/chat/message-parts.test.ts
@@ -5,38 +5,82 @@ import {
 } from '@/components/jovie/message-parts';
 
 describe('message parts persistence', () => {
-  it('preserves full tool invocation parts for persistence', () => {
+  it('encodes SDK 6 tool parts into persisted tool events', () => {
     const toolCalls = extractPersistableToolCalls([
       { type: 'text', text: 'Hello' },
       {
-        type: 'tool-invocation',
-        toolInvocationId: 'tool-1',
+        type: 'dynamic-tool',
         toolName: 'showTopInsights',
-        state: 'result',
-        result: { success: true, title: 'Top signals' },
-        toolInvocation: {
-          toolName: 'showTopInsights',
-          state: 'result',
-        },
+        toolCallId: 'tool-1',
+        state: 'output-available',
+        input: { artistId: 'artist-1' },
+        output: { success: true, title: 'Top Signals' },
       },
     ]);
 
     expect(toolCalls).toEqual([
       {
-        type: 'tool-invocation',
-        toolInvocationId: 'tool-1',
+        schemaVersion: 2,
+        toolCallId: 'tool-1',
         toolName: 'showTopInsights',
-        state: 'result',
-        result: { success: true, title: 'Top signals' },
-        toolInvocation: {
-          toolName: 'showTopInsights',
-          state: 'result',
-        },
+        state: 'succeeded',
+        input: { artistId: 'artist-1' },
+        output: { success: true, title: 'Top Signals' },
+        summary: 'Top Signals',
+        uiHint: 'artifact',
       },
     ]);
   });
 
-  it('hydrates persisted legacy tool calls back into renderable tool invocation parts', () => {
+  it('maps output success false to a failed persisted event', () => {
+    const toolCalls = extractPersistableToolCalls([
+      {
+        type: 'dynamic-tool',
+        toolName: 'generateReleasePitch',
+        toolCallId: 'tool-2',
+        state: 'output-available',
+        input: { releaseId: 'release-1' },
+        output: { success: false, error: 'Pitch provider unavailable' },
+      },
+    ]);
+
+    expect(toolCalls).toEqual([
+      expect.objectContaining({
+        toolCallId: 'tool-2',
+        toolName: 'generateReleasePitch',
+        state: 'failed',
+        errorMessage: undefined,
+        summary: 'Pitch provider unavailable',
+      }),
+    ]);
+  });
+
+  it('hydrates persisted v2 tool events into renderable SDK 6 parts', () => {
+    const parts = hydratePersistedMessageParts('', [
+      {
+        schemaVersion: 2,
+        toolCallId: 'tool-v2',
+        toolName: 'showTopInsights',
+        state: 'succeeded',
+        output: { success: true, title: 'Top Signals' },
+        summary: 'Top Signals',
+        uiHint: 'artifact',
+      },
+    ]);
+
+    expect(parts).toEqual([
+      {
+        type: 'dynamic-tool',
+        toolName: 'showTopInsights',
+        toolCallId: 'tool-v2',
+        state: 'output-available',
+        input: {},
+        output: { success: true, title: 'Top Signals' },
+      },
+    ]);
+  });
+
+  it('hydrates legacy tool invocation records through the compatibility bridge', () => {
     const parts = hydratePersistedMessageParts('Here is your summary.', [
       {
         type: 'tool-invocation',
@@ -44,17 +88,44 @@ describe('message parts persistence', () => {
           toolCallId: 'tool-legacy',
           toolName: 'showTopInsights',
           state: 'result',
-          result: { success: true, title: 'Top signals' },
+          result: { success: true, title: 'Top Signals' },
         },
       },
     ]);
 
     expect(parts).toHaveLength(2);
-    expect(parts[1]).toMatchObject({
-      type: 'tool-invocation',
-      toolInvocationId: 'tool-legacy',
+    expect(parts[1]).toEqual({
+      type: 'dynamic-tool',
       toolName: 'showTopInsights',
-      state: 'result',
+      toolCallId: 'tool-legacy',
+      state: 'output-available',
+      input: {},
+      output: { success: true, title: 'Top Signals' },
     });
+  });
+
+  it('hydrates failed legacy tool results as output errors', () => {
+    const parts = hydratePersistedMessageParts('', [
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          toolCallId: 'tool-legacy-failed',
+          toolName: 'generateReleasePitch',
+          state: 'result',
+          result: { success: false, error: 'Pitch provider unavailable' },
+        },
+      },
+    ]);
+
+    expect(parts).toEqual([
+      {
+        type: 'dynamic-tool',
+        toolName: 'generateReleasePitch',
+        toolCallId: 'tool-legacy-failed',
+        state: 'output-error',
+        input: undefined,
+        errorText: 'Pitch provider unavailable',
+      },
+    ]);
   });
 });

--- a/apps/web/tests/unit/chat/tool-events.test.ts
+++ b/apps/web/tests/unit/chat/tool-events.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   decodeToolEvents,
+  encodeToolEvents,
   persistedToolEventsSchema,
+  toolEventToMessagePart,
 } from '@/lib/chat/tool-events';
 import { TOOL_UI_REGISTRY } from '@/lib/chat/tool-ui-registry';
 import {
@@ -80,6 +82,49 @@ describe('tool event contract', () => {
     for (const toolName of CHAT_ROUTE_TOOL_NAMES) {
       expect(TOOL_UI_REGISTRY[toolName]).toBeDefined();
     }
+  });
+
+  it('preserves approval responses through persistence and hydration', () => {
+    const [event] =
+      encodeToolEvents([
+        {
+          type: 'dynamic-tool',
+          toolName: 'submitFeedback',
+          toolCallId: 'approval-1',
+          state: 'approval-responded',
+          input: { feedback: 'Ship it' },
+          approval: {
+            id: 'approval-1-state',
+            approved: true,
+            reason: 'Reviewed by user',
+          },
+        },
+      ]) ?? [];
+
+    expect(event).toEqual(
+      expect.objectContaining({
+        toolCallId: 'approval-1',
+        state: 'needs-approval',
+        approval: {
+          id: 'approval-1-state',
+          approved: true,
+          reason: 'Reviewed by user',
+        },
+      })
+    );
+
+    expect(toolEventToMessagePart(event)).toEqual({
+      type: 'dynamic-tool',
+      toolName: 'submitFeedback',
+      toolCallId: 'approval-1',
+      state: 'approval-responded',
+      input: { feedback: 'Ship it' },
+      approval: {
+        id: 'approval-1-state',
+        approved: true,
+        reason: 'Reviewed by user',
+      },
+    });
   });
 });
 

--- a/apps/web/tests/unit/chat/tool-events.test.ts
+++ b/apps/web/tests/unit/chat/tool-events.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decodeToolEvents,
+  persistedToolEventsSchema,
+} from '@/lib/chat/tool-events';
+import { TOOL_UI_REGISTRY } from '@/lib/chat/tool-ui-registry';
+import {
+  getBackfillDecision,
+  parseBackfillArgs,
+} from '@/scripts/backfill-chat-tool-events';
+
+const CHAT_ROUTE_TOOL_NAMES = [
+  'proposeAvatarUpload',
+  'proposeSocialLink',
+  'proposeSocialLinkRemoval',
+  'submitFeedback',
+  'showTopInsights',
+  'proposeProfileEdit',
+  'checkCanvasStatus',
+  'suggestRelatedArtists',
+  'writeWorldClassBio',
+  'generateCanvasPlan',
+  'generateAlbumArt',
+  'createPromoStrategy',
+  'markCanvasUploaded',
+  'formatLyrics',
+  'createRelease',
+  'generateReleasePitch',
+] as const;
+
+describe('tool event contract', () => {
+  it('passes through persisted v2 events unchanged', () => {
+    const toolCalls = [
+      {
+        schemaVersion: 2,
+        toolCallId: 'tool-1',
+        toolName: 'showTopInsights',
+        state: 'succeeded',
+        output: { success: true, title: 'Top Signals' },
+        summary: 'Top Signals',
+        uiHint: 'artifact',
+      },
+    ];
+
+    const decoded = decodeToolEvents(toolCalls);
+
+    expect(decoded.source).toBe('v2');
+    expect(persistedToolEventsSchema.parse(decoded.events)).toEqual(toolCalls);
+  });
+
+  it('maps failed legacy results to failed persisted events', () => {
+    const decoded = decodeToolEvents([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          toolCallId: 'legacy-1',
+          toolName: 'generateReleasePitch',
+          state: 'result',
+          result: {
+            success: false,
+            error: 'Pitch provider unavailable',
+          },
+        },
+      },
+    ]);
+
+    expect(decoded.source).toBe('legacy');
+    expect(decoded.events).toEqual([
+      expect.objectContaining({
+        toolCallId: 'legacy-1',
+        toolName: 'generateReleasePitch',
+        state: 'failed',
+        errorMessage: 'Pitch provider unavailable',
+        uiHint: 'artifact',
+      }),
+    ]);
+  });
+
+  it('covers every chat tool in the shared UI registry', () => {
+    for (const toolName of CHAT_ROUTE_TOOL_NAMES) {
+      expect(TOOL_UI_REGISTRY[toolName]).toBeDefined();
+    }
+  });
+});
+
+describe('chat tool event backfill helpers', () => {
+  it('parses dry-run, limit, and cursor arguments', () => {
+    expect(
+      parseBackfillArgs(['--dry-run', '--limit', '25', '--cursor', 'msg-25'])
+    ).toEqual({
+      dryRun: true,
+      limit: 25,
+      cursor: 'msg-25',
+    });
+  });
+
+  it('returns legacy rows for backfill and skips already migrated rows', () => {
+    expect(
+      getBackfillDecision([
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            toolCallId: 'legacy-2',
+            toolName: 'showTopInsights',
+            state: 'result',
+            result: { success: true, title: 'Top Signals' },
+          },
+        },
+      ])
+    ).toEqual({
+      source: 'legacy',
+      events: [
+        {
+          schemaVersion: 2,
+          toolCallId: 'legacy-2',
+          toolName: 'showTopInsights',
+          state: 'succeeded',
+          input: undefined,
+          output: { success: true, title: 'Top Signals' },
+          errorMessage: undefined,
+          summary: 'Top Signals',
+          uiHint: 'artifact',
+        },
+      ],
+    });
+
+    expect(
+      getBackfillDecision([
+        {
+          schemaVersion: 2,
+          toolCallId: 'tool-2',
+          toolName: 'showTopInsights',
+          state: 'succeeded',
+          output: { success: true, title: 'Top Signals' },
+          summary: 'Top Signals',
+          uiHint: 'artifact',
+        },
+      ])
+    ).toEqual({
+      source: 'v2',
+      events: null,
+    });
+  });
+});

--- a/apps/web/tests/unit/chat/useJovieChat.rate-limit.test.tsx
+++ b/apps/web/tests/unit/chat/useJovieChat.rate-limit.test.tsx
@@ -15,6 +15,7 @@ vi.mock('next/navigation', () => ({
 const sendMessageMock = vi.fn();
 const maybeExecuteMock = vi.fn();
 const mutateAsyncMock = vi.fn();
+const addMessagesMutateMock = vi.fn();
 const setMessagesMock = vi.fn();
 let onRejectHandler: (() => void) | undefined;
 let mockStatus: 'ready' | 'streaming' = 'ready';
@@ -23,7 +24,7 @@ let currentTransportConversationId: string | null = null;
 let mockMessages: Array<{
   id: string;
   role: string;
-  parts: Array<{ type: 'text'; text: string }>;
+  parts: Array<Record<string, unknown>>;
   createdAt: Date;
 }> = [];
 let mockConversationData:
@@ -92,7 +93,7 @@ vi.mock('@/lib/queries/useChatConversationQuery', () => ({
 
 vi.mock('@/lib/queries/useChatMutations', () => ({
   useAddMessagesMutation: () => ({
-    mutate: vi.fn(),
+    mutate: addMessagesMutateMock,
   }),
   useCreateConversationMutation: () => ({
     mutateAsync: mutateAsyncMock,
@@ -105,6 +106,7 @@ describe('useJovieChat', () => {
     sendMessageMock.mockReset();
     maybeExecuteMock.mockReset();
     mutateAsyncMock.mockReset();
+    addMessagesMutateMock.mockReset();
     setMessagesMock.mockReset();
     mutateAsyncMock.mockResolvedValue({
       conversation: { id: 'conv_123' },
@@ -203,5 +205,124 @@ describe('useJovieChat', () => {
       conversationIdAtSend: 'conv_123',
       payload: { text: 'Hello Jovie' },
     });
+  });
+
+  it('persists tool-only assistant turns and clears submission state on success', async () => {
+    let onSuccess:
+      | ((data: { messages: unknown[]; titlePending?: boolean }) => void)
+      | undefined;
+
+    addMessagesMutateMock.mockImplementation(
+      (
+        _variables: unknown,
+        options?: {
+          onSuccess?: (data: {
+            messages: unknown[];
+            titlePending?: boolean;
+          }) => void;
+        }
+      ) => {
+        onSuccess = options?.onSuccess;
+      }
+    );
+
+    const { result, rerender } = renderHook(() =>
+      useJovieChat({ profileId: 'profile_1', conversationId: 'conv_123' })
+    );
+
+    await act(async () => {
+      await result.current.submitMessage('Generate album art');
+    });
+
+    expect(result.current.isSubmitting).toBe(true);
+    expect(addMessagesMutateMock).not.toHaveBeenCalled();
+
+    mockMessages = [
+      {
+        id: 'assistant_1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'dynamic-tool',
+            toolName: 'generateAlbumArt',
+            toolCallId: 'tool_album',
+            state: 'output-available',
+            input: { prompt: 'Generate album art' },
+            output: {
+              success: true,
+              state: 'generated',
+              generationId: 'generation-1',
+              releaseTitle: 'Neon Nights',
+              releaseId: 'release-1',
+              hasExistingArtwork: false,
+              candidates: [
+                {
+                  id: 'candidate-1',
+                  previewUrl: 'https://example.com/cover-1.jpg',
+                  styleLabel: 'Cinematic',
+                },
+              ],
+            },
+          },
+        ],
+        createdAt: new Date('2026-01-01T00:00:05.000Z'),
+      },
+    ] as typeof mockMessages;
+
+    rerender();
+
+    expect(addMessagesMutateMock).toHaveBeenCalledWith(
+      {
+        conversationId: 'conv_123',
+        messages: [
+          { role: 'user', content: 'Generate album art' },
+          {
+            role: 'assistant',
+            content: '',
+            toolCalls: [
+              expect.objectContaining({
+                toolCallId: 'tool_album',
+                toolName: 'generateAlbumArt',
+                state: 'succeeded',
+              }),
+            ],
+          },
+        ],
+      },
+      expect.any(Object)
+    );
+    expect(result.current.isSubmitting).toBe(true);
+
+    act(() => {
+      onSuccess?.({ messages: [], titlePending: false });
+    });
+
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('does not persist until an assistant response exists', async () => {
+    const { result, rerender } = renderHook(() =>
+      useJovieChat({ profileId: 'profile_1', conversationId: 'conv_123' })
+    );
+
+    await act(async () => {
+      await result.current.submitMessage('Generate album art');
+    });
+
+    expect(addMessagesMutateMock).not.toHaveBeenCalled();
+
+    mockMessages = [
+      {
+        id: 'user_1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'Generate album art' }],
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      },
+    ];
+
+    rerender();
+
+    expect(addMessagesMutateMock).not.toHaveBeenCalled();
+    expect(result.current.isSubmitting).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- migrate Jovie chat tool persistence from legacy `tool-invocation` records to versioned `PersistedToolEvent[]`
- normalize AI SDK 6 tool parts at the edge, preserve legacy hydration, and allow assistant tool-only turns with empty `content`
- unify tool rendering across chat surfaces with a shared registry-backed UI and add a backfill script for old rows

## Review
- no blocking findings in the final diff review
- remaining note: the PR is larger than the repo's preferred size guideline because this migration had to land end to end across persistence, routes, hooks, rendering, and tests

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/chat tests/unit/api/chat tests/unit/lib/chat tests/unit/services/pitch`
- `doppler run --project jovie-web --config dev -- env E2E_USE_TEST_AUTH_BYPASS=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 E2E_SKIP_WEB_SERVER=1 BASE_URL=http://localhost:3101 pnpm --filter @jovie/web exec playwright test tests/e2e/chat-pitch-generation.spec.ts --project=chromium`
- `pnpm --filter @jovie/web exec tsc -p tsconfig.typecheck.json --noEmit --pretty false`
- `pnpm biome check --write apps/web`
- `git push -u origin HEAD`

## Notes
- QA found two stale pitch E2E assertions and they were updated to match current UI behavior
- I saw one transient `/api/dashboard/profile` warmup 500 during Playwright startup, but it did not reproduce and the full suite passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Consolidated tool result rendering in chat for consistent and unified display of tool outcomes across conversations.
  * Enhanced tool execution state tracking with improved status indicators and messaging.
  * Better handling of tool-only responses in conversations.

* **Bug Fixes**
  * Improved text contrast and readability throughout artist profile sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->