### PR TITLE
fix(home): replace stale '4u' Spotify fallback with canonical Tim White URL (JOV-1991)

### DIFF
--- a/apps/web/components/features/home/homepage-profile-preview-fixture.ts
+++ b/apps/web/components/features/home/homepage-profile-preview-fixture.ts
@@ -213,7 +213,9 @@ export const HOMEPAGE_PROFILE_PREVIEW_SOCIAL_LINKS: readonly LegacySocialLink[] 
       id: 'homepage-preview-spotify',
       artist_id: HOMEPAGE_PROFILE_PREVIEW_ARTIST.id,
       platform: 'spotify',
-      url: HOMEPAGE_PROFILE_PREVIEW_ARTIST.spotify_url ?? 'https://spotify.com',
+      url:
+        HOMEPAGE_PROFILE_PREVIEW_ARTIST.spotify_url ??
+        TIM_WHITE_PROFILE.spotifyUrl,
       clicks: 1820,
       created_at: CREATED_AT,
       is_visible: true,
@@ -264,7 +266,7 @@ export const HOMEPAGE_PROFILE_PREVIEW_MOCK_HOME_SOCIAL_LINKS: readonly LegacySoc
       platform: 'spotify',
       url:
         HOMEPAGE_PROFILE_PREVIEW_MOCK_HOME_ARTIST.spotify_url ??
-        'https://open.spotify.com/artist/4u',
+        TIM_WHITE_PROFILE.spotifyUrl,
       clicks: 1820,
       created_at: CREATED_AT,
       is_visible: true,


### PR DESCRIPTION
## Summary

JOV-1991 flagged that the Spotify artist ID `'4u'` looked hardcoded in profile-rendering code paths, which would "break the verified badge or founder identity for non-founder profiles."

**Audit result:** Production verified-badge logic is already server-side. `ProfileCompactSurface.tsx:454` and `ProfileDesktopSurface.tsx:414` render the badge from `artist.is_verified` (DB column) — there is no `=== '4u'` check anywhere in product code.

**What was actually wrong:** The homepage preview fixture in `apps/web/components/features/home/homepage-profile-preview-fixture.ts` had two fallback strings — `'https://open.spotify.com/artist/4u'` and `'https://spotify.com'` — that contradicted the canonical `TIM_WHITE_SPOTIFY_ID` constant (`4Uwpa6zW3zzCSQvooQNksm`). These were the last remaining non-test references to `'4u'` in product code. Even though both fallbacks are currently unreachable (the spread artist always defines `spotify_url`), they are a footgun: a future change that nulls out `spotify_url` would silently route to a non-canonical founder identity.

## Change

Replace both fallbacks with `TIM_WHITE_PROFILE.spotifyUrl`, keeping the founder identity canonical even on the unreachable fallback path.

## Test plan
- [x] `pnpm --filter @jovie/web run typecheck` — passes
- [x] `pnpm biome check --write apps/web` — clean
- [x] `pnpm --filter web exec vitest run tests/unit/home/` — 24 files, 111 tests pass (incl. `tim-white-profile.test.ts` that pins the canonical identity)
- [x] `pnpm --filter web exec vitest run tests/unit/profile/` — 60 files, 472 tests pass

## Linear

JOV-1991

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Spotify profile links on the homepage to use the correct fallback URL instead of generic placeholders, ensuring users are directed to the accurate artist profile on Spotify.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8540)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->