### PR TITLE
style(design): polish dashboard + admin + settings pages

### DIFF
--- a/apps/web/app/app/(shell)/admin/platform-connections/PlatformConnectionsClient.tsx
+++ b/apps/web/app/app/(shell)/admin/platform-connections/PlatformConnectionsClient.tsx
@@ -202,7 +202,9 @@ function SpotifyTabContent({
               'Not set'}
           </p>
           <p className='mt-1 text-[12px] text-tertiary-token'>
-            Updated {formatDate(spotifyStatus.updatedAt)}
+            {spotifyStatus.updatedAt
+              ? `Updated ${formatDate(spotifyStatus.updatedAt)}`
+              : 'Never updated'}
           </p>
         </div>
         <div>

--- a/apps/web/app/app/(shell)/settings/contacts/ContactsContent.tsx
+++ b/apps/web/app/app/(shell)/settings/contacts/ContactsContent.tsx
@@ -15,11 +15,7 @@ export function ContactsContent() {
   }
 
   return (
-    <SettingsSection
-      id='contacts'
-      title='Contacts'
-      description='Manage bookings, management, and press contacts.'
-    >
+    <SettingsSection id='contacts' title='Contacts'>
       <SettingsContactsSection artist={artist} />
     </SettingsSection>
   );

--- a/apps/web/components/features/admin/ActivityTableUnified.tsx
+++ b/apps/web/components/features/admin/ActivityTableUnified.tsx
@@ -9,10 +9,7 @@ import {
   PAGE_TOOLBAR_META_TEXT_CLASS,
   UnifiedTable,
 } from '@/components/organisms/table';
-import {
-  AdminTableHeader,
-  AdminTableSubheader,
-} from '@/features/admin/table/AdminTableHeader';
+import { AdminTableSubheader } from '@/features/admin/table/AdminTableHeader';
 import type { AdminActivityItem, AdminActivityStatus } from '@/lib/admin/types';
 import { TABLE_MIN_WIDTHS } from '@/lib/constants/layout';
 
@@ -127,10 +124,6 @@ export function ActivityTableUnified({
       className='h-full border-0 bg-(--linear-app-content-surface)'
       data-testid='admin-activity-content'
     >
-      <AdminTableHeader
-        title='Activity'
-        subtitle='Monitor operational actions and recent system outcomes.'
-      />
       <AdminTableSubheader
         start={<p className={PAGE_TOOLBAR_META_TEXT_CLASS}>Last 7 days.</p>}
       />

--- a/apps/web/components/features/dashboard/organisms/SettingsAdPixelsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsAdPixelsSection.tsx
@@ -419,8 +419,8 @@ export function SettingsAdPixelsSection({
         <div className='px-4 py-4 sm:px-5'>
           <SettingsToggleRow
             gated
-            title='Pixel tracking'
-            description='Integrate Facebook, Google, and TikTok conversion tracking pixels.'
+            title='Enable pixel tracking'
+            description='Route fan actions to your Facebook, Google, and TikTok pixels for conversion tracking.'
             gateFeatureContext='Pixel tracking'
           />
         </div>

--- a/apps/web/components/features/dashboard/tasks/TasksUpgradeInterstitial.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksUpgradeInterstitial.tsx
@@ -71,7 +71,7 @@ export function TasksWorkspaceUpgradeInterstitial() {
     <PageShell data-testid='tasks-upgrade-interstitial'>
       <section className='flex min-h-0 flex-1 items-center justify-center px-6 py-6'>
         <TasksUpgradeContent
-          heading='Upgrade To Access Tasks'
+          heading='Upgrade to access Tasks'
           description='Upgrade to turn releases into step-by-step plans and manage all of your work in one task workspace.'
           secondaryHref={APP_ROUTES.DASHBOARD_RELEASES}
           secondaryLabel='Back to Releases'

--- a/apps/web/components/organisms/ErrorBoundary.tsx
+++ b/apps/web/components/organisms/ErrorBoundary.tsx
@@ -18,7 +18,7 @@ export default function ErrorBoundary({
   error,
   reset,
   context,
-  message = 'Something went wrong. Try again?',
+  message = "We couldn't load this page. Give it another try, or head home.",
 }: ErrorBoundaryProps) {
   const router = useRouter();
 

--- a/apps/web/tests/unit/ErrorBoundary.test.tsx
+++ b/apps/web/tests/unit/ErrorBoundary.test.tsx
@@ -53,7 +53,9 @@ describe('ErrorBoundary', () => {
 
       expect(screen.getByText('Something went wrong')).toBeInTheDocument();
       expect(
-        screen.getByText(/Something went wrong\. Try again\?/)
+        screen.getByText(
+          "We couldn't load this page. Give it another try, or head home."
+        )
       ).toBeInTheDocument();
     });
 

--- a/packages/ui/atoms/alert-dialog.test.tsx
+++ b/packages/ui/atoms/alert-dialog.test.tsx
@@ -233,7 +233,10 @@ describe('AlertDialog', () => {
     it('supports variant prop', () => {
       render(<TestAlertDialog open={true} actionVariant='destructive' />);
       const action = screen.getByTestId('alert-dialog-action');
-      expect(action.className).toContain('destructive');
+      expect(action.className).toContain('bg-[var(--color-error)]');
+      expect(action.className).toContain(
+        'text-[var(--color-error-foreground)]'
+      );
     });
   });
 

--- a/packages/ui/atoms/button.tsx
+++ b/packages/ui/atoms/button.tsx
@@ -22,7 +22,7 @@ const buttonVariants = cva(
           'border border-default bg-transparent hover:bg-surface-hover active:bg-interactive-active',
         // Destructive variant
         destructive:
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+          'bg-[var(--color-error)] text-[var(--color-error-foreground)] hover:opacity-90',
         // Link variant
         link: 'text-primary underline-offset-4 hover:underline p-0 h-auto',
         // Frosted glass variants (glassmorphism) - using design tokens


### PR DESCRIPTION
## Summary

Design-review sweep of all dashboard, admin, and settings pages — 58 routes total (including redirect stubs). Fixed drift and one app-wide bug.

### Fixes (commit order)

- **`style(design)`** `/app/dashboard/tasks` — title-case typo "Upgrade **To** Access Tasks" → "Upgrade **to** access Tasks"
- **`fix(admin)`** `/app/admin/activity` — removed duplicate "Activity" header (`AdminWorkspacePage` + inner `AdminTableHeader` both rendered title+description)
- **`fix(admin)`** `/app/admin/platform-connections` — "Updated Never" (template rendering `Updated {formatDate(null)}`) → "Never updated" when no timestamp
- **`fix(ui)`** `ErrorBoundary` — heading "Something went wrong" + default body "Something went wrong. Try again?" were near-identical. New body: "We couldn't load this page. Give it another try, or head home."
- **`fix(settings)`** `/app/settings/audience` — duplicate "Pixel tracking / Integrate Facebook, Google, and TikTok..." appeared twice (panel header + row header). Row now: "Enable pixel tracking / Route fan actions to your Facebook, Google, and TikTok pixels..."
- **`fix(settings)`** `/app/settings/contacts` — page subtitle echoed the inner "Team contacts" subtitle; kept the more specific one
- **`fix(ui)`** 🔴 **Destructive `<Button variant='destructive'>` was rendering transparent** — `bg-destructive` / `text-destructive-foreground` Tailwind classes weren't defined as theme colors. Swapped to `bg-[var(--color-error)] text-[var(--color-error-foreground)] hover:opacity-90` using the design-system tokens that ARE defined. Affects **every destructive button app-wide** (most visibly the Delete account button, which was invisible).

### Pages without changes

Most pages reviewed clean — the admin/dashboard/settings design system is already solid. The destructive-button regression is the biggest find and is the reason it's worth merging.

## Test plan

- [ ] Visit `/app/settings/data-privacy` — "Delete account" button is now a visible red destructive button
- [ ] Visit `/app/admin/activity` — only one "Activity" header
- [ ] Visit `/app/admin/platform-connections` — says "Never updated" (not "Updated Never") when no timestamp
- [ ] Visit `/app/settings/audience` — Pixel tracking section heading + row label are no longer duplicated
- [ ] Visit `/app/settings/contacts` — page has one subtitle, not two
- [ ] Visit `/app/dashboard/tasks` (non-Pro) — heading is "Upgrade to access Tasks"
- [ ] Spot-check any destructive confirmation dialog in the app — button still reads as destructive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Spotify publisher metadata now shows "Never updated" when no timestamp

* **Copy & UX**
  * Clearer default error message
  * Pixel tracking description revised for clarity
  * Adjusted capitalization in upgrade prompt
  * Removed contacts section description

* **UI**
  * Removed redundant table header from Activity feed
  * Refined destructive button styling using theme variables
<!-- end of auto-generated comment: release notes by coderabbit.ai -->