### PR TITLE
fix(stripe): skip unknown price ids without retry storms

### DIFF
--- a/apps/web/lib/stripe/webhooks/base-handler.ts
+++ b/apps/web/lib/stripe/webhooks/base-handler.ts
@@ -106,7 +106,9 @@ export abstract class BaseSubscriptionHandler implements WebhookHandler {
    * 3. If active: Validates price ID, looks up plan, upgrades user (isPro = true)
    *
    * Error Handling:
-   * - Throws on unrecoverable errors (missing price ID, unknown plan)
+   * - Throws on unrecoverable errors (missing price ID)
+   * - Skips with a captured critical error on unknown plans so webhook delivery
+   *   can be acknowledged without retry storms when Stripe price config drifts
    * - Returns error result on billing update failures
    *
    * @param options - Processing options including subscription, user ID, and event metadata
@@ -241,7 +243,11 @@ export abstract class BaseSubscriptionHandler implements WebhookHandler {
           route: '/api/stripe/webhooks',
         }
       );
-      throw new Error(`Unknown price ID: ${priceId}`);
+      return {
+        success: true,
+        skipped: true,
+        reason: 'unknown_price_id',
+      };
     }
 
     // Update user's billing status

--- a/apps/web/tests/unit/lib/stripe/webhooks/handlers/checkout-handler.critical.test.ts
+++ b/apps/web/tests/unit/lib/stripe/webhooks/handlers/checkout-handler.critical.test.ts
@@ -373,8 +373,19 @@ describe('@critical CheckoutSessionHandler', () => {
         stripeEventTimestamp: new Date(),
       };
 
-      await expect(handler.handle(context)).rejects.toThrow(
-        'Unknown price ID: price_unknown'
+      await expect(handler.handle(context)).resolves.toMatchObject({
+        success: true,
+        skipped: true,
+        reason: 'unknown_price_id',
+      });
+
+      expect(mockCaptureCriticalError).toHaveBeenCalledWith(
+        'Unknown price ID in subscription',
+        expect.any(Error),
+        expect.objectContaining({
+          route: '/api/stripe/webhooks',
+          priceId: 'price_unknown',
+        })
       );
     });
 

--- a/apps/web/tests/unit/lib/stripe/webhooks/handlers/subscription-handler.errors.test.ts
+++ b/apps/web/tests/unit/lib/stripe/webhooks/handlers/subscription-handler.errors.test.ts
@@ -184,8 +184,19 @@ describe('@critical SubscriptionHandler - Errors', () => {
         stripeEventTimestamp: new Date(),
       };
 
-      await expect(handler.handle(context)).rejects.toThrow(
-        'Unknown price ID: price_unknown'
+      await expect(handler.handle(context)).resolves.toMatchObject({
+        success: true,
+        skipped: true,
+        reason: 'unknown_price_id',
+      });
+
+      expect(mockCaptureCriticalError).toHaveBeenCalledWith(
+        'Unknown price ID in subscription',
+        expect.any(Error),
+        expect.objectContaining({
+          route: '/api/stripe/webhooks',
+          priceId: 'price_unknown',
+        })
       );
     });
 


### PR DESCRIPTION
## What changed
- Treat unknown Stripe subscription price IDs as a controlled skip instead of throwing from the webhook handler.
- Keep the critical error capture so the mismatch is still observable in Sentry/error tracking.
- Add regression coverage for subscription and checkout webhook paths.

## Why it matters
- Prevents repeated webhook retry storms when Stripe price config drifts or stale price IDs appear in production.
- Keeps billing processing fail-closed without turning config drift into a 500 loop.

## Testing
- pnpm --filter=@jovie/web exec vitest run tests/unit/lib/stripe/webhooks/handlers/subscription-handler.errors.test.ts tests/unit/lib/stripe/webhooks/handlers/checkout-handler.critical.test.ts tests/unit/api/stripe/webhooks.errors.test.ts
- pre-push checks ran successfully on push:
  - biome check .
  - @jovie/web next:proxy-guard
  - @jovie/web tailwind:check
  - @jovie/web typecheck
  - @jovie/web lint

## Risk
- Low to medium. The change only affects the unknown price ID branch and preserves observability while avoiding retries.

## Rollback
- Revert the commit if we need Stripe to retry unknown-price events again.

## Related issues
- #7339
- #7340

## Surface area
- Stripe webhooks / billing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced subscription webhook processing to handle unknown pricing identifiers more gracefully, preventing failed deliveries and avoiding unnecessary retry storms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->