### PR TITLE
fix(security): invert dev-route env gate to prevent staging account takeover

### DIFF
--- a/apps/web/app/api/dev/sync-clerk/route.test.ts
+++ b/apps/web/app/api/dev/sync-clerk/route.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Security regression tests for /api/dev/sync-clerk env gate.
+ *
+ * The original DENY gate (NODE_ENV === 'production' && VERCEL_ENV === 'production')
+ * left the route reachable on Vercel preview deployments where VERCEL_ENV === 'preview'.
+ * The fixed ALLOW gate returns 403 for every env that is not explicitly 'development'.
+ *
+ * Ref: audit finding #1 (P0) — 2026-05-13.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Hoist mocks before any import so vi.mock() can reference them
+// ---------------------------------------------------------------------------
+const hoisted = vi.hoisted(() => ({
+  getCachedAuth: vi.fn(),
+  currentUser: vi.fn(),
+  syncClerkIdForEmail: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/auth/cached', () => ({
+  getCachedAuth: hoisted.getCachedAuth,
+}));
+
+vi.mock('@clerk/nextjs/server', () => ({
+  currentUser: hoisted.currentUser,
+}));
+
+vi.mock('@/lib/auth/sync-clerk-id', () => ({
+  syncClerkIdForEmail: hoisted.syncClerkIdForEmail,
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/dev/sync-clerk — env gate (security)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('DENY cases — must return 403', () => {
+    it('returns 403 when VERCEL_ENV=preview (staging alias)', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.stubEnv('VERCEL_ENV', 'preview');
+
+      const { POST } = await import('./route');
+      const res = await POST();
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.success).toBe(false);
+      expect(body.error).toMatch(/outside development/i);
+    });
+
+    it('returns 403 when VERCEL_ENV=production', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.stubEnv('VERCEL_ENV', 'production');
+
+      const { POST } = await import('./route');
+      const res = await POST();
+
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 when VERCEL_ENV=staging', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.stubEnv('VERCEL_ENV', 'staging');
+
+      const { POST } = await import('./route');
+      const res = await POST();
+
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 when NODE_ENV=production and VERCEL_ENV is unset', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      // Leave VERCEL_ENV unset — delete if it was stubbed previously
+      vi.stubEnv('VERCEL_ENV', '');
+
+      const { POST } = await import('./route');
+      const res = await POST();
+
+      expect(res.status).toBe(403);
+    });
+
+    it('does NOT call downstream auth or DB when blocked', async () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      vi.stubEnv('VERCEL_ENV', 'preview');
+
+      const { POST } = await import('./route');
+      await POST();
+
+      expect(hoisted.getCachedAuth).not.toHaveBeenCalled();
+      expect(hoisted.currentUser).not.toHaveBeenCalled();
+      expect(hoisted.syncClerkIdForEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ALLOW case — development env passes the gate', () => {
+    it('allows when NODE_ENV=development (unauthenticated → 401)', async () => {
+      vi.stubEnv('NODE_ENV', 'development');
+      vi.stubEnv('VERCEL_ENV', '');
+
+      hoisted.getCachedAuth.mockResolvedValue({ userId: null });
+
+      const { POST } = await import('./route');
+      const res = await POST();
+
+      // Gate passes; next check is auth → 401
+      expect(res.status).toBe(401);
+    });
+
+    it('allows when VERCEL_ENV=development regardless of NODE_ENV', async () => {
+      vi.stubEnv('NODE_ENV', 'test');
+      vi.stubEnv('VERCEL_ENV', 'development');
+
+      hoisted.getCachedAuth.mockResolvedValue({ userId: null });
+
+      const { POST } = await import('./route');
+      const res = await POST();
+
+      // Gate passes; next check is auth → 401
+      expect(res.status).toBe(401);
+    });
+  });
+});

--- a/apps/web/app/api/dev/sync-clerk/route.ts
+++ b/apps/web/app/api/dev/sync-clerk/route.ts
@@ -14,13 +14,18 @@ const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
  * but the dev Clerk instance assigns a different user ID for the same email.
  */
 export async function POST() {
-  const isProductionEnv =
-    process.env.NODE_ENV === 'production' &&
-    process.env.VERCEL_ENV === 'production';
+  // SECURITY: dev-only routes use ALLOW gate, not DENY gate. See audit #1.
+  // An AND-gate on (NODE_ENV && VERCEL_ENV === 'production') leaves preview/staging
+  // open because VERCEL_ENV === 'preview' there. The correct pattern is to allow
+  // only when the env is explicitly 'development'; every other env (preview,
+  // staging, production) returns 403.
+  const isDevEnv =
+    process.env.NODE_ENV === 'development' ||
+    process.env.VERCEL_ENV === 'development';
 
-  if (isProductionEnv) {
+  if (!isDevEnv) {
     return NextResponse.json(
-      { success: false, error: 'Not available in production' },
+      { success: false, error: 'Not available outside development' },
       { status: 403, headers: NO_STORE_HEADERS }
     );
   }

--- a/apps/web/app/api/dev/unwaitlist/route.ts
+++ b/apps/web/app/api/dev/unwaitlist/route.ts
@@ -13,14 +13,18 @@ export const runtime = 'nodejs';
 const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
 
 export async function POST() {
-  // Only allow in non-production environments (same guard as DevToolbar)
-  const isProductionEnv =
-    process.env.NODE_ENV === 'production' &&
-    process.env.VERCEL_ENV === 'production';
+  // SECURITY: dev-only routes use ALLOW gate, not DENY gate. See audit #1.
+  // An AND-gate on (NODE_ENV && VERCEL_ENV === 'production') leaves preview/staging
+  // open because VERCEL_ENV === 'preview' there. The correct pattern is to allow
+  // only when the env is explicitly 'development'; every other env (preview,
+  // staging, production) returns 403.
+  const isDevEnv =
+    process.env.NODE_ENV === 'development' ||
+    process.env.VERCEL_ENV === 'development';
 
-  if (isProductionEnv) {
+  if (!isDevEnv) {
     return NextResponse.json(
-      { success: false, error: 'Not available in production' },
+      { success: false, error: 'Not available outside development' },
       { status: 403, headers: NO_STORE_HEADERS }
     );
   }


### PR DESCRIPTION
## Summary
- Inverts the production-DENY gate on `/api/dev/sync-clerk` and `/api/dev/unwaitlist` to a development-ALLOW gate, closing a P0 account-takeover primitive on staging
- The old `NODE_ENV === 'production' && VERCEL_ENV === 'production'` AND-gate left both routes reachable on Vercel preview (where `VERCEL_ENV === 'preview'`); since `staging.jov.ie` is aliased from a Vercel preview deploy and shares the production Neon DB, an attacker with a Clerk session could overwrite any `users.clerk_id` row by email
- New gate: `NODE_ENV === 'development' || VERCEL_ENV === 'development'` — only local dev passes; preview, staging, and production all return 403

## Test plan
- [x] Vitest asserts 403 for `VERCEL_ENV=preview`
- [x] Vitest asserts 403 for `VERCEL_ENV=production`
- [x] Vitest asserts 403 for `VERCEL_ENV=staging`
- [x] Vitest asserts 403 for `NODE_ENV=production` with `VERCEL_ENV` unset
- [x] Vitest asserts downstream auth/DB not called when gate blocks
- [x] Vitest asserts allow when `NODE_ENV=development`
- [x] Vitest asserts allow when `VERCEL_ENV=development` (regardless of `NODE_ENV`)
- [x] Typecheck clean
- [x] Biome clean
- [x] Pre-commit + pre-push hooks passed
- [ ] /qa --exhaustive after merge

## Files changed
- `apps/web/app/api/dev/sync-clerk/route.ts` — gate inversion (P0 fix)
- `apps/web/app/api/dev/unwaitlist/route.ts` — same gate inversion (lower impact — flips caller's own waitlist status only, but same incorrect pattern)
- `apps/web/app/api/dev/sync-clerk/route.test.ts` — new regression test (7 cases)

## Source
2026-05-13 security audit, finding #1 (P0). See `.context/audit/audit-report.md` §3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened access controls for development-only API endpoints by enforcing explicit development environment requirements, preventing unauthorized access from production, staging, and preview deployment environments.

* **Tests**
  * Added comprehensive test coverage to verify that development endpoint access controls properly restrict access across all non-development environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8634)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->