### PR TITLE
fix(hud): reliability shows uptime % not error rate

### DIFF
--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -471,7 +471,7 @@ export function HudDashboardClient({
             />
             <ContentMetricCard
               label='Reliability'
-              value={`${metrics.reliability.errorRatePercent.toFixed(2)}%`}
+              value={`${(100 - metrics.reliability.errorRatePercent).toFixed(1)}%`}
               subtitle={
                 metrics.reliability.p95LatencyMs === null
                   ? 'p95 —'


### PR DESCRIPTION
<!-- linear-issue-id:none -->

## Summary
- `errorRatePercent` was displayed directly under the "Reliability" label, so 0% errors showed as "0% Reliability" — completely inverted
- Changed to display `(100 - errorRatePercent)` so perfect uptime shows as "100.0%" and degraded service shows appropriately lower
- Precision changed from `.toFixed(2)` to `.toFixed(1)` to match the cleaner display format used for other secondary metrics

## Verification
- Typecheck: passed (exit code 0)
- Biome: `No fixes applied`

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Reliability KPI display to show uptime/success percentage instead of error rate percentage, with adjusted decimal precision for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->