### PR TITLE
fix(shell): use essential data for presence actions

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/presence/actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/presence/actions.ts
@@ -14,7 +14,7 @@ import { creatorProfiles } from '@/lib/db/schema/profiles';
 import type { DspMatchStatus, DspProviderId } from '@/lib/dsp-enrichment/types';
 import { PROVIDER_DOMAINS } from '@/lib/dsp-registry';
 import { captureError } from '@/lib/error-tracking';
-import { getDashboardData } from '../actions';
+import { getDashboardDataEssential } from '../actions';
 
 // ============================================================================
 // Types
@@ -142,7 +142,7 @@ export async function loadDspPresenceForProfile(
 }
 
 export async function loadDspPresence(): Promise<DspPresenceData> {
-  const data = await getDashboardData();
+  const data = await getDashboardDataEssential();
 
   if (data.needsOnboarding && !data.dashboardLoadError) {
     redirect(APP_ROUTES.START);
@@ -189,7 +189,7 @@ export async function addManualDspMatch(input: {
   url: string;
   artistName: string;
 }): Promise<{ success: boolean; error?: string }> {
-  const data = await getDashboardData();
+  const data = await getDashboardDataEssential();
 
   if (data.needsOnboarding && !data.dashboardLoadError) {
     redirect(APP_ROUTES.START);

--- a/apps/web/tests/unit/dashboard/presence-actions.test.ts
+++ b/apps/web/tests/unit/dashboard/presence-actions.test.ts
@@ -5,10 +5,12 @@ import {
 } from '@/app/app/(shell)/dashboard/presence/actions';
 import type { DspMatchConfidenceBreakdown } from '@/lib/db/schema/dsp-enrichment';
 
-const { dashboardQueryMock, getDashboardDataMock } = vi.hoisted(() => ({
-  dashboardQueryMock: vi.fn(),
-  getDashboardDataMock: vi.fn(),
-}));
+const { dashboardQueryMock, getDashboardDataEssentialMock } = vi.hoisted(
+  () => ({
+    dashboardQueryMock: vi.fn(),
+    getDashboardDataEssentialMock: vi.fn(),
+  })
+);
 
 vi.mock('@/lib/auth/session', () => ({
   getSessionContext: vi.fn().mockResolvedValue({
@@ -44,7 +46,7 @@ vi.mock('@/lib/db/query-timeout', () => ({
 }));
 
 vi.mock('@/app/app/(shell)/dashboard/actions', () => ({
-  getDashboardData: getDashboardDataMock,
+  getDashboardDataEssential: getDashboardDataEssentialMock,
 }));
 
 const confidenceBreakdown: DspMatchConfidenceBreakdown = {
@@ -146,7 +148,7 @@ describe('presence actions', () => {
   });
 
   it('loads presence for the selected dashboard profile', async () => {
-    getDashboardDataMock.mockResolvedValueOnce({
+    getDashboardDataEssentialMock.mockResolvedValueOnce({
       needsOnboarding: false,
       selectedProfile: {
         id: 'profile-789',


### PR DESCRIPTION
## Summary
- moves DSP presence selected-profile reads to getDashboardDataEssential()
- keeps manual DSP matching and presence loading on the same onboarding/profile contract
- updates the presence action mock to lock the fast path in tests

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/presence-actions.test.ts tests/unit/dashboard/DspPresenceView.test.tsx tests/unit/dashboard/AddPlatformDialog.test.tsx --config=vitest.config.mts
- pnpm exec biome check 'apps/web/app/app/(shell)/dashboard/presence/actions.ts' apps/web/tests/unit/dashboard/presence-actions.test.ts\n- pnpm --filter @jovie/web run typecheck -- --pretty false