### PR TITLE
fix(admin): migrate AdminWaitlistTableWithViews console.error to logger (JOV-2122)

### DIFF
--- a/apps/web/components/features/admin/waitlist-table/AdminWaitlistTableWithViews.tsx
+++ b/apps/web/components/features/admin/waitlist-table/AdminWaitlistTableWithViews.tsx
@@ -38,6 +38,7 @@ import {
   useApproveWaitlistMutation,
   useDisapproveWaitlistMutation,
 } from '@/lib/queries';
+import { logger } from '@/lib/utils/logger';
 import { AdminWaitlistTableUnified } from './AdminWaitlistTableUnified';
 import {
   persistGroupingPreference,
@@ -267,7 +268,10 @@ export function AdminWaitlistTableWithViews(props: WaitlistTableProps) {
           toast.error('Unsupported waitlist status update.');
         }
       } catch (error) {
-        console.error('Failed to update waitlist status:', error);
+        logger.error(
+          '[admin/waitlist] Failed to update waitlist status:',
+          error
+        );
         toast.error('Failed to update status', {
           description:
             error instanceof Error ? error.message : 'Please try again',


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2122 -->

## Summary

Audit + targeted fix for JOV-2122 admin design-system conformity pass. This PR delivers the immediate fix (violation #2) and documents the full audit findings for violations #1, #3, #4 as separate follow-up Linear issues.

## Fix in this PR

**AdminWaitlistTableWithViews.tsx line 271** — console.error → logger.error

The handleItemMove catch block was using a raw console.error, bypassing the canonical @/lib/utils/logger module. Replaced with logger.error('[admin/waitlist] ...'), consistent with the project-wide logging convention enforced by the console-check.sh post-write hook.

## Audit findings

| File | Violation type | Severity | Linked Linear |
|---|---|---|---|
| apps/web/components/features/admin/leads/LeadGtmInsights.tsx:79–103 | ALL-CAPS KPI labels (SCRAPED, CONTACTED, CLAIM RATE, SIGNUP RATE, PAID RATE) violating DESIGN.md Title Case rule | Medium | JOV-2170 |
| apps/web/components/features/admin/leads/GtmFunnel.tsx:112,137 + TimActionRequiredSection.tsx:87,94,228 | uppercase tracking-[0.08em] on section sub-labels and priority badge | Low | JOV-2171 |
| apps/web/components/features/admin/leads/GrowthStatusPanel.tsx:80–103 + campaigns/CampaignSettingsPanel.tsx:259 | ContentMetricCard with bg-surface-0 shadow-none inside surface-1 parent — weak elevation differentiation in dark mode | Low | JOV-2172 |
| All admin components (focus states audit) | No focus:ring (non-focus-visible) violations found. All admin focus states already use focus-visible:* correctly. | — | N/A — clean |
| apps/web/components/features/admin/waitlist-table/AdminWaitlistTableWithViews.tsx:271 | console.error — FIXED in this PR | — | JOV-2122 |

### Focus states verdict

All admin files already use focus-visible:* consistently. No mouse-click loud focus rings found in any admin feature component. Violation #1 was not reproducible — the implementation is already correct per JOV-2083 guidance.

### Column headers verdict

No ALL-CAPS column header strings found in table column definitions. The violations found are in KPI card title props and CSS-uppercase section labels (filed as JOV-2170 and JOV-2171).

### Invisible card verdict

The border-0 patterns on AdminTableShell, AdminWaitlistTableWithViews, AdminCreatorProfilesUnified, and AdminUsersTableUnified are intentional shell resets (placed directly on app canvas, not inside another Card). The genuine invisible-card risk is the shadow-none on ContentMetricCard inside ContentSurfaceCard parents — elevated to JOV-2172.

## Verification

- typecheck: PASS (zero errors)
- biome check --write: PASS (auto-sorted import, no violations)
- pre-commit hooks: PASS (eslint, a11y:check:staged, typecheck all green)
- pre-push hooks: PASS (proxy-guard, tailwind:check, typecheck, lint all green)

## Changes

- apps/web/components/features/admin/waitlist-table/AdminWaitlistTableWithViews.tsx — logger import + console.error migration