### PR TITLE
feat(releases): click artist name in release drawer to filter table

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
@@ -789,6 +789,7 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
           width={RELEASE_DETAIL_PANEL_WIDTH}
           providerConfig={providerConfig}
           artistName={artistName}
+          onArtistClick={name => setSearchQuery(name)}
           canGenerateAlbumArt={showGenerateAlbumArtAction}
           onGenerateAlbumArt={handleGenerateAlbumArt}
           onClose={closeEditor}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/utils/filterReleases.ts
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/utils/filterReleases.ts
@@ -19,10 +19,14 @@ export function filterReleases(
   searchQuery: string
 ): ReleaseViewModel[] {
   return releases.filter(release => {
-    // Text search filter
+    // Text search filter — matches title or any artist name (case-insensitive)
     if (searchQuery) {
       const query = searchQuery.toLowerCase();
-      if (!release.title.toLowerCase().includes(query)) return false;
+      const titleMatches = release.title.toLowerCase().includes(query);
+      const artistMatches =
+        release.artistNames?.some(name => name.toLowerCase().includes(query)) ??
+        false;
+      if (!titleMatches && !artistMatches) return false;
     }
 
     // Filter by release type

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -45,7 +45,6 @@ import {
   buildArtworkSizes,
 } from '@/features/release/AlbumArtworkContextMenu';
 import { copyToClipboard } from '@/hooks/useClipboard';
-import { formatReleaseArtistLine } from '@/lib/discography/formatting';
 import type { ProviderKey } from '@/lib/discography/types';
 import { usePlanGate } from '@/lib/queries';
 import type { CanvasStatus } from '@/lib/services/canvas/types';
@@ -102,6 +101,7 @@ interface ReleaseEntityHeaderProps {
   readonly headerLabel: string;
   readonly release: Release;
   readonly artistName: string | null | undefined;
+  readonly onArtistClick?: (artistName: string) => void;
   readonly canUploadArtwork: boolean;
   readonly canRevertArtwork: boolean;
   readonly onArtworkUpload: ((file: File) => Promise<string>) | undefined;
@@ -114,10 +114,62 @@ interface ReleaseEntityHeaderProps {
   readonly footer?: ReactNode;
 }
 
+const releaseArtistListFormatter = new Intl.ListFormat('en', {
+  style: 'long',
+  type: 'conjunction',
+});
+
+function renderArtistLine(
+  artistNames: string[] | undefined,
+  fallbackArtistName: string | null | undefined,
+  onArtistClick: ((artistName: string) => void) | undefined
+): ReactNode {
+  const normalizedNames = (artistNames ?? [])
+    .map(name => name.trim())
+    .filter(Boolean);
+
+  if (normalizedNames.length === 0) {
+    const fallback = fallbackArtistName?.trim();
+    if (!fallback) return null;
+    if (!onArtistClick) return fallback;
+    return (
+      <button
+        type='button'
+        onClick={() => onArtistClick(fallback)}
+        className='rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-focus-ring)'
+      >
+        {fallback}
+      </button>
+    );
+  }
+
+  if (!onArtistClick) {
+    return releaseArtistListFormatter.format(normalizedNames);
+  }
+
+  return releaseArtistListFormatter
+    .formatToParts(normalizedNames)
+    .map((part, index) =>
+      part.type === 'element' ? (
+        <button
+          key={`artist-${index}`}
+          type='button'
+          onClick={() => onArtistClick(part.value)}
+          className='rounded-sm hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-focus-ring)'
+        >
+          {part.value}
+        </button>
+      ) : (
+        <span key={`sep-${index}`}>{part.value}</span>
+      )
+    );
+}
+
 function ReleaseEntityHeader({
   headerLabel,
   release,
   artistName,
+  onArtistClick,
   canUploadArtwork,
   canRevertArtwork,
   onArtworkUpload,
@@ -132,7 +184,11 @@ function ReleaseEntityHeader({
   const artworkAlt = release.title
     ? `${release.title} artwork`
     : 'Release artwork';
-  const artistLine = formatReleaseArtistLine(release.artistNames, artistName);
+  const artistLine = renderArtistLine(
+    release.artistNames,
+    artistName,
+    onArtistClick
+  );
   const hasActionBar = Boolean(actionBar);
 
   return (
@@ -274,6 +330,7 @@ export function ReleaseSidebar({
   width,
   providerConfig,
   artistName,
+  onArtistClick,
   canGenerateAlbumArt,
   onGenerateAlbumArt,
   onClose,
@@ -631,6 +688,7 @@ export function ReleaseSidebar({
             headerLabel={headerLabel}
             release={release}
             artistName={artistName}
+            onArtistClick={onArtistClick}
             canUploadArtwork={canUploadArtwork}
             canRevertArtwork={canRevertArtwork}
             onArtworkUpload={handleArtworkUpload}

--- a/apps/web/components/organisms/release-sidebar/types.ts
+++ b/apps/web/components/organisms/release-sidebar/types.ts
@@ -62,6 +62,12 @@ export interface ReleaseSidebarProps {
   >;
   /** Artist name to display in the sidebar header */
   readonly artistName?: string | null;
+  /**
+   * When provided, each artist name in the header becomes a button that
+   * invokes this callback with the clicked name. Used to set a filter on
+   * the surrounding release table.
+   */
+  readonly onArtistClick?: (artistName: string) => void;
   readonly canGenerateAlbumArt?: boolean;
   readonly onGenerateAlbumArt?: (release: Release) => void;
   readonly onClose?: () => void;

--- a/apps/web/tests/lib/discography/release-search-filter.test.ts
+++ b/apps/web/tests/lib/discography/release-search-filter.test.ts
@@ -116,6 +116,37 @@ describe('filterReleases — text search', () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('2');
   });
+
+  it('matches by artist name (case-insensitive)', () => {
+    const releases = [
+      makeRelease({ id: 'a', title: 'Song A', artistNames: ['Deadmau5'] }),
+      makeRelease({ id: 'b', title: 'Song B', artistNames: ['Kaskade'] }),
+      makeRelease({
+        id: 'c',
+        title: 'Song C',
+        artistNames: ['Deadmau5', 'Kaskade'],
+      }),
+    ];
+    const result = filterReleases(releases, EMPTY_FILTERS, 'deadmau5');
+    expect(result.map(r => r.id).sort()).toEqual(['a', 'c']);
+  });
+
+  it('matches artist name even when title does not contain the query', () => {
+    const releases = [
+      makeRelease({ id: 'x', title: 'Unrelated', artistNames: ['Avicii'] }),
+    ];
+    const result = filterReleases(releases, EMPTY_FILTERS, 'Avicii');
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('x');
+  });
+
+  it('does not match when neither title nor artist names contain the query', () => {
+    const releases = [
+      makeRelease({ id: 'y', title: 'Foo', artistNames: ['Bar'] }),
+    ];
+    const result = filterReleases(releases, EMPTY_FILTERS, 'baz');
+    expect(result).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Clicking an artist name in the release sidebar header sets the release-table search query to that artist
- `filterReleases` now also matches against `artistNames` (case-insensitive substring), so clicking lands on relevant rows
- Drawer stays open — just sets the filter

Closes JOV-1536

## Test plan
- [x] `pnpm --filter web test -- release-search-filter` (27 passed)
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [ ] Manual: open release drawer, click artist, verify search query updates and table filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Artist names in the sidebar are now clickable, allowing you to filter releases by clicking on any artist.
  * Search functionality now matches against artist names in addition to release titles.

* **Tests**
  * Added test coverage for artist name search matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->