### PR TITLE
test(shell): address focus and date review fixes

### DIFF
--- a/apps/web/components/shell/PillSearch.test.tsx
+++ b/apps/web/components/shell/PillSearch.test.tsx
@@ -30,10 +30,13 @@ describe('PillSearch', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not use browser-style cyan focus rings on the input', () => {
+  it('uses a quiet tokenized focus ring instead of the cyan input ring', () => {
     setup();
     const input = screen.getByLabelText('Filter tracks');
-    expect(input.className).toContain('focus-visible:ring-0');
+    expect(input.className).toContain('focus-visible:ring-1');
+    expect(input.className).toContain(
+      'focus-visible:ring-(--linear-border-focus)/25'
+    );
     expect(input.className).not.toContain('ring-cyan');
   });
 

--- a/apps/web/components/shell/PillSearch.tsx
+++ b/apps/web/components/shell/PillSearch.tsx
@@ -361,7 +361,7 @@ export function PillSearch({
           aria-autocomplete='list'
           aria-activedescendant={activeOptionId}
           placeholder={pills.length === 0 ? placeholder : 'and… (/ for fields)'}
-          className='flex-1 min-w-[120px] rounded-sm bg-transparent text-[13px] text-primary-token outline-none placeholder:text-tertiary-token focus:outline-none focus:ring-0 focus:shadow-none focus-visible:outline-none focus-visible:ring-0 focus-visible:shadow-none'
+          className='flex-1 min-w-[120px] rounded-sm bg-transparent text-[13px] text-primary-token outline-none placeholder:text-tertiary-token focus:outline-none focus:ring-0 focus:shadow-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/25 focus-visible:ring-offset-0 focus-visible:shadow-none'
         />
         <button
           type='button'

--- a/apps/web/lib/format-relative-date.test.ts
+++ b/apps/web/lib/format-relative-date.test.ts
@@ -29,9 +29,18 @@ describe('relativeDate', () => {
     expect(relativeDate('2026-05-02T12:00:00Z', NOW)).toBe('in 7d');
   });
 
-  it('falls back to localised absolute date past a week', () => {
+  it('falls back to localised absolute date for later future dates', () => {
     const out = relativeDate('2026-06-01T12:00:00Z', NOW);
     expect(out).toMatch(/Jun/);
+  });
+
+  it('omits the year for same-year absolute dates and includes it across years', () => {
+    const sameYear = relativeDate('2026-12-20T12:00:00Z', NOW);
+    expect(sameYear).toMatch(/Dec/);
+    expect(sameYear).not.toMatch(/2026/);
+
+    const crossYear = relativeDate('2027-01-10T12:00:00Z', NOW);
+    expect(crossYear).toMatch(/2027/);
   });
 
   it('returns an empty string for invalid date input', () => {


### PR DESCRIPTION
## Summary
- restore a subtle tokenized, non-cyan keyboard focus affordance for `PillSearch`
- add `relativeDate` coverage for same-year absolute labels and cross-year absolute labels

## Verification
- `pnpm --filter web exec vitest run lib/format-relative-date.test.ts components/shell/PillSearch.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- push preflight passed: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`

Linear: JOV-2286


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual focus indicator on the search input with improved theme-aligned styling for better keyboard navigation accessibility.

* **Tests**
  * Expanded test coverage for date formatting functionality, including validation of year display logic for dates spanning multiple calendar years.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8824?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->