### PR TITLE
fix(JOV-2313): remove duplicate task header search

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button, Input } from '@jovie/ui';
-import { ArrowDown, ArrowUp, Settings2 } from 'lucide-react';
+import { ArrowDown, ArrowUp, Search, Settings2, X } from 'lucide-react';
 import type { FormEvent } from 'react';
 import {
   TableFilterDropdown,
@@ -36,6 +36,9 @@ export interface TaskWorkspaceHeaderBarProps {
   readonly onCancelCreate: () => void;
   readonly onSubmitCreate: (event: FormEvent<HTMLFormElement>) => void;
   readonly createPending: boolean;
+  readonly searchValue: string;
+  readonly onSearchValueChange: (value: string) => void;
+  readonly onClearSearch: () => void;
   readonly filterCategories: ReadonlyArray<TableFilterDropdownCategory>;
   readonly onClearFilters: () => void;
   readonly viewMode: ViewMode;
@@ -57,6 +60,9 @@ export function TaskWorkspaceHeaderBar({
   onCancelCreate,
   onSubmitCreate,
   createPending,
+  searchValue,
+  onSearchValueChange,
+  onClearSearch,
   filterCategories,
   onClearFilters,
   viewMode,
@@ -123,6 +129,30 @@ export function TaskWorkspaceHeaderBar({
       </>
     ) : (
       <>
+        <div className='relative hidden h-7 w-[min(12rem,24vw)] min-w-[9rem] items-center lg:flex'>
+          <Search
+            className='pointer-events-none absolute bottom-0 left-2 top-0 my-auto h-3.5 w-3.5 text-quaternary-token'
+            aria-hidden='true'
+          />
+          <Input
+            type='search'
+            value={searchValue}
+            onChange={event => onSearchValueChange(event.target.value)}
+            placeholder='Search tasks'
+            aria-label='Search tasks'
+            className='h-7 w-full rounded-md border-border-token bg-surface-0 py-0 pl-7 pr-7 text-[12.5px] text-primary-token placeholder:text-quaternary-token'
+          />
+          {searchValue ? (
+            <button
+              type='button'
+              aria-label='Clear task search'
+              onClick={onClearSearch}
+              className='absolute bottom-0 right-1 top-0 my-auto inline-flex h-5 w-5 items-center justify-center rounded text-quaternary-token transition-[background-color,color] hover:bg-surface-1 hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-token'
+            >
+              <X className='h-3 w-3' aria-hidden='true' />
+            </button>
+          ) : null}
+        </div>
         <TableFilterDropdown
           categories={filterCategories}
           onClearAll={onClearFilters}

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuContent,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Input,
   UserAvatar,
 } from '@jovie/ui';
 import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
@@ -16,7 +17,9 @@ import {
   FileText,
   MoreHorizontal,
   Plus,
+  Search,
   Trash2,
+  X,
 } from 'lucide-react';
 import {
   type ComponentPropsWithoutRef,
@@ -48,7 +51,6 @@ import {
   useTextareaAutosize,
 } from '@/components/jovie/hooks/useTextareaAutosize';
 import { ConfirmDialog } from '@/components/molecules/ConfirmDialog';
-import { HeaderSearchAction } from '@/components/molecules/HeaderSearchAction';
 import {
   TOOLBAR_MENU_CONTENT_CLASS,
   TOOLBAR_MENU_SEPARATOR_CLASS,
@@ -124,10 +126,6 @@ function shouldIgnoreTaskShortcut(event: KeyboardEvent): boolean {
   return (
     event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey
   );
-}
-
-function isTaskSearchShortcut(event: KeyboardEvent): boolean {
-  return event.key === '/' && !event.shiftKey && !isFormElement(event.target);
 }
 
 function isTaskRowNavigationAction(
@@ -1213,9 +1211,6 @@ export function TasksPageClient() {
   );
   const [headerMode, setHeaderMode] = useState<'default' | 'create'>('default');
   const [search, setSearch] = useState('');
-  const [taskSearchOpenSignal, setTaskSearchOpenSignal] = useState<
-    number | undefined
-  >(undefined);
   const [statusFilter, setStatusFilter] = useState<TaskStatus | 'all'>('all');
   const [priorityFilter, setPriorityFilter] = useState<TaskPriority | 'all'>(
     'all'
@@ -1736,12 +1731,6 @@ export function TasksPageClient() {
     function handleKeyDown(event: KeyboardEvent) {
       if (shouldIgnoreTaskShortcut(event)) return;
 
-      if (isTaskSearchShortcut(event)) {
-        event.preventDefault();
-        setTaskSearchOpenSignal(signal => (signal ?? 0) + 1);
-        return;
-      }
-
       const action = resolveTableNavAction(event.key, event.target);
       if (action === 'close') {
         handleCloseShortcut(event);
@@ -1775,16 +1764,6 @@ export function TasksPageClient() {
   const headerActions = useMemo(
     () => (
       <DashboardHeaderActionGroup>
-        <HeaderSearchAction
-          searchValue={search}
-          onSearchValueChange={setSearch}
-          onClearAction={() => setSearch('')}
-          placeholder='Search tasks'
-          ariaLabel='Search tasks'
-          submitAriaLabel='Search tasks'
-          tooltipLabel='Search'
-          openSignal={taskSearchOpenSignal}
-        />
         <DashboardHeaderActionButton
           ariaLabel='Create task'
           icon={<Plus className='h-3.5 w-3.5' />}
@@ -1795,7 +1774,7 @@ export function TasksPageClient() {
         />
       </DashboardHeaderActionGroup>
     ),
-    [headerMode, search, taskSearchOpenSignal]
+    [headerMode]
   );
 
   useEffect(() => {
@@ -1993,6 +1972,9 @@ export function TasksPageClient() {
               }}
               onSubmitCreate={handleCreateTask}
               createPending={createTaskMutation.isPending}
+              searchValue={search}
+              onSearchValueChange={setSearch}
+              onClearSearch={() => setSearch('')}
               filterCategories={taskFilterCategories}
               onClearFilters={clearFilters}
               viewMode={viewMode}
@@ -2054,10 +2036,34 @@ export function TasksPageClient() {
                     className='flex h-full min-h-0 flex-col overflow-hidden'
                     data-testid='mobile-task-list'
                   >
-                    <div className='flex items-center px-4 pb-1 pt-3'>
+                    <div className='flex items-center justify-between gap-3 px-4 pb-1 pt-3'>
                       <p className='text-xs text-secondary-token'>
                         {mobileScopeCounts.all} total tasks
                       </p>
+                      <div className='relative w-[min(12rem,48vw)] min-w-[8.5rem]'>
+                        <Search
+                          className='pointer-events-none absolute bottom-0 left-2 top-0 my-auto h-3.5 w-3.5 text-quaternary-token'
+                          aria-hidden='true'
+                        />
+                        <Input
+                          type='search'
+                          value={search}
+                          onChange={event => setSearch(event.target.value)}
+                          placeholder='Search tasks'
+                          aria-label='Search tasks'
+                          className='h-7 w-full rounded-md border-border-token bg-surface-0 py-0 pl-7 pr-7 text-[12.5px] text-primary-token placeholder:text-quaternary-token'
+                        />
+                        {search ? (
+                          <button
+                            type='button'
+                            aria-label='Clear task search'
+                            onClick={() => setSearch('')}
+                            className='absolute bottom-0 right-1 top-0 my-auto inline-flex h-5 w-5 items-center justify-center rounded text-quaternary-token transition-[background-color,color] hover:bg-surface-1 hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-token'
+                          >
+                            <X className='h-3 w-3' aria-hidden='true' />
+                          </button>
+                        ) : null}
+                      </div>
                     </div>
                     <TaskSubviewTabs
                       subviews={taskSubviewOptions}

--- a/apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
@@ -83,6 +83,9 @@ function createBaseProps() {
       event.preventDefault()
     ),
     createPending: false,
+    searchValue: '',
+    onSearchValueChange: vi.fn(),
+    onClearSearch: vi.fn(),
     filterCategories: [],
     onClearFilters: vi.fn(),
     viewMode: 'board',
@@ -114,8 +117,8 @@ describe('TaskWorkspaceHeaderBar', () => {
       screen.getByRole('tab', { name: 'Assigned To Me 1' })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('button', { name: 'Search tasks' })
-    ).not.toBeInTheDocument();
+      screen.getByRole('searchbox', { name: 'Search tasks' })
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Filters' })).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Display options' })
@@ -140,6 +143,22 @@ describe('TaskWorkspaceHeaderBar', () => {
     fireEvent.click(screen.getByRole('button', { name: 'List view' }));
 
     expect(props.onViewModeChange).toHaveBeenCalledWith('list');
+  });
+
+  it('emits compact task search changes and clears the field', () => {
+    const props = createBaseProps();
+
+    render(
+      <TaskWorkspaceHeaderBar {...props} mode='default' searchValue='press' />
+    );
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search tasks' }), {
+      target: { value: 'metadata' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Clear task search' }));
+
+    expect(props.onSearchValueChange).toHaveBeenCalledWith('metadata');
+    expect(props.onClearSearch).toHaveBeenCalledTimes(1);
   });
 
   it('renders create mode controls and submits the draft form', () => {

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -4,9 +4,16 @@ import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TaskBoardResult, TaskStatus, TaskView } from '@/lib/tasks/types';
 
-const { mockRegisterRightPanel, mockUseAppFlag } = vi.hoisted(() => ({
+const {
+  mockRegisterRightPanel,
+  mockUseAppFlag,
+  mockUseTaskBoardQuery,
+  mockUseTasksQuery,
+} = vi.hoisted(() => ({
   mockRegisterRightPanel: vi.fn(),
   mockUseAppFlag: vi.fn(),
+  mockUseTaskBoardQuery: vi.fn(),
+  mockUseTasksQuery: vi.fn(),
 }));
 
 vi.mock('@jovie/ui', async () => {
@@ -285,23 +292,39 @@ vi.mock('@/lib/queries/useReleasesQuery', () => ({
 }));
 
 vi.mock('@/lib/queries/useTasksQuery', () => ({
-  useTasksQuery: () => ({
-    data:
-      mockListQueryData === null
-        ? { tasks: mockTasksData }
-        : mockListQueryData
-          ? { tasks: mockListQueryData }
-          : undefined,
-    isLoading: false,
-    isError: false,
-    refetch: vi.fn(),
-  }),
-  useTaskBoardQuery: () => ({
-    data: createMockTaskBoardResult(mockTasksData as TaskView[]),
-    isLoading: false,
-    isError: false,
-    refetch: vi.fn(),
-  }),
+  useTasksQuery: (
+    profileId: string | undefined,
+    filters: unknown,
+    options: unknown
+  ) => {
+    mockUseTasksQuery(profileId, filters, options);
+
+    return {
+      data:
+        mockListQueryData === null
+          ? { tasks: mockTasksData }
+          : mockListQueryData
+            ? { tasks: mockListQueryData }
+            : undefined,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    };
+  },
+  useTaskBoardQuery: (
+    profileId: string | undefined,
+    filters: unknown,
+    options: unknown
+  ) => {
+    mockUseTaskBoardQuery(profileId, filters, options);
+
+    return {
+      data: createMockTaskBoardResult(mockTasksData as TaskView[]),
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    };
+  },
   useTaskQuery: (taskId: string | null) => ({
     data: mockTasksData.find(task => task.id === taskId),
   }),
@@ -525,6 +548,8 @@ describe('TasksPageClient', () => {
     mockSetViewMode.mockClear();
     mockSetHeaderActions.mockReset();
     mockRegisterRightPanel.mockReset();
+    mockUseTaskBoardQuery.mockClear();
+    mockUseTasksQuery.mockClear();
     mockUseAppFlag.mockReturnValue(false);
     mockUnifiedTable.mockReset();
     mockIsXlUp = true;
@@ -1008,34 +1033,60 @@ describe('TasksPageClient', () => {
     expect(screen.getByRole('button', { name: 'Next task' })).toBeEnabled();
   });
 
-  it('promotes the header into search mode when search is triggered', () => {
+  it('keeps task search local to the workspace controls', () => {
     renderPage();
 
+    const headerActions = screen.getByTestId('header-actions-host');
+
     expect(
-      screen.queryByRole('searchbox', { name: 'Search tasks' })
+      headerActions.querySelector('[aria-label="Search tasks"]')
     ).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Search tasks' }));
-
+    expect(
+      screen.getByRole('button', { name: 'Create task' })
+    ).toBeInTheDocument();
     expect(
       screen.getByRole('searchbox', { name: 'Search tasks' })
     ).toBeInTheDocument();
   });
 
-  it('opens task search with / unless focus is in a text editor', () => {
+  it('does not open or focus task search with the slash key', () => {
     renderPage();
+
+    const searchBox = screen.getByRole('searchbox', { name: 'Search tasks' });
 
     fireEvent.keyDown(screen.getByLabelText('Task title'), { key: '/' });
 
-    expect(
-      screen.queryByRole('searchbox', { name: 'Search tasks' })
-    ).not.toBeInTheDocument();
+    expect(document.activeElement).not.toBe(searchBox);
 
     fireEvent.keyDown(window, { key: '/' });
 
-    expect(
-      screen.getByRole('searchbox', { name: 'Search tasks' })
-    ).toBeInTheDocument();
+    expect(document.activeElement).not.toBe(searchBox);
+  });
+
+  it('keeps task title search wired into list filters', () => {
+    renderPage();
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search tasks' }), {
+      target: { value: 'metadata' },
+    });
+
+    expect(mockUseTasksQuery.mock.calls.at(-1)?.[1]).toEqual(
+      expect.objectContaining({ search: 'metadata' })
+    );
+  });
+
+  it('keeps task title search wired into board filters', () => {
+    mockViewMode = 'board';
+
+    renderPage();
+
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search tasks' }), {
+      target: { value: 'press' },
+    });
+
+    expect(mockUseTaskBoardQuery.mock.calls.at(-1)?.[1]).toEqual(
+      expect.objectContaining({ search: 'press' })
+    );
   });
 
   it('promotes the header into create mode when new task is triggered', () => {
@@ -1216,7 +1267,7 @@ describe('TasksPageClient', () => {
 
     expect(screen.getByText('2 total tasks')).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Search tasks' })
+      screen.getByRole('searchbox', { name: 'Search tasks' })
     ).toBeInTheDocument();
 
     fireEvent.click(screen.getAllByTestId('mobile-task-row')[0]!);


### PR DESCRIPTION
## Summary
- remove the task route shell-header Search action and local slash-key search opener
- keep task title filtering in compact workspace controls on desktop and mobile
- preserve list and board task query filters when the local task search text changes

## Verification
- JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh
- pnpm exec biome check --write apps/web/components/features/dashboard/tasks/TasksPageClient.tsx apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx apps/web/tests/unit/dashboard/TasksPageClient.test.tsx apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
- pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/TasksPageClient.test.tsx tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git push pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, biome lint .

## GStack Gate Evidence
- gstack.qa.exhaustive: Scoped exhaustive QA for the tasks shell-search slice passed: focused Vitest, web typecheck, and pre-push guards completed.
- gstack.review: Pre-landing review found the change scoped to task search/header behavior with focused tests for query preservation and toolbar state.
- gstack.ship: Ship readiness passed: branch pushed, PR opened, marked ready, auto-merge enabled, and CI is running on the pushed SHA.

Linear: JOV-2313

<!-- agent-run-artifact
{
  "id": "jov-2313-gstack-gates",
  "source": "github",
  "sourceRunId": "363a6f60fe8fa4544977ab0a3a475cad8d6327d6",
  "kind": "qa",
  "status": "done",
  "title": "GStack gates for JOV-2313",
  "summary": "Recorded scoped GStack gate evidence for agent PR readiness.",
  "modelRoute": "deterministic",
  "allowedActions": [
    "read",
    "classify",
    "write_code",
    "open_pr",
    "ready_pr"
  ],
  "forbiddenActions": [
    "deploy",
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2313",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2313/tasks-align-local-filtering-with-command-palette-shell-search",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/8879",
  "adminSurface": "/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Scoped exhaustive QA for the tasks shell-search slice passed: focused Vitest, web typecheck, and pre-push guards completed.",
      "checkedAt": "2026-05-16T22:45:53.462Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Pre-landing review found the change scoped to task search/header behavior with focused tests for query preservation and toolbar state.",
      "checkedAt": "2026-05-16T22:45:54.462Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Ship readiness passed: branch pushed, PR opened, marked ready, auto-merge enabled, and CI is running on the pushed SHA.",
      "checkedAt": "2026-05-16T22:45:55.462Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-16T22:45:53.462Z",
  "updatedAt": "2026-05-16T22:45:56.462Z",
  "metadata": {
    "source": "codex-local",
    "gateMode": "scoped-pr-readiness"
  }
}
-->
