### PR TITLE
feat(shortcuts): unify player + global shortcut registries (JOV-2110)

### DIFF
--- a/apps/web/components/organisms/keyboard-shortcuts-sheet/KeyboardShortcutsSheet.tsx
+++ b/apps/web/components/organisms/keyboard-shortcuts-sheet/KeyboardShortcutsSheet.tsx
@@ -129,6 +129,7 @@ export function KeyboardShortcutsSheet() {
       general: [],
       navigation: [],
       actions: [],
+      player: [],
     };
 
     for (const shortcut of filteredShortcuts) {

--- a/apps/web/lib/keyboard-shortcuts.test.ts
+++ b/apps/web/lib/keyboard-shortcuts.test.ts
@@ -28,6 +28,7 @@ describe('keyboard-shortcuts definitions', () => {
       'general',
       'navigation',
       'actions',
+      'player',
     ];
     for (const shortcut of KEYBOARD_SHORTCUTS) {
       expect(validCategories).toContain(shortcut.category);
@@ -38,6 +39,22 @@ describe('keyboard-shortcuts definitions', () => {
     expect(SHORTCUT_CATEGORY_LABELS.general).toBe('General');
     expect(SHORTCUT_CATEGORY_LABELS.navigation).toBe('Navigation');
     expect(SHORTCUT_CATEGORY_LABELS.actions).toBe('Actions');
+    expect(SHORTCUT_CATEGORY_LABELS.player).toBe('Player');
+  });
+
+  it('every shortcut declares a decision', () => {
+    const valid = ['required', 'deferred', 'none'];
+    for (const s of KEYBOARD_SHORTCUTS) {
+      expect(valid, `${s.id} missing decision`).toContain(s.decision.status);
+    }
+  });
+
+  it('every required shortcut has a non-empty binding', () => {
+    for (const s of KEYBOARD_SHORTCUTS) {
+      if (s.decision.status === 'required') {
+        expect(s.decision.binding, `${s.id} must have a binding`).toBeTruthy();
+      }
+    }
   });
 
   describe('sequential shortcuts', () => {
@@ -184,25 +201,28 @@ describe('keyboard-shortcuts definitions', () => {
   });
 
   describe('chord conflict detection (JOV-1827)', () => {
-    it('has no duplicate `shortcutKey` chord (canonicalized)', () => {
-      // Canonicalize so semantically identical chords with different
-      // casing/modifier order can't slip through (e.g. "Alt+Shift+Q" vs
-      // "Shift+Alt+q").
-      const normalizeChord = (chord: string) => {
-        const parts = chord
-          .split('+')
-          .map(p => p.trim())
-          .filter(Boolean);
-        const key = (parts.pop() ?? '').toLowerCase();
-        const modifiers = parts
-          .map(m => `${m[0]?.toUpperCase() ?? ''}${m.slice(1).toLowerCase()}`)
-          .sort();
-        return [...modifiers, key].join('+');
-      };
-      const chords = KEYBOARD_SHORTCUTS.filter(s => s.shortcutKey).map(s =>
-        normalizeChord(s.shortcutKey!)
-      );
-      expect(new Set(chords).size).toBe(chords.length);
+    // Canonicalize so semantically identical chords with different
+    // casing/modifier order can't slip through (e.g. "Alt+Shift+Q" vs
+    // "Shift+Alt+q").
+    const normalizeChord = (chord: string) => {
+      const parts = chord
+        .split('+')
+        .map(p => p.trim())
+        .filter(Boolean);
+      const key = (parts.pop() ?? '').toLowerCase();
+      const modifiers = parts
+        .map(m => `${m[0]?.toUpperCase() ?? ''}${m.slice(1).toLowerCase()}`)
+        .sort();
+      return [...modifiers, key].join('+');
+    };
+
+    it('has no duplicate shortcutKey chord among global-scoped shortcuts (canonicalized)', () => {
+      // Player- and overlay-scoped shortcuts can share chords with global shortcuts
+      // because they only fire in their respective contexts.
+      const globalChords = KEYBOARD_SHORTCUTS.filter(
+        s => s.shortcutKey && s.scope !== 'player' && s.scope !== 'overlay'
+      ).map(s => normalizeChord(s.shortcutKey!));
+      expect(new Set(globalChords).size).toBe(globalChords.length);
     });
 
     it('does not advertise bare single-letter chords for action shortcuts', () => {
@@ -213,10 +233,14 @@ describe('keyboard-shortcuts definitions', () => {
       }
     });
 
-    it('sequential first keys do not collide with single-key chords', () => {
-      const chords = new Set(
+    it('sequential first keys do not collide with global single-key chords', () => {
+      const globalSingleKeyChords = new Set(
         KEYBOARD_SHORTCUTS.filter(
-          s => s.shortcutKey && !s.shortcutKey.includes('+')
+          s =>
+            s.shortcutKey &&
+            !s.shortcutKey.includes('+') &&
+            s.scope !== 'player' &&
+            s.scope !== 'overlay'
         ).map(s => s.shortcutKey!.toLowerCase())
       );
       const sequentialFirsts = new Set(
@@ -225,30 +249,31 @@ describe('keyboard-shortcuts definitions', () => {
         )
       );
       for (const f of sequentialFirsts) {
-        expect(chords.has(f)).toBe(false);
+        expect(globalSingleKeyChords.has(f)).toBe(false);
       }
     });
 
-    it('every overlay shortcut has a known wiring location', () => {
-      // Document handler ownership in code so removals fail this test.
-      const HANDLED: Record<string, string> = {
-        'command-menu': 'CommandPalette.tsx',
-        'keyboard-shortcuts': 'useSequentialShortcuts',
-        'toggle-sidebar': 'useSidebarKeyboardShortcut',
-        'toggle-theme': 'useGlobalShortcutActions',
-        'sign-out': 'useGlobalShortcutActions',
-        'nav-dashboard': 'useSequentialShortcuts',
-        'nav-profile': 'useSequentialShortcuts',
-        'nav-contacts': 'useSequentialShortcuts',
-        'nav-releases': 'useSequentialShortcuts',
-        'nav-tour-dates': 'useSequentialShortcuts',
-        'nav-audience': 'useSequentialShortcuts',
-        'nav-earnings': 'useSequentialShortcuts',
-        'nav-chat': 'useSequentialShortcuts',
-        'nav-settings': 'useSequentialShortcuts',
-      };
+    it('every required shortcut has a known handler (decision.binding)', () => {
+      // The decision field replaces the old HANDLED map. This test ensures
+      // the binding field is populated for every wired shortcut so removals
+      // without updating the registry are caught.
       for (const s of KEYBOARD_SHORTCUTS) {
-        expect(HANDLED[s.id]).toBeTruthy();
+        if (s.decision.status === 'required') {
+          expect(
+            s.decision.binding,
+            `${s.id} has status "required" but binding is empty`
+          ).toBeTruthy();
+        }
+      }
+    });
+  });
+
+  describe('shortcuts.ts shim', () => {
+    it('shim resolves all SHORTCUTS keys without throwing', async () => {
+      const { SHORTCUTS } = await import('./shortcuts');
+      for (const [key, hint] of Object.entries(SHORTCUTS)) {
+        expect(hint.keys, `${key} should have keys`).toBeTruthy();
+        expect(hint.description, `${key} should have description`).toBeTruthy();
       }
     });
   });

--- a/apps/web/lib/keyboard-shortcuts.ts
+++ b/apps/web/lib/keyboard-shortcuts.ts
@@ -1,19 +1,28 @@
 import type { LucideIcon } from 'lucide-react';
 import {
+  AudioLines,
   Banknote,
   CalendarDays,
+  ChevronRight,
+  Columns2,
   Command,
   Home,
   IdCard,
   Keyboard,
   LogOut,
   MessageCircle,
+  Mic2,
   Music,
   PanelLeft,
+  Play,
+  Radio,
+  Search,
   Settings,
   Sun,
+  Type,
   UserCircle,
   Users,
+  X,
 } from 'lucide-react';
 import { APP_ROUTES } from '@/constants/routes';
 // Unicode glyphs via String.fromCodePoint so they survive encoding-unaware
@@ -22,6 +31,25 @@ export const GLYPH_CMD = String.fromCodePoint(0x2318);
 export const GLYPH_OPT = String.fromCodePoint(0x2325);
 export const GLYPH_SHIFT = String.fromCodePoint(0x21e7);
 export const GLYPH_ARROW_RIGHT = String.fromCodePoint(0x2192);
+
+/**
+ * Shipping gate — every shortcut must declare its status before merge.
+ * `required` means the shortcut is wired and tested; `binding` names the handler.
+ * `deferred` means intentionally not wired globally yet (e.g. desktop-only, needs conflict testing).
+ * `none` means no shortcut was the deliberate product decision.
+ */
+export type ShortcutDecision =
+  | { status: 'required'; binding: string }
+  | { status: 'deferred'; reason: string }
+  | { status: 'none'; reason: string };
+
+/**
+ * Where the shortcut fires.
+ * `global` = fires from anywhere in the shell.
+ * `player` = fires only when the audio player surface owns focus.
+ * `overlay` = fires only when a modal/overlay is active.
+ */
+export type ShortcutScope = 'global' | 'player' | 'overlay';
 
 /**
  * Keyboard shortcut definition
@@ -49,9 +77,13 @@ export interface KeyboardShortcut {
   secondKey?: string;
   /** Single key with modifiers (e.g., 'Meta+/') for non-sequential shortcuts */
   shortcutKey?: string;
+  /** Shipping gate: every shortcut must declare required | deferred | none */
+  decision: ShortcutDecision;
+  /** Where this shortcut fires; omit for 'global' (the default) */
+  scope?: ShortcutScope;
 }
 
-export type ShortcutCategory = 'general' | 'navigation' | 'actions';
+export type ShortcutCategory = 'general' | 'navigation' | 'actions' | 'player';
 
 /**
  * All keyboard shortcuts organized by category
@@ -65,6 +97,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     category: 'general',
     icon: Command,
     shortcutKey: 'Meta+k',
+    decision: { status: 'required', binding: 'CommandPalette.tsx' },
   },
   {
     id: 'keyboard-shortcuts',
@@ -73,6 +106,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     category: 'general',
     icon: Keyboard,
     shortcutKey: 'Meta+/',
+    decision: { status: 'required', binding: 'useSequentialShortcuts' },
   },
   {
     id: 'toggle-sidebar',
@@ -81,6 +115,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     category: 'general',
     icon: PanelLeft,
     shortcutKey: 'Meta+b',
+    decision: { status: 'required', binding: 'useSidebarKeyboardShortcut' },
   },
 
   // Navigation shortcuts (G then letter)
@@ -94,6 +129,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     isSequential: true,
     firstKey: 'g',
     secondKey: 'd',
+    decision: { status: 'required', binding: 'useSequentialShortcuts' },
   },
   {
     id: 'nav-profile',
@@ -105,6 +141,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     isSequential: true,
     firstKey: 'g',
     secondKey: 'p',
+    decision: { status: 'required', binding: 'useSequentialShortcuts' },
   },
   {
     id: 'nav-contacts',
@@ -116,6 +153,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     isSequential: true,
     firstKey: 'g',
     secondKey: 'c',
+    decision: { status: 'required', binding: 'useSequentialShortcuts' },
   },
   {
     id: 'nav-releases',
@@ -127,6 +165,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     isSequential: true,
     firstKey: 'g',
     secondKey: 'r',
+    decision: { status: 'required', binding: 'useSequentialShortcuts' },
   },
   {
     id: 'nav-tour-dates',
@@ -138,6 +177,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     isSequential: true,
     firstKey: 'g',
     secondKey: 'o',
+    decision: { status: 'required', binding: 'useSequentialShortcuts' },
   },
   {
     id: 'nav-audience',
@@ -149,6 +189,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     isSequential: true,
     firstKey: 'g',
     secondKey: 'a',
+    decision: { status: 'required', binding: 'useSequentialShortcuts' },
   },
   {
     id: 'nav-earnings',
@@ -160,6 +201,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     isSequential: true,
     firstKey: 'g',
     secondKey: 'e',
+    decision: { status: 'required', binding: 'useSequentialShortcuts' },
   },
   {
     id: 'nav-chat',
@@ -171,6 +213,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     isSequential: true,
     firstKey: 'g',
     secondKey: 't',
+    decision: { status: 'required', binding: 'useSequentialShortcuts' },
   },
   {
     id: 'nav-settings',
@@ -182,6 +225,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     isSequential: true,
     firstKey: 'g',
     secondKey: 's',
+    decision: { status: 'required', binding: 'useSequentialShortcuts' },
   },
 
   // Action shortcuts
@@ -192,6 +236,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     category: 'actions',
     icon: Sun,
     shortcutKey: 'Alt+t',
+    decision: { status: 'required', binding: 'useGlobalShortcutActions' },
   },
   {
     id: 'sign-out',
@@ -200,6 +245,106 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     category: 'actions',
     icon: LogOut,
     shortcutKey: 'Alt+Shift+Q',
+    decision: { status: 'required', binding: 'useGlobalShortcutActions' },
+  },
+
+  // Player shortcuts — scope: 'player' means only fires when audio player has focus.
+  // Bare single-key shortcuts here are intentional and safe in that scoped context.
+  {
+    id: 'player-play-pause',
+    label: 'Play / Pause',
+    keys: 'Space',
+    category: 'player',
+    icon: Play,
+    scope: 'player',
+    decision: { status: 'required', binding: 'AudioBar' },
+  },
+  {
+    id: 'player-toggle-waveform',
+    label: 'Toggle waveform',
+    keys: 'W',
+    category: 'player',
+    icon: AudioLines,
+    scope: 'player',
+    decision: { status: 'required', binding: 'AudioBar' },
+  },
+  {
+    id: 'player-toggle-lyrics',
+    label: 'Toggle lyrics',
+    keys: 'L',
+    category: 'player',
+    icon: Type,
+    scope: 'player',
+    decision: { status: 'required', binding: 'AudioBar' },
+  },
+  {
+    id: 'player-toggle-bar',
+    label: 'Toggle audio bar',
+    keys: '`',
+    category: 'player',
+    icon: Radio,
+    shortcutKey: '`',
+    scope: 'global',
+    decision: { status: 'required', binding: 'AudioBar' },
+  },
+  {
+    id: 'player-toggle-bar-alt',
+    label: 'Toggle audio bar (alt)',
+    keys: `${GLYPH_CMD} \\`,
+    category: 'player',
+    icon: Radio,
+    shortcutKey: 'Meta+\\',
+    scope: 'global',
+    decision: { status: 'required', binding: 'AudioBar' },
+  },
+  {
+    id: 'player-search-slash',
+    label: 'Search (player)',
+    keys: '/',
+    category: 'player',
+    icon: Search,
+    scope: 'player',
+    decision: { status: 'required', binding: 'AudioBar' },
+  },
+  {
+    id: 'player-toggle-sidebar',
+    label: 'Toggle sidebar dock',
+    keys: '[',
+    category: 'player',
+    icon: Columns2,
+    scope: 'player',
+    decision: { status: 'required', binding: 'AudioBar' },
+  },
+  {
+    id: 'player-toggle-sidebar-tab',
+    label: 'Cycle sidebar tab',
+    keys: 'Tab',
+    category: 'player',
+    icon: ChevronRight,
+    scope: 'player',
+    decision: { status: 'required', binding: 'AudioBar' },
+  },
+  {
+    id: 'player-dictate',
+    label: 'Push-to-talk to Jovie',
+    keys: `Hold ${GLYPH_CMD} J`,
+    category: 'player',
+    icon: Mic2,
+    scope: 'global',
+    decision: {
+      status: 'deferred',
+      reason:
+        'Desktop-first; browser conflict testing pending before global default',
+    },
+  },
+  {
+    id: 'player-close-overlay',
+    label: 'Close overlay',
+    keys: 'Esc',
+    category: 'player',
+    icon: X,
+    scope: 'overlay',
+    decision: { status: 'required', binding: 'ContextMenuOverlay' },
   },
 ];
 
@@ -225,4 +370,5 @@ export const SHORTCUT_CATEGORY_LABELS: Record<ShortcutCategory, string> = {
   general: 'General',
   navigation: 'Navigation',
   actions: 'Actions',
+  player: 'Player',
 };

--- a/apps/web/lib/shortcuts.ts
+++ b/apps/web/lib/shortcuts.ts
@@ -1,24 +1,31 @@
-// Central registry of keyboard shortcuts surfaced via Tooltip's kbd chip.
-// Symbols: `⌘K`, `⌥/`, `Hold ⌘J`, `[`, `Esc`. Use `⌘` not `Cmd`, `⌥`
-// not `Alt`, for visual density.
+// Backward-compat shim. All shortcut data now lives in keyboard-shortcuts.ts.
+// Do not add new entries here. Migrate callers to import from keyboard-shortcuts.ts directly.
+
+import { KEYBOARD_SHORTCUTS } from './keyboard-shortcuts';
 
 export interface ShortcutHint {
   readonly keys: string;
   readonly description: string;
 }
 
+function makeHint(id: string): ShortcutHint {
+  const s = KEYBOARD_SHORTCUTS.find(x => x.id === id);
+  if (!s) throw new Error(`[shortcuts] Unknown shortcut id: ${id}`);
+  return { keys: s.keys, description: s.description ?? s.label };
+}
+
 export const SHORTCUTS = {
-  search: { keys: '⌘K', description: 'Open search / filter bar' },
-  searchSlash: { keys: '/', description: 'Open search (no modifier)' },
-  toggleSidebar: { keys: '[', description: 'Toggle sidebar dock / float' },
-  toggleSidebarTab: { keys: 'Tab', description: 'Toggle sidebar dock / float' },
-  toggleBar: { keys: '`', description: 'Toggle audio bar in / out' },
-  toggleBarAlt: { keys: '⌘\\', description: 'Toggle audio bar (alt)' },
-  toggleWaveform: { keys: 'W', description: 'Toggle waveform drawer' },
-  toggleLyrics: { keys: 'L', description: 'Open / close the lyrics view' },
-  playPause: { keys: 'Space', description: 'Play / pause current track' },
-  jovieDictate: { keys: 'Hold ⌘J', description: 'Push-to-talk to Jovie' },
-  closeOverlay: { keys: 'Esc', description: 'Close overlay / clear input' },
+  search: makeHint('command-menu'),
+  searchSlash: makeHint('player-search-slash'),
+  toggleSidebar: makeHint('player-toggle-sidebar'),
+  toggleSidebarTab: makeHint('player-toggle-sidebar-tab'),
+  toggleBar: makeHint('player-toggle-bar'),
+  toggleBarAlt: makeHint('player-toggle-bar-alt'),
+  toggleWaveform: makeHint('player-toggle-waveform'),
+  toggleLyrics: makeHint('player-toggle-lyrics'),
+  playPause: makeHint('player-play-pause'),
+  jovieDictate: makeHint('player-dictate'),
+  closeOverlay: makeHint('player-close-overlay'),
 } as const satisfies Record<string, ShortcutHint>;
 
 export type ShortcutKey = keyof typeof SHORTCUTS;


### PR DESCRIPTION
## Summary

- **Unified two diverging shortcut registries** into a single source of truth in `keyboard-shortcuts.ts`
- **Mandatory `decision` shipping gate**: every shortcut now declares `required(binding) | deferred(reason) | none(reason)` — missing field is a TypeScript build failure
- **Backward-compat shim**: `shortcuts.ts` replaced with a thin wrapper via `makeHint(id)`, all callers unchanged

## What changed

| File | Change |
|------|--------|
| `apps/web/lib/keyboard-shortcuts.ts` | Added `ShortcutDecision` + `ShortcutScope` types; added `decision` (required) + `scope` (optional) to `KeyboardShortcut`; annotated 14 existing shortcuts; added 10 player shortcuts |
| `apps/web/lib/shortcuts.ts` | Replaced body with backward-compat shim reading from unified registry |
| `apps/web/lib/keyboard-shortcuts.test.ts` | Added player category, scope-aware chord conflict checks, decision-status tests, shim resolution test |
| `apps/web/components/organisms/keyboard-shortcuts-sheet/KeyboardShortcutsSheet.tsx` | Added `player: []` to fix TypeScript exhaustiveness error on `ShortcutCategory` record |

## New shortcuts registered (Phase 1)

Player shortcuts now visible in the help sheet (scope-tagged so Phase 2 can filter by surface):

| ID | Keys | Scope |
|----|------|-------|
| `player-play-pause` | Space | player |
| `player-toggle-waveform` | W | player |
| `player-toggle-lyrics` | L | player |
| `player-toggle-bar` | `` ` `` | global |
| `player-toggle-bar-alt` | ⌘\ | global |
| `player-search-slash` | / | player |
| `player-toggle-sidebar` | [ | player |
| `player-toggle-sidebar-tab` | Tab | player |
| `player-dictate` | Hold ⌘J | global (deferred — desktop-only pending conflict test) |
| `player-close-overlay` | Esc | overlay |

## Test results

```
Test Files  2 passed (2)
     Tests  28 passed (28)
```

## What this does NOT change (Phases 2 & 3)

- `KeyboardShortcutsSheet` still renders all shortcuts without scope/surface filtering — Phase 2 adds a `surfaces` field and filters the overlay to `surfaces.includes('helper')`
- `TooltipShortcut` still takes literal strings — Phase 2 adds `actionId` prop
- Electron `main.ts` still hard-codes accelerators — Phase 3 generates from registry

<!-- linear-issue-id:JOV-2110 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "player" keyboard shortcut category to organize player-scoped control bindings
  * Implemented decision tracking for keyboard shortcuts to manage feature availability and rollout status

* **Tests**
  * Strengthened keyboard shortcut validation with improved category and decision field checks
  * Enhanced conflict detection for keyboard chord assignments across different scopes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8478)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->