### PR TITLE
fix(shell): canonicalize release task routes

### DIFF
--- a/apps/web/app/app/(shell)/releases/[releaseId]/tasks/loading.tsx
+++ b/apps/web/app/app/(shell)/releases/[releaseId]/tasks/loading.tsx
@@ -1,0 +1,3 @@
+import DashboardReleaseTasksLoading from '@/app/app/(shell)/dashboard/releases/[releaseId]/tasks/loading';
+
+export default DashboardReleaseTasksLoading;

--- a/apps/web/app/app/(shell)/releases/[releaseId]/tasks/page.tsx
+++ b/apps/web/app/app/(shell)/releases/[releaseId]/tasks/page.tsx
@@ -1,0 +1,3 @@
+import DashboardReleaseTasksPage from '@/app/app/(shell)/dashboard/releases/[releaseId]/tasks/page';
+
+export default DashboardReleaseTasksPage;

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/release-plan-generation.ts
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/release-plan-generation.ts
@@ -4,7 +4,7 @@ import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 import { instantiateReleaseTasksFromCatalog } from '@/app/app/(shell)/dashboard/releases/catalog-task-actions';
 import { instantiateReleaseTasks } from '@/app/app/(shell)/dashboard/releases/task-actions';
-import { APP_ROUTES } from '@/constants/routes';
+import { buildReleaseTasksRoute } from '@/constants/routes';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 import { captureError } from '@/lib/error-tracking';
 import type { ReleaseContext } from '@/lib/release-tasks/applicability';
@@ -19,7 +19,7 @@ export async function generateReleasePlanTasks(
     await instantiateReleaseTasks(releaseId);
   }
 
-  return APP_ROUTES.DASHBOARD_RELEASE_TASKS.replace('[releaseId]', releaseId);
+  return buildReleaseTasksRoute(releaseId);
 }
 
 interface UsePostCreateReleasePlanOptions {

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -48,7 +48,7 @@ import {
   StatusBadge,
 } from '@/components/shell/StatusBadge';
 import { TypeBadge } from '@/components/shell/TypeBadge';
-import { APP_ROUTES } from '@/constants/routes';
+import { buildReleaseTasksRoute } from '@/constants/routes';
 import { buildReleaseActions } from '@/features/dashboard/organisms/releases/release-actions';
 import { CompactReleasePlanUpgradeCard } from '@/features/dashboard/tasks/TasksUpgradeInterstitial';
 import {
@@ -805,10 +805,7 @@ export function ReleaseSidebar({
       return;
     }
 
-    globalThis.location.href = APP_ROUTES.DASHBOARD_RELEASE_TASKS.replace(
-      '[releaseId]',
-      release.id
-    );
+    globalThis.location.href = buildReleaseTasksRoute(release.id);
   }, [release]);
 
   const handleDismissTasksUpgrade = useCallback(() => {

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -164,6 +164,10 @@ export function buildLyricsRoute(trackId: string): string {
   return `${APP_ROUTES.LYRICS}/${encodeURIComponent(trackId)}`;
 }
 
+export function buildReleaseTasksRoute(releaseId: string): string {
+  return `${APP_ROUTES.RELEASES}/${encodeURIComponent(releaseId)}/tasks`;
+}
+
 export function isDemoRoutePath(pathname: string | null | undefined): boolean {
   return (
     typeof pathname === 'string' &&

--- a/apps/web/lib/commands/entity-routing.ts
+++ b/apps/web/lib/commands/entity-routing.ts
@@ -12,12 +12,12 @@
  * silently dropping the user on an unrelated screen.
  */
 
-import { APP_ROUTES } from '@/constants/routes';
+import { buildReleaseTasksRoute } from '@/constants/routes';
 import type { EntityRef } from '@/lib/commands/entities';
 
 export function resolveEntityHref(entity: EntityRef): string | null {
   if (entity.kind === 'release') {
-    return `${APP_ROUTES.DASHBOARD_RELEASES}/${entity.id}/tasks`;
+    return buildReleaseTasksRoute(entity.id);
   }
   // Artists and tracks don't have per-entity detail pages yet.
   return null;

--- a/apps/web/tests/unit/app/release-tasks-page.test.tsx
+++ b/apps/web/tests/unit/app/release-tasks-page.test.tsx
@@ -85,7 +85,8 @@ vi.mock(
   })
 );
 
-import ReleaseTasksPage from '@/app/app/(shell)/dashboard/releases/[releaseId]/tasks/page';
+import LegacyReleaseTasksPage from '@/app/app/(shell)/dashboard/releases/[releaseId]/tasks/page';
+import CanonicalReleaseTasksPage from '@/app/app/(shell)/releases/[releaseId]/tasks/page';
 
 function setupReleaseQueryRows(rows: Array<Record<string, unknown>>) {
   mockDbRows.rows = rows;
@@ -99,7 +100,7 @@ function setupReleaseQueryRows(rows: Array<Record<string, unknown>>) {
 }
 
 async function renderResolvedTasksContent() {
-  const tree = await ReleaseTasksPage({
+  const tree = await LegacyReleaseTasksPage({
     params: Promise.resolve({ releaseId: 'release_1' }),
   });
   const tasksContentElement = (tree as React.ReactElement).props.children;
@@ -152,5 +153,9 @@ describe('release tasks page', () => {
     expect(screen.getByTestId('release-task-page')).toHaveTextContent(
       'release_1:My Release'
     );
+  });
+
+  it('uses the same implementation for the canonical release route', () => {
+    expect(CanonicalReleaseTasksPage).toBe(LegacyReleaseTasksPage);
   });
 });

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -138,9 +138,7 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
       .find(el => el.textContent?.includes('Midnight Run'));
     expect(releaseRow).toBeDefined();
     fireEvent.mouseDown(releaseRow!);
-    expect(pushMock).toHaveBeenCalledWith(
-      '/app/dashboard/releases/rel-1/tasks'
-    );
+    expect(pushMock).toHaveBeenCalledWith('/app/releases/rel-1/tasks');
   });
 
   it('renders additional sections (e.g. recent threads) and routes via callback', () => {

--- a/apps/web/tests/unit/constants/routes.test.ts
+++ b/apps/web/tests/unit/constants/routes.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it } from 'vitest';
-import { APP_ROUTES, isDemoRoutePath } from '@/constants/routes';
+import {
+  APP_ROUTES,
+  buildReleaseTasksRoute,
+  isDemoRoutePath,
+} from '@/constants/routes';
+
+describe('buildReleaseTasksRoute', () => {
+  it('builds the canonical release tasks path', () => {
+    expect(buildReleaseTasksRoute('release_1')).toBe(
+      '/app/releases/release_1/tasks'
+    );
+  });
+
+  it('encodes release ids for path-safe navigation', () => {
+    expect(buildReleaseTasksRoute('release 1/alt')).toBe(
+      '/app/releases/release%201%2Falt/tasks'
+    );
+  });
+});
 
 describe('isDemoRoutePath', () => {
   it('matches the demo landing route', () => {

--- a/apps/web/tests/unit/dashboard/ReleaseProviderMatrix.test.tsx
+++ b/apps/web/tests/unit/dashboard/ReleaseProviderMatrix.test.tsx
@@ -911,7 +911,7 @@ describe('ReleaseProviderMatrix', () => {
         );
       });
       expect(mockRouterPush).toHaveBeenCalledWith(
-        '/app/dashboard/releases/created-release/tasks'
+        '/app/releases/created-release/tasks'
       );
     });
 

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -24,6 +24,8 @@ const INTENTIONAL_INTERNAL_ROUTES: Record<string, string> = {
   '/app/admin/playlists': 'Internal admin workflow (manual entry)',
   '/app/dashboard/releases/[releaseId]/tasks':
     'Dynamic workflow route reached from releases actions',
+  '/app/releases/[releaseId]/tasks':
+    'Canonical dynamic workflow route reached from release actions',
   '/app/dashboard/releases/[releaseId]/downloads':
     'Internal release workflow (manual entry)',
   '/app/dashboard/releases':


### PR DESCRIPTION
## Summary
- add canonical /app/releases/:releaseId/tasks shell route wrappers around the existing release task implementation
- add buildReleaseTasksRoute() and use it from cmd+k release routing, release-plan generation, and release sidebar task navigation
- keep legacy dashboard release task routes supported while moving internal navigation to the canonical shell path

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/constants/routes.test.ts tests/unit/commands/SharedCommandPalette.test.tsx tests/unit/dashboard/ReleaseProviderMatrix.test.tsx tests/unit/app/release-tasks-page.test.tsx tests/unit/routes/shell-nav-coverage.test.ts --config=vitest.config.mts
- pnpm exec biome check apps/web/constants/routes.ts apps/web/lib/commands/entity-routing.ts apps/web/components/features/dashboard/organisms/release-provider-matrix/release-plan-generation.ts apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx apps/web/app/app/(shell)/releases/[releaseId]/tasks/page.tsx apps/web/app/app/(shell)/releases/[releaseId]/tasks/loading.tsx apps/web/tests/unit/constants/routes.test.ts apps/web/tests/unit/commands/SharedCommandPalette.test.tsx apps/web/tests/unit/dashboard/ReleaseProviderMatrix.test.tsx apps/web/tests/unit/app/release-tasks-page.test.tsx apps/web/tests/unit/routes/shell-nav-coverage.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
