### PR TITLE
fix: resolve SonarCloud void operator and nested ternary issues

### DIFF
--- a/apps/web/app/hud/HudDashboardClient.tsx
+++ b/apps/web/app/hud/HudDashboardClient.tsx
@@ -538,7 +538,7 @@ export function HudDashboardClient({
               <HermesDispatchControls
                 aiOps={metrics.aiOps}
                 onDispatchComplete={() => {
-                  void refetch();
+                  refetch().catch(() => {});
                 }}
               />
             ) : (

--- a/apps/web/components/organisms/CmdKPalette.tsx
+++ b/apps/web/components/organisms/CmdKPalette.tsx
@@ -166,12 +166,10 @@ export function CmdKPalette({
 
       const key = pickerItemKey(item);
       if (additionalIds.has(key)) {
-        const id =
-          item.kind === 'nav'
-            ? item.nav.id
-            : item.kind === 'skill'
-              ? item.skill.id
-              : item.entity.id;
+        let id: string;
+        if (item.kind === 'nav') id = item.nav.id;
+        else if (item.kind === 'skill') id = item.skill.id;
+        else id = item.entity.id;
         onAdditionalSelect?.(id);
         handleClose();
         return;

--- a/apps/web/components/organisms/hooks/useProfileTracking.ts
+++ b/apps/web/components/organisms/hooks/useProfileTracking.ts
@@ -111,14 +111,11 @@ export function useProfileVisitTracking(
             `/api/audience/visit-token?profileId=${encodeURIComponent(profileId)}`,
             { cache: 'no-store' }
           );
-          const payload = (await response.json().catch(() => null)) as {
-            token?: string | null;
-          } | null;
           // We intentionally don't re-fire the visit beacon here — the visit
           // was already recorded above. Token enrichment that arrives after
           // the visit is recorded is acceptable analytics loss for the
           // signed-fingerprint dedupe path; bounce coverage matters more.
-          void payload;
+          await response.json().catch(() => null);
         } catch {
           // best-effort
         }

--- a/apps/web/components/organisms/release-sidebar/ReleaseFields.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseFields.tsx
@@ -34,13 +34,15 @@ export function ReleaseFields({
   const releaseTypeLabel = releaseType
     ? (RELEASE_TYPE_LABELS[releaseType] ?? releaseType)
     : null;
+  const trackNoun = totalTracks === 1 ? 'Track' : 'Tracks';
   const trackLabel =
     totalTracks != null && totalTracks > 0
-      ? `${totalTracks} ${totalTracks === 1 ? 'Track' : 'Tracks'}`
+      ? `${totalTracks} ${trackNoun}`
       : null;
+  const platformNoun = platformCount === 1 ? 'DSP' : 'DSPs';
   const platformLabel =
     platformCount != null && platformCount > 0
-      ? `${platformCount} ${platformCount === 1 ? 'DSP' : 'DSPs'}`
+      ? `${platformCount} ${platformNoun}`
       : null;
   const dropDate = releaseDate ? dropDateMeta(releaseDate) : null;
 

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -30,34 +30,30 @@ export function SidebarNavItem({
   nested,
   tight,
 }: SidebarNavItemProps) {
+  const nonCollapsedSize = tight ? 'h-6 pl-2.5 pr-2' : 'h-7 pl-3 pr-2';
+  const inactiveColor = nested
+    ? 'text-tertiary-token hover:bg-surface-1/40 hover:text-primary-token'
+    : 'text-secondary-token hover:bg-surface-1/60 hover:text-primary-token';
+  const inactiveIconColor = nested
+    ? 'text-quaternary-token'
+    : 'text-tertiary-token';
+
   const button = (
     <button
       type='button'
       onClick={item.onActivate}
       className={cn(
-        'relative flex items-center rounded-md w-full transition-colors duration-150 ease-out tracking-[-0.005em]',
+        'relative flex items-center rounded-md w-full transition-colors duration-subtle ease-out tracking-[-0.005em]',
         tight ? 'gap-2 text-[12.5px]' : 'gap-2.5 text-[13px]',
-        collapsed
-          ? 'h-8 w-10 mx-auto justify-center'
-          : tight
-            ? 'h-6 pl-2.5 pr-2'
-            : 'h-7 pl-3 pr-2',
-        item.active
-          ? 'text-primary-token bg-surface-1'
-          : nested
-            ? 'text-tertiary-token hover:bg-surface-1/40 hover:text-primary-token'
-            : 'text-secondary-token hover:bg-surface-1/60 hover:text-primary-token'
+        collapsed ? 'h-8 w-10 mx-auto justify-center' : nonCollapsedSize,
+        item.active ? 'text-primary-token bg-surface-1' : inactiveColor
       )}
     >
       <item.icon
         className={cn(
           'shrink-0',
           tight ? 'h-3 w-3' : 'h-3.5 w-3.5',
-          item.active
-            ? 'text-primary-token'
-            : nested
-              ? 'text-quaternary-token'
-              : 'text-tertiary-token'
+          item.active ? 'text-primary-token' : inactiveIconColor
         )}
         strokeWidth={2.25}
       />

--- a/apps/web/components/site/MarketingFooter.tsx
+++ b/apps/web/components/site/MarketingFooter.tsx
@@ -73,12 +73,9 @@ export function MarketingFooter({
   showCta = true,
 }: Readonly<MarketingFooterProps>) {
   const pathname = usePathname();
-  const resolvedVariant =
-    variant === 'auto'
-      ? pathname && MINIMAL_FOOTER_PATHS.has(pathname)
-        ? 'minimal'
-        : 'expanded'
-      : variant;
+  const isMinimalPath = pathname && MINIMAL_FOOTER_PATHS.has(pathname);
+  const autoVariant = isMinimalPath ? 'minimal' : 'expanded';
+  const resolvedVariant = variant === 'auto' ? autoVariant : variant;
   const isMinimal = resolvedVariant === 'minimal';
   const pageOwnsFinalCta =
     typeof pathname === 'string' && PAGE_OWNS_FINAL_CTA_PATHS.has(pathname);


### PR DESCRIPTION
## Summary
Fixes 8 SonarCloud issues (2 CRITICAL, 6 MAJOR):
- **S3735** (CRITICAL): Remove void operator usage in `useProfileTracking` and `HudDashboardClient`
- **S3358** (MAJOR): Extract nested ternary operations in `MarketingFooter`, `CmdKPalette`, `ReleaseFields`, `SidebarNavItem`
- Bonus: Fix pre-existing `duration-150` → `duration-subtle` design token in `SidebarNavItem`

## SonarCloud Rules Addressed
- `typescript:S3735`: Remove use of the "void" operator (2 issues)
- `typescript:S3358`: Extract nested ternary operations into independent statements (6 issues)

## Test plan
- [x] TypeScript compiles
- [x] Biome lint passes
- [x] ESLint passes (0 warnings)
- [x] a11y check passes
- [x] No behavior changes (code quality fixes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal component logic across the dashboard, command palette, release sidebar, and profile tracking modules for improved code maintainability.
  * Enhanced error handling in worker dispatch and data refresh workflows.

* **Style**
  * Refined sidebar navigation transition timing for smoother visual feedback during navigation interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->