### PR TITLE
feat(shell): unify onboarding chat and lyrics shell

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -180,8 +180,7 @@ export function ChatPageClient({
     isFirstSession: dashboardIsFirstSession,
   } = useDashboardData();
   const { setPreviewData } = usePreviewPanelData();
-  const { isOpen: isPreviewPanelOpen, open: openPreviewPanel } =
-    usePreviewPanelState();
+  const { open: openPreviewPanel } = usePreviewPanelState();
   const router = useRouter();
   const searchParams = useSearchParams();
   const notifications = useNotifications();
@@ -226,11 +225,10 @@ export function ChatPageClient({
   const fromOnboarding = searchParams.get('from') === 'onboarding';
   const panelParam = searchParams.get('panel');
   const designV1ChatEntitiesEnabled = useAppFlag('DESIGN_V1');
-  // Hydrate only when the panel is open, deep-linked, or onboarding requested it.
-  // This keeps closed chat routes cheap while allowing sidebar/mobile profile clicks.
+  // Hydrate the profile panel only for explicit profile entry. Entity mentions
+  // use ChatEntityPanelContext and do not need the profile preview fallback.
   const shouldHydratePreviewPanel =
-    enablePreviewPanel &&
-    (isPreviewPanelOpen || panelParam === 'profile' || fromOnboarding);
+    enablePreviewPanel && panelParam === 'profile';
 
   useEffect(() => {
     if (shouldHydratePreviewPanel) return;

--- a/apps/web/app/app/(shell)/layout.tsx
+++ b/apps/web/app/app/(shell)/layout.tsx
@@ -3,6 +3,7 @@ import { headers } from 'next/headers';
 import { redirect, unstable_rethrow } from 'next/navigation';
 import { Suspense } from 'react';
 import { AppShellSkeleton } from '@/components/organisms/AppShellSkeleton';
+import { LyricsRouteSkeleton } from '@/components/shell/LyricsRouteSkeleton';
 import { APP_ROUTES } from '@/constants/routes';
 import { ErrorBanner } from '@/features/feedback/ErrorBanner';
 import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
@@ -13,6 +14,7 @@ import { DashboardShellContent } from './DashboardShellContent';
 import { ReleaseTableSkeleton } from './dashboard/releases/loading';
 import {
   isChatShellRoute,
+  isLyricsShellRoute,
   isReleasesShellRoute,
   resolveAppShellRequestPath,
 } from './shell-route-matches';
@@ -61,6 +63,13 @@ export default async function AppShellLayout({
       shellFallback = (
         <AppShellSkeleton
           main={<ReleaseTableSkeleton showHeader={false} />}
+          variant={shellVariant}
+        />
+      );
+    } else if (isLyricsShellRoute(pathname)) {
+      shellFallback = (
+        <AppShellSkeleton
+          main={<LyricsRouteSkeleton />}
           variant={shellVariant}
         />
       );

--- a/apps/web/app/app/(shell)/loading.tsx
+++ b/apps/web/app/app/(shell)/loading.tsx
@@ -1,8 +1,10 @@
 import { headers } from 'next/headers';
+import { LyricsRouteSkeleton } from '@/components/shell/LyricsRouteSkeleton';
 import ChatLoading from './chat/loading';
 import { ReleaseTableSkeleton } from './dashboard/releases/loading';
 import {
   isChatShellRoute,
+  isLyricsShellRoute,
   isReleasesShellRoute,
   resolveAppShellRequestPath,
 } from './shell-route-matches';
@@ -29,6 +31,10 @@ export default async function ShellLoading() {
 
   if (isReleasesShellRoute(pathname)) {
     return <ReleaseTableSkeleton showHeader={false} />;
+  }
+
+  if (isLyricsShellRoute(pathname)) {
+    return <LyricsRouteSkeleton />;
   }
 
   return (

--- a/apps/web/app/app/(shell)/lyrics/[trackId]/LyricsPageClient.tsx
+++ b/apps/web/app/app/(shell)/lyrics/[trackId]/LyricsPageClient.tsx
@@ -1,11 +1,15 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 import { useTrackAudioPlayer } from '@/components/organisms/release-sidebar/useTrackAudioPlayer';
 import {
   type LyricLine,
   LyricsView,
   type LyricsViewTrack,
 } from '@/components/shell/LyricsView';
+import { APP_ROUTES } from '@/constants/routes';
+import { isFormElement } from '@/lib/utils/keyboard';
 
 /**
  * Client wrapper for the lyrics route.
@@ -25,8 +29,29 @@ export function LyricsPageClient({
   readonly initialDurationSec: number;
   readonly trackId: string;
 }) {
+  const router = useRouter();
   const { playbackState, seek } = useTrackAudioPlayer();
   const isActive = playbackState.activeTrackId === trackId;
+
+  useEffect(() => {
+    if (isActive) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (
+        event.defaultPrevented ||
+        event.key !== 'Escape' ||
+        isFormElement(event.target)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      router.push(APP_ROUTES.LIBRARY);
+    }
+
+    globalThis.addEventListener('keydown', handleKeyDown);
+    return () => globalThis.removeEventListener('keydown', handleKeyDown);
+  }, [isActive, router]);
 
   const track = {
     title:
@@ -58,6 +83,7 @@ export function LyricsPageClient({
       lines={initialLines}
       onSeek={seek}
       timed={false}
+      autoFocusView
     />
   );
 }

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -10,6 +10,10 @@ import {
   ErrorDisplay,
 } from '@/components/jovie/components';
 import { useChatJankMonitor, useStickToBottom } from '@/components/jovie/hooks';
+import {
+  composeMessage,
+  useChipTray,
+} from '@/components/jovie/hooks/useChipTray';
 import { ToolPartsRenderer } from '@/components/jovie/tool-ui';
 import type { ChatError, MessagePart } from '@/components/jovie/types';
 import {
@@ -66,6 +70,17 @@ interface OnboardingChatProps {
 
 /** Pull the user-visible text out of a UIMessage's parts. */
 const THINKING_PLACEHOLDER_ID = 'thinking-placeholder';
+const ONBOARDING_INTRO_MESSAGE_ID = 'onboarding-intro';
+const ONBOARDING_INTRO_MESSAGE = {
+  id: ONBOARDING_INTRO_MESSAGE_ID,
+  role: 'assistant',
+  parts: [
+    {
+      type: 'text',
+      text: "Hey, I'm Jovie. What are you working on?",
+    },
+  ],
+} satisfies UIMessage;
 
 function getMessageText(message: UIMessage): string {
   return (message.parts ?? [])
@@ -430,12 +445,14 @@ function renderOnboardingTools({
 
 function OnboardingMessageList({
   displayMessages,
+  hideIntroMessage,
   isStreaming,
   lastAssistantMessageId,
   isBusy,
   onSelectArtist,
 }: {
   readonly displayMessages: readonly UIMessage[];
+  readonly hideIntroMessage: boolean;
   readonly isStreaming: boolean;
   readonly lastAssistantMessageId: string | null;
   readonly isBusy: boolean;
@@ -447,11 +464,25 @@ function OnboardingMessageList({
         const text = getMessageText(message);
         const toolParts = getToolParts(message);
         const isThinking = message.id === THINKING_PLACEHOLDER_ID;
+        const isIntroHidden =
+          hideIntroMessage && message.id === ONBOARDING_INTRO_MESSAGE_ID;
         const shouldRenderMessage =
           isThinking || Boolean(text) || toolParts.length === 0;
 
         return (
-          <div key={message.id} className='pb-5'>
+          <div
+            key={message.id}
+            className={cn(
+              'pb-5 transition-opacity duration-fast',
+              isIntroHidden && 'pointer-events-none opacity-0'
+            )}
+            aria-hidden={isIntroHidden ? 'true' : undefined}
+            data-testid={
+              message.id === ONBOARDING_INTRO_MESSAGE_ID
+                ? 'onboarding-intro-message'
+                : undefined
+            }
+          >
             {shouldRenderMessage ? (
               <ChatMessage
                 id={message.id}
@@ -491,6 +522,7 @@ export function OnboardingChat({
   const [composerPickerOpen, setComposerPickerOpen] = useState(false);
   const [selectedArtist, setSelectedArtist] =
     useState<OnboardingArtistSelection | null>(null);
+  const chipTray = useChipTray();
   const completedUserTurnsRef = useRef(0);
   const lastAttemptedMessageRef = useRef<string | null>(null);
   const formatArtistSelectionMessage = useArtistSelectionMessage();
@@ -544,6 +576,7 @@ export function OnboardingChat({
   const shouldShowThinking = isBusy && lastMessage?.role === 'user';
   const displayMessages: readonly UIMessage[] = shouldShowThinking
     ? [
+        ONBOARDING_INTRO_MESSAGE,
         ...messages,
         {
           id: THINKING_PLACEHOLDER_ID,
@@ -551,7 +584,7 @@ export function OnboardingChat({
           parts: [],
         },
       ]
-    : messages;
+    : [ONBOARDING_INTRO_MESSAGE, ...messages];
   const lastAssistantMessageId = findLastAssistantMessageId(displayMessages);
   const { isStuckToBottom, onScroll, totalSizeRef, scrollContainerRef } =
     useStickToBottom({ messageCount: displayMessages.length });
@@ -567,7 +600,7 @@ export function OnboardingChat({
 
   const submitText = useCallback(
     (rawText: string) => {
-      const text = rawText.trim();
+      const text = composeMessage(chipTray.chips, rawText).trim();
       if (!text || isBusy) return;
       if (isAwaitingFirstToken) {
         // Turnstile hasn't issued a token yet; the widget normally resolves
@@ -578,10 +611,11 @@ export function OnboardingChat({
       setChatError(null);
       notifyJankSend();
       sendMessage({ text });
+      chipTray.clear();
       setHasSentFirst(true);
       setInput('');
     },
-    [isAwaitingFirstToken, isBusy, notifyJankSend, sendMessage]
+    [chipTray, isAwaitingFirstToken, isBusy, notifyJankSend, sendMessage]
   );
 
   const handleSubmit = useCallback(
@@ -607,11 +641,15 @@ export function OnboardingChat({
   );
 
   const profileBuilderState = useMemo(
-    () => deriveProfileBuilderState({ messages, selectedArtist }),
-    [messages, selectedArtist]
+    () =>
+      onProfileBuilderChange
+        ? deriveProfileBuilderState({ messages, selectedArtist })
+        : null,
+    [messages, onProfileBuilderChange, selectedArtist]
   );
 
   useEffect(() => {
+    if (!profileBuilderState) return;
     onProfileBuilderChange?.(profileBuilderState);
   }, [onProfileBuilderChange, profileBuilderState]);
 
@@ -668,27 +706,14 @@ export function OnboardingChat({
           ref={totalSizeRef}
           className='mx-auto flex min-h-full w-full max-w-[44rem] flex-col'
         >
-          {messages.length === 0 ? (
-            <div className='flex flex-1 items-center justify-center py-12'>
-              <h1
-                className={cn(
-                  'text-balance text-center text-[2.25rem] font-semibold leading-[1.08] tracking-[-0.035em] text-primary-token transition-opacity duration-fast sm:text-[3rem]',
-                  composerPickerOpen && 'opacity-0'
-                )}
-                aria-hidden={composerPickerOpen}
-              >
-                What are you working on?
-              </h1>
-            </div>
-          ) : (
-            <OnboardingMessageList
-              displayMessages={displayMessages}
-              isStreaming={isStreaming}
-              lastAssistantMessageId={lastAssistantMessageId}
-              isBusy={isBusy}
-              onSelectArtist={handleArtistSelect}
-            />
-          )}
+          <OnboardingMessageList
+            displayMessages={displayMessages}
+            hideIntroMessage={composerPickerOpen}
+            isStreaming={isStreaming}
+            lastAssistantMessageId={lastAssistantMessageId}
+            isBusy={isBusy}
+            onSelectArtist={handleArtistSelect}
+          />
         </div>
       </div>
 
@@ -716,6 +741,11 @@ export function OnboardingChat({
               isAwaitingFirstToken ? 'Securing chat...' : 'Ask Jovie...'
             }
             onPickerOpenChange={setComposerPickerOpen}
+            chips={chipTray.chips}
+            onRemoveChipAt={chipTray.removeAt}
+            onRemoveLastChip={chipTray.removeLast}
+            onAddSkill={chipTray.addSkill}
+            onAddEntity={chipTray.addEntity}
             shellChatV1
             statusBanner={composerStatusBanner}
           />

--- a/apps/web/components/features/onboarding/OnboardingProfileRail.tsx
+++ b/apps/web/components/features/onboarding/OnboardingProfileRail.tsx
@@ -1,8 +1,16 @@
 'use client';
 
-import { Check, Circle, Gauge, Music2, UserRound, Users } from 'lucide-react';
+import {
+  Circle,
+  CircleCheckBig,
+  Gauge,
+  Music2,
+  UserRound,
+  Users,
+} from 'lucide-react';
 import Image from 'next/image';
 import type { ReactNode } from 'react';
+import { SocialIcon } from '@/components/atoms/SocialIcon';
 import { cn } from '@/lib/utils';
 import {
   formatCompactCount,
@@ -79,6 +87,48 @@ function RailAvatar({ artist }: { readonly artist: OnboardingProfileArtist }) {
   );
 }
 
+function RailMatchBadge({
+  artistName,
+  href,
+  label,
+  tone,
+}: {
+  readonly artistName: string;
+  readonly href: string | null;
+  readonly label: string;
+  readonly tone: 'matched' | 'selected';
+}) {
+  const className = cn(
+    'inline-flex h-5 shrink-0 items-center gap-1 rounded-full border px-1.5 text-[10.5px] font-medium leading-5 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20',
+    tone === 'matched'
+      ? 'border-green-500/20 text-green-500'
+      : 'border-cyan-400/20 text-cyan-300',
+    href && 'hover:bg-surface-2'
+  );
+  const content = (
+    <>
+      <SocialIcon platform='spotify' className='h-3 w-3' aria-hidden />
+      <span>{label}</span>
+    </>
+  );
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        target='_blank'
+        rel='noreferrer'
+        className={className}
+        aria-label={`Open ${artistName} on Spotify`}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return <span className={className}>{content}</span>;
+}
+
 function RailMetric({
   children,
   icon,
@@ -115,19 +165,22 @@ function TimelineItem({
     <li className='relative z-10 grid grid-cols-[18px_minmax(0,1fr)] gap-2.5 max-lg:gap-2'>
       <span
         className={cn(
-          'mt-0.5 flex h-[18px] w-[18px] items-center justify-center rounded-full border',
+          'mt-0.5 flex h-[18px] w-[18px] items-center justify-center',
           state === 'done'
-            ? 'border-green-500/25 bg-green-500/10 text-green-500'
+            ? 'text-green-500'
             : state === 'active'
-              ? 'border-cyan-400/25 bg-cyan-400/10 text-cyan-300'
-              : 'border-subtle bg-surface-0 text-tertiary-token'
+              ? 'text-cyan-300'
+              : 'text-tertiary-token'
         )}
         aria-hidden
       >
         {state === 'done' ? (
-          <Check className='h-3 w-3' />
+          <CircleCheckBig className='h-[18px] w-[18px]' strokeWidth={2.65} />
         ) : (
-          <Circle className='h-2 w-2 fill-current' />
+          <Circle
+            className={cn('h-2.5 w-2.5', state === 'active' && 'fill-current')}
+            strokeWidth={2.4}
+          />
         )}
       </span>
       <span className='min-w-0'>
@@ -148,8 +201,10 @@ function TimelineItem({
 }
 
 export function OnboardingProfileRail({
+  placement = 'side',
   state,
 }: {
+  readonly placement?: 'inline' | 'side';
   readonly state: OnboardingProfileBuilderState;
 }) {
   const artist = state.artist;
@@ -159,22 +214,33 @@ export function OnboardingProfileRail({
   const genres = artist?.genres?.slice(0, 2).map(formatGenreLabel) ?? [];
   const firstSocialLink = state.socialLinks[0] ?? null;
   const safeArtistUrl = getSafeSpotifyArtistUrl(artist?.url);
+  const isInline = placement === 'inline';
 
   return (
     <aside
       className={cn(
-        'z-30 overflow-hidden bg-(--linear-app-content-surface) text-primary-token transition-[opacity,transform,width,border-color] duration-cinematic ease-out',
-        'max-lg:absolute max-lg:inset-x-3 max-lg:bottom-[calc(5.25rem+env(safe-area-inset-bottom))] max-lg:max-h-[44vh] max-lg:w-auto max-lg:rounded-2xl max-lg:border max-lg:shadow-[0_24px_80px_rgba(0,0,0,0.45)]',
-        'lg:relative lg:h-full lg:border-l lg:border-(--linear-app-shell-border)',
+        'overflow-hidden bg-(--linear-app-content-surface) text-primary-token transition-[opacity,transform,width,border-color] duration-cinematic ease-out',
+        isInline
+          ? 'relative z-0 w-full rounded-2xl border border-(--linear-app-shell-border)'
+          : 'z-30 max-lg:hidden lg:relative lg:h-full lg:border-l lg:border-(--linear-app-shell-border)',
         visible
-          ? 'pointer-events-auto translate-y-0 opacity-100 lg:w-[322px] lg:translate-x-0'
-          : 'pointer-events-none translate-y-4 opacity-0 lg:w-0 lg:translate-x-3'
+          ? cn(
+              'pointer-events-auto opacity-100',
+              isInline ? 'translate-y-0' : 'lg:w-[322px] lg:translate-x-0'
+            )
+          : cn(
+              'pointer-events-none opacity-0',
+              isInline ? 'hidden' : 'lg:w-0 lg:translate-x-3'
+            )
       )}
       aria-hidden={!visible}
-      data-testid='onboarding-profile-rail'
+      data-testid={
+        isInline ? 'onboarding-profile-rail-inline' : 'onboarding-profile-rail'
+      }
       data-visible={visible ? 'true' : 'false'}
+      data-placement={placement}
     >
-      <div className='max-lg:max-h-[44vh] max-lg:overflow-y-auto lg:w-[322px]'>
+      <div className={cn(!isInline && 'lg:w-[322px]')}>
         <div className='border-b border-(--linear-app-shell-border) px-4 py-3.5 max-lg:px-3.5 max-lg:py-3'>
           <p className='text-[12px] font-medium leading-5 text-secondary-token'>
             Artist Profile
@@ -194,27 +260,13 @@ export function OnboardingProfileRail({
                     <p className='truncate text-[13.5px] font-semibold leading-5 text-primary-token'>
                       {artist.name}
                     </p>
-                    <span
-                      className={cn(
-                        'h-5 shrink-0 rounded-full border px-1.5 text-[10.5px] font-medium leading-5',
-                        state.artistConfirmed
-                          ? 'border-green-500/20 text-green-500'
-                          : 'border-cyan-400/20 text-cyan-300'
-                      )}
-                    >
-                      {state.artistConfirmed ? 'Matched' : 'Selected'}
-                    </span>
-                  </div>
-                  {safeArtistUrl ? (
-                    <a
+                    <RailMatchBadge
+                      artistName={artist.name}
                       href={safeArtistUrl}
-                      target='_blank'
-                      rel='noreferrer'
-                      className='mt-0.5 block truncate text-[12px] leading-5 text-tertiary-token transition-colors hover:text-secondary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20'
-                    >
-                      {hostnameFor(safeArtistUrl)}
-                    </a>
-                  ) : null}
+                      label={state.artistConfirmed ? 'Matched' : 'Selected'}
+                      tone={state.artistConfirmed ? 'matched' : 'selected'}
+                    />
+                  </div>
                 </div>
               </div>
 

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -5,11 +5,6 @@ import { AppShellFrame } from '@/components/organisms/AppShellFrame';
 import { SidebarProvider } from '@/components/organisms/Sidebar';
 import { cn } from '@/lib/utils';
 import { OnboardingChat } from './OnboardingChat';
-import {
-  EMPTY_ONBOARDING_PROFILE_BUILDER_STATE,
-  type OnboardingProfileBuilderState,
-  OnboardingProfileRail,
-} from './OnboardingProfileRail';
 import { OnboardingTurnstile } from './OnboardingTurnstile';
 import { useOnboardingClaim } from './useOnboardingClaim';
 
@@ -23,52 +18,10 @@ interface OnboardingShellProps {
   readonly sessionLabel: string;
 }
 
-function areStringArraysEqual(
-  left: readonly string[],
-  right: readonly string[]
-): boolean {
-  return (
-    left.length === right.length && left.every((item, i) => item === right[i])
-  );
-}
-
-function areProfileArtistsEqual(
-  left: OnboardingProfileBuilderState['artist'],
-  right: OnboardingProfileBuilderState['artist']
-): boolean {
-  if (left === right) return true;
-  if (!left || !right) return false;
-  return (
-    left.id === right.id &&
-    left.name === right.name &&
-    left.url === right.url &&
-    left.imageUrl === right.imageUrl &&
-    left.followers === right.followers &&
-    left.popularity === right.popularity &&
-    areStringArraysEqual(left.genres ?? [], right.genres ?? [])
-  );
-}
-
-function areProfileBuilderStatesEqual(
-  left: OnboardingProfileBuilderState,
-  right: OnboardingProfileBuilderState
-): boolean {
-  return (
-    left.artistConfirmed === right.artistConfirmed &&
-    left.handle === right.handle &&
-    areProfileArtistsEqual(left.artist, right.artist) &&
-    areStringArraysEqual(left.socialLinks, right.socialLinks)
-  );
-}
-
 export function OnboardingShell({ sessionLabel }: OnboardingShellProps) {
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   const [turnstileError, setTurnstileError] = useState<string | null>(null);
   const [claimTrigger, setClaimTrigger] = useState(0);
-  const [profileBuilderState, setProfileBuilderState] =
-    useState<OnboardingProfileBuilderState>(
-      EMPTY_ONBOARDING_PROFILE_BUILDER_STATE
-    );
 
   const handleConversationActivity = useCallback(() => {
     setClaimTrigger(current => current + 1);
@@ -83,15 +36,6 @@ export function OnboardingShell({ sessionLabel }: OnboardingShellProps) {
     setTurnstileError(message);
   }, []);
 
-  const handleProfileBuilderChange = useCallback(
-    (nextState: OnboardingProfileBuilderState) => {
-      setProfileBuilderState(current =>
-        areProfileBuilderStatesEqual(current, nextState) ? current : nextState
-      );
-    },
-    []
-  );
-
   // Auto-claim any anonymous transcript onto the user the moment Clerk
   // reports they're authenticated, then retry after completed chat turns.
   // On success, this hook navigates away to
@@ -100,8 +44,6 @@ export function OnboardingShell({ sessionLabel }: OnboardingShellProps) {
   const claimStatus = useOnboardingClaim(claimTrigger);
   const isLinking =
     claimStatus === 'pending' || claimStatus === 'retry-after-webhook';
-  const shouldShowProfileRail = Boolean(profileBuilderState.artist);
-
   return (
     <SidebarProvider defaultOpen={false}>
       <AppShellFrame
@@ -116,7 +58,6 @@ export function OnboardingShell({ sessionLabel }: OnboardingShellProps) {
           >
             <OnboardingChat
               onConversationActivity={handleConversationActivity}
-              onProfileBuilderChange={handleProfileBuilderChange}
               turnstileToken={turnstileToken}
             />
 
@@ -132,11 +73,7 @@ export function OnboardingShell({ sessionLabel }: OnboardingShellProps) {
             />
           </div>
         }
-        rightPanel={
-          shouldShowProfileRail ? (
-            <OnboardingProfileRail state={profileBuilderState} />
-          ) : null
-        }
+        rightPanel={null}
       />
 
       <OnboardingTurnstile

--- a/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
+++ b/apps/web/components/features/onboarding/OnboardingToolArtifacts.tsx
@@ -14,6 +14,7 @@ import {
 import Image from 'next/image';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
+import { SocialIcon } from '@/components/atoms/SocialIcon';
 import type { SpotifyArtistResult } from '@/lib/contracts/api';
 import { useArtistSearchQuery } from '@/lib/queries/useArtistSearchQuery';
 import { useHandleAvailabilityQuery } from '@/lib/queries/useHandleAvailabilityQuery';
@@ -97,7 +98,21 @@ export function formatExactCount(
 }
 
 export function formatGenreLabel(genre: string): string {
-  return genre.trim().toUpperCase();
+  return genre
+    .trim()
+    .replaceAll(/\s+/g, ' ')
+    .split(' ')
+    .map(word =>
+      word
+        .split('-')
+        .map(part =>
+          part
+            ? `${part.charAt(0).toUpperCase()}${part.slice(1).toLowerCase()}`
+            : part
+        )
+        .join('-')
+    )
+    .join(' ');
 }
 
 function formatFollowers(count: number | null | undefined): string | null {
@@ -155,9 +170,9 @@ function StatusShell({
       <div className='flex items-start gap-3'>
         <span
           className={cn(
-            'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border border-subtle bg-surface-0 text-secondary-token',
-            tone === 'error' && 'border-red-500/20 text-red-400',
-            tone === 'success' && 'border-green-500/20 text-green-500'
+            'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center text-secondary-token',
+            tone === 'error' && 'text-red-400',
+            tone === 'success' && 'text-green-500'
           )}
         >
           {icon}
@@ -248,6 +263,15 @@ function MetadataChip({
       ) : null}
       <span className='sr-only'>{title}</span>
       <span aria-hidden>{children}</span>
+    </span>
+  );
+}
+
+function SpotifyMatchBadge({ label }: { readonly label: string }) {
+  return (
+    <span className='inline-flex h-5 shrink-0 items-center gap-1 rounded-full border border-green-500/20 px-1.5 text-[10.5px] font-medium text-green-500'>
+      <SocialIcon platform='spotify' className='h-3 w-3' aria-hidden />
+      <span>{label}</span>
     </span>
   );
 }
@@ -512,9 +536,7 @@ export function OnboardingArtistConfirmedCard({
             <p className='truncate text-[14.5px] font-semibold leading-5 tracking-[-0.01em] text-primary-token'>
               {artist.name}
             </p>
-            <span className='inline-flex h-5 shrink-0 items-center rounded-full border border-green-500/20 px-1.5 text-[10.5px] font-medium text-green-500'>
-              Matched
-            </span>
+            <SpotifyMatchBadge label='Matched' />
           </div>
           {hasMetadata ? (
             <div className='mt-2 flex flex-wrap gap-1.5'>
@@ -674,7 +696,7 @@ export function OnboardingSocialLinkCard({
 export function useArtistSelectionMessage() {
   return useMemo(
     () => (artist: OnboardingArtistSelection) =>
-      `I picked ${artist.name} on Spotify. Let's build my artist profile from here: ${artist.url}.`,
+      `I picked ${artist.name} on Spotify. Let's build my artist profile from that match.`,
     []
   );
 }

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -29,6 +29,14 @@ import type { JovieChatProps, MessagePart } from './types';
 const THINKING_PLACEHOLDER_ID = 'thinking-placeholder';
 const VIRTUALIZATION_THRESHOLD = 12;
 
+export function getFirstNameForGreeting(
+  name: string | null | undefined
+): string | null {
+  const trimmed = name?.trim();
+  if (!trimmed) return null;
+  return trimmed.split(/\s+/)[0] ?? null;
+}
+
 function findLastAssistantIndex(
   messages: readonly { id: string; role: string }[]
 ): number {
@@ -374,7 +382,8 @@ export function JovieChat({
     profileId,
   } as const;
 
-  const greetingName = displayName?.trim() || username?.trim() || null;
+  const greetingName =
+    getFirstNameForGreeting(displayName) ?? getFirstNameForGreeting(username);
   let emptyStateHeading: string;
   if (isFirstSession) {
     emptyStateHeading = 'Welcome to Jovie';

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -164,6 +164,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
     const isOverLimit = characterCount > MAX_MESSAGE_LENGTH;
     const hasAttachButton = Boolean(onImageAttach);
     const hasPendingImages = (pendingImages?.length ?? 0) > 0;
+    const hasChips = (chips?.length ?? 0) > 0;
 
     const [plusMenuOpen, setPlusMenuOpen] = useState(false);
     const [isFocused, setIsFocused] = useState(false);
@@ -219,7 +220,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
     // is open above it and Enter is committing the active row, not sending.
     const sendBlockedByPicker = isPickerOpen && value.trim() === '/';
     const canSend =
-      Boolean(value.trim() || hasPendingImages) &&
+      Boolean(value.trim() || hasPendingImages || hasChips) &&
       !isLoading &&
       !isSubmitting &&
       !isOverLimit &&

--- a/apps/web/components/organisms/AuthShellWrapper.tsx
+++ b/apps/web/components/organisms/AuthShellWrapper.tsx
@@ -104,7 +104,9 @@ function AuthShellWrapperInner({
   const previewEnabled =
     config.section === 'dashboard' || config.isArtistProfileSettings;
   const shouldDefaultOpenPreviewPanel =
-    config.section === 'dashboard' && previewPanelDefaultOpen;
+    config.section === 'dashboard' &&
+    !config.isChatRoute &&
+    previewPanelDefaultOpen;
   const previewPanelScope = config.isArtistProfileSettings
     ? 'artist-profile-settings'
     : 'app-shell';

--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -3,7 +3,7 @@
 import { Pause, Play, X } from 'lucide-react';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { SeekBar } from '@/components/atoms/SeekBar';
 import { TruncatedText } from '@/components/atoms/TruncatedText';
@@ -11,7 +11,7 @@ import { useTrackAudioPlayer } from '@/components/organisms/release-sidebar/useT
 import { AudioBar, type AudioBarTrack } from '@/components/shell/AudioBar';
 import { SidebarBottomNowPlaying } from '@/components/shell/SidebarBottomNowPlaying';
 import { SidebarNowPlaying } from '@/components/shell/SidebarNowPlaying';
-import { buildLyricsRoute } from '@/constants/routes';
+import { APP_ROUTES, buildLyricsRoute } from '@/constants/routes';
 import { useAppFlag } from '@/lib/flags/client';
 import { cn } from '@/lib/utils';
 import { formatDuration } from '@/lib/utils/formatDuration';
@@ -26,6 +26,13 @@ interface PersistentAudioBarProps {
 const SHELL_AUDIO_BAR_TRANSITION =
   'max-height var(--duration-cinematic) var(--ease-cinematic), opacity var(--duration-cinematic) var(--ease-cinematic), transform var(--duration-cinematic) var(--ease-cinematic)';
 
+function isLyricsRoutePath(pathname: string | null): boolean {
+  return (
+    pathname === APP_ROUTES.LYRICS ||
+    Boolean(pathname?.startsWith(`${APP_ROUTES.LYRICS}/`))
+  );
+}
+
 export function PersistentAudioBar({
   variant = 'legacy',
 }: Readonly<PersistentAudioBarProps>) {
@@ -37,6 +44,7 @@ export function PersistentAudioBar({
   const [imgError, setImgError] = useState(false);
   const [barCollapsed, setBarCollapsed] = useState(false);
   const [waveformOn, setWaveformOn] = useState(true);
+  const lastNonLyricsPathRef = useRef<string>(APP_ROUTES.LIBRARY);
 
   useEffect(() => {
     return onError(() => {
@@ -52,6 +60,12 @@ export function PersistentAudioBar({
     setBarCollapsed(false);
   }, [playbackState.activeTrackId]);
 
+  useEffect(() => {
+    if (!isLyricsRoutePath(pathname) && pathname) {
+      lastNonLyricsPathRef.current = pathname;
+    }
+  }, [pathname]);
+
   const handleToggle = useCallback(() => {
     if (playbackState.playbackStatus === 'loading') return;
     if (!playbackState.activeTrackId || !playbackState.trackTitle) return;
@@ -66,10 +80,19 @@ export function PersistentAudioBar({
     toggleTrack,
   ]);
 
+  const handleCloseLyrics = useCallback(() => {
+    router.push(lastNonLyricsPathRef.current);
+  }, [router]);
+
   const handleOpenLyrics = useCallback(() => {
     if (!playbackState.activeTrackId) return;
-    router.push(buildLyricsRoute(playbackState.activeTrackId));
-  }, [playbackState.activeTrackId, router]);
+    const lyricsPath = buildLyricsRoute(playbackState.activeTrackId);
+    if (pathname === lyricsPath) {
+      handleCloseLyrics();
+      return;
+    }
+    router.push(lyricsPath);
+  }, [handleCloseLyrics, pathname, playbackState.activeTrackId, router]);
 
   const activeTrackId = playbackState.activeTrackId;
 
@@ -82,6 +105,12 @@ export function PersistentAudioBar({
       const hasModifier = event.metaKey || event.ctrlKey || event.altKey;
       const plainKey = !hasModifier && !event.shiftKey;
       const key = event.key.toLowerCase();
+
+      if (event.key === 'Escape' && isLyricsRoutePath(pathname)) {
+        event.preventDefault();
+        handleCloseLyrics();
+        return;
+      }
 
       if (event.key === ' ' && plainKey) {
         event.preventDefault();
@@ -128,8 +157,10 @@ export function PersistentAudioBar({
   }, [
     activeTrackId,
     designV1LyricsEnabled,
+    handleCloseLyrics,
     handleOpenLyrics,
     handleToggle,
+    pathname,
     playbackState.hasLyrics,
     variant,
   ]);

--- a/apps/web/components/shell/AudioBar.tsx
+++ b/apps/web/components/shell/AudioBar.tsx
@@ -139,7 +139,7 @@ export function AudioBar({
         <button
           type='button'
           onClick={onPlay}
-          className='h-8 w-8 rounded-full grid place-items-center bg-primary text-on-primary transition-colors duration-150 ease-out hover:bg-primary/90'
+          className='h-8 w-8 rounded-full grid place-items-center bg-primary text-on-primary transition-colors duration-subtle ease-subtle hover:bg-primary/90'
           aria-label={isPlaying ? 'Pause (space)' : 'Play (space)'}
         >
           {isPlaying ? (
@@ -176,7 +176,7 @@ export function AudioBar({
     <div className='flex items-center gap-1.5 justify-self-end'>
       {track.hasLyrics && onOpenLyrics && (
         <IconBtn
-          label='Lyrics'
+          label={lyricsActive ? 'Close lyrics' : 'Lyrics'}
           shortcut={SHORTCUTS.toggleLyrics}
           onClick={onOpenLyrics}
           active={lyricsActive}

--- a/apps/web/components/shell/LyricsRouteSkeleton.tsx
+++ b/apps/web/components/shell/LyricsRouteSkeleton.tsx
@@ -1,0 +1,47 @@
+const LYRIC_LINES = [
+  { key: 'opening', width: '92%' },
+  { key: 'response', width: '76%' },
+  { key: 'lift', width: '88%' },
+  { key: 'turn', width: '64%' },
+  { key: 'resolve', width: '84%' },
+  { key: 'outro', width: '72%' },
+] as const;
+
+export function LyricsRouteSkeleton() {
+  return (
+    <section
+      aria-label='Loading lyrics'
+      aria-busy='true'
+      aria-live='polite'
+      className='flex h-full min-h-0 flex-col bg-(--linear-app-content-surface)'
+    >
+      <header className='flex h-16 shrink-0 items-center justify-between gap-4 border-b border-(--linear-app-shell-border) px-6'>
+        <div className='min-w-0 space-y-2'>
+          <div className='skeleton h-5 w-44 rounded-md' />
+          <div className='skeleton h-3.5 w-28 rounded' />
+        </div>
+        <div className='skeleton h-8 w-8 rounded-full' />
+      </header>
+
+      <div className='min-h-0 flex-1 overflow-hidden'>
+        <div className='mx-auto flex h-full max-w-2xl flex-col justify-center px-6 py-10'>
+          <div className='space-y-5'>
+            {LYRIC_LINES.map(line => (
+              <div
+                key={`lyrics-loading-line-${line.key}`}
+                className='skeleton h-7 rounded-lg'
+                style={{ width: line.width }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <footer className='flex h-14 shrink-0 items-center gap-4 border-t border-(--linear-app-shell-border) px-6'>
+        <div className='skeleton h-3 w-10 rounded' />
+        <div className='skeleton h-1.5 flex-1 rounded-full' />
+        <div className='skeleton h-3 w-10 rounded' />
+      </footer>
+    </section>
+  );
+}

--- a/apps/web/components/shell/LyricsView.tsx
+++ b/apps/web/components/shell/LyricsView.tsx
@@ -2,7 +2,7 @@
 
 import { Mic2, Sparkles } from 'lucide-react';
 import type { KeyboardEvent } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { LyricRow } from './LyricRow';
 import { LyricsHeader } from './LyricsHeader';
@@ -49,6 +49,7 @@ export function LyricsView({
   onPaste,
   editing = false,
   timed = true,
+  autoFocusView = false,
   className,
 }: {
   readonly track: LyricsViewTrack;
@@ -62,9 +63,11 @@ export function LyricsView({
   readonly onPaste?: () => void;
   readonly editing?: boolean;
   readonly timed?: boolean;
+  readonly autoFocusView?: boolean;
   readonly className?: string;
 }) {
   const [focusedIndex, setFocusedIndex] = useState(0);
+  const lyricsRootRef = useRef<HTMLElement | null>(null);
 
   const activeIndex = useMemo(() => {
     // Scan every line — caller may have edited a stamp out of order
@@ -83,6 +86,12 @@ export function LyricsView({
   useEffect(() => {
     if (activeIndex >= 0) setFocusedIndex(activeIndex);
   }, [activeIndex]);
+
+  useEffect(() => {
+    if (autoFocusView && lines.length > 0) {
+      lyricsRootRef.current?.focus({ preventScroll: true });
+    }
+  }, [autoFocusView, lines.length]);
 
   function stampLine(index: number) {
     if (!onLinesChange) return;
@@ -138,7 +147,7 @@ export function LyricsView({
                 <button
                   type='button'
                   onClick={onTranscribe}
-                  className='inline-flex items-center gap-1.5 h-8 px-4 rounded-full bg-white text-black text-[12.5px] font-caption tracking-[-0.005em] hover:brightness-110 active:scale-[0.99] transition-all duration-150 ease-out'
+                  className='inline-flex items-center gap-1.5 h-8 px-4 rounded-full bg-white text-black text-[12.5px] font-caption tracking-[-0.005em] transition-[filter] duration-subtle ease-subtle hover:brightness-110'
                 >
                   <Sparkles className='h-3.5 w-3.5' strokeWidth={2.25} />
                   Transcribe with Jovie
@@ -148,7 +157,7 @@ export function LyricsView({
                 <button
                   type='button'
                   onClick={onPaste}
-                  className='inline-flex items-center h-8 px-4 rounded-full border border-(--linear-app-shell-border) bg-surface-1/60 text-[12.5px] font-caption text-secondary-token tracking-[-0.005em] transition-colors duration-150 ease-out hover:text-primary-token hover:bg-surface-1'
+                  className='inline-flex items-center h-8 px-4 rounded-full border border-(--linear-app-shell-border) bg-surface-1/60 text-[12.5px] font-caption text-secondary-token tracking-[-0.005em] transition-colors duration-subtle ease-subtle hover:text-primary-token hover:bg-surface-1'
                 >
                   Paste lyrics
                 </button>
@@ -163,6 +172,7 @@ export function LyricsView({
   return (
     // biome-ignore lint/a11y/noNoninteractiveElementInteractions: keyboard list root for J/K + Enter, mirrors TracksView
     <section
+      ref={lyricsRootRef}
       className={cn('flex h-full flex-col focus:outline-none', className)}
       // biome-ignore lint/a11y/noNoninteractiveTabindex: keyboard entry point for J/K + Enter navigation
       tabIndex={0}

--- a/apps/web/components/shell/__tests__/AudioBar.test.tsx
+++ b/apps/web/components/shell/__tests__/AudioBar.test.tsx
@@ -44,6 +44,18 @@ describe('AudioBar', () => {
     expect(screen.getByLabelText(/^Lyrics/)).toBeInTheDocument();
   });
 
+  it('labels the lyrics button as a close action when active', () => {
+    render(
+      <AudioBar
+        {...baseProps}
+        track={{ ...baseTrack, hasLyrics: true }}
+        onOpenLyrics={() => {}}
+        lyricsActive
+      />
+    );
+    expect(screen.getByLabelText(/^Close lyrics/)).toBeInTheDocument();
+  });
+
   it('calls onPlay when the play button is pressed', () => {
     const onPlay = vi.fn();
     render(<AudioBar {...baseProps} onPlay={onPlay} />);

--- a/apps/web/hooks/useAuthRouteConfig.ts
+++ b/apps/web/hooks/useAuthRouteConfig.ts
@@ -19,6 +19,7 @@ export interface AuthRouteConfig {
   showMobileTabs: boolean;
   isTableRoute: boolean;
   isArtistProfileSettings: boolean;
+  isChatRoute: boolean;
   isDemoRoute: boolean;
   showChatUsageIndicator: boolean;
 }
@@ -159,8 +160,10 @@ export function useAuthRouteConfig(): AuthRouteConfig {
     [pathname]
   );
 
-  const showChatUsageIndicator = useMemo(
-    () => pathname.startsWith(`${APP_ROUTES.CHAT}/`),
+  const isChatRoute = useMemo(
+    () =>
+      pathname === APP_ROUTES.CHAT ||
+      pathname.startsWith(`${APP_ROUTES.CHAT}/`),
     [pathname]
   );
 
@@ -170,7 +173,8 @@ export function useAuthRouteConfig(): AuthRouteConfig {
     showMobileTabs,
     isTableRoute,
     isArtistProfileSettings,
+    isChatRoute,
     isDemoRoute,
-    showChatUsageIndicator,
+    showChatUsageIndicator: isChatRoute,
   };
 }

--- a/apps/web/lib/services/onboarding/welcome-message.test.ts
+++ b/apps/web/lib/services/onboarding/welcome-message.test.ts
@@ -47,12 +47,13 @@ describe('buildWelcomeMessage', () => {
   });
 
   describe('basic message structure', () => {
-    it('includes the artist display name', () => {
+    it('greets with the first name from the artist display name', () => {
       const message = buildWelcomeMessage({
         ...BASE_PARAMS,
         careerHighlights: null,
       });
-      expect(message).toContain('Welcome to Jovie, Test Artist.');
+      expect(message).toContain('Welcome to Jovie, Test.');
+      expect(message).not.toContain('Welcome to Jovie, Test Artist.');
     });
 
     it('falls back to "there" for empty display name', () => {

--- a/apps/web/lib/services/onboarding/welcome-message.ts
+++ b/apps/web/lib/services/onboarding/welcome-message.ts
@@ -9,6 +9,11 @@ function formatCount(value: number, singular: string, plural = `${singular}s`) {
   return `${value} ${value === 1 ? singular : plural}`;
 }
 
+function getFirstName(displayName: string): string {
+  const trimmed = displayName.trim();
+  return trimmed.split(/\s+/)[0] ?? '';
+}
+
 export interface WelcomeMessageParams {
   displayName: string;
   releaseCount: number;
@@ -26,7 +31,7 @@ export function buildWelcomeMessage({
   socialCount,
   careerHighlights,
 }: WelcomeMessageParams) {
-  const resolvedName = displayName.trim() || 'there';
+  const resolvedName = getFirstName(displayName) || 'there';
   const musicSummary =
     trackCount > 0
       ? formatCount(trackCount, 'track')

--- a/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
+++ b/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildLyricsRoute } from '@/constants/routes';
+import { APP_ROUTES, buildLyricsRoute } from '@/constants/routes';
 import { AppFlagProvider } from '@/lib/flags/client';
 import { APP_FLAG_DEFAULTS } from '@/lib/flags/contracts';
 
@@ -282,6 +282,29 @@ describe('PersistentAudioBar', () => {
     expect(push).toHaveBeenCalledWith(buildLyricsRoute('track-1'));
   });
 
+  it('closes the shell V1 lyrics button back to the last non-lyrics route', async () => {
+    const user = userEvent.setup();
+    setPlaying({ artistName: 'DJ Cool', hasLyrics: true });
+    pathname = APP_ROUTES.RELEASES;
+
+    const { rerender } = render(
+      <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, DESIGN_V1: true }}>
+        <PersistentAudioBar variant='shellChatV1' />
+      </AppFlagProvider>
+    );
+
+    pathname = buildLyricsRoute('track-1');
+    rerender(
+      <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, DESIGN_V1: true }}>
+        <PersistentAudioBar variant='shellChatV1' />
+      </AppFlagProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Close lyrics' }));
+
+    expect(push).toHaveBeenCalledWith(APP_ROUTES.RELEASES);
+  });
+
   it('keeps the shell V1 lyrics button hidden when the active track has no lyrics', () => {
     setPlaying({ artistName: 'DJ Cool', hasLyrics: false });
 
@@ -349,5 +372,27 @@ describe('PersistentAudioBar', () => {
 
     fireEvent.keyDown(globalThis, { key: '`' });
     expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
+  });
+
+  it('closes the lyrics route with Escape when an active track is present', () => {
+    setPlaying({ artistName: 'DJ Cool', hasLyrics: true });
+    pathname = APP_ROUTES.CHAT;
+
+    const { rerender } = render(
+      <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, DESIGN_V1: true }}>
+        <PersistentAudioBar variant='shellChatV1' />
+      </AppFlagProvider>
+    );
+
+    pathname = buildLyricsRoute('track-1');
+    rerender(
+      <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, DESIGN_V1: true }}>
+        <PersistentAudioBar variant='shellChatV1' />
+      </AppFlagProvider>
+    );
+
+    fireEvent.keyDown(globalThis, { key: 'Escape' });
+
+    expect(push).toHaveBeenCalledWith(APP_ROUTES.CHAT);
   });
 });

--- a/apps/web/tests/e2e/start-onboarding-chat.spec.ts
+++ b/apps/web/tests/e2e/start-onboarding-chat.spec.ts
@@ -270,6 +270,7 @@ test.describe('canonical /start onboarding chat', () => {
       )
     ).toBeVisible();
     await expect(page.locator(CHAT_PANEL)).toBeVisible();
+    await expect(page.getByText("Hey, I'm Jovie.")).toBeVisible();
     const mainBox = await page.locator('#main-content').boundingBox();
     const chatBox = await page.locator(CHAT_PANEL).boundingBox();
     expect(mainBox).not.toBeNull();
@@ -292,6 +293,9 @@ test.describe('canonical /start onboarding chat', () => {
     await expect(
       page.locator('[data-testid="slash-command-menu"]')
     ).toBeVisible();
+    await expect(
+      page.getByRole('option', { name: /send feedback/i })
+    ).toBeVisible();
     const after = await surface.boundingBox();
     expect(before).not.toBeNull();
     expect(after).not.toBeNull();
@@ -307,23 +311,38 @@ test.describe('canonical /start onboarding chat', () => {
     ).toEqual([]);
   });
 
-  test('empty narrow screen hides the headline behind the root picker', async ({
+  test('narrow screen keeps the intro and feedback slash command usable', async ({
     page,
   }) => {
     await page.setViewportSize({ width: 615, height: 407 });
     await page.goto('/start', { waitUntil: 'domcontentloaded' });
     await waitForHydration(page);
+    await expect(page.getByText("Hey, I'm Jovie.")).toBeVisible();
 
     const textarea = page.locator(COMPOSER_TEXTAREA);
-    await textarea.fill('/');
+    await textarea.fill('/feed');
     await expect(
       page.locator('[data-testid="slash-command-menu"]')
     ).toBeVisible();
-    await expect(page.locator('h1')).toHaveCSS('opacity', '0');
+    await expect(page.getByTestId('onboarding-intro-message')).toHaveCSS(
+      'opacity',
+      '0'
+    );
+    await expect(
+      page.getByRole('option', { name: /send feedback/i })
+    ).toBeVisible();
 
     await expect(page).toHaveScreenshot('start-empty-picker-narrow.png', {
       maxDiffPixelRatio: 0.04,
     });
+
+    await page.getByRole('option', { name: /send feedback/i }).click();
+    await expect(page.getByTestId('chat-input-chip-tray')).toContainText(
+      'Send feedback'
+    );
+    await expect(
+      page.getByRole('button', { name: 'Send message' })
+    ).toBeEnabled();
   });
 
   test('auth error and slash picker do not collide at narrow desktop size', async ({
@@ -414,17 +433,12 @@ test.describe('canonical /start onboarding chat', () => {
     await expect(
       page
         .getByTestId('onboarding-artist-confirmed')
-        .getByText('PROGRESSIVE HOUSE', { exact: true })
+        .getByText('Progressive House', { exact: true })
     ).toBeVisible();
-    await expect(page.getByTestId('onboarding-profile-rail')).toHaveAttribute(
-      'data-visible',
-      'true'
-    );
+    await expect(page.getByTestId('onboarding-profile-rail')).toHaveCount(0);
     await expect(
-      page
-        .getByTestId('onboarding-profile-rail')
-        .getByText('Building Test Artist')
-    ).toBeVisible();
+      page.getByTestId('onboarding-profile-rail-inline')
+    ).toHaveCount(0);
     await expect(
       page.getByText('find the exact Spotify profile')
     ).toBeVisible();
@@ -436,6 +450,7 @@ test.describe('canonical /start onboarding chat', () => {
     expect(bodyText).not.toContain('searchSpotifyArtist');
     expect(bodyText).not.toContain('confirmSpotifyArtist');
     expect(bodyText).not.toContain('recordInterviewSignal');
+    expect(bodyText).not.toContain('open.spotify.com');
     expect(getChatRequestCount()).toBe(2);
 
     const cookies = await page.context().cookies();

--- a/apps/web/tests/unit/chat/ChatInput.aria.test.tsx
+++ b/apps/web/tests/unit/chat/ChatInput.aria.test.tsx
@@ -1,11 +1,12 @@
 import { TooltipProvider } from '@jovie/ui';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen } from '@testing-library/react';
-import type { ComponentProps, ReactNode } from 'react';
+import type { ComponentProps, FormEvent, ReactNode } from 'react';
 import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ChatInput } from '@/components/jovie/components/ChatInput';
+import { useChipTray } from '@/components/jovie/hooks/useChipTray';
 
 /**
  * ARIA combobox contract for the chat composer textarea.
@@ -30,6 +31,10 @@ vi.mock('@/lib/queries/useArtistSearchQuery', () => ({
     state: 'idle' as const,
     search: vi.fn(),
   }),
+}));
+
+vi.mock('@/lib/queries/useEventsQuery', () => ({
+  useEventsQuery: () => ({ data: [], isLoading: false }),
 }));
 
 // Match ChatInput.test.tsx's motion mock so motion's ref forwarding doesn't
@@ -105,18 +110,25 @@ function withProviders(ui: ReactNode) {
 
 interface HarnessProps {
   readonly initialValue?: string;
+  readonly onSubmit?: (e?: FormEvent) => void;
 }
 
-function Harness({ initialValue = '' }: HarnessProps) {
+function Harness({ initialValue = '', onSubmit = () => {} }: HarnessProps) {
   const [value, setValue] = useState(initialValue);
+  const chipTray = useChipTray();
   return (
     <ChatInput
       value={value}
       onChange={setValue}
-      onSubmit={() => {}}
+      onSubmit={onSubmit}
       isLoading={false}
       isSubmitting={false}
       profileId='profile-test'
+      chips={chipTray.chips}
+      onRemoveChipAt={chipTray.removeAt}
+      onRemoveLastChip={chipTray.removeLast}
+      onAddSkill={chipTray.addSkill}
+      onAddEntity={chipTray.addEntity}
     />
   );
 }
@@ -197,5 +209,30 @@ describe('ChatInput combobox ARIA wiring', () => {
 
     const sendButton = screen.getByRole('button', { name: /send message/i });
     expect(sendButton).toBeDisabled();
+  });
+
+  it('commits the Feedback slash command into a sendable skill chip', () => {
+    const onSubmit = vi.fn();
+    render(withProviders(<Harness onSubmit={onSubmit} />));
+    const textarea = getTextarea();
+    textarea.focus();
+    fireEvent.change(textarea, { target: { value: '/feed' } });
+
+    expect(
+      screen.getByRole('option', { name: /send feedback/i })
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(screen.getByTestId('chat-input-chip-tray')).toHaveTextContent(
+      'Send feedback'
+    );
+    expect(textarea).toHaveValue('');
+
+    const sendButton = screen.getByRole('button', { name: /send message/i });
+    expect(sendButton).toBeEnabled();
+
+    fireEvent.click(sendButton);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/tests/unit/chat/ChatPageClient.test.tsx
+++ b/apps/web/tests/unit/chat/ChatPageClient.test.tsx
@@ -289,13 +289,14 @@ describe('ChatPageClient', () => {
     expect(mockSetHeaderActions).toHaveBeenCalledWith(null);
   });
 
-  it('hydrates the profile right panel when preview state is open without a panel query', () => {
+  it('does not hydrate the profile right panel from ambient preview state without a panel query', () => {
     mockPreviewPanelState.isOpen = true;
 
     renderChatPage();
 
     expect(mockUseRegisterRightPanel).toHaveBeenCalled();
-    expect(hasRegisteredRightPanel()).toBe(true);
+    expect(hasRegisteredRightPanel()).toBe(false);
+    expect(mockSetPreviewData).toHaveBeenCalledWith(null);
   });
 
   it('clears preview data while profile panel hydration is inactive', () => {

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -138,6 +138,15 @@ describe('JovieChat empty state', () => {
     expect(getByText('Welcome to Jovie')).toBeTruthy();
   });
 
+  it('uses only the first name in the returning-user welcome heading', () => {
+    const { getByText, queryByText } = renderWithQueryClient(
+      <JovieChat profileId='profile-1' displayName='Tim White' />
+    );
+
+    expect(getByText('Welcome Back Tim')).toBeTruthy();
+    expect(queryByText('Welcome Back Tim White')).toBeNull();
+  });
+
   it('renders chat messages after in-place message array updates', () => {
     const messages = mockChatState.messages;
     const { getAllByTestId, queryByText, rerender } = renderWithQueryClient(

--- a/apps/web/tests/unit/chat/SlashCommandMenu.keyboard.test.tsx
+++ b/apps/web/tests/unit/chat/SlashCommandMenu.keyboard.test.tsx
@@ -140,6 +140,28 @@ describe('SlashCommandMenu keyboard + IME + ARIA', () => {
     expect(typeof skill.id).toBe('string');
   });
 
+  it('filters and commits the Feedback skill from the root slash query', () => {
+    const handlers = makeHandlers();
+    renderMenu(
+      {
+        status: 'root',
+        query: 'feed',
+        startIdx: 0,
+        selectedIndex: 0,
+      },
+      handlers
+    );
+
+    expect(
+      screen.getByRole('option', { name: /send feedback/i })
+    ).toBeVisible();
+    fireEvent.keyDown(window, { key: 'Enter' });
+
+    expect(handlers.onSelectSkill).toHaveBeenCalledTimes(1);
+    const skill = handlers.onSelectSkill.mock.calls[0][0] as SkillCommand;
+    expect(skill.id).toBe('submitFeedback');
+  });
+
   it('Escape calls onClose', () => {
     const handlers = makeHandlers();
     renderMenu(rootState(0), handlers);

--- a/apps/web/tests/unit/components/AuthShellWrapper.test.tsx
+++ b/apps/web/tests/unit/components/AuthShellWrapper.test.tsx
@@ -10,6 +10,7 @@ vi.mock('@/hooks/useAuthRouteConfig', () => ({
     showMobileTabs: false,
     isArtistProfileSettings: false,
     isDemoRoute: false,
+    isChatRoute: false,
     showChatUsageIndicator: false,
   }),
 }));

--- a/apps/web/tests/unit/components/organisms/AuthShellWrapper.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AuthShellWrapper.test.tsx
@@ -15,6 +15,7 @@ const { previewPanelProviderMock, useAuthRouteConfigMock } = vi.hoisted(() => ({
     showMobileTabs: false,
     isTableRoute: false,
     isDemoRoute: false,
+    isChatRoute: false,
     showChatUsageIndicator: false,
   })),
 }));
@@ -123,6 +124,7 @@ describe('AuthShellWrapper', () => {
       showMobileTabs: false,
       isTableRoute: false,
       isDemoRoute: false,
+      isChatRoute: false,
       showChatUsageIndicator: false,
     });
   });
@@ -159,6 +161,7 @@ describe('AuthShellWrapper', () => {
       showMobileTabs: false,
       isTableRoute: false,
       isDemoRoute: false,
+      isChatRoute: false,
       showChatUsageIndicator: false,
     });
 
@@ -170,6 +173,30 @@ describe('AuthShellWrapper', () => {
 
     expect(previewPanelProviderMock).toHaveBeenCalledWith(
       expect.objectContaining({ defaultOpen: false, enabled: false }),
+      undefined
+    );
+  });
+
+  it('does not default-open preview panel on chat routes', () => {
+    useAuthRouteConfigMock.mockReturnValue({
+      section: 'dashboard',
+      isArtistProfileSettings: false,
+      breadcrumbs: [],
+      showMobileTabs: false,
+      isTableRoute: false,
+      isDemoRoute: false,
+      isChatRoute: true,
+      showChatUsageIndicator: true,
+    });
+
+    render(
+      <AuthShellWrapper previewPanelDefaultOpen>
+        <div>child content</div>
+      </AuthShellWrapper>
+    );
+
+    expect(previewPanelProviderMock).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultOpen: false, enabled: true }),
       undefined
     );
   });

--- a/apps/web/tests/unit/lyrics/LyricsPageClient.test.tsx
+++ b/apps/web/tests/unit/lyrics/LyricsPageClient.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  seek: vi.fn(),
+  playbackState: {
+    activeTrackId: null as string | null,
+    trackTitle: null as string | null,
+    artistName: null as string | null,
+    duration: 0,
+    currentTime: 0,
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
+  useTrackAudioPlayer: () => ({
+    playbackState: mocks.playbackState,
+    seek: mocks.seek,
+  }),
+}));
+
+vi.mock('@/components/shell/LyricsView', () => ({
+  LyricsView: ({
+    track,
+    currentTimeSec,
+    autoFocusView,
+  }: {
+    track: { title: string; artist?: string };
+    currentTimeSec: number;
+    autoFocusView?: boolean;
+  }) => (
+    <section aria-label='Lyrics view'>
+      <h1>{track.title}</h1>
+      <p>{track.artist}</p>
+      <span data-testid='current-time'>{currentTimeSec}</span>
+      <span data-testid='auto-focus'>{String(Boolean(autoFocusView))}</span>
+    </section>
+  ),
+}));
+
+const { LyricsPageClient } = await import(
+  '@/app/app/(shell)/lyrics/[trackId]/LyricsPageClient'
+);
+
+type LyricsPageClientProps = ComponentProps<typeof LyricsPageClient>;
+
+const baseProps = {
+  initialLines: [],
+  initialTrack: {
+    title: 'Server Track',
+    artist: 'Server Artist',
+  },
+  initialDurationSec: 180,
+  trackId: 'track-1',
+} satisfies LyricsPageClientProps;
+
+describe('LyricsPageClient', () => {
+  beforeEach(() => {
+    mocks.push.mockClear();
+    mocks.seek.mockClear();
+    mocks.playbackState.activeTrackId = null;
+    mocks.playbackState.trackTitle = null;
+    mocks.playbackState.artistName = null;
+    mocks.playbackState.duration = 0;
+    mocks.playbackState.currentTime = 0;
+  });
+
+  it('renders the server-resolved track when audio is not active', () => {
+    render(<LyricsPageClient {...baseProps} />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Server Track' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Server Artist')).toBeInTheDocument();
+    expect(screen.getByTestId('current-time')).toHaveTextContent('0');
+    expect(screen.getByTestId('auto-focus')).toHaveTextContent('true');
+  });
+
+  it('closes direct lyrics entry to the library on Escape', () => {
+    render(<LyricsPageClient {...baseProps} />);
+
+    fireEvent.keyDown(globalThis, { key: 'Escape' });
+
+    expect(mocks.push).toHaveBeenCalledWith(APP_ROUTES.LIBRARY);
+  });
+
+  it('uses active playback state and leaves Escape to the persistent player', () => {
+    mocks.playbackState.activeTrackId = 'track-1';
+    mocks.playbackState.trackTitle = 'Live Track';
+    mocks.playbackState.artistName = 'Live Artist';
+    mocks.playbackState.duration = 32;
+    mocks.playbackState.currentTime = 11;
+
+    render(<LyricsPageClient {...baseProps} />);
+
+    expect(
+      screen.getByRole('heading', { name: 'Live Track' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Live Artist')).toBeInTheDocument();
+    expect(screen.getByTestId('current-time')).toHaveTextContent('11');
+
+    fireEvent.keyDown(globalThis, { key: 'Escape' });
+
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/onboarding/OnboardingProfileRail.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingProfileRail.test.tsx
@@ -30,14 +30,15 @@ describe('OnboardingProfileRail', () => {
     expect(screen.getByText('Building Test Artist')).toBeDefined();
     expect(screen.getByText('Matched')).toBeDefined();
     expect(
-      screen.getByRole('link', { name: 'open.spotify.com' })
+      screen.getByRole('link', { name: 'Open Test Artist on Spotify' })
     ).toHaveAttribute('href', 'https://open.spotify.com/artist/artist-1');
+    expect(screen.queryByText('open.spotify.com')).toBeNull();
     expect(screen.getByTitle('12,300 Spotify followers')).toBeDefined();
     expect(screen.getByText('12,300 Spotify followers')).toBeDefined();
     expect(screen.getByTitle('Popularity score: 48 out of 100')).toBeDefined();
     expect(screen.getByText('Popularity score: 48 out of 100')).toBeDefined();
-    expect(screen.getByText('Genre: PROGRESSIVE HOUSE')).toBeDefined();
-    expect(screen.getByText('PROGRESSIVE HOUSE')).toBeDefined();
+    expect(screen.getByText('Genre: Progressive House')).toBeDefined();
+    expect(screen.getByText('Progressive House')).toBeDefined();
     expect(screen.getByText('jov.ie/testartist')).toBeDefined();
     expect(screen.getByText('instagram.com')).toBeDefined();
   });

--- a/apps/web/tests/unit/onboarding/OnboardingToolArtifacts.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingToolArtifacts.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  formatGenreLabel,
   OnboardingArtistConfirmedCard,
   OnboardingHandleCheckCard,
   OnboardingSocialLinkCard,
@@ -119,9 +120,14 @@ describe('onboarding tool artifacts', () => {
     expect(screen.getByTitle('Popularity score: 42 out of 100')).toBeDefined();
     expect(screen.getByText('Popularity score: 42 out of 100')).toBeDefined();
     expect(screen.getByText('42')).toBeDefined();
-    expect(screen.getByText('Genre: INDIE POP')).toBeDefined();
-    expect(screen.getByText('INDIE POP')).toBeDefined();
+    expect(screen.getByText('Genre: Indie Pop')).toBeDefined();
+    expect(screen.getByText('Indie Pop')).toBeDefined();
     expect(screen.queryByText('confirmSpotifyArtist')).toBeNull();
+  });
+
+  it('formats genre labels without shouting', () => {
+    expect(formatGenreLabel('progressive house')).toBe('Progressive House');
+    expect(formatGenreLabel('alt-pop')).toBe('Alt-Pop');
   });
 
   it('does not render unsafe Spotify profile links', () => {


### PR DESCRIPTION
## Summary
- Adds the immediate /start Jovie greeting and keeps default chat free of profile/right rail unless explicitly entered via profile or entity context.
- Wires onboarding slash commands to the shared chat chip tray, including covered /feed -> Send feedback flow.
- Polishes Spotify matched cards, first-name welcome copy, chat profile-panel hydration, and lyrics/audio route cohesion with route-aware shell loading.

## Verification
- pnpm biome check --write apps/web/components/features/onboarding/OnboardingChat.tsx apps/web/components/jovie/components/ChatInput.tsx apps/web/tests/unit/chat/ChatInput.aria.test.tsx apps/web/tests/unit/chat/SlashCommandMenu.keyboard.test.tsx apps/web/tests/e2e/start-onboarding-chat.spec.ts
- pnpm --filter @jovie/web exec vitest run tests/unit/chat/ChatInput.aria.test.tsx tests/unit/chat/SlashCommandMenu.keyboard.test.tsx tests/unit/onboarding/OnboardingToolArtifacts.test.tsx tests/unit/onboarding/OnboardingProfileRail.test.tsx
- pnpm --filter @jovie/web exec vitest run tests/unit/onboarding/OnboardingToolArtifacts.test.tsx tests/unit/onboarding/OnboardingProfileRail.test.tsx tests/unit/chat/JovieChat.empty-state.test.tsx lib/services/onboarding/welcome-message.test.ts tests/unit/components/organisms/AuthShellWrapper.test.tsx tests/unit/components/AuthShellWrapper.test.tsx tests/unit/chat/ChatPageClient.test.tsx tests/unit/chat/ChatEntityRightPanelHost.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- BASE_URL=http://127.0.0.1:3112 E2E_SKIP_WEB_SERVER=1 E2E_USE_TEST_AUTH_BYPASS=1 pnpm --filter @jovie/web exec playwright test tests/e2e/start-onboarding-chat.spec.ts --project=chromium
- git push pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

## Visual Evidence
- /tmp/jovie-start-intro-mobile.png
- /tmp/jovie-start-feedback-slash-mobile.png
- /tmp/jovie-start-intro-tablet.png
- /tmp/jovie-start-feedback-slash-tablet.png

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added lyrics viewing page with keyboard navigation (Escape to close)
  * Added chip-based selections in onboarding chat composer
  * Added feedback slash command in chat

* **Improvements**
  * Enhanced welcome-back greetings to use first names only
  * Improved Spotify artist matching badge and UI
  * Refined genre label formatting and capitalization
  * Enhanced keyboard shortcuts and navigation patterns
  * Updated button styling and transitions for better interaction feedback

* **Bug Fixes**
  * Fixed preview panel behavior to only hydrate on explicit deep-links

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->