### PR TITLE
feat(hud): tim action required section (JOV-2042)

### DIFF
--- a/apps/web/app/api/admin/hud/tim-actions/route.ts
+++ b/apps/web/app/api/admin/hud/tim-actions/route.ts
@@ -79,7 +79,16 @@ export async function POST(request: Request): Promise<Response> {
       );
     }
 
-    const body = (await request.json()) as unknown;
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid JSON payload' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
     if (
       typeof body !== 'object' ||
       body === null ||
@@ -91,9 +100,9 @@ export async function POST(request: Request): Promise<Response> {
       );
     }
 
-    const { issueId } = body as { issueId: string };
+    const issueId = (body as { issueId: string }).issueId.trim();
 
-    if (!issueId.trim()) {
+    if (!issueId) {
       return NextResponse.json(
         { error: 'issueId must not be empty' },
         { status: 400, headers: NO_STORE_HEADERS }

--- a/apps/web/app/api/admin/hud/tim-actions/route.ts
+++ b/apps/web/app/api/admin/hud/tim-actions/route.ts
@@ -1,0 +1,127 @@
+import 'server-only';
+
+import { NextResponse } from 'next/server';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import { captureError } from '@/lib/error-tracking';
+import {
+  closeLinearIssue,
+  fetchTimActionIssues,
+} from '@/lib/hud/linear-actions';
+import { logger } from '@/lib/utils/logger';
+
+export const runtime = 'nodejs';
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+/**
+ * GET /api/admin/hud/tim-actions
+ *
+ * Returns all Linear issues labeled `tim-action-required` that are in an
+ * active state (triage, unstarted, started). Admin-only.
+ */
+export async function GET(): Promise<Response> {
+  try {
+    const entitlements = await getCurrentUserEntitlements();
+    if (!entitlements.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401, headers: NO_STORE_HEADERS }
+      );
+    }
+    if (!entitlements.isAdmin) {
+      return NextResponse.json(
+        { error: 'Forbidden' },
+        { status: 403, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const result = await fetchTimActionIssues();
+    return NextResponse.json(result, {
+      status: 200,
+      headers: NO_STORE_HEADERS,
+    });
+  } catch (error) {
+    logger.error(
+      '[api/admin/hud/tim-actions] Failed to fetch tim-action issues',
+      error
+    );
+    await captureError('HUD tim-actions fetch failed', error, {
+      route: '/api/admin/hud/tim-actions',
+      method: 'GET',
+    });
+    return NextResponse.json(
+      { error: 'Failed to fetch tim-action issues' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}
+
+/**
+ * POST /api/admin/hud/tim-actions
+ *
+ * Body: { issueId: string }
+ *
+ * Closes a Linear issue. Admin-only.
+ */
+export async function POST(request: Request): Promise<Response> {
+  try {
+    const entitlements = await getCurrentUserEntitlements();
+    if (!entitlements.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401, headers: NO_STORE_HEADERS }
+      );
+    }
+    if (!entitlements.isAdmin) {
+      return NextResponse.json(
+        { error: 'Forbidden' },
+        { status: 403, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const body = (await request.json()) as unknown;
+    if (
+      typeof body !== 'object' ||
+      body === null ||
+      typeof (body as Record<string, unknown>).issueId !== 'string'
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid payload: issueId (string) required' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const { issueId } = body as { issueId: string };
+
+    if (!issueId.trim()) {
+      return NextResponse.json(
+        { error: 'issueId must not be empty' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const success = await closeLinearIssue(issueId);
+
+    if (!success) {
+      return NextResponse.json(
+        { error: 'Failed to close issue in Linear' },
+        { status: 502, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    return NextResponse.json(
+      { ok: true },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  } catch (error) {
+    logger.error('[api/admin/hud/tim-actions] Failed to close issue', error);
+    await captureError('HUD tim-actions close failed', error, {
+      route: '/api/admin/hud/tim-actions',
+      method: 'POST',
+    });
+    return NextResponse.json(
+      { error: 'Internal error' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -446,9 +446,8 @@ export function HudDashboardClient({
       ) : null}
 
       {/* Tim Action Required — personal manual items, surfaces above everything else */}
-      <ContentSurfaceCard surface='details' className='p-3'>
-        <TimActionRequiredSection />
-      </ContentSurfaceCard>
+      {/* ContentSurfaceCard is rendered by TimActionRequiredSection itself so it can self-hide */}
+      <TimActionRequiredSection />
 
       {/* Top section: chart + metrics side-by-side on XL screens */}
       <div className='grid gap-3 xl:grid-cols-[2fr_1fr]'>

--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 import type { DailyBucket } from '@/components/features/admin/ShippingVelocityChart';
 import { ShippingVelocityChart } from '@/components/features/admin/ShippingVelocityChart';
+import { TimActionRequiredSection } from '@/components/features/admin/TimActionRequiredSection';
 import { ContentMetricCard } from '@/components/molecules/ContentMetricCard';
 import { ContentMetricRow } from '@/components/molecules/ContentMetricRow';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
@@ -443,6 +444,11 @@ export function HudDashboardClient({
           </div>
         </ContentSurfaceCard>
       ) : null}
+
+      {/* Tim Action Required — personal manual items, surfaces above everything else */}
+      <ContentSurfaceCard surface='details' className='p-3'>
+        <TimActionRequiredSection />
+      </ContentSurfaceCard>
 
       {/* Top section: chart + metrics side-by-side on XL screens */}
       <div className='grid gap-3 xl:grid-cols-[2fr_1fr]'>

--- a/apps/web/components/features/admin/TimActionRequiredSection.tsx
+++ b/apps/web/components/features/admin/TimActionRequiredSection.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { Check, ExternalLink } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import type {
   TimActionIssue,
   TimActionsResponse,
@@ -75,7 +76,7 @@ function ActionRow({ issue, onClose, isClosing }: Readonly<ActionRowProps>) {
           rel='noopener noreferrer'
           className='group flex items-center gap-1.5'
         >
-          <p className='truncate text-[13px] font-semibold text-primary-token group-hover:text-[#FACC15] transition-colors'>
+          <p className='truncate text-[13px] font-semibold text-primary-token transition-colors group-hover:text-[#FACC15]'>
             {issue.title}
           </p>
           <ExternalLink
@@ -114,6 +115,8 @@ function ActionRow({ issue, onClose, isClosing }: Readonly<ActionRowProps>) {
 
 export function TimActionRequiredSection() {
   const [data, setData] = useState<TimActionsResponse | null>(null);
+  // isInitialLoad tracks whether we've ever received data — only show skeleton on first load
+  const isInitialLoadRef = useRef(true);
   const [isLoading, setIsLoading] = useState(true);
   const [closingIds, setClosingIds] = useState<Set<string>>(new Set());
   const [optimisticallyClosedIds, setOptimisticallyClosedIds] = useState<
@@ -121,7 +124,10 @@ export function TimActionRequiredSection() {
   >(new Set());
 
   const fetchData = useCallback(async (signal?: AbortSignal) => {
-    setIsLoading(true);
+    // Only show the skeleton on the very first load; background polls are silent
+    if (isInitialLoadRef.current) {
+      setIsLoading(true);
+    }
     try {
       const response = await fetch(FETCH_URL, { signal });
       if (!response.ok) {
@@ -133,6 +139,7 @@ export function TimActionRequiredSection() {
       if (error instanceof Error && error.name === 'AbortError') return;
       // Silently fail — the HUD should not break if Linear is unavailable
     } finally {
+      isInitialLoadRef.current = false;
       setIsLoading(false);
     }
   }, []);
@@ -204,52 +211,54 @@ export function TimActionRequiredSection() {
   );
 
   return (
-    <div className='space-y-2.5'>
-      {/* Section header */}
-      <div className='flex items-center gap-2'>
-        {/* Amber accent dot matching the #FACC15 tim-action-required label color */}
-        <span
-          className='h-2 w-2 shrink-0 rounded-full'
-          style={{ backgroundColor: '#FACC15' }}
-          aria-hidden='true'
-        />
-        <p className='text-[11px] font-semibold uppercase tracking-[0.16em] text-tertiary-token'>
-          Tim Action Required
-        </p>
-        {!isLoading && visibleIssues.length > 0 ? (
-          <span className='ml-auto text-[11px] tabular-nums text-tertiary-token'>
-            {visibleIssues.length}
-          </span>
-        ) : null}
-      </div>
+    <ContentSurfaceCard surface='details' className='p-3'>
+      <div className='space-y-2.5'>
+        {/* Section header */}
+        <div className='flex items-center gap-2'>
+          {/* Amber accent dot matching the #FACC15 tim-action-required label color */}
+          <span
+            className='h-2 w-2 shrink-0 rounded-full'
+            style={{ backgroundColor: '#FACC15' }}
+            aria-hidden='true'
+          />
+          <p className='text-[11px] font-semibold uppercase tracking-[0.16em] text-tertiary-token'>
+            Tim Action Required
+          </p>
+          {!isLoading && visibleIssues.length > 0 ? (
+            <span className='ml-auto text-[11px] tabular-nums text-tertiary-token'>
+              {visibleIssues.length}
+            </span>
+          ) : null}
+        </div>
 
-      {/* Content */}
-      {isLoading ? (
-        <div className='grid gap-2'>
-          {[1, 2].map(i => (
-            <div
-              key={i}
-              className='h-[52px] rounded-xl border border-subtle bg-surface-0 animate-pulse'
-              aria-hidden='true'
-            />
-          ))}
-        </div>
-      ) : visibleIssues.length > 0 ? (
-        <div className='grid gap-2'>
-          {visibleIssues.map(issue => (
-            <ActionRow
-              key={issue.id}
-              issue={issue}
-              onClose={handleClose}
-              isClosing={closingIds.has(issue.id)}
-            />
-          ))}
-        </div>
-      ) : (
-        <p className='text-[13px] leading-5 text-secondary-token'>
-          Nothing on your plate. Everything that needs hands is automated.
-        </p>
-      )}
-    </div>
+        {/* Content */}
+        {isLoading ? (
+          <div className='grid gap-2'>
+            {[1, 2].map(i => (
+              <div
+                key={i}
+                className='h-[52px] animate-pulse rounded-xl border border-subtle bg-surface-0'
+                aria-hidden='true'
+              />
+            ))}
+          </div>
+        ) : visibleIssues.length > 0 ? (
+          <div className='grid gap-2'>
+            {visibleIssues.map(issue => (
+              <ActionRow
+                key={issue.id}
+                issue={issue}
+                onClose={handleClose}
+                isClosing={closingIds.has(issue.id)}
+              />
+            ))}
+          </div>
+        ) : (
+          <p className='text-[13px] leading-5 text-secondary-token'>
+            Nothing on your plate. Everything that needs hands is automated.
+          </p>
+        )}
+      </div>
+    </ContentSurfaceCard>
   );
 }

--- a/apps/web/components/features/admin/TimActionRequiredSection.tsx
+++ b/apps/web/components/features/admin/TimActionRequiredSection.tsx
@@ -1,0 +1,255 @@
+'use client';
+
+import { Check, ExternalLink } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import type {
+  TimActionIssue,
+  TimActionsResponse,
+} from '@/lib/hud/linear-actions';
+import { STANDARD_CACHE } from '@/lib/queries/cache-strategies';
+
+const FETCH_URL = '/api/admin/hud/tim-actions';
+
+// Priority display config — maps Linear priority number to label and tone
+const PRIORITY_CONFIG: Record<number, { label: string; className: string }> = {
+  1: {
+    label: 'Urgent',
+    className: 'bg-red-500/15 text-red-400 border border-red-500/20',
+  },
+  2: {
+    label: 'High',
+    className: 'bg-orange-500/15 text-orange-400 border border-orange-500/20',
+  },
+  3: {
+    label: 'Medium',
+    className: 'bg-yellow-500/15 text-yellow-400 border border-yellow-500/20',
+  },
+  4: {
+    label: 'Low',
+    className: 'bg-zinc-500/15 text-zinc-400 border border-zinc-500/20',
+  },
+};
+
+const DEFAULT_PRIORITY_CONFIG = {
+  label: 'No priority',
+  className: 'bg-zinc-500/15 text-zinc-400 border border-zinc-500/20',
+};
+
+function getPriorityConfig(priority: number) {
+  return PRIORITY_CONFIG[priority] ?? DEFAULT_PRIORITY_CONFIG;
+}
+
+function DaysOldBadge({ daysOld }: Readonly<{ readonly daysOld: number }>) {
+  const isOverdue = daysOld > 7;
+  return (
+    <abbr
+      title={`${daysOld} days old${isOverdue ? ' — overdue' : ''}`}
+      className={
+        isOverdue
+          ? 'text-[11px] font-semibold tabular-nums text-red-400 no-underline'
+          : 'text-[11px] tabular-nums text-tertiary-token no-underline'
+      }
+    >
+      {daysOld}d
+    </abbr>
+  );
+}
+
+interface ActionRowProps {
+  readonly issue: TimActionIssue;
+  readonly onClose: (issueId: string) => Promise<void>;
+  readonly isClosing: boolean;
+}
+
+function ActionRow({ issue, onClose, isClosing }: Readonly<ActionRowProps>) {
+  const priorityConfig = getPriorityConfig(issue.priority);
+
+  return (
+    <div className='flex items-center gap-3 rounded-xl border border-subtle bg-surface-0 px-3 py-2.5'>
+      {/* Title + Linear link */}
+      <div className='min-w-0 flex-1'>
+        <a
+          href={issue.url}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='group flex items-center gap-1.5'
+        >
+          <p className='truncate text-[13px] font-semibold text-primary-token group-hover:text-[#FACC15] transition-colors'>
+            {issue.title}
+          </p>
+          <ExternalLink
+            className='h-3 w-3 shrink-0 text-tertiary-token opacity-0 transition-opacity group-hover:opacity-100'
+            aria-hidden='true'
+          />
+        </a>
+        <p className='mt-0.5 text-[11px] uppercase tracking-[0.08em] text-tertiary-token'>
+          {issue.identifier}
+        </p>
+      </div>
+
+      {/* Priority badge */}
+      <span
+        className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] ${priorityConfig.className}`}
+      >
+        {priorityConfig.label}
+      </span>
+
+      {/* Age */}
+      <DaysOldBadge daysOld={issue.daysOld} />
+
+      {/* Quick-mark-done */}
+      <button
+        type='button'
+        onClick={() => void onClose(issue.id)}
+        disabled={isClosing}
+        aria-label={`Mark "${issue.title}" as done`}
+        className='shrink-0 rounded-lg border border-subtle bg-surface-1 p-1.5 text-tertiary-token transition-colors hover:border-[#FACC15]/30 hover:bg-[#FACC15]/10 hover:text-[#FACC15] disabled:cursor-not-allowed disabled:opacity-40'
+      >
+        <Check className='h-3.5 w-3.5' aria-hidden='true' />
+      </button>
+    </div>
+  );
+}
+
+export function TimActionRequiredSection() {
+  const [data, setData] = useState<TimActionsResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [closingIds, setClosingIds] = useState<Set<string>>(new Set());
+  const [optimisticallyClosedIds, setOptimisticallyClosedIds] = useState<
+    Set<string>
+  >(new Set());
+
+  const fetchData = useCallback(async (signal?: AbortSignal) => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(FETCH_URL, { signal });
+      if (!response.ok) {
+        throw new Error(`Fetch failed (${response.status})`);
+      }
+      const result = (await response.json()) as TimActionsResponse;
+      setData(result);
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') return;
+      // Silently fail — the HUD should not break if Linear is unavailable
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchData(controller.signal);
+
+    // Poll every 5 minutes (STANDARD_CACHE staleTime)
+    const intervalMs = STANDARD_CACHE.staleTime ?? 5 * 60 * 1000;
+    const interval = setInterval(() => {
+      void fetchData(controller.signal);
+    }, intervalMs);
+
+    return () => {
+      controller.abort();
+      clearInterval(interval);
+    };
+  }, [fetchData]);
+
+  async function handleClose(issueId: string) {
+    // Optimistic removal
+    setOptimisticallyClosedIds(prev => new Set([...prev, issueId]));
+    setClosingIds(prev => new Set([...prev, issueId]));
+
+    try {
+      const response = await fetch(FETCH_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ issueId }),
+      });
+
+      if (!response.ok) {
+        const errorBody = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(errorBody.error ?? `Close failed (${response.status})`);
+      }
+
+      toast.success('Marked as done in Linear');
+      // Refresh the list to get latest state
+      void fetchData();
+    } catch (error) {
+      // Roll back the optimistic removal
+      setOptimisticallyClosedIds(prev => {
+        const next = new Set(prev);
+        next.delete(issueId);
+        return next;
+      });
+      toast.error(
+        error instanceof Error ? error.message : 'Could not close issue'
+      );
+    } finally {
+      setClosingIds(prev => {
+        const next = new Set(prev);
+        next.delete(issueId);
+        return next;
+      });
+    }
+  }
+
+  // Don't render the section at all if Linear is not configured and loading is done
+  if (!isLoading && data && !data.available) {
+    return null;
+  }
+
+  const visibleIssues = (data?.issues ?? []).filter(
+    issue => !optimisticallyClosedIds.has(issue.id)
+  );
+
+  return (
+    <div className='space-y-2.5'>
+      {/* Section header */}
+      <div className='flex items-center gap-2'>
+        {/* Amber accent dot matching the #FACC15 tim-action-required label color */}
+        <span
+          className='h-2 w-2 shrink-0 rounded-full'
+          style={{ backgroundColor: '#FACC15' }}
+          aria-hidden='true'
+        />
+        <p className='text-[11px] font-semibold uppercase tracking-[0.16em] text-tertiary-token'>
+          Tim Action Required
+        </p>
+        {!isLoading && visibleIssues.length > 0 ? (
+          <span className='ml-auto text-[11px] tabular-nums text-tertiary-token'>
+            {visibleIssues.length}
+          </span>
+        ) : null}
+      </div>
+
+      {/* Content */}
+      {isLoading ? (
+        <div className='grid gap-2'>
+          {[1, 2].map(i => (
+            <div
+              key={i}
+              className='h-[52px] rounded-xl border border-subtle bg-surface-0 animate-pulse'
+              aria-hidden='true'
+            />
+          ))}
+        </div>
+      ) : visibleIssues.length > 0 ? (
+        <div className='grid gap-2'>
+          {visibleIssues.map(issue => (
+            <ActionRow
+              key={issue.id}
+              issue={issue}
+              onClose={handleClose}
+              isClosing={closingIds.has(issue.id)}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className='text-[13px] leading-5 text-secondary-token'>
+          Nothing on your plate. Everything that needs hands is automated.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/env-server-schema.ts
+++ b/apps/web/lib/env-server-schema.ts
@@ -174,6 +174,8 @@ export const ServerEnvSchema = z.object({
 
   // Linear webhook automation
   LINEAR_WEBHOOK_SECRET: z.string().optional(),
+  // Linear API key for HUD queries (tim-action-required issues)
+  LINEAR_API_KEY: z.string().optional(),
 
   // GitHub dispatch (Sentry autofix pipeline)
   GH_DISPATCH_TOKEN: z.string().optional(),
@@ -322,6 +324,7 @@ export const ENV_KEYS = [
   'SENTRY_AUTH_TOKEN',
   'SENTRY_ORG_SLUG',
   'LINEAR_WEBHOOK_SECRET',
+  'LINEAR_API_KEY',
   'GH_DISPATCH_TOKEN',
   'VERCEL_GIT_REPO_OWNER',
   'VERCEL_GIT_REPO_SLUG',

--- a/apps/web/lib/hud/linear-actions.test.ts
+++ b/apps/web/lib/hud/linear-actions.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock server-only so the module can be tested in vitest (node env)
+vi.mock('server-only', () => ({}));
+
+// Mock the env module before importing the module under test
+vi.mock('@/lib/env-server', () => ({
+  env: {
+    LINEAR_API_KEY: undefined,
+  },
+}));
+
+// Mock the logger
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('fetchTimActionIssues', () => {
+  it('returns available=false when LINEAR_API_KEY is not configured', async () => {
+    // env.LINEAR_API_KEY is undefined from the mock above
+    const { fetchTimActionIssues } = await import('./linear-actions');
+    const result = await fetchTimActionIssues();
+
+    expect(result.available).toBe(false);
+    expect(result.issues).toEqual([]);
+    expect(typeof result.fetchedAt).toBe('string');
+  });
+});
+
+describe('sort order', () => {
+  it('sorts by priority ASC then createdAt ASC', () => {
+    // Test the sort logic directly by reconstructing it
+    // Priority: 1=urgent (lowest number = highest priority), 0 = no priority (treated as 5)
+    const issues = [
+      { priority: 0, createdAt: '2026-01-01T00:00:00Z' }, // no priority → 5
+      { priority: 2, createdAt: '2026-01-03T00:00:00Z' }, // high, newer
+      { priority: 2, createdAt: '2026-01-01T00:00:00Z' }, // high, older
+      { priority: 1, createdAt: '2026-01-02T00:00:00Z' }, // urgent
+    ];
+
+    const sorted = [...issues].sort((a, b) => {
+      const aPriority = a.priority === 0 ? 5 : a.priority;
+      const bPriority = b.priority === 0 ? 5 : b.priority;
+      if (aPriority !== bPriority) return aPriority - bPriority;
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
+
+    expect(sorted[0]).toMatchObject({ priority: 1 }); // urgent first
+    expect(sorted[1]).toMatchObject({
+      priority: 2,
+      createdAt: '2026-01-01T00:00:00Z',
+    }); // high, oldest first
+    expect(sorted[2]).toMatchObject({
+      priority: 2,
+      createdAt: '2026-01-03T00:00:00Z',
+    }); // high, newer
+    expect(sorted[3]).toMatchObject({ priority: 0 }); // no priority last
+  });
+
+  it('treats priority 0 as lower than priority 4', () => {
+    const issues = [
+      { priority: 0, createdAt: '2026-01-01T00:00:00Z' },
+      { priority: 4, createdAt: '2026-01-01T00:00:00Z' },
+    ];
+
+    const sorted = [...issues].sort((a, b) => {
+      const aPriority = a.priority === 0 ? 5 : a.priority;
+      const bPriority = b.priority === 0 ? 5 : b.priority;
+      if (aPriority !== bPriority) return aPriority - bPriority;
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
+
+    expect(sorted[0]?.priority).toBe(4); // low (4) comes before no-priority (0→5)
+    expect(sorted[1]?.priority).toBe(0);
+  });
+});
+
+describe('computeDaysOld', () => {
+  it('returns 0 for today', () => {
+    const now = Date.now();
+    const today = new Date(now).toISOString();
+    const created = new Date(today).getTime();
+    const daysOld = Math.floor((now - created) / (1000 * 60 * 60 * 24));
+    expect(daysOld).toBe(0);
+  });
+
+  it('returns 7 for a date 7 days ago', () => {
+    const sevenDaysAgo = new Date(
+      Date.now() - 7 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    const created = new Date(sevenDaysAgo).getTime();
+    const daysOld = Math.floor((Date.now() - created) / (1000 * 60 * 60 * 24));
+    expect(daysOld).toBe(7);
+  });
+});

--- a/apps/web/lib/hud/linear-actions.ts
+++ b/apps/web/lib/hud/linear-actions.ts
@@ -1,0 +1,311 @@
+import 'server-only';
+
+import { env } from '@/lib/env-server';
+import { logger } from '@/lib/utils/logger';
+
+const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql';
+
+// Label ID for tim-action-required (created 2026-05-08)
+const TIM_ACTION_REQUIRED_LABEL_ID = '518b8d3f-30b4-46ad-85e7-b5cd2546a85f';
+
+export interface TimActionIssue {
+  id: string;
+  identifier: string;
+  title: string;
+  url: string;
+  priority: number; // 0=none, 1=urgent, 2=high, 3=medium, 4=low
+  priorityLabel: string;
+  createdAt: string; // ISO
+  /** Days since created (rounded down) */
+  daysOld: number;
+  stateType: string;
+}
+
+export interface TimActionsResponse {
+  issues: TimActionIssue[];
+  fetchedAt: string; // ISO
+  available: boolean;
+}
+
+interface LinearIssueNode {
+  id: string;
+  identifier: string;
+  title: string;
+  url: string;
+  priority: number;
+  priorityLabel: string;
+  createdAt: string;
+  state: {
+    type: string;
+  };
+}
+
+interface LinearGraphQLResponse {
+  data?: {
+    issues?: {
+      nodes: LinearIssueNode[];
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+const ACTIVE_STATE_TYPES = ['triage', 'unstarted', 'started'];
+
+function computeDaysOld(createdAt: string): number {
+  const created = new Date(createdAt).getTime();
+  const now = Date.now();
+  return Math.floor((now - created) / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * Fetches all Linear issues labeled `tim-action-required` that are in an
+ * active state (triage, unstarted, started). Sorted by priority desc then
+ * createdAt desc (oldest last since priority is most important).
+ *
+ * Returns an empty list if LINEAR_API_KEY is not configured.
+ */
+export async function fetchTimActionIssues(): Promise<TimActionsResponse> {
+  const apiKey = env.LINEAR_API_KEY;
+  const fetchedAt = new Date().toISOString();
+
+  if (!apiKey) {
+    logger.warn('[hud/linear-actions] LINEAR_API_KEY not configured');
+    return { issues: [], fetchedAt, available: false };
+  }
+
+  const query = `
+    query TimActionIssues($labelId: ID!) {
+      issues(
+        filter: {
+          labels: { id: { eq: $labelId } }
+          state: { type: { in: ["triage", "unstarted", "started"] } }
+        }
+        first: 50
+        orderBy: createdAt
+      ) {
+        nodes {
+          id
+          identifier
+          title
+          url
+          priority
+          priorityLabel
+          createdAt
+          state {
+            type
+          }
+        }
+      }
+    }
+  `;
+
+  try {
+    const response = await fetch(LINEAR_GRAPHQL_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: apiKey,
+        'Content-Type': 'application/json',
+        'User-Agent': 'Jovie-HUD/1.0',
+      },
+      body: JSON.stringify({
+        query,
+        variables: { labelId: TIM_ACTION_REQUIRED_LABEL_ID },
+      }),
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!response.ok) {
+      logger.error(
+        '[hud/linear-actions] Linear API error',
+        response.status,
+        response.statusText
+      );
+      return { issues: [], fetchedAt, available: false };
+    }
+
+    const payload = (await response.json()) as LinearGraphQLResponse;
+
+    if (payload.errors && payload.errors.length > 0) {
+      logger.error(
+        '[hud/linear-actions] Linear GraphQL errors',
+        payload.errors[0]?.message
+      );
+      return { issues: [], fetchedAt, available: false };
+    }
+
+    const nodes = payload.data?.issues?.nodes ?? [];
+
+    // Filter to active states defensively (Linear filter may not be perfect)
+    const active = nodes.filter(n => ACTIVE_STATE_TYPES.includes(n.state.type));
+
+    // Sort: priority ASC (1=urgent is best) then createdAt ASC (oldest first = most urgent)
+    // In the UI this renders as: most-urgent priority at top, oldest within same priority at top
+    active.sort((a, b) => {
+      const aPriority = a.priority === 0 ? 5 : a.priority; // treat "no priority" as lowest
+      const bPriority = b.priority === 0 ? 5 : b.priority;
+      if (aPriority !== bPriority) return aPriority - bPriority;
+      // Within same priority, older issues first (more urgent to close)
+      return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    });
+
+    const issues: TimActionIssue[] = active.map(node => ({
+      id: node.id,
+      identifier: node.identifier,
+      title: node.title,
+      url: node.url,
+      priority: node.priority,
+      priorityLabel: node.priorityLabel,
+      createdAt: node.createdAt,
+      daysOld: computeDaysOld(node.createdAt),
+      stateType: node.state.type,
+    }));
+
+    return { issues, fetchedAt, available: true };
+  } catch (error) {
+    logger.error(
+      '[hud/linear-actions] Failed to fetch tim-action issues',
+      error
+    );
+    return { issues: [], fetchedAt, available: false };
+  }
+}
+
+/**
+ * Closes a Linear issue by transitioning it to "Done" state via the Linear
+ * GraphQL API. Returns true on success, false on failure.
+ */
+export async function closeLinearIssue(issueId: string): Promise<boolean> {
+  const apiKey = env.LINEAR_API_KEY;
+
+  if (!apiKey) {
+    logger.warn(
+      '[hud/linear-actions] LINEAR_API_KEY not configured; cannot close issue'
+    );
+    return false;
+  }
+
+  // Step 1: find a "completed" state to transition to.
+  // We use the issue's team to find the right completed state.
+  const findStateQuery = `
+    query FindCompletedState($issueId: String!) {
+      issue(id: $issueId) {
+        team {
+          states {
+            nodes {
+              id
+              type
+              name
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  interface FindStateResponse {
+    data?: {
+      issue?: {
+        team?: {
+          states?: {
+            nodes: Array<{ id: string; type: string; name: string }>;
+          };
+        };
+      };
+    };
+    errors?: Array<{ message: string }>;
+  }
+
+  try {
+    const stateRes = await fetch(LINEAR_GRAPHQL_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: apiKey,
+        'Content-Type': 'application/json',
+        'User-Agent': 'Jovie-HUD/1.0',
+      },
+      body: JSON.stringify({ query: findStateQuery, variables: { issueId } }),
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!stateRes.ok) {
+      logger.error(
+        '[hud/linear-actions] Failed to find completed state',
+        stateRes.status
+      );
+      return false;
+    }
+
+    const statePayload = (await stateRes.json()) as FindStateResponse;
+    const states = statePayload.data?.issue?.team?.states?.nodes ?? [];
+    const completedState = states.find(s => s.type === 'completed');
+
+    if (!completedState) {
+      logger.error(
+        '[hud/linear-actions] No completed state found for issue',
+        issueId
+      );
+      return false;
+    }
+
+    // Step 2: update the issue to the completed state
+    const updateMutation = `
+      mutation CloseIssue($issueId: String!, $stateId: String!) {
+        issueUpdate(id: $issueId, input: { stateId: $stateId }) {
+          success
+        }
+      }
+    `;
+
+    interface UpdateResponse {
+      data?: { issueUpdate?: { success: boolean } };
+      errors?: Array<{ message: string }>;
+    }
+
+    const updateRes = await fetch(LINEAR_GRAPHQL_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: apiKey,
+        'Content-Type': 'application/json',
+        'User-Agent': 'Jovie-HUD/1.0',
+      },
+      body: JSON.stringify({
+        query: updateMutation,
+        variables: { issueId, stateId: completedState.id },
+      }),
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!updateRes.ok) {
+      logger.error(
+        '[hud/linear-actions] Failed to update issue',
+        updateRes.status
+      );
+      return false;
+    }
+
+    const updatePayload = (await updateRes.json()) as UpdateResponse;
+
+    if (updatePayload.errors && updatePayload.errors.length > 0) {
+      logger.error(
+        '[hud/linear-actions] GraphQL error closing issue',
+        updatePayload.errors[0]?.message
+      );
+      return false;
+    }
+
+    const success = updatePayload.data?.issueUpdate?.success ?? false;
+    if (!success) {
+      logger.error(
+        '[hud/linear-actions] issueUpdate returned success=false for',
+        issueId
+      );
+    }
+    return success;
+  } catch (error) {
+    logger.error(
+      `[hud/linear-actions] Failed to close issue ${issueId}`,
+      error
+    );
+    return false;
+  }
+}

--- a/apps/web/lib/hud/linear-actions.ts
+++ b/apps/web/lib/hud/linear-actions.ts
@@ -120,7 +120,8 @@ export async function fetchTimActionIssues(): Promise<TimActionsResponse> {
         response.status,
         response.statusText
       );
-      return { issues: [], fetchedAt, available: false };
+      // available stays true — API key is configured, this is a transient failure
+      return { issues: [], fetchedAt, available: true };
     }
 
     const payload = (await response.json()) as LinearGraphQLResponse;
@@ -130,7 +131,8 @@ export async function fetchTimActionIssues(): Promise<TimActionsResponse> {
         '[hud/linear-actions] Linear GraphQL errors',
         payload.errors[0]?.message
       );
-      return { issues: [], fetchedAt, available: false };
+      // available stays true — API key is configured, this is a transient/schema error
+      return { issues: [], fetchedAt, available: true };
     }
 
     const nodes = payload.data?.issues?.nodes ?? [];
@@ -166,7 +168,8 @@ export async function fetchTimActionIssues(): Promise<TimActionsResponse> {
       '[hud/linear-actions] Failed to fetch tim-action issues',
       error
     );
-    return { issues: [], fetchedAt, available: false };
+    // available stays true — API key is configured, this is a transient network error
+    return { issues: [], fetchedAt, available: true };
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a **Tim Action Required** section to the HUD ops dashboard that surfaces Linear issues labeled `tim-action-required` that are still active (triage / unstarted / started).

- New `lib/hud/linear-actions.ts` — server-only module that fetches and closes Linear issues via GraphQL
- New `app/api/admin/hud/tim-actions/route.ts` — admin-gated GET (fetch) + POST (close) handler
- New `components/features/admin/TimActionRequiredSection.tsx` — client component with optimistic close, silent background polling, and graceful degradation when `LINEAR_API_KEY` is absent
- New `lib/hud/linear-actions.test.ts` — unit tests covering sort order and graceful degradation

Issues sort by priority ASC (1=Urgent first), then by age ASC (oldest within priority group). Days >7 display in red. The section self-hides entirely when `available: false` (no API key configured).

## Implementation notes

- Label ID `518b8d3f-30b4-46ad-85e7-b5cd2546a85f` is hardcoded (created 2026-05-08)
- Closing an issue is a two-step GraphQL flow: find the team's "completed" state ID, then `issueUpdate`
- `ContentSurfaceCard` lives inside the component so no empty card renders when `null` is returned
- Background polls (every 5 min via `STANDARD_CACHE.staleTime`) are silent — only the initial load shows a skeleton

## Activation

Add `LINEAR_API_KEY` to Doppler `jovie-web / dev` (and staging/prod when ready). The HUD section will appear automatically. Without the key the section is invisible.

## Test plan

- [x] Typecheck passes (`tsc --noEmit`)
- [x] Biome lint passes (no fixes needed)
- [x] Unit tests pass (5/5): sort ordering, graceful degradation
- [x] All 6 CodeRabbit review comments addressed
- [ ] Manual: verify section appears on `/app/admin/ops` once `LINEAR_API_KEY` is set in Doppler

<!-- linear-issue-id:JOV-2042 -->