### PR TITLE
feat: add Hermes CLI worker dispatch

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,5 +1,6 @@
 self-hosted-runner:
   labels:
+    - hermes
     - ubicloud-standard-2
     - ubicloud-standard-8
 

--- a/.github/workflows/hermes-cli-worker.yml
+++ b/.github/workflows/hermes-cli-worker.yml
@@ -89,13 +89,29 @@ jobs:
           const eventName = process.env.EVENT_NAME;
           const validRuntimes = new Set(['codex-cli', 'claude-code', 'ruflo']);
 
+          function trimHyphens(value) {
+            let start = 0;
+            let end = value.length;
+
+            while (start < end && value[start] === '-') {
+              start += 1;
+            }
+
+            while (end > start && value[end - 1] === '-') {
+              end -= 1;
+            }
+
+            return value.slice(start, end);
+          }
+
           function slug(value) {
-            const safe = String(value || 'manual')
-              .toLowerCase()
-              .replace(/[^a-z0-9._/-]+/g, '-')
-              .replace(/\/+/g, '-')
-              .replace(/^-+|-+$/g, '')
-              .slice(0, 64);
+            const safe = trimHyphens(
+              String(value || 'manual')
+                .toLowerCase()
+                .replace(/[^a-z0-9._/-]+/g, '-')
+                .replace(/\/+/g, '-')
+                .slice(0, 64)
+            );
             return safe || 'manual';
           }
 

--- a/.github/workflows/hermes-cli-worker.yml
+++ b/.github/workflows/hermes-cli-worker.yml
@@ -1,0 +1,187 @@
+name: Hermes CLI Worker
+
+on:
+  repository_dispatch:
+    types: [hermes_cli_worker]
+  workflow_dispatch:
+    inputs:
+      source_url:
+        description: 'Source URL for the worker context'
+        required: false
+        type: string
+      kind:
+        description: 'Hermes task kind'
+        required: true
+        default: investigation
+        type: choice
+        options:
+          - investigation
+          - bug_patch
+          - code_review
+          - qa
+          - triage
+          - support_draft
+      runtime:
+        description: 'CLI runtime on the self-hosted runner'
+        required: true
+        default: codex-cli
+        type: choice
+        options:
+          - codex-cli
+          - claude-code
+          - ruflo
+      dry_run:
+        description: 'Build and validate the dispatch without launching a worker'
+        required: true
+        default: true
+        type: boolean
+
+permissions: {}
+
+concurrency:
+  group: hermes-cli-${{ github.event.client_payload.dispatchId || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  worker:
+    name: Run Hermes CLI Worker
+    runs-on: [self-hosted, hermes]
+    timeout-minutes: 120
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+    env:
+      JOVIE_AGENT_PROFILE: coder
+    steps:
+      - name: Generate Jovie Bot token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.JOVIE_BOT_APP_ID }}
+          private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
+
+      - name: Checkout main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Node.js and pnpm
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Materialize dispatch payload
+        id: payload
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CLIENT_PAYLOAD: ${{ toJson(github.event.client_payload) }}
+          INPUT_SOURCE_URL: ${{ inputs.source_url }}
+          INPUT_KIND: ${{ inputs.kind }}
+          INPUT_RUNTIME: ${{ inputs.runtime }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require('node:fs');
+
+          const payloadFile = `${process.env.RUNNER_TEMP}/hermes-payload.json`;
+          const eventName = process.env.EVENT_NAME;
+          const validRuntimes = new Set(['codex-cli', 'claude-code', 'ruflo']);
+
+          function slug(value) {
+            const safe = String(value || 'manual')
+              .toLowerCase()
+              .replace(/[^a-z0-9._/-]+/g, '-')
+              .replace(/\/+/g, '-')
+              .replace(/^-+|-+$/g, '')
+              .slice(0, 64);
+            return safe || 'manual';
+          }
+
+          const payload =
+            eventName === 'repository_dispatch'
+              ? JSON.parse(process.env.CLIENT_PAYLOAD || '{}')
+              : {
+                  dispatchId: `manual-${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}`,
+                  source: 'hermes',
+                  sourceId: `manual-${process.env.GITHUB_RUN_ID}-${process.env.GITHUB_RUN_ATTEMPT}`,
+                  sourceUrl: process.env.INPUT_SOURCE_URL || null,
+                  kind: process.env.INPUT_KIND,
+                  runtime: process.env.INPUT_RUNTIME,
+                  priority: 50,
+                  skills: ['autoplan'],
+                  allowedPaths: ['apps/web', 'scripts', '.github/workflows'],
+                  verification: ['pnpm --filter web exec tsc --noEmit'],
+                  dryRun: process.env.INPUT_DRY_RUN === 'true',
+                  prompt: 'Manual Hermes CLI worker dispatch.',
+                  owner: 'workflow_dispatch',
+                  branchName: `codex/hermes-${slug(process.env.INPUT_KIND)}-${process.env.GITHUB_RUN_ID}`,
+                  requestedAt: new Date().toISOString(),
+                };
+
+          if (
+            typeof payload.branchName !== 'string' ||
+            !/^codex\/[a-z0-9._/-]+$/.test(payload.branchName) ||
+            payload.branchName.includes('..')
+          ) {
+            throw new Error(`Invalid Hermes branch name: ${payload.branchName}`);
+          }
+
+          if (!validRuntimes.has(payload.runtime)) {
+            throw new Error(`Invalid Hermes runtime: ${payload.runtime}`);
+          }
+
+          fs.writeFileSync(payloadFile, `${JSON.stringify(payload, null, 2)}\n`);
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            [
+              `payload_file=${payloadFile}`,
+              `branch_name=${payload.branchName}`,
+              `dry_run=${payload.dryRun === true ? 'true' : 'false'}`,
+              '',
+            ].join('\n')
+          );
+          NODE
+
+      - name: Create worker branch
+        if: steps.payload.outputs.dry_run != 'true'
+        env:
+          BRANCH_NAME: ${{ steps.payload.outputs.branch_name }}
+        run: |
+          git checkout -b "$BRANCH_NAME"
+
+      - name: Run Hermes CLI worker
+        env:
+          HERMES_CLIENT_PAYLOAD_FILE: ${{ steps.payload.outputs.payload_file }}
+        run: |
+          pnpm --filter @jovie/web exec tsx scripts/hermes-cli-worker.ts \
+            --payload-file "$HERMES_CLIENT_PAYLOAD_FILE" \
+            --workspace "$GITHUB_WORKSPACE"
+
+      - name: Verify worker changes
+        if: steps.payload.outputs.dry_run != 'true'
+        run: |
+          if git diff --quiet && git diff --staged --quiet && [[ -z "$(git status --porcelain)" ]]; then
+            echo "No changes produced by Hermes worker; skipping verification."
+            exit 0
+          fi
+
+          bash scripts/automation-verify.sh affected
+
+      - name: Commit and push worker branch
+        if: steps.payload.outputs.dry_run != 'true'
+        env:
+          BRANCH_NAME: ${{ steps.payload.outputs.branch_name }}
+        run: |
+          if git diff --quiet && git diff --staged --quiet && [[ -z "$(git status --porcelain)" ]]; then
+            echo "No changes produced by Hermes worker; nothing to push."
+            exit 0
+          fi
+
+          git config user.name "jovie-bot[bot]"
+          git config user.email "jovie-bot[bot]@users.noreply.github.com"
+
+          git add -A
+          git commit -m "feat: run Hermes CLI worker"
+          git push origin "HEAD:${BRANCH_NAME}"

--- a/apps/web/app/api/hud/ai-ops/dispatch/route.ts
+++ b/apps/web/app/api/hud/ai-ops/dispatch/route.ts
@@ -1,0 +1,78 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { authorizeHud } from '@/lib/auth/hud';
+import { captureError } from '@/lib/error-tracking';
+import {
+  dispatchHermesWorker,
+  HermesDispatchConfigurationError,
+  HermesDispatchGitHubError,
+} from '@/lib/hermes/dispatch';
+import { logger } from '@/lib/utils/logger';
+
+export const runtime = 'nodejs';
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+export async function POST(request: NextRequest) {
+  try {
+    const kioskToken = request.nextUrl.searchParams.get('kiosk');
+    const auth = await authorizeHud(kioskToken);
+
+    if (!auth.ok) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    if (auth.mode !== 'admin') {
+      return NextResponse.json(
+        { error: 'HUD kiosk mode cannot dispatch AI ops workers' },
+        { status: 403, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const body = (await request.json()) as unknown;
+    const result = await dispatchHermesWorker(body);
+
+    return NextResponse.json(
+      { dispatched: true, ...result },
+      { status: 202, headers: NO_STORE_HEADERS }
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: 'Invalid Hermes dispatch request', issues: error.issues },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    if (error instanceof HermesDispatchConfigurationError) {
+      return NextResponse.json(
+        { error: error.message },
+        { status: 503, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    if (error instanceof HermesDispatchGitHubError) {
+      logger.error('[HUD AI Ops] GitHub dispatch failed', {
+        status: error.status,
+        message: error.message,
+      });
+      return NextResponse.json(
+        { error: 'Hermes worker dispatch failed' },
+        { status: 502, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    await captureError('HUD AI ops dispatch route failed', error, {
+      route: '/api/hud/ai-ops/dispatch',
+    });
+    logger.error('Error in HUD AI ops dispatch API:', error);
+    return NextResponse.json(
+      { error: 'Failed to dispatch Hermes worker' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/hud/HudDashboardClient.tsx
+++ b/apps/web/app/hud/HudDashboardClient.tsx
@@ -1,7 +1,9 @@
 'use client';
 
+import { Loader2, Rocket } from 'lucide-react';
 import Image from 'next/image';
 import type { ReactNode } from 'react';
+import { useState } from 'react';
 import { ContentMetricCard } from '@/components/molecules/ContentMetricCard';
 import { ContentMetricRow } from '@/components/molecules/ContentMetricRow';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
@@ -10,11 +12,21 @@ import {
   getDefaultStatusTone,
   getDeploymentLabel,
   getDeploymentTone,
+  type HudTone,
 } from '@/lib/hud/tone-determination';
+import type { HermesCliRuntime, HermesDispatchRequest } from '@/types/ai-ops';
 import type { HudMetrics } from '@/types/hud';
 import { HudClockClient } from './HudClockClient';
 import { HudStatusPill } from './HudStatusPill';
 import { useHudMetricsQuery } from './useHudMetricsQuery';
+
+type HermesDispatchKind =
+  | 'triage'
+  | 'bug_patch'
+  | 'code_review'
+  | 'qa'
+  | 'investigation'
+  | 'support_draft';
 
 function formatUsd(value: number): string {
   return value.toLocaleString('en-US', {
@@ -64,6 +76,32 @@ function getDeploymentDetail(deployments: HudMetrics['deployments']): string {
   return deployments.errorMessage ?? '\u2014';
 }
 
+function getAiOpsTone(aiOps: HudMetrics['aiOps']): HudTone {
+  if (aiOps.counts.failed > 0 || aiOps.counts.blocked > 0) return 'bad';
+  if (aiOps.counts.stale > 0 || aiOps.availability === 'partial') {
+    return 'warning';
+  }
+  if (aiOps.availability === 'available') return 'good';
+  return 'neutral';
+}
+
+function getAiOpsLabel(aiOps: HudMetrics['aiOps']): string {
+  if (aiOps.counts.failed > 0) return 'Failed';
+  if (aiOps.counts.blocked > 0) return 'Blocked';
+  if (aiOps.counts.stale > 0) return 'Stale';
+  if (aiOps.counts.running > 0) return 'Running';
+  if (aiOps.dispatch.available) return 'Ready';
+  return 'Not configured';
+}
+
+function getDefaultSkills(kind: HermesDispatchKind): readonly string[] {
+  if (kind === 'qa') return ['qa'];
+  if (kind === 'code_review') return ['review'];
+  if (kind === 'investigation') return ['investigate'];
+  if (kind === 'triage') return ['autoplan'];
+  return ['autoplan', 'investigate'];
+}
+
 function SectionEyebrow({
   children,
 }: Readonly<{ readonly children: ReactNode }>) {
@@ -101,6 +139,165 @@ function DeploymentRow({
   );
 }
 
+function AiOpsItemRow({
+  item,
+}: Readonly<{
+  readonly item: HudMetrics['aiOps']['blockers'][number];
+}>) {
+  return (
+    <div className='flex items-start justify-between gap-3 rounded-xl border border-subtle bg-surface-0 px-3 py-2.5'>
+      <div className='min-w-0'>
+        <p className='truncate text-[13px] font-semibold text-primary-token'>
+          {item.summary}
+        </p>
+        <p className='mt-1 text-[11px] uppercase tracking-[0.08em] text-tertiary-token'>
+          {item.source} / {item.status}
+        </p>
+      </div>
+      <p className='shrink-0 text-right text-[11px] text-tertiary-token'>
+        {formatDeploymentTime(item.updatedAt)}
+      </p>
+    </div>
+  );
+}
+
+function HermesDispatchControls({
+  aiOps,
+  onDispatchComplete,
+}: Readonly<{
+  readonly aiOps: HudMetrics['aiOps'];
+  readonly onDispatchComplete: () => void;
+}>) {
+  const [sourceUrl, setSourceUrl] = useState('');
+  const [runtime, setRuntime] = useState<HermesCliRuntime>('codex-cli');
+  const [kind, setKind] = useState<HermesDispatchKind>('investigation');
+  const [isDispatching, setIsDispatching] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  if (!aiOps.dispatch.available) {
+    return (
+      <p className='text-[13px] leading-5 text-secondary-token'>
+        {aiOps.dispatch.unavailableReason ??
+          'Hermes dispatch is not configured.'}
+      </p>
+    );
+  }
+
+  async function dispatchWorker(dryRun: boolean) {
+    setIsDispatching(true);
+    setMessage(null);
+
+    const payload: HermesDispatchRequest = {
+      source: 'hermes',
+      sourceId: sourceUrl.trim() || `hud-${Date.now()}`,
+      sourceUrl: sourceUrl.trim() || null,
+      kind,
+      runtime,
+      priority: kind === 'bug_patch' ? 80 : 60,
+      skills: getDefaultSkills(kind),
+      allowedPaths: ['apps/web', 'scripts', '.github/workflows'],
+      verification: ['pnpm --filter web exec tsc --noEmit'],
+      dryRun,
+      prompt: sourceUrl.trim()
+        ? `Use the linked work item as source context: ${sourceUrl.trim()}`
+        : 'Pick up the highest-value scoped internal AI ops task from the provided context.',
+      owner: 'HUD',
+    };
+
+    try {
+      const response = await fetch('/api/hud/ai-ops/dispatch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const result = (await response.json()) as {
+        error?: string;
+        branchName?: string;
+      };
+
+      if (!response.ok) {
+        throw new Error(result.error ?? `Dispatch failed (${response.status})`);
+      }
+
+      setMessage(
+        dryRun
+          ? 'Dry run dispatched to Hermes worker workflow.'
+          : `Worker dispatched on ${result.branchName ?? 'agent branch'}.`
+      );
+      onDispatchComplete();
+    } catch (error) {
+      setMessage(
+        error instanceof Error ? error.message : 'Hermes dispatch failed.'
+      );
+    } finally {
+      setIsDispatching(false);
+    }
+  }
+
+  return (
+    <div className='grid gap-3'>
+      <div className='grid gap-2 sm:grid-cols-[minmax(0,1fr)_160px_180px]'>
+        <input
+          type='url'
+          value={sourceUrl}
+          onChange={event => setSourceUrl(event.target.value)}
+          placeholder='Linear, GitHub, or Sentry URL'
+          className='min-h-10 rounded-lg border border-subtle bg-surface-0 px-3 text-[13px] text-primary-token outline-none'
+        />
+        <select
+          value={runtime}
+          onChange={event => setRuntime(event.target.value as HermesCliRuntime)}
+          className='min-h-10 rounded-lg border border-subtle bg-surface-0 px-3 text-[13px] text-primary-token outline-none'
+        >
+          {aiOps.dispatch.runtimes.map(option => (
+            <option key={option} value={option}>
+              {option}
+            </option>
+          ))}
+        </select>
+        <select
+          value={kind}
+          onChange={event => setKind(event.target.value as HermesDispatchKind)}
+          className='min-h-10 rounded-lg border border-subtle bg-surface-0 px-3 text-[13px] text-primary-token outline-none'
+        >
+          <option value='investigation'>investigation</option>
+          <option value='bug_patch'>bug_patch</option>
+          <option value='code_review'>code_review</option>
+          <option value='qa'>qa</option>
+          <option value='triage'>triage</option>
+          <option value='support_draft'>support_draft</option>
+        </select>
+      </div>
+      <div className='flex flex-wrap gap-2'>
+        <button
+          type='button'
+          onClick={() => void dispatchWorker(false)}
+          disabled={isDispatching}
+          className='inline-flex min-h-10 items-center gap-2 rounded-lg border border-subtle bg-primary px-3 text-[13px] font-semibold text-primary-foreground disabled:cursor-not-allowed disabled:opacity-60'
+        >
+          {isDispatching ? (
+            <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
+          ) : (
+            <Rocket className='h-4 w-4' aria-hidden='true' />
+          )}
+          Dispatch worker
+        </button>
+        <button
+          type='button'
+          onClick={() => void dispatchWorker(true)}
+          disabled={isDispatching}
+          className='inline-flex min-h-10 items-center gap-2 rounded-lg border border-subtle bg-surface-0 px-3 text-[13px] font-semibold text-primary-token disabled:cursor-not-allowed disabled:opacity-60'
+        >
+          Dry run
+        </button>
+      </div>
+      {message ? (
+        <p className='text-[13px] leading-5 text-secondary-token'>{message}</p>
+      ) : null}
+    </div>
+  );
+}
+
 export interface HudDashboardClientProps {
   readonly initialMetrics: HudMetrics;
   readonly hudUrl: string;
@@ -112,12 +309,17 @@ export function HudDashboardClient({
   hudUrl,
   kioskToken,
 }: HudDashboardClientProps) {
-  const { data: metrics } = useHudMetricsQuery(initialMetrics, kioskToken);
+  const { data: metrics, refetch } = useHudMetricsQuery(
+    initialMetrics,
+    kioskToken
+  );
 
   const defaultTone = getDefaultStatusTone(metrics.overview.defaultStatus);
   const deploymentsTone = getDeploymentTone(metrics.deployments);
   const deploymentLabel = getDeploymentLabel(metrics.deployments);
   const deploymentDetail = getDeploymentDetail(metrics.deployments);
+  const aiOpsTone = getAiOpsTone(metrics.aiOps);
+  const aiOpsLabel = getAiOpsLabel(metrics.aiOps);
 
   return (
     <div className='mx-auto flex w-full max-w-[1560px] flex-col gap-4 px-4 py-4 sm:px-6 sm:py-6 xl:px-8'>
@@ -263,6 +465,104 @@ export function HudDashboardClient({
           </div>
         </ContentSurfaceCard>
       </div>
+
+      <ContentSurfaceCard surface='details' className='space-y-5 p-4 sm:p-5'>
+        <div className='flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between'>
+          <div className='space-y-1'>
+            <SectionEyebrow>AI ops</SectionEyebrow>
+            <p className='text-[24px] font-[620] leading-none text-primary-token sm:text-[28px]'>
+              Hermes control plane
+            </p>
+            <p className='text-[13px] leading-5 text-secondary-token'>
+              {metrics.aiOps.mergeQueue.openAgentPrs} /{' '}
+              {metrics.aiOps.mergeQueue.openAgentPrThreshold} agent PRs open
+            </p>
+          </div>
+          <HudStatusPill label={aiOpsLabel} tone={aiOpsTone} />
+        </div>
+
+        <div className='grid gap-3 sm:grid-cols-3 lg:grid-cols-6'>
+          <ContentMetricRow
+            label='Queued'
+            value={metrics.aiOps.counts.queued.toLocaleString('en-US')}
+          />
+          <ContentMetricRow
+            label='Running'
+            value={metrics.aiOps.counts.running.toLocaleString('en-US')}
+          />
+          <ContentMetricRow
+            label='Review'
+            value={metrics.aiOps.counts.review.toLocaleString('en-US')}
+          />
+          <ContentMetricRow
+            label='Blocked'
+            value={metrics.aiOps.counts.blocked.toLocaleString('en-US')}
+          />
+          <ContentMetricRow
+            label='Failed'
+            value={metrics.aiOps.counts.failed.toLocaleString('en-US')}
+          />
+          <ContentMetricRow
+            label='Stale'
+            value={metrics.aiOps.counts.stale.toLocaleString('en-US')}
+          />
+        </div>
+
+        <div className='grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.9fr)]'>
+          <div className='space-y-3'>
+            <div className='flex items-center justify-between gap-3'>
+              <SectionEyebrow>Blockers</SectionEyebrow>
+              <p className='text-[12px] text-secondary-token'>
+                {metrics.aiOps.availability}
+              </p>
+            </div>
+            {metrics.aiOps.blockers.length > 0 ? (
+              <div className='grid gap-2'>
+                {metrics.aiOps.blockers.slice(0, 4).map(item => (
+                  <AiOpsItemRow
+                    key={`${item.source}-${item.kind}-${item.url ?? item.summary}`}
+                    item={item}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className='text-[13px] text-secondary-token'>
+                No blocked worker runs or agent PRs.
+              </p>
+            )}
+          </div>
+
+          <div className='space-y-3'>
+            <SectionEyebrow>Dispatch</SectionEyebrow>
+            {metrics.accessMode === 'admin' ? (
+              <HermesDispatchControls
+                aiOps={metrics.aiOps}
+                onDispatchComplete={() => {
+                  void refetch();
+                }}
+              />
+            ) : (
+              <p className='text-[13px] leading-5 text-secondary-token'>
+                Admin access required for worker dispatch.
+              </p>
+            )}
+          </div>
+        </div>
+
+        {metrics.aiOps.recommendations.length > 0 ? (
+          <div className='border-t border-subtle pt-4'>
+            <SectionEyebrow>Next actions</SectionEyebrow>
+            <div className='mt-3 grid gap-2'>
+              {metrics.aiOps.recommendations.slice(0, 3).map(item => (
+                <AiOpsItemRow
+                  key={`${item.source}-${item.priority}-${item.summary}`}
+                  item={item}
+                />
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </ContentSurfaceCard>
 
       <ContentSurfaceCard surface='details' className='p-4 sm:p-5'>
         <div className='flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between'>

--- a/apps/web/lib/hermes/dispatch.ts
+++ b/apps/web/lib/hermes/dispatch.ts
@@ -1,0 +1,226 @@
+import 'server-only';
+
+import { z } from 'zod';
+import { env } from '@/lib/env-server';
+import { serverFetch } from '@/lib/http/server-fetch';
+import type {
+  HermesCliRuntime,
+  HermesDispatchAvailability,
+  HermesDispatchPayload,
+  HermesDispatchResult,
+} from '@/types/ai-ops';
+
+const DISPATCH_TIMEOUT_MS = 5000;
+const HERMES_DISPATCH_EVENT = 'hermes_cli_worker' as const;
+const HERMES_RUNTIMES: readonly HermesCliRuntime[] = [
+  'codex-cli',
+  'claude-code',
+  'ruflo',
+];
+const DEFAULT_SKILLS = ['autoplan'] as const;
+const DEFAULT_ALLOWED_PATHS = ['apps/web', 'scripts', '.github/workflows'];
+const DEFAULT_VERIFICATION = ['pnpm --filter web exec tsc --noEmit'] as const;
+
+const SAFE_PATH_REGEX = /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[a-zA-Z0-9._/@-]+$/;
+const SAFE_SKILL_REGEX = /^\/?[a-z][a-z0-9-]{1,48}$/;
+const SAFE_VERIFICATION_PREFIXES = [
+  'pnpm ',
+  'pnpm --filter ',
+  'bash scripts/automation-verify.sh ',
+] as const;
+
+export class HermesDispatchConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HermesDispatchConfigurationError';
+  }
+}
+
+export class HermesDispatchGitHubError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number
+  ) {
+    super(message);
+    this.name = 'HermesDispatchGitHubError';
+  }
+}
+
+const HermesDispatchRequestSchema = z.object({
+  source: z.enum(['github', 'linear', 'sentry', 'hermes', 'ci']),
+  sourceId: z.string().trim().min(1).max(160).optional(),
+  sourceUrl: z
+    .union([z.string().trim().url(), z.literal(''), z.null()])
+    .optional(),
+  kind: z.enum([
+    'triage',
+    'bug_patch',
+    'code_review',
+    'qa',
+    'investigation',
+    'support_draft',
+  ]),
+  runtime: z.enum(HERMES_RUNTIMES),
+  priority: z.number().int().min(0).max(100).optional(),
+  skills: z.array(z.string().trim().regex(SAFE_SKILL_REGEX)).max(8).optional(),
+  allowedPaths: z
+    .array(z.string().trim().regex(SAFE_PATH_REGEX))
+    .max(20)
+    .optional(),
+  verification: z
+    .array(
+      z
+        .string()
+        .trim()
+        .min(1)
+        .max(180)
+        .refine(
+          command =>
+            SAFE_VERIFICATION_PREFIXES.some(prefix =>
+              command.startsWith(prefix)
+            ),
+          'Verification commands must use pnpm or scripts/automation-verify.sh'
+        )
+    )
+    .max(8)
+    .optional(),
+  dryRun: z.boolean().optional(),
+  prompt: z.string().trim().max(4000).optional(),
+  owner: z.union([z.string().trim().min(1).max(120), z.null()]).optional(),
+});
+
+function normalizeSkill(skill: string): string {
+  return skill.trim().replace(/^\//, '');
+}
+
+function slugify(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .replace(/[^a-z0-9._/-]+/g, '-')
+    .replace(/\/+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+
+  return slug.length > 0 ? slug : 'manual';
+}
+
+function getDispatchRepoConfig():
+  | { configured: true; owner: string; repo: string; token: string }
+  | { configured: false; reason: string } {
+  const token = env.GH_DISPATCH_TOKEN;
+  const owner = env.HUD_GITHUB_OWNER ?? env.VERCEL_GIT_REPO_OWNER;
+  const repo = env.HUD_GITHUB_REPO ?? env.VERCEL_GIT_REPO_SLUG;
+
+  if (!token) {
+    return {
+      configured: false,
+      reason: 'GH_DISPATCH_TOKEN is not configured.',
+    };
+  }
+  if (!owner || !repo) {
+    return {
+      configured: false,
+      reason:
+        'HUD_GITHUB_OWNER/HUD_GITHUB_REPO or VERCEL_GIT_REPO_OWNER/VERCEL_GIT_REPO_SLUG must be configured.',
+    };
+  }
+
+  return { configured: true, owner, repo, token };
+}
+
+export function getHermesDispatchAvailability(): HermesDispatchAvailability {
+  const config = getDispatchRepoConfig();
+
+  return {
+    available: config.configured,
+    unavailableReason: config.configured ? null : config.reason,
+    runtimes: HERMES_RUNTIMES,
+  };
+}
+
+export function normalizeHermesDispatchRequest(
+  input: unknown,
+  requestedAt = new Date()
+): HermesDispatchPayload {
+  const parsed = HermesDispatchRequestSchema.parse(input);
+  const dispatchId = crypto.randomUUID();
+  const sourceId =
+    parsed.sourceId ??
+    (parsed.sourceUrl && parsed.sourceUrl.length > 0
+      ? parsed.sourceUrl
+      : dispatchId);
+  const branchSlug = slugify(`${parsed.kind}-${sourceId}`);
+
+  return {
+    source: parsed.source,
+    sourceId,
+    sourceUrl:
+      typeof parsed.sourceUrl === 'string' && parsed.sourceUrl.length > 0
+        ? parsed.sourceUrl
+        : null,
+    kind: parsed.kind,
+    runtime: parsed.runtime,
+    priority: parsed.priority ?? 50,
+    skills:
+      parsed.skills && parsed.skills.length > 0
+        ? parsed.skills.map(normalizeSkill)
+        : [...DEFAULT_SKILLS],
+    allowedPaths:
+      parsed.allowedPaths && parsed.allowedPaths.length > 0
+        ? parsed.allowedPaths
+        : [...DEFAULT_ALLOWED_PATHS],
+    verification:
+      parsed.verification && parsed.verification.length > 0
+        ? parsed.verification
+        : [...DEFAULT_VERIFICATION],
+    dryRun: parsed.dryRun ?? false,
+    prompt: parsed.prompt ?? '',
+    owner: parsed.owner ?? null,
+    dispatchId,
+    branchName: `codex/hermes-${branchSlug}-${dispatchId.slice(0, 8)}`,
+    requestedAt: requestedAt.toISOString(),
+  };
+}
+
+export async function dispatchHermesWorker(
+  request: unknown
+): Promise<HermesDispatchResult> {
+  const config = getDispatchRepoConfig();
+  if (!config.configured) {
+    throw new HermesDispatchConfigurationError(config.reason);
+  }
+
+  const payload = normalizeHermesDispatchRequest(request);
+  const response = await serverFetch(
+    `https://api.github.com/repos/${encodeURIComponent(config.owner)}/${encodeURIComponent(config.repo)}/dispatches`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `token ${config.token}`,
+        Accept: 'application/vnd.github.v3+json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        event_type: HERMES_DISPATCH_EVENT,
+        client_payload: payload,
+      }),
+      timeoutMs: DISPATCH_TIMEOUT_MS,
+      context: 'GitHub repository dispatch for Hermes CLI worker',
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new HermesDispatchGitHubError(
+      `GitHub dispatch failed (${response.status}): ${errorText}`,
+      response.status
+    );
+  }
+
+  return {
+    dispatchId: payload.dispatchId,
+    branchName: payload.branchName,
+    eventType: HERMES_DISPATCH_EVENT,
+    dryRun: payload.dryRun,
+  };
+}

--- a/apps/web/lib/hermes/dispatch.ts
+++ b/apps/web/lib/hermes/dispatch.ts
@@ -93,13 +93,29 @@ function normalizeSkill(skill: string): string {
   return skill.trim().replace(/^\//, '');
 }
 
+function trimHyphens(value: string): string {
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && value[start] === '-') {
+    start += 1;
+  }
+
+  while (end > start && value[end - 1] === '-') {
+    end -= 1;
+  }
+
+  return value.slice(start, end);
+}
+
 function slugify(value: string): string {
-  const slug = value
-    .toLowerCase()
-    .replace(/[^a-z0-9._/-]+/g, '-')
-    .replace(/\/+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 64);
+  const slug = trimHyphens(
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9._/-]+/g, '-')
+      .replace(/\/+/g, '-')
+      .slice(0, 64)
+  );
 
   return slug.length > 0 ? slug : 'manual';
 }

--- a/apps/web/lib/hud/ai-ops.ts
+++ b/apps/web/lib/hud/ai-ops.ts
@@ -1,0 +1,450 @@
+import 'server-only';
+
+import { env } from '@/lib/env-server';
+import { getHermesDispatchAvailability } from '@/lib/hermes/dispatch';
+import { serverFetch } from '@/lib/http/server-fetch';
+import type {
+  HermesAiOpsCounts,
+  HermesAiOpsItem,
+  HermesAiOpsSourceStatus,
+  HermesAiOpsStatus,
+  HermesAiOpsSummary,
+} from '@/types/ai-ops';
+
+const AGENT_PR_THRESHOLD = 10;
+const HERMES_WORKER_WORKFLOW = 'hermes-cli-worker.yml';
+const STALE_RUN_MS = 2 * 60 * 60 * 1000;
+const STALE_PR_MS = 48 * 60 * 60 * 1000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizeIso(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed)
+      ? new Date().toISOString()
+      : new Date(parsed).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function emptyCounts(): HermesAiOpsCounts {
+  return {
+    queued: 0,
+    running: 0,
+    blocked: 0,
+    review: 0,
+    done: 0,
+    failed: 0,
+    stale: 0,
+  };
+}
+
+function countStatuses(items: readonly HermesAiOpsItem[]): HermesAiOpsCounts {
+  const counts: Record<HermesAiOpsStatus, number> = { ...emptyCounts() };
+  for (const item of items) {
+    counts[item.status] += 1;
+  }
+  return counts;
+}
+
+function isAgentBranch(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  return (
+    /^(codex|claude|codegen-bot|linear)\//.test(value) ||
+    /(^|\/)jov-[0-9]+/i.test(value)
+  );
+}
+
+function hasBlockingLabel(labels: unknown): boolean {
+  if (!Array.isArray(labels)) return false;
+  return labels.some(label => {
+    if (!isRecord(label)) return false;
+    const name = typeof label.name === 'string' ? label.name : '';
+    return name === 'needs-human' || name === 'human-review-required';
+  });
+}
+
+function formatWorkflowStatus(
+  status: unknown,
+  conclusion: unknown,
+  createdAtIso: string,
+  now: Date
+): HermesAiOpsStatus {
+  const statusText = String(status);
+  const conclusionText = String(conclusion);
+  const ageMs = now.getTime() - Date.parse(createdAtIso);
+
+  if (Number.isFinite(ageMs) && ageMs > STALE_RUN_MS) {
+    if (statusText === 'queued' || statusText === 'in_progress') return 'stale';
+  }
+  if (statusText === 'queued') return 'queued';
+  if (statusText === 'in_progress') return 'running';
+  if (statusText === 'completed') {
+    if (conclusionText === 'success') return 'done';
+    if (
+      conclusionText === 'failure' ||
+      conclusionText === 'cancelled' ||
+      conclusionText === 'timed_out'
+    ) {
+      return 'failed';
+    }
+  }
+
+  return 'running';
+}
+
+function formatPrStatus(
+  pr: Record<string, unknown>,
+  now: Date
+): HermesAiOpsStatus {
+  const updatedAtIso = normalizeIso(pr.updated_at);
+  const ageMs = now.getTime() - Date.parse(updatedAtIso);
+
+  if (Number.isFinite(ageMs) && ageMs > STALE_PR_MS) return 'stale';
+  if (hasBlockingLabel(pr.labels)) return 'blocked';
+  if (pr.draft === true) return 'running';
+  return 'review';
+}
+
+async function fetchGitHubJson(
+  path: string,
+  context: string
+): Promise<
+  | { ok: true; payload: unknown }
+  | { ok: false; errorMessage: string; status?: number }
+> {
+  const token = env.HUD_GITHUB_TOKEN;
+  const owner = env.HUD_GITHUB_OWNER;
+  const repo = env.HUD_GITHUB_REPO;
+
+  if (!token || !owner || !repo) {
+    return { ok: false, errorMessage: 'GitHub HUD source not configured.' };
+  }
+
+  try {
+    const response = await serverFetch(
+      `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}${path}`,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        cache: 'no-store',
+        context,
+        retry: {
+          maxRetries: 1,
+          baseDelayMs: 500,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status,
+        errorMessage: `GitHub API error (${response.status})`,
+      };
+    }
+
+    return { ok: true, payload: await response.json() };
+  } catch (error) {
+    return {
+      ok: false,
+      errorMessage: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+function normalizePrItems(payload: unknown, now: Date): HermesAiOpsItem[] {
+  const prs = Array.isArray(payload) ? payload : [];
+
+  return prs
+    .map((pr): HermesAiOpsItem | null => {
+      if (!isRecord(pr) || !isRecord(pr.head)) return null;
+      if (!isAgentBranch(pr.head.ref)) return null;
+
+      const number = typeof pr.number === 'number' ? pr.number : null;
+      const title = typeof pr.title === 'string' ? pr.title : 'Agent PR';
+      const url = typeof pr.html_url === 'string' ? pr.html_url : null;
+      const user =
+        isRecord(pr.user) && typeof pr.user.login === 'string'
+          ? pr.user.login
+          : null;
+
+      return {
+        source: 'github',
+        kind: 'pr',
+        status: formatPrStatus(pr, now),
+        priority: hasBlockingLabel(pr.labels) ? 90 : 60,
+        url,
+        owner: user,
+        summary: number == null ? title : `#${number} ${title}`,
+        updatedAt: normalizeIso(pr.updated_at),
+      };
+    })
+    .filter((item): item is HermesAiOpsItem => item !== null);
+}
+
+function normalizeWorkflowRuns(payload: unknown, now: Date): HermesAiOpsItem[] {
+  if (!isRecord(payload) || !Array.isArray(payload.workflow_runs)) return [];
+
+  return payload.workflow_runs
+    .map((run): HermesAiOpsItem | null => {
+      if (!isRecord(run)) return null;
+      const id = typeof run.id === 'number' ? run.id : null;
+      if (id == null) return null;
+
+      const branch =
+        typeof run.head_branch === 'string' ? run.head_branch : null;
+      const actor =
+        isRecord(run.actor) && typeof run.actor.login === 'string'
+          ? run.actor.login
+          : null;
+      const status = formatWorkflowStatus(
+        run.status,
+        run.conclusion,
+        normalizeIso(run.created_at),
+        now
+      );
+
+      return {
+        source: 'ci',
+        kind: 'workflow',
+        status,
+        priority: status === 'failed' || status === 'stale' ? 85 : 50,
+        url: typeof run.html_url === 'string' ? run.html_url : null,
+        owner: actor,
+        summary: branch
+          ? `Hermes CLI worker on ${branch}`
+          : `Hermes CLI worker run ${id}`,
+        updatedAt: normalizeIso(run.updated_at ?? run.created_at),
+      };
+    })
+    .filter((item): item is HermesAiOpsItem => item !== null);
+}
+
+function sourceStatus(
+  configured: boolean,
+  itemCount: number,
+  errorMessage?: string
+): HermesAiOpsSourceStatus {
+  return {
+    availability: !configured
+      ? 'not_configured'
+      : errorMessage
+        ? 'error'
+        : 'available',
+    configured,
+    itemCount,
+    ...(errorMessage ? { errorMessage } : {}),
+  };
+}
+
+function buildRecommendations(params: {
+  blockers: readonly HermesAiOpsItem[];
+  dispatchAvailable: boolean;
+  dispatchUnavailableReason: string | null;
+  mergePressure: 'normal' | 'elevated' | 'high';
+  runningCount: number;
+  generatedAtIso: string;
+}): HermesAiOpsItem[] {
+  const recommendations: HermesAiOpsItem[] = [];
+
+  if (!params.dispatchAvailable) {
+    recommendations.push({
+      source: 'hermes',
+      kind: 'recommendation',
+      status: 'blocked',
+      priority: 100,
+      url: null,
+      owner: 'Hermes',
+      summary:
+        params.dispatchUnavailableReason ??
+        'Configure GitHub dispatch credentials before launching workers.',
+      updatedAt: params.generatedAtIso,
+    });
+  }
+
+  if (params.blockers.length > 0) {
+    recommendations.push({
+      source: 'hermes',
+      kind: 'recommendation',
+      status: 'blocked',
+      priority: 90,
+      url: params.blockers[0]?.url ?? null,
+      owner: 'Hermes',
+      summary: `Clear ${params.blockers.length} blocked or failed automation item${params.blockers.length === 1 ? '' : 's'} before increasing worker volume.`,
+      updatedAt: params.generatedAtIso,
+    });
+  }
+
+  if (params.mergePressure !== 'normal') {
+    recommendations.push({
+      source: 'hermes',
+      kind: 'recommendation',
+      status: 'review',
+      priority: params.mergePressure === 'high' ? 95 : 75,
+      url: null,
+      owner: 'Hermes',
+      summary:
+        params.mergePressure === 'high'
+          ? 'Merge queue pressure is high; review or land agent PRs before dispatching more.'
+          : 'Merge queue pressure is elevated; prefer review work over new worker starts.',
+      updatedAt: params.generatedAtIso,
+    });
+  }
+
+  if (
+    params.dispatchAvailable &&
+    params.blockers.length === 0 &&
+    params.runningCount === 0
+  ) {
+    recommendations.push({
+      source: 'hermes',
+      kind: 'recommendation',
+      status: 'queued',
+      priority: 50,
+      url: null,
+      owner: 'Hermes',
+      summary:
+        'Dispatch one focused Codex or Claude worker from HUD when a scoped issue is ready.',
+      updatedAt: params.generatedAtIso,
+    });
+  }
+
+  return recommendations;
+}
+
+export async function getHudAiOpsSummary(
+  now = new Date()
+): Promise<HermesAiOpsSummary> {
+  const generatedAtIso = now.toISOString();
+  const dispatch = getHermesDispatchAvailability();
+  const githubConfigured = Boolean(
+    env.HUD_GITHUB_TOKEN && env.HUD_GITHUB_OWNER && env.HUD_GITHUB_REPO
+  );
+
+  if (!githubConfigured) {
+    const blockers: HermesAiOpsItem[] = [];
+    const recommendations = buildRecommendations({
+      blockers,
+      dispatchAvailable: dispatch.available,
+      dispatchUnavailableReason: dispatch.unavailableReason,
+      mergePressure: 'normal',
+      runningCount: 0,
+      generatedAtIso,
+    });
+
+    return {
+      availability: 'not_configured',
+      generatedAtIso,
+      counts: emptyCounts(),
+      dispatch,
+      mergeQueue: {
+        openAgentPrs: 0,
+        openAgentPrThreshold: AGENT_PR_THRESHOLD,
+        pressure: 'normal',
+      },
+      runs: [],
+      blockers,
+      recommendations,
+      sources: {
+        github: sourceStatus(false, 0),
+        linear: sourceStatus(false, 0),
+        sentry: sourceStatus(false, 0),
+        hermes: sourceStatus(true, recommendations.length),
+        ci: sourceStatus(false, 0),
+      },
+      errorMessage: 'GitHub HUD source not configured.',
+    };
+  }
+
+  const [prsResult, runsResult] = await Promise.all([
+    fetchGitHubJson(
+      '/pulls?state=open&per_page=40',
+      'GitHub open PRs for HUD AI ops'
+    ),
+    fetchGitHubJson(
+      `/actions/workflows/${encodeURIComponent(HERMES_WORKER_WORKFLOW)}/runs?per_page=10`,
+      'GitHub Hermes CLI workflow runs'
+    ),
+  ]);
+
+  const prItems = prsResult.ok ? normalizePrItems(prsResult.payload, now) : [];
+  const runItems = runsResult.ok
+    ? normalizeWorkflowRuns(runsResult.payload, now)
+    : [];
+  const allItems = [...prItems, ...runItems];
+  const blockers = allItems.filter(
+    item =>
+      item.status === 'blocked' ||
+      item.status === 'failed' ||
+      item.status === 'stale'
+  );
+
+  const openAgentPrs = prItems.length;
+  const pressure =
+    openAgentPrs >= AGENT_PR_THRESHOLD
+      ? 'high'
+      : openAgentPrs >= Math.ceil(AGENT_PR_THRESHOLD * 0.7)
+        ? 'elevated'
+        : 'normal';
+
+  const recommendations = buildRecommendations({
+    blockers,
+    dispatchAvailable: dispatch.available,
+    dispatchUnavailableReason: dispatch.unavailableReason,
+    mergePressure: pressure,
+    runningCount: allItems.filter(item => item.status === 'running').length,
+    generatedAtIso,
+  });
+
+  const errorMessages = [
+    prsResult.ok ? null : prsResult.errorMessage,
+    runsResult.ok ? null : runsResult.errorMessage,
+  ].filter((message): message is string => Boolean(message));
+  const availability =
+    errorMessages.length === 0
+      ? 'available'
+      : errorMessages.length === 2
+        ? 'error'
+        : 'partial';
+
+  return {
+    availability,
+    generatedAtIso,
+    counts: countStatuses(allItems),
+    dispatch,
+    mergeQueue: {
+      openAgentPrs,
+      openAgentPrThreshold: AGENT_PR_THRESHOLD,
+      pressure,
+    },
+    runs: runItems.slice(0, 8),
+    blockers: blockers.slice(0, 8),
+    recommendations: recommendations.slice(0, 6),
+    sources: {
+      github: sourceStatus(
+        true,
+        prItems.length,
+        prsResult.ok ? undefined : prsResult.errorMessage
+      ),
+      linear: sourceStatus(false, 0),
+      sentry: sourceStatus(false, 0),
+      hermes: sourceStatus(true, recommendations.length),
+      ci: sourceStatus(
+        true,
+        runItems.length,
+        runsResult.ok ? undefined : runsResult.errorMessage
+      ),
+    },
+    ...(errorMessages.length > 0
+      ? { errorMessage: errorMessages.join('; ') }
+      : {}),
+  };
+}

--- a/apps/web/lib/hud/metrics.ts
+++ b/apps/web/lib/hud/metrics.ts
@@ -6,6 +6,7 @@ import { getAdminStripeOverviewMetrics } from '@/lib/admin/stripe-metrics';
 import { checkDbHealth } from '@/lib/db';
 import { getHudDeployments } from '@/lib/deployments/github';
 import { env } from '@/lib/env-server';
+import { getHudAiOpsSummary } from '@/lib/hud/ai-ops';
 import type { HudAccessMode, HudMetrics } from '@/types/hud';
 
 function normalizeIso(value: unknown): string {
@@ -139,12 +140,14 @@ export async function getHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
     reliabilitySummary,
     dbHealth,
     deployments,
+    aiOps,
   ] = await Promise.all([
     getAdminStripeOverviewMetrics(),
     getAdminMercuryMetrics(),
     getAdminReliabilitySummary(),
     checkDbHealth(),
     getHudDeployments(),
+    getHudAiOpsSummary(generatedAt),
   ]);
 
   const financialStatus = calculateFinancialStatus(
@@ -188,6 +191,7 @@ export async function getHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
       lastIncidentAtIso,
     },
     deployments,
+    aiOps,
     generatedAtIso: generatedAt.toISOString(),
   };
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -140,6 +140,7 @@
     "qa:overnight:resume": "tsx scripts/overnight-qa-controller.ts --resume",
     "qa:overnight:status": "tsx scripts/overnight-qa-controller.ts --status",
     "qa:overnight:dry-run": "tsx scripts/overnight-qa-controller.ts --dry-run",
+    "hermes:worker": "tsx scripts/hermes-cli-worker.ts",
     "profile:mock-diff": "tsx scripts/profile-mock-diff.ts",
     "perf:loop": "tsx scripts/performance-optimizer.ts",
     "perf:loop:end-user": "tsx scripts/performance-optimizer.ts --scope end-user",

--- a/apps/web/scripts/hermes-cli-worker.ts
+++ b/apps/web/scripts/hermes-cli-worker.ts
@@ -1,0 +1,314 @@
+#!/usr/bin/env tsx
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { HermesCliRuntime, HermesDispatchPayload } from '../types/ai-ops';
+
+interface RuntimeCommand {
+  readonly executable: string;
+  readonly args: readonly string[];
+  readonly stdin: string | null;
+}
+
+interface WorkerRunOptions {
+  readonly payload: HermesDispatchPayload;
+  readonly workspace: string;
+  readonly dryRun?: boolean;
+}
+
+interface CliArgs {
+  readonly payloadFile: string | null;
+  readonly payloadJson: string | null;
+  readonly workspace: string;
+  readonly dryRun: boolean;
+}
+
+const RUNTIME_EXECUTABLE: Record<HermesCliRuntime, string> = {
+  'codex-cli': 'codex',
+  'claude-code': 'claude',
+  ruflo: 'ruflo',
+};
+
+const VALID_RUNTIMES = new Set<HermesCliRuntime>([
+  'codex-cli',
+  'claude-code',
+  'ruflo',
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
+}
+
+function requireString(
+  value: unknown,
+  field: keyof HermesDispatchPayload
+): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Hermes payload missing ${field}`);
+  }
+  return value;
+}
+
+export function parseHermesPayload(input: unknown): HermesDispatchPayload {
+  if (!isRecord(input)) {
+    throw new Error('Hermes payload must be an object');
+  }
+
+  const runtime = requireString(input.runtime, 'runtime') as HermesCliRuntime;
+  if (!VALID_RUNTIMES.has(runtime)) {
+    throw new Error(`Unsupported Hermes runtime: ${runtime}`);
+  }
+
+  return {
+    dispatchId: requireString(input.dispatchId, 'dispatchId'),
+    source: requireString(
+      input.source,
+      'source'
+    ) as HermesDispatchPayload['source'],
+    sourceId: requireString(input.sourceId, 'sourceId'),
+    sourceUrl:
+      typeof input.sourceUrl === 'string' && input.sourceUrl.length > 0
+        ? input.sourceUrl
+        : null,
+    kind: requireString(input.kind, 'kind') as HermesDispatchPayload['kind'],
+    runtime,
+    priority:
+      typeof input.priority === 'number' && Number.isFinite(input.priority)
+        ? input.priority
+        : 50,
+    skills: asStringArray(input.skills),
+    allowedPaths: asStringArray(input.allowedPaths),
+    verification: asStringArray(input.verification),
+    dryRun: input.dryRun === true,
+    prompt: typeof input.prompt === 'string' ? input.prompt : '',
+    owner: typeof input.owner === 'string' ? input.owner : null,
+    branchName: requireString(input.branchName, 'branchName'),
+    requestedAt: requireString(input.requestedAt, 'requestedAt'),
+  };
+}
+
+export function buildHermesWorkerPrompt(
+  payload: HermesDispatchPayload
+): string {
+  const skillLines = payload.skills
+    .map(skill => `- /${skill.replace(/^\//, '')}`)
+    .join('\n');
+  const allowedPaths = payload.allowedPaths.length
+    ? payload.allowedPaths.map(path => `- ${path}`).join('\n')
+    : '- Repo-wide, but keep the diff minimal and scoped.';
+  const verification = payload.verification.length
+    ? payload.verification.map(command => `- ${command}`).join('\n')
+    : '- Run the narrowest relevant verification.';
+
+  return `Load gstack. You are a Hermes CLI worker for Jovie.
+
+Set and honor this profile before editing:
+JOVIE_AGENT_PROFILE=coder
+
+Use these gstack skills:
+${skillLines || '- /autoplan'}
+
+Task:
+- Dispatch ID: ${payload.dispatchId}
+- Kind: ${payload.kind}
+- Source: ${payload.source}:${payload.sourceId}
+- Source URL: ${payload.sourceUrl ?? 'none'}
+- Owner: ${payload.owner ?? 'HUD'}
+- Priority: ${payload.priority}
+
+User prompt:
+${payload.prompt || 'Implement the scoped task using the source context.'}
+
+Allowed path guidance:
+${allowedPaths}
+
+Verification:
+${verification}
+
+Hard requirements:
+- Read AGENTS.md/CLAUDE.md and scoped rules before editing.
+- Use Node 22.x, pnpm 9.15.4, and run commands from repo root.
+- Do not edit drizzle/migrations.
+- Do not add biome-ignore comments.
+- Keep the change focused and reviewable.
+- Do not merge or deploy.
+- Do not commit or push; leave changes in the working tree for the Hermes workflow commit step.
+- If the task is unsafe or ambiguous, write a short result note and leave code unchanged.
+`;
+}
+
+export function buildRuntimeCommand(
+  runtime: HermesCliRuntime,
+  prompt: string,
+  workspace: string
+): RuntimeCommand {
+  if (runtime === 'codex-cli') {
+    return {
+      executable: RUNTIME_EXECUTABLE[runtime],
+      args: [
+        'exec',
+        '--cd',
+        workspace,
+        '--sandbox',
+        'workspace-write',
+        '--ask-for-approval',
+        'never',
+        '-',
+      ],
+      stdin: prompt,
+    };
+  }
+
+  if (runtime === 'claude-code') {
+    return {
+      executable: RUNTIME_EXECUTABLE[runtime],
+      args: [
+        '--print',
+        '--permission-mode',
+        process.env.HERMES_CLAUDE_PERMISSION_MODE ?? 'acceptEdits',
+        '--output-format',
+        'stream-json',
+        prompt,
+      ],
+      stdin: null,
+    };
+  }
+
+  return {
+    executable: RUNTIME_EXECUTABLE[runtime],
+    args: ['swarm', 'start', '-o', prompt, '-s', 'development'],
+    stdin: null,
+  };
+}
+
+export function runtimeAvailable(executable: string): boolean {
+  const result = spawnSync('sh', ['-lc', `command -v ${executable}`], {
+    encoding: 'utf8',
+  });
+  return result.status === 0;
+}
+
+export function runHermesCliWorker({
+  payload,
+  workspace,
+  dryRun,
+}: WorkerRunOptions): number {
+  const prompt = buildHermesWorkerPrompt(payload);
+  const command = buildRuntimeCommand(payload.runtime, prompt, workspace);
+  const effectiveDryRun = dryRun === true || payload.dryRun;
+
+  if (effectiveDryRun) {
+    console.log(
+      JSON.stringify(
+        {
+          dryRun: true,
+          dispatchId: payload.dispatchId,
+          runtime: payload.runtime,
+          executable: command.executable,
+          args: command.args.map(arg => (arg === prompt ? '<prompt>' : arg)),
+          branchName: payload.branchName,
+        },
+        null,
+        2
+      )
+    );
+    return 0;
+  }
+
+  if (!runtimeAvailable(command.executable)) {
+    console.error(
+      `Hermes runtime '${payload.runtime}' requires '${command.executable}' on PATH.`
+    );
+    return 127;
+  }
+
+  const result = spawnSync(command.executable, [...command.args], {
+    cwd: workspace,
+    env: {
+      ...process.env,
+      JOVIE_AGENT_PROFILE: 'coder',
+      HERMES_DISPATCH_ID: payload.dispatchId,
+      HERMES_SOURCE_URL: payload.sourceUrl ?? '',
+    },
+    input: command.stdin ?? undefined,
+    stdio: command.stdin ? ['pipe', 'inherit', 'inherit'] : 'inherit',
+  });
+
+  return result.status ?? 1;
+}
+
+function parseArgs(argv: readonly string[]): CliArgs {
+  let payloadFile: string | null = null;
+  let payloadJson: string | null = process.env.HERMES_CLIENT_PAYLOAD ?? null;
+  let workspace = process.env.GITHUB_WORKSPACE ?? process.cwd();
+  let dryRun = false;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--payload-file') {
+      payloadFile = argv[index + 1] ?? null;
+      index += 1;
+    } else if (arg === '--payload-json') {
+      payloadJson = argv[index + 1] ?? null;
+      index += 1;
+    } else if (arg === '--workspace') {
+      workspace = argv[index + 1] ?? workspace;
+      index += 1;
+    } else if (arg === '--dry-run') {
+      dryRun = true;
+    }
+  }
+
+  return {
+    payloadFile,
+    payloadJson,
+    workspace: resolve(workspace),
+    dryRun,
+  };
+}
+
+function readPayload(args: CliArgs): HermesDispatchPayload {
+  if (args.payloadFile) {
+    if (!existsSync(args.payloadFile)) {
+      throw new Error(`Payload file not found: ${args.payloadFile}`);
+    }
+    return parseHermesPayload(
+      JSON.parse(readFileSync(args.payloadFile, 'utf8'))
+    );
+  }
+
+  if (!args.payloadJson) {
+    throw new Error(
+      'Provide --payload-file, --payload-json, or HERMES_CLIENT_PAYLOAD.'
+    );
+  }
+
+  return parseHermesPayload(JSON.parse(args.payloadJson));
+}
+
+function main(): void {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const payload = readPayload(args);
+    process.exitCode = runHermesCliWorker({
+      payload,
+      workspace: args.workspace,
+      dryRun: args.dryRun,
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  main();
+}

--- a/apps/web/tests/lib/hud/metrics.test.ts
+++ b/apps/web/tests/lib/hud/metrics.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { getHudMetrics } from '@/lib/hud/metrics';
 
 const mockGetHudDeployments = vi.hoisted(() => vi.fn());
+const mockGetHudAiOpsSummary = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/env-server', () => ({
   env: {
@@ -54,11 +55,63 @@ vi.mock('@/lib/deployments/github', () => ({
   getHudDeployments: mockGetHudDeployments,
 }));
 
+vi.mock('@/lib/hud/ai-ops', () => ({
+  getHudAiOpsSummary: mockGetHudAiOpsSummary,
+}));
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe('getHudMetrics', () => {
+  beforeEach(() => {
+    mockGetHudAiOpsSummary.mockResolvedValue({
+      availability: 'not_configured',
+      generatedAtIso: '2026-05-07T00:00:00.000Z',
+      counts: {
+        queued: 0,
+        running: 0,
+        blocked: 0,
+        review: 0,
+        done: 0,
+        failed: 0,
+        stale: 0,
+      },
+      dispatch: {
+        available: false,
+        unavailableReason: 'GH_DISPATCH_TOKEN is not configured.',
+        runtimes: ['codex-cli', 'claude-code', 'ruflo'],
+      },
+      mergeQueue: {
+        openAgentPrs: 0,
+        openAgentPrThreshold: 10,
+        pressure: 'normal',
+      },
+      runs: [],
+      blockers: [],
+      recommendations: [],
+      sources: {
+        github: {
+          availability: 'not_configured',
+          configured: false,
+          itemCount: 0,
+        },
+        linear: {
+          availability: 'not_configured',
+          configured: false,
+          itemCount: 0,
+        },
+        sentry: {
+          availability: 'not_configured',
+          configured: false,
+          itemCount: 0,
+        },
+        hermes: { availability: 'available', configured: true, itemCount: 0 },
+        ci: { availability: 'not_configured', configured: false, itemCount: 0 },
+      },
+    });
+  });
+
   it('degrades deployment metrics when GitHub request times out', async () => {
     mockGetHudDeployments.mockResolvedValueOnce({
       availability: 'error',
@@ -75,5 +128,61 @@ describe('getHudMetrics', () => {
     expect(metrics.deployments.errorMessage).toContain(
       'External request timed out'
     );
+  });
+
+  it('includes degraded AI ops metrics without failing the HUD payload', async () => {
+    mockGetHudDeployments.mockResolvedValueOnce({
+      availability: 'not_configured',
+      current: null,
+      recent: [],
+    });
+    mockGetHudAiOpsSummary.mockResolvedValueOnce({
+      availability: 'partial',
+      generatedAtIso: '2026-05-07T00:00:00.000Z',
+      counts: {
+        queued: 1,
+        running: 1,
+        blocked: 1,
+        review: 0,
+        done: 0,
+        failed: 0,
+        stale: 0,
+      },
+      dispatch: {
+        available: true,
+        unavailableReason: null,
+        runtimes: ['codex-cli', 'claude-code', 'ruflo'],
+      },
+      mergeQueue: {
+        openAgentPrs: 1,
+        openAgentPrThreshold: 10,
+        pressure: 'normal',
+      },
+      runs: [],
+      blockers: [],
+      recommendations: [],
+      sources: {
+        github: { availability: 'available', configured: true, itemCount: 1 },
+        linear: {
+          availability: 'not_configured',
+          configured: false,
+          itemCount: 0,
+        },
+        sentry: {
+          availability: 'not_configured',
+          configured: false,
+          itemCount: 0,
+        },
+        hermes: { availability: 'available', configured: true, itemCount: 0 },
+        ci: { availability: 'error', configured: true, itemCount: 0 },
+      },
+      errorMessage: 'GitHub API error (404)',
+    });
+
+    const metrics = await getHudMetrics('admin');
+
+    expect(metrics.aiOps.availability).toBe('partial');
+    expect(metrics.aiOps.dispatch.available).toBe(true);
+    expect(metrics.aiOps.counts.blocked).toBe(1);
   });
 });

--- a/apps/web/tests/unit/api/hud-ai-ops-dispatch-route.test.ts
+++ b/apps/web/tests/unit/api/hud-ai-ops-dispatch-route.test.ts
@@ -1,0 +1,100 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { POST } from '@/app/api/hud/ai-ops/dispatch/route';
+import { HermesDispatchConfigurationError } from '@/lib/hermes/dispatch';
+
+const mockAuthorizeHud = vi.hoisted(() => vi.fn());
+const mockDispatchHermesWorker = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth/hud', () => ({
+  authorizeHud: mockAuthorizeHud,
+}));
+
+vi.mock('@/lib/hermes/dispatch', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/hermes/dispatch')>();
+  return {
+    ...actual,
+    dispatchHermesWorker: mockDispatchHermesWorker,
+  };
+});
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+function postRequest(body: unknown): NextRequest {
+  return new NextRequest('http://localhost:3000/api/hud/ai-ops/dispatch', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('POST /api/hud/ai-ops/dispatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuthorizeHud.mockResolvedValue({ ok: true, mode: 'admin' });
+    mockDispatchHermesWorker.mockResolvedValue({
+      dispatchId: 'dispatch-1',
+      branchName: 'codex/hermes-test',
+      eventType: 'hermes_cli_worker',
+      dryRun: true,
+    });
+  });
+
+  it('rejects kiosk sessions', async () => {
+    mockAuthorizeHud.mockResolvedValueOnce({ ok: true, mode: 'kiosk' });
+
+    const response = await POST(postRequest({}));
+
+    expect(response.status).toBe(403);
+    expect(mockDispatchHermesWorker).not.toHaveBeenCalled();
+  });
+
+  it('dispatches admin requests', async () => {
+    const response = await POST(
+      postRequest({
+        source: 'hermes',
+        kind: 'investigation',
+        runtime: 'codex-cli',
+        dryRun: true,
+      })
+    );
+
+    await expect(response.json()).resolves.toEqual({
+      dispatched: true,
+      dispatchId: 'dispatch-1',
+      branchName: 'codex/hermes-test',
+      eventType: 'hermes_cli_worker',
+      dryRun: true,
+    });
+    expect(response.status).toBe(202);
+  });
+
+  it('returns unavailable when dispatch credentials are missing', async () => {
+    mockDispatchHermesWorker.mockRejectedValueOnce(
+      new HermesDispatchConfigurationError(
+        'GH_DISPATCH_TOKEN is not configured.'
+      )
+    );
+
+    const response = await POST(
+      postRequest({
+        source: 'hermes',
+        kind: 'investigation',
+        runtime: 'codex-cli',
+      })
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: 'GH_DISPATCH_TOKEN is not configured.',
+    });
+  });
+});

--- a/apps/web/tests/unit/hermes/ai-ops-summary.test.ts
+++ b/apps/web/tests/unit/hermes/ai-ops-summary.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getHudAiOpsSummary } from '@/lib/hud/ai-ops';
+
+const mockEnv = vi.hoisted(() => ({
+  HUD_GITHUB_TOKEN: 'hud-token',
+  HUD_GITHUB_OWNER: 'JovieInc',
+  HUD_GITHUB_REPO: 'Jovie',
+  GH_DISPATCH_TOKEN: 'dispatch-token',
+  VERCEL_GIT_REPO_OWNER: undefined as string | undefined,
+  VERCEL_GIT_REPO_SLUG: undefined as string | undefined,
+}));
+const mockServerFetch = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/env-server', () => ({
+  env: mockEnv,
+}));
+
+vi.mock('@/lib/http/server-fetch', () => ({
+  serverFetch: mockServerFetch,
+}));
+
+describe('getHudAiOpsSummary', () => {
+  beforeEach(() => {
+    mockEnv.HUD_GITHUB_TOKEN = 'hud-token';
+    mockEnv.HUD_GITHUB_OWNER = 'JovieInc';
+    mockEnv.HUD_GITHUB_REPO = 'Jovie';
+    mockEnv.GH_DISPATCH_TOKEN = 'dispatch-token';
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('degrades when GitHub HUD source is not configured', async () => {
+    mockEnv.HUD_GITHUB_TOKEN = undefined;
+
+    const summary = await getHudAiOpsSummary(
+      new Date('2026-05-07T12:00:00.000Z')
+    );
+
+    expect(summary.availability).toBe('not_configured');
+    expect(summary.dispatch.available).toBe(true);
+    expect(summary.sources.github.availability).toBe('not_configured');
+    expect(summary.recommendations[0]?.summary).toContain('Dispatch');
+  });
+
+  it('normalizes blocked PRs and partial workflow failures', async () => {
+    mockServerFetch
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            {
+              number: 42,
+              title: 'Fix agent regression',
+              html_url: 'https://github.com/JovieInc/Jovie/pull/42',
+              updated_at: '2026-05-07T11:00:00.000Z',
+              draft: false,
+              labels: [{ name: 'needs-human' }],
+              user: { login: 'jovie-bot' },
+              head: { ref: 'codex/fix-agent-regression' },
+            },
+          ]),
+          { status: 200 }
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'not found' }), {
+          status: 404,
+        })
+      );
+
+    const summary = await getHudAiOpsSummary(
+      new Date('2026-05-07T12:00:00.000Z')
+    );
+
+    expect(summary.availability).toBe('partial');
+    expect(summary.counts.blocked).toBe(1);
+    expect(summary.blockers[0]?.summary).toContain('#42');
+    expect(summary.sources.ci.availability).toBe('error');
+    expect(summary.mergeQueue.openAgentPrs).toBe(1);
+  });
+});

--- a/apps/web/tests/unit/hermes/dispatch.test.ts
+++ b/apps/web/tests/unit/hermes/dispatch.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  dispatchHermesWorker,
+  getHermesDispatchAvailability,
+  normalizeHermesDispatchRequest,
+} from '@/lib/hermes/dispatch';
+
+const mockEnv = vi.hoisted(() => ({
+  GH_DISPATCH_TOKEN: 'dispatch-token',
+  HUD_GITHUB_OWNER: 'JovieInc',
+  HUD_GITHUB_REPO: 'Jovie',
+  VERCEL_GIT_REPO_OWNER: undefined as string | undefined,
+  VERCEL_GIT_REPO_SLUG: undefined as string | undefined,
+}));
+const mockServerFetch = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/env-server', () => ({
+  env: mockEnv,
+}));
+
+vi.mock('@/lib/http/server-fetch', () => ({
+  serverFetch: mockServerFetch,
+}));
+
+describe('Hermes dispatch', () => {
+  beforeEach(() => {
+    mockEnv.GH_DISPATCH_TOKEN = 'dispatch-token';
+    mockEnv.HUD_GITHUB_OWNER = 'JovieInc';
+    mockEnv.HUD_GITHUB_REPO = 'Jovie';
+    mockServerFetch.mockResolvedValue(new Response(null, { status: 204 }));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('normalizes skills, defaults, and branch names', () => {
+    const payload = normalizeHermesDispatchRequest({
+      source: 'linear',
+      sourceId: 'JOV-123',
+      sourceUrl: 'https://linear.app/jovie/issue/JOV-123/test',
+      kind: 'bug_patch',
+      runtime: 'codex-cli',
+      skills: ['/investigate'],
+      dryRun: true,
+    });
+
+    expect(payload.skills).toEqual(['investigate']);
+    expect(payload.allowedPaths).toContain('apps/web');
+    expect(payload.verification).toEqual([
+      'pnpm --filter web exec tsc --noEmit',
+    ]);
+    expect(payload.branchName).toMatch(/^codex\/hermes-bug_patch-jov-123-/);
+  });
+
+  it('rejects unsafe verification commands', () => {
+    expect(() =>
+      normalizeHermesDispatchRequest({
+        source: 'hermes',
+        kind: 'investigation',
+        runtime: 'claude-code',
+        verification: ['rm -rf .next'],
+      })
+    ).toThrow();
+  });
+
+  it('reports unavailable dispatch config', () => {
+    mockEnv.GH_DISPATCH_TOKEN = undefined;
+
+    expect(getHermesDispatchAvailability()).toEqual({
+      available: false,
+      unavailableReason: 'GH_DISPATCH_TOKEN is not configured.',
+      runtimes: ['codex-cli', 'claude-code', 'ruflo'],
+    });
+  });
+
+  it('sends a repository_dispatch payload for Hermes workers', async () => {
+    const result = await dispatchHermesWorker({
+      source: 'github',
+      sourceId: '123',
+      sourceUrl: 'https://github.com/JovieInc/Jovie/issues/123',
+      kind: 'investigation',
+      runtime: 'ruflo',
+      skills: ['autoplan', 'investigate'],
+      dryRun: false,
+    });
+
+    expect(result.eventType).toBe('hermes_cli_worker');
+    expect(result.branchName).toMatch(/^codex\/hermes-investigation-123-/);
+    expect(mockServerFetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/JovieInc/Jovie/dispatches',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'token dispatch-token',
+        }),
+      })
+    );
+
+    const body = JSON.parse(mockServerFetch.mock.calls[0][1].body);
+    expect(body.event_type).toBe('hermes_cli_worker');
+    expect(body.client_payload.runtime).toBe('ruflo');
+    expect(body.client_payload.skills).toEqual(['autoplan', 'investigate']);
+  });
+});

--- a/apps/web/tests/unit/hermes/runner.test.ts
+++ b/apps/web/tests/unit/hermes/runner.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { HermesDispatchPayload } from '@/types/ai-ops';
+import {
+  buildHermesWorkerPrompt,
+  buildRuntimeCommand,
+  parseHermesPayload,
+  runHermesCliWorker,
+} from '../../../scripts/hermes-cli-worker';
+
+const basePayload: HermesDispatchPayload = {
+  dispatchId: 'dispatch-1',
+  source: 'linear',
+  sourceId: 'JOV-123',
+  sourceUrl: 'https://linear.app/jovie/issue/JOV-123/test',
+  kind: 'investigation',
+  runtime: 'codex-cli',
+  priority: 70,
+  skills: ['investigate'],
+  allowedPaths: ['apps/web'],
+  verification: ['pnpm --filter web exec tsc --noEmit'],
+  dryRun: false,
+  prompt: 'Find the root cause.',
+  owner: 'HUD',
+  branchName: 'codex/hermes-investigation-jov-123',
+  requestedAt: '2026-05-07T12:00:00.000Z',
+};
+
+describe('Hermes CLI worker runner', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('builds prompts with profile and gstack skills', () => {
+    const prompt = buildHermesWorkerPrompt(basePayload);
+
+    expect(prompt).toContain('JOVIE_AGENT_PROFILE=coder');
+    expect(prompt).toContain('/investigate');
+    expect(prompt).toContain('Do not commit or push');
+    expect(prompt).toContain('pnpm --filter web exec tsc --noEmit');
+  });
+
+  it('builds Codex CLI commands with prompt on stdin', () => {
+    const command = buildRuntimeCommand('codex-cli', 'prompt body', '/repo');
+
+    expect(command.executable).toBe('codex');
+    expect(command.args).toContain('exec');
+    expect(command.args).toContain('--cd');
+    expect(command.args).toContain('/repo');
+    expect(command.stdin).toBe('prompt body');
+  });
+
+  it('rejects unknown runtimes', () => {
+    expect(() =>
+      parseHermesPayload({ ...basePayload, runtime: 'unknown' })
+    ).toThrow('Unsupported Hermes runtime');
+  });
+
+  it('does not require binaries in dry-run mode', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const status = runHermesCliWorker({
+      payload: { ...basePayload, dryRun: true },
+      workspace: '/repo',
+    });
+
+    expect(status).toBe(0);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"dryRun": true')
+    );
+  });
+});

--- a/apps/web/types/ai-ops.ts
+++ b/apps/web/types/ai-ops.ts
@@ -1,0 +1,134 @@
+export type HermesAiOpsSource =
+  | 'github'
+  | 'linear'
+  | 'sentry'
+  | 'hermes'
+  | 'ci';
+
+export type HermesAiOpsKind =
+  | 'triage'
+  | 'bug_patch'
+  | 'code_review'
+  | 'qa'
+  | 'investigation'
+  | 'support_draft'
+  | 'issue'
+  | 'pr'
+  | 'workflow'
+  | 'blocker'
+  | 'recommendation';
+
+export type HermesAiOpsStatus =
+  | 'queued'
+  | 'running'
+  | 'blocked'
+  | 'review'
+  | 'done'
+  | 'failed'
+  | 'stale';
+
+export type HermesAiOpsAvailability =
+  | 'available'
+  | 'partial'
+  | 'not_configured'
+  | 'error';
+
+export interface HermesAiOpsItem {
+  readonly source: HermesAiOpsSource;
+  readonly kind: HermesAiOpsKind;
+  readonly status: HermesAiOpsStatus;
+  readonly priority: number;
+  readonly url: string | null;
+  readonly owner: string | null;
+  readonly summary: string;
+  readonly updatedAt: string;
+}
+
+export interface HermesAiOpsCounts {
+  readonly queued: number;
+  readonly running: number;
+  readonly blocked: number;
+  readonly review: number;
+  readonly done: number;
+  readonly failed: number;
+  readonly stale: number;
+}
+
+export type HermesCliRuntime = 'codex-cli' | 'claude-code' | 'ruflo';
+
+export interface HermesDispatchAvailability {
+  readonly available: boolean;
+  readonly unavailableReason: string | null;
+  readonly runtimes: readonly HermesCliRuntime[];
+}
+
+export interface HermesAiOpsSourceStatus {
+  readonly availability: Exclude<HermesAiOpsAvailability, 'partial'>;
+  readonly configured: boolean;
+  readonly itemCount: number;
+  readonly errorMessage?: string;
+}
+
+export interface HermesAiOpsMergeQueue {
+  readonly openAgentPrs: number;
+  readonly openAgentPrThreshold: number;
+  readonly pressure: 'normal' | 'elevated' | 'high';
+}
+
+export interface HermesAiOpsSummary {
+  readonly availability: HermesAiOpsAvailability;
+  readonly generatedAtIso: string;
+  readonly counts: HermesAiOpsCounts;
+  readonly dispatch: HermesDispatchAvailability;
+  readonly mergeQueue: HermesAiOpsMergeQueue;
+  readonly runs: HermesAiOpsItem[];
+  readonly blockers: HermesAiOpsItem[];
+  readonly recommendations: HermesAiOpsItem[];
+  readonly sources: Record<HermesAiOpsSource, HermesAiOpsSourceStatus>;
+  readonly errorMessage?: string;
+}
+
+export interface HermesDispatchRequest {
+  readonly source: HermesAiOpsSource;
+  readonly sourceId?: string;
+  readonly sourceUrl?: string | null;
+  readonly kind: Extract<
+    HermesAiOpsKind,
+    | 'triage'
+    | 'bug_patch'
+    | 'code_review'
+    | 'qa'
+    | 'investigation'
+    | 'support_draft'
+  >;
+  readonly runtime: HermesCliRuntime;
+  readonly priority?: number;
+  readonly skills?: readonly string[];
+  readonly allowedPaths?: readonly string[];
+  readonly verification?: readonly string[];
+  readonly dryRun?: boolean;
+  readonly prompt?: string;
+  readonly owner?: string | null;
+}
+
+export interface HermesDispatchPayload extends HermesDispatchRequest {
+  readonly dispatchId: string;
+  readonly sourceId: string;
+  readonly sourceUrl: string | null;
+  readonly priority: number;
+  readonly skills: readonly string[];
+  readonly allowedPaths: readonly string[];
+  readonly verification: readonly string[];
+  readonly dryRun: boolean;
+  readonly prompt: string;
+  readonly owner: string | null;
+  readonly branchName: string;
+  readonly requestedAt: string;
+}
+
+export interface HermesDispatchResult {
+  readonly dispatchId: string;
+  readonly branchName: string;
+  readonly eventType: 'hermes_cli_worker';
+  readonly dryRun: boolean;
+}

--- a/apps/web/types/hud.ts
+++ b/apps/web/types/hud.ts
@@ -1,3 +1,5 @@
+import type { HermesAiOpsSummary } from '@/types/ai-ops';
+
 export type HudAccessMode = 'admin' | 'kiosk';
 
 export type HudDeploymentState =
@@ -56,5 +58,6 @@ export interface HudMetrics {
     lastIncidentAtIso: string | null;
   };
   deployments: HudDeployments;
+  aiOps: HermesAiOpsSummary;
   generatedAtIso: string;
 }

--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
     "knip": "knip",
     "version:check": "node scripts/version-check.mjs",
     "changelog:send": "doppler run -- node scripts/send-changelog-email.mjs",
-    "video:footer:generate": "doppler run --project jovie-web --config dev -- tsx scripts/generate-footer-cta-video.ts"
+    "video:footer:generate": "doppler run --project jovie-web --config dev -- tsx scripts/generate-footer-cta-video.ts",
+    "hermes:worker": "pnpm --filter @jovie/web run hermes:worker"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.91.1",


### PR DESCRIPTION
## Summary

- Add HUD AI ops status for Hermes runs, agent PR pressure, blockers, and next actions.
- Add admin-only HUD dispatch route that sends `hermes_cli_worker` repository dispatch events instead of running CLI workers in the web process.
- Add a self-hosted `[self-hosted, hermes]` GitHub workflow plus runner script for Codex CLI, Claude Code, and Ruflo dispatch with gstack skill prompts.

## Test plan

- `pnpm --filter @jovie/web exec vitest run tests/lib/hud/metrics.test.ts tests/unit/hermes/dispatch.test.ts tests/unit/hermes/ai-ops-summary.test.ts tests/unit/hermes/runner.test.ts tests/unit/api/hud-ai-ops-dispatch-route.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/api/hud-metrics-route.test.ts`
- `pnpm --filter @jovie/web exec tsc --noEmit`
- `pnpm biome check --write apps/web/app/hud/HudDashboardClient.tsx apps/web/types/ai-ops.ts apps/web/types/hud.ts apps/web/lib/hermes/dispatch.ts apps/web/lib/hud/ai-ops.ts apps/web/app/api/hud/ai-ops/dispatch/route.ts apps/web/scripts/hermes-cli-worker.ts apps/web/tests/lib/hud/metrics.test.ts apps/web/tests/unit/hermes/dispatch.test.ts apps/web/tests/unit/hermes/ai-ops-summary.test.ts apps/web/tests/unit/hermes/runner.test.ts apps/web/tests/unit/api/hud-ai-ops-dispatch-route.test.ts package.json apps/web/package.json`
- `git diff --check`
- pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Notes

- `pnpm --filter @jovie/web exec tsc -p tsconfig.test.json --noEmit` still fails on existing repo-wide script/test typing issues unrelated to this PR.
- Existing version files are already skewed (`version.json`, root package, web package, and `VERSION` disagree), so this PR avoids a release-version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI Ops control panel to the HUD dashboard with worker dispatch capabilities
  * Introduced Hermes worker dispatching for automated operations with configurable runtime options
  * Added dry-run support for testing worker execution before applying changes
  * Implemented AI operations monitoring showing agent PR status and workflow run tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->