### PR TITLE
fix: resolve SonarCloud S7781 in normalizeTaskText

### DIFF
--- a/apps/web/lib/release-tasks/normalize-task-text.ts
+++ b/apps/web/lib/release-tasks/normalize-task-text.ts
@@ -6,7 +6,7 @@ export function normalizeTaskText(s: string): string {
   if (!s) return '';
   return s
     .toLowerCase()
-    .replace(/[^\p{L}\p{N}\s&-]/gu, ' ')
-    .replace(/\s+/g, ' ')
+    .replaceAll(/[^\p{L}\p{N}\s&-]/gu, ' ')
+    .replaceAll(/\s+/g, ' ')
     .trim();
 }


### PR DESCRIPTION
## Summary
Prefer `String#replaceAll` over `String#replace(/g)` in `normalizeTaskText`.

- **S7781** L9, L10 — two replace-all regex calls converted.

No behavior change — both forms are equivalent for a global regex.

## Test plan
- [x] biome check passes
- [x] typecheck passes (husky)
- [x] eslint passes (husky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal text normalization implementation for improved efficiency. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->