### PR TITLE
fix(a11y): improve changelog empty-state contrast

### DIFF
--- a/apps/web/app/(marketing)/changelog/page.tsx
+++ b/apps/web/app/(marketing)/changelog/page.tsx
@@ -138,7 +138,9 @@ export default async function ChangelogPage() {
         <div className='marketing-divider mb-10' />
         <div className='max-w-3xl'>
           {releases.length === 0 ? (
-            <p className='opacity-40'>No updates yet. Check back soon!</p>
+            <p className='text-secondary-token'>
+              No updates yet. Check back soon!
+            </p>
           ) : (
             <div className='space-y-10'>
               {releases.map(release => (


### PR DESCRIPTION
## Summary
- Fixes JOV-1966 by replacing the low-opacity changelog empty-state copy with `text-secondary-token`.
- Restores WCAG AA contrast for the marketing axe surface that renders the changelog empty state.

## Checks
- `node --version` -> `v22.22.1`
- `pnpm --version` -> `9.15.4`
- `pnpm biome check --write apps/web/app/'(marketing)'/changelog/page.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `BASE_URL=http://127.0.0.1:3210 PUBLIC_SURFACE_FILTER=marketing-blog-post PLAYWRIGHT_WORKERS=1 pnpm --filter @jovie/web exec playwright test tests/e2e/axe-audit.spec.ts --project=chromium --grep "marketing-blog-post passes WCAG AA" --no-deps --reporter=line`
- Pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`