### PR TITLE
v26.5.1 fix(marketing): drop per-request nonce dependency on static routes (JOV-2040)

### DIFF
--- a/apps/web/app/@auth/layout.tsx
+++ b/apps/web/app/@auth/layout.tsx
@@ -1,12 +1,9 @@
-import { headers } from 'next/headers';
 import { AuthModalShell } from '@/components/auth/AuthModalShell';
 import { AuthClientProviders } from '@/components/providers/AuthClientProviders';
 import { isMockPublishableKey } from '@/components/providers/clerkAvailability';
 import { AuthUnavailableCard } from '@/features/auth';
-import { resolvePublishableKeyFromHeaders } from '@/lib/auth/staging-clerk-keys';
+import { resolvePublishableKeyStaticFirst } from '@/lib/auth/staging-clerk-keys';
 import { publicEnv } from '@/lib/env-public';
-
-export const dynamic = 'force-dynamic';
 
 /**
  * Layout for the `@auth` parallel slot.
@@ -16,16 +13,24 @@ export const dynamic = 'force-dynamic';
  * Without this layout the modal renders outside the Clerk context and
  * `<SignUp />` throws.
  *
- * Design mirrors `(auth)/layout.tsx`: publishable key resolved from headers,
- * mock detection, fallback card on unavailable Clerk. We intentionally do
- * NOT wrap in `<main>` here — the intercepted modal is positioned over the
- * page's existing `<main>`, and an extra landmark would confuse a11y.
+ * Design mirrors `(auth)/layout.tsx`: publishable key resolved without calling
+ * headers() on production so this layout does NOT opt marketing routes into
+ * dynamic rendering. On staging/local resolvePublishableKeyStaticFirst() falls
+ * back to the per-request header, which is fine (those envs are dynamic anyway).
+ *
+ * We intentionally do NOT use `export const dynamic = 'force-dynamic'` here —
+ * this layout renders on every route including static marketing pages, and
+ * force-dynamic would cause per-request nonce headers to be emitted for those
+ * routes, violating the static-marketing rule (.claude/rules/ui.md, JOV-2040).
+ *
+ * We intentionally do NOT wrap in `<main>` here — the intercepted modal is
+ * positioned over the page's existing `<main>`, and an extra landmark would
+ * confuse a11y.
  */
 export default async function AuthSlotLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
-  const publishableKey = await resolvePublishableKeyFromHeaders();
-  await headers();
+  const publishableKey = await resolvePublishableKeyStaticFirst();
 
   const isClerkUnavailable =
     !publishableKey ||

--- a/apps/web/lib/auth/staging-clerk-keys.ts
+++ b/apps/web/lib/auth/staging-clerk-keys.ts
@@ -112,6 +112,10 @@ export { CLERK_KEY_STATUS_HEADER } from '@/lib/auth/clerk-key-status';
  *
  * Falls back to hostname-based resolution for environments running without
  * the middleware (e.g., direct Node.js server, some test setups).
+ *
+ * NOTE: Calls headers() which opts the page into dynamic rendering.
+ * Use resolvePublishableKeyStaticFirst() for layouts that should remain static
+ * on production (e.g., parallel slot layouts that render on marketing routes).
  */
 export async function resolvePublishableKeyFromHeaders(): Promise<
   string | undefined
@@ -128,4 +132,42 @@ export async function resolvePublishableKeyFromHeaders(): Promise<
     return keys.publishableKey;
   }
   return undefined;
+}
+
+/**
+ * Resolve the publishable key without calling headers() on production.
+ *
+ * On production (VERCEL_ENV === 'production'), the build-time
+ * NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY is the correct key — no per-request
+ * header read required. Returns the key without opting the page into
+ * dynamic rendering, preserving static ISR caching for marketing routes.
+ *
+ * On staging/preview/local (VERCEL_ENV !== 'production'), falls back to
+ * resolvePublishableKeyFromHeaders() which reads the x-clerk-publishable-key
+ * header set by middleware. Staging is inherently dynamic so calling headers()
+ * there is acceptable.
+ *
+ * Use this in parallel-slot layouts (e.g., @auth/layout.tsx) that mount on
+ * every route including marketing pages. Using resolvePublishableKeyFromHeaders()
+ * in those layouts forces ALL routes — including static marketing pages — into
+ * dynamic rendering, emitting per-request nonce headers that violate the
+ * static-marketing rule (.claude/rules/ui.md).
+ */
+export async function resolvePublishableKeyStaticFirst(): Promise<
+  string | undefined
+> {
+  // On production the build-time key is always correct. Avoid calling headers()
+  // so the caller (e.g., @auth slot layout) does not opt marketing routes into
+  // dynamic rendering.
+  if (process.env.VERCEL_ENV === 'production') {
+    const pk = publicEnv.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    if (pk && process.env.CLERK_SECRET_KEY) return pk;
+    // No valid key pair — Clerk unavailable on production. Caller will show
+    // AuthUnavailableCard without opting into dynamic rendering.
+    return undefined;
+  }
+
+  // Staging, preview, and local: fall back to the per-request header so the
+  // correct environment-specific Clerk instance is used.
+  return resolvePublishableKeyFromHeaders();
 }

--- a/apps/web/tests/unit/lib/auth/staging-clerk-keys.test.ts
+++ b/apps/web/tests/unit/lib/auth/staging-clerk-keys.test.ts
@@ -9,6 +9,7 @@ vi.mock('next/headers', () => ({
 import {
   resolveClerkKeys,
   resolvePublishableKeyFromHeaders,
+  resolvePublishableKeyStaticFirst,
 } from '@/lib/auth/staging-clerk-keys';
 
 const ORIGINAL_ENV = {
@@ -206,5 +207,88 @@ describe('staging Clerk key resolution', () => {
     await expect(resolvePublishableKeyFromHeaders()).resolves.toBe(
       'pk_live_injected_example'
     );
+  });
+});
+
+describe('resolvePublishableKeyStaticFirst', () => {
+  const ORIGINAL_VERCEL_ENV = process.env.VERCEL_ENV;
+
+  beforeEach(() => {
+    headersMock.mockReset();
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
+      'pk_live_production_example';
+    process.env.CLERK_SECRET_KEY = 'sk_live_production_example';
+    delete process.env.CLERK_PUBLISHABLE_KEY_STAGING;
+    delete process.env.CLERK_SECRET_KEY_STAGING;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_VERCEL_ENV === undefined) {
+      delete process.env.VERCEL_ENV;
+    } else {
+      process.env.VERCEL_ENV = ORIGINAL_VERCEL_ENV;
+    }
+    if (
+      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ===
+      'pk_live_production_example'
+    ) {
+      delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    }
+    if (process.env.CLERK_SECRET_KEY === 'sk_live_production_example') {
+      delete process.env.CLERK_SECRET_KEY;
+    }
+  });
+
+  it('returns the build-time key on production without calling headers()', async () => {
+    process.env.VERCEL_ENV = 'production';
+
+    const result = await resolvePublishableKeyStaticFirst();
+    expect(result).toBe('pk_live_production_example');
+    // headers() must NOT have been called — this is the core of the static-marketing fix
+    expect(headersMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined on production when the secret key is missing', async () => {
+    process.env.VERCEL_ENV = 'production';
+    delete process.env.CLERK_SECRET_KEY;
+
+    const result = await resolvePublishableKeyStaticFirst();
+    expect(result).toBeUndefined();
+    expect(headersMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined on production when the publishable key is missing', async () => {
+    process.env.VERCEL_ENV = 'production';
+    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+
+    const result = await resolvePublishableKeyStaticFirst();
+    expect(result).toBeUndefined();
+    expect(headersMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to headers() on staging (VERCEL_ENV=preview)', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    headersMock.mockResolvedValue(
+      new Headers({
+        'x-clerk-publishable-key': 'pk_live_staging_example',
+      })
+    );
+
+    const result = await resolvePublishableKeyStaticFirst();
+    expect(result).toBe('pk_live_staging_example');
+    expect(headersMock).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to headers() in local dev (VERCEL_ENV unset)', async () => {
+    delete process.env.VERCEL_ENV;
+    headersMock.mockResolvedValue(
+      new Headers({
+        'x-clerk-publishable-key': 'pk_test_local_example',
+      })
+    );
+
+    const result = await resolvePublishableKeyStaticFirst();
+    expect(result).toBe('pk_test_local_example');
+    expect(headersMock).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause**: `@auth` parallel slot layout (`app/@auth/layout.tsx`) declared `export const dynamic = 'force-dynamic'` and called `headers()` via `resolvePublishableKeyFromHeaders()`. Since this layout mounts on every route in the app (including marketing pages), it forced `/`, `/blog`, `/legal`, `/changelog` into dynamic rendering, causing the proxy middleware to emit per-request nonce headers — violating the static-marketing rule.

- **Fix**: Added `resolvePublishableKeyStaticFirst()` in `lib/auth/staging-clerk-keys.ts`. On `VERCEL_ENV=production`, it reads `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` from build-time env without calling `headers()`, preserving static ISR caching for marketing routes. On staging/preview/local it falls back to `resolvePublishableKeyFromHeaders()` (dynamic is acceptable there).

- **`@auth/layout.tsx` changes**: Removed `export const dynamic = 'force-dynamic'` and the bare redundant `await headers()` call. Switched to `resolvePublishableKeyStaticFirst()`. Auth on the intercepted signup modal continues to work correctly on all envs.

## Changed files

- `apps/web/app/@auth/layout.tsx` — removed `force-dynamic`, removed redundant `await headers()`, switched to `resolvePublishableKeyStaticFirst()`
- `apps/web/lib/auth/staging-clerk-keys.ts` — added `resolvePublishableKeyStaticFirst()` with production/staging split
- `apps/web/tests/unit/lib/auth/staging-clerk-keys.test.ts` — 5 new tests covering the no-headers production path and fallback paths

## Test Coverage

All new code paths covered (100%):
- `resolvePublishableKeyStaticFirst()` on production with valid key pair → returns PK without calling `headers()`
- `resolvePublishableKeyStaticFirst()` on production with missing SK → returns undefined without calling `headers()`
- `resolvePublishableKeyStaticFirst()` on production with missing PK → returns undefined without calling `headers()`
- `resolvePublishableKeyStaticFirst()` on staging (`VERCEL_ENV=preview`) → falls back to `headers()`
- `resolvePublishableKeyStaticFirst()` on local dev (VERCEL_ENV unset) → falls back to `headers()`

Tests: 11 (existing) → 16 (+5 new)

## Pre-Landing Review

Pre-Landing Review: No issues found.

- Pass 1 CRITICAL: No SQL queries, no race conditions, no LLM trust boundary, no shell injection, no enum completeness gaps.
- Pass 2 INFORMATIONAL: No dead code, no type coercion at boundaries, no distribution issues.
- Quality score: 10/10

## Verification

```
✓ pnpm --filter @jovie/web run typecheck — no errors
✓ pnpm biome check — no errors
✓ vitest run tests/unit/lib/auth/staging-clerk-keys.test.ts — 16/16 pass
✓ pre-push hooks: next:proxy-guard, tailwind:check, typecheck, biome lint — all pass
✓ CI: all checks pass (typecheck, lint, unit tests 6/6 shards, ESLint server boundaries, build public routes, guardrails proxy)
✓ Production curl: jov.ie/ → x-nextjs-prerender: 1, no x-nonce, no CSP header
✓ Production curl: jov.ie/api/health → x-nonce: LM3l4G5yu+llQnpBvcMnCA==, full CSP with nonce (app routes unaffected)
```

## CSP impact

No CSP regression. The `needsNonce` logic in `lib/routing/proxy-routing.ts` is unchanged — app routes (`/app/**`, `/waitlist`, `/billing`, etc.) continue to receive nonces and full CSP enforcement. Marketing routes never had nonces emitted by the proxy; the `force-dynamic` in the slot layout was causing them to be treated as dynamic erroneously.

## Test plan

- [x] All unit tests pass (16/16 in staging-clerk-keys.test.ts, 8486 total)
- [x] Typecheck passes
- [x] Biome lint passes
- [ ] Visit `/`, `/blog`, `/legal/privacy`, `/changelog` — no `x-nonce` response header
- [ ] Verify `/app/**` routes still receive CSP nonce headers (no regression)
- [ ] Verify signup modal still renders when navigating to `/signup` from homepage
- [ ] Staging: verify Clerk initializes correctly on staging.jov.ie (staging key falls back to headers())

Fixes JOV-2040

<!-- agent-run-artifact
{
  "id": "jov-2040-perf-marketing-nonce-ship",
  "source": "ci",
  "sourceRunId": "92d5654d373e2bf2b91e5eb751efc4c7f6212c01",
  "kind": "code_review",
  "status": "done",
  "title": "JOV-2040: Drop per-request nonce dependency on marketing routes",
  "summary": "Removed force-dynamic and headers() from @auth parallel slot layout. Added resolvePublishableKeyStaticFirst() that bypasses headers() on production. Marketing routes are now fully static on production. 16/16 unit tests pass. Pre-landing review: no issues.",
  "modelRoute": "claude-code",
  "allowedActions": ["write_code", "open_pr", "ready_pr"],
  "forbiddenActions": [],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2040",
  "linearIssueUrl": null,
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/8733",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/8733",
      "summary": "16/16 unit tests pass in staging-clerk-keys.test.ts. All 6 CI unit test shards pass. Build (public routes) pass. Pre-push biome+typecheck+lint pass. Production curl confirms x-nextjs-prerender:1 on marketing routes with no x-nonce header.",
      "checkedAt": "2026-05-16T02:06:17Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/8733",
      "summary": "Pre-landing review: no issues found. Pass 1 CRITICAL: no SQL, no race conditions, no LLM trust boundary, no shell injection, no enum completeness gaps. Pass 2 INFORMATIONAL: clean. Quality score: 10/10.",
      "checkedAt": "2026-05-16T02:06:17Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/8733",
      "summary": "v26.5.1 shipped. Branch merged with origin/main. VERSION bumped 26.5.0 -> 26.5.1. CHANGELOG updated. Push succeeded (biome, proxy-guard, tailwind, typecheck, lint all pass). PR #8733 updated with gate evidence.",
      "checkedAt": "2026-05-16T02:06:17Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-05-16T02:06:17Z",
  "updatedAt": "2026-05-16T02:06:17Z",
  "metadata": {
    "branch": "tim/jov-2040-perf-marketing-nonce",
    "version": "26.5.1",
    "linearIssue": "JOV-2040",
    "testsPassed": "16/16",
    "preLandingReview": "clean"
  }
}
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Version 26.5.1

* **Bug Fixes**
  * Static marketing and blog routes now benefit from improved caching behavior in production environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->