### PR TITLE
fix(perf): fail loudly in performance-budgets-guard waitForAnyVisible

### DIFF
--- a/apps/web/scripts/performance-budgets-guard.ts
+++ b/apps/web/scripts/performance-budgets-guard.ts
@@ -982,9 +982,14 @@ async function measureRouteSample(
         );
         timingValues['interactive-shell-ready'] = Date.now() - startedAt;
       } else if (route.readySelectors.content?.length) {
-        await waitForAnyVisible(page, route.readySelectors.content).catch(
-          () => undefined
-        );
+        try {
+          await waitForAnyVisible(page, route.readySelectors.content);
+        } catch (error) {
+          const reason = error instanceof Error ? error.message : String(error);
+          throw new Error(
+            `Route ${route.id} content selectors never became visible at ${page.url()} (expected ${resolvedPath}). Selectors: ${route.readySelectors.content.join(', ')}. Underlying: ${reason}`
+          );
+        }
       }
 
       if (hasTimingBudget(route, 'skeleton-to-content')) {


### PR DESCRIPTION
Linear: [JOV-1705](https://linear.app/jovie/issue/JOV-1705)

## Why

Inside `measureRouteSample`, the `else if (route.readySelectors.content?.length)` branch called `waitForAnyVisible(...).catch(() => undefined)`. If the route silently redirected to sign-in/onboarding or failed to render, the timeout was swallowed and the guard happily recorded a measurement for the wrong page — producing misleading perf numbers instead of a real failure.

## What changed

- Replace the silent `.catch(() => undefined)` with a `try/catch` that rethrows an error tagged with the route id, current URL, expected resolved path, the selectors it was waiting for, and the underlying message.
- The thrown error propagates up to the sample loop in `runGuard`, aborting that sample loudly rather than poisoning the dataset. Warmup paths (lines ~904/916) are intentionally left alone — they are best-effort primers, not measurements.

Script-only change, no UI impact.

## Verification

- `pnpm --filter web typecheck` passes
- `biome check` on the changed file passes
- pre-commit hooks (biome + eslint + turbo typecheck) green

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>