### PR TITLE
fix(admin-middleware): stop reporting routine unauth hits to Sentry

### DIFF
--- a/apps/web/lib/admin/middleware.ts
+++ b/apps/web/lib/admin/middleware.ts
@@ -56,11 +56,17 @@ export async function requireAdmin(): Promise<NextResponse | null> {
     }
   }
 
-  // User not authenticated
+  // User not authenticated. This is routine traffic (unauth hits to admin
+  // routes) — not an actionable signal, so we record a breadcrumb for
+  // audit correlation but do not emit a Sentry event. The authenticated-
+  // but-not-admin case below remains a captureWarning since that IS worth
+  // surfacing.
   if (!userId) {
-    captureWarning(
-      '[admin/middleware] Unauthorized admin access attempt - no user ID'
-    );
+    Sentry.addBreadcrumb({
+      category: 'admin',
+      level: 'info',
+      message: 'admin/middleware: unauth hit (no user id)',
+    });
     return NextResponse.json(
       { error: 'Unauthorized. Please sign in.' },
       { status: 401 }


### PR DESCRIPTION
## Summary

Closes JOV-1797 (Sentry JOVIE-WEB-JT: 88 events / 18 users in 14d).

Replaces `captureWarning` with `Sentry.addBreadcrumb` in the `requireAdmin()` no-userId path. Routine unauth hits to admin handlers were generating a Sentry issue per event — not actionable. The authenticated-but-not-admin branch is left as `captureWarning` (that case IS worth surfacing).

## Test plan

- [x] Typecheck / lint pass
- [ ] Verify Sentry event count for JOVIE-WEB-JT drops to zero after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal logging and monitoring for admin authentication workflows to provide better visibility into access patterns without affecting user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->