### PR TITLE
refactor(ui): font tokens in ProfileEditPreviewCard

### DIFF
--- a/apps/web/components/features/dashboard/organisms/ProfileEditPreviewCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/ProfileEditPreviewCard.tsx
@@ -93,14 +93,14 @@ export function ProfileEditPreviewCard({
       <ContentSurfaceCard className='p-3'>
         <div className='flex items-center justify-between gap-2'>
           <div className='min-w-0 space-y-0.5'>
-            <p className='truncate text-[13px] font-[560] tracking-[-0.01em] text-primary-token'>
+            <p className='truncate text-[13px] font-semibold tracking-[-0.01em] text-primary-token'>
               {preview.fieldLabel}
             </p>
             <p className='text-[12px] text-secondary-token'>
               Updated successfully
             </p>
           </div>
-          <span className='inline-flex shrink-0 items-center gap-1 rounded-md border border-subtle bg-surface-1 px-1.5 py-0.5 text-[11px] font-[510] tracking-[-0.01em] text-success'>
+          <span className='inline-flex shrink-0 items-center gap-1 rounded-md border border-subtle bg-surface-1 px-1.5 py-0.5 text-[11px] font-caption tracking-[-0.01em] text-success'>
             <Check className='h-3.5 w-3.5' />
             Applied
           </span>
@@ -115,12 +115,12 @@ export function ProfileEditPreviewCard({
       <ContentSurfaceCard className='p-3 opacity-70'>
         <div className='flex items-center justify-between gap-2'>
           <div className='min-w-0 space-y-0.5'>
-            <p className='truncate text-[13px] font-[560] tracking-[-0.01em] text-primary-token'>
+            <p className='truncate text-[13px] font-semibold tracking-[-0.01em] text-primary-token'>
               {preview.fieldLabel}
             </p>
             <p className='text-[12px] text-secondary-token'>Edit cancelled</p>
           </div>
-          <span className='inline-flex shrink-0 items-center gap-1 rounded-md bg-surface-0 px-1.5 py-0.5 text-[11px] font-[510] tracking-[-0.01em] text-secondary-token'>
+          <span className='inline-flex shrink-0 items-center gap-1 rounded-md bg-surface-0 px-1.5 py-0.5 text-[11px] font-caption tracking-[-0.01em] text-secondary-token'>
             <X className='h-3.5 w-3.5' />
             Cancelled
           </span>
@@ -133,7 +133,7 @@ export function ProfileEditPreviewCard({
     <ContentSurfaceCard className='overflow-hidden'>
       <div className='px-3 py-2'>
         <div className='space-y-0.5'>
-          <h4 className='text-[13px] font-[560] tracking-[-0.01em] text-primary-token'>
+          <h4 className='text-[13px] font-semibold tracking-[-0.01em] text-primary-token'>
             Update {preview.fieldLabel}
           </h4>
           {preview.reason && (
@@ -146,7 +146,7 @@ export function ProfileEditPreviewCard({
 
       <div className='space-y-2 px-3 py-2'>
         <div className='rounded-[10px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-2'>
-          <div className='mb-0.5 text-[13px] font-[510] tracking-normal text-secondary-token'>
+          <div className='mb-0.5 text-[13px] font-caption tracking-normal text-secondary-token'>
             Current
           </div>
           <div
@@ -159,7 +159,7 @@ export function ProfileEditPreviewCard({
           </div>
         </div>
         <div className='rounded-[10px] border border-accent/20 bg-accent/5 px-2.5 py-2'>
-          <div className='mb-0.5 text-[13px] font-[510] tracking-normal text-(--linear-accent)'>
+          <div className='mb-0.5 text-[13px] font-caption tracking-normal text-(--linear-accent)'>
             New
           </div>
           <div className='text-[13px] tracking-[-0.01em] text-primary-token'>


### PR DESCRIPTION
## Summary

Replaces 7 arbitrary Tailwind font-weight utilities in `ProfileEditPreviewCard.tsx` with design-system tokens.

| Arbitrary | Count | Token | Delta |
|-----------|-------|-------|-------|
| `font-[510]` | 4 | `font-caption` | 0 (exact) |
| `font-[560]` | 3 | `font-semibold` | 30 (closest; alt `font-medium` = 60) |

Max Δ30 — imperceptible at UI text sizes. Closest-token rule per #7522 review.

Continues the #7522 through #7549 UI-consistency sweep (auth `/app/*` surfaces only).

## Test plan

- [ ] CI green (biome, eslint, typecheck)
- [ ] Visual spot-check ProfileEditPreviewCard in /app dashboard — no perceptible weight shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)