### PR TITLE
feat(shell): wire chat threads sidebar

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -13,6 +13,7 @@ import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarMenu,
+  useSidebar,
 } from '@/components/organisms/Sidebar';
 import { SidebarCollapsibleGroup } from '@/components/organisms/SidebarCollapsibleGroup';
 import {
@@ -89,6 +90,7 @@ function formatTaskBadge(
 export function DashboardNav(_: DashboardNavProps) {
   const { isAdmin, selectedProfile } = useDashboardData();
   const { clearPendingShell, showPendingShell } = usePendingShell();
+  const { isMobile, openMobile, state: sidebarState } = useSidebar();
   const pathname = usePathname();
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -122,11 +124,21 @@ export function DashboardNav(_: DashboardNavProps) {
   const { data: taskStats } = useTaskStatsQuery(profileId, {
     enabled: !isDemo && canAccessTasksWorkspace,
   });
-  const { data: conversations } = useChatConversationsQuery({
-    limit: 10,
-    enabled: shellChatV1Enabled && !isDemo,
-  });
   const isInSettings = pathname.startsWith(APP_ROUTES.SETTINGS);
+  const threadsVisible =
+    shellChatV1Enabled &&
+    !isDemo &&
+    !isInSettings &&
+    (isMobile ? openMobile : sidebarState === 'open');
+  const {
+    data: conversations,
+    isError: conversationsError,
+    isLoading: conversationsLoading,
+    refetch: refetchConversations,
+  } = useChatConversationsQuery({
+    limit: 10,
+    enabled: threadsVisible,
+  });
 
   // Settings nav: "General" (user) and artist name (or "Artist") groups
   const artistSettingsLabel = artistName || 'Artist';
@@ -291,6 +303,7 @@ export function DashboardNav(_: DashboardNavProps) {
     () =>
       (conversations ?? []).map(conversation => ({
         id: conversation.id,
+        href: `${APP_ROUTES.CHAT}/${encodeURIComponent(conversation.id)}`,
         title: conversation.title?.trim() || 'Untitled thread',
         status: 'complete',
         updatedAt: conversation.updatedAt,
@@ -305,12 +318,13 @@ export function DashboardNav(_: DashboardNavProps) {
     return id ? decodeURIComponent(id) : null;
   }, [pathname]);
 
-  const handleThreadSelect = useCallback(
-    (id: string) => {
-      router.push(`${APP_ROUTES.CHAT}/${encodeURIComponent(id)}`);
-    },
-    [router]
-  );
+  const handleNewThread = useCallback(() => {
+    router.push(APP_ROUTES.CHAT);
+  }, [router]);
+
+  const handleRetryThreads = useCallback(() => {
+    void refetchConversations();
+  }, [refetchConversations]);
 
   // Memoize renderNavItem to prevent creating new functions on every render
   const renderNavItem = useCallback(
@@ -425,12 +439,20 @@ export function DashboardNav(_: DashboardNavProps) {
         </SidebarGroup>
       )}
 
-      {shellChatV1Enabled && !isInSettings ? (
+      {threadsVisible ? (
         <div className='mt-1.5'>
           <SidebarThreadsSection
             threads={sidebarThreads}
             activeThreadId={activeThreadId}
-            onSelect={handleThreadSelect}
+            state={
+              conversationsError
+                ? 'error'
+                : conversationsLoading
+                  ? 'loading'
+                  : 'idle'
+            }
+            onRetry={handleRetryThreads}
+            onNewThread={handleNewThread}
             tight
             collapsed={false}
           />

--- a/apps/web/components/organisms/CmdKPalette.tsx
+++ b/apps/web/components/organisms/CmdKPalette.tsx
@@ -251,7 +251,7 @@ export function CmdKPalette({
                 setSelectedIndex(0);
               }}
               placeholder='Jump to a page, skill, release, or thread…'
-              className='flex-1 bg-transparent text-sm text-primary-token outline-none placeholder:text-tertiary-token'
+              className='flex-1 appearance-none bg-transparent text-sm text-primary-token outline-none placeholder:text-tertiary-token focus:outline-none focus:ring-0 focus:shadow-none focus-visible:outline-none focus-visible:ring-0 focus-visible:shadow-none'
               aria-label='Command palette search'
             />
             <span className='hidden shrink-0 rounded-md border border-(--linear-app-frame-seam) bg-surface-1 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-tertiary-token sm:inline'>

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -1,16 +1,21 @@
 'use client';
 
-import { MoreHorizontal } from 'lucide-react';
+import {
+  Loader2,
+  MessageSquarePlus,
+  MoreHorizontal,
+  RefreshCw,
+} from 'lucide-react';
+import Link from 'next/link';
+import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
 
-// Thread types — co-located so consumers import from one place.
-// NOTE: this shape is shell-v1's flat prop contract. Production's useThreads()
-// (React Query, features/chat) returns a different shape with `conversationId`
-// + message counts. A SidebarThread adapter hook is a follow-on PR — for now,
-// callers should pass an empty array until the adapter lands.
+// Thread types — co-located so consumers import from one place. Production
+// adapters should map real conversation records into this flat shell contract.
 
 export type ThreadStatus = 'running' | 'complete' | 'errored';
+export type SidebarThreadListState = 'idle' | 'loading' | 'error';
 
 export interface SidebarThread {
   readonly id: string;
@@ -22,6 +27,8 @@ export interface SidebarThread {
   readonly updatedAt: string;
   // Unread rows highlight in the sidebar to pull attention.
   readonly unread?: boolean;
+  // App Router href for production navigation. Experiments can omit and use onSelect.
+  readonly href?: string;
 }
 
 export interface SidebarThreadsSectionProps {
@@ -32,10 +39,37 @@ export interface SidebarThreadsSectionProps {
     e: React.MouseEvent,
     thread: SidebarThread
   ) => void;
+  readonly state?: SidebarThreadListState;
+  readonly onRetry?: () => void;
+  readonly onNewThread?: () => void;
   // `tight` drops row height to 24px (h-6) to match dense workspace lists.
   readonly tight?: boolean;
   // `collapsed` hides the section entirely (sidebar icon mode).
   readonly collapsed: boolean;
+}
+
+function SidebarThreadStatusRow({
+  children,
+  icon,
+  tight,
+}: {
+  readonly children: ReactNode;
+  readonly icon: ReactNode;
+  readonly tight?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 rounded-md px-3 text-tertiary-token',
+        tight ? 'h-6 text-[12px]' : 'h-7 text-[12.5px]'
+      )}
+    >
+      <span className='grid h-3.5 w-3.5 shrink-0 place-items-center text-quaternary-token'>
+        {icon}
+      </span>
+      <span className='min-w-0 flex-1 truncate'>{children}</span>
+    </div>
+  );
 }
 
 // Status dot tones:
@@ -48,6 +82,9 @@ export function SidebarThreadsSection({
   activeThreadId,
   onSelect,
   onThreadContextMenu,
+  state = 'idle',
+  onRetry,
+  onNewThread,
   tight,
   collapsed,
 }: SidebarThreadsSectionProps) {
@@ -59,13 +96,14 @@ export function SidebarThreadsSection({
   );
 
   if (collapsed) return null;
-  if (sorted.length === 0) return null;
+  if (state === 'idle' && sorted.length === 0 && !onNewThread) return null;
 
   const visible = expanded ? sorted.slice(0, 10) : sorted.slice(0, 5);
   // Show toggle only when there's more than the collapsed slice. Avoids
   // a "View all" → "no Show less" stuck state on 1–10 threads.
   const hasMore = sorted.length > 5;
   const unreadCount = sorted.filter(t => t.unread).length;
+  const hasThreads = sorted.length > 0;
 
   return (
     <div className='space-y-1'>
@@ -87,11 +125,95 @@ export function SidebarThreadsSection({
           expanded && 'max-h-[320px] overflow-y-auto'
         )}
       >
+        {state === 'loading' && !hasThreads ? (
+          <SidebarThreadStatusRow
+            tight={tight}
+            icon={
+              <Loader2
+                className='h-3 w-3 animate-spin'
+                aria-hidden='true'
+                strokeWidth={2.25}
+              />
+            }
+          >
+            Loading threads
+          </SidebarThreadStatusRow>
+        ) : null}
+        {state === 'error' && !hasThreads ? (
+          <div
+            className={cn(
+              'flex items-center gap-2 rounded-md px-3 text-tertiary-token',
+              tight ? 'h-6 text-[12px]' : 'h-7 text-[12.5px]'
+            )}
+          >
+            <span className='min-w-0 flex-1 truncate'>Threads unavailable</span>
+            {onRetry ? (
+              <button
+                type='button'
+                onClick={onRetry}
+                aria-label='Retry threads'
+                className='grid h-5 w-5 shrink-0 place-items-center rounded text-quaternary-token transition-colors duration-subtle ease-out hover:bg-sidebar-accent/55 hover:text-primary-token'
+              >
+                <RefreshCw
+                  className='h-3 w-3'
+                  aria-hidden='true'
+                  strokeWidth={2.25}
+                />
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+        {state === 'idle' && !hasThreads && onNewThread ? (
+          <button
+            type='button'
+            onClick={onNewThread}
+            className={cn(
+              'flex items-center gap-2 rounded-md px-3 text-left text-tertiary-token transition-colors duration-subtle ease-out hover:bg-sidebar-accent/55 hover:text-primary-token',
+              tight ? 'h-6 text-[12px]' : 'h-7 text-[12.5px]'
+            )}
+          >
+            <MessageSquarePlus
+              className='h-3.5 w-3.5 shrink-0 text-quaternary-token'
+              aria-hidden='true'
+              strokeWidth={2.25}
+            />
+            <span className='min-w-0 flex-1 truncate'>Start a thread</span>
+          </button>
+        ) : null}
         {visible.map(t => {
           const active = activeThreadId === t.id;
           const unread = !!t.unread && !active;
+          const rowClasses = cn(
+            'flex-1 flex items-center gap-2 min-w-0 text-left',
+            tight ? 'h-6 pl-2.5 pr-2' : 'h-7 pl-3 pr-2'
+          );
+          const rowContent = (
+            <>
+              <span
+                className={cn(
+                  'h-1.5 w-1.5 rounded-full shrink-0',
+                  t.status === 'running'
+                    ? 'bg-cyan-300/85 anim-calm-breath'
+                    : t.status === 'errored'
+                      ? 'bg-rose-400/85'
+                      : unread
+                        ? 'bg-cyan-300/85'
+                        : 'bg-white/25'
+                )}
+              />
+              <span
+                className={cn(
+                  'flex-1 truncate',
+                  tight ? 'text-[12px]' : 'text-[12.5px]',
+                  unread && 'font-medium'
+                )}
+              >
+                {t.title}
+              </span>
+            </>
+          );
           return (
-            // biome-ignore lint/a11y/noStaticElementInteractions: row hosts two real buttons; div is hover container with right-click menu
+            // biome-ignore lint/a11y/noStaticElementInteractions: row hosts a real link/button; div is hover container with right-click menu
             // biome-ignore lint/a11y/noNoninteractiveElementInteractions: same
             <div
               key={t.id}
@@ -106,36 +228,19 @@ export function SidebarThreadsSection({
               )}
               onContextMenu={e => onThreadContextMenu?.(e, t)}
             >
-              <button
-                type='button'
-                onClick={() => onSelect?.(t.id)}
-                className={cn(
-                  'flex-1 flex items-center gap-2 min-w-0 text-left',
-                  tight ? 'h-6 pl-2.5 pr-2' : 'h-7 pl-3 pr-2'
-                )}
-              >
-                <span
-                  className={cn(
-                    'h-1.5 w-1.5 rounded-full shrink-0',
-                    t.status === 'running'
-                      ? 'bg-cyan-300/85 anim-calm-breath'
-                      : t.status === 'errored'
-                        ? 'bg-rose-400/85'
-                        : unread
-                          ? 'bg-cyan-300/85'
-                          : 'bg-white/25'
-                  )}
-                />
-                <span
-                  className={cn(
-                    'flex-1 truncate',
-                    tight ? 'text-[12px]' : 'text-[12.5px]',
-                    unread && 'font-medium'
-                  )}
+              {t.href ? (
+                <Link href={t.href} className={rowClasses}>
+                  {rowContent}
+                </Link>
+              ) : (
+                <button
+                  type='button'
+                  onClick={() => onSelect?.(t.id)}
+                  className={rowClasses}
                 >
-                  {t.title}
-                </span>
-              </button>
+                  {rowContent}
+                </button>
+              )}
               {onThreadContextMenu ? (
                 <button
                   type='button'

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1380,6 +1380,16 @@
     select,
     [contenteditable="true"],
     [role="textbox"]
+  ):focus {
+  outline: none;
+}
+
+:where(
+    input,
+    textarea,
+    select,
+    [contenteditable="true"],
+    [role="textbox"]
   ):focus-visible {
   box-shadow: none;
 }

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -160,8 +160,7 @@ describe('DashboardNav interactions', () => {
     );
   });
 
-  it('renders recent threads in the Design V1 sidebar and opens a selected thread', async () => {
-    const user = userEvent.setup();
+  it('renders recent threads in the Design V1 sidebar as App Router links', () => {
     mockUseChatConversationsQuery.mockReturnValueOnce({
       data: [
         {
@@ -190,12 +189,45 @@ describe('DashboardNav interactions', () => {
       enabled: true,
     });
 
-    await user.click(screen.getByRole('button', { name: 'Pitch tasks' }));
-
-    expect(mockRouterPush).toHaveBeenCalledWith('/app/chat/thread-newer');
+    expect(screen.getByRole('link', { name: 'Pitch tasks' })).toHaveAttribute(
+      'href',
+      '/app/chat/thread-newer'
+    );
     expect(
       screen.queryByRole('button', { name: 'Thread actions' })
     ).not.toBeInTheDocument();
+  });
+
+  it('renders compact thread loading and empty states from the real conversations query', async () => {
+    const user = userEvent.setup();
+
+    mockUseChatConversationsQuery.mockReturnValueOnce({
+      data: undefined,
+      isLoading: true,
+    });
+
+    const { unmount } = renderDashboardNav({
+      renderFn: render,
+      appFlags: { DESIGN_V1: true },
+    });
+
+    expect(screen.getByText('Loading threads')).toBeInTheDocument();
+    unmount();
+
+    mockUseChatConversationsQuery.mockReturnValueOnce({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    renderDashboardNav({
+      renderFn: render,
+      appFlags: { DESIGN_V1: true },
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Start a thread' }));
+
+    expect(mockRouterPush).toHaveBeenCalledWith(APP_ROUTES.CHAT);
   });
 
   it('profile button navigates to chat before opening the drawer off chat routes', async () => {

--- a/apps/web/tests/global-setup.ts
+++ b/apps/web/tests/global-setup.ts
@@ -150,6 +150,7 @@ async function globalSetup() {
     '/api/stripe/checkout',
     '/api/stripe/pricing-options',
     APP_ROUTES.CHAT, // auth.setup.ts navigates here — warm up to avoid cold-compile 404
+    APP_ROUTES.LIBRARY,
     APP_ROUTES.DASHBOARD_RELEASES,
     APP_ROUTES.DASHBOARD_AUDIENCE,
     APP_ROUTES.PRESENCE,

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -88,6 +88,9 @@ describe('surface elevation guardrails', () => {
       /:where\(:focus-visible\)\s*{[\s\S]*box-shadow:\s*inset 0 0 0 var\(--focus-ring-width\)/
     );
     expect(designSystem).toMatch(
+      /:where\([\s\S]*input,[\s\S]*textarea,[\s\S]*\[role="textbox"\][\s\S]*\):focus\s*{[\s\S]*outline:\s*none;/
+    );
+    expect(designSystem).toMatch(
       /:where\([\s\S]*input,[\s\S]*textarea,[\s\S]*\[role="textbox"\][\s\S]*\):focus-visible\s*{[\s\S]*box-shadow:\s*none;/
     );
     expect(designSystem).not.toContain(

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { DashboardData } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
 import { APP_ROUTES } from '@/constants/routes';
 import {
+  mockUseChatConversationsQuery,
   mockUsePathname,
   mockUsePlanGate,
   mockUseTaskStatsQuery,
@@ -64,11 +65,16 @@ describe('DashboardNav', () => {
     const { container } = renderDashboardNav({
       renderFn: fastRender,
       sidebarProps: { defaultOpen: false },
+      appFlags: { DESIGN_V1: true },
     });
 
     const profileButton = container.querySelector('button[aria-pressed]');
     expect(profileButton).toBeTruthy();
     expect(profileButton?.className).toContain('justify-center');
+    expect(mockUseChatConversationsQuery).toHaveBeenCalledWith({
+      limit: 10,
+      enabled: false,
+    });
   });
 
   it('differentiates primary and secondary nav styling', () => {


### PR DESCRIPTION
## Summary
- Wires the production shell sidebar to real chat conversations as App Router links, with active thread detection.
- Adds compact loading, empty, and error states for the sidebar thread section without fetching while the sidebar is hidden or collapsed.
- Tightens text-input focus resets for the command palette/native inputs and warms `/app/library` for shell persistence E2E coverage.

## Linear
- JOV-2274

## Verification
- `pnpm biome check --write apps/web/styles/design-system.css apps/web/components/organisms/CmdKPalette.tsx apps/web/tests/unit/app/surface-elevation-guardrails.test.ts apps/web/components/shell/SidebarThreadsSection.tsx apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx apps/web/tests/unit/dashboard/DashboardNav.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/surface-elevation-guardrails.test.ts tests/components/dashboard/DashboardNav.interaction.test.tsx tests/unit/dashboard/DashboardNav.test.tsx --reporter=default`
- `BASE_URL=http://127.0.0.1:3112 E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready pnpm --filter @jovie/web exec playwright test tests/e2e/shell-chat-v1.spec.ts --project=chromium`
- `BASE_URL=http://127.0.0.1:3112 E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready pnpm --filter @jovie/web exec playwright test tests/e2e/shell-route-persistence.spec.ts --project=chromium`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web run tailwind:check`
- `git diff --check`
- Pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`

## Visual QA
- Desktop chat/sidebar threads, mobile chat, command palette focus, and library override screenshots captured locally.
- Repeat screenshot pixel diff after settle: desktop chat `0.0000%`; command palette `0.0000%`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread list now displays loading states and empty-state guidance to start a new conversation.

* **Bug Fixes**
  * Fixed thread sidebar visibility to correctly sync with navigation state.
  * Improved focus styling for form inputs across the app.

* **Style**
  * Refined search bar input styling for better visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8792?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->