### PR TITLE
ci: seed public a11y fixtures on isolated db

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2256,9 +2256,10 @@ jobs:
         if: steps.check_changes.outputs.run_full_ci == 'true'
 
       - name: Create ephemeral Neon database branch (with retry)
-        # Only create an ephemeral branch when DB-relevant code changed.
-        # Non-DB PRs skip branch creation; resolve-neon-database-url falls back to DATABASE_URL_MAIN.
-        if: steps.check_changes.outputs.run_full_ci == 'true' && needs.ci-path-changes.outputs.run_neon == 'true'
+        # Public a11y routes depend on seeded QA profiles and smart links.
+        # Always use an isolated branch when this job runs so the gate is
+        # deterministic and never relies on or mutates the stable main DB.
+        if: steps.check_changes.outputs.run_full_ci == 'true'
         id: neon-branch
         uses: ./.github/actions/neon-create-branch-with-retry
         with:
@@ -2269,8 +2270,7 @@ jobs:
           protected_branches: main,development,preview,br-main,br-production,${{ needs.neon-db.outputs.branch_name }}
 
       - name: Resolve DATABASE_URL (Neon ephemeral)
-        # Only resolve from the ephemeral branch when one was created.
-        if: steps.check_changes.outputs.run_full_ci == 'true' && needs.ci-path-changes.outputs.run_neon == 'true'
+        if: steps.check_changes.outputs.run_full_ci == 'true'
         id: resolve-a11y-neon-db-url
         uses: ./.github/actions/resolve-neon-database-url
         with:
@@ -2280,13 +2280,8 @@ jobs:
           credential_fallback_url: ${{ secrets.DATABASE_URL }}
 
       - name: Export DATABASE_URL (ephemeral branch)
-        if: steps.check_changes.outputs.run_full_ci == 'true' && needs.ci-path-changes.outputs.run_neon == 'true'
+        if: steps.check_changes.outputs.run_full_ci == 'true'
         run: echo "DATABASE_URL=${{ steps.resolve-a11y-neon-db-url.outputs.database_url }}" >> "$GITHUB_ENV"
-
-      - name: Export DATABASE_URL (main — non-DB PR)
-        # No ephemeral branch was created; use the stable main DB for SSR reads.
-        if: steps.check_changes.outputs.run_full_ci == 'true' && needs.ci-path-changes.outputs.run_neon != 'true'
-        run: echo "DATABASE_URL=${{ secrets.DATABASE_URL_MAIN }}" >> "$GITHUB_ENV"
 
       - name: Cache Playwright Browsers
         if: steps.check_changes.outputs.run_full_ci == 'true'
@@ -2314,7 +2309,7 @@ jobs:
         run: tar -xf /tmp/nextjs-build-download/nextjs-build.tar -C apps/web
 
       - name: Run migrations (ephemeral Neon)
-        if: steps.check_changes.outputs.run_full_ci == 'true' && needs.ci-path-changes.outputs.run_neon == 'true'
+        if: steps.check_changes.outputs.run_full_ci == 'true'
         run: pnpm --filter=@jovie/web run drizzle:migrate:ci
         env:
           DATABASE_URL: ${{ env.DATABASE_URL }}
@@ -2323,7 +2318,7 @@ jobs:
           ALLOW_PROD_MIGRATIONS: 'true'
 
       - name: Seed public QA fixtures
-        if: steps.check_changes.outputs.run_full_ci == 'true' && needs.ci-path-changes.outputs.run_neon == 'true'
+        if: steps.check_changes.outputs.run_full_ci == 'true'
         run: pnpm --filter=@jovie/web exec tsx tests/seed-test-data.ts
         env:
           DATABASE_URL: ${{ env.DATABASE_URL }}

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -27,6 +27,25 @@ function getStepBlock(workflow: string, stepName: string): string {
   return block.join('\n');
 }
 
+function getJobBlock(workflow: string, jobKey: string): string {
+  const lines = workflow.split('\n');
+  const start = lines.findIndex(line => line === `  ${jobKey}:`);
+
+  expect(start, `Missing workflow job: ${jobKey}`).toBeGreaterThanOrEqual(0);
+
+  const block: string[] = [];
+
+  for (let index = start; index < lines.length; index++) {
+    const line = lines[index]!;
+
+    if (index > start && /^  [a-zA-Z0-9_-]+:/.test(line)) break;
+
+    block.push(line);
+  }
+
+  return block.join('\n');
+}
+
 describe('deploy workflow Vercel env resolution', () => {
   it('pins Vercel pull and build commands to the configured project', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
@@ -45,5 +64,42 @@ describe('deploy workflow Vercel env resolution', () => {
         'VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}'
       );
     }
+  });
+});
+
+describe('CI public a11y workflow', () => {
+  it('uses seeded isolated Neon fixtures instead of the stable main DB', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const a11yJob = getJobBlock(workflow, 'ci-a11y');
+    const createBranchStep = getStepBlock(
+      a11yJob,
+      'Create ephemeral Neon database branch (with retry)'
+    );
+    const exportStep = getStepBlock(
+      a11yJob,
+      'Export DATABASE_URL (ephemeral branch)'
+    );
+    const migrateStep = getStepBlock(
+      a11yJob,
+      'Run migrations (ephemeral Neon)'
+    );
+    const seedStep = getStepBlock(a11yJob, 'Seed public QA fixtures');
+
+    expect(createBranchStep).toContain(
+      "if: steps.check_changes.outputs.run_full_ci == 'true'"
+    );
+    expect(exportStep).toContain(
+      "if: steps.check_changes.outputs.run_full_ci == 'true'"
+    );
+    expect(migrateStep).toContain(
+      "if: steps.check_changes.outputs.run_full_ci == 'true'"
+    );
+    expect(seedStep).toContain(
+      "if: steps.check_changes.outputs.run_full_ci == 'true'"
+    );
+
+    expect(createBranchStep).not.toContain('run_neon');
+    expect(seedStep).not.toContain('run_neon');
+    expect(a11yJob).not.toContain('Export DATABASE_URL (main');
   });
 });


### PR DESCRIPTION
## Summary
- Make the public A11y (axe) CI lane use an isolated Neon branch whenever the job runs.
- Run migrations and seed public QA fixtures for that isolated DB, instead of depending on DATABASE_URL_MAIN fixture state.
- Add a workflow unit guard so this cannot regress back to the stable main DB path.

Linear: JOV-2356

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts
- pnpm biome check .github/workflows/ci.yml apps/web/tests/unit/ci/deploy-workflow.test.ts
- git commit hook: next:proxy-guard, staged Biome, ESLint, web typecheck
- git push hook: biome check ., web pre-push (next:proxy-guard, tailwind:check, typecheck, lint)