### PR TITLE
refactor(ui): text-size tokens in SettingsPaymentsSection

### DIFF
--- a/apps/web/components/features/dashboard/organisms/SettingsPaymentsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsPaymentsSection.tsx
@@ -153,7 +153,7 @@ export function SettingsPaymentsSection() {
         }
       />,
       error ? (
-        <p className='text-[13px] leading-[18px] text-destructive'>{error}</p>
+        <p className='text-app leading-[18px] text-destructive'>{error}</p>
       ) : undefined
     );
   }
@@ -192,7 +192,7 @@ export function SettingsPaymentsSection() {
         }
       />,
       error ? (
-        <p className='text-[13px] leading-[18px] text-destructive'>{error}</p>
+        <p className='text-app leading-[18px] text-destructive'>{error}</p>
       ) : undefined
     );
   }
@@ -223,7 +223,7 @@ export function SettingsPaymentsSection() {
       }
     />,
     error ? (
-      <p className='text-[13px] leading-[18px] text-destructive'>{error}</p>
+      <p className='text-app leading-[18px] text-destructive'>{error}</p>
     ) : undefined
   );
 }


### PR DESCRIPTION
## Summary
- 3 `text-[13px]` -> `text-app` in SettingsPaymentsSection. Byte-identical token swap.
- Part of the text-size consolidation wave.

## Test plan
- [x] grep confirms zero `text-[13px]` remain
- [x] typecheck + lint + a11y passed via pre-commit hooks

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>