### PR TITLE
refactor(ui): font tokens in ReleaseCell

### DIFF
--- a/apps/web/components/features/dashboard/organisms/releases/cells/ReleaseCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/cells/ReleaseCell.tsx
@@ -123,7 +123,7 @@ export const ReleaseCell = memo(function ReleaseCell({
           <div className='flex min-w-0 items-center gap-1.5 leading-none'>
             <TruncatedText
               lines={1}
-              className='min-w-0 flex-1 text-[13px] font-[510] leading-[1.15] tracking-[-0.012em] text-primary-token'
+              className='min-w-0 flex-1 text-[13px] font-caption leading-[1.15] tracking-[-0.012em] text-primary-token'
               tooltipSide='top'
               tooltipAlign='start'
             >
@@ -132,7 +132,7 @@ export const ReleaseCell = memo(function ReleaseCell({
             {showType && typeStyle && hasPreview && (
               <span
                 className={cn(
-                  'shrink-0 text-[10px] font-[510] leading-none tracking-normal',
+                  'shrink-0 text-[10px] font-caption leading-none tracking-normal',
                   typeStyle.text
                 )}
               >
@@ -143,7 +143,7 @@ export const ReleaseCell = memo(function ReleaseCell({
           {artistLine ? (
             <TruncatedText
               lines={1}
-              className='mt-px text-[11px] font-[400] leading-[1.2] tracking-[-0.005em] text-secondary-token'
+              className='mt-px text-[11px] font-normal leading-[1.2] tracking-[-0.005em] text-secondary-token'
             >
               {artistLine}
             </TruncatedText>
@@ -154,7 +154,7 @@ export const ReleaseCell = memo(function ReleaseCell({
           <div className='flex min-w-0 items-center gap-1.5 leading-none'>
             <TruncatedText
               lines={1}
-              className='min-w-0 flex-1 text-[13px] font-[510] leading-[1.15] tracking-[-0.012em] text-primary-token'
+              className='min-w-0 flex-1 text-[13px] font-caption leading-[1.15] tracking-[-0.012em] text-primary-token'
               tooltipSide='top'
               tooltipAlign='start'
             >
@@ -163,7 +163,7 @@ export const ReleaseCell = memo(function ReleaseCell({
             {showType && typeStyle && hasPreview && (
               <span
                 className={cn(
-                  'shrink-0 text-[10px] font-[510] leading-none tracking-normal',
+                  'shrink-0 text-[10px] font-caption leading-none tracking-normal',
                   typeStyle.text
                 )}
               >
@@ -174,7 +174,7 @@ export const ReleaseCell = memo(function ReleaseCell({
           {artistLine ? (
             <TruncatedText
               lines={1}
-              className='mt-px text-[11px] font-[400] leading-[1.2] tracking-[-0.005em] text-secondary-token'
+              className='mt-px text-[11px] font-normal leading-[1.2] tracking-[-0.005em] text-secondary-token'
             >
               {artistLine}
             </TruncatedText>


### PR DESCRIPTION
## Token mapping

| Before | Count | After | Token |
|---|---|---|---|
| `font-[400]` | 2 | `font-normal` | `--font-weight-normal` |
| `font-[510]` | 4 | `font-caption` | `--linear-caption-weight` |

Δ0 batch, screenshots skipped because byte-identical computed styles make visual diff impossible.

Continues #7522 through #7544 sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)