### PR TITLE
feat(homepage): tighten prelaunch waitlist homepage

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -2627,11 +2627,11 @@ body:has(.home-viewport)::-webkit-scrollbar {
 
 .homepage-trust-logo-grid {
   display: grid;
+  /* 5 logos: awal, orchard, umg (widest), armada, black-hole.
+     Prior 8-track layout was leftover from JOV-2075 logo removal. */
   grid-template-columns:
-    minmax(7rem, 0.95fr) minmax(7.5rem, 1fr)
-    minmax(11rem, 1.38fr) minmax(7.75rem, 1fr)
-    minmax(8rem, 1fr) minmax(6.75rem, 0.8fr)
-    minmax(7.5rem, 0.9fr) minmax(6.25rem, 0.72fr);
+    minmax(7rem, 0.95fr) minmax(7.5rem, 1fr) minmax(11rem, 1.38fr)
+    minmax(7.75rem, 1fr) minmax(7.5rem, 0.9fr);
   align-items: center;
   gap: clamp(1rem, 2.4vw, 3.1rem);
   transform-origin: center top;
@@ -2700,8 +2700,8 @@ body:has(.home-viewport)::-webkit-scrollbar {
   }
 
   .homepage-trust-logo-grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 1.45rem 2rem;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 1.45rem 1.5rem;
   }
 
   .homepage-trust-logo-slot {
@@ -2709,7 +2709,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
   }
 
   .homepage-trust-logo-slot--umg {
-    grid-column: span 2;
+    grid-column: auto;
   }
 
   .homepage-spec-wall-grid {
@@ -2974,12 +2974,16 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 .homepage-go-live-card h3 {
-  margin: 1.2rem 0 0;
+  margin: 0;
   color: rgba(255, 255, 255, 0.95);
   font-size: clamp(1.05rem, 1.45vw, 1.24rem);
   font-weight: 650;
   line-height: 1.12;
   letter-spacing: 0;
+}
+
+.homepage-go-live-card span + h3 {
+  margin-top: 1.2rem;
 }
 
 .homepage-go-live-card p {

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -242,18 +242,20 @@ function HomepageHeroActions() {
       >
         {HERO_COPY.primaryCta.label}
       </HomepageTrackedLink>
-      <HomepageTrackedLink
-        href={HERO_COPY.secondaryCta.href}
-        className='homepage-hero-secondary-link focus-ring-themed'
-        eventName='homepage_hero_cta_clicked'
-        eventProperties={{
-          cta: 'secondary',
-          label: HERO_COPY.secondaryCta.label,
-        }}
-      >
-        {HERO_COPY.secondaryCta.label}
-        <ArrowRight aria-hidden='true' size={15} strokeWidth={1.9} />
-      </HomepageTrackedLink>
+      {FEATURE_FLAGS.WAITLIST_ENABLED ? null : (
+        <HomepageTrackedLink
+          href={HERO_COPY.secondaryCta.href}
+          className='homepage-hero-secondary-link focus-ring-themed'
+          eventName='homepage_hero_cta_clicked'
+          eventProperties={{
+            cta: 'secondary',
+            label: HERO_COPY.secondaryCta.label,
+          }}
+        >
+          {HERO_COPY.secondaryCta.label}
+          <ArrowRight aria-hidden='true' size={15} strokeWidth={1.9} />
+        </HomepageTrackedLink>
+      )}
     </div>
   );
 }
@@ -269,21 +271,25 @@ function HomepageProductStatement() {
       data-testid='homepage-product-statement'
     >
       <div className='homepage-product-statement__inner'>
-        <p className='homepage-section-eyebrow'>{copy.eyebrow}</p>
+        {copy.eyebrow ? (
+          <p className='homepage-section-eyebrow'>{copy.eyebrow}</p>
+        ) : null}
         <h2 id='homepage-product-statement-heading'>
-          <span className='homepage-product-statement__lead'>{copy.lead}</span>
+          <span className='homepage-product-statement__lead'>{copy.lead}</span>{' '}
           <span className='homepage-product-statement__body'>{copy.body}</span>
         </h2>
-        <div
-          className='homepage-product-statement__ai'
-          data-testid='homepage-ai-composer-demo'
-        >
-          <HomeComposerHero />
-          <div className='homepage-product-statement__ai-copy'>
-            <h3>{aiCopy.headline}</h3>
-            <p>{aiCopy.body}</p>
+        {FEATURE_FLAGS.SHOW_HOMEPAGE_AI_COMPOSER_SECTION ? (
+          <div
+            className='homepage-product-statement__ai'
+            data-testid='homepage-ai-composer-demo'
+          >
+            <HomeComposerHero />
+            <div className='homepage-product-statement__ai-copy'>
+              <h3>{aiCopy.headline}</h3>
+              <p>{aiCopy.body}</p>
+            </div>
           </div>
-        </div>
+        ) : null}
       </div>
     </section>
   );
@@ -302,15 +308,15 @@ function HomepageGoLiveStepsSection() {
         <h2 id='homepage-go-live-heading'>
           {HOMEPAGE_LAUNCH_COPY.workspace.kicker}
         </h2>
-        <ol className='homepage-go-live-section__cards'>
+        <ul className='homepage-go-live-section__cards'>
           {copy.cards.map(card => (
             <li className='homepage-go-live-card' key={card.title}>
-              <span>{card.number}</span>
+              {card.number ? <span>{card.number}</span> : null}
               <h3>{card.title}</h3>
               <p>{card.body}</p>
             </li>
           ))}
-        </ol>
+        </ul>
       </div>
     </section>
   );
@@ -335,7 +341,9 @@ function HomepageUnlockedSections() {
   return (
     <>
       <HomepageProductStatement />
-      <HomepageGoLiveStepsSection />
+      {FEATURE_FLAGS.SHOW_HOMEPAGE_GO_LIVE_SECTION ? (
+        <HomepageGoLiveStepsSection />
+      ) : null}
       <HomepageWorkspaceSection screenshot={WORKSPACE_SCREENSHOT} />
       <HomepageArtistProfilesCarousel cards={ARTIST_PROFILE_CARDS} />
       {FEATURE_FLAGS.SHOW_HOMEPAGE_FRIDAY_RHYTHM ? (
@@ -345,7 +353,7 @@ function HomepageUnlockedSections() {
       {FEATURE_FLAGS.SHOW_HOME_REFRESH_2026 ? <HomeLoopDiagramSection /> : null}
       {FEATURE_FLAGS.SHOW_HOME_REFRESH_2026 ? <HomeStatQuoteSection /> : null}
       {FEATURE_FLAGS.SHOW_HOMEPAGE_V2_PRICING ? <HomepageV2Pricing /> : null}
-      <HomepageFaq />
+      {FEATURE_FLAGS.SHOW_HOMEPAGE_FAQ ? <HomepageFaq /> : null}
     </>
   );
 }
@@ -376,7 +384,8 @@ function HomePageShell({ children }: { readonly children: React.ReactNode }) {
       <script type='application/ld+json'>{WEBSITE_SCHEMA}</script>
       <script type='application/ld+json'>{SOFTWARE_SCHEMA}</script>
       <script type='application/ld+json'>{ORGANIZATION_SCHEMA}</script>
-      {FEATURE_FLAGS.SHOW_HOMEPAGE_UNLOCKED_SECTIONS ? (
+      {FEATURE_FLAGS.SHOW_HOMEPAGE_UNLOCKED_SECTIONS &&
+      FEATURE_FLAGS.SHOW_HOMEPAGE_FAQ ? (
         <script type='application/ld+json'>{FAQ_SCHEMA}</script>
       ) : null}
       {children}
@@ -428,40 +437,10 @@ export default async function HomePage() {
           <div className='homepage-hero-inner relative z-[3] mx-auto flex w-full max-w-none min-w-0 flex-1 flex-col items-center justify-start'>
             <div className='homepage-hero-copy w-full min-w-0'>
               <h1
-                aria-label={HERO_COPY.headline}
                 id='home-hero-heading'
-                className='homepage-hero-headline self-center text-center text-white'
+                className='homepage-hero-headline self-center text-center text-white text-balance'
               >
-                <span
-                  aria-hidden='true'
-                  className='homepage-hero-headline__desktop'
-                >
-                  Release more music
-                </span>
-                <span
-                  aria-hidden='true'
-                  className='homepage-hero-headline__desktop'
-                >
-                  with less work
-                </span>
-                <span
-                  aria-hidden='true'
-                  className='homepage-hero-headline__mobile'
-                >
-                  Release more
-                </span>
-                <span
-                  aria-hidden='true'
-                  className='homepage-hero-headline__mobile'
-                >
-                  music with
-                </span>
-                <span
-                  aria-hidden='true'
-                  className='homepage-hero-headline__mobile'
-                >
-                  less work
-                </span>
+                {HERO_COPY.headline}
               </h1>
               <p className='homepage-hero-subhead self-center text-center text-white/68'>
                 {HERO_COPY.subhead}
@@ -474,7 +453,7 @@ export default async function HomePage() {
       </section>
       <div className='homepage-trust-section'>
         <HomeTrustSection
-          label='Trusted by artists and teams releasing on'
+          label='Used by artists and teams with releases distributed through'
           presentation='inline-strip'
         />
       </div>

--- a/apps/web/components/homepage/HomepageIntent.test.tsx
+++ b/apps/web/components/homepage/HomepageIntent.test.tsx
@@ -49,12 +49,12 @@ describe('HomepageIntent', () => {
     render(<HomepageIntent />);
     expect(
       screen.getByRole('heading', {
-        name: 'Release more music with less work',
+        name: 'Monetize your music catalog with AI',
       })
     ).toBeTruthy();
     expect(
       screen.getByText(
-        'Plan the drop, route every fan, and keep the next release moving.'
+        'Jovie surfaces the opportunities hiding in your releases — and turns each one into a fan path, presave, or pitch you can ship today.'
       )
     ).toBeTruthy();
     expect(getInput()).toBeTruthy();

--- a/apps/web/components/organisms/HeaderNav.tsx
+++ b/apps/web/components/organisms/HeaderNav.tsx
@@ -35,6 +35,7 @@ export interface HeaderNavProps {
   readonly includePublicLoginInMobileNav?: boolean;
   readonly mobilePublicCtaHref?: string;
   readonly mobilePublicCtaLabel?: string;
+  readonly publicCtaLabel?: string;
   readonly presentation?: 'default' | 'homepage-embedded' | 'marketing-glass';
   readonly flyoutMenus?: readonly HeaderFlyoutMenu[];
   readonly showContactLink?: boolean;
@@ -54,11 +55,13 @@ export interface HeaderFlyoutMenu {
 type PublicAuthActionsProps = Readonly<{
   readonly minimal?: boolean;
   readonly minimalVariant?: 'link' | 'pill';
+  readonly publicCtaLabel?: string;
 }>;
 
 function PublicAuthActions({
   minimal = false,
   minimalVariant = 'link',
+  publicCtaLabel = 'Request Access',
 }: PublicAuthActionsProps = {}) {
   if (minimal) {
     if (minimalVariant === 'pill') {
@@ -89,15 +92,16 @@ function PublicAuthActions({
           className: 'focus-ring-themed shrink-0 whitespace-nowrap',
         })}
       >
-        Request Access
+        {publicCtaLabel}
       </Link>
     </div>
   );
 }
 
 function GlassAuthActions({
+  publicCtaLabel = 'Start Free Trial',
   showContactLink = true,
-}: Readonly<{ showContactLink?: boolean }>) {
+}: Readonly<{ publicCtaLabel?: string; showContactLink?: boolean }>) {
   return (
     <div className='flex items-center gap-1'>
       {showContactLink ? (
@@ -118,7 +122,7 @@ function GlassAuthActions({
         href={APP_ROUTES.SIGNUP}
         className='marketing-glass-header__cta focus-ring-themed'
       >
-        Start Free Trial
+        {publicCtaLabel}
       </Link>
     </div>
   );
@@ -268,6 +272,7 @@ export function HeaderNav({
   includePublicLoginInMobileNav = true,
   mobilePublicCtaHref,
   mobilePublicCtaLabel,
+  publicCtaLabel,
   presentation = 'default',
   flyoutMenus,
   showContactLink = true,
@@ -551,11 +556,15 @@ export function HeaderNav({
             )}
           >
             {authMode === 'public-static' && isMarketingGlass ? (
-              <GlassAuthActions showContactLink={showContactLink} />
+              <GlassAuthActions
+                publicCtaLabel={publicCtaLabel}
+                showContactLink={showContactLink}
+              />
             ) : authMode === 'public-static' ? (
               <PublicAuthActions
                 minimal={minimalAuth}
                 minimalVariant={minimalAuthVariant}
+                publicCtaLabel={publicCtaLabel}
               />
             ) : (
               <AuthActions />

--- a/apps/web/components/site/MarketingHeader.tsx
+++ b/apps/web/components/site/MarketingHeader.tsx
@@ -7,6 +7,7 @@ import {
   HeaderNav,
 } from '@/components/organisms/HeaderNav';
 import { APP_ROUTES } from '@/constants/routes';
+import { FRONT_DOOR_CTA_LABEL } from '@/data/homepageLaunchCopy';
 import { MARKETING_NAV_LINKS } from '@/data/marketingNavigation';
 import { FEATURE_FLAGS } from '@/lib/flags/marketing-static';
 
@@ -109,6 +110,9 @@ const MARKETING_GLASS_MOBILE_LINKS: readonly MarketingHeaderNavLink[] = [
   ),
   ...MARKETING_GLASS_DESKTOP_LINKS,
 ] as const;
+const HOMEPAGE_PUBLIC_CTA_LABEL = FEATURE_FLAGS.WAITLIST_ENABLED
+  ? 'Request access'
+  : FRONT_DOOR_CTA_LABEL;
 
 export interface MarketingHeaderProps
   extends Readonly<{
@@ -189,9 +193,10 @@ export function MarketingHeader({
       presentation={presentation}
       flyoutMenus={navConfig.flyoutMenus}
       mobilePublicCtaHref={isHomepage ? APP_ROUTES.SIGNUP : undefined}
-      mobilePublicCtaLabel={isHomepage ? 'Start Free Trial' : undefined}
+      mobilePublicCtaLabel={isHomepage ? HOMEPAGE_PUBLIC_CTA_LABEL : undefined}
       mobileNavLinks={navConfig.mobileNavLinks}
       navLinks={navConfig.desktopNavLinks}
+      publicCtaLabel={isHomepage ? HOMEPAGE_PUBLIC_CTA_LABEL : undefined}
       showContactLink={centerNavEnabled && !isHomepage}
     />
   );

--- a/apps/web/data/homepageLaunchCopy.ts
+++ b/apps/web/data/homepageLaunchCopy.ts
@@ -1,4 +1,14 @@
 import { APP_ROUTES } from '@/constants/routes';
+import { FEATURE_FLAGS } from '@/lib/flags/marketing-static';
+
+// Prelaunch front-door label. Server-side waitlist gate handles the
+// post-/signup routing; this controls only the marketing copy.
+export const FRONT_DOOR_CTA_LABEL = FEATURE_FLAGS.WAITLIST_ENABLED
+  ? 'Request access'
+  : 'Claim your free profile';
+const FALLBACK_CTA_SUPPORT = FEATURE_FLAGS.WAITLIST_ENABLED
+  ? 'Limited prelaunch access. We will email when you are in.'
+  : 'Free forever. No credit card.';
 
 export interface HomepageHeroCarouselSlide {
   readonly id: string;
@@ -12,78 +22,78 @@ export interface HomepageHeroCarouselSlide {
 
 export const HOMEPAGE_LAUNCH_COPY = {
   seo: {
-    title: 'Jovie | Release more music with less work',
+    title: 'Jovie | Monetize your music catalog with AI',
     description:
-      'Jovie gives artists one workspace for profiles, releases, fan capture, and release momentum.',
+      'Jovie is the AI artist workspace that surfaces opportunities in your catalog — fan paths, presaves, pitches — and helps you ship the next one.',
   },
   hero: {
-    headline: 'Release more music with less work',
+    headline: 'Monetize your music catalog with AI',
     subhead:
-      'Plan the drop, route every fan, and keep the next release moving.',
+      'Jovie surfaces the opportunities hiding in your releases — and turns each one into a fan path, presave, or pitch you can ship today.',
     primaryCta: {
-      label: 'Start Free Trial',
+      label: FRONT_DOOR_CTA_LABEL,
       href: APP_ROUTES.SIGNUP,
     },
     secondaryCta: {
-      label: 'Explore Profiles',
+      label: 'See a live profile',
       href: APP_ROUTES.ARTIST_PROFILES,
     },
   },
   fallbackCta: {
-    label: 'Start Free',
+    label: FRONT_DOOR_CTA_LABEL,
     href: APP_ROUTES.SIGNUP,
-    support: 'Free profile. 14-day Pro trial.',
+    support: FALLBACK_CTA_SUPPORT,
   },
   workspace: {
-    kicker: 'Go live in 60 seconds',
-    headline: 'One workspace\nFor every release',
+    kicker: 'What Jovie finds.',
+    headline: 'All your music.\nWorking while you sleep.',
     screenshotKey: 'shell-v1-releases-desktop',
     callouts: [
       {
         key: 'import',
         number: '01',
-        title: 'Import the drop automatically',
-        body: 'Jovie pulls artwork, credits, links, dates, and status into the workspace automatically.',
+        title: 'Your catalog, in one place',
+        body: 'Releases, assets, links, dates, fans, and stream history come together automatically.',
       },
       {
         key: 'publish',
         number: '02',
-        title: 'Generate the launch plan',
-        body: 'Turn the release into tasks for profile updates, DSP links, fan capture, and launch timing.',
+        title: 'Opportunities surfaced',
+        body: 'Jovie scans the whole catalog for underexposed releases, missing fan paths, and presave gaps.',
       },
       {
         key: 'review',
         number: '03',
-        title: 'Run the next action',
-        body: 'Let Jovie handle the next action or assign it to your team with the context attached.',
+        title: 'Launch the next one',
+        body: 'Generate the presave page, fan path, or pitch and send it live to your audience.',
       },
     ],
   },
   productStatement: {
-    eyebrow: 'Meet Jovie',
-    lead: 'A new kind of operating system',
-    body: 'Built for music artists',
+    eyebrow: '',
+    lead: 'Meet Jovie',
+    body: 'Your always-on AI artist manager.',
     cards: [
       {
-        number: '01',
-        title: 'Import the drop automatically',
-        body: 'Jovie pulls artwork, credits, dates, links, and release status into one workspace automatically.',
+        number: '',
+        title: 'Underexposed releases.',
+        body: 'Songs gaining momentum that have no presave page or fan capture set up.',
       },
       {
-        number: '02',
-        title: 'Generate the launch plan',
-        body: 'Turn each release into the plan, tasks, profile updates, fan paths, and launch timing it needs.',
+        number: '',
+        title: 'Missing fan paths.',
+        body: 'Streams that arrive without a way for listeners to follow, subscribe, or save the next drop.',
       },
       {
-        number: '03',
-        title: 'Run the next action',
-        body: 'Let Jovie run the next action or assign it to your team with the release context attached.',
+        number: '',
+        title: 'Playlist openings.',
+        body: 'Editorial and curator playlists adding artists with your sound.',
       },
     ],
   },
   aiComposer: {
-    headline: 'Ask once. Get the launch plan',
-    body: 'Jovie turns a release into the fan path, launch tasks, and next actions your team can run.',
+    headline: 'Ask once. Surface the next opportunity.',
+    body: 'Jovie turns a release into the fan path, presave, or pitch your team can ship.',
   },
   intentBand: {
     eyebrow: 'Ask Jovie',
@@ -137,7 +147,7 @@ export const HOMEPAGE_LAUNCH_COPY = {
       },
     ],
     primaryCta: {
-      label: 'Claim your profile',
+      label: FRONT_DOOR_CTA_LABEL,
       href: APP_ROUTES.SIGNUP,
     },
     secondaryCta: {
@@ -183,29 +193,29 @@ export const HOMEPAGE_LAUNCH_COPY = {
   },
   faq: [
     {
-      question: 'Are artist profiles free?',
+      question: 'What does Jovie actually do?',
       answer:
-        'Yes. Artist profiles are free forever. Pro adds the release tools when you need presaves, notifications, deeper analytics, and more launch automation.',
+        'Connect your music. Jovie watches your catalog, fans, and stream movement, then surfaces specific opportunities. A release worth a presave. A playlist that fits your sound. A fan moment to capture.',
     },
     {
-      question: 'What does Jovie generate for a release?',
+      question: 'Where does my catalog data come from?',
       answer:
-        'Jovie turns release metadata into a working plan: profile updates, release pages, smart links, fan capture, launch tasks, and the next actions around the drop.',
+        'Spotify, Apple Music, and your DSPs. Connect once. Jovie keeps every release, asset, and fan path in one place.',
     },
     {
-      question: 'Can my team use the release plan?',
+      question: 'Does Jovie post or pitch on my behalf?',
       answer:
-        'Yes. Tasks can be assigned with the release context attached, so managers, collaborators, and artists work from the same source of truth.',
+        'Only when you say so. Jovie surfaces and drafts. You decide what goes live.',
     },
     {
-      question: 'Do I need to replace my current link in bio?',
+      question: 'How does Jovie know what is worth surfacing?',
       answer:
-        'No. You can use Jovie as the primary artist profile or as a launch-specific fan path while you compare how it performs.',
+        'It watches every track in your catalog every day. Streams, fan moments, playlist movement, and editorial activity all feed the model.',
     },
     {
-      question: 'Can I review everything before publishing?',
+      question: 'Who is Jovie for?',
       answer:
-        'Yes. You can review and adjust the profile, release details, smart links, fan actions, and task plan before anything becomes part of your public launch path.',
+        'Artists with a catalog already out and the team around them. Built for the work between drops, not just launch week.',
     },
   ],
 } as const;

--- a/apps/web/data/homepageV2Copy.ts
+++ b/apps/web/data/homepageV2Copy.ts
@@ -5,6 +5,14 @@ import {
   ARTIST_PROFILE_SPEC_TILES,
   type ArtistProfileFeatureTile,
 } from '@/data/artistProfileFeatures';
+import { FEATURE_FLAGS } from '@/lib/flags/marketing-static';
+
+// Footer CTA label tracks the prelaunch waitlist gate. Mirrors the hero
+// front-door pattern: "Request access" while we're waitlisting, then
+// "Start free trial" once the doors open.
+const FOOTER_CTA_LABEL = FEATURE_FLAGS.WAITLIST_ENABLED
+  ? 'Request access'
+  : 'Start free trial';
 
 function requireTile<T extends { readonly id: string }>(
   tiles: readonly T[],
@@ -158,9 +166,9 @@ export const HOMEPAGE_V2_COPY: HomepageV2Copy = {
     href: APP_ROUTES.PRICING,
   },
   finalCta: {
-    headline: 'Keep Your Music Moving.',
+    headline: 'Keep your music moving.',
     body: 'Jovie handles the plan, assets, and follow-up from there.',
-    primaryCtaLabel: 'Start Free Trial',
+    primaryCtaLabel: FOOTER_CTA_LABEL,
     secondaryCtaLabel: 'See Pricing',
   },
   footerColumns: [

--- a/apps/web/lib/flags/marketing-static.ts
+++ b/apps/web/lib/flags/marketing-static.ts
@@ -42,8 +42,21 @@ export const FEATURE_FLAGS = {
   SHOW_HOMEPAGE_V2_SPOTLIGHT: true,
   SHOW_HOMEPAGE_V2_CAPTURE_REACTIVATE: true,
   SHOW_HOMEPAGE_V2_POWER_GRID: false,
-  SHOW_HOMEPAGE_V2_PRICING: true,
+  SHOW_HOMEPAGE_V2_PRICING: false,
   SHOW_HOMEPAGE_V2_FINAL_CTA: true,
+  // "What Jovie finds" 3-card section. Off for prelaunch until the
+  // opportunity-type cards land harder.
+  SHOW_HOMEPAGE_GO_LIVE_SECTION: false,
+  // FAQ section. Off for prelaunch — answers will firm up post-waitlist
+  // when we know what people actually ask.
+  SHOW_HOMEPAGE_FAQ: false,
+  // Prelaunch waitlist gate. When true, public-front-door CTAs on the
+  // marketing homepage render as "Request access" (waitlisting everyone who
+  // comes in). When false, they revert to "Claim your free profile". The
+  // server-side waitlist gate (`isWaitlistGateEnabled`) handles routing once
+  // a user hits /signup; this flag only controls marketing copy. Flip to
+  // false to open the doors.
+  WAITLIST_ENABLED: true,
   SHOW_HOMEPAGE_V2_FOOTER_LINKS: false,
   SHOW_ARTIST_PROFILE_PAY_FLOW_VIDEO: true,
   SHOW_FORGEUI_MARKETING_UPDATES,

--- a/apps/web/tests/e2e/homepage.spec.ts
+++ b/apps/web/tests/e2e/homepage.spec.ts
@@ -32,25 +32,28 @@ test.describe('Homepage', () => {
     const hero = page.getByTestId('homepage-hero-shell');
 
     await expect(hero).toBeVisible();
-    await expect(hero.getByText('Release operating system')).toHaveCount(0);
+    await expect(hero.getByText('operating system')).toHaveCount(0);
     await expect(
-      hero.getByRole('heading', { name: 'Release more music with less work' })
+      hero.getByRole('heading', {
+        name: 'Monetize your music catalog with AI',
+      })
     ).toBeVisible();
     await expect(
       hero.getByText(
-        'Plan the drop, route every fan, and keep the next release moving.'
+        'Jovie surfaces the opportunities hiding in your releases — and turns each one into a fan path, presave, or pitch you can ship today.'
       )
     ).toBeVisible();
     await expect(
-      hero.getByRole('link', { name: 'Start Free Trial', exact: true })
+      hero.getByRole('link', { name: 'Request access', exact: true })
     ).toHaveAttribute('href', '/signup');
+    // Secondary CTA hidden while WAITLIST_ENABLED is on.
     await expect(
-      hero.getByRole('link', { name: 'Explore Profiles', exact: true })
-    ).toHaveAttribute('href', '/artist-profiles');
+      hero.getByRole('link', { name: 'See a live profile', exact: true })
+    ).toHaveCount(0);
     await expect(hero.getByPlaceholder('Ask Jovie...')).toHaveCount(0);
   });
 
-  test('header uses compact homepage presentation and signup CTA', async ({
+  test('header uses compact homepage presentation and waitlist CTA', async ({
     page,
   }) => {
     const header = page.getByTestId('header-nav');
@@ -71,7 +74,7 @@ test.describe('Homepage', () => {
     await expect(header.getByRole('link', { name: 'Contact' })).toHaveCount(0);
     await expect(header.getByRole('link', { name: 'Sign in' })).toHaveCount(1);
     await expect(
-      header.getByRole('link', { name: 'Start Free Trial' })
+      header.getByRole('link', { name: 'Request access' })
     ).toHaveAttribute('href', '/signup');
   });
 
@@ -163,7 +166,7 @@ test.describe('Homepage', () => {
     }
   });
 
-  test('trust, product statement, workspace, artist profiles, pricing, FAQ, and final CTA render', async ({
+  test('trust, product statement, workspace, artist profiles, and footer CTA render (prelaunch — pricing, FAQ, go-live, AI composer flagged off)', async ({
     page,
   }) => {
     await expect(page.getByTestId('homepage-trust')).toHaveAttribute(
@@ -186,82 +189,47 @@ test.describe('Homepage', () => {
       expect(proofParallaxAnimation).toBe('homepage-proof-logos-parallax');
     }
     await expect(page.getByTestId('homepage-product-statement')).toBeVisible();
-    await expect(page.getByText('Meet Jovie')).toBeVisible();
     await expect(
       page.getByRole('heading', {
-        name: /A new kind of operating system\s+Built for music artists/,
+        name: /Meet Jovie\s+Your always-on AI artist manager\./,
       })
     ).toBeVisible();
-    const aiComposer = page.getByTestId('homepage-ai-composer-demo');
-    await expect(aiComposer).toBeVisible();
-    await expect(
-      aiComposer.getByRole('heading', {
-        name: 'Ask once. Get the launch plan',
-      })
-    ).toBeVisible();
-    const aiComposerBefore = await aiComposer.boundingBox();
-    await page.waitForTimeout(5600);
-    const aiComposerAfter = await aiComposer.boundingBox();
-    expect(
-      Math.abs((aiComposerAfter?.height ?? 0) - (aiComposerBefore?.height ?? 0))
-    ).toBeLessThanOrEqual(2);
-    await expect(page.getByTestId('homepage-go-live-section')).toBeVisible();
-    await expect(
-      page.getByRole('heading', { name: 'Go live in 60 seconds' })
-    ).toBeVisible();
+    // AI composer demo flagged off until we have a real opportunity-surfacing demo.
+    await expect(page.getByTestId('homepage-ai-composer-demo')).toHaveCount(0);
+    // 'What Jovie finds.' section flagged off (SHOW_HOMEPAGE_GO_LIVE_SECTION=false).
+    await expect(page.getByTestId('homepage-go-live-section')).toHaveCount(0);
     const productStatement = page.getByTestId('homepage-product-statement');
-    const goLiveSection = page.getByTestId('homepage-go-live-section');
     const workspaceSection = page.getByTestId('homepage-workspace-section');
-    for (const outcome of [
-      'Import the drop automatically',
-      'Generate the launch plan',
-      'Run the next action',
-    ]) {
-      await expect(
-        goLiveSection.getByRole('heading', { name: outcome })
-      ).toBeVisible();
-    }
     const sectionOrder = await page.evaluate(() => {
       const product = document.querySelector(
         '[data-testid="homepage-product-statement"]'
       );
-      const goLive = document.querySelector(
-        '[data-testid="homepage-go-live-section"]'
-      );
       const workspace = document.querySelector(
         '[data-testid="homepage-workspace-section"]'
       );
-      if (!product || !goLive || !workspace) return [];
-      return [
-        product.compareDocumentPosition(goLive),
-        goLive.compareDocumentPosition(workspace),
-      ];
+      if (!product || !workspace) return [];
+      return [product.compareDocumentPosition(workspace)];
     });
-    expect(sectionOrder).toEqual([4, 4]);
+    expect(sectionOrder).toEqual([4]);
     await expect(productStatement).toBeVisible();
-    await expect(goLiveSection).toBeVisible();
     await expect(workspaceSection).toBeVisible();
     await expect(
       page.getByRole('heading', {
-        name: 'One workspace For every release',
+        name: 'All your music. Working while you sleep.',
       })
     ).toBeVisible();
     await expect(
       page.getByTestId('homepage-workspace-screenshot').locator('img')
     ).toBeVisible();
-    await expect(
-      workspaceSection.getByRole('heading', {
-        name: 'Import the drop automatically',
-      })
-    ).toBeVisible();
-    await expect(
-      workspaceSection.getByRole('heading', {
-        name: 'Generate the launch plan',
-      })
-    ).toBeVisible();
-    await expect(
-      workspaceSection.getByRole('heading', { name: 'Run the next action' })
-    ).toBeVisible();
+    for (const outcome of [
+      'Your catalog, in one place',
+      'Opportunities surfaced',
+      'Launch the next one',
+    ]) {
+      await expect(
+        workspaceSection.getByRole('heading', { name: outcome })
+      ).toBeVisible();
+    }
     await expect(page.getByTestId('homepage-product-depth-band')).toHaveCount(
       0
     );
@@ -284,7 +252,7 @@ test.describe('Homepage', () => {
       artistProfiles.getByText('Streams. Fans. Shows. Payments. Drops.')
     ).toBeVisible();
     await expect(
-      artistProfiles.getByRole('link', { name: 'Claim your profile' })
+      artistProfiles.getByRole('link', { name: 'Request access' })
     ).toHaveAttribute('href', '/signup');
     await expect(
       artistProfiles.getByRole('link', { name: 'View example' })
@@ -338,68 +306,22 @@ test.describe('Homepage', () => {
       ).toBeGreaterThanOrEqual(image.requiredWidth);
     }
     // Spec wall section removed — JOV-2073
-    const pricing = page.getByTestId('homepage-v2-pricing');
-    await expect(pricing).toBeVisible();
-    await expect(
-      page.getByRole('heading', { name: 'Simple pricing' })
-    ).toBeVisible();
-    const freePricingCard = page.getByTestId('marketing-pricing-plan-free');
-    await expect(freePricingCard).toBeVisible();
-    await expect(
-      freePricingCard.getByText('Free forever', { exact: true })
-    ).toBeVisible();
-    await expect(
-      pricing.getByText('Artist profiles are free forever.')
-    ).toBeVisible();
-    await expect(page.getByTestId('marketing-pricing-plan-pro')).toBeVisible();
-    await expect(
-      page.getByTestId('marketing-pricing-plan-enterprise')
-    ).toHaveCount(0);
-    await expect(page.getByTestId('marketing-pricing-plan-team')).toHaveCount(
-      0
-    );
-    await expect(
-      page
-        .getByTestId('marketing-pricing-plan-pro')
-        .getByRole('link', { name: 'Request Access' })
-    ).toHaveAttribute('href', '/signup?plan=pro');
-    const pricingCtasOnGrid = await pricing
-      .locator('.marketing-pricing-plan-card')
-      .evaluateAll(cards =>
-        cards.map(card => {
-          const cta = card.querySelector<HTMLElement>(
-            '.marketing-pricing-plan-card__cta'
-          );
-          const cardRect = card.getBoundingClientRect();
-          const ctaRect = cta?.getBoundingClientRect();
-          if (!ctaRect) return false;
-          return (
-            Math.abs(
-              cardRect.left +
-                cardRect.width / 2 -
-                (ctaRect.left + ctaRect.width / 2)
-            ) <= 1 && ctaRect.right <= cardRect.right
-          );
-        })
-      );
-    expect(pricingCtasOnGrid).toEqual([true, true]);
-    await expect(page.getByTestId('homepage-faq')).toBeVisible();
-    await expect(
-      page.getByRole('heading', { name: 'Frequently Asked Questions' })
-    ).toBeVisible();
-
+    // Pricing and FAQ flagged off for prelaunch.
+    await expect(page.getByTestId('homepage-v2-pricing')).toHaveCount(0);
+    await expect(page.getByTestId('homepage-faq')).toHaveCount(0);
+    // Footer CTA on; label tracks WAITLIST_ENABLED (currently true).
     const finalCta = page.getByTestId('homepage-v2-final-cta');
     await finalCta.scrollIntoViewIfNeeded();
     await expect(finalCta).toBeVisible();
     await expect(page.getByTestId('homepage-v2-final-cta-heading')).toHaveText(
-      'Keep Your Music Moving.'
+      'Keep your music moving.'
+    );
+    await expect(page.getByTestId('homepage-v2-final-cta-primary')).toHaveText(
+      'Request access'
     );
     await expect(
       page.getByTestId('homepage-v2-final-cta-primary')
     ).toHaveAttribute('href', '/signup');
-    await expect(
-      page.getByTestId('homepage-v2-final-cta-secondary')
-    ).toHaveCount(0);
     const footer = page.getByTestId('marketing-footer');
     await expect(footer).toBeVisible();
     await expect(footer.getByRole('link', { name: 'Privacy' })).toHaveAttribute(
@@ -424,7 +346,9 @@ test.describe('Homepage', () => {
     await waitForHydration(page);
 
     await expect(
-      page.getByRole('heading', { name: 'Release more music with less work' })
+      page.getByRole('heading', {
+        name: 'Monetize your music catalog with AI',
+      })
     ).toBeVisible({
       timeout: SMOKE_TIMEOUTS.VISIBILITY,
     });
@@ -451,7 +375,7 @@ test.describe('Homepage', () => {
       0
     );
     await expect(
-      header.getByRole('link', { name: 'Start Free Trial', exact: true })
+      header.getByRole('link', { name: 'Request access', exact: true })
     ).toHaveAttribute('href', '/signup');
     await expect(
       header.getByRole('link', { name: 'Sign in', exact: true })

--- a/apps/web/tests/unit/marketing/homepage-v2-final-cta.test.tsx
+++ b/apps/web/tests/unit/marketing/homepage-v2-final-cta.test.tsx
@@ -9,10 +9,10 @@ describe('HomepageV2FinalCta', () => {
     expect(screen.getByTestId('homepage-v2-final-cta')).toBeInTheDocument();
     expect(
       screen.getByTestId('homepage-v2-final-cta-heading')
-    ).toHaveTextContent('Keep Your Music Moving.');
+    ).toHaveTextContent('Keep your music moving.');
     expect(
       screen.getByTestId('homepage-v2-final-cta-primary')
-    ).toBeInTheDocument();
+    ).toHaveTextContent('Request access');
     expect(
       screen.queryByTestId('homepage-v2-final-cta-secondary')
     ).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Tightens the homepage for prelaunch around catalog monetization and opportunity surfacing.
- Gates public front-door CTAs behind the static waitlist flag so homepage hero, header, artist-profile section, and footer CTA show Request access while waitlist is on.
- Flags off pricing, FAQ, AI composer demo, and 3-step go-live section for prelaunch while keeping the approved page flow.

Linear: JOV-1924

## Screenshots
- Desktop: apps/web/.context/homepage-prelaunch-qa/homepage-desktop-full.png
- Mobile: apps/web/.context/homepage-prelaunch-qa/homepage-mobile-full.png

## Verification
- pnpm biome check --write on the 10 edited files
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm --filter @jovie/web exec vitest run components/homepage/HomepageIntent.test.tsx tests/unit/marketing/homepage-v2-final-cta.test.tsx tests/unit/marketing/marketing-static-flags.test.ts tests/unit/components/site/MarketingHeader.test.tsx (24 tests passed)
- E2E_SKIP_WEB_SERVER=1 BASE_URL=http://localhost:3101 pnpm --filter @jovie/web exec playwright test tests/e2e/homepage.spec.ts --project=chromium --reporter=line (11 passed)
- git diff --check
- Commit/push hooks: proxy guard, Biome, ESLint, a11y staged lint, Tailwind guard, typecheck, Biome lint

## Visual QA
- Used existing watched Next server at http://localhost:3101 for desktop and mobile screenshots.
- Verified approved sections render in order and footer CTA says Request access.

## Risk
- Low-risk static homepage copy/flag/header CTA change. No schema, auth, billing, or server runtime changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Several homepage sections now render conditionally (prelaunch/waitlist gating); header/footer CTAs toggle between “Request access” and “Start free trial” and header CTA can be customized.

* **Style**
  * Updated homepage trust logo to a 5-column grid and refined go-live card heading spacing.

* **Content Updates**
  * Refreshed homepage copy and hero headline (prelaunch messaging shows “Request access” primary CTA).

* **Tests**
  * Unit and e2e tests updated to match prelaunch/waitlist UI and CTA text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8693)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->