### PR TITLE
fix(shell): align calendar release data

### DIFF
--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -32,7 +32,7 @@ import { getEventLocalDateKey } from '@/lib/events/date';
 import { normalizeTicketUrl } from '@/lib/events/ticket-url';
 import { queryKeys } from '@/lib/queries';
 import { type EventRecord, useEventsQuery } from '@/lib/queries/useEventsQuery';
-import { useRecentReleasesQuery } from '@/lib/queries/useRecentReleasesQuery';
+import { useReleasesQuery } from '@/lib/queries/useReleasesQuery';
 import { cn } from '@/lib/utils';
 import { useDashboardData } from '../dashboard/DashboardDataContext';
 
@@ -204,7 +204,7 @@ export function CalendarPageClient() {
   const profileId = selectedProfile?.id ?? '';
   const queryClient = useQueryClient();
   const { data: releases, isLoading: isLoadingReleases } =
-    useRecentReleasesQuery(profileId);
+    useReleasesQuery(profileId);
   const { data: events, isLoading: isLoadingEvents } =
     useEventsQuery(profileId);
 
@@ -218,7 +218,7 @@ export function CalendarPageClient() {
         id: r.id,
         title: r.title,
         artworkUrl: r.artworkUrl ?? undefined,
-        status: deriveStatus(r.releaseDate),
+        status: deriveStatus(r.releaseDate ?? null),
       };
       const list = map.get(key);
       if (list) list.push(dot);

--- a/apps/web/app/app/(shell)/calendar/page.tsx
+++ b/apps/web/app/app/(shell)/calendar/page.tsx
@@ -4,7 +4,7 @@ import { APP_ROUTES } from '@/constants/routes';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
 import { getCachedAuth } from '@/lib/auth/cached';
 import { captureError } from '@/lib/error-tracking';
-import { queryKeys, type RecentRelease } from '@/lib/queries';
+import { queryKeys } from '@/lib/queries';
 import { HydrateClient } from '@/lib/queries/HydrateClient';
 import { getDehydratedState, getQueryClient } from '@/lib/queries/server';
 import type { EventRecord } from '@/lib/queries/useEventsQuery';
@@ -77,24 +77,8 @@ async function prefetchCalendarQueries(profileId: string) {
 
   await Promise.all([
     queryClient.fetchQuery({
-      queryKey: queryKeys.releases.recent(profileId),
-      queryFn: async (): Promise<RecentRelease[]> => {
-        const releases = await loadReleaseMatrix(profileId);
-        return [...releases]
-          .sort((a, b) => {
-            const aTime = a.releaseDate ? Date.parse(a.releaseDate) : 0;
-            const bTime = b.releaseDate ? Date.parse(b.releaseDate) : 0;
-            return bTime - aTime;
-          })
-          .slice(0, 8)
-          .map(release => ({
-            id: release.id,
-            title: release.title,
-            artworkUrl: release.artworkUrl ?? null,
-            releaseDate: release.releaseDate ?? null,
-            releaseType: release.releaseType,
-          }));
-      },
+      queryKey: queryKeys.releases.matrix(profileId),
+      queryFn: () => loadReleaseMatrix(profileId),
     }),
     queryClient.fetchQuery({
       queryKey: queryKeys.events.list(profileId),
@@ -109,7 +93,7 @@ async function prefetchCalendarQueries(profileId: string) {
 /**
  * Calendar route — unified month-grid view of releases + events.
  *
- * Releases come from `useRecentReleasesQuery`. Events (tour, livestream,
+ * Releases come from the shared release matrix query. Events (tour, livestream,
  * listening party, AMA, signing) come from `useEventsQuery`. Synced
  * provider events land as `pending` and surface in the day-detail
  * sidebar with inline confirm/reject — they do not bleed to fans or

--- a/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
+++ b/apps/web/tests/unit/calendar/CalendarPageClient.test.tsx
@@ -1,0 +1,136 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CalendarPageClient } from '@/app/app/(shell)/calendar/CalendarPageClient';
+import type { EventRecord } from '@/lib/queries/useEventsQuery';
+
+const mocks = vi.hoisted(() => ({
+  useDashboardData: vi.fn(),
+  useEventsQuery: vi.fn(),
+  useReleasesQuery: vi.fn(),
+  confirmEvent: vi.fn(),
+  confirmEvents: vi.fn(),
+  rejectEvent: vi.fn(),
+  rejectEvents: vi.fn(),
+  undoRejectEvent: vi.fn(),
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/DashboardDataContext', () => ({
+  useDashboardData: mocks.useDashboardData,
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/tour-dates/events-actions', () => ({
+  confirmEvent: mocks.confirmEvent,
+  confirmEvents: mocks.confirmEvents,
+  rejectEvent: mocks.rejectEvent,
+  rejectEvents: mocks.rejectEvents,
+  undoRejectEvent: mocks.undoRejectEvent,
+}));
+
+vi.mock('@/lib/queries/useEventsQuery', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/lib/queries/useEventsQuery')
+  >('@/lib/queries/useEventsQuery');
+  return {
+    ...actual,
+    useEventsQuery: mocks.useEventsQuery,
+  };
+});
+
+vi.mock('@/lib/queries/useReleasesQuery', () => ({
+  useReleasesQuery: mocks.useReleasesQuery,
+}));
+
+const release = {
+  profileId: 'profile-1',
+  id: 'release-1',
+  title: 'May Release',
+  artistNames: ['Tim White'],
+  releaseDate: '2026-05-17T00:00:00.000Z',
+  status: 'scheduled',
+  artworkUrl: null,
+  slug: 'may-release',
+  smartLinkPath: '/tim/may-release',
+  providers: [],
+  releaseType: 'single',
+  isExplicit: false,
+  totalTracks: 1,
+};
+
+const pendingEvent: EventRecord = {
+  id: 'event-1',
+  title: 'Movement Festival',
+  subtitle: 'Detroit, MI · Bandsintown',
+  eventDate: '2026-05-18T20:00:00.000Z',
+  timezone: 'America/Detroit',
+  eventType: 'tour',
+  confirmationStatus: 'pending',
+  providerKey: 'bandsintown',
+  reviewedAt: null,
+  lastSyncedAt: '2026-05-10T00:00:00.000Z',
+  provider: 'Bandsintown',
+};
+
+function renderCalendar() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <CalendarPageClient />
+    </QueryClientProvider>
+  );
+}
+
+describe('CalendarPageClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-16T12:00:00.000Z'));
+    mocks.useDashboardData.mockReturnValue({
+      selectedProfile: { id: 'profile-1' },
+    });
+    mocks.useReleasesQuery.mockReturnValue({
+      data: [release],
+      isLoading: false,
+    });
+    mocks.useEventsQuery.mockReturnValue({
+      data: [pendingEvent],
+      isLoading: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reads calendar releases from the canonical release matrix query', () => {
+    renderCalendar();
+
+    expect(mocks.useReleasesQuery).toHaveBeenCalledWith('profile-1');
+    expect(screen.getByText('May Release')).toBeInTheDocument();
+    expect(screen.getByText('Movement Festival')).toBeInTheDocument();
+  });
+
+  it('keeps event review filtering backed by the event query', () => {
+    renderCalendar();
+
+    expect(mocks.useEventsQuery).toHaveBeenCalledWith('profile-1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Needs review · 1' }));
+
+    expect(screen.queryByText('May Release')).not.toBeInTheDocument();
+    expect(screen.getByText('Movement Festival')).toBeInTheDocument();
+  });
+
+  it('does not fetch scoped release or event data without a selected profile', () => {
+    mocks.useDashboardData.mockReturnValue({
+      selectedProfile: null,
+    });
+    renderCalendar();
+
+    expect(mocks.useReleasesQuery).toHaveBeenCalledWith('');
+    expect(mocks.useEventsQuery).toHaveBeenCalledWith('');
+  });
+});

--- a/apps/web/tests/unit/calendar/calendar-page.test.tsx
+++ b/apps/web/tests/unit/calendar/calendar-page.test.tsx
@@ -171,7 +171,7 @@ describe('CalendarPage', () => {
     expect(mocks.fetchQuery).not.toHaveBeenCalled();
   });
 
-  it('hydrates recent releases and events for the selected profile', async () => {
+  it('hydrates release matrix and events for the selected profile', async () => {
     render(await CalendarPage());
 
     expect(screen.getByTestId('hydrate-client')).toHaveAttribute(
@@ -181,7 +181,7 @@ describe('CalendarPage', () => {
     expect(screen.getByTestId('calendar-client')).toBeInTheDocument();
     expect(mocks.fetchQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        queryKey: queryKeys.releases.recent('profile-1'),
+        queryKey: queryKeys.releases.matrix('profile-1'),
       })
     );
     expect(mocks.fetchQuery).toHaveBeenCalledWith(


### PR DESCRIPTION
Linear: JOV-2321

Summary:
- Switched /app/calendar release data from the legacy recent-releases query to the shared release matrix query used by Releases and Library.
- Updated the calendar server prefetch to hydrate `queryKeys.releases.matrix(profileId)` directly instead of reshaping release matrix data into a separate recent-releases cache entry.
- Added focused CalendarPageClient coverage so the route stays on the canonical release query while event review filters remain intact.

Verification:
- `pnpm exec biome check --write apps/web/app/app/(shell)/calendar/page.tsx apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx apps/web/tests/unit/calendar/calendar-page.test.tsx apps/web/tests/unit/calendar/CalendarPageClient.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/calendar/CalendarPageClient.test.tsx tests/unit/calendar/calendar-page.test.tsx tests/unit/calendar/action-results.test.ts tests/unit/calendar/calendar-shell-style-guard.test.ts --config=vitest.config.mts` (11 tests passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm run version:check`
- Browser/design QA against `http://127.0.0.1:3125/app/calendar` at 1440x900 and 390x844: no horizontal overflow, no console errors/warnings, calendar title rendered. Screenshots: `/tmp/jovie-jov2321-calendar-desktop-rebased.png`, `/tmp/jovie-jov2321-calendar-mobile-rebased.png`.
- Pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`.

<!-- agent-run-artifact
{
  "id": "jov-2321-calendar-shell-data-f974115a716879d6dc8fcd84afe2a34bcc24fc03",
  "source": "ruflo",
  "sourceRunId": "f974115a716879d6dc8fcd84afe2a34bcc24fc03",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2321 calendar shell data alignment",
  "summary": "Aligned calendar release data with the shared release matrix query and kept the route visually stable in the app shell across desktop and mobile.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "User approved autonomous shipping for non-visual shell migration slices.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2321",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2321/shell-migrate-calendar-route-to-canonical-data-boundary",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/8895",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused calendar page/client tests passed 11 tests, and browser QA covered /app/calendar at desktop and mobile with no console warnings/errors or horizontal overflow.",
      "checkedAt": "2026-05-17T00:47:00Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review confirmed the slice only changes calendar release data ownership from recent releases to the shared matrix query, with no experimental imports, routing rewrites, auth changes, billing changes, or visual redesign.",
      "checkedAt": "2026-05-17T00:47:00Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Version check, focused tests, typecheck, browser/design QA, and pre-push biome/proxy/tailwind/typecheck/lint gates passed on commit f974115a716879d6dc8fcd84afe2a34bcc24fc03.",
      "checkedAt": "2026-05-17T00:47:00Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local coding and verification only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-17T00:47:00Z",
  "updatedAt": "2026-05-17T00:47:00Z",
  "metadata": {
    "screenshots": ["/tmp/jovie-jov2321-calendar-desktop-rebased.png", "/tmp/jovie-jov2321-calendar-mobile-rebased.png"],
    "routes": ["/app/calendar"],
    "viewportWidths": [1440, 390]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Calendar release data now sources from the shared release matrix to ensure consistency across the application based on selected profile.

* **Tests**
  * Added comprehensive unit tests for calendar functionality to verify proper data sourcing and filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->