### PR TITLE
fix(shell): canonicalize releases route

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/ReleasesRoute.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/ReleasesRoute.tsx
@@ -1,0 +1,75 @@
+import { redirect } from 'next/navigation';
+import { APP_ROUTES } from '@/constants/routes';
+import { PageErrorState } from '@/features/feedback/PageErrorState';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { captureError } from '@/lib/error-tracking';
+import { queryKeys } from '@/lib/queries';
+import { HydrateClient } from '@/lib/queries/HydrateClient';
+import { getDehydratedState, getQueryClient } from '@/lib/queries/server';
+import { getDashboardShellData } from '../actions';
+import { loadReleaseMatrix } from './actions';
+import { ReleasesClientBoundary } from './ReleasesClientBoundary';
+import { ReleasesPageClient } from './ReleasesPageClient';
+
+/**
+ * Releases page — client-first with shell-only server work.
+ *
+ * Auth check via getCachedAuth (Clerk JWT, no DB) runs first. The shared shell
+ * and /app route warm the release matrix cache ahead of navigation, so this
+ * page keeps warm transitions instant while still hydrating release data on
+ * direct visits, refreshes, and bookmarks.
+ */
+export async function ReleasesRoute() {
+  const { userId } = await getCachedAuth();
+  if (!userId) {
+    const signInParams = new URLSearchParams({
+      redirect_url: APP_ROUTES.RELEASES,
+    });
+    redirect(`${APP_ROUTES.SIGNIN}?${signInParams.toString()}`);
+  }
+
+  // Shell data is cached from the shell layout (same request) — resolves instantly.
+  const dashboardData = await getDashboardShellData(userId);
+
+  if (dashboardData.dashboardLoadError) {
+    void captureError(
+      'Dashboard data load failed on releases page',
+      dashboardData.dashboardLoadError,
+      { route: APP_ROUTES.RELEASES }
+    );
+    return (
+      <PageErrorState message='Failed to load releases data. Please refresh the page.' />
+    );
+  }
+
+  if (dashboardData.needsOnboarding) {
+    redirect(APP_ROUTES.START);
+  }
+
+  const profileId = dashboardData.selectedProfile?.id;
+  if (profileId) {
+    const queryClient = getQueryClient();
+    try {
+      await queryClient.fetchQuery({
+        queryKey: queryKeys.releases.matrix(profileId),
+        queryFn: () => loadReleaseMatrix(profileId),
+      });
+    } catch (error) {
+      void captureError(
+        'Release matrix prefetch failed on releases page',
+        error,
+        {
+          route: APP_ROUTES.RELEASES,
+        }
+      );
+    }
+  }
+
+  return (
+    <HydrateClient state={getDehydratedState()}>
+      <ReleasesClientBoundary>
+        <ReleasesPageClient />
+      </ReleasesClientBoundary>
+    </HydrateClient>
+  );
+}

--- a/apps/web/app/app/(shell)/releases/error.tsx
+++ b/apps/web/app/app/(shell)/releases/error.tsx
@@ -1,0 +1,3 @@
+'use client';
+
+export { default } from '../dashboard/releases/error';

--- a/apps/web/app/app/(shell)/releases/loading.tsx
+++ b/apps/web/app/app/(shell)/releases/loading.tsx
@@ -1,0 +1,1 @@
+export { default, ReleaseTableSkeleton } from '../dashboard/releases/loading';

--- a/apps/web/app/app/(shell)/releases/page.tsx
+++ b/apps/web/app/app/(shell)/releases/page.tsx
@@ -1,4 +1,4 @@
-import { ReleasesRoute } from './ReleasesRoute';
+import { ReleasesRoute } from '../dashboard/releases/ReleasesRoute';
 
 export const runtime = 'nodejs';
 

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -23,7 +23,7 @@ export const APP_ROUTES = {
   /** Legacy library path. Keep as a redirect source only. */
   LEGACY_DASHBOARD_LIBRARY: '/app/dashboard/library',
   DASHBOARD_LIBRARY: '/app/library',
-  /** Legacy release workspace route. Keep for the route owner and nested task aliases; use RELEASES for navigation. */
+  /** Legacy release workspace route. Keep for old bookmarks and nested task aliases; use RELEASES for navigation. */
   DASHBOARD_RELEASES: '/app/dashboard/releases',
   DASHBOARD_TASKS: '/app/dashboard/tasks',
   DASHBOARD_RELEASE_TASKS: '/app/dashboard/releases/[releaseId]/tasks',

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -428,14 +428,7 @@ const nextConfig = {
     ];
   },
   async rewrites() {
-    return [
-      // Keep canonical releases attached to the legacy dashboard route owner
-      // until the releases surface is migrated.
-      {
-        source: '/app/releases',
-        destination: '/app/dashboard/releases',
-      },
-    ];
+    return [];
   },
   env: {
     // Build-time env vars — these get inlined into client bundles by Next.js

--- a/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
@@ -73,6 +73,7 @@ describe('@critical DashboardShellContent behavior contracts', () => {
     });
 
     it('releases routes use essential shell data', () => {
+      expect(shouldUseEssentialShellData(APP_ROUTES.RELEASES)).toBe(true);
       expect(shouldUseEssentialShellData('/app/dashboard/releases')).toBe(true);
     });
 

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -15,10 +15,6 @@ import {
 
 const SHELL_ROOT = path.resolve(__dirname, '../../../app/app/(shell)');
 
-const NAV_ROUTE_PAGE_ALIASES: Record<string, string> = {
-  '/app/releases': '/app/dashboard/releases',
-};
-
 const INTENTIONAL_INTERNAL_ROUTES: Record<string, string> = {
   '/app': 'Shell root entry page',
   '/app/chat/[id]': 'Thread detail is reached from chat history',
@@ -30,6 +26,8 @@ const INTENTIONAL_INTERNAL_ROUTES: Record<string, string> = {
     'Dynamic workflow route reached from releases actions',
   '/app/dashboard/releases/[releaseId]/downloads':
     'Internal release workflow (manual entry)',
+  '/app/dashboard/releases':
+    'Legacy releases workspace retained for old bookmarks',
   '/app/settings/retargeting-ads':
     'Legacy settings route redirected to Audience',
   '/app/dashboard/release-plan':
@@ -105,9 +103,7 @@ function getNavRoutePaths(): Set<string> {
     ...adminSettingsNavigation,
   ];
 
-  return new Set(
-    navItems.map(item => NAV_ROUTE_PAGE_ALIASES[item.href] ?? item.href)
-  );
+  return new Set(navItems.map(item => item.href));
 }
 
 describe('shell route coverage', () => {

--- a/apps/web/tests/unit/routing/chat-route-rewrite.test.ts
+++ b/apps/web/tests/unit/routing/chat-route-rewrite.test.ts
@@ -56,4 +56,14 @@ describe('chat route rewrites', () => {
       rewrites.find(rewrite => rewrite.source === APP_ROUTES.PRESENCE)
     ).toBeUndefined();
   }, 20_000);
+
+  it('does not rewrite canonical releases through the legacy dashboard alias', async () => {
+    const nextConfigModule = await import('../../../next.config.js');
+    const nextConfig = nextConfigModule.default ?? nextConfigModule;
+    const rewrites = flattenRewrites(await nextConfig.rewrites());
+
+    expect(
+      rewrites.find(rewrite => rewrite.source === APP_ROUTES.RELEASES)
+    ).toBeUndefined();
+  }, 20_000);
 });


### PR DESCRIPTION
## Summary
- Add canonical `/app/releases` route ownership instead of rewriting it through `/app/dashboard/releases`.
- Reuse the existing releases server/client route contract from both canonical and legacy entry points.
- Keep releases shell loading/error parity and update the rewrite regression tests.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/routes/shell-nav-coverage.test.ts tests/unit/routing/chat-route-rewrite.test.ts tests/unit/app/shell-route-matches.test.ts tests/unit/dashboard/dashboard-shell-content.test.ts --config=vitest.config.mts`
- `JOVIE_AGENT_PROFILE=coder pnpm exec biome check 'apps/web/app/app/(shell)/dashboard/releases/page.tsx' 'apps/web/app/app/(shell)/dashboard/releases/ReleasesRoute.tsx' 'apps/web/app/app/(shell)/releases/page.tsx' 'apps/web/app/app/(shell)/releases/loading.tsx' 'apps/web/app/app/(shell)/releases/error.tsx' apps/web/next.config.js apps/web/constants/routes.ts apps/web/tests/unit/routing/chat-route-rewrite.test.ts apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts apps/web/tests/unit/routes/shell-nav-coverage.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm turbo typecheck`
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_mock NEXT_IGNORE_ESLINT=1 NEXT_IGNORE_TYPECHECK=1 NEXT_PRIVATE_SKIP_SIZE_CHECK=true JOVIE_AGENT_PROFILE=coder pnpm turbo build --filter=@jovie/web`
- `JOVIE_AGENT_PROFILE=coder git diff --check`

## Visual Review
- No production visual rendering delta. This is route ownership and App Router persistence cleanup only; the canonical route renders the same releases client surface and loading/error states.

<!-- agent-run-artifact
{
  "id": "codex-jov-2337-canonical-releases",
  "source": "ruflo",
  "sourceRunId": "389707998323b17e5cd01101db40f806fef7aa55",
  "kind": "workflow",
  "status": "done",
  "title": "Canonicalize releases route",
  "summary": "Moved /app/releases off the Next rewrite path by adding a canonical App Router page that reuses the existing releases route contract, preserving the legacy dashboard entry point for bookmarks and nested aliases.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "write_code",
    "open_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "No production visual rendering change; user approved no-visual-change slices to proceed autonomously.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": null,
  "linearIssueUrl": null,
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/8941",
  "adminSurface": "/app/releases",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused Vitest passed: shell nav coverage, route rewrite removal, shell route matching, and dashboard shell data contract. 60 tests passed.",
      "checkedAt": "2026-05-17T05:12:30Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed the diff for App Router route ownership, shared releases route contract reuse, legacy entry-point preservation, and absence of experimental imports or visual component changes.",
      "checkedAt": "2026-05-17T05:12:30Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome passed, web typecheck passed, local public-routes Next build passed, pnpm turbo typecheck passed, git diff --check passed, and commit hooks passed.",
      "checkedAt": "2026-05-17T05:12:30Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic code and verification run."
  },
  "blockedReason": null,
  "createdAt": "2026-05-17T04:51:30Z",
  "updatedAt": "2026-05-17T05:12:30Z",
  "metadata": {
    "slice": "canonical-releases",
    "visualDelta": false,
    "localCommit": "389707998323b17e5cd01101db40f806fef7aa55"
  }
}
-->
