### PR TITLE
test: cover investor portal route qa slug

### DIFF
--- a/apps/web/content/investors/manifest.json
+++ b/apps/web/content/investors/manifest.json
@@ -1,0 +1,14 @@
+{
+  "pages": [
+    {
+      "slug": "memo",
+      "file": "investor-memo.md",
+      "title": "Investor Memo",
+      "nav": true
+    }
+  ],
+  "deck": {
+    "slides": [],
+    "downloadFilename": "Jovie-Pitch-Deck.pdf"
+  }
+}

--- a/apps/web/scripts/route-qa.ts
+++ b/apps/web/scripts/route-qa.ts
@@ -368,7 +368,12 @@ export async function expandDynamicRoute(
         buildDynamicCase(
           `/investor-portal/${page.slug}`,
           `${source} -> investor-portal/${page.slug}`,
-          route
+          route,
+          {
+            expectedState: 'not-found',
+            notes:
+              'Investor portal routes are token-gated and intentionally return not-found without an investor token.',
+          }
         )
       );
     } catch (error) {

--- a/apps/web/tests/scripts/route-qa.test.ts
+++ b/apps/web/tests/scripts/route-qa.test.ts
@@ -57,11 +57,13 @@ describe('route-qa not-found detection', () => {
   it('expands investor portal slugs as token-gated not-found cases', async () => {
     await expect(
       expandDynamicRoute('/investor-portal/[slug]', 'route-qa-test')
-    ).resolves.toEqual([
-      expect.objectContaining({
-        path: '/investor-portal/memo',
-        expectedState: 'not-found',
-      }),
-    ]);
+    ).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: '/investor-portal/memo',
+          expectedState: 'not-found',
+        }),
+      ])
+    );
   });
 });

--- a/apps/web/tests/scripts/route-qa.test.ts
+++ b/apps/web/tests/scripts/route-qa.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  expandDynamicRoute,
   isNotFoundLike,
   resolveRouteCaseTimeoutMs,
   settleWithTimeout,
@@ -51,5 +52,16 @@ describe('route-qa not-found detection', () => {
 
   it('uses a two minute per-route timeout by default', () => {
     expect(resolveRouteCaseTimeoutMs()).toBe(120_000);
+  });
+
+  it('expands investor portal slugs as token-gated not-found cases', async () => {
+    await expect(
+      expandDynamicRoute('/investor-portal/[slug]', 'route-qa-test')
+    ).resolves.toEqual([
+      expect.objectContaining({
+        path: '/investor-portal/memo',
+        expectedState: 'not-found',
+      }),
+    ]);
   });
 });


### PR DESCRIPTION
Linear: JOV-1896

## Summary
- add the investor content manifest so `/investor-portal/[slug]` expands in route QA
- mark generated investor slug cases as token-gated not-found expectations
- add a unit regression for investor slug expansion

## Testing
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/scripts/route-qa.test.ts lib/investors/__tests__/manifest.test.ts --config=vitest.config.mts
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- pre-commit hook: next:proxy-guard, biome, eslint, web typecheck
- pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

## Route QA
- ROUTE_QA_FILTER=investor-portal ROUTE_QA_OUTPUT_DIR=jov-1896 JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run qa:routes
- Result: failed because the local app/auth bootstrap probe could not connect (`fetch failed`). The produced matrix includes `/investor-portal/memo` with `expectedState: not-found`.

## Risk
Token-gated investor route. Keep this PR human-gated; do not auto-land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched "Investor Memo" page in the investor section, now visible in primary navigation
  * Added investor pitch deck for download

* **Tests**
  * Added QA coverage to validate investor-portal access behavior, ensuring token-gated routes are reported as not-found where appropriate
<!-- end of auto-generated comment: release notes by coderabbit.ai -->