### PR TITLE
fix(a11y): avoid product rail focus clipping

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -2689,6 +2689,11 @@ body:has(.home-viewport)::-webkit-scrollbar {
   display: none;
 }
 
+.homepage-product-rail:focus-within {
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
 .homepage-product-pane {
   position: relative;
   flex: 0 0 auto;


### PR DESCRIPTION
## Summary
- Prevent the product rail focus affordance from being clipped by the masked edge fade
- Keep the fade during normal viewing, and remove it only while keyboard focus is inside the rail
- Addresses Sentry feedback from #8333: https://github.com/JovieInc/Jovie/pull/8333#discussion_r3212114166

## Verification
- `pnpm biome check --write apps/web/app/'(home)'/home.css`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Focused local axe for `home passes WCAG AA|marketing-launch passes WCAG AA`: 2 passed
- Pre-push hook: Biome, proxy guard, Tailwind guard, typecheck, lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard navigation on the product carousel rail to ensure content is fully visible when tabbing through items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->