### PR TITLE
fix(shell): use essential data for release credits

### DIFF
--- a/apps/web/components/organisms/release-sidebar/release-credits-action.ts
+++ b/apps/web/components/organisms/release-sidebar/release-credits-action.ts
@@ -3,7 +3,7 @@
 import { and, eq } from 'drizzle-orm';
 import type { SmartLinkCreditGroup } from '@/app/[username]/[slug]/_lib/data';
 import { groupReleaseCredits } from '@/app/[username]/[slug]/_lib/data';
-import { getDashboardData } from '@/app/app/(shell)/dashboard/actions';
+import { getDashboardDataEssential } from '@/app/app/(shell)/dashboard/actions';
 import { getOptionalAuth } from '@/lib/auth/cached';
 import { db } from '@/lib/db';
 import {
@@ -21,7 +21,7 @@ export async function fetchReleaseCreditsAction(
     return [];
   }
 
-  const dashboardData = await getDashboardData();
+  const dashboardData = await getDashboardDataEssential();
   const selectedProfile = dashboardData.selectedProfile;
 
   if (!selectedProfile) {

--- a/apps/web/tests/unit/organisms/release-credits-action.test.ts
+++ b/apps/web/tests/unit/organisms/release-credits-action.test.ts
@@ -1,16 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockGetOptionalAuth, mockGetDashboardData } = vi.hoisted(() => ({
-  mockGetOptionalAuth: vi.fn(),
-  mockGetDashboardData: vi.fn(),
-}));
+const { mockGetOptionalAuth, mockGetDashboardDataEssential } = vi.hoisted(
+  () => ({
+    mockGetOptionalAuth: vi.fn(),
+    mockGetDashboardDataEssential: vi.fn(),
+  })
+);
 
 vi.mock('@/lib/auth/cached', () => ({
   getOptionalAuth: mockGetOptionalAuth,
 }));
 
 vi.mock('@/app/app/(shell)/dashboard/actions', () => ({
-  getDashboardData: mockGetDashboardData,
+  getDashboardDataEssential: mockGetDashboardDataEssential,
 }));
 
 vi.mock('@/lib/db', () => ({
@@ -50,6 +52,6 @@ describe('fetchReleaseCreditsAction', () => {
     });
 
     await expect(fetchReleaseCreditsAction('release_123')).resolves.toEqual([]);
-    expect(mockGetDashboardData).not.toHaveBeenCalled();
+    expect(mockGetDashboardDataEssential).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Switch release-sidebar credit fetching from the full dashboard payload to `getDashboardDataEssential()`.
- Keep selected-profile authorization intact while avoiding slower supplementary dashboard queries.
- Update the existing auth-unavailable regression test to assert the lighter helper is not called.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/organisms/release-credits-action.test.ts --config=vitest.config.mts`
- `pnpm exec biome check apps/web/components/organisms/release-sidebar/release-credits-action.ts apps/web/tests/unit/organisms/release-credits-action.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Design Review
- No visual surface changed. Approval assumed per shell migration instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data source for release credits management, streamlining dashboard performance by leveraging a more efficient data retrieval approach.

* **Tests**
  * Updated unit tests to ensure all functionality operates correctly following the internal optimization changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8971?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->