### PR TITLE
feat(perf): add hot path interaction audit harness

### DIFF
--- a/apps/web/lib/monitoring/interaction-latency.ts
+++ b/apps/web/lib/monitoring/interaction-latency.ts
@@ -1,0 +1,74 @@
+export interface InteractionLatencyMarkHandle {
+  readonly id: string;
+  readonly name: string;
+  readonly startMark: string;
+}
+
+let fallbackInteractionIdCounter = 0;
+
+function canUsePerformanceMarks() {
+  return (
+    typeof performance !== 'undefined' &&
+    typeof performance.mark === 'function' &&
+    typeof performance.measure === 'function'
+  );
+}
+
+function createInteractionId(name: string) {
+  const suffix =
+    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+      ? crypto.randomUUID()
+      : `${Date.now()}-${(fallbackInteractionIdCounter += 1)}`;
+
+  return `${name}:${suffix}`;
+}
+
+export function markInteractionStart(
+  name: string
+): InteractionLatencyMarkHandle | null {
+  if (!canUsePerformanceMarks()) {
+    return null;
+  }
+
+  const id = createInteractionId(name);
+  const startMark = `${id}:start`;
+  performance.mark(startMark);
+
+  return {
+    id,
+    name,
+    startMark,
+  };
+}
+
+export function measureInteractionPoint(
+  handle: InteractionLatencyMarkHandle | null,
+  point: string
+) {
+  if (!handle || !canUsePerformanceMarks()) {
+    return null;
+  }
+
+  const markName = `${handle.id}:${point}`;
+  const measureName = `${handle.name}:event-to-${point}`;
+  performance.mark(markName);
+  performance.measure(measureName, handle.startMark, markName);
+  return measureName;
+}
+
+export function measureInteractionNextPaint(
+  handle: InteractionLatencyMarkHandle | null,
+  point = 'first-paint'
+) {
+  if (!handle || typeof requestAnimationFrame !== 'function') {
+    return Promise.resolve(null);
+  }
+
+  return new Promise<string | null>(resolve => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        resolve(measureInteractionPoint(handle, point));
+      });
+    });
+  });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -138,6 +138,7 @@
     "test:a11y": "vitest run --config=vitest.config.storybook.mts",
     "test:visual-a11y": "pnpm run e2e:visual && pnpm run test:a11y",
     "perf:auth": "tsx scripts/performance-auth.ts",
+    "perf:interactions": "tsx scripts/performance-interaction-audit.ts",
     "perf:queue": "doppler run --project jovie-web --config dev -- tsx scripts/performance-batch-queue.ts",
     "qa:routes": "tsx scripts/route-qa.ts",
     "public:route-qa": "tsx scripts/public-route-qa.ts",

--- a/apps/web/scripts/performance-interaction-audit.ts
+++ b/apps/web/scripts/performance-interaction-audit.ts
@@ -1,0 +1,281 @@
+#!/usr/bin/env tsx
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  getFirstSliceInteractionHotPaths,
+  getInteractionHotPathManifest,
+  type InteractionTier,
+  selectInteractionHotPaths,
+} from './performance-interaction-manifest';
+import {
+  buildInteractionLatencyReport,
+  type InteractionLatencySample,
+  type InteractionRunMetadata,
+  renderInteractionLatencyMarkdown,
+} from './performance-interaction-report';
+
+export interface InteractionAuditCliOptions {
+  readonly firstSliceOnly: boolean;
+  readonly json: boolean;
+  readonly list: boolean;
+  readonly outDir: string;
+  readonly sampleFile?: string;
+  readonly scenarioIds: readonly string[];
+  readonly tiers: readonly InteractionTier[];
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const webRoot = resolve(scriptDir, '..');
+const repoRoot = resolve(webRoot, '..', '..');
+const defaultOutDir = resolve(webRoot, 'test-results', 'interaction-latency');
+
+function printHelp() {
+  console.log(
+    [
+      'Usage: pnpm --filter @jovie/web run perf:interactions -- --list',
+      '       pnpm --filter @jovie/web run perf:interactions -- --sample-file samples.json',
+      '',
+      'Options:',
+      '  --first-slice       Only include the initial P0/P1 audit scenarios',
+      '  --json              Print JSON report to stdout',
+      '  --list              Print selected scenario manifest entries',
+      '  --out-dir <path>    Output directory for report.json and report.md',
+      '  --sample-file <path> Read collected interaction samples from JSON',
+      '  --scenario-id <id>  Include a scenario id, repeatable',
+      '  --tier <P0|P1|P2>   Include a tier, repeatable',
+    ].join('\n')
+  );
+}
+
+function requireValue(args: readonly string[], index: number, option: string) {
+  const value = args[index + 1];
+  if (!value) {
+    throw new TypeError(`Missing value for ${option}`);
+  }
+  return value;
+}
+
+function resolveCliPath(value: string) {
+  const normalized = value.replaceAll('\\', '/');
+
+  if (normalized === 'apps/web' || normalized.startsWith('apps/web/')) {
+    return resolve(repoRoot, value);
+  }
+
+  return resolve(value);
+}
+
+export function parseInteractionAuditCliArgs(
+  args: readonly string[],
+  defaultOutputDir = defaultOutDir
+): InteractionAuditCliOptions {
+  const scenarioIds: string[] = [];
+  const tiers: InteractionTier[] = [];
+  let firstSliceOnly = false;
+  let json = false;
+  let list = false;
+  let outDir = defaultOutputDir;
+  let sampleFile: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--') {
+      continue;
+    }
+
+    if (arg === '--first-slice') {
+      firstSliceOnly = true;
+      continue;
+    }
+
+    if (arg === '--json') {
+      json = true;
+      continue;
+    }
+
+    if (arg === '--list') {
+      list = true;
+      continue;
+    }
+
+    if (arg === '--out-dir') {
+      outDir = resolveCliPath(requireValue(args, index, arg));
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--sample-file') {
+      sampleFile = resolveCliPath(requireValue(args, index, arg));
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--scenario-id') {
+      scenarioIds.push(requireValue(args, index, arg));
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--tier') {
+      const value = requireValue(args, index, arg);
+      if (!['P0', 'P1', 'P2'].includes(value)) {
+        throw new TypeError(`Unknown tier: ${value}`);
+      }
+      tiers.push(value as InteractionTier);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    }
+
+    throw new TypeError(`Unknown option: ${arg}`);
+  }
+
+  return {
+    firstSliceOnly,
+    json,
+    list,
+    outDir,
+    sampleFile,
+    scenarioIds,
+    tiers,
+  };
+}
+
+function readJsonFile<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+function ensureDir(path: string) {
+  mkdirSync(path, { recursive: true });
+}
+
+function normalizeSamples(raw: unknown): readonly InteractionLatencySample[] {
+  if (Array.isArray(raw)) {
+    return raw as readonly InteractionLatencySample[];
+  }
+
+  if (raw && typeof raw === 'object' && 'samples' in raw) {
+    return (raw as { readonly samples: readonly InteractionLatencySample[] })
+      .samples;
+  }
+
+  throw new TypeError(
+    'Sample file must be an array or an object with a samples array'
+  );
+}
+
+function readSamples(sampleFile: string | undefined) {
+  if (!sampleFile) {
+    return [];
+  }
+
+  if (!existsSync(sampleFile)) {
+    throw new Error(`Sample file does not exist: ${sampleFile}`);
+  }
+
+  return normalizeSamples(readJsonFile<unknown>(sampleFile));
+}
+
+function buildMetadata(options: InteractionAuditCliOptions) {
+  const metadata = {
+    authPersona: process.env.INTERACTION_AUDIT_AUTH_PERSONA,
+    baseUrl: process.env.BASE_URL,
+    browser: process.env.INTERACTION_AUDIT_BROWSER ?? 'chromium',
+    buildMode: process.env.NODE_ENV as InteractionRunMetadata['buildMode'],
+    cpuProfile: process.env.INTERACTION_AUDIT_CPU_PROFILE,
+    datasetSize: process.env.INTERACTION_AUDIT_DATASET_SIZE,
+    networkProfile: process.env.INTERACTION_AUDIT_NETWORK_PROFILE,
+    sampleCount: undefined,
+    viewport: process.env.INTERACTION_AUDIT_VIEWPORT,
+  } satisfies InteractionRunMetadata;
+
+  return {
+    ...metadata,
+    sampleCount: options.sampleFile ? undefined : 0,
+  };
+}
+
+export function runInteractionAuditReport(options: InteractionAuditCliOptions) {
+  const scenarios =
+    options.scenarioIds.length > 0 || options.tiers.length > 0
+      ? selectInteractionHotPaths({
+          firstSliceOnly: options.firstSliceOnly,
+          scenarioIds: options.scenarioIds,
+          tiers: options.tiers,
+        })
+      : options.firstSliceOnly
+        ? getFirstSliceInteractionHotPaths()
+        : getInteractionHotPathManifest();
+  const samples = readSamples(options.sampleFile);
+
+  return buildInteractionLatencyReport({
+    metadata: {
+      ...buildMetadata(options),
+      sampleCount: samples.length,
+    },
+    samples,
+    scenarios,
+  });
+}
+
+export function writeInteractionAuditArtifacts(
+  options: InteractionAuditCliOptions
+) {
+  const report = runInteractionAuditReport(options);
+  const markdown = renderInteractionLatencyMarkdown(report);
+
+  ensureDir(options.outDir);
+  writeFileSync(
+    resolve(options.outDir, 'report.json'),
+    JSON.stringify(report, null, 2) + '\n'
+  );
+  writeFileSync(resolve(options.outDir, 'report.md'), markdown);
+
+  return report;
+}
+
+async function main() {
+  const options = parseInteractionAuditCliArgs(process.argv.slice(2));
+
+  if (options.list) {
+    const scenarios = options.firstSliceOnly
+      ? getFirstSliceInteractionHotPaths()
+      : selectInteractionHotPaths({
+          scenarioIds: options.scenarioIds,
+          tiers: options.tiers,
+        });
+    const output = scenarios.map(scenario => ({
+      budget: scenario.budget,
+      id: scenario.id,
+      managerLoopProximity: scenario.managerLoopProximity,
+      route: scenario.route,
+      tier: scenario.tier,
+      title: scenario.title,
+    }));
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  const report = writeInteractionAuditArtifacts(options);
+
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  console.log(renderInteractionLatencyMarkdown(report));
+  console.error(`Wrote interaction latency artifacts to ${options.outDir}`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/apps/web/scripts/performance-interaction-audit.ts
+++ b/apps/web/scripts/performance-interaction-audit.ts
@@ -4,8 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
-  getFirstSliceInteractionHotPaths,
-  getInteractionHotPathManifest,
+  type InteractionScenarioDefinition,
   type InteractionTier,
   selectInteractionHotPaths,
 } from './performance-interaction-manifest';
@@ -24,6 +23,17 @@ export interface InteractionAuditCliOptions {
   readonly sampleFile?: string;
   readonly scenarioIds: readonly string[];
   readonly tiers: readonly InteractionTier[];
+}
+
+export interface InteractionAuditEnvironment {
+  readonly authPersona?: string;
+  readonly baseUrl?: string;
+  readonly browser?: string;
+  readonly buildMode?: InteractionRunMetadata['buildMode'];
+  readonly cpuProfile?: string;
+  readonly datasetSize?: string;
+  readonly networkProfile?: string;
+  readonly viewport?: string;
 }
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
@@ -155,14 +165,18 @@ function ensureDir(path: string) {
   mkdirSync(path, { recursive: true });
 }
 
-function normalizeSamples(raw: unknown): readonly InteractionLatencySample[] {
+export function normalizeSamples(
+  raw: unknown
+): readonly InteractionLatencySample[] {
   if (Array.isArray(raw)) {
     return raw as readonly InteractionLatencySample[];
   }
 
   if (raw && typeof raw === 'object' && 'samples' in raw) {
-    return (raw as { readonly samples: readonly InteractionLatencySample[] })
-      .samples;
+    const samples = (raw as { readonly samples?: unknown }).samples;
+    if (Array.isArray(samples)) {
+      return samples as readonly InteractionLatencySample[];
+    }
   }
 
   throw new TypeError(
@@ -182,17 +196,63 @@ function readSamples(sampleFile: string | undefined) {
   return normalizeSamples(readJsonFile<unknown>(sampleFile));
 }
 
-function buildMetadata(options: InteractionAuditCliOptions) {
+function normalizeBuildMode(
+  value: string | undefined
+): InteractionRunMetadata['buildMode'] | undefined {
+  if (
+    value === 'development' ||
+    value === 'preview' ||
+    value === 'production' ||
+    value === 'test'
+  ) {
+    return value;
+  }
+
+  return undefined;
+}
+
+export function resolveInteractionAuditEnvironment(
+  source: Readonly<Record<string, string | undefined>> = process.env
+): InteractionAuditEnvironment {
+  return {
+    authPersona: source.INTERACTION_AUDIT_AUTH_PERSONA,
+    baseUrl: source.BASE_URL,
+    browser: source.INTERACTION_AUDIT_BROWSER ?? 'chromium',
+    buildMode: normalizeBuildMode(source.NODE_ENV),
+    cpuProfile: source.INTERACTION_AUDIT_CPU_PROFILE,
+    datasetSize: source.INTERACTION_AUDIT_DATASET_SIZE,
+    networkProfile: source.INTERACTION_AUDIT_NETWORK_PROFILE,
+    viewport: source.INTERACTION_AUDIT_VIEWPORT,
+  };
+}
+
+export function selectInteractionAuditScenarios(
+  options: Pick<
+    InteractionAuditCliOptions,
+    'firstSliceOnly' | 'scenarioIds' | 'tiers'
+  >
+): readonly InteractionScenarioDefinition[] {
+  return selectInteractionHotPaths({
+    firstSliceOnly: options.firstSliceOnly,
+    scenarioIds: options.scenarioIds,
+    tiers: options.tiers,
+  });
+}
+
+function buildMetadata(
+  options: InteractionAuditCliOptions,
+  auditEnv = resolveInteractionAuditEnvironment()
+) {
   const metadata = {
-    authPersona: process.env.INTERACTION_AUDIT_AUTH_PERSONA,
-    baseUrl: process.env.BASE_URL,
-    browser: process.env.INTERACTION_AUDIT_BROWSER ?? 'chromium',
-    buildMode: process.env.NODE_ENV as InteractionRunMetadata['buildMode'],
-    cpuProfile: process.env.INTERACTION_AUDIT_CPU_PROFILE,
-    datasetSize: process.env.INTERACTION_AUDIT_DATASET_SIZE,
-    networkProfile: process.env.INTERACTION_AUDIT_NETWORK_PROFILE,
+    authPersona: auditEnv.authPersona,
+    baseUrl: auditEnv.baseUrl,
+    browser: auditEnv.browser ?? 'chromium',
+    buildMode: auditEnv.buildMode,
+    cpuProfile: auditEnv.cpuProfile,
+    datasetSize: auditEnv.datasetSize,
+    networkProfile: auditEnv.networkProfile,
     sampleCount: undefined,
-    viewport: process.env.INTERACTION_AUDIT_VIEWPORT,
+    viewport: auditEnv.viewport,
   } satisfies InteractionRunMetadata;
 
   return {
@@ -202,16 +262,7 @@ function buildMetadata(options: InteractionAuditCliOptions) {
 }
 
 export function runInteractionAuditReport(options: InteractionAuditCliOptions) {
-  const scenarios =
-    options.scenarioIds.length > 0 || options.tiers.length > 0
-      ? selectInteractionHotPaths({
-          firstSliceOnly: options.firstSliceOnly,
-          scenarioIds: options.scenarioIds,
-          tiers: options.tiers,
-        })
-      : options.firstSliceOnly
-        ? getFirstSliceInteractionHotPaths()
-        : getInteractionHotPathManifest();
+  const scenarios = selectInteractionAuditScenarios(options);
   const samples = readSamples(options.sampleFile);
 
   return buildInteractionLatencyReport({
@@ -244,12 +295,7 @@ async function main() {
   const options = parseInteractionAuditCliArgs(process.argv.slice(2));
 
   if (options.list) {
-    const scenarios = options.firstSliceOnly
-      ? getFirstSliceInteractionHotPaths()
-      : selectInteractionHotPaths({
-          scenarioIds: options.scenarioIds,
-          tiers: options.tiers,
-        });
+    const scenarios = selectInteractionAuditScenarios(options);
     const output = scenarios.map(scenario => ({
       budget: scenario.budget,
       id: scenario.id,

--- a/apps/web/scripts/performance-interaction-manifest.ts
+++ b/apps/web/scripts/performance-interaction-manifest.ts
@@ -1,0 +1,495 @@
+import { APP_ROUTES } from '../constants/routes';
+
+export type InteractionTier = 'P0' | 'P1' | 'P2';
+
+export type InteractionClass =
+  | 'audio-transport-visual-response'
+  | 'cached-route-view-switch'
+  | 'cold-view-useful-shell'
+  | 'command-palette-open'
+  | 'keyboard-selection-row-movement'
+  | 'local-ui-toggle'
+  | 'mutation-visible-feedback'
+  | 'type-to-filter-result-update';
+
+export type DataTrustClass =
+  | 'approval-critical'
+  | 'editable'
+  | 'navigational'
+  | 'playback-only';
+
+export type FeedbackSemantic =
+  | 'active'
+  | 'failure'
+  | 'optimistic'
+  | 'pending'
+  | 'pressed'
+  | 'rollback'
+  | 'stale'
+  | 'success';
+
+export type ManagerLoopProximity = 'high' | 'low' | 'medium';
+
+export type RootCauseBucket =
+  | 'audio-pipeline-delay'
+  | 'bundle-hydration-cost'
+  | 'cache-miss-no-prefetch'
+  | 'database-api-latency'
+  | 'large-dom-table-cost'
+  | 'main-thread-blocking'
+  | 'network-gated-ui'
+  | 'react-render-cascade'
+  | 'request-waterfall'
+  | 'unknown';
+
+export interface InteractionLatencyBudget {
+  readonly firstFeedbackP95Ms: number;
+  readonly usableStateP95Ms?: number;
+  readonly dataReadyP95Ms?: number;
+  readonly targetLabel: string;
+}
+
+export interface InteractionIaContract {
+  readonly trigger: string;
+  readonly focusOrigin: string;
+  readonly firstVisibleFeedback: string;
+  readonly usableState: string;
+  readonly focusDestination: string;
+  readonly escapePath: string;
+  readonly returnFocus: string;
+  readonly contextPreservation: readonly string[];
+  readonly dataTrustClass: DataTrustClass;
+  readonly feedbackSemantics: readonly FeedbackSemantic[];
+}
+
+export interface InteractionSelectors {
+  readonly firstFeedback?: string;
+  readonly focusOrigin?: string;
+  readonly usableState?: string;
+}
+
+export interface InteractionScenarioDefinition {
+  readonly id: string;
+  readonly title: string;
+  readonly tier: InteractionTier;
+  readonly route: string;
+  readonly requiresAuth: boolean;
+  readonly interactionClass: InteractionClass;
+  readonly managerLoopProximity: ManagerLoopProximity;
+  readonly expectedFrequency: 'high' | 'low' | 'medium';
+  readonly trustRisk: 'high' | 'low' | 'medium';
+  readonly budget: InteractionLatencyBudget;
+  readonly ia: InteractionIaContract;
+  readonly likelyRootCauseBuckets: readonly RootCauseBucket[];
+  readonly selectors: InteractionSelectors;
+  readonly firstSlice: boolean;
+}
+
+export const INTERACTION_CLASS_BUDGETS = {
+  'audio-transport-visual-response': {
+    firstFeedbackP95Ms: 50,
+    targetLabel: 'Audio transport visual response <=50ms p95',
+  },
+  'cached-route-view-switch': {
+    firstFeedbackP95Ms: 200,
+    usableStateP95Ms: 200,
+    targetLabel: 'Cached route/view switch <=200ms p95',
+  },
+  'cold-view-useful-shell': {
+    firstFeedbackP95Ms: 500,
+    usableStateP95Ms: 500,
+    targetLabel: 'Cold view useful shell <=500ms p95',
+  },
+  'command-palette-open': {
+    firstFeedbackP95Ms: 100,
+    usableStateP95Ms: 100,
+    targetLabel: 'Command palette open <=100ms p95',
+  },
+  'keyboard-selection-row-movement': {
+    firstFeedbackP95Ms: 50,
+    usableStateP95Ms: 50,
+    targetLabel: 'Keyboard selection / row movement <=50ms p95',
+  },
+  'local-ui-toggle': {
+    firstFeedbackP95Ms: 100,
+    usableStateP95Ms: 100,
+    targetLabel: 'Local UI toggle <=100ms p95',
+  },
+  'mutation-visible-feedback': {
+    firstFeedbackP95Ms: 100,
+    targetLabel: 'Mutation visible feedback <=100ms p95',
+  },
+  'type-to-filter-result-update': {
+    firstFeedbackP95Ms: 50,
+    usableStateP95Ms: 50,
+    targetLabel: 'Type-to-filter result update <=50ms p95',
+  },
+} as const satisfies Record<InteractionClass, InteractionLatencyBudget>;
+
+const commandPaletteIa = {
+  trigger: 'Meta+K or Ctrl+K from the app shell',
+  focusOrigin: 'Body or current shell control outside a text input',
+  firstVisibleFeedback: 'Shared command palette surface is visible',
+  usableState:
+    'Command palette search input is focused and results list exists',
+  focusDestination: 'Command palette search input',
+  escapePath: 'Escape closes the palette',
+  returnFocus: 'The element or shell region that owned focus before open',
+  contextPreservation: [
+    'current route',
+    'draft chat text',
+    'active audio state',
+  ],
+  dataTrustClass: 'navigational',
+  feedbackSemantics: ['active'],
+} as const satisfies InteractionIaContract;
+
+export const INTERACTION_HOT_PATHS = [
+  {
+    id: 'command-palette-open',
+    title: 'Command palette opens from keyboard',
+    tier: 'P0',
+    route: APP_ROUTES.DASHBOARD_RELEASES,
+    requiresAuth: true,
+    interactionClass: 'command-palette-open',
+    managerLoopProximity: 'high',
+    expectedFrequency: 'high',
+    trustRisk: 'medium',
+    budget: INTERACTION_CLASS_BUDGETS['command-palette-open'],
+    ia: commandPaletteIa,
+    likelyRootCauseBuckets: [
+      'react-render-cascade',
+      'main-thread-blocking',
+      'bundle-hydration-cost',
+    ],
+    selectors: {
+      firstFeedback: '[data-testid="shared-command-palette"]',
+      usableState: 'input[aria-label="Command palette search"]',
+    },
+    firstSlice: true,
+  },
+  {
+    id: 'command-palette-filter',
+    title: 'Command palette type-to-filter updates results',
+    tier: 'P0',
+    route: APP_ROUTES.DASHBOARD_RELEASES,
+    requiresAuth: true,
+    interactionClass: 'type-to-filter-result-update',
+    managerLoopProximity: 'high',
+    expectedFrequency: 'high',
+    trustRisk: 'medium',
+    budget: INTERACTION_CLASS_BUDGETS['type-to-filter-result-update'],
+    ia: {
+      ...commandPaletteIa,
+      trigger: 'Type a query while the command palette input is focused',
+      focusOrigin: 'Command palette search input',
+      firstVisibleFeedback: 'Result list reflects the typed query',
+      usableState: 'A matching command item is keyboard-selectable',
+      focusDestination: 'Command palette search input',
+      returnFocus: 'Command palette search input until command commit or close',
+      feedbackSemantics: ['active', 'stale'],
+    },
+    likelyRootCauseBuckets: [
+      'main-thread-blocking',
+      'react-render-cascade',
+      'network-gated-ui',
+    ],
+    selectors: {
+      firstFeedback: '[cmdk-item]',
+      focusOrigin: 'input[aria-label="Command palette search"]',
+      usableState: '[cmdk-item]',
+    },
+    firstSlice: true,
+  },
+  {
+    id: 'slash-picker-open',
+    title: 'Slash picker opens from chat composer',
+    tier: 'P0',
+    route: APP_ROUTES.CHAT,
+    requiresAuth: true,
+    interactionClass: 'local-ui-toggle',
+    managerLoopProximity: 'high',
+    expectedFrequency: 'high',
+    trustRisk: 'medium',
+    budget: INTERACTION_CLASS_BUDGETS['local-ui-toggle'],
+    ia: {
+      trigger: 'Type / in the chat composer',
+      focusOrigin: 'Chat composer textarea',
+      firstVisibleFeedback: 'Slash command menu is visible',
+      usableState: 'First slash command is keyboard-selectable',
+      focusDestination: 'Chat composer textarea with menu active',
+      escapePath: 'Escape closes the slash menu and keeps composer focus',
+      returnFocus: 'Chat composer textarea',
+      contextPreservation: ['draft chat text', 'current route', 'active panel'],
+      dataTrustClass: 'editable',
+      feedbackSemantics: ['active'],
+    },
+    likelyRootCauseBuckets: [
+      'react-render-cascade',
+      'network-gated-ui',
+      'cache-miss-no-prefetch',
+    ],
+    selectors: {
+      firstFeedback: '[data-testid="slash-command-menu"]',
+      focusOrigin: '[aria-label="Chat message input"]',
+      usableState: '[data-testid="slash-command-menu"]',
+    },
+    firstSlice: true,
+  },
+  {
+    id: 'release-table-row-move',
+    title: 'Release table arrow-key row movement',
+    tier: 'P1',
+    route: APP_ROUTES.DASHBOARD_RELEASES,
+    requiresAuth: true,
+    interactionClass: 'keyboard-selection-row-movement',
+    managerLoopProximity: 'medium',
+    expectedFrequency: 'high',
+    trustRisk: 'medium',
+    budget: INTERACTION_CLASS_BUDGETS['keyboard-selection-row-movement'],
+    ia: {
+      trigger: 'ArrowDown or ArrowUp in the release table',
+      focusOrigin: 'Currently active release row',
+      firstVisibleFeedback: 'Next release row becomes active',
+      usableState: 'Active row is visible and keyboard-selectable',
+      focusDestination: 'New active release row',
+      escapePath: 'Escape clears transient menus without losing row context',
+      returnFocus: 'Active release row',
+      contextPreservation: [
+        'scroll position',
+        'selected release',
+        'table sort',
+      ],
+      dataTrustClass: 'navigational',
+      feedbackSemantics: ['active'],
+    },
+    likelyRootCauseBuckets: [
+      'large-dom-table-cost',
+      'react-render-cascade',
+      'main-thread-blocking',
+    ],
+    selectors: {
+      firstFeedback: '[data-selected="true"], [aria-selected="true"]',
+      usableState: '[data-selected="true"], [aria-selected="true"]',
+    },
+    firstSlice: false,
+  },
+  {
+    id: 'release-drawer-open',
+    title: 'Release drawer opens from row focus',
+    tier: 'P0',
+    route: APP_ROUTES.DASHBOARD_RELEASES,
+    requiresAuth: true,
+    interactionClass: 'cached-route-view-switch',
+    managerLoopProximity: 'high',
+    expectedFrequency: 'high',
+    trustRisk: 'high',
+    budget: INTERACTION_CLASS_BUDGETS['cached-route-view-switch'],
+    ia: {
+      trigger: 'Enter on an active release row',
+      focusOrigin: 'Active release row',
+      firstVisibleFeedback:
+        'Release drawer or release detail surface starts opening',
+      usableState: 'Release drawer content is visible and focusable',
+      focusDestination:
+        'Release drawer first focusable control or content region',
+      escapePath: 'Escape closes drawer',
+      returnFocus: 'Previously active release row',
+      contextPreservation: ['selected release', 'table scroll position'],
+      dataTrustClass: 'approval-critical',
+      feedbackSemantics: ['active', 'stale', 'pending'],
+    },
+    likelyRootCauseBuckets: [
+      'cache-miss-no-prefetch',
+      'request-waterfall',
+      'database-api-latency',
+      'react-render-cascade',
+    ],
+    selectors: {
+      firstFeedback: '[data-testid="release-sidebar"], [role="dialog"]',
+      usableState: '[data-testid="release-sidebar"]',
+    },
+    firstSlice: true,
+  },
+  {
+    id: 'chat-route-cached-switch',
+    title: 'Cached route switch into chat',
+    tier: 'P0',
+    route: APP_ROUTES.CHAT,
+    requiresAuth: true,
+    interactionClass: 'cached-route-view-switch',
+    managerLoopProximity: 'high',
+    expectedFrequency: 'high',
+    trustRisk: 'medium',
+    budget: INTERACTION_CLASS_BUDGETS['cached-route-view-switch'],
+    ia: {
+      trigger: 'Keyboard command or nav action opens chat route',
+      focusOrigin: 'App shell navigation or command surface',
+      firstVisibleFeedback: 'Chat route shell or active nav state appears',
+      usableState: 'Chat composer is visible and focusable',
+      focusDestination: 'Chat composer or expected route focus target',
+      escapePath: 'Browser/app back returns to prior route',
+      returnFocus: 'Previous route shell region after back navigation',
+      contextPreservation: [
+        'active audio state',
+        'draft text where applicable',
+      ],
+      dataTrustClass: 'navigational',
+      feedbackSemantics: ['active', 'stale'],
+    },
+    likelyRootCauseBuckets: [
+      'cache-miss-no-prefetch',
+      'request-waterfall',
+      'bundle-hydration-cost',
+    ],
+    selectors: {
+      firstFeedback: '[data-testid="app-shell-scroll"], main',
+      usableState: '[aria-label="Chat message input"]',
+    },
+    firstSlice: false,
+  },
+  {
+    id: 'metadata-save-feedback',
+    title: 'Metadata save shows local feedback',
+    tier: 'P0',
+    route: APP_ROUTES.DASHBOARD_RELEASES,
+    requiresAuth: true,
+    interactionClass: 'mutation-visible-feedback',
+    managerLoopProximity: 'high',
+    expectedFrequency: 'medium',
+    trustRisk: 'high',
+    budget: INTERACTION_CLASS_BUDGETS['mutation-visible-feedback'],
+    ia: {
+      trigger: 'Save, create, edit, assign, tag, or approve action',
+      focusOrigin: 'Mutating control inside the current row, drawer, or form',
+      firstVisibleFeedback: 'Same-surface optimistic or pending state appears',
+      usableState: 'Control is acknowledged locally without losing user input',
+      focusDestination: 'Mutating control or next logical editable field',
+      escapePath: 'Undo, retry, or validation recovery where applicable',
+      returnFocus: 'Mutating control or preserved form field',
+      contextPreservation: [
+        'draft form values',
+        'selected entity',
+        'route state',
+      ],
+      dataTrustClass: 'approval-critical',
+      feedbackSemantics: [
+        'optimistic',
+        'pending',
+        'success',
+        'failure',
+        'rollback',
+      ],
+    },
+    likelyRootCauseBuckets: [
+      'network-gated-ui',
+      'database-api-latency',
+      'request-waterfall',
+    ],
+    selectors: {
+      firstFeedback:
+        '[aria-busy="true"], [data-save-state], [data-pending="true"]',
+      usableState: '[data-save-state], [data-pending="true"]',
+    },
+    firstSlice: true,
+  },
+  {
+    id: 'lyrics-toggle',
+    title: 'Lyric view toggles from keyboard',
+    tier: 'P1',
+    route: APP_ROUTES.LYRICS,
+    requiresAuth: true,
+    interactionClass: 'local-ui-toggle',
+    managerLoopProximity: 'medium',
+    expectedFrequency: 'medium',
+    trustRisk: 'low',
+    budget: INTERACTION_CLASS_BUDGETS['local-ui-toggle'],
+    ia: {
+      trigger: 'L from player or song context',
+      focusOrigin: 'Current player, song, or app-shell region',
+      firstVisibleFeedback: 'Lyrics view starts opening or closing',
+      usableState: 'Lyrics region is visible, focused, and navigable',
+      focusDestination: 'Lyrics region',
+      escapePath: 'L or Escape returns to prior context',
+      returnFocus: 'Prior player/song context',
+      contextPreservation: ['audio state', 'current lyric line', 'route state'],
+      dataTrustClass: 'editable',
+      feedbackSemantics: ['active', 'stale'],
+    },
+    likelyRootCauseBuckets: ['react-render-cascade', 'main-thread-blocking'],
+    selectors: {
+      firstFeedback: '[aria-label="Lyrics"]',
+      usableState: '[aria-label="Lyrics"]',
+    },
+    firstSlice: false,
+  },
+  {
+    id: 'audio-play-pause-visual',
+    title: 'Audio play/pause visual response',
+    tier: 'P2',
+    route: APP_ROUTES.CHAT,
+    requiresAuth: true,
+    interactionClass: 'audio-transport-visual-response',
+    managerLoopProximity: 'low',
+    expectedFrequency: 'medium',
+    trustRisk: 'medium',
+    budget: INTERACTION_CLASS_BUDGETS['audio-transport-visual-response'],
+    ia: {
+      trigger: 'Spacebar or player play/pause control',
+      focusOrigin: 'Player or app shell when a track is active',
+      firstVisibleFeedback: 'Play/pause indicator changes immediately',
+      usableState: 'Transport control remains keyboard operable',
+      focusDestination: 'Transport control or prior focused app shell region',
+      escapePath: 'Spacebar toggles state again',
+      returnFocus: 'Prior focused app shell region',
+      contextPreservation: ['current track', 'playhead', 'lyrics state'],
+      dataTrustClass: 'playback-only',
+      feedbackSemantics: ['pressed', 'active'],
+    },
+    likelyRootCauseBuckets: ['audio-pipeline-delay', 'main-thread-blocking'],
+    selectors: {
+      firstFeedback: '[aria-label*="Pause"], [aria-label*="Play"]',
+      usableState: '[aria-label*="Pause"], [aria-label*="Play"]',
+    },
+    firstSlice: false,
+  },
+] as const satisfies readonly InteractionScenarioDefinition[];
+
+export function getInteractionHotPathManifest() {
+  return [...INTERACTION_HOT_PATHS];
+}
+
+export function getFirstSliceInteractionHotPaths() {
+  return INTERACTION_HOT_PATHS.filter(scenario => scenario.firstSlice);
+}
+
+export function getInteractionHotPathById(scenarioId: string) {
+  return INTERACTION_HOT_PATHS.find(scenario => scenario.id === scenarioId);
+}
+
+export function selectInteractionHotPaths(
+  options: {
+    readonly firstSliceOnly?: boolean;
+    readonly scenarioIds?: readonly string[];
+    readonly tiers?: readonly InteractionTier[];
+  } = {}
+) {
+  const scenarioIds = new Set(options.scenarioIds ?? []);
+  const tiers = new Set(options.tiers ?? []);
+
+  return INTERACTION_HOT_PATHS.filter(scenario => {
+    if (options.firstSliceOnly && !scenario.firstSlice) {
+      return false;
+    }
+
+    if (scenarioIds.size > 0 && !scenarioIds.has(scenario.id)) {
+      return false;
+    }
+
+    if (tiers.size > 0 && !tiers.has(scenario.tier)) {
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/apps/web/scripts/performance-interaction-report.test.ts
+++ b/apps/web/scripts/performance-interaction-report.test.ts
@@ -1,7 +1,12 @@
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
-import { parseInteractionAuditCliArgs } from './performance-interaction-audit';
+import {
+  normalizeSamples,
+  parseInteractionAuditCliArgs,
+  resolveInteractionAuditEnvironment,
+  selectInteractionAuditScenarios,
+} from './performance-interaction-audit';
 import {
   getFirstSliceInteractionHotPaths,
   getInteractionHotPathById,
@@ -58,6 +63,48 @@ describe('performance interaction audit cli', () => {
         'samples.json'
       )
     );
+  });
+
+  it('rejects malformed sample envelopes with a clear error', () => {
+    expect(() => normalizeSamples({ samples: { scenarioId: 'bad' } })).toThrow(
+      'Sample file must be an array or an object with a samples array'
+    );
+  });
+
+  it('applies first-slice, scenario, and tier filters consistently', () => {
+    const scenarios = selectInteractionAuditScenarios({
+      firstSliceOnly: true,
+      scenarioIds: ['command-palette-open', 'release-table-row-move'],
+      tiers: ['P0'],
+    });
+
+    expect(scenarios.map(scenario => scenario.id)).toEqual([
+      'command-palette-open',
+    ]);
+  });
+
+  it('resolves interaction audit metadata from a typed script env snapshot', () => {
+    expect(
+      resolveInteractionAuditEnvironment({
+        BASE_URL: 'https://preview.jov.ie',
+        INTERACTION_AUDIT_AUTH_PERSONA: 'artist-manager',
+        INTERACTION_AUDIT_BROWSER: 'chromium',
+        INTERACTION_AUDIT_CPU_PROFILE: '4x',
+        INTERACTION_AUDIT_DATASET_SIZE: 'large',
+        INTERACTION_AUDIT_NETWORK_PROFILE: 'fast-4g',
+        INTERACTION_AUDIT_VIEWPORT: '1440x900',
+        NODE_ENV: 'preview',
+      })
+    ).toEqual({
+      authPersona: 'artist-manager',
+      baseUrl: 'https://preview.jov.ie',
+      browser: 'chromium',
+      buildMode: 'preview',
+      cpuProfile: '4x',
+      datasetSize: 'large',
+      networkProfile: 'fast-4g',
+      viewport: '1440x900',
+    });
   });
 });
 
@@ -123,5 +170,19 @@ describe('performance interaction report', () => {
       '| 1 | Command palette opens from keyboard | 90ms |'
     );
     expect(markdown).toContain('90ms');
+  });
+
+  it('fails closed when samples reference an unknown scenario id', () => {
+    expect(() =>
+      buildInteractionLatencyReport({
+        samples: [
+          {
+            firstFeedbackMs: 80,
+            runIndex: 0,
+            scenarioId: 'unknown-hot-path',
+          },
+        ],
+      })
+    ).toThrow('Unknown scenarioId in samples: unknown-hot-path');
   });
 });

--- a/apps/web/scripts/performance-interaction-report.test.ts
+++ b/apps/web/scripts/performance-interaction-report.test.ts
@@ -185,4 +185,19 @@ describe('performance interaction report', () => {
       })
     ).toThrow('Unknown scenarioId in samples: unknown-hot-path');
   });
+
+  it('rejects malformed next-paint timing samples', () => {
+    expect(() =>
+      buildInteractionLatencyReport({
+        samples: [
+          {
+            firstFeedbackMs: 80,
+            nextPaintMs: -1,
+            runIndex: 0,
+            scenarioId: 'command-palette-open',
+          },
+        ],
+      })
+    ).toThrow('Expected non-negative finite nextPaintMs');
+  });
 });

--- a/apps/web/scripts/performance-interaction-report.test.ts
+++ b/apps/web/scripts/performance-interaction-report.test.ts
@@ -1,0 +1,127 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { parseInteractionAuditCliArgs } from './performance-interaction-audit';
+import {
+  getFirstSliceInteractionHotPaths,
+  getInteractionHotPathById,
+} from './performance-interaction-manifest';
+import {
+  buildInteractionLatencyReport,
+  type InteractionLatencySample,
+  percentile,
+  renderInteractionLatencyMarkdown,
+} from './performance-interaction-report';
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+describe('performance interaction manifest', () => {
+  it('keeps the first slice bounded to the approved P0/P1 audit size', () => {
+    const firstSlice = getFirstSliceInteractionHotPaths();
+
+    expect(firstSlice.length).toBeGreaterThanOrEqual(3);
+    expect(firstSlice.length).toBeLessThanOrEqual(5);
+    expect(firstSlice.every(scenario => scenario.tier !== 'P2')).toBe(true);
+    expect(firstSlice.every(scenario => scenario.ia.trigger)).toBe(true);
+    expect(firstSlice.every(scenario => scenario.ia.usableState)).toBe(true);
+  });
+
+  it('stores concrete product budgets from the hot-path audit', () => {
+    expect(
+      getInteractionHotPathById('command-palette-open')?.budget
+        .firstFeedbackP95Ms
+    ).toBe(100);
+    expect(
+      getInteractionHotPathById('command-palette-filter')?.budget
+        .firstFeedbackP95Ms
+    ).toBe(50);
+  });
+});
+
+describe('performance interaction audit cli', () => {
+  it('accepts repo-root style apps/web output paths from package scripts', () => {
+    const options = parseInteractionAuditCliArgs([
+      '--out-dir',
+      'apps/web/test-results/interaction-latency-smoke',
+      '--sample-file',
+      'apps/web/test-results/interaction-latency-smoke/samples.json',
+    ]);
+
+    expect(options.outDir).toBe(
+      resolve(webRoot, 'test-results', 'interaction-latency-smoke')
+    );
+    expect(options.sampleFile).toBe(
+      resolve(
+        webRoot,
+        'test-results',
+        'interaction-latency-smoke',
+        'samples.json'
+      )
+    );
+  });
+});
+
+describe('performance interaction report', () => {
+  it('uses nearest-rank percentiles for small audit samples', () => {
+    expect(percentile([10, 20, 30, 40, 50], 50)).toBe(30);
+    expect(percentile([10, 20, 30, 40, 50], 95)).toBe(50);
+    expect(percentile([], 95)).toBeNull();
+  });
+
+  it('ranks failing manager-loop interactions ahead of passing lower risk ones', () => {
+    const samples: InteractionLatencySample[] = [
+      {
+        firstFeedbackMs: 140,
+        nextPaintMs: 18,
+        rootCauseBucket: 'react-render-cascade',
+        runIndex: 0,
+        scenarioId: 'command-palette-open',
+        usableStateMs: 160,
+      },
+      {
+        firstFeedbackMs: 28,
+        nextPaintMs: 16,
+        rootCauseBucket: 'main-thread-blocking',
+        runIndex: 0,
+        scenarioId: 'audio-play-pause-visual',
+        usableStateMs: 32,
+      },
+    ];
+
+    const report = buildInteractionLatencyReport({
+      generatedAt: '2026-05-17T00:00:00.000Z',
+      samples,
+    });
+
+    expect(report.status).toBe('fail');
+    expect(report.summaries[0]?.scenario.id).toBe('command-palette-open');
+    expect(report.summaries[0]?.p95NextPaintMs).toBe(18);
+    expect(report.summaries[0]?.passed).toBe(false);
+    expect(report.summaries[1]?.passed).toBe(true);
+  });
+
+  it('renders the requested ranked markdown table shape', () => {
+    const report = buildInteractionLatencyReport({
+      generatedAt: '2026-05-17T00:00:00.000Z',
+      samples: [
+        {
+          cacheStatus: 'hit',
+          firstFeedbackMs: 80,
+          rootCauseBucket: 'unknown',
+          runIndex: 0,
+          scenarioId: 'command-palette-open',
+          usableStateMs: 90,
+        },
+      ],
+    });
+
+    const markdown = renderInteractionLatencyMarkdown(report);
+
+    expect(markdown).toContain('| Rank | Hot path | Current p95 |');
+    expect(markdown).toContain('Command palette opens from keyboard');
+    expect(markdown).toContain(
+      '| 1 | Command palette opens from keyboard | 90ms |'
+    );
+    expect(markdown).toContain('90ms');
+  });
+});

--- a/apps/web/scripts/performance-interaction-report.ts
+++ b/apps/web/scripts/performance-interaction-report.ts
@@ -152,6 +152,9 @@ function summarizeScenario(
 ): InteractionScenarioSummary {
   for (const sample of samples) {
     assertFiniteSampleValue(sample.firstFeedbackMs, 'firstFeedbackMs');
+    if (sample.nextPaintMs !== undefined) {
+      assertFiniteSampleValue(sample.nextPaintMs, 'nextPaintMs');
+    }
     if (sample.usableStateMs !== undefined) {
       assertFiniteSampleValue(sample.usableStateMs, 'usableStateMs');
     }

--- a/apps/web/scripts/performance-interaction-report.ts
+++ b/apps/web/scripts/performance-interaction-report.ts
@@ -1,0 +1,342 @@
+import {
+  getInteractionHotPathById,
+  type InteractionScenarioDefinition,
+  type RootCauseBucket,
+} from './performance-interaction-manifest';
+
+export type InteractionCacheStatus = 'hit' | 'miss' | 'mixed' | 'unknown';
+
+export interface InteractionLatencySample {
+  readonly scenarioId: string;
+  readonly runIndex: number;
+  readonly firstFeedbackMs: number;
+  readonly nextPaintMs?: number;
+  readonly usableStateMs?: number;
+  readonly dataReadyMs?: number;
+  readonly reactCommitMs?: number;
+  readonly longTaskCount?: number;
+  readonly networkRequestCount?: number;
+  readonly requestWaterfallCount?: number;
+  readonly cacheStatus?: InteractionCacheStatus;
+  readonly rootCauseBucket?: RootCauseBucket;
+}
+
+export interface InteractionRunMetadata {
+  readonly authPersona?: string;
+  readonly baseUrl?: string;
+  readonly browser?: string;
+  readonly buildMode?: 'development' | 'preview' | 'production' | 'test';
+  readonly cpuProfile?: string;
+  readonly datasetSize?: string;
+  readonly networkProfile?: string;
+  readonly sampleCount?: number;
+  readonly viewport?: string;
+}
+
+export interface InteractionScenarioSummary {
+  readonly scenario: InteractionScenarioDefinition;
+  readonly samples: readonly InteractionLatencySample[];
+  readonly sampleCount: number;
+  readonly p50FirstFeedbackMs: number | null;
+  readonly p75FirstFeedbackMs: number | null;
+  readonly p95FirstFeedbackMs: number | null;
+  readonly p95NextPaintMs: number | null;
+  readonly p95UsableStateMs: number | null;
+  readonly p95DataReadyMs: number | null;
+  readonly worstFirstFeedbackMs: number | null;
+  readonly targetP95Ms: number;
+  readonly passed: boolean | null;
+  readonly rootCauseBucket: RootCauseBucket;
+  readonly cacheStatus: InteractionCacheStatus;
+  readonly requestWaterfallCount: number;
+  readonly userImpact: string;
+  readonly expectedImpact: string;
+  readonly effort: 'L' | 'M' | 'S' | 'XL' | 'XS';
+  readonly confidence: 'High' | 'Low' | 'Med';
+}
+
+export interface InteractionLatencyReport {
+  readonly generatedAt: string;
+  readonly metadata: InteractionRunMetadata;
+  readonly summaries: readonly InteractionScenarioSummary[];
+  readonly status: 'fail' | 'pass' | 'pending';
+}
+
+function assertFiniteSampleValue(value: number, label: string) {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new TypeError(`Expected non-negative finite ${label}`);
+  }
+}
+
+export function percentile(values: readonly number[], p: number) {
+  if (values.length === 0) {
+    return null;
+  }
+
+  if (!Number.isFinite(p) || p < 0 || p > 100) {
+    throw new TypeError('Expected percentile between 0 and 100');
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.max(0, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[index] ?? null;
+}
+
+function compactNumbers(values: readonly Array<number | undefined>) {
+  return values.filter((value): value is number => typeof value === 'number');
+}
+
+function mode<T extends string>(values: readonly T[], fallback: T): T {
+  if (values.length === 0) {
+    return fallback;
+  }
+
+  const counts = new Map<T, number>();
+  for (const value of values) {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+
+  return (
+    [...counts.entries()].sort((left, right) => right[1] - left[1])[0]?.[0] ??
+    fallback
+  );
+}
+
+function deriveUserImpact(scenario: InteractionScenarioDefinition) {
+  if (scenario.managerLoopProximity === 'high') {
+    return 'Core manager-loop workflow feels blocked';
+  }
+
+  if (scenario.expectedFrequency === 'high') {
+    return 'Power-user keyboard flow feels heavy';
+  }
+
+  return 'Protected interaction loses perceived snappiness';
+}
+
+function deriveExpectedImpact(summary: {
+  readonly passed: boolean | null;
+  readonly scenario: InteractionScenarioDefinition;
+}) {
+  if (summary.passed === true) {
+    return 'Protect with regression coverage';
+  }
+
+  if (summary.scenario.tier === 'P0') {
+    return 'High perceived-speed improvement if fixed';
+  }
+
+  return 'Medium perceived-speed improvement if fixed';
+}
+
+function deriveEffort(
+  scenario: InteractionScenarioDefinition
+): 'L' | 'M' | 'S' | 'XL' | 'XS' {
+  if (
+    scenario.likelyRootCauseBuckets.includes('database-api-latency') ||
+    scenario.likelyRootCauseBuckets.includes('request-waterfall')
+  ) {
+    return 'M';
+  }
+
+  if (scenario.likelyRootCauseBuckets.includes('bundle-hydration-cost')) {
+    return 'L';
+  }
+
+  return 'S';
+}
+
+function summarizeScenario(
+  scenario: InteractionScenarioDefinition,
+  samples: readonly InteractionLatencySample[]
+): InteractionScenarioSummary {
+  for (const sample of samples) {
+    assertFiniteSampleValue(sample.firstFeedbackMs, 'firstFeedbackMs');
+    if (sample.usableStateMs !== undefined) {
+      assertFiniteSampleValue(sample.usableStateMs, 'usableStateMs');
+    }
+    if (sample.dataReadyMs !== undefined) {
+      assertFiniteSampleValue(sample.dataReadyMs, 'dataReadyMs');
+    }
+  }
+
+  const firstFeedbackValues = samples.map(sample => sample.firstFeedbackMs);
+  const nextPaintValues = compactNumbers(
+    samples.map(sample => sample.nextPaintMs)
+  );
+  const usableStateValues = compactNumbers(
+    samples.map(sample => sample.usableStateMs)
+  );
+  const dataReadyValues = compactNumbers(
+    samples.map(sample => sample.dataReadyMs)
+  );
+  const p95FirstFeedbackMs = percentile(firstFeedbackValues, 95);
+  const p95UsableStateMs = percentile(usableStateValues, 95);
+  const p95DataReadyMs = percentile(dataReadyValues, 95);
+  const targetP95Ms =
+    scenario.budget.usableStateP95Ms ?? scenario.budget.firstFeedbackP95Ms;
+  const measuredP95 = p95UsableStateMs ?? p95FirstFeedbackMs;
+  const passed = measuredP95 === null ? null : measuredP95 <= targetP95Ms;
+  const rootCauseBucket = mode(
+    compactStrings(samples.map(sample => sample.rootCauseBucket)),
+    'unknown'
+  );
+  const cacheStatus = mode(
+    compactStrings(samples.map(sample => sample.cacheStatus)),
+    'unknown'
+  );
+
+  const summary = {
+    scenario,
+    samples,
+    sampleCount: samples.length,
+    p50FirstFeedbackMs: percentile(firstFeedbackValues, 50),
+    p75FirstFeedbackMs: percentile(firstFeedbackValues, 75),
+    p95FirstFeedbackMs,
+    p95NextPaintMs: percentile(nextPaintValues, 95),
+    p95UsableStateMs,
+    p95DataReadyMs,
+    worstFirstFeedbackMs: percentile(firstFeedbackValues, 100),
+    targetP95Ms,
+    passed,
+    rootCauseBucket,
+    cacheStatus,
+    requestWaterfallCount: Math.max(
+      0,
+      ...samples.map(sample => sample.requestWaterfallCount ?? 0)
+    ),
+    userImpact: deriveUserImpact(scenario),
+    expectedImpact: '',
+    effort: deriveEffort(scenario),
+    confidence:
+      samples.length >= 15 ? 'High' : samples.length >= 5 ? 'Med' : 'Low',
+  } satisfies Omit<InteractionScenarioSummary, 'expectedImpact'> & {
+    readonly expectedImpact: '';
+  };
+
+  return {
+    ...summary,
+    expectedImpact: deriveExpectedImpact(summary),
+  };
+}
+
+function compactStrings<T extends string>(
+  values: readonly Array<T | undefined>
+) {
+  return values.filter((value): value is T => typeof value === 'string');
+}
+
+function rankSummary(summary: InteractionScenarioSummary) {
+  const tierWeight =
+    summary.scenario.tier === 'P0' ? 3 : summary.scenario.tier === 'P1' ? 2 : 1;
+  const proximityWeight =
+    summary.scenario.managerLoopProximity === 'high'
+      ? 3
+      : summary.scenario.managerLoopProximity === 'medium'
+        ? 2
+        : 1;
+  const trustWeight =
+    summary.scenario.trustRisk === 'high'
+      ? 3
+      : summary.scenario.trustRisk === 'medium'
+        ? 2
+        : 1;
+  const measured = summary.p95UsableStateMs ?? summary.p95FirstFeedbackMs ?? 0;
+  const overshoot = Math.max(0, measured - summary.targetP95Ms);
+  return (
+    overshoot * 10 + tierWeight * 100 + proximityWeight * 50 + trustWeight * 25
+  );
+}
+
+export function buildInteractionLatencyReport(options: {
+  readonly generatedAt?: string;
+  readonly metadata?: InteractionRunMetadata;
+  readonly samples: readonly InteractionLatencySample[];
+  readonly scenarios?: readonly InteractionScenarioDefinition[];
+}): InteractionLatencyReport {
+  const scenarios =
+    options.scenarios ??
+    [...new Set(options.samples.map(sample => sample.scenarioId))]
+      .map(scenarioId => getInteractionHotPathById(scenarioId))
+      .filter(
+        (scenario): scenario is InteractionScenarioDefinition =>
+          scenario !== undefined
+      );
+
+  const summaries = scenarios
+    .map(scenario =>
+      summarizeScenario(
+        scenario,
+        options.samples.filter(sample => sample.scenarioId === scenario.id)
+      )
+    )
+    .sort((left, right) => rankSummary(right) - rankSummary(left));
+
+  const measuredSummaries = summaries.filter(
+    summary => summary.passed !== null
+  );
+  const hasFailure = measuredSummaries.some(
+    summary => summary.passed === false
+  );
+
+  return {
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    metadata: options.metadata ?? {},
+    summaries,
+    status:
+      measuredSummaries.length === 0 ? 'pending' : hasFailure ? 'fail' : 'pass',
+  };
+}
+
+function formatMs(value: number | null) {
+  return value === null ? 'n/a' : `${Math.round(value)}ms`;
+}
+
+function formatMetadata(metadata: InteractionRunMetadata) {
+  const entries = Object.entries(metadata).filter(
+    ([, value]) => value !== undefined && value !== ''
+  );
+
+  if (entries.length === 0) {
+    return '_No run metadata supplied._';
+  }
+
+  return entries.map(([key, value]) => `- ${key}: ${String(value)}`).join('\n');
+}
+
+export function renderInteractionLatencyMarkdown(
+  report: InteractionLatencyReport
+) {
+  const rows = report.summaries.map(
+    (summary, index) =>
+      `| ${[
+        String(index + 1),
+        summary.scenario.title,
+        formatMs(summary.p95UsableStateMs ?? summary.p95FirstFeedbackMs),
+        `${summary.targetP95Ms}ms`,
+        summary.userImpact,
+        summary.rootCauseBucket,
+        summary.expectedImpact,
+        summary.effort,
+        summary.confidence,
+      ].join(' | ')} |`
+  );
+
+  return [
+    '# Hot Path Interaction Latency Audit',
+    '',
+    `Generated: ${report.generatedAt}`,
+    `Status: ${report.status}`,
+    '',
+    '## Run Metadata',
+    '',
+    formatMetadata(report.metadata),
+    '',
+    '## Ranked Interactions',
+    '',
+    '| Rank | Hot path | Current p95 | Target p95 | User impact | Root cause | Fix | Effort | Confidence |',
+    '| ---: | --- | ---: | ---: | --- | --- | --- | --- | --- |',
+    ...rows,
+    '',
+  ].join('\n');
+}

--- a/apps/web/scripts/performance-interaction-report.ts
+++ b/apps/web/scripts/performance-interaction-report.ts
@@ -248,6 +248,33 @@ function rankSummary(summary: InteractionScenarioSummary) {
   );
 }
 
+function resolveScenariosFromSamples(
+  samples: readonly InteractionLatencySample[]
+) {
+  const scenarioIds = [...new Set(samples.map(sample => sample.scenarioId))];
+  const scenarios: InteractionScenarioDefinition[] = [];
+  const unknownScenarioIds: string[] = [];
+
+  for (const scenarioId of scenarioIds) {
+    const scenario = getInteractionHotPathById(scenarioId);
+
+    if (!scenario) {
+      unknownScenarioIds.push(scenarioId);
+      continue;
+    }
+
+    scenarios.push(scenario);
+  }
+
+  if (unknownScenarioIds.length > 0) {
+    throw new TypeError(
+      `Unknown scenarioId in samples: ${unknownScenarioIds.join(', ')}`
+    );
+  }
+
+  return scenarios;
+}
+
 export function buildInteractionLatencyReport(options: {
   readonly generatedAt?: string;
   readonly metadata?: InteractionRunMetadata;
@@ -255,13 +282,7 @@ export function buildInteractionLatencyReport(options: {
   readonly scenarios?: readonly InteractionScenarioDefinition[];
 }): InteractionLatencyReport {
   const scenarios =
-    options.scenarios ??
-    [...new Set(options.samples.map(sample => sample.scenarioId))]
-      .map(scenarioId => getInteractionHotPathById(scenarioId))
-      .filter(
-        (scenario): scenario is InteractionScenarioDefinition =>
-          scenario !== undefined
-      );
+    options.scenarios ?? resolveScenariosFromSamples(options.samples);
 
   const summaries = scenarios
     .map(scenario =>

--- a/apps/web/tests/e2e/performance/interaction-latency-utils.spec.ts
+++ b/apps/web/tests/e2e/performance/interaction-latency-utils.spec.ts
@@ -35,4 +35,78 @@ test.describe('interaction latency measurement helper', () => {
     expect(sample.nextPaintMs).toBeLessThanOrEqual(sample.firstFeedbackMs);
     expect(sample.usableStateMs).toBeGreaterThanOrEqual(sample.firstFeedbackMs);
   });
+
+  test('disconnects and resets the long-task observer between measurements', async ({
+    page,
+  }) => {
+    await page.setContent('<main>Ready</main>');
+    await page.evaluate(() => {
+      const stateWindow = window as Window & {
+        __jovieDisconnectCount?: number;
+        __jovieObserverActive?: boolean;
+      };
+
+      class TestPerformanceObserver {
+        private readonly callback: PerformanceObserverCallback;
+
+        constructor(callback: PerformanceObserverCallback) {
+          this.callback = callback;
+        }
+
+        observe() {
+          stateWindow.__jovieObserverActive = true;
+          this.callback(
+            {
+              getEntries: () =>
+                [
+                  {
+                    duration: 12,
+                    startTime: performance.now(),
+                  },
+                ] as PerformanceEntry[],
+            } as unknown as PerformanceObserverEntryList,
+            this as unknown as PerformanceObserver
+          );
+        }
+
+        disconnect() {
+          stateWindow.__jovieDisconnectCount =
+            (stateWindow.__jovieDisconnectCount ?? 0) + 1;
+          stateWindow.__jovieObserverActive = false;
+        }
+      }
+
+      Object.defineProperty(window, 'PerformanceObserver', {
+        configurable: true,
+        value: TestPerformanceObserver,
+      });
+    });
+
+    const first = await measureInteractionLatency(page, {
+      action: () => page.evaluate(() => undefined),
+      firstFeedback: async () => undefined,
+      scenarioId: 'synthetic-first-feedback',
+    });
+    const second = await measureInteractionLatency(page, {
+      action: () => page.evaluate(() => undefined),
+      firstFeedback: async () => undefined,
+      scenarioId: 'synthetic-first-feedback',
+    });
+
+    const observerState = await page.evaluate(() => {
+      const stateWindow = window as Window & {
+        __jovieDisconnectCount?: number;
+        __jovieObserverActive?: boolean;
+      };
+      return {
+        disconnectCount: stateWindow.__jovieDisconnectCount ?? 0,
+        observerActive: stateWindow.__jovieObserverActive ?? false,
+      };
+    });
+
+    expect(first.longTaskCount).toBe(1);
+    expect(second.longTaskCount).toBe(1);
+    expect(observerState.disconnectCount).toBe(2);
+    expect(observerState.observerActive).toBe(false);
+  });
 });

--- a/apps/web/tests/e2e/performance/interaction-latency-utils.spec.ts
+++ b/apps/web/tests/e2e/performance/interaction-latency-utils.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+import { measureInteractionLatency } from '../utils/interaction-latency-utils';
+
+test.describe('interaction latency measurement helper', () => {
+  test('measures event to first feedback and usable state in the browser', async ({
+    page,
+  }) => {
+    await page.setContent(`
+      <button id="trigger" type="button">Trigger</button>
+      <div id="feedback" hidden>Feedback</div>
+      <script>
+        document.querySelector('#trigger').addEventListener('click', () => {
+          setTimeout(() => {
+            document.querySelector('#feedback').hidden = false;
+            document.querySelector('#feedback').setAttribute('data-usable', 'true');
+          }, 50);
+        });
+      </script>
+    `);
+
+    const sample = await measureInteractionLatency(page, {
+      action: () => page.locator('#trigger').click(),
+      firstFeedback: () => expect(page.locator('#feedback')).toBeVisible(),
+      scenarioId: 'synthetic-first-feedback',
+      usableState: () =>
+        expect(page.locator('#feedback')).toHaveAttribute(
+          'data-usable',
+          'true'
+        ),
+    });
+
+    expect(sample.firstFeedbackMs).toBeGreaterThanOrEqual(45);
+    expect(sample.firstFeedbackMs).toBeLessThan(500);
+    expect(sample.nextPaintMs).toBeGreaterThanOrEqual(0);
+    expect(sample.nextPaintMs).toBeLessThanOrEqual(sample.firstFeedbackMs);
+    expect(sample.usableStateMs).toBeGreaterThanOrEqual(sample.firstFeedbackMs);
+  });
+});

--- a/apps/web/tests/e2e/utils/interaction-latency-utils.ts
+++ b/apps/web/tests/e2e/utils/interaction-latency-utils.ts
@@ -2,6 +2,7 @@ import type { Page } from '@playwright/test';
 import type { InteractionLatencySample } from '@/scripts/performance-interaction-report';
 
 interface InteractionLatencyPageWindow extends Window {
+  __jovieInteractionLatencyLongTaskObserver?: PerformanceObserver;
   __jovieInteractionLatencyLongTasks?: number[];
 }
 
@@ -28,21 +29,33 @@ async function waitForNextPaint(page: Page, startTime: number) {
 async function installLongTaskObserver(page: Page) {
   await page.evaluate(() => {
     const latencyWindow = window as InteractionLatencyPageWindow;
+    latencyWindow.__jovieInteractionLatencyLongTaskObserver?.disconnect();
     latencyWindow.__jovieInteractionLatencyLongTasks = [];
+    const installTime = performance.now();
 
     try {
       const observer = new PerformanceObserver(list => {
         const tasks = latencyWindow.__jovieInteractionLatencyLongTasks ?? [];
         for (const entry of list.getEntries()) {
-          tasks.push(entry.duration);
+          if (entry.startTime >= installTime) {
+            tasks.push(entry.duration);
+          }
         }
         latencyWindow.__jovieInteractionLatencyLongTasks = tasks;
       });
-      observer.observe({ type: 'longtask', buffered: true });
-      setTimeout(() => observer.disconnect(), 30_000);
+      observer.observe({ type: 'longtask' });
+      latencyWindow.__jovieInteractionLatencyLongTaskObserver = observer;
     } catch {
       // Some browsers do not support longtask observers.
     }
+  });
+}
+
+async function uninstallLongTaskObserver(page: Page) {
+  await page.evaluate(() => {
+    const latencyWindow = window as InteractionLatencyPageWindow;
+    latencyWindow.__jovieInteractionLatencyLongTaskObserver?.disconnect();
+    latencyWindow.__jovieInteractionLatencyLongTaskObserver = undefined;
   });
 }
 
@@ -60,23 +73,27 @@ export async function measureInteractionLatency(
   await installLongTaskObserver(page);
   const startTime = await page.evaluate(() => performance.now());
 
-  await options.action();
-  const nextPaintMs = await waitForNextPaint(page, startTime);
-  await options.firstFeedback();
-  const firstFeedbackMs = await waitForNextPaint(page, startTime);
+  try {
+    await options.action();
+    const nextPaintMs = await waitForNextPaint(page, startTime);
+    await options.firstFeedback();
+    const firstFeedbackMs = await waitForNextPaint(page, startTime);
 
-  let usableStateMs: number | undefined;
-  if (options.usableState) {
-    await options.usableState();
-    usableStateMs = await waitForNextPaint(page, startTime);
+    let usableStateMs: number | undefined;
+    if (options.usableState) {
+      await options.usableState();
+      usableStateMs = await waitForNextPaint(page, startTime);
+    }
+
+    return {
+      firstFeedbackMs,
+      longTaskCount: await getLongTaskCount(page),
+      nextPaintMs,
+      runIndex: options.runIndex ?? 0,
+      scenarioId: options.scenarioId,
+      usableStateMs,
+    };
+  } finally {
+    await uninstallLongTaskObserver(page);
   }
-
-  return {
-    firstFeedbackMs,
-    longTaskCount: await getLongTaskCount(page),
-    nextPaintMs,
-    runIndex: options.runIndex ?? 0,
-    scenarioId: options.scenarioId,
-    usableStateMs,
-  };
 }

--- a/apps/web/tests/e2e/utils/interaction-latency-utils.ts
+++ b/apps/web/tests/e2e/utils/interaction-latency-utils.ts
@@ -1,0 +1,82 @@
+import type { Page } from '@playwright/test';
+import type { InteractionLatencySample } from '@/scripts/performance-interaction-report';
+
+interface InteractionLatencyPageWindow extends Window {
+  __jovieInteractionLatencyLongTasks?: number[];
+}
+
+export interface MeasureInteractionLatencyOptions {
+  readonly action: () => Promise<void>;
+  readonly firstFeedback: () => Promise<void>;
+  readonly runIndex?: number;
+  readonly scenarioId: string;
+  readonly usableState?: () => Promise<void>;
+}
+
+async function waitForNextPaint(page: Page, startTime: number) {
+  return page.evaluate(start => {
+    return new Promise<number>(resolve => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          resolve(performance.now() - start);
+        });
+      });
+    });
+  }, startTime);
+}
+
+async function installLongTaskObserver(page: Page) {
+  await page.evaluate(() => {
+    const latencyWindow = window as InteractionLatencyPageWindow;
+    latencyWindow.__jovieInteractionLatencyLongTasks = [];
+
+    try {
+      const observer = new PerformanceObserver(list => {
+        const tasks = latencyWindow.__jovieInteractionLatencyLongTasks ?? [];
+        for (const entry of list.getEntries()) {
+          tasks.push(entry.duration);
+        }
+        latencyWindow.__jovieInteractionLatencyLongTasks = tasks;
+      });
+      observer.observe({ type: 'longtask', buffered: true });
+      setTimeout(() => observer.disconnect(), 30_000);
+    } catch {
+      // Some browsers do not support longtask observers.
+    }
+  });
+}
+
+async function getLongTaskCount(page: Page) {
+  return page.evaluate(() => {
+    const latencyWindow = window as InteractionLatencyPageWindow;
+    return latencyWindow.__jovieInteractionLatencyLongTasks?.length ?? 0;
+  });
+}
+
+export async function measureInteractionLatency(
+  page: Page,
+  options: MeasureInteractionLatencyOptions
+): Promise<InteractionLatencySample> {
+  await installLongTaskObserver(page);
+  const startTime = await page.evaluate(() => performance.now());
+
+  await options.action();
+  const nextPaintMs = await waitForNextPaint(page, startTime);
+  await options.firstFeedback();
+  const firstFeedbackMs = await waitForNextPaint(page, startTime);
+
+  let usableStateMs: number | undefined;
+  if (options.usableState) {
+    await options.usableState();
+    usableStateMs = await waitForNextPaint(page, startTime);
+  }
+
+  return {
+    firstFeedbackMs,
+    longTaskCount: await getLongTaskCount(page),
+    nextPaintMs,
+    runIndex: options.runIndex ?? 0,
+    scenarioId: options.scenarioId,
+    usableStateMs,
+  };
+}


### PR DESCRIPTION
## Summary
- Add a first-slice Hot Path Interaction Latency manifest for command palette, slash picker, release drawer, and metadata-save feedback workflows.
- Add `perf:interactions` report generation for JSON/Markdown ranked audit tables, with sample ingestion and p50/p75/p95 summary logic.
- Add lightweight Performance API mark helpers plus a Playwright helper that measures next paint, first visible feedback, usable state, and long-task count.

## Evidence

gstack.qa.exhaustive:
- `pnpm --filter @jovie/web exec vitest run scripts/performance-interaction-report.test.ts` PASS
- `E2E_SKIP_WEB_SERVER=1 pnpm --filter @jovie/web exec playwright test tests/e2e/performance/interaction-latency-utils.spec.ts --project=chromium` PASS
- `pnpm --filter @jovie/web run perf:interactions -- --first-slice --json --out-dir apps/web/test-results/interaction-latency-smoke` PASS, wrote `report.json` and `report.md`

gstack.review:
- `git diff --check` PASS
- First-slice manifest checked: `command-palette-open`, `command-palette-filter`, `slash-picker-open`, `release-drawer-open`, `metadata-save-feedback`
- Review fix applied: repo-root-style `apps/web/...` output paths no longer create nested `apps/web/apps/web/...` artifacts
- Sonar hotspot fix applied: non-crypto fallback mark IDs use a monotonic counter, not `Math.random()`

gstack.ship:
- Rebased on `origin/main` at `16c150b3a`
- Commit: `ea21c1b87 feat(perf): add hot path interaction audit harness`
- Push hook PASS: Biome, proxy guard, Tailwind guard, typecheck, lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interaction-latency monitoring with start/point/next-paint measurements.
  * Added a CLI to run interaction-latency audits, produce JSON/markdown reports, and write artifacts.
  * Introduced a hot‑path interaction manifest and reporting that computes percentiles, ranked summaries, and pass/fail/pending status with impact/effort/confidence guidance.
  * Added a npm script to run interaction audits.

* **Tests**
  * Added unit and end-to-end tests and Playwright utilities validating manifest selection, CLI args, report generation, and runtime latency measurement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->