### PR TITLE
chore: harden agent delegation controls

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -31,6 +31,7 @@ All files in this directory are checked into the repo and shared across the team
 | `/neon-backup` | Create a manual Neon database backup |
 | `/clean` | Run E2E smoke tests, fix console errors, open PR |
 | `/perf-check` | React/Next.js performance audit |
+| `/perf-loop` | Measurement-first closed-loop performance hardening |
 | `/a11y-audit` | Accessibility and UX compliance audit |
 | `/sonar-fix` | Fix SonarCloud findings |
 | `/ideate` | Run ideation analysis for improvements |
@@ -58,6 +59,8 @@ Hooks run automatically on agent events. Configured in `settings.json`.
 |---------|------|---------|---------|
 | `Bash` | `bash-safety-check.sh` | 5s | Block dangerous shell commands |
 | `Edit\|Write` | `file-protection-check.sh` | 5s | Protect critical files from edits |
+| `Edit\|Write` | `infra-guardrails-check.sh` | 5s | Guard cron and scheduling changes |
+| `Edit\|Write` | `orchestrator-boundary-check.sh` | 5s | Block non-coding profiles from product/CI edits |
 
 ### PostToolUse
 | Matcher | Hook | Timeout | Purpose |
@@ -87,6 +90,7 @@ Use `/review` explicitly when you want the simplify + pre-landing review workflo
 |-------|-------------|
 | `coderabbit-review` | Run CodeRabbit AI code review on changes |
 | `consolidate-ui` | Consolidate UI component patterns |
+| `jovie-performance-hardening` | Measurement-first performance, database, CI, and test-speed hardening loop |
 | `turborepo` | Turborepo monorepo expert (builds, caching, worktrees, OOM) |
 
 ## Adding New Commands

--- a/.claude/commands/autopilot.md
+++ b/.claude/commands/autopilot.md
@@ -1,5 +1,5 @@
 ---
-description: Lead-orchestrator skill for Jovie Agent Teams mode. Use to continuously intake Linear work, dispatch teammates, run /ship, and keep PR + Linear status synchronized with retry/escalation.
+description: Lead-orchestrator skill for Jovie Agent Teams mode. Use to continuously intake Linear work, dispatch teammates, and keep PR + Linear status synchronized without direct coding by the lead.
 ---
 
 # Autopilot Lead Orchestrator Skill (Jovie)
@@ -8,7 +8,27 @@ Use this skill when operating Claude Code in **Agent Teams mode** with backgroun
 
 ## Mission
 
-Continuously intake Linear work, route tasks to teammates, ship safely through `/ship`, and keep PR + Linear state synchronized with minimal operator intervention.
+Continuously intake Linear work, route tasks to teammates, keep PR + Linear state synchronized, and prevent the lead agent from becoming the implementer.
+
+## Profile Boundary
+
+Autopilot is a lead-orchestrator workflow. The lead may prioritize, batch, dispatch, monitor, comment, update HUD/Linear state, and create repair manifests.
+
+The lead must not:
+
+- edit product, package, migration, workflow, or CI files
+- check out teammate branches to fix code
+- commit or push implementation fixes
+- run `/ship` as the task handler
+- merge, deploy, change credentials, change auth/payment, or run production-impacting scripts
+
+When a PR, issue, or batch needs implementation, the lead creates a dispatch manifest and routes it to the correct profile:
+
+- `code-orchestrator` for planning/decomposition/review strategy
+- `coder` for implementation, test fixes, conflict repair, and PR updates
+- `no_agent` for deterministic HUD, cron, usage-ledger, and GBrain sync work
+
+Every dispatch prompt must include `JOVIE_AGENT_PROFILE=<profile>` so hooks can enforce the profile boundary.
 
 ## Required Environment (hard requirements)
 
@@ -124,7 +144,7 @@ After intake, group small related issues into batches before dispatch. This avoi
 #### Solo issues (default path)
 
 - Assign unclaimed tasks (or allow self-claim)
-- Each task handler must:
+- Each task handler must be a dispatched coder or code-orchestrator session, never the lead. The handler must:
   1. Implement minimal root-cause fix
   2. Run required validation gates
   3. Run `/ship` to commit, push branch, and open PR
@@ -135,10 +155,10 @@ After intake, group small related issues into batches before dispatch. This avoi
 When picking up a stuck issue that a previous agent failed on:
 
 1. **Check for existing work** — look for branches matching the issue's `gitBranchName`, open/closed PRs, and Linear comments describing what was attempted
-2. **Assess salvageability** — if the existing branch has useful partial work, build on it. If it's broken or conflicts with main, start fresh from main
-3. **Start fresh by default** — create a new branch from main (e.g., `fix/jov-XXXX-<slug>`) rather than continuing on a potentially broken branch
-4. **Delete stale branches** — if the old branch has no useful commits, delete it to avoid confusion
-5. **Comment on the Linear issue** — note that the previous attempt stalled and a new attempt is starting, with a brief summary of what went wrong if discoverable
+2. **Create a recovery manifest** — include prior branch/PR links, likely failure mode, KPI, owner, profile, cost route, GBrain queries, gstack skills, expected output, and verification
+3. **Dispatch recovery** — route salvage/fresh-start judgment to `code-orchestrator`; route implementation to `coder`
+4. **Do not delete stale branches directly** — request cleanup approval or dispatch a no-agent cleanup manifest after confirming no open PR depends on the branch
+5. **Comment on the Linear issue** — note that the previous attempt stalled and a new attempt is being dispatched, with a brief summary of what went wrong if discoverable
 
 #### Batched issues
 
@@ -160,13 +180,15 @@ If task touches app/web runtime/db flows, run relevant scoped checks too.
 
 ### 5) Background PR Orchestration (parallel)
 
-Continuously monitor teammate PRs and run `/orchestrate` behavior:
+Continuously monitor teammate PRs and run read-only `/orchestrate` behavior:
 
-- Rebase/update branch
-- Resolve merge conflicts when safe
-- Address failing tests/CI
-- Push follow-up fixes
+- Enable safe GitHub-side auto-merge/update-branch actions where allowed
+- Detect merge conflicts, failing tests/CI, review blockers, stale branches, and duplicate PRs
+- Create repair manifests for coder/code-orchestrator profiles
+- Track owner, verification, blocker, retry count, and next action in HUD/Linear
 - Sync PR status and summary back to Linear
+
+If `/orchestrate` would require checkout/edit/commit/push, stop and dispatch a coder repair manifest instead.
 
 ### 6) Linear Status Sync Rules
 

--- a/.claude/commands/ideate-perf.md
+++ b/.claude/commands/ideate-perf.md
@@ -7,6 +7,8 @@ tags: [ideation, performance, optimization, bundle]
 
 Analyze the codebase to identify performance bottlenecks, optimization opportunities, and efficiency improvements across bundle size, runtime, and network.
 
+For implementation or closed-loop optimization, route to the `jovie-performance-hardening` skill. `/ideate-perf` is discovery-only and must not make code changes.
+
 ## Arguments
 
 - `[path]` - Target directory (default: `apps/web`)

--- a/.claude/commands/orchestrate.md
+++ b/.claude/commands/orchestrate.md
@@ -1,11 +1,27 @@
 ---
-description: Review and process all open PRs (including drafts) to completion with AI agent assignment and validation
+description: Review and process open PRs with strict profile separation. Chief/default profile runs read-only triage and dispatch manifests; coder profiles may repair branches with validation.
 allowed-tools: Bash(gh:*), Bash(git:*), Bash(pnpm:*), Bash(jq:*)
 ---
 
 # Orchestrate PR Workflow
 
 Process ALL open pull requests to zero. Run once, walk away, come back to an empty queue.
+
+## Profile Gate
+
+This command has two modes:
+
+- **Lead/read-only mode:** Chief of Staff, default, CFO, Founder OS, and Code Orchestrator profiles may inventory PRs, classify blockers, enable safe GitHub-side auto-merge/update-branch actions, comment with status, and create repair manifests.
+- **Implementation mode:** only a dispatched `coder` profile with a HUD/delegation manifest may check out branches, edit files, commit, push, or run repair validation.
+
+Before any checkout/edit/commit/push action, verify all of these are true:
+
+1. `JOVIE_AGENT_PROFILE=coder` or equivalent runtime profile is set.
+2. A manifest exists with `hud_id`, `kpi`, `owner`, `hermes_profile`, `runtime`, `model_route`, `worktree`, `gstack_skills`, `gbrain_queries`, `hard_gates`, `expected_output`, and `verification`.
+3. The manifest authorizes this PR and this branch.
+4. No hard gate is present: merge, deploy, destructive cleanup, credential/auth/payment change, migration, dependency replacement, or production-impacting script.
+
+If any item is missing, do not repair directly. Create or update a repair manifest and dispatch it to the correct profile.
 
 ## Linear State — Hands Off
 
@@ -89,11 +105,11 @@ Before doing any fix-up work, identify PRs that address the same concern:
 For each duplicate set:
 1. **Compare quality**: Which PR has better code, more complete implementation, passing checks?
 2. **Pick the winner**: Choose the PR with the most progress / best implementation
-3. **Close the loser**: Close the redundant PR with a comment explaining why:
+3. **Close the loser only in lead/read-only mode if it is clearly redundant and has no unique commits worth preserving.** Otherwise create a coder manifest to salvage/cherry-pick the useful commits. Close with a comment explaining why:
 ```bash
 gh pr close <LOSER_NUMBER> --comment "Closing in favor of #<WINNER_NUMBER> which provides a more complete implementation of the same change."
 ```
-4. If the losing PR has useful commits not in the winner, cherry-pick them:
+4. If the losing PR has useful commits not in the winner, lead mode must dispatch a coder repair manifest. Implementation mode may cherry-pick them:
 ```bash
 git checkout <winner-branch>
 git cherry-pick <useful-commit-sha>
@@ -102,7 +118,7 @@ git push
 
 ## Phase 3: Fix Blocking Issues (Sorted by Easiest First)
 
-Process remaining PRs in this order:
+Process remaining PRs in this order. Lead/read-only mode creates repair manifests for each blocking PR and stops before checkout/edit/commit/push. Implementation mode may execute the repair only when the profile gate above passes.
 1. **COMMENT_PENDING** — just needs replies/fixes to review comments
 2. **FAILING_CHECKS** — lint/type/test failures
 3. **REVIEW_BLOCKED** — needs review dismissal or re-review
@@ -121,18 +137,19 @@ gh pr view <NUMBER> --json comments
 
 **Process each comment:**
 1. **Read the comment** — understand what's being asked
-2. **Check out the branch**: `git checkout <branch-name> && git pull`
-3. **Assess the comment:**
+2. **Profile gate** — if not running as authorized `coder`, create a repair manifest and skip direct repair
+3. **Check out the branch**: `git checkout <branch-name> && git pull`
+4. **Assess the comment:**
    - If it's a valid code concern: fix the code
    - If it's a style/nit suggestion: apply it if it improves the code, otherwise reply explaining why not
    - If it's an AI-generated false positive: reply explaining why the current code is correct
    - If it's a question: answer it
-4. **Make the fix** — edit the files, commit, push
-5. **Reply to the comment** confirming the fix:
+5. **Make the fix** — edit the files, commit, push
+6. **Reply to the comment** confirming the fix:
 ```bash
 gh api repos/{owner}/{repo}/pulls/<NUMBER>/comments/<COMMENT_ID>/replies --method POST -f body="Fixed in <SHA>."
 ```
-6. **Resolve the conversation** if GitHub supports it via API
+7. **Resolve the conversation** if GitHub supports it via API
 
 **IMPORTANT**: After addressing all comments on a PR, run `/verify` to catch issues before pushing. This prevents review ping-pong.
 
@@ -145,8 +162,9 @@ gh pr checks <NUMBER>
 ```
 
 1. **Identify failures**: lint, typecheck, tests, build, security
-2. **Check out the branch**: `git checkout <branch-name> && git pull`
-3. **Fix each failure type:**
+2. **Profile gate** — if not running as authorized `coder`, create a repair manifest and skip direct repair
+3. **Check out the branch**: `git checkout <branch-name> && git pull`
+4. **Fix each failure type:**
 
    **Lint failures:**
    ```bash
@@ -171,8 +189,8 @@ gh pr checks <NUMBER>
    pnpm --filter web lint:server-boundaries
    ```
 
-4. **Commit and push** all fixes
-5. **Run `/verify`** before pushing to ensure no regressions
+5. **Commit and push** all fixes
+6. **Run `/verify`** before pushing to ensure no regressions
 
 ### 3c. Dismiss Blocking Reviews (Only When Comments Are Addressed)
 
@@ -191,7 +209,7 @@ gh api repos/{owner}/{repo}/pulls/<NUMBER>/reviews/<REVIEW_ID>/dismissals --meth
 
 ### 3d. Resolve Merge Conflicts
 
-For each PR with conflicts:
+For each PR with conflicts. Lead/read-only mode records conflict details and dispatches a coder manifest; only implementation mode resolves conflicts directly:
 
 1. **Check out the branch** and update from main:
 ```bash

--- a/.claude/commands/perf-loop.md
+++ b/.claude/commands/perf-loop.md
@@ -2,6 +2,10 @@
 
 Run the resumable performance loop against Jovie's canonical end-user routes.
 
+Use the `jovie-performance-hardening` skill as the operating contract for this command. The loop is measurement-first: baseline, pick one hypothesis family, implement one coherent change cluster, re-measure, and keep only validated wins.
+
+If the current actor is Chief of Staff, default, CFO, Founder OS, or Code Orchestrator, do not implement performance fixes directly. Create a HUD/delegation manifest for a `coder` or performance agent with the required routes, metrics, gstack skills, GBrain queries, expected output, and verification commands.
+
 ## Core Commands
 
 ```bash

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -2,6 +2,14 @@
 
 Pull Linear issues and dispatch isolated agents in parallel, each in its own git worktree. Each agent ships its own PR independently with zero cross-contamination.
 
+## Lead Role Boundary
+
+The swarm lead is an orchestrator, not an implementer. The lead may select issues, create isolated worktrees, spawn agents, watch results, update HUD/Linear, and retry failed dispatches.
+
+The lead must not edit product code, fix validation failures, commit, push implementation changes, merge, deploy, or delete branch data as part of swarm recovery. If work needs code changes after dispatch, create a repair manifest and route it to a `coder` profile.
+
+Every spawned coding agent prompt must include `JOVIE_AGENT_PROFILE=coder`. Planning-only swarm agents should use `JOVIE_AGENT_PROFILE=code-orchestrator`.
+
 **Arguments:** Optional — number of issues to process (default: 5, max: 5 per batch)
 
 ## Required Environment
@@ -76,6 +84,9 @@ For each agent:
 **Agent prompt template:**
 
 ```
+Environment contract:
+Set JOVIE_AGENT_PROFILE=coder before editing files or running validation.
+
 You are working on Linear issue JOV-<NUMBER>: <TITLE>
 
 WORKTREE INSTRUCTIONS (CRITICAL — read these before doing ANYTHING):
@@ -177,7 +188,7 @@ Shipped: X/Y | Failed: Z | Skipped (dupes): W
 
 ## Error Handling
 
-- **Agent fails validation:** Log the failure, mark issue as blocked in Linear with error details
+- **Agent fails validation:** Log the failure and create a coder repair manifest. Do not have the swarm lead fix the branch directly.
 - **Worktree creation fails:** Clean up and retry once, then skip issue
 - **Agent crashes:** Read output file for error, retry once with fresh worktree
 - **Branch conflict:** Delete local branch, recreate worktree from origin/main

--- a/.claude/hooks/orchestrator-boundary-check.sh
+++ b/.claude/hooks/orchestrator-boundary-check.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Block non-coding orchestration profiles from editing product code.
+#
+# This hook is intentionally inert unless a launcher sets one of the profile
+# environment variables below. Hermes/Conductor should set JOVIE_AGENT_PROFILE
+# before starting Claude Code/Codex sessions so profile drift becomes a hard
+# gate instead of a memory test.
+
+if command -v jq &> /dev/null; then
+  file_path=$(echo "$TOOL_INPUT" | jq -r '.file_path // empty' 2>/dev/null)
+else
+  file_path=$(echo "$TOOL_INPUT" | grep -oP '"file_path"\s*:\s*"\K[^"]+' 2>/dev/null || true)
+fi
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+profile="${JOVIE_AGENT_PROFILE:-${HERMES_PROFILE:-${HERMES_AGENT_PROFILE:-${CLAUDE_AGENT_ROLE:-${AGENT_PROFILE:-}}}}}"
+profile="$(printf '%s' "$profile" | tr '[:upper:]' '[:lower:]')"
+
+if [ -z "$profile" ]; then
+  exit 0
+fi
+
+case "$profile" in
+  default|chief|chief-of-staff|chief_of_staff|cfo|cfo-milan-v2|founder-os|code-orchestrator|orchestrator)
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+case "$file_path" in
+  apps/web/*|packages/*|drizzle/*|.github/workflows/*|proxy.ts|tailwind.config.ts|next.config.js|package.json|pnpm-lock.yaml|turbo.json)
+    echo "BLOCKED: Non-coding profile cannot edit product or CI code"
+    echo "Profile: $profile"
+    echo "File: $file_path"
+    echo ""
+    echo "Chief of Staff, CFO, Founder OS, and Code Orchestrator profiles must create"
+    echo "or update a HUD/delegation manifest and dispatch an authorized coder profile."
+    echo ""
+    echo "Required manifest fields:"
+    echo "  hud_id, kpi, owner, hermes_profile, runtime, model_route, worktree,"
+    echo "  gstack_skills, gbrain_queries, hard_gates, expected_output, verification"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/.claude/rules/gstack.md
+++ b/.claude/rules/gstack.md
@@ -68,7 +68,9 @@ gstack skill files are part of the agent control plane. Keep them fast, stable, 
 
 ## Performance Optimization Loop
 
-`/perf-loop` runs an autonomous optimization loop that measures, experiments, and keeps only improvements. State is persisted to `.context/perf/` for resume capability. The skill uses `perf:loop` (performance-optimizer.ts) as its measurement primitive and commits each accepted improvement atomically.
+`/perf-loop` runs an autonomous optimization loop that measures, experiments, and keeps only improvements. It must follow `.claude/skills/jovie-performance-hardening/SKILL.md`: baseline first, one hypothesis family per iteration, re-measure with the same method, and keep only validated wins. State is persisted to `.context/perf/` for resume capability. The skill uses `perf:loop` (performance-optimizer.ts) as its measurement primitive.
+
+Chief/default/CFO/Founder OS/Code Orchestrator profiles must not implement performance changes directly. They create a HUD/delegation manifest and dispatch a coder/performance agent with `JOVIE_AGENT_PROFILE=coder`.
 
 Runtime: ~30–50 minutes for a full run (4–10 iterations with builds).
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,6 +37,11 @@
             "type": "command",
             "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/infra-guardrails-check.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/orchestrator-boundary-check.sh",
+            "timeout": 5
           }
         ]
       },
@@ -132,6 +137,8 @@
       "Skill(ideate-quality:*)",
       "Skill(ideate-perf)",
       "Skill(ideate-perf:*)",
+      "Skill(jovie-performance-hardening)",
+      "Skill(jovie-performance-hardening:*)",
       "Skill(consolidate-ui)",
       "Skill(consolidate-ui:*)",
       "Skill(turborepo)",
@@ -162,6 +169,7 @@
       "SlashCommand(/review)",
       "SlashCommand(/browse)",
       "SlashCommand(/qa)",
+      "SlashCommand(/perf-loop)",
       "SlashCommand(/retro)",
       "SlashCommand(/gstack-upgrade)"
     ],

--- a/.claude/skills/jovie-performance-hardening/SKILL.md
+++ b/.claude/skills/jovie-performance-hardening/SKILL.md
@@ -1,0 +1,493 @@
+---
+name: jovie-performance-hardening
+description: |
+  Measurement-first performance hardening for Jovie. Use when app runtime,
+  database, bundle, CI, Vitest, Playwright, or route-budget performance needs
+  continuous optimization with validated before/after metrics.
+version: 2026-05-07
+owner: ops-agent
+scope: JovieInc/Jovie
+purpose: Keep app performance, database performance, CI speed, and test speed continuously hardened through measurement-first optimization loops.
+mode: closed-loop
+---
+
+# jovie-performance-hardening
+
+## INDEX
+
+[0] Mission
+[1] Repo anchors
+[2] Trigger routing
+[3] Standing rules
+[4] Measurement order
+[5] Stack-specific hunt lists
+[6] Iteration loop
+[7] Acceptance gates
+[8] Subagent roles
+[9] Deliverables
+[10] Stop conditions
+
+## [0] Mission
+
+You are Jovie's standing performance hardening operator.
+
+Your job is to continuously:
+
+1. detect bottlenecks,
+2. measure the current state,
+3. pick the smallest high-leverage fix,
+4. implement one change cluster at a time,
+5. re-measure,
+6. keep only validated wins,
+7. tighten budgets when the surface is stable,
+8. repeat until budgets pass or marginal gains flatten.
+
+You optimize:
+
+- user-facing runtime performance,
+- bundle size and request cost,
+- route-level Core Web Vitals and app-shell timings,
+- database query performance,
+- TanStack query behavior,
+- build speed,
+- Vitest speed,
+- Playwright throughput and flake resistance,
+- CI resource efficiency.
+
+Never guess. Measure first.
+
+## [1] Repo anchors
+
+Always load these files before acting:
+
+- `apps/web/next.config.js`
+- `apps/web/package.json`
+- `apps/web/lib/db/client/connection.ts`
+- `apps/web/lib/queries/README.md`
+- `apps/web/components/providers/QueryProvider.tsx`
+- `apps/web/scripts/performance-route-manifest.ts`
+- `apps/web/scripts/performance-budgets-guard.ts`
+- `apps/web/scripts/performance-optimizer.ts`
+- `apps/web/scripts/performance-end-user-loop.ts`
+- `apps/web/scripts/test-performance-profiler.ts`
+- `apps/web/scripts/test-performance-guard.ts`
+- `apps/web/tests/TESTING.md`
+- `.github/workflows/ci.yml`
+- `.claude/commands/ideate-perf.md`
+- `.agents/skills/gstack/benchmark/SKILL.md`
+
+Interpretation:
+
+- `next.config.js` = runtime and cache truth
+- `connection.ts` = DB and pooling truth
+- `lib/queries/*` = client data-fetching truth
+- `performance-route-manifest.ts` = route budget truth
+- `ci.yml` = enforcement truth
+- `TESTING.md` + test perf scripts = test-speed truth
+
+## [2] Trigger routing
+
+Run this skill proactively when:
+
+- a diff touches `apps/web/app`, `apps/web/components`, `apps/web/lib`, `apps/web/hooks`, or `packages/*`
+- Lighthouse budgets fail
+- bundle size rises
+- route timings regress
+- query waterfalls appear
+- DB latency rises
+- tests exceed targets
+- CI duration grows materially
+- a PR changes cache, auth, routing, images, charts, tables, rich client UI, profile pages, dashboard shell, chat, onboarding, billing, admin, or DB code
+
+If the platform supports macros/subagents, expose:
+
+- `!perf-hardening`
+- `!bundle-audit`
+- `!query-waterfall`
+- `!db-hotpath`
+- `!test-speed`
+- `!ci-speed`
+
+## [3] Standing rules
+
+1. Use Jovie's existing scripts first. Prefer package scripts when present. If absent, run the TS entrypoint directly.
+2. Never introduce a perf "win" that breaks auth, freshness, correctness, SEO, or hydration stability.
+3. Never accept a local micro-benchmark win without route-level remeasurement.
+4. Never cargo-cult `useMemo`/`useCallback`. Trust React Compiler unless profiling proves a miss.
+5. Never create new DB connection code. Use the canonical DB module.
+6. Never optimize one surface by silently regressing another.
+7. For experimental Next.js flags, validate in production-like build/preview before keeping the change.
+8. Optimize change clusters, not random edits. One hypothesis family per iteration.
+9. Keep a ledger of hypotheses, metrics, and accepted/reverted changes.
+10. If no measurable gain appears after 3 serious attempts on the same bottleneck, pivot.
+
+## [4] Measurement order
+
+### Phase A: scope
+
+- Read git diff.
+- Map changed files to likely surfaces:
+  - public/marketing/legal/profile
+  - creator shell/dashboard/chat
+  - billing/account
+  - onboarding/auth
+  - database/query layer
+  - tests/CI
+
+### Phase B: baseline
+
+Run the smallest truthful baseline first.
+
+Preferred order:
+
+1. route budget guard
+2. relevant Lighthouse surface
+3. bundle analysis if JS/script budget is implicated
+4. DB/query analysis if server timings or TTFB regress
+5. test-performance profiler/guard if test or CI speed regresses
+
+Fallback invocation style:
+
+```bash
+pnpm --filter @jovie/web run perf:budgets || pnpm --filter @jovie/web exec tsx scripts/performance-budgets-guard.ts
+pnpm --filter @jovie/web run perf:optimize || pnpm --filter @jovie/web exec tsx scripts/performance-optimizer.ts
+pnpm --filter @jovie/web run perf:end-user:loop || pnpm --filter @jovie/web exec tsx scripts/performance-end-user-loop.ts
+pnpm --filter @jovie/web run test:perf:profile || pnpm --filter @jovie/web exec tsx scripts/test-performance-profiler.ts
+pnpm --filter @jovie/web run test:perf:guard || pnpm --filter @jovie/web exec tsx scripts/test-performance-guard.ts
+```
+
+If a route requires auth, use the repo's existing auth bootstrap path and storage-state flow. Do not invent a new auth flow.
+
+### Phase C: classify the bottleneck
+
+Classify each issue into one primary bucket:
+
+- cache/correctness
+- bundle/client JS
+- network/request waterfall
+- server render/TTFB
+- DB query/indexing
+- image/font/asset weight
+- hydration/client render churn
+- test setup overhead
+- E2E worker throughput
+- CI pipeline overscope
+
+## [5] Stack-specific hunt lists
+
+### Next.js hunt list
+
+Look for:
+
+- uncached or wrongly cached data fetches
+- stale or over-broad invalidation
+- dynamic route segments doing unnecessary client work
+- oversized client components that should be server-first
+- avoidable `"use client"` boundaries
+- needless third-party JS in initial path
+- missing dynamic imports for heavy optional UI
+- route segments that should prefetch earlier
+- image misuse, oversized remote images, bad placeholder strategy
+- font overuse
+- expensive layout shifts
+- duplicate data fetching between server and client
+- experimental `staleTimes`/`optimizePackageImports` settings that help one surface but hurt another
+
+Prefer:
+
+- server-first rendering
+- route-aware prefetching
+- targeted dynamic import
+- cache tagging/revalidation discipline
+- better image and script budgets
+- smaller initial JS
+
+### TanStack Query hunt list
+
+Look for:
+
+- serial dependent queries
+- nested parent/child waterfalls
+- duplicate query keys for same data
+- over-invalidating broad scopes
+- `staleTime`/`gcTime` mismatches by surface
+- unneeded `refetchOnMount` or focus churn
+- mutation flows missing precise invalidation
+- dashboard routes missing prefetch opportunities
+- cache populated too late in the render tree
+
+Prefer:
+
+- prefetch before render or on navigation intent
+- route-level/query-client priming
+- precise invalidation scopes
+- stable query keys
+- surface-specific cache strategies
+- using server hydration where data is already known
+
+### Drizzle + DB hunt list
+
+Look for:
+
+- large select projections
+- missing limits
+- missing `orderBy` in paginated paths
+- loops with `await db`
+- per-item queries instead of one relational query
+- hot-path queries that repeat with different params and should be prepared
+- missing indexes for where/order/join predicates
+- avoidable JSON overfetch
+- expensive count queries in hot views
+- unnecessary DB work during app shell load
+
+Prefer:
+
+- partial select
+- prepared statements on hot repeated shapes
+- relational one-query fetches where appropriate
+- explicit indexes aligned to predicates
+- batched lookup patterns
+- push heavy work out of first render path where possible
+
+### Lighthouse + route budgets hunt list
+
+Look for:
+
+- resource budget overruns
+- route groups whose budgets drifted from actual UX expectations
+- auth route audits that do not match real authenticated state
+- public/profile/chat/onboarding surfaces missing separate budget treatment
+- third-party scripts blocking initial render
+
+Prefer:
+
+- route-specific budgets
+- separate assertion matrices for public vs app shell
+- authenticated audit setup through the existing auth bootstrap
+- n>=3 runs with median-based acceptance
+
+### Vitest hunt list
+
+Look for:
+
+- huge global setup
+- jsdom used where node is enough
+- expensive top-level mocks
+- repeated heavyweight imports
+- isolate on suites that could safely avoid it
+- forks where threads would be faster
+- excess workers causing thrash
+- synchronous setup repeated per file
+- broad test helpers importing the world
+
+Prefer:
+
+- shrinking setup time first
+- lighter environment selection
+- threads for compatible suites
+- selective no-isolate only for truly side-effect-safe suites
+- worker caps that match actual machine parallelism
+- splitting pure node tests from jsdom tests
+
+### Playwright hunt list
+
+Look for:
+
+- serial suites that could be isolated
+- shared mutable test state
+- auth rework per test when storage/bootstrap can be reused
+- too many browsers for the PR path
+- no sharding on slow full suites
+- flaky selectors tied to copy/layout
+- traces/videos enabled too broadly
+- overlong smoke coverage
+
+Prefer:
+
+- strict isolation
+- worker-indexed data
+- sharding on CI
+- locators by role/intent
+- retry-only heavy diagnostics
+- smoke path discipline
+- broad suite only on main or explicit label
+
+### CI hunt list
+
+Look for:
+
+- path filters that miss or over-trigger work
+- duplicate builds
+- full-suite work on low-risk diffs
+- missing artifact reuse
+- wrong worker count for runner shape
+- lighthouse/test jobs that should be surface-targeted
+- drift between route-manifest budgets and CI jobs
+
+Prefer:
+
+- selective enforcement
+- shared artifacts
+- route/surface-aware gates
+- main-vs-PR split
+- stable performance baselines
+
+## [6] Iteration loop
+
+For each bottleneck:
+
+1. State the bottleneck in one sentence.
+2. Name the primary metric and current value.
+3. Name the target budget.
+4. Generate top 3 hypotheses, ranked by expected leverage.
+5. Pick exactly one hypothesis family.
+6. Make one coherent change cluster.
+7. Rebuild only as much as needed.
+8. Re-measure the same metric with the same method.
+9. Record:
+   - hypothesis
+   - files changed
+   - before
+   - after
+   - keep/revert
+   - side effects
+10. If improved and safe, keep it.
+11. If flat or worse, revert or pivot.
+12. Repeat until budget passes or no-progress threshold triggers.
+
+Use median or p75 for noisy route measurements.
+Use p95 for test-speed guardrails.
+Do not accept single-run miracles.
+
+## [7] Acceptance gates
+
+A change is accepted only if all are true:
+
+- primary target improves materially
+- no secondary surface regresses materially
+- correctness remains intact
+- auth still works
+- hydration remains clean
+- CI path still makes sense
+- tests still pass
+- budget drift is documented if thresholds changed
+
+Default acceptance heuristics:
+
+- route timing win: >= 5% faster or clear budget pass
+- bundle win: meaningful JS/resource reduction on affected route
+- DB win: lower query count, lower bytes, lower latency, or better TTFB
+- unit/integration speed win: lower setup time or lower p95 without flake increase
+- E2E speed win: lower wall time without isolation loss
+
+Reject:
+
+- noisy wins
+- synthetic-only wins
+- regressions hidden behind caching bugs
+- "optimizations" that only move work later in a harmful way
+
+## [8] Subagent roles
+
+If the platform supports specialized workers, spawn these:
+
+### perf-router-scout
+
+Maps diff -> affected surfaces -> route IDs -> budgets -> CI jobs.
+
+### next-cache-auditor
+
+Owns caching, invalidation, dynamic/static boundaries, lazy loading, image/script pressure.
+
+### tanstack-waterfall-hunter
+
+Owns client-data waterfalls, prefetch strategy, invalidation precision, dashboard/query churn.
+
+### db-hotpath-surgeon
+
+Owns query shape, index alignment, prepared statements, TTFB-linked DB issues.
+
+### bundle-surgeon
+
+Owns initial JS, dynamic imports, heavy dependencies, third-party pressure.
+
+### test-speed-surgeon
+
+Owns Vitest setup cost, pool strategy, isolation strategy, jsdom scope.
+
+### e2e-throughput-operator
+
+Owns Playwright workers, sharding, auth reuse, retries/trace policy, smoke/full partitioning.
+
+### ci-budget-enforcer
+
+Owns workflow filters, artifacts, perf gate consistency, and budget synchronization.
+
+Each subagent returns:
+
+- diagnosis
+- evidence
+- candidate fixes
+- risk notes
+- exact remeasurement commands
+
+## [9] Deliverables
+
+Every run must output:
+
+### A. Brief verdict
+
+- bottleneck
+- root cause
+- accepted fix
+- measured delta
+- remaining risk
+
+### B. Change ledger
+
+One row per iteration:
+
+- hypothesis
+- files
+- before
+- after
+- verdict
+
+### C. Budget status
+
+- passed
+- failed
+- tightened
+- deferred with reason
+
+### D. Next move
+
+- next highest-leverage bottleneck
+- whether to continue loop or stop
+
+### E. Artifact paths
+
+Point to:
+
+- perf baseline
+- route measurements
+- Lighthouse reports
+- bundle report
+- test perf baseline/report
+
+## [10] Stop conditions
+
+Stop when any of these are true:
+
+- all affected budgets pass
+- 3 no-progress iterations on same bottleneck
+- candidate fixes now create unacceptable correctness or freshness risk
+- remaining gains are marginal and lower priority than shipping
+- issue is blocked by third-party dependency/runtime constraints
+
+When stopping, state clearly:
+
+- what improved
+- what did not
+- what should be watched in CI
+- what future work is worth a deeper refactor

--- a/.claude/skills/parallel-agents.md
+++ b/.claude/skills/parallel-agents.md
@@ -8,6 +8,12 @@ description: Parallel agent orchestration using git worktrees for isolated branc
 
 Orchestrate multiple agents working on separate Linear issues in parallel, using git worktrees so each agent has a completely isolated working directory. Turbo 2.8+ automatically shares build cache across worktrees.
 
+## Lead Role Boundary
+
+The lead coordinates and verifies; it does not become the coder. If a delegated agent fails validation, conflicts, or review repair, the lead records the blocker and dispatches a new coder/code-orchestrator task. The lead must not check out the branch, edit product files, commit, or push implementation fixes itself.
+
+Set `JOVIE_AGENT_PROFILE=default` or `JOVIE_AGENT_PROFILE=code-orchestrator` in lead sessions. Set `JOVIE_AGENT_PROFILE=coder` in implementation sessions so repo hooks can enforce the boundary.
+
 ## When to Use
 
 - Spawning 2+ agents to work on different issues simultaneously
@@ -149,4 +155,4 @@ pnpm install
 ```
 
 ### Agent's typecheck/lint fails
-The agent should fix issues in its worktree. If it can't, it reports failure and the lead agent handles it or marks the issue as blocked.
+The agent should fix issues in its worktree. If it can't, it reports failure and the lead agent creates a repair manifest, redispatches to an authorized coder, or marks the issue as blocked. The lead does not fix the branch directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,19 @@ Controller file for AI agents working in this repo. `AGENTS.md` is a symlink to 
 - Don't hide failing checks. Report exact failures and the likely cause.
 - Ask before destructive operations: data deletion, irreversible migrations, credential changes, dependency replacement, auth/payment changes, or production-impacting scripts.
 
+## Agent Role Boundary
+
+Orchestrated sessions must set `JOVIE_AGENT_PROFILE` before editing:
+
+- `default` / Chief of Staff: prioritize, dispatch, verify, update HUD/Linear. Do not code.
+- `cfo-milan-v2`: cost, runway, usage, spend routing. Do not code.
+- `founder-os`: GTM, fundraising, applications, company facts. Do not code.
+- `code-orchestrator`: plan, decompose, review, and create manifests. Do not implement.
+- `coder`: implement assigned HUD/delegation manifests only.
+- `no_agent`: deterministic scripts, HUD refresh, cron checks, usage ledger, GBrain sync.
+
+If a non-coding profile discovers work that needs product/CI changes, create or update a HUD/delegation manifest with KPI, owner, profile, runtime, cost route, GBrain queries, gstack skills, expected output, and verification. Then dispatch a `coder` profile. Do not check out teammate branches, edit code, commit, push, merge, deploy, or repair CI directly from Chief/default/code-orchestrator sessions.
+
 ## Instruction Architecture
 
 - `AGENTS.md` is the canonical cross-agent contract and is intentionally a symlink to this file. Do not replace it with a standalone file.

--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,7 @@
     "includes": [
       "**/*",
       "!!.claude",
+      "!apps/web/drizzle/migrations/**",
       "!**/.context/**",
       "!.agents/skills/gstack/**",
       "!.claude/skills/gstack/**",


### PR DESCRIPTION
## Summary
- add a profile-boundary hook so non-coding profiles can be blocked from product/CI edits when launchers set JOVIE_AGENT_PROFILE
- update Chief/autopilot/orchestrate/swarm/perf prompts to dispatch repair manifests instead of letting lead agents directly code
- add the jovie-performance-hardening skill and wire /perf-loop to measurement-first operation
- exclude generated Drizzle migration history from Biome checks so hooks do not require modifying immutable migrations

## Live ops updates
- installed ~/.hermes/scripts/delegation-judge.py and ~/.hermes/scripts/delegation-doctor.py for HUD plan ingestion and delegation drift checks
- connected ~/.hermes/scripts/agent-stack-doctor.py to run the delegation doctor

## Verification
- pnpm biome check .
- pre-push hook: biome check, next:proxy-guard, tailwind:check, typecheck, lint
- python3 -m json.tool .claude/settings.json
- bash -n .claude/hooks/orchestrator-boundary-check.sh
- python3 -m py_compile ~/.hermes/scripts/delegation-judge.py ~/.hermes/scripts/delegation-doctor.py ~/.hermes/scripts/agent-stack-doctor.py ~/.hermes/scripts/hud-plan-ingest.py
- python3 ~/.hermes/scripts/delegation-doctor.py
- delegation judge smoke test for production synthetic monitoring route

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/perf-loop` slash command for measurement-first performance optimization workflows.
  * Introduced `jovie-performance-hardening` skill for closed-loop performance detection and validation.

* **Chores**
  * Enhanced orchestration boundary safeguards and role-based execution controls.
  * Updated configuration to exclude certain migration files from processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->