### PR TITLE
fix(hud): mercury metrics — correct USD amounts + timeout resilience

### DIFF
--- a/apps/web/lib/admin/mercury-metrics.ts
+++ b/apps/web/lib/admin/mercury-metrics.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import { env } from '@/lib/env-server';
 import { captureError } from '@/lib/error-tracking';
-import { serverFetch } from '@/lib/http/server-fetch';
+import { ServerFetchTimeoutError, serverFetch } from '@/lib/http/server-fetch';
 
 const MERCURY_BASE_URL =
   env.MERCURY_API_BASE_URL?.trim() || 'https://api.mercury.com/api/v1';
@@ -90,6 +90,9 @@ async function fetchMercury<T>(
       'Content-Type': 'application/json',
     },
     cache: 'no-store',
+    // Mercury transactions endpoint can be slow when paginating 30 days of data.
+    // 8s gives enough headroom without blocking the HUD indefinitely.
+    timeoutMs: 8000,
   });
 
   if (!response.ok) {
@@ -119,11 +122,10 @@ function isDebit(transaction: MercuryTransaction, amount: number): boolean {
   return amount < 0;
 }
 
-function centsToUsd(amountCents: number): number {
-  return amountCents / 100;
-}
+// NOTE: Mercury API returns amounts in USD dollars (e.g. 328.92 = $328.92),
+// NOT cents. Do not divide by 100.
 
-async function getCheckingBalanceCents(): Promise<number> {
+async function getCheckingBalanceUsd(): Promise<number> {
   const mercuryEnv = getMercuryEnv();
   if (!mercuryEnv) return 0;
 
@@ -131,14 +133,14 @@ async function getCheckingBalanceCents(): Promise<number> {
     `/accounts/${mercuryEnv.checkingAccountId}`
   );
 
-  const balanceCents = Number(
+  const balanceUsd = Number(
     account.availableBalance ?? account.currentBalance ?? account.balance ?? 0
   );
 
-  return balanceCents;
+  return balanceUsd;
 }
 
-async function getCheckingTransactionsCents(
+async function getCheckingTransactions(
   startDate: Date,
   endDate: Date
 ): Promise<MercuryTransaction[]> {
@@ -194,21 +196,37 @@ export async function getAdminMercuryMetrics(): Promise<AdminMercuryMetrics> {
     const endDate = new Date();
     const startDate = new Date(endDate.getTime() - 30 * MS_PER_DAY);
 
-    const [balanceCents, transactions] = await Promise.all([
-      getCheckingBalanceCents(),
-      getCheckingTransactionsCents(startDate, endDate),
-    ]);
+    // Fetch balance first — it's fast and most important for the HUD.
+    const balanceUsd = await getCheckingBalanceUsd();
 
-    const debitCents = transactions.reduce((total, transaction) => {
-      const amount = normalizeAmount(transaction.amount);
-      if (Number.isNaN(amount)) return total;
-      if (!isDebit(transaction, amount)) return total;
-      return total + Math.abs(amount);
-    }, 0);
+    // Transactions can be slow (30-day pagination). If they time out, degrade
+    // gracefully: show the balance as available with burnRateUsd=0 rather than
+    // marking Mercury as unavailable entirely.
+    let burnRateUsd = 0;
+    try {
+      const transactions = await getCheckingTransactions(startDate, endDate);
+      burnRateUsd = transactions.reduce((total, transaction) => {
+        const amount = normalizeAmount(transaction.amount);
+        if (Number.isNaN(amount)) return total;
+        if (!isDebit(transaction, amount)) return total;
+        return total + Math.abs(amount);
+      }, 0);
+    } catch (txError) {
+      if (txError instanceof ServerFetchTimeoutError) {
+        // Degraded mode: balance is still accurate, burn rate unavailable.
+        captureError(
+          'Mercury transactions timed out — burn rate unavailable',
+          txError
+        );
+      } else {
+        // Re-throw non-timeout errors so the outer catch handles them.
+        throw txError;
+      }
+    }
 
     return {
-      balanceUsd: centsToUsd(balanceCents),
-      burnRateUsd: centsToUsd(debitCents),
+      balanceUsd,
+      burnRateUsd,
       burnWindowDays: 30,
       isConfigured: true,
       isAvailable: true,

--- a/apps/web/lib/admin/mercury-metrics.ts
+++ b/apps/web/lib/admin/mercury-metrics.ts
@@ -149,8 +149,15 @@ async function getCheckingTransactions(
 
   const transactions: MercuryTransaction[] = [];
   let cursor: string | undefined;
+  // Safety guard: cap pagination to avoid unbounded iteration if Mercury
+  // returns unexpectedly many pages (each request has its own 8s timeout).
+  const MAX_PAGES = 20;
+  let pageCount = 0;
 
   for (;;) {
+    if (pageCount >= MAX_PAGES) break;
+    pageCount++;
+
     const response = await fetchMercury<MercuryTransactionsResponse>(
       `/accounts/${mercuryEnv.checkingAccountId}/transactions`,
       {

--- a/apps/web/tests/lib/admin/mercury-metrics.test.ts
+++ b/apps/web/tests/lib/admin/mercury-metrics.test.ts
@@ -40,20 +40,22 @@ describe('getAdminMercuryMetrics', () => {
     process.env.MERCURY_API_TOKEN = 'token';
     process.env.MERCURY_CHECKING_ACCOUNT_ID = 'acct_123';
 
+    // Mercury API returns amounts in USD dollars (not cents).
+    // $2,500.00 balance, $50.00 + $25.00 debits = $75.00 burn rate.
     fetchMock
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
-          availableBalance: 250000,
+          availableBalance: 2500,
         }),
       })
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
           transactions: [
-            { amount: 5000, direction: 'debit' },
-            { amount: 2500, direction: 'debit' },
-            { amount: 4000, direction: 'credit' },
+            { amount: 50, direction: 'debit' },
+            { amount: 25, direction: 'debit' },
+            { amount: 40, direction: 'credit' },
           ],
         }),
       });


### PR DESCRIPTION
<!-- linear-issue-id:none -->

## Summary
- Mercury returns USD not cents; remove `centsToUsd()` division (balance was showing 100x too low — e.g. $328.92 displayed as $3.29)
- Add 8s timeout to Mercury API calls via `timeoutMs: 8000`; degrade gracefully (return `isAvailable:true` with `burnRateUsd:0`) instead of `isAvailable:false` on slow transaction fetches
- Import `ServerFetchTimeoutError` to distinguish timeout failures from real API errors

## Changes
- `apps/web/lib/admin/mercury-metrics.ts`
  - Removed `centsToUsd()` helper (it was wrong — Mercury uses dollars not cents)
  - Renamed `getCheckingBalanceCents` → `getCheckingBalanceUsd`, `getCheckingTransactionsCents` → `getCheckingTransactions`
  - Added `timeoutMs: 8000` to all `serverFetch` calls
  - Split balance + transaction fetches: balance failure = full unavailable; transaction timeout = degraded mode (balance shown, burn rate = 0)

## Test plan
- [ ] Typecheck passes
- [ ] Balance displayed in HUD matches actual Mercury balance (no 100x division)
- [ ] HUD shows Mercury as available even when transactions endpoint is slow/times out

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout protection for Mercury metrics requests to prevent indefinite hangs.
  * Balance now displays reliably even if transaction fetches time out; system degrades gracefully and logs timeouts.
  * Corrected financial calculations to use USD amounts.
  * Capped transaction pagination to avoid unbounded loops.

* **Tests**
  * Updated unit tests to reflect USD-based values and expected burn-rate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->