### PR TITLE
perf(profile): wire web-vitals reporter and image fallbacks (JOV-2027)

### DIFF
--- a/apps/web/app/[username]/layout.tsx
+++ b/apps/web/app/[username]/layout.tsx
@@ -1,3 +1,4 @@
+import { ProfileWebVitalsReporter } from '@/components/features/profile/ProfileWebVitalsReporter';
 import { ClientProviders } from '@/components/providers/ClientProviders';
 import { publicEnv } from '@/lib/env-public';
 
@@ -26,6 +27,7 @@ export default function ProfileLayout({
       skipCoreProviders
     >
       {children}
+      <ProfileWebVitalsReporter />
     </ClientProviders>
   );
 }

--- a/apps/web/components/features/profile/AboutSection.tsx
+++ b/apps/web/components/features/profile/AboutSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Calendar, Download, Home, MapPin } from 'lucide-react';
-import Image from 'next/image';
+import { ImageWithFallback } from '@/components/atoms/ImageWithFallback';
 import { hexToRgba, lightenHex } from '@/lib/utils/color';
 import type { Artist } from '@/types/db';
 import type { PressPhoto } from '@/types/press-photos';
@@ -165,17 +165,18 @@ export function AboutSection({
             {pressPhotos.map((photo, index) => (
               <div key={photo.id} className='overflow-hidden rounded-xl'>
                 <div className='relative aspect-[4/5]'>
-                  <Image
-                    src={
-                      photo.mediumUrl ?? photo.smallUrl ?? photo.blobUrl ?? ''
-                    }
+                  <ImageWithFallback
+                    src={photo.mediumUrl ?? photo.smallUrl ?? photo.blobUrl}
                     alt={
                       photo.originalFilename ??
                       `${artist.name} press photo ${index + 1}`
                     }
                     fill
                     sizes='(max-width: 640px) 50vw, 33vw'
+                    loading={index < 2 ? 'eager' : 'lazy'}
                     className='object-cover'
+                    fallbackVariant='avatar'
+                    fallbackClassName='bg-surface-2'
                   />
                   {/* Download button — flat icon, circle on hover */}
                   <button

--- a/apps/web/components/features/profile/ProfileWebVitalsReporter.tsx
+++ b/apps/web/components/features/profile/ProfileWebVitalsReporter.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const DEFERRED_INIT_DELAY_MS = 300;
+
+/**
+ * Lightweight RUM hook for the public profile route group.
+ *
+ * The profile layout uses `skipCoreProviders` (see [username]/layout.tsx),
+ * which omits the CoreProviders web-vitals initializer. Without this
+ * component, profile routes don't emit LCP/INP/CLS/FCP/TTFB events to
+ * analytics — leaving the highest-traffic surface unmeasured.
+ *
+ * The component renders nothing, lazy-loads the web-vitals module after
+ * first paint, and routes metrics through `initWebVitals()` → analytics
+ * + a `web-vitals` CustomEvent that anything subscribing can pick up.
+ */
+export function ProfileWebVitalsReporter() {
+  useEffect(() => {
+    let cleanup: (() => void) | undefined;
+    let cancelled = false;
+
+    function dispatchWebVital(metric: unknown) {
+      const event = new CustomEvent('web-vitals', { detail: metric });
+      globalThis.dispatchEvent(event);
+    }
+
+    const handle = setTimeout(() => {
+      import('@/lib/monitoring/web-vitals')
+        .then(mod => {
+          const dispose = mod.initWebVitals(dispatchWebVital);
+          if (cancelled) {
+            dispose();
+            return;
+          }
+          cleanup = dispose;
+        })
+        .catch(() => {
+          // Web vitals are best-effort; never break the profile page.
+        });
+    }, DEFERRED_INIT_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+      cleanup?.();
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
Phase 9 (of 11) of the Profile Hardening initiative — initial cut focused on production telemetry and image-failure handling for the public profile route group.

- Wire `ProfileWebVitalsReporter` into `app/[username]/layout.tsx`. The layout uses `skipCoreProviders`, which otherwise skips the web-vitals init from `CoreProviders`, leaving the highest-traffic surface unmeasured. The reporter lazy-loads `@/lib/monitoring/web-vitals` after first paint and routes LCP/INP/CLS/FCP/TTFB events through the existing `initWebVitals()` singleton (idempotent — safe if `CoreProviders` is later re-introduced for these routes).
- Migrate `AboutSection` press photos from raw `next/image` to `ImageWithFallback`. Broken/expired CDN URLs now render the styled avatar placeholder rather than the browser's broken-image icon, satisfying the "Missing-image fallback renders cleanly" AC. The first two press photos load eagerly (above-the-fold on mobile profile views) while the rest stay lazy.

Other profile route images (`ProfileHeroCard`, `ProfileMediaCard`, `ProfilePrimaryActionCard`, `views/ReleasesView`) already use `ImageWithFallback` with explicit `fill` + `sizes`, plus `priority` on the hero. No regressions introduced; remaining Phase 9 perf work (bundle audit, Lighthouse measurement, lazy-load boundaries) tracked under the parent JOV-2027 acceptance criteria for follow-up.

Linear: https://linear.app/jovie/issue/JOV-2027

## Test plan
- [x] `pnpm --filter @jovie/web run typecheck` — passes
- [x] `pnpm biome check --write apps/web/...` — clean
- [x] `pnpm exec vitest run tests/unit/profile/ tests/unit/components/atoms/ImageWithFallback.test.tsx` — 478 tests pass
- [ ] Manual: confirm a fresh public profile page emits a `web_vital_lcp` event in analytics
- [ ] Manual: simulate a 404 on a press photo URL and confirm the avatar fallback renders instead of a broken-image icon

## Cost Impact
None. Reuses the existing `initWebVitals()` singleton and the existing `track()` analytics destination — no new external API calls or scheduled work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced image handling in profile About section with improved fallback support for missing or unavailable images.

* **Performance**
  * Optimized profile page image loading with prioritized loading for critical images.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8522)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->