### PR TITLE
fix(auth): force path-based OAuth callback to fix prod OAuth hang

### DIFF
--- a/apps/web/components/features/auth/AuthShell.tsx
+++ b/apps/web/components/features/auth/AuthShell.tsx
@@ -131,7 +131,8 @@ export function AuthShell({
 
       {isSignUp ? (
         <SignUp
-          routing='hash'
+          routing='path'
+          path='/signup'
           oauthFlow='redirect'
           signInUrl={crossLinkUrl}
           fallbackRedirectUrl={resolvedRedirect}
@@ -139,7 +140,8 @@ export function AuthShell({
         />
       ) : (
         <SignIn
-          routing='hash'
+          routing='path'
+          path='/signin'
           oauthFlow='redirect'
           signUpUrl={crossLinkUrl}
           fallbackRedirectUrl={resolvedRedirect}

--- a/apps/web/tests/unit/app/signin-page.test.tsx
+++ b/apps/web/tests/unit/app/signin-page.test.tsx
@@ -60,7 +60,8 @@ describe('signin page', () => {
     expect(routerPrefetchMock).toHaveBeenCalledWith(APP_ROUTES.SIGNUP);
     expect(clerkSignInMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        routing: 'hash',
+        routing: 'path',
+        path: '/signin',
         oauthFlow: 'redirect',
         signUpUrl: APP_ROUTES.SIGNUP,
         fallbackRedirectUrl: APP_ROUTES.DASHBOARD,

--- a/apps/web/tests/unit/app/signup-page.test.tsx
+++ b/apps/web/tests/unit/app/signup-page.test.tsx
@@ -106,7 +106,8 @@ describe('signup page', () => {
     expect(routerPrefetchMock).toHaveBeenCalledWith(APP_ROUTES.WAITLIST);
     expect(clerkSignUpMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        routing: 'hash',
+        routing: 'path',
+        path: '/signup',
         oauthFlow: 'redirect',
         signInUrl: APP_ROUTES.SIGNIN,
         fallbackRedirectUrl: APP_ROUTES.WAITLIST,


### PR DESCRIPTION
## Summary

Fixes audit findings #83 + #84 (both P0): OAuth callback hangs after Google Allow because Clerk was redirecting to `/signin#/sso-callback?...` (fragment hash) instead of `/signin/sso-callback?...` (dedicated route). The `<SignIn>` component cannot process hash callbacks when landed on the bare `/signin` route, so the page sat indefinitely — no spinner, no progress, no redirect. After 15+ seconds, navigating away surfaced raw Clerk error `"The External Account was not found."` with zero recovery UI.

Root cause: `AuthShell.tsx` had `routing='hash'` on both `<SignIn>` and `<SignUp>`. Hash routing tells Clerk to handle the OAuth callback via a fragment appended to the current page URL. Path routing tells Clerk to redirect to the dedicated `/signin/sso-callback` route, which already has `SsoCallbackHandler` calling `clerk.handleRedirectCallback()` correctly.

Fix: switch both components to `routing='path'` with explicit `path` prop (`path='/signin'` / `path='/signup'`), per the Clerk Next.js App Router canonical pattern. The dedicated sso-callback routes (`/signin/sso-callback`, `/signup/sso-callback`) already existed and were already correct — they just were never being used.

## What changed

- `apps/web/components/features/auth/AuthShell.tsx`: `routing='hash'` → `routing='path'` with `path='/signin'` / `path='/signup'` on `<SignIn>` / `<SignUp>`
- `apps/web/tests/unit/app/signin-page.test.tsx`: updated assertions to expect `routing: 'path'` and `path: '/signin'`
- `apps/web/tests/unit/app/signup-page.test.tsx`: updated assertions to expect `routing: 'path'` and `path: '/signup'`

## Test plan

- [x] `routing: 'path'` and `path` prop asserted in Vitest for both signin and signup pages (4 + 9 tests pass)
- [x] Typecheck clean (zero errors)
- [x] Biome clean (zero errors on changed files)
- [ ] Post-merge: `/browse` + imported Google cookies → Allow → OAuth completes within 10s on prod
- [ ] Post-merge: no "External Account was not found" surface

## ⚠️ Manual steps Tim must do in Clerk dashboard

The code fix routes to the correct sso-callback pages. For the OAuth round-trip to complete, Clerk's dashboard must allow those URLs as redirect targets.

**In both the production AND staging Clerk instances**, go to Configure → Restrictions → Allowed redirect URLs and add:

```
https://jov.ie/signin/sso-callback
https://jov.ie/signup/sso-callback
https://staging.jov.ie/signin/sso-callback
https://staging.jov.ie/signup/sso-callback
```

If they already exist, no action needed.

**Also verify (read-only check):** In Google Cloud Console → OAuth 2.0 Client → Authorized redirect URIs, confirm the URI points to Clerk's FAPI domain (something like `https://clerk.jov.ie/v1/oauth_callback` or `https://<fapi-host>/v1/oauth_callback`). It should NOT point to a `jov.ie` URL directly. This is Clerk's responsibility — the Google redirect goes to Clerk, then Clerk redirects to Jovie. If the Google URI is wrong, Clerk auth will stay broken regardless of this code fix.

## Why hash routing was wrong

With `routing='hash'`, Clerk appends `#/sso-callback?...` to the current page URL after OAuth completes. This is designed for SPAs where you control the routing layer. In Next.js App Router, the hash fragment is NOT a route — Next.js does not render a different component for hash changes. So `<SignIn>` at `/signin` renders the sign-in form, sees no hash route it recognizes, and sits idle. With `routing='path'`, Clerk does a full navigation to `/signin/sso-callback?...`, which Next.js renders as the dedicated route with `SsoCallbackHandler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated authentication routing to use cleaner URL paths for sign-in and sign-up flows instead of hash-based navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8635)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->