### PR TITLE
fix(shell): stabilize entity provider registration

### DIFF
--- a/apps/web/components/jovie/components/ChatProvidersRegistrar.tsx
+++ b/apps/web/components/jovie/components/ChatProvidersRegistrar.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { useEffect, useMemo } from 'react';
-import { registerEntityProvider } from '@/lib/commands/entities';
+import {
+  registerEntityProvider,
+  unregisterEntityProvider,
+} from '@/lib/commands/entities';
 import { artistProvider } from './artist-provider';
 import { createEventProvider } from './event-provider';
 import { createReleaseProvider } from './release-provider';
@@ -33,6 +36,11 @@ export function ChatProvidersRegistrar({
     registerEntityProvider(releaseProvider);
     registerEntityProvider(artistProvider);
     registerEntityProvider(eventProvider);
+    return () => {
+      unregisterEntityProvider(releaseProvider);
+      unregisterEntityProvider(artistProvider);
+      unregisterEntityProvider(eventProvider);
+    };
   }, [releaseProvider, eventProvider]);
 
   return null;

--- a/apps/web/components/jovie/components/EntityResolutionProvider.test.tsx
+++ b/apps/web/components/jovie/components/EntityResolutionProvider.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook } from '@testing-library/react';
-import type { ReactElement, ReactNode } from 'react';
+import { act, render, renderHook } from '@testing-library/react';
+import { type ReactElement, type ReactNode, useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 import { queryKeys } from '@/lib/queries';
@@ -66,6 +66,18 @@ function wrapperWithClient(
   };
 }
 
+function CacheWriter({
+  client,
+}: Readonly<{ client: QueryClient }>): ReactElement | null {
+  useState(() => {
+    client.setQueryData(queryKeys.releases.matrix('p1'), [
+      makeRelease('rel_sync'),
+    ]);
+    return null;
+  });
+  return null;
+}
+
 describe('EntityResolutionProvider', () => {
   it('returns NULL_ENTITY_RESOLUTION when no provider is mounted', () => {
     const client = new QueryClient();
@@ -107,6 +119,70 @@ describe('EntityResolutionProvider', () => {
     expect(result.current.ref?.label).toBe('Sober');
     expect(result.current.ref?.thumbnail).toBe('https://example.com/cover.jpg');
     expect(result.current.ref?.meta?.kind).toBe('release');
+  });
+
+  it('refreshes release chips when the cached matrix key updates', async () => {
+    const client = new QueryClient();
+    const { result } = renderHook(
+      () => useEntityResolution('release', 'rel_later'),
+      { wrapper: wrapperWithClient(client, 'p1') }
+    );
+
+    expect(result.current.ref).toBeUndefined();
+
+    await act(async () => {
+      client.setQueryData(queryKeys.releases.matrix('p1'), [
+        makeRelease('rel_later', { title: 'Late Arrival' }),
+      ]);
+      await Promise.resolve();
+    });
+
+    expect(result.current.ref?.label).toBe('Late Arrival');
+  });
+
+  it('ignores unrelated release detail cache updates', async () => {
+    const client = new QueryClient();
+    let renderCount = 0;
+    renderHook(
+      () => {
+        renderCount += 1;
+        return useEntityResolution('release', 'rel_detail');
+      },
+      { wrapper: wrapperWithClient(client, 'p1') }
+    );
+
+    await act(async () => {
+      client.setQueryData(queryKeys.releases.detail('p1', 'rel_detail'), {
+        id: 'rel_detail',
+      });
+      await Promise.resolve();
+    });
+
+    expect(renderCount).toBe(1);
+  });
+
+  it('defers cache notifications that happen during child render', async () => {
+    const client = new QueryClient();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <QueryClientProvider client={client}>
+        <EntityResolutionProvider profileId='p1'>
+          <CacheWriter client={client} />
+        </EntityResolutionProvider>
+      </QueryClientProvider>
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(
+      errorSpy.mock.calls.some(args =>
+        String(args[0]).includes('Cannot update a component')
+      )
+    ).toBe(false);
+    errorSpy.mockRestore();
   });
 
   it('returns undefined when release id is not in the cache', () => {

--- a/apps/web/components/jovie/components/EntityResolutionProvider.tsx
+++ b/apps/web/components/jovie/components/EntityResolutionProvider.tsx
@@ -4,10 +4,10 @@ import { QueryClientContext } from '@tanstack/react-query';
 import {
   createContext,
   type ReactNode,
+  useCallback,
   useContext,
-  useEffect,
   useMemo,
-  useState,
+  useSyncExternalStore,
 } from 'react';
 import type { EntityKind } from '@/lib/chat/tokens';
 import type { EntityRef } from '@/lib/commands/entities';
@@ -34,10 +34,21 @@ const NULL_RESOLUTION: EntityResolution = {
 const NULL_RESOLVER: ResolverFn = () => NULL_RESOLUTION;
 
 const EntityResolutionContext = createContext<ResolverFn>(NULL_RESOLVER);
+const EMPTY_ENTITY_CACHE_SNAPSHOT = '0:0:0:0';
 
 interface EntityResolutionProviderProps {
   readonly profileId: string | null | undefined;
   readonly children: ReactNode;
+}
+
+function areQueryKeysEqual(
+  left: readonly unknown[],
+  right: readonly unknown[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => Object.is(value, right[index]))
+  );
 }
 
 /**
@@ -65,29 +76,75 @@ export function EntityResolutionProvider({
   // of JovieChat, or hypothetical SSR-only consumers). `useQueryClient()`
   // throws on missing provider; we'd rather no-op.
   const queryClient = useContext(QueryClientContext);
-  // Bump on every QueryCache update — the resolver function reads from
-  // getQueryData, so its closed-over cache snapshot is implicit. The version
-  // counter forces a context re-publish when the underlying data changes.
-  const [cacheVersion, setCacheVersion] = useState(0);
+  const releaseMatrixKey = useMemo(
+    () => (profileId ? queryKeys.releases.matrix(profileId) : null),
+    [profileId]
+  );
+  const eventsListKey = useMemo(
+    () => (profileId ? queryKeys.events.list(profileId) : null),
+    [profileId]
+  );
 
-  useEffect(() => {
-    if (!queryClient) return;
-    const cache = queryClient.getQueryCache();
-    const unsubscribe = cache.subscribe(event => {
-      // Only re-publish when releases or events data actually changes.
-      // Filters out unrelated cache churn (billing, audience, etc.).
-      const key = event.query.queryKey;
-      if (!Array.isArray(key)) return;
-      const root = key[0];
-      if (root === 'releases' || root === 'events') {
-        setCacheVersion(v => v + 1);
+  const getEntityCacheSnapshot = useCallback(() => {
+    if (!queryClient || !releaseMatrixKey || !eventsListKey) {
+      return EMPTY_ENTITY_CACHE_SNAPSHOT;
+    }
+
+    const releaseState = queryClient.getQueryState(releaseMatrixKey);
+    const eventState = queryClient.getQueryState(eventsListKey);
+    return [
+      releaseState?.dataUpdateCount ?? 0,
+      releaseState?.dataUpdatedAt ?? 0,
+      eventState?.dataUpdateCount ?? 0,
+      eventState?.dataUpdatedAt ?? 0,
+    ].join(':');
+  }, [eventsListKey, queryClient, releaseMatrixKey]);
+
+  const subscribeToEntityCache = useCallback(
+    (notify: () => void) => {
+      if (!queryClient || !releaseMatrixKey || !eventsListKey) {
+        return () => {};
       }
-    });
-    return unsubscribe;
-  }, [queryClient]);
+
+      let isSubscribed = true;
+      let notifyQueued = false;
+      const queueNotify = () => {
+        if (notifyQueued) return;
+        notifyQueued = true;
+        queueMicrotask(() => {
+          notifyQueued = false;
+          if (!isSubscribed) return;
+          notify();
+        });
+      };
+
+      const cache = queryClient.getQueryCache();
+      const unsubscribe = cache.subscribe(event => {
+        const key = event.query.queryKey;
+        if (!Array.isArray(key)) return;
+        if (
+          areQueryKeysEqual(key, releaseMatrixKey) ||
+          areQueryKeysEqual(key, eventsListKey)
+        ) {
+          queueNotify();
+        }
+      });
+      return () => {
+        isSubscribed = false;
+        unsubscribe();
+      };
+    },
+    [eventsListKey, queryClient, releaseMatrixKey]
+  );
+
+  const cacheSnapshot = useSyncExternalStore(
+    subscribeToEntityCache,
+    getEntityCacheSnapshot,
+    () => EMPTY_ENTITY_CACHE_SNAPSHOT
+  );
 
   const resolver = useMemo<ResolverFn>(() => {
-    // cacheVersion is intentionally part of the closure so memoization
+    // cacheSnapshot is intentionally part of the closure so memoization
     // re-fires when caches change. Reads are deferred until each chip calls.
     if (!profileId || !queryClient) {
       return () => NULL_RESOLUTION;
@@ -116,10 +173,10 @@ export function EntityResolutionProvider({
       // + label, which is identical to today's empty-thumbnail behavior.
       return NULL_RESOLUTION;
     };
-    // cacheVersion participates so consumers re-derive on cache change.
+    // cacheSnapshot participates so consumers re-derive on cache change.
     // queryClient is stable from React Query's provider.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [profileId, queryClient, cacheVersion]);
+  }, [profileId, queryClient, cacheSnapshot]);
 
   return (
     <EntityResolutionContext.Provider value={resolver}>

--- a/apps/web/components/jovie/components/artist-provider.tsx
+++ b/apps/web/components/jovie/components/artist-provider.tsx
@@ -19,6 +19,7 @@ import { EntityChip } from './EntityChip';
  */
 export const artistProvider: EntityProvider = {
   kind: 'artist',
+  registryKey: 'artist:spotify-search',
   label: 'Artists',
   useSearch(query: string): EntitySearchResult {
     const { results, state, search } = useArtistSearchQuery({

--- a/apps/web/components/jovie/components/event-provider.tsx
+++ b/apps/web/components/jovie/components/event-provider.tsx
@@ -55,6 +55,7 @@ function eventToEntityRef(event: EventRecord): EntityRef {
 export function createEventProvider(profileId: string): EntityProvider {
   return {
     kind: 'event',
+    registryKey: `event:${profileId}`,
     label: 'Events',
     useSearch(query: string): EntitySearchResult {
       const { data, isLoading } = useEventsQuery(profileId);

--- a/apps/web/components/jovie/components/release-provider.tsx
+++ b/apps/web/components/jovie/components/release-provider.tsx
@@ -77,6 +77,7 @@ function toEntityRef(release: ReleaseLike): EntityRef {
 export function createReleaseProvider(profileId: string): EntityProvider {
   return {
     kind: 'release',
+    registryKey: `release:${profileId}`,
     label: 'Releases',
     useSearch(query: string): EntitySearchResult {
       const { data, isLoading } = useReleasesQuery(profileId);

--- a/apps/web/lib/commands/entities.ts
+++ b/apps/web/lib/commands/entities.ts
@@ -94,6 +94,13 @@ export type UseEntitySearch = (query: string) => EntitySearchResult;
 
 export interface EntityProvider {
   readonly kind: EntityKind;
+  /**
+   * Stable semantic identity for dev duplicate-registration checks.
+   * Providers that are recreated for the same profile/scope should keep the
+   * same key so React Strict Mode and route remounts do not look like wiring
+   * bugs.
+   */
+  readonly registryKey?: string;
   readonly label: string;
   readonly useSearch: UseEntitySearch;
   readonly renderChip: (ref: EntityRef) => ReactNode;
@@ -108,7 +115,12 @@ const PROVIDERS: Partial<Record<EntityKind, EntityProvider>> = {};
 
 export function registerEntityProvider(provider: EntityProvider): void {
   const existing = PROVIDERS[provider.kind];
-  if (existing && existing !== provider) {
+  const isSameProvider =
+    existing === provider ||
+    (existing?.registryKey !== undefined &&
+      existing.registryKey === provider.registryKey);
+
+  if (existing && !isSameProvider) {
     // Dev warning only — multiple mount/unmount cycles (React strict mode,
     // test renders, profile switches) legitimately create new provider
     // instances for the same kind. Overwrite is the sane default; a true
@@ -119,6 +131,12 @@ export function registerEntityProvider(provider: EntityProvider): void {
     );
   }
   PROVIDERS[provider.kind] = provider;
+}
+
+export function unregisterEntityProvider(provider: EntityProvider): void {
+  if (PROVIDERS[provider.kind] === provider) {
+    delete PROVIDERS[provider.kind];
+  }
 }
 
 export function getEntityProvider(

--- a/apps/web/tests/unit/chat/entity-provider-registry.test.ts
+++ b/apps/web/tests/unit/chat/entity-provider-registry.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EntityProvider } from '@/lib/commands/entities';
+
+function makeProvider(registryKey: string): EntityProvider {
+  return {
+    kind: 'release',
+    registryKey,
+    label: 'Releases',
+    useSearch: () => ({ items: [], isLoading: false }),
+    renderChip: () => null,
+  };
+}
+
+describe('entity provider registry', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not warn when the same semantic provider registers again', async () => {
+    vi.resetModules();
+    const { registerEntityProvider } = await import('@/lib/commands/entities');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    registerEntityProvider(makeProvider('release:profile-1'));
+    registerEntityProvider(makeProvider('release:profile-1'));
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('still warns when a different scoped provider replaces an existing kind', async () => {
+    vi.resetModules();
+    const { registerEntityProvider } = await import('@/lib/commands/entities');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    registerEntityProvider(makeProvider('release:profile-1'));
+    registerEntityProvider(makeProvider('release:profile-2'));
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '[commands] Replacing existing EntityProvider for kind="release".'
+      )
+    );
+  });
+
+  it('unregisters only the active provider object', async () => {
+    vi.resetModules();
+    const {
+      getEntityProvider,
+      registerEntityProvider,
+      unregisterEntityProvider,
+    } = await import('@/lib/commands/entities');
+    const firstProvider = makeProvider('release:profile-1');
+    const replacementProvider = makeProvider('release:profile-1');
+
+    registerEntityProvider(firstProvider);
+    registerEntityProvider(replacementProvider);
+    unregisterEntityProvider(firstProvider);
+
+    expect(getEntityProvider('release')).toBe(replacementProvider);
+
+    unregisterEntityProvider(replacementProvider);
+
+    expect(getEntityProvider('release')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Linear: JOV-2320

Summary:
- Moved chat entity cache subscriptions to useSyncExternalStore so release/event chip refreshes do not call React state updates from TanStack Query cache notifications during sibling renders.
- Narrowed cache invalidation to the exact release matrix and event list keys used by the resolver, avoiding route-wide churn from unrelated release/event queries.
- Added scoped provider registry keys plus cleanup on registrar unmount so Strict Mode/remounts do not emit duplicate provider warnings or leave stale scoped providers registered.

Verification:
- `pnpm exec biome check --write apps/web/components/jovie/components/EntityResolutionProvider.tsx apps/web/components/jovie/components/EntityResolutionProvider.test.tsx apps/web/components/jovie/components/ChatProvidersRegistrar.tsx apps/web/components/jovie/components/artist-provider.tsx apps/web/components/jovie/components/release-provider.tsx apps/web/components/jovie/components/event-provider.tsx apps/web/lib/commands/entities.ts apps/web/tests/unit/chat/entity-provider-registry.test.ts`
- `pnpm --filter @jovie/web run test -- components/jovie/components/EntityResolutionProvider.test.tsx tests/unit/chat/entity-provider-registry.test.ts --reporter=dot` (14 tests passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm run version:check`
- Browser QA against `http://127.0.0.1:3124/app/dashboard/tasks` and `/app/chat`: no horizontal overflow and no React "Cannot update a component" or `[commands] Replacing existing EntityProvider` console warnings. Screenshots: `/tmp/jovie-jov2320-tasks.png`, `/tmp/jovie-jov2320-chat.png`.
- Pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`.

<!-- agent-run-artifact
{
  "id": "jov-2320-entity-provider-registration-3cc7720aca0460aad6123e542838786701d58084",
  "source": "ruflo",
  "sourceRunId": "3cc7720aca0460aad6123e542838786701d58084",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2320 shell entity provider stability",
  "summary": "Stabilized chat entity provider registration and cache subscriptions so shell routes no longer warn about render-time updates or duplicate release/event providers during tasks/chat navigation.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "User approved autonomous shipping for non-visual shell migration slices.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2320",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2320/shell-prevent-entity-provider-render-time-updates",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/8891",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused entity resolver and provider registry tests passed 14 tests, plus route-level browser QA covered tasks and chat with no target React/provider warnings and no horizontal overflow.",
      "checkedAt": "2026-05-17T00:33:00Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review confirmed the fix stays inside chat entity provider contracts, does not import exp shell code, avoids global shell rewrites, and narrows cache subscriptions to resolver-owned query keys.",
      "checkedAt": "2026-05-17T00:33:00Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Version check, focused tests, typecheck, browser QA, and pre-push biome/proxy/tailwind/typecheck/lint gates passed on commit 3cc7720aca0460aad6123e542838786701d58084.",
      "checkedAt": "2026-05-17T00:33:00Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local coding and verification only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-17T00:33:00Z",
  "updatedAt": "2026-05-17T00:33:00Z",
  "metadata": {
    "screenshots": ["/tmp/jovie-jov2320-tasks.png", "/tmp/jovie-jov2320-chat.png"],
    "routes": ["/app/dashboard/tasks", "/app/chat"],
    "targetConsoleWarnings": ["Cannot update a component", "Replacing existing EntityProvider"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where cache updates to entity data could trigger console errors during component rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->