### PR TITLE
fix(billing): repair cancelScheduledPlanChange in plan-change (JOV-1670)

### DIFF
--- a/apps/web/lib/stripe/plan-change.ts
+++ b/apps/web/lib/stripe/plan-change.ts
@@ -401,11 +401,80 @@ export async function executePlanChange(
       shouldProrate,
     });
 
-    // For both upgrades and downgrades, use subscription update
-    // Stripe handles proration automatically
-    const updatedSubscription = await stripe.subscriptions.update(
-      subscriptionId,
-      {
+    const periodEndMs = subscription.current_period_end * 1000;
+    const effectiveDate = isScheduledChange
+      ? new Date(periodEndMs)
+      : new Date();
+
+    let updatedSubscription: Stripe.Subscription;
+
+    if (isScheduledChange) {
+      // For downgrades (plan-tier or interval), use a subscription schedule
+      // so the change applies at period end AND is cancellable via
+      // cancelScheduledPlanChange(). Direct subscription.update would take
+      // effect immediately and leave nothing for us to cancel.
+
+      // Create a schedule from the existing subscription if one doesn't
+      // already exist. Stripe's `from_subscription` seeds phase[0] from the
+      // current subscription; we append a new phase with the target price.
+      let scheduleId: string;
+      if (subscription.schedule) {
+        scheduleId =
+          typeof subscription.schedule === 'string'
+            ? subscription.schedule
+            : subscription.schedule.id;
+      } else {
+        const created = await stripe.subscriptionSchedules.create({
+          from_subscription: subscriptionId,
+        });
+        scheduleId = created.id;
+      }
+
+      // Re-read the schedule to get the seeded current phase, then append
+      // the downgrade phase. We copy the current phase's items verbatim so
+      // the user finishes their paid period on the current plan, and only
+      // flip to the new price in the next phase.
+      const schedule = await stripe.subscriptionSchedules.retrieve(scheduleId);
+      const currentPhase = schedule.phases[0];
+      if (!currentPhase) {
+        return {
+          success: false,
+          error: 'Schedule has no current phase',
+          isScheduledChange: false,
+          effectiveDate: new Date(),
+        };
+      }
+
+      await stripe.subscriptionSchedules.update(scheduleId, {
+        end_behavior: 'release',
+        phases: [
+          {
+            items: currentPhase.items.map(item => ({
+              price:
+                typeof item.price === 'string' ? item.price : item.price.id,
+              quantity: item.quantity,
+            })),
+            start_date: currentPhase.start_date,
+            end_date: currentPhase.end_date,
+            proration_behavior: 'none',
+          },
+          {
+            items: [{ price: newPriceId, quantity: 1 }],
+            proration_behavior: shouldProrate ? 'create_prorations' : 'none',
+          },
+        ],
+        metadata: {
+          previous_plan: currentPriceDetails.plan,
+          target_plan: newPriceDetails.plan,
+          scheduled_at: new Date().toISOString(),
+        },
+      });
+
+      // Return the underlying subscription (still on the current plan).
+      updatedSubscription = await stripe.subscriptions.retrieve(subscriptionId);
+    } else {
+      // Immediate change (upgrade). Stripe handles proration automatically.
+      updatedSubscription = await stripe.subscriptions.update(subscriptionId, {
         items: [
           {
             id: currentItem.id,
@@ -418,14 +487,8 @@ export async function executePlanChange(
           previous_plan: currentPriceDetails.plan,
           changed_at: new Date().toISOString(),
         },
-      }
-    );
-
-    // Calculate effective date
-    const periodEndMs = subscription.current_period_end * 1000;
-    const effectiveDate = isScheduledChange
-      ? new Date(periodEndMs)
-      : new Date();
+      });
+    }
 
     logger.info('Plan change executed successfully', {
       subscriptionId,
@@ -482,7 +545,22 @@ export async function cancelScheduledPlanChange(
         ? subscription.schedule
         : subscription.schedule.id;
 
-    await stripe.subscriptionSchedules.cancel(scheduleId);
+    // Idempotency: if the schedule is already released/canceled, treat this
+    // call as a no-op success. Prevents errors on double-clicks and retries.
+    const schedule = await stripe.subscriptionSchedules.retrieve(scheduleId);
+    if (schedule.status === 'released' || schedule.status === 'canceled') {
+      logger.info('Scheduled plan change already cleared', {
+        subscriptionId,
+        scheduleId,
+        status: schedule.status,
+      });
+      return { success: true };
+    }
+
+    // Release (not cancel): detaches the schedule from the subscription and
+    // leaves the subscription running on its current plan. `cancel` would
+    // end the subscription, which is not what "cancel downgrade" means.
+    await stripe.subscriptionSchedules.release(scheduleId);
 
     logger.info('Cancelled scheduled plan change', { subscriptionId });
 

--- a/apps/web/tests/unit/lib/stripe/plan-change.critical.test.ts
+++ b/apps/web/tests/unit/lib/stripe/plan-change.critical.test.ts
@@ -29,6 +29,10 @@ const {
   mockStripeSubscriptionSchedules: {
     list: vi.fn(),
     cancel: vi.fn(),
+    release: vi.fn(),
+    create: vi.fn(),
+    retrieve: vi.fn(),
+    update: vi.fn(),
   },
   mockCaptureError: vi.fn(),
   mockGetActivePriceIds: vi.fn(),
@@ -398,14 +402,27 @@ describe('@critical plan-change.ts', () => {
       );
     });
 
-    it('executes a downgrade as a scheduled change', async () => {
+    it('executes a downgrade as a scheduled change via subscription schedule', async () => {
       const sub = makeSubscription({
         items: {
           data: [{ id: 'si_item_1', price: { id: PRICE_MAX_MONTHLY } }],
         },
       });
       mockStripeSubscriptions.retrieve.mockResolvedValue(sub);
-      mockStripeSubscriptions.update.mockResolvedValue(sub);
+      mockStripeSubscriptionSchedules.create.mockResolvedValue({
+        id: 'sub_sched_new',
+      });
+      mockStripeSubscriptionSchedules.retrieve.mockResolvedValue({
+        id: 'sub_sched_new',
+        phases: [
+          {
+            items: [{ price: PRICE_MAX_MONTHLY, quantity: 1 }],
+            start_date: sub.current_period_start,
+            end_date: sub.current_period_end,
+          },
+        ],
+      });
+      mockStripeSubscriptionSchedules.update.mockResolvedValue({});
 
       const result = await executePlanChange({
         subscriptionId: 'sub_123',
@@ -415,11 +432,58 @@ describe('@critical plan-change.ts', () => {
       expect(result.success).toBe(true);
       // max -> pro is a downgrade, should be scheduled
       expect(result.isScheduledChange).toBe(true);
-      expect(mockStripeSubscriptions.update).toHaveBeenCalledWith(
-        'sub_123',
+      // Must NOT call subscriptions.update (that would apply immediately)
+      expect(mockStripeSubscriptions.update).not.toHaveBeenCalled();
+      // Schedule should be created from the existing subscription
+      expect(mockStripeSubscriptionSchedules.create).toHaveBeenCalledWith({
+        from_subscription: 'sub_123',
+      });
+      // Schedule should be updated with a second phase targeting the new price
+      expect(mockStripeSubscriptionSchedules.update).toHaveBeenCalledWith(
+        'sub_sched_new',
         expect.objectContaining({
-          proration_behavior: 'none',
+          end_behavior: 'release',
+          phases: expect.arrayContaining([
+            expect.objectContaining({
+              items: expect.arrayContaining([
+                expect.objectContaining({ price: PRICE_PRO_MONTHLY }),
+              ]),
+            }),
+          ]),
         })
+      );
+    });
+
+    it('reuses an existing subscription schedule when one already exists', async () => {
+      const sub = makeSubscription({
+        items: {
+          data: [{ id: 'si_item_1', price: { id: PRICE_MAX_MONTHLY } }],
+        },
+        schedule: 'sub_sched_existing',
+      });
+      mockStripeSubscriptions.retrieve.mockResolvedValue(sub);
+      mockStripeSubscriptionSchedules.retrieve.mockResolvedValue({
+        id: 'sub_sched_existing',
+        phases: [
+          {
+            items: [{ price: PRICE_MAX_MONTHLY, quantity: 1 }],
+            start_date: sub.current_period_start,
+            end_date: sub.current_period_end,
+          },
+        ],
+      });
+      mockStripeSubscriptionSchedules.update.mockResolvedValue({});
+
+      const result = await executePlanChange({
+        subscriptionId: 'sub_123',
+        newPriceId: PRICE_PRO_MONTHLY,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockStripeSubscriptionSchedules.create).not.toHaveBeenCalled();
+      expect(mockStripeSubscriptionSchedules.update).toHaveBeenCalledWith(
+        'sub_sched_existing',
+        expect.any(Object)
       );
     });
 
@@ -430,7 +494,20 @@ describe('@critical plan-change.ts', () => {
         },
       });
       mockStripeSubscriptions.retrieve.mockResolvedValue(sub);
-      mockStripeSubscriptions.update.mockResolvedValue(sub);
+      mockStripeSubscriptionSchedules.create.mockResolvedValue({
+        id: 'sub_sched_iv',
+      });
+      mockStripeSubscriptionSchedules.retrieve.mockResolvedValue({
+        id: 'sub_sched_iv',
+        phases: [
+          {
+            items: [{ price: PRICE_PRO_YEARLY, quantity: 1 }],
+            start_date: sub.current_period_start,
+            end_date: sub.current_period_end,
+          },
+        ],
+      });
+      mockStripeSubscriptionSchedules.update.mockResolvedValue({});
 
       const result = await executePlanChange({
         subscriptionId: 'sub_123',
@@ -439,6 +516,7 @@ describe('@critical plan-change.ts', () => {
 
       expect(result.success).toBe(true);
       expect(result.isScheduledChange).toBe(true);
+      expect(mockStripeSubscriptionSchedules.update).toHaveBeenCalled();
     });
 
     it('returns error for invalid price ID', async () => {
@@ -502,7 +580,20 @@ describe('@critical plan-change.ts', () => {
         },
       });
       mockStripeSubscriptions.retrieve.mockResolvedValue(sub);
-      mockStripeSubscriptions.update.mockResolvedValue(sub);
+      mockStripeSubscriptionSchedules.create.mockResolvedValue({
+        id: 'sub_sched_p',
+      });
+      mockStripeSubscriptionSchedules.retrieve.mockResolvedValue({
+        id: 'sub_sched_p',
+        phases: [
+          {
+            items: [{ price: PRICE_MAX_MONTHLY, quantity: 1 }],
+            start_date: sub.current_period_start,
+            end_date: sub.current_period_end,
+          },
+        ],
+      });
+      mockStripeSubscriptionSchedules.update.mockResolvedValue({});
 
       await executePlanChange({
         subscriptionId: 'sub_123',
@@ -510,11 +601,13 @@ describe('@critical plan-change.ts', () => {
         prorate: true,
       });
 
-      expect(mockStripeSubscriptions.update).toHaveBeenCalledWith(
-        'sub_123',
-        expect.objectContaining({
-          proration_behavior: 'create_prorations',
-        })
+      // For scheduled downgrades, proration lives on the future phase.
+      const call = mockStripeSubscriptionSchedules.update.mock.calls[0];
+      const updatePayload = call[1] as {
+        phases: Array<{ proration_behavior?: string }>;
+      };
+      expect(updatePayload.phases[1].proration_behavior).toBe(
+        'create_prorations'
       );
     });
 
@@ -544,32 +637,40 @@ describe('@critical plan-change.ts', () => {
   // cancelScheduledPlanChange
   // -------------------------------------------------------
   describe('cancelScheduledPlanChange()', () => {
-    it('cancels a pending subscription schedule (string ID)', async () => {
+    it('releases a pending subscription schedule (string ID)', async () => {
       mockStripeSubscriptions.retrieve.mockResolvedValue({
         id: 'sub_123',
         schedule: 'sub_sched_abc',
       });
-      mockStripeSubscriptionSchedules.cancel.mockResolvedValue({});
+      mockStripeSubscriptionSchedules.retrieve.mockResolvedValue({
+        id: 'sub_sched_abc',
+        status: 'active',
+      });
+      mockStripeSubscriptionSchedules.release.mockResolvedValue({});
 
       const result = await cancelScheduledPlanChange('sub_123');
 
       expect(result.success).toBe(true);
-      expect(mockStripeSubscriptionSchedules.cancel).toHaveBeenCalledWith(
+      expect(mockStripeSubscriptionSchedules.release).toHaveBeenCalledWith(
         'sub_sched_abc'
       );
     });
 
-    it('cancels a pending subscription schedule (expanded object)', async () => {
+    it('releases a pending subscription schedule (expanded object)', async () => {
       mockStripeSubscriptions.retrieve.mockResolvedValue({
         id: 'sub_123',
         schedule: { id: 'sub_sched_expanded' },
       });
-      mockStripeSubscriptionSchedules.cancel.mockResolvedValue({});
+      mockStripeSubscriptionSchedules.retrieve.mockResolvedValue({
+        id: 'sub_sched_expanded',
+        status: 'active',
+      });
+      mockStripeSubscriptionSchedules.release.mockResolvedValue({});
 
       const result = await cancelScheduledPlanChange('sub_123');
 
       expect(result.success).toBe(true);
-      expect(mockStripeSubscriptionSchedules.cancel).toHaveBeenCalledWith(
+      expect(mockStripeSubscriptionSchedules.release).toHaveBeenCalledWith(
         'sub_sched_expanded'
       );
     });
@@ -584,7 +685,39 @@ describe('@critical plan-change.ts', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('No scheduled change to cancel');
-      expect(mockStripeSubscriptionSchedules.cancel).not.toHaveBeenCalled();
+      expect(mockStripeSubscriptionSchedules.release).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent when the schedule has already been released', async () => {
+      mockStripeSubscriptions.retrieve.mockResolvedValue({
+        id: 'sub_123',
+        schedule: 'sub_sched_abc',
+      });
+      mockStripeSubscriptionSchedules.retrieve.mockResolvedValue({
+        id: 'sub_sched_abc',
+        status: 'released',
+      });
+
+      const result = await cancelScheduledPlanChange('sub_123');
+
+      expect(result.success).toBe(true);
+      expect(mockStripeSubscriptionSchedules.release).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent when the schedule has already been canceled', async () => {
+      mockStripeSubscriptions.retrieve.mockResolvedValue({
+        id: 'sub_123',
+        schedule: 'sub_sched_abc',
+      });
+      mockStripeSubscriptionSchedules.retrieve.mockResolvedValue({
+        id: 'sub_sched_abc',
+        status: 'canceled',
+      });
+
+      const result = await cancelScheduledPlanChange('sub_123');
+
+      expect(result.success).toBe(true);
+      expect(mockStripeSubscriptionSchedules.release).not.toHaveBeenCalled();
     });
 
     it('captures error and returns failure on Stripe API error', async () => {


### PR DESCRIPTION
## Summary

Fixes [JOV-1670](https://linear.app/jovie/issue/JOV-1670). `cancelScheduledPlanChange()` was a no-op because `executePlanChange()` never created a Stripe subscription schedule — it used `stripe.subscriptions.update()` directly, so `subscription.schedule` was always null and DELETE `/api/stripe/plan-change` always returned `{ success: false, error: 'No scheduled change to cancel' }`.

## Option chosen: A (subscription schedules)

Two options in the issue:

- **A (chosen)**: create an explicit Stripe subscription schedule for downgrades. Makes `cancelScheduledPlanChange()` work as designed.
- **B**: track pending downgrade in our own DB/metadata and rewrite `cancelScheduledPlanChange()` to clear that state.

**Why A:** it matches existing code. `cancelScheduledPlanChange` already reads `subscription.schedule`, and `GET /api/stripe/plan-change` already computes `hasScheduledChange = !!subscription?.schedule`. Option B would require a new DB/metadata store and rewiring both call sites. Option A is the smaller diff and keeps Stripe as the source of truth for scheduled changes.

## Before / after

**Before**
- Downgrade → `subscriptions.update` flips the price immediately (not what "effective at period end" copy implies).
- Cancel downgrade → always `{ success: false, error: 'No scheduled change to cancel' }`.
- If anything had set a schedule, `cancelScheduledPlanChange` called `subscriptionSchedules.cancel`, which actually **cancels the subscription**, not the pending change.

**After**
- Downgrade (tier or yearly→monthly interval) → `executePlanChange` creates a `subscriptionSchedule` from the existing subscription, seeds phase 0 with the current plan through `current_period_end`, and appends phase 1 with the new price. `end_behavior: 'release'`.
- Cancel downgrade → `cancelScheduledPlanChange` calls `subscriptionSchedules.release` (reverts to current plan, keeps subscription alive). Idempotent when the schedule is already `released` or `canceled`.
- Upgrades are unchanged (immediate `subscriptions.update` with proration).

## Test plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web exec vitest run tests/unit/lib/stripe/plan-change.critical.test.ts tests/unit/api/stripe/plan-change.test.ts` — 49 passed

### New / updated test cases (`plan-change.critical.test.ts`)

- `executes a downgrade as a scheduled change via subscription schedule`
- `reuses an existing subscription schedule when one already exists`
- `treats yearly-to-monthly same-plan as a scheduled (interval downgrade) change`
- `respects explicit prorate=true override on downgrade`
- `releases a pending subscription schedule (string ID)`
- `releases a pending subscription schedule (expanded object)`
- `returns error when no schedule exists`
- `is idempotent when the schedule has already been released`
- `is idempotent when the schedule has already been canceled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)