### PR TITLE
fix(shell): use essential data for tour actions

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/tour-dates/actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/tour-dates/actions.ts
@@ -32,7 +32,7 @@ import type { TicketStatus, TourDateViewModel } from '@/lib/tour-dates/types';
 import { mapTourDateToViewModel } from '@/lib/tour-dates/view-model';
 import { toISOStringOrNull } from '@/lib/utils/date';
 import { decryptPII, encryptPII } from '@/lib/utils/pii-encryption';
-import { getDashboardData } from '../actions';
+import { getDashboardDataEssential } from '../actions';
 
 // ============================================================================
 // Types
@@ -55,7 +55,7 @@ async function requireProfile(): Promise<{
   bandsintownApiKey: string | null;
   handle: string;
 }> {
-  const data = await getDashboardData();
+  const data = await getDashboardDataEssential();
 
   if (data.needsOnboarding && !data.dashboardLoadError) {
     redirect(APP_ROUTES.START);
@@ -66,7 +66,7 @@ async function requireProfile(): Promise<{
     redirect(APP_ROUTES.START);
   }
 
-  // Use bandsintown fields directly from selectedProfile (already fetched by getDashboardData)
+  // Use bandsintown fields directly from selectedProfile (already fetched by the essential dashboard path)
   return {
     id: data.selectedProfile.id,
     bandsintownArtistName: data.selectedProfile.bandsintownArtistName,

--- a/apps/web/app/app/(shell)/dashboard/tour-dates/events-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/tour-dates/events-actions.ts
@@ -6,7 +6,7 @@ import { getCachedAuth } from '@/lib/auth/cached';
 import { db } from '@/lib/db';
 import { tourDates } from '@/lib/db/schema/tour';
 import { trackServerEvent } from '@/lib/server-analytics';
-import { getDashboardData } from '../actions';
+import { getDashboardDataEssential } from '../actions';
 
 /**
  * Trust-gate server actions for events. Confirm, reject, and undo-reject —
@@ -47,7 +47,7 @@ async function requireAuthedProfile(): Promise<AuthedProfile | null> {
   if (!userId) {
     return null;
   }
-  const data = await getDashboardData();
+  const data = await getDashboardDataEssential();
   if (data.needsOnboarding && !data.dashboardLoadError) {
     return null;
   }

--- a/apps/web/tests/unit/actions/tour-dates-actions.test.ts
+++ b/apps/web/tests/unit/actions/tour-dates-actions.test.ts
@@ -6,7 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   mockGetCachedAuth,
-  mockGetDashboardData,
+  mockGetDashboardDataEssential,
   mockDbSelect,
   mockDbInsert,
   mockDbUpdate,
@@ -24,7 +24,7 @@ const {
   mockRedirect,
 } = vi.hoisted(() => ({
   mockGetCachedAuth: vi.fn(),
-  mockGetDashboardData: vi.fn(),
+  mockGetDashboardDataEssential: vi.fn(),
   mockDbSelect: vi.fn(),
   mockDbInsert: vi.fn(),
   mockDbUpdate: vi.fn(),
@@ -50,10 +50,10 @@ vi.mock('@/lib/auth/cached', () => ({
   getCachedAuth: mockGetCachedAuth,
 }));
 
-// The source file imports getDashboardData from '../actions' which resolves to
-// the dashboard actions barrel. We mock the entire barrel re-export here.
+// The source file imports getDashboardDataEssential from '../actions' which
+// resolves to the dashboard actions barrel. We mock the barrel re-export here.
 vi.mock('@/app/app/(shell)/dashboard/actions', () => ({
-  getDashboardData: mockGetDashboardData,
+  getDashboardDataEssential: mockGetDashboardDataEssential,
 }));
 
 vi.mock('@/lib/db', () => ({
@@ -146,7 +146,7 @@ vi.mock('drizzle-orm', () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Default authenticated profile returned by getDashboardData */
+/** Default authenticated profile returned by getDashboardDataEssential */
 const DEFAULT_PROFILE = {
   id: 'prof_123',
   username: 'testartist',
@@ -159,7 +159,7 @@ function setupAuthenticatedUser(
   overrides: Partial<typeof DEFAULT_PROFILE> = {}
 ) {
   mockGetCachedAuth.mockResolvedValue({ userId: 'user_123' });
-  mockGetDashboardData.mockResolvedValue({
+  mockGetDashboardDataEssential.mockResolvedValue({
     needsOnboarding: false,
     selectedProfile: { ...DEFAULT_PROFILE, ...overrides },
   });

--- a/apps/web/tests/unit/actions/tour-dates-events-actions.test.ts
+++ b/apps/web/tests/unit/actions/tour-dates-events-actions.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   mockGetCachedAuth,
-  mockGetDashboardData,
+  mockGetDashboardDataEssential,
   mockDbUpdate,
   mockDbSelect,
   mockSelectFrom,
@@ -15,7 +15,7 @@ const {
   mockEq,
 } = vi.hoisted(() => ({
   mockGetCachedAuth: vi.fn(),
-  mockGetDashboardData: vi.fn(),
+  mockGetDashboardDataEssential: vi.fn(),
   mockDbUpdate: vi.fn(),
   mockDbSelect: vi.fn(),
   mockSelectFrom: vi.fn(),
@@ -33,7 +33,7 @@ vi.mock('@/lib/auth/cached', () => ({
 }));
 
 vi.mock('@/app/app/(shell)/dashboard/actions', () => ({
-  getDashboardData: mockGetDashboardData,
+  getDashboardDataEssential: mockGetDashboardDataEssential,
 }));
 
 vi.mock('@/lib/db', () => ({
@@ -71,7 +71,7 @@ const OTHER_EVENT_ID = '550e8400-e29b-41d4-a716-446655440001';
 
 function setupAuthenticatedUser() {
   mockGetCachedAuth.mockResolvedValue({ userId: 'user_123' });
-  mockGetDashboardData.mockResolvedValue({
+  mockGetDashboardDataEssential.mockResolvedValue({
     dashboardLoadError: null,
     needsOnboarding: false,
     selectedProfile: { id: 'prof_123' },


### PR DESCRIPTION
## Summary
- moves tour-date profile resolution to getDashboardDataEssential()
- keeps event moderation ownership checks on the same selected-profile contract
- updates unit mocks so these actions cannot drift back to the full dashboard loader silently

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/actions/tour-dates-actions.test.ts tests/unit/actions/tour-dates-events-actions.test.ts --config=vitest.config.mts
- pnpm exec biome check 'apps/web/app/app/(shell)/dashboard/tour-dates/actions.ts' 'apps/web/app/app/(shell)/dashboard/tour-dates/events-actions.ts' apps/web/tests/unit/actions/tour-dates-actions.test.ts apps/web/tests/unit/actions/tour-dates-events-actions.test.ts\n- pnpm --filter @jovie/web run typecheck -- --pretty false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal dashboard data fetching mechanism for tour dates management.
  * Updated unit tests to align with optimized data retrieval process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->