### PR TITLE
fix(ds): correct profile token migration color/class regressions

### DIFF
--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx
@@ -504,7 +504,7 @@ export function ProfileMobileNotificationsFlow({
           footer={
             <div className='space-y-3'>
               {error ? (
-                <p className='text-sm text-error' role='alert'>
+                <p className='text-sm text-[#ff8b8b]' role='alert'>
                   {error}
                 </p>
               ) : null}
@@ -543,7 +543,7 @@ export function ProfileMobileNotificationsFlow({
           footer={
             <div className='space-y-3'>
               {error ? (
-                <p className='text-sm text-error' role='alert'>
+                <p className='text-sm text-[#ff8b8b]' role='alert'>
                   {error}
                 </p>
               ) : null}

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -671,8 +671,7 @@ export function ProfileCompactTemplate({
     <ProfileNotificationsContext.Provider value={notificationsContextValue}>
       <div
         className={cn(
-          'profile-viewport relative h-[100dvh] overflow-hidden bg-[color:var(--profile-stage-bg)] text-primary-token',
-          isV1 && 'bg-[color:var(--profile-stage-bg)]'
+          'profile-viewport relative h-[100dvh] overflow-hidden bg-[color:var(--profile-stage-bg)] text-primary-token'
         )}
         style={profileAccentStyle}
         data-profile-visual-variant={visualVariant}


### PR DESCRIPTION
## Summary

Follow-up to #8155 — addresses two Greptile P1/P2 issues flagged after merge:

- **Revert `text-error` → `text-[#ff8b8b]`** in `ProfileMobileNotificationsFlow`: `text-error` resolves to `#ff4d5f` (darker, more saturated red) — not a like-for-like swap for the soft pink `#ff8b8b` used for error messages on dark profile overlays
- **Remove duplicate `isV1` conditional** in `ProfileCompactTemplate`: `isV1 && 'bg-[color:var(--profile-stage-bg)]'` was identical to the base class after the migration, making it a silent no-op; removed the redundant branch

## Test plan

- [x] `pnpm biome check --write apps/web/components/features/profile` — no fixes applied
- [x] `pnpm --filter @jovie/web run typecheck` — passed
- [x] 15 profile unit tests pass (drawer-overlay-styles, profile-surface-state, hero-invariants, ProfileDesktopSurface)

🤖 Generated with [Claude Code](https://claude.com/claude-code)