### PR TITLE
JOV-2310 route shell search through command palette

### DIFF
--- a/apps/web/components/organisms/AuthShell.tsx
+++ b/apps/web/components/organisms/AuthShell.tsx
@@ -22,9 +22,6 @@ export interface AuthShellProps {
   readonly breadcrumbs: DashboardBreadcrumbItem[];
   readonly headerBadge?: ReactNode;
   readonly headerAction?: ReactNode;
-  /** Shell-owned search surface (Shell V1). Replaces the breadcrumb when active. */
-  readonly headerSearchSurface?: ReactNode;
-  readonly isHeaderSearchActive?: boolean;
   readonly showMobileTabs?: boolean;
   readonly isTableRoute?: boolean;
   readonly onSidebarOpenChange?: (open: boolean) => void;
@@ -42,8 +39,6 @@ function AuthShellInner({
   breadcrumbs,
   headerBadge,
   headerAction,
-  headerSearchSurface,
-  isHeaderSearchActive = false,
   showMobileTabs = false,
   isTableRoute = false,
   children,
@@ -86,8 +81,6 @@ function AuthShellInner({
             sidebarTrigger={sidebarTrigger}
             breadcrumbSuffix={headerBadge}
             action={headerAction}
-            searchSurface={headerSearchSurface}
-            isSearchActive={isHeaderSearchActive}
             mobileProfileSlot={
               <MobileProfileDrawer onOpen={previewPanelState.toggle} />
             }

--- a/apps/web/components/organisms/AuthShellWrapper.tsx
+++ b/apps/web/components/organisms/AuthShellWrapper.tsx
@@ -13,7 +13,6 @@ import {
 import { PreviewPanelProvider } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
 import { UpdateAvailablePill } from '@/components/atoms/UpdateAvailablePill';
 import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
-import { HeaderSearchSurface } from '@/components/shell/HeaderSearchSurface';
 import {
   HeaderActionsProvider,
   useHeaderActions,
@@ -36,8 +35,6 @@ import { useAuthRouteConfig } from '@/hooks/useAuthRouteConfig';
 import { useDashboardShortcuts } from '@/hooks/useDashboardShortcuts';
 import { useGlobalShortcutActions } from '@/hooks/useGlobalShortcutActions';
 import { useIsElectronRuntime } from '@/lib/desktop/electron-bridge';
-import { useAppFlag } from '@/lib/flags/client';
-import { isFormElement } from '@/lib/utils/keyboard';
 import { AuthShell } from './AuthShell';
 import { CommandPalette } from './CommandPalette';
 import { KeyboardShortcutsSheet } from './keyboard-shortcuts-sheet';
@@ -82,10 +79,7 @@ function AuthShellWrapperInner({
 }>) {
   const config = useAuthRouteConfig();
   const headerActions = useHeaderActions();
-  const shellChatV1Enabled = useAppFlag('SHELL_CHAT_V1');
   const isElectron = useIsElectronRuntime();
-  const { headerSearchAdapter, isSearchOpen, openSearch, closeSearch } =
-    headerActions;
   const [, startTransition] = useTransition();
   const [pendingShellRoute, setPendingShellRoute] =
     useState<PendingShellRoute>(null);
@@ -137,81 +131,6 @@ function AuthShellWrapperInner({
   const headerBadge = rawHeaderBadge ? (
     <ErrorBoundary fallback={null}>{rawHeaderBadge}</ErrorBoundary>
   ) : null;
-
-  // Shell-owned search surface: when SHELL_CHAT_V1 is on and the route has
-  // registered an adapter, render the morphing pill search/trigger in the
-  // breadcrumb slot. The header owns the open/closed transition so that
-  // global shortcuts (/, Cmd/Ctrl+K, Escape) drive the same surface.
-  const headerSearchEnabled =
-    shellChatV1Enabled && Boolean(headerSearchAdapter);
-  const headerSearchSurface = useMemo(() => {
-    if (!headerSearchEnabled || !headerSearchAdapter) return null;
-    return (
-      <ErrorBoundary fallback={null}>
-        <HeaderSearchSurface
-          adapter={headerSearchAdapter}
-          isOpen={isSearchOpen}
-          onOpen={openSearch}
-          onClose={closeSearch}
-        />
-      </ErrorBoundary>
-    );
-  }, [
-    closeSearch,
-    headerSearchAdapter,
-    headerSearchEnabled,
-    isSearchOpen,
-    openSearch,
-  ]);
-
-  // Global key bindings for the shell search surface:
-  //   /         → open (and let the existing SearchKeyboardShortcut focus the input)
-  //   Cmd/Ctrl+K → open / focus
-  //   Escape    → collapse the open pill surface back to the breadcrumb
-  useEffect(() => {
-    if (!headerSearchEnabled) return undefined;
-
-    function onKeyDown(event: KeyboardEvent) {
-      if (event.defaultPrevented) return;
-
-      const isCmdK =
-        (event.metaKey || event.ctrlKey) &&
-        !event.altKey &&
-        !event.shiftKey &&
-        event.key?.toLowerCase() === 'k';
-
-      if (isCmdK) {
-        if (isFormElement(event.target)) {
-          // Allow Cmd/Ctrl+K inside a search input only when the input belongs
-          // to the shell search itself; outside, fall through so generic
-          // text inputs keep their native bindings.
-          const target = event.target as HTMLElement | null;
-          if (!target?.matches('[data-app-search-field="true"]')) {
-            return;
-          }
-        }
-        event.preventDefault();
-        // Prevent the command-palette listener (also registered on globalThis)
-        // from toggling itself on top of the shell search.
-        event.stopImmediatePropagation();
-        openSearch();
-        return;
-      }
-
-      if (event.key === 'Escape' && isSearchOpen) {
-        // PillSearch already handles Escape on its own input; only close from
-        // the shell when the user is *not* focused inside the input (otherwise
-        // we double-fire and break the "Esc clears text first" behavior).
-        const target = event.target as HTMLElement | null;
-        if (target?.matches('[data-app-search-field="true"]')) return;
-        event.preventDefault();
-        closeSearch();
-      }
-    }
-
-    globalThis.addEventListener('keydown', onKeyDown);
-    return () => globalThis.removeEventListener('keydown', onKeyDown);
-  }, [closeSearch, headerSearchEnabled, isSearchOpen, openSearch]);
 
   // Memoize the sidebar open change handler to prevent context value changes
   // that would cause infinite re-render loops in sidebar consumers.
@@ -341,8 +260,6 @@ function AuthShellWrapperInner({
               breadcrumbs={config.breadcrumbs}
               headerBadge={headerBadge}
               headerAction={headerAction}
-              headerSearchSurface={headerSearchSurface}
-              isHeaderSearchActive={headerSearchEnabled ? isSearchOpen : false}
               showMobileTabs={config.showMobileTabs}
               isTableRoute={config.isTableRoute}
               onSidebarOpenChange={

--- a/apps/web/tests/unit/app/command-palette-search-guard.test.ts
+++ b/apps/web/tests/unit/app/command-palette-search-guard.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = join(__dirname, '../../..');
+
+function readSource(path: string): string {
+  return readFileSync(join(ROOT, path), 'utf-8');
+}
+
+describe('command palette search shell guard', () => {
+  it('keeps AuthShellWrapper out of the header search surface path', () => {
+    const source = readSource('components/organisms/AuthShellWrapper.tsx');
+
+    expect(source).not.toMatch(/import\s+\{\s*HeaderSearchSurface\s*\}\s+from/);
+    expect(source).not.toContain('<HeaderSearchSurface');
+    expect(source).not.toContain('stopImmediatePropagation');
+    expect(source).not.toContain('headerSearchSurface=');
+    expect(source).not.toContain('isHeaderSearchActive=');
+  });
+
+  it('keeps AuthShell from forwarding header search props into DashboardHeader', () => {
+    const source = readSource('components/organisms/AuthShell.tsx');
+
+    expect(source).not.toContain('headerSearchSurface');
+    expect(source).not.toContain('isHeaderSearchActive');
+    expect(source).not.toContain('searchSurface=');
+    expect(source).not.toContain('isSearchActive=');
+  });
+
+  it('keeps DashboardNav Search wired to the command palette event', () => {
+    const source = readSource(
+      'components/features/dashboard/dashboard-nav/DashboardNav.tsx'
+    );
+
+    expect(source).toContain('OPEN_COMMAND_PALETTE_EVENT');
+    expect(source).toContain('globalThis.dispatchEvent');
+    expect(source).toMatch(/new\s+Event\(\s*OPEN_COMMAND_PALETTE_EVENT\s*\)/);
+  });
+});

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -294,7 +294,7 @@ describe('surface elevation guardrails', () => {
     expect(shellReleasesView).not.toMatch(
       /const\s*\[\s*searchOpen\s*,\s*setSearchOpen\s*\]\s*=\s*useState/
     );
-    expect(authShellWrapper).toContain('HeaderSearchSurface');
+    expect(authShellWrapper).not.toContain('HeaderSearchSurface');
   });
 
   it('keeps admin shell tables on the canonical AdminDataTable wrapper', () => {


### PR DESCRIPTION
## Summary
- remove the route-level header search surface from AuthShell/AuthShellWrapper
- stop intercepting Cmd/Ctrl+K for route-local header search so the global command palette owns shell search
- add source guards proving AuthShell does not forward search props and DashboardNav Search dispatches the command-palette event

## Verification
- ./scripts/setup.sh
- pnpm exec biome check --write apps/web/components/organisms/AuthShellWrapper.tsx apps/web/components/organisms/AuthShell.tsx apps/web/tests/unit/app/command-palette-search-guard.test.ts apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
- pnpm --filter web exec vitest run tests/unit/app/command-palette-search-guard.test.ts tests/unit/app/surface-elevation-guardrails.test.ts tests/components/dashboard/DashboardNav.interaction.test.tsx tests/unit/components/organisms/AuthShellWrapper.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- git push pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, lint