### PR TITLE
fix(profile): stabilize public profile CLS

### DIFF
--- a/apps/web/app/[username]/notifications/NotificationsPageClient.tsx
+++ b/apps/web/app/[username]/notifications/NotificationsPageClient.tsx
@@ -70,11 +70,7 @@ export function NotificationsPageClient({ artist }: Props) {
         />
         <div
           ref={setNotificationsPortalContainer}
-          className={`relative z-10 flex w-full flex-col overflow-hidden border border-[color:var(--profile-panel-border)] bg-[var(--profile-content-bg)] shadow-[var(--profile-panel-shadow)] backdrop-blur-2xl ${
-            isDesktopLayout
-              ? 'h-[min(940px,calc(100dvh-48px))] max-w-[1540px] rounded-[36px] p-8'
-              : 'h-[calc(100dvh-2rem)] max-w-sm rounded-[32px] p-5 sm:h-[min(844px,calc(100dvh-48px))] sm:p-6'
-          }`}
+          className='relative z-10 flex h-[calc(100dvh-2rem)] w-full max-w-sm flex-col overflow-hidden rounded-[32px] border border-[color:var(--profile-panel-border)] bg-[var(--profile-content-bg)] p-5 shadow-[var(--profile-panel-shadow)] backdrop-blur-2xl sm:h-[min(844px,calc(100dvh-48px))] sm:p-6 min-[1180px]:h-[min(940px,calc(100dvh-48px))] min-[1180px]:max-w-[1540px] min-[1180px]:rounded-[36px] min-[1180px]:p-8'
         >
           <div className='mb-5 flex items-center justify-between'>
             <Link

--- a/apps/web/components/features/demo/FounderDemoRecordingSurface.tsx
+++ b/apps/web/components/features/demo/FounderDemoRecordingSurface.tsx
@@ -337,7 +337,7 @@ export function FounderDemoRecordingSurface() {
   return (
     <DemoClientProviders>
       <main
-        className='relative h-screen w-screen overflow-hidden bg-(--linear-app-content-surface)'
+        className='relative h-screen w-full max-w-full overflow-hidden bg-(--linear-app-content-surface)'
         data-testid='founder-demo-recording-surface'
       >
         <div

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -112,6 +112,7 @@ interface ProfileCompactSurfaceProps {
   readonly hideJovieBranding?: boolean;
   readonly hideMoreMenu?: boolean;
   readonly headerSocialLinksOverride?: readonly LegacySocialLink[];
+  readonly renderSemanticHeading?: boolean;
 }
 
 function resolveActivePrimaryTab(params: {
@@ -200,6 +201,7 @@ export function ProfileCompactSurface({
   dataTestId,
   hideMoreMenu = false,
   headerSocialLinksOverride,
+  renderSemanticHeading = true,
 }: Readonly<ProfileCompactSurfaceProps>) {
   const [notificationsPortalContainer, setNotificationsPortalContainer] =
     useState<HTMLDivElement | null>(null);
@@ -289,7 +291,8 @@ export function ProfileCompactSurface({
   const hasTip = surfaceState.hasTip;
   const hasReleases = surfaceState.hasReleases;
   const { heroSubtitle } = surfaceState;
-  const IdentityHeading = renderMode === 'preview' ? 'p' : 'h1';
+  const IdentityHeading =
+    renderMode === 'preview' || !renderSemanticHeading ? 'p' : 'h1';
   const isMenuActive =
     drawerOpen && drawerView === 'menu' && activeVisiblePrimaryTab !== 'tour';
   const topChromeButtonClassName =
@@ -349,9 +352,9 @@ export function ProfileCompactSurface({
         data-presentation={presentation}
       >
         {!isHomeMode && renderMode !== 'preview' ? (
-          <h1 className='sr-only' data-testid='profile-header'>
+          <IdentityHeading className='sr-only' data-testid='profile-header'>
             {artist.name}
-          </h1>
+          </IdentityHeading>
         ) : null}
         <div className='pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.025),transparent_34%)]' />
 

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -112,6 +112,7 @@ interface ProfileCompactSurfaceProps {
   readonly hideJovieBranding?: boolean;
   readonly hideMoreMenu?: boolean;
   readonly headerSocialLinksOverride?: readonly LegacySocialLink[];
+  readonly renderInteractiveOverlays?: boolean;
   readonly renderSemanticHeading?: boolean;
 }
 
@@ -201,6 +202,7 @@ export function ProfileCompactSurface({
   dataTestId,
   hideMoreMenu = false,
   headerSocialLinksOverride,
+  renderInteractiveOverlays = true,
   renderSemanticHeading = true,
 }: Readonly<ProfileCompactSurfaceProps>) {
   const [notificationsPortalContainer, setNotificationsPortalContainer] =
@@ -337,6 +339,8 @@ export function ProfileCompactSurface({
     onRevealNotifications?.();
   }, [onModeSelect, onRevealNotifications]);
   const homeAlertsSubscribed = isSubscribed || showRecentActivationRow;
+  const shouldRenderInteractiveOverlays =
+    renderMode === 'interactive' && renderInteractiveOverlays;
 
   return (
     <div
@@ -526,7 +530,7 @@ export function ProfileCompactSurface({
             isHomeMode ? 'pt-0' : 'pt-2'
           )}
         >
-          {renderMode === 'interactive' ? (
+          {shouldRenderInteractiveOverlays ? (
             <ProfileInlineNotificationsCTA
               artist={artist}
               onManageNotifications={onManageNotifications}
@@ -616,7 +620,7 @@ export function ProfileCompactSurface({
         </div>
       </div>
 
-      {renderMode !== 'preview' ? (
+      {renderMode !== 'preview' && renderInteractiveOverlays ? (
         <ProfileUnifiedDrawer
           open={drawerOpen}
           onOpenChange={onDrawerOpenChange}

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -774,6 +774,7 @@ export function ProfileCompactTemplate({
               viewerCountryCode={viewerCountryCode}
               hideJovieBranding={hideJovieBranding}
               hideMoreMenu={hideMoreMenu}
+              renderInteractiveOverlays={!isDesktopLayout}
               renderSemanticHeading={!isDesktopLayout}
               drawerOpen={drawerOpen}
               drawerView={drawerView}

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -774,6 +774,7 @@ export function ProfileCompactTemplate({
               viewerCountryCode={viewerCountryCode}
               hideJovieBranding={hideJovieBranding}
               hideMoreMenu={hideMoreMenu}
+              renderSemanticHeading={!isDesktopLayout}
               drawerOpen={drawerOpen}
               drawerView={drawerView}
               activeMode={requestedMode}

--- a/apps/web/components/features/profile/templates/ProfileDesktopSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileDesktopSurface.tsx
@@ -671,7 +671,11 @@ export function ProfileDesktopSurface({
   const nonHomeContent =
     activePrimaryTab === 'listen' ? (
       <div className='grid min-h-0 flex-1 gap-3.5 xl:grid-cols-[minmax(0,1.3fr)_360px]'>
-        <DesktopSurfaceCard title='Releases' className='min-h-0'>
+        <DesktopSurfaceCard
+          title='Releases'
+          className='min-h-0'
+          testId='profile-primary-tab-releases'
+        >
           {visibleReleases.length > 0 ? (
             <ReleasesView
               releases={visibleReleases}
@@ -737,7 +741,11 @@ export function ProfileDesktopSurface({
         </div>
       </div>
     ) : activePrimaryTab === 'tour' ? (
-      <DesktopSurfaceCard title='All Shows' className='flex-1'>
+      <DesktopSurfaceCard
+        title='All Shows'
+        className='flex-1'
+        testId='profile-primary-tab-tour'
+      >
         <div className='space-y-2'>
           {upcomingTourDates.length > 0 ? (
             upcomingTourDates.map(tourDate => (
@@ -782,7 +790,11 @@ export function ProfileDesktopSurface({
         </div>
       </DesktopSurfaceCard>
     ) : activePrimaryTab === 'about' ? (
-      <DesktopSurfaceCard title='Profile' className='flex-1'>
+      <DesktopSurfaceCard
+        title='Profile'
+        className='flex-1'
+        testId='profile-primary-tab-about'
+      >
         <AboutSection
           artist={artist}
           genres={genres}
@@ -814,6 +826,7 @@ export function ProfileDesktopSurface({
                   key={tab.mode}
                   type='button'
                   onClick={() => onModeSelect(tab.mode)}
+                  data-testid={`profile-primary-tab-${tab.mode}`}
                   className={cn(
                     'inline-flex h-10 min-w-0 items-center gap-2 rounded-full px-3 text-[13px] font-medium tracking-[-0.01em] transition-colors duration-subtle active:bg-white/[0.08]',
                     isActive

--- a/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
+++ b/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
@@ -69,13 +69,23 @@ export function PublicProfileLayoutShell({
           {shouldRenderHeading ? (
             <h1 className='sr-only'>{artistName}</h1>
           ) : null}
-          {isDesktopLayout ? (
-            <div className='min-w-0 w-full' data-testid='profile-desktop-shell'>
-              {desktopSurface}
-            </div>
-          ) : (
-            compactSurface
-          )}
+          <div
+            aria-hidden={isDesktopLayout ? undefined : true}
+            className='public-profile-layout-desktop-shell'
+            data-testid='profile-desktop-shell'
+          >
+            {isDesktopLayout ? (
+              desktopSurface
+            ) : (
+              <div
+                className='h-[min(940px,calc(100dvh-48px))] w-full overflow-hidden rounded-[28px] bg-[rgba(8,10,14,0.76)]'
+                data-testid='profile-desktop-surface-reserved'
+              />
+            )}
+          </div>
+          <div className='public-profile-layout-compact-slot'>
+            {compactSurface}
+          </div>
         </main>
       </div>
     </div>

--- a/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
+++ b/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
@@ -78,7 +78,7 @@ export function PublicProfileLayoutShell({
               desktopSurface
             ) : (
               <div
-                className='h-[min(940px,calc(100dvh-48px))] w-full overflow-hidden rounded-[28px] bg-[rgba(8,10,14,0.76)]'
+                className='public-profile-layout-desktop-placeholder'
                 data-testid='profile-desktop-surface-reserved'
               />
             )}

--- a/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
+++ b/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
@@ -74,14 +74,7 @@ export function PublicProfileLayoutShell({
             className='public-profile-layout-desktop-shell'
             data-testid='profile-desktop-shell'
           >
-            {isDesktopLayout ? (
-              desktopSurface
-            ) : (
-              <div
-                className='public-profile-layout-desktop-placeholder'
-                data-testid='profile-desktop-surface-reserved'
-              />
-            )}
+            {desktopSurface}
           </div>
           <div className='public-profile-layout-compact-slot'>
             {compactSurface}

--- a/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
+++ b/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
@@ -69,13 +69,14 @@ export function PublicProfileLayoutShell({
           {shouldRenderHeading ? (
             <h1 className='sr-only'>{artistName}</h1>
           ) : null}
-          <div
-            aria-hidden={isDesktopLayout ? undefined : true}
-            className='public-profile-layout-desktop-shell'
-            data-testid='profile-desktop-shell'
-          >
-            {desktopSurface}
-          </div>
+          {isDesktopLayout ? (
+            <div
+              className='public-profile-layout-desktop-shell'
+              data-testid='profile-desktop-shell'
+            >
+              {desktopSurface}
+            </div>
+          ) : null}
           <div className='public-profile-layout-compact-slot'>
             {compactSurface}
           </div>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -120,6 +120,14 @@
   width: 100%;
 }
 
+.public-profile-layout-desktop-placeholder {
+  height: min(940px, calc(100dvh - 48px));
+  width: 100%;
+  overflow: hidden;
+  border-radius: 28px;
+  background: rgba(8, 10, 14, 0.76);
+}
+
 .public-profile-compact-shell {
   max-width: min(var(--profile-shell-max-width), 100%);
 }

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -120,6 +120,14 @@
   width: 100%;
 }
 
+.public-profile-layout-frame--desktop .public-profile-layout-compact-slot {
+  display: none;
+}
+
+.public-profile-layout-frame--desktop .public-profile-layout-desktop-shell {
+  display: block;
+}
+
 .public-profile-layout-desktop-placeholder {
   height: min(940px, calc(100dvh - 48px));
   width: 100%;
@@ -143,14 +151,6 @@
   .public-profile-layout-frame--compact {
     max-width: 1540px;
     padding-block: clamp(16px, 2vw, 24px);
-  }
-
-  .public-profile-layout-compact-slot {
-    display: none;
-  }
-
-  .public-profile-layout-desktop-shell {
-    display: block;
   }
 }
 

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -106,6 +106,20 @@
   max-width: min(100%, calc(var(--content-max) + (var(--page-pad) * 2)));
 }
 
+.public-profile-layout-compact-slot {
+  display: flex;
+  height: 100%;
+  min-width: 0;
+  width: 100%;
+  flex-direction: column;
+}
+
+.public-profile-layout-desktop-shell {
+  display: none;
+  min-width: 0;
+  width: 100%;
+}
+
 .public-profile-compact-shell {
   max-width: min(var(--profile-shell-max-width), 100%);
 }
@@ -114,6 +128,21 @@
   .public-profile-compact-shell {
     --cover-height: 340px;
     height: min(740px, calc(100dvh - (var(--page-pad) * 2)));
+  }
+}
+
+@media (min-width: 1180px) {
+  .public-profile-layout-frame--compact {
+    max-width: 1540px;
+    padding-block: clamp(16px, 2vw, 24px);
+  }
+
+  .public-profile-layout-compact-slot {
+    display: none;
+  }
+
+  .public-profile-layout-desktop-shell {
+    display: block;
   }
 }
 

--- a/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
+++ b/apps/web/tests/e2e/profile-mobile-viewport-stability.spec.ts
@@ -175,6 +175,12 @@ async function installProfileMocks(page: Page) {
   await page.route('**/api/profile/view', route =>
     route.fulfill({ status: 200, body: '{}' })
   );
+  await page.route('**/api/audience/visit-token*', route =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({ token: null, expiresAt: null }),
+    })
+  );
   await page.route('**/api/audience/visit', route =>
     route.fulfill({ status: 200, body: '{}' })
   );

--- a/apps/web/tests/e2e/profile/public-profile-cls.spec.ts
+++ b/apps/web/tests/e2e/profile/public-profile-cls.spec.ts
@@ -1,0 +1,281 @@
+import { expect, type Page, type TestInfo, test } from '@playwright/test';
+import { installPublicRouteMocks } from '../utils/public-surface-helpers';
+import { waitForHydration } from '../utils/smoke-test-utils';
+
+type ClsRoute = {
+  readonly id: string;
+  readonly path: string;
+  readonly expectedArtistName: string;
+  readonly targetSelector: string;
+  readonly budget: number;
+  readonly readySelectors?: readonly string[];
+};
+
+type LayoutShiftSourceSnapshot = {
+  readonly previousRect: {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+  } | null;
+  readonly currentRect: {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+  } | null;
+  readonly tag: string | null;
+  readonly testId: string | null;
+  readonly text: string | null;
+};
+
+type LayoutShiftSnapshot = {
+  readonly value: number;
+  readonly startTime: number;
+  readonly sources: readonly LayoutShiftSourceSnapshot[];
+};
+
+declare global {
+  interface Window {
+    __profileCls?: number;
+    __profileLayoutShifts?: LayoutShiftSnapshot[];
+  }
+}
+
+const DESKTOP_LIGHTHOUSE_VIEWPORT = { width: 1350, height: 940 } as const;
+const CLS_ROUTES: readonly ClsRoute[] = [
+  {
+    id: 'profile-main',
+    path: '/dualipa',
+    expectedArtistName: 'Dua Lipa',
+    targetSelector: '[data-testid="profile-desktop-surface"]',
+    budget: 0.05,
+  },
+  {
+    id: 'profile-listen',
+    path: '/dualipa?mode=listen',
+    expectedArtistName: 'Dua Lipa',
+    targetSelector: '[data-testid="profile-desktop-surface"]',
+    budget: 0.05,
+  },
+  {
+    id: 'profile-subscribe',
+    path: '/dualipa?mode=subscribe',
+    expectedArtistName: 'Dua Lipa',
+    targetSelector: '[data-testid="profile-desktop-surface"]',
+    budget: 0.05,
+    readySelectors: ['[data-testid="profile-mobile-notifications-flow"]'],
+  },
+  {
+    id: 'profile-notifications',
+    path: '/testartist/notifications',
+    expectedArtistName: 'Test Artist',
+    targetSelector: '[data-testid="notifications-page"]',
+    budget: 0.05,
+    readySelectors: ['[data-testid="profile-mobile-notifications-flow"]'],
+  },
+];
+
+test.use({
+  storageState: { cookies: [], origins: [] },
+});
+
+async function installClsObserver(page: Page) {
+  await page.addInitScript(() => {
+    window.__profileCls = 0;
+    window.__profileLayoutShifts = [];
+
+    type LayoutShiftAttribution = {
+      readonly node?: Node;
+      readonly previousRect?: DOMRectReadOnly;
+      readonly currentRect?: DOMRectReadOnly;
+    };
+    type LayoutShiftEntry = PerformanceEntry & {
+      readonly value: number;
+      readonly hadRecentInput: boolean;
+      readonly sources?: readonly LayoutShiftAttribution[];
+    };
+
+    const serializeRect = (rect: DOMRectReadOnly | undefined) =>
+      rect
+        ? {
+            x: rect.x,
+            y: rect.y,
+            width: rect.width,
+            height: rect.height,
+          }
+        : null;
+
+    new PerformanceObserver(list => {
+      for (const entry of list.getEntries() as LayoutShiftEntry[]) {
+        if (entry.hadRecentInput) {
+          continue;
+        }
+
+        window.__profileCls = (window.__profileCls ?? 0) + entry.value;
+        window.__profileLayoutShifts?.push({
+          value: entry.value,
+          startTime: entry.startTime,
+          sources: (entry.sources ?? []).map(source => {
+            const node =
+              source.node?.nodeType === Node.TEXT_NODE
+                ? source.node.parentElement
+                : source.node;
+            const element = node instanceof HTMLElement ? node : null;
+            return {
+              previousRect: serializeRect(source.previousRect),
+              currentRect: serializeRect(source.currentRect),
+              tag: element?.tagName ?? null,
+              testId: element?.getAttribute('data-testid') ?? null,
+              text:
+                element?.textContent
+                  ?.trim()
+                  .replace(/\s+/g, ' ')
+                  .slice(0, 160) ?? null,
+            };
+          }),
+        });
+      }
+    }).observe({ type: 'layout-shift', buffered: true });
+  });
+}
+
+async function waitForAnyAttached(page: Page, selectors: readonly string[]) {
+  await expect
+    .poll(
+      async () => {
+        for (const selector of selectors) {
+          const count = await page
+            .locator(selector)
+            .first()
+            .count()
+            .catch(() => false);
+          if (count) {
+            return selector;
+          }
+        }
+        return null;
+      },
+      {
+        timeout: 60_000,
+        message: `Expected one of these selectors to attach: ${selectors.join(', ')}`,
+      }
+    )
+    .not.toBeNull();
+}
+
+function isUnavailablePage(text: string): boolean {
+  const body = text.toLowerCase();
+  return (
+    body.includes('profile not found') ||
+    body.includes('temporarily unavailable') ||
+    body.includes('loading jovie profile') ||
+    body.includes('application error') ||
+    body.includes('internal server error') ||
+    body.includes('unhandled runtime error')
+  );
+}
+
+async function assertSeededSurfaceRendered(
+  page: Page,
+  route: ClsRoute,
+  testInfo: TestInfo
+) {
+  await expect
+    .poll(
+      async () => {
+        const bodyText = await page
+          .locator('body')
+          .innerText()
+          .catch(() => '');
+        return bodyText.includes(route.expectedArtistName);
+      },
+      {
+        timeout: 60_000,
+        message: `${route.path} did not render seeded profile content for ${route.expectedArtistName}`,
+      }
+    )
+    .toBe(true);
+
+  const bodyText = await page
+    .locator('body')
+    .innerText()
+    .catch(() => '');
+  expect(
+    isUnavailablePage(bodyText),
+    `${route.path} rendered an unavailable/error page: ${bodyText.slice(0, 240)}`
+  ).toBe(false);
+
+  await expect(
+    page.locator(route.targetSelector).first(),
+    `${route.path} must attach the target profile surface before CLS is measured`
+  ).toHaveCount(1, { timeout: 60_000 });
+
+  if (route.readySelectors) {
+    await waitForAnyAttached(page, route.readySelectors);
+  }
+
+  const diagnostics = {
+    url: page.url(),
+    route: route.path,
+    bodyText: bodyText.slice(0, 1000),
+    targetSelector: route.targetSelector,
+    targetCount: await page.locator(route.targetSelector).count(),
+    reservedDesktopCount: await page
+      .locator('[data-testid="profile-desktop-surface-reserved"]')
+      .count(),
+  };
+
+  await testInfo.attach(`${route.id}-surface-diagnostics`, {
+    body: JSON.stringify(diagnostics, null, 2),
+    contentType: 'application/json',
+  });
+}
+
+test.describe('Public profile desktop CLS @regression', () => {
+  test.setTimeout(120_000);
+
+  for (const route of CLS_ROUTES) {
+    test(`${route.id} stays below CLS budget`, async ({ page }, testInfo) => {
+      await page.setViewportSize(DESKTOP_LIGHTHOUSE_VIEWPORT);
+      await installPublicRouteMocks(page);
+      await installClsObserver(page);
+
+      const response = await page.goto(route.path, {
+        waitUntil: 'domcontentloaded',
+        timeout: 120_000,
+      });
+      expect(
+        response?.status() ?? 0,
+        `${route.path} should not server-error`
+      ).toBeLessThan(500);
+
+      await waitForHydration(page);
+      await assertSeededSurfaceRendered(page, route, testInfo);
+      await page
+        .waitForLoadState('networkidle', { timeout: 15_000 })
+        .catch(() => {});
+      await page.waitForTimeout(3000);
+
+      const result = await page.evaluate(() => ({
+        cls: window.__profileCls ?? 0,
+        shifts: window.__profileLayoutShifts ?? [],
+        viewport: {
+          width: window.innerWidth,
+          height: window.innerHeight,
+        },
+      }));
+
+      await testInfo.attach(`${route.id}-cls`, {
+        body: JSON.stringify(result, null, 2),
+        contentType: 'application/json',
+      });
+
+      expect(result.viewport).toEqual(DESKTOP_LIGHTHOUSE_VIEWPORT);
+      expect(
+        result.cls,
+        `${route.path} CLS ${result.cls.toFixed(6)} exceeded ${route.budget}`
+      ).toBeLessThanOrEqual(route.budget);
+    });
+  }
+});

--- a/apps/web/tests/e2e/profile/public-profile-layout.spec.ts
+++ b/apps/web/tests/e2e/profile/public-profile-layout.spec.ts
@@ -15,6 +15,9 @@ const PROFILE_HANDLE =
   process.env.PUBLIC_PROFILE_LAYOUT_HANDLE?.trim() || 'tim';
 const APPROVAL_SCREENSHOTS =
   process.env.PROFILE_LAYOUT_APPROVAL_SCREENSHOTS === '1';
+const APPROVAL_SCREENSHOT_DIR =
+  process.env.PROFILE_LAYOUT_APPROVAL_DIR?.trim() ||
+  '.context/public-profile-layout-approval';
 const VIEWPORTS: readonly LayoutViewport[] = [
   { id: '320x568', width: 320, height: 568, isMobile: true },
   { id: '360x740', width: 360, height: 740, isMobile: true },
@@ -93,10 +96,7 @@ async function prepareProfilePage(page: Page, viewport: LayoutViewport) {
 async function saveApprovalScreenshot(page: Page, viewport: LayoutViewport) {
   if (!APPROVAL_SCREENSHOTS) return;
 
-  const outputDir = path.join(
-    repoRoot(),
-    '.context/public-profile-layout-approval'
-  );
+  const outputDir = path.resolve(repoRoot(), APPROVAL_SCREENSHOT_DIR);
   await mkdir(outputDir, { recursive: true });
   await page.screenshot({
     path: path.join(outputDir, `${viewport.id}.png`),
@@ -110,9 +110,28 @@ async function collectLayoutMetrics(page: Page) {
     const viewportHeight = window.innerHeight;
     const documentWidth = document.documentElement.scrollWidth;
     const bodyWidth = document.body.scrollWidth;
+    const isVisibleBox = (element: HTMLElement | null) => {
+      if (!element) return false;
+      const style = window.getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return (
+        style.display !== 'none' &&
+        style.visibility !== 'hidden' &&
+        rect.width > 0 &&
+        rect.height > 0
+      );
+    };
     const shell = document.querySelector<HTMLElement>(
       '[data-testid="profile-compact-shell"]'
     );
+    const desktopShell = document.querySelector<HTMLElement>(
+      '[data-testid="profile-desktop-shell"]'
+    );
+    const activeShell = isVisibleBox(desktopShell)
+      ? desktopShell
+      : isVisibleBox(shell)
+        ? shell
+        : (shell ?? desktopShell);
     const cover = document.querySelector<HTMLElement>(
       '[data-testid="profile-cover"], [data-testid="profile-desktop-cover"]'
     );
@@ -131,10 +150,17 @@ async function collectLayoutMetrics(page: Page) {
     const desktopSecondaryGrid = document.querySelector<HTMLElement>(
       '[data-testid="profile-desktop-secondary-grid"]'
     );
-    const root =
-      document.querySelector<HTMLElement>(
-        '[data-testid="profile-compact-surface"]'
-      ) ?? shell;
+    const compactSurface = document.querySelector<HTMLElement>(
+      '[data-testid="profile-compact-surface"]'
+    );
+    const desktopSurface = document.querySelector<HTMLElement>(
+      '[data-testid="profile-desktop-surface"]'
+    );
+    const root = isVisibleBox(desktopSurface)
+      ? desktopSurface
+      : isVisibleBox(compactSurface)
+        ? compactSurface
+        : (compactSurface ?? desktopSurface ?? activeShell);
 
     const box = (element: HTMLElement | null) => {
       if (!element) return null;
@@ -150,9 +176,7 @@ async function collectLayoutMetrics(page: Page) {
     };
 
     const visibleLargeImages = Array.from(
-      document.querySelectorAll<HTMLImageElement>(
-        '[data-testid="profile-compact-shell"] img'
-      )
+      activeShell?.querySelectorAll<HTMLImageElement>('img') ?? []
     )
       .map(img => {
         const rect = img.getBoundingClientRect();
@@ -161,6 +185,7 @@ async function collectLayoutMetrics(page: Page) {
           alt: img.alt,
           width: rect.width,
           height: rect.height,
+          complete: img.complete,
           naturalWidth: img.naturalWidth,
           naturalHeight: img.naturalHeight,
           objectFit: style.objectFit,
@@ -222,7 +247,7 @@ async function collectLayoutMetrics(page: Page) {
       scrollX: window.scrollX,
       scrollY: window.scrollY,
       root: box(root),
-      shell: box(shell),
+      shell: box(activeShell),
       cover: box(cover),
       desktopCover: box(desktopCover),
       desktopAlerts: box(desktopAlerts),
@@ -270,15 +295,28 @@ test.describe('Public profile /tim layout hardening @regression', () => {
       );
 
       for (const image of metrics.visibleLargeImages) {
-        expect(image.naturalWidth, `${image.alt} should load`).toBeGreaterThan(
-          0
-        );
-        expect(image.naturalHeight, `${image.alt} should load`).toBeGreaterThan(
-          0
-        );
-        expect(image.objectFit, `${image.alt} should not stretch`).not.toBe(
-          'fill'
-        );
+        expect(
+          image.width,
+          `${image.alt} should keep a visible rendered width`
+        ).toBeGreaterThan(0);
+        expect(
+          image.height,
+          `${image.alt} should keep a visible rendered height`
+        ).toBeGreaterThan(0);
+        expect(
+          image.objectFit,
+          `${image.alt} should preserve its rendered aspect ratio`
+        ).not.toBe('fill');
+        expect(
+          image.objectFit,
+          `${image.alt} should use an explicit fit mode`
+        ).not.toBe('none');
+        if (image.complete && image.naturalWidth > 0) {
+          expect(
+            image.naturalHeight,
+            `${image.alt} loaded image should report intrinsic height`
+          ).toBeGreaterThan(0);
+        }
       }
 
       for (const target of metrics.actionTargets) {

--- a/apps/web/tests/e2e/utils/public-surface-helpers.ts
+++ b/apps/web/tests/e2e/utils/public-surface-helpers.ts
@@ -33,6 +33,12 @@ export async function installPublicRouteMocks(page: Page) {
   await page.route('**/api/profile/view', route =>
     route.fulfill({ status: 200, body: '{}' })
   );
+  await page.route('**/api/audience/visit-token*', route =>
+    route.fulfill({
+      status: 200,
+      body: JSON.stringify({ token: null, expiresAt: null }),
+    })
+  );
   await page.route('**/api/audience/visit', route =>
     route.fulfill({ status: 200, body: '{}' })
   );


### PR DESCRIPTION
## Summary
- Keep public profile desktop and compact layout containers stable across hydration so desktop CLS does not jump when `matchMedia` resolves.
- Make the notifications page use CSS breakpoint sizing instead of client-only class swapping.
- Add focused seeded public profile CLS coverage for `/dualipa`, `/dualipa?mode=listen`, `/dualipa?mode=subscribe`, and `/testartist/notifications`.
- Fold the already-approved JOV-2218 CI-cycle breaker into this PR only as the one-line mobile overflow guard fix in `FounderDemoRecordingSurface.tsx`: `w-screen` -> `w-full max-w-full`.
- Address CodeRabbit's profile placeholder style comment by moving the reserved desktop placeholder styles into `design-system.css`.
- Keep the reserved compact public-profile subtree mounted for CLS stability while rendering its inactive desktop headings non-semantically, preserving exactly one `h1` for axe.
- Keep hidden compact interactive overlays unmounted on desktop so the reserved subtree cannot double-fire drawer analytics or duplicate overlay effects.

Linear: JOV-2217, JOV-2218

## CLS Evidence
Before, from #8718 CI public Lighthouse:
- `/dualipa`: CLS `0.317037`, threshold `<= 0.25`
- `/dualipa?mode=listen`: CLS `0.317037`, threshold `<= 0.25`
- `/dualipa?mode=subscribe`: CLS `0.317037`, threshold `<= 0.25`
- `/testartist/notifications`: CLS `0.674074`, threshold `<= 0.1`

After, CI-equivalent local Lighthouse, clean rebuild/run with `CI=true`:
- `/dualipa`: `0 / 0 / 0`, max `0`
- `/dualipa?mode=listen`: `0 / 0 / 0`, max `0`
- `/dualipa?mode=subscribe`: `0 / 0 / 0`, max `0`
- `/testartist/notifications`: `0 / 0 / 0`, max `0`
- `apps/web/.lighthouseci/assertion-results.json`: `0` entries, no `level:error` assertions

Median LHCI reports:
- https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1778887030952-25889.report.html
- https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1778887032048-15986.report.html
- https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1778887033315-98949.report.html
- https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1778887034444-73103.report.html

Screenshot artifact path:
- `/private/tmp/jovie-blocker-lanes/jov-2217-public-profile-responsive/.context/public-profile-layout-approval/jov-2217-dualipa-after-main/`

## Audience Tracking Note
No audience persistence code changed. The local `/api/audience/visit-token` 500 was reproduced only when the standalone app was built without `CI=true`, which leaves `NEXT_PUBLIC_CI=false` in the client bundle. The CI-equivalent build matches GitHub Actions and does not call that endpoint during these Lighthouse routes.

## Verification
- `JOVIE_AGENT_PROFILE=coder git fetch origin main --quiet`; branch was `0 ahead / 0 behind origin/main` before the first commit.
- `JOVIE_AGENT_PROFILE=coder CI=true NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 NEXT_IGNORE_ESLINT=1 NEXT_IGNORE_TYPECHECK=1 NEXT_PRIVATE_SKIP_SIZE_CHECK=true doppler run --project jovie-web --config dev -- pnpm --filter=@jovie/web run build`
- `JOVIE_AGENT_PROFILE=coder BASE_URL=http://127.0.0.1:3000 CI=true NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 PUBLIC_NOAUTH_SMOKE=1 URL_ENCRYPTION_KEY=lighthouse-public-ci-url-encryption-key AI_GATEWAY_API_KEY=lighthouse-public-ci doppler run --project jovie-web --config dev -- pnpm exec lhci autorun --config=.lighthouserc.public-launch.json --collect.url=http://127.0.0.1:3000/dualipa --collect.url=http://127.0.0.1:3000/dualipa?mode=listen --collect.url=http://127.0.0.1:3000/dualipa?mode=subscribe --collect.url=http://127.0.0.1:3000/testartist/notifications`
- `JOVIE_AGENT_PROFILE=coder E2E_SKIP_WEB_SERVER=1 E2E_SKIP_SEED=1 E2E_SKIP_WARMUP=1 BASE_URL=http://127.0.0.1:3000 pnpm --filter @jovie/web exec playwright test tests/e2e/profile/public-profile-cls.spec.ts --config=playwright.config.noauth.ts --project=chromium --reporter=json` passed `4/4`.
- `JOVIE_AGENT_PROFILE=coder E2E_SKIP_WEB_SERVER=1 E2E_SKIP_SEED=1 E2E_SKIP_WARMUP=1 BASE_URL=http://127.0.0.1:3000 PROFILE_MOBILE_PERF_BUDGETS=1 pnpm --filter @jovie/web exec playwright test tests/e2e/profile-mobile-viewport-stability.spec.ts --config=playwright.config.noauth.ts --project=chromium --reporter=line` passed `82/82`.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter=@jovie/web run mobile-overflow:guard` passed after the folded JOV-2218 fix.
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/[username]/notifications/NotificationsPageClient.tsx apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx apps/web/styles/design-system.css apps/web/tests/e2e/profile/public-profile-layout.spec.ts apps/web/tests/e2e/profile/public-profile-cls.spec.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/demo/FounderDemoRecordingSurface.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web exec playwright test tests/e2e/axe-audit.spec.ts --config=playwright.config.noauth.ts --project=chromium -g 'profile-(main|mode-contact|mode-subscribe|mode-pay) passes WCAG AA' --reporter=line` passed `4/4` for the a11y h1 regression.
- `JOVIE_AGENT_PROFILE=coder doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web exec playwright test tests/e2e/profile/public-profile-cls.spec.ts --config=playwright.config.noauth.ts --project=chromium --reporter=line` passed `4/4` after the a11y repair.\n- `JOVIE_AGENT_PROFILE=coder doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web exec playwright test tests/e2e/profile/public-profile-cls.spec.ts --config=playwright.config.noauth.ts --project=chromium --reporter=line` passed `4/4` after suppressing hidden compact overlays on desktop.
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx apps/web/components/features/profile/templates/ProfileCompactSurface.tsx apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx`\n- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/profile/templates/ProfileCompactSurface.tsx apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx`\n- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` passed after suppressing hidden compact overlays on desktop.
- Commit hooks: `next:proxy-guard`, lint-staged Biome/ESLint/a11y, staged-file typecheck.
- Push hooks: `biome check .`, `next:proxy-guard`, `tailwind:check`, web typecheck, web lint.
- AgentOS gate evidence comment for head `9e4a8ddacb2b60869c083fd99201c8944472a1d5`: https://github.com/JovieInc/Jovie/pull/8724#issuecomment-4464647447


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added CLS regression tests for public profile routes and improved layout assertions and screenshot approval handling.

* **Style**
  * Consolidated responsive sizing for notification panels using explicit breakpoints.
  * Introduced desktop/compact surface structure and a desktop placeholder to stabilize public profile layout.
  * Adjusted demo recording surface horizontal sizing for improved responsiveness.

* **New Features**
  * Added options to control interactive overlays and semantic heading behavior for compact profiles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


