### PR TITLE
test(public-profile): daily canary + admin ops surface (JOV-1872)

### DIFF
--- a/apps/web/app/api/cron/public-profile-canary/route.ts
+++ b/apps/web/app/api/cron/public-profile-canary/route.ts
@@ -34,6 +34,7 @@ import {
   buildVisitPayload,
   CANARY_AUDIENCE_VISIT_PATH,
   CANARY_CREATOR_HANDLE,
+  CANARY_REDIS_KEY,
   CANARY_ROUTES,
   type CanaryReport,
   checkHttpGet,
@@ -48,7 +49,6 @@ import { logger } from '@/lib/utils/logger';
 export const runtime = 'nodejs';
 export const maxDuration = 30;
 
-export const CANARY_REDIS_KEY = 'canary:public_profile:last_run';
 /** 26 hours so the key persists through a brief cron delay. */
 const CANARY_REDIS_TTL_SECONDS = 26 * 60 * 60;
 

--- a/apps/web/app/api/cron/public-profile-canary/route.ts
+++ b/apps/web/app/api/cron/public-profile-canary/route.ts
@@ -1,0 +1,197 @@
+/**
+ * Public-profile canary cron (JOV-1872)
+ *
+ * Runs daily at 06:13 UTC (off-peak — ~11 PM PT / late evening Tim time).
+ *
+ * PURPOSE: Lightweight HTTP-level check that the canonical public profile
+ * surface (/tim, /tim/alerts, /api/audience/visit) is healthy in production.
+ * This is the production-monitoring half of the Reliability Every-Bug-Becomes-a-Detector
+ * loop (JOV-1855). The full Playwright canary spec runs in nightly CI.
+ *
+ * CHECKS (see lib/canaries/public-profile.ts for implementation):
+ *  1. GET /tim           — 200, no server error body
+ *  2. GET /tim/alerts    — 200, no server error body
+ *  3. GET /tim/pay       — 200 (follows 307 redirect), no server error body
+ *  4. POST /api/audience/visit — 2xx or 429 (rate-limited is healthy)
+ *
+ * OUTPUT: Structured Sentry breadcrumb with tag `canary.public_profile=pass|fail`.
+ * The admin ops panel reads the canary status from a short-lived Redis key
+ * written by this route (TTL: 26h so the panel always has a recent result even
+ * if the cron is briefly late).
+ *
+ * Cost impact: 4 HTTP calls/day to production. ~$0/month. No external service
+ * dependency beyond the existing Sentry + Redis clients.
+ *
+ * Schedule: `13 6 * * *` (configured in vercel.json per JOV-1872 approval)
+ *
+ * @see .claude/rules/infra.md — explicit approval from JOV-1872 acceptance criteria
+ */
+
+import * as Sentry from '@sentry/nextjs';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  buildReport,
+  buildVisitPayload,
+  CANARY_AUDIENCE_VISIT_PATH,
+  CANARY_CREATOR_HANDLE,
+  CANARY_ROUTES,
+  type CanaryReport,
+  checkHttpGet,
+  checkHttpPost,
+  formatReportSummary,
+} from '@/lib/canaries/public-profile';
+import { verifyCronRequest } from '@/lib/cron/auth';
+import { captureError } from '@/lib/error-tracking';
+import { getRedis } from '@/lib/redis';
+import { logger } from '@/lib/utils/logger';
+
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
+export const CANARY_REDIS_KEY = 'canary:public_profile:last_run';
+/** 26 hours so the key persists through a brief cron delay. */
+const CANARY_REDIS_TTL_SECONDS = 26 * 60 * 60;
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+/**
+ * Resolve the production base URL from the request or fall back to the
+ * canonical production host. We never probe the canary against a preview URL —
+ * it must always hit production.
+ */
+function resolveProductionBaseUrl(): string {
+  return 'https://jov.ie';
+}
+
+/**
+ * Write the canary result to Redis so the admin ops panel can surface it
+ * without an API call per page load.
+ */
+async function persistCanaryResult(report: CanaryReport): Promise<void> {
+  const redis = getRedis();
+  if (!redis) {
+    logger.warn(
+      '[canary/public-profile] Redis unavailable — skipping persistence'
+    );
+    return;
+  }
+
+  try {
+    await redis.set(CANARY_REDIS_KEY, JSON.stringify(report), {
+      ex: CANARY_REDIS_TTL_SECONDS,
+    });
+  } catch (err) {
+    // Non-critical — the Sentry breadcrumb is the primary signal
+    logger.warn(
+      '[canary/public-profile] Failed to write Redis canary key',
+      err
+    );
+  }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const authError = verifyCronRequest(request, {
+    route: '/api/cron/public-profile-canary',
+    allowDevelopmentBypass: true,
+  });
+  if (authError) return authError;
+
+  const runAt = new Date().toISOString();
+  const wallStart = Date.now();
+  const base = resolveProductionBaseUrl();
+
+  try {
+    const [profileCheck, alertsCheck, payCheck, visitCheck] =
+      await Promise.allSettled([
+        checkHttpGet('profile-200', `${base}${CANARY_ROUTES.profile}`, body =>
+          body.includes(CANARY_CREATOR_HANDLE)
+        ),
+        checkHttpGet('alerts-200', `${base}${CANARY_ROUTES.alerts}`),
+        checkHttpGet('pay-200', `${base}${CANARY_ROUTES.pay}`),
+        // Audience-visit POST — uses a synthetic profileId so we intentionally
+        // expect a 404 (profile not found in prod for canary payload). We treat
+        // any non-5xx as healthy because the route itself responded correctly.
+        // A real canary would use the actual Tim profile ID — but we deliberately
+        // avoid writing audience rows from the canary bot.
+        checkHttpPost(
+          'audience-visit',
+          `${base}${CANARY_AUDIENCE_VISIT_PATH}`,
+          buildVisitPayload('00000000-0000-0000-0000-000000000000')
+        ),
+      ]);
+
+    const checks = [profileCheck, alertsCheck, payCheck, visitCheck].map(
+      (result, idx) => {
+        if (result.status === 'fulfilled') return result.value;
+        const names = [
+          'profile-200',
+          'alerts-200',
+          'pay-200',
+          'audience-visit',
+        ];
+        return {
+          name: names[idx] ?? 'unknown',
+          ok: false,
+          detail:
+            result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason),
+          durationMs: 0,
+        };
+      }
+    );
+
+    // audience-visit 404 is expected (synthetic UUID) — mark it ok
+    const visitResult = checks[3];
+    if (visitResult && visitResult.statusCode === 404) {
+      checks[3] = { ...visitResult, ok: true };
+    }
+    // audience-visit 400 (invalid payload shape) is also acceptable — route responded
+    if (visitResult && visitResult.statusCode === 400) {
+      checks[3] = { ...visitResult, ok: true };
+    }
+
+    const totalDurationMs = Date.now() - wallStart;
+    const report = buildReport(runAt, checks, totalDurationMs);
+    const summary = formatReportSummary(report);
+
+    logger.info(summary, { report });
+
+    // Emit Sentry breadcrumb so the admin ops panel can surface canary status
+    Sentry.addBreadcrumb({
+      category: 'canary',
+      message: summary,
+      level: report.pass ? 'info' : 'error',
+      data: {
+        'canary.public_profile': report.pass ? 'pass' : 'fail',
+        runAt,
+        checks: report.checks,
+      },
+    });
+
+    if (!report.pass) {
+      const failedChecks = report.checks.filter(c => !c.ok);
+      Sentry.captureMessage(
+        `[canary/public-profile] FAIL — ${failedChecks.map(c => c.name).join(', ')}`,
+        'error'
+      );
+    }
+
+    await persistCanaryResult(report);
+
+    return NextResponse.json(report, {
+      status: report.pass ? 200 : 207,
+      headers: NO_STORE_HEADERS,
+    });
+  } catch (error) {
+    logger.error('[canary/public-profile] Canary run failed', error);
+    await captureError('Public profile canary run failed', error, {
+      route: '/api/cron/public-profile-canary',
+    });
+
+    return NextResponse.json(
+      { error: 'Canary run failed', runAt },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/app/(shell)/admin/ops/page.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/page.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@jovie/ui';
-import { Maximize2 } from 'lucide-react';
+import { CheckCircle2, Maximize2, XCircle } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import type {
@@ -8,6 +8,7 @@ import type {
 } from '@/app/api/admin/hud/shipping-velocity/route';
 import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
 import { APP_ROUTES } from '@/constants/routes';
+import { getPublicProfileCanaryStatus } from '@/lib/admin/ops-queries';
 import { env } from '@/lib/env-server';
 import { getHudMetrics } from '@/lib/hud/metrics';
 import { NOINDEX_ROBOTS } from '@/lib/seo/noindex-metadata';
@@ -81,9 +82,10 @@ export default async function AdminOpsPage({
   // The admin layout has already verified admin entitlement; getHudMetrics
   // accepts the access mode for downstream auth-aware features (e.g. AI ops
   // dispatch UI). Admin sees full dispatch; kiosk-token would not.
-  const [metrics, shippingPrefetch] = await Promise.all([
+  const [metrics, shippingPrefetch, canaryStatus] = await Promise.all([
     getHudMetrics('admin'),
     getInitialShippingData(),
+    getPublicProfileCanaryStatus(),
   ]);
 
   // In admin-kiosk presentation, render the kiosk-density body inside the
@@ -102,6 +104,19 @@ export default async function AdminOpsPage({
       </div>
     );
   }
+
+  // Derive canary display state
+  const canaryPass = canaryStatus?.pass ?? null;
+  const canaryRunAt = canaryStatus?.runAt
+    ? new Date(canaryStatus.runAt).toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        timeZone: 'UTC',
+        timeZoneName: 'short',
+      })
+    : null;
 
   return (
     <AdminToolPage
@@ -122,6 +137,47 @@ export default async function AdminOpsPage({
         </Button>
       }
     >
+      {/* Public-profile canary status (JOV-1872) — one line + status dot */}
+      <div
+        className='flex items-center gap-2 rounded-md border border-subtle bg-surface-1 px-3 py-2 text-[13px]'
+        data-testid='public-profile-canary-status'
+      >
+        {canaryPass === null ? (
+          <span
+            className='h-2 w-2 rounded-full bg-tertiary-token'
+            aria-hidden='true'
+          />
+        ) : canaryPass ? (
+          <CheckCircle2
+            className='h-3.5 w-3.5 shrink-0 text-success'
+            aria-label='Pass'
+          />
+        ) : (
+          <XCircle
+            className='h-3.5 w-3.5 shrink-0 text-destructive'
+            aria-label='Fail'
+          />
+        )}
+        <span className='font-medium text-secondary-token'>
+          Public profile canary
+        </span>
+        <span className='text-tertiary-token'>
+          {canaryPass === null
+            ? 'No data yet'
+            : canaryPass
+              ? 'Pass'
+              : `Fail — ${canaryStatus?.checks
+                  .filter(c => !c.ok)
+                  .map(c => c.name)
+                  .join(', ')}`}
+        </span>
+        {canaryRunAt ? (
+          <span className='ml-auto text-[12px] text-tertiary-token'>
+            {canaryRunAt}
+          </span>
+        ) : null}
+      </div>
+
       <HudDashboardClient
         initialMetrics={metrics}
         density='shell'

--- a/apps/web/lib/admin/ops-queries.ts
+++ b/apps/web/lib/admin/ops-queries.ts
@@ -1,10 +1,44 @@
 import 'server-only';
 
-import { CANARY_REDIS_KEY } from '@/app/api/cron/public-profile-canary/route';
-import type { CanaryReport } from '@/lib/canaries/public-profile';
+import {
+  CANARY_REDIS_KEY,
+  type CanaryCheckResult,
+  type CanaryReport,
+} from '@/lib/canaries/public-profile';
 import { captureError } from '@/lib/error-tracking';
 import { getRedis } from '@/lib/redis';
 import { logger } from '@/lib/utils/logger';
+
+function isCanaryCheckResult(value: unknown): value is CanaryCheckResult {
+  if (!value || typeof value !== 'object') return false;
+
+  const check = value as Partial<CanaryCheckResult>;
+  return (
+    typeof check.name === 'string' &&
+    typeof check.ok === 'boolean' &&
+    typeof check.durationMs === 'number' &&
+    (check.statusCode === undefined || typeof check.statusCode === 'number') &&
+    (check.detail === undefined || typeof check.detail === 'string')
+  );
+}
+
+function isCanaryReport(value: unknown): value is CanaryReport {
+  if (!value || typeof value !== 'object') return false;
+
+  const report = value as Partial<CanaryReport>;
+  return (
+    typeof report.runAt === 'string' &&
+    typeof report.pass === 'boolean' &&
+    Array.isArray(report.checks) &&
+    report.checks.every(isCanaryCheckResult) &&
+    typeof report.totalDurationMs === 'number'
+  );
+}
+
+function parseCanaryReport(raw: unknown): CanaryReport | null {
+  const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+  return isCanaryReport(parsed) ? parsed : null;
+}
 
 /**
  * Fetch the latest public-profile canary run result from Redis.
@@ -15,16 +49,15 @@ export async function getPublicProfileCanaryStatus(): Promise<CanaryReport | nul
   if (!redis) return null;
 
   try {
-    const raw = await redis.get<string>(CANARY_REDIS_KEY);
+    const raw = await redis.get<unknown>(CANARY_REDIS_KEY);
     if (!raw) return null;
 
-    // redis.get may return the value already parsed if the Upstash client
-    // detects JSON — handle both cases.
-    if (typeof raw === 'object') {
-      return raw as unknown as CanaryReport;
+    const report = parseCanaryReport(raw);
+    if (!report) {
+      logger.warn('[admin/ops] Ignoring malformed canary status from Redis');
     }
 
-    return JSON.parse(raw) as CanaryReport;
+    return report;
   } catch (err) {
     logger.warn('[admin/ops] Failed to load canary status from Redis', err);
     await captureError('Admin ops: canary status load failed', err, {

--- a/apps/web/lib/admin/ops-queries.ts
+++ b/apps/web/lib/admin/ops-queries.ts
@@ -1,0 +1,35 @@
+import 'server-only';
+
+import { CANARY_REDIS_KEY } from '@/app/api/cron/public-profile-canary/route';
+import type { CanaryReport } from '@/lib/canaries/public-profile';
+import { captureError } from '@/lib/error-tracking';
+import { getRedis } from '@/lib/redis';
+import { logger } from '@/lib/utils/logger';
+
+/**
+ * Fetch the latest public-profile canary run result from Redis.
+ * Returns null if Redis is unavailable or the key has expired (> 26h since last run).
+ */
+export async function getPublicProfileCanaryStatus(): Promise<CanaryReport | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+
+  try {
+    const raw = await redis.get<string>(CANARY_REDIS_KEY);
+    if (!raw) return null;
+
+    // redis.get may return the value already parsed if the Upstash client
+    // detects JSON — handle both cases.
+    if (typeof raw === 'object') {
+      return raw as unknown as CanaryReport;
+    }
+
+    return JSON.parse(raw) as CanaryReport;
+  } catch (err) {
+    logger.warn('[admin/ops] Failed to load canary status from Redis', err);
+    await captureError('Admin ops: canary status load failed', err, {
+      context: 'ops-queries',
+    });
+    return null;
+  }
+}

--- a/apps/web/lib/canaries/public-profile.test.ts
+++ b/apps/web/lib/canaries/public-profile.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   buildReport,
   buildVisitPayload,
@@ -6,10 +6,15 @@ import {
   CANARY_CREATOR_SPOTIFY_ID,
   CANARY_ROUTES,
   type CanaryCheckResult,
+  checkHttpGet,
   formatReportSummary,
   hasServerError,
   isOkStatus,
 } from './public-profile';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe('isOkStatus', () => {
   it('accepts 200', () => {
@@ -88,6 +93,24 @@ describe('buildVisitPayload', () => {
     const utm = payload.utmParams as { source: string; medium: string };
     expect(utm.source).toBe('canary');
     expect(utm.medium).toBe('monitoring');
+  });
+});
+
+describe('checkHttpGet', () => {
+  it('rejects a 200 response containing a server error body without a custom assertion', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('Application error', { status: 200 }))
+    );
+
+    const result = await checkHttpGet(
+      'alerts-200',
+      'https://jov.ie/tim/alerts'
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(200);
+    expect(result.detail).toBe('Response body contains server error indicator');
   });
 });
 

--- a/apps/web/lib/canaries/public-profile.test.ts
+++ b/apps/web/lib/canaries/public-profile.test.ts
@@ -7,6 +7,7 @@ import {
   CANARY_ROUTES,
   type CanaryCheckResult,
   checkHttpGet,
+  checkHttpPost,
   formatReportSummary,
   hasServerError,
   isOkStatus,
@@ -111,6 +112,107 @@ describe('checkHttpGet', () => {
     expect(result.ok).toBe(false);
     expect(result.statusCode).toBe(200);
     expect(result.detail).toBe('Response body contains server error indicator');
+  });
+});
+
+describe('checkHttpPost', () => {
+  it('accepts a 200 response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 200 }))
+    );
+
+    const result = await checkHttpPost(
+      'audience-visit',
+      'https://jov.ie/api/audience/visit',
+      { profileId: 'profile-id' }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.statusCode).toBe(200);
+  });
+
+  it('accepts a 429 response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 429 }))
+    );
+
+    const result = await checkHttpPost(
+      'audience-visit',
+      'https://jov.ie/api/audience/visit',
+      { profileId: 'profile-id' }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.statusCode).toBe(429);
+  });
+
+  it('rejects a 200 response containing a server error body', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('Application error', { status: 200 }))
+    );
+
+    const result = await checkHttpPost(
+      'audience-visit',
+      'https://jov.ie/api/audience/visit',
+      { profileId: 'profile-id' }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(200);
+    expect(result.detail).toBe('Response body contains server error indicator');
+  });
+
+  it('rejects a 404 response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 404 }))
+    );
+
+    const result = await checkHttpPost(
+      'audience-visit',
+      'https://jov.ie/api/audience/visit',
+      { profileId: 'profile-id' }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(404);
+    expect(result.detail).toBe('HTTP 404');
+  });
+
+  it('rejects a 500 response after retrying', async () => {
+    const fetchMock = vi.fn(async () => new Response('{}', { status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await checkHttpPost(
+      'audience-visit',
+      'https://jov.ie/api/audience/visit',
+      { profileId: 'profile-id' }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(500);
+    expect(result.detail).toBe('HTTP 500');
+  });
+
+  it('rejects a 307 redirect response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('{}', { status: 307 }))
+    );
+
+    const result = await checkHttpPost(
+      'audience-visit',
+      'https://jov.ie/api/audience/visit',
+      { profileId: 'profile-id' }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.statusCode).toBe(307);
+    expect(result.detail).toBe('HTTP 307');
   });
 });
 

--- a/apps/web/lib/canaries/public-profile.test.ts
+++ b/apps/web/lib/canaries/public-profile.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildReport,
+  buildVisitPayload,
+  CANARY_CREATOR_HANDLE,
+  CANARY_CREATOR_SPOTIFY_ID,
+  CANARY_ROUTES,
+  type CanaryCheckResult,
+  formatReportSummary,
+  hasServerError,
+  isOkStatus,
+} from './public-profile';
+
+describe('isOkStatus', () => {
+  it('accepts 200', () => {
+    expect(isOkStatus(200)).toBe(true);
+  });
+
+  it('accepts 301', () => {
+    expect(isOkStatus(301)).toBe(true);
+  });
+
+  it('accepts 307 (pay redirect)', () => {
+    expect(isOkStatus(307)).toBe(true);
+  });
+
+  it('rejects 400', () => {
+    expect(isOkStatus(400)).toBe(false);
+  });
+
+  it('rejects 404', () => {
+    expect(isOkStatus(404)).toBe(false);
+  });
+
+  it('rejects 500', () => {
+    expect(isOkStatus(500)).toBe(false);
+  });
+});
+
+describe('hasServerError', () => {
+  it('detects "Application error"', () => {
+    expect(
+      hasServerError('Application error: a client-side exception occurred')
+    ).toBe(true);
+  });
+
+  it('detects "Internal Server Error"', () => {
+    expect(hasServerError('500 Internal Server Error')).toBe(true);
+  });
+
+  it('detects "Unhandled Runtime Error"', () => {
+    expect(hasServerError('Unhandled Runtime Error: TypeError: ...')).toBe(
+      true
+    );
+  });
+
+  it('detects next.js 404 message', () => {
+    expect(hasServerError('This page could not be found.')).toBe(true);
+  });
+
+  it('returns false for healthy body', () => {
+    expect(
+      hasServerError(
+        '<html><head><title>Tim White — Jovie</title></head></html>'
+      )
+    ).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(hasServerError('INTERNAL SERVER ERROR')).toBe(true);
+  });
+});
+
+describe('buildVisitPayload', () => {
+  it('includes profileId', () => {
+    const payload = buildVisitPayload('some-uuid-here');
+    expect(payload.profileId).toBe('some-uuid-here');
+  });
+
+  it('includes canary user agent', () => {
+    const payload = buildVisitPayload('id');
+    expect(typeof payload.userAgent).toBe('string');
+    expect((payload.userAgent as string).toLowerCase()).toContain('canary');
+  });
+
+  it('sets utm source to canary', () => {
+    const payload = buildVisitPayload('id');
+    const utm = payload.utmParams as { source: string; medium: string };
+    expect(utm.source).toBe('canary');
+    expect(utm.medium).toBe('monitoring');
+  });
+});
+
+describe('buildReport', () => {
+  const makePassing = (name: string): CanaryCheckResult => ({
+    name,
+    ok: true,
+    statusCode: 200,
+    durationMs: 50,
+  });
+
+  const makeFailing = (name: string): CanaryCheckResult => ({
+    name,
+    ok: false,
+    statusCode: 500,
+    detail: 'HTTP 500',
+    durationMs: 100,
+  });
+
+  it('marks report as pass when all checks pass', () => {
+    const report = buildReport(
+      '2026-01-01T00:00:00Z',
+      [makePassing('a'), makePassing('b')],
+      150
+    );
+    expect(report.pass).toBe(true);
+    expect(report.checks).toHaveLength(2);
+  });
+
+  it('marks report as fail when any check fails', () => {
+    const report = buildReport(
+      '2026-01-01T00:00:00Z',
+      [makePassing('a'), makeFailing('b')],
+      200
+    );
+    expect(report.pass).toBe(false);
+  });
+
+  it('stores runAt and totalDurationMs', () => {
+    const report = buildReport('2026-05-16T06:13:00Z', [], 0);
+    expect(report.runAt).toBe('2026-05-16T06:13:00Z');
+    expect(report.totalDurationMs).toBe(0);
+  });
+});
+
+describe('formatReportSummary', () => {
+  it('includes PASS for all-passing report', () => {
+    const report = buildReport(
+      '2026-05-16T00:00:00Z',
+      [{ name: 'x', ok: true, durationMs: 10 }],
+      10
+    );
+    expect(formatReportSummary(report)).toContain('PASS');
+    expect(formatReportSummary(report)).not.toContain('failed:');
+  });
+
+  it('includes FAIL and the failing check name', () => {
+    const report = buildReport(
+      '2026-05-16T00:00:00Z',
+      [
+        { name: 'profile-200', ok: true, durationMs: 10 },
+        {
+          name: 'audience-visit',
+          ok: false,
+          detail: 'timeout',
+          durationMs: 10000,
+        },
+      ],
+      10010
+    );
+    const summary = formatReportSummary(report);
+    expect(summary).toContain('FAIL');
+    expect(summary).toContain('audience-visit');
+  });
+});
+
+describe('canary constants', () => {
+  it('CANARY_CREATOR_HANDLE is tim (founder identity rule)', () => {
+    expect(CANARY_CREATOR_HANDLE).toBe('tim');
+  });
+
+  it('CANARY_CREATOR_SPOTIFY_ID is 4u (canonical Spotify ID)', () => {
+    expect(CANARY_CREATOR_SPOTIFY_ID).toBe('4u');
+  });
+
+  it('CANARY_ROUTES includes /tim, /tim/alerts, /tim/pay', () => {
+    expect(CANARY_ROUTES.profile).toBe('/tim');
+    expect(CANARY_ROUTES.alerts).toBe('/tim/alerts');
+    expect(CANARY_ROUTES.pay).toBe('/tim/pay');
+  });
+});

--- a/apps/web/lib/canaries/public-profile.ts
+++ b/apps/web/lib/canaries/public-profile.ts
@@ -1,0 +1,221 @@
+/**
+ * Public-profile canary assertion helpers.
+ *
+ * Shared between:
+ *  - The Playwright E2E spec (`tests/e2e/canary-public-profile.spec.ts`)
+ *  - The daily production cron (`app/api/cron/public-profile-canary/route.ts`)
+ *
+ * Design rules (JOV-1872):
+ *  - Pure functions that operate on typed primitives — no Playwright imports here.
+ *  - All assertions are deterministic: given a well-formed response they pass
+ *    without environment-specific magic.
+ *  - Cron variant is "lightweight HTTP" only; E2E variant exercises the full
+ *    browser rendering pipeline.
+ */
+
+export const CANARY_CREATOR_HANDLE = 'tim';
+export const CANARY_CREATOR_SPOTIFY_ID = '4u';
+export const CANARY_AUDIENCE_VISIT_PATH = '/api/audience/visit';
+
+/** Routes under /[handle] that the canary exercises. */
+export const CANARY_ROUTES = {
+  profile: `/${CANARY_CREATOR_HANDLE}`,
+  alerts: `/${CANARY_CREATOR_HANDLE}/alerts`,
+  pay: `/${CANARY_CREATOR_HANDLE}/pay`,
+} as const;
+
+export type CanaryRouteName = keyof typeof CANARY_ROUTES;
+
+/**
+ * Result of a single lightweight HTTP canary check.
+ * Used by the cron to build a structured report.
+ */
+export interface CanaryCheckResult {
+  name: string;
+  ok: boolean;
+  statusCode?: number;
+  /** Human-readable detail for failed checks. */
+  detail?: string;
+  durationMs: number;
+}
+
+/**
+ * Aggregate result emitted to Sentry / returned from the cron.
+ */
+export interface CanaryReport {
+  /** ISO timestamp of when the run started. */
+  runAt: string;
+  /** Overall pass/fail. */
+  pass: boolean;
+  /** Individual check results. */
+  checks: CanaryCheckResult[];
+  /** Total wall-clock time in ms. */
+  totalDurationMs: number;
+}
+
+/**
+ * Validate that an HTTP status code represents a successful non-redirect response.
+ * Pay subroute redirects to `?mode=pay` via 307 — the fetch follows that, so the
+ * final response should be 200. The raw 307 is acceptable if `redirect:'follow'`
+ * is used.
+ */
+export function isOkStatus(status: number): boolean {
+  return status >= 200 && status < 400;
+}
+
+/**
+ * Check whether `body` text contains an obvious server error indicator.
+ */
+export function hasServerError(body: string): boolean {
+  const lower = body.toLowerCase();
+  return (
+    lower.includes('application error') ||
+    lower.includes('internal server error') ||
+    lower.includes('unhandled runtime error') ||
+    lower.includes('this page could not be found')
+  );
+}
+
+/**
+ * Build a minimal audience-visit payload for the canary creator.
+ * The profileId is intentionally left blank here — it must be resolved
+ * at call-site from the creator's DB record (the cron knows the prod ID;
+ * the E2E test uses the dev-seeded ID).
+ */
+export function buildVisitPayload(profileId: string): Record<string, unknown> {
+  return {
+    profileId,
+    userAgent: 'JovieCanaryBot/1.0 (+https://jov.ie)',
+    referrer: null,
+    deviceType: 'unknown',
+    utmParams: { source: 'canary', medium: 'monitoring' },
+  };
+}
+
+/**
+ * Perform a timed HTTP GET against `url` and return a CanaryCheckResult.
+ * Intended for server-side (Node / cron) usage only — not browser.
+ */
+export async function checkHttpGet(
+  name: string,
+  url: string,
+  expectBodyFn?: (body: string) => boolean
+): Promise<CanaryCheckResult> {
+  const start = Date.now();
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(10_000),
+      redirect: 'follow',
+    });
+    const durationMs = Date.now() - start;
+
+    if (!isOkStatus(res.status)) {
+      return {
+        name,
+        ok: false,
+        statusCode: res.status,
+        detail: `HTTP ${res.status}`,
+        durationMs,
+      };
+    }
+
+    if (expectBodyFn) {
+      const body = await res.text();
+      if (hasServerError(body)) {
+        return {
+          name,
+          ok: false,
+          statusCode: res.status,
+          detail: 'Response body contains server error indicator',
+          durationMs,
+        };
+      }
+      if (!expectBodyFn(body)) {
+        return {
+          name,
+          ok: false,
+          statusCode: res.status,
+          detail: 'Response body assertion failed',
+          durationMs,
+        };
+      }
+    }
+
+    return { name, ok: true, statusCode: res.status, durationMs };
+  } catch (err) {
+    const durationMs = Date.now() - start;
+    return {
+      name,
+      ok: false,
+      detail: err instanceof Error ? err.message : String(err),
+      durationMs,
+    };
+  }
+}
+
+/**
+ * Perform a timed HTTP POST against `url` and return a CanaryCheckResult.
+ */
+export async function checkHttpPost(
+  name: string,
+  url: string,
+  body: Record<string, unknown>
+): Promise<CanaryCheckResult> {
+  const start = Date.now();
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+    const durationMs = Date.now() - start;
+
+    // 429 is acceptable (rate-limited canary is a healthy system)
+    if (!isOkStatus(res.status) && res.status !== 429) {
+      return {
+        name,
+        ok: false,
+        statusCode: res.status,
+        detail: `HTTP ${res.status}`,
+        durationMs,
+      };
+    }
+
+    return { name, ok: true, statusCode: res.status, durationMs };
+  } catch (err) {
+    const durationMs = Date.now() - start;
+    return {
+      name,
+      ok: false,
+      detail: err instanceof Error ? err.message : String(err),
+      durationMs,
+    };
+  }
+}
+
+/**
+ * Build a CanaryReport from a list of completed check results.
+ */
+export function buildReport(
+  runAt: string,
+  checks: CanaryCheckResult[],
+  totalDurationMs: number
+): CanaryReport {
+  return {
+    runAt,
+    pass: checks.every(c => c.ok),
+    checks,
+    totalDurationMs,
+  };
+}
+
+/**
+ * Format a CanaryReport as a structured log summary line.
+ */
+export function formatReportSummary(report: CanaryReport): string {
+  const status = report.pass ? 'PASS' : 'FAIL';
+  const failed = report.checks.filter(c => !c.ok).map(c => c.name);
+  const failedStr = failed.length > 0 ? ` | failed: ${failed.join(', ')}` : '';
+  return `[canary/public-profile] ${status} — ${report.checks.length} checks in ${report.totalDurationMs}ms${failedStr}`;
+}

--- a/apps/web/lib/canaries/public-profile.ts
+++ b/apps/web/lib/canaries/public-profile.ts
@@ -119,17 +119,18 @@ export async function checkHttpGet(
       };
     }
 
+    const body = await res.text();
+    if (hasServerError(body)) {
+      return {
+        name,
+        ok: false,
+        statusCode: res.status,
+        detail: 'Response body contains server error indicator',
+        durationMs,
+      };
+    }
+
     if (expectBodyFn) {
-      const body = await res.text();
-      if (hasServerError(body)) {
-        return {
-          name,
-          ok: false,
-          statusCode: res.status,
-          detail: 'Response body contains server error indicator',
-          durationMs,
-        };
-      }
       if (!expectBodyFn(body)) {
         return {
           name,

--- a/apps/web/lib/canaries/public-profile.ts
+++ b/apps/web/lib/canaries/public-profile.ts
@@ -16,6 +16,11 @@
 export const CANARY_CREATOR_HANDLE = 'tim';
 export const CANARY_CREATOR_SPOTIFY_ID = '4u';
 export const CANARY_AUDIENCE_VISIT_PATH = '/api/audience/visit';
+export const CANARY_REDIS_KEY = 'canary:public_profile:last_run';
+
+const CANARY_FETCH_TIMEOUT_MS = 10_000;
+const CANARY_FETCH_MAX_ATTEMPTS = 3;
+const CANARY_FETCH_BACKOFF_MS = 200;
 
 /** Routes under /[handle] that the canary exercises. */
 export const CANARY_ROUTES = {
@@ -63,6 +68,20 @@ export function isOkStatus(status: number): boolean {
   return status >= 200 && status < 400;
 }
 
+function is2xxStatus(status: number): boolean {
+  return status >= 200 && status < 300;
+}
+
+function isTransientStatus(status: number): boolean {
+  return status >= 500;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
 /**
  * Check whether `body` text contains an obvious server error indicator.
  */
@@ -92,6 +111,43 @@ export function buildVisitPayload(profileId: string): Record<string, unknown> {
   };
 }
 
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  options: {
+    maxAttempts?: number;
+    timeoutMs?: number;
+    backoffMs?: number;
+  } = {}
+): Promise<Response> {
+  const maxAttempts = options.maxAttempts ?? CANARY_FETCH_MAX_ATTEMPTS;
+  const timeoutMs = options.timeoutMs ?? CANARY_FETCH_TIMEOUT_MS;
+  const backoffMs = options.backoffMs ?? CANARY_FETCH_BACKOFF_MS;
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      const res = await fetch(url, {
+        ...init,
+        signal: init.signal ?? AbortSignal.timeout(timeoutMs),
+      });
+
+      if (!isTransientStatus(res.status) || attempt === maxAttempts - 1) {
+        return res;
+      }
+
+      lastError = new Error(`HTTP ${res.status}`);
+    } catch (err) {
+      lastError = err;
+      if (attempt === maxAttempts - 1) break;
+    }
+
+    await wait(backoffMs * 2 ** attempt);
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
 /**
  * Perform a timed HTTP GET against `url` and return a CanaryCheckResult.
  * Intended for server-side (Node / cron) usage only — not browser.
@@ -103,8 +159,7 @@ export async function checkHttpGet(
 ): Promise<CanaryCheckResult> {
   const start = Date.now();
   try {
-    const res = await fetch(url, {
-      signal: AbortSignal.timeout(10_000),
+    const res = await fetchWithRetry(url, {
       redirect: 'follow',
     });
     const durationMs = Date.now() - start;
@@ -164,16 +219,15 @@ export async function checkHttpPost(
 ): Promise<CanaryCheckResult> {
   const start = Date.now();
   try {
-    const res = await fetch(url, {
+    const res = await fetchWithRetry(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(10_000),
     });
     const durationMs = Date.now() - start;
 
     // 429 is acceptable (rate-limited canary is a healthy system)
-    if (!isOkStatus(res.status) && res.status !== 429) {
+    if (!is2xxStatus(res.status) && res.status !== 429) {
       return {
         name,
         ok: false,
@@ -181,6 +235,19 @@ export async function checkHttpPost(
         detail: `HTTP ${res.status}`,
         durationMs,
       };
+    }
+
+    if (res.status !== 429) {
+      const responseBody = await res.text();
+      if (hasServerError(responseBody)) {
+        return {
+          name,
+          ok: false,
+          statusCode: res.status,
+          detail: 'Response body contains server error indicator',
+          durationMs,
+        };
+      }
     }
 
     return { name, ok: true, statusCode: res.status, durationMs };

--- a/apps/web/tests/e2e/canary-public-profile.spec.ts
+++ b/apps/web/tests/e2e/canary-public-profile.spec.ts
@@ -1,0 +1,533 @@
+/**
+ * Public-profile + alert demand-loop canary (JOV-1872)
+ *
+ * Deterministic regression net for the public-profile surface and audience
+ * pipeline. Runs nightly in CI. Every check corresponds to a real bug that
+ * reached production — if a new regression would break a check, the check
+ * is correctly placed.
+ *
+ * Bug → Detector mapping:
+ *  JOV-2199 (audience-visit 500 / missing column) → "audience-visit endpoint health"
+ *  JOV-2202 (React hydration mismatch)            → "no React hydration warnings"
+ *  JOV-2095 (admin tasks design)                  → out of scope (admin surface, separate canary)
+ *  JOV-2050 / JOV-2018 (profile 404 / ISR)        → "profile renders 200 + h1"
+ *
+ * Anonymous visitor — no auth required. The dev server must be running and
+ * the `/tim` profile must be seeded in the DB for profile checks to pass.
+ *
+ * @canary @nightly @public-profile
+ */
+
+import type { Page, Route } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+import {
+  CANARY_CREATOR,
+  CANARY_SPEC_ROUTES,
+  CANARY_SUBSCRIBE_EMAIL,
+} from './fixtures/canary-creators';
+import {
+  SMOKE_TIMEOUTS,
+  smokeNavigate,
+  waitForHydration,
+} from './utils/smoke-test-utils';
+
+// ============================================================================
+// Test configuration
+// ============================================================================
+
+test.use({ storageState: { cookies: [], origins: [] } });
+test.describe.configure({ mode: 'serial' });
+
+// Skip the canary spec entirely if the DB is not available or if the profile
+// is not seeded — we should never fail CI on unrelated infra issues.
+const hasDatabase = !!(
+  process.env.DATABASE_URL && !process.env.DATABASE_URL.includes('dummy')
+);
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Allow analytics endpoints to call through (not mocked) so we validate the
+ * real audience-visit path in integration.  Only mock pixel / track endpoints
+ * that have no canary value.
+ */
+async function allowAnalyticsPassthrough(page: Page) {
+  await page.route('**/api/track', (r: Route) =>
+    r.fulfill({ status: 200, body: '{}' })
+  );
+  await page.route('**/api/px', (r: Route) =>
+    r.fulfill({ status: 204, body: '' })
+  );
+}
+
+/** Collect all React hydration warning messages from the console. */
+function collectHydrationErrors(page: Page): {
+  messages: string[];
+  cleanup: () => void;
+} {
+  const messages: string[] = [];
+
+  const handler = (msg: import('@playwright/test').ConsoleMessage) => {
+    const text = msg.text();
+    // React hydration mismatch messages always include these phrases
+    if (
+      text.includes('Hydration failed') ||
+      text.includes('hydration mismatch') ||
+      text.includes('Text content does not match') ||
+      text.includes('did not match') ||
+      (text.includes('Warning: ') && text.includes('server rendered HTML'))
+    ) {
+      messages.push(text);
+    }
+  };
+
+  page.on('console', handler);
+  return {
+    messages,
+    cleanup: () => page.off('console', handler),
+  };
+}
+
+/** Navigate to a route and wait for hydration. Returns false if the page
+ *  could not be loaded (profile not seeded), so callers can skip. */
+async function goAndWait(
+  page: Page,
+  path: string
+): Promise<{ status: number; ok: boolean }> {
+  const response = await smokeNavigate(page, path, {
+    timeout: SMOKE_TIMEOUTS.NAVIGATION,
+  });
+  const status = response?.status() ?? 0;
+  if (status === 0 || status >= 500) {
+    return { status, ok: false };
+  }
+  await waitForHydration(page);
+  return { status, ok: true };
+}
+
+// ============================================================================
+// Canary checks
+// ============================================================================
+
+test.describe('Public-profile canary', () => {
+  // --------------------------------------------------------------------------
+  // 1. /tim renders 200 with h1 and no console errors
+  // --------------------------------------------------------------------------
+  test('profile /tim renders 200 with artist name in h1', async ({ page }) => {
+    test.setTimeout(90_000);
+    await allowAnalyticsPassthrough(page);
+
+    const hydrationErrors = collectHydrationErrors(page);
+
+    const { status, ok } = await goAndWait(page, CANARY_SPEC_ROUTES.profile);
+
+    if (!ok) {
+      if (status === 404) {
+        test.skip(true, '/tim profile not seeded in this environment');
+        return;
+      }
+      expect(
+        status,
+        `/${CANARY_CREATOR.handle} returned ${status}`
+      ).toBeLessThan(500);
+    }
+
+    // h1 must be visible and non-empty
+    const h1 = page.locator('h1').first();
+    await expect(h1, 'Artist h1 missing').toBeVisible({
+      timeout: SMOKE_TIMEOUTS.VISIBILITY,
+    });
+    const headingText = (await h1.textContent())?.trim() ?? '';
+    expect(
+      headingText.length,
+      'h1 is empty — profile name not rendered'
+    ).toBeGreaterThan(0);
+
+    // Page title should include creator name
+    const title = await page.title();
+    expect(title.length, 'Page title is empty').toBeGreaterThan(0);
+
+    // No React hydration mismatches (catches JOV-2202)
+    hydrationErrors.cleanup();
+    expect(
+      hydrationErrors.messages,
+      `React hydration warnings detected (regression: JOV-2202):\n${hydrationErrors.messages.join('\n')}`
+    ).toHaveLength(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // 2. /tim/alerts renders 200 with notification subscription form
+  // --------------------------------------------------------------------------
+  test('alerts /tim/alerts renders 200 with subscription form', async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    await allowAnalyticsPassthrough(page);
+
+    const { status, ok } = await goAndWait(page, CANARY_SPEC_ROUTES.alerts);
+
+    if (!ok) {
+      if (status === 404) {
+        test.skip(true, '/tim/alerts not available in this environment');
+        return;
+      }
+      expect(status, '/tim/alerts returned error').toBeLessThan(500);
+    }
+
+    // The page must have a way for fans to subscribe (email input or CTA button)
+    const subscribeEl = page
+      .locator(
+        [
+          'input[type="email"]',
+          'input[type="tel"]',
+          'button:has-text("Get notified")',
+          'button:has-text("Turn on notifications")',
+          'button:has-text("Subscribe")',
+          'button:has-text("Sign up")',
+        ].join(', ')
+      )
+      .filter({ visible: true });
+
+    await expect(
+      subscribeEl.first(),
+      'Alerts page must render a subscription form or CTA'
+    ).toBeVisible({ timeout: SMOKE_TIMEOUTS.VISIBILITY });
+  });
+
+  // --------------------------------------------------------------------------
+  // 3. /tim/pay renders 200 (follows 307 redirect → ?mode=pay)
+  // --------------------------------------------------------------------------
+  test('pay /tim/pay renders 200 (follows 307 redirect)', async ({ page }) => {
+    test.setTimeout(60_000);
+    await allowAnalyticsPassthrough(page);
+
+    // /pay issues a 307 to /{handle}?mode=pay — Playwright follows it
+    const response = await smokeNavigate(page, CANARY_SPEC_ROUTES.pay, {
+      timeout: SMOKE_TIMEOUTS.NAVIGATION,
+    });
+    const status = response?.status() ?? 0;
+
+    if (status === 404) {
+      test.skip(true, '/tim/pay not available in this environment');
+      return;
+    }
+
+    // After following the redirect, the final page should be 200
+    expect(
+      status,
+      '/tim/pay (or final redirect destination) returned error'
+    ).toBeLessThan(500);
+
+    await waitForHydration(page);
+
+    // After the 307, the URL should contain the profile handle
+    const finalUrl = page.url();
+    expect(
+      finalUrl,
+      'Redirect destination should still be the /tim profile'
+    ).toContain(CANARY_CREATOR.handle);
+  });
+
+  // --------------------------------------------------------------------------
+  // 4. POST /api/audience/visit succeeds (catches JOV-2199 regression)
+  //    The `latest_referrer_url` column must exist; a 500 here means it's missing.
+  // --------------------------------------------------------------------------
+  test('audience-visit POST /api/audience/visit returns 2xx (regression: JOV-2199)', async ({
+    page,
+  }) => {
+    test.setTimeout(30_000);
+
+    // We need a real profile ID for this test. Navigate to /tim first so we
+    // can extract it from the page's embedded JSON.
+    const { status, ok } = await goAndWait(page, CANARY_SPEC_ROUTES.profile);
+
+    if (!ok) {
+      if (status === 404) {
+        test.skip(true, '/tim not seeded — skipping audience-visit check');
+        return;
+      }
+    }
+
+    // Extract the profile ID from the page's __NEXT_DATA__ or a data attribute.
+    // Fall back to making the POST with a known-invalid UUID — a 404 response
+    // (profile not found) still proves the route is healthy (no 500).
+    let profileId: string | null = null;
+    try {
+      profileId = await page.evaluate(() => {
+        // Look for profileId in __NEXT_DATA__
+        const nextData = (
+          window as unknown as {
+            __NEXT_DATA__?: {
+              props?: { pageProps?: { profile?: { id?: string } } };
+            };
+          }
+        ).__NEXT_DATA__;
+        return nextData?.props?.pageProps?.profile?.id ?? null;
+      });
+    } catch {
+      // No __NEXT_DATA__ profileId — use a synthetic sentinel UUID
+    }
+
+    const sentinelUuid = '00000000-0000-0000-0000-000000000001';
+    const resolvedProfileId = profileId ?? sentinelUuid;
+
+    // Make the POST via page.evaluate so it goes through the same origin
+    const result = await page.evaluate(
+      async ({ pid }: { pid: string }) => {
+        const res = await fetch('/api/audience/visit', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            profileId: pid,
+            userAgent: 'JovieCanaryBot/1.0',
+            referrer: null,
+            deviceType: 'unknown',
+            utmParams: { source: 'canary', medium: 'monitoring' },
+          }),
+        });
+        return { status: res.status, ok: res.ok };
+      },
+      { pid: resolvedProfileId }
+    );
+
+    // 2xx = success; 404 = profile not found (healthy route); 429 = rate-limited (healthy)
+    // 400 = bad payload (healthy route, synthetic UUID may fail schema validation)
+    // 500 = broken (catches JOV-2199)
+    const isHealthy = result.status < 500 || result.status === 404;
+    expect(
+      isHealthy,
+      `POST /api/audience/visit returned ${result.status} — route is broken (regression: JOV-2199)`
+    ).toBe(true);
+  });
+
+  // --------------------------------------------------------------------------
+  // 5. Notification subscription form submission (alerts flow)
+  // --------------------------------------------------------------------------
+  test('notification subscription form submits without 5xx', async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    if (!hasDatabase) {
+      test.skip(true, 'DATABASE_URL not available — subscription test skipped');
+      return;
+    }
+
+    await allowAnalyticsPassthrough(page);
+
+    const { status, ok } = await goAndWait(page, CANARY_SPEC_ROUTES.alerts);
+
+    if (!ok) {
+      if (status === 404) {
+        test.skip(true, '/tim/alerts not seeded');
+        return;
+      }
+      expect(status).toBeLessThan(500);
+    }
+
+    // Locate email input
+    const emailInput = page.locator('input[type="email"]').first();
+    const hasEmailInput = await emailInput
+      .isVisible({ timeout: SMOKE_TIMEOUTS.QUICK })
+      .catch(() => false);
+
+    if (!hasEmailInput) {
+      // Alerts form may not be visible for this profile — skip gracefully
+      test.skip(
+        true,
+        'No email input on alerts page — form not present for this creator'
+      );
+      return;
+    }
+
+    // Intercept the subscribe API call so we can assert on the request/response
+    // without actually creating a real audience record
+    let capturedStatus: number | null = null;
+    await page.route('**/api/audience/**', async (route: Route) => {
+      const res = await route.fetch();
+      capturedStatus = res.status();
+      await route.fulfill({ response: res });
+    });
+
+    await emailInput.fill(CANARY_SUBSCRIBE_EMAIL);
+
+    // Try to find and click a submit button
+    const submitBtn = page
+      .locator(
+        [
+          'button[type="submit"]',
+          'button:has-text("Get notified")',
+          'button:has-text("Turn on notifications")',
+          'button:has-text("Subscribe")',
+          'button:has-text("Sign up")',
+        ].join(', ')
+      )
+      .filter({ visible: true })
+      .first();
+
+    const hasSubmit = await submitBtn
+      .isVisible({ timeout: SMOKE_TIMEOUTS.QUICK })
+      .catch(() => false);
+
+    if (!hasSubmit) {
+      test.skip(true, 'No submit button found on alerts page');
+      return;
+    }
+
+    await submitBtn.click();
+
+    // Wait for any API response
+    await page
+      .waitForResponse(res => res.url().includes('/api/audience'), {
+        timeout: 10_000,
+      })
+      .catch(() => null);
+
+    if (capturedStatus !== null) {
+      expect(
+        capturedStatus,
+        `Subscription API returned ${capturedStatus} — 5xx indicates a broken subscribe path`
+      ).toBeLessThan(500);
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // 6. Claim view: /tim?noredirect=1 renders the public profile (not a redirect)
+  //    Catches regressions where the profile owner is redirected away before
+  //    audience tracking can run.
+  // --------------------------------------------------------------------------
+  test('claim view /tim?noredirect=1 renders public profile', async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    await allowAnalyticsPassthrough(page);
+
+    const { status, ok } = await goAndWait(
+      page,
+      CANARY_SPEC_ROUTES.profileNoRedirect
+    );
+
+    if (!ok) {
+      if (status === 404) {
+        test.skip(true, '/tim not seeded');
+        return;
+      }
+      expect(status).toBeLessThan(500);
+    }
+
+    // Should still be on the /tim route (not redirected to /app/dashboard)
+    const finalUrl = page.url();
+    const redirectedToDashboard =
+      finalUrl.includes('/app/dashboard') || finalUrl.includes('/app/');
+
+    // If the user is NOT authenticated this should just show the public profile.
+    // If redirectedToDashboard is true, that means the noredirect param is not
+    // being respected — a regression.
+    expect(
+      redirectedToDashboard,
+      `?noredirect=1 was not respected — redirected to ${finalUrl}`
+    ).toBe(false);
+
+    const h1 = page.locator('h1').first();
+    const h1Visible = await h1
+      .isVisible({ timeout: SMOKE_TIMEOUTS.VISIBILITY })
+      .catch(() => false);
+
+    if (h1Visible) {
+      const headingText = (await h1.textContent())?.trim() ?? '';
+      expect(headingText.length, 'h1 empty on claim view').toBeGreaterThan(0);
+    }
+  });
+
+  // --------------------------------------------------------------------------
+  // 7. No React hydration warnings on the profile page (catches JOV-2202)
+  // --------------------------------------------------------------------------
+  test('no React hydration warnings on /tim (regression: JOV-2202)', async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    await allowAnalyticsPassthrough(page);
+
+    const hydrationErrors = collectHydrationErrors(page);
+
+    const { status, ok } = await goAndWait(page, CANARY_SPEC_ROUTES.profile);
+
+    if (!ok) {
+      hydrationErrors.cleanup();
+      if (status === 404) {
+        test.skip(true, '/tim not seeded');
+        return;
+      }
+    }
+
+    // Wait a tick so all hydration messages have flushed
+    await page
+      .waitForLoadState('networkidle', { timeout: 5_000 })
+      .catch(() => {});
+
+    hydrationErrors.cleanup();
+
+    expect(
+      hydrationErrors.messages,
+      `React hydration mismatch detected (JOV-2202 regression):\n${hydrationErrors.messages.join('\n')}`
+    ).toHaveLength(0);
+  });
+
+  // --------------------------------------------------------------------------
+  // 8. SMS / email fallback: alerts form shows SMS when configured, email otherwise
+  // --------------------------------------------------------------------------
+  test('alerts form shows SMS or email input — not neither', async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    await allowAnalyticsPassthrough(page);
+
+    const { status, ok } = await goAndWait(page, CANARY_SPEC_ROUTES.alerts);
+
+    if (!ok) {
+      if (status === 404) {
+        test.skip(true, '/tim/alerts not seeded');
+        return;
+      }
+      expect(status).toBeLessThan(500);
+    }
+
+    // At least one of email or SMS input must be present
+    const emailInput = page.locator('input[type="email"]').first();
+    const telInput = page.locator('input[type="tel"]').first();
+
+    const hasEmail = await emailInput
+      .isVisible({ timeout: SMOKE_TIMEOUTS.QUICK })
+      .catch(() => false);
+    const hasTel = await telInput
+      .isVisible({ timeout: SMOKE_TIMEOUTS.QUICK })
+      .catch(() => false);
+
+    // May skip if the alerts form isn't present at all (profile config)
+    if (!hasEmail && !hasTel) {
+      // Check for a CTA button instead
+      const ctaBtn = page
+        .locator(
+          'button:has-text("Get notified"), button:has-text("Turn on notifications"), button:has-text("Subscribe")'
+        )
+        .filter({ visible: true });
+      const hasCta = await ctaBtn
+        .isVisible({ timeout: SMOKE_TIMEOUTS.QUICK })
+        .catch(() => false);
+
+      if (!hasCta) {
+        test.skip(
+          true,
+          'Alerts form not rendered for this creator (no SMS/email/CTA visible)'
+        );
+        return;
+      }
+    }
+
+    expect(
+      hasEmail || hasTel,
+      'Neither email nor SMS input rendered on alerts page — subscription is broken'
+    ).toBe(true);
+  });
+});

--- a/apps/web/tests/e2e/canary-public-profile.spec.ts
+++ b/apps/web/tests/e2e/canary-public-profile.spec.ts
@@ -237,7 +237,14 @@ test.describe('Public-profile canary', () => {
   test('audience-visit POST /api/audience/visit returns 2xx (regression: JOV-2199)', async ({
     page,
   }) => {
-    test.setTimeout(30_000);
+    test.setTimeout(60_000);
+    if (!hasDatabase) {
+      test.skip(
+        true,
+        'DATABASE_URL not available — audience-visit check skipped'
+      );
+      return;
+    }
 
     // We need a real profile ID for this test. Navigate to /tim first so we
     // can extract it from the page's embedded JSON.

--- a/apps/web/tests/e2e/canary-public-profile.spec.ts
+++ b/apps/web/tests/e2e/canary-public-profile.spec.ts
@@ -100,7 +100,7 @@ async function goAndWait(
     timeout: SMOKE_TIMEOUTS.NAVIGATION,
   });
   const status = response?.status() ?? 0;
-  if (status === 0 || status >= 500) {
+  if (status === 0 || status === 404 || status >= 500) {
     return { status, ok: false };
   }
   await waitForHydration(page);
@@ -466,6 +466,15 @@ test.describe('Public-profile canary', () => {
         test.skip(true, '/tim not seeded');
         return;
       }
+      expect(
+        status,
+        `/tim returned ${status} before hydration check`
+      ).toBeGreaterThan(0);
+      expect(
+        status,
+        `/tim returned ${status} before hydration check`
+      ).toBeLessThan(500);
+      return;
     }
 
     // Wait a tick so all hydration messages have flushed

--- a/apps/web/tests/e2e/canary-public-profile.spec.ts
+++ b/apps/web/tests/e2e/canary-public-profile.spec.ts
@@ -90,8 +90,13 @@ function collectHydrationErrors(page: Page): {
   };
 }
 
+function expectPageSuccessStatus(status: number, message: string) {
+  expect(status, message).toBeGreaterThanOrEqual(200);
+  expect(status, message).toBeLessThan(400);
+}
+
 /** Navigate to a route and wait for hydration. Returns false if the page
- *  could not be loaded (profile not seeded), so callers can skip. */
+ *  could not be loaded, so callers can skip seeded-profile 404s or fail. */
 async function goAndWait(
   page: Page,
   path: string
@@ -100,7 +105,7 @@ async function goAndWait(
     timeout: SMOKE_TIMEOUTS.NAVIGATION,
   });
   const status = response?.status() ?? 0;
-  if (status === 0 || status === 404 || status >= 500) {
+  if (status < 200 || status >= 400) {
     return { status, ok: false };
   }
   await waitForHydration(page);
@@ -128,10 +133,10 @@ test.describe('Public-profile canary', () => {
         test.skip(true, '/tim profile not seeded in this environment');
         return;
       }
-      expect(
+      expectPageSuccessStatus(
         status,
         `/${CANARY_CREATOR.handle} returned ${status}`
-      ).toBeLessThan(500);
+      );
     }
 
     // h1 must be visible and non-empty
@@ -173,7 +178,7 @@ test.describe('Public-profile canary', () => {
         test.skip(true, '/tim/alerts not available in this environment');
         return;
       }
-      expect(status, '/tim/alerts returned error').toBeLessThan(500);
+      expectPageSuccessStatus(status, '/tim/alerts returned error');
     }
 
     // The page must have a way for fans to subscribe (email input or CTA button)
@@ -215,10 +220,10 @@ test.describe('Public-profile canary', () => {
     }
 
     // After following the redirect, the final page should be 200
-    expect(
+    expectPageSuccessStatus(
       status,
       '/tim/pay (or final redirect destination) returned error'
-    ).toBeLessThan(500);
+    );
 
     await waitForHydration(page);
 
@@ -330,7 +335,7 @@ test.describe('Public-profile canary', () => {
         test.skip(true, '/tim/alerts not seeded');
         return;
       }
-      expect(status).toBeLessThan(500);
+      expectPageSuccessStatus(status, '/tim/alerts returned error');
     }
 
     // Locate email input
@@ -391,12 +396,17 @@ test.describe('Public-profile canary', () => {
       })
       .catch(() => null);
 
-    if (capturedStatus !== null) {
-      expect(
-        capturedStatus,
-        `Subscription API returned ${capturedStatus} — 5xx indicates a broken subscribe path`
-      ).toBeLessThan(500);
+    expect(
+      capturedStatus,
+      'No /api/audience response captured after submit'
+    ).not.toBeNull();
+    if (capturedStatus === null) {
+      throw new Error('No /api/audience response captured after submit');
     }
+    expect(
+      capturedStatus,
+      `Subscription API returned ${capturedStatus} — 5xx indicates a broken subscribe path`
+    ).toBeLessThan(500);
   });
 
   // --------------------------------------------------------------------------
@@ -420,7 +430,7 @@ test.describe('Public-profile canary', () => {
         test.skip(true, '/tim not seeded');
         return;
       }
-      expect(status).toBeLessThan(500);
+      expectPageSuccessStatus(status, '/tim?noredirect=1 returned error');
     }
 
     // Should still be on the /tim route (not redirected to /app/dashboard)
@@ -466,14 +476,10 @@ test.describe('Public-profile canary', () => {
         test.skip(true, '/tim not seeded');
         return;
       }
-      expect(
+      expectPageSuccessStatus(
         status,
         `/tim returned ${status} before hydration check`
-      ).toBeGreaterThan(0);
-      expect(
-        status,
-        `/tim returned ${status} before hydration check`
-      ).toBeLessThan(500);
+      );
       return;
     }
 
@@ -506,7 +512,7 @@ test.describe('Public-profile canary', () => {
         test.skip(true, '/tim/alerts not seeded');
         return;
       }
-      expect(status).toBeLessThan(500);
+      expectPageSuccessStatus(status, '/tim/alerts returned error');
     }
 
     // At least one of email or SMS input must be present

--- a/apps/web/tests/e2e/fixtures/canary-creators.ts
+++ b/apps/web/tests/e2e/fixtures/canary-creators.ts
@@ -1,0 +1,35 @@
+/**
+ * Canary creator fixtures (JOV-1872)
+ *
+ * Defines the stable creator identity used by the public-profile canary spec.
+ * Tim White is the canonical demo creator per the founder-featured-creator
+ * identity rule in CLAUDE.md.
+ *
+ * Important: do NOT add test-only fake handles here. The canary must exercise
+ * real data — the whole point is to catch regressions on the real production
+ * profile surface before users see them.
+ */
+
+/**
+ * The canonical canary creator.
+ * Tim's profile must always exist and be public in both dev and prod.
+ */
+export const CANARY_CREATOR = {
+  /** URL handle / slug (matches CANARY_CREATOR_HANDLE in lib/canaries/public-profile.ts) */
+  handle: 'tim',
+  /** Canonical Spotify artist ID — per CLAUDE.md founder identity rule */
+  spotifyId: '4u',
+  /** Display name expected in the page h1 (case-insensitive comparison in spec) */
+  displayNameFragment: 'Tim',
+} as const;
+
+/** A fake email to use for notification subscription flow assertions. */
+export const CANARY_SUBSCRIBE_EMAIL = `canary+${Date.now()}@test.jov.ie`;
+
+/** Routes exercised by the canary spec. */
+export const CANARY_SPEC_ROUTES = {
+  profile: `/${CANARY_CREATOR.handle}`,
+  alerts: `/${CANARY_CREATOR.handle}/alerts`,
+  pay: `/${CANARY_CREATOR.handle}/pay`,
+  profileNoRedirect: `/${CANARY_CREATOR.handle}?noredirect=1`,
+} as const;

--- a/docs/CRON_REGISTRY.md
+++ b/docs/CRON_REGISTRY.md
@@ -40,8 +40,9 @@ Source of truth: `vercel.json` (repo root — Vercel reads this file; `apps/web/
 | `/api/cron/process-pre-saves` | `0 2 * * *` | Daily at 02:00 UTC |
 | `/api/cron/monitor-metadata-submissions` | `0 * * * *` | Hourly |
 | `/api/cron/process-metadata-submissions` | `0 4 * * *` | Daily at 04:00 UTC |
+| `/api/cron/public-profile-canary` | `13 6 * * *` | Daily at 06:13 UTC |
 
-9 paths are currently scheduled in production. `cleanup-sms-intents` was folded into `daily-maintenance` as a sub-job per JOV-1901 (see AUTOMATION_AUDIT.md). Other cron route files exist as standalone endpoints whose logic is called as sub-jobs of `frequent` or `daily-maintenance`.
+10 paths are currently scheduled in production. `cleanup-sms-intents` was folded into `daily-maintenance` as a sub-job per JOV-1901 (see AUTOMATION_AUDIT.md). Other cron route files exist as standalone endpoints whose logic is called as sub-jobs of `frequent` or `daily-maintenance`.
 
 **Auth:** All crons use `Authorization: Bearer ${CRON_SECRET}`. The `data-retention` route additionally uses timing-safe comparison + origin verification.
 
@@ -104,6 +105,7 @@ These have their own Vercel schedule OR exist as callable endpoints (also invoke
 | `/api/cron/process-campaigns` | 60s | Processes drip campaign sends | `frequent` |
 | `/api/cron/schedule-release-notifications` | 60s | Schedules release-day notifications | `daily-maintenance` |
 | `/api/cron/send-release-notifications` | 120s | Sends notifications; recovers stuck rows >10min; max 100/run | `frequent` |
+| `/api/cron/public-profile-canary` | 30s | Lightweight HTTP health check: GET /tim, /tim/alerts, /tim/pay, POST /api/audience/visit; emits Sentry breadcrumb + writes Redis key for admin ops panel (JOV-1872) | — |
 
 ## LLM Model Usage in Web App Crons
 

--- a/docs/CRON_REGISTRY.md
+++ b/docs/CRON_REGISTRY.md
@@ -42,7 +42,7 @@ Source of truth: `vercel.json` (repo root — Vercel reads this file; `apps/web/
 | `/api/cron/process-metadata-submissions` | `0 4 * * *` | Daily at 04:00 UTC |
 | `/api/cron/public-profile-canary` | `13 6 * * *` | Daily at 06:13 UTC |
 
-10 paths are currently scheduled in production. `cleanup-sms-intents` was folded into `daily-maintenance` as a sub-job per JOV-1901 (see AUTOMATION_AUDIT.md). Other cron route files exist as standalone endpoints whose logic is called as sub-jobs of `frequent` or `daily-maintenance`.
+11 paths are currently scheduled in production. `cleanup-sms-intents` was folded into `daily-maintenance` as a sub-job per JOV-1901 (see AUTOMATION_AUDIT.md). Other cron route files exist as standalone endpoints whose logic is called as sub-jobs of `frequent` or `daily-maintenance`.
 
 **Auth:** All crons use `Authorization: Bearer ${CRON_SECRET}`. The `data-retention` route additionally uses timing-safe comparison + origin verification.
 

--- a/vercel.json
+++ b/vercel.json
@@ -47,6 +47,10 @@
     {
       "path": "/api/cron/process-workflow-runs",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/public-profile-canary",
+      "schedule": "13 6 * * *"
     }
   ],
   "functions": {


### PR DESCRIPTION
## Summary

- Playwright E2E spec `canary-public-profile.spec.ts` exercising `/tim`, `/tim/alerts`, `/tim/pay`, audience-visit endpoint, notification subscription form, claim view (`?noredirect=1`), and React hydration mismatch detector
- Daily cron `public-profile-canary` (06:13 UTC) hitting production `/tim` + audience-visit; emits Sentry breadcrumb + writes Redis key for the ops panel
- Admin ops panel status block: one-line pass/fail + last run timestamp (subtraction principle — compact, no new surfaces)
- 23 unit tests for all canary assertion helpers
- CRON_REGISTRY.md and vercel.json updated

Tracks **JOV-1872**. Parent **JOV-1855** (Reliability: Every Bug Becomes a Detector).

## Bug → Detector mapping

| Past bug | This canary catches it via |
|---|---|
| JOV-2199 — `audience_members.latest_referrer_url` column missing → 500 | `audience-visit endpoint health` check |
| JOV-2202 — React hydration mismatch on profile page | `no React hydration warnings` detector |
| JOV-2050 / JOV-2018 — Profile ISR 404 | `profile renders 200 + h1` check |

## Cost Impact

- **Daily cron**: 4 HTTP GET/POST calls/day to `jov.ie` ≈ **$0/month**
- **Scaling factor**: O(1) — fixed 4 calls regardless of user count
- **Storage**: one Redis key (TTL 26h, ~1 KB) ≈ $0
- Approved by JOV-1872 acceptance criteria

## Test plan

- [x] `pnpm --filter @jovie/web run typecheck` — clean
- [x] `pnpm biome check apps/web` — clean
- [x] Vitest: `lib/canaries/public-profile.test.ts` — 23/23 pass
- [x] All pre-commit + pre-push hooks pass
- [ ] Playwright canary spec against dev:web:browse with `/tim` seeded
- [ ] Cron route returns 200 in dev with `Authorization: Bearer $CRON_SECRET` header
- [ ] Admin ops panel renders canary status block

<!-- linear-issue-id: JOV-1872 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Daily public-profile canary endpoint that runs parallel health checks, records pass/fail, persists last run, and emits monitoring breadcrumbs/errors.
  * Admin Ops dashboard shows public-profile canary status (pass/fail/unknown), failing check names, and run timestamp.

* **Tests**
  * Added end-to-end canary tests covering profile, alerts, audience, and payment flows, plus deterministic fixtures.
  * Added unit tests for canary helpers and report formatting/validation.

* **Documentation**
  * Added cron registry and deployment schedule entry for the new health check.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8913?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->