### PR TITLE
fix(hud): require Stripe for financial availability

### DIFF
--- a/apps/web/lib/hud/metrics.ts
+++ b/apps/web/lib/hud/metrics.ts
@@ -154,6 +154,8 @@ export async function getHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
     stripeMetrics,
     mercuryMetrics
   );
+  const financialDataAvailable =
+    stripeMetrics.isAvailable && mercuryMetrics.isAvailable;
 
   const operationsStatus: HudMetrics['operations'] = {
     status: dbHealth.healthy ? 'ok' : 'degraded',
@@ -179,16 +181,16 @@ export async function getHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
       activeSubscribers: stripeMetrics.activeSubscribers,
       balanceUsd: mercuryMetrics.isAvailable ? mercuryMetrics.balanceUsd : 0,
       burnRateUsd: mercuryMetrics.isAvailable ? mercuryMetrics.burnRateUsd : 0,
-      runwayMonths: mercuryMetrics.isAvailable
+      runwayMonths: financialDataAvailable
         ? financialStatus.runwayMonths
         : null,
-      defaultStatus: mercuryMetrics.isAvailable
+      defaultStatus: financialDataAvailable
         ? financialStatus.isDefaultAlive
           ? 'alive'
           : 'dead'
         : 'unknown',
       defaultStatusDetail: financialStatus.defaultStatusDetail,
-      financialDataAvailable: mercuryMetrics.isAvailable,
+      financialDataAvailable,
     },
     operations: operationsStatus,
     reliability: {

--- a/apps/web/tests/lib/hud/metrics.test.ts
+++ b/apps/web/tests/lib/hud/metrics.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAdminStripeOverviewMetrics } from '@/lib/admin/stripe-metrics';
 import { getHudMetrics } from '@/lib/hud/metrics';
 
 const mockGetHudDeployments = vi.hoisted(() => vi.fn());
@@ -184,5 +185,29 @@ describe('getHudMetrics', () => {
     expect(metrics.aiOps.availability).toBe('partial');
     expect(metrics.aiOps.dispatch.available).toBe(true);
     expect(metrics.aiOps.counts.blocked).toBe(1);
+  });
+
+  it('marks financial data unavailable when Stripe is down', async () => {
+    mockGetHudDeployments.mockResolvedValueOnce({
+      availability: 'not_configured',
+      current: null,
+      recent: [],
+    });
+    vi.mocked(getAdminStripeOverviewMetrics).mockResolvedValueOnce({
+      mrrUsd: 0,
+      activeSubscribers: 0,
+      mrrGrowth30dUsd: 0,
+      isConfigured: true,
+      isAvailable: false,
+    });
+
+    const metrics = await getHudMetrics('admin');
+
+    expect(metrics.overview.financialDataAvailable).toBe(false);
+    expect(metrics.overview.runwayMonths).toBeNull();
+    expect(metrics.overview.defaultStatus).toBe('unknown');
+    expect(metrics.overview.defaultStatusDetail).toContain(
+      'Stripe (unavailable)'
+    );
   });
 });

--- a/apps/web/types/hud.ts
+++ b/apps/web/types/hud.ts
@@ -33,7 +33,7 @@ export interface HudOverviewMetrics {
   runwayMonths: number | null;
   defaultStatus: 'alive' | 'dead' | 'unknown';
   defaultStatusDetail: string;
-  /** True when Mercury data is available; false means financial fields are stubs */
+  /** True when Stripe and Mercury data are available; false means financial fields are partial or stubs */
   financialDataAvailable: boolean;
 }
 


### PR DESCRIPTION
## Summary
- require both Stripe and Mercury availability before HUD runway/default status are considered available
- keep missing-service details visible while returning unknown default status
- add a regression test for Stripe outage handling

## Verification
- pnpm exec biome check apps/web/lib/hud/metrics.ts apps/web/types/hud.ts apps/web/tests/lib/hud/metrics.test.ts
- pnpm --filter @jovie/web exec vitest run tests/lib/hud/metrics.test.ts tests/lib/admin/mercury-metrics.test.ts tests/unit/admin/hud-reliability-mercury.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false

Addresses JOV-2030 post-merge CodeRabbit finding from #8354.