### PR TITLE
feat(releases): simplify release row context menu (JOV-1777)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/releases/release-actions.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/release-actions.tsx
@@ -49,13 +49,47 @@ export interface BuildReleaseActionsOptions {
   readonly onGenerateAlbumArt?: (release: ReleaseViewModel) => void;
 }
 
+function buildPrimaryCopySmartLinkItem(
+  opts: Pick<BuildReleaseActionsOptions, 'release' | 'onCopy'> & {
+    locked: boolean;
+    lockReason: 'scheduled' | 'cap' | null;
+  }
+): ContextMenuItemType {
+  const { release, onCopy, locked, lockReason } = opts;
+
+  if (locked) {
+    return {
+      id: 'copy-smart-link',
+      label:
+        lockReason === 'scheduled'
+          ? 'Scheduled smart link (Pro)'
+          : 'Smart link (Pro)',
+      icon: menuIcon(lockReason === 'scheduled' ? 'Clock' : 'Lock'),
+      disabled: true,
+      onClick: () => {},
+    };
+  }
+
+  return {
+    id: 'copy-smart-link',
+    label: 'Copy smart link',
+    icon: menuIcon('Copy'),
+    onClick: () => {
+      void onCopy(
+        release.smartLinkPath,
+        `${release.title} smart link`,
+        `smart-link-copy-${release.id}`
+      );
+    },
+  };
+}
+
 function buildShareItems(
   opts: Pick<
     BuildReleaseActionsOptions,
     'release' | 'onCopy' | 'artistName' | 'onCopyQrCode' | 'qrCodeIcon'
   > & {
     locked: boolean;
-    lockReason: 'scheduled' | 'cap' | null;
     smartLinkUrl: string;
   }
 ): ContextMenuItemType[] {
@@ -66,39 +100,14 @@ function buildShareItems(
     onCopyQrCode,
     qrCodeIcon,
     locked,
-    lockReason,
     smartLinkUrl,
   } = opts;
 
   if (locked) {
-    return [
-      {
-        id: 'copy-smart-link',
-        label:
-          lockReason === 'scheduled'
-            ? 'Scheduled smart link (Pro)'
-            : 'Smart link (Pro)',
-        icon: menuIcon(lockReason === 'scheduled' ? 'Clock' : 'Lock'),
-        disabled: true,
-        onClick: () => {},
-      },
-    ];
+    return [];
   }
 
-  const items: ContextMenuItemType[] = [
-    {
-      id: 'copy-smart-link',
-      label: 'Copy smart link',
-      icon: menuIcon('Copy'),
-      onClick: () => {
-        void onCopy(
-          release.smartLinkPath,
-          `${release.title} smart link`,
-          `smart-link-copy-${release.id}`
-        );
-      },
-    },
-  ];
+  const items: ContextMenuItemType[] = [];
 
   const trackedContext = buildUTMContext({
     smartLinkUrl,
@@ -219,6 +228,12 @@ export function buildReleaseActions({
   const locked = isSmartLinkLocked?.(release.id) ?? false;
   const lockReason = getSmartLinkLockReason?.(release.id) ?? null;
   const smartLinkUrl = `${getBaseUrl()}${release.smartLinkPath}`;
+  const copySmartLinkItem = buildPrimaryCopySmartLinkItem({
+    release,
+    onCopy,
+    locked,
+    lockReason,
+  });
   const shareItems = buildShareItems({
     release,
     onCopy,
@@ -226,7 +241,6 @@ export function buildReleaseActions({
     onCopyQrCode,
     qrCodeIcon,
     locked,
-    lockReason,
     smartLinkUrl,
   });
 
@@ -241,6 +255,7 @@ export function buildReleaseActions({
       : null,
   ]);
 
+  // ── Group 1: Primary edit/create actions ──
   const items: ContextMenuItemType[] = [
     {
       id: 'edit',
@@ -258,22 +273,28 @@ export function buildReleaseActions({
           } satisfies ContextMenuItemType,
         ]
       : []),
-    {
-      type: 'separator',
-    },
-    {
+    { type: 'separator' },
+    // ── Group 2: Share / copy / open ──
+    copySmartLinkItem,
+  ];
+
+  // Share submenu only when there are additional share options
+  // (tracked links, Use Sound, QR code) beyond the primary copy.
+  if (shareItems.length > 0) {
+    items.push({
       id: 'share-link',
       label: 'Share link',
       icon: menuIcon('Link2'),
       items: shareItems,
-    },
-    {
-      id: 'copy-metadata',
-      label: 'Copy metadata',
-      icon: menuIcon('Hash'),
-      items: metadataItems,
-    },
-  ];
+    });
+  }
+
+  items.push({
+    id: 'copy-metadata',
+    label: 'Copy metadata',
+    icon: menuIcon('Hash'),
+    items: metadataItems,
+  });
 
   // ── External provider links ──
   const supportedProviders = new Set<ProviderKey>([
@@ -293,7 +314,18 @@ export function buildReleaseActions({
     p => supportedProviders.has(p.key) && p.url
   );
 
-  if (externalProviders.length > 0) {
+  if (externalProviders.length === 1) {
+    // Flatten a single-provider "Open in" submenu to a top-level action
+    const provider = externalProviders[0];
+    items.push({
+      id: 'open-release',
+      label: `Open in ${providerLabels[provider.key] || provider.key}`,
+      icon: menuIcon('ExternalLink'),
+      onClick: () => {
+        globalThis.open(provider.url, '_blank', 'noopener,noreferrer');
+      },
+    });
+  } else if (externalProviders.length > 1) {
     items.push({
       id: 'open-release',
       label: 'Open in',
@@ -309,7 +341,7 @@ export function buildReleaseActions({
     });
   }
 
-  // ── Destructive group ──
+  // ── Group 3: Destructive ──
   if (onDelete) {
     items.push(
       { type: 'separator' },

--- a/apps/web/tests/components/releases/release-actions.test.tsx
+++ b/apps/web/tests/components/releases/release-actions.test.tsx
@@ -68,7 +68,7 @@ function everyNestedItemHasIcon(items: readonly unknown[]): boolean {
 }
 
 describe('buildReleaseActions', () => {
-  it('keeps edit separate from copy/share actions without extra separators', () => {
+  it('promotes copy smart link to top level with grouping separator before it', () => {
     const items = buildReleaseActions({
       release: createRelease(),
       onEdit: vi.fn(),
@@ -86,21 +86,16 @@ describe('buildReleaseActions', () => {
     expect(items[1]).toEqual({ type: 'separator' });
     expect(separators).toHaveLength(1);
     expect(items[2]).toMatchObject({
+      id: 'copy-smart-link',
+      label: 'Copy smart link',
+    });
+    const shareMenu = items.find(
+      item => 'id' in item && item.id === 'share-link'
+    );
+    expect(shareMenu).toMatchObject({
       id: 'share-link',
       label: 'Share link',
     });
-    if (!('items' in items[2])) {
-      throw new Error('Expected share submenu');
-    }
-    expect(items[2].items).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          id: 'copy-smart-link',
-          label: 'Copy smart link',
-          icon: expect.anything(),
-        }),
-      ])
-    );
     const metadataItem = items.find(
       item => 'id' in item && item.id === 'copy-metadata'
     );
@@ -111,7 +106,7 @@ describe('buildReleaseActions', () => {
     });
   });
 
-  it('shows a disabled scheduled smart-link label when locked by schedule', () => {
+  it('shows a disabled scheduled smart-link label at top level when locked by schedule', () => {
     const items = buildReleaseActions({
       release: createRelease(),
       onEdit: vi.fn(),
@@ -121,20 +116,18 @@ describe('buildReleaseActions', () => {
     });
 
     expect(items[2]).toMatchObject({
-      id: 'share-link',
-      label: 'Share link',
-    });
-    if (!('items' in items[2])) {
-      throw new Error('Expected share submenu');
-    }
-    expect(items[2].items[0]).toMatchObject({
       id: 'copy-smart-link',
       label: 'Scheduled smart link (Pro)',
       disabled: true,
     });
+    // Share submenu should be omitted entirely when locked (nothing to share)
+    const shareMenu = items.find(
+      item => 'id' in item && item.id === 'share-link'
+    );
+    expect(shareMenu).toBeUndefined();
   });
 
-  it('includes external provider actions when provider urls are present', () => {
+  it('flattens single-provider open action to a top-level item', () => {
     const items = buildReleaseActions({
       release: createRelease({
         providers: [
@@ -153,6 +146,49 @@ describe('buildReleaseActions', () => {
       onCopy: vi.fn(),
     });
 
+    const openItem = items.find(
+      item => 'id' in item && item.id === 'open-release'
+    );
+
+    expect(openItem).toMatchObject({
+      id: 'open-release',
+      label: 'Open in Spotify',
+    });
+
+    // Flattened: should NOT be a submenu
+    if (openItem && 'items' in openItem) {
+      throw new Error('Expected flattened action, not submenu');
+    }
+  });
+
+  it('keeps Open in as a submenu when multiple providers are present', () => {
+    const items = buildReleaseActions({
+      release: createRelease({
+        providers: [
+          {
+            key: 'spotify',
+            label: 'Spotify',
+            url: 'https://open.spotify.com/album/123',
+            path: '/spotify',
+            source: 'ingested',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            isPrimary: true,
+          },
+          {
+            key: 'apple_music',
+            label: 'Apple Music',
+            url: 'https://music.apple.com/album/123',
+            path: '/apple',
+            source: 'ingested',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            isPrimary: false,
+          },
+        ],
+      }),
+      onEdit: vi.fn(),
+      onCopy: vi.fn(),
+    });
+
     const openMenu = items.find(
       item => 'id' in item && item.id === 'open-release'
     );
@@ -161,17 +197,18 @@ describe('buildReleaseActions', () => {
       id: 'open-release',
       label: 'Open in',
     });
-
     if (!openMenu || !('items' in openMenu)) {
       throw new Error('Expected open submenu');
     }
-
     expect(openMenu.items).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           id: 'open-spotify',
           label: 'Open in Spotify',
-          icon: expect.anything(),
+        }),
+        expect.objectContaining({
+          id: 'open-apple_music',
+          label: 'Open in Apple Music',
         }),
       ])
     );


### PR DESCRIPTION
## Summary

Simplifies the release row context menu per JOV-1777. Promotes the most-used action (Copy smart link) to the top level so it is no longer buried inside a submenu, flattens the single-provider Open in submenu, and keeps the destructive Delete action clearly separated.

Resolves [JOV-1777](https://linear.app/jovie/issue/JOV-1777).

## What changed

**New menu structure (from top to bottom):**

1. Group 1 — edit/create
   - Edit release links
   - Generate Album Art (when available)
2. `---` separator
3. Group 2 — share / copy / open
   - Copy smart link (was nested under Share link → now top-level, one click)
   - Share link (submenu: Tracked Links, Copy Use Sound link, Copy QR code)
   - Copy metadata (submenu: Release ID / UPC / ISRC / Lyrics)
   - Open in Spotify / Apple Music / etc. — flattened to a direct action when there is a single provider, kept as a submenu when 2+ providers exist
4. `---` separator (before destructive)
5. Group 3 — destructive
   - Delete release (destructive styling, own group)

**Reduced nesting:**
- Copy smart link went from `Share link → Copy smart link` (2 levels) to top-level
- Open in (single provider) went from `Open in → Open in Spotify` (2 levels) to top-level
- Share submenu is now omitted entirely when the smart link is locked (scheduled / Pro cap) because the lock state is already shown at top level on the Copy smart link action

**Preserved:** every existing action (edit, generate album art, copy smart link, tracked links, sounds link, QR code, metadata copies, open-in providers, delete) and every existing behavior (Pro lock states, scheduled messaging).

## Files

- \`apps/web/components/features/dashboard/organisms/releases/release-actions.tsx\` — menu builder
- \`apps/web/tests/components/releases/release-actions.test.tsx\` — updated structural assertions + new test for multi-provider submenu behavior

## Test plan

- [x] \`pnpm --filter web test tests/components/releases/release-actions.test.tsx\` — 5/5 pass
- [x] \`pnpm --filter web typecheck\` — clean
- [x] \`pnpm --filter web lint\` — clean
- [ ] Manual QA: right-click a release row on the dashboard; confirm Copy smart link is top-level, Share link still offers tracked links / sounds / QR, Open in shows the provider directly when one provider exists, Delete is separated and destructive
- [ ] Manual QA: verify locked smart link (scheduled / Pro cap) shows the disabled lock label at top level and the Share link submenu is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)