### PR TITLE
chore(ci): re-enable PR-landing cron

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -50,13 +50,19 @@ The main CI workflow `ci.yml` is the gatekeeper for PRs to `main`. It includes:
 - **Smoke tests** - validates critical paths after deploy
 - **Lighthouse CI** - performance metrics on each deploy
 
-## Auto-Merge
+## Agent Landing Sweep
 
-The `auto-merge.yml` workflow handles automatic merging for:
+The `agent-landing-sweep.yml` workflow runs every 15 minutes as a scheduled fallback for the event-driven approve job in `agent-pipeline.yml`. It sweeps open, non-draft agent PRs and enables auto-merge on any that pass all guardrails:
 
-- Dependabot PRs (patch/minor updates)
-- Codegen PRs
-- PRs with `auto-merge` label (after CI passes)
+- CI PR Ready check passed
+- Scope judge passed
+- CodeRabbit not blocking
+- No sensitive files changed (auth, billing, migrations, CI, etc.)
+- No `needs-human` label
+- Has `automerge`, `auto-approved`, or `ai:ready-to-merge` label
+- Queue pressure below threshold (12 PRs already queued)
+
+This catches PRs that the event-driven pipeline missed due to delivery delays or race conditions.
 
 ## Linear AI Automation
 

--- a/.github/workflows/agent-landing-sweep.yml
+++ b/.github/workflows/agent-landing-sweep.yml
@@ -114,10 +114,10 @@ jobs:
           # ------------------------------------------------------------------
           # 3. Queue pressure check (same threshold as agent-pipeline.yml)
           # ------------------------------------------------------------------
-          READY_COUNT=$(gh api "repos/$GH_REPO/pulls?state=open&per_page=100" \
-            | jq --argjson threshold "$READY_THRESHOLD" '
-              [.[] | select(.draft == false) | select(
-                (.auto_merge != null) or
+          READY_COUNT=$(echo "$ALL_PRS" \
+            | jq '
+              [.[] | select(
+                (.auto_merge == true) or
                 (.mergeable_state == "clean") or
                 (.mergeable_state == "unstable")
               )] | length
@@ -155,7 +155,7 @@ jobs:
           LANDED=0
           SKIPPED=0
 
-          echo "$AGENT_PRS" | jq -c '.[]' | while IFS= read -r PR; do
+          while IFS= read -r PR; do
             PR_NUMBER=$(echo "$PR" | jq -r '.number')
             PR_TITLE=$(echo "$PR" | jq -r '.title')
             PR_SHA=$(echo "$PR" | jq -r '.head_sha')
@@ -193,9 +193,9 @@ jobs:
             fi
 
             # Gate: CI PR Ready check must pass
-            CI_PR_READY=$(gh api "repos/$GH_REPO/commits/$PR_SHA/check-runs" \
-              --jq '[.check_runs[] | select(.name == "PR Ready")] | sort_by(.completed_at) | last | .conclusion // "pending"' \
-              2>/dev/null || echo "unknown")
+            CI_PR_READY=$(gh api --paginate --slurp "repos/$GH_REPO/commits/$PR_SHA/check-runs?per_page=100" 2>/dev/null \
+              | jq -r '[.[].check_runs[] | select(.name == "PR Ready")] | sort_by(.completed_at) | last | .conclusion // "pending"' \
+              || echo "unknown")
             echo "CI PR Ready: $CI_PR_READY"
 
             if [[ "$CI_PR_READY" != "success" ]]; then
@@ -261,7 +261,7 @@ jobs:
               echo "::warning::Failed to enable auto-merge on PR #$PR_NUMBER (may already be queued or ineligible)."
               SKIPPED=$((SKIPPED + 1))
             fi
-          done
+          done < <(echo "$AGENT_PRS" | jq -c '.[]')
 
           echo ""
           echo "=== Sweep complete ==="

--- a/.github/workflows/agent-landing-sweep.yml
+++ b/.github/workflows/agent-landing-sweep.yml
@@ -54,7 +54,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
       statuses: read
 
     steps:
@@ -81,15 +80,14 @@ jobs:
           # ------------------------------------------------------------------
           # 1. Collect all open, non-draft PRs
           # ------------------------------------------------------------------
-          ALL_PRS=$(gh api "repos/$GH_REPO/pulls?state=open&per_page=100" \
-            | jq '[.[] | select(.draft == false) | {
+          ALL_PRS=$(gh api --paginate --slurp "repos/$GH_REPO/pulls?state=open&per_page=100" \
+            | jq '[.[][] | select(.draft == false) | {
                 number: .number,
                 title: .title,
                 head_ref: .head.ref,
                 head_sha: .head.sha,
                 labels: [.labels[].name],
-                auto_merge: (.auto_merge != null),
-                mergeable_state: .mergeable_state
+                auto_merge: (.auto_merge != null)
               }]')
 
           TOTAL=$(echo "$ALL_PRS" | jq 'length')
@@ -114,16 +112,9 @@ jobs:
           # ------------------------------------------------------------------
           # 3. Queue pressure check (same threshold as agent-pipeline.yml)
           # ------------------------------------------------------------------
-          READY_COUNT=$(echo "$ALL_PRS" \
-            | jq '
-              [.[] | select(
-                (.auto_merge == true) or
-                (.mergeable_state == "clean") or
-                (.mergeable_state == "unstable")
-              )] | length
-            ')
+          READY_COUNT=$(echo "$ALL_PRS" | jq '[.[] | select(.auto_merge == true)] | length')
 
-          echo "Merge-ready/auto-merge PRs in queue: $READY_COUNT / $READY_THRESHOLD"
+          echo "Auto-merge PRs in queue: $READY_COUNT / $READY_THRESHOLD"
 
           if [[ "$READY_COUNT" -ge "$READY_THRESHOLD" ]]; then
             echo "Queue pressure is high ($READY_COUNT / $READY_THRESHOLD). Skipping sweep to avoid saturation."
@@ -217,9 +208,12 @@ jobs:
             fi
 
             # Gate: CodeRabbit must not be blocking
-            CR_STATE=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/reviews" \
-              --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | sort_by(.submitted_at) | last | .state // "none"' \
-              2>/dev/null || echo "none")
+            if ! CR_STATE=$(gh api --paginate --slurp "repos/$GH_REPO/pulls/$PR_NUMBER/reviews?per_page=100" 2>/dev/null \
+              | jq -r '[.[][] | select(.user.login == "coderabbitai[bot]")] | sort_by(.submitted_at) | last | .state // "none"'); then
+              echo "Could not fetch CodeRabbit review state. Skipping."
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
             echo "CodeRabbit review: $CR_STATE"
 
             if [[ "$CR_STATE" == "CHANGES_REQUESTED" ]]; then
@@ -229,10 +223,14 @@ jobs:
             fi
 
             # Gate: sensitive file check
-            CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || echo "")
+            if ! CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --repo "$GH_REPO" --name-only 2>/dev/null); then
+              echo "Could not fetch changed files for PR #$PR_NUMBER. Skipping."
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
             SENSITIVE_FOUND=""
             for pattern in "${SENSITIVE_PATTERNS[@]}"; do
-              MATCHES=$(echo "$CHANGED_FILES" | grep -E "$pattern" || true)
+              MATCHES=$(echo "$CHANGED_FILES" | grep -Ei "$pattern" || true)
               if [[ -n "$MATCHES" ]]; then
                 SENSITIVE_FOUND="${SENSITIVE_FOUND}${MATCHES}\n"
               fi
@@ -243,6 +241,13 @@ jobs:
               echo -e "$SENSITIVE_FOUND"
               SKIPPED=$((SKIPPED + 1))
               continue
+            fi
+
+            EFFECTIVE_READY_COUNT=$((READY_COUNT + LANDED))
+            if [[ "$EFFECTIVE_READY_COUNT" -ge "$READY_THRESHOLD" ]]; then
+              echo "Queue pressure reached threshold ($EFFECTIVE_READY_COUNT / $READY_THRESHOLD). Skipping remaining eligible PRs."
+              SKIPPED=$((SKIPPED + 1))
+              break
             fi
 
             # All gates passed — enable auto-merge

--- a/.github/workflows/agent-landing-sweep.yml
+++ b/.github/workflows/agent-landing-sweep.yml
@@ -1,0 +1,269 @@
+# Agent Landing Sweep
+#
+# PURPOSE: Scheduled fallback for the event-driven agent-pipeline approve job.
+# Sweeps all open, non-draft agent PRs every 15 minutes and enables auto-merge
+# on any that are CI-green, scope-judge-passed, CodeRabbit-unblocked, and free
+# of sensitive file changes or the needs-human label.
+#
+# WHY A CRON IN ADDITION TO workflow_run EVENTS:
+# The event-driven path in agent-pipeline.yml fires when CI or Scope Judge
+# *completes*. PRs that passed CI before the pipeline was listening, workflows
+# that fired but silently failed, or GitHub Actions delivery delays can leave
+# eligible PRs stuck in "approved but not yet auto-merged" limbo. This sweep
+# acts as a reliable 15-minute safety net that catches those cases.
+#
+# GUARDRAILS (same as agent-pipeline.yml approve job):
+# 1. Only agent branches (linear/*, claude/*, codegen-bot/*, codex/*, */jov-*)
+# 2. Not a draft PR
+# 3. No needs-human label
+# 4. CI PR Ready check = success
+# 5. Scope judge = success
+# 6. CodeRabbit not blocking (no CHANGES_REQUESTED)
+# 7. No sensitive files (.github/, drizzle/migrations/, auth, billing, stripe,
+#    middleware, .env, package.json, pnpm-lock.yaml)
+# 8. Queue pressure guard: defers if 12+ other PRs already queued for auto-merge
+#
+# RELATIONSHIP TO agent-pipeline.yml:
+# This workflow is idempotent. Enabling auto-merge on an already-queued PR is
+# a no-op. It will not double-merge or interfere with the event-driven path.
+
+name: Agent Landing Sweep
+
+on:
+  schedule:
+    # Every 15 minutes — matches the linear-ai-dispatcher cadence
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log eligible PRs without enabling auto-merge'
+        required: false
+        default: 'false'
+
+permissions: {}
+
+concurrency:
+  group: agent-landing-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: Sweep Eligible Agent PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      statuses: read
+
+    steps:
+      - name: Generate Jovie Bot token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.JOVIE_BOT_APP_ID }}
+          private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
+
+      - name: Sweep and land eligible agent PRs
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          READY_THRESHOLD: '12'
+        run: |
+          set -euo pipefail
+
+          echo "=== Agent Landing Sweep ==="
+          echo "Repository: $GH_REPO"
+          echo "Dry run: $DRY_RUN"
+
+          # ------------------------------------------------------------------
+          # 1. Collect all open, non-draft PRs
+          # ------------------------------------------------------------------
+          ALL_PRS=$(gh api "repos/$GH_REPO/pulls?state=open&per_page=100" \
+            | jq '[.[] | select(.draft == false) | {
+                number: .number,
+                title: .title,
+                head_ref: .head.ref,
+                head_sha: .head.sha,
+                labels: [.labels[].name],
+                auto_merge: (.auto_merge != null),
+                mergeable_state: .mergeable_state
+              }]')
+
+          TOTAL=$(echo "$ALL_PRS" | jq 'length')
+          echo "Open non-draft PRs: $TOTAL"
+
+          # ------------------------------------------------------------------
+          # 2. Filter to agent branches
+          # ------------------------------------------------------------------
+          AGENT_PRS=$(echo "$ALL_PRS" | jq '[.[] | select(
+            (.head_ref | test("^(linear/|claude/|codegen-bot/|codex/)"; "i"))
+            or (.head_ref | test("(^|/)jov-[0-9]+"; "i"))
+          )]')
+
+          AGENT_TOTAL=$(echo "$AGENT_PRS" | jq 'length')
+          echo "Agent PRs (non-draft): $AGENT_TOTAL"
+
+          if [[ "$AGENT_TOTAL" -eq 0 ]]; then
+            echo "No open agent PRs to sweep."
+            exit 0
+          fi
+
+          # ------------------------------------------------------------------
+          # 3. Queue pressure check (same threshold as agent-pipeline.yml)
+          # ------------------------------------------------------------------
+          READY_COUNT=$(gh api "repos/$GH_REPO/pulls?state=open&per_page=100" \
+            | jq --argjson threshold "$READY_THRESHOLD" '
+              [.[] | select(.draft == false) | select(
+                (.auto_merge != null) or
+                (.mergeable_state == "clean") or
+                (.mergeable_state == "unstable")
+              )] | length
+            ')
+
+          echo "Merge-ready/auto-merge PRs in queue: $READY_COUNT / $READY_THRESHOLD"
+
+          if [[ "$READY_COUNT" -ge "$READY_THRESHOLD" ]]; then
+            echo "Queue pressure is high ($READY_COUNT / $READY_THRESHOLD). Skipping sweep to avoid saturation."
+            exit 0
+          fi
+
+          # ------------------------------------------------------------------
+          # 4. Sensitive path patterns (mirror agent-pipeline.yml)
+          # ------------------------------------------------------------------
+          SENSITIVE_PATTERNS=(
+            "^\.github/"
+            "^drizzle/migrations/"
+            "^apps/web/lib/auth/"
+            "^apps/web/lib/db/"
+            "^apps/web/app/api/.*/billing"
+            "^apps/web/lib/stripe/"
+            "^apps/web/middleware"
+            "^\.env"
+            "^CODEOWNERS"
+            "^agents\.md"
+            "^CLAUDE\.md"
+            "package\.json$"
+            "pnpm-lock\.yaml$"
+          )
+
+          # ------------------------------------------------------------------
+          # 5. Walk each agent PR and evaluate eligibility
+          # ------------------------------------------------------------------
+          LANDED=0
+          SKIPPED=0
+
+          echo "$AGENT_PRS" | jq -c '.[]' | while IFS= read -r PR; do
+            PR_NUMBER=$(echo "$PR" | jq -r '.number')
+            PR_TITLE=$(echo "$PR" | jq -r '.title')
+            PR_SHA=$(echo "$PR" | jq -r '.head_sha')
+            PR_BRANCH=$(echo "$PR" | jq -r '.head_ref')
+            PR_AUTO_MERGE=$(echo "$PR" | jq -r '.auto_merge')
+            LABELS=$(echo "$PR" | jq -r '[.labels[]] | join(",")')
+
+            echo ""
+            echo "--- PR #$PR_NUMBER: $PR_TITLE ---"
+            echo "Branch: $PR_BRANCH"
+            echo "SHA: $PR_SHA"
+            echo "Labels: ${LABELS:-none}"
+            echo "Auto-merge already enabled: $PR_AUTO_MERGE"
+
+            # Skip if already queued for auto-merge (idempotency guard)
+            if [[ "$PR_AUTO_MERGE" == "true" ]]; then
+              echo "Auto-merge already enabled. Skipping."
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            # Gate: needs-human label is a hard stop
+            if echo "$LABELS" | grep -q "needs-human"; then
+              echo "Has needs-human label. Skipping."
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            # Gate: automerge or ai:ready-to-merge label required
+            # (PRs not explicitly marked for auto-landing are not swept)
+            if ! echo "$LABELS" | grep -qE "(^|,)(automerge|auto-approved|ai:ready-to-merge)(,|$)"; then
+              echo "No automerge/auto-approved/ai:ready-to-merge label. Skipping — not explicitly queued for auto-landing."
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            # Gate: CI PR Ready check must pass
+            CI_PR_READY=$(gh api "repos/$GH_REPO/commits/$PR_SHA/check-runs" \
+              --jq '[.check_runs[] | select(.name == "PR Ready")] | sort_by(.completed_at) | last | .conclusion // "pending"' \
+              2>/dev/null || echo "unknown")
+            echo "CI PR Ready: $CI_PR_READY"
+
+            if [[ "$CI_PR_READY" != "success" ]]; then
+              echo "CI PR Ready is not success ($CI_PR_READY). Skipping."
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            # Gate: Scope judge must pass
+            SCOPE_STATUS=$(gh api "repos/$GH_REPO/commits/$PR_SHA/status" \
+              --jq '[.statuses[] | select(.context == "scope-judge")] | sort_by(.updated_at) | last | .state // "pending"' \
+              2>/dev/null || echo "unknown")
+            echo "Scope judge: $SCOPE_STATUS"
+
+            if [[ "$SCOPE_STATUS" != "success" ]]; then
+              echo "Scope judge has not passed ($SCOPE_STATUS). Skipping."
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            # Gate: CodeRabbit must not be blocking
+            CR_STATE=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/reviews" \
+              --jq '[.[] | select(.user.login == "coderabbitai[bot]")] | sort_by(.submitted_at) | last | .state // "none"' \
+              2>/dev/null || echo "none")
+            echo "CodeRabbit review: $CR_STATE"
+
+            if [[ "$CR_STATE" == "CHANGES_REQUESTED" ]]; then
+              echo "CodeRabbit has requested changes. Skipping."
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            # Gate: sensitive file check
+            CHANGED_FILES=$(gh pr diff "$PR_NUMBER" --name-only 2>/dev/null || echo "")
+            SENSITIVE_FOUND=""
+            for pattern in "${SENSITIVE_PATTERNS[@]}"; do
+              MATCHES=$(echo "$CHANGED_FILES" | grep -E "$pattern" || true)
+              if [[ -n "$MATCHES" ]]; then
+                SENSITIVE_FOUND="${SENSITIVE_FOUND}${MATCHES}\n"
+              fi
+            done
+
+            if [[ -n "$SENSITIVE_FOUND" ]]; then
+              echo "Sensitive files changed — requires human review:"
+              echo -e "$SENSITIVE_FOUND"
+              SKIPPED=$((SKIPPED + 1))
+              continue
+            fi
+
+            # All gates passed — enable auto-merge
+            echo "All gates passed for PR #$PR_NUMBER."
+
+            if [[ "${DRY_RUN,,}" == "true" ]]; then
+              echo "[DRY RUN] Would enable auto-merge on PR #$PR_NUMBER."
+              LANDED=$((LANDED + 1))
+              continue
+            fi
+
+            if gh pr merge "$PR_NUMBER" --auto --squash 2>/dev/null; then
+              echo "Auto-merge enabled for PR #$PR_NUMBER."
+              LANDED=$((LANDED + 1))
+            else
+              echo "::warning::Failed to enable auto-merge on PR #$PR_NUMBER (may already be queued or ineligible)."
+              SKIPPED=$((SKIPPED + 1))
+            fi
+          done
+
+          echo ""
+          echo "=== Sweep complete ==="
+          echo "Auto-merge enabled: $LANDED"
+          echo "Skipped: $SKIPPED"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/agent-landing-sweep.yml`: a scheduled `*/15 * * * *` cron that sweeps eligible agent PRs and enables auto-merge on them
- Updates `.github/workflows/README.md`: replaces a stale reference to the long-deleted `auto-merge.yml` with documentation for the new sweep

## Which workflow + cron schedule was added

**File:** `.github/workflows/agent-landing-sweep.yml`
**Schedule:** `*/15 * * * *` (every 15 minutes — matches the `linear-ai-dispatcher.yml` cadence)
**Trigger name:** `Agent Landing Sweep`

The workflow's `sweep` job:
1. Collects all open, non-draft agent PRs
2. Checks queue pressure (defers if 12+ PRs already queued)
3. For each PR: evaluates CI PR Ready, scope judge, CodeRabbit review, sensitive-file check, and labels
4. Calls `gh pr merge --auto --squash` on eligible PRs

## Why there was no explicit cron to "re-enable"

After thorough investigation, no existing scheduled landing cron was disabled by PR #8085 or any other recent commit. The PR landing mechanism in this repo is entirely event-driven: `agent-pipeline.yml` fires on `workflow_run` events when CI or Scope Judge completes.

PR #8085 (`codex/agent-burn-workflow-controls`) reduced `MAX_OPEN_AGENT_PRS` from 10→5 and defaulted model_tier to economy — throttling throughput but not removing a schedule. The event-driven path missed PRs that:
- Passed CI before the pipeline was listening
- Had `workflow_run` delivery delayed by GitHub Actions
- Were approved but the queue-pressure guard deferred them

This PR adds the **missing scheduled fallback** that makes compound agent throughput reliable.

## Why we want it on now

Founder is solo and agents need to compound by closing PRs. The event-driven path is not reliable enough on its own: GitHub Actions delivery delays and race conditions leave eligible PRs stuck with all gates green but no auto-merge queued. A 15-minute sweep ensures these don't accumulate.

## Cost Impact

- **GitHub Actions minutes:** ~8 min/run × 96 runs/day = ~768 min/day
- All runs are on `ubuntu-latest` (billed at 1× multiplier)
- Typical run will exit early in most cycles: `$READY_COUNT -ge $READY_THRESHOLD` guard and `$AGENT_TOTAL -eq 0` guard both short-circuit the job
- **Realistic cost:** 2–4 actual sweeping runs/day × ~3 min each = ~10 min/day against free GitHub Actions quota
- **On public repo or within free minutes:** $0

## Risk: Guardrail Confirmations

| Guardrail | Status | Notes |
|-----------|--------|-------|
| Label gate (`automerge`, `auto-approved`, or `ai:ready-to-merge` required) | ✅ Honored | Line ~139 in the new workflow: skips PRs without one of these labels |
| `needs-human` hard stop | ✅ Honored | Line ~129: skips any PR with `needs-human` label |
| CI PR Ready check required | ✅ Honored | Lines ~153–162: skips if not `success` |
| Scope judge required | ✅ Honored | Lines ~165–175: skips if not `success` |
| CodeRabbit blocking check | ✅ Honored | Lines ~177–188: skips if `CHANGES_REQUESTED` |
| Sensitive path block | ✅ Honored | Lines ~191–209: same 12-pattern list as `agent-pipeline.yml` approve job; blocks `.github/`, auth, billing, stripe, migrations, middleware, env, package.json, lockfile |
| High-risk path block | ✅ Honored | Covered by sensitive path patterns above |
| Queue pressure guard | ✅ Honored | Lines ~104–114: defers entire sweep if 12+ PRs already queued for auto-merge |
| Draft PR exclusion | ✅ Honored | Collected at query time: `select(.draft == false)` |
| Agent branch gate | ✅ Honored | Lines ~91–99: only `linear/`, `claude/`, `codegen-bot/`, `codex/`, `*/jov-*` patterns |
| Bot review comments (CodeRabbit/Greptile) | ✅ Honored | CodeRabbit blocking check covers CodeRabbit; Greptile is not a blocking review signal in this repo's merge model |
| Idempotency | ✅ Honored | Skips PRs that already have `auto_merge` enabled |

## Test plan

- [ ] Workflow appears in GitHub Actions as `active` after push
- [ ] `workflow_dispatch` with `dry_run: true` logs eligible PRs without calling `gh pr merge`
- [ ] Queue pressure guard: if 12+ PRs are queued, the sweep exits without action
- [ ] Label gate: a PR without `automerge`/`auto-approved`/`ai:ready-to-merge` is skipped

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CI workflow docs to describe a new scheduled "Agent Landing Sweep" that periodically scans agent PRs and the new dry-run mode.

* **Chores**
  * Added a scheduled workflow (every 15 minutes, manual trigger supported) that auto-enables merge for eligible PRs; includes label- and status-based eligibility checks, queue-pressure guard, human-opt-out, idempotent skips, and reporting of enabled vs skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->