### PR TITLE
JOV-1918 Fix public 404 contrast

### DIFF
--- a/apps/web/app/(marketing)/not-found.tsx
+++ b/apps/web/app/(marketing)/not-found.tsx
@@ -19,7 +19,7 @@ export default function NotFound() {
         {/* Error code — oversized, muted */}
         <div className='mb-8 select-none'>
           <span
-            className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.34]'
+            className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.42]'
             aria-hidden='true'
           >
             404

--- a/apps/web/app/[username]/[slug]/not-found.tsx
+++ b/apps/web/app/[username]/[slug]/not-found.tsx
@@ -9,7 +9,7 @@ export default function SmartLinkNotFound() {
       <div className='w-full max-w-sm text-center'>
         <div className='mb-6 select-none'>
           <span
-            className='block text-[100px] font-semibold leading-none tracking-tighter text-primary-token/[0.34]'
+            className='block text-[100px] font-semibold leading-none tracking-tighter text-primary-token/[0.42]'
             aria-hidden='true'
           >
             404

--- a/apps/web/app/[username]/not-found.tsx
+++ b/apps/web/app/[username]/not-found.tsx
@@ -14,7 +14,7 @@ export default function NotFound() {
           {/* Error code — oversized, ghosted */}
           <div className='mb-8 select-none'>
             <span
-              className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.34]'
+              className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.42]'
               aria-hidden='true'
             >
               404
@@ -33,7 +33,7 @@ export default function NotFound() {
 
             <Link
               href='/'
-              className='inline-flex items-center justify-center h-8 px-4 text-[13px] font-medium rounded-lg bg-[var(--color-btn-primary-bg)] text-[var(--color-btn-primary-fg)] hover:bg-[var(--color-btn-primary-hover)] transition-colors duration-100'
+              className='inline-flex items-center justify-center h-8 px-4 text-[13px] font-medium rounded-lg bg-[var(--color-btn-primary-bg)] text-[var(--color-btn-primary-fg)] hover:bg-[var(--color-btn-primary-hover)] transition-colors duration-subtle'
             >
               Go home
             </Link>

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -18,7 +18,7 @@ export default function NotFound() {
             {/* Error code — oversized, muted, architectural */}
             <div className='mb-8 select-none'>
               <span
-                className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.34]'
+                className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.42]'
                 aria-hidden='true'
               >
                 404
@@ -37,7 +37,7 @@ export default function NotFound() {
 
               <Link
                 href='/'
-                className='inline-flex items-center justify-center h-8 px-4 text-[13px] font-medium rounded-lg bg-[var(--color-btn-primary-bg)] text-[var(--color-btn-primary-fg)] hover:bg-[var(--color-btn-primary-hover)] transition-colors duration-100'
+                className='inline-flex items-center justify-center h-8 px-4 text-[13px] font-medium rounded-lg bg-[var(--color-btn-primary-bg)] text-[var(--color-btn-primary-fg)] hover:bg-[var(--color-btn-primary-hover)] transition-colors duration-subtle'
               >
                 Return home
               </Link>


### PR DESCRIPTION
## Summary
- raise the decorative 404 number from `text-primary-token/[0.34]` to `[0.42]` on public not-found pages
- replace raw `duration-100` with `duration-subtle` in the touched 404 links so staged lint passes

Linear: JOV-1918

## Testing
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/not-found.tsx apps/web/app/[username]/not-found.tsx apps/web/app/(marketing)/not-found.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/app/not-found.tsx apps/web/app/[username]/not-found.tsx apps/web/app/(marketing)/not-found.tsx`
- commit hook: `next:proxy-guard`, staged Biome, staged ESLint, `node scripts/turbo-local.mjs typecheck --filter=@jovie/web`

## CI focus
Public A11y axe previously failed on `profile-catchall`, `profile-not-found`, and `smart-link-not-found` due 2.97:1 contrast on the decorative 404 text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased visibility of the error code display on 404 pages for better prominence.
  * Enhanced transition animations on action buttons across error pages for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->