### PR TITLE
refactor(ui): text-size tokens in ReleasesEmptyState

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleasesEmptyState.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleasesEmptyState.tsx
@@ -30,10 +30,10 @@ export function ReleasesEmptyState({
           <Icon name='Sparkles' className='h-4 w-4 text-tertiary-token' />
         </div>
         <div className='mb-2.5 h-4.5 w-4.5 animate-spin rounded-full border-2 border-accent/30 border-t-accent' />
-        <h3 className='text-[13px] font-[510] text-primary-token'>
+        <h3 className='text-app font-[510] text-primary-token'>
           Finding your music...
         </h3>
-        <p className='mt-0.5 max-w-sm text-[12px] leading-[17px] text-secondary-token'>
+        <p className='mt-0.5 max-w-sm text-xs leading-[17px] text-secondary-token'>
           We&apos;re discovering your releases across streaming platforms. This
           usually takes a few seconds.
         </p>
@@ -52,10 +52,10 @@ export function ReleasesEmptyState({
         <div className='mb-2.5 flex h-9 w-9 items-center justify-center rounded-[10px] border border-subtle bg-surface-1'>
           <Icon name='Disc3' className='h-4 w-4 text-tertiary-token' />
         </div>
-        <h3 className='text-[13px] font-[510] text-primary-token'>
+        <h3 className='text-app font-[510] text-primary-token'>
           We found some of your music
         </h3>
-        <p className='mt-0.5 max-w-sm text-[12px] leading-[17px] text-secondary-token'>
+        <p className='mt-0.5 max-w-sm text-xs leading-[17px] text-secondary-token'>
           We couldn&apos;t find all your streaming links. You can add missing
           ones manually or try again.
         </p>
@@ -63,7 +63,7 @@ export function ReleasesEmptyState({
           <DrawerButton
             tone='secondary'
             onClick={onRetryEnrichment}
-            className='mt-3 h-7 rounded-[8px] px-2.5 text-[11px]'
+            className='mt-3 h-7 rounded-[8px] px-2.5 text-2xs'
           >
             Try again
           </DrawerButton>
@@ -83,10 +83,10 @@ export function ReleasesEmptyState({
         <div className='mb-2.5 flex h-9 w-9 items-center justify-center rounded-[10px] border border-subtle bg-surface-1'>
           <Icon name='SearchX' className='h-4 w-4 text-tertiary-token' />
         </div>
-        <h3 className='text-[13px] font-[510] text-primary-token'>
+        <h3 className='text-app font-[510] text-primary-token'>
           We had trouble finding your music
         </h3>
-        <p className='mt-0.5 max-w-sm text-[12px] leading-[17px] text-secondary-token'>
+        <p className='mt-0.5 max-w-sm text-xs leading-[17px] text-secondary-token'>
           Something went wrong while searching streaming platforms. You can try
           again or add your releases manually.
         </p>
@@ -94,7 +94,7 @@ export function ReleasesEmptyState({
           <DrawerButton
             tone='primary'
             onClick={onRetryEnrichment}
-            className='mt-3 h-7 rounded-[8px] px-2.5 text-[11px]'
+            className='mt-3 h-7 rounded-[8px] px-2.5 text-2xs'
           >
             Try again
           </DrawerButton>
@@ -113,16 +113,16 @@ export function ReleasesEmptyState({
       <div className='mb-2.5 flex h-9 w-9 items-center justify-center rounded-[10px] border border-subtle bg-surface-1'>
         <Icon name='Disc3' className='h-4 w-4 text-tertiary-token' />
       </div>
-      <h3 className='text-[13px] font-[510] text-primary-token'>
+      <h3 className='text-app font-[510] text-primary-token'>
         Connect Spotify
       </h3>
-      <p className='mt-0.5 max-w-sm text-[12px] leading-[17px] text-secondary-token'>
+      <p className='mt-0.5 max-w-sm text-xs leading-[17px] text-secondary-token'>
         Search your artist profile to import releases.
       </p>
       <DrawerButton
         tone='primary'
         onClick={onConnectSpotify}
-        className='mt-3 h-7 rounded-[8px] px-2.5 text-[11px]'
+        className='mt-3 h-7 rounded-[8px] px-2.5 text-2xs'
       >
         Connect Spotify
       </DrawerButton>


### PR DESCRIPTION
## Token mapping

- 13px x4 -> `text-app`
- 12px x4 -> `text-xs`
- 11px x3 -> `text-2xs`

11 swaps, all exact-match. Δ0. Text-size wave.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated typography and button sizing in the releases empty state for improved visual consistency across different UI states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->