### PR TITLE
refactor(ui): text-size tokens in ContactItem

### DIFF
--- a/apps/web/components/features/dashboard/molecules/ContactItem.tsx
+++ b/apps/web/components/features/dashboard/molecules/ContactItem.tsx
@@ -53,10 +53,10 @@ export const ContactItem = memo(function ContactItem({
     <div className='rounded-[10px] border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-4'>
       <div className='flex items-start justify-between gap-3'>
         <div>
-          <p className='text-[13px] font-[590] text-primary-token'>
+          <p className='text-app font-[590] text-primary-token'>
             {buildSummary(contact)}
           </p>
-          <p className='text-[13px] text-secondary-token'>
+          <p className='text-app text-secondary-token'>
             {preferredChannel
               ? `Default action: ${preferredChannel}`
               : 'Select a default action'}
@@ -67,7 +67,7 @@ export const ContactItem = memo(function ContactItem({
             size='sm'
             variant='ghost'
             onClick={() => onUpdate({ isExpanded: !contact.isExpanded })}
-            className='rounded-[8px] px-3 text-[11px] font-[510] tracking-[-0.01em]'
+            className='rounded-[8px] px-3 text-2xs font-[510] tracking-[-0.01em]'
           >
             {contact.isExpanded ? 'Collapse' : 'Edit'}
           </Button>
@@ -124,7 +124,7 @@ export const ContactItem = memo(function ContactItem({
           )}
 
           {contact.error ? (
-            <p className='text-[13px] text-error'>{contact.error}</p>
+            <p className='text-app text-error'>{contact.error}</p>
           ) : null}
 
           <ContactItemActions


### PR DESCRIPTION
## Summary
- 4 text-[Npx] arbitraries tokenized in ContactItem (exact-match, delta 0)
- 13px x3 -> text-app, 11px x1 -> text-2xs
- Byte-identical; text-size consolidation wave

## Test plan
- [x] Visual diff: no change (tokens map to same pixel values)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated typography styling in contact components for improved consistency with design system standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->