### PR TITLE
fix: resolve SonarCloud issues in OnboardingInterviewModal

### DIFF
--- a/apps/web/components/onboarding/OnboardingInterviewModal.tsx
+++ b/apps/web/components/onboarding/OnboardingInterviewModal.tsx
@@ -66,8 +66,8 @@ export function OnboardingInterviewModal({
     if (!isRequested) return;
 
     const alreadySubmitted =
-      typeof window !== 'undefined' &&
-      window.sessionStorage.getItem(SESSION_KEY) === '1';
+      typeof globalThis.window !== 'undefined' &&
+      globalThis.sessionStorage.getItem(SESSION_KEY) === '1';
 
     if (alreadySubmitted) {
       router.replace(pathname);
@@ -101,11 +101,11 @@ export function OnboardingInterviewModal({
           transcript,
           metadata: {
             locale:
-              typeof navigator !== 'undefined' ? navigator.language : null,
+              typeof navigator === 'undefined' ? null : navigator.language,
             userAgent:
-              typeof navigator !== 'undefined'
-                ? navigator.userAgent.slice(0, 512)
-                : null,
+              typeof navigator === 'undefined'
+                ? null
+                : navigator.userAgent.slice(0, 512),
           },
         }),
       });
@@ -113,8 +113,8 @@ export function OnboardingInterviewModal({
       // Silent failure — this is a research feature, not a paywall.
       // Loss of one transcript is acceptable.
     } finally {
-      if (typeof window !== 'undefined') {
-        window.sessionStorage.setItem(SESSION_KEY, '1');
+      if (typeof globalThis.window !== 'undefined') {
+        globalThis.sessionStorage.setItem(SESSION_KEY, '1');
       }
       setSubmitting(false);
       setOpen(false);
@@ -130,12 +130,11 @@ export function OnboardingInterviewModal({
             : entry
         );
 
-        const isLast = current === prev.length - 1;
-        if (isLast) {
+        if (current === prev.length - 1) {
           void submit(next);
-          return next;
+        } else {
+          setCurrent(current + 1);
         }
-        setCurrent(current + 1);
         return next;
       });
     },


### PR DESCRIPTION
## Summary
Quick-win SonarCloud fixes scoped to `OnboardingInterviewModal.tsx`.

- **S3516 (BLOCKER)** consolidate setDraft callback to a single return
- **S7764** prefer `globalThis` / `globalThis.window` over bare `window` (4 sites)
- **S7735** flip negated `typeof navigator !== 'undefined'` ternaries (L104, L106)

No behavior changes.

## Test plan
- [x] biome check passes
- [x] typecheck passes (husky)
- [x] eslint passes (husky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)