### PR TITLE
fix(security): require auth on visit-token endpoint + harden tracking (JOV-1964 part A)

### DIFF
--- a/apps/web/tests/unit/api/audience/visit-token.test.ts
+++ b/apps/web/tests/unit/api/audience/visit-token.test.ts
@@ -1,0 +1,204 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPublicVisitLimiterLimit = vi.hoisted(() => vi.fn());
+const mockDbSelect = vi.hoisted(() => vi.fn());
+const mockGetClientTrackingToken = vi.hoisted(() => vi.fn());
+const mockCaptureError = vi.hoisted(() => vi.fn());
+const mockExtractClientIP = vi.hoisted(() =>
+  vi.fn().mockReturnValue('127.0.0.1')
+);
+const mockLoggerError = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/rate-limit', () => ({
+  publicVisitLimiter: {
+    limit: mockPublicVisitLimiterLimit,
+  },
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mockDbSelect,
+  },
+}));
+
+vi.mock('@/lib/db/schema/profiles', () => ({
+  creatorProfiles: { id: 'profile-id-column' },
+}));
+
+vi.mock('@/lib/analytics/tracking-token', () => ({
+  getClientTrackingToken: mockGetClientTrackingToken,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: mockCaptureError,
+}));
+
+vi.mock('@/lib/utils/ip-extraction', () => ({
+  extractClientIP: mockExtractClientIP,
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    error: mockLoggerError,
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const { GET } = await import('@/app/api/audience/visit-token/route');
+
+const VALID_UUID = '11111111-1111-4111-8111-111111111111';
+
+function buildRequest(profileId: string | null): NextRequest {
+  const url = new URL('http://localhost/api/audience/visit-token');
+  if (profileId !== null) {
+    url.searchParams.set('profileId', profileId);
+  }
+  return new NextRequest(url);
+}
+
+function mockProfileLookup(profile: { id: string } | null) {
+  const limit = vi.fn().mockResolvedValue(profile ? [profile] : []);
+  const where = vi.fn().mockReturnValue({ limit });
+  const from = vi.fn().mockReturnValue({ where });
+  mockDbSelect.mockReturnValue({ from });
+  return { limit, where, from };
+}
+
+function passingRateLimit() {
+  mockPublicVisitLimiterLimit.mockResolvedValue({
+    success: true,
+    limit: 100,
+    remaining: 99,
+    reset: new Date(Date.now() + 60_000),
+  });
+}
+
+describe('GET /api/audience/visit-token', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExtractClientIP.mockReturnValue('127.0.0.1');
+  });
+
+  it('returns 400 when profileId is malformed', async () => {
+    passingRateLimit();
+    const response = await GET(buildRequest('not-a-uuid'));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body).toEqual({ error: 'Invalid request' });
+    // Must not consume DB or signing on bad input
+    expect(mockDbSelect).not.toHaveBeenCalled();
+    expect(mockGetClientTrackingToken).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when profileId is missing entirely', async () => {
+    passingRateLimit();
+    const response = await GET(buildRequest(null));
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 429 with Retry-After when the IP is rate-limited (closes Greptile P1: visit-token unauth abuse vector)', async () => {
+    mockPublicVisitLimiterLimit.mockResolvedValue({
+      success: false,
+      limit: 100,
+      remaining: 0,
+      reset: new Date(Date.now() + 30_000),
+    });
+
+    const response = await GET(buildRequest(VALID_UUID));
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBeTruthy();
+    expect(Number(response.headers.get('Retry-After'))).toBeGreaterThan(0);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(response.headers.get('X-RateLimit-Limit')).toBe('100');
+    expect(response.headers.get('X-RateLimit-Remaining')).toBe('0');
+    // Importantly: no DB lookup or token mint when rate-limited
+    expect(mockDbSelect).not.toHaveBeenCalled();
+    expect(mockGetClientTrackingToken).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the profile UUID does not exist (closes Greptile P1: caller-supplied UUID minted tokens)', async () => {
+    passingRateLimit();
+    mockProfileLookup(null);
+
+    const response = await GET(buildRequest(VALID_UUID));
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body).toEqual({ error: 'Not found' });
+    // Must not mint a token for a nonexistent profile
+    expect(mockGetClientTrackingToken).not.toHaveBeenCalled();
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('returns a signed token for a real profile under the rate limit', async () => {
+    passingRateLimit();
+    mockProfileLookup({ id: VALID_UUID });
+    mockGetClientTrackingToken.mockReturnValue({
+      token: 'signed-token-abc',
+      expiresAt: 1_700_000_000_000,
+    });
+
+    const response = await GET(buildRequest(VALID_UUID));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toEqual({
+      token: 'signed-token-abc',
+      expiresAt: 1_700_000_000_000,
+    });
+    expect(mockGetClientTrackingToken).toHaveBeenCalledWith(VALID_UUID);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('captures and reports profile-lookup failures (closes CodeRabbit Major: silent failure swallowing)', async () => {
+    passingRateLimit();
+    const dbError = new Error('connection refused');
+    const limit = vi.fn().mockRejectedValue(dbError);
+    const where = vi.fn().mockReturnValue({ limit });
+    const from = vi.fn().mockReturnValue({ where });
+    mockDbSelect.mockReturnValue({ from });
+
+    const response = await GET(buildRequest(VALID_UUID));
+
+    expect(response.status).toBe(500);
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      '[visit-token] profile lookup failed',
+      dbError
+    );
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      'visit-token profile lookup failed',
+      dbError,
+      expect.objectContaining({ route: '/api/audience/visit-token' })
+    );
+  });
+
+  it('captures and reports token-signing failures while preserving fallback shape (closes CodeRabbit Major: silent token-mint swallowing)', async () => {
+    passingRateLimit();
+    mockProfileLookup({ id: VALID_UUID });
+    const signingError = new Error('TRACKING_TOKEN_SECRET missing');
+    mockGetClientTrackingToken.mockImplementation(() => {
+      throw signingError;
+    });
+
+    const response = await GET(buildRequest(VALID_UUID));
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    // Existing clients (which read `token` defensively) must still degrade
+    // gracefully — the fallback shape is part of the contract.
+    expect(body).toEqual({ token: null, expiresAt: null });
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      '[visit-token] signing failed',
+      signingError
+    );
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      'visit-token signing failed',
+      signingError,
+      expect.objectContaining({ route: '/api/audience/visit-token' })
+    );
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-1964 -->

Part A of 3 to unblock #7986 per JOV-1964.

## Summary

The `/api/audience/visit-token` route on `main` already implements the full hardening: per-IP rate limiting, server-side profile-existence verification before minting, and explicit `captureError` + `logger.error` around both lookup and signing failures. `useProfileTracking` already mints the token server-side via the `visitTrackingToken` prop and fires the beacon immediately when no token is provided (async enrichment is non-blocking).

This PR locks in that contract with **7 unit tests** so future regressions are caught.

## Bot review findings addressed

Re PR #7986:

- **Greptile P1 #1** — `/api/audience/visit-token` unauth abuse vector ([comment 3165368214](https://github.com/JovieInc/Jovie/pull/7986#discussion_r3165368214))
  - Implementation already on main: option (b) — public route + per-IP `publicVisitLimiter` + UUID validation + DB-backed profile-existence check before minting
  - Test: 429 with `Retry-After`/`X-RateLimit-*` headers; 404 for unknown UUIDs; 400 for malformed input
- **CodeRabbit Major** — drop redundant `runtime = 'nodejs'` ([comment 3164378648](https://github.com/JovieInc/Jovie/pull/7986#discussion_r3164378648))
  - Already removed from main
- **CodeRabbit Major** — token-generation failure swallowed silently ([comment 3164378654](https://github.com/JovieInc/Jovie/pull/7986#discussion_r3164378654))
  - Already wrapped with `logger.error` + `captureError` on main; fallback shape preserved for client compatibility
  - Test: asserts both observability calls fire and the `{ token: null, expiresAt: null }` fallback is returned with status 500
- **CodeRabbit Major** — `useProfileTracking` second network hop ([comment 3164378696](https://github.com/JovieInc/Jovie/pull/7986#discussion_r3164378696))
  - Already fixed on main: visit token is server-minted via the `visitTrackingToken` prop and threaded through `useProfileShell` → `useProfileVisitTracking`. When no token is provided, the visit beacon fires immediately and async enrichment runs as best-effort

Replies posted on each original bot comment.

## Tests added (7)

`apps/web/tests/unit/api/audience/visit-token.test.ts`
1. malformed `profileId` → 400, no DB / no signing
2. missing `profileId` → 400
3. rate-limit exhaustion → 429 with `Retry-After` + `X-RateLimit-*` headers
4. unknown profile UUID → 404, never mints a token
5. valid profile under limit → returns signed token
6. DB lookup failure → 500 + `logger.error` + `captureError`
7. signing failure → 500 with fallback shape + `logger.error` + `captureError`

## Test plan

- [x] `pnpm --filter web exec tsc --noEmit` clean
- [x] `pnpm biome check apps/web/tests/unit/api/audience/visit-token.test.ts` clean
- [x] `pnpm --filter web exec vitest run tests/unit/api/audience/visit-token.test.ts` — 7 passed
- [x] `pnpm --filter web exec vitest run tests/unit/profile/useProfileTracking.test.tsx` — 2 passed (regression check)

## Risk

Test-only change. No product code modified.

## Refs

- Linear: JOV-1964
- Original PR: #7986
- Sibling PRs: JOV-1964 part B (intake email-verified gate) + part C (access-request status precedence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for the audience visit token API endpoint, including validation, rate limiting, error handling, and successful token minting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->