### PR TITLE
fix(profile): address CodeRabbit + Greptile findings

### DIFF
--- a/apps/web/components/features/profile/AboutSection.tsx
+++ b/apps/web/components/features/profile/AboutSection.tsx
@@ -131,9 +131,14 @@ export function AboutSection({
         <div className='flex flex-wrap gap-2'>
           {genres.map((genre, i) => {
             const accent = GENRE_ACCENTS[i % GENRE_ACCENTS.length];
+            // Dedupe duplicate genre labels deterministically: track how
+            // many times each label has appeared so the key is stable
+            // across renders but still unique. Avoids array index in key.
+            const dupIndex = genres.slice(0, i).filter(g => g === genre).length;
+            const key = dupIndex === 0 ? genre : `${genre}-${dupIndex}`;
             return (
               <span
-                key={genre}
+                key={key}
                 className='rounded-full border px-3 py-1 text-[11px] font-[510] capitalize'
                 style={{
                   backgroundColor: hexToRgba(accent, 0.14),

--- a/apps/web/components/features/profile/ProfileDrawerShell.tsx
+++ b/apps/web/components/features/profile/ProfileDrawerShell.tsx
@@ -51,7 +51,7 @@ export function ProfileDrawerShell({
     ['--profile-drawer-header' as string]: '72px',
   } as React.CSSProperties;
   const contentClasses = `relative flex max-h-[var(--profile-drawer-height-max)] w-full flex-col overflow-hidden rounded-t-[var(--profile-drawer-radius-mobile)] border-t border-white/[0.08] bg-[color:var(--profile-drawer-bg)] text-primary-token shadow-[0_-8px_40px_rgba(0,0,0,0.4)] backdrop-blur-2xl md:max-w-(--profile-shell-max-width) md:rounded-t-[var(--profile-drawer-radius-desktop)] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-24 before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.04),transparent)] ${contentClassName ?? ''}`;
-  const bodyClasses = `relative z-10 min-h-[calc(var(--profile-drawer-height-max)-var(--profile-drawer-header))] overflow-y-auto overscroll-contain px-5 pb-[calc(1.25rem+env(safe-area-inset-bottom))] pt-3 ${bodyClassName ?? ''}`;
+  const bodyClasses = `relative z-10 min-h-[calc(var(--profile-drawer-height-max)_-_var(--profile-drawer-header))] overflow-y-auto overscroll-contain px-5 pb-[calc(1.25rem_+_env(safe-area-inset-bottom))] pt-3 ${bodyClassName ?? ''}`;
 
   const header = (
     <>

--- a/apps/web/components/features/profile/ProfileUnifiedDrawer.tsx
+++ b/apps/web/components/features/profile/ProfileUnifiedDrawer.tsx
@@ -306,7 +306,7 @@ function ReleasesDrawerContent({
             ) : null}
             <a
               href={`/${artistHandle}/${release.slug}`}
-              className='flex items-center gap-3 rounded-xl px-4 py-3 transition-colors duration-150 ease-out hover:bg-white/[0.05] focus-visible:bg-white/[0.06] focus-visible:outline-none active:bg-white/[0.08]'
+              className='flex items-center gap-3 rounded-xl px-4 py-3 transition-colors duration-150 ease-out hover:bg-white/[0.05] focus-visible:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-inset active:bg-white/[0.08]'
               aria-label={ariaLabel}
             >
               <div className='relative h-10 w-10 shrink-0 overflow-hidden rounded-md'>

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -396,6 +396,11 @@ export function ProfileInlineNotificationsCTA({
   const lastInteractionWasKeyboardRef = useRef(false);
   const suppressNextFocusOpenRef = useRef(false);
   const emailInputFocusedRef = useRef(false);
+  // Mirror `step` into a ref so the blur guard can read the latest value
+  // after its 250 ms timeout fires. Without this, the setTimeout closes
+  // over whichever step was active when the blur started, which under
+  // Concurrent Mode scheduling could be stale.
+  const stepRef = useRef<Step>('cta');
 
   const nameMutation = useUpdateSubscriberNameMutation();
   const birthdayMutation = useUpdateSubscriberBirthdayMutation();
@@ -512,6 +517,7 @@ export function ProfileInlineNotificationsCTA({
   }, []);
 
   useEffect(() => {
+    stepRef.current = step;
     if (step !== 'otp') {
       lastAutoVerifiedCodeRef.current = null;
     }
@@ -621,8 +627,11 @@ export function ProfileInlineNotificationsCTA({
   const handleRevealShellBlurCapture = useCallback(() => {
     // Defer past the autofocus window so the reveal transition isn't
     // interrupted by the click-blur that precedes input mount/focus.
+    // Read step via ref so the timeout sees the latest value even if
+    // Concurrent Mode defers the effect that would otherwise invalidate
+    // this closure.
     globalThis.setTimeout(() => {
-      if (step !== 'email') return;
+      if (stepRef.current !== 'email') return;
 
       const activeElement = document.activeElement;
       if (revealShellRef.current?.contains(activeElement)) {
@@ -637,7 +646,7 @@ export function ProfileInlineNotificationsCTA({
         setStep('cta');
       }
     }, REVEAL_SHELL_BLUR_GUARD_MS);
-  }, [step, emailInput, isSubmitting]);
+  }, [emailInput, isSubmitting]);
 
   const handleManageButtonFocus = useCallback(() => {
     if (!lastInteractionWasKeyboardRef.current) return;

--- a/apps/web/components/features/profile/profile-drawer-classes.ts
+++ b/apps/web/components/features/profile/profile-drawer-classes.ts
@@ -1,13 +1,15 @@
 // Drawer rows read as list items, not buttons: no visible border/elevation at rest,
 // subtle hover-only background + subtle rounding, brighter primary text.
+// Keyboard focus gets a visible ring (WCAG 2.4.11 AA — 3:1 contrast) in
+// addition to the background tint, since the native outline is suppressed.
 export const PROFILE_DRAWER_MENU_ITEM_CLASS =
-  'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-[14px] font-[450] text-white/92 transition-colors duration-150 ease-out hover:bg-white/[0.05] focus-visible:bg-white/[0.06] focus-visible:outline-none active:bg-white/[0.08]';
+  'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-[14px] font-[450] text-white/92 transition-colors duration-150 ease-out hover:bg-white/[0.05] focus-visible:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-inset active:bg-white/[0.08]';
 
 export const PROFILE_DRAWER_DANGER_ITEM_CLASS =
-  'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-[14px] font-[450] text-red-400/88 transition-colors duration-150 ease-out hover:bg-red-400/[0.06] focus-visible:bg-red-400/[0.07] focus-visible:outline-none active:bg-red-400/[0.09]';
+  'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-[14px] font-[450] text-red-400/88 transition-colors duration-150 ease-out hover:bg-red-400/[0.06] focus-visible:bg-red-400/[0.07] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/50 focus-visible:ring-inset active:bg-red-400/[0.09]';
 
 export const PROFILE_DRAWER_TOGGLE_ROW_CLASS =
-  'flex w-full items-center justify-between rounded-xl px-4 py-3 text-left transition-colors duration-150 ease-out hover:bg-white/[0.04]';
+  'flex w-full items-center justify-between rounded-xl px-4 py-3 text-left transition-colors duration-150 ease-out hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-inset';
 
 export const PROFILE_DRAWER_TITLE_CLASS =
   'text-[14px] font-[450] text-white/92';

--- a/apps/web/components/features/profile/profile-drawer-classes.ts
+++ b/apps/web/components/features/profile/profile-drawer-classes.ts
@@ -8,8 +8,10 @@ export const PROFILE_DRAWER_MENU_ITEM_CLASS =
 export const PROFILE_DRAWER_DANGER_ITEM_CLASS =
   'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-[14px] font-[450] text-red-400/88 transition-colors duration-150 ease-out hover:bg-red-400/[0.06] focus-visible:bg-red-400/[0.07] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/50 focus-visible:ring-inset active:bg-red-400/[0.09]';
 
+// Applied to non-focusable <div> wrappers; use focus-within so the ring
+// appears when keyboard focus lands on an interactive child (link, Switch).
 export const PROFILE_DRAWER_TOGGLE_ROW_CLASS =
-  'flex w-full items-center justify-between rounded-xl px-4 py-3 text-left transition-colors duration-150 ease-out hover:bg-white/[0.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-inset';
+  'flex w-full items-center justify-between rounded-xl px-4 py-3 text-left transition-colors duration-150 ease-out hover:bg-white/[0.04] focus-within:outline-none focus-within:ring-2 focus-within:ring-white/40 focus-within:ring-inset';
 
 export const PROFILE_DRAWER_TITLE_CLASS =
   'text-[14px] font-[450] text-white/92';

--- a/apps/web/lib/utils/color.ts
+++ b/apps/web/lib/utils/color.ts
@@ -75,11 +75,18 @@ export function contrastRatio(hex1: string, hex2: string): number {
 /**
  * Lighten a hex color by mixing toward white. amount=0.35 mixes 35% white in.
  * Used for readable text on low-alpha brand fills over dark surfaces.
+ * Amount is clamped to [0, 1] so callers passing out-of-range values don't
+ * produce negative channels or values above 255. Returns a hex string so
+ * the function composes with other hex-expecting helpers in this module.
  */
 export function lightenHex(hex: string, amount: number): string {
   const { r, g, b } = hexToRgb(hex);
-  const mix = (c: number) => Math.round(c + (255 - c) * amount);
-  return `rgb(${mix(r)}, ${mix(g)}, ${mix(b)})`;
+  const t = Math.max(0, Math.min(1, amount));
+  const mix = (c: number) => Math.round(c + (255 - c) * t);
+  const nr = mix(r);
+  const ng = mix(g);
+  const nb = mix(b);
+  return `#${((1 << 24) | (nr << 16) | (ng << 8) | nb).toString(16).slice(1)}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #7491 that addresses every finding from CodeRabbit and Greptile.

- `ProfileDrawerShell.tsx`: encode spaces in Tailwind arbitrary `calc()` values so `var()` subtraction parses (CodeRabbit Major).
- `color.ts`: clamp `lightenHex` amount to [0,1] and return a hex string to match `darkenHex` and avoid mixed return types (CodeRabbit + Greptile).
- `AboutSection.tsx`: dedupe duplicate genre labels with a running-count key instead of array index (CodeRabbit Minor, Biome clean).
- `profile-drawer-classes.ts` + `ProfileUnifiedDrawer.tsx`: add a visible inset focus ring to drawer list rows so keyboard focus meets WCAG 2.4.11 AA 3:1 contrast (Greptile P2).
- `ProfileInlineNotificationsCTA.tsx`: read `step` from a ref inside the blur-guard `setTimeout` so the collapse logic is resilient to Concurrent Mode effect scheduling (Greptile P2).

Retarget to `main` once #7491 merges.

## Test plan

- [x] `pnpm vitest run artist-notifications-cta/hero-invariants OtpInput.hero` — 8/8 pass
- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm biome check apps/web/components/features/profile/` — 0 warnings
- [ ] Browser verify on `/tim` — bell→email→OTP→name→birthday→done flow + tab focus visible on drawer rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed asynchronous state synchronization in the notification CTA to prevent focus/blur races.

* **Improvements**
  * Better keyboard accessibility: clearer visible focus rings and focus behavior across profile and drawer interfaces.
  * More consistent color handling to ensure reliable color transformations across the site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->