### PR TITLE
fix(release-tasks): address review comments from #7548

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/catalog-task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/catalog-task-actions.ts
@@ -329,18 +329,6 @@ export async function addCatalogTaskToRelease(releaseId: string, slug: string) {
   const profileId = await requireProfileId();
   await requireReleaseAccess(releaseId, profileId);
 
-  const [existingSnapshot] = await db
-    .select({ id: releaseTaskSnapshots.id })
-    .from(releaseTaskSnapshots)
-    .where(
-      and(
-        eq(releaseTaskSnapshots.releaseId, releaseId),
-        eq(releaseTaskSnapshots.catalogSlug, slug)
-      )
-    )
-    .limit(1);
-  if (existingSnapshot) return getReleaseTasks(releaseId);
-
   const [row] = await db
     .select({
       slug: releaseTaskCatalog.slug,
@@ -379,63 +367,88 @@ export async function addCatalogTaskToRelease(releaseId: string, slug: string) {
   const position = (positionRow?.maxPosition ?? -1) + 1;
   const releaseDate = release?.releaseDate ?? null;
 
-  await db.transaction(async tx => {
-    const [counterRow] = await tx
-      .update(creatorProfiles)
-      .set({
-        nextTaskNumber: drizzleSql`${creatorProfiles.nextTaskNumber} + 1`,
-        updatedAt: new Date(),
-      })
-      .where(eq(creatorProfiles.id, profileId))
-      .returning({ nextTaskNumber: creatorProfiles.nextTaskNumber });
-    const taskNumber = (counterRow?.nextTaskNumber ?? 1) - 1;
+  try {
+    await db.transaction(async tx => {
+      // Re-check inside the transaction to close the read-before-write race.
+      // Defense-in-depth on top of the UNIQUE(release_id, catalog_slug) index.
+      const [existingSnapshot] = await tx
+        .select({ id: releaseTaskSnapshots.id })
+        .from(releaseTaskSnapshots)
+        .where(
+          and(
+            eq(releaseTaskSnapshots.releaseId, releaseId),
+            eq(releaseTaskSnapshots.catalogSlug, slug)
+          )
+        )
+        .limit(1);
+      if (existingSnapshot) return;
 
-    await tx.insert(tasks).values({
-      taskNumber,
-      creatorProfileId: profileId,
-      title: row.name,
-      description: row.shortDescription ?? null,
-      status: 'todo' as const,
-      priority: row.priority,
-      assigneeKind:
-        row.assigneeType === 'ai_workflow'
-          ? ('jovie' as const)
-          : ('human' as const),
-      agentType: row.aiSkillId ?? null,
-      agentStatus: 'idle' as const,
-      releaseId,
-      category: row.category,
-      dueAt:
-        releaseDate === null || row.flowStageDaysOffset === null
-          ? null
-          : computeDueDate(releaseDate, row.flowStageDaysOffset),
-      position,
-      sourceTemplateId: null,
-      metadata: {
-        dueDaysOffset: row.flowStageDaysOffset,
+      const [counterRow] = await tx
+        .update(creatorProfiles)
+        .set({
+          nextTaskNumber: drizzleSql`${creatorProfiles.nextTaskNumber} + 1`,
+          updatedAt: new Date(),
+        })
+        .where(eq(creatorProfiles.id, profileId))
+        .returning({ nextTaskNumber: creatorProfiles.nextTaskNumber });
+      const taskNumber = (counterRow?.nextTaskNumber ?? 1) - 1;
+
+      await tx.insert(tasks).values({
+        taskNumber,
+        creatorProfileId: profileId,
+        title: row.name,
+        description: row.shortDescription ?? null,
+        status: 'todo' as const,
+        priority: row.priority,
+        assigneeKind:
+          row.assigneeType === 'ai_workflow'
+            ? ('jovie' as const)
+            : ('human' as const),
+        agentType: row.aiSkillId ?? null,
+        agentStatus: 'idle' as const,
+        releaseId,
+        category: row.category,
+        dueAt:
+          releaseDate === null || row.flowStageDaysOffset === null
+            ? null
+            : computeDueDate(releaseDate, row.flowStageDaysOffset),
+        position,
+        sourceTemplateId: null,
+        metadata: {
+          dueDaysOffset: row.flowStageDaysOffset,
+          catalogSlug: row.slug,
+          catalogVersion: row.catalogVersion,
+          selectionScore: null,
+          selectionReasons: ['manual_add'],
+        },
+      });
+      await tx.insert(releaseTaskSnapshots).values({
+        releaseId,
         catalogSlug: row.slug,
         catalogVersion: row.catalogVersion,
-        selectionScore: null,
-        selectionReasons: ['manual_add'],
-      },
+        name: row.name,
+        category: row.category,
+        clusterId: row.clusterId,
+        shortDescription: row.shortDescription,
+        priority: row.priority,
+        flowStageDaysOffset: row.flowStageDaysOffset,
+        assigneeType: row.assigneeType,
+        aiSkillId: row.aiSkillId,
+        aiSkillStatus: row.aiSkillStatus,
+        reasons: ['manual_add'],
+        score: null,
+      });
     });
-    await tx.insert(releaseTaskSnapshots).values({
-      releaseId,
-      catalogSlug: row.slug,
-      catalogVersion: row.catalogVersion,
-      name: row.name,
-      category: row.category,
-      clusterId: row.clusterId,
-      shortDescription: row.shortDescription,
-      priority: row.priority,
-      flowStageDaysOffset: row.flowStageDaysOffset,
-      assigneeType: row.assigneeType,
-      aiSkillId: row.aiSkillId,
-      aiSkillStatus: row.aiSkillStatus,
-      reasons: ['manual_add'],
-      score: null,
-    });
-  });
+  } catch (error) {
+    // A concurrent add that lost the race trips the UNIQUE(release_id,
+    // catalog_slug) constraint. Treat that as success and fall through to
+    // return the up-to-date task list.
+    const message = error instanceof Error ? error.message : String(error);
+    const isUniqueViolation =
+      message.includes('release_task_snapshots_release_catalog_slug_unique') ||
+      message.includes('23505');
+    if (!isUniqueViolation) throw error;
+  }
 
   revalidatePath(APP_ROUTES.DASHBOARD_RELEASES);
   revalidatePath(APP_ROUTES.TASKS);

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskChecklist.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskChecklist.tsx
@@ -3,6 +3,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { motion } from 'motion/react';
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { queryKeys } from '@/lib/queries';
 import {
   useReleaseSkillClustersQuery,
   useReleaseTaskCatalogQuery,
@@ -289,7 +290,7 @@ export function ReleaseTaskChecklist({
             onClose={() => setCatalogDialogOpen(false)}
             onAdded={() =>
               queryClient.invalidateQueries({
-                queryKey: ['release-tasks', releaseId],
+                queryKey: queryKeys.releaseTasks.byRelease(releaseId),
               })
             }
           />


### PR DESCRIPTION
## Summary

Two real correctness fixes from the Greptile / Sentry / CodeRabbit reviews on merged PR #7548. Most of the reviewer feedback was already addressed in the final merged code (unique constraint, counter inside tx, computeDueDate reuse, ORDER BY, captureError, aria-label, wizard double-submit guard, optimistic addedSlugs). These are the two remaining issues.

### 1. Wrong queryKey in `ReleaseTaskChecklist` onAdded invalidation

\`onAdded\` passed \`['release-tasks', releaseId]\` to \`invalidateQueries\`, but \`useReleaseTasksQuery\` stores at \`queryKeys.releaseTasks.byRelease(releaseId)\` = \`['release-tasks', 'release', releaseId]\`. Since the invalidation key was not a prefix of the real key, the cache never invalidated — adding a catalog task left the list stale until a full page reload.

Fix: use \`queryKeys.releaseTasks.byRelease(releaseId)\`.

### 2. Snapshot existence check outside the transaction in \`addCatalogTaskToRelease\`

Two concurrent "Add from catalog" clicks for the same slug could both pass the pre-tx existence check and both try to insert. The \`UNIQUE(release_id, catalog_slug)\` index already prevents duplicates, but the second call threw an unhandled error.

Fix:
- Moved the existence check inside the transaction (defense-in-depth)
- Wrapped the transaction in try/catch that swallows the unique-violation error and falls through to return the up-to-date task list
- Race-losing calls now return the current state instead of surfacing a 500

## Test plan

- [x] Typecheck clean
- [x] 69 release-tasks unit tests pass
- [ ] CI: full unit + E2E
- [ ] Smoke: create a release, complete wizard, open Add from Catalog, click Add on a row → row disables to "Added", task appears in list without reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)