### PR TITLE
docs(cron): record LLM model usage audit and OpenRouter swap status (JOV-1970)

### DIFF
--- a/docs/CRON_REGISTRY.md
+++ b/docs/CRON_REGISTRY.md
@@ -95,6 +95,18 @@ These have their own Vercel schedule OR exist as callable endpoints (also invoke
 | `/api/cron/schedule-release-notifications` | 60s | Schedules release-day notifications | `daily-maintenance` |
 | `/api/cron/send-release-notifications` | 120s | Sends notifications; recovers stuck rows >10min; max 100/run | `frequent` |
 
+## LLM Model Usage in Web App Crons
+
+> **OpenRouter free-model swap status (JOV-1970):** OpenRouter is not yet integrated in `apps/web/`. The three LLM-calling crons currently use Anthropic models directly. Swap to `nvidia/llama-3.3-nemotron-super-49b-v1:free` is deferred to JOV-1970.
+
+| Cron | File | SDK | Model |
+|------|------|-----|-------|
+| `generate-insights` | `lib/services/insights/insight-generator.ts` | Vercel AI SDK Gateway (`@ai-sdk/gateway`) | `anthropic/claude-haiku-4-5-20251001` (via `INSIGHT_MODEL` constant) |
+| `summarize-interviews` | `lib/interviews/summarize.ts` | Anthropic SDK directly (`@anthropic-ai/sdk`) | `claude-haiku-4-5-20251001` (hard-coded) |
+| `generate-playlist` | `lib/playlists/generate-concept.ts` + `curate-tracklist.ts` | Anthropic SDK directly (`@anthropic-ai/sdk`) | `claude-haiku-4-5-20251001` (concept) + `claude-sonnet-4-20250514` (tracklist, hard-coded) |
+
+To swap these to OpenRouter free Nemotron, see JOV-1970 for the full integration checklist.
+
 ## Adding Logic to an Existing Cron
 
 1. **Prefer adding a sub-job** to `frequent` (sub-hourly) or `daily-maintenance` (daily) rather than creating a new route


### PR DESCRIPTION
## Summary

Investigation task for resuming P0 Watch / Agent Health Watcher / Cost Router Watchdog crons and swapping LLM crons to OpenRouter free Nemotron.

**Task 1 — Resume Hermes crons:** No action required. All three crons recovered automatically from the 2026-05-07 402 storm. Confirmed `enabled: true`, `state: scheduled`, `last_status: ok` in `~/.hermes/cron/jobs.json`. Hermes default model is already `nvidia/nemotron-3-super-120b-a12b:free`.

**Task 2 — Swap web app LLM crons:** STOPPED per task rule — OpenRouter is not integrated in `apps/web/`. No `@openrouter/ai-sdk-provider`, no `OPENROUTER_API_KEY`, no runtime OpenRouter usage. Swap deferred to **JOV-1970** with full integration checklist.

## Changes

- `docs/CRON_REGISTRY.md` — Added "LLM Model Usage in Web App Crons" section documenting current model+SDK usage for `generate-insights`, `summarize-interviews`, and `generate-playlist`. Links to JOV-1970 for the OpenRouter swap.

## Cost Impact

- **No new API calls introduced.** This PR is documentation only.
- JOV-1970 (OpenRouter swap) will eliminate Anthropic Haiku costs for 3 crons — estimated savings documented in JOV-1970.

## Verification

- No TypeScript changes — typecheck not required.
- No Biome-linted code changed — lint not required.
- Docs-only change.

<!-- linear-issue-id:JOV-1970 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation detailing AI model usage in background jobs, including which jobs use AI, the integration methods, and currently configured models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->