### PR TITLE
fix(auth): stabilize Clerk last-used badge layout

### DIFF
--- a/apps/web/components/features/auth/AuthShell.tsx
+++ b/apps/web/components/features/auth/AuthShell.tsx
@@ -12,6 +12,45 @@ import { buildDisabledOAuthProviderElements } from '@/lib/auth/oauth-providers';
 
 export type AuthShellMode = 'sign-in' | 'sign-up';
 
+type ClerkAppearanceElements = Record<string, unknown>;
+
+const REQUIRED_CLERK_AUTH_ELEMENTS = {
+  socialButtonsBlockButton: {
+    alignItems: 'center',
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1fr) auto',
+    overflow: 'visible',
+  },
+  lastAuthenticationStrategyBadge: {
+    alignSelf: 'center',
+    gridColumn: '2',
+    justifySelf: 'end',
+    order: 2,
+    pointerEvents: 'none',
+    position: 'static',
+    transform: 'none',
+    whiteSpace: 'nowrap',
+  },
+} as const satisfies ClerkAppearanceElements;
+
+function mergeRequiredClerkElement(
+  baseElement: unknown,
+  requiredElement: Readonly<Record<string, unknown>>
+) {
+  if (
+    typeof baseElement === 'object' &&
+    baseElement !== null &&
+    !Array.isArray(baseElement)
+  ) {
+    return {
+      ...baseElement,
+      ...requiredElement,
+    };
+  }
+
+  return requiredElement;
+}
+
 interface AuthShellProps {
   /** Which Clerk flow to render. */
   readonly mode: AuthShellMode;
@@ -35,8 +74,9 @@ interface AuthShellProps {
   readonly compact?: boolean;
   /**
    * Clerk appearance override. Merged with the canonical
-   * `buildDisabledOAuthProviderElements()` map so disabled providers stay
-   * hidden even when callers pass their own appearance.
+   * `buildDisabledOAuthProviderElements()` map and required auth layout guards
+   * so disabled providers stay hidden and Clerk's "Last used" badge cannot
+   * overlap the provider button row when callers pass their own appearance.
    */
   readonly appearance?: Record<string, unknown>;
   /**
@@ -97,11 +137,19 @@ export function AuthShell({
   const mergedAppearance = useMemo(() => {
     const providerGuard = buildDisabledOAuthProviderElements();
     const baseElements =
-      (appearance?.elements as Record<string, string> | undefined) ?? {};
+      (appearance?.elements as ClerkAppearanceElements | undefined) ?? {};
     return {
       ...appearance,
       elements: {
         ...baseElements,
+        socialButtonsBlockButton: mergeRequiredClerkElement(
+          baseElements.socialButtonsBlockButton,
+          REQUIRED_CLERK_AUTH_ELEMENTS.socialButtonsBlockButton
+        ),
+        lastAuthenticationStrategyBadge: mergeRequiredClerkElement(
+          baseElements.lastAuthenticationStrategyBadge,
+          REQUIRED_CLERK_AUTH_ELEMENTS.lastAuthenticationStrategyBadge
+        ),
         ...providerGuard,
       },
     } as Record<string, unknown>;

--- a/apps/web/tests/unit/auth/AuthShell.test.tsx
+++ b/apps/web/tests/unit/auth/AuthShell.test.tsx
@@ -1,0 +1,80 @@
+import { render, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { clerkSignInMock, searchParamsState } = vi.hoisted(() => ({
+  clerkSignInMock: vi.fn(),
+  searchParamsState: { value: '' },
+}));
+
+vi.mock('@clerk/nextjs', () => ({
+  SignIn: (props: unknown) => {
+    clerkSignInMock(props);
+    return <div data-testid='clerk-sign-in' />;
+  },
+  SignUp: () => <div data-testid='clerk-sign-up' />,
+}));
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(searchParamsState.value),
+}));
+
+import { AuthShell } from '@/features/auth';
+
+describe('AuthShell Clerk appearance guards', () => {
+  beforeEach(() => {
+    clerkSignInMock.mockReset();
+    searchParamsState.value = '';
+  });
+
+  it('keeps required provider and last-used badge layout guards after caller overrides', async () => {
+    render(
+      <AuthShell
+        mode='sign-in'
+        appearance={{
+          elements: {
+            lastAuthenticationStrategyBadge: {
+              position: 'absolute',
+              transform: 'translate(10px, -50%)',
+            },
+            socialButtonsBlockButton: {
+              backgroundColor: 'rgb(1, 2, 3)',
+              display: 'flex',
+              overflow: 'hidden',
+            },
+            socialButtonsBlockButton__facebook: 'block',
+          },
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(clerkSignInMock).toHaveBeenCalledTimes(1);
+    });
+
+    const signInProps = clerkSignInMock.mock.calls[0]?.[0] as {
+      readonly appearance?: {
+        readonly elements?: Record<string, unknown>;
+      };
+    };
+    const elements = signInProps.appearance?.elements;
+
+    expect(elements?.socialButtonsBlockButton).toEqual(
+      expect.objectContaining({
+        backgroundColor: 'rgb(1, 2, 3)',
+        display: 'grid',
+        gridTemplateColumns: 'minmax(0, 1fr) auto',
+        overflow: 'visible',
+      })
+    );
+    expect(elements?.lastAuthenticationStrategyBadge).toEqual(
+      expect.objectContaining({
+        gridColumn: '2',
+        order: 2,
+        position: 'static',
+        transform: 'none',
+        whiteSpace: 'nowrap',
+      })
+    );
+    expect(elements?.socialButtonsBlockButton__facebook).toBe('hidden');
+  });
+});


### PR DESCRIPTION
## Summary
- Hardens the canonical AuthShell Clerk appearance merge so provider buttons always use a two-column layout that reserves space for Clerk's Last used badge.
- Forces the Last used badge back into static grid flow when caller appearance overrides would otherwise position or transform it over the button row.
- Adds a mocked AuthShell regression test proving caller overrides cannot remove the badge/button guards and disabled-provider guards still win.

## Verification
- `./scripts/setup.sh`
- `pnpm install --frozen-lockfile`
- `pnpm --filter web exec vitest run tests/unit/auth/AuthShell.test.tsx` — 1 test passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- `pnpm biome check --write apps/web/components/features/auth/AuthShell.tsx apps/web/tests/unit/auth/AuthShell.test.tsx` — passed
- pre-commit hook: proxy guard, Biome, ESLint, staged a11y check, web typecheck — passed
- pre-push hook: full Biome check, proxy guard, Tailwind guard, web typecheck, web lint — passed

Resolves JOV-2111.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved authentication interface layout issues where disabled OAuth provider options were not properly hidden and interface elements could overlap the provider selection area.

## Tests
* Added unit tests to verify authentication interface appearance and layout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8700)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->