### PR TITLE
test(submission-agent): cover provider utilities

### DIFF
--- a/apps/web/tests/unit/lib/submission-agent/amazon-provider.test.ts
+++ b/apps/web/tests/unit/lib/submission-agent/amazon-provider.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockServerFetch } = vi.hoisted(() => ({
+  mockServerFetch: vi.fn(),
+}));
+
+vi.mock('@/lib/http/server-fetch', () => ({
+  serverFetch: mockServerFetch,
+}));
+
+describe('submission-agent/monitoring/providers/amazon.ts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('returns null when the target fetch fails', async () => {
+    mockServerFetch.mockResolvedValue({
+      ok: false,
+    });
+
+    const { snapshotAmazonTarget } = await import(
+      '@/lib/submission-agent/monitoring/providers/amazon'
+    );
+
+    const result = await snapshotAmazonTarget({} as never, {
+      targetType: 'artist',
+      canonicalUrl: 'https://music.amazon.com/artists/abc',
+    });
+
+    expect(result).toBeNull();
+    expect(mockServerFetch).toHaveBeenCalledWith(
+      'https://music.amazon.com/artists/abc',
+      expect.objectContaining({
+        context: 'Amazon target fetch (artist)',
+        timeoutMs: 8_000,
+      })
+    );
+  });
+
+  it('extracts description and image metadata from the page', async () => {
+    mockServerFetch.mockResolvedValue({
+      ok: true,
+      text: vi.fn().mockResolvedValue(`
+        <html>
+          <head>
+            <meta name="description" content="Artist bio summary">
+            <meta property="twitter:image" content="https://cdn.example/image.jpg">
+          </head>
+        </html>
+      `),
+    });
+
+    const { snapshotAmazonTarget } = await import(
+      '@/lib/submission-agent/monitoring/providers/amazon'
+    );
+
+    const result = await snapshotAmazonTarget({} as never, {
+      targetType: 'artist',
+      canonicalUrl: 'https://music.amazon.com/artists/abc',
+    });
+
+    expect(result).toEqual({
+      targetType: 'artist',
+      canonicalUrl: 'https://music.amazon.com/artists/abc',
+      normalizedData: {
+        hasBio: true,
+        hasArtistImage: true,
+        hasArtwork: true,
+      },
+    });
+  });
+});

--- a/apps/web/tests/unit/lib/submission-agent/discovery.test.ts
+++ b/apps/web/tests/unit/lib/submission-agent/discovery.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDiscoverAllMusicTargets } = vi.hoisted(() => ({
+  mockDiscoverAllMusicTargets: vi.fn(),
+}));
+
+vi.mock('@/lib/submission-agent/monitoring/providers/allmusic', () => ({
+  discoverAllMusicTargets: mockDiscoverAllMusicTargets,
+}));
+
+describe('submission-agent/monitoring/discovery.ts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('returns only new AllMusic targets for the Xperi provider', async () => {
+    mockDiscoverAllMusicTargets.mockResolvedValue([
+      {
+        targetType: 'artist',
+        canonicalUrl: 'https://allmusic.example/artist/dua-lipa',
+      },
+      {
+        targetType: 'album',
+        canonicalUrl: 'https://allmusic.example/album/future-nostalgia',
+      },
+    ]);
+
+    const { discoverSubmissionTargets } = await import(
+      '@/lib/submission-agent/monitoring/discovery'
+    );
+
+    const result = await discoverSubmissionTargets({
+      providerId: 'xperi_allmusic_email',
+      canonical: {
+        artistName: 'Dua Lipa',
+      } as never,
+      existingTargets: [
+        {
+          targetType: 'artist',
+          canonicalUrl: 'https://allmusic.example/artist/dua-lipa',
+        },
+      ],
+    });
+
+    expect(mockDiscoverAllMusicTargets).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      {
+        targetType: 'album',
+        canonicalUrl: 'https://allmusic.example/album/future-nostalgia',
+      },
+    ]);
+  });
+
+  it('skips discovery for unsupported providers', async () => {
+    const { discoverSubmissionTargets } = await import(
+      '@/lib/submission-agent/monitoring/discovery'
+    );
+
+    const result = await discoverSubmissionTargets({
+      providerId: 'musicbrainz_authenticated_edit',
+      canonical: {} as never,
+      existingTargets: [],
+    });
+
+    expect(result).toEqual([]);
+    expect(mockDiscoverAllMusicTargets).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/lib/submission-agent/email-package.test.ts
+++ b/apps/web/tests/unit/lib/submission-agent/email-package.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildSubmissionPackage,
+  computeAttachmentChecksum,
+} from '@/lib/submission-agent/artifacts/email-package';
+import type {
+  CanonicalSubmissionContext,
+  SubmissionAttachment,
+} from '@/lib/submission-agent/types';
+
+function createCanonical(
+  overrides: Partial<CanonicalSubmissionContext> = {}
+): CanonicalSubmissionContext {
+  return {
+    profileId: 'profile-1',
+    artistName: 'Dua <Lipa>',
+    artistBio: 'Pop artist',
+    artistContactEmail: 'artist@example.com',
+    replyToEmail: 'reply@example.com',
+    release: {
+      id: 'release-1',
+      title: 'Future Nostalgia <Deluxe>',
+      releaseType: 'album',
+      releaseDate: new Date('2025-08-15T00:00:00Z'),
+      label: 'Warner',
+      upc: '123456789012',
+      totalTracks: 11,
+      artworkUrl: 'https://example.com/artwork.jpg',
+      genres: ['pop'],
+      catalogNumber: 'CAT-001',
+    },
+    tracks: [],
+    pressPhotos: [],
+    ...overrides,
+  };
+}
+
+describe('submission-agent/email-package.ts', () => {
+  it('computes a deterministic attachment checksum', () => {
+    expect(computeAttachmentChecksum('hello')).toBe(
+      '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+    );
+  });
+
+  it('builds a package with escaped html and release metadata', () => {
+    const attachments: SubmissionAttachment[] = [
+      {
+        kind: 'release_artwork',
+        filename: 'cover-art.png',
+        mimeType: 'image/png',
+        checksum: 'checksum-1',
+      },
+      {
+        kind: 'artist_bio',
+        filename: 'bio.txt',
+        mimeType: 'text/plain',
+        checksum: 'checksum-2',
+      },
+    ];
+
+    const result = buildSubmissionPackage({
+      canonical: createCanonical(),
+      subject: 'Submission package',
+      greeting: 'Hello <team>',
+      bodyIntro: 'Please review & approve.',
+      attachments,
+      monitoringBaseline: { hasBio: true },
+    });
+
+    expect(result.subject).toBe('Submission package');
+    expect(result.attachments).toEqual(attachments);
+    expect(result.monitoringBaseline).toEqual({ hasBio: true });
+    expect(result.text).toContain('Artist: Dua <Lipa>');
+    expect(result.text).toContain('Release: Future Nostalgia <Deluxe>');
+    expect(result.text).toContain('Release Date: 2025-08-15');
+    expect(result.text).toContain('Reply-To: reply@example.com');
+    expect(result.text).toContain('- cover-art.png');
+    expect(result.html).toContain('Hello &lt;team&gt;');
+    expect(result.html).toContain('Future Nostalgia &lt;Deluxe&gt;');
+    expect(result.html).toContain('Please review &amp; approve.');
+    expect(result.html).toContain('<li>cover-art.png</li><li>bio.txt</li>');
+  });
+
+  it('falls back to placeholder values when release and reply-to are missing', () => {
+    const result = buildSubmissionPackage({
+      canonical: createCanonical({
+        artistContactEmail: null,
+        replyToEmail: null,
+        release: null,
+      }),
+      subject: 'Fallback package',
+      greeting: 'Hi there',
+      bodyIntro: 'Missing release metadata',
+      attachments: [],
+      monitoringBaseline: {},
+    });
+
+    expect(result.text).toContain('Release: Untitled release');
+    expect(result.text).toContain('Release Date: Unknown');
+    expect(result.text).toContain('Reply-To: Not provided');
+    expect(result.html).toContain('Untitled release');
+    expect(result.html).toContain('Unknown');
+    expect(result.html).toContain('Not provided');
+  });
+});

--- a/apps/web/tests/unit/lib/submission-agent/musicbrainz-provider.test.ts
+++ b/apps/web/tests/unit/lib/submission-agent/musicbrainz-provider.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { musicBrainzAuthenticatedEditProvider } from '@/lib/submission-agent/providers/musicbrainz';
+
+describe('submission-agent/providers/musicbrainz.ts', () => {
+  it('advertises the authenticated edit transport and launch guardrail', async () => {
+    expect(musicBrainzAuthenticatedEditProvider.id).toBe(
+      'musicbrainz_authenticated_edit'
+    );
+    expect(musicBrainzAuthenticatedEditProvider.transport).toBe(
+      'authenticated_edit'
+    );
+    expect(musicBrainzAuthenticatedEditProvider.requiredInputs).toEqual([
+      'artist_name',
+      'release',
+      'release_tracks',
+    ]);
+
+    const result = await musicBrainzAuthenticatedEditProvider.buildPackage(
+      {} as never
+    );
+
+    expect(result).toEqual({
+      package: null,
+      missingFields: [
+        {
+          field: 'provider',
+          reason:
+            'MusicBrainz authenticated edits are not part of the Xperi-first launch.',
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add focused unit coverage for the untested exported seams in `submission-agent`
- cover `email-package`, discovery filtering, the Amazon snapshot helper, and the MusicBrainz launch guardrail provider

## Dependency
- depends on the draft PR `test(fit-scoring): cover spotify enrichment`
- stacked base branch: `itstimwhite/test-fit-enrich`
- next draft in stack: `chore(ci): add ui coverage uploads`

## Notes
- this is the second concrete coverage-debt paydown draft in the app-side rollout
- because this draft targets a non-`main` base branch, the normal `pull_request` CI workflow will not fully run until a later agent retargets/rebases it toward `main` during the merge queue walk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Comprehensive unit test coverage added for submission agent components, including provider integrations, discovery mechanisms, and email package generation and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->