### PR TITLE
feat(onboarding): PR 2 — onboarding tools + system prompt + deterministic eval (JOV-2132)

### DIFF
--- a/apps/web/app/api/chat/onboarding-handler.ts
+++ b/apps/web/app/api/chat/onboarding-handler.ts
@@ -1,9 +1,18 @@
 import 'server-only';
 import { randomUUID } from 'node:crypto';
 import * as Sentry from '@sentry/nextjs';
+import type { UIMessage } from 'ai';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { executeChatTurn, isClientDisconnect } from '@/lib/chat/run';
+import {
+  buildOnboardingTools,
+  createOnboardingTurnState,
+} from '@/lib/chat/tools/onboarding-tool-impls';
+import type { ChatTelemetry } from '@/lib/chat/types';
+import { getEntitlements } from '@/lib/entitlements/registry';
 import { env, isSecureEnv } from '@/lib/env-server';
+import { checkGateForUser } from '@/lib/flags/server';
 import { createAuthenticatedCorsHeaders } from '@/lib/http/headers';
 import {
   encodeSessionCookie,
@@ -20,26 +29,42 @@ import {
 } from '@/lib/turnstile/verify';
 import { extractClientIPFromRequest } from '@/lib/utils/ip-extraction';
 
+/** Statsig kill-switch gate for the anonymous onboarding chat (JOV-2132). */
+const ONBOARDING_CHAT_GATE = 'onboarding_chat_v2';
+
+/** Maximum onboarding messages we accept in a single request payload. */
+const MAX_ONBOARDING_MESSAGES = 50;
+
+/** Maximum text length per onboarding message. */
+const MAX_ONBOARDING_MESSAGE_LENGTH = 4000;
+
 /**
- * Anonymous onboarding chat handler (JOV-2132 PR 1 — scaffolding).
+ * Anonymous onboarding chat handler (JOV-2132).
  *
- * Wires the request through the abuse-containment gates that PR 2's actual
- * LLM tools will run behind:
- *  1. Resolve or mint a signed onboarding session cookie.
- *  2. Resolve IP + ASN from request headers.
- *  3. Verify a Cloudflare Turnstile token on the first message of the session.
- *  4. Apply IP + ASN + session-lifetime rate limits.
- *  5. Return 501 Not Implemented (real LLM dispatch lands in PR 2).
+ * Gate chain (in order):
+ *  1. Statsig kill-switch `onboarding_chat_v2` — return 503 if disabled.
+ *  2. Resolve or mint a signed onboarding session cookie.
+ *  3. Resolve client IP (via trusted proxy header helper) + ASN.
+ *  4. Verify Cloudflare Turnstile token on the first message of a fresh
+ *     session. Fail-closed when unconfigured in non-dev envs.
+ *  5. Apply IP + ASN + session-lifetime rate limits.
+ *  6. Validate the UIMessage payload (length caps).
+ *  7. Dispatch `executeChatTurn` with `mode='onboarding'`, the onboarding
+ *     tool palette, and the Stanley-style system prompt. Stream the
+ *     UIMessage response back.
  *
  * Returns `null` when the request is not addressed to onboarding mode, so the
  * main `/api/chat` handler can fall through to the authenticated chat flow.
  */
 
-const TURNSTILE_VERIFIED_FLAG_PREFIX = 'anon_onb_chat_verified';
-
 const onboardingPayloadSchema = z.object({
   mode: z.literal('onboarding'),
   turnstileToken: z.string().max(2048).optional(),
+  /**
+   * UIMessage[] from the AI SDK client. Validated for shape elsewhere (message
+   * role + parts structure); we only enforce length caps here.
+   */
+  messages: z.array(z.unknown()).max(MAX_ONBOARDING_MESSAGES).optional(),
 });
 
 interface PeekedBody {
@@ -117,6 +142,27 @@ export async function tryHandleAnonymousOnboardingChat(
 
   Sentry.setTag('chat_mode', 'onboarding');
   Sentry.setTag('chat_anonymous', 'true');
+
+  // --- Statsig kill switch (onboarding_chat_v2) ---
+  // The whole onboarding surface is gated. When the gate evaluates to false
+  // (default OFF / kill-switch flipped) we return 503 so on-call sees a
+  // clean signal and we never quietly burn LLM spend during an incident.
+  // Anonymous → pass `null` userId; Statsig falls back to public conditions.
+  const onboardingEnabled = await checkGateForUser(
+    null,
+    ONBOARDING_CHAT_GATE,
+    false
+  );
+  if (!onboardingEnabled) {
+    return NextResponse.json(
+      {
+        error: 'Onboarding chat is temporarily unavailable',
+        errorCode: 'ONBOARDING_CHAT_DISABLED',
+        requestId,
+      },
+      { status: 503, headers: { ...corsHeaders, 'x-request-id': requestId } }
+    );
+  }
 
   // --- Session cookie: read existing or mint a new one ---
   const incomingCookieHeader = req.headers.get('cookie') || '';
@@ -226,44 +272,179 @@ export async function tryHandleAnonymousOnboardingChat(
     );
   }
 
-  // PR 1 scope ends here. PR 2 will replace this 501 with the actual
-  // executeChatTurn dispatch (Haiku-forced, onboarding tools wired in).
-  const response = NextResponse.json(
-    {
-      error: 'Onboarding chat not yet implemented',
-      message:
-        'Onboarding chat infrastructure landed in JOV-2132 PR 1; LLM tools land in PR 2.',
-      errorCode: 'NOT_IMPLEMENTED',
-      sessionId,
-      requestId,
-    },
-    {
-      status: 501,
-      headers: {
-        ...corsHeaders,
-        'x-request-id': requestId,
+  // --- Validate and shape the UIMessage payload ---
+  const rawMessages = (parsed.data.messages ?? []) as unknown[];
+  const messagesError = validateOnboardingMessages(rawMessages);
+  if (messagesError) {
+    return NextResponse.json(
+      {
+        error: messagesError,
+        errorCode: 'INVALID_MESSAGES',
+        requestId,
       },
-    }
-  );
-
-  if (mintedSessionCookie) {
-    response.cookies.set(ONBOARDING_SESSION_COOKIE_NAME, mintedSessionCookie, {
-      httpOnly: true,
-      secure: isSecureEnv(),
-      sameSite: 'lax',
-      path: '/',
-      maxAge: 60 * 60 * 24 * 7,
-    });
+      { status: 400, headers: { ...corsHeaders, 'x-request-id': requestId } }
+    );
   }
+  const uiMessages = rawMessages as UIMessage[];
+  const turnCount = uiMessages.filter(m => m.role === 'user').length;
 
-  Sentry.addBreadcrumb({
-    category: 'onboarding-chat',
-    message: 'anonymous_request_handled',
-    level: 'info',
-    data: { sessionMinted: !existingSessionId, asnPresent: Boolean(asn) },
-  });
+  // --- Build the per-turn state accumulator and the onboarding tool palette ---
+  const onboardingState = createOnboardingTurnState({ sessionId, turnCount });
+  const tools = buildOnboardingTools(onboardingState);
 
-  return response;
+  // --- Telemetry hooks (mirror authenticated chat) ---
+  const telemetry: ChatTelemetry = {
+    setTags: tags => {
+      try {
+        Sentry.setTags(tags);
+      } catch {}
+    },
+    setExtra: (key, value) => {
+      try {
+        Sentry.setExtra(key, value);
+      } catch {}
+    },
+    captureException: (error, context) => {
+      try {
+        Sentry.captureException(error, context);
+      } catch {}
+    },
+  };
+
+  // --- Dispatch the LLM turn ---
+  // Anonymous: no userId, no creator profile, no artist context. The free-tier
+  // entitlements are passed so the planLimits flags (aiCanUseTools, etc.) line
+  // up with what the LLM expects. forceLightModel keeps onboarding on Haiku
+  // until we have signal a real artist is on the other end — flipped via
+  // confirmSpotifyArtist + recordInterviewSignal in a follow-up commit.
+  const freeTierLimits = getEntitlements('free');
+  try {
+    const turn = await executeChatTurn({
+      uiMessages,
+      artistContext: null,
+      releases: [],
+      resolvedProfileId: null,
+      resolvedConversationId: null,
+      userId: null,
+      userPlan: 'free',
+      planLimits: freeTierLimits,
+      insightsEnabled: false,
+      // Haiku-forced for anonymous traffic. PR follow-up: allow Sonnet once
+      // confirmSpotifyArtist has resolved a verified or 1k+-follower artist.
+      forceLightModel: true,
+      tools,
+      signal: req.signal,
+      requestId,
+      telemetry,
+      mode: 'onboarding',
+    });
+
+    Sentry.addBreadcrumb({
+      category: 'onboarding-chat',
+      message: 'anonymous_dispatch',
+      level: 'info',
+      data: {
+        sessionMinted: !existingSessionId,
+        asnPresent: Boolean(asn),
+        turnCount,
+        selectedModel: turn.selectedModel,
+        toolCount: turn.toolNames.length,
+      },
+    });
+
+    const responseHeaders: Record<string, string> = {
+      ...corsHeaders,
+      'x-request-id': requestId,
+      'x-chat-mode': 'onboarding',
+    };
+    if (mintedSessionCookie) {
+      responseHeaders['set-cookie'] =
+        buildSessionCookieHeader(mintedSessionCookie);
+    }
+
+    return turn.streamResult.toUIMessageStreamResponse({
+      headers: responseHeaders,
+    });
+  } catch (error) {
+    if (isClientDisconnect(error, req.signal)) {
+      return new NextResponse(null, {
+        status: 499,
+        headers: { ...corsHeaders, 'x-request-id': requestId },
+      });
+    }
+    Sentry.captureException(error, {
+      tags: { feature: 'ai-chat', chat_mode: 'onboarding' },
+      extra: { sessionId: sessionId.slice(0, 8), requestId, turnCount },
+    });
+    return NextResponse.json(
+      {
+        error: 'Onboarding chat failed',
+        errorCode: 'INTERNAL_ERROR',
+        requestId,
+      },
+      {
+        status: 500,
+        headers: { ...corsHeaders, 'x-request-id': requestId },
+      }
+    );
+  }
+}
+
+/**
+ * Build the wire `set-cookie` header value for the onboarding session cookie.
+ * Used when `executeChatTurn`'s streaming response prevents us from using the
+ * `NextResponse.cookies.set` helper.
+ */
+function buildSessionCookieHeader(value: string): string {
+  const parts = [
+    `${ONBOARDING_SESSION_COOKIE_NAME}=${value}`,
+    'Path=/',
+    'HttpOnly',
+    'SameSite=Lax',
+    `Max-Age=${60 * 60 * 24 * 7}`,
+  ];
+  if (isSecureEnv()) parts.push('Secure');
+  return parts.join('; ');
+}
+
+/**
+ * Lightweight shape check for the UIMessage payload. We deliberately don't
+ * pull in the full `validateMessagesArray` from `/api/chat/route.ts` to keep
+ * this handler import-light — onboarding mode has stricter caps anyway.
+ */
+function validateOnboardingMessages(messages: unknown[]): string | null {
+  if (messages.length === 0) {
+    return 'messages array must be non-empty';
+  }
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (!msg || typeof msg !== 'object') {
+      return `messages[${i}] must be an object`;
+    }
+    const m = msg as { role?: unknown; parts?: unknown };
+    if (m.role !== 'user' && m.role !== 'assistant' && m.role !== 'system') {
+      return `messages[${i}].role must be user/assistant/system`;
+    }
+    if (!Array.isArray(m.parts)) {
+      return `messages[${i}].parts must be an array`;
+    }
+    for (const part of m.parts) {
+      if (
+        part &&
+        typeof part === 'object' &&
+        (part as { type?: unknown }).type === 'text'
+      ) {
+        const text = (part as { text?: unknown }).text;
+        if (
+          typeof text === 'string' &&
+          text.length > MAX_ONBOARDING_MESSAGE_LENGTH
+        ) {
+          return `messages[${i}] text part exceeds ${MAX_ONBOARDING_MESSAGE_LENGTH} chars`;
+        }
+      }
+    }
+  }
+  return null;
 }
 
 function parseCookieHeader(header: string): Map<string, string> {
@@ -286,6 +467,3 @@ function parseCookieHeader(header: string): Map<string, string> {
   }
   return map;
 }
-
-/** Exported for the Redis verification flag key prefix used in PR 2 follow-ups. */
-export { TURNSTILE_VERIFIED_FLAG_PREFIX };

--- a/apps/web/app/api/chat/onboarding-handler.ts
+++ b/apps/web/app/api/chat/onboarding-handler.ts
@@ -411,37 +411,52 @@ function buildSessionCookieHeader(value: string): string {
  * Lightweight shape check for the UIMessage payload. We deliberately don't
  * pull in the full `validateMessagesArray` from `/api/chat/route.ts` to keep
  * this handler import-light — onboarding mode has stricter caps anyway.
+ *
+ * Split into shape-and-parts helpers so SonarCloud's cognitive-complexity
+ * budget (15) is satisfied at each layer.
  */
 function validateOnboardingMessages(messages: unknown[]): string | null {
   if (messages.length === 0) {
     return 'messages array must be non-empty';
   }
   for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i];
-    if (!msg || typeof msg !== 'object') {
-      return `messages[${i}] must be an object`;
-    }
-    const m = msg as { role?: unknown; parts?: unknown };
-    if (m.role !== 'user' && m.role !== 'assistant' && m.role !== 'system') {
-      return `messages[${i}].role must be user/assistant/system`;
-    }
-    if (!Array.isArray(m.parts)) {
-      return `messages[${i}].parts must be an array`;
-    }
-    for (const part of m.parts) {
-      if (
-        part &&
-        typeof part === 'object' &&
-        (part as { type?: unknown }).type === 'text'
-      ) {
-        const text = (part as { text?: unknown }).text;
-        if (
-          typeof text === 'string' &&
-          text.length > MAX_ONBOARDING_MESSAGE_LENGTH
-        ) {
-          return `messages[${i}] text part exceeds ${MAX_ONBOARDING_MESSAGE_LENGTH} chars`;
-        }
-      }
+    const shapeError = validateMessageShape(messages[i], i);
+    if (shapeError) return shapeError;
+    // shape check guarantees parts is an array
+    const parts = (messages[i] as { parts: unknown[] }).parts;
+    const partsError = validateTextPartLengths(parts, i);
+    if (partsError) return partsError;
+  }
+  return null;
+}
+
+function validateMessageShape(msg: unknown, index: number): string | null {
+  if (!msg || typeof msg !== 'object') {
+    return `messages[${index}] must be an object`;
+  }
+  const m = msg as { role?: unknown; parts?: unknown };
+  if (m.role !== 'user' && m.role !== 'assistant' && m.role !== 'system') {
+    return `messages[${index}].role must be user/assistant/system`;
+  }
+  if (!Array.isArray(m.parts)) {
+    return `messages[${index}].parts must be an array`;
+  }
+  return null;
+}
+
+function validateTextPartLengths(
+  parts: unknown[],
+  messageIndex: number
+): string | null {
+  for (const part of parts) {
+    if (!part || typeof part !== 'object') continue;
+    if ((part as { type?: unknown }).type !== 'text') continue;
+    const text = (part as { text?: unknown }).text;
+    if (
+      typeof text === 'string' &&
+      text.length > MAX_ONBOARDING_MESSAGE_LENGTH
+    ) {
+      return `messages[${messageIndex}] text part exceeds ${MAX_ONBOARDING_MESSAGE_LENGTH} chars`;
     }
   }
   return null;

--- a/apps/web/lib/chat/prompts/onboarding.ts
+++ b/apps/web/lib/chat/prompts/onboarding.ts
@@ -1,0 +1,88 @@
+/**
+ * Onboarding chat system prompt (JOV-2132 PR 2).
+ *
+ * Inspired by Stanley-style onboarding conversations. The goal: make a real
+ * artist feel SEEN within 30 seconds, then build their profile through
+ * conversation rather than form fields. Tool widgets do deterministic work
+ * (Spotify search, handle check, social link adds); the LLM holds the
+ * conversation around them.
+ *
+ * This prompt is paired with the onboarding tool set in tool-schemas.ts.
+ * It is NOT used in authenticated chat mode — that has its own prompt.
+ *
+ * To iterate: replay real transcripts, identify drift, refine the rules
+ * below. Keep this file under ~150 lines so a human can scan it in one pass.
+ */
+
+export const ONBOARDING_SYSTEM_PROMPT = `You are Jovie, an AI guide helping musicians set up their Jovie profile in a single conversation. The visitor is unauthenticated — they have no account yet. By the end of this conversation, if they qualify, they will sign up and check out; if they don't, they go on the waitlist.
+
+# Voice
+
+Confident, warm, sharp. Not customer-service polite. Not over-eager. Not LinkedIn-bro. You sound like a sharp friend who happens to work at a music tech company and is genuinely excited to set someone up. Short messages. Real punctuation. No emoji. No "Awesome!" / "Great question!" / "Absolutely!" — say what you mean.
+
+Speak like you would in iMessage to a peer. Lowercase is fine. No bullet lists, no headers, no markdown. Just sentences.
+
+# Hard rules
+
+- One question per turn. Never two. Never a "first, ... then, ..." sequence.
+- Never list "next steps" or "here's what we'll do." Just do the next thing.
+- Never say "I'll" + future tense for things a tool does. Call the tool.
+- Never describe the UI. The widgets are doing that work. You name the moment, not the mechanism.
+- Never claim a profile is "live" or "set up" until the user has actually signed up and the conversation has been claimed onto their account.
+- Never invent stats, claims, or pricing. If asked something you don't know, say "I don't actually know — let me find out" and stop. Don't bullshit.
+- Don't promise instant access. The server decides via \`proposeNextStep\` — you trigger the evaluation, you don't predict it.
+
+# Goals, in order
+
+1. Make them feel seen in under 30 seconds via the Spotify pick. Lead with \`searchSpotifyArtist\` on the first turn that signals they're a musician — even if they haven't told you their name yet, the picker lets them type. The moment you have \`confirmSpotifyArtist\` resolved, the profile preview slides in and that's the wow moment.
+2. Mom-test their current workflow with ONE open question. What are they cooking right now? What's annoying about how they handle it today? Use \`recordInterviewSignal\` to log the answer silently. Do not turn this into a survey — one question, listen.
+3. Build tangible profile. \`checkHandle\` for the @, \`proposeSocialLink\` for one social. The profile preview gains pieces as tools resolve.
+4. Qualify. After step 2 and 3 you typically have enough signal. Call \`proposeNextStep\` and the server decides: instant access, waitlist, or one more question.
+5. Land the next step. If instant_access: \`proposeCheckout\`. If waitlist: render the confirmation card and tell them what comes next, no more questions.
+
+# When to call which tool
+
+- First turn user mentions music → \`searchSpotifyArtist\` (query empty or pre-filled if they named themselves)
+- User picks a Spotify artist → \`confirmSpotifyArtist\` (do not ask "is that you?" — they just picked it)
+- After artist confirmed → ask the one mom-test question
+- User answers the mom-test question → \`recordInterviewSignal\` with everything you learned
+- User has chosen a handle in conversation → \`checkHandle\`
+- Handle is available + you have at least one social → \`proposeNextStep\`
+- proposeNextStep returns instant_access → \`proposeCheckout\`
+- proposeNextStep returns waitlist → render confirmation, stop asking questions
+- proposeNextStep returns needs_more_info → ask one more sharp question, then call proposeNextStep again
+
+# Handling meta-questions inline
+
+When the visitor asks "what is this?" / "how much does it cost?" / "why should I trust you?" — answer briefly (one or two sentences) and return to the flow. Don't break into a sales pitch. Pricing summary: free tier exists; paid plans start at $39/mo for Pro and $149/mo for Max with a 14-day reverse trial. If they ask deeper pricing questions, name those numbers and offer the checkout when they're ready. Never invent fan counts, customer counts, or testimonials.
+
+# Objection handling
+
+When they push back, log the objection via \`recordInterviewSignal\` (objection field) and address it concretely. Examples:
+- "I already use Linktree" → "Same idea but Jovie pulls your Spotify monthly listeners and latest release in. You don't have to maintain the bio." (then keep going)
+- "Why should I pay?" → "Free is fine if you just want the link page. Pro is for the smart notifications and the release page that updates itself."
+- Trust / brand-unknown → "Fair. Want to keep it free for now and upgrade if it earns it?"
+
+If an objection genuinely kills the conversation, don't fight it. Thank them and surface the waitlist card via proposeNextStep — let the deterministic eval decide.
+
+# Privacy disclosure
+
+The FIRST chat bubble (your opener) must include a one-line disclosure that the conversation is remembered to help personalize, e.g. "Heads up — I'll remember this chat so I can pick up where we left off when you sign up." Don't make it heavy.
+
+# What you sound like (examples)
+
+GOOD (opener):
+"hey — I'm Jovie. heads up, I'll remember this chat so we can pick up where we left off when you sign up. what are you working on right now?"
+
+GOOD (after Spotify pick):
+"got you. 47k monthly listeners on Spotify — your last release dropped two weeks ago, right? what's the most annoying part of running your bio link / fan page today?"
+
+BAD (do not):
+"Hi! 😊 I'm Jovie, your AI music assistant! I'm here to help you create your perfect profile. Let's get started by finding you on Spotify! First, I'll need to ask you a few quick questions..."
+
+GOOD (waitlist):
+"got it. let me put you on the early-access list — I'll email you when you're up. we can pick up right where we left off."
+
+# Ending the conversation
+
+When the user accepts checkout OR the waitlist card renders, you do not need to send another message. The widgets close the loop. If the user wants to keep chatting after sign-up, they will be in the authenticated app and talking to a different system prompt.`;

--- a/apps/web/lib/chat/run.ts
+++ b/apps/web/lib/chat/run.ts
@@ -7,6 +7,7 @@ import {
   type UIMessage,
 } from 'ai';
 import { selectKnowledgeContext } from '@/lib/chat/knowledge/router';
+import { ONBOARDING_SYSTEM_PROMPT } from '@/lib/chat/prompts/onboarding';
 import { buildSystemPrompt } from '@/lib/chat/system-prompt';
 import type {
   ArtistContext,
@@ -98,24 +99,39 @@ export function selectKnowledgeContextForTurn(uiMessages: UIMessage[]): string {
 
 export interface ExecuteChatTurnInput {
   uiMessages: UIMessage[];
-  artistContext: ArtistContext;
+  /**
+   * Required for `mode='app'` (authenticated artist chat). Ignored when
+   * `mode='onboarding'` — the anonymous visitor has no creator profile yet.
+   */
+  artistContext: ArtistContext | null;
   releases: ReleaseContext[];
+  /** Internal creator-profile UUID. Null when anonymous (`mode='onboarding'`). */
   resolvedProfileId: string | null;
   resolvedConversationId: string | null;
-  userId: string;
+  /** Clerk user id. Null when anonymous (`mode='onboarding'`). */
+  userId: string | null;
   userPlan: string;
   planLimits: EntitlementsForPlan;
   insightsEnabled: boolean;
   forceLightModel: boolean;
   /**
    * Pre-built tools for the turn. The caller composes free + paid tool sets
-   * based on plan and feature flags before invoking.
+   * based on plan and feature flags before invoking. For `mode='onboarding'`,
+   * the caller passes the ONBOARDING_TOOLS palette.
    */
   tools: ToolSet;
   signal: AbortSignal;
   requestId: string;
   /** Telemetry hooks (Sentry in prod, no-op in eval/tests). */
   telemetry?: ChatTelemetry;
+  /**
+   * Mode discriminator (JOV-2132). `'app'` is the existing authenticated
+   * artist chat path; `'onboarding'` is the anonymous /start visitor flow
+   * that uses the Stanley-style ONBOARDING_SYSTEM_PROMPT, skips knowledge
+   * context, and never reads artistContext. Default `'app'` keeps existing
+   * callers behaviour-stable.
+   */
+  mode?: 'app' | 'onboarding';
 }
 
 export interface ExecuteChatTurnResult {
@@ -164,16 +180,23 @@ export async function executeChatTurn(
     requestId,
     resolvedProfileId,
     telemetry,
+    mode = 'app',
   } = input;
 
-  const knowledgeContext = selectKnowledgeContextForTurn(uiMessages);
-
-  const systemPrompt = buildSystemPrompt(artistContext, releases, {
-    aiCanUseTools: planLimits.booleans.aiCanUseTools,
-    aiDailyMessageLimit: planLimits.limits.aiDailyMessageLimit,
-    insightsEnabled,
-    knowledgeContext: knowledgeContext || undefined,
-  });
+  // Onboarding mode swaps in the Stanley-style prompt and skips the
+  // music-industry knowledge context (which is keyed on the artist's profile,
+  // not relevant pre-account). Authenticated `mode='app'` keeps the existing
+  // buildSystemPrompt path so this refactor is behaviour-stable for in-app chat.
+  const systemPrompt =
+    mode === 'onboarding'
+      ? ONBOARDING_SYSTEM_PROMPT
+      : buildSystemPrompt(artistContext as ArtistContext, releases, {
+          aiCanUseTools: planLimits.booleans.aiCanUseTools,
+          aiDailyMessageLimit: planLimits.limits.aiDailyMessageLimit,
+          insightsEnabled,
+          knowledgeContext:
+            selectKnowledgeContextForTurn(uiMessages) || undefined,
+        });
 
   const modelMessages = await convertToModelMessages(uiMessages);
 

--- a/apps/web/lib/chat/run.ts
+++ b/apps/web/lib/chat/run.ts
@@ -187,16 +187,23 @@ export async function executeChatTurn(
   // music-industry knowledge context (which is keyed on the artist's profile,
   // not relevant pre-account). Authenticated `mode='app'` keeps the existing
   // buildSystemPrompt path so this refactor is behaviour-stable for in-app chat.
-  const systemPrompt =
-    mode === 'onboarding'
-      ? ONBOARDING_SYSTEM_PROMPT
-      : buildSystemPrompt(artistContext as ArtistContext, releases, {
-          aiCanUseTools: planLimits.booleans.aiCanUseTools,
-          aiDailyMessageLimit: planLimits.limits.aiDailyMessageLimit,
-          insightsEnabled,
-          knowledgeContext:
-            selectKnowledgeContextForTurn(uiMessages) || undefined,
-        });
+  let systemPrompt: string;
+  if (mode === 'onboarding') {
+    systemPrompt = ONBOARDING_SYSTEM_PROMPT;
+  } else {
+    // Runtime guard rather than a `as ArtistContext` cast — the type system
+    // can't express "non-null when mode='app'" without a discriminated union,
+    // and we'd rather fail fast at the entry than crash inside buildSystemPrompt.
+    if (!artistContext) {
+      throw new Error('artistContext is required when mode is "app"');
+    }
+    systemPrompt = buildSystemPrompt(artistContext, releases, {
+      aiCanUseTools: planLimits.booleans.aiCanUseTools,
+      aiDailyMessageLimit: planLimits.limits.aiDailyMessageLimit,
+      insightsEnabled,
+      knowledgeContext: selectKnowledgeContextForTurn(uiMessages) || undefined,
+    });
+  }
 
   const modelMessages = await convertToModelMessages(uiMessages);
 

--- a/apps/web/lib/chat/tool-schemas.ts
+++ b/apps/web/lib/chat/tool-schemas.ts
@@ -7,6 +7,7 @@
  */
 
 import { z } from 'zod';
+import { interviewSignalSchema } from './tools/onboarding-signals';
 
 // ---------------------------------------------------------------------------
 // Schema definitions (descriptions + Zod input schemas)
@@ -72,6 +73,75 @@ export const TOOL_SCHEMAS = {
         .describe('The feedback message from the artist'),
     }),
   },
+
+  // -------------------------------------------------------------------------
+  // Onboarding tools (JOV-2132 PR 2) — available only in mode='onboarding'.
+  // -------------------------------------------------------------------------
+
+  searchSpotifyArtist: {
+    description:
+      'Open the Spotify artist picker popout in the chat. Use this on the FIRST turn the visitor mentions being a musician/artist, or whenever you need to identify which artist they are. The widget calls /api/spotify/search and renders suggestion cards; pass the query if the visitor has already named themselves, otherwise leave it empty to let them type.',
+    inputSchema: z.object({
+      query: z
+        .string()
+        .max(200)
+        .optional()
+        .describe('Pre-fill search query (artist name or shorthand)'),
+    }),
+  },
+
+  confirmSpotifyArtist: {
+    description:
+      'Lock in the Spotify artist the visitor picked. This pulls full enrichment (avatar, name, monthly listeners, latest release, genres) and is the trigger for the profile-preview reveal stage. Call this ONLY after the user has explicitly selected a candidate from searchSpotifyArtist results.',
+    inputSchema: z.object({
+      spotifyArtistId: z
+        .string()
+        .min(1)
+        .max(64)
+        .describe(
+          'Spotify artist ID (alphanumeric, e.g. "4uA0L8H4DcXmKkJtGTQGzz")'
+        ),
+    }),
+  },
+
+  checkHandle: {
+    description:
+      'Check whether a Jovie handle (username) is available. Use after the visitor has been identified (Spotify pick or self-named) to claim their handle. The widget shows green-check / red-x with suggestions if taken. Pass the proposed handle without the @ prefix.',
+    inputSchema: z.object({
+      handle: z
+        .string()
+        .min(1)
+        .max(30)
+        .regex(
+          /^[a-z0-9._-]+$/i,
+          'Handle can only contain letters, numbers, dots, dashes, underscores'
+        )
+        .describe('Proposed handle (without @ prefix)'),
+    }),
+  },
+
+  recordInterviewSignal: {
+    description:
+      'Silently record qualifying signal you learned this turn. Use whenever the visitor reveals their release stage, audience size band, what tool they currently use, or any objection / hesitation they raised. No UI surface — this is for analytics + later proposeNextStep scoring. Always pass at least one field; never call this with an empty signal.',
+    inputSchema: interviewSignalSchema,
+  },
+
+  proposeNextStep: {
+    description:
+      'Decide whether to render the checkout card, the waitlist confirmation card, or continue the interview. Call this once you believe you have enough signal (typically after confirmSpotifyArtist + checkHandle, OR after 2+ interview turns). The server runs the deterministic evaluator — you do NOT score the decision, you trigger the evaluation.',
+    inputSchema: z.object({}),
+  },
+
+  proposeCheckout: {
+    description:
+      'Render the checkout card. Only call this AFTER proposeNextStep returned instant_access. The card defaults to a route-handoff to /onboarding/checkout (Stripe Embedded Checkout iframe is behind a separate flag pending CSP verification).',
+    inputSchema: z.object({
+      plan: z
+        .enum(['free', 'pro', 'max'])
+        .optional()
+        .describe('Plan intent. If omitted the user picks on the next screen.'),
+    }),
+  },
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -85,4 +155,19 @@ export const FREE_TIER_TOOLS = [
   'proposeSocialLink',
   'proposeSocialLinkRemoval',
   'submitFeedback',
+] as const satisfies readonly ToolSchemaKey[];
+
+/**
+ * Onboarding-mode tool set (JOV-2132 PR 2). These are the only tools exposed
+ * to the LLM when `mode='onboarding'`. proposeSocialLink is reused from the
+ * authenticated set; the rest are new.
+ */
+export const ONBOARDING_TOOLS = [
+  'searchSpotifyArtist',
+  'confirmSpotifyArtist',
+  'checkHandle',
+  'proposeSocialLink',
+  'recordInterviewSignal',
+  'proposeNextStep',
+  'proposeCheckout',
 ] as const satisfies readonly ToolSchemaKey[];

--- a/apps/web/lib/chat/tools/onboarding-access-eval.test.ts
+++ b/apps/web/lib/chat/tools/onboarding-access-eval.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateAccessSignal,
+  MAX_INTERVIEW_TURNS_BEFORE_FORCE,
+} from './onboarding-access-eval';
+
+const EMPTY_SIGNAL = {};
+
+describe('evaluateAccessSignal', () => {
+  it('grants instant access when the Spotify artist is verified', () => {
+    const result = evaluateAccessSignal({
+      signal: EMPTY_SIGNAL,
+      spotifyFollowers: 47,
+      spotifyVerified: true,
+      turnCount: 1,
+    });
+    expect(result.kind).toBe('instant_access');
+    expect(result.rationale).toBe('spotify_verified');
+  });
+
+  it('grants instant access at >= 1000 followers even if not verified', () => {
+    const result = evaluateAccessSignal({
+      signal: EMPTY_SIGNAL,
+      spotifyFollowers: 1500,
+      spotifyVerified: false,
+      turnCount: 1,
+    });
+    expect(result.kind).toBe('instant_access');
+    expect(result.rationale).toContain('spotify_followers_1500');
+  });
+
+  it('grants instant access at audience band 5k_to_50k', () => {
+    const result = evaluateAccessSignal({
+      signal: { audienceBand: '5k_to_50k' },
+      spotifyFollowers: 200, // below threshold
+      spotifyVerified: false,
+      turnCount: 1,
+    });
+    expect(result.kind).toBe('instant_access');
+    expect(result.rationale).toContain('audience_band_5k_to_50k');
+  });
+
+  it('grants instant access at 500_to_5k IF an active release is in flight', () => {
+    const result = evaluateAccessSignal({
+      signal: {
+        audienceBand: '500_to_5k',
+        releaseStage: 'announced_unreleased',
+      },
+      spotifyFollowers: null,
+      spotifyVerified: false,
+      turnCount: 1,
+    });
+    expect(result.kind).toBe('instant_access');
+    expect(result.rationale).toContain('active_release');
+  });
+
+  it('asks for more info when signal is too weak and turn cap not reached', () => {
+    const result = evaluateAccessSignal({
+      signal: { audienceBand: 'under_500' },
+      spotifyFollowers: null,
+      spotifyVerified: false,
+      turnCount: 1,
+    });
+    expect(result.kind).toBe('needs_more_info');
+    expect(result.rationale).toBe('insufficient_signal');
+  });
+
+  it('forces waitlist after the max-turn cap with weak signal', () => {
+    const result = evaluateAccessSignal({
+      signal: { audienceBand: 'under_500' },
+      spotifyFollowers: null,
+      spotifyVerified: false,
+      turnCount: MAX_INTERVIEW_TURNS_BEFORE_FORCE,
+    });
+    expect(result.kind).toBe('waitlist');
+    expect(result.rationale).toContain('max_turns_reached');
+  });
+
+  it('still grants instant access even at the turn cap if signal qualifies', () => {
+    const result = evaluateAccessSignal({
+      signal: EMPTY_SIGNAL,
+      spotifyFollowers: 10_000,
+      spotifyVerified: false,
+      turnCount: MAX_INTERVIEW_TURNS_BEFORE_FORCE + 5,
+    });
+    expect(result.kind).toBe('instant_access');
+  });
+
+  it('500_to_5k WITHOUT an active release does NOT auto-qualify', () => {
+    const result = evaluateAccessSignal({
+      signal: {
+        audienceBand: '500_to_5k',
+        releaseStage: 'between_releases',
+      },
+      spotifyFollowers: null,
+      spotifyVerified: false,
+      turnCount: 1,
+    });
+    expect(result.kind).toBe('needs_more_info');
+  });
+
+  it('handles a null follower count gracefully', () => {
+    const result = evaluateAccessSignal({
+      signal: { audienceBand: '50k_to_500k' },
+      spotifyFollowers: null,
+      spotifyVerified: false,
+      turnCount: 0,
+    });
+    expect(result.kind).toBe('instant_access');
+  });
+});

--- a/apps/web/lib/chat/tools/onboarding-access-eval.ts
+++ b/apps/web/lib/chat/tools/onboarding-access-eval.ts
@@ -1,0 +1,145 @@
+/**
+ * Deterministic access-decision evaluator (JOV-2132 PR 2).
+ *
+ * This is NOT an LLM tool. It is a server function called by the
+ * `proposeNextStep` tool to decide whether the visitor should:
+ *
+ *   - `instant_access` — Spotify-verified or has solid signal, route to checkout
+ *   - `waitlist`       — qualifying signal too weak, defer with waitlist confirmation
+ *   - `needs_more_info` — interview not complete enough to decide either way
+ *
+ * Keeping this deterministic prevents the LLM from owning the scoring logic
+ * (which would let it hallucinate "you're getting instant access" without
+ * the underlying signal). The LLM picks WHEN to evaluate; the server decides
+ * WHAT the decision is.
+ */
+
+import type {
+  AudienceBand,
+  InterviewSignal,
+  ReleaseStage,
+} from './onboarding-signals';
+
+export type AccessDecisionKind =
+  | 'instant_access'
+  | 'waitlist'
+  | 'needs_more_info';
+
+export interface AccessDecisionInput {
+  /** Collapsed view of all interview signal so far. */
+  readonly signal: InterviewSignal;
+  /** Spotify follower count from confirmSpotifyArtist (if resolved). */
+  readonly spotifyFollowers: number | null;
+  /** Whether the picked Spotify artist is verified on Spotify. */
+  readonly spotifyVerified: boolean;
+  /** Number of LLM turns observed so far. Used to break stuck loops. */
+  readonly turnCount: number;
+}
+
+export interface AccessDecision {
+  readonly kind: AccessDecisionKind;
+  /** Short rationale for logging + UI surfaces. Not user-facing copy. */
+  readonly rationale: string;
+  /** 0-100 confidence; useful for retroactive analysis of where to tune thresholds. */
+  readonly score: number;
+}
+
+/** Maximum LLM turns before we force a decision even with weak signal. */
+export const MAX_INTERVIEW_TURNS_BEFORE_FORCE = 3;
+
+/** Spotify follower bands that auto-qualify for instant access. */
+const INSTANT_ACCESS_FOLLOWER_THRESHOLD = 1_000;
+
+const audienceBandRank: Record<AudienceBand, number> = {
+  under_500: 0,
+  '500_to_5k': 1,
+  '5k_to_50k': 2,
+  '50k_to_500k': 3,
+  over_500k: 4,
+};
+
+const releaseStageRank: Record<ReleaseStage, number> = {
+  no_active_release: 0,
+  between_releases: 1,
+  pre_announce: 2,
+  announced_unreleased: 3,
+  ongoing_rollout: 3,
+  just_released: 4,
+};
+
+/**
+ * Score the accumulated signal and return a routing decision.
+ *
+ * Pure function, deterministic, no I/O. Safe to call repeatedly across turns.
+ *
+ * Decision rules (top match wins):
+ *  1. Spotify verified artist OR followers >= 1k → instant_access
+ *  2. Audience band 5k+ → instant_access
+ *  3. Audience band 500-5k AND active release stage → instant_access
+ *  4. Hit MAX_INTERVIEW_TURNS_BEFORE_FORCE without instant-access signal → waitlist
+ *  5. Otherwise → needs_more_info
+ */
+export function evaluateAccessSignal(
+  input: AccessDecisionInput
+): AccessDecision {
+  const { signal, spotifyFollowers, spotifyVerified, turnCount } = input;
+
+  // 1. Strong Spotify signal — instant access.
+  if (spotifyVerified) {
+    return {
+      kind: 'instant_access',
+      rationale: 'spotify_verified',
+      score: 95,
+    };
+  }
+  if (
+    spotifyFollowers !== null &&
+    spotifyFollowers >= INSTANT_ACCESS_FOLLOWER_THRESHOLD
+  ) {
+    return {
+      kind: 'instant_access',
+      rationale: `spotify_followers_${spotifyFollowers}`,
+      score: 90,
+    };
+  }
+
+  // 2. Strong self-reported audience signal.
+  const audienceBand = signal.audienceBand;
+  if (audienceBand && audienceBandRank[audienceBand] >= 2) {
+    return {
+      kind: 'instant_access',
+      rationale: `audience_band_${audienceBand}`,
+      score: 80,
+    };
+  }
+
+  // 3. Mid audience + active release stage.
+  const releaseStage = signal.releaseStage;
+  if (
+    audienceBand === '500_to_5k' &&
+    releaseStage &&
+    releaseStageRank[releaseStage] >= 3
+  ) {
+    return {
+      kind: 'instant_access',
+      rationale: `audience_${audienceBand}_with_active_release_${releaseStage}`,
+      score: 70,
+    };
+  }
+
+  // 4. Turn cap reached — force decision into waitlist.
+  if (turnCount >= MAX_INTERVIEW_TURNS_BEFORE_FORCE) {
+    return {
+      kind: 'waitlist',
+      rationale: `max_turns_reached_${turnCount}`,
+      score: 30,
+    };
+  }
+
+  // 5. Not enough signal yet — ask another question.
+  return {
+    kind: 'needs_more_info',
+    rationale: 'insufficient_signal',
+    score: 10,
+  };
+}

--- a/apps/web/lib/chat/tools/onboarding-signals.ts
+++ b/apps/web/lib/chat/tools/onboarding-signals.ts
@@ -1,0 +1,120 @@
+/**
+ * Onboarding interview signal schemas (JOV-2132 PR 2).
+ *
+ * Defines the Zod shape for `recordInterviewSignal` payloads written to
+ * `chat_conversations.metadata.interviewSignals`. Schemaless JSONB without
+ * a typed contract is future analytics pain, so every signal type a tool
+ * can record is enumerated here.
+ *
+ * Adding a new signal kind:
+ *  1. Add its shape to `InterviewSignalSchema` below.
+ *  2. Bump the metadata version in `metadataVersion`.
+ *  3. Update analytics queries that read these signals.
+ */
+
+import { z } from 'zod';
+
+/** Release stage the artist self-reports. */
+export const releaseStageSchema = z.enum([
+  'no_active_release',
+  'pre_announce',
+  'announced_unreleased',
+  'just_released',
+  'ongoing_rollout',
+  'between_releases',
+]);
+export type ReleaseStage = z.infer<typeof releaseStageSchema>;
+
+/** Coarse-grained audience size band — useful for plan/qualification logic. */
+export const audienceBandSchema = z.enum([
+  'under_500',
+  '500_to_5k',
+  '5k_to_50k',
+  '50k_to_500k',
+  'over_500k',
+]);
+export type AudienceBand = z.infer<typeof audienceBandSchema>;
+
+/** What the artist is currently using (the status quo Jovie is replacing). */
+export const currentToolSchema = z.object({
+  /** Free-text identifier: "linktree", "bio.fm", "my own site", "nothing", etc. */
+  name: z.string().min(1).max(120),
+  /** What about it does/doesn't work — short free text. Optional. */
+  note: z.string().max(500).optional(),
+});
+
+/** A single objection or hesitation the user raised. */
+export const objectionSchema = z.object({
+  /** Categorized objection kind, free-text fallback allowed via `other`. */
+  category: z.enum([
+    'price',
+    'effort_to_set_up',
+    'data_lock_in',
+    'feature_gap',
+    'trust_brand_unknown',
+    'wrong_audience',
+    'platform_specific_concern',
+    'other',
+  ]),
+  /** What they actually said, paraphrased — 1-2 sentences max. */
+  text: z.string().min(1).max(500),
+});
+
+/**
+ * Recorded signal payload. The LLM writes one of these per relevant turn.
+ * The tool can pass only the fields it has signal on — every field is
+ * optional, but at least one MUST be present (enforced via refine).
+ */
+export const interviewSignalSchema = z
+  .object({
+    releaseStage: releaseStageSchema.optional(),
+    audienceBand: audienceBandSchema.optional(),
+    currentTool: currentToolSchema.optional(),
+    objection: objectionSchema.optional(),
+    /** Free-form note for anything that doesn't fit the typed schema yet. */
+    freeNote: z.string().max(2000).optional(),
+  })
+  .refine(
+    v =>
+      Boolean(
+        v.releaseStage ||
+          v.audienceBand ||
+          v.currentTool ||
+          v.objection ||
+          v.freeNote
+      ),
+    { message: 'At least one signal field must be present' }
+  );
+export type InterviewSignal = z.infer<typeof interviewSignalSchema>;
+
+/**
+ * The aggregate shape persisted at chat_conversations.metadata.interviewSignals.
+ * Append-only: each tool call appends one entry. Read-time consumers should
+ * use the most recent occurrence of a given field as the canonical value.
+ */
+export const interviewSignalsMetadataSchema = z.object({
+  metadataVersion: z.literal(1),
+  signals: z
+    .array(
+      interviewSignalSchema.and(z.object({ recordedAt: z.string().datetime() }))
+    )
+    .max(50),
+});
+export type InterviewSignalsMetadata = z.infer<
+  typeof interviewSignalsMetadataSchema
+>;
+
+/** Reduce the append-only signal log to the most-recent value per field. */
+export function collapseInterviewSignals(
+  signals: InterviewSignalsMetadata['signals']
+): InterviewSignal {
+  const result: InterviewSignal = {};
+  for (const s of signals) {
+    if (s.releaseStage) result.releaseStage = s.releaseStage;
+    if (s.audienceBand) result.audienceBand = s.audienceBand;
+    if (s.currentTool) result.currentTool = s.currentTool;
+    if (s.objection) result.objection = s.objection;
+    if (s.freeNote) result.freeNote = s.freeNote;
+  }
+  return result;
+}

--- a/apps/web/lib/chat/tools/onboarding-tool-impls.ts
+++ b/apps/web/lib/chat/tools/onboarding-tool-impls.ts
@@ -1,0 +1,214 @@
+import 'server-only';
+import { type ToolSet, tool } from 'ai';
+import { z } from 'zod';
+import { TOOL_SCHEMAS } from '@/lib/chat/tool-schemas';
+import {
+  type AccessDecision,
+  evaluateAccessSignal,
+} from '@/lib/chat/tools/onboarding-access-eval';
+import {
+  collapseInterviewSignals,
+  type InterviewSignal,
+  interviewSignalSchema,
+} from '@/lib/chat/tools/onboarding-signals';
+
+/**
+ * Onboarding tool execute closures (JOV-2132 PR 2).
+ *
+ * These are server-side closures the LLM calls during the onboarding chat.
+ * They return structured payloads the UI cards (landing in PR 3) will render.
+ *
+ * Implementation strategy by tool type:
+ *
+ *   Deterministic (real logic now):
+ *     - recordInterviewSignal  → appends to in-memory signal accumulator
+ *     - proposeNextStep        → runs evaluateAccessSignal against accumulator
+ *
+ *   Pass-throughs to existing APIs (real logic now):
+ *     - searchSpotifyArtist    → emits a marker for client-side popout (the
+ *                                client already calls /api/spotify/search via
+ *                                WaitlistSpotifySearch's hook; the tool just
+ *                                signals "show the picker, optionally pre-filled")
+ *     - checkHandle            → ditto for /api/handle/check
+ *
+ *   UI-coordination markers (real implementations land in PR 3):
+ *     - confirmSpotifyArtist   → records the picked artist id on the
+ *                                accumulator; PR 3 will fetch full enrichment
+ *     - proposeCheckout        → emits the route-handoff marker; PR 4 swaps
+ *                                in the Stripe-Embedded experiment
+ *
+ *   Reused from authenticated chat:
+ *     - proposeSocialLink      → same tool as in-app chat
+ */
+
+/**
+ * Per-request state accumulator. The handler creates one instance per turn
+ * and threads it through the tool closures so they can share state (e.g.
+ * recordInterviewSignal writes; proposeNextStep reads).
+ *
+ * Persistence (chat_messages + chat_conversations.metadata) lands in a
+ * follow-up commit so the handler diff stays focused on the dispatch path.
+ */
+export interface OnboardingTurnState {
+  sessionId: string;
+  /** Set when confirmSpotifyArtist is called. */
+  spotifyArtistId: string | null;
+  /** Set after confirmSpotifyArtist enrichment (PR 3 will populate). */
+  spotifyVerified: boolean;
+  spotifyFollowers: number | null;
+  /** Append-only log of recordInterviewSignal calls within this turn. */
+  signals: InterviewSignal[];
+  /** Cumulative LLM turn count (1-indexed). Drives the proposeNextStep eval. */
+  turnCount: number;
+}
+
+export function createOnboardingTurnState(input: {
+  sessionId: string;
+  turnCount: number;
+}): OnboardingTurnState {
+  return {
+    sessionId: input.sessionId,
+    spotifyArtistId: null,
+    spotifyVerified: false,
+    spotifyFollowers: null,
+    signals: [],
+    turnCount: input.turnCount,
+  };
+}
+
+export interface NextStepCardPayload {
+  readonly action: 'propose_next_step';
+  readonly decision: AccessDecision;
+}
+
+export interface CheckoutCardPayload {
+  readonly action: 'propose_checkout';
+  readonly plan: 'free' | 'pro' | 'max' | null;
+  /** Route to send the visitor to. PR 4 may swap in Embedded Checkout. */
+  readonly handoffUrl: string;
+}
+
+/**
+ * Build the onboarding tool palette wired to a per-turn state accumulator.
+ * Pass the result as the `tools` argument to `executeChatTurn`.
+ */
+export function buildOnboardingTools(state: OnboardingTurnState): ToolSet {
+  const tools = {
+    searchSpotifyArtist: tool({
+      description: TOOL_SCHEMAS.searchSpotifyArtist.description,
+      inputSchema: TOOL_SCHEMAS.searchSpotifyArtist.inputSchema,
+      execute: async ({ query }) => {
+        // The client renders the popout picker (reusing WaitlistSpotifySearch);
+        // the actual /api/spotify/search call happens client-side via the
+        // existing useArtistSearchQuery hook. The tool result is the trigger
+        // marker the UI listens for.
+        return {
+          action: 'open_artist_picker' as const,
+          query: query ?? null,
+        };
+      },
+    }),
+
+    confirmSpotifyArtist: tool({
+      description: TOOL_SCHEMAS.confirmSpotifyArtist.description,
+      inputSchema: TOOL_SCHEMAS.confirmSpotifyArtist.inputSchema,
+      execute: async ({ spotifyArtistId }) => {
+        state.spotifyArtistId = spotifyArtistId;
+        // PR 3 will fetch full enrichment server-side here (avatar, followers,
+        // latest release, verified flag, genres) and persist it onto the
+        // conversation. For now we mark the pick; the LLM proceeds knowing the
+        // artist has been identified, and proposeNextStep will see whatever
+        // signal accumulates by the time it fires.
+        return {
+          action: 'spotify_artist_confirmed' as const,
+          spotifyArtistId,
+        };
+      },
+    }),
+
+    checkHandle: tool({
+      description: TOOL_SCHEMAS.checkHandle.description,
+      inputSchema: TOOL_SCHEMAS.checkHandle.inputSchema,
+      execute: async ({ handle }) => {
+        // Client-side rendering hits /api/handle/check directly so the gate
+        // surfaces the same constant-time response budget regardless of who
+        // asks. The tool just emits the marker + the proposed handle.
+        return {
+          action: 'check_handle' as const,
+          handle: handle.toLowerCase(),
+        };
+      },
+    }),
+
+    proposeSocialLink: tool({
+      description: TOOL_SCHEMAS.proposeSocialLink.description,
+      inputSchema: TOOL_SCHEMAS.proposeSocialLink.inputSchema,
+      execute: async ({ url }) => {
+        // PR 3 will wire this through the same SocialLink confirmation card
+        // the authenticated chat uses (detectPlatform + preview). For PR 2 we
+        // just emit the URL — the LLM treats this as "I've offered to attach
+        // this link" and the UI will render the card.
+        return {
+          action: 'propose_social_link' as const,
+          url,
+        };
+      },
+    }),
+
+    recordInterviewSignal: tool({
+      description: TOOL_SCHEMAS.recordInterviewSignal.description,
+      inputSchema: TOOL_SCHEMAS.recordInterviewSignal.inputSchema,
+      execute: async (signal: z.infer<typeof interviewSignalSchema>) => {
+        state.signals.push(signal);
+        // Persistence to chat_conversations.metadata.interviewSignals lands
+        // in the follow-up commit. The accumulator above is sufficient to
+        // feed proposeNextStep within the same turn.
+        return {
+          action: 'signal_recorded' as const,
+          signalCount: state.signals.length,
+        };
+      },
+    }),
+
+    proposeNextStep: tool({
+      description: TOOL_SCHEMAS.proposeNextStep.description,
+      inputSchema: TOOL_SCHEMAS.proposeNextStep.inputSchema,
+      execute: async () => {
+        const decision = evaluateAccessSignal({
+          signal: collapseInterviewSignals(
+            state.signals.map(s => ({
+              ...s,
+              recordedAt: new Date().toISOString(),
+            }))
+          ),
+          spotifyFollowers: state.spotifyFollowers,
+          spotifyVerified: state.spotifyVerified,
+          turnCount: state.turnCount,
+        });
+        const payload: NextStepCardPayload = {
+          action: 'propose_next_step',
+          decision,
+        };
+        return payload;
+      },
+    }),
+
+    proposeCheckout: tool({
+      description: TOOL_SCHEMAS.proposeCheckout.description,
+      inputSchema: TOOL_SCHEMAS.proposeCheckout.inputSchema,
+      execute: async ({ plan }) => {
+        const handoffUrl = plan
+          ? `/onboarding/checkout?plan=${encodeURIComponent(plan)}`
+          : '/onboarding/checkout';
+        const payload: CheckoutCardPayload = {
+          action: 'propose_checkout',
+          plan: plan ?? null,
+          handoffUrl,
+        };
+        return payload;
+      },
+    }),
+  } satisfies ToolSet;
+
+  return tools;
+}

--- a/apps/web/tests/unit/api/chat/onboarding-handler.test.ts
+++ b/apps/web/tests/unit/api/chat/onboarding-handler.test.ts
@@ -136,6 +136,17 @@ describe('tryHandleAnonymousOnboardingChat', () => {
     expect(body.errorCode).toBe('INVALID_MESSAGES');
   });
 
+  it('returns 400 when the messages array is empty', async () => {
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest({ mode: 'onboarding', messages: [] });
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-3b');
+    expect(result?.status).toBe(400);
+    const body = await result?.json();
+    expect(body.errorCode).toBe('INVALID_MESSAGES');
+  });
+
   it('returns 400 when a message is shaped wrong', async () => {
     const { tryHandleAnonymousOnboardingChat } = await import(
       '@/app/api/chat/onboarding-handler'

--- a/apps/web/tests/unit/api/chat/onboarding-handler.test.ts
+++ b/apps/web/tests/unit/api/chat/onboarding-handler.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  checkGateForUserMock: vi.fn(),
+  executeChatTurnMock: vi.fn(),
+  checkAnonymousChatRateLimitMock: vi.fn(),
+  isTurnstileConfiguredMock: vi.fn(),
+  verifyTurnstileTokenMock: vi.fn(),
+  encodeSessionCookieMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
+  captureMessageMock: vi.fn(),
+  setTagMock: vi.fn(),
+  setTagsMock: vi.fn(),
+  setExtraMock: vi.fn(),
+  addBreadcrumbMock: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/flags/server', () => ({
+  checkGateForUser: hoisted.checkGateForUserMock,
+}));
+
+vi.mock('@/lib/chat/run', () => ({
+  executeChatTurn: hoisted.executeChatTurnMock,
+  isClientDisconnect: () => false,
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkAnonymousChatRateLimit: hoisted.checkAnonymousChatRateLimitMock,
+  createRateLimitHeaders: () => ({}),
+}));
+
+vi.mock('@/lib/turnstile/verify', () => ({
+  isTurnstileConfigured: hoisted.isTurnstileConfiguredMock,
+  verifyTurnstileToken: hoisted.verifyTurnstileTokenMock,
+}));
+
+vi.mock('@/lib/onboarding/session', () => ({
+  ONBOARDING_SESSION_COOKIE_NAME: 'jovie_onboarding_session',
+  verifySessionCookie: (v: string | undefined) =>
+    v && v.startsWith('valid-session.')
+      ? v.slice('valid-session.'.length)
+      : null,
+  encodeSessionCookie: hoisted.encodeSessionCookieMock,
+}));
+
+vi.mock('@/lib/utils/ip-extraction', () => ({
+  extractClientIPFromRequest: () => '203.0.113.5',
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: hoisted.captureExceptionMock,
+  captureMessage: hoisted.captureMessageMock,
+  setTag: hoisted.setTagMock,
+  setTags: hoisted.setTagsMock,
+  setExtra: hoisted.setExtraMock,
+  addBreadcrumb: hoisted.addBreadcrumbMock,
+}));
+
+// Default to development so the Turnstile fail-closed path doesn't fire in
+// the happy-path tests. The "non-dev" test overrides this with vi.doMock.
+vi.mock('@/lib/env-server', () => ({
+  env: { NODE_ENV: 'development' },
+  isSecureEnv: () => false,
+}));
+
+function makeRequest(body: unknown, cookieHeader = ''): Request {
+  return new Request('http://localhost/api/chat', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      cookie: cookieHeader,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function userMessage(text: string) {
+  return {
+    id: crypto.randomUUID(),
+    role: 'user' as const,
+    parts: [{ type: 'text', text }],
+  };
+}
+
+describe('tryHandleAnonymousOnboardingChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.checkGateForUserMock.mockResolvedValue(true);
+    hoisted.checkAnonymousChatRateLimitMock.mockResolvedValue({
+      success: true,
+    });
+    hoisted.isTurnstileConfiguredMock.mockReturnValue(false);
+    hoisted.encodeSessionCookieMock.mockImplementation(
+      (id: string) => `signed.${id}.sig`
+    );
+  });
+
+  it('returns null when mode is not onboarding (fall through to authenticated path)', async () => {
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest({ mode: 'app', messages: [userMessage('hi')] });
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-1');
+    expect(result).toBeNull();
+    expect(hoisted.checkGateForUserMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 503 when the Statsig kill-switch is disabled', async () => {
+    hoisted.checkGateForUserMock.mockResolvedValue(false);
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest({
+      mode: 'onboarding',
+      messages: [userMessage('hi')],
+    });
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-2');
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe(503);
+    const body = await result?.json();
+    expect(body.errorCode).toBe('ONBOARDING_CHAT_DISABLED');
+    // Dispatch must NOT have been called when the gate is closed.
+    expect(hoisted.executeChatTurnMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the messages array is missing', async () => {
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest({ mode: 'onboarding' });
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-3');
+    expect(result?.status).toBe(400);
+    const body = await result?.json();
+    expect(body.errorCode).toBe('INVALID_MESSAGES');
+  });
+
+  it('returns 400 when a message is shaped wrong', async () => {
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest({
+      mode: 'onboarding',
+      messages: [{ role: 'banana', parts: [] }],
+    });
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-4');
+    expect(result?.status).toBe(400);
+    const body = await result?.json();
+    expect(body.errorCode).toBe('INVALID_MESSAGES');
+  });
+
+  it('returns 503 when Turnstile is not configured outside dev (first turn)', async () => {
+    // Re-mock env to non-dev for this case.
+    vi.resetModules();
+    vi.doMock('@/lib/env-server', () => ({
+      env: { NODE_ENV: 'production' },
+      isSecureEnv: () => true,
+    }));
+    hoisted.isTurnstileConfiguredMock.mockReturnValue(false);
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest({
+      mode: 'onboarding',
+      messages: [userMessage('hi')],
+    });
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-5');
+    expect(result?.status).toBe(503);
+    const body = await result?.json();
+    expect(body.errorCode).toBe('TURNSTILE_NOT_CONFIGURED');
+  });
+
+  it('dispatches executeChatTurn with mode=onboarding and the 7 onboarding tools', async () => {
+    vi.resetModules();
+    // Restore the dev env mock so Turnstile gate is skipped.
+    vi.doMock('@/lib/env-server', () => ({
+      env: { NODE_ENV: 'development' },
+      isSecureEnv: () => false,
+    }));
+    // Make executeChatTurn return a fake stream response.
+    hoisted.executeChatTurnMock.mockResolvedValue({
+      streamResult: {
+        toUIMessageStreamResponse: ({
+          headers,
+        }: {
+          headers: Record<string, string>;
+        }) => new Response('ok', { status: 200, headers }),
+      },
+      selectedModel: 'anthropic/claude-haiku-4-5-20251001',
+      systemPrompt: '<onboarding prompt>',
+      toolNames: [
+        'checkHandle',
+        'confirmSpotifyArtist',
+        'proposeCheckout',
+        'proposeNextStep',
+        'proposeSocialLink',
+        'recordInterviewSignal',
+        'searchSpotifyArtist',
+      ],
+      modelMessages: [],
+    });
+
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const req = makeRequest({
+      mode: 'onboarding',
+      messages: [userMessage("I'm a musician")],
+    });
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-6');
+
+    expect(result?.status).toBe(200);
+    expect(hoisted.executeChatTurnMock).toHaveBeenCalledTimes(1);
+
+    const call = hoisted.executeChatTurnMock.mock.calls[0]![0];
+    expect(call.mode).toBe('onboarding');
+    expect(call.userId).toBeNull();
+    expect(call.artistContext).toBeNull();
+    expect(call.resolvedProfileId).toBeNull();
+    expect(call.forceLightModel).toBe(true);
+    expect(call.userPlan).toBe('free');
+    // The 7 tool names: 6 onboarding-specific + proposeSocialLink reused
+    expect(Object.keys(call.tools).sort()).toEqual([
+      'checkHandle',
+      'confirmSpotifyArtist',
+      'proposeCheckout',
+      'proposeNextStep',
+      'proposeSocialLink',
+      'recordInterviewSignal',
+      'searchSpotifyArtist',
+    ]);
+
+    // Fresh session → set-cookie header on the response
+    expect(result?.headers.get('set-cookie')).toContain(
+      'jovie_onboarding_session='
+    );
+    expect(result?.headers.get('x-chat-mode')).toBe('onboarding');
+  });
+
+  it('reuses an existing valid session cookie (no fresh cookie minted)', async () => {
+    vi.resetModules();
+    vi.doMock('@/lib/env-server', () => ({
+      env: { NODE_ENV: 'development' },
+      isSecureEnv: () => false,
+    }));
+    hoisted.executeChatTurnMock.mockResolvedValue({
+      streamResult: {
+        toUIMessageStreamResponse: ({
+          headers,
+        }: {
+          headers: Record<string, string>;
+        }) => new Response('ok', { status: 200, headers }),
+      },
+      selectedModel: 'anthropic/claude-haiku-4-5-20251001',
+      systemPrompt: '',
+      toolNames: [],
+      modelMessages: [],
+    });
+
+    const { tryHandleAnonymousOnboardingChat } = await import(
+      '@/app/api/chat/onboarding-handler'
+    );
+    const existingSessionId = '00112233-4455-6677-8899-aabbccddeeff';
+    const req = makeRequest(
+      { mode: 'onboarding', messages: [userMessage('hi again')] },
+      `jovie_onboarding_session=valid-session.${existingSessionId}`
+    );
+    const result = await tryHandleAnonymousOnboardingChat(req, 'req-7');
+
+    expect(result?.status).toBe(200);
+    // No fresh cookie minted on a returning session
+    expect(result?.headers.get('set-cookie')).toBeNull();
+    expect(hoisted.encodeSessionCookieMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

PR 2 of 4 in the unified Jovie AI chat front-door (JOV-2132). This PR adds the foundation: 6 new onboarding LLM tools, a Stanley-inspired system prompt, deterministic access-decision logic, and Zod-shaped metadata schemas.

**Status: WIP draft.** This is the foundation commit. The handler replacement (replacing PR 1's 501 stub with the real LLM dispatch) lands in a follow-up commit on this branch.

Stacked on top of PR 1 (#8509 — merged). Builds on the session cookie, Turnstile gate, rate limiters, and claim endpoint from that PR.

## What ships in this commit

**`lib/chat/prompts/onboarding.ts`** — Stanley-inspired system prompt
- Voice: confident, warm, sharp. NOT customer-service polite. NO emoji.
- One question per turn. Never two. Never a "first then" sequence.
- Spotify pick is the wow moment (lead with \`searchSpotifyArtist\`)
- Goals in order: feel-seen → mom-test → tangible profile → qualify → next step
- Handles meta-questions ("how much does it cost?") inline without breaking flow
- Objection handling with concrete rebuttals + \`recordInterviewSignal\` logging

**`lib/chat/tools/onboarding-signals.ts`** — Zod-shaped interview signal schema
- Typed payload for \`recordInterviewSignal\` → \`chat_conversations.metadata.interviewSignals\`
- Fields: releaseStage, audienceBand, currentTool, objection, freeNote
- Append-only metadata with versioning (\`metadataVersion: 1\`)
- \`collapseInterviewSignals\` helper for read-time aggregation

**`lib/chat/tools/onboarding-access-eval.ts`** — deterministic decision logic
- Pure server function (NOT an LLM tool — LLM cannot hallucinate the decision)
- Decision rules (top match wins):
  1. Spotify verified → \`instant_access\`
  2. Spotify followers >= 1,000 → \`instant_access\`
  3. Audience band >= 5k_to_50k → \`instant_access\`
  4. Audience 500_to_5k + active release → \`instant_access\`
  5. >= 3 turns without qualifying signal → \`waitlist\` (force decision)
  6. Otherwise → \`needs_more_info\` (LLM asks another question)
- 9 test cases covering every branch

**`lib/chat/tool-schemas.ts`** — 6 new tool schemas + \`ONBOARDING_TOOLS\` array
- \`searchSpotifyArtist\` — open artist picker popout
- \`confirmSpotifyArtist\` — lock the picked artist, pull enrichment
- \`checkHandle\` — handle availability via existing \`/api/handle/check\`
- \`recordInterviewSignal\` — silently log qualifying signal
- \`proposeNextStep\` — trigger deterministic eval, render decision card
- \`proposeCheckout\` — render checkout (route-handoff default, Embedded behind separate flag)
- \`proposeSocialLink\` reused from authenticated tools
- **Deleted from earlier plan:** \`revealProfilePreview\` — reveal state derives from tool history, not from an LLM command (single source of truth)

## What does NOT ship in this commit (next commits)

- [ ] Replace \`/api/chat\` onboarding mode 501 stub with executeChatTurn dispatch
- [ ] Statsig kill-switch flag \`onboarding_chat_v2\` wiring (default off)
- [ ] Per-tool deterministic UI escape hatches
- [ ] Integration test driving a full transcript end-to-end

## Test plan

- [x] \`pnpm --filter @jovie/web run typecheck\` — clean
- [x] \`pnpm biome check\` — clean
- [x] \`vitest lib/chat/tools/onboarding-access-eval.test.ts\` — 9/9 pass
- [ ] After dispatch lands: end-to-end test against /api/chat with mode='onboarding'
- [ ] /qa --exhaustive on \`/start\` once PR 3 lands the route

## Linear

JOV-2132 — Unified Jovie AI chat front-door (PR 2 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich anonymous onboarding chat with guided flow: artist picker, handle checks, interview signal capture, and checkout/waitlist proposals.
  * Onboarding-only toolset and deterministic eligibility evaluator for instant access / waitlist / needs-more-info.
  * Structured capture and consolidation of per-turn interview signals.

* **Tests**
  * New unit tests covering access-evaluation logic, onboarding handler flows, and edge cases.

* **Bug Fixes / Reliability**
  * Stricter message validation, improved streaming/error handling, client-disconnect handling, telemetry, and session cookie management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8551)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->