### PR TITLE
fix(hud): resolve "default export is not a React Component" black screen (JOV-1900)

### DIFF
--- a/apps/web/app/hud/page.tsx
+++ b/apps/web/app/hud/page.tsx
@@ -60,9 +60,10 @@ async function getHudAbsoluteUrl(kioskToken: string | null): Promise<string> {
 export default async function HudPage({
   searchParams,
 }: Readonly<{
-  searchParams: SearchParams;
+  searchParams: Promise<SearchParams>;
 }>) {
-  const kioskTokenRaw = searchParams.kiosk;
+  const resolvedSearchParams = await searchParams;
+  const kioskTokenRaw = resolvedSearchParams.kiosk;
   const kioskToken = typeof kioskTokenRaw === 'string' ? kioskTokenRaw : null;
 
   const auth = await authorizeHud(kioskToken);


### PR DESCRIPTION
## Summary

- Fixes `http://localhost:3000/hud` black screen with console error: `Uncaught Error: The default export is not a React Component in "/hud/page"`
- Awaits `searchParams` as `Promise<SearchParams>` per Next.js 15+/16 requirement
- Single-file, minimal change with no behavioral differences

## Root cause

In Next.js 15 and above, `searchParams` in App Router page components is a `Promise<SearchParams>` that must be `await`ed before accessing keys. The HUD page used the Next.js 14 synchronous pattern (`searchParams: SearchParams`), which caused the Next.js runtime to fail to recognize the default export as a valid React component — producing the black screen.

## The fix

Changed `searchParams` type from `SearchParams` to `Promise<SearchParams>` and added `const resolvedSearchParams = await searchParams;` before accessing `.kiosk`. Pattern matches the canonical admin pages in this codebase (e.g., `apps/web/app/app/(shell)/admin/waitlist/page.tsx`).

## Test plan

- Navigate to `http://localhost:3000/hud` — page renders (shows auth wall or HUD metrics, depending on auth state)
- No "default export is not a React Component" error in browser console
- TypeScript typecheck passes (`pnpm turbo typecheck`)
- Biome clean on modified file

## Linear

[JOV-1900](https://linear.app/jovie/issue/JOV-1900/hud-black-screen-on-hud-root-cause-investigation)

## Cost Impact

None — no new external API, no cron, no scheduled work. Single-file type annotation fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated search parameter handling to support asynchronous resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->