### PR TITLE
fix(ci): include standalone sync script

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -48,6 +48,8 @@ scripts/
 cleanup_old_branches*.sh
 
 # Source-deploy fallback still needs these runtime directories from apps/web.
+!apps/web/scripts/
+!apps/web/scripts/sync-standalone-assets.mjs
 !apps/web/content/
 !apps/web/content/**
 !apps/web/lib/docs/


### PR DESCRIPTION
## Summary
- allow the source-deploy package to include `apps/web/scripts/sync-standalone-assets.mjs`
- keep the rest of the `.vercelignore` pruning in place

## Why
`main` staging deploy run `24594392344` is failing because Vercel source deploy cannot find `apps/web/scripts/sync-standalone-assets.mjs` during `postbuild`.

## Validation
- `git check-ignore -v apps/web/scripts/sync-standalone-assets.mjs` returns no ignore match
- push gate passed: `biome check .` and `pnpm --filter=@jovie/web run pre-push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to ensure build scripts are properly included in production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->