### PR TITLE
feat(agentos): add run artifact schema

### DIFF
--- a/apps/web/lib/agent-os/artifact.ts
+++ b/apps/web/lib/agent-os/artifact.ts
@@ -1,0 +1,224 @@
+import { z } from 'zod';
+
+export const AGENT_RUN_SOURCES = [
+  'github',
+  'linear',
+  'sentry',
+  'hermes',
+  'ci',
+  'ruflo',
+  'vercel-workflow',
+] as const;
+
+export const AGENT_RUN_KINDS = [
+  'qa',
+  'design_review',
+  'code_review',
+  'triage',
+  'gtm',
+  'yc',
+  'cost',
+  'deploy_readiness',
+  'workflow',
+] as const;
+
+export const AGENT_RUN_STATUSES = [
+  'queued',
+  'running',
+  'blocked',
+  'review',
+  'done',
+  'failed',
+  'stale',
+] as const;
+
+export const AGENT_RUN_MODEL_ROUTES = [
+  'deterministic',
+  'openrouter-free',
+  'ai-sdk-gateway',
+  'claude-code',
+  'codex-cli',
+] as const;
+
+export const AGENT_RUN_ACTIONS = [
+  'read',
+  'classify',
+  'rank',
+  'summarize',
+  'draft',
+  'dispatch_agent',
+  'write_code',
+  'open_pr',
+  'ready_pr',
+  'merge',
+  'deploy',
+  'mutate_linear',
+  'send_outbound',
+  'mutate_production_data',
+  'change_auth',
+  'change_billing',
+  'change_security',
+] as const;
+
+export const AGENT_RUN_GATE_EVIDENCE_NAMES = [
+  'gstack.qa.exhaustive',
+  'gstack.review',
+  'gstack.ship',
+  'github.ci',
+  'github.scope-judge',
+  'github.coderabbit',
+  'github.greptile',
+  'github.branch-protection',
+  'gstack.land-and-deploy',
+  'sentry.canary',
+] as const;
+
+const nullableUrlSchema = z.union([z.string().trim().url(), z.null()]);
+const nullableTextSchema = z.union([z.string().trim().min(1), z.null()]);
+const isoDateTimeSchema = z.string().datetime();
+
+export const AgentRunSourceSchema = z.enum(AGENT_RUN_SOURCES);
+export const AgentRunKindSchema = z.enum(AGENT_RUN_KINDS);
+export const AgentRunStatusSchema = z.enum(AGENT_RUN_STATUSES);
+export const AgentRunModelRouteSchema = z.enum(AGENT_RUN_MODEL_ROUTES);
+export const AgentRunActionSchema = z.enum(AGENT_RUN_ACTIONS);
+export const AgentRunGateEvidenceNameSchema = z.enum(
+  AGENT_RUN_GATE_EVIDENCE_NAMES
+);
+
+export const HumanGateStatusSchema = z.enum([
+  'not_required',
+  'pending',
+  'approved',
+  'rejected',
+]);
+
+export const VerificationGateStatusSchema = z.enum([
+  'missing',
+  'queued',
+  'running',
+  'passed',
+  'failed',
+  'skipped',
+  'blocked',
+]);
+
+export const HumanGateSchema = z
+  .object({
+    required: z.boolean(),
+    status: HumanGateStatusSchema,
+    reason: nullableTextSchema,
+    reviewer: nullableTextSchema,
+    reviewedAt: z.union([isoDateTimeSchema, z.null()]),
+  })
+  .strict()
+  .superRefine((gate, context) => {
+    if (gate.required && gate.status === 'not_required') {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Required human gates cannot use not_required status.',
+        path: ['status'],
+      });
+    }
+
+    if (!gate.required && gate.status !== 'not_required') {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Optional human gates must use not_required status.',
+        path: ['status'],
+      });
+    }
+  });
+
+export const VerificationGateSchema = z
+  .object({
+    name: AgentRunGateEvidenceNameSchema,
+    required: z.boolean(),
+    status: VerificationGateStatusSchema,
+    evidenceUrl: nullableUrlSchema,
+    summary: nullableTextSchema,
+    checkedAt: z.union([isoDateTimeSchema, z.null()]),
+  })
+  .strict();
+
+export const CostEstimateSchema = z
+  .object({
+    usd: z.number().min(0),
+    route: AgentRunModelRouteSchema,
+    inputTokens: z.number().int().min(0).nullable(),
+    outputTokens: z.number().int().min(0).nullable(),
+    notes: nullableTextSchema,
+  })
+  .strict();
+
+export const AgentRunArtifactSchema = z
+  .object({
+    id: z.string().trim().min(1).max(180),
+    source: AgentRunSourceSchema,
+    sourceRunId: nullableTextSchema,
+    kind: AgentRunKindSchema,
+    status: AgentRunStatusSchema,
+    title: z.string().trim().min(1).max(180),
+    summary: z.string().trim().min(1).max(1200),
+    modelRoute: AgentRunModelRouteSchema,
+    allowedActions: z.array(AgentRunActionSchema).max(40),
+    forbiddenActions: z.array(AgentRunActionSchema).max(40),
+    humanApprovalRequired: z.boolean(),
+    humanGate: HumanGateSchema,
+    linearIssueId: nullableTextSchema,
+    linearIssueUrl: nullableUrlSchema,
+    pullRequestUrl: nullableUrlSchema,
+    adminSurface: z.union([
+      z.string().trim().startsWith('/').max(160),
+      z.null(),
+    ]),
+    verificationGates: z.array(VerificationGateSchema).max(32),
+    costEstimate: z.union([CostEstimateSchema, z.null()]),
+    blockedReason: nullableTextSchema,
+    createdAt: isoDateTimeSchema,
+    updatedAt: isoDateTimeSchema,
+    metadata: z.record(z.string(), z.unknown()),
+  })
+  .strict()
+  .superRefine((artifact, context) => {
+    if (artifact.humanApprovalRequired !== artifact.humanGate.required) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'humanApprovalRequired must match humanGate.required.',
+        path: ['humanApprovalRequired'],
+      });
+    }
+
+    if (artifact.status === 'blocked' && artifact.blockedReason === null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Blocked runs must include blockedReason.',
+        path: ['blockedReason'],
+      });
+    }
+  });
+
+export type AgentRunSource = z.infer<typeof AgentRunSourceSchema>;
+export type AgentRunKind = z.infer<typeof AgentRunKindSchema>;
+export type AgentRunStatus = z.infer<typeof AgentRunStatusSchema>;
+export type AgentRunModelRoute = z.infer<typeof AgentRunModelRouteSchema>;
+export type AgentRunAction = z.infer<typeof AgentRunActionSchema>;
+export type AgentRunGateEvidenceName = z.infer<
+  typeof AgentRunGateEvidenceNameSchema
+>;
+export type HumanGateStatus = z.infer<typeof HumanGateStatusSchema>;
+export type VerificationGateStatus = z.infer<
+  typeof VerificationGateStatusSchema
+>;
+export type HumanGate = z.infer<typeof HumanGateSchema>;
+export type VerificationGate = z.infer<typeof VerificationGateSchema>;
+export type CostEstimate = z.infer<typeof CostEstimateSchema>;
+export type AgentRunArtifact = z.infer<typeof AgentRunArtifactSchema>;
+
+export function parseAgentRunArtifact(input: unknown): AgentRunArtifact {
+  return AgentRunArtifactSchema.parse(input);
+}
+
+export function safeParseAgentRunArtifact(input: unknown) {
+  return AgentRunArtifactSchema.safeParse(input);
+}

--- a/apps/web/tests/unit/agent-os/artifact.test.ts
+++ b/apps/web/tests/unit/agent-os/artifact.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_RUN_GATE_EVIDENCE_NAMES,
+  type AgentRunArtifact,
+  AgentRunArtifactSchema,
+  parseAgentRunArtifact,
+  safeParseAgentRunArtifact,
+} from '@/lib/agent-os/artifact';
+
+const baseArtifact: AgentRunArtifact = {
+  id: 'agent-run-001',
+  source: 'vercel-workflow',
+  sourceRunId: 'workflow-run-001',
+  kind: 'workflow',
+  status: 'running',
+  title: 'Free model health dry run',
+  summary: 'Harmless dry run proving AgentOS artifact emission.',
+  modelRoute: 'deterministic',
+  allowedActions: ['read', 'summarize'],
+  forbiddenActions: ['merge', 'deploy', 'mutate_linear', 'write_code'],
+  humanApprovalRequired: false,
+  humanGate: {
+    required: false,
+    status: 'not_required',
+    reason: null,
+    reviewer: null,
+    reviewedAt: null,
+  },
+  linearIssueId: 'JOV-1923',
+  linearIssueUrl:
+    'https://linear.app/jovie/issue/JOV-1923/agentos-shared-agentrunartifact-schema',
+  pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8192',
+  adminSurface: '/app/admin/ops',
+  verificationGates: [
+    {
+      name: 'gstack.qa.exhaustive',
+      required: true,
+      status: 'queued',
+      evidenceUrl: null,
+      summary: 'QA gate has not started yet.',
+      checkedAt: null,
+    },
+    {
+      name: 'github.ci',
+      required: true,
+      status: 'running',
+      evidenceUrl: 'https://github.com/JovieInc/Jovie/actions/runs/123',
+      summary: 'GitHub CI is running.',
+      checkedAt: '2026-05-08T03:35:00.000Z',
+    },
+  ],
+  costEstimate: {
+    usd: 0,
+    route: 'deterministic',
+    inputTokens: null,
+    outputTokens: null,
+    notes: 'No model call in dry run.',
+  },
+  blockedReason: null,
+  createdAt: '2026-05-08T03:30:00.000Z',
+  updatedAt: '2026-05-08T03:35:00.000Z',
+  metadata: {
+    dryRun: true,
+  },
+};
+
+describe('AgentRunArtifactSchema', () => {
+  it('parses the canonical Vercel Workflow dry-run artifact shape', () => {
+    const artifact = parseAgentRunArtifact(baseArtifact);
+
+    expect(artifact.source).toBe('vercel-workflow');
+    expect(artifact.modelRoute).toBe('deterministic');
+    expect(artifact.verificationGates.map(gate => gate.name)).toEqual([
+      'gstack.qa.exhaustive',
+      'github.ci',
+    ]);
+  });
+
+  it('keeps gate evidence names explicit and stable', () => {
+    expect(AGENT_RUN_GATE_EVIDENCE_NAMES).toEqual([
+      'gstack.qa.exhaustive',
+      'gstack.review',
+      'gstack.ship',
+      'github.ci',
+      'github.scope-judge',
+      'github.coderabbit',
+      'github.greptile',
+      'github.branch-protection',
+      'gstack.land-and-deploy',
+      'sentry.canary',
+    ]);
+  });
+
+  it('rejects blocked runs without a blocked reason', () => {
+    const result = safeParseAgentRunArtifact({
+      ...baseArtifact,
+      status: 'blocked',
+      blockedReason: null,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['blockedReason']);
+  });
+
+  it('rejects human-gate mismatches', () => {
+    const result = AgentRunArtifactSchema.safeParse({
+      ...baseArtifact,
+      humanApprovalRequired: true,
+      humanGate: {
+        ...baseArtifact.humanGate,
+        required: false,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.path).toEqual(['humanApprovalRequired']);
+  });
+
+  it('accepts read-only OpenRouter free-model artifacts with forbidden mutations', () => {
+    const artifact = parseAgentRunArtifact({
+      ...baseArtifact,
+      id: 'agent-run-002',
+      source: 'hermes',
+      kind: 'triage',
+      status: 'done',
+      modelRoute: 'openrouter-free',
+      allowedActions: ['read', 'classify', 'rank', 'summarize', 'draft'],
+      forbiddenActions: [
+        'write_code',
+        'send_outbound',
+        'deploy',
+        'merge',
+        'change_auth',
+        'change_billing',
+        'change_security',
+        'mutate_production_data',
+      ],
+      costEstimate: {
+        usd: 0,
+        route: 'openrouter-free',
+        inputTokens: 1200,
+        outputTokens: 250,
+        notes: 'Free-model route.',
+      },
+      updatedAt: '2026-05-08T03:40:00.000Z',
+    });
+
+    expect(artifact.forbiddenActions).toContain('write_code');
+    expect(artifact.costEstimate?.route).toBe('openrouter-free');
+  });
+});


### PR DESCRIPTION
## Summary
- Add the canonical AgentOS AgentRunArtifact Zod schema and inferred TypeScript types.
- Encode sources, kinds, statuses, model routes, allowed/forbidden actions, human gates, Linear/PR/admin links, verification gate evidence, cost estimates, and blocked reasons.
- Add focused unit tests for Vercel Workflow dry-run artifacts, GStack gate evidence names, blocked-run validation, human-gate consistency, and read-only OpenRouter routes.

Closes JOV-1923

## Verification
- pnpm biome check apps/web/lib/agent-os/artifact.ts apps/web/tests/unit/agent-os/artifact.test.ts
- pnpm --filter @jovie/web exec vitest run tests/unit/agent-os/artifact.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- commit hook: next proxy guard, Biome/write, ESLint, web typecheck
- pre-push hook: biome check ., next proxy guard, tailwind guard, @jovie/web typecheck, @jovie/web lint

## Gate Evidence
- gstack.qa.exhaustive: pending
- gstack.review: pending
- gstack.ship: pending
- github.ci: pending PR checks