### PR TITLE
fix: polish public profile and desktop shell

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -51,16 +51,15 @@ html[data-desktop-runtime="electron"] body {
 
 html[data-desktop-runtime="electron"] [data-app-shell-frame="true"] {
   box-sizing: border-box;
-  padding-top: var(--electron-titlebar-height);
 }
 
 html[data-desktop-runtime="electron"] [data-electron-titlebar="true"] {
   -webkit-app-region: drag;
-  position: absolute;
-  inset: 0 0 auto;
   z-index: 60;
-  display: flex;
+  display: grid;
+  grid-template-columns: var(--linear-app-sidebar-width) minmax(0, 1fr);
   align-items: center;
+  flex-shrink: 0;
   height: var(--electron-titlebar-height);
   user-select: none;
   background: rgb(var(--sidebar-background));
@@ -88,10 +87,6 @@ html[data-desktop-runtime="electron"]
 }
 
 html[data-desktop-runtime="electron"] [data-electron-update-pill="true"] {
-  position: fixed;
-  top: 7px;
-  right: 12px;
-  z-index: 80;
   height: 26px;
   padding-inline: 12px;
   border-radius: 999px;

--- a/apps/web/components/atoms/DesktopTitlebar.tsx
+++ b/apps/web/components/atoms/DesktopTitlebar.tsx
@@ -11,15 +11,12 @@ import {
 import { cn } from '@/lib/utils';
 
 /**
- * DesktopTitlebar — Electron-only titlebar with traffic-light spacer,
- * back/forward arrows, and the update pill.
+ * DesktopTitlebar — Electron-only titlebar grid with traffic-light spacer,
+ * update pill, and back/forward arrows.
  *
- * Layout (left → right):
- *   [72px traffic-light spacer, drag]
- *   [← → nav buttons, no-drag]
- *   [flex-1 center spacer, drag]
- *   [UpdateAvailablePill, no-drag]
- *   [12px right padding, drag]
+ * Layout:
+ *   [sidebar-width: traffic-light spacer, update pill]
+ *   [main: back/forward nav, drag region]
  *
  * Renders as a zero-height invisible element in the browser; CSS on
  * [data-electron-titlebar="true"] makes it visible only inside Electron.
@@ -34,17 +31,29 @@ export function DesktopTitlebar() {
   return (
     <div
       data-electron-titlebar='true'
+      data-testid='electron-titlebar-row'
       data-electron-drag-region='true'
       style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
     >
       {isDesktop ? (
         <>
-          {/* Traffic-light clearance — macOS hiddenInset reserves ~72px on the left */}
-          <div className='w-[72px] shrink-0' />
-
-          {/* Back / Forward navigation arrows */}
           <div
-            className='flex items-center gap-0.5'
+            data-testid='electron-titlebar-sidebar-cell'
+            className='flex min-w-0 items-center gap-2 px-2.5'
+          >
+            {/* Traffic-light clearance — macOS hiddenInset reserves ~72px on the left */}
+            <div className='w-[72px] shrink-0' aria-hidden='true' />
+            <div
+              className='min-w-0 shrink-0'
+              style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+            >
+              <UpdateAvailablePill compact={sidebarOpen} />
+            </div>
+          </div>
+
+          <div
+            data-testid='electron-titlebar-main-cell'
+            className='flex min-w-0 items-center gap-1 border-l border-(--linear-app-shell-sidebar-seam) px-2.5'
             style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
           >
             <button
@@ -52,8 +61,9 @@ export function DesktopTitlebar() {
               onClick={goBack}
               disabled={!canGoBack}
               aria-label='Go back'
+              data-testid='electron-nav-back'
               className={cn(
-                'flex h-6 w-6 items-center justify-center rounded text-secondary-token',
+                'flex h-7 w-7 items-center justify-center rounded-[10px] text-secondary-token',
                 'transition-colors duration-subtle',
                 'hover:bg-white/[0.06] hover:text-primary-token',
                 'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30',
@@ -67,8 +77,9 @@ export function DesktopTitlebar() {
               onClick={goForward}
               disabled={!canGoForward}
               aria-label='Go forward'
+              data-testid='electron-nav-forward'
               className={cn(
-                'flex h-6 w-6 items-center justify-center rounded text-secondary-token',
+                'flex h-7 w-7 items-center justify-center rounded-[10px] text-secondary-token',
                 'transition-colors duration-subtle',
                 'hover:bg-white/[0.06] hover:text-primary-token',
                 'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30',
@@ -77,20 +88,10 @@ export function DesktopTitlebar() {
             >
               <ArrowRight className='h-3.5 w-3.5' strokeWidth={2} />
             </button>
-          </div>
-
-          {/* Center drag region */}
-          <div
-            className='flex-1'
-            style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
-          />
-
-          {/* Update pill — compact when sidebar is open, full pill when sidebar is closed */}
-          <div
-            className='flex items-center pr-3'
-            style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
-          >
-            <UpdateAvailablePill compact={sidebarOpen} />
+            <div
+              className='min-w-0 flex-1 self-stretch'
+              style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+            />
           </div>
         </>
       ) : null}

--- a/apps/web/components/atoms/UpdateAvailablePill.tsx
+++ b/apps/web/components/atoms/UpdateAvailablePill.tsx
@@ -42,6 +42,7 @@ export function UpdateAvailablePill({
       type='button'
       data-electron-update-pill='true'
       data-electron-no-drag='true'
+      data-testid='update-available-pill'
       onClick={handleClick}
       disabled={updating}
       aria-label='Update available — click to install'

--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -165,7 +165,7 @@ function LatestReleaseFeature({
       }
       priority
       dataTestId='profile-home-latest-card'
-      className='rounded-[18px] [&>div:first-child]:aspect-[3/1] [@media(max-height:880px)]:[&>div:last-child]:px-2.5 [@media(max-height:880px)]:[&>div:last-child]:py-2'
+      className='rounded-[18px] [@media(max-height:880px)]:[&>div:first-child]:min-h-[132px] [@media(max-height:880px)]:[&>div:last-child]:px-2.5 [@media(max-height:880px)]:[&>div:last-child]:py-2.5'
     />
   );
 }
@@ -216,7 +216,7 @@ function TourFeatureCard({
       }}
       priority
       dataTestId='profile-home-rail-tour'
-      className='rounded-[18px] [&>div:first-child]:aspect-[3/1] [@media(max-height:880px)]:[&>div:last-child]:px-2.5 [@media(max-height:880px)]:[&>div:last-child]:py-2'
+      className='rounded-[18px] [@media(max-height:880px)]:[&>div:first-child]:min-h-[132px] [@media(max-height:880px)]:[&>div:last-child]:px-2.5 [@media(max-height:880px)]:[&>div:last-child]:py-2.5'
     />
   );
 }
@@ -243,7 +243,7 @@ function PlaylistFeatureCard({
       }}
       priority
       dataTestId='profile-home-rail-playlist'
-      className='rounded-[18px] [&>div:first-child]:aspect-[3/1] [@media(max-height:880px)]:[&>div:last-child]:px-2.5 [@media(max-height:880px)]:[&>div:last-child]:py-2'
+      className='rounded-[18px] [@media(max-height:880px)]:[&>div:first-child]:min-h-[132px] [@media(max-height:880px)]:[&>div:last-child]:px-2.5 [@media(max-height:880px)]:[&>div:last-child]:py-2.5'
     />
   );
 }
@@ -274,7 +274,7 @@ function ListenFeatureCard({
       }}
       priority
       dataTestId='profile-home-rail-listen'
-      className='rounded-[18px] [&>div:first-child]:aspect-[3/1] [@media(max-height:880px)]:[&>div:last-child]:px-2.5 [@media(max-height:880px)]:[&>div:last-child]:py-2'
+      className='rounded-[18px] [@media(max-height:880px)]:[&>div:first-child]:min-h-[132px] [@media(max-height:880px)]:[&>div:last-child]:px-2.5 [@media(max-height:880px)]:[&>div:last-child]:py-2.5'
     />
   );
 }

--- a/apps/web/components/features/profile/ProfileMediaCard.tsx
+++ b/apps/web/components/features/profile/ProfileMediaCard.tsx
@@ -94,14 +94,14 @@ const ACTION_ICONS: Record<ProfileMediaCardIcon, LucideIcon> = {
 const RATIO_CLASS_NAMES: Record<ProfileMediaCardRatio, string> = {
   square: 'aspect-square',
   portrait: 'aspect-[4/5]',
-  landscape: 'aspect-[5/3]',
+  landscape: 'aspect-[5/3] min-h-[142px]',
   compact: 'aspect-[3/4]',
 };
 
 const CONTENT_CLASS_NAMES: Record<ProfileMediaCardRatio, string> = {
   square: 'p-4',
   portrait: 'p-4',
-  landscape: 'max-w-[63%] justify-end p-4',
+  landscape: 'max-w-[66%] justify-center px-4 py-5',
   compact: 'p-2',
 };
 
@@ -443,9 +443,9 @@ export function ProfileMediaCard({
         <div
           className={cn(
             'absolute inset-0 z-10 flex flex-col',
-            'justify-end',
             CONTENT_CLASS_NAMES[ratio]
           )}
+          data-testid={dataTestId ? `${dataTestId}-content` : undefined}
         >
           <div className={cn('space-y-1.5', compact && 'space-y-1')}>
             <p
@@ -465,9 +465,10 @@ export function ProfileMediaCard({
                 compact
                   ? 'line-clamp-2 text-[12px]'
                   : landscape
-                    ? 'text-[26px]'
+                    ? 'line-clamp-2 text-[clamp(20px,6.1vw,25px)] [@media(max-height:760px)]:text-[20px]'
                     : 'line-clamp-2 text-[26px]'
               )}
+              data-testid={dataTestId ? `${dataTestId}-title` : undefined}
             >
               {title}
             </h3>

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -297,7 +297,7 @@ export function ProfileCompactSurface({
   const socialIconClassName =
     'inline-flex h-8 w-8 items-center justify-center text-white/68 transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
   const heroHeightClassName = isHomeMode
-    ? 'h-[34svh] min-h-[232px] max-h-[250px] [@media(min-height:761px)_and_(max-height:880px)]:max-h-[190px] [@media(min-height:761px)_and_(max-height:880px)]:min-h-[190px] [@media(max-height:760px)]:h-[156px] [@media(max-height:760px)]:min-h-[156px]'
+    ? 'h-[36svh] min-h-[248px] max-h-[276px] [@media(min-height:761px)_and_(max-height:880px)]:max-h-[218px] [@media(min-height:761px)_and_(max-height:880px)]:min-h-[214px] [@media(max-height:760px)]:h-[178px] [@media(max-height:760px)]:min-h-[178px]'
     : 'h-14 border-b border-white/[0.075]';
   const locationLabel = artist.location?.trim() || artist.hometown?.trim();
   const registerNotificationsReveal = useCallback(
@@ -366,7 +366,7 @@ export function ProfileCompactSurface({
                     fill
                     priority
                     sizes='(max-width: 767px) 100vw, 430px'
-                    className='object-cover object-center'
+                    className='object-cover object-[50%_34%]'
                     fallbackVariant='avatar'
                     fallbackClassName='bg-surface-2'
                   />
@@ -378,8 +378,8 @@ export function ProfileCompactSurface({
                 )}
               </div>
 
-              <div className='pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(2,3,4,0.08)_0%,rgba(2,3,4,0.12)_26%,rgba(3,4,6,0.34)_58%,rgba(5,6,8,0.9)_84%,var(--profile-stage-bg)_100%)]' />
-              <div className='pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-[linear-gradient(180deg,transparent,var(--profile-stage-bg)_92%)]' />
+              <div className='pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(2,3,4,0.1)_0%,rgba(2,3,4,0.18)_30%,rgba(3,4,6,0.48)_64%,rgba(5,6,8,0.94)_88%,var(--profile-stage-bg)_100%)]' />
+              <div className='pointer-events-none absolute inset-x-0 bottom-0 h-28 bg-[linear-gradient(180deg,transparent,var(--profile-stage-bg)_90%)]' />
             </>
           ) : (
             <div className='absolute inset-0 bg-black/94 backdrop-blur-2xl' />
@@ -433,9 +433,9 @@ export function ProfileCompactSurface({
           </div>
 
           {isHomeMode ? (
-            <div className='absolute inset-x-0 bottom-0 z-10 px-4 pb-4 [@media(max-height:820px)]:pb-3'>
+            <div className='absolute inset-x-0 bottom-0 z-10 px-4 pb-5 [@media(max-height:820px)]:pb-4 [@media(max-height:760px)]:pb-3'>
               <div
-                className='min-w-0 space-y-1'
+                className='min-w-0 rounded-[18px] bg-black/18 px-3 py-2.5 shadow-[0_16px_38px_-24px_rgba(0,0,0,0.72)] backdrop-blur-[2px] [@media(max-height:820px)]:px-2.5 [@media(max-height:820px)]:py-2'
                 data-testid='profile-hero-identity-block'
               >
                 <IdentityHeading
@@ -448,7 +448,7 @@ export function ProfileCompactSurface({
                     data-testid='profile-identity-link'
                     href={profileHref}
                     aria-label={`Go to ${artist.name}'s profile`}
-                    className='inline-flex max-w-full min-w-0 items-center gap-1.5 rounded-md text-[36px] font-semibold leading-[0.98] tracking-[-0.026em] text-white drop-shadow-[0_2px_14px_rgba(0,0,0,0.42)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent [@media(max-height:820px)]:text-[32px] [@media(max-height:760px)]:text-[31px]'
+                    className='inline-flex max-w-full min-w-0 items-center gap-1.5 rounded-md text-[34px] font-semibold leading-[0.98] tracking-[-0.026em] text-white drop-shadow-[0_2px_14px_rgba(0,0,0,0.42)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent [@media(max-height:820px)]:text-[30px] [@media(max-height:760px)]:text-[28px]'
                   >
                     <span className='truncate'>{artist.name}</span>
                     {artist.is_verified ? (
@@ -463,7 +463,7 @@ export function ProfileCompactSurface({
                   </Link>
                 </IdentityHeading>
 
-                <p className='line-clamp-1 text-[13px] font-medium leading-5 tracking-[-0.012em] text-white/76 [@media(max-height:820px)]:text-[12px]'>
+                <p className='mt-1 line-clamp-1 text-[13px] font-medium leading-5 tracking-[-0.012em] text-white/76 [@media(max-height:820px)]:text-[12px]'>
                   {heroSubtitle}
                 </p>
 

--- a/apps/web/components/organisms/AppShellFrame.tsx
+++ b/apps/web/components/organisms/AppShellFrame.tsx
@@ -51,51 +51,58 @@ export const AppShellFrame = memo(function AppShellFrame({
       data-app-shell-frame='true'
       data-shell-design={variant}
       className={cn(
-        'relative flex h-full w-full overflow-hidden',
+        'relative flex h-full w-full flex-col overflow-hidden',
         isShellChatV1 ? 'bg-(--linear-bg-page)' : 'bg-base',
         /* PWA safe area: pad top for notch/Dynamic Island in standalone mode (mobile only) */
         'max-lg:pt-[env(safe-area-inset-top)]',
-        isShellChatV1 &&
-          'lg:gap-[var(--linear-app-shell-gap)] lg:p-[var(--linear-app-shell-gap)]',
         containerClassName
       )}
     >
       <DesktopTitlebar />
-      {sidebar}
-
-      <main
-        id='main-content'
+      <div
+        data-app-shell-body='true'
         className={cn(
-          'relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-surface-0',
-          isShellChatV1
-            ? 'lg:rounded-[var(--linear-app-shell-radius)] lg:border-t lg:border-r lg:border-b lg:border-(--linear-app-shell-border) lg:bg-(--linear-app-content-surface) lg:shadow-[var(--linear-app-shell-shadow)] lg:pt-px'
-            : 'lg:border-l lg:border-subtle'
+          'flex min-h-0 min-w-0 flex-1 overflow-hidden',
+          isShellChatV1 &&
+            'lg:gap-[var(--linear-app-shell-gap)] lg:p-[var(--linear-app-shell-gap)]'
         )}
       >
-        {isEnabled('CANVAS_GRAIN') && <CanvasGrain />}
-        {header}
-        <div
+        {sidebar}
+
+        <main
+          id='main-content'
           className={cn(
-            'flex flex-1 min-h-0 min-w-0 overflow-hidden',
-            isShellChatV1 && 'lg:gap-[var(--linear-app-shell-gap)]'
+            'relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-surface-0',
+            isShellChatV1
+              ? 'lg:rounded-[var(--linear-app-shell-radius)] lg:border-t lg:border-r lg:border-b lg:border-(--linear-app-shell-border) lg:bg-(--linear-app-content-surface) lg:shadow-[var(--linear-app-shell-shadow)] lg:pt-px'
+              : 'lg:border-l lg:border-subtle'
           )}
         >
+          {isEnabled('CANVAS_GRAIN') && <CanvasGrain />}
+          {header}
           <div
-            data-testid='app-shell-scroll'
             className={cn(
-              'flex flex-1 min-h-0 min-w-0 flex-col pb-[var(--dev-toolbar-height,0px)]',
-              isTableRoute
-                ? 'overflow-hidden overflow-x-auto overscroll-contain'
-                : 'overflow-y-auto overflow-x-hidden overscroll-contain',
-              contentClassName
+              'flex flex-1 min-h-0 min-w-0 overflow-hidden',
+              isShellChatV1 && 'lg:gap-[var(--linear-app-shell-gap)]'
             )}
           >
-            {main}
+            <div
+              data-testid='app-shell-scroll'
+              className={cn(
+                'flex flex-1 min-h-0 min-w-0 flex-col pb-[var(--dev-toolbar-height,0px)]',
+                isTableRoute
+                  ? 'overflow-hidden overflow-x-auto overscroll-contain'
+                  : 'overflow-y-auto overflow-x-hidden overscroll-contain',
+                contentClassName
+              )}
+            >
+              {main}
+            </div>
+            {rightPanel}
           </div>
-          {rightPanel}
-        </div>
-        {audioPlayer}
-      </main>
+          {audioPlayer}
+        </main>
+      </div>
 
       {mobileBottomNav}
     </div>

--- a/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
+++ b/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
@@ -513,6 +513,136 @@ async function focusAndAssertNoShift(
   expectNoFocusShift(before, after, label);
 }
 
+const MOCK_HOME_RELEASE_CARD_VIEWPORTS = [
+  {
+    id: 'iphone-se-2-3',
+    label: 'iPhone SE 2/3',
+    width: 375,
+    height: 667,
+    deviceScaleFactor: 2,
+    devices: ['iPhone SE 2', 'iPhone SE 3'],
+  },
+  {
+    id: 'iphone-13-14',
+    label: 'iPhone 13/14',
+    width: 390,
+    height: 844,
+    deviceScaleFactor: 3,
+    devices: ['iPhone 13', 'iPhone 13 Pro', 'iPhone 14'],
+  },
+] as const satisfies readonly MobileProfileViewport[];
+
+type ReleaseCardLayout = {
+  readonly card: {
+    readonly top: number;
+    readonly bottom: number;
+    readonly left: number;
+    readonly right: number;
+  };
+  readonly media: {
+    readonly top: number;
+    readonly bottom: number;
+    readonly left: number;
+    readonly right: number;
+  };
+  readonly title: {
+    readonly top: number;
+    readonly bottom: number;
+    readonly left: number;
+    readonly right: number;
+  };
+  readonly hero: {
+    readonly top: number;
+    readonly bottom: number;
+  } | null;
+};
+
+async function collectMockHomeReleaseCardLayout(
+  page: Page
+): Promise<ReleaseCardLayout> {
+  return page.evaluate(() => {
+    const title = Array.from(document.querySelectorAll<HTMLElement>('h3')).find(
+      heading => heading.textContent?.trim() === "Don't Look Down"
+    );
+    const card = title?.closest<HTMLElement>('article');
+    const media = card?.querySelector<HTMLElement>(':scope > div:first-child');
+    const hero = document.querySelector<HTMLElement>(
+      '[data-testid="profile-hero-identity-block"]'
+    );
+
+    if (!card || !media || !title) {
+      throw new Error('Mock-home release card layout target missing');
+    }
+
+    const rect = (element: Element) => {
+      const box = element.getBoundingClientRect();
+      return {
+        top: box.top,
+        bottom: box.bottom,
+        left: box.left,
+        right: box.right,
+      };
+    };
+
+    return {
+      card: rect(card),
+      media: rect(media),
+      title: rect(title),
+      hero: hero ? rect(hero) : null,
+    };
+  });
+}
+
+test.describe('Public Profile Mock Home Release Card Layout @smoke @critical', () => {
+  for (const viewport of MOCK_HOME_RELEASE_CARD_VIEWPORTS) {
+    test(`${viewport.label} keeps release title inside the card`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({
+        width: viewport.width,
+        height: viewport.height,
+      });
+      await installProfileMocks(page);
+
+      await smokeNavigate(
+        page,
+        '/demo/showcase/tim-white-profile?state=mock-home',
+        { timeout: 120_000 }
+      );
+      await waitForHydration(page);
+      await waitForAnyVisible(page, [
+        '[data-testid="profile-home-latest-card"]',
+      ]);
+      await settleLayout(page);
+
+      const snapshot = await collectViewportSnapshot(
+        page,
+        '[data-testid="profile-compact-surface"]'
+      );
+      expect(
+        snapshot.horizontalOverflow,
+        `${viewport.label} mock-home profile should not overflow horizontally`
+      ).toBeLessThanOrEqual(2);
+
+      const layout = await collectMockHomeReleaseCardLayout(page);
+      expect(
+        layout.title.top,
+        `${viewport.label} release title should not clip above media`
+      ).toBeGreaterThanOrEqual(layout.media.top + 6);
+      expect(
+        layout.title.bottom,
+        `${viewport.label} release title should fit inside media`
+      ).toBeLessThanOrEqual(layout.media.bottom - 6);
+      if (layout.hero) {
+        expect(
+          layout.card.top,
+          `${viewport.label} release card should sit below hero identity`
+        ).toBeGreaterThanOrEqual(layout.hero.bottom + 4);
+      }
+    });
+  }
+});
+
 test.describe('Public Profile Mobile Viewport Stability @smoke @critical', () => {
   test.setTimeout(120_000);
 

--- a/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
+++ b/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DesktopTitlebar } from '@/components/atoms/DesktopTitlebar';
+import { SidebarContext } from '@/components/organisms/sidebar/context';
+
+vi.mock('@/lib/desktop/electron-bridge', () => ({
+  useDesktopNavigation: () => ({
+    canGoBack: true,
+    canGoForward: false,
+    goBack: vi.fn(),
+    goForward: vi.fn(),
+  }),
+  useIsElectronRuntime: () => true,
+}));
+
+vi.mock('@/components/atoms/UpdateAvailablePill', () => ({
+  UpdateAvailablePill: ({ compact }: { readonly compact?: boolean }) => (
+    <button
+      type='button'
+      data-testid='update-available-pill'
+      data-compact={compact ? 'true' : 'false'}
+    >
+      Update
+    </button>
+  ),
+}));
+
+describe('DesktopTitlebar', () => {
+  it('renders Electron titlebar controls in sidebar and main grid cells', () => {
+    render(
+      <SidebarContext.Provider
+        value={{
+          state: 'open',
+          open: true,
+          setOpen: vi.fn(),
+          openMobile: false,
+          setOpenMobile: vi.fn(),
+          isMobile: false,
+          toggleSidebar: vi.fn(),
+        }}
+      >
+        <DesktopTitlebar />
+      </SidebarContext.Provider>
+    );
+
+    expect(screen.getByTestId('electron-titlebar-row')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('electron-titlebar-sidebar-cell')
+    ).toContainElement(screen.getByTestId('update-available-pill'));
+    expect(screen.getByTestId('update-available-pill')).toHaveAttribute(
+      'data-compact',
+      'true'
+    );
+    expect(screen.getByTestId('electron-titlebar-main-cell')).toContainElement(
+      screen.getByTestId('electron-nav-back')
+    );
+    expect(screen.getByTestId('electron-titlebar-main-cell')).toContainElement(
+      screen.getByTestId('electron-nav-forward')
+    );
+    expect(screen.getByRole('button', { name: 'Go back' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Go forward' })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes Tim White mock-home public profile card clipping by giving landscape release media safer height, padding, and responsive title sizing.
- Adjusts the compact profile hero composition so the identity/social zone is less crowded against the face crop and top chrome.
- Reworks the Electron titlebar into the shell grid: sidebar-width left cell, main-content right cell, traffic-light clearance, update pill, and browser back/forward controls.
- Adds regression coverage for the Electron titlebar structure and mock-home mobile release card layout.

## Test Coverage
- Added `DesktopTitlebar` unit coverage for titlebar row/cells, update pill placement, and accessible nav buttons.
- Added Playwright coverage for `/demo/showcase/tim-white-profile?state=mock-home` at `375x667` and `390x844`.

## Verification Results
- `pnpm biome check --write apps/web/components/features/profile/ProfileMediaCard.tsx apps/web/components/features/profile/ProfileHomeRail.tsx apps/web/components/features/profile/templates/ProfileCompactSurface.tsx apps/web/components/organisms/AppShellFrame.tsx apps/web/components/atoms/DesktopTitlebar.tsx apps/web/components/atoms/UpdateAvailablePill.tsx apps/web/app/globals.css apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/components/atoms/DesktopTitlebar.test.tsx tests/unit/components/organisms/AppShellFrame.test.tsx --config vitest.config.mts` — 4 passed
- `E2E_SKIP_WEB_SERVER=1 BASE_URL=http://localhost:3110 pnpm --filter @jovie/web exec playwright test tests/e2e/profile-mobile-viewport-stability.spec.ts --grep "Mock Home Release Card" --config=playwright.config.ts --project=chromium` — 3 passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-push gate: `biome check . && pnpm --filter=@jovie/web run pre-push` passed

## Notes
- Local `/app/admin/ops` redirects to sign-in without Clerk test credentials in this workspace, so Electron shell geometry was verified on the public `/demo` AppShellFrame with Electron runtime/update/nav injected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/Layout Improvements**
  * Improved desktop application titlebar layout and responsiveness
  * Enhanced profile card sizing and layout on various screen heights
  * Refined update notification positioning for better visual consistency

* **Tests**
  * Added mobile viewport stability test coverage for profile pages
  * Added unit tests for desktop titlebar component

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8620)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->