### PR TITLE
fix(ds): address greptile follow-up issues from dashboard token migration

### DIFF
--- a/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
@@ -311,7 +311,7 @@ export function LiquidGlassMenu({
                   <button
                     type='button'
                     onClick={onSignOut}
-                    className='flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-app font-caption text-secondary-token transition-colors duration-subtle hover:bg-surface-1 hover:text-primary-token active:scale-[0.98]'
+                    className='flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-app font-caption text-secondary-token transition-[background-color,color,transform] duration-subtle hover:bg-surface-1 hover:text-primary-token active:scale-[0.98]'
                   >
                     <LogOut
                       className='size-5 shrink-0 text-tertiary-token'
@@ -351,7 +351,7 @@ export function LiquidGlassMenu({
                 href={item.href}
                 aria-current={active ? 'page' : undefined}
                 className={cn(
-                  'relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-colors duration-subtle',
+                  'relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-[color,transform] duration-subtle',
                   'active:scale-95',
                   active
                     ? 'text-primary-token'
@@ -389,7 +389,7 @@ export function LiquidGlassMenu({
             aria-label={isExpanded ? 'Close menu' : 'More options'}
             aria-expanded={isExpanded}
             className={cn(
-              'relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-colors duration-subtle',
+              'relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-[color,transform] duration-subtle',
               'active:scale-95',
               isExpanded
                 ? 'text-primary-token'
@@ -413,7 +413,7 @@ export function LiquidGlassMenu({
               type='button'
               onClick={onSearchClick}
               aria-label='Search'
-              className='relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 text-tertiary-token transition-colors duration-subtle hover:text-secondary-token active:scale-95'
+              className='relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 text-tertiary-token transition-[color,transform] duration-subtle hover:text-secondary-token active:scale-95'
             >
               <Search className='h-5 w-5' aria-hidden='true' />
               <span className='text-3xs leading-tight font-caption'>

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/cells/initials.ts
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/cells/initials.ts
@@ -38,7 +38,7 @@ const MONOGRAM_PALETTE = [
   'bg-surface-2 text-primary-token',
   'bg-surface-2 text-secondary-token',
   'bg-surface-1 text-secondary-token',
-  'bg-surface-1 text-primary-token',
+  'bg-surface-0 text-tertiary-token',
   'bg-indigo-900/50 text-indigo-100',
   'bg-violet-900/50 text-violet-100',
   'bg-blue-900/50 text-blue-100',

--- a/apps/web/components/organisms/CTASection.tsx
+++ b/apps/web/components/organisms/CTASection.tsx
@@ -35,7 +35,6 @@ export function CTASection({
             level={2}
             size={variant === 'secondary' ? 'xl' : 'md'}
             align={variant === 'secondary' ? 'center' : 'left'}
-            className='text-primary-token'
           >
             {title}
           </SectionHeading>

--- a/apps/web/components/organisms/HeroSection.tsx
+++ b/apps/web/components/organisms/HeroSection.tsx
@@ -123,7 +123,7 @@ export const HeroSection = memo(function HeroSection({
               )}
 
               {/* Content card */}
-              <div className='relative bg-surface-0 rounded-2xl border border-subtle shadow-xl hover:shadow-2xl transition-shadow duration-subtle p-8'>
+              <div className='relative bg-surface-0/90 backdrop-blur-xl rounded-2xl border border-subtle shadow-xl hover:shadow-2xl transition-shadow duration-subtle p-8'>
                 {children}
               </div>
             </div>

--- a/apps/web/components/organisms/combobox/Combobox.tsx
+++ b/apps/web/components/organisms/combobox/Combobox.tsx
@@ -236,8 +236,8 @@ export const Combobox = forwardRef<HTMLDivElement, ComboboxProps>(
                         'h-12 sm:h-11 rounded-xl sm:rounded-l-none sm:rounded-r-xl',
                         'px-4 sm:px-6 flex items-center justify-center',
                         'text-sm font-medium',
-                        'bg-surface-1 text-primary-token hover:bg-surface-2 transition-colors',
-                        'disabled:bg-surface-1/50 disabled:text-disabled-token disabled:cursor-not-allowed',
+                        'bg-white text-gray-900 hover:bg-white/90 transition-colors',
+                        'disabled:bg-white/50 disabled:text-gray-500 disabled:cursor-not-allowed',
                         'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white'
                       )}
                       aria-label={`${ctaText} for ${value?.name || 'selected artist'}`}

--- a/apps/web/components/organisms/keyboard-shortcuts-sheet/KeyboardShortcutsSheet.tsx
+++ b/apps/web/components/organisms/keyboard-shortcuts-sheet/KeyboardShortcutsSheet.tsx
@@ -171,7 +171,7 @@ export function KeyboardShortcutsSheet() {
         hideClose
         onAnimationEnd={handleAnimationEnd}
       >
-        <div className='sticky top-0 z-10 shrink-0 bg-surface-0 backdrop-blur-md'>
+        <div className='sticky top-0 z-10 shrink-0 bg-surface-0/95 backdrop-blur-md'>
           <SheetHeader className='flex flex-row items-center gap-2 space-y-0 px-3 py-2'>
             <Button
               variant='ghost'


### PR DESCRIPTION
## Summary

Follow-up to #8157 — addresses greptile review comments that arrived after the PR merged.

- **CTASection**: removed dead conditional on heading class (both branches produced `text-primary-token` after migration)
- **initials.ts**: diversified MONOGRAM_PALETTE slots 0 and 3 (were identical — both resolved to `bg-surface-2 text-primary-token` after zinc/neutral migration); slot 3 is now `bg-surface-0 text-tertiary-token`
- **HeroSection**: restored partial opacity (`bg-surface-0/90`) on content card so `backdrop-blur-xl` has visual effect
- **KeyboardShortcutsSheet**: restored partial opacity (`bg-surface-0/95`) on sticky header so `backdrop-blur-md` has visual effect
- **Combobox**: reverted CTA button to `bg-white text-gray-900` — the combobox is designed for dark glass containers (`bg-white/5`) where `bg-surface-1` loses high contrast
- **LiquidGlassMenu**: updated `transition-colors` to `transition-[color,transform]` or `transition-[background-color,color,transform]` on elements with `active:scale` so press feedback animates correctly

## Test plan

- [ ] Typecheck: `pnpm --filter @jovie/web run typecheck` passes (0 errors)
- [ ] Lint: `pnpm biome check` passes (0 errors)
- [ ] Unit tests: no new failures

<!-- linear-issue-id:JOV-1928 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of special characters and Unicode support in name initials extraction with fallback for empty names.

* **Style**
  * Enhanced button transitions and hover effects in dashboard navigation.
  * Improved responsive sizing for call-to-action sections based on display variants.
  * Added optional backdrop blur visual effects to hero sections and keyboard shortcuts sheet.
  * Refined button styling in comboboxes with updated color and hover states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->