### PR TITLE
fix(investors): handle missing manifest without crashing portal

### DIFF
--- a/apps/web/lib/investors/__tests__/manifest.test.ts
+++ b/apps/web/lib/investors/__tests__/manifest.test.ts
@@ -99,7 +99,7 @@ describe('getInvestorManifest', () => {
     await getInvestorManifest();
 
     expect(mockReadFile).toHaveBeenCalledWith(
-      expect.stringContaining('content/investors/manifest.json'),
+      expect.stringMatching(/content[\\/]+investors[\\/]+manifest\.json$/),
       'utf-8'
     );
   });
@@ -122,5 +122,22 @@ describe('getInvestorManifest', () => {
     await getInvestorManifest();
 
     expect(mockReadFile).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns an empty manifest when manifest.json is missing', async () => {
+    mockReadFile.mockRejectedValueOnce(
+      Object.assign(new Error('Missing file'), { code: 'ENOENT' })
+    );
+
+    const { getInvestorManifest } = await import('../manifest');
+    const manifest = await getInvestorManifest();
+
+    expect(manifest).toEqual({
+      pages: [],
+      deck: {
+        slides: [],
+        downloadFilename: 'Jovie-Pitch-Deck.pdf',
+      },
+    });
   });
 });

--- a/apps/web/lib/investors/manifest.ts
+++ b/apps/web/lib/investors/manifest.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'node:fs';
+import { captureError } from '@/lib/error-tracking';
 import { resolveAppContentPath } from '@/lib/filesystem-paths';
 
 export interface InvestorPage {
@@ -19,6 +20,21 @@ export interface InvestorManifest {
 }
 
 let cachedManifest: InvestorManifest | null = null;
+const EMPTY_MANIFEST: InvestorManifest = {
+  pages: [],
+  deck: {
+    slides: [],
+    downloadFilename: 'Jovie-Pitch-Deck.pdf',
+  },
+};
+
+function isMissingFileError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
 
 /**
  * Load the investor content manifest.
@@ -30,7 +46,23 @@ export async function getInvestorManifest(): Promise<InvestorManifest> {
   }
 
   const manifestPath = resolveAppContentPath('investors/manifest.json');
-  const raw = await fs.readFile(manifestPath, 'utf-8');
-  cachedManifest = JSON.parse(raw) as InvestorManifest;
-  return cachedManifest;
+  try {
+    const raw = await fs.readFile(manifestPath, 'utf-8');
+    cachedManifest = JSON.parse(raw) as InvestorManifest;
+    return cachedManifest;
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error;
+    }
+
+    captureError(
+      'Investor manifest missing, falling back to empty manifest',
+      error,
+      {
+        manifestPath,
+      }
+    );
+    cachedManifest = EMPTY_MANIFEST;
+    return EMPTY_MANIFEST;
+  }
 }


### PR DESCRIPTION
## Summary
- Handle missing content/investors/manifest.json in getInvestorManifest() by falling back to an empty manifest instead of throwing ENOENT.
- Emit captureError telemetry when fallback is used so missing content remains visible.
- Add regression coverage for the ENOENT fallback and make the file-path assertion OS-safe.

## Test Coverage
- pnpm --filter web exec vitest run lib/investors/__tests__/manifest.test.ts
- pnpm --filter web exec tsc --noEmit
- pre-push gate passed: biome check, proxy guard, tailwind guard, typecheck, lint.

## Pre-Landing Review
- No blocking findings in this diff.

## Greptile Review
- No Greptile comments.

## Test plan
- [x] Unit tests pass for investor manifest loader
- [x] Typecheck and lint gates pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of missing manifest files—the app now gracefully falls back to default values instead of throwing an error.

* **Tests**
  * Enhanced test coverage for file path validation and missing manifest file scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->