### PR TITLE
refactor(ui): font tokens in AnalyticsSidebar

### DIFF
--- a/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
@@ -98,15 +98,15 @@ function FunnelStage({
   return (
     <div className='space-y-1.5 px-3 py-2'>
       <div className='flex items-baseline justify-between gap-2'>
-        <span className='text-[11.5px] font-[510] text-secondary-token'>
+        <span className='text-[11.5px] font-caption text-secondary-token'>
           {label}
         </span>
         <span className='flex items-baseline gap-1.5'>
-          <span className='tabular-nums text-[15px] font-[590] leading-none tracking-[-0.02em] text-primary-token'>
+          <span className='tabular-nums text-[15px] font-semibold leading-none tracking-[-0.02em] text-primary-token'>
             {numberFormatter.format(value)}
           </span>
           {rate && (
-            <span className='tabular-nums text-[10px] font-[510] text-tertiary-token'>
+            <span className='tabular-nums text-[10px] font-caption text-tertiary-token'>
               {rate}
             </span>
           )}
@@ -216,7 +216,7 @@ function RankedList({
           className='group flex h-9 items-center justify-between rounded-[8px] px-2.5 transition-colors hover:bg-surface-1'
         >
           <div className='flex min-w-0 flex-1 items-center gap-1.5'>
-            <span className='w-3 text-[11px] font-[510] text-tertiary-token tabular-nums'>
+            <span className='w-3 text-[11px] font-caption text-tertiary-token tabular-nums'>
               {index + 1}
             </span>
             <IconComponent className='h-3.5 w-3.5 text-tertiary-token' />
@@ -224,7 +224,7 @@ function RankedList({
               {item.label}
             </span>
           </div>
-          <span className='ml-2 text-[13px] font-[590] text-primary-token tabular-nums'>
+          <span className='ml-2 text-[13px] font-semibold text-primary-token tabular-nums'>
             {item.value}
           </span>
         </li>
@@ -291,7 +291,7 @@ export function AnalyticsSidebarView({
             </div>
             <div className='flex items-start justify-between gap-3 pr-8'>
               <div className='space-y-0.5'>
-                <p className='text-[15px] font-[590] tracking-[-0.016em] text-primary-token'>
+                <p className='text-[15px] font-semibold tracking-[-0.016em] text-primary-token'>
                   Audience funnel
                 </p>
                 <p className='text-[12px] leading-[16px] text-secondary-token'>


### PR DESCRIPTION
## Token mapping

| From | To | Count | Delta |
|---|---|---|---|
| `font-[510]` | `font-caption` (`--linear-caption-weight`) | 3 | 0 |
| `font-[590]` | `font-semibold` (`--font-weight-semibold`) | 3 | 0 |

## Summary

Exact-match token swaps in `AnalyticsSidebar.tsx`. Computed style is byte-identical, so screenshots are skipped for this delta-0 batch (zero visual change by construction).

Continues the scope-locked UI-consistency sweep (auth `/app/*` surfaces only) from #7522 through #7543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)