### PR TITLE
chore(ci): add ui coverage uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
     outputs:
       run_build: ${{ steps.detect.outputs.run_build }}
       run_test: ${{ steps.detect.outputs.run_test }}
+      run_ui_coverage: ${{ steps.detect.outputs.run_ui_coverage }}
       run_public_lighthouse: ${{ steps.detect.outputs.run_public_lighthouse }}
       run_dashboard_lighthouse: ${{ steps.detect.outputs.run_dashboard_lighthouse }}
       run_onboarding_lighthouse: ${{ steps.detect.outputs.run_onboarding_lighthouse }}
@@ -61,7 +62,7 @@ jobs:
           # Force run all if the 'testing' label is present
           if [[ "$FULL_CI_LABEL" == "true" ]]; then
             echo "Forcing full CI run due to 'testing' label"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_e2e run_drizzle has_code_changes; do
+            for t in run_build run_test run_ui_coverage run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_e2e run_drizzle has_code_changes; do
               echo "$t=true" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -74,7 +75,7 @@ jobs:
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             # Manual dispatch: run everything
             echo "Manual dispatch: running all checks"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_e2e run_drizzle has_code_changes; do
+            for t in run_build run_test run_ui_coverage run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_e2e run_drizzle has_code_changes; do
               echo "$t=true" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -85,7 +86,7 @@ jobs:
           # Check if only docs changed (exclude .github/ — workflow changes must run CI)
           if echo "$CHANGED_FILES" | grep -v -E '^\.(github/)' | grep -v -E '\.(md|txt)$' | wc -l | grep -q '^0$'; then
             echo "Only documentation files changed"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_e2e run_drizzle has_code_changes; do
+            for t in run_build run_test run_ui_coverage run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_e2e run_drizzle has_code_changes; do
               echo "$t=false" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -111,6 +112,13 @@ jobs:
           else
             RUN_TEST=false
             echo "run_test=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          UI_COVERAGE_PATTERN='^(packages/ui/|packages/ui/package.*\.json|package.*\.json)'
+          if echo "$CHANGED_FILES" | grep -q -E "$UI_COVERAGE_PATTERN"; then
+            echo "run_ui_coverage=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_ui_coverage=false" >> "$GITHUB_OUTPUT"
           fi
 
           PUBLIC_LIGHTHOUSE_PATTERN='^(\.github/workflows/ci\.yml|apps/web/\.lighthouserc\.pr\.json|apps/web/\.lighthouserc\.public-launch\.json|apps/web/app/\(home\)/|apps/web/app/\(marketing\)/|apps/web/app/\(dynamic\)/legal/|apps/web/content/legal/|apps/web/app/\[username\]/|apps/web/app/layout\.tsx|apps/web/app/globals\.css|apps/web/public/|apps/web/styles/|apps/web/components/features/home/|apps/web/components/features/marketing/|apps/web/components/features/profile/|apps/web/scripts/run-public-lighthouse\.ts|apps/web/scripts/public-route-qa\.ts|apps/web/scripts/public-surface-qa\.ts|apps/web/scripts/performance-route-manifest\.ts|apps/web/tests/e2e/public-exhaustive\.spec\.ts|apps/web/tests/e2e/axe-audit\.spec\.ts|apps/web/tests/e2e/utils/(public-surface-(manifest|helpers)|smoke-test-utils)\.ts|packages/|apps/web/package.*\.json|package.*\.json|apps/web/tailwind\.config\.|apps/web/postcss\.config\.)'
@@ -166,6 +174,7 @@ jobs:
             echo "run_dashboard_lighthouse=false" >> "$GITHUB_OUTPUT"
             echo "run_admin_lighthouse=false" >> "$GITHUB_OUTPUT"
             echo "run_test=false" >> "$GITHUB_OUTPUT"
+            echo "run_ui_coverage=false" >> "$GITHUB_OUTPUT"
           fi
 
   ci-env-example-guard:
@@ -1859,9 +1868,20 @@ jobs:
           TURBO_SCM_BASE: ${{ github.event_name == 'merge_group' && 'origin/main' || (github.base_ref && format('origin/{0}', github.base_ref)) || '' }}
         run: pnpm --filter=@jovie/web run test:fast -- --pool=forks --maxWorkers=2 --retry=2 ${{ steps.quarantine.outputs.unit_files }}
 
-      - name: Run packages/ui unit tests
-        if: steps.check_changes.outputs.run_full_ci == 'true'
-        run: pnpm turbo test --filter=@jovie/ui
+      - name: Run packages/ui unit tests with coverage
+        if: steps.check_changes.outputs.run_full_ci == 'true' && matrix.shard == '1/4' && (github.ref == 'refs/heads/main' || needs.ci-path-changes.outputs.run_ui_coverage == 'true')
+        run: pnpm --filter=@jovie/ui exec vitest run --coverage
+
+      - name: Upload packages/ui coverage to Codecov
+        if: steps.check_changes.outputs.run_full_ci == 'true' && matrix.shard == '1/4' && (github.ref == 'refs/heads/main' || needs.ci-path-changes.outputs.run_ui_coverage == 'true')
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
+        with:
+          files: packages/ui/coverage/lcov.info
+          flags: ui
+          name: ui-${{ github.sha }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          verbose: true
 
       - name: Upload coverage to Codecov
         if: steps.check_changes.outputs.run_full_ci == 'true' && (github.event_name == 'pull_request' || github.ref == 'refs/heads/main')

--- a/codecov.yml
+++ b/codecov.yml
@@ -57,6 +57,10 @@ flags:
     paths:
       - apps/web/
     carryforward: true
+  ui:
+    paths:
+      - packages/ui/
+    carryforward: true
 
 # Ignore patterns - files not considered for coverage
 ignore:
@@ -71,7 +75,6 @@ ignore:
   - "**/dist/**"
   - "**/__mocks__/**"
   - "**/storybook-static/**"
-  - "packages/ui/**"  # UI package has its own coverage if needed
 
 # Component management for better PR insights
 component_management:

--- a/packages/ui/atoms/searchable-submenu.test.tsx
+++ b/packages/ui/atoms/searchable-submenu.test.tsx
@@ -1,9 +1,11 @@
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { SearchableSubmenuItem } from './searchable-submenu';
-import { SearchableList } from './searchable-submenu';
+import { SearchableList, SearchableSubmenu } from './searchable-submenu';
 
 // Sample items for testing
 const sampleItems: SearchableSubmenuItem[] = [
@@ -13,6 +15,19 @@ const sampleItems: SearchableSubmenuItem[] = [
   { id: 'item-4', label: 'Date', disabled: true },
   { id: 'item-5', label: 'Elderberry', shortcut: '⌘E' },
 ];
+
+const sampleSections = [
+  {
+    id: 'fruits',
+    label: 'Fruits',
+    items: sampleItems.slice(0, 3),
+  },
+  {
+    id: 'dates',
+    label: 'Dates',
+    items: sampleItems.slice(3),
+  },
+] as const;
 
 /**
  * Helper to get the visual items container (aria-hidden div with buttons).
@@ -32,6 +47,32 @@ function getItemButton(container: HTMLElement, label: string): HTMLElement {
   const visual = getVisualContainer(container);
   return within(visual).getByText(label).closest('button')!;
 }
+
+async function openSubmenu(triggerLabel = 'Choose Fruit') {
+  const user = userEvent.setup({ delay: null });
+  await user.click(screen.getByRole('button', { name: 'Open menu' }));
+  await user.click(screen.getByText(triggerLabel));
+  return user;
+}
+
+function renderInMenu(ui: ReactNode) {
+  return render(
+    <DropdownMenuPrimitive.Root modal={false}>
+      <DropdownMenuPrimitive.Trigger asChild>
+        <button type='button'>Open menu</button>
+      </DropdownMenuPrimitive.Trigger>
+      <DropdownMenuPrimitive.Portal>
+        <DropdownMenuPrimitive.Content forceMount>
+          {ui}
+        </DropdownMenuPrimitive.Content>
+      </DropdownMenuPrimitive.Portal>
+    </DropdownMenuPrimitive.Root>
+  );
+}
+
+beforeEach(() => {
+  HTMLElement.prototype.scrollIntoView = vi.fn();
+});
 
 describe('SearchableList', () => {
   describe('Rendering', () => {
@@ -410,5 +451,167 @@ describe('SearchableList', () => {
       render(<SearchableList items={items} onSelect={vi.fn()} />);
       expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
     });
+  });
+});
+
+describe('SearchableSubmenu', () => {
+  it('opens the submenu, focuses search, and renders sections and footer', async () => {
+    renderInMenu(
+      <SearchableSubmenu
+        triggerLabel='Choose Fruit'
+        sections={sampleSections}
+        onSelect={vi.fn()}
+        footer={<div data-testid='submenu-footer'>Footer</div>}
+      />
+    );
+
+    await openSubmenu();
+
+    expect(screen.getByRole('combobox', { name: 'Search...' })).toHaveFocus();
+    expect(screen.getByText('Fruits')).toBeInTheDocument();
+    expect(screen.getByText('Dates')).toBeInTheDocument();
+    expect(screen.getByTestId('submenu-footer')).toBeInTheDocument();
+    expect(
+      screen.getByRole('listbox', { name: 'Choose Fruit results' })
+    ).toBeInTheDocument();
+  });
+
+  it('filters items, emits search changes, and clears the query', async () => {
+    const onSearchChange = vi.fn();
+    renderInMenu(
+      <SearchableSubmenu
+        triggerLabel='Choose Fruit'
+        sections={sampleSections}
+        onSelect={vi.fn()}
+        onSearchChange={onSearchChange}
+      />
+    );
+
+    await openSubmenu();
+    const search = screen.getByRole('combobox', { name: 'Search...' });
+    fireEvent.change(search, { target: { value: 'ban' } });
+
+    expect(onSearchChange).toHaveBeenCalledWith('ban');
+    expect(search).toHaveValue('ban');
+    expect(screen.getByText('Banana')).toBeInTheDocument();
+    expect(screen.queryByText('Apple')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear search' }));
+
+    expect(onSearchChange).toHaveBeenLastCalledWith('');
+    expect(search).toHaveValue('');
+    expect(search).toHaveFocus();
+  });
+
+  it('shows empty state when there are no sections', async () => {
+    renderInMenu(
+      <SearchableSubmenu
+        triggerLabel='Choose Fruit'
+        sections={[]}
+        onSelect={vi.fn()}
+        emptyMessage='Nothing here'
+      />
+    );
+
+    await openSubmenu();
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+
+  it('shows loading state', async () => {
+    renderInMenu(
+      <SearchableSubmenu
+        triggerLabel='Choose Fruit'
+        sections={sampleSections}
+        onSelect={vi.fn()}
+        isLoading
+      />
+    );
+
+    await openSubmenu();
+
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  it('supports keyboard navigation and selects the highlighted item on Enter', async () => {
+    const onSelect = vi.fn();
+    renderInMenu(
+      <SearchableSubmenu
+        triggerLabel='Choose Fruit'
+        sections={sampleSections}
+        onSelect={onSelect}
+      />
+    );
+
+    await openSubmenu();
+    const search = screen.getByRole('combobox', { name: 'Search...' });
+
+    fireEvent.keyDown(search, { key: 'ArrowDown' });
+    fireEvent.keyDown(search, { key: 'End' });
+    expect(search).toHaveAttribute('aria-activedescendant', 'item-item-5');
+
+    fireEvent.keyDown(search, { key: 'Home' });
+    expect(search).toHaveAttribute('aria-activedescendant', 'item-item-1');
+
+    fireEvent.keyDown(search, { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledWith(sampleItems[0]);
+  });
+
+  it('clears search on escape', async () => {
+    renderInMenu(
+      <SearchableSubmenu
+        triggerLabel='Choose Fruit'
+        sections={sampleSections}
+        onSelect={vi.fn()}
+      />
+    );
+
+    await openSubmenu();
+    const search = screen.getByRole('combobox', { name: 'Search...' });
+    fireEvent.change(search, { target: { value: 'dat' } });
+
+    fireEvent.keyDown(search, { key: 'Escape' });
+    expect(search).toHaveValue('');
+  });
+
+  it('does not select disabled items from the accessible listbox', async () => {
+    const onSelect = vi.fn();
+    renderInMenu(
+      <SearchableSubmenu
+        triggerLabel='Choose Fruit'
+        sections={sampleSections}
+        onSelect={onSelect}
+      />
+    );
+
+    await openSubmenu();
+    fireEvent.change(
+      screen.getByRole('listbox', { name: 'Choose Fruit results' }),
+      {
+        target: { value: 'item-4' },
+      }
+    );
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('supports selecting an item from the accessible listbox', async () => {
+    const onSelect = vi.fn();
+    renderInMenu(
+      <SearchableSubmenu
+        triggerLabel='Choose Fruit'
+        sections={sampleSections}
+        onSelect={onSelect}
+      />
+    );
+
+    await openSubmenu();
+    fireEvent.change(
+      screen.getByRole('listbox', { name: 'Choose Fruit results' }),
+      {
+        target: { value: 'item-2' },
+      }
+    );
+
+    expect(onSelect).toHaveBeenCalledWith(sampleItems[1]);
   });
 });


### PR DESCRIPTION
## Summary
- stop ignoring `packages/ui/**` in Codecov
- add a dedicated `ui` Codecov flag
- run `@jovie/ui` tests with coverage on `main` and on PRs that touch `packages/ui/**`, uploading coverage from a single unit-test shard
- add focused `SearchableSubmenu` tests so the package is already above the planned enforcement floor

## Dependency
- depends on the draft PR `test(submission-agent): cover provider utilities`
- stacked base branch: `itstimwhite/test-subm-agent`

## Notes
- local `@jovie/ui` coverage now reports `93.34%` statements and `94.28%` lines, so the planned `85%` enforcement target is no longer blocked by package coverage debt
- because this draft targets a non-`main` base branch, the normal `pull_request` CI workflow will not fully run until a later agent retargets/rebases it toward `main` during the merge queue walk