### PR TITLE
fix(ci): restore p0 synthetic monitoring coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,8 @@ jobs:
             ${{ runner.os }}-tsc-${{ github.ref }}-
             ${{ runner.os }}-tsc-
       - name: Run typecheck
+        env:
+          TURBO_SCM_BASE: ${{ github.event_name == 'merge_group' && 'origin/main' || (github.base_ref && format('origin/{0}', github.base_ref)) || '' }}
         run: pnpm turbo typecheck --affected
 
   neon-db:

--- a/.github/workflows/main-autofix.yml
+++ b/.github/workflows/main-autofix.yml
@@ -76,26 +76,30 @@ jobs:
           # workflow_dispatch with explicit run ID overrides evaluation (for smoke testing).
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ -n "$DISPATCH_RUN_ID" ]; then
             echo "Manual dispatch override: forcing autofix for run $DISPATCH_RUN_ID"
-            echo "needs_autofix=true" >> "$GITHUB_OUTPUT"
-            echo "failing_run_id=$DISPATCH_RUN_ID" >> "$GITHUB_OUTPUT"
-            # Rest of fields still come from evaluation (most recent failure context).
-            echo "failing_sha=$EVAL_FAILING_SHA" >> "$GITHUB_OUTPUT"
-            echo "failing_short_sha=$EVAL_FAILING_SHORT_SHA" >> "$GITHUB_OUTPUT"
-            echo "last_green_sha=$EVAL_LAST_GREEN_SHA" >> "$GITHUB_OUTPUT"
-            echo "failed_job_names=$EVAL_FAILED_JOB_NAMES" >> "$GITHUB_OUTPUT"
-            echo "systemic=false" >> "$GITHUB_OUTPUT"
-            echo "autofix_skip_reason=" >> "$GITHUB_OUTPUT"
+            {
+              echo "needs_autofix=true"
+              echo "failing_run_id=$DISPATCH_RUN_ID"
+              # Rest of fields still come from evaluation (most recent failure context).
+              echo "failing_sha=$EVAL_FAILING_SHA"
+              echo "failing_short_sha=$EVAL_FAILING_SHORT_SHA"
+              echo "last_green_sha=$EVAL_LAST_GREEN_SHA"
+              echo "failed_job_names=$EVAL_FAILED_JOB_NAMES"
+              echo "systemic=false"
+              echo "autofix_skip_reason="
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "needs_autofix=$EVAL_NEEDS_AUTOFIX" >> "$GITHUB_OUTPUT"
-          echo "failing_run_id=$EVAL_FAILING_RUN_ID" >> "$GITHUB_OUTPUT"
-          echo "failing_sha=$EVAL_FAILING_SHA" >> "$GITHUB_OUTPUT"
-          echo "failing_short_sha=$EVAL_FAILING_SHORT_SHA" >> "$GITHUB_OUTPUT"
-          echo "last_green_sha=$EVAL_LAST_GREEN_SHA" >> "$GITHUB_OUTPUT"
-          echo "failed_job_names=$EVAL_FAILED_JOB_NAMES" >> "$GITHUB_OUTPUT"
-          echo "systemic=$EVAL_SYSTEMIC" >> "$GITHUB_OUTPUT"
-          echo "autofix_skip_reason=$EVAL_SKIP_REASON" >> "$GITHUB_OUTPUT"
+          {
+            echo "needs_autofix=$EVAL_NEEDS_AUTOFIX"
+            echo "failing_run_id=$EVAL_FAILING_RUN_ID"
+            echo "failing_sha=$EVAL_FAILING_SHA"
+            echo "failing_short_sha=$EVAL_FAILING_SHORT_SHA"
+            echo "last_green_sha=$EVAL_LAST_GREEN_SHA"
+            echo "failed_job_names=$EVAL_FAILED_JOB_NAMES"
+            echo "systemic=$EVAL_SYSTEMIC"
+            echo "autofix_skip_reason=$EVAL_SKIP_REASON"
+          } >> "$GITHUB_OUTPUT"
 
           if [ "$EVAL_SYSTEMIC" = "true" ]; then
             echo "::warning::Systemic failure detected across multiple SHAs — autofix will NOT dispatch. Human triage required."
@@ -271,6 +275,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa # v1
         with:
+          allowed_bots: 'github-merge-queue[bot]'
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             Main branch CI is red. Your job is to diagnose and fix the root cause.

--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -59,9 +59,9 @@ jobs:
           E2E_SKIP_WEB_SERVER: '1'
           E2E_SYNTHETIC_MODE: 'true'
           E2E_ENVIRONMENT: production
-          PLAYWRIGHT_JSON_OUTPUT_NAME: test-results/results.json
+          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/synthetic-golden-path-results.json
         run: |
-          doppler run -- pnpm --filter=@jovie/web exec playwright test tests/e2e/synthetic-golden-path.spec.ts --project=chromium --reporter=line,json --output=test-results
+          doppler run -- pnpm --filter=@jovie/web exec playwright test tests/e2e/synthetic-golden-path.spec.ts --config=playwright.synthetic.config.ts --project=chromium-synthetic --output=test-results/synthetic-golden-path
         continue-on-error: true
 
       - name: Run Public Profile Smoke Test (JOV-1653)
@@ -72,9 +72,9 @@ jobs:
           E2E_SKIP_WEB_SERVER: '1'
           E2E_SYNTHETIC_MODE: 'true'
           E2E_ENVIRONMENT: production
-          PLAYWRIGHT_JSON_OUTPUT_NAME: test-results/public-profile-smoke-results.json
+          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/public-profile-smoke-results.json
         run: |
-          doppler run -- pnpm --filter=@jovie/web exec playwright test tests/e2e/public-profile-smoke.spec.ts --project=chromium --reporter=line,json --output=test-results
+          doppler run -- pnpm --filter=@jovie/web exec playwright test tests/e2e/public-profile-smoke.spec.ts --config=playwright.synthetic.config.ts --project=chromium-synthetic --output=test-results/public-profile-smoke
         continue-on-error: true
 
       - name: Upload Public Profile Smoke Screenshots
@@ -101,7 +101,16 @@ jobs:
           node <<'NODE'
           const fs = require('node:fs');
 
-          const resultsFile = 'apps/web/test-results/results.json';
+          const resultFiles = [
+            {
+              name: 'synthetic-golden-path',
+              path: 'apps/web/test-results/synthetic-golden-path-results.json',
+            },
+            {
+              name: 'public-profile-smoke',
+              path: 'apps/web/test-results/public-profile-smoke-results.json',
+            },
+          ];
           const outputFile = process.env.GITHUB_OUTPUT;
 
           function emit(line) {
@@ -118,28 +127,43 @@ jobs:
             emit('EOF');
           }
 
-          if (!fs.existsSync(resultsFile)) {
-            emit('test_status=error');
-            emitMultiline('failed_tests', ['Test results file not found']);
-            process.exit(0);
-          }
-
-          const results = JSON.parse(fs.readFileSync(resultsFile, 'utf8'));
           const specs = [];
+          const missingResults = [];
 
-          function collectSpecs(suites = []) {
+          function collectSpecs(suites = [], source) {
             for (const suite of suites) {
-              specs.push(...(suite.specs ?? []));
-              collectSpecs(suite.suites ?? []);
+              specs.push(
+                ...(suite.specs ?? []).map(spec => ({ source, spec }))
+              );
+              collectSpecs(suite.suites ?? [], source);
             }
           }
 
-          collectSpecs(results.suites ?? []);
+          for (const resultFile of resultFiles) {
+            if (!fs.existsSync(resultFile.path)) {
+              missingResults.push(
+                `${resultFile.name}: Test results file not found (${resultFile.path})`
+              );
+              continue;
+            }
 
-          const tests = specs.flatMap(spec =>
-            (spec.tests ?? []).map(testCase => ({ spec, testCase }))
+            try {
+              const results = JSON.parse(
+                fs.readFileSync(resultFile.path, 'utf8')
+              );
+              collectSpecs(results.suites ?? [], resultFile.name);
+            } catch (error) {
+              missingResults.push(
+                `${resultFile.name}: Failed to parse ${resultFile.path}: ${error.message}`
+              );
+            }
+          }
+
+          const tests = specs.flatMap(({ source, spec }) =>
+            (spec.tests ?? []).map(testCase => ({ source, spec, testCase }))
           );
           const skipped = tests.filter(({ testCase }) =>
+            testCase.status === 'skipped' ||
             (testCase.results ?? []).some(result => result.status === 'skipped')
           );
           const flaky = tests.filter(({ testCase }) => testCase.status === 'flaky');
@@ -158,14 +182,18 @@ jobs:
           emit(`skipped_tests=${skipped.length}`);
 
           const details = [
-            ...failed.map(({ spec }) => spec.title),
+            ...missingResults,
+            ...failed.map(({ source, spec }) => `${source}: ${spec.title}`),
             ...(skipped.length > 0
-              ? ['Skipped tests:', ...skipped.map(({ spec }) => spec.title)]
+              ? [
+                  'Skipped tests:',
+                  ...skipped.map(({ source, spec }) => `${source}: ${spec.title}`),
+                ]
               : []),
           ];
           emitMultiline('failed_tests', details);
 
-          if (tests.length === 0) {
+          if (missingResults.length > 0 || tests.length === 0) {
             emit('test_status=error');
           } else if (failed.length > 0 || skipped.length > 0) {
             emit('test_status=failed');

--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -59,8 +59,7 @@ jobs:
           E2E_SKIP_WEB_SERVER: '1'
           E2E_SYNTHETIC_MODE: 'true'
           E2E_ENVIRONMENT: production
-          # Overrides the synthetic Playwright config's default JSON output file.
-          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/synthetic-golden-path-results.json
+          SYNTHETIC_PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/synthetic-golden-path-results.json
         run: |
           doppler run -- pnpm --filter=@jovie/web exec playwright test tests/e2e/synthetic-golden-path.spec.ts --config=playwright.synthetic.config.ts --project=chromium-synthetic --output=test-results/synthetic-golden-path
         continue-on-error: true
@@ -73,8 +72,7 @@ jobs:
           E2E_SKIP_WEB_SERVER: '1'
           E2E_SYNTHETIC_MODE: 'true'
           E2E_ENVIRONMENT: production
-          # Overrides the synthetic Playwright config's default JSON output file.
-          PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/public-profile-smoke-results.json
+          SYNTHETIC_PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/public-profile-smoke-results.json
         run: |
           doppler run -- pnpm --filter=@jovie/web exec playwright test tests/e2e/public-profile-smoke.spec.ts --config=playwright.synthetic.config.ts --project=chromium-synthetic --output=test-results/public-profile-smoke
         continue-on-error: true
@@ -168,6 +166,14 @@ jobs:
             testCase.status === 'skipped' ||
             (testCase.results ?? []).some(result => result.status === 'skipped')
           );
+          const warnings = tests.flatMap(({ source, spec, testCase }) =>
+            (testCase.results ?? []).flatMap(result =>
+              [...(result.stdout ?? []), ...(result.stderr ?? [])]
+                .map(entry => entry.text ?? '')
+                .filter(text => text.includes('[Synthetic][warning]'))
+                .map(text => `${source}: ${spec.title}: ${text.trim()}`)
+            )
+          );
           const flaky = tests.filter(({ testCase }) => testCase.status === 'flaky');
           const failed = tests.filter(
             ({ testCase }) => testCase.status === 'unexpected'
@@ -182,6 +188,7 @@ jobs:
           emit(`passed_tests=${passed.length}`);
           emit(`flaky_tests=${flaky.length}`);
           emit(`skipped_tests=${skipped.length}`);
+          emit(`warning_count=${warnings.length}`);
 
           const details = [
             ...missingResults,
@@ -194,6 +201,10 @@ jobs:
               : []),
           ];
           emitMultiline('failed_tests', details);
+          emitMultiline('test_warnings', warnings);
+          for (const warning of warnings) {
+            console.log(`::warning::${warning}`);
+          }
 
           if (missingResults.length > 0 || tests.length === 0) {
             emit('test_status=error');
@@ -279,7 +290,7 @@ jobs:
                     },
                     {
                       "title": "Status",
-                      "value": "Configured production synthetic checks passing",
+                      "value": "Configured production synthetic checks passing (${{ steps.test-results.outputs.warning_count }} warnings)",
                       "short": false
                     },
                     {

--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   synthetic-test:
-    name: Golden Path Synthetic Test
+    name: Production Synthetic Tests
     runs-on: ubuntu-latest
     timeout-minutes: 12
 
@@ -59,6 +59,7 @@ jobs:
           E2E_SKIP_WEB_SERVER: '1'
           E2E_SYNTHETIC_MODE: 'true'
           E2E_ENVIRONMENT: production
+          # Overrides the synthetic Playwright config's default JSON output file.
           PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/synthetic-golden-path-results.json
         run: |
           doppler run -- pnpm --filter=@jovie/web exec playwright test tests/e2e/synthetic-golden-path.spec.ts --config=playwright.synthetic.config.ts --project=chromium-synthetic --output=test-results/synthetic-golden-path
@@ -72,6 +73,7 @@ jobs:
           E2E_SKIP_WEB_SERVER: '1'
           E2E_SYNTHETIC_MODE: 'true'
           E2E_ENVIRONMENT: production
+          # Overrides the synthetic Playwright config's default JSON output file.
           PLAYWRIGHT_JSON_OUTPUT_FILE: test-results/public-profile-smoke-results.json
         run: |
           doppler run -- pnpm --filter=@jovie/web exec playwright test tests/e2e/public-profile-smoke.spec.ts --config=playwright.synthetic.config.ts --project=chromium-synthetic --output=test-results/public-profile-smoke
@@ -229,7 +231,7 @@ jobs:
           author_name: 'Synthetic Monitoring'
           custom_payload: |
             {
-              "text": "🚨 Golden Path Test Failed - jov.ie",
+              "text": "Production Synthetic Monitoring Failed - jov.ie",
               "attachments": [
                 {
                   "color": "danger",
@@ -265,7 +267,7 @@ jobs:
           author_name: 'Synthetic Monitoring'
           custom_payload: |
             {
-              "text": "✅ Golden Path Health Check - jov.ie",
+              "text": "Production Synthetic Monitoring Passed - jov.ie",
               "attachments": [
                 {
                   "color": "good",
@@ -277,7 +279,7 @@ jobs:
                     },
                     {
                       "title": "Status",
-                      "value": "All critical user journeys passing",
+                      "value": "Configured production synthetic checks passing",
                       "short": false
                     },
                     {

--- a/apps/web/playwright.synthetic.config.ts
+++ b/apps/web/playwright.synthetic.config.ts
@@ -24,7 +24,14 @@ export default defineConfig({
   globalTimeout: 600_000, // 10 minutes total
 
   reporter: [
-    ['json', { outputFile: 'test-results/results.json' }],
+    [
+      'json',
+      {
+        outputFile:
+          process.env.SYNTHETIC_PLAYWRIGHT_JSON_OUTPUT_FILE ??
+          'test-results/results.json',
+      },
+    ],
     ['html', { outputFolder: 'playwright-report', open: 'never' }],
     ['line'],
   ],

--- a/apps/web/tests/e2e/public-profile-smoke.spec.ts
+++ b/apps/web/tests/e2e/public-profile-smoke.spec.ts
@@ -57,7 +57,7 @@ test('public profile renders core elements within budget', async ({ page }) => {
   const headingText = (await heading.textContent())?.trim() ?? '';
   expect(headingText.length, 'Artist display name is empty').toBeGreaterThan(0);
 
-  const releaseOrListenAffordance = page
+  const releaseOrListenAffordances = page
     .locator(
       [
         'a[aria-label^="View "]',
@@ -70,13 +70,13 @@ test('public profile renders core elements within budget', async ({ page }) => {
         'button:has-text("Apple Music")',
       ].join(', ')
     )
-    .first();
+    .filter({ visible: true });
   await expect(
-    releaseOrListenAffordance,
+    releaseOrListenAffordances.first(),
     'No release or listen affordance visible on public profile'
   ).toBeVisible({ timeout: 5_000 });
 
-  const actionAffordance = page
+  const actionAffordances = page
     .locator(
       [
         'a[href*="/tip"]',
@@ -92,9 +92,9 @@ test('public profile renders core elements within budget', async ({ page }) => {
         '[data-mode]',
       ].join(', ')
     )
-    .first();
+    .filter({ visible: true });
   await expect(
-    actionAffordance,
+    actionAffordances.first(),
     'No support/contact/listen-mode affordance visible on public profile'
   ).toBeVisible({ timeout: 5_000 });
 

--- a/apps/web/tests/e2e/public-profile-smoke.spec.ts
+++ b/apps/web/tests/e2e/public-profile-smoke.spec.ts
@@ -10,8 +10,8 @@ import { expect, test } from '@playwright/test';
  *  - 200 response (not 404, not redirect loop)
  *  - Page loads within LOAD_BUDGET_MS
  *  - Artist display name renders (h1 visible, non-empty)
- *  - At least one DSP link is visible (Spotify / Apple Music / etc.)
- *  - At least one action affordance (tip / contact / listen mode)
+ *  - At least one release/listen affordance is visible
+ *  - At least one action affordance (support / contact / listen mode)
  *  - Captures a screenshot as a test artifact
  *
  * Intentionally does NOT assert on CSS / design values (per JOV-1381 learnings).
@@ -31,7 +31,7 @@ const LOAD_BUDGET_MS = Number(process.env.SMOKE_LOAD_BUDGET_MS ?? '3000');
 test('public profile renders core elements within budget', async ({ page }) => {
   test.setTimeout(60_000);
 
-  // Listen mode surfaces DSP links; default mode often hides them behind a
+  // Listen mode surfaces music links; default mode often hides them behind a
   // tab selector. Fan flow lands here from outreach messages.
   const start = Date.now();
   const response = await page.goto(`/${PROFILE_HANDLE}?mode=listen`, {
@@ -57,9 +57,11 @@ test('public profile renders core elements within budget', async ({ page }) => {
   const headingText = (await heading.textContent())?.trim() ?? '';
   expect(headingText.length, 'Artist display name is empty').toBeGreaterThan(0);
 
-  const dspLink = page
+  const releaseOrListenAffordance = page
     .locator(
       [
+        'a[aria-label^="View "]',
+        '[data-testid="latest-release-card"]',
         'a[href*="spotify"]',
         'a[href*="apple"]',
         'a[href*="music"]',
@@ -69,9 +71,10 @@ test('public profile renders core elements within budget', async ({ page }) => {
       ].join(', ')
     )
     .first();
-  await expect(dspLink, 'No DSP link visible on public profile').toBeVisible({
-    timeout: 5_000,
-  });
+  await expect(
+    releaseOrListenAffordance,
+    'No release or listen affordance visible on public profile'
+  ).toBeVisible({ timeout: 5_000 });
 
   const actionAffordance = page
     .locator(
@@ -84,13 +87,15 @@ test('public profile renders core elements within budget', async ({ page }) => {
         'button:has-text("Follow")',
         'button:has-text("Subscribe")',
         'button:has-text("Listen")',
+        'button:has-text("Support")',
+        'button:has-text("Open support")',
         '[data-mode]',
       ].join(', ')
     )
     .first();
   await expect(
     actionAffordance,
-    'No tip/contact/listen-mode affordance visible on public profile'
+    'No support/contact/listen-mode affordance visible on public profile'
   ).toBeVisible({ timeout: 5_000 });
 
   await page.screenshot({

--- a/apps/web/tests/e2e/synthetic-golden-path.spec.ts
+++ b/apps/web/tests/e2e/synthetic-golden-path.spec.ts
@@ -6,6 +6,8 @@ test.use({ storageState: { cookies: [], origins: [] } });
 
 const HOMEPAGE_INTENT_PROMPT = 'Help me launch my artist profile';
 const SIGNUP_PATH = '/signup';
+const SIGNUP_COVERAGE_WARNING =
+  'Onboarding/profile creation not exercised while production email signup is unavailable. See JOV-1919.';
 
 async function isVisibleWithin(
   locator: Locator,
@@ -106,91 +108,94 @@ test.describe('Synthetic Monitoring - Golden Path', () => {
         console.log(
           '[Synthetic] Email sign-up unavailable; OAuth sign-up entry is visible'
         );
-        console.log(
-          '[Synthetic] Partial path only: onboarding/profile creation not exercised while production email signup is unavailable. See JOV-1919.'
-        );
-        return;
-      }
+        test.info().annotations.push({
+          type: 'synthetic-warning',
+          description: SIGNUP_COVERAGE_WARNING,
+        });
+        console.warn(`[Synthetic][warning] ${SIGNUP_COVERAGE_WARNING}`);
+      } else {
+        await emailInput.fill(testEmail);
 
-      await emailInput.fill(testEmail);
+        const passwordInput = page
+          .locator('input[name="password"], input[type="password"]')
+          .first();
+        await passwordInput.fill('SyntheticTest123!');
 
-      const passwordInput = page
-        .locator('input[name="password"], input[type="password"]')
-        .first();
-      await passwordInput.fill('SyntheticTest123!');
+        // Handle both test and production Clerk flows
+        const submitButton = page
+          .getByRole('button', { name: /continue|sign up/i })
+          .first();
+        await submitButton.click();
 
-      // Handle both test and production Clerk flows
-      const submitButton = page
-        .getByRole('button', { name: /continue|sign up/i })
-        .first();
-      await submitButton.click();
+        // Wait for navigation after submit instead of arbitrary timeout
+        await page.waitForLoadState('domcontentloaded');
 
-      // Wait for navigation after submit instead of arbitrary timeout
-      await page.waitForLoadState('domcontentloaded');
-
-      // Production environment might require email verification
-      // Skip verification if in test mode, otherwise handle production flow
-      if (process.env.E2E_ENVIRONMENT === 'production') {
-        // In production, we might need to handle verification differently
-        // This is a placeholder for production-specific verification handling
-        try {
-          const verifyButton = page.getByRole('button', {
-            name: /verify|continue/i,
-          });
-          if (await verifyButton.isVisible({ timeout: 5000 })) {
-            await verifyButton.click();
+        // Production environment might require email verification
+        // Skip verification if in test mode, otherwise handle production flow
+        if (process.env.E2E_ENVIRONMENT === 'production') {
+          // In production, we might need to handle verification differently
+          // This is a placeholder for production-specific verification handling
+          try {
+            const verifyButton = page.getByRole('button', {
+              name: /verify|continue/i,
+            });
+            if (await verifyButton.isVisible({ timeout: 5000 })) {
+              await verifyButton.click();
+            }
+          } catch {
+            console.log('[Synthetic] No verification step needed');
           }
-        } catch {
-          console.log('[Synthetic] No verification step needed');
         }
+
+        // CRITICAL PATH 4: Onboarding flow
+        console.log('[Synthetic] Step 4: Onboarding flow test');
+        await expect(page).toHaveURL('/onboarding', { timeout: 45000 });
+
+        const usernameInput = page.getByLabel('Claim your handle');
+        await expect(usernameInput).toBeVisible({ timeout: 15000 });
+
+        await usernameInput.fill(testHandle);
+        // Poll for validation to clear instead of arbitrary wait
+        await expect
+          .poll(
+            async () => {
+              const claimBtn = page.getByTestId('onboarding-handle-submit');
+              return claimBtn.isEnabled().catch(() => false);
+            },
+            { timeout: SMOKE_TIMEOUTS.VISIBILITY, intervals: [300, 500, 1000] }
+          )
+          .toBeTruthy();
+
+        const claimButton = page.getByTestId('onboarding-handle-submit');
+        await expect(claimButton).toBeEnabled({ timeout: 15000 });
+        await claimButton.click();
+
+        // CRITICAL PATH 5: Onboarding continuation
+        console.log('[Synthetic] Step 5: Onboarding continuation test');
+        await expect(page).toHaveURL(/\/onboarding.*resume=spotify/, {
+          timeout: 45000,
+        });
+
+        await expect(
+          page.getByPlaceholder(
+            /search by artist name or paste a spotify link/i
+          )
+        ).toBeVisible({ timeout: 15000 });
+
+        // CRITICAL PATH 6: Public profile accessibility
+        console.log('[Synthetic] Step 6: Public profile test');
+        await page.goto(`/${testHandle}`, {
+          waitUntil: 'commit',
+          timeout: SMOKE_TIMEOUTS.NAVIGATION,
+        });
+        await waitForHydration(page);
+
+        await expect(page).toHaveURL(`/${testHandle}`);
+        const publicProfile = page.locator('[data-test="public-profile-root"]');
+        await expect(publicProfile).toBeVisible({ timeout: 15000 });
+
+        console.log('[Synthetic] ✅ All critical paths verified successfully');
       }
-
-      // CRITICAL PATH 4: Onboarding flow
-      console.log('[Synthetic] Step 4: Onboarding flow test');
-      await expect(page).toHaveURL('/onboarding', { timeout: 45000 });
-
-      const usernameInput = page.getByLabel('Claim your handle');
-      await expect(usernameInput).toBeVisible({ timeout: 15000 });
-
-      await usernameInput.fill(testHandle);
-      // Poll for validation to clear instead of arbitrary wait
-      await expect
-        .poll(
-          async () => {
-            const claimBtn = page.getByTestId('onboarding-handle-submit');
-            return claimBtn.isEnabled().catch(() => false);
-          },
-          { timeout: SMOKE_TIMEOUTS.VISIBILITY, intervals: [300, 500, 1000] }
-        )
-        .toBeTruthy();
-
-      const claimButton = page.getByTestId('onboarding-handle-submit');
-      await expect(claimButton).toBeEnabled({ timeout: 15000 });
-      await claimButton.click();
-
-      // CRITICAL PATH 5: Onboarding continuation
-      console.log('[Synthetic] Step 5: Onboarding continuation test');
-      await expect(page).toHaveURL(/\/onboarding.*resume=spotify/, {
-        timeout: 45000,
-      });
-
-      await expect(
-        page.getByPlaceholder(/search by artist name or paste a spotify link/i)
-      ).toBeVisible({ timeout: 15000 });
-
-      // CRITICAL PATH 6: Public profile accessibility
-      console.log('[Synthetic] Step 6: Public profile test');
-      await page.goto(`/${testHandle}`, {
-        waitUntil: 'commit',
-        timeout: SMOKE_TIMEOUTS.NAVIGATION,
-      });
-      await waitForHydration(page);
-
-      await expect(page).toHaveURL(`/${testHandle}`);
-      const publicProfile = page.locator('[data-test="public-profile-root"]');
-      await expect(publicProfile).toBeVisible({ timeout: 15000 });
-
-      console.log('[Synthetic] ✅ All critical paths verified successfully');
     } catch (error) {
       console.error('[Synthetic] ❌ Critical path failure:', error);
 

--- a/apps/web/tests/e2e/synthetic-golden-path.spec.ts
+++ b/apps/web/tests/e2e/synthetic-golden-path.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Locator, test } from '@playwright/test';
 import { SMOKE_TIMEOUTS, waitForHydration } from './utils/smoke-test-utils';
 
 // Override global storageState to run these tests as unauthenticated
@@ -6,6 +6,16 @@ test.use({ storageState: { cookies: [], origins: [] } });
 
 const HOMEPAGE_INTENT_PROMPT = 'Help me launch my artist profile';
 const SIGNUP_PATH = '/signup';
+
+async function isVisibleWithin(
+  locator: Locator,
+  timeout: number
+): Promise<boolean> {
+  return locator
+    .waitFor({ state: 'visible', timeout })
+    .then(() => true)
+    .catch(() => false);
+}
 
 /**
  * Synthetic Monitoring Golden Path Test
@@ -72,12 +82,27 @@ test.describe('Synthetic Monitoring - Golden Path', () => {
         timeout: 20000,
       });
 
-      // CRITICAL PATH 3: Clerk registration
-      console.log('[Synthetic] Step 3: Clerk registration test');
+      // CRITICAL PATH 3: Clerk sign-up entry
+      console.log('[Synthetic] Step 3: Clerk sign-up entry test');
       const emailInput = page
         .locator('input[name="emailAddress"], input[type="email"]')
         .first();
-      await emailInput.waitFor({ state: 'visible', timeout: 15000 });
+      const hasEmailSignup = await isVisibleWithin(emailInput, 15000);
+
+      if (!hasEmailSignup) {
+        const oauthSignupButton = page
+          .locator('button:has-text("Apple"), button:has-text("Google")')
+          .first();
+        await expect(
+          oauthSignupButton,
+          'Production sign-up should expose at least one supported OAuth option'
+        ).toBeVisible({ timeout: 5000 });
+        console.log(
+          '[Synthetic] Email sign-up unavailable; OAuth sign-up entry is visible'
+        );
+        return;
+      }
+
       await emailInput.fill(testEmail);
 
       const passwordInput = page

--- a/apps/web/tests/e2e/synthetic-golden-path.spec.ts
+++ b/apps/web/tests/e2e/synthetic-golden-path.spec.ts
@@ -11,10 +11,16 @@ async function isVisibleWithin(
   locator: Locator,
   timeout: number
 ): Promise<boolean> {
-  return locator
-    .waitFor({ state: 'visible', timeout })
-    .then(() => true)
-    .catch(() => false);
+  try {
+    await locator.waitFor({ state: 'visible', timeout });
+    return true;
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('Timeout')) {
+      return false;
+    }
+
+    throw error;
+  }
 }
 
 /**
@@ -99,6 +105,9 @@ test.describe('Synthetic Monitoring - Golden Path', () => {
         ).toBeVisible({ timeout: 5000 });
         console.log(
           '[Synthetic] Email sign-up unavailable; OAuth sign-up entry is visible'
+        );
+        console.log(
+          '[Synthetic] Partial path only: onboarding/profile creation not exercised while production email signup is unavailable. See JOV-1919.'
         );
         return;
       }


### PR DESCRIPTION
## Summary

- Allow Main Autofix to run when `github-merge-queue[bot]` triggers the red-main monitor.
- Run production synthetic jobs through `playwright.synthetic.config.ts` / `chromium-synthetic`, preserving separate JSON result files for golden-path and public-profile parsing through a synthetic-owned output env var.
- Align synthetic assertions with current production behavior: OAuth signup entry is valid when email signup is unavailable, public-profile smoke accepts visible release/listen links plus support actions, and degraded signup coverage is surfaced as an explicit workflow warning.
- Set the CI typecheck job's Turbo affected base so PR typecheck does not fall back to every package when the bare `main` ref is unavailable.

## Verification

- `./scripts/setup.sh`
- `pnpm exec actionlint .github/workflows/main-autofix.yml .github/workflows/synthetic-monitoring.yml`
- `pnpm exec actionlint .github/workflows/synthetic-monitoring.yml`
- `git diff --check`
- `pnpm biome check apps/web/tests/e2e/synthetic-golden-path.spec.ts apps/web/tests/e2e/public-profile-smoke.spec.ts`
- `pnpm biome check apps/web/tests/e2e/synthetic-golden-path.spec.ts apps/web/playwright.synthetic.config.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Production synthetic golden path with `playwright.synthetic.config.ts` / `chromium-synthetic`: 3 passed
- Production public profile smoke with `playwright.synthetic.config.ts` / `chromium-synthetic`: 1 passed
- Synthetic parser smoke: `test_status=passed`, 4/4 tests passed, 1 explicit warning for JOV-1919 signup coverage
- Pre-push hook: full Biome check, proxy guard, Tailwind guard, web typecheck, web lint

## Risk

Production Clerk currently exposes OAuth signup only. JOV-1919 tracks the P0 monitoring restoration and signup-path decision; this patch monitors the supported signup entry and emits a warning for the known onboarding/profile-creation coverage gap instead of silently reporting a fully clean synthetic run.
