### PR TITLE
fix(ci): skip neon-dependent lighthouse jobs for dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -778,7 +778,7 @@ jobs:
     needs: [ci-build-public, ci-path-changes, neon-db]
     # Runs Lighthouse CI against the public-route build artifact on PRs.
     # Blocks PRs when triggered (path-gated to public-route changes).
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.ci-build-public.outputs.has_artifact == 'true' && needs.ci-path-changes.outputs.run_public_lighthouse == 'true' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' && needs.ci-build-public.outputs.has_artifact == 'true' && needs.ci-path-changes.outputs.run_public_lighthouse == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1031,7 +1031,7 @@ jobs:
   ci-lighthouse-onboarding-pr:
     name: Lighthouse (onboarding PR)
     needs: [ci-fast, ci-path-changes, neon-db]
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.ci-path-changes.outputs.run_onboarding_lighthouse == 'true' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' && needs.ci-path-changes.outputs.run_onboarding_lighthouse == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -1165,7 +1165,7 @@ jobs:
     # so dependent jobs would silently skip on admin-UI-only PRs. This job creates
     # its own ephemeral branch below and does not reuse the shared neon-db branch.
     needs: [ci-fast, ci-path-changes]
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.ci-path-changes.outputs.run_admin_lighthouse == 'true' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' && needs.ci-path-changes.outputs.run_admin_lighthouse == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary
- Adds `github.actor != 'dependabot[bot]'` guard to the three lighthouse jobs that create ephemeral Neon branches (public, onboarding, admin).
- Dependabot PRs run in a restricted secrets context; `NEON_API_KEY` is empty, so these jobs were failing with *Input required and not supplied: api_key* and blocking the required **PR Ready** merge gate on 10 open dependabot PRs.
- `ci-pr-ready` already treats `skipped` as passing for these path-gated jobs (see ci.yml:605-624), so skipping them for dependabot unblocks dep bumps without weakening the gate for real PRs.

## Context
Discovered during a PR drain pass. 10 of 23 open PRs were dependabot bumps blocked on `Lighthouse (admin PR)`. Unrelated to the `Preview Deploy (PR)` failures being noisy in the UI — those are not a required check and don't block merges.

## Test plan
- [ ] CI on this PR stays green (public lighthouse should skip since no app files change; others path-gated off)
- [ ] Once merged, dependabot PRs (#7443, #7442, #7441, etc.) re-run CI and PR Ready goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to optimize pipeline execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->