### PR TITLE
fix(billing): gate status error toast by surface

### DIFF
--- a/apps/web/components/organisms/user-button/useUserButton.ts
+++ b/apps/web/components/organisms/user-button/useUserButton.ts
@@ -43,7 +43,10 @@ export interface UseUserButtonReturn {
 }
 
 function isRoutePath(pathname: string | null | undefined, route: string) {
-  return pathname === route || pathname?.startsWith(`${route}/`);
+  return (
+    typeof pathname === 'string' &&
+    (pathname === route || pathname.startsWith(`${route}/`))
+  );
 }
 
 function isBillingOwnedSurface(pathname: string | null | undefined) {
@@ -95,8 +98,9 @@ export function useUserButton({
   const isDemoRoute = isDemoRoutePath(pathname);
   const billingStatusErrorToastSessionKey =
     getBillingStatusErrorToastSessionKey(user?.id);
+  const hasLoadedUser = isLoaded && Boolean(user?.id);
   const { data, isLoading, error } = useBillingStatusQuery({
-    enabled: !isPassiveRuntime && !isDemoRoute,
+    enabled: hasLoadedUser && !isPassiveRuntime && !isDemoRoute,
   });
   const shouldSurfaceBillingStatusError = isBillingOwnedSurface(pathname);
 
@@ -132,6 +136,7 @@ export function useUserButton({
 
   useEffect(() => {
     if (
+      hasLoadedUser &&
       billingStatus.error &&
       shouldSurfaceBillingStatusError &&
       !hasNotifiedBillingErrorThisSession(billingStatusErrorToastSessionKey)
@@ -145,6 +150,7 @@ export function useUserButton({
   }, [
     billingStatus.error,
     billingStatusErrorToastSessionKey,
+    hasLoadedUser,
     shouldSurfaceBillingStatusError,
   ]);
 

--- a/apps/web/components/organisms/user-button/useUserButton.ts
+++ b/apps/web/components/organisms/user-button/useUserButton.ts
@@ -53,27 +53,29 @@ function isBillingOwnedSurface(pathname: string | null | undefined) {
   );
 }
 
-function hasNotifiedBillingErrorThisSession() {
+function getBillingStatusErrorToastSessionKey(
+  userId: string | null | undefined
+) {
+  return userId
+    ? `${BILLING_STATUS_ERROR_TOAST_SESSION_KEY}:${userId}`
+    : BILLING_STATUS_ERROR_TOAST_SESSION_KEY;
+}
+
+function hasNotifiedBillingErrorThisSession(storageKey: string) {
   if (typeof window === 'undefined') return true;
 
   try {
-    return (
-      window.sessionStorage.getItem(BILLING_STATUS_ERROR_TOAST_SESSION_KEY) ===
-      'true'
-    );
+    return window.sessionStorage.getItem(storageKey) === 'true';
   } catch {
     return false;
   }
 }
 
-function markBillingErrorNotifiedThisSession() {
+function markBillingErrorNotifiedThisSession(storageKey: string) {
   if (typeof window === 'undefined') return;
 
   try {
-    window.sessionStorage.setItem(
-      BILLING_STATUS_ERROR_TOAST_SESSION_KEY,
-      'true'
-    );
+    window.sessionStorage.setItem(storageKey, 'true');
   } catch {
     // Storage can be unavailable in private browsing or constrained test envs.
   }
@@ -91,6 +93,8 @@ export function useUserButton({
   const [isFeedbackOpen, setIsFeedbackOpen] = useState(false);
   const isPassiveRuntime = env.IS_E2E;
   const isDemoRoute = isDemoRoutePath(pathname);
+  const billingStatusErrorToastSessionKey =
+    getBillingStatusErrorToastSessionKey(user?.id);
   const { data, isLoading, error } = useBillingStatusQuery({
     enabled: !isPassiveRuntime && !isDemoRoute,
   });
@@ -130,15 +134,19 @@ export function useUserButton({
     if (
       billingStatus.error &&
       shouldSurfaceBillingStatusError &&
-      !hasNotifiedBillingErrorThisSession()
+      !hasNotifiedBillingErrorThisSession(billingStatusErrorToastSessionKey)
     ) {
       toast.error(
         "Couldn't confirm your plan. Billing actions may be unavailable.",
         { duration: 6000, id: 'billing-status-error' }
       );
-      markBillingErrorNotifiedThisSession();
+      markBillingErrorNotifiedThisSession(billingStatusErrorToastSessionKey);
     }
-  }, [billingStatus.error, shouldSurfaceBillingStatusError]);
+  }, [
+    billingStatus.error,
+    billingStatusErrorToastSessionKey,
+    shouldSurfaceBillingStatusError,
+  ]);
 
   // User display info - upgrade OAuth avatar to high resolution
   const userImageUrl = useMemo(

--- a/apps/web/components/organisms/user-button/useUserButton.ts
+++ b/apps/web/components/organisms/user-button/useUserButton.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { APP_ROUTES, isDemoRoutePath } from '@/constants/routes';
 import { useAuthSafe, useUserSafe } from '@/hooks/useClerkSafe';
@@ -11,6 +11,9 @@ import { upgradeOAuthAvatarUrl } from '@/lib/utils/avatar-url';
 import type { Artist } from '@/types/db';
 import { useUserMenuActions } from '../useUserMenuActions';
 import type { UserDisplayInfo } from './types';
+
+const BILLING_STATUS_ERROR_TOAST_SESSION_KEY =
+  'jovie:billing-status-error-toast-shown';
 
 export interface UseUserButtonProps {
   readonly artist?: Artist | null;
@@ -39,6 +42,43 @@ export interface UseUserButtonReturn {
   menuActions: ReturnType<typeof useUserMenuActions>;
 }
 
+function isRoutePath(pathname: string | null | undefined, route: string) {
+  return pathname === route || pathname?.startsWith(`${route}/`);
+}
+
+function isBillingOwnedSurface(pathname: string | null | undefined) {
+  return (
+    isRoutePath(pathname, APP_ROUTES.BILLING) ||
+    isRoutePath(pathname, APP_ROUTES.SETTINGS_BILLING)
+  );
+}
+
+function hasNotifiedBillingErrorThisSession() {
+  if (typeof window === 'undefined') return true;
+
+  try {
+    return (
+      window.sessionStorage.getItem(BILLING_STATUS_ERROR_TOAST_SESSION_KEY) ===
+      'true'
+    );
+  } catch {
+    return false;
+  }
+}
+
+function markBillingErrorNotifiedThisSession() {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.sessionStorage.setItem(
+      BILLING_STATUS_ERROR_TOAST_SESSION_KEY,
+      'true'
+    );
+  } catch {
+    // Storage can be unavailable in private browsing or constrained test envs.
+  }
+}
+
 export function useUserButton({
   artist,
   profileHref,
@@ -54,7 +94,7 @@ export function useUserButton({
   const { data, isLoading, error } = useBillingStatusQuery({
     enabled: !isPassiveRuntime && !isDemoRoute,
   });
-  const billingErrorNotifiedRef = useRef(false);
+  const shouldSurfaceBillingStatusError = isBillingOwnedSurface(pathname);
 
   // Normalize error to string without nested ternary
   const errorMessage = (() => {
@@ -87,18 +127,18 @@ export function useUserButton({
   };
 
   useEffect(() => {
-    if (billingStatus.error && !billingErrorNotifiedRef.current) {
+    if (
+      billingStatus.error &&
+      shouldSurfaceBillingStatusError &&
+      !hasNotifiedBillingErrorThisSession()
+    ) {
       toast.error(
         "Couldn't confirm your plan. Billing actions may be unavailable.",
         { duration: 6000, id: 'billing-status-error' }
       );
-      billingErrorNotifiedRef.current = true;
+      markBillingErrorNotifiedThisSession();
     }
-
-    if (!billingStatus.error) {
-      billingErrorNotifiedRef.current = false;
-    }
-  }, [billingStatus.error]);
+  }, [billingStatus.error, shouldSurfaceBillingStatusError]);
 
   // User display info - upgrade OAuth avatar to high resolution
   const userImageUrl = useMemo(

--- a/apps/web/tests/components/user-button.test.tsx
+++ b/apps/web/tests/components/user-button.test.tsx
@@ -378,6 +378,19 @@ describe('UserButton billing actions', () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
+  it('does not show the passive billing-status toast while the pathname is unavailable', () => {
+    mockUsePathname.mockReturnValue(null);
+    mockUseBillingStatusQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error('Billing unavailable'),
+    } as any);
+
+    render(<UserButton showUserInfo />);
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
   it('shows the passive billing-status toast on billing surfaces', () => {
     mockUsePathname.mockReturnValue('/billing');
     mockUseBillingStatusQuery.mockReturnValue({
@@ -441,6 +454,59 @@ describe('UserButton billing actions', () => {
     render(<UserButton showUserInfo />);
 
     expect(toast.error).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits for the loaded user before showing the passive billing-status toast', () => {
+    mockUsePathname.mockReturnValue('/billing');
+    mockUseBillingStatusQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error('Billing unavailable'),
+    } as any);
+    mockUseUserSafe.mockReturnValue({
+      isLoaded: false,
+      isSignedIn: false,
+      user: null,
+    } as any);
+
+    const { rerender } = render(<UserButton showUserInfo />);
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(mockUseBillingStatusQuery).toHaveBeenLastCalledWith({
+      enabled: false,
+    });
+
+    mockUseUserSafe.mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+      user: {
+        id: 'user_123',
+        imageUrl: null,
+        fullName: 'Adele Adkins',
+        firstName: 'Adele',
+        emailAddresses: [{ emailAddress: 'adele@example.com' }],
+        primaryEmailAddress: { emailAddress: 'adele@example.com' },
+      } as any,
+    });
+
+    rerender(<UserButton showUserInfo />);
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(mockUseBillingStatusQuery).toHaveBeenLastCalledWith({
+      enabled: true,
+    });
+    expect(
+      window.sessionStorage.getItem('jovie:billing-status-error-toast-shown')
+    ).toBeNull();
+    expect(
+      window.sessionStorage.getItem(
+        'jovie:billing-status-error-toast-shown:user_123'
+      )
+    ).toBe('true');
+
+    rerender(<UserButton showUserInfo />);
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
   it('renders a custom trigger while user data is still loading', () => {

--- a/apps/web/tests/components/user-button.test.tsx
+++ b/apps/web/tests/components/user-button.test.tsx
@@ -49,7 +49,8 @@ vi.mock('@/lib/analytics', () => ({
   track: vi.fn(),
 }));
 
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 import { UserButton } from '@/components/organisms/user-button';
 import { useAuthSafe, useUserSafe } from '@/hooks/useClerkSafe';
 import { track } from '@/lib/analytics';
@@ -74,6 +75,7 @@ const mockUsePortalMutation = vi.mocked(usePortalMutation);
 const mockUseUserSafe = vi.mocked(useUserSafe);
 const mockUseAuthSafe = vi.mocked(useAuthSafe);
 const mockUseRouter = vi.mocked(useRouter);
+const mockUsePathname = vi.mocked(usePathname);
 
 const originalLocation = window.location;
 
@@ -83,6 +85,7 @@ describe('UserButton billing actions', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    window.sessionStorage.clear();
 
     fetchMock = vi.fn();
     vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock);
@@ -158,6 +161,7 @@ describe('UserButton billing actions', () => {
     mockUseRouter.mockReturnValue({
       push: pushMock,
     } as any);
+    mockUsePathname.mockReturnValue('/app');
 
     mockUseBillingStatusQuery.mockReset();
 
@@ -358,6 +362,53 @@ describe('UserButton billing actions', () => {
       'billing_manage_billing_redirected',
       expect.any(Object)
     );
+  });
+
+  it('does not show the passive billing-status toast on admin surfaces', () => {
+    mockUsePathname.mockReturnValue('/app/admin');
+    mockUseBillingStatusQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error('Billing unavailable'),
+    } as any);
+
+    render(<UserButton showUserInfo />);
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('shows the passive billing-status toast on billing surfaces', () => {
+    mockUsePathname.mockReturnValue('/billing');
+    mockUseBillingStatusQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error('Billing unavailable'),
+    } as any);
+
+    render(<UserButton showUserInfo />);
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't confirm your plan. Billing actions may be unavailable.",
+      { duration: 6000, id: 'billing-status-error' }
+    );
+  });
+
+  it('does not repeat the passive billing-status toast after remounting in the same browser session', () => {
+    mockUsePathname.mockReturnValue('/app/settings/billing');
+    mockUseBillingStatusQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error('Billing unavailable'),
+    } as any);
+
+    const firstRender = render(<UserButton showUserInfo />);
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+
+    firstRender.unmount();
+    render(<UserButton showUserInfo />);
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
   });
 
   it('renders a custom trigger while user data is still loading', () => {

--- a/apps/web/tests/components/user-button.test.tsx
+++ b/apps/web/tests/components/user-button.test.tsx
@@ -134,6 +134,7 @@ describe('UserButton billing actions', () => {
       isLoaded: true,
       isSignedIn: true,
       user: {
+        id: 'user_123',
         imageUrl: null,
         fullName: 'Adele Adkins',
         firstName: 'Adele',
@@ -409,6 +410,37 @@ describe('UserButton billing actions', () => {
     render(<UserButton showUserInfo />);
 
     expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not suppress the passive billing-status toast for a different user in the same browser session', () => {
+    mockUsePathname.mockReturnValue('/app/settings/billing');
+    mockUseBillingStatusQuery.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: new Error('Billing unavailable'),
+    } as any);
+
+    const firstRender = render(<UserButton showUserInfo />);
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+
+    firstRender.unmount();
+    mockUseUserSafe.mockReturnValue({
+      isLoaded: true,
+      isSignedIn: true,
+      user: {
+        id: 'user_456',
+        imageUrl: null,
+        fullName: 'Beyonce Knowles',
+        firstName: 'Beyonce',
+        emailAddresses: [{ emailAddress: 'beyonce@example.com' }],
+        primaryEmailAddress: { emailAddress: 'beyonce@example.com' },
+      } as any,
+    });
+
+    render(<UserButton showUserInfo />);
+
+    expect(toast.error).toHaveBeenCalledTimes(2);
   });
 
   it('renders a custom trigger while user data is still loading', () => {


### PR DESCRIPTION
## Summary
- Gates the passive billing-status error toast to loaded billing-owned flows only.
- Stores the passive billing-status toast sentinel in `sessionStorage` per user, so same-session remounts do not re-fire while account switches can still notify.
- Disables the passive billing-status query until Clerk has a loaded user id, preventing pre-auth billing errors from being surfaced later.
- Adds regressions for admin/non-billing surfaces, unavailable pathname, billing surfaces, same-session remounts, different users, and Clerk loading-to-user transitions.

## Verification
- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh` — passed; dependencies unchanged, `pnpm install` skipped.
- `JOVIE_AGENT_PROFILE=coder git fetch origin main && git merge origin/main --no-edit` — passed, no conflicts.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/components/user-button.test.tsx` — passed, 11 tests.
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/organisms/user-button/useUserButton.ts apps/web/tests/components/user-button.test.tsx` — passed, no fixes applied.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- Commit hooks on `1cb921e4a` — passed: `next:proxy-guard`, staged Biome, ESLint, staged a11y check, web typecheck.
- Push hook on `1cb921e4a` — passed: full Biome, `next:proxy-guard`, `tailwind:check`, web typecheck, web lint.
- gstack `/review` adversarial diff review — found the pre-auth stale-error path; fixed in `1cb921e4a` by gating the query on loaded `user.id`.

## PR status
- Head SHA: `1cb921e4a878857705e237e16823b7639a1cd739`.
- `testing` label is present.
- Latest GitHub CI is running on the refreshed head, so previous Lighthouse/mobile/preview failures from `99dac72cb` are stale and being retested.
- Greptile posted only trial-ended notices; no actionable Greptile code comments found.
- CodeRabbit/Sentry actionable billing-toast comments are addressed by `a8dbf9bc7` and `1cb921e4a`.
- Leave unmerged/manual-review gated because this is billing-adjacent.

## Linear
- Issue: JOV-2112
- URL: https://linear.app/jovie/issue/JOV-2112/bug-p1-spurious-billing-toast-fires-on-admin-login-session-lifecycle

<!-- linear-issue-id:ae299ebf-08db-44cd-a22e-cb2027c1a53f -->
<!-- linear-issue-identifier:JOV-2112 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Billing error notifications now appear only once per browser session and only on billing-related pages, are suppressed on admin/demo routes, and won't show before user data finishes loading.
  * Notifications will reappear appropriately if the signed-in user changes within the same session.

* **Tests**
  * Expanded tests to ensure deterministic, pathname-aware billing notification behavior and session-based suppression.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->