### PR TITLE
fix: resolve SonarCloud S6582, S4624, S3735 + duration tokens

### DIFF
--- a/apps/web/app/[username]/tour/TourDateCard.tsx
+++ b/apps/web/app/[username]/tour/TourDateCard.tsx
@@ -93,7 +93,9 @@ export function TourDateCard({
       locationLabel={location}
       secondaryLocationLabel={
         tourDate.startTime
-          ? `Doors: ${tourDate.startTime}${timezoneAbbr ? ` ${timezoneAbbr}` : ''}`
+          ? 'Doors: ' +
+            tourDate.startTime +
+            (timezoneAbbr ? ' ' + timezoneAbbr : '')
           : null
       }
       imageAlt={tourDate.venueName}
@@ -103,7 +105,9 @@ export function TourDateCard({
       datePill={{
         month: monthFormatter.format(date),
         day: dayFormatter.format(date),
-        meta: `${weekdayFormatter.format(date)}${tourDate.startTime ? ` · ${tourDate.startTime}` : ''}`,
+        meta:
+          weekdayFormatter.format(date) +
+          (tourDate.startTime ? ' · ' + tourDate.startTime : ''),
       }}
       action={{
         label: actionLabel,

--- a/apps/web/app/api/calendar/profile/[username]/route.ts
+++ b/apps/web/app/api/calendar/profile/[username]/route.ts
@@ -74,7 +74,7 @@ export async function GET(
     // Private profiles AND missing profiles return 404. Same surface a
     // scraper would see for either case → no profile-existence side
     // channel.
-    if (!profile || !profile.isPublic) {
+    if (!profile?.isPublic) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 });
     }
 
@@ -87,8 +87,8 @@ export async function GET(
       `PRODID:-//Jovie//Tour Dates · ${escapeIcsText(artistName)}//EN`,
       'CALSCALE:GREGORIAN',
       'METHOD:PUBLISH',
-      `X-WR-CALNAME:${escapeIcsText(`${artistName} — tour`)}`,
-      `X-WR-CALDESC:${escapeIcsText(`Confirmed tour dates for ${artistName} · jov.ie/${profile.username}`)}`,
+      `X-WR-CALNAME:${escapeIcsText(artistName + ' — tour')}`,
+      `X-WR-CALDESC:${escapeIcsText('Confirmed tour dates for ' + artistName + ' · jov.ie/' + profile.username)}`,
     ];
 
     const stamp = formatIcsTimestamp(new Date());

--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -288,7 +288,7 @@ export function CalendarPageClient() {
 
   const invalidateEvents = useCallback(() => {
     if (!profileId) return;
-    void queryClient.invalidateQueries({
+    queryClient.invalidateQueries({
       queryKey: queryKeys.events.list(profileId),
     });
   }, [profileId, queryClient]);
@@ -474,7 +474,9 @@ export function CalendarPageClient() {
             onClick={() => setFilter('events')}
           />
           <FilterPill
-            label={`Needs review${pendingCount > 0 ? ` · ${pendingCount}` : ''}`}
+            label={
+              'Needs review' + (pendingCount > 0 ? ' · ' + pendingCount : '')
+            }
             active={filter === 'needs_review'}
             onClick={() => setFilter('needs_review')}
             tone={pendingCount > 0 ? 'warn' : 'default'}

--- a/apps/web/components/features/profile/LatestReleaseCard.tsx
+++ b/apps/web/components/features/profile/LatestReleaseCard.tsx
@@ -56,7 +56,7 @@ export function LatestReleaseCard({
       <ProfileMediaCard
         eyebrow={isFutureRelease ? 'New Single' : 'New Release'}
         title={release.title}
-        subtitle={`${releaseTypeLabel}${releaseYear ? ` · ${releaseYear}` : ''}`}
+        subtitle={releaseTypeLabel + (releaseYear ? ' · ' + releaseYear : '')}
         imageUrl={release.artworkUrl}
         imageAlt={`${release.title} artwork`}
         fallbackVariant='release'

--- a/apps/web/components/features/profile/artist-notifications-cta/NativeSmsSubscribeButton.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/NativeSmsSubscribeButton.tsx
@@ -256,7 +256,7 @@ export function NativeSmsSubscribeButton({
           'inline-flex h-11 items-center justify-center gap-2 rounded-full px-4',
           'bg-[oklch(10%_0_0)] text-white',
           'text-[15px] font-medium tracking-[-0.165px]',
-          'transition-colors duration-150',
+          'transition-colors duration-subtle',
           'hover:bg-[oklch(15%_0_0)]',
           'disabled:cursor-not-allowed disabled:opacity-60'
         )}
@@ -296,7 +296,7 @@ export function NativeSmsSubscribeButton({
           </span>
           {intent.smsTo && (
             <a
-              href={`sms:${intent.smsTo}?body=${encodeURIComponent(`JOIN ${intent.code}`)}`}
+              href={`sms:${intent.smsTo}?body=${encodeURIComponent('JOIN ' + intent.code)}`}
               className='text-sm text-[var(--accent)] underline-offset-2 hover:underline'
             >
               Text {intent.smsTo}

--- a/apps/web/components/shell/PillSearch.tsx
+++ b/apps/web/components/shell/PillSearch.tsx
@@ -173,7 +173,7 @@ export function PillSearch({
     if (!text) return [];
     const slash = parseSlash(text);
 
-    if (slash && slash.kind === 'choosing') {
+    if (slash?.kind === 'choosing') {
       const q = slash.query.toLowerCase();
       const fields = Object.keys(FIELD_LABEL) as FilterField[];
       const acc: Suggestion[] = [];
@@ -194,7 +194,7 @@ export function PillSearch({
       return acc.sort((a, b) => b.score - a.score).slice(0, 8);
     }
 
-    if (slash && slash.kind === 'scoped') {
+    if (slash?.kind === 'scoped') {
       const q = slash.query.toLowerCase().trim();
       const opts = fieldValueOptions(
         slash.field,
@@ -366,7 +366,7 @@ export function PillSearch({
         <button
           type='button'
           onClick={onClose}
-          className='shrink-0 inline-flex items-center h-5 px-1.5 rounded text-[10px] font-caption uppercase tracking-[0.06em] text-quaternary-token hover:text-primary-token hover:bg-surface-1/60 transition-colors duration-150 ease-out'
+          className='shrink-0 inline-flex items-center h-5 px-1.5 rounded text-[10px] font-caption uppercase tracking-[0.06em] text-quaternary-token hover:text-primary-token hover:bg-surface-1/60 transition-colors duration-subtle ease-out'
           aria-label='Close search'
         >
           Esc
@@ -395,7 +395,7 @@ export function PillSearch({
                   commitSuggestion(sug);
                 }}
                 className={cn(
-                  'w-full flex items-center gap-2 px-2.5 py-1.5 text-left text-[12.5px] transition-colors duration-100 ease-out',
+                  'w-full flex items-center gap-2 px-2.5 py-1.5 text-left text-[12.5px] transition-colors duration-subtle ease-out',
                   i === highlight
                     ? 'bg-cyan-500/10 text-primary-token'
                     : 'text-secondary-token hover:bg-surface-1/60'
@@ -455,7 +455,7 @@ function PillChip({
       <button
         type='button'
         onClick={onToggleOp}
-        className='px-1.5 text-tertiary-token hover:text-primary-token transition-colors duration-150 ease-out'
+        className='px-1.5 text-tertiary-token hover:text-primary-token transition-colors duration-subtle ease-out'
         title='Toggle is / is not'
       >
         {pill.op}
@@ -473,7 +473,7 @@ function PillChip({
               <button
                 type='button'
                 onClick={() => onRemoveValue(v)}
-                className='ml-1 text-cyan-300/70 hover:text-cyan-100 transition-colors duration-150 ease-out'
+                className='ml-1 text-cyan-300/70 hover:text-cyan-100 transition-colors duration-subtle ease-out'
                 aria-label={`Remove ${v}`}
               >
                 ×
@@ -485,7 +485,7 @@ function PillChip({
       <button
         type='button'
         onClick={onRemove}
-        className='px-1.5 text-cyan-300/70 hover:text-cyan-100 transition-colors duration-150 ease-out'
+        className='px-1.5 text-cyan-300/70 hover:text-cyan-100 transition-colors duration-subtle ease-out'
         aria-label='Remove filter'
       >
         ×

--- a/apps/web/lib/stripe/connect-readiness.ts
+++ b/apps/web/lib/stripe/connect-readiness.ts
@@ -93,7 +93,7 @@ export async function getStripeConnectReadiness(
     .where(eq(creatorProfiles.stripeAccountId, stripeAccountId))
     .limit(1);
 
-  if (!row || !row.stripeAccountId) return null;
+  if (!row?.stripeAccountId) return null;
 
   const cached = row as CachedRow;
 


### PR DESCRIPTION
## Summary
- **S6582** (4 issues): Use optional chaining instead of `x && x.prop` pattern
- **S4624** (6 issues): Flatten nested template literals to concatenation
- **S3735** (1 issue): Remove unnecessary `void` operator
- **Bonus**: Replace 6 raw `duration-150`/`duration-100` classes with `duration-subtle` DS token

## Files Changed (7)
- `apps/web/app/api/calendar/profile/[username]/route.ts`
- `apps/web/lib/stripe/connect-readiness.ts`
- `apps/web/components/shell/PillSearch.tsx`
- `apps/web/components/features/profile/artist-notifications-cta/NativeSmsSubscribeButton.tsx`
- `apps/web/components/features/profile/LatestReleaseCard.tsx`
- `apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx`
- `apps/web/app/[username]/tour/TourDateCard.tsx`

## SonarCloud Rules Addressed
- S6582: Prefer optional chain expressions
- S4624: Do not use nested template literals
- S3735: Remove void operator

## Test plan
- [x] TypeScript compiles (zero errors)
- [x] Biome lint passes
- [x] ESLint passes (zero warnings)
- [x] No behavior changes (code quality fixes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile privacy handling for calendar endpoints to properly return 404 for private profiles.
  * Enhanced null-safety checks in payment account readiness validation.

* **Style**
  * Updated animation transition timing across search filters and SMS subscription flows for improved UX consistency.

* **UI Updates**
  * Refined text formatting and label displays for tour dates, release information, and calendar event metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->