### PR TITLE
fix(tests): pin viewport before overflow pre-check (Greptile P2)

### DIFF
--- a/apps/web/tests/e2e/hud-scroll.spec.ts
+++ b/apps/web/tests/e2e/hud-scroll.spec.ts
@@ -93,6 +93,13 @@ test.describe('App-shell scroll-pane regression', () => {
         'dev-auth bypass not enabled — set E2E_USE_TEST_AUTH_BYPASS=1'
       );
 
+      // Pin the viewport BEFORE the overflow pre-check so it matches the
+      // viewport that `assertScrollable` will measure at. Without this, a
+      // taller runner-default viewport could let the pre-check pass while
+      // the helper's stricter overflow precondition fails at 1280x720,
+      // surfacing a hard error where we intended a clean test.skip.
+      await page.setViewportSize({ width: 1280, height: 720 });
+
       await page.goto(route.bypass);
       await page.waitForURL(route.expectedPath, { timeout: 30_000 });
 


### PR DESCRIPTION
## Summary

Greptile P2 follow-up to #8257 / #8264. The viewport-mismatch fix was committed locally but stranded when PR #8257 auto-merged before I could re-push.

The overflow pre-check on \`apps/web/tests/e2e/hud-scroll.spec.ts\` ran at whatever viewport the Playwright runner had by default, but \`assertScrollable\` then called \`setViewportSize({ width: 1280, height: 720 })\` before measuring. If the runner default was taller, a route that overflowed at the default but not at 1280×720 would skip the \`test.skip()\` path and hit a hard failure inside the helper's precondition with a misleading message.

## Fix

Set \`page.setViewportSize({ width: 1280, height: 720 })\` before the pre-check so both measurements happen at the same viewport size.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm biome check\` clean
- [ ] CI runs the spec without the misleading-failure path triggering

## Cost impact

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of scroll functionality tests by pinning viewport dimensions to ensure consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->