### PR TITLE
fix(billing): lock pricing entitlement contracts

### DIFF
--- a/apps/web/app/api/max-access-request/route.ts
+++ b/apps/web/app/api/max-access-request/route.ts
@@ -11,6 +11,7 @@ import { z } from 'zod';
 import { requireAuth } from '@/lib/auth/require-auth';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema/auth';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 import { captureError } from '@/lib/error-tracking';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
 import { notifySlackGrowthRequest } from '@/lib/notifications/providers/slack';
@@ -40,6 +41,7 @@ export async function POST(request: Request) {
     }
 
     const { reason } = parsed.data;
+    const entitlements = await getCurrentUserEntitlements();
 
     // Look up the user
     const [user] = await db
@@ -61,8 +63,8 @@ export async function POST(request: Request) {
       );
     }
 
-    // Check if already on Max plan (or legacy Growth plan)
-    if (user.plan === 'max' || user.plan === 'growth') {
+    // Check if already on Max-level entitlements.
+    if (entitlements.hasAdvancedFeatures) {
       return NextResponse.json(
         { error: 'You already have the Max plan' },
         { status: 400, headers: NO_STORE_HEADERS }

--- a/apps/web/app/api/max-access-request/route.ts
+++ b/apps/web/app/api/max-access-request/route.ts
@@ -66,7 +66,7 @@ export async function POST(request: Request) {
     // Check if already on Max-level entitlements.
     if (entitlements.hasAdvancedFeatures) {
       return NextResponse.json(
-        { error: 'You already have the Max plan' },
+        { error: 'You already have Max access' },
         { status: 400, headers: NO_STORE_HEADERS }
       );
     }

--- a/apps/web/tests/unit/api/max-access-request.test.ts
+++ b/apps/web/tests/unit/api/max-access-request.test.ts
@@ -115,7 +115,7 @@ describe('POST /api/max-access-request', () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
-      error: 'You already have the Max plan',
+      error: 'You already have Max access',
     });
     expect(hoisted.getCurrentUserEntitlementsMock).toHaveBeenCalledOnce();
     expect(hoisted.updateSetMock).not.toHaveBeenCalled();

--- a/apps/web/tests/unit/api/max-access-request.test.ts
+++ b/apps/web/tests/unit/api/max-access-request.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  eqMock: vi.fn(() => 'where-clause'),
+  requireAuthMock: vi.fn(),
+  getCurrentUserEntitlementsMock: vi.fn(),
+  selectFromMock: vi.fn(),
+  selectWhereMock: vi.fn(),
+  selectLimitMock: vi.fn(),
+  updateSetMock: vi.fn(),
+  updateWhereMock: vi.fn(),
+  notifySlackGrowthRequestMock: vi.fn(),
+  loggerInfoMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+  captureErrorMock: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: hoisted.eqMock,
+}));
+
+vi.mock('@/lib/auth/require-auth', () => ({
+  requireAuth: hoisted.requireAuthMock,
+}));
+
+vi.mock('@/lib/entitlements/server', () => ({
+  getCurrentUserEntitlements: hoisted.getCurrentUserEntitlementsMock,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: hoisted.selectFromMock,
+    })),
+    update: vi.fn(() => ({
+      set: hoisted.updateSetMock,
+    })),
+  },
+}));
+
+vi.mock('@/lib/db/schema/auth', () => ({
+  users: {
+    id: 'id',
+    name: 'name',
+    email: 'email',
+    plan: 'plan',
+    clerkId: 'clerkId',
+    growthAccessRequestedAt: 'growthAccessRequestedAt',
+  },
+}));
+
+vi.mock('@/lib/notifications/providers/slack', () => ({
+  notifySlackGrowthRequest: hoisted.notifySlackGrowthRequestMock,
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    info: hoisted.loggerInfoMock,
+    error: hoisted.loggerErrorMock,
+  },
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: hoisted.captureErrorMock,
+}));
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/max-access-request', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/max-access-request', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    hoisted.requireAuthMock.mockResolvedValue({
+      userId: 'clerk_123',
+      error: null,
+    });
+    hoisted.getCurrentUserEntitlementsMock.mockResolvedValue({
+      hasAdvancedFeatures: false,
+    });
+    hoisted.selectFromMock.mockReturnValue({
+      where: hoisted.selectWhereMock,
+    });
+    hoisted.selectWhereMock.mockReturnValue({
+      limit: hoisted.selectLimitMock,
+    });
+    hoisted.selectLimitMock.mockResolvedValue([
+      {
+        id: 'user_123',
+        name: 'Test Artist',
+        email: 'artist@example.com',
+        plan: 'pro',
+        growthAccessRequestedAt: null,
+      },
+    ]);
+    hoisted.updateSetMock.mockReturnValue({
+      where: hoisted.updateWhereMock,
+    });
+    hoisted.updateWhereMock.mockResolvedValue(undefined);
+    hoisted.notifySlackGrowthRequestMock.mockResolvedValue(undefined);
+  });
+
+  it('blocks users who already have Max-level entitlements', async () => {
+    hoisted.getCurrentUserEntitlementsMock.mockResolvedValue({
+      hasAdvancedFeatures: true,
+    });
+
+    const { POST } = await import('@/app/api/max-access-request/route');
+    const response = await POST(makeRequest({ reason: 'Need API access' }));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'You already have the Max plan',
+    });
+    expect(hoisted.getCurrentUserEntitlementsMock).toHaveBeenCalledOnce();
+    expect(hoisted.updateSetMock).not.toHaveBeenCalled();
+    expect(hoisted.notifySlackGrowthRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('stores a request for authenticated users without Max-level entitlements', async () => {
+    const { POST } = await import('@/app/api/max-access-request/route');
+    const response = await POST(makeRequest({ reason: 'Need API access' }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+    expect(hoisted.updateSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        growthAccessReason: 'Need API access',
+      })
+    );
+    expect(hoisted.notifySlackGrowthRequestMock).toHaveBeenCalledWith(
+      'Test Artist',
+      'artist@example.com',
+      'pro',
+      'Need API access'
+    );
+  });
+});

--- a/apps/web/tests/unit/pricing/pricing-source-of-truth.test.ts
+++ b/apps/web/tests/unit/pricing/pricing-source-of-truth.test.ts
@@ -1,5 +1,5 @@
 /**
- * Pricing source of truth contract tests (JOV-2079)
+ * Pricing source of truth contract tests (JOV-2178)
  *
  * Enforces:
  * - CANONICAL_PLANS in constants/plans.ts matches the entitlement registry plan IDs
@@ -62,7 +62,7 @@ const MAX_ONLY_MARKETING_FEATURES = [
   },
 ] as const;
 
-describe('CANONICAL_PLANS (constants/plans.ts) — source of truth (JOV-2079)', () => {
+describe('CANONICAL_PLANS (constants/plans.ts) — source of truth (JOV-2178)', () => {
   it('contains exactly the three billing plan tiers: free, pro, max', () => {
     expect(CANONICAL_PLAN_IDS).toEqual(['free', 'pro', 'max']);
   });
@@ -141,7 +141,7 @@ describe('CANONICAL_PLANS (constants/plans.ts) — source of truth (JOV-2079)', 
   });
 });
 
-describe('MARKETING_PRICING_PLANS (data/marketingPricingPlans.ts) — contract (JOV-2079)', () => {
+describe('MARKETING_PRICING_PLANS (data/marketingPricingPlans.ts) — contract (JOV-2178)', () => {
   it('only contains plan IDs that exist in the entitlement registry', () => {
     const validPlanIds = new Set<string>(Object.keys(ENTITLEMENT_REGISTRY));
     for (const plan of MARKETING_PRICING_PLANS) {

--- a/apps/web/tests/unit/pricing/pricing-source-of-truth.test.ts
+++ b/apps/web/tests/unit/pricing/pricing-source-of-truth.test.ts
@@ -11,9 +11,17 @@
 
 import { describe, expect, it } from 'vitest';
 import { CANONICAL_PLAN_IDS, CANONICAL_PLANS } from '@/constants/plans';
-import { MARKETING_PRICING_PLANS } from '@/data/marketingPricingPlans';
+import {
+  getMarketingPlanHref,
+  getVisibleMarketingPricingPlans,
+  MARKETING_PRICING_PLAN_IDS,
+  MARKETING_PRICING_PLANS,
+} from '@/data/marketingPricingPlans';
 import { PLAN_PRICES } from '@/lib/config/plan-prices';
-import { ENTITLEMENT_REGISTRY } from '@/lib/entitlements/registry';
+import {
+  ENTITLEMENT_REGISTRY,
+  resolveCanonicalPlanId,
+} from '@/lib/entitlements/registry';
 
 // Phrases banned from any public pricing CTA or label
 const BANNED_PRICING_PHRASES = [
@@ -21,6 +29,37 @@ const BANNED_PRICING_PHRASES = [
   'request access',
   'request_access',
   'coming soon',
+] as const;
+
+const MAX_ONLY_MARKETING_FEATURES = [
+  {
+    label: 'Release plan generation',
+    entitlement: 'canGenerateReleasePlans',
+  },
+  {
+    label: 'Metadata submission agent',
+    entitlement: 'canAccessMetadataSubmissionAgent',
+  },
+  {
+    label: 'Email campaigns',
+    entitlement: 'canAccessEmailCampaigns',
+  },
+  {
+    label: 'Fan subscriptions',
+    entitlement: 'canAccessFanSubscriptions',
+  },
+  {
+    label: 'API access',
+    entitlement: 'canAccessApiKeys',
+  },
+  {
+    label: 'Team management',
+    entitlement: 'canAccessTeamManagement',
+  },
+  {
+    label: 'White-label / custom domain',
+    entitlement: 'canAccessWhiteLabel',
+  },
 ] as const;
 
 describe('CANONICAL_PLANS (constants/plans.ts) — source of truth (JOV-2079)', () => {
@@ -104,13 +143,27 @@ describe('CANONICAL_PLANS (constants/plans.ts) — source of truth (JOV-2079)', 
 
 describe('MARKETING_PRICING_PLANS (data/marketingPricingPlans.ts) — contract (JOV-2079)', () => {
   it('only contains plan IDs that exist in the entitlement registry', () => {
-    const validPlanIds = new Set<string>(['free', 'pro', 'max']);
+    const validPlanIds = new Set<string>(Object.keys(ENTITLEMENT_REGISTRY));
     for (const plan of MARKETING_PRICING_PLANS) {
       expect(
         validPlanIds.has(plan.id),
         `Marketing plan "${plan.id}" is not a valid entitlement registry plan ID`
       ).toBe(true);
     }
+  });
+
+  it('uses the canonical public billing tiers and visible pricing excludes legacy tiers', () => {
+    expect(MARKETING_PRICING_PLAN_IDS).toEqual(['free', 'pro', 'max']);
+    expect(MARKETING_PRICING_PLANS.map(plan => plan.id)).toEqual([
+      'free',
+      'pro',
+      'max',
+    ]);
+    expect(getVisibleMarketingPricingPlans().map(plan => plan.id)).toEqual([
+      'free',
+      'pro',
+      'max',
+    ]);
   });
 
   it('no CTA label or badge uses banned waitlist/request-access phrases', () => {
@@ -133,6 +186,12 @@ describe('MARKETING_PRICING_PLANS (data/marketingPricingPlans.ts) — contract (
         plan.ctaHref,
         `Marketing plan "${plan.id}" ctaHref must include ?plan= so onboarding can read intent`
       ).toContain(`plan=${plan.id}`);
+
+      const signupUrl = new URL(plan.ctaHref, 'https://jov.ie');
+      expect(resolveCanonicalPlanId(signupUrl.searchParams.get('plan'))).toBe(
+        plan.id
+      );
+      expect(getMarketingPlanHref(plan.id)).toBe(plan.ctaHref);
     }
   });
 
@@ -150,6 +209,27 @@ describe('MARKETING_PRICING_PLANS (data/marketingPricingPlans.ts) — contract (
     const planIds = MARKETING_PRICING_PLANS.map(p => p.id);
     expect(planIds).not.toContain('team');
     expect(planIds).not.toContain('enterprise');
+  });
+
+  it('does not advertise Max-only release operations on Pro', () => {
+    const proPlan = MARKETING_PRICING_PLANS.find(p => p.id === 'pro');
+    const maxPlan = MARKETING_PRICING_PLANS.find(p => p.id === 'max');
+    expect(proPlan).toBeDefined();
+    expect(maxPlan).toBeDefined();
+
+    for (const { label, entitlement } of MAX_ONLY_MARKETING_FEATURES) {
+      expect(
+        ENTITLEMENT_REGISTRY.pro.booleans[entitlement],
+        `${label} must remain disabled for Pro in the entitlement registry`
+      ).toBe(false);
+      expect(
+        ENTITLEMENT_REGISTRY.max.booleans[entitlement],
+        `${label} must remain enabled for Max in the entitlement registry`
+      ).toBe(true);
+      expect(proPlan?.features).not.toContain(label);
+      expect(maxPlan?.features).toContain(label);
+      expect(ENTITLEMENT_REGISTRY.max.marketing.features).toContain(label);
+    }
   });
 
   it('has non-empty features list for every plan (no silent drift from canonical plans)', () => {


### PR DESCRIPTION
## Summary
- Locks public pricing contracts to canonical Free / Pro / Max tiers and asserts visible marketing plans, CTA plan params, PlanId resolution, prices, and Max-only features stay aligned with `ENTITLEMENT_REGISTRY`.
- Keeps Stripe checkout mapping coverage tied to Pro / Max price IDs and entitlement registry coverage tied to `getCurrentUserEntitlements()`.
- Replaces raw Max/Growth plan string checks in `/api/max-access-request` with `getCurrentUserEntitlements()` and returns access-oriented copy for Max-level entitlement holders.

## Verification
- `./scripts/setup.sh` — passed; dependencies unchanged, setup skipped install.
- `pnpm --filter web exec vitest run tests/unit/pricing/pricing-source-of-truth.test.ts tests/unit/api/max-access-request.test.ts` — 20 tests passed.
- `pnpm --filter web exec vitest run tests/unit/api/stripe/pricing-options.test.ts tests/unit/api/stripe/checkout.test.ts` — 9 tests passed.
- `pnpm --filter web exec vitest run tests/unit/lib/entitlement-registry.test.ts tests/unit/lib/entitlements.server.test.ts` — 38 tests passed.
- `pnpm biome check --write apps/web/app/api/max-access-request/route.ts apps/web/tests/unit/pricing/pricing-source-of-truth.test.ts apps/web/tests/unit/api/max-access-request.test.ts` — passed, no fixes applied.
- `pnpm biome check apps/web` — passed, 5396 files checked.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- pre-commit hook — passed proxy guard, Biome, ESLint, and web typecheck.
- pre-push hook — passed full Biome, proxy guard, Tailwind guard, web typecheck, and web lint.
- gstack `/review` — passed; clean review logged at `6481caa03`.
- gstack `/ship` — passed to PR refresh; merged latest `origin/main`, committed `6481caa03`, pushed branch, PR remains open with `testing` and `needs-human`.

## PR Status
- Branch was refreshed from `origin/main` and pushed at commit `6481caa030e98ed38b06acb464e4c6b716d5c2e7`; auto-merge is not enabled.
- Product contract blockers found locally: none. The JOV-2178 contract tests cover visible Free / Pro / Max pricing, CTA plan params, checkout price mapping, PlanId resolution, and `getCurrentUserEntitlements()` alignment.
- CodeRabbit actionable comment was addressed in `apps/web/app/api/max-access-request/route.ts`; no Greptile actionable comments were found.
- Fresh CI run `25937747041` retested the previously stale shared lanes on this head.
- Shared mobile blocker: `Mobile Overflow Guard (320px)`, `(390px)`, and `(430px)` all fail in `pnpm --filter=@jovie/web run mobile-overflow:guard` before Playwright, with the exact static finding `apps/web/components/features/demo/FounderDemoRecordingSurface.tsx:340 w-screen`. This file is outside the JOV-2178 pricing/entitlements diff.
- CI infra/API-key blockers: `E2E DB Migrate` fails after 12 Neon retries with `password authentication failed for user 'neondb_owner'`; `Extended Smoke (Preview)` fails during `drizzle:migrate:ci` with `The requested endpoint could not be found, or you don't have access to it`; `E2E Smoke (PR Fast Feedback)` fails in dev-test-auth/session and dashboard smoke with Neon endpoint/password errors plus `/app` and `/app/chat` 500s.
- Pending shared lane: `Lighthouse (public routes PR)` is still `in_progress` on run `25937747041` as of the latest poll after 19:55 UTC on May 15, 2026.
- Manual review gate: required for pricing/entitlement behavior; leave this PR open for human review.

Resolves JOV-2178.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Use current entitlements to determine Max access for requests, improving accuracy of access checks
  * Tightened pricing tier handling and marketing plan presentation

* **Tests**
  * Added unit tests covering Max access request flows (already-has-access vs request submission)
  * Expanded pricing/marketing contract tests to validate plan visibility, features, and signup URLs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8701)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
