### PR TITLE
JOV-2214: Address brand review feedback

### DIFF
--- a/apps/web/app/brand/page.tsx
+++ b/apps/web/app/brand/page.tsx
@@ -140,13 +140,7 @@ function HeroSection() {
     <section id='hero' className='px-6 pt-24 pb-8 md:px-8 md:pt-28 md:pb-10'>
       <div className='mx-auto grid min-h-[62svh] w-full max-w-[1180px] grid-cols-1 content-center gap-12 md:grid-cols-[minmax(0,1fr)_280px] md:gap-16'>
         <div className='max-w-[760px]'>
-          <h1
-            className='max-w-[720px] text-balance text-5xl font-bold leading-[0.96] text-[#F5F4F0] md:text-7xl lg:text-8xl'
-            style={{
-              fontFamily:
-                '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-            }}
-          >
+          <h1 className='max-w-[720px] text-balance font-sans text-5xl font-bold leading-[0.96] text-[#F5F4F0] md:text-7xl lg:text-8xl'>
             One loop. Every release.
           </h1>
           <div className='mt-8 max-w-[620px] space-y-4'>

--- a/apps/web/tests/e2e/brand-page.spec.ts
+++ b/apps/web/tests/e2e/brand-page.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from './setup';
+import { SMOKE_TIMEOUTS } from './utils/smoke-test-utils';
 
 test.use({ storageState: { cookies: [], origins: [] } });
 
@@ -15,6 +16,8 @@ test.describe('brand page', () => {
     }) => {
       await page.setViewportSize(viewport);
       await page.goto('/brand', { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForTimeout(SMOKE_TIMEOUTS.HYDRATION_SETTLE);
 
       await expect(
         page.getByRole('heading', { name: 'One loop. Every release.' })


### PR DESCRIPTION
## Summary
- removes the brand hero H1 inline font style in favor of the existing Tailwind font utility
- adds the shared hydration settle wait to the brand page scroll/overflow e2e spec

## Verification
- pnpm biome check apps/web/app/brand/page.tsx apps/web/tests/e2e/brand-page.spec.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm --filter @jovie/web exec vitest run tests/unit/app/brand/page.test.tsx tests/unit/marketing/static-revalidate-policy.test.ts scripts/performance-route-manifest.test.ts
- BASE_URL=http://localhost:3200 E2E_SKIP_WEB_SERVER=1 E2E_USE_TEST_AUTH_BYPASS=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 pnpm --filter @jovie/web exec playwright test tests/e2e/brand-page.spec.ts --project=chromium
- CI=true BASE_URL=http://localhost:3200 pnpm --filter @jovie/web run test:budgets -- --base-url http://localhost:3200 --route-id marketing-brand --runs 5
- BASE_URL=http://localhost:3200 E2E_SKIP_WEB_SERVER=1 pnpm --filter @jovie/web exec lhci autorun --config=.lighthouserc.public-launch.json --collect.url=http://localhost:3200/brand

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated brand page heading styling for consistency.

* **Tests**
  * Enhanced brand page test reliability with improved page load validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8695)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->