### PR TITLE
JOV-1895 Keep renders state route static

### DIFF
--- a/apps/web/app/(marketing)/renders/[state]/MarketingStateRenderClient.tsx
+++ b/apps/web/app/(marketing)/renders/[state]/MarketingStateRenderClient.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { APP_ROUTES } from '@/constants/routes';
+import {
+  HOMEPAGE_PROFILE_PREVIEW_ARTIST,
+  HOMEPAGE_PROFILE_PREVIEW_CONTACTS,
+  HOMEPAGE_PROFILE_PREVIEW_RELEASES,
+  HOMEPAGE_PROFILE_PREVIEW_SOCIAL_LINKS,
+  HOMEPAGE_PROFILE_PREVIEW_TOUR_DATES,
+  HOMEPAGE_PROFILE_SHOWCASE_STATES,
+} from '@/features/home/homepage-profile-preview-fixture';
+import type {
+  ProfilePrimaryTab,
+  ProfileShowcaseStateId,
+} from '@/features/profile/contracts';
+import { ProfileCompactSurface } from '@/features/profile/templates/ProfileCompactSurface';
+
+interface MarketingStateRenderClientProps {
+  readonly stateId: ProfileShowcaseStateId;
+}
+
+function getLatestRelease(stateId: ProfileShowcaseStateId) {
+  const state = HOMEPAGE_PROFILE_SHOWCASE_STATES[stateId];
+  switch (state.latestReleaseKey) {
+    case 'presave':
+      return HOMEPAGE_PROFILE_PREVIEW_RELEASES.presave;
+    case 'live':
+      return HOMEPAGE_PROFILE_PREVIEW_RELEASES.live;
+    default:
+      return null;
+  }
+}
+
+function getPreviewActiveMode(
+  stateId: ProfileShowcaseStateId
+): ProfilePrimaryTab {
+  const drawerView = HOMEPAGE_PROFILE_SHOWCASE_STATES[stateId].drawerView;
+
+  switch (drawerView) {
+    case 'listen':
+    case 'subscribe':
+    case 'tour':
+      return drawerView;
+    default:
+      return 'profile';
+  }
+}
+
+function getRenderWidth(value: string | null) {
+  const width = Number.parseInt(value ?? '430', 10);
+  return Number.isFinite(width) ? width : 430;
+}
+
+export function MarketingStateRenderClient({
+  stateId,
+}: MarketingStateRenderClientProps) {
+  const searchParams = useSearchParams();
+  const state = HOMEPAGE_PROFILE_SHOWCASE_STATES[stateId];
+  const hideChrome = searchParams.get('chrome') !== 'true';
+  const width = getRenderWidth(searchParams.get('width'));
+
+  return (
+    <div
+      style={{
+        width: `${width}px`,
+        maxWidth: '100%',
+        borderRadius: '2rem',
+        overflow: 'hidden',
+        background: '#030507',
+      }}
+      data-testid='marketing-render'
+      data-hide-chrome={hideChrome}
+    >
+      <ProfileCompactSurface
+        dataTestId='marketing-render-surface'
+        renderMode='preview'
+        presentation='embedded'
+        artist={HOMEPAGE_PROFILE_PREVIEW_ARTIST}
+        socialLinks={[...HOMEPAGE_PROFILE_PREVIEW_SOCIAL_LINKS]}
+        contacts={[...HOMEPAGE_PROFILE_PREVIEW_CONTACTS]}
+        latestRelease={getLatestRelease(stateId)}
+        profileSettings={{ showOldReleases: true }}
+        genres={HOMEPAGE_PROFILE_PREVIEW_ARTIST.genres ?? []}
+        photoDownloadSizes={[]}
+        pressPhotos={[]}
+        allowPhotoDownloads={false}
+        tourDates={[...HOMEPAGE_PROFILE_PREVIEW_TOUR_DATES]}
+        showSubscriptionConfirmedBanner={state.showSubscriptionConfirmedBanner}
+        drawerOpen={state.drawerView !== null}
+        drawerView={state.drawerView ?? 'menu'}
+        activeMode={getPreviewActiveMode(stateId)}
+        onDrawerOpenChange={() => {}}
+        onDrawerViewChange={() => {}}
+        onModeSelect={() => {}}
+        onBack={() => {}}
+        onOpenMenu={() => {}}
+        onPlayClick={() => {}}
+        onShare={() => {}}
+        profileHref={`/${HOMEPAGE_PROFILE_PREVIEW_ARTIST.handle}`}
+        artistProfilesHref={APP_ROUTES.ARTIST_PROFILES}
+        isSubscribed={
+          stateId === 'fans-confirmed' ||
+          stateId === 'fans-song-alert' ||
+          stateId === 'fans-show-alert'
+        }
+        onTogglePref={() => {}}
+        onUnsubscribe={() => {}}
+        onManageNotifications={() => {}}
+        onRegisterReveal={() => {}}
+        onRevealNotifications={() => {}}
+        previewNotificationsState={state.notifications}
+        previewReleaseActionLabel={state.releaseActionLabel}
+        hideJovieBranding={hideChrome}
+        hideMoreMenu={hideChrome}
+      />
+    </div>
+  );
+}

--- a/apps/web/app/(marketing)/renders/[state]/page.tsx
+++ b/apps/web/app/(marketing)/renders/[state]/page.tsx
@@ -1,59 +1,26 @@
-'use client';
+import { Suspense } from 'react';
+import { HOMEPAGE_PROFILE_SHOWCASE_STATES } from '@/features/home/homepage-profile-preview-fixture';
+import type { ProfileShowcaseStateId } from '@/features/profile/contracts';
+import { MarketingStateRenderClient } from './MarketingStateRenderClient';
 
-import { useParams, useSearchParams } from 'next/navigation';
-import { APP_ROUTES } from '@/constants/routes';
-import {
-  HOMEPAGE_PROFILE_PREVIEW_ARTIST,
-  HOMEPAGE_PROFILE_PREVIEW_CONTACTS,
-  HOMEPAGE_PROFILE_PREVIEW_RELEASES,
-  HOMEPAGE_PROFILE_PREVIEW_SOCIAL_LINKS,
-  HOMEPAGE_PROFILE_PREVIEW_TOUR_DATES,
-  HOMEPAGE_PROFILE_SHOWCASE_STATES,
-} from '@/features/home/homepage-profile-preview-fixture';
-import type {
-  ProfilePrimaryTab,
-  ProfileShowcaseStateId,
-} from '@/features/profile/contracts';
-import { ProfileCompactSurface } from '@/features/profile/templates/ProfileCompactSurface';
+export const revalidate = false;
+export const dynamicParams = false;
 
 const VALID_STATES = Object.keys(
   HOMEPAGE_PROFILE_SHOWCASE_STATES
 ) as ProfileShowcaseStateId[];
 
-function getLatestRelease(stateId: ProfileShowcaseStateId) {
-  const state = HOMEPAGE_PROFILE_SHOWCASE_STATES[stateId];
-  switch (state.latestReleaseKey) {
-    case 'presave':
-      return HOMEPAGE_PROFILE_PREVIEW_RELEASES.presave;
-    case 'live':
-      return HOMEPAGE_PROFILE_PREVIEW_RELEASES.live;
-    default:
-      return null;
-  }
+export function generateStaticParams() {
+  return VALID_STATES.map(state => ({ state }));
 }
 
-function getPreviewActiveMode(
-  stateId: ProfileShowcaseStateId
-): ProfilePrimaryTab {
-  const drawerView = HOMEPAGE_PROFILE_SHOWCASE_STATES[stateId].drawerView;
-
-  switch (drawerView) {
-    case 'listen':
-    case 'subscribe':
-    case 'tour':
-      return drawerView;
-    default:
-      return 'profile';
-  }
-}
-
-export default function MarketingRenderPage() {
-  const params = useParams<{ state: string }>();
-  const searchParams = useSearchParams();
-
-  const stateId = params.state as ProfileShowcaseStateId;
-  const hideChrome = searchParams.get('chrome') !== 'true';
-  const width = searchParams.get('width') ?? '430';
+export default async function MarketingRenderPage({
+  params,
+}: {
+  readonly params: Promise<{ state: string }>;
+}) {
+  const { state } = await params;
+  const stateId = state as ProfileShowcaseStateId;
 
   if (!VALID_STATES.includes(stateId)) {
     return (
@@ -75,69 +42,14 @@ export default function MarketingRenderPage() {
     );
   }
 
-  const state = HOMEPAGE_PROFILE_SHOWCASE_STATES[stateId];
-
   return (
     <div
       className='flex min-h-screen items-center justify-center bg-black'
       style={{ padding: '2rem' }}
     >
-      <div
-        style={{
-          width: `${width}px`,
-          maxWidth: '100%',
-          borderRadius: '2rem',
-          overflow: 'hidden',
-          background: '#030507',
-        }}
-        data-testid='marketing-render'
-        data-hide-chrome={hideChrome}
-      >
-        <ProfileCompactSurface
-          dataTestId='marketing-render-surface'
-          renderMode='preview'
-          presentation='embedded'
-          artist={HOMEPAGE_PROFILE_PREVIEW_ARTIST}
-          socialLinks={[...HOMEPAGE_PROFILE_PREVIEW_SOCIAL_LINKS]}
-          contacts={[...HOMEPAGE_PROFILE_PREVIEW_CONTACTS]}
-          latestRelease={getLatestRelease(stateId)}
-          profileSettings={{ showOldReleases: true }}
-          genres={HOMEPAGE_PROFILE_PREVIEW_ARTIST.genres ?? []}
-          photoDownloadSizes={[]}
-          pressPhotos={[]}
-          allowPhotoDownloads={false}
-          tourDates={[...HOMEPAGE_PROFILE_PREVIEW_TOUR_DATES]}
-          showSubscriptionConfirmedBanner={
-            state.showSubscriptionConfirmedBanner
-          }
-          drawerOpen={state.drawerView !== null}
-          drawerView={state.drawerView ?? 'menu'}
-          activeMode={getPreviewActiveMode(stateId)}
-          onDrawerOpenChange={() => {}}
-          onDrawerViewChange={() => {}}
-          onModeSelect={() => {}}
-          onBack={() => {}}
-          onOpenMenu={() => {}}
-          onPlayClick={() => {}}
-          onShare={() => {}}
-          profileHref={`/${HOMEPAGE_PROFILE_PREVIEW_ARTIST.handle}`}
-          artistProfilesHref={APP_ROUTES.ARTIST_PROFILES}
-          isSubscribed={
-            stateId === 'fans-confirmed' ||
-            stateId === 'fans-song-alert' ||
-            stateId === 'fans-show-alert'
-          }
-          onTogglePref={() => {}}
-          onUnsubscribe={() => {}}
-          onManageNotifications={() => {}}
-          onRegisterReveal={() => {}}
-          onRevealNotifications={() => {}}
-          previewNotificationsState={state.notifications}
-          previewReleaseActionLabel={state.releaseActionLabel}
-          hideJovieBranding={hideChrome}
-          hideMoreMenu={hideChrome}
-        />
-      </div>
+      <Suspense fallback={null}>
+        <MarketingStateRenderClient stateId={stateId} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/web/tests/unit/marketing/static-revalidate-policy.test.ts
+++ b/apps/web/tests/unit/marketing/static-revalidate-policy.test.ts
@@ -55,10 +55,8 @@ describe('static marketing route policy', () => {
       source: readFileSync(path, 'utf8'),
     }));
     const staticEntrypointViolations = routeSources
-      .filter(
-        ({ path, source }) =>
-          STATIC_ENTRYPOINT_FILENAMES.has(path.split(/[\\/]/).at(-1) ?? '') &&
-          !/^\s*['"]use client['"];/m.test(source)
+      .filter(({ path }) =>
+        STATIC_ENTRYPOINT_FILENAMES.has(path.split(/[\\/]/).at(-1) ?? '')
       )
       .filter(
         ({ source }) =>


### PR DESCRIPTION
## Summary
- make `/renders/[state]` a static server route with explicit static params
- move query-string render controls into a nested client component
- tighten static marketing policy coverage so client route entrypoints are not exempt

## Testing
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write `apps/web/app/(marketing)/renders/[state]/page.tsx` `apps/web/app/(marketing)/renders/[state]/MarketingStateRenderClient.tsx` apps/web/tests/unit/marketing/static-revalidate-policy.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/marketing/static-revalidate-policy.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec tsc --noEmit
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push

Linear: JOV-1895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Marketing preview pages now support URL parameters to customize UI chrome visibility and rendering width for flexible preview testing and configuration

* **Performance**
  * Marketing render pages now use static generation for faster initial page loads and improved site performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->