### PR TITLE
perf: wave 0 foundation + wave 1 shared-shell defers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       run_public_lighthouse: ${{ steps.detect.outputs.run_public_lighthouse }}
       run_dashboard_lighthouse: ${{ steps.detect.outputs.run_dashboard_lighthouse }}
       run_onboarding_lighthouse: ${{ steps.detect.outputs.run_onboarding_lighthouse }}
+      run_admin_lighthouse: ${{ steps.detect.outputs.run_admin_lighthouse }}
       run_e2e: ${{ steps.detect.outputs.run_e2e }}
       run_drizzle: ${{ steps.detect.outputs.run_drizzle }}
       has_code_changes: ${{ steps.detect.outputs.has_code_changes }}
@@ -60,7 +61,7 @@ jobs:
           # Force run all if the 'testing' label is present
           if [[ "$FULL_CI_LABEL" == "true" ]]; then
             echo "Forcing full CI run due to 'testing' label"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_e2e run_drizzle has_code_changes; do
+            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_e2e run_drizzle has_code_changes; do
               echo "$t=true" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -73,7 +74,7 @@ jobs:
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             # Manual dispatch: run everything
             echo "Manual dispatch: running all checks"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_e2e run_drizzle has_code_changes; do
+            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_e2e run_drizzle has_code_changes; do
               echo "$t=true" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -84,7 +85,7 @@ jobs:
           # Check if only docs changed (exclude .github/ — workflow changes must run CI)
           if echo "$CHANGED_FILES" | grep -v -E '^\.(github/)' | grep -v -E '\.(md|txt)$' | wc -l | grep -q '^0$'; then
             echo "Only documentation files changed"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_e2e run_drizzle has_code_changes; do
+            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_e2e run_drizzle has_code_changes; do
               echo "$t=false" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -133,6 +134,13 @@ jobs:
             echo "run_onboarding_lighthouse=false" >> $GITHUB_OUTPUT
           fi
 
+          ADMIN_LIGHTHOUSE_PATTERN='^(\.github/workflows/ci\.yml|apps/web/\.lighthouserc\.admin\.pr\.json|apps/web/scripts/lighthouse-dashboard-auth\.cjs|apps/web/app/app/\(shell\)/admin/|apps/web/components/features/admin/)'
+          if [[ "$RUN_BUILD" == "true" || "$RUN_TEST" == "true" ]] || echo "$CHANGED_FILES" | grep -q -E "$ADMIN_LIGHTHOUSE_PATTERN"; then
+            echo "run_admin_lighthouse=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_admin_lighthouse=false" >> "$GITHUB_OUTPUT"
+          fi
+
           # E2E paths
           E2E_PATTERN='^(apps/web/app/|apps/web/components/|apps/web/tests/e2e/|apps/web/tests/smoke/|apps/web/playwright\.config\.|apps/web/package.*\.json|package.*\.json)'
           if echo "$CHANGED_FILES" | grep -q -E "$E2E_PATTERN"; then
@@ -156,6 +164,7 @@ jobs:
             echo "run_build=false" >> "$GITHUB_OUTPUT"
             echo "run_public_lighthouse=false" >> "$GITHUB_OUTPUT"
             echo "run_dashboard_lighthouse=false" >> "$GITHUB_OUTPUT"
+            echo "run_admin_lighthouse=false" >> "$GITHUB_OUTPUT"
             echo "run_test=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -554,7 +563,7 @@ jobs:
     name: PR Ready
     # Single merge gate for PRs and merge queue.
     # Gates on fast checks (typecheck, lint, guardrails), unit tests, public-route build, and Lighthouse audits.
-    needs: [ci-fast, ci-unit-tests, ci-build-public, ci-lighthouse-dashboard-pr, ci-lighthouse-onboarding-pr, ci-lighthouse-pr]
+    needs: [ci-fast, ci-unit-tests, ci-build-public, ci-lighthouse-dashboard-pr, ci-lighthouse-onboarding-pr, ci-lighthouse-admin-pr, ci-lighthouse-pr]
     if: ${{ always() && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -566,12 +575,14 @@ jobs:
           BUILD_RESULT="${{ needs.ci-build-public.result }}"
           DASHBOARD_LIGHTHOUSE_RESULT="${{ needs.ci-lighthouse-dashboard-pr.result }}"
           ONBOARDING_LIGHTHOUSE_RESULT="${{ needs.ci-lighthouse-onboarding-pr.result }}"
+          ADMIN_LIGHTHOUSE_RESULT="${{ needs.ci-lighthouse-admin-pr.result }}"
           PUBLIC_LIGHTHOUSE_RESULT="${{ needs.ci-lighthouse-pr.result }}"
           echo "ci-fast: $FAST_RESULT"
           echo "ci-unit-tests: $UNIT_RESULT"
           echo "ci-build-public: $BUILD_RESULT"
           echo "ci-lighthouse-dashboard-pr: $DASHBOARD_LIGHTHOUSE_RESULT"
           echo "ci-lighthouse-onboarding-pr: $ONBOARDING_LIGHTHOUSE_RESULT"
+          echo "ci-lighthouse-admin-pr: $ADMIN_LIGHTHOUSE_RESULT"
           echo "ci-lighthouse-pr: $PUBLIC_LIGHTHOUSE_RESULT"
 
           # ci-fast must succeed (or be skipped when path-gated with no app files changed)
@@ -600,6 +611,12 @@ jobs:
           # Onboarding Lighthouse — path-gated, so skipped when no onboarding files changed
           if [[ "$ONBOARDING_LIGHTHOUSE_RESULT" != "success" && "$ONBOARDING_LIGHTHOUSE_RESULT" != "skipped" ]]; then
             echo "❌ ci-lighthouse-onboarding-pr did not pass (result: $ONBOARDING_LIGHTHOUSE_RESULT)"
+            exit 1
+          fi
+
+          # Admin Lighthouse — path-gated, so skipped when no admin files changed
+          if [[ "$ADMIN_LIGHTHOUSE_RESULT" != "success" && "$ADMIN_LIGHTHOUSE_RESULT" != "skipped" ]]; then
+            echo "❌ ci-lighthouse-admin-pr did not pass (result: $ADMIN_LIGHTHOUSE_RESULT)"
             exit 1
           fi
 
@@ -1130,6 +1147,137 @@ jobs:
         with:
           name: lighthouse-onboarding-pr-${{ github.run_id }}-${{ github.run_attempt }}
           path: apps/web/.lighthouseci/onboarding-pr/
+          if-no-files-found: ignore
+          retention-days: 3
+
+      - name: Cleanup ephemeral Neon branch
+        if: always() && steps.neon-branch.outputs.branch_id != ''
+        continue-on-error: true
+        run: |
+          curl -sS -X DELETE \
+            -H "Authorization: Bearer ${{ secrets.NEON_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            "https://console.neon.tech/api/v2/projects/${{ vars.NEON_PROJECT_ID }}/branches/${{ steps.neon-branch.outputs.branch_id }}"
+
+  ci-lighthouse-admin-pr:
+    name: Lighthouse (admin PR)
+    needs: [ci-fast, ci-path-changes, neon-db]
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.ci-path-changes.outputs.run_admin_lighthouse == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - uses: ./.github/actions/setup-node-pnpm
+
+      - name: Cache Playwright Browsers
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-chromium-
+
+      - name: Install Playwright (Chromium)
+        run: pnpm --filter=@jovie/web exec playwright install chromium
+
+      - name: Create ephemeral Neon database branch (with retry)
+        id: neon-branch
+        uses: ./.github/actions/neon-create-branch-with-retry
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch_name: admin-lighthouse-${{ github.run_id }}-${{ github.run_attempt }}
+          role: neondb_owner
+          api_key: ${{ secrets.NEON_API_KEY }}
+          protected_branches: main,development,preview,br-main,br-production,${{ needs.neon-db.outputs.branch_name }}
+
+      - name: Resolve DATABASE_URL (Neon ephemeral)
+        id: resolve-admin-neon-db-url
+        uses: ./.github/actions/resolve-neon-database-url
+        with:
+          candidate_url: ${{ steps.neon-branch.outputs.db_url_pooled }}
+          fallback_candidate_url: ${{ steps.neon-branch.outputs.db_url }}
+          credential_source_url: ${{ secrets.DATABASE_URL_MAIN }}
+          credential_fallback_url: ${{ secrets.DATABASE_URL }}
+
+      - name: Export DATABASE_URL
+        run: echo "DATABASE_URL=${{ steps.resolve-admin-neon-db-url.outputs.database_url }}" >> "$GITHUB_ENV"
+
+      - name: Run migrations (ephemeral Neon)
+        run: pnpm --filter=@jovie/web run drizzle:migrate:ci
+        env:
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+          NODE_ENV: test
+          GIT_BRANCH: pr-${{ github.event.pull_request.number }}
+          ALLOW_PROD_MIGRATIONS: 'true'
+
+      - name: Build app for admin Lighthouse
+        run: pnpm --filter=@jovie/web run build
+        env:
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          NEXT_IGNORE_ESLINT: '1'
+          NEXT_IGNORE_TYPECHECK: '1'
+          NEXT_PRIVATE_SKIP_SIZE_CHECK: 'true'
+
+      - name: Run authenticated admin Lighthouse
+        run: |
+          cd apps/web
+
+          if [ -z "$E2E_CLERK_USER_ID" ]; then
+            echo "E2E_ADMIN_CLERK_USER_ID not set — skipping admin Lighthouse."
+            exit 0
+          fi
+
+          export E2E_USE_TEST_AUTH_BYPASS=1
+          export NEXT_PUBLIC_CLERK_MOCK=1
+          export NEXT_PUBLIC_CLERK_PROXY_DISABLED=1
+
+          if [ ! -f .next/standalone/apps/web/server.js ]; then
+            echo "Standalone server not found — admin Lighthouse cannot start."
+            exit 1
+          fi
+
+          node .next/standalone/apps/web/server.js &
+          SERVER_PID=$!
+          trap 'kill $SERVER_PID 2>/dev/null || true' EXIT
+
+          echo "Waiting for standalone server..."
+          SERVER_READY=false
+          for i in {1..30}; do
+            if curl -s http://localhost:3000 > /dev/null; then
+              SERVER_READY=true
+              break
+            fi
+            sleep 1
+          done
+
+          if [ "$SERVER_READY" = "false" ]; then
+            echo "Server failed to start within 30s."
+            exit 1
+          fi
+
+          pnpm run test:lighthouse:admin:pr
+        env:
+          CI: true
+          BASE_URL: http://localhost:3000
+          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
+          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+          URL_ENCRYPTION_KEY: lighthouse-admin-ci-url-encryption-key
+          AI_GATEWAY_API_KEY: lighthouse-admin-ci
+          FLAGS_SECRET: ${{ secrets.FLAGS_SECRET }}
+          E2E_CLERK_USER_ID: ${{ secrets.E2E_ADMIN_CLERK_USER_ID }}
+          E2E_CLERK_USER_USERNAME: ${{ secrets.E2E_ADMIN_CLERK_USER_USERNAME }}
+          E2E_CLERK_USER_PASSWORD: ${{ secrets.E2E_ADMIN_CLERK_USER_PASSWORD }}
+
+      - name: Upload admin Lighthouse artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: lighthouse-admin-pr-${{ github.run_id }}-${{ github.run_attempt }}
+          path: apps/web/.lighthouseci/admin-pr/
           if-no-files-found: ignore
           retention-days: 3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1226,7 +1226,7 @@ jobs:
           cd apps/web
 
           if [ -z "$E2E_CLERK_USER_ID" ]; then
-            echo "E2E_ADMIN_CLERK_USER_ID not set — skipping admin Lighthouse."
+            echo "E2E_CLERK_USER_ID empty (no E2E_ADMIN_CLERK_USER_ID secret) — skipping admin Lighthouse."
             exit 0
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1161,7 +1161,10 @@ jobs:
 
   ci-lighthouse-admin-pr:
     name: Lighthouse (admin PR)
-    needs: [ci-fast, ci-path-changes, neon-db]
+    # Do NOT depend on neon-db — it only runs on push / testing-labeled / drizzle PRs,
+    # so dependent jobs would silently skip on admin-UI-only PRs. This job creates
+    # its own ephemeral branch below and does not reuse the shared neon-db branch.
+    needs: [ci-fast, ci-path-changes]
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.ci-path-changes.outputs.run_admin_lighthouse == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1191,7 +1194,7 @@ jobs:
           branch_name: admin-lighthouse-${{ github.run_id }}-${{ github.run_attempt }}
           role: neondb_owner
           api_key: ${{ secrets.NEON_API_KEY }}
-          protected_branches: main,development,preview,br-main,br-production,${{ needs.neon-db.outputs.branch_name }}
+          protected_branches: main,development,preview,br-main,br-production
 
       - name: Resolve DATABASE_URL (Neon ephemeral)
         id: resolve-admin-neon-db-url

--- a/apps/web/.lighthouserc.admin.pr.json
+++ b/apps/web/.lighthouserc.admin.pr.json
@@ -1,0 +1,74 @@
+{
+  "ci": {
+    "collect": {
+      "numberOfRuns": 3,
+      "puppeteerScript": "scripts/lighthouse-dashboard-auth.cjs",
+      "puppeteerLaunchOptions": {
+        "args": [
+          "--no-sandbox",
+          "--disable-setuid-sandbox",
+          "--disable-dev-shm-usage"
+        ]
+      },
+      "settings": {
+        "disableStorageReset": true
+      }
+    },
+    "assert": {
+      "assertMatrix": [
+        {
+          "matchingUrlPattern": "\\/app\\/admin\\/(growth|creators|users|releases)$",
+          "assertions": {
+            "categories:performance": [
+              "error",
+              {
+                "minScore": 0.6
+              }
+            ],
+            "categories:accessibility": [
+              "error",
+              {
+                "minScore": 0.9
+              }
+            ],
+            "categories:best-practices": [
+              "error",
+              {
+                "minScore": 0.8
+              }
+            ],
+            "first-contentful-paint": [
+              "error",
+              {
+                "maxNumericValue": 2200
+              }
+            ],
+            "largest-contentful-paint": [
+              "error",
+              {
+                "maxNumericValue": 4000
+              }
+            ],
+            "cumulative-layout-shift": [
+              "error",
+              {
+                "maxNumericValue": 0.1
+              }
+            ],
+            "total-blocking-time": [
+              "error",
+              {
+                "maxNumericValue": 500
+              }
+            ],
+            "errors-in-console": "error"
+          }
+        }
+      ]
+    },
+    "upload": {
+      "target": "filesystem",
+      "outputDir": ".lighthouseci/admin-pr"
+    }
+  }
+}

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -180,19 +180,28 @@ export function DashboardNav(_: DashboardNavProps) {
     }
 
     releasesPrefetchedProfileIdRef.current = profileId;
-    router.prefetch(APP_ROUTES.DASHBOARD_RELEASES);
-    void import('@/features/dashboard/organisms/release-provider-matrix').catch(
-      () => {
-        releasesPrefetchedProfileIdRef.current = null;
-      }
-    );
-    void import('@/lib/queries/prefetch-dashboard')
-      .then(({ prefetchForRoute }) =>
-        prefetchForRoute('releases', queryClient, profileId)
-      )
-      .catch(() => {
+
+    // Defer the eager releases prefetch past initial dashboard paint so the
+    // shell can hydrate without competing with a background chunk fetch +
+    // TanStack Query warmup. Matches the hover-prefetch debounce pattern
+    // used by handlePrefetch below.
+    const handle = setTimeout(() => {
+      router.prefetch(APP_ROUTES.DASHBOARD_RELEASES);
+      void import(
+        '@/features/dashboard/organisms/release-provider-matrix'
+      ).catch(() => {
         releasesPrefetchedProfileIdRef.current = null;
       });
+      void import('@/lib/queries/prefetch-dashboard')
+        .then(({ prefetchForRoute }) =>
+          prefetchForRoute('releases', queryClient, profileId)
+        )
+        .catch(() => {
+          releasesPrefetchedProfileIdRef.current = null;
+        });
+    }, 300);
+
+    return () => clearTimeout(handle);
   }, [isDemo, pathname, profileId, queryClient, router]);
 
   const handlePrefetch = useCallback(

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -179,13 +179,14 @@ export function DashboardNav(_: DashboardNavProps) {
       return;
     }
 
-    releasesPrefetchedProfileIdRef.current = profileId;
-
     // Defer the eager releases prefetch past initial dashboard paint so the
     // shell can hydrate without competing with a background chunk fetch +
     // TanStack Query warmup. Matches the hover-prefetch debounce pattern
-    // used by handlePrefetch below.
+    // used by handlePrefetch below. The prefetched marker is written inside
+    // the timer so a cleanup that fires before the timer runs (fast route
+    // change) leaves the ref null and a later visit will retry.
     const handle = setTimeout(() => {
+      releasesPrefetchedProfileIdRef.current = profileId;
       router.prefetch(APP_ROUTES.DASHBOARD_RELEASES);
       void import(
         '@/features/dashboard/organisms/release-provider-matrix'

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/MobileReleaseListLazy.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/MobileReleaseListLazy.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { type ComponentProps, lazy, Suspense } from 'react';
+import type { MobileReleaseList as MobileReleaseListImpl } from './MobileReleaseList';
+
+const MobileReleaseList = lazy(() =>
+  import('./MobileReleaseList').then(m => ({
+    default: m.MobileReleaseList,
+  }))
+);
+
+export type MobileReleaseListProps = ComponentProps<
+  typeof MobileReleaseListImpl
+>;
+
+/**
+ * Lazy-loaded MobileReleaseList with reserved-height Suspense fallback.
+ *
+ * MobileReleaseList is only rendered on mobile viewports, but ReleaseTable
+ * and ReleaseTableWithTracks both need to reference it. Consolidating the
+ * lazy wrapper here keeps the shared chunk-boundary logic in one place
+ * and avoids duplicating the Suspense fallback across render paths.
+ */
+export function MobileReleaseListLazy(props: MobileReleaseListProps) {
+  return (
+    <Suspense fallback={<div className='min-h-[320px]' aria-hidden />}>
+      <MobileReleaseList {...props} />
+    </Suspense>
+  );
+}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
@@ -8,6 +8,7 @@ import { useBreakpointDown } from '@/hooks/useBreakpoint';
 import { TABLE_ROW_HEIGHTS } from '@/lib/constants/layout';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 import { useSortingManager } from './hooks/useSortingManager';
+import { MobileReleaseListLazy } from './MobileReleaseListLazy';
 import type { ReleaseTableProps } from './ReleaseTable.types';
 import { getReleaseContextMenuItems } from './utils/release-context-actions';
 import {
@@ -18,12 +19,6 @@ import {
 const ReleaseTableWithTracks = lazy(() =>
   import('./ReleaseTableWithTracks').then(m => ({
     default: m.ReleaseTableWithTracks,
-  }))
-);
-
-const MobileReleaseList = lazy(() =>
-  import('./MobileReleaseList').then(m => ({
-    default: m.MobileReleaseList,
   }))
 );
 
@@ -252,19 +247,17 @@ export function ReleaseTable({
     }
 
     return (
-      <Suspense fallback={<div className='min-h-[320px]' aria-hidden />}>
-        <MobileReleaseList
-          releases={releases}
-          artistName={artistName}
-          onEdit={onEdit}
-          onCopy={onCopy}
-          canGenerateAlbumArt={canGenerateAlbumArt}
-          onGenerateAlbumArt={onGenerateAlbumArt}
-          isSmartLinkLocked={isSmartLinkLocked}
-          getSmartLinkLockReason={getSmartLinkLockReason}
-          groupByYear={groupByYear}
-        />
-      </Suspense>
+      <MobileReleaseListLazy
+        releases={releases}
+        artistName={artistName}
+        onEdit={onEdit}
+        onCopy={onCopy}
+        canGenerateAlbumArt={canGenerateAlbumArt}
+        onGenerateAlbumArt={onGenerateAlbumArt}
+        isSmartLinkLocked={isSmartLinkLocked}
+        getSmartLinkLockReason={getSmartLinkLockReason}
+        groupByYear={groupByYear}
+      />
     );
   }
 

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
@@ -8,7 +8,6 @@ import { useBreakpointDown } from '@/hooks/useBreakpoint';
 import { TABLE_ROW_HEIGHTS } from '@/lib/constants/layout';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 import { useSortingManager } from './hooks/useSortingManager';
-import { MobileReleaseList } from './MobileReleaseList';
 import type { ReleaseTableProps } from './ReleaseTable.types';
 import { getReleaseContextMenuItems } from './utils/release-context-actions';
 import {
@@ -19,6 +18,12 @@ import {
 const ReleaseTableWithTracks = lazy(() =>
   import('./ReleaseTableWithTracks').then(m => ({
     default: m.ReleaseTableWithTracks,
+  }))
+);
+
+const MobileReleaseList = lazy(() =>
+  import('./MobileReleaseList').then(m => ({
+    default: m.MobileReleaseList,
   }))
 );
 
@@ -247,17 +252,19 @@ export function ReleaseTable({
     }
 
     return (
-      <MobileReleaseList
-        releases={releases}
-        artistName={artistName}
-        onEdit={onEdit}
-        onCopy={onCopy}
-        canGenerateAlbumArt={canGenerateAlbumArt}
-        onGenerateAlbumArt={onGenerateAlbumArt}
-        isSmartLinkLocked={isSmartLinkLocked}
-        getSmartLinkLockReason={getSmartLinkLockReason}
-        groupByYear={groupByYear}
-      />
+      <Suspense fallback={<div className='min-h-[320px]' aria-hidden />}>
+        <MobileReleaseList
+          releases={releases}
+          artistName={artistName}
+          onEdit={onEdit}
+          onCopy={onCopy}
+          canGenerateAlbumArt={canGenerateAlbumArt}
+          onGenerateAlbumArt={onGenerateAlbumArt}
+          isSmartLinkLocked={isSmartLinkLocked}
+          getSmartLinkLockReason={getSmartLinkLockReason}
+          groupByYear={groupByYear}
+        />
+      </Suspense>
     );
   }
 

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
@@ -9,6 +9,7 @@ import { TABLE_ROW_HEIGHTS } from '@/lib/constants/layout';
 import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
 import { useExpandedTracks } from './hooks/useExpandedTracks';
 import { useSortingManager } from './hooks/useSortingManager';
+import { MobileReleaseListLazy } from './MobileReleaseListLazy';
 import type { ReleaseTableProps } from './ReleaseTable.types';
 import { getReleaseContextMenuItems } from './utils/release-context-actions';
 import {
@@ -21,12 +22,6 @@ const TrackRowsContainer = lazy(() =>
     '@/features/dashboard/organisms/release-provider-matrix/components'
   ).then(m => ({
     default: m.TrackRowsContainer,
-  }))
-);
-
-const MobileReleaseList = lazy(() =>
-  import('./MobileReleaseList').then(m => ({
-    default: m.MobileReleaseList,
   }))
 );
 
@@ -273,19 +268,17 @@ export function ReleaseTableWithTracks({
     }
 
     return (
-      <Suspense fallback={<div className='min-h-[320px]' aria-hidden />}>
-        <MobileReleaseList
-          releases={releases}
-          artistName={artistName}
-          onEdit={onEdit}
-          onCopy={onCopy}
-          canGenerateAlbumArt={canGenerateAlbumArt}
-          onGenerateAlbumArt={onGenerateAlbumArt}
-          isSmartLinkLocked={isSmartLinkLocked}
-          getSmartLinkLockReason={getSmartLinkLockReason}
-          groupByYear={groupByYear}
-        />
-      </Suspense>
+      <MobileReleaseListLazy
+        releases={releases}
+        artistName={artistName}
+        onEdit={onEdit}
+        onCopy={onCopy}
+        canGenerateAlbumArt={canGenerateAlbumArt}
+        onGenerateAlbumArt={onGenerateAlbumArt}
+        isSmartLinkLocked={isSmartLinkLocked}
+        getSmartLinkLockReason={getSmartLinkLockReason}
+        groupByYear={groupByYear}
+      />
     );
   }
 

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
@@ -9,7 +9,6 @@ import { TABLE_ROW_HEIGHTS } from '@/lib/constants/layout';
 import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
 import { useExpandedTracks } from './hooks/useExpandedTracks';
 import { useSortingManager } from './hooks/useSortingManager';
-import { MobileReleaseList } from './MobileReleaseList';
 import type { ReleaseTableProps } from './ReleaseTable.types';
 import { getReleaseContextMenuItems } from './utils/release-context-actions';
 import {
@@ -22,6 +21,12 @@ const TrackRowsContainer = lazy(() =>
     '@/features/dashboard/organisms/release-provider-matrix/components'
   ).then(m => ({
     default: m.TrackRowsContainer,
+  }))
+);
+
+const MobileReleaseList = lazy(() =>
+  import('./MobileReleaseList').then(m => ({
+    default: m.MobileReleaseList,
   }))
 );
 
@@ -268,17 +273,19 @@ export function ReleaseTableWithTracks({
     }
 
     return (
-      <MobileReleaseList
-        releases={releases}
-        artistName={artistName}
-        onEdit={onEdit}
-        onCopy={onCopy}
-        canGenerateAlbumArt={canGenerateAlbumArt}
-        onGenerateAlbumArt={onGenerateAlbumArt}
-        isSmartLinkLocked={isSmartLinkLocked}
-        getSmartLinkLockReason={getSmartLinkLockReason}
-        groupByYear={groupByYear}
-      />
+      <Suspense fallback={<div className='min-h-[320px]' aria-hidden />}>
+        <MobileReleaseList
+          releases={releases}
+          artistName={artistName}
+          onEdit={onEdit}
+          onCopy={onCopy}
+          canGenerateAlbumArt={canGenerateAlbumArt}
+          onGenerateAlbumArt={onGenerateAlbumArt}
+          isSmartLinkLocked={isSmartLinkLocked}
+          getSmartLinkLockReason={getSmartLinkLockReason}
+          groupByYear={groupByYear}
+        />
+      </Suspense>
     );
   }
 

--- a/apps/web/components/providers/CoreProviders.tsx
+++ b/apps/web/components/providers/CoreProviders.tsx
@@ -24,11 +24,12 @@ function LazyProvidersSkeleton(props: DynamicOptionsLoadingProps) {
   return <>{children}</>;
 }
 
-// Global keyboard shortcut listeners are deferred past first paint. Users
-// do not press `t` or `/` within the first 300ms of page load, and leaving
-// listener attachment on the critical path added two `addEventListener`
-// calls plus per-keypress handler dispatch overhead during boot.
-const KEYBOARD_SHORTCUT_ATTACH_DELAY_MS = 300;
+// Deferral delay shared by the keyboard-shortcut listeners and the monitoring
+// chunk imports. 300ms gives the first-paint burst of work room to finish
+// before we schedule optional side effects. Users do not press `t` or `/`,
+// nor do monitoring chunks need to arrive, within this window of boot.
+const BOOT_DEFERRED_WORK_DELAY_MS = 300;
+const KEYBOARD_SHORTCUT_ATTACH_DELAY_MS = BOOT_DEFERRED_WORK_DELAY_MS;
 
 function ThemeKeyboardShortcut({ isEnabled }: { isEnabled: boolean }) {
   const { resolvedTheme, setTheme } = useTheme();
@@ -184,8 +185,8 @@ function CoreProvidersInner({
     let cleanupWebVitals: (() => void) | undefined;
     let isUnmounted = false;
 
+    // useEffect only runs on the client, so we can dispatch unconditionally.
     function dispatchWebVital(metric: unknown) {
-      if (typeof globalThis.window === 'undefined') return;
       const event = new CustomEvent('web-vitals', { detail: metric });
       globalThis.dispatchEvent(event);
     }
@@ -226,7 +227,7 @@ function CoreProvidersInner({
             logger.error('Failed to initialize monitoring:', error);
           });
       }
-    }, 300);
+    }, BOOT_DEFERRED_WORK_DELAY_MS);
 
     return () => {
       isUnmounted = true;

--- a/apps/web/components/providers/CoreProviders.tsx
+++ b/apps/web/components/providers/CoreProviders.tsx
@@ -5,7 +5,7 @@ import { PacerProvider } from '@tanstack/react-pacer';
 import dynamic, { type DynamicOptionsLoadingProps } from 'next/dynamic';
 import { usePathname } from 'next/navigation';
 import { ThemeProvider, useTheme } from 'next-themes';
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { env } from '@/lib/env-client';
 import { useChunkErrorHandler } from '@/lib/hooks/useChunkErrorHandler';
 import { PACER_TIMING } from '@/lib/pacer/hooks';
@@ -33,6 +33,16 @@ const KEYBOARD_SHORTCUT_ATTACH_DELAY_MS = 300;
 function ThemeKeyboardShortcut({ isEnabled }: { isEnabled: boolean }) {
   const { resolvedTheme, setTheme } = useTheme();
 
+  // Keep the listener referentially stable — reading the current theme +
+  // setter from a ref — so the useEffect below does not re-run and
+  // re-defer the listener attachment every time resolvedTheme changes.
+  // Without the ref, pressing `t` within 300ms of a theme toggle would
+  // do nothing while the new setTimeout was pending.
+  const themeRef = useRef({ resolvedTheme, setTheme });
+  useEffect(() => {
+    themeRef.current = { resolvedTheme, setTheme };
+  }, [resolvedTheme, setTheme]);
+
   useEffect(() => {
     if (!isEnabled) return;
 
@@ -43,7 +53,9 @@ function ThemeKeyboardShortcut({ isEnabled }: { isEnabled: boolean }) {
       if (isFormElement(event.target)) return;
 
       event.preventDefault();
-      setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
+      const { resolvedTheme: currentTheme, setTheme: setCurrentTheme } =
+        themeRef.current;
+      setCurrentTheme(currentTheme === 'dark' ? 'light' : 'dark');
     }
 
     const attachHandle = setTimeout(() => {
@@ -54,7 +66,7 @@ function ThemeKeyboardShortcut({ isEnabled }: { isEnabled: boolean }) {
       clearTimeout(attachHandle);
       globalThis.removeEventListener('keydown', handleKeyDown);
     };
-  }, [resolvedTheme, setTheme, isEnabled]);
+  }, [isEnabled]);
 
   return null;
 }

--- a/apps/web/components/providers/CoreProviders.tsx
+++ b/apps/web/components/providers/CoreProviders.tsx
@@ -24,6 +24,12 @@ function LazyProvidersSkeleton(props: DynamicOptionsLoadingProps) {
   return <>{children}</>;
 }
 
+// Global keyboard shortcut listeners are deferred past first paint. Users
+// do not press `t` or `/` within the first 300ms of page load, and leaving
+// listener attachment on the critical path added two `addEventListener`
+// calls plus per-keypress handler dispatch overhead during boot.
+const KEYBOARD_SHORTCUT_ATTACH_DELAY_MS = 300;
+
 function ThemeKeyboardShortcut({ isEnabled }: { isEnabled: boolean }) {
   const { resolvedTheme, setTheme } = useTheme();
 
@@ -40,8 +46,12 @@ function ThemeKeyboardShortcut({ isEnabled }: { isEnabled: boolean }) {
       setTheme(resolvedTheme === 'dark' ? 'light' : 'dark');
     }
 
-    globalThis.addEventListener('keydown', handleKeyDown);
+    const attachHandle = setTimeout(() => {
+      globalThis.addEventListener('keydown', handleKeyDown);
+    }, KEYBOARD_SHORTCUT_ATTACH_DELAY_MS);
+
     return () => {
+      clearTimeout(attachHandle);
       globalThis.removeEventListener('keydown', handleKeyDown);
     };
   }, [resolvedTheme, setTheme, isEnabled]);
@@ -95,8 +105,12 @@ function SearchKeyboardShortcut() {
       });
     }
 
-    globalThis.addEventListener('keydown', handleKeyDown);
+    const attachHandle = setTimeout(() => {
+      globalThis.addEventListener('keydown', handleKeyDown);
+    }, KEYBOARD_SHORTCUT_ATTACH_DELAY_MS);
+
     return () => {
+      clearTimeout(attachHandle);
       globalThis.removeEventListener('keydown', handleKeyDown);
     };
   }, []);

--- a/apps/web/components/providers/CoreProviders.tsx
+++ b/apps/web/components/providers/CoreProviders.tsx
@@ -172,38 +172,44 @@ function CoreProvidersInner({
     let cleanupWebVitals: (() => void) | undefined;
     let isUnmounted = false;
 
+    function dispatchWebVital(metric: unknown) {
+      if (typeof globalThis.window === 'undefined') return;
+      const event = new CustomEvent('web-vitals', { detail: metric });
+      globalThis.dispatchEvent(event);
+    }
+
+    function handleWebVitalsReady(
+      mod: typeof import('@/lib/monitoring/web-vitals')
+    ) {
+      const cleanup = mod.initWebVitals(dispatchWebVital);
+      if (isUnmounted) {
+        cleanup();
+        return;
+      }
+      cleanupWebVitals = cleanup;
+    }
+
+    function handleMonitoringReady(
+      mod: typeof import('@/lib/monitoring/client')
+    ) {
+      if (isUnmounted) return;
+      mod.initAllMonitoring();
+    }
+
     // Defer monitoring chunks past initial provider hydration so they do
     // not contend with main-thread work during first paint. Web Vitals
     // still captures FCP/LCP/CLS because the underlying PerformanceObserver
     // subscriptions use `{ buffered: true }` to replay early entries.
     const handle = setTimeout(() => {
       import('@/lib/monitoring/web-vitals')
-        .then(({ initWebVitals }) => {
-          const cleanup = initWebVitals(metric => {
-            // Create a custom event for the performance dashboard
-            if (typeof window !== 'undefined') {
-              const event = new CustomEvent('web-vitals', { detail: metric });
-              window.dispatchEvent(event);
-            }
-          });
-
-          if (isUnmounted) {
-            cleanup();
-            return;
-          }
-
-          cleanupWebVitals = cleanup;
-        })
+        .then(handleWebVitalsReady)
         .catch(error => {
           logger.error('Failed to initialize Web Vitals:', error);
         });
 
-      // Initialize other performance monitoring in production
       if (process.env.NODE_ENV === 'production') {
         import('@/lib/monitoring/client')
-          .then(({ initAllMonitoring }) => {
-            initAllMonitoring();
-          })
+          .then(handleMonitoringReady)
           .catch(error => {
             logger.error('Failed to initialize monitoring:', error);
           });

--- a/apps/web/components/providers/CoreProviders.tsx
+++ b/apps/web/components/providers/CoreProviders.tsx
@@ -155,44 +155,50 @@ function CoreProvidersInner({
     });
     logger.groupEnd();
 
-    // Initialize Web Vitals tracking for performance monitoring
     let cleanupWebVitals: (() => void) | undefined;
     let isUnmounted = false;
 
-    import('@/lib/monitoring/web-vitals')
-      .then(({ initWebVitals }) => {
-        const cleanup = initWebVitals(metric => {
-          // Create a custom event for the performance dashboard
-          if (typeof window !== 'undefined') {
-            const event = new CustomEvent('web-vitals', { detail: metric });
-            window.dispatchEvent(event);
+    // Defer monitoring chunks past initial provider hydration so they do
+    // not contend with main-thread work during first paint. Web Vitals
+    // still captures FCP/LCP/CLS because the underlying PerformanceObserver
+    // subscriptions use `{ buffered: true }` to replay early entries.
+    const handle = setTimeout(() => {
+      import('@/lib/monitoring/web-vitals')
+        .then(({ initWebVitals }) => {
+          const cleanup = initWebVitals(metric => {
+            // Create a custom event for the performance dashboard
+            if (typeof window !== 'undefined') {
+              const event = new CustomEvent('web-vitals', { detail: metric });
+              window.dispatchEvent(event);
+            }
+          });
+
+          if (isUnmounted) {
+            cleanup();
+            return;
           }
-        });
 
-        if (isUnmounted) {
-          cleanup();
-          return;
-        }
-
-        cleanupWebVitals = cleanup;
-      })
-      .catch(error => {
-        logger.error('Failed to initialize Web Vitals:', error);
-      });
-
-    // Initialize other performance monitoring in production
-    if (process.env.NODE_ENV === 'production') {
-      import('@/lib/monitoring/client')
-        .then(({ initAllMonitoring }) => {
-          initAllMonitoring();
+          cleanupWebVitals = cleanup;
         })
         .catch(error => {
-          logger.error('Failed to initialize monitoring:', error);
+          logger.error('Failed to initialize Web Vitals:', error);
         });
-    }
+
+      // Initialize other performance monitoring in production
+      if (process.env.NODE_ENV === 'production') {
+        import('@/lib/monitoring/client')
+          .then(({ initAllMonitoring }) => {
+            initAllMonitoring();
+          })
+          .catch(error => {
+            logger.error('Failed to initialize monitoring:', error);
+          });
+      }
+    }, 300);
 
     return () => {
       isUnmounted = true;
+      clearTimeout(handle);
       cleanupWebVitals?.();
     };
   }, [enableMonitoring]);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,6 +45,7 @@
     "test:lighthouse:public:launch": "tsx scripts/run-public-lighthouse.ts",
     "test:lighthouse:dashboard:pr": "node scripts/lighthouse-dashboard-auth.cjs",
     "test:lighthouse:onboarding:pr": "LIGHTHOUSE_CONFIG=.lighthouserc.onboarding.pr.json LIGHTHOUSE_DASHBOARD_URLS=/onboarding node scripts/lighthouse-dashboard-auth.cjs",
+    "test:lighthouse:admin:pr": "LIGHTHOUSE_CONFIG=.lighthouserc.admin.pr.json LIGHTHOUSE_DASHBOARD_URLS=/app/admin/growth,/app/admin/creators,/app/admin/users,/app/admin/releases LIGHTHOUSE_TEST_PERSONA=admin node scripts/lighthouse-dashboard-auth.cjs",
     "test:flaky": "tsx scripts/flaky-test-detector.ts",
     "test:e2e": "playwright test",
     "test:e2e:fast": "node scripts/run-playwright-fast.mjs",

--- a/apps/web/scripts/compare-chunks.ts
+++ b/apps/web/scripts/compare-chunks.ts
@@ -12,9 +12,10 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const WEB_ROOT = join(import.meta.dirname, '..');
+const WEB_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 const BASELINE_PATH = join(
   WEB_ROOT,
   '../../docs/performance/bundle-baseline.json'

--- a/apps/web/scripts/lighthouse-dashboard-auth.cjs
+++ b/apps/web/scripts/lighthouse-dashboard-auth.cjs
@@ -10,6 +10,21 @@ const TEST_USER_ID_COOKIE = '__e2e_test_user_id';
 const TEST_PERSONA_COOKIE = '__e2e_test_persona';
 const TEST_AUTH_BYPASS_MODE = 'bypass-auth';
 
+// Mirrors DevTestAuthPersona in apps/web/lib/auth/dev-test-auth-types.ts.
+const ALLOWED_PERSONAS = new Set(['creator', 'creator-ready', 'admin']);
+const DEFAULT_PERSONA = 'creator-ready';
+
+function resolveTestPersona() {
+  const configured = process.env.LIGHTHOUSE_TEST_PERSONA?.trim();
+  if (!configured) return DEFAULT_PERSONA;
+  if (!ALLOWED_PERSONAS.has(configured)) {
+    throw new Error(
+      `LIGHTHOUSE_TEST_PERSONA must be one of ${[...ALLOWED_PERSONAS].join(', ')}; got "${configured}"`
+    );
+  }
+  return configured;
+}
+
 const webRoot = path.resolve(__dirname, '..');
 const repoRoot = path.resolve(webRoot, '..', '..');
 const defaultBaseUrl = process.env.BASE_URL || 'http://localhost:3000';
@@ -277,7 +292,7 @@ async function seedDashboardAuth(browser, { url }) {
       },
       {
         name: TEST_PERSONA_COOKIE,
-        value: 'creator-ready',
+        value: resolveTestPersona(),
         url: origin,
         sameSite: 'Lax',
       },

--- a/apps/web/tests/unit/home/HomeAdaptiveProfileStory.test.tsx
+++ b/apps/web/tests/unit/home/HomeAdaptiveProfileStory.test.tsx
@@ -2,6 +2,20 @@ import { render, screen } from '@testing-library/react';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { HomeAdaptiveProfileStory } from '@/features/home/HomeAdaptiveProfileStory';
 
+vi.mock('@/features/home/HomeProfileShowcase', () => ({
+  HomeProfileShowcase: ({
+    stateId,
+    className,
+  }: {
+    readonly stateId: string;
+    readonly className?: string;
+  }) => (
+    <div data-testid={`homepage-phone-state-${stateId}`} className={className}>
+      {stateId}
+    </div>
+  ),
+}));
+
 vi.mock('@/lib/feature-flags/shared', async importOriginal => {
   const actual =
     await importOriginal<typeof import('@/lib/feature-flags/shared')>();

--- a/apps/web/tests/unit/home/HomePageNarrative.test.tsx
+++ b/apps/web/tests/unit/home/HomePageNarrative.test.tsx
@@ -2,6 +2,20 @@ import { render, screen } from '@testing-library/react';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { HomePageNarrative } from '@/features/home/HomePageNarrative';
 
+vi.mock('@/features/home/HomeProfileShowcase', () => ({
+  HomeProfileShowcase: ({
+    stateId,
+    className,
+  }: {
+    readonly stateId: string;
+    readonly className?: string;
+  }) => (
+    <div data-testid={`homepage-phone-state-${stateId}`} className={className}>
+      {stateId}
+    </div>
+  ),
+}));
+
 vi.mock('@/lib/feature-flags/shared', async importOriginal => {
   const actual =
     await importOriginal<typeof import('@/lib/feature-flags/shared')>();

--- a/apps/web/tests/unit/home/marketing-content-guardrails.test.ts
+++ b/apps/web/tests/unit/home/marketing-content-guardrails.test.ts
@@ -8,6 +8,24 @@ import {
 } from '@/features/home/home-surface-seed';
 import { INTERNAL_DJ_DEMO_PERSONA } from '@/lib/demo-personas';
 
+vi.mock('@/features/home/HomeProfileShowcase', () => ({
+  HomeProfileShowcase: ({
+    stateId,
+    className,
+  }: {
+    readonly stateId: string;
+    readonly className?: string;
+  }) =>
+    createElement(
+      'div',
+      {
+        'data-testid': `homepage-phone-state-${stateId}`,
+        className,
+      },
+      stateId
+    ),
+}));
+
 vi.mock('@/lib/feature-flags/shared', async importOriginal => {
   const actual =
     await importOriginal<typeof import('@/lib/feature-flags/shared')>();


### PR DESCRIPTION
## Summary

Foundation commits for the continuous performance factory program (see `.context/attachments/plan.md`). 8 atomic commits covering Wave 0 gate tooling + admin Lighthouse wiring, plus 4 Wave 1 shared-shell defer wins.

Each commit is one concern and can be cherry-picked out if the reviewer prefers 5–6 separate PRs.

### Wave 0 — Restore trust in the gates

- \`d5eeeaeb7\` **fix(perf): restore compare-chunks script** — \`import.meta.dirname\` was undefined under tsx's CJS loader; switched to repo idiom \`dirname(fileURLToPath(import.meta.url))\`.
- \`938790b34\` **feat(perf): add admin Lighthouse PR config** — new \`apps/web/.lighthouserc.admin.pr.json\` with Level 1 thresholds per plan (perf ≥ 0.60, FCP ≤ 2200, LCP ≤ 4000, CLS ≤ 0.10, TBT ≤ 500, errors-in-console=error).
- \`c2097cf7c\` **feat(perf): wire admin persona into Lighthouse harness** — \`LIGHTHOUSE_TEST_PERSONA\` env var with allowlist (creator/creator-ready/admin), new \`test:lighthouse:admin:pr\` npm script.
- \`42980c8e4\` **ci(perf): wire admin Lighthouse job into PR gate** — new \`ci-lighthouse-admin-pr\` job mirroring the onboarding Lighthouse structure; blocking in \`ci-pr-ready\`; inert until \`E2E_ADMIN_CLERK_USER_ID\` secrets are added.

### Wave 1 — Shared-shell defers

All four commits add a 300ms \`setTimeout\` to move chunk fetches / listener attachment past first paint. No UI changes.

- \`010040854\` **perf(releases): lazy-load MobileReleaseList** — 369 LOC mobile-only component was statically imported. Now \`React.lazy()\` with \`min-h-[320px]\` Suspense fallback to preserve mobile cold-load height.
- \`50a42574a\` **perf(dashboard-nav): defer eager releases prefetch** — 3 concurrent operations (router.prefetch, release-provider-matrix import, TanStack warmup) that kicked off during dashboard shell hydration now wait 300ms.
- \`fa0d59e95\` **perf(providers): defer monitoring chunk imports** — \`monitoring/web-vitals\` + \`monitoring/client\` dynamic imports now deferred 300ms. web-vitals v5 replays \`{buffered: true}\` PerformanceObserver entries so FCP/LCP/CLS capture is preserved.
- \`18700039a\` **perf(providers): defer global keyboard-shortcut listeners** — \`t\` theme toggle + \`/\` search global keydown listeners now attached after 300ms instead of on mount.

## Test plan

- [x] \`compare-chunks\` runs cleanly (\`npx tsx apps/web/scripts/compare-chunks.ts\` reports 570.7KB JS / 11 chunks / ~171.2KB gzip).
- [x] Harness YAML validates; \`actionlint\` reports only pre-existing shellcheck noise.
- [x] Inline smoke-test: \`resolveTestPersona()\` default → \`creator-ready\`; admin/creator pass; invalid values throw.
- [x] Typecheck passes on all affected files (\`tsc -p tsconfig.typecheck.json\`).
- [x] Vitest green: \`ReleaseTable.test.tsx\` (3/3), \`MobileReleaseList.test.tsx\` (3/3), \`DashboardNav.test.tsx\` (11/11), \`DashboardNav.interaction.test.tsx\` (10/10).
- [ ] \`test:budgets:launch\` before/after on \`/app/dashboard/releases\` and \`/onboarding\` to confirm no regression and quantify the Wave 1 wins (requires local prod build + auth bypass harness — deferred to a follow-up session).
- [ ] Add \`E2E_ADMIN_CLERK_USER_ID\` / \`_USERNAME\` / \`_PASSWORD\` to repo secrets so \`ci-lighthouse-admin-pr\` becomes active (until then the job exits \`success\` as a skip).

## Follow-ups parked in \`.context/perf-program/\`

- Wave 0 #1 — \`onboarding-resume-profile-ready\` CLS 0.0570 vs 0.05. Investigation at \`wave0-onboarding-cls-investigation.md\`; needs harness for shift attribution before fix.
- Wave 1 #10 — further releases subtree split. Prep at \`wave1-releases-prep.md\`; candidates are \`AvailabilityCell\` popover extraction (~400 LOC refactor, own PR) and \`useReleaseProviderMatrix\` hook transitive imports.
- Route-manifest audit at \`route-audit.md\` identifies 5 Wave 3 + 3 Wave 4 + 18 Wave 6 missing budget entries for follow-up budget-add PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added authenticated Lighthouse checks for admin dashboard pages with persona-driven runs, assertions/thresholds, and result uploads.

* **Chores**
  * CI will conditionally run admin Lighthouse on admin-related changes and block merges unless the check passes or is skipped.
  * Added a project script to run authenticated admin Lighthouse locally/CI.

* **Performance**
  * Deferred prefetching, monitoring init, and keyboard-shortcut listener attachment by 300ms.
  * Mobile release list now lazy-loads to reduce upfront bundle size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->