### PR TITLE
refactor(ui): tokenize shared onboarding step organisms

### DIFF
--- a/apps/web/components/features/dashboard/organisms/onboarding/OnboardingDspStep.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding/OnboardingDspStep.tsx
@@ -195,7 +195,7 @@ export function OnboardingDspStep({
                           <div className='h-8 w-8 shrink-0 rounded-full bg-surface-0' />
                         )}
                         <div className='min-w-0 flex-1'>
-                          <p className='truncate text-[13px] font-[510] text-primary-token'>
+                          <p className='truncate text-[13px] font-caption text-primary-token'>
                             {artist.name}
                           </p>
                           {artist.followers != null && (

--- a/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
@@ -84,7 +84,7 @@ export function OnboardingHandleStep({
   return (
     <div className='mx-auto flex w-full max-w-2xl flex-col gap-6'>
       <div className='space-y-3'>
-        <h1 className='text-3xl font-[620] tracking-[-0.04em] text-primary-token sm:text-[2.7rem]'>
+        <h1 className='text-3xl font-semibold tracking-[-0.04em] text-primary-token sm:text-[2.7rem]'>
           {title}
         </h1>
         {prompt ? (
@@ -106,7 +106,7 @@ export function OnboardingHandleStep({
               hasError && 'border-destructive/60'
             )}
           >
-            <span className='pl-3 text-[15px] font-[560] whitespace-nowrap text-secondary-token'>
+            <span className='pl-3 text-[15px] font-semibold whitespace-nowrap text-secondary-token'>
               jov.ie/
             </span>
             <input
@@ -130,7 +130,7 @@ export function OnboardingHandleStep({
               autoCorrect='off'
               spellCheck={false}
               aria-invalid={hasError ? 'true' : undefined}
-              className='min-w-0 flex-1 bg-transparent text-[15px] font-[560] tracking-[-0.02em] text-primary-token placeholder:text-tertiary-token placeholder:opacity-60 focus-visible:outline-none'
+              className='min-w-0 flex-1 bg-transparent text-[15px] font-semibold tracking-[-0.02em] text-primary-token placeholder:text-tertiary-token placeholder:opacity-60 focus-visible:outline-none'
             />
             <button
               data-testid='onboarding-handle-submit'

--- a/apps/web/components/features/dashboard/organisms/onboarding/OnboardingProfileReviewStep.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding/OnboardingProfileReviewStep.tsx
@@ -409,7 +409,7 @@ export function OnboardingProfileReviewStep({
                           maxLength={50}
                           className={cn(
                             AUTH_SURFACE.fieldInput,
-                            'text-center text-[15px] font-[590]'
+                            'text-center text-[15px] font-semibold'
                           )}
                           aria-label='Edit display name'
                         />
@@ -426,7 +426,7 @@ export function OnboardingProfileReviewStep({
                         className='group cursor-pointer'
                         aria-label='Edit display name'
                       >
-                        <span className='text-[16px] font-[590] text-primary-token transition-colors group-hover:text-accent'>
+                        <span className='text-[16px] font-semibold text-primary-token transition-colors group-hover:text-accent'>
                           {editableDisplayName}
                         </span>
                       </button>


### PR DESCRIPTION
## Summary

Tokenizes 6 `font-[###]` arbitraries across 3 shared-organism files used by BOTH the real auth'd `/onboarding` flow AND `/demo/onboarding`.

## Token mapping (closest-token rule, max Δ30)

| File | Before | After | Δ |
|---|---|---|---|
| OnboardingHandleStep (H1 ~30-43px) | `font-[560]` × 2 | `font-semibold` | 30 |
| OnboardingHandleStep (H1 ~30-43px) | `font-[620]` × 1 | `font-semibold` | 30 (alt `font-bold` Δ60) |
| OnboardingDspStep | `font-[510]` × 1 | `font-caption` | 0 |
| OnboardingProfileReviewStep | `font-[590]` × 2 | `font-semibold` | 0 |

## Before / After

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/JovieInc/Jovie/ui-loop-screenshots/pr-onboarding-steps/onboarding-step-before.png) | ![after](https://raw.githubusercontent.com/JovieInc/Jovie/ui-loop-screenshots/pr-onboarding-steps/onboarding-step-after.png) |

H1 weight shift (620→600) is visually imperceptible at display sizes.

Max Δ30. Closest-token rule per #7522 review. Follow-up to #7549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)