### PR TITLE
feat(design-tokens): add text-mid (15px)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -431,10 +431,11 @@ body {
 
 @theme {
   /* Custom font sizes — Linear's type scale registered as Tailwind utilities
-     text-3xs = 10px, text-2xs = 11px, text-app = 13px (Linear's default UI size) */
+     text-3xs = 10px, text-2xs = 11px, text-app = 13px (Linear's default UI size), text-mid = 15px */
   --text-3xs: 0.625rem;
   --text-2xs: 0.6875rem;
   --text-app: 0.8125rem;
+  --text-mid: 0.9375rem;
   /* Font stack: var(--font-inter) for Next.js localFont, then Linear's exact fallbacks */
   --font-sans:
     var(--font-inter), "Inter Variable", "SF Pro Display", -apple-system, "system-ui", "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -882,6 +882,8 @@
   /* 13px — LINEAR'S DEFAULT APP UI SIZE (sidebar, issues, tabs) */
   --text-sm: 0.875rem;
   /* 14px */
+  --text-mid: 0.9375rem;
+  /* 15px — between sm and base; intentional tight fit */
   --text-base: 1rem;
   /* 16px */
   --text-lg: 1.125rem;

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -48,6 +48,7 @@ module.exports = {
         '2xs': ['var(--text-2xs)', { lineHeight: '1.25' }], // 11px
         app: ['var(--text-app)', { lineHeight: '1.4' }], // 13px — Linear's default
         caption: ['var(--linear-caption-size)', { lineHeight: '1.4' }], // 13px — compact app controls
+        mid: ['var(--text-mid)', { lineHeight: '1.4' }], // 15px — between sm and base
       },
 
       // Linear spacing tokens


### PR DESCRIPTION
## Summary

Adds a new `text-mid` (15px / 0.9375rem) design token sitting between `text-sm` (14px) and `text-base` (16px). This gives a token home to the 24+ in-scope `text-[15px]` arbitrary-value usages, which will be swapped mechanically in a follow-up PR.

Registered in all three sync'd locations (same pattern as `text-3xs` in #7576):
- `apps/web/styles/design-system.css` — single source of truth CSS var
- `apps/web/app/globals.css` `@theme { }` — Tailwind v4 auto-utility generation
- `apps/web/tailwind.config.js` — v3 `fontSize` entry with `lineHeight: '1.4'` (matches `text-app`)

No code files touched — token plumbing only.

Precedent: #7576 (added `text-3xs`).

## Test plan
- [x] `pnpm --filter web typecheck` passes
- [x] `grep "text-mid\|--text-mid"` shows entries in all 3 files
- [ ] Follow-up PR will sweep `text-[15px]` → `text-mid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new intermediate text size option to the design system's typography scale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->