### PR TITLE
fix(profile): close drawer on backdrop tap on mobile (JOV-1992)

### DIFF
--- a/apps/web/components/features/profile/ProfileDrawerShell.tsx
+++ b/apps/web/components/features/profile/ProfileDrawerShell.tsx
@@ -224,6 +224,8 @@ export function ProfileDrawerShell({
       <Drawer.Portal>
         <Drawer.Overlay
           className={`fixed inset-0 ${PROFILE_Z.DRAWER_BACKDROP} bg-black/60 backdrop-blur-sm`}
+          onClick={() => onOpenChange(false)}
+          data-testid='profile-drawer-overlay'
         />
         <div
           className={`fixed inset-x-0 bottom-0 ${PROFILE_Z.DRAWER_CONTENT} flex justify-center`}

--- a/apps/web/tests/unit/profile/ProfileDrawerShell.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileDrawerShell.test.tsx
@@ -194,6 +194,23 @@ describe('ProfileDrawerShell', () => {
     );
   });
 
+  // Regression: tapping the overlay must dismiss the standalone (vaul) drawer.
+  // Mobile Safari does not reliably trigger Radix's onPointerDownOutside on
+  // single-finger taps, so the shell adds an explicit onClick on Drawer.Overlay.
+  it('closes the standalone drawer when the backdrop is tapped', () => {
+    const onOpenChange = vi.fn();
+
+    render(
+      <ProfileDrawerShell open onOpenChange={onOpenChange} title='Menu'>
+        <div>Drawer body</div>
+      </ProfileDrawerShell>
+    );
+
+    fireEvent.click(screen.getByTestId('profile-drawer-overlay'));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it('anchors embedded drawers flush to the phone shell instead of floating them', () => {
     render(
       <ProfileDrawerShell


### PR DESCRIPTION
Vaul's Drawer.Overlay only calls onRelease (drag finalization) on mouseUp
and relies on Radix's onPointerDownOutside to close on backdrop click.
On mobile Safari this is unreliable for single-finger taps, so tapping
outside the ProfileUnifiedDrawer did not dismiss it. Add an explicit
onClick on Drawer.Overlay that calls onOpenChange(false), matching the
pattern already used by the embedded and modal presentations in the
same shell. handleOpenChange in ProfileUnifiedDrawer continues to reset
the active view on close.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile drawer overlay can now be dismissed by tapping the backdrop.

* **Tests**
  * Added regression test verifying drawer dismissal via overlay interaction.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8541)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->