### PR TITLE
feat(releases): clarify new release creation with labeled dropdown

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/NewReleaseHeaderAction.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/NewReleaseHeaderAction.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@jovie/ui';
+import { ChevronDown } from 'lucide-react';
+import { Icon } from '@/components/atoms/Icon';
+import {
+  DASHBOARD_HEADER_ACTION_TEXT_BUTTON_CLASS,
+  DashboardHeaderActionButton,
+} from '@/features/dashboard/atoms/DashboardHeaderActionButton';
+import { cn } from '@/lib/utils';
+
+export interface NewReleaseHeaderActionProps {
+  /** Whether manual creation is permitted for this profile (plan-gated). */
+  readonly canCreateManualReleases: boolean;
+  /** Whether the Spotify sync is currently running. */
+  readonly isSyncing?: boolean;
+  /** Triggered when the user chooses "Sync from Spotify". */
+  readonly onSyncSpotify: () => void;
+  /** Triggered when the user chooses "Add manually". */
+  readonly onCreateManual: () => void;
+}
+
+/**
+ * Header affordance for creating a new release.
+ *
+ * - When only one creation path exists (Spotify sync), renders a single
+ *   labeled button instead of a dropdown.
+ * - When multiple paths exist, renders a labeled "New release" button with a
+ *   chevron that opens a dropdown listing every wired-up creation path.
+ *
+ * Only wires up creation paths that already exist in the codebase.
+ */
+export function NewReleaseHeaderAction({
+  canCreateManualReleases,
+  isSyncing = false,
+  onSyncSpotify,
+  onCreateManual,
+}: NewReleaseHeaderActionProps) {
+  // Single path: render a plain labeled button (no dropdown).
+  if (!canCreateManualReleases) {
+    return (
+      <DashboardHeaderActionButton
+        ariaLabel='Sync releases from Spotify'
+        onClick={onSyncSpotify}
+        disabled={isSyncing}
+        icon={
+          <Icon
+            name={isSyncing ? 'Loader2' : 'RefreshCw'}
+            className={cn(
+              'h-3.5 w-3.5',
+              isSyncing && 'animate-spin motion-reduce:animate-none'
+            )}
+            strokeWidth={2}
+          />
+        }
+        label={isSyncing ? 'Syncing...' : 'Sync from Spotify'}
+        hideLabelOnMobile
+        tooltipLabel='Sync from Spotify'
+      />
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type='button'
+          variant='ghost'
+          size='sm'
+          aria-label='Create a new release'
+          className={cn(DASHBOARD_HEADER_ACTION_TEXT_BUTTON_CLASS, 'pr-1.5')}
+          data-testid='new-release-header-trigger'
+        >
+          <Icon name='Plus' className='h-3.5 w-3.5' strokeWidth={2} />
+          <span className='max-sm:hidden sm:inline'>New release</span>
+          <ChevronDown
+            className='h-3 w-3 text-tertiary-token'
+            strokeWidth={2}
+            aria-hidden='true'
+          />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align='end' sideOffset={6} className='w-56'>
+        <DropdownMenuItem
+          onSelect={event => {
+            event.preventDefault();
+            onSyncSpotify();
+          }}
+          disabled={isSyncing}
+          data-testid='new-release-sync-spotify'
+        >
+          <Icon
+            name={isSyncing ? 'Loader2' : 'RefreshCw'}
+            className={cn(
+              'h-4 w-4',
+              isSyncing && 'animate-spin motion-reduce:animate-none'
+            )}
+            aria-hidden='true'
+          />
+          <span>{isSyncing ? 'Syncing...' : 'Sync from Spotify'}</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onSelect={event => {
+            event.preventDefault();
+            onCreateManual();
+          }}
+          data-testid='new-release-add-manually'
+        >
+          <Icon name='Plus' className='h-4 w-4' aria-hidden='true' />
+          <span>Add manually</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
@@ -32,7 +32,6 @@ import { PageShell } from '@/components/organisms/PageShell';
 import type { TrackSidebarData } from '@/components/organisms/release-sidebar';
 import { APP_ROUTES } from '@/constants/routes';
 import { useSetHeaderActions } from '@/contexts/HeaderActionsContext';
-import { DashboardHeaderActionButton } from '@/features/dashboard/atoms/DashboardHeaderActionButton';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import { openChatWithPrompt } from '@/lib/chat/open-chat-with-prompt';
 import type { ReleaseViewModel } from '@/lib/discography/types';
@@ -42,6 +41,7 @@ import { QueryErrorBoundary, usePlanGate } from '@/lib/queries';
 import { cn } from '@/lib/utils';
 import { useImportPolling } from './hooks/useImportPolling';
 import { useReleaseTablePreferences } from './hooks/useReleaseTablePreferences';
+import { NewReleaseHeaderAction } from './NewReleaseHeaderAction';
 import { ReleaseTable } from './ReleaseTable';
 import {
   DEFAULT_RELEASE_FILTERS,
@@ -654,18 +654,18 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
 
   const { setHeaderActions } = useSetHeaderActions();
 
+  const syncAction = experienceAdapter?.onSync ?? handleSync;
+
   const headerActions = useMemo(
-    () =>
-      canCreateManualReleases ? (
-        <DashboardHeaderActionButton
-          ariaLabel='Create a new release'
-          onClick={handleNewRelease}
-          icon={<Icon name='Plus' className='h-3.5 w-3.5' strokeWidth={2} />}
-          iconOnly
-          tooltipLabel='New Release'
-        />
-      ) : null,
-    [canCreateManualReleases, handleNewRelease]
+    () => (
+      <NewReleaseHeaderAction
+        canCreateManualReleases={canCreateManualReleases}
+        isSyncing={isSyncing}
+        onSyncSpotify={syncAction}
+        onCreateManual={handleNewRelease}
+      />
+    ),
+    [canCreateManualReleases, handleNewRelease, isSyncing, syncAction]
   );
 
   useEffect(() => {

--- a/apps/web/tests/unit/dashboard/NewReleaseHeaderAction.test.tsx
+++ b/apps/web/tests/unit/dashboard/NewReleaseHeaderAction.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { NewReleaseHeaderAction } from '@/features/dashboard/organisms/release-provider-matrix/NewReleaseHeaderAction';
+
+// Radix portals its content by default; flatten the primitives for testing.
+vi.mock('@jovie/ui', async importOriginal => {
+  const actual = await importOriginal<typeof import('@jovie/ui')>();
+  return {
+    ...actual,
+    DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+      <>{children}</>
+    ),
+    DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+      <div role='menu'>{children}</div>
+    ),
+    DropdownMenuItem: ({
+      children,
+      onSelect,
+      disabled,
+      'data-testid': testId,
+    }: {
+      children: ReactNode;
+      onSelect?: (event: Event) => void;
+      disabled?: boolean;
+      'data-testid'?: string;
+    }) => (
+      <button
+        type='button'
+        data-testid={testId}
+        disabled={disabled}
+        data-disabled={disabled ? '' : undefined}
+        onClick={() => onSelect?.(new Event('select'))}
+      >
+        {children}
+      </button>
+    ),
+  };
+});
+
+describe('NewReleaseHeaderAction', () => {
+  it('renders a single Spotify sync button when manual creation is not allowed', () => {
+    const onSyncSpotify = vi.fn();
+    const onCreateManual = vi.fn();
+
+    render(
+      <NewReleaseHeaderAction
+        canCreateManualReleases={false}
+        onSyncSpotify={onSyncSpotify}
+        onCreateManual={onCreateManual}
+      />
+    );
+
+    const button = screen.getByRole('button', {
+      name: 'Sync releases from Spotify',
+    });
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(onSyncSpotify).toHaveBeenCalledTimes(1);
+    expect(onCreateManual).not.toHaveBeenCalled();
+  });
+
+  it('renders a "New release" dropdown trigger when manual creation is allowed', () => {
+    render(
+      <NewReleaseHeaderAction
+        canCreateManualReleases
+        onSyncSpotify={vi.fn()}
+        onCreateManual={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Create a new release' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('New release')).toBeInTheDocument();
+  });
+
+  it('fires onSyncSpotify when "Sync from Spotify" is chosen', () => {
+    const onSyncSpotify = vi.fn();
+    const onCreateManual = vi.fn();
+
+    render(
+      <NewReleaseHeaderAction
+        canCreateManualReleases
+        onSyncSpotify={onSyncSpotify}
+        onCreateManual={onCreateManual}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('new-release-sync-spotify'));
+    expect(onSyncSpotify).toHaveBeenCalledTimes(1);
+    expect(onCreateManual).not.toHaveBeenCalled();
+  });
+
+  it('fires onCreateManual when "Add manually" is chosen', () => {
+    const onSyncSpotify = vi.fn();
+    const onCreateManual = vi.fn();
+
+    render(
+      <NewReleaseHeaderAction
+        canCreateManualReleases
+        onSyncSpotify={onSyncSpotify}
+        onCreateManual={onCreateManual}
+      />
+    );
+
+    fireEvent.click(screen.getByTestId('new-release-add-manually'));
+    expect(onCreateManual).toHaveBeenCalledTimes(1);
+    expect(onSyncSpotify).not.toHaveBeenCalled();
+  });
+
+  it('disables the sync item while isSyncing is true', () => {
+    render(
+      <NewReleaseHeaderAction
+        canCreateManualReleases
+        isSyncing
+        onSyncSpotify={vi.fn()}
+        onCreateManual={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('new-release-sync-spotify')).toBeDisabled();
+  });
+});

--- a/apps/web/tests/unit/dashboard/ReleaseProviderMatrix.test.tsx
+++ b/apps/web/tests/unit/dashboard/ReleaseProviderMatrix.test.tsx
@@ -161,7 +161,45 @@ vi.mock('@/features/dashboard/atoms/DashboardHeaderActionButton', () => ({
       {label}
     </button>
   ),
+  DASHBOARD_HEADER_ACTION_TEXT_BUTTON_CLASS: '',
+  DASHBOARD_HEADER_ACTION_TEXT_BUTTON_ACTIVE_CLASS: '',
+  DASHBOARD_HEADER_ACTION_ICON_BUTTON_CLASS: '',
+  DASHBOARD_HEADER_ACTION_ICON_BUTTON_ACTIVE_CLASS: '',
 }));
+
+vi.mock(
+  '@/features/dashboard/organisms/release-provider-matrix/NewReleaseHeaderAction',
+  () => ({
+    NewReleaseHeaderAction: ({
+      canCreateManualReleases,
+      onCreateManual,
+      onSyncSpotify,
+    }: {
+      canCreateManualReleases: boolean;
+      onCreateManual: () => void;
+      onSyncSpotify: () => void;
+    }) => (
+      <div>
+        {canCreateManualReleases ? (
+          <button
+            type='button'
+            aria-label='Create a new release'
+            onClick={onCreateManual}
+          >
+            Create a new release
+          </button>
+        ) : null}
+        <button
+          type='button'
+          aria-label='Sync releases from Spotify'
+          onClick={onSyncSpotify}
+        >
+          Sync from Spotify
+        </button>
+      </div>
+    ),
+  })
+);
 
 vi.mock('@/features/dashboard/atoms/DashboardHeaderActionGroup', () => ({
   DashboardHeaderActionGroup: ({ children }: { children: React.ReactNode }) => (


### PR DESCRIPTION
## Summary

- Replace the bare plus icon in the releases dashboard header with a labeled "New release" affordance that opens a dropdown listing every wired-up creation path.
- When only Spotify sync is available for the profile (no manual creation entitlement), render a single "Sync from Spotify" labeled button instead of an empty dropdown.
- No backend changes — only surfaces creation paths that already exist: Spotify sync (`handleSync`) and manual create (`handleNewRelease` → `AddReleaseSidebar`). Apple Music remains a match-confirmation banner, not an add-release action, and CSV / distributor imports are not yet implemented.

Closes JOV-1784.

## Test plan

- [ ] Unit tests pass: `pnpm --filter web exec vitest run tests/unit/dashboard/NewReleaseHeaderAction.test.tsx tests/unit/dashboard/ReleaseProviderMatrix.test.tsx`
- [ ] Typecheck + lint clean: `pnpm --filter web typecheck && pnpm --filter web lint`
- [ ] Manually verify in dashboard:
  - [ ] Header shows "New release ⌄" button on accounts with manual-create entitlement; dropdown offers "Sync from Spotify" and "Add manually"
  - [ ] Header shows "Sync from Spotify" labeled button on accounts without manual-create entitlement
  - [ ] Sync item is disabled + shows spinner while syncing
  - [ ] Empty-state CTAs still work (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dropdown menu for release creation with "Sync from Spotify" and "Add manually" options
  * Implemented permission-based UI that displays different controls based on user access level
  * Added visual loading indicator during Spotify sync operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->