### PR TITLE
fix(shell): use essential data for release actions

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/actions.ts
@@ -86,7 +86,7 @@ import { slugify } from '@/lib/utils';
 import { toISOStringOrNull } from '@/lib/utils/date';
 import { throwIfRedirect } from '@/lib/utils/redirect-error';
 import { targetPlaylistsSchema } from '@/lib/validation/schemas/dashboard/profile';
-import { getDashboardData, getDashboardShellData } from '../actions';
+import { getDashboardDataEssential, getDashboardShellData } from '../actions';
 
 const SPOTIFY_ALREADY_CLAIMED_MESSAGE =
   'This Spotify artist is already linked to another Jovie account. Please sign in with the original account or choose a different artist.';
@@ -190,7 +190,7 @@ async function requireProfile(profileId?: string): Promise<{
   spotifyId: string | null;
   handle: string;
 }> {
-  const data = await getDashboardData();
+  const data = await getDashboardDataEssential();
 
   if (data.needsOnboarding && !data.dashboardLoadError) {
     redirect(APP_ROUTES.START);
@@ -1242,7 +1242,7 @@ export async function checkSpotifyConnection(): Promise<{
   }
 
   try {
-    const data = await getDashboardData();
+    const data = await getDashboardDataEssential();
 
     if (data.needsOnboarding || !data.selectedProfile) {
       return { connected: false, spotifyId: null, artistName: null };

--- a/apps/web/tests/unit/actions/releases-actions.create.nightly.test.ts
+++ b/apps/web/tests/unit/actions/releases-actions.create.nightly.test.ts
@@ -52,7 +52,7 @@ vi.mock('@/lib/auth/cached', () => ({
 }));
 
 vi.mock('@/app/app/(shell)/dashboard/actions', () => ({
-  getDashboardData: mockGetDashboardData,
+  getDashboardDataEssential: mockGetDashboardData,
 }));
 
 vi.mock('next/cache', () => ({
@@ -152,7 +152,11 @@ vi.mock('@/lib/utils/redirect-error', () => ({
 }));
 
 vi.mock('@/constants/routes', () => ({
-  APP_ROUTES: { RELEASES: '/dashboard/releases', SIGNIN: '/signin' },
+  APP_ROUTES: {
+    RELEASES: '/dashboard/releases',
+    SIGNIN: '/signin',
+    START: '/start',
+  },
 }));
 
 vi.mock('@/lib/env-public', () => ({

--- a/apps/web/tests/unit/actions/releases-actions.publish.nightly.test.ts
+++ b/apps/web/tests/unit/actions/releases-actions.publish.nightly.test.ts
@@ -58,7 +58,7 @@ vi.mock('@/lib/auth/cached', () => ({
 }));
 
 vi.mock('@/app/app/(shell)/dashboard/actions', () => ({
-  getDashboardData: mockGetDashboardData,
+  getDashboardDataEssential: mockGetDashboardData,
   getDashboardShellData: mockGetDashboardShellData,
 }));
 
@@ -197,7 +197,7 @@ vi.mock('@/lib/utils/redirect-error', () => ({
 }));
 
 vi.mock('@/constants/routes', () => ({
-  APP_ROUTES: { RELEASES: '/dashboard/releases' },
+  APP_ROUTES: { RELEASES: '/dashboard/releases', START: '/start' },
 }));
 
 vi.mock('@/lib/env-public', () => ({

--- a/apps/web/tests/unit/actions/releases-actions.update.nightly.test.ts
+++ b/apps/web/tests/unit/actions/releases-actions.update.nightly.test.ts
@@ -58,7 +58,7 @@ vi.mock('@/lib/auth/cached', () => ({
 }));
 
 vi.mock('@/app/app/(shell)/dashboard/actions', () => ({
-  getDashboardData: mockGetDashboardData,
+  getDashboardDataEssential: mockGetDashboardData,
 }));
 
 vi.mock('next/cache', () => ({
@@ -191,7 +191,7 @@ vi.mock('@/lib/utils/redirect-error', () => ({
 }));
 
 vi.mock('@/constants/routes', () => ({
-  APP_ROUTES: { RELEASES: '/dashboard/releases' },
+  APP_ROUTES: { RELEASES: '/dashboard/releases', START: '/start' },
 }));
 
 vi.mock('@/lib/env-public', () => ({


### PR DESCRIPTION
## Summary
- moves release action profile resolution to getDashboardDataEssential()
- keeps release matrix and Spotify connection checks on selected profile + creator profile contracts
- updates release action mocks for the essential dashboard path and START route redirect

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/actions/releases-actions.create.nightly.test.ts tests/unit/actions/releases-actions.update.nightly.test.ts tests/unit/actions/releases-actions.publish.nightly.test.ts --config=vitest.config.ci.mts
- pnpm exec biome check 'apps/web/app/app/(shell)/dashboard/releases/actions.ts' apps/web/tests/unit/actions/releases-actions.create.nightly.test.ts apps/web/tests/unit/actions/releases-actions.update.nightly.test.ts apps/web/tests/unit/actions/releases-actions.publish.nightly.test.ts\n- pnpm --filter @jovie/web run typecheck -- --pretty false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dashboard data loading to use optimized data fetching logic.
  * Updated test infrastructure to align with new data loading implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->