### PR TITLE
refactor(ui): text-size tokens in ReleaseProviderMatrix

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
@@ -1013,10 +1013,10 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
                   aria-hidden='true'
                 />
               </div>
-              <h3 className='text-[13px] font-[510] text-primary-token'>
+              <h3 className='text-app font-[510] text-primary-token'>
                 No releases yet
               </h3>
-              <p className='mt-0.5 max-w-sm text-[12px] leading-[17px] text-secondary-token'>
+              <p className='mt-0.5 max-w-sm text-xs leading-[17px] text-secondary-token'>
                 {canCreateManualReleases
                   ? 'Sync from Spotify or create one manually to start generating smart links.'
                   : 'Sync from Spotify to start generating smart links.'}
@@ -1026,7 +1026,7 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
                   tone='primary'
                   disabled={isSyncing}
                   onClick={experienceAdapter?.onSync ?? handleSync}
-                  className='h-7 rounded-[8px] px-2.5 text-[11px] inline-flex items-center gap-2'
+                  className='h-7 rounded-[8px] px-2.5 text-2xs inline-flex items-center gap-2'
                   data-testid='sync-spotify-empty-state'
                 >
                   <Icon
@@ -1042,7 +1042,7 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
                 {canCreateManualReleases && (
                   <DrawerButton
                     onClick={handleNewRelease}
-                    className='h-7 rounded-[8px] px-2.5 text-[11px] inline-flex items-center gap-2'
+                    className='h-7 rounded-[8px] px-2.5 text-2xs inline-flex items-center gap-2'
                     data-testid='create-release-empty-state'
                   >
                     <Icon name='Plus' className='h-4 w-4' aria-hidden='true' />


### PR DESCRIPTION
## Summary
- 4 `text-[Npx]` arbitraries replaced with tokens in `ReleaseProviderMatrix.tsx`
- 11px x2 → `text-2xs`, 13px x1 → `text-app`, 12px x1 → `text-xs`
- Byte-identical (delta 0); text-size consolidation wave

## Test plan
- [x] Grep confirms zero `text-[1[123]px]` remain
- [x] Typecheck + lint via pre-commit hook passed

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>