### PR TITLE
fix(shell): canonicalize tasks route

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/tasks/TasksRoute.tsx
+++ b/apps/web/app/app/(shell)/dashboard/tasks/TasksRoute.tsx
@@ -1,0 +1,13 @@
+import { TasksPageClient } from '@/components/features/dashboard/tasks/TasksPageClient';
+import { TasksWorkspaceUpgradeInterstitial } from '@/components/features/dashboard/tasks/TasksUpgradeInterstitial';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+
+export async function TasksRoute() {
+  const entitlements = await getCurrentUserEntitlements();
+
+  if (!entitlements.canAccessTasksWorkspace) {
+    return <TasksWorkspaceUpgradeInterstitial />;
+  }
+
+  return <TasksPageClient />;
+}

--- a/apps/web/app/app/(shell)/tasks/loading.tsx
+++ b/apps/web/app/app/(shell)/tasks/loading.tsx
@@ -1,0 +1,5 @@
+import { TasksRouteSkeleton } from '@/components/shell/TasksRouteSkeleton';
+
+export default function TasksLoading() {
+  return <TasksRouteSkeleton />;
+}

--- a/apps/web/app/app/(shell)/tasks/page.tsx
+++ b/apps/web/app/app/(shell)/tasks/page.tsx
@@ -1,4 +1,4 @@
-import { TasksRoute } from './TasksRoute';
+import { TasksRoute } from '../dashboard/tasks/TasksRoute';
 
 export default async function TasksPage() {
   return TasksRoute();

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -25,6 +25,7 @@ export const APP_ROUTES = {
   DASHBOARD_LIBRARY: '/app/library',
   /** Legacy release workspace route. Keep for old bookmarks and nested task aliases; use RELEASES for navigation. */
   DASHBOARD_RELEASES: '/app/dashboard/releases',
+  /** Legacy tasks path. Keep for old bookmarks; use TASKS for navigation. */
   DASHBOARD_TASKS: '/app/dashboard/tasks',
   DASHBOARD_RELEASE_TASKS: '/app/dashboard/releases/[releaseId]/tasks',
   DASHBOARD_TIPPING: '/app/dashboard/tipping',
@@ -39,7 +40,7 @@ export const APP_ROUTES = {
   AUDIENCE: '/app/audience',
   EARNINGS: '/app/earnings',
   LIBRARY: '/app/library',
-  TASKS: '/app/dashboard/tasks',
+  TASKS: '/app/tasks',
   CHAT: '/app/chat',
   CHAT_PROFILE_PANEL: '/app/chat?panel=profile',
   INSIGHTS: '/app/insights',

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -322,7 +322,7 @@ describe('DashboardNav interactions', () => {
     });
 
     const tasksLink = screen.getByRole('link', { name: 'Tasks' });
-    expect(tasksLink).toHaveAttribute('href', APP_ROUTES.DASHBOARD_TASKS);
+    expect(tasksLink).toHaveAttribute('href', APP_ROUTES.TASKS);
     tasksLink.addEventListener('click', event => event.preventDefault());
 
     await user.click(tasksLink);

--- a/apps/web/tests/unit/app/dashboard-tasks-page.test.tsx
+++ b/apps/web/tests/unit/app/dashboard-tasks-page.test.tsx
@@ -24,9 +24,10 @@ vi.mock(
   })
 );
 
-import TasksPage from '@/app/app/(shell)/dashboard/tasks/page';
+import LegacyTasksPage from '@/app/app/(shell)/dashboard/tasks/page';
+import TasksPage from '@/app/app/(shell)/tasks/page';
 
-describe('dashboard tasks page', () => {
+describe('tasks page routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -55,5 +56,15 @@ describe('dashboard tasks page', () => {
     expect(
       screen.queryByTestId('tasks-upgrade-interstitial')
     ).not.toBeInTheDocument();
+  });
+
+  it('keeps the legacy dashboard entry point on the same task contract', async () => {
+    mockGetCurrentUserEntitlements.mockResolvedValueOnce({
+      canAccessTasksWorkspace: true,
+    });
+
+    render(await LegacyTasksPage());
+
+    expect(screen.getByTestId('tasks-page-client')).toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -116,6 +116,7 @@ describe('isTasksShellRoute', () => {
   });
 
   it('matches nested task subroutes', () => {
+    expect(isTasksShellRoute(`${APP_ROUTES.TASKS}/task-abc`)).toBe(true);
     expect(isTasksShellRoute(`${APP_ROUTES.DASHBOARD_TASKS}/task-abc`)).toBe(
       true
     );
@@ -156,6 +157,7 @@ describe('shouldUseEssentialShellData', () => {
   it('returns true for lyrics, library, and tasks routes', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.LYRICS)).toBe(true);
     expect(shouldUseEssentialShellData(APP_ROUTES.LIBRARY)).toBe(true);
+    expect(shouldUseEssentialShellData(APP_ROUTES.TASKS)).toBe(true);
     expect(shouldUseEssentialShellData(APP_ROUTES.DASHBOARD_TASKS)).toBe(true);
   });
 
@@ -196,6 +198,7 @@ describe('shouldRedirectToOnboarding', () => {
     expect(shouldRedirectToOnboarding('/app/dashboard/releases')).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.LYRICS)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.LIBRARY)).toBe(true);
+    expect(shouldRedirectToOnboarding(APP_ROUTES.TASKS)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.DASHBOARD_TASKS)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.INSIGHTS)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.PRESENCE)).toBe(true);

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -23,7 +23,9 @@ describe('DashboardNav', () => {
 
     expect(getByRole('button', { name: 'Profile' })).toBeDefined();
     expect(getByRole('link', { name: 'Releases' })).toBeDefined();
-    expect(getByRole('link', { name: 'Tasks' })).toBeDefined();
+    expect(getByRole('link', { name: 'Tasks' }).getAttribute('href')).toBe(
+      APP_ROUTES.TASKS
+    );
     expect(getByRole('link', { name: 'Audience' })).toBeDefined();
     expect(getByRole('link', { name: 'Library' })).toBeDefined();
     expect(queryByRole('link', { name: 'Earnings' })).toBeNull();

--- a/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
@@ -80,6 +80,7 @@ describe('@critical DashboardShellContent behavior contracts', () => {
     it('lyrics, library, tasks, insights, and presence routes use essential shell data', () => {
       expect(shouldUseEssentialShellData(APP_ROUTES.LYRICS)).toBe(true);
       expect(shouldUseEssentialShellData(APP_ROUTES.LIBRARY)).toBe(true);
+      expect(shouldUseEssentialShellData(APP_ROUTES.TASKS)).toBe(true);
       expect(shouldUseEssentialShellData(APP_ROUTES.DASHBOARD_TASKS)).toBe(
         true
       );

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -28,6 +28,7 @@ const INTENTIONAL_INTERNAL_ROUTES: Record<string, string> = {
     'Internal release workflow (manual entry)',
   '/app/dashboard/releases':
     'Legacy releases workspace retained for old bookmarks',
+  '/app/dashboard/tasks': 'Legacy tasks workspace retained for old bookmarks',
   '/app/settings/retargeting-ads':
     'Legacy settings route redirected to Audience',
   '/app/dashboard/release-plan':


### PR DESCRIPTION
## Summary
- Add canonical `/app/tasks` route ownership instead of navigating primary shell users through `/app/dashboard/tasks`.
- Reuse the existing tasks entitlement/server route contract from both canonical and legacy entry points.
- Keep legacy `/app/dashboard/tasks` available for old bookmarks and document it in shell nav coverage.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/routes/shell-nav-coverage.test.ts tests/unit/app/dashboard-tasks-page.test.tsx tests/unit/app/shell-route-matches.test.ts tests/unit/dashboard/dashboard-shell-content.test.ts tests/unit/dashboard/DashboardNav.test.tsx --config=vitest.config.mts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/components/dashboard/DashboardNav.interaction.test.tsx tests/unit/dashboard/DashboardNav.test.tsx --config=vitest.config.mts`
- `JOVIE_AGENT_PROFILE=coder pnpm exec biome check 'apps/web/app/app/(shell)/dashboard/tasks/page.tsx' 'apps/web/app/app/(shell)/dashboard/tasks/TasksRoute.tsx' 'apps/web/app/app/(shell)/tasks/page.tsx' 'apps/web/app/app/(shell)/tasks/loading.tsx' apps/web/constants/routes.ts apps/web/tests/unit/app/dashboard-tasks-page.test.tsx apps/web/tests/unit/app/shell-route-matches.test.ts apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts apps/web/tests/unit/dashboard/DashboardNav.test.tsx apps/web/tests/unit/routes/shell-nav-coverage.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_mock NEXT_IGNORE_ESLINT=1 NEXT_IGNORE_TYPECHECK=1 NEXT_PRIVATE_SKIP_SIZE_CHECK=true JOVIE_AGENT_PROFILE=coder pnpm turbo build --filter=@jovie/web`
- `JOVIE_AGENT_PROFILE=coder git diff --check`
- Commit hooks: `next:proxy-guard`, Biome, ESLint, and web typecheck passed.

## Visual Review
- No production visual rendering delta. This is route ownership and App Router persistence cleanup only; the canonical route renders the same tasks client surface, entitlement interstitial, and loading state.

<!-- agent-run-artifact
{
  "id": "codex-jov-2338-canonical-tasks",
  "source": "ruflo",
  "sourceRunId": "603fd7d51e27b344cb3219665970b91b6c331e95",
  "kind": "workflow",
  "status": "done",
  "title": "Canonicalize tasks route",
  "summary": "Moved primary task navigation to /app/tasks by adding a canonical App Router page that reuses the existing tasks route contract, preserving the legacy dashboard entry point for bookmarks.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "write_code",
    "open_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "No production visual rendering change; user approved no-visual-change slices to proceed autonomously.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": null,
  "linearIssueUrl": null,
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/8944",
  "adminSurface": "/app/tasks",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused Vitest passed: shell nav coverage, task page route contract, shell route matching, dashboard shell data contract, DashboardNav, and DashboardNav interaction coverage. 108 tests passed across focused runs.",
      "checkedAt": "2026-05-17T05:43:00Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed the diff for App Router route ownership, shared tasks route contract reuse, legacy entry-point preservation, and absence of experimental imports or visual component changes.",
      "checkedAt": "2026-05-17T05:43:00Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome passed, web typecheck passed, local public-routes Next build passed, git diff --check passed, commit hooks passed, and pre-push hooks passed.",
      "checkedAt": "2026-05-17T05:43:00Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic code and verification run."
  },
  "blockedReason": null,
  "createdAt": "2026-05-17T05:34:00Z",
  "updatedAt": "2026-05-17T05:43:00Z",
  "metadata": {
    "slice": "canonical-tasks",
    "visualDelta": false,
    "localCommit": "603fd7d51e27b344cb3219665970b91b6c331e95"
  }
}
-->
