### PR TITLE
test(shell): harden release search guardrail (JOV-2289)

### DIFF
--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -279,8 +279,8 @@ describe('surface elevation guardrails', () => {
     expect(shellReleasesView).toContain('useRegisterHeaderSearch');
     expect(shellReleasesView).toContain("key: 'shell-releases'");
     expect(shellReleasesView).toContain("triggerLabel: 'Filter'");
-    expect(shellReleasesView).not.toContain(
-      'const [searchOpen, setSearchOpen]'
+    expect(shellReleasesView).not.toMatch(
+      /const\s*\[\s*searchOpen\s*,\s*setSearchOpen\s*\]\s*=\s*useState/
     );
     expect(authShellWrapper).toContain('HeaderSearchSurface');
   });


### PR DESCRIPTION
## Summary
- harden the shell release header-search guardrail with a whitespace-tolerant regex
- keeps route-local release search state from returning under alternate formatting

## Verification
- pnpm --filter web exec vitest run tests/unit/app/surface-elevation-guardrails.test.ts
- pre-push: biome check ., next:proxy-guard, tailwind:check, @jovie/web typecheck, @jovie/web lint

Linear: JOV-2289

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated guardrail test to enforce more precise architectural constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8832?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->