### PR TITLE
feat(eslint-rule): enforce canonical currency formatter (JOV-2154)

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -234,6 +234,7 @@ useQuery({
 | `readonly-component-props` | Props interface/type properties without `readonly` modifier | Add `readonly` before each property (auto-fixable) |
 | `edge-runtime-node-imports` | `node:fs`, `crypto`, `stripe`, `path`, `stream` in files with `export const runtime = 'edge'` | Remove the Node-only import or remove the Edge runtime declaration |
 | `no-direct-electron-bridge` | Direct `window.electronAPI` access (or via `globalThis`/`self`/TS cast) outside `apps/web/lib/desktop/electron-bridge.ts` | Import the guarded wrapper: `import { useDesktopUpdate, isDesktopEnvironment } from '@/lib/desktop/electron-bridge'`. Stale installed binaries may expose a partial bridge — wrappers handle missing methods gracefully + capture Sentry warning. |
+| `no-ad-hoc-currency` | Template literals like `$${x.toFixed(2)}` or `$${(x/100).toFixed(2)}` | Import `formatAmount` from `@/lib/utils/format-number` for cent values; `formatUsd` from `@/lib/admin/format` for admin USD values |
 
 **Run:** `pnpm --filter web lint:eslint` (all rules) or `pnpm --filter web lint:server-boundaries` (boundary rules only).
 

--- a/apps/web/components/features/admin/OutreachPipelineCard.tsx
+++ b/apps/web/components/features/admin/OutreachPipelineCard.tsx
@@ -10,7 +10,7 @@ import { ContentMetricCard } from '@/components/molecules/ContentMetricCard';
 import { ContentMetricRow } from '@/components/molecules/ContentMetricRow';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
-import { formatPercent } from '@/lib/admin/format';
+import { formatPercent, formatUsd } from '@/lib/admin/format';
 import type { AdminFunnelMetrics } from '@/lib/admin/types';
 
 interface OutreachPipelineCardProps {
@@ -19,7 +19,7 @@ interface OutreachPipelineCardProps {
 
 function formatDollarPerOutreach(value: number | null): string {
   if (value === null) return '--';
-  return `$${value.toFixed(2)}`;
+  return formatUsd(value);
 }
 
 interface ConversionMetricProps {

--- a/apps/web/components/features/dashboard/organisms/EarningsTab.tsx
+++ b/apps/web/components/features/dashboard/organisms/EarningsTab.tsx
@@ -24,6 +24,7 @@ import { useClipboard } from '@/hooks/useClipboard';
 import { useNotifications } from '@/lib/hooks/useNotifications';
 import { type TipperRow, useEarningsQuery } from '@/lib/queries';
 import { downloadBlob, downloadString } from '@/lib/utils/download';
+import { formatAmount } from '@/lib/utils/format-number';
 import {
   generateQrCodeDataUrl,
   generateQrCodeSvg,
@@ -60,7 +61,7 @@ const tipperColumns = [
     meta: { align: 'right' },
     cell: ({ getValue }) => (
       <span className='text-right font-caption tabular-nums text-primary-token'>
-        {formatCents(getValue())}
+        {formatAmount(getValue())}
       </span>
     ),
   }),
@@ -79,10 +80,6 @@ const tipperColumns = [
 // =============================================================================
 // Helpers
 // =============================================================================
-
-function formatCents(cents: number): string {
-  return `$${(cents / 100).toFixed(2)}`;
-}
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString('en-US', {
@@ -310,7 +307,7 @@ export function EarningsTab() {
         <dl className='grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-2'>
           <StatCard
             label='Total revenue'
-            value={formatCents(stats?.totalRevenueCents ?? 0)}
+            value={formatAmount(stats?.totalRevenueCents ?? 0)}
             icon={DollarSign}
             iconBg='bg-surface-1 border border-subtle'
             iconColor='text-success'
@@ -324,7 +321,7 @@ export function EarningsTab() {
           />
           <StatCard
             label='Average tip'
-            value={formatCents(stats?.averageTipCents ?? 0)}
+            value={formatAmount(stats?.averageTipCents ?? 0)}
             icon={TrendingUp}
             iconBg='bg-surface-1 border border-subtle'
             iconColor='text-accent'

--- a/apps/web/components/features/home/demo/DashboardEarningsDemo.tsx
+++ b/apps/web/components/features/home/demo/DashboardEarningsDemo.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { formatAmount } from '@/lib/utils/format-number';
 import { EARNINGS_SUMMARY, MONTHLY_EARNINGS, RECENT_TIPS } from './mock-data';
 
 /**
@@ -25,8 +26,6 @@ export function DashboardEarningsDemo() {
 
   const maxEarning = Math.max(...MONTHLY_EARNINGS.map(m => m.amount));
 
-  const formatCents = (cents: number) => `$${(cents / 100).toFixed(2)}`;
-
   return (
     <div ref={containerRef} className='space-y-4'>
       {/* Summary cards */}
@@ -34,11 +33,11 @@ export function DashboardEarningsDemo() {
         {[
           {
             label: 'Total Earned',
-            value: formatCents(EARNINGS_SUMMARY.totalReceivedCents),
+            value: formatAmount(EARNINGS_SUMMARY.totalReceivedCents),
           },
           {
             label: 'This Month',
-            value: formatCents(EARNINGS_SUMMARY.monthReceivedCents),
+            value: formatAmount(EARNINGS_SUMMARY.monthReceivedCents),
           },
           {
             label: 'Tips Received',

--- a/apps/web/eslint-rules/no-ad-hoc-currency.js
+++ b/apps/web/eslint-rules/no-ad-hoc-currency.js
@@ -1,0 +1,57 @@
+/**
+ * ESLint rule to enforce canonical currency formatter usage.
+ *
+ * Flags ad-hoc currency formatting in template literals where:
+ * 1. A preceding quasi string ends with "$"
+ * 2. AND the immediately-following expression contains a `.toFixed(` call
+ *
+ * Bad:  `$${(cents / 100).toFixed(2)}`
+ * Bad:  `$${amount.toFixed(2)}`
+ * Good: formatAmount(cents)         — @/lib/utils/format-number (takes cents)
+ * Good: formatUsd(value)            — @/lib/admin/format (takes whole USD, admin only)
+ */
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Enforce canonical currency formatter (formatAmount / formatUsd) instead of ad-hoc template literals',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      noAdHocCurrency:
+        'Ad-hoc currency formatting detected. Use formatAmount(cents) from "@/lib/utils/format-number" for cent values, or formatUsd(value) from "@/lib/admin/format" for admin USD values.',
+    },
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    return {
+      TemplateLiteral(node) {
+        // node.quasis are the string parts; node.expressions are the interpolated values.
+        // We check each expression: if the quasi immediately before it ends with "$"
+        // and the expression text contains ".toFixed(", flag it.
+        node.expressions.forEach((expr, i) => {
+          const prevQuasi = node.quasis[i];
+          if (!prevQuasi) return;
+
+          const rawText = prevQuasi.value.raw;
+          if (!rawText.endsWith('$')) return;
+
+          const exprText = sourceCode.getText(expr);
+          if (exprText.includes('.toFixed(')) {
+            context.report({
+              node: expr,
+              messageId: 'noAdHocCurrency',
+            });
+          }
+        });
+      },
+    };
+  },
+};

--- a/apps/web/eslint-rules/no-ad-hoc-currency.test.ts
+++ b/apps/web/eslint-rules/no-ad-hoc-currency.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the no-ad-hoc-currency ESLint rule.
+ *
+ * Uses ESLint's RuleTester with flat-config format (ESLint 10+).
+ * Wraps RuleTester in explicit describe/it blocks since Vitest runs
+ * with globals:false in this project.
+ */
+
+import { createRequire } from 'node:module';
+import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const rule = require('./no-ad-hoc-currency.js');
+
+// Wire RuleTester to use Vitest's describe/it (needed when globals:false)
+RuleTester.describe = describe as typeof RuleTester.describe;
+RuleTester.it = it as typeof RuleTester.it;
+
+// ESLint 10 uses flat config format — use `languageOptions` instead of `parserOptions`
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+});
+
+ruleTester.run('no-ad-hoc-currency', rule, {
+  valid: [
+    // Canonical cent formatter — no violation
+    {
+      code: `const display = formatAmount(cents);`,
+    },
+    // Canonical admin USD formatter — no violation
+    {
+      code: `const display = formatUsd(value);`,
+    },
+    // toFixed not preceded by a $ quasi — not currency
+    {
+      code: `const s = \`\${ratio.toFixed(2)}:1\`;`,
+    },
+    // toFixed in a non-$ template — file size, lat/lng, etc.
+    {
+      code: `const size = \`\${(bytes / 1024).toFixed(2)} MB\`;`,
+    },
+    // $ in template but expression has no toFixed — ambiguous, don't flag
+    {
+      code: `const label = \`$\${amount}\`;`,
+    },
+    // formatPercent with toFixed — not currency (no $ quasi before it)
+    {
+      code: `const pct = \`\${(rate * 100).toFixed(1)}%\`;`,
+    },
+  ],
+
+  invalid: [
+    // Classic cents-to-dollars pattern
+    {
+      code: `const display = \`$\${(cents / 100).toFixed(2)}\`;`,
+      errors: [{ messageId: 'noAdHocCurrency' }],
+    },
+    // Direct toFixed on an already-dollar value
+    {
+      code: `const display = \`$\${amount.toFixed(2)}\`;`,
+      errors: [{ messageId: 'noAdHocCurrency' }],
+    },
+    // toFixed with 0 decimal places but preceded by $
+    {
+      code: `const display = \`$\${(cents / 100).toFixed(0)}\`;`,
+      errors: [{ messageId: 'noAdHocCurrency' }],
+    },
+    // Longer prefix string ending with $
+    {
+      code: `const msg = \`Total: $\${(value).toFixed(2)}\`;`,
+      errors: [{ messageId: 'noAdHocCurrency' }],
+    },
+    // Variable declared inside function with $ prefix and toFixed
+    {
+      code: `function fmt(v) { return \`$\${v.toFixed(2)}\`; }`,
+      errors: [{ messageId: 'noAdHocCurrency' }],
+    },
+  ],
+});

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -16,6 +16,7 @@ const noRawMotionValuesRule = require('./eslint-rules/no-raw-motion-values');
 const noDirectElectronBridgeRule = require('./eslint-rules/no-direct-electron-bridge');
 const noBannedMarketingCopyRule = require('./eslint-rules/no-banned-marketing-copy');
 const noRawFocusRingRule = require('./eslint-rules/no-raw-focus-ring');
+const noAdHocCurrencyRule = require('./eslint-rules/no-ad-hoc-currency');
 
 const [nextBase, nextTypescript, nextIgnores] = nextConfig;
 
@@ -40,6 +41,7 @@ const baseConfig = {
         'no-direct-electron-bridge': noDirectElectronBridgeRule,
         'no-banned-marketing-copy': noBannedMarketingCopyRule,
         'no-raw-focus-ring': noRawFocusRingRule,
+        'no-ad-hoc-currency': noAdHocCurrencyRule,
       },
     },
   },
@@ -192,6 +194,7 @@ const baseConfig = {
     // Design-system focus ring enforcement — interactive elements must use
     // canonical focus-ring-themed or focus-visible:* utilities
     '@jovie/no-raw-focus-ring': 'warn',
+    '@jovie/no-ad-hoc-currency': 'error',
   },
 };
 
@@ -385,6 +388,20 @@ module.exports = [
           ],
         },
       ],
+    },
+  },
+  // JOV-2168: Deferred no-ad-hoc-currency violations — each suppressed here pending
+  // migration to the canonical formatter (see linked issue for per-file rationale).
+  {
+    files: [
+      'lib/chat/system-prompt.ts',
+      'components/organisms/billing/PlanComparisonSection.tsx',
+      'components/molecules/PaySelector.tsx',
+      'app/investor-portal/_components/FundraiseProgress.tsx',
+      'app/onboarding/checkout/OnboardingCheckoutClient.tsx',
+    ],
+    rules: {
+      '@jovie/no-ad-hoc-currency': 'off',
     },
   },
 ];


### PR DESCRIPTION
## Summary

- Adds `@jovie/no-ad-hoc-currency` ESLint rule that flags template literals where a `$` quasi is immediately followed by a `.toFixed()` expression (e.g. `` `$${(cents / 100).toFixed(2)}` ``)
- Fixes 3 high-traffic violations: `EarningsTab.tsx`, `DashboardEarningsDemo.tsx` (both use `formatAmount` from `@/lib/utils/format-number`), `OutreachPipelineCard.tsx` (uses `formatUsd` from `@/lib/admin/format`)
- Suppresses 6 deferred violations via `eslint.config.js` file-level rule override (pending JOV-2168)
- Documents rule in `.claude/rules/code-style.md` ESLint table

## Rule design

The rule visits `TemplateLiteral` nodes and flags expressions where:
1. The preceding quasi string ends with `$`
2. AND the expression contains `.toFixed(`

No auto-fix (signatures differ: `formatAmount` takes cents, `formatUsd` takes whole USD). Filed as `error` level.

## Deferred violations (JOV-2168)

| File | Line | Reason deferred |
|------|------|-----------------|
| `lib/chat/system-prompt.ts` | 60 | LLM prompt string; canonical formatter not appropriate |
| `components/organisms/billing/PlanComparisonSection.tsx` | 128 | Intentional no-cents price display ("$39"); `formatAmount` always shows 2 decimals |
| `components/molecules/PaySelector.tsx` | 25 | Screen reader label; `amount` is already whole dollars |
| `app/investor-portal/_components/FundraiseProgress.tsx` | 15, 19 | Compact M/K suffix formatting; canonical formatters don't support this |
| `app/onboarding/checkout/OnboardingCheckoutClient.tsx` | 30 | No-cents checkout price display ("$39") |

## Verification

- Typecheck: ✅ passed (singleflight cache hit)
- ESLint on fixed files: ✅ no violations
- Vitest rule tests: ✅ 11/11 passed
- Biome: ✅ no fixes needed
- Pre-commit hooks: ✅ all passed
- Pre-push hooks: ✅ typecheck + lint passed

## Files changed

- `apps/web/eslint-rules/no-ad-hoc-currency.js` — new rule
- `apps/web/eslint-rules/no-ad-hoc-currency.test.ts` — 11 unit tests (6 valid, 5 invalid)
- `apps/web/eslint.config.js` — register rule + deferred file exclusions
- `apps/web/components/features/dashboard/organisms/EarningsTab.tsx` — use `formatAmount`
- `apps/web/components/features/home/demo/DashboardEarningsDemo.tsx` — use `formatAmount`
- `apps/web/components/features/admin/OutreachPipelineCard.tsx` — use `formatUsd`
- `.claude/rules/code-style.md` — document rule in ESLint table

Closes JOV-2154 | Follow-up: JOV-2168