### PR TITLE
fix(profile): sync alert prefs across all 3 notification entry points (JOV-1986)

### DIFF
--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -179,8 +179,20 @@ export function ProfileInlineNotificationsCTA({
   const [nameInput, setNameInput] = useState('');
   const [birthdayInput, setBirthdayInput] = useState('');
   const [birthdayHintShown, setBirthdayHintShown] = useState(false);
-  const [alertPrefs, setAlertPrefs] = useState(DEFAULT_ALERT_PREFS);
-  const [artistEmailOptIn, setArtistEmailOptIn] = useState(false);
+  const [alertPrefs, setAlertPrefs] = useState<
+    Record<NotificationContentType, boolean>
+  >(() => {
+    // Seed from server preferences when the user is already subscribed at mount,
+    // so all three entry points (inline CTA, notifications drawer, subscribe
+    // drawer) start from the same canonical state rather than DEFAULT_ALERT_PREFS.
+    if (isSubscribed && contentPreferences) {
+      return { ...DEFAULT_ALERT_PREFS, ...contentPreferences };
+    }
+    return DEFAULT_ALERT_PREFS;
+  });
+  const [artistEmailOptIn, setArtistEmailOptIn] = useState(() =>
+    isSubscribed ? (artistEmail?.optedIn ?? false) : false
+  );
   const [canEditPreferences, setCanEditPreferences] = useState(isSubscribed);
   const subscribedEmailRef = useRef('');
   const hasAutoOpenedRef = useRef(false);
@@ -308,10 +320,21 @@ export function ProfileInlineNotificationsCTA({
       return;
     }
 
+    // Sync server preferences before transitioning to manage mode so that the
+    // preferences step shows the actual saved values, not DEFAULT_ALERT_PREFS.
+    syncPreferencesFromStatus();
     setFlowOrigin('manage');
     setCanEditPreferences(true);
     setStep('preferences');
-  }, [autoOpen, flowOrigin, isFlowOpen, isInline, isSubscribed, step]);
+  }, [
+    autoOpen,
+    flowOrigin,
+    isFlowOpen,
+    isInline,
+    isSubscribed,
+    step,
+    syncPreferencesFromStatus,
+  ]);
 
   const activeEmail = useMemo(
     () =>

--- a/apps/web/tests/unit/profile/inline-notifications-cta.test.tsx
+++ b/apps/web/tests/unit/profile/inline-notifications-cta.test.tsx
@@ -288,4 +288,128 @@ describe('ProfileInlineNotificationsCTA flow', () => {
 
     expect(container).toBeEmptyDOMElement();
   });
+
+  // JOV-1986: alert mode consistency across all three entry points.
+  // The preference labels in ProfileMobileNotificationsFlow map as:
+  //   newMusic → 'New Music', tourDates → 'Shows', merch → 'Merch'
+  describe('alert mode consistency (JOV-1986)', () => {
+    it('initializes alertPrefs from server contentPreferences when already subscribed (overlay entry)', async () => {
+      // Subscriber has tourDates disabled on the server (rendered as 'Shows' label)
+      mockUseProfileNotifications.mockReturnValue(
+        buildProfileNotifications({
+          contentPreferences: {
+            newMusic: true,
+            tourDates: false,
+            merch: true,
+            general: true,
+          },
+        })
+      );
+      mockUseSubscriptionForm.mockReturnValue(
+        buildFormState({
+          notificationsState: 'success',
+          subscribedChannels: { email: true },
+        })
+      );
+
+      render(<ProfileInlineNotificationsCTA artist={makeArtist()} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /manage alerts/i }));
+
+      // Preferences step must show the saved server value, not the all-true default
+      await waitFor(() => {
+        expect(screen.getByRole('switch', { name: 'Shows' })).not.toBeChecked();
+      });
+      // Other preferences remain as saved
+      expect(screen.getByRole('switch', { name: 'New Music' })).toBeChecked();
+    });
+
+    it('seeds alertPrefs from context at mount when already subscribed (inline entry)', async () => {
+      // Subscriber has merch disabled on the server
+      mockUseProfileNotifications.mockReturnValue(
+        buildProfileNotifications({
+          contentPreferences: {
+            newMusic: true,
+            tourDates: true,
+            merch: false,
+            general: true,
+          },
+        })
+      );
+      mockUseSubscriptionForm.mockReturnValue(
+        buildFormState({
+          notificationsState: 'success',
+          subscribedChannels: { email: true },
+        })
+      );
+
+      render(
+        <ProfileInlineNotificationsCTA
+          artist={makeArtist()}
+          presentation='inline'
+        />
+      );
+
+      // Inline flows go directly to preferences for subscribed users
+      await waitFor(() => {
+        expect(screen.getByRole('switch', { name: 'Merch' })).not.toBeChecked();
+      });
+      expect(screen.getByRole('switch', { name: 'New Music' })).toBeChecked();
+    });
+
+    it('syncs alertPrefs from server when hydration resolves to subscribed mid-flow (subscribe-drawer entry)', async () => {
+      // Start as unsubscribed (hydration pending)
+      mockUseProfileNotifications.mockReturnValue(
+        buildProfileNotifications({
+          contentPreferences: {
+            newMusic: true,
+            tourDates: false,
+            merch: true,
+            general: true,
+          },
+        })
+      );
+      mockUseSubscriptionForm.mockReturnValue(
+        buildFormState({
+          notificationsState: 'idle',
+          subscribedChannels: {},
+        })
+      );
+
+      const { rerender } = render(
+        <ProfileInlineNotificationsCTA
+          artist={makeArtist()}
+          presentation='inline'
+          autoOpen
+        />
+      );
+
+      // Initially shows email step for unsubscribed user
+      await waitFor(() => {
+        expect(screen.getByTestId('mobile-email-input')).toBeInTheDocument();
+      });
+
+      // Hydration completes: user is now subscribed
+      mockUseSubscriptionForm.mockReturnValue(
+        buildFormState({
+          notificationsState: 'success',
+          subscribedChannels: { email: true },
+        })
+      );
+
+      rerender(
+        <ProfileInlineNotificationsCTA
+          artist={makeArtist()}
+          presentation='inline'
+          autoOpen
+        />
+      );
+
+      // Must transition to preferences with saved server prefs (tourDates/Shows = off)
+      await waitFor(() => {
+        expect(screen.getByRole('switch', { name: 'Shows' })).not.toBeChecked();
+      });
+      expect(screen.getByRole('switch', { name: 'New Music' })).toBeChecked();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes [JOV-1986](https://linear.app/jovie/issue/JOV-1986) — inconsistent notification alert modes between subscribe/unsubscribe states.

### Root cause

`alertPrefs` in `ProfileInlineNotificationsCTA` was always initialized to `DEFAULT_ALERT_PREFS` (all `true`), regardless of the user's server-side preferences. This caused divergence between:
- The **notifications drawer** (showed real server prefs via `contentPrefs` prop chain from `ProfileCompactTemplate`)  
- The **inline CTA** and **subscribe drawer** flows (both initialized to hardcoded defaults)

### Fix

Two targeted changes in `ProfileInlineNotificationsCTA.tsx`:

1. **Lazy `useState` initializer for `alertPrefs`** — seeds from server `contentPreferences` at mount when the user is already subscribed, so all three entry points start from the same canonical state instead of `DEFAULT_ALERT_PREFS`.

2. **`syncPreferencesFromStatus()` call in the auto-transition effect** — handles the late-hydration case where subscription state resolves after component mount; server preferences are now merged before switching to manage mode.

`artistEmailOptIn` received the same treatment — seeds from `artistEmail?.optedIn` when subscribed rather than always `false`.

### Tests

Added 3 regression tests in `inline-notifications-cta.test.tsx` covering all three entry points:
- Overlay entry (already-subscribed fan opens manage alerts)
- Inline entry (inline CTA when already subscribed)
- Subscribe-drawer entry (hydration resolves to subscribed mid-flow)

### Verification

- 8/8 new + existing tests pass
- 475/475 profile unit tests pass  
- 0 TypeScript errors
- Biome clean

<!-- linear-issue-id:JOV-1986 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification preferences now correctly initialize from saved server settings when managing alert preferences, ensuring users see their actual configured preferences instead of defaults.

* **Tests**
  * Added test coverage verifying notification preference synchronization across different subscription states and component entry points.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8659)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->