### PR TITLE
test(route-qa): expand profile mode routes

### DIFF
--- a/apps/web/scripts/route-qa.ts
+++ b/apps/web/scripts/route-qa.ts
@@ -506,10 +506,13 @@ export async function expandDynamicRoute(
 
   if (
     route === '/[username]/about' ||
+    route === '/[username]/alerts' ||
     route === '/[username]/claim' ||
     route === '/[username]/contact' ||
     route === '/[username]/listen' ||
     route === '/[username]/notifications' ||
+    route === '/[username]/pay' ||
+    route === '/[username]/releases' ||
     route === '/[username]/shop' ||
     route === '/[username]/subscribe' ||
     route === '/[username]/tip' ||


### PR DESCRIPTION
## Summary
- Expand route QA coverage for profile alert, pay, and releases route templates.
- Keeps route behavior unchanged; this only removes false blocked entries from QA route expansion.

## Verification
- `ROUTE_QA_FILTER=pay pnpm --filter @jovie/web run qa:routes`
- `ROUTE_QA_FILTER=alerts pnpm --filter @jovie/web run qa:routes`
- `ROUTE_QA_FILTER=releases pnpm --filter @jovie/web run qa:routes` (profile releases pass; existing dashboard dynamic release-id fixtures remain blocked)
- `pnpm biome check --write apps/web/scripts/route-qa.ts`
- `pnpm --filter @jovie/web run typecheck`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`

<!-- linear-issue-id:JOV-1849 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated QA testing logic to expand route coverage for profile-related pages, ensuring improved test validation for additional user features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->