### PR TITLE
feat(onboarding): PR 3 — /start route + chat client + Turnstile (JOV-2132)

### DIFF
--- a/apps/web/app/(dynamic)/start/page.tsx
+++ b/apps/web/app/(dynamic)/start/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from 'next';
+import { OnboardingShell } from '@/components/features/onboarding/OnboardingShell';
+import { getOrMintOnboardingSessionId } from '@/lib/onboarding/session';
+
+/**
+ * Anonymous onboarding chat entry point (JOV-2132 PR 3).
+ *
+ * Pre-account musicians land here. The server component ensures an
+ * `jovie_onboarding_session` cookie is minted (signed; PR 1 helper) before
+ * the client OnboardingChat opens its first POST to /api/chat in
+ * `mode='onboarding'`.
+ *
+ * Placed under `app/(dynamic)/` so the marketing-static rule does not apply
+ * — this route mints session cookies per request and dispatches a streaming
+ * LLM response. CSP nonce and middleware behavior follow the existing
+ * dynamic-group conventions.
+ *
+ * The visual shell here is intentionally minimal for v1. Cinematic reveal
+ * choreography (per the JOV-2132 plan + Stanley refs) lands incrementally
+ * after the first round of real-artist watch sessions.
+ */
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Start with Jovie',
+  description: 'Set up your Jovie artist profile in one conversation.',
+  robots: { index: false, follow: false },
+};
+
+export default async function StartPage() {
+  // Mint or read the signed onboarding session cookie. The /api/chat handler
+  // will read this cookie on the first message; persisting it here means the
+  // first POST already has a stable session id and Turnstile gate behavior.
+  const { sessionId } = await getOrMintOnboardingSessionId();
+
+  // We expose only the leading 8 chars of the session id to the client for
+  // debugging breadcrumbs — the full signed cookie value is httpOnly, the
+  // client never needs the full id, and we keep it scrubbed in any Sentry
+  // crumbs that mention it.
+  const sessionLabel = sessionId.slice(0, 8);
+
+  return <OnboardingShell sessionLabel={sessionLabel} />;
+}

--- a/apps/web/app/waitlist/page.tsx
+++ b/apps/web/app/waitlist/page.tsx
@@ -1,35 +1,34 @@
 import { redirect } from 'next/navigation';
-import { WaitlistIntakeChat } from '@/components/features/waitlist/WaitlistIntakeChat';
-import { WaitlistSuccessView } from '@/components/features/waitlist/WaitlistSuccessView';
 import { APP_ROUTES } from '@/constants/routes';
 import { CanonicalUserState, resolveUserState } from '@/lib/auth/gate';
 
+/**
+ * Legacy /waitlist route — redirects to /start (the anonymous onboarding
+ * chat, JOV-2132). Authenticated-state redirects are preserved so users who
+ * already have a profile / are in onboarding don't bounce through the
+ * pre-account chat.
+ *
+ * The WaitlistIntakeChat / WaitlistSuccessView components stay on disk per
+ * the JOV-2132 plan — they're the deterministic fallback. PR 4's cleanup
+ * commit removes them once /start has 48 hours of clean metrics.
+ */
 export default async function WaitlistPage() {
   const authResult = await resolveUserState();
-
-  if (authResult.state === CanonicalUserState.UNAUTHENTICATED) {
-    redirect(`${APP_ROUTES.SIGNUP}?redirect_url=${APP_ROUTES.WAITLIST}`);
-  }
 
   if (authResult.state === CanonicalUserState.BANNED) {
     redirect(APP_ROUTES.UNAVAILABLE);
   }
-
   if (authResult.state === CanonicalUserState.USER_CREATION_FAILED) {
     redirect('/error/user-creation-failed');
   }
-
   if (authResult.state === CanonicalUserState.ACTIVE) {
     redirect(APP_ROUTES.DASHBOARD);
   }
-
   if (authResult.state === CanonicalUserState.NEEDS_ONBOARDING) {
     redirect(APP_ROUTES.ONBOARDING);
   }
 
-  if (authResult.state === CanonicalUserState.WAITLIST_PENDING) {
-    return <WaitlistSuccessView />;
-  }
-
-  return <WaitlistIntakeChat userEmail={authResult.context.email} />;
+  // UNAUTHENTICATED, WAITLIST_PENDING, and any default state all funnel into
+  // the new anonymous onboarding chat.
+  redirect(APP_ROUTES.START);
 }

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { useChat } from '@ai-sdk/react';
+import { DefaultChatTransport, type UIMessage } from 'ai';
+import { ArrowUp, Loader2 } from 'lucide-react';
+import {
+  type FormEvent,
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { cn } from '@/lib/utils';
+
+/**
+ * Anonymous onboarding chat client (JOV-2132 PR 3).
+ *
+ * Streams against `/api/chat` in `mode='onboarding'`. The first request also
+ * carries the Cloudflare Turnstile token; subsequent requests in the same
+ * session do not (the signed cookie + session-lifetime rate limit carry
+ * trust forward).
+ *
+ * v1 visual: a single column of message bubbles with a composer at the
+ * bottom. Tool-call previews are rendered as small inline chips so the LLM's
+ * tool use is visible while we iterate on the dedicated tool cards in a
+ * follow-up commit on this branch.
+ */
+
+interface OnboardingChatProps {
+  /** Turnstile token from the widget. Required on first message. */
+  readonly turnstileToken: string | null;
+}
+
+/** Pull the user-visible text out of a UIMessage's parts. */
+function getMessageText(message: UIMessage): string {
+  return (message.parts ?? [])
+    .filter(
+      (p): p is { type: 'text'; text: string } =>
+        p.type === 'text' && typeof p.text === 'string'
+    )
+    .map(p => p.text)
+    .join('');
+}
+
+/** Surface visible tool-call markers as inline chips. */
+function getToolMarkers(message: UIMessage): readonly string[] {
+  return (message.parts ?? []).flatMap(part => {
+    if (part.type === 'dynamic-tool' || part.type?.startsWith('tool-')) {
+      const toolPart = part as { toolName?: string; type: string };
+      return [toolPart.toolName ?? toolPart.type];
+    }
+    return [];
+  });
+}
+
+export function OnboardingChat({ turnstileToken }: OnboardingChatProps) {
+  const [input, setInput] = useState('');
+  const [hasSentFirst, setHasSentFirst] = useState(false);
+  const messagesRef = useRef<HTMLDivElement | null>(null);
+
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: '/api/chat',
+        // `prepareSendMessagesRequest` lets us mutate the body per-request so
+        // the first POST carries the Turnstile token; subsequent POSTs skip it.
+        prepareSendMessagesRequest: ({ messages, body }) => ({
+          body: {
+            ...body,
+            mode: 'onboarding' as const,
+            messages,
+            ...(hasSentFirst ? {} : { turnstileToken }),
+          },
+        }),
+      }),
+    [hasSentFirst, turnstileToken]
+  );
+
+  const { messages, sendMessage, status } = useChat({
+    id: 'onboarding',
+    transport,
+  });
+
+  const isStreaming = status === 'streaming' || status === 'submitted';
+
+  const handleSubmit = useCallback(
+    (event?: FormEvent<HTMLFormElement>) => {
+      event?.preventDefault();
+      const text = input.trim();
+      if (!text || isStreaming) return;
+      if (!hasSentFirst && !turnstileToken) {
+        // Turnstile hasn't issued a token yet; the widget normally resolves
+        // within ~500ms. Silently no-op so the user can retry.
+        return;
+      }
+      sendMessage({ text });
+      setHasSentFirst(true);
+      setInput('');
+    },
+    [hasSentFirst, input, isStreaming, sendMessage, turnstileToken]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        handleSubmit();
+      }
+    },
+    [handleSubmit]
+  );
+
+  // Auto-scroll on new content
+  useEffect(() => {
+    const node = messagesRef.current;
+    if (!node) return;
+    node.scrollTop = node.scrollHeight;
+  }, [messages.length, isStreaming]);
+
+  const composerDisabled = isStreaming || (!hasSentFirst && !turnstileToken);
+
+  return (
+    <div className='flex flex-1 flex-col'>
+      <div
+        ref={messagesRef}
+        className='flex-1 space-y-3 overflow-y-auto px-1 py-6'
+        aria-live='polite'
+      >
+        {messages.length === 0 ? (
+          <p className='text-center text-[13px] text-white/40'>
+            {`heads up — I'll remember this chat so you can pick up where we left off when you sign up. what are you working on?`}
+          </p>
+        ) : null}
+
+        {messages.map(message => {
+          const text = getMessageText(message);
+          const toolMarkers = getToolMarkers(message);
+          return (
+            <div
+              key={message.id}
+              className={cn(
+                'flex',
+                message.role === 'user' ? 'justify-end' : 'justify-start'
+              )}
+            >
+              <div
+                className={cn(
+                  'max-w-[80%] rounded-2xl px-3.5 py-2.5 text-[14px] leading-6',
+                  message.role === 'user'
+                    ? 'bg-white text-black'
+                    : 'border border-white/[0.08] bg-white/[0.035] text-white/82'
+                )}
+              >
+                {text || (
+                  <span className='text-white/40'>
+                    <Loader2
+                      className='inline h-3.5 w-3.5 animate-spin'
+                      aria-hidden
+                    />
+                  </span>
+                )}
+                {toolMarkers.length > 0 ? (
+                  <div className='mt-2 flex flex-wrap gap-1.5'>
+                    {toolMarkers.map((marker, i) => (
+                      <span
+                        key={`${message.id}-tool-${i}`}
+                        className='rounded-full border border-white/[0.12] bg-white/[0.04] px-2 py-0.5 text-[11px] text-white/60'
+                      >
+                        {marker}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className='sticky bottom-0 flex items-end gap-2 border-t border-white/[0.07] bg-[#06070a]/90 pb-3 pt-3 backdrop-blur'
+      >
+        <textarea
+          value={input}
+          onChange={event => setInput(event.target.value)}
+          onKeyDown={handleKeyDown}
+          rows={1}
+          placeholder={
+            !hasSentFirst && !turnstileToken
+              ? 'just a sec…'
+              : 'tell me what you are working on'
+          }
+          disabled={composerDisabled}
+          className='min-h-[44px] max-h-[160px] flex-1 resize-none rounded-2xl border border-white/[0.09] bg-white/[0.04] px-4 py-2.5 text-[14px] text-white outline-none placeholder:text-white/32 focus:border-white/24 disabled:cursor-not-allowed disabled:opacity-50'
+          aria-label='Type a message to Jovie'
+        />
+        <button
+          type='submit'
+          disabled={composerDisabled || input.trim().length === 0}
+          className='inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-black transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-40 focus-ring-themed'
+          aria-label='Send message'
+        >
+          <ArrowUp className='h-4 w-4' aria-hidden />
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+import { BrandLogo } from '@/components/atoms/BrandLogo';
+import { OnboardingChat } from './OnboardingChat';
+import { OnboardingTurnstile } from './OnboardingTurnstile';
+
+/**
+ * Outer shell for the anonymous onboarding chat (JOV-2132 PR 3).
+ *
+ * v1 is a calm, dark canvas with the chat as the only thing on the page.
+ * Cinematic reveal choreography (per the plan's 6-stage state machine)
+ * lands incrementally after real-artist watch sessions inform the timing.
+ *
+ * Holds the Turnstile token until the chat client wires its first request.
+ */
+interface OnboardingShellProps {
+  /** First 8 chars of the session id. Debug breadcrumb only — not sensitive. */
+  readonly sessionLabel: string;
+}
+
+export function OnboardingShell({ sessionLabel }: OnboardingShellProps) {
+  const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
+  const [turnstileError, setTurnstileError] = useState<string | null>(null);
+
+  return (
+    <div
+      className='flex min-h-dvh w-full flex-col bg-[#06070a] text-white [color-scheme:dark]'
+      data-onboarding-session={sessionLabel}
+    >
+      <header className='flex h-12 items-center justify-between px-4 sm:px-6'>
+        <div className='inline-flex items-center gap-2'>
+          <BrandLogo size={20} tone='white' aria-hidden />
+          <span className='text-[15px] font-semibold text-white'>Jovie</span>
+        </div>
+      </header>
+
+      <main className='mx-auto flex w-full max-w-[680px] flex-1 flex-col px-4 pb-4 sm:px-6'>
+        <OnboardingChat turnstileToken={turnstileToken} />
+      </main>
+
+      <OnboardingTurnstile
+        onToken={token => {
+          setTurnstileToken(token);
+          setTurnstileError(null);
+        }}
+        onError={message => setTurnstileError(message)}
+      />
+
+      {turnstileError ? (
+        <p
+          className='fixed bottom-3 left-1/2 -translate-x-1/2 rounded-full bg-red-500/15 px-3 py-1 text-[12px] text-red-300'
+          role='alert'
+        >
+          {turnstileError}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
+++ b/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import Script from 'next/script';
+import { useCallback, useEffect, useId, useRef } from 'react';
+import { publicEnv } from '@/lib/env-public';
+
+/**
+ * Cloudflare Turnstile widget for the onboarding chat (JOV-2132 PR 3).
+ *
+ * Loads the Turnstile script and mounts an invisible/managed widget. The
+ * resulting token is passed back via `onToken`, then consumed by the chat
+ * client on the first /api/chat POST in `mode='onboarding'`. Subsequent
+ * messages within the same session rely on the signed session cookie + the
+ * session-lifetime rate limiter and do NOT re-verify.
+ *
+ * If the site key isn't configured (local dev without Doppler creds), the
+ * widget short-circuits and the chat handler's dev-mode skip kicks in.
+ */
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        target: HTMLElement,
+        options: {
+          sitekey: string;
+          callback: (token: string) => void;
+          'error-callback'?: (code: string) => void;
+          'expired-callback'?: () => void;
+          appearance?: 'always' | 'execute' | 'interaction-only';
+          size?: 'normal' | 'flexible' | 'compact' | 'invisible';
+          theme?: 'auto' | 'light' | 'dark';
+        }
+      ) => string;
+      reset: (widgetId: string) => void;
+      remove: (widgetId: string) => void;
+    };
+  }
+}
+
+interface OnboardingTurnstileProps {
+  readonly onToken: (token: string) => void;
+  readonly onError: (message: string) => void;
+}
+
+export function OnboardingTurnstile({
+  onToken,
+  onError,
+}: OnboardingTurnstileProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const widgetIdRef = useRef<string | null>(null);
+  const widgetDomId = useId();
+  const siteKey = publicEnv.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+
+  const render = useCallback(() => {
+    if (!siteKey) return; // dev-only fallback handled server-side
+    if (!containerRef.current || !window.turnstile) return;
+    if (widgetIdRef.current) return; // already rendered
+    try {
+      widgetIdRef.current = window.turnstile.render(containerRef.current, {
+        sitekey: siteKey,
+        size: 'invisible',
+        appearance: 'interaction-only',
+        theme: 'dark',
+        callback: token => onToken(token),
+        'error-callback': code =>
+          onError(`bot challenge failed (${code}). try refreshing.`),
+        'expired-callback': () => {
+          if (widgetIdRef.current) {
+            window.turnstile?.reset(widgetIdRef.current);
+          }
+        },
+      });
+    } catch (err) {
+      onError('turnstile failed to load');
+      // biome-ignore lint/suspicious/noConsole: dev-time diagnostic
+      console.error('[onboarding] turnstile render error', err);
+    }
+  }, [onToken, onError, siteKey]);
+
+  useEffect(() => {
+    if (window.turnstile) {
+      render();
+    }
+    return () => {
+      const id = widgetIdRef.current;
+      if (id && window.turnstile) {
+        try {
+          window.turnstile.remove(id);
+        } catch {
+          // ignore — widget already torn down
+        }
+      }
+    };
+  }, [render]);
+
+  if (!siteKey) {
+    // No site key in dev — handler's dev-mode skip lets the chat proceed.
+    return null;
+  }
+
+  return (
+    <>
+      <Script
+        src='https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit'
+        strategy='afterInteractive'
+        onLoad={() => render()}
+      />
+      <div ref={containerRef} id={`cf-turnstile-${widgetDomId}`} aria-hidden />
+    </>
+  );
+}

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -141,6 +141,8 @@ export const APP_ROUTES = {
   ONBOARDING: '/onboarding',
   ONBOARDING_CHECKOUT: '/onboarding/checkout',
   WAITLIST: '/waitlist',
+  /** Anonymous onboarding chat (JOV-2132). Replaces /waitlist as the front door. */
+  START: '/start',
 
   // Billing
   BILLING: '/billing',


### PR DESCRIPTION
## Summary

Front-door for the unified Jovie AI chat is now live. Visitors land at \`/start\` (anonymous, no account required), hit the LLM dispatch PR 2 wired, and see streaming responses with tool-call markers.

This is PR 3 of 4 in JOV-2132. PR 4 wires checkout-in-chat + inline Clerk SignUp + post-claim cleanup.

## What ships

- **\`app/(dynamic)/start/page.tsx\`** — server component. Mints or resolves the signed onboarding session cookie via \`getOrMintOnboardingSessionId()\` before any client code runs, so the first \`/api/chat\` POST already has a stable session id. Placed under \`(dynamic)\` per the plan's marketing-static-rule carve-out. \`force-dynamic\`, noindex/nofollow.
- **\`OnboardingShell.tsx\`** — outer shell. Calm dark canvas, brand logo, holds the Turnstile token state. v1 visual is intentionally minimal; cinematic 6-stage reveal lands incrementally once watch sessions inform timing.
- **\`OnboardingChat.tsx\`** — client. Uses \`@ai-sdk/react useChat\` + \`DefaultChatTransport\` pointed at \`/api/chat\` with \`mode='onboarding'\`. \`prepareSendMessagesRequest\` closure attaches \`turnstileToken\` on the FIRST send and drops it on subsequent sends (session cookie + session-lifetime rate limiter carry trust forward).
- **\`OnboardingTurnstile.tsx\`** — Cloudflare Turnstile widget. Invisible/interaction-only/dark. Short-circuits when \`NEXT_PUBLIC_TURNSTILE_SITE_KEY\` is unset (local dev fallback — handler's \`NODE_ENV==='development'\` skip kicks in).
- **\`app/waitlist/page.tsx\`** — now a redirect. Authenticated-state checks preserved (banned → unavailable, active → dashboard, needs-onboarding → onboarding). Anonymous / waitlist-pending / default → \`/start\`.
- **\`constants/routes.ts\`** — adds \`APP_ROUTES.START = '/start'\`.

## What does NOT ship

- Dedicated tool-card UI (artist picker, handle picker, profile preview, access decision, checkout). Tool calls render as small inline chips for now; LLM still streams its text responses fully. Cards land on this branch in follow-up commits.
- Cinematic 6-stage reveal state machine. Shell scaffolds it but stages are not yet animated.
- \`WaitlistIntakeChat.tsx\` deletion — kept on disk per the plan as the deterministic fallback. PR 4 cleanup commit deletes it once \`/start\` has 48h of clean metrics.

## Test plan

- [x] \`pnpm --filter @jovie/web run typecheck\` — clean
- [x] \`pnpm biome check\` — clean
- [x] \`pnpm --filter web lint:server-boundaries\` — clean
- [x] \`vitest lib/chat lib/onboarding lib/turnstile tests/unit/api/chat\` — 107/107 pass (no regressions)
- [ ] Manual: open /start in incognito, expect a single chat bubble, send "I'm a musician" → expect streamed Stanley-voice response with tool-call chips for searchSpotifyArtist (full Spotify card in follow-up commits)
- [ ] 3 watch sessions with real artists before any marketing acquisition (per JOV-2132 plan)

## Linear

JOV-2132 — Unified Jovie AI chat front-door (PR 3 of 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New anonymous onboarding chat interface now available at `/start`
  * Added security verification layer to protect the onboarding flow
  * Streamlined user entry flow with updated routing behavior
  * Enhanced chat experience with real-time message streaming and auto-scrolling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8566)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->