### PR TITLE
feat(library): move library into shell sidebar (JOV-2224)

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -1,24 +1,38 @@
 'use client';
 
 import {
+  ArrowUpDown,
+  Check,
+  ChevronDown,
   Disc3,
   ExternalLink,
   FileAudio2,
   FileText,
+  Filter,
+  Grid3x3,
   ImageIcon,
+  LayoutList,
+  type LucideIcon,
   Music2,
+  PlayCircle,
   Search,
+  Video,
   X,
 } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { type RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import { type CSSProperties, useEffect, useMemo, useState } from 'react';
+import { OPEN_COMMAND_PALETTE_EVENT } from '@/components/organisms/command-palette-events';
+import { ShellDropdown } from '@/components/shell/ShellDropdown';
+import { Tooltip } from '@/components/shell/Tooltip';
 import { APP_ROUTES } from '@/constants/routes';
+import { useRegisterShellSidebarOverride } from '@/contexts/ShellSidebarOverrideContext';
 import { cn } from '@/lib/utils';
-import { isFormElement } from '@/lib/utils/keyboard';
 import { capitalizeFirst } from '@/lib/utils/string-utils';
 import {
+  formatLibraryDuration,
   formatLibraryReleaseDate,
+  type LibraryAssetKind,
   type LibraryReleaseAsset,
 } from './library-data';
 
@@ -31,6 +45,98 @@ const LIBRARY_LOADING_PLACEHOLDERS = [
   'library-loading-release-6',
 ] as const;
 
+type LibraryViewMode = 'grid' | 'list';
+type LibrarySortKey = 'releaseDate' | 'title' | 'status' | 'providers';
+type LibraryPresetId = 'all' | 'ready' | 'needsAssets' | 'scheduled';
+type ArtworkSize = 'card' | 'row' | 'drawer';
+
+type LibraryFilters = {
+  readonly statuses: Set<LibraryReleaseAsset['status']>;
+  readonly releaseTypes: Set<LibraryReleaseAsset['releaseType']>;
+  readonly assetKinds: Set<LibraryAssetKind>;
+  readonly providers: Set<string>;
+};
+
+type CountMap<T extends string> = ReadonlyMap<T, number>;
+
+const ASSET_KIND_LABELS: Record<LibraryAssetKind, string> = {
+  artwork: 'Artwork',
+  preview: 'Preview',
+  lyrics: 'Lyrics',
+  providers: 'Providers',
+  video: 'Video',
+};
+
+const ASSET_KIND_ICONS: Record<LibraryAssetKind, LucideIcon> = {
+  artwork: ImageIcon,
+  preview: FileAudio2,
+  lyrics: FileText,
+  providers: Music2,
+  video: Video,
+};
+
+const SORT_LABELS: Record<LibrarySortKey, string> = {
+  releaseDate: 'Release Date',
+  title: 'Title',
+  status: 'Status',
+  providers: 'Providers',
+};
+
+const PRESETS: readonly {
+  readonly id: LibraryPresetId;
+  readonly label: string;
+  readonly description: string;
+  readonly predicate: (asset: LibraryReleaseAsset) => boolean;
+}[] = [
+  {
+    id: 'all',
+    label: 'All Releases',
+    description: 'Everything in the connected catalog',
+    predicate: () => true,
+  },
+  {
+    id: 'ready',
+    label: 'Ready Assets',
+    description: 'Artwork plus at least one provider link',
+    predicate: asset => asset.hasArtwork && asset.providerCount > 0,
+  },
+  {
+    id: 'needsAssets',
+    label: 'Needs Assets',
+    description: 'Missing artwork, previews, lyrics, or provider links',
+    predicate: asset =>
+      !asset.hasArtwork ||
+      !asset.previewUrl ||
+      !asset.hasLyrics ||
+      asset.providerCount === 0,
+  },
+  {
+    id: 'scheduled',
+    label: 'Scheduled',
+    description: 'Upcoming catalog work',
+    predicate: asset => asset.status === 'scheduled',
+  },
+];
+
+function emptyFilters(): LibraryFilters {
+  return {
+    statuses: new Set(),
+    releaseTypes: new Set(),
+    assetKinds: new Set(),
+    providers: new Set(),
+  };
+}
+
+function toggleSet<T>(set: ReadonlySet<T>, value: T): Set<T> {
+  const next = new Set(set);
+  if (next.has(value)) {
+    next.delete(value);
+  } else {
+    next.add(value);
+  }
+  return next;
+}
+
 function formatReleaseType(type: LibraryReleaseAsset['releaseType']): string {
   return type.split('_').map(capitalizeFirst).join(' ');
 }
@@ -39,90 +145,133 @@ function formatReleaseStatus(status: LibraryReleaseAsset['status']): string {
   return capitalizeFirst(status);
 }
 
-function Artwork({ asset }: { readonly asset: LibraryReleaseAsset }) {
+function releaseStatusClasses(status: LibraryReleaseAsset['status']): string {
+  if (status === 'released') {
+    return 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300';
+  }
+  if (status === 'scheduled') {
+    return 'border-cyan-500/20 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300';
+  }
+  return 'border-subtle bg-surface-1 text-tertiary-token';
+}
+
+function releaseStatusDotClasses(
+  status: LibraryReleaseAsset['status']
+): string {
+  if (status === 'released') return 'bg-emerald-400';
+  if (status === 'scheduled') return 'bg-cyan-300';
+  return 'bg-white/35';
+}
+
+function assetMatchesFilters(
+  asset: LibraryReleaseAsset,
+  filters: LibraryFilters
+): boolean {
+  if (filters.statuses.size > 0 && !filters.statuses.has(asset.status)) {
+    return false;
+  }
+  if (
+    filters.releaseTypes.size > 0 &&
+    !filters.releaseTypes.has(asset.releaseType)
+  ) {
+    return false;
+  }
+  if (
+    filters.assetKinds.size > 0 &&
+    !asset.assetKinds.some(kind => filters.assetKinds.has(kind))
+  ) {
+    return false;
+  }
+  if (
+    filters.providers.size > 0 &&
+    !asset.providers.some(provider => filters.providers.has(provider.key))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function hasActiveFilters(filters: LibraryFilters): boolean {
+  return (
+    filters.statuses.size +
+      filters.releaseTypes.size +
+      filters.assetKinds.size +
+      filters.providers.size >
+    0
+  );
+}
+
+function releaseDateTime(asset: LibraryReleaseAsset): number {
+  if (!asset.releaseDate) return 0;
+  const date = new Date(asset.releaseDate);
+  return Number.isNaN(date.getTime()) ? 0 : date.getTime();
+}
+
+function compareAssets(sort: LibrarySortKey) {
+  return (a: LibraryReleaseAsset, b: LibraryReleaseAsset) => {
+    if (sort === 'releaseDate') return releaseDateTime(b) - releaseDateTime(a);
+    if (sort === 'title') return a.title.localeCompare(b.title);
+    if (sort === 'status') return a.status.localeCompare(b.status);
+    return b.providerCount - a.providerCount;
+  };
+}
+
+function uniqueSorted<T extends string>(values: readonly T[]): T[] {
+  return Array.from(new Set(values)).sort((a, b) => a.localeCompare(b));
+}
+
+function countBy<T extends string>(
+  assets: readonly LibraryReleaseAsset[],
+  getValues: (asset: LibraryReleaseAsset) => readonly T[]
+): CountMap<T> {
+  const counts = new Map<T, number>();
+  for (const asset of assets) {
+    for (const value of getValues(asset)) {
+      counts.set(value, (counts.get(value) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+function formatCompactCount(value: number): string {
+  if (value >= 1000) return `${(value / 1000).toFixed(1)}K`;
+  return String(value);
+}
+
+function Artwork({
+  asset,
+  size = 'card',
+}: {
+  readonly asset: LibraryReleaseAsset;
+  readonly size?: ArtworkSize;
+}) {
+  const sizeClasses = {
+    card: 'h-full w-full',
+    row: 'h-10 w-10',
+    drawer: 'h-full w-full',
+  } satisfies Record<ArtworkSize, string>;
+
   if (asset.artworkUrl) {
     return (
       <Image
         src={asset.artworkUrl}
         alt=''
-        width={104}
-        height={104}
-        className='h-20 w-20 rounded-md object-cover sm:h-24 sm:w-24'
+        width={size === 'row' ? 48 : 320}
+        height={size === 'row' ? 48 : 320}
+        className={cn('object-cover', sizeClasses[size])}
         unoptimized
       />
     );
   }
 
   return (
-    <div className='grid h-20 w-20 place-items-center rounded-md border border-subtle bg-surface-1 text-tertiary-token sm:h-24 sm:w-24'>
-      <ImageIcon className='h-5 w-5' strokeWidth={2.25} />
-    </div>
-  );
-}
-
-function assetMatchesSearch(asset: LibraryReleaseAsset, query: string) {
-  const normalized = query.trim().toLowerCase();
-  if (!normalized) return true;
-
-  const haystack = [
-    asset.title,
-    asset.artist,
-    asset.status,
-    formatReleaseType(asset.releaseType),
-    ...asset.providers.map(provider => provider.label),
-  ]
-    .join(' ')
-    .toLowerCase();
-
-  return haystack.includes(normalized);
-}
-
-function LibrarySearchInput({
-  value,
-  onChange,
-  inputRef,
-}: Readonly<{
-  value: string;
-  onChange: (value: string) => void;
-  inputRef: RefObject<HTMLInputElement | null>;
-}>) {
-  return (
-    <div className='flex h-8 min-w-0 items-center gap-2 rounded-md border border-(--linear-app-shell-border) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,transparent)] px-2.5 text-secondary-token transition-[border-color,background-color] focus-within:border-(--linear-border-focus) focus-within:bg-surface-1'>
-      <Search className='h-3.5 w-3.5 shrink-0 text-tertiary-token' />
-      <input
-        ref={inputRef}
-        type='search'
-        value={value}
-        onChange={event => onChange(event.target.value)}
-        onKeyDown={event => {
-          if (event.key === 'Escape') {
-            event.preventDefault();
-            if (value) {
-              onChange('');
-            } else {
-              event.currentTarget.blur();
-            }
-          }
-        }}
-        aria-label='Search library assets'
-        placeholder='Search assets, artists, providers'
-        data-app-search-field='true'
-        className='min-w-0 flex-1 bg-transparent text-[12.5px] text-primary-token outline-none placeholder:text-tertiary-token'
-      />
-      {value ? (
-        <button
-          type='button'
-          onClick={() => onChange('')}
-          aria-label='Clear library search'
-          className='inline-flex h-5 w-5 shrink-0 items-center justify-center rounded text-tertiary-token transition-colors hover:bg-surface-2 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
-        >
-          <X className='h-3 w-3' />
-        </button>
-      ) : (
-        <kbd className='hidden h-5 shrink-0 items-center rounded border border-(--linear-app-shell-border) bg-surface-1 px-1.5 text-[10px] font-semibold text-tertiary-token sm:inline-flex'>
-          /
-        </kbd>
+    <div
+      className={cn(
+        'grid place-items-center border border-subtle bg-surface-1 text-tertiary-token',
+        sizeClasses[size]
       )}
+    >
+      <ImageIcon className='h-5 w-5' strokeWidth={2.25} />
     </div>
   );
 }
@@ -132,46 +281,847 @@ export function LibraryLoadingState() {
     <main
       aria-busy='true'
       aria-label='Loading Library'
-      className='h-full overflow-y-auto px-5 py-5 sm:px-6 lg:px-8'
+      className='h-full overflow-hidden px-4 py-4 sm:px-5 lg:px-6'
     >
-      <div className='mx-auto max-w-6xl space-y-5'>
-        <div className='flex items-end justify-between gap-4'>
-          <div className='space-y-2'>
-            <div className='h-4 w-56 max-w-[72vw] rounded-md bg-surface-1' />
-            <div className='h-4 w-32 rounded-md bg-surface-1' />
+      <div className='mx-auto grid h-full max-w-[1440px] overflow-hidden rounded-lg border border-subtle bg-surface-1 shadow-card'>
+        <div className='flex min-w-0 flex-col'>
+          <div className='border-b border-subtle p-3'>
+            <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+              <div className='space-y-2'>
+                <div className='h-4 w-56 max-w-[72vw] rounded-md bg-surface-0' />
+                <div className='h-4 w-32 rounded-md bg-surface-0' />
+              </div>
+              <div className='h-8 w-full rounded-md bg-surface-0 sm:w-80' />
+            </div>
           </div>
-          <div className='hidden h-4 w-20 rounded-md bg-surface-1 sm:block' />
-        </div>
-
-        <div className='grid gap-3 sm:grid-cols-2 xl:grid-cols-3'>
-          {LIBRARY_LOADING_PLACEHOLDERS.map(placeholderId => (
-            <div
-              key={placeholderId}
-              className='min-w-0 rounded-lg border border-subtle bg-surface-0 p-3'
-            >
-              <div className='flex gap-3'>
-                <div className='h-20 w-20 shrink-0 rounded-md bg-surface-1 sm:h-24 sm:w-24' />
-                <div className='min-w-0 flex-1 space-y-3'>
-                  <div className='space-y-2'>
-                    <div className='h-4 w-3/4 rounded-md bg-surface-1' />
-                    <div className='h-3 w-1/2 rounded-md bg-surface-1' />
-                  </div>
-                  <div className='grid grid-cols-2 gap-3'>
-                    <div className='h-8 rounded-md bg-surface-1' />
-                    <div className='h-8 rounded-md bg-surface-1' />
-                  </div>
+          <div className='grid gap-3 p-3 sm:grid-cols-2 xl:grid-cols-3'>
+            {LIBRARY_LOADING_PLACEHOLDERS.map(placeholderId => (
+              <div
+                key={placeholderId}
+                className='min-w-0 rounded-lg border border-subtle bg-surface-0 p-2'
+              >
+                <div className='aspect-square rounded-md bg-surface-1' />
+                <div className='space-y-2 px-1 py-3'>
+                  <div className='h-4 w-3/4 rounded-md bg-surface-1' />
+                  <div className='h-3 w-1/2 rounded-md bg-surface-1' />
                 </div>
               </div>
-              <div className='mt-3 flex gap-1.5'>
-                <div className='h-6 w-16 rounded-md bg-surface-1' />
-                <div className='h-6 w-20 rounded-md bg-surface-1' />
-                <div className='h-6 w-14 rounded-md bg-surface-1' />
-              </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       </div>
     </main>
+  );
+}
+
+function LibraryRail({
+  assets,
+  preset,
+  filters,
+  onPreset,
+  onFilters,
+  onClearFilters,
+  className,
+}: {
+  readonly assets: readonly LibraryReleaseAsset[];
+  readonly preset: LibraryPresetId;
+  readonly filters: LibraryFilters;
+  readonly onPreset: (preset: LibraryPresetId) => void;
+  readonly onFilters: (filters: LibraryFilters) => void;
+  readonly onClearFilters: () => void;
+  readonly className?: string;
+}) {
+  const releaseTypes = uniqueSorted(assets.map(asset => asset.releaseType));
+  const statuses = uniqueSorted(assets.map(asset => asset.status));
+  const providerKeys = uniqueSorted(
+    assets.flatMap(asset => asset.providers.map(provider => provider.key))
+  );
+  const providerLabels = new Map(
+    assets.flatMap(asset =>
+      asset.providers.map(provider => [provider.key, provider.label] as const)
+    )
+  );
+  const assetKinds = uniqueSorted(
+    assets.flatMap(asset => asset.assetKinds)
+  ) as LibraryAssetKind[];
+  const counts = {
+    releaseTypes: countBy(assets, asset => [asset.releaseType]),
+    statuses: countBy(assets, asset => [asset.status]),
+    providers: countBy(
+      assets,
+      asset => asset.providers.map(provider => provider.key) as string[]
+    ),
+    assetKinds: countBy(assets, asset => asset.assetKinds),
+  };
+  const activeFilterCount =
+    filters.statuses.size +
+    filters.releaseTypes.size +
+    filters.assetKinds.size +
+    filters.providers.size;
+  const openCommandPalette = () => {
+    globalThis.dispatchEvent(new Event(OPEN_COMMAND_PALETTE_EVENT));
+  };
+
+  return (
+    <nav
+      aria-label='Library navigation'
+      className={cn('flex min-h-0 flex-col bg-surface-0 p-2.5', className)}
+    >
+      <div className='px-1.5 pb-2'>
+        <button
+          type='button'
+          onClick={openCommandPalette}
+          className='flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[12.5px] text-secondary-token transition-colors duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+        >
+          <Search className='h-3.5 w-3.5 shrink-0 text-sidebar-item-icon' />
+          <span className='min-w-0 flex-1 truncate'>Search</span>
+          <span className='text-2xs text-tertiary-token'>Cmd K</span>
+        </button>
+      </div>
+
+      <div className='px-1.5 pb-2'>
+        <div className='flex items-center justify-between gap-2'>
+          <p className='text-xs font-semibold text-primary-token'>Views</p>
+          <span className='text-2xs tabular-nums text-tertiary-token'>
+            {assets.length}
+          </span>
+        </div>
+        <div className='mt-1.5 space-y-px'>
+          {PRESETS.map(view => {
+            const active = preset === view.id;
+            const count = assets.filter(view.predicate).length;
+            return (
+              <button
+                key={view.id}
+                type='button'
+                onClick={() => onPreset(view.id)}
+                className={cn(
+                  'flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[12.5px] transition-colors duration-subtle',
+                  active
+                    ? 'bg-surface-1 text-primary-token'
+                    : 'text-secondary-token hover:bg-surface-1 hover:text-primary-token'
+                )}
+              >
+                <span className='min-w-0 flex-1 truncate'>{view.label}</span>
+                <span className='text-2xs tabular-nums text-tertiary-token'>
+                  {count}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className='min-h-0 flex-1 overflow-y-auto px-1.5 pb-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
+        <div className='flex items-center justify-between gap-2 pb-1 pt-2'>
+          <p className='text-xs font-semibold text-primary-token'>Filters</p>
+          {hasActiveFilters(filters) ? (
+            <button
+              type='button'
+              onClick={onClearFilters}
+              className='rounded px-1.5 py-0.5 text-2xs text-tertiary-token transition-colors duration-subtle hover:bg-surface-1 hover:text-primary-token'
+            >
+              Clear {activeFilterCount}
+            </button>
+          ) : null}
+        </div>
+
+        <FilterSection label='Status'>
+          {statuses.map(status => (
+            <FilterRow
+              key={status}
+              active={filters.statuses.has(status)}
+              count={counts.statuses.get(status) ?? 0}
+              label={formatReleaseStatus(status)}
+              dotClassName={releaseStatusDotClasses(status)}
+              onClick={() =>
+                onFilters({
+                  ...filters,
+                  statuses: toggleSet(filters.statuses, status),
+                })
+              }
+            />
+          ))}
+        </FilterSection>
+
+        <FilterSection label='Type'>
+          {releaseTypes.map(type => (
+            <FilterRow
+              key={type}
+              active={filters.releaseTypes.has(type)}
+              count={counts.releaseTypes.get(type) ?? 0}
+              icon={Disc3}
+              label={formatReleaseType(type)}
+              onClick={() =>
+                onFilters({
+                  ...filters,
+                  releaseTypes: toggleSet(filters.releaseTypes, type),
+                })
+              }
+            />
+          ))}
+        </FilterSection>
+
+        <FilterSection label='Assets'>
+          {assetKinds.map(kind => (
+            <FilterRow
+              key={kind}
+              active={filters.assetKinds.has(kind)}
+              count={counts.assetKinds.get(kind) ?? 0}
+              icon={ASSET_KIND_ICONS[kind]}
+              label={ASSET_KIND_LABELS[kind]}
+              onClick={() =>
+                onFilters({
+                  ...filters,
+                  assetKinds: toggleSet(filters.assetKinds, kind),
+                })
+              }
+            />
+          ))}
+        </FilterSection>
+
+        {providerKeys.length > 0 ? (
+          <FilterSection label='Providers'>
+            {providerKeys.map(key => (
+              <FilterRow
+                key={key}
+                active={filters.providers.has(key)}
+                count={counts.providers.get(key) ?? 0}
+                icon={Music2}
+                label={providerLabels.get(key) ?? capitalizeFirst(key)}
+                onClick={() =>
+                  onFilters({
+                    ...filters,
+                    providers: toggleSet(filters.providers, key),
+                  })
+                }
+              />
+            ))}
+          </FilterSection>
+        ) : null}
+      </div>
+    </nav>
+  );
+}
+
+function FilterSection({
+  label,
+  children,
+}: {
+  readonly label: string;
+  readonly children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className='pt-2'>
+      <button
+        type='button'
+        onClick={() => setOpen(value => !value)}
+        className='flex h-6 w-full items-center justify-between rounded-md px-1 text-[11px] font-medium text-tertiary-token transition-colors duration-subtle hover:bg-surface-1 hover:text-primary-token'
+      >
+        <span>{label}</span>
+        <ChevronDown
+          className={cn(
+            'h-3 w-3 transition-transform duration-subtle',
+            !open && '-rotate-90'
+          )}
+          aria-hidden='true'
+        />
+      </button>
+      {open ? <div className='space-y-px pt-0.5'>{children}</div> : null}
+    </div>
+  );
+}
+
+function FilterRow({
+  label,
+  count,
+  active,
+  onClick,
+  icon: Icon,
+  dotClassName,
+}: {
+  readonly label: string;
+  readonly count: number;
+  readonly active: boolean;
+  readonly onClick: () => void;
+  readonly icon?: LucideIcon;
+  readonly dotClassName?: string;
+}) {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      className={cn(
+        'flex h-7 w-full items-center gap-2 rounded-md px-2 text-[12px] transition-colors duration-subtle',
+        active
+          ? 'bg-surface-1 text-primary-token'
+          : 'text-secondary-token hover:bg-surface-1 hover:text-primary-token'
+      )}
+    >
+      {Icon ? (
+        <Icon className='h-3 w-3 shrink-0 text-tertiary-token' />
+      ) : (
+        <span
+          className={cn('h-1.5 w-1.5 shrink-0 rounded-full', dotClassName)}
+          aria-hidden='true'
+        />
+      )}
+      <span className='min-w-0 flex-1 truncate text-left'>{label}</span>
+      <span className='text-2xs tabular-nums text-tertiary-token'>{count}</span>
+      {active ? (
+        <Check className='h-3 w-3 shrink-0 text-primary-token' />
+      ) : null}
+    </button>
+  );
+}
+
+function SortDropdown({
+  sort,
+  onSort,
+}: {
+  readonly sort: LibrarySortKey;
+  readonly onSort: (sort: LibrarySortKey) => void;
+}) {
+  return (
+    <ShellDropdown
+      align='end'
+      side='bottom'
+      sideOffset={6}
+      width={184}
+      trigger={
+        <button
+          type='button'
+          className='inline-flex h-8 items-center gap-1.5 rounded-md border border-(--linear-app-shell-border) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,transparent)] px-2.5 text-[12px] text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+        >
+          <ArrowUpDown className='h-3.5 w-3.5' strokeWidth={2.25} />
+          <span className='hidden sm:inline'>{SORT_LABELS[sort]}</span>
+          <ChevronDown className='h-3 w-3' strokeWidth={2.25} />
+        </button>
+      }
+    >
+      <ShellDropdown.Label>Sort By</ShellDropdown.Label>
+      <ShellDropdown.RadioGroup
+        value={sort}
+        onValueChange={value => onSort(value as LibrarySortKey)}
+      >
+        {(Object.keys(SORT_LABELS) as LibrarySortKey[]).map(key => (
+          <ShellDropdown.RadioItem
+            key={key}
+            value={key}
+            label={SORT_LABELS[key]}
+          />
+        ))}
+      </ShellDropdown.RadioGroup>
+    </ShellDropdown>
+  );
+}
+
+function ViewToggle({
+  view,
+  onView,
+}: {
+  readonly view: LibraryViewMode;
+  readonly onView: (view: LibraryViewMode) => void;
+}) {
+  return (
+    <div className='inline-flex h-8 rounded-md border border-(--linear-app-shell-border) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,transparent)] p-0.5'>
+      <Tooltip label='Grid View' side='bottom'>
+        <button
+          type='button'
+          onClick={() => onView('grid')}
+          aria-label='Grid view'
+          className={cn(
+            'grid h-7 w-8 place-items-center rounded-[5px] transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+            view === 'grid'
+              ? 'bg-surface-2 text-primary-token'
+              : 'text-tertiary-token hover:text-primary-token'
+          )}
+        >
+          <Grid3x3 className='h-3.5 w-3.5' />
+        </button>
+      </Tooltip>
+      <Tooltip label='List View' side='bottom'>
+        <button
+          type='button'
+          onClick={() => onView('list')}
+          aria-label='List view'
+          className={cn(
+            'grid h-7 w-8 place-items-center rounded-[5px] transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+            view === 'list'
+              ? 'bg-surface-2 text-primary-token'
+              : 'text-tertiary-token hover:text-primary-token'
+          )}
+        >
+          <LayoutList className='h-3.5 w-3.5' />
+        </button>
+      </Tooltip>
+    </div>
+  );
+}
+
+function LibraryToolbar({
+  sort,
+  onSort,
+  view,
+  onView,
+  visibleCount,
+  totalCount,
+  mobileFiltersOpen,
+  onToggleMobileFilters,
+}: {
+  readonly sort: LibrarySortKey;
+  readonly onSort: (sort: LibrarySortKey) => void;
+  readonly view: LibraryViewMode;
+  readonly onView: (view: LibraryViewMode) => void;
+  readonly visibleCount: number;
+  readonly totalCount: number;
+  readonly mobileFiltersOpen: boolean;
+  readonly onToggleMobileFilters: () => void;
+}) {
+  return (
+    <div className='border-b border-subtle bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,transparent)] p-3'>
+      <div className='flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between'>
+        <div className='min-w-0'>
+          <p className='text-sm text-secondary-token'>
+            Release assets from your connected catalog.
+          </p>
+          <p className='mt-0.5 text-xs text-tertiary-token'>
+            {visibleCount}
+            {visibleCount === totalCount ? '' : ` of ${totalCount}`} visible
+          </p>
+        </div>
+        <div className='flex min-w-0 flex-wrap items-center justify-end gap-2'>
+          <button
+            type='button'
+            onClick={onToggleMobileFilters}
+            aria-expanded={mobileFiltersOpen}
+            className='inline-flex h-8 items-center gap-1.5 rounded-md border border-(--linear-app-shell-border) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,transparent)] px-2.5 text-[12px] text-secondary-token transition-colors duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus) lg:hidden'
+          >
+            <Filter className='h-3.5 w-3.5' />
+            Filters
+          </button>
+          <SortDropdown sort={sort} onSort={onSort} />
+          <ViewToggle view={view} onView={onView} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AssetKindPill({ kind }: { readonly kind: LibraryAssetKind }) {
+  const Icon = ASSET_KIND_ICONS[kind];
+  return (
+    <span className='inline-flex h-6 items-center gap-1 rounded-md bg-surface-1 px-2 text-xs text-secondary-token'>
+      <Icon className='h-3 w-3' strokeWidth={2.25} />
+      {ASSET_KIND_LABELS[kind]}
+    </span>
+  );
+}
+
+function AssetCard({
+  asset,
+  selected,
+  onSelect,
+}: {
+  readonly asset: LibraryReleaseAsset;
+  readonly selected: boolean;
+  readonly onSelect: () => void;
+}) {
+  return (
+    <article
+      className={cn(
+        'group relative min-w-0 overflow-hidden rounded-lg border bg-surface-0 transition-[border-color,background-color] duration-subtle',
+        selected
+          ? 'border-(--linear-border-focus) bg-surface-1'
+          : 'border-subtle hover:border-default'
+      )}
+    >
+      <button
+        type='button'
+        onClick={onSelect}
+        className='flex h-full w-full flex-col text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)'
+      >
+        <div className='relative aspect-square overflow-hidden bg-black'>
+          <Artwork asset={asset} />
+          <span
+            className={cn(
+              'absolute left-2 top-2 rounded-md border px-1.5 py-0.5 text-[11px] leading-4 shadow-[0_6px_16px_rgba(0,0,0,0.18)] backdrop-blur',
+              releaseStatusClasses(asset.status)
+            )}
+          >
+            {formatReleaseStatus(asset.status)}
+          </span>
+        </div>
+        <div className='min-w-0 p-3'>
+          <div className='flex min-w-0 items-start justify-between gap-2'>
+            <div className='min-w-0'>
+              <h2 className='truncate text-sm font-semibold text-primary-token'>
+                {asset.title}
+              </h2>
+              <p className='mt-0.5 truncate text-xs text-secondary-token'>
+                {asset.artist}
+              </p>
+            </div>
+            <span className='shrink-0 text-2xs tabular-nums text-tertiary-token'>
+              {formatCompactCount(asset.providerCount)}
+            </span>
+          </div>
+          <div className='mt-2 flex min-w-0 items-center gap-1.5 text-xs text-tertiary-token'>
+            <Disc3 className='h-3 w-3 shrink-0' />
+            <span>{formatReleaseType(asset.releaseType)}</span>
+            <span className='opacity-50'>.</span>
+            <span>{asset.trackCount} Tracks</span>
+          </div>
+          <div className='mt-3 flex flex-wrap gap-1.5'>
+            {asset.assetKinds.slice(0, 3).map(kind => (
+              <AssetKindPill key={kind} kind={kind} />
+            ))}
+            {asset.assetKinds.length > 3 ? (
+              <span className='inline-flex h-6 items-center rounded-md bg-surface-1 px-2 text-xs text-tertiary-token'>
+                +{asset.assetKinds.length - 3}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </button>
+    </article>
+  );
+}
+
+function AssetGrid({
+  assets,
+  selectedId,
+  onSelect,
+}: {
+  readonly assets: readonly LibraryReleaseAsset[];
+  readonly selectedId: string | null;
+  readonly onSelect: (id: string) => void;
+}) {
+  return (
+    <div className='grid gap-3 p-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4'>
+      {assets.map(asset => (
+        <AssetCard
+          key={asset.id}
+          asset={asset}
+          selected={selectedId === asset.id}
+          onSelect={() => onSelect(asset.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function AssetList({
+  assets,
+  selectedId,
+  onSelect,
+}: {
+  readonly assets: readonly LibraryReleaseAsset[];
+  readonly selectedId: string | null;
+  readonly onSelect: (id: string) => void;
+}) {
+  return (
+    <div className='p-2'>
+      <div className='hidden grid-cols-[52px_minmax(0,1.4fr)_110px_92px_92px_96px] items-center gap-2 border-b border-subtle px-2 py-1.5 text-2xs font-medium text-tertiary-token md:grid'>
+        <span />
+        <span>Title</span>
+        <span>Status</span>
+        <span>Type</span>
+        <span>Providers</span>
+        <span className='text-right'>Release Date</span>
+      </div>
+      <div className='space-y-px'>
+        {assets.map(asset => {
+          const selected = selectedId === asset.id;
+          return (
+            <button
+              type='button'
+              key={asset.id}
+              onClick={() => onSelect(asset.id)}
+              className={cn(
+                'grid w-full grid-cols-[44px_minmax(0,1fr)_auto] items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus) md:grid-cols-[52px_minmax(0,1.4fr)_110px_92px_92px_96px]',
+                selected
+                  ? 'bg-surface-1 text-primary-token'
+                  : 'text-secondary-token hover:bg-surface-1 hover:text-primary-token'
+              )}
+            >
+              <span className='overflow-hidden rounded-md bg-black'>
+                <Artwork asset={asset} size='row' />
+              </span>
+              <span className='min-w-0'>
+                <span className='block truncate text-sm font-medium text-primary-token'>
+                  {asset.title}
+                </span>
+                <span className='mt-0.5 block truncate text-xs text-tertiary-token'>
+                  {asset.artist}
+                </span>
+              </span>
+              <span
+                className={cn(
+                  'hidden w-fit rounded-md border px-1.5 py-0.5 text-[11px] leading-4 md:inline-flex',
+                  releaseStatusClasses(asset.status)
+                )}
+              >
+                {formatReleaseStatus(asset.status)}
+              </span>
+              <span className='hidden truncate text-xs text-tertiary-token md:block'>
+                {formatReleaseType(asset.releaseType)}
+              </span>
+              <span className='hidden text-xs tabular-nums text-tertiary-token md:block'>
+                {asset.providerCount}
+              </span>
+              <span className='hidden text-right text-xs tabular-nums text-tertiary-token md:block'>
+                {formatLibraryReleaseDate(asset.releaseDate)}
+              </span>
+              <span className='text-xs tabular-nums text-tertiary-token md:hidden'>
+                {asset.providerCount}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function EmptyCatalog() {
+  return (
+    <main
+      aria-label='Library'
+      className='flex h-full min-h-[420px] items-center justify-center px-6'
+      data-testid='library-surface'
+    >
+      <div className='max-w-sm text-center'>
+        <div className='mx-auto mb-4 grid h-10 w-10 place-items-center rounded-md border border-subtle bg-surface-1 text-tertiary-token'>
+          <Music2 className='h-4 w-4' strokeWidth={2.25} />
+        </div>
+        <h2 className='text-base font-semibold text-primary-token'>
+          No Release Assets
+        </h2>
+        <p className='mt-2 text-sm leading-6 text-secondary-token'>
+          Releases and artwork will appear here after your catalog is connected.
+        </p>
+        <Link
+          href={APP_ROUTES.DASHBOARD_RELEASES}
+          className='mt-5 inline-flex h-8 items-center rounded-md border border-subtle bg-surface-0 px-3 text-sm font-medium text-primary-token transition-[background-color,border-color] duration-subtle hover:border-default hover:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token'
+        >
+          Open Releases
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function NoResults({ onReset }: { readonly onReset: () => void }) {
+  return (
+    <div className='grid min-h-[300px] place-items-center px-6 text-center'>
+      <div className='max-w-sm'>
+        <h2 className='text-base font-semibold text-primary-token'>
+          No Assets Match
+        </h2>
+        <p className='mt-2 text-sm leading-6 text-secondary-token'>
+          No release assets match the selected view or filters.
+        </p>
+        <button
+          type='button'
+          onClick={onReset}
+          className='mt-4 inline-flex h-8 items-center rounded-md border border-subtle bg-surface-0 px-3 text-sm font-medium text-primary-token transition-[background-color,border-color] duration-subtle hover:border-default hover:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token'
+        >
+          Reset View
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function MetadataRow({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: React.ReactNode;
+}) {
+  return (
+    <div className='grid grid-cols-[96px_minmax(0,1fr)] gap-3 border-t border-subtle py-2 text-xs'>
+      <dt className='text-tertiary-token'>{label}</dt>
+      <dd className='min-w-0 text-primary-token'>{value}</dd>
+    </div>
+  );
+}
+
+function AssetDrawer({
+  asset,
+  open,
+  onClose,
+}: {
+  readonly asset: LibraryReleaseAsset | null;
+  readonly open: boolean;
+  readonly onClose: () => void;
+}) {
+  const [stickyAsset, setStickyAsset] = useState<LibraryReleaseAsset | null>(
+    asset
+  );
+
+  useEffect(() => {
+    if (asset) setStickyAsset(asset);
+  }, [asset]);
+
+  const current = asset ?? stickyAsset;
+
+  return (
+    <aside
+      aria-hidden={!open}
+      className={cn(
+        'overflow-hidden border-l border-subtle bg-surface-0 transition-[opacity,transform] duration-cinematic ease-cinematic',
+        'fixed inset-x-3 bottom-3 top-16 z-40 rounded-lg border shadow-[0_18px_48px_rgba(0,0,0,0.28)] lg:static lg:z-auto lg:rounded-none lg:border-y-0 lg:border-r-0 lg:shadow-none',
+        open
+          ? 'translate-y-0 opacity-100'
+          : 'pointer-events-none translate-y-2 opacity-0 max-lg:hidden'
+      )}
+      data-testid='library-asset-drawer'
+    >
+      {current ? (
+        <div className='flex h-full min-h-0 flex-col'>
+          <div className='flex h-10 shrink-0 items-center justify-between border-b border-subtle px-3'>
+            <span className='text-xs font-semibold text-primary-token'>
+              Asset Details
+            </span>
+            <button
+              type='button'
+              onClick={onClose}
+              aria-label='Close asset details'
+              className='grid h-7 w-7 place-items-center rounded-md text-tertiary-token transition-colors duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+            >
+              <X className='h-3.5 w-3.5' />
+            </button>
+          </div>
+
+          <div className='min-h-0 flex-1 overflow-y-auto p-3'>
+            <div className='overflow-hidden rounded-lg border border-subtle bg-black'>
+              <div className='aspect-square'>
+                <Artwork asset={current} size='drawer' />
+              </div>
+            </div>
+
+            <div className='mt-3'>
+              <h2 className='text-[18px] font-semibold leading-6 text-primary-token'>
+                {current.title}
+              </h2>
+              <p className='mt-1 text-sm text-secondary-token'>
+                {current.artist}
+              </p>
+            </div>
+
+            <div className='mt-3 flex flex-wrap gap-1.5'>
+              <span
+                className={cn(
+                  'inline-flex h-6 items-center rounded-md border px-2 text-xs',
+                  releaseStatusClasses(current.status)
+                )}
+              >
+                {formatReleaseStatus(current.status)}
+              </span>
+              {current.assetKinds.map(kind => (
+                <AssetKindPill key={kind} kind={kind} />
+              ))}
+            </div>
+
+            <div className='mt-4 flex flex-wrap gap-1.5'>
+              <Link
+                href={current.smartLinkPath}
+                className='inline-flex h-8 items-center gap-1.5 rounded-md border border-subtle bg-surface-1 px-3 text-xs font-medium text-primary-token transition-[background-color,border-color] duration-subtle hover:border-default hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token'
+              >
+                Open Release
+                <ExternalLink className='h-3 w-3' />
+              </Link>
+              {current.previewUrl ? (
+                <a
+                  href={current.previewUrl}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='inline-flex h-8 items-center gap-1.5 rounded-md border border-subtle bg-surface-1 px-3 text-xs font-medium text-primary-token transition-[background-color,border-color] duration-subtle hover:border-default hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token'
+                >
+                  <PlayCircle className='h-3 w-3' />
+                  Preview
+                </a>
+              ) : null}
+            </div>
+
+            <dl className='mt-4'>
+              <MetadataRow
+                label='Release Date'
+                value={formatLibraryReleaseDate(current.releaseDate)}
+              />
+              <MetadataRow
+                label='Type'
+                value={formatReleaseType(current.releaseType)}
+              />
+              <MetadataRow label='Tracks' value={current.trackCount} />
+              <MetadataRow
+                label='Duration'
+                value={formatLibraryDuration(current.totalDurationMs)}
+              />
+              <MetadataRow
+                label='Popularity'
+                value={
+                  current.spotifyPopularity == null
+                    ? 'No Score'
+                    : `${current.spotifyPopularity}/100`
+                }
+              />
+              <MetadataRow
+                label='Genres'
+                value={
+                  current.genres.length > 0
+                    ? current.genres.join(', ')
+                    : 'No Genres'
+                }
+              />
+              <MetadataRow
+                label='Label'
+                value={current.label ?? current.distributor ?? 'No Label'}
+              />
+              <MetadataRow label='UPC' value={current.upc ?? 'No UPC'} />
+              <MetadataRow
+                label='Pitch Targets'
+                value={current.targetPlaylistCount}
+              />
+            </dl>
+
+            <div className='mt-4 border-t border-subtle pt-3'>
+              <h3 className='text-xs font-semibold text-primary-token'>
+                Providers
+              </h3>
+              {current.providers.length > 0 ? (
+                <div className='mt-2 space-y-1'>
+                  {current.providers.map(provider => (
+                    <a
+                      key={`${current.id}-${provider.key}`}
+                      href={provider.url}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='flex h-8 items-center gap-2 rounded-md px-2 text-xs text-secondary-token transition-colors duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+                    >
+                      <Music2 className='h-3.5 w-3.5 text-tertiary-token' />
+                      <span className='min-w-0 flex-1 truncate'>
+                        {provider.label}
+                      </span>
+                      <ExternalLink className='h-3 w-3 text-tertiary-token' />
+                    </a>
+                  ))}
+                </div>
+              ) : (
+                <p className='mt-2 text-xs leading-5 text-secondary-token'>
+                  No provider links are connected for this release yet.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </aside>
   );
 }
 
@@ -180,12 +1130,33 @@ export function LibrarySurface({
 }: {
   readonly assets: readonly LibraryReleaseAsset[];
 }) {
-  const [search, setSearch] = useState('');
-  const searchInputRef = useRef<HTMLInputElement>(null);
-  const visibleAssets = useMemo(
-    () => assets.filter(asset => assetMatchesSearch(asset, search)),
-    [assets, search]
-  );
+  const [preset, setPreset] = useState<LibraryPresetId>('all');
+  const [filters, setFilters] = useState<LibraryFilters>(() => emptyFilters());
+  const [sort, setSort] = useState<LibrarySortKey>('releaseDate');
+  const [view, setView] = useState<LibraryViewMode>('grid');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+
+  const visibleAssets = useMemo(() => {
+    const presetPredicate =
+      PRESETS.find(item => item.id === preset)?.predicate ?? (() => true);
+
+    return assets
+      .filter(presetPredicate)
+      .filter(asset => assetMatchesFilters(asset, filters))
+      .toSorted(compareAssets(sort));
+  }, [assets, filters, preset, sort]);
+
+  const selectedAsset =
+    visibleAssets.find(asset => asset.id === selectedId) ?? null;
+
+  useEffect(() => {
+    if (selectedId && !visibleAssets.some(asset => asset.id === selectedId)) {
+      setSelectedId(null);
+      setDrawerOpen(false);
+    }
+  }, [selectedId, visibleAssets]);
 
   useEffect(() => {
     function onKeyDown(event: KeyboardEvent) {
@@ -193,213 +1164,121 @@ export function LibrarySurface({
       if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
         return;
       }
-      if (event.key !== '/') return;
-      if (isFormElement(event.target)) return;
-
-      event.preventDefault();
-      searchInputRef.current?.focus();
+      if (event.key === 'Escape' && drawerOpen) {
+        event.preventDefault();
+        setDrawerOpen(false);
+      }
     }
 
     globalThis.addEventListener('keydown', onKeyDown);
     return () => globalThis.removeEventListener('keydown', onKeyDown);
-  }, []);
+  }, [drawerOpen]);
+
+  function resetView() {
+    setPreset('all');
+    setFilters(emptyFilters());
+  }
+
+  function openAsset(id: string) {
+    setSelectedId(id);
+    setDrawerOpen(true);
+  }
+
+  const sidebarNavigation = useMemo(
+    () => (
+      <LibraryRail
+        assets={assets}
+        preset={preset}
+        filters={filters}
+        onPreset={setPreset}
+        onFilters={setFilters}
+        onClearFilters={() => setFilters(emptyFilters())}
+      />
+    ),
+    [assets, filters, preset]
+  );
+
+  const sidebarOverride = useMemo(
+    () => ({
+      key: 'library',
+      backHref: APP_ROUTES.CHAT,
+      backLabel: 'Back to App',
+      content: sidebarNavigation,
+    }),
+    [sidebarNavigation]
+  );
+
+  useRegisterShellSidebarOverride(sidebarOverride);
 
   if (assets.length === 0) {
-    return (
-      <main
-        aria-label='Library'
-        className='flex h-full min-h-[420px] items-center justify-center px-6'
-        data-testid='library-surface'
-      >
-        <div className='max-w-sm text-center'>
-          <div className='mx-auto mb-4 grid h-10 w-10 place-items-center rounded-md border border-subtle bg-surface-1 text-tertiary-token'>
-            <Music2 className='h-4 w-4' strokeWidth={2.25} />
-          </div>
-          <h2 className='text-base font-semibold text-primary-token'>
-            No Release Assets
-          </h2>
-          <p className='mt-2 text-sm leading-6 text-secondary-token'>
-            Releases and artwork will appear here after your catalog is
-            connected.
-          </p>
-          <Link
-            href={APP_ROUTES.DASHBOARD_RELEASES}
-            className='mt-5 inline-flex h-8 items-center rounded-md border border-subtle bg-surface-0 px-3 text-sm font-medium text-primary-token transition-[background-color,border-color] hover:border-default hover:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token'
-          >
-            Open Releases
-          </Link>
-        </div>
-      </main>
-    );
+    return <EmptyCatalog />;
   }
 
   return (
     <main
       aria-label='Library'
-      className='h-full overflow-y-auto px-5 py-5 sm:px-6 lg:px-8'
+      className='h-full overflow-hidden px-4 py-4 sm:px-5 lg:px-6'
       data-testid='library-surface'
     >
-      <div className='mx-auto max-w-6xl space-y-5'>
-        <div className='flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between'>
-          <p className='max-w-2xl text-sm text-secondary-token'>
-            Read-only release assets from your connected catalog.
-          </p>
-          <div className='flex min-w-0 items-center gap-3 sm:min-w-[24rem]'>
-            <div className='min-w-0 flex-1'>
-              <LibrarySearchInput
-                value={search}
-                onChange={setSearch}
-                inputRef={searchInputRef}
-              />
+      <div className='mx-auto flex h-full max-w-[1440px] overflow-hidden rounded-lg border border-subtle bg-surface-1 shadow-card'>
+        <section className='flex min-w-0 flex-1 flex-col overflow-hidden'>
+          <LibraryToolbar
+            sort={sort}
+            onSort={setSort}
+            view={view}
+            onView={setView}
+            visibleCount={visibleAssets.length}
+            totalCount={assets.length}
+            mobileFiltersOpen={mobileFiltersOpen}
+            onToggleMobileFilters={() => setMobileFiltersOpen(value => !value)}
+          />
+
+          {mobileFiltersOpen ? (
+            <LibraryRail
+              assets={assets}
+              preset={preset}
+              filters={filters}
+              onPreset={setPreset}
+              onFilters={setFilters}
+              onClearFilters={() => setFilters(emptyFilters())}
+              className='max-h-[45svh] border-b border-subtle lg:hidden'
+            />
+          ) : null}
+
+          <div
+            className='grid min-h-0 flex-1 overflow-hidden lg:grid-cols-[minmax(0,1fr)_var(--library-drawer-width)]'
+            style={
+              {
+                '--library-drawer-width': drawerOpen ? '360px' : '0px',
+                transition:
+                  'grid-template-columns var(--duration-cinematic) var(--ease-cinematic)',
+              } as CSSProperties
+            }
+          >
+            <div className='min-w-0 overflow-y-auto'>
+              {visibleAssets.length === 0 ? (
+                <NoResults onReset={resetView} />
+              ) : view === 'grid' ? (
+                <AssetGrid
+                  assets={visibleAssets}
+                  selectedId={selectedId}
+                  onSelect={openAsset}
+                />
+              ) : (
+                <AssetList
+                  assets={visibleAssets}
+                  selectedId={selectedId}
+                  onSelect={openAsset}
+                />
+              )}
             </div>
-            <div className='hidden shrink-0 text-sm tabular-nums text-tertiary-token sm:block'>
-              {visibleAssets.length}
-              {visibleAssets.length === assets.length
-                ? ''
-                : ` of ${assets.length}`}{' '}
-              {assets.length === 1 ? 'Release' : 'Releases'}
-            </div>
+            <AssetDrawer
+              asset={selectedAsset}
+              open={drawerOpen}
+              onClose={() => setDrawerOpen(false)}
+            />
           </div>
-        </div>
-
-        {visibleAssets.length === 0 ? (
-          <div className='flex min-h-[300px] items-center justify-center rounded-lg border border-subtle bg-surface-0 px-6 text-center'>
-            <div>
-              <h2 className='text-base font-semibold text-primary-token'>
-                No assets match your search
-              </h2>
-              <p className='mt-2 text-sm text-secondary-token'>
-                Try a release title, artist, provider, status, or asset type.
-              </p>
-              <button
-                type='button'
-                onClick={() => setSearch('')}
-                className='mt-4 inline-flex h-8 items-center rounded-md border border-subtle bg-surface-0 px-3 text-sm font-medium text-primary-token transition-[background-color,border-color] hover:border-default hover:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token'
-              >
-                Clear Search
-              </button>
-            </div>
-          </div>
-        ) : (
-          <div className='grid gap-3 sm:grid-cols-2 xl:grid-cols-3'>
-            {visibleAssets.map(asset => (
-              <article
-                key={asset.id}
-                className='min-w-0 rounded-lg border border-subtle bg-surface-0 p-3'
-              >
-                <div className='flex gap-3'>
-                  <Artwork asset={asset} />
-                  <div className='min-w-0 flex-1'>
-                    <div className='flex items-start gap-2'>
-                      <div className='min-w-0 flex-1'>
-                        <h2 className='truncate text-sm font-semibold text-primary-token'>
-                          {asset.title}
-                        </h2>
-                        <p className='mt-0.5 truncate text-xs text-secondary-token'>
-                          {asset.artist}
-                        </p>
-                      </div>
-                      <span
-                        className={cn(
-                          'shrink-0 rounded-md border px-1.5 py-0.5 text-[11px] leading-4',
-                          asset.status === 'released'
-                            ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
-                            : 'border-subtle bg-surface-1 text-tertiary-token'
-                        )}
-                      >
-                        {formatReleaseStatus(asset.status)}
-                      </span>
-                    </div>
-
-                    <dl className='mt-3 grid grid-cols-2 gap-x-3 gap-y-2 text-xs'>
-                      <div>
-                        <dt className='text-tertiary-token'>Date</dt>
-                        <dd className='mt-0.5 truncate text-primary-token'>
-                          {formatLibraryReleaseDate(asset.releaseDate)}
-                        </dd>
-                      </div>
-                      <div>
-                        <dt className='text-tertiary-token'>Type</dt>
-                        <dd className='mt-0.5 truncate text-primary-token'>
-                          {formatReleaseType(asset.releaseType)}
-                        </dd>
-                      </div>
-                    </dl>
-                  </div>
-                </div>
-
-                <div className='mt-3 flex flex-wrap items-center gap-1.5 text-xs text-secondary-token'>
-                  <span className='inline-flex items-center gap-1 rounded-md bg-surface-1 px-2 py-1'>
-                    <Disc3 className='h-3 w-3' strokeWidth={2.25} />
-                    {asset.trackCount}{' '}
-                    {asset.trackCount === 1 ? 'Track' : 'Tracks'}
-                  </span>
-                  <span className='inline-flex items-center gap-1 rounded-md bg-surface-1 px-2 py-1'>
-                    <Music2 className='h-3 w-3' strokeWidth={2.25} />
-                    {asset.providerCount}{' '}
-                    {asset.providerCount === 1 ? 'Provider' : 'Providers'}
-                  </span>
-                  {asset.hasArtwork ? (
-                    <span className='inline-flex items-center gap-1 rounded-md bg-surface-1 px-2 py-1'>
-                      <ImageIcon className='h-3 w-3' strokeWidth={2.25} />
-                      Artwork
-                    </span>
-                  ) : null}
-                  {asset.previewUrl ? (
-                    <span className='inline-flex items-center gap-1 rounded-md bg-surface-1 px-2 py-1'>
-                      <FileAudio2 className='h-3 w-3' strokeWidth={2.25} />
-                      Preview
-                    </span>
-                  ) : null}
-                  {asset.hasLyrics ? (
-                    <span className='inline-flex items-center gap-1 rounded-md bg-surface-1 px-2 py-1'>
-                      <FileText className='h-3 w-3' strokeWidth={2.25} />
-                      Lyrics
-                    </span>
-                  ) : null}
-                </div>
-
-                <div className='mt-3 flex flex-wrap items-center gap-1.5'>
-                  <Link
-                    href={asset.smartLinkPath}
-                    className='inline-flex h-7 items-center gap-1 rounded-md border border-subtle bg-surface-0 px-2 text-xs font-medium text-primary-token transition-[background-color,border-color] hover:border-default hover:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token'
-                  >
-                    Open Release
-                    <ExternalLink className='h-3 w-3' strokeWidth={2.25} />
-                  </Link>
-                  {asset.previewUrl ? (
-                    <a
-                      href={asset.previewUrl}
-                      target='_blank'
-                      rel='noopener noreferrer'
-                      className='inline-flex h-7 items-center gap-1 rounded-md border border-subtle bg-surface-0 px-2 text-xs font-medium text-secondary-token transition-[background-color,border-color,color] hover:border-default hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token'
-                    >
-                      Open Preview
-                      <ExternalLink className='h-3 w-3' strokeWidth={2.25} />
-                    </a>
-                  ) : null}
-                  {asset.providers.slice(0, 3).map(provider => (
-                    <a
-                      key={`${asset.id}-${provider.key}`}
-                      href={provider.url}
-                      target='_blank'
-                      rel='noopener noreferrer'
-                      className='inline-flex h-7 items-center gap-1 rounded-md border border-subtle bg-surface-0 px-2 text-xs font-medium text-secondary-token transition-[background-color,border-color,color] hover:border-default hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token'
-                    >
-                      {provider.label}
-                      <ExternalLink className='h-3 w-3' strokeWidth={2.25} />
-                    </a>
-                  ))}
-                  {asset.providerCount > 3 ? (
-                    <span className='inline-flex h-7 items-center rounded-md bg-surface-1 px-2 text-xs text-tertiary-token'>
-                      {asset.providerCount - 3} More
-                    </span>
-                  ) : null}
-                </div>
-              </article>
-            ))}
-          </div>
-        )}
+        </section>
       </div>
     </main>
   );

--- a/apps/web/app/app/(shell)/library/library-data.ts
+++ b/apps/web/app/app/(shell)/library/library-data.ts
@@ -6,6 +6,13 @@ export interface LibraryProviderLink {
   readonly url: string;
 }
 
+export type LibraryAssetKind =
+  | 'artwork'
+  | 'preview'
+  | 'lyrics'
+  | 'providers'
+  | 'video';
+
 export interface LibraryReleaseAsset {
   readonly id: string;
   readonly title: string;
@@ -21,6 +28,16 @@ export interface LibraryReleaseAsset {
   readonly providers: readonly LibraryProviderLink[];
   readonly hasLyrics: boolean;
   readonly hasArtwork: boolean;
+  readonly hasVideoLinks: boolean;
+  readonly assetKinds: readonly LibraryAssetKind[];
+  readonly genres: readonly string[];
+  readonly spotifyPopularity: number | null;
+  readonly targetPlaylistCount: number;
+  readonly isExplicit: boolean;
+  readonly label: string | null;
+  readonly upc: string | null;
+  readonly distributor: string | null;
+  readonly totalDurationMs: number | null;
 }
 
 function normalizeHttpUrl(value: string | null | undefined): string | null {
@@ -47,6 +64,15 @@ export function buildLibraryReleaseAssets(
     });
     const artworkUrl = normalizeHttpUrl(release.artworkUrl);
     const previewUrl = normalizeHttpUrl(release.previewUrl);
+    const hasArtwork = Boolean(artworkUrl);
+    const hasLyrics = Boolean(release.lyrics?.trim());
+    const hasVideoLinks = Boolean(release.hasVideoLinks);
+    const assetKinds: LibraryAssetKind[] = [];
+    if (hasArtwork) assetKinds.push('artwork');
+    if (previewUrl) assetKinds.push('preview');
+    if (hasLyrics) assetKinds.push('lyrics');
+    if (providers.length > 0) assetKinds.push('providers');
+    if (hasVideoLinks) assetKinds.push('video');
 
     return {
       id: release.id,
@@ -61,8 +87,22 @@ export function buildLibraryReleaseAssets(
       trackCount: release.totalTracks,
       providerCount: providers.length,
       providers,
-      hasLyrics: Boolean(release.lyrics?.trim()),
-      hasArtwork: Boolean(artworkUrl),
+      hasLyrics,
+      hasArtwork,
+      hasVideoLinks,
+      assetKinds,
+      genres:
+        release.genres
+          ?.map(genre => genre.trim())
+          .filter(Boolean)
+          .slice(0, 4) ?? [],
+      spotifyPopularity: release.spotifyPopularity ?? null,
+      targetPlaylistCount: release.targetPlaylists?.length ?? 0,
+      isExplicit: release.isExplicit,
+      label: release.label?.trim() || null,
+      upc: release.upc?.trim() || null,
+      distributor: release.distributor?.trim() || null,
+      totalDurationMs: release.totalDurationMs ?? null,
     };
   });
 }
@@ -79,4 +119,19 @@ export function formatLibraryReleaseDate(value: string | null): string {
     year: 'numeric',
     timeZone: 'UTC',
   }).format(date);
+}
+
+export function formatLibraryDuration(value: number | null): string {
+  if (!value || value <= 0) return 'No Duration';
+
+  const totalSeconds = Math.round(value / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  }
+
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
 }

--- a/apps/web/components/organisms/AuthShell.tsx
+++ b/apps/web/components/organisms/AuthShell.tsx
@@ -18,7 +18,7 @@ import type { DashboardBreadcrumbItem } from '@/types/dashboard';
 import { AppShellFrame } from './AppShellFrame';
 import { PersistentAudioBar } from './PersistentAudioBar';
 export interface AuthShellProps {
-  readonly section: 'admin' | 'dashboard' | 'settings';
+  readonly section: 'admin' | 'dashboard' | 'library' | 'settings';
   readonly breadcrumbs: DashboardBreadcrumbItem[];
   readonly headerBadge?: ReactNode;
   readonly headerAction?: ReactNode;

--- a/apps/web/components/organisms/AuthShellWrapper.tsx
+++ b/apps/web/components/organisms/AuthShellWrapper.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { TooltipProvider } from '@jovie/ui';
-import { Search } from 'lucide-react';
 import type { ReactNode } from 'react';
 import {
   useCallback,
@@ -24,6 +23,7 @@ import {
   useKeyboardShortcuts,
 } from '@/contexts/KeyboardShortcutsContext';
 import { RightPanelProvider } from '@/contexts/RightPanelContext';
+import { ShellSidebarOverrideProvider } from '@/contexts/ShellSidebarOverrideContext';
 import {
   type TableMeta,
   TableMetaContext,
@@ -40,7 +40,6 @@ import { useAppFlag } from '@/lib/flags/client';
 import { isFormElement } from '@/lib/utils/keyboard';
 import { AuthShell } from './AuthShell';
 import { CommandPalette } from './CommandPalette';
-import { OPEN_COMMAND_PALETTE_EVENT } from './command-palette-events';
 import { KeyboardShortcutsSheet } from './keyboard-shortcuts-sheet';
 import {
   PendingShellContext,
@@ -67,26 +66,6 @@ function KeyboardShortcutsHandler() {
   return <KeyboardShortcutsSheet />;
 }
 
-function HeaderCommandSearchButton() {
-  const openCommandPalette = useCallback(() => {
-    globalThis.dispatchEvent(new Event(OPEN_COMMAND_PALETTE_EVENT));
-  }, []);
-
-  return (
-    <button
-      type='button'
-      data-app-search-trigger='true'
-      onClick={openCommandPalette}
-      className='inline-flex h-7 items-center gap-1.5 rounded-md border border-(--linear-app-shell-border) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,transparent)] px-2 text-[12px] text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
-      aria-label='Search Jovie'
-    >
-      <Search className='h-3.5 w-3.5' aria-hidden='true' />
-      <span className='hidden sm:inline'>Search</span>
-      <span className='hidden text-tertiary-token lg:inline'>/</span>
-    </button>
-  );
-}
-
 /**
  * AuthShellWrapperInner - Inner component with access to HeaderActionsContext
  */
@@ -103,7 +82,6 @@ function AuthShellWrapperInner({
 }>) {
   const config = useAuthRouteConfig();
   const headerActions = useHeaderActions();
-  const designV1Enabled = useAppFlag('DESIGN_V1');
   const shellChatV1Enabled = useAppFlag('SHELL_CHAT_V1');
   const isElectron = useIsElectronRuntime();
   const { headerSearchAdapter, isSearchOpen, openSearch, closeSearch } =
@@ -127,13 +105,15 @@ function AuthShellWrapperInner({
     config.section === 'dashboard' || config.isArtistProfileSettings;
   const shouldDefaultOpenPreviewPanel =
     config.section === 'dashboard' && previewPanelDefaultOpen;
+  const previewPanelScope = config.isArtistProfileSettings
+    ? 'artist-profile-settings'
+    : 'app-shell';
 
   // Determine header action: use custom actions from context if available,
   // otherwise fall back to default based on route type
   const defaultHeaderAction = useMemo(
     () => (
       <>
-        {designV1Enabled ? <HeaderCommandSearchButton /> : null}
         {config.showChatUsageIndicator && !config.isDemoRoute ? (
           <HeaderChatUsageIndicator />
         ) : null}
@@ -141,12 +121,7 @@ function AuthShellWrapperInner({
         {isElectron ? null : <UpdateAvailablePill />}
       </>
     ),
-    [
-      config.isDemoRoute,
-      config.showChatUsageIndicator,
-      designV1Enabled,
-      isElectron,
-    ]
+    [config.isDemoRoute, config.showChatUsageIndicator, isElectron]
   );
   // Wrap page-injected header elements in ErrorBoundary so a throwing badge/action
   // degrades gracefully (renders nothing + toast) instead of crashing the shell.
@@ -355,7 +330,7 @@ function AuthShellWrapperInner({
       <PendingShellContext.Provider value={pendingShellContextValue}>
         <RightPanelProvider>
           <PreviewPanelProvider
-            key={config.section}
+            key={previewPanelScope}
             defaultOpen={shouldDefaultOpenPreviewPanel}
             enabled={previewEnabled}
           >
@@ -404,15 +379,17 @@ export function AuthShellWrapper({
     <TooltipProvider delayDuration={1200}>
       <KeyboardShortcutsProvider>
         <HeaderActionsProvider>
-          <AuthShellWrapperInner
-            persistSidebarCollapsed={persistSidebarCollapsed}
-            sidebarDefaultOpen={sidebarDefaultOpen}
-            previewPanelDefaultOpen={previewPanelDefaultOpen}
-          >
-            {children}
-          </AuthShellWrapperInner>
-          <KeyboardShortcutsHandler />
-          <CommandPalette />
+          <ShellSidebarOverrideProvider>
+            <AuthShellWrapperInner
+              persistSidebarCollapsed={persistSidebarCollapsed}
+              sidebarDefaultOpen={sidebarDefaultOpen}
+              previewPanelDefaultOpen={previewPanelDefaultOpen}
+            >
+              {children}
+            </AuthShellWrapperInner>
+            <KeyboardShortcutsHandler />
+            <CommandPalette />
+          </ShellSidebarOverrideProvider>
         </HeaderActionsProvider>
       </KeyboardShortcutsProvider>
     </TooltipProvider>

--- a/apps/web/components/organisms/UnifiedSidebar.tsx
+++ b/apps/web/components/organisms/UnifiedSidebar.tsx
@@ -36,6 +36,7 @@ import { InstallBanner } from '@/components/shell/InstallBanner';
 import { Tooltip } from '@/components/shell/Tooltip';
 import { BASE_URL } from '@/constants/domains';
 import { APP_ROUTES, isDemoRoutePath } from '@/constants/routes';
+import { useShellSidebarOverride } from '@/contexts/ShellSidebarOverrideContext';
 import { DashboardNav } from '@/features/dashboard/dashboard-nav';
 import {
   adminSettingsNavItem,
@@ -61,7 +62,7 @@ import { ProfileSwitcher } from './ProfileSwitcher';
 import { SidebarBottomNowPlayingBridge } from './SidebarBottomNowPlayingBridge';
 
 export interface UnifiedSidebarProps {
-  readonly section: 'admin' | 'dashboard' | 'settings';
+  readonly section: 'admin' | 'dashboard' | 'library' | 'settings';
 }
 
 const VERSION_DISMISSAL_KEY = 'jovie-version-update-dismissed';
@@ -239,19 +240,23 @@ function SidebarDockButton() {
 
 /** Workspace button (logo + name) or back button for settings */
 function SidebarHeaderNav({
-  isInSettings,
+  isRouteSidebar,
   isAdmin,
   isDashboardOrAdmin,
   profileHref,
   hasMultipleProfiles,
   isDemoRoute,
+  routeBackHref = APP_ROUTES.DASHBOARD,
+  routeBackLabel = 'Back to App',
 }: Readonly<{
-  isInSettings: boolean;
+  isRouteSidebar: boolean;
   isAdmin: boolean;
   isDashboardOrAdmin: boolean;
   profileHref: string | undefined;
   hasMultipleProfiles: boolean;
   isDemoRoute: boolean;
+  routeBackHref?: string;
+  routeBackLabel?: string;
 }>) {
   const shellChatV1Enabled = useAppFlag('DESIGN_V1');
   const legacyNewThreadLink = (
@@ -267,12 +272,12 @@ function SidebarHeaderNav({
   return (
     <div className='flex w-full items-center'>
       {(() => {
-        if (isInSettings) {
+        if (isRouteSidebar) {
           return (
             <div className='flex w-full items-center gap-2'>
               <Link
-                href={APP_ROUTES.DASHBOARD}
-                aria-label='Back to App'
+                href={routeBackHref}
+                aria-label={routeBackLabel}
                 className={cn(
                   'inline-flex h-6 shrink-0 items-center gap-1 rounded-lg px-2 text-xs text-sidebar-item-foreground transition-[background,border-color,color] duration-normal ease-interactive hover:bg-sidebar-accent/55 hover:text-sidebar-item-foreground focus-visible:outline-none focus-visible:bg-sidebar-accent/55 focus-visible:text-sidebar-item-foreground [font-weight:var(--font-weight-nav)]',
                   'group-data-[collapsible=icon]:size-7 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0'
@@ -283,7 +288,7 @@ function SidebarHeaderNav({
                   aria-hidden='true'
                 />
                 <span className='truncate group-data-[collapsible=icon]:hidden'>
-                  Back to App
+                  {routeBackLabel}
                 </span>
               </Link>
             </div>
@@ -344,7 +349,7 @@ function SidebarHeaderNav({
         );
       })()}
 
-      {!isInSettings &&
+      {!isRouteSidebar &&
         isDashboardOrAdmin &&
         (shellChatV1Enabled ? (
           <div className='ml-auto flex items-center group-data-[collapsible=icon]:hidden'>
@@ -446,11 +451,14 @@ function ShellSidebarInstallBanner() {
 export function UnifiedSidebar({ section }: UnifiedSidebarProps) {
   const { isAdmin: isUserAdmin, creatorProfiles } = useDashboardData();
   const shellChatV1Enabled = useAppFlag('DESIGN_V1');
+  const sidebarOverride = useShellSidebarOverride();
   const pathname = usePathname();
   const isDemoRoute = isDemoRoutePath(pathname);
   const isInSettings = section === 'settings';
   const isAdmin = section === 'admin';
-  const isDashboardOrAdmin = section !== 'settings';
+  const isInLibrary = section === 'library';
+  const isRouteSidebar = isInSettings || isInLibrary;
+  const isDashboardOrAdmin = section === 'dashboard' || section === 'admin';
   const hasMultipleProfiles = creatorProfiles.length >= 2;
 
   const { profileHref } = useProfileData(isDashboardOrAdmin);
@@ -473,28 +481,36 @@ export function UnifiedSidebar({ section }: UnifiedSidebarProps) {
         )}
       >
         <SidebarHeaderNav
-          isInSettings={isInSettings}
+          isRouteSidebar={isRouteSidebar}
           isAdmin={isAdmin}
           isDashboardOrAdmin={isDashboardOrAdmin}
           profileHref={profileHref}
           hasMultipleProfiles={hasMultipleProfiles}
           isDemoRoute={isDemoRoute}
+          routeBackHref={sidebarOverride?.backHref}
+          routeBackLabel={sidebarOverride?.backLabel}
         />
       </SidebarHeader>
 
       <SidebarContent className='min-h-0 flex-1 px-2.5 pb-2.5 pt-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
         <SidebarGroup className='flex min-h-0 flex-1 flex-col pb-1'>
           <SidebarGroupContent className='flex-1'>
-            {isDashboardOrAdmin ? (
-              <DashboardNav />
-            ) : (
+            {isInSettings ? (
               <SettingsNavigation pathname={pathname} section={section} />
+            ) : isInLibrary ? (
+              (sidebarOverride?.content ?? (
+                <div className='px-2.5 py-2 text-xs text-sidebar-muted'>
+                  Loading Library
+                </div>
+              ))
+            ) : (
+              <DashboardNav />
             )}
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
 
-      {isInSettings ? null : (
+      {isRouteSidebar ? null : (
         <div className='mt-auto shrink-0'>
           <SidebarBottomNowPlayingBridge />
           {isDemoRoute ? null : <SidebarUpgradeBanner />}

--- a/apps/web/contexts/ShellSidebarOverrideContext.tsx
+++ b/apps/web/contexts/ShellSidebarOverrideContext.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import {
+  createContext,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+export interface ShellSidebarOverride {
+  readonly key: string;
+  readonly backHref?: string;
+  readonly backLabel?: string;
+  readonly content: ReactNode;
+}
+
+type ShellSidebarOverrideDispatch = Dispatch<
+  SetStateAction<ShellSidebarOverride | null>
+>;
+
+const ShellSidebarOverrideStateContext = createContext<
+  ShellSidebarOverride | null | undefined
+>(undefined);
+
+const ShellSidebarOverrideDispatchContext = createContext<
+  ShellSidebarOverrideDispatch | undefined
+>(undefined);
+
+export function ShellSidebarOverrideProvider({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  const [override, setOverride] = useState<ShellSidebarOverride | null>(null);
+
+  return (
+    <ShellSidebarOverrideDispatchContext.Provider value={setOverride}>
+      <ShellSidebarOverrideStateContext.Provider value={override}>
+        {children}
+      </ShellSidebarOverrideStateContext.Provider>
+    </ShellSidebarOverrideDispatchContext.Provider>
+  );
+}
+
+export function useShellSidebarOverride(): ShellSidebarOverride | null {
+  return useContext(ShellSidebarOverrideStateContext) ?? null;
+}
+
+export function useRegisterShellSidebarOverride(
+  override: ShellSidebarOverride | null
+): void {
+  const setOverride = useContext(ShellSidebarOverrideDispatchContext);
+  const overrideKey = override?.key ?? null;
+
+  const stableOverride = useMemo(() => override, [override]);
+
+  useEffect(() => {
+    if (!setOverride) return undefined;
+
+    setOverride(stableOverride);
+
+    return () => {
+      setOverride(current =>
+        current?.key && current.key === overrideKey ? null : current
+      );
+    };
+  }, [overrideKey, setOverride, stableOverride]);
+}

--- a/apps/web/hooks/useAuthRouteConfig.ts
+++ b/apps/web/hooks/useAuthRouteConfig.ts
@@ -14,7 +14,7 @@ import { getBreadcrumbLabel } from '@/lib/constants/breadcrumb-labels';
 import type { DashboardBreadcrumbItem } from '@/types/dashboard';
 
 export interface AuthRouteConfig {
-  section: 'admin' | 'dashboard' | 'settings';
+  section: 'admin' | 'dashboard' | 'library' | 'settings';
   breadcrumbs: DashboardBreadcrumbItem[];
   showMobileTabs: boolean;
   isTableRoute: boolean;
@@ -51,9 +51,17 @@ export function useAuthRouteConfig(): AuthRouteConfig {
   const isDemoRoute = isDemoRoutePath(pathname);
 
   // Detect section based on pathname
-  const section = useMemo<'admin' | 'dashboard' | 'settings'>(() => {
+  const section = useMemo<
+    'admin' | 'dashboard' | 'library' | 'settings'
+  >(() => {
     if (pathname.startsWith(APP_ROUTES.ADMIN)) return 'admin';
     if (pathname.startsWith(APP_ROUTES.SETTINGS)) return 'settings';
+    if (
+      pathname === APP_ROUTES.LIBRARY ||
+      pathname.startsWith(`${APP_ROUTES.LIBRARY}/`)
+    ) {
+      return 'library';
+    }
     return 'dashboard';
   }, [pathname]);
 

--- a/apps/web/tests/e2e/shell-route-persistence.spec.ts
+++ b/apps/web/tests/e2e/shell-route-persistence.spec.ts
@@ -363,15 +363,19 @@ test('app shell persists across core app routes without duplicate request bursts
   await assertPersistentShellFrame(page, 'library route');
   await assertNoDocumentReloadSince(page, baselineLoadCount, 'library route');
 
+  await clickFirstVisibleAppLink(page, [APP_ROUTES.CHAT], [APP_ROUTES.CHAT]);
+  await expectRouteContent(page, 'chat');
+  await assertPersistentShellFrame(page, 'library back route');
+  await assertNoDocumentReloadSince(
+    page,
+    baselineLoadCount,
+    'library back route'
+  );
+
   await clickFirstVisibleAppLink(page, [APP_ROUTES.TASKS], [APP_ROUTES.TASKS]);
   await expectRouteContent(page, 'tasks');
   await assertPersistentShellFrame(page, 'tasks route');
   await assertNoDocumentReloadSince(page, baselineLoadCount, 'tasks route');
-
-  await clickFirstVisibleAppLink(page, [APP_ROUTES.CHAT], [APP_ROUTES.CHAT]);
-  await expectRouteContent(page, 'chat');
-  await assertPersistentShellFrame(page, 'chat route');
-  await assertNoDocumentReloadSince(page, baselineLoadCount, 'chat route');
 
   const openedThreadLink = await clickOptionalFirstVisibleAppLink(
     page,

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { LibrarySurface } from '@/app/app/(shell)/library/LibrarySurface';
 import type { LibraryReleaseAsset } from '@/app/app/(shell)/library/library-data';
+import { OPEN_COMMAND_PALETTE_EVENT } from '@/components/organisms/command-palette-events';
 import { APP_ROUTES } from '@/constants/routes';
 
 vi.mock('next/image', () => ({
@@ -38,6 +39,16 @@ function buildAsset(
     ],
     hasLyrics: true,
     hasArtwork: true,
+    hasVideoLinks: false,
+    assetKinds: ['artwork', 'preview', 'lyrics', 'providers'],
+    genres: ['Progressive House'],
+    spotifyPopularity: 68,
+    targetPlaylistCount: 2,
+    isExplicit: false,
+    label: 'Jovie',
+    upc: '123456789012',
+    distributor: 'Jovie',
+    totalDurationMs: 212_000,
     ...overrides,
   };
 }
@@ -60,20 +71,23 @@ describe('LibrarySurface', () => {
     );
   });
 
-  it('renders release assets with read-only release and provider links', () => {
+  it('renders release assets with grid cards and a read-only detail drawer', () => {
     render(<LibrarySurface assets={[buildAsset()]} />);
 
     expect(screen.getByTestId('library-surface')).toBeDefined();
-    expect(
-      screen.getByRole('searchbox', { name: 'Search library assets' })
-    ).toBeDefined();
     expect(screen.getByRole('heading', { name: 'Take Me Over' })).toBeDefined();
     expect(screen.getByText('Tim White')).toBeDefined();
-    expect(screen.getByText('Apr 28, 2026')).toBeDefined();
-    expect(screen.getByText('Artwork')).toBeDefined();
-    expect(screen.getByText('Preview')).toBeDefined();
-    expect(screen.getByText('Lyrics')).toBeDefined();
+    expect(screen.getAllByText('Artwork').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Preview').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Lyrics').length).toBeGreaterThan(0);
 
+    fireEvent.click(screen.getByRole('button', { name: /Take Me Over/u }));
+
+    expect(screen.getByText('Apr 28, 2026')).toBeDefined();
+    expect(screen.getByTestId('library-asset-drawer')).toHaveAttribute(
+      'aria-hidden',
+      'false'
+    );
     expect(screen.getByRole('link', { name: /Open Release/u })).toHaveAttribute(
       'href',
       '/tim/take-me-over'
@@ -82,13 +96,22 @@ describe('LibrarySurface', () => {
       'href',
       'https://open.spotify.com/album/take-me-over'
     );
-    expect(screen.getByRole('link', { name: /Open Preview/u })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /^Preview$/u })).toHaveAttribute(
       'href',
       'https://cdn.example.com/preview.mp3'
     );
+    expect(screen.getByText('68/100')).toBeDefined();
+    expect(screen.getByText('Progressive House')).toBeDefined();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(screen.getByTestId('library-asset-drawer')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    );
   });
 
-  it('filters release assets with library search and focuses it from /', () => {
+  it('switches between grid and list modes without losing the release list', () => {
     render(
       <LibrarySurface
         assets={[
@@ -109,14 +132,77 @@ describe('LibrarySurface', () => {
       />
     );
 
-    const search = screen.getByRole('searchbox', {
-      name: 'Search library assets',
-    });
+    fireEvent.click(screen.getByRole('button', { name: 'List view' }));
 
-    fireEvent.keyDown(window, { key: '/' });
-    expect(search).toHaveFocus();
+    expect(
+      screen.getByRole('button', { name: /Never Say A Word/u })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Take Me Over/u })
+    ).toBeInTheDocument();
+  });
 
-    fireEvent.change(search, { target: { value: 'apple' } });
+  it('uses the shared command palette event from the Library navigation search', () => {
+    const onOpenCommandPalette = vi.fn();
+    globalThis.addEventListener(
+      OPEN_COMMAND_PALETTE_EVENT,
+      onOpenCommandPalette
+    );
+
+    render(
+      <LibrarySurface
+        assets={[
+          buildAsset(),
+          buildAsset({
+            id: 'release-2',
+            title: 'Never Say A Word',
+            artist: 'Other Artist',
+            providers: [
+              {
+                key: 'apple',
+                label: 'Apple Music',
+                url: 'https://music.apple.com/album/never-say-a-word',
+              },
+            ],
+          }),
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    fireEvent.click(screen.getByRole('button', { name: /Search/u }));
+
+    expect(onOpenCommandPalette).toHaveBeenCalledTimes(1);
+
+    globalThis.removeEventListener(
+      OPEN_COMMAND_PALETTE_EVENT,
+      onOpenCommandPalette
+    );
+  });
+
+  it('filters release assets from the Library navigation', () => {
+    render(
+      <LibrarySurface
+        assets={[
+          buildAsset(),
+          buildAsset({
+            id: 'release-2',
+            title: 'Never Say A Word',
+            artist: 'Other Artist',
+            artworkUrl: null,
+            previewUrl: null,
+            providerCount: 0,
+            providers: [],
+            hasArtwork: false,
+            hasLyrics: false,
+            assetKinds: [],
+          }),
+        ]}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    fireEvent.click(screen.getByRole('button', { name: /Needs Assets/u }));
 
     expect(
       screen.getByRole('heading', { name: 'Never Say A Word' })
@@ -125,11 +211,13 @@ describe('LibrarySurface', () => {
       screen.queryByRole('heading', { name: 'Take Me Over' })
     ).not.toBeInTheDocument();
 
-    fireEvent.keyDown(search, { key: 'Escape' });
+    fireEvent.click(screen.getByRole('button', { name: /All Releases/u }));
 
-    expect(search).toHaveValue('');
     expect(
       screen.getByRole('heading', { name: 'Take Me Over' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Never Say A Word' })
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/library/library-data.test.ts
+++ b/apps/web/tests/unit/library/library-data.test.ts
@@ -67,6 +67,16 @@ describe('library data', () => {
         ],
         hasLyrics: true,
         hasArtwork: true,
+        hasVideoLinks: false,
+        assetKinds: ['artwork', 'preview', 'lyrics', 'providers'],
+        genres: [],
+        spotifyPopularity: null,
+        targetPlaylistCount: 0,
+        isExplicit: false,
+        label: null,
+        upc: null,
+        distributor: null,
+        totalDurationMs: null,
       },
     ]);
   });
@@ -96,6 +106,7 @@ describe('library data', () => {
       providerCount: 0,
       providers: [],
       hasArtwork: false,
+      assetKinds: [],
     });
   });
 


### PR DESCRIPTION
## Summary
- Moves Library into the shared app shell sidebar pattern so `/app/library` owns the left rail like Settings.
- Removes the Library-local/header search surfaces and routes Library Search through the shared command palette.
- Expands the Library surface with real release-asset data mapping, grid/list modes, presets, filters, sort, detail drawer, responsive mobile filters, and empty/loading/error-friendly states.
- Tightens shell persistence coverage for the route-sidebar transition from Library back into the dashboard nav.

## Verification
- `pnpm biome check --write` on targeted changed files
- `pnpm --filter @jovie/web exec vitest run tests/unit/library/LibrarySurface.test.tsx tests/unit/library/library-data.test.ts --reporter=default` — 8 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- targeted `eslint --config eslint.config.js --max-warnings=0 --no-warn-ignored ...`
- `pnpm --filter @jovie/web run tailwind:check`
- `BASE_URL=http://127.0.0.1:3112 E2E_USE_TEST_AUTH_BYPASS=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 E2E_SKIP_WARMUP=1 E2E_SKIP_SEED=1 pnpm --filter @jovie/web exec playwright test tests/e2e/shell-route-persistence.spec.ts --project=chromium --reporter=line --no-deps` — 1 passed
- pre-push hook: `biome check .`, web `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`
- Browser QA at desktop/tablet/mobile: no console errors, no horizontal overflow, Library Search opens shared command palette

## Design QA
- Desktop, command palette, tablet, mobile, and compact-mobile screenshots captured under `~/.gstack/projects/JovieInc-Jovie/designs/library-slice-20260515/sidebar-search-update/screenshots/`.
- User approved the visual direction in Codex before push.

Linear: JOV-2224


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched a comprehensive library interface with preset-based filtering, sortable results, and customizable view modes (grid/list).
  * Added asset details drawer displaying release information, preview links, and provider availability.
  * Introduced filter rail with status, type, asset, and provider filters.

* **Tests**
  * Updated unit and e2e tests to validate new library UI interactions and filtering functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->