### PR TITLE
feat(releases): richer smart link analytics summary (JOV-1779)

### DIFF
--- a/apps/web/app/api/dashboard/releases/[releaseId]/analytics/route.ts
+++ b/apps/web/app/api/dashboard/releases/[releaseId]/analytics/route.ts
@@ -114,6 +114,7 @@ export async function GET(
       .execute<{
         total_clicks: AggregateValue;
         clicks_last_7: AggregateValue;
+        last_click_at: string | Date | null;
         provider_clicks: JsonArray<{
           provider: string | null;
           clicks: number;
@@ -144,16 +145,23 @@ export async function GET(
           select
             (select count(*) from release_clicks) as total_clicks,
             (select count(*) from recent_clicks) as clicks_last_7,
+            (select max(created_at) from release_clicks) as last_click_at,
             coalesce((select json_agg(row_to_json(p)) from provider_clicks p), '[]'::json) as provider_clicks
           ;
         `
       )
       .then(res => res.rows?.[0]);
 
+    const lastClickAtRaw = aggregates?.last_click_at ?? null;
+    const lastClickAt = lastClickAtRaw
+      ? new Date(lastClickAtRaw).toISOString()
+      : null;
+
     return NextResponse.json(
       {
         totalClicks: Number(aggregates?.total_clicks ?? 0),
         last7DaysClicks: Number(aggregates?.clicks_last_7 ?? 0),
+        lastClickAt,
         providerClicks: parseJsonArray<{
           provider: string | null;
           clicks: number;

--- a/apps/web/components/features/demo/mock-release-data.ts
+++ b/apps/web/components/features/demo/mock-release-data.ts
@@ -151,9 +151,15 @@ function makeDemoAnalytics(
     clicks: Math.max(24, Math.round(totalClicks / (i + 2.4))),
   }));
 
+  const lastClickHoursAgo = 2 + index * 3;
+  const lastClickAt = new Date(
+    Date.now() - lastClickHoursAgo * 60 * 60 * 1000
+  ).toISOString();
+
   return {
     totalClicks,
     last7DaysClicks: Math.max(32, Math.round(totalClicks * 0.18)),
+    lastClickAt,
     providerClicks,
   };
 }

--- a/apps/web/components/organisms/release-sidebar/ReleaseSmartLinkAnalytics.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSmartLinkAnalytics.tsx
@@ -16,8 +16,10 @@ import {
   TEST_USER_ID_COOKIE,
   TEST_USER_ID_HEADER,
 } from '@/lib/auth/test-mode-constants';
+import { PROVIDER_LABELS } from '@/lib/discography/provider-labels';
 import { env } from '@/lib/env-client';
 import { buildTrackedShareDropdownItems } from '@/lib/share/tracked-sources';
+import { formatTimeAgo } from '@/lib/utils/date-formatting';
 import { getBaseUrl } from '@/lib/utils/platform-detection';
 import { buildUTMContext } from '@/lib/utm';
 import type { Release, ReleaseSidebarAnalytics } from './types';
@@ -273,27 +275,38 @@ export function ReleaseSmartLinkAnalytics({
 
   const totalClicks = data?.totalClicks ?? 0;
   const last7DaysClicks = data?.last7DaysClicks ?? 0;
+  const lastClickAt = data?.lastClickAt ?? null;
+  const topProvider = data?.providerClicks?.[0] ?? null;
+  const topProviderLabel = topProvider
+    ? (PROVIDER_LABELS[topProvider.provider] ?? topProvider.provider)
+    : null;
 
   const state = getReleaseAnalyticsState({ isLoading, hasError, data });
+  const hasClicks = totalClicks > 0;
 
-  return (
-    <DrawerAnalyticsSummaryCard
-      metrics={[
+  const metrics = hasClicks
+    ? [
         {
           id: 'total-clicks',
           label: 'Total clicks',
           value: numberFormatter.format(totalClicks),
-          hint: 'All time',
+          hint: topProviderLabel ? `Top: ${topProviderLabel}` : 'All time',
         },
         {
-          id: 'last-7-days-clicks',
-          label: 'Last 7 days',
-          value: numberFormatter.format(last7DaysClicks),
-          hint: 'Recent',
+          id: 'last-click',
+          label: 'Last click',
+          value: lastClickAt ? formatTimeAgo(lastClickAt) : '—',
+          hint: `${numberFormatter.format(last7DaysClicks)} in last 7 days`,
         },
-      ]}
+      ]
+    : [];
+
+  return (
+    <DrawerAnalyticsSummaryCard
+      metrics={metrics}
       state={state}
       dimmed={isSwitching}
+      emptyMessage='No clicks yet. Share your smart link to start tracking where fans listen.'
       errorMessage='Analytics unavailable'
       testId='release-smart-link-analytics'
       variant={variant}

--- a/apps/web/components/organisms/release-sidebar/types.ts
+++ b/apps/web/components/organisms/release-sidebar/types.ts
@@ -38,6 +38,7 @@ export type ReleaseSidebarTrack = Pick<
 export interface ReleaseSidebarAnalytics {
   totalClicks: number;
   last7DaysClicks: number;
+  lastClickAt: string | null;
   providerClicks: Array<{ provider: string; clicks: number }>;
 }
 


### PR DESCRIPTION
## Summary

Improves the release detail panel analytics so zero-click releases have a real empty state, and releases with clicks surface more useful signal than two bare numbers — while staying compact.

**Empty state**
- Replaces the old "0 / 0" tiles with: _"No clicks yet. Share your smart link to start tracking where fans listen."_

**With-clicks state**
- Tile 1 — Total clicks, hint shows the top DSP when available (e.g. _"Top: Spotify"_)
- Tile 2 — Last click as a relative timestamp (e.g. _"2h ago"_), hint shows _"N in last 7 days"_

**Backend**
- `/api/dashboard/releases/[releaseId]/analytics` already returned `providerClicks`; this PR adds `lastClickAt` via a `max(created_at)` in the existing CTE. No new queries, tables, or indexes.

Linear: https://linear.app/jovie/issue/JOV-1779

## Test plan
- [ ] Release with zero clicks shows the new empty-state copy
- [ ] Release with clicks shows Total clicks + top DSP hint
- [ ] Last click tile shows a sensible relative timestamp and the last-7-days hint
- [ ] Demo route (`/demo`) still renders analytics (mock includes `lastClickAt`)
- [ ] `pnpm --filter web typecheck` and `pnpm --filter web lint` pass
- [ ] `DrawerAnalyticsSummaryCard` tests pass

Generated with Claude Code