### PR TITLE
ci: verify production promotion through jov.ie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3843,20 +3843,19 @@ jobs:
             BYPASS_ARGS+=(-H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
           fi
 
-          # Probe the DEPLOYMENT URL directly rather than jov.ie. Rationale:
-          # jov.ie is fronted by Vercel's edge router + CDN. After `vercel
-          # promote` succeeds, the alias IS atomically pointed at the new
-          # deployment at the router level, but edge caches can take longer
-          # than our 60s window to start serving fresh responses (observed
-          # 2026-04-24 on commit 57a7dc3 — promote succeeded, prod flipped
-          # within ~2 min, but the verify loop expired first and emitted a
-          # false-positive verify_mismatch). The deployment URL is stable —
-          # it always serves exactly this deployment's code, no aliases, no
-          # edge timing. If the deployment's /api/health/build-info returns
-          # expected commitSha, the promote was successful and prod is
-          # serving it (edge cache will catch up asynchronously).
-          probe_url="${deploy_url}/api/health/build-info"
-          echo "Verifying ${probe_url} serves ${expected}..."
+          # Prefer the deployment URL when Vercel allows direct access, but
+          # also verify the canonical production alias. Protected deployment
+          # URLs can return 401 even after a successful promote; jov.ie is the
+          # user-facing surface and catches domain/project wiring regressions.
+          probe_urls=(
+            "${deploy_url}/api/health/build-info"
+            "https://jov.ie/api/health/build-info"
+          )
+          probe_labels=(
+            "deployment"
+            "production-alias"
+          )
+          echo "Verifying promoted deployment serves ${expected}..."
           # Track confirmed_mismatch separately from saw_valid_probe so a
           # late 500 can't overwrite an earlier confirmed mismatch. Once we
           # see a 200 with a wrong SHA, it IS a mismatch — routing a
@@ -3866,59 +3865,61 @@ jobs:
           last_status=""
           saw_valid_probe=false
           confirmed_mismatch=false
-          # Vercel edge rollout can lag behind a successful `vercel promote`
-          # by more than a minute. Keep verification strict, but use a longer
-          # bounded window to avoid false negatives on healthy deploys.
-          max_attempts=18
+          # Vercel edge rollout can lag behind a successful `vercel promote`.
+          # Keep verification strict, but use a bounded 5-minute window to
+          # avoid false negatives on healthy deploys.
+          max_attempts=30
           for attempt in $(seq 1 "$max_attempts"); do
             # Skip sleep on the first attempt; wait between retries so we
             # don't burn 10s after the final failing attempt.
             if [ "$attempt" -gt 1 ]; then
               sleep 10
             fi
-            response=$(curl -sS -L \
-              --connect-timeout 5 \
-              --max-time 10 \
-              -A "$USER_AGENT" \
-              -H "Cache-Control: no-cache" \
-              "${BYPASS_ARGS[@]}" \
-              -w "\n%{http_code}" \
-              "${probe_url}?_cb=$(date +%s%N)" 2>/dev/null || printf '\n000')
-            last_status="${response##*$'\n'}"
-            body="${response%$'\n'*}"
+            for index in "${!probe_urls[@]}"; do
+              probe_url="${probe_urls[$index]}"
+              probe_label="${probe_labels[$index]}"
+              response=$(curl -sS -L \
+                --connect-timeout 5 \
+                --max-time 10 \
+                -A "$USER_AGENT" \
+                -H "Cache-Control: no-cache" \
+                "${BYPASS_ARGS[@]}" \
+                -w "\n%{http_code}" \
+                "${probe_url}?_cb=$(date +%s%N)" 2>/dev/null || printf '\n000')
+              last_status="${response##*$'\n'}"
+              body="${response%$'\n'*}"
 
-            if [ "$last_status" != "200" ]; then
-              echo "  attempt ${attempt}: build-info returned HTTP ${last_status}"
-              continue
-            fi
+              if [ "$last_status" != "200" ]; then
+                echo "  attempt ${attempt} ${probe_label}: build-info returned HTTP ${last_status}"
+                continue
+              fi
 
-            actual=$(printf '%s' "$body" | jq -r '.commitSha // ""' 2>/dev/null || echo "")
-            if [ -z "$actual" ]; then
-              echo "  attempt ${attempt}: build-info returned 200 without commitSha"
-              continue
-            fi
+              actual=$(printf '%s' "$body" | jq -r '.commitSha // ""' 2>/dev/null || echo "")
+              if [ -z "$actual" ]; then
+                echo "  attempt ${attempt} ${probe_label}: build-info returned 200 without commitSha"
+                continue
+              fi
 
-            echo "  attempt ${attempt}: build-info commitSha=${actual}"
-            saw_valid_probe=true
-            if [ "$actual" = "$expected" ]; then
-              echo "✅ Deployment ${deploy_url} serves ${expected} — promote succeeded."
-              echo "   Edge cache on jov.ie will catch up asynchronously (typically 1-3 min)."
-              exit 0
-            fi
-            confirmed_mismatch=true
+              echo "  attempt ${attempt} ${probe_label}: build-info commitSha=${actual}"
+              saw_valid_probe=true
+              if [ "$actual" = "$expected" ]; then
+                echo "✅ ${probe_label} serves ${expected} — promote succeeded."
+                exit 0
+              fi
+              confirmed_mismatch=true
+            done
           done
 
           if [ "$confirmed_mismatch" = "true" ]; then
-            echo "❌ Deployment ${deploy_url} returned commitSha='${actual:-<empty>}' but expected '${expected}'."
-            echo "   This is a data integrity problem: the Vercel API matched this deployment"
-            echo "   URL to GITHUB_SHA, but the deployment's runtime reports a different SHA."
+            echo "❌ Production verification returned commitSha='${actual:-<empty>}' but expected '${expected}'."
+            echo "   The promoted deployment or jov.ie alias is serving a different SHA."
             echo "failure_subtype=verify_mismatch" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
           if [ "$saw_valid_probe" != "true" ]; then
-            echo "❌ Deployment build-info probe failed across all attempts (last HTTP ${last_status})."
-            echo "   Cannot confirm whether the deployment itself is serving ${expected}."
+            echo "❌ Production build-info probes failed across all attempts (last HTTP ${last_status})."
+            echo "   Cannot confirm whether production is serving ${expected}."
             echo "failure_subtype=verify_probe_failed" >> "$GITHUB_OUTPUT"
             exit 1
           fi

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -98,6 +98,20 @@ describe('deploy workflow Vercel env resolution', () => {
       expect(deployStep).toContain(`${key}: \${{ secrets.${key} }}`);
     }
   });
+
+  it('verifies production promotion through the canonical public alias', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const promoteStep = getStepBlock(
+      workflow,
+      'Promote specific deployment for this SHA'
+    );
+
+    expect(promoteStep).toContain('"https://jov.ie/api/health/build-info"');
+    expect(promoteStep).toContain('probe_labels=(');
+    expect(promoteStep).toContain('"production-alias"');
+    expect(promoteStep).toContain('max_attempts=30');
+    expect(promoteStep).toContain('URLs can return 401');
+  });
 });
 
 describe('canary health gate workflow', () => {


### PR DESCRIPTION
## Summary
- verify promoted production deployments through both the Vercel deployment URL and the canonical jov.ie alias
- keep the deployment URL probe for unprotected deployments, but let protected deployment URLs fall back to the user-facing production surface
- add workflow test coverage for the alias verification path

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts
- pnpm biome check .github/workflows/ci.yml apps/web/tests/unit/ci/deploy-workflow.test.ts
- pnpm exec actionlint -shellcheck= .github/workflows/ci.yml
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

## Production evidence
- jov.ie /api/health returns 200 {"status":"ok"}
- jov.ie and www.jov.ie /api/health/build-info report commitSha 1e76efd
- staging.jov.ie /api/health reports 200 and build-info commitSha 1e76efd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved production deployment verification by probing multiple health endpoints with expanded retry attempts to ensure greater reliability during promotion.

* **Tests**
  * Added test coverage for production promotion workflow configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8972?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->