### PR TITLE
JOV-2296: Unify chat threads in the app shell

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -84,18 +84,16 @@ export function resetWelcomeChatBootstrapState(
 }
 
 /**
- * Header badge that displays the conversation title as a subtle breadcrumb suffix.
+ * Header badge that displays the conversation title as the breadcrumb suffix.
  * Rendered inside the DashboardHeader via HeaderActionsContext.
  */
 function ChatTitleBadge({ title }: { readonly title: string }) {
   return (
-    <span className='flex min-w-0 items-center gap-2 rounded-xl border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-2.5 py-1.5'>
-      <span className='shrink-0 text-2xs font-semibold tracking-normal text-tertiary-token'>
-        Thread
-      </span>
-      <span className='block max-w-[220px] truncate text-xs font-caption text-primary-token'>
-        {title}
-      </span>
+    <span
+      className='block max-w-[260px] truncate text-xs font-semibold tracking-[-0.01em] text-primary-token'
+      title={title}
+    >
+      {title}
     </span>
   );
 }

--- a/apps/web/app/app/(shell)/chat/[id]/loading.tsx
+++ b/apps/web/app/app/(shell)/chat/[id]/loading.tsx
@@ -1,4 +1,5 @@
 import { ChatWorkspaceSurface } from '@/components/jovie/ChatWorkspaceSurface';
+import { CHAT_COMPOSER_DOCK_CLASSNAME } from '@/components/jovie/chat-layout';
 import { ChatMessageSkeleton } from '@/components/jovie/components/ChatMessageSkeleton';
 import { LoadingSkeleton } from '@/components/molecules/LoadingSkeleton';
 
@@ -13,7 +14,7 @@ export default function ChatConversationLoading() {
         <div className='flex-1 px-4 py-5 sm:px-5'>
           <ChatMessageSkeleton />
         </div>
-        <div className='bg-(--linear-app-content-surface) px-4 pb-4 pt-2 sm:px-5 sm:pb-5 sm:pt-2.5'>
+        <div className={CHAT_COMPOSER_DOCK_CLASSNAME}>
           <div className='mx-auto max-w-2xl'>
             <LoadingSkeleton height='h-10' width='w-full' rounded='lg' />
           </div>

--- a/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
@@ -9,7 +9,6 @@ import {
 } from '@jovie/ui';
 import { Copy, ExternalLink } from 'lucide-react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import {
   type ComponentType,
   type MouseEvent,
@@ -114,7 +113,6 @@ export function NavMenuItem({
   onPrefetch,
   useShellNavItem = false,
 }: NavMenuItemProps) {
-  const router = useRouter();
   const isElectronRuntime = useIsElectronRuntime();
   const pendingNavigationRef = useRef(false);
   const clearPendingNavigationListenersRef = useRef<(() => void) | null>(null);
@@ -204,7 +202,7 @@ export function NavMenuItem({
       if (preventNavigation) {
         event.preventDefault();
       }
-      const shouldInterceptNavigation =
+      const isPlainNavigation =
         !preventNavigation &&
         Boolean(onNavigate) &&
         event.button === 0 &&
@@ -213,30 +211,21 @@ export function NavMenuItem({
         !event.shiftKey &&
         !event.altKey;
 
-      if (!hadPendingPointerNavigation && shouldInterceptNavigation) {
+      if (!hadPendingPointerNavigation && isPlainNavigation) {
         showPendingShell();
       }
       onClick?.();
 
-      if (!shouldInterceptNavigation && onNavigate) {
+      if (!isPlainNavigation && onNavigate) {
         onCancelNavigate?.();
-      }
-
-      if (shouldInterceptNavigation) {
-        event.preventDefault();
-        requestAnimationFrame(() => {
-          router.push(item.href);
-        });
       }
     },
     [
-      item.href,
       clearPendingNavigationListeners,
       onCancelNavigate,
       onClick,
       onNavigate,
       preventNavigation,
-      router,
       showPendingShell,
     ]
   );

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useAppFlag } from '@/lib/flags/client';
 import { SUPPORTED_IMAGE_MIME_TYPES } from '@/lib/images/config';
 
+import { CHAT_COMPOSER_DOCK_CLASSNAME } from './chat-layout';
 import {
   ChatInput,
   ChatMessage,
@@ -387,11 +388,11 @@ export function JovieChat({
     getFirstNameForGreeting(displayName) ?? getFirstNameForGreeting(username);
   let emptyStateHeading: string;
   if (isFirstSession) {
-    emptyStateHeading = 'Welcome to Jovie';
+    emptyStateHeading = "Hey, I'm Jovie";
   } else if (greetingName) {
-    emptyStateHeading = `Welcome Back ${greetingName}`;
+    emptyStateHeading = `Welcome back, ${greetingName}`;
   } else {
-    emptyStateHeading = 'Welcome Back';
+    emptyStateHeading = 'Welcome back';
   }
 
   return (
@@ -423,16 +424,18 @@ export function JovieChat({
           {isDragOver && (
             <motion.div
               data-testid='chat-attachment-dropzone'
-              className='absolute inset-0 z-50 flex items-center justify-center rounded-[var(--linear-app-shell-radius)] border border-dashed border-white/22 bg-black/58 p-6 backdrop-blur-md'
-              initial={{ opacity: 0, scale: 0.995 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.995 }}
+              className='absolute inset-0 z-50 flex items-center justify-center rounded-[var(--linear-app-shell-radius)] border border-dashed border-(--linear-app-frame-seam) bg-[linear-gradient(180deg,color-mix(in_oklab,var(--linear-app-content-surface)_82%,black),color-mix(in_oklab,var(--linear-app-content-surface)_70%,black))] p-6 backdrop-blur-md'
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
               transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
             >
-              <div className='flex min-h-40 w-full max-w-sm flex-col items-center justify-center gap-3 rounded-2xl border border-white/[0.1] bg-[linear-gradient(180deg,rgba(255,255,255,0.07),rgba(255,255,255,0.03)),#17181d] px-6 py-8 text-center shadow-[0_24px_80px_-32px_rgba(0,0,0,0.95)]'>
-                <span className='flex h-11 w-11 items-center justify-center rounded-full bg-white text-black shadow-[0_8px_24px_-12px_rgba(0,0,0,0.9)]'>
-                  <ImagePlus className='h-5 w-5' />
-                </span>
+              <div className='flex min-h-40 w-full max-w-sm flex-col items-center justify-center gap-3 rounded-xl border border-(--linear-app-frame-seam) bg-surface-1 px-6 py-8 text-center shadow-[0_24px_80px_-32px_rgba(0,0,0,0.95)]'>
+                <ImagePlus
+                  className='h-7 w-7 text-secondary-token'
+                  aria-hidden='true'
+                  strokeWidth={2.25}
+                />
                 <div>
                   <p className='text-sm font-semibold tracking-[-0.01em] text-primary-token'>
                     Drop images to attach
@@ -553,7 +556,7 @@ export function JovieChat({
             mounted. Now each alert opts in to its own bottom margin and is
             unmounted entirely when empty.
           */}
-            <div className='shrink-0 bg-(--linear-app-content-surface) px-4 pb-4 pt-2 sm:px-5 sm:pb-5 sm:pt-2.5'>
+            <div className={CHAT_COMPOSER_DOCK_CLASSNAME}>
               <div className='mx-auto w-full max-w-[45rem]'>
                 {/* Transient alerts stack above the input. Each contributes its
                   own bottom margin only when rendered, so toggling them does
@@ -659,7 +662,7 @@ export function JovieChat({
               </div>
             </div>
 
-            <div className='shrink-0 bg-(--linear-app-content-surface) px-4 pb-4 pt-2 sm:px-5 sm:pb-5 sm:pt-2.5'>
+            <div className={CHAT_COMPOSER_DOCK_CLASSNAME}>
               <div className='mx-auto w-full max-w-[45rem]'>
                 <ChatUsageAlert />
 

--- a/apps/web/components/jovie/chat-layout.ts
+++ b/apps/web/components/jovie/chat-layout.ts
@@ -1,0 +1,2 @@
+export const CHAT_COMPOSER_DOCK_CLASSNAME =
+  'shrink-0 bg-(--linear-app-content-surface) px-4 pt-2 pb-4 max-lg:pb-[calc(1.5rem+env(safe-area-inset-bottom))] sm:px-5 sm:pt-2.5 lg:pb-5';

--- a/apps/web/components/shell/SidebarThreadsSection.test.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type SidebarThread,
+  SidebarThreadsSection,
+} from './SidebarThreadsSection';
+
+const threads: SidebarThread[] = [
+  {
+    id: 'thread-older',
+    href: '/app/chat/thread-older',
+    title: 'Release rollout',
+    status: 'complete',
+    updatedAt: '2026-05-10T00:00:00.000Z',
+  },
+  {
+    id: 'thread-newer',
+    href: '/app/chat/thread-newer',
+    title: 'Pitch tasks',
+    status: 'complete',
+    updatedAt: '2026-05-12T00:00:00.000Z',
+  },
+];
+
+describe('SidebarThreadsSection', () => {
+  it('renders dense thread links with canonical shell row state', () => {
+    render(
+      <SidebarThreadsSection
+        threads={threads}
+        activeThreadId='thread-newer'
+        tight
+        collapsed={false}
+      />
+    );
+
+    const activeThread = screen.getByRole('link', { name: 'Pitch tasks' });
+    const inactiveThread = screen.getByRole('link', {
+      name: 'Release rollout',
+    });
+
+    expect(activeThread).toHaveAttribute('href', '/app/chat/thread-newer');
+    expect(activeThread).toHaveAttribute('aria-current', 'page');
+    expect(activeThread).toHaveClass('h-6');
+    expect(activeThread).toHaveClass('bg-surface-1');
+    expect(activeThread).toHaveClass('text-primary-token');
+    expect(inactiveThread).toHaveClass('text-secondary-token');
+    expect(inactiveThread).toHaveClass('hover:bg-surface-1');
+    expect(inactiveThread).toHaveClass('focus-visible:ring-1');
+  });
+
+  it('keeps thread action affordances opt-in and wired to the row thread', () => {
+    const onThreadContextMenu = vi.fn();
+
+    render(
+      <SidebarThreadsSection
+        threads={threads.slice(1)}
+        activeThreadId={null}
+        onThreadContextMenu={onThreadContextMenu}
+        tight
+        collapsed={false}
+      />
+    );
+
+    const threadLink = screen.getByRole('link', { name: 'Pitch tasks' });
+    const actionsButton = screen.getByRole('button', {
+      name: 'Thread actions for Pitch tasks',
+    });
+
+    fireEvent.contextMenu(threadLink);
+    fireEvent.click(actionsButton);
+
+    expect(onThreadContextMenu).toHaveBeenCalledTimes(2);
+    expect(onThreadContextMenu.mock.calls[0][1]).toMatchObject({
+      id: 'thread-newer',
+    });
+    expect(onThreadContextMenu.mock.calls[1][1]).toMatchObject({
+      id: 'thread-newer',
+    });
+  });
+
+  it('renders selectable button rows when no href is provided', () => {
+    const onSelect = vi.fn();
+
+    render(
+      <SidebarThreadsSection
+        threads={[
+          {
+            id: 'draft-thread',
+            title: 'Draft thread',
+            status: 'running',
+            updatedAt: '2026-05-12T00:00:00.000Z',
+          },
+        ]}
+        activeThreadId='draft-thread'
+        onSelect={onSelect}
+        tight
+        collapsed={false}
+      />
+    );
+
+    const threadButton = screen.getByRole('button', { name: 'Draft thread' });
+
+    expect(threadButton).toHaveAttribute('aria-pressed', 'true');
+    fireEvent.click(threadButton);
+    expect(onSelect).toHaveBeenCalledWith('draft-thread');
+  });
+});

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
+import { Tooltip } from './Tooltip';
 
 // Thread types — co-located so consumers import from one place. Production
 // adapters should map real conversation records into this flat shell contract.
@@ -183,9 +184,16 @@ export function SidebarThreadsSection({
         {visible.map(t => {
           const active = activeThreadId === t.id;
           const unread = !!t.unread && !active;
+          const hasThreadActions = Boolean(onThreadContextMenu);
           const rowClasses = cn(
-            'flex-1 flex items-center gap-2 min-w-0 text-left',
-            tight ? 'h-6 pl-2.5 pr-2' : 'h-7 pl-3 pr-2'
+            'flex w-full min-w-0 items-center gap-2 rounded-md text-left transition-colors duration-subtle ease-out focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35',
+            tight ? 'h-6 pl-2.5' : 'h-7 pl-3',
+            hasThreadActions ? 'pr-7' : 'pr-2',
+            active
+              ? 'bg-surface-1 text-primary-token'
+              : unread
+                ? 'text-primary-token hover:bg-surface-1 focus-visible:bg-surface-1'
+                : 'text-secondary-token hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:text-primary-token'
           );
           const rowContent = (
             <>
@@ -204,7 +212,7 @@ export function SidebarThreadsSection({
               <span
                 className={cn(
                   'flex-1 truncate',
-                  tight ? 'text-[12px]' : 'text-[12.5px]',
+                  'text-[12.5px]',
                   unread && 'font-medium'
                 )}
               >
@@ -213,46 +221,53 @@ export function SidebarThreadsSection({
             </>
           );
           return (
-            // biome-ignore lint/a11y/noStaticElementInteractions: row hosts a real link/button; div is hover container with right-click menu
-            // biome-ignore lint/a11y/noNoninteractiveElementInteractions: same
             <div
               key={t.id}
               className={cn(
-                'group/thread relative flex items-center rounded-md transition-colors duration-subtle ease-out',
-                tight ? 'h-6' : 'h-7',
-                active
-                  ? 'bg-surface-1 text-primary-token'
-                  : unread
-                    ? 'text-primary-token hover:bg-surface-1/50'
-                    : 'text-tertiary-token hover:bg-surface-1/50 hover:text-primary-token'
+                'group/thread relative flex items-center',
+                tight ? 'h-6' : 'h-7'
               )}
-              onContextMenu={e => onThreadContextMenu?.(e, t)}
             >
-              {t.href ? (
-                <Link href={t.href} className={rowClasses}>
-                  {rowContent}
-                </Link>
-              ) : (
-                <button
-                  type='button'
-                  onClick={() => onSelect?.(t.id)}
-                  className={rowClasses}
-                >
-                  {rowContent}
-                </button>
-              )}
+              <Tooltip label={t.title} side='right' block>
+                {t.href ? (
+                  <Link
+                    href={t.href}
+                    aria-current={active ? 'page' : undefined}
+                    className={rowClasses}
+                    onContextMenu={e => onThreadContextMenu?.(e, t)}
+                  >
+                    {rowContent}
+                  </Link>
+                ) : (
+                  <button
+                    type='button'
+                    onClick={() => onSelect?.(t.id)}
+                    onContextMenu={e => onThreadContextMenu?.(e, t)}
+                    aria-pressed={active}
+                    className={rowClasses}
+                  >
+                    {rowContent}
+                  </button>
+                )}
+              </Tooltip>
               {onThreadContextMenu ? (
-                <button
-                  type='button'
-                  onClick={e => onThreadContextMenu(e, t)}
-                  aria-label='Thread actions'
-                  className={cn(
-                    'absolute right-1 top-1/2 -translate-y-1/2 h-5 w-5 rounded grid place-items-center text-quaternary-token hover:text-primary-token hover:bg-surface-2/70 transition-opacity duration-subtle ease-out',
-                    'opacity-0 group-hover/thread:opacity-100 focus-visible:opacity-100'
-                  )}
-                >
-                  <MoreHorizontal className='h-3 w-3' strokeWidth={2.25} />
-                </button>
+                <Tooltip label='Thread actions' side='right'>
+                  <button
+                    type='button'
+                    onClick={e => onThreadContextMenu(e, t)}
+                    aria-label={`Thread actions for ${t.title}`}
+                    className={cn(
+                      'absolute right-1 top-1/2 grid h-5 w-5 -translate-y-1/2 place-items-center rounded-md text-quaternary-token transition-[background-color,color,opacity] duration-subtle ease-out hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35',
+                      'opacity-0 group-hover/thread:opacity-100 focus-visible:opacity-100'
+                    )}
+                  >
+                    <MoreHorizontal
+                      className='h-3 w-3'
+                      strokeWidth={2.25}
+                      aria-hidden='true'
+                    />
+                  </button>
+                </Tooltip>
               ) : null}
             </div>
           );

--- a/apps/web/tests/e2e/shell-chat-v1.spec.ts
+++ b/apps/web/tests/e2e/shell-chat-v1.spec.ts
@@ -152,3 +152,57 @@ test('chat route picker opens without moving the shell or composer', async ({
   }
   expect(afterScrollTop).toBe(beforeScrollTop);
 });
+
+test('chat composer clears mobile shell tabs on tablet and phone', async ({
+  page,
+}) => {
+  test.skip(
+    process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
+    'Requires E2E_USE_TEST_AUTH_BYPASS=1'
+  );
+  test.setTimeout(180_000);
+
+  await forceDesignV1(page);
+  await setTestAuthBypassSession(
+    page,
+    'creator-ready',
+    'e2e-shell-chat-mobile-user'
+  );
+
+  for (const viewport of [
+    { label: 'tablet', width: 768, height: 1024 },
+    { label: 'phone', width: 390, height: 844 },
+    { label: 'small phone', width: 320, height: 568 },
+  ] as const) {
+    await page.setViewportSize({
+      width: viewport.width,
+      height: viewport.height,
+    });
+    await gotoChatRoute(page);
+    await page.waitForURL(/\/app\/chat/, { timeout: 60_000 });
+
+    const { composer } = shellChatFrameLocators(page);
+    const mobileTabs = page.getByRole('navigation', {
+      name: 'Dashboard tabs',
+    });
+
+    await expect(composer).toBeVisible({ timeout: 30_000 });
+    await expect(mobileTabs).toBeVisible({ timeout: 30_000 });
+
+    const composerBox = await composer.boundingBox();
+    const tabsBox = await mobileTabs.boundingBox();
+
+    expect(composerBox, `${viewport.label} composer is measurable`).not.toBe(
+      null
+    );
+    expect(tabsBox, `${viewport.label} mobile tabs are measurable`).not.toBe(
+      null
+    );
+    if (composerBox && tabsBox) {
+      expect(
+        composerBox.y + composerBox.height,
+        `${viewport.label} composer bottom clears tabs`
+      ).toBeLessThanOrEqual(tabsBox.y - 2);
+    }
+  }
+});

--- a/apps/web/tests/e2e/shell-route-persistence.spec.ts
+++ b/apps/web/tests/e2e/shell-route-persistence.spec.ts
@@ -280,11 +280,19 @@ async function clickOptionalFirstVisibleAppLink(
     const link = links.nth(index);
     if (!(await link.isVisible().catch(() => false))) continue;
 
-    await link.click({ noWaitAfter: true });
-    await page.waitForURL(url => expectedPathnames.includes(url.pathname), {
-      timeout: 60_000,
-      waitUntil: 'commit',
-    });
+    const currentPathname = new URL(page.url()).pathname;
+    const waitForTargetRoute = expectedPathnames.includes(currentPathname)
+      ? Promise.resolve()
+      : page.waitForURL(url => expectedPathnames.includes(url.pathname), {
+          timeout: 60_000,
+          waitUntil: 'commit',
+        });
+
+    await Promise.all([waitForTargetRoute, link.click({ noWaitAfter: true })]);
+    await expect(page).toHaveURL(
+      url => expectedPathnames.includes(url.pathname),
+      { timeout: 60_000 }
+    );
     return true;
   }
 

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -115,8 +115,8 @@ describe('JovieChat empty state', () => {
       <JovieChat profileId='profile-1' />
     );
 
-    expect(getByText('Welcome Back')).toBeTruthy();
-    expect(queryByText('Welcome to Jovie')).toBeNull();
+    expect(getByText('Welcome back')).toBeTruthy();
+    expect(queryByText("Hey, I'm Jovie")).toBeNull();
     expect(queryByText('Jovie Assistant')).toBeNull();
     expect(queryByText('Ask anything or tell Jovie what you need')).toBeNull();
     expect(getByTestId('chat-input')).toBeTruthy();
@@ -135,7 +135,7 @@ describe('JovieChat empty state', () => {
       <JovieChat profileId='profile-1' isFirstSession />
     );
 
-    expect(getByText('Welcome to Jovie')).toBeTruthy();
+    expect(getByText("Hey, I'm Jovie")).toBeTruthy();
   });
 
   it('uses only the first name in the returning-user welcome heading', () => {
@@ -143,8 +143,8 @@ describe('JovieChat empty state', () => {
       <JovieChat profileId='profile-1' displayName='Tim White' />
     );
 
-    expect(getByText('Welcome Back Tim')).toBeTruthy();
-    expect(queryByText('Welcome Back Tim White')).toBeNull();
+    expect(getByText('Welcome back, Tim')).toBeTruthy();
+    expect(queryByText('Welcome back, Tim White')).toBeNull();
   });
 
   it('renders chat messages after in-place message array updates', () => {
@@ -153,7 +153,7 @@ describe('JovieChat empty state', () => {
       <JovieChat profileId='profile-1' />
     );
 
-    expect(queryByText('Welcome Back')).toBeTruthy();
+    expect(queryByText('Welcome back')).toBeTruthy();
 
     messages.push(
       {
@@ -173,7 +173,7 @@ describe('JovieChat empty state', () => {
 
     rerender(<JovieChat profileId='profile-1' />);
 
-    expect(queryByText('Welcome Back')).toBeNull();
+    expect(queryByText('Welcome back')).toBeNull();
     expect(getAllByTestId('chat-message')).toHaveLength(2);
   });
 });

--- a/apps/web/tests/unit/chat/JovieChat.styling.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.styling.test.tsx
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { CHAT_COMPOSER_DOCK_CLASSNAME } from '@/components/jovie/chat-layout';
 import { JovieChat } from '@/components/jovie/JovieChat';
 import { renderWithQueryClient } from '@/tests/utils/test-utils';
 
@@ -146,5 +147,19 @@ describe('JovieChat styling regressions', () => {
     // Verify the chat input area renders
     const chatInput = container.querySelector('[data-testid="chat-input"]');
     expect(chatInput).toBeTruthy();
+  });
+
+  it('keeps the composer dock padded above mobile shell navigation', () => {
+    const { container } = renderWithQueryClient(
+      <JovieChat profileId='profile-1' />
+    );
+
+    const composerDock = container.querySelector('[data-testid="chat-input"]')
+      ?.parentElement?.parentElement;
+
+    expect(composerDock?.className).toContain(CHAT_COMPOSER_DOCK_CLASSNAME);
+    expect(composerDock?.className).toContain(
+      'max-lg:pb-[calc(1.5rem+env(safe-area-inset-bottom))]'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Align chat header, empty-state copy, and composer dock spacing with the canonical shell.
- Move chat thread sidebar rows onto the same dense tokenized shell row treatment, with accessible row/action affordances.
- Keep Releases route navigation on normal Next Link routing while preserving the pending-shell visual state so fast route switches cannot replay stale content over Library.
- Harden the shell persistence E2E helper by arming URL waits before clicks and asserting the final pathname.

## Verification
- `pnpm biome check --write apps/web/app/app/'(shell)'/chat/ChatPageClient.tsx apps/web/app/app/'(shell)'/chat/'[id]'/loading.tsx apps/web/components/jovie/JovieChat.tsx apps/web/components/jovie/chat-layout.ts apps/web/components/shell/SidebarThreadsSection.tsx apps/web/components/shell/SidebarThreadsSection.test.tsx apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx apps/web/tests/e2e/shell-chat-v1.spec.ts apps/web/tests/e2e/shell-route-persistence.spec.ts apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx apps/web/tests/unit/chat/JovieChat.styling.test.tsx`
- `pnpm --filter web exec vitest run components/shell/SidebarThreadsSection.test.tsx tests/components/dashboard/DashboardNav.interaction.test.tsx tests/unit/chat/JovieChat.empty-state.test.tsx tests/unit/chat/JovieChat.styling.test.tsx tests/unit/chat/ChatPageClient.test.tsx tests/unit/chat/ChatInput.aria.test.tsx tests/unit/chat/SlashCommandMenu.keyboard.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `BASE_URL=http://127.0.0.1:3112 E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready E2E_SKIP_WEB_SERVER=1 PLAYWRIGHT_WORKERS=1 pnpm --filter web exec playwright test tests/e2e/shell-route-persistence.spec.ts --project=chromium --reporter=line`
- `BASE_URL=http://127.0.0.1:3112 E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready E2E_SKIP_WEB_SERVER=1 PLAYWRIGHT_WORKERS=1 pnpm --filter web exec playwright test tests/e2e/shell-chat-v1.spec.ts --project=chromium --reporter=line`
- pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`

## Visual QA
- Desktop: `/Users/timwhite/.gstack/projects/JovieInc-Jovie/screenshots/jov-2296-chat-desktop.png`
- Tablet: `/Users/timwhite/.gstack/projects/JovieInc-Jovie/screenshots/jov-2296-chat-tablet.png`
- Mobile: `/Users/timwhite/.gstack/projects/JovieInc-Jovie/screenshots/jov-2296-chat-mobile.png`
- Small mobile: `/Users/timwhite/.gstack/projects/JovieInc-Jovie/screenshots/jov-2296-chat-mobile-small.png`
- Metrics: `/Users/timwhite/.gstack/projects/JovieInc-Jovie/screenshots/jov-2296-chat-screenshot-metrics.json`

Linear: JOV-2296


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips to thread navigation items for improved usability.

* **Improvements**
  * Updated chat greeting messages: first-time users see "Hey, I'm Jovie"; returning users see "Welcome back" personalization.
  * Enhanced chat interface styling consistency across components.
  * Refined drag-and-drop overlay visual styling.
  * Improved mobile layout to ensure chat composer is properly positioned on smaller screens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8845?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->