### PR TITLE
feat(agentos): add admin run artifact panel

### DIFF
--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -4,10 +4,12 @@ import { Loader2, Rocket } from 'lucide-react';
 import Image from 'next/image';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
+import { AgentOsRunsPanel } from '@/components/features/admin/agent-os';
 import { ContentMetricCard } from '@/components/molecules/ContentMetricCard';
 import { ContentMetricRow } from '@/components/molecules/ContentMetricRow';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { QRCode } from '@/components/molecules/QRCode';
+import { AGENT_OS_ADMIN_FIXTURE_ARTIFACTS } from '@/lib/agent-os/fixtures';
 import {
   getDefaultStatusTone,
   getDeploymentLabel,
@@ -634,6 +636,10 @@ export function HudDashboardClient({
           </div>
         ) : null}
       </ContentSurfaceCard>
+
+      {isShell && metrics.accessMode === 'admin' ? (
+        <AgentOsRunsPanel artifacts={AGENT_OS_ADMIN_FIXTURE_ARTIFACTS} />
+      ) : null}
 
       <ContentSurfaceCard
         surface='details'

--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -4,12 +4,10 @@ import { Loader2, Rocket } from 'lucide-react';
 import Image from 'next/image';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
-import { AgentOsRunsPanel } from '@/components/features/admin/agent-os';
 import { ContentMetricCard } from '@/components/molecules/ContentMetricCard';
 import { ContentMetricRow } from '@/components/molecules/ContentMetricRow';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { QRCode } from '@/components/molecules/QRCode';
-import { AGENT_OS_ADMIN_FIXTURE_ARTIFACTS } from '@/lib/agent-os/fixtures';
 import {
   getDefaultStatusTone,
   getDeploymentLabel,
@@ -636,10 +634,6 @@ export function HudDashboardClient({
           </div>
         ) : null}
       </ContentSurfaceCard>
-
-      {isShell && metrics.accessMode === 'admin' ? (
-        <AgentOsRunsPanel artifacts={AGENT_OS_ADMIN_FIXTURE_ARTIFACTS} />
-      ) : null}
 
       <ContentSurfaceCard
         surface='details'

--- a/apps/web/app/app/(shell)/admin/ops/page.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/page.tsx
@@ -1,8 +1,10 @@
 import { Maximize2 } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { AgentOsRunsPanel } from '@/components/features/admin/agent-os';
 import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
 import { APP_ROUTES } from '@/constants/routes';
+import { AGENT_OS_ADMIN_FIXTURE_ARTIFACTS } from '@/lib/agent-os/fixtures';
 import { getHudMetrics } from '@/lib/hud/metrics';
 import { NOINDEX_ROBOTS } from '@/lib/seo/noindex-metadata';
 import { HudDashboardClient } from './HudDashboardClient';
@@ -85,6 +87,7 @@ export default async function AdminOpsPage({
         density='shell'
         presentationMode='shell'
       />
+      <AgentOsRunsPanel artifacts={AGENT_OS_ADMIN_FIXTURE_ARTIFACTS} />
     </AdminToolPage>
   );
 }

--- a/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
+++ b/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { Badge } from '@jovie/ui';
+import type { CellContext, ColumnDef } from '@tanstack/react-table';
+import { createColumnHelper } from '@tanstack/react-table';
+import { Bot, GitPullRequestArrow } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
+import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
+import { TableEmptyState, UnifiedTable } from '@/components/organisms/table';
+import type { AgentRunArtifact } from '@/lib/agent-os/artifact';
+import { ApprovalQueuePanel } from './ApprovalQueuePanel';
+import { ArtifactDrawer } from './ArtifactDrawer';
+import { WorkflowRunRow } from './WorkflowRunRow';
+import { WorkflowStatusPill } from './WorkflowStatusPill';
+
+const columnHelper = createColumnHelper<AgentRunArtifact>();
+
+function countPassedRequiredGates(artifact: AgentRunArtifact): string {
+  const required = artifact.verificationGates.filter(gate => gate.required);
+  const requiredTotal = required.length;
+  const passed = required.filter(gate => gate.status === 'passed').length;
+
+  if (requiredTotal === 0) {
+    return `${artifact.verificationGates.length} gates`;
+  }
+
+  return `${passed}/${requiredTotal}`;
+}
+
+function renderRunCell({ row }: CellContext<AgentRunArtifact, unknown>) {
+  const artifact = row.original;
+
+  return (
+    <div className='min-w-0'>
+      <p className='truncate text-[13px] font-[560] text-primary-token'>
+        {artifact.title}
+      </p>
+      <p className='mt-1 line-clamp-2 text-[11.5px] leading-4 text-tertiary-token'>
+        {artifact.summary}
+      </p>
+    </div>
+  );
+}
+
+function renderStatusCell({ row }: CellContext<AgentRunArtifact, unknown>) {
+  return <WorkflowStatusPill status={row.original.status} />;
+}
+
+function renderRouteCell({ row }: CellContext<AgentRunArtifact, unknown>) {
+  return (
+    <div className='grid gap-1 text-[11.5px] text-secondary-token'>
+      <span className='truncate font-[520] text-primary-token'>
+        {row.original.modelRoute}
+      </span>
+      <span className='truncate text-tertiary-token'>
+        {row.original.source}
+      </span>
+    </div>
+  );
+}
+
+function renderGateCell({ row }: CellContext<AgentRunArtifact, unknown>) {
+  return (
+    <span className='text-[12px] font-[540] text-primary-token tabular-nums'>
+      {countPassedRequiredGates(row.original)}
+    </span>
+  );
+}
+
+function renderHumanGateCell({ row }: CellContext<AgentRunArtifact, unknown>) {
+  if (!row.original.humanApprovalRequired) {
+    return (
+      <span className='text-[12px] text-tertiary-token'>Not required</span>
+    );
+  }
+
+  return (
+    <Badge
+      variant={
+        row.original.humanGate.status === 'approved' ? 'success' : 'warning'
+      }
+      size='sm'
+    >
+      {row.original.humanGate.status === 'approved'
+        ? 'Approved'
+        : 'Review Required'}
+    </Badge>
+  );
+}
+
+const AGENT_OS_COLUMNS: ColumnDef<AgentRunArtifact, unknown>[] = [
+  columnHelper.display({
+    id: 'run',
+    header: 'Run',
+    cell: renderRunCell,
+    size: 300,
+    meta: { className: 'min-w-[240px]' },
+  }),
+  columnHelper.display({
+    id: 'status',
+    header: 'Status',
+    cell: renderStatusCell,
+    size: 90,
+  }),
+  columnHelper.display({
+    id: 'route',
+    header: 'Route',
+    cell: renderRouteCell,
+    size: 120,
+  }),
+  columnHelper.display({
+    id: 'gates',
+    header: 'Gates',
+    cell: renderGateCell,
+    size: 80,
+  }),
+  columnHelper.display({
+    id: 'humanGate',
+    header: 'Approval',
+    cell: renderHumanGateCell,
+    size: 140,
+  }),
+];
+
+function getRowClassName(artifact: AgentRunArtifact) {
+  return artifact.status === 'blocked' || artifact.status === 'failed'
+    ? 'group bg-surface-0 hover:bg-(--linear-row-hover)'
+    : 'group hover:bg-(--linear-row-hover)';
+}
+
+interface AgentOsRunsPanelProps {
+  readonly artifacts: readonly AgentRunArtifact[];
+}
+
+export function AgentOsRunsPanel({ artifacts }: AgentOsRunsPanelProps) {
+  const [selectedId, setSelectedId] = useState<string | null>(
+    artifacts[0]?.id ?? null
+  );
+  const columns = useMemo<ColumnDef<AgentRunArtifact, unknown>[]>(
+    () => AGENT_OS_COLUMNS,
+    []
+  );
+  const rows = useMemo(() => [...artifacts], [artifacts]);
+  const selectedArtifact =
+    rows.find(artifact => artifact.id === selectedId) ?? rows[0] ?? null;
+
+  return (
+    <ContentSurfaceCard
+      surface='details'
+      className='overflow-hidden'
+      data-testid='agent-os-runs-panel'
+    >
+      <ContentSectionHeader
+        title='AgentOS Runs'
+        subtitle={`${rows.length.toLocaleString('en-US')} artifact${rows.length === 1 ? '' : 's'}`}
+        actions={
+          <div className='flex items-center gap-2 text-[11px] text-tertiary-token'>
+            <Bot className='size-3.5' aria-hidden='true' />
+            WDK fixture
+          </div>
+        }
+        className='min-h-0 px-(--linear-app-header-padding-x) py-3'
+      />
+
+      <div className='grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_360px]'>
+        <div className='hidden min-w-0 rounded-lg border border-subtle bg-(--linear-app-content-surface) md:block'>
+          <UnifiedTable
+            data={rows}
+            columns={columns}
+            isLoading={false}
+            emptyState={
+              <TableEmptyState
+                icon={<GitPullRequestArrow className='size-5' />}
+                title='No AgentOS runs'
+                description='AgentRunArtifact records will appear here after a workflow emits them.'
+              />
+            }
+            getRowId={artifact => artifact.id}
+            onRowClick={artifact => setSelectedId(artifact.id)}
+            getRowClassName={getRowClassName}
+            getRowTestId={artifact => `agent-os-run-${artifact.id}`}
+            enableVirtualization={false}
+            minWidth='700px'
+            className='text-[12.5px] [&_thead_th]:py-1 [&_thead_th]:text-3xs [&_thead_th]:tracking-[0.07em]'
+            containerClassName='max-h-[420px]'
+          />
+        </div>
+
+        <div className='grid gap-2 md:hidden'>
+          {rows.length > 0 ? (
+            rows.map(artifact => (
+              <WorkflowRunRow
+                key={artifact.id}
+                artifact={artifact}
+                isSelected={artifact.id === selectedArtifact?.id}
+                onSelect={item => setSelectedId(item.id)}
+              />
+            ))
+          ) : (
+            <TableEmptyState
+              icon={<GitPullRequestArrow className='size-5' />}
+              title='No AgentOS runs'
+              description='AgentRunArtifact records will appear here after a workflow emits them.'
+            />
+          )}
+        </div>
+
+        <div className='grid content-start gap-4'>
+          <ApprovalQueuePanel
+            artifacts={rows}
+            selectedId={selectedArtifact?.id ?? null}
+            onSelect={artifact => setSelectedId(artifact.id)}
+          />
+          <ArtifactDrawer artifact={selectedArtifact} />
+        </div>
+      </div>
+    </ContentSurfaceCard>
+  );
+}

--- a/apps/web/components/features/admin/agent-os/ApprovalQueuePanel.tsx
+++ b/apps/web/components/features/admin/agent-os/ApprovalQueuePanel.tsx
@@ -1,0 +1,52 @@
+import type { AgentRunArtifact } from '@/lib/agent-os/artifact';
+import { WorkflowRunRow } from './WorkflowRunRow';
+
+interface ApprovalQueuePanelProps {
+  readonly artifacts: readonly AgentRunArtifact[];
+  readonly selectedId: string | null;
+  readonly onSelect: (artifact: AgentRunArtifact) => void;
+}
+
+function needsApproval(artifact: AgentRunArtifact): boolean {
+  return (
+    artifact.humanApprovalRequired && artifact.humanGate.status !== 'approved'
+  );
+}
+
+export function ApprovalQueuePanel({
+  artifacts,
+  selectedId,
+  onSelect,
+}: ApprovalQueuePanelProps) {
+  const approvalArtifacts = artifacts.filter(needsApproval);
+
+  return (
+    <div className='rounded-lg border border-subtle bg-surface-0 p-3'>
+      <div className='flex items-center justify-between gap-3'>
+        <p className='text-[12.5px] font-[560] text-primary-token'>
+          Approval Queue
+        </p>
+        <span className='text-[11px] text-tertiary-token'>
+          {approvalArtifacts.length}
+        </span>
+      </div>
+
+      {approvalArtifacts.length > 0 ? (
+        <div className='mt-3 grid gap-2'>
+          {approvalArtifacts.map(artifact => (
+            <WorkflowRunRow
+              key={artifact.id}
+              artifact={artifact}
+              isSelected={artifact.id === selectedId}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className='mt-3 text-[12px] leading-5 text-tertiary-token'>
+          No approvals waiting.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx
+++ b/apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx
@@ -1,0 +1,113 @@
+import { ExternalLink } from 'lucide-react';
+import type { AgentRunArtifact } from '@/lib/agent-os/artifact';
+import { VerificationGateList } from './VerificationGateList';
+import { WorkflowStatusPill } from './WorkflowStatusPill';
+
+function formatCost(artifact: AgentRunArtifact): string {
+  if (!artifact.costEstimate) return 'Not estimated';
+  if (artifact.costEstimate.usd === 0) return '$0.00';
+  return artifact.costEstimate.usd.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 4,
+  });
+}
+
+function ArtifactLink({
+  href,
+  label,
+}: Readonly<{ readonly href: string | null; readonly label: string }>) {
+  if (!href) return null;
+
+  return (
+    <a
+      href={href}
+      target='_blank'
+      rel='noopener noreferrer'
+      className='inline-flex items-center gap-1 text-[12px] font-[520] text-secondary-token hover:text-primary-token'
+    >
+      {label}
+      <ExternalLink className='size-3' aria-hidden='true' />
+    </a>
+  );
+}
+
+interface ArtifactDrawerProps {
+  readonly artifact: AgentRunArtifact | null;
+}
+
+export function ArtifactDrawer({ artifact }: ArtifactDrawerProps) {
+  if (!artifact) {
+    return (
+      <aside className='rounded-lg border border-subtle bg-surface-0 p-4'>
+        <p className='text-[13px] text-secondary-token'>
+          Select a run to inspect its gates.
+        </p>
+      </aside>
+    );
+  }
+
+  return (
+    <aside
+      className='rounded-lg border border-subtle bg-surface-0 p-4'
+      data-testid='agent-os-artifact-drawer'
+    >
+      <div className='flex items-start justify-between gap-3'>
+        <div className='min-w-0'>
+          <p className='truncate text-[13px] font-[590] text-primary-token'>
+            {artifact.title}
+          </p>
+          <p className='mt-1 text-[12px] leading-5 text-secondary-token'>
+            {artifact.summary}
+          </p>
+        </div>
+        <WorkflowStatusPill status={artifact.status} />
+      </div>
+
+      <dl className='mt-4 grid grid-cols-2 gap-2 text-[12px]'>
+        <div className='rounded-lg bg-surface-1 px-3 py-2'>
+          <dt className='text-tertiary-token'>Source</dt>
+          <dd className='mt-1 truncate font-[540] text-primary-token'>
+            {artifact.source}
+          </dd>
+        </div>
+        <div className='rounded-lg bg-surface-1 px-3 py-2'>
+          <dt className='text-tertiary-token'>Route</dt>
+          <dd className='mt-1 truncate font-[540] text-primary-token'>
+            {artifact.modelRoute}
+          </dd>
+        </div>
+        <div className='rounded-lg bg-surface-1 px-3 py-2'>
+          <dt className='text-tertiary-token'>Cost</dt>
+          <dd className='mt-1 truncate font-[540] text-primary-token'>
+            {formatCost(artifact)}
+          </dd>
+        </div>
+        <div className='rounded-lg bg-surface-1 px-3 py-2'>
+          <dt className='text-tertiary-token'>Human Gate</dt>
+          <dd className='mt-1 truncate font-[540] text-primary-token'>
+            {artifact.humanGate.status.replaceAll('_', ' ')}
+          </dd>
+        </div>
+      </dl>
+
+      {artifact.blockedReason ? (
+        <div className='mt-4 rounded-lg border border-warning/20 bg-surface-1 px-3 py-2 text-[12px] leading-5 text-warning'>
+          {artifact.blockedReason}
+        </div>
+      ) : null}
+
+      <div className='mt-4 flex flex-wrap gap-3'>
+        <ArtifactLink href={artifact.linearIssueUrl} label='Linear' />
+        <ArtifactLink href={artifact.pullRequestUrl} label='Pull Request' />
+      </div>
+
+      <div className='mt-4'>
+        <p className='mb-2 text-[12.5px] font-[560] text-primary-token'>
+          Verification Gates
+        </p>
+        <VerificationGateList gates={artifact.verificationGates} />
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx
+++ b/apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx
@@ -48,6 +48,7 @@ function ArtifactLink({
       href={safeHref}
       target='_blank'
       rel='noopener noreferrer'
+      aria-label={`${label} (opens in a new tab)`}
       className='inline-flex items-center gap-1 text-[12px] font-[520] text-secondary-token hover:text-primary-token'
     >
       {label}

--- a/apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx
+++ b/apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx
@@ -3,6 +3,16 @@ import type { AgentRunArtifact } from '@/lib/agent-os/artifact';
 import { VerificationGateList } from './VerificationGateList';
 import { WorkflowStatusPill } from './WorkflowStatusPill';
 
+const HUMAN_GATE_LABELS: Record<
+  AgentRunArtifact['humanGate']['status'],
+  string
+> = {
+  not_required: 'Not Required',
+  pending: 'Pending',
+  approved: 'Approved',
+  rejected: 'Rejected',
+};
+
 function formatCost(artifact: AgentRunArtifact): string {
   if (!artifact.costEstimate) return 'Not estimated';
   if (artifact.costEstimate.usd === 0) return '$0.00';
@@ -86,7 +96,7 @@ export function ArtifactDrawer({ artifact }: ArtifactDrawerProps) {
         <div className='rounded-lg bg-surface-1 px-3 py-2'>
           <dt className='text-tertiary-token'>Human Gate</dt>
           <dd className='mt-1 truncate font-[540] text-primary-token'>
-            {artifact.humanGate.status.replaceAll('_', ' ')}
+            {HUMAN_GATE_LABELS[artifact.humanGate.status]}
           </dd>
         </div>
       </dl>

--- a/apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx
+++ b/apps/web/components/features/admin/agent-os/ArtifactDrawer.tsx
@@ -23,15 +23,29 @@ function formatCost(artifact: AgentRunArtifact): string {
   });
 }
 
+function getSafeExternalHref(href: string | null): string | null {
+  if (!href) return null;
+
+  try {
+    const url = new URL(href);
+    return url.protocol === 'http:' || url.protocol === 'https:'
+      ? url.toString()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 function ArtifactLink({
   href,
   label,
 }: Readonly<{ readonly href: string | null; readonly label: string }>) {
-  if (!href) return null;
+  const safeHref = getSafeExternalHref(href);
+  if (!safeHref) return null;
 
   return (
     <a
-      href={href}
+      href={safeHref}
       target='_blank'
       rel='noopener noreferrer'
       className='inline-flex items-center gap-1 text-[12px] font-[520] text-secondary-token hover:text-primary-token'

--- a/apps/web/components/features/admin/agent-os/VerificationGateList.tsx
+++ b/apps/web/components/features/admin/agent-os/VerificationGateList.tsx
@@ -1,0 +1,67 @@
+import { ShieldCheck } from 'lucide-react';
+import type { VerificationGate } from '@/lib/agent-os/artifact';
+import { VerificationStatusPill } from './WorkflowStatusPill';
+
+const GATE_LABELS: Record<VerificationGate['name'], string> = {
+  'gstack.qa.exhaustive': 'GStack / QA / Exhaustive',
+  'gstack.review': 'GStack / Review',
+  'gstack.ship': 'GStack / Ship',
+  'github.ci': 'GitHub / CI',
+  'github.scope-judge': 'GitHub / Scope Judge',
+  'github.coderabbit': 'GitHub / CodeRabbit',
+  'github.greptile': 'GitHub / Greptile',
+  'github.branch-protection': 'GitHub / Branch Protection',
+  'gstack.land-and-deploy': 'GStack / Land And Deploy',
+  'sentry.canary': 'Sentry / Canary',
+};
+
+function formatGateName(name: VerificationGate['name']): string {
+  return GATE_LABELS[name];
+}
+
+interface VerificationGateListProps {
+  readonly gates: readonly VerificationGate[];
+}
+
+export function VerificationGateList({ gates }: VerificationGateListProps) {
+  if (gates.length === 0) {
+    return (
+      <div className='rounded-lg bg-surface-0 px-3 py-3 text-[12px] text-tertiary-token'>
+        No gates recorded.
+      </div>
+    );
+  }
+
+  return (
+    <div className='grid gap-2'>
+      {gates.map(gate => (
+        <div
+          key={gate.name}
+          className='grid gap-2 rounded-lg bg-surface-1 px-3 py-2.5 sm:grid-cols-[minmax(0,1fr)_auto]'
+        >
+          <div className='min-w-0'>
+            <div className='flex min-w-0 items-center gap-2'>
+              <ShieldCheck
+                className='size-3.5 shrink-0 text-tertiary-token'
+                aria-hidden='true'
+              />
+              <p className='truncate text-[12.5px] font-[540] text-primary-token'>
+                {formatGateName(gate.name)}
+              </p>
+            </div>
+            <p className='mt-1 text-[11.5px] leading-4 text-tertiary-token'>
+              {gate.summary ??
+                (gate.required ? 'Required gate.' : 'Optional gate.')}
+            </p>
+          </div>
+          <div className='flex items-center gap-2 sm:justify-end'>
+            <span className='text-[11px] text-tertiary-token'>
+              {gate.required ? 'Required' : 'Optional'}
+            </span>
+            <VerificationStatusPill status={gate.status} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/components/features/admin/agent-os/WorkflowRunRow.tsx
+++ b/apps/web/components/features/admin/agent-os/WorkflowRunRow.tsx
@@ -25,16 +25,12 @@ export function WorkflowRunRow({
   isSelected = false,
   onSelect,
 }: WorkflowRunRowProps) {
-  return (
-    <button
-      type='button'
-      onClick={() => onSelect?.(artifact)}
-      className={cn(
-        'grid w-full gap-2 rounded-lg border border-subtle bg-surface-1 px-3 py-2.5 text-left transition-colors hover:bg-surface-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
-        isSelected && 'border-(--linear-border-focus) bg-surface-0'
-      )}
-      aria-pressed={isSelected}
-    >
+  const className = cn(
+    'grid w-full gap-2 rounded-lg border border-subtle bg-surface-1 px-3 py-2.5 text-left transition-colors hover:bg-surface-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+    isSelected && 'border-(--linear-border-focus) bg-surface-0'
+  );
+  const content = (
+    <>
       <div className='flex min-w-0 items-start justify-between gap-3'>
         <div className='min-w-0'>
           <p className='truncate text-[13px] font-[560] text-primary-token'>
@@ -54,6 +50,21 @@ export function WorkflowRunRow({
           {formatUpdatedAt(artifact.updatedAt)}
         </span>
       </div>
+    </>
+  );
+
+  if (!onSelect) {
+    return <div className={className}>{content}</div>;
+  }
+
+  return (
+    <button
+      type='button'
+      onClick={() => onSelect(artifact)}
+      className={className}
+      aria-pressed={isSelected}
+    >
+      {content}
     </button>
   );
 }

--- a/apps/web/components/features/admin/agent-os/WorkflowRunRow.tsx
+++ b/apps/web/components/features/admin/agent-os/WorkflowRunRow.tsx
@@ -1,0 +1,55 @@
+import { Clock3 } from 'lucide-react';
+import type { AgentRunArtifact } from '@/lib/agent-os/artifact';
+import { WorkflowStatusPill } from './WorkflowStatusPill';
+
+function formatUpdatedAt(value: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'UTC',
+    timeZoneName: 'short',
+  }).format(new Date(value));
+}
+
+interface WorkflowRunRowProps {
+  readonly artifact: AgentRunArtifact;
+  readonly isSelected?: boolean;
+  readonly onSelect?: (artifact: AgentRunArtifact) => void;
+}
+
+export function WorkflowRunRow({
+  artifact,
+  isSelected = false,
+  onSelect,
+}: WorkflowRunRowProps) {
+  return (
+    <button
+      type='button'
+      onClick={() => onSelect?.(artifact)}
+      className='grid w-full gap-2 rounded-lg border border-subtle bg-surface-1 px-3 py-2.5 text-left transition-colors hover:bg-surface-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+      aria-pressed={isSelected}
+    >
+      <div className='flex min-w-0 items-start justify-between gap-3'>
+        <div className='min-w-0'>
+          <p className='truncate text-[13px] font-[560] text-primary-token'>
+            {artifact.title}
+          </p>
+          <p className='mt-1 line-clamp-2 text-[11.5px] leading-4 text-tertiary-token'>
+            {artifact.summary}
+          </p>
+        </div>
+        <WorkflowStatusPill status={artifact.status} />
+      </div>
+      <div className='flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-tertiary-token'>
+        <span>{artifact.modelRoute}</span>
+        <span>{artifact.source}</span>
+        <span className='inline-flex items-center gap-1'>
+          <Clock3 className='size-3' aria-hidden='true' />
+          {formatUpdatedAt(artifact.updatedAt)}
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/apps/web/components/features/admin/agent-os/WorkflowRunRow.tsx
+++ b/apps/web/components/features/admin/agent-os/WorkflowRunRow.tsx
@@ -1,5 +1,6 @@
 import { Clock3 } from 'lucide-react';
 import type { AgentRunArtifact } from '@/lib/agent-os/artifact';
+import { cn } from '@/lib/utils';
 import { WorkflowStatusPill } from './WorkflowStatusPill';
 
 function formatUpdatedAt(value: string): string {
@@ -28,7 +29,10 @@ export function WorkflowRunRow({
     <button
       type='button'
       onClick={() => onSelect?.(artifact)}
-      className='grid w-full gap-2 rounded-lg border border-subtle bg-surface-1 px-3 py-2.5 text-left transition-colors hover:bg-surface-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+      className={cn(
+        'grid w-full gap-2 rounded-lg border border-subtle bg-surface-1 px-3 py-2.5 text-left transition-colors hover:bg-surface-0 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+        isSelected && 'border-(--linear-border-focus) bg-surface-0'
+      )}
       aria-pressed={isSelected}
     >
       <div className='flex min-w-0 items-start justify-between gap-3'>

--- a/apps/web/components/features/admin/agent-os/WorkflowStatusPill.tsx
+++ b/apps/web/components/features/admin/agent-os/WorkflowStatusPill.tsx
@@ -1,0 +1,77 @@
+import { Badge } from '@jovie/ui';
+import type {
+  AgentRunStatus,
+  VerificationGateStatus,
+} from '@/lib/agent-os/artifact';
+
+const RUN_STATUS_LABEL: Record<AgentRunStatus, string> = {
+  queued: 'Queued',
+  running: 'Running',
+  blocked: 'Blocked',
+  review: 'Review',
+  done: 'Done',
+  failed: 'Failed',
+  stale: 'Stale',
+};
+
+const RUN_STATUS_VARIANT: Record<
+  AgentRunStatus,
+  'primary' | 'secondary' | 'success' | 'warning' | 'error'
+> = {
+  queued: 'secondary',
+  running: 'primary',
+  blocked: 'warning',
+  review: 'warning',
+  done: 'success',
+  failed: 'error',
+  stale: 'secondary',
+};
+
+const GATE_STATUS_LABEL: Record<VerificationGateStatus, string> = {
+  missing: 'Missing',
+  queued: 'Queued',
+  running: 'Running',
+  passed: 'Passed',
+  failed: 'Failed',
+  skipped: 'Skipped',
+  blocked: 'Blocked',
+};
+
+const GATE_STATUS_VARIANT: Record<
+  VerificationGateStatus,
+  'primary' | 'secondary' | 'success' | 'warning' | 'error'
+> = {
+  missing: 'secondary',
+  queued: 'secondary',
+  running: 'primary',
+  passed: 'success',
+  failed: 'error',
+  skipped: 'secondary',
+  blocked: 'warning',
+};
+
+interface WorkflowStatusPillProps {
+  readonly status: AgentRunStatus;
+}
+
+interface VerificationStatusPillProps {
+  readonly status: VerificationGateStatus;
+}
+
+export function WorkflowStatusPill({ status }: WorkflowStatusPillProps) {
+  return (
+    <Badge variant={RUN_STATUS_VARIANT[status]} size='sm'>
+      {RUN_STATUS_LABEL[status]}
+    </Badge>
+  );
+}
+
+export function VerificationStatusPill({
+  status,
+}: VerificationStatusPillProps) {
+  return (
+    <Badge variant={GATE_STATUS_VARIANT[status]} size='sm'>
+      {GATE_STATUS_LABEL[status]}
+    </Badge>
+  );
+}

--- a/apps/web/components/features/admin/agent-os/index.ts
+++ b/apps/web/components/features/admin/agent-os/index.ts
@@ -1,0 +1,1 @@
+export { AgentOsRunsPanel } from './AgentOsRunsPanel';

--- a/apps/web/lib/agent-os/artifact.ts
+++ b/apps/web/lib/agent-os/artifact.ts
@@ -73,9 +73,20 @@ export const AGENT_RUN_GATE_EVIDENCE_NAMES = [
   'sentry.canary',
 ] as const;
 
+function isHttpUrl(value: string): boolean {
+  const protocol = new URL(value).protocol;
+  return protocol === 'http:' || protocol === 'https:';
+}
+
+export const AgentRunHttpUrlSchema = z
+  .string()
+  .trim()
+  .url()
+  .refine(isHttpUrl, { message: 'URL must use http or https protocol.' });
+
 const nullableUrlSchema = z.preprocess(
   value => (typeof value === 'string' && value.trim() === '' ? null : value),
-  z.union([z.string().trim().url(), z.null()])
+  z.union([AgentRunHttpUrlSchema, z.null()])
 );
 const nullableTextSchema = z.preprocess(
   value => (typeof value === 'string' && value.trim() === '' ? null : value),

--- a/apps/web/lib/agent-os/fixtures.ts
+++ b/apps/web/lib/agent-os/fixtures.ts
@@ -1,0 +1,302 @@
+import { APP_ROUTES } from '@/constants/routes';
+import type { AgentRunArtifact, VerificationGate } from './artifact';
+
+const CREATED_AT = '2026-05-08T18:00:00.000Z';
+
+function gate(
+  name: VerificationGate['name'],
+  status: VerificationGate['status'],
+  summary: string,
+  required = true
+): VerificationGate {
+  return {
+    name,
+    required,
+    status,
+    evidenceUrl: null,
+    summary,
+    checkedAt:
+      status === 'missing' || status === 'queued'
+        ? null
+        : '2026-05-08T20:30:00.000Z',
+  };
+}
+
+export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
+  {
+    id: 'agentos-run-queued-wdk-health',
+    source: 'vercel-workflow',
+    sourceRunId: 'wrun_agentos_health_001',
+    kind: 'workflow',
+    status: 'queued',
+    title: 'WDK health dry run',
+    summary:
+      'Queued harmless workflow proof that emits an AgentRunArtifact without schedules, deploys, Linear mutation, or model calls.',
+    modelRoute: 'deterministic',
+    allowedActions: ['read', 'summarize'],
+    forbiddenActions: [
+      'write_code',
+      'merge',
+      'deploy',
+      'mutate_linear',
+      'send_outbound',
+      'mutate_production_data',
+      'change_auth',
+      'change_billing',
+      'change_security',
+    ],
+    humanApprovalRequired: false,
+    humanGate: {
+      required: false,
+      status: 'not_required',
+      reason: null,
+      reviewer: null,
+      reviewedAt: null,
+    },
+    linearIssueId: 'JOV-1971',
+    linearIssueUrl:
+      'https://linear.app/jovie/issue/JOV-1971/agentos-vercel-workflow-dry-run-artifact-proof',
+    pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8282',
+    adminSurface: APP_ROUTES.ADMIN_OPS,
+    verificationGates: [
+      gate('github.ci', 'queued', 'Waiting for GitHub Actions.'),
+      gate('gstack.qa.exhaustive', 'missing', 'QA evidence not recorded yet.'),
+      gate('gstack.review', 'missing', 'Review evidence not recorded yet.'),
+    ],
+    costEstimate: {
+      usd: 0,
+      route: 'deterministic',
+      inputTokens: 0,
+      outputTokens: 0,
+      notes: 'No model call.',
+    },
+    blockedReason: null,
+    createdAt: CREATED_AT,
+    updatedAt: '2026-05-08T18:05:00.000Z',
+    metadata: { fixture: true },
+  },
+  {
+    id: 'agentos-run-running-main-tail',
+    source: 'ci',
+    sourceRunId: '25582719008',
+    kind: 'deploy_readiness',
+    status: 'running',
+    title: 'Main post-merge verification',
+    summary:
+      'Main branch deploy path is watching unit shards, production Lighthouse, smoke, auth smoke, and Sentry soak gates.',
+    modelRoute: 'deterministic',
+    allowedActions: ['read', 'summarize'],
+    forbiddenActions: ['merge', 'deploy', 'mutate_linear', 'send_outbound'],
+    humanApprovalRequired: false,
+    humanGate: {
+      required: false,
+      status: 'not_required',
+      reason: null,
+      reviewer: null,
+      reviewedAt: null,
+    },
+    linearIssueId: 'JOV-1971',
+    linearIssueUrl:
+      'https://linear.app/jovie/issue/JOV-1971/agentos-vercel-workflow-dry-run-artifact-proof',
+    pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8282',
+    adminSurface: APP_ROUTES.ADMIN_OPS,
+    verificationGates: [
+      gate('github.ci', 'running', 'Main CI is still reporting active jobs.'),
+      gate('sentry.canary', 'running', 'Production Sentry soak is active.'),
+    ],
+    costEstimate: {
+      usd: 0,
+      route: 'deterministic',
+      inputTokens: 0,
+      outputTokens: 0,
+      notes: 'Status read only.',
+    },
+    blockedReason: null,
+    createdAt: CREATED_AT,
+    updatedAt: '2026-05-08T22:45:00.000Z',
+    metadata: { fixture: true },
+  },
+  {
+    id: 'agentos-run-review-gstack-ship',
+    source: 'github',
+    sourceRunId: '8282',
+    kind: 'code_review',
+    status: 'review',
+    title: 'Review GStack ship evidence',
+    summary:
+      'Ready PR requires recorded exhaustive QA, review, ship, and land evidence before non-dry-run AgentOS dispatch is allowed.',
+    modelRoute: 'codex-cli',
+    allowedActions: ['read', 'summarize', 'draft'],
+    forbiddenActions: [
+      'ready_pr',
+      'merge',
+      'deploy',
+      'mutate_production_data',
+      'change_auth',
+      'change_billing',
+      'change_security',
+    ],
+    humanApprovalRequired: true,
+    humanGate: {
+      required: true,
+      status: 'pending',
+      reason: 'Human approval required before AgentOS moves beyond dry-run.',
+      reviewer: null,
+      reviewedAt: null,
+    },
+    linearIssueId: 'JOV-1926',
+    linearIssueUrl:
+      'https://linear.app/jovie/issue/JOV-1926/agentos-enforce-gstack-gates-before-non-dry-run-agents',
+    pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8282',
+    adminSurface: APP_ROUTES.ADMIN_OPS,
+    verificationGates: [
+      gate('gstack.qa.exhaustive', 'passed', 'Focused QA evidence recorded.'),
+      gate('gstack.review', 'passed', 'Bot and human review threads resolved.'),
+      gate('gstack.ship', 'passed', 'Ship gate evidence recorded.'),
+      gate('gstack.land-and-deploy', 'running', 'Landing sequence active.'),
+    ],
+    costEstimate: {
+      usd: 0,
+      route: 'codex-cli',
+      inputTokens: null,
+      outputTokens: null,
+      notes: 'Local coding agent route.',
+    },
+    blockedReason: null,
+    createdAt: CREATED_AT,
+    updatedAt: '2026-05-08T22:20:00.000Z',
+    metadata: { fixture: true },
+  },
+  {
+    id: 'agentos-run-blocked-trigger-check',
+    source: 'github',
+    sourceRunId: '75105012992',
+    kind: 'deploy_readiness',
+    status: 'blocked',
+    title: 'Trigger.dev deploy check mismatch',
+    summary:
+      'External Trigger.dev production deployment integration is active while AgentOS is intentionally WDK-first.',
+    modelRoute: 'deterministic',
+    allowedActions: ['read', 'summarize', 'draft'],
+    forbiddenActions: ['deploy', 'merge', 'mutate_production_data'],
+    humanApprovalRequired: true,
+    humanGate: {
+      required: true,
+      status: 'pending',
+      reason:
+        'Infra owner must disable or reconfigure the Trigger.dev project.',
+      reviewer: null,
+      reviewedAt: null,
+    },
+    linearIssueId: 'JOV-1994',
+    linearIssueUrl:
+      'https://linear.app/jovie/issue/JOV-1994/agentos-disable-stale-triggerdev-production-deploy-check-while-wdk-is',
+    pullRequestUrl: null,
+    adminSurface: APP_ROUTES.ADMIN_OPS,
+    verificationGates: [
+      gate(
+        'github.ci',
+        'blocked',
+        'External Trigger.dev check reports missing trigger.config.ts.'
+      ),
+    ],
+    costEstimate: {
+      usd: 0,
+      route: 'deterministic',
+      inputTokens: 0,
+      outputTokens: 0,
+      notes: 'Infra status only.',
+    },
+    blockedReason:
+      'Trigger.dev deploy integration expects trigger.config.ts before the fallback runtime PR exists.',
+    createdAt: CREATED_AT,
+    updatedAt: '2026-05-08T22:40:00.000Z',
+    metadata: { fixture: true },
+  },
+  {
+    id: 'agentos-run-failed-unsafe-payload',
+    source: 'hermes',
+    sourceRunId: 'hermes_dispatch_rejected_001',
+    kind: 'triage',
+    status: 'failed',
+    title: 'Unsafe dispatch payload rejected',
+    summary:
+      'Hermes rejected a non-dry-run payload because requested paths and forbidden actions exceeded the approved manifest.',
+    modelRoute: 'deterministic',
+    allowedActions: ['read', 'classify', 'summarize'],
+    forbiddenActions: ['write_code', 'merge', 'deploy', 'mutate_linear'],
+    humanApprovalRequired: false,
+    humanGate: {
+      required: false,
+      status: 'not_required',
+      reason: null,
+      reviewer: null,
+      reviewedAt: null,
+    },
+    linearIssueId: 'JOV-1926',
+    linearIssueUrl:
+      'https://linear.app/jovie/issue/JOV-1926/agentos-enforce-gstack-gates-before-non-dry-run-agents',
+    pullRequestUrl: null,
+    adminSurface: APP_ROUTES.ADMIN_OPS,
+    verificationGates: [
+      gate(
+        'github.scope-judge',
+        'failed',
+        'Changed-file guard rejected out-of-scope paths.'
+      ),
+    ],
+    costEstimate: {
+      usd: 0,
+      route: 'deterministic',
+      inputTokens: 0,
+      outputTokens: 0,
+      notes: 'Rejected before model routing.',
+    },
+    blockedReason: null,
+    createdAt: CREATED_AT,
+    updatedAt: '2026-05-08T19:15:00.000Z',
+    metadata: { fixture: true },
+  },
+  {
+    id: 'agentos-run-done-schema-pr',
+    source: 'github',
+    sourceRunId: '8240',
+    kind: 'workflow',
+    status: 'done',
+    title: 'AgentRunArtifact schema landed',
+    summary:
+      'Canonical AgentRunArtifact schema is available for GitHub, Linear, Hermes, Ruflo, CI, and Vercel Workflow adapters.',
+    modelRoute: 'deterministic',
+    allowedActions: ['read', 'summarize'],
+    forbiddenActions: ['merge', 'deploy', 'mutate_production_data'],
+    humanApprovalRequired: false,
+    humanGate: {
+      required: false,
+      status: 'not_required',
+      reason: null,
+      reviewer: null,
+      reviewedAt: null,
+    },
+    linearIssueId: 'JOV-1923',
+    linearIssueUrl:
+      'https://linear.app/jovie/issue/JOV-1923/agentos-shared-agentrunartifact-schema',
+    pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8240',
+    adminSurface: APP_ROUTES.ADMIN_OPS,
+    verificationGates: [
+      gate('github.ci', 'passed', 'CI passed.'),
+      gate('gstack.review', 'passed', 'Review gate passed.'),
+      gate('gstack.ship', 'passed', 'Ship gate passed.'),
+    ],
+    costEstimate: {
+      usd: 0,
+      route: 'deterministic',
+      inputTokens: 0,
+      outputTokens: 0,
+      notes: 'No model call.',
+    },
+    blockedReason: null,
+    createdAt: CREATED_AT,
+    updatedAt: '2026-05-08T17:30:00.000Z',
+    metadata: { fixture: true },
+  },
+];

--- a/apps/web/lib/agent-os/fixtures.ts
+++ b/apps/web/lib/agent-os/fixtures.ts
@@ -2,6 +2,15 @@ import { APP_ROUTES } from '@/constants/routes';
 import type { AgentRunArtifact, VerificationGate } from './artifact';
 
 const CREATED_AT = '2026-05-08T18:00:00.000Z';
+const CHECKED_AT = '2026-05-08T20:30:00.000Z';
+
+type FixtureArtifactInput = Omit<
+  AgentRunArtifact,
+  'adminSurface' | 'createdAt' | 'metadata'
+> & {
+  readonly createdAt?: string;
+  readonly metadata?: Record<string, unknown>;
+};
 
 function gate(
   name: VerificationGate['name'],
@@ -15,15 +24,58 @@ function gate(
     status,
     evidenceUrl: null,
     summary,
-    checkedAt:
-      status === 'missing' || status === 'queued'
-        ? null
-        : '2026-05-08T20:30:00.000Z',
+    checkedAt: status === 'missing' || status === 'queued' ? null : CHECKED_AT,
+  };
+}
+
+function noHumanGate(): AgentRunArtifact['humanGate'] {
+  return {
+    required: false,
+    status: 'not_required',
+    reason: null,
+    reviewer: null,
+    reviewedAt: null,
+  };
+}
+
+function pendingHumanGate(reason: string): AgentRunArtifact['humanGate'] {
+  return {
+    required: true,
+    status: 'pending',
+    reason,
+    reviewer: null,
+    reviewedAt: null,
+  };
+}
+
+function zeroCost(
+  route: AgentRunArtifact['modelRoute'],
+  notes: string,
+  inputTokens: number | null = 0,
+  outputTokens: number | null = 0
+): AgentRunArtifact['costEstimate'] {
+  return {
+    usd: 0,
+    route,
+    inputTokens,
+    outputTokens,
+    notes,
+  };
+}
+
+function fixtureArtifact(input: FixtureArtifactInput): AgentRunArtifact {
+  const { createdAt = CREATED_AT, metadata, ...artifact } = input;
+
+  return {
+    ...artifact,
+    adminSurface: APP_ROUTES.ADMIN_OPS,
+    createdAt,
+    metadata: { fixture: true, ...metadata },
   };
 }
 
 export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
-  {
+  fixtureArtifact({
     id: 'agentos-run-queued-wdk-health',
     source: 'vercel-workflow',
     sourceRunId: 'wrun_agentos_health_001',
@@ -46,36 +98,21 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
       'change_security',
     ],
     humanApprovalRequired: false,
-    humanGate: {
-      required: false,
-      status: 'not_required',
-      reason: null,
-      reviewer: null,
-      reviewedAt: null,
-    },
+    humanGate: noHumanGate(),
     linearIssueId: 'JOV-1971',
     linearIssueUrl:
       'https://linear.app/jovie/issue/JOV-1971/agentos-vercel-workflow-dry-run-artifact-proof',
     pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8282',
-    adminSurface: APP_ROUTES.ADMIN_OPS,
     verificationGates: [
       gate('github.ci', 'queued', 'Waiting for GitHub Actions.'),
       gate('gstack.qa.exhaustive', 'missing', 'QA evidence not recorded yet.'),
       gate('gstack.review', 'missing', 'Review evidence not recorded yet.'),
     ],
-    costEstimate: {
-      usd: 0,
-      route: 'deterministic',
-      inputTokens: 0,
-      outputTokens: 0,
-      notes: 'No model call.',
-    },
+    costEstimate: zeroCost('deterministic', 'No model call.'),
     blockedReason: null,
-    createdAt: CREATED_AT,
     updatedAt: '2026-05-08T18:05:00.000Z',
-    metadata: { fixture: true },
-  },
-  {
+  }),
+  fixtureArtifact({
     id: 'agentos-run-running-main-tail',
     source: 'ci',
     sourceRunId: '25582719008',
@@ -88,35 +125,20 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
     allowedActions: ['read', 'summarize'],
     forbiddenActions: ['merge', 'deploy', 'mutate_linear', 'send_outbound'],
     humanApprovalRequired: false,
-    humanGate: {
-      required: false,
-      status: 'not_required',
-      reason: null,
-      reviewer: null,
-      reviewedAt: null,
-    },
+    humanGate: noHumanGate(),
     linearIssueId: 'JOV-1971',
     linearIssueUrl:
       'https://linear.app/jovie/issue/JOV-1971/agentos-vercel-workflow-dry-run-artifact-proof',
     pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8282',
-    adminSurface: APP_ROUTES.ADMIN_OPS,
     verificationGates: [
       gate('github.ci', 'running', 'Main CI is still reporting active jobs.'),
       gate('sentry.canary', 'running', 'Production Sentry soak is active.'),
     ],
-    costEstimate: {
-      usd: 0,
-      route: 'deterministic',
-      inputTokens: 0,
-      outputTokens: 0,
-      notes: 'Status read only.',
-    },
+    costEstimate: zeroCost('deterministic', 'Status read only.'),
     blockedReason: null,
-    createdAt: CREATED_AT,
     updatedAt: '2026-05-08T22:45:00.000Z',
-    metadata: { fixture: true },
-  },
-  {
+  }),
+  fixtureArtifact({
     id: 'agentos-run-review-gstack-ship',
     source: 'github',
     sourceRunId: '8282',
@@ -137,37 +159,29 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
       'change_security',
     ],
     humanApprovalRequired: true,
-    humanGate: {
-      required: true,
-      status: 'pending',
-      reason: 'Human approval required before AgentOS moves beyond dry-run.',
-      reviewer: null,
-      reviewedAt: null,
-    },
+    humanGate: pendingHumanGate(
+      'Human approval required before AgentOS moves beyond dry-run.'
+    ),
     linearIssueId: 'JOV-1926',
     linearIssueUrl:
       'https://linear.app/jovie/issue/JOV-1926/agentos-enforce-gstack-gates-before-non-dry-run-agents',
     pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8282',
-    adminSurface: APP_ROUTES.ADMIN_OPS,
     verificationGates: [
       gate('gstack.qa.exhaustive', 'passed', 'Focused QA evidence recorded.'),
       gate('gstack.review', 'passed', 'Bot and human review threads resolved.'),
       gate('gstack.ship', 'passed', 'Ship gate evidence recorded.'),
       gate('gstack.land-and-deploy', 'running', 'Landing sequence active.'),
     ],
-    costEstimate: {
-      usd: 0,
-      route: 'codex-cli',
-      inputTokens: null,
-      outputTokens: null,
-      notes: 'Local coding agent route.',
-    },
+    costEstimate: zeroCost(
+      'codex-cli',
+      'Local coding agent route.',
+      null,
+      null
+    ),
     blockedReason: null,
-    createdAt: CREATED_AT,
     updatedAt: '2026-05-08T22:20:00.000Z',
-    metadata: { fixture: true },
-  },
-  {
+  }),
+  fixtureArtifact({
     id: 'agentos-run-blocked-trigger-check',
     source: 'github',
     sourceRunId: '75105012992',
@@ -180,19 +194,13 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
     allowedActions: ['read', 'summarize', 'draft'],
     forbiddenActions: ['deploy', 'merge', 'mutate_production_data'],
     humanApprovalRequired: true,
-    humanGate: {
-      required: true,
-      status: 'pending',
-      reason:
-        'Infra owner must disable or reconfigure the Trigger.dev project.',
-      reviewer: null,
-      reviewedAt: null,
-    },
+    humanGate: pendingHumanGate(
+      'Infra owner must disable or reconfigure the Trigger.dev project.'
+    ),
     linearIssueId: 'JOV-1994',
     linearIssueUrl:
       'https://linear.app/jovie/issue/JOV-1994/agentos-disable-stale-triggerdev-production-deploy-check-while-wdk-is',
     pullRequestUrl: null,
-    adminSurface: APP_ROUTES.ADMIN_OPS,
     verificationGates: [
       gate(
         'github.ci',
@@ -200,20 +208,12 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
         'External Trigger.dev check reports missing trigger.config.ts.'
       ),
     ],
-    costEstimate: {
-      usd: 0,
-      route: 'deterministic',
-      inputTokens: 0,
-      outputTokens: 0,
-      notes: 'Infra status only.',
-    },
+    costEstimate: zeroCost('deterministic', 'Infra status only.'),
     blockedReason:
       'Trigger.dev deploy integration expects trigger.config.ts before the fallback runtime PR exists.',
-    createdAt: CREATED_AT,
     updatedAt: '2026-05-08T22:40:00.000Z',
-    metadata: { fixture: true },
-  },
-  {
+  }),
+  fixtureArtifact({
     id: 'agentos-run-failed-unsafe-payload',
     source: 'hermes',
     sourceRunId: 'hermes_dispatch_rejected_001',
@@ -226,18 +226,11 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
     allowedActions: ['read', 'classify', 'summarize'],
     forbiddenActions: ['write_code', 'merge', 'deploy', 'mutate_linear'],
     humanApprovalRequired: false,
-    humanGate: {
-      required: false,
-      status: 'not_required',
-      reason: null,
-      reviewer: null,
-      reviewedAt: null,
-    },
+    humanGate: noHumanGate(),
     linearIssueId: 'JOV-1926',
     linearIssueUrl:
       'https://linear.app/jovie/issue/JOV-1926/agentos-enforce-gstack-gates-before-non-dry-run-agents',
     pullRequestUrl: null,
-    adminSurface: APP_ROUTES.ADMIN_OPS,
     verificationGates: [
       gate(
         'github.scope-judge',
@@ -245,19 +238,11 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
         'Changed-file guard rejected out-of-scope paths.'
       ),
     ],
-    costEstimate: {
-      usd: 0,
-      route: 'deterministic',
-      inputTokens: 0,
-      outputTokens: 0,
-      notes: 'Rejected before model routing.',
-    },
+    costEstimate: zeroCost('deterministic', 'Rejected before model routing.'),
     blockedReason: null,
-    createdAt: CREATED_AT,
     updatedAt: '2026-05-08T19:15:00.000Z',
-    metadata: { fixture: true },
-  },
-  {
+  }),
+  fixtureArtifact({
     id: 'agentos-run-done-schema-pr',
     source: 'github',
     sourceRunId: '8240',
@@ -270,33 +255,18 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
     allowedActions: ['read', 'summarize'],
     forbiddenActions: ['merge', 'deploy', 'mutate_production_data'],
     humanApprovalRequired: false,
-    humanGate: {
-      required: false,
-      status: 'not_required',
-      reason: null,
-      reviewer: null,
-      reviewedAt: null,
-    },
+    humanGate: noHumanGate(),
     linearIssueId: 'JOV-1923',
     linearIssueUrl:
       'https://linear.app/jovie/issue/JOV-1923/agentos-shared-agentrunartifact-schema',
     pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8240',
-    adminSurface: APP_ROUTES.ADMIN_OPS,
     verificationGates: [
       gate('github.ci', 'passed', 'CI passed.'),
       gate('gstack.review', 'passed', 'Review gate passed.'),
       gate('gstack.ship', 'passed', 'Ship gate passed.'),
     ],
-    costEstimate: {
-      usd: 0,
-      route: 'deterministic',
-      inputTokens: 0,
-      outputTokens: 0,
-      notes: 'No model call.',
-    },
+    costEstimate: zeroCost('deterministic', 'No model call.'),
     blockedReason: null,
-    createdAt: CREATED_AT,
-    updatedAt: '2026-05-08T17:30:00.000Z',
-    metadata: { fixture: true },
-  },
+    updatedAt: '2026-05-08T18:30:00.000Z',
+  }),
 ];

--- a/apps/web/lib/agent-os/fixtures.ts
+++ b/apps/web/lib/agent-os/fixtures.ts
@@ -1,8 +1,39 @@
 import { APP_ROUTES } from '@/constants/routes';
-import type { AgentRunArtifact, VerificationGate } from './artifact';
+import type {
+  AgentRunAction,
+  AgentRunArtifact,
+  AgentRunKind,
+  AgentRunModelRoute,
+  AgentRunSource,
+  AgentRunStatus,
+  VerificationGate,
+} from './artifact';
 
 const CREATED_AT = '2026-05-08T18:00:00.000Z';
 const CHECKED_AT = '2026-05-08T20:30:00.000Z';
+const JOVIE_LINEAR_ISSUE_URL = 'https://linear.app/jovie/issue';
+const JOVIE_GITHUB_PULL_URL = 'https://github.com/JovieInc/Jovie/pull';
+
+const DEFAULT_ALLOWED_ACTIONS: readonly AgentRunAction[] = [
+  'read',
+  'summarize',
+];
+const DEFAULT_FORBIDDEN_ACTIONS: readonly AgentRunAction[] = [
+  'merge',
+  'deploy',
+  'mutate_production_data',
+];
+const CONTROL_PLANE_FORBIDDEN_ACTIONS: readonly AgentRunAction[] = [
+  'write_code',
+  'merge',
+  'deploy',
+  'mutate_linear',
+  'send_outbound',
+  'mutate_production_data',
+  'change_auth',
+  'change_billing',
+  'change_security',
+];
 
 type FixtureArtifactInput = Omit<
   AgentRunArtifact,
@@ -10,6 +41,32 @@ type FixtureArtifactInput = Omit<
 > & {
   readonly createdAt?: string;
   readonly metadata?: Record<string, unknown>;
+};
+
+type FixtureIssueLink = {
+  readonly id: string;
+  readonly slug: string;
+};
+
+type FixtureSeed = {
+  readonly id: string;
+  readonly source: AgentRunSource;
+  readonly sourceRunId: string | null;
+  readonly kind: AgentRunKind;
+  readonly status: AgentRunStatus;
+  readonly title: string;
+  readonly summary: string;
+  readonly modelRoute?: AgentRunModelRoute;
+  readonly allowedActions?: readonly AgentRunAction[];
+  readonly forbiddenActions?: readonly AgentRunAction[];
+  readonly humanApprovalReason?: string;
+  readonly linearIssue?: FixtureIssueLink;
+  readonly pullRequest?: number;
+  readonly verificationGates: readonly VerificationGate[];
+  readonly costNotes?: string;
+  readonly costTokens?: readonly [number | null, number | null];
+  readonly blockedReason?: string;
+  readonly updatedAt: string;
 };
 
 function gate(
@@ -48,6 +105,14 @@ function pendingHumanGate(reason: string): AgentRunArtifact['humanGate'] {
   };
 }
 
+function linearIssueUrl(issue: FixtureIssueLink): string {
+  return `${JOVIE_LINEAR_ISSUE_URL}/${issue.id}/${issue.slug}`;
+}
+
+function pullRequestUrl(number: number): string {
+  return `${JOVIE_GITHUB_PULL_URL}/${number}`;
+}
+
 function zeroCost(
   route: AgentRunArtifact['modelRoute'],
   notes: string,
@@ -74,8 +139,44 @@ function fixtureArtifact(input: FixtureArtifactInput): AgentRunArtifact {
   };
 }
 
-export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
-  fixtureArtifact({
+function artifactFromSeed(seed: FixtureSeed): AgentRunArtifact {
+  const modelRoute = seed.modelRoute ?? 'deterministic';
+  const humanGate = seed.humanApprovalReason
+    ? pendingHumanGate(seed.humanApprovalReason)
+    : noHumanGate();
+  const [inputTokens, outputTokens] = seed.costTokens ?? [0, 0];
+
+  return fixtureArtifact({
+    id: seed.id,
+    source: seed.source,
+    sourceRunId: seed.sourceRunId,
+    kind: seed.kind,
+    status: seed.status,
+    title: seed.title,
+    summary: seed.summary,
+    modelRoute,
+    allowedActions: [...(seed.allowedActions ?? DEFAULT_ALLOWED_ACTIONS)],
+    forbiddenActions: [...(seed.forbiddenActions ?? DEFAULT_FORBIDDEN_ACTIONS)],
+    humanApprovalRequired: humanGate.required,
+    humanGate,
+    linearIssueId: seed.linearIssue?.id ?? null,
+    linearIssueUrl: seed.linearIssue ? linearIssueUrl(seed.linearIssue) : null,
+    pullRequestUrl:
+      seed.pullRequest === undefined ? null : pullRequestUrl(seed.pullRequest),
+    verificationGates: [...seed.verificationGates],
+    costEstimate: zeroCost(
+      modelRoute,
+      seed.costNotes ?? 'No model call.',
+      inputTokens,
+      outputTokens
+    ),
+    blockedReason: seed.blockedReason ?? null,
+    updatedAt: seed.updatedAt,
+  });
+}
+
+const AGENT_OS_ADMIN_FIXTURE_SEEDS: readonly FixtureSeed[] = [
+  {
     id: 'agentos-run-queued-wdk-health',
     source: 'vercel-workflow',
     sourceRunId: 'wrun_agentos_health_001',
@@ -84,35 +185,20 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
     title: 'WDK health dry run',
     summary:
       'Queued harmless workflow proof that emits an AgentRunArtifact without schedules, deploys, Linear mutation, or model calls.',
-    modelRoute: 'deterministic',
-    allowedActions: ['read', 'summarize'],
-    forbiddenActions: [
-      'write_code',
-      'merge',
-      'deploy',
-      'mutate_linear',
-      'send_outbound',
-      'mutate_production_data',
-      'change_auth',
-      'change_billing',
-      'change_security',
-    ],
-    humanApprovalRequired: false,
-    humanGate: noHumanGate(),
-    linearIssueId: 'JOV-1971',
-    linearIssueUrl:
-      'https://linear.app/jovie/issue/JOV-1971/agentos-vercel-workflow-dry-run-artifact-proof',
-    pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8282',
+    forbiddenActions: CONTROL_PLANE_FORBIDDEN_ACTIONS,
+    linearIssue: {
+      id: 'JOV-1971',
+      slug: 'agentos-vercel-workflow-dry-run-artifact-proof',
+    },
+    pullRequest: 8282,
     verificationGates: [
       gate('github.ci', 'queued', 'Waiting for GitHub Actions.'),
       gate('gstack.qa.exhaustive', 'missing', 'QA evidence not recorded yet.'),
       gate('gstack.review', 'missing', 'Review evidence not recorded yet.'),
     ],
-    costEstimate: zeroCost('deterministic', 'No model call.'),
-    blockedReason: null,
     updatedAt: '2026-05-08T18:05:00.000Z',
-  }),
-  fixtureArtifact({
+  },
+  {
     id: 'agentos-run-running-main-tail',
     source: 'ci',
     sourceRunId: '25582719008',
@@ -121,24 +207,20 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
     title: 'Main post-merge verification',
     summary:
       'Main branch deploy path is watching unit shards, production Lighthouse, smoke, auth smoke, and Sentry soak gates.',
-    modelRoute: 'deterministic',
-    allowedActions: ['read', 'summarize'],
     forbiddenActions: ['merge', 'deploy', 'mutate_linear', 'send_outbound'],
-    humanApprovalRequired: false,
-    humanGate: noHumanGate(),
-    linearIssueId: 'JOV-1971',
-    linearIssueUrl:
-      'https://linear.app/jovie/issue/JOV-1971/agentos-vercel-workflow-dry-run-artifact-proof',
-    pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8282',
+    linearIssue: {
+      id: 'JOV-1971',
+      slug: 'agentos-vercel-workflow-dry-run-artifact-proof',
+    },
+    pullRequest: 8282,
     verificationGates: [
       gate('github.ci', 'running', 'Main CI is still reporting active jobs.'),
       gate('sentry.canary', 'running', 'Production Sentry soak is active.'),
     ],
-    costEstimate: zeroCost('deterministic', 'Status read only.'),
-    blockedReason: null,
+    costNotes: 'Status read only.',
     updatedAt: '2026-05-08T22:45:00.000Z',
-  }),
-  fixtureArtifact({
+  },
+  {
     id: 'agentos-run-review-gstack-ship',
     source: 'github',
     sourceRunId: '8282',
@@ -158,30 +240,24 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
       'change_billing',
       'change_security',
     ],
-    humanApprovalRequired: true,
-    humanGate: pendingHumanGate(
-      'Human approval required before AgentOS moves beyond dry-run.'
-    ),
-    linearIssueId: 'JOV-1926',
-    linearIssueUrl:
-      'https://linear.app/jovie/issue/JOV-1926/agentos-enforce-gstack-gates-before-non-dry-run-agents',
-    pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8282',
+    humanApprovalReason:
+      'Human approval required before AgentOS moves beyond dry-run.',
+    linearIssue: {
+      id: 'JOV-1926',
+      slug: 'agentos-enforce-gstack-gates-before-non-dry-run-agents',
+    },
+    pullRequest: 8282,
     verificationGates: [
       gate('gstack.qa.exhaustive', 'passed', 'Focused QA evidence recorded.'),
       gate('gstack.review', 'passed', 'Bot and human review threads resolved.'),
       gate('gstack.ship', 'passed', 'Ship gate evidence recorded.'),
       gate('gstack.land-and-deploy', 'running', 'Landing sequence active.'),
     ],
-    costEstimate: zeroCost(
-      'codex-cli',
-      'Local coding agent route.',
-      null,
-      null
-    ),
-    blockedReason: null,
+    costNotes: 'Local coding agent route.',
+    costTokens: [null, null],
     updatedAt: '2026-05-08T22:20:00.000Z',
-  }),
-  fixtureArtifact({
+  },
+  {
     id: 'agentos-run-blocked-trigger-check',
     source: 'github',
     sourceRunId: '75105012992',
@@ -190,17 +266,14 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
     title: 'Trigger.dev deploy check mismatch',
     summary:
       'External Trigger.dev production deployment integration is active while AgentOS is intentionally WDK-first.',
-    modelRoute: 'deterministic',
     allowedActions: ['read', 'summarize', 'draft'],
     forbiddenActions: ['deploy', 'merge', 'mutate_production_data'],
-    humanApprovalRequired: true,
-    humanGate: pendingHumanGate(
-      'Infra owner must disable or reconfigure the Trigger.dev project.'
-    ),
-    linearIssueId: 'JOV-1994',
-    linearIssueUrl:
-      'https://linear.app/jovie/issue/JOV-1994/agentos-disable-stale-triggerdev-production-deploy-check-while-wdk-is',
-    pullRequestUrl: null,
+    humanApprovalReason:
+      'Infra owner must disable or reconfigure the Trigger.dev project.',
+    linearIssue: {
+      id: 'JOV-1994',
+      slug: 'agentos-disable-stale-triggerdev-production-deploy-check-while-wdk-is',
+    },
     verificationGates: [
       gate(
         'github.ci',
@@ -208,12 +281,12 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
         'External Trigger.dev check reports missing trigger.config.ts.'
       ),
     ],
-    costEstimate: zeroCost('deterministic', 'Infra status only.'),
+    costNotes: 'Infra status only.',
     blockedReason:
       'Trigger.dev deploy integration expects trigger.config.ts before the fallback runtime PR exists.',
     updatedAt: '2026-05-08T22:40:00.000Z',
-  }),
-  fixtureArtifact({
+  },
+  {
     id: 'agentos-run-failed-unsafe-payload',
     source: 'hermes',
     sourceRunId: 'hermes_dispatch_rejected_001',
@@ -222,15 +295,12 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
     title: 'Unsafe dispatch payload rejected',
     summary:
       'Hermes rejected a non-dry-run payload because requested paths and forbidden actions exceeded the approved manifest.',
-    modelRoute: 'deterministic',
     allowedActions: ['read', 'classify', 'summarize'],
     forbiddenActions: ['write_code', 'merge', 'deploy', 'mutate_linear'],
-    humanApprovalRequired: false,
-    humanGate: noHumanGate(),
-    linearIssueId: 'JOV-1926',
-    linearIssueUrl:
-      'https://linear.app/jovie/issue/JOV-1926/agentos-enforce-gstack-gates-before-non-dry-run-agents',
-    pullRequestUrl: null,
+    linearIssue: {
+      id: 'JOV-1926',
+      slug: 'agentos-enforce-gstack-gates-before-non-dry-run-agents',
+    },
     verificationGates: [
       gate(
         'github.scope-judge',
@@ -238,11 +308,10 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
         'Changed-file guard rejected out-of-scope paths.'
       ),
     ],
-    costEstimate: zeroCost('deterministic', 'Rejected before model routing.'),
-    blockedReason: null,
+    costNotes: 'Rejected before model routing.',
     updatedAt: '2026-05-08T19:15:00.000Z',
-  }),
-  fixtureArtifact({
+  },
+  {
     id: 'agentos-run-done-schema-pr',
     source: 'github',
     sourceRunId: '8240',
@@ -251,22 +320,19 @@ export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] = [
     title: 'AgentRunArtifact schema landed',
     summary:
       'Canonical AgentRunArtifact schema is available for GitHub, Linear, Hermes, Ruflo, CI, and Vercel Workflow adapters.',
-    modelRoute: 'deterministic',
-    allowedActions: ['read', 'summarize'],
-    forbiddenActions: ['merge', 'deploy', 'mutate_production_data'],
-    humanApprovalRequired: false,
-    humanGate: noHumanGate(),
-    linearIssueId: 'JOV-1923',
-    linearIssueUrl:
-      'https://linear.app/jovie/issue/JOV-1923/agentos-shared-agentrunartifact-schema',
-    pullRequestUrl: 'https://github.com/JovieInc/Jovie/pull/8240',
+    linearIssue: {
+      id: 'JOV-1923',
+      slug: 'agentos-shared-agentrunartifact-schema',
+    },
+    pullRequest: 8240,
     verificationGates: [
       gate('github.ci', 'passed', 'CI passed.'),
       gate('gstack.review', 'passed', 'Review gate passed.'),
       gate('gstack.ship', 'passed', 'Ship gate passed.'),
     ],
-    costEstimate: zeroCost('deterministic', 'No model call.'),
-    blockedReason: null,
     updatedAt: '2026-05-08T18:30:00.000Z',
-  }),
+  },
 ];
+
+export const AGENT_OS_ADMIN_FIXTURE_ARTIFACTS: readonly AgentRunArtifact[] =
+  AGENT_OS_ADMIN_FIXTURE_SEEDS.map(artifactFromSeed);

--- a/apps/web/tests/unit/agent-os/artifact.test.ts
+++ b/apps/web/tests/unit/agent-os/artifact.test.ts
@@ -116,6 +116,29 @@ describe('AgentRunArtifactSchema', () => {
     expect(result.error?.issues[0]?.path).toEqual(['humanApprovalRequired']);
   });
 
+  it('rejects non-http artifact URLs before UI rendering', () => {
+    const result = safeParseAgentRunArtifact({
+      ...baseArtifact,
+      linearIssueUrl: 'javascript:alert(1)',
+      pullRequestUrl: 'data:text/html,<script>alert(1)</script>',
+      verificationGates: [
+        {
+          ...baseArtifact.verificationGates[0],
+          evidenceUrl: 'javascript:alert(1)',
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map(issue => issue.path)).toEqual(
+      expect.arrayContaining([
+        ['linearIssueUrl'],
+        ['pullRequestUrl'],
+        ['verificationGates', 0, 'evidenceUrl'],
+      ])
+    );
+  });
+
   it('accepts read-only OpenRouter free-model artifacts with forbidden mutations', () => {
     const artifact = parseAgentRunArtifact({
       ...baseArtifact,

--- a/apps/web/tests/unit/agent-os/dry-run-workflow.test.ts
+++ b/apps/web/tests/unit/agent-os/dry-run-workflow.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  AgentOsDryRunWorkflowInputSchema,
   buildAgentOsDryRunArtifact,
   emitAgentOsDryRunArtifact,
 } from '@/workflows/agent-os-dry-run';
@@ -80,6 +81,14 @@ describe('AgentOS dry-run workflow artifact', () => {
 
     expect(artifact.id).toHaveLength(180);
     expect(artifact.id).toBe(`agentos-wdk-dry-run-${sourceRunId}`);
+  });
+
+  it('rejects non-http Linear URLs in workflow input', () => {
+    const result = AgentOsDryRunWorkflowInputSchema.safeParse({
+      linearIssueUrl: 'javascript:alert(1)',
+    });
+
+    expect(result.success).toBe(false);
   });
 
   it('emits the artifact and summary through the workflow writable stream', async () => {

--- a/apps/web/tests/unit/agent-os/fixtures.test.ts
+++ b/apps/web/tests/unit/agent-os/fixtures.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { AgentRunArtifactSchema } from '@/lib/agent-os/artifact';
+import { AGENT_OS_ADMIN_FIXTURE_ARTIFACTS } from '@/lib/agent-os/fixtures';
+
+describe('AGENT_OS_ADMIN_FIXTURE_ARTIFACTS', () => {
+  it('matches the AgentRunArtifact schema', () => {
+    for (const artifact of AGENT_OS_ADMIN_FIXTURE_ARTIFACTS) {
+      expect(AgentRunArtifactSchema.safeParse(artifact).success).toBe(true);
+    }
+  });
+
+  it('covers the admin ops v1 run states', () => {
+    const statuses = new Set(
+      AGENT_OS_ADMIN_FIXTURE_ARTIFACTS.map(artifact => artifact.status)
+    );
+
+    expect([...statuses]).toEqual(
+      expect.arrayContaining([
+        'queued',
+        'running',
+        'blocked',
+        'failed',
+        'review',
+        'done',
+      ])
+    );
+    expect(
+      AGENT_OS_ADMIN_FIXTURE_ARTIFACTS.some(
+        artifact =>
+          artifact.humanApprovalRequired &&
+          artifact.humanGate.status === 'pending'
+      )
+    ).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/agent-os/fixtures.test.ts
+++ b/apps/web/tests/unit/agent-os/fixtures.test.ts
@@ -9,6 +9,14 @@ describe('AGENT_OS_ADMIN_FIXTURE_ARTIFACTS', () => {
     }
   });
 
+  it('keeps fixture update timestamps at or after creation', () => {
+    for (const artifact of AGENT_OS_ADMIN_FIXTURE_ARTIFACTS) {
+      expect(new Date(artifact.updatedAt).getTime()).toBeGreaterThanOrEqual(
+        new Date(artifact.createdAt).getTime()
+      );
+    }
+  });
+
   it('covers the admin ops v1 run states', () => {
     const statuses = new Set(
       AGENT_OS_ADMIN_FIXTURE_ARTIFACTS.map(artifact => artifact.status)

--- a/apps/web/tests/unit/components/admin/AgentOsRunsPanel.test.tsx
+++ b/apps/web/tests/unit/components/admin/AgentOsRunsPanel.test.tsx
@@ -1,11 +1,17 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { AgentOsRunsPanel } from '@/components/features/admin/agent-os';
 import { AGENT_OS_ADMIN_FIXTURE_ARTIFACTS } from '@/lib/agent-os/fixtures';
 
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
 beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterAll(() => {
+  Element.prototype.scrollIntoView = originalScrollIntoView;
 });
 
 describe('AgentOsRunsPanel', () => {

--- a/apps/web/tests/unit/components/admin/AgentOsRunsPanel.test.tsx
+++ b/apps/web/tests/unit/components/admin/AgentOsRunsPanel.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { AgentOsRunsPanel } from '@/components/features/admin/agent-os';
+import { AGENT_OS_ADMIN_FIXTURE_ARTIFACTS } from '@/lib/agent-os/fixtures';
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe('AgentOsRunsPanel', () => {
+  it('renders fixture runs with status, approval, and gate details', async () => {
+    render(<AgentOsRunsPanel artifacts={AGENT_OS_ADMIN_FIXTURE_ARTIFACTS} />);
+
+    expect(screen.getByTestId('agent-os-runs-panel')).toBeInTheDocument();
+    expect(screen.getByText('AgentOS Runs')).toBeInTheDocument();
+    expect(screen.getAllByText('WDK health dry run').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('Main post-merge verification').length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('Trigger.dev deploy check mismatch').length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('Unsafe dispatch payload rejected').length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText('AgentRunArtifact schema landed').length
+    ).toBeGreaterThan(0);
+
+    for (const label of [
+      'Queued',
+      'Running',
+      'Review',
+      'Blocked',
+      'Failed',
+      'Done',
+    ]) {
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+    }
+
+    expect(screen.getByText('Approval Queue')).toBeInTheDocument();
+    expect(screen.getAllByText('Review Required').length).toBeGreaterThan(0);
+
+    const drawer = screen.getByTestId('agent-os-artifact-drawer');
+    expect(drawer).toHaveTextContent('WDK health dry run');
+    expect(drawer).toHaveTextContent('Verification Gates');
+
+    await userEvent.click(
+      screen.getAllByTestId('agent-os-run-agentos-run-blocked-trigger-check')[0]
+    );
+
+    expect(screen.getByTestId('agent-os-artifact-drawer')).toHaveTextContent(
+      'Trigger.dev deploy check mismatch'
+    );
+    expect(screen.getByTestId('agent-os-artifact-drawer')).toHaveTextContent(
+      'Trigger.dev deploy integration expects trigger.config.ts'
+    );
+  });
+
+  it('renders an empty table and empty approval queue', () => {
+    render(<AgentOsRunsPanel artifacts={[]} />);
+
+    expect(screen.getAllByText('No AgentOS runs').length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(
+        'AgentRunArtifact records will appear here after a workflow emits them.'
+      ).length
+    ).toBeGreaterThan(0);
+
+    expect(screen.getByText('No approvals waiting.')).toBeInTheDocument();
+  });
+});

--- a/apps/web/workflows/agent-os-dry-run.ts
+++ b/apps/web/workflows/agent-os-dry-run.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { APP_ROUTES } from '@/constants/routes';
 import {
   type AgentRunArtifact,
+  AgentRunHttpUrlSchema,
   parseAgentRunArtifact,
 } from '@/lib/agent-os/artifact';
 
@@ -23,7 +24,7 @@ export const AgentOsDryRunWorkflowInputSchema = z
       .nullable()
       .optional(),
     linearIssueId: z.string().trim().min(1).max(80).nullable().optional(),
-    linearIssueUrl: z.string().trim().url().nullable().optional(),
+    linearIssueUrl: AgentRunHttpUrlSchema.nullable().optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- Adds a private `/app/admin/ops` AgentOS runs panel backed by seeded `AgentRunArtifact` fixtures.
- Adds compact admin components for workflow status, run rows, verification gates, approval queue, and artifact details.
- Mounts the panel only inside the authenticated admin shell, leaving kiosk `/hud` behavior read-only.

## Linear
- JOV-1941

## Verification
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web exec vitest run tests/unit/components/admin/AgentOsRunsPanel.test.tsx tests/unit/agent-os/fixtures.test.ts --reporter=default`
- `pnpm --filter @jovie/web run build`
- `git diff --check`
- Commit hook: proxy guard, Biome, ESLint, a11y, web typecheck
- Pre-push hook: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint

## Visual QA
- Desktop Playwright screenshot: `/tmp/agentos-admin-ops-panel-viewport-desktop.png`
- Mobile Playwright screenshot at `390x844`: `/tmp/agentos-admin-ops-panel-viewport-mobile.png`

## Gate Notes
- GStack review/ship gates will be run on this draft PR before it is marked ready.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AgentOS runs management panel to admin dashboard, displaying run status, verification gates, and cost information.
  * Implemented approval queue feature to streamline review workflows for pending approvals.
  * Added detailed artifact viewer with verification gate summaries and metadata display.

* **Bug Fixes**
  * Improved URL validation to reject non-HTTPS external links in artifact metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->