### PR TITLE
fix(profile-drawer): keep view stable under releases data churn (JOV-2150)

### DIFF
--- a/apps/web/components/features/profile/ProfileUnifiedDrawer.tsx
+++ b/apps/web/components/features/profile/ProfileUnifiedDrawer.tsx
@@ -309,14 +309,15 @@ export function ProfileUnifiedDrawer({
     visibleReleases.length,
   ]);
 
-  useEffect(() => {
-    if (view === 'releases' && !canOpenReleasesDrawer) {
-      onViewChange('menu');
-    }
-    if (view === 'tour' && !canOpenTourDrawer) {
-      onViewChange('menu');
-    }
-  }, [canOpenReleasesDrawer, canOpenTourDrawer, onViewChange, view]);
+  // Intentionally do NOT mutate `view` when capability flips false.
+  // `resolveRenderedView` already returns 'menu' for that case (line 124),
+  // and `resolveViewMeta` falls back to the menu title (line 104). Mutating
+  // here causes the drawer to flicker whenever the releases query refetches
+  // and transiently returns empty data — the effect would snap view back to
+  // 'menu', the data would resolve, and the user would see a blink as the
+  // drawer re-rendered releases content. The view stays as 'releases' in
+  // parent state; rendering is the source of truth for what the user sees.
+  // See JOV-2150.
 
   const venmoLink =
     socialLinks.find(link => link.platform === 'venmo')?.url ?? null;

--- a/apps/web/tests/unit/profile/ProfileUnifiedDrawerStability.test.tsx
+++ b/apps/web/tests/unit/profile/ProfileUnifiedDrawerStability.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * No-flicker regression tests for ProfileUnifiedDrawer (JOV-2150).
+ *
+ * The original bug: an effect mutated `view` → 'menu' the moment
+ * `canOpenReleasesDrawer` flipped false during a releases query refetch.
+ * When the data resolved, the drawer rendered releases again — producing
+ * a visible flicker. The fix removed the effect; `resolveRenderedView`
+ * handles the render-time fallback without mutating state.
+ *
+ * Invariant: when capability transiently flips false (refetch with empty
+ * data), the drawer must NOT call `onViewChange`.
+ */
+import { cleanup, render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import type { PublicRelease } from '@/components/features/profile/releases/types';
+import type { Artist } from '@/types/db';
+
+// ─── Mocks aligned with ProfileUnifiedDrawerReleases.test.tsx ────────────────
+
+vi.mock('@/features/profile/ProfileDrawerShell', () => ({
+  ProfileDrawerShell: ({
+    open,
+    onOpenChange,
+    title,
+    children,
+    dataTestId,
+  }: {
+    readonly open: boolean;
+    readonly onOpenChange: (open: boolean) => void;
+    readonly title: string;
+    readonly children: React.ReactNode;
+    readonly dataTestId?: string;
+  }) => (
+    <div data-testid={dataTestId ?? 'profile-drawer-shell'}>
+      {open ? (
+        <button
+          type='button'
+          data-testid='profile-drawer-shell-close'
+          onClick={() => onOpenChange(false)}
+        >
+          Close
+        </button>
+      ) : null}
+      <div data-testid='drawer-title'>{title}</div>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('@/features/profile/AboutSection', () => ({
+  AboutSection: () => <div data-testid='about-section' />,
+}));
+
+vi.mock('@/features/profile/TourModePanel', () => ({
+  TourDrawerContent: () => <div data-testid='tour-drawer-content' />,
+}));
+
+vi.mock('@/features/profile/StaticListenInterface', () => ({
+  StaticListenInterface: () => <div data-testid='static-listen-interface' />,
+}));
+
+vi.mock('@/features/profile/artist-notifications-cta', () => ({
+  TwoStepNotificationsCTA: () => <div data-testid='two-step-notifications' />,
+  ArtistNotificationsCTA: () => <div data-testid='artist-notifications' />,
+}));
+
+vi.mock('@/components/molecules/TipSelector', () => ({
+  TipSelector: () => <div data-testid='tip-selector' />,
+}));
+
+vi.mock('@/features/profile/artist-contacts-button/useArtistContacts', () => ({
+  useArtistContacts: () => ({
+    getActionHref: () => 'mailto:test@example.com',
+    trackAction: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }));
+
+vi.mock('@/components/atoms/ImageWithFallback', () => ({
+  ImageWithFallback: ({ alt }: { readonly alt: string }) => (
+    <img alt={alt} data-testid='release-artwork' />
+  ),
+}));
+
+const mockArtist: Artist = {
+  id: 'artist-1',
+  name: 'Test Artist',
+  handle: 'testartist',
+  image_url: null,
+  tagline: null,
+  location: null,
+  hometown: null,
+  career_highlights: null,
+  is_public: true,
+  is_verified: false,
+  active_since_year: null,
+  published: true,
+  is_verified_flag: false,
+};
+
+function makeRelease(overrides: Partial<PublicRelease> = {}): PublicRelease {
+  return {
+    id: `release-${Math.random().toString(36).slice(2)}`,
+    title: 'Test Song',
+    slug: 'test-song',
+    releaseType: 'single',
+    releaseDate: '2024-06-15T00:00:00.000Z',
+    artworkUrl: 'https://example.com/art.jpg',
+    artistNames: ['Test Artist'],
+    ...overrides,
+  };
+}
+
+const baseProps = {
+  open: true,
+  view: 'releases' as const,
+  artist: mockArtist,
+  socialLinks: [],
+  contacts: [],
+  primaryChannel: vi.fn() as never,
+  dsps: [],
+  isSubscribed: false,
+  contentPrefs: { newMusic: true, tourDates: true, merch: true, general: true },
+  onTogglePref: vi.fn(),
+  onUnsubscribe: vi.fn(),
+  isUnsubscribing: false,
+  onShare: vi.fn(),
+  hasAbout: false,
+  hasTourDates: false,
+  hasTip: false,
+  hasContacts: false,
+};
+
+let ProfileUnifiedDrawer: typeof import('@/features/profile/ProfileUnifiedDrawer').ProfileUnifiedDrawer;
+
+describe('ProfileUnifiedDrawer — no-flicker invariant (JOV-2150)', () => {
+  beforeAll(async () => {
+    ({ ProfileUnifiedDrawer } = await import(
+      '@/features/profile/ProfileUnifiedDrawer'
+    ));
+  }, 10_000);
+
+  afterEach(() => cleanup());
+
+  it('does NOT call onViewChange when releases data transiently empties', () => {
+    const onViewChange = vi.fn();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <ProfileUnifiedDrawer
+        {...(baseProps as never)}
+        onOpenChange={onOpenChange}
+        onViewChange={onViewChange}
+        hasReleases={true}
+        releases={[makeRelease({ id: 'r1', slug: 'first', title: 'First' })]}
+      />
+    );
+
+    // Simulate refetch race: data temporarily empty.
+    rerender(
+      <ProfileUnifiedDrawer
+        {...(baseProps as never)}
+        onOpenChange={onOpenChange}
+        onViewChange={onViewChange}
+        hasReleases={false}
+        releases={[]}
+      />
+    );
+
+    // The drawer must keep view='releases' in parent state. The pre-fix
+    // effect would have called onViewChange('menu') here, producing the
+    // flicker — the post-fix rendering handles this without mutation.
+    expect(onViewChange).not.toHaveBeenCalled();
+  });
+
+  it('recovers cleanly when releases data comes back without mutating view', () => {
+    const onViewChange = vi.fn();
+    const onOpenChange = vi.fn();
+
+    const { rerender } = render(
+      <ProfileUnifiedDrawer
+        {...(baseProps as never)}
+        onOpenChange={onOpenChange}
+        onViewChange={onViewChange}
+        hasReleases={false}
+        releases={[]}
+      />
+    );
+
+    expect(onViewChange).not.toHaveBeenCalled();
+
+    rerender(
+      <ProfileUnifiedDrawer
+        {...(baseProps as never)}
+        onOpenChange={onOpenChange}
+        onViewChange={onViewChange}
+        hasReleases={true}
+        releases={[makeRelease({ id: 'r1', slug: 'first', title: 'First' })]}
+      />
+    );
+
+    expect(onViewChange).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Drops the `useEffect` in `ProfileUnifiedDrawer` that snapped `view` back to `'menu'` whenever `canOpenReleasesDrawer`/`canOpenTourDrawer` flipped false. That effect was the source of the visible flicker — `resolveRenderedView`/`resolveViewMeta` already handle the no-capability render case without mutating state.
- New `ProfileUnifiedDrawerStability.test.tsx` rerenders the drawer with `hasReleases` going true → false → true and asserts `onViewChange` is never called. Pre-fix this test fails on the false transition; post-fix it passes.

Linear: JOV-2150 (sub-issue of JOV-2148).
Stacked on: #8585 (PR A introduces the `dom-stability` helper used by the upcoming PR C stability spec).

## Bug

The profile drawer was opening and closing intermittently when the releases query refetched (window focus, mutation invalidation). The transient empty result tripped a guard effect that mutated parent state back to `'menu'`, producing a visible blink when the data resolved.

## Root cause

`ProfileUnifiedDrawer.tsx:312-319`:
```ts
useEffect(() => {
  if (view === 'releases' && !canOpenReleasesDrawer) {
    onViewChange('menu');
  }
  ...
}, [canOpenReleasesDrawer, canOpenTourDrawer, onViewChange, view]);
```

`canOpenReleasesDrawer = hasReleases && visibleReleases.length > 0` goes false transiently during refetch. The effect fired, parent state mutated, and the drawer's render cycle thrashed.

## Fix

Drop the effect. The render-time helpers already cover the case:
- `resolveRenderedView` (line 124): when `view === 'releases'` and `!canOpenReleasesDrawer`, returns `'menu'` so the menu content renders.
- `resolveViewMeta` (line 104): same condition, returns the menu title.

Parent `view` state stays as `'releases'`. When data resolves, the drawer renders releases without unmounting. No flicker because nothing mounted/unmounted in between.

## What about state-vs-URL drift?

The URL (or whatever parent owns) can briefly hold `view=releases` while rendering menu. This is intentional: the user *wanted* releases; we're holding their intent until data resolves. The alternative — mutating their intent on transient empty data — is the bug.

## Coverage

- **Unit invariant**: `tests/unit/profile/ProfileUnifiedDrawerStability.test.tsx`. Two tests cover the false→true and true→false→true sequences and assert `onViewChange` is never called. Existing 18-test `ProfileUnifiedDrawerReleases.test.tsx` continues to pass.
- **Filed follow-up**: JOV-2158 covers the Playwright stability spec for the dashboard preview drawer (the surface where the bug actually manifests — public profile uses SSR/RSC and doesn't expose the refetch).

## Test plan

- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] `pnpm --filter web exec vitest run tests/unit/profile/ProfileUnifiedDrawerStability.test.tsx tests/unit/profile/ProfileUnifiedDrawerReleases.test.tsx` — 20 tests pass
- [ ] CI: build, lint, full test suite
- [ ] Manual: `/app/dashboard/earnings` → open profile preview → releases drawer → throttle network and refetch; assert no blink

🤖 Generated with [Claude Code](https://claude.com/claude-code)