### PR TITLE
refactor(ui): text-size tokens in LinkClicksCard

### DIFF
--- a/apps/web/components/features/dashboard/organisms/LinkClicksCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/LinkClicksCard.tsx
@@ -39,11 +39,11 @@ export function LinkClicksCard({ stats, total }: LinkClicksCardProps) {
     return (
       <ContentSurfaceCard className='p-4 sm:p-5'>
         <div className='flex items-baseline justify-between'>
-          <h3 className='text-[13px] font-caption text-secondary-token'>
+          <h3 className='text-app font-caption text-secondary-token'>
             Link Clicks
           </h3>
         </div>
-        <p className='mt-4 text-center text-[13px] text-tertiary-token'>
+        <p className='mt-4 text-center text-app text-tertiary-token'>
           No link clicks yet. Share your profile to start tracking.
         </p>
       </ContentSurfaceCard>
@@ -54,14 +54,14 @@ export function LinkClicksCard({ stats, total }: LinkClicksCardProps) {
     <ContentSurfaceCard className='p-4 sm:p-5' data-testid='link-clicks-card'>
       <div className='flex items-baseline justify-between'>
         <div>
-          <h3 className='text-[13px] font-caption text-secondary-token'>
+          <h3 className='text-app font-caption text-secondary-token'>
             Link Clicks
           </h3>
-          <p className='mt-0.5 text-[11px] font-book text-tertiary-token'>
+          <p className='mt-0.5 text-2xs font-book text-tertiary-token'>
             Last 30 days
           </p>
         </div>
-        <p className='text-[24px] font-semibold tracking-[-0.04em] text-primary-token'>
+        <p className='text-2xl font-semibold tracking-[-0.04em] text-primary-token'>
           {total.toLocaleString()}
         </p>
       </div>
@@ -87,10 +87,10 @@ export function LinkClicksCard({ stats, total }: LinkClicksCardProps) {
                     aria-hidden
                   />
                 </div>
-                <span className='flex-1 text-[13px] font-book text-primary-token'>
+                <span className='flex-1 text-app font-book text-primary-token'>
                   {capitalizeFirst(stat.platform)}
                 </span>
-                <span className='text-[13px] font-caption tabular-nums text-primary-token'>
+                <span className='text-app font-caption tabular-nums text-primary-token'>
                   {formatCount(stat.clicks)}
                 </span>
               </div>


### PR DESCRIPTION
## Summary
- 7 `text-[Npx]` arbitraries tokenized in `LinkClicksCard.tsx`, all exact-match (delta 0).
- 13px x5 -> `text-app`, 24px x1 -> `text-2xl`, 11px x1 -> `text-2xs`.
- Byte-identical rendering. Text-size consolidation wave.

## Test plan
- [x] Zero `text-\[[0-9]+px\]` remaining in file
- [x] Lint + typecheck passing via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)