### PR TITLE
ci(scope-judge): skip llm call without api key

### DIFF
--- a/.github/workflows/scope-judge.yml
+++ b/.github/workflows/scope-judge.yml
@@ -9,8 +9,11 @@
 # HOW IT WORKS:
 # 1. Extracts Linear ticket intent from PR body (populated by linear-ai-orchestrator)
 # 2. Gets the full diff of the PR
-# 3. Sends diff + intent to OpenAI GPT-4o for scope alignment judgment
-# 4. Reports pass/fail as a commit status (used as required check for auto-approve)
+# 3. If an API key is configured, sends diff + intent to OpenAI GPT-4o for
+#    scope alignment judgment
+# 4. If no API key is configured, skips the LLM call and reports a deterministic
+#    human-review status so CI does not burn tokens or fail inconclusively
+# 5. Reports pass/fail/skip as a commit status (used as required check for auto-approve)
 #
 # SAFETY:
 # - Read-only: does not modify code, only reports status
@@ -131,9 +134,23 @@ jobs:
 
           echo "diff=$(echo "$FULL_DIFF" | base64 -w0)" >> "$GITHUB_OUTPUT"
 
+      - name: Check scope judge API key
+        id: judge-key
+        if: steps.intent.outputs.has_intent == 'true' && steps.diff.outputs.has_diff == 'true'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [[ -n "$OPENAI_API_KEY" ]]; then
+            echo "Scope judge API key is configured."
+            echo "has_key=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Scope judge API key is not configured. Skipping LLM-backed scope judgment."
+            echo "has_key=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run scope alignment judge (OpenAI)
         id: judge
-        if: steps.intent.outputs.has_intent == 'true' && steps.diff.outputs.has_diff == 'true'
+        if: steps.intent.outputs.has_intent == 'true' && steps.diff.outputs.has_diff == 'true' && steps.judge-key.outputs.has_key == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
@@ -214,7 +231,7 @@ jobs:
           fi
 
       - name: Report scope judge status
-        if: steps.intent.outputs.has_intent == 'true' && steps.diff.outputs.has_diff == 'true'
+        if: steps.intent.outputs.has_intent == 'true' && steps.diff.outputs.has_diff == 'true' && steps.judge-key.outputs.has_key == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -240,6 +257,19 @@ jobs:
             -f state="$STATE" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
             -f description="$DESCRIPTION" \
+            -f context="scope-judge"
+
+      - name: Skip status (scope judge API key missing)
+        if: steps.intent.outputs.has_intent == 'true' && steps.diff.outputs.has_diff == 'true' && steps.judge-key.outputs.has_key != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          SHA="${{ github.event.pull_request.head.sha }}"
+
+          gh api repos/${{ github.repository }}/statuses/$SHA \
+            -f state="failure" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            -f description="Scope judge skipped - API key missing; human review required" \
             -f context="scope-judge"
 
       - name: Skip status (no Linear intent found)


### PR DESCRIPTION
<!-- linear-issue-id:JOV-1850 -->
<!-- linear-issue-identifier:JOV-1850 -->

## Summary
- Adds an explicit Scope Judge API-key check before the LLM-backed OpenAI request.
- Skips the LLM call when `OPENAI_API_KEY` is not configured, avoiding token burn and `ERROR: No response` output.
- Publishes a deterministic non-success `scope-judge` status requiring human review when the key is missing, so auto-approve cannot treat a skipped scope judge as a pass.

## Testing
- `actionlint .github/workflows/scope-judge.yml`
- `git diff --check`
- pre-push hook: `biome check .`, `pnpm --filter=@jovie/web run pre-push` (`next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`)
- `/review`: independent Codex review initially found that a success skip would bypass auto-approval; fixed by making the missing-key status `failure` / human-review required.

## Risk
- CI/release control plane. This PR is intentionally `needs-human` and should not auto-land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced scope judgment workflow to gracefully handle scenarios where API credentials are unavailable, adding explicit validation checks before attempting evaluation to prevent unexpected failures.
  * Improved workflow status reporting with dedicated feedback when scope judgment is skipped due to missing credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->