### PR TITLE
refactor(ui): text-size tokens in DspPresenceSidebar

### DIFF
--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceSidebar.tsx
@@ -102,10 +102,10 @@ function SidebarEntityHeader({
             </div>
           )}
           <div className='min-w-0 flex-1'>
-            <div className='truncate text-[14px] font-[590] text-primary-token'>
+            <div className='truncate text-sm font-[590] text-primary-token'>
               {item.externalArtistName ?? 'Unknown Artist'}
             </div>
-            <div className='mt-0.5 flex items-center gap-1.5 text-[12px] text-tertiary-token'>
+            <div className='mt-0.5 flex items-center gap-1.5 text-xs text-tertiary-token'>
               <DspProviderIcon provider={item.providerId} size='sm' />
               <span>{label}</span>
             </div>
@@ -140,29 +140,29 @@ function SidebarContent({ item }: { readonly item: DspPresenceItem }) {
       <DrawerSection title='Match Status' className='space-y-1.5'>
         <div className='space-y-2'>
           <div className='flex items-center justify-between'>
-            <span className='text-[12px] text-tertiary-token'>Status</span>
+            <span className='text-xs text-tertiary-token'>Status</span>
             <MatchStatusBadge status={item.status} size='sm' />
           </div>
           <div className='flex items-center justify-between'>
-            <span className='text-[12px] text-tertiary-token'>Source</span>
-            <span className='text-[12px] text-primary-token'>
+            <span className='text-xs text-tertiary-token'>Source</span>
+            <span className='text-xs text-primary-token'>
               {getMatchSourceLabel(item.matchSource)}
             </span>
           </div>
           {item.matchingIsrcCount > 0 && (
             <div className='flex items-center justify-between'>
-              <span className='text-[12px] text-tertiary-token'>
+              <span className='text-xs text-tertiary-token'>
                 Tracks Verified
               </span>
-              <span className='text-[12px] text-primary-token'>
+              <span className='text-xs text-primary-token'>
                 {item.matchingIsrcCount}
               </span>
             </div>
           )}
           {item.confirmedAt && (
             <div className='flex items-center justify-between'>
-              <span className='text-[12px] text-tertiary-token'>Confirmed</span>
-              <span className='text-[12px] text-primary-token'>
+              <span className='text-xs text-tertiary-token'>Confirmed</span>
+              <span className='text-xs text-primary-token'>
                 {formatDate(item.confirmedAt)}
               </span>
             </div>
@@ -185,7 +185,7 @@ function SidebarContent({ item }: { readonly item: DspPresenceItem }) {
               <Button
                 variant='ghost'
                 size='sm'
-                className='h-8 w-full justify-start rounded-full border-subtle bg-surface-0 px-3 text-[12px] font-[510]'
+                className='h-8 w-full justify-start rounded-full border-subtle bg-surface-0 px-3 text-xs font-[510]'
               >
                 <Icon name='ExternalLink' className='mr-1.5 h-3.5 w-3.5' />
                 View on {label}
@@ -220,7 +220,7 @@ function SuggestedMatchActions({ matchId }: { readonly matchId: string }) {
         size='sm'
         onClick={() => rejectMatch(matchId)}
         disabled={isLoading}
-        className='h-8 flex-1 rounded-full border border-subtle bg-surface-0 text-[12px] font-[510]'
+        className='h-8 flex-1 rounded-full border border-subtle bg-surface-0 text-xs font-[510]'
       >
         {isRejecting ? 'Rejecting...' : 'Reject'}
       </Button>
@@ -229,7 +229,7 @@ function SuggestedMatchActions({ matchId }: { readonly matchId: string }) {
         size='sm'
         onClick={() => confirmMatch(matchId)}
         disabled={isLoading}
-        className='h-8 flex-1 rounded-full text-[12px] font-[510]'
+        className='h-8 flex-1 rounded-full text-xs font-[510]'
       >
         {isConfirming ? 'Confirming...' : 'Confirm Match'}
       </Button>


### PR DESCRIPTION
## Token swaps

| Arbitrary | Token | Count |
|---|---|---|
| `text-[12px]` | `text-xs` | 11 |
| `text-[14px]` | `text-sm` | 1 |

Δ0. Continues text-size wave.