### PR TITLE
fix(profile): hide release countdown after release date passes (JOV-1990)

### DIFF
--- a/apps/web/components/features/profile/LatestReleaseCard.tsx
+++ b/apps/web/components/features/profile/LatestReleaseCard.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { ProfileMediaCard } from '@/features/profile/ProfileMediaCard';
 import { useBreakpointDown } from '@/hooks/useBreakpoint';
+import { useReleaseAwareNow } from '@/hooks/useReleaseAwareNow';
 import type { AvailableDSP } from '@/lib/dsp';
 import type { Artist } from '@/types/db';
 import { ListenDrawer } from './ListenDrawer';
@@ -36,6 +37,10 @@ export function LatestReleaseCard({
   const releaseDate = release.releaseDate
     ? new Date(release.releaseDate)
     : null;
+  // Re-evaluate at the release boundary so an ISR-cached page transitions
+  // from "Drops in"/"Notify me" to "Out Now"/"Listen Now" the moment the
+  // release drops.
+  const now = useReleaseAwareNow(releaseDate);
   const releaseYear =
     releaseDate && !Number.isNaN(releaseDate.getTime())
       ? releaseDate.getUTCFullYear()
@@ -43,7 +48,7 @@ export function LatestReleaseCard({
   const isFutureRelease =
     releaseDate !== null &&
     !Number.isNaN(releaseDate.getTime()) &&
-    releaseDate.getTime() > Date.now();
+    releaseDate.getTime() > now.getTime();
   const releaseTypeLabel =
     release.releaseType === 'ep'
       ? 'EP'

--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -14,6 +14,7 @@ import {
   startOfProfileSurfaceLocalDay as startOfLocalDay,
   toProfileSurfaceDateValue as toDateValue,
 } from '@/features/profile/profile-surface-state';
+import { useReleaseAwareNow } from '@/hooks/useReleaseAwareNow';
 import { useTourDateProximity } from '@/hooks/useTourDateProximity';
 import type { UserLocation } from '@/hooks/useUserLocation';
 import { useUserLocation } from '@/hooks/useUserLocation';
@@ -357,13 +358,17 @@ export function ProfileHomeRail({
   viewerLocation,
   resolveNearbyTour = true,
 }: Readonly<ProfileHomeRailProps>) {
+  // Re-evaluate visibility at the release boundary so the rail's "Drops in"
+  // chrome transitions to "Out Now" when the release drops, even if the
+  // page was served from a stale ISR cache.
+  const now = useReleaseAwareNow(latestRelease?.releaseDate);
   const upcomingTourDates = useMemo(
-    () => getUpcomingTourDates(tourDates),
-    [tourDates]
+    () => getUpcomingTourDates(tourDates, now),
+    [now, tourDates]
   );
   const releaseVisibility = useMemo(
-    () => getProfileReleaseVisibility(latestRelease, profileSettings),
-    [latestRelease, profileSettings]
+    () => getProfileReleaseVisibility(latestRelease, profileSettings, now),
+    [latestRelease, now, profileSettings]
   );
   const shouldResolveGeo =
     resolveNearbyTour &&
@@ -388,6 +393,7 @@ export function ProfileHomeRail({
         nearbyTourDate,
         featuredPlaylistFallback,
         hasPlayableDestinations,
+        now,
       }),
     [
       artist.name,
@@ -396,6 +402,7 @@ export function ProfileHomeRail({
       latestRelease,
       nearbyTourDate,
       nextTourDate,
+      now,
       profileSettings,
     ]
   );

--- a/apps/web/components/features/profile/ProfilePrimaryActionCard.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryActionCard.tsx
@@ -11,6 +11,7 @@ import {
   startOfProfileSurfaceLocalDay as startOfLocalDay,
   toProfileSurfaceDateValue as toDateValue,
 } from '@/features/profile/profile-surface-state';
+import { useReleaseAwareNow } from '@/hooks/useReleaseAwareNow';
 import { useTourDateProximity } from '@/hooks/useTourDateProximity';
 import type { UserLocation } from '@/hooks/useUserLocation';
 import { useUserLocation } from '@/hooks/useUserLocation';
@@ -609,14 +610,20 @@ export function ProfilePrimaryActionCard({
   size = 'compact',
   now,
 }: Readonly<ProfilePrimaryActionCardProps>) {
+  // Re-evaluate visibility at the release boundary so the countdown card
+  // chrome transitions to "live" the moment the release drops (even if the
+  // surrounding page is served from a stale ISR cache).
+  const releaseAwareNow = useReleaseAwareNow(latestRelease?.releaseDate);
+  const effectiveNow = now ?? releaseAwareNow;
   const upcomingTourDates = useMemo(
-    () => getUpcomingTourDates(tourDates, now),
-    [now, tourDates]
+    () => getUpcomingTourDates(tourDates, effectiveNow),
+    [effectiveNow, tourDates]
   );
   const nextTourDate = upcomingTourDates[0] ?? null;
   const releaseVisibility = useMemo(
-    () => getProfileReleaseVisibility(latestRelease, profileSettings, now),
-    [latestRelease, now, profileSettings]
+    () =>
+      getProfileReleaseVisibility(latestRelease, profileSettings, effectiveNow),
+    [latestRelease, effectiveNow, profileSettings]
   );
   const shouldResolveGeo =
     resolveNearbyTour &&
@@ -642,16 +649,16 @@ export function ProfilePrimaryActionCard({
         nearbyTourDate,
         featuredPlaylistFallback,
         hasPlayableDestinations,
-        now,
+        now: effectiveNow,
       }),
     [
       artist.name,
+      effectiveNow,
       featuredPlaylistFallback,
       hasPlayableDestinations,
       latestRelease,
       nearbyTourDate,
       nextTourDate,
-      now,
       profileSettings,
     ]
   );

--- a/apps/web/components/features/release/ReleaseCountdown.tsx
+++ b/apps/web/components/features/release/ReleaseCountdown.tsx
@@ -19,11 +19,19 @@ interface TimeLeft {
 }
 
 /**
- * Calculate time remaining until target date
+ * Calculate time remaining until target date.
+ * Returns zero-state for invalid or already-past dates.
  */
 function getTimeLeft(targetDate: Date): TimeLeft {
+  const targetMs = targetDate.getTime();
+  // Treat non-finite timestamps (NaN, ±Infinity) as expired to prevent NaN
+  // values propagating into the countdown digits.
+  if (!Number.isFinite(targetMs)) {
+    return { days: 0, hours: 0, minutes: 0, total: 0 };
+  }
+
   const now = new Date();
-  const total = targetDate.getTime() - now.getTime();
+  const total = targetMs - now.getTime();
 
   if (total <= 0) {
     return { days: 0, hours: 0, minutes: 0, total: 0 };

--- a/apps/web/components/features/release/ReleaseCountdown.tsx
+++ b/apps/web/components/features/release/ReleaseCountdown.tsx
@@ -89,8 +89,14 @@ export function ReleaseCountdown({
     return () => clearInterval(timer);
   }, [releaseDate, router]);
 
-  // Don't render until mounted or if release has passed
-  if (!timeLeft || timeLeft.total <= 0) {
+  // Defensive synchronous expiry check: if an ISR-cached parent rendered us
+  // with a release date already in the past, render nothing immediately
+  // instead of waiting for the next interval tick. The `typeof window` guard
+  // preserves SSR-safe hydration (server matches the initial null state).
+  const isPastNow =
+    typeof window !== 'undefined' && releaseDate.getTime() <= Date.now();
+
+  if (!timeLeft || timeLeft.total <= 0 || isPastNow) {
     return null;
   }
 

--- a/apps/web/hooks/useReleaseAwareNow.ts
+++ b/apps/web/hooks/useReleaseAwareNow.ts
@@ -17,21 +17,25 @@ export function useReleaseAwareNow(
 ): Date {
   const [now, setNow] = useState<Date>(() => new Date());
 
-  useEffect(() => {
-    if (!releaseDate) return;
-    const target =
-      releaseDate instanceof Date ? releaseDate : new Date(releaseDate);
-    if (Number.isNaN(target.getTime())) return;
+  // Compute a stable numeric timestamp so callers that create a new Date
+  // object on every render (e.g. `new Date(release.releaseDate)`) do not
+  // cause the effect to re-run unnecessarily.
+  const releaseTimestamp =
+    releaseDate instanceof Date
+      ? releaseDate.getTime()
+      : releaseDate
+        ? new Date(releaseDate).getTime()
+        : Number.NaN;
 
-    const msUntil = target.getTime() - Date.now();
-    if (msUntil <= 0) {
-      setNow(new Date());
-      return;
-    }
+  useEffect(() => {
+    // Bail out for null/invalid or already-past dates — no timer needed.
+    if (!Number.isFinite(releaseTimestamp)) return;
+    const msUntil = releaseTimestamp - Date.now();
+    if (msUntil <= 0) return;
 
     const timeout = setTimeout(() => setNow(new Date()), msUntil + 50);
     return () => clearTimeout(timeout);
-  }, [releaseDate]);
+  }, [releaseTimestamp]);
 
   return now;
 }

--- a/apps/web/hooks/useReleaseAwareNow.ts
+++ b/apps/web/hooks/useReleaseAwareNow.ts
@@ -12,6 +12,11 @@ import { useEffect, useState } from 'react';
  * Initial value is `new Date()` at mount. If `releaseDate` is null/invalid
  * or already in the past, no timer is scheduled.
  */
+
+// JavaScript's setTimeout overflows for delays > 2^31 - 1 ms (~24.8 days).
+// Chunk long waits so far-future releases are handled correctly.
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
 export function useReleaseAwareNow(
   releaseDate: Date | string | null | undefined
 ): Date {
@@ -30,10 +35,23 @@ export function useReleaseAwareNow(
   useEffect(() => {
     // Bail out for null/invalid or already-past dates — no timer needed.
     if (!Number.isFinite(releaseTimestamp)) return;
-    const msUntil = releaseTimestamp - Date.now();
-    if (msUntil <= 0) return;
+    const initialMs = releaseTimestamp - Date.now();
+    if (initialMs <= 0) return;
 
-    const timeout = setTimeout(() => setNow(new Date()), msUntil + 50);
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    // Chunk long waits so far-future releases (>24.8 days) are handled
+    // correctly — setTimeout overflows for delays > 2^31-1 ms.
+    const schedule = () => {
+      const msUntil = releaseTimestamp - Date.now();
+      if (msUntil <= 0) {
+        setNow(new Date());
+        return;
+      }
+      timeout = setTimeout(schedule, Math.min(msUntil + 50, MAX_TIMEOUT_MS));
+    };
+
+    timeout = setTimeout(schedule, Math.min(initialMs + 50, MAX_TIMEOUT_MS));
     return () => clearTimeout(timeout);
   }, [releaseTimestamp]);
 

--- a/apps/web/hooks/useReleaseAwareNow.ts
+++ b/apps/web/hooks/useReleaseAwareNow.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns a `Date` that re-renders the calling component exactly once when
+ * `releaseDate` passes. Use as the `now` argument to
+ * `getProfileReleaseVisibility` (or equivalent client-side time checks) so
+ * that ISR-cached parents do not get stuck in a "countdown" state after the
+ * release has actually dropped.
+ *
+ * Initial value is `new Date()` at mount. If `releaseDate` is null/invalid
+ * or already in the past, no timer is scheduled.
+ */
+export function useReleaseAwareNow(
+  releaseDate: Date | string | null | undefined
+): Date {
+  const [now, setNow] = useState<Date>(() => new Date());
+
+  useEffect(() => {
+    if (!releaseDate) return;
+    const target =
+      releaseDate instanceof Date ? releaseDate : new Date(releaseDate);
+    if (Number.isNaN(target.getTime())) return;
+
+    const msUntil = target.getTime() - Date.now();
+    if (msUntil <= 0) {
+      setNow(new Date());
+      return;
+    }
+
+    const timeout = setTimeout(() => setNow(new Date()), msUntil + 50);
+    return () => clearTimeout(timeout);
+  }, [releaseDate]);
+
+  return now;
+}

--- a/apps/web/tests/unit/hooks/useReleaseAwareNow.test.ts
+++ b/apps/web/tests/unit/hooks/useReleaseAwareNow.test.ts
@@ -27,6 +27,22 @@ describe('useReleaseAwareNow', () => {
     expect(result.current).toBe(initial);
   });
 
+  it('does not update when rerendered with an equivalent past Date instance', () => {
+    const pastIso = '2026-05-10T00:00:00Z';
+    const { result, rerender } = renderHook(
+      ({ date }: { date: Date }) => useReleaseAwareNow(date),
+      { initialProps: { date: new Date(pastIso) } }
+    );
+    const initial = result.current;
+    // Simulate a caller that creates a new Date object on every render but
+    // with the same underlying timestamp — the hook must not re-render.
+    rerender({ date: new Date(pastIso) });
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current).toBe(initial);
+  });
+
   it('re-renders with a fresh Date when the release boundary passes', () => {
     const future = new Date('2026-05-11T00:00:30Z'); // 30s in the future
     const { result } = renderHook(() => useReleaseAwareNow(future));

--- a/apps/web/tests/unit/hooks/useReleaseAwareNow.test.ts
+++ b/apps/web/tests/unit/hooks/useReleaseAwareNow.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useReleaseAwareNow } from '@/hooks/useReleaseAwareNow';
+
+describe('useReleaseAwareNow', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns initial Date at mount when releaseDate is null', () => {
+    const { result } = renderHook(() => useReleaseAwareNow(null));
+    expect(result.current.toISOString()).toBe('2026-05-11T00:00:00.000Z');
+  });
+
+  it('does not schedule a re-render when releaseDate is already in the past', () => {
+    const past = new Date('2026-05-10T00:00:00Z');
+    const { result } = renderHook(() => useReleaseAwareNow(past));
+    const initial = result.current;
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current).toBe(initial);
+  });
+
+  it('re-renders with a fresh Date when the release boundary passes', () => {
+    const future = new Date('2026-05-11T00:00:30Z'); // 30s in the future
+    const { result } = renderHook(() => useReleaseAwareNow(future));
+    const initial = result.current;
+    expect(initial.toISOString()).toBe('2026-05-11T00:00:00.000Z');
+
+    act(() => {
+      vi.advanceTimersByTime(31_000);
+    });
+
+    // After the boundary, the hook scheduled a fresh new Date()
+    expect(result.current).not.toBe(initial);
+    expect(result.current.getTime()).toBeGreaterThanOrEqual(future.getTime());
+  });
+
+  it('treats string releaseDate the same as a Date', () => {
+    const future = '2026-05-11T00:00:30Z';
+    const { result } = renderHook(() => useReleaseAwareNow(future));
+    const initial = result.current;
+
+    act(() => {
+      vi.advanceTimersByTime(31_000);
+    });
+
+    expect(result.current).not.toBe(initial);
+  });
+
+  it('ignores invalid date strings', () => {
+    const { result } = renderHook(() => useReleaseAwareNow('not-a-date'));
+    const initial = result.current;
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current).toBe(initial);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [JOV-1990](https://linear.app/jovie/issue/JOV-1990) — the release countdown timer was still rendering on already-released items.

ISR-cached profile pages (`/[username]`, ~1h revalidate) could render the release countdown after the release had actually dropped, because the page snapshot evaluated `releaseDate > now` at cache time. On revisit, the cached HTML still showed "Drops in …" instead of "Out Now / Listen Now".

## Changes

- New `useReleaseAwareNow(releaseDate)` hook (`apps/web/hooks/useReleaseAwareNow.ts`): returns a `Date` that re-renders the calling component exactly once when the release boundary passes. No-op when the date is null/invalid/past.
- `LatestReleaseCard`, `ProfileHomeRail`, `ProfilePrimaryActionCard`: wire `useReleaseAwareNow` into the `isCountdown` / `isFutureRelease` evaluation so the chrome transitions live without a manual refresh, even on a stale ISR snapshot.
- `ReleaseCountdown`: add a defensive synchronous client-side expiry check (`releaseDate <= Date.now()` after hydration) so the timer never renders against a past releaseDate, even if the parent was server-rendered stale.
- New test: `apps/web/tests/unit/hooks/useReleaseAwareNow.test.ts` (5 tests) — locks in the boundary re-render behavior with fake timers.

## Test plan

- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] `pnpm biome check --write apps/web/...` (no fixes applied)
- [x] `vitest run` for `release-visibility.test.ts`, `release-countdown.test.tsx`, `useReleaseAwareNow.test.ts` — 34/34 pass
- [ ] Manual browser check: load a profile with `releaseDate` set to ~30s in the future, observe transition from "Drops in" → "Out Now" without manual refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added release-boundary–aware timing (new client hook) so profile cards, primary action cards, and countdowns update precisely at release moments.

* **Bug Fixes**
  * Resolved stale cached pages not flipping from "Coming Soon" to "Out Now".
  * Countdown now defensively treats invalid/past release timestamps and avoids rendering when already expired.

* **Tests**
  * Added unit tests covering release-aware timing across date inputs and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8539)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->