### PR TITLE
test(e2e): relax chat first-turn timeout

### DIFF
--- a/apps/web/tests/e2e/chat-first-turn-regression.spec.ts
+++ b/apps/web/tests/e2e/chat-first-turn-regression.spec.ts
@@ -121,7 +121,7 @@ test('new thread album-art unavailable state survives refresh', async ({
     process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
     'Requires E2E_USE_TEST_AUTH_BYPASS=1'
   );
-  test.setTimeout(120_000);
+  test.setTimeout(240_000);
 
   await mockChatLifecycle(page);
   await setTestAuthBypassSession(page, 'creator-ready', 'e2e-chat-first-turn');


### PR DESCRIPTION
## Summary
- Increase the chat first-turn regression spec timeout from 120s to 240s so cold Next dev compiles do not consume the entire test budget before the refresh assertions run.

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm biome check apps/web/tests/e2e/chat-first-turn-regression.spec.ts
- git diff --check
- E2E_USE_TEST_AUTH_BYPASS=1 E2E_SKIP_SEED=1 E2E_SKIP_WARMUP=1 BASE_URL=http://localhost:3195 JOVIE_AGENT_PROFILE=coder doppler run --preserve-env="E2E_USE_TEST_AUTH_BYPASS,E2E_SKIP_SEED,E2E_SKIP_WARMUP,BASE_URL,JOVIE_AGENT_PROFILE" --project jovie-web --config dev -- pnpm --filter @jovie/web exec playwright test tests/e2e/chat-first-turn-regression.spec.ts --project=chromium --no-deps --reporter=line
- git commit hook: next:proxy-guard, staged Biome/ESLint, web typecheck
- git push hook: repo Biome, next:proxy-guard, tailwind:check, typecheck, lint