### PR TITLE
feat(email-signature): add buildEmailSignature util (JOV-1581 part 1)

### DIFF
--- a/apps/web/lib/email-signature/build-signature.ts
+++ b/apps/web/lib/email-signature/build-signature.ts
@@ -1,0 +1,116 @@
+/**
+ * Build an HTML email signature for an artist's Jovie profile.
+ *
+ * The output is email-client-safe: table-based layout, inline styles,
+ * system font stack, and https-only absolute URLs. A conditional
+ * "Get yours at jov.ie" footer is appended when `hideJovieBranding` is false.
+ */
+
+import { BASE_URL, HOSTNAME } from '@/constants/domains';
+
+export interface EmailSignatureSocial {
+  readonly label: string;
+  readonly url: string;
+}
+
+export interface EmailSignatureInput {
+  readonly name: string;
+  readonly handle: string;
+  readonly tagline?: string | null;
+  readonly avatarUrl?: string | null;
+  readonly socials?: ReadonlyArray<EmailSignatureSocial>;
+  readonly hideJovieBranding?: boolean;
+}
+
+export interface BuiltEmailSignature {
+  readonly html: string;
+  readonly text: string;
+}
+
+const FONT_STACK =
+  "-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif";
+
+const UTM_FOOTER_SUFFIX =
+  '?utm_source=email_signature&utm_medium=footer&utm_campaign=get_yours';
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function isSafeHttpsUrl(raw: string): boolean {
+  try {
+    const parsed = new URL(raw);
+    return parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function sanitizeSocials(
+  socials: ReadonlyArray<EmailSignatureSocial> | undefined
+): EmailSignatureSocial[] {
+  if (!socials) return [];
+  return socials
+    .map(social => ({
+      label: social.label.trim(),
+      url: social.url.trim(),
+    }))
+    .filter(social => social.label && isSafeHttpsUrl(social.url));
+}
+
+function buildProfileUrl(handle: string): string {
+  return `${BASE_URL}/${encodeURIComponent(handle)}`;
+}
+
+export function buildEmailSignature(
+  input: EmailSignatureInput
+): BuiltEmailSignature {
+  const name = input.name.trim();
+  const handle = input.handle.trim();
+  const tagline = input.tagline?.trim() ?? '';
+  const avatarUrl =
+    input.avatarUrl && isSafeHttpsUrl(input.avatarUrl) ? input.avatarUrl : null;
+  const socials = sanitizeSocials(input.socials);
+  const showFooter = input.hideJovieBranding !== true;
+
+  const profileUrl = buildProfileUrl(handle);
+  const profileUrlDisplay = `${HOSTNAME}/${handle}`;
+
+  const avatarCell = avatarUrl
+    ? `<td style="padding-right:12px;vertical-align:top;"><img src="${escapeHtml(avatarUrl)}" width="56" height="56" alt="${escapeHtml(name)}" style="display:block;border:0;border-radius:28px;width:56px;height:56px;object-fit:cover;"/></td>`
+    : '';
+
+  const socialsLine = socials.length
+    ? `<div style="margin-top:4px;color:#525866;font-size:12px;">${socials
+        .map(
+          social =>
+            `<a href="${escapeHtml(social.url)}" style="color:#525866;text-decoration:none;">${escapeHtml(social.label)}</a>`
+        )
+        .join('&nbsp;·&nbsp;')}</div>`
+    : '';
+
+  const taglineLine = tagline
+    ? `<div style="color:#525866;font-size:13px;line-height:1.45;">${escapeHtml(tagline)}</div>`
+    : '';
+
+  const footer = showFooter
+    ? `<tr><td colspan="2" style="padding-top:8px;font-size:11px;color:#8b94a3;">Get yours at <a href="${escapeHtml(`${BASE_URL}/${UTM_FOOTER_SUFFIX}`)}" style="color:#8b94a3;text-decoration:none;">${HOSTNAME}</a></td></tr>`
+    : '';
+
+  const html = `<table cellpadding="0" cellspacing="0" border="0" style="font-family:${FONT_STACK};color:#0d0e12;font-size:14px;line-height:1.4;"><tr>${avatarCell}<td style="vertical-align:top;"><div style="font-weight:600;font-size:15px;color:#0d0e12;">${escapeHtml(name)}</div>${taglineLine}<div style="margin-top:4px;"><a href="${escapeHtml(profileUrl)}" style="color:#3b5bdb;text-decoration:none;font-weight:500;">${escapeHtml(profileUrlDisplay)}</a></div>${socialsLine}</td></tr>${footer}</table>`;
+
+  const textLines = [name];
+  if (tagline) textLines.push(tagline);
+  textLines.push(profileUrlDisplay);
+  if (socials.length) {
+    textLines.push(socials.map(s => `${s.label}: ${s.url}`).join(' | '));
+  }
+  if (showFooter) textLines.push(`Get yours at ${HOSTNAME}`);
+
+  return { html, text: textLines.join('\n') };
+}

--- a/apps/web/tests/unit/lib/email-signature/build-signature.test.ts
+++ b/apps/web/tests/unit/lib/email-signature/build-signature.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildEmailSignature } from '@/lib/email-signature/build-signature';
+
+describe('buildEmailSignature', () => {
+  it('renders name, handle link, and default Jovie footer', () => {
+    const { html, text } = buildEmailSignature({
+      name: 'Deadmau5',
+      handle: 'deadmau5',
+    });
+
+    expect(html).toContain('Deadmau5');
+    expect(html).toContain('jov.ie/deadmau5');
+    expect(html).toContain('Get yours at');
+    expect(text).toContain('Deadmau5');
+    expect(text).toContain('jov.ie/deadmau5');
+    expect(text).toContain('Get yours at');
+  });
+
+  it('HTML-escapes interpolated values', () => {
+    const { html } = buildEmailSignature({
+      name: '<script>alert(1)</script>',
+      handle: 'safe',
+      tagline: `Quote"ed & 'test'`,
+    });
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&amp;');
+    expect(html).toContain('&quot;');
+    expect(html).toContain('&#39;');
+  });
+
+  it('drops http:// and data: avatar URLs but keeps https://', () => {
+    const insecure = buildEmailSignature({
+      name: 'A',
+      handle: 'a',
+      avatarUrl: 'http://example.com/a.png',
+    });
+    expect(insecure.html).not.toContain('example.com');
+
+    const dataUri = buildEmailSignature({
+      name: 'A',
+      handle: 'a',
+      avatarUrl: 'data:image/png;base64,AAAA',
+    });
+    expect(dataUri.html).not.toContain('data:image/png');
+
+    const secure = buildEmailSignature({
+      name: 'A',
+      handle: 'a',
+      avatarUrl: 'https://cdn.example.com/a.png',
+    });
+    expect(secure.html).toContain('https://cdn.example.com/a.png');
+  });
+
+  it('filters out socials with non-https URLs', () => {
+    const { html } = buildEmailSignature({
+      name: 'A',
+      handle: 'a',
+      socials: [
+        { label: 'Good', url: 'https://good.example/x' },
+        { label: 'Bad', url: 'http://bad.example/x' },
+        { label: 'NoLabel', url: '' },
+      ],
+    });
+    expect(html).toContain('Good');
+    expect(html).not.toContain('Bad');
+    expect(html).not.toContain('NoLabel');
+  });
+
+  it('omits the Jovie footer when hideJovieBranding=true', () => {
+    const { html, text } = buildEmailSignature({
+      name: 'A',
+      handle: 'a',
+      hideJovieBranding: true,
+    });
+    expect(html).not.toContain('Get yours at');
+    expect(text).not.toContain('Get yours at');
+  });
+
+  it('includes UTM params on the footer link', () => {
+    const { html } = buildEmailSignature({ name: 'A', handle: 'a' });
+    expect(html).toContain('utm_source=email_signature');
+    expect(html).toContain('utm_medium=footer');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `buildEmailSignature` pure util at `apps/web/lib/email-signature/build-signature.ts`
- Email-client-safe: table-based layout, inline styles, system font stack, HTML escaping, https-only URL guard
- Conditional UTM-tagged "Get yours at jov.ie" footer (omitted when `hideJovieBranding: true`)
- 6 unit tests covering escape, https filter, socials filter, footer toggle, UTM params

Refs JOV-1581. Menu wiring (sidebar context menu + drawer actions menu) ships in part 2 to keep this PR reviewable.

## Test plan
- [x] `pnpm --filter web test -- build-signature` (6 passed)
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [ ] Manual: visual spot-check of generated HTML in a real email client (follow-up PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced email signature generation enabling users to create professional signatures with customizable profile information, social media links, avatar support, and optional branding. Signatures are formatted for both HTML and plain-text email clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->