### PR TITLE
fix(auth): polish AuthLayout per visual audit findings (JOV-2044)

### DIFF
--- a/apps/web/app/(auth)/signup/page.tsx
+++ b/apps/web/app/(auth)/signup/page.tsx
@@ -172,11 +172,34 @@ function SignUpOauthErrorBanner() {
   );
 }
 
+/**
+ * Clerk appearance override for the signup page only.
+ * Hides Clerk's built-in "Create your account" header because we render our
+ * own "Request Access" heading. Also hides the Clerk footer sign-in link when
+ * an OAuth error banner is present to satisfy the subtraction principle (one
+ * error message, one action).
+ */
+const SIGNUP_APPEARANCE_HIDE_HEADER = {
+  elements: {
+    headerTitle: 'hidden',
+    headerSubtitle: 'hidden',
+  },
+} as const;
+
+const SIGNUP_APPEARANCE_HIDE_HEADER_AND_FOOTER = {
+  elements: {
+    headerTitle: 'hidden',
+    headerSubtitle: 'hidden',
+    footer: 'hidden',
+  },
+} as const;
+
 function SignUpPageContent() {
   const [isMounted, setIsMounted] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const searchParams = useSearchParams();
   const signInUrl = buildAuthRouteUrl(APP_ROUTES.SIGNIN, searchParams);
+  const oauthError = searchParams.get('oauth_error');
 
   useNormalizeClerkHomeLink(containerRef);
 
@@ -188,11 +211,16 @@ function SignUpPageContent() {
     return <AuthFormSkeleton />;
   }
 
+  // When oauth_error is present, hide Clerk's own footer sign-in link to avoid
+  // a redundant third prompt alongside our error banner + its action link.
+  const signUpAppearance = oauthError
+    ? SIGNUP_APPEARANCE_HIDE_HEADER_AND_FOOTER
+    : SIGNUP_APPEARANCE_HIDE_HEADER;
+
   return (
     <>
       <AuthRoutePrefetch href={APP_ROUTES.WAITLIST} />
-      <SignUpClaimDataPersistence />
-      <SignUpOauthErrorBanner />
+      {/* P0: heading first so it anchors the form visually */}
       <div className='mb-4 text-center lg:text-left'>
         <h1 className='text-[22px] font-semibold leading-7 text-white'>
           Request Access
@@ -201,12 +229,16 @@ function SignUpPageContent() {
           Create an account to start your private launch request.
         </p>
       </div>
+      {/* P2: banner and error notice render below the heading */}
+      <SignUpOauthErrorBanner />
+      <SignUpClaimDataPersistence />
       <div ref={containerRef}>
         <SignUp
           routing='hash'
           oauthFlow='redirect'
           signInUrl={signInUrl}
           fallbackRedirectUrl={APP_ROUTES.WAITLIST}
+          appearance={signUpAppearance}
         />
       </div>
       <p className='mt-4 text-center text-2xs leading-relaxed text-white/80'>

--- a/apps/web/components/features/auth/AuthLayout.tsx
+++ b/apps/web/components/features/auth/AuthLayout.tsx
@@ -71,14 +71,16 @@ function SplitLayoutContent({
   designV1,
 }: AuthLayoutInnerProps) {
   return (
-    <div className='relative z-10 flex w-full flex-1 items-stretch'>
-      <div className='grid w-full gap-2 lg:grid-cols-[minmax(0,420px)_minmax(0,1fr)] lg:items-stretch'>
-        <div className='flex min-h-0 flex-col items-center justify-center px-4 sm:px-8 lg:max-w-[460px] lg:px-10'>
+    <div className='relative z-10 flex w-full flex-1 items-stretch justify-center'>
+      {/* max-w constrains the split layout on ultra-wide displays so the form
+          column doesn't strand at the left with an enormous dead-space right panel */}
+      <div className='grid w-full max-w-[1440px] gap-2 lg:grid-cols-[minmax(0,480px)_minmax(0,1fr)] lg:items-stretch'>
+        <div className='flex min-h-0 flex-col items-center justify-center px-4 sm:px-8 lg:max-w-[480px] lg:px-10'>
           {showFormTitle && formTitle ? (
             <h1
               className={cn(
                 formTitleClassName,
-                'mb-6 text-center transition-all duration-200 ease-out',
+                'mb-6 text-center transition-[margin,height,opacity] duration-subtle ease-subtle',
                 isKeyboardVisible && 'mb-0 h-0 overflow-hidden opacity-0'
               )}
               aria-hidden={isKeyboardVisible}
@@ -97,7 +99,7 @@ function SplitLayoutContent({
           </main>
 
           {showFooterPrompt && !isKeyboardVisible ? (
-            <p className='mt-3 text-center text-app font-normal text-white/58 animate-in fade-in-0 duration-200'>
+            <p className='mt-3 text-center text-app font-normal text-white/58 animate-in fade-in-0 duration-subtle'>
               {footerPrompt}{' '}
               <Link
                 href={footerLinkHref}
@@ -143,7 +145,7 @@ function StackLayoutContent({
           <h1
             className={cn(
               formTitleClassName,
-              'transition-all duration-200 ease-out',
+              'transition-[margin,height,opacity] duration-subtle ease-subtle',
               isKeyboardVisible && 'mb-0 h-0 overflow-hidden opacity-0'
             )}
             aria-hidden={isKeyboardVisible}
@@ -163,7 +165,7 @@ function StackLayoutContent({
       </div>
 
       {showFooterPrompt && !isKeyboardVisible ? (
-        <p className='relative z-10 mt-auto pt-8 text-center text-app font-normal text-[lch(68%_1.35_282)] animate-in fade-in-0 duration-200'>
+        <p className='relative z-10 mt-auto pt-8 text-center text-app font-normal text-[lch(68%_1.35_282)] animate-in fade-in-0 duration-subtle'>
           {footerPrompt}{' '}
           <Link
             href={footerLinkHref}
@@ -238,7 +240,7 @@ export function AuthLayout({
         'pb-[max(0.5rem,env(safe-area-inset-bottom))]',
         'pl-[max(0.5rem,env(safe-area-inset-left))]',
         'pr-[max(0.5rem,env(safe-area-inset-right))]',
-        'transition-[padding] duration-200 ease-out'
+        'transition-[padding] duration-subtle ease-subtle'
       )}
     >
       <div
@@ -273,14 +275,14 @@ export function AuthLayout({
       {showLogo ? (
         <div
           className={cn(
-            'absolute top-5 left-5 z-50 transition-opacity duration-200 ease-out sm:top-6 sm:left-7 lg:top-7 lg:left-14',
+            'absolute top-5 left-5 z-50 transition-opacity duration-subtle ease-subtle sm:top-6 sm:left-7 lg:top-7 lg:left-14',
             isKeyboardVisible && 'pointer-events-none opacity-0'
           )}
           aria-hidden={isKeyboardVisible}
         >
           <Link
             href='/'
-            className='inline-flex items-center justify-center text-white/45 transition-colors duration-200 hover:text-white/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20'
+            className='inline-flex items-center justify-center text-white/45 transition-colors duration-subtle hover:text-white/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20'
             aria-label='Go to homepage'
             tabIndex={isKeyboardVisible ? -1 : undefined}
           >


### PR DESCRIPTION
## Summary

Addresses 4 visual-audit findings from `apps/web/docs/auth-visual-audit-2026-05-09T031254Z.md` on the full-page auth experience.

### P0 — Double heading on `/signup` (fixed)
Clerk's built-in "Create your account" heading was rendering alongside the custom "Request Access" `<h1>`. Fixed by passing `appearance.elements.headerTitle: 'hidden'` and `headerSubtitle: 'hidden'` directly to the `<SignUp>` component so Clerk's header is suppressed while the intentional Jovie heading remains the single H1.

### P1 — Ultra-wide imbalance on `AuthLayout` split variant (fixed)
At 2560/3440px the right (brand) column stretched to 2000–3000px, stranding the form. Fixed by adding `max-w-[1440px]` and `justify-center` to the outer split layout wrapper so both columns are capped and centred. Also bumped form column from `minmax(0,420px)` to `minmax(0,480px)` for better visual balance.

### P2 — Handle availability banner above heading on `/signup` (fixed)
`SignUpClaimDataPersistence` (availability banner) and `SignUpOauthErrorBanner` rendered before the `<h1>`. Reordered: heading first, then OAuth error banner, then handle availability banner. Banners are still rendered in context directly above the form.

### P3 — OAuth error state stacks three sign-in prompts (fixed)
When `?oauth_error=account_exists`, three prompts rendered: (1) our error banner message, (2) our "Sign in instead" link, (3) Clerk's own footer "Already have an account? Sign in" link. Fixed by passing `appearance.elements.footer: 'hidden'` when `oauth_error` is present — one error message, one action, no redundancy.

### Bonus — Pre-existing motion token violations cleared
Touching `AuthLayout.tsx` surfaced pre-existing `@jovie/no-raw-motion-values` warnings (`transition-all`, `duration-200`) that would have failed the `--max-warnings=0` pre-commit ESLint gate. Replaced with DS tokens (`duration-subtle`, `ease-subtle`, explicit transition properties) across all 7 occurrences in the same file.

## Files changed
- `apps/web/app/(auth)/signup/page.tsx` — P0, P2, P3
- `apps/web/components/features/auth/AuthLayout.tsx` — P1, bonus motion cleanup

## Verification
- TypeScript: `tsc --noEmit` → 0 errors
- Biome: `pnpm biome check --write` → no fixes needed
- ESLint: `--max-warnings=0` → 0 warnings on changed files
- Auth tests: 37 tests passed (`tests/components/auth`)
- Pre-push hooks: all passed (biome, typecheck, tailwind guard, lint)

## Screenshots
Screenshots pending preview deploy. The preview URL will show:
- `/signin` — unchanged (uses `showFormTitle={false}`, no heading)
- `/signup` — single "Request Access" heading (no Clerk duplicate)
- `/signup?oauth_error=account_exists` — one error banner, one "Sign in instead" link, no Clerk footer prompt
- `/signup?handle=artist123` — heading above the handle availability banner

Closes JOV-2044
<!-- linear-issue-id:JOV-2044 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined animation transitions for a smoother authentication experience
  * Improved signup page layout and visual presentation
  * Adjusted layout constraints for better responsive behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->