### PR TITLE
test(auth): use ready persona for signup smoke

### DIFF
--- a/apps/web/tests/e2e/signup-funnel.smoke.spec.ts
+++ b/apps/web/tests/e2e/signup-funnel.smoke.spec.ts
@@ -90,7 +90,7 @@ test.describe('Signup Funnel Smoke @smoke', () => {
       return;
     }
 
-    await setTestAuthBypassSession(page, 'creator');
+    await setTestAuthBypassSession(page, 'creator-ready');
 
     const appResponse = await smokeNavigateWithRetry(page, '/app/chat', {
       timeout: 120_000,


### PR DESCRIPTION
<!-- linear-issue-id:JOV-1851 -->
<!-- linear-issue-identifier:JOV-1851 -->

## Summary
- Updates the authenticated signup smoke bootstrap from `creator` to `creator-ready`.
- Aligns the persona with the test expectation that `/app/chat` is reachable after auth bypass.

## Testing
- `pnpm biome check --write apps/web/tests/e2e/signup-funnel.smoke.spec.ts`
- `pnpm --filter @jovie/web run typecheck`
- `BASE_URL=http://localhost:3101 E2E_SKIP_WEB_SERVER=1 E2E_SKIP_WARMUP=1 E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready E2E_CLERK_USER_ID=qa-bypass-user E2E_CLERK_USER_USERNAME=browse+clerk_test@jov.ie SMOKE_ONLY=1 pnpm --filter @jovie/web exec playwright test tests/e2e/signup-funnel.smoke.spec.ts --project=chromium --no-deps --reporter=line` → 3 passed
- pre-push hook: `biome check .`, `pnpm --filter=@jovie/web run pre-push` (`next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`)

## Risk
- Auth/onboarding smoke coverage only, but guarded test contract. Marking `testing` and `needs-human` because current scope-judge secret configuration blocks unattended landing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authentication verification for signup and onboarding flow tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->