### PR TITLE
fix(shell): add canonical earnings route

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/earnings/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/earnings/page.tsx
@@ -1,17 +1,8 @@
-import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
-import { getCachedAuth } from '@/lib/auth/cached';
+import { redirectFromEarningsRoute } from '../../earnings/earnings-route';
 
 export const runtime = 'nodejs';
 
 export default async function EarningsPage() {
-  const { userId } = await getCachedAuth();
-
-  if (!userId) {
-    redirect(
-      `${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.DASHBOARD_EARNINGS}`
-    );
-  }
-
-  redirect(`${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`);
+  await redirectFromEarningsRoute(APP_ROUTES.DASHBOARD_EARNINGS);
 }

--- a/apps/web/app/app/(shell)/earnings/earnings-route.ts
+++ b/apps/web/app/app/(shell)/earnings/earnings-route.ts
@@ -6,7 +6,8 @@ export async function redirectFromEarningsRoute(returnPath: string) {
   const { userId } = await getCachedAuth();
 
   if (!userId) {
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${returnPath}`);
+    const redirectUrl = encodeURIComponent(returnPath);
+    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${redirectUrl}`);
   }
 
   redirect(`${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`);

--- a/apps/web/app/app/(shell)/earnings/earnings-route.ts
+++ b/apps/web/app/app/(shell)/earnings/earnings-route.ts
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+import { APP_ROUTES } from '@/constants/routes';
+import { getCachedAuth } from '@/lib/auth/cached';
+
+export async function redirectFromEarningsRoute(returnPath: string) {
+  const { userId } = await getCachedAuth();
+
+  if (!userId) {
+    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${returnPath}`);
+  }
+
+  redirect(`${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`);
+}

--- a/apps/web/app/app/(shell)/earnings/page.tsx
+++ b/apps/web/app/app/(shell)/earnings/page.tsx
@@ -1,0 +1,8 @@
+import { APP_ROUTES } from '@/constants/routes';
+import { redirectFromEarningsRoute } from './earnings-route';
+
+export const runtime = 'nodejs';
+
+export default async function EarningsPage() {
+  await redirectFromEarningsRoute(APP_ROUTES.EARNINGS);
+}

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -15,6 +15,7 @@ export const APP_ROUTES = {
   DASHBOARD: '/app',
   /** Legacy dashboard landing path. Kept as a constant so the legacy redirect in `next.config.js` has a referenceable source. Do NOT use for navigation. */
   LEGACY_DASHBOARD: '/app/dashboard',
+  /** Legacy earnings path. Keep for old bookmarks; use EARNINGS for canonical entry. */
   DASHBOARD_EARNINGS: '/app/dashboard/earnings',
   DASHBOARD_LINKS: '/app/dashboard/links',
   DASHBOARD_PROFILE: '/app/dashboard/profile',

--- a/apps/web/tests/unit/app/dashboard-earnings-page.test.tsx
+++ b/apps/web/tests/unit/app/dashboard-earnings-page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
 
 const { redirectMock, getCachedAuthMock } = vi.hoisted(() => ({
@@ -19,16 +19,22 @@ vi.mock('@/lib/auth/cached', () => ({
 import EarningsPage from '@/app/app/(shell)/dashboard/earnings/page';
 import CanonicalEarningsPage from '@/app/app/(shell)/earnings/page';
 
+beforeEach(() => {
+  redirectMock.mockClear();
+  getCachedAuthMock.mockReset();
+});
+
 describe('dashboard earnings page', () => {
   it('redirects unauthenticated users to sign-in with the legacy route as the return target', async () => {
     getCachedAuthMock.mockResolvedValueOnce({ userId: null });
+    const encodedReturnPath = encodeURIComponent(APP_ROUTES.DASHBOARD_EARNINGS);
 
     await expect(EarningsPage()).rejects.toThrow(
-      `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.DASHBOARD_EARNINGS}`
+      `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${encodedReturnPath}`
     );
 
     expect(redirectMock).toHaveBeenCalledWith(
-      `${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.DASHBOARD_EARNINGS}`
+      `${APP_ROUTES.SIGNIN}?redirect_url=${encodedReturnPath}`
     );
   });
 
@@ -48,13 +54,14 @@ describe('dashboard earnings page', () => {
 describe('canonical earnings page', () => {
   it('redirects unauthenticated users to sign-in with the canonical route as the return target', async () => {
     getCachedAuthMock.mockResolvedValueOnce({ userId: null });
+    const encodedReturnPath = encodeURIComponent(APP_ROUTES.EARNINGS);
 
     await expect(CanonicalEarningsPage()).rejects.toThrow(
-      `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.EARNINGS}`
+      `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${encodedReturnPath}`
     );
 
     expect(redirectMock).toHaveBeenCalledWith(
-      `${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.EARNINGS}`
+      `${APP_ROUTES.SIGNIN}?redirect_url=${encodedReturnPath}`
     );
   });
 

--- a/apps/web/tests/unit/app/dashboard-earnings-page.test.tsx
+++ b/apps/web/tests/unit/app/dashboard-earnings-page.test.tsx
@@ -17,6 +17,7 @@ vi.mock('@/lib/auth/cached', () => ({
 }));
 
 import EarningsPage from '@/app/app/(shell)/dashboard/earnings/page';
+import CanonicalEarningsPage from '@/app/app/(shell)/earnings/page';
 
 describe('dashboard earnings page', () => {
   it('redirects unauthenticated users to sign-in with the legacy route as the return target', async () => {
@@ -35,6 +36,32 @@ describe('dashboard earnings page', () => {
     getCachedAuthMock.mockResolvedValueOnce({ userId: 'user_123' });
 
     await expect(EarningsPage()).rejects.toThrow(
+      `REDIRECT:${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`
+    );
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      `${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`
+    );
+  });
+});
+
+describe('canonical earnings page', () => {
+  it('redirects unauthenticated users to sign-in with the canonical route as the return target', async () => {
+    getCachedAuthMock.mockResolvedValueOnce({ userId: null });
+
+    await expect(CanonicalEarningsPage()).rejects.toThrow(
+      `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.EARNINGS}`
+    );
+
+    expect(redirectMock).toHaveBeenCalledWith(
+      `${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.EARNINGS}`
+    );
+  });
+
+  it('redirects authenticated users to artist profile tips', async () => {
+    getCachedAuthMock.mockResolvedValueOnce({ userId: 'user_123' });
+
+    await expect(CanonicalEarningsPage()).rejects.toThrow(
       `REDIRECT:${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`
     );
 

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -88,7 +88,11 @@ function findShellPages(dir: string = SHELL_ROOT): ShellPage[] {
 }
 
 function isRedirectStub(source: string): boolean {
-  return /\bredirect\(/.test(source) || /\bpermanentRedirect\(/.test(source);
+  return (
+    /\bredirect\(/.test(source) ||
+    /\bpermanentRedirect\(/.test(source) ||
+    /\bredirectFromEarningsRoute\(/.test(source)
+  );
 }
 
 function getNavRoutePaths(): Set<string> {


### PR DESCRIPTION
## Summary
- adds `/app/earnings` as the canonical shell entry for earnings
- keeps `/app/dashboard/earnings` as a legacy bookmark path using the same auth/redirect contract
- expands route coverage so the shell nav recognizes the canonical earnings surface

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/dashboard-earnings-page.test.tsx tests/unit/routing/earnings-auth-redirect.test.ts tests/unit/routes/shell-nav-coverage.test.ts --config=vitest.config.mts`
- `pnpm exec biome check apps/web/app/app/(shell)/dashboard/earnings/page.tsx apps/web/app/app/(shell)/earnings/page.tsx apps/web/app/app/(shell)/earnings/earnings-route.ts apps/web/constants/routes.ts apps/web/tests/unit/app/dashboard-earnings-page.test.tsx apps/web/tests/unit/routes/shell-nav-coverage.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check origin/main...HEAD`
- pre-push hook: Biome, proxy guard, Tailwind guard, typecheck, lint

Agent artifact: sourceRunId=41d735e52279bf9d8a0b1d641eeb361942a64457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a canonical earnings page that centralizes how users reach earnings.
  * Legacy earnings bookmarks now redirect correctly to the canonical earnings location.

* **Refactor**
  * Consolidated redirect handling for earnings to ensure consistent authentication and routing behavior.

* **Tests**
  * Updated and expanded unit tests to cover the new earnings routing and redirect scenarios, with improved test setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->