### PR TITLE
feat(chat): lane 1 observability — sentry tagging, kill switch, canary probe

### DIFF
--- a/.github/workflows/canary-health-gate.yml
+++ b/.github/workflows/canary-health-gate.yml
@@ -399,6 +399,32 @@ jobs:
 
           echo "✅ Signin renders correctly"
 
+          # Verify /api/chat is reachable and auth-gated. We send an unauthenticated
+          # POST and expect HTTP 401 — that proves the route exists, the auth wall
+          # is intact, and the handler is not 5xxing on boot (bad Sentry config,
+          # missing env, broken import). A full streaming smoke would require auth
+          # and is deferred (see chat instrumentation plan, 30-day review).
+          echo "Checking /api/chat is reachable and auth-gated..."
+          chat_url="${deployment_url%/}/api/chat"
+          chat_response=$(curl -s -L -A "$USER_AGENT" -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"hi"}]}]}' -w "\n%{http_code}" "${chat_url}" || echo "\n000")
+          chat_code="${chat_response##*$'\n'}"
+
+          # 401 = expected (auth-gated). 400 = acceptable (validation ran, route alive).
+          # Anything 5xx or 404 = regression.
+          if [ "$chat_code" = "401" ] || [ "$chat_code" = "400" ]; then
+            echo "✅ /api/chat reachable and auth-gated (HTTP $chat_code)"
+          elif [ "$chat_code" = "404" ]; then
+            echo "❌ Canary failed: /api/chat returned HTTP 404 — route missing or broken build"
+            echo "canary_status=failed_chat_route" >> "$GITHUB_OUTPUT"
+            exit 1
+          elif [ "$chat_code" -ge 500 ] 2>/dev/null; then
+            echo "❌ Canary failed: /api/chat returned HTTP $chat_code — handler crashing on boot"
+            echo "canary_status=failed_chat_route" >> "$GITHUB_OUTPUT"
+            exit 1
+          else
+            echo "⚠️ /api/chat returned unexpected HTTP $chat_code — investigate (non-blocking)"
+          fi
+
           # Verify the public profile route renders without a server error.
           # "Profile not found" with HTTP 200 is a valid app response (data issue,
           # not a code regression), so only block on 5xx or actual error pages.

--- a/.github/workflows/canary-health-gate.yml
+++ b/.github/workflows/canary-health-gate.yml
@@ -406,7 +406,7 @@ jobs:
           # and is deferred (see chat instrumentation plan, 30-day review).
           echo "Checking /api/chat is reachable and auth-gated..."
           chat_url="${deployment_url%/}/api/chat"
-          chat_response=$(curl -s -L -A "$USER_AGENT" -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"hi"}]}]}' -w "\n%{http_code}" "${chat_url}" || echo "\n000")
+          chat_response=$(curl -s -L -A "$USER_AGENT" -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"hi"}]}]}' -w "\n%{http_code}" "${chat_url}" || printf '\n000')
           chat_code="${chat_response##*$'\n'}"
 
           # 401 = expected (auth-gated). 400 = acceptable (validation ran, route alive).

--- a/.github/workflows/canary-health-gate.yml
+++ b/.github/workflows/canary-health-gate.yml
@@ -409,10 +409,11 @@ jobs:
           chat_response=$(curl -s -L -A "$USER_AGENT" -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"hi"}]}]}' -w "\n%{http_code}" "${chat_url}" || printf '\n000')
           chat_code="${chat_response##*$'\n'}"
 
-          # 401 = expected (auth-gated). 400 = acceptable (validation ran, route alive).
-          # Anything 5xx or 404 = regression.
-          if [ "$chat_code" = "401" ] || [ "$chat_code" = "400" ]; then
-            echo "✅ /api/chat reachable and auth-gated (HTTP $chat_code)"
+          # The chat route checks auth BEFORE body parsing, so an unauthenticated
+          # probe must return exactly 401. Any other code means routing/auth
+          # behavior changed (broken build, middleware rewrite, auth bypass).
+          if [ "$chat_code" = "401" ]; then
+            echo "✅ /api/chat reachable and auth-gated (HTTP 401)"
           elif [ "$chat_code" = "404" ]; then
             echo "❌ Canary failed: /api/chat returned HTTP 404 — route missing or broken build"
             echo "canary_status=failed_chat_route" >> "$GITHUB_OUTPUT"
@@ -422,7 +423,9 @@ jobs:
             echo "canary_status=failed_chat_route" >> "$GITHUB_OUTPUT"
             exit 1
           else
-            echo "⚠️ /api/chat returned unexpected HTTP $chat_code — investigate (non-blocking)"
+            echo "❌ Canary failed: /api/chat returned unexpected HTTP $chat_code — expected 401"
+            echo "canary_status=failed_chat_route" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
 
           # Verify the public profile route renders without a server error.

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -23,6 +23,7 @@ import { generateUniqueSlug } from '@/lib/discography/slug';
 import { getEntitlements } from '@/lib/entitlements/registry';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 import { FEATURE_FLAGS } from '@/lib/feature-flags/shared';
+import { checkGateForUser } from '@/lib/flags/statsig';
 import { createAuthenticatedCorsHeaders } from '@/lib/http/headers';
 import {
   classifyIntent,
@@ -1692,6 +1693,13 @@ export async function POST(req: Request) {
     'POST, OPTIONS'
   );
 
+  // Tag every Sentry event captured during this request as chat-surface. The
+  // error path already tags `feature: 'ai-chat'`, but breadcrumbs, performance
+  // events, and any intermediate captureException elsewhere in the handler
+  // would otherwise go untagged. One call here covers all of them.
+  Sentry.getCurrentScope().setTag('feature', 'ai-chat');
+  Sentry.getCurrentScope().setTag('request_id', requestId);
+
   // Auth check - ensure user is authenticated
   const { userId } = await getCachedAuth();
   if (!userId) {
@@ -1701,9 +1709,38 @@ export async function POST(req: Request) {
     );
   }
 
+  // Kill switch: Statsig-backed, no deploy required. When a provider incident
+  // happens, flip `ai_chat_disabled` to 503 all chat traffic with a friendly
+  // message, or `ai_chat_force_light` to force-route to the cheaper/faster
+  // light model without a code change. Defaults (both false) = normal behavior.
+  const chatDisabled = await checkGateForUser(
+    userId,
+    'ai_chat_disabled',
+    false
+  );
+  if (chatDisabled) {
+    return NextResponse.json(
+      {
+        error: 'Chat is temporarily unavailable',
+        message:
+          'Jovie chat is paused while we address an upstream issue. Please try again in a few minutes.',
+        errorCode: 'CHAT_DISABLED',
+        requestId,
+      },
+      { status: 503, headers: { ...corsHeaders, 'x-request-id': requestId } }
+    );
+  }
+  const forceLightModel = await checkGateForUser(
+    userId,
+    'ai_chat_force_light',
+    false
+  );
+
   // Fetch user plan for rate limiting and tool gating
   const billingInfo = await getUserBillingInfo();
   const userPlan = billingInfo.data?.plan ?? 'free';
+  // Tag plan on the request scope so every Sentry event is queryable by tier.
+  Sentry.getCurrentScope().setTag('plan_tier', userPlan);
   const planLimits = getEntitlements(userPlan);
   const currentUserEntitlements = await getCurrentUserEntitlements().catch(
     () => null
@@ -1846,12 +1883,23 @@ export async function POST(req: Request) {
         }
       : freeTools;
 
-    const selectedModel = canUseLightModel(
-      uiMessages,
-      planLimits.booleans.aiCanUseTools
-    )
-      ? CHAT_MODEL_LIGHT
-      : CHAT_MODEL;
+    // `forceLightModel` is the runtime lever (Statsig `ai_chat_force_light`)
+    // that degrades the entire chat surface to the light model during a
+    // provider incident, overriding the per-request heuristic.
+    const selectedModel =
+      forceLightModel ||
+      canUseLightModel(uiMessages, planLimits.booleans.aiCanUseTools)
+        ? CHAT_MODEL_LIGHT
+        : CHAT_MODEL;
+
+    // Tag the request scope with chat-specific dimensions so all Sentry events
+    // for this request (errors, perf, breadcrumbs) are filterable together.
+    Sentry.getCurrentScope().setTags({
+      chat_model: selectedModel,
+      chat_force_light: String(forceLightModel),
+      chat_has_tools: String(Object.keys(tools).length > 0),
+      chat_conversation_id: resolvedConversationId ?? 'none',
+    });
 
     const result = streamText({
       model: gateway(selectedModel),
@@ -1861,10 +1909,12 @@ export async function POST(req: Request) {
       abortSignal: req.signal,
       experimental_telemetry: {
         isEnabled: true,
-        recordInputs: true,
-        recordOutputs: true,
+        // PII: do not capture prompts/outputs in AI SDK spans. Tokens, model,
+        // latency, and tool-call structure are still captured.
+        recordInputs: false,
+        recordOutputs: false,
         functionId: 'jovie-chat',
-        metadata: { model: selectedModel },
+        metadata: { model: selectedModel, plan: userPlan },
       },
       onError: ({ error }) => {
         if (isClientDisconnect(error, req.signal)) return;

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -23,7 +23,7 @@ import { generateUniqueSlug } from '@/lib/discography/slug';
 import { getEntitlements } from '@/lib/entitlements/registry';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 import { FEATURE_FLAGS } from '@/lib/feature-flags/shared';
-import { checkGateForUser } from '@/lib/flags/statsig';
+import { checkGateForUser } from '@/lib/flags/server';
 import { createAuthenticatedCorsHeaders } from '@/lib/http/headers';
 import {
   classifyIntent,
@@ -75,6 +75,17 @@ const MAX_MESSAGE_LENGTH = 4000;
 
 /** Maximum allowed messages per request */
 const MAX_MESSAGES_PER_REQUEST = 50;
+
+/**
+ * Statsig gate keys for the chat kill switch. Declared as const so typos fail
+ * at compile time rather than silently defaulting to `false` (never firing).
+ * Kept local to the chat route — once other routes need runtime kill switches
+ * these should graduate into the typed APP_FLAG_* registry.
+ */
+const CHAT_KILL_SWITCH_GATES = {
+  DISABLED: 'ai_chat_disabled',
+  FORCE_LIGHT: 'ai_chat_force_light',
+} as const;
 
 /**
  * Zod schema for validating client-provided artist context.
@@ -1697,8 +1708,10 @@ export async function POST(req: Request) {
   // error path already tags `feature: 'ai-chat'`, but breadcrumbs, performance
   // events, and any intermediate captureException elsewhere in the handler
   // would otherwise go untagged. One call here covers all of them.
+  // `request_id` is stored as extra (not tag) — it is unique per request and
+  // would blow out Sentry's tag cardinality budget.
   Sentry.getCurrentScope().setTag('feature', 'ai-chat');
-  Sentry.getCurrentScope().setTag('request_id', requestId);
+  Sentry.getCurrentScope().setExtra('request_id', requestId);
 
   // Auth check - ensure user is authenticated
   const { userId } = await getCachedAuth();
@@ -1709,13 +1722,22 @@ export async function POST(req: Request) {
     );
   }
 
+  // Fetch billing/plan before the kill switch so 503 responses are still
+  // tagged by tier — lets us answer "how many paid users did this incident
+  // block" from Sentry without a second data source.
+  const billingInfo = await getUserBillingInfo();
+  const userPlan = billingInfo.data?.plan ?? 'free';
+  Sentry.getCurrentScope().setTag('plan_tier', userPlan);
+
   // Kill switch: Statsig-backed, no deploy required. When a provider incident
   // happens, flip `ai_chat_disabled` to 503 all chat traffic with a friendly
   // message, or `ai_chat_force_light` to force-route to the cheaper/faster
   // light model without a code change. Defaults (both false) = normal behavior.
+  // Keys are const-declared so a typo fails at compile time rather than
+  // silently falling back to the default.
   const chatDisabled = await checkGateForUser(
     userId,
-    'ai_chat_disabled',
+    CHAT_KILL_SWITCH_GATES.DISABLED,
     false
   );
   if (chatDisabled) {
@@ -1732,15 +1754,9 @@ export async function POST(req: Request) {
   }
   const forceLightModel = await checkGateForUser(
     userId,
-    'ai_chat_force_light',
+    CHAT_KILL_SWITCH_GATES.FORCE_LIGHT,
     false
   );
-
-  // Fetch user plan for rate limiting and tool gating
-  const billingInfo = await getUserBillingInfo();
-  const userPlan = billingInfo.data?.plan ?? 'free';
-  // Tag plan on the request scope so every Sentry event is queryable by tier.
-  Sentry.getCurrentScope().setTag('plan_tier', userPlan);
   const planLimits = getEntitlements(userPlan);
   const currentUserEntitlements = await getCurrentUserEntitlements().catch(
     () => null
@@ -1885,12 +1901,12 @@ export async function POST(req: Request) {
 
     // `forceLightModel` is the runtime lever (Statsig `ai_chat_force_light`)
     // that degrades the entire chat surface to the light model during a
-    // provider incident, overriding the per-request heuristic.
-    const selectedModel =
+    // provider incident, overriding the per-request heuristic. Intermediate
+    // variable keeps the precedence explicit (|| binds tighter than ?:).
+    const shouldUseLightModel =
       forceLightModel ||
-      canUseLightModel(uiMessages, planLimits.booleans.aiCanUseTools)
-        ? CHAT_MODEL_LIGHT
-        : CHAT_MODEL;
+      canUseLightModel(uiMessages, planLimits.booleans.aiCanUseTools);
+    const selectedModel = shouldUseLightModel ? CHAT_MODEL_LIGHT : CHAT_MODEL;
 
     // Tag the request scope with chat-specific dimensions so all Sentry events
     // for this request (errors, perf, breadcrumbs) are filterable together.

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1910,12 +1910,20 @@ export async function POST(req: Request) {
 
     // Tag the request scope with chat-specific dimensions so all Sentry events
     // for this request (errors, perf, breadcrumbs) are filterable together.
+    // `chat_conversation_id` goes in `extra` (high cardinality per Sentry
+    // guidance); `chat_has_tools` reflects the real plan capability boundary
+    // rather than a count of always-on freeTools.
     Sentry.getCurrentScope().setTags({
       chat_model: selectedModel,
       chat_force_light: String(forceLightModel),
-      chat_has_tools: String(Object.keys(tools).length > 0),
-      chat_conversation_id: resolvedConversationId ?? 'none',
+      chat_has_tools: String(planLimits.booleans.aiCanUseTools),
     });
+    if (resolvedConversationId) {
+      Sentry.getCurrentScope().setExtra(
+        'chat_conversation_id',
+        resolvedConversationId.slice(0, 120)
+      );
+    }
 
     const result = streamText({
       model: gateway(selectedModel),

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -35,11 +35,13 @@ Sentry.init({
     /toHaveURL/,
   ],
 
-  // AI Agent Monitoring: Explicit for edge runtime (not auto-enabled like Node)
+  // AI Agent Monitoring: Explicit for edge runtime (not auto-enabled like Node).
+  // recordInputs/recordOutputs disabled to avoid capturing PII from user
+  // prompts or model replies. See sentry.server.config.ts for rationale.
   integrations: [
     Sentry.vercelAIIntegration({
-      recordInputs: true,
-      recordOutputs: true,
+      recordInputs: false,
+      recordOutputs: false,
     }),
   ],
 });

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -74,11 +74,15 @@ Sentry.init({
     /Daily query budget exhausted/,
   ],
 
-  // AI Agent Monitoring: Track Vercel AI SDK calls (LLM requests, token usage)
+  // AI Agent Monitoring: Track Vercel AI SDK calls (LLM requests, token usage).
+  // recordInputs/recordOutputs are intentionally `false` — user prompts and
+  // model replies can contain PII (DM drafts, fan messages, DSAR-relevant
+  // content). Re-enable per-environment only after a data-classification
+  // review with whoever owns privacy. Tokens/model/latency/cost still captured.
   integrations: [
     Sentry.vercelAIIntegration({
-      recordInputs: true,
-      recordOutputs: true,
+      recordInputs: false,
+      recordOutputs: false,
     }),
   ],
 });


### PR DESCRIPTION
## Summary
- Flip Sentry `vercelAIIntegration` + `experimental_telemetry` to `recordInputs:false` / `recordOutputs:false` to avoid capturing PII from chat prompts and model replies. Tokens, model, latency, and cost still captured for the AI Agents Insights dashboard.
- Tag every Sentry event captured during a chat request with `feature='ai-chat'`, `plan_tier`, `chat_model`, `chat_force_light`, `chat_has_tools`, and `chat_conversation_id` (today only the error path is tagged).
- Add Statsig-backed kill switch: `ai_chat_disabled` → 503 + friendly message; `ai_chat_force_light` → all traffic forced to `CHAT_MODEL_LIGHT`. Both default `false`. No deploy needed to flip during a provider incident.
- Add post-deploy `/api/chat` canary probe (unauthenticated POST, expect 401). Catches route-deleted or handler-crashing regressions without needing auth plumbing. Streaming smoke deferred.

## Context
`/plan-eng-review` followed by `/autoplan` CEO dual voices (Claude subagent + Codex) converged on shipping **Lane 1 only** (~4 hrs, ~70% of the value) and deferring the richer plan (client TTFT marks, streaming smoke as pre-merge gate, cost dashboards, instrumentation unit tests) to a 30-day review once we have real baseline data. Both voices also flagged the PII risk that this PR addresses.

## Step 0 finding — recorded for the 30-day review
- `0` errors tagged `feature:ai-chat` or `transaction:/api/chat` in Sentry over the last 30 days
- `1053` total prod errors same window → chat's share of error volume: **0%**
- Linear ticket count + Vercel Analytics DAU: not pulled (no MCP access in this session). Surface manually before the 30-day review.

## Deferred (30-day review, ~2026-05-22)
- Client-side `performance.mark` for perceived TTFT
- Streaming smoke E2E (pre-merge hard gate was rejected as flake-prone; may revisit as soft gate)
- Cost tracking dashboards — evaluate Sentry's calculation vs LangSmith/Helicone/PostHog
- `recordInputs:true` for a subset of traces (e.g., errored requests only) pending privacy review
- Per-provider / per-region kill switches

## Test plan
- [ ] Typecheck passes (`pnpm --filter web typecheck`)
- [ ] Biome + ESLint pre-commit hooks pass (enforced by husky)
- [ ] All 445 chat unit tests pass locally (`pnpm --filter web test tests/unit/chat`)
- [ ] In Sentry dev project: fire a chat request, confirm the trace shows `feature:ai-chat`, `plan_tier`, `chat_model`, `chat_conversation_id` tags + `gen_ai.*` span attributes (tokens, model, latency) with no prompt/output content
- [ ] Set `ai_chat_force_light=true` in Statsig dev, send a request, confirm `chat_model=anthropic/claude-haiku-4-5-20251001` on the next trace
- [ ] Set `ai_chat_disabled=true`, confirm 503 + friendly `CHAT_DISABLED` error
- [ ] Canary job runs `/api/chat` probe against staging after merge and returns 401 (route alive, auth-gated)

## Plan doc
`~/.claude/plans/system-instruction-you-are-working-glittery-pearl.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime controls to temporarily disable chat or force a lightweight model for some users.

* **Chores**
  * Deployment health check improved to detect missing or failing chat endpoints earlier.

* **Bug Fixes**
  * Stopped capturing AI conversation inputs/outputs in telemetry and error reports to better protect user privacy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->