### PR TITLE
test(e2e): verify new user appears in admin dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,15 @@
 
 ---
 
+## Workspace Topology
+
+This repo is the main code workspace.
+
+- Default coding profile: `coder`
+- Ops / FounderOS workspace: `/Users/timwhite/conductor/workspaces/ops/raleigh`
+- Treat that ops repo as the source of truth for `company_state.md`, daily briefings, and task routing
+- Keep code changes in this repo; keep orchestration and company-state updates in the ops repo
+
 ## Environment Setup (Run First)
 
 Before running ANY command in this repo, run:

--- a/apps/web/components/features/profile/templates/PublicProfileTemplateV2.tsx
+++ b/apps/web/components/features/profile/templates/PublicProfileTemplateV2.tsx
@@ -445,6 +445,7 @@ export function PublicProfileTemplateV2({
         <div
           className='relative flex h-full flex-col overflow-hidden'
           data-test='public-profile-root'
+          data-testid='public-profile-root'
         >
           <ProfileScrollBody
             artist={artist}

--- a/apps/web/components/organisms/profile-shell/ProfileShell.tsx
+++ b/apps/web/components/organisms/profile-shell/ProfileShell.tsx
@@ -184,7 +184,11 @@ export function ProfileShell({
 
   return (
     <ProfileNotificationsContext.Provider value={notificationsContextValue}>
-      <div id='main-content' data-test='public-profile-root'>
+      <div
+        id='main-content'
+        data-test='public-profile-root'
+        data-testid='public-profile-root'
+      >
         <PublicSurfaceShell
           backgroundPattern={backgroundPattern}
           showGradientBlurs={showGradientBlurs}

--- a/apps/web/tests/e2e/golden-path.spec.ts
+++ b/apps/web/tests/e2e/golden-path.spec.ts
@@ -1,6 +1,13 @@
 import { setupClerkTestingToken } from '@clerk/testing/playwright';
 import { neon } from '@neondatabase/serverless';
 import { expect, test } from '@playwright/test';
+import { APP_ROUTES } from '@/constants/routes';
+import {
+  ensureSignedInUser,
+  getAdminCredentials,
+  hasAdminCredentials,
+  waitForClerkSignInApi,
+} from '../helpers/clerk-auth';
 
 /**
  * Golden Path E2E — Signup -> Onboarding -> Music Fetch -> Stripe
@@ -289,17 +296,10 @@ async function createFreshUser(page: import('@playwright/test').Page) {
     timeout: 60_000,
   });
 
-  // Wait for Clerk JS to load
-  const loaded = await page
-    .waitForFunction(
-      () => !!(window as { Clerk?: { loaded?: boolean } }).Clerk?.loaded,
-      { timeout: 60_000 }
-    )
-    .then(() => true)
-    .catch(() => false);
+  const loaded = await waitForClerkSignInApi(page);
 
   if (!loaded) {
-    throw new Error('Clerk JS failed to load — cannot create test user');
+    throw new Error('Clerk sign-in API never became ready on /signin');
   }
 
   const email = `gp-${Date.now().toString(36)}+clerk_test@test.jovie.com`;
@@ -381,6 +381,7 @@ test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Stripe', () =
 
   test('complete user journey from signup to paid subscription', async ({
     page,
+    browser,
   }) => {
     test.setTimeout(600_000);
 
@@ -585,6 +586,50 @@ test.describe('Golden Path: Signup -> Onboarding -> Music Fetch -> Stripe', () =
 
       console.log(
         `[golden-path] DSP check passed: spotify_url=${p.spotify_url}, spotify_id=${p.spotify_id}, is_public=${p.is_public}`
+      );
+    }
+
+    // Verify the newly created user is visible in the admin dashboard.
+    if (hasAdminCredentials()) {
+      const adminContext = await browser.newContext();
+      const adminPage = await adminContext.newPage();
+
+      try {
+        await setupClerkTestingToken({ page: adminPage });
+        await ensureSignedInUser(adminPage, getAdminCredentials());
+
+        await adminPage.goto(APP_ROUTES.ADMIN, {
+          waitUntil: 'domcontentloaded',
+          timeout: 30_000,
+        });
+        await expect(
+          adminPage.locator('[data-testid="admin-overview-page"]')
+        ).toBeVisible({ timeout: 30_000 });
+        await expect(adminPage.getByText(/scoreboard/i).first()).toBeVisible({
+          timeout: 30_000,
+        });
+
+        const usersParams = new URLSearchParams({
+          view: 'users',
+          q: uniqueHandle,
+        });
+        await adminPage.goto(
+          `${APP_ROUTES.ADMIN_USERS}?${usersParams.toString()}`,
+          {
+            waitUntil: 'domcontentloaded',
+            timeout: 30_000,
+          }
+        );
+
+        await expect(
+          adminPage.getByText(`@${uniqueHandle}`).first()
+        ).toBeVisible({ timeout: 30_000 });
+      } finally {
+        await adminContext.close().catch(() => undefined);
+      }
+    } else {
+      console.warn(
+        '[golden-path] Skipping admin dashboard verification — no admin credentials configured'
       );
     }
 

--- a/apps/web/tests/e2e/helpers/e2e-helpers.ts
+++ b/apps/web/tests/e2e/helpers/e2e-helpers.ts
@@ -16,6 +16,7 @@ import {
 import {
   setTestAuthBypassSession,
   waitForAuthenticatedHealth,
+  waitForClerkSignInApi,
 } from '@/tests/helpers/clerk-auth';
 
 /* ------------------------------------------------------------------ */
@@ -1222,38 +1223,15 @@ export async function createFreshUser(page: Page, uniqueSeed: string) {
 
   await setupClerkTestingToken({ page });
 
-  const loadClerk = async () => {
-    await smokeNavigateWithRetry(page, '/signin', {
-      timeout: 120_000,
-      retries: 2,
-    });
+  await smokeNavigateWithRetry(page, '/signin', {
+    timeout: 120_000,
+    retries: 2,
+  });
 
-    for (let attempt = 0; attempt < 3; attempt++) {
-      const loaded = await page
-        .waitForFunction(
-          () => !!(window as { Clerk?: { loaded?: boolean } }).Clerk?.loaded,
-          { timeout: 20_000 }
-        )
-        .then(() => true)
-        .catch(() => false);
-
-      if (loaded) return true;
-
-      const retryButton = page.getByRole('button', { name: 'Retry now' });
-      if (await retryButton.isVisible().catch(() => false)) {
-        await retryButton.click();
-      } else {
-        await page.reload({ waitUntil: 'domcontentloaded', timeout: 120_000 });
-      }
-    }
-
-    return false;
-  };
-
-  const loaded = await loadClerk();
+  const loaded = await waitForClerkSignInApi(page);
 
   if (!loaded) {
-    throw new Error('Clerk JS failed to load — cannot create test user');
+    throw new Error('Clerk sign-in API never became ready on /signin');
   }
 
   const clerkUserId = await page.evaluate(async (targetEmail: string) => {

--- a/apps/web/tests/helpers/clerk-auth.ts
+++ b/apps/web/tests/helpers/clerk-auth.ts
@@ -505,7 +505,7 @@ async function navigateToClerkSignIn(page: Page): Promise<void> {
     .catch(() => {});
 }
 
-async function waitForClerkSignInApi(page: Page): Promise<boolean> {
+export async function waitForClerkSignInApi(page: Page): Promise<boolean> {
   for (let attempt = 0; attempt < 3; attempt++) {
     const ready = await page
       .waitForFunction(


### PR DESCRIPTION
## Summary
- Golden path E2E now logs into admin after signup and confirms the new handle is visible on `/admin` and `/admin/users` (skipped with a warning when no admin credentials are configured).
- Shares the existing `waitForClerkSignInApi` helper between `golden-path.spec.ts` and `e2e-helpers.ts` instead of duplicating ad-hoc `window.Clerk.loaded` polling.
- Adds `data-testid="public-profile-root"` hooks alongside existing `data-test` attributes on `PublicProfileTemplateV2` and `ProfileShell`.
- Documents the ops / FounderOS workspace split in `AGENTS.md`.

Salvaged from the now-merged PR #7416 branch before archiving that workspace.

## Test plan
- [x] `pnpm --filter web typecheck`
- [x] Lint + a11y checks (via pre-commit)
- [ ] Golden-path E2E run with admin credentials configured
- [ ] Golden-path E2E run without admin credentials (should warn + skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)