### PR TITLE
fix: pin vercel env pulls to configured project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2945,6 +2945,9 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
       - name: Pull env (preview)
         run: ./node_modules/.bin/vercel pull --yes --environment=preview --token ${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       - name: Strip deprecated Turbo env overrides (preview)
         run: |
           for env_file in .vercel/.env.preview.local .vercel/.env.local; do
@@ -2958,6 +2961,8 @@ jobs:
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
           COREPACK_ENABLE_STRICT: 0
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       - name: Deploy (PR preview, fast deployment for UI-only changes)
         id: pr_deploy
         run: |
@@ -3534,6 +3539,9 @@ jobs:
           secrets: ${{ toJSON(secrets) }}
       - name: Pull env (production)
         run: ./node_modules/.bin/vercel pull --yes --environment=production --token ${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       - name: Strip deprecated Turbo env overrides (production)
         run: |
           for env_file in .vercel/.env.production.local .vercel/.env.local; do
@@ -3549,6 +3557,8 @@ jobs:
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: 0
           COREPACK_ENABLE_STRICT: 0
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       - name: Deploy (staging preview, prebuilt)
         id: deploy
         run: |

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(testDir, '..', '..', '..', '..', '..');
+const workflowPath = resolve(repoRoot, '.github/workflows/ci.yml');
+
+function getStepBlock(workflow: string, stepName: string): string {
+  const lines = workflow.split('\n');
+  const start = lines.findIndex(line => line.trim() === `- name: ${stepName}`);
+
+  expect(start, `Missing workflow step: ${stepName}`).toBeGreaterThanOrEqual(0);
+
+  const block: string[] = [];
+
+  for (let index = start; index < lines.length; index++) {
+    const line = lines[index]!;
+
+    if (index > start && line.startsWith('      - name: ')) break;
+    if (index > start && /^[a-zA-Z0-9_-]+:/.test(line)) break;
+
+    block.push(line);
+  }
+
+  return block.join('\n');
+}
+
+describe('deploy workflow Vercel env resolution', () => {
+  it('pins Vercel pull and build commands to the configured project', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const steps = [
+      'Pull env (preview)',
+      'Build (PR preview)',
+      'Pull env (production)',
+      'Build (preview target for staging verification)',
+    ];
+
+    for (const stepName of steps) {
+      const step = getStepBlock(workflow, stepName);
+
+      expect(step).toContain('VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}');
+      expect(step).toContain(
+        'VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}'
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- pin preview and production Vercel pull/build steps to the configured org/project env
- add a workflow unit guard so Vercel env resolution cannot silently fall back to an implicit project

## Verification
- pnpm biome check --write .github/workflows/ci.yml apps/web/tests/unit/ci/deploy-workflow.test.ts
- pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts scripts/check-signup-readiness.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- VERCEL_ORG_ID=$(node -p 'require("./.vercel/project.json").orgId') VERCEL_PROJECT_ID=$(node -p 'require("./.vercel/project.json").projectId') ./node_modules/.bin/vercel pull --yes --environment=production && pnpm --filter=@jovie/web exec tsx scripts/check-signup-readiness.ts --target=prd --source=vercel-file --file=.vercel/.env.production.local\n- git push pre-push hook: biome check . && pnpm --filter=@jovie/web run pre-push