### PR TITLE
fix: resolve SonarCloud S3358 nested ternary issues

### DIFF
--- a/apps/web/app/app/(shell)/admin/platform-connections/PlatformConnectionsClient.tsx
+++ b/apps/web/app/app/(shell)/admin/platform-connections/PlatformConnectionsClient.tsx
@@ -161,11 +161,9 @@ function SpotifyTabContent({
   }
 
   const isBusy = isPending || isConnecting;
-  const connectButtonLabel = isConnecting
-    ? 'Connecting'
-    : currentUser.hasSpotify
-      ? 'Reconnect Spotify'
-      : 'Connect Spotify';
+  let connectButtonLabel = 'Connect Spotify';
+  if (isConnecting) connectButtonLabel = 'Connecting';
+  else if (currentUser.hasSpotify) connectButtonLabel = 'Reconnect Spotify';
 
   return (
     <div className='divide-y divide-(--linear-app-frame-seam) rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-1'>

--- a/apps/web/components/features/demo/DemoAudienceWorkspace.tsx
+++ b/apps/web/components/features/demo/DemoAudienceWorkspace.tsx
@@ -141,14 +141,12 @@ export function DemoAudienceWorkspace() {
     captureMode === 'retargeting'
       ? null
       : 'analytics';
-  const tableTestId =
-    captureMode === 'quality'
-      ? 'demo-audience-capture-quality'
-      : captureMode === 'crm'
-        ? 'demo-audience-capture-crm'
-        : captureMode === 'retargeting'
-          ? 'demo-audience-capture-retargeting'
-          : 'demo-audience-shell';
+  const captureTestIds: Record<string, string> = {
+    quality: 'demo-audience-capture-quality',
+    crm: 'demo-audience-capture-crm',
+    retargeting: 'demo-audience-capture-retargeting',
+  };
+  const tableTestId = captureTestIds[captureMode] ?? 'demo-audience-shell';
   const analyticsSidebarTestId =
     captureMode === 'geo'
       ? 'demo-audience-capture-geo'

--- a/apps/web/components/features/profile/StaticListenInterface.tsx
+++ b/apps/web/components/features/profile/StaticListenInterface.tsx
@@ -166,6 +166,10 @@ export const StaticListenInterface = React.memo(function StaticListenInterface({
               DSP_LOGO_CONFIG[dsp.key as keyof typeof DSP_LOGO_CONFIG];
             const isSelected = selectedDSP === dsp.key;
 
+            let buttonClassName: string | undefined;
+            if (isPreview) buttonClassName = 'pointer-events-none opacity-88';
+            else if (isSelected || isLoading) buttonClassName = 'opacity-60';
+
             return (
               <SmartLinkProviderButton
                 key={dsp.key}
@@ -174,13 +178,7 @@ export const StaticListenInterface = React.memo(function StaticListenInterface({
                 }}
                 label={isSelected ? `Opening ${dsp.name}...` : dsp.name}
                 iconPath={logoConfig?.iconPath}
-                className={
-                  isPreview
-                    ? 'pointer-events-none opacity-88'
-                    : isSelected || isLoading
-                      ? 'opacity-60'
-                      : undefined
-                }
+                className={buttonClassName}
               />
             );
           })

--- a/apps/web/components/organisms/table/atoms/TableCheckboxCell.tsx
+++ b/apps/web/components/organisms/table/atoms/TableCheckboxCell.tsx
@@ -42,6 +42,15 @@ function isLegacyProps<TData = unknown>(
   return 'checked' in props && 'onChange' in props;
 }
 
+function resolveCheckboxState(
+  checked: boolean,
+  indeterminate: boolean
+): boolean | 'indeterminate' {
+  if (checked) return true;
+  if (indeterminate) return 'indeterminate';
+  return false;
+}
+
 // Normalize header checkbox state to string format
 function normalizeHeaderState(
   headerCheckboxState: 'checked' | 'unchecked' | 'indeterminate' | boolean
@@ -167,7 +176,7 @@ function LegacyCheckboxCell({
           )}
         >
           <Checkbox
-            checked={checked ? true : indeterminate ? 'indeterminate' : false}
+            checked={resolveCheckboxState(checked, indeterminate)}
             onCheckedChange={(value: boolean | 'indeterminate') =>
               onChange(value === true)
             }

--- a/apps/web/components/site/MarketingFooter.tsx
+++ b/apps/web/components/site/MarketingFooter.tsx
@@ -12,14 +12,12 @@ export function MarketingFooter({
   variant = 'auto',
 }: Readonly<MarketingFooterProps>) {
   const pathname = usePathname();
-  const resolvedVariant =
-    variant === 'auto'
-      ? pathname === APP_ROUTES.PRICING
-        ? 'regular'
-        : 'minimal'
-      : variant === 'expanded'
-        ? 'regular'
-        : 'minimal';
+  let resolvedVariant: 'regular' | 'minimal';
+  if (variant === 'auto') {
+    resolvedVariant = pathname === APP_ROUTES.PRICING ? 'regular' : 'minimal';
+  } else {
+    resolvedVariant = variant === 'expanded' ? 'regular' : 'minimal';
+  }
 
   return (
     <FooterOrganism

--- a/apps/web/lib/chat/tool-events.ts
+++ b/apps/web/lib/chat/tool-events.ts
@@ -212,6 +212,19 @@ function normalizeApproval(value: unknown): PersistedToolApproval | undefined {
   };
 }
 
+function getSummaryForState(
+  state: PersistedToolState,
+  output: Record<string, unknown> | undefined,
+  outputError: string | undefined,
+  approvalReason: string | undefined
+): string | undefined {
+  if (state === 'succeeded') return extractSummary(output);
+  if (state === 'failed' || state === 'denied') {
+    return extractSummary(output) ?? outputError ?? approvalReason;
+  }
+  return undefined;
+}
+
 function normalizeToolPart(part: ToolPart): PersistedToolEvent | null {
   if (!isToolUIPart(part)) {
     return null;
@@ -241,12 +254,12 @@ function normalizeToolPart(part: ToolPart): PersistedToolEvent | null {
       ? approval.reason
       : undefined;
   const outputError = extractErrorMessage(output);
-  const errorMessage =
-    typeof part.errorText === 'string'
-      ? part.errorText
-      : state === 'failed' || state === 'denied'
-        ? (outputError ?? approvalReason)
-        : undefined;
+  let errorMessage: string | undefined;
+  if (typeof part.errorText === 'string') {
+    errorMessage = part.errorText;
+  } else if (state === 'failed' || state === 'denied') {
+    errorMessage = outputError ?? approvalReason;
+  }
 
   return {
     schemaVersion: 2,
@@ -256,12 +269,7 @@ function normalizeToolPart(part: ToolPart): PersistedToolEvent | null {
     input,
     output,
     errorMessage,
-    summary:
-      state === 'succeeded'
-        ? extractSummary(output)
-        : state === 'failed' || state === 'denied'
-          ? (extractSummary(output) ?? outputError ?? approvalReason)
-          : undefined,
+    summary: getSummaryForState(state, output, outputError, approvalReason),
     uiHint: config.uiHint,
     approval,
   };

--- a/apps/web/lib/share/destinations.ts
+++ b/apps/web/lib/share/destinations.ts
@@ -121,14 +121,13 @@ async function launchInstagramStory(
   }
 
   const downloaded = await downloadAsset(context);
-  return {
-    status: 'fallback',
-    helperText: downloaded
-      ? copied
-        ? 'Story asset downloaded and link copied. Add it in Instagram Stories.'
-        : 'Story asset downloaded. Copy the link manually for your story sticker.'
-      : 'Could not prepare the story asset. Try again.',
-  };
+  let helperText = 'Could not prepare the story asset. Try again.';
+  if (downloaded) {
+    helperText = copied
+      ? 'Story asset downloaded and link copied. Add it in Instagram Stories.'
+      : 'Story asset downloaded. Copy the link manually for your story sticker.';
+  }
+  return { status: 'fallback', helperText };
 }
 
 async function launchTwitter(


### PR DESCRIPTION
## Summary
- Extract 10 nested ternary expressions (S3358) into if/else blocks, helper functions, or lookup maps across 7 files
- No behavior changes — purely code quality improvements

## SonarCloud Rules Addressed
- **S3358**: Extract nested ternary operation into an independent statement

## Files Changed
- `lib/share/destinations.ts` — extract download/copy status ternary
- `components/site/MarketingFooter.tsx` — extract variant resolution
- `admin/platform-connections/PlatformConnectionsClient.tsx` — extract connect label
- `lib/chat/tool-events.ts` — extract error message and summary logic into helper function
- `components/features/demo/DemoAudienceWorkspace.tsx` — use lookup map for test IDs
- `components/features/profile/StaticListenInterface.tsx` — extract className logic
- `components/organisms/table/atoms/TableCheckboxCell.tsx` — extract checkbox state resolver

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] ESLint passes
- [x] A11y check passes
- [x] No behavior changes (code quality fixes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code readability and maintainability across multiple components by simplifying complex conditional expressions into explicit control flows, helper functions, and lookup structures. No user-facing functionality has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->