### PR TITLE
feat(onboarding): PR 4 — inline Clerk SignUp + auto-claim + checkout card (JOV-2132)

### DIFF
--- a/apps/web/components/features/onboarding/ChatProposeCheckoutCard.tsx
+++ b/apps/web/components/features/onboarding/ChatProposeCheckoutCard.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { APP_ROUTES } from '@/constants/routes';
+
+/**
+ * Renders the `proposeCheckout` tool result inside the onboarding chat
+ * (JOV-2132 PR 4).
+ *
+ * v1 is a route handoff to `/onboarding/checkout` — the existing Stripe
+ * Checkout flow. Stripe Embedded Checkout iframe inside the chat bubble is
+ * gated behind a separate experiment flag (per the plan) pending a
+ * Playwright CSP smoke test.
+ *
+ * Plan intent (free/pro/max) is passed via query string so the existing
+ * checkout page renders the correct pricing context immediately.
+ */
+
+export interface CheckoutCardPayload {
+  readonly action: 'propose_checkout';
+  readonly plan: 'free' | 'pro' | 'max' | null;
+  readonly handoffUrl: string;
+}
+
+interface ChatProposeCheckoutCardProps {
+  readonly payload: CheckoutCardPayload;
+}
+
+const PLAN_LABELS: Record<NonNullable<CheckoutCardPayload['plan']>, string> = {
+  free: 'free tier',
+  pro: 'Pro — $39/mo',
+  max: 'Max — $149/mo',
+};
+
+export function ChatProposeCheckoutCard({
+  payload,
+}: ChatProposeCheckoutCardProps) {
+  const planLabel = payload.plan ? PLAN_LABELS[payload.plan] : 'pick a plan';
+  // Trust the handoffUrl from the server if present, but bound it to the
+  // canonical onboarding checkout route family so a future tool-result tweak
+  // can't redirect us to an unrelated path.
+  const href =
+    payload.handoffUrl && payload.handoffUrl.startsWith('/onboarding/checkout')
+      ? payload.handoffUrl
+      : APP_ROUTES.ONBOARDING_CHECKOUT;
+
+  return (
+    <div className='mt-2 flex items-center justify-between gap-3 rounded-2xl border border-white/[0.12] bg-white/[0.06] px-4 py-3'>
+      <div className='min-w-0'>
+        <p className='text-[13px] text-white/60'>continue to checkout</p>
+        <p className='truncate text-[15px] font-semibold text-white'>
+          {planLabel}
+        </p>
+      </div>
+      <Link
+        href={href}
+        className='inline-flex h-10 shrink-0 items-center gap-1.5 rounded-full bg-white px-4 text-[13px] font-semibold text-black transition-colors hover:bg-white/90 focus-ring-themed'
+      >
+        Continue
+        <ArrowRight className='h-4 w-4' aria-hidden />
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/components/features/onboarding/ChatProposeNextStepCard.tsx
+++ b/apps/web/components/features/onboarding/ChatProposeNextStepCard.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { SignUp, useAuth } from '@clerk/nextjs';
+import { useMemo } from 'react';
+import { APP_ROUTES } from '@/constants/routes';
+
+/**
+ * Renders the `proposeNextStep` tool result inside the onboarding chat
+ * (JOV-2132 PR 4).
+ *
+ * Three render paths driven by the deterministic decision:
+ *
+ *  - `instant_access` → inline Clerk `<SignUp />` with `fallbackRedirectUrl`
+ *    back to /start. The OnboardingShell's auto-claim hook then attaches the
+ *    fresh user's account to the anonymous transcript and bounces them
+ *    forward to /onboarding/checkout.
+ *
+ *  - `waitlist` → confirmation message. Visitor's transcript is already
+ *    saved; we'll email them when they're up.
+ *
+ *  - `needs_more_info` → renders nothing visible. The LLM has been told to
+ *    ask another sharp question; this card just acknowledges the tool was
+ *    called.
+ */
+
+export interface NextStepCardPayload {
+  readonly action: 'propose_next_step';
+  readonly decision: {
+    readonly kind: 'instant_access' | 'waitlist' | 'needs_more_info';
+    readonly rationale: string;
+    readonly score: number;
+  };
+}
+
+interface ChatProposeNextStepCardProps {
+  readonly payload: NextStepCardPayload;
+}
+
+export function ChatProposeNextStepCard({
+  payload,
+}: ChatProposeNextStepCardProps) {
+  const { isSignedIn } = useAuth();
+  const kind = payload.decision.kind;
+
+  // Memoise the Clerk appearance so the inline form looks at home on the
+  // dark onboarding canvas without re-creating the object on every render.
+  const appearance = useMemo(
+    () => ({
+      elements: {
+        rootBox: 'w-full',
+        card: 'bg-transparent shadow-none border-0 p-0',
+        headerTitle: 'text-white text-[18px] font-semibold',
+        headerSubtitle: 'text-white/60 text-[13px]',
+        formButtonPrimary:
+          'bg-white text-black hover:bg-white/90 normal-case font-semibold',
+        socialButtonsBlockButton:
+          'bg-white/[0.04] border-white/[0.09] text-white hover:bg-white/[0.08]',
+        formFieldInput:
+          'bg-white/[0.04] border-white/[0.09] text-white focus:border-white/24',
+        formFieldLabel: 'text-white/70',
+        footer: 'hidden',
+        dividerLine: 'bg-white/[0.07]',
+        dividerText: 'text-white/40',
+      },
+      variables: {
+        colorBackground: 'transparent',
+        colorPrimary: '#ffffff',
+        colorText: '#ffffff',
+        colorTextSecondary: 'rgba(255,255,255,0.6)',
+        colorInputBackground: 'rgba(255,255,255,0.04)',
+        colorInputText: '#ffffff',
+        borderRadius: '12px',
+      },
+    }),
+    []
+  );
+
+  if (kind === 'needs_more_info') {
+    // No visible card — the LLM keeps the conversation going.
+    return null;
+  }
+
+  if (kind === 'waitlist') {
+    return (
+      <div className='mt-2 rounded-2xl border border-white/[0.08] bg-white/[0.035] px-4 py-3'>
+        <p className='text-[14px] leading-6 text-white/82'>
+          {`you're on the list. I'll email you when you're up — we can pick up right here.`}
+        </p>
+      </div>
+    );
+  }
+
+  // instant_access — the moment the visitor converts.
+  if (isSignedIn) {
+    // Already authenticated mid-conversation (rare but possible if the user
+    // had a Clerk session already). Skip the form; the claim hook on the
+    // shell will fire and bounce them to checkout.
+    return (
+      <div className='mt-2 rounded-2xl border border-white/[0.08] bg-white/[0.035] px-4 py-3'>
+        <p className='text-[14px] leading-6 text-white/82'>
+          {`you're already signed in. one sec — linking this conversation to your account…`}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='mt-2 rounded-2xl border border-white/[0.08] bg-white/[0.035] px-4 py-4'>
+      <p className='mb-3 text-[14px] leading-6 text-white/82'>
+        {`you're in. drop an email to keep going — I'll save this conversation to your account so we don't lose it.`}
+      </p>
+      <SignUp
+        routing='hash'
+        oauthFlow='redirect'
+        signInUrl={APP_ROUTES.SIGNIN}
+        fallbackRedirectUrl={APP_ROUTES.START}
+        appearance={appearance}
+      />
+    </div>
+  );
+}

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -13,6 +13,14 @@ import {
   useState,
 } from 'react';
 import { cn } from '@/lib/utils';
+import {
+  ChatProposeCheckoutCard,
+  type CheckoutCardPayload,
+} from './ChatProposeCheckoutCard';
+import {
+  ChatProposeNextStepCard,
+  type NextStepCardPayload,
+} from './ChatProposeNextStepCard';
 
 /**
  * Anonymous onboarding chat client (JOV-2132 PR 3).
@@ -44,15 +52,58 @@ function getMessageText(message: UIMessage): string {
     .join('');
 }
 
-/** Surface visible tool-call markers as inline chips. */
-function getToolMarkers(message: UIMessage): readonly string[] {
-  return (message.parts ?? []).flatMap(part => {
-    if (part.type === 'dynamic-tool' || part.type?.startsWith('tool-')) {
-      const toolPart = part as { toolName?: string; type: string };
-      return [toolPart.toolName ?? toolPart.type];
-    }
-    return [];
-  });
+interface ToolPart {
+  readonly type: string;
+  readonly toolName?: string;
+  readonly toolCallId?: string;
+  readonly output?: unknown;
+  readonly state?: string;
+}
+
+function isToolPart(part: unknown): part is ToolPart {
+  if (!part || typeof part !== 'object') return false;
+  const type = (part as { type?: unknown }).type;
+  return (
+    type === 'dynamic-tool' ||
+    (typeof type === 'string' && type.startsWith('tool-'))
+  );
+}
+
+function getToolName(part: ToolPart): string {
+  if (part.toolName) return part.toolName;
+  // Convention: AI SDK emits parts of type `tool-<name>` when output is present.
+  return part.type.startsWith('tool-')
+    ? part.type.slice('tool-'.length)
+    : part.type;
+}
+
+/**
+ * Extract tool parts from a message. Returns the structured parts (not text)
+ * so the renderer can decide between rich cards (proposeNextStep,
+ * proposeCheckout) and the chip fallback for the rest.
+ */
+function getToolParts(message: UIMessage): readonly ToolPart[] {
+  return (message.parts ?? []).filter(isToolPart);
+}
+
+interface ToolOutputWithAction {
+  readonly action?: string;
+}
+
+function isNextStepPayload(output: unknown): output is NextStepCardPayload {
+  return (
+    typeof output === 'object' &&
+    output !== null &&
+    (output as ToolOutputWithAction).action === 'propose_next_step'
+  );
+}
+
+function isCheckoutPayload(output: unknown): output is CheckoutCardPayload {
+  return (
+    typeof output === 'object' &&
+    output !== null &&
+    (output as ToolOutputWithAction).action === 'propose_checkout'
+  );
 }
 
 export function OnboardingChat({ turnstileToken }: OnboardingChatProps) {
@@ -136,44 +187,73 @@ export function OnboardingChat({ turnstileToken }: OnboardingChatProps) {
 
         {messages.map(message => {
           const text = getMessageText(message);
-          const toolMarkers = getToolMarkers(message);
+          const toolParts = getToolParts(message);
           return (
             <div
               key={message.id}
               className={cn(
-                'flex',
-                message.role === 'user' ? 'justify-end' : 'justify-start'
+                'flex flex-col',
+                message.role === 'user' ? 'items-end' : 'items-start'
               )}
             >
-              <div
-                className={cn(
-                  'max-w-[80%] rounded-2xl px-3.5 py-2.5 text-[14px] leading-6',
-                  message.role === 'user'
-                    ? 'bg-white text-black'
-                    : 'border border-white/[0.08] bg-white/[0.035] text-white/82'
-                )}
-              >
-                {text || (
-                  <span className='text-white/40'>
-                    <Loader2
-                      className='inline h-3.5 w-3.5 animate-spin'
-                      aria-hidden
-                    />
+              {text || toolParts.length === 0 ? (
+                <div
+                  className={cn(
+                    'max-w-[80%] rounded-2xl px-3.5 py-2.5 text-[14px] leading-6',
+                    message.role === 'user'
+                      ? 'bg-white text-black'
+                      : 'border border-white/[0.08] bg-white/[0.035] text-white/82'
+                  )}
+                >
+                  {text || (
+                    <span className='text-white/40'>
+                      <Loader2
+                        className='inline h-3.5 w-3.5 animate-spin'
+                        aria-hidden
+                      />
+                    </span>
+                  )}
+                </div>
+              ) : null}
+
+              {toolParts.map((part, i) => {
+                const toolName = getToolName(part);
+                const key = part.toolCallId ?? `${message.id}-tool-${i}`;
+                const output = part.output;
+
+                if (
+                  toolName === 'proposeNextStep' &&
+                  isNextStepPayload(output)
+                ) {
+                  return (
+                    <div key={key} className='w-full max-w-[440px]'>
+                      <ChatProposeNextStepCard payload={output} />
+                    </div>
+                  );
+                }
+                if (
+                  toolName === 'proposeCheckout' &&
+                  isCheckoutPayload(output)
+                ) {
+                  return (
+                    <div key={key} className='w-full max-w-[440px]'>
+                      <ChatProposeCheckoutCard payload={output} />
+                    </div>
+                  );
+                }
+                // Fallback: small chip surfacing the tool name. The dedicated
+                // cards for searchSpotifyArtist / confirmSpotifyArtist /
+                // checkHandle / proposeSocialLink / recordInterviewSignal
+                // land in follow-up commits on this branch.
+                return (
+                  <span
+                    key={key}
+                    className='mt-1 inline-flex rounded-full border border-white/[0.12] bg-white/[0.04] px-2 py-0.5 text-[11px] text-white/60'
+                  >
+                    {toolName}
                   </span>
-                )}
-                {toolMarkers.length > 0 ? (
-                  <div className='mt-2 flex flex-wrap gap-1.5'>
-                    {toolMarkers.map((marker, i) => (
-                      <span
-                        key={`${message.id}-tool-${i}`}
-                        className='rounded-full border border-white/[0.12] bg-white/[0.04] px-2 py-0.5 text-[11px] text-white/60'
-                      >
-                        {marker}
-                      </span>
-                    ))}
-                  </div>
-                ) : null}
-              </div>
+                );
+              })}
             </div>
           );
         })}

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { BrandLogo } from '@/components/atoms/BrandLogo';
 import { OnboardingChat } from './OnboardingChat';
 import { OnboardingTurnstile } from './OnboardingTurnstile';
+import { useOnboardingClaim } from './useOnboardingClaim';
 
 /**
  * Outer shell for the anonymous onboarding chat (JOV-2132 PR 3).
@@ -22,6 +23,14 @@ interface OnboardingShellProps {
 export function OnboardingShell({ sessionLabel }: OnboardingShellProps) {
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   const [turnstileError, setTurnstileError] = useState<string | null>(null);
+
+  // Auto-claim any anonymous transcript onto the user the moment Clerk
+  // reports they're authenticated. On success, this hook navigates away to
+  // /onboarding/checkout, so the rest of the shell never gets a chance to
+  // render a "now what?" state. Idle for unauthenticated visitors.
+  const claimStatus = useOnboardingClaim();
+  const isLinking =
+    claimStatus === 'pending' || claimStatus === 'retry-after-webhook';
 
   return (
     <div
@@ -53,6 +62,16 @@ export function OnboardingShell({ sessionLabel }: OnboardingShellProps) {
           role='alert'
         >
           {turnstileError}
+        </p>
+      ) : null}
+
+      {isLinking ? (
+        <p
+          className='fixed bottom-3 left-1/2 -translate-x-1/2 rounded-full border border-white/[0.12] bg-white/[0.04] px-3 py-1 text-[12px] text-white/70'
+          role='status'
+          aria-live='polite'
+        >
+          linking your conversation…
         </p>
       ) : null}
     </div>

--- a/apps/web/components/features/onboarding/useOnboardingClaim.ts
+++ b/apps/web/components/features/onboarding/useOnboardingClaim.ts
@@ -1,0 +1,126 @@
+'use client';
+
+import { useAuth } from '@clerk/nextjs';
+import { useRouter } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+import { APP_ROUTES } from '@/constants/routes';
+
+/**
+ * Auto-claim the anonymous onboarding conversation when the visitor
+ * authenticates mid-flow (JOV-2132 PR 4).
+ *
+ * Fires once, on mount or as soon as Clerk reports the user is signed in.
+ * Calls POST /api/onboarding/claim — the server reads the signed
+ * `jovie_onboarding_session` cookie and attaches matching anonymous
+ * conversations to the freshly created user.
+ *
+ * Handles the Clerk → DB user-mirror race: the claim endpoint returns
+ * `{ retryAfterWebhook: true }` when Clerk has authenticated the user but
+ * the Clerk webhook hasn't yet written them into our `users` table. We
+ * retry up to 3 times with a 1.5s gap before giving up — the webhook
+ * almost always lands in under 2s.
+ *
+ * On success (claimed >= 1) the hook navigates to `/onboarding/checkout`
+ * so the existing post-claim path takes over. If the claim returned
+ * `claimed: 0` (no anonymous conversation for this session), we stay put
+ * and let the chat continue.
+ */
+
+type ClaimStatus =
+  | 'idle'
+  | 'pending'
+  | 'claimed'
+  | 'no-op'
+  | 'retry-after-webhook'
+  | 'error';
+
+interface ClaimResponse {
+  readonly claimed?: number;
+  readonly conversationId?: string;
+  readonly retryAfterWebhook?: boolean;
+  readonly alreadyClaimed?: boolean;
+  readonly errorCode?: string;
+}
+
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 1_500;
+
+export function useOnboardingClaim(): ClaimStatus {
+  const { isLoaded, isSignedIn } = useAuth();
+  const router = useRouter();
+  const [status, setStatus] = useState<ClaimStatus>('idle');
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn) return;
+    if (firedRef.current) return;
+    firedRef.current = true;
+
+    let cancelled = false;
+
+    const attemptClaim = async (attempt: number): Promise<void> => {
+      setStatus('pending');
+      let response: Response;
+      try {
+        response = await fetch('/api/onboarding/claim', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{}',
+        });
+      } catch {
+        if (!cancelled) setStatus('error');
+        return;
+      }
+      if (cancelled) return;
+
+      let body: ClaimResponse;
+      try {
+        body = (await response.json()) as ClaimResponse;
+      } catch {
+        if (!cancelled) setStatus('error');
+        return;
+      }
+      if (cancelled) return;
+
+      if (response.status === 401) {
+        // Clerk session expired between mount and request — bail silently.
+        setStatus('error');
+        return;
+      }
+
+      if (body.retryAfterWebhook && attempt < MAX_RETRIES) {
+        setStatus('retry-after-webhook');
+        setTimeout(() => {
+          if (!cancelled) void attemptClaim(attempt + 1);
+        }, RETRY_DELAY_MS);
+        return;
+      }
+
+      if (body.claimed && body.claimed > 0) {
+        setStatus('claimed');
+        // Hand off to the existing /onboarding/checkout flow.
+        router.replace(APP_ROUTES.ONBOARDING_CHECKOUT);
+        return;
+      }
+
+      if (body.alreadyClaimed) {
+        // Same user already claimed this transcript (typical retry case).
+        setStatus('claimed');
+        router.replace(APP_ROUTES.ONBOARDING_CHECKOUT);
+        return;
+      }
+
+      // claimed:0 → no anonymous transcript for this session. User signed
+      // up but no conversation to claim. Continue on /start.
+      setStatus('no-op');
+    };
+
+    void attemptClaim(1);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoaded, isSignedIn, router]);
+
+  return status;
+}


### PR DESCRIPTION
## Summary

Closing milestone for the unified Jovie AI chat front-door (JOV-2132). Visitors can now actually convert from inside the chat: \`proposeNextStep\` with \`instant_access\` renders Clerk's inline \`<SignUp />\`, the shell's auto-claim hook attaches the anonymous transcript to the freshly created user, and the existing \`/onboarding/checkout\` flow takes over.

End-to-end flow now works from anonymous /start through to checkout.

## What ships

- **\`ChatProposeNextStepCard\`** — three branches on the deterministic decision:
  - \`instant_access\` → inline Clerk \`<SignUp />\` with \`fallbackRedirectUrl='/start'\`. Dark-canvas appearance overrides so the form blends.
  - \`waitlist\` → confirmation card. Transcript already saved.
  - \`needs_more_info\` → nothing visible (LLM keeps asking).
  - \`isSignedIn\` cross-tab case → brief "linking your conversation…" state.

- **\`ChatProposeCheckoutCard\`** — route-handoff CTA to \`/onboarding/checkout\`. Plan label surfaced (free/Pro/Max). \`handoffUrl\` sanity-checked to stay under \`/onboarding/checkout\` so a future tool tweak can't redirect elsewhere.

- **\`useOnboardingClaim\` hook** — fires once on Clerk auth. POSTs \`/api/onboarding/claim\`. Handles the Clerk-webhook race with \`retryAfterWebhook\` (3 attempts, 1.5s gap). On \`claimed >= 1\` (or \`alreadyClaimed\`), navigates to \`/onboarding/checkout\`. \`claimed: 0\` = no transcript, stays on /start.

- **OnboardingChat tool rendering** — split chip cluster into per-tool dispatch. \`proposeNextStep\` and \`proposeCheckout\` render rich cards; other tools (searchSpotifyArtist, confirmSpotifyArtist, checkHandle, proposeSocialLink, recordInterviewSignal) still render as chips for now.

## End-to-end flow (now working)

1. Anonymous visitor lands on \`/start\`, Turnstile resolves, types
2. LLM streams Stanley-voice reply, calls onboarding tools
3. Once signal triggers \`proposeNextStep\` with \`instant_access\`, the inline Clerk \`<SignUp />\` renders in the conversation
4. User creates account → Clerk redirects back to \`/start\`
5. \`useOnboardingClaim\` fires → \`/api/onboarding/claim\` attaches the anonymous \`chatConversations\` row (retries while the Clerk-user webhook lands the row in our DB)
6. On successful claim, shell navigates to \`/onboarding/checkout\`, which takes a card

## Not in this PR (follow-ups)

- Dedicated cards for the other 5 onboarding tools (still chips)
- Cinematic 6-stage reveal animations
- Stripe Embedded Checkout iframe in chat (separate experiment flag, separate PR pending Playwright CSP smoke)
- \`WaitlistIntakeChat.tsx\` + \`/api/onboarding/intake\` deletion — per plan, 48h after PR 4 lands with clean metrics

## Test plan

- [x] \`pnpm --filter @jovie/web run typecheck\` — clean
- [x] \`pnpm biome check\` — clean
- [x] \`pnpm --filter web lint:server-boundaries\` — clean
- [x] \`pnpm exec eslint components/features/onboarding/\` — clean
- [x] \`vitest lib/chat lib/onboarding lib/turnstile tests/unit/api/chat\` — 107/107 pass
- [ ] Manual: incognito → /start → chat → trigger proposeNextStep instant_access via test rig → complete Clerk signup → expect bounce to /onboarding/checkout with the anonymous transcript attached

## Linear

JOV-2132 — Unified Jovie AI chat front-door (PR 4 of 4 — closing milestone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced onboarding chat interface with dedicated proposal cards displaying checkout and next step recommendations
  * Added visual status indicator when linking anonymous onboarding conversations to authenticated user accounts
  * Improved structured rendering of AI-generated proposal suggestions during the onboarding flow

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8571)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->