### PR TITLE
fix(profile): remove deleted draft from Tim White preview

### DIFF
--- a/apps/web/components/features/home/homepage-profile-preview-fixture.ts
+++ b/apps/web/components/features/home/homepage-profile-preview-fixture.ts
@@ -14,10 +14,6 @@ import type { PublicContact } from '@/types/contacts';
 import type { Artist, LegacySocialLink } from '@/types/db';
 
 const CREATED_AT = '2026-01-10T00:00:00.000Z';
-const MOCK_HOME_HERO_IMAGE_URL =
-  '/images/mock-profile/tim-white-dont-look-down-hero.jpg';
-const MOCK_HOME_CARD_IMAGE_URL =
-  '/images/mock-profile/tim-white-dont-look-down-card.jpg';
 
 type HomepageContactInput = {
   readonly id: string;
@@ -192,8 +188,8 @@ export const HOMEPAGE_PROFILE_PREVIEW_ARTIST: Artist = {
 export const HOMEPAGE_PROFILE_PREVIEW_MOCK_HOME_ARTIST: Artist = {
   ...HOMEPAGE_PROFILE_PREVIEW_ARTIST,
   id: 'homepage-preview-artist-mock-home',
-  image_url: MOCK_HOME_HERO_IMAGE_URL,
-  tagline: "Don't Look Down",
+  image_url: TIM_WHITE_PROFILE.avatarSrc,
+  tagline: HOMEPAGE_PROFILE_PREVIEW_ARTIST.tagline,
   settings: {
     ...(HOMEPAGE_PROFILE_PREVIEW_ARTIST.settings ?? {}),
     heroRoleLabel: 'DJ / Producer',
@@ -201,8 +197,8 @@ export const HOMEPAGE_PROFILE_PREVIEW_MOCK_HOME_ARTIST: Artist = {
   theme: {
     profileAccent: {
       version: 1,
-      primaryHex: '#ed9962',
-      sourceUrl: MOCK_HOME_HERO_IMAGE_URL,
+      primaryHex: '#d3834e',
+      sourceUrl: TIM_WHITE_PROFILE.avatarSrc,
     },
   },
 };
@@ -526,7 +522,7 @@ export const HOMEPAGE_PROFILE_PREVIEW_MOCK_HOME_TOUR_DATES: readonly TourDateVie
       eventType: 'tour',
       confirmationStatus: 'confirmed',
       reviewedAt: CREATED_AT,
-      title: "Don't Look Down Tour",
+      title: 'The Deep End Tour',
       startDate: '2026-06-21',
       startTime: '20:00',
       timezone: 'America/Los_Angeles',
@@ -569,26 +565,19 @@ export const HOMEPAGE_PROFILE_PREVIEW_RELEASES = {
 } as const;
 
 export const HOMEPAGE_PROFILE_PREVIEW_MOCK_HOME_RELEASE = {
-  title: "Don't Look Down",
-  slug: 'dont-look-down',
-  artworkUrl: MOCK_HOME_CARD_IMAGE_URL,
-  releaseDate: '2025-10-01T07:00:00.000Z',
-  releaseType: 'single',
-  metadata: {
-    artistNames: ['Tim White'],
-  },
+  ...HOMEPAGE_PROFILE_PREVIEW_RELEASES.live,
 } as const;
 
 export const HOMEPAGE_PROFILE_PREVIEW_DRAWER_RELEASES: readonly PublicRelease[] =
   [
     {
       id: 'drawer-release-1',
-      title: "Don't Look Down",
-      slug: 'dont-look-down',
+      title: HOMEPAGE_PROFILE_PREVIEW_RELEASES.live.title,
+      slug: HOMEPAGE_PROFILE_PREVIEW_RELEASES.live.slug,
       releaseType: 'single',
-      releaseDate: '2024-11-01T07:00:00.000Z',
-      artworkUrl: '/images/mock-profile/tim-white-dont-look-down-card.jpg',
-      artistNames: ['Tim White'],
+      releaseDate: HOMEPAGE_PROFILE_PREVIEW_RELEASES.live.releaseDate,
+      artworkUrl: HOMEPAGE_PROFILE_PREVIEW_RELEASES.live.artworkUrl,
+      artistNames: ['Cosmic Gate', 'Tim White'],
     },
     {
       id: 'drawer-release-2',

--- a/apps/web/tests/unit/home/tim-white-marketing-fixtures.test.ts
+++ b/apps/web/tests/unit/home/tim-white-marketing-fixtures.test.ts
@@ -27,6 +27,14 @@ describe('Tim White marketing fixtures', () => {
     }
   });
 
+  it('does not expose the deleted Tim White draft release in profile preview fixtures', () => {
+    for (const path of FIXTURE_PATHS) {
+      const source = readFixture(path);
+      expect(source).not.toContain("Don't Look Down");
+      expect(source).not.toContain('dont-look-down');
+    }
+  });
+
   it('uses /tim for visible marketing shortlinks instead of /timwhite', () => {
     const sandboxSource = readFixture(
       'components/features/home/HomeSandboxCard.tsx'


### PR DESCRIPTION
## Root cause
The database-backed public profile loader already excludes soft-deleted releases and `status = draft` releases. The stale title survived because the Tim White mock-home/demo profile bypasses that loader and injects hardcoded fixture data from `apps/web/components/features/home/homepage-profile-preview-fixture.ts`. That fixture still used `Don't Look Down` for the mock-home artist tagline, latest release, tour title, and drawer release.

## Changes
- Replaced the mock-home/profile fixture data with canonical Tim White preview data and the existing live `Take Me Over` release.
- Added a regression assertion so owned Tim White marketing/demo fixtures cannot reintroduce `Don't Look Down` or `dont-look-down`.

## Verification
- `node --version && pnpm --version` → `v22.22.1` / `9.15.4`
- `./scripts/setup.sh` → completed successfully in the clean worktree
- `pnpm --filter web exec vitest run tests/unit/home/tim-white-marketing-fixtures.test.ts tests/unit/home/tim-white-profile.test.ts` → 2 files passed, 9 tests passed
- `pnpm biome check apps/web/components/features/home/homepage-profile-preview-fixture.ts apps/web/tests/unit/home/tim-white-marketing-fixtures.test.ts` → checked 2 files, no fixes applied
- `pnpm --filter @jovie/web run typecheck -- --pretty false` → passed
- `git push` pre-push hook → completed; Biome reported an existing warning in `apps/web/components/features/onboarding/OnboardingTurnstile.tsx` outside this diff

<!-- linear-issue-id:JOV-2175 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized profile preview data across the application for consistency
  * Updated tour information, including renaming a tour entry to "The Deep End Tour"

* **Tests**
  * Added validation to ensure fixture data integrity and prevent inconsistencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8623)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->