### PR TITLE
fix(shell): canonicalize releases navigation

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/catalog-task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/catalog-task-actions.ts
@@ -236,6 +236,7 @@ export async function instantiateReleaseTasksFromCatalog(
       .where(eq(discogReleases.id, releaseId));
   });
 
+  revalidatePath(APP_ROUTES.RELEASES);
   revalidatePath(APP_ROUTES.DASHBOARD_RELEASES);
   revalidatePath(APP_ROUTES.TASKS);
 
@@ -450,6 +451,7 @@ export async function addCatalogTaskToRelease(releaseId: string, slug: string) {
     if (!isUniqueViolation) throw error;
   }
 
+  revalidatePath(APP_ROUTES.RELEASES);
   revalidatePath(APP_ROUTES.DASHBOARD_RELEASES);
   revalidatePath(APP_ROUTES.TASKS);
 

--- a/apps/web/app/app/(shell)/dashboard/releases/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/page.tsx
@@ -24,9 +24,7 @@ export const runtime = 'nodejs';
 export default async function ReleasesPage() {
   const { userId } = await getCachedAuth();
   if (!userId) {
-    redirect(
-      `${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.DASHBOARD_RELEASES}`
-    );
+    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.RELEASES}`);
   }
 
   // Shell data is cached from the shell layout (same request) — resolves instantly.
@@ -36,7 +34,7 @@ export default async function ReleasesPage() {
     void captureError(
       'Dashboard data load failed on releases page',
       dashboardData.dashboardLoadError,
-      { route: APP_ROUTES.DASHBOARD_RELEASES }
+      { route: APP_ROUTES.RELEASES }
     );
     return (
       <PageErrorState message='Failed to load releases data. Please refresh the page.' />
@@ -60,7 +58,7 @@ export default async function ReleasesPage() {
         'Release matrix prefetch failed on releases page',
         error,
         {
-          route: APP_ROUTES.DASHBOARD_RELEASES,
+          route: APP_ROUTES.RELEASES,
         }
       );
     }

--- a/apps/web/app/app/(shell)/dashboard/releases/task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/task-actions.ts
@@ -177,6 +177,7 @@ export async function instantiateReleaseTasks(releaseId: string) {
 
   await db.insert(tasks).values(taskRows);
 
+  revalidatePath(APP_ROUTES.RELEASES);
   revalidatePath(APP_ROUTES.DASHBOARD_RELEASES);
   revalidatePath(APP_ROUTES.TASKS);
 
@@ -400,6 +401,7 @@ export async function recomputeTaskDueDates(
       AND metadata ->> 'dueDaysOffset' IS NOT NULL
   `);
 
+  revalidatePath(APP_ROUTES.RELEASES);
   revalidatePath(APP_ROUTES.DASHBOARD_RELEASES);
   revalidatePath(APP_ROUTES.TASKS);
 }

--- a/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
@@ -271,6 +271,7 @@ async function createTaskForProfile(
       .returning();
 
     revalidatePath(APP_ROUTES.TASKS);
+    revalidatePath(APP_ROUTES.RELEASES);
     revalidatePath(APP_ROUTES.DASHBOARD_RELEASES);
 
     return mapTaskRow(created);
@@ -632,6 +633,7 @@ export async function updateTask(
     .returning();
 
   revalidatePath(APP_ROUTES.TASKS);
+  revalidatePath(APP_ROUTES.RELEASES);
   revalidatePath(APP_ROUTES.DASHBOARD_RELEASES);
 
   return mapTaskRow(updated);
@@ -810,6 +812,7 @@ export async function moveTask(
 
     if (succeeded) {
       revalidatePath(APP_ROUTES.TASKS);
+      revalidatePath(APP_ROUTES.RELEASES);
       revalidatePath(APP_ROUTES.DASHBOARD_RELEASES);
       return { success: true };
     }
@@ -818,6 +821,7 @@ export async function moveTask(
   // All retries exhausted — still succeed from the client's perspective.
   // The onSettled invalidateQueries in useMoveTaskMutation will re-sync state.
   revalidatePath(APP_ROUTES.TASKS);
+  revalidatePath(APP_ROUTES.RELEASES);
   revalidatePath(APP_ROUTES.DASHBOARD_RELEASES);
   return { success: true };
 }
@@ -838,6 +842,7 @@ export async function deleteTask(
     .where(eq(tasks.id, taskId));
 
   revalidatePath(APP_ROUTES.TASKS);
+  revalidatePath(APP_ROUTES.RELEASES);
   revalidatePath(APP_ROUTES.DASHBOARD_RELEASES);
 
   return { success: true };

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -1027,7 +1027,7 @@ function EmptyCatalog() {
         className='m-3 min-h-[360px]'
         action={
           <Link
-            href={APP_ROUTES.DASHBOARD_RELEASES}
+            href={APP_ROUTES.RELEASES}
             className='inline-flex h-8 items-center rounded-md border border-subtle bg-surface-0 px-3 text-sm font-medium text-primary-token transition-[background-color,border-color] duration-subtle hover:border-default hover:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token'
           >
             Open Releases

--- a/apps/web/app/app/(shell)/shell-route-matches.ts
+++ b/apps/web/app/app/(shell)/shell-route-matches.ts
@@ -59,6 +59,7 @@ export function isReleasesShellRoute(pathname: string | null): boolean {
   if (!pathname) return false;
   return (
     pathname === APP_ROUTES.RELEASES ||
+    pathname.startsWith(`${APP_ROUTES.RELEASES}/`) ||
     pathname === APP_ROUTES.DASHBOARD_RELEASES ||
     pathname.startsWith(`${APP_ROUTES.DASHBOARD_RELEASES}/`)
   );

--- a/apps/web/app/billing/success/page.test.tsx
+++ b/apps/web/app/billing/success/page.test.tsx
@@ -291,13 +291,13 @@ describe('CheckoutSuccessPage — CTAs and verification', () => {
     );
   });
 
-  it('secondary CTA routes to /app/dashboard/releases', () => {
+  it('secondary CTA routes to /app/releases', () => {
     setSearchParams('plan_id=pro');
     mockBilling('pro');
     render(<CheckoutSuccessPage />);
     expect(
       screen.getByRole('link', { name: /view your releases/i })
-    ).toHaveAttribute('href', '/app/dashboard/releases');
+    ).toHaveAttribute('href', '/app/releases');
   });
 
   it('hides the secondary CTA on onboarding flow and shows "Explore your dashboard"', () => {

--- a/apps/web/app/billing/success/page.tsx
+++ b/apps/web/app/billing/success/page.tsx
@@ -376,9 +376,7 @@ export default function CheckoutSuccessPage() {
             </Button>
             {isOnboardingUpgrade ? null : (
               <Button asChild variant='ghost' size='sm'>
-                <Link href={APP_ROUTES.DASHBOARD_RELEASES}>
-                  View your releases
-                </Link>
+                <Link href={APP_ROUTES.RELEASES}>View your releases</Link>
               </Button>
             )}
 

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -63,7 +63,8 @@ function isItemActive(pathname: string, item: NavItem): boolean {
   if (
     normalizedPathname === item.href ||
     (normalizedPathname === APP_ROUTES.RELEASES &&
-      item.href === APP_ROUTES.DASHBOARD_RELEASES)
+      (item.href === APP_ROUTES.RELEASES ||
+        item.href === APP_ROUTES.DASHBOARD_RELEASES))
   ) {
     return true;
   }
@@ -252,7 +253,7 @@ export function DashboardNav(_: DashboardNavProps) {
     // change) leaves the ref null and a later visit will retry.
     const handle = setTimeout(() => {
       releasesPrefetchedProfileIdRef.current = profileId;
-      router.prefetch(APP_ROUTES.DASHBOARD_RELEASES);
+      router.prefetch(APP_ROUTES.RELEASES);
       void import(
         '@/features/dashboard/organisms/release-provider-matrix'
       ).catch(() => {

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -67,7 +67,7 @@ export const primaryNavigation: NavItem[] = [
   profileNavItem,
   {
     name: 'Releases',
-    href: APP_ROUTES.DASHBOARD_RELEASES,
+    href: APP_ROUTES.RELEASES,
     id: 'releases',
     icon: Music,
     description: 'Link out every provider with one smart link',

--- a/apps/web/components/features/dashboard/organisms/MusicImportHero.tsx
+++ b/apps/web/components/features/dashboard/organisms/MusicImportHero.tsx
@@ -82,7 +82,7 @@ export const MusicImportHero = memo(function MusicImportHero({
           <p className='text-sm'>
             We had trouble importing your music. Try refreshing from the{' '}
             <Link
-              href={APP_ROUTES.DASHBOARD_RELEASES}
+              href={APP_ROUTES.RELEASES}
               className='font-medium text-accent underline-offset-2 hover:underline'
             >
               releases page
@@ -135,7 +135,7 @@ export const MusicImportHero = memo(function MusicImportHero({
           asChild
           className='rounded-[10px] text-2xs font-caption tracking-[-0.01em]'
         >
-          <Link href={APP_ROUTES.DASHBOARD_RELEASES}>
+          <Link href={APP_ROUTES.RELEASES}>
             {isImporting ? 'View All Releases' : 'Explore Your Releases'}
           </Link>
         </Button>

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -933,7 +933,7 @@ function TaskEmptyState({
               variant='secondary'
               size='sm'
               onClick={() => {
-                globalThis.location.href = APP_ROUTES.DASHBOARD_RELEASES;
+                globalThis.location.href = APP_ROUTES.RELEASES;
               }}
             >
               Set Up Release

--- a/apps/web/components/features/dashboard/tasks/TasksUpgradeInterstitial.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksUpgradeInterstitial.tsx
@@ -73,7 +73,7 @@ export function TasksWorkspaceUpgradeInterstitial() {
         <TasksUpgradeContent
           heading='Upgrade to access Tasks'
           description='Upgrade to turn releases into step-by-step plans and manage all of your work in one task workspace.'
-          secondaryHref={APP_ROUTES.DASHBOARD_RELEASES}
+          secondaryHref={APP_ROUTES.RELEASES}
           secondaryLabel='Back to Releases'
         />
       </section>
@@ -94,7 +94,7 @@ export function ReleasePlanUpgradeInterstitial({
       <TasksUpgradeContent
         heading='Upgrade To Generate A Release Plan'
         description={`Upgrade to turn ${releaseName} into a step-by-step plan with tasks you can assign to Jovie AI.`}
-        secondaryHref={APP_ROUTES.DASHBOARD_RELEASES}
+        secondaryHref={APP_ROUTES.RELEASES}
         secondaryLabel='Back to Releases'
       />
     </div>

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -22,6 +22,7 @@ export const APP_ROUTES = {
   /** Legacy library path. Keep as a redirect source only. */
   LEGACY_DASHBOARD_LIBRARY: '/app/dashboard/library',
   DASHBOARD_LIBRARY: '/app/library',
+  /** Legacy release workspace route. Keep for the route owner and nested task aliases; use RELEASES for navigation. */
   DASHBOARD_RELEASES: '/app/dashboard/releases',
   DASHBOARD_TASKS: '/app/dashboard/tasks',
   DASHBOARD_RELEASE_TASKS: '/app/dashboard/releases/[releaseId]/tasks',

--- a/apps/web/lib/canonical-surfaces.ts
+++ b/apps/web/lib/canonical-surfaces.ts
@@ -78,9 +78,9 @@ export const CANONICAL_SURFACES = [
   {
     id: 'dashboard-releases',
     label: 'Dashboard Releases',
-    liveRoutes: [APP_ROUTES.DASHBOARD_RELEASES],
+    liveRoutes: [APP_ROUTES.RELEASES, APP_ROUTES.DASHBOARD_RELEASES],
     reviewRoute: '/demo',
-    sourceRoute: APP_ROUTES.DASHBOARD_RELEASES,
+    sourceRoute: APP_ROUTES.RELEASES,
     sourceComponent:
       'features/dashboard/organisms/release-provider-matrix/ReleasesExperience',
     demoRoute: '/demo',

--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -175,7 +175,7 @@ export const COMMANDS: readonly Command[] = [
     'Releases',
     'Manage your release catalog and smart links.',
     'Music',
-    APP_ROUTES.DASHBOARD_RELEASES
+    APP_ROUTES.RELEASES
   ),
   nav(
     'go-audience',

--- a/apps/web/lib/keyboard-shortcuts.test.ts
+++ b/apps/web/lib/keyboard-shortcuts.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
 import {
   KEYBOARD_SHORTCUTS,
   NAV_SHORTCUTS,
@@ -97,6 +98,10 @@ describe('keyboard-shortcuts definitions', () => {
       expect(ids).toContain('nav-earnings');
       expect(ids).toContain('nav-chat');
       expect(ids).toContain('nav-settings');
+    });
+
+    it('uses the canonical releases route for release navigation', () => {
+      expect(NAV_SHORTCUTS.releases.href).toBe(APP_ROUTES.RELEASES);
     });
   });
 

--- a/apps/web/lib/keyboard-shortcuts.ts
+++ b/apps/web/lib/keyboard-shortcuts.ts
@@ -174,7 +174,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     keys: 'G then R',
     category: 'navigation',
     icon: Music,
-    href: APP_ROUTES.DASHBOARD_RELEASES,
+    href: APP_ROUTES.RELEASES,
     isSequential: true,
     firstKey: 'g',
     secondKey: 'r',

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -28,7 +28,7 @@ describe('DashboardNav interactions', () => {
     expect(screen.getByRole('button', { name: 'Profile' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
       'href',
-      APP_ROUTES.DASHBOARD_RELEASES
+      APP_ROUTES.RELEASES
     );
     expect(screen.getByRole('link', { name: 'Audience' })).toHaveAttribute(
       'href',
@@ -152,7 +152,7 @@ describe('DashboardNav interactions', () => {
     expect(screen.getByRole('button', { name: 'Profile' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
       'href',
-      APP_ROUTES.DASHBOARD_RELEASES
+      APP_ROUTES.RELEASES
     );
     expect(screen.getByRole('link', { name: 'Audience' })).toHaveAttribute(
       'href',

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -48,11 +48,16 @@ describe('resolveAppShellRequestPath', () => {
 });
 
 describe('isReleasesShellRoute', () => {
+  it('matches the canonical releases route', () => {
+    expect(isReleasesShellRoute(APP_ROUTES.RELEASES)).toBe(true);
+  });
+
   it('matches the releases dashboard route', () => {
     expect(isReleasesShellRoute('/app/dashboard/releases')).toBe(true);
   });
 
   it('matches nested releases subroutes', () => {
+    expect(isReleasesShellRoute('/app/releases/abc/tasks')).toBe(true);
     expect(isReleasesShellRoute('/app/dashboard/releases/abc/tasks')).toBe(
       true
     );

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -115,7 +115,7 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
       .find(el => el.textContent?.includes('Manage your release catalog'));
     expect(releasesNav).toBeDefined();
     fireEvent.mouseDown(releasesNav!);
-    expect(pushMock).toHaveBeenCalledWith('/app/dashboard/releases');
+    expect(pushMock).toHaveBeenCalledWith('/app/releases');
   });
 
   it('routes a skill commit to chat with the ?skill= handoff', () => {

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -48,6 +48,15 @@ describe('DashboardNav', () => {
     expect(activeLink.getAttribute('aria-current')).toBe('page');
   });
 
+  it('keeps the legacy releases dashboard alias active', () => {
+    mockUsePathname.mockReturnValueOnce(APP_ROUTES.DASHBOARD_RELEASES);
+    const { getByRole } = renderDashboardNav({ renderFn: fastRender });
+
+    const releasesLink = getByRole('link', { name: 'Releases' });
+    expect(releasesLink.getAttribute('href')).toBe(APP_ROUTES.RELEASES);
+    expect(releasesLink.getAttribute('aria-current')).toBe('page');
+  });
+
   it('only marks New thread active on the chat root', () => {
     mockUsePathname.mockReturnValueOnce(`${APP_ROUTES.CHAT}/thread-123`);
 

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -88,7 +88,7 @@ describe('LibrarySurface', () => {
     ).toBeDefined();
     expect(screen.getByRole('link', { name: 'Open Releases' })).toHaveAttribute(
       'href',
-      APP_ROUTES.DASHBOARD_RELEASES
+      APP_ROUTES.RELEASES
     );
   });
 

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -15,7 +15,9 @@ import {
 
 const SHELL_ROOT = path.resolve(__dirname, '../../../app/app/(shell)');
 
-const NAV_ROUTE_PAGE_ALIASES: Record<string, string> = {};
+const NAV_ROUTE_PAGE_ALIASES: Record<string, string> = {
+  '/app/releases': '/app/dashboard/releases',
+};
 
 const INTENTIONAL_INTERNAL_ROUTES: Record<string, string> = {
   '/app': 'Shell root entry page',


### PR DESCRIPTION
Linear: JOV-2319

Summary:
- Canonicalized user-facing Releases navigation to `/app/releases` across shell sidebar, command palette, keyboard shortcuts, library/billing/task escape hatches, and canonical surface metadata.
- Kept `/app/dashboard/releases` as the route owner and legacy alias, including active-state matching and release-task entity routes.
- Revalidated both canonical and legacy release workspace paths from task/release-task mutations.

Verification:
- `pnpm exec biome check --write <23 changed files>`
- `pnpm --filter @jovie/web run test -- tests/components/dashboard/DashboardNav.interaction.test.tsx tests/unit/dashboard/DashboardNav.test.tsx tests/unit/commands/SharedCommandPalette.test.tsx lib/keyboard-shortcuts.test.ts tests/unit/app/shell-route-matches.test.ts tests/unit/library/LibrarySurface.test.tsx app/billing/success/page.test.tsx --reporter=dot` (125 tests passed after final rebase)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm run version:check`
- `BASE_URL=http://127.0.0.1:3123 E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready pnpm --filter @jovie/web exec playwright test tests/e2e/shell-route-persistence.spec.ts --project=chromium` (2 passed)
- Browser/design QA: `/app/releases`, `/app/dashboard/releases`, mobile `/app/releases`, and cmd+k Releases navigation. Screenshots: `/tmp/jovie-jov2319-releases-canonical-rebased.png`, `/tmp/jovie-jov2319-releases-legacy-rebased.png`, `/tmp/jovie-jov2319-releases-mobile-rebased.png`. Canonical vs legacy pixel diff: 0 changed pixels.
- `pnpm --filter @jovie/web exec vitest run tests/unit/routes/shell-nav-coverage.test.ts --config=vitest.config.mts` (3 tests passed after adding the canonical alias coverage entry)
- Pre-push hook after latest push: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`.

<!-- agent-run-artifact
{
  "id": "jov-2319-canonical-releases-route-0cb11f5e3bd3f14a5be851489537b87224c1730b",
  "source": "ruflo",
  "sourceRunId": "0cb11f5e3bd3f14a5be851489537b87224c1730b",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2319 canonical releases route",
  "summary": "Canonicalized user-facing release navigation to /app/releases while preserving the dashboard release route as an alias and route owner. Browser QA showed no visual drift: canonical and legacy screenshots had a 0-pixel diff and no horizontal overflow.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "User approved autonomous shipping for non-visual shell migration slices.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2319",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2319/releases-canonicalize-shell-navigation-to-appreleases",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/8889",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused Vitest route-contract suite passed 125 tests, shell nav coverage passed 3 tests after the alias fix, on 0cb11f5e3bd3f14a5be851489537b87224c1730b, shell-route-persistence Playwright passed 2 tests, and browser QA covered canonical, alias, mobile, and cmd+k releases navigation with no console or failed-request errors after filtering expected navigation aborts.",
      "checkedAt": "2026-05-17T00:13:48Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review confirmed no experimental app imports, no route data ownership move, legacy alias preserved, and canonical destinations limited to user-facing links/commands/shortcuts plus revalidation parity.",
      "checkedAt": "2026-05-17T00:13:48Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Version check, typecheck, focused tests, alias coverage test, browser/pixel QA, and pre-push biome/proxy/tailwind/typecheck/lint gates passed on commit 0cb11f5e3bd3f14a5be851489537b87224c1730b.",
      "checkedAt": "2026-05-17T00:13:48Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local coding and verification only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-17T00:13:48Z",
  "updatedAt": "2026-05-17T00:29:00Z",
  "metadata": {
    "screenshots": [
      "/tmp/jovie-jov2319-releases-canonical-rebased.png",
      "/tmp/jovie-jov2319-releases-legacy-rebased.png",
      "/tmp/jovie-jov2319-releases-mobile-rebased.png"
    ],
    "pixelDiffChangedPixels": 0,
    "routes": ["/app/releases", "/app/dashboard/releases"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated Releases routing and navigation across the app so links and nav items now point to the unified Releases route.
  * Improved cache invalidation so release-related views refresh consistently after task and release actions.

* **Tests**
  * Updated and added tests to reflect the revised Releases routing and active-nav behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
