### PR TITLE
fix: remove invalid Turnstile size

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
+++ b/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
@@ -28,7 +28,7 @@ declare global {
           'error-callback'?: (code: string) => void;
           'expired-callback'?: () => void;
           appearance?: 'always' | 'execute' | 'interaction-only';
-          size?: 'normal' | 'flexible' | 'compact' | 'invisible';
+          size?: 'normal' | 'flexible' | 'compact';
           theme?: 'auto' | 'light' | 'dark';
         }
       ) => string;
@@ -62,7 +62,6 @@ export function OnboardingTurnstile({
     try {
       widgetIdRef.current = window.turnstile.render(containerRef.current, {
         sitekey: siteKey,
-        size: 'invisible',
         appearance: 'interaction-only',
         theme: 'dark',
         callback: token => onToken(token),

--- a/apps/web/tests/unit/ci/vercel-config.test.ts
+++ b/apps/web/tests/unit/ci/vercel-config.test.ts
@@ -29,9 +29,13 @@ describe('Vercel function config', () => {
       expect(functionGlobs, configPath).not.toContain(
         'apps/web/app/api/**/*.ts'
       );
+      expect(functionGlobs, configPath).not.toContain('apps/web/app/api/**/*');
+      expect(functionGlobs, configPath).not.toContain(
+        'apps/web/app/api/cron/**/*'
+      );
       expect(
         functionGlobs.every(
-          glob => /(^|\/)app\/api\//.test(glob) && glob.endsWith('/**/*')
+          glob => glob.startsWith('app/api/') && glob.endsWith('/**/*')
         ),
         configPath
       ).toBe(true);

--- a/apps/web/tests/unit/ci/vercel-config.test.ts
+++ b/apps/web/tests/unit/ci/vercel-config.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(testDir, '..', '..', '..', '..', '..');
+
+function readVercelFunctions(relativePath: string): Record<string, unknown> {
+  const configPath = resolve(repoRoot, relativePath);
+  const config = JSON.parse(readFileSync(configPath, 'utf8')) as {
+    functions?: Record<string, unknown>;
+  };
+
+  return config.functions ?? {};
+}
+
+describe('Vercel function config', () => {
+  it('uses App Router function globs that Vercel can match', () => {
+    const configs = ['vercel.json', 'apps/web/vercel.json'];
+
+    for (const configPath of configs) {
+      const functionGlobs = Object.keys(readVercelFunctions(configPath));
+
+      expect(functionGlobs.length, `${configPath} functions`).toBeGreaterThan(
+        0
+      );
+      expect(functionGlobs, configPath).not.toContain('app/api/**/*.ts');
+      expect(functionGlobs, configPath).not.toContain(
+        'apps/web/app/api/**/*.ts'
+      );
+      expect(
+        functionGlobs.every(
+          glob => /(^|\/)app\/api\//.test(glob) && glob.endsWith('/**/*')
+        ),
+        configPath
+      ).toBe(true);
+    }
+  });
+});

--- a/apps/web/tests/unit/onboarding/OnboardingTurnstile.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingTurnstile.test.tsx
@@ -62,10 +62,11 @@ describe('OnboardingTurnstile', () => {
         expect.any(HTMLElement),
         expect.objectContaining({
           sitekey: 'site-key',
-          size: 'invisible',
+          appearance: 'interaction-only',
         })
       );
     });
+    expect(renderMock.mock.calls[0]?.[1]).not.toHaveProperty('size');
     expect(onToken).toHaveBeenCalledWith('turnstile-token');
     expect(onError).not.toHaveBeenCalled();
   });

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -50,10 +50,10 @@
     }
   ],
   "functions": {
-    "app/api/**/*.ts": {
+    "app/api/**/*": {
       "maxDuration": 30
     },
-    "app/api/cron/**/*.ts": {
+    "app/api/cron/**/*": {
       "maxDuration": 300
     }
   },

--- a/vercel.json
+++ b/vercel.json
@@ -54,10 +54,10 @@
     }
   ],
   "functions": {
-    "apps/web/app/api/**/*.ts": {
+    "apps/web/app/api/**/*": {
       "maxDuration": 30
     },
-    "apps/web/app/api/cron/**/*.ts": {
+    "apps/web/app/api/cron/**/*": {
       "maxDuration": 300
     }
   },

--- a/vercel.json
+++ b/vercel.json
@@ -54,10 +54,10 @@
     }
   ],
   "functions": {
-    "apps/web/app/api/**/*": {
+    "app/api/**/*": {
       "maxDuration": 30
     },
-    "apps/web/app/api/cron/**/*": {
+    "app/api/cron/**/*": {
       "maxDuration": 300
     }
   },


### PR DESCRIPTION
## Summary
- remove the invalid `size: invisible` option from the onboarding Turnstile render call
- narrow the local Turnstile type so `invisible` cannot be passed as a render size again
- update the regression test to assert we keep the interaction-only appearance without sending an invalid size
- align Vercel App Router function globs with current Vercel matching rules so the deploy can pass after readiness

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/onboarding/OnboardingTurnstile.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/vercel-config.test.ts tests/unit/ci/deploy-workflow.test.ts tests/unit/onboarding/OnboardingTurnstile.test.tsx`
- `pnpm biome check --write vercel.json apps/web/vercel.json apps/web/tests/unit/ci/vercel-config.test.ts apps/web/components/features/onboarding/OnboardingTurnstile.tsx apps/web/tests/unit/onboarding/OnboardingTurnstile.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Production evidence
- `https://jov.ie/start` returns 200 and no longer renders `turnstile is not configured`
- current deployed code still logs `[Cloudflare Turnstile] Invalid value for parameter "size" ... got "invisible"`; this PR removes that invalid option
- rerun of `main` deploy after resetting GitHub Vercel project secrets reached `[signup-readiness] status=passed` before hitting the now-fixed Vercel function-glob build error
