### PR TITLE
fix(a11y): add visible focus ring to primary CTAs (JOV-2181)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -946,6 +946,15 @@ body {
     background: #ffffff;
     opacity: 0.94;
   }
+  /* WCAG SC 2.4.7 — visible focus ring for keyboard users.
+     Uses a double-ring (offset + color ring) that is visible on both dark
+     and light backgrounds. */
+  .public-action-primary:focus-visible {
+    outline: none;
+    box-shadow:
+      0 0 0 2px rgba(0, 0, 0, 0.85),
+      0 0 0 4px color-mix(in oklab, var(--linear-border-focus) 72%, transparent);
+  }
   .public-action-secondary {
     display: inline-flex;
     align-items: center;
@@ -977,6 +986,13 @@ body {
       white 32%
     );
     opacity: 0.92;
+  }
+  /* WCAG SC 2.4.7 — visible focus ring for keyboard users */
+  .public-action-secondary:focus-visible {
+    outline: none;
+    box-shadow:
+      0 0 0 2px rgba(0, 0, 0, 0.85),
+      0 0 0 4px color-mix(in oklab, var(--linear-border-focus) 72%, transparent);
   }
   .marketing-pricing-plans {
     display: grid;
@@ -1428,8 +1444,10 @@ body {
     background-color: transparent;
     border-color: transparent;
     box-shadow: none;
+    /* Only suppress hover/active background — do NOT include :focus-visible here
+       so that the focus-ring-themed utility class (applied at usage sites) can
+       render the WCAG SC 2.4.7-required focus ring. */
     &:hover,
-    &:focus-visible,
     &:active {
       background-color: transparent;
       border-color: transparent;
@@ -1470,6 +1488,16 @@ body {
       background-color: var(--linear-btn-primary-hover);
       border-color: var(--linear-btn-primary-hover);
     }
+    /* WCAG SC 2.4.7 — visible focus ring for keyboard users */
+    &:focus-visible {
+      outline: none;
+      box-shadow:
+        var(--shadow-button-inset),
+        0 1px 1px rgba(0, 0, 0, 0.14),
+        0 0 0 2px var(--linear-bg-page),
+        0 0 0 4px
+        color-mix(in oklab, var(--linear-border-focus) 55%, transparent);
+    }
   }
   /* Linear Button - Primary CTA styling using tokens */
   .btn-linear-primary {
@@ -1495,6 +1523,16 @@ body {
     transition: all 150ms cubic-bezier(0.4, 0, 0.2, 1);
     &:hover {
       background-color: var(--color-btn-primary-hover);
+    }
+    /* WCAG SC 2.4.7 — visible focus ring for keyboard users */
+    &:focus-visible {
+      outline: none;
+      box-shadow:
+        var(--shadow-button-inset),
+        0 1px 1px rgba(0, 0, 0, 0.14),
+        0 0 0 2px var(--linear-bg-page),
+        0 0 0 4px
+        color-mix(in oklab, var(--linear-border-focus) 55%, transparent);
     }
   }
   /* Linear Spacing System — symmetric section padding from tokens */


### PR DESCRIPTION
## Summary

- **WCAG SC 2.4.7 (Focus Visible)** — audit finding #27: primary CTAs had `outline-width: 0px` and empty `box-shadow` on `:focus-visible`, making keyboard focus invisible.
- Added `:focus-visible` rules to 4 CSS utility classes in `globals.css`: `.public-action-primary`, `.public-action-secondary`, `.btn-linear-signup`, `.btn-linear-primary`. Double-ring pattern: `0 0 0 2px rgba(0,0,0,0.85)` (dark offset) + `0 0 0 4px color-mix(in oklab, var(--linear-border-focus) 72%, transparent)` (brand color) — visible on dark and light surfaces.
- Removed `:focus-visible` from the grouped hover/active reset in `.btn-linear-login` — it was actively suppressing `box-shadow: none` on keyboard focus, blocking the `focus-ring-themed` Tailwind utility applied at usage sites.
- Added explicit `:focus-visible` rule to `.marketing-glass-header__cta` in `HeaderNav.css`. Root cause: `HeaderNav.css` imports outside any CSS `@layer`, so its base `box-shadow` overrides the layered `focus-ring-themed` Tailwind ring. Split the combined `:hover, :focus-visible` selector and added the explicit box-shadow including the Tailwind ring values inline.

## Files changed

- `apps/web/app/globals.css` — 4 button utility classes fixed
- `apps/web/components/organisms/HeaderNav.css` — marketing header CTA fixed

## Test plan

- [ ] Keyboard Tab through the marketing header — "Request access" / "Get early access" CTA shows visible ring (dark offset + blue-purple glow)
- [ ] Keyboard Tab through homepage hero CTAs (`.public-action-primary`, `.public-action-secondary`) — rings visible
- [ ] Keyboard Tab through auth CTA buttons (`.btn-linear-signup`, `.btn-linear-primary`) — rings visible
- [ ] Keyboard Tab through `.btn-linear-login` (text-link style) — ring is visible via `focus-ring-themed` utility (no longer suppressed)
- [ ] Mouse click does not show focus ring (`:focus-visible` vs `:focus`)
- [ ] Typecheck: passes
- [ ] Biome: clean

## Verification

```
pnpm --filter @jovie/web run typecheck -- --pretty false  # passes (cached)
pnpm biome check apps/web/app/globals.css apps/web/components/organisms/HeaderNav.css  # Checked 2 files. No fixes applied.
```

Closes JOV-2181

<!-- linear-issue-id:JOV-2181 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)