### PR TITLE
fix: show listen DSP actions with releases

### DIFF
--- a/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
@@ -447,18 +447,31 @@ export function ProfilePrimaryTabPanel({
     if (visibleReleases.length > 0) {
       return (
         <div
-          className={NATIVE_PANEL_CLASS_NAME}
+          className='-mx-4 space-y-4 pb-2'
           data-testid='profile-primary-tab-releases'
         >
-          <div className='px-4 pb-2 pt-3'>
-            <h2 className='text-[22px] font-[680] leading-none tracking-[-0.025em] text-white'>
-              Music
-            </h2>
+          <div>
+            <div className='px-4 pb-2 pt-3'>
+              <h2 className='text-[22px] font-[680] leading-none tracking-[-0.025em] text-white'>
+                Music
+              </h2>
+            </div>
+            <ReleasesView
+              releases={visibleReleases}
+              artistHandle={artist.handle}
+              artistName={artist.name}
+            />
           </div>
-          <ReleasesView
-            releases={visibleReleases}
-            artistHandle={artist.handle}
-            artistName={artist.name}
+          <StaticListenInterface
+            artist={artist}
+            handle={artist.handle}
+            dspsOverride={dsps}
+            enableDynamicEngagement={enableDynamicEngagement}
+            renderMode={renderMode}
+            containerClassName='max-w-none px-4'
+            providerButtonClassName='rounded-[22px] border-white/8 bg-white/[0.045] px-4 py-3.5 text-white hover:bg-white/[0.08]'
+            emptyStateClassName='border-white/8 bg-white/[0.04] shadow-none'
+            hideHelpText
           />
         </div>
       );

--- a/apps/web/components/features/profile/templates/ProfileDesktopSurface.test.tsx
+++ b/apps/web/components/features/profile/templates/ProfileDesktopSurface.test.tsx
@@ -82,8 +82,31 @@ vi.mock('@/features/profile/ProfileUnifiedDrawer', () => ({
   ),
 }));
 
+vi.mock('@/features/profile/StaticListenInterface', () => ({
+  StaticListenInterface: ({
+    dspsOverride = [],
+  }: {
+    readonly dspsOverride?: ReadonlyArray<{ readonly name: string }>;
+  }) => (
+    <div data-testid='mock-static-listen-interface'>
+      {dspsOverride.map(dsp => (
+        <button key={dsp.name} type='button'>
+          {dsp.name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
 vi.mock('@/lib/profile-dsps', () => ({
-  getCanonicalProfileDSPs: () => [],
+  getCanonicalProfileDSPs: () => [
+    {
+      key: 'spotify',
+      name: 'Spotify',
+      url: 'https://open.spotify.com/artist/4u',
+      config: {},
+    },
+  ],
 }));
 
 vi.mock('@/lib/dsp', () => ({
@@ -158,5 +181,32 @@ describe('ProfileDesktopSurface', () => {
       'data-presentation',
       'modal'
     );
+  });
+
+  it('renders DSP actions in desktop listen mode', () => {
+    render(
+      <ProfileDesktopSurface
+        artist={artist}
+        socialLinks={[]}
+        contacts={contacts}
+        photoDownloadSizes={[]}
+        drawerOpen={false}
+        drawerView='menu'
+        activeMode='listen'
+        onModeSelect={vi.fn()}
+        onDrawerOpenChange={vi.fn()}
+        onDrawerViewChange={vi.fn()}
+        onOpenMenu={vi.fn()}
+        onPlayClick={vi.fn()}
+        profileHref='/timwhite'
+        isSubscribed={false}
+        contentPrefs={contentPrefs}
+        onTogglePref={vi.fn()}
+        onUnsubscribe={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('mock-static-listen-interface')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Spotify' })).toBeVisible();
   });
 });

--- a/apps/web/components/features/profile/templates/ProfileDesktopSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileDesktopSurface.tsx
@@ -30,6 +30,7 @@ import type {
 import type { DrawerView } from '@/features/profile/ProfileUnifiedDrawer';
 import { ProfileUnifiedDrawer } from '@/features/profile/ProfileUnifiedDrawer';
 import { resolveProfileSurfaceState } from '@/features/profile/profile-surface-state';
+import { StaticListenInterface } from '@/features/profile/StaticListenInterface';
 import { ReleasesView } from '@/features/profile/views/ReleasesView';
 import { sortDSPsByGeoPopularity } from '@/lib/dsp';
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
@@ -672,6 +673,17 @@ export function ProfileDesktopSurface({
           )}
         </DesktopSurfaceCard>
         <div className='grid gap-3.5'>
+          <DesktopSurfaceCard title='Listen'>
+            <StaticListenInterface
+              artist={artist}
+              handle={artist.handle}
+              dspsOverride={mergedDSPs}
+              containerClassName='max-w-none'
+              providerButtonClassName='rounded-[18px] border-white/8 bg-white/[0.045] px-4 py-3.5 text-white hover:bg-white/[0.08]'
+              emptyStateClassName='rounded-[18px] border-white/8 bg-white/[0.04] shadow-none'
+              hideHelpText
+            />
+          </DesktopSurfaceCard>
           <DesktopSurfaceCard title='Latest Release'>
             <div className='space-y-4'>
               <div className='relative aspect-square overflow-hidden rounded-[22px] border border-white/8'>

--- a/apps/web/tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx
+++ b/apps/web/tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ProfilePrimaryTabPanel } from '@/features/profile/ProfilePrimaryTabPanel';
+import type { AvailableDSP } from '@/lib/dsp';
+import type { Artist } from '@/types/db';
+import type { NotificationContentType } from '@/types/notifications';
+
+vi.mock('@/features/profile/views/ReleasesView', () => ({
+  ReleasesView: () => <div data-testid='mock-releases-view'>Releases</div>,
+}));
+
+vi.mock('@/features/profile/StaticListenInterface', () => ({
+  StaticListenInterface: ({
+    dspsOverride = [],
+  }: {
+    readonly dspsOverride?: ReadonlyArray<AvailableDSP>;
+  }) => (
+    <div data-testid='mock-static-listen-interface'>
+      {dspsOverride.map(dsp => (
+        <button key={dsp.key} type='button'>
+          {dsp.name}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+const artist = {
+  id: 'artist-1',
+  owner_user_id: 'user-1',
+  name: 'Dua Lipa',
+  handle: 'dualipa',
+  spotify_id: 'artist-spotify-id',
+  image_url: null,
+  tagline: null,
+  location: null,
+  hometown: null,
+  career_highlights: null,
+  is_verified: true,
+  active_since_year: null,
+  published: true,
+  is_featured: false,
+  marketing_opt_out: false,
+  created_at: '2026-04-24T00:00:00.000Z',
+  settings: null,
+} satisfies Artist;
+
+const contentPrefs: Record<NotificationContentType, boolean> = {
+  newMusic: false,
+  tourDates: false,
+  merch: false,
+  general: false,
+};
+
+const dsps: AvailableDSP[] = [
+  {
+    key: 'spotify',
+    name: 'Spotify',
+    url: 'https://open.spotify.com/artist/artist-spotify-id',
+    config: {
+      name: 'Spotify',
+      color: '#1DB954',
+      textColor: '#FFFFFF',
+      logoSvg: '<svg />',
+    },
+  },
+];
+
+describe('ProfilePrimaryTabPanel listen mode', () => {
+  it('renders releases and DSP actions together', () => {
+    render(
+      <ProfilePrimaryTabPanel
+        mode='listen'
+        artist={artist}
+        dsps={dsps}
+        isSubscribed={false}
+        contentPrefs={contentPrefs}
+        onTogglePref={vi.fn()}
+        onUnsubscribe={vi.fn()}
+        isUnsubscribing={false}
+        releases={[
+          {
+            id: 'release-1',
+            title: 'Training Season',
+            slug: 'training-season',
+            releaseType: 'single',
+            releaseDate: '2026-04-24',
+            artworkUrl: null,
+            artistNames: ['Dua Lipa'],
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByTestId('mock-releases-view')).toBeVisible();
+    expect(screen.getByTestId('mock-static-listen-interface')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Spotify' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
Linear: JOV-1892

## Summary
- render DSP listen actions in desktop listen mode
- keep DSP listen actions visible on compact/mobile listen mode when releases exist
- add focused regressions for desktop and primary tab listen behavior

## Testing
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run components/features/profile/templates/ProfileDesktopSurface.test.tsx tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- pre-commit hook: next:proxy-guard, biome, eslint, a11y:check:staged, web typecheck
- pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

## Browser QA
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec playwright test tests/e2e/smartlink-experience.spec.ts --project=chromium --grep "listen mode"
- Result: stopped after hanging for several minutes with no reporter output. Needs a live browser rerun in CI or a stable local dev server.

## Risk
Public unauthenticated smart-link/listen UI. Draft until CI and browser lane are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Listen" section to user profiles displaying integrated music streaming services (including Spotify)
  * Reorganized profile layout to present music releases and streaming platforms together in a unified view

<!-- end of auto-generated comment: release notes by coderabbit.ai -->