### PR TITLE
JOV-2299 canonicalize releases and tasks shell chrome

### DIFF
--- a/apps/web/components/features/dashboard/organisms/ReleaseTablePendingShell.tsx
+++ b/apps/web/components/features/dashboard/organisms/ReleaseTablePendingShell.tsx
@@ -1,4 +1,10 @@
-import { LoadingSkeleton } from '@/components/molecules/LoadingSkeleton';
+import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import { PageShell } from '@/components/organisms/PageShell';
+import {
+  PAGE_TOOLBAR_META_TEXT_CLASS,
+  PageToolbar,
+  UnifiedTableSkeleton,
+} from '@/components/organisms/table';
 import { SKELETON_ROW_COUNT } from '@/lib/constants/layout';
 
 interface ReleaseTablePendingShellProps {
@@ -6,63 +12,92 @@ interface ReleaseTablePendingShellProps {
   readonly testId?: string;
 }
 
-const RELEASES_LOADING_ROW_KEYS = Array.from(
-  { length: SKELETON_ROW_COUNT.TABLE },
-  (_, i) => `loading-row-${i + 1}`
-);
+type ReleaseLoadingRow = {
+  readonly id: string;
+  readonly release: string;
+  readonly status: string;
+  readonly date: string;
+  readonly platforms: string;
+  readonly actions: string;
+};
+
+const releaseLoadingColumnHelper = createColumnHelper<ReleaseLoadingRow>();
+
+const RELEASE_LOADING_COLUMNS = [
+  releaseLoadingColumnHelper.accessor('release', {
+    id: 'release',
+    header: 'Release',
+    size: 9999,
+    minSize: 220,
+  }),
+  releaseLoadingColumnHelper.accessor('status', {
+    id: 'status',
+    header: 'Status',
+    size: 112,
+    minSize: 92,
+    meta: { className: 'hidden md:table-cell' },
+  }),
+  releaseLoadingColumnHelper.accessor('date', {
+    id: 'date',
+    header: 'Release Date',
+    size: 128,
+    minSize: 112,
+    meta: { className: 'hidden lg:table-cell' },
+  }),
+  releaseLoadingColumnHelper.accessor('platforms', {
+    id: 'platforms',
+    header: 'Platforms',
+    size: 112,
+    minSize: 92,
+    meta: { className: 'hidden md:table-cell' },
+  }),
+  releaseLoadingColumnHelper.accessor('actions', {
+    id: 'actions',
+    header: '',
+    size: 72,
+    minSize: 64,
+  }),
+] as ColumnDef<ReleaseLoadingRow, unknown>[];
+
+const RELEASE_LOADING_SKELETON_CONFIG = [
+  { variant: 'release' as const, width: '100%' },
+  { variant: 'badge' as const, width: '74px' },
+  { variant: 'meta' as const, width: '96px' },
+  { variant: 'avatar' as const, width: '84px' },
+  { variant: 'button' as const, width: '56px' },
+];
 
 export function ReleaseTablePendingShell({
   showHeader = true,
   testId = 'releases-loading',
 }: Readonly<ReleaseTablePendingShellProps>) {
   return (
-    <div
-      className='flex h-full min-h-0 flex-col gap-4 px-3 py-3 lg:px-4'
-      data-testid={testId}
+    <PageShell
       aria-busy='true'
+      aria-label='Loading Releases'
+      frame='content-container'
+      contentPadding='none'
+      data-testid={testId}
+      toolbar={
+        showHeader ? (
+          <PageToolbar
+            start={
+              <span className={PAGE_TOOLBAR_META_TEXT_CLASS}>
+                Loading releases
+              </span>
+            }
+          />
+        ) : undefined
+      }
     >
-      {showHeader ? (
-        <div className='flex items-center justify-between rounded-[18px] border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-4 py-4'>
-          <div className='space-y-2'>
-            <div className='skeleton h-5 w-40 rounded' />
-            <div className='skeleton h-4 w-64 rounded' />
-          </div>
-          <div className='skeleton h-10 w-24 rounded-full' />
-        </div>
-      ) : null}
-
-      <div className='overflow-hidden rounded-[20px] border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) flex-1 min-h-0'>
-        <div className='border-b border-(--linear-app-frame-seam) px-4 py-3'>
-          <div className='grid grid-cols-[minmax(0,2.3fr)_repeat(4,minmax(84px,1fr))] gap-3'>
-            <LoadingSkeleton height='h-3' width='w-full' rounded='full' />
-            <LoadingSkeleton height='h-3' width='w-full' rounded='full' />
-            <LoadingSkeleton height='h-3' width='w-full' rounded='full' />
-            <LoadingSkeleton height='h-3' width='w-full' rounded='full' />
-            <LoadingSkeleton height='h-3' width='w-full' rounded='full' />
-          </div>
-        </div>
-
-        <div className='divide-y divide-(--linear-app-frame-seam) overflow-hidden'>
-          {RELEASES_LOADING_ROW_KEYS.map(rowKey => (
-            <div
-              key={rowKey}
-              className='grid grid-cols-[minmax(0,2.3fr)_repeat(4,minmax(84px,1fr))] gap-3 px-4 py-4'
-            >
-              <div className='space-y-2'>
-                <LoadingSkeleton height='h-4' width='w-[68%]' rounded='full' />
-                <LoadingSkeleton height='h-3' width='w-[44%]' rounded='full' />
-              </div>
-              <LoadingSkeleton height='h-9' width='w-full' rounded='lg' />
-              <LoadingSkeleton height='h-9' width='w-full' rounded='lg' />
-              <LoadingSkeleton height='h-9' width='w-full' rounded='lg' />
-              <div className='flex items-center justify-end gap-2'>
-                <LoadingSkeleton height='h-8' width='w-16' rounded='full' />
-                <LoadingSkeleton height='h-8' width='w-8' rounded='full' />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
+      <UnifiedTableSkeleton<ReleaseLoadingRow>
+        columns={RELEASE_LOADING_COLUMNS}
+        skeletonRows={SKELETON_ROW_COUNT.TABLE}
+        skeletonColumnConfig={RELEASE_LOADING_SKELETON_CONFIG}
+        rowHeight={56}
+        minWidth='0'
+        containerClassName='h-full px-2.5 pb-2.5 pt-1'
+      />
+    </PageShell>
   );
 }

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
@@ -8,6 +8,7 @@ import {
   DrawerLoadingSkeleton,
   DrawerSurfaceCard,
 } from '@/components/molecules/drawer';
+import { PageShell } from '@/components/organisms/PageShell';
 import type {
   ReleaseSidebarProps,
   TrackSidebarData,
@@ -861,9 +862,11 @@ export function ShellReleasesView({
 
   return (
     <>
-      <section
+      <PageShell
         aria-label='Releases'
-        className='flex h-full flex-col focus:outline-none'
+        frame='content-container'
+        contentPadding='none'
+        className='h-full focus:outline-none'
         data-design-v1-releases='true'
         data-testid='shell-releases-view'
       >
@@ -903,7 +906,7 @@ export function ShellReleasesView({
             onClearFilters={handleClearFilters}
           />
         </div>
-      </section>
+      </PageShell>
 
       <ReleaseWorkflowOverlays
         amPaletteOpen={amPaletteOpen}

--- a/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
@@ -7,7 +7,10 @@ import {
   TableFilterDropdown,
   type TableFilterDropdownCategory,
 } from '@/components/molecules/filters';
-import { PageToolbarActionButton } from '@/components/organisms/table';
+import {
+  PageToolbar,
+  PageToolbarActionButton,
+} from '@/components/organisms/table';
 import {
   DisplayMenuDropdown,
   type ViewMode,
@@ -71,115 +74,116 @@ export function TaskWorkspaceHeaderBar({
 }: Readonly<TaskWorkspaceHeaderBarProps>) {
   const createFormId = 'task-workspace-create-form';
 
-  return (
-    <div
-      data-testid='tasks-workspace-subheader'
-      className='flex h-[var(--linear-app-header-height-compact)] min-h-[var(--linear-app-header-height-compact)] items-center justify-between gap-3 px-app-header'
-    >
-      <div className='min-w-0 flex-1'>
-        {mode === 'create' && (
-          <form
-            id={createFormId}
-            onSubmit={onSubmitCreate}
-            className='flex min-w-0 items-center gap-2'
-          >
-            <Input
-              value={draftTitle}
-              onChange={event => onDraftTitleChange(event.target.value)}
-              placeholder='Draft press release, update bio, pitch sync supervisor...'
-              aria-label='New task name'
-              autoFocus
-              className='h-8 max-w-[32rem] min-w-0'
-            />
-          </form>
-        )}
-        {mode !== 'create' && (
-          <TaskSubviewTabs
-            subviews={subviews}
-            activeSubview={activeSubview}
-            onSubviewChange={onSubviewChange}
-            taskCount={taskCount}
-          />
-        )}
-      </div>
+  const toolbarStart =
+    mode === 'create' ? (
+      <form
+        id={createFormId}
+        onSubmit={onSubmitCreate}
+        className='flex min-w-0 flex-1 items-center gap-2'
+      >
+        <Input
+          value={draftTitle}
+          onChange={event => onDraftTitleChange(event.target.value)}
+          placeholder='Draft press release, update bio, pitch sync supervisor...'
+          aria-label='New task name'
+          autoFocus
+          className='h-8 max-w-[32rem] min-w-0'
+        />
+      </form>
+    ) : (
+      <TaskSubviewTabs
+        subviews={subviews}
+        activeSubview={activeSubview}
+        onSubviewChange={onSubviewChange}
+        taskCount={taskCount}
+      />
+    );
 
-      <div className='flex shrink-0 items-center gap-1'>
-        {mode === 'create' ? (
-          <>
-            <Button
-              type='submit'
-              size='sm'
-              form={createFormId}
-              disabled={createPending || !draftTitle.trim()}
-              className='h-7 px-2.5'
-            >
-              Create
-            </Button>
-            <Button
-              type='button'
-              variant='secondary'
-              size='sm'
-              onClick={onCancelCreate}
-              className='h-7 px-2.5'
-            >
-              Cancel
-            </Button>
-          </>
-        ) : (
-          <>
-            <TableFilterDropdown
-              categories={filterCategories}
-              onClearAll={onClearFilters}
+  const toolbarEnd =
+    mode === 'create' ? (
+      <>
+        <Button
+          type='submit'
+          size='sm'
+          form={createFormId}
+          disabled={createPending || !draftTitle.trim()}
+          className='h-7 px-2.5'
+        >
+          Create
+        </Button>
+        <Button
+          type='button'
+          variant='secondary'
+          size='sm'
+          onClick={onCancelCreate}
+          className='h-7 px-2.5'
+        >
+          Cancel
+        </Button>
+      </>
+    ) : (
+      <>
+        <TableFilterDropdown
+          categories={filterCategories}
+          onClearAll={onClearFilters}
+          iconOnly
+          align='end'
+          shortcutHint='S'
+        />
+        <DisplayMenuDropdown
+          viewMode={viewMode}
+          availableViewModes={['board', 'list']}
+          onViewModeChange={onViewModeChange}
+          availableColumns={[{ id: 'cancelled', label: 'Cancelled' }]}
+          columnVisibility={{ cancelled: showCancelledColumn }}
+          onColumnVisibilityChange={(columnId, visible) => {
+            if (columnId === 'cancelled') {
+              onShowCancelledColumnChange(visible);
+            }
+          }}
+          trigger={
+            <PageToolbarActionButton
+              ariaLabel='Display options'
+              label='Display options'
+              tooltipLabel='Display'
               iconOnly
-              align='end'
-              shortcutHint='S'
+              icon={<Settings2 className='h-3.5 w-3.5' />}
             />
-            <DisplayMenuDropdown
-              viewMode={viewMode}
-              availableViewModes={['board', 'list']}
-              onViewModeChange={onViewModeChange}
-              availableColumns={[{ id: 'cancelled', label: 'Cancelled' }]}
-              columnVisibility={{ cancelled: showCancelledColumn }}
-              onColumnVisibilityChange={(columnId, visible) => {
-                if (columnId === 'cancelled') {
-                  onShowCancelledColumnChange(visible);
-                }
-              }}
-              trigger={
-                <PageToolbarActionButton
-                  ariaLabel='Display options'
-                  label='Display options'
-                  tooltipLabel='Display'
-                  iconOnly
-                  icon={<Settings2 className='h-3.5 w-3.5' />}
-                />
-              }
+          }
+        />
+        {showTaskNavigation ? (
+          <div className='flex items-center gap-0.5'>
+            <PageToolbarActionButton
+              ariaLabel='Previous task'
+              label='Previous task'
+              onClick={onSelectPrevious}
+              tooltipLabel='Previous task'
+              disabled={!canSelectPrevious}
+              iconOnly
+              icon={<ArrowUp className='h-3.5 w-3.5' />}
             />
-            {showTaskNavigation ? (
-              <div className='flex items-center gap-0.5'>
-                <PageToolbarActionButton
-                  ariaLabel='Previous task'
-                  label='Previous task'
-                  onClick={onSelectPrevious}
-                  tooltipLabel='Previous task'
-                  disabled={!canSelectPrevious}
-                  iconOnly
-                  icon={<ArrowUp className='h-3.5 w-3.5' />}
-                />
-                <PageToolbarActionButton
-                  ariaLabel='Next task'
-                  label='Next task'
-                  onClick={onSelectNext}
-                  tooltipLabel='Next task'
-                  disabled={!canSelectNext}
-                  iconOnly
-                  icon={<ArrowDown className='h-3.5 w-3.5' />}
-                />
-              </div>
-            ) : null}
-          </>
-        )}
-      </div>
+            <PageToolbarActionButton
+              ariaLabel='Next task'
+              label='Next task'
+              onClick={onSelectNext}
+              tooltipLabel='Next task'
+              disabled={!canSelectNext}
+              iconOnly
+              icon={<ArrowDown className='h-3.5 w-3.5' />}
+            />
+          </div>
+        ) : null}
+      </>
+    );
+
+  return (
+    <div data-testid='tasks-workspace-subheader' className='contents'>
+      <PageToolbar
+        start={toolbarStart}
+        end={toolbarEnd}
+        className='h-[var(--linear-app-header-height-compact)] min-h-[var(--linear-app-header-height-compact)]'
+        startClassName={mode === 'create' ? 'overflow-visible' : undefined}
+      />
     </div>
   );
 }

--- a/apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
@@ -22,6 +22,18 @@ vi.mock('@/components/molecules/filters', () => ({
 }));
 
 vi.mock('@/components/organisms/table', () => ({
+  PageToolbar: ({
+    start,
+    end,
+  }: {
+    readonly start: ReactNode;
+    readonly end?: ReactNode;
+  }) => (
+    <div>
+      <div>{start}</div>
+      <div>{end}</div>
+    </div>
+  ),
   PageToolbarActionButton: ({
     ariaLabel,
     label,


### PR DESCRIPTION
## Summary
- Wrap the DESIGN_V1 releases surface in the canonical PageShell frame.
- Replace the releases pending skeleton with PageShell + PageToolbar + UnifiedTableSkeleton.
- Align the tasks workspace subheader with the shared PageToolbar while preserving create/filter/display/task navigation behavior.

## Visual QA
- Screenshots: /tmp/jovie-shell-2299-20260516-133727/
- Checked releases desktop/tablet/mobile and tasks entitlement shell desktop/tablet/mobile.
- Verified mobile releases has no horizontal overflow.

## Verification
- pnpm biome check --write apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx apps/web/components/features/dashboard/organisms/ReleaseTablePendingShell.tsx
- pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- E2E_USE_TEST_AUTH_BYPASS=1 pnpm --filter @jovie/web exec playwright test tests/e2e/releases-page-stability.spec.ts --project=chromium --reporter=line
- git diff --check
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push

Linear: JOV-2299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured dashboard loading states and navigation components for improved consistency across application views.
  * Enhanced layout organization in release displays and task workspace headers using improved component architecture.

* **Tests**
  * Updated test infrastructure to support refactored dashboard components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8851?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->