### PR TITLE
fix(auth): intent_id from redirect_url + shared truncation

### DIFF
--- a/apps/web/app/@auth/(.)signup/page.tsx
+++ b/apps/web/app/@auth/(.)signup/page.tsx
@@ -4,7 +4,10 @@ import { SignUp } from '@clerk/nextjs';
 import { useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useState } from 'react';
 import { AuthModalShell } from '@/components/auth/AuthModalShell';
-import { readHomepageIntent } from '@/components/homepage/intent-store';
+import {
+  HOMEPAGE_PROMPT_HINT_TRUNCATE,
+  readHomepageIntent,
+} from '@/components/homepage/intent-store';
 import { AuthFormSkeleton } from '@/components/molecules/LoadingSkeleton';
 import { APP_ROUTES } from '@/constants/routes';
 import { buildAuthRouteUrl } from '@/lib/auth/build-auth-route-url';
@@ -34,7 +37,20 @@ function SignupModalBody() {
   // Hydrate the intent hint from localStorage (text only — the load-bearing
   // restoration happens on /onboarding after the OAuth round-trip).
   useEffect(() => {
-    const intentId = searchParams.get('intent_id');
+    // `intent_id` travels inside the encoded `redirect_url` (so it survives
+    // Clerk's OAuth round-trip), not as a sibling query param on /signup.
+    // Parse it out of redirect_url's own query string.
+    const redirectUrlRaw = searchParams.get('redirect_url');
+    if (!redirectUrlRaw) return;
+    let intentId: string | null = null;
+    try {
+      intentId = new URL(
+        redirectUrlRaw,
+        globalThis.window?.location.origin ?? 'http://localhost'
+      ).searchParams.get('intent_id');
+    } catch {
+      return;
+    }
     if (!intentId) return;
     const intent = readHomepageIntent(intentId);
     if (intent) setPromptHint(intent.finalPrompt);
@@ -50,7 +66,9 @@ function SignupModalBody() {
       title={promptHint}
     >
       Continuing with &ldquo;
-      {promptHint.length > 48 ? `${promptHint.slice(0, 48)}…` : promptHint}
+      {promptHint.length > HOMEPAGE_PROMPT_HINT_TRUNCATE
+        ? `${promptHint.slice(0, HOMEPAGE_PROMPT_HINT_TRUNCATE)}…`
+        : promptHint}
       &rdquo;
     </p>
   ) : null;

--- a/apps/web/components/homepage/intent-store.ts
+++ b/apps/web/components/homepage/intent-store.ts
@@ -23,6 +23,14 @@ export const HOMEPAGE_ACTIVE_INTENT_KEY = 'jovie_active_homepage_intent_id';
 export const HOMEPAGE_INTENT_TTL_MS = 30 * 60 * 1000;
 export const HOMEPAGE_INTENT_MAX_CHARS = 140;
 
+/**
+ * Shared truncation length for rendering the prompt hint back to the user
+ * (modal status row + onboarding restorer). Keep both surfaces in lockstep
+ * so the visible copy doesn't change mid-flow when the user moves from
+ * signup → onboarding.
+ */
+export const HOMEPAGE_PROMPT_HINT_TRUNCATE = 60;
+
 export interface StoredHomepageIntent extends HomepageIntent {
   readonly id: string;
   readonly expiresAt: number;

--- a/apps/web/components/onboarding/IntentRestorer.tsx
+++ b/apps/web/components/onboarding/IntentRestorer.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import {
   consumeHomepageIntent,
+  HOMEPAGE_PROMPT_HINT_TRUNCATE,
   readHomepageIntent,
   sanitizeHomepagePrompt,
 } from '@/components/homepage/intent-store';
@@ -45,7 +46,10 @@ export function IntentRestorer({ intentId }: IntentRestorerProps) {
 
   if (!prompt) return null;
 
-  const truncated = prompt.length > 72 ? `${prompt.slice(0, 72)}…` : prompt;
+  const truncated =
+    prompt.length > HOMEPAGE_PROMPT_HINT_TRUNCATE
+      ? `${prompt.slice(0, HOMEPAGE_PROMPT_HINT_TRUNCATE)}…`
+      : prompt;
 
   return (
     <p

--- a/apps/web/tests/e2e/homepage-intent.spec.ts
+++ b/apps/web/tests/e2e/homepage-intent.spec.ts
@@ -1,7 +1,8 @@
 import { setupClerkTestingToken } from '@clerk/testing/playwright';
+import { HOMEPAGE_INTENTS_KEY } from '@/components/homepage/intent-store';
 import { expect, test } from './setup';
 
-const INTENTS_KEY = 'jovie_homepage_intents';
+const INTENTS_KEY = HOMEPAGE_INTENTS_KEY;
 
 test.use({ storageState: { cookies: [], origins: [] } });
 
@@ -143,7 +144,7 @@ test.describe('Homepage chat intake — ID-keyed intent store + viewport-split a
     await page.goto('/');
     // Seed an intent with an HTML-looking prompt via localStorage so we can
     // test the RENDER path on /onboarding without needing real auth.
-    await page.evaluate(() => {
+    await page.evaluate(key => {
       const id = '11111111-1111-4111-8111-111111111111';
       const intent = {
         id,
@@ -157,11 +158,8 @@ test.describe('Homepage chat intake — ID-keyed intent store + viewport-split a
         createdAt: new Date().toISOString(),
         expiresAt: Date.now() + 30 * 60 * 1000,
       };
-      window.localStorage.setItem(
-        'jovie_homepage_intents',
-        JSON.stringify({ [id]: intent })
-      );
-    });
+      window.localStorage.setItem(key, JSON.stringify({ [id]: intent }));
+    }, INTENTS_KEY);
 
     // No real auth — we are only checking React's escaping. The body
     // should contain the literal text, never a live <script>.


### PR DESCRIPTION
Follow-up to #7508 addressing bot-review findings that landed after merge.

## Summary

- **P1 bug (Sentry + Greptile, independent catches):** the intercepted signup modal read \`searchParams.get('intent_id')\`, but the URL is \`/signup?redirect_url=%2Fonboarding%3Fintent_id%3D<uuid>\` — \`intent_id\` is encoded INSIDE \`redirect_url\`. \`intentId\` was always null, so the "Continuing with '…'" status row never rendered in the modal. Fixed by parsing \`redirect_url\` as a URL and extracting \`intent_id\` from its own query string. The load-bearing \`/onboarding\` restoration was unaffected (that path already received \`intent_id\` as a direct query param after Clerk's redirect).

- **Shared truncation constant (CodeRabbit nitpick):** the modal truncated at 48 chars, \`IntentRestorer\` at 72 — so the prompt would reflow when users crossed from signup → onboarding. Extracted \`HOMEPAGE_PROMPT_HINT_TRUNCATE = 60\` in \`intent-store.ts\`. Both surfaces now use the same cap.

- **E2E hardcoded key (CodeRabbit nitpick):** \`homepage-intent.spec.ts\` hardcoded \`'jovie_homepage_intents'\` (top-level + inside \`page.evaluate\`). Now imports \`HOMEPAGE_INTENTS_KEY\` and passes it through \`page.evaluate\`, preventing drift.

## Test plan

- [x] \`pnpm --filter web typecheck\` clean
- [x] \`pnpm --filter web lint\` clean
- [x] 31/31 unit tests pass (19 intent-store + 12 HomepageIntent)
- [ ] After deploy, verify "Continuing with '…'" status row shows in the signup modal on desktop

## Deferred

Remaining CodeRabbit nitpicks on \`HomepageIntent.test.tsx\` (window.matchMedia afterEach restore, sessionStorage assertion on empty-submit, active-id lookup instead of \`Object.values()[0]\`) — main's test file already has most of the matchMedia mocking structure; those can land in a follow-up if they keep surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced signup flow with improved intent identification and validation for malformed URLs
  * Standardized text truncation length across signup and onboarding experiences for consistent display

* **Tests**
  * Updated end-to-end tests to use shared constants for improved maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->