### PR TITLE
fix(auth): include /api/chat in Clerk middleware matcher (JOV-1795)

### DIFF
--- a/apps/web/lib/auth/clerk-middleware-bypass.ts
+++ b/apps/web/lib/auth/clerk-middleware-bypass.ts
@@ -39,6 +39,7 @@ const AUTHENTICATED_API_PREFIXES = [
   '/api/referrals',
   '/api/stripe',
   '/api/suggestions',
+  '/api/waitlist',
 ] as const;
 
 const PUBLIC_API_EXACT_PATHS = [
@@ -48,7 +49,16 @@ const PUBLIC_API_EXACT_PATHS = [
 
 const PUBLIC_API_PREFIXES = ['/api/dev/test-auth/'] as const;
 
-function isClerkRequiredPath(pathname: string, pathInfo: ClerkBypassPathInfo) {
+/**
+ * Public — returns true when the path absolutely requires Clerk middleware to
+ * have populated request context before route handlers run. Used both for the
+ * per-request bypass decision AND for the cold-start "Clerk config missing"
+ * fallback in proxy.ts, so those two code paths can't diverge.
+ */
+export function isClerkRequiredPath(
+  pathname: string,
+  pathInfo: ClerkBypassPathInfo
+) {
   if (
     pathInfo.isProtectedPath ||
     pathInfo.isAuthPath ||

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -21,6 +21,7 @@ import { APP_ROUTES } from '@/constants/routes';
 import { buildProtectedAuthRedirectUrl } from '@/lib/auth/build-auth-route-url';
 import {
   type ClerkBypassPathInfo,
+  isClerkRequiredPath,
   shouldBypassClerkForRequest,
 } from '@/lib/auth/clerk-middleware-bypass';
 import { sanitizeRedirectUrl } from '@/lib/auth/constants';
@@ -1182,8 +1183,11 @@ export default async function middleware(
   // This can happen during Vercel cold starts when env vars are temporarily unavailable
   if (clerkConfigMissing) {
     // For public routes (non-protected), proceed without auth
-    // This allows the homepage, marketing pages, and public profiles to load
-    if (!pathInfo.isProtectedPath) {
+    // This allows the homepage, marketing pages, and public profiles to load.
+    // Authenticated API routes (e.g. /api/chat) must NOT fall through here —
+    // their route handlers call auth() and would throw "Clerk can't detect
+    // usage of clerkMiddleware()" (JOV-1795) if Clerk context wasn't set up.
+    if (!pathInfo.isProtectedPath && !isClerkRequiredPath(pathname, pathInfo)) {
       return handleRequest(req, null);
     }
 
@@ -1236,7 +1240,7 @@ export default async function middleware(
     : clerkProductionMiddleware;
 
   if (!selectedMiddleware) {
-    if (!pathInfo.isProtectedPath) {
+    if (!pathInfo.isProtectedPath && !isClerkRequiredPath(pathname, pathInfo)) {
       return handleRequest(req, null);
     }
 


### PR DESCRIPTION
## Summary

Closes Sentry JOVIE-WEB-G9 (`Clerk: auth() was called but Clerk can't detect usage of clerkMiddleware()` — 14 events / 13 users on `POST /api/chat`).

Root cause: during Vercel cold starts, Clerk's publishable/secret keys are briefly unavailable. `proxy.ts` treated authenticated API routes as "public" in that window — using only `pathInfo.isProtectedPath` (which covers app-shell + account / billing / onboarding / waitlist page routes, not `/api/*`). Requests to `/api/chat` fell through to `handleRequest(req, null)` without Clerk middleware, and then the route handler's `auth()` threw.

## Changes

- Export `isClerkRequiredPath` from `clerk-middleware-bypass.ts` and reuse it in both proxy.ts cold-start fallbacks (missing config + null staging middleware) so the "Clerk required" decision lives in exactly one place.
- Add `/api/waitlist` to `AUTHENTICATED_API_PREFIXES` — its route handler uses `getCachedAuth` + `currentUser`, both of which require Clerk context. Same latent bug class as `/api/chat`.

The `/__clerk` FAPI proxy path is untouched (per CLAUDE.md).

## Test plan

- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint` (no new errors/warnings)
- [x] `pnpm exec vitest run tests/unit/middleware/` — 44/44 passing
- [ ] Sentry: JOVIE-WEB-G9 event count flatlines post-deploy