### PR TITLE
ci(agents): reduce automation burn controls

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -66,6 +66,9 @@ The Linear automation path uses two workflows:
   - Trigger: `repository_dispatch` (`linear_todo_ready`) from `/api/webhooks/linear`
   - Behavior: waits for a CodeRabbit plan marker, assigns the issue to Codex in Linear, runs implementation, pushes a codex/* branch for auto-PR creation, then updates Linear to review
   - Includes bounded polling with configurable loop counts (`MAX_PLAN_WAIT_ATTEMPTS`, `PLAN_POLL_INTERVAL_SECONDS`)
+  - Burn controls: routine dispatch defaults to `model_tier: economy`; only an explicit
+    `premium` payload preserves the premium path
+  - Capacity controls: new agent work is deferred when 5 agent PRs are already open
 
 - **`linear-sync-on-merge.yml`**
   - Trigger: `pull_request.closed` (merged)
@@ -93,4 +96,8 @@ The `synthetic-monitoring.yml` workflow runs golden path tests against jov.ie on
 
 ## Agent Push-to-PR Bridge
 
-The `auto-pr-on-push.yml` workflow closes the handoff gap for agent branches (`codex/*`, `claude/*`, `codegen-bot/*`, `linear/*`) by creating a PR immediately after a push and enabling auto-merge.
+The `auto-pr-on-push.yml` workflow closes the handoff gap for agent branches
+(`codex/*`, `claude/*`, `codegen-bot/*`, `linear/*`) by creating a draft PR
+after a push. It enforces the same 5 open-agent-PR capacity cap before creating
+new draft PRs; downstream verification and agent pipeline jobs decide when a
+draft is ready and whether auto-merge is eligible.

--- a/.github/workflows/auto-pr-on-push.yml
+++ b/.github/workflows/auto-pr-on-push.yml
@@ -11,7 +11,7 @@
 # - Idempotent: skips if PR already exists for the branch
 # - Skips audit-only pushes (branches with only docs/audits and no code changes)
 # - Extracts Linear ticket ID from branch name for traceability
-# - Enables auto-merge so the PR flows through the full pipeline
+# - Creates a draft PR so verification can run before it enters the full pipeline
 # - Does NOT bypass any quality gates (CI, scope judge, auto-approve all still apply)
 
 name: Auto-PR on Agent Push
@@ -100,7 +100,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH: ${{ github.ref_name }}
-          MAX_OPEN_AGENT_PRS: '10'
+          MAX_OPEN_AGENT_PRS: '5'
           MAX_WAIT_MINUTES: '6'
         run: |
           echo "Branch: $BRANCH"

--- a/.github/workflows/auto-pr-on-push.yml
+++ b/.github/workflows/auto-pr-on-push.yml
@@ -35,7 +35,7 @@ jobs:
   open-pr:
     name: Open PR
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 12
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/auto-pr-on-push.yml
+++ b/.github/workflows/auto-pr-on-push.yml
@@ -124,7 +124,7 @@ jobs:
             # Use gh api (REST) instead of gh pr list (GraphQL) to avoid
             # App token scope issues with gh CLI's internal GraphQL queries
             OPEN_AGENT_PRS=$(gh api "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
-              | jq '[.[] | select(.head.ref | test("^(codex|codegen-bot|linear|claude)/") or test("^[^/]+/jov-[0-9]+-"; "i"))] | length')
+              | jq '[.[] | select(.head.ref | test("^(codex|codegen-bot|linear|claude)/") or test("^[^/]+/jov-[0-9]+([_-].+)?$"; "i"))] | length')
 
             echo "Open agent PRs: $OPEN_AGENT_PRS / $MAX_OPEN_AGENT_PRS (waited ${WAITED}s)"
 

--- a/.github/workflows/linear-ai-dispatcher.yml
+++ b/.github/workflows/linear-ai-dispatcher.yml
@@ -47,7 +47,7 @@ jobs:
       READY_LABEL: ${{ inputs.ready_label || 'automated' }}
       MAX_DISPATCH: ${{ inputs.max_dispatch || '2' }}
       DRY_RUN: ${{ inputs.dry_run || 'false' }}
-      MAX_OPEN_AGENT_PRS: '10'
+      MAX_OPEN_AGENT_PRS: '5'
     steps:
       - name: Generate Jovie Bot token
         id: app-token
@@ -157,7 +157,7 @@ jobs:
                     plan_ready: true,
                     verify_required: true,
                     simplify_bounded: true,
-                    model_tier: "premium"
+                    model_tier: "economy"
                   }
                 }' > "$DISPATCH_BODY"
 

--- a/.github/workflows/linear-ai-orchestrator.yml
+++ b/.github/workflows/linear-ai-orchestrator.yml
@@ -152,7 +152,7 @@ jobs:
           # Rate limit: don't start new Codex work if too many agent PRs are open
           MAX_OPEN_AGENT_PRS=5
           OPEN_AGENT_PRS=$(gh pr list --state open --json headRefName --limit 200 \
-            | jq '[.[] | select(.headRefName | test("^(codex|claude|codegen-bot|linear)/"))] | length')
+            | jq '[.[] | select(.headRefName | test("^(codex|claude|codegen-bot|linear)/") or test("^[^/]+/jov-[0-9]+-"; "i"))] | length')
 
           echo "Open agent PRs: $OPEN_AGENT_PRS / $MAX_OPEN_AGENT_PRS"
 

--- a/.github/workflows/linear-ai-orchestrator.yml
+++ b/.github/workflows/linear-ai-orchestrator.yml
@@ -152,7 +152,7 @@ jobs:
           # Rate limit: don't start new Codex work if too many agent PRs are open
           MAX_OPEN_AGENT_PRS=5
           OPEN_AGENT_PRS=$(gh pr list --state open --json headRefName --limit 200 \
-            | jq '[.[] | select(.headRefName | test("^(codex|claude|codegen-bot|linear)/") or test("^[^/]+/jov-[0-9]+-"; "i"))] | length')
+            | jq '[.[] | select(.headRefName | test("^(codex|claude|codegen-bot|linear)/") or test("^[^/]+/jov-[0-9]+([_-].+)?$"; "i"))] | length')
 
           echo "Open agent PRs: $OPEN_AGENT_PRS / $MAX_OPEN_AGENT_PRS"
 

--- a/.github/workflows/linear-ai-orchestrator.yml
+++ b/.github/workflows/linear-ai-orchestrator.yml
@@ -129,8 +129,8 @@ jobs:
           fi
 
           MODEL_TIER="${PAYLOAD_MODEL_TIER,,}"
-          if [[ "$MODEL_TIER" != "economy" ]]; then
-            MODEL_TIER="premium"
+          if [[ "$MODEL_TIER" != "premium" ]]; then
+            MODEL_TIER="economy"
           fi
 
           EXISTING_PR=$(gh pr list --state open --json number,title,body --jq '
@@ -150,7 +150,7 @@ jobs:
           fi
 
           # Rate limit: don't start new Codex work if too many agent PRs are open
-          MAX_OPEN_AGENT_PRS=10
+          MAX_OPEN_AGENT_PRS=5
           OPEN_AGENT_PRS=$(gh pr list --state open --json headRefName --limit 200 \
             | jq '[.[] | select(.headRefName | test("^(codex|claude|codegen-bot|linear)/"))] | length')
 
@@ -212,8 +212,8 @@ jobs:
           fi
 
           MODEL_TIER="${DEFAULT_MODEL_TIER,,}"
-          if [[ "$MODEL_TIER" != "economy" ]]; then
-            MODEL_TIER="premium"
+          if [[ "$MODEL_TIER" != "premium" ]]; then
+            MODEL_TIER="economy"
           fi
 
           if [[ -z "$LINEAR_API_KEY" ]]; then
@@ -351,6 +351,8 @@ jobs:
 
       - name: Run Claude Code for implementation
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa # v1
+        env:
+          JOVIE_AGENT_PROFILE: coder
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
@@ -375,13 +377,17 @@ jobs:
             4) Never add // biome-ignore.
             5) Find and fix sibling occurrences if this is a bug-pattern issue.
             6) Keep changes focused and minimal.
-            7) If simplify_bounded=true, run a small simplification pass on touched files only:
+            7) Keep context tight:
+               - use targeted rg searches before opening files
+               - read exact relevant files, diffs, and scoped rules only
+               - do not re-read broad repo docs or inject whole-repo context unless the failure requires it
+            8) If simplify_bounded=true, run a small simplification pass on touched files only:
                - remove dead imports/locals
                - flatten obvious nested conditionals
                - improve unclear local variable names
                - do not change behavior/API contracts
                - skip sensitive paths (.github/, drizzle/migrations/, auth/billing/security-critical)
-            8) Use model_tier as guidance for depth/cost profile:
+            9) Use model_tier as guidance for depth/cost profile:
                - premium: thorough and comprehensive
                - economy: concise and targeted
 

--- a/docs/AI_AUTOMATION.md
+++ b/docs/AI_AUTOMATION.md
@@ -14,6 +14,13 @@ This document explains the automation and labels used in this repo so agents can
 - Auto-merge is allowed only when CI is green and the PR is eligible.
 - Use the `auto-merge` label only for low-risk changes.
 
+## Agent burn controls
+
+- Routine Linear AI dispatch defaults to `model_tier: economy`; reserve `premium`
+  for explicit planner escalation.
+- Agent branch automation defers new work when 5 agent PRs are already open.
+- Implementation agents should inspect targeted diffs and exact relevant files instead of re-reading broad repo docs.
+
 ### Do not fight automation
 
 If an automated workflow opens a fix PR (e.g. Codex/CI healing):

--- a/docs/PR_WORKFLOW_GUIDE.md
+++ b/docs/PR_WORKFLOW_GUIDE.md
@@ -22,6 +22,11 @@ If neither is present, the workflows cannot find the Linear issue and state stay
 
 ## Creating PRs with Auto-merge
 
+Agent automation has a separate capacity guard: Linear dispatch, orchestrator
+pickup, and the agent push-to-PR bridge defer new agent work when 5 agent PRs
+are already open. The push-to-PR bridge creates draft PRs; verification and
+agent pipeline jobs decide when they are ready for auto-merge.
+
 ### Option 1: Helper Script (Recommended)
 ```bash
 ./scripts/create-pr.sh "feat: add user authentication" "Implement OAuth login with Google and GitHub providers"


### PR DESCRIPTION
## Summary

- cap Linear agent dispatch/orchestrator pickup and agent push-to-PR creation at 5 open agent PRs
- default routine Linear dispatch to `model_tier: economy` while preserving explicit `premium` escalation
- set `JOVIE_AGENT_PROFILE=coder` for orchestrated implementation and add tighter context-budget instructions
- update workflow docs and remove stale auto-merge wording from the draft PR bridge

## Test plan

- `git diff --check`
- `SHELLCHECK_OPTS='--exclude=SC2001,SC2016,SC2028,SC2034,SC2086,SC2126,SC2129,SC2329' actionlint .github/workflows/linear-ai-orchestrator.yml .github/workflows/linear-ai-dispatcher.yml .github/workflows/auto-pr-on-push.yml`
- `pnpm turbo typecheck --affected`
- `pnpm biome check --write .github/workflows/linear-ai-orchestrator.yml .github/workflows/linear-ai-dispatcher.yml .github/workflows/auto-pr-on-push.yml .github/workflows/README.md docs/AI_AUTOMATION.md docs/PR_WORKFLOW_GUIDE.md` (not applicable: these paths are ignored by Biome config)

## Risk

Touches `.github/` workflow automation, so this is a sensitive-path PR and should not auto-land without the repository's required workflow review gates passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent-generated pull requests are now created as drafts to allow verification before full pipeline entry.
  * Capacity controls limit concurrent agent pull requests to 5 open PRs.
  * Default AI dispatches use an economy model tier unless premium is explicitly requested.

* **Documentation**
  * Updated documentation to describe draft-PR behavior, the 5-PR capacity guardrail, and guidance for agents to target specific diffs/files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->