### PR TITLE
refactor(ui): font tokens in DemoSettingsPanel (3/N)

### DIFF
--- a/apps/web/components/features/demo/DemoSettingsPanel.tsx
+++ b/apps/web/components/features/demo/DemoSettingsPanel.tsx
@@ -73,7 +73,7 @@ export function DemoSettingsPanel() {
                     }}
                   />
                   <span
-                    className='truncate text-[13px] font-[510]'
+                    className='truncate text-[13px] font-caption'
                     style={{ color: platform.color }}
                   >
                     {platform.name}
@@ -130,12 +130,12 @@ function AudienceQualityCaptureCard() {
         data-testid='demo-settings-audience-quality-capture'
       >
         <div className='border-b border-subtle px-5 py-4'>
-          <p className='text-[11px] font-[560] tracking-[0.12em] text-tertiary-token uppercase'>
+          <p className='text-[11px] font-semibold tracking-[0.12em] text-tertiary-token uppercase'>
             Settings
           </p>
           <div className='mt-2 flex items-end justify-between gap-4'>
             <div>
-              <h2 className='text-[22px] font-[590] tracking-[-0.03em] text-primary-token'>
+              <h2 className='text-[22px] font-semibold tracking-[-0.03em] text-primary-token'>
                 Audience Quality Filtering
               </h2>
               <p className='mt-1 max-w-[34rem] text-[13px] leading-[1.55] text-secondary-token'>
@@ -143,7 +143,7 @@ function AudienceQualityCaptureCard() {
                 traffic, repeat self-visits, and low-signal activity.
               </p>
             </div>
-            <span className='rounded-full border border-[color:color-mix(in_srgb,var(--color-success)_38%,transparent)] bg-[color:color-mix(in_srgb,var(--color-success)_16%,transparent)] px-3 py-1 text-[12px] font-[560] text-primary-token'>
+            <span className='rounded-full border border-[color:color-mix(in_srgb,var(--color-success)_38%,transparent)] bg-[color:color-mix(in_srgb,var(--color-success)_16%,transparent)] px-3 py-1 text-[12px] font-semibold text-primary-token'>
               Active
             </span>
           </div>
@@ -177,7 +177,7 @@ function AudienceQualityCaptureCard() {
             <div className='rounded-[18px] border border-subtle bg-surface-1 p-4'>
               <div className='flex items-start justify-between gap-4'>
                 <div>
-                  <p className='text-[13px] font-[560] text-primary-token'>
+                  <p className='text-[13px] font-semibold text-primary-token'>
                     Advanced Quality Filtering
                   </p>
                   <p className='mt-1 text-[12px] leading-[1.5] text-secondary-token'>
@@ -212,10 +212,10 @@ function SyncSettingsCaptureCard() {
         data-testid='demo-settings-sync-capture'
       >
         <div className='border-b border-subtle px-5 py-4'>
-          <p className='text-[11px] font-[560] tracking-[0.12em] text-tertiary-token uppercase'>
+          <p className='text-[11px] font-semibold tracking-[0.12em] text-tertiary-token uppercase'>
             Settings
           </p>
-          <h2 className='mt-2 text-[22px] font-[590] tracking-[-0.03em] text-primary-token'>
+          <h2 className='mt-2 text-[22px] font-semibold tracking-[-0.03em] text-primary-token'>
             Always in sync
           </h2>
           <p className='mt-1 max-w-[34rem] text-[13px] leading-[1.55] text-secondary-token'>
@@ -228,7 +228,7 @@ function SyncSettingsCaptureCard() {
           <div className='rounded-[18px] border border-subtle bg-surface-1 p-4'>
             <div className='flex items-start justify-between gap-4'>
               <div>
-                <p className='text-[13px] font-[560] text-primary-token'>
+                <p className='text-[13px] font-semibold text-primary-token'>
                   Always in sync
                 </p>
                 <p className='mt-1 text-[12px] leading-[1.5] text-secondary-token'>
@@ -246,7 +246,7 @@ function SyncSettingsCaptureCard() {
           </div>
 
           <div className='rounded-[18px] border border-subtle bg-surface-1 p-4'>
-            <p className='text-[12px] font-[560] text-secondary-token'>
+            <p className='text-[12px] font-semibold text-secondary-token'>
               Connected surfaces
             </p>
             <div className='mt-3 space-y-2'>
@@ -260,7 +260,9 @@ function SyncSettingsCaptureCard() {
                   key={label}
                   className='flex items-center justify-between rounded-[14px] bg-surface-0 px-3 py-2 text-[12px]'
                 >
-                  <span className='font-[510] text-primary-token'>{label}</span>
+                  <span className='font-caption text-primary-token'>
+                    {label}
+                  </span>
                   <span className='text-secondary-token'>
                     Updated automatically
                   </span>
@@ -277,7 +279,7 @@ function SyncSettingsCaptureCard() {
 function AlwaysInSyncToggle() {
   return (
     <div className='inline-flex items-center gap-3'>
-      <span className='text-[12px] font-[560] text-primary-token'>
+      <span className='text-[12px] font-semibold text-primary-token'>
         Always in sync
       </span>
       <span className='flex h-7 w-12 items-center rounded-full bg-[color:var(--color-accent)] px-1 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.08)]'>
@@ -302,14 +304,16 @@ function QualitySignalRow({
     <div className='rounded-[18px] border border-subtle bg-surface-1 p-4'>
       <div className='flex items-start justify-between gap-3'>
         <div>
-          <p className='text-[13px] font-[560] text-primary-token'>{label}</p>
+          <p className='text-[13px] font-semibold text-primary-token'>
+            {label}
+          </p>
           <p className='mt-1 text-[12px] leading-[1.5] text-secondary-token'>
             {detail}
           </p>
         </div>
         <span
           className={cn(
-            'rounded-full px-2.5 py-1 text-[11px] font-[560]',
+            'rounded-full px-2.5 py-1 text-[11px] font-semibold',
             tone === 'success'
               ? 'bg-[color:color-mix(in_srgb,var(--color-success)_18%,transparent)] text-primary-token'
               : 'bg-surface-0 text-secondary-token'
@@ -331,7 +335,7 @@ function FilterRule({
 }>) {
   return (
     <div className='flex items-center justify-between rounded-[14px] bg-surface-0 px-3 py-2 text-[12px]'>
-      <span className='font-[510] text-primary-token'>{label}</span>
+      <span className='font-caption text-primary-token'>{label}</span>
       <span className='text-secondary-token'>{value}</span>
     </div>
   );
@@ -346,10 +350,12 @@ function SyncSurfacePill({
 }>) {
   return (
     <div className='rounded-[16px] border border-subtle bg-surface-1 px-3 py-3'>
-      <p className='text-[11px] font-[560] tracking-[-0.01em] text-secondary-token'>
+      <p className='text-[11px] font-semibold tracking-[-0.01em] text-secondary-token'>
         {label}
       </p>
-      <p className='mt-1 text-[14px] font-[560] text-primary-token'>{value}</p>
+      <p className='mt-1 text-[14px] font-semibold text-primary-token'>
+        {value}
+      </p>
     </div>
   );
 }
@@ -411,7 +417,7 @@ function ToggleRow({
       className='flex cursor-pointer items-start justify-between gap-3 border-b border-[color-mix(in_oklab,var(--linear-app-shell-border)_72%,transparent)] py-2.5 last:border-b-0'
     >
       <div>
-        <p className='text-[13px] font-[510] text-primary-token'>{label}</p>
+        <p className='text-[13px] font-caption text-primary-token'>{label}</p>
         <p className='text-[12px] text-tertiary-token'>{description}</p>
       </div>
       <input


### PR DESCRIPTION
## Summary
Continues the UI-consistency sweep (#7522, #7525). `DemoSettingsPanel.tsx` had 17 `font-[###]` arbitraries across 3 weights.

## Token mapping
| Before | Count | After | Delta | Notes |
|--------|-------|-------|-------|-------|
| `font-[510]` | 4  | `font-caption` (510) | 0 | exact (`--linear-caption-weight`) |
| `font-[560]` | 11 | `font-semibold` (590) | +30 | closest token (alt: medium Δ60) |
| `font-[590]` | 2  | `font-semibold` (590) | 0 | exact |

Deltas ≤30. Closest-token rule per #7522 review.

Non-token diff: Biome auto-reformatted a few JSX closing tags onto their own lines during the pre-commit pass. No semantic changes.

## Test plan
- [x] Biome + ESLint + a11y + typecheck (pre-commit)
- [ ] Visually verify the demo settings panel on preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined typography styling in the settings panel for improved visual consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->