### PR TITLE
fix(shell): route contact and tour aliases through app shell

### DIFF
--- a/apps/web/app/app/(shell)/contacts/page.tsx
+++ b/apps/web/app/app/(shell)/contacts/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+import { APP_ROUTES } from '@/constants/routes';
+
+export default function ContactsPage() {
+  redirect(APP_ROUTES.SETTINGS_CONTACTS);
+}

--- a/apps/web/app/app/(shell)/tour-dates/page.tsx
+++ b/apps/web/app/app/(shell)/tour-dates/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+import { APP_ROUTES } from '@/constants/routes';
+
+export default function TourDatesPage() {
+  redirect(APP_ROUTES.SETTINGS_TOURING);
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -248,21 +248,17 @@ const nextConfig = {
     ];
 
     const legacyAppRedirects = [
-      { source: '/app/contact', destination: '/app/settings/contacts' },
       { source: '/app/profile', destination: '/app/chat?panel=profile' },
-      { source: '/app/contacts', destination: '/app/settings/contacts' },
       {
         source: '/app/tipping',
         destination: '/app/settings/artist-profile?tab=earn#pay',
       },
-      { source: '/app/tour-dates', destination: '/app/settings/touring' },
       { source: '/app/dashboard', destination: '/app' },
       { source: '/app/dashboard/overview', destination: '/app' },
-      // NOTE: /app/earnings and /app/dashboard/earnings are intentionally
-      // omitted here. proxy.ts handles auth-aware redirection: unauthenticated
-      // users are sent to /signin?redirect_url=<requested earnings path>, while
-      // authenticated users go to the canonical artist profile pay section.
-      // Static redirects bypass Clerk middleware and lose the original deep link.
+      // NOTE: shell-owned aliases such as /app/earnings, /app/contacts, and
+      // /app/tour-dates are intentionally omitted here. App Router pages handle
+      // their final destination so middleware can preserve the requested deep
+      // link for unauthenticated users.
       {
         source: '/app/dashboard/links',
         destination: '/app/chat?panel=profile',
@@ -276,14 +272,6 @@ const nextConfig = {
         destination: '/app/chat?panel=profile',
       },
       { source: '/app/dashboard/chat', destination: '/app/chat' },
-      {
-        source: '/app/dashboard/contacts',
-        destination: '/app/settings/contacts',
-      },
-      {
-        source: '/app/dashboard/tour-dates',
-        destination: '/app/settings/touring',
-      },
       { source: '/app/settings', destination: '/app/settings/account' },
       {
         source: '/app/settings/profile',

--- a/apps/web/tests/unit/routing/shell-alias-redirects.test.ts
+++ b/apps/web/tests/unit/routing/shell-alias-redirects.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
+
+type RedirectRule = {
+  readonly source: string;
+};
+
+const { redirectMock } = vi.hoisted(() => ({
+  redirectMock: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
+}));
+
+import ContactPage from '@/app/app/(shell)/contact/page';
+import CanonicalContactsPage from '@/app/app/(shell)/contacts/page';
+import DashboardContactsPage from '@/app/app/(shell)/dashboard/contacts/page';
+import DashboardTourDatesPage from '@/app/app/(shell)/dashboard/tour-dates/page';
+import CanonicalTourDatesPage from '@/app/app/(shell)/tour-dates/page';
+
+beforeEach(() => {
+  redirectMock.mockClear();
+});
+
+describe('shell alias redirects', () => {
+  it('keeps contacts and tour aliases out of static redirects', async () => {
+    const nextConfigModule = await import('../../../next.config.js');
+    const nextConfig = nextConfigModule.default ?? nextConfigModule;
+    const redirects = (await nextConfig.redirects()) as RedirectRule[];
+
+    expect(
+      redirects
+        .map(redirect => redirect.source)
+        .filter(source =>
+          [
+            APP_ROUTES.CONTACTS,
+            APP_ROUTES.DASHBOARD_CONTACTS,
+            '/app/contact',
+            APP_ROUTES.TOUR_DATES,
+            APP_ROUTES.DASHBOARD_TOUR_DATES,
+          ].includes(source)
+        )
+    ).toEqual([]);
+  });
+
+  it('routes contact aliases through shell pages to contact settings', () => {
+    for (const Page of [
+      ContactPage,
+      CanonicalContactsPage,
+      DashboardContactsPage,
+    ]) {
+      expect(() => Page()).toThrow(`REDIRECT:${APP_ROUTES.SETTINGS_CONTACTS}`);
+    }
+
+    expect(redirectMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('routes tour aliases through shell pages to touring settings', () => {
+    for (const Page of [CanonicalTourDatesPage, DashboardTourDatesPage]) {
+      expect(() => Page()).toThrow(`REDIRECT:${APP_ROUTES.SETTINGS_TOURING}`);
+    }
+
+    expect(redirectMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- adds App Router shell pages for `/app/contacts` and `/app/tour-dates`
- removes contact and tour aliases from static `next.config.js` redirects so middleware/shell routing owns the deep links
- keeps each alias redirecting to the existing settings destination

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/routing/shell-alias-redirects.test.ts tests/unit/routes/shell-nav-coverage.test.ts --config=vitest.config.mts`
- `pnpm exec biome check apps/web/next.config.js apps/web/app/app/(shell)/contacts/page.tsx apps/web/app/app/(shell)/tour-dates/page.tsx apps/web/tests/unit/routing/shell-alias-redirects.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hook: proxy guard, lint-staged Biome/ESLint/typecheck
- pre-push hook: Biome, proxy guard, Tailwind guard, typecheck, lint

Agent artifact: sourceRunId=188da0e7f