### PR TITLE
fix(shell): align feature flags with admin table

### DIFF
--- a/apps/web/app/app/(shell)/feature-flags/FeatureFlagsTable.tsx
+++ b/apps/web/app/app/(shell)/feature-flags/FeatureFlagsTable.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import type { ColumnDef } from '@tanstack/react-table';
+import { PAGE_TOOLBAR_META_TEXT_CLASS } from '@/components/organisms/table';
+import { AdminDataTable } from '@/features/admin/table/AdminDataTable';
+import { AdminTableSubheader } from '@/features/admin/table/AdminTableHeader';
+import { AdminTableShell } from '@/features/admin/table/AdminTableShell';
+import { cn } from '@/lib/utils';
+import type { FlagRow } from './page';
+
+interface FeatureFlagsTableProps {
+  readonly flags: FlagRow[];
+}
+
+function FeatureFlagStatePill({
+  enabled,
+}: Readonly<{ readonly enabled: boolean }>) {
+  return (
+    <span
+      className={cn(
+        'inline-flex h-5 items-center rounded-full border px-2 text-[11.5px] font-medium',
+        enabled
+          ? 'border-cyan-400/20 bg-cyan-500/12 text-cyan-300'
+          : 'border-subtle bg-surface-0 text-tertiary-token'
+      )}
+    >
+      {enabled ? 'On' : 'Off'}
+    </span>
+  );
+}
+
+const FEATURE_FLAG_COLUMNS: ColumnDef<FlagRow, unknown>[] = [
+  {
+    id: 'name',
+    accessorFn: row => row.name,
+    header: 'Flag',
+    cell: ({ getValue }) => (
+      <span className='font-caption text-primary-token'>
+        {String(getValue())}
+      </span>
+    ),
+    size: 220,
+    minSize: 160,
+  },
+  {
+    id: 'enabled',
+    accessorFn: row => row.enabled,
+    header: 'State',
+    cell: ({ getValue }) => (
+      <FeatureFlagStatePill enabled={getValue() === true} />
+    ),
+    size: 72,
+    minSize: 64,
+  },
+  {
+    id: 'defaultValue',
+    accessorFn: row => row.defaultValue,
+    header: 'Default',
+    cell: ({ getValue }) => (
+      <span className='font-caption text-tertiary-token'>
+        {getValue() === true ? 'On' : 'Off'}
+      </span>
+    ),
+    size: 72,
+    minSize: 64,
+  },
+];
+
+export function FeatureFlagsTable({ flags }: Readonly<FeatureFlagsTableProps>) {
+  const totalFlags = flags.length;
+
+  return (
+    <AdminTableShell
+      testId='feature-flags-table'
+      toolbar={
+        <AdminTableSubheader
+          start={
+            <p className={PAGE_TOOLBAR_META_TEXT_CLASS}>
+              Environment-driven flags and current state.
+            </p>
+          }
+          end={
+            <p className={PAGE_TOOLBAR_META_TEXT_CLASS}>
+              {totalFlags.toLocaleString()} flag{totalFlags === 1 ? '' : 's'}
+            </p>
+          }
+        />
+      }
+    >
+      {() => (
+        <AdminDataTable
+          data={flags}
+          columns={FEATURE_FLAG_COLUMNS}
+          getRowId={row => row.name}
+          enableVirtualization={false}
+          minWidth='100%'
+          containerClassName='flex-1'
+        />
+      )}
+    </AdminTableShell>
+  );
+}

--- a/apps/web/app/app/(shell)/feature-flags/page.tsx
+++ b/apps/web/app/app/(shell)/feature-flags/page.tsx
@@ -1,14 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
-import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
-import {
-  CONTENT_TABLE_CELL_CLASS,
-  CONTENT_TABLE_HEAD_CELL_CLASS,
-  CONTENT_TABLE_HEAD_ROW_CLASS,
-  CONTENT_TABLE_ROW_CLASS,
-  ContentTable,
-} from '@/components/molecules/ContentTable';
 import { APP_ROUTES } from '@/constants/routes';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 import {
@@ -16,6 +8,7 @@ import {
   type FeatureFlag,
   isEnabled,
 } from '@/lib/feature-flags';
+import { FeatureFlagsTable } from './FeatureFlagsTable';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -25,26 +18,10 @@ export const metadata: Metadata = {
   description: 'Environment-driven feature flags and current state.',
 };
 
-interface FlagRow {
+export interface FlagRow {
   readonly name: FeatureFlag;
   readonly enabled: boolean;
   readonly defaultValue: boolean;
-}
-
-function FeatureFlagStatePill({
-  enabled,
-}: Readonly<{ readonly enabled: boolean }>) {
-  return (
-    <span
-      className={
-        enabled
-          ? 'inline-flex items-center rounded-full border border-cyan-400/20 bg-cyan-500/12 px-2 py-0.5 text-[11.5px] font-medium text-cyan-300'
-          : 'inline-flex items-center rounded-full border border-subtle bg-surface-0 px-2 py-0.5 text-[11.5px] font-medium text-tertiary-token'
-      }
-    >
-      {enabled ? 'On' : 'Off'}
-    </span>
-  );
 }
 
 export default async function FeatureFlagsPage() {
@@ -66,41 +43,8 @@ export default async function FeatureFlagsPage() {
   }));
 
   return (
-    <AdminToolPage
-      title='Feature Flags'
-      description='Environment-driven flags and current state.'
-      testId='feature-flags-page'
-    >
-      <ContentSurfaceCard surface='table' className='overflow-hidden'>
-        <ContentTable wrapperClassName='px-0 py-0' className='text-[12.5px]'>
-          <thead>
-            <tr className={CONTENT_TABLE_HEAD_ROW_CLASS}>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Flag</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>State</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Default</th>
-            </tr>
-          </thead>
-          <tbody>
-            {flags.map(flag => (
-              <tr key={flag.name} className={CONTENT_TABLE_ROW_CLASS}>
-                <td className={CONTENT_TABLE_CELL_CLASS}>
-                  <div className='font-medium text-primary-token'>
-                    {flag.name}
-                  </div>
-                </td>
-                <td className={CONTENT_TABLE_CELL_CLASS}>
-                  <FeatureFlagStatePill enabled={flag.enabled} />
-                </td>
-                <td className={CONTENT_TABLE_CELL_CLASS}>
-                  <span className='text-tertiary-token'>
-                    {flag.defaultValue ? 'On' : 'Off'}
-                  </span>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </ContentTable>
-      </ContentSurfaceCard>
+    <AdminToolPage testId='feature-flags-page'>
+      <FeatureFlagsTable flags={[...flags]} />
     </AdminToolPage>
   );
 }

--- a/apps/web/tests/unit/app/feature-flags-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/feature-flags-shell-normalization.test.ts
@@ -16,6 +16,13 @@ const FEATURE_FLAGS_PAGE = findSourceFile(
   resolve(process.cwd(), 'app/app/(shell)/feature-flags/page.tsx'),
   resolve(process.cwd(), 'apps/web/app/app/(shell)/feature-flags/page.tsx')
 );
+const FEATURE_FLAGS_TABLE = findSourceFile(
+  resolve(process.cwd(), 'app/app/(shell)/feature-flags/FeatureFlagsTable.tsx'),
+  resolve(
+    process.cwd(),
+    'apps/web/app/app/(shell)/feature-flags/FeatureFlagsTable.tsx'
+  )
+);
 
 describe('feature flags shell normalization', () => {
   it('keeps feature flags in the shared admin tool shell', () => {
@@ -23,16 +30,22 @@ describe('feature flags shell normalization', () => {
 
     expect(source).toContain('AdminToolPage');
     expect(source).toContain("testId='feature-flags-page'");
-    expect(source).toContain('ContentSurfaceCard');
+    expect(source).not.toContain('title=');
+    expect(source).not.toContain('description=');
   });
 
-  it('uses shared content table primitives instead of bespoke table chrome', () => {
-    const source = readFileSync(FEATURE_FLAGS_PAGE, 'utf8');
+  it('uses shared admin table primitives instead of bespoke table chrome', () => {
+    const pageSource = readFileSync(FEATURE_FLAGS_PAGE, 'utf8');
+    const tableSource = readFileSync(FEATURE_FLAGS_TABLE, 'utf8');
 
-    expect(source).toContain('ContentTable');
-    expect(source).toContain('CONTENT_TABLE_HEAD_CELL_CLASS');
-    expect(source).toContain('CONTENT_TABLE_ROW_CLASS');
-    expect(source).not.toContain('max-w-3xl');
-    expect(source).not.toContain("className='w-full text-sm'");
+    expect(pageSource).toContain('FeatureFlagsTable');
+    expect(tableSource).toContain('AdminTableShell');
+    expect(tableSource).toContain('AdminTableSubheader');
+    expect(tableSource).toContain('AdminDataTable');
+    expect(pageSource).not.toContain('ContentTable');
+    expect(pageSource).not.toContain('ContentSurfaceCard');
+    expect(pageSource).not.toContain('CONTENT_TABLE_HEAD_CELL_CLASS');
+    expect(pageSource).not.toContain('CONTENT_TABLE_ROW_CLASS');
+    expect(tableSource).not.toMatch(/<table\b/);
   });
 });


### PR DESCRIPTION
## Summary
- moves /app/feature-flags onto the shared AdminTableShell/AdminDataTable path
- removes bespoke ContentTable chrome from the route page
- keeps the compact feature flag table responsive on phone widths

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/app/feature-flags-shell-normalization.test.ts tests/unit/app/surface-elevation-guardrails.test.ts tests/unit/components/admin/AdminDataTable.test.tsx --config=vitest.config.mts
- pnpm exec biome check 'apps/web/app/app/(shell)/feature-flags' apps/web/tests/unit/app/feature-flags-shell-normalization.test.ts\n- pnpm --filter @jovie/web run typecheck -- --pretty false\n- browser smoke via dev auth at 1440x1000, 900x1180, 390x844; no horizontal document overflow, no console errors\n- pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, lint