### PR TITLE
fix: let trusted automation bypass health rate limit

### DIFF
--- a/apps/web/app/api/health/route.ts
+++ b/apps/web/app/api/health/route.ts
@@ -12,6 +12,16 @@ import {
   healthLimiter,
 } from '@/lib/rate-limit';
 
+function hasTrustedAutomationBypass(request: Request): boolean {
+  const configuredSecret = env.VERCEL_AUTOMATION_BYPASS_SECRET?.trim();
+  if (!configuredSecret) return false;
+
+  const providedSecret = request.headers
+    .get('x-vercel-protection-bypass')
+    ?.trim();
+  return providedSecret === configuredSecret;
+}
+
 /**
  * Health check endpoint for uptime monitoring and deployment verification.
  *
@@ -21,27 +31,34 @@ import {
  * - No CORS headers to prevent unauthorized cross-origin access
  */
 export async function GET(request: Request) {
-  // Rate limit check (30 req/60s for health endpoints)
-  const clientIP = getClientIP(request);
-  const rateLimitResult = await healthLimiter.limit(clientIP);
+  const bypassRateLimit = hasTrustedAutomationBypass(request);
+  let rateLimitHeaders: Record<string, string> = {};
 
-  if (!rateLimitResult.success) {
-    return NextResponse.json(
-      {
-        error: 'Too many requests',
-        retryAfter: Math.max(
-          0,
-          Math.ceil((rateLimitResult.reset.getTime() - Date.now()) / 1000)
-        ),
-      },
-      {
-        status: 429,
-        headers: {
-          ...NO_STORE_HEADERS,
-          ...createRateLimitHeaders(rateLimitResult),
+  if (!bypassRateLimit) {
+    // Rate limit check (30 req/60s for health endpoints)
+    const clientIP = getClientIP(request);
+    const rateLimitResult = await healthLimiter.limit(clientIP);
+
+    rateLimitHeaders = createRateLimitHeaders(rateLimitResult);
+
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        {
+          error: 'Too many requests',
+          retryAfter: Math.max(
+            0,
+            Math.ceil((rateLimitResult.reset.getTime() - Date.now()) / 1000)
+          ),
         },
-      }
-    );
+        {
+          status: 429,
+          headers: {
+            ...NO_STORE_HEADERS,
+            ...rateLimitHeaders,
+          },
+        }
+      );
+    }
   }
 
   // Minimal response - only status and timestamp (no environment details)
@@ -73,7 +90,7 @@ export async function GET(request: Request) {
         status: 200,
         headers: {
           ...NO_STORE_HEADERS,
-          ...createRateLimitHeaders(rateLimitResult),
+          ...rateLimitHeaders,
         },
       }
     );
@@ -88,7 +105,7 @@ export async function GET(request: Request) {
       status: 503, // Service Unavailable - allows monitoring to detect issues
       headers: {
         ...NO_STORE_HEADERS,
-        ...createRateLimitHeaders(rateLimitResult),
+        ...rateLimitHeaders,
         'Retry-After': RETRY_AFTER_HEALTH,
       },
     });

--- a/apps/web/lib/env-server-schema.ts
+++ b/apps/web/lib/env-server-schema.ts
@@ -45,6 +45,7 @@ export const ServerEnvSchema = z.object({
         'VERCEL_URL must be a hostname or hostname:port without a scheme or path',
     })
     .optional(),
+  VERCEL_AUTOMATION_BYPASS_SECRET: z.string().optional(),
 
   // Clerk server-side configuration
   CLERK_SECRET_KEY: z.string().optional(),
@@ -283,6 +284,7 @@ export const ENV_KEYS = [
   'VITEST',
   'VERCEL_ENV',
   'VERCEL_URL',
+  'VERCEL_AUTOMATION_BYPASS_SECRET',
   'CLERK_SECRET_KEY',
   'CLERK_WEBHOOK_SECRET',
   'RESEND_API_KEY',

--- a/apps/web/tests/unit/api/health/main.critical.test.ts
+++ b/apps/web/tests/unit/api/health/main.critical.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockHealthLimiterLimit = vi.hoisted(() => vi.fn());
 const mockDbExecute = vi.hoisted(() => vi.fn());
 const mockCaptureWarning = vi.hoisted(() => vi.fn());
+const mockEnv = vi.hoisted(() => ({
+  DATABASE_URL: 'postgres://test:test@localhost:5432/test',
+  VERCEL_AUTOMATION_BYPASS_SECRET: undefined as string | undefined,
+}));
 
 vi.mock('@/lib/rate-limit', () => ({
   healthLimiter: {
@@ -23,15 +27,15 @@ vi.mock('@/lib/error-tracking', () => ({
 }));
 
 vi.mock('@/lib/env-server', () => ({
-  env: {
-    DATABASE_URL: 'postgres://test:test@localhost:5432/test',
-  },
+  env: mockEnv,
 }));
 
 describe('@critical GET /api/health', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    mockEnv.DATABASE_URL = 'postgres://test:test@localhost:5432/test';
+    mockEnv.VERCEL_AUTOMATION_BYPASS_SECRET = undefined;
     mockHealthLimiterLimit.mockResolvedValue({
       success: true,
       limit: 30,
@@ -55,6 +59,50 @@ describe('@critical GET /api/health', () => {
 
     expect(response.status).toBe(429);
     expect(data.error).toBe('Too many requests');
+  });
+
+  it('skips rate limiting for trusted Vercel automation bypass checks', async () => {
+    mockEnv.VERCEL_AUTOMATION_BYPASS_SECRET = 'trusted-bypass-secret';
+    mockDbExecute.mockResolvedValue(undefined);
+
+    const { GET } = await import('@/app/api/health/route');
+    const response = await GET(
+      new Request('http://localhost/api/health', {
+        headers: {
+          'x-vercel-protection-bypass': 'trusted-bypass-secret',
+        },
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ status: 'ok' });
+    expect(mockHealthLimiterLimit).not.toHaveBeenCalled();
+  });
+
+  it('keeps rate limiting when the Vercel automation bypass is invalid', async () => {
+    mockEnv.VERCEL_AUTOMATION_BYPASS_SECRET = 'trusted-bypass-secret';
+    mockHealthLimiterLimit.mockResolvedValue({
+      success: false,
+      limit: 30,
+      remaining: 0,
+      reset: new Date(Date.now() + 60000),
+      reason: 'Rate limit exceeded',
+    });
+
+    const { GET } = await import('@/app/api/health/route');
+    const response = await GET(
+      new Request('http://localhost/api/health', {
+        headers: {
+          'x-vercel-protection-bypass': 'wrong-secret',
+        },
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(data.error).toBe('Too many requests');
+    expect(mockHealthLimiterLimit).toHaveBeenCalledWith('127.0.0.1');
   });
 
   it('returns ok status when database is healthy', async () => {


### PR DESCRIPTION
## Summary
- allow `/api/health` to skip the app health rate limiter only when `x-vercel-protection-bypass` matches `VERCEL_AUTOMATION_BYPASS_SECRET`
- add `VERCEL_AUTOMATION_BYPASS_SECRET` to the server env contract
- add regression coverage for trusted and invalid bypass headers

Linear: JOV-2356

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/api/health/main.critical.test.ts` (red before implementation, green after)
- `pnpm biome check apps/web/app/api/health/route.ts apps/web/lib/env-server-schema.ts apps/web/tests/unit/api/health/main.critical.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/api/health/main.critical.test.ts tests/unit/e2e/production-signup-canary.test.ts tests/unit/onboarding/OnboardingTurnstile.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Runtime Config
- `VERCEL_AUTOMATION_BYPASS_SECRET` is present in Doppler PRD, Vercel production env for `jovie-v1`, and GitHub repo secrets.
- Production signup canary still fails closed until the dedicated mailbox secrets are added to Doppler PRD.
