### PR TITLE
refactor(ui): text-size tokens in DspMatchCard

### DIFF
--- a/apps/web/components/features/dashboard/molecules/DspMatchCard.tsx
+++ b/apps/web/components/features/dashboard/molecules/DspMatchCard.tsx
@@ -132,7 +132,7 @@ export function DspMatchCard({
                 </a>
               )}
             </div>
-            <div className='mt-0.5 flex items-center gap-2 text-[13px] text-tertiary-token'>
+            <div className='mt-0.5 flex items-center gap-2 text-app text-tertiary-token'>
               <DspProviderIcon provider={providerId} size='sm' />
               <span>{PROVIDER_LABELS[providerId]}</span>
               <span className='text-quaternary-token'>•</span>
@@ -154,7 +154,7 @@ export function DspMatchCard({
           <button
             type='button'
             onClick={() => setIsExpanded(!isExpanded)}
-            className='flex h-7 w-full items-center justify-between rounded-[8px] border border-transparent px-2 text-[12px] text-tertiary-token transition-[background-color,border-color,color] duration-150 hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+            className='flex h-7 w-full items-center justify-between rounded-[8px] border border-transparent px-2 text-xs text-tertiary-token transition-[background-color,border-color,color] duration-150 hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
           >
             <span>Confidence breakdown</span>
             <Icon
@@ -183,7 +183,7 @@ export function DspMatchCard({
               size='sm'
               onClick={() => onReject(matchId)}
               disabled={isLoading}
-              className='h-7 rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 text-[11px] font-[510] text-secondary-token hover:bg-surface-1 hover:text-primary-token'
+              className='h-7 rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 text-2xs font-[510] text-secondary-token hover:bg-surface-1 hover:text-primary-token'
             >
               {isRejecting ? 'Rejecting...' : 'Reject'}
             </Button>
@@ -194,7 +194,7 @@ export function DspMatchCard({
               size='sm'
               onClick={() => onConfirm(matchId)}
               disabled={isLoading}
-              className='h-7 rounded-[8px] px-2.5 text-[11px] font-[510]'
+              className='h-7 rounded-[8px] px-2.5 text-2xs font-[510]'
             >
               {isConfirming ? 'Confirming...' : 'Confirm Match'}
             </Button>


### PR DESCRIPTION
## Summary
- Tokenize 4 arbitrary text sizes in `DspMatchCard.tsx` (all exact-match, delta 0)
- 11px x2 -> `text-2xs`, 13px x1 -> `text-app`, 12px x1 -> `text-xs`
- Byte-identical rendering; text-size consolidation wave

## Test plan
- [ ] Visual check: DSP match card renders identically
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)