### PR TITLE
fix(hud): proper reliability score + Mercury unknown state (JOV-2030)

### DIFF
--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -81,6 +81,24 @@ function getDeploymentDetail(deployments: HudMetrics['deployments']): string {
   return deployments.errorMessage ?? '\u2014';
 }
 
+function formatReliabilitySubtitle(
+  reliability: HudMetrics['reliability']
+): string {
+  const p95 =
+    reliability.p95LatencyMs === null
+      ? '\u2014'
+      : `${reliability.p95LatencyMs.toFixed(0)}ms`;
+  return `${reliability.unresolvedSentryIssues24h.toLocaleString('en-US')} unresolved | p95 ${p95}`;
+}
+
+function formatDefaultStatusLabel(
+  status: HudMetrics['overview']['defaultStatus']
+): string {
+  if (status === 'alive') return 'Alive';
+  if (status === 'dead') return 'Dead';
+  return 'Unknown';
+}
+
 const DEPLOYMENT_STATE_LABELS: Record<HudDeploymentState, string> = {
   success: 'Success',
   failure: 'Failure',
@@ -529,18 +547,26 @@ export function HudDashboardClient({
           />
           <ContentMetricCard
             label='Runway'
-            value={formatRunway(metrics.overview.runwayMonths)}
+            value={
+              metrics.overview.financialDataAvailable
+                ? formatRunway(metrics.overview.runwayMonths)
+                : '\u2014'
+            }
             subtitle={
-              <div className='mt-2 grid gap-1.5'>
-                <ContentMetricRow
-                  label='Cash'
-                  value={formatUsd(metrics.overview.balanceUsd)}
-                />
-                <ContentMetricRow
-                  label='Burn (30d)'
-                  value={formatUsd(metrics.overview.burnRateUsd)}
-                />
-              </div>
+              metrics.overview.financialDataAvailable ? (
+                <div className='mt-2 grid gap-1.5'>
+                  <ContentMetricRow
+                    label='Cash'
+                    value={formatUsd(metrics.overview.balanceUsd)}
+                  />
+                  <ContentMetricRow
+                    label='Burn (30d)'
+                    value={formatUsd(metrics.overview.burnRateUsd)}
+                  />
+                </div>
+              ) : (
+                'Unavailable'
+              )
             }
             className='p-3'
             valueClassName={secondaryValueClass}
@@ -558,12 +584,8 @@ export function HudDashboardClient({
           />
           <ContentMetricCard
             label='Reliability'
-            value={`${(100 - metrics.reliability.errorRatePercent).toFixed(1)}%`}
-            subtitle={
-              metrics.reliability.p95LatencyMs === null
-                ? 'p95 -'
-                : `p95 ${metrics.reliability.p95LatencyMs.toFixed(0)}ms`
-            }
+            value={`${metrics.reliability.reliabilityScorePercent.toFixed(1)}%`}
+            subtitle={formatReliabilitySubtitle(metrics.reliability)}
             className='p-3'
             valueClassName={secondaryValueClass}
           />
@@ -601,18 +623,14 @@ export function HudDashboardClient({
               <div className='space-y-2'>
                 <SectionEyebrow>Default status</SectionEyebrow>
                 <p className='text-[26px] font-[620] leading-none tracking-[-0.03em] text-primary-token sm:text-[32px]'>
-                  {metrics.overview.defaultStatus === 'alive'
-                    ? 'Alive'
-                    : 'Dead'}
+                  {formatDefaultStatusLabel(metrics.overview.defaultStatus)}
                 </p>
                 <p className='max-w-4xl text-[13px] leading-6 text-secondary-token'>
                   {metrics.overview.defaultStatusDetail}
                 </p>
               </div>
               <HudStatusPill
-                label={
-                  metrics.overview.defaultStatus === 'alive' ? 'Alive' : 'Dead'
-                }
+                label={formatDefaultStatusLabel(metrics.overview.defaultStatus)}
                 tone={defaultTone}
               />
             </div>
@@ -695,18 +713,26 @@ export function HudDashboardClient({
           <div className='grid grid-cols-2 xl:grid-cols-2 gap-3'>
             <ContentMetricCard
               label='Runway'
-              value={formatRunway(metrics.overview.runwayMonths)}
+              value={
+                metrics.overview.financialDataAvailable
+                  ? formatRunway(metrics.overview.runwayMonths)
+                  : '—'
+              }
               subtitle={
-                <div className='mt-2 grid gap-1.5'>
-                  <ContentMetricRow
-                    label='Cash'
-                    value={formatUsd(metrics.overview.balanceUsd)}
-                  />
-                  <ContentMetricRow
-                    label='Burn (30d)'
-                    value={formatUsd(metrics.overview.burnRateUsd)}
-                  />
-                </div>
+                metrics.overview.financialDataAvailable ? (
+                  <div className='mt-2 grid gap-1.5'>
+                    <ContentMetricRow
+                      label='Cash'
+                      value={formatUsd(metrics.overview.balanceUsd)}
+                    />
+                    <ContentMetricRow
+                      label='Burn (30d)'
+                      value={formatUsd(metrics.overview.burnRateUsd)}
+                    />
+                  </div>
+                ) : (
+                  'Unavailable'
+                )
               }
               className='p-3'
               labelClassName='uppercase tracking-[0.16em] text-tertiary-token'
@@ -728,12 +754,8 @@ export function HudDashboardClient({
             />
             <ContentMetricCard
               label='Reliability'
-              value={`${(100 - metrics.reliability.errorRatePercent).toFixed(1)}%`}
-              subtitle={
-                metrics.reliability.p95LatencyMs === null
-                  ? 'p95 —'
-                  : `p95 ${metrics.reliability.p95LatencyMs.toFixed(0)}ms`
-              }
+              value={`${metrics.reliability.reliabilityScorePercent.toFixed(1)}%`}
+              subtitle={formatReliabilitySubtitle(metrics.reliability)}
               className='p-3 col-span-2'
               labelClassName='uppercase tracking-[0.16em] text-tertiary-token'
               valueClassName={secondaryValueClass}
@@ -1007,9 +1029,7 @@ export function HudDashboardClient({
             </p>
           </div>
           <HudStatusPill
-            label={
-              metrics.overview.defaultStatus === 'alive' ? 'Alive' : 'Dead'
-            }
+            label={formatDefaultStatusLabel(metrics.overview.defaultStatus)}
             tone={defaultTone}
           />
         </div>

--- a/apps/web/lib/admin/hud-metric-derivations.ts
+++ b/apps/web/lib/admin/hud-metric-derivations.ts
@@ -1,0 +1,14 @@
+export type MercuryDefaultStatus = 'alive' | 'dead' | 'unknown';
+
+export function computeReliabilityScore(errorRatePercent: number): number {
+  return Math.max(0, Math.min(100, 100 - errorRatePercent));
+}
+
+export function computeMercuryDefaultStatus(
+  isAvailable: boolean,
+  balanceUsd: number,
+  burnRateUsd: number
+): MercuryDefaultStatus {
+  if (!isAvailable) return 'unknown';
+  return balanceUsd > burnRateUsd ? 'alive' : 'dead';
+}

--- a/apps/web/lib/admin/mercury-metrics.ts
+++ b/apps/web/lib/admin/mercury-metrics.ts
@@ -3,6 +3,10 @@ import 'server-only';
 import { env } from '@/lib/env-server';
 import { captureError } from '@/lib/error-tracking';
 import { ServerFetchTimeoutError, serverFetch } from '@/lib/http/server-fetch';
+import {
+  computeMercuryDefaultStatus,
+  type MercuryDefaultStatus,
+} from './hud-metric-derivations';
 
 const MERCURY_BASE_URL =
   env.MERCURY_API_BASE_URL?.trim() || 'https://api.mercury.com/api/v1';
@@ -45,6 +49,13 @@ export interface AdminMercuryMetrics {
   isConfigured: boolean;
   /** Indicates whether the Mercury API call succeeded */
   isAvailable: boolean;
+  /**
+   * Explicit default-status signal.
+   * - 'alive'  — balance > burn (runway > profitability horizon)
+   * - 'dead'   — balance <= burn (runway ends before profitability)
+   * - 'unknown' — Mercury is unavailable or data is missing; must NOT be shown as dead
+   */
+  defaultStatus: MercuryDefaultStatus;
   /** Error message if Mercury API call failed */
   errorMessage?: string;
 }
@@ -194,6 +205,7 @@ export async function getAdminMercuryMetrics(): Promise<AdminMercuryMetrics> {
       burnWindowDays: 30,
       isConfigured: false,
       isAvailable: false,
+      defaultStatus: 'unknown',
       errorMessage:
         'Mercury credentials not configured (set MERCURY_API_TOKEN or MERCURY_API_KEY and MERCURY_CHECKING_ACCOUNT_ID or MERCURY_ACCOUNT_ID)',
     };
@@ -237,6 +249,7 @@ export async function getAdminMercuryMetrics(): Promise<AdminMercuryMetrics> {
       burnWindowDays: 30,
       isConfigured: true,
       isAvailable: true,
+      defaultStatus: computeMercuryDefaultStatus(true, balanceUsd, burnRateUsd),
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
@@ -247,6 +260,7 @@ export async function getAdminMercuryMetrics(): Promise<AdminMercuryMetrics> {
       burnWindowDays: 30,
       isConfigured: true,
       isAvailable: false,
+      defaultStatus: 'unknown',
       errorMessage: `Mercury API error: ${message}`,
     };
   }

--- a/apps/web/lib/admin/reliability.ts
+++ b/apps/web/lib/admin/reliability.ts
@@ -7,6 +7,7 @@ import { sqlTimestamp } from '@/lib/db/sql-helpers';
 import { getHudDeployments } from '@/lib/deployments/github';
 import { captureError, captureWarning } from '@/lib/error-tracking';
 import { getRedis } from '@/lib/redis';
+import { computeReliabilityScore } from './hud-metric-derivations';
 import { getAdminSentryMetrics } from './sentry-metrics';
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -16,6 +17,8 @@ const DISABLED_RELIABILITY_TABLES = new Set<string>();
 
 export interface AdminReliabilitySummary {
   errorRatePercent: number;
+  /** Pre-computed reliability score: Math.max(0, Math.min(100, 100 - errorRatePercent)) */
+  reliabilityScorePercent: number;
   p95LatencyMs: number | null;
   incidents24h: number;
   lastIncidentAt: Date | null;
@@ -72,6 +75,14 @@ export async function getAdminReliabilitySummary(): Promise<AdminReliabilitySumm
         ? null
         : (deployments.current?.status ?? null),
   };
+
+  function withReliabilityScore(
+    errorRatePercent: number
+  ): Pick<AdminReliabilitySummary, 'reliabilityScorePercent'> {
+    return {
+      reliabilityScorePercent: computeReliabilityScore(errorRatePercent),
+    };
+  }
   let hasStripeEvents = false;
 
   try {
@@ -85,6 +96,7 @@ export async function getAdminReliabilitySummary(): Promise<AdminReliabilitySumm
   if (!hasStripeEvents) {
     return {
       errorRatePercent: 0,
+      ...withReliabilityScore(0),
       incidents24h: 0,
       lastIncidentAt: null,
       ...reliabilityBase,
@@ -112,6 +124,7 @@ export async function getAdminReliabilitySummary(): Promise<AdminReliabilitySumm
 
       return {
         errorRatePercent: 0,
+        ...withReliabilityScore(0),
         incidents24h: 0,
         lastIncidentAt: null,
         ...reliabilityBase,
@@ -148,6 +161,7 @@ export async function getAdminReliabilitySummary(): Promise<AdminReliabilitySumm
 
       return {
         errorRatePercent: 0,
+        ...withReliabilityScore(0),
         incidents24h: 0,
         lastIncidentAt: null,
         ...reliabilityBase,
@@ -159,6 +173,7 @@ export async function getAdminReliabilitySummary(): Promise<AdminReliabilitySumm
 
     return {
       errorRatePercent,
+      ...withReliabilityScore(errorRatePercent),
       incidents24h: Number(incidentCount),
       lastIncidentAt,
       ...reliabilityBase,
@@ -168,6 +183,7 @@ export async function getAdminReliabilitySummary(): Promise<AdminReliabilitySumm
 
     return {
       errorRatePercent: 0,
+      ...withReliabilityScore(0),
       incidents24h: 0,
       lastIncidentAt: null,
       ...reliabilityBase,

--- a/apps/web/lib/hud/metrics.ts
+++ b/apps/web/lib/hud/metrics.ts
@@ -177,18 +177,27 @@ export async function getHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
     overview: {
       mrrUsd: stripeMetrics.mrrUsd,
       activeSubscribers: stripeMetrics.activeSubscribers,
-      balanceUsd: mercuryMetrics.balanceUsd,
-      burnRateUsd: mercuryMetrics.burnRateUsd,
-      runwayMonths: financialStatus.runwayMonths,
-      defaultStatus: financialStatus.isDefaultAlive ? 'alive' : 'dead',
+      balanceUsd: mercuryMetrics.isAvailable ? mercuryMetrics.balanceUsd : 0,
+      burnRateUsd: mercuryMetrics.isAvailable ? mercuryMetrics.burnRateUsd : 0,
+      runwayMonths: mercuryMetrics.isAvailable
+        ? financialStatus.runwayMonths
+        : null,
+      defaultStatus: mercuryMetrics.isAvailable
+        ? financialStatus.isDefaultAlive
+          ? 'alive'
+          : 'dead'
+        : 'unknown',
       defaultStatusDetail: financialStatus.defaultStatusDetail,
+      financialDataAvailable: mercuryMetrics.isAvailable,
     },
     operations: operationsStatus,
     reliability: {
       errorRatePercent: reliabilitySummary.errorRatePercent,
+      reliabilityScorePercent: reliabilitySummary.reliabilityScorePercent,
       p95LatencyMs: reliabilitySummary.p95LatencyMs,
       incidents24h: reliabilitySummary.incidents24h,
       lastIncidentAtIso,
+      unresolvedSentryIssues24h: reliabilitySummary.unresolvedSentryIssues24h,
     },
     deployments,
     aiOps,

--- a/apps/web/lib/hud/tone-determination.ts
+++ b/apps/web/lib/hud/tone-determination.ts
@@ -46,8 +46,12 @@ export function getDeploymentLabel(deployments: HudDeployments): string {
 }
 
 /**
- * Get the visual tone for default alive/dead status.
+ * Get the visual tone for default alive/dead/unknown status.
  */
-export function getDefaultStatusTone(defaultStatus: 'alive' | 'dead'): HudTone {
-  return defaultStatus === 'alive' ? 'good' : 'bad';
+export function getDefaultStatusTone(
+  defaultStatus: 'alive' | 'dead' | 'unknown'
+): HudTone {
+  if (defaultStatus === 'alive') return 'good';
+  if (defaultStatus === 'dead') return 'bad';
+  return 'warning';
 }

--- a/apps/web/tests/lib/admin/mercury-metrics.test.ts
+++ b/apps/web/tests/lib/admin/mercury-metrics.test.ts
@@ -31,6 +31,7 @@ describe('getAdminMercuryMetrics', () => {
       burnWindowDays: 30,
       isConfigured: false,
       isAvailable: false,
+      defaultStatus: 'unknown',
       errorMessage:
         'Mercury credentials not configured (set MERCURY_API_TOKEN or MERCURY_API_KEY and MERCURY_CHECKING_ACCOUNT_ID or MERCURY_ACCOUNT_ID)',
     });
@@ -67,6 +68,7 @@ describe('getAdminMercuryMetrics', () => {
     expect(metrics.burnWindowDays).toBe(30);
     expect(metrics.isConfigured).toBe(true);
     expect(metrics.isAvailable).toBe(true);
+    expect(metrics.defaultStatus).toBe('alive');
     expect(metrics.errorMessage).toBeUndefined();
   });
 
@@ -82,6 +84,7 @@ describe('getAdminMercuryMetrics', () => {
     expect(metrics.burnRateUsd).toBe(0);
     expect(metrics.isConfigured).toBe(true);
     expect(metrics.isAvailable).toBe(false);
+    expect(metrics.defaultStatus).toBe('unknown');
     expect(metrics.errorMessage).toContain('Mercury API error');
   });
 });

--- a/apps/web/tests/unit/admin/hud-reliability-mercury.test.ts
+++ b/apps/web/tests/unit/admin/hud-reliability-mercury.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeMercuryDefaultStatus,
+  computeReliabilityScore,
+} from '@/lib/admin/hud-metric-derivations';
+
+// ---------------------------------------------------------------------------
+// reliabilityScorePercent derivation
+// ---------------------------------------------------------------------------
+describe('reliabilityScorePercent derivation', () => {
+  it('returns 100 when errorRatePercent is 0', () => {
+    expect(computeReliabilityScore(0)).toBe(100);
+  });
+
+  it('returns 95 when errorRatePercent is 5', () => {
+    expect(computeReliabilityScore(5)).toBe(95);
+  });
+
+  it('clamps to 0 when errorRatePercent exceeds 100', () => {
+    expect(computeReliabilityScore(110)).toBe(0);
+  });
+
+  it('clamps to 100 when errorRatePercent is negative', () => {
+    expect(computeReliabilityScore(-5)).toBe(100);
+  });
+
+  it('returns 50 when errorRatePercent is 50', () => {
+    expect(computeReliabilityScore(50)).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mercury defaultStatus derivation
+// ---------------------------------------------------------------------------
+describe('Mercury defaultStatus derivation', () => {
+  it('returns unknown when Mercury is unavailable', () => {
+    expect(computeMercuryDefaultStatus(false, 0, 0)).toBe('unknown');
+  });
+
+  it('returns unknown when Mercury is unavailable even with non-zero values', () => {
+    expect(computeMercuryDefaultStatus(false, 100_000, 50_000)).toBe('unknown');
+  });
+
+  it('returns alive when balance > burn and Mercury is available', () => {
+    expect(computeMercuryDefaultStatus(true, 100_000, 50_000)).toBe('alive');
+  });
+
+  it('returns dead when balance <= burn and Mercury is available', () => {
+    expect(computeMercuryDefaultStatus(true, 40_000, 50_000)).toBe('dead');
+  });
+
+  it('returns dead when balance equals burn', () => {
+    expect(computeMercuryDefaultStatus(true, 50_000, 50_000)).toBe('dead');
+  });
+});

--- a/apps/web/types/hud.ts
+++ b/apps/web/types/hud.ts
@@ -31,8 +31,10 @@ export interface HudOverviewMetrics {
   balanceUsd: number;
   burnRateUsd: number;
   runwayMonths: number | null;
-  defaultStatus: 'alive' | 'dead';
+  defaultStatus: 'alive' | 'dead' | 'unknown';
   defaultStatusDetail: string;
+  /** True when Mercury data is available; false means financial fields are stubs */
+  financialDataAvailable: boolean;
 }
 
 export interface HudOperationsStatus {
@@ -53,9 +55,12 @@ export interface HudMetrics {
   operations: HudOperationsStatus;
   reliability: {
     errorRatePercent: number;
+    /** Pre-computed reliability score: 100 - errorRatePercent, clamped [0, 100] */
+    reliabilityScorePercent: number;
     p95LatencyMs: number | null;
     incidents24h: number;
     lastIncidentAtIso: string | null;
+    unresolvedSentryIssues24h: number;
   };
   deployments: HudDeployments;
   aiOps: HermesAiOpsSummary;


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2030 -->

## Summary
- Adds `reliabilityScorePercent` field (`100 - errorRatePercent`, clamped [0, 100]) to `AdminReliabilitySummary` and `HudMetrics.reliability`
- Exposes `unresolvedSentryIssues24h` in `HudMetrics.reliability` (was computed internally but not passed through)
- Reliability card now shows `reliabilityScorePercent` (not the error rate) and subtitle includes Sentry issue count
- Adds `defaultStatus: 'alive' | 'dead' | 'unknown'` to `AdminMercuryMetrics`; Mercury unavailable renders `UNKNOWN` not `DEAD`
- Runway shows `—` / `Unavailable` instead of `∞` / `$0.00` when Mercury is down
- `getDefaultStatusTone` updated to handle `'unknown'` → amber/warning tone
- Adds `financialDataAvailable` flag to `HudOverviewMetrics` for clean unavailable-data guards in the client
- 10 unit tests covering reliability score derivation and Mercury default status logic

## QA
- [ ] `/app/admin/ops` shows Reliability 100.0% when no errors
- [ ] Mercury unavailable shows UNKNOWN not DEAD
- [ ] Runway shows — not ∞ when Mercury down
- [ ] Sentry issue count appears in Reliability subtitle

Supersedes #8351 (reliability display inversion fix)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reliability shown as a percent (with one decimal) and unresolved Sentry issues (24h)
  * "Unknown" default status added alongside "Alive" and "Dead"; status label/tone updated to reflect it
  * Runway KPI shows formatted value and Cash/Burn grid when financial data exists; shows "—" and "Unavailable" when not

* **Bug Fixes**
  * HUD gracefully handles missing financial data by marking it unavailable

* **Tests**
  * Added unit tests for reliability scoring and financial-status derivation

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8354)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->