### PR TITLE
fix(typecheck): bump tsconfig lib from es2022 to esnext (JOV-2048)

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "ignoreDeprecations": "6.0",
     "target": "es2022",
-    "lib": ["dom", "dom.iterable", "es2022"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
## Summary

- `lib: es2022` in `tsconfig.json` does not include ES2023+ array method types, causing `TS2550` errors for `Array.prototype.toReversed()` and `Array.prototype.findLast()`
- Bumps `lib` to `esnext` so those types are available to the type checker and future ES2023+ API usage won't require workarounds

## Context

The immediate call-sites were already patched to use `[...arr].reverse()` and `[...arr].reverse().find()` in PR #8385, but the root cause (stale `lib` target) was left in place. This PR fixes the underlying tsconfig.

## Test plan

- [x] `pnpm exec tsc -p tsconfig.typecheck.json --noEmit` exits 0

Closes JOV-2048

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to target the latest JavaScript features.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8421)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->