### PR TITLE
fix: resolve SonarCloud minor quality issues

### DIFF
--- a/apps/web/app/[username]/tour/TourDatesList.tsx
+++ b/apps/web/app/[username]/tour/TourDatesList.tsx
@@ -48,7 +48,7 @@ export function TourDatesList({
           handle={handle}
           isNearYou={item.isNearby}
           distanceKm={
-            item.distanceMiles != null ? item.distanceMiles / 0.621371 : null
+            item.distanceMiles == null ? null : item.distanceMiles / 0.621371
           }
         />
       ))}

--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -187,7 +187,7 @@ export function ChatPageClient({
   const [initialQueryHandled, setInitialQueryHandled] = useState(false);
   const { setHeaderBadge, setHeaderActions } = useSetHeaderActions();
   const [autoRetryCount, setAutoRetryCount] = useState(0);
-  const [_welcomeChatBootstrapState, setWelcomeChatBootstrapState] =
+  const [, setWelcomeChatBootstrapState] =
     useState<WelcomeChatBootstrapState>('idle');
   const welcomeChatBootstrapStateRef =
     useRef<WelcomeChatBootstrapState>('idle');

--- a/apps/web/components/features/dashboard/molecules/ProfilePreview.tsx
+++ b/apps/web/components/features/dashboard/molecules/ProfilePreview.tsx
@@ -81,7 +81,6 @@ export function ProfilePreview({
           showBackButton={false}
           contacts={[]}
           showFooter={false}
-          autoOpenCapture={false}
         />
       </div>
     </div>

--- a/apps/web/components/features/dashboard/organisms/DashboardPreview.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardPreview.tsx
@@ -89,7 +89,6 @@ export const DashboardPreview: React.FC<DashboardPreviewProps> = ({
                   showBackButton={false}
                   contacts={[]}
                   showFooter={false}
-                  autoOpenCapture={false}
                 />
               </div>
             </div>

--- a/apps/web/components/features/profile/StaticArtistPage.tsx
+++ b/apps/web/components/features/profile/StaticArtistPage.tsx
@@ -22,7 +22,6 @@ export interface StaticArtistPageProps {
   readonly showBackButton: boolean;
   readonly showTourButton?: boolean;
   readonly showFooter?: boolean;
-  readonly autoOpenCapture?: boolean;
   readonly enableDynamicEngagement?: boolean;
   readonly latestRelease?: DiscogRelease | null;
   readonly photoDownloadSizes?: AvatarSize[];

--- a/apps/web/components/marketing/artist-profile/ArtistProfileSocialProof.tsx
+++ b/apps/web/components/marketing/artist-profile/ArtistProfileSocialProof.tsx
@@ -76,11 +76,11 @@ export function ArtistProfileSocialProof({
         </div>
       ) : null}
 
-      {!proofData.hasRealQuotes ? (
+      {proofData.hasRealQuotes ? null : (
         <p className='mt-6 text-[13px] leading-[1.65] text-tertiary-token'>
           {proofData.founderFallback}
         </p>
-      ) : null}
+      )}
     </ArtistProfileSectionShell>
   );
 }

--- a/apps/web/components/site/MarketingHeader.tsx
+++ b/apps/web/components/site/MarketingHeader.tsx
@@ -15,10 +15,10 @@ const DEFAULT_STAGED_HOMEPAGE_NAV_LINKS: readonly MarketingHeaderNavLink[] = [
   { href: APP_ROUTES.PRICING, label: 'Pricing' },
   { href: APP_ROUTES.SUPPORT, label: 'Support' },
 ] as const;
-const STAGED_NAV_PATHS: readonly string[] = [
+const STAGED_NAV_PATHS = new Set<string>([
   APP_ROUTES.LANDING_NEW,
   APP_ROUTES.PRICING,
-];
+]);
 
 export interface MarketingHeaderProps
   extends Readonly<{
@@ -36,8 +36,7 @@ export function MarketingHeader({
   variant = 'landing',
 }: MarketingHeaderProps) {
   const pathname = usePathname();
-  const showStagedNav =
-    pathname !== null && STAGED_NAV_PATHS.includes(pathname);
+  const showStagedNav = pathname !== null && STAGED_NAV_PATHS.has(pathname);
   const resolvedNavLinks =
     navLinks ?? (showStagedNav ? DEFAULT_STAGED_HOMEPAGE_NAV_LINKS : undefined);
 

--- a/apps/web/lib/flags/server.ts
+++ b/apps/web/lib/flags/server.ts
@@ -15,7 +15,6 @@ import {
   parseAppFlagOverrides,
 } from './overrides';
 import { APP_FLAG_REGISTRY, SUBSCRIBE_CTA_VARIANT_FLAG } from './registry';
-import { checkGateForUser, getExperiment, shutdownStatsig } from './statsig';
 
 function shouldHonorClientFlagOverrides(): boolean {
   return !(
@@ -103,4 +102,4 @@ export async function getSubscribeCTAVariant(
   });
 }
 
-export { checkGateForUser, getExperiment, shutdownStatsig };
+export { checkGateForUser, getExperiment, shutdownStatsig } from './statsig';


### PR DESCRIPTION
## Summary
Fixes 7 SonarCloud issues across minor/info severity:
- **S6754**: Remove unused `useState` value in `ChatPageClient` (skip first element)
- **S6767**: Remove unused `autoOpenCapture` prop from `StaticArtistPage` interface and callers
- **S7735**: Flip negated conditions in `ArtistProfileSocialProof` and `TourDatesList`
- **S7763**: Use `export { ... } from` syntax for re-exports in `flags/server.ts`
- **S7776**: Use `Set` instead of array for `STAGED_NAV_PATHS` in `MarketingHeader`

## SonarCloud Rules Addressed
- S6754: useState call is not destructured into value + setter pair
- S6767: PropType is defined but prop is never used
- S7735: Unexpected negated condition
- S7763: Use export…from to re-export
- S7776: Use Set and .has() for membership checks

## Test plan
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Biome lint passes
- [x] All pre-commit hooks pass
- [x] No behavior changes (code quality fixes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null handling in distance calculations.

* **Refactor**
  * Simplified profile preview behavior by using default artist page settings.
  * Optimized navigation path lookups.
  * Reorganized internal module exports for maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->