### PR TITLE
refactor(ui): text-size tokens in ProfilePaySurface

### DIFF
--- a/apps/web/components/features/dashboard/molecules/ProfilePaySurface.tsx
+++ b/apps/web/components/features/dashboard/molecules/ProfilePaySurface.tsx
@@ -67,7 +67,7 @@ function ProviderPill({
   if (provider === 'none') return null;
 
   return (
-    <span className='inline-flex items-center rounded-full border border-(--linear-app-frame-seam) bg-surface-0 px-2 py-0.5 text-[11px] font-[510] text-secondary-token'>
+    <span className='inline-flex items-center rounded-full border border-(--linear-app-frame-seam) bg-surface-0 px-2 py-0.5 text-2xs font-[510] text-secondary-token'>
       {provider === 'stripe' ? 'Stripe' : 'Venmo'}
     </span>
   );
@@ -206,7 +206,7 @@ export function ProfilePaySurface({
     >
       <div className={cn('min-w-0', isDrawer ? 'space-y-4' : 'space-y-3')}>
         <div className='flex flex-wrap items-center gap-2'>
-          <span className='inline-flex items-center gap-1.5 rounded-full border border-(--linear-app-frame-seam) bg-surface-0 px-2 py-0.5 text-[11px] font-[510] text-secondary-token'>
+          <span className='inline-flex items-center gap-1.5 rounded-full border border-(--linear-app-frame-seam) bg-surface-0 px-2 py-0.5 text-2xs font-[510] text-secondary-token'>
             <StatusIcon paymentState={summary.paymentState} />
             {getProfileMonetizationHeading(summary.paymentState)}
           </span>
@@ -215,7 +215,7 @@ export function ProfilePaySurface({
 
         <p
           className={cn(
-            'text-[13px] leading-[19px] text-secondary-token',
+            'text-app leading-[19px] text-secondary-token',
             isDrawer ? 'max-w-[30ch]' : 'max-w-[48ch]'
           )}
         >
@@ -282,7 +282,7 @@ export function ProfilePaySurface({
             <button
               type='button'
               onClick={onViewAnalytics}
-              className='inline-flex w-fit items-start gap-1.5 text-left text-[12px] font-[510] text-secondary-token transition-colors hover:text-primary-token'
+              className='inline-flex w-fit items-start gap-1.5 text-left text-xs font-[510] text-secondary-token transition-colors hover:text-primary-token'
             >
               <span>View payment traffic in Analytics</span>
               <ArrowUpRight
@@ -294,7 +294,7 @@ export function ProfilePaySurface({
 
           <p
             className={cn(
-              'text-[12px] text-tertiary-token',
+              'text-xs text-tertiary-token',
               !statusMessage && 'sr-only'
             )}
             aria-live='polite'
@@ -332,7 +332,7 @@ export function ProfilePaySurface({
               <div className='mx-auto flex h-10 w-10 items-center justify-center rounded-[12px] border border-(--linear-app-frame-seam) bg-surface-1 text-tertiary-token'>
                 <Link2 className='h-4 w-4' aria-hidden='true' />
               </div>
-              <p className='text-[11px] leading-[14px] text-tertiary-token'>
+              <p className='text-2xs leading-[14px] text-tertiary-token'>
                 QR unlocks when payments are live.
               </p>
             </div>


### PR DESCRIPTION
## Summary
- Tokenize 6 arbitrary text-size classes in ProfilePaySurface
- 11px x3 -> text-2xs, 12px x2 -> text-xs, 13px x1 -> text-app
- Byte-identical; text-size consolidation wave

## Test plan
- [x] Visual parity (all exact-match token swaps, delta 0)
- [x] typecheck/lint via pre-commit

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text sizing across the payment profile interface for improved visual consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->