### PR TITLE
fix: resolve SonarCloud issues in CatalogTaskBuilderDialog

### DIFF
--- a/apps/web/components/features/dashboard/release-tasks/CatalogTaskBuilderDialog.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/CatalogTaskBuilderDialog.tsx
@@ -86,8 +86,8 @@ export function CatalogTaskBuilderDialog({
       groups.set(key, list);
     }
     return Array.from(groups.entries()).sort((a, b) => {
-      const aOrder = a[0] === null ? Infinity : a[0];
-      const bOrder = b[0] === null ? Infinity : b[0];
+      const aOrder = a[0] ?? Infinity;
+      const bOrder = b[0] ?? Infinity;
       return aOrder - bOrder;
     });
   }, [filtered]);
@@ -148,7 +148,7 @@ export function CatalogTaskBuilderDialog({
             ) : (
               grouped.map(([clusterId, rows]) => {
                 const cluster =
-                  clusterId !== null ? clustersById.get(clusterId) : null;
+                  clusterId === null ? null : clustersById.get(clusterId);
                 const heading = cluster?.displayName ?? 'Uncategorized';
                 return (
                   <div key={String(clusterId ?? 'null')}>
@@ -159,6 +159,14 @@ export function CatalogTaskBuilderDialog({
                       {rows.map(row => {
                         const isAdded = addedSet.has(row.slug);
                         const isPending = pendingSlug === row.slug;
+                        let buttonLabel: string;
+                        if (isAdded) {
+                          buttonLabel = 'Added';
+                        } else if (isPending) {
+                          buttonLabel = 'Adding...';
+                        } else {
+                          buttonLabel = 'Add';
+                        }
                         return (
                           <li
                             key={row.slug}
@@ -185,11 +193,7 @@ export function CatalogTaskBuilderDialog({
                               onClick={() => handleAdd(row.slug)}
                               data-testid={`catalog-add-${row.slug}`}
                             >
-                              {isAdded
-                                ? 'Added'
-                                : isPending
-                                  ? 'Adding...'
-                                  : 'Add'}
+                              {buttonLabel}
                             </Button>
                           </li>
                         );


### PR DESCRIPTION
## Summary
Quick-win SonarCloud fixes scoped to `CatalogTaskBuilderDialog.tsx`.

- **S6606** use nullish coalescing (`??`) for null cluster order (L89-90)
- **S7735** flip negated cluster lookup ternary (L151)
- **S3358** extract nested ternary for button label (L188-192)

No behavior changes.

## Test plan
- [x] biome check passes
- [x] typecheck passes (husky)
- [x] eslint passes (husky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and maintainability in the task builder dialog component through logic simplifications and variable consolidation.

---

**Note:** This release contains no user-visible changes. Updates are internal code improvements focused on code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->