### PR TITLE
fix(billing): cancel at period end instead of immediate (JOV-2180)

### DIFF
--- a/apps/web/app/api/stripe/cancel/route.ts
+++ b/apps/web/app/api/stripe/cancel/route.ts
@@ -1,7 +1,12 @@
 /**
  * Stripe Subscription Cancellation API
- * Cancels the user's subscription in-app with immediate effect.
- * The webhook handler (subscription.deleted) will revoke pro access.
+ *
+ * Schedules cancellation at the end of the current billing period (industry
+ * norm). The user keeps Pro access until `current_period_end`; Stripe fires
+ * `customer.subscription.updated` immediately and
+ * `customer.subscription.deleted` at the boundary when access is revoked.
+ *
+ * @see JOV-2180 — subset #1 (cancel period-end)
  */
 
 import { NextResponse } from 'next/server';
@@ -53,20 +58,41 @@ export async function POST() {
       );
     }
 
-    // Cancel the subscription via Stripe
+    // Schedule cancellation at end of current billing period
     const cancelledSubscription =
       await cancelSubscription(stripeSubscriptionId);
 
-    logger.info('Subscription cancelled in-app', {
+    // Stripe SDK types for `current_period_end` vary by API version; read it
+    // defensively so we can surface the cancel-on date to the client.
+    const rawPeriodEnd = Reflect.get(
+      cancelledSubscription,
+      'current_period_end'
+    );
+    const cancelAtSeconds =
+      typeof cancelledSubscription.cancel_at === 'number'
+        ? cancelledSubscription.cancel_at
+        : typeof rawPeriodEnd === 'number'
+          ? rawPeriodEnd
+          : null;
+    const cancelAtIso =
+      cancelAtSeconds !== null
+        ? new Date(cancelAtSeconds * 1000).toISOString()
+        : null;
+
+    logger.info('Subscription scheduled to cancel at period end', {
       userId,
       subscriptionId: stripeSubscriptionId,
       status: cancelledSubscription.status,
+      cancelAtPeriodEnd: cancelledSubscription.cancel_at_period_end,
+      cancelAt: cancelAtIso,
     });
 
     return NextResponse.json(
       {
         success: true,
         status: cancelledSubscription.status,
+        cancelAtPeriodEnd: cancelledSubscription.cancel_at_period_end === true,
+        cancelAt: cancelAtIso,
       },
       { headers: NO_STORE_HEADERS }
     );

--- a/apps/web/components/organisms/BillingDashboard.tsx
+++ b/apps/web/components/organisms/BillingDashboard.tsx
@@ -67,11 +67,27 @@ const BillingDashboardContent = memo(function BillingDashboardContent() {
       source: 'billing_dashboard',
     });
     cancelMutation.mutate(undefined, {
-      onSuccess: () => {
-        notifySuccess('Your subscription has been cancelled.');
+      onSuccess: response => {
+        // Cancellation is scheduled at end of current billing period (JOV-2180).
+        // Surface the cancel-on date when Stripe returns it; otherwise fall
+        // back to a generic period-end message.
+        const cancelAtMs = response?.cancelAt
+          ? Date.parse(response.cancelAt)
+          : Number.NaN;
+        const message = Number.isFinite(cancelAtMs)
+          ? `Pro access continues until ${new Date(
+              cancelAtMs
+            ).toLocaleDateString(undefined, {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })} — cancellation scheduled.`
+          : 'Pro access continues until the end of your billing period — cancellation scheduled.';
+        notifySuccess(message);
         setCancelDialogOpen(false);
         track('subscription_cancelled', {
           source: 'billing_dashboard',
+          cancelAtPeriodEnd: response?.cancelAtPeriodEnd === true,
         });
       },
     });

--- a/apps/web/components/organisms/billing/BillingActionsSection.tsx
+++ b/apps/web/components/organisms/billing/BillingActionsSection.tsx
@@ -74,8 +74,8 @@ export function BillingActionsSection({
                 <AlertDialogDescription asChild>
                   <div className='space-y-3'>
                     <p>
-                      If you cancel, you will immediately lose access to these
-                      features:
+                      Your Pro access continues until the end of your current
+                      billing period. After that, you&apos;ll lose access to:
                     </p>
                     <ul className='space-y-2'>
                       <li className='flex items-start gap-2 text-app'>
@@ -115,7 +115,7 @@ export function BillingActionsSection({
                       </li>
                     </ul>
                     <p className='text-secondary-token'>
-                      This takes effect immediately. You can re-subscribe at any
+                      You won&apos;t be charged again. You can re-subscribe any
                       time.
                     </p>
                   </div>

--- a/apps/web/lib/queries/useBillingMutations.ts
+++ b/apps/web/lib/queries/useBillingMutations.ts
@@ -141,10 +141,17 @@ export function usePortalMutation() {
 
 /**
  * Response from the cancel subscription API.
+ *
+ * Cancellation is scheduled at the end of the current billing period; the
+ * user keeps Pro access until `cancelAt`. See JOV-2180.
  */
 export interface CancelSubscriptionResponse {
   success: boolean;
   status?: string;
+  /** True when Stripe has flagged the subscription to cancel at period end */
+  cancelAtPeriodEnd?: boolean;
+  /** ISO timestamp when Pro access ends; null if Stripe did not return it */
+  cancelAt?: string | null;
 }
 
 /**
@@ -182,18 +189,17 @@ export function useCancelSubscriptionMutation() {
     mutationFn: cancelSubscriptionRequest,
 
     onMutate: async () => {
+      // Cancellation is scheduled at period end (JOV-2180). Pro access
+      // continues until current_period_end, so we intentionally do NOT
+      // optimistically flip isPro/plan here — the webhook will mark the
+      // subscription as cancel_at_period_end and the eventual
+      // customer.subscription.deleted event revokes access at the boundary.
       await queryClient.cancelQueries({
         queryKey: queryKeys.billing.status(),
       });
 
       const previousBilling = queryClient.getQueryData(
         queryKeys.billing.status()
-      );
-
-      queryClient.setQueryData(
-        queryKeys.billing.status(),
-        (old: { isPro: boolean; plan: string | null } | undefined) =>
-          old ? { ...old, isPro: false, plan: 'free' } : old
       );
 
       return { previousBilling };

--- a/apps/web/lib/stripe/client.ts
+++ b/apps/web/lib/stripe/client.ts
@@ -293,16 +293,29 @@ export async function getCustomerSubscription(
 }
 
 /**
- * Cancel a subscription immediately
+ * Schedule a subscription to cancel at the end of the current billing period.
+ *
+ * Industry-norm cancel UX: the user keeps Pro access through the period they
+ * already paid for, and Stripe auto-cancels at `current_period_end`. The
+ * `customer.subscription.updated` webhook fires immediately with
+ * `cancel_at_period_end: true`, and `customer.subscription.deleted` fires at
+ * the period boundary when access is revoked.
+ *
+ * @see JOV-2180 — subset #1 (cancel period-end)
  */
 export async function cancelSubscription(
   subscriptionId: string
 ): Promise<Stripe.Subscription> {
   try {
-    const subscription = await getStripe().subscriptions.cancel(subscriptionId);
+    const subscription = await getStripe().subscriptions.update(
+      subscriptionId,
+      { cancel_at_period_end: true }
+    );
     return subscription;
   } catch (error) {
-    captureError('Error canceling subscription', error, { subscriptionId });
+    captureError('Error scheduling subscription cancellation', error, {
+      subscriptionId,
+    });
     throw new Error('Failed to cancel subscription');
   }
 }

--- a/apps/web/tests/unit/api/stripe/cancel.test.ts
+++ b/apps/web/tests/unit/api/stripe/cancel.test.ts
@@ -30,15 +30,106 @@ vi.mock('@/lib/utils/logger', () => ({
   },
 }));
 
-describe('POST /api/stripe/cancel', () => {
+// Cold-import + module reset between cases is slow on this route;
+// give the suite enough headroom on a chilly machine.
+describe('POST /api/stripe/cancel', { timeout: 15000 }, () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
   });
 
+  it('schedules cancellation at period end and returns the cancel-on date (JOV-2180)', async () => {
+    mockAuth.mockResolvedValueOnce({ userId: 'user_123' });
+    mockGetUserBillingInfo.mockResolvedValueOnce({
+      success: true,
+      data: {
+        stripeSubscriptionId: 'sub_123',
+        isPro: true,
+      },
+    });
+    // 2026-06-15T00:00:00Z in seconds
+    const periodEndSeconds = 1781481600;
+    mockCancelSubscription.mockResolvedValue({
+      id: 'sub_123',
+      status: 'active',
+      cancel_at_period_end: true,
+      cancel_at: periodEndSeconds,
+      current_period_end: periodEndSeconds,
+    });
+
+    const { POST } = await import('@/app/api/stripe/cancel/route');
+
+    const response = await POST();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(mockCancelSubscription).toHaveBeenCalledWith('sub_123');
+    expect(data).toEqual({
+      success: true,
+      status: 'active',
+      cancelAtPeriodEnd: true,
+      cancelAt: new Date(periodEndSeconds * 1000).toISOString(),
+    });
+  });
+
+  it('falls back to current_period_end when cancel_at is missing', async () => {
+    mockAuth.mockResolvedValueOnce({ userId: 'user_123' });
+    mockGetUserBillingInfo.mockResolvedValueOnce({
+      success: true,
+      data: {
+        stripeSubscriptionId: 'sub_123',
+        isPro: true,
+      },
+    });
+    const periodEndSeconds = 1781481600;
+    mockCancelSubscription.mockResolvedValue({
+      id: 'sub_123',
+      status: 'active',
+      cancel_at_period_end: true,
+      // cancel_at intentionally null — Stripe sometimes omits it on the
+      // initial update; current_period_end is the source of truth.
+      cancel_at: null,
+      current_period_end: periodEndSeconds,
+    });
+
+    const { POST } = await import('@/app/api/stripe/cancel/route');
+
+    const response = await POST();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.cancelAt).toBe(new Date(periodEndSeconds * 1000).toISOString());
+  });
+
+  it('returns null cancelAt when neither cancel_at nor current_period_end is set', async () => {
+    mockAuth.mockResolvedValueOnce({ userId: 'user_123' });
+    mockGetUserBillingInfo.mockResolvedValueOnce({
+      success: true,
+      data: {
+        stripeSubscriptionId: 'sub_123',
+        isPro: true,
+      },
+    });
+    mockCancelSubscription.mockResolvedValue({
+      id: 'sub_123',
+      status: 'active',
+      cancel_at_period_end: true,
+      cancel_at: null,
+    });
+
+    const { POST } = await import('@/app/api/stripe/cancel/route');
+
+    const response = await POST();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.cancelAt).toBeNull();
+    expect(data.cancelAtPeriodEnd).toBe(true);
+  });
+
   it('captures critical error with user and subscription context when cancellation fails', async () => {
-    mockAuth.mockResolvedValue({ userId: 'user_123' });
-    mockGetUserBillingInfo.mockResolvedValue({
+    mockAuth.mockResolvedValueOnce({ userId: 'user_123' });
+    mockGetUserBillingInfo.mockResolvedValueOnce({
       success: true,
       data: {
         stripeSubscriptionId: 'sub_123',

--- a/apps/web/tests/unit/lib/queries/useBillingMutations.test.tsx
+++ b/apps/web/tests/unit/lib/queries/useBillingMutations.test.tsx
@@ -321,14 +321,13 @@ describe('useCancelSubscriptionMutation', () => {
     );
   });
 
-  it('should optimistically set billing status to free during mutation', async () => {
-    // Seed the billing status cache with a pro subscription via a query
-    // so the data persists through cancelQueries
+  it('should preserve pro billing status during cancel mutation (JOV-2180: cancel at period end)', async () => {
+    // Pro access continues until current_period_end after cancel; the cache
+    // must NOT optimistically flip to free.
     queryClient.setQueryData(['billing', 'status'], {
       isPro: true,
       plan: 'pro',
     });
-    // Keep a query observer alive so the data is not garbage collected
     const unsubscribe = queryClient.getQueryCache().subscribe(() => {});
 
     let resolveCancel!: (value: unknown) => void;
@@ -341,12 +340,11 @@ describe('useCancelSubscriptionMutation', () => {
       wrapper: TestWrapper,
     });
 
-    // Fire the mutation and let onMutate run
     await act(async () => {
       result.current.mutate(undefined);
     });
 
-    // The optimistic update should have set isPro=false, plan=free
+    // During the in-flight cancellation, isPro/plan must stay unchanged.
     await waitFor(() => {
       const status = queryClient.getQueryData(['billing', 'status']) as
         | {
@@ -355,13 +353,17 @@ describe('useCancelSubscriptionMutation', () => {
           }
         | undefined;
       expect(status).toBeDefined();
-      expect(status!.isPro).toBe(false);
-      expect(status!.plan).toBe('free');
+      expect(status!.isPro).toBe(true);
+      expect(status!.plan).toBe('pro');
     });
 
-    // Resolve the mutation to clean up
     await act(async () => {
-      resolveCancel({ success: true });
+      resolveCancel({
+        success: true,
+        status: 'active',
+        cancelAtPeriodEnd: true,
+        cancelAt: '2026-06-15T00:00:00.000Z',
+      });
     });
 
     unsubscribe();

--- a/apps/web/tests/unit/lib/stripe/client.cancel.test.ts
+++ b/apps/web/tests/unit/lib/stripe/client.cancel.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Stripe Client - cancelSubscription regression test (JOV-2180)
+ *
+ * Locks in the cancel-at-period-end semantics so a future refactor cannot
+ * silently re-introduce immediate cancellation.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockSubscriptionsUpdate = vi.hoisted(() => vi.fn());
+const mockSubscriptionsCancel = vi.hoisted(() => vi.fn());
+const mockCaptureError = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/db/cache', () => ({
+  cacheQuery: vi.fn(),
+  invalidateCache: vi.fn(),
+}));
+
+vi.mock('@/lib/redis', () => ({
+  getRedis: vi.fn(),
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: mockCaptureError,
+  captureWarning: vi.fn(),
+}));
+
+vi.mock('@/lib/env-public', () => ({
+  publicEnv: {
+    NEXT_PUBLIC_PROFILE_URL: 'https://test.jovie.ai',
+  },
+}));
+
+vi.mock('@/lib/env-server', () => ({
+  env: {
+    STRIPE_SECRET_KEY: 'sk_test_123',
+  },
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('stripe', () => {
+  return {
+    default: class MockStripe {
+      subscriptions = {
+        update: mockSubscriptionsUpdate,
+        cancel: mockSubscriptionsCancel,
+        list: vi.fn(),
+        retrieve: vi.fn(),
+      };
+      customers = {
+        search: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+      };
+    },
+  };
+});
+
+import { cancelSubscription } from '@/lib/stripe/client';
+
+describe('cancelSubscription (JOV-2180)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls subscriptions.update with cancel_at_period_end: true (NOT subscriptions.cancel)', async () => {
+    const periodEndSeconds = 1781481600;
+    mockSubscriptionsUpdate.mockResolvedValueOnce({
+      id: 'sub_abc',
+      status: 'active',
+      cancel_at_period_end: true,
+      cancel_at: periodEndSeconds,
+      current_period_end: periodEndSeconds,
+    });
+
+    const result = await cancelSubscription('sub_abc');
+
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledTimes(1);
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith('sub_abc', {
+      cancel_at_period_end: true,
+    });
+
+    // The immediate-cancel API must NOT be called.
+    expect(mockSubscriptionsCancel).not.toHaveBeenCalled();
+
+    // Returned subscription propagates the cancel-at-period-end flag.
+    expect(result.cancel_at_period_end).toBe(true);
+    expect(result.status).toBe('active');
+  });
+
+  it('captures the underlying error and throws a generic message', async () => {
+    const stripeError = new Error('Stripe is on fire');
+    mockSubscriptionsUpdate.mockRejectedValueOnce(stripeError);
+
+    await expect(cancelSubscription('sub_err')).rejects.toThrow(
+      'Failed to cancel subscription'
+    );
+
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      'Error scheduling subscription cancellation',
+      stripeError,
+      { subscriptionId: 'sub_err' }
+    );
+  });
+});


### PR DESCRIPTION
**AUTO-MERGE BLOCKED per `.claude/rules/release.md` (billing path = money). Do NOT enable auto-merge — needs human review.**

Refs JOV-2180 (subset #1 only). Recon scope (#21) and trial surfacing (#67) remain in the epic.
Follow-up: JOV-2272 (webhook persistence + persistent in-page banner + Reactivate CTA).

## Changes

- `apps/web/lib/stripe/client.ts` — `cancelSubscription` now calls `subscriptions.update(id, { cancel_at_period_end: true })` instead of `subscriptions.cancel(id)`. The user keeps Pro access through the period they already paid for; Stripe auto-cancels at `current_period_end`.
- `apps/web/app/api/stripe/cancel/route.ts` — Returns `cancelAtPeriodEnd` and `cancelAt` (ISO timestamp) so the client can render the cancel-on date. Reads the date defensively from `cancel_at` first, falling back to `current_period_end`.
- `apps/web/lib/queries/useBillingMutations.ts` — Removed the optimistic `isPro: false / plan: 'free'` cache flip in `onMutate` because access continues until period end. Response type now includes `cancelAtPeriodEnd` and `cancelAt`.
- `apps/web/components/organisms/BillingDashboard.tsx` — Success toast now reads "Pro access continues until <DATE> — cancellation scheduled."
- `apps/web/components/organisms/billing/BillingActionsSection.tsx` — Confirmation dialog copy updated to reflect period-end semantics (no longer says "you will immediately lose access").

## Why this is degraded to toast-only (not a persistent banner)

The `customer.subscription.updated` webhook handler does not currently persist `cancel_at_period_end` or `cancel_at` to the `users` table. Without those fields, the billing page cannot render a persistent "Scheduled to cancel on <DATE>. Reactivate?" banner after a page refresh — only the in-session toast. Adding the schema column + webhook persistence + Reactivate route + banner is scoped to follow-up **JOV-2272** so this PR stays focused on the immediate user-protection bug.

## Tests

- `apps/web/tests/unit/lib/stripe/client.cancel.test.ts` (new) — locks in that `cancelSubscription` calls `subscriptions.update` with `cancel_at_period_end: true` and never calls the immediate `subscriptions.cancel` API. Regression test for JOV-2180 acceptance criteria.
- `apps/web/tests/unit/api/stripe/cancel.test.ts` — 3 new cases: returns the cancel-on date, falls back to `current_period_end` when `cancel_at` is missing, returns null when neither is set. Existing error-path test preserved.
- `apps/web/tests/unit/lib/queries/useBillingMutations.test.tsx` — Existing "optimistically set billing status to free" test rewritten to assert isPro/plan stay unchanged during the in-flight cancel (since access continues).

## Verification

- typecheck: pass (`pnpm --filter @jovie/web run typecheck`)
- biome: pass (`pnpm biome check --write`)
- vitest: 19/19 pass across the three affected test files + webhook subscription handler regression check
- Manual smoke planned on staging: open billing dashboard as a Pro user, click Cancel Subscription, confirm toast shows the cancel-on date and that isPro stays true until the period boundary.

## Cost Impact

Zero new API calls. This is a parameter change to the existing `/api/stripe/cancel` endpoint — same Stripe call count, different argument shape.

## Risk

- **Webhook compatibility:** The existing `customer.subscription.updated` handler treats `cancel_at_period_end: true` as a normal update and reprocesses via `updateUserBillingStatus`. The subscription status remains `active` until the period boundary, then Stripe fires `customer.subscription.deleted` which clears Pro access. Manually verified the handler path; no schema change required for the access revocation half of the flow.
- **In-app cache:** Removing the optimistic flip means the UI no longer momentarily shows "Free" after the cancel click. The success toast carries the new mental model, and the existing `invalidateQueries` on success refreshes from the server.

## Linear

JOV-2180 marked In Progress at start of work. Will be manually transitioned to In Review on PR open (ad-hoc branch — orchestrator auto-transition does not apply here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)