### PR TITLE
JOV-2305 normalize settings retargeting shell

### DIFF
--- a/apps/web/app/app/(shell)/settings/retargeting-ads/loading.tsx
+++ b/apps/web/app/app/(shell)/settings/retargeting-ads/loading.tsx
@@ -1,7 +1,7 @@
 import { ContentSectionHeaderSkeleton } from '@/components/molecules/ContentSectionHeaderSkeleton';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { LoadingSkeleton } from '@/components/molecules/LoadingSkeleton';
-import { PageContent, PageShell } from '@/components/organisms/PageShell';
+import { PageContent } from '@/components/organisms/PageShell';
 
 function SummaryCardSkeleton() {
   return (
@@ -16,7 +16,7 @@ function SummaryCardSkeleton() {
 function AdPreviewCardSkeleton() {
   return (
     <ContentSurfaceCard surface='nested' className='space-y-3 p-4'>
-      <div className='aspect-square rounded-[10px] skeleton motion-reduce:animate-none' />
+      <div className='aspect-square rounded-lg skeleton motion-reduce:animate-none' />
       <div className='flex items-start justify-between gap-3'>
         <div className='min-w-0 space-y-1'>
           <LoadingSkeleton height='h-4' width='w-20' rounded='md' />
@@ -50,47 +50,45 @@ function AdGroupSkeleton() {
  */
 export default function RetargetingAdsLoading() {
   return (
-    <PageShell>
-      <PageContent>
-        <div className='space-y-6'>
-          {/* Summary section */}
-          <ContentSurfaceCard surface='details'>
-            <ContentSectionHeaderSkeleton
-              titleWidth='w-36'
-              descriptionWidth='w-96'
-              className='min-h-0 px-4 py-3'
-            />
-            <div className='grid grid-cols-1 gap-3 p-3 pt-0 sm:grid-cols-3 sm:p-4 sm:pt-0'>
-              <SummaryCardSkeleton />
-              <SummaryCardSkeleton />
-              <SummaryCardSkeleton />
-            </div>
-          </ContentSurfaceCard>
+    <PageContent>
+      <div className='space-y-6'>
+        {/* Summary section */}
+        <ContentSurfaceCard surface='details'>
+          <ContentSectionHeaderSkeleton
+            titleWidth='w-36'
+            descriptionWidth='w-96'
+            className='min-h-0 px-4 py-3'
+          />
+          <div className='grid grid-cols-1 gap-3 p-3 pt-0 sm:grid-cols-3 sm:p-4 sm:pt-0'>
+            <SummaryCardSkeleton />
+            <SummaryCardSkeleton />
+            <SummaryCardSkeleton />
+          </div>
+        </ContentSurfaceCard>
 
-          {/* Fan retargeting ad group */}
-          <AdGroupSkeleton />
+        {/* Fan retargeting ad group */}
+        <AdGroupSkeleton />
 
-          {/* Profile claim ad group */}
-          <AdGroupSkeleton />
+        {/* Profile claim ad group */}
+        <AdGroupSkeleton />
 
-          {/* Instructions section */}
-          <ContentSurfaceCard surface='details'>
-            <ContentSectionHeaderSkeleton
-              titleWidth='w-48'
-              descriptionWidth='w-96'
-              className='min-h-0 px-4 py-3'
-            />
-            <div className='space-y-2 px-8 py-5 pt-4'>
-              <LoadingSkeleton height='h-4' width='w-full' rounded='md' />
-              <LoadingSkeleton height='h-4' width='w-11/12' rounded='md' />
-              <LoadingSkeleton height='h-4' width='w-full' rounded='md' />
-              <LoadingSkeleton height='h-4' width='w-10/12' rounded='md' />
-              <LoadingSkeleton height='h-4' width='w-full' rounded='md' />
-              <LoadingSkeleton height='h-4' width='w-9/12' rounded='md' />
-            </div>
-          </ContentSurfaceCard>
-        </div>
-      </PageContent>
-    </PageShell>
+        {/* Instructions section */}
+        <ContentSurfaceCard surface='details'>
+          <ContentSectionHeaderSkeleton
+            titleWidth='w-48'
+            descriptionWidth='w-96'
+            className='min-h-0 px-4 py-3'
+          />
+          <div className='space-y-2 px-8 py-5 pt-4'>
+            <LoadingSkeleton height='h-4' width='w-full' rounded='md' />
+            <LoadingSkeleton height='h-4' width='w-11/12' rounded='md' />
+            <LoadingSkeleton height='h-4' width='w-full' rounded='md' />
+            <LoadingSkeleton height='h-4' width='w-10/12' rounded='md' />
+            <LoadingSkeleton height='h-4' width='w-full' rounded='md' />
+            <LoadingSkeleton height='h-4' width='w-9/12' rounded='md' />
+          </div>
+        </ContentSurfaceCard>
+      </div>
+    </PageContent>
   );
 }

--- a/apps/web/app/app/(shell)/settings/retargeting-ads/page.tsx
+++ b/apps/web/app/app/(shell)/settings/retargeting-ads/page.tsx
@@ -5,7 +5,7 @@ import { Download, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
-import { PageContent, PageShell } from '@/components/organisms/PageShell';
+import { PageContent } from '@/components/organisms/PageShell';
 import { useNotifications } from '@/lib/hooks/useNotifications';
 
 interface AttributionStats {
@@ -30,12 +30,8 @@ function SummaryCard({
 }: Readonly<SummaryCardProps>) {
   return (
     <ContentSurfaceCard surface='nested' className='space-y-1 p-4'>
-      <p className='text-2xl font-semibold tracking-[-0.03em] text-primary-token'>
-        {value}
-      </p>
-      <p className='text-xs font-semibold uppercase tracking-[0.14em] text-tertiary-token'>
-        {label}
-      </p>
+      <p className='text-2xl font-semibold text-primary-token'>{value}</p>
+      <p className='text-xs font-medium text-tertiary-token'>{label}</p>
       <p className='text-app leading-5 text-secondary-token'>{description}</p>
     </ContentSurfaceCard>
   );
@@ -80,7 +76,7 @@ function AttributionStatsCard() {
       />
       <div className='space-y-3 p-3 pt-0 sm:p-4 sm:pt-0'>
         <div>
-          <p className='text-2xl font-semibold tracking-[-0.03em] text-primary-token'>
+          <p className='text-2xl font-semibold text-primary-token'>
             {stats.total}
           </p>
           <p className='text-app text-secondary-token'>
@@ -211,8 +207,8 @@ function AdPreviewCard({ variant }: { readonly variant: AdVariant }) {
       <div
         className={
           variant.size === 'story'
-            ? 'relative aspect-[9/16] overflow-hidden rounded-[10px] bg-surface-2'
-            : 'relative aspect-square overflow-hidden rounded-[10px] bg-surface-2'
+            ? 'relative aspect-[9/16] overflow-hidden rounded-lg bg-surface-2'
+            : 'relative aspect-square overflow-hidden rounded-lg bg-surface-2'
         }
       >
         {/* eslint-disable-next-line @next/next/no-img-element -- Preview image from our own API */}
@@ -292,80 +288,78 @@ function AdGroupSection({
 
 export default function RetargetingAdsPage() {
   return (
-    <PageShell>
-      <PageContent>
-        <div className='space-y-6'>
-          <ContentSurfaceCard surface='details'>
-            <ContentSectionHeader
-              density='compact'
-              title='Retargeting ads'
-              subtitle='Download ready-to-run creatives for Meta retargeting campaigns.'
-            />
-            <div className='grid grid-cols-1 gap-3 p-3 pt-0 sm:grid-cols-3 sm:p-4 sm:pt-0'>
-              <SummaryCard
-                value='4'
-                label='Creatives'
-                description='Feed and story assets for both fan retargeting and profile-claim campaigns.'
-              />
-              <SummaryCard
-                value='2'
-                label='Audiences'
-                description='Separate messaging for returning fans and artists who have not claimed their profile.'
-              />
-              <SummaryCard
-                value='Meta'
-                label='Destination'
-                description='Upload these PNG assets directly to Ads Manager for Instagram and Facebook placements.'
-              />
-            </div>
-          </ContentSurfaceCard>
-
-          <AttributionStatsCard />
-
-          <AdGroupSection
-            title='Fan retargeting'
-            subtitle="Show these ads to fans who visited your profile but haven't enabled notifications yet."
-            variants={AD_VARIANTS.filter(variant => variant.type === 'fan')}
+    <PageContent>
+      <div className='space-y-6'>
+        <ContentSurfaceCard surface='details'>
+          <ContentSectionHeader
+            density='compact'
+            title='Retargeting ads'
+            subtitle='Download ready-to-run creatives for Meta retargeting campaigns.'
           />
-
-          <AdGroupSection
-            title='Profile claim'
-            subtitle='Show these ads to artists who have an unclaimed profile and want to take ownership.'
-            variants={AD_VARIANTS.filter(variant => variant.type === 'claim')}
-          />
-
-          <ContentSurfaceCard surface='details'>
-            <ContentSectionHeader
-              density='compact'
-              title='How to use these ads'
-              subtitle='Upload the feed and story assets directly to Meta Ads Manager.'
+          <div className='grid grid-cols-1 gap-3 p-3 pt-0 sm:grid-cols-3 sm:p-4 sm:pt-0'>
+            <SummaryCard
+              value='4'
+              label='Creatives'
+              description='Feed and story assets for both fan retargeting and profile-claim campaigns.'
             />
-            <ol className='list-decimal space-y-2 px-8 py-5 pt-4 text-app text-secondary-token'>
-              <li>Download the ad images above.</li>
-              <li>
-                Create a new campaign in Meta Ads Manager with the Traffic
-                objective.
-              </li>
-              <li>
-                Target your website visitors custom audience built from your
-                pixel.
-              </li>
-              <li>
-                Exclude your existing subscribers so these ads stay focused on
-                conversion opportunities.
-              </li>
-              <li>
-                Use the square asset for feed placements and the vertical asset
-                for stories.
-              </li>
-              <li>
-                Set your daily budget, publish, and monitor attribution above
-                for results.
-              </li>
-            </ol>
-          </ContentSurfaceCard>
-        </div>
-      </PageContent>
-    </PageShell>
+            <SummaryCard
+              value='2'
+              label='Audiences'
+              description='Separate messaging for returning fans and artists who have not claimed their profile.'
+            />
+            <SummaryCard
+              value='Meta'
+              label='Destination'
+              description='Upload these PNG assets directly to Ads Manager for Instagram and Facebook placements.'
+            />
+          </div>
+        </ContentSurfaceCard>
+
+        <AttributionStatsCard />
+
+        <AdGroupSection
+          title='Fan retargeting'
+          subtitle="Show these ads to fans who visited your profile but haven't enabled notifications yet."
+          variants={AD_VARIANTS.filter(variant => variant.type === 'fan')}
+        />
+
+        <AdGroupSection
+          title='Profile claim'
+          subtitle='Show these ads to artists who have an unclaimed profile and want to take ownership.'
+          variants={AD_VARIANTS.filter(variant => variant.type === 'claim')}
+        />
+
+        <ContentSurfaceCard surface='details'>
+          <ContentSectionHeader
+            density='compact'
+            title='How to use these ads'
+            subtitle='Upload the feed and story assets directly to Meta Ads Manager.'
+          />
+          <ol className='list-decimal space-y-2 px-8 py-5 pt-4 text-app text-secondary-token'>
+            <li>Download the ad images above.</li>
+            <li>
+              Create a new campaign in Meta Ads Manager with the Traffic
+              objective.
+            </li>
+            <li>
+              Target your website visitors custom audience built from your
+              pixel.
+            </li>
+            <li>
+              Exclude your existing subscribers so these ads stay focused on
+              conversion opportunities.
+            </li>
+            <li>
+              Use the square asset for feed placements and the vertical asset
+              for stories.
+            </li>
+            <li>
+              Set your daily budget, publish, and monitor attribution above for
+              results.
+            </li>
+          </ol>
+        </ContentSurfaceCard>
+      </div>
+    </PageContent>
   );
 }

--- a/apps/web/tests/unit/app/settings-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/settings-shell-normalization.test.ts
@@ -1,0 +1,70 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function findSourceFile(...candidates: string[]): string | undefined {
+  return candidates.find(candidate => existsSync(candidate));
+}
+
+const SETTINGS_LAYOUT = findSourceFile(
+  resolve(process.cwd(), 'app/app/(shell)/settings/layout.tsx'),
+  resolve(process.cwd(), 'apps/web/app/app/(shell)/settings/layout.tsx')
+);
+
+const RETARGETING_ROUTE_FILES = [
+  findSourceFile(
+    resolve(process.cwd(), 'app/app/(shell)/settings/retargeting-ads/page.tsx'),
+    resolve(
+      process.cwd(),
+      'apps/web/app/app/(shell)/settings/retargeting-ads/page.tsx'
+    )
+  ),
+  findSourceFile(
+    resolve(
+      process.cwd(),
+      'app/app/(shell)/settings/retargeting-ads/loading.tsx'
+    ),
+    resolve(
+      process.cwd(),
+      'apps/web/app/app/(shell)/settings/retargeting-ads/loading.tsx'
+    )
+  ),
+] as const;
+
+const RETARGETING_ROUTE_CANDIDATES = [
+  resolve(process.cwd(), 'app/app/(shell)/settings/retargeting-ads/page.tsx'),
+  resolve(
+    process.cwd(),
+    'app/app/(shell)/settings/retargeting-ads/loading.tsx'
+  ),
+] as const;
+
+describe('settings shell normalization', () => {
+  it('keeps the settings route group as the only PageShell owner', () => {
+    expect(SETTINGS_LAYOUT).toBeDefined();
+
+    if (!SETTINGS_LAYOUT) {
+      throw new Error('Could not find settings layout source');
+    }
+    const layoutSource = readFileSync(SETTINGS_LAYOUT, 'utf8');
+    expect(layoutSource).toContain('<PageShell');
+    expect(layoutSource).toContain("data-testid='settings-shell-content'");
+  });
+
+  it('keeps focused settings subroutes inside the parent shell', () => {
+    const missingFiles = RETARGETING_ROUTE_FILES.filter(filePath => !filePath);
+    expect(missingFiles).toEqual([]);
+
+    for (const filePath of RETARGETING_ROUTE_FILES) {
+      if (!filePath) {
+        throw new Error(
+          `Could not find retargeting settings source. Checked: ${RETARGETING_ROUTE_CANDIDATES.join(', ')}`
+        );
+      }
+      const source = readFileSync(filePath, 'utf8');
+      expect(source).not.toMatch(/<PageShell\b/);
+      expect(source).not.toMatch(/import\s*\{[^}]*PageShell/);
+      expect(source).toMatch(/<PageContent\b/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Remove the nested PageShell from the retargeting ads settings page and loading state so the settings route group owns the frame.
- Keep existing retargeting behavior while cleaning local typography and radius drift.
- Add a route-group guard test for settings shell ownership.

## Verification
- pnpm exec biome check --write 'apps/web/app/app/(shell)/settings/retargeting-ads/page.tsx' 'apps/web/app/app/(shell)/settings/retargeting-ads/loading.tsx' apps/web/tests/unit/app/settings-shell-normalization.test.ts
- pnpm --filter @jovie/web exec vitest run tests/unit/app/settings-shell-normalization.test.ts tests/unit/app/settings-scroll-mode.test.ts tests/unit/app/settings-page.test.tsx tests/unit/app/settings-route-error-guard.test.ts --config=vitest.config.mts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push

Linear: JOV-2305