### PR TITLE
ci(desktop-release): notarize via App Store Connect API key

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -9,8 +9,12 @@ name: desktop-release
 # - Manual workflow_dispatch lets you target staging or re-run production.
 #
 # Signing & notarization:
-# - Requires GH secrets: APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID,
-#   MAC_CERTIFICATE_BASE64, MAC_CERTIFICATE_PASSWORD.
+# - Requires GH secrets: MAC_CERTIFICATE_BASE64, MAC_CERTIFICATE_PASSWORD,
+#   APPLE_TEAM_ID, APPLE_API_KEY (the .p8 contents), APPLE_API_KEY_ID,
+#   APPLE_API_ISSUER.
+# - Notarization uses the modern App Store Connect API key flow (no
+#   app-specific password). The cert still imports into a temp keychain
+#   for codesigning.
 # - When secrets are absent (e.g. a fork PR), the macOS build skips signing
 #   gracefully and produces an unsigned DMG. Auto-update will not work for
 #   unsigned builds; that's by design — they're for sanity checks only.
@@ -53,6 +57,7 @@ jobs:
     env:
       ENVIRONMENT: ${{ github.event.inputs.environment || 'production' }}
       HAS_MAC_SIGNING_CREDENTIALS: ${{ secrets.MAC_CERTIFICATE_BASE64 != '' && secrets.MAC_CERTIFICATE_PASSWORD != '' }}
+      HAS_APPLE_API_CREDENTIALS: ${{ secrets.APPLE_API_KEY != '' && secrets.APPLE_API_KEY_ID != '' && secrets.APPLE_API_ISSUER != '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -113,15 +118,43 @@ jobs:
           rm -f "$CERT_PATH"
           echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
 
+      # Notarization uses App Store Connect API keys instead of an Apple ID +
+      # app-specific password. @electron/notarize (which electron-builder
+      # invokes) reads APPLE_API_KEY as a filesystem path to the .p8 file, so
+      # write the secret contents to a temp file and export the path.
+      # Accepts the secret either as raw PEM (-----BEGIN PRIVATE KEY-----) or
+      # base64-encoded; whichever Tim pasted works.
+      - name: Stage Apple API key (macOS)
+        if: env.HAS_APPLE_API_CREDENTIALS == 'true'
+        env:
+          APPLE_API_KEY_CONTENTS: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          set -euo pipefail
+          KEY_PATH="$RUNNER_TEMP/apple-api-key.p8"
+          if printf '%s' "$APPLE_API_KEY_CONTENTS" | grep -q "BEGIN PRIVATE KEY"; then
+            printf '%s' "$APPLE_API_KEY_CONTENTS" > "$KEY_PATH"
+          else
+            printf '%s' "$APPLE_API_KEY_CONTENTS" | base64 --decode > "$KEY_PATH"
+          fi
+          chmod 600 "$KEY_PATH"
+          # Sanity-check the staged key without leaking contents.
+          head -1 "$KEY_PATH" | grep -q "BEGIN PRIVATE KEY" || {
+            echo "::error::Staged Apple API key is not a valid PEM .p8 file"
+            exit 1
+          }
+          echo "APPLE_API_KEY=$KEY_PATH" >> "$GITHUB_ENV"
+
       - name: Build desktop app
         env:
           ELECTRON_ENV: ${{ env.ENVIRONMENT }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Apple notarization (notarytool). All three required by
-          # electron-builder when notarize: true is set; if any are missing,
-          # electron-builder skips notarization with a warning.
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          # Apple notarization via App Store Connect API key. All three are
+          # required by @electron/notarize when notarize: true is set; if any
+          # are missing, electron-builder skips notarization with a warning.
+          # APPLE_API_KEY is the path written by "Stage Apple API key" above.
+          APPLE_API_KEY: ${{ env.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           # CSC_LINK is the alternative to MAC_CERTIFICATE_BASE64 when not
           # using a pre-imported keychain. Left unset; we use the keychain
@@ -133,3 +166,8 @@ jobs:
         if: always() && env.KEYCHAIN_PATH != ''
         run: |
           security delete-keychain "$KEYCHAIN_PATH" || true
+
+      - name: Clean up Apple API key
+        if: always() && env.APPLE_API_KEY != ''
+        run: |
+          rm -f "$APPLE_API_KEY"

--- a/apps/desktop/SIGNING.md
+++ b/apps/desktop/SIGNING.md
@@ -1,8 +1,10 @@
 # Desktop App Signing & Auto-Update Setup
 
-> One-time setup. Once these 5 GitHub secrets are added, every push to `main`
-> that touches `apps/desktop/**` or `VERSION` will produce a signed, notarized
-> macOS DMG that the existing app can auto-update to.
+> One-time setup. Once these 6 GitHub secrets are added, every push to `main`
+> that bumps `VERSION` (or changes `desktop-release.yml`) will produce a
+> signed, notarized macOS DMG that the existing app can auto-update to.
+> Notarization uses the modern App Store Connect API key flow — no
+> app-specific passwords to rotate.
 
 ## What this fixes
 
@@ -46,18 +48,21 @@ to step 2.
 2. Right-click `Developer ID Application: …` → Export
 3. Save as `jovie-cert.p12`, choose a strong password (you'll need it in step 4)
 
-### 3. Generate an app-specific password for `notarytool`
+### 3. Create an App Store Connect API key for `notarytool`
 
-1. Sign in at <https://appleid.apple.com> with the Apple ID that owns the team
-2. Sign-In and Security → App-Specific Passwords → Generate
-3. Label it `jovie-notarytool` and copy the password (format: `abcd-efgh-ijkl-mnop`)
+1. Sign in at <https://appstoreconnect.apple.com/access/integrations/api>
+2. Click `+` → choose **Developer** access (sufficient for notarization)
+3. Name it `jovie-notarytool` and download the `.p8` file (one-time download —
+   save it; Apple won't show it again)
+4. Note the **Key ID** (10-char string in the row, e.g. `ABC123DEF4`) and the
+   **Issuer ID** (UUID at the top of the Keys page)
 
 ### 4. Get the Team ID
 
 1. Sign in at <https://developer.apple.com/account>
 2. Membership → Team ID is the 10-character string (e.g. `A1B2C3D4E5`)
 
-### 5. Add 5 GitHub secrets
+### 5. Add 6 GitHub secrets
 
 ```bash
 # 1. Base64-encode the .p12 cert
@@ -66,27 +71,30 @@ base64 -i jovie-cert.p12 | gh secret set MAC_CERTIFICATE_BASE64
 # 2. The .p12 export password (from step 2)
 gh secret set MAC_CERTIFICATE_PASSWORD
 
-# 3. Apple ID email (the account that owns the team)
-gh secret set APPLE_ID
-
-# 4. App-specific password from step 3
-gh secret set APPLE_APP_SPECIFIC_PASSWORD
-
-# 5. Team ID from step 4
+# 3. Team ID from step 4
 gh secret set APPLE_TEAM_ID
+
+# 4. The .p8 API key contents from step 3 (paste raw PEM, base64 also accepted)
+gh secret set APPLE_API_KEY < AuthKey_ABC123DEF4.p8
+
+# 5. The Key ID from step 3
+gh secret set APPLE_API_KEY_ID
+
+# 6. The Issuer ID (UUID) from step 3
+gh secret set APPLE_API_ISSUER
 ```
 
 `gh secret set` will prompt for each value. Verify with `gh secret list | grep -E 'MAC_|APPLE_'`.
 
-### 6. Securely dispose of the local `.p12`
+### 6. Securely dispose of the local `.p12` and `.p8`
 
 ```bash
-rm -P jovie-cert.p12  # macOS
+rm -P jovie-cert.p12 AuthKey_*.p8   # macOS
 # Linux alternative:
-shred -u jovie-cert.p12
+shred -u jovie-cert.p12 AuthKey_*.p8
 ```
 
-The cert lives in GH secrets now; don't keep a copy in a downloads folder.
+The cert and API key live in GH secrets now; don't keep copies in a downloads folder.
 
 ## Verifying the setup
 
@@ -133,7 +141,8 @@ auto-update they can apply with one click.
 | Build succeeds but DMG is unsigned | `MAC_CERTIFICATE_BASE64` secret missing or empty | Re-run step 5 |
 | `electron-builder` fails with `code signing identity not found` | `MAC_CERTIFICATE_PASSWORD` is wrong | Re-export `.p12` and re-set the secret |
 | Notarization times out | Apple's notary service is slow; usually 2-15 min | Re-run the workflow; if persistent, check <https://www.apple.com/support/systemstatus/> |
-| `notarytool` fails with `Invalid credentials` | App-specific password expired or `APPLE_ID` wrong | Generate a new app-specific password (step 3) and update the secret |
+| `notarytool` fails with `Invalid credentials` | API key revoked, wrong Key ID, or wrong Issuer ID | Re-create the App Store Connect API key (step 3) and update the three `APPLE_API_*` secrets |
+| `Staged Apple API key is not a valid PEM .p8 file` | `APPLE_API_KEY` secret is corrupt or wasn't the .p8 contents | Re-download the .p8 from App Store Connect and re-set the secret with `gh secret set APPLE_API_KEY < AuthKey_*.p8` |
 | App installs but won't update | First signed install — older unsigned binary can't transition | One-time manual download of the new signed DMG (renderer falls back to download URL automatically) |
 
 ## Related files


### PR DESCRIPTION
## Summary
- Swap notarization auth from Apple ID + app-specific password to the App Store Connect API key flow already configured in repo secrets
- New 'Stage Apple API key' step writes the .p8 secret contents to a temp file (electron-builder reads \`APPLE_API_KEY\` as a path, not contents)
- Cleanup step removes the .p8 regardless of build outcome
- SIGNING.md rewritten for the API key flow (6 secrets total, no app-specific passwords to rotate)

## Context
The signed/notarized pipeline shipped in #8353 was wired for the legacy Apple ID + app-specific password notarization flow, but only the modern API key secrets (\`APPLE_API_KEY\`, \`APPLE_API_KEY_ID\`, \`APPLE_API_ISSUER\`) were configured in the repo. Result: v26.4.226 shipped unsigned. This wires the workflow to use the secrets that actually exist.

The cert (\`MAC_CERTIFICATE_BASE64\` / \`MAC_CERTIFICATE_PASSWORD\`) is still a separate prerequisite — notarization is downstream of code signing — and is currently MISSING from repo secrets. This PR alone won't produce a signed build; Tim still needs to add the cert per the updated SIGNING.md.

## Test plan
- [x] \`actionlint .github/workflows/desktop-release.yml\` passes
- [ ] PR CI green (Workflow Lint + actionlint)
- [ ] After merge + cert secrets added, manual \`gh workflow run desktop-release.yml -f environment=staging\` produces a signed + notarized DMG
- [ ] Verify on the staging artifact: \`codesign -dv --verbose=4 Jovie.app\` shows \`Notarized Developer ID\`

## Cost Impact
- **External API calls**: none added — same notarytool calls, different auth
- **Monthly projection**: zero — auth method is a side-step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated macOS desktop release infrastructure to use API key-based authentication for app notarization instead of password-based authentication
  * Updated release workflow configuration and signing documentation to reflect the new authentication approach

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8404)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->