### PR TITLE
fix(repo-health): harden static and billing checks

### DIFF
--- a/apps/web/app/(dynamic)/legal/layout.tsx
+++ b/apps/web/app/(dynamic)/legal/layout.tsx
@@ -1,8 +1,7 @@
 import { MarketingContainer } from '@/components/marketing';
 import { PublicPageShell } from '@/components/site/PublicPageShell';
 
-// Note: dynamic = 'force-dynamic' removed for cacheComponents compatibility
-// Legal pages will still be dynamic by default
+export const revalidate = false;
 
 export default function LegalLayout({
   children,

--- a/apps/web/app/(marketing)/blog/[slug]/opengraph-image.tsx
+++ b/apps/web/app/(marketing)/blog/[slug]/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { getBlogPost } from '@/lib/blog/getBlogPosts';
 import { loadSatoshiFont, OG_SIZE, THEME } from '@/lib/share/image-utils';
 
 export const runtime = 'nodejs';
-export const revalidate = 900;
+export const revalidate = false;
 
 export const alt = 'Jovie blog post';
 export const size = OG_SIZE;

--- a/apps/web/app/(marketing)/investors/layout.tsx
+++ b/apps/web/app/(marketing)/investors/layout.tsx
@@ -6,6 +6,8 @@
  * by rendering a separate header here, but that would require suppressing the
  * parent header which isn't currently supported without changes to the shared layout.
  */
+export const revalidate = false;
+
 export default function InvestorsLayout({
   children,
 }: {

--- a/apps/web/app/(marketing)/pricing/layout.tsx
+++ b/apps/web/app/(marketing)/pricing/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import { APP_NAME, BASE_URL } from '@/constants/app';
 
+export const revalidate = false;
+
 export const metadata: Metadata = {
   title: `${APP_NAME} Pricing`,
   description:

--- a/apps/web/app/(marketing)/renders/page.tsx
+++ b/apps/web/app/(marketing)/renders/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link';
 import { HOMEPAGE_PROFILE_SHOWCASE_STATES } from '@/features/home/homepage-profile-preview-fixture';
 import { MARKETING_RENDER_ROUTE_SURFACES } from '@/features/home/MarketingRenderSurface';
 
+export const revalidate = false;
+
 const states = Object.keys(HOMEPAGE_PROFILE_SHOWCASE_STATES);
 
 export default function RendersIndexPage() {

--- a/apps/web/app/(marketing)/renders/surfaces/[surface]/page.tsx
+++ b/apps/web/app/(marketing)/renders/surfaces/[surface]/page.tsx
@@ -4,6 +4,8 @@ import {
   MarketingRenderSurface,
 } from '@/features/home/MarketingRenderSurface';
 
+export const revalidate = false;
+
 function getSearchParam(
   value: string | string[] | undefined
 ): string | undefined {

--- a/apps/web/lib/stripe/webhooks/base-handler.ts
+++ b/apps/web/lib/stripe/webhooks/base-handler.ts
@@ -107,13 +107,14 @@ export abstract class BaseSubscriptionHandler implements WebhookHandler {
    *
    * Error Handling:
    * - Throws on unrecoverable errors (missing price ID)
-   * - Skips with a captured critical error on unknown plans so webhook delivery
-   *   can be acknowledged without retry storms when Stripe price config drifts
+   * - Skips unknown price IDs with a captured critical error containing the
+   *   customerId, priceId, subscriptionId, and userId so webhook delivery can
+   *   be acknowledged without retry storms when Stripe price config drifts
    * - Returns error result on billing update failures
    *
    * @param options - Processing options including subscription, user ID, and event metadata
    * @returns Promise resolving to the processing result
-   * @throws If price ID is missing or unknown (unrecoverable errors)
+   * @throws If price ID is missing
    */
   protected async processSubscription(
     options: ProcessSubscriptionOptions
@@ -209,7 +210,9 @@ export abstract class BaseSubscriptionHandler implements WebhookHandler {
    * Handle an active subscription by upgrading the user.
    *
    * @private
-   * @throws If price ID is missing or unknown
+   * @returns A skipped result with reason `unknown_price_id` when the price ID
+   * does not map to a known plan.
+   * @throws If price ID is missing
    */
   private async handleActiveSubscription(
     subscription: Stripe.Subscription,

--- a/apps/web/lib/stripe/webhooks/base-handler.ts
+++ b/apps/web/lib/stripe/webhooks/base-handler.ts
@@ -234,11 +234,14 @@ export abstract class BaseSubscriptionHandler implements WebhookHandler {
 
     const plan = getPlanFromPriceId(priceId);
     if (!plan) {
+      const customerId = getCustomerId(subscription.customer);
       await captureCriticalError(
         'Unknown price ID in subscription',
         new Error(`Unknown price ID: ${priceId}`),
         {
+          customerId,
           priceId,
+          subscriptionId: subscription.id,
           userId,
           route: '/api/stripe/webhooks',
         }

--- a/apps/web/tests/unit/lib/stripe/webhooks/handlers/subscription-handler.errors.test.ts
+++ b/apps/web/tests/unit/lib/stripe/webhooks/handlers/subscription-handler.errors.test.ts
@@ -162,7 +162,7 @@ describe('@critical SubscriptionHandler - Errors', () => {
   });
 
   describe('price validation errors', () => {
-    it('throws error when subscription price ID is unknown', async () => {
+    it('skips and captures a critical error when subscription price ID is unknown', async () => {
       mockGetPlanFromPriceId.mockReturnValue(null);
 
       const context: WebhookContext = {
@@ -194,8 +194,11 @@ describe('@critical SubscriptionHandler - Errors', () => {
         'Unknown price ID in subscription',
         expect.any(Error),
         expect.objectContaining({
-          route: '/api/stripe/webhooks',
+          customerId: 'cus_123',
           priceId: 'price_unknown',
+          route: '/api/stripe/webhooks',
+          subscriptionId: 'sub_unknown_price',
+          userId: 'user_test',
         })
       );
     });

--- a/apps/web/tests/unit/marketing/static-revalidate-policy.test.ts
+++ b/apps/web/tests/unit/marketing/static-revalidate-policy.test.ts
@@ -4,6 +4,25 @@ import { describe, expect, it } from 'vitest';
 
 const STATIC_ROUTE_ROOTS = ['app/(marketing)', 'app/(dynamic)/legal'];
 const ROUTE_FILE_EXTENSIONS = new Set(['.ts', '.tsx']);
+const STATIC_ENTRYPOINT_FILENAMES = new Set([
+  'layout.ts',
+  'layout.tsx',
+  'opengraph-image.ts',
+  'opengraph-image.tsx',
+  'page.ts',
+  'page.tsx',
+  'robots.ts',
+  'route.ts',
+  'route.tsx',
+  'sitemap.ts',
+  'twitter-image.ts',
+  'twitter-image.tsx',
+]);
+const FORBIDDEN_REQUEST_TIME_PATTERNS: readonly RegExp[] = [
+  /\bheaders\s*\(/,
+  /\bcookies\s*\(/,
+  /cache\s*:\s*['"]no-store['"]/,
+];
 
 function listRouteFiles(directory: string): string[] {
   return readdirSync(directory).flatMap(entry => {
@@ -25,23 +44,47 @@ function listRouteFiles(directory: string): string[] {
 }
 
 describe('static marketing route policy', () => {
-  it('does not allow non-static revalidate exports in marketing or legal routes', () => {
+  it('keeps marketing and legal route entrypoints fully static', () => {
     const repoRoot = process.cwd();
     const routeFiles = STATIC_ROUTE_ROOTS.flatMap(root =>
       listRouteFiles(join(repoRoot, root))
     );
-    const dynamicRevalidateExports = routeFiles
-      .map(path => ({
-        path,
-        source: readFileSync(path, 'utf8'),
-      }))
+    const routeSources = routeFiles.map(path => ({
+      path,
+      relativePath: relative(repoRoot, path),
+      source: readFileSync(path, 'utf8'),
+    }));
+    const staticEntrypointViolations = routeSources
+      .filter(
+        ({ path, source }) =>
+          STATIC_ENTRYPOINT_FILENAMES.has(path.split(/[\\/]/).at(-1) ?? '') &&
+          !/^\s*['"]use client['"];/m.test(source)
+      )
+      .filter(
+        ({ source }) =>
+          !/export\s+const\s+revalidate\s*=\s*false\b/.test(source)
+      )
+      .map(({ relativePath }) => `${relativePath}: missing revalidate=false`);
+    const requestTimeApiViolations = routeSources.flatMap(
+      ({ relativePath, source }) =>
+        FORBIDDEN_REQUEST_TIME_PATTERNS.filter(pattern =>
+          pattern.test(source)
+        ).map(pattern => `${relativePath}: forbidden ${pattern.source}`)
+    );
+    const dynamicRevalidateExports = routeSources
       .filter(({ source }) => /export\s+const\s+revalidate\s*=/.test(source))
       .filter(
         ({ source }) =>
-          !/export\s+const\s+revalidate\s*=\s*false\s*;/.test(source)
+          !/export\s+const\s+revalidate\s*=\s*false\b/.test(source)
       )
-      .map(({ path }) => relative(repoRoot, path));
+      .map(
+        ({ relativePath }) => `${relativePath}: non-static revalidate export`
+      );
 
-    expect(dynamicRevalidateExports).toEqual([]);
+    expect([
+      ...staticEntrypointViolations,
+      ...dynamicRevalidateExports,
+      ...requestTimeApiViolations,
+    ]).toEqual([]);
   });
 });

--- a/apps/web/tests/unit/marketing/static-revalidate-policy.test.ts
+++ b/apps/web/tests/unit/marketing/static-revalidate-policy.test.ts
@@ -1,0 +1,47 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const STATIC_ROUTE_ROOTS = ['app/(marketing)', 'app/(dynamic)/legal'];
+const ROUTE_FILE_EXTENSIONS = new Set(['.ts', '.tsx']);
+
+function listRouteFiles(directory: string): string[] {
+  return readdirSync(directory).flatMap(entry => {
+    const path = join(directory, entry);
+    const stats = statSync(path);
+
+    if (stats.isDirectory()) {
+      return listRouteFiles(path);
+    }
+
+    if (
+      ![...ROUTE_FILE_EXTENSIONS].some(extension => path.endsWith(extension))
+    ) {
+      return [];
+    }
+
+    return [path];
+  });
+}
+
+describe('static marketing route policy', () => {
+  it('does not allow non-static revalidate exports in marketing or legal routes', () => {
+    const repoRoot = process.cwd();
+    const routeFiles = STATIC_ROUTE_ROOTS.flatMap(root =>
+      listRouteFiles(join(repoRoot, root))
+    );
+    const dynamicRevalidateExports = routeFiles
+      .map(path => ({
+        path,
+        source: readFileSync(path, 'utf8'),
+      }))
+      .filter(({ source }) => /export\s+const\s+revalidate\s*=/.test(source))
+      .filter(
+        ({ source }) =>
+          !/export\s+const\s+revalidate\s*=\s*false\s*;/.test(source)
+      )
+      .map(({ path }) => relative(repoRoot, path));
+
+    expect(dynamicRevalidateExports).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Enforce the static marketing route policy by making the blog Open Graph image route use `revalidate = false`.
- Add a filesystem regression test that fails on non-static `revalidate` exports under marketing and legal routes.
- Make Stripe unknown-price webhook alerts include customer and subscription identifiers for reconciliation.
- Bump release metadata to `26.4.160`.

## Test Coverage

All new code paths have focused regression coverage.

## Pre-Landing Review

No code findings found in the local `/review` pass. Codex CLI adversarial review was unavailable because `codex.exe` returned Access denied in this Windows environment.

## Design Review

No user-facing UI changes.

## Eval Results

No prompt-related files changed, evals skipped.

## Plan Completion

No plan file completion checklist applied. This PR implements the repo health fix plan from the automation thread.

## Verification Results

- `pnpm install --frozen-lockfile`
- `pnpm biome check --write apps/web`
- `pnpm --filter @jovie/web exec vitest run tests/unit/marketing/static-revalidate-policy.test.ts tests/unit/lib/stripe/webhooks/handlers/subscription-handler.errors.test.ts tests/unit/lib/stripe/webhooks/handlers/checkout-handler.critical.test.ts` passed, 26 tests
- `pnpm --filter @jovie/web run typecheck` passed
- `pnpm --filter @jovie/web run lint` passed
- `pnpm --filter @jovie/web exec eslint --max-warnings=0 ...touched files...` passed
- `NEXT_IGNORE_TYPECHECK=1 next build --turbopack` equivalent passed in PowerShell with one existing `statsig-node` optional import warning
- `git diff --check` passed
- pre-push hook passed: `biome check .`, proxy guard, tailwind guard, typecheck, Biome lint

## TODOS

No TODO items completed in this PR.

## Test plan

- [x] Focused Vitest regression tests pass, 26 tests
- [x] Web typecheck passes
- [x] Web Biome lint passes
- [x] Next production build passes
- [x] Pre-push hook passes

Generated with [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enforcement testing for static caching policies across marketing and legal routes.

* **Bug Fixes**
  * Improved Stripe webhook handling to gracefully handle unknown subscription price IDs instead of throwing errors.

* **Chores**
  * Configured static caching for marketing pages (pricing, renders, investors) and legal routes for improved performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->