### PR TITLE
refactor(ui): text-size tokens in SidebarLinkInput

### DIFF
--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SidebarLinkInput.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SidebarLinkInput.tsx
@@ -56,7 +56,7 @@ function SidebarSuggestionItem({
     <button
       type='button'
       className={cn(
-        'flex w-full min-h-[44px] items-center gap-2.5 px-3 py-2.5 text-left text-[13px] text-primary-token transition',
+        'flex w-full min-h-[44px] items-center gap-2.5 px-3 py-2.5 text-left text-app text-primary-token transition',
         active ? 'bg-surface-2' : 'hover:bg-surface-2',
         'active:scale-[0.99]'
       )}
@@ -179,7 +179,7 @@ export function SidebarLinkInput({
         autoCapitalize='none'
         autoCorrect='off'
         autoComplete='off'
-        className='h-9 rounded-[8px] border-(--linear-app-frame-seam) bg-surface-0 text-[13px]'
+        className='h-9 rounded-[8px] border-(--linear-app-frame-seam) bg-surface-0 text-app'
         aria-label='Add link'
         autoFocus
       />
@@ -210,7 +210,7 @@ export function SidebarLinkInput({
         <button
           type='button'
           onClick={handleAdd}
-          className='mt-2 flex w-full items-center gap-2 rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-3 py-2 text-[13px] transition-colors hover:bg-surface-1'
+          className='mt-2 flex w-full items-center gap-2 rounded-[6px] border border-(--linear-app-frame-seam) bg-surface-0 px-3 py-2 text-app transition-colors hover:bg-surface-1'
         >
           <SocialIcon
             platform={detectedLink.platform.icon}
@@ -219,7 +219,7 @@ export function SidebarLinkInput({
           <span className='min-w-0 flex-1 truncate'>
             {detectedLink.normalizedUrl}
           </span>
-          <span className='ml-auto shrink-0 text-[13px] font-[510] text-accent'>
+          <span className='ml-auto shrink-0 text-app font-[510] text-accent'>
             Add
           </span>
         </button>


### PR DESCRIPTION
## Summary
- 4 `text-[13px]` -> `text-app` in SidebarLinkInput (byte-identical; `--text-app = 0.8125rem`)
- Text-size consolidation wave

## Test plan
- [x] Visual diff: no change