### PR TITLE
fix(demo): constrain founder recording width

### DIFF
--- a/apps/web/components/features/demo/FounderDemoRecordingSurface.tsx
+++ b/apps/web/components/features/demo/FounderDemoRecordingSurface.tsx
@@ -337,7 +337,7 @@ export function FounderDemoRecordingSurface() {
   return (
     <DemoClientProviders>
       <main
-        className='relative h-screen w-screen overflow-hidden bg-(--linear-app-content-surface)'
+        className='relative h-screen w-full max-w-full overflow-hidden bg-(--linear-app-content-surface)'
         data-testid='founder-demo-recording-surface'
       >
         <div


### PR DESCRIPTION
Resolves JOV-2218

## Summary
- replace the founder demo recording surface `w-screen` with constrained `w-full max-w-full` sizing
- keep the full-height recording surface and hidden overflow behavior intact

## Verification
- `./scripts/setup.sh`
- `pnpm install --frozen-lockfile`
- `pnpm --filter=@jovie/web run mobile-overflow:guard`
- `pnpm --filter web exec vitest run tests/unit/demo/demo-surface-boundaries.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write apps/web/components/features/demo/FounderDemoRecordingSurface.tsx`
- `FOUNDER_DEMO_RECORDING_SECONDS=0 pnpm --filter @jovie/web exec playwright test tests/e2e/founder-demo-video.spec.ts --project=chromium --no-deps --reporter=line`
- pre-commit and pre-push hooks passed

## Risk
- Low: one Tailwind width class swap on the internal founder demo recording surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted the demo recording surface container width to prevent horizontal overflow and ensure consistent layout across screen sizes while preserving full-height and scroll behavior for a stable, polished presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8704)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->