### PR TITLE
fix(ci): clean up production synthetic users

### DIFF
--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -64,6 +64,15 @@ jobs:
           doppler run -- pnpm --filter=@jovie/web exec playwright test tests/e2e/golden-path.spec.ts --project=chromium --reporter=line,json --output=test-results
         continue-on-error: true
 
+      - name: Cleanup Synthetic E2E Users
+        if: always()
+        continue-on-error: true
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_PRD }}
+        run: |
+          cd apps/web
+          doppler run -- pnpm tsx scripts/cleanup-e2e-users.ts --force
+
       - name: Parse test results
         id: test-results
         run: |

--- a/apps/web/tests/e2e/golden-path.spec.ts
+++ b/apps/web/tests/e2e/golden-path.spec.ts
@@ -148,7 +148,9 @@ async function ensureDbUser(clerkUserId: string, email: string) {
     UPDATE creator_profiles
     SET spotify_id = NULL, spotify_url = NULL
     WHERE user_id IN (
-      SELECT id FROM users WHERE email LIKE 'gp-%+clerk_test@test.jovie.com'
+      SELECT id
+      FROM users
+      WHERE email LIKE ${'gp-%+clerk\\_test@test.jovie.com'} ESCAPE ${'\\'}
     ) AND spotify_id IS NOT NULL
   `;
 


### PR DESCRIPTION
## Summary
- add an always-run production cleanup step after synthetic golden-path runs
- escape the literal underscore in the synthetic Clerk test email cleanup query

## Verification
- pnpm --filter @jovie/web exec biome check --write tests/e2e/golden-path.spec.ts
- git diff --check
- pre-push: biome check ., next proxy guard, tailwind check, typecheck, lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automatic cleanup of synthetic test user data after Golden Path end-to-end tests; cleanup runs regardless of test outcomes and won’t fail the job if it encounters errors.

* **Bug Fixes**
  * Improved test user matching in database queries to avoid unintended wildcard interpretation during pattern-based selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->