### PR TITLE
docs(notifications): canonical channel type story (JOV-1839)

### DIFF
--- a/apps/web/types/notifications.ts
+++ b/apps/web/types/notifications.ts
@@ -1,8 +1,23 @@
-// Fan-facing notification channels stored in the DB today
+/**
+ * Fan-facing subscription channel — the values a fan can choose from when
+ * subscribing on a public profile and the values persisted in the DB
+ * (`notification_subscriptions.channel`, `notification_contacts.*Status`).
+ *
+ * Use this type for: subscribe/unsubscribe flows, fan preferences UI, DB-row
+ * shapes. Do NOT use it as the dispatch enum on `sendNotification()` — see
+ * `NotificationDeliveryChannel` below.
+ */
 export type NotificationChannel = 'sms' | 'email';
 
-// App-wide delivery channels. `email` and `sms` overlap with NotificationChannel
-// (the DB-facing fan enum); `push`/`in_app` are creator-facing only.
+/**
+ * App-wide outbound delivery channel — the transports `sendNotification()`
+ * can target. Superset of `NotificationChannel`:
+ *   - `email`, `sms` overlap with `NotificationChannel` (fan-facing)
+ *   - `push`, `in_app` are creator-facing only
+ *
+ * Both fan and creator code paths converge on this enum for outbound
+ * dispatch; there is no shadow type. See `docs/NOTIFICATION_GUIDELINES.md`.
+ */
 export type NotificationDeliveryChannel = 'email' | 'sms' | 'push' | 'in_app';
 
 export type NotificationCategory = 'transactional' | 'product' | 'marketing';

--- a/docs/NOTIFICATION_GUIDELINES.md
+++ b/docs/NOTIFICATION_GUIDELINES.md
@@ -8,10 +8,11 @@ Jovie uses a unified toast notification system that provides consistent user fee
 
 > **Note**: This notification system was designed to replace direct calls to external toast libraries and provide a consistent user experience throughout the application.
 
-## Server-delivered notifications (email/push/in-app)
+## Server-delivered notifications (email/sms/push/in-app)
 
 - Send cross-channel notifications through `lib/notifications/service.ts` to avoid duplicating provider logic.
 - Email delivery is handled by Resend (`RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `RESEND_REPLY_TO_EMAIL`). Defaults are `notifications@jov.ie` for system sender/reply-to; founder-personal mail uses `tim@jov.ie`.
+- SMS delivery is handled by Twilio (`providers/sms/twilio-sender.ts`) and gated by the global STOP suppression ledger (`notification_contacts.smsStatus`). Per-artist consent and unsubscribe are enforced upstream by the subscribe flow and release scheduler.
 - Preferences are resolved from creator profile settings (`settings.marketing_emails` + `marketingOptOut`) and channel toggles under `settings.notifications.channels`.
 - Provide a stable `id`/`dedupKey` so `dismissNotification` can stop the same message from fanning out across channels (e.g., when a user dismisses an in-app toast).
 - Example:
@@ -24,14 +25,29 @@ Jovie uses a unified toast notification system that provides consistent user fee
       category: 'product',
       subject: 'New feature available',
       text: 'Try the new dashboard filters.',
-      channels: ['email', 'in_app'],
+      channels: ['email', 'sms', 'in_app'],
     },
-    { creatorProfileId, email }
+    { creatorProfileId, email, phone }
   );
 
   // When user dismisses the in-app notification:
   await dismissNotification(`dashboard-alert-${userId}`, { creatorProfileId });
   ```
+
+### Channel type reference (`NotificationChannel` vs `NotificationDeliveryChannel`)
+
+Two channel types live in `apps/web/types/notifications.ts`. They look similar but mean different things — do not mix them.
+
+| Type | Values | Purpose | Where it lives |
+| --- | --- | --- | --- |
+| `NotificationChannel` | `'sms' \| 'email'` | Fan-facing subscription enum. What a fan picks on a public profile and what's persisted in the DB (`notification_subscriptions.channel`, `notification_contacts.*Status`). | Subscribe/unsubscribe API, fan preference UI, validation schemas |
+| `NotificationDeliveryChannel` | `'email' \| 'sms' \| 'push' \| 'in_app'` | App-wide outbound dispatch enum. The transports `sendNotification()` can target. Superset of `NotificationChannel`. | `service.ts`, notification preferences, dispatch results |
+
+Rules:
+
+- `sendNotification()` only accepts `NotificationDeliveryChannel`. SMS dispatch goes through it directly — there is no shadow type or bypass path.
+- DB-facing fan subscription code (subscribe API, fan UI) uses `NotificationChannel` because fans cannot pick `push` or `in_app`.
+- When converting between the two, the safe direction is `NotificationChannel → NotificationDeliveryChannel` (widening). Do not narrow `NotificationDeliveryChannel` to `NotificationChannel` without explicitly handling `push`/`in_app`.
 
 ## When to Use Toasts vs Console Logging
 


### PR DESCRIPTION
## Summary

Closes out the documentation deliverable for JOV-1839. The structural unification (adding `sms` to `NotificationDeliveryChannel` + first-class SMS dispatch in `service.ts`) shipped in #8064; this PR closes the last remaining acceptance criterion — "one canonical channel type story, documented in `docs/` or inline."

- Expand JSDoc on `NotificationChannel` and `NotificationDeliveryChannel` in `apps/web/types/notifications.ts` so the boundary is obvious at the import site.
- Update `docs/NOTIFICATION_GUIDELINES.md`:
  - Rename the section to cover SMS alongside email/push/in-app.
  - Add SMS delivery note (Twilio + global STOP suppression ledger).
  - Add a "Channel type reference" table contrasting `NotificationChannel` (fan-facing, DB-persisted) vs `NotificationDeliveryChannel` (dispatch superset), plus rules for safe conversions.
  - Update the `sendNotification` example to include `'sms'` and `phone`.

No runtime code paths change. The 29 existing `service.test.ts` cases (which already cover the SMS dispatch path end-to-end) all pass.

## Acceptance criteria

- [x] One canonical channel type story, documented in `docs/` or inline.
- [x] `sendNotification()` accepts `'sms'` directly with no shadow types. *(already shipped in #8064)*
- [x] All TypeScript consumers compile; no `any` shims.
- [x] No behavioral regression to existing email/push/in_app paths.

## Test plan

- [x] `pnpm --filter @jovie/web run typecheck` — green
- [x] `pnpm biome check --write apps/web/types/notifications.ts docs/NOTIFICATION_GUIDELINES.md` — clean
- [x] `pnpm --filter web exec vitest run lib/notifications/service.test.ts` — 29/29 pass

<!-- linear-issue-id:JOV-1839 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded notification system guidance with clearer information on channel types and their proper usage.
  * Added detailed SMS delivery information and enhanced code examples.
  * Introduced a new reference section distinguishing between notification channel types and safe conversion practices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8519)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->