### PR TITLE
fix: resolve SonarCloud S7763 in staging-clerk-keys

### DIFF
--- a/apps/web/lib/auth/staging-clerk-keys.ts
+++ b/apps/web/lib/auth/staging-clerk-keys.ts
@@ -1,10 +1,7 @@
 import { headers } from 'next/headers';
 import { getRequestLocationFromHeaders } from '@/components/providers/clerkAvailability';
 import { STAGING_HOSTNAMES } from '@/constants/domains';
-import {
-  CLERK_KEY_STATUS_HEADER,
-  type ClerkKeyStatus,
-} from '@/lib/auth/clerk-key-status';
+import type { ClerkKeyStatus } from '@/lib/auth/clerk-key-status';
 import { publicEnv } from '@/lib/env-public';
 
 /**
@@ -104,7 +101,7 @@ export function resolveClerkKeys(hostname: string): ClerkKeys {
   };
 }
 
-export { CLERK_KEY_STATUS_HEADER };
+export { CLERK_KEY_STATUS_HEADER } from '@/lib/auth/clerk-key-status';
 
 /**
  * Resolve the publishable key for dynamic server component layouts.


### PR DESCRIPTION
## Summary
Use \`export…from\` to re-export \`CLERK_KEY_STATUS_HEADER\` instead of import-then-re-export.

## Test plan
- [x] biome check passes
- [x] typecheck passes (husky)
- [x] eslint passes (husky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->