### PR TITLE
fix(profile): replace hardcoded colors in More menu with design tokens (JOV-1988)

### DIFF
--- a/apps/web/components/features/profile/ProfileDrawerShell.tsx
+++ b/apps/web/components/features/profile/ProfileDrawerShell.tsx
@@ -66,7 +66,7 @@ export function ProfileDrawerShell({
             <button
               type='button'
               onClick={onBack}
-              className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white/[0.04] text-white/44 transition-colors duration-subtle hover:bg-white/[0.08] hover:text-white/74 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]'
+              className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[color:var(--color-bg-hover)] text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-interactive-active hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus'
               aria-label='Back'
               data-testid='profile-drawer-back-button'
             >
@@ -87,7 +87,7 @@ export function ProfileDrawerShell({
                 {subtitle ? (
                   <p
                     id={subtitleId}
-                    className='truncate text-3xs font-[440] leading-[1.1] tracking-[-0.01em] text-white/46'
+                    className='truncate text-3xs font-[440] leading-[1.1] tracking-[-0.01em] text-tertiary-token'
                   >
                     {subtitle}
                   </p>
@@ -104,7 +104,7 @@ export function ProfileDrawerShell({
             <button
               type='button'
               onClick={() => onOpenChange(false)}
-              className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white/[0.04] text-white/44 transition-colors duration-subtle hover:bg-white/[0.08] hover:text-white/74 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))]'
+              className='flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-[color:var(--color-bg-hover)] text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-interactive-active hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus'
               aria-label='Close'
               data-testid='profile-drawer-close-button'
             >
@@ -126,7 +126,7 @@ export function ProfileDrawerShell({
               {subtitle ? (
                 <p
                   id={subtitleId}
-                  className='mt-1 truncate text-3xs font-[440] leading-[1.1] tracking-[-0.01em] text-white/46'
+                  className='mt-1 truncate text-3xs font-[440] leading-[1.1] tracking-[-0.01em] text-tertiary-token'
                 >
                   {subtitle}
                 </p>
@@ -136,7 +136,9 @@ export function ProfileDrawerShell({
         )}
       </div>
 
-      {isSecondaryHeader ? <div className='mx-5 h-px bg-white/[0.06]' /> : null}
+      {isSecondaryHeader ? (
+        <div className='mx-5 h-px bg-[color:var(--color-border-subtle)]' />
+      ) : null}
     </>
   );
 

--- a/apps/web/components/features/profile/ProfileUnifiedDrawer.tsx
+++ b/apps/web/components/features/profile/ProfileUnifiedDrawer.tsx
@@ -185,7 +185,7 @@ function ContactList({
                   <a
                     key={`${contact.id}-${channel.type}`}
                     href={channelHref}
-                    className='flex h-8 w-8 items-center justify-center rounded-full text-white/50 transition-colors duration-normal hover:bg-white/[0.08] hover:text-white/80'
+                    className='flex h-8 w-8 items-center justify-center rounded-full text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-interactive-active hover:text-primary-token'
                     aria-label={`${labels[channel.type] ?? 'Call'} ${contact.roleLabel}`}
                     onClick={() => trackAction(channel, contact)}
                   >
@@ -398,12 +398,12 @@ export function ProfileUnifiedDrawer({
                     checked={contentPrefs[pref.key]}
                     onCheckedChange={() => onTogglePref(pref.key)}
                     aria-label={pref.label}
-                    className='data-[state=checked]:bg-green-500 data-[state=checked]:hover:bg-green-600 data-[state=unchecked]:bg-white/[0.16] data-[state=unchecked]:hover:bg-white/[0.22]'
+                    className='data-[state=checked]:bg-success data-[state=checked]:hover:bg-success/90'
                   />
                 </div>
               ))}
 
-              <div className='mx-1 my-1 h-px bg-white/[0.06]' />
+              <div className='mx-1 my-1 h-px bg-[color:var(--color-border-subtle)]' />
 
               <button
                 type='button'
@@ -412,7 +412,7 @@ export function ProfileUnifiedDrawer({
                 onClick={onUnsubscribe}
                 disabled={isUnsubscribing}
               >
-                <BellOff className='size-4 text-red-400/50' />
+                <BellOff className='size-4 text-error/60' />
                 {isUnsubscribing
                   ? 'Turning off\u2026'
                   : 'Turn off notifications'}
@@ -501,11 +501,11 @@ export function ProfileUnifiedDrawer({
                   otherPaymentOptionsLabel='Other payment options'
                 />
               ) : (
-                <div className='rounded-[var(--profile-drawer-radius-mobile)] border border-white/8 bg-white/[0.035] px-4 py-5 text-center'>
-                  <p className='text-sm font-semibold text-white/88'>
+                <div className='rounded-[var(--profile-drawer-radius-mobile)] border border-subtle bg-[color:var(--color-interactive-hover)] px-4 py-5 text-center'>
+                  <p className='text-sm font-semibold text-primary-token'>
                     Payments not available yet
                   </p>
-                  <p className='mt-2 text-sm leading-6 text-white/54'>
+                  <p className='mt-2 text-sm leading-6 text-tertiary-token'>
                     This profile has not added a public Venmo link.
                   </p>
                 </div>

--- a/apps/web/components/features/profile/profile-drawer-classes.ts
+++ b/apps/web/components/features/profile/profile-drawer-classes.ts
@@ -3,16 +3,18 @@
 // Keyboard focus gets a visible ring (WCAG 2.4.11 AA — 3:1 contrast) in
 // addition to the background tint, since the native outline is suppressed.
 export const PROFILE_DRAWER_MENU_ITEM_CLASS =
-  'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-book text-white/92 transition-colors duration-150 ease-out hover:bg-white/[0.05] focus-visible:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-inset active:bg-white/[0.08]';
+  'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-book text-primary-token transition-colors duration-subtle ease-subtle hover:bg-interactive-hover focus-visible:bg-interactive-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-inset active:bg-interactive-active';
 
 export const PROFILE_DRAWER_DANGER_ITEM_CLASS =
-  'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-book text-red-400/88 transition-colors duration-150 ease-out hover:bg-red-400/[0.06] focus-visible:bg-red-400/[0.07] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-400/50 focus-visible:ring-inset active:bg-red-400/[0.09]';
+  'flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-book text-error transition-colors duration-subtle ease-subtle hover:bg-error-subtle focus-visible:bg-error-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-error focus-visible:ring-inset active:bg-error-subtle';
 
 // Applied to non-focusable <div> wrappers; use focus-within so the ring
 // appears when keyboard focus lands on an interactive child (link, Switch).
 export const PROFILE_DRAWER_TOGGLE_ROW_CLASS =
-  'flex w-full items-center justify-between rounded-xl px-4 py-3 text-left transition-colors duration-150 ease-out hover:bg-white/[0.04] focus-within:outline-none focus-within:ring-2 focus-within:ring-white/40 focus-within:ring-inset';
+  'flex w-full items-center justify-between rounded-xl px-4 py-3 text-left transition-colors duration-subtle ease-subtle hover:bg-interactive-hover focus-within:outline-none focus-within:ring-2 focus-within:ring-focus focus-within:ring-inset';
 
-export const PROFILE_DRAWER_TITLE_CLASS = 'text-sm font-book text-white/92';
+export const PROFILE_DRAWER_TITLE_CLASS =
+  'text-sm font-book text-primary-token';
 
-export const PROFILE_DRAWER_META_CLASS = 'text-2xs font-normal text-white/46';
+export const PROFILE_DRAWER_META_CLASS =
+  'text-2xs font-normal text-tertiary-token';

--- a/apps/web/components/features/profile/views/MenuView.tsx
+++ b/apps/web/components/features/profile/views/MenuView.tsx
@@ -4,7 +4,7 @@ import { Disc3, Mail, Share2, Ticket, Wallet } from 'lucide-react';
 import { PROFILE_DRAWER_MENU_ITEM_CLASS } from '../profile-drawer-classes';
 import type { ProfileViewKey } from './registry';
 
-const ICON_CLASS = 'size-4 text-white/40';
+const ICON_CLASS = 'size-4 text-quaternary-token';
 
 export interface MenuViewProps {
   readonly onNavigate: (view: ProfileViewKey) => void;


### PR DESCRIPTION
The profile More menu (ProfileUnifiedDrawer, ProfileDrawerShell, MenuView)
was using raw white/black opacity values and Tailwind palette colors
(text-white/88, bg-white/[0.06], text-red-400, bg-green-500) instead of
semantic design tokens, producing visual drift from the rest of the app.

Migrate text colors to primary/secondary/tertiary/quaternary tokens,
backgrounds to interactive-hover/active, dividers to border-subtle,
danger states to error/error-subtle, the notifications toggle to
bg-success, and focus rings to ring-focus.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated icon, text, and divider colors in profile components to use design tokens, improving visual consistency and ensuring cohesive styling across the interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8511)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->