### PR TITLE
fix(ci): materialize standalone symlinks before deploy

### DIFF
--- a/apps/web/scripts/sync-standalone-assets.mjs
+++ b/apps/web/scripts/sync-standalone-assets.mjs
@@ -1,10 +1,20 @@
-import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs';
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+} from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const appRoot = path.resolve(scriptDir, '..');
-const standaloneRoot = path.join(appRoot, '.next', 'standalone', 'apps', 'web');
+const standaloneOutputRoot = path.join(appRoot, '.next', 'standalone');
+const standaloneRoot = path.join(standaloneOutputRoot, 'apps', 'web');
 const standaloneNextRoot = path.join(standaloneRoot, '.next');
 
 const copyTargets = [
@@ -26,6 +36,56 @@ if (!existsSync(standaloneRoot)) {
   );
 }
 
+function countSymlinks(rootDir) {
+  let total = 0;
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    const entryPath = path.join(rootDir, entry.name);
+
+    if (entry.isSymbolicLink()) {
+      total += 1;
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      total += countSymlinks(entryPath);
+    }
+  }
+
+  return total;
+}
+
+function materializeSymlinks(rootDir) {
+  let materialized = 0;
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    const entryPath = path.join(rootDir, entry.name);
+
+    if (entry.isSymbolicLink()) {
+      const resolvedPath = realpathSync(entryPath);
+      const resolvedStats = lstatSync(resolvedPath);
+
+      rmSync(entryPath, { force: true, recursive: true });
+
+      if (resolvedStats.isDirectory()) {
+        cpSync(resolvedPath, entryPath, { recursive: true, dereference: true });
+        materialized += 1 + materializeSymlinks(entryPath);
+        continue;
+      }
+
+      copyFileSync(resolvedPath, entryPath);
+      materialized += 1;
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      materialized += materializeSymlinks(entryPath);
+    }
+  }
+
+  return materialized;
+}
+
 for (const target of copyTargets) {
   if (!existsSync(target.source)) {
     throw new Error(`Missing ${target.label} source at ${target.source}`);
@@ -36,4 +96,21 @@ for (const target of copyTargets) {
   cpSync(target.source, target.destination, { recursive: true });
 }
 
-console.log('Synced standalone public and static assets.');
+const symlinkCount = countSymlinks(standaloneOutputRoot);
+
+if (symlinkCount > 0) {
+  const materializedCount = materializeSymlinks(standaloneOutputRoot);
+  const remainingSymlinks = countSymlinks(standaloneOutputRoot);
+
+  if (remainingSymlinks > 0) {
+    throw new Error(
+      `Standalone output still contains ${remainingSymlinks} symlinks after materialization.`
+    );
+  }
+
+  console.log(
+    `Synced standalone public/static assets and materialized ${materializedCount} standalone symlinks.`
+  );
+} else {
+  console.log('Synced standalone public and static assets.');
+}


### PR DESCRIPTION
## Summary
- materialize pnpm symlinks across the full `apps/web/.next/standalone` tree during postbuild
- keep the standalone asset sync, but fail if any symlinks remain afterward
- address the Vercel deploy failure on `main` where serverless packaging rejected symlinked directories

## Root cause
Recent `main` deploys were failing in `deploy-staging` with:

`The framework produced an invalid deployment package for a Serverless Function. Typically this means that the framework produces files in symlinked directories.`

Local inspection of `apps/web/.next/standalone` after build showed pnpm-created symlinks in the standalone server bundle. The original sync script only copied `public` and `.next/static`, leaving those symlinks intact.

## Verification
- `doppler run --project jovie-web --config dev -- pnpm --filter web build`
- `node apps/web/scripts/sync-standalone-assets.mjs`
- `find apps/web/.next/standalone -type l | wc -l` -> `0`
- pre-push gate passed on `git push` (`biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced standalone asset synchronization to properly materialize symbolic links during the build process, ensuring all dependencies are correctly included in standalone deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->