### PR TITLE
refactor(ui): text-size tokens in SessionManagementCard

### DIFF
--- a/apps/web/components/features/dashboard/organisms/account-settings/SessionManagementCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/account-settings/SessionManagementCard.tsx
@@ -108,7 +108,7 @@ export function SessionManagementCard({
         className='overflow-hidden'
       >
         <div className='px-4 py-3 sm:px-5'>
-          <p className='text-[13px] text-destructive'>{sessionsError}</p>
+          <p className='text-app text-destructive'>{sessionsError}</p>
         </div>
       </DashboardCard>
     );
@@ -122,7 +122,7 @@ export function SessionManagementCard({
         className='overflow-hidden'
       >
         <div className='px-4 py-3 sm:px-5'>
-          <p className='text-[13px] text-secondary-token'>
+          <p className='text-app text-secondary-token'>
             No other active sessions.
           </p>
         </div>
@@ -148,7 +148,7 @@ export function SessionManagementCard({
             >
               <div className='min-w-0'>
                 <div className='flex flex-wrap items-center gap-1.5'>
-                  <p className='text-[13px] font-[510] text-primary-token'>
+                  <p className='text-app font-[510] text-primary-token'>
                     {isCurrent
                       ? 'This device'
                       : activity?.browserName || 'Unknown device'}
@@ -159,7 +159,7 @@ export function SessionManagementCard({
                     </Badge>
                   ) : null}
                 </div>
-                <p className='mt-0.5 text-[11px] text-secondary-token'>
+                <p className='mt-0.5 text-2xs text-secondary-token'>
                   Last active {formatRelativeDate(session.lastActiveAt)}
                   {activity?.city && activity?.country
                     ? ` · ${activity.city}, ${activity.country}`
@@ -173,7 +173,7 @@ export function SessionManagementCard({
                   size='sm'
                   disabled={endingSessionId === session.id}
                   onClick={() => setSessionToEnd(session)}
-                  className='h-7 shrink-0 rounded-[8px] border border-transparent bg-transparent px-2.5 text-[11px] font-[510] text-secondary-token hover:border-destructive/20 hover:bg-destructive/10 hover:text-destructive'
+                  className='h-7 shrink-0 rounded-[8px] border border-transparent bg-transparent px-2.5 text-2xs font-[510] text-secondary-token hover:border-destructive/20 hover:bg-destructive/10 hover:text-destructive'
                 >
                   {endingSessionId === session.id ? 'Ending…' : 'End session'}
                 </Button>


### PR DESCRIPTION
## Summary
- 5 `text-[Npx]` arbitraries tokenized in `SessionManagementCard.tsx`
- `text-[13px]` x3 -> `text-app`, `text-[11px]` x2 -> `text-2xs`
- Byte-identical (delta 0). Text-size consolidation wave.

## Test plan
- [x] Typecheck + lint via pre-commit hooks
- [ ] Visual spot-check session management UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)