### PR TITLE
fix(shell): simplify settings alias routes

### DIFF
--- a/apps/web/app/app/(shell)/settings/appearance/page.tsx
+++ b/apps/web/app/app/(shell)/settings/appearance/page.tsx
@@ -1,22 +1,8 @@
 import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
-import { DashboardSettings } from '@/features/dashboard/DashboardSettings';
-import { getCachedAuth } from '@/lib/auth/cached';
-import { getDashboardData } from '../../dashboard/actions';
 
 export const runtime = 'nodejs';
 
-export default async function SettingsAppearancePage() {
-  const { userId } = await getCachedAuth();
-
-  if (!userId) {
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=/app/settings/appearance`);
-  }
-
-  const dashboardData = await getDashboardData();
-  if (dashboardData.needsOnboarding && !dashboardData.dashboardLoadError) {
-    redirect(APP_ROUTES.START);
-  }
-
-  return <DashboardSettings focusSection='account' />;
+export default function SettingsAppearancePage() {
+  redirect(APP_ROUTES.SETTINGS_ACCOUNT);
 }

--- a/apps/web/app/app/(shell)/settings/delete-account/page.tsx
+++ b/apps/web/app/app/(shell)/settings/delete-account/page.tsx
@@ -1,22 +1,8 @@
 import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
-import { DashboardSettings } from '@/features/dashboard/DashboardSettings';
-import { getCachedAuth } from '@/lib/auth/cached';
-import { getDashboardData } from '../../dashboard/actions';
 
 export const runtime = 'nodejs';
 
-export default async function SettingsDeleteAccountPage() {
-  const { userId } = await getCachedAuth();
-
-  if (!userId) {
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=/app/settings/delete-account`);
-  }
-
-  const dashboardData = await getDashboardData();
-  if (dashboardData.needsOnboarding && !dashboardData.dashboardLoadError) {
-    redirect(APP_ROUTES.START);
-  }
-
-  return <DashboardSettings focusSection='data-privacy' />;
+export default function SettingsDeleteAccountPage() {
+  redirect(APP_ROUTES.SETTINGS_DATA_PRIVACY);
 }

--- a/apps/web/app/app/(shell)/settings/page.tsx
+++ b/apps/web/app/app/(shell)/settings/page.tsx
@@ -1,37 +1,8 @@
-import * as Sentry from '@sentry/nextjs';
 import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
-import { DashboardSettings } from '@/features/dashboard/DashboardSettings';
-import { PageErrorState } from '@/features/feedback/PageErrorState';
-import { getCachedAuth } from '@/lib/auth/cached';
-import { getDashboardData } from '../dashboard/actions';
 
 export const runtime = 'nodejs';
 
-export default async function SettingsPage() {
-  const { userId } = await getCachedAuth();
-
-  if (!userId) {
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=/app/settings`);
-  }
-
-  try {
-    const dashboardData = await getDashboardData();
-
-    if (dashboardData.needsOnboarding && !dashboardData.dashboardLoadError) {
-      redirect(APP_ROUTES.START);
-    }
-
-    return <DashboardSettings />;
-  } catch (error) {
-    if (error instanceof Error && error.message === 'NEXT_REDIRECT') {
-      throw error;
-    }
-
-    Sentry.captureException(error);
-
-    return (
-      <PageErrorState message='Failed to load settings data. Please refresh the page.' />
-    );
-  }
+export default function SettingsPage() {
+  redirect(APP_ROUTES.SETTINGS_ACCOUNT);
 }

--- a/apps/web/app/app/(shell)/settings/profile/page.tsx
+++ b/apps/web/app/app/(shell)/settings/profile/page.tsx
@@ -1,22 +1,8 @@
 import { redirect } from 'next/navigation';
-
 import { APP_ROUTES } from '@/constants/routes';
-import { getCachedAuth } from '@/lib/auth/cached';
-import { getDashboardData } from '../../dashboard/actions';
 
 export const runtime = 'nodejs';
 
-export default async function SettingsProfilePage() {
-  const { userId } = await getCachedAuth();
-
-  if (!userId) {
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=/app/settings/profile`);
-  }
-
-  const dashboardData = await getDashboardData();
-  if (dashboardData.needsOnboarding && !dashboardData.dashboardLoadError) {
-    redirect(APP_ROUTES.START);
-  }
-
+export default function SettingsProfilePage() {
   redirect(APP_ROUTES.SETTINGS_ARTIST_PROFILE);
 }

--- a/apps/web/tests/unit/app/settings-page.test.tsx
+++ b/apps/web/tests/unit/app/settings-page.test.tsx
@@ -1,97 +1,22 @@
-import { render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
 
-const { captureExceptionMock, getDashboardDataMock, redirectMock } = vi.hoisted(
-  () => ({
-    captureExceptionMock: vi.fn(),
-    getDashboardDataMock: vi.fn(),
-    redirectMock: vi.fn(),
-  })
-);
-
-vi.mock('@sentry/nextjs', () => ({
-  captureException: captureExceptionMock,
+const { redirectMock } = vi.hoisted(() => ({
+  redirectMock: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
   redirect: redirectMock,
 }));
 
-vi.mock('@/lib/auth/cached', () => ({
-  getCachedAuth: async () => ({ userId: 'user-1' }),
-}));
-
-vi.mock('../../../app/app/(shell)/dashboard/actions', () => ({
-  getDashboardData: getDashboardDataMock,
-}));
-
-vi.mock('@/features/dashboard/DashboardSettings', () => ({
-  DashboardSettings: () => <div data-testid='dashboard-settings' />,
-}));
-
-vi.mock('@/features/feedback/PageErrorState', () => ({
-  PageErrorState: ({ message }: { readonly message: string }) => (
-    <div data-testid='page-error-state'>{message}</div>
-  ),
-}));
-
-async function renderSettingsPage({
-  userId = 'user-1',
-}: {
-  readonly userId?: string | null;
-}) {
-  vi.resetModules();
-
-  vi.doMock('@/lib/auth/cached', () => ({
-    getCachedAuth: async () => ({ userId }),
-  }));
-
-  const { default: SettingsPage } = await import(
-    '../../../app/app/(shell)/settings/page'
-  );
-
-  return SettingsPage();
-}
-
-describe('settings page', () => {
-  afterEach(() => {
-    vi.resetAllMocks();
-    vi.resetModules();
-  });
-
-  it('renders the canonical page error state when settings data fails to load', async () => {
-    getDashboardDataMock.mockRejectedValueOnce(new Error('boom'));
-    render(await renderSettingsPage({ userId: 'user-1' }));
-
-    expect(screen.getByTestId('page-error-state')).toHaveTextContent(
-      'Failed to load settings data. Please refresh the page.'
-    );
-    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders dashboard settings when data loads successfully', async () => {
-    getDashboardDataMock.mockResolvedValueOnce({
-      needsOnboarding: false,
-      dashboardLoadError: null,
-    });
-    render(await renderSettingsPage({ userId: 'user-1' }));
-
-    expect(screen.getByTestId('dashboard-settings')).toBeInTheDocument();
-  });
-
-  it('redirects unauthenticated users to sign-in', async () => {
-    redirectMock.mockImplementation(() => {
-      throw new Error('NEXT_REDIRECT');
-    });
-
-    await expect(renderSettingsPage({ userId: null })).rejects.toThrow(
-      'NEXT_REDIRECT'
+describe('settings page aliases', () => {
+  it('redirects the settings root to the canonical account settings page', async () => {
+    const { default: SettingsPage } = await import(
+      '../../../app/app/(shell)/settings/page'
     );
 
-    expect(redirectMock).toHaveBeenCalledWith(
-      `${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.SETTINGS}`
-    );
-    expect(getDashboardDataMock).not.toHaveBeenCalled();
+    SettingsPage();
+
+    expect(redirectMock).toHaveBeenCalledWith(APP_ROUTES.SETTINGS_ACCOUNT);
   });
 });

--- a/apps/web/tests/unit/app/settings-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/settings-shell-normalization.test.ts
@@ -39,6 +39,53 @@ const RETARGETING_ROUTE_CANDIDATES = [
   ),
 ] as const;
 
+const SETTINGS_ALIAS_ROUTES = [
+  {
+    route: 'settings root',
+    expectedDestination: 'APP_ROUTES.SETTINGS_ACCOUNT',
+    filePath: findSourceFile(
+      resolve(process.cwd(), 'app/app/(shell)/settings/page.tsx'),
+      resolve(process.cwd(), 'apps/web/app/app/(shell)/settings/page.tsx')
+    ),
+  },
+  {
+    route: 'settings profile',
+    expectedDestination: 'APP_ROUTES.SETTINGS_ARTIST_PROFILE',
+    filePath: findSourceFile(
+      resolve(process.cwd(), 'app/app/(shell)/settings/profile/page.tsx'),
+      resolve(
+        process.cwd(),
+        'apps/web/app/app/(shell)/settings/profile/page.tsx'
+      )
+    ),
+  },
+  {
+    route: 'settings appearance',
+    expectedDestination: 'APP_ROUTES.SETTINGS_ACCOUNT',
+    filePath: findSourceFile(
+      resolve(process.cwd(), 'app/app/(shell)/settings/appearance/page.tsx'),
+      resolve(
+        process.cwd(),
+        'apps/web/app/app/(shell)/settings/appearance/page.tsx'
+      )
+    ),
+  },
+  {
+    route: 'settings delete-account',
+    expectedDestination: 'APP_ROUTES.SETTINGS_DATA_PRIVACY',
+    filePath: findSourceFile(
+      resolve(
+        process.cwd(),
+        'app/app/(shell)/settings/delete-account/page.tsx'
+      ),
+      resolve(
+        process.cwd(),
+        'apps/web/app/app/(shell)/settings/delete-account/page.tsx'
+      )
+    ),
+  },
+] as const;
+
 describe('settings shell normalization', () => {
   it('keeps the settings route group as the only PageShell owner', () => {
     expect(SETTINGS_LAYOUT).toBeDefined();
@@ -66,6 +113,24 @@ describe('settings shell normalization', () => {
       expect(source).not.toMatch(/import\s*\{[^}]*PageShell/);
       expect(source).not.toMatch(/<PageContent\b/);
       expect(source).not.toMatch(/import\s*\{[^}]*PageContent/);
+    }
+  });
+
+  it('keeps legacy settings aliases as lightweight route redirects', () => {
+    for (const aliasRoute of SETTINGS_ALIAS_ROUTES) {
+      expect(aliasRoute.filePath).toBeDefined();
+
+      if (!aliasRoute.filePath) {
+        throw new Error(`Could not find ${aliasRoute.route} source`);
+      }
+
+      const source = readFileSync(aliasRoute.filePath, 'utf8');
+      expect(source).toContain("import { redirect } from 'next/navigation'");
+      expect(source).toContain(`redirect(${aliasRoute.expectedDestination})`);
+      expect(source).not.toContain('getDashboardData');
+      expect(source).not.toContain('getCachedAuth');
+      expect(source).not.toContain('DashboardSettings');
+      expect(source).not.toContain('redirect_url=/app/settings');
     }
   });
 });


### PR DESCRIPTION
## Summary
- Replaced legacy settings alias pages with lightweight redirects to canonical settings routes.
- Removed duplicate auth/dashboard data fetches and hardcoded sign-in redirect URLs from those alias pages.
- Updated settings route tests/source contracts so aliases stay redirect-only and the parent settings shell remains the shell owner.

Linear: JOV-2330

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/app/settings-page.test.tsx tests/unit/app/settings-shell-normalization.test.ts tests/unit/routes/route-coverage.test.ts tests/unit/routes/shell-nav-coverage.test.ts --config=vitest.config.mts` — 10 tests passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- `pnpm run version:check` — passed
- `git diff --check` — passed
- `pnpm biome check apps/web/app/app/'(shell)'/settings/page.tsx apps/web/app/app/'(shell)'/settings/profile/page.tsx apps/web/app/app/'(shell)'/settings/appearance/page.tsx apps/web/app/app/'(shell)'/settings/delete-account/page.tsx apps/web/tests/unit/app/settings-page.test.tsx apps/web/tests/unit/app/settings-shell-normalization.test.ts` — passed
- Pre-push: Biome, proxy guard, Tailwind guard, typecheck, and lint passed

<!-- agent-run-artifact
{
  "id": "jov-2330-settings-alias-routes-c0d771a7b5cef87da54869ac663738fac5e0c5b0",
  "source": "ruflo",
  "sourceRunId": "c0d771a7b5cef87da54869ac663738fac5e0c5b0",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2330 settings alias route simplification",
  "summary": "Converted legacy settings alias pages into lightweight redirects to canonical settings routes and locked the contract with focused source tests.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "User approved autonomous shipping for non-visual shell migration slices.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2330",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2330/shell-simplify-legacy-settings-alias-routes",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/8908",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused settings route/source tests, route coverage, and shell nav coverage passed; this is a no-visual alias cleanup.",
      "checkedAt": "2026-05-17T01:52:00Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review confirmed the slice removes redundant data fetches from legacy settings aliases and redirects through APP_ROUTES constants without changing canonical settings UI, auth, billing, or data ownership.",
      "checkedAt": "2026-05-17T01:52:00Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Version check, focused tests, typecheck, diff check, Biome, commit hooks, and pre-push biome/proxy/tailwind/typecheck/lint gates passed on commit c0d771a7b5cef87da54869ac663738fac5e0c5b0.",
      "checkedAt": "2026-05-17T01:52:00Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local coding and verification only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-17T01:52:00Z",
  "updatedAt": "2026-05-17T01:52:00Z",
  "metadata": {
    "routes": ["/app/settings", "/app/settings/profile", "/app/settings/appearance", "/app/settings/delete-account"],
    "visualChange": false
  }
}
-->
