### PR TITLE
refactor(ui): font tokens in EarningsTab (9/N)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/EarningsTab.tsx
+++ b/apps/web/components/features/dashboard/organisms/EarningsTab.tsx
@@ -59,7 +59,7 @@ const tipperColumns = [
     size: 100,
     meta: { align: 'right' },
     cell: ({ getValue }) => (
-      <span className='text-right font-[510] tabular-nums text-primary-token'>
+      <span className='text-right font-caption tabular-nums text-primary-token'>
         {formatCents(getValue())}
       </span>
     ),
@@ -120,9 +120,11 @@ const StatCard = memo(function StatCard({
         >
           <Icon className={`h-3.5 w-3.5 ${iconColor}`} />
         </div>
-        <dt className='text-[13px] font-[510] text-secondary-token'>{label}</dt>
+        <dt className='text-[13px] font-caption text-secondary-token'>
+          {label}
+        </dt>
       </div>
-      <dd className='mt-2 text-2xl font-[590] tabular-nums leading-none tracking-[-0.011em] text-primary-token'>
+      <dd className='mt-2 text-2xl font-semibold tabular-nums leading-none tracking-[-0.011em] text-primary-token'>
         {value}
       </dd>
     </ContentSurfaceCard>
@@ -273,7 +275,7 @@ export function EarningsTab() {
         >
           <QrCode className='h-6 w-6 text-tertiary-token' />
         </div>
-        <h2 className='text-base font-[590] text-primary-token'>
+        <h2 className='text-base font-semibold text-primary-token'>
           No handle set
         </h2>
         <p className='max-w-sm text-[13px] text-secondary-token'>
@@ -290,7 +292,7 @@ export function EarningsTab() {
   return (
     <div className='flex flex-col gap-4'>
       {/* ── Earnings Stats ─────────────────────────── */}
-      <p className='text-[13px] font-[510] tracking-normal text-secondary-token'>
+      <p className='text-[13px] font-caption tracking-normal text-secondary-token'>
         Revenue
       </p>
 
@@ -333,7 +335,7 @@ export function EarningsTab() {
       )}
 
       {/* ── Tippers Table ──────────────────────────── */}
-      <p className='text-[13px] font-[510] tracking-normal text-secondary-token'>
+      <p className='text-[13px] font-caption tracking-normal text-secondary-token'>
         Recent tippers
       </p>
 
@@ -355,7 +357,7 @@ export function EarningsTab() {
       </ContentSurfaceCard>
 
       {/* ── QR Code Card ───────────────────────────── */}
-      <p className='text-[13px] font-[510] tracking-normal text-secondary-token'>
+      <p className='text-[13px] font-caption tracking-normal text-secondary-token'>
         QR Code
       </p>
 
@@ -367,7 +369,7 @@ export function EarningsTab() {
           >
             <QrCode className='h-3.5 w-3.5 text-accent' />
           </div>
-          <h2 className='text-[13px] font-[510] text-primary-token'>
+          <h2 className='text-[13px] font-caption text-primary-token'>
             Tip QR Code
           </h2>
         </div>
@@ -381,7 +383,7 @@ export function EarningsTab() {
           {/* Actions */}
           <div className='flex flex-1 flex-col gap-4'>
             <div>
-              <p className='text-[13px] font-[510] text-primary-token'>
+              <p className='text-[13px] font-caption text-primary-token'>
                 Share your tip page
               </p>
               <p className='mt-1 text-[13px] leading-5 text-secondary-token'>


### PR DESCRIPTION
## Summary
Continues the scope-locked UI-consistency sweep (auth `/app/*` only). `EarningsTab.tsx` had 9 `font-[###]` arbitraries across 2 weights — **both exact matches (Δ0)**.

## Token mapping
| Before | Count | After | Delta |
|--------|-------|-------|-------|
| `font-[510]` | 7 | `font-caption` (510) | 0 |
| `font-[590]` | 2 | `font-semibold` (590) | 0 |

Byte-identical computed style.

## Visual verification

Captured at `/app/settings/artist-profile?tab=earn#pay` (admin persona bypass). The right-side Earn panel + center "Payments" section are both EarningsTab surfaces — "Payments Live / Venmo / Copy Pay Link / Download QR" etc. Career highlights + target playlists (left) are also inside EarningsTab.

![earnings tab surfaces](https://raw.githubusercontent.com/JovieInc/Jovie/ui-loop-screenshots/pr-7538/earnings-tab-after.png)

## Test plan
- [x] Biome + ESLint + a11y + typecheck (pre-commit)
- [x] Exact-match swap — no computed-style change possible
- [x] Visual: Earn tab renders cleanly on branch (screenshot above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)