### PR TITLE
feat(infra): cost-anomaly auto-rollback gate (dry-run default)

### DIFF
--- a/.claude/rules/infra.md
+++ b/.claude/rules/infra.md
@@ -104,3 +104,4 @@ All API routes run on **Node.js runtime** (the Next.js default). Do not use Edge
 | `docs/WEBHOOK_MAP.md` | Which webhooks handle this provider's events? |
 | `docs/API_ROUTE_MAP.md` | Does an API endpoint already exist for this? What auth does it need? |
 | `docs/FEATURE_REGISTRY.md` | What feature flags exist? What are their current states? |
+| `docs/COST_MONITORING.md` | What stops a runaway code path from blowing up the bill? Provider spend caps + the cost-anomaly auto-rollback gate. |

--- a/.github/workflows/cost-anomaly-gate.yml
+++ b/.github/workflows/cost-anomaly-gate.yml
@@ -1,0 +1,319 @@
+# Cost Anomaly Gate
+#
+# PURPOSE: Continuous post-deploy safety net that detects when production event
+# volume (a proxy for cost-driving activity: function invocations, external API
+# calls, log volume) spikes beyond a baseline. On anomaly: auto-rollback +
+# Slack alert.
+#
+# This complements the one-shot Sentry Error Gate. The error gate catches
+# regressions that THROW; this gate catches runaways that SUCCEED — a tight
+# loop hammering an external API, a cron processing an unbounded backlog, or
+# a code path that suddenly emits 1000x its normal traffic. Those scenarios
+# don't generate errors but do burn money.
+#
+# Background: an earlier project the founder ran lost ~$12k over 12 days
+# from a runaway log/API loop while he was unavailable. Hard caps at the
+# provider level (Vercel Spend Management, Anthropic usage limits, etc.) are
+# the primary defense; see docs/COST_MONITORING.md for the full checklist.
+# This workflow is the secondary defense: it triggers a rollback BEFORE
+# spending hits the cap.
+#
+# TRIGGER: Scheduled every 15 minutes + manual workflow_dispatch.
+#
+# HOW IT WORKS:
+# 1. Query Sentry for current event count (last 60 min, all event types).
+# 2. Query Sentry for baseline event count: same hour-of-week from the
+#    prior 4 weeks, averaged.
+# 3. Anomaly if current > max(baseline * threshold_multiplier, absolute_floor).
+# 4. On anomaly: vercel rollback --yes + Slack alert + GitHub issue.
+#
+# SAFETY:
+# - Defaults to DRY RUN until explicitly enabled. Initial rollouts post to
+#   Slack only; flip dry_run to false after threshold is calibrated.
+# - Absolute floor prevents low-traffic-hour false positives.
+# - Cooldown via GitHub Actions concurrency group prevents flapping.
+
+name: Cost Anomaly Gate
+
+on:
+  schedule:
+    # Every 15 minutes. GH Actions cron has up to several minutes of drift
+    # under load; that's acceptable for cost monitoring.
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run: detect anomalies but do NOT trigger rollback'
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+      threshold_multiplier:
+        description: 'Multiplier above baseline that triggers rollback'
+        required: false
+        default: '5'
+        type: string
+      absolute_floor:
+        description: 'Minimum event count required to consider anomaly real (prevents low-traffic noise)'
+        required: false
+        default: '1000'
+        type: string
+      lookback_minutes:
+        description: 'Minutes of recent traffic to evaluate'
+        required: false
+        default: '60'
+        type: string
+
+# Prevent overlapping runs; if a previous run is still evaluating or rolling
+# back, the next one waits. This also implicitly cools down rapid-fire
+# rollbacks because a fresh evaluation can't start until the prior one
+# completes.
+concurrency:
+  group: cost-anomaly-gate
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  evaluate:
+    name: Evaluate Production Event Volume
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Defaults to DRY RUN on schedule until thresholds are calibrated against
+    # real production baselines. After observing 1-2 weeks of healthy runs in
+    # Slack with no false positives, flip this default to 'false' to enable
+    # auto-rollback. Manual workflow_dispatch honors the input choice.
+    env:
+      DRY_RUN: ${{ github.event.inputs.dry_run || 'true' }}
+      THRESHOLD_MULTIPLIER: ${{ github.event.inputs.threshold_multiplier || '5' }}
+      ABSOLUTE_FLOOR: ${{ github.event.inputs.absolute_floor || '1000' }}
+      LOOKBACK_MINUTES: ${{ github.event.inputs.lookback_minutes || '60' }}
+    steps:
+      - name: Query current event volume
+        id: current
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          END_EPOCH=$(date +%s)
+          START_EPOCH=$((END_EPOCH - LOOKBACK_MINUTES * 60))
+          START_ISO=$(date -u -d "@$START_EPOCH" '+%Y-%m-%dT%H:%M:%S')
+          END_ISO=$(date -u -d "@$END_EPOCH" '+%Y-%m-%dT%H:%M:%S')
+
+          echo "Current window: $START_ISO to $END_ISO (${LOOKBACK_MINUTES} min)"
+
+          STATS_RESPONSE=$(curl -sS \
+            -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+            "https://sentry.io/api/0/organizations/$SENTRY_ORG/events-stats/?project=$SENTRY_PROJECT&field=count()&start=$START_ISO&end=$END_ISO&interval=1m" \
+            2>/dev/null || echo '{"data":[]}')
+
+          COUNT=$(echo "$STATS_RESPONSE" | jq '[.data[]?[1][]?.count // 0] | add // 0' 2>/dev/null || echo "0")
+
+          echo "Current event count: $COUNT"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
+      - name: Query baseline event volume (same hour-of-week, prior 4 weeks)
+        id: baseline
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          # Sample the same hour-of-week from each of the prior 4 weeks
+          # (7, 14, 21, 28 days ago). Average them. This handles weekly
+          # traffic seasonality (weekend dips, business-hour peaks).
+          NOW_EPOCH=$(date +%s)
+          TOTAL=0
+          SAMPLES=0
+
+          for WEEKS_AGO in 1 2 3 4; do
+            END_EPOCH=$((NOW_EPOCH - WEEKS_AGO * 7 * 86400))
+            START_EPOCH=$((END_EPOCH - LOOKBACK_MINUTES * 60))
+            START_ISO=$(date -u -d "@$START_EPOCH" '+%Y-%m-%dT%H:%M:%S')
+            END_ISO=$(date -u -d "@$END_EPOCH" '+%Y-%m-%dT%H:%M:%S')
+
+            STATS_RESPONSE=$(curl -sS \
+              -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+              "https://sentry.io/api/0/organizations/$SENTRY_ORG/events-stats/?project=$SENTRY_PROJECT&field=count()&start=$START_ISO&end=$END_ISO&interval=1m" \
+              2>/dev/null || echo '{"data":[]}')
+
+            SAMPLE=$(echo "$STATS_RESPONSE" | jq '[.data[]?[1][]?.count // 0] | add // 0' 2>/dev/null || echo "0")
+
+            echo "Week -${WEEKS_AGO}: $START_ISO to $END_ISO → $SAMPLE events"
+            TOTAL=$((TOTAL + SAMPLE))
+            SAMPLES=$((SAMPLES + 1))
+          done
+
+          if [[ "$SAMPLES" -gt 0 ]]; then
+            AVG=$((TOTAL / SAMPLES))
+          else
+            AVG=0
+          fi
+
+          echo "Baseline (4-week avg): $AVG events"
+          echo "average=$AVG" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate anomaly
+        id: evaluate
+        run: |
+          CURRENT="${{ steps.current.outputs.count }}"
+          BASELINE="${{ steps.baseline.outputs.average }}"
+
+          echo "=== Cost Anomaly Evaluation ==="
+          echo "Current events:  $CURRENT (last ${LOOKBACK_MINUTES} min)"
+          echo "Baseline events: $BASELINE (4-week avg, same hour-of-week)"
+          echo "Multiplier:      ${THRESHOLD_MULTIPLIER}x"
+          echo "Absolute floor:  $ABSOLUTE_FLOOR"
+
+          # Threshold = max(baseline * multiplier, absolute_floor)
+          # The floor prevents low-traffic-hour false positives where
+          # baseline=10 and current=60 would otherwise fire.
+          MULTIPLIED=$((BASELINE * THRESHOLD_MULTIPLIER))
+          if [[ "$MULTIPLIED" -gt "$ABSOLUTE_FLOOR" ]]; then
+            THRESHOLD=$MULTIPLIED
+          else
+            THRESHOLD=$ABSOLUTE_FLOOR
+          fi
+          echo "Effective threshold: $THRESHOLD"
+
+          if [[ "$CURRENT" -gt "$THRESHOLD" ]]; then
+            if [[ "$BASELINE" -gt 0 ]]; then
+              RATIO=$((CURRENT * 100 / BASELINE))
+              REASON="Event volume spike: ${RATIO}% of baseline (${CURRENT} vs ${BASELINE}, threshold ${THRESHOLD_MULTIPLIER}x)"
+            else
+              REASON="Event volume spike: ${CURRENT} events (no baseline; absolute floor ${ABSOLUTE_FLOOR} exceeded)"
+            fi
+            echo "ANOMALY DETECTED: $REASON"
+            echo "status=anomaly" >> "$GITHUB_OUTPUT"
+            echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+          else
+            echo "Event volume within normal range"
+            echo "status=normal" >> "$GITHUB_OUTPUT"
+            echo "reason=Within normal range (current=${CURRENT}, threshold=${THRESHOLD})" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository for rollback
+        if: steps.evaluate.outputs.status == 'anomaly' && env.DRY_RUN == 'false'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js and pnpm for rollback
+        if: steps.evaluate.outputs.status == 'anomaly' && env.DRY_RUN == 'false'
+        uses: ./.github/actions/setup-node-pnpm
+
+      - name: Auto-rollback on anomaly
+        if: steps.evaluate.outputs.status == 'anomaly' && env.DRY_RUN == 'false'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          echo "Cost anomaly gate FAILED. Triggering auto-rollback..."
+
+          ./node_modules/.bin/vercel rollback --yes --token "$VERCEL_TOKEN" 2>&1 || {
+            echo "Auto-rollback failed or not supported. Manual intervention required."
+            exit 0
+          }
+
+          echo "Auto-rollback completed"
+
+      - name: Slack alert on anomaly
+        if: steps.evaluate.outputs.status == 'anomaly' && env.SLACK_WEBHOOK_URL != ''
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          CURRENT="${{ steps.current.outputs.count }}"
+          BASELINE="${{ steps.baseline.outputs.average }}"
+          REASON="${{ steps.evaluate.outputs.reason }}"
+
+          if [[ "$DRY_RUN" == "true" ]]; then
+            HEADLINE="🟡 Cost Anomaly Detected (DRY RUN — no rollback)"
+            COLOR="warning"
+          else
+            HEADLINE="🚨 Cost Anomaly Gate FAILED — Auto-Rollback Triggered"
+            COLOR="danger"
+          fi
+
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -n \
+              --arg headline "$HEADLINE" \
+              --arg color "$COLOR" \
+              --arg reason "$REASON" \
+              --arg current "$CURRENT" \
+              --arg baseline "$BASELINE" \
+              --arg lookback "$LOOKBACK_MINUTES" \
+              --arg multiplier "$THRESHOLD_MULTIPLIER" \
+              --arg dry_run "$DRY_RUN" \
+              --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              '{
+                text: $headline,
+                attachments: [{
+                  color: $color,
+                  fields: [
+                    {title: "Reason", value: $reason, short: false},
+                    {title: "Current Events", value: ($current + " (last " + $lookback + " min)"), short: true},
+                    {title: "Baseline", value: ($baseline + " (4-week avg)"), short: true},
+                    {title: "Threshold", value: ($multiplier + "x baseline"), short: true},
+                    {title: "Dry Run", value: $dry_run, short: true},
+                    {title: "Action", value: ("<" + $run_url + "|View Run>  •  See docs/COST_MONITORING.md for runbook"), short: false}
+                  ]
+                }]
+              }'
+            )" || true
+
+      - name: Open GitHub issue on anomaly
+        if: steps.evaluate.outputs.status == 'anomaly' && env.DRY_RUN == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT="${{ steps.current.outputs.count }}"
+          BASELINE="${{ steps.baseline.outputs.average }}"
+          REASON="${{ steps.evaluate.outputs.reason }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BODY_FILE=$(mktemp)
+          {
+            printf '## Cost anomaly detected and rolled back\n\n'
+            printf '**Reason:** %s\n\n' "$REASON"
+            printf '**Current event volume:** %s (last %s min)\n' "$CURRENT" "$LOOKBACK_MINUTES"
+            printf '**Baseline (4-week avg):** %s\n' "$BASELINE"
+            printf '**Threshold:** %sx baseline OR %s absolute floor\n\n' "$THRESHOLD_MULTIPLIER" "$ABSOLUTE_FLOOR"
+            printf '**Workflow run:** %s\n\n' "$RUN_URL"
+            printf '## Required follow-up\n\n'
+            printf '1. Confirm rollback succeeded and verify production points to the prior deployment.\n'
+            printf '2. Identify which deployment caused the spike via `git log` between the rolled-back HEAD and the previous prod SHA.\n'
+            printf '3. Identify the runaway code path: Sentry transactions, Vercel function logs, per-route invocation counts.\n'
+            printf '4. Verify provider-side spend caps held (see docs/COST_MONITORING.md Layer 1 checklist).\n'
+            printf '5. Patch the root cause and redeploy.\n'
+            printf '6. If this was a false positive, tune `threshold_multiplier` or `absolute_floor` in the workflow.\n\n'
+            printf '## Runbook\nSee `docs/COST_MONITORING.md`.\n'
+          } > "$BODY_FILE"
+
+          gh issue create \
+            --title "Cost anomaly auto-rollback triggered: $(date -u +%Y-%m-%dT%H:%MZ)" \
+            --label "cost-monitoring,incident" \
+            --body-file "$BODY_FILE" || echo "Failed to open GitHub issue (non-fatal)"
+
+      - name: Summary
+        if: always()
+        run: |
+          STATUS="${{ steps.evaluate.outputs.status }}"
+          REASON="${{ steps.evaluate.outputs.reason }}"
+          CURRENT="${{ steps.current.outputs.count }}"
+          BASELINE="${{ steps.baseline.outputs.average }}"
+
+          echo "### Cost Anomaly Gate Result" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Metric | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Status | $STATUS |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Current events (${LOOKBACK_MINUTES} min) | $CURRENT |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Baseline (4-week avg) | $BASELINE |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Threshold multiplier | ${THRESHOLD_MULTIPLIER}x |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Absolute floor | $ABSOLUTE_FLOOR |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Dry run | $DRY_RUN |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Reason | $REASON |" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cost-anomaly-gate.yml
+++ b/.github/workflows/cost-anomaly-gate.yml
@@ -93,6 +93,7 @@ jobs:
       THRESHOLD_MULTIPLIER: ${{ github.event.inputs.threshold_multiplier || '5' }}
       ABSOLUTE_FLOOR: ${{ github.event.inputs.absolute_floor || '1000' }}
       LOOKBACK_MINUTES: ${{ github.event.inputs.lookback_minutes || '60' }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
       - name: Query current event volume
         id: current
@@ -225,7 +226,7 @@ jobs:
           fi
 
       - name: Slack alert on anomaly
-        if: steps.evaluate.outputs.status == 'anomaly' && secrets.SLACK_WEBHOOK_URL != ''
+        if: steps.evaluate.outputs.status == 'anomaly' && env.SLACK_WEBHOOK_URL != ''
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |

--- a/.github/workflows/cost-anomaly-gate.yml
+++ b/.github/workflows/cost-anomaly-gate.yml
@@ -40,6 +40,7 @@ on:
     # Every 15 minutes. GH Actions cron has up to several minutes of drift
     # under load; that's acceptable for cost monitoring.
     - cron: '*/15 * * * *'
+      timezone: 'America/Los_Angeles'
   workflow_dispatch:
     inputs:
       dry_run:
@@ -206,6 +207,7 @@ jobs:
         uses: ./.github/actions/setup-node-pnpm
 
       - name: Auto-rollback on anomaly
+        id: rollback
         if: steps.evaluate.outputs.status == 'anomaly' && env.DRY_RUN == 'false'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -214,15 +216,16 @@ jobs:
         run: |
           echo "Cost anomaly gate FAILED. Triggering auto-rollback..."
 
-          ./node_modules/.bin/vercel rollback --yes --token "$VERCEL_TOKEN" 2>&1 || {
+          if ./node_modules/.bin/vercel rollback --yes --token "$VERCEL_TOKEN" 2>&1; then
+            echo "Auto-rollback completed"
+            echo "rollback_status=success" >> "$GITHUB_OUTPUT"
+          else
             echo "Auto-rollback failed or not supported. Manual intervention required."
-            exit 0
-          }
-
-          echo "Auto-rollback completed"
+            echo "rollback_status=failed" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Slack alert on anomaly
-        if: steps.evaluate.outputs.status == 'anomaly' && env.SLACK_WEBHOOK_URL != ''
+        if: steps.evaluate.outputs.status == 'anomaly' && secrets.SLACK_WEBHOOK_URL != ''
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
@@ -238,6 +241,8 @@ jobs:
             COLOR="danger"
           fi
 
+          ROLLBACK_STATUS="${{ steps.rollback.outputs.rollback_status }}"
+
           curl -sS -X POST "$SLACK_WEBHOOK_URL" \
             -H 'Content-Type: application/json' \
             -d "$(jq -n \
@@ -249,6 +254,7 @@ jobs:
               --arg lookback "$LOOKBACK_MINUTES" \
               --arg multiplier "$THRESHOLD_MULTIPLIER" \
               --arg dry_run "$DRY_RUN" \
+              --arg rollback_status "$ROLLBACK_STATUS" \
               --arg run_url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
               '{
                 text: $headline,
@@ -260,11 +266,21 @@ jobs:
                     {title: "Baseline", value: ($baseline + " (4-week avg)"), short: true},
                     {title: "Threshold", value: ($multiplier + "x baseline"), short: true},
                     {title: "Dry Run", value: $dry_run, short: true},
+                    {title: "Rollback Status", value: (if $rollback_status == "" then "n/a (dry run)" else $rollback_status end), short: true},
                     {title: "Action", value: ("<" + $run_url + "|View Run>  •  See docs/COST_MONITORING.md for runbook"), short: false}
                   ]
                 }]
               }'
             )" || true
+
+      - name: Ensure required labels exist
+        if: steps.evaluate.outputs.status == 'anomaly' && env.DRY_RUN == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Idempotent — gh label create fails silently if the label already exists.
+          gh label create cost-monitoring --description "Cost monitoring and anomaly detection" --color "e4e669" 2>/dev/null || true
+          gh label create incident --description "Production incident or rollback" --color "d93f0b" 2>/dev/null || true
 
       - name: Open GitHub issue on anomaly
         if: steps.evaluate.outputs.status == 'anomaly' && env.DRY_RUN == 'false'
@@ -274,6 +290,7 @@ jobs:
           CURRENT="${{ steps.current.outputs.count }}"
           BASELINE="${{ steps.baseline.outputs.average }}"
           REASON="${{ steps.evaluate.outputs.reason }}"
+          ROLLBACK_STATUS="${{ steps.rollback.outputs.rollback_status }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BODY_FILE=$(mktemp)
           {
@@ -282,6 +299,7 @@ jobs:
             printf '**Current event volume:** %s (last %s min)\n' "$CURRENT" "$LOOKBACK_MINUTES"
             printf '**Baseline (4-week avg):** %s\n' "$BASELINE"
             printf '**Threshold:** %sx baseline OR %s absolute floor\n\n' "$THRESHOLD_MULTIPLIER" "$ABSOLUTE_FLOOR"
+            printf '**Rollback status:** %s\n\n' "$ROLLBACK_STATUS"
             printf '**Workflow run:** %s\n\n' "$RUN_URL"
             printf '## Required follow-up\n\n'
             printf '1. Confirm rollback succeeded and verify production points to the prior deployment.\n'

--- a/docs/COST_MONITORING.md
+++ b/docs/COST_MONITORING.md
@@ -21,6 +21,7 @@ This document covers the cost-anomaly defense layer. It exists because of a real
 This is the primary defense. Walk this checklist on initial setup and re-verify quarterly as baseline traffic grows.
 
 ### Vercel
+
 - Dashboard: **Settings → Billing → Spend Management**
 - Action: enable hard cap (pauses project at limit; does NOT just alert)
 - Recommended: 3-5x current monthly baseline
@@ -28,30 +29,36 @@ This is the primary defense. Walk this checklist on initial setup and re-verify 
 - Verify: take a screenshot of the configured cap and attach to the verification PR
 
 ### Anthropic
+
 - Dashboard: **Console → Plans & Billing → Usage limits**
 - Action: set both **daily** and **monthly** caps
 - Recommended daily: 2x typical day's spend (gives runaway ~12 hours before hard stop)
 - Critical because we have 3 LLM-calling crons (`generate-insights`, `summarize-interviews`, `generate-playlist`) with no per-call ledger
 
 ### OpenAI (if used)
+
 - Dashboard: **Billing → Usage limits**
 - Action: set both **soft** (email alert) and **hard** (refuses requests) limits
 - Recommended hard limit: 3x typical monthly spend
 
 ### Resend
+
 - Dashboard: **Settings → API rate limit**
 - Action: cap requests/hour at 10x typical send volume
 - Critical because `frequent` cron's `sendNotifications` sub-job can fan out to many fans on release-day events
 
 ### Twilio (if used)
+
 - Dashboard: **Console → Usage triggers**
 - Action: set daily SMS spend cap with notification + suspend action
 
 ### Neon
+
 - Already configured: compute autosuspend
 - Verify: autosuspend timeout = 5 minutes (Neon dashboard → branch settings)
 
 ### R2 / Cloudflare
+
 - R2 has no native spend cap as of writing; rely on Layer 2 and bandwidth alerts in Cloudflare dashboard
 
 ---

--- a/docs/COST_MONITORING.md
+++ b/docs/COST_MONITORING.md
@@ -1,0 +1,159 @@
+# Cost Monitoring & Auto-Rollback
+
+> **Question this answers:** "If a deploy lands and starts costing $X/day in unexpected spend, will the system catch it before I notice?"
+
+This document covers the cost-anomaly defense layer. It exists because of a real prior incident where a runaway log/API loop cost ~$12k over 12 days while the founder was unavailable.
+
+## Architecture: Three Layers
+
+| Layer | Mechanism | Coverage | Defense Type |
+|---|---|---|---|
+| **1** | Provider-native spend caps | All providers | **Hard circuit-breaker** — provider stops billing |
+| **2** | `cost-anomaly-gate.yml` | Vercel deployments | **Auto-rollback** — reverts deploy on event-volume spike |
+| **3** | Provider usage ledger (future) | Per-provider attribution | Per-provider day-over-day anomaly detection |
+
+**Layers 1 and 2 are independent.** If Layer 2's monitoring breaks, Layer 1 still caps your spend. If Layer 1's cap is set too high, Layer 2 catches the spike sooner.
+
+---
+
+## Layer 1: Provider Spend Caps (Checklist)
+
+This is the primary defense. Walk this checklist on initial setup and re-verify quarterly as baseline traffic grows.
+
+### Vercel
+- Dashboard: **Settings → Billing → Spend Management**
+- Action: enable hard cap (pauses project at limit; does NOT just alert)
+- Recommended: 3-5x current monthly baseline
+- Requires: Vercel Pro plan (Hobby has no spend management)
+- Verify: take a screenshot of the configured cap and attach to the verification PR
+
+### Anthropic
+- Dashboard: **Console → Plans & Billing → Usage limits**
+- Action: set both **daily** and **monthly** caps
+- Recommended daily: 2x typical day's spend (gives runaway ~12 hours before hard stop)
+- Critical because we have 3 LLM-calling crons (`generate-insights`, `summarize-interviews`, `generate-playlist`) with no per-call ledger
+
+### OpenAI (if used)
+- Dashboard: **Billing → Usage limits**
+- Action: set both **soft** (email alert) and **hard** (refuses requests) limits
+- Recommended hard limit: 3x typical monthly spend
+
+### Resend
+- Dashboard: **Settings → API rate limit**
+- Action: cap requests/hour at 10x typical send volume
+- Critical because `frequent` cron's `sendNotifications` sub-job can fan out to many fans on release-day events
+
+### Twilio (if used)
+- Dashboard: **Console → Usage triggers**
+- Action: set daily SMS spend cap with notification + suspend action
+
+### Neon
+- Already configured: compute autosuspend
+- Verify: autosuspend timeout = 5 minutes (Neon dashboard → branch settings)
+
+### R2 / Cloudflare
+- R2 has no native spend cap as of writing; rely on Layer 2 and bandwidth alerts in Cloudflare dashboard
+
+---
+
+## Layer 2: Cost Anomaly Gate Workflow
+
+`.github/workflows/cost-anomaly-gate.yml` runs every 15 minutes against production. It queries Sentry for total event volume over the last hour and compares against a 4-week same-hour-of-week baseline. On anomaly: triggers `vercel rollback --yes`, posts to Slack, opens a GitHub issue.
+
+### Why event volume?
+
+A runaway code path that **succeeds** but burns money (tight loop hammering an external API, cron processing an unbounded backlog, log-volume blowup) doesn't show up in error metrics. But it almost always shows up in transaction/event volume because:
+- Sentry instruments all API routes and server actions
+- A runaway loop produces orders-of-magnitude more transactions
+- Even non-instrumented runaways usually have downstream effects (DB queries, errors eventually)
+
+This is a proxy metric, not a direct cost metric. If the runaway is in something Sentry doesn't see (e.g. a pure `console.log` flood), Layer 1 catches it instead.
+
+### Tunable knobs (workflow inputs on `workflow_dispatch`)
+
+| Input | Default | Purpose |
+|---|---|---|
+| `dry_run` | `true` | When true, detects anomalies + posts to Slack but does NOT roll back. Flip to `false` after calibration. |
+| `threshold_multiplier` | `5` | Anomaly = current > baseline × this. |
+| `absolute_floor` | `1000` | Anomaly requires current > this many events even if multiplier hits. Prevents low-traffic-hour false positives. |
+| `lookback_minutes` | `60` | How much recent traffic to evaluate. |
+
+### Calibration procedure (run on initial setup)
+
+1. **Deploy the workflow with `dry_run` defaulted to `true`**. The current default is already `true`.
+2. **Watch Slack for 1-2 weeks.** Note any "Cost Anomaly Detected (DRY RUN)" alerts. Each one would have triggered a rollback in production.
+3. **Investigate every alert.** Was it a real anomaly or a false positive?
+   - **Real anomaly with a known cause** (release-day notification fan-out, traffic spike from press): adjust `threshold_multiplier` upward or document as expected.
+   - **False positive** (stable traffic, just baseline drift): adjust `threshold_multiplier` upward.
+4. **When you go a full week with zero false positives**, edit `.github/workflows/cost-anomaly-gate.yml` and change the default of `DRY_RUN` from `'true'` to `'false'`.
+5. **Verify rollback path** before flipping: run `gh workflow run cost-anomaly-gate.yml -f dry_run=false -f threshold_multiplier=0 -f absolute_floor=0` in a maintenance window. This forces a synthetic anomaly. Confirm `vercel rollback --yes` actually reverts production. Roll forward immediately afterward.
+
+### When the gate fires (on-call runbook)
+
+Slack alert lands. GitHub issue opens. Production has been rolled back to the prior deployment.
+
+1. **Confirm rollback succeeded:**
+   ```bash
+   doppler run -- vercel ls --token "$VERCEL_TOKEN" | head -5
+   curl -s https://jov.ie/api/health
+   ```
+
+2. **Identify the bad deployment.** The rollback reverts to the immediately-prior production deployment. Find the commits in between:
+   ```bash
+   gh pr list --state merged --base main --limit 10
+   git log --oneline <prior-prod-sha>..<rolled-back-sha>
+   ```
+
+3. **Find the runaway code path.** In order of speed:
+   - **Sentry → Performance → Transactions** filtered to the spike window. Sort by count desc. The top-1 transaction is your culprit.
+   - **Vercel → Logs** filtered to the spike window. Look for repeated patterns.
+   - **Vercel → Functions** filtered to the spike window. Look for one function with 10-100x normal invocation count.
+   - **Anthropic / Resend dashboards** for spend spike correlated to the same window.
+
+4. **Verify Layer 1 caps held.** Spot-check Vercel Spend Management, Anthropic usage, Resend logs. If any provider went above its cap, the cap is misconfigured.
+
+5. **Fix and redeploy.** The rolled-back code is back in production; you have time. Open a fix PR, get it through normal review, ship.
+
+6. **If false positive:** tune `threshold_multiplier` upward in `.github/workflows/cost-anomaly-gate.yml` and document why in the commit message.
+
+### Recovery from a wrong rollback
+
+If the gate fires on a real anomaly that was actually intentional (e.g. you launched a marketing campaign that legitimately 10x'd traffic), roll forward:
+```bash
+# List recent deployments
+doppler run -- vercel ls --token "$VERCEL_TOKEN"
+
+# Promote a specific deployment back to production
+doppler run -- vercel promote <deployment-url> --token "$VERCEL_TOKEN"
+```
+
+---
+
+## Layer 3: Provider Usage Ledger (Future)
+
+Not built. Tracked in Linear as candidate follow-up work. The design would be:
+- Daily cron writes per-provider usage to a `provider_usage_daily` table (rows per provider, day, units, est_cost_usd)
+- Sources: Anthropic usage API, Resend events, Vercel usage API, Sentry events
+- Daily check: each row vs 30-day rolling average; alert on day-over-day anomaly per provider
+
+This is finer-grained than Layer 2 but slower to react (daily vs every-15-min). Layers 1+2 cover the high-trauma scenario. Build Layer 3 only if observed gaps demand it.
+
+---
+
+## Verification of This System
+
+### Initial setup (one-time)
+
+- [ ] Layer 1: walk the checklist above. Screenshot every cap. Attach to the setup PR.
+- [ ] Layer 2: confirm `cost-anomaly-gate.yml` is scheduled (`gh workflow list | grep cost-anomaly`).
+- [ ] Layer 2: trigger a dry-run manually and confirm Slack message arrives:
+  ```bash
+  gh workflow run cost-anomaly-gate.yml -f dry_run=true -f threshold_multiplier=0 -f absolute_floor=0
+  ```
+- [ ] Layer 2: confirm the workflow's required secrets exist: `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, `SLACK_WEBHOOK_URL`. (All exist already, used by `sentry-error-gate.yml`.)
+
+### Ongoing (quarterly)
+
+- [ ] Re-walk Layer 1 checklist. Increase caps as baseline traffic grows.
+- [ ] Review last quarter's gate fires. Tune thresholds if false-positive rate > 1/month.
+- [ ] Confirm rollback still works by triggering a synthetic anomaly in maintenance window.


### PR DESCRIPTION
## Summary
- New scheduled GH Actions workflow `cost-anomaly-gate.yml` that runs every 15min, queries Sentry for production event volume over the last hour, compares to a 4-week same-hour-of-week baseline, and triggers `vercel rollback --yes` on a 5x spike (anomaly = `current > max(baseline * 5x, 1000 absolute floor)`)
- Reuses the existing rollback path proven in `sentry-error-gate.yml:229` (same `vercel rollback --yes --token` invocation, same `VERCEL_TOKEN`/`SENTRY_*`/`SLACK_WEBHOOK_URL` secrets — no new infrastructure)
- Defaults to **DRY RUN** until thresholds are calibrated against real baselines (1-2 week observation period). Slack alerts arrive but rollback does NOT fire until an explicit code change flips the default
- Concurrency group prevents flapping; GitHub issue auto-opened with on-call runbook on every live anomaly
- New `docs/COST_MONITORING.md` documents the 3-layer architecture (provider caps → this gate → optional usage ledger), the Layer 1 dashboard checklist (Vercel Spend Management, Anthropic/OpenAI usage limits, Resend rate caps, Twilio triggers, Neon autosuspend), the calibration procedure, and the on-call runbook

## Why
Real prior incident: a runaway log/API loop cost ~$12k over 12 days in a previous project while the founder was unavailable (the system hit a $1k/day cap, reset, recurred). This change closes the gap between the existing Sentry Error Gate (catches regressions that THROW, one-shot post-deploy) and the trauma scenario (runaway code that SUCCEEDS but burns money, develops slowly post-deploy). Provider-side hard caps remain the primary defense — this gate is a faster-reacting secondary layer that rolls back before spending hits the cap.

## What's deliberately NOT in this PR
- **Layer 1 caps**: dashboard configuration in each provider — the user must walk the checklist in `docs/COST_MONITORING.md` once. Cannot be code-automated.
- **Per-route invocation attribution**: v1 uses global event volume; per-route breakdown is a follow-up
- **Provider usage ledger** (Layer 3): per-provider daily usage table with day-over-day anomaly detection. Layers 1+2 cover the high-trauma scenario; Layer 3 is defensive-in-depth and deferred

## Follow-ups (not yet filed in Linear — ask if you want me to)
1. **Provider usage ledger** — Layer 3 from the plan (candidate)
2. **Per-route invocation attribution** — extend gate to identify the runaway route (candidate)
3. **Quarterly cap review reminder** — cron + Slack ping to re-walk Layer 1 as baseline traffic grows (required if caps are to stay calibrated)

## Test plan
- [ ] Walk Layer 1 checklist in each provider dashboard, screenshot every cap
- [ ] After merge: confirm workflow is scheduled — `gh workflow list | grep cost-anomaly`
- [ ] Trigger forced dry-run anomaly to verify Slack alert arrives:
  ```bash
  gh workflow run cost-anomaly-gate.yml -f dry_run=true -f threshold_multiplier=0 -f absolute_floor=0
  ```
- [ ] Watch Slack for 1-2 weeks of dry-run alerts. Tune `threshold_multiplier` if any false positives
- [ ] In a maintenance window, trigger a forced live anomaly to verify rollback path:
  ```bash
  gh workflow run cost-anomaly-gate.yml -f dry_run=false -f threshold_multiplier=0 -f absolute_floor=0
  ```
  Confirm `vercel rollback --yes` executes and reverts production. Roll forward immediately afterward.
- [ ] Once calibrated with no false positives, edit the workflow to flip `DRY_RUN` default from `'true'` to `'false'` in a follow-up PR

## Cost Impact
- 96 Sentry API queries/day (4 baseline samples + 1 current per run × 96 runs) — well within free-tier limits
- 0 additional Vercel/Anthropic/Resend calls
- This change *reduces* expected cost by capping worst-case runaway spend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated cost anomaly detection that monitors production spending and can trigger rollbacks when anomalies are detected.
  * Includes Slack alerts and GitHub issue creation for cost spike incidents.

* **Documentation**
  * Added comprehensive cost monitoring guide outlining defense strategies and procedures for preventing runaway spend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->