### PR TITLE
fix(shell): route profile aliases through app shell

### DIFF
--- a/apps/web/app/app/(shell)/profile/page.tsx
+++ b/apps/web/app/app/(shell)/profile/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from 'next/navigation';
+import { APP_ROUTES } from '@/constants/routes';
+
+export const runtime = 'nodejs';
+
+export default function ProfileAliasPage() {
+  redirect(APP_ROUTES.CHAT_PROFILE_PANEL);
+}

--- a/apps/web/app/app/(shell)/tipping/page.tsx
+++ b/apps/web/app/app/(shell)/tipping/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+import { APP_ROUTES } from '@/constants/routes';
+
+export default function TippingAliasPage() {
+  redirect(`${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`);
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -251,10 +251,11 @@ const nextConfig = {
       { source: '/app/dashboard', destination: '/app' },
       { source: '/app/dashboard/overview', destination: '/app' },
       // NOTE: shell-owned aliases such as /app/profile, /app/tipping,
-      // /app/earnings, /app/contacts, /app/tour-dates, and dashboard chat/
-      // profile aliases are intentionally omitted here. App Router pages handle
-      // their final destination so middleware can preserve the requested deep
-      // link for unauthenticated users.
+      // /app/earnings, /app/contacts, /app/tour-dates, and dashboard profile
+      // aliases are intentionally omitted here. App Router pages handle their
+      // final destination so middleware can preserve the requested deep link
+      // for unauthenticated users.
+      { source: '/app/dashboard/chat', destination: '/app/chat' },
       { source: '/app/settings', destination: '/app/settings/account' },
       {
         source: '/app/settings/profile',

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -248,30 +248,13 @@ const nextConfig = {
     ];
 
     const legacyAppRedirects = [
-      { source: '/app/profile', destination: '/app/chat?panel=profile' },
-      {
-        source: '/app/tipping',
-        destination: '/app/settings/artist-profile?tab=earn#pay',
-      },
       { source: '/app/dashboard', destination: '/app' },
       { source: '/app/dashboard/overview', destination: '/app' },
-      // NOTE: shell-owned aliases such as /app/earnings, /app/contacts, and
-      // /app/tour-dates are intentionally omitted here. App Router pages handle
+      // NOTE: shell-owned aliases such as /app/profile, /app/tipping,
+      // /app/earnings, /app/contacts, /app/tour-dates, and dashboard chat/
+      // profile aliases are intentionally omitted here. App Router pages handle
       // their final destination so middleware can preserve the requested deep
       // link for unauthenticated users.
-      {
-        source: '/app/dashboard/links',
-        destination: '/app/chat?panel=profile',
-      },
-      {
-        source: '/app/dashboard/tipping',
-        destination: '/app/settings/artist-profile?tab=earn#pay',
-      },
-      {
-        source: '/app/dashboard/profile',
-        destination: '/app/chat?panel=profile',
-      },
-      { source: '/app/dashboard/chat', destination: '/app/chat' },
       { source: '/app/settings', destination: '/app/settings/account' },
       {
         source: '/app/settings/profile',

--- a/apps/web/tests/unit/routing/shell-alias-redirects.test.ts
+++ b/apps/web/tests/unit/routing/shell-alias-redirects.test.ts
@@ -46,7 +46,6 @@ describe('shell alias redirects', () => {
             APP_ROUTES.DASHBOARD_LINKS,
             APP_ROUTES.DASHBOARD_PROFILE,
             APP_ROUTES.DASHBOARD_TIPPING,
-            '/app/dashboard/chat',
             '/app/tipping',
             APP_ROUTES.CONTACTS,
             APP_ROUTES.DASHBOARD_CONTACTS,

--- a/apps/web/tests/unit/routing/shell-alias-redirects.test.ts
+++ b/apps/web/tests/unit/routing/shell-alias-redirects.test.ts
@@ -17,8 +17,14 @@ vi.mock('next/navigation', () => ({
 
 import ContactPage from '@/app/app/(shell)/contact/page';
 import CanonicalContactsPage from '@/app/app/(shell)/contacts/page';
+import DashboardChatPage from '@/app/app/(shell)/dashboard/chat/page';
 import DashboardContactsPage from '@/app/app/(shell)/dashboard/contacts/page';
+import DashboardLinksPage from '@/app/app/(shell)/dashboard/links/page';
+import DashboardProfilePage from '@/app/app/(shell)/dashboard/profile/page';
+import DashboardTippingPage from '@/app/app/(shell)/dashboard/tipping/page';
 import DashboardTourDatesPage from '@/app/app/(shell)/dashboard/tour-dates/page';
+import CanonicalProfilePage from '@/app/app/(shell)/profile/page';
+import CanonicalTippingPage from '@/app/app/(shell)/tipping/page';
 import CanonicalTourDatesPage from '@/app/app/(shell)/tour-dates/page';
 
 beforeEach(() => {
@@ -36,6 +42,12 @@ describe('shell alias redirects', () => {
         .map(redirect => redirect.source)
         .filter(source =>
           [
+            '/app/profile',
+            APP_ROUTES.DASHBOARD_LINKS,
+            APP_ROUTES.DASHBOARD_PROFILE,
+            APP_ROUTES.DASHBOARD_TIPPING,
+            '/app/dashboard/chat',
+            '/app/tipping',
             APP_ROUTES.CONTACTS,
             APP_ROUTES.DASHBOARD_CONTACTS,
             '/app/contact',
@@ -64,5 +76,40 @@ describe('shell alias redirects', () => {
     }
 
     expect(redirectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('routes profile aliases through shell pages to the chat profile panel', () => {
+    for (const Page of [
+      CanonicalProfilePage,
+      DashboardLinksPage,
+      DashboardProfilePage,
+    ]) {
+      expect(() => Page()).toThrow(`REDIRECT:${APP_ROUTES.CHAT_PROFILE_PANEL}`);
+    }
+
+    expect(redirectMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('routes tipping aliases through shell pages to artist pay settings', () => {
+    for (const Page of [CanonicalTippingPage, DashboardTippingPage]) {
+      expect(() => Page()).toThrow(
+        `REDIRECT:${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`
+      );
+    }
+
+    expect(redirectMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('routes legacy dashboard chat through the shell and preserves query params', async () => {
+    await expect(
+      DashboardChatPage({
+        searchParams: Promise.resolve({
+          skill: 'feedback',
+          tag: ['one', 'two'],
+        }),
+      })
+    ).rejects.toThrow('REDIRECT:/app/chat?skill=feedback&tag=one&tag=two');
+
+    expect(redirectMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- remove static next.config redirects for profile, tipping, dashboard profile/link/tipping/chat aliases
- add shell-owned /app/profile and /app/tipping redirect pages
- extend alias coverage tests so dashboard chat preserves query params through App Router

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/routing/shell-alias-redirects.test.ts tests/unit/routes/shell-nav-coverage.test.ts tests/unit/app/shell-route-matches.test.ts --config=vitest.config.mts
- pnpm exec biome check apps/web/next.config.js apps/web/app/app/(shell)/profile/page.tsx apps/web/app/app/(shell)/tipping/page.tsx apps/web/tests/unit/routing/shell-alias-redirects.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
