### PR TITLE
fix(shell): use essential data for settings profile

### DIFF
--- a/apps/web/app/app/(shell)/settings/artist-profile/page.tsx
+++ b/apps/web/app/app/(shell)/settings/artist-profile/page.tsx
@@ -1,7 +1,7 @@
 import { PreviewDataHydrator } from '@/features/dashboard/organisms/PreviewDataHydrator';
 import { getCanonicalProfileDSPs } from '@/lib/profile-dsps';
 import {
-  getDashboardData,
+  getDashboardDataEssential,
   getProfileSocialLinks,
 } from '../../dashboard/actions';
 import { ProfilePreviewOpener } from '../../dashboard/profile/ProfilePreviewOpener';
@@ -10,7 +10,7 @@ import { ArtistProfileContent } from './ArtistProfileContent';
 export const runtime = 'nodejs';
 
 export default async function SettingsArtistProfilePage() {
-  const dashboardData = await getDashboardData();
+  const dashboardData = await getDashboardDataEssential();
   const profileId = dashboardData.selectedProfile?.id;
   const initialLinks = profileId
     ? await getProfileSocialLinks(profileId).catch(() => [])

--- a/apps/web/tests/unit/app/settings-page.test.tsx
+++ b/apps/web/tests/unit/app/settings-page.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
 
@@ -18,5 +20,18 @@ describe('settings page aliases', () => {
     SettingsPage();
 
     expect(redirectMock).toHaveBeenCalledWith(APP_ROUTES.SETTINGS_ACCOUNT);
+  });
+
+  it('keeps artist profile settings on the essential dashboard data path', () => {
+    const source = readFileSync(
+      resolve(
+        process.cwd(),
+        'app/app/(shell)/settings/artist-profile/page.tsx'
+      ),
+      'utf8'
+    );
+
+    expect(source).toContain('getDashboardDataEssential');
+    expect(source).not.toMatch(/\bgetDashboardData\(/);
   });
 });


### PR DESCRIPTION
## Summary
- moves /app/settings/artist-profile to getDashboardDataEssential()
- keeps social-link hydration unchanged for preview/profile DSP state
- adds a settings route guard so this page does not drift back to the full dashboard loader

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/app/settings-page.test.tsx tests/unit/app/settings-scroll-mode.test.ts tests/unit/app/internal-shell-surface-guard.test.ts --config=vitest.config.mts
- pnpm exec biome check 'apps/web/app/app/(shell)/settings/artist-profile/page.tsx' apps/web/tests/unit/app/settings-page.test.tsx\n- pnpm --filter @jovie/web run typecheck -- --pretty false