### PR TITLE
fix(profile): prevent user name write on missing profile

### DIFF
--- a/apps/web/app/api/dashboard/profile/lib/db-operations.ts
+++ b/apps/web/app/api/dashboard/profile/lib/db-operations.ts
@@ -69,18 +69,18 @@ export async function updateProfileRecords({
     .where(eq(creatorProfiles.userId, user.id))
     .returning();
 
-  if (displayNameForUserUpdate) {
-    await db
-      .update(users)
-      .set({ name: displayNameForUserUpdate, updatedAt: new Date() })
-      .where(eq(users.id, user.id));
-  }
-
   if (!updatedProfile) {
     return NextResponse.json(
       { error: 'Profile not found' },
       { status: 404, headers: NO_STORE_HEADERS }
     );
+  }
+
+  if (displayNameForUserUpdate) {
+    await db
+      .update(users)
+      .set({ name: displayNameForUserUpdate, updatedAt: new Date() })
+      .where(eq(users.id, user.id));
   }
 
   return {

--- a/apps/web/tests/unit/api/dashboard/profile/db-operations.test.ts
+++ b/apps/web/tests/unit/api/dashboard/profile/db-operations.test.ts
@@ -99,6 +99,26 @@ describe('updateProfileRecords', () => {
     );
   });
 
+  it('does not update user name when profile update returns no row', async () => {
+    mockGetUserByClerkId.mockResolvedValue({ id: 'user-1' });
+    createSelectChain([]);
+    createUpdateChain([]);
+
+    const { updateProfileRecords } = await import(
+      '@/app/api/dashboard/profile/lib/db-operations'
+    );
+
+    const result = await updateProfileRecords({
+      clerkUserId: 'clerk_123',
+      displayNameForUserUpdate: 'Updated Name',
+      dbProfileUpdates: { location: 'Austin, TX' },
+    });
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect(mockDbUpdate).toHaveBeenCalledTimes(1);
+    expect(mockDbUpdate).toHaveBeenCalledWith(creatorProfiles);
+  });
+
   it('loads the profile through the user lookup and creator_profiles relation', async () => {
     mockGetUserByClerkId.mockResolvedValue({ id: 'user-1' });
     createSelectChain([


### PR DESCRIPTION
## Summary
- Prevented a false-success side effect in dashboard profile updates by returning 404 before any users table write when creator_profiles update returns no row.
- Added unit coverage for the failure path to assert we do not update users.name when the profile row is missing.

## Test Coverage
- pnpm --filter web exec vitest run tests/unit/api/dashboard/profile/db-operations.test.ts (pass, 5 tests)
- pnpm --filter web exec tsc --noEmit (pass)
- Pre-push gate passed: iome check ., @jovie/web pre-push (
ext:proxy-guard, 	ailwind:check, 	ypecheck, lint).

## Pre-Landing Review
- No additional findings after fix. The only issue identified was fixed in this branch.

## Design Review
- No frontend files changed, design review skipped.

## Eval Results
- No prompt-related files changed, evals skipped.

## Scope Drift
- Scope Check: CLEAN.

## Plan Completion
- No plan file detected.

## Verification Results
- PASS.

## TODOS
- No TODO items completed in this PR.

## Test plan
- [x] Targeted unit test pass (db-operations.test.ts)
- [x] Typecheck pass (	sc --noEmit)

🤖 Generated with [Codex](https://openai.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency in profile update operations by ensuring proper error handling before updating related records.

* **Tests**
  * Added unit test coverage for profile update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->