### PR TITLE
refactor(ui): text-size tokens in ReleaseTaskPastReleaseState

### DIFF
--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskPastReleaseState.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskPastReleaseState.tsx
@@ -11,10 +11,10 @@ export function ReleaseTaskPastReleaseState({
 }: ReleaseTaskPastReleaseStateProps) {
   return (
     <div className='flex min-h-[180px] flex-col items-center justify-center rounded-lg border border-(--linear-app-frame-seam) bg-surface-1 px-4 py-10 text-center'>
-      <p className='text-[14px] font-medium text-secondary-token mb-1'>
+      <p className='text-sm font-medium text-secondary-token mb-1'>
         This release is already out
       </p>
-      <p className='text-[12px] text-tertiary-token mb-4 max-w-[260px]'>
+      <p className='text-xs text-tertiary-token mb-4 max-w-[260px]'>
         Campaign tasks help you prepare for upcoming releases. Since this one is
         already live, there&apos;s nothing to prepare.
       </p>
@@ -22,7 +22,7 @@ export function ReleaseTaskPastReleaseState({
         type='button'
         onClick={onSetUpAnyway}
         disabled={isLoading}
-        className='text-[11px] text-tertiary-token hover:text-secondary-token underline transition-colors disabled:cursor-not-allowed disabled:opacity-50'
+        className='text-2xs text-tertiary-token hover:text-secondary-token underline transition-colors disabled:cursor-not-allowed disabled:opacity-50'
         aria-busy={isLoading}
       >
         {isLoading ? 'Generating...' : 'Generate Release Plan Anyway'}


### PR DESCRIPTION
## Summary
- 3 text-[Npx] arbitraries tokenized in ReleaseTaskPastReleaseState (all exact-match, delta 0)
- 14px x1 -> text-sm, 12px x1 -> text-xs, 11px x1 -> text-2xs
- Byte-identical rendering. Text-size consolidation wave.

## Test plan
- [ ] Visual diff: past-release state card unchanged

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>