### PR TITLE
fix(shell): lazy-load task release context

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -51,6 +51,7 @@ import {
   useTextareaAutosize,
 } from '@/components/jovie/hooks/useTextareaAutosize';
 import { ConfirmDialog } from '@/components/molecules/ConfirmDialog';
+import { EntitySidebarShell } from '@/components/molecules/drawer';
 import {
   TOOLBAR_MENU_CONTENT_CLASS,
   TOOLBAR_MENU_SEPARATOR_CLASS,
@@ -75,7 +76,7 @@ import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import { useAppFlag } from '@/lib/flags/client';
-import { useReleasesQuery } from '@/lib/queries/useReleasesQuery';
+import { useReleaseEntityQuery } from '@/lib/queries/useReleaseEntityQuery';
 import {
   useCreateTaskMutation,
   useDeleteTaskMutation,
@@ -171,6 +172,7 @@ const TASK_WORKSPACE_PANE_CLASSNAME = 'min-h-0 overflow-hidden';
 const TASK_VIEW_MODES: Array<'board' | 'list'> = ['board', 'list'];
 
 type MobileTaskScope = 'all' | 'open' | 'done';
+type ReleasePanelStatus = 'loading' | 'error' | 'empty';
 
 const MOBILE_TASK_SCOPE_OPTIONS = [
   ['all', 'All'],
@@ -247,6 +249,69 @@ function resolveArtistName(
     profile?.username_normalized ??
     profile?.username ??
     null
+  );
+}
+
+function TaskReleasePanelStatus({
+  status,
+  onClose,
+  onRetry,
+}: Readonly<{
+  status: ReleasePanelStatus;
+  onClose: () => void;
+  onRetry?: () => void;
+}>) {
+  const copy = {
+    loading: {
+      title: 'Loading release',
+      body: 'Getting release context for this task.',
+    },
+    error: {
+      title: 'Release unavailable',
+      body: 'We hit a problem loading this release. Try again when the connection settles.',
+    },
+    empty: {
+      title: 'Release not found',
+      body: 'This task still has a release link, but the release is not available in this profile.',
+    },
+  } satisfies Record<ReleasePanelStatus, { title: string; body: string }>;
+
+  const state = copy[status];
+
+  return (
+    <EntitySidebarShell
+      isOpen
+      width={344}
+      ariaLabel='Release details'
+      title='Release'
+      onClose={onClose}
+      scrollStrategy='shell'
+      data-testid='task-release-panel-status'
+    >
+      <div
+        className='rounded-lg border border-subtle bg-surface-1 px-3 py-3'
+        data-testid={`task-release-panel-${status}`}
+      >
+        {status === 'loading' ? (
+          <div className='mb-3 h-20 rounded-md skeleton' aria-hidden='true' />
+        ) : null}
+        <p className='text-sm font-medium text-primary-token'>{state.title}</p>
+        <p className='mt-1 text-xs leading-5 text-secondary-token'>
+          {state.body}
+        </p>
+        {status === 'error' && onRetry ? (
+          <Button
+            type='button'
+            size='sm'
+            variant='secondary'
+            className='mt-3'
+            onClick={onRetry}
+          >
+            Retry
+          </Button>
+        ) : null}
+      </div>
+    </EntitySidebarShell>
   );
 }
 
@@ -1251,7 +1316,10 @@ export function TasksPageClient() {
   const { mutateAsync: deleteTaskAsync } = deleteTaskMutation;
   const { mutate: updateTask } = updateTaskMutation;
   const { mutate: moveTask } = moveTaskMutation;
-  const { data: releases = [] } = useReleasesQuery(profileId ?? '');
+  const selectedReleaseQuery = useReleaseEntityQuery(
+    profileId ?? '',
+    selectedReleaseId ?? ''
+  );
   const searchFilter = deferredSearch.trim();
   const listFilters = useMemo<TaskFilters>(
     () => ({
@@ -1387,10 +1455,9 @@ export function TasksPageClient() {
     boardTasks.find(task => task.id === effectiveSelectedTaskId) ??
     tasks.find(task => task.id === effectiveSelectedTaskId) ??
     null;
-  const selectedRelease =
-    releases.find(release => release.id === selectedReleaseId) ?? null;
+  const selectedRelease = selectedReleaseQuery.data ?? null;
   const shouldPrioritizeRightPanel =
-    Boolean(selectedRelease) && !canShowTaskDocumentAlongsideReleaseSidebar;
+    Boolean(selectedReleaseId) && !canShowTaskDocumentAlongsideReleaseSidebar;
   const artistName = resolveArtistName(selectedProfile);
   const hasFilters =
     Boolean(deferredSearch.trim()) ||
@@ -1748,16 +1815,34 @@ export function TasksPageClient() {
     };
   }, [handleCloseShortcut, handleRowNavigationShortcut]);
 
-  const sidebarPanel = selectedRelease ? (
-    <ReleaseSidebar
-      release={selectedRelease}
-      mode='admin'
-      isOpen
-      providerConfig={providerConfig}
-      artistName={artistName}
-      readOnly
-      onClose={() => setSelectedReleaseId(null)}
-    />
+  const closeReleaseSidebar = useCallback(() => {
+    setSelectedReleaseId(null);
+  }, []);
+
+  const sidebarPanel = selectedReleaseId ? (
+    selectedRelease ? (
+      <ReleaseSidebar
+        release={selectedRelease}
+        mode='admin'
+        isOpen
+        providerConfig={providerConfig}
+        artistName={artistName}
+        readOnly
+        onClose={closeReleaseSidebar}
+      />
+    ) : (
+      <TaskReleasePanelStatus
+        status={
+          selectedReleaseQuery.isError
+            ? 'error'
+            : selectedReleaseQuery.isLoading
+              ? 'loading'
+              : 'empty'
+        }
+        onClose={closeReleaseSidebar}
+        onRetry={() => void selectedReleaseQuery.refetch()}
+      />
+    )
   ) : null;
   useRegisterRightPanel(sidebarPanel);
 

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -7,11 +7,13 @@ import type { TaskBoardResult, TaskStatus, TaskView } from '@/lib/tasks/types';
 const {
   mockRegisterRightPanel,
   mockUseAppFlag,
+  mockUseReleaseEntityQuery,
   mockUseTaskBoardQuery,
   mockUseTasksQuery,
 } = vi.hoisted(() => ({
   mockRegisterRightPanel: vi.fn(),
   mockUseAppFlag: vi.fn(),
+  mockUseReleaseEntityQuery: vi.fn(),
   mockUseTaskBoardQuery: vi.fn(),
   mockUseTasksQuery: vi.fn(),
 }));
@@ -285,10 +287,17 @@ vi.mock('@/components/organisms/table/utils/useViewMode', () => ({
   }),
 }));
 
-vi.mock('@/lib/queries/useReleasesQuery', () => ({
-  useReleasesQuery: () => ({
-    data: [{ id: 'release-1', title: 'QA Release' }],
-  }),
+vi.mock('@/lib/queries/useReleaseEntityQuery', () => ({
+  useReleaseEntityQuery: (profileId: string, releaseId: string) => {
+    mockUseReleaseEntityQuery(profileId, releaseId);
+
+    return {
+      data: releaseId ? { id: releaseId, title: 'QA Release' } : null,
+      isError: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+  },
 }));
 
 vi.mock('@/lib/queries/useTasksQuery', () => ({
@@ -548,6 +557,7 @@ describe('TasksPageClient', () => {
     mockSetViewMode.mockClear();
     mockSetHeaderActions.mockReset();
     mockRegisterRightPanel.mockReset();
+    mockUseReleaseEntityQuery.mockClear();
     mockUseTaskBoardQuery.mockClear();
     mockUseTasksQuery.mockClear();
     mockUseAppFlag.mockReturnValue(false);
@@ -572,6 +582,17 @@ describe('TasksPageClient', () => {
     expect(screen.queryByText('All Statuses')).not.toBeInTheDocument();
     expect(screen.queryByText('All Priorities')).not.toBeInTheDocument();
     expect(screen.queryByText('All Assignees')).not.toBeInTheDocument();
+  });
+
+  it('keeps release detail loading disabled until a release context is opened', () => {
+    renderPage();
+
+    expect(mockUseReleaseEntityQuery).toHaveBeenCalledWith('profile-1', '');
+    expect(
+      mockUseReleaseEntityQuery.mock.calls.some(
+        ([, releaseId]) => releaseId === 'release-1'
+      )
+    ).toBe(false);
   });
 
   it('renders the board workspace when board mode is active', () => {
@@ -788,6 +809,10 @@ describe('TasksPageClient', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'QA Release' }));
 
+    expect(mockUseReleaseEntityQuery).toHaveBeenLastCalledWith(
+      'profile-1',
+      'release-1'
+    );
     expect(screen.getByTestId('task-document-pane')).toHaveClass('hidden');
     expect(screen.getByTestId('tasks-table')).toBeInTheDocument();
   });
@@ -797,6 +822,10 @@ describe('TasksPageClient', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'QA Release' }));
 
+    expect(mockUseReleaseEntityQuery).toHaveBeenLastCalledWith(
+      'profile-1',
+      'release-1'
+    );
     expect(mockRegisterRightPanel).toHaveBeenLastCalledWith(
       expect.objectContaining({
         type: expect.any(Function),


### PR DESCRIPTION
## Summary
- Stops the tasks dashboard from loading the full release matrix on initial render.
- Uses the existing selected-release entity query only after a task release context is opened.
- Adds loading/error/missing right-panel states for release context failures.

Linear: JOV-2316

## Verification
- pnpm exec biome check --write apps/web/components/features/dashboard/tasks/TasksPageClient.tsx apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
- pnpm --filter @jovie/web run test -- tests/unit/dashboard/TasksPageClient.test.tsx --reporter=dot (45 passed)
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm run version:check
- Browser/design QA: /app/dashboard/tasks desktop and mobile screenshots, no horizontal overflow, no initial right panel, no clipped button/tab text
- Dev-server request check: initial /app/dashboard/tasks logged task queries only, not loadReleaseMatrix
- git push pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, biome lint .

<!-- agent-run-artifact
{
  "id": "jov-2316-tasks-lazy-release-panel-ad2c4e5cfac28d4f269ca195d03df23f505c2921",
  "source": "github",
  "sourceRunId": "ad2c4e5cfac28d4f269ca195d03df23f505c2921",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2316 tasks lazy release context",
  "summary": "Verified the tasks route no longer pays release matrix cost on initial render and keeps the task UI visually stable across desktop and mobile.",
  "modelRoute": "codex-cli",
  "allowedActions": ["write_code", "open_pr", "ready_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2316",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2316/tasks-lazy-load-release-panel-data-in-the-unified-shell",
  "pullRequestUrl": null,
  "adminSurface": "/app/dashboard/tasks",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused route QA passed on desktop/mobile: no initial right panel, no horizontal overflow, no button/tab clipping, and initial dev-server logs showed task queries only.",
      "checkedAt": "2026-05-16T23:29:35Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for App Router shell persistence and canonical selected-release data flow; route now uses useReleaseEntityQuery instead of eager useReleasesQuery.",
      "checkedAt": "2026-05-16T23:29:35Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, focused Vitest, typecheck, version check, and pre-push checks passed before opening the PR.",
      "checkedAt": "2026-05-16T23:29:35Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-05-16T23:29:35Z",
  "updatedAt": "2026-05-16T23:29:35Z",
  "metadata": {
    "screenshots": [
      "/tmp/jovie-jov2316-tasks-initial.png",
      "/tmp/jovie-jov2316-tasks-mobile.png"
    ]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit loading, error, and empty states to the release sidebar panel with retry action on failures

* **Improvements**
  * Enhanced release sidebar behavior for better user experience when managing task releases
  * Optimized release data fetching for improved performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->