### PR TITLE
fix(ci): scope main concurrency per-commit so deploys don't starve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,19 @@ permissions:
   actions: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  # On main, scope the concurrency group per-commit so rapid merges cannot
+  # cancel each other's deploy pipelines. GitHub evaluates cancel-in-progress
+  # expressions as strings and treats "false" as truthy, which was cancelling
+  # every main CI run when the next merge landed and starving production
+  # promotion. Using github.sha in the group on main sidesteps the issue
+  # entirely. PRs and merge_group runs still share a group per ref so stale
+  # runs are superseded as usual.
+  group: >-
+    ci-${{ github.workflow }}-${{
+      (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        && github.sha
+        || github.ref
+    }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:


### PR DESCRIPTION
## Summary

Production hasn't shipped a new deploy in ~12 hours. The last successful `ci.yml` run on `main` was at 2026-04-22T18:56Z (#7517). Since then every single push to main has been cancelled — ~30+ consecutive cancellations — and no pipeline has reached `promote-production`.

## Root cause

`.github/workflows/ci.yml` top-level concurrency was:

```yaml
group: ci-${{ github.workflow }}-${{ github.ref }}
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

On `main`, the expression returns the string `"false"`. GitHub evaluates the `cancel-in-progress` field by parsing the expression result as a string, and any non-empty string is truthy. So the guard was silently inverted and every new push to main cancelled the in-flight run. The UI-token refactor sweep merging at ~1 merge/min meant no run ever survived long enough to run `deploy-staging` → `canary-health-gate` → `promote-production`.

## Fix

Scope the concurrency group per-SHA on main so two post-merge runs can never collide, regardless of how the expression is stringified:

```yaml
group: ci-${{ github.workflow }}-${{
  (github.event_name == 'push' && github.ref == 'refs/heads/main')
    && github.sha
    || github.ref
}}
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

PR and `merge_group` runs still share a group per ref, so stale PR runs are superseded as usual. The inner `production-deploy` concurrency (`cancel-in-progress: false`) already serializes deploys, so the worst case is a queue, not starvation.

## Test plan

- [ ] Land this PR.
- [ ] Pause merge queue temporarily while this + the next main push drain. (Can't set via API — needs admin UI.)
- [ ] Watch next post-merge run complete fully: staging deploy → canary → production promotion.
- [ ] `curl https://jov.ie/api/health` returns 200 and serves the new HEAD.
- [ ] Re-enable the merge queue. Confirm 2-3 consecutive merges each complete a full deploy without cancellation.

## Related

- #7640 (`fix(ci): avoid stale-main false positives during active newer runs`) touched the same area but only adjusted stale-main health eval — didn't address the concurrency bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)