### PR TITLE
refactor(ui): font tokens in ReleaseMetadata (6/N)

### DIFF
--- a/apps/web/components/organisms/release-sidebar/ReleaseMetadata.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseMetadata.tsx
@@ -47,26 +47,26 @@ const METADATA_ROW_PROPS = {
   size: 'sm' as const,
 };
 const METADATA_TEXT_CLASSNAME =
-  'text-[12px] font-[460] leading-[16px] text-secondary-token';
+  'text-[12px] font-book leading-[16px] text-secondary-token';
 const METADATA_MUTED_TEXT_CLASSNAME =
   'text-[11px] leading-[15px] text-tertiary-token';
 const METADATA_LABEL_CLASSNAME =
-  'text-[11px] font-[500] leading-[15px] tracking-normal text-quaternary-token';
+  'text-[11px] font-medium leading-[15px] tracking-normal text-quaternary-token';
 const METADATA_VALUE_CLASSNAME =
   'text-[12px] leading-[16px] text-secondary-token';
 const METADATA_BADGE_CLASSNAME =
-  'h-5 rounded-full border border-subtle bg-surface-0 px-2 text-[9.5px] font-[510] tracking-normal shadow-none';
+  'h-5 rounded-full border border-subtle bg-surface-0 px-2 text-[9.5px] font-caption tracking-normal shadow-none';
 const METADATA_ROW_CLASSNAME = 'rounded-none px-0 py-1 first:pt-0 last:pb-0';
 const METADATA_STACK_CLASSNAME = 'space-y-0.5';
 const METADATA_DISPLAY_VALUE_CLASSNAME =
-  'text-[11.5px] font-[460] leading-[16px] text-primary-token';
+  'text-[11.5px] font-book leading-[16px] text-primary-token';
 const METADATA_INPUT_CLASSNAME =
-  'h-7 rounded-[8px] border-subtle bg-surface-0 px-2.5 text-[11px] font-[460] text-primary-token shadow-none';
+  'h-7 rounded-[8px] border-subtle bg-surface-0 px-2.5 text-[11px] font-book text-primary-token shadow-none';
 
 function PopularityScore({ value }: { readonly value: number }) {
   const clamped = Math.max(0, Math.min(100, value));
   return (
-    <span className='text-[11.5px] font-[460] tabular-nums text-primary-token'>
+    <span className='text-[11.5px] font-book tabular-nums text-primary-token'>
       {clamped} / 100
     </span>
   );
@@ -85,7 +85,7 @@ function ReleaseTypeBadges({ release }: { readonly release: Release }) {
       {release.isExplicit && (
         <Badge
           size='sm'
-          className='h-5 rounded-full border border-transparent bg-red-500/10 px-2 text-[9.5px] font-[510] tracking-normal text-red-600 shadow-none dark:text-red-300'
+          className='h-5 rounded-full border border-transparent bg-red-500/10 px-2 text-[9.5px] font-caption tracking-normal text-red-600 shadow-none dark:text-red-300'
         >
           E
         </Badge>
@@ -337,7 +337,7 @@ export function ReleaseMetadata({
             labelClassName={METADATA_LABEL_CLASSNAME}
             label='Tracks'
             value={
-              <span className='text-[11.5px] font-[460] tabular-nums text-primary-token'>
+              <span className='text-[11.5px] font-book tabular-nums text-primary-token'>
                 {release.totalTracks}{' '}
                 {release.totalTracks === 1 ? 'track' : 'tracks'}
               </span>
@@ -376,7 +376,7 @@ export function ReleaseMetadata({
                     <DrawerButton
                       tone='secondary'
                       size='sm'
-                      className='-mx-0.5 h-5.5 gap-1 rounded-full border-subtle bg-surface-0 px-2 text-[10.5px] font-[510] leading-none text-secondary-token shadow-none hover:bg-surface-0'
+                      className='-mx-0.5 h-5.5 gap-1 rounded-full border-subtle bg-surface-0 px-2 text-[10.5px] font-caption leading-none text-secondary-token shadow-none hover:bg-surface-0'
                     >
                       <span>{canvasStatusDisplayLabel}</span>
                       <ChevronDown
@@ -443,7 +443,7 @@ export function ReleaseMetadata({
               labelClassName={METADATA_LABEL_CLASSNAME}
               label='Duration'
               value={
-                <span className='text-[11.5px] font-[460] tabular-nums text-primary-token'>
+                <span className='text-[11.5px] font-book tabular-nums text-primary-token'>
                   {formatDuration(release.totalDurationMs)}
                 </span>
               }
@@ -482,7 +482,7 @@ export function ReleaseMetadata({
                     <Badge
                       key={genre}
                       variant='secondary'
-                      className='rounded-full border border-subtle bg-surface-0 px-2 py-0 text-[9.5px] font-[510] tracking-normal text-secondary-token shadow-none'
+                      className='rounded-full border border-subtle bg-surface-0 px-2 py-0 text-[9.5px] font-caption tracking-normal text-secondary-token shadow-none'
                     >
                       {genre}
                     </Badge>


### PR DESCRIPTION
## Summary
Continues the UI-consistency sweep (#7522, #7525, #7526, #7528, #7531). `ReleaseMetadata.tsx` had 11 `font-[###]` arbitraries across 3 weights, all exact or near-exact matches.

## Token mapping
| Before | Count | After | Delta | Notes |
|--------|-------|-------|-------|-------|
| `font-[460]` | 6 | `font-book` (450) | −10 | `--font-weight-book`, Linear's UI default |
| `font-[500]` | 1 | `font-medium` (500) | 0 | exact |
| `font-[510]` | 4 | `font-caption` (510) | 0 | exact (`--linear-caption-weight`) |

Max Δ10. Tightest mapping in the sweep so far.

## Visual verification

Captured on the demo release surface (`/demo/showcase/releases` → click release row). ReleaseMetadata renders the right sidebar: title, artist, "Released September 5, 2025", "Album · 18 tracks · 5 DSPs", plus the Properties block (ISRC, UPC, Label, Tracks, Canvas, Popularity, Duration, Released).

![release sidebar with ReleaseMetadata visible on branch](https://raw.githubusercontent.com/JovieInc/Jovie/ui-loop-screenshots/pr-7532/release-sidebar-after.png)

_Screenshot hosted on the repo's `ui-loop-screenshots` orphan branch (separate from main, never merged). Branch created this iteration — see closing note on #7528._

## Test plan
- [x] Biome + ESLint + a11y + typecheck (pre-commit)
- [x] Visual: release sidebar typography renders cleanly on local branch (screenshot above)
- [ ] Preview deploy: same surface, same look

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated font styling across the release metadata interface for improved visual consistency and design standardization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->