### PR TITLE
fix(a11y): darken light-mode text tokens for 4.5:1 contrast

### DIFF
--- a/apps/web/styles/linear-tokens.css
+++ b/apps/web/styles/linear-tokens.css
@@ -43,9 +43,9 @@
      TEXT COLORS — LIGHT MODE
      ============================================ */
   --linear-text-primary: oklch(12% 0.005 282);
-  --linear-text-secondary: oklch(45% 0.012 282);
-  --linear-text-tertiary: oklch(55% 0.01 282);
-  --linear-text-quaternary: oklch(70% 0.008 282);
+  --linear-text-secondary: oklch(42% 0.012 282);
+  --linear-text-tertiary: oklch(45% 0.01 282);
+  --linear-text-quaternary: oklch(55% 0.008 282);
   --linear-text-inverse: oklch(97% 0.005 282);
   /* ============================================
      BACKGROUNDS — LIGHT MODE


### PR DESCRIPTION
Fixes the systemic axe color-contrast failure hitting #7414 (and anywhere the public footer renders on light mode).

**Root cause:** `--linear-text-tertiary` was `oklch(55% 0.01 282)` on `--linear-bg-footer: oklch(98.5% 0.002 282)` → ~3.4:1, below WCAG AA 4.5:1.

**Fix:** light-mode text tokens shifted:
- secondary: 45% → 42%
- tertiary: 55% → 45% (~5:1, passes)
- quaternary: 70% → 55%

Dark-mode tokens are hex and already measure ≥ 4.5:1 against the dark footer bg. Not touched.

Unblocks A11y (axe) check on multiple open PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted light-mode text color tokens. Secondary and tertiary text colors have been darkened for enhanced visual contrast and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->