### PR TITLE
refactor(ui): extend FilterChip prop surface + tighten keyboard tests

### DIFF
--- a/apps/web/components/molecules/filters/FilterChip.test.tsx
+++ b/apps/web/components/molecules/filters/FilterChip.test.tsx
@@ -73,4 +73,22 @@ describe('FilterChip', () => {
     );
     expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
   });
+
+  it('forwards arbitrary button attributes (disabled, tabIndex, aria-describedby)', () => {
+    render(
+      <FilterChip
+        pressed={false}
+        onClick={vi.fn()}
+        disabled
+        tabIndex={-1}
+        aria-describedby='help-text'
+      >
+        Label
+      </FilterChip>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toBeDisabled();
+    expect(btn).toHaveAttribute('tabindex', '-1');
+    expect(btn).toHaveAttribute('aria-describedby', 'help-text');
+  });
 });

--- a/apps/web/components/molecules/filters/FilterChip.test.tsx
+++ b/apps/web/components/molecules/filters/FilterChip.test.tsx
@@ -74,6 +74,16 @@ describe('FilterChip', () => {
     expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
   });
 
+  it('does not allow callers to override aria-pressed via rest props', () => {
+    const hostileProps = { 'aria-pressed': false } as Record<string, unknown>;
+    render(
+      <FilterChip pressed={true} onClick={vi.fn()} {...hostileProps}>
+        Label
+      </FilterChip>
+    );
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true');
+  });
+
   it('forwards arbitrary button attributes (disabled, tabIndex, aria-describedby)', () => {
     render(
       <FilterChip

--- a/apps/web/components/molecules/filters/FilterChip.tsx
+++ b/apps/web/components/molecules/filters/FilterChip.tsx
@@ -21,8 +21,8 @@ export function FilterChip({
     <button
       type='button'
       onClick={onClick}
-      aria-pressed={pressed}
       {...rest}
+      aria-pressed={pressed}
       className={cn(
         'rounded-full border px-2.5 py-1 text-xs transition-colors',
         pressed

--- a/apps/web/components/molecules/filters/FilterChip.tsx
+++ b/apps/web/components/molecules/filters/FilterChip.tsx
@@ -1,15 +1,13 @@
 'use client';
 
-import type { ReactNode } from 'react';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
-interface FilterChipProps {
+interface FilterChipProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'type'> {
   readonly pressed: boolean;
   readonly onClick: () => void;
   readonly children: ReactNode;
-  readonly className?: string;
-  readonly 'data-testid'?: string;
-  readonly 'aria-label'?: string;
 }
 
 export function FilterChip({
@@ -17,16 +15,14 @@ export function FilterChip({
   onClick,
   children,
   className,
-  'data-testid': testId,
-  'aria-label': ariaLabel,
+  ...rest
 }: FilterChipProps) {
   return (
     <button
       type='button'
       onClick={onClick}
       aria-pressed={pressed}
-      aria-label={ariaLabel}
-      data-testid={testId}
+      {...rest}
       className={cn(
         'rounded-full border px-2.5 py-1 text-xs transition-colors',
         pressed

--- a/apps/web/components/organisms/table/atoms/TableHeaderCell.test.tsx
+++ b/apps/web/components/organisms/table/atoms/TableHeaderCell.test.tsx
@@ -108,17 +108,14 @@ describe('TableHeaderCell', () => {
     expect(screen.getByRole('button', { name: /Col/ })).toHaveTextContent('⇅');
   });
 
-  it('activates sort via keyboard Enter (native button behavior)', () => {
-    const onSort = vi.fn();
+  it('sort button is focusable (native button, keyboard-reachable)', () => {
     renderInTable(
-      <TableHeaderCell sortable onSort={onSort}>
+      <TableHeaderCell sortable onSort={vi.fn()}>
         Col
       </TableHeaderCell>
     );
     const btn = screen.getByRole('button', { name: /Col/ });
     btn.focus();
-    // Native buttons fire click on Enter; simulate via click which jsdom uses for keyboard activation
-    fireEvent.click(btn);
-    expect(onSort).toHaveBeenCalled();
+    expect(document.activeElement).toBe(btn);
   });
 });


### PR DESCRIPTION
## Summary

Post-merge follow-up addressing Greptile P2 feedback on #7646:

- **`FilterChip` prop surface** extended to `Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' \| 'type'>` so downstream callers (PR 3 Tasks/Releases filters, PR 4b Growth pipeline bulk chips) can pass `disabled`, `tabIndex`, `aria-describedby`, etc. without churning the interface each time.
- **`TableHeaderCell.test.tsx`** — replaced the "activates sort via keyboard Enter" test, which was a copy of the click test (jsdom doesn't simulate Enter→click), with a focus-reachability assertion. Matches the pattern already used in `FilterChip.test.tsx`.
- Added `FilterChip` test covering forwarded `disabled` / `tabIndex` / `aria-describedby` so the extended interface is exercised.

## Test plan
- [x] `pnpm --filter web test` on the affected files — 27/27 pass
- [x] `pnpm --filter web typecheck` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)