### PR TITLE
fix: resolve signup readiness env file from repo root

### DIFF
--- a/apps/web/scripts/check-signup-readiness.test.ts
+++ b/apps/web/scripts/check-signup-readiness.test.ts
@@ -1,0 +1,33 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveEnvFilePath } from './check-signup-readiness';
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const webRoot = resolve(scriptsDir, '..');
+const repoRoot = resolve(webRoot, '..', '..');
+const testDirName = `.tmp-signup-readiness-env-file-test-${process.pid}`;
+const testDir = resolve(repoRoot, testDirName);
+
+afterEach(() => {
+  rmSync(testDir, { force: true, recursive: true });
+});
+
+describe('signup readiness env file resolution', () => {
+  it('finds repo-root Vercel env files when invoked from the web package cwd', () => {
+    const relativeEnvPath = `${testDirName}/prod.env`;
+    const repoEnvPath = resolve(repoRoot, relativeEnvPath);
+    mkdirSync(dirname(repoEnvPath), { recursive: true });
+    writeFileSync(repoEnvPath, 'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test\n');
+
+    const originalCwd = process.cwd();
+    process.chdir(webRoot);
+
+    try {
+      expect(resolveEnvFilePath(relativeEnvPath)).toBe(repoEnvPath);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+});

--- a/apps/web/scripts/check-signup-readiness.ts
+++ b/apps/web/scripts/check-signup-readiness.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
 import { existsSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parse } from 'dotenv';
 import {
   checkSignupOnboardingReadiness,
@@ -14,6 +15,10 @@ interface CliOptions {
   readonly source: SignupOnboardingReadinessSource;
   readonly file?: string;
 }
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const webRoot = resolve(scriptDir, '..');
+const repoRoot = resolve(webRoot, '..', '..');
 
 function parseArgValue(arg: string, name: string): string | null {
   const prefix = `${name}=`;
@@ -73,11 +78,27 @@ function defaultVercelEnvFile(target: SignupOnboardingReadinessTarget): string {
   return '.env.local';
 }
 
-function readEnvFile(path: string): Record<string, string> {
-  const resolvedPath = resolve(process.cwd(), path);
-  if (!existsSync(resolvedPath)) {
-    throw new Error(`Env file not found: ${path}`);
+export function resolveEnvFilePath(path: string): string {
+  const candidates = isAbsolute(path)
+    ? [path]
+    : [
+        resolve(process.cwd(), path),
+        resolve(webRoot, path),
+        resolve(repoRoot, path),
+      ];
+  const resolvedPath = candidates.find(candidate => existsSync(candidate));
+
+  if (!resolvedPath) {
+    throw new Error(
+      `Env file not found: ${path} (checked ${candidates.join(', ')})`
+    );
   }
+
+  return resolvedPath;
+}
+
+function readEnvFile(path: string): Record<string, string> {
+  const resolvedPath = resolveEnvFilePath(path);
   return parse(readFileSync(resolvedPath));
 }
 
@@ -113,11 +134,16 @@ async function main() {
   process.exit(result.ok ? 0 : 1);
 }
 
-main().catch(error => {
-  console.error(
-    `[signup-readiness] crashed: ${
-      error instanceof Error ? error.message : String(error)
-    }`
-  );
-  process.exit(1);
-});
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch(error => {
+    console.error(
+      `[signup-readiness] crashed: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- Fixes the production deploy gate crash from `pnpm --filter=@jovie/web exec` running the readiness script from `apps/web` while Vercel writes `.vercel/.env.production.local` at the repo root.
- Adds focused script coverage for repo-root env file resolution from the web package cwd.

## Verification
- `pnpm biome check --write apps/web/scripts/check-signup-readiness.ts apps/web/scripts/check-signup-readiness.test.ts`
- `pnpm --filter @jovie/web exec vitest run scripts/check-signup-readiness.test.ts tests/unit/lib/readiness/signup-onboarding.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter=@jovie/web exec tsx scripts/check-signup-readiness.ts --target=prd --source=vercel-file --file=.vercel/.env.production.local`
- pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`
