### PR TITLE
fix(demo): polish release capture chrome (JOV-2196, JOV-2197, JOV-2198)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
@@ -794,7 +794,7 @@ export function ShellReleasesView({
 
   useRegisterRightPanel(sidebarPanel);
 
-  // ── Header actions: NewReleaseHeaderAction + search trigger / PillSearch ──
+  // ── Header actions: NewReleaseHeaderAction + secondary filter control ──
 
   const selectedReleaseId = editingRelease?.id ?? null;
   const releaseCountSuffix = formatReleaseCountSuffix(
@@ -827,14 +827,15 @@ export function ShellReleasesView({
     ) : (
       <button
         type='button'
+        data-app-filter-trigger='true'
         data-app-search-trigger='true'
         onClick={() => setSearchOpen(true)}
         className='inline-flex h-7 items-center gap-1.5 rounded-md border border-(--linear-app-shell-border) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,transparent)] px-2 text-[12px] text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
-        aria-label='Search releases'
-        title='Search releases (/)'
+        aria-label='Filter releases'
+        title='Filter releases (/)'
       >
-        <Icon name='Search' className='h-3.5 w-3.5' aria-hidden='true' />
-        <span className='hidden sm:inline'>Search Releases</span>
+        <Icon name='Filter' className='h-3.5 w-3.5' aria-hidden='true' />
+        <span className='hidden sm:inline'>Filter</span>
         <span className='hidden text-tertiary-token lg:inline'>/</span>
         <span className='tabular-nums text-tertiary-token'>
           {visibleReleases.length}

--- a/apps/web/components/features/dev/DevToolbarGate.tsx
+++ b/apps/web/components/features/dev/DevToolbarGate.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import {
+  isDemoRecordingClient,
+  isDevChromeDisabledClient,
+} from '@/lib/demo-recording';
 
 const DevToolbar = dynamic(
   () =>
@@ -16,7 +21,12 @@ interface DevToolbarGateProps {
   readonly disabled?: boolean;
 }
 
-const DEV_TOOLBAR_SUPPRESSED_PATHS = new Set(['/demovideo', '/demo/video']);
+const DEV_TOOLBAR_SUPPRESSED_PATHS = new Set([
+  '/demovideo',
+  '/demo',
+  '/demo/video',
+]);
+const DEV_TOOLBAR_SUPPRESSED_PREFIXES = ['/demo/'];
 
 function hasDevToolbarCookie(): boolean {
   if (typeof document === 'undefined') return false;
@@ -26,10 +36,18 @@ function hasDevToolbarCookie(): boolean {
     .some(cookie => cookie.trim().startsWith('__dev_toolbar=1'));
 }
 
-function isSuppressedPath(): boolean {
+export function isDevToolbarSuppressedPath(pathname: string): boolean {
   return (
-    typeof window !== 'undefined' &&
-    DEV_TOOLBAR_SUPPRESSED_PATHS.has(window.location.pathname)
+    DEV_TOOLBAR_SUPPRESSED_PATHS.has(pathname) ||
+    DEV_TOOLBAR_SUPPRESSED_PREFIXES.some(prefix => pathname.startsWith(prefix))
+  );
+}
+
+function isSuppressedClientContext(pathname: string): boolean {
+  return (
+    isDemoRecordingClient() ||
+    isDevChromeDisabledClient() ||
+    isDevToolbarSuppressedPath(pathname)
   );
 }
 
@@ -40,19 +58,56 @@ export function DevToolbarGate({
   disabled = false,
 }: DevToolbarGateProps) {
   const [shouldRender, setShouldRender] = useState(false);
+  const pathname = usePathname();
 
   useEffect(() => {
-    if (disabled || isSuppressedPath()) {
+    let cancelled = false;
+
+    const hideToolbar = () => {
       document.documentElement.style.setProperty('--dev-toolbar-height', '0px');
       setShouldRender(false);
-      return;
-    }
+    };
 
-    const isProduction =
-      process.env.NODE_ENV === 'production' && env === 'production';
+    const syncToolbarVisibility = () => {
+      if (cancelled) return;
 
-    setShouldRender(!isProduction || hasDevToolbarCookie());
-  }, [disabled, env]);
+      if (disabled || isSuppressedClientContext(pathname)) {
+        hideToolbar();
+        return;
+      }
+
+      const isProduction =
+        process.env.NODE_ENV === 'production' && env === 'production';
+
+      setShouldRender(!isProduction || hasDevToolbarCookie());
+    };
+
+    syncToolbarVisibility();
+
+    const animationFrame = globalThis.requestAnimationFrame?.(
+      syncToolbarVisibility
+    );
+    const handleDomReady = () => syncToolbarVisibility();
+    document.addEventListener('DOMContentLoaded', handleDomReady);
+
+    const observer =
+      typeof MutationObserver === 'undefined'
+        ? null
+        : new MutationObserver(syncToolbarVisibility);
+    observer?.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-demo-recording', 'data-dev-chrome-disabled'],
+    });
+
+    return () => {
+      cancelled = true;
+      if (animationFrame !== undefined) {
+        globalThis.cancelAnimationFrame?.(animationFrame);
+      }
+      document.removeEventListener('DOMContentLoaded', handleDomReady);
+      observer?.disconnect();
+    };
+  }, [disabled, env, pathname]);
 
   if (disabled || !shouldRender) {
     return null;

--- a/apps/web/components/shell/ArtworkThumb.test.tsx
+++ b/apps/web/components/shell/ArtworkThumb.test.tsx
@@ -3,23 +3,25 @@ import { describe, expect, it } from 'vitest';
 import { ArtworkThumb } from './ArtworkThumb';
 
 describe('ArtworkThumb', () => {
-  it('renders the first-letter fallback while the image loads', () => {
+  it('renders abstract fallback art while the image loads', () => {
     render(
       <ArtworkThumb src='https://x.invalid/a.jpg' title='Lost' size={40} />
     );
-    expect(screen.getByText('L')).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-artwork-fallback="true"]')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('L')).not.toBeInTheDocument();
   });
 
-  it('uppercases the fallback letter from the trimmed title', () => {
-    render(
-      <ArtworkThumb src='https://x.invalid/a.jpg' title='  echo' size={40} />
+  it('uses fallback art for an empty artwork source', () => {
+    const { container } = render(
+      <ArtworkThumb src='' title='Echo' size={40} />
     );
-    expect(screen.getByText('E')).toBeInTheDocument();
-  });
-
-  it('uses a middle-dot when the title is empty', () => {
-    render(<ArtworkThumb src='https://x.invalid/a.jpg' title='' size={40} />);
-    expect(screen.getByText('·')).toBeInTheDocument();
+    const tile = container.firstElementChild as HTMLElement;
+    expect(tile).toHaveAttribute('data-artwork-state', 'fallback');
+    expect(
+      document.querySelector('[data-artwork-fallback="true"]')
+    ).toBeInTheDocument();
   });
 
   it('applies the size as inline width and height', () => {

--- a/apps/web/components/shell/ArtworkThumb.tsx
+++ b/apps/web/components/shell/ArtworkThumb.tsx
@@ -1,16 +1,18 @@
 'use client';
 
+import type { CSSProperties } from 'react';
 import { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 
 /**
- * ArtworkThumb — square artwork tile with first-letter fallback.
+ * ArtworkThumb — square artwork tile with a polished fallback.
  *
  * Preloads the source via the `Image()` constructor so we can detect failures
  * without attaching `onError` to a rendered `<img>` (sidesteps Next's
  * `@next/next/no-img-element` rule — we never render an `<img>`). On success
- * the source paints as a CSS background; on failure or while loading we
- * render the title's first uppercase letter as a calm placeholder.
+ * the source paints as a CSS background; on failure or while loading we render
+ * deterministic abstract art instead of letter tiles that look like missing
+ * album assets in recording frames.
  *
  * Pure leaf — owns no app state. Caller controls `src`, `title`, `size`.
  *
@@ -19,6 +21,29 @@ import { cn } from '@/lib/utils';
  * <ArtworkThumb src={release.artwork} title={release.title} size={40} />
  * ```
  */
+function hashTitle(title: string): number {
+  let hash = 0;
+  for (const char of title.trim() || 'release') {
+    hash = (hash * 31 + char.charCodeAt(0)) % 997;
+  }
+  return hash;
+}
+
+function getFallbackStyle(title: string): CSSProperties {
+  const hash = hashTitle(title);
+  const hue = (hash * 47) % 360;
+  const accentHue = (hue + 34 + (hash % 56)) % 360;
+  const depthHue = (hue + 210) % 360;
+
+  return {
+    background: [
+      `radial-gradient(circle at 28% 24%, oklch(0.78 0.12 ${accentHue}) 0 13%, transparent 34%)`,
+      `radial-gradient(circle at 72% 78%, oklch(0.5 0.11 ${depthHue}) 0 16%, transparent 39%)`,
+      `linear-gradient(${128 + (hash % 42)}deg, oklch(0.24 0.075 ${hue}), oklch(0.16 0.04 ${depthHue}) 62%, oklch(0.32 0.09 ${accentHue}))`,
+    ].join(', '),
+  };
+}
+
 export function ArtworkThumb({
   src,
   title,
@@ -37,6 +62,10 @@ export function ArtworkThumb({
     setLoaded(false);
     setErrored(false);
     if (typeof window === 'undefined') return;
+    if (!src.trim()) {
+      setErrored(true);
+      return;
+    }
     const img = new window.Image();
     img.onload = () => setLoaded(true);
     img.onerror = () => setErrored(true);
@@ -47,26 +76,36 @@ export function ArtworkThumb({
     };
   }, [src]);
 
-  const fallbackLetter = title.trim().charAt(0).toUpperCase() || '·';
+  const isLoaded = loaded && !errored;
 
   return (
     <div
       className={cn(
-        'relative grid shrink-0 place-items-center overflow-hidden rounded-md border border-subtle bg-surface-1',
+        'relative rounded-sm overflow-hidden shrink-0 bg-surface-1',
         className
       )}
+      data-artwork-state={isLoaded ? 'image' : 'fallback'}
       style={{ height: size, width: size }}
     >
-      {loaded && !errored ? (
+      {isLoaded ? (
         <span
           aria-hidden='true'
           className='absolute inset-0 bg-cover bg-center'
           style={{ backgroundImage: `url(${src})` }}
         />
       ) : (
-        <span className='text-[10px] font-caption text-tertiary-token'>
-          {fallbackLetter}
-        </span>
+        <>
+          <span
+            aria-hidden='true'
+            className='absolute inset-0'
+            data-artwork-fallback='true'
+            style={getFallbackStyle(title)}
+          />
+          <span
+            aria-hidden='true'
+            className='absolute inset-[1px] rounded-[3px] border border-white/10 bg-white/5'
+          />
+        </>
       )}
     </div>
   );

--- a/apps/web/lib/demo-recording.ts
+++ b/apps/web/lib/demo-recording.ts
@@ -1,7 +1,14 @@
 const DEMO_RECORDING_ENABLED_VALUE = '1';
 
-function isEnabled(value: string | undefined): boolean {
-  return value === DEMO_RECORDING_ENABLED_VALUE;
+declare global {
+  interface Window {
+    __JOVIE_DEMO_RECORDING__?: boolean | string;
+    __JOVIE_DEV_CHROME_DISABLED__?: boolean | string;
+  }
+}
+
+function isEnabled(value: boolean | string | undefined): boolean {
+  return value === true || value === DEMO_RECORDING_ENABLED_VALUE;
 }
 
 function getRuntimeHtmlDatasetValue(
@@ -14,6 +21,16 @@ function getRuntimeHtmlDatasetValue(
   return document.documentElement.dataset[key] || undefined;
 }
 
+function getRuntimeWindowFlagValue(
+  key: '__JOVIE_DEMO_RECORDING__' | '__JOVIE_DEV_CHROME_DISABLED__'
+): boolean | string | undefined {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  return window[key];
+}
+
 export function isDemoRecordingServer(): boolean {
   return (
     isEnabled(process.env.DEMO_RECORDING) ||
@@ -24,6 +41,7 @@ export function isDemoRecordingServer(): boolean {
 export function isDemoRecordingClient(): boolean {
   return (
     isEnabled(process.env.NEXT_PUBLIC_DEMO_RECORDING) ||
+    isEnabled(getRuntimeWindowFlagValue('__JOVIE_DEMO_RECORDING__')) ||
     isEnabled(getRuntimeHtmlDatasetValue('demoRecording'))
   );
 }
@@ -33,7 +51,10 @@ export function isDevChromeDisabledServer(): boolean {
 }
 
 export function isDevChromeDisabledClient(): boolean {
-  return isEnabled(getRuntimeHtmlDatasetValue('devChromeDisabled'));
+  return (
+    isEnabled(getRuntimeWindowFlagValue('__JOVIE_DEV_CHROME_DISABLED__')) ||
+    isEnabled(getRuntimeHtmlDatasetValue('devChromeDisabled'))
+  );
 }
 
 interface RootLayoutChromeStateInput {

--- a/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx
+++ b/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx
@@ -441,24 +441,27 @@ describe('ShellReleasesView', () => {
     });
   });
 
-  it('registers header actions exposing the release count in the search trigger', async () => {
+  it('registers header actions exposing the release count in a secondary filter trigger', async () => {
     renderShell([
       fakeRelease({ id: '1', title: 'Alpha' }),
       fakeRelease({ id: '2', title: 'Beta' }),
     ]);
     // The route registers headerActions (not a structured adapter) so the shell
-    // header slot renders an inline search trigger with the visible count.
+    // header slot renders an inline filter trigger with the visible count.
     // Use findByTestId so we wait for the effect that calls setHeaderActions to run.
     const probe = await screen.findByTestId('header-actions-probe');
     expect(probe).toBeInTheDocument();
-    // The closed search trigger has aria-label="Search releases" and renders the count.
-    const searchTrigger = await screen.findByRole('button', {
-      name: /search releases/i,
+    expect(
+      screen.queryByRole('button', { name: /search releases/i })
+    ).not.toBeInTheDocument();
+    const filterTrigger = await screen.findByRole('button', {
+      name: /filter releases/i,
     });
-    expect(searchTrigger).toHaveTextContent('2');
+    expect(filterTrigger).toHaveTextContent('2');
+    expect(filterTrigger).toHaveAttribute('data-app-search-trigger', 'true');
   });
 
-  it('opens header search with / unless focus is in a form field', async () => {
+  it('opens the releases filter with / unless focus is in a form field', async () => {
     renderShell([fakeRelease({ id: '1', title: 'Alpha' })]);
     const textInput = document.createElement('input');
     textInput.setAttribute('aria-label', 'Release note');
@@ -472,7 +475,7 @@ describe('ShellReleasesView', () => {
     ).not.toBeInTheDocument();
 
     textInput.blur();
-    fireEvent.keyDown(globalThis, { key: '/' });
+    fireEvent.keyDown(window, { key: '/' });
 
     expect(
       await screen.findByRole('combobox', { name: 'Filter releases' })

--- a/apps/web/tests/e2e/yc-demo.spec.ts
+++ b/apps/web/tests/e2e/yc-demo.spec.ts
@@ -106,6 +106,52 @@ async function configureRecordingContext(
     localStorage.removeItem('__dev_toolbar_open');
     localStorage.removeItem('__dev_toolbar_hidden');
     document.documentElement.removeAttribute('data-demo-transition');
+
+    let applyingDemoChrome = false;
+    const markDemoRecordingChrome = () => {
+      if (applyingDemoChrome) return;
+      applyingDemoChrome = true;
+      const recordingWindow = window as Window & {
+        __JOVIE_DEMO_RECORDING__?: boolean;
+        __JOVIE_DEV_CHROME_DISABLED__?: boolean;
+      };
+      recordingWindow.__JOVIE_DEMO_RECORDING__ = true;
+      recordingWindow.__JOVIE_DEV_CHROME_DISABLED__ = true;
+      document.documentElement.dataset.demoRecording = '1';
+      document.documentElement.dataset.devChromeDisabled = '1';
+      document.documentElement.style.setProperty('--dev-toolbar-height', '0px');
+      applyingDemoChrome = false;
+    };
+
+    const ensureDemoRecordingChrome = () => {
+      if (
+        document.documentElement.dataset.demoRecording === '1' &&
+        document.documentElement.dataset.devChromeDisabled === '1' &&
+        document.documentElement.style.getPropertyValue(
+          '--dev-toolbar-height'
+        ) === '0px'
+      ) {
+        return;
+      }
+
+      markDemoRecordingChrome();
+    };
+
+    markDemoRecordingChrome();
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', ensureDemoRecordingChrome);
+    }
+    new MutationObserver(ensureDemoRecordingChrome).observe(
+      document.documentElement,
+      {
+        attributes: true,
+        attributeFilter: [
+          'data-demo-recording',
+          'data-dev-chrome-disabled',
+          'style',
+        ],
+      }
+    );
   });
 
   await context.addCookies([
@@ -625,6 +671,13 @@ test.describe('YC Demo Recording', () => {
         readyText: selectedReleases[0].title,
       });
     });
+    await expect(demoPage.getByTestId('dev-toolbar')).toHaveCount(0);
+    await expect(
+      demoPage.getByRole('button', { name: /search releases/i })
+    ).toHaveCount(0);
+    await expect(
+      demoPage.getByRole('button', { name: /filter releases/i })
+    ).toHaveCount(1);
     await injectCaptionOverlay(demoPage);
     await setCaption(
       demoPage,

--- a/apps/web/tests/product-screenshots/releases.spec.ts
+++ b/apps/web/tests/product-screenshots/releases.spec.ts
@@ -12,7 +12,7 @@
  *   public/product-screenshots/
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import {
   assertNoDevOverlays,
   hideTransientUI,
@@ -21,6 +21,24 @@ import {
   waitForImages,
   waitForSettle,
 } from './helpers';
+
+async function waitForReleaseArtwork(page: Page) {
+  await page.waitForFunction(
+    () => {
+      const matrix = document.querySelector('[data-testid="releases-matrix"]');
+      if (!matrix) return false;
+
+      const artworkTiles = matrix.querySelectorAll('[data-artwork-state]');
+      if (artworkTiles.length === 0) return false;
+
+      return Array.from(artworkTiles).every(
+        tile => tile.getAttribute('data-artwork-state') === 'image'
+      );
+    },
+    undefined,
+    { timeout: TIMEOUTS.CONTENT_VISIBLE }
+  );
+}
 
 test.describe('Product Screenshots – Releases Dashboard', () => {
   test('releases table – full view', async ({ page }) => {
@@ -33,10 +51,7 @@ test.describe('Product Screenshots – Releases Dashboard', () => {
 
     const matrix = page.getByTestId('releases-matrix');
     await expect(matrix).toBeVisible({ timeout: TIMEOUTS.CONTENT_VISIBLE });
-    // Some demo releases have no artwork — don't block on missing images
-    await waitForImages(page, 'table').catch(() => {
-      console.log('⚠ Some table images may not have loaded, continuing...');
-    });
+    await waitForReleaseArtwork(page);
     await waitForSettle(page);
     await hideTransientUI(page);
     await assertNoDevOverlays(page);
@@ -58,9 +73,7 @@ test.describe('Product Screenshots – Releases Dashboard', () => {
 
     const matrix = page.getByTestId('releases-matrix');
     await expect(matrix).toBeVisible({ timeout: TIMEOUTS.CONTENT_VISIBLE });
-    await waitForImages(page, 'table').catch(() => {
-      console.log('⚠ Some table images may not have loaded, continuing...');
-    });
+    await waitForReleaseArtwork(page);
     await waitForSettle(page, 2000);
 
     // Click on the first release row to open the sidebar

--- a/apps/web/tests/unit/demo-recording.test.ts
+++ b/apps/web/tests/unit/demo-recording.test.ts
@@ -44,6 +44,8 @@ afterEach(() => {
 
   delete document.documentElement.dataset.demoRecording;
   delete document.documentElement.dataset.devChromeDisabled;
+  delete window.__JOVIE_DEMO_RECORDING__;
+  delete window.__JOVIE_DEV_CHROME_DISABLED__;
 });
 
 describe('demo recording helpers', () => {
@@ -161,5 +163,29 @@ describe('demo recording helpers', () => {
     const { isDevChromeDisabledClient } = await loadModule();
 
     expect(isDevChromeDisabledClient()).toBe(true);
+  });
+
+  it('reads client chrome suppression from the stable window marker', async () => {
+    window.__JOVIE_DEV_CHROME_DISABLED__ = true;
+
+    const { isDevChromeDisabledClient } = await loadModule();
+
+    expect(isDevChromeDisabledClient()).toBe(true);
+  });
+
+  it('reads client recording mode from the html dataset', async () => {
+    document.documentElement.dataset.demoRecording = '1';
+
+    const { isDemoRecordingClient } = await loadModule();
+
+    expect(isDemoRecordingClient()).toBe(true);
+  });
+
+  it('reads client recording mode from the stable window marker', async () => {
+    window.__JOVIE_DEMO_RECORDING__ = true;
+
+    const { isDemoRecordingClient } = await loadModule();
+
+    expect(isDemoRecordingClient()).toBe(true);
   });
 });

--- a/apps/web/tests/unit/demo/mock-release-data.test.ts
+++ b/apps/web/tests/unit/demo/mock-release-data.test.ts
@@ -1,9 +1,16 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   DEMO_RELEASE_SIDEBAR_FIXTURES,
   DEMO_RELEASE_VIEW_MODELS,
+  FOUNDER_DEMO_RELEASE_VIEW_MODELS,
 } from '@/features/demo/mock-release-data';
 import { INTERNAL_DJ_DEMO_PERSONA } from '@/lib/demo-personas';
+
+const WEB_ROOT = process.cwd().endsWith('/apps/web')
+  ? process.cwd()
+  : join(process.cwd(), 'apps/web');
 
 describe('mock release data', () => {
   it('keeps the 96 Months sidebar fixture sparse relative to the full release', () => {
@@ -32,5 +39,34 @@ describe('mock release data', () => {
     expect(fixtureText).not.toContain('Blessings');
     expect(fixtureText).not.toContain('Clementine Douglas');
     expect(fixtureText).not.toContain('Tim White');
+  });
+
+  it('keeps demo-visible release artwork resolvable or explicitly external', () => {
+    const demoReleases = [
+      ...DEMO_RELEASE_VIEW_MODELS,
+      ...FOUNDER_DEMO_RELEASE_VIEW_MODELS,
+    ];
+
+    expect(demoReleases.length).toBeGreaterThan(0);
+
+    for (const release of demoReleases) {
+      const artworkUrl = release.artworkUrl?.trim();
+      expect(artworkUrl, release.title).toBeTruthy();
+      if (!artworkUrl) continue;
+
+      if (!artworkUrl.startsWith('/')) {
+        expect(
+          URL.canParse(artworkUrl),
+          `${release.title} has invalid external artwork`
+        ).toBe(true);
+        continue;
+      }
+
+      const publicPath = join(WEB_ROOT, 'public', artworkUrl);
+      expect(
+        existsSync(publicPath),
+        `${release.title} artwork asset is missing at ${publicPath}`
+      ).toBe(true);
+    }
   });
 });

--- a/apps/web/tests/unit/dev/DevToolbar.test.tsx
+++ b/apps/web/tests/unit/dev/DevToolbar.test.tsx
@@ -42,6 +42,7 @@ vi.mock('@/lib/flags/contracts', () => ({
 }));
 
 import { DevToolbar } from '@/components/features/dev/DevToolbar';
+import { isDevToolbarSuppressedPath } from '@/components/features/dev/DevToolbarGate';
 
 const TOOLBAR_HIDDEN_KEY = '__dev_toolbar_hidden';
 const TOOLBAR_OPEN_KEY = '__dev_toolbar_open';
@@ -91,6 +92,17 @@ describe('DevToolbar', () => {
   afterEach(() => {
     cleanup();
     document.documentElement.style.setProperty('--dev-toolbar-height', '0px');
+  });
+
+  describe('gate suppression', () => {
+    it('suppresses demo capture routes without suppressing normal app routes', () => {
+      expect(isDevToolbarSuppressedPath('/demovideo')).toBe(true);
+      expect(isDevToolbarSuppressedPath('/demo')).toBe(true);
+      expect(isDevToolbarSuppressedPath('/demo/video')).toBe(true);
+      expect(isDevToolbarSuppressedPath('/demo/founder-video')).toBe(true);
+      expect(isDevToolbarSuppressedPath('/app/dashboard/releases')).toBe(false);
+      expect(isDevToolbarSuppressedPath('/start')).toBe(false);
+    });
   });
 
   // ─── Show/Hide ───────────────────────────────────────────────
@@ -934,7 +946,9 @@ describe('DevToolbar', () => {
       vi.stubGlobal('fetch', fetchSpy);
       setTimeoutSpy = vi
         .spyOn(globalThis, 'setTimeout')
-        .mockImplementation((() => 0) as typeof globalThis.setTimeout);
+        .mockImplementation(
+          (() => 0) as unknown as typeof globalThis.setTimeout
+        );
     });
 
     afterEach(() => {


### PR DESCRIPTION
## Summary
- JOV-2196: demoted the releases header affordance to one visible Filter control and covered it in component/E2E assertions.
- JOV-2197: replaced missing/letter artwork placeholders with deterministic fallback art and added fixture coverage for demo release artwork URLs.
- JOV-2198: suppresses dev toolbar/internal chrome for demo capture contexts and demo routes while preserving normal dev toolbar behavior.

## Changed files
- apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
- apps/web/components/features/dev/DevToolbarGate.tsx
- apps/web/components/shell/ArtworkThumb.tsx
- apps/web/components/shell/ArtworkThumb.test.tsx
- apps/web/lib/demo-recording.ts
- apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx
- apps/web/tests/e2e/yc-demo.spec.ts
- apps/web/tests/product-screenshots/releases.spec.ts
- apps/web/tests/unit/demo-recording.test.ts
- apps/web/tests/unit/demo/mock-release-data.test.ts
- apps/web/tests/unit/dev/DevToolbar.test.tsx

## Verification
- `env JOVIE_AGENT_PROFILE=coder node --version` -> v22.22.1
- `env JOVIE_AGENT_PROFILE=coder pnpm --version` -> 9.15.4
- `env JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh`
- `env JOVIE_AGENT_PROFILE=coder pnpm install --frozen-lockfile`
- `env JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx apps/web/components/features/dev/DevToolbarGate.tsx apps/web/components/shell/ArtworkThumb.test.tsx apps/web/components/shell/ArtworkThumb.tsx apps/web/lib/demo-recording.ts apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx apps/web/tests/e2e/yc-demo.spec.ts apps/web/tests/product-screenshots/releases.spec.ts apps/web/tests/unit/demo-recording.test.ts apps/web/tests/unit/demo/mock-release-data.test.ts apps/web/tests/unit/dev/DevToolbar.test.tsx` -> passed
- `env JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run components/shell/ArtworkThumb.test.tsx tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx tests/unit/dev/DevToolbar.test.tsx tests/unit/demo-recording.test.ts tests/unit/demo/mock-release-data.test.ts` -> 5 files passed, 105 tests passed
- `env JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` -> passed
- Focused Playwright route verification script against `http://localhost:3001/app/dashboard/releases` and `/demo` -> passed: normal dev toolbar present, recording toolbar absent, zero Search releases buttons, one Filter releases button, fallback/image artwork present, no broken demo route images.
- `env JOVIE_AGENT_PROFILE=coder E2E_SKIP_WEB_SERVER=1 BASE_URL=http://localhost:3001 E2E_USE_TEST_AUTH_BYPASS=1 pnpm --filter @jovie/web exec playwright test tests/e2e/yc-demo.spec.ts --grep "yc demo - zero" --project=chromium --no-deps` -> command ran; spec skipped because `DEMO_CLERK_USER_ID` is not configured in this lane.
- `env JOVIE_AGENT_PROFILE=coder git diff --check origin/main...HEAD` -> passed
- Commit hook -> passed `next:proxy-guard`, Biome, ESLint, staged a11y check, web typecheck
- Pre-push hook -> passed `biome check .`, web `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`

## Screenshots
- apps/web/.context/outputs/jov-2197-releases-demo-polish/releases-normal-dev-1440x900.png
- apps/web/.context/outputs/jov-2197-releases-demo-polish/releases-recording-1280x720.png
- apps/web/.context/outputs/jov-2197-releases-demo-polish/demo-route-1280x720.png

## Residual status
- No local code blockers. Draft PR is waiting for GitHub CI and bot review.
- Product screenshot spec command note: `playwright test tests/product-screenshots/releases.spec.ts --project=chromium --no-deps` under the default E2E config returned `No tests found`; the route was verified with the focused Playwright script and the screenshot config path remains typechecked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Releases header action changed from "Search releases" to "Filter releases (/)" with updated icon, tooltip and visible count.
  * Artwork fallbacks now use deterministic abstract gradients instead of letter placeholders.

* **Improvements**
  * Dev toolbar suppression now respects demo-recording and dev-chrome-disabled runtime conditions, including window-provided flags and route-aware checks.
  * Demo/dev runtime flags can be set via window globals for more reliable test/setup control.

* **Tests**
  * Updated unit, e2e, and screenshot tests to align with filter UI, demo-recording behavior, and artwork loading checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->