### PR TITLE
fix(shell): canonicalize calendar route data

### DIFF
--- a/apps/web/app/app/(shell)/calendar/page.tsx
+++ b/apps/web/app/app/(shell)/calendar/page.tsx
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
   description: 'Releases and events at a glance',
 };
 
-const CALENDAR_ROUTE = `${APP_ROUTES.DASHBOARD}/calendar`;
+const CALENDAR_ROUTE = APP_ROUTES.CALENDAR;
 
 function formatProvider(provider: TourDateProviderValue): string {
   if (provider === 'bandsintown') return 'Bandsintown';

--- a/apps/web/app/app/(shell)/shell-route-matches.ts
+++ b/apps/web/app/app/(shell)/shell-route-matches.ts
@@ -121,6 +121,14 @@ export function isAudienceShellRoute(pathname: string | null): boolean {
   );
 }
 
+export function isCalendarShellRoute(pathname: string | null): boolean {
+  if (!pathname) return false;
+  return (
+    pathname === APP_ROUTES.CALENDAR ||
+    pathname.startsWith(`${APP_ROUTES.CALENDAR}/`)
+  );
+}
+
 function isDashboardSubRoute(pathname: string | null): boolean {
   if (!pathname) return false;
   return pathname.startsWith(`${APP_ROUTES.LEGACY_DASHBOARD}/`);
@@ -150,6 +158,7 @@ function isLightweightShellRoute(pathname: string | null): boolean {
     isInsightsShellRoute(pathname) ||
     isPresenceShellRoute(pathname) ||
     isAudienceShellRoute(pathname) ||
+    isCalendarShellRoute(pathname) ||
     isDashboardSubRoute(pathname) ||
     isShellOptimizedSettingsRoute(pathname)
   );
@@ -169,6 +178,7 @@ export function shouldRedirectToOnboarding(pathname: string | null): boolean {
     isInsightsShellRoute(pathname) ||
     isPresenceShellRoute(pathname) ||
     isAudienceShellRoute(pathname) ||
+    isCalendarShellRoute(pathname) ||
     isDashboardSubRoute(pathname)
   );
 }

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -38,6 +38,7 @@ export const APP_ROUTES = {
   CONTACTS: '/app/contacts',
   RELEASES: '/app/releases',
   TOUR_DATES: '/app/tour-dates',
+  CALENDAR: '/app/calendar',
   AUDIENCE: '/app/audience',
   EARNINGS: '/app/earnings',
   LIBRARY: '/app/library',

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   isAudienceShellRoute,
+  isCalendarShellRoute,
   isChatShellRoute,
   isInsightsShellRoute,
   isLibraryShellRoute,
@@ -163,6 +164,18 @@ describe('isAudienceShellRoute', () => {
   });
 });
 
+describe('isCalendarShellRoute', () => {
+  it('matches the canonical calendar route', () => {
+    expect(isCalendarShellRoute(APP_ROUTES.CALENDAR)).toBe(true);
+  });
+
+  it('matches nested calendar subroutes', () => {
+    expect(isCalendarShellRoute(`${APP_ROUTES.CALENDAR}/week/2026-05-15`)).toBe(
+      true
+    );
+  });
+});
+
 describe('shouldUseEssentialShellData', () => {
   it('returns true for chat routes', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.CHAT)).toBe(true);
@@ -192,6 +205,10 @@ describe('shouldUseEssentialShellData', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.DASHBOARD_AUDIENCE)).toBe(
       true
     );
+  });
+
+  it('returns true for the canonical calendar route', () => {
+    expect(shouldUseEssentialShellData(APP_ROUTES.CALENDAR)).toBe(true);
   });
 
   it('returns true for dashboard root', () => {
@@ -228,6 +245,7 @@ describe('shouldRedirectToOnboarding', () => {
     expect(shouldRedirectToOnboarding(APP_ROUTES.INSIGHTS)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.PRESENCE)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.AUDIENCE)).toBe(true);
+    expect(shouldRedirectToOnboarding(APP_ROUTES.CALENDAR)).toBe(true);
   });
 
   it('does not add onboarding redirects to settings route chrome optimization', () => {

--- a/apps/web/tests/unit/calendar/calendar-page.test.tsx
+++ b/apps/web/tests/unit/calendar/calendar-page.test.tsx
@@ -130,7 +130,7 @@ describe('CalendarPage', () => {
     mocks.getCachedAuth.mockResolvedValueOnce({ userId: null });
 
     await expect(CalendarPage()).rejects.toThrow(
-      `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.DASHBOARD}/calendar`
+      `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.CALENDAR}`
     );
 
     expect(mocks.getDashboardShellData).not.toHaveBeenCalled();
@@ -152,7 +152,7 @@ describe('CalendarPage', () => {
     expect(mocks.captureError).toHaveBeenCalledWith(
       'Dashboard data load failed on calendar page',
       dashboardLoadError,
-      { route: `${APP_ROUTES.DASHBOARD}/calendar` }
+      { route: APP_ROUTES.CALENDAR }
     );
     expect(mocks.fetchQuery).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Adds a canonical `APP_ROUTES.CALENDAR` constant and routes calendar sign-in/error telemetry through it.
- Treats `/app/calendar` as a lightweight app-shell route so shell chrome can use the essential data path instead of full dashboard data.
- Extends route-matching tests for calendar shell behavior.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/app/shell-route-matches.test.ts tests/unit/calendar/calendar-page.test.tsx --config=vitest.config.mts`
- `JOVIE_AGENT_PROFILE=coder pnpm exec biome check apps/web/constants/routes.ts 'apps/web/app/app/(shell)/calendar/page.tsx' 'apps/web/app/app/(shell)/shell-route-matches.ts' apps/web/tests/unit/app/shell-route-matches.test.ts apps/web/tests/unit/calendar/calendar-page.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized the calendar route into a single canonical route constant and updated routing/redirect and error-reporting behavior to use it.
  * Enhanced route detection so calendar paths are treated as lightweight shell routes and considered in onboarding redirect logic.

* **Tests**
  * Updated unit tests to expect the canonical calendar route for redirects, error tracking, and shell-data decisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8964?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->