### PR TITLE
fix(agentos): address admin bot review comments

### DIFF
--- a/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
+++ b/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@jovie/ui';
 import type { CellContext, ColumnDef } from '@tanstack/react-table';
 import { createColumnHelper } from '@tanstack/react-table';
 import { Bot, GitPullRequestArrow } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { type ComponentProps, useEffect, useMemo, useState } from 'react';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { TableEmptyState, UnifiedTable } from '@/components/organisms/table';
@@ -15,6 +15,17 @@ import { WorkflowRunRow } from './WorkflowRunRow';
 import { WorkflowStatusPill } from './WorkflowStatusPill';
 
 const columnHelper = createColumnHelper<AgentRunArtifact>();
+type BadgeVariant = ComponentProps<typeof Badge>['variant'];
+
+const HUMAN_GATE_BADGES: Record<
+  AgentRunArtifact['humanGate']['status'],
+  { readonly label: string; readonly variant: BadgeVariant }
+> = {
+  not_required: { label: 'Not required', variant: 'secondary' },
+  pending: { label: 'Review Required', variant: 'warning' },
+  approved: { label: 'Approved', variant: 'success' },
+  rejected: { label: 'Rejected', variant: 'destructive' },
+};
 
 function countPassedRequiredGates(artifact: AgentRunArtifact): string {
   const required = artifact.verificationGates.filter(gate => gate.required);
@@ -74,17 +85,11 @@ function renderHumanGateCell({ row }: CellContext<AgentRunArtifact, unknown>) {
       <span className='text-[12px] text-tertiary-token'>Not required</span>
     );
   }
+  const humanGateBadge = HUMAN_GATE_BADGES[row.original.humanGate.status];
 
   return (
-    <Badge
-      variant={
-        row.original.humanGate.status === 'approved' ? 'success' : 'warning'
-      }
-      size='sm'
-    >
-      {row.original.humanGate.status === 'approved'
-        ? 'Approved'
-        : 'Review Required'}
+    <Badge variant={humanGateBadge.variant} size='sm'>
+      {humanGateBadge.label}
     </Badge>
   );
 }
@@ -143,7 +148,20 @@ export function AgentOsRunsPanel({ artifacts }: AgentOsRunsPanelProps) {
   );
   const rows = useMemo(() => [...artifacts], [artifacts]);
   const selectedArtifact =
-    rows.find(artifact => artifact.id === selectedId) ?? rows[0] ?? null;
+    selectedId === null
+      ? null
+      : (rows.find(artifact => artifact.id === selectedId) ?? null);
+
+  useEffect(() => {
+    const nextSelectedId = rows[0]?.id ?? null;
+    const selectedIdStillExists = rows.some(
+      artifact => artifact.id === selectedId
+    );
+
+    if (!selectedIdStillExists && selectedId !== nextSelectedId) {
+      setSelectedId(nextSelectedId);
+    }
+  }, [rows, selectedId]);
 
   return (
     <ContentSurfaceCard

--- a/apps/web/lib/agent-os/artifact.ts
+++ b/apps/web/lib/agent-os/artifact.ts
@@ -74,8 +74,12 @@ export const AGENT_RUN_GATE_EVIDENCE_NAMES = [
 ] as const;
 
 function isHttpUrl(value: string): boolean {
-  const protocol = new URL(value).protocol;
-  return protocol === 'http:' || protocol === 'https:';
+  try {
+    const protocol = new URL(value).protocol;
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
 }
 
 export const AgentRunHttpUrlSchema = z
@@ -212,6 +216,18 @@ export const AgentRunArtifactSchema = z
         message: 'Blocked runs must include blockedReason.',
         path: ['blockedReason'],
       });
+    }
+
+    const gateNames = new Set<VerificationGate['name']>();
+    for (const [index, gate] of artifact.verificationGates.entries()) {
+      if (gateNames.has(gate.name)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'verificationGates must use unique names.',
+          path: ['verificationGates', index, 'name'],
+        });
+      }
+      gateNames.add(gate.name);
     }
   });
 

--- a/apps/web/lib/agent-os/fixtures.ts
+++ b/apps/web/lib/agent-os/fixtures.ts
@@ -135,7 +135,7 @@ function fixtureArtifact(input: FixtureArtifactInput): AgentRunArtifact {
     ...artifact,
     adminSurface: APP_ROUTES.ADMIN_OPS,
     createdAt,
-    metadata: { fixture: true, ...metadata },
+    metadata: { ...metadata, fixture: true },
   };
 }
 

--- a/apps/web/tests/unit/agent-os/artifact.test.ts
+++ b/apps/web/tests/unit/agent-os/artifact.test.ts
@@ -139,6 +139,37 @@ describe('AgentRunArtifactSchema', () => {
     );
   });
 
+  it('returns schema failures instead of throwing for malformed URLs', () => {
+    let result: ReturnType<typeof safeParseAgentRunArtifact> | null = null;
+
+    expect(() => {
+      result = safeParseAgentRunArtifact({
+        ...baseArtifact,
+        linearIssueUrl: 'not a url',
+      });
+    }).not.toThrow();
+
+    expect(result?.success).toBe(false);
+  });
+
+  it('rejects duplicate verification gate names', () => {
+    const result = safeParseAgentRunArtifact({
+      ...baseArtifact,
+      verificationGates: [
+        baseArtifact.verificationGates[0],
+        {
+          ...baseArtifact.verificationGates[1],
+          name: baseArtifact.verificationGates[0].name,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map(issue => issue.path)).toEqual(
+      expect.arrayContaining([['verificationGates', 1, 'name']])
+    );
+  });
+
   it('accepts read-only OpenRouter free-model artifacts with forbidden mutations', () => {
     const artifact = parseAgentRunArtifact({
       ...baseArtifact,

--- a/apps/web/tests/unit/agent-os/dry-run-workflow.test.ts
+++ b/apps/web/tests/unit/agent-os/dry-run-workflow.test.ts
@@ -89,6 +89,11 @@ describe('AgentOS dry-run workflow artifact', () => {
     });
 
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map(issue => issue.path)).toEqual(
+        expect.arrayContaining([['linearIssueUrl']])
+      );
+    }
   });
 
   it('emits the artifact and summary through the workflow writable stream', async () => {

--- a/apps/web/tests/unit/components/admin/AgentOsRunsPanel.test.tsx
+++ b/apps/web/tests/unit/components/admin/AgentOsRunsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { AgentOsRunsPanel } from '@/components/features/admin/agent-os';
@@ -53,7 +53,9 @@ describe('AgentOsRunsPanel', () => {
     expect(drawer).toHaveTextContent('Verification Gates');
 
     await userEvent.click(
-      screen.getAllByTestId('agent-os-run-agentos-run-blocked-trigger-check')[0]
+      within(screen.getByRole('table')).getByTestId(
+        'agent-os-run-agentos-run-blocked-trigger-check'
+      )
     );
 
     expect(screen.getByTestId('agent-os-artifact-drawer')).toHaveTextContent(
@@ -75,5 +77,30 @@ describe('AgentOsRunsPanel', () => {
     ).toBeGreaterThan(0);
 
     expect(screen.getByText('No approvals waiting.')).toBeInTheDocument();
+  });
+
+  it('labels rejected human gates without showing them as review required', () => {
+    const artifact = AGENT_OS_ADMIN_FIXTURE_ARTIFACTS[0];
+
+    render(
+      <AgentOsRunsPanel
+        artifacts={[
+          {
+            ...artifact,
+            humanApprovalRequired: true,
+            humanGate: {
+              required: true,
+              status: 'rejected',
+              reason: 'Operator rejected this run.',
+              reviewer: 'ops@example.com',
+              reviewedAt: artifact.updatedAt,
+            },
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getAllByText('Rejected').length).toBeGreaterThan(0);
+    expect(screen.queryByText('Review Required')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- Address final bot-review hardening from AgentOS admin PR #8306.
- Keep the follow-up scoped to URL validation safety, human-gate rendering, fixture metadata precedence, verification gate uniqueness, and focused tests.

## Gate Evidence
- Head: 648bf9e86297aee928a7c27df51355571c5cb1e4
- GStack QA: focused local checks plus CI required checks.
- GStack Review: Greptile, CodeRabbit, Seer/Sentry, SonarCloud review checks.
- GStack Ship: pre-push hook passed on rebased head.
- Bot comments: Greptile thread addressed and confirmed.

## Local Verification
- pnpm biome check --write apps/web/lib/agent-os/artifact.ts apps/web/lib/agent-os/fixtures.ts apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx apps/web/components/features/admin/agent-os/VerificationGateList.tsx apps/web/tests/unit/agent-os/artifact.test.ts apps/web/tests/unit/agent-os/dry-run-workflow.test.ts apps/web/tests/unit/components/admin/AgentOsRunsPanel.test.tsx
- pnpm --filter @jovie/web exec vitest run tests/unit/components/admin/AgentOsRunsPanel.test.tsx tests/unit/agent-os/artifact.test.ts tests/unit/agent-os/dry-run-workflow.test.ts tests/unit/agent-os/fixtures.test.ts --reporter=default
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push: biome check ., proxy guard, tailwind guard, web typecheck, web lint
