### PR TITLE
fix(ci): reduce max-old-space-size to prevent OOM in test workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1652,7 +1652,7 @@ jobs:
             COVERAGE_FLAG="--coverage"
           fi
           # Use forked pool with limited workers to reduce CI flakiness from memory pressure
-          export NODE_OPTIONS="--max-old-space-size=4096"
+          export NODE_OPTIONS="--max-old-space-size=2048"
           VITEST_CI_FLAGS="--pool=forks --maxWorkers=2"
           # Mitigate low-frequency flakes by retrying failed tests once in CI
           RETRY_FLAG="--retry=1"


### PR DESCRIPTION
## Summary

- Reduce `NODE_OPTIONS --max-old-space-size` from 4096 to 2048 in Unit Tests CI job
- Fixes OOM crash in Vitest fork workers on all PRs that trigger actual test runs

## Root Cause

The Unit Tests step sets `--max-old-space-size=4096` (4 GB heap per process). With `--pool=forks --maxWorkers=2`, three Node.js processes run simultaneously (parent + 2 workers). Total potential heap: **12 GB** — well above the **7 GB** available on GitHub Actions `ubuntu-latest` runners. The OS OOM killer terminates workers after tests pass, causing "Worker exited unexpectedly" failures in shards 1/4 and 2/4 across all open PRs.

## Fix

Reduce to 2048 MB per process: 3 × 2 GB = 6 GB, within the 7 GB runner budget.

## Test plan

- [ ] CI Unit Tests pass on this PR (all 4 shards)
- [ ] Re-run CI on open PRs #7403, #7407, #7408 after merge to verify fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted CI memory configuration for test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->