### PR TITLE
fix(shell): use essential data for profile actions

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/requireProfileId.ts
+++ b/apps/web/app/app/(shell)/dashboard/requireProfileId.ts
@@ -2,10 +2,10 @@
 
 import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
-import { getDashboardData } from './actions';
+import { getDashboardDataEssential } from './actions';
 
 export async function requireProfileId(): Promise<string> {
-  const data = await getDashboardData();
+  const data = await getDashboardDataEssential();
 
   if (data.needsOnboarding && !data.dashboardLoadError) {
     redirect(APP_ROUTES.START);

--- a/apps/web/tests/unit/app/require-profile-id-fast-path.test.ts
+++ b/apps/web/tests/unit/app/require-profile-id-fast-path.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = join(__dirname, '../../..');
+
+function readSource(path: string): string {
+  return readFileSync(join(ROOT, path), 'utf-8');
+}
+
+describe('requireProfileId fast path', () => {
+  it('uses essential dashboard data instead of the full dashboard payload', () => {
+    const source = readSource('app/app/(shell)/dashboard/requireProfileId.ts');
+
+    expect(source).toContain('getDashboardDataEssential');
+    expect(source).not.toContain('getDashboardData()');
+  });
+});


### PR DESCRIPTION
## Summary
- Switch `requireProfileId()` from the full dashboard payload to `getDashboardDataEssential()`.
- Keep task and release-task server actions on the lighter profile-resolution data path.
- Add a source guard so the helper does not drift back to the full dashboard fetch.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/require-profile-id-fast-path.test.ts tests/unit/dashboard/task-gating-actions.test.ts tests/unit/app/dashboard-tasks-page.test.tsx tests/unit/app/release-tasks-page.test.tsx --config=vitest.config.mts`
- `pnpm exec biome check 'apps/web/app/app/(shell)/dashboard/requireProfileId.ts' apps/web/tests/unit/app/require-profile-id-fast-path.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Design Review
- No visual surface changed. Approval assumed per shell migration instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized dashboard initialization to use streamlined data fetching for faster loading.

* **Tests**
  * Added unit test to validate dashboard profile requirement logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->