### PR TITLE
refactor(shell): share route prefix matching

### DIFF
--- a/apps/web/app/app/(shell)/shell-route-matches.ts
+++ b/apps/web/app/app/(shell)/shell-route-matches.ts
@@ -26,6 +26,32 @@ function parseAppShellPath(headerValue: string | null): string | null {
   }
 }
 
+function matchesExactRoute(
+  pathname: string | null,
+  ...routes: readonly string[]
+): boolean {
+  if (!pathname) return false;
+  return routes.some(route => pathname === route);
+}
+
+function matchesRoutePrefix(
+  pathname: string | null,
+  ...routes: readonly string[]
+): boolean {
+  if (!pathname) return false;
+  return routes.some(
+    route => pathname === route || pathname.startsWith(`${route}/`)
+  );
+}
+
+function matchesNestedRoute(
+  pathname: string | null,
+  ...routes: readonly string[]
+): boolean {
+  if (!pathname) return false;
+  return routes.some(route => pathname.startsWith(`${route}/`));
+}
+
 export function resolveAppShellRequestPath(
   ...headerValues: readonly (string | null)[]
 ): string | null {
@@ -44,108 +70,70 @@ export function resolveAppShellRequestPath(
 }
 
 export function isChatShellRoute(pathname: string | null): boolean {
-  if (!pathname) {
-    return false;
-  }
-
   return (
-    pathname === APP_ROUTES.DASHBOARD ||
-    pathname === APP_ROUTES.CHAT ||
-    pathname.startsWith(`${APP_ROUTES.CHAT}/`)
+    matchesExactRoute(pathname, APP_ROUTES.DASHBOARD) ||
+    matchesRoutePrefix(pathname, APP_ROUTES.CHAT)
   );
 }
 
 export function isReleasesShellRoute(pathname: string | null): boolean {
-  if (!pathname) return false;
-  return (
-    pathname === APP_ROUTES.RELEASES ||
-    pathname.startsWith(`${APP_ROUTES.RELEASES}/`) ||
-    pathname === APP_ROUTES.DASHBOARD_RELEASES ||
-    pathname.startsWith(`${APP_ROUTES.DASHBOARD_RELEASES}/`)
+  return matchesRoutePrefix(
+    pathname,
+    APP_ROUTES.RELEASES,
+    APP_ROUTES.DASHBOARD_RELEASES
   );
 }
 
 export function isLyricsShellRoute(pathname: string | null): boolean {
-  if (!pathname) return false;
-  return (
-    pathname === APP_ROUTES.LYRICS ||
-    pathname.startsWith(`${APP_ROUTES.LYRICS}/`)
-  );
+  return matchesRoutePrefix(pathname, APP_ROUTES.LYRICS);
 }
 
 export function isLibraryShellRoute(pathname: string | null): boolean {
-  if (!pathname) return false;
-  return (
-    pathname === APP_ROUTES.LIBRARY ||
-    pathname.startsWith(`${APP_ROUTES.LIBRARY}/`) ||
-    pathname === APP_ROUTES.DASHBOARD_LIBRARY ||
-    pathname.startsWith(`${APP_ROUTES.DASHBOARD_LIBRARY}/`) ||
-    pathname === APP_ROUTES.LEGACY_DASHBOARD_LIBRARY ||
-    pathname.startsWith(`${APP_ROUTES.LEGACY_DASHBOARD_LIBRARY}/`)
+  return matchesRoutePrefix(
+    pathname,
+    APP_ROUTES.LIBRARY,
+    APP_ROUTES.DASHBOARD_LIBRARY,
+    APP_ROUTES.LEGACY_DASHBOARD_LIBRARY
   );
 }
 
 export function isTasksShellRoute(pathname: string | null): boolean {
-  if (!pathname) return false;
-  return (
-    pathname === APP_ROUTES.TASKS ||
-    pathname.startsWith(`${APP_ROUTES.TASKS}/`) ||
-    pathname === APP_ROUTES.DASHBOARD_TASKS ||
-    pathname.startsWith(`${APP_ROUTES.DASHBOARD_TASKS}/`)
+  return matchesRoutePrefix(
+    pathname,
+    APP_ROUTES.TASKS,
+    APP_ROUTES.DASHBOARD_TASKS
   );
 }
 
 export function isInsightsShellRoute(pathname: string | null): boolean {
-  if (!pathname) return false;
-  return (
-    pathname === APP_ROUTES.INSIGHTS ||
-    pathname.startsWith(`${APP_ROUTES.INSIGHTS}/`)
-  );
+  return matchesRoutePrefix(pathname, APP_ROUTES.INSIGHTS);
 }
 
 export function isPresenceShellRoute(pathname: string | null): boolean {
-  if (!pathname) return false;
-  return (
-    pathname === APP_ROUTES.PRESENCE ||
-    pathname.startsWith(`${APP_ROUTES.PRESENCE}/`)
-  );
+  return matchesRoutePrefix(pathname, APP_ROUTES.PRESENCE);
 }
 
 export function isAudienceShellRoute(pathname: string | null): boolean {
-  if (!pathname) return false;
-  return (
-    pathname === APP_ROUTES.AUDIENCE ||
-    pathname.startsWith(`${APP_ROUTES.AUDIENCE}/`) ||
-    pathname === APP_ROUTES.DASHBOARD_AUDIENCE ||
-    pathname.startsWith(`${APP_ROUTES.DASHBOARD_AUDIENCE}/`)
+  return matchesRoutePrefix(
+    pathname,
+    APP_ROUTES.AUDIENCE,
+    APP_ROUTES.DASHBOARD_AUDIENCE
   );
 }
 
 export function isCalendarShellRoute(pathname: string | null): boolean {
-  if (!pathname) return false;
-  return (
-    pathname === APP_ROUTES.CALENDAR ||
-    pathname.startsWith(`${APP_ROUTES.CALENDAR}/`)
-  );
+  return matchesRoutePrefix(pathname, APP_ROUTES.CALENDAR);
 }
 
 function isDashboardSubRoute(pathname: string | null): boolean {
-  if (!pathname) return false;
-  return pathname.startsWith(`${APP_ROUTES.LEGACY_DASHBOARD}/`);
+  return matchesNestedRoute(pathname, APP_ROUTES.LEGACY_DASHBOARD);
 }
 
 function isShellOptimizedSettingsRoute(pathname: string | null): boolean {
-  if (!pathname) return false;
-  if (
-    pathname === APP_ROUTES.SETTINGS_ARTIST_PROFILE ||
-    pathname.startsWith(`${APP_ROUTES.SETTINGS_ARTIST_PROFILE}/`)
-  ) {
+  if (matchesRoutePrefix(pathname, APP_ROUTES.SETTINGS_ARTIST_PROFILE)) {
     return false;
   }
-  return (
-    pathname === APP_ROUTES.SETTINGS ||
-    pathname.startsWith(`${APP_ROUTES.SETTINGS}/`)
-  );
+  return matchesRoutePrefix(pathname, APP_ROUTES.SETTINGS);
 }
 
 function isLightweightShellRoute(pathname: string | null): boolean {

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -215,6 +215,12 @@ describe('shouldUseEssentialShellData', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.DASHBOARD)).toBe(true);
   });
 
+  it('does not treat the legacy dashboard root as a nested dashboard subroute', () => {
+    expect(shouldUseEssentialShellData(APP_ROUTES.LEGACY_DASHBOARD)).toBe(
+      false
+    );
+  });
+
   it('returns true for settings routes that do not need supplementary dashboard data', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.SETTINGS_ACCOUNT)).toBe(true);
     expect(shouldUseEssentialShellData(APP_ROUTES.SETTINGS_CONTACTS)).toBe(
@@ -246,6 +252,10 @@ describe('shouldRedirectToOnboarding', () => {
     expect(shouldRedirectToOnboarding(APP_ROUTES.PRESENCE)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.AUDIENCE)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.CALENDAR)).toBe(true);
+  });
+
+  it('does not add onboarding redirects to the legacy dashboard root', () => {
+    expect(shouldRedirectToOnboarding(APP_ROUTES.LEGACY_DASHBOARD)).toBe(false);
   });
 
   it('does not add onboarding redirects to settings route chrome optimization', () => {


### PR DESCRIPTION
## Summary
- Add shared exact, prefix, and nested route match helpers for shell route contracts
- Rewrite chat, releases, lyrics, library, tasks, insights, presence, audience, calendar, dashboard, and settings route classifiers through the same matcher path
- Preserve the legacy dashboard root behavior with explicit tests

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/app/shell-route-matches.test.ts --config=vitest.config.mts` (44 tests passed)
- `JOVIE_AGENT_PROFILE=coder pnpm exec biome check 'apps/web/app/app/(shell)/shell-route-matches.ts' apps/web/tests/unit/app/shell-route-matches.test.ts` (passed)
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` (passed)
