### PR TITLE
refactor(ui): text-size tokens in SocialBioNudge

### DIFF
--- a/apps/web/components/features/dashboard/molecules/SocialBioNudge.tsx
+++ b/apps/web/components/features/dashboard/molecules/SocialBioNudge.tsx
@@ -66,7 +66,7 @@ function MilestoneRow({
         )}
       </span>
       <div className='min-w-0'>
-        <p className='text-[13px] font-[560] text-primary-token'>{label}</p>
+        <p className='text-app font-[560] text-primary-token'>{label}</p>
         <p className='text-[12.5px] leading-5 text-secondary-token'>
           {description}
         </p>
@@ -182,10 +182,10 @@ export const SocialBioNudge = memo(function SocialBioNudge({
           </div>
           <div className='min-w-0 flex-1 space-y-1.5'>
             <div className='space-y-0.5'>
-              <p className='text-[14px] font-[590] text-primary-token'>
+              <p className='text-sm font-[590] text-primary-token'>
                 Instagram activated
               </p>
-              <p className='text-[13px] leading-5 text-secondary-token'>
+              <p className='text-app leading-5 text-secondary-token'>
                 Your first Instagram visitor landed on Jovie
                 {activatedAtLabel ? ` on ${activatedAtLabel}.` : '.'}
               </p>
@@ -224,8 +224,8 @@ export const SocialBioNudge = memo(function SocialBioNudge({
         </div>
         <div className='min-w-0 flex-1 space-y-3'>
           <div className='space-y-1'>
-            <p className='text-[14px] font-[590] text-primary-token'>{title}</p>
-            <p className='text-[13px] leading-5 text-secondary-token'>
+            <p className='text-sm font-[590] text-primary-token'>{title}</p>
+            <p className='text-app leading-5 text-secondary-token'>
               {description}
             </p>
             <p className='text-[12.5px] font-[560] text-primary-token'>


### PR DESCRIPTION
## Summary
- 5 arbitrary text-size classes tokenized in SocialBioNudge (delta 0)
- 13px x3 -> text-app, 14px x2 -> text-sm
- Byte-identical rendering; part of text-size consolidation wave

## Test plan
- [x] Visual: unchanged
- [x] Typecheck + lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)