### PR TITLE
refactor(ui): text-size tokens in TaskDescriptionHelper

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskDescriptionHelper.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskDescriptionHelper.tsx
@@ -26,7 +26,7 @@ export function TaskDescriptionHelper({
       />
       <div className='pointer-events-none relative z-10 max-w-[40rem] space-y-3 px-5 py-5 text-left'>
         <div className='space-y-1'>
-          <h3 className='text-[13px] font-[600] text-primary-token'>
+          <h3 className='text-app font-[600] text-primary-token'>
             {helper.title}
           </h3>
           {helper.intro.map(paragraph => {
@@ -36,7 +36,7 @@ export function TaskDescriptionHelper({
             return (
               <p
                 key={`intro-${paragraph}-${occurrence}`}
-                className='text-[13px] leading-6 text-secondary-token'
+                className='text-app leading-6 text-secondary-token'
               >
                 {paragraph}
               </p>
@@ -45,7 +45,7 @@ export function TaskDescriptionHelper({
         </div>
 
         {helper.bullets && helper.bullets.length > 0 ? (
-          <ul className='space-y-1.5 pl-4 text-[13px] leading-6 text-secondary-token marker:text-tertiary-token'>
+          <ul className='space-y-1.5 pl-4 text-app leading-6 text-secondary-token marker:text-tertiary-token'>
             {helper.bullets.map(bullet => {
               const occurrence = bulletKeyCounts.get(bullet) ?? 0;
               bulletKeyCounts.set(bullet, occurrence + 1);
@@ -56,7 +56,7 @@ export function TaskDescriptionHelper({
         ) : null}
 
         {helper.links && helper.links.length > 0 ? (
-          <ul className='space-y-1.5 text-[12px] leading-5 text-secondary-token'>
+          <ul className='space-y-1.5 text-xs leading-5 text-secondary-token'>
             {helper.links.map(link => {
               const linkKey = `${link.href}:${link.label}`;
               const occurrence = linkKeyCounts.get(linkKey) ?? 0;
@@ -79,7 +79,7 @@ export function TaskDescriptionHelper({
         ) : null}
 
         {helper.footer ? (
-          <p className='text-[12px] leading-5 text-tertiary-token'>
+          <p className='text-xs leading-5 text-tertiary-token'>
             {helper.footer}
           </p>
         ) : null}


### PR DESCRIPTION
## Summary
- Tokenize 5 text-size arbitraries in TaskDescriptionHelper.tsx
- 3x text-[13px] -> text-app
- 2x text-[12px] -> text-xs

Byte-identical. Text-size consolidation wave.

## Test plan
- [x] Visual: no change (exact-match tokens)
- [x] Lint/typecheck pass via pre-commit hooks

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>