### PR TITLE
feat(pitch): rename Playlist Pitches to Pitch Builder (JOV-1783)

### DIFF
--- a/apps/web/components/jovie/components/ChatPitchCard.tsx
+++ b/apps/web/components/jovie/components/ChatPitchCard.tsx
@@ -179,7 +179,7 @@ export function ChatPitchCard({
       <div className='mb-3 flex items-center gap-2'>
         <Sparkles className='h-4 w-4 text-accent-token' />
         <span className='text-[13px] font-medium text-secondary-token'>
-          Playlist Pitches{releaseTitle ? ` — ${releaseTitle}` : ''}
+          Pitch Builder{releaseTitle ? ` — ${releaseTitle}` : ''}
         </span>
       </div>
       <div className='space-y-2'>

--- a/apps/web/components/organisms/release-sidebar/ReleasePitchSection.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleasePitchSection.tsx
@@ -225,7 +225,7 @@ export function ReleasePitchSection({
             <Sparkles className='h-3.5 w-3.5 text-tertiary-token' />
           )}
           <span className='text-[11px] font-medium text-secondary-token'>
-            Playlist Pitches
+            Pitch Builder
           </span>
         </div>
         {pitches && activeText && !isTyping && (
@@ -270,8 +270,7 @@ export function ReleasePitchSection({
 
         {!isPending && !pitches && (
           <p className='py-2 text-center text-[11px] text-tertiary-token'>
-            Generate AI-powered playlist pitches formatted for each streaming
-            platform.
+            Generate AI-powered pitches formatted for each streaming platform.
           </p>
         )}
 

--- a/apps/web/tests/e2e/chat-pitch-generation.spec.ts
+++ b/apps/web/tests/e2e/chat-pitch-generation.spec.ts
@@ -113,9 +113,7 @@ test.describe
 
       // Wait for the actual pitch tool UI, not just "some assistant activity".
       // The tool can surface either the loading title or the completed card.
-      const pitchToolUi = page.getByText(
-        /Generating pitches|Playlist Pitches/i
-      );
+      const pitchToolUi = page.getByText(/Generating pitches|Pitch Builder/i);
       await expect(pitchToolUi.first()).toBeVisible({ timeout: 30_000 });
     });
 

--- a/apps/web/tests/unit/organisms/ReleasePitchSection.test.tsx
+++ b/apps/web/tests/unit/organisms/ReleasePitchSection.test.tsx
@@ -51,7 +51,7 @@ describe('ReleasePitchSection', () => {
 
     expect(
       screen.getByText(
-        'Generate AI-powered playlist pitches formatted for each streaming platform.'
+        'Generate AI-powered pitches formatted for each streaming platform.'
       )
     ).toBeInTheDocument();
     expect(screen.getByText('Generate Pitch')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Renames user-facing label "Playlist Pitches" to "Pitch Builder" in `ReleasePitchSection` (release sidebar) and `ChatPitchCard` (chat tool card).
- Updates empty-state copy and unit/e2e tests to match.
- All existing behavior preserved: Spotify/Apple/Amazon/Generic platform tabs, inline preview with typewriter, Copy, Regenerate, character counters. Module remains compact.

Closes JOV-1783

## Notes
- Acceptance criterion "Target playlist input remains available" was not implemented: no such input exists today, and the backend (`/api/dashboard/releases/[releaseId]/pitch`) does not accept a target playlist. Per project rules ("don't invent abstractions"; only include actions supported by backend), this was left out of scope. Happy to scope a follow-up if the intent was to add it.

## Test plan
- [x] Unit: `tests/unit/organisms/ReleasePitchSection.test.tsx` (9/9 pass)
- [x] Typecheck clean (`pnpm turbo typecheck --filter=@jovie/web`)
- [x] Lint clean via pre-commit hooks
- [ ] Manual: open a release drawer, confirm the header reads "Pitch Builder", tabs switch, Copy + Regenerate work
- [ ] Manual: in chat, trigger pitch tool and confirm card header reads "Pitch Builder — <Release>"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Renamed pitch generation feature from "Playlist Pitches" to "Pitch Builder" throughout the application for improved clarity and consistency
  * Refined empty-state messaging to better describe the feature's AI-powered pitch generation capabilities for streaming platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->