### PR TITLE
JOV-2301 clean entity popover tokens

### DIFF
--- a/apps/web/components/jovie/components/EntityChipPopover.test.tsx
+++ b/apps/web/components/jovie/components/EntityChipPopover.test.tsx
@@ -54,6 +54,26 @@ describe('EntityChipPopover', () => {
     expect(screen.getByTestId('entity-chip-popover-content')).toBeTruthy();
   });
 
+  it('opens on mouse hover and closes after pointer leave', async () => {
+    const user = userEvent.setup();
+    renderPopover();
+    const trigger = screen.getByTestId('entity-chip-popover-trigger');
+
+    await user.hover(trigger);
+
+    await waitFor(() =>
+      expect(trigger.getAttribute('aria-expanded')).toBe('true')
+    );
+    expect(screen.getByTestId('entity-chip-popover-content')).toBeTruthy();
+
+    await user.unhover(trigger);
+
+    await waitFor(() =>
+      expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    );
+    expect(screen.queryByTestId('entity-chip-popover-content')).toBeNull();
+  });
+
   it('opens on keyboard Enter', async () => {
     const user = userEvent.setup();
     renderPopover();

--- a/apps/web/components/jovie/components/EntityChipPopover.tsx
+++ b/apps/web/components/jovie/components/EntityChipPopover.tsx
@@ -152,8 +152,8 @@ export function EntityChipPopover({
           onPointerLeave={handlePointerLeave}
           onKeyDown={handleKeyDown}
           className={cn(
-            'inline-flex items-baseline align-baseline appearance-none p-0 m-0 bg-transparent border-0 cursor-pointer',
-            'focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_oklab,var(--linear-border-focus)_72%,transparent)] focus-visible:rounded-md'
+            'm-0 inline-flex cursor-pointer appearance-none items-baseline align-baseline border-0 bg-transparent p-0',
+            'rounded-(--linear-app-radius-item) focus:outline-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35'
           )}
           data-testid='entity-chip-popover-trigger'
         >
@@ -161,7 +161,7 @@ export function EntityChipPopover({
         </button>
       </PopoverTrigger>
       <PopoverContent
-        className='w-[280px] p-0 overflow-hidden'
+        className='w-[272px] overflow-hidden p-0'
         sideOffset={6}
         align='start'
         testId='entity-chip-popover-content'
@@ -209,7 +209,7 @@ function EntityChipPopoverBody({
   const thumbnail = entity?.thumbnail;
 
   return (
-    <div className='flex gap-3 p-3'>
+    <div className='flex gap-2.5 p-2'>
       <div className='shrink-0'>
         {thumbnail ? (
           <Image
@@ -217,27 +217,25 @@ function EntityChipPopoverBody({
             alt=''
             width={48}
             height={48}
-            className='h-12 w-12 rounded-md object-cover'
+            className='h-12 w-12 rounded-(--linear-app-radius-item) border border-subtle object-cover shadow-app-control'
             aria-hidden
           />
         ) : (
           <div
             aria-hidden
-            className='h-12 w-12 rounded-md border border-subtle bg-surface-1 flex items-center justify-center'
+            className='flex h-12 w-12 items-center justify-center rounded-(--linear-app-radius-item) border border-subtle bg-surface-1 shadow-app-control'
           >
             <span className='h-2 w-2 rounded-full bg-tertiary-token' />
           </div>
         )}
       </div>
       <div className='min-w-0 flex-1'>
-        <p className='text-2xs font-medium uppercase tracking-[0.06em] text-tertiary-token'>
-          {eyebrow}
-        </p>
-        <p className='mt-0.5 truncate text-[13px] font-medium leading-tight text-primary-token'>
+        <p className='text-2xs font-caption text-tertiary-token'>{eyebrow}</p>
+        <p className='mt-0.5 truncate text-app font-caption leading-tight text-primary-token'>
           {label}
         </p>
         {subtitle ? (
-          <p className='mt-0.5 truncate text-xs leading-tight text-secondary-token'>
+          <p className='mt-0.5 truncate text-2xs leading-tight text-secondary-token'>
             {subtitle}
           </p>
         ) : null}
@@ -250,7 +248,7 @@ function EntityChipPopoverBody({
           <button
             type='button'
             onClick={onOpenEntity}
-            className='mt-2 inline-flex items-center gap-1 rounded-md text-xs font-medium text-primary-token hover:text-primary-token focus:outline-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[color-mix(in_oklab,var(--linear-border-focus)_72%,transparent)]'
+            className='mt-2 inline-flex items-center gap-1 rounded-(--linear-app-radius-item) px-1 py-0.5 text-2xs font-caption text-secondary-token transition-colors duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus:outline-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35'
           >
             Open {KIND_PREFIX[kind].toLowerCase()}
             <ArrowUpRight className='h-3 w-3' />

--- a/apps/web/components/shell/EntityPopover.test.tsx
+++ b/apps/web/components/shell/EntityPopover.test.tsx
@@ -1,0 +1,62 @@
+import { act, fireEvent, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fastRender } from '@/tests/utils/fast-render';
+import { EntityHoverLink, type EntityPopoverData } from './EntityPopover';
+
+vi.mock('next/image', () => ({
+  default: ({ src, alt, ...rest }: ComponentProps<'img'>) => (
+    <img src={src as string} alt={alt ?? ''} {...rest} />
+  ),
+}));
+
+const release = {
+  kind: 'release',
+  id: 'rel_1',
+  label: 'Sober',
+  artist: 'Jovie',
+  releaseType: 'Single',
+} satisfies EntityPopoverData;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function advanceTimers(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+describe('EntityHoverLink', () => {
+  it('opens on hover and closes on mouse leave', () => {
+    vi.useFakeTimers();
+    fastRender(<EntityHoverLink entity={release}>Sober</EntityHoverLink>);
+    const trigger = screen.getByRole('button', { name: 'Sober' });
+
+    fireEvent.mouseEnter(trigger);
+    advanceTimers(200);
+
+    expect(screen.getByRole('tooltip').textContent).toContain('Sober');
+
+    fireEvent.mouseLeave(trigger);
+    advanceTimers(120);
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('opens on focus and closes on Escape', () => {
+    vi.useFakeTimers();
+    fastRender(<EntityHoverLink entity={release}>Sober</EntityHoverLink>);
+    const trigger = screen.getByRole('button', { name: 'Sober' });
+
+    fireEvent.focus(trigger);
+    advanceTimers(200);
+
+    expect(screen.getByRole('tooltip').textContent).toContain('Sober');
+
+    fireEvent.keyDown(trigger, { key: 'Escape' });
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+});

--- a/apps/web/components/shell/EntityPopover.tsx
+++ b/apps/web/components/shell/EntityPopover.tsx
@@ -15,6 +15,7 @@
 
 import Image from 'next/image';
 import {
+  type KeyboardEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -191,11 +192,11 @@ export function EntityRowArt({
     const stamp = stampParts(entity.eventDate);
     if (stamp) {
       return (
-        <span className='flex h-7 w-7 shrink-0 flex-col items-center justify-center rounded-md border border-subtle bg-surface-1 shadow-[inset_0_0.5px_0_rgba(255,255,255,0.05)]'>
-          <span className='text-[7px] font-semibold uppercase tracking-[0.1em] text-tertiary-token leading-none'>
+        <span className='flex h-7 w-7 shrink-0 flex-col items-center justify-center rounded-(--linear-app-radius-item) border border-subtle bg-surface-1 shadow-app-control'>
+          <span className='text-3xs font-caption leading-none text-tertiary-token'>
             {stamp.month}
           </span>
-          <span className='text-[12px] font-bold leading-none tracking-[-0.02em] text-primary-token mt-0.5'>
+          <span className='mt-0.5 text-2xs font-bold leading-none text-primary-token'>
             {stamp.day}
           </span>
         </span>
@@ -212,7 +213,7 @@ export function EntityRowArt({
     return (
       <span
         className={cn(
-          'relative h-7 w-7 shrink-0 overflow-hidden shadow-[inset_0_0_0_0.5px_rgba(255,255,255,0.06)]',
+          'relative h-7 w-7 shrink-0 overflow-hidden shadow-app-control',
           rounded
         )}
       >
@@ -234,8 +235,8 @@ export function EntityRowArt({
   return (
     <span
       className={cn(
-        'flex h-7 w-7 shrink-0 items-center justify-center border border-subtle bg-surface-1 text-[10px] font-semibold text-primary-token shadow-[inset_0_0.5px_0_rgba(255,255,255,0.05)]',
-        isCircular ? 'rounded-full' : 'rounded-md'
+        'flex h-7 w-7 shrink-0 items-center justify-center border border-subtle bg-surface-1 text-3xs font-caption text-primary-token shadow-app-control',
+        isCircular ? 'rounded-full' : 'rounded-(--linear-app-radius-item)'
       )}
     >
       {initialsOf(entity.label) || '·'}
@@ -422,11 +423,11 @@ function CardArtwork({ entity }: { readonly entity: EntityPopoverData }) {
     const stamp = stampParts(entity.eventDate);
     if (stamp) {
       return (
-        <div className='flex h-12 w-12 shrink-0 flex-col items-center justify-center rounded-md border border-subtle bg-surface-1 shadow-[inset_0_0.5px_0_rgba(255,255,255,0.05)]'>
-          <span className='text-[8px] font-semibold uppercase tracking-[0.12em] text-tertiary-token'>
+        <div className='flex h-12 w-12 shrink-0 flex-col items-center justify-center rounded-(--linear-app-radius-item) border border-subtle bg-surface-1 shadow-app-control'>
+          <span className='text-3xs font-caption text-tertiary-token'>
             {stamp.month}
           </span>
-          <span className='text-[20px] font-bold leading-none tracking-[-0.02em] text-primary-token'>
+          <span className='text-mid font-bold leading-none text-primary-token'>
             {stamp.day}
           </span>
         </div>
@@ -441,8 +442,8 @@ function CardArtwork({ entity }: { readonly entity: EntityPopoverData }) {
     return (
       <div
         className={cn(
-          'relative h-12 w-12 shrink-0 overflow-hidden border border-subtle shadow-[inset_0_0.5px_0_rgba(255,255,255,0.05)]',
-          isCircular ? 'rounded-full' : 'rounded-md'
+          'relative h-12 w-12 shrink-0 overflow-hidden border border-subtle shadow-app-control',
+          isCircular ? 'rounded-full' : 'rounded-(--linear-app-radius-item)'
         )}
       >
         <Image
@@ -459,8 +460,8 @@ function CardArtwork({ entity }: { readonly entity: EntityPopoverData }) {
   return (
     <div
       className={cn(
-        'flex h-12 w-12 shrink-0 items-center justify-center border border-subtle bg-surface-1 text-[15px] font-semibold text-primary-token shadow-[inset_0_0.5px_0_rgba(255,255,255,0.05)]',
-        isCircular ? 'rounded-full' : 'rounded-md'
+        'flex h-12 w-12 shrink-0 items-center justify-center border border-subtle bg-surface-1 text-app font-caption text-primary-token shadow-app-control',
+        isCircular ? 'rounded-full' : 'rounded-(--linear-app-radius-item)'
       )}
     >
       {initialsOf(entity.label) || '·'}
@@ -487,10 +488,10 @@ function EntityCard({ entity, onActivate }: EntityCardProps) {
     <div className='flex items-start gap-2.5'>
       <CardArtwork entity={entity} />
       <div className='min-w-0 flex-1 pt-0.5'>
-        <div className='mb-1 text-[9.5px] font-semibold uppercase tracking-[0.1em] text-quaternary-token'>
+        <div className='mb-1 text-2xs font-caption text-tertiary-token'>
           {eyebrow}
         </div>
-        <h3 className='m-0 mb-2 truncate text-[14px] font-semibold leading-[1.25] text-primary-token'>
+        <h3 className='m-0 mb-2 truncate text-app font-caption leading-tight text-primary-token'>
           {entity.label}
         </h3>
         {artistLink ? (
@@ -504,20 +505,20 @@ function EntityCard({ entity, onActivate }: EntityCardProps) {
                 label: artistLink,
               });
             }}
-            className='mb-2 inline-flex items-center text-[11.5px] text-tertiary-token hover:text-primary-token underline underline-offset-2 decoration-(--linear-app-shell-border) hover:decoration-current transition-colors duration-subtle ease-out'
+            className='mb-2 inline-flex items-center text-2xs font-caption text-secondary-token underline decoration-subtle underline-offset-2 transition-colors duration-subtle ease-subtle hover:text-primary-token hover:decoration-default'
           >
             {artistLink}
           </button>
         ) : null}
         {stats.length > 0 ? (
-          <div className='flex flex-wrap items-center text-[11.5px] leading-[1.5] text-tertiary-token'>
+          <div className='flex flex-wrap items-center text-2xs leading-normal text-tertiary-token'>
             {stats.map((stat, i) => (
               <span
                 key={stat.key}
                 className={cn(
                   'relative inline-flex items-center whitespace-nowrap',
                   stat.emphasis === 'solid'
-                    ? 'ml-1.5 rounded-[3px] border border-subtle bg-surface-1 px-1.5 py-px text-[9.5px] font-semibold uppercase tracking-[0.1em] text-primary-token'
+                    ? 'ml-1.5 rounded-(--linear-app-radius-item) border border-subtle bg-surface-1 px-1.5 py-px text-3xs font-caption text-primary-token'
                     : 'px-1.5',
                   i === 0 && stat.emphasis !== 'solid' && 'pl-0',
                   i > 0 &&
@@ -621,10 +622,10 @@ export function EntityPopover({
       }}
       className={cn(
         'z-[80]',
-        'rounded-lg border border-(--linear-app-shell-border)',
-        'bg-(--linear-app-content-surface)/95 backdrop-blur-xl',
-        'p-2.5 shadow-[0_12px_40px_rgba(0,0,0,0.32)]',
-        'animate-in fade-in-0 duration-subtle ease-out',
+        'rounded-(--linear-app-radius-menu) border border-default',
+        'bg-(--linear-bg-surface-0) text-primary-token shadow-card-elevated',
+        'p-2',
+        'animate-in fade-in-0 zoom-in-95 duration-subtle ease-subtle',
         pos?.side === 'left' ? 'slide-in-from-right-1' : 'slide-in-from-left-1'
       )}
     >
@@ -670,6 +671,19 @@ export function EntityHoverLink({
     }
   }, []);
 
+  const cancelOpen = useCallback(() => {
+    if (openTimer.current !== undefined) {
+      window.clearTimeout(openTimer.current);
+      openTimer.current = undefined;
+    }
+  }, []);
+
+  const closeNow = useCallback(() => {
+    cancelOpen();
+    cancelClose();
+    setOpen(false);
+  }, [cancelClose, cancelOpen]);
+
   const requestOpen = useCallback(() => {
     cancelClose();
     if (openTimer.current !== undefined) return;
@@ -680,25 +694,29 @@ export function EntityHoverLink({
   }, [cancelClose]);
 
   const requestClose = useCallback(() => {
-    if (openTimer.current !== undefined) {
-      window.clearTimeout(openTimer.current);
-      openTimer.current = undefined;
-    }
+    cancelOpen();
     if (closeTimer.current !== undefined) return;
     closeTimer.current = window.setTimeout(() => {
       setOpen(false);
       closeTimer.current = undefined;
     }, HOVER_CLOSE_MS);
-  }, []);
+  }, [cancelOpen]);
 
   useEffect(
     () => () => {
-      if (openTimer.current !== undefined)
-        window.clearTimeout(openTimer.current);
-      if (closeTimer.current !== undefined)
-        window.clearTimeout(closeTimer.current);
+      cancelOpen();
+      cancelClose();
     },
-    []
+    [cancelClose, cancelOpen]
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      closeNow();
+    },
+    [closeNow]
   );
 
   return (
@@ -710,13 +728,15 @@ export function EntityHoverLink({
         onMouseLeave={requestClose}
         onFocus={requestOpen}
         onBlur={requestClose}
+        onKeyDown={handleKeyDown}
         onClick={() => onActivate?.(entity)}
         // Subtle treatment: underline only on hover/focus, no static
         // decoration — keeps entity-rich copy from reading as a wall of
         // dotted lines while still surfacing the affordance on intent.
         className={cn(
-          'inline-flex items-center hover:text-primary-token transition-colors duration-subtle ease-out',
+          'inline-flex items-center rounded-(--linear-app-radius-item) transition-colors duration-subtle ease-subtle hover:text-primary-token',
           'no-underline hover:underline focus-visible:underline underline-offset-2',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35',
           className
         )}
       >


### PR DESCRIPTION
## Summary
- Tighten entity popover padding, surfaces, focus treatment, artwork fallbacks, and typography against the shell token system.
- Add Escape/hover cleanup behavior for entity hover links.
- Add focused coverage for hover close behavior and the shell entity hover popover lifecycle.

## Verification
- pnpm exec biome check --write apps/web/components/jovie/components/EntityChipPopover.tsx apps/web/components/jovie/components/EntityChipPopover.test.tsx apps/web/components/shell/EntityPopover.tsx apps/web/components/shell/EntityPopover.test.tsx
- pnpm --filter @jovie/web exec vitest run components/jovie/components/EntityChipPopover.test.tsx components/shell/EntityPopover.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push

Linear: JOV-2301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Escape key support to immediately close entity popovers for improved keyboard navigation.

* **Style**
  * Updated styling, typography, spacing, and focus/underline behaviors across entity preview and popover interfaces for a cleaner visual presentation.

* **Tests**
  * Added tests covering hover/focus popover behavior, aria-expanded accessibility updates, open/close timing, and keyboard interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->