### PR TITLE
feat(desktop): compact update pill — icon when sidebar open, full pill when closed

### DIFF
--- a/apps/web/components/atoms/DesktopTitlebar.tsx
+++ b/apps/web/components/atoms/DesktopTitlebar.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { ArrowLeft, ArrowRight } from 'lucide-react';
+import { useContext } from 'react';
 import { UpdateAvailablePill } from '@/components/atoms/UpdateAvailablePill';
+import { SidebarContext } from '@/components/organisms/sidebar/context';
 import {
   useDesktopNavigation,
   useIsElectronRuntime,
@@ -25,6 +27,9 @@ import { cn } from '@/lib/utils';
 export function DesktopTitlebar() {
   const isDesktop = useIsElectronRuntime();
   const { canGoBack, canGoForward, goBack, goForward } = useDesktopNavigation();
+  // useContext (not useSidebar) so this is safe outside SidebarProvider (e.g. demo shell)
+  const sidebarCtx = useContext(SidebarContext);
+  const sidebarOpen = sidebarCtx?.state === 'open';
 
   return (
     <div
@@ -80,12 +85,12 @@ export function DesktopTitlebar() {
             style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
           />
 
-          {/* Update pill — no-drag so clicks register */}
+          {/* Update pill — compact when sidebar is open, full pill when sidebar is closed */}
           <div
             className='flex items-center pr-3'
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
           >
-            <UpdateAvailablePill />
+            <UpdateAvailablePill compact={sidebarOpen} />
           </div>
         </>
       ) : null}

--- a/apps/web/components/atoms/UpdateAvailablePill.tsx
+++ b/apps/web/components/atoms/UpdateAvailablePill.tsx
@@ -1,24 +1,23 @@
 'use client';
 
-import { Loader2 } from 'lucide-react';
+import { Download, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { useDesktopUpdate } from '@/lib/desktop/electron-bridge';
+import { cn } from '@/lib/utils';
 import { useWebUpdate } from '@/lib/version/use-web-update';
 
-/**
- * UpdateAvailablePill — Codex titlebar-style update indicator.
- *
- * Renders only when an update is detected from either:
- *   - Electron auto-updater IPC (desktop)
- *   - /api/version build-hash drift (web)
- *
- * Visual spec (locked):
- *   - bg-white hover:bg-white/90 text-black (matches ActionPill canonical style)
- *   - text-[12px] font-medium rounded-full px-3 h-7
- *   - WebkitAppRegion: no-drag (so click works inside Electron titlebar)
- *   - Click: shows "Updating…" spinner, then triggers install/reload
- */
-export function UpdateAvailablePill() {
+interface UpdateAvailablePillProps {
+  /**
+   * Compact mode — collapses to an icon-only circle.
+   * Used in the Electron titlebar when the sidebar is open to conserve space.
+   * Transitions smoothly to the full text pill when false.
+   */
+  readonly compact?: boolean;
+}
+
+export function UpdateAvailablePill({
+  compact = false,
+}: UpdateAvailablePillProps) {
   const desktop = useDesktopUpdate();
   const web = useWebUpdate();
   const [updating, setUpdating] = useState(false);
@@ -46,18 +45,31 @@ export function UpdateAvailablePill() {
       onClick={handleClick}
       disabled={updating}
       aria-label='Update available — click to install'
-      // WebkitAppRegion no-drag so clicks register inside Electron's frameless titlebar
       style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-      className='inline-flex h-7 items-center gap-1.5 rounded-full bg-white px-3 text-[12px] font-medium text-black transition-colors duration-subtle hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-1 disabled:opacity-70'
+      className={cn(
+        'inline-flex h-7 min-w-[28px] items-center justify-center rounded-full bg-white text-black',
+        'overflow-hidden transition-[max-width,padding,gap] duration-subtle',
+        'hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-1 disabled:opacity-70',
+        compact ? 'max-w-[28px] gap-0 px-0' : 'max-w-[100px] gap-1.5 px-3'
+      )}
     >
       {updating ? (
-        <>
-          <Loader2 className='h-3 w-3 animate-spin' aria-hidden='true' />
-          <span>Updating…</span>
-        </>
+        <Loader2
+          className='h-3.5 w-3.5 shrink-0 animate-spin'
+          aria-hidden='true'
+        />
       ) : (
-        <span>Update</span>
+        <Download className='h-3.5 w-3.5 shrink-0' aria-hidden='true' />
       )}
+      <span
+        className={cn(
+          'whitespace-nowrap text-[12px] font-medium',
+          'transition-opacity duration-subtle',
+          compact ? 'opacity-0' : 'opacity-100'
+        )}
+      >
+        {updating ? 'Updating…' : 'Update'}
+      </span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary

- `UpdateAvailablePill` gains a `compact` prop — collapses to a white circle with a `Download` icon when true, expands to the full text pill when false
- `DesktopTitlebar` reads `SidebarContext` via `useContext` (not `useSidebar`, so it's safe outside `SidebarProvider`) and passes `compact={sidebarOpen}` to the pill
- Sidebar open → compact circle (icon only); sidebar closed → full "Update" pill with text
- Transition: `transition-[max-width,padding,gap] duration-subtle` on the button + `transition-opacity duration-subtle` on the text span — smooth crossfade between states
- Mirrors the Codex titlebar UX pattern

## Test plan

- [ ] Electron app with update available: sidebar open → compact white circle with download icon
- [ ] Toggle sidebar closed → pill expands to "Update" text + icon with smooth animation
- [ ] Toggle sidebar open again → collapses back to circle smoothly
- [ ] Browser (no Electron): `UpdateAvailablePill` in header still works, always full (no compact)
- [ ] TypeCheck: 0 errors ✅
- [ ] Biome: clean ✅
- [ ] ESLint: 0 warnings ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The update notification pill now intelligently adapts its display based on sidebar visibility. When the sidebar is open, it appears in a compact, icon-only format to maximize available space. When the sidebar is closed, it displays in full-sized format with complete information visible, providing a more flexible user experience across different layouts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8420)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->