### PR TITLE
fix(shell): use canonical audience command routes

### DIFF
--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -182,7 +182,7 @@ export const COMMANDS: readonly Command[] = [
     'Audience',
     'Understand your audience demographics.',
     'Users',
-    APP_ROUTES.DASHBOARD_AUDIENCE
+    APP_ROUTES.AUDIENCE
   ),
   nav(
     'go-tasks',

--- a/apps/web/lib/keyboard-shortcuts.test.ts
+++ b/apps/web/lib/keyboard-shortcuts.test.ts
@@ -103,6 +103,10 @@ describe('keyboard-shortcuts definitions', () => {
     it('uses the canonical releases route for release navigation', () => {
       expect(NAV_SHORTCUTS.releases.href).toBe(APP_ROUTES.RELEASES);
     });
+
+    it('uses the canonical audience route for audience navigation', () => {
+      expect(NAV_SHORTCUTS.audience.href).toBe(APP_ROUTES.AUDIENCE);
+    });
   });
 
   describe('modifier shortcuts', () => {

--- a/apps/web/lib/keyboard-shortcuts.ts
+++ b/apps/web/lib/keyboard-shortcuts.ts
@@ -198,7 +198,7 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     keys: 'G then A',
     category: 'navigation',
     icon: Users,
-    href: APP_ROUTES.DASHBOARD_AUDIENCE,
+    href: APP_ROUTES.AUDIENCE,
     isSequential: true,
     firstKey: 'g',
     secondKey: 'a',

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -118,6 +118,17 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
     expect(pushMock).toHaveBeenCalledWith('/app/releases');
   });
 
+  it('uses the canonical audience route for the Audience nav item', () => {
+    pushMock.mockClear();
+    render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);
+    const audienceNav = screen
+      .getAllByRole('option')
+      .find(el => el.textContent?.includes('Understand your audience'));
+    expect(audienceNav).toBeDefined();
+    fireEvent.mouseDown(audienceNav!);
+    expect(pushMock).toHaveBeenCalledWith('/app/audience');
+  });
+
   it('routes a skill commit to chat with the ?skill= handoff', () => {
     pushMock.mockClear();
     render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);


### PR DESCRIPTION
## Summary
- route cmd+k Audience navigation to /app/audience instead of the legacy dashboard URL
- route the G then A keyboard shortcut to the canonical audience route
- add focused command/shortcut coverage for the canonical route

## Verification
- pnpm --filter @jovie/web exec vitest run ../../apps/web/lib/keyboard-shortcuts.test.ts tests/unit/commands/SharedCommandPalette.test.tsx --config=vitest.config.mts
- pnpm exec biome check apps/web/lib/commands/registry.ts apps/web/lib/keyboard-shortcuts.ts apps/web/lib/keyboard-shortcuts.test.ts apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
