### PR TITLE
fix(audience): tolerate missing visit summary columns

### DIFF
--- a/apps/web/app/[username]/[slug]/_lib/data.ts
+++ b/apps/web/app/[username]/[slug]/_lib/data.ts
@@ -287,6 +287,8 @@ const fetchCreatorByUsername = async (usernameNormalized: string) => {
     .where(eq(creatorProfiles.usernameNormalized, usernameNormalized))
     .limit(1);
 
+  // Schema-rollout fallback only: this is not canonical profile state.
+  // Revisit once creator_profiles.is_claimed exists in every environment.
   return creator ? { ...creator, isClaimed: true } : null;
 };
 

--- a/apps/web/app/[username]/[slug]/_lib/data.ts
+++ b/apps/web/app/[username]/[slug]/_lib/data.ts
@@ -8,7 +8,7 @@
 import { and, sql as drizzleSql, eq, isNotNull } from 'drizzle-orm';
 import { unstable_cache } from 'next/cache';
 import { cache } from 'react';
-import { db } from '@/lib/db';
+import { db, doesColumnExist } from '@/lib/db';
 import {
   type ArtistRole,
   artists,
@@ -258,22 +258,36 @@ export interface CachedContentData {
  * Fetch creator by normalized username.
  */
 const fetchCreatorByUsername = async (usernameNormalized: string) => {
+  const smartLinkCreatorSelect = {
+    id: creatorProfiles.id,
+    userId: creatorProfiles.userId,
+    displayName: creatorProfiles.displayName,
+    username: creatorProfiles.username,
+    usernameNormalized: creatorProfiles.usernameNormalized,
+    avatarUrl: creatorProfiles.avatarUrl,
+    settings: creatorProfiles.settings,
+  };
+
+  if (await doesColumnExist('creator_profiles', 'is_claimed')) {
+    const [creator] = await db
+      .select({
+        ...smartLinkCreatorSelect,
+        isClaimed: creatorProfiles.isClaimed,
+      })
+      .from(creatorProfiles)
+      .where(eq(creatorProfiles.usernameNormalized, usernameNormalized))
+      .limit(1);
+
+    return creator ?? null;
+  }
+
   const [creator] = await db
-    .select({
-      id: creatorProfiles.id,
-      userId: creatorProfiles.userId,
-      displayName: creatorProfiles.displayName,
-      username: creatorProfiles.username,
-      usernameNormalized: creatorProfiles.usernameNormalized,
-      avatarUrl: creatorProfiles.avatarUrl,
-      settings: creatorProfiles.settings,
-      isClaimed: creatorProfiles.isClaimed,
-    })
+    .select(smartLinkCreatorSelect)
     .from(creatorProfiles)
     .where(eq(creatorProfiles.usernameNormalized, usernameNormalized))
     .limit(1);
 
-  return creator ?? null;
+  return creator ? { ...creator, isClaimed: true } : null;
 };
 
 /**

--- a/apps/web/app/api/audience/visit/route.ts
+++ b/apps/web/app/api/audience/visit/route.ts
@@ -10,7 +10,12 @@ import {
 } from '@/lib/analytics/tracking-token';
 import { isVisitorBlocked } from '@/lib/audience/block-check';
 import { recordAudienceEvent } from '@/lib/audience/record-audience-event';
-import { type DbOrTransaction, db, doesTableExist } from '@/lib/db';
+import {
+  type DbOrTransaction,
+  db,
+  doesColumnExist,
+  doesTableExist,
+} from '@/lib/db';
 import { unwrapPgError } from '@/lib/db/errors';
 import {
   audienceMembers,
@@ -47,6 +52,42 @@ export const runtime = 'nodejs';
 const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
 
 const INTERNAL_HOST_SUFFIXES = ['jov.ie', 'jovie.fm'];
+
+interface AudienceVisitSchemaCompatibility {
+  canWriteAudienceActions: boolean;
+  hasAudienceMemberLatestActionLabelColumn: boolean;
+  hasAudienceMemberLatestReferrerUrlColumn: boolean;
+  hasAudienceReferrersTable: boolean;
+  hasCreatorDistributionEventsTable: boolean;
+  hasDailyProfileViewsTable: boolean;
+}
+
+async function resolveAudienceVisitSchemaCompatibility(): Promise<AudienceVisitSchemaCompatibility> {
+  const [
+    canWriteAudienceActions,
+    hasAudienceMemberLatestActionLabelColumn,
+    hasAudienceMemberLatestReferrerUrlColumn,
+    hasAudienceReferrersTable,
+    hasCreatorDistributionEventsTable,
+    hasDailyProfileViewsTable,
+  ] = await Promise.all([
+    doesColumnExist('audience_actions', 'event_type'),
+    doesColumnExist('audience_members', 'latest_action_label'),
+    doesColumnExist('audience_members', 'latest_referrer_url'),
+    doesTableExist('audience_referrers'),
+    doesTableExist('creator_distribution_events'),
+    doesTableExist('daily_profile_views'),
+  ]);
+
+  return {
+    canWriteAudienceActions,
+    hasAudienceMemberLatestActionLabelColumn,
+    hasAudienceMemberLatestReferrerUrlColumn,
+    hasAudienceReferrersTable,
+    hasCreatorDistributionEventsTable,
+    hasDailyProfileViewsTable,
+  };
+}
 
 function isInternalTrafficReferrer(referrerUrl: string): boolean {
   try {
@@ -475,9 +516,8 @@ export async function POST(request: NextRequest) {
       : [];
 
     try {
-      const hasDailyProfileViewsTable = await doesTableExist(
-        'daily_profile_views'
-      );
+      const schemaCompatibility =
+        await resolveAudienceVisitSchemaCompatibility();
 
       await withSystemIngestionSession(async tx => {
         const viewDate = now.toISOString().slice(0, 10);
@@ -541,11 +581,18 @@ export async function POST(request: NextRequest) {
         const instagramReferrerHost =
           getInstagramReferrerHost(resolvedReferrer);
 
-        if (hasDailyProfileViewsTable && !isBotAudienceMember) {
+        if (
+          schemaCompatibility.hasDailyProfileViewsTable &&
+          !isBotAudienceMember
+        ) {
           await writeDailyProfileViews(tx, profileId, viewDate, now);
         }
 
-        if (shouldTrackInstagramActivation && !isBotAudienceMember) {
+        if (
+          schemaCompatibility.hasCreatorDistributionEventsTable &&
+          shouldTrackInstagramActivation &&
+          !isBotAudienceMember
+        ) {
           await writeInstagramActivation(
             tx,
             profileId,
@@ -557,6 +604,37 @@ export async function POST(request: NextRequest) {
 
         // Summary column value for fast list views
         const latestReferrerUrl = resolvedReferrer?.trim() ?? null;
+        const recordProfileVisitEvent = async (audienceMemberId: string) => {
+          if (!schemaCompatibility.canWriteAudienceActions) return;
+
+          await recordAudienceEvent(
+            tx,
+            {
+              creatorProfileId: profileId,
+              audienceMemberId,
+              eventType: 'profile_visited',
+              verb: 'visited',
+              confidence: 'observed',
+              sourceKind: resolveVisitSourceKind(utmParams, latestReferrerUrl),
+              sourceLabel: resolveVisitSourceLabel(
+                utmParams,
+                latestReferrerUrl
+              ),
+              objectType: 'profile',
+              objectId: profileId,
+              objectLabel: 'Profile',
+              properties: {
+                referrer: latestReferrerUrl,
+                utmParams: resolvedUtmParams,
+              },
+              timestamp: now,
+            },
+            {
+              includeLatestActionLabel:
+                schemaCompatibility.hasAudienceMemberLatestActionLabelColumn,
+            }
+          );
+        };
 
         if (existing) {
           await tx
@@ -572,31 +650,19 @@ export async function POST(request: NextRequest) {
               deviceType: normalizedDevice,
               referrerHistory,
               tags: mergedTags,
-              ...(latestReferrerUrl && { latestReferrerUrl }),
+              ...(schemaCompatibility.hasAudienceMemberLatestReferrerUrlColumn &&
+                latestReferrerUrl && { latestReferrerUrl }),
               ...(utmParams && { utmParams: resolvedUtmParams }),
             })
             .where(eq(audienceMembers.id, existing.id));
 
-          if (latestReferrerUrl) {
+          if (
+            schemaCompatibility.hasAudienceReferrersTable &&
+            latestReferrerUrl
+          ) {
             await writeReferrer(tx, existing.id, latestReferrerUrl, now);
           }
-          await recordAudienceEvent(tx, {
-            creatorProfileId: profileId,
-            audienceMemberId: existing.id,
-            eventType: 'profile_visited',
-            verb: 'visited',
-            confidence: 'observed',
-            sourceKind: resolveVisitSourceKind(utmParams, latestReferrerUrl),
-            sourceLabel: resolveVisitSourceLabel(utmParams, latestReferrerUrl),
-            objectType: 'profile',
-            objectId: profileId,
-            objectLabel: 'Profile',
-            properties: {
-              referrer: latestReferrerUrl,
-              utmParams: resolvedUtmParams,
-            },
-            timestamp: now,
-          });
+          await recordProfileVisitEvent(existing.id);
           return;
         }
 
@@ -619,7 +685,8 @@ export async function POST(request: NextRequest) {
             utmParams: resolvedUtmParams,
             tags: mergedTags,
             latestActions: [],
-            latestReferrerUrl,
+            ...(schemaCompatibility.hasAudienceMemberLatestReferrerUrlColumn &&
+              latestReferrerUrl && { latestReferrerUrl }),
             updatedAt: now,
             createdAt: now,
           })
@@ -631,27 +698,15 @@ export async function POST(request: NextRequest) {
           })
           .returning({ id: audienceMembers.id });
 
-        if (inserted && latestReferrerUrl) {
+        if (
+          inserted &&
+          schemaCompatibility.hasAudienceReferrersTable &&
+          latestReferrerUrl
+        ) {
           await writeReferrer(tx, inserted.id, latestReferrerUrl, now);
         }
         if (inserted) {
-          await recordAudienceEvent(tx, {
-            creatorProfileId: profileId,
-            audienceMemberId: inserted.id,
-            eventType: 'profile_visited',
-            verb: 'visited',
-            confidence: 'observed',
-            sourceKind: resolveVisitSourceKind(utmParams, latestReferrerUrl),
-            sourceLabel: resolveVisitSourceLabel(utmParams, latestReferrerUrl),
-            objectType: 'profile',
-            objectId: profileId,
-            objectLabel: 'Profile',
-            properties: {
-              referrer: latestReferrerUrl,
-              utmParams: resolvedUtmParams,
-            },
-            timestamp: now,
-          });
+          await recordProfileVisitEvent(inserted.id);
         }
       });
 

--- a/apps/web/app/app/(shell)/dashboard/audience/audience-data.ts
+++ b/apps/web/app/app/(shell)/dashboard/audience/audience-data.ts
@@ -14,6 +14,7 @@ import { unstable_cache } from 'next/cache';
 import { z } from 'zod';
 import { withDbSessionTx } from '@/lib/auth/session';
 import { CACHE_TAGS, CACHE_TTL, createAudienceDataTag } from '@/lib/cache/tags';
+import { doesColumnExist } from '@/lib/db';
 import {
   buildCursorCondition,
   decodeCursor,
@@ -110,6 +111,34 @@ const MEMBER_SORT_COLUMNS = {
   engagement: audienceMembers.engagementScore,
   createdAt: audienceMembers.firstSeenAt,
 } as const;
+
+export interface AudienceMemberColumnAvailability {
+  hasActiveAlerts: boolean;
+  activeAlertChannels: boolean;
+  lastAlertConfirmedAt: boolean;
+}
+
+const FALLBACK_AUDIENCE_MEMBER_COLUMN_AVAILABILITY: AudienceMemberColumnAvailability =
+  {
+    hasActiveAlerts: false,
+    activeAlertChannels: false,
+    lastAlertConfirmedAt: false,
+  };
+
+async function getAudienceMemberColumnAvailability(): Promise<AudienceMemberColumnAvailability> {
+  const [hasActiveAlerts, activeAlertChannels, lastAlertConfirmedAt] =
+    await Promise.all([
+      doesColumnExist('audience_members', 'has_active_alerts'),
+      doesColumnExist('audience_members', 'active_alert_channels'),
+      doesColumnExist('audience_members', 'last_alert_confirmed_at'),
+    ]);
+
+  return {
+    hasActiveAlerts,
+    activeAlertChannels,
+    lastAlertConfirmedAt,
+  };
+}
 
 /**
  * Build ownership filter based on clerk user ID
@@ -322,7 +351,8 @@ function buildClickAggSubquery(tx: DbSessionTx, profileId: string) {
  */
 function buildMemberSelectFields(
   includeDetails: boolean,
-  clickAgg: ReturnType<typeof buildClickAggSubquery>
+  clickAgg: ReturnType<typeof buildClickAggSubquery>,
+  columns: AudienceMemberColumnAvailability = FALLBACK_AUDIENCE_MEMBER_COLUMN_AVAILABILITY
 ) {
   return {
     id: audienceMembers.id,
@@ -364,16 +394,25 @@ function buildMemberSelectFields(
     ltvTicketSalesCents: drizzleSql<number>`0`.as('ltv_ticket_sales_cents'),
     tags: audienceMembers.tags,
     lastSeenAt: audienceMembers.lastSeenAt,
-    hasActiveAlerts: audienceMembers.hasActiveAlerts,
-    activeAlertChannels: audienceMembers.activeAlertChannels,
-    lastAlertConfirmedAt: audienceMembers.lastAlertConfirmedAt,
+    hasActiveAlerts: columns.hasActiveAlerts
+      ? audienceMembers.hasActiveAlerts
+      : drizzleSql<boolean>`false`.as('has_active_alerts'),
+    activeAlertChannels: columns.activeAlertChannels
+      ? audienceMembers.activeAlertChannels
+      : drizzleSql<unknown[]>`'[]'::jsonb`.as('active_alert_channels'),
+    lastAlertConfirmedAt: columns.lastAlertConfirmedAt
+      ? audienceMembers.lastAlertConfirmedAt
+      : drizzleSql<Date | null>`NULL::timestamp`.as('last_alert_confirmed_at'),
   };
 }
 
 /**
  * Map a single segment filter ID to its drizzle condition.
  */
-function segmentToCondition(segment: string) {
+function segmentToCondition(
+  segment: string,
+  columns: AudienceMemberColumnAvailability = FALLBACK_AUDIENCE_MEMBER_COLUMN_AVAILABILITY
+) {
   switch (segment) {
     case 'highIntent':
       return eq(audienceMembers.intentLevel, 'high');
@@ -387,11 +426,19 @@ function segmentToCondition(segment: string) {
         drizzleSql`NOW() - INTERVAL '24 hours'`
       );
     case 'alertsOn':
+      if (!columns.hasActiveAlerts) {
+        return drizzleSql<boolean>`false`;
+      }
       return eq(audienceMembers.hasActiveAlerts, true);
     default:
       return null;
   }
 }
+
+export const __testing = {
+  buildMemberSelectFields,
+  segmentToCondition,
+};
 
 /**
  * Build segment filter condition based on multiple segment filters.
@@ -399,11 +446,14 @@ function segmentToCondition(segment: string) {
  * (union): selecting multiple segments shows members matching ANY of the
  * selected segments, matching the behavior in the API route.
  */
-function buildSegmentFilter(segments: string[] | undefined) {
+function buildSegmentFilter(
+  segments: string[] | undefined,
+  columns: AudienceMemberColumnAvailability
+) {
   if (!segments || segments.length === 0) return drizzleSql<boolean>`true`;
 
   const conditions = segments
-    .map(segmentToCondition)
+    .map(segment => segmentToCondition(segment, columns))
     .filter((c): c is NonNullable<typeof c> => c !== null);
 
   if (conditions.length === 0) return drizzleSql<boolean>`true`;
@@ -424,11 +474,13 @@ async function fetchMembersData(
     memberId: string | undefined;
     viewFilter: AudienceView;
     segmentFilter?: string[];
+    columns: AudienceMemberColumnAvailability;
   }
 ): Promise<
   Omit<AudienceServerData, 'view' | 'subscriberCount' | 'totalAudienceCount'>
 > {
-  const { includeDetails, memberId, viewFilter, segmentFilter } = options;
+  const { includeDetails, memberId, viewFilter, segmentFilter, columns } =
+    options;
   const safe = parseMemberQueryParams(searchParams);
   const sortColumn = MEMBER_SORT_COLUMNS[safe.sort];
   const orderFn = safe.direction === 'asc' ? asc : desc;
@@ -443,7 +495,7 @@ async function fetchMembersData(
   } else {
     typeCondition = drizzleSql<boolean>`true`;
   }
-  const segmentCondition = buildSegmentFilter(segmentFilter);
+  const segmentCondition = buildSegmentFilter(segmentFilter, columns);
 
   // Keyset cursor WHERE clause — avoids full-table OFFSET scan (JOV-1254).
   let cursorCondition: SQL<unknown> = drizzleSql`true`;
@@ -475,7 +527,7 @@ async function fetchMembersData(
   const clickAgg = buildClickAggSubquery(tx, selectedProfileId);
 
   const baseQuery = tx
-    .select(buildMemberSelectFields(includeDetails, clickAgg))
+    .select(buildMemberSelectFields(includeDetails, clickAgg, columns))
     .from(audienceMembers)
     .innerJoin(
       creatorProfiles,
@@ -753,13 +805,19 @@ function buildDataPromise(
   selectedProfileId: string,
   view: AudienceView,
   searchParams: SearchParams,
-  options: { includeDetails: boolean; memberId?: string; segments?: string[] }
+  options: {
+    includeDetails: boolean;
+    memberId?: string;
+    segments?: string[];
+    columns: AudienceMemberColumnAvailability;
+  }
 ) {
   return fetchMembersData(tx, clerkUserId, selectedProfileId, searchParams, {
     includeDetails: options.includeDetails,
     memberId: options.memberId,
     viewFilter: view,
     segmentFilter: options.segments,
+    columns: options.columns,
   });
 }
 
@@ -776,6 +834,8 @@ async function fetchAudienceData(
   view: AudienceView,
   segments: string[] | undefined
 ): Promise<AudienceServerData> {
+  const columns = await getAudienceMemberColumnAvailability();
+
   return await withDbSessionTx(async (tx, clerkUserId) => {
     const data = await buildDataPromise(
       tx,
@@ -783,7 +843,7 @@ async function fetchAudienceData(
       selectedProfileId,
       view,
       searchParams,
-      { includeDetails, memberId, segments }
+      { includeDetails, memberId, segments, columns }
     );
 
     // Exact subscriber/audience counts are omitted per JOV-1262 —

--- a/apps/web/lib/audience/record-audience-event.ts
+++ b/apps/web/lib/audience/record-audience-event.ts
@@ -32,6 +32,10 @@ export interface RecordAudienceEventInput {
   readonly duplicateWindowMs?: number;
 }
 
+export interface RecordAudienceEventOptions {
+  readonly includeLatestActionLabel?: boolean;
+}
+
 function compactActionProjection(
   input: RecordAudienceEventInput,
   label: string
@@ -62,7 +66,8 @@ function compactActionProjection(
 
 export async function recordAudienceEvent(
   tx: DbOrTransaction,
-  input: RecordAudienceEventInput
+  input: RecordAudienceEventInput,
+  options: RecordAudienceEventOptions = {}
 ): Promise<void> {
   const now = input.timestamp ?? new Date();
   if (input.eventType === 'source_scanned' && input.sourceLinkId) {
@@ -134,7 +139,9 @@ export async function recordAudienceEvent(
           LIMIT 5
         ) AS entry
       )`,
-      latestActionLabel: label,
+      ...(options.includeLatestActionLabel === false
+        ? {}
+        : { latestActionLabel: label }),
       lastSeenAt: now,
       updatedAt: now,
     })

--- a/apps/web/lib/db/client/guards.ts
+++ b/apps/web/lib/db/client/guards.ts
@@ -4,7 +4,11 @@
  * Type guard functions for database query results.
  */
 
-import type { ActiveConnectionsRow, TableExistsRow } from './types';
+import type {
+  ActiveConnectionsRow,
+  ColumnExistsRow,
+  TableExistsRow,
+} from './types';
 
 /**
  * Check if a value is a record (object)
@@ -22,6 +26,17 @@ export function isTableExistsRow(value: unknown): value is TableExistsRow {
   }
 
   return typeof value.table_exists === 'boolean';
+}
+
+/**
+ * Type guard for column existence query result
+ */
+export function isColumnExistsRow(value: unknown): value is ColumnExistsRow {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return typeof value.column_exists === 'boolean';
 }
 
 /**

--- a/apps/web/lib/db/client/health.ts
+++ b/apps/web/lib/db/client/health.ts
@@ -14,10 +14,15 @@ import {
   initializeDb,
   setInternalDb,
 } from './connection';
-import { isActiveConnectionsRow, isTableExistsRow } from './guards';
+import {
+  isActiveConnectionsRow,
+  isColumnExistsRow,
+  isTableExistsRow,
+} from './guards';
 import { logDbError, logDbInfo } from './logging';
 import { DB_CONFIG, isRetryableError, withRetry } from './retry';
 import type {
+  ColumnExistsRow,
   ConnectionValidationResult,
   HealthCheckResult,
   PerformanceCheckResult,
@@ -26,6 +31,10 @@ import type {
 
 // Cache with TTL for both positive and negative results
 const tableExistenceCache = new Map<
+  string,
+  { exists: boolean; timestamp: number }
+>();
+const columnExistenceCache = new Map<
   string,
   { exists: boolean; timestamp: number }
 >();
@@ -38,6 +47,14 @@ const TABLE_EXISTENCE_CACHE_TTL_MS = 60_000;
 // Neon cold starts can take 10-15s, so use a 15s timeout to avoid false negatives.
 const TABLE_EXISTS_TIMEOUT_MS = 15_000;
 
+function clearExistenceCachesIfDatabaseChanged() {
+  if (env.DATABASE_URL && env.DATABASE_URL !== lastTableExistenceDatabaseUrl) {
+    tableExistenceCache.clear();
+    columnExistenceCache.clear();
+    lastTableExistenceDatabaseUrl = env.DATABASE_URL;
+  }
+}
+
 /**
  * Check if a table exists in the database.
  * Uses a TTL-based cache for both positive and negative results to avoid
@@ -48,11 +65,7 @@ const TABLE_EXISTS_TIMEOUT_MS = 15_000;
  * profile routes while still allowing Neon cold starts. See JOV-1218.
  */
 export async function doesTableExist(tableName: string): Promise<boolean> {
-  // Clear cache if database URL changes
-  if (env.DATABASE_URL && env.DATABASE_URL !== lastTableExistenceDatabaseUrl) {
-    tableExistenceCache.clear();
-    lastTableExistenceDatabaseUrl = env.DATABASE_URL;
-  }
+  clearExistenceCachesIfDatabaseChanged();
 
   // Check cache (both positive and negative results)
   const cached = tableExistenceCache.get(tableName);
@@ -112,6 +125,76 @@ export async function doesTableExist(tableName: string): Promise<boolean> {
     // likely exists but the connection failed transiently.
     if (!isRetryableError(error)) {
       tableExistenceCache.set(tableName, {
+        exists: false,
+        timestamp: Date.now(),
+      });
+    }
+    return false;
+  }
+}
+
+/**
+ * Check if a column exists in a public table.
+ * Uses the same TTL cache, retry, and timeout policy as doesTableExist so
+ * public routes can avoid issuing schema-incompatible writes during rollout.
+ */
+export async function doesColumnExist(
+  tableName: string,
+  columnName: string
+): Promise<boolean> {
+  clearExistenceCachesIfDatabaseChanged();
+
+  const cacheKey = `${tableName}.${columnName}`;
+  const cached = columnExistenceCache.get(cacheKey);
+  if (cached && Date.now() - cached.timestamp < TABLE_EXISTENCE_CACHE_TTL_MS) {
+    return cached.exists;
+  }
+
+  if (!env.DATABASE_URL) {
+    return false;
+  }
+
+  try {
+    const db = getDb();
+    const result = await withRetry(
+      () =>
+        Promise.race([
+          db.execute(
+            drizzleSql<ColumnExistsRow>`
+              SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = ${tableName}
+                  AND column_name = ${columnName}
+              ) AS column_exists
+            `
+          ),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    `columnExists timeout after ${TABLE_EXISTS_TIMEOUT_MS}ms`
+                  )
+                ),
+              TABLE_EXISTS_TIMEOUT_MS
+            )
+          ),
+        ]),
+      `columnExists(${cacheKey})`
+    );
+
+    const firstRow = result.rows[0];
+    const exists = isColumnExistsRow(firstRow) ? firstRow.column_exists : false;
+
+    columnExistenceCache.set(cacheKey, { exists, timestamp: Date.now() });
+
+    return exists;
+  } catch (error) {
+    logDbError('columnExists', error, { tableName, columnName });
+    if (!isRetryableError(error)) {
+      columnExistenceCache.set(cacheKey, {
         exists: false,
         timestamp: Date.now(),
       });

--- a/apps/web/lib/db/client/index.ts
+++ b/apps/web/lib/db/client/index.ts
@@ -22,6 +22,7 @@ export { isActiveConnectionsRow, isRecord, isTableExistsRow } from './guards';
 export {
   checkDbHealth,
   checkDbPerformance,
+  doesColumnExist,
   doesTableExist,
   getDbConfig,
   validateDbConnection,
@@ -36,6 +37,7 @@ export { setSessionUser, withDb } from './session';
 // Types
 export type {
   ActiveConnectionsRow,
+  ColumnExistsRow,
   ConnectionValidationResult,
   DbOrTransaction,
   DbType,

--- a/apps/web/lib/db/client/types.ts
+++ b/apps/web/lib/db/client/types.ts
@@ -35,6 +35,11 @@ export interface TableExistsRow {
   table_exists: boolean;
 }
 
+/** Row type for column existence check query */
+export interface ColumnExistsRow {
+  column_exists: boolean;
+}
+
 /** Row type for active connections query */
 export interface ActiveConnectionsRow {
   active_connections: string | number;

--- a/apps/web/lib/db/index.ts
+++ b/apps/web/lib/db/index.ts
@@ -30,6 +30,7 @@ export {
   db,
   // Retry logic
   dbCircuitBreaker,
+  doesColumnExist,
   doesTableExist,
   getDb,
   getDbConfig,

--- a/apps/web/tests/unit/api/audience/visit.test.ts
+++ b/apps/web/tests/unit/api/audience/visit.test.ts
@@ -6,6 +6,7 @@ const mockPublicVisitLimiterGetStatus = vi.hoisted(() => vi.fn());
 const mockPublicVisitLimiterLimit = vi.hoisted(() => vi.fn());
 const mockDetectBot = vi.hoisted(() => vi.fn());
 const mockDbSelect = vi.hoisted(() => vi.fn());
+const mockDoesColumnExist = vi.hoisted(() => vi.fn());
 const mockDoesTableExist = vi.hoisted(() => vi.fn());
 const mockWithSystemIngestionSession = vi.hoisted(() => vi.fn());
 const mockCheckVisitRateLimit = vi.hoisted(() => vi.fn());
@@ -28,6 +29,7 @@ vi.mock('@/lib/db', () => ({
   db: {
     select: mockDbSelect,
   },
+  doesColumnExist: mockDoesColumnExist,
   doesTableExist: mockDoesTableExist,
 }));
 
@@ -82,6 +84,7 @@ describe('POST /api/audience/visit', () => {
     mockDetectBot.mockReturnValue({ isBot: false });
     mockIsTrackingTokenEnabled.mockReturnValue(false);
     mockCheckVisitRateLimit.mockResolvedValue({ success: true });
+    mockDoesColumnExist.mockResolvedValue(true);
     mockDoesTableExist.mockResolvedValue(true);
     mockCaptureError.mockReset();
   });
@@ -523,6 +526,93 @@ describe('POST /api/audience/visit', () => {
     expect(response.status).toBe(200);
     expect(data.success).toBe(true);
     expect(data.fingerprint).toBeDefined();
+  });
+
+  it('uses schema-compatible visit writes when optional audience summary columns are absent', async () => {
+    mockDoesColumnExist.mockImplementation(
+      async (tableName: string, columnName: string) => {
+        if (
+          tableName === 'audience_members' &&
+          (columnName === 'latest_referrer_url' ||
+            columnName === 'latest_action_label')
+        ) {
+          return false;
+        }
+
+        if (tableName === 'audience_actions' && columnName === 'event_type') {
+          return false;
+        }
+
+        return true;
+      }
+    );
+    mockDoesTableExist.mockImplementation(async (tableName: string) => {
+      return tableName === 'daily_profile_views';
+    });
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi
+            .fn()
+            .mockResolvedValue([{ id: 'profile_123', isPublic: true }]),
+        }),
+      }),
+    });
+
+    const insertedValues: Record<string, unknown>[] = [];
+    mockWithSystemIngestionSession.mockImplementation(async callback => {
+      const mockInsert = vi.fn().mockReturnValue({
+        values: vi.fn().mockImplementation((value: Record<string, unknown>) => {
+          insertedValues.push(value);
+          return {
+            onConflictDoNothing: vi.fn().mockReturnValue({
+              returning: vi.fn().mockResolvedValue([{ id: 'inserted_member' }]),
+            }),
+            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          };
+        }),
+      });
+
+      await callback({
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+        insert: mockInsert,
+      });
+    });
+
+    const request = new NextRequest('http://localhost/api/audience/visit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        profileId: '123e4567-e89b-12d3-a456-426614174000',
+        referrer: 'https://example.com/profile',
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+    const audienceMemberInsert = insertedValues.find(
+      value => value.type === 'anonymous'
+    );
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.degraded).toBeUndefined();
+    expect(audienceMemberInsert).toBeDefined();
+    expect(audienceMemberInsert).toEqual(
+      expect.objectContaining({
+        referrerHistory: expect.arrayContaining([
+          expect.objectContaining({ url: 'https://example.com/profile' }),
+        ]),
+      })
+    );
+    expect(audienceMemberInsert).not.toHaveProperty('latestReferrerUrl');
+    expect(mockCaptureError).not.toHaveBeenCalled();
   });
 
   it('fails soft when optional persistence degrades after fingerprint resolution', async () => {

--- a/apps/web/tests/unit/api/audience/visit.test.ts
+++ b/apps/web/tests/unit/api/audience/visit.test.ts
@@ -539,10 +539,6 @@ describe('POST /api/audience/visit', () => {
           return false;
         }
 
-        if (tableName === 'audience_actions' && columnName === 'event_type') {
-          return false;
-        }
-
         return true;
       }
     );
@@ -560,6 +556,7 @@ describe('POST /api/audience/visit', () => {
     });
 
     const insertedValues: Record<string, unknown>[] = [];
+    const updatedValues: Record<string, unknown>[] = [];
     mockWithSystemIngestionSession.mockImplementation(async callback => {
       const mockInsert = vi.fn().mockReturnValue({
         values: vi.fn().mockImplementation((value: Record<string, unknown>) => {
@@ -569,6 +566,14 @@ describe('POST /api/audience/visit', () => {
               returning: vi.fn().mockResolvedValue([{ id: 'inserted_member' }]),
             }),
             onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          };
+        }),
+      });
+      const mockUpdate = vi.fn().mockReturnValue({
+        set: vi.fn().mockImplementation((value: Record<string, unknown>) => {
+          updatedValues.push(value);
+          return {
+            where: vi.fn().mockResolvedValue(undefined),
           };
         }),
       });
@@ -582,6 +587,7 @@ describe('POST /api/audience/visit', () => {
           }),
         }),
         insert: mockInsert,
+        update: mockUpdate,
       });
     });
 
@@ -612,6 +618,9 @@ describe('POST /api/audience/visit', () => {
       })
     );
     expect(audienceMemberInsert).not.toHaveProperty('latestReferrerUrl');
+    expect(updatedValues).toHaveLength(1);
+    expect(updatedValues[0]).toHaveProperty('latestActions');
+    expect(updatedValues[0]).not.toHaveProperty('latestActionLabel');
     expect(mockCaptureError).not.toHaveBeenCalled();
   });
 

--- a/apps/web/tests/unit/dashboard/audience-data-schema.test.ts
+++ b/apps/web/tests/unit/dashboard/audience-data-schema.test.ts
@@ -1,0 +1,89 @@
+import { sql as drizzleSql } from 'drizzle-orm';
+import { describe, expect, it, vi } from 'vitest';
+import { __testing } from '@/app/app/(shell)/dashboard/audience/audience-data';
+import { audienceMembers } from '@/lib/db/schema/analytics';
+
+vi.mock('next/cache', () => ({
+  unstable_cache: (callback: () => unknown) => callback,
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  withDbSessionTx: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({ doesColumnExist: vi.fn() }));
+
+function aliasedFieldName(value: unknown) {
+  return typeof value === 'object' && value !== null && 'fieldAlias' in value
+    ? String((value as { fieldAlias: unknown }).fieldAlias)
+    : null;
+}
+
+function sqlChunks(value: unknown) {
+  return typeof value === 'object' && value !== null && 'queryChunks' in value
+    ? ((value as { queryChunks: unknown[] }).queryChunks ?? [])
+    : [];
+}
+
+function buildCompatibility(
+  columns: Parameters<typeof __testing.buildMemberSelectFields>[2]
+) {
+  const clickAgg = {
+    streamingClicks: drizzleSql<number>`0`,
+    tipClickValueCents: drizzleSql<number>`0`,
+  } as unknown as Parameters<typeof __testing.buildMemberSelectFields>[1];
+
+  return {
+    selectFields: __testing.buildMemberSelectFields(false, clickAgg, columns),
+    alertsOnCondition: __testing.segmentToCondition('alertsOn', columns),
+  };
+}
+
+describe('audience data schema compatibility', () => {
+  it('does not select alert columns or filter by them when they are unavailable', () => {
+    const { selectFields, alertsOnCondition } = buildCompatibility({
+      hasActiveAlerts: false,
+      activeAlertChannels: false,
+      lastAlertConfirmedAt: false,
+    });
+
+    expect(selectFields.hasActiveAlerts).not.toBe(
+      audienceMembers.hasActiveAlerts
+    );
+    expect(selectFields.activeAlertChannels).not.toBe(
+      audienceMembers.activeAlertChannels
+    );
+    expect(selectFields.lastAlertConfirmedAt).not.toBe(
+      audienceMembers.lastAlertConfirmedAt
+    );
+    expect(aliasedFieldName(selectFields.hasActiveAlerts)).toBe(
+      'has_active_alerts'
+    );
+    expect(aliasedFieldName(selectFields.activeAlertChannels)).toBe(
+      'active_alert_channels'
+    );
+    expect(aliasedFieldName(selectFields.lastAlertConfirmedAt)).toBe(
+      'last_alert_confirmed_at'
+    );
+    expect(sqlChunks(alertsOnCondition)).toHaveLength(1);
+  });
+
+  it('uses the real alert columns when the schema has them', () => {
+    const { selectFields, alertsOnCondition } = buildCompatibility({
+      hasActiveAlerts: true,
+      activeAlertChannels: true,
+      lastAlertConfirmedAt: true,
+    });
+
+    expect(selectFields.hasActiveAlerts).toBe(audienceMembers.hasActiveAlerts);
+    expect(selectFields.activeAlertChannels).toBe(
+      audienceMembers.activeAlertChannels
+    );
+    expect(selectFields.lastAlertConfirmedAt).toBe(
+      audienceMembers.lastAlertConfirmedAt
+    );
+    expect(sqlChunks(alertsOnCondition)).toContain(
+      audienceMembers.hasActiveAlerts
+    );
+  });
+});

--- a/apps/web/tests/unit/release/smart-link-creator-schema.test.ts
+++ b/apps/web/tests/unit/release/smart-link-creator-schema.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { doesColumnExistMock, fromMock, limitMock, selectMock, whereMock } =
+  vi.hoisted(() => {
+    const limitMock = vi.fn();
+    const whereMock = vi.fn(() => ({ limit: limitMock }));
+    const fromMock = vi.fn(() => ({ where: whereMock }));
+    const selectMock = vi.fn(() => ({ from: fromMock }));
+
+    return {
+      doesColumnExistMock: vi.fn(),
+      fromMock,
+      limitMock,
+      selectMock,
+      whereMock,
+    };
+  });
+
+vi.mock('react', () => ({
+  cache: (fn: unknown) => fn,
+}));
+
+vi.mock('next/cache', () => ({
+  unstable_cache: (fn: unknown) => () => fn,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: selectMock,
+  },
+  doesColumnExist: doesColumnExistMock,
+}));
+
+describe('smart-link creator schema compatibility', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    doesColumnExistMock.mockReset();
+    selectMock.mockClear();
+    fromMock.mockClear();
+    whereMock.mockClear();
+    limitMock.mockReset();
+  });
+
+  it('does not select is_claimed when the column is absent', async () => {
+    doesColumnExistMock.mockResolvedValue(false);
+    limitMock.mockResolvedValue([
+      {
+        id: 'creator-1',
+        userId: 'user-1',
+        displayName: 'Dua Lipa',
+        username: 'dualipa',
+        usernameNormalized: 'dualipa',
+        avatarUrl: null,
+        settings: {},
+      },
+    ]);
+
+    const { getCreatorByUsername } = await import(
+      '@/app/[username]/[slug]/_lib/data'
+    );
+
+    await expect(getCreatorByUsername('dualipa')).resolves.toMatchObject({
+      usernameNormalized: 'dualipa',
+      isClaimed: true,
+    });
+
+    const selection = selectMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(Object.keys(selection)).not.toContain('isClaimed');
+    expect(doesColumnExistMock).toHaveBeenCalledWith(
+      'creator_profiles',
+      'is_claimed'
+    );
+  });
+
+  it('preserves is_claimed when the column exists', async () => {
+    doesColumnExistMock.mockResolvedValue(true);
+    limitMock.mockResolvedValue([
+      {
+        id: 'creator-1',
+        userId: 'user-1',
+        displayName: 'Dua Lipa',
+        username: 'dualipa',
+        usernameNormalized: 'dualipa',
+        avatarUrl: null,
+        settings: {},
+        isClaimed: false,
+      },
+    ]);
+
+    const { getCreatorByUsername } = await import(
+      '@/app/[username]/[slug]/_lib/data'
+    );
+
+    await expect(getCreatorByUsername('dualipa')).resolves.toMatchObject({
+      usernameNormalized: 'dualipa',
+      isClaimed: false,
+    });
+
+    const selection = selectMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(Object.keys(selection)).toContain('isClaimed');
+  });
+});


### PR DESCRIPTION
## Summary
- Add a cached public-schema column existence check alongside the existing table check.
- Make `/api/audience/visit` omit optional summary-column writes when the active DB lacks them.
- Skip optional normalized audience event/referrer/activation writes when their schema is not available, avoiding transaction-aborting missing-column/table errors.
- Make public smartlink creator lookups omit `creator_profiles.is_claimed` when the active DB lacks that column, which keeps `/[username]/[slug]` Lighthouse routes rendering during schema rollout.
- Add regression tests for the missing audience summary columns and the missing smartlink `is_claimed` path.

## Investigation
- `pnpm --filter @jovie/web run drizzle:verify` reproduces the active DB mismatch: `audience_members.latest_referrer_url`, `audience_members.latest_action_label`, `audience_actions`, `creator_distribution_events`, and other columns/tables are absent from the active dev DB.
- The public-route Lighthouse failure on `/dualipa/neon-skyline` came from selecting `creator_profiles.is_claimed` against the same schema-compatible DB shape.
- No existing migration files were modified.

## Checks
- PASS: `pnpm --filter @jovie/web exec vitest run tests/unit/api/audience/visit.test.ts`
- PASS: `pnpm --filter @jovie/web exec vitest run tests/unit/release/smart-link-creator-schema.test.ts tests/unit/api/audience/visit.test.ts`
- PASS: `pnpm biome check --write apps/web`
- PASS: `pnpm biome check --write 'apps/web/app/[username]/[slug]/_lib/data.ts' apps/web/tests/unit/release/smart-link-creator-schema.test.ts`
- PASS: `pnpm --filter @jovie/web run typecheck -- --pretty false`
- PASS on push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`
- PASS: `PORT=3189 pnpm run dev:web:browse` + gstack `/browse` visit to `/tim?noredirect=1`; page loaded, `/api/audience/visit` returned 200, and dev logs showed no `Audience visit persistence degraded` error

## Risk
- This PR makes public visit and public smartlink reads compatible with the schema currently used by CI and dev DBs. Active schema drift remains tracked by JOV-2199 / `drizzle:verify`.

Fixes #8666
<!-- linear-issue-id:JOV-2199 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime schema compatibility so audience tracking and creator lookups gracefully skip missing optional columns/tables and avoid failures.

* **Refactor**
  * Audience event recording and analytics writes are now schema-aware, gating profile analytics, distribution events, and audience-member updates on available schema features.
  * Query logic tolerates missing creator profile fields and returns sensible defaults.

* **Tests**
  * Added unit tests simulating absent optional columns to verify correct field inclusion/omission and no errors.

* **Style**
  * Adjusted founder demo surface layout to prevent overflow and better constrain width.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8705)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->