### PR TITLE
refactor(ui): sweep text-[12px] → text-xs across /app surfaces

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -92,7 +92,7 @@ function ChatTitleBadge({ title }: { readonly title: string }) {
       <span className='shrink-0 text-[11px] font-[560] tracking-normal text-tertiary-token'>
         Thread
       </span>
-      <span className='block max-w-[220px] truncate text-[12px] font-[510] text-primary-token'>
+      <span className='block max-w-[220px] truncate text-xs font-[510] text-primary-token'>
         {title}
       </span>
     </span>

--- a/apps/web/app/app/(shell)/settings/artist-profile/ArtistProfileContent.tsx
+++ b/apps/web/app/app/(shell)/settings/artist-profile/ArtistProfileContent.tsx
@@ -56,7 +56,7 @@ export function ArtistProfileContent() {
               href={`/${artist.handle}`}
               target='_blank'
               rel='noopener noreferrer'
-              className='inline-flex h-8 items-center gap-1.5 rounded-[10px] border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-3 text-[12px] font-[510] text-secondary-token transition-colors hover:bg-surface-0 hover:text-primary-token'
+              className='inline-flex h-8 items-center gap-1.5 rounded-[10px] border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-3 text-xs font-[510] text-secondary-token transition-colors hover:bg-surface-0 hover:text-primary-token'
             >
               View as Visitor
               <ExternalLink className='h-3.5 w-3.5' aria-hidden='true' />

--- a/apps/web/app/app/(shell)/settings/retargeting-ads/page.tsx
+++ b/apps/web/app/app/(shell)/settings/retargeting-ads/page.tsx
@@ -33,7 +33,7 @@ function SummaryCard({
       <p className='text-2xl font-semibold tracking-[-0.03em] text-primary-token'>
         {value}
       </p>
-      <p className='text-[12px] font-[560] uppercase tracking-[0.14em] text-tertiary-token'>
+      <p className='text-xs font-[560] uppercase tracking-[0.14em] text-tertiary-token'>
         {label}
       </p>
       <p className='text-[13px] leading-5 text-secondary-token'>
@@ -99,10 +99,10 @@ function AttributionStatsCard() {
                 surface='nested'
                 className='px-3 py-2'
               >
-                <p className='text-[12px] font-[560] text-primary-token'>
+                <p className='text-xs font-[560] text-primary-token'>
                   {platform.label}
                 </p>
-                <p className='text-[12px] text-secondary-token'>
+                <p className='text-xs text-secondary-token'>
                   {stats.byPlatform[platform.key]}
                 </p>
               </ContentSurfaceCard>
@@ -231,9 +231,7 @@ function AdPreviewCard({ variant }: { readonly variant: AdVariant }) {
           <p className='text-[13px] font-[560] text-primary-token'>
             {variant.label}
           </p>
-          <p className='text-[12px] text-tertiary-token'>
-            {variant.dimensions}
-          </p>
+          <p className='text-xs text-tertiary-token'>{variant.dimensions}</p>
         </div>
         <div className='flex items-center gap-2'>
           <Button

--- a/apps/web/components/features/dashboard/atoms/DashboardHeaderActionButton.tsx
+++ b/apps/web/components/features/dashboard/atoms/DashboardHeaderActionButton.tsx
@@ -10,7 +10,7 @@ import { cn } from '@/lib/utils';
 
 export const DASHBOARD_HEADER_ACTION_TEXT_BUTTON_CLASS = cn(
   APP_CONTROL_BUTTON_CLASS,
-  'h-7 gap-1.5 rounded-full border-transparent bg-transparent px-2 text-[12px] font-[560] text-secondary-token shadow-none hover:border-transparent hover:bg-surface-0 hover:text-primary-token focus-visible:border-transparent focus-visible:bg-surface-0 active:border-transparent active:bg-surface-0 [&_svg]:h-3.5 [&_svg]:w-3.5'
+  'h-7 gap-1.5 rounded-full border-transparent bg-transparent px-2 text-xs font-[560] text-secondary-token shadow-none hover:border-transparent hover:bg-surface-0 hover:text-primary-token focus-visible:border-transparent focus-visible:bg-surface-0 active:border-transparent active:bg-surface-0 [&_svg]:h-3.5 [&_svg]:w-3.5'
 );
 
 export const DASHBOARD_HEADER_ACTION_TEXT_BUTTON_ACTIVE_CLASS =

--- a/apps/web/components/features/dashboard/atoms/DspConnectionPill.tsx
+++ b/apps/web/components/features/dashboard/atoms/DspConnectionPill.tsx
@@ -24,7 +24,7 @@ import {
 } from './DspProviderIcon';
 
 const BASE_PILL_CLASSNAME =
-  'inline-flex min-h-[28px] items-center gap-1.5 rounded-md border px-2 py-1 text-[12px] font-[510] tracking-[-0.01em] transition-[background-color,border-color,color] duration-150';
+  'inline-flex min-h-[28px] items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-[510] tracking-[-0.01em] transition-[background-color,border-color,color] duration-150';
 
 const INTERACTIVE_PILL_CLASSNAME =
   'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20 disabled:opacity-50 disabled:cursor-not-allowed';

--- a/apps/web/components/features/dashboard/atoms/PlatformPill.utils.ts
+++ b/apps/web/components/features/dashboard/atoms/PlatformPill.utils.ts
@@ -26,7 +26,7 @@ export interface PillClassNameParams {
  * Base classes applied to all pills
  */
 const BASE_CLASSES = [
-  'group/pill relative min-w-0 border text-[12px] font-[510] tracking-[-0.01em]',
+  'group/pill relative min-w-0 border text-xs font-[510] tracking-[-0.01em]',
   'border-(--pill-border) hover:border-(--pill-border-hover)',
   'bg-(--linear-app-content-surface) hover:bg-(--pill-bg-hover)',
   'text-secondary-token hover:text-primary-token',

--- a/apps/web/components/features/dashboard/dashboard-analytics/RangeToggle.tsx
+++ b/apps/web/components/features/dashboard/dashboard-analytics/RangeToggle.tsx
@@ -104,7 +104,7 @@ export function RangeToggle({
             title={
               disabled ? 'Upgrade to Pro for extended analytics' : undefined
             }
-            className={`relative h-[26px] rounded-full border border-transparent px-2.5 text-[12px] font-[510] tracking-[-0.01em] shadow-none transition-[background-color,color,border-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-app-content-surface) ${stateClass}`}
+            className={`relative h-[26px] rounded-full border border-transparent px-2.5 text-xs font-[510] tracking-[-0.01em] shadow-none transition-[background-color,color,border-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-app-content-surface) ${stateClass}`}
           >
             {opt.label}
           </button>

--- a/apps/web/components/features/dashboard/insights/InsightCard.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightCard.tsx
@@ -53,7 +53,7 @@ export function InsightCard({ insight }: InsightCardProps) {
 
           {insight.actionSuggestion ? (
             <div className='mt-2 rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-2'>
-              <p className='text-[12px] font-[510] text-primary-token'>
+              <p className='text-xs font-[510] text-primary-token'>
                 {insight.actionSuggestion}
               </p>
             </div>

--- a/apps/web/components/features/dashboard/insights/InsightsSummaryWidget.tsx
+++ b/apps/web/components/features/dashboard/insights/InsightsSummaryWidget.tsx
@@ -61,7 +61,7 @@ export function InsightsSummaryWidget() {
             className='flex items-start gap-2 rounded-[8px] border border-transparent px-2 py-1.5 transition-[background-color,border-color] duration-150 hover:border-(--linear-app-frame-seam) hover:bg-surface-0'
           >
             <InsightCategoryIcon category={insight.category} size='sm' />
-            <p className='line-clamp-2 text-[12px] leading-snug text-secondary-token'>
+            <p className='line-clamp-2 text-xs leading-snug text-secondary-token'>
               <span className='font-[510] text-primary-token'>
                 {insight.title}
               </span>

--- a/apps/web/components/features/dashboard/layout/PreviewPanel.tsx
+++ b/apps/web/components/features/dashboard/layout/PreviewPanel.tsx
@@ -293,7 +293,7 @@ export function PreviewPanel() {
         Live preview
       </p>
       <div className='flex min-w-0 items-center gap-1.5'>
-        <span className='truncate text-[12px] font-semibold tracking-[-0.01em] text-primary-token'>
+        <span className='truncate text-xs font-semibold tracking-[-0.01em] text-primary-token'>
           {displayName || username || 'Profile'}
         </span>
         {username && displayName !== username && (
@@ -383,7 +383,7 @@ export function PreviewPanel() {
               <Button
                 asChild
                 variant='primary'
-                className='h-9 w-full rounded-[10px] text-[12px] font-caption tracking-[-0.01em]'
+                className='h-9 w-full rounded-[10px] text-xs font-caption tracking-[-0.01em]'
               >
                 <a href={profileUrl} target='_blank' rel='noopener noreferrer'>
                   <ExternalLink

--- a/apps/web/components/features/dashboard/molecules/DspMatchCard.tsx
+++ b/apps/web/components/features/dashboard/molecules/DspMatchCard.tsx
@@ -154,7 +154,7 @@ export function DspMatchCard({
           <button
             type='button'
             onClick={() => setIsExpanded(!isExpanded)}
-            className='flex h-7 w-full items-center justify-between rounded-[8px] border border-transparent px-2 text-[12px] text-tertiary-token transition-[background-color,border-color,color] duration-150 hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+            className='flex h-7 w-full items-center justify-between rounded-[8px] border border-transparent px-2 text-xs text-tertiary-token transition-[background-color,border-color,color] duration-150 hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-secondary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
           >
             <span>Confidence breakdown</span>
             <Icon

--- a/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
@@ -203,7 +203,7 @@ function RankedList({
     return (
       <div className='flex min-h-[196px] flex-col items-center justify-center text-center'>
         <IconComponent className='mb-1.5 h-4 w-4 text-quaternary-token' />
-        <p className='text-[12px] text-tertiary-token'>{emptyMessage}</p>
+        <p className='text-xs text-tertiary-token'>{emptyMessage}</p>
       </div>
     );
   }
@@ -294,7 +294,7 @@ export function AnalyticsSidebarView({
                 <p className='text-[15px] font-semibold tracking-[-0.016em] text-primary-token'>
                   Audience funnel
                 </p>
-                <p className='text-[12px] leading-[16px] text-secondary-token'>
+                <p className='text-xs leading-[16px] text-secondary-token'>
                   Views, clicks, and top traffic sources.
                 </p>
               </div>

--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -71,7 +71,7 @@ export function DashboardHeader({
         {/* Desktop: Simplified breadcrumb - just current page */}
         <div className='flex min-w-0 flex-1 items-center gap-1 tracking-[-0.012em]'>
           {usesSectionTitleLayout ? (
-            <span className='truncate text-[12px] font-[560] tracking-[-0.01em] text-primary-token'>
+            <span className='truncate text-xs font-[560] tracking-[-0.01em] text-primary-token'>
               {currentLabel}
             </span>
           ) : (
@@ -81,11 +81,11 @@ export function DashboardHeader({
               </span>
               <ChevronRight className='size-3 shrink-0 text-quaternary-token/85' />
               {breadcrumbSuffix ? (
-                <div className='min-w-0 truncate text-[12px] tracking-[-0.01em] text-secondary-token'>
+                <div className='min-w-0 truncate text-xs tracking-[-0.01em] text-secondary-token'>
                   {breadcrumbSuffix}
                 </div>
               ) : (
-                <span className='truncate text-[12px] font-[560] tracking-[-0.01em] text-primary-token'>
+                <span className='truncate text-xs font-[560] tracking-[-0.01em] text-primary-token'>
                   {currentLabel}
                 </span>
               )}

--- a/apps/web/components/features/dashboard/organisms/DashboardOverview.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardOverview.tsx
@@ -93,7 +93,7 @@ function SetupTaskItem({
       {!isComplete && (
         <Link
           href={actionHref}
-          className='rounded-full border border-transparent px-2.5 py-1 text-[12px] font-[510] text-secondary-token transition-[background-color,border-color,color] hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-primary-token'
+          className='rounded-full border border-transparent px-2.5 py-1 text-xs font-[510] text-secondary-token transition-[background-color,border-color,color] hover:border-(--linear-app-frame-seam) hover:bg-surface-0 hover:text-primary-token'
         >
           {actionLabel} {GLYPH_ARROW_RIGHT}
         </Link>

--- a/apps/web/components/features/dashboard/organisms/GetStartedChecklistCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/GetStartedChecklistCard.tsx
@@ -171,7 +171,7 @@ export function GetStartedChecklistCard({
     <ContentSurfaceCard className='overflow-hidden p-0'>
       <div className='flex items-center justify-between gap-3 border-b border-(--linear-app-frame-seam) px-3 py-2'>
         <div className='flex items-center gap-1.5'>
-          <h3 className='text-[12px] font-[510] tracking-[-0.01em] text-primary-token'>
+          <h3 className='text-xs font-[510] tracking-[-0.01em] text-primary-token'>
             Get started
           </h3>
           <span className='text-[11px] text-tertiary-token'>
@@ -237,7 +237,7 @@ export function GetStartedChecklistCard({
 
           const labelEl = (
             <p
-              className={`min-w-0 flex-1 text-[12px] leading-snug ${isDone ? 'line-through text-tertiary-token' : 'text-secondary-token'}`}
+              className={`min-w-0 flex-1 text-xs leading-snug ${isDone ? 'line-through text-tertiary-token' : 'text-secondary-token'}`}
             >
               {item.label}
             </p>

--- a/apps/web/components/features/dashboard/organisms/SettingsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsSection.tsx
@@ -46,7 +46,7 @@ export function SettingsSection({
           description={description}
           className='border-b-0'
           titleClassName='text-[13px] font-[540]'
-          subtitleClassName='text-[12px] text-secondary-token'
+          subtitleClassName='text-xs text-secondary-token'
         />
         {headerAction}
       </div>

--- a/apps/web/components/features/dashboard/organisms/SmartActionCards.tsx
+++ b/apps/web/components/features/dashboard/organisms/SmartActionCards.tsx
@@ -44,7 +44,7 @@ function ActionCard({
         </div>
         <div className='min-w-0'>
           <p className='text-[13px] font-[510] text-primary-token'>{heading}</p>
-          <p className='truncate text-[12px] text-secondary-token'>{subtext}</p>
+          <p className='truncate text-xs text-secondary-token'>{subtext}</p>
         </div>
       </div>
       <ArrowRight

--- a/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberActions.tsx
+++ b/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberActions.tsx
@@ -31,7 +31,7 @@ export function AudienceMemberActions({ member }: AudienceMemberActionsProps) {
         <li
           key={`${member.id}-${action.label}-${action.timestamp ?? ''}`}
           className={cn(
-            'group flex items-start gap-2 rounded-md border border-transparent px-1.5 py-1.5 text-[12px] text-primary-token transition-colors hover:bg-surface-0'
+            'group flex items-start gap-2 rounded-md border border-transparent px-1.5 py-1.5 text-xs text-primary-token transition-colors hover:bg-surface-0'
           )}
         >
           <span

--- a/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberActivityFeed.tsx
+++ b/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberActivityFeed.tsx
@@ -72,9 +72,7 @@ function ActivityItem({
       </span>
 
       <div className='min-w-0 flex-1 pt-px'>
-        <p className='truncate text-[12px] leading-4 text-primary-token'>
-          {label}
-        </p>
+        <p className='truncate text-xs leading-4 text-primary-token'>{label}</p>
         <div className='mt-0.5 flex items-center gap-1.5 text-[10.5px] text-tertiary-token'>
           {action.sourceLabel ? (
             <span className='max-w-[140px] truncate rounded bg-surface-0 px-1 text-secondary-token'>

--- a/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberReferrers.tsx
+++ b/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberReferrers.tsx
@@ -128,7 +128,7 @@ export function AudienceMemberReferrers({
       {sources.map(source => (
         <li
           key={`${member.id}-${source.key}`}
-          className='rounded-md border border-transparent px-1.5 py-1.5 text-[12px] text-primary-token transition-colors hover:bg-surface-0'
+          className='rounded-md border border-transparent px-1.5 py-1.5 text-xs text-primary-token transition-colors hover:bg-surface-0'
         >
           <div className='flex items-start gap-2'>
             <SourceIcon kind={source.kind} />

--- a/apps/web/components/features/dashboard/organisms/dashboard-activity-feed/DashboardActivityFeed.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-activity-feed/DashboardActivityFeed.tsx
@@ -42,7 +42,7 @@ function ActivityEmptyState({
   return (
     <div className={isRefreshing ? 'opacity-70 transition-opacity' : undefined}>
       <div className='flex min-h-[140px] items-center rounded-md bg-surface-1 px-2'>
-        <p className='text-[12px] leading-[17px] text-secondary-token'>
+        <p className='text-xs leading-[17px] text-secondary-token'>
           No recent activity. Share your profile to see engagement here.
         </p>
       </div>

--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceCard.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceCard.tsx
@@ -68,7 +68,7 @@ export function DspPresenceCard({
                   {item.externalArtistName ?? 'Unknown Artist'}
                 </span>
               </div>
-              <div className='mt-0.5 flex items-center gap-1.5 text-[12px] text-tertiary-token'>
+              <div className='mt-0.5 flex items-center gap-1.5 text-xs text-tertiary-token'>
                 <DspProviderIcon provider={item.providerId} size='sm' />
                 <span>{label}</span>
               </div>
@@ -80,7 +80,7 @@ export function DspPresenceCard({
           </div>
         </div>
 
-        <div className='flex min-h-5 items-center gap-2.5 text-[12px] text-tertiary-token'>
+        <div className='flex min-h-5 items-center gap-2.5 text-xs text-tertiary-token'>
           {isConfirmed && (
             <ConfidenceBadge score={item.confidenceScore ?? 0} size='sm' />
           )}
@@ -96,7 +96,7 @@ export function DspPresenceCard({
             href={item.externalArtistUrl}
             target='_blank'
             rel='noopener noreferrer'
-            className='inline-flex items-center gap-1.5 text-[12px] text-tertiary-token transition-colors hover:text-primary-token'
+            className='inline-flex items-center gap-1.5 text-xs text-tertiary-token transition-colors hover:text-primary-token'
           >
             <Icon name='ExternalLink' className='h-3.5 w-3.5' />
             <span>View on {label}</span>

--- a/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
@@ -176,7 +176,7 @@ export function OnboardingHandleStep({
             ) : null}
             {handleValidation.suggestions.length > 0 && (
               <div className='flex flex-wrap items-center gap-2'>
-                <span className='text-[12px] text-tertiary-token'>Try:</span>
+                <span className='text-xs text-tertiary-token'>Try:</span>
                 {handleValidation.suggestions.map(suggestion => (
                   <button
                     key={suggestion}

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileAboutTab.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileAboutTab.tsx
@@ -158,7 +158,7 @@ function LocationField({
           trigger={
             <button
               type='button'
-              className='flex items-center gap-2 rounded-[10px] px-1.5 py-1 text-[12px] text-secondary-token transition-colors hover:bg-surface-0 hover:text-primary-token'
+              className='flex items-center gap-2 rounded-[10px] px-1.5 py-1 text-xs text-secondary-token transition-colors hover:bg-surface-0 hover:text-primary-token'
             >
               <Icon
                 className='h-3.5 w-3.5 shrink-0 text-tertiary-token'
@@ -171,7 +171,7 @@ function LocationField({
       );
     }
     return (
-      <div className='flex items-center gap-2 text-[12px] text-tertiary-token'>
+      <div className='flex items-center gap-2 text-xs text-tertiary-token'>
         <Icon className='h-3.5 w-3.5 shrink-0' aria-hidden='true' />
         <span className='capitalize'>{label(value)}</span>
       </div>
@@ -187,7 +187,7 @@ function LocationField({
         trigger={
           <button
             type='button'
-            className='flex items-center gap-2 rounded-[10px] px-1.5 py-1 text-[12px] text-tertiary-token transition-colors hover:bg-surface-0 hover:text-secondary-token'
+            className='flex items-center gap-2 rounded-[10px] px-1.5 py-1 text-xs text-tertiary-token transition-colors hover:bg-surface-0 hover:text-secondary-token'
           >
             <Icon className='h-3.5 w-3.5 shrink-0' aria-hidden='true' />
             <span>Add your {addLabel.toLowerCase()}</span>
@@ -534,7 +534,7 @@ function PressPhotosSection({
                   <ImagePlus className='h-4 w-4' />
                 </div>
                 <div className='space-y-0.5'>
-                  <p className='text-[12px] font-medium text-secondary-token'>
+                  <p className='text-xs font-medium text-secondary-token'>
                     Add photo
                   </p>
                   <p className='text-[11px] text-tertiary-token'>
@@ -614,7 +614,7 @@ export function ProfileAboutTab({
             </p>
           )}
           {!onBioChange && !bio && (
-            <p className='text-[12px] text-tertiary-token'>
+            <p className='text-xs text-tertiary-token'>
               No bio yet. Use the chat to generate one.
             </p>
           )}
@@ -649,7 +649,7 @@ export function ProfileAboutTab({
             {Boolean(activeSinceYear) && (
               <div className='space-y-1' data-testid='active-since'>
                 <DetailLabel>Active Since</DetailLabel>
-                <div className='flex items-center gap-2 text-[12px] text-secondary-token'>
+                <div className='flex items-center gap-2 text-xs text-secondary-token'>
                   <Calendar
                     className='h-3.5 w-3.5 shrink-0 text-tertiary-token'
                     aria-hidden='true'
@@ -711,7 +711,7 @@ export function ProfileAboutTab({
               trigger={
                 <button
                   type='button'
-                  className='flex items-center gap-1.5 text-[12px] text-tertiary-token transition-colors hover:text-secondary-token'
+                  className='flex items-center gap-1.5 text-xs text-tertiary-token transition-colors hover:text-secondary-token'
                 >
                   <Plus className='h-3.5 w-3.5' />
                   <span>Add genres</span>
@@ -720,7 +720,7 @@ export function ProfileAboutTab({
             />
           )}
           {!hasGenres && !onGenresChange && (
-            <p className='text-[12px] text-tertiary-token'>
+            <p className='text-xs text-tertiary-token'>
               Auto-detected from your music connections.
             </p>
           )}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ImportProgressBanner.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ImportProgressBanner.tsx
@@ -31,7 +31,7 @@ export const ImportProgressBanner = memo(function ImportProgressBanner({
   if (compact) {
     return (
       <div
-        className='inline-flex h-7.5 items-center gap-2 rounded-[6px] border border-[#1DB954]/16 bg-[#1DB954]/6 px-2.5 text-[12px] text-primary-token'
+        className='inline-flex h-7.5 items-center gap-2 rounded-[6px] border border-[#1DB954]/16 bg-[#1DB954]/6 px-2.5 text-xs text-primary-token'
         aria-live='polite'
       >
         <ProviderIcon provider='spotify' className='h-3.5 w-3.5 shrink-0' />

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
@@ -1016,7 +1016,7 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
               <h3 className='text-[13px] font-[510] text-primary-token'>
                 No releases yet
               </h3>
-              <p className='mt-0.5 max-w-sm text-[12px] leading-[17px] text-secondary-token'>
+              <p className='mt-0.5 max-w-sm text-xs leading-[17px] text-secondary-token'>
                 {canCreateManualReleases
                   ? 'Sync from Spotify or create one manually to start generating smart links.'
                   : 'Sync from Spotify to start generating smart links.'}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
@@ -203,7 +203,7 @@ export function ReleaseTable({
     return (
       <Suspense
         fallback={
-          <div className='px-4 py-3 text-[12px] text-secondary-token'>
+          <div className='px-4 py-3 text-xs text-secondary-token'>
             Loading releases...
           </div>
         }

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableDisplayMenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableDisplayMenu.tsx
@@ -42,7 +42,7 @@ function ReleaseViewSegmentedControl({
       }))}
       size='md'
       className='grid w-full grid-cols-2'
-      triggerClassName='min-h-[34px] px-3 py-1.5 text-[12px]'
+      triggerClassName='min-h-[34px] px-3 py-1.5 text-xs'
       aria-label='Choose releases view'
     />
   );
@@ -65,9 +65,7 @@ function ToggleSwitch({
       onClick={onToggle}
       className='flex w-full items-center justify-between gap-2 rounded-full px-2 py-1.5 transition-[background-color,color] duration-150 hover:bg-surface-1 focus-visible:outline-none focus-visible:bg-surface-1'
     >
-      <span className='text-[12px] font-[510] text-secondary-token'>
-        {label}
-      </span>
+      <span className='text-xs font-[510] text-secondary-token'>{label}</span>
       <span
         className={cn(
           'flex h-[18px] w-[30px] shrink-0 items-center rounded-full p-[3px] transition-colors',

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableSubheader.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableSubheader.tsx
@@ -165,7 +165,7 @@ export const ReleaseTableSubheader = memo(function ReleaseTableSubheader({
               />
             }
             tooltipLabel='Search'
-            className='h-7 text-[12px] text-tertiary-token hover:text-primary-token'
+            className='h-7 text-xs text-tertiary-token hover:text-primary-token'
           />
           <Suspense
             fallback={

--- a/apps/web/components/features/dashboard/organisms/releases/ReleaseEditDialog.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/ReleaseEditDialog.tsx
@@ -161,7 +161,7 @@ export function ReleaseEditDialog({
                         }
                         placeholder={`${provider.label} URL`}
                         data-testid={`provider-input-${release.id}-${provider.key}`}
-                        className='h-8 rounded-[8px] border-subtle bg-surface-0 text-[12px]'
+                        className='h-8 rounded-[8px] border-subtle bg-surface-0 text-xs'
                       />
                       <div className='flex items-center justify-between gap-2'>
                         <DrawerButton

--- a/apps/web/components/features/dashboard/organisms/releases/cells/AvailabilityCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/cells/AvailabilityCell.tsx
@@ -208,7 +208,7 @@ export const AvailabilityCell = memo(function AvailabilityCell({
           aria-label='Show provider availability details'
           aria-haspopup='listbox'
           aria-expanded={open}
-          className='inline-flex min-w-0 max-w-full items-center gap-1 rounded-full border border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_82%,var(--linear-bg-surface-0))] px-1.5 py-1 text-[12px] font-normal tracking-[-0.01em] text-secondary-token transition-[background-color,border-color,color,box-shadow] duration-150 hover:border-default hover:bg-surface-1 hover:text-primary-token focus-visible:border-(--color-accent) focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)'
+          className='inline-flex min-w-0 max-w-full items-center gap-1 rounded-full border border-(--linear-app-frame-seam) bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_82%,var(--linear-bg-surface-0))] px-1.5 py-1 text-xs font-normal tracking-[-0.01em] text-secondary-token transition-[background-color,border-color,color,box-shadow] duration-150 hover:border-default hover:bg-surface-1 hover:text-primary-token focus-visible:border-(--color-accent) focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--color-accent)'
         >
           <CompactLinkRail
             items={compactProviders.map(providerKey => ({
@@ -247,7 +247,7 @@ export const AvailabilityCell = memo(function AvailabilityCell({
         className='w-[320px] rounded-[12px] border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-0 shadow-popover'
       >
         <div className='border-b border-(--linear-app-frame-seam) px-3 py-2'>
-          <p className='text-[12px] font-caption tracking-[-0.01em] text-primary-token'>
+          <p className='text-xs font-caption tracking-[-0.01em] text-primary-token'>
             Platform Availability
           </p>
           <p className='text-[11px] text-secondary-token'>
@@ -299,7 +299,7 @@ export const AvailabilityCell = memo(function AvailabilityCell({
                     className='h-4 w-4'
                     aria-label={config.label}
                   />
-                  <span className='truncate text-[12px] font-normal text-primary-token'>
+                  <span className='truncate text-xs font-normal text-primary-token'>
                     {config.label}
                   </span>
                 </div>
@@ -365,7 +365,7 @@ export const AvailabilityCell = memo(function AvailabilityCell({
                             setValidationError('');
                           }}
                           disabled={isAddingUrl}
-                          className='h-8 w-[150px] rounded-full border-subtle bg-surface-1 text-[12px]'
+                          className='h-8 w-[150px] rounded-full border-subtle bg-surface-1 text-xs'
                           autoFocus
                         />
                         <DrawerButton

--- a/apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx
@@ -59,9 +59,7 @@ function MiniRankedList({
   readonly emptyMessage: string;
 }) {
   if (items.length === 0) {
-    return (
-      <p className='py-2 text-[12px] text-tertiary-token'>{emptyMessage}</p>
-    );
+    return <p className='py-2 text-xs text-tertiary-token'>{emptyMessage}</p>;
   }
 
   return (
@@ -76,11 +74,11 @@ function MiniRankedList({
               {index + 1}
             </span>
             <IconComponent className='h-3 w-3 text-tertiary-token' />
-            <span className='truncate text-[12px] text-secondary-token'>
+            <span className='truncate text-xs text-secondary-token'>
               {item.label}
             </span>
           </div>
-          <span className='ml-2 text-[12px] font-[510] text-primary-token tabular-nums'>
+          <span className='ml-2 text-xs font-[510] text-primary-token tabular-nums'>
             {item.value}
           </span>
         </li>
@@ -274,7 +272,7 @@ export function TourDateSidebar({
                 }
                 meta={
                   tourDate.provider === 'bandsintown' ? (
-                    <div className='flex items-center gap-2 rounded-full border border-[color:color-mix(in_oklab,var(--color-success)_18%,var(--linear-app-frame-seam))] bg-[color:color-mix(in_oklab,var(--color-success)_10%,transparent)] px-3 py-1.5 text-[12px] text-[var(--color-success)]'>
+                    <div className='flex items-center gap-2 rounded-full border border-[color:color-mix(in_oklab,var(--color-success)_18%,var(--linear-app-frame-seam))] bg-[color:color-mix(in_oklab,var(--color-success)_10%,transparent)] px-3 py-1.5 text-xs text-[var(--color-success)]'>
                       <Icon name='Link' className='h-3.5 w-3.5' />
                       <span>Synced from Bandsintown</span>
                     </div>
@@ -486,7 +484,7 @@ export function TourDateSidebar({
                         }
                         disabled={isPending}
                         className={cn(
-                          'flex-1 rounded-full border px-3 py-2 text-[12px] font-[510] transition-[background-color,border-color,color] duration-150',
+                          'flex-1 rounded-full border px-3 py-2 text-xs font-[510] transition-[background-color,border-color,color] duration-150',
                           formData.ticketStatus === status
                             ? 'border-accent/35 bg-accent/10 text-accent'
                             : 'border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token hover:bg-surface-1 hover:text-primary-token'
@@ -512,7 +510,7 @@ export function TourDateSidebar({
                 </DrawerSurfaceCard>
               )}
               {!analyticsLoading && analyticsError && (
-                <p className='text-[12px] text-tertiary-token'>
+                <p className='text-xs text-tertiary-token'>
                   Unable to load analytics data.
                 </p>
               )}
@@ -560,7 +558,7 @@ export function TourDateSidebar({
                   )}
 
                   {(analyticsData?.ticketClicks ?? 0) === 0 && (
-                    <p className='text-[12px] text-tertiary-token'>
+                    <p className='text-xs text-tertiary-token'>
                       No ticket click data yet. Analytics will appear once fans
                       click ticket links for this show.
                     </p>

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCategoryGroup.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCategoryGroup.tsx
@@ -27,7 +27,7 @@ export function ReleaseTaskCategoryGroup({
       <button
         type='button'
         onClick={() => setIsOpen(!isOpen)}
-        className='flex w-full items-center justify-between px-4 py-1 text-[12px] font-[510] text-secondary-token hover:bg-surface-1 rounded transition-colors'
+        className='flex w-full items-center justify-between px-4 py-1 text-xs font-[510] text-secondary-token hover:bg-surface-1 rounded transition-colors'
         aria-expanded={isOpen}
       >
         <span className='flex items-center gap-1.5'>

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskEmptyState.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskEmptyState.tsx
@@ -14,7 +14,7 @@ export function ReleaseTaskEmptyState({
       <p className='text-[13px] font-medium text-primary-token mb-1'>
         Your release playbook
       </p>
-      <p className='text-[12px] text-tertiary-token mb-4 max-w-[280px]'>
+      <p className='text-xs text-tertiary-token mb-4 max-w-[280px]'>
         20 battle-tested tasks to maximize your release — from DSP pitching to
         fan notifications.
       </p>
@@ -28,7 +28,7 @@ export function ReleaseTaskEmptyState({
         type='button'
         onClick={onSetUp}
         disabled={isLoading}
-        className='rounded-md bg-[var(--linear-accent,#5e6ad2)] px-4 py-2 text-[12px] font-medium text-white hover:opacity-90 transition-opacity disabled:opacity-50'
+        className='rounded-md bg-[var(--linear-accent,#5e6ad2)] px-4 py-2 text-xs font-medium text-white hover:opacity-90 transition-opacity disabled:opacity-50'
       >
         {isLoading ? 'Generating...' : 'Generate Release Plan'}
       </button>

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskPage.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskPage.tsx
@@ -64,7 +64,7 @@ export function ReleaseTaskPage({
       data-testid='release-task-page'
     >
       {/* Breadcrumb */}
-      <nav className='mb-4 text-[12px] text-tertiary-token'>
+      <nav className='mb-4 text-xs text-tertiary-token'>
         <span className='hover:text-secondary-token cursor-pointer'>
           Releases
         </span>

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskPastReleaseState.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskPastReleaseState.tsx
@@ -14,7 +14,7 @@ export function ReleaseTaskPastReleaseState({
       <p className='text-[14px] font-medium text-secondary-token mb-1'>
         This release is already out
       </p>
-      <p className='text-[12px] text-tertiary-token mb-4 max-w-[260px]'>
+      <p className='text-xs text-tertiary-token mb-4 max-w-[260px]'>
         Campaign tasks help you prepare for upcoming releases. Since this one is
         already live, there&apos;s nothing to prepare.
       </p>

--- a/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
@@ -69,7 +69,7 @@ export function TaskWorkspaceHeaderBar({
             ariaLabel='Search tasks'
             autoFocus
             className='h-8 max-w-[28rem] bg-transparent'
-            inputClassName='text-[12px]'
+            inputClassName='text-xs'
           />
         )}
         {mode === 'create' && (

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -1697,7 +1697,7 @@ export function TasksPageClient() {
                 >
                   <div className='flex items-center justify-between px-4 pb-1 pt-3'>
                     <div>
-                      <p className='text-[12px] text-secondary-token'>
+                      <p className='text-xs text-secondary-token'>
                         {mobileScopeCounts.all} total tasks
                       </p>
                     </div>

--- a/apps/web/components/features/dashboard/tokens/mobile-tokens.ts
+++ b/apps/web/components/features/dashboard/tokens/mobile-tokens.ts
@@ -11,18 +11,18 @@ export const mobileReleaseTokens = {
     container:
       'flex w-full items-center gap-3 px-4 py-3 text-left transition-[background-color,border-color] active:bg-surface-0 focus-visible:outline-none focus-visible:bg-surface-0',
     title: 'text-[14px] font-semibold leading-tight text-primary-token',
-    subtitle: 'mt-0.5 text-[12px] leading-tight text-secondary-token',
+    subtitle: 'mt-0.5 text-xs leading-tight text-secondary-token',
     /** Badge-style type label — pair with getReleaseTypeStyle().bg */
     typeBadge:
       'inline-flex h-[16px] shrink-0 items-center justify-center rounded-[6px] px-1.5 py-0 align-middle text-3xs font-caption leading-none tracking-normal',
-    year: 'shrink-0 text-[12px] tabular-nums text-tertiary-token',
+    year: 'shrink-0 text-xs tabular-nums text-tertiary-token',
     chevron: 'h-3.5 w-3.5 shrink-0 text-quaternary-token',
     /** Dot separator between metadata items */
     dot: 'text-3xs text-quaternary-token',
   },
   groupHeader:
     'sticky top-0 z-10 flex items-center justify-between border-b border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-4 py-2',
-  groupHeaderTitle: 'text-[12px] font-semibold text-primary-token',
+  groupHeaderTitle: 'text-xs font-semibold text-primary-token',
   groupHeaderCount: 'text-[11px] tabular-nums text-tertiary-token',
   footer: {
     container:

--- a/apps/web/components/features/profile/ProfileHeroCard.tsx
+++ b/apps/web/components/features/profile/ProfileHeroCard.tsx
@@ -190,7 +190,7 @@ export function ArtistHero({
           <div className='flex items-start justify-between gap-4'>
             <div className='min-w-0 space-y-2 text-left'>
               {eyebrow ? (
-                <p className='text-[12px] font-[590] tracking-[0.01em] text-white/58'>
+                <p className='text-xs font-[590] tracking-[0.01em] text-white/58'>
                   {eyebrow}
                 </p>
               ) : null}

--- a/apps/web/components/features/profile/ProfileRedirectSurface.tsx
+++ b/apps/web/components/features/profile/ProfileRedirectSurface.tsx
@@ -26,7 +26,7 @@ export function ProfileRedirectSurface({
           <div className='flex h-12 w-12 items-center justify-center rounded-full border border-subtle bg-surface-0'>
             <LoadingSpinner size='lg' tone='primary' />
           </div>
-          <p className='text-[12px] text-tertiary-token'>{helperText}</p>
+          <p className='text-xs text-tertiary-token'>{helperText}</p>
         </div>
       </ContentSurfaceCard>
     </StandaloneProductPage>

--- a/apps/web/components/features/profile/artist-notifications-cta/shared.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/shared.tsx
@@ -37,7 +37,7 @@ export const subscriptionHeadingClassName =
   'text-balance text-center text-[1.55rem] font-[640] tracking-[-0.045em] text-primary-token sm:text-[1.8rem]';
 
 export const subscriptionDisclaimerClassName =
-  'text-center text-[12px] leading-5 font-normal tracking-[-0.01em] text-muted-foreground/80';
+  'text-center text-xs leading-5 font-normal tracking-[-0.01em] text-muted-foreground/80';
 
 export const profilePrimaryPillClassName =
   'inline-flex h-12 items-center justify-center rounded-full border border-transparent bg-[var(--profile-pearl-primary-bg)] px-5 text-[15px] font-[590] tracking-[-0.018em] text-[var(--profile-pearl-primary-fg)] shadow-[0_10px_24px_rgba(0,0,0,0.16)] transition-[background-color,color,opacity,box-shadow,border-color] duration-200 ease-out hover:opacity-[0.96] hover:shadow-[0_12px_28px_rgba(0,0,0,0.18)] active:opacity-[0.9] disabled:cursor-not-allowed disabled:opacity-50 focus-ring-themed';
@@ -93,10 +93,10 @@ export const subscriptionFeedbackCopyClassName =
   'text-[11px] leading-4 tracking-[-0.01em] text-secondary-token/68';
 
 export const subscriptionErrorTextClassName =
-  'text-[12px] leading-4 tracking-[-0.012em] text-red-400';
+  'text-xs leading-4 tracking-[-0.012em] text-red-400';
 
 export const subscriptionSuccessTextClassName =
-  'text-[12px] leading-4 tracking-[-0.012em] text-emerald-400';
+  'text-xs leading-4 tracking-[-0.012em] text-emerald-400';
 
 export const subscriptionDesktopErrorAffordanceClassName =
   'inline-flex items-center gap-1.5 text-red-400';
@@ -524,7 +524,7 @@ export function SubscriptionSuccess({
           type='button'
           onClick={handleSkip}
           disabled={phase === 'saving'}
-          className='w-full text-center text-[12px] text-secondary-token/70 hover:text-secondary-token transition-colors'
+          className='w-full text-center text-xs text-secondary-token/70 hover:text-secondary-token transition-colors'
           style={noFontSynthesisStyle}
         >
           Skip


### PR DESCRIPTION
## Summary

Mechanical mass-swap of `text-[12px]` → `text-xs` across authenticated /app surfaces.

- **Files changed:** 42
- **Swaps:** 75 occurrences
- **Byte-identical Δ0:** `text-xs` = Tailwind default `0.75rem` = `12px`

## Scope

- `apps/web/app/app/**`
- `apps/web/components/features/dashboard/**`
- `apps/web/components/features/profile/**`

Excludes `admin/`, `templates/`, `features/home/**`, `features/demo/[A-Z]*`.

Continuation of #7522 through #7630 sweep.

## Test plan

- [x] Typecheck passes (`pnpm --filter web typecheck`)
- [x] Biome + ESLint pre-commit hooks pass
- [x] Zero in-scope `text-[12px]` occurrences remain
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)