### PR TITLE
feat(sentry): attach masked user id and request_id to server scope

### DIFF
--- a/apps/web/lib/admin/middleware.ts
+++ b/apps/web/lib/admin/middleware.ts
@@ -1,28 +1,15 @@
 import 'server-only';
-import crypto from 'node:crypto';
 import { auth } from '@clerk/nextjs/server';
 import * as Sentry from '@sentry/nextjs';
 import { cookies, headers } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { maskUserIdForLog } from '@/lib/auth/mask-user-id';
 import {
   isTestAuthBypassEnabled,
   resolveTestBypassUserId,
 } from '@/lib/auth/test-mode';
 import { captureWarning } from '@/lib/error-tracking';
 import { isAdmin } from './roles';
-
-/**
- * Mask user ID for logging to prevent PII exposure while maintaining correlation.
- * Format: first 4 chars + hash suffix for audit trail correlation
- */
-function maskUserIdForLog(userId: string): string {
-  const hash = crypto
-    .createHash('sha256')
-    .update(userId)
-    .digest('hex')
-    .substring(0, 8);
-  return `${userId.substring(0, 4)}...${hash}`;
-}
 
 /**
  * Admin route protection middleware

--- a/apps/web/lib/auth/cached.ts
+++ b/apps/web/lib/auth/cached.ts
@@ -6,6 +6,7 @@ import {
   buildDevTestAuthCurrentUser,
   getCachedDevTestAuthSession,
 } from '@/lib/auth/dev-test-auth.server';
+import { attachSentryContext } from '@/lib/sentry/set-user-context';
 
 type CachedCurrentUser = Awaited<ReturnType<typeof currentUser>>;
 
@@ -40,14 +41,18 @@ function isMissingAuthRequestContext(error: unknown): boolean {
 async function resolveCachedAuth() {
   const bypassSession = await getCachedDevTestAuthSession();
   if (bypassSession) {
-    return {
+    const result = {
       userId: bypassSession.clerkUserId,
       sessionId: 'sess_test_bypass',
       orgId: undefined,
     };
+    await attachSentryContext(result.userId);
+    return result;
   }
 
-  return auth();
+  const result = await auth();
+  await attachSentryContext(result.userId);
+  return result;
 }
 
 /**

--- a/apps/web/lib/auth/mask-user-id.ts
+++ b/apps/web/lib/auth/mask-user-id.ts
@@ -1,0 +1,19 @@
+import 'server-only';
+
+import crypto from 'node:crypto';
+
+/**
+ * Mask a user ID for logging and error-tracking to prevent raw Clerk ID
+ * exposure while preserving correlation across audit surfaces.
+ *
+ * Format: first 4 chars + "..." + 8-char SHA-256 suffix.
+ * Same input always yields the same output, so Sentry + server logs line up.
+ */
+export function maskUserIdForLog(userId: string): string {
+  const hash = crypto
+    .createHash('sha256')
+    .update(userId)
+    .digest('hex')
+    .substring(0, 8);
+  return `${userId.substring(0, 4)}...${hash}`;
+}

--- a/apps/web/lib/sentry/set-user-context.ts
+++ b/apps/web/lib/sentry/set-user-context.ts
@@ -1,0 +1,35 @@
+import 'server-only';
+
+import * as Sentry from '@sentry/nextjs';
+import { headers } from 'next/headers';
+import { maskUserIdForLog } from '@/lib/auth/mask-user-id';
+import { REQUEST_ID_HEADER } from '@/lib/monitoring/middleware';
+
+/**
+ * Attach request-scoped context to the current Sentry scope so any error
+ * captured during this request carries the masked user id + request id.
+ *
+ * Masks the Clerk user id with the same scheme as admin/audit logs so Sentry
+ * and server logs line up without leaking raw Clerk ids into Sentry.
+ *
+ * Safe to fire-and-forget: wraps all work in try/catch and never throws into
+ * the auth path.
+ */
+export async function attachSentryContext(
+  userId: string | null | undefined
+): Promise<void> {
+  try {
+    if (userId) {
+      Sentry.setUser({ id: maskUserIdForLog(userId) });
+    }
+
+    const headerStore = await headers();
+    const requestId = headerStore.get(REQUEST_ID_HEADER);
+    if (requestId) {
+      Sentry.setTag('request_id', requestId);
+    }
+  } catch {
+    // Never throw into the auth path. Missing context is acceptable;
+    // broken auth because of a Sentry import is not.
+  }
+}

--- a/apps/web/tests/unit/lib/sentry/set-user-context.test.ts
+++ b/apps/web/tests/unit/lib/sentry/set-user-context.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setUserMock = vi.fn();
+const setTagMock = vi.fn();
+const headersGetMock = vi.fn();
+
+vi.mock('server-only', () => ({}));
+vi.mock('@sentry/nextjs', () => ({
+  setUser: (...args: unknown[]) => setUserMock(...args),
+  setTag: (...args: unknown[]) => setTagMock(...args),
+}));
+vi.mock('next/headers', () => ({
+  headers: async () => ({ get: (name: string) => headersGetMock(name) }),
+}));
+
+// Import after mocks so the module resolves to the mocked deps.
+const { attachSentryContext } = await import('@/lib/sentry/set-user-context');
+const { maskUserIdForLog } = await import('@/lib/auth/mask-user-id');
+
+describe('attachSentryContext', () => {
+  beforeEach(() => {
+    setUserMock.mockReset();
+    setTagMock.mockReset();
+    headersGetMock.mockReset();
+  });
+
+  it('sets Sentry user with the masked id, never the raw Clerk id', async () => {
+    headersGetMock.mockReturnValue(null);
+    const rawId = 'user_2abcd1234EFGH';
+
+    await attachSentryContext(rawId);
+
+    expect(setUserMock).toHaveBeenCalledTimes(1);
+    const arg = setUserMock.mock.calls[0][0];
+    expect(arg.id).toBe(maskUserIdForLog(rawId));
+    expect(arg.id).not.toBe(rawId);
+    expect(arg.id).not.toContain('EFGH');
+  });
+
+  it('skips setUser when userId is null or undefined', async () => {
+    headersGetMock.mockReturnValue(null);
+
+    await attachSentryContext(null);
+    await attachSentryContext(undefined);
+
+    expect(setUserMock).not.toHaveBeenCalled();
+  });
+
+  it('sets request_id tag when the header is present', async () => {
+    headersGetMock.mockImplementation((name: string) =>
+      name === 'x-request-id' ? 'req_abc123' : null
+    );
+
+    await attachSentryContext('user_xxxxAAAA');
+
+    expect(setTagMock).toHaveBeenCalledWith('request_id', 'req_abc123');
+  });
+
+  it('does not set request_id tag when the header is missing', async () => {
+    headersGetMock.mockReturnValue(null);
+
+    await attachSentryContext('user_xxxxAAAA');
+
+    expect(setTagMock).not.toHaveBeenCalled();
+  });
+
+  it('never throws when Sentry or headers fail', async () => {
+    headersGetMock.mockImplementation(() => {
+      throw new Error('headers not available');
+    });
+    setUserMock.mockImplementation(() => {
+      throw new Error('sentry init race');
+    });
+
+    await expect(attachSentryContext('user_xxxxAAAA')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- `getCachedAuth()` now calls a small `attachSentryContext(userId)` helper that sets `Sentry.setUser({ id: masked })` + `Sentry.setTag('request_id', ...)` on the current Sentry scope
- User id is masked with the same scheme `lib/admin/middleware` already uses, so raw Clerk ids never leave the process
- `request_id` is pulled from the `x-request-id` header already set by `lib/monitoring/middleware`
- Helper wraps everything in try/catch: if Sentry or `headers()` throws, auth still proceeds

## Why
The recent wave of "Clerk: auth() was called…" Sentry issues were triaged purely by stack trace. Prod events had no user correlation and no request correlation, so dedup failed and 7 Linear tickets got created for what was ultimately a single developer's laptop leaking into prod Sentry. Filter for that specific leak already landed in #7153; this PR makes the *next* real prod issue triage-able in one pass.

## Not included
- `release` tag: already injected by `@sentry/nextjs` webpack plugin, adding a manual one would collide (verified against Sentry event `JOVIE-WEB-G9`)
- Edge runtime: `attachSentryContext` is server-only. Edge routes don't call `getCachedAuth`, so scope bleed across concurrent edge invocations is not in play here

## Test plan
- [x] `pnpm --filter web test -- set-user-context` (5 passed)
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [ ] Manual: trigger a deliberate error in dev-opted-in Sentry project; confirm `user.id` is masked (not raw Clerk id) and `request_id` tag present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Monitoring**
  * Enhanced privacy in logs and error tracking with automatic user identifier masking
  * Improved error correlation with per-request ID tracking for better debugging and support

* **Refactor**
  * Consolidated user ID masking logic into shared utility for consistency across authentication flows

* **Tests**
  * Added comprehensive test coverage for Sentry context attachment functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->