### PR TITLE
fix(setup): fall back to Doppler GitHub token

### DIFF
--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -13,7 +13,9 @@ if (-not (Test-Path -LiteralPath $SetupSh)) {
 $candidates = @()
 
 if ($env:GIT_BASH) {
-  $candidates += $env:GIT_BASH
+  if ($env:GIT_BASH -notlike "*\Windows\System32\bash.exe") {
+    $candidates += $env:GIT_BASH
+  }
 }
 
 $programFiles = [Environment]::GetFolderPath("ProgramFiles")

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -383,7 +383,9 @@ else
       if GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}" gh auth status -h github.com &>/dev/null 2>&1; then
         GH_AUTH_OK=true
       fi
-    elif command -v doppler &>/dev/null && "${DOPPLER_LOCAL_RUN[@]}" sh -c 'test -n "${GH_TOKEN:-${GITHUB_TOKEN:-}}"' &>/dev/null 2>&1; then
+    fi
+
+    if [[ "$GH_AUTH_OK" != "true" ]] && command -v doppler &>/dev/null && "${DOPPLER_LOCAL_RUN[@]}" sh -c 'test -n "${GH_TOKEN:-${GITHUB_TOKEN:-}}"' &>/dev/null 2>&1; then
       if "${DOPPLER_LOCAL_RUN[@]}" gh auth status -h github.com &>/dev/null 2>&1; then
         GH_AUTH_OK=true
       fi


### PR DESCRIPTION
## Summary

- Falls back to Doppler-provided `GH_TOKEN` / `GITHUB_TOKEN` if a local environment token exists but fails `gh auth status`.
- Ignores `GIT_BASH=C:\Windows\System32\bash.exe` so the PowerShell wrapper cannot be pointed back at the WSL launcher.

## Verification Results

- [x] `bash -n ./scripts/setup.sh`
- [x] `GH_TOKEN=bad-token-for-fallback-test .\scripts\setup.ps1` authenticated through Doppler fallback
- [x] `git diff --check HEAD~1..HEAD`
- [x] Pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

Generated with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved setup process to correctly identify Git Bash executable and avoid System32 conflicts.
  * Optimized GitHub authentication verification to prevent unnecessary re-checks after successful authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->