### PR TITLE
fix(admin): guard /app/admin/screenshots against catalog load errors

### DIFF
--- a/apps/web/app/app/(shell)/admin/screenshots/page.tsx
+++ b/apps/web/app/app/(shell)/admin/screenshots/page.tsx
@@ -3,8 +3,10 @@ import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
+import { APP_ROUTES } from '@/constants/routes';
 import { getScreenshots } from '@/lib/admin/screenshots';
 import { CANONICAL_SURFACES } from '@/lib/canonical-surfaces';
+import { captureError } from '@/lib/error-tracking';
 
 const SKELETON_KEYS = Array.from({ length: 8 }, (_, i) => `ss-skel-${i}`);
 
@@ -38,16 +40,31 @@ export const metadata: Metadata = {
 export const runtime = 'nodejs';
 
 export default async function AdminScreenshotsPage() {
-  const screenshots = await getScreenshots();
+  let screenshots: Awaited<ReturnType<typeof getScreenshots>> = [];
+  let catalogError: string | undefined;
+  try {
+    screenshots = await getScreenshots();
+  } catch (err) {
+    catalogError =
+      err instanceof Error ? err.message : 'Unknown error loading catalog';
+    captureError('Admin screenshots page failed to load catalog', err, {
+      route: APP_ROUTES.ADMIN_SCREENSHOTS,
+    });
+  }
+
   const canonicalCaptureCount = screenshots.filter(
     screenshot => screenshot.canonicalSurfaceId !== undefined
   ).length;
   const supportingCaptureCount = screenshots.length - canonicalCaptureCount;
 
+  const description = catalogError
+    ? `Screenshot catalog is unavailable in this environment (${catalogError}). Check the deploy logs and ensure the catalog directory is bundled.`
+    : `Review ${CANONICAL_SURFACES.length} canonical surfaces across ${canonicalCaptureCount} canonical captures, plus ${supportingCaptureCount} supporting captures from the latest screenshot catalog.`;
+
   return (
     <AdminToolPage
       title='Screenshots'
-      description={`Review ${CANONICAL_SURFACES.length} canonical surfaces across ${canonicalCaptureCount} canonical captures, plus ${supportingCaptureCount} supporting captures from the latest screenshot catalog.`}
+      description={description}
       testId='admin-screenshots-page'
     >
       <ScreenshotGallery screenshots={screenshots} />

--- a/apps/web/app/app/(shell)/admin/screenshots/page.tsx
+++ b/apps/web/app/app/(shell)/admin/screenshots/page.tsx
@@ -47,7 +47,7 @@ export default async function AdminScreenshotsPage() {
   } catch (err) {
     catalogError =
       err instanceof Error ? err.message : 'Unknown error loading catalog';
-    captureError('Admin screenshots page failed to load catalog', err, {
+    await captureError('Admin screenshots page failed to load catalog', err, {
       route: APP_ROUTES.ADMIN_SCREENSHOTS,
     });
   }
@@ -58,7 +58,7 @@ export default async function AdminScreenshotsPage() {
   const supportingCaptureCount = screenshots.length - canonicalCaptureCount;
 
   const description = catalogError
-    ? `Screenshot catalog is unavailable in this environment (${catalogError}). Check the deploy logs and ensure the catalog directory is bundled.`
+    ? 'Screenshot catalog is unavailable in this environment. Check the deploy logs and ensure the catalog directory is bundled.'
     : `Review ${CANONICAL_SURFACES.length} canonical surfaces across ${canonicalCaptureCount} canonical captures, plus ${supportingCaptureCount} supporting captures from the latest screenshot catalog.`;
 
   return (


### PR DESCRIPTION
## Summary

Closes JOV-1374 (Sentry JOVIE-WEB-DP: `error: server conn crashed?` — 3 events / 3 users in last 14d on `GET /app/admin/screenshots`).

Wraps `getScreenshots()` in a try/catch so a catalog load failure no longer crashes the RSC stream before the admin `error.tsx` boundary can render. Reports the failure via `captureError` with route context and shows a graceful description explaining the catalog is unavailable.

## Likely root cause

The screenshot catalog reads `apps/web/screenshot-catalog/current/manifest.json` and `stat`s PNG assets via `resolveMonorepoPath`. On Vercel, `MONOREPO_ROOT` can resolve incorrectly (fallback path may not contain `turbo.json`) and the catalog directory may not be bundled. Non-ENOENT errors bubble up uncaught.

This PR does not fix that root cause — it stops the crash, adds diagnostic context, and renders a helpful description. Follow-up can harden `resolveMonorepoPath` once Sentry shows the exact path failing.

## Test plan

- [x] Typecheck passes
- [x] Lint passes
- [ ] Verify Sentry event count drops after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Admin screenshots page now shows a clear "catalog unavailable" notice when the catalog cannot be loaded.
  * When screenshots load successfully, the page continues to show the usual capture-count summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->