### PR TITLE
JOV-2302 align release task detail shell

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/tasks/loading.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/tasks/loading.tsx
@@ -1,31 +1,5 @@
+import { ReleaseTaskPageSkeleton } from '@/components/features/dashboard/release-tasks';
+
 export default function TasksLoading() {
-  return (
-    <div className='mx-auto max-w-2xl px-4 py-6'>
-      {/* Breadcrumb skeleton */}
-      <div className='mb-4 flex gap-1.5'>
-        <div className='h-3 w-14 animate-pulse rounded bg-surface-1' />
-        <div className='h-3 w-2 animate-pulse rounded bg-surface-1' />
-        <div className='h-3 w-20 animate-pulse rounded bg-surface-1' />
-        <div className='h-3 w-2 animate-pulse rounded bg-surface-1' />
-        <div className='h-3 w-10 animate-pulse rounded bg-surface-1' />
-      </div>
-
-      {/* Progress bar skeleton */}
-      <div className='mb-6 px-4 py-2'>
-        <div className='mb-1 h-3 w-24 animate-pulse rounded bg-surface-1' />
-        <div className='h-1 w-full rounded-full bg-surface-1' />
-      </div>
-
-      {/* Task rows skeleton */}
-      <div className='space-y-3'>
-        {[1, 2, 3, 4, 5, 6, 7, 8].map(i => (
-          <div
-            key={i}
-            className='h-10 animate-pulse rounded bg-surface-1'
-            style={{ opacity: 1 - i * 0.08 }}
-          />
-        ))}
-      </div>
-    </div>
-  );
+  return <ReleaseTaskPageSkeleton />;
 }

--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/tasks/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/tasks/page.tsx
@@ -1,7 +1,10 @@
 import { and, eq } from 'drizzle-orm';
 import { notFound, redirect } from 'next/navigation';
 import { Suspense } from 'react';
-import { ReleaseTaskPage } from '@/components/features/dashboard/release-tasks';
+import {
+  ReleaseTaskPage,
+  ReleaseTaskPageSkeleton,
+} from '@/components/features/dashboard/release-tasks';
 import { ReleasePlanUpgradeInterstitial } from '@/components/features/dashboard/tasks/TasksUpgradeInterstitial';
 import { APP_ROUTES } from '@/constants/routes';
 import { getCurrentUserProfile } from '@/lib/auth/session';
@@ -17,13 +20,7 @@ export default async function TasksPage({ params }: TasksPageProps) {
   const { releaseId } = await params;
 
   return (
-    <Suspense
-      fallback={
-        <div className='flex flex-1 items-center justify-center p-8'>
-          <div className='h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent' />
-        </div>
-      }
-    >
+    <Suspense fallback={<ReleaseTaskPageSkeleton />}>
       <TasksContent releaseId={releaseId} />
     </Suspense>
   );

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskPage.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskPage.tsx
@@ -1,6 +1,12 @@
 'use client';
 
+import { ChevronRight } from 'lucide-react';
 import { useMemo } from 'react';
+import { PageShell } from '@/components/organisms/PageShell';
+import {
+  PAGE_TOOLBAR_META_TEXT_CLASS,
+  PageToolbar,
+} from '@/components/organisms/table';
 import { useTaskToggleMutation } from '@/lib/queries/useReleaseTaskMutations';
 import { useReleaseTasksQuery } from '@/lib/queries/useReleaseTasksQuery';
 import type { ReleaseTaskView } from '@/lib/release-tasks/types';
@@ -36,6 +42,30 @@ function getUpNextTasks(tasks: ReleaseTaskView[]): ReleaseTaskView[] {
     .slice(0, 3);
 }
 
+function ReleaseTaskBreadcrumbs({
+  releaseTitle,
+}: Readonly<{ releaseTitle: string }>) {
+  return (
+    <div className='flex min-w-0 items-center gap-1.5'>
+      <span className='shrink-0 text-tertiary-token'>Releases</span>
+      <ChevronRight
+        className='h-3 w-3 shrink-0 text-quaternary-token'
+        strokeWidth={2}
+        aria-hidden='true'
+      />
+      <span className='max-w-[min(46vw,20rem)] truncate text-secondary-token'>
+        {releaseTitle}
+      </span>
+      <ChevronRight
+        className='h-3 w-3 shrink-0 text-quaternary-token'
+        strokeWidth={2}
+        aria-hidden='true'
+      />
+      <span className='shrink-0 text-primary-token'>Tasks</span>
+    </div>
+  );
+}
+
 export function ReleaseTaskPage({
   profileId,
   releaseId,
@@ -59,55 +89,98 @@ export function ReleaseTaskPage({
   };
 
   return (
-    <div
-      className='mx-auto max-w-2xl px-4 py-6'
+    <PageShell
+      aria-label={`${releaseTitle} tasks`}
+      contentClassName='overflow-y-auto overflow-x-hidden'
+      contentPadding='none'
+      frame='content-container'
       data-testid='release-task-page'
-    >
-      {/* Breadcrumb */}
-      <nav className='mb-4 text-xs text-tertiary-token'>
-        <span className='hover:text-secondary-token cursor-pointer'>
-          Releases
-        </span>
-        <span className='mx-1.5'>/</span>
-        <span className='hover:text-secondary-token cursor-pointer'>
-          {releaseTitle}
-        </span>
-        <span className='mx-1.5'>/</span>
-        <span className='text-primary-token'>Tasks</span>
-      </nav>
-
-      {showMetadataAgentPanel ? (
-        <MetadataAgentPanel
-          profileId={profileId}
-          releaseId={releaseId}
-          releaseTitle={releaseTitle}
+      toolbar={
+        <PageToolbar
+          start={
+            <div className={PAGE_TOOLBAR_META_TEXT_CLASS}>
+              <ReleaseTaskBreadcrumbs releaseTitle={releaseTitle} />
+            </div>
+          }
         />
-      ) : null}
+      }
+    >
+      <div className='mx-auto flex w-full max-w-3xl flex-col gap-5 px-3 py-3 sm:px-4 lg:px-5'>
+        {showMetadataAgentPanel ? (
+          <MetadataAgentPanel
+            profileId={profileId}
+            releaseId={releaseId}
+            releaseTitle={releaseTitle}
+          />
+        ) : null}
 
-      {/* Up Next section (only when tasks exist and not all done) */}
-      {upNextTasks.length > 0 && !allDone && (
-        <div className='mb-6'>
-          <h3 className='px-4 text-2xs font-medium uppercase tracking-wider text-tertiary-token mb-2'>
-            Up Next
-          </h3>
-          <div className='rounded-lg border border-(--linear-app-frame-seam) bg-surface-1'>
-            {upNextTasks.map(task => (
-              <ReleaseTaskRow
-                key={task.id}
-                task={task}
-                onToggle={handleToggle}
-              />
-            ))}
-          </div>
+        {upNextTasks.length > 0 && !allDone && (
+          <section aria-label='Up next' className='space-y-2'>
+            <h2 className='px-1 text-xs font-medium text-secondary-token'>
+              Up next
+            </h2>
+            <div className='rounded-lg border border-subtle bg-surface-1 p-1 shadow-app-control'>
+              {upNextTasks.map(task => (
+                <ReleaseTaskRow
+                  key={task.id}
+                  task={task}
+                  onToggle={handleToggle}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+
+        <div className='min-w-0'>
+          <ReleaseTaskChecklist
+            releaseId={releaseId}
+            variant='full'
+            releaseDate={releaseDate}
+          />
         </div>
-      )}
+      </div>
+    </PageShell>
+  );
+}
 
-      {/* Main checklist */}
-      <ReleaseTaskChecklist
-        releaseId={releaseId}
-        variant='full'
-        releaseDate={releaseDate}
-      />
-    </div>
+export function ReleaseTaskPageSkeleton() {
+  return (
+    <PageShell
+      aria-busy='true'
+      aria-label='Loading release tasks'
+      contentClassName='overflow-y-auto overflow-x-hidden'
+      contentPadding='none'
+      frame='content-container'
+      toolbar={
+        <PageToolbar
+          start={
+            <div className='flex items-center gap-1.5'>
+              <div className='skeleton h-3 w-14 rounded' />
+              <div className='skeleton h-3 w-3 rounded' />
+              <div className='skeleton h-3 w-28 rounded' />
+              <div className='skeleton h-3 w-3 rounded' />
+              <div className='skeleton h-3 w-10 rounded' />
+            </div>
+          }
+        />
+      }
+    >
+      <div className='mx-auto flex w-full max-w-3xl flex-col gap-5 px-3 py-3 sm:px-4 lg:px-5'>
+        <div className='rounded-lg border border-subtle bg-surface-1 p-3 shadow-app-control'>
+          <div className='mb-2 h-3 w-24 rounded bg-surface-2' />
+          <div className='h-1 w-full rounded-full bg-surface-2' />
+        </div>
+
+        <div className='space-y-3'>
+          {[1, 2, 3, 4, 5, 6, 7, 8].map(i => (
+            <div
+              key={i}
+              className='h-10 animate-pulse rounded-lg bg-surface-1'
+              style={{ opacity: 1 - i * 0.08 }}
+            />
+          ))}
+        </div>
+      </div>
+    </PageShell>
   );
 }

--- a/apps/web/components/features/dashboard/release-tasks/index.ts
+++ b/apps/web/components/features/dashboard/release-tasks/index.ts
@@ -1,3 +1,3 @@
 export { ReleaseTaskChecklist } from './ReleaseTaskChecklist';
-export { ReleaseTaskPage } from './ReleaseTaskPage';
+export { ReleaseTaskPage, ReleaseTaskPageSkeleton } from './ReleaseTaskPage';
 export { ReleaseTaskProgressBar } from './ReleaseTaskProgressBar';

--- a/apps/web/tests/unit/app/release-tasks-page.test.tsx
+++ b/apps/web/tests/unit/app/release-tasks-page.test.tsx
@@ -67,6 +67,9 @@ vi.mock('@/components/features/dashboard/release-tasks', () => ({
       {releaseId}:{releaseTitle}
     </div>
   ),
+  ReleaseTaskPageSkeleton: () => (
+    <div data-testid='release-task-page-skeleton'>Loading tasks</div>
+  ),
 }));
 
 vi.mock(

--- a/apps/web/tests/unit/dashboard/ReleaseTaskPage.test.tsx
+++ b/apps/web/tests/unit/dashboard/ReleaseTaskPage.test.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReleaseTaskView } from '@/lib/release-tasks/types';
+
+const { mockToggleMutate, mockUseReleaseTasksQuery } = vi.hoisted(() => ({
+  mockToggleMutate: vi.fn(),
+  mockUseReleaseTasksQuery: vi.fn(),
+}));
+
+vi.mock('@/lib/queries/useReleaseTasksQuery', () => ({
+  useReleaseTasksQuery: mockUseReleaseTasksQuery,
+}));
+
+vi.mock('@/lib/queries/useReleaseTaskMutations', () => ({
+  useTaskToggleMutation: vi.fn(() => ({ mutate: mockToggleMutate })),
+}));
+
+vi.mock(
+  '@/components/features/dashboard/release-tasks/MetadataAgentPanel',
+  () => ({
+    MetadataAgentPanel: ({
+      releaseTitle,
+    }: {
+      readonly releaseTitle: string;
+    }) => <aside data-testid='metadata-agent-panel'>{releaseTitle}</aside>,
+  })
+);
+
+vi.mock(
+  '@/components/features/dashboard/release-tasks/ReleaseTaskChecklist',
+  () => ({
+    ReleaseTaskChecklist: ({ releaseId }: { readonly releaseId: string }) => (
+      <div data-testid='release-task-checklist'>{releaseId}</div>
+    ),
+  })
+);
+
+vi.mock('@/components/features/dashboard/release-tasks/ReleaseTaskRow', () => ({
+  ReleaseTaskRow: ({
+    task,
+    onToggle,
+  }: {
+    readonly task: ReleaseTaskView;
+    readonly onToggle: (taskId: string, done: boolean) => void;
+  }) => (
+    <button type='button' onClick={() => onToggle(task.id, true)}>
+      {task.title}
+    </button>
+  ),
+}));
+
+const { ReleaseTaskPage, ReleaseTaskPageSkeleton } = await import(
+  '@/components/features/dashboard/release-tasks/ReleaseTaskPage'
+);
+
+function createTask(overrides: Partial<ReleaseTaskView> = {}): ReleaseTaskView {
+  return {
+    id: 'task_1',
+    releaseId: 'release_1',
+    creatorProfileId: 'profile_1',
+    templateItemId: 'template_1',
+    title: 'Pitch playlist editors',
+    description: null,
+    explainerText: null,
+    learnMoreUrl: null,
+    videoUrl: null,
+    category: 'Marketing',
+    status: 'todo',
+    priority: 'medium',
+    position: 1,
+    assigneeType: 'human',
+    assigneeUserId: null,
+    aiWorkflowId: null,
+    dueDaysOffset: 3,
+    dueDate: new Date('2026-06-01T00:00:00.000Z'),
+    completedAt: null,
+    metadata: null,
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('ReleaseTaskPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseReleaseTasksQuery.mockReturnValue({
+      data: [
+        createTask(),
+        createTask({
+          id: 'task_2',
+          title: 'Completed setup',
+          status: 'done',
+          position: 2,
+        }),
+      ],
+    });
+  });
+
+  it('renders release tasks inside the canonical page shell toolbar', () => {
+    render(
+      <ReleaseTaskPage
+        profileId='profile_1'
+        releaseId='release_1'
+        releaseTitle='The Deep End'
+      />
+    );
+
+    expect(screen.getByTestId('release-task-page')).toHaveAttribute(
+      'aria-label',
+      'The Deep End tasks'
+    );
+    expect(screen.getByText('Releases')).toBeVisible();
+    expect(screen.getByText('The Deep End')).toBeVisible();
+    expect(screen.getByText('Tasks')).toBeVisible();
+    expect(screen.getByTestId('release-task-checklist')).toHaveTextContent(
+      'release_1'
+    );
+    expect(screen.getByText('Up next')).toBeVisible();
+    expect(screen.getByText('Pitch playlist editors')).toBeVisible();
+    expect(screen.queryByText('Completed setup')).not.toBeInTheDocument();
+  });
+
+  it('keeps metadata agent and task toggles wired through the shell frame', () => {
+    render(
+      <ReleaseTaskPage
+        profileId='profile_1'
+        releaseId='release_1'
+        releaseTitle='The Deep End'
+        showMetadataAgentPanel
+      />
+    );
+
+    expect(screen.getByTestId('metadata-agent-panel')).toHaveTextContent(
+      'The Deep End'
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Pitch playlist editors' })
+    );
+
+    expect(mockToggleMutate).toHaveBeenCalledWith({
+      taskId: 'task_1',
+      done: true,
+    });
+  });
+
+  it('renders the route skeleton with the same shell geometry', () => {
+    render(<ReleaseTaskPageSkeleton />);
+
+    expect(screen.getByLabelText('Loading release tasks')).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Wrap the release-task detail route in the canonical PageShell/PageToolbar geometry.
- Move the loading state to the same shell frame instead of a bespoke centered skeleton.
- Add focused coverage for toolbar breadcrumbs, up-next filtering, metadata panel wiring, task toggles, and the route skeleton mock contract.

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/ReleaseTaskPage.test.tsx tests/unit/app/release-tasks-page.test.tsx tests/unit/app/surface-elevation-guardrails.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm exec lint-staged --no-stash
- git diff --check
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push

Linear: JOV-2302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated breadcrumb navigation with chevron icon styling.
  * Refined release tasks page layout and visual structure.
  * Improved loading state display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8857?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->