### PR TITLE
chore(ci): block codecov statuses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Local `/browse` auth is bypass-first, not Clerk-form-first.
 ## Test Coverage Policy
 
 - Treat Codecov patch coverage as the PR readiness signal and project coverage as the regression ratchet.
-- During the rollout soak window, coverage statuses stay informational before becoming required checks in GitHub branch protection.
+- Codecov statuses are blocking in repo config; branch protection should require `codecov/project/default`, `codecov/patch/default`, `codecov/patch/critical`, and `E2E Smoke (PR Fast Feedback)` once each check has appeared recently in the repo.
 - Bug-fix PRs must add or update a regression test, or explain the exception in the PR body.
 - Add the `testing` label to billing, auth, entitlements, webhook, migration, and environment/config PRs so `E2E Smoke (PR Fast Feedback)` runs before merge.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,8 +17,8 @@ coverage:
       default:
         target: auto
         threshold: 0.5%
-        # Soak window: report until branch protection is tightened after rollout.
-        informational: true
+        # Block regressions in the repo config; branch protection follows separately.
+        informational: false
         # Ratchet PRs against the existing main baseline.
         only_pulls: true
     # Patch coverage: coverage of new/modified lines
@@ -27,12 +27,12 @@ coverage:
         target: 80%
         threshold: 0%
         if_not_found: success
-        informational: true
+        informational: false
       critical:
         target: 95%
         threshold: 0%
         if_not_found: success
-        informational: true
+        informational: false
         paths:
           - apps/web/lib/stripe/**
           - apps/web/lib/billing/**


### PR DESCRIPTION
## Summary
- flip `codecov/project/default`, `codecov/patch/default`, and `codecov/patch/critical` from informational to blocking in repo config
- update coverage policy copy so the repo docs match the blocking-state config

## Dependency
- depends on #7413 landing first
- stacked base branch: `itstimwhite/test-coverage`
- next draft in stack: `test(fit-scoring): cover spotify enrichment`

## Notes
- GitHub branch protection is still external to the repo and is not changed by this PR
- because this draft targets a non-`main` base branch, the normal `pull_request` CI workflow will not fully run until a later agent retargets/rebases it toward `main` during the merge queue walk