### PR TITLE
feat(user-menu): add Download Desktop App link

### DIFF
--- a/apps/web/components/organisms/user-button/UserButton.tsx
+++ b/apps/web/components/organisms/user-button/UserButton.tsx
@@ -9,6 +9,7 @@ import {
   Keyboard,
   LogOut,
   MessageSquare,
+  Monitor,
   Settings,
   Shield,
   Sparkles,
@@ -128,6 +129,19 @@ function buildDropdownItems({
       icon: Settings,
       onClick: handleSettings,
       shortcut: 'G S',
+    },
+    {
+      type: 'action' as const,
+      id: 'download-desktop',
+      label: 'Download Desktop App',
+      icon: Monitor,
+      onClick: () => {
+        window.open(
+          'https://github.com/JovieInc/Jovie/releases/latest',
+          '_blank',
+          'noopener,noreferrer'
+        );
+      },
     },
   ];
 


### PR DESCRIPTION
## Summary

- Adds a **Download Desktop App** item to the avatar dropdown menu, positioned directly after Settings (before the Learn more submenu).
- Uses the `Monitor` icon from `lucide-react`; clicking opens `https://github.com/JovieInc/Jovie/releases/latest` in a new tab with `noopener,noreferrer`.

## Test plan

- [ ] Sign in and open the avatar dropdown in the top-right corner of the dashboard.
- [ ] Confirm "Download Desktop App" appears immediately after "Settings".
- [ ] Click the item — verify it opens the GitHub Releases page in a new tab.
- [ ] Confirm no layout regressions in the dropdown (separators, billing item, feedback, sign out all render correctly).

## Cost Impact
None — no external API calls, no cron jobs, no scheduled work. Pure client-side `window.open`.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * A "Download Desktop App" menu option has been added to the user menu, enabling quick access to the latest desktop application release. Selecting this option opens the desktop app download page in a new browser window, providing a streamlined process for users interested in trying or upgrading to the desktop version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->