### PR TITLE
fix(tests): throw on missing scroll container in assertion helper

### DIFF
--- a/apps/web/tests/helpers/scroll-assertions.ts
+++ b/apps/web/tests/helpers/scroll-assertions.ts
@@ -26,7 +26,13 @@ async function readScrollMetrics(
     const el = sel
       ? (document.querySelector(sel) as HTMLElement | null)
       : (document.scrollingElement as HTMLElement | null);
-    if (!el) return { scrollTop: 0, scrollHeight: 0, clientHeight: 0 };
+    if (!el) {
+      throw new Error(
+        sel
+          ? `Scroll container not found for selector: ${sel}`
+          : 'Document scrollingElement is null — cannot measure scroll metrics'
+      );
+    }
     return {
       scrollTop: el.scrollTop,
       scrollHeight: el.scrollHeight,


### PR DESCRIPTION
## Summary

Single-commit follow-up to #8264 (which bundled the bulk of the scroll-fix work via the stacked-PR squash). This PR addresses the **CodeRabbit nitpick** that wasn't carried into the squash: \`readScrollMetrics\` now throws an explicit error when the scroll container can't be found instead of returning zeroed metrics.

Why it matters: zeroed metrics defer the failure to the caller's \`expect()\` assertions, producing confusing test output ("expected scrollHeight > 0 but got 0"). Throwing immediately gives the maintainer a precise diagnostic with the bad selector in the message.

## Changes

- \`apps/web/tests/helpers/scroll-assertions.ts\` — \`readScrollMetrics\` throws with a descriptive message:
  - \`Scroll container not found for selector: <selector>\` when a selector was passed but didn't match
  - \`Document scrollingElement is null — cannot measure scroll metrics\` when no selector was passed and the document has no scrolling element

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm biome check\` clean
- [x] Pre-commit hook passed (biome, eslint, a11y, turbo-local typecheck)
- [ ] CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertion reliability for scroll container verification with explicit error reporting when containers cannot be properly resolved, enabling more effective test debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->