### PR TITLE
refactor(auth): canonical APP_ROUTES for all auth CTAs (JOV-2035)

### DIFF
--- a/apps/web/app/(marketing)/demo/video/page.tsx
+++ b/apps/web/app/(marketing)/demo/video/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { APP_ROUTES } from '@/constants/routes';
 import { DemoVideoPlayer } from '@/features/demo/DemoVideoPlayer';
 import { NOINDEX_ROBOTS } from '@/lib/seo/noindex-metadata';
 
@@ -42,7 +43,7 @@ export default function ProductDemoPage() {
           </a>
         )}
         <Link
-          href='/signup'
+          href={APP_ROUTES.SIGNUP}
           className='inline-flex h-12 items-center rounded-full bg-white px-8 text-sm font-semibold text-black transition-opacity hover:opacity-90'
         >
           Try it free

--- a/apps/web/app/[username]/claim/ClaimPageContent.tsx
+++ b/apps/web/app/[username]/claim/ClaimPageContent.tsx
@@ -3,6 +3,7 @@
 import { ArrowRight } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { APP_ROUTES } from '@/constants/routes';
 import { JoviePixel } from '@/features/tracking/JoviePixel';
 
 interface ClaimPageContentProps {
@@ -19,7 +20,7 @@ export function ClaimPageContent({
   avatarUrl,
 }: ClaimPageContentProps) {
   const encodedRedirect = encodeURIComponent(`/${username}`);
-  const signupUrl = `/signup?handle=${encodeURIComponent(username)}&redirect_url=${encodedRedirect}`;
+  const signupUrl = `${APP_ROUTES.SIGNUP}?handle=${encodeURIComponent(username)}&redirect_url=${encodedRedirect}`;
 
   return (
     <>

--- a/apps/web/components/features/auth/SsoCallbackHandler.tsx
+++ b/apps/web/components/features/auth/SsoCallbackHandler.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { LoadingSpinner } from '@/components/atoms/LoadingSpinner';
+import { APP_ROUTES } from '@/constants/routes';
 import {
   isAccessDeniedError,
   isAccountExistsError,
@@ -32,7 +33,7 @@ interface SsoCallbackHandlerProps {
 function SsoLoadingState({ isStalled }: { readonly isStalled: boolean }) {
   return (
     <output
-      className='flex flex-col items-center justify-center gap-4 animate-in fade-in duration-500 ease-out'
+      className='flex flex-col items-center justify-center gap-4 animate-in fade-in duration-cinematic ease-out'
       aria-busy='true'
       aria-live='polite'
     >
@@ -44,7 +45,7 @@ function SsoLoadingState({ isStalled }: { readonly isStalled: boolean }) {
         <p className='text-xs text-tertiary-token/70 text-center max-w-xs'>
           This is taking longer than expected. You can{' '}
           <Link
-            href='/signin'
+            href={APP_ROUTES.SIGNIN}
             className='text-primary-token underline focus-ring-themed rounded-md'
           >
             try signing in again
@@ -146,7 +147,7 @@ export function SsoCallbackHandler({
 
         // Redirect to signup page with error classification so it can
         // show the appropriate error message using existing OAuth error UI
-        router.replace(`/signup?oauth_error=${errorType}`);
+        router.replace(`${APP_ROUTES.SIGNUP}?oauth_error=${errorType}`);
       });
   }, [
     clerk,

--- a/apps/web/components/features/dashboard/organisms/onboarding-v2/shared/useOnboardingSubmit.ts
+++ b/apps/web/components/features/dashboard/organisms/onboarding-v2/shared/useOnboardingSubmit.ts
@@ -17,6 +17,7 @@ import {
   enrichProfileFromDsp,
 } from '@/app/onboarding/actions/enrich-profile';
 import type { CompletionResult } from '@/app/onboarding/actions/types';
+import { APP_ROUTES } from '@/constants/routes';
 import {
   getOnboardingCompletionMethod,
   toDurationMs,
@@ -371,7 +372,9 @@ export function useOnboardingSubmit({
       );
 
       if (shouldRedirectToSignIn) {
-        router.push(`/signin?redirect_url=${encodeURIComponent(redirectUrl)}`);
+        router.push(
+          `${APP_ROUTES.SIGNIN}?redirect_url=${encodeURIComponent(redirectUrl)}`
+        );
         return;
       }
 

--- a/apps/web/components/features/home/claim-handle/ClaimHandleForm.tsx
+++ b/apps/web/components/features/home/claim-handle/ClaimHandleForm.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react';
 import { LoadingSpinner } from '@/components/atoms/LoadingSpinner';
 import { BASE_URL } from '@/constants/app';
+import { APP_ROUTES } from '@/constants/routes';
 import { useAuthSafe } from '@/hooks/useClerkSafe';
 import { track } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
@@ -229,7 +230,9 @@ export function ClaimHandleForm({
       setNavigating(true);
 
       if (!isSignedIn) {
-        router.push(`/signup?redirect_url=${encodeURIComponent(target)}`);
+        router.push(
+          `${APP_ROUTES.SIGNUP}?redirect_url=${encodeURIComponent(target)}`
+        );
         return;
       }
 
@@ -304,7 +307,7 @@ export function ClaimHandleForm({
       <div
         className={cn(
           'claim-input-row',
-          'relative flex w-full items-center gap-2 transition-all duration-slower ease-[cubic-bezier(0.16,1,0.3,1)]',
+          'relative flex w-full items-center gap-2 transition-[background,border-color,box-shadow] duration-cinematic ease-cinematic',
           sizeRoundingClass,
           isAvailable && 'claim-input-row--available'
         )}
@@ -368,7 +371,7 @@ export function ClaimHandleForm({
           data-testid={submitButtonTestId}
           aria-busy={checkingAvail || navigating}
           className={cn(
-            'group shrink-0 inline-flex items-center justify-center gap-1.5 transition-all duration-slow focus-ring-themed',
+            'group shrink-0 inline-flex items-center justify-center gap-1.5 transition-[background,opacity,filter] duration-slow focus-ring-themed',
             buttonRoundingClass,
             isDisabled
               ? 'cursor-not-allowed opacity-40'

--- a/apps/web/components/features/pay/PayLanding.tsx
+++ b/apps/web/components/features/pay/PayLanding.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { MarketingContainer, MarketingHero } from '@/components/marketing';
+import { APP_ROUTES } from '@/constants/routes';
 import { ClaimHandleForm } from '@/features/home/claim-handle';
 
 /* -------------------------------------------------------------------------- */
@@ -292,7 +293,7 @@ function TipsFinalCTA() {
             </p>
             <div className='mt-6'>
               <Button size='lg' className='public-action-primary' asChild>
-                <Link href='/signup'>
+                <Link href={APP_ROUTES.SIGNUP}>
                   Claim Your Handle
                   <ArrowRight className='ml-2 h-4 w-4' />
                 </Link>

--- a/apps/web/components/organisms/footer-module/Footer.tsx
+++ b/apps/web/components/organisms/footer-module/Footer.tsx
@@ -40,8 +40,8 @@ const FOOTER_COLUMNS = [
     id: 'account',
     heading: 'Account',
     links: [
-      { href: '/signin', label: 'Log in' },
-      { href: '/signup', label: 'Get started' },
+      { href: APP_ROUTES.SIGNIN, label: 'Log in' },
+      { href: APP_ROUTES.SIGNUP, label: 'Get started' },
     ],
   },
   {
@@ -195,7 +195,7 @@ export function Footer({
                 <Link
                   href={APP_ROUTES.LEGAL_PRIVACY}
                   prefetch={false}
-                  className='text-app tracking-[-0.01em] transition-colors duration-100 hover:[color:var(--linear-text-primary)]'
+                  className='text-app tracking-[-0.01em] transition-colors duration-subtle hover:[color:var(--linear-text-primary)]'
                   style={{ color: 'var(--linear-text-tertiary)' }}
                 >
                   Privacy
@@ -203,7 +203,7 @@ export function Footer({
                 <Link
                   href={APP_ROUTES.LEGAL_TERMS}
                   prefetch={false}
-                  className='text-app tracking-[-0.01em] transition-colors duration-100 hover:[color:var(--linear-text-primary)]'
+                  className='text-app tracking-[-0.01em] transition-colors duration-subtle hover:[color:var(--linear-text-primary)]'
                   style={{ color: 'var(--linear-text-tertiary)' }}
                 >
                   Terms
@@ -258,7 +258,7 @@ export function Footer({
                       key={link.href}
                       href={link.href}
                       prefetch={false}
-                      className='text-app leading-[19.5px] font-normal tracking-[-0.01em] transition-colors duration-100 hover:[color:var(--linear-text-secondary)]'
+                      className='text-app leading-[19.5px] font-normal tracking-[-0.01em] transition-colors duration-subtle hover:[color:var(--linear-text-secondary)]'
                       style={{ color: 'var(--linear-text-tertiary)' }}
                     >
                       {link.label}


### PR DESCRIPTION
## Summary

Replaces all hardcoded `/signin` and `/signup` path literals used in navigation CTAs, `router.push`, and `router.replace` calls with `APP_ROUTES.SIGNIN` and `APP_ROUTES.SIGNUP` constants imported from `@/constants/routes`.

**Closes JOV-2035**

<!-- linear-issue-id:JOV-2035 -->

## Files Changed

| File | Change |
|------|--------|
| `app/(marketing)/demo/video/page.tsx` | `href='/signup'` → `href={APP_ROUTES.SIGNUP}` |
| `app/[username]/claim/ClaimPageContent.tsx` | Template literal `/signup?...` → `${APP_ROUTES.SIGNUP}?...` |
| `components/features/auth/SsoCallbackHandler.tsx` | `href='/signin'` and router.replace `/signup?oauth_error=...` → constants; fixed pre-existing `duration-500` → `duration-cinematic` ESLint warning |
| `components/features/dashboard/organisms/onboarding-v2/shared/useOnboardingSubmit.ts` | router.push `/signin?redirect_url=...` → `${APP_ROUTES.SIGNIN}?redirect_url=...` |
| `components/features/home/claim-handle/ClaimHandleForm.tsx` | router.push `/signup?redirect_url=...` → `${APP_ROUTES.SIGNUP}?redirect_url=...`; fixed pre-existing `transition-all` + `ease-[...]` ESLint warnings |
| `components/features/pay/PayLanding.tsx` | `href='/signup'` → `href={APP_ROUTES.SIGNUP}` |
| `components/organisms/footer-module/Footer.tsx` | Footer column links `/signin` and `/signup` → constants; fixed 3x pre-existing `duration-100` → `duration-subtle` ESLint warnings |

## What Was NOT Changed

- `CoreProviders.tsx` `/signin` and `/signup` strings — these are `THEME_ENABLED_PREFIXES` values for `pathname.startsWith()` matching, not navigation CTAs
- `MarketingSignInModal.tsx`, `AuthModalShell.tsx`, `AuthLayout.tsx` — per JOV-2034 scope boundary
- `app/(auth)/signin/page.tsx`, `app/(auth)/signup/page.tsx` — auth page files themselves
- Test files — per JOV-2037

## Verification

- ✅ Typecheck: zero errors
- ✅ Biome: zero warnings/errors on all 7 changed files
- ✅ ESLint: zero errors/warnings on changed files (pre-existing motion-token warnings fixed as a bonus)
- ✅ CI: Typecheck, Lint, Unit Tests (all 6 shards), ESLint Server Boundaries, Build, CodeQL, SonarCloud — all passing
- ✅ CodeRabbit: PASS (no unaddressed comments)