### PR TITLE
fix(tasks): address kanban board review findings

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
@@ -339,6 +339,10 @@ function assertMoveTaskInput(
     throw new Error('Invalid task status');
   }
 
+  if (input.beforeTaskId && input.afterTaskId) {
+    throw new Error('Provide only one task order anchor');
+  }
+
   const adjacentIds = [input.beforeTaskId, input.afterTaskId].filter(Boolean);
   if (adjacentIds.includes(input.taskId)) {
     throw new Error('Task cannot be moved next to itself');
@@ -758,6 +762,33 @@ export async function moveTask(
     return { success: true };
   }
 
+  const originalUpdatedAtByTaskId = new Map(
+    affectedRows.map(row => [row.id, row.updatedAt] as const)
+  );
+  const updatePreconditions: SQL<unknown>[] = [];
+
+  for (const update of updates) {
+    const originalUpdatedAt = originalUpdatedAtByTaskId.get(update.id);
+    const precondition =
+      originalUpdatedAt &&
+      and(eq(tasks.id, update.id), eq(tasks.updatedAt, originalUpdatedAt));
+
+    if (!precondition) {
+      throw new Error('Task order changed. Reload and try again.');
+    }
+
+    updatePreconditions.push(precondition);
+  }
+
+  const guardedUpdateCondition =
+    updatePreconditions.length === 1
+      ? updatePreconditions[0]
+      : or(...updatePreconditions);
+
+  if (!guardedUpdateCondition) {
+    throw new Error('Task order changed. Reload and try again.');
+  }
+
   const statusCase = drizzleSql<typeof tasks.status>`case ${drizzleSql.join(
     updates.map(
       update =>
@@ -792,10 +823,7 @@ export async function moveTask(
       and(
         eq(tasks.creatorProfileId, profileId),
         isNull(tasks.deletedAt),
-        inArray(
-          tasks.id,
-          updates.map(update => update.id)
-        )
+        guardedUpdateCondition
       )
     )
     .returning({ id: tasks.id });

--- a/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
@@ -101,6 +101,30 @@ function findTaskStatus(
   );
 }
 
+function resolveDropInsertIndex({
+  overTaskIndex,
+  destinationLength,
+  isSameColumn,
+  sourceIndex,
+  overIndex,
+}: Readonly<{
+  overTaskIndex: number;
+  destinationLength: number;
+  isSameColumn: boolean;
+  sourceIndex: number;
+  overIndex: number;
+}>): number {
+  if (overTaskIndex === -1) {
+    return destinationLength;
+  }
+
+  if (isSameColumn && sourceIndex < overIndex) {
+    return overTaskIndex + 1;
+  }
+
+  return overTaskIndex;
+}
+
 function resolveTaskBoardMoveInput({
   activeTaskId,
   overId,
@@ -141,12 +165,13 @@ function resolveTaskBoardMoveInput({
     sourceColumn?.tasks.findIndex(task => task.id === activeTaskId) ?? -1;
   const overIndex =
     destinationColumn.tasks.findIndex(task => task.id === overId) ?? -1;
-  const insertIndex =
-    overTaskIndex === -1
-      ? destinationTasksWithoutActive.length
-      : activeTask.status === overColumnStatus && sourceIndex < overIndex
-        ? overTaskIndex + 1
-        : overTaskIndex;
+  const insertIndex = resolveDropInsertIndex({
+    overTaskIndex,
+    destinationLength: destinationTasksWithoutActive.length,
+    isSameColumn: activeTask.status === overColumnStatus,
+    sourceIndex,
+    overIndex,
+  });
   const beforeTaskId = destinationTasksWithoutActive[insertIndex]?.id ?? null;
   const afterTaskId =
     destinationTasksWithoutActive[insertIndex - 1]?.id ?? null;
@@ -282,7 +307,6 @@ export function TaskBoard({
             artistName={artistName}
             selected={false}
             draggingOverlay
-            onOpenTask={onOpenTask}
           />
         ) : null}
       </DragOverlay>
@@ -414,19 +438,25 @@ function SortableTaskBoardCard({
         transform: CSS.Transform.toString(transform),
         transition,
       }}
-      {...attributes}
-      {...listeners}
       className={cn(
         'group/task-board-card-shell relative',
         isDragging && 'opacity-45'
       )}
     >
-      <TaskBoardCard
-        task={task}
-        artistName={artistName}
-        selected={selected}
-        onOpenTask={onOpenTask}
-      />
+      <button
+        type='button'
+        {...attributes}
+        {...listeners}
+        data-testid={`task-board-card-${task.id}`}
+        onClick={() => onOpenTask(task)}
+        className='block w-full text-left focus-visible:outline-none'
+      >
+        <TaskBoardCard
+          task={task}
+          artistName={artistName}
+          selected={selected}
+        />
+      </button>
       <div className='absolute right-2 top-2'>
         <TableActionMenu
           items={convertContextMenuItems(getTaskContextMenuItems(task))}
@@ -452,13 +482,11 @@ function TaskBoardCard({
   artistName,
   selected,
   draggingOverlay = false,
-  onOpenTask,
 }: Readonly<{
   task: TaskView;
   artistName?: string | null;
   selected: boolean;
   draggingOverlay?: boolean;
-  onOpenTask: (task: TaskView) => void;
 }>) {
   const stage = getTaskStageVisual(task.status, task.agentStatus);
   const stageAccent = getAccentCssVars(stage.accent);
@@ -469,10 +497,7 @@ function TaskBoardCard({
   const StageIcon = stage.icon;
 
   return (
-    <button
-      type='button'
-      data-testid={`task-board-card-${task.id}`}
-      onClick={() => onOpenTask(task)}
+    <div
       className={cn(
         'group/task-board-card min-h-[7.25rem] w-full cursor-default rounded-lg border border-[color-mix(in_oklab,var(--linear-app-shell-border)_68%,transparent)] bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_38%,var(--linear-app-content-surface))] px-3 py-2.5 text-left shadow-[0_1px_0_rgba(255,255,255,0.025)] transition-[background-color,border-color,box-shadow,opacity]',
         'hover:border-[color-mix(in_oklab,var(--linear-app-shell-border)_90%,transparent)] hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_42%,var(--linear-app-content-surface))]',
@@ -546,7 +571,7 @@ function TaskBoardCard({
           />
         ) : null}
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -1203,7 +1203,9 @@ export function TasksPageClient() {
   const designV1TasksEnabled = useAppFlag('DESIGN_V1');
   const { selectedProfile } = useDashboardData();
   const { setHeaderActions } = useSetHeaderActions();
-  const isXlUp = useBreakpoint('xl');
+  const isDesktopTaskLayout = useBreakpoint('lg');
+  const [hasResolvedResponsiveLayout, setHasResolvedResponsiveLayout] =
+    useState(false);
   const canShowTaskDocumentAlongsideReleaseSidebar = useMediaQuery(
     '(min-width: 1720px)'
   );
@@ -1237,8 +1239,13 @@ export function TasksPageClient() {
     defaultMode: 'board',
     availableModes: TASK_VIEW_MODES,
   });
-  const isBoardMode = isXlUp && viewMode === 'board';
+  const isBoardMode = isDesktopTaskLayout && viewMode === 'board';
   const profileId = selectedProfile?.id;
+
+  useEffect(() => {
+    setHasResolvedResponsiveLayout(true);
+  }, []);
+
   const createTaskMutation = useCreateTaskMutation();
   const deleteTaskMutation = useDeleteTaskMutation();
   const updateTaskMutation = useUpdateTaskMutation();
@@ -1274,10 +1281,17 @@ export function TasksPageClient() {
       }),
     [showCancelledColumn, statusFilter]
   );
+  const shouldFetchBoard =
+    hasResolvedResponsiveLayout && isBoardMode && Boolean(profileId);
+  const shouldFetchList =
+    hasResolvedResponsiveLayout && !isBoardMode && Boolean(profileId);
 
   const { data, isLoading, isError, refetch } = useTasksQuery(
     profileId,
-    listFilters
+    listFilters,
+    {
+      enabled: shouldFetchList,
+    }
   );
   const {
     data: boardData,
@@ -1285,7 +1299,7 @@ export function TasksPageClient() {
     isError: isBoardError,
     refetch: refetchBoard,
   } = useTaskBoardQuery(profileId, boardFilters, {
-    enabled: Boolean(profileId),
+    enabled: shouldFetchBoard,
   });
 
   const taskSubviewBaseTasks = useMemo(() => {
@@ -1330,7 +1344,7 @@ export function TasksPageClient() {
     () => getMobileScopedTasks(tasks, mobileScope),
     [mobileScope, tasks]
   );
-  const visibleTasks = isXlUp ? tasks : mobileScopedTasks;
+  const visibleTasks = isDesktopTaskLayout ? tasks : mobileScopedTasks;
   const boardTasks = useMemo(
     () => boardData?.columns.flatMap(column => column.tasks) ?? [],
     [boardData?.columns]
@@ -1344,7 +1358,7 @@ export function TasksPageClient() {
   );
   const effectiveSelectedTaskId =
     selectedTaskId ??
-    (isXlUp && !isBoardMode && !designV1TasksEnabled
+    (isDesktopTaskLayout && !isBoardMode && !designV1TasksEnabled
       ? (visibleTasks[0]?.id ?? null)
       : null);
   const { data: selectedTaskData } = useTaskQuery(
@@ -1367,14 +1381,17 @@ export function TasksPageClient() {
     statusFilter !== 'all' ||
     priorityFilter !== 'all' ||
     assigneeFilter !== 'all';
-  const isResolvingProfile = !profileId;
+  const isResolvingProfile = !profileId || !hasResolvedResponsiveLayout;
   const isActiveBoardLoading = isResolvingProfile || isBoardLoading;
   const isActiveListLoading = isResolvingProfile || isLoading;
   const showTaskListPane =
-    isBoardMode || isXlUp || !selectedTask || shouldPrioritizeRightPanel;
+    isBoardMode ||
+    isDesktopTaskLayout ||
+    !selectedTask ||
+    shouldPrioritizeRightPanel;
   const showTaskDocumentPane =
-    !isBoardMode &&
-    (isXlUp || Boolean(selectedTask)) &&
+    ((isBoardMode && isDesktopTaskLayout && Boolean(selectedTask)) ||
+      (!isBoardMode && (isDesktopTaskLayout || Boolean(selectedTask)))) &&
     !shouldPrioritizeRightPanel;
   const clearFilters = useCallback(() => {
     setSearch('');
@@ -1524,6 +1541,10 @@ export function TasksPageClient() {
   }, [canShowTaskDocumentAlongsideReleaseSidebar, selectedReleaseId]);
 
   useEffect(() => {
+    if (isBoardMode) {
+      return;
+    }
+
     if (isLoading) {
       return;
     }
@@ -1535,15 +1556,11 @@ export function TasksPageClient() {
       return;
     }
 
-    if (isBoardMode) {
-      return;
-    }
-
     const hasVisibleSelection = visibleTasks.some(
       task => task.id === selectedTaskId
     );
     if (!hasVisibleSelection) {
-      if (!isXlUp && selectedTaskId === null) {
+      if (!isDesktopTaskLayout && selectedTaskId === null) {
         return;
       }
 
@@ -1555,7 +1572,7 @@ export function TasksPageClient() {
     designV1TasksEnabled,
     isBoardMode,
     isLoading,
-    isXlUp,
+    isDesktopTaskLayout,
     selectedTaskId,
     tasks,
     visibleTasks,
@@ -1724,30 +1741,7 @@ export function TasksPageClient() {
       onClose={() => setSelectedReleaseId(null)}
     />
   ) : null;
-  const boardTaskPanel =
-    isBoardMode && selectedTask ? (
-      <TaskDocumentPanel
-        task={selectedTask}
-        title={editorTitle}
-        description={editorDescription}
-        onTitleChange={setEditorTitle}
-        onDescriptionChange={setEditorDescription}
-        onClose={() => setSelectedTaskId(null)}
-        onOpenRelease={openReleaseSidebar}
-        onUpdateStatus={(taskId, status) => updateTaskField(taskId, { status })}
-        onUpdatePriority={(taskId, priority) =>
-          updateTaskField(taskId, { priority })
-        }
-        onUpdateAssignee={(taskId, assigneeKind) =>
-          updateTaskField(taskId, { assigneeKind })
-        }
-        artistName={artistName}
-        isDesktopLayout={isXlUp}
-        designV1={designV1TasksEnabled}
-      />
-    ) : null;
-
-  useRegisterRightPanel(sidebarPanel ?? boardTaskPanel);
+  useRegisterRightPanel(sidebarPanel);
 
   const headerActions = useMemo(
     () => (
@@ -1867,7 +1861,7 @@ export function TasksPageClient() {
         getTaskContextMenuItems={getTaskContextMenuItems}
       />
     );
-  } else if (isXlUp) {
+  } else if (isDesktopTaskLayout) {
     desktopTaskPane = (
       <UnifiedTable
         data={visibleTasks}
@@ -1955,7 +1949,7 @@ export function TasksPageClient() {
         data-testid='tasks-workspace'
         data-design-v1-tasks={designV1TasksEnabled ? 'true' : undefined}
         toolbar={
-          isXlUp || headerMode !== 'default' ? (
+          isDesktopTaskLayout || headerMode !== 'default' ? (
             <TaskWorkspaceHeaderBar
               mode={headerMode}
               search={search}
@@ -1988,7 +1982,7 @@ export function TasksPageClient() {
               showCancelledColumn={showCancelledColumn}
               onShowCancelledColumnChange={setShowCancelledColumn}
               showTaskNavigation={
-                !isBoardMode && isXlUp && Boolean(selectedTask)
+                !isBoardMode && isDesktopTaskLayout && Boolean(selectedTask)
               }
               canSelectPrevious={canSelectPrevious}
               canSelectNext={canSelectNext}
@@ -2030,11 +2024,11 @@ export function TasksPageClient() {
                 className={cn(
                   'min-h-0 min-w-0',
                   TASK_WORKSPACE_PANE_CLASSNAME,
-                  selectedTask && showTaskDocumentPane
-                    ? 'xl:flex-none xl:basis-[32rem] xl:min-w-[28rem] xl:max-w-[36rem] xl:border-r xl:border-[color-mix(in_oklab,var(--linear-app-shell-border)_74%,transparent)]'
+                  selectedTask && showTaskDocumentPane && !isBoardMode
+                    ? 'lg:flex-none lg:basis-[32rem] lg:min-w-[28rem] lg:max-w-[36rem] lg:border-r lg:border-[color-mix(in_oklab,var(--linear-app-shell-border)_74%,transparent)]'
                     : 'flex-1',
                   showTaskListPane ? 'block' : 'hidden',
-                  !selectedTask && 'xl:max-w-none'
+                  !selectedTask && 'lg:max-w-none'
                 )}
               >
                 {desktopTaskPane ?? (
@@ -2080,7 +2074,10 @@ export function TasksPageClient() {
               </div>
               <div
                 className={cn(
-                  'min-h-0 min-w-0 flex-1 overflow-hidden',
+                  'min-h-0 min-w-0 overflow-hidden',
+                  isBoardMode
+                    ? 'lg:flex-none lg:w-[min(34rem,42vw)] lg:border-l lg:border-[color-mix(in_oklab,var(--linear-app-shell-border)_74%,transparent)]'
+                    : 'flex-1',
                   TASK_WORKSPACE_PANE_CLASSNAME,
                   showTaskDocumentPane ? 'flex' : 'hidden'
                 )}
@@ -2105,7 +2102,7 @@ export function TasksPageClient() {
                       updateTaskField(taskId, { assigneeKind })
                     }
                     artistName={artistName}
-                    isDesktopLayout={isXlUp}
+                    isDesktopLayout={isDesktopTaskLayout}
                     designV1={designV1TasksEnabled}
                   />
                 ) : (
@@ -2121,7 +2118,7 @@ export function TasksPageClient() {
                     onUpdatePriority={NOOP_TASK_PRIORITY_UPDATE}
                     onUpdateAssignee={NOOP_TASK_ASSIGNEE_UPDATE}
                     artistName={artistName}
-                    isDesktopLayout={isXlUp}
+                    isDesktopLayout={isDesktopTaskLayout}
                     designV1={designV1TasksEnabled}
                   />
                 )}

--- a/apps/web/lib/queries/useTaskMutations.ts
+++ b/apps/web/lib/queries/useTaskMutations.ts
@@ -31,6 +31,7 @@ type TaskBoardCacheEntry = readonly [
 ];
 type TaskDetailCacheEntry = readonly [readonly unknown[], TaskView | undefined];
 type TaskStatsCacheEntry = readonly [readonly unknown[], TaskStats | undefined];
+type TaskQueryClient = ReturnType<typeof useQueryClient>;
 
 interface TaskCacheSnapshot {
   readonly previousLists: TaskListCacheEntry[];
@@ -112,7 +113,7 @@ function getCachedTask(
 }
 
 function getTaskCacheSnapshot(
-  queryClient: ReturnType<typeof useQueryClient>,
+  queryClient: TaskQueryClient,
   taskId: string
 ): TaskCacheSnapshot {
   return {
@@ -132,7 +133,7 @@ function getTaskCacheSnapshot(
 }
 
 function restoreTaskCacheSnapshot(
-  queryClient: ReturnType<typeof useQueryClient>,
+  queryClient: TaskQueryClient,
   snapshot: TaskCacheSnapshot
 ) {
   for (const [queryKey, list] of snapshot.previousLists) {
@@ -157,7 +158,7 @@ function restoreTaskCacheSnapshot(
 }
 
 async function invalidateTaskQueries(
-  queryClient: ReturnType<typeof useQueryClient>,
+  queryClient: TaskQueryClient,
   options: Readonly<{ includeStats?: boolean }> = {}
 ) {
   await queryClient.invalidateQueries({ queryKey: queryKeys.tasks.all });
@@ -231,6 +232,77 @@ function updateTaskStatsForDeletion(
         ? previousStatusCount
         : stats.inProgress),
   };
+}
+
+function patchMovedTaskBoards(
+  queryClient: TaskQueryClient,
+  previousBoards: ReadonlyArray<TaskBoardCacheEntry>,
+  input: MoveTaskInput
+) {
+  for (const [queryKey, board] of previousBoards) {
+    queryClient.setQueryData(queryKey, applyTaskBoardMove(board, input));
+  }
+}
+
+function patchMovedTaskLists(
+  queryClient: TaskQueryClient,
+  previousLists: ReadonlyArray<TaskListCacheEntry>,
+  input: MoveTaskInput
+) {
+  for (const [queryKey, list] of previousLists) {
+    queryClient.setQueryData(queryKey, applyTaskListMove(list, input));
+  }
+}
+
+function getOptimisticMoveCompletedAt(
+  detail: TaskView,
+  nextStatus: TaskView['status']
+): Date | null {
+  if (nextStatus === 'done') {
+    return detail.completedAt ?? new Date();
+  }
+
+  return nextStatus !== detail.status ? null : detail.completedAt;
+}
+
+function patchMovedTaskDetails(
+  queryClient: TaskQueryClient,
+  previousDetails: ReadonlyArray<TaskDetailCacheEntry>,
+  input: MoveTaskInput
+) {
+  for (const [queryKey, detail] of previousDetails) {
+    if (!detail) {
+      continue;
+    }
+
+    queryClient.setQueryData(queryKey, {
+      ...detail,
+      status: input.toStatus,
+      completedAt: getOptimisticMoveCompletedAt(detail, input.toStatus),
+    });
+  }
+}
+
+function patchMovedTaskStatsIfNeeded(
+  queryClient: TaskQueryClient,
+  previousStatsEntries: ReadonlyArray<TaskStatsCacheEntry>,
+  previousTask: TaskView | undefined,
+  nextStatus: TaskView['status']
+) {
+  if (!previousTask || previousTask.status === nextStatus) {
+    return;
+  }
+
+  for (const [queryKey, stats] of previousStatsEntries) {
+    if (!stats) {
+      continue;
+    }
+
+    queryClient.setQueryData(
+      queryKey,
+      updateTaskStatsForStatusChange(stats, previousTask.status, nextStatus)
+    );
+  }
 }
 
 export function useCreateTaskMutation() {
@@ -372,47 +444,15 @@ export function useMoveTaskMutation() {
         input.taskId
       );
 
-      for (const [queryKey, board] of snapshot.previousBoards) {
-        queryClient.setQueryData(queryKey, applyTaskBoardMove(board, input));
-      }
-
-      for (const [queryKey, list] of snapshot.previousLists) {
-        queryClient.setQueryData(queryKey, applyTaskListMove(list, input));
-      }
-
-      for (const [queryKey, detail] of snapshot.previousDetails) {
-        if (!detail) {
-          continue;
-        }
-
-        queryClient.setQueryData(queryKey, {
-          ...detail,
-          status: input.toStatus,
-          completedAt:
-            input.toStatus === 'done'
-              ? (detail.completedAt ?? new Date())
-              : input.toStatus !== detail.status
-                ? null
-                : detail.completedAt,
-        });
-      }
-
-      if (previousTask && previousTask.status !== input.toStatus) {
-        for (const [queryKey, stats] of snapshot.previousStatsEntries) {
-          if (!stats) {
-            continue;
-          }
-
-          queryClient.setQueryData(
-            queryKey,
-            updateTaskStatsForStatusChange(
-              stats,
-              previousTask.status,
-              input.toStatus
-            )
-          );
-        }
-      }
+      patchMovedTaskBoards(queryClient, snapshot.previousBoards, input);
+      patchMovedTaskLists(queryClient, snapshot.previousLists, input);
+      patchMovedTaskDetails(queryClient, snapshot.previousDetails, input);
+      patchMovedTaskStatsIfNeeded(
+        queryClient,
+        snapshot.previousStatsEntries,
+        previousTask,
+        input.toStatus
+      );
 
       return snapshot;
     },
@@ -463,6 +503,10 @@ export function useDeleteTaskMutation() {
           continue;
         }
 
+        const removedFromBoard = board.columns.some(column =>
+          column.tasks.some(task => task.id === taskId)
+        );
+
         queryClient.setQueryData(queryKey, {
           ...board,
           columns: board.columns.map(column => {
@@ -475,7 +519,9 @@ export function useDeleteTaskMutation() {
                 : column.totalCount,
             };
           }),
-          totalCount: Math.max(0, board.totalCount - 1),
+          totalCount: removedFromBoard
+            ? Math.max(0, board.totalCount - 1)
+            : board.totalCount,
         });
       }
 

--- a/apps/web/lib/queries/useTasksQuery.ts
+++ b/apps/web/lib/queries/useTasksQuery.ts
@@ -15,7 +15,11 @@ const TASK_STATS_CACHE = {
   gcTime: 5 * 60 * 1000,
 };
 
-export function useTasksQuery(profileId?: string, filters?: TaskFilters) {
+export function useTasksQuery(
+  profileId?: string,
+  filters?: TaskFilters,
+  options?: { readonly enabled?: boolean }
+) {
   const queryFilters = filters ? { ...filters } : undefined;
 
   return useQuery({
@@ -24,7 +28,7 @@ export function useTasksQuery(profileId?: string, filters?: TaskFilters) {
     queryFn: () => getTasks(filters),
     ...STANDARD_CACHE,
     placeholderData: keepPreviousData,
-    enabled: Boolean(profileId),
+    enabled: Boolean(profileId) && (options?.enabled ?? true),
   });
 }
 

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -256,7 +256,7 @@ vi.mock('@/hooks/useBreakpoint', () => ({
       return mockIs2xlUp;
     }
 
-    if (breakpoint === 'xl') {
+    if (breakpoint === 'lg' || breakpoint === 'xl') {
       return mockIsXlUp;
     }
 
@@ -553,11 +553,7 @@ describe('TasksPageClient', () => {
 
     fireEvent.click(screen.getByTestId('mock-board-card-task-2'));
 
-    expect(mockRegisterRightPanel).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        type: expect.any(Function),
-      })
-    );
+    expect(screen.getByLabelText('Task title')).toHaveValue(mockTaskTwo.title);
   });
 
   it('submits board moves through the move mutation', () => {


### PR DESCRIPTION
JOV-2204

## Summary
- Harden task board moves with single-anchor validation plus stale-position guards around the status/position update.
- Fix board card semantics so the action menu is isolated from card selection and the card remains keyboard/pointer draggable.
- Stabilize board/list query gating and render board details inside the task workspace pane.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check apps/web/app/app/'(shell)'/dashboard/tasks/task-actions.ts apps/web/components/features/dashboard/tasks/TaskBoard.tsx apps/web/components/features/dashboard/tasks/TasksPageClient.tsx apps/web/lib/queries/useTaskMutations.ts apps/web/lib/queries/useTasksQuery.ts apps/web/tests/unit/dashboard/TasksPageClient.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run lib/tasks/task-board.test.ts tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx tests/unit/dashboard/TasksPageClient.test.tsx`
- `doppler run --project jovie-web --config dev -- env JOVIE_AGENT_PROFILE=coder E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready pnpm --filter @jovie/web exec playwright test tests/e2e/tasks-layout.spec.ts --project=chromium`
- `/qa --ecxhaustive`: board default, display menu/list fallback, card menu isolation, card click detail, mobile fallback, drag across columns, reload persistence.
- `/design-review`: fixed board workspace height and rechecked desktop/mobile screenshots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task move validation now rejects requests with conflicting parameters.
  * Added concurrency guards to prevent race conditions during task updates.
  * Adjusted responsive layout breakpoint for improved desktop experience.

* **Improvements**
  * Enhanced drag-and-drop interaction for moving tasks between columns.
  * Improved task query flexibility with conditional enable/disable option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8686)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->