### PR TITLE
fix(shell): use essential data for audience

### DIFF
--- a/apps/web/app/app/(shell)/DashboardShellContent.tsx
+++ b/apps/web/app/app/(shell)/DashboardShellContent.tsx
@@ -65,9 +65,8 @@ export async function DashboardShellContent({
   readonly pathname: string | null;
   readonly children: React.ReactNode;
 }) {
-  // Keep the shell fast on the chat-first landing path and releases.
-  // Other dashboard/settings routes still receive the full dashboard context
-  // because they rely on supplementary fields from the slower fetch.
+  // Keep the shell fast on route-owned workspaces. Routes that fetch their own
+  // page data should not force the shared shell through the full dashboard path.
   const useEssentialShell = shouldUseEssentialShellData(pathname);
   const cookieStorePromise = cookies();
   const initialFlagsPromise = useEssentialShell

--- a/apps/web/app/app/(shell)/shell-route-matches.ts
+++ b/apps/web/app/app/(shell)/shell-route-matches.ts
@@ -111,6 +111,16 @@ export function isPresenceShellRoute(pathname: string | null): boolean {
   );
 }
 
+export function isAudienceShellRoute(pathname: string | null): boolean {
+  if (!pathname) return false;
+  return (
+    pathname === APP_ROUTES.AUDIENCE ||
+    pathname.startsWith(`${APP_ROUTES.AUDIENCE}/`) ||
+    pathname === APP_ROUTES.DASHBOARD_AUDIENCE ||
+    pathname.startsWith(`${APP_ROUTES.DASHBOARD_AUDIENCE}/`)
+  );
+}
+
 function isDashboardSubRoute(pathname: string | null): boolean {
   if (!pathname) return false;
   return pathname.startsWith(`${APP_ROUTES.LEGACY_DASHBOARD}/`);
@@ -139,6 +149,7 @@ function isLightweightShellRoute(pathname: string | null): boolean {
     isTasksShellRoute(pathname) ||
     isInsightsShellRoute(pathname) ||
     isPresenceShellRoute(pathname) ||
+    isAudienceShellRoute(pathname) ||
     isDashboardSubRoute(pathname) ||
     isShellOptimizedSettingsRoute(pathname)
   );
@@ -157,6 +168,7 @@ export function shouldRedirectToOnboarding(pathname: string | null): boolean {
     isTasksShellRoute(pathname) ||
     isInsightsShellRoute(pathname) ||
     isPresenceShellRoute(pathname) ||
+    isAudienceShellRoute(pathname) ||
     isDashboardSubRoute(pathname)
   );
 }

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isAudienceShellRoute,
   isChatShellRoute,
   isInsightsShellRoute,
   isLibraryShellRoute,
@@ -145,6 +146,23 @@ describe('isPresenceShellRoute', () => {
   });
 });
 
+describe('isAudienceShellRoute', () => {
+  it('matches the canonical audience route', () => {
+    expect(isAudienceShellRoute(APP_ROUTES.AUDIENCE)).toBe(true);
+  });
+
+  it('matches the legacy dashboard audience route', () => {
+    expect(isAudienceShellRoute(APP_ROUTES.DASHBOARD_AUDIENCE)).toBe(true);
+  });
+
+  it('matches nested audience subroutes', () => {
+    expect(isAudienceShellRoute(`${APP_ROUTES.AUDIENCE}/segments`)).toBe(true);
+    expect(
+      isAudienceShellRoute(`${APP_ROUTES.DASHBOARD_AUDIENCE}/segments`)
+    ).toBe(true);
+  });
+});
+
 describe('shouldUseEssentialShellData', () => {
   it('returns true for chat routes', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.CHAT)).toBe(true);
@@ -167,6 +185,13 @@ describe('shouldUseEssentialShellData', () => {
 
   it('returns true for the canonical presence route', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.PRESENCE)).toBe(true);
+  });
+
+  it('returns true for audience routes that own their page data', () => {
+    expect(shouldUseEssentialShellData(APP_ROUTES.AUDIENCE)).toBe(true);
+    expect(shouldUseEssentialShellData(APP_ROUTES.DASHBOARD_AUDIENCE)).toBe(
+      true
+    );
   });
 
   it('returns true for dashboard root', () => {
@@ -202,6 +227,7 @@ describe('shouldRedirectToOnboarding', () => {
     expect(shouldRedirectToOnboarding(APP_ROUTES.DASHBOARD_TASKS)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.INSIGHTS)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.PRESENCE)).toBe(true);
+    expect(shouldRedirectToOnboarding(APP_ROUTES.AUDIENCE)).toBe(true);
   });
 
   it('does not add onboarding redirects to settings route chrome optimization', () => {

--- a/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
@@ -77,7 +77,7 @@ describe('@critical DashboardShellContent behavior contracts', () => {
       expect(shouldUseEssentialShellData('/app/dashboard/releases')).toBe(true);
     });
 
-    it('lyrics, library, tasks, insights, and presence routes use essential shell data', () => {
+    it('lyrics, library, tasks, insights, presence, and audience routes use essential shell data', () => {
       expect(shouldUseEssentialShellData(APP_ROUTES.LYRICS)).toBe(true);
       expect(shouldUseEssentialShellData(APP_ROUTES.LIBRARY)).toBe(true);
       expect(shouldUseEssentialShellData(APP_ROUTES.TASKS)).toBe(true);
@@ -86,6 +86,10 @@ describe('@critical DashboardShellContent behavior contracts', () => {
       );
       expect(shouldUseEssentialShellData(APP_ROUTES.INSIGHTS)).toBe(true);
       expect(shouldUseEssentialShellData(APP_ROUTES.PRESENCE)).toBe(true);
+      expect(shouldUseEssentialShellData(APP_ROUTES.AUDIENCE)).toBe(true);
+      expect(shouldUseEssentialShellData(APP_ROUTES.DASHBOARD_AUDIENCE)).toBe(
+        true
+      );
     });
 
     it('dashboard root uses essential shell data', () => {


### PR DESCRIPTION
## Summary
- classify canonical and legacy audience routes as lightweight shell routes
- keep the app shell on getDashboardShellData for audience because the page owns its audience data fetch
- extend shell route and dashboard shell tests for audience route behavior

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/app/shell-route-matches.test.ts tests/unit/dashboard/dashboard-shell-content.test.ts --config=vitest.config.mts
- pnpm exec biome check apps/web/app/app/(shell)/shell-route-matches.ts apps/web/app/app/(shell)/DashboardShellContent.tsx apps/web/tests/unit/app/shell-route-matches.test.ts apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audience section routes now use optimized (lightweight) shell data loading for improved performance and consistency.

* **Refactor**
  * Routing logic updated to recognize audience route variants and include them in onboarding redirect and lightweight-shell decisions.

* **Tests**
  * Added/expanded tests covering audience route matching, lightweight vs full shell selection, and onboarding redirect behavior.

* **Documentation**
  * Clarified inline documentation around shell selection for route-owned workspaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8961?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->