### PR TITLE
fix(privacy): InstantlyPixel allowlist marketing pages, exclude auth surface

### DIFF
--- a/apps/web/components/providers/InstantlyPixel.tsx
+++ b/apps/web/components/providers/InstantlyPixel.tsx
@@ -8,19 +8,37 @@ import { env } from '@/lib/env-client';
 import { publicEnv } from '@/lib/env-public';
 import { isMarketingAllowed } from '@/lib/tracking/consent';
 
-const DENIED_PREFIXES = [
-  '/app',
-  '/onboarding',
-  '/account',
-  '/artist-selection',
-  '/billing',
-  '/sso-callback',
+// Allowlist approach (fail-closed): the pixel only fires on explicit marketing
+// pages. Any route NOT in this list — including future auth-adjacent routes,
+// /signin, /signup, /sso-callback, /app/*, /onboarding, etc. — gets NO pixel
+// by default. This prevents pre-auth fingerprinting (audit finding #8, P0).
+//
+// Previous DENY-list omitted /signin and /signup, letting the pixel fire on
+// auth surfaces (live-capture: r2.leadsy.ai/tag.js, wvbknd.leadsy.ai POSTs).
+// An ALLOW-list is safer: new routes default to excluded; authors must
+// explicitly opt a page in rather than remembering to opt it out.
+const ALLOWED_PREFIXES = [
+  '/', // exact root only — home
+  '/about',
+  '/pricing',
+  '/blog',
+  '/changelog',
+  '/support',
+  '/download',
+  '/artist-profiles',
+  '/ai',
+  '/compare',
+  '/alternatives',
 ] as const;
 
-function isDeniedRoute(pathname: string | null): boolean {
+function isAllowedRoute(pathname: string | null): boolean {
   if (!pathname) return false;
-  return DENIED_PREFIXES.some(
-    prefix => pathname === prefix || pathname.startsWith(`${prefix}/`)
+  return ALLOWED_PREFIXES.some(prefix =>
+    // For '/' allow exact match only to avoid matching everything.
+    // For all other prefixes allow exact + sub-paths.
+    prefix === '/'
+      ? pathname === '/'
+      : pathname === prefix || pathname.startsWith(`${prefix}/`)
   );
 }
 
@@ -28,9 +46,9 @@ export function InstantlyPixel() {
   const pathname = usePathname();
   const pixelId = publicEnv.NEXT_PUBLIC_INSTANTLY_PIXEL_ID;
   const isPassive = env.IS_TEST || env.IS_E2E;
-  const isDenied = isDeniedRoute(pathname);
+  const isAllowed = isAllowedRoute(pathname);
   const isDemo = isDemoRecordingClient();
-  const skip = !pixelId || isPassive || isDenied || isDemo;
+  const skip = !pixelId || isPassive || !isAllowed || isDemo;
 
   const [allowed, setAllowed] = useState(false);
 

--- a/apps/web/tests/unit/tracking/instantly-pixel.test.tsx
+++ b/apps/web/tests/unit/tracking/instantly-pixel.test.tsx
@@ -117,6 +117,20 @@ describe('InstantlyPixel', () => {
     expect(hasScript(container)).toBe(false);
   });
 
+  // --- Allowlist: routes that should NOT fire the pixel ---
+
+  it('returns null on /signin (auth surface — audit finding #8)', () => {
+    _pathname = '/signin';
+    const { container } = render(<InstantlyPixel />);
+    expect(hasScript(container)).toBe(false);
+  });
+
+  it('returns null on /signup (auth surface — audit finding #8)', () => {
+    _pathname = '/signup';
+    const { container } = render(<InstantlyPixel />);
+    expect(hasScript(container)).toBe(false);
+  });
+
   it('returns null on /app/dashboard route', () => {
     _pathname = '/app/dashboard';
     const { container } = render(<InstantlyPixel />);
@@ -133,6 +147,57 @@ describe('InstantlyPixel', () => {
     _pathname = '/billing/success';
     const { container } = render(<InstantlyPixel />);
     expect(hasScript(container)).toBe(false);
+  });
+
+  it('returns null on /sso-callback (not in allowlist)', () => {
+    _pathname = '/sso-callback';
+    const { container } = render(<InstantlyPixel />);
+    expect(hasScript(container)).toBe(false);
+  });
+
+  it('returns null on an unknown future route (fail-closed default)', () => {
+    _pathname = '/some-new-auth-route';
+    const { container } = render(<InstantlyPixel />);
+    expect(hasScript(container)).toBe(false);
+  });
+
+  it('does not treat /about-us as matching /about prefix', () => {
+    // /about-us is NOT in the allowlist; only /about and /about/* are allowed
+    _pathname = '/about-us';
+    const { container } = render(<InstantlyPixel />);
+    expect(hasScript(container)).toBe(false);
+  });
+
+  // --- Allowlist: routes that SHOULD fire the pixel ---
+
+  it('renders on / (home — exact match)', () => {
+    _pathname = '/';
+    const { container } = render(<InstantlyPixel />);
+    expect(hasScript(container)).toBe(true);
+  });
+
+  it('renders on /about', () => {
+    _pathname = '/about';
+    const { container } = render(<InstantlyPixel />);
+    expect(hasScript(container)).toBe(true);
+  });
+
+  it('renders on /blog/some-post (sub-path of allowed prefix)', () => {
+    _pathname = '/blog/some-post';
+    const { container } = render(<InstantlyPixel />);
+    expect(hasScript(container)).toBe(true);
+  });
+
+  it('renders on /changelog', () => {
+    _pathname = '/changelog';
+    const { container } = render(<InstantlyPixel />);
+    expect(hasScript(container)).toBe(true);
+  });
+
+  it('renders on /artist-profiles', () => {
+    _pathname = '/artist-profiles';
+    const { container } = render(<InstantlyPixel />);
+    expect(hasScript(container)).toBe(true);
   });
 
   it('returns null in test runtime', () => {


### PR DESCRIPTION
## Summary

- Switches `InstantlyPixel` route gating from DENY-list to ALLOW-list (fail-closed). Only marketing pages (/, /about, /pricing, /blog, /changelog, /support, /download, /artist-profiles, /ai, /compare, /alternatives) load the pixel.
- Auth pages (/signin, /signup) and all authenticated/onboarding routes are excluded by default. Any future route not in the allowlist gets no pixel without an explicit opt-in.
- Previous `DENIED_PREFIXES` was missing `/signin` and `/signup`, causing live network requests from `r2.leadsy.ai/tag.js` and `wvbknd.leadsy.ai/v1/website-visitors/test` POSTs on the auth surface.

Closes audit finding #8 (P0): pre-auth fingerprinting on auth surface. Also eliminates CORS error console noise on those routes.

Source: 2026-05-13 audit, finding #8.

## Test plan

- [x] Vitest: pixel mounts on `/`, `/pricing`, `/about`, `/blog/some-post`, `/changelog`, `/artist-profiles`
- [x] Vitest: pixel does NOT mount on `/signin`, `/signup`, `/app/dashboard`, `/onboarding`, `/billing`, `/sso-callback`, unknown future routes
- [x] Vitest: `/about-us` does not match `/about` prefix (exact prefix boundary check)
- [x] Typecheck: clean
- [x] Biome: clean (25 tests, 25 passing)
- [ ] Post-merge: verify on staging via /browse network tab — confirm no pixel requests on /signin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated tracking pixel to use an allowlist approach, ensuring it only loads on designated marketing routes and is blocked on authentication pages (e.g., sign-in, sign-up).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8636)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->