### PR TITLE
feat(design-tokens): add text-3xs (10px)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -431,7 +431,8 @@ body {
 
 @theme {
   /* Custom font sizes — Linear's type scale registered as Tailwind utilities
-     text-2xs = 11px, text-app = 13px (Linear's default UI size) */
+     text-3xs = 10px, text-2xs = 11px, text-app = 13px (Linear's default UI size) */
+  --text-3xs: 0.625rem;
   --text-2xs: 0.6875rem;
   --text-app: 0.8125rem;
   /* Font stack: var(--font-inter) for Next.js localFont, then Linear's exact fallbacks */

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -872,6 +872,8 @@
 
   /* Type scale - based on 16px base
      KEY: Linear uses 13px (0.8125rem) as the primary app UI size */
+  --text-3xs: 0.625rem;
+  /* 10px — micro labels, legal */
   --text-2xs: 0.6875rem;
   /* 11px — tiny labels, badges */
   --text-xs: 0.75rem;

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -44,6 +44,7 @@ module.exports = {
 
       // Font sizes - including Linear's 13px app UI size
       fontSize: {
+        '3xs': ['var(--text-3xs)', { lineHeight: '1.2' }], // 10px — micro labels
         '2xs': ['var(--text-2xs)', { lineHeight: '1.25' }], // 11px
         app: ['var(--text-app)', { lineHeight: '1.4' }], // 13px — Linear's default
         caption: ['var(--linear-caption-size)', { lineHeight: '1.4' }], // 13px — compact app controls


### PR DESCRIPTION
## Summary

Adds a `text-3xs` (10px / 0.625rem) token to the font-size scale so pending `text-[10px]` arbitraries across the codebase get a clean home.

Prior text-size consolidation PRs (#7568, #7573, #7574) had to defer **5+ instances** of `text-[10px]` across 3 files because no 10px token existed below `text-2xs` (11px). This PR unlocks mechanical follow-up swaps `text-[10px]` -> `text-3xs`.

## Changes

Registered in all three sync'd locations:
- `apps/web/styles/design-system.css` — single source of truth CSS var
- `apps/web/app/globals.css` `@theme { }` block — Tailwind v4 auto-utility
- `apps/web/tailwind.config.js` `theme.extend.fontSize` — v3-style with `lineHeight: '1.2'`

No code files touched — token plumbing only.

## Test plan

- [x] `pnpm --filter web typecheck` passes
- [x] Token visible in all 3 files (`grep -n "text-3xs\|--text-3xs"` returns 4+ hits)
- [ ] CI passes
- [ ] Follow-up PR can mechanically swap the deferred `text-[10px]` instances

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>