### PR TITLE
JOV-1904 Fix duplicate profile mode h1

### DIFF
--- a/apps/web/app/(marketing)/not-found.tsx
+++ b/apps/web/app/(marketing)/not-found.tsx
@@ -19,7 +19,7 @@ export default function NotFound() {
         {/* Error code — oversized, muted */}
         <div className='mb-8 select-none'>
           <span
-            className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.34]'
+            className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.42]'
             aria-hidden='true'
           >
             404

--- a/apps/web/app/[username]/[slug]/not-found.tsx
+++ b/apps/web/app/[username]/[slug]/not-found.tsx
@@ -9,7 +9,7 @@ export default function SmartLinkNotFound() {
       <div className='w-full max-w-sm text-center'>
         <div className='mb-6 select-none'>
           <span
-            className='block text-[100px] font-semibold leading-none tracking-tighter text-primary-token/[0.34]'
+            className='block text-[100px] font-semibold leading-none tracking-tighter text-primary-token/[0.42]'
             aria-hidden='true'
           >
             404

--- a/apps/web/app/[username]/not-found.tsx
+++ b/apps/web/app/[username]/not-found.tsx
@@ -14,7 +14,7 @@ export default function NotFound() {
           {/* Error code — oversized, ghosted */}
           <div className='mb-8 select-none'>
             <span
-              className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.34]'
+              className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.42]'
               aria-hidden='true'
             >
               404
@@ -33,7 +33,7 @@ export default function NotFound() {
 
             <Link
               href='/'
-              className='inline-flex items-center justify-center h-8 px-4 text-[13px] font-medium rounded-lg bg-[var(--color-btn-primary-bg)] text-[var(--color-btn-primary-fg)] hover:bg-[var(--color-btn-primary-hover)] transition-colors duration-100'
+              className='inline-flex items-center justify-center h-8 px-4 text-[13px] font-medium rounded-lg bg-[var(--color-btn-primary-bg)] text-[var(--color-btn-primary-fg)] hover:bg-[var(--color-btn-primary-hover)] transition-colors duration-subtle'
             >
               Go home
             </Link>

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -18,7 +18,7 @@ export default function NotFound() {
             {/* Error code — oversized, muted, architectural */}
             <div className='mb-8 select-none'>
               <span
-                className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.34]'
+                className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.42]'
                 aria-hidden='true'
               >
                 404
@@ -37,7 +37,7 @@ export default function NotFound() {
 
               <Link
                 href='/'
-                className='inline-flex items-center justify-center h-8 px-4 text-[13px] font-medium rounded-lg bg-[var(--color-btn-primary-bg)] text-[var(--color-btn-primary-fg)] hover:bg-[var(--color-btn-primary-hover)] transition-colors duration-100'
+                className='inline-flex items-center justify-center h-8 px-4 text-[13px] font-medium rounded-lg bg-[var(--color-btn-primary-bg)] text-[var(--color-btn-primary-fg)] hover:bg-[var(--color-btn-primary-hover)] transition-colors duration-subtle'
               >
                 Return home
               </Link>

--- a/apps/web/components/features/profile/ProfileDrawerShell.tsx
+++ b/apps/web/components/features/profile/ProfileDrawerShell.tsx
@@ -66,7 +66,7 @@ export function ProfileDrawerShell({
             <button
               type='button'
               onClick={onBack}
-              className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white/[0.04] text-white/44 transition-colors duration-150 hover:bg-white/[0.08] hover:text-white/74 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]'
+              className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white/[0.04] text-white/44 transition-colors duration-subtle hover:bg-white/[0.08] hover:text-white/74 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]'
               aria-label='Back'
               data-testid='profile-drawer-back-button'
             >
@@ -104,7 +104,7 @@ export function ProfileDrawerShell({
             <button
               type='button'
               onClick={() => onOpenChange(false)}
-              className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white/[0.04] text-white/44 transition-colors duration-150 hover:bg-white/[0.08] hover:text-white/74 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]'
+              className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white/[0.04] text-white/44 transition-colors duration-subtle hover:bg-white/[0.08] hover:text-white/74 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]'
               aria-label='Close'
               data-testid='profile-drawer-close-button'
             >
@@ -222,15 +222,12 @@ export function ProfileDrawerShell({
             style={drawerHeightStyle}
             data-testid={dataTestId}
             aria-labelledby={titleId}
-            aria-describedby={accessibleDescriptionId}
           >
             <Drawer.Title asChild>
               <span className='sr-only'>{title}</span>
             </Drawer.Title>
             <Drawer.Description asChild>
-              <span id={accessibleDescriptionId} className='sr-only'>
-                {accessibleDescription}
-              </span>
+              <span className='sr-only'>{accessibleDescription}</span>
             </Drawer.Description>
             {header}
             {body}

--- a/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Bell, CheckCircle2, ChevronRight, Mail } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
 import { AboutSection } from '@/features/profile/AboutSection';
 import { ArtistNotificationsCTA } from '@/features/profile/artist-notifications-cta/ArtistNotificationsCTA';
 import { TwoStepNotificationsCTA } from '@/features/profile/artist-notifications-cta/TwoStepNotificationsCTA';
@@ -167,6 +168,7 @@ function SubscribePanel({
   previewNotificationsState,
   onFlowClosed,
   onSubscriptionActivated,
+  keepSubscribeFlowMounted = false,
 }: Readonly<{
   artist: Artist;
   isSubscribed: boolean;
@@ -181,6 +183,7 @@ function SubscribePanel({
   previewNotificationsState?: ProfilePreviewNotificationsState;
   onFlowClosed?: () => void;
   onSubscriptionActivated?: () => void;
+  keepSubscribeFlowMounted?: boolean;
 }>) {
   if (renderMode === 'preview') {
     return (
@@ -197,7 +200,7 @@ function SubscribePanel({
     );
   }
 
-  if (!isSubscribed) {
+  if (!(isSubscribed && !keepSubscribeFlowMounted)) {
     return (
       <div
         className={NATIVE_PANEL_CLASS_NAME}
@@ -419,6 +422,25 @@ export function ProfilePrimaryTabPanel({
   onFlowClosed,
   onSubscriptionActivated,
 }: Readonly<ProfilePrimaryTabPanelProps>) {
+  const [keepSubscribeFlowMounted, setKeepSubscribeFlowMounted] =
+    useState(false);
+
+  useEffect(() => {
+    if (!isSubscribed) {
+      setKeepSubscribeFlowMounted(true);
+    }
+  }, [isSubscribed]);
+
+  const handleSubscribeFlowClosed = useCallback(() => {
+    setKeepSubscribeFlowMounted(false);
+    onFlowClosed?.();
+  }, [onFlowClosed]);
+
+  const handleSubscriptionActivated = useCallback(() => {
+    setKeepSubscribeFlowMounted(true);
+    onSubscriptionActivated?.();
+  }, [onSubscriptionActivated]);
+
   if (mode === 'listen') {
     const visibleReleases = releases.filter(release => Boolean(release.slug));
 
@@ -497,8 +519,9 @@ export function ProfilePrimaryTabPanel({
         subscribeTwoStep={subscribeTwoStep}
         alertOptInVariant={alertOptInVariant}
         previewNotificationsState={previewNotificationsState}
-        onFlowClosed={onFlowClosed}
-        onSubscriptionActivated={onSubscriptionActivated}
+        onFlowClosed={handleSubscribeFlowClosed}
+        onSubscriptionActivated={handleSubscriptionActivated}
+        keepSubscribeFlowMounted={keepSubscribeFlowMounted}
       />
     );
   }

--- a/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
@@ -2,6 +2,8 @@
 
 import { Bell, CheckCircle2, ChevronRight, Mail } from 'lucide-react';
 import { AboutSection } from '@/features/profile/AboutSection';
+import { ArtistNotificationsCTA } from '@/features/profile/artist-notifications-cta/ArtistNotificationsCTA';
+import { TwoStepNotificationsCTA } from '@/features/profile/artist-notifications-cta/TwoStepNotificationsCTA';
 import type {
   ProfilePreviewNotificationsState,
   ProfilePrimaryTab,
@@ -152,21 +154,33 @@ function PreviewAlertsPanel({
 }
 
 function SubscribePanel({
+  artist,
   isSubscribed,
   contentPrefs,
   onTogglePref,
   onUnsubscribe,
   isUnsubscribing,
   renderMode,
+  notificationsPortalContainer,
+  subscribeTwoStep,
+  alertOptInVariant,
   previewNotificationsState,
+  onFlowClosed,
+  onSubscriptionActivated,
 }: Readonly<{
+  artist: Artist;
   isSubscribed: boolean;
   contentPrefs: Record<NotificationContentType, boolean>;
   onTogglePref: (key: NotificationContentType) => void;
   onUnsubscribe: () => void;
   isUnsubscribing: boolean;
   renderMode: ProfileRenderMode;
+  notificationsPortalContainer?: HTMLElement | null;
+  subscribeTwoStep?: boolean;
+  alertOptInVariant?: ProfileAlertOptInVariant;
   previewNotificationsState?: ProfilePreviewNotificationsState;
+  onFlowClosed?: () => void;
+  onSubscriptionActivated?: () => void;
 }>) {
   if (renderMode === 'preview') {
     return (
@@ -180,6 +194,40 @@ function SubscribePanel({
         }
         isSubscribed={isSubscribed}
       />
+    );
+  }
+
+  if (!isSubscribed) {
+    return (
+      <div
+        className={NATIVE_PANEL_CLASS_NAME}
+        data-testid='profile-primary-tab-subscribe'
+      >
+        {subscribeTwoStep ? (
+          <TwoStepNotificationsCTA
+            artist={artist}
+            startExpanded
+            presentation='inline'
+            portalContainer={notificationsPortalContainer}
+            onFlowClosed={onFlowClosed}
+            onSubscriptionActivated={onSubscriptionActivated}
+            experimentVariant={alertOptInVariant}
+          />
+        ) : (
+          <ArtistNotificationsCTA
+            artist={artist}
+            presentation='inline'
+            variant='button'
+            autoOpen
+            forceExpanded
+            hideListenFallback
+            portalContainer={notificationsPortalContainer}
+            onFlowClosed={onFlowClosed}
+            onSubscriptionActivated={onSubscriptionActivated}
+            experimentVariant={alertOptInVariant}
+          />
+        )}
+      </div>
     );
   }
 
@@ -204,7 +252,7 @@ function SettingsToggle({
   return (
     <span
       className={cn(
-        'relative h-[26px] w-[42px] shrink-0 rounded-full border p-0.5 transition-colors duration-200',
+        'relative h-[26px] w-[42px] shrink-0 rounded-full border p-0.5 transition-colors duration-subtle',
         checked
           ? 'border-white/40 bg-white'
           : 'border-white/14 bg-white/[0.08]',
@@ -214,7 +262,7 @@ function SettingsToggle({
     >
       <span
         className={cn(
-          'block h-[22px] w-[22px] rounded-full shadow-[0_4px_10px_rgba(0,0,0,0.22)] transition-transform duration-200',
+          'block h-[22px] w-[22px] rounded-full shadow-[0_4px_10px_rgba(0,0,0,0.22)] transition-transform duration-subtle',
           checked ? 'translate-x-4 bg-black' : 'translate-x-0 bg-white'
         )}
       />
@@ -240,7 +288,7 @@ function AlertsSettingsRow({
       type='button'
       onClick={onClick}
       disabled={disabled}
-      className='flex min-h-[62px] w-full items-center gap-3 border-t border-white/[0.075] px-4 py-3 text-left transition-colors duration-200 first:border-t-0 hover:bg-white/[0.03] disabled:cursor-default disabled:hover:bg-transparent'
+      className='flex min-h-[62px] w-full items-center gap-3 border-t border-white/[0.075] px-4 py-3 text-left transition-colors duration-subtle first:border-t-0 hover:bg-white/[0.03] disabled:cursor-default disabled:hover:bg-transparent'
     >
       <div className='min-w-0 flex-1'>
         <p className='truncate text-[15px] font-medium tracking-[-0.01em] text-white'>
@@ -335,7 +383,7 @@ function AlertsSettingsView({
           type='button'
           onClick={onUnsubscribe}
           disabled={isUnsubscribing}
-          className='mt-5 w-full px-4 py-3 text-center text-[14px] font-semibold text-white/72 transition-colors duration-200 hover:text-white disabled:cursor-not-allowed disabled:text-white/36'
+          className='mt-5 w-full px-4 py-3 text-center text-[14px] font-semibold text-white/72 transition-colors duration-subtle hover:text-white disabled:cursor-not-allowed disabled:text-white/36'
         >
           {isUnsubscribing ? 'Turning Off...' : 'Turn Off Alerts'}
         </button>
@@ -353,7 +401,10 @@ export function ProfilePrimaryTabPanel({
   renderMode = 'interactive',
   artist,
   dsps,
+  notificationsPortalContainer,
   enableDynamicEngagement = false,
+  subscribeTwoStep = false,
+  alertOptInVariant,
   isSubscribed,
   contentPrefs,
   onTogglePref,
@@ -365,6 +416,8 @@ export function ProfilePrimaryTabPanel({
   tourDates = [],
   releases = [],
   previewNotificationsState,
+  onFlowClosed,
+  onSubscriptionActivated,
 }: Readonly<ProfilePrimaryTabPanelProps>) {
   if (mode === 'listen') {
     const visibleReleases = releases.filter(release => Boolean(release.slug));
@@ -433,13 +486,19 @@ export function ProfilePrimaryTabPanel({
   if (mode === 'subscribe') {
     return (
       <SubscribePanel
+        artist={artist}
         renderMode={renderMode}
         isSubscribed={isSubscribed}
         contentPrefs={contentPrefs}
         onTogglePref={onTogglePref}
         onUnsubscribe={onUnsubscribe}
         isUnsubscribing={isUnsubscribing}
+        notificationsPortalContainer={notificationsPortalContainer}
+        subscribeTwoStep={subscribeTwoStep}
+        alertOptInVariant={alertOptInVariant}
         previewNotificationsState={previewNotificationsState}
+        onFlowClosed={onFlowClosed}
+        onSubscriptionActivated={onSubscriptionActivated}
       />
     );
   }

--- a/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
@@ -200,7 +200,7 @@ function SubscribePanel({
     );
   }
 
-  if (!(isSubscribed && !keepSubscribeFlowMounted)) {
+  if (!isSubscribed || keepSubscribeFlowMounted) {
     return (
       <div
         className={NATIVE_PANEL_CLASS_NAME}

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -187,6 +187,7 @@ export function ProfileInlineNotificationsCTA({
   const activatedInCurrentFlowRef = useRef(false);
   const otpVerificationInFlightRef = useRef(false);
   const previousOtpLengthRef = useRef(otpCode.length);
+  const pendingCompletedOtpRef = useRef<string | null>(null);
 
   const isInline = presentation === 'inline';
   const artistEmailReady = readArtistEmailReadyFromSettings(artist.settings);
@@ -438,17 +439,31 @@ export function ProfileInlineNotificationsCTA({
     const previousOtpLength = previousOtpLengthRef.current;
     previousOtpLengthRef.current = otpCode.length;
 
-    if (
-      step !== 'otp' ||
-      previousOtpLength >= 6 ||
-      otpCode.length !== 6 ||
-      isSubmitting
-    ) {
+    if (step !== 'otp') {
+      pendingCompletedOtpRef.current = null;
       return;
     }
 
+    if (otpCode.length < 6) {
+      pendingCompletedOtpRef.current = null;
+      return;
+    }
+
+    if (previousOtpLength < 6) {
+      pendingCompletedOtpRef.current = otpCode;
+    }
+
+    if (pendingCompletedOtpRef.current !== otpCode) {
+      return;
+    }
+
+    if (isSubmitting || otpVerificationInFlightRef.current) {
+      return;
+    }
+
+    pendingCompletedOtpRef.current = null;
     void handleOtpSubmit();
-  }, [handleOtpSubmit, isSubmitting, otpCode.length, step]);
+  }, [handleOtpSubmit, isSubmitting, otpCode, step]);
 
   const handleNameSubmit = useCallback(() => {
     const trimmed = nameInput.trim();

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -186,6 +186,7 @@ export function ProfileInlineNotificationsCTA({
   const hasAutoOpenedRef = useRef(false);
   const activatedInCurrentFlowRef = useRef(false);
   const otpVerificationInFlightRef = useRef(false);
+  const previousOtpLengthRef = useRef(otpCode.length);
 
   const isInline = presentation === 'inline';
   const artistEmailReady = readArtistEmailReadyFromSettings(artist.settings);
@@ -434,7 +435,15 @@ export function ProfileInlineNotificationsCTA({
   );
 
   useEffect(() => {
-    if (step !== 'otp' || otpCode.length !== 6 || isSubmitting) {
+    const previousOtpLength = previousOtpLengthRef.current;
+    previousOtpLengthRef.current = otpCode.length;
+
+    if (
+      step !== 'otp' ||
+      previousOtpLength >= 6 ||
+      otpCode.length !== 6 ||
+      isSubmitting
+    ) {
       return;
     }
 

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -433,6 +433,14 @@ export function ProfileInlineNotificationsCTA({
     ]
   );
 
+  useEffect(() => {
+    if (step !== 'otp' || otpCode.length !== 6 || isSubmitting) {
+      return;
+    }
+
+    void handleOtpSubmit();
+  }, [handleOtpSubmit, isSubmitting, otpCode.length, step]);
+
   const handleNameSubmit = useCallback(() => {
     const trimmed = nameInput.trim();
     setStep('birthday');

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -295,7 +295,12 @@ export function ProfileInlineNotificationsCTA({
       !(isInline || autoOpen) ||
       !isFlowOpen ||
       !isSubscribed ||
-      activatedInCurrentFlowRef.current
+      activatedInCurrentFlowRef.current ||
+      (flowOrigin === 'subscribe' &&
+        (step === 'otp' ||
+          step === 'name' ||
+          step === 'birthday' ||
+          step === 'done'))
     ) {
       return;
     }
@@ -303,7 +308,7 @@ export function ProfileInlineNotificationsCTA({
     setFlowOrigin('manage');
     setCanEditPreferences(true);
     setStep('preferences');
-  }, [autoOpen, isFlowOpen, isInline, isSubscribed]);
+  }, [autoOpen, flowOrigin, isFlowOpen, isInline, isSubscribed, step]);
 
   const activeEmail = useMemo(
     () =>

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -188,6 +188,7 @@ export function ProfileInlineNotificationsCTA({
   const otpVerificationInFlightRef = useRef(false);
   const previousOtpLengthRef = useRef(otpCode.length);
   const pendingCompletedOtpRef = useRef<string | null>(null);
+  const autoSubmittedOtpRef = useRef<string | null>(null);
 
   const isInline = presentation === 'inline';
   const artistEmailReady = readArtistEmailReadyFromSettings(artist.settings);
@@ -446,6 +447,7 @@ export function ProfileInlineNotificationsCTA({
 
     if (otpCode.length < 6) {
       pendingCompletedOtpRef.current = null;
+      autoSubmittedOtpRef.current = null;
       return;
     }
 
@@ -457,12 +459,17 @@ export function ProfileInlineNotificationsCTA({
       return;
     }
 
+    if (autoSubmittedOtpRef.current === otpCode) {
+      return;
+    }
+
     if (isSubmitting || otpVerificationInFlightRef.current) {
       return;
     }
 
     pendingCompletedOtpRef.current = null;
-    void handleOtpSubmit();
+    autoSubmittedOtpRef.current = otpCode;
+    handleOtpSubmit().catch(() => {});
   }, [handleOtpSubmit, isSubmitting, otpCode, step]);
 
   const handleNameSubmit = useCallback(() => {

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -330,7 +330,7 @@ export function ProfileCompactSurface({
   const topChromeButtonClassName =
     'h-9! w-9! border-white/14 bg-black/24 text-white shadow-[0_10px_24px_rgba(0,0,0,0.22)] backdrop-blur-md hover:bg-black/36 active:scale-100';
   const socialIconClassName =
-    'inline-flex h-8 w-8 items-center justify-center text-white/68 transition-colors duration-200 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
+    'inline-flex h-8 w-8 items-center justify-center text-white/68 transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
   const heroHeightClassName = isHomeMode
     ? 'h-[34svh] min-h-[232px] max-h-[250px] [@media(min-height:761px)_and_(max-height:880px)]:max-h-[190px] [@media(min-height:761px)_and_(max-height:880px)]:min-h-[190px] [@media(max-height:760px)]:h-[156px] [@media(max-height:760px)]:min-h-[156px]'
     : 'h-14 border-b border-white/[0.075]';
@@ -378,9 +378,6 @@ export function ProfileCompactSurface({
         data-testid='profile-compact-surface'
         data-presentation={presentation}
       >
-        {!isHomeMode && renderMode !== 'preview' ? (
-          <h1 className='sr-only'>{artist.name}</h1>
-        ) : null}
         <div className='pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.025),transparent_34%)]' />
 
         <header
@@ -537,11 +534,7 @@ export function ProfileCompactSurface({
                 </div>
               </div>
             </div>
-          ) : renderMode === 'preview' ? null : (
-            <h1 className='sr-only' data-testid='profile-header'>
-              {artist.name}
-            </h1>
-          )}
+          ) : null}
         </header>
 
         <div className='relative z-10 flex min-h-0 flex-1 flex-col px-4 pt-2'>
@@ -566,7 +559,7 @@ export function ProfileCompactSurface({
                   type='button'
                   onClick={openNotifications}
                   disabled={renderMode !== 'interactive'}
-                  className='flex min-h-11 w-full items-center gap-3 rounded-[14px] border border-white/10 bg-white/[0.035] px-3 text-left text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_14px_28px_-18px_rgba(0,0,0,0.55)] backdrop-blur-2xl transition-[background-color,border-color] duration-200 hover:bg-white/[0.055] disabled:cursor-default disabled:hover:bg-white/[0.035] [@media(max-height:820px)]:hidden'
+                  className='flex min-h-11 w-full items-center gap-3 rounded-[14px] border border-white/10 bg-white/[0.035] px-3 text-left text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_14px_28px_-18px_rgba(0,0,0,0.55)] backdrop-blur-2xl transition-[background-color,border-color] duration-subtle hover:bg-white/[0.055] disabled:cursor-default disabled:hover:bg-white/[0.035] [@media(max-height:820px)]:hidden'
                   data-testid='profile-hero-alerts-row'
                 >
                   <span
@@ -586,8 +579,8 @@ export function ProfileCompactSurface({
                   <span
                     className={cn(
                       alertOptInVariant === 'toggle'
-                        ? 'relative h-[26px] w-[42px] shrink-0 rounded-full border p-0.5 transition-colors duration-200'
-                        : 'inline-flex h-8 shrink-0 items-center rounded-full bg-white px-3 text-[12px] font-semibold text-black transition-colors duration-200',
+                        ? 'relative h-[26px] w-[42px] shrink-0 rounded-full border p-0.5 transition-colors duration-subtle'
+                        : 'inline-flex h-8 shrink-0 items-center rounded-full bg-white px-3 text-[12px] font-semibold text-black transition-colors duration-subtle',
                       alertOptInVariant === 'toggle' &&
                         (isSubscribed
                           ? 'border-white/42 bg-white'
@@ -598,7 +591,7 @@ export function ProfileCompactSurface({
                     {alertOptInVariant === 'toggle' ? (
                       <span
                         className={cn(
-                          'block h-[22px] w-[22px] rounded-full shadow-[0_4px_10px_rgba(0,0,0,0.22)] transition-transform duration-200',
+                          'block h-[22px] w-[22px] rounded-full shadow-[0_4px_10px_rgba(0,0,0,0.22)] transition-transform duration-subtle',
                           isSubscribed
                             ? 'translate-x-4 bg-black'
                             : 'translate-x-0 bg-white'
@@ -692,7 +685,7 @@ export function ProfileCompactSurface({
                         type='button'
                         onClick={() => onModeSelect(tab.mode)}
                         className={cn(
-                          'relative flex min-h-[52px] min-w-0 flex-col items-center justify-center gap-1 rounded-[22px] px-1.5 py-1.5 text-center transition-[background-color,color] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+                          'relative flex min-h-[52px] min-w-0 flex-col items-center justify-center gap-1 rounded-[22px] px-1.5 py-1.5 text-center transition-[background-color,color] duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
                           isActive
                             ? 'text-white'
                             : 'text-white/40 hover:text-white/62'
@@ -721,7 +714,7 @@ export function ProfileCompactSurface({
                       type='button'
                       onClick={onOpenMenu}
                       className={cn(
-                        'relative flex min-h-[52px] min-w-0 flex-col items-center justify-center gap-1 rounded-[22px] px-1.5 py-1.5 text-center transition-[background-color,color] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+                        'relative flex min-h-[52px] min-w-0 flex-col items-center justify-center gap-1 rounded-[22px] px-1.5 py-1.5 text-center transition-[background-color,color] duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
                         isMenuActive
                           ? 'text-white'
                           : 'text-white/40 hover:text-white/62'

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -668,18 +668,12 @@ export function ProfileCompactTemplate({
   const isV1 = visualVariant === 'v1';
   const hasTourDates = tourDates.length > 0;
   const compactSurfaceShowsModeHeading = drawerOpen
-    ? drawerView === 'about' ||
-      drawerView === 'contact' ||
-      drawerView === 'listen' ||
-      drawerView === 'pay' ||
+    ? drawerView === 'listen' ||
       drawerView === 'releases' ||
       drawerView === 'subscribe' ||
       drawerView === 'notifications' ||
       (drawerView === 'tour' && hasTourDates)
-    : requestedMode === 'about' ||
-      requestedMode === 'contact' ||
-      requestedMode === 'listen' ||
-      requestedMode === 'pay' ||
+    : requestedMode === 'listen' ||
       requestedMode === 'releases' ||
       requestedMode === 'subscribe' ||
       (requestedMode === 'tour' && hasTourDates);

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -668,12 +668,18 @@ export function ProfileCompactTemplate({
   const isV1 = visualVariant === 'v1';
   const hasTourDates = tourDates.length > 0;
   const compactSurfaceShowsModeHeading = drawerOpen
-    ? drawerView === 'listen' ||
+    ? drawerView === 'about' ||
+      drawerView === 'contact' ||
+      drawerView === 'listen' ||
+      drawerView === 'pay' ||
       drawerView === 'releases' ||
       drawerView === 'subscribe' ||
       drawerView === 'notifications' ||
       (drawerView === 'tour' && hasTourDates)
-    : requestedMode === 'listen' ||
+    : requestedMode === 'about' ||
+      requestedMode === 'contact' ||
+      requestedMode === 'listen' ||
+      requestedMode === 'pay' ||
       requestedMode === 'releases' ||
       requestedMode === 'subscribe' ||
       (requestedMode === 'tour' && hasTourDates);

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -666,6 +666,20 @@ export function ProfileCompactTemplate({
     .slice(0, 4)
     .map(dsp => ({ id: dsp.key, url: dsp.url, label: dsp.name }));
   const isV1 = visualVariant === 'v1';
+  const hasTourDates = tourDates.length > 0;
+  const compactSurfaceShowsModeHeading = drawerOpen
+    ? drawerView === 'listen' ||
+      drawerView === 'releases' ||
+      drawerView === 'subscribe' ||
+      drawerView === 'notifications' ||
+      (drawerView === 'tour' && hasTourDates)
+    : requestedMode === 'listen' ||
+      requestedMode === 'releases' ||
+      requestedMode === 'subscribe' ||
+      (requestedMode === 'tour' && hasTourDates);
+  const shouldRenderTemplateHeading = isDesktopLayout
+    ? !isV1
+    : compactSurfaceShowsModeHeading;
 
   return (
     <ProfileNotificationsContext.Provider value={notificationsContextValue}>
@@ -758,8 +772,10 @@ export function ProfileCompactTemplate({
             </aside>
           ) : null}
           <main className='relative flex h-full w-full items-stretch md:items-center'>
-            {isDesktopLayout && !isV1 ? (
-              <h1 className='sr-only'>{artist.name}</h1>
+            {shouldRenderTemplateHeading ? (
+              <h1 className='sr-only' data-testid='profile-header'>
+                {artist.name}
+              </h1>
             ) : null}
             {isDesktopLayout ? (
               <div className='w-full' data-testid='profile-compact-shell'>

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -773,9 +773,7 @@ export function ProfileCompactTemplate({
           ) : null}
           <main className='relative flex h-full w-full items-stretch md:items-center'>
             {shouldRenderTemplateHeading ? (
-              <h1 className='sr-only' data-testid='profile-header'>
-                {artist.name}
-              </h1>
+              <h1 className='sr-only'>{artist.name}</h1>
             ) : null}
             {isDesktopLayout ? (
               <div className='w-full' data-testid='profile-compact-shell'>

--- a/apps/web/components/marketing/artist-profile/captureShared.tsx
+++ b/apps/web/components/marketing/artist-profile/captureShared.tsx
@@ -160,7 +160,7 @@ export function CaptureActionPill({
     >
       <div
         className={cn(
-          'flex min-h-[4rem] items-center rounded-full px-2 py-1.5 transition-[background-color,transform,opacity] duration-300',
+          'flex min-h-[4rem] items-center rounded-full px-2 py-1.5 transition-[background-color,transform,opacity] duration-subtle',
           isDone
             ? 'justify-center bg-white text-black'
             : 'gap-2 bg-[linear-gradient(180deg,rgba(255,255,255,0.04),rgba(255,255,255,0.015))]'
@@ -171,7 +171,7 @@ export function CaptureActionPill({
             <span className='inline-flex h-7 w-7 items-center justify-center rounded-full bg-black text-white'>
               <Check className='h-3.5 w-3.5' strokeWidth={2.4} />
             </span>
-            <span className='text-[12.5px] font-semibold tracking-[-0.02em] text-black'>
+            <span className='rounded-full bg-white px-1 text-[12.5px] font-semibold tracking-[-0.02em] text-black'>
               {capture.action.confirmedLabel}
             </span>
           </div>
@@ -200,7 +200,7 @@ export function CaptureActionPill({
 
             <span
               className={cn(
-                'rounded-full px-4 py-2.5 text-[12px] font-semibold tracking-[-0.02em] transition-all duration-300',
+                'rounded-full px-4 py-2.5 text-[12px] font-semibold tracking-[-0.02em] transition-[background-color,color,transform] duration-subtle',
                 isSubmitting
                   ? 'scale-[0.96] bg-white/88 text-black'
                   : 'bg-white text-black'

--- a/apps/web/tests/unit/profile/ProfileInlineNotificationsCTA.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileInlineNotificationsCTA.test.tsx
@@ -368,6 +368,68 @@ describe('ProfileInlineNotificationsCTA', () => {
     });
   });
 
+  it('does not retry a failed OTP auto-submit for the same code', async () => {
+    const handleSubscribe = vi.fn().mockResolvedValue('pending_confirmation');
+    const handleVerifyOtp = vi.fn().mockResolvedValue('error');
+    mockUseSubscriptionForm.mockReturnValue(
+      buildFormState({
+        emailInput: 'fan@test.com',
+        handleSubscribe,
+        handleVerifyOtp,
+      })
+    );
+
+    const view = render(
+      <ProfileInlineNotificationsCTA artist={makeArtist()} autoOpen />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue' }));
+    expect(await screen.findByText('Enter the code')).toBeInTheDocument();
+
+    mockUseSubscriptionForm.mockReturnValue(
+      buildFormState({
+        emailInput: 'fan@test.com',
+        otpCode: '123456',
+        handleSubscribe,
+        handleVerifyOtp,
+      })
+    );
+    view.rerender(
+      <ProfileInlineNotificationsCTA artist={makeArtist()} autoOpen />
+    );
+
+    await waitFor(() => {
+      expect(handleVerifyOtp).toHaveBeenCalledTimes(1);
+    });
+
+    mockUseSubscriptionForm.mockReturnValue(
+      buildFormState({
+        emailInput: 'fan@test.com',
+        otpCode: '123456',
+        isSubmitting: true,
+        handleSubscribe,
+        handleVerifyOtp,
+      })
+    );
+    view.rerender(
+      <ProfileInlineNotificationsCTA artist={makeArtist()} autoOpen />
+    );
+
+    mockUseSubscriptionForm.mockReturnValue(
+      buildFormState({
+        emailInput: 'fan@test.com',
+        otpCode: '123456',
+        handleSubscribe,
+        handleVerifyOtp,
+      })
+    );
+    view.rerender(
+      <ProfileInlineNotificationsCTA artist={makeArtist()} autoOpen />
+    );
+
+    expect(handleVerifyOtp).toHaveBeenCalledTimes(1);
+  });
+
   it('submits Jovie preferences and artist email consent together', async () => {
     const mutateAsync = vi.fn().mockResolvedValue(undefined);
     mockUpdateContentPreferencesMutation.mockReturnValue({

--- a/apps/web/tests/unit/profile/ProfileInlineNotificationsCTA.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileInlineNotificationsCTA.test.tsx
@@ -317,6 +317,57 @@ describe('ProfileInlineNotificationsCTA', () => {
     expect(await screen.findByText('Alerts')).toBeInTheDocument();
   });
 
+  it('submits a completed OTP after the email submit settles', async () => {
+    const handleSubscribe = vi.fn().mockResolvedValue('pending_confirmation');
+    const handleVerifyOtp = vi.fn().mockResolvedValue('subscribed');
+    mockUseSubscriptionForm.mockReturnValue(
+      buildFormState({
+        emailInput: 'fan@test.com',
+        handleSubscribe,
+        handleVerifyOtp,
+      })
+    );
+
+    const view = render(
+      <ProfileInlineNotificationsCTA artist={makeArtist()} autoOpen />
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Continue' }));
+    expect(await screen.findByText('Enter the code')).toBeInTheDocument();
+
+    mockUseSubscriptionForm.mockReturnValue(
+      buildFormState({
+        emailInput: 'fan@test.com',
+        otpCode: '123456',
+        isSubmitting: true,
+        handleSubscribe,
+        handleVerifyOtp,
+      })
+    );
+    view.rerender(
+      <ProfileInlineNotificationsCTA artist={makeArtist()} autoOpen />
+    );
+
+    expect(handleVerifyOtp).not.toHaveBeenCalled();
+
+    mockUseSubscriptionForm.mockReturnValue(
+      buildFormState({
+        emailInput: 'fan@test.com',
+        otpCode: '123456',
+        isSubmitting: false,
+        handleSubscribe,
+        handleVerifyOtp,
+      })
+    );
+    view.rerender(
+      <ProfileInlineNotificationsCTA artist={makeArtist()} autoOpen />
+    );
+
+    await waitFor(() => {
+      expect(handleVerifyOtp).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('submits Jovie preferences and artist email consent together', async () => {
     const mutateAsync = vi.fn().mockResolvedValue(undefined);
     mockUpdateContentPreferencesMutation.mockReturnValue({


### PR DESCRIPTION
## Summary
- remove duplicate profile-mode h1 ownership by moving the canonical sr-only heading to the template layer
- keep compact/mobile fallback behavior aligned with surface mode logic, including no-tour-date fallback
- raise decorative public 404 contrast from `[0.34]` to `[0.42]` so the same public axe lane can pass on the combined SHA
- show the subscribe composer inline on the mobile subscribe tab and make completed OTP entry submit after the email submit state settles
- guard OTP auto-submit so a failed verification for the same code does not retry in a loop
- keep the inline subscribe flow mounted after OTP activation so the name and birthday enrichment steps can render before settings replace the flow
- let Vaul/Radix own the profile drawer description id so contact/tip/subscribe drawer cases no longer emit `Missing Description` warnings in smoke

Linear: JOV-1904
Linear: JOV-1918

## Testing
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx apps/web/tests/unit/profile/ProfileInlineNotificationsCTA.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/profile/subscription-form-states.test.tsx tests/unit/profile/ProfileInlineNotificationsCTA.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec tsc --noEmit`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/profile/ProfileInlineNotificationsCTA.test.tsx`
- `JOVIE_AGENT_PROFILE=coder SMOKE_ONLY=1 E2E_FAST_ITERATION=1 E2E_SKIP_WARMUP=1 BASE_URL=http://127.0.0.1:3124 PLAYWRIGHT_WORKERS=1 pnpm --filter @jovie/web exec playwright test tests/e2e/profile-visual-audit.spec.ts -g "contact · legacy · dark · mobile|tip · legacy · dark · mobile|subscribe · legacy · dark · mobile" --project=chromium --reporter=line` (passed; local fallback DB logged existing `tour_dates.event_type` schema warning; Radix drawer description warning did not recur)
- commit hooks: `next:proxy-guard`, staged Biome, staged ESLint, staged a11y check where applicable, `node scripts/turbo-local.mjs typecheck --filter=@jovie/web`
- `JOVIE_AGENT_PROFILE=coder BASE_URL=http://localhost:3123 SMOKE_ONLY=1 E2E_FAST_ITERATION=1 PLAYWRIGHT_WORKERS=1 pnpm --filter @jovie/web exec playwright test tests/e2e/profile-subscribe-e2e.spec.ts -g "email happy path" --project=chromium --reporter=line` (passed; local fallback DB logged existing `tour_dates.event_type` schema warning)
- pre-push passed after latest rebase/push: root Biome, web `next:proxy-guard`, Tailwind guard, web typecheck, web Biome lint

## CI focus
This combined PR should clear the public `A11y (axe)` failures for profile modes and public not-found surfaces, the subscribe OTP smoke failure caused by completed-code entry racing the email-submit state, and the profile drawer Radix warning retries that pushed smoke over the 10-minute wall. The standalone JOV-1918 PR is superseded by this combined CI-gating fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced notification subscription flow with two-step verification and lifecycle management options
  * Automatic OTP submission during email verification in notifications signup

* **Style**
  * Refined 404 error page visual styling across the app
  * Improved UI transition timings for smoother interactions

* **Tests**
  * Added unit tests for OTP auto-submission behavior in the notifications flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->