### PR TITLE
fix(hooks): add set -e to pre-commit and LC_ALL=C for locale safety

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 
 bash scripts/check-conflict-markers.sh
 pnpm run next:proxy-guard

--- a/scripts/check-conflict-markers.sh
+++ b/scripts/check-conflict-markers.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Check staged files for leftover merge conflict markers.
 # Uses git's built-in conflict marker detector, fails fast before lint/typecheck.
-output=$(git diff --cached --check 2>&1 || true)
+output=$(LC_ALL=C git diff --cached --check 2>&1 || true)
 
 if echo "$output" | grep -q "leftover conflict marker"; then
   echo "ERROR: Merge conflict markers found in staged files:"


### PR DESCRIPTION
## Summary

Fixes two bugs in the conflict-marker pre-commit check landed in #8249.

- **`set -e` missing from `.husky/pre-commit`** — without it, a failing `check-conflict-markers.sh` (exit 1) doesn't abort the hook. `sh` continues and uses lint-staged's exit code (0), so commits with conflict markers go through unblocked. The entire purpose of the check was defeated.
- **`LC_ALL=C` missing from `check-conflict-markers.sh`** — the `grep "leftover conflict marker"` pattern depends on git outputting English diagnostic text. On localized systems, git may emit non-English output and the grep silently matches nothing, again letting markers through.

Both bugs were found by the `/autoplan` review pipeline during the prior session.

## Root cause

The `set -e` omission is the critical one. Verified with a shell test:

```sh
sh -c 'false; true; exit $?'  # exits 0 — last command wins without set -e
sh -c 'set -e; false; true'   # exits 1 — set -e propagates failure
```

## Test plan

- [ ] CI passes on this PR
- [ ] Manually verify: stage a file with `<<<<<<< HEAD` markers, run `git commit` — should be blocked with "ERROR: Merge conflict markers found"
- [ ] Clean commit still passes through

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pre-commit hook execution reliability
  * Improved merge conflict detection accuracy in the development process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->