### PR TITLE
fix(profile): contain ssr:false bailout in local Suspense boundaries (JOV-2273)

### DIFF
--- a/apps/web/app/[username]/layout.tsx
+++ b/apps/web/app/[username]/layout.tsx
@@ -3,7 +3,21 @@ import { ClientProviders } from '@/components/providers/ClientProviders';
 import { publicEnv } from '@/lib/env-public';
 
 // ISR: profiles are statically generated and revalidated every hour.
-// On-demand invalidation via revalidateTag('profile:{username}') handles mutations.
+// On-demand invalidation via revalidateTag(createProfileTag(username))
+// + revalidatePath(`/${username}`) handles mutations — both fired from
+// `lib/cache/profile.ts::invalidateProfileCache()`, called after every
+// profile/social-link/avatar mutation from the dashboard.
+//
+// Cache layers (JOV-2270 investigation):
+//   1. Server-side Full Route Cache (ISR): 3600s, busted on mutation
+//      via revalidatePath() and revalidateTag(createProfileTag()).
+//   2. Browser-side Router Cache (RSC): governed by next.config.js
+//      `experimental.staleTimes.static: 300` (5 min). Independent of
+//      revalidateTag — auto-expires per-browser. Worst-case staleness on
+//      SPA navigation between profile pages is 5 minutes; this is
+//      acceptable for public profile content and matches the Next 15
+//      default for static-classified routes. A profile update is
+//      reflected within 5 min on the same browser session.
 export const revalidate = 3600;
 
 export default function ProfileLayout({

--- a/apps/web/components/features/profile/DesktopQrOverlayClient.tsx
+++ b/apps/web/components/features/profile/DesktopQrOverlayClient.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
 
+// Wrapped in <Suspense> so the `ssr: false` dynamic import does not bail the
+// entire parent React tree to client-side rendering. Without the boundary,
+// Next.js 15 + React 19 emit `BAILOUT_TO_CLIENT_SIDE_RENDERING` on the nearest
+// ancestor Suspense, which on the /[username] route is the implicit boundary
+// wrapping `loading.tsx` — causing the animated skeleton to ship as the
+// initial visible HTML instead of the actual profile content (JOV-2273).
 const DesktopQrOverlay = dynamic(
   () =>
     import('./DesktopQrOverlay').then(mod => ({
@@ -16,5 +23,9 @@ const DesktopQrOverlay = dynamic(
 export function DesktopQrOverlayClient({
   handle,
 }: Readonly<{ handle: string }>) {
-  return <DesktopQrOverlay handle={handle} />;
+  return (
+    <Suspense fallback={null}>
+      <DesktopQrOverlay handle={handle} />
+    </Suspense>
+  );
 }

--- a/apps/web/components/features/profile/DesktopQrOverlayClient.tsx
+++ b/apps/web/components/features/profile/DesktopQrOverlayClient.tsx
@@ -1,31 +1,22 @@
 'use client';
 
-import dynamic from 'next/dynamic';
-import { Suspense } from 'react';
+import { DesktopQrOverlay } from './DesktopQrOverlay';
 
-// Wrapped in <Suspense> so the `ssr: false` dynamic import does not bail the
-// entire parent React tree to client-side rendering. Without the boundary,
-// Next.js 15 + React 19 emit `BAILOUT_TO_CLIENT_SIDE_RENDERING` on the nearest
-// ancestor Suspense, which on the /[username] route is the implicit boundary
-// wrapping `loading.tsx` — causing the animated skeleton to ship as the
-// initial visible HTML instead of the actual profile content (JOV-2273).
-const DesktopQrOverlay = dynamic(
-  () =>
-    import('./DesktopQrOverlay').then(mod => ({
-      default: mod.DesktopQrOverlay,
-    })),
-  {
-    ssr: false,
-    loading: () => null,
-  }
-);
-
+// Previously wrapped `DesktopQrOverlay` in a `dynamic({ ssr: false })` import.
+// That bailed the parent SSR tree to client-side rendering and emitted
+// `<template data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING">` in the streaming
+// payload — which on the /[username] route forced the animated skeleton from
+// `loading.tsx` to be the initial visible HTML for every cold visit
+// (JOV-2273).
+//
+// `DesktopQrOverlay` initial state is `mode: 'hidden'` and renders `null` on
+// first paint, so SSR is safe: server-rendered output is also `null`, and the
+// component progressively enables itself in `useEffect` once
+// `globalThis.matchMedia('(min-width: 768px)')` resolves on the client. The
+// `ssr: false` deferral was costing us a visible CSR bailout for no rendering
+// benefit.
 export function DesktopQrOverlayClient({
   handle,
 }: Readonly<{ handle: string }>) {
-  return (
-    <Suspense fallback={null}>
-      <DesktopQrOverlay handle={handle} />
-    </Suspense>
-  );
+  return <DesktopQrOverlay handle={handle} />;
 }

--- a/apps/web/components/features/profile/ProfilePrimaryCTA.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryCTA.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { Suspense, useMemo, useState } from 'react';
 import { CTAButton } from '@/components/molecules/CTAButton';
 import { useProfileNotifications } from '@/components/organisms/profile-shell/ProfileNotificationsContext';
 import { AUDIENCE_SPOTIFY_PREFERRED_COOKIE } from '@/constants/app';
@@ -27,6 +27,14 @@ const ctaLoadingFallback = (
   </div>
 );
 
+// `ssr: false` on these dynamic imports defers the notification flow modules
+// (which include Statsig calls, browser cookie/contact storage, and form
+// submission UI) to the client. Without an explicit <Suspense> boundary at
+// each consumer site, Next.js 15 + React 19 bail the parent tree to
+// client-side rendering and emit `BAILOUT_TO_CLIENT_SIDE_RENDERING` on the
+// route's implicit Suspense boundary (loading.tsx) — shipping the animated
+// skeleton as the initial visible HTML instead of the actual profile content
+// (JOV-2273). Suspense boundaries are added at each consumer below.
 const ArtistNotificationsCTA = dynamic(
   () =>
     import(
@@ -121,17 +129,21 @@ export function ProfilePrimaryCTA({
     if (subscribeTwoStep) {
       return (
         <div className='space-y-3 py-2 sm:py-3'>
-          <TwoStepNotificationsCTA artist={artist} />
+          <Suspense fallback={ctaLoadingFallback}>
+            <TwoStepNotificationsCTA artist={artist} />
+          </Suspense>
         </div>
       );
     }
     return (
       <div className='space-y-3 py-2 sm:py-3'>
-        <ArtistNotificationsCTA
-          artist={artist}
-          variant='button'
-          autoOpen={autoOpenCapture}
-        />
+        <Suspense fallback={ctaLoadingFallback}>
+          <ArtistNotificationsCTA
+            artist={artist}
+            variant='button'
+            autoOpen={autoOpenCapture}
+          />
+        </Suspense>
       </div>
     );
   }

--- a/apps/web/components/features/profile/ProfilePrimaryCTA.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryCTA.tsx
@@ -1,15 +1,13 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import Link from 'next/link';
-import { Suspense, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { CTAButton } from '@/components/molecules/CTAButton';
 import { useProfileNotifications } from '@/components/organisms/profile-shell/ProfileNotificationsContext';
 import { AUDIENCE_SPOTIFY_PREFERRED_COOKIE } from '@/constants/app';
-import {
-  profilePrimaryPillClassName,
-  SubscriptionFormSkeleton,
-} from '@/features/profile/artist-notifications-cta/shared';
+import { ArtistNotificationsCTA } from '@/features/profile/artist-notifications-cta/ArtistNotificationsCTA';
+import { profilePrimaryPillClassName } from '@/features/profile/artist-notifications-cta/shared';
+import { TwoStepNotificationsCTA } from '@/features/profile/artist-notifications-cta/TwoStepNotificationsCTA';
 import { useBreakpointDown } from '@/hooks/useBreakpoint';
 import type { AvailableDSP } from '@/lib/dsp';
 import {
@@ -20,40 +18,19 @@ import { cn } from '@/lib/utils';
 import type { Artist, LegacySocialLink } from '@/types/db';
 import { ListenDrawer } from './ListenDrawer';
 
-const ctaLoadingFallback = (
-  <div className='space-y-3 py-2 sm:py-3'>
-    <div className='h-3 w-40 rounded skeleton' aria-hidden='true' />
-    <SubscriptionFormSkeleton />
-  </div>
-);
-
-// `ssr: false` on these dynamic imports defers the notification flow modules
-// (which include Statsig calls, browser cookie/contact storage, and form
-// submission UI) to the client. Without an explicit <Suspense> boundary at
-// each consumer site, Next.js 15 + React 19 bail the parent tree to
-// client-side rendering and emit `BAILOUT_TO_CLIENT_SIDE_RENDERING` on the
-// route's implicit Suspense boundary (loading.tsx) — shipping the animated
-// skeleton as the initial visible HTML instead of the actual profile content
-// (JOV-2273). Suspense boundaries are added at each consumer below.
-const ArtistNotificationsCTA = dynamic(
-  () =>
-    import(
-      '@/features/profile/artist-notifications-cta/ArtistNotificationsCTA'
-    ).then(mod => ({
-      default: mod.ArtistNotificationsCTA,
-    })),
-  { ssr: false, loading: () => ctaLoadingFallback }
-);
-
-const TwoStepNotificationsCTA = dynamic(
-  () =>
-    import(
-      '@/features/profile/artist-notifications-cta/TwoStepNotificationsCTA'
-    ).then(mod => ({
-      default: mod.TwoStepNotificationsCTA,
-    })),
-  { ssr: false, loading: () => ctaLoadingFallback }
-);
+// Previously these imports used `dynamic({ ssr: false })` to defer the
+// notification flow modules to the client. That bailed the parent SSR tree
+// to client-side rendering and emitted
+// `<template data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING">` in the streaming
+// payload — shipping the animated skeleton from `loading.tsx` as the initial
+// visible HTML for every cold visit (JOV-2273).
+//
+// Notification CTAs render trivially on the server (just markup + a Bell
+// icon) and only need client JS for the subscribe interaction itself, so
+// direct import is safe.
+//
+// `ProfilePrimaryCTA` is currently only consumed by unit tests; the change
+// is preventative against future usage on the public profile RSC tree.
 
 /**
  * Read Spotify preference from client-side cookie.
@@ -129,21 +106,17 @@ export function ProfilePrimaryCTA({
     if (subscribeTwoStep) {
       return (
         <div className='space-y-3 py-2 sm:py-3'>
-          <Suspense fallback={ctaLoadingFallback}>
-            <TwoStepNotificationsCTA artist={artist} />
-          </Suspense>
+          <TwoStepNotificationsCTA artist={artist} />
         </div>
       );
     }
     return (
       <div className='space-y-3 py-2 sm:py-3'>
-        <Suspense fallback={ctaLoadingFallback}>
-          <ArtistNotificationsCTA
-            artist={artist}
-            variant='button'
-            autoOpen={autoOpenCapture}
-          />
-        </Suspense>
+        <ArtistNotificationsCTA
+          artist={artist}
+          variant='button'
+          autoOpen={autoOpenCapture}
+        />
       </div>
     );
   }

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -3,6 +3,7 @@
 import dynamic from 'next/dynamic';
 import {
   type CSSProperties,
+  Suspense,
   useCallback,
   useEffect,
   useMemo,
@@ -49,6 +50,14 @@ import type { PressPhoto } from '@/types/press-photos';
 import { ProfileCompactSurface } from './ProfileCompactSurface';
 import { PublicProfileLayoutShell } from './PublicProfileLayoutShell';
 
+// `ssr: false` deferred this component to the client because it is only
+// rendered on >=1180px desktop viewports (gated by isDesktopLayout, which is
+// false during SSR). Without a <Suspense> wrapper, Next.js 15 + React 19 bail
+// the parent tree to client-side rendering and emit
+// `BAILOUT_TO_CLIENT_SIDE_RENDERING` on the route's implicit Suspense boundary
+// (loading.tsx) — shipping the animated skeleton as the initial visible HTML
+// instead of the actual profile content (JOV-2273). The fix is the explicit
+// <Suspense> boundary at the consumer site below.
 const ProfileDesktopSurface = dynamic(
   () =>
     import('./ProfileDesktopSurface').then(mod => ({
@@ -63,6 +72,13 @@ const ProfileDesktopSurface = dynamic(
       />
     ),
   }
+);
+
+const desktopSurfaceFallback = (
+  <div
+    data-testid='profile-desktop-surface-loading'
+    className='h-[min(940px,calc(100dvh-48px))] w-full rounded-[36px] border border-white/8 bg-[rgba(8,10,14,0.9)]'
+  />
 );
 
 interface ProfileCompactTemplateProps {
@@ -708,44 +724,46 @@ export function ProfileCompactTemplate({
         shouldRenderHeading={shouldRenderTemplateHeading}
         profileAccentStyle={profileAccentStyle}
         desktopSurface={
-          <ProfileDesktopSurface
-            presentation={drawerPresentation}
-            artist={artist}
-            socialLinks={socialLinks}
-            contacts={contacts}
-            showPayButton={showPayButton}
-            latestRelease={latestRelease}
-            profileSettings={profileSettings}
-            alertOptInVariant={resolvedAlertOptInVariant}
-            genres={genres}
-            pressPhotos={pressPhotos}
-            allowPhotoDownloads={allowPhotoDownloads}
-            photoDownloadSizes={photoDownloadSizes}
-            tourDates={tourDates}
-            viewerCountryCode={viewerCountryCode}
-            drawerOpen={drawerOpen}
-            drawerView={drawerView}
-            activeMode={requestedMode}
-            onModeSelect={nextMode => {
-              clearCloseResetTimer();
-              setRequestedMode(nextMode);
-            }}
-            onAlertsModalClose={() => {
-              clearCloseResetTimer();
-              setRequestedMode(lastPrimaryModeRef.current);
-            }}
-            onDrawerOpenChange={handleDrawerOpenChange}
-            onDrawerViewChange={handleDrawerViewChange}
-            onOpenMenu={() => openDrawerMode('menu')}
-            onPlayClick={handlePlayClick}
-            profileHref={profileHref}
-            isSubscribed={isSubscribed}
-            contentPrefs={contentPrefs}
-            onTogglePref={handleTogglePref}
-            onUnsubscribe={handleUnsubscribe}
-            isUnsubscribing={unsubMutation.isPending}
-            releases={releases}
-          />
+          <Suspense fallback={desktopSurfaceFallback}>
+            <ProfileDesktopSurface
+              presentation={drawerPresentation}
+              artist={artist}
+              socialLinks={socialLinks}
+              contacts={contacts}
+              showPayButton={showPayButton}
+              latestRelease={latestRelease}
+              profileSettings={profileSettings}
+              alertOptInVariant={resolvedAlertOptInVariant}
+              genres={genres}
+              pressPhotos={pressPhotos}
+              allowPhotoDownloads={allowPhotoDownloads}
+              photoDownloadSizes={photoDownloadSizes}
+              tourDates={tourDates}
+              viewerCountryCode={viewerCountryCode}
+              drawerOpen={drawerOpen}
+              drawerView={drawerView}
+              activeMode={requestedMode}
+              onModeSelect={nextMode => {
+                clearCloseResetTimer();
+                setRequestedMode(nextMode);
+              }}
+              onAlertsModalClose={() => {
+                clearCloseResetTimer();
+                setRequestedMode(lastPrimaryModeRef.current);
+              }}
+              onDrawerOpenChange={handleDrawerOpenChange}
+              onDrawerViewChange={handleDrawerViewChange}
+              onOpenMenu={() => openDrawerMode('menu')}
+              onPlayClick={handlePlayClick}
+              profileHref={profileHref}
+              isSubscribed={isSubscribed}
+              contentPrefs={contentPrefs}
+              onTogglePref={handleTogglePref}
+              onUnsubscribe={handleUnsubscribe}
+              isUnsubscribing={unsubMutation.isPending}
+              releases={releases}
+            />
+          </Suspense>
         }
         compactSurface={
           <div

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import {
   type CSSProperties,
-  Suspense,
   useCallback,
   useEffect,
   useMemo,
@@ -48,38 +46,20 @@ import type { Artist, LegacySocialLink } from '@/types/db';
 import type { NotificationContentType } from '@/types/notifications';
 import type { PressPhoto } from '@/types/press-photos';
 import { ProfileCompactSurface } from './ProfileCompactSurface';
+import { ProfileDesktopSurface } from './ProfileDesktopSurface';
 import { PublicProfileLayoutShell } from './PublicProfileLayoutShell';
 
-// `ssr: false` deferred this component to the client because it is only
-// rendered on >=1180px desktop viewports (gated by isDesktopLayout, which is
-// false during SSR). Without a <Suspense> wrapper, Next.js 15 + React 19 bail
-// the parent tree to client-side rendering and emit
-// `BAILOUT_TO_CLIENT_SIDE_RENDERING` on the route's implicit Suspense boundary
-// (loading.tsx) — shipping the animated skeleton as the initial visible HTML
-// instead of the actual profile content (JOV-2273). The fix is the explicit
-// <Suspense> boundary at the consumer site below.
-const ProfileDesktopSurface = dynamic(
-  () =>
-    import('./ProfileDesktopSurface').then(mod => ({
-      default: mod.ProfileDesktopSurface,
-    })),
-  {
-    ssr: false,
-    loading: () => (
-      <div
-        data-testid='profile-desktop-surface-loading'
-        className='h-[min(940px,calc(100dvh-48px))] w-full rounded-[36px] border border-white/8 bg-[rgba(8,10,14,0.9)]'
-      />
-    ),
-  }
-);
-
-const desktopSurfaceFallback = (
-  <div
-    data-testid='profile-desktop-surface-loading'
-    className='h-[min(940px,calc(100dvh-48px))] w-full rounded-[36px] border border-white/8 bg-[rgba(8,10,14,0.9)]'
-  />
-);
+// Previously imported via `dynamic({ ssr: false })`. That bailed the parent
+// SSR tree to client-side rendering and emitted
+// `<template data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING">` in the streaming
+// payload, forcing the animated skeleton from `loading.tsx` to be the initial
+// visible HTML for every cold visit (JOV-2273).
+//
+// `ProfileDesktopSurface` is only rendered when `isDesktopLayout === true`,
+// which starts as `false` during SSR and is set in `useEffect` from
+// `matchMedia('(min-width: 1180px)')`. So the component is never rendered
+// server-side anyway — the `ssr: false` deferral was costing us a visible
+// CSR bailout for no rendering benefit.
 
 interface ProfileCompactTemplateProps {
   readonly mode: ProfileMode;
@@ -724,46 +704,44 @@ export function ProfileCompactTemplate({
         shouldRenderHeading={shouldRenderTemplateHeading}
         profileAccentStyle={profileAccentStyle}
         desktopSurface={
-          <Suspense fallback={desktopSurfaceFallback}>
-            <ProfileDesktopSurface
-              presentation={drawerPresentation}
-              artist={artist}
-              socialLinks={socialLinks}
-              contacts={contacts}
-              showPayButton={showPayButton}
-              latestRelease={latestRelease}
-              profileSettings={profileSettings}
-              alertOptInVariant={resolvedAlertOptInVariant}
-              genres={genres}
-              pressPhotos={pressPhotos}
-              allowPhotoDownloads={allowPhotoDownloads}
-              photoDownloadSizes={photoDownloadSizes}
-              tourDates={tourDates}
-              viewerCountryCode={viewerCountryCode}
-              drawerOpen={drawerOpen}
-              drawerView={drawerView}
-              activeMode={requestedMode}
-              onModeSelect={nextMode => {
-                clearCloseResetTimer();
-                setRequestedMode(nextMode);
-              }}
-              onAlertsModalClose={() => {
-                clearCloseResetTimer();
-                setRequestedMode(lastPrimaryModeRef.current);
-              }}
-              onDrawerOpenChange={handleDrawerOpenChange}
-              onDrawerViewChange={handleDrawerViewChange}
-              onOpenMenu={() => openDrawerMode('menu')}
-              onPlayClick={handlePlayClick}
-              profileHref={profileHref}
-              isSubscribed={isSubscribed}
-              contentPrefs={contentPrefs}
-              onTogglePref={handleTogglePref}
-              onUnsubscribe={handleUnsubscribe}
-              isUnsubscribing={unsubMutation.isPending}
-              releases={releases}
-            />
-          </Suspense>
+          <ProfileDesktopSurface
+            presentation={drawerPresentation}
+            artist={artist}
+            socialLinks={socialLinks}
+            contacts={contacts}
+            showPayButton={showPayButton}
+            latestRelease={latestRelease}
+            profileSettings={profileSettings}
+            alertOptInVariant={resolvedAlertOptInVariant}
+            genres={genres}
+            pressPhotos={pressPhotos}
+            allowPhotoDownloads={allowPhotoDownloads}
+            photoDownloadSizes={photoDownloadSizes}
+            tourDates={tourDates}
+            viewerCountryCode={viewerCountryCode}
+            drawerOpen={drawerOpen}
+            drawerView={drawerView}
+            activeMode={requestedMode}
+            onModeSelect={nextMode => {
+              clearCloseResetTimer();
+              setRequestedMode(nextMode);
+            }}
+            onAlertsModalClose={() => {
+              clearCloseResetTimer();
+              setRequestedMode(lastPrimaryModeRef.current);
+            }}
+            onDrawerOpenChange={handleDrawerOpenChange}
+            onDrawerViewChange={handleDrawerViewChange}
+            onOpenMenu={() => openDrawerMode('menu')}
+            onPlayClick={handlePlayClick}
+            profileHref={profileHref}
+            isSubscribed={isSubscribed}
+            contentPrefs={contentPrefs}
+            onTogglePref={handleTogglePref}
+            onUnsubscribe={handleUnsubscribe}
+            isUnsubscribing={unsubMutation.isPending}
+            releases={releases}
+          />
         }
         compactSurface={
           <div

--- a/apps/web/tests/unit/profile/ProfilePrimaryCTA.loading.test.tsx
+++ b/apps/web/tests/unit/profile/ProfilePrimaryCTA.loading.test.tsx
@@ -4,18 +4,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { ProfilePrimaryCTA } from '@/features/profile/ProfilePrimaryCTA';
 import type { Artist, LegacySocialLink } from '@/types/db';
 
-vi.mock('next/dynamic', () => ({
-  default: (
-    _loader: unknown,
-    options?: { loading?: () => React.ReactNode }
-  ) => {
-    const Loading = options?.loading;
-    return function DynamicComponent() {
-      return Loading ? Loading() : null;
-    };
-  },
-}));
-
 vi.mock('next/link', () => ({
   __esModule: true,
   default: ({
@@ -76,6 +64,26 @@ vi.mock('@/components/organisms/profile-shell', () => ({
   }),
 }));
 
+vi.mock(
+  '@/features/profile/artist-notifications-cta/ArtistNotificationsCTA',
+  () => ({
+    ArtistNotificationsCTA: () => (
+      <div data-testid='artist-notifications-cta'>ArtistNotificationsCTA</div>
+    ),
+  })
+);
+
+vi.mock(
+  '@/features/profile/artist-notifications-cta/TwoStepNotificationsCTA',
+  () => ({
+    TwoStepNotificationsCTA: () => (
+      <div data-testid='two-step-notifications-cta'>
+        TwoStepNotificationsCTA
+      </div>
+    ),
+  })
+);
+
 function makeArtist(overrides: Partial<Artist> = {}): Artist {
   return {
     id: 'artist-1',
@@ -92,8 +100,15 @@ function makeArtist(overrides: Partial<Artist> = {}): Artist {
   };
 }
 
-describe('ProfilePrimaryCTA loading fallback', () => {
-  it('renders the subscription skeleton while dynamic CTA loads', () => {
+describe('ProfilePrimaryCTA notifications branch', () => {
+  // Previously this test asserted the `SubscriptionFormSkeleton` "Loading
+  // subscription form" copy because `ArtistNotificationsCTA` was dynamically
+  // imported with `ssr: false` and the test mocked `next/dynamic` to surface
+  // the loading fallback. After JOV-2273 the dynamic import was removed —
+  // the CTA renders synchronously without an SSR bailout — so the loading
+  // fallback no longer appears in the first render and the assertion has
+  // been updated to verify the CTA renders directly instead.
+  it('renders the ArtistNotificationsCTA when capture is enabled', () => {
     render(
       <ProfilePrimaryCTA
         artist={makeArtist()}
@@ -102,6 +117,6 @@ describe('ProfilePrimaryCTA loading fallback', () => {
       />
     );
 
-    expect(screen.getByText('Loading subscription form')).toBeInTheDocument();
+    expect(screen.getByTestId('artist-notifications-cta')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2273 -->

## Summary

The `/[username]` profile route currently ships an animated skeleton (from `loading.tsx`) as the initial visible SSR HTML and bails to client-side rendering before the actual profile content streams in. This is because `DesktopQrOverlayClient` (and several sibling components in the profile RSC subtree) used `next/dynamic({ ssr: false })`. React emitted `<template data-dgst=\"BAILOUT_TO_CLIENT_SIDE_RENDERING\">` on the nearest ancestor Suspense — which on this route is the implicit boundary wrapping `loading.tsx`, so the route's skeleton becomes the initial visible HTML for every cold visit.

Fix: drop the `ssr: false` dynamic wrappers and import the components directly. Each component is verified to be SSR-safe (renders `null` on first paint or is gated behind a `useEffect`-resolved layout flag).

## Why this is the right fix

The first iteration of this PR wrapped each `ssr: false` dynamic in a local `<Suspense>` boundary, hoping to contain the bailout. That stopped the bailout from propagating to `loading.tsx` BUT React still emitted the `<template data-dgst=\"BAILOUT_TO_CLIENT_SIDE_RENDERING\">` on the local Suspense fallback — so the marker remained in the HTML, failing JOV-2273's acceptance criterion (\"Curl ... must NOT contain `BAILOUT_TO_CLIENT_SIDE_RENDERING`\").

The right fix is to make the components SSR-safe and remove the deferral, not to wrap the deferral. None of the affected components had a real SSR-incompatibility — they were deferred for bundle-cost reasons but the cost of the visible bailout (skeleton flash + delayed LCP) outweighs the bundle savings on a fully-cached ISR route.

## Changes

| File | What changed |
|------|------|
| `apps/web/components/features/profile/DesktopQrOverlayClient.tsx` | Drop `dynamic({ ssr: false })`. `DesktopQrOverlay` initial state is `mode: 'hidden'` and renders `null` until `useEffect` resolves matchMedia — SSR-safe. |
| `apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx` | Drop `dynamic({ ssr: false })` for `ProfileDesktopSurface`. Only rendered when `isDesktopLayout === true`, which starts `false` during SSR and flips in `useEffect` — never rendered server-side. |
| `apps/web/components/features/profile/ProfilePrimaryCTA.tsx` | Drop `dynamic({ ssr: false })` for `ArtistNotificationsCTA` / `TwoStepNotificationsCTA`. Static markup + Bell icon, SSR-safe. (ProfilePrimaryCTA itself is only consumed by tests; change is preventative.) |
| `apps/web/tests/unit/profile/ProfilePrimaryCTA.loading.test.tsx` | Rewritten to assert the CTA renders directly (the dynamic loader's fallback skeleton no longer fires because there's no async load). |
| `apps/web/app/[username]/layout.tsx` | Document the ISR + client-router-cache layering (closes JOV-2270 as working-as-intended). |

## JOV-2273 acceptance verification

Production HTML (`https://jov.ie/tim`) was inspected before the fix:

```
$ curl -sS https://jov.ie/tim | grep -c BAILOUT_TO_CLIENT_SIDE_RENDERING
1
```

The marker sits immediately after `</main></div></div>` — exactly where `<DesktopQrOverlayClient>` is rendered as a sibling to `<StaticArtistPage>` in `page.tsx`.

After the fix lands, the curl assertion must be empty:

```
$ curl -sS https://jov.ie/tim | grep -c BAILOUT_TO_CLIENT_SIDE_RENDERING
0
```

…and the cover-image `<img>` for the artist should appear in the initial SSR HTML instead of only the streaming RSC chunk.

A dev-mode reproduction confirms the bailout previously emitted after `</main>` (the DesktopQrOverlay bailout) is gone after the change. A second dev-mode bailout from `ReactQueryDevtools` (in `QueryProvider.tsx`) remains, but `DevToolsLoader` returns `null` when `NODE_ENV !== 'development'`, so it does not render in production and does not affect prod HTML.

## JOV-2270 (cache coherence) verdict

Investigation completed during this work. Server ISR and client Router Cache operate independently and correctly:

- **Server ISR** (3600s, busted on mutation): `lib/cache/profile.ts::invalidateProfileCache()` calls both `revalidatePath(\`/${username}\`)` and `revalidateTag(createProfileTag(username))` after every profile/social-link/avatar mutation from the dashboard. The Full Route Cache + Data Cache both bust correctly.
- **Client Router Cache** (300s, `staleTimes.static: 300`): per-browser only, auto-expires every 5 minutes. `revalidateTag` does not (and should not) invalidate the browser router cache — that is by design in Next 15. Worst-case staleness on SPA navigation between profile pages is 5 minutes, which matches the Next 15 default for static-classified routes and is acceptable for public profile content.

Recommended close-out: JOV-2270 → Done (working as intended). Documentation comment added to `layout.tsx` to make the layering explicit for future readers.

## JOV-2271 (49 chunks → ≤30) status

Out of scope for this PR. JOV-2271 is Turbopack chunk-strategy work that needs an `ANALYZE=true` webpack build measurement pass + `experimental.turbopack.moduleIdStrategy` tuning, and should land separately to keep this fix focused. The fix here does not regress chunk count — it removes three `dynamic` wrappers, which may actually reduce chunk count slightly because the inner components are no longer separate chunks.

## Validation

- `pnpm --filter @jovie/web run typecheck -- --pretty false` → exit 0
- `pnpm biome check --write` against the five modified files → clean
- `pnpm --filter web lint:server-boundaries` → clean
- `pnpm --filter web exec vitest run` against affected profile test files (9 files, 17 tests) → all pass:
  - `tests/unit/DesktopQrOverlay.test.tsx` (4)
  - `components/features/profile/templates/ProfileDesktopSurface.test.tsx` (2)
  - `tests/unit/profile/ProfileShell.{tour,notifications,mode-override,dsp-preferences,accessibility}.test.tsx` (9)
  - `tests/unit/profile/ProfilePrimaryCTA.{,loading.}test.tsx` (2)
- Dev server boot smoke test (`next dev --turbopack`): ready in 5.4s, no compile errors. `/tim` curl shows the DesktopQrOverlay-sibling bailout is gone; remaining dev bailout is `ReactQueryDevtools` (dev-only, not in production).
- Local production build (`pnpm build`) exited 143 (esbuild OOM on this machine). CI will run the real production build.

## Test plan

- [ ] CI staging deploy renders `/[username]` without `BAILOUT_TO_CLIENT_SIDE_RENDERING` in the initial HTML
- [ ] Staging `<img>` for the artist cover appears in the initial SSR HTML (filmstrip check via Lighthouse / `curl -sS staging-url/tim | grep -o '<img[^>]*src=\"[^\"]*scdn'`)
- [ ] No skeleton flash on cold load (visual QA on staging.jov.ie/tim)
- [ ] Desktop QR overlay still appears for desktop viewports after hydration
- [ ] Profile compact/desktop switching still works (resize past 1180px)
- [ ] Notification CTAs still render correctly on subscribe flow