### PR TITLE
test(e2e): wrap file-scope test.use/configure in describe (JOV-2169)

### DIFF
--- a/apps/web/tests/e2e/auth.setup.ts
+++ b/apps/web/tests/e2e/auth.setup.ts
@@ -3,44 +3,48 @@ import { ClerkTestError, signInUser } from '../helpers/clerk-auth';
 
 const AUTH_FILE = 'tests/.auth/user.json';
 
-setup.describe.configure({ mode: 'serial' });
+setup.describe('Auth Setup', () => {
+  setup.describe.configure({ mode: 'serial' });
 
-setup.setTimeout(360_000); // 6min to absorb local cold-start compilation plus Clerk bootstrap
+  setup.setTimeout(360_000); // 6min to absorb local cold-start compilation plus Clerk bootstrap
 
-setup('authenticate', async ({ page }) => {
-  const username = process.env.E2E_CLERK_USER_USERNAME;
-  const password = process.env.E2E_CLERK_USER_PASSWORD;
-  const useTestAuthBypass = process.env.E2E_USE_TEST_AUTH_BYPASS === '1';
+  setup('authenticate', async ({ page }) => {
+    const username = process.env.E2E_CLERK_USER_USERNAME;
+    const password = process.env.E2E_CLERK_USER_PASSWORD;
+    const useTestAuthBypass = process.env.E2E_USE_TEST_AUTH_BYPASS === '1';
 
-  // Guard: write empty auth state if prerequisites missing
-  if (
-    !useTestAuthBypass &&
-    (!username || process.env.CLERK_TESTING_SETUP_SUCCESS !== 'true')
-  ) {
-    console.log('  Auth prerequisites not met, writing empty auth state');
-    await page.context().storageState({ path: AUTH_FILE });
-    return;
-  }
-
-  try {
-    await signInUser(page, { username, password });
-  } catch (error) {
+    // Guard: write empty auth state if prerequisites missing
     if (
-      error instanceof ClerkTestError &&
-      ['CLERK_SETUP_FAILED', 'CLERK_NOT_READY', 'MISSING_CREDENTIALS'].includes(
-        error.code
-      )
+      !useTestAuthBypass &&
+      (!username || process.env.CLERK_TESTING_SETUP_SUCCESS !== 'true')
     ) {
-      console.log(
-        `  Auth setup failed (${error.message.substring(0, 120)}), writing empty auth state`
-      );
+      console.log('  Auth prerequisites not met, writing empty auth state');
       await page.context().storageState({ path: AUTH_FILE });
       return;
     }
-    throw error;
-  }
 
-  // 7. Save authenticated session
-  await page.context().storageState({ path: AUTH_FILE });
-  console.log(`  Session saved to ${AUTH_FILE}`);
+    try {
+      await signInUser(page, { username, password });
+    } catch (error) {
+      if (
+        error instanceof ClerkTestError &&
+        [
+          'CLERK_SETUP_FAILED',
+          'CLERK_NOT_READY',
+          'MISSING_CREDENTIALS',
+        ].includes(error.code)
+      ) {
+        console.log(
+          `  Auth setup failed (${error.message.substring(0, 120)}), writing empty auth state`
+        );
+        await page.context().storageState({ path: AUTH_FILE });
+        return;
+      }
+      throw error;
+    }
+
+    // 7. Save authenticated session
+    await page.context().storageState({ path: AUTH_FILE });
+    console.log(`  Session saved to ${AUTH_FILE}`);
+  });
 });

--- a/apps/web/tests/e2e/mobile-overflow.spec.ts
+++ b/apps/web/tests/e2e/mobile-overflow.spec.ts
@@ -11,13 +11,6 @@ import {
   waitForNetworkIdle,
 } from './utils/smoke-test-utils';
 
-test.use({
-  deviceScaleFactor: 3,
-  hasTouch: true,
-  isMobile: true,
-  storageState: { cookies: [], origins: [] },
-});
-
 const DEFAULT_MOBILE_WIDTHS = [
   320, 360, 375, 390, 393, 402, 414, 428, 430,
 ] as const;
@@ -256,135 +249,146 @@ async function clickFirstVisible(
   return false;
 }
 
-test.describe('Mobile Overflow Release Guard', () => {
-  test.setTimeout(120_000);
+test.describe('Mobile Overflow', () => {
+  test.use({
+    deviceScaleFactor: 3,
+    hasTouch: true,
+    isMobile: true,
+    storageState: { cookies: [], origins: [] },
+  });
 
-  for (const width of MOBILE_WIDTHS) {
-    test.describe(`${width}px`, () => {
-      test.use({ viewport: { width, height: MOBILE_HEIGHT } });
+  test.describe('Mobile Overflow Release Guard', () => {
+    test.setTimeout(120_000);
 
-      for (const surface of PUBLIC_SURFACES) {
-        test(`public ${surface.id} has no horizontal overflow @ ${width}px`, async ({
-          page,
-        }, testInfo) => {
-          await navigateToPublicSurface(page, surface);
-          await assertSurfaceDoesNotOverflow(
+    for (const width of MOBILE_WIDTHS) {
+      test.describe(`${width}px`, () => {
+        test.use({ viewport: { width, height: MOBILE_HEIGHT } });
+
+        for (const surface of PUBLIC_SURFACES) {
+          test(`public ${surface.id} has no horizontal overflow @ ${width}px`, async ({
             page,
-            testInfo,
-            `${surface.id} ${width}px`
-          );
-        });
-      }
+          }, testInfo) => {
+            await navigateToPublicSurface(page, surface);
+            await assertSurfaceDoesNotOverflow(
+              page,
+              testInfo,
+              `${surface.id} ${width}px`
+            );
+          });
+        }
 
-      for (const route of AUTHENTICATED_ROUTES) {
-        test(`authenticated ${route.id} has no horizontal overflow @ ${width}px`, async ({
-          page,
-        }, testInfo) => {
-          await enterAuthenticatedRoute(page, route);
-          await assertSurfaceDoesNotOverflow(
+        for (const route of AUTHENTICATED_ROUTES) {
+          test(`authenticated ${route.id} has no horizontal overflow @ ${width}px`, async ({
             page,
-            testInfo,
-            `${route.id} ${width}px`
-          );
-        });
+          }, testInfo) => {
+            await enterAuthenticatedRoute(page, route);
+            await assertSurfaceDoesNotOverflow(
+              page,
+              testInfo,
+              `${route.id} ${width}px`
+            );
+          });
+        }
+      });
+    }
+  });
+
+  test.describe('Mobile Overflow Open States', () => {
+    test.use({ viewport: { width: 390, height: MOBILE_HEIGHT } });
+
+    test('homepage mobile navigation does not overflow', async ({
+      page,
+    }, testInfo) => {
+      const home = PUBLIC_SURFACES_BY_ID.get('home');
+      expect(home, 'Expected home surface in public manifest').toBeTruthy();
+
+      await navigateToPublicSurface(page, home as ResolvedPublicSurfaceSpec);
+      await expectNoDocumentOverflow(page, testInfo, 'home before nav open');
+
+      await clickFirstVisible(page, [
+        'button[aria-label*="menu" i]',
+        'button[aria-label*="navigation" i]',
+        'button[aria-expanded="false"]',
+      ]);
+
+      await expectNoDocumentOverflow(page, testInfo, 'home nav open state');
+    });
+
+    test('profile mobile drawers do not overflow', async ({
+      page,
+    }, testInfo) => {
+      const profile = PUBLIC_SURFACES_BY_ID.get('profile-main');
+      expect(
+        profile,
+        'Expected profile-main surface in public manifest'
+      ).toBeTruthy();
+
+      await navigateToPublicSurface(page, profile as ResolvedPublicSurfaceSpec);
+      await expectNoDocumentOverflow(
+        page,
+        testInfo,
+        'profile before open states'
+      );
+
+      const triggers = page.locator(
+        [
+          '[data-testid^="profile-primary-tab-"]',
+          'a[href*="mode="]',
+          'button[aria-haspopup="dialog"]',
+          'button[aria-label*="contact" i]',
+          'button[aria-label*="tip" i]',
+          'button[aria-label*="pay" i]',
+        ].join(', ')
+      );
+      const count = Math.min(await triggers.count(), OPEN_STATE_CLICK_LIMIT);
+
+      for (let index = 0; index < count; index += 1) {
+        const trigger = triggers.nth(index);
+        if (!(await trigger.isVisible().catch(() => false))) continue;
+
+        await trigger.click({ timeout: 10_000 }).catch(() => {});
+        await waitForHydration(page, { timeout: 15_000 });
+        await expectNoDocumentOverflow(
+          page,
+          testInfo,
+          `profile open state ${index + 1}`
+        );
+        await page.keyboard.press('Escape').catch(() => {});
       }
     });
-  }
-});
 
-test.describe('Mobile Overflow Open States', () => {
-  test.use({ viewport: { width: 390, height: MOBILE_HEIGHT } });
-
-  test('homepage mobile navigation does not overflow', async ({
-    page,
-  }, testInfo) => {
-    const home = PUBLIC_SURFACES_BY_ID.get('home');
-    expect(home, 'Expected home surface in public manifest').toBeTruthy();
-
-    await navigateToPublicSurface(page, home as ResolvedPublicSurfaceSpec);
-    await expectNoDocumentOverflow(page, testInfo, 'home before nav open');
-
-    await clickFirstVisible(page, [
-      'button[aria-label*="menu" i]',
-      'button[aria-label*="navigation" i]',
-      'button[aria-expanded="false"]',
-    ]);
-
-    await expectNoDocumentOverflow(page, testInfo, 'home nav open state');
-  });
-
-  test('profile mobile drawers do not overflow', async ({ page }, testInfo) => {
-    const profile = PUBLIC_SURFACES_BY_ID.get('profile-main');
-    expect(
-      profile,
-      'Expected profile-main surface in public manifest'
-    ).toBeTruthy();
-
-    await navigateToPublicSurface(page, profile as ResolvedPublicSurfaceSpec);
-    await expectNoDocumentOverflow(
+    test('dashboard menus and dialogs do not overflow', async ({
       page,
-      testInfo,
-      'profile before open states'
-    );
-
-    const triggers = page.locator(
-      [
-        '[data-testid^="profile-primary-tab-"]',
-        'a[href*="mode="]',
-        'button[aria-haspopup="dialog"]',
-        'button[aria-label*="contact" i]',
-        'button[aria-label*="tip" i]',
-        'button[aria-label*="pay" i]',
-      ].join(', ')
-    );
-    const count = Math.min(await triggers.count(), OPEN_STATE_CLICK_LIMIT);
-
-    for (let index = 0; index < count; index += 1) {
-      const trigger = triggers.nth(index);
-      if (!(await trigger.isVisible().catch(() => false))) continue;
-
-      await trigger.click({ timeout: 10_000 }).catch(() => {});
-      await waitForHydration(page, { timeout: 15_000 });
+    }, testInfo) => {
+      await enterAuthenticatedRoute(page, AUTHENTICATED_ROUTES[0]);
       await expectNoDocumentOverflow(
         page,
         testInfo,
-        `profile open state ${index + 1}`
+        'dashboard before open states'
       );
-      await page.keyboard.press('Escape').catch(() => {});
-    }
-  });
 
-  test('dashboard menus and dialogs do not overflow', async ({
-    page,
-  }, testInfo) => {
-    await enterAuthenticatedRoute(page, AUTHENTICATED_ROUTES[0]);
-    await expectNoDocumentOverflow(
-      page,
-      testInfo,
-      'dashboard before open states'
-    );
-
-    const triggers = page.locator(
-      [
-        'button[aria-haspopup="menu"]:not([disabled])',
-        'button[aria-haspopup="dialog"]:not([disabled])',
-        'button[aria-expanded="false"]:not([disabled])',
-      ].join(', ')
-    );
-    const count = Math.min(await triggers.count(), OPEN_STATE_CLICK_LIMIT);
-
-    for (let index = 0; index < count; index += 1) {
-      const trigger = triggers.nth(index);
-      if (!(await trigger.isVisible().catch(() => false))) continue;
-
-      await trigger.click({ timeout: 10_000 }).catch(() => {});
-      await waitForHydration(page, { timeout: 15_000 });
-      await expectNoDocumentOverflow(
-        page,
-        testInfo,
-        `dashboard open state ${index + 1}`
+      const triggers = page.locator(
+        [
+          'button[aria-haspopup="menu"]:not([disabled])',
+          'button[aria-haspopup="dialog"]:not([disabled])',
+          'button[aria-expanded="false"]:not([disabled])',
+        ].join(', ')
       );
-      await page.keyboard.press('Escape').catch(() => {});
-    }
+      const count = Math.min(await triggers.count(), OPEN_STATE_CLICK_LIMIT);
+
+      for (let index = 0; index < count; index += 1) {
+        const trigger = triggers.nth(index);
+        if (!(await trigger.isVisible().catch(() => false))) continue;
+
+        await trigger.click({ timeout: 10_000 }).catch(() => {});
+        await waitForHydration(page, { timeout: 15_000 });
+        await expectNoDocumentOverflow(
+          page,
+          testInfo,
+          `dashboard open state ${index + 1}`
+        );
+        await page.keyboard.press('Escape').catch(() => {});
+      }
+    });
   });
 });


### PR DESCRIPTION
Closes JOV-2169.

## Summary

**Playwright API compliance fix** — moves `test.use()` and `test.describe.configure()` calls from file scope into named describe blocks where Playwright requires them.

- **`mobile-overflow.spec.ts`**: Wrapped both `Mobile Overflow Release Guard` and `Mobile Overflow Open States` describe blocks inside a new top-level `test.describe('Mobile Overflow', ...)` that carries the shared `test.use({ isMobile, hasTouch, deviceScaleFactor, storageState })` fixture. The inner `test.use({ viewport })` calls in nested describes were already correctly placed.
- **`auth.setup.ts`**: Wrapped `setup.describe.configure({ mode: 'serial' })` and `setup.setTimeout()` and the `setup()` call inside a new `setup.describe('Auth Setup', ...)` block.

## Test Coverage

Test-only structural refactor — no new application code paths. All existing test names and behaviors are preserved.

`playwright test --list` output clean — no "did not expect test.use() to be called here" errors. All tests enumerate correctly under their describe hierarchy.

## Pre-Landing Review

No issues found. Pure structural Playwright API compliance fix — no logic changes, no new functionality, no security or data implications.

## Plan Completion

No plan file — dispatched inline as JOV-2169.

## Test plan
- [x] `playwright test --list` lists all tests cleanly without file-scope config errors
- [x] TypeScript typecheck passes (exit 0)
- [x] Biome lint passes — no issues
- [x] Pre-push hooks pass (biome, tailwind, typecheck, lint)
- [ ] CI: Mobile Overflow Guard 320/390/430px lanes return to green
- [ ] CI: A11y (axe) lane returns to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)