### PR TITLE
style(onboarding): align start chat with app shell

### DIFF
--- a/apps/web/components/features/onboarding/ChatProposeCheckoutCard.tsx
+++ b/apps/web/components/features/onboarding/ChatProposeCheckoutCard.tsx
@@ -28,7 +28,7 @@ interface ChatProposeCheckoutCardProps {
 }
 
 const PLAN_LABELS: Record<NonNullable<CheckoutCardPayload['plan']>, string> = {
-  free: 'free tier',
+  free: 'Free tier',
   pro: 'Pro — $39/mo',
   max: 'Max — $149/mo',
 };
@@ -36,7 +36,7 @@ const PLAN_LABELS: Record<NonNullable<CheckoutCardPayload['plan']>, string> = {
 export function ChatProposeCheckoutCard({
   payload,
 }: ChatProposeCheckoutCardProps) {
-  const planLabel = payload.plan ? PLAN_LABELS[payload.plan] : 'pick a plan';
+  const planLabel = payload.plan ? PLAN_LABELS[payload.plan] : 'Pick a plan';
   // Trust the handoffUrl from the server if present, but bound it to the
   // canonical onboarding checkout route family so a future tool-result tweak
   // can't redirect us to an unrelated path.
@@ -46,10 +46,10 @@ export function ChatProposeCheckoutCard({
       : APP_ROUTES.ONBOARDING_CHECKOUT;
 
   return (
-    <div className='mt-2 flex items-center justify-between gap-3 rounded-2xl border border-white/[0.12] bg-white/[0.06] px-4 py-3'>
+    <div className='flex items-center justify-between gap-3 rounded-xl border border-subtle bg-surface-1 px-4 py-3'>
       <div className='min-w-0'>
-        <p className='text-[13px] text-white/60'>continue to checkout</p>
-        <p className='truncate text-[15px] font-semibold text-white'>
+        <p className='text-[13px] text-secondary-token'>Continue to checkout</p>
+        <p className='truncate text-[15px] font-semibold text-primary-token'>
           {planLabel}
         </p>
       </div>

--- a/apps/web/components/features/onboarding/ChatProposeNextStepCard.tsx
+++ b/apps/web/components/features/onboarding/ChatProposeNextStepCard.tsx
@@ -51,18 +51,18 @@ export function ChatProposeNextStepCard({
       elements: {
         rootBox: 'w-full',
         card: 'bg-transparent shadow-none border-0 p-0',
-        headerTitle: 'text-white text-[18px] font-semibold',
-        headerSubtitle: 'text-white/60 text-[13px]',
+        headerTitle: 'text-primary-token text-[18px] font-semibold',
+        headerSubtitle: 'text-secondary-token text-[13px]',
         formButtonPrimary:
-          'bg-white text-black hover:bg-white/90 normal-case font-semibold',
+          'bg-white text-black hover:bg-white/90 font-semibold',
         socialButtonsBlockButton:
-          'bg-white/[0.04] border-white/[0.09] text-white hover:bg-white/[0.08]',
+          'bg-surface-1 border-subtle text-primary-token hover:bg-surface-2',
         formFieldInput:
-          'bg-white/[0.04] border-white/[0.09] text-white focus:border-white/24',
-        formFieldLabel: 'text-white/70',
+          'bg-surface-0 border-subtle text-primary-token focus:border-primary-token/30',
+        formFieldLabel: 'text-secondary-token',
         footer: 'hidden',
-        dividerLine: 'bg-white/[0.07]',
-        dividerText: 'text-white/40',
+        dividerLine: 'bg-(--linear-border-subtle)',
+        dividerText: 'text-tertiary-token',
       },
       variables: {
         colorBackground: 'transparent',
@@ -84,9 +84,9 @@ export function ChatProposeNextStepCard({
 
   if (kind === 'waitlist') {
     return (
-      <div className='mt-2 rounded-2xl border border-white/[0.08] bg-white/[0.035] px-4 py-3'>
-        <p className='text-[14px] leading-6 text-white/82'>
-          {`you're on the list. I'll email you when you're up — we can pick up right here.`}
+      <div className='rounded-xl border border-subtle bg-surface-1 px-4 py-3'>
+        <p className='text-[15px] leading-7 text-primary-token'>
+          {`You're on the list. I'll email you when you're up — we can pick up right here.`}
         </p>
       </div>
     );
@@ -98,9 +98,9 @@ export function ChatProposeNextStepCard({
     // had a Clerk session already). Skip the form; the claim hook on the
     // shell will fire and bounce them to checkout.
     return (
-      <div className='mt-2 rounded-2xl border border-white/[0.08] bg-white/[0.035] px-4 py-3'>
-        <p className='text-[14px] leading-6 text-white/82'>
-          {`you're already signed in. one sec — linking this conversation to your account…`}
+      <div className='rounded-xl border border-subtle bg-surface-1 px-4 py-3'>
+        <p className='text-[15px] leading-7 text-primary-token'>
+          {`You're already signed in. Linking this conversation to your account…`}
         </p>
       </div>
     );
@@ -108,18 +108,18 @@ export function ChatProposeNextStepCard({
 
   if (!canRenderClerkUi) {
     return (
-      <div className='mt-2 rounded-2xl border border-white/[0.08] bg-white/[0.035] px-4 py-3'>
-        <p className='text-[14px] leading-6 text-white/82'>
-          {`you're in. use the dev toolbar to continue as a local test user — I'll keep this conversation ready to link.`}
+      <div className='rounded-xl border border-subtle bg-surface-1 px-4 py-3'>
+        <p className='text-[15px] leading-7 text-primary-token'>
+          {`You're in. Use the dev toolbar to continue as a local test user — I'll keep this conversation ready to link.`}
         </p>
       </div>
     );
   }
 
   return (
-    <div className='mt-2 rounded-2xl border border-white/[0.08] bg-white/[0.035] px-4 py-4'>
-      <p className='mb-3 text-[14px] leading-6 text-white/82'>
-        {`you're in. drop an email to keep going — I'll save this conversation to your account so we don't lose it.`}
+    <div className='rounded-xl border border-subtle bg-surface-1 px-4 py-4'>
+      <p className='mb-3 text-[15px] leading-7 text-primary-token'>
+        {`You're in. Add an email to keep going — I'll save this conversation to your account so we don't lose it.`}
       </p>
       <SignUp
         routing='hash'

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -2,16 +2,19 @@
 
 import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport, type UIMessage } from 'ai';
-import { ArrowUp, Loader2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  type FormEvent,
-  type KeyboardEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+  ChatInput,
+  ChatMessage,
+  ErrorDisplay,
+} from '@/components/jovie/components';
+import { ToolPartsRenderer } from '@/components/jovie/tool-ui';
+import type { ChatError, MessagePart } from '@/components/jovie/types';
+import {
+  extractErrorMetadata,
+  getErrorType,
+  getPreferredErrorMessage,
+} from '@/components/jovie/utils';
 import { cn } from '@/lib/utils';
 import {
   ChatProposeCheckoutCard,
@@ -29,11 +32,6 @@ import {
  * carries the Cloudflare Turnstile token; subsequent requests in the same
  * session do not (the signed cookie + session-lifetime rate limit carry
  * trust forward).
- *
- * v1 visual: a single column of message bubbles with a composer at the
- * bottom. Tool-call previews are rendered as small inline chips so the LLM's
- * tool use is visible while we iterate on the dedicated tool cards in a
- * follow-up commit on this branch.
  */
 
 interface OnboardingChatProps {
@@ -44,6 +42,8 @@ interface OnboardingChatProps {
 }
 
 /** Pull the user-visible text out of a UIMessage's parts. */
+const THINKING_PLACEHOLDER_ID = 'onboarding-thinking-placeholder';
+
 function getMessageText(message: UIMessage): string {
   return (message.parts ?? [])
     .filter(
@@ -54,13 +54,13 @@ function getMessageText(message: UIMessage): string {
     .join('');
 }
 
-interface ToolPart {
+type ToolPart = MessagePart & {
   readonly type: string;
   readonly toolName?: string;
   readonly toolCallId?: string;
   readonly output?: unknown;
   readonly state?: string;
-}
+};
 
 function isToolPart(part: unknown): part is ToolPart {
   if (!part || typeof part !== 'object') return false;
@@ -85,7 +85,7 @@ function getToolName(part: ToolPart): string {
  * proposeCheckout) and the chip fallback for the rest.
  */
 function getToolParts(message: UIMessage): readonly ToolPart[] {
-  return (message.parts ?? []).filter(isToolPart);
+  return ((message.parts ?? []) as readonly MessagePart[]).filter(isToolPart);
 }
 
 interface ToolOutputWithAction {
@@ -108,14 +108,82 @@ function isCheckoutPayload(output: unknown): output is CheckoutCardPayload {
   );
 }
 
+function findLastAssistantMessageId(messages: readonly UIMessage[]) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (
+      message.role === 'assistant' &&
+      message.id !== THINKING_PLACEHOLDER_ID
+    ) {
+      return message.id;
+    }
+  }
+  return null;
+}
+
+function renderOnboardingTools({
+  messageId,
+  toolParts,
+  hasMessageText,
+}: {
+  readonly messageId: string;
+  readonly toolParts: readonly ToolPart[];
+  readonly hasMessageText: boolean;
+}) {
+  const genericParts: ToolPart[] = [];
+  const cards = toolParts.map((part, i) => {
+    const toolName = getToolName(part);
+    const key = part.toolCallId ?? `${messageId}-tool-${i}`;
+    const output = part.output;
+
+    if (toolName === 'proposeNextStep' && isNextStepPayload(output)) {
+      return (
+        <div key={key} className='w-full max-w-[440px]'>
+          <ChatProposeNextStepCard payload={output} />
+        </div>
+      );
+    }
+
+    if (toolName === 'proposeCheckout' && isCheckoutPayload(output)) {
+      return (
+        <div key={key} className='w-full max-w-[440px]'>
+          <ChatProposeCheckoutCard payload={output} />
+        </div>
+      );
+    }
+
+    genericParts.push(part);
+    return null;
+  });
+
+  if (toolParts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn('space-y-3 pl-9', hasMessageText && 'mt-3')}>
+      {cards}
+      {genericParts.length > 0 ? (
+        <ToolPartsRenderer
+          parts={genericParts}
+          variant='chat'
+          hasMessageText={false}
+        />
+      ) : null}
+    </div>
+  );
+}
+
 export function OnboardingChat({
   onConversationActivity,
   turnstileToken,
 }: OnboardingChatProps) {
   const [input, setInput] = useState('');
   const [hasSentFirst, setHasSentFirst] = useState(false);
+  const [chatError, setChatError] = useState<ChatError | null>(null);
   const messagesRef = useRef<HTMLDivElement | null>(null);
   const completedUserTurnsRef = useRef(0);
+  const lastAttemptedMessageRef = useRef<string | null>(null);
 
   const transport = useMemo(
     () =>
@@ -135,46 +203,84 @@ export function OnboardingChat({
     [turnstileToken]
   );
 
-  const { messages, sendMessage, status } = useChat({
+  const { messages, sendMessage, status, stop } = useChat({
     id: 'onboarding',
     transport,
+    onError: error => {
+      const type = getErrorType(error);
+      const metadata = extractErrorMetadata(error);
+      setChatError({
+        type,
+        message: getPreferredErrorMessage(error, type, metadata),
+        retryAfter: metadata.retryAfter,
+        errorCode: metadata.errorCode,
+        requestId: metadata.requestId,
+        failedMessage: lastAttemptedMessageRef.current ?? undefined,
+      });
+      if (lastAttemptedMessageRef.current) {
+        setInput(lastAttemptedMessageRef.current);
+      }
+    },
   });
 
-  const isStreaming = status === 'streaming' || status === 'submitted';
+  const isSubmitted = status === 'submitted';
+  const isStreaming = status === 'streaming';
+  const isBusy = isSubmitted || isStreaming;
+  const requiresTurnstile = process.env.NODE_ENV !== 'development';
+  const isAwaitingFirstToken =
+    requiresTurnstile && !hasSentFirst && !turnstileToken;
+  const lastMessage = messages[messages.length - 1];
+  const shouldShowThinking = isBusy && lastMessage?.role === 'user';
+  const displayMessages: readonly UIMessage[] = shouldShowThinking
+    ? [
+        ...messages,
+        {
+          id: THINKING_PLACEHOLDER_ID,
+          role: 'assistant',
+          parts: [],
+        },
+      ]
+    : messages;
+  const lastAssistantMessageId = findLastAssistantMessageId(displayMessages);
 
-  const handleSubmit = useCallback(
-    (event?: FormEvent<HTMLFormElement>) => {
-      event?.preventDefault();
-      const text = input.trim();
-      if (!text || isStreaming) return;
-      if (!hasSentFirst && !turnstileToken) {
+  const submitText = useCallback(
+    (rawText: string) => {
+      const text = rawText.trim();
+      if (!text || isBusy) return;
+      if (isAwaitingFirstToken) {
         // Turnstile hasn't issued a token yet; the widget normally resolves
         // within ~500ms. Silently no-op so the user can retry.
         return;
       }
+      lastAttemptedMessageRef.current = text;
+      setChatError(null);
       sendMessage({ text });
       setHasSentFirst(true);
       setInput('');
     },
-    [hasSentFirst, input, isStreaming, sendMessage, turnstileToken]
+    [isAwaitingFirstToken, isBusy, sendMessage]
   );
 
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLTextAreaElement>) => {
-      if (event.key === 'Enter' && !event.shiftKey) {
-        event.preventDefault();
-        handleSubmit();
-      }
+  const handleSubmit = useCallback(
+    (event?: React.FormEvent) => {
+      event?.preventDefault();
+      submitText(input);
     },
-    [handleSubmit]
+    [input, submitText]
   );
+
+  const handleRetry = useCallback(() => {
+    const failedMessage = chatError?.failedMessage;
+    if (!failedMessage) return;
+    submitText(failedMessage);
+  }, [chatError?.failedMessage, submitText]);
 
   // Auto-scroll on new content
   useEffect(() => {
     const node = messagesRef.current;
     if (!node) return;
     node.scrollTop = node.scrollHeight;
-  }, [messages.length, isStreaming]);
+  }, [displayMessages.length, isBusy]);
 
   useEffect(() => {
     if (status !== 'ready') return;
@@ -186,122 +292,96 @@ export function OnboardingChat({
     onConversationActivity?.();
   }, [messages, onConversationActivity, status]);
 
-  const composerDisabled = isStreaming || (!hasSentFirst && !turnstileToken);
-
   return (
-    <div className='flex flex-1 flex-col'>
+    <div className='flex flex-1 flex-col overflow-hidden'>
       <div
         ref={messagesRef}
-        className='flex-1 space-y-3 overflow-y-auto px-1 py-6'
+        className='relative flex-1 overflow-y-auto px-4 py-5 sm:px-5'
         aria-live='polite'
       >
-        {messages.length === 0 ? (
-          <p className='text-center text-[13px] text-white/40'>
-            {`heads up — I'll remember this chat so you can pick up where we left off when you sign up. what are you working on?`}
-          </p>
-        ) : null}
+        <div className='mx-auto flex min-h-full w-full max-w-[44rem] flex-col'>
+          {messages.length === 0 ? (
+            <div className='flex flex-1 items-center justify-center py-12'>
+              <h1 className='text-balance text-center text-[2.25rem] font-semibold leading-[1.08] tracking-[-0.035em] text-primary-token sm:text-[3rem]'>
+                What are you working on?
+              </h1>
+            </div>
+          ) : (
+            <div className='flex flex-col pb-4'>
+              {displayMessages.map(message => {
+                const text = getMessageText(message);
+                const toolParts = getToolParts(message);
+                const isThinking = message.id === THINKING_PLACEHOLDER_ID;
+                const shouldRenderMessage =
+                  isThinking || Boolean(text) || toolParts.length === 0;
 
-        {messages.map(message => {
-          const text = getMessageText(message);
-          const toolParts = getToolParts(message);
-          return (
-            <div
-              key={message.id}
-              className={cn(
-                'flex flex-col',
-                message.role === 'user' ? 'items-end' : 'items-start'
-              )}
-            >
-              {text || toolParts.length === 0 ? (
-                <div
-                  className={cn(
-                    'max-w-[80%] rounded-2xl px-3.5 py-2.5 text-[14px] leading-6',
-                    message.role === 'user'
-                      ? 'bg-white text-black'
-                      : 'border border-white/[0.08] bg-white/[0.035] text-white/82'
-                  )}
-                >
-                  {text || (
-                    <span className='text-white/40'>
-                      <Loader2
-                        className='inline h-3.5 w-3.5 animate-spin'
-                        aria-hidden
-                      />
-                    </span>
-                  )}
-                </div>
-              ) : null}
-
-              {toolParts.map((part, i) => {
-                const toolName = getToolName(part);
-                const key = part.toolCallId ?? `${message.id}-tool-${i}`;
-                const output = part.output;
-
-                if (
-                  toolName === 'proposeNextStep' &&
-                  isNextStepPayload(output)
-                ) {
-                  return (
-                    <div key={key} className='w-full max-w-[440px]'>
-                      <ChatProposeNextStepCard payload={output} />
-                    </div>
-                  );
-                }
-                if (
-                  toolName === 'proposeCheckout' &&
-                  isCheckoutPayload(output)
-                ) {
-                  return (
-                    <div key={key} className='w-full max-w-[440px]'>
-                      <ChatProposeCheckoutCard payload={output} />
-                    </div>
-                  );
-                }
-                // Fallback: small chip surfacing the tool name. The dedicated
-                // cards for searchSpotifyArtist / confirmSpotifyArtist /
-                // checkHandle / proposeSocialLink / recordInterviewSignal
-                // land in follow-up commits on this branch.
                 return (
-                  <span
-                    key={key}
-                    className='mt-1 inline-flex rounded-full border border-white/[0.12] bg-white/[0.04] px-2 py-0.5 text-[11px] text-white/60'
-                  >
-                    {toolName}
-                  </span>
+                  <div key={message.id} className='pb-5'>
+                    {shouldRenderMessage ? (
+                      <ChatMessage
+                        id={message.id}
+                        role={message.role}
+                        parts={(message.parts ?? []) as MessagePart[]}
+                        isThinking={isThinking}
+                        isStreaming={
+                          isStreaming && message.id === lastAssistantMessageId
+                        }
+                        renderTools={false}
+                      />
+                    ) : null}
+                    {!isThinking
+                      ? renderOnboardingTools({
+                          messageId: message.id,
+                          toolParts,
+                          hasMessageText: Boolean(text),
+                        })
+                      : null}
+                  </div>
                 );
               })}
             </div>
-          );
-        })}
+          )}
+        </div>
       </div>
 
-      <form
-        onSubmit={handleSubmit}
-        className='sticky bottom-0 flex items-end gap-2 border-t border-white/[0.07] bg-[#06070a]/90 pb-3 pt-3 backdrop-blur'
-      >
-        <textarea
-          value={input}
-          onChange={event => setInput(event.target.value)}
-          onKeyDown={handleKeyDown}
-          rows={1}
-          placeholder={
-            !hasSentFirst && !turnstileToken
-              ? 'just a sec…'
-              : 'tell me what you are working on'
-          }
-          disabled={composerDisabled}
-          className='min-h-[44px] max-h-[160px] flex-1 resize-none rounded-2xl border border-white/[0.09] bg-white/[0.04] px-4 py-2.5 text-[14px] text-white outline-none placeholder:text-white/32 focus:border-white/24 disabled:cursor-not-allowed disabled:opacity-50'
-          aria-label='Type a message to Jovie'
-        />
-        <button
-          type='submit'
-          disabled={composerDisabled || input.trim().length === 0}
-          className='inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-black transition-colors hover:bg-white/90 disabled:cursor-not-allowed disabled:opacity-40 focus-ring-themed'
-          aria-label='Send message'
-        >
-          <ArrowUp className='h-4 w-4' aria-hidden />
-        </button>
-      </form>
+      <div className='shrink-0 bg-surface-1 px-4 pb-4 pt-2 sm:px-5 sm:pb-5 sm:pt-2.5'>
+        <div className='mx-auto w-full max-w-[34rem]'>
+          {chatError ? (
+            <div className='mb-2'>
+              <ErrorDisplay
+                chatError={chatError}
+                onRetry={handleRetry}
+                isLoading={isBusy}
+                isSubmitting={isSubmitted}
+              />
+            </div>
+          ) : null}
+
+          {isAwaitingFirstToken ? (
+            <p
+              className='mb-1.5 text-center text-xs text-tertiary-token'
+              role='status'
+              aria-live='polite'
+            >
+              Securing chat...
+            </p>
+          ) : null}
+
+          <ChatInput
+            value={input}
+            onChange={setInput}
+            onSubmit={handleSubmit}
+            isLoading={isBusy}
+            isSubmitting={isSubmitted || isAwaitingFirstToken}
+            isStreaming={isStreaming}
+            onStop={stop}
+            placeholder={
+              isAwaitingFirstToken ? 'Securing chat...' : 'Ask Jovie...'
+            }
+            shellChatV1
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -49,21 +49,28 @@ export function OnboardingShell({ sessionLabel }: OnboardingShellProps) {
 
   return (
     <div
-      className='flex min-h-dvh w-full flex-col bg-[#06070a] text-white [color-scheme:dark]'
+      className='flex min-h-dvh w-full flex-col bg-(--linear-app-content-surface) text-primary-token [color-scheme:dark]'
       data-onboarding-session={sessionLabel}
     >
       <header className='flex h-12 items-center justify-between px-4 sm:px-6'>
         <div className='inline-flex items-center gap-2'>
-          <BrandLogo size={20} tone='white' aria-hidden />
-          <span className='text-[15px] font-semibold text-white'>Jovie</span>
+          <BrandLogo size={20} tone='auto' aria-hidden />
+          <span className='text-[15px] font-semibold text-primary-token'>
+            Jovie
+          </span>
         </div>
       </header>
 
-      <main className='mx-auto flex w-full max-w-[680px] flex-1 flex-col px-4 pb-4 sm:px-6'>
-        <OnboardingChat
-          onConversationActivity={handleConversationActivity}
-          turnstileToken={turnstileToken}
-        />
+      <main className='flex min-h-0 flex-1 overflow-hidden px-3 pb-14 sm:px-6 sm:pb-6'>
+        <section
+          className='mx-auto flex min-h-0 w-full max-w-[56rem] flex-1 overflow-hidden rounded-[20px] border border-subtle bg-surface-1 shadow-card'
+          aria-label='Jovie onboarding chat'
+        >
+          <OnboardingChat
+            onConversationActivity={handleConversationActivity}
+            turnstileToken={turnstileToken}
+          />
+        </section>
       </main>
 
       <OnboardingTurnstile
@@ -73,7 +80,7 @@ export function OnboardingShell({ sessionLabel }: OnboardingShellProps) {
 
       {turnstileError ? (
         <p
-          className='fixed bottom-3 left-1/2 -translate-x-1/2 rounded-full bg-red-500/15 px-3 py-1 text-[12px] text-red-300'
+          className='fixed bottom-3 left-1/2 -translate-x-1/2 rounded-full border border-red-500/20 bg-error-subtle px-3 py-1 text-[12px] text-error'
           role='alert'
         >
           {turnstileError}
@@ -82,11 +89,11 @@ export function OnboardingShell({ sessionLabel }: OnboardingShellProps) {
 
       {isLinking ? (
         <p
-          className='fixed bottom-3 left-1/2 -translate-x-1/2 rounded-full border border-white/[0.12] bg-white/[0.04] px-3 py-1 text-[12px] text-white/70'
+          className='fixed bottom-3 left-1/2 -translate-x-1/2 rounded-full border border-subtle bg-surface-1 px-3 py-1 text-[12px] text-secondary-token'
           role='status'
           aria-live='polite'
         >
-          linking your conversation…
+          Linking your conversation…
         </p>
       ) : null}
     </div>

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -415,6 +415,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
       <form
         onSubmit={handleFormSubmit}
         aria-label='Compose a message — type / for skills and references'
+        className='focus-within:outline-none'
       >
         <div className={dockClass}>
           {/* ROOT inline picker: rendered above the surface via absolute
@@ -464,6 +465,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
               'overflow-hidden border border-white/[0.07] shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_1px_0_rgba(0,0,0,0.18)]',
               isExpanded &&
                 'border-white/[0.10] shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_1px_0_rgba(0,0,0,0.22),0_12px_32px_-16px_rgba(0,0,0,0.45)]',
+              'outline-none focus-within:border-white/[0.16] focus-within:shadow-[inset_0_1px_0_rgba(255,255,255,0.05),0_0_0_3px_rgba(255,255,255,0.035)] focus-within:outline-none',
               isOverLimit && 'border-error',
               showEntitySurface && !isStacked ? 'flex' : 'flex flex-col'
             )}
@@ -838,7 +840,7 @@ function InputRow({
             // the suppress intentional for both mouse and keyboard paths since
             // the surface-level glow IS the keyboard focus indicator for this
             // compound widget.
-            'focus:outline-none focus-visible:outline-none',
+            'focus:outline-none focus-visible:outline-none focus-visible:ring-0',
             isPillMode
               ? 'overflow-hidden whitespace-nowrap py-[7px] px-1'
               : 'py-2 px-1',
@@ -849,8 +851,12 @@ function InputRow({
               ? {
                   height: isPillMode ? undefined : measuredHeight,
                   overflow: isAtMaxHeight ? 'auto' : 'hidden',
+                  boxShadow: 'none',
                 }
-              : { overflow: isAtMaxHeight ? 'auto' : 'hidden' }
+              : {
+                  overflow: isAtMaxHeight ? 'auto' : 'hidden',
+                  boxShadow: 'none',
+                }
           }
           onKeyDown={handleKeyDown}
           onPaste={onPaste}

--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -32,6 +32,11 @@ interface ChatMessageProps {
   readonly profileId?: string;
   /** Skip entrance animation for messages loaded from persistence. */
   readonly skipEntrance?: boolean;
+  /**
+   * Render generic app tool cards/status rows. Callers with surface-specific
+   * tool cards can opt out and render their own tool UI beside the message.
+   */
+  readonly renderTools?: boolean;
 }
 
 export function ChatMessage({
@@ -43,6 +48,7 @@ export function ChatMessage({
   avatarUrl,
   profileId,
   skipEntrance,
+  renderTools = true,
 }: ChatMessageProps) {
   const isUser = role === 'user';
   const { copy, isSuccess } = useClipboard();
@@ -109,96 +115,79 @@ export function ChatMessage({
           )}
         </div>
       ) : (
-        <div className='flex max-w-[78%] flex-col'>
-          {/* Thinking indicator — bouncing dots inside the virtualizer */}
-          {isThinking && (
-            <div className='space-y-2'>
-              <div className='flex items-center gap-2 pl-0.5'>
-                <span
-                  data-testid='chat-loading-avatar'
-                  className='flex h-5.5 w-5.5 items-center justify-center rounded-full border border-subtle bg-surface-0 text-secondary-token'
-                >
-                  <BrandLogo size={10} tone='auto' rounded={false} />
-                </span>
-                <span className='text-2xs font-semibold tracking-[-0.01em] text-secondary-token'>
-                  Jovie
-                </span>
-                <span className='text-2xs text-tertiary-token'>
-                  Writing reply…
-                </span>
-              </div>
+        <div className='grid w-full max-w-full grid-cols-[24px_minmax(0,1fr)] gap-3'>
+          <span
+            data-testid={isThinking ? 'chat-loading-avatar' : undefined}
+            className='mt-0.5 flex h-6 w-6 items-center justify-center rounded-full border border-subtle bg-surface-0 text-secondary-token'
+          >
+            <BrandLogo size={11} tone='auto' rounded={false} />
+          </span>
+          <div className='min-w-0'>
+            {isThinking ? (
               <div
-                data-testid='chat-loading-bubble'
-                className='rounded-[18px] border border-subtle bg-surface-1 px-4 py-3.5 shadow-card'
+                data-testid='chat-loading-indicator'
+                className='flex min-h-7 items-center gap-2 text-[15px] leading-7 text-secondary-token'
+                role='status'
+                aria-live='polite'
               >
-                <div className='flex items-center gap-1.5'>
-                  <span className='flex items-center gap-1' aria-hidden='true'>
-                    <span className='h-1.5 w-1.5 rounded-full bg-tertiary-token animate-bounce [animation-delay:-0.3s] motion-reduce:animate-none' />
-                    <span className='h-1.5 w-1.5 rounded-full bg-tertiary-token animate-bounce [animation-delay:-0.15s] motion-reduce:animate-none' />
-                    <span className='h-1.5 w-1.5 rounded-full bg-tertiary-token animate-bounce motion-reduce:animate-none' />
-                  </span>
-                </div>
+                <span>Thinking</span>
+                <span className='flex items-center gap-1' aria-hidden='true'>
+                  <span className='h-1.5 w-1.5 animate-bounce rounded-full bg-tertiary-token [animation-delay:-0.3s] motion-reduce:animate-none' />
+                  <span className='h-1.5 w-1.5 animate-bounce rounded-full bg-tertiary-token [animation-delay:-0.15s] motion-reduce:animate-none' />
+                  <span className='h-1.5 w-1.5 animate-bounce rounded-full bg-tertiary-token motion-reduce:animate-none' />
+                </span>
+                <span className='sr-only'>Jovie is thinking</span>
               </div>
-              <span className='sr-only' aria-live='polite'>
-                Jovie is writing a reply
-              </span>
-            </div>
-          )}
+            ) : null}
 
-          {!isThinking && hasAssistantContent && (
-            <div className='space-y-1.5'>
-              <div className='flex items-center gap-2 pl-0.5'>
-                <span className='flex h-5.5 w-5.5 items-center justify-center rounded-full border border-subtle bg-surface-0 text-secondary-token'>
-                  <BrandLogo size={10} tone='auto' rounded={false} />
-                </span>
-                <span className='text-2xs font-semibold tracking-[-0.01em] text-secondary-token'>
-                  Jovie
-                </span>
-                <span className='text-2xs text-tertiary-token'>
-                  {isStreaming ? 'Writing reply…' : 'Reply'}
-                </span>
-              </div>
-              {messageText ? (
-                <div
-                  data-testid='chat-message-reply-bubble'
-                  className='rounded-[18px] border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_70%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,var(--linear-surface))] px-4 py-3.5 text-primary-token shadow-none'
-                >
-                  <ChatMarkdown
-                    content={messageText}
-                    isStreaming={Boolean(isStreaming)}
+            {!isThinking && hasAssistantContent ? (
+              <div className='space-y-3'>
+                {messageText ? (
+                  <div
+                    data-testid='chat-message-reply'
+                    className='text-[15px] leading-7 text-primary-token tracking-[-0.008em] sm:text-[15.5px]'
+                  >
+                    <ChatMarkdown
+                      content={messageText}
+                      isStreaming={Boolean(isStreaming)}
+                    />
+                  </div>
+                ) : null}
+
+                {renderTools ? (
+                  <ToolPartsRenderer
+                    parts={parts}
+                    profileId={profileId}
+                    variant='chat'
+                    hasMessageText={Boolean(messageText)}
                   />
-                </div>
-              ) : null}
-            </div>
-          )}
+                ) : null}
+              </div>
+            ) : null}
 
-          <ToolPartsRenderer
-            parts={parts}
-            profileId={profileId}
-            variant='chat'
-            hasMessageText={Boolean(messageText)}
-          />
-
-          {!isStreaming && messageText && (
-            <div className='mt-1.5 flex items-center justify-end pr-0.5'>
-              <SimpleTooltip content={isSuccess ? 'Copied!' : 'Copy response'}>
-                <button
-                  type='button'
-                  onClick={() => copy(messageText)}
-                  className='inline-flex h-7 w-7 items-center justify-center rounded-full border border-transparent bg-transparent text-tertiary-token shadow-none transition-colors duration-150 hover:bg-surface-1 hover:text-secondary-token focus-visible:bg-surface-1 focus-visible:outline-none'
-                  aria-label={
-                    isSuccess ? 'Copied to clipboard' : 'Copy message'
-                  }
+            {!isThinking && !isStreaming && messageText ? (
+              <div className='mt-1.5 flex items-center justify-start'>
+                <SimpleTooltip
+                  content={isSuccess ? 'Copied!' : 'Copy response'}
                 >
-                  {isSuccess ? (
-                    <Check className='h-3.5 w-3.5' />
-                  ) : (
-                    <Copy className='h-3.5 w-3.5' />
-                  )}
-                </button>
-              </SimpleTooltip>
-            </div>
-          )}
+                  <button
+                    type='button'
+                    onClick={() => copy(messageText)}
+                    className='inline-flex h-7 w-7 items-center justify-center rounded-full border border-transparent bg-transparent text-tertiary-token shadow-none transition-colors duration-subtle hover:bg-surface-1 hover:text-secondary-token focus-visible:bg-surface-1 focus-visible:outline-none'
+                    aria-label={
+                      isSuccess ? 'Copied to clipboard' : 'Copy message'
+                    }
+                  >
+                    {isSuccess ? (
+                      <Check className='h-3.5 w-3.5' />
+                    ) : (
+                      <Copy className='h-3.5 w-3.5' />
+                    )}
+                  </button>
+                </SimpleTooltip>
+              </div>
+            ) : null}
+          </div>
         </div>
       )}
     </motion.div>

--- a/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
@@ -44,7 +44,7 @@ describe('ChatMessage analytics cards', () => {
     };
     fastRender(<ChatMessage {...messageProps} />);
 
-    expect(screen.getByTestId('chat-message-reply-bubble')).toBeTruthy();
+    expect(screen.getByTestId('chat-message-reply')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Copy message' })).toBeTruthy();
     expect(screen.queryByText('Copy')).toBeNull();
   });


### PR DESCRIPTION
## Summary
- Reuses the production chat composer/message stack on `/start` and removes the bespoke onboarding chat UI.
- Moves `/start` into an elevated app-style chat panel with tokenized surfaces, plain assistant prose, larger readable text, and visible thinking/streaming states.
- Removes the square inner textarea focus halo while keeping the rounded composer focus affordance.
- Keeps onboarding-specific tool cards for checkout/claim handoff while routing generic tool status through the shared chat tool renderer.
- Mirrors the local dev Turnstile bypass in the client so dev-persona users can send the first onboarding chat turn and trigger transcript claim retries.

## QA
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/chat/ChatMessage.analytics-card.test.tsx tests/unit/chat/JovieChat.styling.test.tsx tests/components/features/onboarding/useOnboardingClaim.test.tsx tests/unit/app/start-page.test.tsx tests/unit/app/onboarding-page.test.tsx tests/unit/api/chat/onboarding-handler.test.ts tests/unit/api/dev/test-auth-routes.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run tailwind:check`
- Pre-commit hook: `next:proxy-guard`, staged Biome, staged ESLint, staged a11y check, scoped web typecheck.
- Pre-push hook: repo Biome check, web proxy guard, Tailwind guard, web typecheck, web Biome lint.

## Browser QA
- `/start` desktop render, keyboard focus, no console errors. Screenshot: `/tmp/jovie-final-start-desktop-focus.png`.
- `/start` mobile render, composer visible above dev toolbar, no console errors. Screenshot: `/tmp/jovie-final-start-mobile.png`.
- Anonymous first chat turn shows thinking/streaming UI and sets `jovie_onboarding_session` cookie. Screenshot: `/tmp/jovie-final-start-chat-turn.png`.
- `/onboarding?resume=spotify&handle=testhandle&intent_id=intent_123` redirects to `/start?resume=spotify&handle=testhandle&intent_id=intent_123` and renders chat, not the legacy form.
- `/waitlist` redirects to `/start` and renders chat.
- Slash picker opens from `/`, wires combobox ARIA, and Escape restores focus.
- Dev persona `/start` first chat turn posts `/api/chat`, sets onboarding session cookie, and retries `/api/onboarding/claim` after chat activity.

## PR Context
- Confirmed `#8643` is merged.
- Checked open PRs for onboarding/chat/shell-v1 overlap. Only `#8516` is open in that search set, scoped to shell-v1 releases controls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual thinking state indicator during chat response generation
  * Implemented enhanced error handling with message retry capability

* **Improvements**
  * Updated onboarding checkout and signup UI styling with improved consistency
  * Enhanced chat input focus behavior and visual feedback
  * Improved assistant message layout and rendering
  * Better status messaging for connection security during chat initialization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8648)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->