### PR TITLE
fix(shell): align library table rows

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -51,6 +51,7 @@ import {
   getArtworkFallbackAccentStyle,
   getArtworkFallbackSurfaceStyle,
 } from '@/lib/artwork-fallback';
+import { SKELETON_ROW_COUNT } from '@/lib/constants/layout';
 import { cn } from '@/lib/utils';
 import { capitalizeFirst } from '@/lib/utils/string-utils';
 import {
@@ -60,16 +61,7 @@ import {
   type LibraryReleaseAsset,
 } from './library-data';
 
-const LIBRARY_LOADING_PLACEHOLDERS = [
-  'library-loading-release-1',
-  'library-loading-release-2',
-  'library-loading-release-3',
-  'library-loading-release-4',
-  'library-loading-release-5',
-  'library-loading-release-6',
-] as const;
-
-const LIBRARY_TABLE_ROW_HEIGHT = 58;
+const LIBRARY_TABLE_ROW_HEIGHT = 56;
 const LIBRARY_TABLE_MIN_WIDTH = '0';
 
 const LIBRARY_TABLE_SKELETON_CONFIG: Array<{
@@ -490,7 +482,7 @@ export function LibraryLoadingState() {
         hideHeader
         rowHeight={LIBRARY_TABLE_ROW_HEIGHT}
         minWidth={LIBRARY_TABLE_MIN_WIDTH}
-        skeletonRows={LIBRARY_LOADING_PLACEHOLDERS.length}
+        skeletonRows={SKELETON_ROW_COUNT.TABLE}
         skeletonColumnConfig={LIBRARY_TABLE_SKELETON_CONFIG}
         containerClassName='h-full px-2.5 pb-2.5 pt-1'
       />
@@ -975,7 +967,7 @@ function AssetGrid({
   );
 }
 
-function AssetList({
+function LibraryDataTable({
   assets,
   selectedId,
   onSelect,
@@ -984,7 +976,12 @@ function AssetList({
   readonly selectedId: string | null;
   readonly onSelect: (id: string) => void;
 }) {
+  const tableData = useMemo(() => [...assets], [assets]);
   const getRowId = useMemo(() => (asset: LibraryReleaseAsset) => asset.id, []);
+  const getRowTestId = useMemo(
+    () => (asset: LibraryReleaseAsset) => `library-release-row-${asset.id}`,
+    []
+  );
   const getRowClassName = useMemo(
     () => (asset: LibraryReleaseAsset) =>
       cn(
@@ -997,10 +994,11 @@ function AssetList({
 
   return (
     <UnifiedTable<LibraryReleaseAsset>
-      data={[...assets]}
+      data={tableData}
       columns={LIBRARY_TABLE_COLUMNS}
       onRowClick={asset => onSelect(asset.id)}
       getRowId={getRowId}
+      getRowTestId={getRowTestId}
       getRowClassName={getRowClassName}
       enableVirtualization={assets.length >= 20}
       rowHeight={LIBRARY_TABLE_ROW_HEIGHT}
@@ -1008,7 +1006,7 @@ function AssetList({
       hideHeader
       className='text-app text-primary-token'
       containerClassName='h-full px-2.5 pb-2.5 pt-1'
-      skeletonRows={LIBRARY_LOADING_PLACEHOLDERS.length}
+      skeletonRows={SKELETON_ROW_COUNT.TABLE}
       skeletonColumnConfig={LIBRARY_TABLE_SKELETON_CONFIG}
     />
   );
@@ -1450,7 +1448,7 @@ export function LibrarySurface({
               onSelect={openAsset}
             />
           ) : (
-            <AssetList
+            <LibraryDataTable
               assets={visibleAssets}
               selectedId={selectedId}
               onSelect={openAsset}

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -8,6 +8,8 @@ import { HeaderSearchSurfaceFromContext } from '@/components/shell/HeaderSearchS
 import { APP_ROUTES } from '@/constants/routes';
 import { HeaderActionsProvider } from '@/contexts/HeaderActionsContext';
 
+Element.prototype.scrollIntoView = vi.fn();
+
 vi.mock('next/image', () => ({
   default: (
     props: ComponentProps<'img'> & { readonly unoptimized?: boolean }
@@ -149,8 +151,28 @@ describe('LibrarySurface', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'List view' }));
 
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('library-release-row-release-1')
+    ).toBeInTheDocument();
     expect(screen.getByText('Never Say A Word')).toBeInTheDocument();
     expect(screen.getByText('Take Me Over')).toBeInTheDocument();
+  });
+
+  it('opens the read-only asset drawer from list rows', () => {
+    renderLibrary([buildAsset()]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'List view' }));
+    fireEvent.click(screen.getByTestId('library-release-row-release-1'));
+
+    expect(screen.getByTestId('library-asset-drawer')).toHaveAttribute(
+      'aria-hidden',
+      'false'
+    );
+    expect(screen.getByRole('link', { name: /Open Release/u })).toHaveAttribute(
+      'href',
+      '/tim/take-me-over'
+    );
   });
 
   it('filters release assets from the shell header search contract', () => {


### PR DESCRIPTION
## Summary
- Names the library list-mode wrapper as the route's LibraryDataTable contract.
- Keeps table row data stable across renders and adds deterministic row test ids.
- Normalizes library table density and loading skeleton count to shared shell constants.

Linear: JOV-2317

## Verification
- pnpm exec biome check --write apps/web/app/app/(shell)/library/LibrarySurface.tsx apps/web/tests/unit/library/LibrarySurface.test.tsx
- pnpm --filter @jovie/web run test -- tests/unit/library/LibrarySurface.test.tsx --reporter=dot (6 passed)
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm run version:check
- Browser/design QA: /app/library desktop list mode and mobile card mode screenshots, no horizontal overflow, table semantics present in list mode
- git push pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, biome lint .

<!-- agent-run-artifact
{
  "id": "jov-2317-library-row-contract-3e064cd435592b96cb9e08770beb6794d1b6a4f4",
  "source": "github",
  "sourceRunId": "3e064cd435592b96cb9e08770beb6794d1b6a4f4",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2317 library shell table contract",
  "summary": "Verified the library list route keeps its visuals while using a named shared-table wrapper, stable row ids, and shared skeleton constants.",
  "modelRoute": "codex-cli",
  "allowedActions": ["write_code", "open_pr", "ready_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2317",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2317/library-align-list-rows-with-the-unified-shell-table-contract",
  "pullRequestUrl": null,
  "adminSurface": "/app/library",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused library QA passed on desktop list and mobile card modes with no horizontal overflow; list mode rendered table semantics and opened the read-only drawer.",
      "checkedAt": "2026-05-16T23:42:31Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed against shell table direction; LibraryPageClient and library-data boundaries stayed unchanged while list rows moved to the explicit LibraryDataTable contract.",
      "checkedAt": "2026-05-16T23:42:31Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, focused Vitest, typecheck, version check, and pre-push checks passed before opening the PR.",
      "checkedAt": "2026-05-16T23:42:31Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-05-16T23:42:31Z",
  "updatedAt": "2026-05-16T23:42:31Z",
  "metadata": {
    "screenshots": [
      "/tmp/jovie-jov2317-library-list-desktop.png",
      "/tmp/jovie-jov2317-library-mobile.png"
    ]
  }
}
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced library list view component with improved rendering performance.
  * Refined loading state skeleton configuration for consistent visual display.
  * Adjusted row height for better visual presentation.

* **Tests**
  * Expanded test coverage for list view rendering and mode switching verification.
  * Added assertions for asset drawer interaction behavior in list mode.
  * Improved scroll behavior test stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->