### PR TITLE
fix(tasks): persist rapid kanban item edits

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
@@ -21,6 +21,7 @@ import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { tasks } from '@/lib/db/schema/tasks';
 import { requireTasksWorkspaceAccess } from '@/lib/entitlements/tasks-gate';
 import { isTaskStatus, TASK_BOARD_STATUSES } from '@/lib/tasks/task-board';
+import { buildTaskUpdateFieldPatch } from '@/lib/tasks/task-update';
 import type {
   CreateTaskInput,
   MoveTaskInput,
@@ -608,75 +609,6 @@ export async function createTask(data: CreateTaskInput): Promise<TaskView> {
   return createTaskForProfile(profileId, data);
 }
 
-function resolveCompletedAt(
-  data: UpdateTaskInput,
-  existingTask: typeof tasks.$inferSelect,
-  nextStatus: string
-): Date | null | undefined {
-  if (data.completedAt !== undefined) return data.completedAt;
-  if (data.status === undefined) return existingTask.completedAt;
-  return nextStatus === 'done'
-    ? (existingTask.completedAt ?? new Date())
-    : null;
-}
-
-function mergeTaskFields(
-  data: UpdateTaskInput,
-  existingTask: typeof tasks.$inferSelect,
-  completedAt: Date | null | undefined,
-  nextStatus: typeof tasks.$inferSelect.status
-) {
-  return {
-    title: data.title ?? existingTask.title,
-    description:
-      data.description === undefined
-        ? existingTask.description
-        : data.description,
-    status: nextStatus,
-    priority: data.priority ?? existingTask.priority,
-    assigneeKind: data.assigneeKind ?? existingTask.assigneeKind,
-    assigneeUserId:
-      data.assigneeUserId === undefined
-        ? existingTask.assigneeUserId
-        : data.assigneeUserId,
-    agentType:
-      data.agentType === undefined ? existingTask.agentType : data.agentType,
-    agentStatus: data.agentStatus ?? existingTask.agentStatus,
-    agentInput:
-      data.agentInput === undefined ? existingTask.agentInput : data.agentInput,
-    agentOutput:
-      data.agentOutput === undefined
-        ? existingTask.agentOutput
-        : data.agentOutput,
-    agentError:
-      data.agentError === undefined ? existingTask.agentError : data.agentError,
-    releaseId:
-      data.releaseId === undefined ? existingTask.releaseId : data.releaseId,
-    parentTaskId:
-      data.parentTaskId === undefined
-        ? existingTask.parentTaskId
-        : data.parentTaskId,
-    category:
-      data.category === undefined ? existingTask.category : data.category,
-    dueAt: data.dueAt === undefined ? existingTask.dueAt : data.dueAt,
-    scheduledFor:
-      data.scheduledFor === undefined
-        ? existingTask.scheduledFor
-        : data.scheduledFor,
-    startedAt:
-      data.startedAt === undefined ? existingTask.startedAt : data.startedAt,
-    completedAt,
-    position: data.position ?? existingTask.position,
-    sourceTemplateId:
-      data.sourceTemplateId === undefined
-        ? existingTask.sourceTemplateId
-        : data.sourceTemplateId,
-    metadata:
-      data.metadata === undefined ? existingTask.metadata : data.metadata,
-    updatedAt: new Date(),
-  };
-}
-
 export async function updateTask(
   taskId: string,
   data: UpdateTaskInput
@@ -687,13 +619,16 @@ export async function updateTask(
 
   await assertReleaseAccess(profileId, data.releaseId);
 
-  const nextStatus = data.status ?? existingTask.status;
-  const completedAt = resolveCompletedAt(data, existingTask, nextStatus);
-
   const [updated] = await db
     .update(tasks)
-    .set(mergeTaskFields(data, existingTask, completedAt, nextStatus))
-    .where(eq(tasks.id, taskId))
+    .set(buildTaskUpdateFieldPatch(data, existingTask))
+    .where(
+      and(
+        eq(tasks.id, taskId),
+        eq(tasks.creatorProfileId, profileId),
+        isNull(tasks.deletedAt)
+      )
+    )
     .returning();
 
   revalidatePath(APP_ROUTES.TASKS);

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -1251,7 +1251,7 @@ export function TasksPageClient() {
   const updateTaskMutation = useUpdateTaskMutation();
   const moveTaskMutation = useMoveTaskMutation();
   const { mutateAsync: deleteTaskAsync } = deleteTaskMutation;
-  const { mutate: updateTask, isPending: isUpdatingTask } = updateTaskMutation;
+  const { mutate: updateTask } = updateTaskMutation;
   const { mutate: moveTask } = moveTaskMutation;
   const { data: releases = [] } = useReleasesQuery(profileId ?? '');
   const searchFilter = deferredSearch.trim();
@@ -1479,17 +1479,24 @@ export function TasksPageClient() {
     ],
     [artistName, assigneeFilter, priorityFilter, statusFilter]
   );
+  const selectedTaskEditorId = selectedTask?.id ?? null;
+  const selectedTaskEditorTitle = selectedTask?.title ?? '';
+  const selectedTaskEditorDescription = selectedTask?.description ?? '';
 
   useEffect(() => {
-    if (!selectedTask) {
+    if (!selectedTaskEditorId) {
       setEditorTitle('');
       setEditorDescription('');
       return;
     }
 
-    setEditorTitle(selectedTask.title);
-    setEditorDescription(selectedTask.description ?? '');
-  }, [selectedTask]);
+    setEditorTitle(selectedTaskEditorTitle);
+    setEditorDescription(selectedTaskEditorDescription);
+  }, [
+    selectedTaskEditorDescription,
+    selectedTaskEditorId,
+    selectedTaskEditorTitle,
+  ]);
 
   const openReleaseSidebar = useCallback((task: TaskView) => {
     if (task.releaseId) {
@@ -1607,26 +1614,26 @@ export function TasksPageClient() {
   }, [canSelectNext, selectTaskByIndex, selectedTaskIndex]);
 
   useEffect(() => {
-    latestSelectedTaskIdRef.current = selectedTask?.id ?? null;
-  }, [selectedTask]);
+    latestSelectedTaskIdRef.current = selectedTaskEditorId;
+  }, [selectedTaskEditorId]);
 
   useEffect(() => {
-    if (!selectedTask || isUpdatingTask) {
+    if (!selectedTaskEditorId) {
       return;
     }
 
     const nextTitle = editorTitle.trim();
     const nextDescription = editorDescription.trim();
-    const currentDescription = selectedTask.description ?? '';
+    const currentDescription = selectedTaskEditorDescription;
     const hasChanges =
-      nextTitle !== selectedTask.title ||
+      nextTitle !== selectedTaskEditorTitle ||
       nextDescription !== currentDescription;
 
     if (!hasChanges || !nextTitle) {
       return;
     }
 
-    const selectedTaskIdAtSchedule = selectedTask.id;
+    const selectedTaskIdAtSchedule = selectedTaskEditorId;
 
     const timeoutId = globalThis.setTimeout(() => {
       if (selectedTaskIdAtSchedule !== latestSelectedTaskIdRef.current) {
@@ -1655,8 +1662,9 @@ export function TasksPageClient() {
   }, [
     editorDescription,
     editorTitle,
-    isUpdatingTask,
-    selectedTask,
+    selectedTaskEditorDescription,
+    selectedTaskEditorId,
+    selectedTaskEditorTitle,
     updateTask,
   ]);
 

--- a/apps/web/lib/queries/useTaskMutations.ts
+++ b/apps/web/lib/queries/useTaskMutations.ts
@@ -8,7 +8,11 @@ import {
   moveTask,
   updateTask,
 } from '@/app/app/(shell)/dashboard/tasks/task-actions';
-import { applyTaskBoardMove, applyTaskListMove } from '@/lib/tasks/task-board';
+import {
+  applyTaskBoardMove,
+  applyTaskListMove,
+  compareTasksByBoardOrder,
+} from '@/lib/tasks/task-board';
 import type {
   CreateTaskInput,
   MoveTaskInput,
@@ -47,17 +51,20 @@ function toTaskStatsStatusKey(status: TaskView['status']): TaskStatsStatusKey {
 function updateTaskInList(
   list: TaskListResult | undefined,
   taskId: string,
-  patch: Partial<TaskView>
+  patch: Partial<TaskView>,
+  options: Readonly<{ sort?: boolean }> = {}
 ): TaskListResult | undefined {
   if (!list) {
     return list;
   }
 
+  const tasks = list.tasks.map(task =>
+    task.id === taskId ? { ...task, ...patch } : task
+  );
+
   return {
     ...list,
-    tasks: list.tasks.map(task =>
-      task.id === taskId ? { ...task, ...patch } : task
-    ),
+    tasks: options.sort ? tasks.sort(compareTasksByBoardOrder) : tasks,
   };
 }
 
@@ -337,30 +344,37 @@ export function useUpdateTaskMutation() {
         snapshot.previousDetails,
         taskId
       );
-      const optimisticCompletedAt = getOptimisticCompletedAt(
-        previousTask,
-        data.status
-      );
+      const optimisticCompletedAt =
+        data.completedAt === undefined
+          ? getOptimisticCompletedAt(previousTask, data.status)
+          : data.completedAt;
+      const optimisticPatch: Partial<TaskView> = {
+        ...data,
+        ...(optimisticCompletedAt === undefined
+          ? {}
+          : { completedAt: optimisticCompletedAt }),
+      };
 
       for (const [queryKey, list] of snapshot.previousLists) {
         queryClient.setQueryData(
           queryKey,
-          updateTaskInList(list, taskId, {
-            ...data,
-            completedAt: optimisticCompletedAt,
+          updateTaskInList(list, taskId, optimisticPatch, {
+            sort: data.status !== undefined,
           })
         );
       }
 
       for (const [queryKey, board] of snapshot.previousBoards) {
+        const boardWithStatusUpdate = data.status
+          ? applyTaskBoardMove(board, {
+              taskId,
+              toStatus: data.status,
+            })
+          : board;
+
         queryClient.setQueryData(
           queryKey,
-          data.status
-            ? applyTaskBoardMove(board, {
-                taskId,
-                toStatus: data.status,
-              })
-            : updateTaskInBoard(board, taskId, data)
+          updateTaskInBoard(boardWithStatusUpdate, taskId, optimisticPatch)
         );
       }
 
@@ -371,11 +385,7 @@ export function useUpdateTaskMutation() {
 
         queryClient.setQueryData(queryKey, {
           ...detail,
-          ...data,
-          completedAt:
-            data.status === undefined
-              ? detail.completedAt
-              : optimisticCompletedAt,
+          ...optimisticPatch,
         });
       }
 

--- a/apps/web/lib/tasks/task-update.test.ts
+++ b/apps/web/lib/tasks/task-update.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { buildTaskUpdateFieldPatch } from './task-update';
+import type { TaskView } from './types';
+
+function createExistingTask(
+  overrides: Partial<Pick<TaskView, 'completedAt' | 'status'>> = {}
+): Pick<TaskView, 'completedAt' | 'status'> {
+  return {
+    status: overrides.status ?? 'todo',
+    completedAt: overrides.completedAt ?? null,
+  };
+}
+
+describe('buildTaskUpdateFieldPatch', () => {
+  const now = new Date('2026-05-15T12:00:00.000Z');
+
+  it('only writes submitted scalar fields so stale saves cannot clobber metadata', () => {
+    expect(
+      buildTaskUpdateFieldPatch(
+        { priority: 'urgent' },
+        createExistingTask({
+          status: 'backlog',
+          completedAt: new Date('2026-05-01T00:00:00.000Z'),
+        }),
+        now
+      )
+    ).toEqual({
+      priority: 'urgent',
+      updatedAt: now,
+    });
+  });
+
+  it('preserves explicit nulls while omitting unrelated fields', () => {
+    expect(
+      buildTaskUpdateFieldPatch(
+        { description: null, assigneeKind: 'jovie' },
+        createExistingTask(),
+        now
+      )
+    ).toEqual({
+      description: null,
+      assigneeKind: 'jovie',
+      updatedAt: now,
+    });
+  });
+
+  it('sets completedAt when a task first moves to done', () => {
+    expect(
+      buildTaskUpdateFieldPatch({ status: 'done' }, createExistingTask(), now)
+    ).toEqual({
+      status: 'done',
+      completedAt: now,
+      updatedAt: now,
+    });
+  });
+
+  it('keeps an existing completion timestamp when done is reselected', () => {
+    const completedAt = new Date('2026-05-14T08:30:00.000Z');
+
+    expect(
+      buildTaskUpdateFieldPatch(
+        { status: 'done' },
+        createExistingTask({ status: 'done', completedAt }),
+        now
+      )
+    ).toEqual({
+      status: 'done',
+      completedAt,
+      updatedAt: now,
+    });
+  });
+
+  it('clears completedAt when a closed task is reopened', () => {
+    expect(
+      buildTaskUpdateFieldPatch(
+        { status: 'in_progress' },
+        createExistingTask({
+          status: 'done',
+          completedAt: new Date('2026-05-14T08:30:00.000Z'),
+        }),
+        now
+      )
+    ).toEqual({
+      status: 'in_progress',
+      completedAt: null,
+      updatedAt: now,
+    });
+  });
+});

--- a/apps/web/lib/tasks/task-update.ts
+++ b/apps/web/lib/tasks/task-update.ts
@@ -1,0 +1,81 @@
+import type { TaskStatus, TaskView, UpdateTaskInput } from './types';
+
+export interface TaskUpdateFieldPatch {
+  readonly title?: string;
+  readonly description?: string | null;
+  readonly status?: TaskStatus;
+  readonly priority?: TaskView['priority'];
+  readonly assigneeKind?: TaskView['assigneeKind'];
+  readonly assigneeUserId?: string | null;
+  readonly agentType?: string | null;
+  readonly agentStatus?: TaskView['agentStatus'];
+  readonly agentInput?: Record<string, unknown> | null;
+  readonly agentOutput?: Record<string, unknown> | null;
+  readonly agentError?: string | null;
+  readonly releaseId?: string | null;
+  readonly parentTaskId?: string | null;
+  readonly category?: string | null;
+  readonly dueAt?: Date | null;
+  readonly scheduledFor?: Date | null;
+  readonly startedAt?: Date | null;
+  readonly completedAt?: Date | null;
+  readonly position?: number;
+  readonly sourceTemplateId?: string | null;
+  readonly metadata?: Record<string, unknown> | null;
+  readonly updatedAt: Date;
+}
+
+type MutableTaskUpdateFieldPatch = {
+  -readonly [Key in keyof TaskUpdateFieldPatch]: TaskUpdateFieldPatch[Key];
+};
+
+function resolvePatchCompletedAt(
+  data: UpdateTaskInput,
+  existingTask: Pick<TaskView, 'completedAt' | 'status'>,
+  now: Date
+): Date | null | undefined {
+  if (data.completedAt !== undefined) return data.completedAt;
+  if (data.status === undefined) return undefined;
+  return data.status === 'done' ? (existingTask.completedAt ?? now) : null;
+}
+
+export function buildTaskUpdateFieldPatch(
+  data: UpdateTaskInput,
+  existingTask: Pick<TaskView, 'completedAt' | 'status'>,
+  now = new Date()
+): TaskUpdateFieldPatch {
+  const patch: Partial<MutableTaskUpdateFieldPatch> = {
+    updatedAt: now,
+  };
+
+  if (data.title !== undefined) patch.title = data.title;
+  if (data.description !== undefined) patch.description = data.description;
+  if (data.status !== undefined) patch.status = data.status;
+  if (data.priority !== undefined) patch.priority = data.priority;
+  if (data.assigneeKind !== undefined) patch.assigneeKind = data.assigneeKind;
+  if (data.assigneeUserId !== undefined) {
+    patch.assigneeUserId = data.assigneeUserId;
+  }
+  if (data.agentType !== undefined) patch.agentType = data.agentType;
+  if (data.agentStatus !== undefined) patch.agentStatus = data.agentStatus;
+  if (data.agentInput !== undefined) patch.agentInput = data.agentInput;
+  if (data.agentOutput !== undefined) patch.agentOutput = data.agentOutput;
+  if (data.agentError !== undefined) patch.agentError = data.agentError;
+  if (data.releaseId !== undefined) patch.releaseId = data.releaseId;
+  if (data.parentTaskId !== undefined) patch.parentTaskId = data.parentTaskId;
+  if (data.category !== undefined) patch.category = data.category;
+  if (data.dueAt !== undefined) patch.dueAt = data.dueAt;
+  if (data.scheduledFor !== undefined) patch.scheduledFor = data.scheduledFor;
+  if (data.startedAt !== undefined) patch.startedAt = data.startedAt;
+
+  const completedAt = resolvePatchCompletedAt(data, existingTask, now);
+  if (completedAt !== undefined) patch.completedAt = completedAt;
+
+  if (data.position !== undefined) patch.position = data.position;
+  if (data.sourceTemplateId !== undefined) {
+    patch.sourceTemplateId = data.sourceTemplateId;
+  }
+  if (data.metadata !== undefined) patch.metadata = data.metadata;
+
+  return patch as TaskUpdateFieldPatch;
+}

--- a/apps/web/tests/e2e/tasks-layout.spec.ts
+++ b/apps/web/tests/e2e/tasks-layout.spec.ts
@@ -1,10 +1,15 @@
 import { neon } from '@neondatabase/serverless';
 import { expect, type Page, type TestInfo, test } from '@playwright/test';
-import { and, asc, desc, eq, isNull } from 'drizzle-orm';
+import { and, asc, desc, eq, isNull, or } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/neon-http';
 import { APP_ROUTES } from '@/constants/routes';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { tasks } from '@/lib/db/schema/tasks';
+import type {
+  TaskAssigneeKind,
+  TaskPriority,
+  TaskStatus,
+} from '@/lib/tasks/types';
 import { ensureSignedInUser, hasClerkCredentials } from '../helpers/clerk-auth';
 
 const LAYOUT_TASK_TITLE = 'Layout QA task fixture';
@@ -21,6 +26,17 @@ const VIEWPORTS = [
   { name: 'desktop-1280', width: 1280, height: 900 },
   { name: 'desktop-1440', width: 1440, height: 960 },
 ] as const;
+interface LayoutTaskFixture {
+  readonly id: string;
+  readonly title: string;
+}
+
+interface SeededTaskState {
+  readonly title: string;
+  readonly status: TaskStatus;
+  readonly priority: TaskPriority;
+  readonly assigneeKind: TaskAssigneeKind;
+}
 
 function resolveLayoutProfileUsername(): string {
   const persona = process.env.E2E_TEST_AUTH_PERSONA?.trim();
@@ -47,7 +63,7 @@ async function stubPassiveTracking(page: Page): Promise<void> {
   );
 }
 
-async function ensureTaskExists(): Promise<string> {
+async function ensureTaskExists(): Promise<LayoutTaskFixture> {
   const databaseUrl = process.env.DATABASE_URL?.trim();
   if (!databaseUrl) {
     throw new Error('DATABASE_URL is required for tasks layout seeding.');
@@ -73,7 +89,10 @@ async function ensureTaskExists(): Promise<string> {
     .where(
       and(
         eq(tasks.creatorProfileId, profile.id),
-        eq(tasks.title, LAYOUT_TASK_TITLE),
+        or(
+          eq(tasks.title, LAYOUT_TASK_TITLE),
+          eq(tasks.description, 'Used by the Playwright tasks layout spec.')
+        ),
         isNull(tasks.deletedAt)
       )
     )
@@ -95,22 +114,33 @@ async function ensureTaskExists(): Promise<string> {
       .orderBy(desc(tasks.taskNumber))
       .limit(1);
 
-    await db.insert(tasks).values({
-      creatorProfileId: profile.id,
-      taskNumber: (lastTaskNumber?.taskNumber ?? 0) + 1,
-      title: LAYOUT_TASK_TITLE,
-      description: 'Used by the Playwright tasks layout spec.',
-      status: 'backlog',
-      priority: 'high',
-      assigneeKind: 'human',
-      agentStatus: 'approved',
-      position: fixturePosition,
-      metadata: {},
-    });
+    const [insertedTask] = await db
+      .insert(tasks)
+      .values({
+        creatorProfileId: profile.id,
+        taskNumber: (lastTaskNumber?.taskNumber ?? 0) + 1,
+        title: LAYOUT_TASK_TITLE,
+        description: 'Used by the Playwright tasks layout spec.',
+        status: 'backlog',
+        priority: 'high',
+        assigneeKind: 'human',
+        agentStatus: 'approved',
+        position: fixturePosition,
+        metadata: {},
+      })
+      .returning({ id: tasks.id });
+
+    if (!insertedTask) {
+      throw new Error('Failed to seed the tasks layout fixture.');
+    }
+
+    return { id: insertedTask.id, title: LAYOUT_TASK_TITLE };
   } else {
     await db
       .update(tasks)
       .set({
+        title: LAYOUT_TASK_TITLE,
+        description: 'Used by the Playwright tasks layout spec.',
         status: 'backlog',
         priority: 'high',
         assigneeKind: 'human',
@@ -119,9 +149,34 @@ async function ensureTaskExists(): Promise<string> {
         deletedAt: null,
       })
       .where(eq(tasks.id, existingTask.id));
+
+    return { id: existingTask.id, title: LAYOUT_TASK_TITLE };
+  }
+}
+
+async function getSeededTaskState(
+  taskId: string
+): Promise<SeededTaskState | null> {
+  const databaseUrl = process.env.DATABASE_URL?.trim();
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required for tasks layout assertions.');
   }
 
-  return LAYOUT_TASK_TITLE;
+  const db = drizzle(neon(databaseUrl), {
+    schema: { tasks },
+  });
+  const [task] = await db
+    .select({
+      title: tasks.title,
+      status: tasks.status,
+      priority: tasks.priority,
+      assigneeKind: tasks.assigneeKind,
+    })
+    .from(tasks)
+    .where(and(eq(tasks.id, taskId), isNull(tasks.deletedAt)))
+    .limit(1);
+
+  return task ?? null;
 }
 
 function getVisibleTaskTitleEditor(page: Page) {
@@ -191,12 +246,21 @@ async function ensureBoardViewMode(page: Page): Promise<void> {
   await page.getByRole('button', { name: 'Board view' }).click();
 }
 
+async function selectTaskMetaOption(
+  page: Page,
+  triggerName: string,
+  optionName: string
+): Promise<void> {
+  await page.getByLabel(triggerName).click();
+  await page.getByRole('menuitem', { name: optionName }).click();
+}
+
 async function assertTasksBoardLayout(
   page: Page,
   testInfo: TestInfo,
   viewport: (typeof VIEWPORTS)[number]
 ): Promise<void> {
-  const taskTitle = await ensureTaskExists();
+  const { title: taskTitle } = await ensureTaskExists();
 
   await setTaskViewMode(page, 'board');
   await page.setViewportSize({
@@ -262,7 +326,7 @@ async function assertTasksLayout(
   testInfo: TestInfo,
   viewport: (typeof VIEWPORTS)[number]
 ): Promise<void> {
-  const taskTitle = await ensureTaskExists();
+  const { title: taskTitle } = await ensureTaskExists();
 
   await setTaskViewMode(page, 'list');
   await page.setViewportSize({
@@ -349,4 +413,67 @@ test.describe('Tasks layout', () => {
       await assertTasksLayout(page, testInfo, viewport);
     });
   }
+
+  test('persists board item edits after rapid title and metadata changes', async ({
+    page,
+  }, testInfo) => {
+    const { id: taskId, title: taskTitle } = await ensureTaskExists();
+    const editedTitle = `${LAYOUT_TASK_TITLE} ${Date.now()}`;
+
+    await setTaskViewMode(page, 'board');
+    await page.setViewportSize({ width: 1440, height: 960 });
+
+    await page.goto(APP_ROUTES.DASHBOARD_TASKS, {
+      waitUntil: 'domcontentloaded',
+      timeout: 120_000,
+    });
+    await expect(page.getByTestId('tasks-workspace')).toBeVisible({
+      timeout: 30_000,
+    });
+    await ensureBoardViewMode(page);
+
+    const boardCard = getTaskBoardCardByTitle(page, taskTitle);
+    await expect(boardCard).toBeVisible({ timeout: 30_000 });
+    await boardCard.click();
+
+    const titleEditor = getVisibleTaskTitleEditor(page);
+    await expect(titleEditor).toHaveValue(taskTitle, { timeout: 15_000 });
+    await titleEditor.fill(editedTitle);
+
+    await selectTaskMetaOption(page, 'Change task priority', 'Urgent');
+    await selectTaskMetaOption(page, 'Change task assignee', 'Jovie');
+    await selectTaskMetaOption(page, 'Change task status', 'In Progress');
+
+    await expect
+      .poll(() => getSeededTaskState(taskId), {
+        timeout: 30_000,
+        message: 'task item edits should persist to the database',
+      })
+      .toMatchObject({
+        title: editedTitle,
+        status: 'in_progress',
+        priority: 'urgent',
+        assigneeKind: 'jovie',
+      });
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('tasks-workspace')).toBeVisible({
+      timeout: 30_000,
+    });
+    await ensureBoardViewMode(page);
+
+    const movedCard = page
+      .getByTestId('tasks-board-column-in_progress')
+      .locator(TASK_BOARD_CARD_SELECTOR)
+      .filter({ hasText: editedTitle })
+      .first();
+    await expect(movedCard).toBeVisible({ timeout: 30_000 });
+    await expect(movedCard).toContainText('Urgent');
+    await expect(movedCard).toContainText('Jovie');
+
+    await testInfo.attach('tasks-board-persisted-item-edit', {
+      body: await page.getByTestId('tasks-workspace').screenshot(),
+      contentType: 'image/png',
+    });
+  });
 });

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -182,7 +182,7 @@ const mockSetHeaderActions = vi.fn();
 let setHeaderActionsHost: ((actions: React.ReactNode) => void) | null = null;
 let mockIsXlUp = true;
 let mockIs2xlUp = true;
-let mockTasksData = [mockTask, mockTaskTwo];
+let mockTasksData: TaskView[] = [mockTask, mockTaskTwo];
 let mockViewMode: 'board' | 'list' = 'list';
 let mockCanShowTaskDocumentAlongsideReleaseSidebar = true;
 const mockUnifiedTable = vi.fn();
@@ -756,6 +756,52 @@ describe('TasksPageClient', () => {
         taskId: 'task-2',
         data: {
           title: 'Updated release handoff title',
+          description: mockTaskTwo.description,
+        },
+      },
+      expect.objectContaining({
+        onError: expect.any(Function),
+      })
+    );
+  });
+
+  it('does not reset unsaved title text when task metadata refreshes', () => {
+    const view = renderPage();
+
+    const titleEditor = screen.getByLabelText('Task title');
+    fireEvent.change(titleEditor, {
+      target: { value: 'Unsaved metadata-safe title' },
+    });
+
+    mockTasksData = [
+      {
+        ...mockTaskTwo,
+        priority: 'urgent',
+        assigneeKind: 'jovie',
+      },
+      mockTask,
+    ];
+
+    view.rerender(
+      <TooltipProvider>
+        <HeaderActionsHost />
+        <TasksPageClient />
+      </TooltipProvider>
+    );
+
+    expect(screen.getByLabelText('Task title')).toHaveValue(
+      'Unsaved metadata-safe title'
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(mockUpdateTask).toHaveBeenCalledWith(
+      {
+        taskId: 'task-2',
+        data: {
+          title: 'Unsaved metadata-safe title',
           description: mockTaskTwo.description,
         },
       },

--- a/apps/web/tests/unit/lib/queries/useTaskMutations.test.tsx
+++ b/apps/web/tests/unit/lib/queries/useTaskMutations.test.tsx
@@ -4,7 +4,13 @@ import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { queryKeys } from '@/lib/queries';
 import { useUpdateTaskMutation } from '@/lib/queries/useTaskMutations';
-import type { TaskListResult, TaskStats, TaskView } from '@/lib/tasks/types';
+import type {
+  TaskBoardResult,
+  TaskListResult,
+  TaskStats,
+  TaskStatus,
+  TaskView,
+} from '@/lib/tasks/types';
 
 const mockUpdateTask = vi.hoisted(() => vi.fn());
 
@@ -54,7 +60,29 @@ function createTaskList(task: TaskView): TaskListResult {
   return {
     tasks: [task],
     nextCursor: null,
-    hasMore: false,
+  };
+}
+
+function createTaskBoard(task: TaskView): TaskBoardResult {
+  const statuses: TaskStatus[] = [
+    'backlog',
+    'todo',
+    'in_progress',
+    'done',
+    'cancelled',
+  ];
+
+  return {
+    columns: statuses.map(status => {
+      const tasks = task.status === status ? [task] : [];
+      return {
+        status,
+        tasks,
+        totalCount: tasks.length,
+        nextCursor: null,
+      };
+    }),
+    totalCount: 1,
   };
 }
 
@@ -195,5 +223,167 @@ describe('useTaskMutations', () => {
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
     });
+  });
+
+  it('moves and patches board cards optimistically when status and metadata change together', async () => {
+    const task = createTask({
+      status: 'backlog',
+      priority: 'high',
+      assigneeKind: 'human',
+    });
+    let resolveUpdate!: (value: TaskView) => void;
+
+    mockUpdateTask.mockImplementation(
+      () =>
+        new Promise<TaskView>(resolve => {
+          resolveUpdate = resolve;
+        })
+    );
+
+    queryClient.setQueryData(
+      queryKeys.tasks.board('profile-1'),
+      createTaskBoard(task)
+    );
+    queryClient.setQueryData(
+      queryKeys.tasks.list('profile-1'),
+      createTaskList(task)
+    );
+    queryClient.setQueryData(
+      queryKeys.tasks.detail(task.id, 'profile-1'),
+      task
+    );
+
+    const { result } = renderHook(() => useUpdateTaskMutation(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        taskId: task.id,
+        data: {
+          status: 'in_progress',
+          priority: 'urgent',
+          assigneeKind: 'jovie',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      const board = queryClient.getQueryData<TaskBoardResult>(
+        queryKeys.tasks.board('profile-1')
+      );
+      const backlogTasks =
+        board?.columns.find(column => column.status === 'backlog')?.tasks ?? [];
+      const inProgressTask = board?.columns
+        .find(column => column.status === 'in_progress')
+        ?.tasks.find(candidate => candidate.id === task.id);
+
+      expect(backlogTasks).toEqual([]);
+      expect(inProgressTask).toMatchObject({
+        id: task.id,
+        status: 'in_progress',
+        priority: 'urgent',
+        assigneeKind: 'jovie',
+      });
+    });
+
+    expect(
+      queryClient.getQueryData<TaskView>(
+        queryKeys.tasks.detail(task.id, 'profile-1')
+      )
+    ).toMatchObject({
+      status: 'in_progress',
+      priority: 'urgent',
+      assigneeKind: 'jovie',
+    });
+
+    expect(
+      queryClient
+        .getQueryData<TaskListResult>(queryKeys.tasks.list('profile-1'))
+        ?.tasks.at(0)
+    ).toMatchObject({
+      status: 'in_progress',
+      priority: 'urgent',
+      assigneeKind: 'jovie',
+    });
+
+    await act(async () => {
+      resolveUpdate(
+        createTask({
+          status: 'in_progress',
+          priority: 'urgent',
+          assigneeKind: 'jovie',
+          completedAt: null,
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+  });
+
+  it('rolls back optimistic board item edits when the update fails', async () => {
+    const task = createTask({
+      status: 'todo',
+      priority: 'medium',
+      assigneeKind: 'human',
+    });
+    const previousBoard = createTaskBoard(task);
+    let rejectUpdate!: (error: Error) => void;
+
+    mockUpdateTask.mockImplementation(
+      () =>
+        new Promise<TaskView>((_resolve, reject) => {
+          rejectUpdate = reject;
+        })
+    );
+
+    queryClient.setQueryData(queryKeys.tasks.board('profile-1'), previousBoard);
+    queryClient.setQueryData(
+      queryKeys.tasks.detail(task.id, 'profile-1'),
+      task
+    );
+
+    const { result } = renderHook(() => useUpdateTaskMutation(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        taskId: task.id,
+        data: {
+          priority: 'urgent',
+          assigneeKind: 'jovie',
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        queryClient
+          .getQueryData<TaskBoardResult>(queryKeys.tasks.board('profile-1'))
+          ?.columns.find(column => column.status === 'todo')
+          ?.tasks.at(0)
+      ).toMatchObject({
+        priority: 'urgent',
+        assigneeKind: 'jovie',
+      });
+    });
+
+    await act(async () => {
+      rejectUpdate(new Error('update failed'));
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(
+      queryClient.getQueryData<TaskBoardResult>(
+        queryKeys.tasks.board('profile-1')
+      )
+    ).toEqual(previousBoard);
+    expect(
+      queryClient.getQueryData<TaskView>(
+        queryKeys.tasks.detail(task.id, 'profile-1')
+      )
+    ).toEqual(task);
   });
 });


### PR DESCRIPTION
## Summary
- Fixes JOV-2216 by making task edits partial-field writes instead of rewriting stale task rows.
- Keeps unsaved title/description edits alive while priority, assignee, or status metadata updates are in flight.
- Patches board/list/detail React Query caches together so moved cards keep edited metadata and rollback correctly on failure.

## QA
- `pnpm --filter web exec vitest run lib/tasks/task-update.test.ts tests/unit/lib/queries/useTaskMutations.test.tsx tests/unit/dashboard/TasksPageClient.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/app/app/'(shell)'/dashboard/tasks/task-actions.ts apps/web/components/features/dashboard/tasks/TasksPageClient.tsx apps/web/lib/queries/useTaskMutations.ts apps/web/lib/tasks/task-update.ts apps/web/lib/tasks/task-update.test.ts apps/web/tests/unit/lib/queries/useTaskMutations.test.tsx apps/web/tests/unit/dashboard/TasksPageClient.test.tsx apps/web/tests/e2e/tasks-layout.spec.ts`
- `doppler run --project jovie-web --config dev -- env JOVIE_AGENT_PROFILE=coder E2E_SKIP_WEB_SERVER=1 E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready BASE_URL=http://localhost:3001 pnpm --filter @jovie/web exec playwright test tests/e2e/tasks-layout.spec.ts --project=chromium --reporter=line`
- Pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`

## Design Review
- Captured live board at 1440px after the persistence test: `.gstack/qa-reports/screenshots/tasks-board-design-review-1440.png`.
- Verified no page-level horizontal overflow (`scrollWidth=1440`, `innerWidth=1440`) and no browser console errors in the visual pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task update reliability by refining field-level patch handling.
  * Enhanced metadata persistence for task priority, assignee, and status changes.
  * Fixed unsaved text preservation in task editor during metadata refreshes.

* **Tests**
  * Added comprehensive test coverage for task update field behavior and optimistic updates.
  * Added E2E test verifying rapid metadata edits persist correctly and UI reflects changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8691)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->