### PR TITLE
fix(shell): converge admin tables on wrapper

### DIFF
--- a/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
+++ b/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
@@ -24,7 +24,8 @@ import {
 } from 'react';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
-import { TableEmptyState, UnifiedTable } from '@/components/organisms/table';
+import { TableEmptyState } from '@/components/organisms/table';
+import { AdminDataTable } from '@/features/admin/table/AdminDataTable';
 import type { AgentRunArtifact, AgentRunStatus } from '@/lib/agent-os/artifact';
 import { cn } from '@/lib/utils';
 import { ApprovalQueuePanel } from './ApprovalQueuePanel';
@@ -555,7 +556,7 @@ export function AgentOsRunsPanel({
             />
           ) : (
             <div className='min-w-0 rounded-lg border border-subtle bg-(--linear-app-content-surface)'>
-              <UnifiedTable
+              <AdminDataTable
                 data={rows}
                 columns={columns}
                 isLoading={false}
@@ -578,7 +579,6 @@ export function AgentOsRunsPanel({
                 getRowTestId={artifact => `agent-os-run-${artifact.id}`}
                 enableVirtualization={false}
                 minWidth='700px'
-                className='text-[12.5px] [&_thead_th]:py-1 [&_thead_th]:text-3xs [&_thead_th]:tracking-[0.07em]'
                 containerClassName='max-h-[460px]'
               />
             </div>

--- a/apps/web/components/features/admin/leads/LeadTable.tsx
+++ b/apps/web/components/features/admin/leads/LeadTable.tsx
@@ -12,9 +12,9 @@ import {
   PageToolbar,
   PageToolbarTabButton,
   TableEmptyState,
-  UnifiedTable,
 } from '@/components/organisms/table';
 import { APP_ROUTES } from '@/constants/routes';
+import { AdminDataTable } from '@/features/admin/table/AdminDataTable';
 import { useSearchUrlSync } from '@/hooks/useSearchUrlSync';
 import {
   type AdminLead,
@@ -379,7 +379,7 @@ export function LeadTable({
           Unable to refresh leads. Showing cached data.
         </div>
       )}
-      <UnifiedTable
+      <AdminDataTable
         data={leads}
         columns={columns as ColumnDef<AdminLead, unknown>[]}
         isLoading={isLoading}

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -315,10 +315,12 @@ describe('surface elevation guardrails', () => {
   it('keeps admin shell tables on the canonical AdminDataTable wrapper', () => {
     const files = [
       'components/features/admin/ActivityTableUnified.tsx',
+      'components/features/admin/agent-os/AgentOsRunsPanel.tsx',
       'components/features/admin/admin-creator-profiles/AdminCreatorProfilesUnified.tsx',
       'components/features/admin/admin-releases-table/AdminReleasesTableUnified.tsx',
       'components/features/admin/admin-users-table/AdminUsersTableUnified.tsx',
       'components/features/admin/feedback-table/AdminFeedbackTable.tsx',
+      'components/features/admin/leads/LeadTable.tsx',
       'components/features/admin/waitlist-table/AdminWaitlistTableUnified.tsx',
     ] as const;
 


### PR DESCRIPTION
## Summary
- routes LeadTable through AdminDataTable instead of direct UnifiedTable
- routes AgentOS table mode through AdminDataTable and removes bespoke header tracking override
- expands the admin table guardrail so these surfaces stay on the canonical wrapper

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/app/surface-elevation-guardrails.test.ts tests/unit/admin/LeadTable.test.tsx tests/unit/components/admin/AgentOsRunsPanel.test.tsx tests/unit/components/admin/AdminDataTable.test.tsx --config=vitest.config.mts
- pnpm exec biome check apps/web/components/features/admin/leads/LeadTable.tsx apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false