### PR TITLE
JOV-2309 normalize admin table typography

### DIFF
--- a/apps/web/components/features/admin/table/AdminDataTable.tsx
+++ b/apps/web/components/features/admin/table/AdminDataTable.tsx
@@ -8,7 +8,7 @@ import { TABLE_MIN_WIDTHS } from '@/lib/constants/layout';
 import { cn } from '@/lib/utils';
 
 export const ADMIN_DATA_TABLE_CLASSNAME =
-  'text-[12.5px] [&_thead_th]:py-1 [&_thead_th]:text-3xs [&_thead_th]:tracking-[0.07em]';
+  'text-[12.5px] [&_thead_th]:py-1 [&_thead_th]:text-3xs [&_thead_th]:tracking-normal';
 
 export type AdminDataTableProps<TData> = UnifiedTableProps<TData>;
 

--- a/apps/web/tests/unit/app/admin-table-shell-typography.test.ts
+++ b/apps/web/tests/unit/app/admin-table-shell-typography.test.ts
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function findSourceFile(...candidates: string[]): string {
+  const found = candidates.find(candidate => existsSync(candidate));
+  if (!found) {
+    throw new Error(
+      `Could not find source file. Checked: ${candidates.join(', ')}`
+    );
+  }
+  return found;
+}
+
+const ADMIN_DATA_TABLE = findSourceFile(
+  resolve(process.cwd(), 'components/features/admin/table/AdminDataTable.tsx'),
+  resolve(
+    process.cwd(),
+    'apps/web/components/features/admin/table/AdminDataTable.tsx'
+  )
+);
+
+describe('admin table shell typography', () => {
+  it('keeps AdminDataTable backed by the unified shell table', () => {
+    const source = readFileSync(ADMIN_DATA_TABLE, 'utf8');
+
+    expect(source).toContain("from '@/components/organisms/table'");
+    expect(source).toContain('<UnifiedTable<TData>');
+  });
+
+  it('does not force expanded all-caps header tracking', () => {
+    const source = readFileSync(ADMIN_DATA_TABLE, 'utf8');
+
+    expect(source).toContain('[&_thead_th]:tracking-normal');
+    expect(source).not.toMatch(/uppercase/);
+    expect(source).not.toMatch(/tracking-\[(?!-)/);
+    expect(source).not.toMatch(/tracking-wide/);
+  });
+});


### PR DESCRIPTION
## Summary
- keep AdminDataTable backed by UnifiedTable while removing forced wide header tracking
- align admin table headers with the unified shell table typography tokens
- add a source guard that blocks all-caps/wide-tracking drift in the admin table wrapper

## Verification
- ./scripts/setup.sh
- pnpm exec biome check --write apps/web/components/features/admin/table/AdminDataTable.tsx apps/web/tests/unit/app/admin-table-shell-typography.test.ts
- pnpm --filter @jovie/web exec vitest run tests/unit/app/admin-table-shell-typography.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- git push pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated admin table header letter-spacing to standard tracking.

* **Tests**
  * Added test coverage for admin table typography and styling contracts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->