### PR TITLE
Require durable Linear follow-up issues

### DIFF
--- a/.agents/skills/gstack/CHANGELOG.md
+++ b/.agents/skills/gstack/CHANGELOG.md
@@ -248,7 +248,7 @@ The Chrome sidebar now defends against prompt injection attacks. Three layers: X
 - **XML prompt framing with trust boundaries.** User messages are wrapped in `<user-message>` tags with explicit instructions to treat content as data, not instructions. XML special characters (`< > &`) are escaped to prevent tag injection attacks.
 - **Bash command allowlist.** The sidebar's system prompt now restricts Claude to browse binary commands only (`$B goto`, `$B click`, `$B snapshot`, etc.). All other bash commands (`curl`, `rm`, `cat`, etc.) are forbidden. This prevents prompt injection from escalating to arbitrary code execution.
 - **Opus default for sidebar.** The sidebar now uses Opus (the most injection-resistant model) by default, instead of whatever model Claude Code happens to be running.
-- **ML prompt injection defense design doc.** Full design doc at `docs/designs/ML_PROMPT_INJECTION_KILLER.md` covering the follow-up ML classifier (DeBERTa, BrowseSafe-bench, Bun-native 5ms vision). P0 TODO for the next PR.
+- **ML prompt injection defense design doc.** Full design doc at `docs/designs/ML_PROMPT_INJECTION_KILLER.md` covering a historical ML classifier design (DeBERTa, BrowseSafe-bench, Bun-native 5ms vision). Kept as design context only.
 
 ## [0.13.3.0] - 2026-03-28 — Lock It Down
 
@@ -806,7 +806,7 @@ Thanks to @osc, @Explorer1092, @Qike-Li, @francoisaubert1, @itstimwhite, @yinanl
 
 - `test/gen-skill-docs.test.ts` validates all `.agents/` descriptions stay within 1024 chars
 - `gstack-update-check` includes a one-time migration that deletes oversized Codex SKILL.md files
-- P1 TODO added: Codex→Claude reverse buddy check skill
+- P1 tracked follow-up added: Codex→Claude reverse buddy check skill
 
 ## [0.11.8.0] - 2026-03-23 — zsh Compatibility Fix
 

--- a/.agents/skills/gstack/ETHOS.md
+++ b/.agents/skills/gstack/ETHOS.md
@@ -49,7 +49,7 @@ human engineering time was the bottleneck.
 
 **Anti-patterns:**
 - "Choose B — it covers 90% with less code." (If A is 70 lines more, choose A.)
-- "Let's defer tests to a follow-up PR." (Tests are the cheapest lake to boil.)
+- "Let's leave tests as untracked later work." (Tests are the cheapest lake to boil.)
 - "This would take 2 weeks." (Say: "2 weeks human / ~1 hour AI-assisted.")
 
 Read more: https://garryslist.org/posts/boil-the-ocean

--- a/.agents/skills/gstack/autoplan/SKILL.md
+++ b/.agents/skills/gstack/autoplan/SKILL.md
@@ -732,7 +732,7 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
   that is NOT auto-decided. Premises require human judgment.
 - Alternatives: pick highest completeness (P1). If tied, pick simplest (P5).
   If top 2 are close → mark TASTE DECISION.
-- Scope expansion: in blast radius + <1d CC → approve (P2). Outside → defer to TODOS.md (P3).
+- Scope expansion: in blast radius + <1d CC → approve (P2). Outside → create candidate Linear follow-up (P3).
   Duplicates → reject (P4). Borderline (3-5 files) → mark TASTE DECISION.
 - All 10 review sections: run fully, auto-decide each issue, log every decision.
 - Dual voices: always run BOTH Claude subagent AND Codex if available (P6).
@@ -958,7 +958,7 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 - Architecture choices: explicit over clever (P5). If codex disagrees with valid reason → TASTE DECISION. Scope changes both models agree on → USER CHALLENGE.
 - Evals: always include all relevant suites (P1)
 - Test plan: generate artifact at `~/.gstack/projects/$SLUG/{user}-{branch}-test-plan-{datetime}.md`
-- TODOS.md: collect all deferred scope expansions from Phase 1, auto-write
+- Linear follow-up issues: collect all deferred scope expansions from Phase 1, create issues, and record created issue IDs in the plan output.
 
 **Required execution checklist (Eng):**
 
@@ -1013,7 +1013,7 @@ Missing voice = N/A (not CONFIRMED). Single critical finding from one voice = fl
 - Test plan artifact written to disk (Section 3)
 - Failure modes registry with critical gap flags
 - Completion Summary (the full summary from the Eng skill)
-- TODOS.md updates (collected from all phases)
+- Linear follow-up issues (collected from all phases)
 
 ---
 
@@ -1129,8 +1129,8 @@ I recommend [X] — [principle]. But [Y] is also viable:
 **Theme: [topic]** — flagged in [Phase 1, Phase 3]. High-confidence signal.
 [If no themes span phases:] "No cross-phase themes — each phase's concerns were distinct."
 
-### Deferred to TODOS.md
-[Items auto-deferred with reasons]
+### Linear follow-up issues
+[Created issue IDs for items auto-deferred with reasons]
 ```
 
 **Cognitive load management:**

--- a/.agents/skills/gstack/autoplan/SKILL.md.tmpl
+++ b/.agents/skills/gstack/autoplan/SKILL.md.tmpl
@@ -231,7 +231,7 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
   that is NOT auto-decided. Premises require human judgment.
 - Alternatives: pick highest completeness (P1). If tied, pick simplest (P5).
   If top 2 are close → mark TASTE DECISION.
-- Scope expansion: in blast radius + <1d CC → approve (P2). Outside → defer to TODOS.md (P3).
+- Scope expansion: in blast radius + <1d CC → approve (P2). Outside → create candidate Linear follow-up (P3).
   Duplicates → reject (P4). Borderline (3-5 files) → mark TASTE DECISION.
 - All 10 review sections: run fully, auto-decide each issue, log every decision.
 - Dual voices: always run BOTH Claude subagent AND Codex if available (P6).
@@ -457,7 +457,7 @@ Override: every AskUserQuestion → auto-decide using the 6 principles.
 - Architecture choices: explicit over clever (P5). If codex disagrees with valid reason → TASTE DECISION. Scope changes both models agree on → USER CHALLENGE.
 - Evals: always include all relevant suites (P1)
 - Test plan: generate artifact at `~/.gstack/projects/$SLUG/{user}-{branch}-test-plan-{datetime}.md`
-- TODOS.md: collect all deferred scope expansions from Phase 1, auto-write
+- Linear follow-up issues: collect all deferred scope expansions from Phase 1, create issues, and record created issue IDs in the plan output.
 
 **Required execution checklist (Eng):**
 
@@ -512,7 +512,7 @@ Missing voice = N/A (not CONFIRMED). Single critical finding from one voice = fl
 - Test plan artifact written to disk (Section 3)
 - Failure modes registry with critical gap flags
 - Completion Summary (the full summary from the Eng skill)
-- TODOS.md updates (collected from all phases)
+- Linear follow-up issues (collected from all phases)
 
 ---
 
@@ -628,8 +628,8 @@ I recommend [X] — [principle]. But [Y] is also viable:
 **Theme: [topic]** — flagged in [Phase 1, Phase 3]. High-confidence signal.
 [If no themes span phases:] "No cross-phase themes — each phase's concerns were distinct."
 
-### Deferred to TODOS.md
-[Items auto-deferred with reasons]
+### Linear follow-up issues
+[Created issue IDs for items auto-deferred with reasons]
 ```
 
 **Cognitive load management:**

--- a/.agents/skills/gstack/docs/designs/ML_PROMPT_INJECTION_KILLER.md
+++ b/.agents/skills/gstack/docs/designs/ML_PROMPT_INJECTION_KILLER.md
@@ -1,6 +1,6 @@
 # ML Prompt Injection Killer
 
-**Status:** P0 TODO (follow-up to sidebar security fix PR)
+**Status:** Legacy design context for sidebar security hardening
 **Branch:** garrytan/extension-prompt-injection-defense
 **Date:** 2026-03-28
 **CEO Plan:** ~/.gstack/projects/garrytan-gstack/ceo-plans/2026-03-28-sidebar-prompt-injection-defense.md

--- a/.agents/skills/gstack/document-release/SKILL.md
+++ b/.agents/skills/gstack/document-release/SKILL.md
@@ -632,25 +632,29 @@ After auditing each file individually, do a cross-doc consistency pass:
 
 ---
 
-## Step 7: TODOS.md Cleanup
+## Step 7: Legacy TODO Context + Linear Follow-Ups
 
-This is a second pass that complements `/ship`'s Step 5.5. Read `review/TODOS-format.md` (if
-available) for the canonical TODO item format.
+This is a second pass that complements `/ship`'s follow-up capture. Existing `TODOS.md`
+is legacy context only. Do not add new TODO items. Read `review/LINEAR-followups.md` for
+the canonical follow-up issue format.
 
-If TODOS.md does not exist, skip this step.
+If TODOS.md does not exist, skip the legacy cross-reference and still check for new
+follow-up work in the diff.
 
-1. **Completed items not yet marked:** Cross-reference the diff against open TODO items. If a
-   TODO is clearly completed by the changes in this branch, move it to the Completed section
-   with `**Completed:** vX.Y.Z.W (YYYY-MM-DD)`. Be conservative — only mark items with clear
-   evidence in the diff.
+1. **Legacy context:** Cross-reference the diff against open TODO items. If a TODO is clearly
+   completed by the changes in this branch, note it in the documentation summary, but do not
+   edit `TODOS.md`.
 
 2. **Items needing description updates:** If a TODO references files or components that were
-   significantly changed, its description may be stale. Use AskUserQuestion to confirm whether
-   the TODO should be updated, completed, or left as-is.
+   significantly changed, its description may be stale. Create a Linear follow-up issue only
+   if this creates actionable work that should not be lost.
 
 3. **New deferred work:** Check the diff for `TODO`, `FIXME`, `HACK`, and `XXX` comments. For
-   each one that represents meaningful deferred work (not a trivial inline note), use
-   AskUserQuestion to ask whether it should be captured in TODOS.md.
+   each one that represents meaningful deferred work (not a trivial inline note), create a
+   Linear follow-up issue before final closeout. Optional work uses the title
+   `Candidate follow-up: <title>` and must include: "Pickup agent must first judge whether to
+   implement, close, or split this." Do not add the `automated` label by default. Record and
+   include Linear issue ID(s) for every follow-up created in the final report or PR body.
 
 ---
 

--- a/.agents/skills/gstack/document-release/SKILL.md.tmpl
+++ b/.agents/skills/gstack/document-release/SKILL.md.tmpl
@@ -204,25 +204,29 @@ After auditing each file individually, do a cross-doc consistency pass:
 
 ---
 
-## Step 7: TODOS.md Cleanup
+## Step 7: Legacy TODO Context + Linear Follow-Ups
 
-This is a second pass that complements `/ship`'s Step 5.5. Read `review/TODOS-format.md` (if
-available) for the canonical TODO item format.
+This is a second pass that complements `/ship`'s follow-up capture. Existing `TODOS.md`
+is legacy context only. Do not add new TODO items. Read `review/LINEAR-followups.md` for
+the canonical follow-up issue format.
 
-If TODOS.md does not exist, skip this step.
+If TODOS.md does not exist, skip the legacy cross-reference and still check for new
+follow-up work in the diff.
 
-1. **Completed items not yet marked:** Cross-reference the diff against open TODO items. If a
-   TODO is clearly completed by the changes in this branch, move it to the Completed section
-   with `**Completed:** vX.Y.Z.W (YYYY-MM-DD)`. Be conservative — only mark items with clear
-   evidence in the diff.
+1. **Legacy context:** Cross-reference the diff against open TODO items. If a TODO is clearly
+   completed by the changes in this branch, note it in the documentation summary, but do not
+   edit `TODOS.md`.
 
 2. **Items needing description updates:** If a TODO references files or components that were
-   significantly changed, its description may be stale. Use AskUserQuestion to confirm whether
-   the TODO should be updated, completed, or left as-is.
+   significantly changed, its description may be stale. Create a Linear follow-up issue only
+   if this creates actionable work that should not be lost.
 
 3. **New deferred work:** Check the diff for `TODO`, `FIXME`, `HACK`, and `XXX` comments. For
-   each one that represents meaningful deferred work (not a trivial inline note), use
-   AskUserQuestion to ask whether it should be captured in TODOS.md.
+   each one that represents meaningful deferred work (not a trivial inline note), create a
+   Linear follow-up issue before final closeout. Optional work uses the title
+   `Candidate follow-up: <title>` and must include: "Pickup agent must first judge whether to
+   implement, close, or split this." Do not add the `automated` label by default. Record and
+   include Linear issue ID(s) for every follow-up created in the final report or PR body.
 
 ---
 

--- a/.agents/skills/gstack/plan-ceo-review/SKILL.md
+++ b/.agents/skills/gstack/plan-ceo-review/SKILL.md
@@ -491,7 +491,7 @@ Do NOT make any code changes. Do NOT start implementation. Your only job right n
 4. Interactions have edge cases. Every user-visible interaction has edge cases: double-click, navigate-away-mid-action, slow connection, stale state, back button. Map them.
 5. Observability is scope, not afterthought. New dashboards, alerts, and runbooks are first-class deliverables, not post-launch cleanup items.
 6. Diagrams are mandatory. No non-trivial flow goes undiagrammed. ASCII art for every new data flow, state machine, processing pipeline, dependency graph, and decision tree.
-7. Everything deferred must be written down. Vague intentions are lies. TODOS.md or it doesn't exist.
+7. Everything deferred must become a Linear issue with an ID. Vague intentions are lies. Candidate work still gets a triage issue.
 8. Optimize for the 6-month future, not just today. If this plan solves today's problem but creates next quarter's nightmare, say so explicitly.
 9. You have permission to say "scrap it and do this instead." If there's a fundamentally better approach, table it. I'd rather hear it now.
 
@@ -798,7 +798,7 @@ Rules:
 1. 10x check: What's the version that's 10x more ambitious and delivers 10x more value for 2x the effort? Describe it concretely.
 2. Platonic ideal: If the best engineer in the world had unlimited time and perfect taste, what would this system look like? What would the user feel when using it? Start from experience, not architecture.
 3. Delight opportunities: What adjacent 30-minute improvements would make this feature sing? Things where a user would think "oh nice, they thought of that." List at least 5.
-4. **Expansion opt-in ceremony:** Describe the vision first (10x check, platonic ideal). Then distill concrete scope proposals from those visions — individual features, components, or improvements. Present each proposal as its own AskUserQuestion. Recommend enthusiastically — explain why it's worth doing. But the user decides. Options: **A)** Add to this plan's scope **B)** Defer to TODOS.md **C)** Skip. Accepted items become plan scope for all remaining review sections. Rejected items go to "NOT in scope."
+4. **Expansion opt-in ceremony:** Describe the vision first (10x check, platonic ideal). Then distill concrete scope proposals from those visions — individual features, components, or improvements. Present each proposal as its own AskUserQuestion. Recommend enthusiastically — explain why it's worth doing. But the user decides. Options: **A)** Add to this plan's scope **B)** Create candidate Linear follow-up **C)** Skip as not actionable. Accepted items become plan scope for all remaining review sections. Candidate items get Linear issues using `review/LINEAR-followups.md`. Rejected items go to "NOT in scope."
 
 **For SELECTIVE EXPANSION** — run the HOLD SCOPE analysis first, then surface expansions:
 1. Complexity check: If the plan touches more than 8 files or introduces more than 2 new classes/services, treat that as a smell and challenge whether the same goal can be achieved with fewer moving parts.
@@ -807,7 +807,7 @@ Rules:
    - 10x check: What's the version that's 10x more ambitious? Describe it concretely.
    - Delight opportunities: What adjacent 30-minute improvements would make this feature sing? List at least 5.
    - Platform potential: Would any expansion turn this feature into infrastructure other features can build on?
-4. **Cherry-pick ceremony:** Present each expansion opportunity as its own individual AskUserQuestion. Neutral recommendation posture — present the opportunity, state effort (S/M/L) and risk, let the user decide without bias. Options: **A)** Add to this plan's scope **B)** Defer to TODOS.md **C)** Skip. If you have more than 8 candidates, present the top 5-6 and note the remainder as lower-priority options the user can request. Accepted items become plan scope for all remaining review sections. Rejected items go to "NOT in scope."
+4. **Cherry-pick ceremony:** Present each expansion opportunity as its own individual AskUserQuestion. Neutral recommendation posture — present the opportunity, state effort (S/M/L) and risk, let the user decide without bias. Options: **A)** Add to this plan's scope **B)** Create candidate Linear follow-up **C)** Skip as not actionable. If you have more than 8 candidates, present the top 5-6 and note the remainder as lower-priority options the user can request. Accepted items become plan scope for all remaining review sections. Candidate items get Linear issues using `review/LINEAR-followups.md`. Rejected items go to "NOT in scope."
 
 **For HOLD SCOPE** — run this:
 1. Complexity check: If the plan touches more than 8 files or introduces more than 2 new classes/services, treat that as a smell and challenge whether the same goal can be achieved with fewer moving parts.
@@ -815,7 +815,7 @@ Rules:
 
 **For SCOPE REDUCTION** — run this:
 1. Ruthless cut: What is the absolute minimum that ships value to a user? Everything else is deferred. No exceptions.
-2. What can be a follow-up PR? Separate "must ship together" from "nice to ship together."
+2. What can be a Linear follow-up issue? Separate "must ship together" from "candidate for later."
 
 ### 0D-POST. Persist CEO Plan (EXPANSION and SELECTIVE EXPANSION only)
 
@@ -860,8 +860,8 @@ Repo: {owner/repo}
 ## Accepted Scope (added to this plan)
 - {bullet list of what's now in scope}
 
-## Deferred to TODOS.md
-- {items with context}
+## Linear follow-up issues
+- {created issue IDs with context}
 ```
 
 Derive the feature slug from the plan being reviewed (e.g., "user-dashboard", "auth-refactor"). Use the date in YYYY-MM-DD format.
@@ -1323,7 +1323,10 @@ Options:
 - A) Accept the outside voice's recommendation (I'll apply this change)
 - B) Keep the current approach (reject the outside voice)
 - C) Investigate further before deciding
-- D) Add to TODOS.md for later
+- D) Create candidate Linear follow-up for later
+
+If the user chooses D, create the candidate issue using the canonical format in
+`review/LINEAR-followups.md`, then show the created Linear issue ID before continuing.
 
 Wait for the user's response. Do NOT default to accepting because you agree with the
 outside voice. If the user chooses B, the current approach stands — do not re-argue.
@@ -1384,10 +1387,11 @@ Complete table of every method that can fail, every exception class, rescued sta
 ```
 Any row with RESCUED=N, TEST=N, USER SEES=Silent → **CRITICAL GAP**.
 
-### TODOS.md updates
-Present each potential TODO as its own individual AskUserQuestion. Never batch TODOs — one per question. Never silently skip this step. Follow the format in `.claude/skills/review/TODOS-format.md`.
+### Linear follow-up issues
 
-For each TODO, describe:
+Present each potential follow-up as its own individual AskUserQuestion. Never batch follow-ups — one per question. Never silently skip this step. Follow the format in `.claude/skills/gstack/review/LINEAR-followups.md`.
+
+For each follow-up, describe:
 * **What:** One-line description of the work.
 * **Why:** The concrete problem it solves or value it unlocks.
 * **Pros:** What you gain by doing this work.
@@ -1397,12 +1401,12 @@ For each TODO, describe:
 * **Priority:** P1/P2/P3
 * **Depends on / blocked by:** Any prerequisites or ordering constraints.
 
-Then present options: **A)** Add to TODOS.md **B)** Skip — not valuable enough **C)** Build it now in this PR instead of deferring.
+Then present options: **A)** Create Linear follow-up issue and display the created issue ID **B)** Skip as not actionable **C)** Schedule implementation via a follow-up workflow/PR — do not implement in this review skill. Optional work uses the title `Candidate follow-up: <title>` and must include: "Pickup agent must first judge whether to implement, close, or split this."
 
 ### Scope Expansion Decisions (EXPANSION and SELECTIVE EXPANSION only)
 For EXPANSION and SELECTIVE EXPANSION modes: expansion opportunities and delight items were surfaced and decided in Step 0D (opt-in/cherry-pick ceremony). The decisions are persisted in the CEO plan document. Reference the CEO plan for the full record. Do not re-surface them here — list the accepted expansions for completeness:
 * Accepted: {list items added to scope}
-* Deferred: {list items sent to TODOS.md}
+* Deferred: {list created Linear follow-up issue IDs}
 * Skipped: {list items rejected}
 
 ### Diagrams (mandatory, produce all that apply)
@@ -1441,7 +1445,7 @@ List every ASCII diagram in files this plan touches. Still accurate?
   | Dream state delta    | written                                     |
   | Error/rescue registry| ___ methods, ___ CRITICAL GAPS              |
   | Failure modes        | ___ total, ___ CRITICAL GAPS                |
-  | TODOS.md updates     | ___ items proposed                          |
+  | Linear follow-ups    | ___ issues created / ___ proposed           |
   | Scope proposals      | ___ proposed, ___ accepted (EXP + SEL)      |
   | CEO plan             | written / skipped (HOLD/REDUCTION)           |
   | Outside voice        | ran (codex/claude) / skipped                 |
@@ -1488,7 +1492,7 @@ Before running this command, substitute the placeholder values from the Completi
 - **MODE**: the mode the user selected (SCOPE_EXPANSION / SELECTIVE_EXPANSION / HOLD_SCOPE / SCOPE_REDUCTION)
 - **scope_proposed**: number from "Scope proposals: ___ proposed" in the summary (0 for HOLD/REDUCTION)
 - **scope_accepted**: number from "Scope proposals: ___ accepted" in the summary (0 for HOLD/REDUCTION)
-- **scope_deferred**: number of items deferred to TODOS.md from scope decisions (0 for HOLD/REDUCTION)
+- **scope_deferred**: number of items captured as Linear follow-ups from scope decisions (0 for HOLD/REDUCTION)
 - **COMMIT**: output of `git rev-parse --short HEAD`
 
 ## Review Readiness Dashboard

--- a/.agents/skills/gstack/plan-ceo-review/SKILL.md.tmpl
+++ b/.agents/skills/gstack/plan-ceo-review/SKILL.md.tmpl
@@ -45,7 +45,7 @@ Do NOT make any code changes. Do NOT start implementation. Your only job right n
 4. Interactions have edge cases. Every user-visible interaction has edge cases: double-click, navigate-away-mid-action, slow connection, stale state, back button. Map them.
 5. Observability is scope, not afterthought. New dashboards, alerts, and runbooks are first-class deliverables, not post-launch cleanup items.
 6. Diagrams are mandatory. No non-trivial flow goes undiagrammed. ASCII art for every new data flow, state machine, processing pipeline, dependency graph, and decision tree.
-7. Everything deferred must be written down. Vague intentions are lies. TODOS.md or it doesn't exist.
+7. Everything deferred must become a Linear issue with an ID. Vague intentions are lies. Candidate work still gets a triage issue.
 8. Optimize for the 6-month future, not just today. If this plan solves today's problem but creates next quarter's nightmare, say so explicitly.
 9. You have permission to say "scrap it and do this instead." If there's a fundamentally better approach, table it. I'd rather hear it now.
 
@@ -243,7 +243,7 @@ Rules:
 1. 10x check: What's the version that's 10x more ambitious and delivers 10x more value for 2x the effort? Describe it concretely.
 2. Platonic ideal: If the best engineer in the world had unlimited time and perfect taste, what would this system look like? What would the user feel when using it? Start from experience, not architecture.
 3. Delight opportunities: What adjacent 30-minute improvements would make this feature sing? Things where a user would think "oh nice, they thought of that." List at least 5.
-4. **Expansion opt-in ceremony:** Describe the vision first (10x check, platonic ideal). Then distill concrete scope proposals from those visions — individual features, components, or improvements. Present each proposal as its own AskUserQuestion. Recommend enthusiastically — explain why it's worth doing. But the user decides. Options: **A)** Add to this plan's scope **B)** Defer to TODOS.md **C)** Skip. Accepted items become plan scope for all remaining review sections. Rejected items go to "NOT in scope."
+4. **Expansion opt-in ceremony:** Describe the vision first (10x check, platonic ideal). Then distill concrete scope proposals from those visions — individual features, components, or improvements. Present each proposal as its own AskUserQuestion. Recommend enthusiastically — explain why it's worth doing. But the user decides. Options: **A)** Add to this plan's scope **B)** Create candidate Linear follow-up **C)** Skip as not actionable. Accepted items become plan scope for all remaining review sections. Candidate items get Linear issues using `review/LINEAR-followups.md`. Rejected items go to "NOT in scope."
 
 **For SELECTIVE EXPANSION** — run the HOLD SCOPE analysis first, then surface expansions:
 1. Complexity check: If the plan touches more than 8 files or introduces more than 2 new classes/services, treat that as a smell and challenge whether the same goal can be achieved with fewer moving parts.
@@ -252,7 +252,7 @@ Rules:
    - 10x check: What's the version that's 10x more ambitious? Describe it concretely.
    - Delight opportunities: What adjacent 30-minute improvements would make this feature sing? List at least 5.
    - Platform potential: Would any expansion turn this feature into infrastructure other features can build on?
-4. **Cherry-pick ceremony:** Present each expansion opportunity as its own individual AskUserQuestion. Neutral recommendation posture — present the opportunity, state effort (S/M/L) and risk, let the user decide without bias. Options: **A)** Add to this plan's scope **B)** Defer to TODOS.md **C)** Skip. If you have more than 8 candidates, present the top 5-6 and note the remainder as lower-priority options the user can request. Accepted items become plan scope for all remaining review sections. Rejected items go to "NOT in scope."
+4. **Cherry-pick ceremony:** Present each expansion opportunity as its own individual AskUserQuestion. Neutral recommendation posture — present the opportunity, state effort (S/M/L) and risk, let the user decide without bias. Options: **A)** Add to this plan's scope **B)** Create candidate Linear follow-up **C)** Skip as not actionable. If you have more than 8 candidates, present the top 5-6 and note the remainder as lower-priority options the user can request. Accepted items become plan scope for all remaining review sections. Candidate items get Linear issues using `review/LINEAR-followups.md`. Rejected items go to "NOT in scope."
 
 **For HOLD SCOPE** — run this:
 1. Complexity check: If the plan touches more than 8 files or introduces more than 2 new classes/services, treat that as a smell and challenge whether the same goal can be achieved with fewer moving parts.
@@ -260,7 +260,7 @@ Rules:
 
 **For SCOPE REDUCTION** — run this:
 1. Ruthless cut: What is the absolute minimum that ships value to a user? Everything else is deferred. No exceptions.
-2. What can be a follow-up PR? Separate "must ship together" from "nice to ship together."
+2. What can be a Linear follow-up issue? Separate "must ship together" from "candidate for later."
 
 ### 0D-POST. Persist CEO Plan (EXPANSION and SELECTIVE EXPANSION only)
 
@@ -305,8 +305,8 @@ Repo: {owner/repo}
 ## Accepted Scope (added to this plan)
 - {bullet list of what's now in scope}
 
-## Deferred to TODOS.md
-- {items with context}
+## Linear follow-up issues
+- {created issue IDs with context}
 ```
 
 Derive the feature slug from the plan being reviewed (e.g., "user-dashboard", "auth-refactor"). Use the date in YYYY-MM-DD format.
@@ -635,10 +635,11 @@ Complete table of every method that can fail, every exception class, rescued sta
 ```
 Any row with RESCUED=N, TEST=N, USER SEES=Silent → **CRITICAL GAP**.
 
-### TODOS.md updates
-Present each potential TODO as its own individual AskUserQuestion. Never batch TODOs — one per question. Never silently skip this step. Follow the format in `.claude/skills/review/TODOS-format.md`.
+### Linear follow-up issues
 
-For each TODO, describe:
+Present each potential follow-up as its own individual AskUserQuestion. Never batch follow-ups — one per question. Never silently skip this step. Follow the format in `.claude/skills/gstack/review/LINEAR-followups.md`.
+
+For each follow-up, describe:
 * **What:** One-line description of the work.
 * **Why:** The concrete problem it solves or value it unlocks.
 * **Pros:** What you gain by doing this work.
@@ -648,12 +649,12 @@ For each TODO, describe:
 * **Priority:** P1/P2/P3
 * **Depends on / blocked by:** Any prerequisites or ordering constraints.
 
-Then present options: **A)** Add to TODOS.md **B)** Skip — not valuable enough **C)** Build it now in this PR instead of deferring.
+Then present options: **A)** Create Linear follow-up issue and display the created issue ID **B)** Skip as not actionable **C)** Schedule implementation via a follow-up workflow/PR — do not implement in this review skill. Optional work uses the title `Candidate follow-up: <title>` and must include: "Pickup agent must first judge whether to implement, close, or split this."
 
 ### Scope Expansion Decisions (EXPANSION and SELECTIVE EXPANSION only)
 For EXPANSION and SELECTIVE EXPANSION modes: expansion opportunities and delight items were surfaced and decided in Step 0D (opt-in/cherry-pick ceremony). The decisions are persisted in the CEO plan document. Reference the CEO plan for the full record. Do not re-surface them here — list the accepted expansions for completeness:
 * Accepted: {list items added to scope}
-* Deferred: {list items sent to TODOS.md}
+* Deferred: {list created Linear follow-up issue IDs}
 * Skipped: {list items rejected}
 
 ### Diagrams (mandatory, produce all that apply)
@@ -692,7 +693,7 @@ List every ASCII diagram in files this plan touches. Still accurate?
   | Dream state delta    | written                                     |
   | Error/rescue registry| ___ methods, ___ CRITICAL GAPS              |
   | Failure modes        | ___ total, ___ CRITICAL GAPS                |
-  | TODOS.md updates     | ___ items proposed                          |
+  | Linear follow-ups    | ___ issues created / ___ proposed           |
   | Scope proposals      | ___ proposed, ___ accepted (EXP + SEL)      |
   | CEO plan             | written / skipped (HOLD/REDUCTION)           |
   | Outside voice        | ran (codex/claude) / skipped                 |
@@ -739,7 +740,7 @@ Before running this command, substitute the placeholder values from the Completi
 - **MODE**: the mode the user selected (SCOPE_EXPANSION / SELECTIVE_EXPANSION / HOLD_SCOPE / SCOPE_REDUCTION)
 - **scope_proposed**: number from "Scope proposals: ___ proposed" in the summary (0 for HOLD/REDUCTION)
 - **scope_accepted**: number from "Scope proposals: ___ accepted" in the summary (0 for HOLD/REDUCTION)
-- **scope_deferred**: number of items deferred to TODOS.md from scope decisions (0 for HOLD/REDUCTION)
+- **scope_deferred**: number of items captured as Linear follow-ups from scope decisions (0 for HOLD/REDUCTION)
 - **COMMIT**: output of `git rev-parse --short HEAD`
 
 {{REVIEW_DASHBOARD}}

--- a/.agents/skills/gstack/plan-design-review/SKILL.md
+++ b/.agents/skills/gstack/plan-design-review/SKILL.md
@@ -559,7 +559,7 @@ Then read:
 - The plan file (current plan or branch diff)
 - CLAUDE.md — project conventions
 - DESIGN.md — if it exists, ALL design decisions calibrate against it
-- TODOS.md — any design-related TODOs this plan touches
+- TODOS.md — legacy context for design-related TODOs this plan touches, if present
 
 Map:
 * What is the UI scope of this plan? (pages, components, interactions)
@@ -1107,10 +1107,11 @@ Design decisions considered and explicitly deferred, with one-line rationale eac
 ### "What already exists" section
 Existing DESIGN.md, UI patterns, and components that the plan should reuse.
 
-### TODOS.md updates
-After all review passes are complete, present each potential TODO as its own individual AskUserQuestion. Never batch TODOs — one per question. Never silently skip this step.
+### Linear follow-up issues
 
-For design debt: missing a11y, unresolved responsive behavior, deferred empty states. Each TODO gets:
+After all review passes are complete, present each potential follow-up as its own individual AskUserQuestion. Never batch follow-ups — one per question. Never silently skip this step. Follow the format in `.claude/skills/gstack/review/LINEAR-followups.md`.
+
+For design debt: missing a11y, unresolved responsive behavior, deferred empty states. Each follow-up gets:
 * **What:** One-line description of the work.
 * **Why:** The concrete problem it solves or value it unlocks.
 * **Pros:** What you gain by doing this work.
@@ -1118,7 +1119,7 @@ For design debt: missing a11y, unresolved responsive behavior, deferred empty st
 * **Context:** Enough detail that someone picking this up in 3 months understands the motivation.
 * **Depends on / blocked by:** Any prerequisites.
 
-Then present options: **A)** Add to TODOS.md **B)** Skip — not valuable enough **C)** Build it now in this PR instead of deferring.
+Then present options: **A)** Create Linear follow-up issue and display the created issue ID **B)** Skip as not actionable **C)** Schedule implementation via a follow-up workflow/PR — do not implement in this review skill. Optional work uses the title `Candidate follow-up: <title>` and must include: "Pickup agent must first judge whether to implement, close, or split this."
 
 ### Completion Summary
 ```
@@ -1137,7 +1138,7 @@ Then present options: **A)** Add to TODOS.md **B)** Skip — not valuable enough
   +--------------------------------------------------------------------+
   | NOT in scope         | written (___ items)                         |
   | What already exists  | written                                     |
-  | TODOS.md updates     | ___ items proposed                          |
+  | Linear follow-ups    | ___ issues created / ___ proposed           |
   | Approved Mockups     | ___ generated, ___ approved                  |
   | Decisions made       | ___ added to plan                           |
   | Decisions deferred   | ___ (listed below)                          |

--- a/.agents/skills/gstack/plan-design-review/SKILL.md.tmpl
+++ b/.agents/skills/gstack/plan-design-review/SKILL.md.tmpl
@@ -113,7 +113,7 @@ Then read:
 - The plan file (current plan or branch diff)
 - CLAUDE.md — project conventions
 - DESIGN.md — if it exists, ALL design decisions calibrate against it
-- TODOS.md — any design-related TODOs this plan touches
+- TODOS.md — legacy context for design-related TODOs this plan touches, if present
 
 Map:
 * What is the UI scope of this plan? (pages, components, interactions)
@@ -347,10 +347,11 @@ Design decisions considered and explicitly deferred, with one-line rationale eac
 ### "What already exists" section
 Existing DESIGN.md, UI patterns, and components that the plan should reuse.
 
-### TODOS.md updates
-After all review passes are complete, present each potential TODO as its own individual AskUserQuestion. Never batch TODOs — one per question. Never silently skip this step.
+### Linear follow-up issues
 
-For design debt: missing a11y, unresolved responsive behavior, deferred empty states. Each TODO gets:
+After all review passes are complete, present each potential follow-up as its own individual AskUserQuestion. Never batch follow-ups — one per question. Never silently skip this step. Follow the format in `.claude/skills/gstack/review/LINEAR-followups.md`.
+
+For design debt: missing a11y, unresolved responsive behavior, deferred empty states. Each follow-up gets:
 * **What:** One-line description of the work.
 * **Why:** The concrete problem it solves or value it unlocks.
 * **Pros:** What you gain by doing this work.
@@ -358,7 +359,7 @@ For design debt: missing a11y, unresolved responsive behavior, deferred empty st
 * **Context:** Enough detail that someone picking this up in 3 months understands the motivation.
 * **Depends on / blocked by:** Any prerequisites.
 
-Then present options: **A)** Add to TODOS.md **B)** Skip — not valuable enough **C)** Build it now in this PR instead of deferring.
+Then present options: **A)** Create Linear follow-up issue and display the created issue ID **B)** Skip as not actionable **C)** Schedule implementation via a follow-up workflow/PR — do not implement in this review skill. Optional work uses the title `Candidate follow-up: <title>` and must include: "Pickup agent must first judge whether to implement, close, or split this."
 
 ### Completion Summary
 ```
@@ -377,7 +378,7 @@ Then present options: **A)** Add to TODOS.md **B)** Skip — not valuable enough
   +--------------------------------------------------------------------+
   | NOT in scope         | written (___ items)                         |
   | What already exists  | written                                     |
-  | TODOS.md updates     | ___ items proposed                          |
+  | Linear follow-ups    | ___ issues created / ___ proposed           |
   | Approved Mockups     | ___ generated, ___ approved                  |
   | Decisions made       | ___ added to plan                           |
   | Decisions deferred   | ___ (listed below)                          |

--- a/.agents/skills/gstack/plan-eng-review/SKILL.md
+++ b/.agents/skills/gstack/plan-eng-review/SKILL.md
@@ -556,11 +556,11 @@ Before reviewing anything, answer these questions:
    If WebSearch is unavailable, skip this check and note: "Search unavailable — proceeding with in-distribution knowledge only."
 
    If the plan rolls a custom solution where a built-in exists, flag it as a scope reduction opportunity. Annotate recommendations with **[Layer 1]**, **[Layer 2]**, **[Layer 3]**, or **[EUREKA]** (see preamble's Search Before Building section). If you find a eureka moment — a reason the standard approach is wrong for this case — present it as an architectural insight.
-5. **TODOS cross-reference:** Read `TODOS.md` if it exists. Are any deferred items blocking this plan? Can any deferred items be bundled into this PR without expanding scope? Does this plan create new work that should be captured as a TODO?
+5. **Legacy TODO cross-reference:** Read `TODOS.md` if it exists as legacy context only. Are any deferred items blocking this plan? Can any deferred items be bundled into this PR without expanding scope? Does this plan create actionable deferred work that should become a Linear issue?
 
-5. **Completeness check:** Is the plan doing the complete version or a shortcut? With AI-assisted coding, the cost of completeness (100% test coverage, full edge case handling, complete error paths) is 10-100x cheaper than with a human team. If the plan proposes a shortcut that saves human-hours but only saves minutes with CC+gstack, recommend the complete version. Boil the lake.
+6. **Completeness check:** Is the plan doing the complete version or a shortcut? With AI-assisted coding, the cost of completeness (100% test coverage, full edge case handling, complete error paths) is 10-100x cheaper than with a human team. If the plan proposes a shortcut that saves human-hours but only saves minutes with CC+gstack, recommend the complete version. Boil the lake.
 
-6. **Distribution check:** If the plan introduces a new artifact type (CLI binary, library package, container image, mobile app), does it include the build/publish pipeline? Code without distribution is code nobody can use. Check:
+7. **Distribution check:** If the plan introduces a new artifact type (CLI binary, library package, container image, mobile app), does it include the build/publish pipeline? Code without distribution is code nobody can use. Check:
    - Is there a CI/CD workflow for building and publishing the artifact?
    - Are target platforms defined (linux/darwin/windows, amd64/arm64)?
    - How will users download or install it (GitHub Releases, package manager, container registry)?
@@ -991,7 +991,10 @@ Options:
 - A) Accept the outside voice's recommendation (I'll apply this change)
 - B) Keep the current approach (reject the outside voice)
 - C) Investigate further before deciding
-- D) Add to TODOS.md for later
+- D) Create candidate Linear follow-up for later
+
+If the user chooses D, create the candidate issue using the canonical format in
+`review/LINEAR-followups.md`, then show the created Linear issue ID before continuing.
 
 Wait for the user's response. Do NOT default to accepting because you agree with the
 outside voice. If the user chooses B, the current approach stands — do not re-argue.
@@ -1036,10 +1039,11 @@ Every plan review MUST produce a "NOT in scope" section listing work that was co
 ### "What already exists" section
 List existing code/flows that already partially solve sub-problems in this plan, and whether the plan reuses them or unnecessarily rebuilds them.
 
-### TODOS.md updates
-After all review sections are complete, present each potential TODO as its own individual AskUserQuestion. Never batch TODOs — one per question. Never silently skip this step. Follow the format in `.claude/skills/review/TODOS-format.md`.
+### Linear follow-up issues
 
-For each TODO, describe:
+After all review sections are complete, present each potential follow-up as its own individual AskUserQuestion. Never batch follow-ups — one per question. Never silently skip this step. Follow the format in `.claude/skills/gstack/review/LINEAR-followups.md`.
+
+For each follow-up, describe:
 * **What:** One-line description of the work.
 * **Why:** The concrete problem it solves or value it unlocks.
 * **Pros:** What you gain by doing this work.
@@ -1047,9 +1051,9 @@ For each TODO, describe:
 * **Context:** Enough detail that someone picking this up in 3 months understands the motivation, the current state, and where to start.
 * **Depends on / blocked by:** Any prerequisites or ordering constraints.
 
-Then present options: **A)** Add to TODOS.md **B)** Skip — not valuable enough **C)** Build it now in this PR instead of deferring.
+Then present options: **A)** Create Linear follow-up issue and display the created issue ID **B)** Skip as not actionable **C)** Schedule implementation via a follow-up workflow/PR — do not implement in this review skill. Optional work uses the title `Candidate follow-up: <title>` and must include: "Pickup agent must first judge whether to implement, close, or split this."
 
-Do NOT just append vague bullet points. A TODO without context is worse than no TODO — it creates false confidence that the idea was captured while actually losing the reasoning.
+Do NOT just append vague bullet points. A follow-up without a Linear issue ID creates false confidence that the idea was captured while actually losing the reasoning. Include every created issue ID in the completion summary.
 
 ### Diagrams
 The plan itself should use ASCII diagrams for any non-trivial data flow, state machine, or processing pipeline. Additionally, identify which files in the implementation should get inline ASCII diagram comments — particularly Models with complex state transitions, Services with multi-step pipelines, and Concerns with non-obvious mixin behavior.
@@ -1098,7 +1102,7 @@ At the end of the review, fill in and display this summary so the user can see a
 - Performance Review: ___ issues found
 - NOT in scope: written
 - What already exists: written
-- TODOS.md updates: ___ items proposed to user
+- Linear follow-ups: <count> issues created (IDs: <ids or none>) / <count> proposed to user
 - Failure modes: ___ critical gaps flagged
 - Outside voice: ran (codex/claude) / skipped
 - Parallelization: ___ lanes, ___ parallel / ___ sequential

--- a/.agents/skills/gstack/plan-eng-review/SKILL.md.tmpl
+++ b/.agents/skills/gstack/plan-eng-review/SKILL.md.tmpl
@@ -92,11 +92,11 @@ Before reviewing anything, answer these questions:
    If WebSearch is unavailable, skip this check and note: "Search unavailable — proceeding with in-distribution knowledge only."
 
    If the plan rolls a custom solution where a built-in exists, flag it as a scope reduction opportunity. Annotate recommendations with **[Layer 1]**, **[Layer 2]**, **[Layer 3]**, or **[EUREKA]** (see preamble's Search Before Building section). If you find a eureka moment — a reason the standard approach is wrong for this case — present it as an architectural insight.
-5. **TODOS cross-reference:** Read `TODOS.md` if it exists. Are any deferred items blocking this plan? Can any deferred items be bundled into this PR without expanding scope? Does this plan create new work that should be captured as a TODO?
+5. **Legacy TODO cross-reference:** Read `TODOS.md` if it exists as legacy context only. Are any deferred items blocking this plan? Can any deferred items be bundled into this PR without expanding scope? Does this plan create actionable deferred work that should become a Linear issue?
 
-5. **Completeness check:** Is the plan doing the complete version or a shortcut? With AI-assisted coding, the cost of completeness (100% test coverage, full edge case handling, complete error paths) is 10-100x cheaper than with a human team. If the plan proposes a shortcut that saves human-hours but only saves minutes with CC+gstack, recommend the complete version. Boil the lake.
+6. **Completeness check:** Is the plan doing the complete version or a shortcut? With AI-assisted coding, the cost of completeness (100% test coverage, full edge case handling, complete error paths) is 10-100x cheaper than with a human team. If the plan proposes a shortcut that saves human-hours but only saves minutes with CC+gstack, recommend the complete version. Boil the lake.
 
-6. **Distribution check:** If the plan introduces a new artifact type (CLI binary, library package, container image, mobile app), does it include the build/publish pipeline? Code without distribution is code nobody can use. Check:
+7. **Distribution check:** If the plan introduces a new artifact type (CLI binary, library package, container image, mobile app), does it include the build/publish pipeline? Code without distribution is code nobody can use. Check:
    - Is there a CI/CD workflow for building and publishing the artifact?
    - Are target platforms defined (linux/darwin/windows, amd64/arm64)?
    - How will users download or install it (GitHub Releases, package manager, container registry)?
@@ -183,10 +183,11 @@ Every plan review MUST produce a "NOT in scope" section listing work that was co
 ### "What already exists" section
 List existing code/flows that already partially solve sub-problems in this plan, and whether the plan reuses them or unnecessarily rebuilds them.
 
-### TODOS.md updates
-After all review sections are complete, present each potential TODO as its own individual AskUserQuestion. Never batch TODOs — one per question. Never silently skip this step. Follow the format in `.claude/skills/review/TODOS-format.md`.
+### Linear follow-up issues
 
-For each TODO, describe:
+After all review sections are complete, present each potential follow-up as its own individual AskUserQuestion. Never batch follow-ups — one per question. Never silently skip this step. Follow the format in `.claude/skills/gstack/review/LINEAR-followups.md`.
+
+For each follow-up, describe:
 * **What:** One-line description of the work.
 * **Why:** The concrete problem it solves or value it unlocks.
 * **Pros:** What you gain by doing this work.
@@ -194,9 +195,9 @@ For each TODO, describe:
 * **Context:** Enough detail that someone picking this up in 3 months understands the motivation, the current state, and where to start.
 * **Depends on / blocked by:** Any prerequisites or ordering constraints.
 
-Then present options: **A)** Add to TODOS.md **B)** Skip — not valuable enough **C)** Build it now in this PR instead of deferring.
+Then present options: **A)** Create Linear follow-up issue and display the created issue ID **B)** Skip as not actionable **C)** Schedule implementation via a follow-up workflow/PR — do not implement in this review skill. Optional work uses the title `Candidate follow-up: <title>` and must include: "Pickup agent must first judge whether to implement, close, or split this."
 
-Do NOT just append vague bullet points. A TODO without context is worse than no TODO — it creates false confidence that the idea was captured while actually losing the reasoning.
+Do NOT just append vague bullet points. A follow-up without a Linear issue ID creates false confidence that the idea was captured while actually losing the reasoning. Include every created issue ID in the completion summary.
 
 ### Diagrams
 The plan itself should use ASCII diagrams for any non-trivial data flow, state machine, or processing pipeline. Additionally, identify which files in the implementation should get inline ASCII diagram comments — particularly Models with complex state transitions, Services with multi-step pipelines, and Concerns with non-obvious mixin behavior.
@@ -245,7 +246,7 @@ At the end of the review, fill in and display this summary so the user can see a
 - Performance Review: ___ issues found
 - NOT in scope: written
 - What already exists: written
-- TODOS.md updates: ___ items proposed to user
+- Linear follow-ups: <count> issues created (IDs: <ids or none>) / <count> proposed to user
 - Failure modes: ___ critical gaps flagged
 - Outside voice: ran (codex/claude) / skipped
 - Parallelization: ___ lanes, ___ parallel / ___ sequential

--- a/.agents/skills/gstack/review/LINEAR-followups.md
+++ b/.agents/skills/gstack/review/LINEAR-followups.md
@@ -1,0 +1,52 @@
+# Linear Follow-Up Issue Format
+
+Shared reference for durable follow-up capture. Use Linear issues for new follow-up work; do not add new items to `TODOS.md`. Existing `TODOS.md` files are legacy context only.
+
+## Required Issue Fields
+
+Every follow-up issue description should include:
+
+```markdown
+## Source
+- Current issue: <JOV-XXXX or "ad-hoc">
+- Source PR: <PR URL or "not opened yet">
+- Source branch/session: <branch name or session context>
+- Created follow-up issue ID: <fill with the Linear issue key after creation>
+
+## Follow-up
+<What was not done. Be specific enough that another agent can find the code or workflow.>
+
+## Why it matters
+<User impact, risk reduction, cleanup value, or product reason.>
+
+## Classification
+Required / Candidate
+
+## Acceptance criteria or triage question
+<Required work gets acceptance criteria. Candidate work gets the decision question.>
+
+## Dependency
+<Use blockedBy or note that this depends on the source issue/PR landing first. Otherwise "None".>
+```
+
+## Closeout Requirement
+
+After creating the issue, record the Linear issue ID (for example `JOV-1234`) in the PR body or final output next to the follow-up. Do not close out with "created" but no ID.
+
+## Candidate Follow-Ups
+
+Optional work must use the title format:
+
+```text
+Candidate follow-up: <title>
+```
+
+Include this exact note in the description:
+
+> Pickup agent must first judge whether to implement, close, or split this.
+
+Do not add the `automated` label by default. Candidate issues must remain visible for triage without being blindly dispatched.
+
+## Required Follow-Ups
+
+Required deferred work should have a direct action title, concrete acceptance criteria, and a dependency link when it cannot start until the source issue or PR lands.

--- a/.agents/skills/gstack/review/SKILL.md
+++ b/.agents/skills/gstack/review/SKILL.md
@@ -673,7 +673,7 @@ The plan completion results augment the existing Scope Drift Detection. If a pla
 - **Items in the diff that don't match any plan item** become evidence for **SCOPE CREEP** detection.
 - **HIGH-impact discrepancies** trigger AskUserQuestion:
   - Show the investigation findings
-  - Options: A) Stop and implement missing items, B) Ship anyway + create P1 TODOs, C) Intentionally dropped
+  - Options: A) Stop and implement missing items, B) Ship anyway + create required Linear follow-up issues using `review/LINEAR-followups.md` and record their IDs, C) Intentionally dropped
 
 This is **INFORMATIONAL** unless HIGH-impact discrepancies are found (then it gates via AskUserQuestion).
 
@@ -1056,7 +1056,7 @@ Before replying to any comment, run the **Escalation Detection** algorithm from 
    - Deterministic parser/script failures -> focused test.
    - Repeated repo-policy mistake -> `.claude/rules/*` or `LESSONS.md`.
    - Repeated workflow mistake -> edit the gstack `.tmpl` source and regenerate generated skills.
-   - High-risk product/auth/billing/migration work -> create or mention a Linear follow-up instead of broadening this review.
+   - High-risk product/auth/billing/migration work -> create a Linear follow-up issue instead of broadening this review. Do not merely mention it.
 
 ---
 

--- a/.agents/skills/gstack/review/SKILL.md.tmpl
+++ b/.agents/skills/gstack/review/SKILL.md.tmpl
@@ -187,7 +187,7 @@ Before replying to any comment, run the **Escalation Detection** algorithm from 
    - Deterministic parser/script failures -> focused test.
    - Repeated repo-policy mistake -> `.claude/rules/*` or `LESSONS.md`.
    - Repeated workflow mistake -> edit the gstack `.tmpl` source and regenerate generated skills.
-   - High-risk product/auth/billing/migration work -> create or mention a Linear follow-up instead of broadening this review.
+   - High-risk product/auth/billing/migration work -> create a Linear follow-up issue instead of broadening this review. Do not merely mention it.
 
 ---
 

--- a/.agents/skills/gstack/review/TODOS-format.md
+++ b/.agents/skills/gstack/review/TODOS-format.md
@@ -1,6 +1,6 @@
 # TODOS.md Format Reference
 
-Shared reference for the canonical TODOS.md format. Referenced by `/ship` (Step 5.5) and `/plan-ceo-review` (TODOS.md updates section) to ensure consistent TODO item structure.
+Legacy reference for older `TODOS.md` files. New follow-up work must be captured in Linear using `review/LINEAR-followups.md`; do not add new items here.
 
 ---
 

--- a/.agents/skills/gstack/scripts/resolvers/preamble.ts
+++ b/.agents/skills/gstack/scripts/resolvers/preamble.ts
@@ -283,7 +283,9 @@ function generateRepoModeSection(): string {
 Always flag anything that looks wrong — one sentence, what you noticed and its impact.`;
 }
 
-export function generateTestFailureTriage(): string {
+export function generateTestFailureTriage(ctx: TemplateContext): string {
+  const linearFollowupsPath = `${ctx.paths.skillRoot}/review/LINEAR-followups.md`;
+
   return `## Test Failure Ownership Triage
 
 When tests fail, do NOT immediately stop. First, determine ownership:
@@ -324,7 +326,7 @@ Use AskUserQuestion:
 >
 > RECOMMENDATION: Choose A — fix now while the context is fresh. Completeness: 9/10.
 > A) Investigate and fix now (human: ~2-4h / CC: ~15min) — Completeness: 10/10
-> B) Add as P0 TODO — fix after this branch lands — Completeness: 7/10
+> B) Create required Linear follow-up — fix after this branch lands — Completeness: 7/10
 > C) Skip — I know about this, ship anyway — Completeness: 3/10
 
 **If REPO_MODE is \`collaborative\` or \`unknown\`:**
@@ -340,7 +342,7 @@ Use AskUserQuestion:
 > RECOMMENDATION: Choose B — assign it to whoever broke it so the right person fixes it. Completeness: 9/10.
 > A) Investigate and fix now anyway — Completeness: 10/10
 > B) Blame + assign GitHub issue to the author — Completeness: 9/10
-> C) Add as P0 TODO — Completeness: 7/10
+> C) Create required Linear follow-up — Completeness: 7/10
 > D) Skip — ship anyway — Completeness: 3/10
 
 ### Step T4: Execute the chosen action
@@ -351,11 +353,11 @@ Use AskUserQuestion:
 - Commit the fix separately from the branch's changes: \`git commit -m "fix: pre-existing test failure in <test-file>"\`
 - Continue with the workflow.
 
-**If "Add as P0 TODO":**
-- If \`TODOS.md\` exists, add the entry following the format in \`review/TODOS-format.md\` (or \`.claude/skills/review/TODOS-format.md\`).
-- If \`TODOS.md\` does not exist, create it with the standard header and add the entry.
-- Entry should include: title, the error output, which branch it was noticed on, and priority P0.
-- Continue with the workflow — treat the pre-existing failure as non-blocking.
+**If "Create required Linear follow-up":**
+- Create a Linear issue using the format in \`${linearFollowupsPath}\`.
+- Classify it as Required. Include the failing test name, first relevant error lines, current branch, source PR if available, and why this can be handled separately.
+- Do not add the \`automated\` label unless a human explicitly asks for unattended dispatch.
+- Continue with the workflow — treat the pre-existing failure as non-blocking once the Linear issue ID is captured.
 
 **If "Blame + assign GitHub issue" (collaborative only):**
 - Find who likely broke it. Check BOTH the test file AND the production code it tests:

--- a/.agents/skills/gstack/scripts/resolvers/review.ts
+++ b/.agents/skills/gstack/scripts/resolvers/review.ts
@@ -657,7 +657,10 @@ Options:
 - A) Accept the outside voice's recommendation (I'll apply this change)
 - B) Keep the current approach (reject the outside voice)
 - C) Investigate further before deciding
-- D) Add to TODOS.md for later
+- D) Create candidate Linear follow-up for later
+
+If the user chooses D, create the candidate issue using the canonical format in
+\`review/LINEAR-followups.md\`, then show the created Linear issue ID before continuing.
 
 Wait for the user's response. Do NOT default to accepting because you agree with the
 outside voice. If the user chooses B, the current approach stands — do not re-argue.
@@ -807,10 +810,10 @@ After producing the completion checklist:
   - RECOMMENDATION: depends on item count and severity. If 1-2 minor items (docs, config), recommend B. If core functionality is missing, recommend A.
   - Options:
     A) Stop — implement the missing items before shipping
-    B) Ship anyway — defer these to a follow-up (will create P1 TODOs in Step 5.5)
+    B) Ship anyway — create required Linear follow-up issues before PR/final closeout
     C) These items were intentionally dropped — remove from scope
   - If A: STOP. List the missing items for the user to implement.
-  - If B: Continue. For each NOT DONE item, create a P1 TODO in Step 5.5 with "Deferred from plan: {plan file path}".
+  - If B: Continue. For each NOT DONE item, create a Required Linear follow-up issue using \`review/LINEAR-followups.md\` with "Deferred from plan: {plan file path}", then record the created issue IDs in PR/final output.
   - If C: Continue. Note in PR body: "Plan items intentionally dropped: {list}."
 
 **No plan file found:** Skip entirely. "No plan file detected — skipping plan completion audit."
@@ -879,7 +882,7 @@ The plan completion results augment the existing Scope Drift Detection. If a pla
 - **Items in the diff that don't match any plan item** become evidence for **SCOPE CREEP** detection.
 - **HIGH-impact discrepancies** trigger AskUserQuestion:
   - Show the investigation findings
-  - Options: A) Stop and implement missing items, B) Ship anyway + create P1 TODOs, C) Intentionally dropped
+  - Options: A) Stop and implement missing items, B) Ship anyway + create required Linear follow-up issues using \`review/LINEAR-followups.md\` and record their IDs, C) Intentionally dropped
 
 This is **INFORMATIONAL** unless HIGH-impact discrepancies are found (then it gates via AskUserQuestion).
 

--- a/.agents/skills/gstack/setup
+++ b/.agents/skills/gstack/setup
@@ -469,7 +469,7 @@ create_codex_runtime_root() {
     ln -snf "$agents_dir/gstack-upgrade/SKILL.md" "$codex_gstack/gstack-upgrade/SKILL.md"
   fi
   # Review runtime assets (individual files, NOT the whole review/ dir which has SKILL.md)
-  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md LINEAR-followups.md; do
     if [ -f "$gstack_dir/review/$f" ]; then
       ln -snf "$gstack_dir/review/$f" "$codex_gstack/review/$f"
     fi
@@ -508,7 +508,7 @@ create_factory_runtime_root() {
   if [ -f "$factory_dir/gstack-upgrade/SKILL.md" ]; then
     ln -snf "$factory_dir/gstack-upgrade/SKILL.md" "$factory_gstack/gstack-upgrade/SKILL.md"
   fi
-  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md; do
+  for f in checklist.md design-checklist.md greptile-triage.md TODOS-format.md LINEAR-followups.md; do
     if [ -f "$gstack_dir/review/$f" ]; then
       ln -snf "$gstack_dir/review/$f" "$factory_gstack/review/$f"
     fi

--- a/.agents/skills/gstack/ship/SKILL.md
+++ b/.agents/skills/gstack/ship/SKILL.md
@@ -390,8 +390,7 @@ You are running the `/ship` workflow. This is a **non-interactive, fully automat
 - AI-assessed coverage below minimum threshold (hard gate with user override — see Step 3.4)
 - Plan items NOT DONE with no user override (see Step 3.45)
 - Plan verification failures (see Step 3.47)
-- TODOS.md missing and user wants to create one (ask — see Step 5.5)
-- TODOS.md disorganized and user wants to reorganize (ask — see Step 5.5)
+- Linear issue creation fails for actionable deferred work (see Step 5.5)
 
 **Never stop for:**
 - Uncommitted changes (always include them)
@@ -399,7 +398,7 @@ You are running the `/ship` workflow. This is a **non-interactive, fully automat
 - CHANGELOG content (auto-generate from diff)
 - Commit message approval (auto-commit)
 - Multi-file changesets (auto-split into bisectable commits)
-- TODOS.md completed-item detection (auto-mark)
+- Legacy TODO cross-reference that does not create new follow-up work
 - Auto-fixable review findings (dead code, N+1, stale comments — fixed automatically)
 - Test coverage gaps within target threshold (auto-generate and commit, or flag in PR body)
 
@@ -500,7 +499,7 @@ service with existing deployment — verify that a distribution pipeline exists.
    - "This PR adds a new binary/tool but there's no CI/CD pipeline to build and publish it.
      Users won't be able to download the artifact after merge."
    - A) Add a release workflow now (CI/CD release pipeline — GitHub Actions or GitLab CI depending on platform)
-   - B) Defer — add to TODOS.md
+   - B) Create Required Linear follow-up issue using `review/LINEAR-followups.md`
    - C) Not needed — this is internal/web-only, existing deployment covers it
 
 4. **If release pipeline exists:** Continue silently.
@@ -738,7 +737,7 @@ Use AskUserQuestion:
 >
 > RECOMMENDATION: Choose A — fix now while the context is fresh. Completeness: 9/10.
 > A) Investigate and fix now (human: ~2-4h / CC: ~15min) — Completeness: 10/10
-> B) Add as P0 TODO — fix after this branch lands — Completeness: 7/10
+> B) Create required Linear follow-up — fix after this branch lands — Completeness: 7/10
 > C) Skip — I know about this, ship anyway — Completeness: 3/10
 
 **If REPO_MODE is `collaborative` or `unknown`:**
@@ -754,7 +753,7 @@ Use AskUserQuestion:
 > RECOMMENDATION: Choose B — assign it to whoever broke it so the right person fixes it. Completeness: 9/10.
 > A) Investigate and fix now anyway — Completeness: 10/10
 > B) Blame + assign GitHub issue to the author — Completeness: 9/10
-> C) Add as P0 TODO — Completeness: 7/10
+> C) Create required Linear follow-up — Completeness: 7/10
 > D) Skip — ship anyway — Completeness: 3/10
 
 ### Step T4: Execute the chosen action
@@ -765,11 +764,11 @@ Use AskUserQuestion:
 - Commit the fix separately from the branch's changes: `git commit -m "fix: pre-existing test failure in <test-file>"`
 - Continue with the workflow.
 
-**If "Add as P0 TODO":**
-- If `TODOS.md` exists, add the entry following the format in `review/TODOS-format.md` (or `.claude/skills/review/TODOS-format.md`).
-- If `TODOS.md` does not exist, create it with the standard header and add the entry.
-- Entry should include: title, the error output, which branch it was noticed on, and priority P0.
-- Continue with the workflow — treat the pre-existing failure as non-blocking.
+**If "Create required Linear follow-up":**
+- Create a Linear issue using the format in `~/.claude/skills/gstack/review/LINEAR-followups.md`.
+- Classify it as Required. Include the failing test name, first relevant error lines, current branch, source PR if available, and why this can be handled separately.
+- Do not add the `automated` label unless a human explicitly asks for unattended dispatch.
+- Continue with the workflow — treat the pre-existing failure as non-blocking once the Linear issue ID is captured.
 
 **If "Blame + assign GitHub issue" (collaborative only):**
 - Find who likely broke it. Check BOTH the test file AND the production code it tests:
@@ -802,7 +801,7 @@ Use AskUserQuestion:
 - Continue with the workflow.
 - Note in output: "Pre-existing test failure skipped: <test-name>"
 
-**After triage:** If any in-branch failures remain unfixed, **STOP**. Do not proceed. If all failures were pre-existing and handled (fixed, TODOed, assigned, or skipped), continue to Step 3.25.
+**After triage:** If any in-branch failures remain unfixed, **STOP**. Do not proceed. If all failures were pre-existing and handled (fixed, assigned, or captured in Linear with issue IDs), continue to Step 3.25.
 
 **If all pass:** Continue silently — just note the counts briefly.
 
@@ -1241,10 +1240,10 @@ After producing the completion checklist:
   - RECOMMENDATION: depends on item count and severity. If 1-2 minor items (docs, config), recommend B. If core functionality is missing, recommend A.
   - Options:
     A) Stop — implement the missing items before shipping
-    B) Ship anyway — defer these to a follow-up (will create P1 TODOs in Step 5.5)
+    B) Ship anyway — create required Linear follow-up issues before PR/final closeout
     C) These items were intentionally dropped — remove from scope
   - If A: STOP. List the missing items for the user to implement.
-  - If B: Continue. For each NOT DONE item, create a P1 TODO in Step 5.5 with "Deferred from plan: {plan file path}".
+  - If B: Continue. For each NOT DONE item, create a Required Linear follow-up issue using `review/LINEAR-followups.md` with "Deferred from plan: {plan file path}", then record the created issue IDs in PR/final output.
   - If C: Continue. Note in PR body: "Plan items intentionally dropped: {list}."
 
 **No plan file found:** Skip entirely. "No plan file detected — skipping plan completion audit."
@@ -1553,7 +1552,7 @@ For each classified comment:
 - Deterministic parser/script failures -> focused test.
 - Repeated repo-policy mistake -> `.claude/rules/*` or `LESSONS.md`.
 - Repeated workflow mistake -> edit the gstack `.tmpl` source and regenerate generated skills.
-- High-risk product/auth/billing/migration work -> create or mention a Linear follow-up instead of broadening the ship PR.
+- High-risk product/auth/billing/migration work -> create a Linear follow-up issue instead of broadening the ship PR. Do not merely mention it.
 
 ---
 
@@ -1781,58 +1780,45 @@ If output shows `ALREADY_BUMPED`, VERSION was already bumped on this branch (pri
 
 ---
 
-## Step 5.5: TODOS.md (auto-update)
+## Step 5.5: Linear Follow-Up Issue Capture
 
-Cross-reference the project's TODOS.md against the changes being shipped. Mark completed items automatically; prompt only if the file is missing or disorganized.
+`TODOS.md` is legacy context only. Do not create, reorganize, or add new items to it.
+Use Linear for new follow-up work. Read `.claude/skills/gstack/review/LINEAR-followups.md`
+for the canonical issue format.
 
-Read `.claude/skills/review/TODOS-format.md` for the canonical format reference.
+**1. Gather follow-up candidates**
 
-**1. Check if TODOS.md exists** in the repository root.
+Collect every actionable item discovered during this workflow that will not be implemented
+in this PR, including:
+- NOT DONE plan items from Step 3.45.
+- Meaningful deferred work from review, QA, Greptile, design review, or verification.
+- Optional polish, future product work, pre-existing failures, and test gaps worth remembering.
+- Any final/PR-body sentence that would otherwise say "did not do X", "consider later",
+  "follow-up PR", "deferred", or "future work".
 
-**If TODOS.md does not exist:** Use AskUserQuestion:
-- Message: "GStack recommends maintaining a TODOS.md organized by skill/component, then priority (P0 at top through P4, then Completed at bottom). See TODOS-format.md for the full format. Would you like to create one?"
-- Options: A) Create it now, B) Skip for now
-- If A: Create `TODOS.md` with a skeleton (# TODOS heading + ## Completed section). Continue to step 3.
-- If B: Skip the rest of Step 5.5. Continue to Step 6.
+**2. Create Linear issues before closeout**
 
-**2. Check structure and organization:**
+For each actionable follow-up:
+- Create a Linear issue on the relevant team, usually `Jovie`.
+- Use the required structure from `review/LINEAR-followups.md`.
+- Classify as `Required` when the work is needed, or `Candidate` when another agent should
+  first decide whether it is worth doing.
+- Optional work must use the title `Candidate follow-up: <title>` and include:
+  "Pickup agent must first judge whether to implement, close, or split this."
+- If the follow-up depends on this PR or source issue landing first, set `blockedBy` when
+  possible. If not possible, describe the dependency in the issue body.
+- Do not add the `automated` label by default.
 
-Read TODOS.md and verify it follows the recommended structure:
-- Items grouped under `## <Skill/Component>` headings
-- Each item has `**Priority:**` field with P0-P4 value
-- A `## Completed` section at the bottom
+**3. Reference created issue IDs**
 
-**If disorganized** (missing priority fields, no component groupings, no Completed section): Use AskUserQuestion:
-- Message: "TODOS.md doesn't follow the recommended structure (skill/component groupings, P0-P4 priority, Completed section). Would you like to reorganize it?"
-- Options: A) Reorganize now (recommended), B) Leave as-is
-- If A: Reorganize in-place following TODOS-format.md. Preserve all content — only restructure, never delete items.
-- If B: Continue to step 3 without restructuring.
+Add every created follow-up issue ID to the PR body and final output. If no follow-up work
+exists, state `Linear follow-ups: none`.
 
-**3. Detect completed TODOs:**
+**4. Defensive**
 
-This step is fully automatic — no user interaction.
-
-Use the diff and commit history already gathered in earlier steps:
-- `git diff <base>...HEAD` (full diff against the base branch)
-- `git log <base>..HEAD --oneline` (all commits being shipped)
-
-For each TODO item, check if the changes in this PR complete it by:
-- Matching commit messages against the TODO title and description
-- Checking if files referenced in the TODO appear in the diff
-- Checking if the TODO's described work matches the functional changes
-
-**Be conservative:** Only mark a TODO as completed if there is clear evidence in the diff. If uncertain, leave it alone.
-
-**4. Move completed items** to the `## Completed` section at the bottom. Append: `**Completed:** vX.Y.Z (YYYY-MM-DD)`
-
-**5. Output summary:**
-- `TODOS.md: N items marked complete (item1, item2, ...). M items remaining.`
-- Or: `TODOS.md: No completed items detected. M items remaining.`
-- Or: `TODOS.md: Created.` / `TODOS.md: Reorganized.`
-
-**6. Defensive:** If TODOS.md cannot be written (permission error, disk full), warn the user and continue. Never stop the ship workflow for a TODOS failure.
-
-Save this summary — it goes into the PR body in Step 8.
+If Linear issue creation is unavailable or fails, warn the user and do not hide the follow-up
+inside a wall of text. Mark the ship result as blocked or done-with-concerns according to the
+Completion Status Protocol.
 
 ---
 
@@ -1846,7 +1832,7 @@ Save this summary — it goes into the PR body in Step 8.
    - **Infrastructure:** migrations, config changes, route additions
    - **Models & services:** new models, services, concerns (with their tests)
    - **Controllers & views:** controllers, views, JS/React components (with their tests)
-   - **VERSION + CHANGELOG + TODOS.md:** always in the final commit
+   - **VERSION + CHANGELOG + follow-up issue references:** always in the final commit
 
 3. **Rules for splitting:**
    - A model and its test file go in the same commit
@@ -1973,16 +1959,16 @@ you missed it.>
 <If no plan file: "No plan file detected.">
 <If plan items deferred: list deferred items>
 
+## Linear follow-ups
+<List each created Linear issue ID with a one-line rationale. If none: "Linear follow-ups: none.">
+
 ## Verification Results
 <If verification ran: summary from Step 3.47 (N PASS, M FAIL, K SKIPPED)>
 <If skipped: reason (no plan, no server, no verification section)>
 <If not applicable: omit this section>
 
-## TODOS
-<If items marked complete: bullet list of completed items with version>
-<If no items completed: "No TODO items completed in this PR.">
-<If TODOS.md created or reorganized: note that>
-<If TODOS.md doesn't exist and user skipped: omit this section>
+## TODOs (legacy)
+<If legacy TODO items were incidentally completed by this PR, list them. Never add new TODO items here. If none, omit this section.>
 
 ## Test plan
 - [x] All Rails tests pass (N runs, 0 failures)
@@ -2072,7 +2058,7 @@ This step is automatic — never skip it, never ask for confirmation.
 - **Always use the 4-digit version format** from the VERSION file.
 - **Date format in CHANGELOG:** `YYYY-MM-DD`
 - **Split commits for bisectability** — each commit = one logical change.
-- **TODOS.md completion detection must be conservative.** Only mark items as completed when the diff clearly shows the work is done.
+- **TODOS.md is legacy context only.** Never add new TODO items; create Linear issues for actionable follow-ups.
 - **Use Greptile reply templates from greptile-triage.md.** Every reply includes evidence (inline diff, code references, re-rank suggestion). Never post vague replies.
 - **Never push without fresh verification evidence.** If code changed after Step 3 tests, re-run before pushing.
 - **Step 3.4 generates coverage tests.** They must pass before committing. Never commit failing tests.

--- a/.agents/skills/gstack/ship/SKILL.md.tmpl
+++ b/.agents/skills/gstack/ship/SKILL.md.tmpl
@@ -39,8 +39,7 @@ You are running the `/ship` workflow. This is a **non-interactive, fully automat
 - AI-assessed coverage below minimum threshold (hard gate with user override — see Step 3.4)
 - Plan items NOT DONE with no user override (see Step 3.45)
 - Plan verification failures (see Step 3.47)
-- TODOS.md missing and user wants to create one (ask — see Step 5.5)
-- TODOS.md disorganized and user wants to reorganize (ask — see Step 5.5)
+- Linear issue creation fails for actionable deferred work (see Step 5.5)
 
 **Never stop for:**
 - Uncommitted changes (always include them)
@@ -48,7 +47,7 @@ You are running the `/ship` workflow. This is a **non-interactive, fully automat
 - CHANGELOG content (auto-generate from diff)
 - Commit message approval (auto-commit)
 - Multi-file changesets (auto-split into bisectable commits)
-- TODOS.md completed-item detection (auto-mark)
+- Legacy TODO cross-reference that does not create new follow-up work
 - Auto-fixable review findings (dead code, N+1, stale comments — fixed automatically)
 - Test coverage gaps within target threshold (auto-generate and commit, or flag in PR body)
 
@@ -100,7 +99,7 @@ service with existing deployment — verify that a distribution pipeline exists.
    - "This PR adds a new binary/tool but there's no CI/CD pipeline to build and publish it.
      Users won't be able to download the artifact after merge."
    - A) Add a release workflow now (CI/CD release pipeline — GitHub Actions or GitLab CI depending on platform)
-   - B) Defer — add to TODOS.md
+   - B) Create Required Linear follow-up issue using `review/LINEAR-followups.md`
    - C) Not needed — this is internal/web-only, existing deployment covers it
 
 4. **If release pipeline exists:** Continue silently.
@@ -148,7 +147,7 @@ After both complete, read the output files and check pass/fail.
 
 {{TEST_FAILURE_TRIAGE}}
 
-**After triage:** If any in-branch failures remain unfixed, **STOP**. Do not proceed. If all failures were pre-existing and handled (fixed, TODOed, assigned, or skipped), continue to Step 3.25.
+**After triage:** If any in-branch failures remain unfixed, **STOP**. Do not proceed. If all failures were pre-existing and handled (fixed, assigned, or captured in Linear with issue IDs), continue to Step 3.25.
 
 **If all pass:** Continue silently — just note the counts briefly.
 
@@ -326,7 +325,7 @@ For each classified comment:
 - Deterministic parser/script failures -> focused test.
 - Repeated repo-policy mistake -> `.claude/rules/*` or `LESSONS.md`.
 - Repeated workflow mistake -> edit the gstack `.tmpl` source and regenerate generated skills.
-- High-risk product/auth/billing/migration work -> create or mention a Linear follow-up instead of broadening the ship PR.
+- High-risk product/auth/billing/migration work -> create a Linear follow-up issue instead of broadening the ship PR. Do not merely mention it.
 
 ---
 
@@ -369,58 +368,45 @@ If output shows `ALREADY_BUMPED`, VERSION was already bumped on this branch (pri
 
 ---
 
-## Step 5.5: TODOS.md (auto-update)
+## Step 5.5: Linear Follow-Up Issue Capture
 
-Cross-reference the project's TODOS.md against the changes being shipped. Mark completed items automatically; prompt only if the file is missing or disorganized.
+`TODOS.md` is legacy context only. Do not create, reorganize, or add new items to it.
+Use Linear for new follow-up work. Read `.claude/skills/gstack/review/LINEAR-followups.md`
+for the canonical issue format.
 
-Read `.claude/skills/review/TODOS-format.md` for the canonical format reference.
+**1. Gather follow-up candidates**
 
-**1. Check if TODOS.md exists** in the repository root.
+Collect every actionable item discovered during this workflow that will not be implemented
+in this PR, including:
+- NOT DONE plan items from Step 3.45.
+- Meaningful deferred work from review, QA, Greptile, design review, or verification.
+- Optional polish, future product work, pre-existing failures, and test gaps worth remembering.
+- Any final/PR-body sentence that would otherwise say "did not do X", "consider later",
+  "follow-up PR", "deferred", or "future work".
 
-**If TODOS.md does not exist:** Use AskUserQuestion:
-- Message: "GStack recommends maintaining a TODOS.md organized by skill/component, then priority (P0 at top through P4, then Completed at bottom). See TODOS-format.md for the full format. Would you like to create one?"
-- Options: A) Create it now, B) Skip for now
-- If A: Create `TODOS.md` with a skeleton (# TODOS heading + ## Completed section). Continue to step 3.
-- If B: Skip the rest of Step 5.5. Continue to Step 6.
+**2. Create Linear issues before closeout**
 
-**2. Check structure and organization:**
+For each actionable follow-up:
+- Create a Linear issue on the relevant team, usually `Jovie`.
+- Use the required structure from `review/LINEAR-followups.md`.
+- Classify as `Required` when the work is needed, or `Candidate` when another agent should
+  first decide whether it is worth doing.
+- Optional work must use the title `Candidate follow-up: <title>` and include:
+  "Pickup agent must first judge whether to implement, close, or split this."
+- If the follow-up depends on this PR or source issue landing first, set `blockedBy` when
+  possible. If not possible, describe the dependency in the issue body.
+- Do not add the `automated` label by default.
 
-Read TODOS.md and verify it follows the recommended structure:
-- Items grouped under `## <Skill/Component>` headings
-- Each item has `**Priority:**` field with P0-P4 value
-- A `## Completed` section at the bottom
+**3. Reference created issue IDs**
 
-**If disorganized** (missing priority fields, no component groupings, no Completed section): Use AskUserQuestion:
-- Message: "TODOS.md doesn't follow the recommended structure (skill/component groupings, P0-P4 priority, Completed section). Would you like to reorganize it?"
-- Options: A) Reorganize now (recommended), B) Leave as-is
-- If A: Reorganize in-place following TODOS-format.md. Preserve all content — only restructure, never delete items.
-- If B: Continue to step 3 without restructuring.
+Add every created follow-up issue ID to the PR body and final output. If no follow-up work
+exists, state `Linear follow-ups: none`.
 
-**3. Detect completed TODOs:**
+**4. Defensive**
 
-This step is fully automatic — no user interaction.
-
-Use the diff and commit history already gathered in earlier steps:
-- `git diff <base>...HEAD` (full diff against the base branch)
-- `git log <base>..HEAD --oneline` (all commits being shipped)
-
-For each TODO item, check if the changes in this PR complete it by:
-- Matching commit messages against the TODO title and description
-- Checking if files referenced in the TODO appear in the diff
-- Checking if the TODO's described work matches the functional changes
-
-**Be conservative:** Only mark a TODO as completed if there is clear evidence in the diff. If uncertain, leave it alone.
-
-**4. Move completed items** to the `## Completed` section at the bottom. Append: `**Completed:** vX.Y.Z (YYYY-MM-DD)`
-
-**5. Output summary:**
-- `TODOS.md: N items marked complete (item1, item2, ...). M items remaining.`
-- Or: `TODOS.md: No completed items detected. M items remaining.`
-- Or: `TODOS.md: Created.` / `TODOS.md: Reorganized.`
-
-**6. Defensive:** If TODOS.md cannot be written (permission error, disk full), warn the user and continue. Never stop the ship workflow for a TODOS failure.
-
-Save this summary — it goes into the PR body in Step 8.
+If Linear issue creation is unavailable or fails, warn the user and do not hide the follow-up
+inside a wall of text. Mark the ship result as blocked or done-with-concerns according to the
+Completion Status Protocol.
 
 ---
 
@@ -434,7 +420,7 @@ Save this summary — it goes into the PR body in Step 8.
    - **Infrastructure:** migrations, config changes, route additions
    - **Models & services:** new models, services, concerns (with their tests)
    - **Controllers & views:** controllers, views, JS/React components (with their tests)
-   - **VERSION + CHANGELOG + TODOS.md:** always in the final commit
+   - **VERSION + CHANGELOG + follow-up issue references:** always in the final commit
 
 3. **Rules for splitting:**
    - A model and its test file go in the same commit
@@ -561,16 +547,16 @@ you missed it.>
 <If no plan file: "No plan file detected.">
 <If plan items deferred: list deferred items>
 
+## Linear follow-ups
+<List each created Linear issue ID with a one-line rationale. If none: "Linear follow-ups: none.">
+
 ## Verification Results
 <If verification ran: summary from Step 3.47 (N PASS, M FAIL, K SKIPPED)>
 <If skipped: reason (no plan, no server, no verification section)>
 <If not applicable: omit this section>
 
-## TODOS
-<If items marked complete: bullet list of completed items with version>
-<If no items completed: "No TODO items completed in this PR.">
-<If TODOS.md created or reorganized: note that>
-<If TODOS.md doesn't exist and user skipped: omit this section>
+## TODOs (legacy)
+<If legacy TODO items were incidentally completed by this PR, list them. Never add new TODO items here. If none, omit this section.>
 
 ## Test plan
 - [x] All Rails tests pass (N runs, 0 failures)
@@ -660,7 +646,7 @@ This step is automatic — never skip it, never ask for confirmation.
 - **Always use the 4-digit version format** from the VERSION file.
 - **Date format in CHANGELOG:** `YYYY-MM-DD`
 - **Split commits for bisectability** — each commit = one logical change.
-- **TODOS.md completion detection must be conservative.** Only mark items as completed when the diff clearly shows the work is done.
+- **TODOS.md is legacy context only.** Never add new TODO items; create Linear issues for actionable follow-ups.
 - **Use Greptile reply templates from greptile-triage.md.** Every reply includes evidence (inline diff, code references, re-rank suggestion). Never post vague replies.
 - **Never push without fresh verification evidence.** If code changed after Step 3 tests, re-run before pushing.
 - **Step 3.4 generates coverage tests.** They must pass before committing. Never commit failing tests.

--- a/.agents/skills/gstack/test/audit-compliance.test.ts
+++ b/.agents/skills/gstack/test/audit-compliance.test.ts
@@ -35,14 +35,14 @@ describe('Audit compliance', () => {
   test('preamble telemetry calls are conditional on _TEL and binary existence', () => {
     const preamble = readFileSync(join(ROOT, 'scripts/resolvers/preamble.ts'), 'utf-8');
     // Pending finalization must check _TEL and binary existence
-    expect(preamble).toContain('_TEL" != "off"');
+    expect(preamble).toContain('if [ "\\${_TEL:-off}" != "off" ]; then');
     expect(preamble).toContain('-x ');
     expect(preamble).toContain('gstack-telemetry-log');
     // End-of-skill telemetry must also be conditional
     const completionIdx = preamble.indexOf('Telemetry (run last)');
     expect(completionIdx).toBeGreaterThan(-1);
     const completionSection = preamble.slice(completionIdx);
-    expect(completionSection).toContain('_TEL" != "off"');
+    expect(completionSection).toContain('if [ "\\${_TEL:-off}" != "off" ]; then');
   });
 
   // Round 2 Fix 1: W012 — Bun install uses checksum verification
@@ -108,7 +108,7 @@ describe('Audit compliance', () => {
     const skills = getAllSkillMds();
     for (const { name, content } of skills) {
       if (content.includes('gstack-telemetry-log')) {
-        expect(content).toContain('_TEL" != "off"');
+        expect(content).toContain('if [ "${_TEL:-off}" != "off" ]; then');
       }
     }
   });

--- a/.agents/skills/gstack/test/gen-skill-docs.test.ts
+++ b/.agents/skills/gstack/test/gen-skill-docs.test.ts
@@ -767,9 +767,9 @@ describe('TEST_FAILURE_TRIAGE resolver', () => {
     expect(shipSkill).toContain('collaborative');
   });
 
-  test('solo mode offers fix-now, TODO, and skip options', () => {
+  test('solo mode offers fix-now, Linear follow-up, and skip options', () => {
     expect(shipSkill).toContain('Investigate and fix now');
-    expect(shipSkill).toContain('Add as P0 TODO');
+    expect(shipSkill).toContain('Create required Linear follow-up');
     expect(shipSkill).toContain('Skip');
   });
 
@@ -838,7 +838,7 @@ describe('PLAN_COMPLETION_AUDIT placeholders', () => {
   test('ship mode has gate logic for NOT DONE items', () => {
     expect(shipSkill).toContain('NOT DONE');
     expect(shipSkill).toContain('Stop — implement the missing items');
-    expect(shipSkill).toContain('Ship anyway — defer');
+    expect(shipSkill).toContain('Ship anyway — create required Linear follow-up issues');
     expect(shipSkill).toContain('intentionally dropped');
   });
 
@@ -2032,6 +2032,7 @@ describe('setup script validation', () => {
     expect(fnBody).toContain('design-checklist.md');
     expect(fnBody).toContain('greptile-triage.md');
     expect(fnBody).toContain('TODOS-format.md');
+    expect(fnBody).toContain('LINEAR-followups.md');
     expect(fnBody).not.toContain('ln -snf "$gstack_dir" "$codex_gstack"');
   });
 

--- a/.agents/skills/gstack/test/relink.test.ts
+++ b/.agents/skills/gstack/test/relink.test.ts
@@ -6,6 +6,8 @@ import * as os from 'os';
 
 const ROOT = path.resolve(import.meta.dir, '..');
 const BIN = path.join(ROOT, 'bin');
+const TEST_TIMEOUT_MS = 15000;
+const COMMAND_TIMEOUT_MS = TEST_TIMEOUT_MS - 1000;
 
 let tmpDir: string;
 let skillsDir: string;
@@ -17,7 +19,7 @@ function run(cmd: string, env: Record<string, string> = {}, expectFail = false):
       cwd: ROOT,
       env: { ...process.env, GSTACK_STATE_DIR: tmpDir, ...env },
       encoding: 'utf-8',
-      timeout: 10000,
+      timeout: COMMAND_TIMEOUT_MS,
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
   } catch (e: any) {
@@ -81,7 +83,7 @@ describe('gstack-relink (#578)', () => {
     expect(fs.existsSync(path.join(skillsDir, 'gstack-ship'))).toBe(true);
     expect(fs.existsSync(path.join(skillsDir, 'gstack-review'))).toBe(true);
     expect(output).toContain('gstack-');
-  });
+  }, TEST_TIMEOUT_MS);
 
   // Test 12: flat symlinks when skill_prefix=false
   test('creates flat symlinks when skill_prefix=false', () => {
@@ -95,7 +97,7 @@ describe('gstack-relink (#578)', () => {
     expect(fs.existsSync(path.join(skillsDir, 'ship'))).toBe(true);
     expect(fs.existsSync(path.join(skillsDir, 'review'))).toBe(true);
     expect(output).toContain('flat');
-  });
+  }, TEST_TIMEOUT_MS);
 
   // Test 13: cleans stale symlinks from opposite mode
   test('cleans up stale symlinks from opposite mode', () => {
@@ -118,7 +120,7 @@ describe('gstack-relink (#578)', () => {
     // Flat symlinks should exist, prefixed should be gone
     expect(fs.existsSync(path.join(skillsDir, 'qa'))).toBe(true);
     expect(fs.existsSync(path.join(skillsDir, 'gstack-qa'))).toBe(false);
-  });
+  }, TEST_TIMEOUT_MS);
 
   // Test 14: error when install dir missing
   test('prints error when install dir missing', () => {
@@ -127,7 +129,7 @@ describe('gstack-relink (#578)', () => {
       GSTACK_SKILLS_DIR: '/nonexistent/path/skills',
     }, true);
     expect(output).toContain('setup');
-  });
+  }, TEST_TIMEOUT_MS);
 
   // Test: gstack-upgrade does NOT get double-prefixed
   test('does not double-prefix gstack-upgrade directory', () => {
@@ -142,7 +144,7 @@ describe('gstack-relink (#578)', () => {
     expect(fs.existsSync(path.join(skillsDir, 'gstack-gstack-upgrade'))).toBe(false);
     // Regular skills still get prefixed
     expect(fs.existsSync(path.join(skillsDir, 'gstack-qa'))).toBe(true);
-  });
+  }, TEST_TIMEOUT_MS);
 
   // Test 15: gstack-config set skill_prefix triggers relink
   test('gstack-config set skill_prefix triggers relink', () => {
@@ -155,7 +157,7 @@ describe('gstack-relink (#578)', () => {
     // If relink was triggered, symlinks should exist
     expect(fs.existsSync(path.join(skillsDir, 'gstack-qa'))).toBe(true);
     expect(fs.existsSync(path.join(skillsDir, 'gstack-ship'))).toBe(true);
-  });
+  }, TEST_TIMEOUT_MS);
 });
 
 describe('gstack-patch-names (#620/#578)', () => {
@@ -177,7 +179,7 @@ describe('gstack-patch-names (#620/#578)', () => {
     expect(readSkillName(path.join(installDir, 'qa'))).toBe('gstack-qa');
     expect(readSkillName(path.join(installDir, 'ship'))).toBe('gstack-ship');
     expect(readSkillName(path.join(installDir, 'review'))).toBe('gstack-review');
-  });
+  }, TEST_TIMEOUT_MS);
 
   test('prefix=false restores name: field in SKILL.md', () => {
     setupMockInstall(['qa', 'ship']);
@@ -197,7 +199,7 @@ describe('gstack-patch-names (#620/#578)', () => {
     // Verify name: field is restored to unprefixed
     expect(readSkillName(path.join(installDir, 'qa'))).toBe('qa');
     expect(readSkillName(path.join(installDir, 'ship'))).toBe('ship');
-  });
+  }, TEST_TIMEOUT_MS);
 
   test('gstack-upgrade name: not double-prefixed', () => {
     setupMockInstall(['qa', 'gstack-upgrade']);
@@ -210,7 +212,7 @@ describe('gstack-patch-names (#620/#578)', () => {
     expect(readSkillName(path.join(installDir, 'gstack-upgrade'))).toBe('gstack-upgrade');
     // Regular skill should be prefixed
     expect(readSkillName(path.join(installDir, 'qa'))).toBe('gstack-qa');
-  });
+  }, TEST_TIMEOUT_MS);
 
   test('SKILL.md without frontmatter is a no-op', () => {
     setupMockInstall(['qa']);
@@ -225,5 +227,5 @@ describe('gstack-patch-names (#620/#578)', () => {
     // Content should be unchanged (no name: to patch)
     const content = fs.readFileSync(path.join(installDir, 'qa', 'SKILL.md'), 'utf-8');
     expect(content).toBe('# qa\nSome content.');
-  });
+  }, TEST_TIMEOUT_MS);
 });

--- a/.agents/skills/gstack/test/skill-validation.test.ts
+++ b/.agents/skills/gstack/test/skill-validation.test.ts
@@ -516,26 +516,31 @@ describe('No hardcoded branch names in SKILL templates', () => {
   }
 });
 
-// --- Part 7b: TODOS-format.md reference consistency ---
+// --- Part 7b: Linear follow-up reference consistency ---
 
-describe('TODOS-format.md reference consistency', () => {
-  test('review/TODOS-format.md exists and defines canonical format', () => {
-    const content = fs.readFileSync(path.join(ROOT, 'review', 'TODOS-format.md'), 'utf-8');
-    expect(content).toContain('**What:**');
-    expect(content).toContain('**Why:**');
-    expect(content).toContain('**Priority:**');
-    expect(content).toContain('**Effort:**');
-    expect(content).toContain('## Completed');
+describe('LINEAR-followups.md reference consistency', () => {
+  test('review/LINEAR-followups.md exists and defines canonical format', () => {
+    const content = fs.readFileSync(path.join(ROOT, 'review', 'LINEAR-followups.md'), 'utf-8');
+    expect(content).toContain('## Source');
+    expect(content).toContain('## Follow-up');
+    expect(content).toContain('## Why it matters');
+    expect(content).toContain('## Classification');
+    expect(content).toContain('Candidate follow-up: <title>');
+    expect(content.toLowerCase()).toContain('issue id');
   });
 
-  test('skills that write TODOs reference TODOS-format.md', () => {
+  test('skills that create follow-ups reference LINEAR-followups.md', () => {
     const shipContent = fs.readFileSync(path.join(ROOT, 'ship', 'SKILL.md'), 'utf-8');
     const ceoPlanContent = fs.readFileSync(path.join(ROOT, 'plan-ceo-review', 'SKILL.md'), 'utf-8');
     const engPlanContent = fs.readFileSync(path.join(ROOT, 'plan-eng-review', 'SKILL.md'), 'utf-8');
+    const designPlanContent = fs.readFileSync(path.join(ROOT, 'plan-design-review', 'SKILL.md'), 'utf-8');
+    const reviewContent = fs.readFileSync(path.join(ROOT, 'review', 'SKILL.md'), 'utf-8');
 
-    expect(shipContent).toContain('TODOS-format.md');
-    expect(ceoPlanContent).toContain('TODOS-format.md');
-    expect(engPlanContent).toContain('TODOS-format.md');
+    expect(shipContent).toContain('LINEAR-followups.md');
+    expect(ceoPlanContent).toContain('LINEAR-followups.md');
+    expect(engPlanContent).toContain('LINEAR-followups.md');
+    expect(designPlanContent).toContain('LINEAR-followups.md');
+    expect(reviewContent).toContain('LINEAR-followups.md');
   });
 });
 
@@ -1539,7 +1544,7 @@ describe('Test failure triage in ship skill', () => {
     expect(content).toContain('solo');
     expect(content).toContain('collaborative');
     expect(content).toContain('Investigate and fix now');
-    expect(content).toContain('Add as P0 TODO');
+    expect(content).toContain('Create required Linear follow-up');
   });
 
   test('ship/SKILL.md triage has GitHub issue assignment for collaborative mode', () => {

--- a/.claude/rules/linear.md
+++ b/.claude/rules/linear.md
@@ -21,14 +21,47 @@ When scanning Linear for issues to work on, always filter with:
 - Process or workflow changes
 - Issues filed by automated scanners that haven't been triaged
 
-## Always File a Linear Issue for Deferred Follow-Ups
+## Durable Follow-Up Capture
 
-When you identify follow-up work in the course of a task — out-of-scope refactors, next-phase features, known gaps, TODOs — and **choose not to tackle it right away**, open a Linear issue for it before closing out the current work. Do not rely on inline `// TODO` comments, PR-body bullet lists, or chat memory to track it.
+Linear is the durable destination for every actionable follow-up an agent chooses not to implement, including optional or candidate work. Before closing out the current work, any final answer, PR body, plan, review, handoff, or status update that says "did not do X", "consider later", "follow-up PR", "deferred", "future work", "not in scope", or similar must include a created Linear issue ID.
 
-- Create the issue on the relevant team (usually `Jovie`) with a clear title and description of the deferred scope.
-- If the follow-up depends on the current work landing first, use `blockedBy` to link it to the current issue so the dependency is explicit in Linear.
-- Reference the follow-up issue ID in the current PR description and in any planning/design docs so future readers can navigate to it.
-- This applies equally to scope you deferred *to ship faster* (Approach C-style decisions) and scope you noticed but chose not to do. If it's worth remembering, it's worth a Linear issue.
+Do not leave follow-up work only in inline `// TODO` comments, `TODOS.md`, PR-body bullets, chat memory, review summaries, or "remaining risks" prose. If it is worth mentioning as future work, it is worth tracking in Linear.
+
+Create follow-up issues on the relevant team, usually `Jovie`. Do not add the `automated` label by default, so optional work stays visible without being blindly dispatched by automation.
+
+### Required follow-up issue shape
+
+Use this structure for every follow-up issue:
+
+```markdown
+## Source
+- Current issue: <JOV-XXXX or "ad-hoc">
+- Source PR: <PR URL or "not opened yet">
+- Source branch/session: <branch name or session context>
+
+## Follow-up
+<What was not done. Be specific enough that another agent can find the code or workflow.>
+
+## Why it matters
+<User impact, risk reduction, cleanup value, or product reason.>
+
+## Classification
+Required / Candidate
+
+## Acceptance criteria or triage question
+<Required work gets acceptance criteria. Candidate work gets the decision question.>
+
+## Dependency
+<Use blockedBy or note that this depends on the source issue/PR landing first. Otherwise "None".>
+```
+
+For optional work, title the issue `Candidate follow-up: <title>` and include this exact note in the description:
+
+> Pickup agent must first judge whether to implement, close, or split this.
+
+If the follow-up depends on the current work landing first, use `blockedBy` to link it to the current issue when possible. If no direct relationship can be created, include the dependency in the issue description and reference the follow-up issue ID in the current PR description and any planning/design docs.
+
+This applies equally to scope deferred to ship faster, scope noticed but intentionally skipped, pre-existing failures discovered during verification, test gaps, design debt, optional polish, and future product work.
 
 ## Linear Ownership Contract
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ These rules will block your changes if violated.
 
 - Skip any issue labeled `human-review-required` or whose description contains "This issue requires human review".
 - Mark issues `In Progress` before editing. `Done` is automated on merge. `In Review` is automated for orchestrator-dispatched PRs; set it manually only for ad-hoc PRs.
-- File a Linear issue for any deferred follow-up; don't rely on `// TODO` or PR-body bullets.
+- File a Linear issue for any actionable follow-up, including optional/candidate work. Final answers, PR bodies, plans, and reviews must not mention "did not do X", "consider later", "deferred", "future work", or "follow-up PR" unless they include the created Linear issue ID. Do not rely on `// TODO`, `TODOS.md`, PR bullets, or chat memory.
 
 Full contract: [`.claude/rules/linear.md`](.claude/rules/linear.md).
 

--- a/docs/AI_AUTOMATION.md
+++ b/docs/AI_AUTOMATION.md
@@ -25,7 +25,7 @@ This document explains the automation and labels used in this repo so agents can
 
 If an automated workflow opens a fix PR (e.g. Codex/CI healing):
 
-- Prefer incorporating the fix or making a follow-up PR.
+- Prefer incorporating the fix. If follow-up work remains, create a Linear issue for it before closing out the PR and reference the issue ID.
 - Do not repeatedly override it unless you are certain it is incorrect.
 
 ## AI automation labels
@@ -96,7 +96,7 @@ Durable hardening policy:
 - Prefer focused regression tests for deterministic parser/script failures.
 - Update gstack `.tmpl` files before regenerating derived `SKILL.md` files.
 - Update `LESSONS.md` only for repeated root causes, not every weekly finding.
-- Create or mention a Linear follow-up when the right fix requires product work, broad refactors, auth/billing/migration changes, or human prioritization.
+- Create a Linear follow-up issue when the right fix requires product work, broad refactors, auth/billing/migration changes, or human prioritization. Do not merely mention the follow-up in a PR comment or summary.
 - Never auto-merge, never create app/Vercel cron routes, and never touch high-risk paths without human review.
 
 ## CodeRabbit CLI (local)


### PR DESCRIPTION
## Summary
- Require created Linear issue IDs for any actionable follow-up an agent chooses not to implement, including optional/candidate work.
- Add the canonical gstack Linear follow-up issue template and route ship/review/planning/document-release flows away from new `TODOS.md` capture.
- Regenerate generated gstack `SKILL.md` files and update validation tests for the new Linear follow-up contract.

## Linear
- Source issue: ad-hoc request
- Linear follow-ups: none

## Validation
- `bun run gen:skill-docs`
- `rg -n "Add as P0 TODO|defer to TODO|defer to TODOS|deferred to TODOS|create or mention a Linear follow-up|Create or mention a Linear follow-up|TODOed|will create P1 TODOs|P1 TODO|P0 TODO" CLAUDE.md .claude/rules docs/AI_AUTOMATION.md .agents/skills/gstack --glob '*.md' --glob '*.tmpl' --glob '*.ts'` returned no matches
- `bun test test/gen-skill-docs.test.ts test/skill-validation.test.ts test/audit-compliance.test.ts test/relink.test.ts` passed: 677 pass, 0 fail
- `bun run skill:size-check`
- `bun test` in `.agents/skills/gstack` exited 0; captured log had no actual `(fail)` lines
- `pnpm run biome:check`
- `pnpm turbo typecheck --affected`
- `pnpm turbo lint --affected`
- `git diff --check`
- Pre-push hook passed: root Biome, web proxy guard, Tailwind guard, web typecheck, web lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced follow-up work tracking by introducing a standardized Linear issue template for all deferred items.
  * Updated internal workflows to create Linear issues for follow-up work instead of legacy documentation methods.
  * Added guidelines requiring that deferred work be tracked via created Linear issues with complete context (scope, rationale, acceptance criteria, and dependencies).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->