### PR TITLE
feat(testing-helpers): e2e stability hook + 3 specs (JOV-2162)

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/presence/loading.tsx
+++ b/apps/web/app/app/(shell)/dashboard/presence/loading.tsx
@@ -7,6 +7,7 @@ export default function PresenceLoading() {
     <div
       className='flex h-full min-h-0 flex-col bg-[color-mix(in_oklab,var(--linear-bg-page)_72%,var(--linear-bg-surface-1))]'
       aria-busy='true'
+      data-testid='presence-loading-skeleton'
     >
       {/* Summary bar skeleton */}
       <div className='shrink-0 border-b border-(--linear-app-frame-seam) px-3 py-2.5 lg:px-4'>

--- a/apps/web/components/providers/QueryProvider.tsx
+++ b/apps/web/components/providers/QueryProvider.tsx
@@ -7,8 +7,14 @@ import {
   QueryClientProvider,
 } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { isDevChromeDisabledClient } from '@/lib/demo-recording';
+
+declare global {
+  interface Window {
+    __JOVIE_E2E_INVALIDATE_QUERIES__?: (queryKeyPrefix: string[]) => void;
+  }
+}
 
 // Lazy load devtools only in development to avoid production bundle bloat
 const ReactQueryDevtools = dynamic(
@@ -120,6 +126,26 @@ interface QueryProviderProps {
 export function QueryProvider({ children }: QueryProviderProps) {
   // Use useState to ensure client gets the singleton on hydration
   const [queryClient] = useState(getQueryClient);
+
+  // Gated E2E-only hook: exposes window.__JOVIE_E2E_INVALIDATE_QUERIES__ so
+  // Playwright specs can trigger a TanStack Query invalidation and assert the
+  // UI stays stable during async churn. Never active in production.
+  // Gating mirrors the DevToolsLoader pattern above.
+  useEffect(() => {
+    if (
+      process.env.NEXT_PUBLIC_E2E_MODE !== '1' ||
+      process.env.NODE_ENV === 'production'
+    ) {
+      return;
+    }
+    window.__JOVIE_E2E_INVALIDATE_QUERIES__ = (queryKeyPrefix: string[]) => {
+      console.info('[E2E] invalidating', queryKeyPrefix);
+      void queryClient.invalidateQueries({ queryKey: queryKeyPrefix });
+    };
+    return () => {
+      delete window.__JOVIE_E2E_INVALIDATE_QUERIES__;
+    };
+  }, [queryClient]);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/apps/web/tests/e2e/dashboard-profile-drawer-stability.spec.ts
+++ b/apps/web/tests/e2e/dashboard-profile-drawer-stability.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * E2E stability spec: release sidebar (profile drawer) must stay open and
+ * not flash a loading skeleton during a background query invalidation.
+ *
+ * Regression guard for JOV-2150 / JOV-2158 / JOV-2162. Unit-level invariant
+ * for ProfileUnifiedDrawer is in tests/unit. This spec adds a Playwright guard
+ * that the drawer's DOM state is stable when TanStack Query invalidates
+ * the releases cache while the drawer is open.
+ *
+ * How it works:
+ * 1. Auth via the dev bypass to the releases page with a creator-ready session.
+ * 2. Wait for at least one release row to be visible.
+ * 3. Click the first release row to open the release sidebar.
+ * 4. Wait for data-testid="release-sidebar" to be visible.
+ * 5. Trigger window.__JOVIE_E2E_INVALIDATE_QUERIES__(['releases']).
+ * 6. assertDomStable confirms the sidebar stays open and the drawer loading
+ *    skeleton never appears for 2 seconds.
+ *
+ * Run:
+ *   doppler run -- pnpm --filter web exec playwright test dashboard-profile-drawer-stability --project=chromium
+ *
+ * @stability @smoke
+ */
+
+import { expect, test } from '@playwright/test';
+import { assertDomStable } from '../helpers/dom-stability';
+
+const BYPASS_URL =
+  '/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/dashboard/releases';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test('release sidebar stays stable during background query invalidation', async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+
+  const consoleErrors: string[] = [];
+  page.on('pageerror', err => consoleErrors.push(String(err)));
+
+  // Auth and navigate to releases
+  await page.goto(BYPASS_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForURL(/\/app\/dashboard\/releases/, { timeout: 60_000 });
+
+  // Wait for the skeleton to disappear — page is ready
+  await expect(page.locator('[data-testid="releases-loading"]')).toHaveCount(
+    0,
+    {
+      timeout: 30_000,
+    }
+  );
+
+  // Open the first release row to show the sidebar.
+  // ShellReleasesView renders rows in a listbox; click the first option.
+  const firstRow = page.locator('[role="listbox"] [role="option"]').first();
+  const hasRows = await firstRow.count();
+
+  if (hasRows === 0) {
+    // No releases available for this persona — skip drawer test gracefully.
+    test.skip();
+    return;
+  }
+
+  await firstRow.click();
+
+  // Wait for the release sidebar to open
+  await expect(page.locator('[data-testid="release-sidebar"]')).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // Assert the sidebar stays visible and no drawer loading skeleton appears
+  // while a background query invalidation is in flight.
+  await assertDomStable(page, {
+    selector: '[data-testid="release-sidebar"]',
+    absentSelector: '[data-testid="drawer-loading-skeleton"]',
+    durationMs: 2000,
+    while: async () => {
+      await page.evaluate(() => {
+        window.__JOVIE_E2E_INVALIDATE_QUERIES__?.(['releases']);
+      });
+    },
+  });
+
+  // No uncaught JS errors during the stability window
+  const ignorable = [/clerk|handshake|dev-browser/i, /sentry/i, /favicon/i];
+  const relevant = consoleErrors.filter(e => !ignorable.some(rx => rx.test(e)));
+  expect(
+    relevant,
+    `Unexpected console errors during stability window: ${relevant.join('\n')}`
+  ).toEqual([]);
+});

--- a/apps/web/tests/e2e/presence-page-stability.spec.ts
+++ b/apps/web/tests/e2e/presence-page-stability.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * E2E stability spec: presence (DSP) page must not flash a loading skeleton
+ * during a background query invalidation (async data churn).
+ *
+ * Regression guard for JOV-2162. Analogous to releases-page-stability.spec.ts.
+ * The presence page's loading.tsx skeleton (data-testid="presence-loading-skeleton")
+ * should never appear once the page is fully loaded — only on a true cold load
+ * before any data is in cache.
+ *
+ * How it works:
+ * 1. Auth via the dev bypass to a creator-ready session.
+ * 2. Wait for the DSP presence content panel to be visible.
+ * 3. Call window.__JOVIE_E2E_INVALIDATE_QUERIES__(['dsp-enrichment']) to force
+ *    a background refetch.
+ * 4. assertDomStable confirms the skeleton NEVER appears for 2 seconds and
+ *    the content panel remains visible.
+ *
+ * Run:
+ *   doppler run -- pnpm --filter web exec playwright test presence-page-stability --project=chromium
+ *
+ * @stability @smoke
+ */
+
+import { expect, test } from '@playwright/test';
+import { assertDomStable } from '../helpers/dom-stability';
+
+const BYPASS_URL =
+  '/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/dashboard/presence';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test('presence page stays stable during background query invalidation', async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+
+  const consoleErrors: string[] = [];
+  page.on('pageerror', err => consoleErrors.push(String(err)));
+
+  // Auth and navigate to presence page
+  await page.goto(BYPASS_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForURL(/\/app\/dashboard\/presence/, { timeout: 60_000 });
+
+  // Wait for the presence content panel to be visible (skeleton gone)
+  await expect(
+    page.locator('[data-testid="dsp-presence-content-panel"]')
+  ).toBeVisible({ timeout: 30_000 });
+
+  // Trigger a background invalidation and assert no skeleton appears
+  await assertDomStable(page, {
+    selector: '[data-testid="dsp-presence-content-panel"]',
+    absentSelector: '[data-testid="presence-loading-skeleton"]',
+    durationMs: 2000,
+    while: async () => {
+      await page.evaluate(() => {
+        window.__JOVIE_E2E_INVALIDATE_QUERIES__?.(['dsp-enrichment']);
+      });
+    },
+  });
+
+  // No uncaught JS errors during the stability window
+  const ignorable = [/clerk|handshake|dev-browser/i, /sentry/i, /favicon/i];
+  const relevant = consoleErrors.filter(e => !ignorable.some(rx => rx.test(e)));
+  expect(
+    relevant,
+    `Unexpected console errors during stability window: ${relevant.join('\n')}`
+  ).toEqual([]);
+});

--- a/apps/web/tests/e2e/releases-page-stability.spec.ts
+++ b/apps/web/tests/e2e/releases-page-stability.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * E2E stability spec: releases page must not flash a loading skeleton
+ * during a background query invalidation (async data churn).
+ *
+ * Regression guard for JOV-2151 / JOV-2162. The unit invariant in
+ * ReleasesPageClient.test.tsx pins the `data === undefined` skeleton gate.
+ * This spec provides an additional Playwright-layer guard that the DOM
+ * remains stable when TanStack Query invalidates the releases cache.
+ *
+ * How it works:
+ * 1. Auth via the dev bypass so we get a fully-loaded creator-ready session.
+ * 2. Wait for the releases view to be visible (no skeleton).
+ * 3. Call window.__JOVIE_E2E_INVALIDATE_QUERIES__(['releases']) to force a
+ *    background refetch — the same event that previously caused flicker.
+ * 4. assertDomStable confirms the skeleton NEVER appears for 2 seconds.
+ *
+ * Run:
+ *   doppler run -- pnpm --filter web exec playwright test releases-page-stability --project=chromium
+ *
+ * @stability @smoke
+ */
+
+import { expect, test } from '@playwright/test';
+import { assertDomStable } from '../helpers/dom-stability';
+
+const BYPASS_URL =
+  '/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/dashboard/releases';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test('releases page stays stable during background query invalidation', async ({
+  page,
+}) => {
+  test.setTimeout(120_000);
+
+  const consoleErrors: string[] = [];
+  page.on('pageerror', err => consoleErrors.push(String(err)));
+
+  // Auth and navigate to releases
+  await page.goto(BYPASS_URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForURL(/\/app\/dashboard\/releases/, { timeout: 60_000 });
+
+  // Wait for the releases view to be fully rendered (no skeleton)
+  // ShellReleasesView renders data-testid="shell-releases-view" when DESIGN_V1 is on.
+  // ReleasesExperience is the legacy path. Either way, wait for the skeleton to be gone.
+  await expect(page.locator('[data-testid="releases-loading"]')).toHaveCount(
+    0,
+    {
+      timeout: 30_000,
+    }
+  );
+
+  // Confirm the page has a releases view rendered (shell view or legacy matrix)
+  const hasShellView = await page
+    .locator('[data-testid="shell-releases-view"]')
+    .count();
+  if (hasShellView === 0) {
+    // Legacy provider matrix path — ensure any content container is present
+    await expect(page.locator('[role="main"]')).toBeVisible({
+      timeout: 15_000,
+    });
+  }
+
+  // Trigger a background invalidation via the E2E hook and assert no skeleton appears
+  await assertDomStable(page, {
+    absentSelector: '[data-testid="releases-loading"]',
+    durationMs: 2000,
+    while: async () => {
+      await page.evaluate(() => {
+        window.__JOVIE_E2E_INVALIDATE_QUERIES__?.(['releases']);
+      });
+    },
+  });
+
+  // No uncaught JS errors during the stability window
+  const ignorable = [/clerk|handshake|dev-browser/i, /sentry/i, /favicon/i];
+  const relevant = consoleErrors.filter(e => !ignorable.some(rx => rx.test(e)));
+  expect(
+    relevant,
+    `Unexpected console errors during stability window: ${relevant.join('\n')}`
+  ).toEqual([]);
+});

--- a/apps/web/tests/helpers/dom-stability.ts
+++ b/apps/web/tests/helpers/dom-stability.ts
@@ -1,0 +1,110 @@
+/**
+ * Playwright helper: assert that a target element remains stably mounted
+ * and visible during a user interaction or async data churn window.
+ *
+ * Catches gotcha class #3 from JOV-2148: state flicker during async churn
+ * (drawer briefly closes during query refetch, table remounts on window
+ * focus, skeleton flashes on background refetch).
+ *
+ * Usage:
+ *
+ * ```ts
+ * await assertDomStable(page, {
+ *   selector: '[data-testid="profile-drawer"][data-state="open"]',
+ *   absentSelector: '[data-testid="release-table-skeleton"]',
+ *   durationMs: 2000,
+ *   while: async () => {
+ *     // trigger refetch / mutation here
+ *     await page.evaluate(() => window.dispatchEvent(new Event('focus')));
+ *   },
+ * });
+ * ```
+ *
+ * The helper polls the DOM at `intervalMs` and fails the test if at any
+ * sample the present selector is missing OR the absent selector appears.
+ */
+import type { Page } from '@playwright/test';
+
+export interface DomStabilityOptions {
+  /** Selector that MUST remain present and visible the entire window. */
+  readonly selector?: string;
+  /** Selector that MUST NOT appear at any point in the window. */
+  readonly absentSelector?: string;
+  /** Window length in ms. Default 2000. */
+  readonly durationMs?: number;
+  /** Sample interval in ms. Default 50. */
+  readonly intervalMs?: number;
+  /** Async work to run concurrently with the observation. */
+  readonly while?: () => Promise<void>;
+}
+
+export interface DomStabilityViolation {
+  readonly tMs: number;
+  readonly reason: 'missing-present' | 'unexpected-absent';
+  readonly selector: string;
+}
+
+export async function assertDomStable(
+  page: Page,
+  options: DomStabilityOptions
+): Promise<void> {
+  const duration = options.durationMs ?? 2000;
+  const interval = options.intervalMs ?? 50;
+  // Fail fast on misconfiguration. A silently-passing stability check is
+  // worse than no check at all — it produces false confidence that the
+  // DOM was stable when the helper simply never observed anything.
+  // (CodeRabbit JOV-2149 review.)
+  if (duration <= 0) {
+    throw new Error('assertDomStable: durationMs must be > 0');
+  }
+  if (interval <= 0) {
+    throw new Error('assertDomStable: intervalMs must be > 0');
+  }
+  if (!options.selector && !options.absentSelector) {
+    throw new Error(
+      'assertDomStable: provide selector and/or absentSelector — nothing to observe'
+    );
+  }
+  const violations: DomStabilityViolation[] = [];
+  const start = Date.now();
+
+  const observation = (async () => {
+    while (Date.now() - start < duration) {
+      const tMs = Date.now() - start;
+      if (options.selector) {
+        const ok = await page.locator(options.selector).first().isVisible();
+        if (!ok)
+          violations.push({
+            tMs,
+            reason: 'missing-present',
+            selector: options.selector,
+          });
+      }
+      if (options.absentSelector) {
+        const present = await page
+          .locator(options.absentSelector)
+          .first()
+          .count();
+        if (present > 0)
+          violations.push({
+            tMs,
+            reason: 'unexpected-absent',
+            selector: options.absentSelector,
+          });
+      }
+      await page.waitForTimeout(interval);
+    }
+  })();
+
+  await Promise.all([observation, options.while?.() ?? Promise.resolve()]);
+
+  if (violations.length === 0) return;
+
+  const lines = violations
+    .slice(0, 10)
+    .map(v => `  - t=${v.tMs}ms ${v.reason} ${v.selector}`)
+    .join('\n');
+  throw new Error(
+    `DOM stability violated (${violations.length} sample(s) failed):\n${lines}`
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `apps/web/tests/helpers/dom-stability.ts` — `assertDomStable(page, opts)` Playwright helper that polls the DOM for a given duration and fails if a required selector disappears OR a forbidden selector appears. Prevents regressions for gotcha class #3 from JOV-2148 (skeleton flash during async data churn).
- Adds gated E2E query-invalidation hook in `QueryProvider.tsx` (`window.__JOVIE_E2E_INVALIDATE_QUERIES__`), active only when `NEXT_PUBLIC_E2E_MODE === '1'` AND `NODE_ENV !== 'production'`. Mirrors the DevToolsLoader gating pattern; tree-shaken in production.
- Adds `data-testid='presence-loading-skeleton'` to `presence/loading.tsx` so the stability spec can assert the skeleton never appears.
- Adds 3 Playwright stability specs:
  - `releases-page-stability.spec.ts` — invalidates `['releases']`, asserts no `releases-loading` skeleton for 2s
  - `presence-page-stability.spec.ts` — invalidates `['dsp-enrichment']`, asserts `dsp-presence-content-panel` stays visible and no `presence-loading-skeleton`
  - `dashboard-profile-drawer-stability.spec.ts` — opens release sidebar, invalidates `['releases']`, asserts `release-sidebar` stays open and no `drawer-loading-skeleton`

Closes JOV-2162. Supersedes JOV-2158 (the drawer spec is included here).

<!-- linear-issue-id:JOV-2162 -->

## Verification

- Typecheck: clean (`tsc -p apps/web/tsconfig.typecheck.json --noEmit` — no output)
- Biome: clean (`pnpm biome check --write` — fixed 2 formatting nits, zero errors)
- Pre-commit hooks: all passed (eslint, a11y, typecheck)
- Pre-push hooks: passed (typecheck clean, lint warning is pre-existing in `OnboardingTurnstile.tsx` unrelated to this PR)
- Specs require a live dev server (`dev:web:browse`) + `NEXT_PUBLIC_E2E_MODE=1`; CI will exercise them in the E2E lane.

## Test plan

- [ ] CI E2E lane runs the 3 new stability specs
- [ ] Manually: `doppler run -- pnpm --filter web exec playwright test releases-page-stability presence-page-stability dashboard-profile-drawer-stability --project=chromium`