### PR TITLE
perf(profile): restore ISR on /[username] (JOV-2050)

### DIFF
--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -28,7 +28,8 @@ import { toPublicContacts } from '@/lib/contacts/mapper';
 import type { DiscogRelease } from '@/lib/db/schema';
 import { getReleasesForProfileLite } from '@/lib/discography/queries';
 import { captureError } from '@/lib/error-tracking';
-import { getProfileAlertOptInVariant } from '@/lib/flags/server';
+// ISR-safe: profile-variant.ts does NOT import cookies() — no dynamic opt-in
+import { getProfileAlertOptInVariant } from '@/lib/flags/profile-variant';
 import { getConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import { isShopEnabled } from '@/lib/profile/shop-settings';
 import { getUpcomingTourDatesForProfile } from '@/lib/tour-dates/queries';

--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -426,7 +426,8 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
     releasesPromise,
     // stableId is null for ISR renders — returns the default 'button' variant.
     // AnonCookieBootstrap resolves the per-user variant on the client side.
-    getProfileAlertOptInVariant(null),
+    // .catch ensures a Statsig outage doesn't fail the whole ISR page render.
+    getProfileAlertOptInVariant(null).catch(() => 'button' as const),
   ]);
   const tourDates = [...tourDatesRaw].sort(
     (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime()

--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -1,11 +1,13 @@
 import { type Metadata } from 'next';
-import { cookies } from 'next/headers';
 import { notFound } from 'next/navigation';
 
-export const dynamic = 'force-dynamic';
+// No `export const dynamic` here — the parent layout sets `revalidate: 3600`
+// (ISR). The public profile route must stay ISR-cacheable; avoid any Dynamic
+// API (cookies(), headers()) in this RSC tree.
 
+import { AnonCookieBootstrap } from '@/components/features/profile/AnonCookieBootstrap';
 import type { PublicRelease } from '@/components/features/profile/releases/types';
-import { AUDIENCE_ANON_COOKIE, BASE_URL } from '@/constants/app';
+import { BASE_URL } from '@/constants/app';
 import { ErrorBanner } from '@/features/feedback/ErrorBanner';
 import { DesktopQrOverlayClient } from '@/features/profile/DesktopQrOverlayClient';
 import { ProfileViewTracker } from '@/features/profile/ProfileViewTracker';
@@ -322,9 +324,12 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
 
   const isPublicNoAuthSmoke = process.env.PUBLIC_NOAUTH_SMOKE === '1';
   const viewerCountryCode = null;
-  const cookieStore = await cookies();
-  const alertOptInStableId =
-    cookieStore.get(AUDIENCE_ANON_COOKIE)?.value ?? null;
+
+  // IMPORTANT: Do NOT read cookies() here — it would opt this ISR route into
+  // dynamic rendering, defeating the revalidate: 3600 set in layout.tsx.
+  // The jv_aid cookie is set by middleware on every request (analytics still
+  // work). The alertOptInVariant defaults to 'button' for ISR; AnonCookieBootstrap
+  // resolves the per-user variant client-side via /api/profile/audience-anon-cookie.
 
   const profileResult = await getProfileAndLinks(username);
   const {
@@ -418,7 +423,9 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
   const [tourDatesRaw, allReleases, alertOptInVariant] = await Promise.all([
     tourDatesPromise.catch(() => [] as TourDateViewModel[]),
     releasesPromise,
-    getProfileAlertOptInVariant(alertOptInStableId),
+    // stableId is null for ISR renders — returns the default 'button' variant.
+    // AnonCookieBootstrap resolves the per-user variant on the client side.
+    getProfileAlertOptInVariant(null),
   ]);
   const tourDates = [...tourDatesRaw].sort(
     (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
@@ -449,6 +456,10 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
       <script type='application/ld+json'>
         {safeJsonLdStringify(structuredData)}
       </script>
+
+      {/* Bootstraps the per-user jv_aid identity client-side without reading
+          cookies() in the RSC tree, keeping this route ISR-cacheable. */}
+      <AnonCookieBootstrap />
 
       {isPublicNoAuthSmoke ? null : (
         <ProfileViewTracker handle={artist.handle} artistId={artist.id} />

--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -5,7 +5,6 @@ import { notFound } from 'next/navigation';
 // (ISR). The public profile route must stay ISR-cacheable; avoid any Dynamic
 // API (cookies(), headers()) in this RSC tree.
 
-import { AnonCookieBootstrap } from '@/components/features/profile/AnonCookieBootstrap';
 import type { PublicRelease } from '@/components/features/profile/releases/types';
 import { BASE_URL } from '@/constants/app';
 import { ErrorBanner } from '@/features/feedback/ErrorBanner';
@@ -329,8 +328,9 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
   // IMPORTANT: Do NOT read cookies() here — it would opt this ISR route into
   // dynamic rendering, defeating the revalidate: 3600 set in layout.tsx.
   // The jv_aid cookie is set by middleware on every request (analytics still
-  // work). The alertOptInVariant defaults to 'button' for ISR; AnonCookieBootstrap
-  // resolves the per-user variant client-side via /api/profile/audience-anon-cookie.
+  // work). The alertOptInVariant defaults to 'button' for ISR; ProfileCompactTemplate
+  // renders AnonCookieBootstrap which resolves the per-user variant client-side
+  // via /api/profile/audience-anon-cookie and updates its own state.
 
   const profileResult = await getProfileAndLinks(username);
   const {
@@ -457,10 +457,6 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
       <script type='application/ld+json'>
         {safeJsonLdStringify(structuredData)}
       </script>
-
-      {/* Bootstraps the per-user jv_aid identity client-side without reading
-          cookies() in the RSC tree, keeping this route ISR-cacheable. */}
-      <AnonCookieBootstrap />
 
       {isPublicNoAuthSmoke ? null : (
         <ProfileViewTracker handle={artist.handle} artistId={artist.id} />

--- a/apps/web/app/api/profile/audience-anon-cookie/route.ts
+++ b/apps/web/app/api/profile/audience-anon-cookie/route.ts
@@ -17,7 +17,17 @@ import { getProfileAlertOptInVariant } from '@/lib/flags/server';
 export async function GET(): Promise<NextResponse> {
   const cookieStore = await cookies();
   const stableId = cookieStore.get(AUDIENCE_ANON_COOKIE)?.value ?? null;
-  const alertOptInVariant = await getProfileAlertOptInVariant(stableId);
+
+  // Best-effort: fall back to the default variant if Statsig is unavailable.
+  // The client component already handles null/missing responses gracefully.
+  let alertOptInVariant: Awaited<
+    ReturnType<typeof getProfileAlertOptInVariant>
+  >;
+  try {
+    alertOptInVariant = await getProfileAlertOptInVariant(stableId);
+  } catch {
+    alertOptInVariant = 'button';
+  }
 
   return NextResponse.json(
     { alertOptInVariant },

--- a/apps/web/app/api/profile/audience-anon-cookie/route.ts
+++ b/apps/web/app/api/profile/audience-anon-cookie/route.ts
@@ -1,0 +1,30 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { AUDIENCE_ANON_COOKIE } from '@/constants/app';
+import { getProfileAlertOptInVariant } from '@/lib/flags/server';
+
+/**
+ * Thin GET route that reads the httpOnly jv_aid cookie and returns the
+ * per-user Statsig alertOptInVariant.
+ *
+ * Called from the AnonCookieBootstrap client component so the public profile
+ * route can be ISR-cached (no cookies() in the RSC tree) while still
+ * delivering the correct A/B test variant to real visitors on the client side.
+ *
+ * No auth required — this is a public, anonymous endpoint.
+ * Cache-Control: no-store so each real visitor gets their own variant.
+ */
+export async function GET(): Promise<NextResponse> {
+  const cookieStore = await cookies();
+  const stableId = cookieStore.get(AUDIENCE_ANON_COOKIE)?.value ?? null;
+  const alertOptInVariant = await getProfileAlertOptInVariant(stableId);
+
+  return NextResponse.json(
+    { alertOptInVariant },
+    {
+      headers: {
+        'Cache-Control': 'no-store',
+      },
+    }
+  );
+}

--- a/apps/web/components/features/profile/AnonCookieBootstrap.tsx
+++ b/apps/web/components/features/profile/AnonCookieBootstrap.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect } from 'react';
+import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
+
+interface AnonCookieBootstrapProps {
+  /**
+   * Callback invoked once the per-user alertOptInVariant has been resolved
+   * server-side (via the jv_aid httpOnly cookie). The ISR page renders with
+   * the default 'button' variant; this callback lets interactive descendants
+   * react if the user has been assigned a different variant.
+   */
+  readonly onVariantResolved?: (variant: ProfileAlertOptInVariant) => void;
+}
+
+/**
+ * Bootstraps the anonymous visitor identity on the client.
+ *
+ * The public profile route is ISR-cached (revalidate: 3600), so the RSC
+ * cannot read the httpOnly `jv_aid` cookie directly — doing so would force
+ * dynamic rendering and defeat ISR. Instead:
+ *
+ *  1. The RSC renders with the default alertOptInVariant ('button').
+ *  2. This client component calls /api/profile/audience-anon-cookie on mount.
+ *     The API route reads the httpOnly cookie server-side and returns the
+ *     per-user Statsig variant.
+ *  3. If the variant differs from the ISR default, onVariantResolved fires.
+ *
+ * Analytics still work: the jv_aid cookie is set by middleware on every
+ * request and is read directly by /api/audience/visit — it does not depend
+ * on the RSC reading it.
+ */
+export function AnonCookieBootstrap({
+  onVariantResolved,
+}: AnonCookieBootstrapProps) {
+  useEffect(() => {
+    if (!onVariantResolved) return;
+
+    void fetch('/api/profile/audience-anon-cookie', {
+      method: 'GET',
+      credentials: 'same-origin',
+    })
+      .then(res => (res.ok ? res.json() : null))
+      .then((data: { alertOptInVariant: ProfileAlertOptInVariant } | null) => {
+        if (data?.alertOptInVariant) {
+          onVariantResolved(data.alertOptInVariant);
+        }
+      })
+      .catch(() => {
+        // Best-effort: analytics and the default CTA variant are unaffected.
+      });
+  }, [onVariantResolved]);
+
+  return null;
+}

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from 'react';
 import { ImageWithFallback } from '@/components/atoms/ImageWithFallback';
+import { AnonCookieBootstrap } from '@/components/features/profile/AnonCookieBootstrap';
 import {
   ProfileNotificationsContext,
   useProfileShell,
@@ -221,6 +222,11 @@ export function ProfileCompactTemplate({
   hideMoreMenu = false,
   visualVariant = 'default',
 }: ProfileCompactTemplateProps) {
+  // alertOptInVariant starts as the ISR-rendered default ('button').
+  // AnonCookieBootstrap resolves the per-user Statsig variant on mount and
+  // updates this state, so real visitors see their assigned experiment variant.
+  const [resolvedAlertOptInVariant, setResolvedAlertOptInVariant] =
+    useState<ProfileAlertOptInVariant>(alertOptInVariant);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [drawerView, setDrawerView] = useState<DrawerView>('menu');
   const [drawerPresentation, setDrawerPresentation] =
@@ -678,6 +684,9 @@ export function ProfileCompactTemplate({
 
   return (
     <ProfileNotificationsContext.Provider value={notificationsContextValue}>
+      {/* Resolves the per-user jv_aid variant client-side after ISR hydration.
+          Renders null; updates resolvedAlertOptInVariant state on mount. */}
+      <AnonCookieBootstrap onVariantResolved={setResolvedAlertOptInVariant} />
       <div
         className={cn(
           'profile-viewport relative h-[100dvh] overflow-hidden bg-[color:var(--profile-stage-bg)] text-primary-token'
@@ -725,7 +734,7 @@ export function ProfileCompactTemplate({
                   showPayButton={showPayButton}
                   latestRelease={latestRelease}
                   profileSettings={profileSettings}
-                  alertOptInVariant={alertOptInVariant}
+                  alertOptInVariant={resolvedAlertOptInVariant}
                   genres={genres}
                   pressPhotos={pressPhotos}
                   allowPhotoDownloads={allowPhotoDownloads}
@@ -773,7 +782,7 @@ export function ProfileCompactTemplate({
                   featuredPlaylistFallback={featuredPlaylistFallback}
                   enableDynamicEngagement={enableDynamicEngagement}
                   subscribeTwoStep={subscribeTwoStep}
-                  alertOptInVariant={alertOptInVariant}
+                  alertOptInVariant={resolvedAlertOptInVariant}
                   genres={genres}
                   pressPhotos={pressPhotos}
                   allowPhotoDownloads={allowPhotoDownloads}

--- a/apps/web/lib/flags/profile-variant.ts
+++ b/apps/web/lib/flags/profile-variant.ts
@@ -1,0 +1,32 @@
+/**
+ * ISR-safe profile variant resolver.
+ *
+ * This module intentionally does NOT import `cookies` from `next/headers`.
+ * Importing that dynamic API would opt any RSC that imports this file into
+ * dynamic rendering, defeating ISR on /[username].
+ *
+ * Only use this from server components that must remain ISR-cacheable.
+ * For cookie-backed variant resolution (admin, dashboard), use lib/flags/server.ts.
+ */
+import 'server-only';
+import type { ProfileAlertOptInVariant } from './contracts';
+import { PROFILE_ALERT_OPTIN_VARIANT_FLAG } from './registry';
+
+/**
+ * Resolves the profile alert opt-in variant for a given stable ID.
+ *
+ * Safe to call from ISR-cached Server Components — no `cookies()` call
+ * in this module or its transitive imports.
+ *
+ * @param stableId - The jv_aid cookie value (uuid), or null for ISR renders.
+ *   Null returns the flag's default value ('button').
+ */
+export async function getProfileAlertOptInVariant(
+  stableId: string | null
+): Promise<ProfileAlertOptInVariant> {
+  return PROFILE_ALERT_OPTIN_VARIANT_FLAG.run({
+    identify: {
+      userId: stableId,
+    },
+  });
+}

--- a/apps/web/lib/flags/profile-variant.ts
+++ b/apps/web/lib/flags/profile-variant.ts
@@ -1,32 +1,33 @@
 /**
  * ISR-safe profile variant resolver.
  *
- * This module intentionally does NOT import `cookies` from `next/headers`.
- * Importing that dynamic API would opt any RSC that imports this file into
- * dynamic rendering, defeating ISR on /[username].
+ * This module intentionally bypasses the Vercel Flags SDK (`flag().run()`).
+ * The Flags SDK calls `headers()` from `next/headers` inside `.run()` to
+ * implement per-request evaluation caching — that dynamic API opts any RSC
+ * that calls it into dynamic rendering, defeating ISR on /[username].
+ *
+ * Instead, this module calls the underlying Statsig helper directly, which
+ * reads from the initialized Statsig server SDK without touching any Next.js
+ * per-request APIs.
  *
  * Only use this from server components that must remain ISR-cacheable.
- * For cookie-backed variant resolution (admin, dashboard), use lib/flags/server.ts.
+ * For cookie-backed override support and the Flags SDK devtools integration,
+ * use lib/flags/server.ts (safe on dynamic routes like /api/*).
  */
 import 'server-only';
 import type { ProfileAlertOptInVariant } from './contracts';
-import { PROFILE_ALERT_OPTIN_VARIANT_FLAG } from './registry';
+import { getProfileAlertOptInVariantValue } from './statsig';
 
 /**
  * Resolves the profile alert opt-in variant for a given stable ID.
  *
- * Safe to call from ISR-cached Server Components — no `cookies()` call
- * in this module or its transitive imports.
+ * ISR-safe: calls the Statsig SDK directly without touching next/headers.
  *
  * @param stableId - The jv_aid cookie value (uuid), or null for ISR renders.
- *   Null returns the flag's default value ('button').
+ *   Null resolves as the anonymous user and returns the flag's default ('button').
  */
 export async function getProfileAlertOptInVariant(
   stableId: string | null
 ): Promise<ProfileAlertOptInVariant> {
-  return PROFILE_ALERT_OPTIN_VARIANT_FLAG.run({
-    identify: {
-      userId: stableId,
-    },
-  });
+  return getProfileAlertOptInVariantValue(stableId);
 }


### PR DESCRIPTION
## Summary

P0 fix from the JOV-2019 audit + JOV-2020 spec. Removes `force-dynamic`, moves the `AUDIENCE_ANON_COOKIE` read to a client component, and confirms the route is ISR.

- **Removes** `export const dynamic = 'force-dynamic'` from `app/[username]/page.tsx` — this was the root cause, overriding the layout's `revalidate: 3600`
- **Moves** the `cookies()` read (jv_aid / `AUDIENCE_ANON_COOKIE`) out of the RSC tree into a new `AnonCookieBootstrap` client component + `/api/profile/audience-anon-cookie` thin API route
- **Preserves** analytics: `jv_aid` is set by middleware on every request and read directly by `/api/audience/visit` — independent of the RSC

## Build Output (confirms ISR)

```
Route (app)                                          Revalidate  Expire
...
├ ● /[username]        ← ISR (was ƒ Dynamic before this PR)
```

The `●` symbol = prerendered with revalidation (ISR). The route is no longer `ƒ` (server-rendered dynamic).

## Cache Invalidation

Already in place — no additional changes needed:
- `invalidateProfileCache(username)` calls `revalidateTag('profile:{username}')` + `revalidatePath('/${username}')`
- Called from all mutation paths: avatar upload, social links (add/update/delete), profile edit, admin actions, onboarding, ingestion flows, username change
- The public profile loader's `unstable_cache` already tags with `['profiles-all', 'profile:{username}']`

## Mutation Paths With `revalidateTag` Coverage

| Path | Via |
|---|---|
| Profile edit (display name, bio, etc.) | `updateCreatorProfile → invalidateProfileCache` |
| Avatar upload | `invalidateAvatarCache + invalidateProfileCache` |
| Social links (add/update/delete) | `invalidateSocialLinksCache` |
| Username change | `invalidateUsernameChange` |
| Admin profile updates | `invalidateProfileCache` (multiple actions) |
| Spotify/platform connect (onboarding) | `invalidateProfileCache` |
| Ingestion (reingest, social platform) | `invalidateProfileCache` |
| Artist theme | `invalidateProfileCache` |
| Shop settings | `invalidateProfileCache` |
| Featured playlist fallback | `invalidateProfileCache` |

## Test Plan

- [ ] Public profile loads correctly at `/[username]`
- [ ] Build output shows `●` (ISR) for `/[username]`
- [ ] Profile update (e.g., edit bio) triggers ISR revalidation within seconds
- [ ] `jv_aid` cookie is still set by middleware on profile page visits
- [ ] No Sentry hydration errors after deploy

Closes JOV-2050.

<!-- linear-issue-id: JOV-2050 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Profile pages are now ISR-friendly by deferring per-user personalization to the client, improving cacheability and anon visitor load times.
* **New Features**
  * Client-side bootstrap resolves and applies per-user alert opt‑in variants after page load.
  * Added a backend endpoint that securely returns cookie-derived variant info to the client when available.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8393)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->