### PR TITLE
fix(drawer): flatten release/track entity header card nesting (JOV-1824)

### DIFF
--- a/apps/web/components/molecules/drawer/EntitySidebarShell.tsx
+++ b/apps/web/components/molecules/drawer/EntitySidebarShell.tsx
@@ -41,6 +41,13 @@ export interface EntitySidebarShellProps {
    * elements (e.g., entity card + analytics) — they stack with space-y-2.
    */
   readonly entityHeader?: ReactNode;
+  /**
+   * Controls whether the minimal-mode entity header is wrapped in a card surface.
+   * Defaults to `card` to preserve legacy visuals. Pass `flat` when the caller
+   * already provides its own card chrome to avoid nested card-on-card stacking.
+   * Only applies when `headerMode='minimal'`.
+   */
+  readonly entityHeaderSurface?: 'card' | 'flat';
   /** When true, header actions render inside the entity header card instead of the title bar */
   readonly actionsInEntityHeader?: boolean;
   /** Tabs slot — SegmentControl rendered below entity header in standard mode */
@@ -104,6 +111,7 @@ export function EntitySidebarShell({
   headerMode = 'standard',
   hideMinimalHeaderBar = false,
   entityHeader,
+  entityHeaderSurface = 'card',
   actionsInEntityHeader = false,
   tabs,
   minimalTabsPlacement = 'card',
@@ -137,16 +145,27 @@ export function EntitySidebarShell({
   const titleBarActions = actionsInEntityHeader
     ? closeAction
     : (headerActions ?? closeAction);
-  const minimalEntityHeaderContent =
-    isMinimalHeader && !isEmpty && entityHeader ? (
-      <DrawerSurfaceCard
-        testId='entity-sidebar-entity-header'
-        variant='card'
-        className='overflow-hidden lg:mx-0 lg:mt-0'
-      >
-        {entityHeader}
-      </DrawerSurfaceCard>
-    ) : null;
+  let minimalEntityHeaderContent: ReactNode = null;
+  if (isMinimalHeader && !isEmpty && entityHeader) {
+    minimalEntityHeaderContent =
+      entityHeaderSurface === 'card' ? (
+        <DrawerSurfaceCard
+          testId='entity-sidebar-entity-header'
+          variant='card'
+          className='overflow-hidden lg:mx-0 lg:mt-0'
+        >
+          {entityHeader}
+        </DrawerSurfaceCard>
+      ) : (
+        <div
+          data-testid='entity-sidebar-entity-header'
+          data-surface-variant='flat'
+          className='lg:mx-0 lg:mt-0'
+        >
+          {entityHeader}
+        </div>
+      );
+  }
   let footerNode: ReactNode = null;
   if (footer) {
     footerNode =

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -1030,6 +1030,7 @@ export function ReleaseSidebar({
       data-testid='release-sidebar'
       headerMode='minimal'
       hideMinimalHeaderBar
+      entityHeaderSurface='flat'
       entityHeader={
         release ? (
           <ReleaseEntityHeader

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -309,6 +309,7 @@ export function TrackSidebar({
       hideMinimalHeaderBar={Boolean(track)}
       isEmpty={!track}
       emptyMessage='Select a track to view its details.'
+      entityHeaderSurface='flat'
       entityHeader={
         track ? (
           <div className='space-y-2.5'>
@@ -420,7 +421,7 @@ export function TrackSidebar({
                       onClick={handleTogglePlayback}
                       aria-label={isPlaying ? 'Pause preview' : 'Play preview'}
                       aria-pressed={isPlaying}
-                      className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token transition-[background-color,color,border-color] duration-150 hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+                      className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token transition-[background-color,color,border-color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
                     >
                       {isPlaying ? (
                         <Pause className='h-4 w-4' />

--- a/apps/web/tests/unit/components/molecules/EntitySidebarShell.test.tsx
+++ b/apps/web/tests/unit/components/molecules/EntitySidebarShell.test.tsx
@@ -69,6 +69,44 @@ describe('EntitySidebarShell', () => {
     expect(screen.getByText('Drawer tabs')).toBeInTheDocument();
   });
 
+  it('wraps the minimal-mode entity header in a card surface by default', () => {
+    render(
+      <EntitySidebarShell
+        isOpen
+        ariaLabel='Release details'
+        headerMode='minimal'
+        hideMinimalHeaderBar
+        entityHeader={<div>Entity header content</div>}
+      >
+        <div>Body content</div>
+      </EntitySidebarShell>
+    );
+
+    const headerSurface = screen.getByTestId('entity-sidebar-entity-header');
+    expect(headerSurface).toHaveAttribute('data-surface-variant', 'card');
+    expect(headerSurface).toHaveAttribute('data-variant', 'card');
+  });
+
+  it('renders the minimal-mode entity header without an outer card surface when entityHeaderSurface is flat', () => {
+    render(
+      <EntitySidebarShell
+        isOpen
+        ariaLabel='Release details'
+        headerMode='minimal'
+        hideMinimalHeaderBar
+        entityHeaderSurface='flat'
+        entityHeader={<div>Entity header content</div>}
+      >
+        <div>Body content</div>
+      </EntitySidebarShell>
+    );
+
+    const headerSurface = screen.getByTestId('entity-sidebar-entity-header');
+    expect(headerSurface).toHaveAttribute('data-surface-variant', 'flat');
+    expect(headerSurface).not.toHaveAttribute('data-variant', 'card');
+    expect(headerSurface).toHaveTextContent('Entity header content');
+  });
+
   it('can promote minimal-mode tabs into the full-width sticky header and hide the empty utility bar', () => {
     render(
       <EntitySidebarShell


### PR DESCRIPTION
## Summary
- Add `entityHeaderSurface?: 'card' | 'flat'` to `EntitySidebarShell`. Defaults to `'card'` so legacy callers keep their existing visual.
- `ReleaseSidebar` and `TrackSidebar` already wrap their entity header in a `DrawerSurfaceCard variant='card'`. With the shell defaulting to a card too, this was rendering card-on-card in the minimal-mode right rail. Both callers now pass `entityHeaderSurface='flat'` so a single visible surface remains.
- Small bystander cleanup: `TrackSidebar` play-button used `duration-150` (raw motion class). Switched to `duration-subtle` to satisfy `@jovie/no-raw-motion-values` once the file was staged.

## Linear
JOV-1824

<!-- linear-issue-id:jov-1824 -->

## Verification
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write apps/web/components/molecules/drawer/EntitySidebarShell.tsx apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx apps/web/components/organisms/release-sidebar/TrackSidebar.tsx apps/web/tests/unit/components/molecules/EntitySidebarShell.test.tsx`
- `doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web exec vitest run tests/unit/components/molecules/EntitySidebarShell.test.tsx tests/components/organisms/release-sidebar/TrackSidebar.test.tsx tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx tests/components/molecules/drawer/EntitySidebarShell.test.tsx` — 31/31 pass
- Pre-commit pipeline: eslint + biome + turbo typecheck all green

## Test plan
- [ ] Visual QA release drawer @ 1280×900 and 390×844 — confirm one card surface for the entity header, no nested chrome
- [ ] Visual QA track drawer @ 1280×900 and 390×844 — confirm back button sits outside the card, header card is the only surface
- [ ] Confirm sibling drawers (Contact, Profile, Audience, Tour, AddRelease, Admin) are visually unchanged (default `'card'` preserved)

## Risk
Low. New behavior is opt-in via prop; default preserves legacy visuals. Targeted unit test added for both `'card'` and `'flat'` variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Entity headers in sidebars now support both card and flat surface styling options.

* **Improvements**
  * Updated release and track sidebars to use flat header styling for improved visual consistency.
  * Refined transition animation timing for playback control buttons.

* **Tests**
  * Added unit tests for entity header surface styling variants.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8507)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->