### PR TITLE
refactor(ui): font tokens in SuggestedDspMatches (7/N)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SuggestedDspMatches.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SuggestedDspMatches.tsx
@@ -95,7 +95,7 @@ export function SuggestedDspMatches({ profileId }: SuggestedDspMatchesProps) {
   return (
     <div className='mt-3 space-y-1.5'>
       <SectionHeading count={sorted.length} />
-      <p className='px-2 text-[13px] font-[450] leading-[18px] text-secondary-token'>
+      <p className='px-2 text-[13px] font-book leading-[18px] text-secondary-token'>
         We found profiles that may be you on other platforms. Confirm or dismiss
         each one.
       </p>
@@ -115,7 +115,7 @@ export function SuggestedDspMatches({ profileId }: SuggestedDspMatchesProps) {
         <button
           type='button'
           onClick={() => setExpanded(true)}
-          className='px-2 text-[12px] font-[450] text-accent hover:text-accent/80'
+          className='px-2 text-[12px] font-book text-accent hover:text-accent/80'
         >
           Show {hiddenCount} more
         </button>
@@ -127,11 +127,11 @@ export function SuggestedDspMatches({ profileId }: SuggestedDspMatchesProps) {
 function SectionHeading({ count }: { readonly count: number }) {
   return (
     <div className='flex items-center gap-2 px-2'>
-      <span className='text-[11px] font-[450] uppercase tracking-widest text-tertiary-token'>
+      <span className='text-[11px] font-book uppercase tracking-widest text-tertiary-token'>
         Suggested
       </span>
       {count > 0 && (
-        <span className='inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-surface-1 px-1 text-[10px] font-[510] text-tertiary-token'>
+        <span className='inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-surface-1 px-1 text-[10px] font-caption text-tertiary-token'>
           {count}
         </span>
       )}
@@ -190,7 +190,7 @@ function SuggestedMatchRow({
         <PopoverTrigger asChild>
           <span className='contents'>
             <DspProviderIcon provider={match.providerId} size='sm' />
-            <span className='min-w-0 flex-1 truncate text-[13px] font-[450] text-primary-token'>
+            <span className='min-w-0 flex-1 truncate text-[13px] font-book text-primary-token'>
               {match.externalArtistName || label}
             </span>
             <div className='flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 max-lg:opacity-100'>
@@ -287,10 +287,10 @@ function MatchPopoverContent({
           </div>
         )}
         <div className='min-w-0 flex-1'>
-          <p className='truncate text-[14px] font-[590] text-primary-token'>
+          <p className='truncate text-[14px] font-semibold text-primary-token'>
             {match.externalArtistName || 'Unknown Artist'}
           </p>
-          <p className='text-[12px] font-[450] text-tertiary-token'>{label}</p>
+          <p className='text-[12px] font-book text-tertiary-token'>{label}</p>
         </div>
       </div>
 
@@ -309,7 +309,7 @@ function MatchPopoverContent({
             asChild
             variant='ghost'
             size='sm'
-            className='h-7 flex-1 rounded-full text-[12px] font-[510]'
+            className='h-7 flex-1 rounded-full text-[12px] font-caption'
           >
             <a
               href={match.externalArtistUrl}
@@ -326,7 +326,7 @@ function MatchPopoverContent({
           size='sm'
           onClick={onReject}
           disabled={isLoading}
-          className='h-7 flex-1 rounded-full text-[12px] font-[510]'
+          className='h-7 flex-1 rounded-full text-[12px] font-caption'
         >
           {isRejecting ? 'Rejecting...' : 'Reject'}
         </Button>
@@ -335,7 +335,7 @@ function MatchPopoverContent({
           size='sm'
           onClick={onConfirm}
           disabled={isLoading}
-          className='h-7 flex-1 rounded-full text-[12px] font-[510]'
+          className='h-7 flex-1 rounded-full text-[12px] font-caption'
         >
           {isConfirming ? 'Confirming...' : 'Confirm'}
         </Button>


### PR DESCRIPTION
## Summary
Continues the UI-consistency sweep (#7522, #7525, #7526, #7528, #7531, #7533). `SuggestedDspMatches.tsx` had 10 `font-[###]` arbitraries across 3 weights — **every single one is an exact match (Δ0)**. Byte-identical computed styles, zero visual delta.

## Token mapping
| Before | Count | After | Delta | Notes |
|--------|-------|-------|-------|-------|
| `font-[450]` | 5 | `font-book` (450) | 0 | exact — Linear's UI default |
| `font-[510]` | 4 | `font-caption` (510) | 0 | exact — `--linear-caption-weight` |
| `font-[590]` | 1 | `font-semibold` (590) | 0 | exact |

10 swaps, all Δ0. Tightest wedge in the sweep so far.

## Visual verification

`SuggestedDspMatches` renders conditionally inside the profile contact sidebar (only shown when there are unconnected DSPs for the active profile). The default admin chat shell doesn't surface it without additional setup, but since all 10 weight swaps are exact matches to existing tokens, the rendered typography is byte-identical by construction. Screenshot below shows the ambient chat/nav/sidebar shell is intact on-branch:

![admin chat shell on branch](https://raw.githubusercontent.com/JovieInc/Jovie/ui-loop-screenshots/pr-7534/chat-shell-admin.png)

## Deferred wedge — HudDashboardClient
`apps/web/app/hud/HudDashboardClient.tsx` (11 arbitraries, 8× `font-[620]` on 36-72px hero display text) was skipped this iteration. Closest-token rule says semibold (Δ30); hero-display intent argues bold (Δ60). That's a taste call — deserves a dedicated design-review PR, not a mechanical swap. Filed as a follow-up.

## Test plan
- [x] Biome + ESLint + a11y + typecheck (pre-commit)
- [x] Exact-match swap — no computed-style change possible
- [ ] Preview deploy: profile contact sidebar renders cleanly when DSPs are unconnected

🤖 Generated with [Claude Code](https://claude.com/claude-code)