### PR TITLE
fix(profile): use user-first dashboard lookup

### DIFF
--- a/apps/web/app/api/dashboard/profile/lib/db-operations.ts
+++ b/apps/web/app/api/dashboard/profile/lib/db-operations.ts
@@ -90,13 +90,17 @@ export async function updateProfileRecords({
 }
 
 export async function getProfileByClerkId(clerkUserId: string) {
+  const user = await getUserByClerkId(db, clerkUserId);
+  if (!user) {
+    return null;
+  }
+
   const [userProfile] = await db
     .select({
       profile: creatorProfiles,
     })
     .from(creatorProfiles)
-    .innerJoin(users, eq(users.id, creatorProfiles.userId))
-    .where(eq(users.clerkId, clerkUserId))
+    .where(eq(creatorProfiles.userId, user.id))
     .limit(1);
 
   return userProfile ?? null;

--- a/apps/web/tests/unit/api/dashboard/profile/db-operations.test.ts
+++ b/apps/web/tests/unit/api/dashboard/profile/db-operations.test.ts
@@ -1,20 +1,37 @@
 import { NextResponse } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
 
 const mockGetUserByClerkId = vi.hoisted(() => vi.fn());
 const mockDbSelect = vi.hoisted(() => vi.fn());
 const mockDbUpdate = vi.hoisted(() => vi.fn());
+const mockEq = vi.hoisted(() =>
+  vi.fn((left, right) => ({
+    left,
+    right,
+  }))
+);
+const mockDb = vi.hoisted(() => ({
+  select: mockDbSelect,
+  update: mockDbUpdate,
+}));
 
 vi.mock('@/lib/db', () => ({
-  db: {
-    select: mockDbSelect,
-    update: mockDbUpdate,
-  },
+  db: mockDb,
 }));
 
 vi.mock('@/lib/db/queries/shared', () => ({
   getUserByClerkId: mockGetUserByClerkId,
 }));
+
+vi.mock('drizzle-orm', async () => {
+  const actual =
+    await vi.importActual<typeof import('drizzle-orm')>('drizzle-orm');
+  return {
+    ...actual,
+    eq: mockEq,
+  };
+});
 
 function createSelectChain(result: unknown[] = []) {
   const chain = {
@@ -80,5 +97,41 @@ describe('updateProfileRecords', () => {
         },
       })
     );
+  });
+});
+
+describe('getProfileByClerkId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves the Clerk user before loading the profile by user.id', async () => {
+    let resolveUser: (value: { id: string } | null) => void;
+    const userPromise = new Promise<{ id: string } | null>(resolve => {
+      resolveUser = resolve;
+    });
+    mockGetUserByClerkId.mockReturnValue(userPromise);
+
+    const profileRow = { profile: { id: 'profile-1' } };
+    const selectChain = createSelectChain([profileRow]);
+
+    const { getProfileByClerkId } = await import(
+      '@/app/api/dashboard/profile/lib/db-operations'
+    );
+
+    const profilePromise = getProfileByClerkId('clerk_123');
+
+    await Promise.resolve();
+    expect(mockDbSelect).not.toHaveBeenCalled();
+
+    resolveUser!({ id: 'user-1' });
+    await expect(profilePromise).resolves.toEqual(profileRow);
+
+    expect(mockGetUserByClerkId).toHaveBeenCalledWith(mockDb, 'clerk_123');
+    expect(selectChain.from).toHaveBeenCalledWith(creatorProfiles);
+    expect(selectChain.where).toHaveBeenCalledWith({
+      left: creatorProfiles.userId,
+      right: 'user-1',
+    });
   });
 });


### PR DESCRIPTION
## What changed
- Hardened the dashboard profile lookup path for issue #7358.
- getProfileByClerkId now resolves the Clerk user first and then loads the creator profile by user ID.
- This removes the brittle creator_profiles/users inner join from the fetch path.

## Why
- The old join path could fail when the users row or join relationship was out of sync.
- The new path reuses the safer user-first lookup pattern already used elsewhere in the module.

## Testing
- pnpm --filter=@jovie/web exec vitest run tests/unit/api/dashboard/profile/db-operations.test.ts
- pre-push checks ran successfully on push:
  - biome check .
  - @jovie/web next:proxy-guard
  - @jovie/web tailwind:check
  - @jovie/web typecheck
  - @jovie/web lint

## Scope
- Single query-path hardening.
- Focused regression coverage only.

## Related
- #7358


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved profile data retrieval with enhanced error handling to gracefully manage cases where user records don't exist.

* **Performance**
  * Optimized database query execution patterns for profile operations.

* **Tests**
  * Expanded test coverage for profile retrieval workflows to ensure reliability across asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->