### PR TITLE
fix(shell): unify library search chrome (JOV-2292)

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -15,7 +15,6 @@ import {
   type LucideIcon,
   Music2,
   PlayCircle,
-  Search,
   Video,
   X,
 } from 'lucide-react';
@@ -29,10 +28,11 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { OPEN_COMMAND_PALETTE_EVENT } from '@/components/organisms/command-palette-events';
+import type { FilterPill } from '@/components/shell/pill-search.types';
 import { ShellDropdown } from '@/components/shell/ShellDropdown';
 import { Tooltip } from '@/components/shell/Tooltip';
 import { APP_ROUTES } from '@/constants/routes';
+import { useRegisterHeaderSearch } from '@/contexts/HeaderActionsContext';
 import { useRegisterShellSidebarOverride } from '@/contexts/ShellSidebarOverrideContext';
 import {
   getArtworkFallbackAccentStyle,
@@ -200,6 +200,42 @@ function assetMatchesFilters(
     return false;
   }
   return true;
+}
+
+function normalizePillValue(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function valuesMatchPill(values: readonly string[], pill: FilterPill): boolean {
+  const normalizedValues = new Set(values.map(normalizePillValue));
+  const normalizedPillValues = pill.values.map(normalizePillValue);
+  const hasAny = normalizedPillValues.some(value =>
+    normalizedValues.has(value)
+  );
+
+  return pill.op === 'is' ? hasAny : !hasAny;
+}
+
+function assetMatchesPills(
+  asset: LibraryReleaseAsset,
+  pills: readonly FilterPill[]
+): boolean {
+  if (pills.length === 0) return true;
+
+  return pills.every(pill => {
+    switch (pill.field) {
+      case 'artist':
+        return valuesMatchPill([asset.artist], pill);
+      case 'title':
+        return valuesMatchPill([asset.title], pill);
+      case 'status':
+        return valuesMatchPill([asset.status], pill);
+      case 'has':
+        return valuesMatchPill(asset.assetKinds, pill);
+      case 'album':
+        return true;
+    }
+  });
 }
 
 function hasActiveFilters(filters: LibraryFilters): boolean {
@@ -385,27 +421,12 @@ function LibraryRail({
     filters.releaseTypes.size +
     filters.assetKinds.size +
     filters.providers.size;
-  const openCommandPalette = () => {
-    globalThis.dispatchEvent(new Event(OPEN_COMMAND_PALETTE_EVENT));
-  };
 
   return (
     <nav
       aria-label='Library navigation'
       className={cn('flex min-h-0 flex-col bg-surface-0 p-2.5', className)}
     >
-      <div className='px-1.5 pb-2'>
-        <button
-          type='button'
-          onClick={openCommandPalette}
-          className='flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[12.5px] text-secondary-token transition-colors duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
-        >
-          <Search className='h-3.5 w-3.5 shrink-0 text-sidebar-item-icon' />
-          <span className='min-w-0 flex-1 truncate'>Search</span>
-          <span className='text-2xs text-tertiary-token'>Cmd K</span>
-        </button>
-      </div>
-
       <div className='px-1.5 pb-2'>
         <div className='flex items-center justify-between gap-2'>
           <p className='text-xs font-semibold text-primary-token'>Views</p>
@@ -1184,6 +1205,7 @@ export function LibrarySurface({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+  const [pills, setPills] = useState<FilterPill[]>([]);
 
   const visibleAssets = useMemo(() => {
     const presetPredicate =
@@ -1192,8 +1214,26 @@ export function LibrarySurface({
     return assets
       .filter(presetPredicate)
       .filter(asset => assetMatchesFilters(asset, filters))
+      .filter(asset => assetMatchesPills(asset, pills))
       .toSorted(compareAssets(sort));
-  }, [assets, filters, preset, sort]);
+  }, [assets, filters, pills, preset, sort]);
+
+  const artistOptions = useMemo(
+    () => uniqueSorted(assets.map(asset => asset.artist)),
+    [assets]
+  );
+  const titleOptions = useMemo(
+    () => uniqueSorted(assets.map(asset => asset.title)),
+    [assets]
+  );
+  const statusOptions = useMemo(
+    () => uniqueSorted(assets.map(asset => asset.status)),
+    [assets]
+  );
+  const hasOptions = useMemo(
+    () => uniqueSorted(assets.flatMap(asset => asset.assetKinds)),
+    [assets]
+  );
 
   const selectedAsset =
     visibleAssets.find(asset => asset.id === selectedId) ?? null;
@@ -1224,6 +1264,7 @@ export function LibrarySurface({
   function resetView() {
     setPreset('all');
     setFilters(emptyFilters());
+    setPills([]);
   }
 
   function openAsset(id: string) {
@@ -1256,6 +1297,39 @@ export function LibrarySurface({
   );
 
   useRegisterShellSidebarOverride(sidebarOverride);
+
+  const headerSearchAdapter = useMemo(
+    () =>
+      assets.length === 0
+        ? null
+        : {
+            key: 'library',
+            pills,
+            onPillsChange: setPills,
+            artistOptions,
+            titleOptions,
+            albumOptions: [],
+            statusOptions,
+            hasOptions,
+            totalCount: assets.length,
+            visibleCount: visibleAssets.length,
+            triggerLabel: 'Filter',
+            ariaLabel: 'Filter library assets',
+            placeholder: 'Filter library - / for fields',
+            allowedFields: ['artist', 'title', 'status', 'has'] as const,
+          },
+    [
+      artistOptions,
+      assets.length,
+      hasOptions,
+      pills,
+      statusOptions,
+      titleOptions,
+      visibleAssets.length,
+    ]
+  );
+
+  useRegisterHeaderSearch(headerSearchAdapter);
 
   if (assets.length === 0) {
     return <EmptyCatalog />;

--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -28,23 +28,36 @@ export interface DashboardHeaderProps {
 function MobileHeader({
   currentLabel,
   action,
+  searchSurface,
+  isSearchActive,
   mobileProfileSlot,
 }: {
   readonly currentLabel: string;
   readonly action?: ReactNode;
+  readonly searchSurface?: ReactNode;
+  readonly isSearchActive: boolean;
   readonly mobileProfileSlot?: ReactNode;
 }) {
+  if (searchSurface && isSearchActive) {
+    return (
+      <div className='hidden max-sm:flex px-4 pb-2 pt-3'>{searchSurface}</div>
+    );
+  }
+
   return (
     <div className='hidden max-sm:flex items-center justify-between px-4 pb-2 pt-3'>
       <h1 className='text-[17px] font-semibold leading-tight tracking-[-0.018em] text-primary-token'>
         {currentLabel}
       </h1>
       <div className='flex items-center gap-2'>
+        {searchSurface ? (
+          <div className='flex items-center'>{searchSurface}</div>
+        ) : null}
         {action ? (
           <div className='flex items-center gap-1 [&_button]:h-8 [&_button]:rounded-full [&_button]:shadow-none [&_button>svg]:h-4 [&_button>svg]:w-4'>
             {action}
           </div>
-        ) : (
+        ) : searchSurface ? null : (
           mobileProfileSlot
         )}
       </div>
@@ -125,6 +138,8 @@ export function DashboardHeader({
       <MobileHeader
         currentLabel={currentLabel}
         action={action}
+        searchSurface={searchSurface}
+        isSearchActive={searchTakesOver}
         mobileProfileSlot={mobileProfileSlot}
       />
       <div className='relative max-sm:hidden h-(--linear-app-header-height-compact) w-full items-center gap-2 px-2.5 sm:flex'>

--- a/apps/web/components/shell/HeaderSearchSurface.tsx
+++ b/apps/web/components/shell/HeaderSearchSurface.tsx
@@ -80,6 +80,8 @@ export function HeaderSearchSurface({
         artistOptions={adapter.artistOptions}
         titleOptions={adapter.titleOptions}
         albumOptions={adapter.albumOptions}
+        statusOptions={adapter.statusOptions}
+        hasOptions={adapter.hasOptions}
         ariaLabel={adapter.ariaLabel ?? `Filter ${adapter.triggerLabel}`}
         placeholder={adapter.placeholder ?? 'Type to filter — / for fields'}
         allowedFields={adapter.allowedFields}

--- a/apps/web/components/shell/PillSearch.test.tsx
+++ b/apps/web/components/shell/PillSearch.test.tsx
@@ -82,6 +82,24 @@ describe('PillSearch', () => {
     });
   });
 
+  it('uses route-provided status and has suggestions when supplied', () => {
+    const { onPillsChange } = setup({
+      allowedFields: ['status', 'has'],
+      statusOptions: ['released', 'scheduled'],
+      hasOptions: ['artwork', 'lyrics'],
+    });
+    const input = screen.getByLabelText('Filter tracks');
+
+    fireEvent.change(input, { target: { value: 'released' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onPillsChange).toHaveBeenCalledOnce();
+    expect(onPillsChange.mock.calls[0]![0][0]).toMatchObject({
+      field: 'status',
+      values: ['released'],
+    });
+  });
+
   it('drops the last pill when Backspace is pressed on an empty input', () => {
     const { onPillsChange } = setup({
       pills: [

--- a/apps/web/components/shell/PillSearch.tsx
+++ b/apps/web/components/shell/PillSearch.tsx
@@ -34,6 +34,10 @@ export interface PillSearchProps {
   readonly titleOptions: readonly string[];
   /** Distinct album names. */
   readonly albumOptions: readonly string[];
+  /** Distinct status values. Defaults to release status values. */
+  readonly statusOptions?: readonly string[];
+  /** Distinct "has" values. Defaults to release asset values. */
+  readonly hasOptions?: readonly string[];
   /** Called when the user hits Esc on an empty input or focus leaves the surface. */
   readonly onClose: () => void;
   readonly ariaLabel?: string;
@@ -91,7 +95,9 @@ function fieldValueOptions(
   field: FilterField,
   artistOptions: readonly string[],
   titleOptions: readonly string[],
-  albumOptions: readonly string[]
+  albumOptions: readonly string[],
+  statusOptions: readonly string[],
+  hasOptions: readonly string[]
 ): readonly string[] {
   switch (field) {
     case 'artist':
@@ -101,9 +107,9 @@ function fieldValueOptions(
     case 'album':
       return albumOptions;
     case 'status':
-      return STATUS_VALUES;
+      return statusOptions;
     case 'has':
-      return HAS_VALUES;
+      return hasOptions;
   }
 }
 
@@ -147,6 +153,8 @@ export function PillSearch({
   artistOptions,
   titleOptions,
   albumOptions,
+  statusOptions = STATUS_VALUES,
+  hasOptions = HAS_VALUES,
   onClose,
   ariaLabel = 'Filter tracks',
   placeholder = 'Type to filter — / for fields',
@@ -211,7 +219,9 @@ export function PillSearch({
         slash.field,
         artistOptions,
         titleOptions,
-        albumOptions
+        albumOptions,
+        statusOptions,
+        hasOptions
       );
       return opts
         .map(v => ({
@@ -249,14 +259,14 @@ export function PillSearch({
       });
     }
     if (allowedFieldSet.has('status')) {
-      STATUS_VALUES.forEach(v => {
+      statusOptions.forEach(v => {
         const s = fuzzy(q, v);
         if (s > 0)
           out.push({ kind: 'value', field: 'status', value: v, score: s });
       });
     }
     if (allowedFieldSet.has('has')) {
-      HAS_VALUES.forEach(v => {
+      hasOptions.forEach(v => {
         const s = fuzzy(q, v);
         if (s > 0)
           out.push({ kind: 'value', field: 'has', value: v, score: s });
@@ -269,6 +279,8 @@ export function PillSearch({
     artistOptions,
     titleOptions,
     albumOptions,
+    statusOptions,
+    hasOptions,
     effectiveFields,
     text,
   ]);

--- a/apps/web/contexts/HeaderActionsContext.tsx
+++ b/apps/web/contexts/HeaderActionsContext.tsx
@@ -31,6 +31,10 @@ export interface HeaderSearchAdapter {
   readonly artistOptions: readonly string[];
   readonly titleOptions: readonly string[];
   readonly albumOptions: readonly string[];
+  /** Distinct status values surfaced as suggestions. Defaults to release statuses. */
+  readonly statusOptions?: readonly string[];
+  /** Distinct "has" values surfaced as suggestions. Defaults to release asset tags. */
+  readonly hasOptions?: readonly string[];
   /** Total rows the underlying data set has, before filters apply. */
   readonly totalCount: number;
   /** Rows visible after filters apply. Defaults to `totalCount` when omitted. */

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -316,6 +316,18 @@ describe('surface elevation guardrails', () => {
     }
   });
 
+  it('routes library filters through the shared header search contract', () => {
+    const librarySurface = readFileSync(
+      join(ROOT, 'app/app/(shell)/library/LibrarySurface.tsx'),
+      'utf-8'
+    );
+
+    expect(librarySurface).toContain('useRegisterHeaderSearch');
+    expect(librarySurface).toContain("key: 'library'");
+    expect(librarySurface).toContain("triggerLabel: 'Filter'");
+    expect(librarySurface).not.toContain('OPEN_COMMAND_PALETTE_EVENT');
+  });
+
   it('keeps task and preview cards off the shell canvas token', () => {
     const files = [
       'components/features/dashboard/layout/PreviewPanel.tsx',

--- a/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { DashboardHeader } from '@/components/features/dashboard/organisms/DashboardHeader';
 
@@ -49,6 +49,24 @@ describe('DashboardHeader', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps the closed search surface reachable in the mobile header', () => {
+    const { container } = render(
+      <DashboardHeader
+        breadcrumbs={[{ label: 'Library', href: '/app/library' }]}
+        searchSurface={<button type='button'>Filter Library</button>}
+        isSearchActive={false}
+      />
+    );
+
+    const mobileHeader = container.querySelector('.hidden.max-sm\\:flex');
+
+    expect(mobileHeader).not.toBeNull();
+    expect(within(mobileHeader!).getByText('Library')).toBeInTheDocument();
+    expect(
+      within(mobileHeader!).getByRole('button', { name: 'Filter Library' })
+    ).toBeInTheDocument();
+  });
+
   it('collapses the breadcrumb when the search surface takes over', () => {
     const { container } = render(
       <DashboardHeader
@@ -66,7 +84,7 @@ describe('DashboardHeader', () => {
     expect(desktopRow).not.toBeNull();
     expect(within(desktopRow!).queryByText('Releases')).not.toBeInTheDocument();
     expect(
-      screen.getByRole('searchbox', { name: 'Filter releases' })
+      within(desktopRow!).getByRole('searchbox', { name: 'Filter releases' })
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -3,8 +3,9 @@ import type { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { LibrarySurface } from '@/app/app/(shell)/library/LibrarySurface';
 import type { LibraryReleaseAsset } from '@/app/app/(shell)/library/library-data';
-import { OPEN_COMMAND_PALETTE_EVENT } from '@/components/organisms/command-palette-events';
+import { HeaderSearchSurfaceFromContext } from '@/components/shell/HeaderSearchSurface';
 import { APP_ROUTES } from '@/constants/routes';
+import { HeaderActionsProvider } from '@/contexts/HeaderActionsContext';
 
 vi.mock('next/image', () => ({
   default: (
@@ -51,6 +52,15 @@ function buildAsset(
     totalDurationMs: 212_000,
     ...overrides,
   };
+}
+
+function renderLibraryWithHeader(assets: readonly LibraryReleaseAsset[]) {
+  return render(
+    <HeaderActionsProvider>
+      <HeaderSearchSurfaceFromContext />
+      <LibrarySurface assets={assets} />
+    </HeaderActionsProvider>
+  );
 }
 
 describe('LibrarySurface', () => {
@@ -142,44 +152,39 @@ describe('LibrarySurface', () => {
     ).toBeInTheDocument();
   });
 
-  it('uses the shared command palette event from the Library navigation search', () => {
-    const onOpenCommandPalette = vi.fn();
-    globalThis.addEventListener(
-      OPEN_COMMAND_PALETTE_EVENT,
-      onOpenCommandPalette
+  it('filters release assets from the shell header search contract', () => {
+    renderLibraryWithHeader([
+      buildAsset(),
+      buildAsset({
+        id: 'release-2',
+        title: 'Never Say A Word',
+        artist: 'Other Artist',
+        providers: [
+          {
+            key: 'apple',
+            label: 'Apple Music',
+            url: 'https://music.apple.com/album/never-say-a-word',
+          },
+        ],
+      }),
+    ]);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Filter library assets' })
+    );
+    fireEvent.change(screen.getByLabelText('Filter library assets'), {
+      target: { value: 'Never' },
+    });
+    fireEvent.mouseDown(
+      screen.getByRole('option', { name: /Never Say A Word/u })
     );
 
-    try {
-      render(
-        <LibrarySurface
-          assets={[
-            buildAsset(),
-            buildAsset({
-              id: 'release-2',
-              title: 'Never Say A Word',
-              artist: 'Other Artist',
-              providers: [
-                {
-                  key: 'apple',
-                  label: 'Apple Music',
-                  url: 'https://music.apple.com/album/never-say-a-word',
-                },
-              ],
-            }),
-          ]}
-        />
-      );
-
-      fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
-      fireEvent.click(screen.getByRole('button', { name: /Search/u }));
-
-      expect(onOpenCommandPalette).toHaveBeenCalledTimes(1);
-    } finally {
-      globalThis.removeEventListener(
-        OPEN_COMMAND_PALETTE_EVENT,
-        onOpenCommandPalette
-      );
-    }
+    expect(
+      screen.getByRole('heading', { name: 'Never Say A Word' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Take Me Over' })
+    ).not.toBeInTheDocument();
   });
 
   it('filters release assets from the Library navigation', () => {


### PR DESCRIPTION
## Summary
- moves library text filtering into the shared shell header search contract
- keeps library navigation/facets in the sidebar rail and removes the route-local command-palette search button
- lets route adapters provide status/has pill suggestions and keeps mobile shell search reachable

## Verification
- pnpm biome check --write 'apps/web/app/app/(shell)/library/LibrarySurface.tsx' apps/web/components/features/dashboard/organisms/DashboardHeader.tsx apps/web/components/shell/HeaderSearchSurface.tsx apps/web/components/shell/PillSearch.tsx apps/web/contexts/HeaderActionsContext.tsx apps/web/components/shell/PillSearch.test.tsx apps/web/tests/unit/dashboard/DashboardHeader.test.tsx apps/web/tests/unit/library/LibrarySurface.test.tsx apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
- pnpm --filter web exec vitest run tests/unit/dashboard/DashboardHeader.test.tsx components/shell/PillSearch.test.tsx tests/unit/library/LibrarySurface.test.tsx tests/unit/app/surface-elevation-guardrails.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- BASE_URL=http://127.0.0.1:3112 E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready E2E_SKIP_WEB_SERVER=1 PLAYWRIGHT_WORKERS=1 pnpm --filter web exec playwright test tests/e2e/shell-route-persistence.spec.ts --project=chromium --reporter=line
- git push pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

## Design Review
- checked desktop closed/open header search screenshots
- checked mobile closed/open header search screenshots

Linear: JOV-2292

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added header-based filter pills to the library, allowing users to filter assets by artist, title, status, and other criteria directly from the search interface.

* **Improvements**
  * Enhanced mobile header search experience with configurable filter options and better state handling.

* **Changes**
  * Removed command-palette search trigger from library navigation sidebar.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8838?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->