### PR TITLE
refactor(ui): text-size tokens in DashboardAnalytics

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-analytics/DashboardAnalytics.tsx
+++ b/apps/web/components/features/dashboard/dashboard-analytics/DashboardAnalytics.tsx
@@ -60,14 +60,12 @@ function StatCard({
 
   return (
     <ContentSurfaceCard className='p-4 lg:p-5'>
-      <p className='text-[13px] text-secondary-token'>{label}</p>
+      <p className='text-app text-secondary-token'>{label}</p>
       <p className='mt-1 text-2xl font-[590] tracking-[-0.011em] text-primary-token tabular-nums'>
         {value}
       </p>
       {meta && (
-        <p className='mt-1 text-[11px] text-tertiary-token tabular-nums'>
-          {meta}
-        </p>
+        <p className='mt-1 text-2xs text-tertiary-token tabular-nums'>{meta}</p>
       )}
     </ContentSurfaceCard>
   );
@@ -100,7 +98,7 @@ function ListSection({
     <ContentSurfaceCard className='p-4 lg:p-5'>
       <div className='mb-3 flex items-center gap-2'>
         <Icon className='h-4 w-4 text-tertiary-token' />
-        <h3 className='text-[13px] font-[510] text-secondary-token'>{title}</h3>
+        <h3 className='text-app font-[510] text-secondary-token'>{title}</h3>
       </div>
 
       {loading && (
@@ -121,14 +119,14 @@ function ListSection({
               className='flex items-center justify-between group'
             >
               <div className='flex items-center gap-2 min-w-0 flex-1'>
-                <span className='w-4 text-[11px] font-[510] text-tertiary-token tabular-nums'>
+                <span className='w-4 text-2xs font-[510] text-tertiary-token tabular-nums'>
                   {index + 1}
                 </span>
-                <span className='truncate text-[13px] text-secondary-token transition-colors group-hover:text-primary-token'>
+                <span className='truncate text-app text-secondary-token transition-colors group-hover:text-primary-token'>
                   {item.label}
                 </span>
               </div>
-              <span className='ml-2 text-[13px] font-[510] text-primary-token tabular-nums'>
+              <span className='ml-2 text-app font-[510] text-primary-token tabular-nums'>
                 {item.value}
               </span>
             </li>
@@ -136,7 +134,7 @@ function ListSection({
         </ul>
       )}
       {!loading && items.length === 0 && (
-        <p className='py-4 text-center text-[13px] text-tertiary-token'>
+        <p className='py-4 text-center text-app text-tertiary-token'>
           {emptyMessage}
         </p>
       )}
@@ -181,7 +179,7 @@ export function DashboardAnalytics() {
 
       {/* Header */}
       <div className='flex items-center justify-between'>
-        <p className='text-[13px] text-secondary-token'>{rangeLabel}</p>
+        <p className='text-app text-secondary-token'>{rangeLabel}</p>
         <div className='flex items-center gap-2'>
           <DashboardRefreshButton
             ariaLabel='Refresh analytics'
@@ -277,7 +275,7 @@ export function DashboardAnalytics() {
 
         {error && (
           <ContentSurfaceCard className='px-4 py-3 text-center'>
-            <p className='text-[13px] text-destructive'>{error}</p>
+            <p className='text-app text-destructive'>{error}</p>
           </ContentSurfaceCard>
         )}
 


### PR DESCRIPTION
Mapping (all exact Δ0):
- `text-[13px]` x7 -> `text-app`
- `text-[11px]` x2 -> `text-2xs`

Δ0. Text-size wave.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated typography in Dashboard Analytics for improved visual consistency across labels, titles, metrics, list items, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->