### PR TITLE
fix: label changelog signup input

### DIFF
--- a/apps/web/app/(marketing)/changelog/ChangelogEmailSignup.tsx
+++ b/apps/web/app/(marketing)/changelog/ChangelogEmailSignup.tsx
@@ -184,6 +184,7 @@ export function ChangelogEmailSignup() {
                 ref={inputRef}
                 type='email'
                 inputSize='lg'
+                aria-label='Email address for product updates'
                 placeholder='you@example.com'
                 value={email}
                 onChange={e => {


### PR DESCRIPTION
Linear: JOV-1973

## Summary
- Add an explicit accessible name to the changelog/product updates signup email input.
- Fixes the shared A11y (axe) landing blocker on `marketing-blog-post passes WCAG AA`, which reported one visible unlabeled email input.

## Testing
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/\(marketing\)/changelog/ChangelogEmailSignup.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Commit hook: eslint + staged typecheck passed
- Pre-push: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .` passed
- Focused Playwright axe rerun reached the exact `marketing-blog-post passes WCAG AA` test but timed out on local cold `page.goto` to `/blog/the-contact-problem` before assertions; CI remains the authoritative axe gate for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced email input accessibility by adding a descriptive label for screen reader users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->