### PR TITLE
feat(releases): clarify provider status dots with tooltip + docs (JOV-1781)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/releases/components/ProviderStatusDot.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/components/ProviderStatusDot.tsx
@@ -1,14 +1,55 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from '@jovie/ui';
 import { Check, Dot, TriangleAlert } from 'lucide-react';
 import { memo, type ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
+/**
+ * ProviderStatusDot
+ *
+ * Small badge shown next to a release's provider link (Spotify, Apple Music,
+ * etc.) in the dashboard Releases table. It communicates how the link was
+ * obtained so an artist can tell at a glance whether a row was auto-synced or
+ * needs their attention.
+ *
+ * Status -> meaning -> presentation matrix:
+ *
+ *   available  Auto-synced provider link (pulled from the provider API).
+ *              Accent-colored ring + Check icon. The accent is the provider's
+ *              brand color (e.g. Spotify green) so the dot reads as "on-brand,
+ *              connected".
+ *
+ *   manual     Manually added provider link (artist pasted a URL).
+ *              Warning color + TriangleAlert icon. Signals "this exists but
+ *              wasn't verified against the provider".
+ *
+ *   missing    No provider link on file.
+ *              Neutral surface color + Dot icon. Signals "nothing here yet".
+ *
+ * Color is never the only signal:
+ *  - each state uses a distinct icon (Check / TriangleAlert / Dot)
+ *  - each state exposes an aria-label + visually-hidden text for SR users
+ *  - each state is wrapped in a Tooltip so sighted users can read the label
+ *  - `data-provider-status` is emitted for tests and styling hooks
+ *
+ * Colors resolve via design tokens (`--color-warning`, `--linear-*`) and the
+ * provider accent string, so light/dark parity is inherited from the theme.
+ */
+
+const PROVIDER_STATUS_LABELS = {
+  available: 'Auto-synced provider link',
+  manual: 'Manually added provider link',
+  missing: 'Missing provider link',
+} as const;
+
+type ProviderStatus = keyof typeof PROVIDER_STATUS_LABELS;
+
 interface ProviderStatusDotProps {
-  readonly status: 'available' | 'manual' | 'missing';
+  readonly status: ProviderStatus;
   readonly accent: string;
 }
 
 function getProviderStatusConfig(
-  status: ProviderStatusDotProps['status'],
+  status: ProviderStatus,
   accent: string
 ): {
   label: string;
@@ -19,7 +60,7 @@ function getProviderStatusConfig(
   switch (status) {
     case 'available':
       return {
-        label: 'Auto-synced provider link',
+        label: PROVIDER_STATUS_LABELS.available,
         icon: <Check className='h-2.5 w-2.5' aria-hidden='true' />,
         className: 'shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]',
         style: {
@@ -30,14 +71,14 @@ function getProviderStatusConfig(
       };
     case 'manual':
       return {
-        label: 'Manually added provider link',
+        label: PROVIDER_STATUS_LABELS.manual,
         icon: <TriangleAlert className='h-2.5 w-2.5' aria-hidden='true' />,
         className:
           'border-[color:color-mix(in_oklab,var(--color-warning)_28%,var(--linear-app-frame-seam))] bg-[color:color-mix(in_oklab,var(--color-warning)_12%,transparent)] text-[var(--color-warning)] shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]',
       };
     default:
       return {
-        label: 'Missing provider link',
+        label: PROVIDER_STATUS_LABELS.missing,
         icon: <Dot className='h-2.5 w-2.5' aria-hidden='true' />,
         className:
           'border-subtle bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_82%,var(--linear-bg-surface-0))] text-tertiary-token',
@@ -52,19 +93,23 @@ export const ProviderStatusDot = memo(function ProviderStatusDot({
   const config = getProviderStatusConfig(status, accent);
 
   return (
-    <span
-      role='img'
-      className={cn(
-        'inline-flex h-4 w-4 items-center justify-center rounded-full border',
-        config.className
-      )}
-      style={config.style}
-      title={config.label}
-      aria-label={config.label}
-      data-provider-status={status}
-    >
-      {config.icon}
-      <span className='sr-only'>{config.label}</span>
-    </span>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          role='img'
+          className={cn(
+            'inline-flex h-4 w-4 items-center justify-center rounded-full border',
+            config.className
+          )}
+          style={config.style}
+          aria-label={config.label}
+          data-provider-status={status}
+        >
+          {config.icon}
+          <span className='sr-only'>{config.label}</span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side='top'>{config.label}</TooltipContent>
+    </Tooltip>
   );
 });

--- a/apps/web/tests/components/dashboard/organisms/releases/cells/ProviderCell.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/organisms/releases/cells/ProviderCell.interaction.test.tsx
@@ -1,3 +1,4 @@
+import { TooltipProvider } from '@jovie/ui';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { ProviderCell } from '@/features/dashboard/organisms/releases/cells/ProviderCell';
@@ -38,20 +39,22 @@ describe('ProviderCell actions', () => {
     const openSpy = vi.spyOn(globalThis, 'open').mockImplementation(() => null);
 
     render(
-      <table>
-        <tbody>
-          <tr onClick={parentClick}>
-            <td>
-              <ProviderCell
-                release={release}
-                provider={'spotify' as ProviderKey}
-                config={{ label: 'Spotify', accent: '#22c55e' }}
-                onCopy={onCopy}
-              />
-            </td>
-          </tr>
-        </tbody>
-      </table>
+      <TooltipProvider>
+        <table>
+          <tbody>
+            <tr onClick={parentClick}>
+              <td>
+                <ProviderCell
+                  release={release}
+                  provider={'spotify' as ProviderKey}
+                  config={{ label: 'Spotify', accent: '#22c55e' }}
+                  onCopy={onCopy}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </TooltipProvider>
     );
 
     const [openButton, copyButton] = screen.getAllByRole('button');

--- a/apps/web/tests/unit/components/releases/ProviderStatusDot.test.tsx
+++ b/apps/web/tests/unit/components/releases/ProviderStatusDot.test.tsx
@@ -1,10 +1,18 @@
+import { TooltipProvider } from '@jovie/ui';
 import { render, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
 import { describe, expect, it } from 'vitest';
 import { ProviderStatusDot } from '@/components/features/dashboard/organisms/releases/components/ProviderStatusDot';
 
+function renderWithTooltipProvider(ui: ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
 describe('ProviderStatusDot', () => {
   it('exposes a semantic label for auto-synced links', () => {
-    render(<ProviderStatusDot status='available' accent='#1db954' />);
+    renderWithTooltipProvider(
+      <ProviderStatusDot status='available' accent='#1db954' />
+    );
 
     const indicator = screen.getByRole('img', {
       name: 'Auto-synced provider link',
@@ -13,7 +21,9 @@ describe('ProviderStatusDot', () => {
   });
 
   it('exposes a semantic label for manually added links', () => {
-    render(<ProviderStatusDot status='manual' accent='#f59e0b' />);
+    renderWithTooltipProvider(
+      <ProviderStatusDot status='manual' accent='#f59e0b' />
+    );
 
     const indicator = screen.getByRole('img', {
       name: 'Manually added provider link',
@@ -22,7 +32,9 @@ describe('ProviderStatusDot', () => {
   });
 
   it('exposes a semantic label for missing links', () => {
-    render(<ProviderStatusDot status='missing' accent='#94a3b8' />);
+    renderWithTooltipProvider(
+      <ProviderStatusDot status='missing' accent='#94a3b8' />
+    );
 
     const indicator = screen.getByRole('img', {
       name: 'Missing provider link',


### PR DESCRIPTION
## Summary
- Documents the `available` / `manual` / `missing` provider-status contract directly in `ProviderStatusDot.tsx` so future editors know what each color means.
- Wraps the dot in the shared `Tooltip` primitive so sighted users see the same label screen readers already get via `aria-label` + `sr-only` text.
- Keeps status conveyed by icon + shape + text (Check / TriangleAlert / Dot), not color alone. Colors resolve via design tokens, so light/dark parity is inherited from the theme.

## Status mapping
- `available` — Auto-synced provider link. Provider accent color + Check icon.
- `manual` — Manually added provider link. `--color-warning` + TriangleAlert icon.
- `missing` — No provider link on file. Neutral surface + Dot icon.

## Scope notes
- No change to the status state machine — presentation only.
- No row layout changes. Avoids the release row overflow menu that JOV-1777 is editing.

## Test plan
- [x] `pnpm --filter web test -- run tests/unit/components/releases/ProviderStatusDot.test.tsx` — 3 passed (updated to wrap in `TooltipProvider`).
- [x] `pnpm turbo typecheck --filter=@jovie/web` (via lint-staged) — clean.
- [x] ESLint on changed files — clean.
- [ ] Manual hover verification in dashboard Releases table (light + dark).

Closes JOV-1781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider status indicators in the dashboard now feature enhanced tooltips on hover, offering improved clarity about provider availability and status information.

* **Refactor**
  * Optimized internal label management and status type definitions for provider indicators to improve code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->