### PR TITLE
fix(ui): improve dark-mode contrast across releases UI

### DIFF
--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -342,7 +342,9 @@
   /* #969799 — Linear exact */
   --color-text-quaternary-token: #62666d;
   /* Linear: --color-text-quaternary = #62666d (extracted 2026-03-16) */
-  --color-text-disabled-token: oklch(28% 0.006 282);
+  /* JOV-1780: disabled text lifted from oklch(28%) to oklch(45%) so
+     disabled form controls remain legible against page bg `#08090a`. */
+  --color-text-disabled-token: oklch(45% 0.006 282);
   --color-text-tooltip: lch(100% 0 282);
   /* White text on dark tooltips */
 
@@ -354,9 +356,12 @@
      Subtle:  rgba(255,255,255,0.05) — card borders, dividers
      Default: rgba(255,255,255,0.08) — frame borders, input borders
      Strong:  rgba(255,255,255,0.10) — panel outlines */
-  --color-border-subtle: rgba(255, 255, 255, 0.04);
-  --color-border-default: rgba(255, 255, 255, 0.07);
-  --color-border-strong: rgba(255, 255, 255, 0.12);
+  /* JOV-1780: dark-mode border contrast bump so cards, panels, inputs and
+     dividers have clear boundaries against surface-1 `#17171a`. Previous
+     values (0.04 / 0.07 / 0.12) disappeared on dark surfaces. */
+  --color-border-subtle: rgba(255, 255, 255, 0.07);
+  --color-border-default: rgba(255, 255, 255, 0.11);
+  --color-border-strong: rgba(255, 255, 255, 0.18);
   --color-border-focus: #7170ff;
   /* Linear accent for focus */
 
@@ -433,9 +438,11 @@
     rgba(0, 0, 0, 0.2) 0px 0px 12px 0px inset,
     rgba(0, 0, 0, 0.2) 0px 4px 24px 0px;
   --shadow-divider: rgba(255, 255, 255, 0.05) 0px -0.5px 0px 0px inset;
-  /* Popover/dropdown shadow — ring + deep depth for dark backgrounds */
+  /* Popover/dropdown shadow — ring + deep depth for dark backgrounds.
+     JOV-1780: ring opacity lifted 0.06 → 0.12 so menus/popovers have a
+     crisp edge against the app shell in dark mode. */
   --shadow-popover:
-    0 0 0 1px rgba(255, 255, 255, 0.06), 0 8px 24px rgba(0, 0, 0, 0.35);
+    0 0 0 1px rgba(255, 255, 255, 0.12), 0 10px 28px rgba(0, 0, 0, 0.45);
   --shadow-button-inset:
     rgba(0, 0, 0, 0) 0px 8px 2px 0px,
     rgba(0, 0, 0, 0.01) 0px 5px 2px 0px,

--- a/apps/web/styles/linear-tokens.css
+++ b/apps/web/styles/linear-tokens.css
@@ -391,10 +391,12 @@
   --linear-bg-footer: #08090a;
   --linear-border-footer: #2a2a2e;
   --linear-bg-hover: rgba(255, 255, 255, 0.06);
-  /* Borders — extracted 2026-03-17 */
-  --linear-border-subtle: rgba(255, 255, 255, 0.04);
-  --linear-border-default: rgba(255, 255, 255, 0.07);
-  --linear-border-strong: rgba(255, 255, 255, 0.12);
+  /* Borders — JOV-1780: dark-mode contrast bump (prev 0.04/0.07/0.12 blended
+     into surface-1 `#17171a` and page `#08090a`, making cards/panels/inputs
+     edge-less in dark mode). */
+  --linear-border-subtle: rgba(255, 255, 255, 0.07);
+  --linear-border-default: rgba(255, 255, 255, 0.11);
+  --linear-border-strong: rgba(255, 255, 255, 0.18);
   --linear-border-focus: oklch(60% 0.12 282);
   /* Buttons — white primary on dark bg, matching Linear.app */
   --linear-btn-primary-bg: #ffffff;
@@ -425,16 +427,20 @@
   --linear-hero-gradient-to: #8a8f98;
   --linear-separator-from: rgba(255, 255, 255, 0.06);
   --linear-separator-via: rgba(255, 255, 255, 0.03);
-  /* Shadows — deeper on dark */
+  /* Shadows — deeper on dark. JOV-1780: ring bumped from 0.06 → 0.12 so
+     popovers/dropdowns/menus have a clearly visible rim against the app
+     shell in dark mode. */
   --linear-shadow-card: 0px 4px 24px rgba(0, 0, 0, 0.4);
   --linear-shadow-card-elevated:
-    0 0 0 1px rgba(255, 255, 255, 0.06), 0px 8px 40px rgba(0, 0, 0, 0.5);
+    0 0 0 1px rgba(255, 255, 255, 0.12), 0px 8px 40px rgba(0, 0, 0, 0.55);
   --linear-app-content-surface: var(--linear-bg-surface-0);
   /* primary framed main-pane surface */
   --linear-app-card-shadow: none;
-  --linear-app-shell-border: rgba(255, 255, 255, 0.03);
-  --linear-app-shell-sidebar-seam: rgba(255, 255, 255, 0.055);
-  --linear-app-frame-seam: rgba(255, 255, 255, 0.035);
+  /* JOV-1780: panel/frame seams bumped so card & panel boundaries are
+     visible in dark mode (prev 0.03 / 0.035 read as no edge at all). */
+  --linear-app-shell-border: rgba(255, 255, 255, 0.06);
+  --linear-app-shell-sidebar-seam: rgba(255, 255, 255, 0.08);
+  --linear-app-frame-seam: rgba(255, 255, 255, 0.07);
   --linear-app-shell-shadow:
     0 0 0 1px rgba(255, 255, 255, 0.025), 0 14px 36px rgba(0, 0, 0, 0.18);
   --linear-app-sidebar-shadow:


### PR DESCRIPTION
## Summary

Closes [JOV-1780](https://linear.app/jovie/issue/JOV-1780/improve-dark-mode-contrast-across-releases-ui).

Dark-mode border/seam tokens were rendering near-invisible against surface-1 (`#17171a`) and page bg (`#08090a`), so releases-UI cards, panels, inputs, and floating menus looked edgeless. Bumped token opacities centrally in `linear-tokens.css` + `design-system.css` so every downstream surface gains a clearer boundary — no per-component `className` churn.

### Tokens changed (dark mode only)

- `--linear-border-subtle/default/strong`: `0.04 / 0.07 / 0.12` → `0.07 / 0.11 / 0.18`
- `--color-border-subtle/default/strong`: mirrored bump
- `--linear-app-shell-border`: `0.03` → `0.06`
- `--linear-app-shell-sidebar-seam`: `0.055` → `0.08`
- `--linear-app-frame-seam`: `0.035` → `0.07`
- `--linear-shadow-card-elevated` ring: `0.06` → `0.12` (popover/menu rim)
- `--shadow-popover` ring: `0.06` → `0.12` (dropdown/popover rim)
- `--color-text-disabled-token`: `oklch(28%)` → `oklch(45%)` for legible disabled controls

### Surfaces affected

- Release list rows & grouped containers (card borders visible)
- Release detail panel cards (ReleaseFields, ReleaseMetadata, ReleasePitchSection, ReleaseLyricsSection, ReleaseDspLinks, TrackSidebar)
- Inputs / select triggers (`--linear-border-subtle` is the default input border)
- Dropdown menus & popovers (ring lifted → clear elevation from background)
- Disabled form controls now readable

### Not touched

- Selected-row treatment (owned by #7486) — untouched, verified via
  existing unit snapshots.
- `release-sidebar/index.*` / tab-container composition (JOV-1778 owner).

## Test plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [x] `vitest run tests/unit/app/surface-elevation-guardrails` + `internal-shell-surface-guard` + `DrawerSurfaceCard` (18 tests)
- [x] `vitest run tests/components/organisms/release-sidebar tests/components/dashboard/organisms/releases` (66 tests)
- [ ] Visual QA in dark mode on staging: releases list, detail panel cards, Display popover, DSP dropdowns, disabled inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode design tokens with improved border contrast for subtle, default, and strong variants.
  * Increased shadow depth and visibility for elevated UI elements.
  * Refined app interface seams and borders for better visual separation and definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->