### PR TITLE
fix: reject invalid tip intent amounts

### DIFF
--- a/apps/web/app/api/create-tip-intent/route.ts
+++ b/apps/web/app/api/create-tip-intent/route.ts
@@ -42,13 +42,15 @@ function hashHandleForMetadata(handle: string): string {
 
 /**
  * Convert amount to cents with overflow protection.
- * Converts dollars (potentially fractional) to cents, then clamps.
+ * Converts dollars to cents and fails closed if validation ever drifts.
  * Maximum: 50000 cents ($500), Minimum: 100 cents ($1)
  */
-function amountToCents(amount: number): number {
-  // Convert to cents first, then clamp
+function amountToCents(amount: number): number | null {
   const cents = Math.round(amount * 100);
-  return Math.max(100, Math.min(50000, cents));
+  if (!Number.isSafeInteger(cents) || cents < 100 || cents > 50000) {
+    return null;
+  }
+  return cents;
 }
 
 export async function POST(req: NextRequest) {
@@ -107,6 +109,12 @@ export async function POST(req: NextRequest) {
 
     // Convert to cents with overflow protection
     const amountInCents = amountToCents(amount);
+    if (amountInCents === null) {
+      return NextResponse.json(
+        { error: 'Invalid tip request' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
 
     // Look up the creator profile to store an immutable profile_id in metadata.
     // This avoids issues with handle renames and keeps PII out of Stripe metadata.

--- a/apps/web/tests/unit/api/tip/create-tip-intent.test.ts
+++ b/apps/web/tests/unit/api/tip/create-tip-intent.test.ts
@@ -77,7 +77,7 @@ describe('POST /api/create-tip-intent', () => {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        amount: -100,
+        amount: 0,
         handle: 'taylorswift',
       }),
     });
@@ -87,6 +87,7 @@ describe('POST /api/create-tip-intent', () => {
 
     expect(response.status).toBe(400);
     expect(data.error).toBeDefined();
+    expect(mockStripePaymentIntentsCreate).not.toHaveBeenCalled();
   });
 
   it('returns 400 for invalid handle', async () => {


### PR DESCRIPTION
Linear: JOV-1894

## Summary
- reject tip intent amounts outside the validated cent range instead of clamping
- add a regression test for amount: 0 to ensure Stripe is not called

## Testing
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/api/tip/create-tip-intent.test.ts tests/unit/validation/payments.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- pre-commit hook: next:proxy-guard, biome, eslint, web typecheck
- pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

## Risk
Payment-adjacent route. Keep this PR human-gated; do not auto-land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tip amount validation now rejects invalid or unsafe amounts, returning a clear 400 error and preventing creation of payment intents with out-of-range or non-integer cent values.

* **Tests**
  * Tests updated to cover invalid-amount requests and confirm no payment processing is initiated when validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->