### PR TITLE
fix(ci): prevent main deploy starvation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3071,11 +3071,12 @@ jobs:
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    # Deploy concurrency: if multiple main pushes stack up (e.g., merge queue burst),
-    # cancel the in-progress deploy and deploy only the latest commit.
+    # Deploy concurrency: serialize main deploys instead of cancelling them.
+    # Cancelling in-progress main deploys during merge bursts can starve
+    # production promotion and leave main without a completed deploy run.
     concurrency:
       group: production-deploy
-      cancel-in-progress: true
+      cancel-in-progress: false
     outputs:
       migration_status: ${{ steps.migrate.outcome }}
       preflight_status: ${{ steps.preflight.outcome }}
@@ -3158,7 +3159,7 @@ jobs:
     if: ${{ always() && needs.deploy-staging.result == 'success' }}
     concurrency:
       group: production-deploy
-      cancel-in-progress: true
+      cancel-in-progress: false
     uses: ./.github/workflows/canary-health-gate.yml
     with:
       deployment_url: https://staging.jov.ie
@@ -3178,7 +3179,7 @@ jobs:
     timeout-minutes: 10
     concurrency:
       group: production-deploy
-      cancel-in-progress: true
+      cancel-in-progress: false
     environment:
       name: Production – jovie
       url: https://jov.ie


### PR DESCRIPTION
## Summary
- Serialize the shared `production-deploy` concurrency group instead of cancelling in-progress main deploy stages.
- Apply the same `cancel-in-progress: false` behavior to staging deploy, staging canary, and production promotion.
- Keep the change scoped to the CI deploy path so merge-burst pushes can queue and finish a production promotion.

## Root Cause
The original failed main run hit a staging canary failure because unauthenticated `POST /api/chat` returned 500 instead of 401. That was already fixed on main by #7521.

Production still was not deploying because subsequent main CI runs were repeatedly cancelled before promotion. The deploy-stage jobs all shared `concurrency.group: production-deploy` with `cancel-in-progress: true`, so each newer main push cancelled the in-flight deploy/canary/promotion from the previous push. During merge bursts, main could keep passing earlier checks while production promotion was starved.

## Review
- Manual `/review` completed with no findings.
- Checked the CI/CD distribution risk: this preserves the existing production deploy lock but queues instead of cancelling main deploys.
- Could not run the Codex adversarial CLI pass locally because `codex.exe` returned Windows `Access is denied`.

## Verification
- `actionlint 1.7.12 -config-file .github/actionlint.yaml .github/workflows/ci.yml`
- `pnpm --filter=@jovie/web run next:proxy-guard`
- `pnpm turbo typecheck`
- `doppler run --project jovie-web --config dev -- pnpm --filter=@jovie/web exec vitest run --config=vitest.config.mts tests/unit/lib/auth/cached.test.ts tests/unit/chat/session-error-response.test.ts --reporter=dot --pool=forks --maxWorkers=1` (2 files, 23 tests passed)
- `git push` pre-push hook passed Biome, web proxy guard, Tailwind guard, web typecheck, and web lint; Biome reported existing ReleaseSidebar index-key warnings only.

## Notes
- Version and changelog were intentionally left unchanged for this workflow-only emergency unblock. Main already has unrelated version metadata drift (`version.json` and two package versions lag the root/app version), so I kept that cleanup out of this PR.
- Local `pnpm turbo typecheck --affected` fails in this linked Windows worktree because Turbo cannot find a `.git/index`; full non-affected typecheck passed.