### PR TITLE
fix(design-system): canonical white pill CTA + remove decorative hover motion (JOV-1830)

### DIFF
--- a/apps/web/app/(marketing)/blog/components/BlogCard.tsx
+++ b/apps/web/app/(marketing)/blog/components/BlogCard.tsx
@@ -22,7 +22,7 @@ function formatDate(dateString: string): string {
 export function BlogCard({ post, author, variant = 'default' }: BlogCardProps) {
   if (variant === 'featured') {
     return (
-      <article className='group rounded-2xl border border-border-subtle p-8 sm:p-10 transition-all duration-200 hover:border-border-default hover:-translate-y-0.5'>
+      <article className='group rounded-2xl border border-border-subtle p-8 sm:p-10 transition-colors duration-subtle hover:border-border-default'>
         {/* Meta — category pill outside the link to avoid nested <a> */}
         <div className='flex flex-wrap items-center gap-3 mb-4'>
           <time
@@ -84,7 +84,7 @@ export function BlogCard({ post, author, variant = 'default' }: BlogCardProps) {
   }
 
   return (
-    <article className='group rounded-xl border border-border-subtle p-6 h-full transition-all duration-200 hover:border-border-default hover:-translate-y-0.5'>
+    <article className='group rounded-xl border border-border-subtle p-6 h-full transition-colors duration-subtle hover:border-border-default'>
       {/* Meta */}
       <div className='flex flex-wrap items-center gap-2 mb-3'>
         <time

--- a/apps/web/app/(marketing)/demo/video/page.tsx
+++ b/apps/web/app/(marketing)/demo/video/page.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@jovie/ui';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { APP_ROUTES } from '@/constants/routes';
@@ -42,12 +43,13 @@ export default function ProductDemoPage() {
             Download Demo
           </a>
         )}
-        <Link
-          href={APP_ROUTES.SIGNUP}
-          className='inline-flex h-12 items-center rounded-full bg-white px-8 text-sm font-semibold text-black transition-opacity hover:opacity-90'
+        <Button
+          asChild
+          variant='whitePill'
+          className='h-12 px-8 text-sm font-semibold'
         >
-          Try it free
-        </Link>
+          <Link href={APP_ROUTES.SIGNUP}>Try it free</Link>
+        </Button>
       </div>
     </section>
   );

--- a/apps/web/app/(marketing)/download/page.tsx
+++ b/apps/web/app/(marketing)/download/page.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@jovie/ui';
 import { ArrowDownToLine } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
@@ -106,15 +107,20 @@ export default async function DownloadPage() {
           links, fan data, and campaigns without living in another browser tab.
         </p>
         <div className='mt-10 flex flex-col items-center gap-3'>
-          <a
-            href={DOWNLOAD_URL}
-            className='inline-flex items-center gap-3 rounded-full bg-white px-7 py-3.5 text-base font-medium text-black transition-colors hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white'
-            data-analytics-event='download_mac_dmg'
-            data-analytics-source='download_page_hero'
+          <Button
+            asChild
+            variant='whitePill'
+            className='gap-3 px-7 py-3.5 text-base sm:text-base'
           >
-            <ArrowDownToLine className='size-5' aria-hidden='true' />
-            Download for Mac
-          </a>
+            <a
+              href={DOWNLOAD_URL}
+              data-analytics-event='download_mac_dmg'
+              data-analytics-source='download_page_hero'
+            >
+              <ArrowDownToLine className='size-5' aria-hidden='true' />
+              Download for Mac
+            </a>
+          </Button>
           {meta ? <p className='text-sm text-tertiary-token'>{meta}</p> : null}
           <p className='text-xs text-tertiary-token'>
             Developer ID signed · Apple notarized · Auto-updates included
@@ -200,15 +206,20 @@ export default async function DownloadPage() {
             Download Jovie for Mac and keep your release workflow one click
             away.
           </p>
-          <a
-            href={DOWNLOAD_URL}
-            className='mt-10 inline-flex items-center gap-3 rounded-full bg-white px-7 py-3.5 text-base font-medium text-black transition-colors hover:bg-white/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white'
-            data-analytics-event='download_mac_dmg'
-            data-analytics-source='download_page_footer'
+          <Button
+            asChild
+            variant='whitePill'
+            className='mt-10 gap-3 px-7 py-3.5 text-base sm:text-base'
           >
-            <ArrowDownToLine className='size-5' aria-hidden='true' />
-            Download for Mac
-          </a>
+            <a
+              href={DOWNLOAD_URL}
+              data-analytics-event='download_mac_dmg'
+              data-analytics-source='download_page_footer'
+            >
+              <ArrowDownToLine className='size-5' aria-hidden='true' />
+              Download for Mac
+            </a>
+          </Button>
         </section>
       </MarketingContainer>
 

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -30,14 +30,14 @@ export default function RootError({ error, reset }: ErrorProps) {
           <button
             type='button'
             onClick={reset}
-            className='h-9 cursor-pointer rounded-full bg-[#e6e6e6] px-4 text-sm font-medium text-[#06070a] transition-[background] duration-150 hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7170ff] active:scale-[0.97]'
+            className='h-9 cursor-pointer rounded-full bg-[#e6e6e6] px-4 text-sm font-medium text-[#06070a] transition-[background] duration-subtle hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7170ff]'
           >
             Try Again
           </button>
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Using <a> for resilience when Next.js routing may be broken */}
           <a
             href='/'
-            className='flex h-9 items-center rounded-full border border-white/[0.08] bg-transparent px-4 text-sm font-medium text-[#969799] transition-[background,border-color] duration-150 hover:border-white/[0.12] hover:bg-white/[0.04] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7170ff] active:scale-[0.97]'
+            className='flex h-9 items-center rounded-full border border-white/[0.08] bg-transparent px-4 text-sm font-medium text-[#969799] transition-[background,border-color] duration-subtle hover:border-white/[0.12] hover:bg-white/[0.04] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7170ff]'
           >
             Go Home
           </a>

--- a/apps/web/components/features/home/ArtistCarousel.tsx
+++ b/apps/web/components/features/home/ArtistCarousel.tsx
@@ -1,8 +1,5 @@
-'use client';
-
 import Link from 'next/link';
 import { OptimizedImage } from '@/components/molecules/OptimizedImage';
-import { useReducedMotion } from '@/lib/hooks/useReducedMotion';
 
 interface Artist {
   id: string;
@@ -17,8 +14,6 @@ interface ArtistCarouselProps {
 }
 
 export function ArtistCarousel({ artists }: ArtistCarouselProps) {
-  const prefersReducedMotion = useReducedMotion();
-
   if (!artists || artists.length === 0) {
     return null;
   }
@@ -33,7 +28,7 @@ export function ArtistCarousel({ artists }: ArtistCarouselProps) {
             <Link
               key={artist.id}
               href={`/${artist.handle}`}
-              className={`group shrink-0 ${prefersReducedMotion ? '' : 'transition-transform duration-slower hover:scale-110'}`}
+              className='group shrink-0 transition-opacity duration-slower hover:opacity-90'
             >
               <div className='relative'>
                 {/* Artist image */}
@@ -50,13 +45,7 @@ export function ArtistCarousel({ artists }: ArtistCarouselProps) {
                 </div>
 
                 {/* Hover overlay with artist name */}
-                <div
-                  className={`absolute inset-0 flex items-center justify-center bg-black/50 rounded-full ${
-                    prefersReducedMotion
-                      ? 'opacity-0 focus-visible-within:opacity-100 group-focus-visible:opacity-100'
-                      : 'opacity-0 group-hover:opacity-100 transition-opacity duration-slower'
-                  }`}
-                >
+                <div className='absolute inset-0 flex items-center justify-center bg-black/50 rounded-full opacity-0 transition-opacity duration-slower group-hover:opacity-100 group-focus-visible:opacity-100 motion-reduce:transition-none'>
                   <span className='text-white text-xs sm:text-sm font-medium text-center px-2'>
                     {artist.name}
                   </span>

--- a/apps/web/components/features/home/HeroClaimHandle.tsx
+++ b/apps/web/components/features/home/HeroClaimHandle.tsx
@@ -76,7 +76,7 @@ export function HeroClaimHandle({
         </div>
 
         <button
-          className='group inline-flex shrink-0 items-center justify-center gap-1.5 rounded-[0.8rem] px-4 transition-all duration-slow hover:brightness-110 active:scale-[0.98] focus-ring-themed'
+          className='group inline-flex shrink-0 items-center justify-center gap-1.5 rounded-[0.8rem] px-4 transition-[background-color,color,box-shadow,filter,opacity] duration-slow hover:brightness-110 focus-ring-themed'
           data-testid={submitButtonTestId}
           style={FALLBACK_BUTTON_STYLE}
           type='submit'

--- a/apps/web/components/features/home/HomeLiveProofSection.tsx
+++ b/apps/web/components/features/home/HomeLiveProofSection.tsx
@@ -46,7 +46,7 @@ function ProofCard({
               ? '(max-width: 767px) 100vw, 900px'
               : '(max-width: 767px) 100vw, 420px'
           }
-          className='object-cover transition-transform duration-300 ease-out group-hover:scale-[1.02]'
+          className='object-cover'
         />
       </div>
       <div className='absolute inset-0 bg-[linear-gradient(180deg,rgba(5,7,12,0.12),rgba(5,7,12,0.3)_35%,rgba(5,7,12,0.82)_100%)]' />

--- a/apps/web/components/features/home/PreFooterCTA.tsx
+++ b/apps/web/components/features/home/PreFooterCTA.tsx
@@ -18,7 +18,7 @@ export function PreFooterCTA() {
         <div className='mx-auto max-w-4xl text-center'>
           {/* Badge with glass morphism effect */}
           <div className='mb-8'>
-            <div className='inline-flex items-center gap-2 px-4 py-2 rounded-full bg-surface-1/80 border border-subtle backdrop-blur-sm text-sm font-medium text-secondary-token transition-all duration-slower hover:bg-surface-2/80 hover:scale-105'>
+            <div className='inline-flex items-center gap-2 px-4 py-2 rounded-full bg-surface-1/80 border border-subtle backdrop-blur-sm text-sm font-medium text-secondary-token transition-colors duration-slower'>
               <svg
                 className='w-4 h-4 text-blue-600 dark:text-blue-400'
                 fill='none'
@@ -61,7 +61,7 @@ export function PreFooterCTA() {
               asChild
               size='lg'
               variant='primary'
-              className='text-lg px-8 py-4 transition-all duration-slower hover:scale-105 hover:shadow-lg hover:shadow-indigo-500/25 dark:hover:shadow-indigo-400/25'
+              className='text-lg px-8 py-4 transition-shadow duration-slower hover:shadow-lg hover:shadow-indigo-500/25 dark:hover:shadow-indigo-400/25'
             >
               <Link href='/onboarding'>Create Your Profile</Link>
             </Button>
@@ -87,7 +87,7 @@ export function PreFooterCTA() {
           </div>
 
           {/* Social proof with enhanced styling */}
-          <div className='mt-10 p-4 rounded-2xl bg-surface-1/50 backdrop-blur-sm border border-subtle transition-all duration-slower'>
+          <div className='mt-10 p-4 rounded-2xl bg-surface-1/50 backdrop-blur-sm border border-subtle'>
             <p className='text-sm text-tertiary-token font-medium'>
               Join{' '}
               <span className='text-blue-600 dark:text-blue-400 font-semibold'>

--- a/apps/web/components/features/home/SeeItInActionCarousel.tsx
+++ b/apps/web/components/features/home/SeeItInActionCarousel.tsx
@@ -206,7 +206,7 @@ function ReleaseCard({
                 onHoverEnd(release.id);
               }
             }}
-            className='group flex w-full flex-col rounded-xl p-6 text-left no-underline transition-all duration-[var(--linear-duration-normal)] hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--linear-text-secondary)]'
+            className='group flex w-full flex-col rounded-xl p-6 text-left no-underline transition-colors duration-[var(--linear-duration-normal)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--linear-text-secondary)]'
             style={{
               backgroundColor: 'var(--linear-bg-surface-0)',
               border: '1px solid var(--linear-border-subtle)',

--- a/apps/web/components/features/home/claim-handle/ClaimHandleForm.tsx
+++ b/apps/web/components/features/home/claim-handle/ClaimHandleForm.tsx
@@ -375,7 +375,7 @@ export function ClaimHandleForm({
             buttonRoundingClass,
             isDisabled
               ? 'cursor-not-allowed opacity-40'
-              : 'hover:brightness-110 active:scale-[0.98]'
+              : 'hover:brightness-110'
           )}
           style={buttonStyle}
         >

--- a/apps/web/components/jovie/components/ChatComposerToolbar.tsx
+++ b/apps/web/components/jovie/components/ChatComposerToolbar.tsx
@@ -92,9 +92,9 @@ export function ComposerSendButton({
         onClick={showStop ? onStop : undefined}
         disabled={!showStop && !canSend}
         className={cn(
-          'flex shrink-0 items-center justify-center rounded-full transition-[background-color,color,box-shadow,transform] duration-fast',
+          'flex shrink-0 items-center justify-center rounded-full transition-[background-color,color,box-shadow] duration-fast',
           isInteractive
-            ? 'bg-gradient-to-b from-white to-[#e8e8eb] text-black shadow-[inset_0_0.5px_0_rgba(255,255,255,0.6),inset_0_-0.5px_0_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.4)] hover:-translate-y-px hover:shadow-[inset_0_0.5px_0_rgba(255,255,255,0.7),inset_0_-0.5px_0_rgba(0,0,0,0.1),0_4px_12px_-2px_rgba(0,0,0,0.5)]'
+            ? 'bg-gradient-to-b from-white to-[#e8e8eb] text-black shadow-[inset_0_0.5px_0_rgba(255,255,255,0.6),inset_0_-0.5px_0_rgba(0,0,0,0.08),0_1px_2px_rgba(0,0,0,0.4)] hover:shadow-[inset_0_0.5px_0_rgba(255,255,255,0.7),inset_0_-0.5px_0_rgba(0,0,0,0.1),0_4px_12px_-2px_rgba(0,0,0,0.5)]'
             : 'cursor-not-allowed bg-white/[0.04] text-quaternary-token shadow-[inset_0_0_0_0.5px_rgba(255,255,255,0.04)]',
           'h-8 w-8'
         )}

--- a/apps/web/components/jovie/components/ScrollToBottom.tsx
+++ b/apps/web/components/jovie/components/ScrollToBottom.tsx
@@ -33,7 +33,7 @@ export function ScrollToBottom({ visible, onClick }: ScrollToBottomProps) {
             'border border-subtle bg-surface-1/95 px-3.5 py-2 backdrop-blur',
             'text-2xs font-medium uppercase tracking-[0.16em] text-secondary-token',
             'shadow-[0_10px_32px_-20px_rgba(15,23,42,0.7)] transition-[background-color,color,opacity,box-shadow]',
-            'hover:-translate-y-0.5 hover:bg-surface-2 hover:text-primary-token',
+            'hover:bg-surface-2 hover:text-primary-token',
             'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/20'
           )}
           aria-label='Scroll to latest messages'

--- a/apps/web/components/marketing/artist-notifications/ArtistNotificationsHero.tsx
+++ b/apps/web/components/marketing/artist-notifications/ArtistNotificationsHero.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@jovie/ui';
 import Link from 'next/link';
 import { MarketingContainer } from '@/components/marketing';
 import { ArtistNotificationFloatingCardView } from '@/components/marketing/MarketingStoryPrimitives';
@@ -52,12 +53,13 @@ export function ArtistNotificationsHero({
             ) : null}
 
             <div className='mt-8'>
-              <Link
-                href={hero.primaryCtaHref}
-                className='inline-flex h-11 items-center justify-center rounded-full bg-white px-5 text-[14px] font-medium text-black transition-colors hover:bg-white/90'
+              <Button
+                asChild
+                variant='whitePill'
+                className='h-11 px-5 sm:text-[14px]'
               >
-                {hero.primaryCtaLabel}
-              </Link>
+                <Link href={hero.primaryCtaHref}>{hero.primaryCtaLabel}</Link>
+              </Button>
             </div>
           </div>
 

--- a/apps/web/components/marketing/artist-profile/ShellCtaButton.tsx
+++ b/apps/web/components/marketing/artist-profile/ShellCtaButton.tsx
@@ -49,8 +49,7 @@ export function shellCtaClassName({
 } = {}) {
   return cn(
     'inline-flex shrink-0 items-center justify-center rounded-full font-semibold tracking-[-0.011em]',
-    'transition-[background-color,border-color,box-shadow,transform] duration-150 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]',
-    'active:scale-[0.985] motion-reduce:transition-none motion-reduce:active:scale-100',
+    'transition-[background-color,border-color,box-shadow,opacity] duration-150 ease-[cubic-bezier(0.25,0.46,0.45,0.94)]',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--linear-border-focus)] focus-visible:ring-offset-2',
     RING_OFFSET[context],
     SHAPE[size],

--- a/apps/web/components/molecules/CTAButton.tsx
+++ b/apps/web/components/molecules/CTAButton.tsx
@@ -5,7 +5,6 @@ import { Check } from 'lucide-react';
 import Link from 'next/link';
 import React from 'react';
 import { LoadingSpinner } from '@/components/atoms/LoadingSpinner';
-import { useReducedMotion } from '@/lib/hooks/useReducedMotion';
 import { cn } from '@/lib/utils';
 
 export interface CTAButtonProps extends Omit<ButtonProps, 'loading' | 'size'> {
@@ -60,8 +59,6 @@ export const CTAButton = React.forwardRef<
     },
     ref
   ) => {
-    const prefersReducedMotion = useReducedMotion();
-
     const mappedSize: ButtonProps['size'] | undefined =
       size === 'md' ? 'default' : size;
 
@@ -75,14 +72,11 @@ export const CTAButton = React.forwardRef<
       </span>
     );
 
+    // Calm color/opacity/shadow feedback only — no decorative scale/translate.
+    // See .claude/rules/ui.md "No Decorative Hover Motion".
     const sharedClassName = cn(
-      'gap-2 rounded-lg transition-all duration-150 ease-out',
-      'active:translate-y-[1px] focus-visible:translate-y-[0.5px]',
-      'motion-reduce:transition-none motion-reduce:transform-none',
-      'will-change-transform focus-visible:ring-offset-2 focus-visible:ring-ring focus-visible:ring-offset-background',
-      prefersReducedMotion
-        ? 'shadow-none active:translate-y-0 hover:shadow-none'
-        : 'shadow-lg hover:shadow-xl hover:scale-[1.02] active:scale-[0.98]',
+      'gap-2 rounded-lg shadow-lg transition-[background-color,border-color,box-shadow,color,opacity] duration-subtle ease-subtle',
+      'hover:shadow-xl focus-visible:ring-offset-2 focus-visible:ring-ring focus-visible:ring-offset-background',
       className
     );
 
@@ -93,7 +87,6 @@ export const CTAButton = React.forwardRef<
           disabled={isDisabled}
           size={mappedSize}
           data-state={dataState}
-          data-reduced-motion={prefersReducedMotion ? 'true' : undefined}
           className={sharedClassName}
           aria-busy={isLoading || undefined}
           {...props}
@@ -118,7 +111,6 @@ export const CTAButton = React.forwardRef<
         disabled={isDisabled}
         size={mappedSize}
         data-state={dataState}
-        data-reduced-motion={prefersReducedMotion ? 'true' : undefined}
         className={sharedClassName}
         aria-live={isSuccess ? 'polite' : undefined}
         aria-busy={isLoading || undefined}

--- a/apps/web/components/onboarding/OnboardingInterviewModal.tsx
+++ b/apps/web/components/onboarding/OnboardingInterviewModal.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
@@ -214,14 +215,14 @@ export function OnboardingInterviewModal({
         >
           Skip
         </button>
-        <button
-          type='button'
+        <Button
+          variant='whitePill'
           onClick={() => advance(false)}
           disabled={!canSubmit || entry.answer.trim().length === 0}
-          className='rounded-full bg-white px-4 py-2 text-sm font-medium text-black transition-opacity hover:opacity-90 disabled:opacity-40'
+          className='px-4 py-2 text-sm'
         >
           {submitLabel}
-        </button>
+        </Button>
       </div>
     </dialog>
   );

--- a/apps/web/components/organisms/HeaderNav.tsx
+++ b/apps/web/components/organisms/HeaderNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { getLinearPillClassName } from '@jovie/ui';
+import { Button, getLinearPillClassName } from '@jovie/ui';
 import { ChevronDown } from 'lucide-react';
 import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -62,12 +62,13 @@ function PublicAuthActions({
   if (minimal) {
     if (minimalVariant === 'pill') {
       return (
-        <Link
-          href={APP_ROUTES.SIGNIN}
-          className='focus-ring-themed hidden h-[36px] items-center justify-center rounded-full border border-white/88 bg-white px-4 text-[13px] font-medium tracking-[-0.012em] text-black shadow-[0_8px_20px_rgba(0,0,0,0.14),inset_0_1px_0_rgba(255,255,255,0.72)] transition-colors duration-subtle hover:bg-white/95 sm:inline-flex sm:h-[40px] sm:px-5 sm:text-[14px] sm:shadow-[0_10px_24px_rgba(0,0,0,0.18),inset_0_1px_0_rgba(255,255,255,0.72)]'
+        <Button
+          asChild
+          variant='whitePill'
+          className='focus-ring-themed hidden h-[36px] px-4 text-[13px] sm:inline-flex sm:h-[40px] sm:px-5 sm:text-[14px]'
         >
-          Sign in
-        </Link>
+          <Link href={APP_ROUTES.SIGNIN}>Sign in</Link>
+        </Button>
       );
     }
 

--- a/apps/web/components/organisms/MarketingSignInLink.tsx
+++ b/apps/web/components/organisms/MarketingSignInLink.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Button } from '@jovie/ui';
 import dynamic from 'next/dynamic';
 import { useCallback, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
@@ -35,6 +36,24 @@ export function MarketingSignInLink({
     void loadModal();
   }, []);
 
+  if (variant === 'pill') {
+    return (
+      <>
+        <Button
+          variant='whitePill'
+          onClick={onOpen}
+          onMouseEnter={prefetch}
+          onFocus={prefetch}
+          onTouchStart={prefetch}
+          className='focus-ring-themed h-[36px] px-4 sm:h-[40px] sm:px-5 sm:text-[14px]'
+        >
+          Sign in
+        </Button>
+        {open ? <AuthModal onClose={onClose} defaultMode='signin' /> : null}
+      </>
+    );
+  }
+
   return (
     <>
       <button
@@ -45,9 +64,7 @@ export function MarketingSignInLink({
         onTouchStart={prefetch}
         className={cn(
           'focus-ring-themed transition-colors duration-subtle',
-          variant === 'pill'
-            ? 'inline-flex h-[36px] items-center justify-center rounded-full border border-white/88 bg-white px-4 text-[13px] font-medium tracking-[-0.012em] text-black shadow-[0_8px_20px_rgba(0,0,0,0.14),inset_0_1px_0_rgba(255,255,255,0.72)] hover:bg-white/95 sm:h-[40px] sm:px-5 sm:text-[14px] sm:shadow-[0_10px_24px_rgba(0,0,0,0.18),inset_0_1px_0_rgba(255,255,255,0.72)]'
-            : 'text-[13px] text-white/60 hover:text-white/90'
+          'text-[13px] text-white/60 hover:text-white/90'
         )}
       >
         Sign in

--- a/apps/web/components/providers/PublicPageErrorFallback.tsx
+++ b/apps/web/components/providers/PublicPageErrorFallback.tsx
@@ -87,7 +87,7 @@ export function PublicPageErrorFallback({
         <p style={styles.description}>Try refreshing the page.</p>
         <button
           type='button'
-          className='mt-6 inline-flex h-9 cursor-pointer items-center justify-center rounded-full bg-[#e6e6e6] px-4 text-sm font-medium text-[#06070a] transition-[background] duration-150 hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7170ff] active:scale-[0.97]'
+          className='mt-6 inline-flex h-9 cursor-pointer items-center justify-center rounded-full bg-[#e6e6e6] px-4 text-sm font-medium text-[#06070a] transition-[background] duration-subtle hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7170ff]'
           onClick={onRefresh}
         >
           Refresh

--- a/packages/ui/atoms/button.tsx
+++ b/packages/ui/atoms/button.tsx
@@ -32,6 +32,11 @@ const buttonVariants = cva(
           'backdrop-blur-sm bg-surface-0/30 dark:bg-surface-1/10 hover:bg-surface-1/50 dark:hover:bg-surface-2/20 border border-subtle',
         'frosted-outline':
           'backdrop-blur-sm bg-transparent border border-subtle hover:bg-surface-1/20 dark:hover:bg-surface-2/10',
+        // Canonical white pill CTA — high-contrast hero/auth pill used across
+        // marketing headers and homepage sign-in. Calm color/opacity feedback
+        // only — no decorative scale/translate. See .claude/rules/ui.md.
+        whitePill:
+          'border border-white/88 bg-white text-black shadow-[0_8px_20px_rgba(0,0,0,0.14),inset_0_1px_0_rgba(255,255,255,0.72)] hover:bg-white/95 font-medium tracking-[-0.012em] sm:shadow-[0_10px_24px_rgba(0,0,0,0.18),inset_0_1px_0_rgba(255,255,255,0.72)]',
       },
       size: {
         default: 'h-8 px-3 py-1.5',


### PR DESCRIPTION
## Summary

Conform high-visibility CTAs across marketing, home, header, onboarding, and error surfaces to the new design-system rules (JOV-1830). Canonical white pill primitive added; raw `rounded-full bg-white ... text-black` wrappers replaced; decorative `hover:scale` / `active:scale` / `hover:-translate` removed from non-spatial controls.

<!-- linear-issue-id:JOV-1830 -->

## Changes

**New primitive**
- `packages/ui/atoms/button.tsx` — adds `whitePill` variant (high-contrast hero/auth pill, calm color/opacity feedback only — no decorative transform).

**Raw white pill wrappers → `Button variant="whitePill"`**
- `HeaderNav` (minimal pill Sign in)
- `MarketingSignInLink` (pill variant)
- `ArtistNotificationsHero`
- `OnboardingInterviewModal` submit
- `/download` hero + footer CTAs
- `/demo/video` Try it free

**Decorative hover-motion removed from non-spatial controls**
- `CTAButton` — drops `hover:scale-[1.02] active:scale-[0.98]` and the `useReducedMotion` hook (calm color/opacity feedback now works for all users)
- `ClaimHandleForm`, `HeroClaimHandle` — drop `active:scale-[0.98]`
- `PreFooterCTA` — drop `hover:scale-105` on badge + button
- `SeeItInActionCarousel` — drop `hover:-translate-y-0.5` on cards
- `ChatComposerToolbar` — drop `hover:-translate-y-px` on send button
- `ScrollToBottom` — drop `hover:-translate-y-0.5`
- `BlogCard` (featured + default) — drop `hover:-translate-y-0.5`
- `ShellCtaButton` — drop `active:scale-[0.985]`
- `app/error.tsx`, `PublicPageErrorFallback` — drop `active:scale-[0.97]`
- `ArtistCarousel` — drop `hover:scale-110` on artist tiles
- `HomeLiveProofSection` — drop `group-hover:scale-[1.02]` on image

**Spatial cues intentionally preserved**
- Carousel scroll, phone mockup animation, and arrow-direction translates on read-more / next-back links remain.

## Acceptance criteria

- [x] Touched primary CTAs delegate to canonical `whitePill` primitive.
- [x] No new visual CTA wrappers introduced for small visual differences.
- [x] Non-spatial transform violations removed from touched files.
- [x] Visual smoke for touched surfaces still looks intentional.

## Verification

- `pnpm --filter @jovie/ui run typecheck` — passes
- `pnpm --filter @jovie/web run typecheck` — passes
- `pnpm biome check --write apps/web packages/ui` — clean
- `pnpm --filter @jovie/web run lint:server-boundaries` — passes
- Focused vitest: `tests/unit/CTAButton.test.tsx`, `tests/unit/HeaderNavFlyout.test.tsx`, `tests/components/organisms/MarketingSignInLink.test.tsx` — all pass (11 tests)

## Out of scope (separate PRs)

- Lower-visibility hover-motion violations in `apps/web/components/shell/**`, `apps/web/components/features/dashboard/**`, and `apps/web/components/features/admin/**` per task scope ("Keep the first PR focused on high-visibility violations only").
- Experiment files in `apps/web/app/exp/**` are explicitly out of scope per the task.
- Directional-arrow translates on "read more"/back-arrow links (BlogPostPage, ProblemSolutionSection) are spatial cues, not decorative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced whitePill button variant for call-to-action elements

* **Style Updates**
  - Updated button hover effects and transition behaviors throughout the application
  - Refined CTA button styling across marketing and product pages
  - Simplified hover animations on carousel items and interactive elements
  - Adjusted button transition timings and hover states

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8510)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->