### PR TITLE
fix: resolve SonarCloud S7741 in homepage intent helpers

### DIFF
--- a/apps/web/components/homepage/HomepageIntent.tsx
+++ b/apps/web/components/homepage/HomepageIntent.tsx
@@ -44,7 +44,7 @@ const PILL_ICONS: Record<HomepagePillId, LucideIcon> = {
  * a touch device while the media query is still resolving.
  */
 function isDesktopViewport(): boolean {
-  if (typeof globalThis.window === 'undefined') return false;
+  if (globalThis.window === undefined) return false;
   const matcher = globalThis.window.matchMedia;
   if (typeof matcher !== 'function') return false;
   // Require both viewport width AND hover+fine pointer so laptops with touch

--- a/apps/web/components/homepage/intent-store.ts
+++ b/apps/web/components/homepage/intent-store.ts
@@ -60,7 +60,7 @@ export function sanitizeHomepagePrompt(value: string): string {
 }
 
 function hasWindow(): boolean {
-  return typeof globalThis.window !== 'undefined';
+  return globalThis.window !== undefined;
 }
 
 function getLocalStorage(): Storage | null {


### PR DESCRIPTION
## Summary
Compare \`globalThis.window\` with \`undefined\` directly instead of \`typeof\`.

- **S7741** intent-store.ts L63 — \`hasWindow()\`
- **S7741** HomepageIntent.tsx L47 — \`isDesktopViewport()\`

No behavior change — direct comparison and \`typeof\` check are semantically identical for a possibly-missing global.

## Test plan
- [x] biome check passes
- [x] typecheck passes (husky)
- [x] eslint passes (husky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)