### PR TITLE
fix(shell): use lightweight settings data path

### DIFF
--- a/apps/web/app/app/(shell)/settings/contacts/page.tsx
+++ b/apps/web/app/app/(shell)/settings/contacts/page.tsx
@@ -1,17 +1,19 @@
+import { getCachedAuth } from '@/lib/auth/cached';
 import { queryKeys } from '@/lib/queries';
 import { getQueryClient } from '@/lib/queries/server';
-import { getDashboardData } from '../../dashboard/actions';
+import { getDashboardShellData } from '../../dashboard/actions';
 import { getProfileContactsForOwner } from '../../dashboard/contacts/actions';
 import { ContactsContent } from './ContactsContent';
 
 export const runtime = 'nodejs';
 
 export default async function SettingsContactsPage() {
-  const dashboardData = await getDashboardData();
+  const { userId } = await getCachedAuth();
+  const dashboardData = userId ? await getDashboardShellData(userId) : null;
 
   // Prefetch contacts into the shared QueryClient so the client component
   // gets an instant cache hit instead of showing a loading skeleton.
-  const profileId = dashboardData.selectedProfile?.id;
+  const profileId = dashboardData?.selectedProfile?.id;
   if (profileId) {
     const queryClient = getQueryClient();
     await queryClient.prefetchQuery({

--- a/apps/web/app/app/(shell)/settings/touring/page.tsx
+++ b/apps/web/app/app/(shell)/settings/touring/page.tsx
@@ -1,17 +1,19 @@
+import { getCachedAuth } from '@/lib/auth/cached';
 import { queryKeys } from '@/lib/queries';
 import { getQueryClient } from '@/lib/queries/server';
-import { getDashboardData } from '../../dashboard/actions';
+import { getDashboardShellData } from '../../dashboard/actions';
 import { checkBandsintownConnection } from '../../dashboard/tour-dates/actions';
 import { TouringContent } from './TouringContent';
 
 export const runtime = 'nodejs';
 
 export default async function SettingsTouringPage() {
-  const dashboardData = await getDashboardData();
+  const { userId } = await getCachedAuth();
+  const dashboardData = userId ? await getDashboardShellData(userId) : null;
 
   // Prefetch Bandsintown connection status so the client component
   // gets an instant cache hit instead of showing a loading skeleton.
-  const profileId = dashboardData.selectedProfile?.id;
+  const profileId = dashboardData?.selectedProfile?.id;
   if (profileId) {
     const queryClient = getQueryClient();
     await queryClient.prefetchQuery({

--- a/apps/web/app/app/(shell)/shell-route-matches.ts
+++ b/apps/web/app/app/(shell)/shell-route-matches.ts
@@ -100,6 +100,20 @@ function isDashboardSubRoute(pathname: string | null): boolean {
   return pathname.startsWith(`${APP_ROUTES.LEGACY_DASHBOARD}/`);
 }
 
+function isShellOptimizedSettingsRoute(pathname: string | null): boolean {
+  if (!pathname) return false;
+  if (
+    pathname === APP_ROUTES.SETTINGS_ARTIST_PROFILE ||
+    pathname.startsWith(`${APP_ROUTES.SETTINGS_ARTIST_PROFILE}/`)
+  ) {
+    return false;
+  }
+  return (
+    pathname === APP_ROUTES.SETTINGS ||
+    pathname.startsWith(`${APP_ROUTES.SETTINGS}/`)
+  );
+}
+
 function isLightweightShellRoute(pathname: string | null): boolean {
   return (
     isChatShellRoute(pathname) ||
@@ -107,7 +121,8 @@ function isLightweightShellRoute(pathname: string | null): boolean {
     isLyricsShellRoute(pathname) ||
     isLibraryShellRoute(pathname) ||
     isTasksShellRoute(pathname) ||
-    isDashboardSubRoute(pathname)
+    isDashboardSubRoute(pathname) ||
+    isShellOptimizedSettingsRoute(pathname)
   );
 }
 
@@ -116,5 +131,12 @@ export function shouldUseEssentialShellData(pathname: string | null): boolean {
 }
 
 export function shouldRedirectToOnboarding(pathname: string | null): boolean {
-  return isLightweightShellRoute(pathname);
+  return (
+    isChatShellRoute(pathname) ||
+    isReleasesShellRoute(pathname) ||
+    isLyricsShellRoute(pathname) ||
+    isLibraryShellRoute(pathname) ||
+    isTasksShellRoute(pathname) ||
+    isDashboardSubRoute(pathname)
+  );
 }

--- a/apps/web/tests/unit/app/settings-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/settings-shell-normalization.test.ts
@@ -86,6 +86,25 @@ const SETTINGS_ALIAS_ROUTES = [
   },
 ] as const;
 
+const SETTINGS_PROFILE_SCOPED_PREFETCH_ROUTES = [
+  findSourceFile(
+    resolve(process.cwd(), 'app/app/(shell)/settings/contacts/page.tsx'),
+    resolve(
+      process.cwd(),
+      'apps/web/app/app/(shell)/settings/contacts/page.tsx'
+    )
+  ),
+  findSourceFile(
+    resolve(process.cwd(), 'app/app/(shell)/settings/touring/page.tsx'),
+    resolve(process.cwd(), 'apps/web/app/app/(shell)/settings/touring/page.tsx')
+  ),
+] as const;
+
+const SETTINGS_PROFILE_SCOPED_PREFETCH_CANDIDATES = [
+  resolve(process.cwd(), 'app/app/(shell)/settings/contacts/page.tsx'),
+  resolve(process.cwd(), 'app/app/(shell)/settings/touring/page.tsx'),
+] as const;
+
 describe('settings shell normalization', () => {
   it('keeps the settings route group as the only PageShell owner', () => {
     expect(SETTINGS_LAYOUT).toBeDefined();
@@ -131,6 +150,26 @@ describe('settings shell normalization', () => {
       expect(source).not.toContain('getCachedAuth');
       expect(source).not.toContain('DashboardSettings');
       expect(source).not.toContain('redirect_url=/app/settings');
+    }
+  });
+
+  it('keeps profile-scoped settings prefetches on the shell data path', () => {
+    const missingFiles = SETTINGS_PROFILE_SCOPED_PREFETCH_ROUTES.filter(
+      filePath => !filePath
+    );
+    expect(missingFiles).toEqual([]);
+
+    for (const filePath of SETTINGS_PROFILE_SCOPED_PREFETCH_ROUTES) {
+      if (!filePath) {
+        throw new Error(
+          `Could not find profile-scoped settings source. Checked: ${SETTINGS_PROFILE_SCOPED_PREFETCH_CANDIDATES.join(', ')}`
+        );
+      }
+
+      const source = readFileSync(filePath, 'utf8');
+      expect(source).toContain('getCachedAuth');
+      expect(source).toContain('getDashboardShellData');
+      expect(source).not.toContain('getDashboardData');
     }
   });
 });

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -139,6 +139,20 @@ describe('shouldUseEssentialShellData', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.DASHBOARD)).toBe(true);
   });
 
+  it('returns true for settings routes that do not need supplementary dashboard data', () => {
+    expect(shouldUseEssentialShellData(APP_ROUTES.SETTINGS_ACCOUNT)).toBe(true);
+    expect(shouldUseEssentialShellData(APP_ROUTES.SETTINGS_CONTACTS)).toBe(
+      true
+    );
+    expect(shouldUseEssentialShellData(APP_ROUTES.SETTINGS_TOURING)).toBe(true);
+  });
+
+  it('keeps artist profile settings on the full dashboard data path', () => {
+    expect(
+      shouldUseEssentialShellData(APP_ROUTES.SETTINGS_ARTIST_PROFILE)
+    ).toBe(false);
+  });
+
   it('returns false for null', () => {
     expect(shouldUseEssentialShellData(null)).toBe(false);
   });
@@ -151,6 +165,12 @@ describe('shouldRedirectToOnboarding', () => {
     expect(shouldRedirectToOnboarding(APP_ROUTES.LYRICS)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.LIBRARY)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.DASHBOARD_TASKS)).toBe(true);
+  });
+
+  it('does not add onboarding redirects to settings route chrome optimization', () => {
+    expect(shouldRedirectToOnboarding(APP_ROUTES.SETTINGS_CONTACTS)).toBe(
+      false
+    );
   });
 
   it('returns false for null', () => {

--- a/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
@@ -88,8 +88,23 @@ describe('@critical DashboardShellContent behavior contracts', () => {
       expect(shouldUseEssentialShellData('/app')).toBe(true);
     });
 
-    it('settings routes use full dashboard data', () => {
-      expect(shouldUseEssentialShellData('/app/settings')).toBe(false);
+    it('optimized settings routes use essential shell data', () => {
+      expect(shouldUseEssentialShellData(APP_ROUTES.SETTINGS)).toBe(true);
+      expect(shouldUseEssentialShellData(APP_ROUTES.SETTINGS_ACCOUNT)).toBe(
+        true
+      );
+      expect(shouldUseEssentialShellData(APP_ROUTES.SETTINGS_CONTACTS)).toBe(
+        true
+      );
+      expect(shouldUseEssentialShellData(APP_ROUTES.SETTINGS_TOURING)).toBe(
+        true
+      );
+    });
+
+    it('artist profile settings routes use full dashboard data', () => {
+      expect(
+        shouldUseEssentialShellData(APP_ROUTES.SETTINGS_ARTIST_PROFILE)
+      ).toBe(false);
     });
 
     it('null pathname uses full dashboard data', () => {
@@ -124,8 +139,17 @@ describe('@critical DashboardShellContent behavior contracts', () => {
       // instead of wrapping in HydrateClient + FeatureFlagsProvider
     });
 
-    it('settings route is not essential (gets HydrateClient wrapper)', () => {
-      expect(isChatShellRoute('/app/settings')).toBe(false);
+    it('optimized settings route is essential but not a chat route', () => {
+      expect(shouldUseEssentialShellData(APP_ROUTES.SETTINGS_CONTACTS)).toBe(
+        true
+      );
+      expect(isChatShellRoute(APP_ROUTES.SETTINGS_CONTACTS)).toBe(false);
+    });
+
+    it('artist profile settings route gets full shell hydration', () => {
+      expect(
+        shouldUseEssentialShellData(APP_ROUTES.SETTINGS_ARTIST_PROFILE)
+      ).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary
- JOV-2333: route eligible settings pages through the shell-optimized dashboard data path.
- Contacts and touring prefetch profile-scoped data with `getDashboardShellData(userId)`, not the full dashboard fetch.
- Added route/source guards so artist-profile settings stay on the full dashboard data path and settings onboarding redirects do not change.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/shell-route-matches.test.ts tests/unit/app/settings-shell-normalization.test.ts tests/unit/app/settings-page.test.tsx tests/unit/dashboard/dashboard-shell-content.test.ts --config=vitest.config.mts`
- `pnpm biome check apps/web/app/app/(shell)/shell-route-matches.ts apps/web/app/app/(shell)/settings/contacts/page.tsx apps/web/app/app/(shell)/settings/touring/page.tsx apps/web/tests/unit/app/shell-route-matches.test.ts apps/web/tests/unit/app/settings-shell-normalization.test.ts apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`

## Review Notes
- No visual rendering changed. Design review was source-only: route chrome stays the same.
- Artist profile settings remain on the full dashboard data path for avatar-quality and preview hydration.
- Settings onboarding redirect behavior is unchanged.
- JOV-2334 tracks the base version-manifest mismatch separately; this PR does not touch desktop release files.

<!-- agent-run-artifact
{
  "id": "codex-47dcb7381da212257cf1b4c7822125bb13bc11df",
  "source": "github",
  "sourceRunId": "47dcb7381da212257cf1b4c7822125bb13bc11df",
  "kind": "qa",
  "status": "done",
  "title": "Settings shell data path",
  "summary": "JOV-2333 moved eligible settings routes to the shell-optimized dashboard data path. No visual rendering changed.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr",
    "mutate_linear"
  ],
  "forbiddenActions": [
    "merge",
    "deploy",
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "User approved autonomous shipping for non-visual shell slices.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2333",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2333/shell-make-settings-routes-use-the-lightweight-shell-data-path",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/8917",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused route/settings tests passed: 52 assertions across shell-route-matches, settings-shell-normalization, settings-page, and dashboard-shell-content.",
      "checkedAt": "2026-05-17T03:41:21.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Source review passed. No visual UI diff; artist-profile stays full-data; settings onboarding redirect behavior unchanged.",
      "checkedAt": "2026-05-17T03:41:21.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, typecheck, and git diff check passed locally.",
      "checkedAt": "2026-05-17T03:41:21.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic checks only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-17T03:41:21.000Z",
  "updatedAt": "2026-05-17T03:41:21.000Z",
  "metadata": {
    "visualChange": false,
    "worktree": "/tmp/jovie-pr8917-clean"
  }
}
-->
