### PR TITLE
JOV-2312 normalize feature flags route

### DIFF
--- a/apps/web/app/app/(shell)/feature-flags/page.tsx
+++ b/apps/web/app/app/(shell)/feature-flags/page.tsx
@@ -1,5 +1,14 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
+import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
+import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
+import {
+  CONTENT_TABLE_CELL_CLASS,
+  CONTENT_TABLE_HEAD_CELL_CLASS,
+  CONTENT_TABLE_HEAD_ROW_CLASS,
+  CONTENT_TABLE_ROW_CLASS,
+  ContentTable,
+} from '@/components/molecules/ContentTable';
 import { APP_ROUTES } from '@/constants/routes';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 import {
@@ -22,6 +31,22 @@ interface FlagRow {
   readonly defaultValue: boolean;
 }
 
+function FeatureFlagStatePill({
+  enabled,
+}: Readonly<{ readonly enabled: boolean }>) {
+  return (
+    <span
+      className={
+        enabled
+          ? 'inline-flex items-center rounded-full border border-cyan-400/20 bg-cyan-500/12 px-2 py-0.5 text-[11.5px] font-medium text-cyan-300'
+          : 'inline-flex items-center rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-[11.5px] font-medium text-tertiary-token'
+      }
+    >
+      {enabled ? 'On' : 'Off'}
+    </span>
+  );
+}
+
 export default async function FeatureFlagsPage() {
   const entitlements = await getCurrentUserEntitlements();
   if (
@@ -41,57 +66,41 @@ export default async function FeatureFlagsPage() {
   }));
 
   return (
-    <div className='mx-auto w-full max-w-3xl px-6 py-10'>
-      <header className='mb-8'>
-        <h1 className='text-xl font-semibold text-primary-token'>
-          Feature Flags
-        </h1>
-        <p className='mt-1 text-sm text-secondary-token'>
-          Environment-driven flags. New features ship OFF by default. Override
-          via{' '}
-          <code className='rounded bg-surface-1 px-1.5 py-0.5 text-[12px]'>
-            FEATURE_&lt;NAME&gt;
-          </code>
-          .
-        </p>
-      </header>
-
-      <div className='overflow-hidden rounded-md border border-subtle bg-surface-1'>
-        <table className='w-full text-sm'>
-          <thead className='bg-surface-0 text-tertiary-token'>
-            <tr>
-              <th className='px-4 py-2 text-left font-medium'>Flag</th>
-              <th className='px-4 py-2 text-left font-medium'>State</th>
-              <th className='px-4 py-2 text-left font-medium'>Default</th>
+    <AdminToolPage
+      title='Feature Flags'
+      description='Environment-driven flags and current state.'
+      testId='feature-flags-page'
+    >
+      <ContentSurfaceCard surface='table' className='overflow-hidden'>
+        <ContentTable wrapperClassName='px-0 py-0' className='text-[12.5px]'>
+          <thead>
+            <tr className={CONTENT_TABLE_HEAD_ROW_CLASS}>
+              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Flag</th>
+              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>State</th>
+              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Default</th>
             </tr>
           </thead>
           <tbody>
             {flags.map(flag => (
-              <tr key={flag.name} className='border-t border-subtle align-top'>
-                <td className='px-4 py-3'>
+              <tr key={flag.name} className={CONTENT_TABLE_ROW_CLASS}>
+                <td className={CONTENT_TABLE_CELL_CLASS}>
                   <div className='font-medium text-primary-token'>
                     {flag.name}
                   </div>
                 </td>
-                <td className='px-4 py-3'>
-                  <span
-                    className={
-                      flag.enabled
-                        ? 'inline-flex items-center rounded-full bg-cyan-500/15 px-2 py-0.5 text-[11.5px] font-medium text-cyan-300'
-                        : 'inline-flex items-center rounded-full bg-surface-0 px-2 py-0.5 text-[11.5px] font-medium text-tertiary-token'
-                    }
-                  >
-                    {flag.enabled ? 'On' : 'Off'}
-                  </span>
+                <td className={CONTENT_TABLE_CELL_CLASS}>
+                  <FeatureFlagStatePill enabled={flag.enabled} />
                 </td>
-                <td className='px-4 py-3 text-tertiary-token'>
-                  {flag.defaultValue ? 'On' : 'Off'}
+                <td className={CONTENT_TABLE_CELL_CLASS}>
+                  <span className='text-tertiary-token'>
+                    {flag.defaultValue ? 'On' : 'Off'}
+                  </span>
                 </td>
               </tr>
             ))}
           </tbody>
-        </table>
-      </div>
-    </div>
+        </ContentTable>
+      </ContentSurfaceCard>
+    </AdminToolPage>
   );
 }

--- a/apps/web/tests/unit/app/feature-flags-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/feature-flags-shell-normalization.test.ts
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function findSourceFile(...candidates: string[]): string {
+  const found = candidates.find(candidate => existsSync(candidate));
+  if (!found) {
+    throw new Error(
+      `Could not find source file. Checked: ${candidates.join(', ')}`
+    );
+  }
+  return found;
+}
+
+const FEATURE_FLAGS_PAGE = findSourceFile(
+  resolve(process.cwd(), 'app/app/(shell)/feature-flags/page.tsx'),
+  resolve(process.cwd(), 'apps/web/app/app/(shell)/feature-flags/page.tsx')
+);
+
+describe('feature flags shell normalization', () => {
+  it('keeps feature flags in the shared admin tool shell', () => {
+    const source = readFileSync(FEATURE_FLAGS_PAGE, 'utf8');
+
+    expect(source).toContain('AdminToolPage');
+    expect(source).toContain("testId='feature-flags-page'");
+    expect(source).toContain('ContentSurfaceCard');
+  });
+
+  it('uses shared content table primitives instead of bespoke table chrome', () => {
+    const source = readFileSync(FEATURE_FLAGS_PAGE, 'utf8');
+
+    expect(source).toContain('ContentTable');
+    expect(source).toContain('CONTENT_TABLE_HEAD_CELL_CLASS');
+    expect(source).toContain('CONTENT_TABLE_ROW_CLASS');
+    expect(source).not.toContain('max-w-3xl');
+    expect(source).not.toContain("className='w-full text-sm'");
+  });
+});


### PR DESCRIPTION
## Summary
- move /app/feature-flags into the shared AdminToolPage shell frame
- replace bespoke table chrome with ContentTable primitives and tokenized state pills
- add a source guard for the route shell/table contract

## Verification
- ./scripts/setup.sh
- pnpm exec biome check --write 'apps/web/app/app/(shell)/feature-flags/page.tsx' apps/web/tests/unit/app/feature-flags-shell-normalization.test.ts
- pnpm --filter @jovie/web exec vitest run tests/unit/app/feature-flags-shell-normalization.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- git push pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, lint