### PR TITLE
fix(desktop): generate env before typecheck

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -10,6 +10,7 @@
     "build:staging": "tsc && electron-builder --config electron-builder.staging.yml --publish always",
     "prebuild:production": "cross-env ELECTRON_ENV=production node scripts/write-env.mjs",
     "build:production": "tsc && electron-builder --config electron-builder.yml --publish always",
+    "pretypecheck": "node scripts/write-env.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Run the existing desktop env generator before desktop typecheck.
- Keep src/env.generated.ts ignored and uncommitted.
- Fixes the current 
   • Packages in scope: //, @jovie/desktop, @jovie/docs, @jovie/extension, @jovie/extension-contracts, @jovie/should-i-make, @jovie/ui, @jovie/web
   • Running typecheck in 8 packages
   • Remote caching disabled, using shared worktree cache

@jovie/docs:typecheck: cache hit, replaying logs 4469619e31e97905
@jovie/should-i-make:typecheck: cache hit, replaying logs b90880c404a110d0
@jovie/docs:typecheck: 
@jovie/docs:typecheck: > @jovie/docs@26.4.179 typecheck /Users/timwhite/.codex/worktrees/7e78/jovie-v1/apps/docs
@jovie/docs:typecheck: > tsc --noEmit
@jovie/docs:typecheck: 
@jovie/should-i-make:typecheck: 
@jovie/should-i-make:typecheck: > @jovie/should-i-make@26.4.179 typecheck /Users/timwhite/.codex/worktrees/7e78/jovie-v1/apps/should-i-make
@jovie/should-i-make:typecheck: > tsc --noEmit
@jovie/should-i-make:typecheck: 
@jovie/desktop:typecheck: cache hit, replaying logs fd811b8a3072bb6a
@jovie/desktop:typecheck: 
@jovie/desktop:typecheck: > @jovie/desktop@0.1.0 pretypecheck /Users/timwhite/.codex/worktrees/9d5d/jovie-v1/apps/desktop
@jovie/desktop:typecheck: > node scripts/write-env.mjs
@jovie/desktop:typecheck: 
@jovie/desktop:typecheck: [write-env] Wrote APP_ENV='production' to src/env.generated.ts
@jovie/desktop:typecheck: 
@jovie/desktop:typecheck: > @jovie/desktop@0.1.0 typecheck /Users/timwhite/.codex/worktrees/9d5d/jovie-v1/apps/desktop
@jovie/desktop:typecheck: > tsc --noEmit
@jovie/desktop:typecheck: 
@jovie/extension-contracts:typecheck: cache hit, replaying logs 2aa54df37e5386fa
@jovie/extension:typecheck: cache hit, replaying logs b67aa0db75c09fc7
@jovie/extension-contracts:typecheck: 
@jovie/extension-contracts:typecheck: > @jovie/extension-contracts@26.4.179 typecheck /Users/timwhite/.codex/worktrees/7e78/jovie-v1/packages/extension-contracts
@jovie/extension-contracts:typecheck: > tsc --noEmit
@jovie/extension-contracts:typecheck: 
@jovie/extension:typecheck: 
@jovie/extension:typecheck: > @jovie/extension@26.4.179 typecheck /Users/timwhite/.codex/worktrees/7e78/jovie-v1/apps/extension
@jovie/extension:typecheck: > tsc -p tsconfig.json --noEmit
@jovie/extension:typecheck: 
@jovie/ui:typecheck: cache hit, replaying logs d112828f2ef10500
@jovie/ui:typecheck: 
@jovie/ui:typecheck: > @jovie/ui@26.4.179 typecheck /home/runner/work/Jovie/Jovie/packages/ui
@jovie/ui:typecheck: > tsc --noEmit
@jovie/ui:typecheck: 
@jovie/web:typecheck: cache hit, replaying logs 169a27f9622012a7
@jovie/web:typecheck: 
@jovie/web:typecheck: > @jovie/web@26.4.185 typecheck /Users/timwhite/.codex/worktrees/9d5d/jovie-v1/apps/web
@jovie/web:typecheck: > node ../../scripts/typecheck-singleflight.mjs -- tsc -p tsconfig.typecheck.json --noEmit --incremental --tsBuildInfoFile .cache/tsbuildinfo
@jovie/web:typecheck: 

 Tasks:    7 successful, 7 total
Cached:    7 cached, 7 total
  Time:    685ms >>> FULL TURBO CI failure on fresh checkouts.

Closes JOV-1925

## Verification
- pnpm --filter @jovie/desktop run typecheck
- pnpm turbo typecheck --affected
- pnpm biome check apps/desktop/package.json
- git diff --check
- pre-push hook: biome check ., next proxy guard, tailwind guard, @jovie/web typecheck, @jovie/web lint

## Gate Evidence
- gstack.qa.exhaustive: command-level regression only, no browser surface touched
- gstack.review: pending
- gstack.ship: pending
- github.ci: pending PR checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced desktop app build pipeline to ensure proper environment configuration before type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->