### PR TITLE
fix(a11y): use toBeNull for surfaceManifestLoadError check (drain unblock #2)

### DIFF
--- a/apps/web/tests/e2e/axe-audit.spec.ts
+++ b/apps/web/tests/e2e/axe-audit.spec.ts
@@ -138,7 +138,7 @@ test.describe('Axe WCAG 2.1 Compliance', () => {
   test.setTimeout(120_000);
 
   test('public surface manifests load successfully', () => {
-    expect(surfaceManifestLoadError).toBeUndefined();
+    expect(surfaceManifestLoadError).toBeNull();
   });
 
   for (const surface of publicSurfaces) {


### PR DESCRIPTION
## Summary

Unblocks the drain queue (9 auto-merge PRs queued) by fixing the A11y (axe) lane red on main after #8617.

**Root cause:** #8617 replaced `if (err) throw err` with `expect(err).toBeUndefined()` in axe-audit.spec.ts to satisfy SonarCloud S2699 (missing assertion). But `surfaceManifestLoadError` is initialized to `null` on the success path:

\`\`\`ts
function loadSurfaceManifests() {
  try {
    return { ..., error: null } as const;
  } catch (error) {
    return { ..., error: new Error(...) } as const;
  }
}
\`\`\`

`.toBeUndefined()` fails for `null`, so the assertion now fails every run.

**Fix:** Switch to `.toBeNull()` — matches the actual sentinel value, preserves the SonarCloud assertion-coverage fix, restores the original pass/fail semantics.

## Test plan
- [x] Local: typecheck + biome + eslint via pre-commit hooks
- [ ] CI: A11y (axe) lane passes on this PR
- [ ] After merge: queued drain PRs start landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed accessibility audit test assertion to validate the correct null state for surface manifest resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8622)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->