### PR TITLE
feat(profile): reserve mode tokens + consolidate drawer header chrome

### DIFF
--- a/apps/web/components/features/profile/ProfileDrawerShell.tsx
+++ b/apps/web/components/features/profile/ProfileDrawerShell.tsx
@@ -62,21 +62,21 @@ export function ProfileDrawerShell({
           <div className='h-[5px] w-10 rounded-full bg-white/[0.22]' />
         </div>
 
-        <div className='grid grid-cols-[32px_minmax(0,1fr)_32px] items-center gap-2.5 pt-5'>
+        <div className='grid grid-cols-[44px_minmax(0,1fr)_44px] items-center gap-2.5 pt-5'>
           {showBackButton ? (
             <button
               type='button'
               onClick={onBack}
-              className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/[0.04] text-white/44 transition-colors duration-150 hover:bg-white/[0.08] hover:text-white/74 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]'
+              className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white/[0.04] text-white/44 transition-colors duration-150 hover:bg-white/[0.08] hover:text-white/74 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]'
               aria-label='Back'
               data-testid='profile-drawer-back-button'
             >
-              <ChevronLeft className='h-3.5 w-3.5' />
+              <ChevronLeft className='h-4 w-4' />
             </button>
           ) : (
             <span
               aria-hidden='true'
-              className='block h-8 w-8 shrink-0'
+              className='block h-11 w-11 shrink-0'
               data-testid='profile-drawer-back-placeholder'
             />
           )}
@@ -112,11 +112,11 @@ export function ProfileDrawerShell({
           <button
             type='button'
             onClick={() => onOpenChange(false)}
-            className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/[0.04] text-white/44 transition-colors duration-150 hover:bg-white/[0.08] hover:text-white/74 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]'
+            className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white/[0.04] text-white/44 transition-colors duration-150 hover:bg-white/[0.08] hover:text-white/74 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]'
             aria-label='Close'
             data-testid='profile-drawer-close-button'
           >
-            <X className='h-3.5 w-3.5' />
+            <X className='h-4 w-4' />
           </button>
         </div>
       </div>

--- a/apps/web/components/features/profile/ProfileDrawerShell.tsx
+++ b/apps/web/components/features/profile/ProfileDrawerShell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronLeft } from 'lucide-react';
+import { ChevronLeft, X } from 'lucide-react';
 import { useId } from 'react';
 import { Drawer } from 'vaul';
 import type { ProfileSurfacePresentation } from '@/features/profile/contracts';
@@ -109,11 +109,15 @@ export function ProfileDrawerShell({
             </div>
           </div>
 
-          <span
-            aria-hidden='true'
-            className='block h-8 w-8 shrink-0'
-            data-testid='profile-drawer-right-placeholder'
-          />
+          <button
+            type='button'
+            onClick={() => onOpenChange(false)}
+            className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/[0.04] text-white/44 transition-colors duration-150 hover:bg-white/[0.08] hover:text-white/74 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]'
+            aria-label='Close'
+            data-testid='profile-drawer-close-button'
+          >
+            <X className='h-3.5 w-3.5' />
+          </button>
         </div>
       </div>
 

--- a/apps/web/lib/onboarding/profile-mode-collisions.ts
+++ b/apps/web/lib/onboarding/profile-mode-collisions.ts
@@ -1,0 +1,29 @@
+import 'server-only';
+
+import { inArray } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { PROFILE_MODE_RESERVED_TOKENS } from '@/lib/validation/username-core';
+
+/**
+ * Detects existing creator profiles whose normalized handle collides with a
+ * public-profile mode route token (e.g. a creator named "listen" would be
+ * unreachable once /[username]/listen mounts as a mode page).
+ *
+ * Run this before shipping the route-level cutover (plan PR 3a). If this
+ * returns a non-empty list, coordinate renames with the affected creators
+ * first.
+ */
+export async function detectProfileModeHandleCollisions(): Promise<
+  ReadonlyArray<{ id: string; usernameNormalized: string }>
+> {
+  const tokens = [...PROFILE_MODE_RESERVED_TOKENS];
+  const rows = await db
+    .select({
+      id: creatorProfiles.id,
+      usernameNormalized: creatorProfiles.usernameNormalized,
+    })
+    .from(creatorProfiles)
+    .where(inArray(creatorProfiles.usernameNormalized, tokens));
+  return rows;
+}

--- a/apps/web/lib/validation/username-core.ts
+++ b/apps/web/lib/validation/username-core.ts
@@ -156,7 +156,34 @@ export const RESERVED_USERNAMES = [
   'invites',
   'referral',
   'refer',
+
+  // Public profile mode routes (app/[username]/[mode]/page.tsx).
+  // A creator whose handle matches any of these would be unreachable.
+  'subscribe',
+  'pay',
+  'tour',
+  'releases',
+  'menu',
 ] as const;
+
+/**
+ * Public profile mode tokens that become routed pages at /[username]/[mode].
+ * Must all be present in RESERVED_USERNAMES; enforced by a unit test.
+ */
+export const PROFILE_MODE_RESERVED_TOKENS = [
+  'listen',
+  'subscribe',
+  'pay',
+  'contact',
+  'about',
+  'tour',
+  'releases',
+  'share',
+  'menu',
+] as const;
+
+export type ProfileModeReservedToken =
+  (typeof PROFILE_MODE_RESERVED_TOKENS)[number];
 
 // Set for O(1) lookups
 const RESERVED_SET = new Set(RESERVED_USERNAMES.map(u => u.toLowerCase()));

--- a/apps/web/lib/validation/username-core.ts
+++ b/apps/web/lib/validation/username-core.ts
@@ -47,8 +47,8 @@ export const RESERVED_USERNAMES = [
   'artist-profiles',
 
   // Legal/company pages
-  'about',
-  'contact',
+  'about', // also a profile mode route — see PROFILE_MODE_RESERVED_TOKENS
+  'contact', // also a profile mode route — see PROFILE_MODE_RESERVED_TOKENS
   'privacy',
   'terms',
   'legal',
@@ -146,8 +146,8 @@ export const RESERVED_USERNAMES = [
   'jovie',
   'tip',
   'tips',
-  'listen',
-  'share',
+  'listen', // also a profile mode route — see PROFILE_MODE_RESERVED_TOKENS
+  'share', // also a profile mode route — see PROFILE_MODE_RESERVED_TOKENS
   'link',
   'links',
   'bio',

--- a/apps/web/tests/unit/lib/validation/profile-mode-reserved.test.ts
+++ b/apps/web/tests/unit/lib/validation/profile-mode-reserved.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PROFILE_MODE_RESERVED_TOKENS,
+  RESERVED_USERNAMES,
+  validateUsernameCore,
+} from '@/lib/validation/username-core';
+
+describe('PROFILE_MODE_RESERVED_TOKENS', () => {
+  it('covers every public profile mode route segment', () => {
+    // Changing this list without updating the route shape is a critical
+    // regression: a mismatch leaves a route either unreachable (token in
+    // reserved but no route) or hijackable (route without reservation).
+    expect([...PROFILE_MODE_RESERVED_TOKENS].sort()).toEqual(
+      [
+        'about',
+        'contact',
+        'listen',
+        'menu',
+        'pay',
+        'releases',
+        'share',
+        'subscribe',
+        'tour',
+      ].sort()
+    );
+  });
+
+  it('lists every mode token in the global reserved set', () => {
+    const reserved = new Set(RESERVED_USERNAMES);
+    for (const token of PROFILE_MODE_RESERVED_TOKENS) {
+      expect(reserved.has(token), `missing reservation: ${token}`).toBe(true);
+    }
+  });
+
+  it('rejects signup attempts on each mode token', () => {
+    for (const token of PROFILE_MODE_RESERVED_TOKENS) {
+      const result = validateUsernameCore(token);
+      expect(result.isValid, `should reject "${token}"`).toBe(false);
+      expect(result.errorCode).toBe('RESERVED');
+    }
+  });
+});

--- a/apps/web/tests/unit/profile/ProfileDrawerShell.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileDrawerShell.test.tsx
@@ -80,17 +80,22 @@ describe('ProfileDrawerShell', () => {
     expect(screen.getByText('Drawer body')).toBeInTheDocument();
   });
 
-  it('omits the close button and preserves the trailing header slot', () => {
+  it('renders an always-visible close button that invokes onOpenChange', () => {
+    const onOpenChange = vi.fn();
+
     render(
-      <ProfileDrawerShell open onOpenChange={vi.fn()} title='Menu'>
+      <ProfileDrawerShell open onOpenChange={onOpenChange} title='Menu'>
         <div>Drawer body</div>
       </ProfileDrawerShell>
     );
 
-    expect(screen.queryByRole('button', { name: 'Close' })).toBeNull();
-    expect(
-      screen.getByTestId('profile-drawer-right-placeholder')
-    ).toBeVisible();
+    const close = screen.getByTestId('profile-drawer-close-button');
+    expect(close).toBeVisible();
+    expect(close).toHaveAttribute('aria-label', 'Close');
+
+    fireEvent.click(close);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it('reserves the back-button slot for root-level drawers', () => {

--- a/apps/web/tests/unit/profile/ProfileDrawerShell.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileDrawerShell.test.tsx
@@ -98,6 +98,30 @@ describe('ProfileDrawerShell', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  // Regression: tap targets on mode drawers must meet WCAG 2.5.5 (44×44 min).
+  // Found by /qa on 2026-04-23 against every mode drawer on mobile viewport.
+  it('sizes the header tap targets to at least 44×44', () => {
+    render(
+      <ProfileDrawerShell
+        open
+        onOpenChange={vi.fn()}
+        title='Menu'
+        onBack={vi.fn()}
+        navigationLevel='secondary'
+      >
+        <div>Drawer body</div>
+      </ProfileDrawerShell>
+    );
+
+    const close = screen.getByTestId('profile-drawer-close-button');
+    const back = screen.getByTestId('profile-drawer-back-button');
+    // Tailwind: h-11 w-11 → 2.75rem → 44px.
+    expect(close.className).toMatch(/\bh-11\b/);
+    expect(close.className).toMatch(/\bw-11\b/);
+    expect(back.className).toMatch(/\bh-11\b/);
+    expect(back.className).toMatch(/\bw-11\b/);
+  });
+
   it('reserves the back-button slot for root-level drawers', () => {
     render(
       <ProfileDrawerShell open onOpenChange={vi.fn()} title='Menu'>


### PR DESCRIPTION
## Summary

First shippable slice of the [Public Profile UX Consolidation plan](../blob/main/.claude/plans/) (plan PR 1 scope).

- **Reserve 5 new mode tokens** (`subscribe`, `pay`, `tour`, `releases`, `menu`) in `RESERVED_USERNAMES` so creators can't take a handle that would collide with a routed mode page at `/[username]/[mode]`. `listen`, `contact`, `about`, `share`, `tip` were already reserved.
- **`PROFILE_MODE_RESERVED_TOKENS`** as the drift-guarded source of truth for the mode route list, with a unit test pinning it against `RESERVED_USERNAMES`.
- **`detectProfileModeHandleCollisions()`** server util so we can identify existing creators with a colliding handle before the route cutover (plan PR 3a) and coordinate renames.
- **Always-visible X close button** on `ProfileDrawerShell` — every drawer now dismisses by tap without relying on swipe-down or overlay tap discovery.
- **44 px tap targets** on close + back buttons (WCAG 2.5.5). Grid widened 32→44, icons scaled 3.5→4 for visual balance. Found by `/qa` exhaustive sweep on mobile viewport.

## Deferred from plan PR 1

The remaining PR 1 items (z-scale constants, `PROFILE_INTENT_BODY_CLASS` rename, `inert` on base, `history.back()`-based close contract, focus return to trigger) are folded into PR 3b of the plan where they compose with the new `ProfileIntentDrawer` controller. Landing them here means rewriting the same code twice.

## Test plan

- [x] Unit: 3 reserved-mode tests (`tests/unit/lib/validation/profile-mode-reserved.test.ts`)
- [x] Unit: 6 drawer shell tests including new tap-target regression (`tests/unit/profile/ProfileDrawerShell.test.tsx`)
- [x] Browser: close button + Esc verified on all 7 mode drawers (`/listen`, `/subscribe`, `/pay`, `/contact`, `/about`, `/tour`, `/releases`) on 375×812 and 1280×720 viewports
- [x] Pre-commit hooks (biome + eslint + typecheck + a11y:check:staged) green on all 3 commits
- [x] Reserved-handle reject verified by unit test; signup UI path gated by Clerk mock in local dev

## Screenshots

Before (32×32 close): `.gstack/qa-reports/screenshots/qa-04-listen-mobile.png`
After (44×44 close): `.gstack/qa-reports/screenshots/qa-06-listen-mobile-after.png`

## Plan follow-ups (pre-PR 3a checklist)

Run `detectProfileModeHandleCollisions()` against the production DB and coordinate renames if any creator's handle matches the 9 reserved mode tokens. Blocks plan PR 3a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive Close button in the profile drawer header.
  * Reserved additional usernames to prevent profile-mode route collisions.

* **Improvements**
  * Adjusted profile drawer header layout and button sizing.
  * Improved accessibility: labeled controls and larger touch targets.

* **Tests**
  * Added/updated unit tests covering reserved tokens and header button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->