### PR TITLE
fix: resolve SonarCloud S7750 in url-intake

### DIFF
--- a/apps/web/lib/leads/url-intake.ts
+++ b/apps/web/lib/leads/url-intake.ts
@@ -88,7 +88,7 @@ function normalizeUrl(rawUrl: string): string | null {
 function deriveHandleFromUrl(url: string): string | null {
   try {
     const parsed = new URL(url);
-    const pathSegment = parsed.pathname.split('/').filter(Boolean).pop();
+    const pathSegment = parsed.pathname.split('/').findLast(Boolean);
     const fallback = `${parsed.hostname}-${pathSegment ?? 'profile'}`;
     const normalized = fallback
       .toLowerCase()


### PR DESCRIPTION
## Summary
Prefer `Array#findLast(Boolean)` over `.filter(Boolean).pop()` in `deriveHandleFromUrl` (L91).

No behavior change — both return the last truthy element.

## Test plan
- [x] biome check passes
- [x] typecheck passes (husky)
- [x] eslint passes (husky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)