### PR TITLE
fix(onboarding): wrap /start SSR in try/catch with redirect fallback

### DIFF
--- a/apps/web/app/(dynamic)/start/page.test.ts
+++ b/apps/web/app/(dynamic)/start/page.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted mocks must be declared before any imports that use them.
+const { getOrMintOnboardingSessionIdMock, captureErrorMock, redirectMock } =
+  vi.hoisted(() => ({
+    getOrMintOnboardingSessionIdMock: vi.fn(),
+    captureErrorMock: vi.fn(),
+    // In real Next.js, redirect() throws a NEXT_REDIRECT error so execution
+    // stops. Simulate that behaviour so the catch branch returns cleanly.
+    redirectMock: vi.fn(() => {
+      throw new Error('NEXT_REDIRECT');
+    }),
+  }));
+
+vi.mock('@/lib/onboarding/session', () => ({
+  getOrMintOnboardingSessionId: getOrMintOnboardingSessionIdMock,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: captureErrorMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+// OnboardingShell is a UI component we don't need to render in this test.
+vi.mock('@/components/features/onboarding/OnboardingShell', () => ({
+  OnboardingShell: () => null,
+}));
+
+import { APP_ROUTES } from '@/constants/routes';
+
+import StartPage from './page';
+
+describe('StartPage — session error fallback', () => {
+  beforeEach(() => {
+    getOrMintOnboardingSessionIdMock.mockReset();
+    captureErrorMock.mockReset();
+    redirectMock.mockReset();
+    // Re-apply the throw so each test inherits the real-Next.js behaviour.
+    redirectMock.mockImplementation(() => {
+      throw new Error('NEXT_REDIRECT');
+    });
+  });
+
+  it('calls captureError + redirect(/signup) when getOrMintOnboardingSessionId throws', async () => {
+    const boom = new Error('SESSION_SECRET is not configured');
+    getOrMintOnboardingSessionIdMock.mockRejectedValueOnce(boom);
+    captureErrorMock.mockResolvedValue(undefined);
+
+    // The page will throw NEXT_REDIRECT — catch it so the test doesn't fail.
+    await expect(StartPage()).rejects.toThrow('NEXT_REDIRECT');
+
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining('SESSION_SECRET'),
+      boom,
+      expect.objectContaining({ route: '/start' })
+    );
+    expect(redirectMock).toHaveBeenCalledWith(APP_ROUTES.SIGNUP);
+  });
+
+  it('renders normally (returns JSX) and does not redirect when session minting succeeds', async () => {
+    getOrMintOnboardingSessionIdMock.mockResolvedValueOnce({
+      sessionId: '00112233-4455-6677-8899-aabbccddeeff',
+      origin: 'minted',
+    });
+
+    const result = await StartPage();
+
+    expect(result).toBeDefined();
+    expect(redirectMock).not.toHaveBeenCalled();
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/(dynamic)/start/page.tsx
+++ b/apps/web/app/(dynamic)/start/page.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
 import { OnboardingShell } from '@/components/features/onboarding/OnboardingShell';
+import { APP_ROUTES } from '@/constants/routes';
+import { captureError } from '@/lib/error-tracking';
 import { getOrMintOnboardingSessionId } from '@/lib/onboarding/session';
 
 /**
@@ -31,7 +34,22 @@ export default async function StartPage() {
   // Mint or read the signed onboarding session cookie. The /api/chat handler
   // will read this cookie on the first message; persisting it here means the
   // first POST already has a stable session id and Turnstile gate behavior.
-  const { sessionId } = await getOrMintOnboardingSessionId();
+  //
+  // Guard: if session minting fails (e.g. SESSION_SECRET not yet provisioned
+  // on a new environment), redirect to /signup instead of rendering a 500.
+  // The root cause is almost always a missing SESSION_SECRET env var.
+  let sessionId: string;
+  try {
+    const result = await getOrMintOnboardingSessionId();
+    sessionId = result.sessionId;
+  } catch (err) {
+    await captureError(
+      '[/start] getOrMintOnboardingSessionId threw — redirecting to /signup. Check SESSION_SECRET is provisioned.',
+      err,
+      { route: '/start' }
+    );
+    return redirect(APP_ROUTES.SIGNUP);
+  }
 
   // We expose only the leading 8 chars of the session id to the client for
   // debugging breadcrumbs — the full signed cookie value is httpOnly, the


### PR DESCRIPTION
## Summary

- Wraps `getOrMintOnboardingSessionId()` in `/start/page.tsx` in try/catch with `captureError` + `redirect('/signup')` fallback
- Resolves the prod 500 that renders as a 404 (audit finding #7, P0) — top-of-funnel anon onboarding entry is restored
- Root cause: `SESSION_SECRET` is marked `.optional()` in the env schema; when absent (or < 32 chars), `getSessionSecret()` throws; the unhandled throw causes Next.js to render a 500, which the error boundary chain serves as the `not-found.tsx` component

## Root cause detail

`lib/onboarding/session.ts` L31–38: `getSessionSecret()` explicitly throws when `SESSION_SECRET` is falsy or < 32 chars. The env schema (`env-server-schema.ts` L158) defines it as `z.string().min(32).optional()`, meaning builds without this var succeed silently. On production, if `SESSION_SECRET` was never provisioned in Doppler (or was provisioned after deploy but not yet reloaded), every `/start` request throws → 500.

The fix does not mask the root cause — `captureError` fires to Sentry so the missing env var surfaces as an actionable alert, and the redirect keeps users moving toward signup rather than hitting a dead end.

## Test plan
- [x] Vitest: `StartPage — session error fallback` (2 tests) — error path calls `captureError` + `redirect('/signup')`; happy path renders without redirect
- [x] Typecheck clean (`pnpm --filter @jovie/web run typecheck`)
- [x] Biome clean (`pnpm biome check --write` on both files)
- [ ] `curl https://staging.jov.ie/start` post-merge — should return redirect, not 500

## Files changed
- `apps/web/app/(dynamic)/start/page.tsx` — try/catch + captureError + redirect fallback
- `apps/web/app/(dynamic)/start/page.test.ts` — new unit tests for error + happy paths

Source: 2026-05-13 audit, finding #7 (P0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during onboarding session creation—users experiencing issues with session setup are now gracefully redirected to signup instead of encountering an error.

* **Tests**
  * Added test coverage for onboarding session error scenarios and successful session creation paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8637)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->