### PR TITLE
fix: reduce cognitive complexity in 4 files (SonarCloud S3776)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -25,6 +25,78 @@ export interface DashboardHeaderProps {
   readonly className?: string;
 }
 
+function MobileHeader({
+  currentLabel,
+  action,
+  mobileProfileSlot,
+}: {
+  readonly currentLabel: string;
+  readonly action?: ReactNode;
+  readonly mobileProfileSlot?: ReactNode;
+}) {
+  return (
+    <div className='hidden max-sm:flex items-center justify-between px-4 pb-2 pt-3'>
+      <h1 className='text-[17px] font-semibold leading-tight tracking-[-0.018em] text-primary-token'>
+        {currentLabel}
+      </h1>
+      <div className='flex items-center gap-2'>
+        {action ? (
+          <div className='flex items-center gap-1 [&_button]:h-8 [&_button]:rounded-full [&_button]:shadow-none [&_button>svg]:h-4 [&_button>svg]:w-4'>
+            {action}
+          </div>
+        ) : (
+          mobileProfileSlot
+        )}
+      </div>
+    </div>
+  );
+}
+
+function BreadcrumbTrail({
+  usesSectionTitleLayout,
+  currentLabel,
+  rootLabel,
+  breadcrumbSuffix,
+  showInlineSearch,
+  searchSurface,
+}: {
+  readonly usesSectionTitleLayout: boolean;
+  readonly currentLabel: string;
+  readonly rootLabel: string;
+  readonly breadcrumbSuffix?: ReactNode;
+  readonly showInlineSearch: boolean;
+  readonly searchSurface?: ReactNode;
+}) {
+  return (
+    <>
+      {usesSectionTitleLayout ? (
+        <span className='truncate text-xs font-semibold tracking-[-0.01em] text-primary-token'>
+          {currentLabel}
+        </span>
+      ) : (
+        <>
+          <span className='shrink-0 text-2xs font-caption tracking-[-0.01em] text-tertiary-token'>
+            {rootLabel}
+          </span>
+          <ChevronRight className='size-3 shrink-0 text-quaternary-token/85' />
+          {breadcrumbSuffix ? (
+            <div className='min-w-0 truncate text-xs tracking-[-0.01em] text-secondary-token'>
+              {breadcrumbSuffix}
+            </div>
+          ) : (
+            <span className='truncate text-xs font-semibold tracking-[-0.01em] text-primary-token'>
+              {currentLabel}
+            </span>
+          )}
+        </>
+      )}
+      {showInlineSearch ? (
+        <div className='ml-2 flex items-center'>{searchSurface}</div>
+      ) : null}
+    </>
+  );
+}
+
 export function DashboardHeader({
   breadcrumbs,
   leading,
@@ -50,37 +122,23 @@ export function DashboardHeader({
       data-electron-drag-region='true'
       className={cn('z-20 bg-(--linear-app-content-surface)', className)}
     >
-      {/* Mobile: Large page title with action buttons + profile */}
-      <div className='hidden max-sm:flex items-center justify-between px-4 pb-2 pt-3'>
-        <h1 className='text-[17px] font-semibold leading-tight tracking-[-0.018em] text-primary-token'>
-          {currentLabel}
-        </h1>
-        <div className='flex items-center gap-2'>
-          {action ? (
-            <div className='flex items-center gap-1 [&_button]:h-8 [&_button]:rounded-full [&_button]:shadow-none [&_button>svg]:h-4 [&_button>svg]:w-4'>
-              {action}
-            </div>
-          ) : (
-            mobileProfileSlot
-          )}
-        </div>
-      </div>
-      {/* Desktop: Standard header bar with breadcrumbs */}
+      <MobileHeader
+        currentLabel={currentLabel}
+        action={action}
+        mobileProfileSlot={mobileProfileSlot}
+      />
       <div className='relative max-sm:hidden h-(--linear-app-header-height-compact) w-full items-center gap-2 px-2.5 sm:flex'>
         {leading ? <div className='flex items-center'>{leading}</div> : null}
-        {/* Sidebar expand button (desktop only, when collapsed) */}
         {sidebarTrigger ? (
           <div className='max-lg:hidden items-center lg:flex'>
             {sidebarTrigger}
           </div>
         ) : null}
-        {/* Conditional vertical separator between sidebar trigger and actions */}
         {showDivider && sidebarTrigger && action ? (
           <div className='max-lg:hidden lg:flex items-center'>
             <VerticalDivider />
           </div>
         ) : null}
-        {/* Desktop: Simplified breadcrumb - just current page */}
         <div
           className='flex min-w-0 flex-1 items-center gap-2 tracking-[-0.012em]'
           data-search-active={searchTakesOver ? 'true' : 'false'}
@@ -90,32 +148,14 @@ export function DashboardHeader({
               {searchSurface}
             </div>
           ) : (
-            <>
-              {usesSectionTitleLayout ? (
-                <span className='truncate text-xs font-semibold tracking-[-0.01em] text-primary-token'>
-                  {currentLabel}
-                </span>
-              ) : (
-                <>
-                  <span className='shrink-0 text-2xs font-caption tracking-[-0.01em] text-tertiary-token'>
-                    {rootLabel}
-                  </span>
-                  <ChevronRight className='size-3 shrink-0 text-quaternary-token/85' />
-                  {breadcrumbSuffix ? (
-                    <div className='min-w-0 truncate text-xs tracking-[-0.01em] text-secondary-token'>
-                      {breadcrumbSuffix}
-                    </div>
-                  ) : (
-                    <span className='truncate text-xs font-semibold tracking-[-0.01em] text-primary-token'>
-                      {currentLabel}
-                    </span>
-                  )}
-                </>
-              )}
-              {showInlineSearch ? (
-                <div className='ml-2 flex items-center'>{searchSurface}</div>
-              ) : null}
-            </>
+            <BreadcrumbTrail
+              usesSectionTitleLayout={usesSectionTitleLayout}
+              currentLabel={currentLabel}
+              rootLabel={rootLabel}
+              breadcrumbSuffix={breadcrumbSuffix}
+              showInlineSearch={showInlineSearch}
+              searchSurface={searchSurface}
+            />
           )}
         </div>
         {action ? (

--- a/apps/web/components/features/profile/LatestReleaseCard.tsx
+++ b/apps/web/components/features/profile/LatestReleaseCard.tsx
@@ -24,6 +24,23 @@ type LatestReleaseCardProps = {
   readonly enableDynamicEngagement?: boolean;
 };
 
+function isValidDate(d: Date | null): d is Date {
+  return d !== null && !Number.isNaN(d.getTime());
+}
+
+function formatReleaseType(type: string): string {
+  if (type === 'ep') return 'EP';
+  return type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+function buildActionLabel(isFuture: boolean): string {
+  return isFuture ? 'Notify me' : 'Listen Now';
+}
+
+function buildActionIcon(isFuture: boolean): 'Bell' | 'Play' {
+  return isFuture ? 'Bell' : 'Play';
+}
+
 export function LatestReleaseCard({
   release,
   artistHandle,
@@ -37,24 +54,18 @@ export function LatestReleaseCard({
   const releaseDate = release.releaseDate
     ? new Date(release.releaseDate)
     : null;
-  // Re-evaluate at the release boundary so an ISR-cached page transitions
-  // from "Drops in"/"Notify me" to "Out Now"/"Listen Now" the moment the
-  // release drops.
   const now = useReleaseAwareNow(releaseDate);
-  const releaseYear =
-    releaseDate && !Number.isNaN(releaseDate.getTime())
-      ? releaseDate.getUTCFullYear()
-      : null;
-  const isFutureRelease =
-    releaseDate !== null &&
-    !Number.isNaN(releaseDate.getTime()) &&
-    releaseDate.getTime() > now.getTime();
-  const releaseTypeLabel =
-    release.releaseType === 'ep'
-      ? 'EP'
-      : release.releaseType.charAt(0).toUpperCase() +
-        release.releaseType.slice(1);
+  const validDate = isValidDate(releaseDate);
+  const releaseYear = validDate ? releaseDate.getUTCFullYear() : null;
+  const isFutureRelease = validDate && releaseDate.getTime() > now.getTime();
+  const releaseTypeLabel = formatReleaseType(release.releaseType);
   const showDrawer = isMobile && artist && dsps && dsps.length > 0;
+  const label = buildActionLabel(isFutureRelease);
+  const icon = buildActionIcon(isFutureRelease);
+
+  const action = showDrawer
+    ? { label, onClick: () => setDrawerOpen(true), icon }
+    : { label, href: `/${artistHandle}/${release.slug}`, icon };
 
   return (
     <>
@@ -73,19 +84,7 @@ export function LatestReleaseCard({
             : null
         }
         status={isFutureRelease ? null : { label: 'Out Now', tone: 'green' }}
-        action={
-          showDrawer
-            ? {
-                label: isFutureRelease ? 'Notify me' : 'Listen Now',
-                onClick: () => setDrawerOpen(true),
-                icon: isFutureRelease ? 'Bell' : 'Play',
-              }
-            : {
-                label: isFutureRelease ? 'Notify me' : 'Listen Now',
-                href: `/${artistHandle}/${release.slug}`,
-                icon: isFutureRelease ? 'Bell' : 'Play',
-              }
-        }
+        action={action}
         dataTestId='latest-release-card'
       />
       {showDrawer ? (

--- a/apps/web/components/site/MarketingFooter.tsx
+++ b/apps/web/components/site/MarketingFooter.tsx
@@ -47,6 +47,24 @@ interface MarketingFooterProps {
   readonly showCta?: boolean;
 }
 
+type ResolvedVariant = 'expanded' | 'minimal';
+
+function resolveFooterVariant(
+  variant: 'auto' | 'expanded' | 'minimal',
+  pathname: string | null
+): ResolvedVariant {
+  const isMinimalPath = pathname ? MINIMAL_FOOTER_PATHS.has(pathname) : false;
+  const autoVariant: ResolvedVariant =
+    FEATURE_FLAGS.SHOW_MARKETING_FULL_FOOTER && !isMinimalPath
+      ? 'expanded'
+      : 'minimal';
+  const requested = variant === 'auto' ? autoVariant : variant;
+  if (requested === 'expanded' && !FEATURE_FLAGS.SHOW_MARKETING_FULL_FOOTER) {
+    return 'minimal';
+  }
+  return requested;
+}
+
 const markLinkClassName =
   '-m-1.5 inline-flex rounded-full p-1.5 text-white/[0.92] transition-opacity duration-subtle hover:opacity-75 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/25 focus-visible:ring-offset-2 focus-visible:ring-offset-black';
 const footerLinkClassName =
@@ -74,16 +92,7 @@ export function MarketingFooter({
   showCta = true,
 }: Readonly<MarketingFooterProps>) {
   const pathname = usePathname();
-  const isMinimalPath = pathname && MINIMAL_FOOTER_PATHS.has(pathname);
-  const autoVariant =
-    FEATURE_FLAGS.SHOW_MARKETING_FULL_FOOTER && !isMinimalPath
-      ? 'expanded'
-      : 'minimal';
-  const requestedVariant = variant === 'auto' ? autoVariant : variant;
-  const resolvedVariant =
-    requestedVariant === 'expanded' && !FEATURE_FLAGS.SHOW_MARKETING_FULL_FOOTER
-      ? 'minimal'
-      : requestedVariant;
+  const resolvedVariant = resolveFooterVariant(variant, pathname);
   const isMinimal = resolvedVariant === 'minimal';
   const pageOwnsFinalCta =
     typeof pathname === 'string' && PAGE_OWNS_FINAL_CTA_PATHS.has(pathname);

--- a/apps/web/lib/turnstile/verify.ts
+++ b/apps/web/lib/turnstile/verify.ts
@@ -40,6 +40,60 @@ function getSecretKey(): string | null {
   return key;
 }
 
+type AttemptOutcome =
+  | { readonly kind: 'done'; readonly result: TurnstileVerifyResult }
+  | { readonly kind: 'retry'; readonly reason: string };
+
+async function attemptVerify(
+  body: URLSearchParams,
+  isLastAttempt: boolean
+): Promise<AttemptOutcome> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
+  try {
+    const response = await fetch(VERIFY_URL, {
+      method: 'POST',
+      body,
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const reason = `siteverify_http_${response.status}`;
+      if (response.status >= 500 && !isLastAttempt) {
+        return { kind: 'retry', reason };
+      }
+      return { kind: 'done', result: { success: false, reason } };
+    }
+
+    const data = (await response.json()) as SiteverifyResponse;
+    if (data.success) {
+      return { kind: 'done', result: { success: true } };
+    }
+    return {
+      kind: 'done',
+      result: {
+        success: false,
+        errorCodes: data['error-codes'] ?? [],
+        reason: 'siteverify_failed',
+      },
+    };
+  } catch (error) {
+    const isAbort = (error as { name?: string } | null)?.name === 'AbortError';
+    const reason = isAbort ? 'siteverify_timeout' : 'siteverify_error';
+    if (!isLastAttempt) {
+      return { kind: 'retry', reason };
+    }
+    if (!isAbort) {
+      await captureError('Turnstile siteverify request failed', error, {
+        context: 'turnstile_verify',
+      });
+    }
+    return { kind: 'done', result: { success: false, reason } };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 /**
  * Verify a Turnstile token against Cloudflare's siteverify endpoint.
  *
@@ -57,8 +111,6 @@ export async function verifyTurnstileToken(
 
   const secretKey = getSecretKey();
   if (!secretKey) {
-    // No secret configured → treat as fail-closed so we don't silently allow
-    // traffic past the gate in dev/staging environments missing the key.
     return { success: false, reason: 'turnstile_not_configured' };
   }
 
@@ -69,65 +121,17 @@ export async function verifyTurnstileToken(
     body.set('remoteip', remoteIp);
   }
 
-  // One bounded retry on transient failures (network errors, 5xx). Token
-  // can be re-submitted to siteverify within its short validity window;
-  // Cloudflare explicitly supports this for the same token.
   let lastTransientReason: string | null = null;
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), VERIFY_TIMEOUT_MS);
-    try {
-      const response = await fetch(VERIFY_URL, {
-        method: 'POST',
-        body,
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        // 5xx is transient and worth retrying; 4xx is not.
-        if (response.status >= 500 && attempt < MAX_ATTEMPTS - 1) {
-          lastTransientReason = `siteverify_http_${response.status}`;
-          await sleep(RETRY_BACKOFF_MS);
-          continue;
-        }
-        return {
-          success: false,
-          reason: `siteverify_http_${response.status}`,
-        };
-      }
-
-      const data = (await response.json()) as SiteverifyResponse;
-      if (data.success) {
-        return { success: true };
-      }
-      // siteverify returned 200 but success=false — definitive failure, do not retry
-      return {
-        success: false,
-        errorCodes: data['error-codes'] ?? [],
-        reason: 'siteverify_failed',
-      };
-    } catch (error) {
-      const isAbort =
-        (error as { name?: string } | null)?.name === 'AbortError';
-      const reason = isAbort ? 'siteverify_timeout' : 'siteverify_error';
-      // Retry on timeout and network errors
-      if (attempt < MAX_ATTEMPTS - 1) {
-        lastTransientReason = reason;
-        await sleep(RETRY_BACKOFF_MS);
-        continue;
-      }
-      if (!isAbort) {
-        await captureError('Turnstile siteverify request failed', error, {
-          context: 'turnstile_verify',
-        });
-      }
-      return { success: false, reason };
-    } finally {
-      clearTimeout(timeoutId);
+    const isLastAttempt = attempt === MAX_ATTEMPTS - 1;
+    const outcome = await attemptVerify(body, isLastAttempt);
+    if (outcome.kind === 'done') {
+      return outcome.result;
     }
+    lastTransientReason = outcome.reason;
+    await sleep(RETRY_BACKOFF_MS);
   }
 
-  // Unreachable in practice (loop returns on every path), but tsc requires a return
   return {
     success: false,
     reason: lastTransientReason ?? 'siteverify_exhausted_retries',


### PR DESCRIPTION
## Summary
Reduces Cognitive Complexity (SonarCloud rule S3776) in 4 production files by extracting helper functions and sub-components:

- **`lib/turnstile/verify.ts`**: Extract `attemptVerify()` from retry loop (CC 23 → ~12)
- **`components/features/profile/LatestReleaseCard.tsx`**: Extract `isValidDate`, `formatReleaseType`, action builders (CC 21 → ~12)
- **`components/features/dashboard/organisms/DashboardHeader.tsx`**: Extract `MobileHeader` + `BreadcrumbTrail` sub-components (CC 18 → ~8)
- **`components/site/MarketingFooter.tsx`**: Extract `resolveFooterVariant()` helper (CC 18 → ~10)

## SonarCloud Rules Addressed
- **S3776** (Cognitive Complexity): 4 CRITICAL issues resolved

## Test plan
- [x] TypeScript compiles (zero errors)
- [x] Biome lint passes on all changed files
- [x] No behavior changes — pure refactoring to reduce cognitive complexity
- [ ] CI verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal component structure in dashboard header for better code organization.
  * Simplified profile release card logic through centralized validation and formatting.
  * Enhanced marketing footer variant resolution for cleaner logic flow.
  * Optimized Turnstile token verification with improved retry handling and timeout management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8660)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->