### PR TITLE
fix(shell): unify artwork fallback tiles

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -29,6 +29,7 @@ import {
   useMemo,
   useState,
 } from 'react';
+import { ArtworkFallbackTile } from '@/components/atoms/ArtworkFallbackTile';
 import { PageShell } from '@/components/organisms/PageShell';
 import {
   PAGE_TOOLBAR_END_GROUP_CLASS,
@@ -47,10 +48,6 @@ import { APP_ROUTES } from '@/constants/routes';
 import { useRegisterHeaderSearch } from '@/contexts/HeaderActionsContext';
 import { useRegisterShellSidebarOverride } from '@/contexts/ShellSidebarOverrideContext';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
-import {
-  getArtworkFallbackAccentStyle,
-  getArtworkFallbackSurfaceStyle,
-} from '@/lib/artwork-fallback';
 import { SKELETON_ROW_COUNT } from '@/lib/constants/layout';
 import { cn } from '@/lib/utils';
 import { capitalizeFirst } from '@/lib/utils/string-utils';
@@ -339,26 +336,13 @@ function Artwork({
   return (
     <div
       className={cn(
-        'relative overflow-hidden border border-subtle bg-surface-1 text-white/25',
+        'relative overflow-hidden border border-subtle bg-surface-1',
         sizeClasses[size]
       )}
-      data-artwork-fallback='true'
-      style={getArtworkFallbackSurfaceStyle(asset.title)}
     >
-      <div className='absolute inset-0 grid place-items-center'>
-        <Disc3
-          className={cn(size === 'row' ? 'h-4 w-4' : 'h-[18%] w-[18%]')}
-          strokeWidth={1.85}
-        />
-      </div>
-      <span
-        aria-hidden='true'
-        className='absolute inset-x-0 bottom-0 h-1'
-        style={getArtworkFallbackAccentStyle(asset.title)}
-      />
-      <span
-        aria-hidden='true'
-        className='absolute inset-[1px] rounded-[3px] border border-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]'
+      <ArtworkFallbackTile
+        seed={asset.title}
+        iconClassName={size === 'row' ? 'h-4 w-4' : 'h-[18%] w-[18%]'}
       />
     </div>
   );

--- a/apps/web/components/atoms/ArtworkFallbackTile.tsx
+++ b/apps/web/components/atoms/ArtworkFallbackTile.tsx
@@ -1,0 +1,54 @@
+import { Disc3 } from 'lucide-react';
+import {
+  getArtworkFallbackAccentStyle,
+  getArtworkFallbackSurfaceStyle,
+} from '@/lib/artwork-fallback';
+import { cn } from '@/lib/utils';
+
+interface ArtworkFallbackTileProps {
+  readonly seed: string;
+  readonly label?: string;
+  readonly className?: string;
+  readonly iconClassName?: string;
+  readonly accentClassName?: string;
+}
+
+/**
+ * Tokenized fallback cover art used anywhere shell artwork is missing.
+ * Keep this quiet and deterministic so missing artwork reads as intentional UI.
+ */
+export function ArtworkFallbackTile({
+  seed,
+  label,
+  className,
+  iconClassName = 'h-[42%] w-[42%]',
+  accentClassName = 'h-1',
+}: ArtworkFallbackTileProps) {
+  return (
+    <div
+      className={cn(
+        'relative flex h-full w-full items-center justify-center overflow-hidden text-white/25',
+        className
+      )}
+      data-artwork-fallback='true'
+      style={getArtworkFallbackSurfaceStyle(seed)}
+    >
+      <Disc3
+        aria-hidden='true'
+        className={cn('relative z-10', iconClassName)}
+        data-artwork-fallback-icon='true'
+        strokeWidth={1.85}
+      />
+      <span
+        aria-hidden='true'
+        className={cn('absolute inset-x-0 bottom-0', accentClassName)}
+        style={getArtworkFallbackAccentStyle(seed)}
+      />
+      <span
+        aria-hidden='true'
+        className='absolute inset-[1px] rounded-[3px] border border-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]'
+      />
+      {label ? <span className='sr-only'>{label}</span> : null}
+    </div>
+  );
+}

--- a/apps/web/components/atoms/ReleaseArtworkThumb.tsx
+++ b/apps/web/components/atoms/ReleaseArtworkThumb.tsx
@@ -2,11 +2,7 @@
 
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
-import { Icon } from '@/components/atoms/Icon';
-import {
-  getArtworkFallbackAccentStyle,
-  getArtworkFallbackSurfaceStyle,
-} from '@/lib/artwork-fallback';
+import { ArtworkFallbackTile } from '@/components/atoms/ArtworkFallbackTile';
 import { cn } from '@/lib/utils';
 
 interface ReleaseArtworkThumbProps {
@@ -57,27 +53,11 @@ export function ReleaseArtworkThumb({
           onError={() => setImgError(true)}
         />
       ) : (
-        <div
-          className='relative flex h-full w-full items-center justify-center overflow-hidden text-white/25'
-          data-artwork-fallback='true'
-          style={getArtworkFallbackSurfaceStyle(alt)}
-        >
-          <Icon
-            name='Disc3'
-            className={cn('relative z-10', fallbackIconClass)}
-            aria-hidden='true'
-          />
-          <span
-            aria-hidden='true'
-            className='absolute inset-x-0 bottom-0 h-1'
-            style={getArtworkFallbackAccentStyle(alt)}
-          />
-          <span
-            aria-hidden='true'
-            className='absolute inset-[1px] rounded-[3px] border border-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]'
-          />
-          <span className='sr-only'>{alt}</span>
-        </div>
+        <ArtworkFallbackTile
+          seed={alt}
+          label={alt}
+          iconClassName={fallbackIconClass}
+        />
       )}
     </div>
   );

--- a/apps/web/components/atoms/index.ts
+++ b/apps/web/components/atoms/index.ts
@@ -4,6 +4,7 @@
 
 export { AmountSelector } from './AmountSelector';
 export { ArtistName } from './ArtistName';
+export { ArtworkFallbackTile } from './ArtworkFallbackTile';
 export type { Assignee } from './AssigneeAvatar';
 export { AssigneeAvatar } from './AssigneeAvatar';
 export type {

--- a/apps/web/components/shell/ArtworkThumb.tsx
+++ b/apps/web/components/shell/ArtworkThumb.tsx
@@ -1,11 +1,7 @@
 'use client';
 
-import { Disc3 } from 'lucide-react';
 import { useEffect, useState } from 'react';
-import {
-  getArtworkFallbackAccentStyle,
-  getArtworkFallbackSurfaceStyle,
-} from '@/lib/artwork-fallback';
+import { ArtworkFallbackTile } from '@/components/atoms/ArtworkFallbackTile';
 import { cn } from '@/lib/utils';
 
 /**
@@ -75,29 +71,7 @@ export function ArtworkThumb({
           style={{ backgroundImage: `url(${src})` }}
         />
       ) : (
-        <>
-          <span
-            aria-hidden='true'
-            className='absolute inset-0'
-            data-artwork-fallback='true'
-            style={getArtworkFallbackSurfaceStyle(title)}
-          />
-          <span
-            aria-hidden='true'
-            className='absolute inset-0 grid place-items-center text-white/25'
-          >
-            <Disc3 className='h-[42%] w-[42%]' strokeWidth={1.85} />
-          </span>
-          <span
-            aria-hidden='true'
-            className='absolute inset-x-0 bottom-0 h-1'
-            style={getArtworkFallbackAccentStyle(title)}
-          />
-          <span
-            aria-hidden='true'
-            className='absolute inset-[1px] rounded-[3px] border border-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]'
-          />
-        </>
+        <ArtworkFallbackTile seed={title} />
       )}
     </div>
   );

--- a/apps/web/tests/unit/atoms/ReleaseArtworkThumb.test.tsx
+++ b/apps/web/tests/unit/atoms/ReleaseArtworkThumb.test.tsx
@@ -15,12 +15,6 @@ vi.mock('next/image', () => ({
   ),
 }));
 
-vi.mock('@/components/atoms/Icon', () => ({
-  Icon: ({ name, className, 'aria-hidden': ariaHidden }: any) => (
-    <svg data-icon={name} className={className} aria-hidden={ariaHidden} />
-  ),
-}));
-
 describe('ReleaseArtworkThumb', () => {
   it('renders image when src is provided', () => {
     render(<ReleaseArtworkThumb src='/art.jpg' alt='Album art' />);
@@ -35,12 +29,16 @@ describe('ReleaseArtworkThumb', () => {
   it('renders fallback icon when src is null', () => {
     render(<ReleaseArtworkThumb src={null} alt='Missing art' />);
     expect(screen.getByText('Missing art')).toBeInTheDocument();
-    expect(document.querySelector('[data-icon="Disc3"]')).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-artwork-fallback-icon="true"]')
+    ).toBeInTheDocument();
   });
 
   it('renders fallback icon when src is undefined', () => {
     render(<ReleaseArtworkThumb src={undefined} alt='Missing art' />);
-    expect(document.querySelector('[data-icon="Disc3"]')).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-artwork-fallback-icon="true"]')
+    ).toBeInTheDocument();
   });
 
   it('renders fallback sr-only text when showing fallback', () => {
@@ -74,7 +72,9 @@ describe('ReleaseArtworkThumb', () => {
     render(<ReleaseArtworkThumb src='/broken.jpg' alt='Broken' />);
     const img = screen.getByRole('img');
     fireEvent.error(img);
-    expect(document.querySelector('[data-icon="Disc3"]')).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-artwork-fallback-icon="true"]')
+    ).toBeInTheDocument();
     expect(screen.getByText('Broken')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- Add a shared `ArtworkFallbackTile` primitive for missing shell artwork
- Use the shared fallback in shell release thumbnails, library artwork, and release artwork thumbs
- Keep the fallback tokenized and deterministic while removing duplicate local fallback markup

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run components/shell/ArtworkThumb.test.tsx tests/unit/atoms/ReleaseArtworkThumb.test.tsx tests/unit/library/LibrarySurface.test.tsx --config=vitest.config.mts` (18 tests passed)
- `JOVIE_AGENT_PROFILE=coder pnpm exec biome check apps/web/components/atoms/ArtworkFallbackTile.tsx apps/web/components/atoms/ReleaseArtworkThumb.tsx apps/web/components/atoms/index.ts apps/web/components/shell/ArtworkThumb.tsx 'apps/web/app/app/(shell)/library/LibrarySurface.tsx' apps/web/tests/unit/atoms/ReleaseArtworkThumb.test.tsx` (passed)
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` (passed)
- Browser QA at `http://127.0.0.1:3114/app/library` with desktop/tablet/mobile screenshots; no horizontal overflow, fallback rendered in all three viewports, no console errors
- Pixel analysis: fallback tile differs from adjacent blank area on desktop/tablet, average saturation ~0.30, green-dominant pixels below 0.3%
