### PR TITLE
perf(public): defer homepage workspace + carousel hydration (JOV-1835)

### DIFF
--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -20,15 +20,32 @@ import { FEATURE_FLAGS } from '@/lib/feature-flags/shared';
 import { getMarketingExportImage } from '@/lib/screenshots/registry';
 
 // Below-the-fold sections are dynamic-loaded so their `motion/react`
-// hydration cost doesn't compete with above-the-fold work. SSR stays on
-// (SEO + initial HTML preserved) — only the client JS chunk is deferred.
+// hydration cost doesn't compete with above-the-fold work.
+//
 // JOV-1835: cuts homepage TBT from ~1365ms toward the 300ms budget.
+//
+// The heaviest motion-driven sections (`HomepageWorkspaceSection` runs
+// `useScroll` + 7 `useTransform`s on hydration) ship with `ssr: false`
+// and a fixed-height server-rendered placeholder. The placeholder reserves
+// the visual height upfront so there's no layout shift, while the client
+// chunk + motion subscriptions don't load or execute on initial hydration.
+// Other below-the-fold sections keep `ssr: true` so their HTML stays in
+// the initial document for SEO.
 const FridayRhythmSection = dynamic(
   () =>
     import('@/components/marketing/friday-rhythm-section').then(m => ({
       default: m.FridayRhythmSection,
     })),
-  { ssr: true }
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        aria-hidden='true'
+        className='w-full'
+        style={{ minHeight: 'min(96svh, 760px)' }}
+      />
+    ),
+  }
 );
 const HomepageV2Pricing = dynamic(
   () =>
@@ -72,19 +89,70 @@ const HomeStatQuoteSection = dynamic(
     })),
   { ssr: true }
 );
+// `HomepageWorkspaceSection` is the single biggest TBT contributor in
+// CI (motion `useScroll` + 7 `useTransform` derivations subscribe to
+// scroll on hydration). Defer its JS entirely; the placeholder reuses
+// the same outer CSS shell so its rendered height matches the real
+// component to avoid CLS when the chunk mounts.
 const HomepageWorkspaceSection = dynamic(
   () =>
     import('@/components/homepage/HomepageWorkspaceSection').then(m => ({
       default: m.HomepageWorkspaceSection,
     })),
-  { ssr: true }
+  {
+    ssr: false,
+    loading: () => (
+      <section
+        aria-hidden='true'
+        data-testid='homepage-workspace-section-placeholder'
+        className='homepage-workspace-section'
+      >
+        <div className='homepage-workspace-section__inner'>
+          <div className='homepage-workspace-section__copy'>
+            <h2 style={{ visibility: 'hidden' }}>
+              {HOMEPAGE_LAUNCH_COPY.workspace.headline.split('\n').map(line => (
+                <span key={line}>{line}</span>
+              ))}
+            </h2>
+          </div>
+          <div className='homepage-workspace-visual' />
+        </div>
+      </section>
+    ),
+  }
 );
+// `HomepageArtistProfilesCarousel` is a horizontally-scrollable client
+// rail with lazy images. Defer its JS chunk; the placeholder reuses
+// the same outer CSS classes plus a reserved rail height to avoid
+// CLS when the chunk mounts.
 const HomepageArtistProfilesCarousel = dynamic(
   () =>
     import('@/components/homepage/HomepageArtistProfilesCarousel').then(m => ({
       default: m.HomepageArtistProfilesCarousel,
     })),
-  { ssr: true }
+  {
+    ssr: false,
+    loading: () => (
+      <section
+        aria-hidden='true'
+        data-testid='homepage-artist-profiles-section-placeholder'
+        className='homepage-artist-profiles-section'
+      >
+        <div className='homepage-artist-profiles-section__inner'>
+          <div className='homepage-artist-profiles-section__header'>
+            <h2 style={{ visibility: 'hidden' }}>
+              <span>{HOMEPAGE_LAUNCH_COPY.artistProfiles.headline}</span>
+              <span>{HOMEPAGE_LAUNCH_COPY.artistProfiles.headlineAccent}</span>
+            </h2>
+          </div>
+          <div
+            className='homepage-artist-profiles-carousel'
+            style={{ minHeight: 'clamp(28rem, 56vw, 38rem)' }}
+          />
+        </div>
+      </section>
+    ),
+  }
 );
 
 const HERO_PRODUCT_IMAGES = {

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -2,10 +2,13 @@ import { ArrowRight } from 'lucide-react';
 import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
 import { HomeTrustSection } from '@/components/features/home/HomeTrustSection';
+import { HomepageArtistProfilesCarouselLazy } from '@/components/homepage/HomepageArtistProfilesCarouselLazy';
 import { HomepageHeroCommandCenter } from '@/components/homepage/HomepageHeroCommandCenter';
 import { HomepageTrackedLink } from '@/components/homepage/HomepageTrackedLink';
+import { HomepageWorkspaceSectionLazy } from '@/components/homepage/HomepageWorkspaceSectionLazy';
 import { HERO_COPY } from '@/components/homepage/intent';
 import { FaqSection } from '@/components/marketing';
+import { FridayRhythmSectionLazy } from '@/components/marketing/FridayRhythmSectionLazy';
 import { APP_NAME, BASE_URL } from '@/constants/app';
 import { HOMEPAGE_LAUNCH_COPY } from '@/data/homepageLaunchCopy';
 import { AuthRedirectHandler } from '@/features/home/AuthRedirectHandler';
@@ -24,29 +27,13 @@ import { getMarketingExportImage } from '@/lib/screenshots/registry';
 //
 // JOV-1835: cuts homepage TBT from ~1365ms toward the 300ms budget.
 //
-// The heaviest motion-driven sections (`HomepageWorkspaceSection` runs
-// `useScroll` + 7 `useTransform`s on hydration) ship with `ssr: false`
-// and a fixed-height server-rendered placeholder. The placeholder reserves
-// the visual height upfront so there's no layout shift, while the client
-// chunk + motion subscriptions don't load or execute on initial hydration.
-// Other below-the-fold sections keep `ssr: true` so their HTML stays in
-// the initial document for SEO.
-const FridayRhythmSection = dynamic(
-  () =>
-    import('@/components/marketing/friday-rhythm-section').then(m => ({
-      default: m.FridayRhythmSection,
-    })),
-  {
-    ssr: false,
-    loading: () => (
-      <div
-        aria-hidden='true'
-        className='w-full'
-        style={{ minHeight: 'min(96svh, 760px)' }}
-      />
-    ),
-  }
-);
+// Sections that are not motion-heavy keep `ssr: true` so their HTML
+// stays in the initial document for SEO. The heaviest motion-driven
+// sections (FridayRhythmSection / HomepageWorkspaceSection /
+// HomepageArtistProfilesCarousel) live in their own `'use client'`
+// `*Lazy.tsx` shims that pass `ssr: false` to `next/dynamic` (forbidden
+// in Server Components in Next 15 App Router) so the JS chunk and
+// motion subscriptions don't load or execute on initial hydration.
 const HomepageV2Pricing = dynamic(
   () =>
     import('@/components/marketing/homepage-v2/HomepageV2Ctas').then(m => ({
@@ -88,71 +75,6 @@ const HomeStatQuoteSection = dynamic(
       default: m.HomeStatQuoteSection,
     })),
   { ssr: true }
-);
-// `HomepageWorkspaceSection` is the single biggest TBT contributor in
-// CI (motion `useScroll` + 7 `useTransform` derivations subscribe to
-// scroll on hydration). Defer its JS entirely; the placeholder reuses
-// the same outer CSS shell so its rendered height matches the real
-// component to avoid CLS when the chunk mounts.
-const HomepageWorkspaceSection = dynamic(
-  () =>
-    import('@/components/homepage/HomepageWorkspaceSection').then(m => ({
-      default: m.HomepageWorkspaceSection,
-    })),
-  {
-    ssr: false,
-    loading: () => (
-      <section
-        aria-hidden='true'
-        data-testid='homepage-workspace-section-placeholder'
-        className='homepage-workspace-section'
-      >
-        <div className='homepage-workspace-section__inner'>
-          <div className='homepage-workspace-section__copy'>
-            <h2 style={{ visibility: 'hidden' }}>
-              {HOMEPAGE_LAUNCH_COPY.workspace.headline.split('\n').map(line => (
-                <span key={line}>{line}</span>
-              ))}
-            </h2>
-          </div>
-          <div className='homepage-workspace-visual' />
-        </div>
-      </section>
-    ),
-  }
-);
-// `HomepageArtistProfilesCarousel` is a horizontally-scrollable client
-// rail with lazy images. Defer its JS chunk; the placeholder reuses
-// the same outer CSS classes plus a reserved rail height to avoid
-// CLS when the chunk mounts.
-const HomepageArtistProfilesCarousel = dynamic(
-  () =>
-    import('@/components/homepage/HomepageArtistProfilesCarousel').then(m => ({
-      default: m.HomepageArtistProfilesCarousel,
-    })),
-  {
-    ssr: false,
-    loading: () => (
-      <section
-        aria-hidden='true'
-        data-testid='homepage-artist-profiles-section-placeholder'
-        className='homepage-artist-profiles-section'
-      >
-        <div className='homepage-artist-profiles-section__inner'>
-          <div className='homepage-artist-profiles-section__header'>
-            <h2 style={{ visibility: 'hidden' }}>
-              <span>{HOMEPAGE_LAUNCH_COPY.artistProfiles.headline}</span>
-              <span>{HOMEPAGE_LAUNCH_COPY.artistProfiles.headlineAccent}</span>
-            </h2>
-          </div>
-          <div
-            className='homepage-artist-profiles-carousel'
-            style={{ minHeight: 'clamp(28rem, 56vw, 38rem)' }}
-          />
-        </div>
-      </section>
-    ),
-  }
 );
 
 const HERO_PRODUCT_IMAGES = {
@@ -412,10 +334,10 @@ function HomepageUnlockedSections() {
       {FEATURE_FLAGS.SHOW_HOMEPAGE_GO_LIVE_SECTION ? (
         <HomepageGoLiveStepsSection />
       ) : null}
-      <HomepageWorkspaceSection screenshot={WORKSPACE_SCREENSHOT} />
-      <HomepageArtistProfilesCarousel cards={ARTIST_PROFILE_CARDS} />
+      <HomepageWorkspaceSectionLazy screenshot={WORKSPACE_SCREENSHOT} />
+      <HomepageArtistProfilesCarouselLazy cards={ARTIST_PROFILE_CARDS} />
       {FEATURE_FLAGS.SHOW_HOMEPAGE_FRIDAY_RHYTHM ? (
-        <FridayRhythmSection />
+        <FridayRhythmSectionLazy />
       ) : null}
       {FEATURE_FLAGS.SHOW_HOME_REFRESH_2026 ? <HomeBentoPairs /> : null}
       {FEATURE_FLAGS.SHOW_HOME_REFRESH_2026 ? <HomeLoopDiagramSection /> : null}

--- a/apps/web/components/homepage/HomepageArtistProfilesCarouselLazy.tsx
+++ b/apps/web/components/homepage/HomepageArtistProfilesCarouselLazy.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { HOMEPAGE_LAUNCH_COPY } from '@/data/homepageLaunchCopy';
+import type { HomepageArtistProfileCard } from './HomepageArtistProfilesCarousel';
+
+// JOV-1835: `HomepageArtistProfilesCarousel` is a horizontally-scrollable
+// client rail. Defer its JS chunk via a client-component shim
+// (`ssr: false` is forbidden in Server Components in Next 15 App Router)
+// so its hydration doesn't compete with above-the-fold work.
+//
+// The placeholder reuses the outer CSS classes (`.homepage-artist-profiles-section`,
+// `__inner`, `__header`, `.homepage-artist-profiles-carousel`) plus a
+// reserved rail min-height so the section height matches the real
+// component and CLS stays at 0 when the chunk mounts.
+const HomepageArtistProfilesCarouselImpl = dynamic(
+  () =>
+    import('./HomepageArtistProfilesCarousel').then(m => ({
+      default: m.HomepageArtistProfilesCarousel,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <section
+        aria-hidden='true'
+        data-testid='homepage-artist-profiles-section-placeholder'
+        className='homepage-artist-profiles-section'
+      >
+        <div className='homepage-artist-profiles-section__inner'>
+          <div className='homepage-artist-profiles-section__header'>
+            <h2 style={{ visibility: 'hidden' }}>
+              <span>{HOMEPAGE_LAUNCH_COPY.artistProfiles.headline}</span>
+              <span>{HOMEPAGE_LAUNCH_COPY.artistProfiles.headlineAccent}</span>
+            </h2>
+          </div>
+          <div
+            className='homepage-artist-profiles-carousel'
+            style={{ minHeight: 'clamp(28rem, 56vw, 38rem)' }}
+          />
+        </div>
+      </section>
+    ),
+  }
+);
+
+export function HomepageArtistProfilesCarouselLazy({
+  cards,
+}: Readonly<{ cards: readonly HomepageArtistProfileCard[] }>) {
+  return <HomepageArtistProfilesCarouselImpl cards={cards} />;
+}

--- a/apps/web/components/homepage/HomepageWorkspaceSectionLazy.tsx
+++ b/apps/web/components/homepage/HomepageWorkspaceSectionLazy.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { HOMEPAGE_LAUNCH_COPY } from '@/data/homepageLaunchCopy';
+
+type HomepageMarketingImage = {
+  readonly publicUrl: string;
+  readonly width: number;
+  readonly height: number;
+  readonly alt: string;
+};
+
+// JOV-1835: `HomepageWorkspaceSection` is the single biggest TBT
+// contributor on the homepage in CI. It runs `useScroll` plus 7
+// `useTransform` derivations that subscribe to scroll listeners during
+// hydration, competing with the above-the-fold hero work for the main
+// thread.
+//
+// Wrapping the import in a client-component shim lets us pass
+// `ssr: false` (forbidden in Server Components in Next 15 App Router)
+// so the JS chunk and motion subscriptions are deferred until after
+// the initial mount.
+//
+// The placeholder reuses the same outer CSS shell (`.homepage-workspace-section`,
+// `__inner`, `__copy`, `homepage-workspace-visual`) so the reserved
+// height matches the real component to avoid CLS when the chunk mounts.
+// Inner copy uses `visibility: hidden` to preserve layout while keeping
+// the a11y tree quiet; the outer section is `aria-hidden`.
+const HomepageWorkspaceSectionImpl = dynamic(
+  () =>
+    import('./HomepageWorkspaceSection').then(m => ({
+      default: m.HomepageWorkspaceSection,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <section
+        aria-hidden='true'
+        data-testid='homepage-workspace-section-placeholder'
+        className='homepage-workspace-section'
+      >
+        <div className='homepage-workspace-section__inner'>
+          <div className='homepage-workspace-section__copy'>
+            <h2 style={{ visibility: 'hidden' }}>
+              {HOMEPAGE_LAUNCH_COPY.workspace.headline.split('\n').map(line => (
+                <span key={line}>{line}</span>
+              ))}
+            </h2>
+          </div>
+          <div className='homepage-workspace-visual' />
+        </div>
+      </section>
+    ),
+  }
+);
+
+export function HomepageWorkspaceSectionLazy({
+  screenshot,
+}: Readonly<{ screenshot: HomepageMarketingImage }>) {
+  return <HomepageWorkspaceSectionImpl screenshot={screenshot} />;
+}

--- a/apps/web/components/marketing/FridayRhythmSectionLazy.tsx
+++ b/apps/web/components/marketing/FridayRhythmSectionLazy.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+// JOV-1835: `FridayRhythmSection` is a 482-line motion-driven below-the-fold
+// section. It's flag-gated off in the current CI Lighthouse run, but
+// defending against TBT regressions when the flag is flipped is the
+// same fix and keeps the homepage page.tsx structure consistent.
+//
+// `ssr: false` is forbidden in Server Components in Next 15 App Router,
+// so a small client-component shim does the dynamic import.
+const FridayRhythmSectionImpl = dynamic(
+  () =>
+    import('./friday-rhythm-section').then(m => ({
+      default: m.FridayRhythmSection,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        aria-hidden='true'
+        className='w-full'
+        style={{ minHeight: 'min(96svh, 760px)' }}
+      />
+    ),
+  }
+);
+
+export function FridayRhythmSectionLazy() {
+  return <FridayRhythmSectionImpl />;
+}


### PR DESCRIPTION
## Summary

Public-routes Lighthouse on the homepage was hitting TBT ≈ 1.36s (target ≤ 300ms) and perf 0.52 (target ≥ 0.7). Linear: [JOV-1835](https://linear.app/jovie/issue/JOV-1835/public-routes-lighthouse-homepage-tbt-1365ms-perf-052-username-cls-021).

Root cause: `HomepageWorkspaceSection` (the heaviest below-the-fold motion-driven section) runs `useScroll` + 7 `useTransform` derivations on hydration. It was already `dynamic()`-loaded but with `ssr: true`, so the JS chunk + motion subscriptions still executed during the initial hydration window — competing with the above-the-fold hero work for the main thread.

This PR flips the heaviest below-the-fold sections to `ssr: false` with server-rendered placeholders that reuse the same outer CSS shell so reserved height matches the real component and there is no CLS when the chunk mounts.

### Changes

- `HomepageWorkspaceSection`: `ssr: false`, placeholder reuses `.homepage-workspace-section`, `.homepage-workspace-section__inner`, `.homepage-workspace-section__copy`, `.homepage-workspace-visual` shell.
- `HomepageArtistProfilesCarousel`: `ssr: false`, placeholder reuses `.homepage-artist-profiles-section` shell + reserved rail height.
- `FridayRhythmSection`: `ssr: false` with min-height placeholder (flag-gated off in CI today; defensive against future flips).
- Other dynamic-loaded sections (`HomepageV2Pricing`, `HomepageV2FinalCta`, `HomeComposerHero`, `HomeBentoPairs`, `HomeLoopDiagramSection`, `HomeStatQuoteSection`) keep `ssr: true` so their HTML stays in the initial document for SEO.

### Path filter (issue recommendation #2)

`.github/workflows/ci.yml` already includes `apps/web/components/homepage/` and `apps/web/components/marketing/` in `PUBLIC_LIGHTHOUSE_PATTERN`, so future changes to either directory always trigger the public Lighthouse lane. No filter change needed.

### Placeholder strategy (CLS-safe)

Each placeholder uses the same outer CSS classes as the deferred component, with inner text hidden via `visibility: hidden` to preserve layout space without leaking content into the a11y tree. The outer `<section>` is `aria-hidden`, and uses a distinct `data-testid` (`*-placeholder`) so existing e2e selectors on the real test-ids continue to bind to the live component after the chunk mounts.

## Before / After

Before (JOV-1835 baseline, PR #8040):
- Homepage `categories:performance`: 0.52 (target ≥ 0.7)
- Homepage `total-blocking-time`: 1365 ms (target ≤ 300 ms)
- `/[username]` `cumulative-layout-shift`: 0.21 (target ≤ 0.15)

After (this PR): Lighthouse will run on the public-routes lane in CI; numbers will be posted as a PR comment by the Lighthouse CI workflow.

CLS on `/[username]` is being addressed by a separate, already-open PR (#8724 — `fix(profile): stabilize public profile CLS`).

## Verification

- `pnpm --filter @jovie/web run typecheck -- --pretty false` — clean
- `pnpm biome check apps/web/app/\(home\)/page.tsx` — clean
- `pnpm exec vitest run tests/unit/home/` — 24/24 files, 112/112 tests pass
- `pnpm exec vitest run tests/unit/marketing/friday-rhythm-section.test.tsx` — 2/2 tests pass
- Public Lighthouse: gated by CI on this PR

## Out of scope (filed follow-ups)

CLS fix on `/[username]` is owned by PR #8724 (JOV-2217 / JOV-2218). No further follow-up needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Deferred below-the-fold homepage sections to client-side lazy loading, improving initial page load speed.
  * Added loading placeholders that preserve layout and consistent section height to prevent visual shifts while content loads.

* **Accessibility / UX**
  * Placeholders maintain headline structure and avoid disrupting assistive experiences during lazy loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8735?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->