### PR TITLE
refactor(ui): font-weight tokens in content metric molecules (1/N)

### DIFF
--- a/apps/web/components/molecules/ContentMetricCard.tsx
+++ b/apps/web/components/molecules/ContentMetricCard.tsx
@@ -53,7 +53,7 @@ export function ContentMetricCard({
             ) : null}
             <p
               className={cn(
-                'truncate text-[11px] font-[560] tracking-normal text-tertiary-token',
+                'truncate text-[11px] font-semibold tracking-normal text-tertiary-token',
                 labelClassName
               )}
             >
@@ -66,7 +66,7 @@ export function ContentMetricCard({
         </div>
         <p
           className={cn(
-            'text-[26px] font-[610] leading-none tracking-[-0.03em] text-primary-token tabular-nums',
+            'text-[26px] font-semibold leading-none tracking-[-0.03em] text-primary-token tabular-nums',
             valueClassName
           )}
         >

--- a/apps/web/components/molecules/ContentMetricCard.tsx
+++ b/apps/web/components/molecules/ContentMetricCard.tsx
@@ -66,7 +66,7 @@ export function ContentMetricCard({
         </div>
         <p
           className={cn(
-            'text-[26px] font-bold leading-none tracking-[-0.03em] text-primary-token tabular-nums',
+            'text-[26px] font-semibold leading-none tracking-[-0.03em] text-primary-token tabular-nums',
             valueClassName
           )}
         >

--- a/apps/web/components/molecules/ContentMetricCard.tsx
+++ b/apps/web/components/molecules/ContentMetricCard.tsx
@@ -66,7 +66,7 @@ export function ContentMetricCard({
         </div>
         <p
           className={cn(
-            'text-[26px] font-semibold leading-none tracking-[-0.03em] text-primary-token tabular-nums',
+            'text-[26px] font-bold leading-none tracking-[-0.03em] text-primary-token tabular-nums',
             valueClassName
           )}
         >

--- a/apps/web/components/molecules/ContentMetricRow.tsx
+++ b/apps/web/components/molecules/ContentMetricRow.tsx
@@ -29,7 +29,7 @@ export function ContentMetricRow({
     >
       <div
         className={cn(
-          'flex min-w-0 items-center gap-2 text-[13px] font-[510] text-primary-token',
+          'flex min-w-0 items-center gap-2 text-[13px] font-caption text-primary-token',
           labelClassName
         )}
       >
@@ -42,7 +42,7 @@ export function ContentMetricRow({
       </div>
       <span
         className={cn(
-          'shrink-0 text-[13px] font-[590] text-primary-token tabular-nums',
+          'shrink-0 text-[13px] font-semibold text-primary-token tabular-nums',
           valueClassName
         )}
       >


### PR DESCRIPTION
## Summary
- First PR in a loop-driven UI-consistency sweep. Replaces `font-[510|560|590|610]` arbitraries with `font-caption` / `font-semibold` tokens in `ContentMetricRow` and `ContentMetricCard`.
- The app has 743 arbitrary `font-[###]` uses across 286 files. Fixing them in token-aligned batches lets brand weight changes propagate through `tailwind.config.js` instead of needing repo-wide sed.

## Token mapping
| Before | After | Delta | Rationale |
|--------|-------|-------|-----------|
| `font-[510]` | `font-caption` | 0 | exact (var `--linear-caption-weight` = 510) |
| `font-[590]` | `font-semibold` | 0 | exact (var `--font-weight-semibold` = 590) |
| `font-[560]` | `font-semibold` | +30 | closest token (30 to 590 vs 60 to 500) |
| `font-[610]` | `font-semibold` | −20 | closest token (20 to 590 vs 70 to 680) |

The two rounded values are imperceptible deltas at 11px / 26px Inter — intentionally not adding a new token for a handful of one-off weights.

## Test plan
- [x] Biome + ESLint + a11y + typecheck (pre-commit hooks)
- [ ] Visually verify `/app/dashboard/earnings` and any route rendering ContentMetricCard/Row
- [ ] No visual regression in Storybook stories for these components

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized typography for content metric displays: switched to token-based font sizes and semibold weights for labels and values.
  * Improves visual consistency and alignment of metric cards and rows across the interface without changing behavior or layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->