### PR TITLE
fix(shell): handle deployment-skew server action errors gracefully (JOV-2192)

### DIFF
--- a/apps/web/components/organisms/ErrorBoundary.tsx
+++ b/apps/web/components/organisms/ErrorBoundary.tsx
@@ -14,6 +14,24 @@ interface ErrorBoundaryProps {
   readonly message?: string;
 }
 
+/**
+ * Returns true when the error is a deployment-skew server action mismatch.
+ *
+ * Next.js throws `UnrecognizedActionError` (client) or a plain `Error` with
+ * a specific message (server) when a stale client bundle calls a server action
+ * that no longer exists in the current deployment. Retrying with the same
+ * stale bundle always fails — the correct recovery is a hard page reload.
+ */
+function isDeploymentSkewError(error: Error): boolean {
+  const type = error.constructor?.name?.toLowerCase() ?? '';
+  const msg = error.message?.toLowerCase() ?? '';
+  return (
+    type === 'unrecognizedactionerror' ||
+    msg.includes('was not found on the server') ||
+    msg.includes('failed to find server action')
+  );
+}
+
 export default function ErrorBoundary({
   error,
   reset,
@@ -21,13 +39,21 @@ export default function ErrorBoundary({
   message = "We couldn't load this page. Give it another try, or head home.",
 }: ErrorBoundaryProps) {
   const router = useRouter();
+  const isSkewError = isDeploymentSkewError(error);
 
   useEffect(() => {
     console.error(`[${context} Error]`, error);
-    captureErrorInSentry(error, context.toLowerCase(), {
-      digest: error.digest,
-    });
-  }, [error, context]);
+    // Deployment-skew errors are filtered in Sentry's beforeSend — skip capture.
+    if (!isSkewError) {
+      captureErrorInSentry(error, context.toLowerCase(), {
+        digest: error.digest,
+      });
+    }
+  }, [error, context, isSkewError]);
+
+  const displayMessage = isSkewError
+    ? 'The app was just updated. Reload to continue.'
+    : message;
 
   return (
     <div
@@ -44,21 +70,33 @@ export default function ErrorBoundary({
 
         <div className='space-y-1.5'>
           <h3 className='text-sm font-medium text-secondary-token'>
-            Something went wrong
+            {isSkewError ? 'App Updated' : 'Something went wrong'}
           </h3>
-          <p className='text-app text-tertiary-token'>{message}</p>
+          <p className='text-app text-tertiary-token'>{displayMessage}</p>
         </div>
 
         <div className='flex justify-center gap-3'>
-          <Button variant='primary' size='sm' onClick={reset}>
-            Try again
-          </Button>
+          {isSkewError ? (
+            <Button
+              variant='primary'
+              size='sm'
+              onClick={() => globalThis.location.reload()}
+            >
+              Reload
+            </Button>
+          ) : (
+            <Button variant='primary' size='sm' onClick={reset}>
+              Try again
+            </Button>
+          )}
           <Button variant='outline' size='sm' onClick={() => router.push('/')}>
             Go home
           </Button>
         </div>
 
-        <ErrorDetails error={error} extraContext={{ Context: context }} />
+        {!isSkewError && (
+          <ErrorDetails error={error} extraContext={{ Context: context }} />
+        )}
       </div>
     </div>
   );

--- a/apps/web/lib/sentry/config.ts
+++ b/apps/web/lib/sentry/config.ts
@@ -190,14 +190,28 @@ const SENSITIVE_QUERY_PARAMS =
 const DEPLOYMENT_TRANSITION_PATTERN = /^.+ is not defined$/;
 
 /**
- * Pattern matching stale server action IDs after deployment.
+ * Message patterns matching stale server action errors after deployment.
  *
- * When a deployment changes server action manifests, clients with stale
- * JavaScript can reference an old action hash and trigger
- * `UnrecognizedActionError` until refresh.
+ * Next.js uses two error shapes for this condition:
+ *
+ * 1. Client-side `UnrecognizedActionError` (type field) — thrown by the
+ *    App Router when the server returns NEXT_ACTION_NOT_FOUND_HEADER.
+ *    Message: `Server Action "<hash>" was not found on the server.`
+ *
+ * 2. Server-side `Error` — thrown by action-handler.js when the action
+ *    manifest lookup fails (E974/E975 error codes).
+ *    Message: `Failed to find Server Action. This request might be from
+ *              an older or newer deployment.`
+ *
+ * Both are deployment-skew artifacts handled by the UI (reload prompt),
+ * not application bugs. Filter both from Sentry.
  */
-const STALE_SERVER_ACTION_PATTERN =
-  /unrecognizedactionerror: server action ".+" was not found on the server\.?$/;
+const STALE_SERVER_ACTION_MESSAGE_PATTERNS = [
+  // Client: UnrecognizedActionError message body (type checked separately)
+  'was not found on the server',
+  // Server: E974/E975 error message (plain Error type)
+  'failed to find server action',
+] as const;
 
 /**
  * React/Next.js internal error patterns that are framework noise.
@@ -294,7 +308,15 @@ function isDeploymentTransitionError(event: SentryEvent): boolean {
     return true;
   }
 
-  if (STALE_SERVER_ACTION_PATTERN.test(message)) {
+  // Filter stale server action errors (deployment skew).
+  // Check the error type directly (UnrecognizedActionError) and/or message
+  // patterns that cover both the client-side and server-side error shapes.
+  if (
+    type === 'unrecognizedactionerror' ||
+    STALE_SERVER_ACTION_MESSAGE_PATTERNS.some(pattern =>
+      message.includes(pattern)
+    )
+  ) {
     return true;
   }
 

--- a/apps/web/tests/unit/lib/sentry/sentry-config.test.ts
+++ b/apps/web/tests/unit/lib/sentry/sentry-config.test.ts
@@ -176,19 +176,55 @@ describe('scrubPii', () => {
     expect(scrubPii(event as any)).toBeNull();
   });
 
-  it('should filter stale server action lookup errors', () => {
+  it('should filter client-side UnrecognizedActionError (type field match)', () => {
+    // Next.js client throws UnrecognizedActionError when it receives
+    // NEXT_ACTION_NOT_FOUND_HEADER from the server. The error type is
+    // UnrecognizedActionError; the message is the plain server action not found text.
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'UnrecognizedActionError',
+            value:
+              'Server Action "005a331209a8ea5b575bfbb0957bc1531f71788fae" was not found on the server.',
+          },
+        ],
+      },
+    };
+    expect(scrubPii(event as any)).toBeNull();
+  });
+
+  it('should filter server-side "Failed to find Server Action" errors (E974/E975)', () => {
+    // Next.js server-side action-handler.js throws this plain Error when
+    // the action manifest lookup fails (deployment skew). The error type is
+    // plain Error; the message contains the "Failed to find Server Action" text.
     const event = {
       exception: {
         values: [
           {
             type: 'Error',
             value:
-              'UnrecognizedActionError: Server Action "005a331209a8ea5b575bfbb0957bc1531f71788fae" was not found on the server.',
+              'Failed to find Server Action. This request might be from an older or newer deployment.',
           },
         ],
       },
     };
+    expect(scrubPii(event as any)).toBeNull();
+  });
 
+  it('should filter UnrecognizedActionError with action hash in message', () => {
+    // Additional variant: message contains "was not found on the server"
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'UnrecognizedActionError',
+            value:
+              'Server Action "abc123def456" was not found on the server. Read more: https://nextjs.org/docs/messages/failed-to-find-server-action',
+          },
+        ],
+      },
+    };
     expect(scrubPii(event as any)).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

Fixes JOV-2192: Next.js 15 deployment-skew server action errors were leaking into Sentry as noise and presenting users with a broken \"Try again\" loop.

<!-- linear-issue-id:JOV-2192 -->

**Root cause (two bugs):**

1. **Sentry filter never matched.** `STALE_SERVER_ACTION_PATTERN` in `sentry/config.ts` was a regex that embedded `unrecognizedactionerror:` as a prefix and tested against the exception `message` field — but that prefix only lives in the `type` field. The regex never fired, so every stale-action Sentry event slipped through as noise.

2. **ErrorBoundary offered the wrong recovery.** When a server action from a stale bundle is called, Next.js throws `UnrecognizedActionError` (client) or a plain `Error` with code E974/E975 (server). The existing `ErrorBoundary` showed \"Try again\" — which re-invokes the same missing action and loops forever. The correct recovery is a hard page reload.

**Fixes:**

- `sentry/config.ts` — replaced the broken regex with a direct `type === 'unrecognizedactionerror'` check plus message substring patterns covering both Next.js error shapes (`was not found on the server`, `failed to find server action`).
- `ErrorBoundary.tsx` — added `isDeploymentSkewError()` helper; skew errors now show \"App Updated / Reload\" with `location.reload()` instead of the retry loop. Sentry capture is also skipped for skew errors (already filtered in `beforeSend`).
- `sentry-config.test.ts` — replaced the old test (which used the wrong error shape) with three accurate regression tests covering client-side `UnrecognizedActionError`, server-side E974/E975 plain Error, and hash-in-message variants.

## Verification

```
✓ tests/unit/lib/sentry/sentry-config.test.ts — 42/42 tests pass
✓ pnpm biome check — clean (3 files)
✓ pnpm typecheck — clean
✓ Pre-commit hooks — all passed
```

## Files Changed

- `apps/web/lib/sentry/config.ts` — fix `isDeploymentTransitionError()` filter
- `apps/web/components/organisms/ErrorBoundary.tsx` — skew-aware UX + skip redundant Sentry capture
- `apps/web/tests/unit/lib/sentry/sentry-config.test.ts` — accurate regression tests

## Test Plan

- [x] Unit tests cover both Next.js error shapes (client `UnrecognizedActionError` + server E974/E975 plain Error)
- [x] Sentry `beforeSend` now correctly drops stale server action events
- [x] ErrorBoundary shows \"Reload\" CTA instead of looping \"Try again\" on deployment skew
- [x] Typecheck, lint, and pre-commit hooks all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection and handling of deployment-related errors with a dedicated "Reload" button for faster recovery.
  * Enhanced error filtering to reduce monitoring noise from stale server-action errors.

* **Tests**
  * Updated test coverage for server-action error detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8734?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->