### PR TITLE
fix(demo): realign /demo/onboarding with real flow + consolidate design tokens

### DIFF
--- a/apps/web/components/features/demo/OnboardingDemoContent.tsx
+++ b/apps/web/components/features/demo/OnboardingDemoContent.tsx
@@ -15,10 +15,14 @@ const DEMO_ONBOARDING_STEPS = ['handle', 'dsp', 'profile-review'] as const;
 
 export type DemoOnboardingStepId = (typeof DEMO_ONBOARDING_STEPS)[number];
 
+// Labels mirror the canonical sidebar labels used by OnboardingV2Form
+// (Handle / Spotify / Finish). The demo exposes a condensed 3-step slice,
+// but the labels should match the real flow so the demo reads as a faithful
+// preview of real onboarding.
 const STEP_LABELS: Record<DemoOnboardingStepId, string> = {
   handle: 'Handle',
-  dsp: 'Music',
-  'profile-review': 'Profile',
+  dsp: 'Spotify',
+  'profile-review': 'Finish',
 };
 
 function getStepIndicatorClassName(index: number, currentIndex: number) {
@@ -55,7 +59,7 @@ function StepSwitcher({
           type='button'
           onClick={() => onStepChange(step)}
           className={cn(
-            'shrink-0 rounded-full px-3 py-1.5 text-[12px] font-medium transition-colors',
+            'shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
             currentStep === step
               ? 'bg-accent-token text-white'
               : 'text-secondary-token hover:bg-surface-1 hover:text-primary-token'
@@ -111,8 +115,8 @@ export function OnboardingDemoContent({
       case 'handle':
         return (
           <OnboardingHandleStep
-            title='Choose your handle'
-            prompt='This is how fans will find and remember you.'
+            title='Claim your link'
+            prompt='This is the only link you need to share your music. Make it yours.'
             handleInput={handleInput}
             isHydrated
             handleValidation={DEMO_HANDLE_VALIDATION}
@@ -129,8 +133,8 @@ export function OnboardingDemoContent({
       case 'dsp':
         return (
           <OnboardingDspStep
-            title='Connect your music'
-            prompt='Import your releases from Spotify so fans can find your music.'
+            title='Are you on Spotify?'
+            prompt='Connect Spotify so we can pull in your releases, artwork, and DSP links automatically.'
             onConnected={() => onStepChange('profile-review')}
             onSkip={() => onStepChange('profile-review')}
             isTransitioning={false}
@@ -139,8 +143,8 @@ export function OnboardingDemoContent({
       case 'profile-review':
         return (
           <OnboardingProfileReviewStep
-            title='Your profile'
-            prompt='Review your profile before going live.'
+            title='Your link is live'
+            prompt='Review your profile. You can polish anything later from the dashboard.'
             enrichedProfile={DEMO_ENRICHED_PROFILE}
             handle={handleInput}
             onGoToDashboard={onFinish}


### PR DESCRIPTION
## What drifted

The `/demo/onboarding` surface had fallen out of sync with the authenticated onboarding runtime (`OnboardingV2Form`) after the step copy + sidebar overhaul shipped. Specifically:

- Step labels were `Handle / Music / Profile` instead of the canonical `Handle / Spotify / Finish` used by `SIDEBAR_STEPS` in `OnboardingV2Form`.
- Handle step read `"Choose your handle"` with a generic prompt instead of the real `"Claim your link"` framing.
- DSP step read `"Connect your music"` instead of the real `"Are you on Spotify?"` framing.
- Final step read `"Your profile"` / `"Review your profile before going live."` instead of the real `"Your link is live"` completion framing.
- `StepSwitcher` still used a `text-[12px]` arbitrary, which survived the #7525 tokenization pass.

## What I fixed

Scoped strictly to `apps/web/components/features/demo/OnboardingDemoContent.tsx`:

- Realigned step labels to `Handle / Spotify / Finish` to mirror the real sidebar.
- Replaced the three step titles + prompts with the canonical strings used by `OnboardingV2Form`.
- Replaced `text-[12px]` with the `text-xs` token.
- Added a comment documenting that the condensed 3-step slice is intentional (locked in by `surface-elevation-guardrails.test.ts`, which asserts the demo keeps reusing `OnboardingHandleStep` / `OnboardingDspStep` / `OnboardingProfileReviewStep` under `OnboardingExperienceShell`).

The real onboarding flow (`OnboardingV2Form.tsx`) and shared step organisms were **not** touched — they were already tokenized in #7525.

## Before / after

| Step | Before | After |
|---|---|---|
| 1. Handle | ![before](https://raw.githubusercontent.com/JovieInc/Jovie/ui-loop-screenshots/pr-demo-onboarding/step1-handle-before.png) | ![after](https://raw.githubusercontent.com/JovieInc/Jovie/ui-loop-screenshots/pr-demo-onboarding/step1-handle-after.png) |
| 2. DSP / Spotify | ![before](https://raw.githubusercontent.com/JovieInc/Jovie/ui-loop-screenshots/pr-demo-onboarding/step2-dsp-before.png) | ![after](https://raw.githubusercontent.com/JovieInc/Jovie/ui-loop-screenshots/pr-demo-onboarding/step2-dsp-after.png) |
| 3. Profile / Finish | ![before](https://raw.githubusercontent.com/JovieInc/Jovie/ui-loop-screenshots/pr-demo-onboarding/step3-profile-before.png) | ![after](https://raw.githubusercontent.com/JovieInc/Jovie/ui-loop-screenshots/pr-demo-onboarding/step3-profile-after.png) |

## Token consolidation summary

- `text-[12px] font-medium` -> `text-xs font-medium` on the `StepSwitcher` pill — aligns with the design token cleanup series (#7525 and follow-ups). The component is now free of `text-[###]` / `font-[###]` arbitraries.

## Context

Extends the UI-consistency sweep series (#7525 and parallel sibling PRs touching other surfaces). This PR is intentionally small because the demo re-uses shared step organisms that live outside the demo scope and were already tokenized upstream — so the remaining drift was copy and one arbitrary.

## Follow-ups worth considering

- The demo shape is 3 steps (Handle / Spotify / Finish), but real onboarding is now 7 sidebar steps (adds Plan, DSPs, Social, Releases between Spotify and Finish). If product wants the demo to feel truly 1:1 with real onboarding, we should plan a follow-up that either (a) expands the demo to all 7 steps with mocked fixtures, or (b) rewrites the demo to render `OnboardingV2Form` directly against a mocked discovery snapshot. Out of scope for this pass because it requires relaxing `surface-elevation-guardrails.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)