### PR TITLE
JOV-2307 normalize admin ops chrome

### DIFF
--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -161,14 +161,18 @@ function getDefaultSkills(kind: HermesDispatchKind): readonly string[] {
   return ['autoplan', 'investigate'];
 }
 
-function SectionEyebrow({
+function SectionLabel({
   children,
 }: Readonly<{ readonly children: ReactNode }>) {
   return (
-    <p className='text-[11px] font-semibold uppercase tracking-[0.16em] text-tertiary-token'>
+    <p className='text-2xs font-semibold tracking-normal text-tertiary-token'>
       {children}
     </p>
   );
+}
+
+function formatMetaLabel(value: string): string {
+  return value.replaceAll('_', ' ');
 }
 
 async function copyDeploymentId(run: HudDeploymentRun) {
@@ -189,7 +193,7 @@ function DeploymentActionsMenu({
         <button
           type='button'
           aria-label='Deployment actions'
-          className='flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-tertiary-token hover:bg-surface-1 hover:text-secondary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/25'
+          className='flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-tertiary-token transition-colors duration-subtle hover:bg-surface-1 hover:text-secondary-token focus-visible:bg-surface-1 focus-visible:outline-none'
         >
           <MoreHorizontal className='h-3.5 w-3.5' aria-hidden='true' />
         </button>
@@ -286,8 +290,8 @@ function DeploymentRow({
           <p className='text-[11px] text-tertiary-token'>
             {formatDeploymentTime(run.createdAtIso)}
           </p>
-          <p className='mt-0.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-secondary-token'>
-            {run.status}
+          <p className='mt-0.5 text-[11px] font-medium text-secondary-token'>
+            {DEPLOYMENT_STATE_LABELS[run.status]}
           </p>
         </div>
         <DeploymentActionsMenu run={run} />
@@ -346,8 +350,8 @@ function AiOpsItemRow({
         <p className='truncate text-[13px] font-semibold text-primary-token'>
           {item.summary}
         </p>
-        <p className='mt-1 text-[11px] uppercase tracking-[0.08em] text-tertiary-token'>
-          {item.source} / {item.status}
+        <p className='mt-1 text-[11px] text-tertiary-token'>
+          {formatMetaLabel(item.source)} / {formatMetaLabel(item.status)}
         </p>
       </div>
       <div className='flex shrink-0 items-center gap-1.5 text-right text-[11px] text-tertiary-token'>
@@ -705,7 +709,7 @@ export function HudDashboardClient({
           >
             <div className='flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between'>
               <div className='space-y-2'>
-                <SectionEyebrow>Default status</SectionEyebrow>
+                <SectionLabel>Default status</SectionLabel>
                 <p className='text-[26px] font-[620] leading-none tracking-[-0.03em] text-primary-token sm:text-[32px]'>
                   {formatDefaultStatusLabel(metrics.overview.defaultStatus)}
                 </p>
@@ -743,7 +747,7 @@ export function HudDashboardClient({
               />
             </div>
             <div className='min-w-0'>
-              <SectionEyebrow>HUD</SectionEyebrow>
+              <SectionLabel>HUD</SectionLabel>
               <h1 className='mt-1 truncate text-[22px] font-[620] leading-none tracking-[-0.03em] text-primary-token sm:text-[24px]'>
                 {metrics.branding.startupName}
               </h1>
@@ -790,7 +794,6 @@ export function HudDashboardClient({
               <HudStatusPill label={deploymentLabel} tone={deploymentsTone} />
             }
             className='p-3'
-            labelClassName='uppercase tracking-[0.16em] text-tertiary-token'
             valueClassName={mrrValueClass}
           />
 
@@ -819,7 +822,6 @@ export function HudDashboardClient({
                 )
               }
               className='p-3'
-              labelClassName='uppercase tracking-[0.16em] text-tertiary-token'
               valueClassName={secondaryValueClass}
             />
             <ContentMetricCard
@@ -833,7 +835,6 @@ export function HudDashboardClient({
                   : `DB latency ${metrics.operations.dbLatencyMs.toFixed(0)}ms`
               }
               className='p-3'
-              labelClassName='uppercase tracking-[0.16em] text-tertiary-token'
               valueClassName={secondaryValueClass}
             />
             <ContentMetricCard
@@ -841,7 +842,6 @@ export function HudDashboardClient({
               value={`${metrics.reliability.reliabilityScorePercent.toFixed(1)}%`}
               subtitle={formatReliabilitySubtitle(metrics.reliability)}
               className='p-3 col-span-2'
-              labelClassName='uppercase tracking-[0.16em] text-tertiary-token'
               valueClassName={secondaryValueClass}
             />
           </div>
@@ -853,7 +853,7 @@ export function HudDashboardClient({
         <div className='grid gap-3 xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,0.9fr)]'>
           <ContentSurfaceCard surface='details' className='space-y-3 p-3'>
             <div className='flex items-center justify-between gap-3'>
-              <SectionEyebrow>Deployments</SectionEyebrow>
+              <SectionLabel>Deployments</SectionLabel>
               <p className='text-[12px] text-secondary-token'>
                 {deploymentDetail}
               </p>
@@ -874,7 +874,7 @@ export function HudDashboardClient({
           <ContentSurfaceCard surface='details' className='space-y-4 p-3'>
             <div className='flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between'>
               <div className='space-y-1'>
-                <SectionEyebrow>Open on phone</SectionEyebrow>
+                <SectionLabel>Open on phone</SectionLabel>
                 <p className='text-[20px] font-[620] tracking-[-0.03em] text-primary-token'>
                   Scan to view
                 </p>
@@ -896,7 +896,7 @@ export function HudDashboardClient({
       ) : (
         <ContentSurfaceCard surface='details' className='space-y-3 p-3'>
           <div className='flex items-center justify-between gap-3'>
-            <SectionEyebrow>Deployments</SectionEyebrow>
+            <SectionLabel>Deployments</SectionLabel>
             <p className='text-[12px] text-secondary-token'>
               {deploymentDetail}
             </p>
@@ -917,7 +917,7 @@ export function HudDashboardClient({
       <ContentSurfaceCard surface='details' className='space-y-4 p-3'>
         <div className='flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between'>
           <div className='space-y-1'>
-            <SectionEyebrow>AI ops</SectionEyebrow>
+            <SectionLabel>AI ops</SectionLabel>
             <p className='text-[24px] font-[620] leading-none text-primary-token sm:text-[28px]'>
               Hermes control plane
             </p>
@@ -959,7 +959,7 @@ export function HudDashboardClient({
         <div className='grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.9fr)]'>
           <div className='space-y-3'>
             <div className='flex items-center justify-between gap-3'>
-              <SectionEyebrow>Blockers</SectionEyebrow>
+              <SectionLabel>Blockers</SectionLabel>
               <p className='text-[12px] text-secondary-token'>
                 {metrics.aiOps.availability}
               </p>
@@ -991,7 +991,7 @@ export function HudDashboardClient({
                   )}
                   {dismissed.length > 0 ? (
                     <details className='group'>
-                      <summary className='cursor-pointer list-none text-[11px] font-semibold uppercase tracking-[0.12em] text-tertiary-token hover:text-secondary-token'>
+                      <summary className='cursor-pointer list-none text-[11px] font-medium text-tertiary-token hover:text-secondary-token'>
                         Dismissed ({dismissed.length})
                       </summary>
                       <div className='mt-2 grid gap-2'>
@@ -1012,7 +1012,7 @@ export function HudDashboardClient({
           </div>
 
           <div className='space-y-3'>
-            <SectionEyebrow>Dispatch</SectionEyebrow>
+            <SectionLabel>Dispatch</SectionLabel>
             {showDispatch && metrics.accessMode === 'admin' ? (
               <HermesDispatchControls
                 aiOps={metrics.aiOps}
@@ -1043,7 +1043,7 @@ export function HudDashboardClient({
 
           return (
             <div className='border-t border-subtle pt-3'>
-              <SectionEyebrow>Next actions</SectionEyebrow>
+              <SectionLabel>Next actions</SectionLabel>
               {visibleRecs.length > 0 ? (
                 <div className='mt-2 grid gap-2'>
                   {visibleRecs.map(item => (
@@ -1061,7 +1061,7 @@ export function HudDashboardClient({
               )}
               {dismissedRecs.length > 0 ? (
                 <details className='mt-2'>
-                  <summary className='cursor-pointer list-none text-[11px] font-semibold uppercase tracking-[0.12em] text-tertiary-token hover:text-secondary-token'>
+                  <summary className='cursor-pointer list-none text-[11px] font-medium text-tertiary-token hover:text-secondary-token'>
                     Dismissed ({dismissedRecs.length})
                   </summary>
                   <div className='mt-2 grid gap-2'>
@@ -1092,7 +1092,7 @@ export function HudDashboardClient({
       >
         <div className='flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between'>
           <div className='space-y-2'>
-            <SectionEyebrow>Default status</SectionEyebrow>
+            <SectionLabel>Default status</SectionLabel>
             <p
               className={
                 isShell
@@ -1100,7 +1100,7 @@ export function HudDashboardClient({
                   : 'text-[40px] font-[620] leading-none tracking-[-0.045em] text-primary-token sm:text-[52px]'
               }
             >
-              {metrics.overview.defaultStatus.toUpperCase()}
+              {formatDefaultStatusLabel(metrics.overview.defaultStatus)}
             </p>
             <p
               className={

--- a/apps/web/app/app/(shell)/admin/ops/HudStatusPill.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudStatusPill.tsx
@@ -12,7 +12,7 @@ export function HudStatusPill({ label, tone }: Readonly<HudStatusPillProps>) {
   return (
     <span
       className={cn(
-        'inline-flex items-center rounded-full border px-3.5 py-1 text-[11px] font-semibold uppercase tracking-[0.08em]'
+        'inline-flex items-center rounded-full border px-3 py-1 text-[11.5px] font-[510] leading-none'
       )}
       style={{
         borderColor: `color-mix(in oklab, ${accent.solid} 26%, var(--linear-app-frame-seam))`,

--- a/apps/web/app/app/(shell)/admin/ops/page.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/page.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@jovie/ui';
 import { Maximize2 } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
@@ -108,16 +109,17 @@ export default async function AdminOpsPage({
       description='Live operations: deploys, AI ops, runway, blockers.'
       testId='admin-ops-page'
       actions={
-        <Link
-          href={PRESENTATION_VIEW_HREF}
-          target='_blank'
-          rel='noopener'
-          aria-label='Open TV view in a new tab'
-          className='inline-flex h-8 items-center gap-1.5 rounded-lg border border-subtle bg-surface-0 px-2.5 text-[12px] font-[540] text-secondary-token transition-colors hover:bg-surface-1 hover:text-primary-token'
-        >
-          <Maximize2 className='h-3.5 w-3.5' aria-hidden='true' />
-          TV view
-        </Link>
+        <Button asChild variant='secondary' size='sm'>
+          <Link
+            href={PRESENTATION_VIEW_HREF}
+            target='_blank'
+            rel='noopener'
+            aria-label='Open TV view in a new tab'
+          >
+            <Maximize2 className='h-3.5 w-3.5' aria-hidden='true' />
+            TV view
+          </Link>
+        </Button>
       }
     >
       <HudDashboardClient

--- a/apps/web/tests/unit/app/admin-ops-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/admin-ops-shell-normalization.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const TEST_DIR = dirname(
+  import.meta.url.startsWith('file:')
+    ? fileURLToPath(import.meta.url)
+    : import.meta.url
+);
+
+const OPS_ROUTE_DIR = join(TEST_DIR, '../../../app/app/(shell)/admin/ops');
+const OPS_PAGE = join(OPS_ROUTE_DIR, 'page.tsx');
+const HUD_DASHBOARD_CLIENT = join(OPS_ROUTE_DIR, 'HudDashboardClient.tsx');
+const HUD_STATUS_PILL = join(OPS_ROUTE_DIR, 'HudStatusPill.tsx');
+
+const OPS_COMPONENT_FILES = [
+  OPS_PAGE,
+  HUD_DASHBOARD_CLIENT,
+  HUD_STATUS_PILL,
+  join(OPS_ROUTE_DIR, 'HudClockClient.tsx'),
+] as const;
+
+function readSource(filePath: string): string {
+  return readFileSync(filePath, 'utf8');
+}
+
+describe('admin ops shell normalization', () => {
+  it('keeps the ops route inside AdminToolPage while preserving kiosk mode', () => {
+    const source = readSource(OPS_PAGE);
+
+    expect(source).toContain('import { AdminToolPage }');
+    expect(source).toContain('<AdminToolPage');
+    expect(source).toContain("value === 'kiosk' ? 'admin-kiosk' : 'shell'");
+    expect(source).toContain("presentationMode='admin-kiosk'");
+    expect(source).toContain("density='kiosk'");
+  });
+
+  it('does not reintroduce uppercase tracked SectionEyebrow styling', () => {
+    const source = readSource(HUD_DASHBOARD_CLIENT);
+
+    expect(source).not.toContain('SectionEyebrow');
+    expect(source).not.toMatch(
+      /className=['"][^'"]*(uppercase[^'"]*tracking|tracking[^'"]*uppercase)[^'"]*['"]/
+    );
+  });
+
+  it('uses tokenized motion durations in ops components', () => {
+    for (const filePath of OPS_COMPONENT_FILES) {
+      const source = readSource(filePath);
+
+      expect(source).not.toMatch(/\bduration-(150|200)\b/);
+    }
+  });
+
+  it('keeps HudStatusPill quiet and non-uppercase', () => {
+    const source = readSource(HUD_STATUS_PILL);
+
+    expect(source).not.toContain('uppercase');
+    expect(source).not.toMatch(/\btracking-\[/);
+    expect(source).toContain('font-[510]');
+    expect(source).toContain('getAccentCssVars');
+    expect(source).toContain('HUD_TONE_ACCENT');
+  });
+});


### PR DESCRIPTION
## Summary
- move the admin Ops TV action onto the shared Button primitive while preserving AdminToolPage and kiosk mode
- quiet HUD section labels, deployment/meta copy, status pills, and focus chrome
- add source guards for AdminToolPage/kiosk preservation, non-uppercase status pills, tokenized motion, and section-label drift

## Verification
- pnpm install
- pnpm exec biome check --write 'apps/web/app/app/(shell)/admin/ops/page.tsx' 'apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx' 'apps/web/app/app/(shell)/admin/ops/HudStatusPill.tsx' apps/web/tests/unit/app/admin-ops-shell-normalization.test.ts
- pnpm --filter @jovie/web exec vitest run tests/unit/app/admin-ops-shell-normalization.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- git push pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, lint