### PR TITLE
fix(shell): use year-aware relative dates in shell demo

### DIFF
--- a/apps/web/app/exp/shell-v1/page.tsx
+++ b/apps/web/app/exp/shell-v1/page.tsx
@@ -176,6 +176,7 @@ import { ThreadView as ShellThreadView } from '@/components/shell/ThreadView';
 import { Tooltip } from '@/components/shell/Tooltip';
 import { TypeBadge } from '@/components/shell/TypeBadge';
 import { dropDateMeta } from '@/lib/format-drop-date';
+import { relativeDate as formatRelativeDate } from '@/lib/format-relative-date';
 // ---------------------------------------------------------------------------
 // DESIGN RULE — NO AI-SLOP GRADIENTS ON UI CHROME
 // ---------------------------------------------------------------------------
@@ -1691,19 +1692,7 @@ function trackFromRelease(r: Release): TrackInfo {
 }
 
 function relativeDate(iso: string, now = new Date('2026-04-25')) {
-  const d = new Date(iso);
-  const days = Math.round(
-    (d.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
-  );
-  if (days === 0) return 'today';
-  if (days === 1) return 'tomorrow';
-  if (days === -1) return 'yesterday';
-  if (days > 1 && days < 14) return `in ${days}d`;
-  if (days < -1 && days > -14) return `${-days}d ago`;
-  if (days >= 14 && days < 60) return `in ${Math.round(days / 7)}w`;
-  if (days <= -14 && days > -60) return `${Math.round(-days / 7)}w ago`;
-  if (days >= 60) return `in ${Math.round(days / 30)}mo`;
-  return `${Math.round(-days / 30)}mo ago`;
+  return formatRelativeDate(iso, now).toLowerCase();
 }
 
 function formatStreams(n: number) {


### PR DESCRIPTION
## Summary
- replaces the shell-v1 demo's local relative-date math with the canonical formatter
- preserves the demo's lower-case labels while fixing multi-year values like `2193d ago`

## Verification
- `pnpm --filter @jovie/web exec vitest run lib/format-relative-date.test.ts --config=vitest.config.mts`
- `pnpm exec biome check apps/web/app/exp/shell-v1/page.tsx apps/web/lib/format-relative-date.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hook: proxy guard, lint-staged Biome/ESLint/typecheck
- pre-push hook: Biome, proxy guard, Tailwind guard, typecheck, lint

Agent artifact: sourceRunId=a83af6217