### PR TITLE
refactor(ui): sweep text-[15px] → text-mid across /app surfaces

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-pay/DashboardPay.tsx
+++ b/apps/web/components/features/dashboard/dashboard-pay/DashboardPay.tsx
@@ -242,7 +242,7 @@ const VenmoConnectDialog = memo(function VenmoConnectDialog({
           <Wallet className='h-4.5 w-4.5 text-accent-token' />
         </div>
         <div className='min-w-0 flex-1'>
-          <DialogTitle className='text-[15px] font-semibold tracking-[-0.011em] text-primary-token'>
+          <DialogTitle className='text-mid font-semibold tracking-[-0.011em] text-primary-token'>
             Connect Venmo
           </DialogTitle>
           <DialogDescription className='mt-0.5 text-app leading-5 text-secondary-token'>

--- a/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
@@ -102,7 +102,7 @@ function FunnelStage({
           {label}
         </span>
         <span className='flex items-baseline gap-1.5'>
-          <span className='tabular-nums text-[15px] font-semibold leading-none tracking-[-0.02em] text-primary-token'>
+          <span className='tabular-nums text-mid font-semibold leading-none tracking-[-0.02em] text-primary-token'>
             {numberFormatter.format(value)}
           </span>
           {rate && (
@@ -291,7 +291,7 @@ export function AnalyticsSidebarView({
             </div>
             <div className='flex items-start justify-between gap-3 pr-8'>
               <div className='space-y-0.5'>
-                <p className='text-[15px] font-semibold tracking-[-0.016em] text-primary-token'>
+                <p className='text-mid font-semibold tracking-[-0.016em] text-primary-token'>
                   Audience funnel
                 </p>
                 <p className='text-[12px] leading-[16px] text-secondary-token'>

--- a/apps/web/components/features/dashboard/organisms/DashboardOverview.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardOverview.tsx
@@ -152,7 +152,7 @@ export function DashboardOverview({
     <ContentSurfaceCard as='header' className='overflow-hidden'>
       <ContentSectionHeader
         title={
-          <span className='text-[15px] font-[590] tracking-[-0.01em] text-primary-token'>
+          <span className='text-mid font-[590] tracking-[-0.01em] text-primary-token'>
             Welcome back, {greetingName}
           </span>
         }

--- a/apps/web/components/features/dashboard/organisms/ProfileEditorSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/ProfileEditorSection.tsx
@@ -204,7 +204,7 @@ export function ProfileEditorSection({
                 onChange={e => onDisplayNameChange(e.target.value)}
                 onKeyDown={e => onInputKeyDown(e, 'displayName')}
                 onBlur={onInputBlur}
-                className='min-h-[46px] rounded-md border-default bg-surface-0 text-center text-[15px] font-semibold tracking-[-0.02em] text-primary-token'
+                className='min-h-[46px] rounded-md border-default bg-surface-0 text-center text-mid font-semibold tracking-[-0.02em] text-primary-token'
               />
             }
           />

--- a/apps/web/components/features/dashboard/organisms/onboarding-v2/OnboardingV2Form.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding-v2/OnboardingV2Form.tsx
@@ -567,7 +567,7 @@ function StepFrame({ actions, children, prompt, title }: StepFrameProps) {
           {title}
         </h1>
         {prompt ? (
-          <p className='max-w-xl text-sm leading-6 text-secondary-token sm:text-[15px]'>
+          <p className='max-w-xl text-sm leading-6 text-secondary-token sm:text-mid'>
             {prompt}
           </p>
         ) : null}

--- a/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
@@ -88,7 +88,7 @@ export function OnboardingHandleStep({
           {title}
         </h1>
         {prompt ? (
-          <p className='max-w-xl text-sm leading-6 text-secondary-token sm:text-[15px]'>
+          <p className='max-w-xl text-sm leading-6 text-secondary-token sm:text-mid'>
             {prompt}
           </p>
         ) : null}
@@ -106,7 +106,7 @@ export function OnboardingHandleStep({
               hasError && 'border-destructive/60'
             )}
           >
-            <span className='pl-3 text-[15px] font-semibold whitespace-nowrap text-secondary-token'>
+            <span className='pl-3 text-mid font-semibold whitespace-nowrap text-secondary-token'>
               jov.ie/
             </span>
             <input
@@ -130,7 +130,7 @@ export function OnboardingHandleStep({
               autoCorrect='off'
               spellCheck={false}
               aria-invalid={hasError ? 'true' : undefined}
-              className='min-w-0 flex-1 bg-transparent text-[15px] font-semibold tracking-[-0.02em] text-primary-token placeholder:text-tertiary-token placeholder:opacity-60 focus-visible:outline-none'
+              className='min-w-0 flex-1 bg-transparent text-mid font-semibold tracking-[-0.02em] text-primary-token placeholder:text-tertiary-token placeholder:opacity-60 focus-visible:outline-none'
             />
             <button
               data-testid='onboarding-handle-submit'

--- a/apps/web/components/features/dashboard/organisms/onboarding/OnboardingProfileReviewStep.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding/OnboardingProfileReviewStep.tsx
@@ -409,7 +409,7 @@ export function OnboardingProfileReviewStep({
                           maxLength={50}
                           className={cn(
                             AUTH_SURFACE.fieldInput,
-                            'text-center text-[15px] font-semibold'
+                            'text-center text-mid font-semibold'
                           )}
                           aria-label='Edit display name'
                         />

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -689,7 +689,7 @@ function TaskDocumentPanel({
                 onFocus={handleDescriptionFocus}
                 onChange={event => onDescriptionChange(event.target.value)}
                 placeholder='Start writing...'
-                className='min-h-[520px] w-full resize-none border-0 bg-transparent px-0 py-0 text-[15px] leading-[1.8] text-primary-token outline-none placeholder:text-[color-mix(in_oklab,var(--text-tertiary)_82%,transparent)]'
+                className='min-h-[520px] w-full resize-none border-0 bg-transparent px-0 py-0 text-mid leading-[1.8] text-primary-token outline-none placeholder:text-[color-mix(in_oklab,var(--text-tertiary)_82%,transparent)]'
               />
               {showDescriptionHelper && descriptionHelper ? (
                 <TaskDescriptionHelper
@@ -1622,7 +1622,7 @@ export function TasksPageClient() {
         {isError ? (
           <div className='flex min-h-[240px] flex-1 flex-col items-center justify-center gap-3 px-6 text-center'>
             <div className='space-y-1'>
-              <h2 className='text-[15px] font-semibold text-primary-token'>
+              <h2 className='text-mid font-semibold text-primary-token'>
                 Couldn&apos;t Load Tasks
               </h2>
               <p className='text-[13px] text-secondary-token'>

--- a/apps/web/components/features/profile/ProfileDrawerShell.tsx
+++ b/apps/web/components/features/profile/ProfileDrawerShell.tsx
@@ -87,7 +87,7 @@ export function ProfileDrawerShell({
           >
             <h2
               id={titleId}
-              className='truncate text-[15px] font-[590] leading-[1.08] tracking-[-0.018em] text-primary-token'
+              className='truncate text-mid font-[590] leading-[1.08] tracking-[-0.018em] text-primary-token'
             >
               {title}
             </h2>

--- a/apps/web/components/features/profile/ProfileHeroCard.tsx
+++ b/apps/web/components/features/profile/ProfileHeroCard.tsx
@@ -104,7 +104,7 @@ export function ArtistHero({
   const heroPearlClassName =
     'border border-white/12 bg-white/8 shadow-[0_12px_30px_rgba(0,0,0,0.18)] backdrop-blur-2xl';
   const primaryActionClassName =
-    'inline-flex min-h-12 items-center justify-center rounded-full bg-[var(--profile-pearl-primary-bg)] px-5 py-3 text-[15px] font-[590] tracking-[-0.015em] text-[var(--profile-pearl-primary-fg)] shadow-[0_18px_40px_rgba(0,0,0,0.3)] transition-[transform,opacity] duration-slow hover:opacity-94 active:scale-[0.985] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
+    'inline-flex min-h-12 items-center justify-center rounded-full bg-[var(--profile-pearl-primary-bg)] px-5 py-3 text-mid font-[590] tracking-[-0.015em] text-[var(--profile-pearl-primary-fg)] shadow-[0_18px_40px_rgba(0,0,0,0.3)] transition-[transform,opacity] duration-slow hover:opacity-94 active:scale-[0.985] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
 
   return (
     <section
@@ -158,7 +158,7 @@ export function ArtistHero({
             <button
               type='button'
               onClick={handleShare}
-              className={`${heroPearlClassName} inline-flex h-11 min-w-11 items-center justify-center gap-2 rounded-full px-4 text-[15px] font-[590] tracking-[-0.015em] text-white/88 transition-[background-color,border-color,color,opacity] hover:bg-white/12 hover:text-white hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]`}
+              className={`${heroPearlClassName} inline-flex h-11 min-w-11 items-center justify-center gap-2 rounded-full px-4 text-mid font-[590] tracking-[-0.015em] text-white/88 transition-[background-color,border-color,color,opacity] hover:bg-white/12 hover:text-white hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]`}
               aria-label={
                 shareSuccess
                   ? `Copied ${artist.name}'s profile link`
@@ -177,7 +177,7 @@ export function ArtistHero({
             <button
               type='button'
               onClick={onBellClick}
-              className={`${heroPearlClassName} inline-flex h-11 min-w-11 items-center justify-center gap-2 rounded-full px-4 text-[15px] font-[590] tracking-[-0.015em] text-white/88 transition-[background-color,border-color,color,opacity] hover:bg-white/12 hover:text-white hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]`}
+              className={`${heroPearlClassName} inline-flex h-11 min-w-11 items-center justify-center gap-2 rounded-full px-4 text-mid font-[590] tracking-[-0.015em] text-white/88 transition-[background-color,border-color,color,opacity] hover:bg-white/12 hover:text-white hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]`}
               aria-label={`Get notified about ${artist.name}`}
             >
               <Bell className='h-[17px] w-[17px]' aria-hidden='true' />
@@ -207,7 +207,7 @@ export function ArtistHero({
             <button
               type='button'
               onClick={onPlayClick}
-              className={`${heroPearlClassName} inline-flex min-h-11 shrink-0 items-center justify-center rounded-full px-4 py-2.5 text-[15px] font-[590] tracking-[-0.015em] text-white/92 transition-[background-color,border-color,color,opacity] hover:bg-white/12 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]`}
+              className={`${heroPearlClassName} inline-flex min-h-11 shrink-0 items-center justify-center rounded-full px-4 py-2.5 text-mid font-[590] tracking-[-0.015em] text-white/92 transition-[background-color,border-color,color,opacity] hover:bg-white/12 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]`}
               aria-label={`Listen to ${artist.name}`}
             >
               <Play

--- a/apps/web/components/features/profile/artist-notifications-cta/BirthdayInput.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/BirthdayInput.tsx
@@ -86,7 +86,7 @@ export function BirthdayInput({
           <div key={group.label} className='flex items-center gap-1'>
             {gIdx > 0 && (
               <span
-                className='px-0.5 text-[15px] text-secondary-token/40 select-none'
+                className='px-0.5 text-mid text-secondary-token/40 select-none'
                 aria-hidden='true'
               >
                 /

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -159,7 +159,7 @@ function BirthdayInput({
   const isHero = tone === 'hero';
   const className = isHero
     ? `${subscriptionHeroInputClassName} text-left px-3`
-    : 'h-12 w-full rounded-full bg-transparent px-3 text-left text-[15px] font-[590] tracking-[-0.02em] text-primary-token placeholder:text-tertiary-token placeholder:opacity-70 focus-visible:outline-none focus-visible:ring-0';
+    : 'h-12 w-full rounded-full bg-transparent px-3 text-left text-mid font-[590] tracking-[-0.02em] text-primary-token placeholder:text-tertiary-token placeholder:opacity-70 focus-visible:outline-none focus-visible:ring-0';
 
   return (
     <input

--- a/apps/web/components/features/profile/artist-notifications-cta/shared.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/shared.tsx
@@ -40,14 +40,14 @@ export const subscriptionDisclaimerClassName =
   'text-center text-[12px] leading-5 font-normal tracking-[-0.01em] text-muted-foreground/80';
 
 export const profilePrimaryPillClassName =
-  'inline-flex h-12 items-center justify-center rounded-full border border-transparent bg-[var(--profile-pearl-primary-bg)] px-5 text-[15px] font-[590] tracking-[-0.018em] text-[var(--profile-pearl-primary-fg)] shadow-[0_10px_24px_rgba(0,0,0,0.16)] transition-[background-color,color,opacity,box-shadow,border-color] duration-200 ease-out hover:opacity-[0.96] hover:shadow-[0_12px_28px_rgba(0,0,0,0.18)] active:opacity-[0.9] disabled:cursor-not-allowed disabled:opacity-50 focus-ring-themed';
+  'inline-flex h-12 items-center justify-center rounded-full border border-transparent bg-[var(--profile-pearl-primary-bg)] px-5 text-mid font-[590] tracking-[-0.018em] text-[var(--profile-pearl-primary-fg)] shadow-[0_10px_24px_rgba(0,0,0,0.16)] transition-[background-color,color,opacity,box-shadow,border-color] duration-200 ease-out hover:opacity-[0.96] hover:shadow-[0_12px_28px_rgba(0,0,0,0.18)] active:opacity-[0.9] disabled:cursor-not-allowed disabled:opacity-50 focus-ring-themed';
 
 /** Pearl-Notify hero morph-bar CTA pill — glassy dark, sits over the hero image. */
 export const profileHeroMorphPillClassName =
   'inline-flex h-11 items-center justify-center rounded-full border border-white/14 bg-white/10 px-5 text-[13.5px] font-[560] tracking-[-0.01em] text-white shadow-[inset_0_0_0_1px_rgba(255,255,255,0.14),0_6px_16px_rgba(0,0,0,0.22)] backdrop-blur-xl transition-[background-color,color,opacity,box-shadow] duration-200 ease-out hover:bg-white/14 active:opacity-[0.9] disabled:cursor-not-allowed disabled:opacity-50 focus-ring-themed';
 
 export const profileSecondaryPillClassName =
-  'inline-flex h-12 items-center justify-center rounded-full border border-[color:var(--profile-pearl-border)] bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_92%,transparent)] px-5 text-[15px] font-[580] tracking-[-0.018em] text-primary-token shadow-[0_10px_24px_rgba(10,12,18,0.08)] backdrop-blur-xl transition-[background-color,border-color,color,box-shadow,transform] duration-200 ease-out hover:bg-[var(--profile-pearl-bg-hover)] hover:border-[color:var(--profile-pearl-border)] hover:shadow-[0_14px_28px_rgba(10,12,18,0.1)] active:scale-[0.985] disabled:cursor-not-allowed disabled:opacity-50 focus-ring-themed';
+  'inline-flex h-12 items-center justify-center rounded-full border border-[color:var(--profile-pearl-border)] bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_92%,transparent)] px-5 text-mid font-[580] tracking-[-0.018em] text-primary-token shadow-[0_10px_24px_rgba(10,12,18,0.08)] backdrop-blur-xl transition-[background-color,border-color,color,box-shadow,transform] duration-200 ease-out hover:bg-[var(--profile-pearl-bg-hover)] hover:border-[color:var(--profile-pearl-border)] hover:shadow-[0_14px_28px_rgba(10,12,18,0.1)] active:scale-[0.985] disabled:cursor-not-allowed disabled:opacity-50 focus-ring-themed';
 
 export const profileQuietIconButtonClassName =
   'border-transparent bg-transparent text-white/72 shadow-none hover:border-[color:var(--profile-pearl-border)] hover:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_86%,transparent)] hover:text-white focus-visible:border-[color:var(--profile-pearl-border)] focus-visible:bg-[color:color-mix(in_srgb,var(--profile-pearl-bg)_90%,transparent)] focus-visible:text-white active:bg-[var(--profile-pearl-bg-active)] active:text-white';
@@ -67,7 +67,7 @@ export const subscriptionHeroComposerFocusClassName =
   'border-white/22 bg-white/14 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.22),0_8px_22px_rgba(0,0,0,0.28)]';
 
 export const subscriptionInputClassName =
-  'h-12 w-full bg-transparent px-2 text-[15px] font-[590] tracking-[-0.02em] text-primary-token placeholder:text-tertiary-token placeholder:opacity-80 transition-[color,opacity] duration-slow focus-visible:outline-none focus-visible:ring-0';
+  'h-12 w-full bg-transparent px-2 text-mid font-[590] tracking-[-0.02em] text-primary-token placeholder:text-tertiary-token placeholder:opacity-80 transition-[color,opacity] duration-slow focus-visible:outline-none focus-visible:ring-0';
 
 export const subscriptionHeroInputClassName =
   'h-11 w-full bg-transparent px-2 text-[13.5px] font-[560] tracking-[-0.01em] text-white placeholder:text-white/45 focus-visible:outline-none focus-visible:ring-0';
@@ -596,7 +596,7 @@ export function SubscriptionPendingConfirmation() {
         )}
       >
         <Mail className='h-5 w-5 text-primary-token/72' aria-hidden='true' />
-        <span className='text-[15px] font-semibold tracking-[-0.015em]'>
+        <span className='text-mid font-semibold tracking-[-0.015em]'>
           Check your inbox
         </span>
       </div>

--- a/apps/web/components/features/profile/notifications/CountrySelector.tsx
+++ b/apps/web/components/features/profile/notifications/CountrySelector.tsx
@@ -132,7 +132,7 @@ export function CountrySelector({
       <PopoverTrigger asChild>
         <button
           type='button'
-          className='flex h-12 items-center gap-1.5 rounded-full px-3 text-[15px] font-[590] tracking-[-0.015em] text-primary-token transition-colors hover:text-primary-token focus-visible:outline-none'
+          className='flex h-12 items-center gap-1.5 rounded-full px-3 text-mid font-[590] tracking-[-0.015em] text-primary-token transition-colors hover:text-primary-token focus-visible:outline-none'
           style={FONT_SYNTHESIS_STYLE}
           aria-label='Select country code'
         >


### PR DESCRIPTION
## Summary
- Mechanical mass-swap of `text-[15px]` → `text-mid` across 14 files (24 occurrences).
- `text-mid` (`--text-mid = 0.9375rem = 15px`, added in #7599) is byte-identical Δ0.
- Closes out 15px deferrals from #7586, #7587, #7594. Same pattern as the 10px → `text-3xs` sweep in #7591 after #7576.

## Scope
- `apps/web/app/app/**`
- `apps/web/components/features/dashboard/**`
- `apps/web/components/features/profile/**`
- Excludes `admin/`, `templates/`.

## Test plan
- [ ] CI typecheck/lint passes
- [ ] Visual Δ0 (token resolves to 15px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)