### PR TITLE
fix(shell): align route loading skeletons

### DIFF
--- a/apps/web/app/app/(shell)/loading.tsx
+++ b/apps/web/app/app/(shell)/loading.tsx
@@ -1,11 +1,15 @@
 import { headers } from 'next/headers';
 import { LyricsRouteSkeleton } from '@/components/shell/LyricsRouteSkeleton';
+import { TasksRouteSkeleton } from '@/components/shell/TasksRouteSkeleton';
 import ChatLoading from './chat/loading';
 import { ReleaseTableSkeleton } from './dashboard/releases/loading';
+import { LibraryLoadingState } from './library/LibrarySurface';
 import {
   isChatShellRoute,
+  isLibraryShellRoute,
   isLyricsShellRoute,
   isReleasesShellRoute,
+  isTasksShellRoute,
   resolveAppShellRequestPath,
 } from './shell-route-matches';
 
@@ -33,8 +37,16 @@ export default async function ShellLoading() {
     return <ReleaseTableSkeleton showHeader={false} />;
   }
 
+  if (isLibraryShellRoute(pathname)) {
+    return <LibraryLoadingState />;
+  }
+
   if (isLyricsShellRoute(pathname)) {
     return <LyricsRouteSkeleton />;
+  }
+
+  if (isTasksShellRoute(pathname)) {
+    return <TasksRouteSkeleton />;
   }
 
   return (

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -236,6 +236,10 @@ describe('surface elevation guardrails', () => {
       join(ROOT, 'app/app/(shell)/layout.tsx'),
       'utf-8'
     );
+    const appShellLoading = readFileSync(
+      join(ROOT, 'app/app/(shell)/loading.tsx'),
+      'utf-8'
+    );
 
     expect(tasksPage).toContain('PageShell');
     expect(dashboardPanel).toContain("frame = 'content-container'");
@@ -244,6 +248,7 @@ describe('surface elevation guardrails', () => {
     expect(tasksPage).not.toMatch(/<UnifiedTable\b/);
     expect(shellRouteMatches).toContain('isTasksShellRoute');
     expect(appShellLayout).toContain('TasksRouteSkeleton');
+    expect(appShellLoading).toContain('TasksRouteSkeleton');
   });
 
   it('keeps presence and earnings inside framed content panels', () => {
@@ -343,11 +348,17 @@ describe('surface elevation guardrails', () => {
       join(ROOT, 'app/app/(shell)/library/LibrarySurface.tsx'),
       'utf-8'
     );
+    const appShellLoading = readFileSync(
+      join(ROOT, 'app/app/(shell)/loading.tsx'),
+      'utf-8'
+    );
 
     expect(librarySurface).toContain('useRegisterHeaderSearch');
     expect(librarySurface).toContain("key: 'library'");
     expect(librarySurface).toContain("triggerLabel: 'Filter'");
     expect(librarySurface).not.toContain('OPEN_COMMAND_PALETTE_EVENT');
+    expect(appShellLoading).toContain('isLibraryShellRoute');
+    expect(appShellLoading).toContain('LibraryLoadingState');
   });
 
   it('keeps task and preview cards off the shell canvas token', () => {


### PR DESCRIPTION
## Summary
- make shell-level loading.tsx use the same library and tasks route skeletons as the app shell layout fallback
- keep route-level navigation loaders aligned with the destination workspace instead of falling back to a generic table skeleton
- extend guardrails so library/tasks loading contracts stay covered

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/app/shell-route-matches.test.ts tests/unit/app/surface-elevation-guardrails.test.ts --config=vitest.config.mts
- pnpm exec biome check apps/web/app/app/(shell)/loading.tsx apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
