### PR TITLE
JOV-1852 Fix dashboard shell RLS session reads

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
+++ b/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
@@ -15,9 +15,9 @@ import { cache } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
 import { isAdmin as checkAdminRole } from '@/lib/admin/roles';
 import { resolveUserState } from '@/lib/auth/gate';
-import { withDbSession, withDbSessionTx } from '@/lib/auth/session';
+import { withDbSessionTx } from '@/lib/auth/session';
 import { CACHE_TAGS, CACHE_TTL } from '@/lib/cache/tags';
-import { type DbOrTransaction, db, doesTableExist } from '@/lib/db';
+import { type DbOrTransaction, doesTableExist } from '@/lib/db';
 import { getAvatarQualityForProfile } from '@/lib/db/queries/avatar-quality';
 import { dashboardQuery } from '@/lib/db/query-timeout';
 import { clickEvents, tips } from '@/lib/db/schema/analytics';
@@ -877,13 +877,13 @@ async function fetchDashboardShellWithSession(
   clerkUserId: string
 ): Promise<CoreData> {
   try {
-    // Use withDbSession (no transaction) instead of withDbSessionTx.
-    // The shell path only reads user + profiles — no writes, no atomicity needed.
-    // This skips BEGIN/COMMIT overhead (~50-150ms on cold Neon connections) while
-    // still setting the RLS session variable via connection-scoped set_config.
-    return await withDbSession(
-      async sessionUserId =>
-        fetchDashboardBaseWithSession(db, sessionUserId, {
+    // Keep shell reads inside the transaction-scoped session. RLS depends on
+    // app.clerk_user_id being set on the same pooled connection as the profile
+    // query; a connection-scoped setup followed by pooled reads can drop the
+    // session and make complete profiles look like onboarding is required.
+    return await withDbSessionTx(
+      async (tx, sessionUserId) =>
+        fetchDashboardBaseWithSession(tx, sessionUserId, {
           includeSettings: false,
         }),
       { clerkUserId }

--- a/apps/web/tests/unit/dashboard/dashboard-data-prefetch.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-data-prefetch.test.ts
@@ -55,16 +55,18 @@ vi.mock('react', async () => {
 
   return {
     ...actual,
-    cache: <T>(fn: () => Promise<T>) => {
+    cache: <TArgs extends unknown[], TResult>(
+      fn: (...args: TArgs) => Promise<TResult>
+    ) => {
       if (!cacheStore.has(fn)) {
         cacheStore.set(fn, { promise: null });
       }
       const entry = cacheStore.get(fn)!;
-      return () => {
+      return (...args: TArgs) => {
         if (!entry.promise) {
-          entry.promise = fn();
+          entry.promise = fn(...args);
         }
-        return entry.promise as Promise<T>;
+        return entry.promise as Promise<TResult>;
       };
     },
   };
@@ -273,8 +275,9 @@ describe('dashboard data prefetch', () => {
   });
 
   it('retries shell user lookup after auth reconciliation when the clerk row is missing', async () => {
-    // The shell path uses withDbSession (no transaction) + db directly.
-    // Mock db to return empty on first user lookup, then found on retry.
+    // The shell path must keep profile reads inside the same transaction-scoped
+    // session because creator profile visibility depends on RLS.
+    // Mock tx to return empty on first user lookup, then found on retry.
     const profile = {
       id: 'profile_1',
       userId: 'user_db_1',
@@ -287,9 +290,8 @@ describe('dashboard data prefetch', () => {
       updatedAt: new Date('2026-03-31T00:00:00.000Z'),
     };
 
-    const { db } = await import('@/lib/db');
-    const dbSelectMock = vi.mocked(db.select);
-    dbSelectMock
+    const selectMock = vi
+      .fn()
       .mockReturnValueOnce({
         from: vi.fn().mockReturnValue({
           where: vi.fn().mockReturnValue({
@@ -317,6 +319,9 @@ describe('dashboard data prefetch', () => {
           }),
         }),
       } as never);
+    withDbSessionTxMock.mockImplementationOnce(async handler =>
+      handler({ select: selectMock }, 'user_123')
+    );
 
     const { getDashboardShellData } = await import(
       '@/app/app/(shell)/dashboard/actions/dashboard-data'
@@ -327,6 +332,10 @@ describe('dashboard data prefetch', () => {
     expect(resolveUserStateMock).toHaveBeenCalledWith({
       createDbUserIfMissing: true,
     });
+    expect(withDbSessionTxMock).toHaveBeenCalledWith(expect.any(Function), {
+      clerkUserId: 'user_123',
+    });
+    expect(withDbSessionMock).not.toHaveBeenCalled();
     expect(result.user?.id).toBe('user_db_1');
     expect(result.selectedProfile?.id).toBe('profile_1');
     expect(result.needsOnboarding).toBe(false);
@@ -343,9 +352,8 @@ describe('dashboard data prefetch', () => {
       updatedAt: new Date('2026-03-31T00:00:00.000Z'),
     };
 
-    // Shell path now uses withDbSession (no transaction).
     // First call returns empty profile, second returns recovered profile.
-    withDbSessionMock
+    withDbSessionTxMock
       .mockImplementationOnce(async () => ({
         ...baseDashboardResponse,
         creatorProfiles: [],
@@ -365,7 +373,8 @@ describe('dashboard data prefetch', () => {
 
     const result = await getDashboardShellData('user_123');
 
-    expect(withDbSessionMock).toHaveBeenCalledTimes(2);
+    expect(withDbSessionTxMock).toHaveBeenCalledTimes(2);
+    expect(withDbSessionMock).not.toHaveBeenCalled();
     expect(result.selectedProfile?.id).toBe('profile_1');
     expect(result.needsOnboarding).toBe(false);
   });


### PR DESCRIPTION
## Summary\n- keep dashboard shell profile reads inside the existing transaction-scoped DB session\n- add regression coverage that the shell path uses withDbSessionTx and refreshes missing-profile snapshots\n\n## Testing\n- pnpm biome check --write 'apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts' apps/web/tests/unit/dashboard/dashboard-data-prefetch.test.ts\n- pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/dashboard-data-prefetch.test.ts\n- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec tsc --noEmit\n- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push\n\n## QA Notes\n- Root cause: the shell fast path used connection-scoped session setup followed by pooled reads; RLS-sensitive creator profile reads can lose app.clerk_user_id and return empty profiles, which redirects complete users to onboarding.\n- Focused Playwright smoke was attempted twice locally but the dev server hung/compiled for minutes and timed out after restart; this is parked as guarded auth-shell work for human verification.\n\nLinear: JOV-1852\nLabels: testing, needs-human

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where user profiles could incorrectly appear to require onboarding due to session loss when accessing the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->