### PR TITLE
ci(desktop-release): build macOS only

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -46,11 +46,10 @@ concurrency:
 jobs:
   build:
     timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    # macOS-only for now. Windows/Linux were removed because we don't ship
+    # those binaries today and building them on every release wastes runner
+    # time. To re-enable, restore the matrix strategy with the desired OSes.
+    runs-on: macos-latest
     env:
       ENVIRONMENT: ${{ github.event.inputs.environment || 'production' }}
       HAS_MAC_SIGNING_CREDENTIALS: ${{ secrets.MAC_CERTIFICATE_BASE64 != '' && secrets.MAC_CERTIFICATE_PASSWORD != '' }}
@@ -76,7 +75,7 @@ jobs:
       # If MAC_CERTIFICATE_BASE64 is absent, this step no-ops and the build
       # continues unsigned (electron-builder will warn, not fail).
       - name: Import Apple Developer cert (macOS)
-        if: matrix.os == 'macos-latest' && env.HAS_MAC_SIGNING_CREDENTIALS == 'true'
+        if: env.HAS_MAC_SIGNING_CREDENTIALS == 'true'
         env:
           MAC_CERTIFICATE_BASE64: ${{ secrets.MAC_CERTIFICATE_BASE64 }}
           MAC_CERTIFICATE_PASSWORD: ${{ secrets.MAC_CERTIFICATE_PASSWORD }}
@@ -131,6 +130,6 @@ jobs:
         run: pnpm --filter @jovie/desktop build:${{ env.ENVIRONMENT }}
 
       - name: Clean up keychain
-        if: always() && matrix.os == 'macos-latest' && env.KEYCHAIN_PATH != ''
+        if: always() && env.KEYCHAIN_PATH != ''
         run: |
           security delete-keychain "$KEYCHAIN_PATH" || true


### PR DESCRIPTION
## Summary
- Drop Windows and Linux from the desktop-release matrix; pin to `macos-latest`
- We don't ship Windows/Linux desktop binaries today, so building them on every release was wasted runner time
- Restore the matrix when we actually need to ship cross-platform

## Context
Follow-up to #8353. Tim explicitly asked to stop building Windows/Linux until we actually need them. Job header now reads `runs-on: macos-latest` instead of a 3-OS matrix; trailing `matrix.os == 'macos-latest'` step conditions are removed since they're now always true.

## Test plan
- [x] `actionlint .github/workflows/desktop-release.yml` passes locally
- [ ] PR CI green (Workflow Lint + actionlint)
- [ ] Next push that touches `VERSION` or this workflow only spawns one `build` job

## Cost Impact
- **External API calls**: none
- **Monthly projection**: negative — drops 2 GitHub Actions runners per release (~5 min Windows + ~1 min Linux)
- **Scaling factor**: O(releases) reduction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated desktop build workflow configuration to streamline macOS-only build execution and signing processes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8403)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->