### PR TITLE
fix(crons): wire 4 orphaned cron routes into vercel.json

### DIFF
--- a/docs/CRON_REGISTRY.md
+++ b/docs/CRON_REGISTRY.md
@@ -25,8 +25,14 @@ Source of truth: `apps/web/vercel.json`
 | `/api/cron/generate-insights` | `0 5 * * *` | Daily at 05:00 UTC |
 | `/api/cron/process-ingestion-jobs` | `* * * * *` | Every minute |
 | `/api/cron/purge-pixel-ips` | `0 3 * * *` | Daily at 03:00 UTC |
+| `/api/cron/summarize-interviews` | `*/5 * * * *` | Every 5 minutes |
+| `/api/cron/generate-playlist` | `0 6 * * *` | Daily at 06:00 UTC |
+| `/api/cron/process-pre-saves` | `0 2 * * *` | Daily at 02:00 UTC |
+| `/api/cron/cleanup-sms-intents` | `0 1 * * *` | Daily at 01:00 UTC |
+| `/api/cron/monitor-metadata-submissions` | `0 * * * *` | Hourly |
+| `/api/cron/process-metadata-submissions` | `0 4 * * *` | Daily at 04:00 UTC |
 
-Only these 5 paths are scheduled in production. Other cron route files exist as standalone endpoints whose logic is called as sub-jobs of `frequent` or `daily-maintenance`.
+All 11 paths are now scheduled in production. Other cron route files exist as standalone endpoints whose logic is called as sub-jobs of `frequent` or `daily-maintenance`.
 
 **Auth:** All crons use `Authorization: Bearer ${CRON_SECRET}`. The `data-retention` route additionally uses timing-safe comparison + origin verification.
 
@@ -71,7 +77,12 @@ These have their own Vercel schedule OR exist as callable endpoints (also invoke
 | `/api/cron/generate-insights` | 300s | AI insights for eligible Pro/Founding/Growth profiles with sufficient click data | — |
 | `/api/cron/process-ingestion-jobs` | 300s | Claims up to 5 pending ingestion jobs, processes 3 concurrently | `frequent` (fallback) |
 | `/api/cron/purge-pixel-ips` | 60s | NULLs `client_ip` from pixel events >48h old (privacy); retains `ip_hash` | — |
-| `/api/cron/process-pre-saves` | default | Processes Spotify pre-saves where release date has passed; up to 500/run | — |
+| `/api/cron/summarize-interviews` | 300s (default) | Haiku-powered interview summarization; queued jobs stall without this schedule | — |
+| `/api/cron/generate-playlist` | 300s (default) | Daily AI playlist generation for admin review | — |
+| `/api/cron/process-pre-saves` | 300s (default) | Processes pending Spotify pre-saves where release date has passed; up to 500/run | — |
+| `/api/cron/cleanup-sms-intents` | 60s | Marks expired SMS subscribe intents and hard-deletes rows >24h old | — |
+| `/api/cron/monitor-metadata-submissions` | 60s | Polls third-party metadata pages for drift detection; read-only snapshot workflow | — |
+| `/api/cron/process-metadata-submissions` | 60s | Sends queued metadata submissions; processes the outbound send queue | — |
 | `/api/cron/billing-reconciliation` | 60s | Standalone entry for billing reconciliation | `daily-maintenance` |
 | `/api/cron/cleanup-idempotency-keys` | 60s | Standalone entry for key cleanup | `daily-maintenance` |
 | `/api/cron/cleanup-photos` | 60s | Standalone entry for photo cleanup | `daily-maintenance` |

--- a/vercel.json
+++ b/vercel.json
@@ -31,6 +31,22 @@
     {
       "path": "/api/cron/generate-playlist",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/process-pre-saves",
+      "schedule": "0 2 * * *"
+    },
+    {
+      "path": "/api/cron/cleanup-sms-intents",
+      "schedule": "0 1 * * *"
+    },
+    {
+      "path": "/api/cron/monitor-metadata-submissions",
+      "schedule": "0 * * * *"
+    },
+    {
+      "path": "/api/cron/process-metadata-submissions",
+      "schedule": "0 4 * * *"
     }
   ],
   "functions": {


### PR DESCRIPTION
## Summary

- Wires 4 orphaned cron routes that had working code but no schedule entry in `vercel.json`, causing silent failures for paying users
- `process-pre-saves` was the most critical: fan Spotify pre-saves never fired after release dates passed
- `cleanup-sms-intents`, `monitor-metadata-submissions`, and `process-metadata-submissions` were accumulating data or going dark

## Routes Added

| Route | Schedule | Rationale |
|-------|----------|-----------|
| `/api/cron/process-pre-saves` | `0 2 * * *` (daily 02:00 UTC) | HIGH: user-facing Spotify pre-saves silently broken |
| `/api/cron/cleanup-sms-intents` | `0 1 * * *` (daily 01:00 UTC) | LOW: SMS intent rows accumulate without cleanup |
| `/api/cron/monitor-metadata-submissions` | `0 * * * *` (hourly) | MEDIUM: monitoring dark; route doc specifies hourly cadence |
| `/api/cron/process-metadata-submissions` | `0 4 * * *` (daily 04:00 UTC) | MEDIUM: submission queue stalls silently |

No new cron logic is added — these are EXISTING routes with working implementations that were never scheduled.

`docs/CRON_REGISTRY.md` updated to reflect full 11-job production schedule.

Source: `.context/ops/cron-audit-2026-05-07.md` verdicts V1, V3, V4, V5.

## Cost Impact

- **External API calls**: None beyond what these routes already do when called as sub-jobs or manually
- **Scaling factor**: O(1) per run (not per-user)
- Monthly cost impact: $0 additional (Vercel cron executions already budgeted; these are corrections not new jobs)

## Test plan

- [ ] Verify `process-pre-saves` fires at 02:00 UTC by checking Vercel function logs the next day
- [ ] Verify `cleanup-sms-intents` fires at 01:00 UTC — confirm `smsSubscribeIntents` rows are being expired/deleted
- [ ] Verify `monitor-metadata-submissions` fires hourly — check for monitoring output in logs
- [ ] Verify `process-metadata-submissions` fires at 04:00 UTC — check submission queue drains

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated cron job registry documentation to include additional production-scheduled operations for interview summarization, playlist generation, metadata processing, and cleanup tasks.

* **Chores**
  * Added new scheduled cron job to production deployment configuration for playlist generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->