### PR TITLE
fix: improve changelog rss link contrast

### DIFF
--- a/apps/web/app/(marketing)/changelog/page.tsx
+++ b/apps/web/app/(marketing)/changelog/page.tsx
@@ -126,7 +126,7 @@ export default async function ChangelogPage() {
           )}
           <Link
             href='/changelog/feed.xml'
-            className='text-xs opacity-40 hover:opacity-70 transition-opacity'
+            className='text-xs text-secondary-token transition-colors hover:text-primary-token'
           >
             RSS Feed
           </Link>


### PR DESCRIPTION
Linear: JOV-1977

## Summary
- Replace opacity-muted RSS link styling with explicit secondary text color on the changelog header.
- Fixes the refreshed axe `marketing-blog-post` color-contrast failure for `/changelog/feed.xml`.

## Testing
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/\(marketing\)/changelog/page.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Commit hook: eslint + staged typecheck passed
- Pre-push: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the RSS Feed link styling to provide enhanced visual feedback during interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->