### PR TITLE
feat(profile): email signature generator (JOV-1581)

### DIFF
--- a/apps/web/components/features/admin/admin-creator-profiles/AdminCreatorProfilesUnified.tsx
+++ b/apps/web/components/features/admin/admin-creator-profiles/AdminCreatorProfilesUnified.tsx
@@ -31,6 +31,7 @@ import { AdminTableShell } from '@/features/admin/table/AdminTableShell';
 import { useAdminTableKeyboardNavigation } from '@/features/admin/table/useAdminTableKeyboardNavigation';
 import { useCreatorActions } from '@/features/admin/useCreatorActions';
 import { useCreatorVerification } from '@/features/admin/useCreatorVerification';
+import { EmailSignatureDialog } from '@/features/dashboard/molecules/EmailSignatureDialog';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import {
   CREATORS_CSV_FILENAME_PREFIX,
@@ -38,6 +39,7 @@ import {
 } from '@/lib/admin/csv-configs/creators';
 import type { AdminCreatorProfileRow } from '@/lib/admin/types';
 import { TABLE_MIN_WIDTHS } from '@/lib/constants/layout';
+import { buildSignatureInputFromProfile } from '@/lib/email-signature/profile-input';
 import { useAdminCreatorsInfiniteQuery } from '@/lib/queries';
 import { cn } from '@/lib/utils';
 import { AdminProfileSidebar } from './AdminProfileSidebar';
@@ -110,6 +112,34 @@ export function AdminCreatorProfilesUnified({
     clearDeleteProfile,
     clearInviteProfile,
   } = useDialogState();
+
+  const [signatureProfile, setSignatureProfile] =
+    useState<AdminCreatorProfileRow | null>(null);
+  const openEmailSignatureDialog = useCallback(
+    (profile: AdminCreatorProfileRow) => {
+      setSignatureProfile(profile);
+    },
+    []
+  );
+  const signatureInput = useMemo(
+    () =>
+      signatureProfile
+        ? buildSignatureInputFromProfile({
+            profile: {
+              username: signatureProfile.username,
+              displayName: signatureProfile.displayName,
+              avatarUrl: signatureProfile.avatarUrl,
+              genres: signatureProfile.genres,
+              location: signatureProfile.location,
+            },
+            socials: signatureProfile.socialLinks?.map(link => ({
+              label: link.displayText ?? link.platform,
+              url: link.url,
+            })),
+          })
+        : null,
+    [signatureProfile]
+  );
 
   // Load all data without server-side search — filter client-side instead
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -205,6 +235,7 @@ export function AdminCreatorProfilesUnified({
     toggleMarketing,
     openDeleteDialog,
     openInviteDialog,
+    openEmailSignatureDialog,
   });
 
   const {
@@ -556,6 +587,11 @@ export function AdminCreatorProfilesUnified({
         onSuccess={() => {
           clearInviteProfile();
         }}
+      />
+      <EmailSignatureDialog
+        open={signatureProfile !== null}
+        onClose={() => setSignatureProfile(null)}
+        input={signatureInput}
       />
     </>
   );

--- a/apps/web/components/features/admin/admin-creator-profiles/hooks/useContextMenuItems.tsx
+++ b/apps/web/components/features/admin/admin-creator-profiles/hooks/useContextMenuItems.tsx
@@ -10,6 +10,7 @@ import {
   CheckCircle,
   Copy,
   ExternalLink,
+  FileSignature,
   Mail,
   MailX,
   RefreshCw,
@@ -23,6 +24,8 @@ import { toast } from 'sonner';
 import type { ContextMenuItemType } from '@/components/organisms/table';
 import { BASE_URL } from '@/constants/domains';
 import { copyToClipboard } from '@/hooks/useClipboard';
+import { buildEmailSignature } from '@/lib/email-signature/build-signature';
+import { buildSignatureInputFromProfile } from '@/lib/email-signature/profile-input';
 import type { AdminCreatorProfileRow, IngestRefreshStatus } from '../types';
 
 export interface ContextMenuDependencies {
@@ -42,6 +45,7 @@ export interface ContextMenuDependencies {
   ) => Promise<{ success: boolean }>;
   openDeleteDialog: (profile: AdminCreatorProfileRow) => void;
   openInviteDialog: (profile: AdminCreatorProfileRow) => void;
+  openEmailSignatureDialog?: (profile: AdminCreatorProfileRow) => void;
 }
 
 export function useContextMenuItems({
@@ -52,6 +56,7 @@ export function useContextMenuItems({
   toggleMarketing,
   openDeleteDialog,
   openInviteDialog,
+  openEmailSignatureDialog,
 }: ContextMenuDependencies) {
   const getContextMenuItems = useCallback(
     (profile: AdminCreatorProfileRow): ContextMenuItemType[] => {
@@ -169,6 +174,55 @@ export function useContextMenuItems({
         }
       );
 
+      // Email signature — copy HTML directly, or open a preview modal
+      items.push(
+        { type: 'separator' as const },
+        {
+          id: 'copy-email-signature',
+          label: 'Copy email signature',
+          icon: <Copy className='h-3.5 w-3.5' />,
+          onClick: () => {
+            void (async () => {
+              const input = buildSignatureInputFromProfile({
+                profile: {
+                  username: profile.username,
+                  displayName: profile.displayName,
+                  avatarUrl: profile.avatarUrl,
+                  genres: profile.genres,
+                  location: profile.location,
+                },
+                socials: profile.socialLinks?.map(link => ({
+                  label: link.displayText ?? link.platform,
+                  url: link.url,
+                })),
+              });
+              if (!input) {
+                toast.error('Unable to build signature');
+                return;
+              }
+              const { html } = buildEmailSignature(input);
+              const ok = await copyToClipboard(html);
+              if (ok) {
+                toast.success('Email signature copied');
+              } else {
+                toast.error('Failed to copy email signature');
+              }
+            })();
+          },
+        }
+      );
+
+      if (openEmailSignatureDialog) {
+        items.push({
+          id: 'preview-email-signature',
+          label: 'Email signature…',
+          icon: <FileSignature className='h-3.5 w-3.5' />,
+          onClick: () => {
+            openEmailSignatureDialog(profile);
+          },
+        });
+      }
+
       // Copy claim link & Send invite (if unclaimed and has claim token)
       const claimToken = 'claimToken' in profile ? profile.claimToken : null;
       if (!profile.isClaimed && claimToken) {
@@ -224,6 +278,7 @@ export function useContextMenuItems({
       toggleMarketing,
       openDeleteDialog,
       openInviteDialog,
+      openEmailSignatureDialog,
     ]
   );
 

--- a/apps/web/components/features/dashboard/molecules/EmailSignatureDialog.tsx
+++ b/apps/web/components/features/dashboard/molecules/EmailSignatureDialog.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { Button } from '@jovie/ui';
+import { Check, Copy } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { Dialog, DialogBody, DialogTitle } from '@/components/organisms/Dialog';
+import { copyToClipboard } from '@/hooks/useClipboard';
+import {
+  buildEmailSignature,
+  type EmailSignatureInput,
+} from '@/lib/email-signature/build-signature';
+
+type CopyKind = 'html' | 'text';
+
+interface EmailSignatureDialogProps {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly input: EmailSignatureInput | null;
+}
+
+function buildPreviewDocument(signatureHtml: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><base target="_blank"><style>html,body{margin:0;padding:16px;background:transparent;color:#0d0e12;}img{max-width:100%;}</style></head><body>${signatureHtml}</body></html>`;
+}
+
+export function EmailSignatureDialog({
+  open,
+  onClose,
+  input,
+}: EmailSignatureDialogProps) {
+  const signature = useMemo(
+    () => (input ? buildEmailSignature(input) : null),
+    [input]
+  );
+  const previewSrcDoc = useMemo(
+    () => (signature ? buildPreviewDocument(signature.html) : null),
+    [signature]
+  );
+  const [recentCopy, setRecentCopy] = useState<CopyKind | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setRecentCopy(null);
+      return;
+    }
+    if (recentCopy === null) return;
+    const timeout = setTimeout(() => setRecentCopy(null), 1800);
+    return () => clearTimeout(timeout);
+  }, [open, recentCopy]);
+
+  const handleCopy = async (kind: CopyKind) => {
+    if (!signature) return;
+    const payload = kind === 'html' ? signature.html : signature.text;
+    const ok = await copyToClipboard(payload);
+    if (ok) {
+      setRecentCopy(kind);
+      toast.success(
+        kind === 'html'
+          ? 'Email signature copied'
+          : 'Plain text signature copied'
+      );
+    } else {
+      toast.error('Failed to copy signature');
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} size='2xl'>
+      <DialogTitle>Email signature</DialogTitle>
+      <DialogBody className='space-y-4'>
+        <p className='text-xs text-tertiary-token'>
+          Paste this into Gmail, Apple Mail, or Outlook. Every email becomes a
+          link back to the Jovie profile.
+        </p>
+        <div className='overflow-hidden rounded-md border border-subtle bg-surface-0'>
+          {previewSrcDoc ? (
+            <iframe
+              data-testid='email-signature-preview'
+              title='Email signature preview'
+              sandbox=''
+              srcDoc={previewSrcDoc}
+              className='block h-48 w-full border-0 bg-white'
+            />
+          ) : (
+            <p className='p-4 text-xs text-tertiary-token'>
+              Profile data is unavailable. Please retry once the profile loads.
+            </p>
+          )}
+        </div>
+        <div className='flex flex-wrap items-center justify-end gap-2'>
+          <Button
+            type='button'
+            variant='secondary'
+            size='sm'
+            disabled={!signature}
+            onClick={() => {
+              void handleCopy('text');
+            }}
+          >
+            {recentCopy === 'text' ? (
+              <Check className='size-3' />
+            ) : (
+              <Copy className='size-3' />
+            )}
+            Copy as plain text
+          </Button>
+          <Button
+            type='button'
+            variant='primary'
+            size='sm'
+            disabled={!signature}
+            onClick={() => {
+              void handleCopy('html');
+            }}
+          >
+            {recentCopy === 'html' ? (
+              <Check className='size-3' />
+            ) : (
+              <Copy className='size-3' />
+            )}
+            Copy HTML
+          </Button>
+        </div>
+      </DialogBody>
+    </Dialog>
+  );
+}

--- a/apps/web/components/features/dashboard/molecules/useEmailSignatureMenuAction.tsx
+++ b/apps/web/components/features/dashboard/molecules/useEmailSignatureMenuAction.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { Mail } from 'lucide-react';
+import { type ReactNode, useCallback, useMemo, useState } from 'react';
+import type { DrawerHeaderAction } from '@/components/molecules/drawer-header/DrawerHeaderActions';
+import type { EmailSignatureInput } from '@/lib/email-signature/build-signature';
+import { EmailSignatureDialog } from './EmailSignatureDialog';
+
+interface UseEmailSignatureMenuActionResult {
+  readonly action: DrawerHeaderAction;
+  readonly modal: ReactNode;
+  readonly open: () => void;
+}
+
+/**
+ * Returns an overflow-menu action + the modal element that opens when the
+ * action is selected. Render `modal` somewhere in the same tree so the
+ * preview dialog can mount.
+ */
+export function useEmailSignatureMenuAction(
+  input: EmailSignatureInput | null
+): UseEmailSignatureMenuActionResult {
+  const [isOpen, setIsOpen] = useState(false);
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  const action = useMemo<DrawerHeaderAction>(
+    () => ({
+      id: 'email-signature',
+      label: 'Email signature',
+      icon: Mail,
+      disabled: input === null,
+      onClick: open,
+    }),
+    [input, open]
+  );
+
+  const modal = (
+    <EmailSignatureDialog open={isOpen} onClose={close} input={input} />
+  );
+
+  return { action, modal, open };
+}

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
@@ -25,8 +25,10 @@ import { useProfileHeaderParts } from '@/components/organisms/profile-sidebar/Pr
 import { BASE_URL } from '@/constants/domains';
 import { APP_ROUTES } from '@/constants/routes';
 import { ProfilePaySurface } from '@/features/dashboard/molecules/ProfilePaySurface';
+import { useEmailSignatureMenuAction } from '@/features/dashboard/molecules/useEmailSignatureMenuAction';
 import { getPlatformCategory } from '@/features/dashboard/organisms/links/utils/platform-category';
 import { LINEAR_SURFACE } from '@/features/dashboard/tokens';
+import { buildSignatureInputFromProfile } from '@/lib/email-signature/profile-input';
 import {
   useDeletePressPhotoMutation,
   useDspMatchesQuery,
@@ -632,12 +634,38 @@ export function ProfileContactSidebar() {
   );
 
   // Header parts hook needs to be called unconditionally
-  const { overflowActions } = useProfileHeaderParts({
+  const { overflowActions: baseOverflowActions } = useProfileHeaderParts({
     username: previewData?.username ?? '',
     displayName: previewData?.displayName ?? '',
     profilePath: previewData?.profilePath ?? '',
     onClose: close,
   });
+
+  const emailSignatureInput = useMemo(
+    () =>
+      previewData?.username
+        ? buildSignatureInputFromProfile({
+            profile: {
+              username: previewData.username,
+              displayName: previewData.displayName,
+              avatarUrl: previewData.avatarUrl,
+              genres: previewData.genres,
+              location: previewData.location,
+            },
+            socials: previewData.links.map(link => ({
+              label: link.title,
+              url: link.url,
+            })),
+          })
+        : null,
+    [previewData]
+  );
+  const { action: emailSignatureAction, modal: emailSignatureModal } =
+    useEmailSignatureMenuAction(emailSignatureInput);
+  const overflowActions = useMemo(
+    () => [...baseOverflowActions, emailSignatureAction],
+    [baseOverflowActions, emailSignatureAction]
+  );
 
   // Show skeleton sidebar until preview data loads (prevents CLS)
   if (!previewData) {
@@ -648,6 +676,7 @@ export function ProfileContactSidebar() {
         headerMode='minimal'
         hideMinimalHeaderBar
       >
+        {emailSignatureModal}
         <div className='space-y-2.5 pt-0.5'>
           <div className='space-y-2.5 p-3'>
             <div className='grid grid-cols-2 gap-3'>
@@ -718,6 +747,7 @@ export function ProfileContactSidebar() {
         />
       }
     >
+      {emailSignatureModal}
       <DrawerTabbedCard
         testId='profile-contact-tabbed-card'
         className='mt-2.5'

--- a/apps/web/lib/email-signature/build-signature.ts
+++ b/apps/web/lib/email-signature/build-signature.ts
@@ -13,12 +13,19 @@ export interface EmailSignatureSocial {
   readonly url: string;
 }
 
+export interface EmailSignatureRelease {
+  readonly title: string;
+  readonly url: string;
+  readonly artworkUrl?: string | null;
+}
+
 export interface EmailSignatureInput {
   readonly name: string;
   readonly handle: string;
   readonly tagline?: string | null;
   readonly avatarUrl?: string | null;
   readonly socials?: ReadonlyArray<EmailSignatureSocial>;
+  readonly latestRelease?: EmailSignatureRelease | null;
   readonly hideJovieBranding?: boolean;
 }
 
@@ -31,7 +38,7 @@ const FONT_STACK =
   "-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif";
 
 const UTM_FOOTER_SUFFIX =
-  '?utm_source=email_signature&utm_medium=footer&utm_campaign=get_yours';
+  '?utm_source=email_signature&utm_medium=referral&utm_campaign=branding';
 
 function escapeHtml(value: string): string {
   return value
@@ -63,8 +70,29 @@ function sanitizeSocials(
     .filter(social => social.label && isSafeHttpsUrl(social.url));
 }
 
+function sanitizeRelease(
+  release: EmailSignatureRelease | null | undefined
+): EmailSignatureRelease | null {
+  if (!release) return null;
+  const title = release.title.trim();
+  const url = release.url.trim();
+  if (!title || !isSafeHttpsUrl(url)) return null;
+  const artworkUrl =
+    release.artworkUrl && isSafeHttpsUrl(release.artworkUrl)
+      ? release.artworkUrl
+      : null;
+  return { title, url, artworkUrl };
+}
+
 function buildProfileUrl(handle: string): string {
   return `${BASE_URL}/${encodeURIComponent(handle)}`;
+}
+
+function renderReleaseRow(release: EmailSignatureRelease): string {
+  const artwork = release.artworkUrl
+    ? `<td style="padding-right:10px;vertical-align:middle;width:48px;"><a href="${escapeHtml(release.url)}" style="text-decoration:none;"><img src="${escapeHtml(release.artworkUrl)}" width="48" height="48" alt="${escapeHtml(release.title)} artwork" style="display:block;border:0;border-radius:6px;width:48px;height:48px;object-fit:cover;"/></a></td>`
+    : '';
+  return `<tr><td colspan="2" style="padding-top:10px;"><table cellpadding="0" cellspacing="0" border="0" role="presentation"><tr>${artwork}<td style="vertical-align:middle;"><div style="font-size:12px;color:#525866;line-height:1.4;">Latest release</div><div style="font-size:13px;color:#0d0e12;font-weight:500;line-height:1.4;">${escapeHtml(release.title)}</div><div style="margin-top:2px;"><a href="${escapeHtml(release.url)}" style="color:#3b5bdb;text-decoration:none;font-size:12px;">Stream now &rarr;</a></div></td></tr></table></td></tr>`;
 }
 
 export function buildEmailSignature(
@@ -76,17 +104,18 @@ export function buildEmailSignature(
   const avatarUrl =
     input.avatarUrl && isSafeHttpsUrl(input.avatarUrl) ? input.avatarUrl : null;
   const socials = sanitizeSocials(input.socials);
+  const release = sanitizeRelease(input.latestRelease);
   const showFooter = input.hideJovieBranding !== true;
 
   const profileUrl = buildProfileUrl(handle);
   const profileUrlDisplay = `${HOSTNAME}/${handle}`;
 
   const avatarCell = avatarUrl
-    ? `<td style="padding-right:12px;vertical-align:top;"><img src="${escapeHtml(avatarUrl)}" width="56" height="56" alt="${escapeHtml(name)}" style="display:block;border:0;border-radius:28px;width:56px;height:56px;object-fit:cover;"/></td>`
+    ? `<td style="padding-right:12px;vertical-align:top;width:56px;"><img src="${escapeHtml(avatarUrl)}" width="56" height="56" alt="${escapeHtml(name)}" style="display:block;border:0;border-radius:28px;width:56px;height:56px;object-fit:cover;"/></td>`
     : '';
 
   const socialsLine = socials.length
-    ? `<div style="margin-top:4px;color:#525866;font-size:12px;">${socials
+    ? `<div style="margin-top:6px;color:#525866;font-size:12px;">${socials
         .map(
           social =>
             `<a href="${escapeHtml(social.url)}" style="color:#525866;text-decoration:none;">${escapeHtml(social.label)}</a>`
@@ -98,12 +127,14 @@ export function buildEmailSignature(
     ? `<div style="color:#525866;font-size:13px;line-height:1.45;">${escapeHtml(tagline)}</div>`
     : '';
 
+  const releaseRow = release ? renderReleaseRow(release) : '';
+
   const footerHref = `${BASE_URL}/${UTM_FOOTER_SUFFIX}`;
   const footer = showFooter
-    ? `<tr><td colspan="2" style="padding-top:8px;font-size:11px;color:#8b94a3;">Get yours at <a href="${escapeHtml(footerHref)}" style="color:#8b94a3;text-decoration:none;">${HOSTNAME}</a></td></tr>`
+    ? `<tr><td colspan="2" style="padding-top:10px;border-top:1px solid #e5e7eb;"><div style="padding-top:8px;font-size:11px;color:#8b94a3;">Get your free music link in bio &rarr; <a href="${escapeHtml(footerHref)}" style="color:#8b94a3;text-decoration:underline;">${HOSTNAME}</a></div></td></tr>`
     : '';
 
-  const html = `<table cellpadding="0" cellspacing="0" border="0" style="font-family:${FONT_STACK};color:#0d0e12;font-size:14px;line-height:1.4;"><tr>${avatarCell}<td style="vertical-align:top;"><div style="font-weight:600;font-size:15px;color:#0d0e12;">${escapeHtml(name)}</div>${taglineLine}<div style="margin-top:4px;"><a href="${escapeHtml(profileUrl)}" style="color:#3b5bdb;text-decoration:none;font-weight:500;">${escapeHtml(profileUrlDisplay)}</a></div>${socialsLine}</td></tr>${footer}</table>`;
+  const html = `<table cellpadding="0" cellspacing="0" border="0" role="presentation" style="font-family:${FONT_STACK};color:#0d0e12;font-size:14px;line-height:1.4;max-width:600px;"><tr>${avatarCell}<td style="vertical-align:top;"><div style="font-weight:600;font-size:16px;color:#0d0e12;">${escapeHtml(name)}</div>${taglineLine}<div style="margin-top:6px;"><a href="${escapeHtml(profileUrl)}" style="display:inline-block;color:#3b5bdb;text-decoration:none;font-weight:600;font-size:14px;">${escapeHtml(profileUrlDisplay)}</a></div>${socialsLine}</td></tr>${releaseRow}${footer}</table>`;
 
   const textLines = [name];
   if (tagline) textLines.push(tagline);
@@ -111,7 +142,12 @@ export function buildEmailSignature(
   if (socials.length) {
     textLines.push(socials.map(s => `${s.label}: ${s.url}`).join(' | '));
   }
-  if (showFooter) textLines.push(`Get yours at ${HOSTNAME}`);
+  if (release) {
+    textLines.push(`Latest release: ${release.title} — ${release.url}`);
+  }
+  if (showFooter) {
+    textLines.push(`Get your free music link in bio → ${HOSTNAME}`);
+  }
 
   return { html, text: textLines.join('\n') };
 }

--- a/apps/web/lib/email-signature/profile-input.ts
+++ b/apps/web/lib/email-signature/profile-input.ts
@@ -1,0 +1,81 @@
+/**
+ * Adapter helpers that turn the various profile shapes used in the dashboard
+ * into the `EmailSignatureInput` accepted by `buildEmailSignature`.
+ *
+ * Kept separate from the pure signature builder so the builder stays
+ * dependency-free and easy to test.
+ */
+
+import type {
+  EmailSignatureInput,
+  EmailSignatureSocial,
+} from './build-signature';
+
+interface ProfileLikeForSignature {
+  readonly username: string;
+  readonly displayName?: string | null;
+  readonly avatarUrl?: string | null;
+  readonly genres?: readonly string[] | null;
+  readonly location?: string | null;
+}
+
+interface SocialLinkLike {
+  readonly label: string;
+  readonly url: string;
+}
+
+function buildTagline(profile: ProfileLikeForSignature): string | undefined {
+  const segments: string[] = [];
+  const firstGenre = profile.genres?.find(g => g.trim().length > 0)?.trim();
+  if (firstGenre) {
+    segments.push(firstGenre);
+  }
+  const location = profile.location?.trim();
+  if (location) {
+    segments.push(location);
+  }
+  return segments.length ? segments.join(' • ') : undefined;
+}
+
+function dedupeSocials(
+  socials: ReadonlyArray<SocialLinkLike>
+): EmailSignatureSocial[] {
+  const seen = new Set<string>();
+  const result: EmailSignatureSocial[] = [];
+  for (const social of socials) {
+    const url = social.url.trim();
+    if (!url || seen.has(url)) continue;
+    seen.add(url);
+    result.push({ label: social.label.trim() || url, url });
+  }
+  return result;
+}
+
+export interface BuildSignatureInputFromProfileOptions {
+  readonly profile: ProfileLikeForSignature;
+  readonly socials?: ReadonlyArray<SocialLinkLike>;
+  readonly hideJovieBranding?: boolean;
+}
+
+/**
+ * Build the structured signature input from a profile + optional socials.
+ * Returns `null` when there isn't enough data to render a useful signature
+ * (no username/handle).
+ */
+export function buildSignatureInputFromProfile({
+  profile,
+  socials,
+  hideJovieBranding,
+}: BuildSignatureInputFromProfileOptions): EmailSignatureInput | null {
+  const handle = profile.username.trim();
+  if (!handle) return null;
+  const name = (profile.displayName?.trim() || handle).trim();
+  return {
+    name,
+    handle,
+    tagline: buildTagline(profile),
+    avatarUrl: profile.avatarUrl ?? null,
+    socials: socials ? dedupeSocials(socials) : undefined,
+    hideJovieBranding,
+  };
+}

--- a/apps/web/tests/unit/lib/email-signature/build-signature.test.ts
+++ b/apps/web/tests/unit/lib/email-signature/build-signature.test.ts
@@ -11,10 +11,10 @@ describe('buildEmailSignature', () => {
 
     expect(html).toContain('Deadmau5');
     expect(html).toContain('jov.ie/deadmau5');
-    expect(html).toContain('Get yours at');
+    expect(html).toContain('Get your free music link in bio');
     expect(text).toContain('Deadmau5');
     expect(text).toContain('jov.ie/deadmau5');
-    expect(text).toContain('Get yours at');
+    expect(text).toContain('Get your free music link in bio');
   });
 
   it('HTML-escapes interpolated values', () => {
@@ -74,13 +74,72 @@ describe('buildEmailSignature', () => {
       handle: 'a',
       hideJovieBranding: true,
     });
-    expect(html).not.toContain('Get yours at');
-    expect(text).not.toContain('Get yours at');
+    expect(html).not.toContain('Get your free music link in bio');
+    expect(text).not.toContain('Get your free music link in bio');
   });
 
-  it('includes UTM params on the footer link', () => {
+  it('includes branding UTM params on the footer link', () => {
     const { html } = buildEmailSignature({ name: 'A', handle: 'a' });
     expect(html).toContain('utm_source=email_signature');
-    expect(html).toContain('utm_medium=footer');
+    expect(html).toContain('utm_medium=referral');
+    expect(html).toContain('utm_campaign=branding');
+  });
+
+  it('renders a latest release row when https URL is provided', () => {
+    const { html, text } = buildEmailSignature({
+      name: 'A',
+      handle: 'a',
+      latestRelease: {
+        title: 'New Single',
+        url: 'https://open.spotify.com/track/abc',
+        artworkUrl: 'https://cdn.example.com/art.png',
+      },
+    });
+    expect(html).toContain('Latest release');
+    expect(html).toContain('New Single');
+    expect(html).toContain('Stream now');
+    expect(html).toContain('https://cdn.example.com/art.png');
+    expect(text).toContain('New Single');
+    expect(text).toContain('https://open.spotify.com/track/abc');
+  });
+
+  it('drops a release with an insecure URL', () => {
+    const { html } = buildEmailSignature({
+      name: 'A',
+      handle: 'a',
+      latestRelease: {
+        title: 'Insecure Single',
+        url: 'http://bad.example/track',
+      },
+    });
+    expect(html).not.toContain('Insecure Single');
+    expect(html).not.toContain('Latest release');
+  });
+
+  it('renders release without artwork when artworkUrl is missing or insecure', () => {
+    const { html } = buildEmailSignature({
+      name: 'A',
+      handle: 'a',
+      latestRelease: {
+        title: 'Bare Single',
+        url: 'https://open.spotify.com/track/xyz',
+        artworkUrl: 'http://bad.example/art.png',
+      },
+    });
+    expect(html).toContain('Bare Single');
+    expect(html).not.toContain('http://bad.example/art.png');
+  });
+
+  it('produces table-only HTML with no flexbox/grid/style blocks', () => {
+    const { html } = buildEmailSignature({
+      name: 'A',
+      handle: 'a',
+      avatarUrl: 'https://cdn.example.com/a.png',
+      socials: [{ label: 'IG', url: 'https://instagram.com/a' }],
+    });
+    expect(html).toContain('<table');
+    expect(html).not.toContain('<style');
+    expect(html).not.toMatch(/display\s*:\s*(flex|grid)/);
+    expect(html).not.toContain('--');
   });
 });

--- a/apps/web/tests/unit/lib/email-signature/profile-input.test.ts
+++ b/apps/web/tests/unit/lib/email-signature/profile-input.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildSignatureInputFromProfile } from '@/lib/email-signature/profile-input';
+
+describe('buildSignatureInputFromProfile', () => {
+  it('returns null when the username is empty', () => {
+    expect(
+      buildSignatureInputFromProfile({
+        profile: { username: '   ' },
+      })
+    ).toBeNull();
+  });
+
+  it('falls back to the handle when displayName is missing', () => {
+    const input = buildSignatureInputFromProfile({
+      profile: { username: 'deadmau5' },
+    });
+    expect(input).toMatchObject({ name: 'deadmau5', handle: 'deadmau5' });
+  });
+
+  it('joins genre + location into a tagline', () => {
+    const input = buildSignatureInputFromProfile({
+      profile: {
+        username: 'a',
+        displayName: 'Artist A',
+        genres: ['', 'House'],
+        location: 'Berlin',
+      },
+    });
+    expect(input?.tagline).toBe('House • Berlin');
+  });
+
+  it('omits tagline when no genre or location is available', () => {
+    const input = buildSignatureInputFromProfile({
+      profile: { username: 'a', displayName: 'A' },
+    });
+    expect(input?.tagline).toBeUndefined();
+  });
+
+  it('dedupes social links by URL and labels with platform when label is missing', () => {
+    const input = buildSignatureInputFromProfile({
+      profile: { username: 'a' },
+      socials: [
+        { label: 'Instagram', url: 'https://instagram.com/a' },
+        { label: '', url: 'https://spotify.com/a' },
+        { label: 'Instagram (dup)', url: 'https://instagram.com/a' },
+      ],
+    });
+    expect(input?.socials).toHaveLength(2);
+    expect(input?.socials?.[0]).toEqual({
+      label: 'Instagram',
+      url: 'https://instagram.com/a',
+    });
+    expect(input?.socials?.[1]).toEqual({
+      label: 'https://spotify.com/a',
+      url: 'https://spotify.com/a',
+    });
+  });
+
+  it('passes through hideJovieBranding when set', () => {
+    const input = buildSignatureInputFromProfile({
+      profile: { username: 'a' },
+      hideJovieBranding: true,
+    });
+    expect(input?.hideJovieBranding).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Generates a polished, table-based HTML email signature for any artist profile. Adds two entry points (admin context menu + dashboard profile drawer overflow) and a sandboxed preview dialog with copy-as-HTML / copy-as-plain-text actions.

## What changed

- `lib/email-signature/build-signature.ts` — render a 600px-wide, table-only signature with: avatar, name, optional tagline, prominent `jov.ie/handle` CTA, dedup'd social row, optional latest-release row (artwork + Stream now), and a "Get your free music link in bio" footer with branding UTM params (`utm_source=email_signature`, `utm_medium=referral`, `utm_campaign=branding`). `hideJovieBranding=true` strips the footer. All interpolated values are HTML-escaped; only `https://` URLs survive sanitization for avatar/social/release art.
- `lib/email-signature/profile-input.ts` — adapter that turns dashboard/admin profile shapes into the builder's input (joins genre + location into the tagline, dedupes socials by URL, falls back to handle when displayName is empty).
- `components/features/dashboard/molecules/EmailSignatureDialog.tsx` — Dialog + sandboxed iframe preview with Copy HTML and Copy as plain text buttons (toast feedback on each).
- `components/features/dashboard/molecules/useEmailSignatureMenuAction.tsx` — Hook returning a `DrawerHeaderAction` plus the modal element so any drawer-style overflow menu can drop in the entry.
- Admin creator-profiles context menu (`useContextMenuItems.tsx` + `AdminCreatorProfilesUnified.tsx`) — adds "Copy email signature" (one-click HTML copy) and "Email signature…" (preview modal).
- Dashboard `ProfileContactSidebar` overflow menu — picks up the same preview-modal entry so the logged-in artist can grab their signature.
- Vitest coverage for both `buildEmailSignature` (10 tests) and `buildSignatureInputFromProfile` (6 tests).

## Acceptance criteria coverage

- [x] Context menu on artist sidebar includes "Copy email signature"
- [x] Actions menu on artist profile includes "Email signature" option (admin sidebar + dashboard profile drawer)
- [x] Preview modal renders the full signature before copy (sandboxed iframe)
- [x] "Copy HTML" and "Copy as plain text" options in the modal
- [x] Signature includes photo, name, tagline (genre/location), prominent jov.ie link, social row, optional latest release
- [x] Branding footer respects `hideJovieBranding`; UTM-tagged
- [x] Table-based HTML, inline CSS only, system font stack, HTTPS-only images
- [x] Toast confirmation on copy
- [x] Works for any artist (admin-side picks any creator; dashboard surfaces the logged-in user)

## Follow-ups (tracked in Linear)

- **JOV-2133** — Candidate: wire per-profile branding toggle into the signature (`hideJovieBranding` is supported by the builder but no profile-level toggle exists yet).
- **JOV-2134** — Candidate: wire latest-release row into the input adapter (`latestRelease` is supported by the builder but not yet sourced from profile data).
- **JOV-2135** — Candidate: PNG social-icon row to replace text labels (current v1 uses text separators).

## Test plan

- [x] \`pnpm --filter web exec vitest run tests/unit/lib/email-signature/\` — 16 tests pass
- [x] \`pnpm --filter @jovie/web run typecheck\` — clean
- [x] \`pnpm biome check\` on touched files — clean
- [ ] Manual QA: open admin creator-profiles, right-click a row → Copy email signature → paste into Gmail/Apple Mail
- [ ] Manual QA: open admin creator profile drawer → kebab → Email signature… → preview shows, both copies populate clipboard
- [ ] Manual QA: open dashboard profile drawer (logged-in user) → overflow menu → Email signature → preview + copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)