### PR TITLE
feat(releases): DSP status, last verified, and missing row affordance (JOV-1782)

### DIFF
--- a/apps/web/components/organisms/release-sidebar/ReleaseDspLinks.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseDspLinks.tsx
@@ -3,7 +3,10 @@
 /**
  * ReleaseDspLinks Component
  *
- * DSP links section with add/remove functionality
+ * DSP links section with per-row status, last-verified timestamp,
+ * quick actions (open/copy handled by SidebarLinkRow), and a visually
+ * distinct "missing" section for providers we know about but haven't
+ * resolved yet.
  */
 
 import {
@@ -13,7 +16,9 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  SimpleTooltip,
 } from '@jovie/ui';
+import { AlertTriangle } from 'lucide-react';
 import { type ChangeEvent, type KeyboardEvent } from 'react';
 
 import { ProviderIcon } from '@/components/atoms/ProviderIcon';
@@ -25,11 +30,90 @@ import {
   SidebarLinkRow,
 } from '@/components/molecules/drawer';
 import { LINEAR_SURFACE } from '@/features/dashboard/tokens';
-import type { ProviderKey } from '@/lib/discography/types';
+import type {
+  ProviderConfidence,
+  ProviderKey,
+  ProviderSource,
+} from '@/lib/discography/types';
 import { cn } from '@/lib/utils';
+import { formatTimeAgo } from '@/lib/utils/date-formatting';
 
 import type { Release } from './types';
 import { isValidUrl } from './utils';
+
+type DspStatus = 'connected' | 'pending' | 'error' | 'missing';
+
+interface DspStatusVisual {
+  readonly label: string;
+  readonly description: string;
+  readonly dotClassName: string;
+}
+
+const STATUS_VISUALS: Record<DspStatus, DspStatusVisual> = {
+  connected: {
+    label: 'Connected',
+    description: 'Link verified against the provider.',
+    dotClassName: 'bg-success',
+  },
+  pending: {
+    label: 'Pending',
+    description: 'Link resolved via search fallback and not yet verified.',
+    dotClassName: 'bg-warning',
+  },
+  error: {
+    label: 'Error',
+    description: 'Link is present but looks invalid.',
+    dotClassName: 'bg-destructive',
+  },
+  missing: {
+    label: 'Missing',
+    description: "We haven't found this provider for this release yet.",
+    dotClassName: 'bg-tertiary-token',
+  },
+};
+
+function resolveProviderStatus(params: {
+  url: string;
+  source: ProviderSource;
+  confidence?: ProviderConfidence;
+}): DspStatus {
+  const { url, source, confidence } = params;
+  if (!url || !isValidUrl(url)) return 'error';
+  if (source === 'manual') return 'connected';
+  switch (confidence) {
+    case 'canonical':
+    case 'manual_override':
+      return 'connected';
+    case 'search_fallback':
+    case 'unknown':
+      return 'pending';
+    case undefined:
+      return 'connected';
+    default:
+      return 'pending';
+  }
+}
+
+function StatusDot({ status }: { readonly status: DspStatus }) {
+  const visual = STATUS_VISUALS[status];
+  return (
+    <SimpleTooltip
+      content={`${visual.label}: ${visual.description}`}
+      side='top'
+    >
+      <span
+        className='inline-flex h-4 w-4 items-center justify-center'
+        aria-label={visual.label}
+        role='img'
+      >
+        <span
+          className={cn('h-1.5 w-1.5 rounded-full', visual.dotClassName)}
+          aria-hidden='true'
+        />
+      </span>
+    </SimpleTooltip>
+  );
+}
 
 interface ReleaseDspLinksProps {
   readonly release: Release;
@@ -75,11 +159,21 @@ export function ReleaseDspLinks({
     .filter(key => !release.providers.some(p => p.key === key))
     .map(key => [key, providerConfig[key]] as const);
 
+  // Missing providers: those the backend knows about but hasn't resolved yet.
+  // We only surface these if the matrix actually tracked them — we don't
+  // invent "missing" for every provider in the universe.
+  const unresolvedProviders = (
+    release.providerCounts?.unresolvedProviders ?? []
+  ).filter(key => !release.providers.some(p => p.key === key));
+
+  const hasAnyRows =
+    release.providers.length > 0 || unresolvedProviders.length > 0;
+
   return (
     <DrawerLinkSection
       title='DSPs'
       showHeading={showHeading}
-      isEmpty={release.providers.length === 0 && !isAddingLink}
+      isEmpty={!hasAnyRows && !isAddingLink}
       emptyMessage='No DSP links yet.'
     >
       {/* Providers list */}
@@ -88,6 +182,14 @@ export function ReleaseDspLinks({
           {release.providers.map(provider => {
             const config = providerConfig[provider.key];
             const isManual = provider.source === 'manual';
+            const status = resolveProviderStatus({
+              url: provider.url,
+              source: provider.source,
+              confidence: provider.confidence,
+            });
+            const verifiedLabel = provider.updatedAt
+              ? `Verified ${formatTimeAgo(provider.updatedAt)}`
+              : null;
 
             return (
               <SidebarLinkRow
@@ -107,9 +209,82 @@ export function ReleaseDspLinks({
                 isRemoving={isRemovingDspLink === provider.key}
                 onRemove={() => void onRemoveLink(provider.key)}
                 surfaceVariant='track'
+                trailingContent={
+                  <div className='ml-auto flex items-center gap-2'>
+                    {verifiedLabel ? (
+                      <SimpleTooltip
+                        content={`Last verified ${formatTimeAgo(provider.updatedAt)}`}
+                        side='top'
+                      >
+                        <span
+                          className='hidden text-[10px] text-tertiary-token md:inline'
+                          title={verifiedLabel ?? undefined}
+                        >
+                          {formatTimeAgo(provider.updatedAt)}
+                        </span>
+                      </SimpleTooltip>
+                    ) : null}
+                    <StatusDot status={status} />
+                  </div>
+                }
               />
             );
           })}
+        </div>
+      )}
+
+      {/* Missing providers — visually muted, warning affordance */}
+      {unresolvedProviders.length > 0 && (
+        <div className='mt-3 space-y-1.5'>
+          <div className='flex items-center gap-1.5 px-2 text-[10px] font-medium uppercase tracking-wide text-tertiary-token'>
+            <AlertTriangle className='h-3 w-3' aria-hidden='true' />
+            <span>Missing</span>
+          </div>
+          <div className='space-y-1'>
+            {unresolvedProviders.map(key => {
+              const config = providerConfig[key];
+              const label = config?.label || key;
+              return (
+                <div
+                  key={`missing-${key}`}
+                  className={cn(
+                    'group flex min-h-[32px] items-center justify-between rounded-[10px] border border-dashed border-subtle bg-transparent px-2 py-1.5 opacity-75',
+                    'transition-[background-color,opacity] duration-150 lg:hover:opacity-100'
+                  )}
+                  data-dsp-status='missing'
+                  data-provider={key}
+                >
+                  <div className='flex min-w-0 flex-1 items-center gap-2.25'>
+                    <span className='flex h-5 w-5 shrink-0 items-center justify-center text-tertiary-token'>
+                      <ProviderIcon
+                        provider={key}
+                        className='h-4 w-4 opacity-60'
+                        aria-label={label}
+                      />
+                    </span>
+                    <span className='text-[13px] font-[460] text-secondary-token'>
+                      {label}
+                    </span>
+                    <span className='shrink-0 text-[10px] text-tertiary-token'>
+                      Missing
+                    </span>
+                  </div>
+                  <SimpleTooltip
+                    content="We haven't found this provider for this release yet."
+                    side='top'
+                  >
+                    <span
+                      className='flex h-4 w-4 items-center justify-center text-warning'
+                      aria-label='Missing provider'
+                      role='img'
+                    >
+                      <AlertTriangle className='h-3 w-3' aria-hidden='true' />
+                    </span>
+                  </SimpleTooltip>
+                </div>
+              );
+            })}
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Closes [JOV-1782](https://linear.app/jovie/issue/JOV-1782/improve-dsp-status-display-and-actions).

Per-row status and quick-action improvements in the release sidebar DSPs tab. Everything surfaced here is already present in the data model — no new polling, recheck pipeline, or backend queries.

- Status dot per DSP row (`connected` / `pending` / `error`) derived from `ProviderLink.source` / `confidence` / `url`, with a `SimpleTooltip` explaining each state.
- "Last verified" relative time chip on each row (hidden below `md`), sourced from existing `ProviderLink.updatedAt` and formatted with `formatTimeAgo`.
- A visually distinct **Missing** section (dashed border, muted text, warning icon + tooltip) for providers listed in `release.providerCounts.unresolvedProviders` that have no row yet. This makes gaps easy to spot without inventing "missing" for every provider in the universe.
- Open / copy URL quick actions were already wired into `SidebarLinkRow` (swipe + kebab menu) and are preserved.
- Spotify and Apple Music rows render identically to before — they're just now annotated with status + verified time.

## Status states

| State     | Derivation                                                |
| --------- | --------------------------------------------------------- |
| connected | `source === 'manual'`, or confidence `canonical` / `manual_override`, or no confidence set (legacy rows) |
| pending   | confidence `search_fallback` / `unknown`                  |
| error     | provider row with empty / invalid URL                     |
| missing   | provider appears in `providerCounts.unresolvedProviders`  |

## Actions wired

Open URL (with DSP deep-linking) and Copy URL — both already supported via `SidebarLinkRow`'s swipe actions and desktop kebab menu. No refresh/recheck action was added because there's no backend endpoint for a per-release DSP recheck and that was explicitly out of scope.

## Test plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint` (biome)
- [x] `pnpm --filter web test -- tests/components/organisms/release-sidebar/ReleaseDspLinks.interaction.test.tsx` (4/4 pass)
- [ ] Manual QA in sidebar: connected rows show green dot, ingested-with-search-fallback rows show amber dot, unresolved providers render in the dashed Missing block.

## Notes

Browser QA / `/qa --exhaustive` / `/review` slash-skills were skipped — Doppler/browser setup isn't viable in this agent worktree. Bot reviews (CodeRabbit / Greptile) will gate merge per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)