### PR TITLE
fix(hud): await searchParams, add QueryClientProvider, fix clock hydration

### DIFF
--- a/apps/web/app/hud/HudClockClient.tsx
+++ b/apps/web/app/hud/HudClockClient.tsx
@@ -20,9 +20,15 @@ export function HudClockClient({ locale }: HudClockClientProps) {
     });
   }, [resolvedLocale]);
 
-  const [now, setNow] = useState<Date>(() => new Date());
+  // Initialize as null to avoid SSR/client hydration mismatch: the server
+  // renders a timestamp that the client would immediately disagree with.
+  // We show nothing until the first client-side tick so React can safely
+  // hydrate without a warning.
+  const [now, setNow] = useState<Date | null>(null);
 
   useEffect(() => {
+    // Set immediately on mount, then update every second.
+    setNow(new Date());
     const id = setInterval(() => {
       setNow(new Date());
     }, 1000);
@@ -31,6 +37,8 @@ export function HudClockClient({ locale }: HudClockClientProps) {
       clearInterval(id);
     };
   }, []);
+
+  if (now === null) return null;
 
   return <span>{formatter.format(now)}</span>;
 }

--- a/apps/web/app/hud/layout.tsx
+++ b/apps/web/app/hud/layout.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react';
+import { QueryProvider } from '@/components/providers/QueryProvider';
+
+// The HUD route lives outside /app/* and does not inherit the shell QueryClient.
+// Provide a standalone QueryClient so useHudMetricsQuery (TanStack Query) works.
+export default function HudLayout({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  return <QueryProvider>{children}</QueryProvider>;
+}


### PR DESCRIPTION
## Summary

QA pass on HUD route (/hud) — identified and root-caused all console errors observed during exhaustive interaction. Three independent bugs, three minimal fixes.

## Console errors found (before)

**Error 1 — Next.js 15 sync searchParams access (server warning, breaks auth)**
```
Route "/hud" used `searchParams.kiosk`. `searchParams` is a Promise and must be
unwrapped with `await` or `React.use()` before accessing its properties.
```
Result: kiosk token was never read → auth always failed → HUD showed unauthorized screen even with a valid token.

**Error 2 — TanStack Query crash (uncaught exception)**
```
Error: No QueryClient set, use QueryClientProvider to set one
```
The /hud route sits outside /app/* so it doesn't inherit the shell's QueryClientProvider. `useHudMetricsQuery` (polling refresh) threw on every render.

**Error 3 — React hydration mismatch (client warning)**
`HudClockClient` initialized `useState` with `new Date()` at server render time. The client hydrated with a different timestamp (time had advanced), producing a hydration mismatch warning.

## Root causes + fixes

| # | Error | Root cause | Fix | File |
|---|-------|-----------|-----|------|
| 1 | sync-dynamic-apis | `searchParams` typed as sync `Record<...>` (old Next.js 14 pattern) | Changed type to `Promise<Record<...>>`, added `await searchParams` | `apps/web/app/hud/page.tsx` |
| 2 | No QueryClient | /hud has no layout providing QueryClientProvider | Added `apps/web/app/hud/layout.tsx` wrapping children in `<QueryProvider>` | `apps/web/app/hud/layout.tsx` (new file) |
| 3 | Hydration mismatch | `useState(() => new Date())` initializes with server timestamp; client disagrees | Init state as `null`, return `null` until first `useEffect` tick, then tick every 1s | `apps/web/app/hud/HudClockClient.tsx` |

## Console after

- Error 1: gone — kiosk token auth now works correctly
- Error 2: gone — QueryClient available, polling refresh works
- Error 3: gone — clock renders nothing on SSR, shows correct time after hydration

Remaining expected server-side log: `[ERROR] Error loading Mercury metrics` — Mercury API returns 404 in dev because the dev account has no Neon account configured. This is a dev-env-only data issue, not a code bug.

## Verification

- `pnpm typecheck`: pass (pre-push hook: clean)
- `pnpm biome check`: pass (pre-push hook: clean)
- `pnpm lint:eslint`: pass (pre-push hook: clean)
- Pre-commit hooks: pass
- Pre-push hooks: pass (proxy-guard, tailwind-check, typecheck, lint all green)
- Manual interaction sweep: HUD loads with kiosk token, clock ticks, polling refresh runs, console clean

## Screenshots

Before: unauthorized screen even with valid kiosk token (searchParams bug)
After: full HUD dashboard loads, clock shows live time, all sections render

## Notes

No Linear issue — ad-hoc QA driven by Tim's local console errors.

Pattern: `/app/*` routes inherit `QueryClientProvider` through `app/app/layout.tsx → ResolvedClientProviders → ClientProviders → QueryProvider`. Any future routes added outside `/app/` that use TanStack Query must add their own layout with `<QueryProvider>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HUD clock display consistency issues across rendering cycles.
  * Improved HUD routes initialization for stable data queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->