### PR TITLE
fix(profile): make drawer body scrollable when content overflows (JOV-1993)

### DIFF
--- a/apps/web/components/features/profile/ProfileDrawerShell.tsx
+++ b/apps/web/components/features/profile/ProfileDrawerShell.tsx
@@ -50,7 +50,9 @@ export function ProfileDrawerShell({
     ['--profile-drawer-header' as string]: '72px',
   } as React.CSSProperties;
   const contentClasses = `relative flex max-h-[var(--profile-drawer-height-max)] w-full flex-col overflow-hidden rounded-t-[var(--profile-drawer-radius-mobile)] border-t border-white/[0.08] bg-[color:var(--profile-drawer-bg)] text-primary-token shadow-[0_-8px_40px_rgba(0,0,0,0.4)] backdrop-blur-2xl md:max-w-(--profile-shell-max-width) md:rounded-t-[var(--profile-drawer-radius-desktop)] before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-24 before:bg-[linear-gradient(to_bottom,rgba(255,255,255,0.04),transparent)] ${contentClassName ?? ''}`;
-  const bodyClasses = `relative z-10 min-h-[calc(var(--profile-drawer-height-max)_-_var(--profile-drawer-header))] overflow-y-auto overscroll-contain px-5 pb-[calc(1.25rem_+_env(safe-area-inset-bottom))] pt-3 ${bodyClassName ?? ''}`;
+  // Fixed height (not min-h) so overflow-y-auto activates on overflow; min-h
+  // lets the body grow past the parent's max-h and get clipped by overflow-hidden.
+  const bodyClasses = `relative z-10 h-[calc(var(--profile-drawer-height-max)_-_var(--profile-drawer-header))] overflow-y-auto overscroll-contain px-5 pb-[calc(1.25rem_+_env(safe-area-inset-bottom))] pt-3 ${bodyClassName ?? ''}`;
 
   const header = (
     <>

--- a/apps/web/tests/unit/profile/ProfileDrawerShell.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileDrawerShell.test.tsx
@@ -168,6 +168,32 @@ describe('ProfileDrawerShell', () => {
     expect(onBack).toHaveBeenCalledTimes(1);
   });
 
+  // Regression: body must use definite height (not min-h) so overflow-y-auto
+  // activates when content exceeds the drawer envelope. min-h alone lets the
+  // body grow past the parent's max-h and get clipped (JOV-1993).
+  it('gives the drawer body a definite height plus overflow-y-auto for scroll', () => {
+    render(
+      <ProfileDrawerShell
+        open
+        onOpenChange={vi.fn()}
+        title='About'
+        dataTestId='scroll-drawer'
+      >
+        <div data-testid='drawer-body-content'>Body</div>
+      </ProfileDrawerShell>
+    );
+
+    const body = screen.getByTestId('drawer-body-content').parentElement;
+    expect(body).not.toBeNull();
+    expect(body?.className).toMatch(/\boverflow-y-auto\b/);
+    expect(body?.className).toMatch(
+      /\bh-\[calc\(var\(--profile-drawer-height-max\)/
+    );
+    expect(body?.className).not.toMatch(
+      /\bmin-h-\[calc\(var\(--profile-drawer-height-max\)/
+    );
+  });
+
   it('anchors embedded drawers flush to the phone shell instead of floating them', () => {
     render(
       <ProfileDrawerShell


### PR DESCRIPTION
## Summary

- Drawer body now uses a definite height (`h-[calc(...)]`) instead of `min-h-[calc(...)]`, so `overflow-y-auto` actually activates when content exceeds the envelope on mobile.
- Adds a regression test on `ProfileDrawerShell` asserting the body has both a definite height and `overflow-y-auto`.

## Root cause

`ProfileDrawerShell`'s body wrapper used `min-h-[calc(var(--profile-drawer-height-max) - var(--profile-drawer-header))]`. With `min-h` alone, the body element grew to fit content (no max-height), pushing its content past the parent's `max-h` + `overflow-hidden` envelope. That clip prevented the body's own `overflow-y-auto` from ever triggering, so About / Releases / Tour / Pay / Contact would clip their tails on mobile.

Switching to `h-[calc(...)]` fixes both halves of the contract:
- Body stays exactly the envelope-minus-header height, preserving the constant drawer envelope across mode swaps.
- Content overflow now triggers the body's own scroll container.

## Test plan

- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] `pnpm biome check --write apps/web` (clean)
- [x] `pnpm --filter web exec vitest run tests/unit/profile/ProfileDrawerShell.test.tsx` (7/7 pass, including new regression)
- [x] `pnpm --filter web exec vitest run tests/unit/profile` (60 files / 473 tests pass)
- [ ] Manual: open profile drawer on mobile, navigate to About with long bio + press photos, confirm content scrolls inside the drawer instead of clipping.

Closes JOV-1993.

<!-- linear-issue-id:JOV-1993 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed profile drawer scrolling behavior to properly handle content overflow and maintain scroll functionality.

* **Tests**
  * Added regression test to verify drawer height and scroll behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8513)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->