### PR TITLE
feat(agentos): scaffold agentos/ repo structure (JOV-1931)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ output/
 .claude-flow/
 .swarm/
 ruvector.db
+
+# AgentOS run artifacts (binary outputs not source-controlled)
+agentos/runs/**/artifacts/

--- a/agentos/README.md
+++ b/agentos/README.md
@@ -1,0 +1,16 @@
+# AgentOS
+
+AgentOS is the private orchestration surface for Jovie. Linear is the canonical roadmap and source of truth for product work and ownership. This directory mirrors execution detail — specs, persistent agent memory, run artifacts, and role definitions — that belongs in the repo but not in Linear.
+
+| Directory | Purpose |
+|-----------|---------|
+| `roadmap/` | Linear AgentOS issue mirror, per-project specs, and backlog machine-read cache |
+| `memory/` | Persistent context that survives across agent sessions (product principles, design taste, rejected directions) |
+| `agents/` | Per-agent role definition files for AgentOS-specific agent types |
+| `runs/` | Agent run output artifacts (screenshots, diffs, generated proposals) |
+
+## References
+
+- Phase 0 ADR: [`docs/AGENT_OS_ARCHITECTURE.md`](../docs/AGENT_OS_ARCHITECTURE.md)
+- Phase 1 run schema: [`apps/web/lib/agent-os/artifact.ts`](../apps/web/lib/agent-os/artifact.ts) _(introduced in the AgentRunArtifact PR)_
+- Linear initiative: [AgentOS](https://linear.app/jovie/initiative/agentos-1838d0d6b914)

--- a/agentos/agents/README.md
+++ b/agentos/agents/README.md
@@ -1,0 +1,13 @@
+# agents/
+
+Per-agent role definition files for AgentOS-specific agent types. One `.md` file per agent role.
+
+See `.claude/skills/` for gstack skill examples of the general pattern. AgentOS agent roles defined here are product-specific and go beyond gstack's workflow skills.
+
+Planned roles (from the AgentOS architecture plan):
+
+- `design-lever-scout.md` — discovers design improvement opportunities across authenticated routes
+- `design-html-builder.md` — generates production-ready HTML design proposals from Figma/prompts
+- `visual-qa-agent.md` — screenshot-based visual regression and consistency audit
+
+Add new role files here when a new agent type is formally defined and approved.

--- a/agentos/memory/README.md
+++ b/agentos/memory/README.md
@@ -1,0 +1,11 @@
+# memory/
+
+Persistent context that survives across agent sessions. Agents READ these files at session start to orient themselves. Agents do NOT write to these files autonomously — writes require explicit human approval or a defined approval flow (see JOV-1936/D2 for the write-approval protocol).
+
+| File | Purpose |
+|------|---------|
+| `product-principles.md` | Core product decisions and values that constrain all agent work |
+| `design-taste.md` | Visual and UX taste rules derived from human feedback and DESIGN.md |
+| `rejected-directions.md` | Directions that have been explicitly ruled out, with rationale |
+
+Agents: read before acting, never write without approval.

--- a/agentos/memory/design-taste.md
+++ b/agentos/memory/design-taste.md
@@ -1,0 +1,5 @@
+# Design Taste
+
+Visual and UX taste rules distilled from human feedback, DESIGN.md, and post-mortems.
+
+(Empty — populate with human approval.)

--- a/agentos/memory/product-principles.md
+++ b/agentos/memory/product-principles.md
@@ -1,0 +1,3 @@
+# Product Principles
+
+(Empty — populate via `/memory add product-principle "..."` or directly with human approval.)

--- a/agentos/memory/rejected-directions.md
+++ b/agentos/memory/rejected-directions.md
@@ -1,0 +1,5 @@
+# Rejected Directions
+
+Approaches that have been explicitly ruled out, with the rationale recorded so future agents do not re-propose them.
+
+(Empty — populate with human approval.)

--- a/agentos/roadmap/README.md
+++ b/agentos/roadmap/README.md
@@ -1,0 +1,13 @@
+# roadmap/
+
+This directory is a structured mirror of Linear's AgentOS initiative. Linear remains the single source of truth for priority, ownership, and status; files here hold execution detail that doesn't belong in Linear (per-project specs, machine-readable briefs, backlog cache).
+
+| File | Purpose |
+|------|---------|
+| `SYNC_MODEL.md` | Sync protocol spec — how issues move from Linear into this directory. Defined in JOV-1930. |
+| `backlog.json` | Machine-readable mirror of active AgentOS issues (schema defined in `SYNC_MODEL.md §3`) |
+| `<project-slug>.md` | Per-project spec detail, one file per Linear project under the AgentOS initiative |
+
+<!-- TODO(JOV-1930): SYNC_MODEL.md is being defined in the parallel R1 task. Once that PR lands, update this README to link directly to SYNC_MODEL.md §3 for the backlog.json schema. -->
+
+Sync operations are handled by the `/roadmap` command (JOV-1932).

--- a/agentos/roadmap/backlog.json
+++ b/agentos/roadmap/backlog.json
@@ -1,0 +1,5 @@
+{
+  "_schema_ref": "See agentos/roadmap/SYNC_MODEL.md §3 (defined in JOV-1930) for the full backlog entry schema.",
+  "_note": "This file is machine-written by the /roadmap sync command. Do not hand-edit.",
+  "issues": []
+}

--- a/agentos/runs/README.md
+++ b/agentos/runs/README.md
@@ -1,0 +1,11 @@
+# runs/
+
+Agent run output artifacts: screenshots, diffs, generated proposals, build outputs.
+
+Run directories follow the naming convention: `<run-type>/<YYYY-MM-DD>/<run-id>/`
+
+Examples:
+- `design-review/2026-05-08/abc123/`
+- `qa/2026-05-08/def456/`
+
+Binary artifact files (images, zips, built assets) are gitignored via `agentos/runs/**/artifacts/`. Only run metadata files (JSON summaries, markdown reports) are committed.


### PR DESCRIPTION
<!-- linear-issue-id:JOV-1931 -->

## Summary

- Creates `agentos/` directory with four subdirectories: `roadmap/`, `memory/`, `agents/`, `runs/`
- Each directory has an opinionated README explaining purpose, ownership rules, and agent read/write contracts
- Adds `agentos/roadmap/backlog.json` skeleton with schema reference pointer to `SYNC_MODEL.md §3` (JOV-1930)
- Appends `agentos/runs/**/artifacts/` to `.gitignore` so binary run outputs are never committed

## Parallel work (R1)

JOV-1930 (R1) is producing `agentos/roadmap/SYNC_MODEL.md` in a parallel branch. This PR does **not** touch that file. `agentos/roadmap/README.md` includes a `TODO(JOV-1930)` comment to integrate the SYNC_MODEL.md link once R1 lands. R1 was not yet on `main` at the time of this commit.

## Files changed

| File | Type |
|------|------|
| `agentos/README.md` | New — top-level AgentOS orientation, subdirectory map, reference links |
| `agentos/roadmap/README.md` | New — roadmap mirror purpose, file index, JOV-1930 TODO |
| `agentos/roadmap/backlog.json` | New — empty skeleton with schema_ref key |
| `agentos/memory/README.md` | New — persistent memory purpose and read/write rules |
| `agentos/memory/product-principles.md` | New — header-only placeholder |
| `agentos/memory/design-taste.md` | New — header-only placeholder |
| `agentos/memory/rejected-directions.md` | New — header-only placeholder |
| `agentos/agents/README.md` | New — agent role file purpose, planned roles |
| `agentos/runs/README.md` | New — run artifact naming convention, gitignore note |
| `agentos/runs/.gitkeep` | New — keeps empty directory tracked |
| `.gitignore` | Modified — appends `agentos/runs/**/artifacts/` block |

## References

- Linear: [JOV-1931](https://linear.app/jovie/issue/JOV-1931/create-agentos-repo-file-structure)
- Phase 0 ADR: `docs/AGENT_OS_ARCHITECTURE.md`
- AgentOS initiative: https://linear.app/jovie/initiative/agentos-1838d0d6b914
- Parallel R1 (sync model): JOV-1930

## Test plan

- [ ] `agentos/` directory tree is present and matches the subdirectory map in `agentos/README.md`
- [ ] `agentos/runs/**/artifacts/` is gitignored (create a test file under that path and verify `git status` omits it)
- [ ] No `.ts`/`.tsx` files added — scaffold is docs only
- [ ] No migration files touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for AgentOS orchestration system structure, including agent roles, persistent memory management, and roadmap organization.

* **Chores**
  * Configured artifact file exclusion from version control.
  * Initialized infrastructure files for agent memory persistence, role definitions, and roadmap tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->