### PR TITLE
ci: pass canary bypass secret to staging

### DIFF
--- a/.github/workflows/canary-health-gate.yml
+++ b/.github/workflows/canary-health-gate.yml
@@ -139,7 +139,9 @@ jobs:
               -b "$COOKIE_JAR"
             )
           else
-            echo "⚠ VERCEL_AUTOMATION_BYPASS_SECRET not set; canary may hit Vercel Security Checkpoint (HTTP 429)."
+            echo "❌ Canary failed: VERCEL_AUTOMATION_BYPASS_SECRET is required for deterministic staging verification."
+            echo "canary_status=failed_config" >> "$GITHUB_OUTPUT"
+            exit 1
           fi
 
           attempt=1
@@ -263,17 +265,9 @@ jobs:
 
               if [ "$response_code" != "200" ]; then
                 if [ "$response_code" = "429" ]; then
-                  if [ -z "$BYPASS_SECRET" ]; then
-                    echo "⚠️ Canary INCONCLUSIVE: Vercel returned HTTP 429 Security Checkpoint after retries."
-                    echo "⚠️ Cannot verify deployment health without VERCEL_AUTOMATION_BYPASS_SECRET."
-                    echo "⚠️ ACTION REQUIRED: Set VERCEL_AUTOMATION_BYPASS_SECRET to enable proper canary verification."
-                    echo "canary_status=verified" >> "$GITHUB_OUTPUT"
-                    exit 0
-                  else
-                    echo "❌ Canary failed: HTTP 429 Security Checkpoint even though bypass secret is set."
-                    echo "canary_status=failed" >> "$GITHUB_OUTPUT"
-                    exit 1
-                  fi
+                  echo "❌ Canary failed: HTTP 429 after retries even though bypass secret is set."
+                  echo "canary_status=failed" >> "$GITHUB_OUTPUT"
+                  exit 1
                 else
                   echo "❌ Canary fallback failed after retries: HTTP $response_code"
                   echo "canary_status=failed" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3618,7 +3618,13 @@ jobs:
       - name: Deploy (staging preview, prebuilt)
         id: deploy
         run: |
+          if [ -z "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
+            echo "VERCEL_AUTOMATION_BYPASS_SECRET is required for staging canary verification."
+            exit 1
+          fi
+
           bash .github/scripts/vercel-prebuilt-deploy.sh deploy_url \
+            --env VERCEL_AUTOMATION_BYPASS_SECRET="${VERCEL_AUTOMATION_BYPASS_SECRET}" \
             --env CLERK_PUBLISHABLE_KEY_STAGING="${CLERK_PUBLISHABLE_KEY_STAGING}" \
             --env CLERK_SECRET_KEY_STAGING="${CLERK_SECRET_KEY_STAGING}"
         env:
@@ -3626,6 +3632,7 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           CLERK_PUBLISHABLE_KEY_STAGING: ${{ secrets.CLERK_PUBLISHABLE_KEY_STAGING }}
           CLERK_SECRET_KEY_STAGING: ${{ secrets.CLERK_SECRET_KEY_STAGING }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ENABLE_PLAIN_PREBUILT_FALLBACK: 'true'
 

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -6,6 +6,10 @@ import { describe, expect, it } from 'vitest';
 const testDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(testDir, '..', '..', '..', '..', '..');
 const workflowPath = resolve(repoRoot, '.github/workflows/ci.yml');
+const canaryWorkflowPath = resolve(
+  repoRoot,
+  '.github/workflows/canary-health-gate.yml'
+);
 
 function getStepBlock(workflow: string, stepName: string): string {
   const lines = workflow.split('\n');
@@ -64,6 +68,40 @@ describe('deploy workflow Vercel env resolution', () => {
         'VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}'
       );
     }
+  });
+
+  it('passes the automation bypass secret into the staging preview runtime', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const deployStep = getStepBlock(
+      workflow,
+      'Deploy (staging preview, prebuilt)'
+    );
+
+    expect(deployStep).toContain(
+      'VERCEL_AUTOMATION_BYPASS_SECRET is required for staging canary verification.'
+    );
+    expect(deployStep).toContain(
+      '--env VERCEL_AUTOMATION_BYPASS_SECRET="${VERCEL_AUTOMATION_BYPASS_SECRET}"'
+    );
+    expect(deployStep).toContain(
+      'VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}'
+    );
+  });
+});
+
+describe('canary health gate workflow', () => {
+  it('fails closed when the automation bypass secret is missing', () => {
+    const workflow = readFileSync(canaryWorkflowPath, 'utf8');
+    const canaryStep = getStepBlock(workflow, 'Canary health check');
+
+    expect(canaryStep).toContain(
+      'VERCEL_AUTOMATION_BYPASS_SECRET is required for deterministic staging verification.'
+    );
+    expect(canaryStep).toContain('canary_status=failed_config');
+    expect(canaryStep).not.toContain('Canary INCONCLUSIVE');
+    expect(canaryStep).not.toContain(
+      'canary_status=verified" >> "$GITHUB_OUTPUT"\n                    exit 0'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- pass VERCEL_AUTOMATION_BYPASS_SECRET into the staging preview deployment runtime so /api/health can honor the automation bypass
- fail the reusable canary workflow closed when the bypass secret is missing instead of treating a 429 as verified
- add workflow contract coverage for the staging deploy and canary fail-closed behavior

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts
- pnpm biome check .github/workflows/ci.yml .github/workflows/canary-health-gate.yml apps/web/tests/unit/ci/deploy-workflow.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git push pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

## Notes
- Local actionlint reports pre-existing shellcheck warnings across untouched CI blocks; the focused workflow contract test covers this change.