### PR TITLE
fix(profile): centralize z-index layering + drop one-off hex/duration tokens (JOV-2025)

### DIFF
--- a/apps/web/components/features/profile/DesktopQrOverlay.tsx
+++ b/apps/web/components/features/profile/DesktopQrOverlay.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { CircleIconButton } from '@/components/atoms/CircleIconButton';
 import { getQrCodeUrl, QRCode } from '@/components/molecules/QRCode';
 import { useReducedMotion } from '@/lib/hooks/useReducedMotion';
+import { PROFILE_Z } from '@/lib/profile/z-index-constants';
 
 interface DesktopQrOverlayProps {
   readonly handle: string;
@@ -130,7 +131,7 @@ export function DesktopQrOverlay({ handle }: Readonly<DesktopQrOverlayProps>) {
               ? { duration: 0 }
               : { duration: 0.2, ease: 'easeOut' }
           }
-          className='group fixed bottom-4 right-4 z-50 flex flex-col items-center rounded-xl p-4 ring-1 ring-(--color-border-subtle) shadow-xl bg-surface-0 backdrop-blur-md overflow-hidden'
+          className={`group fixed bottom-4 right-4 ${PROFILE_Z.DRAWER_CONTENT} flex flex-col items-center rounded-xl p-4 ring-1 ring-(--color-border-subtle) shadow-xl bg-surface-0 backdrop-blur-md overflow-hidden`}
         >
           <div className='pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-slower group-hover:opacity-100'>
             <div className='absolute inset-0 bg-[radial-gradient(80%_60%_at_50%_0%,rgba(255,255,255,0.35),transparent_60%)]' />
@@ -162,7 +163,7 @@ export function DesktopQrOverlay({ handle }: Readonly<DesktopQrOverlayProps>) {
               ? { duration: 0 }
               : { duration: 0.2, ease: 'easeOut' }
           }
-          className='fixed bottom-4 right-4 z-50'
+          className={`fixed bottom-4 right-4 ${PROFILE_Z.DRAWER_CONTENT}`}
         >
           <CircleIconButton
             size='md'

--- a/apps/web/components/features/profile/ProfileDrawerShell.tsx
+++ b/apps/web/components/features/profile/ProfileDrawerShell.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, X } from 'lucide-react';
 import { useId } from 'react';
 import { Drawer } from 'vaul';
 import type { ProfileSurfacePresentation } from '@/features/profile/contracts';
+import { PROFILE_Z } from '@/lib/profile/z-index-constants';
 
 type ProfileDrawerNavigationLevel = 'root' | 'secondary';
 
@@ -152,11 +153,11 @@ export function ProfileDrawerShell({
         <button
           type='button'
           aria-label='Close drawer overlay'
-          className='fixed inset-0 z-10 bg-black/48 backdrop-blur-sm'
+          className={`fixed inset-0 ${PROFILE_Z.LOCAL_CONTENT} bg-black/48 backdrop-blur-sm`}
           onClick={() => onOpenChange(false)}
         />
         <dialog
-          className='absolute inset-x-0 bottom-0 z-20 m-0 max-w-none border-0 bg-transparent p-0'
+          className={`absolute inset-x-0 bottom-0 ${PROFILE_Z.STICKY_CHROME} m-0 max-w-none border-0 bg-transparent p-0`}
           data-testid={dataTestId}
           aria-describedby={accessibleDescriptionId}
           aria-labelledby={titleId}
@@ -183,7 +184,9 @@ export function ProfileDrawerShell({
     }
 
     return (
-      <div className='absolute inset-0 z-30 flex items-center justify-center bg-black/52 p-6 backdrop-blur-sm'>
+      <div
+        className={`absolute inset-0 ${PROFILE_Z.EMBEDDED_MODAL} flex items-center justify-center bg-black/52 p-6 backdrop-blur-sm`}
+      >
         <button
           type='button'
           aria-label='Close modal overlay'
@@ -215,8 +218,12 @@ export function ProfileDrawerShell({
   return (
     <Drawer.Root open={open} onOpenChange={onOpenChange}>
       <Drawer.Portal>
-        <Drawer.Overlay className='fixed inset-0 z-40 bg-black/60 backdrop-blur-sm' />
-        <div className='fixed inset-x-0 bottom-0 z-50 flex justify-center'>
+        <Drawer.Overlay
+          className={`fixed inset-0 ${PROFILE_Z.DRAWER_BACKDROP} bg-black/60 backdrop-blur-sm`}
+        />
+        <div
+          className={`fixed inset-x-0 bottom-0 ${PROFILE_Z.DRAWER_CONTENT} flex justify-center`}
+        >
           <Drawer.Content
             className={contentClasses}
             style={drawerHeightStyle}

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileMobileNotificationsFlow.tsx
@@ -20,6 +20,7 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { OtpInput } from '@/features/auth/atoms/otp-input';
+import { PROFILE_Z } from '@/lib/profile/z-index-constants';
 import { cn } from '@/lib/utils';
 import type { NotificationContentType } from '@/types/notifications';
 
@@ -504,7 +505,7 @@ export function ProfileMobileNotificationsFlow({
           footer={
             <div className='space-y-3'>
               {error ? (
-                <p className='text-sm text-[#ff8b8b]' role='alert'>
+                <p className='text-sm text-red-400' role='alert'>
                   {error}
                 </p>
               ) : null}
@@ -543,7 +544,7 @@ export function ProfileMobileNotificationsFlow({
           footer={
             <div className='space-y-3'>
               {error ? (
-                <p className='text-sm text-[#ff8b8b]' role='alert'>
+                <p className='text-sm text-red-400' role='alert'>
                   {error}
                 </p>
               ) : null}
@@ -836,8 +837,8 @@ export function ProfileMobileNotificationsFlow({
 
   const overlayRootClassName =
     portalContainer === undefined
-      ? 'pointer-events-auto fixed inset-0 z-[140]'
-      : 'pointer-events-auto absolute inset-0 z-[140]';
+      ? `pointer-events-auto fixed inset-0 ${PROFILE_Z.FULLSCREEN_FLOW}`
+      : `pointer-events-auto absolute inset-0 ${PROFILE_Z.FULLSCREEN_FLOW}`;
   const contentStyle = {
     '--mobile-flow-accent': accentHex,
   } as CSSProperties;

--- a/apps/web/components/features/profile/drawer-overlay-styles.test.ts
+++ b/apps/web/components/features/profile/drawer-overlay-styles.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { PROFILE_Z } from '@/lib/profile/z-index-constants';
 import { DRAWER_OVERLAY_CLASS } from './drawer-overlay-styles';
 
 describe('drawer-overlay-styles', () => {
@@ -11,8 +12,10 @@ describe('drawer-overlay-styles', () => {
     expect(DRAWER_OVERLAY_CLASS).toContain('backdrop-blur-sm');
   });
 
-  it('overlay uses z-40 to sit below drawer content (z-50)', () => {
-    expect(DRAWER_OVERLAY_CLASS).toContain('z-40');
+  it('overlay sits on the canonical drawer-backdrop layer below drawer content', () => {
+    expect(DRAWER_OVERLAY_CLASS).toContain(PROFILE_Z.DRAWER_BACKDROP);
+    expect(PROFILE_Z.DRAWER_BACKDROP).toBe('z-40');
+    expect(PROFILE_Z.DRAWER_CONTENT).toBe('z-50');
   });
 
   it('overlay uses fixed positioning with full coverage', () => {

--- a/apps/web/components/features/profile/drawer-overlay-styles.ts
+++ b/apps/web/components/features/profile/drawer-overlay-styles.ts
@@ -1,7 +1,11 @@
+import { PROFILE_Z } from '@/lib/profile/z-index-constants';
+
 /**
  * Shared overlay class for Vaul-based profile drawers.
  * Ensures consistent backdrop opacity, blur, and z-index across
  * PayDrawer, ListenDrawer, and ContactDrawer.
+ *
+ * Layered at `PROFILE_Z.DRAWER_BACKDROP` (z-40), below drawer content
+ * which sits at `PROFILE_Z.DRAWER_CONTENT` (z-50).
  */
-export const DRAWER_OVERLAY_CLASS =
-  'fixed inset-0 z-40 bg-black/60 backdrop-blur-sm';
+export const DRAWER_OVERLAY_CLASS = `fixed inset-0 ${PROFILE_Z.DRAWER_BACKDROP} bg-black/60 backdrop-blur-sm`;

--- a/apps/web/components/features/profile/views/ReleasesView.tsx
+++ b/apps/web/components/features/profile/views/ReleasesView.tsx
@@ -182,7 +182,7 @@ export function ReleasesView({
                 onClick={() => setActiveFilter(filter.key)}
                 aria-pressed={isActive}
                 className={cn(
-                  'inline-flex h-8 shrink-0 items-center rounded-full border px-3 text-[12px] font-semibold transition-colors duration-200',
+                  'inline-flex h-8 shrink-0 items-center rounded-full border px-3 text-[12px] font-semibold transition-colors duration-subtle',
                   isActive
                     ? 'border-white bg-white text-black'
                     : 'border-white/10 bg-white/[0.035] text-white/58 hover:text-white'
@@ -198,7 +198,7 @@ export function ReleasesView({
       {visibleReleases[0]?.slug ? (
         <a
           href={`/${artistHandle}/${visibleReleases[0].slug}`}
-          className='group flex items-center gap-3 border-y border-white/[0.075] px-4 py-3.5 transition-colors duration-200 hover:bg-white/[0.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
+          className='group flex items-center gap-3 border-y border-white/[0.075] px-4 py-3.5 transition-colors duration-subtle hover:bg-white/[0.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
           aria-label={getReleaseAriaLabel(visibleReleases[0])}
         >
           <div className='relative h-[72px] w-[72px] shrink-0 overflow-hidden rounded-[8px] bg-white/[0.04] shadow-[0_8px_20px_-10px_rgba(0,0,0,0.55)]'>
@@ -269,7 +269,7 @@ export function ReleasesView({
               <a
                 href={`/${artistHandle}/${release.slug}`}
                 className={cn(
-                  'group flex min-h-[60px] items-center gap-3 px-4 py-2.5 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent hover:bg-white/[0.03]',
+                  'group flex min-h-[60px] items-center gap-3 px-4 py-2.5 transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent hover:bg-white/[0.03]',
                   index > 0 && 'border-t border-white/[0.075]'
                 )}
                 aria-label={ariaLabel}
@@ -290,7 +290,7 @@ export function ReleasesView({
                       {release.title}
                     </span>
                     {index === 0 ? (
-                      <span className='inline-flex h-[15px] items-center rounded-full border border-white/8 bg-white px-1.25 text-[8px] font-semibold uppercase tracking-[0.04em] text-[#15161a]'>
+                      <span className='inline-flex h-[15px] items-center rounded-full border border-white/8 bg-white px-1.25 text-[8px] font-semibold uppercase tracking-[0.04em] text-black'>
                         New
                       </span>
                     ) : null}
@@ -306,12 +306,12 @@ export function ReleasesView({
                 </div>
 
                 <div className='ml-1 flex shrink-0 items-center gap-3'>
-                  <span className='flex h-8 w-8 items-center justify-center rounded-full border border-white/8 bg-white/[0.02] text-white/78 transition-[border-color,background-color] duration-200 group-hover:border-white/14 group-hover:bg-white/[0.05]'>
+                  <span className='flex h-8 w-8 items-center justify-center rounded-full border border-white/8 bg-white/[0.02] text-white/78 transition-[border-color,background-color] duration-subtle group-hover:border-white/14 group-hover:bg-white/[0.05]'>
                     <Play className='ml-0.5 h-3 w-3 fill-current' />
                   </span>
                   <span
                     aria-hidden='true'
-                    className='flex items-center gap-[3px] text-white/24 transition-colors duration-200 group-hover:text-white/36'
+                    className='flex items-center gap-[3px] text-white/24 transition-colors duration-subtle group-hover:text-white/36'
                   >
                     <span className='h-[3px] w-[3px] rounded-full bg-current' />
                     <span className='h-[3px] w-[3px] rounded-full bg-current' />

--- a/apps/web/lib/profile/z-index-constants.test.ts
+++ b/apps/web/lib/profile/z-index-constants.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { PROFILE_Z } from './z-index-constants';
+
+describe('profile z-index constants', () => {
+  it('exposes the canonical layering keys', () => {
+    expect(Object.keys(PROFILE_Z)).toEqual([
+      'LOCAL_CONTENT',
+      'STICKY_CHROME',
+      'EMBEDDED_MODAL',
+      'DRAWER_BACKDROP',
+      'DRAWER_CONTENT',
+      'FULLSCREEN_FLOW',
+    ]);
+  });
+
+  it('orders layers from low to high', () => {
+    expect(PROFILE_Z.LOCAL_CONTENT).toBe('z-10');
+    expect(PROFILE_Z.STICKY_CHROME).toBe('z-20');
+    expect(PROFILE_Z.EMBEDDED_MODAL).toBe('z-30');
+    expect(PROFILE_Z.DRAWER_BACKDROP).toBe('z-40');
+    expect(PROFILE_Z.DRAWER_CONTENT).toBe('z-50');
+  });
+
+  it('keeps the full-screen flow above all drawers', () => {
+    expect(PROFILE_Z.FULLSCREEN_FLOW).toBe('z-[140]');
+  });
+});

--- a/apps/web/lib/profile/z-index-constants.ts
+++ b/apps/web/lib/profile/z-index-constants.ts
@@ -1,0 +1,41 @@
+/**
+ * Canonical z-index layering for public profile surfaces.
+ *
+ * Profile surfaces use a small, documented set of z-index layers so drawers,
+ * overlays, and full-screen takeovers stack predictably regardless of which
+ * component file mounts them. New profile UI must pick one of these layers
+ * rather than introducing a new magic value.
+ *
+ * Spec ordering (low → high):
+ *   1. Shell / in-flow content      — `z-auto` (default; tab bar lives here)
+ *   2. Local stacking context       — `z-10`   (content within a card/panel)
+ *   3. Sticky chrome inside panel   — `z-20`   (sticky headers in scrolling panels)
+ *   4. Embedded preview modal       — `z-30`   (centered modal over preview iframe)
+ *   5. Drawer backdrop              — `z-40`   (full-screen blurred backdrop)
+ *   6. Drawer content + QR overlay  — `z-50`   (top-level standalone affordances)
+ *   7. Full-screen mobile flow      — `z-[140]` (subscribe takeover above drawers)
+ *
+ * Tailwind v4 scans this file for class strings, so importing a value here is
+ * equivalent (for JIT class generation) to writing the literal in the JSX.
+ */
+
+export const PROFILE_Z = {
+  /** Default layer for content within a card/panel (most common). */
+  LOCAL_CONTENT: 'z-10',
+  /** Sticky chrome inside a scrolling panel (e.g. desktop drawer header). */
+  STICKY_CHROME: 'z-20',
+  /** Modal centered over an embedded preview surface. */
+  EMBEDDED_MODAL: 'z-30',
+  /** Full-screen backdrop behind drawer content. */
+  DRAWER_BACKDROP: 'z-40',
+  /** Drawer content and top-level affordances (e.g. QR overlay). */
+  DRAWER_CONTENT: 'z-50',
+  /**
+   * Full-screen takeover that must sit above every drawer/overlay
+   * (e.g. mobile notifications signup flow). Uses an arbitrary value
+   * to leave headroom for app-level toasts/system UI above.
+   */
+  FULLSCREEN_FLOW: 'z-[140]',
+} as const;
+
+export type ProfileZLayer = (typeof PROFILE_Z)[keyof typeof PROFILE_Z];


### PR DESCRIPTION
## Summary

Profile Hardening 7/11 — design-token + legacy cleanup (JOV-2025). Centralizes z-index layering on the public profile surface and removes lingering one-off hex/duration tokens flagged on profile routes.

## Changes

- **New `apps/web/lib/profile/z-index-constants.ts`** documents the canonical layering for public profile surfaces:
  - `LOCAL_CONTENT` (z-10) — content within a card/panel
  - `STICKY_CHROME` (z-20) — sticky headers inside scrolling panels
  - `EMBEDDED_MODAL` (z-30) — modal centered over embedded preview
  - `DRAWER_BACKDROP` (z-40) — full-screen drawer backdrop
  - `DRAWER_CONTENT` (z-50) — Vaul drawer + top-level affordances
  - `FULLSCREEN_FLOW` (z-[140]) — mobile notifications takeover
- **`ProfileDrawerShell`, `DesktopQrOverlay`, `ProfileMobileNotificationsFlow`** now bind to `PROFILE_Z.*` constants instead of raw utilities — eliminating the magic `z-[140]` value and aligning the embedded/modal/standalone presentations with the documented layering.
- **`drawer-overlay-styles.ts`** shared overlay class references `PROFILE_Z.DRAWER_BACKDROP`; its test asserts the canonical backdrop/content layering pair.
- **Token swaps** on profile routes:
  - `text-[#15161a]` → `text-black` in ReleasesView's "New" badge
  - `text-[#ff8b8b]` → `text-red-400` in mobile notifications flow error text
  - `duration-200` → `duration-subtle` (5 instances in ReleasesView) to satisfy `@jovie/no-raw-motion-values`

## Legacy components

Phases 1 and 2 (JOV-2021/JOV-2022) already removed the bulk of the legacy components inventoried in JOV-2019: `AnimatedArtistPage`, `AnimatedListenInterface`, `PublicProfileTemplate(V2)`, `ArtistPageShell`, `ProgressiveArtistPage`, `ProfileFeaturedCard`, `ProfileScrollBody`, `ProfileViewportShell`, `ProfileModeDrawer`, `ProfileMenuDrawer`, `SubscribeDrawer`, `SwipeableModeContainer`. The remaining `ProfileShell` organism still has live callers via `useProfileShell` / `ProfileNotificationsContext` and is held for a dedicated extraction pass (tracked under JOV-2018 follow-on). `StaticListenInterface` is heavily live (`ProfilePrimaryTabPanel`, `ListenView`, `ProfileDesktopSurface`, `ProfileUnifiedDrawer`) and was incorrectly flagged in JOV-2019 §3.1 — keeping.

## Out of scope

- No new tokens added — only uses values already in the design system
- No visual redesign — class outputs are identical aside from the small color/duration token swaps
- Performance optimization (JOV-2027)
- `useProfileShell` extraction from organisms (separate phase)

## Test plan

- [x] `pnpm --filter @jovie/web run typecheck` — passes
- [x] `pnpm biome check` — passes
- [x] `pnpm --filter web exec vitest run` for profile components + tests/unit/profile — 478 tests pass
- [x] New `z-index-constants.test.ts` contract test (3 cases) — passes
- [x] Existing `drawer-overlay-styles.test.ts` updated to assert canonical layering — passes
- [ ] Visual regression suite — expected near-zero pixel changes (text-[#15161a]→text-black is a sub-byte tint shift; #ff8b8b→red-400 is a small saturation lift in the error label that already renders inside a mobile takeover, both intentional cleanups)

Closes JOV-2025.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated transition animation timing on profile UI elements.
  * Refined text colors for release badges and error messages.

* **Tests**
  * Added test coverage for profile component layering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8521)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->