### PR TITLE
fix(auth): keep earnings redirects auth-aware

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -252,22 +252,17 @@ const nextConfig = {
       { source: '/app/profile', destination: '/app/chat?panel=profile' },
       { source: '/app/contacts', destination: '/app/settings/contacts' },
       {
-        source: '/app/earnings',
-        destination: '/app/settings/artist-profile?tab=earn#pay',
-      },
-      {
         source: '/app/tipping',
         destination: '/app/settings/artist-profile?tab=earn#pay',
       },
       { source: '/app/tour-dates', destination: '/app/settings/touring' },
       { source: '/app/dashboard', destination: '/app' },
       { source: '/app/dashboard/overview', destination: '/app' },
-      // NOTE: /app/dashboard/earnings intentionally omitted here.
-      // The earnings page.tsx handles auth-aware redirection: unauthenticated
-      // users are sent to /signin?redirect_url=/app/dashboard/earnings so they
-      // return to this deep-link after sign-in, not to the settings page.
-      // Putting a static redirect here bypasses Clerk middleware and sends
-      // unauthenticated users to /app/settings/artist-profile instead of /signin.
+      // NOTE: /app/earnings and /app/dashboard/earnings are intentionally
+      // omitted here. proxy.ts handles auth-aware redirection: unauthenticated
+      // users are sent to /signin?redirect_url=<requested earnings path>, while
+      // authenticated users go to the canonical artist profile pay section.
+      // Static redirects bypass Clerk middleware and lose the original deep link.
       {
         source: '/app/dashboard/links',
         destination: '/app/chat?panel=profile',

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -652,12 +652,13 @@ async function handleRequest(req: NextRequest, userId: string | null) {
     }
 
     // Authenticated legacy earnings deep links should land directly on the
-    // canonical artist profile pay section. Keeping this in proxy avoids an
-    // app-shell render/streamed redirect for smoke tests and real users.
+    // canonical artist profile pay section. Keeping this in proxy preserves
+    // auth-aware handling for anonymous users instead of using static redirects.
     if (
       isNavigationMethod &&
       userId &&
-      pathname === APP_ROUTES.DASHBOARD_EARNINGS
+      (pathname === APP_ROUTES.DASHBOARD_EARNINGS ||
+        pathname === APP_ROUTES.EARNINGS)
     ) {
       return NextResponse.redirect(
         new URL(`${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`, req.url)

--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -15,6 +15,7 @@
  */
 import { NextResponse } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
 import type { ProxyUserState } from '@/lib/auth/proxy-state';
 
 // ============================================================================
@@ -294,7 +295,7 @@ describe('proxy.ts middleware', () => {
 
     it('keeps unauthenticated legacy earnings deep links behind signin', async () => {
       const req = createUnauthenticatedRequest({
-        pathname: '/app/dashboard/earnings',
+        pathname: APP_ROUTES.DASHBOARD_EARNINGS,
       });
       const res = await callMiddleware(req);
 
@@ -303,6 +304,20 @@ describe('proxy.ts middleware', () => {
       expect(isRedirectTo(res, '/signin')).toBe(true);
       expect(res.headers.get('location')).toContain(
         'redirect_url=%2Fapp%2Fdashboard%2Fearnings'
+      );
+    });
+
+    it('keeps unauthenticated app earnings aliases behind signin', async () => {
+      const req = createUnauthenticatedRequest({
+        pathname: APP_ROUTES.EARNINGS,
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBeGreaterThanOrEqual(300);
+      expect(res.status).toBeLessThan(400);
+      expect(isRedirectTo(res, APP_ROUTES.SIGNIN)).toBe(true);
+      expect(res.headers.get('location')).toContain(
+        'redirect_url=%2Fapp%2Fearnings'
       );
     });
 
@@ -675,7 +690,7 @@ describe('proxy.ts middleware', () => {
       mocks.getUserState.mockResolvedValue(USER_STATES.active);
 
       const req = createAuthenticatedRequest('clerk_user_1', {
-        pathname: '/app/dashboard/earnings',
+        pathname: APP_ROUTES.DASHBOARD_EARNINGS,
       });
       const res = await callMiddleware(req);
 
@@ -685,6 +700,25 @@ describe('proxy.ts middleware', () => {
       expect(location).toBeTruthy();
       const locationUrl = new URL(location ?? '', 'https://localhost');
       expect(locationUrl.pathname).toBe('/app/settings/artist-profile');
+      expect(locationUrl.searchParams.get('tab')).toBe('earn');
+      expect(locationUrl.hash).toBe('#pay');
+      expect(mocks.getUserState).not.toHaveBeenCalled();
+    });
+
+    it('redirects authenticated app earnings aliases to artist profile pay', async () => {
+      mocks.getUserState.mockResolvedValue(USER_STATES.active);
+
+      const req = createAuthenticatedRequest('clerk_user_1', {
+        pathname: APP_ROUTES.EARNINGS,
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBeGreaterThanOrEqual(300);
+      expect(res.status).toBeLessThan(400);
+      const location = res.headers.get('location');
+      expect(location).toBeTruthy();
+      const locationUrl = new URL(location ?? '', 'https://localhost');
+      expect(locationUrl.pathname).toBe(APP_ROUTES.SETTINGS_ARTIST_PROFILE);
       expect(locationUrl.searchParams.get('tab')).toBe('earn');
       expect(locationUrl.hash).toBe('#pay');
       expect(mocks.getUserState).not.toHaveBeenCalled();

--- a/apps/web/tests/unit/routing/earnings-auth-redirect.test.ts
+++ b/apps/web/tests/unit/routing/earnings-auth-redirect.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
+
+type RedirectRule = {
+  readonly source: string;
+  readonly destination: string;
+};
+
+describe('earnings auth redirects', () => {
+  it('keeps earnings deep links out of static redirects', async () => {
+    const nextConfigModule = await import('../../../next.config.js');
+    const nextConfig = nextConfigModule.default ?? nextConfigModule;
+    const redirects = (await nextConfig.redirects()) as RedirectRule[];
+
+    expect(
+      redirects.find(redirect => redirect.source === APP_ROUTES.EARNINGS)
+    ).toBeUndefined();
+    expect(
+      redirects.find(
+        redirect => redirect.source === APP_ROUTES.DASHBOARD_EARNINGS
+      )
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Removes the static `/app/earnings` redirect from `next.config.js` so earnings deep links do not bypass proxy auth handling.
- Handles both `/app/dashboard/earnings` and `/app/earnings` in `proxy.ts`: anonymous navigation redirects to `/signin` with the requested earnings path preserved, while authenticated navigation goes straight to the artist profile pay section.
- Adds regression coverage for anonymous and authenticated earnings redirect behavior plus a config-level guard that keeps both earnings routes out of static redirects.

## Verification
- `./scripts/setup.sh`
- `pnpm install --frozen-lockfile`
- `pnpm --filter web exec vitest run tests/unit/middleware/proxy-behavioral.test.ts tests/unit/routing/earnings-auth-redirect.test.ts` — 58 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- `pnpm biome check --write apps/web/next.config.js apps/web/proxy.ts apps/web/tests/unit/middleware/proxy-behavioral.test.ts apps/web/tests/unit/routing/earnings-auth-redirect.test.ts` — passed
- pre-commit hook: proxy guard, Biome, ESLint, web typecheck — passed
- pre-push hook: full Biome check, proxy guard, Tailwind guard, web typecheck, web lint — passed

Refs JOV-2031. This PR covers the repo-side auth-aware redirect hardening; the staging Clerk env-var dependency remains tracked on JOV-2031.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated earnings and payment route handling to use dynamic authentication-aware proxy routing instead of static redirects, ensuring proper user authentication flow when accessing payment-related sections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8702)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->