### PR TITLE
fix(shell): unify tasks search and table chrome (JOV-2294)

### DIFF
--- a/apps/web/app/app/(shell)/layout.tsx
+++ b/apps/web/app/app/(shell)/layout.tsx
@@ -4,6 +4,7 @@ import { redirect, unstable_rethrow } from 'next/navigation';
 import { Suspense } from 'react';
 import { AppShellSkeleton } from '@/components/organisms/AppShellSkeleton';
 import { LyricsRouteSkeleton } from '@/components/shell/LyricsRouteSkeleton';
+import { TasksRouteSkeleton } from '@/components/shell/TasksRouteSkeleton';
 import { APP_ROUTES } from '@/constants/routes';
 import { ErrorBanner } from '@/features/feedback/ErrorBanner';
 import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
@@ -16,6 +17,7 @@ import {
   isChatShellRoute,
   isLyricsShellRoute,
   isReleasesShellRoute,
+  isTasksShellRoute,
   resolveAppShellRequestPath,
 } from './shell-route-matches';
 
@@ -70,6 +72,13 @@ export default async function AppShellLayout({
       shellFallback = (
         <AppShellSkeleton
           main={<LyricsRouteSkeleton />}
+          variant={shellVariant}
+        />
+      );
+    } else if (isTasksShellRoute(pathname)) {
+      shellFallback = (
+        <AppShellSkeleton
+          main={<TasksRouteSkeleton />}
           variant={shellVariant}
         />
       );

--- a/apps/web/app/app/(shell)/shell-route-matches.ts
+++ b/apps/web/app/app/(shell)/shell-route-matches.ts
@@ -84,6 +84,16 @@ export function isLibraryShellRoute(pathname: string | null): boolean {
   );
 }
 
+export function isTasksShellRoute(pathname: string | null): boolean {
+  if (!pathname) return false;
+  return (
+    pathname === APP_ROUTES.TASKS ||
+    pathname.startsWith(`${APP_ROUTES.TASKS}/`) ||
+    pathname === APP_ROUTES.DASHBOARD_TASKS ||
+    pathname.startsWith(`${APP_ROUTES.DASHBOARD_TASKS}/`)
+  );
+}
+
 function isDashboardSubRoute(pathname: string | null): boolean {
   if (!pathname) return false;
   return pathname.startsWith(`${APP_ROUTES.LEGACY_DASHBOARD}/`);
@@ -95,6 +105,7 @@ function isLightweightShellRoute(pathname: string | null): boolean {
     isReleasesShellRoute(pathname) ||
     isLyricsShellRoute(pathname) ||
     isLibraryShellRoute(pathname) ||
+    isTasksShellRoute(pathname) ||
     isDashboardSubRoute(pathname)
   );
 }

--- a/apps/web/components/features/dashboard/tasks/TaskDataTable.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskDataTable.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useCallback } from 'react';
+import {
+  UnifiedTable,
+  type UnifiedTableProps,
+} from '@/components/organisms/table';
+import { cn } from '@/lib/utils';
+
+export const TASK_DATA_TABLE_CLASSNAME = 'text-app';
+
+export const TASK_DATA_TABLE_CONTAINER_CLASSNAME =
+  'h-full overflow-y-auto overflow-x-hidden px-2.5 pb-2 pt-0.5';
+
+export const TASK_DATA_TABLE_ROW_CLASSNAME =
+  'group/task-row bg-transparent shadow-none hover:bg-transparent focus-within:shadow-none focus-visible:bg-transparent focus-visible:shadow-none';
+
+export type TaskDataTableProps<TData> = UnifiedTableProps<TData>;
+
+export function TaskDataTable<TData>({
+  className,
+  containerClassName,
+  enableVirtualization = false,
+  getRowClassName,
+  hideHeader = true,
+  minWidth = '100%',
+  rowHeight = 64,
+  skeletonRows = 8,
+  ...props
+}: Readonly<TaskDataTableProps<TData>>) {
+  const mergedRowClassName = useCallback(
+    (row: TData, index: number) =>
+      cn(TASK_DATA_TABLE_ROW_CLASSNAME, getRowClassName?.(row, index)),
+    [getRowClassName]
+  );
+
+  return (
+    <UnifiedTable<TData>
+      {...props}
+      className={cn(TASK_DATA_TABLE_CLASSNAME, className)}
+      containerClassName={cn(
+        TASK_DATA_TABLE_CONTAINER_CLASSNAME,
+        containerClassName
+      )}
+      enableVirtualization={enableVirtualization}
+      getRowClassName={mergedRowClassName}
+      hideHeader={hideHeader}
+      minWidth={minWidth}
+      rowHeight={rowHeight}
+      skeletonRows={skeletonRows}
+    />
+  );
+}

--- a/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { Button, Input } from '@jovie/ui';
-import { ArrowDown, ArrowUp, Search, Settings2, X } from 'lucide-react';
+import { ArrowDown, ArrowUp, Settings2 } from 'lucide-react';
 import type { FormEvent } from 'react';
-import { AppSearchField } from '@/components/molecules/AppSearchField';
 import {
   TableFilterDropdown,
   type TableFilterDropdownCategory,
@@ -24,17 +23,13 @@ export interface TaskSubviewOption {
 }
 
 export interface TaskWorkspaceHeaderBarProps {
-  readonly mode: 'default' | 'search' | 'create';
-  readonly search: string;
+  readonly mode: 'default' | 'create';
   readonly draftTitle: string;
   readonly taskCount: number;
   readonly subviews: ReadonlyArray<TaskSubviewOption>;
   readonly activeSubview: TaskSubviewId;
   readonly onSubviewChange: (subview: TaskSubviewId) => void;
-  readonly onSearchChange: (value: string) => void;
   readonly onDraftTitleChange: (value: string) => void;
-  readonly onEnterSearch: () => void;
-  readonly onExitSearch: () => void;
   readonly onCancelCreate: () => void;
   readonly onSubmitCreate: (event: FormEvent<HTMLFormElement>) => void;
   readonly createPending: boolean;
@@ -53,13 +48,9 @@ export interface TaskWorkspaceHeaderBarProps {
 
 export function TaskWorkspaceHeaderBar({
   mode,
-  search,
   draftTitle,
   taskCount,
-  onSearchChange,
   onDraftTitleChange,
-  onEnterSearch,
-  onExitSearch,
   onCancelCreate,
   onSubmitCreate,
   createPending,
@@ -86,18 +77,6 @@ export function TaskWorkspaceHeaderBar({
       className='flex h-[var(--linear-app-header-height-compact)] min-h-[var(--linear-app-header-height-compact)] items-center justify-between gap-3 px-app-header'
     >
       <div className='min-w-0 flex-1'>
-        {mode === 'search' && (
-          <AppSearchField
-            value={search}
-            onChange={onSearchChange}
-            onEscape={onExitSearch}
-            placeholder='Search Tasks'
-            ariaLabel='Search tasks'
-            autoFocus
-            className='h-8 max-w-[28rem] bg-transparent'
-            inputClassName='text-xs'
-          />
-        )}
         {mode === 'create' && (
           <form
             id={createFormId}
@@ -114,7 +93,7 @@ export function TaskWorkspaceHeaderBar({
             />
           </form>
         )}
-        {mode !== 'search' && mode !== 'create' && (
+        {mode !== 'create' && (
           <TaskSubviewTabs
             subviews={subviews}
             activeSubview={activeSubview}
@@ -148,36 +127,13 @@ export function TaskWorkspaceHeaderBar({
           </>
         ) : (
           <>
-            {mode === 'search' ? (
-              <PageToolbarActionButton
-                ariaLabel='Close search'
-                label='Close search'
-                onClick={onExitSearch}
-                icon={<X className='h-3.5 w-3.5' />}
-                iconOnly
-                tooltipLabel='Close search'
-              />
-            ) : (
-              <PageToolbarActionButton
-                ariaLabel='Search tasks'
-                label='Search tasks'
-                onClick={onEnterSearch}
-                tooltipLabel='Search'
-                tooltipShortcut='/'
-                iconOnly
-                data-app-search-trigger='true'
-                icon={<Search className='h-3.5 w-3.5' />}
-              />
-            )}
-            <div className={cn(mode === 'search' && 'opacity-100')}>
-              <TableFilterDropdown
-                categories={filterCategories}
-                onClearAll={onClearFilters}
-                iconOnly
-                align='end'
-                shortcutHint='S'
-              />
-            </div>
+            <TableFilterDropdown
+              categories={filterCategories}
+              onClearAll={onClearFilters}
+              iconOnly
+              align='end'
+              shortcutHint='S'
+            />
             <DisplayMenuDropdown
               viewMode={viewMode}
               availableViewModes={['board', 'list']}

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -16,7 +16,6 @@ import {
   FileText,
   MoreHorizontal,
   Plus,
-  Search,
   Trash2,
 } from 'lucide-react';
 import {
@@ -38,6 +37,7 @@ import { TableActionMenu } from '@/components/atoms/table-action-menu/TableActio
 import { DashboardHeaderActionButton } from '@/components/features/dashboard/atoms/DashboardHeaderActionButton';
 import { DashboardHeaderActionGroup } from '@/components/features/dashboard/atoms/DashboardHeaderActionGroup';
 import { ReleaseTaskDueBadge } from '@/components/features/dashboard/release-tasks/ReleaseTaskDueBadge';
+import { TaskDataTable } from '@/components/features/dashboard/tasks/TaskDataTable';
 import { TaskDescriptionHelper } from '@/components/features/dashboard/tasks/TaskDescriptionHelper';
 import {
   PriorityBars,
@@ -48,6 +48,7 @@ import {
   useTextareaAutosize,
 } from '@/components/jovie/hooks/useTextareaAutosize';
 import { ConfirmDialog } from '@/components/molecules/ConfirmDialog';
+import { HeaderSearchAction } from '@/components/molecules/HeaderSearchAction';
 import {
   TOOLBAR_MENU_CONTENT_CLASS,
   TOOLBAR_MENU_SEPARATOR_CLASS,
@@ -59,7 +60,6 @@ import { ReleaseSidebar } from '@/components/organisms/release-sidebar';
 import {
   type ContextMenuItemType,
   convertContextMenuItems,
-  UnifiedTable,
 } from '@/components/organisms/table';
 import {
   isFormElement,
@@ -1211,10 +1211,11 @@ export function TasksPageClient() {
   const canShowTaskDocumentAlongsideReleaseSidebar = useMediaQuery(
     '(min-width: 1720px)'
   );
-  const [headerMode, setHeaderMode] = useState<'default' | 'search' | 'create'>(
-    'default'
-  );
+  const [headerMode, setHeaderMode] = useState<'default' | 'create'>('default');
   const [search, setSearch] = useState('');
+  const [taskSearchOpenSignal, setTaskSearchOpenSignal] = useState<
+    number | undefined
+  >(undefined);
   const [statusFilter, setStatusFilter] = useState<TaskStatus | 'all'>('all');
   const [priorityFilter, setPriorityFilter] = useState<TaskPriority | 'all'>(
     'all'
@@ -1737,7 +1738,7 @@ export function TasksPageClient() {
 
       if (isTaskSearchShortcut(event)) {
         event.preventDefault();
-        setHeaderMode('search');
+        setTaskSearchOpenSignal(signal => (signal ?? 0) + 1);
         return;
       }
 
@@ -1774,6 +1775,16 @@ export function TasksPageClient() {
   const headerActions = useMemo(
     () => (
       <DashboardHeaderActionGroup>
+        <HeaderSearchAction
+          searchValue={search}
+          onSearchValueChange={setSearch}
+          onClearAction={() => setSearch('')}
+          placeholder='Search tasks'
+          ariaLabel='Search tasks'
+          submitAriaLabel='Search tasks'
+          tooltipLabel='Search'
+          openSignal={taskSearchOpenSignal}
+        />
         <DashboardHeaderActionButton
           ariaLabel='Create task'
           icon={<Plus className='h-3.5 w-3.5' />}
@@ -1784,7 +1795,7 @@ export function TasksPageClient() {
         />
       </DashboardHeaderActionGroup>
     ),
-    [headerMode]
+    [headerMode, search, taskSearchOpenSignal]
   );
 
   useEffect(() => {
@@ -1891,25 +1902,13 @@ export function TasksPageClient() {
     );
   } else if (isDesktopTaskLayout) {
     desktopTaskPane = (
-      <UnifiedTable
+      <TaskDataTable
         data={visibleTasks}
         columns={columns}
         isLoading={isLoading}
         getRowId={row => row.id}
-        hideHeader
-        enableVirtualization={false}
-        rowHeight={64}
-        skeletonRows={8}
-        className='text-app'
-        containerClassName='h-full overflow-y-auto overflow-x-hidden px-2.5 pb-2 pt-0.5'
-        minWidth='100%'
         onRowClick={row => openTaskDocument(row)}
         getContextMenuItems={getTaskContextMenuItems}
-        getRowClassName={_row =>
-          cn(
-            'group/task-row bg-transparent shadow-none hover:bg-transparent focus-within:shadow-none focus-visible:bg-transparent focus-visible:shadow-none'
-          )
-        }
         emptyState={
           <TaskEmptyState
             hasFilters={hasFilters}
@@ -1980,7 +1979,6 @@ export function TasksPageClient() {
           isDesktopTaskLayout || headerMode !== 'default' ? (
             <TaskWorkspaceHeaderBar
               mode={headerMode}
-              search={search}
               draftTitle={draftTitle}
               taskCount={
                 isBoardMode ? visibleBoardTaskCount : visibleTasks.length
@@ -1988,15 +1986,7 @@ export function TasksPageClient() {
               subviews={taskSubviewOptions}
               activeSubview={activeTaskSubview}
               onSubviewChange={setTaskSubview}
-              onSearchChange={value => {
-                setSearch(value);
-                if (headerMode === 'default') {
-                  setHeaderMode('search');
-                }
-              }}
               onDraftTitleChange={setDraftTitle}
-              onEnterSearch={() => setHeaderMode('search')}
-              onExitSearch={() => setHeaderMode('default')}
               onCancelCreate={() => {
                 setDraftTitle('');
                 setHeaderMode('default');
@@ -2064,24 +2054,10 @@ export function TasksPageClient() {
                     className='flex h-full min-h-0 flex-col overflow-hidden'
                     data-testid='mobile-task-list'
                   >
-                    <div className='flex items-center justify-between px-4 pb-1 pt-3'>
-                      <div>
-                        <p className='text-xs text-secondary-token'>
-                          {mobileScopeCounts.all} total tasks
-                        </p>
-                      </div>
-                      <button
-                        type='button'
-                        onClick={() =>
-                          setHeaderMode(current =>
-                            current === 'search' ? 'default' : 'search'
-                          )
-                        }
-                        aria-label='Search tasks'
-                        className='inline-flex h-10 w-10 items-center justify-center rounded-full bg-surface-1 text-secondary-token transition-[background-color,color] duration-subtle hover:bg-surface-0 hover:text-primary-token'
-                      >
-                        <Search className='h-4 w-4' />
-                      </button>
+                    <div className='flex items-center px-4 pb-1 pt-3'>
+                      <p className='text-xs text-secondary-token'>
+                        {mobileScopeCounts.all} total tasks
+                      </p>
                     </div>
                     <TaskSubviewTabs
                       subviews={taskSubviewOptions}

--- a/apps/web/components/molecules/HeaderSearchAction.tsx
+++ b/apps/web/components/molecules/HeaderSearchAction.tsx
@@ -19,6 +19,7 @@ export interface HeaderSearchActionProps {
   readonly className?: string;
   readonly inputClassName?: string;
   readonly alwaysOpen?: boolean;
+  readonly openSignal?: number;
 }
 
 export function HeaderSearchAction({
@@ -33,6 +34,7 @@ export function HeaderSearchAction({
   className,
   inputClassName,
   alwaysOpen = false,
+  openSignal,
 }: Readonly<HeaderSearchActionProps>) {
   const [isOpen, setIsOpen] = useState(alwaysOpen || searchValue.length > 0);
 
@@ -41,6 +43,11 @@ export function HeaderSearchAction({
       setIsOpen(true);
     }
   }, [searchValue]);
+
+  useEffect(() => {
+    if (openSignal === undefined) return;
+    setIsOpen(true);
+  }, [openSignal]);
 
   const close = () => {
     if (alwaysOpen) {

--- a/apps/web/components/shell/TasksRouteSkeleton.tsx
+++ b/apps/web/components/shell/TasksRouteSkeleton.tsx
@@ -1,0 +1,82 @@
+const TASK_ROWS = [
+  { key: 'task-1', titleWidth: '72%', metaWidth: '38%' },
+  { key: 'task-2', titleWidth: '84%', metaWidth: '44%' },
+  { key: 'task-3', titleWidth: '64%', metaWidth: '32%' },
+  { key: 'task-4', titleWidth: '78%', metaWidth: '48%' },
+  { key: 'task-5', titleWidth: '58%', metaWidth: '36%' },
+] as const;
+
+const BOARD_COLUMNS = ['backlog', 'todo', 'progress'] as const;
+
+export function TasksRouteSkeleton() {
+  return (
+    <section
+      aria-label='Loading tasks'
+      aria-busy='true'
+      aria-live='polite'
+      className='flex h-full min-h-0 flex-col bg-(--linear-app-content-surface)'
+    >
+      <div className='flex h-(--linear-app-header-height-compact) shrink-0 items-center justify-between gap-3 px-app-header'>
+        <div className='flex items-center gap-1.5'>
+          <div className='skeleton h-7 w-20 rounded-full' />
+          <div className='skeleton h-7 w-28 rounded-full' />
+          <div className='skeleton h-7 w-32 rounded-full' />
+        </div>
+        <div className='flex items-center gap-1'>
+          <div className='skeleton h-7 w-7 rounded-full' />
+          <div className='skeleton h-7 w-7 rounded-full' />
+        </div>
+      </div>
+
+      <div className='flex min-h-0 flex-1 overflow-hidden pb-2'>
+        <div className='hidden min-h-0 flex-1 gap-2 px-2.5 pt-0.5 lg:flex'>
+          {BOARD_COLUMNS.map(column => (
+            <div
+              key={`task-board-skeleton-${column}`}
+              className='min-w-0 flex-1 rounded-lg border border-subtle bg-surface-1 p-2'
+            >
+              <div className='skeleton mb-3 h-4 w-20 rounded' />
+              <div className='space-y-2'>
+                {TASK_ROWS.slice(0, 3).map(row => (
+                  <div
+                    key={`${column}-${row.key}`}
+                    className='rounded-md border border-subtle bg-surface-0 p-2.5'
+                  >
+                    <div
+                      className='skeleton h-3.5 rounded'
+                      style={{ width: row.titleWidth }}
+                    />
+                    <div
+                      className='skeleton mt-2 h-3 rounded'
+                      style={{ width: row.metaWidth }}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className='flex min-h-0 flex-1 flex-col px-2.5 pt-0.5 lg:hidden'>
+          {TASK_ROWS.map(row => (
+            <div
+              key={row.key}
+              className='flex h-16 shrink-0 items-center border-b border-subtle px-2'
+            >
+              <div className='min-w-0 flex-1 space-y-2'>
+                <div
+                  className='skeleton h-3.5 rounded'
+                  style={{ width: row.titleWidth }}
+                />
+                <div
+                  className='skeleton h-3 rounded'
+                  style={{ width: row.metaWidth }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/tests/e2e/tasks-layout.spec.ts
+++ b/apps/web/tests/e2e/tasks-layout.spec.ts
@@ -345,6 +345,10 @@ async function assertTasksLayout(
   await expect(page.getByTestId('task-list-pane')).toBeVisible({
     timeout: 30_000,
   });
+
+  await page.getByRole('button', { name: 'Search tasks' }).click();
+  await page.getByRole('searchbox', { name: 'Search tasks' }).fill(taskTitle);
+
   const targetRow = await openTaskRowByTitle(page, taskTitle);
 
   const listPane = page.getByTestId('task-list-pane');

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -4,6 +4,7 @@ import {
   isLibraryShellRoute,
   isLyricsShellRoute,
   isReleasesShellRoute,
+  isTasksShellRoute,
   resolveAppShellRequestPath,
   shouldRedirectToOnboarding,
   shouldUseEssentialShellData,
@@ -101,6 +102,19 @@ describe('isLibraryShellRoute', () => {
   });
 });
 
+describe('isTasksShellRoute', () => {
+  it('matches the dashboard tasks route', () => {
+    expect(isTasksShellRoute(APP_ROUTES.DASHBOARD_TASKS)).toBe(true);
+    expect(isTasksShellRoute(APP_ROUTES.TASKS)).toBe(true);
+  });
+
+  it('matches nested task subroutes', () => {
+    expect(isTasksShellRoute(`${APP_ROUTES.DASHBOARD_TASKS}/task-abc`)).toBe(
+      true
+    );
+  });
+});
+
 describe('shouldUseEssentialShellData', () => {
   it('returns true for chat routes', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.CHAT)).toBe(true);
@@ -110,9 +124,10 @@ describe('shouldUseEssentialShellData', () => {
     expect(shouldUseEssentialShellData('/app/dashboard/releases')).toBe(true);
   });
 
-  it('returns true for lyrics and library routes', () => {
+  it('returns true for lyrics, library, and tasks routes', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.LYRICS)).toBe(true);
     expect(shouldUseEssentialShellData(APP_ROUTES.LIBRARY)).toBe(true);
+    expect(shouldUseEssentialShellData(APP_ROUTES.DASHBOARD_TASKS)).toBe(true);
   });
 
   it('returns true for dashboard root', () => {
@@ -130,6 +145,7 @@ describe('shouldRedirectToOnboarding', () => {
     expect(shouldRedirectToOnboarding('/app/dashboard/releases')).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.LYRICS)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.LIBRARY)).toBe(true);
+    expect(shouldRedirectToOnboarding(APP_ROUTES.DASHBOARD_TASKS)).toBe(true);
   });
 
   it('returns false for null', () => {

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -218,10 +218,22 @@ describe('surface elevation guardrails', () => {
       join(ROOT, 'components/organisms/AppShellContentPanel.tsx'),
       'utf-8'
     );
+    const shellRouteMatches = readFileSync(
+      join(ROOT, 'app/app/(shell)/shell-route-matches.ts'),
+      'utf-8'
+    );
+    const appShellLayout = readFileSync(
+      join(ROOT, 'app/app/(shell)/layout.tsx'),
+      'utf-8'
+    );
 
     expect(tasksPage).toContain('PageShell');
     expect(dashboardPanel).toContain("frame = 'content-container'");
     expect(tasksPage).toContain("data-testid='tasks-content-panel'");
+    expect(tasksPage).toContain('TaskDataTable');
+    expect(tasksPage).not.toMatch(/<UnifiedTable\b/);
+    expect(shellRouteMatches).toContain('isTasksShellRoute');
+    expect(appShellLayout).toContain('TasksRouteSkeleton');
   });
 
   it('keeps presence and earnings inside framed content panels', () => {

--- a/apps/web/tests/unit/dashboard/TaskDataTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskDataTable.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  TASK_DATA_TABLE_CLASSNAME,
+  TASK_DATA_TABLE_CONTAINER_CLASSNAME,
+  TASK_DATA_TABLE_ROW_CLASSNAME,
+  TaskDataTable,
+} from '@/components/features/dashboard/tasks/TaskDataTable';
+
+vi.mock('@/components/organisms/table', () => ({
+  UnifiedTable: ({
+    className,
+    containerClassName,
+    enableVirtualization,
+    getRowClassName,
+    hideHeader,
+    minWidth,
+    rowHeight,
+    skeletonRows,
+  }: {
+    readonly className?: string;
+    readonly containerClassName?: string;
+    readonly enableVirtualization?: boolean;
+    readonly getRowClassName?: (
+      row: { readonly id: string },
+      index: number
+    ) => string;
+    readonly hideHeader?: boolean;
+    readonly minWidth?: string;
+    readonly rowHeight?: number;
+    readonly skeletonRows?: number;
+  }) => (
+    <div
+      data-class-name={className}
+      data-container-class-name={containerClassName}
+      data-hide-header={String(hideHeader)}
+      data-min-width={minWidth}
+      data-row-class-name={getRowClassName?.({ id: 'task-1' }, 0)}
+      data-row-height={String(rowHeight)}
+      data-skeleton-rows={String(skeletonRows)}
+      data-testid='unified-table'
+      data-virtualized={String(enableVirtualization)}
+    />
+  ),
+}));
+
+describe('TaskDataTable', () => {
+  it('applies canonical task list geometry and density defaults', () => {
+    render(<TaskDataTable columns={[]} data={[]} />);
+
+    const table = screen.getByTestId('unified-table');
+
+    expect(table).toHaveAttribute('data-class-name', TASK_DATA_TABLE_CLASSNAME);
+    expect(table).toHaveAttribute(
+      'data-container-class-name',
+      TASK_DATA_TABLE_CONTAINER_CLASSNAME
+    );
+    expect(table).toHaveAttribute('data-hide-header', 'true');
+    expect(table).toHaveAttribute('data-min-width', '100%');
+    expect(table).toHaveAttribute(
+      'data-row-class-name',
+      TASK_DATA_TABLE_ROW_CLASSNAME
+    );
+    expect(table).toHaveAttribute('data-row-height', '64');
+    expect(table).toHaveAttribute('data-skeleton-rows', '8');
+    expect(table).toHaveAttribute('data-virtualized', 'false');
+  });
+
+  it('allows callers to extend task table chrome without losing row defaults', () => {
+    render(
+      <TaskDataTable
+        className='custom-density'
+        columns={[]}
+        containerClassName='custom-scroll'
+        data={[]}
+        getRowClassName={() => 'selected-row'}
+        rowHeight={72}
+      />
+    );
+
+    const table = screen.getByTestId('unified-table');
+
+    expect(table).toHaveAttribute(
+      'data-class-name',
+      `${TASK_DATA_TABLE_CLASSNAME} custom-density`
+    );
+    expect(table).toHaveAttribute(
+      'data-container-class-name',
+      `${TASK_DATA_TABLE_CONTAINER_CLASSNAME} custom-scroll`
+    );
+    expect(table).toHaveAttribute(
+      'data-row-class-name',
+      `${TASK_DATA_TABLE_ROW_CLASSNAME} selected-row`
+    );
+    expect(table).toHaveAttribute('data-row-height', '72');
+  });
+});

--- a/apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
@@ -17,27 +17,6 @@ vi.mock('@jovie/ui', () => ({
   ),
 }));
 
-vi.mock('@/components/molecules/AppSearchField', () => ({
-  AppSearchField: ({
-    value,
-    onChange,
-    ariaLabel,
-    placeholder,
-  }: {
-    readonly value: string;
-    readonly onChange: (value: string) => void;
-    readonly ariaLabel: string;
-    readonly placeholder?: string;
-  }) => (
-    <input
-      aria-label={ariaLabel}
-      value={value}
-      placeholder={placeholder}
-      onChange={event => onChange(event.target.value)}
-    />
-  ),
-}));
-
 vi.mock('@/components/molecules/filters', () => ({
   TableFilterDropdown: () => <button type='button'>Filters</button>,
 }));
@@ -77,7 +56,6 @@ vi.mock('@/components/organisms/table/molecules/DisplayMenuDropdown', () => ({
 
 function createBaseProps() {
   return {
-    search: '',
     draftTitle: '',
     taskCount: 2,
     subviews: [
@@ -87,10 +65,7 @@ function createBaseProps() {
     ],
     activeSubview: 'all',
     onSubviewChange: vi.fn(),
-    onSearchChange: vi.fn(),
     onDraftTitleChange: vi.fn(),
-    onEnterSearch: vi.fn(),
-    onExitSearch: vi.fn(),
     onCancelCreate: vi.fn(),
     onSubmitCreate: vi.fn((event: FormEvent<HTMLFormElement>) =>
       event.preventDefault()
@@ -127,8 +102,8 @@ describe('TaskWorkspaceHeaderBar', () => {
       screen.getByRole('tab', { name: 'Assigned To Me 1' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Search tasks' })
-    ).toBeInTheDocument();
+      screen.queryByRole('button', { name: 'Search tasks' })
+    ).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Filters' })).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Display options' })
@@ -153,20 +128,6 @@ describe('TaskWorkspaceHeaderBar', () => {
     fireEvent.click(screen.getByRole('button', { name: 'List view' }));
 
     expect(props.onViewModeChange).toHaveBeenCalledWith('list');
-  });
-
-  it('renders search mode controls without reintroducing the divider', () => {
-    const props = createBaseProps();
-
-    render(<TaskWorkspaceHeaderBar {...props} mode='search' />);
-
-    const subheader = screen.getByTestId('tasks-workspace-subheader');
-    expect(subheader).not.toHaveClass('border-b');
-    expect(screen.getByRole('textbox', { name: 'Search tasks' })).toHaveValue(
-      ''
-    );
-    fireEvent.click(screen.getByRole('button', { name: 'Close search' }));
-    expect(props.onExitSearch).toHaveBeenCalledTimes(1);
   });
 
   it('renders create mode controls and submits the draft form', () => {

--- a/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
@@ -76,9 +76,12 @@ describe('@critical DashboardShellContent behavior contracts', () => {
       expect(shouldUseEssentialShellData('/app/dashboard/releases')).toBe(true);
     });
 
-    it('lyrics and library routes use essential shell data', () => {
+    it('lyrics, library, and tasks routes use essential shell data', () => {
       expect(shouldUseEssentialShellData(APP_ROUTES.LYRICS)).toBe(true);
       expect(shouldUseEssentialShellData(APP_ROUTES.LIBRARY)).toBe(true);
+      expect(shouldUseEssentialShellData(APP_ROUTES.DASHBOARD_TASKS)).toBe(
+        true
+      );
     });
 
     it('dashboard root uses essential shell data', () => {


### PR DESCRIPTION
## Summary
- moves primary task text search into the shared shell header actions
- keeps task toolbar focused on subviews, filters, display, task navigation, and create mode
- adds a canonical TaskDataTable wrapper for task list mode
- adds a tasks route skeleton and explicit tasks shell route matching

## Verification
- pnpm biome check --write apps/web/components/molecules/HeaderSearchAction.tsx apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx apps/web/components/features/dashboard/tasks/TaskDataTable.tsx apps/web/components/features/dashboard/tasks/TasksPageClient.tsx apps/web/components/shell/TasksRouteSkeleton.tsx apps/web/app/app/'(shell)'/shell-route-matches.ts apps/web/app/app/'(shell)'/layout.tsx apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx apps/web/tests/unit/dashboard/TaskDataTable.test.tsx apps/web/tests/unit/dashboard/TasksPageClient.test.tsx apps/web/tests/unit/app/shell-route-matches.test.ts apps/web/tests/unit/app/surface-elevation-guardrails.test.ts apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts apps/web/tests/e2e/tasks-layout.spec.ts
- pnpm --filter web exec vitest run tests/unit/dashboard/TaskDataTable.test.tsx tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx tests/unit/dashboard/TasksPageClient.test.tsx tests/unit/app/shell-route-matches.test.ts tests/unit/app/surface-elevation-guardrails.test.ts tests/unit/dashboard/dashboard-shell-content.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- BASE_URL=http://127.0.0.1:3112 E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready E2E_SKIP_WEB_SERVER=1 PLAYWRIGHT_WORKERS=1 pnpm --filter web exec playwright test tests/e2e/shell-route-persistence.spec.ts --project=chromium --reporter=line
- git push pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

## Design Review
- checked desktop list and desktop search screenshots
- checked mobile list and mobile search screenshots

## E2E Note
- tasks-layout.spec.ts could not run locally because DATABASE_URL is unset; it failed before UI assertions at test data seeding.

Linear: JOV-2294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dedicated search action added to the tasks page
  * Loading skeleton UI implemented for tasks routes
  * Optimized table component for displaying task data
  * Enhanced shell routing configuration for tasks pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8842?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->