### PR TITLE
chore(skills): install find-skills and document external skill governance

### DIFF
--- a/.claude/rules/gstack.md
+++ b/.claude/rules/gstack.md
@@ -66,6 +66,33 @@ gstack skill files are part of the agent control plane. Keep them fast, stable, 
 - Keep stable shared text before variable request details so provider prompt caching can work.
 - Run `bun run skill:size-check` after skill-template changes. It is a ratchet, not the final target; new work should reduce skill size when practical.
 
+## External Skill Governance
+
+Engineering agents may install third-party Agent Skills via the [`vercel-labs/skills`](https://github.com/vercel-labs/skills) CLI (`npx skills add | find | update`). The discovery skill itself is installed at `.claude/skills/find-skills/SKILL.md` and is the canonical entry point for "find me a skill that does X" workflows. Lockfile lives at `skills-lock.json` in the repo root.
+
+**Allowed sources** (install without further review):
+
+- `anthropics/*`
+- `vercel-labs/*`
+- `microsoft/*`
+- Official first-party vendor skills (Stripe, Clerk, Sentry, Vercel, etc.)
+- Jovie-owned private skills
+
+**Blocked by default** (require explicit human review before install):
+
+- Unknown community authors
+- Skills shipping executable scripts (read every script before approval)
+- Skills requesting outbound network access
+- Skills that touch credentials, fan data, payments, or artist accounts
+
+**Pre-install checks** (per `find-skills` SKILL.md): inspect install count, source reputation, GitHub stars, and the Snyk/Socket risk badges shown by `skills add` before accepting.
+
+**Telemetry**: every `npx skills` invocation must run with `DISABLE_TELEMETRY=1` and `DO_NOT_TRACK=1`. These are also set in `.claude/settings.json`'s `env` block, so any agent shell inherits them by default.
+
+**Install scope**: prefer project-scoped installs (`--agent claude-code`) so the new skill is reviewable in the PR diff. Avoid `--global`/`-g` for repo-relevant skills.
+
+**Product-surface separation**: external Agent Skills are an engineering-time tool only. They MUST NOT be exposed to artists, fans, or any user-facing Jovie surface. Artist-facing AI workflows are built as Jovie product features and tracked in Linear, not installed from the open ecosystem.
+
 ## Performance Optimization Loop
 
 `/perf-loop` runs an autonomous optimization loop that measures, experiments, and keeps only improvements. It must follow `.claude/skills/jovie-performance-hardening/SKILL.md`: baseline first, one hypothesis family per iteration, re-measure with the same method, and keep only validated wins. State is persisted to `.context/perf/` for resume capability. The skill uses `perf:loop` (performance-optimizer.ts) as its measurement primitive.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,8 @@
 {
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "DISABLE_TELEMETRY": "1",
+    "DO_NOT_TRACK": "1"
   },
   "hooks": {
     "SessionStart": [

--- a/.claude/skills/find-skills/SKILL.md
+++ b/.claude/skills/find-skills/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: find-skills
+description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+---
+
+# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What is the Skills CLI?
+
+The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+
+**Key commands:**
+
+- `npx skills find [query]` - Search for skills interactively or by keyword
+- `npx skills add <package>` - Install a skill from GitHub or other sources
+- `npx skills check` - Check for skill updates
+- `npx skills update` - Update all installed skills
+
+**Browse skills at:** https://skills.sh/
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Check the Leaderboard First
+
+Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
+
+For example, top skills for web development include:
+- `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
+- `anthropics/skills` — Frontend design, document processing (100K+ installs)
+
+### Step 3: Search for Skills
+
+If the leaderboard doesn't cover the user's need, run the find command:
+
+```bash
+npx skills find [query]
+```
+
+For example:
+
+- User asks "how do I make my React app faster?" → `npx skills find react performance`
+- User asks "can you help me with PR reviews?" → `npx skills find pr review`
+- User asks "I need to create a changelog" → `npx skills find changelog`
+
+### Step 4: Verify Quality Before Recommending
+
+**Do not recommend a skill based solely on search results.** Always verify:
+
+1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
+2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
+3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
+
+### Step 5: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install count and source
+3. The install command they can run
+4. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+(185K installs)
+
+To install it:
+npx skills add vercel-labs/agent-skills@react-best-practices
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
+```
+
+### Step 6: Offer to Install
+
+If the user wants to proceed, you can install the skill for them:
+
+```bash
+npx skills add <owner/repo@skill> -g -y
+```
+
+The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with `npx skills init`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill:
+npx skills init my-xyz-skill
+```

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "find-skills": {
+      "source": "vercel-labs/skills",
+      "sourceType": "github",
+      "skillPath": "skills/find-skills/SKILL.md",
+      "computedHash": "9e1c8b3103f92fa8092568a44fe64858de7c5c9dc65ce4bea8f168080e889cfd"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Install `find-skills` (vercel-labs/skills) so engineering agents can discover and install other Agent Skills via `npx skills find/add/check/update`. Skill lives at `.claude/skills/find-skills/SKILL.md`; lockfile at `skills-lock.json`.
- Add an **External Skill Governance** section to `.claude/rules/gstack.md` covering allowed sources (anthropics/*, vercel-labs/*, microsoft/*, official vendors, Jovie-owned), blocked-by-default categories (unknown community, executable scripts, network-access skills, anything touching credentials/fan data/payments), pre-install checks, and a hard separation between engineering-time skills and artist-facing product surfaces.
- Default `DISABLE_TELEMETRY=1` and `DO_NOT_TRACK=1` in `.claude/settings.json`'s `env` block so any agent shell respects telemetry-off without per-command flags.

## Context

A pasted recommendation suggested three things: (1) install `find-skills` for engineering, (2) build Jovie-native artist skills as a product surface, (3) keep open ecosystem skills out of artist-facing flows. Only (1) and the policy framing for (3) ship in this PR. (2) is product-roadmap work tracked separately.

## Why now

`find-skills` is a meta-skill — it costs nothing to install and lets engineering agents find well-vetted skills (security audit, perf, deploy, design) instead of reinventing them. The governance section closes the obvious "agent installs unreviewed community skill against creator data" loophole before anyone hits it.

## Out of scope

- Building `jovie-release-planner`, `jovie-playlist-pitch`, `jovie-artist-profile-builder`, etc. — tracked in **JOV-1955** (https://linear.app/jovie/issue/JOV-1955). Decision question: ship these as Anthropic-format Agent Skills, as Jovie product features, or hybrid.
- Integrating `skills.sh` API as a Jovie product-side discovery layer.

## Pre-Landing Review

`/review` ran clean: 0 critical, 0 informational. Specialists skipped (184-line config/docs-only diff, no executable code). Critical-pass categories (SQL safety, race conditions, LLM trust boundary, shell injection) are all N/A. JSON validity verified (`jq .`).

## Risk

- `DO_NOT_TRACK=1` / `DISABLE_TELEMETRY=1` are scoped to the agent shell (`.claude/settings.json`'s `env`), not the deployed app's runtime. Sentry/PostHog product telemetry is unaffected. Next.js/Vercel use their own vars (`NEXT_TELEMETRY_DISABLED`, `VERCEL_TELEMETRY_DISABLED`) and won't be silenced by `DO_NOT_TRACK` alone.
- `find-skills` SKILL.md (verbatim from upstream) recommends `-g` global installs. The new governance section recommends project-scoped (`--agent claude-code`) so installs land in the PR diff and stay reviewable. Soft policy override; revisit if it bites.

## Cost Impact

None. No new external API calls, no cron jobs, no scheduled work. The `find-skills` SKILL.md is a static file consumed by the agent at session start.

## Test plan

- [x] Pre-push hooks pass (biome 5397 files, proxy-guard, tailwind-guard, typecheck, lint).
- [x] `.claude/settings.json` parses as valid JSON (`jq .` clean).
- [x] `.claude/skills/find-skills/SKILL.md` is the verbatim upstream content (sha matches `skills-lock.json` `computedHash`).
- [x] `find-skills` appears in the available-skills list when a fresh Claude Code session loads (verified during install — see install summary in skill output).
- [ ] No product-surface (web/api) tests required — diff has zero web app impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added find-skills functionality to discover and verify third-party skills with quality metrics, source reputation checks, and installation counts.

* **Documentation**
  * Established external skill governance guidelines with pre-installation verification requirements and telemetry opt-out configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->