### PR TITLE
fix(demo): stabilize demo video readiness (JOV-2194, JOV-2195)

### DIFF
--- a/apps/web/components/features/demo/DemoVideoPlayer.tsx
+++ b/apps/web/components/features/demo/DemoVideoPlayer.tsx
@@ -28,10 +28,20 @@ export function DemoVideoPlayer({
     setState('error');
   }, []);
   const handlePlay = useCallback(() => {
-    setHasStarted(true);
-    void videoRef.current?.play().catch(() => {
-      // If autoplay is blocked despite the click, keep native controls visible.
-    });
+    const video = videoRef.current;
+    if (!video) {
+      return;
+    }
+
+    void video
+      .play()
+      .then(() => {
+        setHasStarted(true);
+      })
+      .catch(() => {
+        // Keep the custom CTA available so the user can retry playback.
+        setHasStarted(false);
+      });
   }, []);
 
   // No video URL configured — show carousel directly

--- a/apps/web/components/features/demo/DemoVideoPlayer.tsx
+++ b/apps/web/components/features/demo/DemoVideoPlayer.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { Play } from 'lucide-react';
+import Image from 'next/image';
+import { useCallback, useRef, useState } from 'react';
 import { BrowserFrame } from './BrowserFrame';
 import { ProductDemoCarousel } from './ProductDemoCarousel';
 
@@ -20,8 +22,16 @@ export function DemoVideoPlayer({
   readonly label?: string;
 }) {
   const [state, setState] = useState<VideoState>(videoUrl ? 'ready' : 'error');
+  const [hasStarted, setHasStarted] = useState(false);
+  const videoRef = useRef<HTMLVideoElement>(null);
   const handleError = useCallback(() => {
     setState('error');
+  }, []);
+  const handlePlay = useCallback(() => {
+    setHasStarted(true);
+    void videoRef.current?.play().catch(() => {
+      // If autoplay is blocked despite the click, keep native controls visible.
+    });
   }, []);
 
   // No video URL configured — show carousel directly
@@ -32,24 +42,56 @@ export function DemoVideoPlayer({
   return (
     <BrowserFrame>
       {state !== 'error' && (
-        <video
-          aria-label={label}
-          className='aspect-[1280/720] w-full bg-black object-contain'
-          src={videoUrl}
-          poster={posterUrl}
-          controls={controls}
-          playsInline
-          preload='auto'
-          onError={handleError}
+        <div
+          className='relative aspect-[1280/720] w-full overflow-hidden bg-black'
+          data-testid='demo-video-visual'
         >
-          <track
-            kind='captions'
-            src={captionsUrl}
-            srcLang='en'
-            label='English'
-            default
-          />
-        </video>
+          {posterUrl ? (
+            <Image
+              alt=''
+              aria-hidden='true'
+              className='object-cover'
+              data-testid='demo-video-poster'
+              fill
+              priority
+              sizes='1280px'
+              src={posterUrl}
+              unoptimized
+            />
+          ) : null}
+          <video
+            aria-label={label}
+            className={`relative z-10 aspect-[1280/720] w-full bg-transparent object-contain transition-opacity duration-subtle ${
+              hasStarted ? 'opacity-100' : 'opacity-0'
+            }`}
+            controls={controls}
+            onError={handleError}
+            onPlay={() => setHasStarted(true)}
+            playsInline
+            poster={posterUrl}
+            preload='none'
+            ref={videoRef}
+            src={videoUrl}
+          >
+            <track
+              kind='captions'
+              src={captionsUrl}
+              srcLang='en'
+              label='English'
+              default
+            />
+          </video>
+          {!hasStarted && posterUrl ? (
+            <button
+              type='button'
+              aria-label='Play Jovie demo video'
+              className='absolute left-1/2 top-1/2 z-20 inline-flex size-16 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-white text-black shadow-2xl shadow-black/40 transition-colors hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-black'
+              onClick={handlePlay}
+            >
+              <Play aria-hidden='true' className='ml-1 size-7 fill-current' />
+            </button>
+          ) : null}
+        </div>
       )}
 
       {/* Error fallback — show carousel */}

--- a/apps/web/scripts/record-yc-demo.sh
+++ b/apps/web/scripts/record-yc-demo.sh
@@ -17,6 +17,7 @@ PUBLIC_MP4="$WEB_ROOT/public/demo/jovie-demo.mp4"
 PUBLIC_POSTER="$WEB_ROOT/public/demo/jovie-demo-poster.jpg"
 CONTACT_SHEET="$OUTPUT_ROOT/founder-demo-contact-sheet.jpg"
 SERVER_LOG="$OUTPUT_ROOT/founder-demo-server.log"
+BLACKDETECT_LOG="$OUTPUT_ROOT/founder-demo-blackdetect.log"
 AUDIO_FILTER="${DEMO_AUDIO_FILTER:-silenceremove=start_periods=1:start_duration=0.1:start_threshold=-30dB:start_silence=0.05:stop_periods=-1:stop_duration=0.25:stop_threshold=-30dB:stop_silence=0.12,atempo=1.025,loudnorm=I=-16:TP=-1.5:LRA=11}"
 
 for cmd in curl doppler ffmpeg ffprobe; do
@@ -116,6 +117,20 @@ ffmpeg -y -i "$RAW_VIDEO" -i "$CLEAN_AUDIO" -map 0:v:0 -map 1:a:0 -c:v libx264 -
 MP4_SIZE="$(ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of csv=p=0:s=x "$MP4_VIDEO")"
 if [[ "$MP4_SIZE" != "1280x720" ]]; then
   echo "Unexpected MP4 video size: $MP4_SIZE" >&2
+  exit 1
+fi
+
+echo "[founder-demo] Checking for blank dark frames..."
+ffmpeg -hide_banner -nostats -i "$MP4_VIDEO" -vf "blackdetect=d=0.12:pix_th=0.06" -an -f null - >"$BLACKDETECT_LOG" 2>&1
+if awk -F 'black_start:' '
+  /black_start:/ {
+    split($2, fields, " ")
+    if ((fields[1] + 0) >= 0.5) found = 1
+  }
+  END { exit found ? 0 : 1 }
+' "$BLACKDETECT_LOG"; then
+  echo "Detected full-dark frame run after the initial recording startup window." >&2
+  grep 'black_start:' "$BLACKDETECT_LOG" >&2 || true
   exit 1
 fi
 

--- a/apps/web/tests/e2e/demo-video.spec.ts
+++ b/apps/web/tests/e2e/demo-video.spec.ts
@@ -1,6 +1,17 @@
 import { expect, test } from '@playwright/test';
 import sharp from 'sharp';
 
+type PosterStats =
+  | {
+      readonly brightPixelRatio: number;
+      readonly max: number;
+      readonly status: 'available';
+    }
+  | {
+      readonly reason: string;
+      readonly status: 'unavailable';
+    };
+
 test.use({
   storageState: { cookies: [], origins: [] },
   viewport: { width: 1280, height: 900 },
@@ -68,7 +79,7 @@ test('demovideo renders a stable non-empty initial visual', async ({
     )
     .toBe(true);
 
-  const posterStats = await page.evaluate(async () => {
+  const posterStats = await page.evaluate(async (): Promise<PosterStats> => {
     const video = document.querySelector(
       'video[aria-label="Jovie demo video"]'
     );
@@ -76,10 +87,22 @@ test('demovideo renders a stable non-empty initial visual', async ({
       throw new Error('Demo video element is missing');
     }
 
+    const posterUrl = new URL(video.poster, globalThis.location.href);
+    const isCrossOrigin = posterUrl.origin !== globalThis.location.origin;
     const image = new Image();
     image.crossOrigin = 'anonymous';
-    image.src = video.poster;
-    await image.decode();
+    image.src = posterUrl.href;
+    try {
+      await image.decode();
+    } catch (error) {
+      if (isCrossOrigin) {
+        return {
+          reason: 'Cross-origin poster image is not CORS-readable',
+          status: 'unavailable',
+        };
+      }
+      throw error;
+    }
 
     const canvas = document.createElement('canvas');
     canvas.width = 160;
@@ -88,9 +111,25 @@ test('demovideo renders a stable non-empty initial visual', async ({
     if (!context) {
       throw new Error('Canvas is unavailable');
     }
-    context.drawImage(image, 0, 0, canvas.width, canvas.height);
 
-    const data = context.getImageData(0, 0, canvas.width, canvas.height).data;
+    let data: Uint8ClampedArray;
+    try {
+      context.drawImage(image, 0, 0, canvas.width, canvas.height);
+      data = context.getImageData(0, 0, canvas.width, canvas.height).data;
+    } catch (error) {
+      if (
+        isCrossOrigin &&
+        error instanceof DOMException &&
+        error.name === 'SecurityError'
+      ) {
+        return {
+          reason: 'Cross-origin poster canvas is not CORS-readable',
+          status: 'unavailable',
+        };
+      }
+      throw error;
+    }
+
     let max = 0;
     let brightPixels = 0;
     for (let index = 0; index < data.length; index += 4) {
@@ -107,10 +146,15 @@ test('demovideo renders a stable non-empty initial visual', async ({
     return {
       brightPixelRatio: brightPixels / (canvas.width * canvas.height),
       max,
+      status: 'available',
     };
   });
-  expect(posterStats.max).toBeGreaterThan(120);
-  expect(posterStats.brightPixelRatio).toBeGreaterThan(0.01);
+  if (posterStats.status === 'available') {
+    expect(posterStats.max).toBeGreaterThan(120);
+    expect(posterStats.brightPixelRatio).toBeGreaterThan(0.01);
+  } else {
+    expect(posterStats.reason).toContain('CORS-readable');
+  }
 
   const screenshotPath = testInfo.outputPath('demo-video-visual.png');
   const screenshot = await visual.screenshot({ path: screenshotPath });

--- a/apps/web/tests/e2e/demo-video.spec.ts
+++ b/apps/web/tests/e2e/demo-video.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test';
+import sharp from 'sharp';
+
+test.use({
+  storageState: { cookies: [], origins: [] },
+  viewport: { width: 1280, height: 900 },
+});
+
+test('demovideo renders a stable non-empty initial visual', async ({
+  page,
+}, testInfo) => {
+  const consoleErrors: string[] = [];
+  const failedRequests: string[] = [];
+  const failedResponses: string[] = [];
+
+  page.on('console', message => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+  page.on('requestfailed', request => {
+    failedRequests.push(
+      `${request.method()} ${request.url()} ${request.failure()?.errorText ?? ''}`
+    );
+  });
+  page.on('response', response => {
+    if (response.status() >= 400) {
+      failedResponses.push(`${response.status()} ${response.url()}`);
+    }
+  });
+
+  await page.goto('/demovideo', {
+    waitUntil: 'domcontentloaded',
+    timeout: 60_000,
+  });
+
+  await expect(page.getByTestId('demo-video-page')).toBeVisible();
+  await expect(page.getByTestId('dev-toolbar')).toHaveCount(0);
+  await expect(page.locator('body')).not.toContainText(/\bYC\b/u);
+
+  const visual = page.getByTestId('demo-video-visual');
+  await expect(visual).toBeVisible();
+
+  const visualBox = await visual.boundingBox();
+  expect(visualBox).not.toBeNull();
+  if (!visualBox) {
+    throw new Error('Missing demo video visual bounds');
+  }
+  expect(visualBox.width / visualBox.height).toBeCloseTo(16 / 9, 1);
+
+  const poster = page.getByTestId('demo-video-poster');
+  await expect(poster).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Play Jovie demo video' })
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      poster.evaluate(element => {
+        if (!(element instanceof HTMLImageElement)) {
+          return false;
+        }
+        return (
+          element.complete &&
+          element.naturalWidth >= 1280 &&
+          element.naturalHeight >= 720
+        );
+      })
+    )
+    .toBe(true);
+
+  const posterStats = await page.evaluate(async () => {
+    const video = document.querySelector(
+      'video[aria-label="Jovie demo video"]'
+    );
+    if (!(video instanceof HTMLVideoElement)) {
+      throw new Error('Demo video element is missing');
+    }
+
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.src = video.poster;
+    await image.decode();
+
+    const canvas = document.createElement('canvas');
+    canvas.width = 160;
+    canvas.height = 90;
+    const context = canvas.getContext('2d');
+    if (!context) {
+      throw new Error('Canvas is unavailable');
+    }
+    context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+    const data = context.getImageData(0, 0, canvas.width, canvas.height).data;
+    let max = 0;
+    let brightPixels = 0;
+    for (let index = 0; index < data.length; index += 4) {
+      const luminance =
+        0.2126 * data[index] +
+        0.7152 * data[index + 1] +
+        0.0722 * data[index + 2];
+      max = Math.max(max, luminance);
+      if (luminance > 45) {
+        brightPixels += 1;
+      }
+    }
+
+    return {
+      brightPixelRatio: brightPixels / (canvas.width * canvas.height),
+      max,
+    };
+  });
+  expect(posterStats.max).toBeGreaterThan(120);
+  expect(posterStats.brightPixelRatio).toBeGreaterThan(0.01);
+
+  const screenshotPath = testInfo.outputPath('demo-video-visual.png');
+  const screenshot = await visual.screenshot({ path: screenshotPath });
+  await testInfo.attach('demo-video-visual', {
+    path: screenshotPath,
+    contentType: 'image/png',
+  });
+  const screenshotStats = await sharp(screenshot).greyscale().stats();
+  expect(screenshotStats.channels[0].max).toBeGreaterThan(120);
+  expect(screenshotStats.channels[0].stdev).toBeGreaterThan(5);
+
+  expect(consoleErrors).toEqual([]);
+  expect(failedRequests).toEqual([]);
+  expect(failedResponses).toEqual([]);
+});

--- a/apps/web/tests/e2e/yc-demo.spec.ts
+++ b/apps/web/tests/e2e/yc-demo.spec.ts
@@ -51,10 +51,6 @@ const LOADING_SELECTORS = [
   '[class*="animate-spin"]',
   '[class*="animate-pulse"]',
 ];
-const TRANSITION_VEIL_ID = 'demo-transition-veil';
-const TRANSITION_STORAGE_KEY = 'demo-transition-visible';
-const TRANSITION_FADE_MS = 140;
-const TRANSITION_BACKGROUND = '#080a10';
 const TOTAL_CLICKS_METRIC_TEST_ID = 'drawer-analytics-metric-total-clicks';
 const TOTAL_CLICKS_METRIC_VALUE_TEST_ID =
   'drawer-analytics-metric-value-total-clicks';
@@ -105,95 +101,12 @@ async function configureRecordingContext(
   context: BrowserContext,
   cookieBaseUrl: string
 ) {
-  await context.addInitScript(
-    ({ transitionBackground }) => {
-      localStorage.setItem('jv_cc', '1');
-      localStorage.removeItem('__dev_toolbar_open');
-      localStorage.removeItem('__dev_toolbar_hidden');
-
-      const isTransitionVisible = () => {
-        try {
-          return sessionStorage.getItem('demo-transition-visible') === '1';
-        } catch {
-          return false;
-        }
-      };
-
-      const syncTransitionRoot = () => {
-        document.documentElement.setAttribute(
-          'data-demo-transition',
-          isTransitionVisible() ? '1' : '0'
-        );
-      };
-
-      const ensureTransitionStyle = () => {
-        const styleId = 'demo-transition-style';
-        const existing = document.getElementById(
-          styleId
-        ) as HTMLStyleElement | null;
-
-        if (existing) {
-          return;
-        }
-
-        const style = document.createElement('style');
-        style.id = styleId;
-        style.textContent = `
-        html {
-          background: ${transitionBackground};
-        }
-
-        html[data-demo-transition="1"]::before,
-        html[data-demo-transition="1"] body::before {
-          content: '';
-          position: fixed;
-          inset: 0;
-          background: ${transitionBackground};
-          pointer-events: none;
-          z-index: 2147483647;
-        }
-      `;
-        (document.head ?? document.documentElement).appendChild(style);
-      };
-
-      const ensureTransitionVeil = () => {
-        const existing = document.getElementById(
-          'demo-transition-veil'
-        ) as HTMLDivElement | null;
-        if (existing) {
-          syncTransitionRoot();
-          existing.style.opacity = isTransitionVisible() ? '1' : '0';
-          existing.style.pointerEvents = 'none';
-          return;
-        }
-
-        const veil = document.createElement('div');
-        veil.id = 'demo-transition-veil';
-        Object.assign(veil.style, {
-          position: 'fixed',
-          inset: '0',
-          background: transitionBackground,
-          opacity: isTransitionVisible() ? '1' : '0',
-          pointerEvents: 'none',
-          transition: 'opacity 140ms ease',
-          zIndex: '2147483647',
-        });
-        document.body.appendChild(veil);
-      };
-
-      ensureTransitionStyle();
-      syncTransitionRoot();
-
-      if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', ensureTransitionVeil, {
-          once: true,
-        });
-      } else {
-        ensureTransitionVeil();
-      }
-    },
-    { transitionBackground: TRANSITION_BACKGROUND }
-  );
+  await context.addInitScript(() => {
+    localStorage.setItem('jv_cc', '1');
+    localStorage.removeItem('__dev_toolbar_open');
+    localStorage.removeItem('__dev_toolbar_hidden');
+    document.documentElement.removeAttribute('data-demo-transition');
+  });
 
   await context.addCookies([
     {
@@ -273,65 +186,6 @@ async function installCleanupStyle(page: Page) {
       });
     }
   }, CLEANUP_SELECTORS);
-}
-
-async function setTransitionVeilVisible(page: Page, visible: boolean) {
-  await page.evaluate(
-    ({ background, storageKey, veilId, nextVisible }) => {
-      try {
-        sessionStorage.setItem(storageKey, nextVisible ? '1' : '0');
-      } catch {}
-
-      const styleId = 'demo-transition-style';
-      if (!document.getElementById(styleId)) {
-        const style = document.createElement('style');
-        style.id = styleId;
-        style.textContent = `
-          html {
-            background: ${background};
-          }
-
-          html[data-demo-transition="1"]::before,
-          html[data-demo-transition="1"] body::before {
-            content: '';
-            position: fixed;
-            inset: 0;
-            background: ${background};
-            pointer-events: none;
-            z-index: 2147483647;
-          }
-        `;
-        (document.head ?? document.documentElement).appendChild(style);
-      }
-
-      document.documentElement.setAttribute(
-        'data-demo-transition',
-        nextVisible ? '1' : '0'
-      );
-
-      let veil = document.getElementById(veilId) as HTMLDivElement | null;
-      if (!veil) {
-        veil = document.createElement('div');
-        veil.id = veilId;
-        Object.assign(veil.style, {
-          position: 'fixed',
-          inset: '0',
-          background,
-          transition: 'opacity 140ms ease',
-          zIndex: '2147483647',
-        });
-        document.body.appendChild(veil);
-      }
-      veil.style.opacity = nextVisible ? '1' : '0';
-      veil.style.pointerEvents = 'none';
-    },
-    {
-      background: TRANSITION_BACKGROUND,
-      nextVisible: visible,
-      storageKey: TRANSITION_STORAGE_KEY,
-      veilId: TRANSITION_VEIL_ID,
-    }
-  );
 }
 
 async function injectCaptionOverlay(page: Page) {
@@ -655,24 +509,17 @@ async function gotoDemoSceneWithTransition(
   url: string,
   options: DemoSceneReadyOptions
 ) {
-  if (page.url() !== 'about:blank') {
-    await setTransitionVeilVisible(page, true);
-  }
   await gotoDemoScene(page, url, options);
-  await setTransitionVeilVisible(page, false);
-  await page.waitForTimeout(TRANSITION_FADE_MS);
+  await waitForAnimationFrames(page, 3);
 }
 
 async function revealDemoSceneAfter(
   page: Page,
   prepareScene: () => Promise<void>
 ) {
-  await setTransitionVeilVisible(page, true);
   await prepareScene();
   await waitForSceneCleanup(page);
   await waitForAnimationFrames(page, 3);
-  await setTransitionVeilVisible(page, false);
-  await page.waitForTimeout(TRANSITION_FADE_MS);
 }
 
 async function smoothScrollPage(


### PR DESCRIPTION
## Summary
- JOV-2195: Render `/demovideo` with a stable 16:9 poster-first visual and a clear play control before native video playback starts.
- JOV-2194: Remove the recorder's full-screen dark transition veil and rely on existing route readiness waits plus settled animation frames.
- Add a demo recording black-frame gate so regenerated MP4s fail when full-dark frame runs appear after the initial startup window.

## Changed files
- `apps/web/components/features/demo/DemoVideoPlayer.tsx`
- `apps/web/tests/e2e/demo-video.spec.ts`
- `apps/web/tests/e2e/yc-demo.spec.ts`
- `apps/web/scripts/record-yc-demo.sh`

## Evidence
- Screenshot: `/private/tmp/jovie-blocker-lanes/jov-2195-demo-video-readiness/.context/outputs/jov-2195-demo-video-readiness/demovideo-visual-final.png`
- Contact sheet sampled from current MP4: `/private/tmp/jovie-blocker-lanes/jov-2195-demo-video-readiness/.context/outputs/jov-2195-demo-video-readiness/current-video-contact-sheet.jpg`
- Black-frame scan: current public MP4 only reports initial startup dark run `black_start:0.04 black_end:0.36 black_duration:0.32`; the new script fails any run beginning at or after 0.5s.

## Verification
- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh`
- `JOVIE_AGENT_PROFILE=coder pnpm install --frozen-lockfile`
- `JOVIE_AGENT_PROFILE=coder bash -n apps/web/scripts/record-yc-demo.sh`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/demo-video.test.ts` — 5 passed
- `JOVIE_AGENT_PROFILE=coder E2E_SKIP_WEB_SERVER=1 BASE_URL=http://localhost:3107 pnpm --filter @jovie/web exec playwright test tests/e2e/demo-video.spec.ts --config=playwright.config.noauth.ts --project=chromium --reporter=line` — 1 passed
- `JOVIE_AGENT_PROFILE=coder pnpm biome check apps/web` — no fixes applied
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- Commit hook: proxy guard, Biome, ESLint, staged a11y, typecheck — passed
- Push hook: `biome check .`, proxy guard, Tailwind guard, typecheck, Biome lint — passed

## Residual blocker
None known locally. Draft PR is left for CI and bot review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Demo video player now displays a customizable poster image with an interactive play button overlay.

* **Quality & Testing**
  * Added dark frame detection validation during video processing to improve video quality standards.
  * Introduced comprehensive end-to-end testing for demo video rendering and poster image validation.
  * Streamlined test infrastructure and transition handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->