### PR TITLE
fix(perf): exclude shell/dashboard dirs from Tailwind scan (JOV-2269)

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -23,6 +23,19 @@
 
 @source "../../../packages/ui";
 @source "../../../node_modules/streamdown/dist/*.js";
+
+/* JOV-2269: Exclude app-shell and dashboard-only source paths from the
+   global Tailwind scan. These directories contain components that are never
+   rendered on public routes (homepage, /[username] profile, marketing pages).
+   Excluding them prevents shell-specific Tailwind utilities (sidebar tokens,
+   dashboard colour-mix variants, shell chrome classes) from being compiled
+   into the shared CSS chunk that is served on every public page.
+   Note: components/shell is intentionally NOT excluded — it is imported by
+   shared organisms (PersistentAudioBar, release-sidebar, etc.) that may
+   render on any route. */
+@source not "../app/app";
+@source not "../components/features/dashboard";
+@source not "../components/features/admin";
 @custom-variant dark (&:is(.dark *));
 
 /* Base document sizing and immediate dark-aware fallback colors */


### PR DESCRIPTION
## Summary

Reduce public-route shared CSS by excluding authenticated app-shell/dashboard-only source paths from the global Tailwind scan.

The rebased PR now changes only `apps/web/app/globals.css`:
- excludes `app/app`
- excludes `components/features/dashboard`
- excludes `components/features/admin`
- keeps `components/shell` in scope because shared surfaces can render it on public routes

## Verification

- `pnpm install --frozen-lockfile` — refreshed stale worktree deps after rebase
- `pnpm exec biome check apps/web/app/globals.css` — pass
- `pnpm --filter @jovie/web run tailwind:check` — pass
- `pnpm --filter @jovie/web run typecheck` — pass
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_mock NEXT_IGNORE_ESLINT=1 NEXT_IGNORE_TYPECHECK=1 NEXT_PRIVATE_SKIP_SIZE_CHECK=true pnpm --filter @jovie/web run build` — pass
- `git diff --check origin/main...HEAD` — pass

## CSS Evidence

Rebased Turbopack build CSS artifacts:

| Chunk | Brotli | Raw |
|---|---:|---:|
| `0175y599xf8~l.css` | 69.6 KB | 738.6 KB |
| `0g7p7tie~8ggw.css` | 13.0 KB | 78.4 KB |

JOV-2269 target is 60 KB brotli. This PR reduces app-shell contamination while keeping the remaining `color-mix()`/shared-component gap assigned to JOV-2278.

<!-- linear-issue-id: JOV-2269 -->