### PR TITLE
JOV-2311 normalize shared table motion tokens

### DIFF
--- a/apps/web/components/features/admin/table/SortableHeaderButton.tsx
+++ b/apps/web/components/features/admin/table/SortableHeaderButton.tsx
@@ -22,7 +22,7 @@ export function SortableHeaderButton({
       onClick={onClick}
       className={cn(
         'inline-flex w-full items-center gap-2 text-left text-app font-medium tracking-normal',
-        'rounded-full px-1.5 py-1 transition-[background-color,color,box-shadow] duration-150',
+        'rounded-full px-1.5 py-1 transition-[background-color,color,box-shadow] duration-subtle',
         'text-secondary-token hover:bg-surface-1 hover:text-primary-token',
         'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
         'active:bg-surface-0',

--- a/apps/web/components/features/admin/table/molecules/TableRow.tsx
+++ b/apps/web/components/features/admin/table/molecules/TableRow.tsx
@@ -50,7 +50,7 @@ export function TableRow({
       data-index={dataIndex}
       className={cn(
         // Base styles
-        'group border-b border-subtle transition-[background-color,box-shadow] duration-150 last:border-b-0',
+        'group border-b border-subtle transition-[background-color,box-shadow] duration-subtle last:border-b-0',
         // Fixed height to prevent layout shift
         'h-[60px]',
         // Hover and selected states — aligned with Linear design tokens

--- a/apps/web/components/organisms/table/atoms/TableRow.tsx
+++ b/apps/web/components/organisms/table/atoms/TableRow.tsx
@@ -53,7 +53,7 @@ export function TableRow({
       data-row-index={rowIndex}
       className={cn(
         // Base styles
-        'group transition-colors duration-150',
+        'group transition-colors duration-subtle',
         // Fixed height to prevent layout shift
         'h-[32px]',
         // Hover state — Linear: rgba(255,255,255,0.02)

--- a/apps/web/components/organisms/table/molecules/ContextMenuSubmenu.tsx
+++ b/apps/web/components/organisms/table/molecules/ContextMenuSubmenu.tsx
@@ -69,7 +69,7 @@ export function ContextMenuSubmenu({
           'flex w-full items-center justify-between gap-2',
           'px-2 py-1.5 text-left text-app',
           'hover:bg-surface-2 rounded',
-          'transition-colors duration-150',
+          'transition-colors duration-subtle',
           className
         )}
         type='button'
@@ -90,7 +90,7 @@ export function ContextMenuSubmenu({
             'bg-surface-1 shadow-lg',
             'p-1',
             'animate-in slide-in-from-left-2 fade-in',
-            'duration-150'
+            'duration-subtle'
           )}
         >
           {children}
@@ -145,7 +145,7 @@ export function ContextMenuItem({
         'flex w-full items-center gap-2',
         'px-2 py-1.5 text-left text-app',
         'hover:bg-surface-2 rounded',
-        'transition-colors duration-150',
+        'transition-colors duration-subtle',
         destructive && 'text-error hover:bg-error/10',
         className
       )}

--- a/apps/web/components/organisms/table/molecules/DisplayMenuDropdown.tsx
+++ b/apps/web/components/organisms/table/molecules/DisplayMenuDropdown.tsx
@@ -33,7 +33,7 @@ function ToggleSwitch({
       role='switch'
       aria-checked={checked}
       onClick={onToggle}
-      className='flex w-full items-center justify-between gap-2 rounded px-1.5 py-1 transition-[background-color] duration-150 hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+      className='flex w-full items-center justify-between gap-2 rounded px-1.5 py-1 transition-[background-color] duration-subtle hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
     >
       <span className='text-app text-secondary-token'>{label}</span>
       <span
@@ -77,7 +77,7 @@ const ColumnToggleButton = memo(function ColumnToggleButton({
       aria-pressed={isVisible}
       aria-label={`${isVisible ? 'Hide' : 'Show'} ${label} column`}
       className={cn(
-        'rounded-full px-2 py-0.5 text-2xs font-caption transition-[background-color,color] duration-150 focus-visible:outline-none focus-visible:bg-surface-1',
+        'rounded-full px-2 py-0.5 text-2xs font-caption transition-[background-color,color] duration-subtle focus-visible:outline-none focus-visible:bg-surface-1',
         isVisible
           ? 'bg-surface-1 text-secondary-token'
           : 'text-tertiary-token hover:bg-surface-1 hover:text-secondary-token'
@@ -140,7 +140,7 @@ export function DisplayMenuDropdown({
   const defaultTrigger = (
     <button
       type='button'
-      className='inline-flex items-center gap-1.5 rounded-full border border-transparent px-2 py-1 text-app font-caption text-secondary-token transition-[background-color,border-color,color] duration-150 hover:border-subtle hover:bg-surface-1 hover:text-primary-token'
+      className='inline-flex items-center gap-1.5 rounded-full border border-transparent px-2 py-1 text-app font-caption text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-1 hover:text-primary-token'
     >
       <Settings2 className='h-4 w-4' />
       Display
@@ -158,7 +158,7 @@ export function DisplayMenuDropdown({
           </span>
           <PopoverPrimitive.Close
             aria-label='Close'
-            className='rounded-full border border-transparent p-0.5 text-tertiary-token transition-[background-color,border-color,color] duration-150 hover:border-subtle hover:bg-surface-1 hover:text-secondary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1'
+            className='rounded-full border border-transparent p-0.5 text-tertiary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-1 hover:text-secondary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1'
           >
             <X className='h-4 w-4' />
           </PopoverPrimitive.Close>
@@ -174,7 +174,7 @@ export function DisplayMenuDropdown({
               {/* Sliding background indicator */}
               <div
                 className={cn(
-                  'absolute inset-y-0.5 w-[calc(50%-2px)] rounded bg-surface-0 transition-all duration-200 ease-out',
+                  'absolute inset-y-0.5 w-[calc(50%-2px)] rounded bg-surface-0 transition-[left,background-color] duration-normal ease-out',
                   viewMode === 'list' ? 'left-0.5' : 'left-[calc(50%+0.5px)]'
                 )}
                 aria-hidden='true'
@@ -184,7 +184,7 @@ export function DisplayMenuDropdown({
                 type='button'
                 onClick={() => onViewModeChange?.('list')}
                 className={cn(
-                  'relative z-10 inline-flex flex-1 items-center justify-center gap-1.5 rounded px-2.5 py-1 text-xs font-caption transition-colors duration-150',
+                  'relative z-10 inline-flex flex-1 items-center justify-center gap-1.5 rounded px-2.5 py-1 text-xs font-caption transition-colors duration-subtle',
                   viewMode === 'list'
                     ? 'text-primary-token'
                     : 'text-tertiary-token hover:text-secondary-token'
@@ -200,7 +200,7 @@ export function DisplayMenuDropdown({
                 type='button'
                 onClick={() => onViewModeChange?.('board')}
                 className={cn(
-                  'relative z-10 inline-flex flex-1 items-center justify-center gap-1.5 rounded px-2.5 py-1 text-xs font-caption transition-colors duration-150',
+                  'relative z-10 inline-flex flex-1 items-center justify-center gap-1.5 rounded px-2.5 py-1 text-xs font-caption transition-colors duration-subtle',
                   viewMode === 'board'
                     ? 'text-primary-token'
                     : 'text-tertiary-token hover:text-secondary-token'

--- a/apps/web/components/organisms/table/molecules/GroupedTableBody.tsx
+++ b/apps/web/components/organisms/table/molecules/GroupedTableBody.tsx
@@ -76,11 +76,11 @@ export function GroupedTableBody<T>({
       {groupedData.map((group, groupIndex) => {
         const isUpcomingGroup = groupIndex === visibleGroupIndex + 1;
         const labelClassName = cn(
-          'transition-colors duration-150 ease-out',
+          'transition-colors duration-subtle ease-out',
           isUpcomingGroup && 'text-secondary-token'
         );
         const countClassName = cn(
-          'transition-colors duration-150 ease-out',
+          'transition-colors duration-subtle ease-out',
           isUpcomingGroup && 'text-tertiary-token'
         );
 

--- a/apps/web/components/organisms/table/molecules/HeaderBulkActions.tsx
+++ b/apps/web/components/organisms/table/molecules/HeaderBulkActions.tsx
@@ -95,7 +95,7 @@ export function HeaderBulkActions({
           variant='ghost'
           size='sm'
           onClick={onClearSelection}
-          className='h-7 w-7 rounded-full border border-transparent p-0 text-tertiary-token transition-[background-color,border-color,color] duration-150 hover:border-subtle hover:bg-surface-1 hover:text-primary-token'
+          className='h-7 w-7 rounded-full border border-transparent p-0 text-tertiary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-1 hover:text-primary-token'
           aria-label='Clear selection'
         >
           <X className='h-3.5 w-3.5' />

--- a/apps/web/components/organisms/table/molecules/ResponsiveActionsCell.tsx
+++ b/apps/web/components/organisms/table/molecules/ResponsiveActionsCell.tsx
@@ -123,7 +123,7 @@ export function ResponsiveActionsCell({
           onClick={action.onClick}
           disabled={action.disabled}
           className={cn(
-            'inline-flex items-center gap-2 rounded-full border border-transparent px-2.5 py-1.5 text-xs font-caption tracking-[-0.01em] transition-[background-color,border-color,color,box-shadow] duration-150 ease-out',
+            'inline-flex items-center gap-2 rounded-full border border-transparent px-2.5 py-1.5 text-xs font-caption tracking-[-0.01em] transition-[background-color,border-color,color,box-shadow] duration-subtle ease-out',
             action.destructive
               ? 'text-destructive hover:border-destructive/20 hover:bg-destructive/10 hover:text-destructive [&_svg]:text-destructive'
               : 'text-secondary-token hover:border-subtle hover:bg-surface-1 hover:text-primary-token',
@@ -145,7 +145,7 @@ export function ResponsiveActionsCell({
           <DropdownMenuTrigger asChild>
             <button
               type='button'
-              className='inline-flex h-7 w-7 items-center justify-center rounded-full bg-surface-0 text-tertiary-token transition-[background-color,color,box-shadow] duration-150 ease-out hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20'
+              className='inline-flex h-7 w-7 items-center justify-center rounded-full bg-surface-0 text-tertiary-token transition-[background-color,color,box-shadow] duration-subtle ease-out hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20'
               aria-label='More actions'
             >
               <MoreVertical className='h-4 w-4' />

--- a/apps/web/components/organisms/table/molecules/TableBulkActionsToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/TableBulkActionsToolbar.tsx
@@ -83,7 +83,7 @@ export function TableBulkActionsToolbar({
         variant='ghost'
         size='sm'
         onClick={onClearSelection}
-        className='ml-auto h-7 rounded-full border border-transparent px-2 text-secondary-token transition-[background-color,border-color,color] duration-150 hover:border-subtle hover:bg-surface-0 hover:text-primary-token'
+        className='ml-auto h-7 rounded-full border border-transparent px-2 text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-0 hover:text-primary-token'
       >
         <X className='h-4 w-4 mr-1' />
         Clear

--- a/apps/web/components/organisms/table/molecules/TableHeaderCell.tsx
+++ b/apps/web/components/organisms/table/molecules/TableHeaderCell.tsx
@@ -70,7 +70,7 @@ export function TableHeaderCell<TData>({
               className={cn(
                 tableHeaderClass,
                 'flex w-full items-center gap-2',
-                'rounded-full border border-transparent px-1.5 transition-[background-color,border-color,box-shadow] duration-150 hover:border-subtle hover:bg-surface-1',
+                'rounded-full border border-transparent px-1.5 transition-[background-color,border-color,box-shadow] duration-subtle hover:border-subtle hover:bg-surface-1',
                 'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-1 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20'
               )}
             >

--- a/apps/web/components/organisms/table/molecules/TableRow.tsx
+++ b/apps/web/components/organisms/table/molecules/TableRow.tsx
@@ -23,7 +23,7 @@ export function TableRow({
     <tr
       className={cn(
         // Base styles
-        'group transition-colors duration-150',
+        'group transition-colors duration-subtle',
         // Fixed height to prevent layout shift
         'h-[32px]',
         // Hover state — Linear: rgba(255,255,255,0.02)

--- a/apps/web/components/organisms/table/molecules/TableStandardToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/TableStandardToolbar.tsx
@@ -147,7 +147,7 @@ export function TableStandardToolbar({
             variant='ghost'
             size='sm'
             onClick={onClearSelection}
-            className='h-7 gap-1 rounded-full border border-transparent px-2 text-secondary-token transition-[background-color,border-color,color] duration-150 hover:border-subtle hover:bg-surface-0 hover:text-primary-token'
+            className='h-7 gap-1 rounded-full border border-transparent px-2 text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-0 hover:text-primary-token'
           >
             <X className='h-4 w-4' />
             Clear

--- a/apps/web/components/organisms/table/table.styles.ts
+++ b/apps/web/components/organisms/table/table.styles.ts
@@ -27,7 +27,7 @@ export const alignment = {
 // Row Selection Colors — aligned with Linear design tokens
 export const selection = {
   unchecked:
-    'hover:bg-(--linear-row-hover) focus-within:bg-(--linear-row-hover) transition-[background-color,box-shadow] duration-150',
+    'hover:bg-(--linear-row-hover) focus-within:bg-(--linear-row-hover) transition-[background-color,box-shadow] duration-subtle',
   checked:
     'bg-(--linear-row-selected) hover:bg-(--linear-row-selected) focus-within:bg-(--linear-row-selected) shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_28%,transparent)]',
   selected:
@@ -51,9 +51,9 @@ export const zIndex = {
 
 // Transition Timings — Linear uses 160ms cubic-bezier for bg
 export const transitions = {
-  fast: 'transition-colors duration-100 ease-out',
-  standard: 'transition-colors duration-150 ease-out',
-  slow: 'transition-colors duration-300 ease-out',
+  fast: 'transition-colors duration-fast ease-out',
+  standard: 'transition-colors duration-subtle ease-out',
+  slow: 'transition-colors duration-slow ease-out',
 } as const;
 
 // Column Widths (Standard)

--- a/apps/web/tests/unit/app/shared-table-motion-tokens.test.ts
+++ b/apps/web/tests/unit/app/shared-table-motion-tokens.test.ts
@@ -1,0 +1,56 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function findRoot(...candidates: string[]): string {
+  const found = candidates.find(candidate => existsSync(candidate));
+  if (!found) {
+    throw new Error(`Could not find source root. Checked: ${candidates}`);
+  }
+  return found;
+}
+
+function listSourceFiles(root: string): string[] {
+  const entries = readdirSync(root);
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const path = join(root, entry);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      files.push(...listSourceFiles(path));
+      continue;
+    }
+    if (/\.(ts|tsx)$/.test(entry)) {
+      files.push(path);
+    }
+  }
+
+  return files;
+}
+
+const TABLE_ROOTS = [
+  findRoot(
+    resolve(process.cwd(), 'components/organisms/table'),
+    resolve(process.cwd(), 'apps/web/components/organisms/table')
+  ),
+  findRoot(
+    resolve(process.cwd(), 'components/features/admin/table'),
+    resolve(process.cwd(), 'apps/web/components/features/admin/table')
+  ),
+];
+
+describe('shared table motion tokens', () => {
+  it('uses named shell duration tokens in table primitives', () => {
+    const offenders = TABLE_ROOTS.flatMap(root =>
+      listSourceFiles(root).flatMap(file => {
+        const source = readFileSync(file, 'utf8');
+        return source.match(/\bduration-(?:100|150|200|300)\b/)
+          ? [file.replace(process.cwd(), '')]
+          : [];
+      })
+    );
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- replace raw duration utilities in shared table primitives with named shell duration tokens
- narrow the display-mode slider from transition-all to explicit left/background transitions
- add a source guard blocking raw duration-100/150/200/300 in shared table primitive directories

## Verification
- ./scripts/setup.sh
- pnpm exec biome check --write apps/web/components/organisms/table apps/web/components/features/admin/table apps/web/tests/unit/app/shared-table-motion-tokens.test.ts
- pnpm --filter @jovie/web exec vitest run tests/unit/app/shared-table-motion-tokens.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- git push pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized animation transition timing across table components for improved consistency.

* **Tests**
  * Added test to enforce consistent transition timing standards throughout table components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->