### PR TITLE
fix(desktop): open chat shell with Jovie metadata

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@jovie/desktop",
   "version": "26.5.14",
   "description": "Jovie desktop app",
-  "author": "Jovie Inc.",
+  "author": "Jovie Technology Inc.",
   "private": true,
   "main": "dist-electron/main.js",
   "scripts": {

--- a/apps/desktop/scripts/desktop-shell-contract.test.mjs
+++ b/apps/desktop/scripts/desktop-shell-contract.test.mjs
@@ -9,12 +9,12 @@ import { promisify } from 'node:util';
 const desktopRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const execFileAsync = promisify(execFile);
 
-test('desktop window enters the authenticated app shell instead of the web root', async () => {
+test('desktop window enters the authenticated chat shell instead of the web root', async () => {
   const mainSource = await readFile(join(desktopRoot, 'src/main.ts'), 'utf8');
 
   assert.match(
     mainSource,
-    /const APP_ENTRY_URL = buildAppUrl\('\/app'\);/
+    /const APP_ENTRY_URL = buildAppUrl\('\/app\/chat'\);/
   );
   assert.match(mainSource, /url\.searchParams\.set\('runtime', 'electron'\);/);
   assert.match(

--- a/apps/desktop/scripts/generate-dmg-background.test.mjs
+++ b/apps/desktop/scripts/generate-dmg-background.test.mjs
@@ -44,3 +44,11 @@ test('electron-builder configs do not pin a stale copyright year', async () => {
     assert.doesNotMatch(config, /^copyright:\s*["']?Copyright/m);
   }
 });
+
+test('desktop package metadata uses the legal Jovie company name', async () => {
+  const packageJson = JSON.parse(
+    await readFile(join(desktopRoot, 'package.json'), 'utf8')
+  );
+
+  assert.equal(packageJson.author, 'Jovie Technology Inc.');
+});

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -18,7 +18,7 @@ if (APP_ENV === 'staging') {
 }
 
 const APP_ORIGIN = new URL(APP_URL).origin;
-const APP_ENTRY_URL = buildAppUrl('/app');
+const APP_ENTRY_URL = buildAppUrl('/app/chat');
 const SETTINGS_URL = buildAppUrl('/app/settings');
 const APP_BACKGROUND_COLOR = '#09090b';
 const NAVIGATION_ABORTED_ERROR_CODE = -3;


### PR DESCRIPTION
## Summary
- starts the Electron window at `/app/chat?runtime=electron` instead of the generic app root
- updates desktop package metadata to `Jovie Technology Inc.`
- adds focused desktop contract coverage for the entry route and legal package metadata

## Verification
- `pnpm --filter @jovie/desktop run test:desktop-shell`
- `pnpm --filter @jovie/desktop run test:dmg-background`
- `pnpm --filter @jovie/desktop run typecheck`
- `pnpm --filter @jovie/desktop run prepare:assets`
- `pnpm --filter @jovie/desktop run test:release-guard`
- `git diff --check -- apps/desktop`
- commit hook: proxy guard, lint-staged Biome
- pre-push hook: Biome, proxy guard, Tailwind guard, web typecheck, web lint

Note: current `main` already has the corrected DMG background/icon assets, so this PR intentionally avoids binary asset churn.

Agent artifact: sourceRunId=54671d14d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop application now opens directly to the chat interface on startup.

* **Tests**
  * Updated shell contract test to validate the new default entry point.
  * Added metadata validation test for package author information.

* **Chores**
  * Updated package author metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->