### PR TITLE
refactor(ui): sweep text-[10px] → text-3xs across /app surfaces

### DIFF
--- a/apps/web/components/features/dashboard/atoms/PlatformPill.parts.tsx
+++ b/apps/web/components/features/dashboard/atoms/PlatformPill.parts.tsx
@@ -111,7 +111,7 @@ export function ExpandedContent({
         {hasSecondary ? (
           <span
             className={cn(
-              'ml-2 text-[10px] text-tertiary-token/80',
+              'ml-2 text-3xs text-tertiary-token/80',
               secondaryText && secondaryText.length > 40 && 'truncate'
             )}
           >
@@ -121,13 +121,13 @@ export function ExpandedContent({
       </div>
 
       {badgeText ? (
-        <span className='shrink-0 rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-[10px] font-[510] text-secondary-token'>
+        <span className='shrink-0 rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-3xs font-[510] text-secondary-token'>
           {badgeText}
         </span>
       ) : null}
 
       {suffix ? (
-        <span className='ml-0.5 shrink-0 text-[10px]' aria-hidden='true'>
+        <span className='ml-0.5 shrink-0 text-3xs' aria-hidden='true'>
           {suffix}
         </span>
       ) : null}

--- a/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
@@ -61,7 +61,7 @@ function ShortcutKeys({ shortcut }: { readonly shortcut: KeyboardShortcut }) {
     return (
       <span className='inline-flex items-center gap-1 ml-2'>
         <Kbd variant='tooltip'>{first}</Kbd>
-        <span className='text-[10px] opacity-70'>then</span>
+        <span className='text-3xs opacity-70'>then</span>
         <Kbd variant='tooltip'>{second}</Kbd>
       </span>
     );

--- a/apps/web/components/features/dashboard/dashboard-nav/RecentChats.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/RecentChats.tsx
@@ -149,7 +149,7 @@ export function RecentChats() {
                 </SidebarMenuButton>
 
                 <span
-                  className='absolute right-1 top-1 flex h-5 items-center px-1 text-[10px] tabular-nums text-sidebar-muted pointer-events-none transition-opacity duration-150 group-hover/menu-item:opacity-0 group-focus-within/menu-item:opacity-0 group-data-[collapsible=icon]:hidden'
+                  className='absolute right-1 top-1 flex h-5 items-center px-1 text-3xs tabular-nums text-sidebar-muted pointer-events-none transition-opacity duration-150 group-hover/menu-item:opacity-0 group-focus-within/menu-item:opacity-0 group-data-[collapsible=icon]:hidden'
                   title={updatedAt.toLocaleString()}
                 >
                   {timeAgo}

--- a/apps/web/components/features/dashboard/insights/InsightCard.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightCard.tsx
@@ -41,7 +41,7 @@ export function InsightCard({ insight }: InsightCardProps) {
             <Badge
               variant='secondary'
               size='sm'
-              className={`rounded-[6px] px-1.5 py-0.5 text-[10px] ${PRIORITY_BADGE_STYLES[insight.priority]}`}
+              className={`rounded-[6px] px-1.5 py-0.5 text-3xs ${PRIORITY_BADGE_STYLES[insight.priority]}`}
             >
               {PRIORITY_LABELS[insight.priority]}
             </Badge>
@@ -61,10 +61,10 @@ export function InsightCard({ insight }: InsightCardProps) {
 
           <div className='mt-3 flex flex-wrap items-center justify-between gap-2 border-t border-(--linear-app-frame-seam) pt-3'>
             <div className='flex items-center gap-2'>
-              <span className='rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-[10px] font-[510] text-secondary-token capitalize'>
+              <span className='rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-3xs font-[510] text-secondary-token capitalize'>
                 {insight.category}
               </span>
-              <span className='text-[10px] text-tertiary-token tabular-nums'>
+              <span className='text-3xs text-tertiary-token tabular-nums'>
                 Confidence: {Math.round(Number(insight.confidence) * 100)}%
               </span>
             </div>

--- a/apps/web/components/features/dashboard/insights/InsightsBadge.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightsBadge.tsx
@@ -14,7 +14,7 @@ export function InsightsBadge() {
   if (count === 0) return null;
 
   return (
-    <span className='ml-auto inline-flex min-w-[18px] items-center justify-center rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-[10px] font-[510] leading-none text-secondary-token tabular-nums'>
+    <span className='ml-auto inline-flex min-w-[18px] items-center justify-center rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-3xs font-[510] leading-none text-secondary-token tabular-nums'>
       {count > 99 ? '99+' : count}
     </span>
   );

--- a/apps/web/components/features/dashboard/insights/InsightsSummaryWidget.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightsSummaryWidget.tsx
@@ -40,7 +40,7 @@ export function InsightsSummaryWidget() {
           <span className='text-[13px] font-[510] text-primary-token'>
             AI Insights
           </span>
-          <span className='inline-flex min-w-[18px] items-center justify-center rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-[10px] font-[510] leading-none text-secondary-token tabular-nums'>
+          <span className='inline-flex min-w-[18px] items-center justify-center rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-3xs font-[510] leading-none text-secondary-token tabular-nums'>
             {totalActive}
           </span>
         </div>

--- a/apps/web/components/features/dashboard/layout/PreviewPanel.tsx
+++ b/apps/web/components/features/dashboard/layout/PreviewPanel.tsx
@@ -64,7 +64,7 @@ function PreviewPanelEmpty({
           <div className='space-y-3 pb-5'>
             <div className={cn(LINEAR_SURFACE.drawerCard, 'space-y-3 p-3')}>
               <div className='space-y-0.5'>
-                <p className='text-[10px] font-semibold uppercase tracking-[0.14em] text-tertiary-token'>
+                <p className='text-3xs font-semibold uppercase tracking-[0.14em] text-tertiary-token'>
                   Live preview
                 </p>
                 <p className='text-xs text-secondary-token'>
@@ -289,7 +289,7 @@ export function PreviewPanel() {
   );
   const headerTitle: ReactNode = (
     <div className='min-w-0 space-y-0.5'>
-      <p className='text-[10px] font-semibold uppercase tracking-[0.14em] text-tertiary-token'>
+      <p className='text-3xs font-semibold uppercase tracking-[0.14em] text-tertiary-token'>
         Live preview
       </p>
       <div className='flex min-w-0 items-center gap-1.5'>
@@ -329,7 +329,7 @@ export function PreviewPanel() {
             <div className={cn(LINEAR_SURFACE.drawerCard, 'space-y-3 p-3')}>
               <div className='flex items-center justify-between gap-3'>
                 <div>
-                  <p className='text-[10px] font-semibold uppercase tracking-[0.14em] text-tertiary-token'>
+                  <p className='text-3xs font-semibold uppercase tracking-[0.14em] text-tertiary-token'>
                     Public profile
                   </p>
                   <p className='text-xs text-secondary-token'>
@@ -337,14 +337,14 @@ export function PreviewPanel() {
                   </p>
                 </div>
                 <div className='flex items-center gap-1.5'>
-                  <div className='rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1 text-[10px] font-caption tracking-[-0.01em] text-secondary-token'>
+                  <div className='rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1 text-3xs font-caption tracking-[-0.01em] text-secondary-token'>
                     Mobile
                   </div>
-                  <div className='rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1 text-[10px] font-caption tracking-[-0.01em] text-secondary-token'>
+                  <div className='rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1 text-3xs font-caption tracking-[-0.01em] text-secondary-token'>
                     {visibleLinkCount} live
                   </div>
                   {hiddenLinkCount > 0 && (
-                    <div className='rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1 text-[10px] font-caption tracking-[-0.01em] text-secondary-token'>
+                    <div className='rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1 text-3xs font-caption tracking-[-0.01em] text-secondary-token'>
                       {hiddenLinkCount} draft{hiddenLinkCount === 1 ? '' : 's'}
                     </div>
                   )}
@@ -354,7 +354,7 @@ export function PreviewPanel() {
               <div className='mx-auto w-full max-w-[320px]'>
                 <div className={cn(LINEAR_SURFACE.sidebarCard, 'p-2.5')}>
                   <div className='rounded-[24px] border border-(--linear-app-frame-seam) bg-surface-1 p-2'>
-                    <div className='mb-2 flex items-center justify-between px-2.5 pt-1 text-[10px] font-caption tracking-[-0.01em] text-secondary-token'>
+                    <div className='mb-2 flex items-center justify-between px-2.5 pt-1 text-3xs font-caption tracking-[-0.01em] text-secondary-token'>
                       <span>Preview</span>
                       <span className='rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0 px-2 py-0.5 text-[9px] tracking-[-0.01em]'>
                         {username ? `@${username}` : 'Profile'}
@@ -440,7 +440,7 @@ export function PreviewPanel() {
 
             <div className={cn(LINEAR_SURFACE.drawerCard, 'space-y-2.5 p-3')}>
               <div className='space-y-0.5'>
-                <p className='text-[10px] font-semibold uppercase tracking-[0.14em] text-tertiary-token'>
+                <p className='text-3xs font-semibold uppercase tracking-[0.14em] text-tertiary-token'>
                   Share link
                 </p>
                 <p className='text-xs text-secondary-token'>
@@ -522,7 +522,7 @@ export function PreviewPanel() {
                 {snapshotTags.map(tag => (
                   <span
                     key={tag}
-                    className='rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1 text-[10px] font-caption tracking-[-0.01em] text-secondary-token'
+                    className='rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1 text-3xs font-caption tracking-[-0.01em] text-secondary-token'
                   >
                     {tag}
                   </span>

--- a/apps/web/components/features/dashboard/molecules/MatchConfidenceBreakdown.tsx
+++ b/apps/web/components/features/dashboard/molecules/MatchConfidenceBreakdown.tsx
@@ -122,7 +122,7 @@ function ScoreRow({ label, score, weight, description }: ScoreRowProps) {
       </div>
 
       {/* Description on hover */}
-      <p className='mt-0.5 text-[10px] text-tertiary-token/60 opacity-0 transition-opacity group-hover:opacity-100'>
+      <p className='mt-0.5 text-3xs text-tertiary-token/60 opacity-0 transition-opacity group-hover:opacity-100'>
         {description}
       </p>
     </div>

--- a/apps/web/components/features/dashboard/molecules/StatusBarMock.tsx
+++ b/apps/web/components/features/dashboard/molecules/StatusBarMock.tsx
@@ -14,7 +14,7 @@ export function StatusBarMock({ className }: StatusBarMockProps) {
         className
       )}
     >
-      <span className='text-[10px] font-[510] text-primary-token'>9:41</span>
+      <span className='text-3xs font-[510] text-primary-token'>9:41</span>
       <div className='flex items-center gap-1'>
         <div className='flex items-end gap-0.5'>
           <div className='w-0.5 h-1 rounded bg-(--fg)' />

--- a/apps/web/components/features/dashboard/molecules/universal-link-input/MultiLinkPasteDialog.tsx
+++ b/apps/web/components/features/dashboard/molecules/universal-link-input/MultiLinkPasteDialog.tsx
@@ -118,7 +118,7 @@ function LinkItem({
             {platform.name}
           </span>
           {isDuplicate && (
-            <span className='flex items-center gap-1 rounded bg-amber-500/10 px-1.5 py-0.5 text-[10px] font-[510] text-amber-600 dark:text-amber-400'>
+            <span className='flex items-center gap-1 rounded bg-amber-500/10 px-1.5 py-0.5 text-3xs font-[510] text-amber-600 dark:text-amber-400'>
               <Icon name='AlertTriangle' className='h-3 w-3' />
               Already added
             </span>

--- a/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
@@ -106,7 +106,7 @@ function FunnelStage({
             {numberFormatter.format(value)}
           </span>
           {rate && (
-            <span className='tabular-nums text-[10px] font-caption text-tertiary-token'>
+            <span className='tabular-nums text-3xs font-caption text-tertiary-token'>
               {rate}
             </span>
           )}

--- a/apps/web/components/features/dashboard/organisms/GetStartedChecklistCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/GetStartedChecklistCard.tsx
@@ -278,7 +278,7 @@ export function GetStartedChecklistCard({
                     e.stopPropagation();
                     handleCopyUrl();
                   }}
-                  className='rounded-full border border-transparent px-2 py-0.5 text-[10px] text-tertiary-token transition-colors hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-secondary-token'
+                  className='rounded-full border border-transparent px-2 py-0.5 text-3xs text-tertiary-token transition-colors hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-secondary-token'
                 >
                   Copy
                 </button>

--- a/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
@@ -368,7 +368,7 @@ export function LiquidGlassMenu({
                 </div>
                 <span
                   className={cn(
-                    'text-[10px] leading-tight',
+                    'text-3xs leading-tight',
                     active ? 'font-semibold' : 'font-caption'
                   )}
                 >
@@ -399,7 +399,7 @@ export function LiquidGlassMenu({
             <MoreHorizontal className='h-5 w-5' aria-hidden='true' />
             <span
               className={cn(
-                'text-[10px] leading-tight',
+                'text-3xs leading-tight',
                 isExpanded ? 'font-semibold' : 'font-caption'
               )}
             >
@@ -416,7 +416,7 @@ export function LiquidGlassMenu({
               className='relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-[8px] py-1.5 text-tertiary-token transition-all duration-150 hover:text-secondary-token active:scale-95'
             >
               <Search className='h-5 w-5' aria-hidden='true' />
-              <span className='text-[10px] leading-tight font-caption'>
+              <span className='text-3xs leading-tight font-caption'>
                 Search
               </span>
             </button>

--- a/apps/web/components/features/dashboard/organisms/SettingsBillingSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsBillingSection.tsx
@@ -124,7 +124,7 @@ export function SettingsBillingSection() {
                 variant={badgeVariant}
                 size='sm'
                 className={cn(
-                  'rounded-[6px] px-1.5 text-[10px]',
+                  'rounded-[6px] px-1.5 text-3xs',
                   badgeVariant === 'secondary' &&
                     'border border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token',
                   badgeVariant === 'warning' &&

--- a/apps/web/components/features/dashboard/organisms/SettingsTouringSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsTouringSection.tsx
@@ -234,7 +234,7 @@ function BandsintownConnectionPill({
               {artistName || 'Connected'}
             </span>
             {lastSyncedAt && !hovered && !menuOpen && (
-              <span className='ml-0.5 text-[10px] text-tertiary-token'>
+              <span className='ml-0.5 text-3xs text-tertiary-token'>
                 {new Date(lastSyncedAt).toLocaleDateString(undefined, {
                   month: 'short',
                   day: 'numeric',

--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailSidebar.tsx
@@ -264,7 +264,7 @@ export const ContactDetailSidebar = memo(function ContactDetailSidebar({
                   <div className='flex flex-wrap items-center gap-1.5 text-2xs text-tertiary-token'>
                     <Badge
                       size='sm'
-                      className='rounded-[6px] border border-subtle bg-surface-0 px-1.5 text-[10px] text-secondary-token'
+                      className='rounded-[6px] border border-subtle bg-surface-0 px-1.5 text-3xs text-secondary-token'
                     >
                       {territorySummary}
                     </Badge>
@@ -399,7 +399,7 @@ export const ContactDetailSidebar = memo(function ContactDetailSidebar({
                   value={
                     <Badge
                       size='sm'
-                      className='rounded-[6px] border border-subtle bg-surface-0 px-1.5 text-[10px] text-secondary-token'
+                      className='rounded-[6px] border border-subtle bg-surface-0 px-1.5 text-3xs text-secondary-token'
                     >
                       {territorySummary}
                     </Badge>

--- a/apps/web/components/features/dashboard/organisms/dashboard-overview-helpers.ts
+++ b/apps/web/components/features/dashboard/organisms/dashboard-overview-helpers.ts
@@ -6,7 +6,7 @@
 const TASK_CONTAINER_BASE =
   'group flex items-center gap-2 rounded-full border border-transparent px-2.5 py-1 transition-[background-color,border-color,color] duration-100';
 const TASK_INDICATOR_BASE =
-  'flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-[560]';
+  'flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-3xs font-[560]';
 const TASK_LABEL_BASE =
   'text-[12.5px] leading-[15px] tracking-[-0.01em] text-primary-token';
 

--- a/apps/web/components/features/dashboard/organisms/dsp-matches/ConfirmMatchDialog.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-matches/ConfirmMatchDialog.tsx
@@ -143,7 +143,7 @@ export function ConfirmMatchDialog({
 
               <div className='mt-2 flex flex-wrap items-center gap-2'>
                 <ConfidenceBadge score={confidenceScore} size='md' showLabel />
-                <span className='rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-[10px] font-caption text-secondary-token'>
+                <span className='rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-3xs font-caption text-secondary-token'>
                   {matchingIsrcCount} matching ISRCs
                 </span>
               </div>

--- a/apps/web/components/features/dashboard/organisms/dsp-matches/DspMatchList.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-matches/DspMatchList.tsx
@@ -123,7 +123,7 @@ export function DspMatchList({ profileId, className }: DspMatchListProps) {
                 <span className='inline-flex items-center gap-1.5'>
                   <span>{filter.label}</span>
                   {count > 0 && (
-                    <span className='rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-[10px] text-secondary-token tabular-nums'>
+                    <span className='rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-1.5 py-0.5 text-3xs text-secondary-token tabular-nums'>
                       {count}
                     </span>
                   )}

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileAboutTab.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileAboutTab.tsx
@@ -314,11 +314,11 @@ function PressPhotosSection({
         <DrawerSectionHeading>Press Photos</DrawerSectionHeading>
         <div className='flex items-center gap-1.5'>
           {draftPhotos.length > 0 && (
-            <Badge variant='outline' className='text-[10px] tabular-nums'>
+            <Badge variant='outline' className='text-3xs tabular-nums'>
               {draftPhotos.length} awaiting approval
             </Badge>
           )}
-          <Badge variant='secondary' className='text-[10px] tabular-nums'>
+          <Badge variant='secondary' className='text-3xs tabular-nums'>
             {pressPhotos.length}/{MAX_PRESS_PHOTOS}
           </Badge>
         </div>
@@ -355,7 +355,7 @@ function PressPhotosSection({
       {/* Drafts section (awaiting approval) */}
       {draftPhotos.length > 0 && (
         <div className='space-y-1.5'>
-          <p className='text-[10px] font-medium uppercase tracking-wider text-tertiary-token'>
+          <p className='text-3xs font-medium uppercase tracking-wider text-tertiary-token'>
             Awaiting approval
           </p>
           <div className='grid grid-cols-2 gap-2'>
@@ -425,7 +425,7 @@ function PressPhotosSection({
       {/* Other status section */}
       {otherStatusPhotos.length > 0 && (
         <div className='space-y-1.5'>
-          <p className='text-[10px] font-medium uppercase tracking-wider text-tertiary-token'>
+          <p className='text-3xs font-medium uppercase tracking-wider text-tertiary-token'>
             Other status
           </p>
           <div className='grid grid-cols-2 gap-2'>
@@ -468,7 +468,7 @@ function PressPhotosSection({
       {(publishedPhotos.length > 0 || canUpload) && (
         <div className='space-y-1.5'>
           {draftPhotos.length > 0 && publishedPhotos.length > 0 && (
-            <p className='text-[10px] font-medium uppercase tracking-wider text-tertiary-token'>
+            <p className='text-3xs font-medium uppercase tracking-wider text-tertiary-token'>
               Published
             </p>
           )}

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileSmartLinkAnalytics.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileSmartLinkAnalytics.tsx
@@ -184,7 +184,7 @@ function AnalyticsMetric({
       <p className='tabular-nums text-[18px] font-[590] leading-none tracking-[-0.02em] text-primary-token'>
         {value}
       </p>
-      <p className='text-[10px] leading-[13px] text-tertiary-token'>{hint}</p>
+      <p className='text-3xs leading-[13px] text-tertiary-token'>{hint}</p>
     </div>
   );
 }

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SuggestedDspMatches.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SuggestedDspMatches.tsx
@@ -131,7 +131,7 @@ function SectionHeading({ count }: { readonly count: number }) {
         Suggested
       </span>
       {count > 0 && (
-        <span className='inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-surface-1 px-1 text-[10px] font-caption text-tertiary-token'>
+        <span className='inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-surface-1 px-1 text-3xs font-caption text-tertiary-token'>
           {count}
         </span>
       )}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/FilterSubmenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/FilterSubmenu.tsx
@@ -111,7 +111,7 @@ export function FilterSubmenu<T extends string = string>({
           />
           <span>{label}</span>
           {selectedCount > 0 && (
-            <span className='rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-1 px-1.5 py-0.5 text-[10px] font-[510] text-secondary-token'>
+            <span className='rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-1 px-1.5 py-0.5 text-3xs font-[510] text-secondary-token'>
               {selectedCount}
             </span>
           )}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseFilterDropdown.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseFilterDropdown.tsx
@@ -382,7 +382,7 @@ export function ReleaseFilterDropdown({
                         />
                         <span>Label</span>
                         {labelFilterCount > 0 && (
-                          <span className='rounded-[6px] bg-(--linear-accent-subtle) px-1.5 py-0.5 text-[10px] font-[510] text-(--linear-accent)'>
+                          <span className='rounded-[6px] bg-(--linear-accent-subtle) px-1.5 py-0.5 text-3xs font-[510] text-(--linear-accent)'>
                             {labelFilterCount}
                           </span>
                         )}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/components/TrackRow.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/components/TrackRow.tsx
@@ -171,7 +171,7 @@ export const TrackRow = memo(function TrackRow({
         {track.isExplicit ? (
           <Badge
             variant='secondary'
-            className='shrink-0 border border-subtle bg-surface-1 px-1 py-0 text-[10px] text-tertiary-token'
+            className='shrink-0 border border-subtle bg-surface-1 px-1 py-0 text-3xs text-tertiary-token'
             title='Explicit content'
             aria-label='Explicit content'
           >
@@ -299,7 +299,7 @@ export const TrackRow = memo(function TrackRow({
                 {track.isExplicit && (
                   <Badge
                     variant='secondary'
-                    className='shrink-0 border border-subtle bg-surface-1 px-1 py-0 text-[10px] text-tertiary-token'
+                    className='shrink-0 border border-subtle bg-surface-1 px-1 py-0 text-3xs text-tertiary-token'
                     title='Explicit content'
                     aria-label='Explicit content'
                   >

--- a/apps/web/components/features/dashboard/organisms/releases/ReleaseEditDialog.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/ReleaseEditDialog.tsx
@@ -143,7 +143,7 @@ export function ReleaseEditDialog({
                       {existing?.source === 'manual' ? (
                         <Badge
                           variant='secondary'
-                          className='rounded-[6px] border border-amber-500/20 bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-700 dark:text-amber-300'
+                          className='rounded-[6px] border border-amber-500/20 bg-amber-500/10 px-1.5 py-0.5 text-3xs text-amber-700 dark:text-amber-300'
                         >
                           Manual
                         </Badge>

--- a/apps/web/components/features/dashboard/organisms/releases/cells/ReleaseCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/cells/ReleaseCell.tsx
@@ -132,7 +132,7 @@ export const ReleaseCell = memo(function ReleaseCell({
             {showType && typeStyle && hasPreview && (
               <span
                 className={cn(
-                  'shrink-0 text-[10px] font-caption leading-none tracking-normal',
+                  'shrink-0 text-3xs font-caption leading-none tracking-normal',
                   typeStyle.text
                 )}
               >
@@ -163,7 +163,7 @@ export const ReleaseCell = memo(function ReleaseCell({
             {showType && typeStyle && hasPreview && (
               <span
                 className={cn(
-                  'shrink-0 text-[10px] font-caption leading-none tracking-normal',
+                  'shrink-0 text-3xs font-caption leading-none tracking-normal',
                   typeStyle.text
                 )}
               >

--- a/apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx
@@ -72,7 +72,7 @@ function MiniRankedList({
           className='flex h-7 items-center justify-between rounded-md px-1.5'
         >
           <div className='flex min-w-0 flex-1 items-center gap-1.5'>
-            <span className='w-3 text-[10px] font-[510] text-tertiary-token tabular-nums'>
+            <span className='w-3 text-3xs font-[510] text-tertiary-token tabular-nums'>
               {index + 1}
             </span>
             <IconComponent className='h-3 w-3 text-tertiary-token' />

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCategoryGroup.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCategoryGroup.tsx
@@ -32,7 +32,7 @@ export function ReleaseTaskCategoryGroup({
       >
         <span className='flex items-center gap-1.5'>
           {category}{' '}
-          <span className='text-[10px] text-tertiary-token font-normal'>
+          <span className='text-3xs text-tertiary-token font-normal'>
             ({done}/{total})
           </span>
           {allDone && (

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskChecklist.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskChecklist.tsx
@@ -188,7 +188,7 @@ export function ReleaseTaskChecklist({
           <button
             type='button'
             onClick={onNavigateToFullPage}
-            className='flex-shrink-0 text-[10px] text-[var(--linear-accent,#5e6ad2)] hover:underline'
+            className='flex-shrink-0 text-3xs text-[var(--linear-accent,#5e6ad2)] hover:underline'
           >
             Open &rarr;
           </button>

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
@@ -36,7 +36,7 @@ export function ReleaseTaskCompactRow({
         } ${isAi ? 'opacity-70' : 'hover:text-[var(--linear-accent,#5e6ad2)]'}`}
       >
         {task.title}
-        {isAi && <span className='ml-1 text-[10px] text-purple-500'>AI</span>}
+        {isAi && <span className='ml-1 text-3xs text-purple-500'>AI</span>}
       </button>
       <ReleaseTaskDueBadge
         dueDate={task.dueDate}

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRow.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRow.tsx
@@ -55,7 +55,7 @@ export function ReleaseTaskRow({ task, onToggle }: ReleaseTaskRowProps) {
         {task.title}
         {isAi && (
           <span
-            className='ml-1.5 text-[10px] font-medium'
+            className='ml-1.5 text-3xs font-medium'
             style={{ color: aiAccent.solid }}
           >
             Auto
@@ -80,7 +80,7 @@ export function ReleaseTaskRow({ task, onToggle }: ReleaseTaskRowProps) {
       {/* Priority */}
       {priority.dots && (
         <span
-          className='flex-shrink-0 w-6 text-right text-[10px]'
+          className='flex-shrink-0 w-6 text-right text-3xs'
           style={priorityAccent ? { color: priorityAccent.solid } : undefined}
           title={task.priority}
         >

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -836,7 +836,7 @@ function MobileTaskScopeTabs({
               )}
             >
               <span>{label}</span>
-              <span className='text-[10px] text-tertiary-token'>
+              <span className='text-3xs text-tertiary-token'>
                 {counts[value]}
               </span>
             </button>
@@ -872,7 +872,7 @@ function MobileTaskSection({
         <h2 className='text-[11px] font-semibold text-tertiary-token'>
           {title}
         </h2>
-        <span className='text-[10px] text-tertiary-token'>{tasks.length}</span>
+        <span className='text-3xs text-tertiary-token'>{tasks.length}</span>
       </div>
       <div className='overflow-hidden rounded-[18px] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_98%,transparent)] shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-app-shell-border)_65%,transparent)]'>
         {tasks.map(task => (
@@ -967,7 +967,7 @@ function MobileTaskListItem({
           />
         ) : null}
         {task.releaseTitle ? (
-          <span className='text-[10px] font-semibold text-tertiary-token'>
+          <span className='text-3xs font-semibold text-tertiary-token'>
             Release
           </span>
         ) : null}

--- a/apps/web/components/features/dashboard/tokens/mobile-tokens.ts
+++ b/apps/web/components/features/dashboard/tokens/mobile-tokens.ts
@@ -14,11 +14,11 @@ export const mobileReleaseTokens = {
     subtitle: 'mt-0.5 text-[12px] leading-tight text-secondary-token',
     /** Badge-style type label — pair with getReleaseTypeStyle().bg */
     typeBadge:
-      'inline-flex h-[16px] shrink-0 items-center justify-center rounded-[6px] px-1.5 py-0 align-middle text-[10px] font-caption leading-none tracking-normal',
+      'inline-flex h-[16px] shrink-0 items-center justify-center rounded-[6px] px-1.5 py-0 align-middle text-3xs font-caption leading-none tracking-normal',
     year: 'shrink-0 text-[12px] tabular-nums text-tertiary-token',
     chevron: 'h-3.5 w-3.5 shrink-0 text-quaternary-token',
     /** Dot separator between metadata items */
-    dot: 'text-[10px] text-quaternary-token',
+    dot: 'text-3xs text-quaternary-token',
   },
   groupHeader:
     'sticky top-0 z-10 flex items-center justify-between border-b border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-4 py-2',
@@ -33,7 +33,7 @@ export const mobileReleaseTokens = {
   swipeActions: {
     button:
       'flex w-16 flex-col items-center justify-center gap-1 text-white transition-colors',
-    label: 'text-[10px] font-caption tracking-normal',
+    label: 'text-3xs font-caption tracking-normal',
     edit: 'bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_72%,var(--linear-accent))] active:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_60%,var(--linear-accent))]',
     link: 'bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_70%,var(--linear-info))] active:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_58%,var(--linear-info))]',
     locked:

--- a/apps/web/components/features/profile/ProfileDrawerShell.tsx
+++ b/apps/web/components/features/profile/ProfileDrawerShell.tsx
@@ -95,7 +95,7 @@ export function ProfileDrawerShell({
               {subtitle ? (
                 <p
                   id={subtitleId}
-                  className='truncate text-[10px] font-[440] leading-[1.1] tracking-[-0.01em] text-white/46'
+                  className='truncate text-3xs font-[440] leading-[1.1] tracking-[-0.01em] text-white/46'
                 >
                   {subtitle}
                 </p>

--- a/apps/web/components/features/profile/ProfileUnifiedDrawer.tsx
+++ b/apps/web/components/features/profile/ProfileUnifiedDrawer.tsx
@@ -326,7 +326,7 @@ function ReleasesDrawerContent({
                   {collabs ? `${collabs} \u00b7 ` : ''}
                   {metaParts.join(' \u00b7 ')}
                   {release.releaseType === 'music_video' ? (
-                    <span className='ml-1.5 rounded-full bg-white/[0.08] px-1.5 py-0.5 text-[10px] font-[510] text-white/50'>
+                    <span className='ml-1.5 rounded-full bg-white/[0.08] px-1.5 py-0.5 text-3xs font-[510] text-white/50'>
                       Video
                     </span>
                   ) : null}


### PR DESCRIPTION
## Summary

Mechanical sweep of all remaining `text-[10px]` arbitraries in `/app` surfaces to the new `text-3xs` token (added in #7576, `--text-3xs = 0.625rem = 10px`).

All swaps are **byte-identical (Δ0)** — `text-3xs` resolves to the same `0.625rem` computed value previously inlined. This is purely a token-adoption refactor.

- **Scope:** `apps/web/app/app/**`, `components/features/dashboard/**`, `components/features/profile/**`
- **Excluded:** `admin/`, `features/profile/templates/**` (public profile), `features/home/**`, `features/demo/[A-Z]*` (marketing)
- **Impact:** 36 files, 62 insertions / 62 deletions
- Unblocks all prior partial PRs that retained `text-[10px]` pending a token home (#7568, #7573, #7574).

## Files touched (first 10 of 36)

- `apps/web/components/features/profile/ProfileDrawerShell.tsx`
- `apps/web/components/features/profile/ProfileUnifiedDrawer.tsx`
- `apps/web/components/features/dashboard/insights/InsightCard.tsx`
- `apps/web/components/features/dashboard/insights/InsightsBadge.tsx`
- `apps/web/components/features/dashboard/insights/InsightsSummaryWidget.tsx`
- `apps/web/components/features/dashboard/molecules/MatchConfidenceBreakdown.tsx`
- `apps/web/components/features/dashboard/molecules/StatusBarMock.tsx`
- `apps/web/components/features/dashboard/atoms/PlatformPill.parts.tsx`
- `apps/web/components/features/dashboard/tasks/TasksPageClient.tsx`
- `apps/web/components/features/dashboard/dashboard-nav/RecentChats.tsx`
- …and 26 more

## Test plan

- [x] `pnpm --filter web typecheck` passes
- [ ] Visual sanity check on staging — no computed-style drift (same 10px resolution)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)