### PR TITLE
fix(ci): resolve vercel cli in deploy script

### DIFF
--- a/.github/scripts/vercel-prebuilt-deploy.sh
+++ b/.github/scripts/vercel-prebuilt-deploy.sh
@@ -15,6 +15,32 @@ if [ -z "${VERCEL_TOKEN:-}" ]; then
   exit 1
 fi
 
+VERCEL_CMD=()
+
+resolve_vercel_cmd() {
+  if command -v vercel >/dev/null 2>&1; then
+    VERCEL_CMD=("$(command -v vercel)")
+    return 0
+  fi
+
+  if command -v pnpm >/dev/null 2>&1 && pnpm exec -- vercel --version >/dev/null 2>&1; then
+    VERCEL_CMD=(pnpm exec -- vercel)
+    return 0
+  fi
+
+  if [ -x "./node_modules/.bin/vercel" ]; then
+    VERCEL_CMD=("./node_modules/.bin/vercel")
+    return 0
+  fi
+
+  echo "Vercel CLI not found in PATH or project dependencies" >&2
+  return 127
+}
+
+run_vercel() {
+  "${VERCEL_CMD[@]}" "$@"
+}
+
 parse_deployment_url() {
   printf '%s\n' "$1" | grep -Eo 'https://[^[:space:]]+\.vercel\.app/?' | tail -1 || true
 }
@@ -39,21 +65,21 @@ run_deploy() {
   shift
 
   if [ "$mode" = "tgz" ]; then
-    vercel deploy --prebuilt --archive=tgz "$@" --token "$VERCEL_TOKEN"
+    run_vercel deploy --prebuilt --archive=tgz "$@" --token "$VERCEL_TOKEN"
     return
   fi
 
   if [ "$mode" = "split-tgz" ]; then
-    vercel deploy --prebuilt --archive=split-tgz "$@" --token "$VERCEL_TOKEN"
+    run_vercel deploy --prebuilt --archive=split-tgz "$@" --token "$VERCEL_TOKEN"
     return
   fi
 
   if [ "$mode" = "plain" ]; then
-    vercel deploy --prebuilt "$@" --token "$VERCEL_TOKEN"
+    run_vercel deploy --prebuilt "$@" --token "$VERCEL_TOKEN"
     return
   fi
 
-  vercel deploy "$@" --token "$VERCEL_TOKEN"
+  run_vercel deploy "$@" --token "$VERCEL_TOKEN"
 }
 
 try_mode() {
@@ -101,6 +127,8 @@ if [ "$has_prebuilt_output" = true ]; then
 else
   echo "Prebuilt output file count: unavailable (.vercel/output missing or empty)"
 fi
+resolve_vercel_cmd
+echo "Using Vercel CLI command: ${VERCEL_CMD[*]}"
 echo "Plain prebuilt fallback requested: $plain_prebuilt_requested"
 echo "Plain prebuilt fallback enabled: $can_use_plain_prebuilt"
 


### PR DESCRIPTION
## Summary
- resolve the Vercel CLI explicitly inside `.github/scripts/vercel-prebuilt-deploy.sh` instead of assuming `vercel` is on PATH
- fall back to `pnpm exec -- vercel` or `./node_modules/.bin/vercel` when the global binary is unavailable
- log which Vercel command was selected so future CI failures are easier to diagnose

## Root cause
`main` push workflow `24599253816` failed in `deploy-staging` because `.github/scripts/vercel-prebuilt-deploy.sh` invoked `vercel` directly and the job log showed `vercel: command not found` on the tgz, split-tgz, and source deploy attempts.

## Validation
- `bash -n .github/scripts/vercel-prebuilt-deploy.sh`
- simulated missing global `vercel` with a stripped PATH and verified `pnpm exec -- vercel --version` still resolves (`50.22.1`)
- `git push` pre-push gate passed: `biome check .` and `pnpm --filter=@jovie/web run pre-push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment script reliability by implementing dynamic resolution for the Vercel CLI with multiple fallback options, ensuring consistent invocation across different development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->