### PR TITLE
fix(web): gate nonessential proxy cookies by consent

### DIFF
--- a/apps/web/app/api/track/route.ts
+++ b/apps/web/app/api/track/route.ts
@@ -7,7 +7,10 @@ import {
   resolveAudienceClickVerb,
 } from '@/lib/audience/click-event-helpers';
 import { recordAudienceEvent } from '@/lib/audience/record-audience-event';
-import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
+import {
+  COOKIE_BANNER_REQUIRED_COOKIE,
+  isCookieBannerRequired,
+} from '@/lib/cookies/consent-regions';
 import {
   CONSENT_COOKIE_NAME,
   parseConsentCookieValue,
@@ -378,13 +381,16 @@ export async function POST(request: NextRequest) {
       request.headers.get('x-vercel-ip-country') ??
       request.headers.get('cf-ipcountry') ??
       undefined;
+    const geoRegion =
+      request.headers.get('x-vercel-ip-country-region') ?? undefined;
     const audienceDeviceType = inferAudienceDeviceType(userAgent);
 
     // Determine marketing consent from jv_cc cookie.
     // Non-regulated jurisdictions remain default-allow when no banner was
     // required, but consent-required visitors need a valid marketing opt-in.
     const requiresCookieConsent =
-      request.cookies?.get(COOKIE_BANNER_REQUIRED_COOKIE)?.value === '1';
+      request.cookies?.get(COOKIE_BANNER_REQUIRED_COOKIE)?.value === '1' ||
+      isCookieBannerRequired(geoCountry ?? null, geoRegion ?? null);
     const consent = parseConsentCookieValue(
       request.cookies?.get(CONSENT_COOKIE_NAME)?.value
     );

--- a/apps/web/app/api/track/route.ts
+++ b/apps/web/app/api/track/route.ts
@@ -7,6 +7,7 @@ import {
   resolveAudienceClickVerb,
 } from '@/lib/audience/click-event-helpers';
 import { recordAudienceEvent } from '@/lib/audience/record-audience-event';
+import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
 import {
   CONSENT_COOKIE_NAME,
   parseConsentCookieValue,
@@ -380,13 +381,16 @@ export async function POST(request: NextRequest) {
     const audienceDeviceType = inferAudienceDeviceType(userAgent);
 
     // Determine marketing consent from jv_cc cookie.
-    // When the cookie banner is not shown (non-regulated jurisdictions),
-    // jv_cc is absent — treat absent cookie as consent given (default-allow).
-    // Only explicit marketing=false (user rejected) blocks audience tracking.
+    // Non-regulated jurisdictions remain default-allow when no banner was
+    // required, but consent-required visitors need a valid marketing opt-in.
+    const requiresCookieConsent =
+      request.cookies?.get(COOKIE_BANNER_REQUIRED_COOKIE)?.value === '1';
     const consent = parseConsentCookieValue(
       request.cookies?.get(CONSENT_COOKIE_NAME)?.value
     );
-    const hasMarketingConsent = consent === null || consent.marketing === true;
+    const hasMarketingConsent =
+      consent?.marketing === true ||
+      (consent === null && !requiresCookieConsent);
 
     // Without marketing consent: anonymize IP and use generic fingerprint.
     // With consent: full behavior (store real IP, create audience members).

--- a/apps/web/app/api/track/route.ts
+++ b/apps/web/app/api/track/route.ts
@@ -7,6 +7,10 @@ import {
   resolveAudienceClickVerb,
 } from '@/lib/audience/click-event-helpers';
 import { recordAudienceEvent } from '@/lib/audience/record-audience-event';
+import {
+  CONSENT_COOKIE_NAME,
+  parseConsentCookieValue,
+} from '@/lib/cookies/consent-state';
 import { db } from '@/lib/db';
 import { audienceMembers, clickEvents } from '@/lib/db/schema/analytics';
 import { socialLinks } from '@/lib/db/schema/links';
@@ -28,30 +32,6 @@ import {
   mergeAudienceTags,
 } from '../audience/lib/audience-utils';
 import { validateTrackRequest } from './validation';
-
-// ---------------------------------------------------------------------------
-// Consent helpers
-// ---------------------------------------------------------------------------
-
-const CONSENT_COOKIE_NAME = 'jv_cc';
-
-interface ConsentPreferences {
-  essential: boolean;
-  analytics: boolean;
-  marketing: boolean;
-}
-
-function parseConsentCookie(request: NextRequest): ConsentPreferences | null {
-  try {
-    const raw = request.cookies?.get(CONSENT_COOKIE_NAME)?.value;
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as ConsentPreferences;
-    if (typeof parsed?.marketing !== 'boolean') return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
 
 /**
  * Anonymize an IP address for privacy:
@@ -403,7 +383,9 @@ export async function POST(request: NextRequest) {
     // When the cookie banner is not shown (non-regulated jurisdictions),
     // jv_cc is absent — treat absent cookie as consent given (default-allow).
     // Only explicit marketing=false (user rejected) blocks audience tracking.
-    const consent = parseConsentCookie(request);
+    const consent = parseConsentCookieValue(
+      request.cookies?.get(CONSENT_COOKIE_NAME)?.value
+    );
     const hasMarketingConsent = consent === null || consent.marketing === true;
 
     // Without marketing consent: anonymize IP and use generic fingerprint.

--- a/apps/web/app/s/[code]/route.ts
+++ b/apps/web/app/s/[code]/route.ts
@@ -6,7 +6,10 @@ import {
 } from '@/app/api/audience/lib/audience-utils';
 import { recordAudienceEvent } from '@/lib/audience/record-audience-event';
 import { appendSourceUtmParams } from '@/lib/audience/source-links';
-import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
+import {
+  COOKIE_BANNER_REQUIRED_COOKIE,
+  isCookieBannerRequired,
+} from '@/lib/cookies/consent-regions';
 import {
   CONSENT_COOKIE_NAME,
   parseConsentCookieValue,
@@ -189,8 +192,14 @@ export async function GET(
 
     const userAgent = request.headers.get('user-agent');
     const botDetection = detectBot(request, '/s/[code]');
+    const geoCity = request.headers.get('x-vercel-ip-city');
+    const geoCountry =
+      request.headers.get('x-vercel-ip-country') ??
+      request.headers.get('cf-ipcountry');
+    const geoRegion = request.headers.get('x-vercel-ip-country-region');
     const requiresCookieConsent =
-      request.cookies?.get(COOKIE_BANNER_REQUIRED_COOKIE)?.value === '1';
+      request.cookies?.get(COOKIE_BANNER_REQUIRED_COOKIE)?.value === '1' ||
+      isCookieBannerRequired(geoCountry, geoRegion);
     const consent = parseConsentCookieValue(
       request.cookies?.get(CONSENT_COOKIE_NAME)?.value
     );
@@ -199,10 +208,6 @@ export async function GET(
     const hasMarketingConsent =
       consent?.marketing === true ||
       (consent === null && !requiresCookieConsent);
-    const geoCity = request.headers.get('x-vercel-ip-city');
-    const geoCountry =
-      request.headers.get('x-vercel-ip-country') ??
-      request.headers.get('cf-ipcountry');
 
     try {
       await withSystemIngestionSession(async tx => {

--- a/apps/web/app/s/[code]/route.ts
+++ b/apps/web/app/s/[code]/route.ts
@@ -6,6 +6,10 @@ import {
 } from '@/app/api/audience/lib/audience-utils';
 import { recordAudienceEvent } from '@/lib/audience/record-audience-event';
 import { appendSourceUtmParams } from '@/lib/audience/source-links';
+import {
+  CONSENT_COOKIE_NAME,
+  parseConsentCookieValue,
+} from '@/lib/cookies/consent-state';
 import { db } from '@/lib/db';
 import {
   audienceMembers,
@@ -19,26 +23,6 @@ import { extractClientIP } from '@/lib/utils/ip-extraction';
 import { validateSocialLinkUrl } from '@/lib/utils/url-validation';
 
 export const runtime = 'nodejs';
-
-const CONSENT_COOKIE_NAME = 'jv_cc';
-
-interface ConsentPreferences {
-  readonly essential: boolean;
-  readonly analytics: boolean;
-  readonly marketing: boolean;
-}
-
-function parseConsentCookie(request: NextRequest): ConsentPreferences | null {
-  try {
-    const raw = request.cookies?.get(CONSENT_COOKIE_NAME)?.value;
-    if (!raw) return null;
-    const parsed = JSON.parse(raw) as ConsentPreferences;
-    if (typeof parsed?.marketing !== 'boolean') return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
 
 function inferDeviceType(
   userAgent: string | null
@@ -204,7 +188,9 @@ export async function GET(
 
     const userAgent = request.headers.get('user-agent');
     const botDetection = detectBot(request, '/s/[code]');
-    const consent = parseConsentCookie(request);
+    const consent = parseConsentCookieValue(
+      request.cookies?.get(CONSENT_COOKIE_NAME)?.value
+    );
     // Match /api/track semantics: absence of jv_cc means default-allow unless the
     // visitor explicitly rejected marketing cookies.
     const hasMarketingConsent = consent === null || consent.marketing === true;

--- a/apps/web/app/s/[code]/route.ts
+++ b/apps/web/app/s/[code]/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/app/api/audience/lib/audience-utils';
 import { recordAudienceEvent } from '@/lib/audience/record-audience-event';
 import { appendSourceUtmParams } from '@/lib/audience/source-links';
+import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
 import {
   CONSENT_COOKIE_NAME,
   parseConsentCookieValue,
@@ -188,12 +189,16 @@ export async function GET(
 
     const userAgent = request.headers.get('user-agent');
     const botDetection = detectBot(request, '/s/[code]');
+    const requiresCookieConsent =
+      request.cookies?.get(COOKIE_BANNER_REQUIRED_COOKIE)?.value === '1';
     const consent = parseConsentCookieValue(
       request.cookies?.get(CONSENT_COOKIE_NAME)?.value
     );
-    // Match /api/track semantics: absence of jv_cc means default-allow unless the
-    // visitor explicitly rejected marketing cookies.
-    const hasMarketingConsent = consent === null || consent.marketing === true;
+    // Match /api/track semantics: non-regulated visits remain default-allow,
+    // but consent-required visits need a valid marketing opt-in.
+    const hasMarketingConsent =
+      consent?.marketing === true ||
+      (consent === null && !requiresCookieConsent);
     const geoCity = request.headers.get('x-vercel-ip-city');
     const geoCountry =
       request.headers.get('x-vercel-ip-country') ??

--- a/apps/web/components/molecules/CookieActions.tsx
+++ b/apps/web/components/molecules/CookieActions.tsx
@@ -7,6 +7,7 @@ export interface CookieActionsProps {
   readonly onReject: () => void;
   readonly onCustomize: () => void;
   readonly className?: string;
+  readonly disabled?: boolean;
 }
 
 const secondaryButtonStyle: CSSProperties = {
@@ -37,6 +38,7 @@ export function CookieActions({
   onReject,
   onCustomize,
   className = '',
+  disabled = false,
 }: CookieActionsProps) {
   return (
     <div
@@ -47,6 +49,7 @@ export function CookieActions({
         <button
           type='button'
           onClick={onReject}
+          disabled={disabled}
           className='flex-1 sm:flex-none transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent'
           style={secondaryButtonStyle}
         >
@@ -55,6 +58,7 @@ export function CookieActions({
         <button
           type='button'
           onClick={onCustomize}
+          disabled={disabled}
           className='flex-1 sm:flex-none transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent'
           style={secondaryButtonStyle}
         >
@@ -64,6 +68,7 @@ export function CookieActions({
       <button
         type='button'
         onClick={onAcceptAll}
+        disabled={disabled}
         className='w-full sm:w-auto transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent'
         style={primaryButtonStyle}
       >

--- a/apps/web/components/organisms/CookieBannerSection.tsx
+++ b/apps/web/components/organisms/CookieBannerSection.tsx
@@ -8,6 +8,9 @@ import { saveConsent } from '@/lib/cookies/consent';
 import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
 import { setConsentState } from '@/lib/tracking/consent';
 
+const CONSENT_SAVE_ERROR =
+  'We could not save preferences. Check your connection and try again.';
+
 declare global {
   var JVConsent:
     | {
@@ -40,6 +43,8 @@ export function CookieBannerSection() {
   const [visible, setVisible] = useState(false);
   const [customize, setCustomize] = useState(false);
   const [isMobileExpanded, setIsMobileExpanded] = useState(false);
+  const [isSavingConsent, setIsSavingConsent] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     if (isDashboard || isDemo) {
@@ -134,37 +139,58 @@ export function CookieBannerSection() {
     return () => globalThis.removeEventListener('jv:cookie:open', handleOpen);
   }, []);
 
-  const acceptAll = () => {
-    const consent = { essential: true, analytics: true, marketing: true };
-    // Persist client-side immediately so the banner hides regardless of
-    // whether the server action succeeds (network/CSRF failures must not
-    // leave the banner stuck open).
-    setConsentState('accepted');
+  const applyConsentLocally = (consent: {
+    essential: boolean;
+    analytics: boolean;
+    marketing: boolean;
+  }) => {
+    setConsentState(
+      consent.analytics || consent.marketing ? 'accepted' : 'rejected'
+    );
     try {
       localStorage.setItem('jv_cc', JSON.stringify(consent));
     } catch {
       // ignore — restricted browsing context
     }
     globalThis.JVConsent?._emit(consent);
-    setVisible(false);
-    // Best-effort server-side persistence (httpOnly cookie). Fire-and-forget
-    // — UI has already updated above.
-    saveConsent(consent).catch(() => undefined);
+  };
+
+  const persistConsent = async (consent: {
+    essential: boolean;
+    analytics: boolean;
+    marketing: boolean;
+  }) => {
+    setIsSavingConsent(true);
+    setSaveError(null);
+    try {
+      await saveConsent(consent);
+      applyConsentLocally(consent);
+      setVisible(false);
+    } catch {
+      setSaveError(CONSENT_SAVE_ERROR);
+    } finally {
+      setIsSavingConsent(false);
+    }
+  };
+
+  const acceptAll = () => {
+    const consent = { essential: true, analytics: true, marketing: true };
+    void persistConsent(consent);
   };
 
   const reject = () => {
     const consent = { essential: true, analytics: false, marketing: false };
-    // Persist client-side immediately — see acceptAll comment above.
-    setConsentState('rejected');
-    try {
-      localStorage.setItem('jv_cc', JSON.stringify(consent));
-    } catch {
-      // ignore — restricted browsing context
-    }
-    globalThis.JVConsent?._emit(consent);
+    void persistConsent(consent);
+  };
+
+  const saveCustomPreferences = (consent: {
+    essential: boolean;
+    analytics: boolean;
+    marketing: boolean;
+  }) => {
+    applyConsentLocally(consent);
     setVisible(false);
-    // Best-effort server-side persistence.
-    saveConsent(consent).catch(() => undefined);
+    setSaveError(null);
   };
 
   return (
@@ -219,7 +245,16 @@ export function CookieBannerSection() {
               onAcceptAll={acceptAll}
               onReject={reject}
               onCustomize={() => setCustomize(true)}
+              disabled={isSavingConsent}
             />
+            {saveError ? (
+              <p
+                role='alert'
+                className='mt-2 text-center text-[11px] leading-snug text-secondary-token'
+              >
+                {saveError}
+              </p>
+            ) : null}
           </div>
         </aside>
       ) : null}
@@ -228,18 +263,7 @@ export function CookieBannerSection() {
         <CookieModal
           open={customize}
           onClose={() => setCustomize(false)}
-          onSave={c => {
-            setConsentState(
-              c.analytics || c.marketing ? 'accepted' : 'rejected'
-            );
-            try {
-              localStorage.setItem('jv_cc', JSON.stringify(c));
-            } catch {
-              // ignore
-            }
-            globalThis.JVConsent?._emit(c);
-            setVisible(false);
-          }}
+          onSave={saveCustomPreferences}
         />
       ) : null}
     </>

--- a/apps/web/components/organisms/CookieModal.tsx
+++ b/apps/web/components/organisms/CookieModal.tsx
@@ -23,6 +23,9 @@ import { APP_ROUTES } from '@/constants/routes';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { type Consent, saveConsent } from '@/lib/cookies/consent';
 
+const CONSENT_SAVE_ERROR =
+  'We could not save preferences. Check your connection and try again.';
+
 const COOKIE_CATEGORIES: ReadonlyArray<{
   id: keyof Consent;
   label: string;
@@ -136,22 +139,27 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
     return { essential: true, analytics: false, marketing: false };
   });
   const isMobile = useMediaQuery('(max-width: 639px)');
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   const handleCheckedChange = (key: keyof Consent, checked: boolean) => {
     if (key === 'essential') return;
+    setSaveError(null);
     setSettings(prev => ({ ...prev, [key]: checked }));
   };
 
-  const save = () => {
-    // Invoke the parent's onSave callback first so the banner hides and
-    // localStorage is updated synchronously, regardless of whether the
-    // server-side cookie write succeeds. The server action is best-effort.
-    onSave?.(settings);
-    onClose();
-    // Best-effort server-side persistence (httpOnly cookie). Errors are
-    // suppressed — the client-side localStorage write is the source of truth
-    // for subsequent page loads.
-    saveConsent(settings).catch(() => undefined);
+  const save = async () => {
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      await saveConsent(settings);
+      onSave?.(settings);
+      onClose();
+    } catch {
+      setSaveError(CONSENT_SAVE_ERROR);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   if (isMobile) {
@@ -184,6 +192,7 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
               variant='secondary'
               size='sm'
               onClick={onClose}
+              disabled={isSaving}
               className='flex-1'
             >
               Cancel
@@ -193,11 +202,20 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
               variant='primary'
               size='sm'
               onClick={save}
+              disabled={isSaving}
               className='flex-1'
             >
               Save preferences
             </Button>
           </SheetFooter>
+          {saveError ? (
+            <p
+              role='alert'
+              className='mt-3 text-center text-2xs text-secondary-token'
+            >
+              {saveError}
+            </p>
+          ) : null}
         </SheetContent>
       </Sheet>
     );
@@ -222,13 +240,33 @@ export function CookieModal({ open, onClose, onSave }: CookieModalProps) {
           settings={settings}
           onCheckedChange={handleCheckedChange}
         />
+        {saveError ? (
+          <p
+            role='alert'
+            className='pt-3 text-center text-2xs text-secondary-token'
+          >
+            {saveError}
+          </p>
+        ) : null}
       </DialogBody>
 
       <DialogActions className='mt-3'>
-        <Button type='button' variant='secondary' size='sm' onClick={onClose}>
+        <Button
+          type='button'
+          variant='secondary'
+          size='sm'
+          onClick={onClose}
+          disabled={isSaving}
+        >
           Cancel
         </Button>
-        <Button type='button' variant='primary' size='sm' onClick={save}>
+        <Button
+          type='button'
+          variant='primary'
+          size='sm'
+          onClick={save}
+          disabled={isSaving}
+        >
           Save preferences
         </Button>
       </DialogActions>

--- a/apps/web/content/legal/cookies.md
+++ b/apps/web/content/legal/cookies.md
@@ -28,6 +28,16 @@ These cookies are required for basic site functionality and cannot be disabled.
 | `jovie_onboarding_complete` | Temporary marker that prevents an onboarding redirect loop | Session |
 | `jovie_pending_claim` | Maintains a profile claim flow while account creation completes | 7 days |
 | `jovie_plan_intent` | Stores selected signup plan long enough to complete checkout | 30 minutes |
+| `jv_tracking_consent` | Stores legacy tracking consent preferences | 1 year |
+
+### Preference Cookies
+
+These cookies remember choices you make on Jovie.
+
+| Cookie Name | Purpose | Duration |
+|------------|---------|----------|
+| `jovie_dsp` | Stores your preferred music service for profile listen links | 1 year |
+| `jv_pref_spotify` | Stores whether Spotify was selected as the preferred music service | 1 year |
 
 ### Analytics Cookies
 
@@ -46,7 +56,11 @@ Jovie currently evaluates Statsig feature flags and experiments server-side and 
 
 When enabled, these allow us to deliver relevant advertisements and measure campaign effectiveness.
 
-We do not place any marketing cookies on your device. However, when you accept marketing cookies, we use server-side event forwarding to send anonymized profile visit data to advertising platforms including Meta, Google, and TikTok. This allows us to measure the effectiveness of retargeting campaigns. No third-party tracking scripts are loaded on your device.
+| Cookie Name | Purpose | Duration |
+|------------|---------|----------|
+| `jovie_lead_attribution` | Stores claim-invite attribution for signup and campaign conversion measurement | 30 days |
+
+When you accept marketing cookies, we use server-side event forwarding to send anonymized profile visit data to advertising platforms including Meta, Google, and TikTok. This allows us to measure the effectiveness of retargeting campaigns. No third-party tracking scripts are loaded on your device.
 
 ## Managing Your Preferences
 

--- a/apps/web/content/legal/cookies.md
+++ b/apps/web/content/legal/cookies.md
@@ -1,6 +1,6 @@
 ## Cookie Policy
 
-_Last updated: February 2026_
+_Last updated: May 2026_
 
 This policy applies to {{LEGAL_ENTITY_NAME}} ("Jovie", "we", "us").
 
@@ -17,7 +17,17 @@ These cookies are required for basic site functionality and cannot be disabled.
 | Cookie Name | Purpose | Duration |
 |------------|---------|----------|
 | `jv_cc` | Stores your cookie consent preferences | 1 year |
-| `__clerk_*` | Authentication and session management | Session |
+| `jv_cc_required` | Stores whether your region requires Jovie to show cookie consent controls | 30 days |
+| `jv_country` | Stores country code for region-appropriate consent and profile localization | 30 days |
+| `__clerk_*` | Authentication, session management, and account security | Session or as configured by Clerk |
+| `__session` | Authentication session management | Session |
+| `__client_uat` | Authentication session freshness check | Session |
+| `__investor_token` | Investor portal access token for shared private links | 30 days |
+| `jovie_redirect_count` | Temporary redirect-loop protection for authentication flows | 30 seconds |
+| `jovie_onboarding_session` | Anonymous onboarding session continuity before account creation | 7 days |
+| `jovie_onboarding_complete` | Temporary marker that prevents an onboarding redirect loop | Session |
+| `jovie_pending_claim` | Maintains a profile claim flow while account creation completes | 7 days |
+| `jovie_plan_intent` | Stores selected signup plan long enough to complete checkout | 30 minutes |
 
 ### Analytics Cookies
 
@@ -25,7 +35,12 @@ When enabled, these help us understand how visitors interact with Jovie so we ca
 
 | Cookie Name | Purpose | Duration |
 |------------|---------|----------|
-| Statsig cookies | Feature experimentation and analytics | Varies |
+| `jv_city` | Stores city-level location for public profile personalization and analytics | 7 days |
+| `jv_region` | Stores region-level location for public profile personalization and analytics | 7 days |
+| `jv_aid` | Anonymous visitor identifier used to de-duplicate profile visits and audience analytics | 1 year |
+| `jv_identified` | Records that a browser has been associated with a signed-in Jovie account for audience de-duplication | 1 year |
+
+Jovie currently evaluates Statsig feature flags and experiments server-side and does not set browser Statsig cookies.
 
 ### Marketing Cookies
 
@@ -47,7 +62,7 @@ Note that disabling certain cookies may affect your experience on Jovie.
 Our trusted partners may set cookies on your device:
 
 - **Clerk**: For secure authentication
-- **Statsig**: For analytics and experimentation (when analytics cookies are enabled)
+- **Statsig**: Used server-side for analytics and experimentation; Jovie does not currently set browser Statsig cookies
 - **Stripe**: For payment processing (only on checkout pages)
 
 ## Updates to This Policy

--- a/apps/web/lib/cookies/consent-state.ts
+++ b/apps/web/lib/cookies/consent-state.ts
@@ -1,0 +1,29 @@
+export type ConsentPreferences = {
+  readonly essential: boolean;
+  readonly analytics: boolean;
+  readonly marketing: boolean;
+};
+
+export const CONSENT_COOKIE_NAME = 'jv_cc';
+
+export function parseConsentCookieValue(
+  cookieValue: string | undefined
+): ConsentPreferences | null {
+  try {
+    if (!cookieValue) return null;
+    const parsed = JSON.parse(cookieValue) as ConsentPreferences;
+    if (typeof parsed?.essential !== 'boolean') return null;
+    if (typeof parsed?.analytics !== 'boolean') return null;
+    if (typeof parsed?.marketing !== 'boolean') return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function hasAnalyticsOrMarketingConsent(
+  cookieValue: string | undefined
+): boolean {
+  const consent = parseConsentCookieValue(cookieValue);
+  return consent?.analytics === true || consent?.marketing === true;
+}

--- a/apps/web/lib/cookies/consent-state.ts
+++ b/apps/web/lib/cookies/consent-state.ts
@@ -27,3 +27,8 @@ export function hasAnalyticsOrMarketingConsent(
   const consent = parseConsentCookieValue(cookieValue);
   return consent?.analytics === true || consent?.marketing === true;
 }
+
+export function hasAnalyticsConsent(cookieValue: string | undefined): boolean {
+  const consent = parseConsentCookieValue(cookieValue);
+  return consent?.analytics === true;
+}

--- a/apps/web/lib/cookies/registry.ts
+++ b/apps/web/lib/cookies/registry.ts
@@ -1,0 +1,193 @@
+import {
+  AUDIENCE_ANON_COOKIE,
+  AUDIENCE_IDENTIFIED_COOKIE,
+  COUNTRY_CODE_COOKIE,
+  HOMEPAGE_CITY_COOKIE,
+  HOMEPAGE_REGION_COOKIE,
+} from '@/constants/app';
+import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
+import { CONSENT_COOKIE_NAME } from '@/lib/cookies/consent-state';
+
+export type CookieCategory = 'essential' | 'analytics' | 'marketing';
+export type CookieMatch = 'exact' | 'prefix';
+
+export type CookieRegistryEntry = {
+  readonly name: string;
+  readonly match: CookieMatch;
+  readonly category: CookieCategory;
+  readonly purpose: string;
+  readonly duration: string;
+  readonly ttlSeconds: number | null;
+  readonly preConsent: boolean;
+};
+
+export const COOKIE_REGISTRY = [
+  {
+    name: CONSENT_COOKIE_NAME,
+    match: 'exact',
+    category: 'essential',
+    purpose: 'Stores your cookie consent preferences.',
+    duration: '1 year',
+    ttlSeconds: 60 * 60 * 24 * 365,
+    preConsent: true,
+  },
+  {
+    name: COOKIE_BANNER_REQUIRED_COOKIE,
+    match: 'exact',
+    category: 'essential',
+    purpose:
+      'Stores whether your region requires Jovie to show cookie consent controls.',
+    duration: '30 days',
+    ttlSeconds: 60 * 60 * 24 * 30,
+    preConsent: true,
+  },
+  {
+    name: COUNTRY_CODE_COOKIE,
+    match: 'exact',
+    category: 'essential',
+    purpose:
+      'Stores country code for region-appropriate consent and profile localization.',
+    duration: '30 days',
+    ttlSeconds: 60 * 60 * 24 * 30,
+    preConsent: true,
+  },
+  {
+    name: '__clerk_*',
+    match: 'prefix',
+    category: 'essential',
+    purpose: 'Authentication, session management, and account security.',
+    duration: 'Session or as configured by Clerk',
+    ttlSeconds: null,
+    preConsent: true,
+  },
+  {
+    name: '__session',
+    match: 'exact',
+    category: 'essential',
+    purpose: 'Authentication session management.',
+    duration: 'Session',
+    ttlSeconds: null,
+    preConsent: true,
+  },
+  {
+    name: '__client_uat',
+    match: 'exact',
+    category: 'essential',
+    purpose: 'Authentication session freshness check.',
+    duration: 'Session',
+    ttlSeconds: null,
+    preConsent: true,
+  },
+  {
+    name: '__investor_token',
+    match: 'exact',
+    category: 'essential',
+    purpose: 'Investor portal access token for shared private links.',
+    duration: '30 days',
+    ttlSeconds: 60 * 60 * 24 * 30,
+    preConsent: true,
+  },
+  {
+    name: 'jovie_redirect_count',
+    match: 'exact',
+    category: 'essential',
+    purpose: 'Temporary redirect-loop protection for authentication flows.',
+    duration: '30 seconds',
+    ttlSeconds: 30,
+    preConsent: true,
+  },
+  {
+    name: 'jovie_onboarding_session',
+    match: 'exact',
+    category: 'essential',
+    purpose: 'Anonymous onboarding session continuity before account creation.',
+    duration: '7 days',
+    ttlSeconds: 60 * 60 * 24 * 7,
+    preConsent: true,
+  },
+  {
+    name: 'jovie_onboarding_complete',
+    match: 'exact',
+    category: 'essential',
+    purpose: 'Temporary marker that prevents an onboarding redirect loop.',
+    duration: 'Session',
+    ttlSeconds: null,
+    preConsent: true,
+  },
+  {
+    name: 'jovie_pending_claim',
+    match: 'exact',
+    category: 'essential',
+    purpose: 'Maintains a profile claim flow while account creation completes.',
+    duration: '7 days',
+    ttlSeconds: 60 * 60 * 24 * 7,
+    preConsent: true,
+  },
+  {
+    name: 'jovie_plan_intent',
+    match: 'exact',
+    category: 'essential',
+    purpose: 'Stores selected signup plan long enough to complete checkout.',
+    duration: '30 minutes',
+    ttlSeconds: 60 * 30,
+    preConsent: true,
+  },
+  {
+    name: HOMEPAGE_CITY_COOKIE,
+    match: 'exact',
+    category: 'analytics',
+    purpose:
+      'Stores city-level location for public profile personalization and analytics.',
+    duration: '7 days',
+    ttlSeconds: 60 * 60 * 24 * 7,
+    preConsent: false,
+  },
+  {
+    name: HOMEPAGE_REGION_COOKIE,
+    match: 'exact',
+    category: 'analytics',
+    purpose:
+      'Stores region-level location for public profile personalization and analytics.',
+    duration: '7 days',
+    ttlSeconds: 60 * 60 * 24 * 7,
+    preConsent: false,
+  },
+  {
+    name: AUDIENCE_ANON_COOKIE,
+    match: 'exact',
+    category: 'analytics',
+    purpose:
+      'Anonymous visitor identifier used to de-duplicate profile visits and audience analytics.',
+    duration: '1 year',
+    ttlSeconds: 60 * 60 * 24 * 365,
+    preConsent: false,
+  },
+  {
+    name: AUDIENCE_IDENTIFIED_COOKIE,
+    match: 'exact',
+    category: 'analytics',
+    purpose:
+      'Records that a browser has been associated with a signed-in Jovie account for audience de-duplication.',
+    duration: '1 year',
+    ttlSeconds: 60 * 60 * 24 * 365,
+    preConsent: false,
+  },
+] as const satisfies readonly CookieRegistryEntry[];
+
+export const NONESSENTIAL_PROXY_COOKIE_NAMES = [
+  HOMEPAGE_CITY_COOKIE,
+  HOMEPAGE_REGION_COOKIE,
+  AUDIENCE_ANON_COOKIE,
+  AUDIENCE_IDENTIFIED_COOKIE,
+] as const;
+
+export function isRegisteredCookieName(cookieName: string): boolean {
+  return COOKIE_REGISTRY.some(entry => {
+    if (entry.match === 'exact') return entry.name === cookieName;
+    return cookieName.startsWith(entry.name.replace('*', ''));
+  });
+}
+
+export function getCookiesByCategory(category: CookieCategory) {
+  return COOKIE_REGISTRY.filter(entry => entry.category === category);
+}

--- a/apps/web/lib/cookies/registry.ts
+++ b/apps/web/lib/cookies/registry.ts
@@ -1,14 +1,20 @@
 import {
   AUDIENCE_ANON_COOKIE,
   AUDIENCE_IDENTIFIED_COOKIE,
+  AUDIENCE_SPOTIFY_PREFERRED_COOKIE,
   COUNTRY_CODE_COOKIE,
   HOMEPAGE_CITY_COOKIE,
   HOMEPAGE_REGION_COOKIE,
+  LISTEN_COOKIE,
 } from '@/constants/app';
 import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
 import { CONSENT_COOKIE_NAME } from '@/lib/cookies/consent-state';
 
-export type CookieCategory = 'essential' | 'analytics' | 'marketing';
+export type CookieCategory =
+  | 'essential'
+  | 'preferences'
+  | 'analytics'
+  | 'marketing';
 export type CookieMatch = 'exact' | 'prefix';
 
 export type CookieRegistryEntry = {
@@ -133,6 +139,34 @@ export const COOKIE_REGISTRY = [
     preConsent: true,
   },
   {
+    name: 'jv_tracking_consent',
+    match: 'exact',
+    category: 'essential',
+    purpose: 'Stores legacy tracking consent preferences.',
+    duration: '1 year',
+    ttlSeconds: 60 * 60 * 24 * 365,
+    preConsent: true,
+  },
+  {
+    name: LISTEN_COOKIE,
+    match: 'exact',
+    category: 'preferences',
+    purpose: 'Stores your preferred music service for profile listen links.',
+    duration: '1 year',
+    ttlSeconds: 60 * 60 * 24 * 365,
+    preConsent: true,
+  },
+  {
+    name: AUDIENCE_SPOTIFY_PREFERRED_COOKIE,
+    match: 'exact',
+    category: 'preferences',
+    purpose:
+      'Stores whether Spotify was selected as the preferred music service.',
+    duration: '1 year',
+    ttlSeconds: 60 * 60 * 24 * 365,
+    preConsent: true,
+  },
+  {
     name: HOMEPAGE_CITY_COOKIE,
     match: 'exact',
     category: 'analytics',
@@ -170,6 +204,16 @@ export const COOKIE_REGISTRY = [
       'Records that a browser has been associated with a signed-in Jovie account for audience de-duplication.',
     duration: '1 year',
     ttlSeconds: 60 * 60 * 24 * 365,
+    preConsent: false,
+  },
+  {
+    name: 'jovie_lead_attribution',
+    match: 'exact',
+    category: 'marketing',
+    purpose:
+      'Stores claim-invite attribution for signup and campaign conversion measurement.',
+    duration: '30 days',
+    ttlSeconds: 60 * 60 * 24 * 30,
     preConsent: false,
   },
 ] as const satisfies readonly CookieRegistryEntry[];

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -40,7 +40,7 @@ import {
 } from '@/lib/cookies/consent-regions';
 import {
   CONSENT_COOKIE_NAME,
-  hasAnalyticsOrMarketingConsent,
+  hasAnalyticsConsent,
 } from '@/lib/cookies/consent-state';
 import { NONESSENTIAL_PROXY_COOKIE_NAMES } from '@/lib/cookies/registry';
 import { captureError } from '@/lib/error-tracking';
@@ -1028,9 +1028,9 @@ function buildFinalResponse(
   const currentCountryCode =
     req.cookies.get(COUNTRY_CODE_COOKIE)?.value ?? null;
   const nextCookieRequirement = requiresCookieConsent ? '1' : '0';
-  const canSetNonessentialProxyCookies =
+  const canSetAnalyticsProxyCookies =
     !requiresCookieConsent ||
-    hasAnalyticsOrMarketingConsent(req.cookies.get(CONSENT_COOKIE_NAME)?.value);
+    hasAnalyticsConsent(req.cookies.get(CONSENT_COOKIE_NAME)?.value);
 
   if (normalizedCountryCode && currentCountryCode !== normalizedCountryCode) {
     res.cookies.set(COUNTRY_CODE_COOKIE, normalizedCountryCode, {
@@ -1055,7 +1055,7 @@ function buildFinalResponse(
     });
   }
 
-  if (requiresCookieConsent && !canSetNonessentialProxyCookies) {
+  if (requiresCookieConsent && !canSetAnalyticsProxyCookies) {
     for (const cookieName of NONESSENTIAL_PROXY_COOKIE_NAMES) {
       if (req.cookies.get(cookieName)?.value) {
         res.cookies.set(cookieName, '', {
@@ -1068,7 +1068,7 @@ function buildFinalResponse(
     }
   }
 
-  if (canSetNonessentialProxyCookies) {
+  if (canSetAnalyticsProxyCookies) {
     if (geo.city && req.cookies.get(HOMEPAGE_CITY_COOKIE)?.value !== geo.city) {
       res.cookies.set(HOMEPAGE_CITY_COOKIE, geo.city, {
         httpOnly: false,

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -38,6 +38,11 @@ import {
   COOKIE_BANNER_REQUIRED_COOKIE,
   isCookieBannerRequired,
 } from '@/lib/cookies/consent-regions';
+import {
+  CONSENT_COOKIE_NAME,
+  hasAnalyticsOrMarketingConsent,
+} from '@/lib/cookies/consent-state';
+import { NONESSENTIAL_PROXY_COOKIE_NAMES } from '@/lib/cookies/registry';
 import { captureError } from '@/lib/error-tracking';
 import {
   analyzeHost,
@@ -1010,30 +1015,6 @@ function buildFinalResponse(
   }
 
   const geo = getGeoFromRequest(req);
-
-  if (geo.city && req.cookies.get(HOMEPAGE_CITY_COOKIE)?.value !== geo.city) {
-    res.cookies.set(HOMEPAGE_CITY_COOKIE, geo.city, {
-      httpOnly: false,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 60 * 60 * 24 * 7,
-      path: '/',
-    });
-  }
-
-  if (
-    geo.region &&
-    req.cookies.get(HOMEPAGE_REGION_COOKIE)?.value !== geo.region
-  ) {
-    res.cookies.set(HOMEPAGE_REGION_COOKIE, geo.region, {
-      httpOnly: false,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 60 * 60 * 24 * 7,
-      path: '/',
-    });
-  }
-
   const countryCode =
     req.headers.get('x-vercel-ip-country') ?? req.headers.get('cf-ipcountry');
   const normalizedCountryCode = countryCode?.trim().toUpperCase() ?? null;
@@ -1047,6 +1028,9 @@ function buildFinalResponse(
   const currentCountryCode =
     req.cookies.get(COUNTRY_CODE_COOKIE)?.value ?? null;
   const nextCookieRequirement = requiresCookieConsent ? '1' : '0';
+  const canSetNonessentialProxyCookies =
+    !requiresCookieConsent ||
+    hasAnalyticsOrMarketingConsent(req.cookies.get(CONSENT_COOKIE_NAME)?.value);
 
   if (normalizedCountryCode && currentCountryCode !== normalizedCountryCode) {
     res.cookies.set(COUNTRY_CODE_COOKIE, normalizedCountryCode, {
@@ -1071,25 +1055,63 @@ function buildFinalResponse(
     });
   }
 
-  // Set audience tracking cookies
-  if (!req.cookies.get(AUDIENCE_ANON_COOKIE)?.value) {
-    res.cookies.set(AUDIENCE_ANON_COOKIE, crypto.randomUUID(), {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 60 * 60 * 24 * 365,
-      path: '/',
-    });
+  if (requiresCookieConsent && !canSetNonessentialProxyCookies) {
+    for (const cookieName of NONESSENTIAL_PROXY_COOKIE_NAMES) {
+      if (req.cookies.get(cookieName)?.value) {
+        res.cookies.set(cookieName, '', {
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'lax',
+          maxAge: 0,
+          path: '/',
+        });
+      }
+    }
   }
 
-  if (userId && res.cookies.get(AUDIENCE_IDENTIFIED_COOKIE)?.value !== '1') {
-    res.cookies.set(AUDIENCE_IDENTIFIED_COOKIE, '1', {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      maxAge: 60 * 60 * 24 * 365,
-      path: '/',
-    });
+  if (canSetNonessentialProxyCookies) {
+    if (geo.city && req.cookies.get(HOMEPAGE_CITY_COOKIE)?.value !== geo.city) {
+      res.cookies.set(HOMEPAGE_CITY_COOKIE, geo.city, {
+        httpOnly: false,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 7,
+        path: '/',
+      });
+    }
+
+    if (
+      geo.region &&
+      req.cookies.get(HOMEPAGE_REGION_COOKIE)?.value !== geo.region
+    ) {
+      res.cookies.set(HOMEPAGE_REGION_COOKIE, geo.region, {
+        httpOnly: false,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 7,
+        path: '/',
+      });
+    }
+
+    // Set audience tracking cookies.
+    if (!req.cookies.get(AUDIENCE_ANON_COOKIE)?.value) {
+      res.cookies.set(AUDIENCE_ANON_COOKIE, crypto.randomUUID(), {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 365,
+        path: '/',
+      });
+    }
+
+    if (userId && req.cookies.get(AUDIENCE_IDENTIFIED_COOKIE)?.value !== '1') {
+      res.cookies.set(AUDIENCE_IDENTIFIED_COOKIE, '1', {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 365,
+        path: '/',
+      });
+    }
   }
 
   // Performance monitoring

--- a/apps/web/tests/unit/api/track/route.test.ts
+++ b/apps/web/tests/unit/api/track/route.test.ts
@@ -206,6 +206,48 @@ describe('POST /api/track', () => {
     expect(recordAudienceEvent).not.toHaveBeenCalled();
   });
 
+  it('uses server geo headers when the consent-required cookie is tampered off', async () => {
+    const insertMock = vi.fn();
+    const valuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 'click_event_123' }]),
+    });
+
+    insertMock.mockReturnValue({
+      values: valuesMock,
+    });
+
+    hoisted.withSystemIngestionSession.mockImplementationOnce(async callback =>
+      callback({
+        insert: insertMock,
+      })
+    );
+
+    const request = new NextRequest('http://localhost/api/track', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: 'jv_cc_required=0',
+        'x-vercel-ip-country': 'DE',
+      },
+      body: JSON.stringify({
+        handle: 'artist123',
+        linkType: 'other',
+        target: 'https://example.com',
+      }),
+    });
+
+    const response = await POST(request as unknown as NextRequest);
+
+    expect(response.status).toBe(200);
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipAddress: '203.0.113.0',
+        audienceMemberId: null,
+      })
+    );
+    expect(recordAudienceEvent).not.toHaveBeenCalled();
+  });
+
   it('records a human-readable source label for tracked audience events', async () => {
     hoisted.withSystemIngestionSession.mockImplementationOnce(async callback =>
       callback({

--- a/apps/web/tests/unit/api/track/route.test.ts
+++ b/apps/web/tests/unit/api/track/route.test.ts
@@ -161,6 +161,51 @@ describe('POST /api/track', () => {
     );
   });
 
+  it.each([
+    ['absent consent cookie', 'jv_cc_required=1'],
+    ['invalid consent cookie', 'jv_cc_required=1; jv_cc=not-json'],
+  ])('anonymizes clicks and skips audience members for consent-required visitors with %s', async (_label, cookieHeader) => {
+    const insertMock = vi.fn();
+    const valuesMock = vi.fn().mockReturnValue({
+      returning: vi.fn().mockResolvedValue([{ id: 'click_event_123' }]),
+    });
+
+    insertMock.mockReturnValue({
+      values: valuesMock,
+    });
+
+    hoisted.withSystemIngestionSession.mockImplementationOnce(async callback =>
+      callback({
+        insert: insertMock,
+      })
+    );
+
+    const request = new NextRequest('http://localhost/api/track', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Cookie: cookieHeader,
+      },
+      body: JSON.stringify({
+        handle: 'artist123',
+        linkType: 'other',
+        target: 'https://example.com',
+      }),
+    });
+
+    const response = await POST(request as unknown as NextRequest);
+
+    expect(response.status).toBe(200);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ipAddress: '203.0.113.0',
+        audienceMemberId: null,
+      })
+    );
+    expect(recordAudienceEvent).not.toHaveBeenCalled();
+  });
+
   it('records a human-readable source label for tracked audience events', async () => {
     hoisted.withSystemIngestionSession.mockImplementationOnce(async callback =>
       callback({

--- a/apps/web/tests/unit/app/s-code-route.test.ts
+++ b/apps/web/tests/unit/app/s-code-route.test.ts
@@ -182,4 +182,24 @@ describe('GET /s/[code]', () => {
     expect(mocks.txInsertMock).not.toHaveBeenCalled();
     expect(recordAudienceEvent).not.toHaveBeenCalled();
   });
+
+  it('uses server geo headers when the consent-required cookie is tampered off', async () => {
+    const request = new NextRequest('http://localhost/s/abc123', {
+      headers: {
+        Cookie: 'jv_cc_required=0',
+        'x-vercel-ip-country': 'DE',
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ code: 'abc123' }),
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      'https://example.com/profile'
+    );
+    expect(mocks.txInsertMock).not.toHaveBeenCalled();
+    expect(recordAudienceEvent).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/tests/unit/app/s-code-route.test.ts
+++ b/apps/web/tests/unit/app/s-code-route.test.ts
@@ -160,4 +160,26 @@ describe('GET /s/[code]', () => {
       })
     );
   });
+
+  it.each([
+    ['absent consent cookie', 'jv_cc_required=1'],
+    ['malformed consent cookie', 'jv_cc_required=1; jv_cc=not-json'],
+  ])('skips audience recording in consent-required regions with %s', async (_caseName, cookieHeader) => {
+    const request = new NextRequest('http://localhost/s/abc123', {
+      headers: {
+        Cookie: cookieHeader,
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ code: 'abc123' }),
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      'https://example.com/profile'
+    );
+    expect(mocks.txInsertMock).not.toHaveBeenCalled();
+    expect(recordAudienceEvent).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/tests/unit/app/s-code-route.test.ts
+++ b/apps/web/tests/unit/app/s-code-route.test.ts
@@ -1,0 +1,163 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from '@/app/s/[code]/route';
+import { recordAudienceEvent } from '@/lib/audience/record-audience-event';
+
+const mocks = vi.hoisted(() => {
+  const sourceLink = {
+    id: 'source_link_123',
+    creatorProfileId: 'profile_123',
+    code: 'abc123',
+    name: 'QR Campaign',
+    sourceType: 'qr',
+    destinationKind: 'profile',
+    destinationId: 'profile_123',
+    destinationUrl: 'https://example.com/profile',
+    utmParams: {},
+    metadata: {},
+    archivedAt: null,
+  };
+
+  const selectLimitMock = vi.fn().mockResolvedValue([sourceLink]);
+  const selectWhereMock = vi.fn().mockReturnValue({ limit: selectLimitMock });
+  const selectFromMock = vi.fn().mockReturnValue({ where: selectWhereMock });
+  const selectMock = vi.fn().mockReturnValue({ from: selectFromMock });
+
+  const txUpdateWhereMock = vi.fn().mockResolvedValue(undefined);
+  const txUpdateSetMock = vi.fn().mockReturnValue({ where: txUpdateWhereMock });
+  const txUpdateMock = vi.fn().mockReturnValue({ set: txUpdateSetMock });
+
+  const txInsertReturningMock = vi.fn().mockResolvedValue([
+    {
+      id: 'audience_member_123',
+      tags: [],
+      visits: 1,
+      engagementScore: 1,
+    },
+  ]);
+  const txInsertOnConflictMock = vi.fn().mockReturnValue({
+    returning: txInsertReturningMock,
+  });
+  const txInsertValuesMock = vi.fn().mockReturnValue({
+    onConflictDoNothing: txInsertOnConflictMock,
+  });
+  const txInsertMock = vi.fn().mockReturnValue({ values: txInsertValuesMock });
+
+  const withSystemIngestionSession = vi
+    .fn()
+    .mockImplementation(async callback =>
+      callback({
+        update: txUpdateMock,
+        insert: txInsertMock,
+      })
+    );
+
+  return {
+    selectMock,
+    selectLimitMock,
+    sourceLink,
+    txInsertMock,
+    withSystemIngestionSession,
+    recordAudienceEvent: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mocks.selectMock,
+  },
+}));
+
+vi.mock('@/lib/db/schema/analytics', () => ({
+  audienceMembers: {
+    id: 'id',
+    creatorProfileId: 'creatorProfileId',
+    fingerprint: 'fingerprint',
+    tags: 'tags',
+    visits: 'visits',
+    engagementScore: 'engagementScore',
+  },
+  audienceSourceLinks: {
+    id: 'id',
+    code: 'code',
+    scanCount: 'scanCount',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  sql: vi.fn().mockReturnValue('sql'),
+}));
+
+vi.mock('@/lib/ingestion/session', () => ({
+  withSystemIngestionSession: mocks.withSystemIngestionSession,
+}));
+
+vi.mock('@/lib/audience/record-audience-event', () => ({
+  recordAudienceEvent: mocks.recordAudienceEvent,
+}));
+
+vi.mock('@/app/api/audience/lib/audience-utils', () => ({
+  createFingerprint: vi.fn().mockReturnValue('fingerprint'),
+  mergeAudienceTags: vi
+    .fn()
+    .mockImplementation((existing, next) => [
+      ...(existing ?? []),
+      ...(next ?? []),
+    ]),
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  publicClickLimiter: {
+    limit: vi.fn().mockResolvedValue({ success: true }),
+  },
+}));
+
+vi.mock('@/lib/utils/bot-detection', () => ({
+  detectBot: vi.fn().mockReturnValue({ isBot: false }),
+}));
+
+vi.mock('@/lib/utils/ip-extraction', () => ({
+  extractClientIP: vi.fn().mockReturnValue('203.0.113.1'),
+}));
+
+vi.mock('@/lib/utils/url-validation', () => ({
+  validateSocialLinkUrl: vi.fn().mockReturnValue({ valid: true }),
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('GET /s/[code]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.selectLimitMock.mockResolvedValue([mocks.sourceLink]);
+  });
+
+  it('treats partial consent cookies as malformed through the shared parser', async () => {
+    const request = new NextRequest('http://localhost/s/abc123', {
+      headers: {
+        Cookie: 'jv_cc={"marketing":false}',
+      },
+    });
+
+    const response = await GET(request, {
+      params: Promise.resolve({ code: 'abc123' }),
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      'https://example.com/profile'
+    );
+    expect(mocks.txInsertMock).toHaveBeenCalledTimes(1);
+    expect(recordAudienceEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        audienceMemberId: 'audience_member_123',
+        eventType: 'source_scanned',
+      })
+    );
+  });
+});

--- a/apps/web/tests/unit/cookie-banner-fixes.test.tsx
+++ b/apps/web/tests/unit/cookie-banner-fixes.test.tsx
@@ -54,7 +54,7 @@ describe('CookieBannerSection consent sync', () => {
     });
   });
 
-  it('hides banner immediately on acceptAll even if saveConsent rejects', async () => {
+  it('keeps banner visible on acceptAll when saveConsent rejects', async () => {
     mockSaveConsent.mockRejectedValue(new Error('server error'));
     const mod = await import('@/components/organisms/CookieBannerSection');
     setCookie('jv_cc_required=1');
@@ -65,26 +65,30 @@ describe('CookieBannerSection consent sync', () => {
     const btn = screen.getByRole('button', { name: /accept all/i });
     fireEvent.click(btn);
 
-    // Banner must disappear even if the server action fails.
     await vi.waitFor(() => {
-      expect(screen.queryByTestId('cookie-banner')).not.toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /could not save preferences/i
+      );
     });
+    expect(screen.getByTestId('cookie-banner')).toBeInTheDocument();
+    expect(localStorage.getItem('jv_cc')).toBeNull();
   });
 
-  it('persists consent to localStorage before server action on acceptAll', async () => {
+  it('persists consent to localStorage after server action on acceptAll', async () => {
     const mod = await import('@/components/organisms/CookieBannerSection');
     setCookie('jv_cc_required=1');
     render(<mod.CookieBannerSection />);
 
     fireEvent.click(screen.getByRole('button', { name: /accept all/i }));
 
-    // localStorage must be written synchronously (before the SA resolves).
-    const saved = localStorage.getItem('jv_cc');
-    expect(saved).toBeTruthy();
-    expect(JSON.parse(saved!)).toMatchObject({
-      essential: true,
-      analytics: true,
-      marketing: true,
+    await vi.waitFor(() => {
+      const saved = localStorage.getItem('jv_cc');
+      expect(saved).toBeTruthy();
+      expect(JSON.parse(saved!)).toMatchObject({
+        essential: true,
+        analytics: true,
+        marketing: true,
+      });
     });
   });
 
@@ -106,7 +110,7 @@ describe('CookieBannerSection consent sync', () => {
     });
   });
 
-  it('hides banner immediately on reject even if saveConsent rejects', async () => {
+  it('keeps banner visible on reject when saveConsent rejects', async () => {
     mockSaveConsent.mockRejectedValue(new Error('server error'));
     const mod = await import('@/components/organisms/CookieBannerSection');
     setCookie('jv_cc_required=1');
@@ -117,12 +121,20 @@ describe('CookieBannerSection consent sync', () => {
     fireEvent.click(screen.getByRole('button', { name: /reject/i }));
 
     await vi.waitFor(() => {
-      expect(screen.queryByTestId('cookie-banner')).not.toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /could not save preferences/i
+      );
     });
+    expect(screen.getByTestId('cookie-banner')).toBeInTheDocument();
+    expect(localStorage.getItem('jv_cc')).toBeNull();
   });
 });
 
 describe('CookieModal loads saved preferences', () => {
+  beforeEach(() => {
+    mockSaveConsent.mockResolvedValue(undefined);
+  });
+
   beforeEach(() => {
     localStorage.clear();
   });
@@ -167,7 +179,22 @@ describe('CookieModal loads saved preferences', () => {
     );
   });
 
-  it('calls onSave and onClose when Save Preferences clicked even if saveConsent rejects', async () => {
+  it('calls onSave and onClose when Save Preferences succeeds', async () => {
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+
+    const { CookieModal } = await import('@/components/organisms/CookieModal');
+    render(<CookieModal open onClose={onClose} onSave={onSave} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /save preferences/i }));
+
+    await vi.waitFor(() => {
+      expect(onSave).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('keeps preferences open when saveConsent rejects', async () => {
     mockSaveConsent.mockRejectedValue(new Error('server error'));
     const onSave = vi.fn();
     const onClose = vi.fn();
@@ -177,9 +204,13 @@ describe('CookieModal loads saved preferences', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /save preferences/i }));
 
-    // onSave and onClose must be called synchronously, before the server action resolves.
-    expect(onSave).toHaveBeenCalledTimes(1);
-    expect(onClose).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /could not save preferences/i
+      );
+    });
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/tests/unit/lib/cookies/registry.test.ts
+++ b/apps/web/tests/unit/lib/cookies/registry.test.ts
@@ -62,8 +62,14 @@ describe('cookie registry', () => {
   });
 
   it('documents that Statsig does not currently set browser cookies', () => {
+    const analyticsCookieNames = getCookiesByCategory('analytics').map(
+      entry => entry.name
+    );
+
     expect(
-      getCookiesByCategory('analytics').map(entry => entry.name)
-    ).not.toEqual(expect.arrayContaining(['statsig_*', '_stsg_*']));
+      analyticsCookieNames.some(
+        name => name.startsWith('statsig_') || name.startsWith('_stsg_')
+      )
+    ).toBe(false);
   });
 });

--- a/apps/web/tests/unit/lib/cookies/registry.test.ts
+++ b/apps/web/tests/unit/lib/cookies/registry.test.ts
@@ -20,6 +20,17 @@ describe('cookie registry', () => {
     expect(isRegisteredCookieName('unknown_cookie')).toBe(false);
   });
 
+  it('registers active first-party cookie writers', () => {
+    expect(COOKIE_REGISTRY.map(entry => entry.name)).toEqual(
+      expect.arrayContaining([
+        'jv_tracking_consent',
+        'jovie_dsp',
+        'jv_pref_spotify',
+        'jovie_lead_attribution',
+      ])
+    );
+  });
+
   it('marks only nonessential proxy cookies as blocked before consent', () => {
     const blocked = new Set(NONESSENTIAL_PROXY_COOKIE_NAMES);
     expect(blocked).toEqual(

--- a/apps/web/tests/unit/lib/cookies/registry.test.ts
+++ b/apps/web/tests/unit/lib/cookies/registry.test.ts
@@ -54,10 +54,14 @@ describe('cookie registry', () => {
       join(process.cwd(), 'content/legal/cookies.md'),
       'utf8'
     );
+    const policyRows = policy.split('\n').filter(line => line.startsWith('|'));
 
     for (const entry of COOKIE_REGISTRY) {
-      expect(policy).toContain(`\`${entry.name}\``);
-      expect(policy).toContain(entry.duration);
+      const row = policyRows.find(line =>
+        line.includes(`| \`${entry.name}\` |`)
+      );
+      expect(row).toBeDefined();
+      expect(row ?? '').toContain(`| ${entry.duration} |`);
     }
   });
 

--- a/apps/web/tests/unit/lib/cookies/registry.test.ts
+++ b/apps/web/tests/unit/lib/cookies/registry.test.ts
@@ -37,15 +37,11 @@ describe('cookie registry', () => {
       new Set(['jv_city', 'jv_region', 'jv_aid', 'jv_identified'])
     );
 
-    for (const entry of COOKIE_REGISTRY) {
-      if (
-        blocked.has(
-          entry.name as (typeof NONESSENTIAL_PROXY_COOKIE_NAMES)[number]
-        )
-      ) {
-        expect(entry.preConsent).toBe(false);
-        expect(entry.category).toBe('analytics');
-      }
+    for (const cookieName of blocked) {
+      const entry = COOKIE_REGISTRY.find(item => item.name === cookieName);
+      expect(entry).toBeDefined();
+      expect(entry?.preConsent).toBe(false);
+      expect(entry?.category).toBe('analytics');
     }
   });
 

--- a/apps/web/tests/unit/lib/cookies/registry.test.ts
+++ b/apps/web/tests/unit/lib/cookies/registry.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  COOKIE_REGISTRY,
+  getCookiesByCategory,
+  isRegisteredCookieName,
+  NONESSENTIAL_PROXY_COOKIE_NAMES,
+} from '@/lib/cookies/registry';
+
+describe('cookie registry', () => {
+  it('keeps registry names unique', () => {
+    const names = COOKIE_REGISTRY.map(entry => entry.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('identifies exact and prefix cookie names', () => {
+    expect(isRegisteredCookieName('jv_aid')).toBe(true);
+    expect(isRegisteredCookieName('__clerk_db_jwt')).toBe(true);
+    expect(isRegisteredCookieName('unknown_cookie')).toBe(false);
+  });
+
+  it('marks only nonessential proxy cookies as blocked before consent', () => {
+    const blocked = new Set(NONESSENTIAL_PROXY_COOKIE_NAMES);
+    expect(blocked).toEqual(
+      new Set(['jv_city', 'jv_region', 'jv_aid', 'jv_identified'])
+    );
+
+    for (const entry of COOKIE_REGISTRY) {
+      if (
+        blocked.has(
+          entry.name as (typeof NONESSENTIAL_PROXY_COOKIE_NAMES)[number]
+        )
+      ) {
+        expect(entry.preConsent).toBe(false);
+        expect(entry.category).toBe('analytics');
+      }
+    }
+  });
+
+  it('keeps cookie policy disclosure aligned with the registry', () => {
+    const policy = readFileSync(
+      join(process.cwd(), 'content/legal/cookies.md'),
+      'utf8'
+    );
+
+    for (const entry of COOKIE_REGISTRY) {
+      expect(policy).toContain(`\`${entry.name}\``);
+      expect(policy).toContain(entry.duration);
+    }
+  });
+
+  it('documents that Statsig does not currently set browser cookies', () => {
+    expect(
+      getCookiesByCategory('analytics').map(entry => entry.name)
+    ).not.toEqual(expect.arrayContaining(['statsig_*', '_stsg_*']));
+  });
+});

--- a/apps/web/tests/unit/lib/tracking/parse-consent-cookie.test.ts
+++ b/apps/web/tests/unit/lib/tracking/parse-consent-cookie.test.ts
@@ -2,7 +2,10 @@
  * Tests for server-side consent cookie parsing used by /api/track.
  */
 import { describe, expect, it } from 'vitest';
-import { parseConsentCookieValue as parseConsentCookie } from '@/lib/cookies/consent-state';
+import {
+  hasAnalyticsConsent,
+  parseConsentCookieValue as parseConsentCookie,
+} from '@/lib/cookies/consent-state';
 
 describe('parseConsentCookie', () => {
   it('returns null for undefined cookie value', () => {
@@ -57,5 +60,19 @@ describe('parseConsentCookie', () => {
 
   it('returns null for array', () => {
     expect(parseConsentCookie('[1,2,3]')).toBe(null);
+  });
+
+  it('requires analytics=true for analytics consent', () => {
+    expect(
+      hasAnalyticsConsent(
+        '{"essential":true,"analytics":true,"marketing":false}'
+      )
+    ).toBe(true);
+    expect(
+      hasAnalyticsConsent(
+        '{"essential":true,"analytics":false,"marketing":true}'
+      )
+    ).toBe(false);
+    expect(hasAnalyticsConsent('not-json')).toBe(false);
   });
 });

--- a/apps/web/tests/unit/lib/tracking/parse-consent-cookie.test.ts
+++ b/apps/web/tests/unit/lib/tracking/parse-consent-cookie.test.ts
@@ -2,26 +2,7 @@
  * Tests for server-side consent cookie parsing used by /api/track.
  */
 import { describe, expect, it } from 'vitest';
-
-interface ConsentPreferences {
-  essential: boolean;
-  analytics: boolean;
-  marketing: boolean;
-}
-
-// Reimplemented from track/route.ts for unit testing
-function parseConsentCookie(
-  cookieValue: string | undefined
-): ConsentPreferences | null {
-  try {
-    if (!cookieValue) return null;
-    const parsed = JSON.parse(cookieValue) as ConsentPreferences;
-    if (typeof parsed?.marketing !== 'boolean') return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
+import { parseConsentCookieValue as parseConsentCookie } from '@/lib/cookies/consent-state';
 
 describe('parseConsentCookie', () => {
   it('returns null for undefined cookie value', () => {

--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -113,9 +113,11 @@ vi.mock('@clerk/nextjs/server', () => ({
 vi.mock('@/constants/app', () => ({
   AUDIENCE_ANON_COOKIE: 'audience_anon',
   AUDIENCE_IDENTIFIED_COOKIE: 'audience_identified',
+  AUDIENCE_SPOTIFY_PREFERRED_COOKIE: 'audience_spotify_preferred',
   COUNTRY_CODE_COOKIE: 'country_code',
   HOMEPAGE_CITY_COOKIE: 'homepage_city',
   HOMEPAGE_REGION_COOKIE: 'homepage_region',
+  LISTEN_COOKIE: 'listen_cookie',
 }));
 vi.mock('@/constants/domains', () => ({
   BASE_URL: 'https://jov.ie',
@@ -288,6 +290,63 @@ describe('proxy.ts middleware', () => {
       expect(cookies.homepage_city).toBe('Berlin');
       expect(cookies.homepage_region).toBe('BE');
       expect(cookies.audience_anon).toBeDefined();
+    });
+
+    it('does not set analytics-classified cookies for marketing-only consent', async () => {
+      mocks.isCookieBannerRequired.mockReturnValue(true);
+
+      const req = createUnauthenticatedRequest({
+        pathname: '/',
+        headers: {
+          'x-vercel-ip-country': 'DE',
+          'x-vercel-ip-city': 'Berlin',
+          'x-vercel-ip-country-region': 'BE',
+        },
+        cookies: {
+          jv_cc: JSON.stringify({
+            essential: true,
+            analytics: false,
+            marketing: true,
+          }),
+        },
+      });
+      const res = await callMiddleware(req);
+
+      const cookies = getResponseCookies(res);
+      expect(cookies.homepage_city).toBeUndefined();
+      expect(cookies.homepage_region).toBeUndefined();
+      expect(cookies.audience_anon).toBeUndefined();
+    });
+
+    it('deletes analytics-classified cookies for marketing-only consent', async () => {
+      mocks.isCookieBannerRequired.mockReturnValue(true);
+
+      const req = createUnauthenticatedRequest({
+        pathname: '/',
+        headers: {
+          'x-vercel-ip-country': 'DE',
+          'x-vercel-ip-city': 'Berlin',
+          'x-vercel-ip-country-region': 'BE',
+        },
+        cookies: {
+          jv_cc: JSON.stringify({
+            essential: true,
+            analytics: false,
+            marketing: true,
+          }),
+          audience_anon: 'anon-1',
+          audience_identified: '1',
+          homepage_city: 'Munich',
+          homepage_region: 'BY',
+        },
+      });
+      const res = await callMiddleware(req);
+
+      const cookies = getResponseCookies(res);
+      expect(cookies.audience_anon).toBe('');
+      expect(cookies.audience_identified).toBe('');
+      expect(cookies.homepage_city).toBe('');
+      expect(cookies.homepage_region).toBe('');
     });
 
     it('sets jv_cc_required=1 for US California (CCPA)', async () => {

--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -217,6 +217,79 @@ describe('proxy.ts middleware', () => {
       expect(cookies.jv_cc_required).toBe('1');
     });
 
+    it('keeps only pre-consent cookies for consent-required visitors without consent', async () => {
+      mocks.isCookieBannerRequired.mockReturnValue(true);
+
+      const req = createUnauthenticatedRequest({
+        pathname: '/',
+        headers: {
+          'x-vercel-ip-country': 'DE',
+          'x-vercel-ip-city': 'Berlin',
+          'x-vercel-ip-country-region': 'BE',
+        },
+      });
+      const res = await callMiddleware(req);
+
+      const cookies = getResponseCookies(res);
+      expect(cookies.jv_cc_required).toBe('1');
+      expect(cookies.country_code).toBe('DE');
+      expect(cookies.homepage_city).toBeUndefined();
+      expect(cookies.homepage_region).toBeUndefined();
+      expect(cookies.audience_anon).toBeUndefined();
+    });
+
+    it('deletes existing nonessential proxy cookies when consent is missing', async () => {
+      mocks.isCookieBannerRequired.mockReturnValue(true);
+
+      const req = createUnauthenticatedRequest({
+        pathname: '/',
+        headers: {
+          'x-vercel-ip-country': 'DE',
+          'x-vercel-ip-city': 'Berlin',
+          'x-vercel-ip-country-region': 'BE',
+        },
+        cookies: {
+          audience_anon: 'anon-1',
+          audience_identified: '1',
+          homepage_city: 'Munich',
+          homepage_region: 'BY',
+        },
+      });
+      const res = await callMiddleware(req);
+
+      const cookies = getResponseCookies(res);
+      expect(cookies.audience_anon).toBe('');
+      expect(cookies.audience_identified).toBe('');
+      expect(cookies.homepage_city).toBe('');
+      expect(cookies.homepage_region).toBe('');
+    });
+
+    it('sets nonessential proxy cookies after analytics consent is granted', async () => {
+      mocks.isCookieBannerRequired.mockReturnValue(true);
+
+      const req = createUnauthenticatedRequest({
+        pathname: '/',
+        headers: {
+          'x-vercel-ip-country': 'DE',
+          'x-vercel-ip-city': 'Berlin',
+          'x-vercel-ip-country-region': 'BE',
+        },
+        cookies: {
+          jv_cc: JSON.stringify({
+            essential: true,
+            analytics: true,
+            marketing: false,
+          }),
+        },
+      });
+      const res = await callMiddleware(req);
+
+      const cookies = getResponseCookies(res);
+      expect(cookies.homepage_city).toBe('Berlin');
+      expect(cookies.homepage_region).toBe('BE');
+      expect(cookies.audience_anon).toBeDefined();
+    });
+
     it('sets jv_cc_required=1 for US California (CCPA)', async () => {
       mocks.isCookieBannerRequired.mockReturnValue(true);
 

--- a/apps/web/tests/unit/middleware/proxy-composition.critical.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-composition.critical.test.ts
@@ -110,9 +110,11 @@ vi.mock('@clerk/nextjs/server', () => ({
 vi.mock('@/constants/app', () => ({
   AUDIENCE_ANON_COOKIE: 'audience_anon',
   AUDIENCE_IDENTIFIED_COOKIE: 'audience_identified',
+  AUDIENCE_SPOTIFY_PREFERRED_COOKIE: 'audience_spotify_preferred',
   COUNTRY_CODE_COOKIE: 'country_code',
   HOMEPAGE_CITY_COOKIE: 'homepage_city',
   HOMEPAGE_REGION_COOKIE: 'homepage_region',
+  LISTEN_COOKIE: 'listen_cookie',
 }));
 vi.mock('@/constants/domains', () => ({
   BASE_URL: 'https://jov.ie',


### PR DESCRIPTION
Refs JOV-2179

## Summary
- Enforce consent-required tracking semantics in `/api/track`: absent or invalid `jv_cc` with `jv_cc_required=1` now keeps click IP anonymized and skips audience-member/fingerprint creation until marketing consent is valid.
- Gate analytics-classified proxy cookies (`jv_city`, `jv_region`, `jv_aid`, `jv_identified`) on analytics consent only in consent-required regions, and expire stale analytics cookies when analytics consent is missing.
- Updated the first-party cookie registry and cookie policy disclosure for active writers: `jv_tracking_consent`, `jovie_dsp`, `jv_pref_spotify`, and `jovie_lead_attribution`.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/middleware/proxy-behavioral.test.ts tests/unit/lib/cookies/consent-regions.test.ts tests/unit/lib/cookies/registry.test.ts tests/unit/lib/tracking/parse-consent-cookie.test.ts tests/unit/api/track/route.test.ts` — 5 files, 100 tests passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/api/track/route.ts apps/web/proxy.ts apps/web/lib/cookies/consent-state.ts apps/web/lib/cookies/registry.ts apps/web/content/legal/cookies.md apps/web/tests/unit/api/track/route.test.ts apps/web/tests/unit/middleware/proxy-behavioral.test.ts apps/web/tests/unit/lib/cookies/registry.test.ts apps/web/tests/unit/lib/tracking/parse-consent-cookie.test.ts` — checked 8 files, no fixes applied after final run
- Commit hook passed: next:proxy-guard, Biome, ESLint, web typecheck
- Pre-push hook passed: `biome check .`, web next:proxy-guard, Tailwind guard, typecheck, lint

## Review posture
High-risk consent/proxy lane. Manual review required; automerge and merge queue are intentionally not enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated cookie policy date, expanded cookie list, and clarified server-side feature-flag/analytics evaluation (no browser Statsig cookies).

* **New Features**
  * Added a typed cookie registry describing cookie purpose, duration, and pre-consent status.
  * Centralized consent parsing so marketing/analytics consent is derived consistently.

* **Bug Fixes**
  * Non‑essential and proxy-set cookies now honor cookie-consent requirements.

* **Tests**
  * Added unit tests for registry, consent parsing, proxy consent behavior, and related routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8706)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- linear-issue-id:JOV-2179 -->

