### PR TITLE
fix(shell): canonicalize presence route

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/presence/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/presence/page.tsx
@@ -4,9 +4,9 @@ import { APP_ROUTES } from '@/constants/routes';
 export const runtime = 'nodejs';
 
 /**
- * Presence page — redirects to artist profile settings (Music tab in the right drawer).
+ * Legacy presence route — redirects to artist profile settings (Music tab in the right drawer).
  * Suggested DSP matches are now shown inline in the profile sidebar.
  */
-export default function PresencePage() {
+export default function LegacyPresencePage() {
   redirect(`${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=music`);
 }

--- a/apps/web/app/app/(shell)/presence/page.tsx
+++ b/apps/web/app/app/(shell)/presence/page.tsx
@@ -1,0 +1,11 @@
+import { redirect } from 'next/navigation';
+import { APP_ROUTES } from '@/constants/routes';
+
+export const runtime = 'nodejs';
+
+/**
+ * Canonical presence alias. DSP matches now live in artist profile settings.
+ */
+export default function PresencePage() {
+  redirect(`${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=music`);
+}

--- a/apps/web/app/app/(shell)/shell-route-matches.ts
+++ b/apps/web/app/app/(shell)/shell-route-matches.ts
@@ -103,6 +103,14 @@ export function isInsightsShellRoute(pathname: string | null): boolean {
   );
 }
 
+export function isPresenceShellRoute(pathname: string | null): boolean {
+  if (!pathname) return false;
+  return (
+    pathname === APP_ROUTES.PRESENCE ||
+    pathname.startsWith(`${APP_ROUTES.PRESENCE}/`)
+  );
+}
+
 function isDashboardSubRoute(pathname: string | null): boolean {
   if (!pathname) return false;
   return pathname.startsWith(`${APP_ROUTES.LEGACY_DASHBOARD}/`);
@@ -130,6 +138,7 @@ function isLightweightShellRoute(pathname: string | null): boolean {
     isLibraryShellRoute(pathname) ||
     isTasksShellRoute(pathname) ||
     isInsightsShellRoute(pathname) ||
+    isPresenceShellRoute(pathname) ||
     isDashboardSubRoute(pathname) ||
     isShellOptimizedSettingsRoute(pathname)
   );
@@ -147,6 +156,7 @@ export function shouldRedirectToOnboarding(pathname: string | null): boolean {
     isLibraryShellRoute(pathname) ||
     isTasksShellRoute(pathname) ||
     isInsightsShellRoute(pathname) ||
+    isPresenceShellRoute(pathname) ||
     isDashboardSubRoute(pathname)
   );
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -429,15 +429,11 @@ const nextConfig = {
   },
   async rewrites() {
     return [
-      // Keep canonical app URLs attached to legacy dashboard route owners while
-      // those surfaces are migrated one-by-one.
+      // Keep canonical releases attached to the legacy dashboard route owner
+      // until the releases surface is migrated.
       {
         source: '/app/releases',
         destination: '/app/dashboard/releases',
-      },
-      {
-        source: '/app/presence',
-        destination: '/app/dashboard/presence',
       },
     ];
   },

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -4,6 +4,7 @@ import {
   isInsightsShellRoute,
   isLibraryShellRoute,
   isLyricsShellRoute,
+  isPresenceShellRoute,
   isReleasesShellRoute,
   isTasksShellRoute,
   resolveAppShellRequestPath,
@@ -133,6 +134,16 @@ describe('isInsightsShellRoute', () => {
   });
 });
 
+describe('isPresenceShellRoute', () => {
+  it('matches the canonical presence route', () => {
+    expect(isPresenceShellRoute(APP_ROUTES.PRESENCE)).toBe(true);
+  });
+
+  it('matches nested presence subroutes', () => {
+    expect(isPresenceShellRoute(`${APP_ROUTES.PRESENCE}/platforms`)).toBe(true);
+  });
+});
+
 describe('shouldUseEssentialShellData', () => {
   it('returns true for chat routes', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.CHAT)).toBe(true);
@@ -150,6 +161,10 @@ describe('shouldUseEssentialShellData', () => {
 
   it('returns true for the canonical insights route', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.INSIGHTS)).toBe(true);
+  });
+
+  it('returns true for the canonical presence route', () => {
+    expect(shouldUseEssentialShellData(APP_ROUTES.PRESENCE)).toBe(true);
   });
 
   it('returns true for dashboard root', () => {
@@ -183,6 +198,7 @@ describe('shouldRedirectToOnboarding', () => {
     expect(shouldRedirectToOnboarding(APP_ROUTES.LIBRARY)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.DASHBOARD_TASKS)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.INSIGHTS)).toBe(true);
+    expect(shouldRedirectToOnboarding(APP_ROUTES.PRESENCE)).toBe(true);
   });
 
   it('does not add onboarding redirects to settings route chrome optimization', () => {

--- a/apps/web/tests/unit/dashboard/PresenceRedirectPage.test.ts
+++ b/apps/web/tests/unit/dashboard/PresenceRedirectPage.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
+
+const { redirectMock } = vi.hoisted(() => ({
+  redirectMock: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+describe('presence redirect routes', () => {
+  afterEach(() => {
+    redirectMock.mockClear();
+  });
+
+  it('redirects the canonical presence route to artist profile music settings', async () => {
+    const { default: PresencePage } = await import(
+      '../../../app/app/(shell)/presence/page'
+    );
+
+    PresencePage();
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      `${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=music`
+    );
+  });
+
+  it('redirects the legacy dashboard presence route to the same destination', async () => {
+    const { default: LegacyPresencePage } = await import(
+      '../../../app/app/(shell)/dashboard/presence/page'
+    );
+
+    LegacyPresencePage();
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      `${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=music`
+    );
+  });
+});

--- a/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
@@ -76,13 +76,14 @@ describe('@critical DashboardShellContent behavior contracts', () => {
       expect(shouldUseEssentialShellData('/app/dashboard/releases')).toBe(true);
     });
 
-    it('lyrics, library, tasks, and insights routes use essential shell data', () => {
+    it('lyrics, library, tasks, insights, and presence routes use essential shell data', () => {
       expect(shouldUseEssentialShellData(APP_ROUTES.LYRICS)).toBe(true);
       expect(shouldUseEssentialShellData(APP_ROUTES.LIBRARY)).toBe(true);
       expect(shouldUseEssentialShellData(APP_ROUTES.DASHBOARD_TASKS)).toBe(
         true
       );
       expect(shouldUseEssentialShellData(APP_ROUTES.INSIGHTS)).toBe(true);
+      expect(shouldUseEssentialShellData(APP_ROUTES.PRESENCE)).toBe(true);
     });
 
     it('dashboard root uses essential shell data', () => {

--- a/apps/web/tests/unit/routing/chat-route-rewrite.test.ts
+++ b/apps/web/tests/unit/routing/chat-route-rewrite.test.ts
@@ -46,4 +46,14 @@ describe('chat route rewrites', () => {
       rewrites.find(rewrite => rewrite.source === APP_ROUTES.INSIGHTS)
     ).toBeUndefined();
   }, 20_000);
+
+  it('does not rewrite canonical presence through the legacy dashboard alias', async () => {
+    const nextConfigModule = await import('../../../next.config.js');
+    const nextConfig = nextConfigModule.default ?? nextConfigModule;
+    const rewrites = flattenRewrites(await nextConfig.rewrites());
+
+    expect(
+      rewrites.find(rewrite => rewrite.source === APP_ROUTES.PRESENCE)
+    ).toBeUndefined();
+  }, 20_000);
 });


### PR DESCRIPTION
## Summary
- Add canonical `/app/presence` route ownership instead of rewriting it through `/app/dashboard/presence`.
- Keep both canonical and legacy presence entry points redirecting directly to artist profile music settings.
- Mark canonical presence as a lightweight/onboarding-guarded shell route so the redirect path does not load full dashboard data first.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/app/shell-route-matches.test.ts tests/unit/routing/chat-route-rewrite.test.ts tests/unit/dashboard/dashboard-shell-content.test.ts tests/unit/dashboard/PresenceRedirectPage.test.ts --config=vitest.config.mts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check 'apps/web/app/app/(shell)/presence/page.tsx' 'apps/web/app/app/(shell)/dashboard/presence/page.tsx' 'apps/web/app/app/(shell)/shell-route-matches.ts' apps/web/next.config.js apps/web/tests/unit/app/shell-route-matches.test.ts apps/web/tests/unit/routing/chat-route-rewrite.test.ts apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts apps/web/tests/unit/dashboard/PresenceRedirectPage.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm turbo typecheck`
- `JOVIE_AGENT_PROFILE=coder git diff --check`

## Visual Review
- No production visual rendering delta. This is route ownership, redirect behavior, and shell-data selection only.

<!-- agent-run-artifact
{
  "id": "codex-jov-2336-canonical-presence",
  "source": "ruflo",
  "sourceRunId": "10ba17503688506beff3cd463da7da0d27cef5f6",
  "kind": "workflow",
  "status": "done",
  "title": "Canonicalize presence route",
  "summary": "Moved /app/presence off the Next rewrite path, kept legacy dashboard presence as a direct redirect to artist profile music settings, and covered shell route matching plus redirect behavior with focused tests.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "write_code",
    "open_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "No production visual rendering change; user approved no-visual-change slices to proceed autonomously.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": null,
  "linearIssueUrl": null,
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/8920",
  "adminSurface": "/app/presence",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused Vitest passed: shell route matches, rewrite removal, dashboard shell contract, and canonical plus legacy presence redirects. 58 tests passed.",
      "checkedAt": "2026-05-17T04:31:30Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed the diff for App Router routing, redirect behavior, shell data selection, and route constant usage. No experimental imports or visual surface changes.",
      "checkedAt": "2026-05-17T04:31:30Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome passed, web typecheck passed, pnpm turbo typecheck passed, git diff --check passed, and commit hooks passed.",
      "checkedAt": "2026-05-17T04:31:30Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic code and verification run."
  },
  "blockedReason": null,
  "createdAt": "2026-05-17T04:31:30Z",
  "updatedAt": "2026-05-17T04:31:30Z",
  "metadata": {
    "slice": "canonical-presence",
    "visualDelta": false,
    "localCommit": "10ba17503688506beff3cd463da7da0d27cef5f6"
  }
}
-->
