### PR TITLE
fix(ci): fail closed production golden path monitor

### DIFF
--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -43,45 +43,107 @@ jobs:
       - name: Install Playwright Browsers (chromium only)
         run: pnpm --filter=@jovie/web exec playwright install --with-deps chromium
 
+      - name: Install Doppler CLI
+        run: |
+          sudo apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
+          curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' | sudo gpg --dearmor -o /usr/share/keyrings/doppler-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/doppler-archive-keyring.gpg] https://packages.doppler.com/public/cli/deb/debian any-version main" | sudo tee /etc/apt/sources.list.d/doppler-cli.list
+          sudo apt-get update && sudo apt-get install -y doppler
+          doppler --version
+
       - name: Run Golden Path Test
         env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_PRD }}
           BASE_URL: https://jov.ie
           PLAYWRIGHT_TEST_BASE_URL: https://jov.ie
-          # Use production Clerk for synthetic tests
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_PUBLISHABLE_KEY_PROD }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY_PROD }}
-          # Enable synthetic monitoring mode
+          E2E_SKIP_WEB_SERVER: '1'
           E2E_SYNTHETIC_MODE: 'true'
           E2E_ENVIRONMENT: production
+          PLAYWRIGHT_JSON_OUTPUT_NAME: test-results/results.json
         run: |
-          # Run only the golden path test
-          pnpm --filter=@jovie/web exec playwright test tests/e2e/golden-path.spec.ts --reporter=json --output=test-results
+          doppler run -- pnpm --filter=@jovie/web exec playwright test tests/e2e/golden-path.spec.ts --project=chromium --reporter=line,json --output=test-results
         continue-on-error: true
 
       - name: Parse test results
         id: test-results
         run: |
-          RESULTS_DIR="test-results"
-          if [ -f "$RESULTS_DIR/results.json" ]; then
-            FAILED_TESTS=$(jq -r '[.suites[].specs[] | select(.outcome == "unexpected") | .title] | join("\n")' "$RESULTS_DIR/results.json")
-            TOTAL_TESTS=$(jq -r '[.suites[].specs[]] | length' "$RESULTS_DIR/results.json")
-            PASSED_TESTS=$(jq -r '[.suites[].specs[] | select(.outcome == "expected")] | length' "$RESULTS_DIR/results.json")
+          node <<'NODE'
+          const fs = require('node:fs');
 
-            echo "total_tests=$TOTAL_TESTS" >> "$GITHUB_OUTPUT"
-            echo "passed_tests=$PASSED_TESTS" >> "$GITHUB_OUTPUT"
-            echo "failed_tests<<EOF" >> "$GITHUB_OUTPUT"
-            echo "$FAILED_TESTS" >> "$GITHUB_OUTPUT"
-            echo "EOF" >> "$GITHUB_OUTPUT"
+          const resultsFile = 'apps/web/test-results/results.json';
+          const outputFile = process.env.GITHUB_OUTPUT;
 
-            if [ "$PASSED_TESTS" -lt "$TOTAL_TESTS" ]; then
-              echo "test_status=failed" >> "$GITHUB_OUTPUT"
-            else
-              echo "test_status=passed" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            echo "test_status=error" >> "$GITHUB_OUTPUT"
-            echo "failed_tests=Test results file not found" >> "$GITHUB_OUTPUT"
-          fi
+          function emit(line) {
+            if (outputFile) {
+              fs.appendFileSync(outputFile, `${line}\n`);
+            } else {
+              console.log(line);
+            }
+          }
+
+          function emitMultiline(name, lines) {
+            emit(`${name}<<EOF`);
+            for (const line of lines) emit(line);
+            emit('EOF');
+          }
+
+          if (!fs.existsSync(resultsFile)) {
+            emit('test_status=error');
+            emitMultiline('failed_tests', ['Test results file not found']);
+            process.exit(0);
+          }
+
+          const results = JSON.parse(fs.readFileSync(resultsFile, 'utf8'));
+          const specs = [];
+
+          function collectSpecs(suites = []) {
+            for (const suite of suites) {
+              specs.push(...(suite.specs ?? []));
+              collectSpecs(suite.suites ?? []);
+            }
+          }
+
+          collectSpecs(results.suites ?? []);
+
+          const tests = specs.flatMap(spec =>
+            (spec.tests ?? []).map(testCase => ({ spec, testCase }))
+          );
+          const skipped = tests.filter(({ testCase }) =>
+            (testCase.results ?? []).some(result => result.status === 'skipped')
+          );
+          const flaky = tests.filter(({ testCase }) => testCase.status === 'flaky');
+          const failed = tests.filter(
+            ({ testCase }) => testCase.status === 'unexpected'
+          );
+          const passed = tests.filter(
+            ({ testCase }) =>
+              ['expected', 'flaky'].includes(testCase.status) &&
+              !(testCase.results ?? []).some(result => result.status === 'skipped')
+          );
+
+          emit(`total_tests=${tests.length}`);
+          emit(`passed_tests=${passed.length}`);
+          emit(`flaky_tests=${flaky.length}`);
+          emit(`skipped_tests=${skipped.length}`);
+
+          const details = [
+            ...failed.map(({ spec }) => spec.title),
+            ...(skipped.length > 0
+              ? ['Skipped tests:', ...skipped.map(({ spec }) => spec.title)]
+              : []),
+          ];
+          emitMultiline('failed_tests', details);
+
+          if (tests.length === 0) {
+            emit('test_status=error');
+          } else if (failed.length > 0 || skipped.length > 0) {
+            emit('test_status=failed');
+          } else if (passed.length === tests.length) {
+            emit('test_status=passed');
+          } else {
+            emit('test_status=error');
+          }
+          NODE
 
       - name: Upload test results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -89,14 +151,14 @@ jobs:
         with:
           name: synthetic-test-results
           path: |
-            test-results/
-            playwright-report/
+            apps/web/test-results/
+            apps/web/playwright-report/
           retention-days: 30
 
       - name: Fail job if tests failed
-        if: steps.test-results.outputs.test_status == 'failed'
+        if: steps.test-results.outputs.test_status != 'passed'
         run: |
-          echo "Marking job as failed due to test failures"
+          echo "Marking job as failed because synthetic status is '${{ steps.test-results.outputs.test_status }}'"
           exit 1
 
       - name: Send Slack Alert on Failure

--- a/apps/web/tests/e2e/golden-path.spec.ts
+++ b/apps/web/tests/e2e/golden-path.spec.ts
@@ -141,7 +141,7 @@ async function ensureDbUser(clerkUserId: string, email: string) {
     UPDATE creator_profiles
     SET spotify_id = NULL, spotify_url = NULL
     WHERE user_id IN (
-      SELECT id FROM users WHERE email LIKE '%+clerk_test@test.jovie.com'
+      SELECT id FROM users WHERE email LIKE 'gp-%+clerk_test@test.jovie.com'
     ) AND spotify_id IS NOT NULL
   `;
 
@@ -281,7 +281,7 @@ async function interceptTrackingCalls(page: import('@playwright/test').Page) {
  * For +clerk_test emails, Clerk requires completing email verification
  * with the magic code 424242 before a session is created.
  */
-async function createFreshUser(page: import('@playwright/test').Page) {
+async function createFreshUserOnce(page: import('@playwright/test').Page) {
   await setupClerkTestingToken({ page });
 
   await page.goto('/signin', {
@@ -352,6 +352,40 @@ async function createFreshUser(page: import('@playwright/test').Page) {
   await ensureDbUser(clerkUserId, email);
 
   return { email, clerkUserId };
+}
+
+async function createFreshUser(page: import('@playwright/test').Page) {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= 6; attempt++) {
+    try {
+      return await createFreshUserOnce(page);
+    } catch (error) {
+      lastError = error;
+      const message = error instanceof Error ? error.message : String(error);
+      const lowerMessage = message.toLowerCase();
+      const isRetryable =
+        lowerMessage.includes('captcha') ||
+        lowerMessage.includes('statement timeout') ||
+        lowerMessage.includes('canceling statement');
+      if (!isRetryable || attempt === 6) {
+        throw error;
+      }
+
+      await page.context().clearCookies();
+      await page
+        .evaluate(() => {
+          localStorage.clear();
+          sessionStorage.clear();
+        })
+        .catch(() => {});
+      await page.waitForTimeout(2000 * attempt);
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('Failed to create Clerk test user');
 }
 
 /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- Run production golden-path monitoring under `doppler run` with `DOPPLER_TOKEN_PRD`, so Clerk, DB, Redis, Stripe, and related prod secrets are present without exporting multiline secrets into `$GITHUB_ENV`.
- Write Playwright JSON into the package test-results directory the workflow can actually parse.
- Parse Playwright results with Node and fail closed on skipped tests, missing result files, zero tests, or final unexpected failures.
- Preserve Playwright retry semantics: recovered `flaky` outcomes do not page production, but artifacts still include the failed attempt evidence.
- Stabilize the golden-path signup/setup lane by narrowing stale test-profile cleanup and retrying transient Clerk CAPTCHA / Neon timeout failures inside the test.

## Root Cause
The production monitor was not proving the golden path. The latest scheduled run skipped `golden-path.spec.ts` because real Clerk/DB env vars were not configured, then the parser looked for `test-results/results.json` at the repo root even though Playwright writes under `apps/web`. The Slack alert said `Test results file not found`, but the job still concluded success because only `test_status=failed` failed the workflow, not `error`.

While validating the fixed monitor, GitHub runners also exposed two transient harness problems: Clerk CAPTCHA occasionally fails during browser-side test-user signup, and the stale test Spotify cleanup used a broad leading-wildcard email scan that could hit Neon statement timeouts. The app golden path itself completed against production.

## QA Evidence
- `doppler run --project jovie-web --config prd -- node -e ...` confirmed prod Doppler has Clerk, DB, Redis, and Stripe secrets.
- `doppler run --project jovie-web --config prd -- pnpm --filter=@jovie/web exec playwright test tests/e2e/golden-path.spec.ts --project=chromium --reporter=line,json --output=test-results` passed locally against `https://jov.ie` with `total=2`, `passed=2`, `failed=0`, `skipped=0`.
- Manual GitHub workflow dispatch on this branch passed: https://github.com/JovieInc/Jovie/actions/runs/24758792948
- `git diff --check` passed.
- `pnpm exec actionlint .github/workflows/synthetic-monitoring.yml` could not run locally because `actionlint` is not installed in this workspace.
- Pre-push hook passed: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`, plus staged-file ESLint and turbo typecheck.