### PR TITLE
chore(security): pin GitHub Actions to SHAs in desktop-release.yml (JOV-2266)

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -59,9 +59,9 @@ jobs:
       HAS_MAC_SIGNING_CREDENTIALS: ${{ secrets.MAC_CERTIFICATE_BASE64 != '' && secrets.MAC_CERTIFICATE_PASSWORD != '' }}
       HAS_APPLE_API_CREDENTIALS: ${{ secrets.APPLE_API_KEY != '' && secrets.APPLE_API_KEY_ID != '' && secrets.APPLE_API_ISSUER != '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
 


### PR DESCRIPTION
## Summary

Closes JOV-2266. Regression from the JOV-1079 sweep (2026-03-01): `desktop-release.yml` was added in May 2026 with unpinned `actions/checkout@v4` and `actions/setup-node@v4`. This PR pins both to their current commit SHAs, matching the style used across all other workflows in the repo.

**Pinned actions:**
- `actions/checkout@v4` → `@34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
- `actions/setup-node@v4` → `@49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0)

**Full sweep result:** `grep -rn "uses:.*@v[0-9]" .github/workflows/*.yml` returns zero matches after this change. All other active workflows were already pinned from JOV-1079.

## Pre-Landing Review

YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"` — valid. `actionlint` — clean, zero errors. No code logic changed.

## Test Coverage

No application code changed — 2 lines in a YAML workflow file. No test coverage required.

## Plan Completion

- [x] Pin `actions/checkout@v4` to current SHA → `@34e114876b...` (v4.3.1)
- [x] Pin `actions/setup-node@v4` to current SHA → `@49933ea5...` (v4.4.0)
- [x] Full sweep of all `.github/workflows/*.yml` — zero remaining unpinned `@v*` references

## Test plan

- [x] YAML syntax valid (python3 yaml.safe_load)
- [x] actionlint passes with zero errors
- [x] Full workflow grep for `@v\d+` returns zero matches post-fix

<!-- linear-issue-id:JOV-2266 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance build process stability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->