### PR TITLE
fix(jovie): pin chat input to bottom in empty state

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -455,49 +455,46 @@ export function JovieChat({
           </div>
         </div>
       ) : (
-        <div className='flex-1 overflow-y-auto px-4 sm:px-6'>
-          <div className='flex min-h-full flex-col'>
-            {/* Top spacer — pushes input to optical center */}
-            <div className='flex-1' />
-
-            {/* Centered anchor: heading + input */}
-            <div className='mx-auto flex w-full max-w-[34rem] flex-col items-center gap-5'>
+        <div className='flex flex-1 flex-col overflow-hidden'>
+          <div className='flex-1 overflow-y-auto px-4 sm:px-6'>
+            <div className='mx-auto flex min-h-full w-full max-w-[34rem] flex-col items-center justify-center gap-5 py-6'>
               <h1 className='text-[1.2rem] font-[560] tracking-[-0.03em] text-primary-token sm:text-[1.35rem]'>
                 {emptyStateHeading}
               </h1>
-              <div className='w-full space-y-2.5'>
-                {isRateLimited && (
-                  <p
-                    className='text-center text-xs text-tertiary-token'
-                    aria-live='polite'
-                  >
-                    Sending too fast. Please wait a second before your next
-                    message.
-                  </p>
+              <div className='mx-auto flex w-full max-w-md flex-col items-center'>
+                <SuggestedPrompts
+                  onSelect={handleSuggestedPrompt}
+                  isFirstSession={isFirstSession}
+                  latestReleaseTitle={latestReleaseTitle}
+                  layout='flat'
+                />
+                {chatError && (
+                  <div className='mt-2.5 w-full'>
+                    <ErrorDisplay
+                      chatError={chatError}
+                      onRetry={handleRetry}
+                      isLoading={isLoading}
+                      isSubmitting={isSubmitting}
+                    />
+                  </div>
                 )}
-                <ChatUsageAlert />
-                <ChatInput {...chatInputProps} placeholder='Ask Jovie...' />
               </div>
             </div>
+          </div>
 
-            {/* Bottom section — items flow below center, don't shift input */}
-            <div className='mx-auto flex w-full max-w-md flex-1 flex-col items-center pt-2'>
-              <SuggestedPrompts
-                onSelect={handleSuggestedPrompt}
-                isFirstSession={isFirstSession}
-                latestReleaseTitle={latestReleaseTitle}
-                layout='flat'
-              />
-              {chatError && (
-                <div className='mt-2.5 w-full'>
-                  <ErrorDisplay
-                    chatError={chatError}
-                    onRetry={handleRetry}
-                    isLoading={isLoading}
-                    isSubmitting={isSubmitting}
-                  />
-                </div>
+          <div className='bg-(--linear-app-content-surface) px-4 pb-4 pt-2 sm:px-5 sm:pb-5 sm:pt-2.5'>
+            <div className='mx-auto w-full max-w-[34rem] space-y-2.5'>
+              {isRateLimited && (
+                <p
+                  className='text-center text-xs text-tertiary-token'
+                  aria-live='polite'
+                >
+                  Sending too fast. Please wait a second before your next
+                  message.
+                </p>
               )}
+              <ChatUsageAlert />
+              <ChatInput {...chatInputProps} placeholder='Ask Jovie...' />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

New-chat empty state pinned the input between two `flex-1` spacers, which vertically re-centered the input any time something below it changed height (async `SuggestedPrompts`, `ChatUsageAlert` mount, `ErrorDisplay` appearing, multi-line textarea growth, mobile keyboard opening). The input visibly jumped.

Restructured the empty state in \`apps/web/components/jovie/JovieChat.tsx\` to mirror the populated state: outer \`flex flex-1 flex-col overflow-hidden\`, scrollable content area (heading + SuggestedPrompts + errors) with \`flex-1 overflow-y-auto\`, input as a stable sibling below. Content stays optically centered via \`justify-center\` within the scroll area, input stays pinned.

## Test plan
- [ ] Verify empty state input stays pinned while SuggestedPrompts renders, when typing multi-line, on window resize, and on mobile (375px with keyboard)
- [ ] Verify transition from empty → first message is smooth (outer container is identical)
- [ ] Screenshot before/after once staging deploys

Screenshots will follow from the staging preview (gh CLI can't upload inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized the empty chat interface layout to improve content positioning and scrolling behavior. Suggested prompts now display in the main scrollable area while input controls remain fixed at the bottom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->