### PR TITLE
JOV-1903 Fix hidden marketing flyout focus

### DIFF
--- a/apps/web/components/organisms/HeaderNav.tsx
+++ b/apps/web/components/organisms/HeaderNav.tsx
@@ -153,6 +153,7 @@ function MarketingGlassFlyout({
         open && 'marketing-glass-header__flyout--open'
       )}
       aria-hidden={!open}
+      inert={!open}
     >
       <div className='marketing-glass-header__flyout-inner'>
         <p className='marketing-glass-header__flyout-heading'>{menu.heading}</p>

--- a/apps/web/tests/unit/components/site/MarketingHeader.test.tsx
+++ b/apps/web/tests/unit/components/site/MarketingHeader.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MarketingHeader } from '@/components/site/MarketingHeader';
 
@@ -36,6 +36,29 @@ describe('MarketingHeader', () => {
       'href',
       '/support'
     );
+  });
+
+  it('removes hidden flyout links from the tab order until opened', () => {
+    const { container } = render(<MarketingHeader />);
+    const featuresTrigger = screen.getByRole('button', { name: /Features/ });
+    const featuresFlyout = container.querySelector(
+      '#marketing-header-flyout-features'
+    );
+    const resourcesFlyout = container.querySelector(
+      '#marketing-header-flyout-resources'
+    );
+
+    expect(featuresFlyout).toHaveAttribute('aria-hidden', 'true');
+    expect(featuresFlyout).toHaveAttribute('inert');
+    expect(resourcesFlyout).toHaveAttribute('aria-hidden', 'true');
+    expect(resourcesFlyout).toHaveAttribute('inert');
+
+    fireEvent.mouseEnter(featuresTrigger);
+
+    expect(featuresFlyout).toHaveAttribute('aria-hidden', 'false');
+    expect(featuresFlyout).not.toHaveAttribute('inert');
+    expect(resourcesFlyout).toHaveAttribute('aria-hidden', 'true');
+    expect(resourcesFlyout).toHaveAttribute('inert');
   });
 
   it('renders explicit custom nav links consistently as simple glass links', () => {


### PR DESCRIPTION
## Summary
- Fixes JOV-1903 / post-merge main CI failure from `A11y (axe)` on run 25528299745 / SHA 92fb3b5.
- Adds `inert` to closed marketing header flyout containers so links inside `aria-hidden` flyouts are not focusable.
- Adds focused MarketingHeader coverage for closed/open flyout inert state.

Linear: https://linear.app/jovie/issue/JOV-1903/fix-hidden-marketing-flyout-focus-in-public-axe-audit

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/organisms/HeaderNav.tsx apps/web/tests/unit/components/site/MarketingHeader.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/components/site/MarketingHeader.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec tsc -p tsconfig.typecheck.json --noEmit --incremental --tsBuildInfoFile .cache/tsbuildinfo`
- pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`

## Risk
- Low-risk accessibility-only UI behavior fix. No route, API, auth, billing, entitlement, schema, or migration changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced header navigation flyout menus' accessibility for screen readers and keyboard navigation.

* **Tests**
  * Added test coverage for flyout menu visibility and accessibility behavior when toggling between different menu sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->