### PR TITLE
fix(deps): clear Vercel audit advisories

### DIFF
--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -658,7 +658,7 @@ export default async function ArtistPage({
     tourDatesPromise.catch(() => [] as TourDateViewModel[]),
     releasesPromise,
   ]);
-  const tourDates = tourDatesRaw.toSorted(
+  const tourDates = [...tourDatesRaw].sort(
     (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
   );
 

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskPage.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskPage.tsx
@@ -22,8 +22,8 @@ function getUpNextTasks(tasks: ReleaseTaskView[]): ReleaseTaskView[] {
   );
 
   // Sort by due date (nearest first), then by position (template order)
-  return incomplete
-    .toSorted((a, b) => {
+  return [...incomplete]
+    .sort((a, b) => {
       // Tasks with due dates come first
       if (a.dueDate && !b.dueDate) return -1;
       if (!a.dueDate && b.dueDate) return 1;

--- a/apps/web/lib/leads/url-intake.ts
+++ b/apps/web/lib/leads/url-intake.ts
@@ -88,7 +88,7 @@ function normalizeUrl(rawUrl: string): string | null {
 function deriveHandleFromUrl(url: string): string | null {
   try {
     const parsed = new URL(url);
-    const pathSegment = parsed.pathname.split('/').findLast(Boolean);
+    const pathSegment = parsed.pathname.split('/').filter(Boolean).pop();
     const fallback = `${parsed.hostname}-${pathSegment ?? 'profile'}`;
     const normalized = fallback
       .toLowerCase()

--- a/package.json
+++ b/package.json
@@ -48,7 +48,11 @@
       "qs": "6.15.0",
       "@vercel/microfrontends": "2.3.2",
       "follow-redirects": "1.16.0",
-      "@clerk/ui>@floating-ui/react": "0.27.19"
+      "@clerk/ui>@floating-ui/react": "0.27.19",
+      "tar": "7.5.13",
+      "@tootallnate/once": "3.0.1",
+      "smol-toml": "1.6.1",
+      "srvx": "0.11.13"
     },
     "patchedDependencies": {
       "eslint-plugin-react@7.37.5": "patches/eslint-plugin-react@7.37.5.patch"
@@ -109,7 +113,7 @@
     "tsx": "^4.21.0",
     "turbo": "^2.9.6",
     "typescript": "^6.0.2",
-    "vercel": "51.8.0",
+    "vercel": "52.0.0",
     "vitest": "4.1.4"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,10 @@ overrides:
   '@vercel/microfrontends': 2.3.2
   follow-redirects: 1.16.0
   '@clerk/ui>@floating-ui/react': 0.27.19
+  tar: 7.5.13
+  '@tootallnate/once': 3.0.1
+  smol-toml: 1.6.1
+  srvx: 0.11.13
 
 patchedDependencies:
   eslint-plugin-react@7.37.5:
@@ -93,8 +97,8 @@ importers:
         specifier: ^6.0.2
         version: 6.0.2
       vercel:
-        specifier: 51.8.0
-        version: 51.8.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)
+        specifier: 52.0.0
+        version: 52.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)
       vitest:
         specifier: 4.1.4
         version: 4.1.4(@edge-runtime/vm@3.2.0)(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(msw@2.12.4(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.9(@types/node@25.5.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -4835,8 +4839,8 @@ packages:
     resolution: {integrity: sha512-GgdKez5AaQRIm0kFNp7BZnxFQ2F7LZ7g3rOQ/v11oYZR3jhH7JPGM+7hZQjYqFXD/5TK/of7hepu418K2fghvg==}
     engines: {node: '>=12.4.0'}
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+  '@tootallnate/once@3.0.1':
+    resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
     engines: {node: '>= 10'}
 
   '@tootallnate/quickjs-emscripten@0.23.0':
@@ -5402,8 +5406,8 @@ packages:
       vue-router:
         optional: true
 
-  '@vercel/backends@0.1.2':
-    resolution: {integrity: sha512-hkE5QpbueWYVZqbolsqR6s+3uSxSvrzSZqoJhM/TzF2BSzwrjZvYjckrppopPFezYu14h5rkxUsLXsjnTVWGLQ==}
+  '@vercel/backends@0.2.0':
+    resolution: {integrity: sha512-7J0nJCd7h29CXG0jeejS8DnI4qAF96Fo6qibAPG7nbbJ5v0ZpWZhzeL8XwvvT3du6S50bRGcQCPJQNcShw6pEQ==}
     peerDependencies:
       typescript: ^4.0.0 || ^5.0.0
 
@@ -5415,11 +5419,11 @@ packages:
     resolution: {integrity: sha512-6f9oWC+DbWxIgBLOdqjjn2/REpFrPDB7y5B5HA1ptYkzZaBgL6E34kWrptJvJ7teApJdbAs3I1a5A7z1y8SDHw==}
     engines: {node: '>=20.0.0'}
 
-  '@vercel/build-utils@13.19.1':
-    resolution: {integrity: sha512-TRb8x9MuRrBYx7SjwW4hGnEMTnEPDk/jCQRjziS7AkPj0ahayqYlSjoZG3AWKc5NLOwulLekGbhQXUMRAdaA/A==}
+  '@vercel/build-utils@13.20.0':
+    resolution: {integrity: sha512-Jd29k42KSCRKOs+oSSVthw4xSjZBK3pUDG6AZl95/TsvIDNwRkjI2Nvs1ZcYDJdeLR346PQdWReFJGqkf/tb6A==}
 
-  '@vercel/cervel@0.0.54':
-    resolution: {integrity: sha512-VHIfHr+5YaKdQAy/tatHlU0PnBzwEkHpWCje5f65gi0vd2Ti9d39jL/80q6PYeiFFlhExOrC7YfO87uHOLjsHg==}
+  '@vercel/cervel@0.0.55':
+    resolution: {integrity: sha512-uRisWx/d5goDEKx9eVpDjT4LA65FsOmDRw65ZMqkFZJbeX496ss37g1+/yiVBrQ0+35RcTYB9K1i8JAMFqv57w==}
     hasBin: true
     peerDependencies:
       typescript: ^4.0.0 || ^5.0.0
@@ -5428,17 +5432,17 @@ packages:
     resolution: {integrity: sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==}
     engines: {node: '>=14'}
 
-  '@vercel/elysia@0.1.70':
-    resolution: {integrity: sha512-UJaXenUsn45b1hrMTs/zAl/OiXPuzj5UzoYXaLf/04rPqvRT6HU9qWYsBpQjtkJgYLg4HB+M1xhv1EKOz1EKWg==}
+  '@vercel/elysia@0.1.71':
+    resolution: {integrity: sha512-YTEIX6hfpgg71D/45QyYGLj/wXUjnvfbbNWOgbnmWs9B2yWeZzWFysp6umVg99bvvyxgaPfes9I0MQbqNMvIgA==}
 
   '@vercel/error-utils@2.0.3':
     resolution: {integrity: sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==}
 
-  '@vercel/express@0.1.80':
-    resolution: {integrity: sha512-noHMleNoodWYlTNZE5hnC1m4Llt2KsK06/8aRM22kWVItmdRg9D63obTBTs14/N6IIrj0qyzt8YMvv4oHNg7XQ==}
+  '@vercel/express@0.1.81':
+    resolution: {integrity: sha512-Y7J5L7jdiJ/3ojo0SO2OVINCN4+CzST0kW9SXLCB75oNajwZ0wFsUSp/x5PqjDtJ2WU9QDIXO7qBhjrRkaEK4Q==}
 
-  '@vercel/fastify@0.1.73':
-    resolution: {integrity: sha512-BGMg/KuTXQX0DHPgSNCMK7Msfcltdlc/H6NyxDOg6yVhw8ITOhv541YnDD4ogBEvqM1qDA1UPQqb47GfQJMvkw==}
+  '@vercel/fastify@0.1.74':
+    resolution: {integrity: sha512-CjjuHKysQs41MJOWHVGXyiZvhLQBzAe5KRamXgs4Tn0lNztQh/tY0TlB8Qtty8+R2c5I4l0EnNCSxQ3a/Nayxg==}
 
   '@vercel/fun@1.3.0':
     resolution: {integrity: sha512-8erw9uPe0dFg45THkNxmjtvMX143SkZebmjgSVbcM3XCkXu3RIiBaJMcMNG8aaS+rnTuw8+d4De9HVT0M/r3wg==}
@@ -5447,23 +5451,23 @@ packages:
   '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
     resolution: {integrity: sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==}
 
-  '@vercel/gatsby-plugin-vercel-builder@2.1.20':
-    resolution: {integrity: sha512-smLWjyPK/9dx0KzRktrqvTBDmA5198a7pju80xgt5DA9ffCwPqPNWfRCEHiCf+20eGtkqn+nlaeA5KBBl0NOVQ==}
+  '@vercel/gatsby-plugin-vercel-builder@2.1.21':
+    resolution: {integrity: sha512-QHsoUoiLaUBq6px9oNUtTh2M/Ba1lNa3fVvEU70gY3PkzVlEf20tS/g04lEnBhtqMCSMJgziO8/Ql058pcppFA==}
 
   '@vercel/go@3.5.0':
     resolution: {integrity: sha512-xMHQLqQiEfK+YJlC5eJ4S/1E4fBEUAf1u2DwQYsZlS3rLlHVqTOcZ973Z+wZV5pr4/d3vvpgB4/GQ0eqdig0jw==}
 
-  '@vercel/h3@0.1.79':
-    resolution: {integrity: sha512-9dHqIr7qNA43GxPW+gWKu1H+jfNVb67w+a28x5bgc/Ienf5t9o618zNWT1w78C86nwHFlK1b/F/kj+LXFhcKuQ==}
+  '@vercel/h3@0.1.80':
+    resolution: {integrity: sha512-Vu+l1qXjD9P8P5rnLKGRaSbKkbBnxc2in+zHN7tD0vWxLcpecrPKnAgbVozT37LDvpT5I38aXQIFMKokjCQfAw==}
 
-  '@vercel/hono@0.2.73':
-    resolution: {integrity: sha512-Lf9iPD1fOK2lv2PX2u5MQEID/FMQyK24qDZFyB56jzEaCWt7Qlihc2uCh2g/ONMPk7DlS4Gw/lHA9VkLP+VjKQ==}
+  '@vercel/hono@0.2.74':
+    resolution: {integrity: sha512-NWOEeb3Vg8d9Y5/wnjajdPzXrrImGoSds/PkqQK802mzR9/8svdFhe1qnqSxzM6e3Y2iID0DJxhnZjVjowkOcQ==}
 
   '@vercel/hydrogen@1.3.6':
     resolution: {integrity: sha512-Ec8dKEjGIM4BfThcRLtQs5zaJ4+iJbgLZwkytwi7Blk8VrK6W2F1dtLDmVQYZdVnQcnmHmTx8mxUuMkfP06Mnw==}
 
-  '@vercel/koa@0.1.53':
-    resolution: {integrity: sha512-vVIQ1zV9f73+Ltr7sWO+uFz6X8KWFT6v1ptjY0l9YE0OZWOY+NPRy0+6n/BFrlE9BWUuWq816Nv5EKqS88/TeQ==}
+  '@vercel/koa@0.1.54':
+    resolution: {integrity: sha512-fUNQ6Wwp8gGT2KnoUH5Xv74eatFjza0cWwj60vY7zdymoNbuVNDBRLxFGiMUHl/wItzYuQIhPoaEeGiiYcuMDw==}
 
   '@vercel/microfrontends@2.3.2':
     resolution: {integrity: sha512-XwG9KrPmRXVIe2MzH+sPJscskk12m7qVPUVM7ehdod5c1HbTtwnuncK4B6KNitBpSL+2C5uRQP0/rUaBq/HLPQ==}
@@ -5492,8 +5496,8 @@ packages:
       vite:
         optional: true
 
-  '@vercel/nestjs@0.2.74':
-    resolution: {integrity: sha512-mE1C+RFWpwtF7erTiwLuL32lnLBg+xlH57JgmSS0JKXKMTZAWKJgbKC/ya06O9ChXB5PYdSowjVvLk/oGqGj0A==}
+  '@vercel/nestjs@0.2.75':
+    resolution: {integrity: sha512-0wTm/Yp15Z3tvu8OFEvzQjXyC7R/77mGQ3vKn61LNxxxGztL2m0N+F2oIciEiIaHYszct3TbEkA6bUbUFBGDLA==}
 
   '@vercel/next@4.16.8':
     resolution: {integrity: sha512-buiiOH7t8afdBHcF9vdIZ9z4LwA5hcTS9AUq6UlSY7qbKeeRUIgSVdz8QrYNvHhKMj/CAaTB92C/k25u9U9Muw==}
@@ -5503,8 +5507,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@vercel/node@5.7.12':
-    resolution: {integrity: sha512-ClU5ttdwMUr+IC43nNdRhHQR9XnIaF1SNUSJ0IrTQvqXt9ItLvS1zEDRF83VPLVFs4Rd6WtSB2kcGGsRzHjcEw==}
+  '@vercel/node@5.7.13':
+    resolution: {integrity: sha512-IbGplZ0lAvk6D4scBENKRLOjVbLa3knA3nDJL/1tmcy32UeWRdumo/YpoNMYo3Eg6y6uLtI1ajwpnQJsfzUtjg==}
 
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
@@ -5520,8 +5524,8 @@ packages:
   '@vercel/python-analysis@0.11.0':
     resolution: {integrity: sha512-gsoj+nscmNm0xDh+tRhECRhit2VlAVaD7jc9h93sN6rDEBDxPo7eLEgIJFzVDaAItxERZ9Od2IK/04fB9vFy+g==}
 
-  '@vercel/python@6.35.0':
-    resolution: {integrity: sha512-BpJ0+jrufofKQqt2lK7zIW4/ll3b4H8hzMnX7cchE1jbTIyywpIUdr4c9hCxLIfjw6j+NWx2Kew6kisRFyzHxQ==}
+  '@vercel/python@6.36.0':
+    resolution: {integrity: sha512-GLCX2JV2zfjGoSaANWi6gfL1z1IO02ulFhDOGYlOwBmVb1qQFLLssTnbN5uDO5heWm5Owi2/eqBG+l2E7TXiVQ==}
 
   '@vercel/redwood@2.4.12':
     resolution: {integrity: sha512-8kJ7eEerI4iMpKVRxQCsnxiIwRVsWtyirEbYb4erCqqsJymTu/xrjhsfAUuzeP8qkuYGP82MJVK+hpKlFtsjGw==}
@@ -5561,8 +5565,8 @@ packages:
       vue-router:
         optional: true
 
-  '@vercel/static-build@2.9.20':
-    resolution: {integrity: sha512-jE0aG9GswRUwXor2CJunUP15Au5XJEpmbwLlnDhOUruMvjVA3nyAmbHGznzBn0n+PjhopXwehiyFazIJUwKWdg==}
+  '@vercel/static-build@2.9.21':
+    resolution: {integrity: sha512-LnaroK/z97iAwg0vNHECQHAm2oaFLSWiKqCZIETnv5RpIqDXgj/URBD8v+DNNSXWGXsYOk7ezLRuQnlpq3Jx5w==}
 
   '@vercel/static-config@3.2.0':
     resolution: {integrity: sha512-UpOEIgWxWx0M+mDe1IMdHS6JuWM/L5nNIJ4ixX8v9JgBAejymo88OkgnmfLCNMem0Wd+b5vcQPWLdZybCndlsA==}
@@ -6637,9 +6641,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cookie-es@2.0.1:
-    resolution: {integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==}
 
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
@@ -11042,10 +11043,6 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  smol-toml@1.5.2:
-    resolution: {integrity: sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==}
-    engines: {node: '>= 18'}
-
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
@@ -11101,8 +11098,8 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  srvx@0.8.9:
-    resolution: {integrity: sha512-wYc3VLZHRzwYrWJhkEqkhLb31TI0SOkfYZDkUhXdp3NoCnNS0FqajiQszZZjfow/VYEuc6Q5sZh9nM6kPy2NBQ==}
+  srvx@0.11.13:
+    resolution: {integrity: sha512-oknN6qduuMPafxKtHucUeG32Q963pjriA5g3/Bl05cwEsUe5VVbIU4qR9LrALHbipSCyBe+VmfDGGydqazDRkw==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -11397,11 +11394,6 @@ packages:
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
-
-  tar@7.5.7:
-    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
-    engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -11882,8 +11874,8 @@ packages:
       react: 19.2.4
       react-dom: 19.2.4
 
-  vercel@51.8.0:
-    resolution: {integrity: sha512-0NVtnfF/7y2b/lEh3MFDpsaSkxdTQEbs58ORJT2orixPDyu67tq/6THvds269JguMWpQui4h7BedYunZXy7d3A==}
+  vercel@52.0.0:
+    resolution: {integrity: sha512-yLQn/wrGWVjvoCKQJuqi+aZvy+yYNDY9tSWiq6sH3LlTZ8zdEIHS7hB07TTsYTLQQWb55rW0h5d05QPExMVcSA==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -16771,7 +16763,7 @@ snapshots:
 
   '@tinyhttp/url@1.3.0': {}
 
-  '@tootallnate/once@2.0.0': {}
+  '@tootallnate/once@3.0.1': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
@@ -17374,9 +17366,9 @@ snapshots:
       next: 16.2.4(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
-  '@vercel/backends@0.1.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)':
+  '@vercel/backends@0.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)':
     dependencies:
-      '@vercel/build-utils': 13.19.1
+      '@vercel/build-utils': 13.20.0
       '@vercel/nft': 1.5.0(rollup@4.60.1)
       '@yarnpkg/parsers': 3.0.3
       execa: 3.2.0
@@ -17386,7 +17378,7 @@ snapshots:
       path-to-regexp: 8.4.2
       resolve.exports: 2.0.3
       rolldown: 1.0.0-rc.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      srvx: 0.8.9
+      srvx: 0.11.13
       tsx: 4.21.0
       typescript: 6.0.2
       zod: 3.22.4
@@ -17413,15 +17405,15 @@ snapshots:
       throttleit: 2.1.0
       undici: 6.24.1
 
-  '@vercel/build-utils@13.19.1':
+  '@vercel/build-utils@13.20.0':
     dependencies:
       '@vercel/python-analysis': 0.11.0
       cjs-module-lexer: 1.2.3
       es-module-lexer: 1.5.0
 
-  '@vercel/cervel@0.0.54(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)':
+  '@vercel/cervel@0.0.55(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)':
     dependencies:
-      '@vercel/backends': 0.1.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)
+      '@vercel/backends': 0.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)
       typescript: 6.0.2
     transitivePeerDependencies:
       - '@emnapi/core'
@@ -17432,9 +17424,9 @@ snapshots:
 
   '@vercel/detect-agent@1.2.3': {}
 
-  '@vercel/elysia@0.1.70(rollup@4.60.1)':
+  '@vercel/elysia@0.1.71(rollup@4.60.1)':
     dependencies:
-      '@vercel/node': 5.7.12(rollup@4.60.1)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
     transitivePeerDependencies:
       - encoding
@@ -17443,11 +17435,11 @@ snapshots:
 
   '@vercel/error-utils@2.0.3': {}
 
-  '@vercel/express@0.1.80(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)':
+  '@vercel/express@0.1.81(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)':
     dependencies:
-      '@vercel/cervel': 0.0.54(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)
+      '@vercel/cervel': 0.0.55(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)
       '@vercel/nft': 1.5.0(rollup@4.60.1)
-      '@vercel/node': 5.7.12(rollup@4.60.1)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
       fs-extra: 11.1.0
       path-to-regexp: 8.4.2
@@ -17461,9 +17453,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vercel/fastify@0.1.73(rollup@4.60.1)':
+  '@vercel/fastify@0.1.74(rollup@4.60.1)':
     dependencies:
-      '@vercel/node': 5.7.12(rollup@4.60.1)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
     transitivePeerDependencies:
       - encoding
@@ -17472,7 +17464,7 @@ snapshots:
 
   '@vercel/fun@1.3.0':
     dependencies:
-      '@tootallnate/once': 2.0.0
+      '@tootallnate/once': 3.0.1
       async-listen: 1.2.0
       debug: 4.3.4
       generic-pool: 3.4.2
@@ -17484,7 +17476,7 @@ snapshots:
       semver: 7.5.4
       stat-mode: 0.3.0
       stream-to-promise: 2.2.0
-      tar: 7.5.7
+      tar: 7.5.13
       tinyexec: 0.3.2
       tree-kill: 1.2.2
       uid-promise: 1.0.0
@@ -17498,29 +17490,29 @@ snapshots:
     dependencies:
       web-vitals: 0.2.4
 
-  '@vercel/gatsby-plugin-vercel-builder@2.1.20':
+  '@vercel/gatsby-plugin-vercel-builder@2.1.21':
     dependencies:
       '@sinclair/typebox': 0.25.24
-      '@vercel/build-utils': 13.19.1
+      '@vercel/build-utils': 13.20.0
       esbuild: 0.28.0
       etag: 1.8.1
       fs-extra: 11.1.0
 
   '@vercel/go@3.5.0': {}
 
-  '@vercel/h3@0.1.79(rollup@4.60.1)':
+  '@vercel/h3@0.1.80(rollup@4.60.1)':
     dependencies:
-      '@vercel/node': 5.7.12(rollup@4.60.1)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/hono@0.2.73(rollup@4.60.1)':
+  '@vercel/hono@0.2.74(rollup@4.60.1)':
     dependencies:
       '@vercel/nft': 1.5.0(rollup@4.60.1)
-      '@vercel/node': 5.7.12(rollup@4.60.1)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
       fs-extra: 11.1.0
       path-to-regexp: 8.4.2
@@ -17536,9 +17528,9 @@ snapshots:
       '@vercel/static-config': 3.2.0
       ts-morph: 12.0.0
 
-  '@vercel/koa@0.1.53(rollup@4.60.1)':
+  '@vercel/koa@0.1.54(rollup@4.60.1)':
     dependencies:
-      '@vercel/node': 5.7.12(rollup@4.60.1)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
     transitivePeerDependencies:
       - encoding
@@ -17569,9 +17561,9 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@vercel/nestjs@0.2.74(rollup@4.60.1)':
+  '@vercel/nestjs@0.2.75(rollup@4.60.1)':
     dependencies:
-      '@vercel/node': 5.7.12(rollup@4.60.1)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
     transitivePeerDependencies:
       - encoding
@@ -17605,13 +17597,13 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/node@5.7.12(rollup@4.60.1)':
+  '@vercel/node@5.7.13(rollup@4.60.1)':
     dependencies:
       '@edge-runtime/node-utils': 2.3.0
       '@edge-runtime/primitives': 4.1.0
       '@edge-runtime/vm': 3.2.0
       '@types/node': 20.11.0
-      '@vercel/build-utils': 13.19.1
+      '@vercel/build-utils': 13.20.0
       '@vercel/error-utils': 2.0.3
       '@vercel/nft': 1.5.0(rollup@4.60.1)
       '@vercel/static-config': 3.2.0
@@ -17647,10 +17639,10 @@ snapshots:
       fs-extra: 11.1.1
       js-yaml: 4.1.1
       minimatch: 10.2.4
-      smol-toml: 1.5.2
+      smol-toml: 1.6.1
       zod: 3.22.4
 
-  '@vercel/python@6.35.0':
+  '@vercel/python@6.36.0':
     dependencies:
       '@vercel/python-analysis': 0.11.0
 
@@ -17683,7 +17675,7 @@ snapshots:
   '@vercel/rust@1.1.1':
     dependencies:
       execa: 5.1.1
-      smol-toml: 1.5.2
+      smol-toml: 1.6.1
 
   '@vercel/sandbox@1.9.0':
     dependencies:
@@ -17706,10 +17698,10 @@ snapshots:
       react: 19.2.4
     optional: true
 
-  '@vercel/static-build@2.9.20':
+  '@vercel/static-build@2.9.21':
     dependencies:
       '@vercel/gatsby-plugin-vercel-analytics': 1.0.11
-      '@vercel/gatsby-plugin-vercel-builder': 2.1.20
+      '@vercel/gatsby-plugin-vercel-builder': 2.1.21
       '@vercel/static-config': 3.2.0
       ts-morph: 12.0.0
 
@@ -19023,8 +19015,6 @@ snapshots:
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
-
-  cookie-es@2.0.1: {}
 
   cookie-signature@1.0.7: {}
 
@@ -24730,8 +24720,6 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  smol-toml@1.5.2: {}
-
   smol-toml@1.6.1: {}
 
   socks-proxy-agent@8.0.5:
@@ -24784,9 +24772,7 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  srvx@0.8.9:
-    dependencies:
-      cookie-es: 2.0.1
+  srvx@0.11.13: {}
 
   stable-hash@0.0.5: {}
 
@@ -25144,14 +25130,6 @@ snapshots:
       - react-native-b4a
 
   tar@7.5.13:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-
-  tar@7.5.7:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -25656,31 +25634,31 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  vercel@51.8.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2):
+  vercel@52.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2):
     dependencies:
-      '@vercel/backends': 0.1.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)
+      '@vercel/backends': 0.2.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)
       '@vercel/blob': 2.3.0
-      '@vercel/build-utils': 13.19.1
+      '@vercel/build-utils': 13.20.0
       '@vercel/detect-agent': 1.2.3
-      '@vercel/elysia': 0.1.70(rollup@4.60.1)
-      '@vercel/express': 0.1.80(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)
-      '@vercel/fastify': 0.1.73(rollup@4.60.1)
+      '@vercel/elysia': 0.1.71(rollup@4.60.1)
+      '@vercel/express': 0.1.81(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(rollup@4.60.1)(typescript@6.0.2)
+      '@vercel/fastify': 0.1.74(rollup@4.60.1)
       '@vercel/fun': 1.3.0
       '@vercel/go': 3.5.0
-      '@vercel/h3': 0.1.79(rollup@4.60.1)
-      '@vercel/hono': 0.2.73(rollup@4.60.1)
+      '@vercel/h3': 0.1.80(rollup@4.60.1)
+      '@vercel/hono': 0.2.74(rollup@4.60.1)
       '@vercel/hydrogen': 1.3.6
-      '@vercel/koa': 0.1.53(rollup@4.60.1)
-      '@vercel/nestjs': 0.2.74(rollup@4.60.1)
+      '@vercel/koa': 0.1.54(rollup@4.60.1)
+      '@vercel/nestjs': 0.2.75(rollup@4.60.1)
       '@vercel/next': 4.16.8(rollup@4.60.1)
-      '@vercel/node': 5.7.12(rollup@4.60.1)
+      '@vercel/node': 5.7.13(rollup@4.60.1)
       '@vercel/prepare-flags-definitions': 0.2.1
-      '@vercel/python': 6.35.0
+      '@vercel/python': 6.36.0
       '@vercel/redwood': 2.4.12(rollup@4.60.1)
       '@vercel/remix-builder': 5.7.2(rollup@4.60.1)
       '@vercel/ruby': 2.3.2
       '@vercel/rust': 1.1.1
-      '@vercel/static-build': 2.9.20
+      '@vercel/static-build': 2.9.21
       chokidar: 4.0.0
       esbuild: 0.28.0
       form-data: 4.0.5
@@ -25688,7 +25666,7 @@ snapshots:
       luxon: 3.7.2
       proxy-agent: 6.4.0
       sandbox: 2.5.6
-      smol-toml: 1.5.2
+      smol-toml: 1.6.1
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'


### PR DESCRIPTION
## Summary
- update the Vercel CLI dev dependency to 52.0.0
- add pnpm overrides for vulnerable Vercel transitive packages: tar, @tootallnate/once, smol-toml, srvx
- replace current-main Array helpers that were outside the active TypeScript lib target so typecheck stays green

## Verification
- pnpm audit --audit-level low
- pnpm --filter @jovie/web run typecheck
- pnpm --filter @jovie/web run lint
- pre-push gate: biome check ., proxy guard, tailwind:check, typecheck, lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated array sorting implementation across multiple components for consistency.
  * Refined URL handle derivation logic to improve path segment extraction.

* **Chores**
  * Updated build tool dependencies to latest versions.
  * Added new package overrides for dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->