### PR TITLE
feat(agentos): add Vercel Workflow dry-run proof

### DIFF
--- a/apps/web/app/api/admin/agent-os/workflows/dry-run/route.ts
+++ b/apps/web/app/api/admin/agent-os/workflows/dry-run/route.ts
@@ -1,0 +1,110 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { start } from 'workflow/api';
+import { z } from 'zod';
+import { areAgentOsWorkflowsEnabled } from '@/lib/agent-os/workflows';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import {
+  AgentOsDryRunWorkflowInputSchema,
+  agentOsDryRunWorkflow,
+} from '@/workflows/agent-os-dry-run';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+function createDefaultSourceRunId() {
+  return `agentos-dry-run-${crypto.randomUUID()}`;
+}
+
+async function authorizeAdmin() {
+  const entitlements = await getCurrentUserEntitlements();
+
+  if (!entitlements.isAuthenticated) {
+    return { ok: false as const, status: 401, error: 'Unauthorized' };
+  }
+
+  if (!entitlements.isAdmin) {
+    return { ok: false as const, status: 403, error: 'Forbidden' };
+  }
+
+  return {
+    ok: true as const,
+    requestedBy: entitlements.email ?? entitlements.userId ?? 'admin',
+  };
+}
+
+async function readOptionalJson(request: NextRequest): Promise<unknown> {
+  const body = await request.text();
+
+  if (body.trim().length === 0) {
+    return {};
+  }
+
+  return JSON.parse(body);
+}
+
+export async function POST(request: NextRequest) {
+  const admin = await authorizeAdmin();
+
+  if (!admin.ok) {
+    return NextResponse.json(
+      { error: admin.error },
+      { status: admin.status, headers: NO_STORE_HEADERS }
+    );
+  }
+
+  if (!areAgentOsWorkflowsEnabled()) {
+    return NextResponse.json(
+      { error: 'AgentOS workflows are disabled' },
+      { status: 503, headers: NO_STORE_HEADERS }
+    );
+  }
+
+  try {
+    const body = await readOptionalJson(request);
+    const parsedInput = AgentOsDryRunWorkflowInputSchema.parse({
+      ...(typeof body === 'object' && body !== null ? body : {}),
+      requestedBy: admin.requestedBy,
+    });
+    const input = {
+      ...parsedInput,
+      sourceRunId: parsedInput.sourceRunId ?? createDefaultSourceRunId(),
+    };
+    const run = await start(agentOsDryRunWorkflow, [input]);
+
+    return NextResponse.json(
+      {
+        ok: true,
+        runId: run.runId,
+        statusUrl: `/api/admin/agent-os/workflows/runs/${encodeURIComponent(run.runId)}`,
+      },
+      { status: 202, headers: NO_STORE_HEADERS }
+    );
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        { error: 'Malformed JSON request body' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          error: 'Invalid AgentOS dry-run workflow request',
+          issues: error.issues,
+        },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    console.error('[agentOsDryRun] Failed to start workflow', error);
+
+    return NextResponse.json(
+      { error: 'Failed to start AgentOS dry-run workflow' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/api/admin/agent-os/workflows/runs/[runId]/route.ts
+++ b/apps/web/app/api/admin/agent-os/workflows/runs/[runId]/route.ts
@@ -1,0 +1,110 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getRun } from 'workflow/api';
+import { WorkflowRunNotFoundError } from 'workflow/errors';
+import {
+  type AgentRunArtifact,
+  safeParseAgentRunArtifact,
+} from '@/lib/agent-os/artifact';
+import { areAgentOsWorkflowsEnabled } from '@/lib/agent-os/workflows';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+type RunRouteContext = {
+  readonly params: Promise<{ readonly runId: string }>;
+};
+
+async function authorizeAdmin() {
+  const entitlements = await getCurrentUserEntitlements();
+
+  if (!entitlements.isAuthenticated) {
+    return { ok: false as const, status: 401, error: 'Unauthorized' };
+  }
+
+  if (!entitlements.isAdmin) {
+    return { ok: false as const, status: 403, error: 'Forbidden' };
+  }
+
+  return { ok: true as const };
+}
+
+function serializeDate(value: Date | undefined): string | null {
+  return value ? value.toISOString() : null;
+}
+
+async function getCompletedArtifact(
+  status: string,
+  loadReturnValue: () => Promise<unknown>
+): Promise<AgentRunArtifact | null> {
+  if (status !== 'completed') {
+    return null;
+  }
+
+  const parsed = safeParseAgentRunArtifact(await loadReturnValue());
+  return parsed.success ? parsed.data : null;
+}
+
+export async function GET(_request: NextRequest, { params }: RunRouteContext) {
+  const admin = await authorizeAdmin();
+
+  if (!admin.ok) {
+    return NextResponse.json(
+      { error: admin.error },
+      { status: admin.status, headers: NO_STORE_HEADERS }
+    );
+  }
+
+  if (!areAgentOsWorkflowsEnabled()) {
+    return NextResponse.json(
+      { error: 'AgentOS workflows are disabled' },
+      { status: 503, headers: NO_STORE_HEADERS }
+    );
+  }
+
+  const { runId } = await params;
+  const run = getRun<AgentRunArtifact>(runId);
+
+  try {
+    const [status, workflowName, createdAt, startedAt, completedAt] =
+      await Promise.all([
+        run.status,
+        run.workflowName,
+        run.createdAt,
+        run.startedAt,
+        run.completedAt,
+      ]);
+    const artifact = await getCompletedArtifact(status, () => run.returnValue);
+
+    return NextResponse.json(
+      {
+        ok: true,
+        runId,
+        status,
+        workflowName,
+        createdAt: serializeDate(createdAt),
+        startedAt: serializeDate(startedAt),
+        completedAt: serializeDate(completedAt),
+        artifact,
+      },
+      { headers: NO_STORE_HEADERS }
+    );
+  } catch (error) {
+    if (WorkflowRunNotFoundError.is(error)) {
+      return NextResponse.json(
+        { error: `Workflow run ${runId} was not found` },
+        { status: 404, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    console.error('[agentOsDryRun] Failed to load workflow run status', error);
+
+    return NextResponse.json(
+      { error: 'Failed to load workflow run status' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/tests/unit/agent-os/dry-run-workflow.test.ts
+++ b/apps/web/tests/unit/agent-os/dry-run-workflow.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildAgentOsDryRunArtifact,
+  emitAgentOsDryRunArtifact,
+} from '@/workflows/agent-os-dry-run';
+
+const { mockWrite, mockReleaseLock } = vi.hoisted(() => ({
+  mockWrite: vi.fn(),
+  mockReleaseLock: vi.fn(),
+}));
+
+vi.mock('workflow', () => ({
+  getWritable: () => ({
+    getWriter: () => ({
+      write: mockWrite,
+      releaseLock: mockReleaseLock,
+    }),
+  }),
+}));
+
+describe('AgentOS dry-run workflow artifact', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWrite.mockResolvedValue(undefined);
+  });
+
+  it('builds a deterministic, read-only AgentRunArtifact', () => {
+    const artifact = buildAgentOsDryRunArtifact({
+      input: {
+        requestedBy: 'admin@example.com',
+        sourceRunId: 'wrun_123',
+      },
+      createdAt: new Date('2026-05-08T21:30:00.000Z'),
+    });
+
+    expect(artifact).toMatchObject({
+      id: 'agentos-wdk-dry-run-wrun_123',
+      source: 'vercel-workflow',
+      sourceRunId: 'wrun_123',
+      kind: 'workflow',
+      status: 'done',
+      modelRoute: 'deterministic',
+      linearIssueId: 'JOV-1971',
+      adminSurface: '/app/admin/ops',
+      costEstimate: {
+        usd: 0,
+        route: 'deterministic',
+      },
+      metadata: {
+        dryRun: true,
+        requestedBy: 'admin@example.com',
+        runtime: 'vercel-workflow',
+      },
+    });
+    expect(artifact.allowedActions).toEqual(['read', 'summarize']);
+    expect(artifact.forbiddenActions).toEqual(
+      expect.arrayContaining([
+        'write_code',
+        'merge',
+        'deploy',
+        'mutate_linear',
+        'send_outbound',
+        'change_auth',
+        'change_billing',
+        'change_security',
+      ])
+    );
+  });
+
+  it('accepts the longest source run id that still fits the artifact id contract', () => {
+    const sourceRunId = 'a'.repeat(160);
+
+    const artifact = buildAgentOsDryRunArtifact({
+      input: {
+        requestedBy: 'admin@example.com',
+        sourceRunId,
+      },
+      createdAt: new Date('2026-05-08T21:30:00.000Z'),
+    });
+
+    expect(artifact.id).toHaveLength(180);
+    expect(artifact.id).toBe(`agentos-wdk-dry-run-${sourceRunId}`);
+  });
+
+  it('emits the artifact and summary through the workflow writable stream', async () => {
+    const artifact = await emitAgentOsDryRunArtifact({
+      requestedBy: 'admin@example.com',
+      sourceRunId: 'wrun_456',
+    });
+
+    expect(artifact.id).toBe('agentos-wdk-dry-run-wrun_456');
+    expect(mockWrite).toHaveBeenCalledTimes(2);
+    expect(mockWrite).toHaveBeenNthCalledWith(1, {
+      type: 'agent_run_artifact',
+      artifact,
+    });
+    expect(mockWrite).toHaveBeenNthCalledWith(2, {
+      type: 'agent_run_summary',
+      artifactId: artifact.id,
+      status: 'done',
+    });
+    expect(mockReleaseLock).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the writer lock when artifact emission fails', async () => {
+    mockWrite.mockRejectedValueOnce(new Error('stream write failed'));
+
+    await expect(
+      emitAgentOsDryRunArtifact({
+        requestedBy: 'admin@example.com',
+        sourceRunId: 'wrun_fail',
+      })
+    ).rejects.toThrow('stream write failed');
+
+    expect(mockReleaseLock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/tests/unit/agent-os/workflow-routes.test.ts
+++ b/apps/web/tests/unit/agent-os/workflow-routes.test.ts
@@ -1,0 +1,392 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildAgentOsDryRunArtifact } from '@/workflows/agent-os-dry-run';
+
+const {
+  mockAreAgentOsWorkflowsEnabled,
+  mockGetCurrentUserEntitlements,
+  mockGetRun,
+  mockIsWorkflowRunNotFoundError,
+  mockStart,
+} = vi.hoisted(() => ({
+  mockAreAgentOsWorkflowsEnabled: vi.fn(),
+  mockGetCurrentUserEntitlements: vi.fn(),
+  mockGetRun: vi.fn(),
+  mockIsWorkflowRunNotFoundError: vi.fn(),
+  mockStart: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/agent-os/workflows', () => ({
+  areAgentOsWorkflowsEnabled: mockAreAgentOsWorkflowsEnabled,
+}));
+
+vi.mock('@/lib/entitlements/server', () => ({
+  getCurrentUserEntitlements: mockGetCurrentUserEntitlements,
+}));
+
+vi.mock('workflow/api', () => ({
+  getRun: mockGetRun,
+  start: mockStart,
+}));
+
+vi.mock('workflow/errors', () => ({
+  WorkflowRunNotFoundError: {
+    is: mockIsWorkflowRunNotFoundError,
+  },
+}));
+
+const adminEntitlements = {
+  userId: 'user_admin',
+  email: 'admin@example.com',
+  isAuthenticated: true,
+  isAdmin: true,
+};
+
+function request(url: string, init: RequestInit = {}): NextRequest {
+  return new NextRequest(url, init);
+}
+
+describe('AgentOS workflow API routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAreAgentOsWorkflowsEnabled.mockReturnValue(true);
+    mockGetCurrentUserEntitlements.mockResolvedValue(adminEntitlements);
+    mockIsWorkflowRunNotFoundError.mockReturnValue(false);
+    mockStart.mockResolvedValue({ runId: 'wrun_123' });
+  });
+
+  it('fails closed when workflow runtime is disabled', async () => {
+    mockAreAgentOsWorkflowsEnabled.mockReturnValueOnce(false);
+    const { POST } = await import(
+      '@/app/api/admin/agent-os/workflows/dry-run/route'
+    );
+
+    const response = await POST(
+      request('http://localhost/api/admin/agent-os/workflows/dry-run', {
+        method: 'POST',
+      })
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: 'AgentOS workflows are disabled',
+    });
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('requires admin entitlement before starting a dry-run workflow', async () => {
+    mockGetCurrentUserEntitlements.mockResolvedValueOnce({
+      ...adminEntitlements,
+      isAdmin: false,
+    });
+    const { POST } = await import(
+      '@/app/api/admin/agent-os/workflows/dry-run/route'
+    );
+
+    const response = await POST(
+      request('http://localhost/api/admin/agent-os/workflows/dry-run', {
+        method: 'POST',
+      })
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: 'Forbidden' });
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('starts the WDK dry-run workflow with admin-scoped input', async () => {
+    const { POST } = await import(
+      '@/app/api/admin/agent-os/workflows/dry-run/route'
+    );
+
+    const response = await POST(
+      request('http://localhost/api/admin/agent-os/workflows/dry-run', {
+        method: 'POST',
+        body: JSON.stringify({ sourceRunId: 'manual-proof' }),
+      })
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      runId: 'wrun_123',
+      statusUrl: '/api/admin/agent-os/workflows/runs/wrun_123',
+    });
+    expect(mockStart).toHaveBeenCalledWith(expect.any(Function), [
+      {
+        requestedBy: 'admin@example.com',
+        sourceRunId: 'manual-proof',
+      },
+    ]);
+  });
+
+  it('does not let request bodies spoof the admin requester', async () => {
+    const { POST } = await import(
+      '@/app/api/admin/agent-os/workflows/dry-run/route'
+    );
+
+    await POST(
+      request('http://localhost/api/admin/agent-os/workflows/dry-run', {
+        method: 'POST',
+        body: JSON.stringify({
+          requestedBy: 'spoofed@example.com',
+          sourceRunId: 'manual-proof',
+        }),
+      })
+    );
+
+    expect(mockStart).toHaveBeenCalledWith(expect.any(Function), [
+      {
+        requestedBy: 'admin@example.com',
+        sourceRunId: 'manual-proof',
+      },
+    ]);
+  });
+
+  it('generates a stable source run id before enqueueing default dry-run input', async () => {
+    const { POST } = await import(
+      '@/app/api/admin/agent-os/workflows/dry-run/route'
+    );
+
+    await POST(
+      request('http://localhost/api/admin/agent-os/workflows/dry-run', {
+        method: 'POST',
+      })
+    );
+
+    expect(mockStart).toHaveBeenCalledWith(expect.any(Function), [
+      {
+        requestedBy: 'admin@example.com',
+        sourceRunId: expect.stringMatching(/^agentos-dry-run-[0-9a-f-]{36}$/),
+      },
+    ]);
+  });
+
+  it('rejects malformed JSON without starting a workflow run', async () => {
+    const { POST } = await import(
+      '@/app/api/admin/agent-os/workflows/dry-run/route'
+    );
+
+    const response = await POST(
+      request('http://localhost/api/admin/agent-os/workflows/dry-run', {
+        method: 'POST',
+        body: '{',
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Malformed JSON request body',
+    });
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('rejects source run ids that would overflow the artifact id before enqueue', async () => {
+    const { POST } = await import(
+      '@/app/api/admin/agent-os/workflows/dry-run/route'
+    );
+
+    const response = await POST(
+      request('http://localhost/api/admin/agent-os/workflows/dry-run', {
+        method: 'POST',
+        body: JSON.stringify({ sourceRunId: 'a'.repeat(161) }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'Invalid AgentOS dry-run workflow request',
+      issues: [expect.objectContaining({ path: ['sourceRunId'] })],
+    });
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when status is requested while workflows are disabled', async () => {
+    mockAreAgentOsWorkflowsEnabled.mockReturnValueOnce(false);
+    const { GET } = await import(
+      '@/app/api/admin/agent-os/workflows/runs/[runId]/route'
+    );
+
+    const response = await GET(
+      request('http://localhost/api/admin/agent-os/workflows/runs/wrun_123'),
+      { params: Promise.resolve({ runId: 'wrun_123' }) }
+    );
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: 'AgentOS workflows are disabled',
+    });
+    expect(mockGetRun).not.toHaveBeenCalled();
+  });
+
+  it('requires authentication before returning workflow status', async () => {
+    mockGetCurrentUserEntitlements.mockResolvedValueOnce({
+      ...adminEntitlements,
+      isAuthenticated: false,
+      isAdmin: false,
+    });
+    const { GET } = await import(
+      '@/app/api/admin/agent-os/workflows/runs/[runId]/route'
+    );
+
+    const response = await GET(
+      request('http://localhost/api/admin/agent-os/workflows/runs/wrun_123'),
+      { params: Promise.resolve({ runId: 'wrun_123' }) }
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized' });
+    expect(mockGetRun).not.toHaveBeenCalled();
+  });
+
+  it('requires admin entitlement before returning workflow status', async () => {
+    mockGetCurrentUserEntitlements.mockResolvedValueOnce({
+      ...adminEntitlements,
+      isAdmin: false,
+    });
+    const { GET } = await import(
+      '@/app/api/admin/agent-os/workflows/runs/[runId]/route'
+    );
+
+    const response = await GET(
+      request('http://localhost/api/admin/agent-os/workflows/runs/wrun_123'),
+      { params: Promise.resolve({ runId: 'wrun_123' }) }
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: 'Forbidden' });
+    expect(mockGetRun).not.toHaveBeenCalled();
+  });
+
+  it('returns WDK run status and completed artifact', async () => {
+    const completedAt = new Date('2026-05-08T21:35:00.000Z');
+    const artifact = buildAgentOsDryRunArtifact({
+      input: { requestedBy: 'admin@example.com', sourceRunId: 'wrun_123' },
+      createdAt: completedAt,
+    });
+    mockGetRun.mockReturnValueOnce({
+      status: Promise.resolve('completed'),
+      workflowName: Promise.resolve('agentOsDryRunWorkflow'),
+      createdAt: Promise.resolve(completedAt),
+      startedAt: Promise.resolve(completedAt),
+      completedAt: Promise.resolve(completedAt),
+      returnValue: Promise.resolve(artifact),
+    });
+    const { GET } = await import(
+      '@/app/api/admin/agent-os/workflows/runs/[runId]/route'
+    );
+
+    const response = await GET(
+      request('http://localhost/api/admin/agent-os/workflows/runs/wrun_123'),
+      { params: Promise.resolve({ runId: 'wrun_123' }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: true,
+      runId: 'wrun_123',
+      status: 'completed',
+      workflowName: 'agentOsDryRunWorkflow',
+      createdAt: completedAt.toISOString(),
+      startedAt: completedAt.toISOString(),
+      completedAt: completedAt.toISOString(),
+      artifact,
+    });
+  });
+
+  it('does not poll returnValue for an incomplete run', async () => {
+    const createdAt = new Date('2026-05-08T21:35:00.000Z');
+    const run = {
+      status: Promise.resolve('running'),
+      workflowName: Promise.resolve('agentOsDryRunWorkflow'),
+      createdAt: Promise.resolve(createdAt),
+      startedAt: Promise.resolve(createdAt),
+      completedAt: Promise.resolve(undefined),
+      get returnValue() {
+        throw new Error('returnValue should not be read while running');
+      },
+    };
+    mockGetRun.mockReturnValueOnce(run);
+    const { GET } = await import(
+      '@/app/api/admin/agent-os/workflows/runs/[runId]/route'
+    );
+
+    const response = await GET(
+      request('http://localhost/api/admin/agent-os/workflows/runs/wrun_123'),
+      { params: Promise.resolve({ runId: 'wrun_123' }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      runId: 'wrun_123',
+      status: 'running',
+      artifact: null,
+    });
+  });
+
+  it('returns 404 when a run cannot be resolved', async () => {
+    const missingRunError = new Error('missing');
+    mockIsWorkflowRunNotFoundError.mockImplementationOnce(
+      (error: unknown) => error === missingRunError
+    );
+    mockGetRun.mockReturnValueOnce({
+      status: Promise.reject(missingRunError),
+      workflowName: Promise.resolve('agentOsDryRunWorkflow'),
+      createdAt: Promise.resolve(undefined),
+      startedAt: Promise.resolve(undefined),
+      completedAt: Promise.resolve(undefined),
+    });
+    const { GET } = await import(
+      '@/app/api/admin/agent-os/workflows/runs/[runId]/route'
+    );
+
+    const response = await GET(
+      request(
+        'http://localhost/api/admin/agent-os/workflows/runs/wrun_missing'
+      ),
+      { params: Promise.resolve({ runId: 'wrun_missing' }) }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Workflow run wrun_missing was not found',
+    });
+  });
+
+  it('returns 500 when workflow status resolution fails for an existing run', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+    mockGetRun.mockReturnValueOnce({
+      status: Promise.reject(new Error('workflow backend unavailable')),
+      workflowName: Promise.resolve('agentOsDryRunWorkflow'),
+      createdAt: Promise.resolve(undefined),
+      startedAt: Promise.resolve(undefined),
+      completedAt: Promise.resolve(undefined),
+    });
+    const { GET } = await import(
+      '@/app/api/admin/agent-os/workflows/runs/[runId]/route'
+    );
+
+    try {
+      const response = await GET(
+        request('http://localhost/api/admin/agent-os/workflows/runs/wrun_123'),
+        { params: Promise.resolve({ runId: 'wrun_123' }) }
+      );
+
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        error: 'Failed to load workflow run status',
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        '[agentOsDryRun] Failed to load workflow run status',
+        expect.any(Error)
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/apps/web/workflows/agent-os-dry-run.ts
+++ b/apps/web/workflows/agent-os-dry-run.ts
@@ -1,0 +1,196 @@
+import { getWritable } from 'workflow';
+import { z } from 'zod';
+import { APP_ROUTES } from '@/constants/routes';
+import {
+  type AgentRunArtifact,
+  parseAgentRunArtifact,
+} from '@/lib/agent-os/artifact';
+
+const DEFAULT_LINEAR_ISSUE_ID = 'JOV-1971';
+const DEFAULT_LINEAR_ISSUE_URL =
+  'https://linear.app/jovie/issue/JOV-1971/agentos-vercel-workflow-dry-run-artifact-proof';
+const DEFAULT_SOURCE_RUN_ID = 'agentos-dry-run-unspecified';
+const MAX_SOURCE_RUN_ID_LENGTH = 160;
+
+export const AgentOsDryRunWorkflowInputSchema = z
+  .object({
+    requestedBy: z.string().trim().min(1).max(120).nullable().optional(),
+    sourceRunId: z
+      .string()
+      .trim()
+      .min(1)
+      .max(MAX_SOURCE_RUN_ID_LENGTH)
+      .nullable()
+      .optional(),
+    linearIssueId: z.string().trim().min(1).max(80).nullable().optional(),
+    linearIssueUrl: z.string().trim().url().nullable().optional(),
+  })
+  .strict();
+
+export type AgentOsDryRunWorkflowInput = z.infer<
+  typeof AgentOsDryRunWorkflowInputSchema
+>;
+
+export type AgentOsDryRunWorkflowEvent =
+  | {
+      readonly type: 'agent_run_artifact';
+      readonly artifact: AgentRunArtifact;
+    }
+  | {
+      readonly type: 'agent_run_summary';
+      readonly artifactId: string;
+      readonly status: AgentRunArtifact['status'];
+    };
+
+interface BuildAgentOsDryRunArtifactInput {
+  readonly input: AgentOsDryRunWorkflowInput;
+  readonly createdAt?: Date;
+}
+
+function normalizeInput(
+  input: AgentOsDryRunWorkflowInput
+): Required<AgentOsDryRunWorkflowInput> {
+  return {
+    requestedBy: input.requestedBy ?? 'admin-ops',
+    sourceRunId: input.sourceRunId ?? DEFAULT_SOURCE_RUN_ID,
+    linearIssueId: input.linearIssueId ?? DEFAULT_LINEAR_ISSUE_ID,
+    linearIssueUrl: input.linearIssueUrl ?? DEFAULT_LINEAR_ISSUE_URL,
+  };
+}
+
+export function buildAgentOsDryRunArtifact({
+  input,
+  createdAt = new Date(),
+}: BuildAgentOsDryRunArtifactInput): AgentRunArtifact {
+  const normalized = normalizeInput(input);
+  const timestamp = createdAt.toISOString();
+
+  return parseAgentRunArtifact({
+    id: `agentos-wdk-dry-run-${normalized.sourceRunId}`,
+    source: 'vercel-workflow',
+    sourceRunId: normalized.sourceRunId,
+    kind: 'workflow',
+    status: 'done',
+    title: 'AgentOS Vercel Workflow dry run',
+    summary:
+      'Harmless WDK proof run emitted a canonical AgentRunArtifact without mutating external systems.',
+    modelRoute: 'deterministic',
+    allowedActions: ['read', 'summarize'],
+    forbiddenActions: [
+      'classify',
+      'rank',
+      'draft',
+      'dispatch_agent',
+      'write_code',
+      'open_pr',
+      'ready_pr',
+      'merge',
+      'deploy',
+      'mutate_linear',
+      'send_outbound',
+      'mutate_production_data',
+      'change_auth',
+      'change_billing',
+      'change_security',
+    ],
+    humanApprovalRequired: false,
+    humanGate: {
+      required: false,
+      status: 'not_required',
+      reason: null,
+      reviewer: null,
+      reviewedAt: null,
+    },
+    linearIssueId: normalized.linearIssueId,
+    linearIssueUrl: normalized.linearIssueUrl,
+    pullRequestUrl: null,
+    adminSurface: APP_ROUTES.ADMIN_OPS,
+    verificationGates: [
+      {
+        name: 'github.ci',
+        required: true,
+        status: 'queued',
+        evidenceUrl: null,
+        summary: 'CI gate is queued for the implementation PR.',
+        checkedAt: null,
+      },
+      {
+        name: 'gstack.qa.exhaustive',
+        required: true,
+        status: 'queued',
+        evidenceUrl: null,
+        summary:
+          'GStack exhaustive QA gate is queued for the implementation PR.',
+        checkedAt: null,
+      },
+      {
+        name: 'gstack.review',
+        required: true,
+        status: 'queued',
+        evidenceUrl: null,
+        summary: 'GStack review gate is queued for the implementation PR.',
+        checkedAt: null,
+      },
+      {
+        name: 'gstack.ship',
+        required: true,
+        status: 'queued',
+        evidenceUrl: null,
+        summary: 'GStack ship gate is queued for the implementation PR.',
+        checkedAt: null,
+      },
+    ],
+    costEstimate: {
+      usd: 0,
+      route: 'deterministic',
+      inputTokens: 0,
+      outputTokens: 0,
+      notes: 'No model call was made.',
+    },
+    blockedReason: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    metadata: {
+      dryRun: true,
+      requestedBy: normalized.requestedBy,
+      runtime: 'vercel-workflow',
+      proof: 'artifact-emission',
+    },
+  });
+}
+
+export async function emitAgentOsDryRunArtifact(
+  input: AgentOsDryRunWorkflowInput
+): Promise<AgentRunArtifact> {
+  'use step';
+
+  console.log('[agentOsDryRun] START emit artifact');
+  const parsedInput = AgentOsDryRunWorkflowInputSchema.parse(input);
+  const artifact = buildAgentOsDryRunArtifact({ input: parsedInput });
+  const writer = getWritable<AgentOsDryRunWorkflowEvent>().getWriter();
+
+  try {
+    await writer.write({ type: 'agent_run_artifact', artifact });
+    await writer.write({
+      type: 'agent_run_summary',
+      artifactId: artifact.id,
+      status: artifact.status,
+    });
+  } finally {
+    writer.releaseLock();
+  }
+
+  console.log(`[agentOsDryRun] DONE artifactId=${artifact.id}`);
+  return artifact;
+}
+
+export async function agentOsDryRunWorkflow(
+  input: AgentOsDryRunWorkflowInput
+): Promise<AgentRunArtifact> {
+  'use workflow';
+
+  console.log('[agentOsDryRunWorkflow] START');
+  const artifact = await emitAgentOsDryRunArtifact(input);
+  console.log('[agentOsDryRunWorkflow] DONE');
+  return artifact;
+}


### PR DESCRIPTION
## Summary
- Adds a harmless Vercel Workflow dry-run that emits a canonical `AgentRunArtifact`.
- Adds admin-only start/status API routes behind `AGENT_OS_WORKFLOWS_ENABLED`.
- Adds focused tests for artifact emission, admin authorization, kill switch behavior, malformed JSON rejection, source-run-id bounds, input normalization, run-status error handling, and completed-run status parsing.

## Guardrails
- No schedules or production crons.
- No Linear mutation.
- No deploy, merge, or PR authority.
- No paid model calls, outbound sends, production data mutation, or secrets logging.
- CI/GStack remain the merge authority.

## Review Fixes
- Malformed JSON now returns `400` before WDK `start()` is called.
- `sourceRunId` is capped so the derived artifact ID cannot overflow `AgentRunArtifact.id`.
- Default `sourceRunId` generation now happens before WDK enqueue, keeping the workflow step deterministic on retry.
- Run-status polling now separates `WorkflowRunNotFoundError` 404s from runtime/status-resolution 500s.
- Added GET auth coverage for unauthorized and forbidden status-route access.
- Added writer-lock cleanup coverage when workflow stream writes fail.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/workflows/agent-os-dry-run.ts apps/web/app/api/admin/agent-os/workflows/dry-run/route.ts apps/web/app/api/admin/agent-os/workflows/runs/'[runId]'/route.ts apps/web/tests/unit/agent-os/dry-run-workflow.test.ts apps/web/tests/unit/agent-os/workflow-routes.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/agent-os/dry-run-workflow.test.ts tests/unit/agent-os/workflow-routes.test.ts tests/unit/agent-os/workflows.test.ts tests/unit/agent-os/artifact.test.ts --reporter=default` — 4 files, 25 tests passed.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run build` — WDK discovered workflow directives, created the webhook route, and created a manifest with 5 steps, 1 workflow, and 0 classes.
- Push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, and `lint` passed.

Fixes JOV-1971
