### PR TITLE
fix(shell): align outreach tables with admin table

### DIFF
--- a/apps/web/components/features/admin/outreach/EmailQueuePanel.tsx
+++ b/apps/web/components/features/admin/outreach/EmailQueuePanel.tsx
@@ -1,18 +1,12 @@
 'use client';
 
 import { Button, Input, Switch } from '@jovie/ui';
+import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { useCallback, useEffect, useState } from 'react';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
-import {
-  CONTENT_TABLE_CELL_CLASS,
-  CONTENT_TABLE_FOOTER_CLASS,
-  CONTENT_TABLE_HEAD_CELL_CLASS,
-  CONTENT_TABLE_HEAD_ROW_CLASS,
-  CONTENT_TABLE_ROW_CLASS,
-  ContentTable,
-  ContentTableStateRow,
-} from '@/components/molecules/ContentTable';
+import { TableEmptyState } from '@/components/organisms/table';
+import { AdminDataTable } from '@/features/admin/table/AdminDataTable';
 import { AdminTablePagination } from '@/features/admin/table/AdminTablePagination';
 import { cn } from '@/lib/utils';
 import { OutreachStatusBadge } from './OutreachStatusBadge';
@@ -46,6 +40,57 @@ interface QueueOutreachResponse {
 interface QueueOutreachErrorResponse {
   error?: string;
 }
+
+const emailQueueColumnHelper = createColumnHelper<EmailQueueLead>();
+
+function formatQueuedAt(value: string | null): string {
+  return value ? new Date(value).toLocaleString() : 'Not queued';
+}
+
+const EMAIL_QUEUE_COLUMNS: ColumnDef<EmailQueueLead, unknown>[] = [
+  emailQueueColumnHelper.accessor('displayName', {
+    header: 'Name',
+    cell: ({ getValue }) => (
+      <span className='font-semibold text-primary-token'>
+        {getValue() || 'Unknown creator'}
+      </span>
+    ),
+    size: 180,
+  }) as ColumnDef<EmailQueueLead, unknown>,
+  emailQueueColumnHelper.accessor('priorityScore', {
+    header: 'Priority',
+    cell: ({ getValue }) => (
+      <span className='tabular-nums'>{getValue() ?? '-'}</span>
+    ),
+    size: 92,
+  }) as ColumnDef<EmailQueueLead, unknown>,
+  emailQueueColumnHelper.accessor('fitScore', {
+    header: 'Fit',
+    cell: ({ getValue }) => (
+      <span className='tabular-nums'>{getValue() ?? '-'}</span>
+    ),
+    size: 72,
+  }) as ColumnDef<EmailQueueLead, unknown>,
+  emailQueueColumnHelper.accessor('contactEmail', {
+    header: 'Email',
+    cell: ({ getValue }) => (
+      <span className='text-secondary-token'>{getValue() || '-'}</span>
+    ),
+    size: 220,
+  }) as ColumnDef<EmailQueueLead, unknown>,
+  emailQueueColumnHelper.accessor('outreachQueuedAt', {
+    header: 'Queued',
+    cell: ({ getValue }) => (
+      <span className='text-secondary-token'>{formatQueuedAt(getValue())}</span>
+    ),
+    size: 190,
+  }) as ColumnDef<EmailQueueLead, unknown>,
+  emailQueueColumnHelper.accessor('outreachStatus', {
+    header: 'Status',
+    cell: ({ getValue }) => <OutreachStatusBadge status={getValue()} />,
+    size: 120,
+  }) as ColumnDef<EmailQueueLead, unknown>,
+];
 
 export function EmailQueuePanel() {
   const [leads, setLeads] = useState<EmailQueueLead[]>([]);
@@ -248,64 +293,27 @@ export function EmailQueuePanel() {
           </div>
         )}
 
-        <ContentTable>
-          <thead>
-            <tr className={CONTENT_TABLE_HEAD_ROW_CLASS}>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Name</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Priority</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Fit</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Email</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Queued</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading || leads.length === 0 ? (
-              <ContentTableStateRow
-                colSpan={6}
-                isLoading={loading}
-                emptyMessage={
-                  loadError ?? 'No leads are queued for email right now.'
-                }
-                loadingLabel='Loading email queue'
-              />
-            ) : (
-              leads.map(lead => (
-                <tr key={lead.id} className={CONTENT_TABLE_ROW_CLASS}>
-                  <td className={CONTENT_TABLE_CELL_CLASS}>
-                    <span className='font-semibold text-primary-token'>
-                      {lead.displayName || 'Unknown creator'}
-                    </span>
-                  </td>
-                  <td className={cn(CONTENT_TABLE_CELL_CLASS, 'tabular-nums')}>
-                    {lead.priorityScore ?? '-'}
-                  </td>
-                  <td className={cn(CONTENT_TABLE_CELL_CLASS, 'tabular-nums')}>
-                    {lead.fitScore ?? '-'}
-                  </td>
-                  <td className={CONTENT_TABLE_CELL_CLASS}>
-                    <span className='text-secondary-token'>
-                      {lead.contactEmail || '-'}
-                    </span>
-                  </td>
-                  <td className={CONTENT_TABLE_CELL_CLASS}>
-                    <span className='text-secondary-token'>
-                      {lead.outreachQueuedAt
-                        ? new Date(lead.outreachQueuedAt).toLocaleString()
-                        : 'Not queued'}
-                    </span>
-                  </td>
-                  <td className={CONTENT_TABLE_CELL_CLASS}>
-                    <OutreachStatusBadge status={lead.outreachStatus} />
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </ContentTable>
+        <AdminDataTable
+          data={leads}
+          columns={EMAIL_QUEUE_COLUMNS}
+          isLoading={loading}
+          getRowId={lead => lead.id}
+          enableVirtualization={false}
+          minWidth='720px'
+          emptyState={
+            <TableEmptyState
+              title={
+                loadError ? 'Unable to load email queue' : 'No email leads'
+              }
+              description={
+                loadError ?? 'No leads are queued for email right now.'
+              }
+            />
+          }
+        />
 
         {totalPages > 1 && (
-          <div className={CONTENT_TABLE_FOOTER_CLASS}>
+          <div className='border-t border-subtle px-(--linear-app-content-padding-x) py-2'>
             <AdminTablePagination
               page={page}
               totalPages={totalPages}

--- a/apps/web/components/features/admin/outreach/ReviewQueuePanel.tsx
+++ b/apps/web/components/features/admin/outreach/ReviewQueuePanel.tsx
@@ -1,24 +1,17 @@
 'use client';
 
 import { Badge } from '@jovie/ui';
+import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { ExternalLink } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { LoadingSpinner } from '@/components/atoms/LoadingSpinner';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
-import {
-  CONTENT_TABLE_CELL_CLASS,
-  CONTENT_TABLE_FOOTER_CLASS,
-  CONTENT_TABLE_HEAD_CELL_CLASS,
-  CONTENT_TABLE_HEAD_ROW_CLASS,
-  CONTENT_TABLE_ROW_CLASS,
-  ContentTable,
-  ContentTableStateRow,
-} from '@/components/molecules/ContentTable';
 import { DrawerButton } from '@/components/molecules/drawer';
+import { TableEmptyState } from '@/components/organisms/table';
+import { AdminDataTable } from '@/features/admin/table/AdminDataTable';
 import { AdminTablePagination } from '@/features/admin/table/AdminTablePagination';
-import { cn } from '@/lib/utils';
 
 interface ReviewLead {
   id: string;
@@ -50,6 +43,8 @@ const SIGNAL_CONFIG: Record<
   emailInvalid: { label: 'Invalid Email', variant: 'error' },
   hasRepresentation: { label: 'Has Representation', variant: 'primary' },
 };
+
+const reviewQueueColumnHelper = createColumnHelper<ReviewLead>();
 
 export function ReviewQueuePanel() {
   const [leads, setLeads] = useState<ReviewLead[]>([]);
@@ -93,23 +88,124 @@ export function ReviewQueuePanel() {
     fetchQueue();
   }, [fetchQueue]);
 
-  async function handleSkip(id: string) {
-    setSkippingId(id);
-    try {
-      const res = await fetch(`/api/admin/leads/${id}/skip`, {
-        method: 'PATCH',
-      });
-      if (!res.ok) {
-        throw new Error('Failed to skip lead');
+  const handleSkip = useCallback(
+    async (id: string) => {
+      setSkippingId(id);
+      try {
+        const res = await fetch(`/api/admin/leads/${id}/skip`, {
+          method: 'PATCH',
+        });
+        if (!res.ok) {
+          throw new Error('Failed to skip lead');
+        }
+        toast.success('Lead skipped');
+        await fetchQueue();
+      } catch {
+        toast.error('Failed to skip lead');
+      } finally {
+        setSkippingId(null);
       }
-      toast.success('Lead skipped');
-      await fetchQueue();
-    } catch {
-      toast.error('Failed to skip lead');
-    } finally {
-      setSkippingId(null);
-    }
-  }
+    },
+    [fetchQueue]
+  );
+
+  const columns = useMemo<ColumnDef<ReviewLead, unknown>[]>(
+    () => [
+      reviewQueueColumnHelper.accessor('displayName', {
+        header: 'Name',
+        cell: ({ getValue }) => (
+          <span className='font-semibold text-primary-token'>
+            {getValue() || '-'}
+          </span>
+        ),
+        size: 180,
+      }) as ColumnDef<ReviewLead, unknown>,
+      reviewQueueColumnHelper.accessor('priorityScore', {
+        header: 'Priority',
+        cell: ({ getValue }) => (
+          <span className='tabular-nums'>{getValue() ?? '-'}</span>
+        ),
+        size: 92,
+      }) as ColumnDef<ReviewLead, unknown>,
+      reviewQueueColumnHelper.accessor('fitScore', {
+        header: 'Fit score',
+        cell: ({ getValue }) => (
+          <span className='tabular-nums'>{getValue() ?? '-'}</span>
+        ),
+        size: 92,
+      }) as ColumnDef<ReviewLead, unknown>,
+      reviewQueueColumnHelper.accessor('contactEmail', {
+        header: 'Email',
+        cell: ({ getValue }) => (
+          <span className='text-secondary-token'>{getValue() || '-'}</span>
+        ),
+        size: 220,
+      }) as ColumnDef<ReviewLead, unknown>,
+      reviewQueueColumnHelper.accessor('instagramHandle', {
+        header: 'Instagram',
+        cell: ({ getValue }) => {
+          const handle = getValue();
+          return handle ? (
+            <a
+              href={`https://instagram.com/${handle}`}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='flex items-center gap-1 text-secondary-token hover:text-primary-token'
+            >
+              @{handle}
+              <ExternalLink className='size-3' aria-hidden='true' />
+            </a>
+          ) : (
+            <span className='text-tertiary-token'>-</span>
+          );
+        },
+        size: 150,
+      }) as ColumnDef<ReviewLead, unknown>,
+      reviewQueueColumnHelper.accessor('signals', {
+        header: 'Signals',
+        cell: ({ getValue }) => (
+          <div className='flex flex-wrap gap-1'>
+            {Object.entries(getValue() ?? {}).map(
+              ([key, value]) =>
+                value &&
+                SIGNAL_CONFIG[key] && (
+                  <Badge
+                    key={key}
+                    variant={SIGNAL_CONFIG[key].variant}
+                    className='text-2xs'
+                  >
+                    {SIGNAL_CONFIG[key].label}
+                  </Badge>
+                )
+            )}
+          </div>
+        ),
+        size: 220,
+      }) as ColumnDef<ReviewLead, unknown>,
+      reviewQueueColumnHelper.display({
+        id: 'actions',
+        header: 'Actions',
+        cell: ({ row }) => (
+          <DrawerButton
+            tone='secondary'
+            size='sm'
+            onClick={() => {
+              void handleSkip(row.original.id);
+            }}
+            disabled={skippingId === row.original.id}
+            className='h-8 px-3 text-xs'
+          >
+            {skippingId === row.original.id ? (
+              <LoadingSpinner size='sm' tone='muted' className='mr-1.5' />
+            ) : null}
+            Skip
+          </DrawerButton>
+        ),
+        size: 110,
+      }) as ColumnDef<ReviewLead, unknown>,
+    ],
+    [handleSkip, skippingId]
+  );
 
   const totalPages = Math.ceil(total / limit);
   const hasPreviousPage = page > 1;
@@ -130,106 +226,25 @@ export function ReviewQueuePanel() {
           actionsClassName='shrink-0'
         />
 
-        <ContentTable>
-          <thead>
-            <tr className={CONTENT_TABLE_HEAD_ROW_CLASS}>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Name</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Priority</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Fit score</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Email</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Instagram</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Signals</th>
-              <th className={CONTENT_TABLE_HEAD_CELL_CLASS}>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {loading || leads.length === 0 ? (
-              <ContentTableStateRow
-                colSpan={7}
-                isLoading={loading}
-                emptyMessage={loadError ?? 'No leads pending review'}
-                loadingLabel='Loading manual review queue'
-              />
-            ) : (
-              leads.map(lead => (
-                <tr key={lead.id} className={CONTENT_TABLE_ROW_CLASS}>
-                  <td className={CONTENT_TABLE_CELL_CLASS}>
-                    <span className='font-semibold text-primary-token'>
-                      {lead.displayName || '-'}
-                    </span>
-                  </td>
-                  <td className={cn(CONTENT_TABLE_CELL_CLASS, 'tabular-nums')}>
-                    {lead.priorityScore ?? '-'}
-                  </td>
-                  <td className={cn(CONTENT_TABLE_CELL_CLASS, 'tabular-nums')}>
-                    {lead.fitScore ?? '-'}
-                  </td>
-                  <td className={CONTENT_TABLE_CELL_CLASS}>
-                    <span className='text-secondary-token'>
-                      {lead.contactEmail || '-'}
-                    </span>
-                  </td>
-                  <td className={CONTENT_TABLE_CELL_CLASS}>
-                    {lead.instagramHandle ? (
-                      <a
-                        href={`https://instagram.com/${lead.instagramHandle}`}
-                        target='_blank'
-                        rel='noopener noreferrer'
-                        className='flex items-center gap-1 text-secondary-token hover:text-primary-token'
-                      >
-                        @{lead.instagramHandle}
-                        <ExternalLink className='size-3' aria-hidden='true' />
-                      </a>
-                    ) : (
-                      <span className='text-tertiary-token'>-</span>
-                    )}
-                  </td>
-                  <td className={CONTENT_TABLE_CELL_CLASS}>
-                    <div className='flex flex-wrap gap-1'>
-                      {lead.signals &&
-                        Object.entries(lead.signals).map(
-                          ([key, value]) =>
-                            value &&
-                            SIGNAL_CONFIG[key] && (
-                              <Badge
-                                key={key}
-                                variant={SIGNAL_CONFIG[key].variant}
-                                className='text-2xs'
-                              >
-                                {SIGNAL_CONFIG[key].label}
-                              </Badge>
-                            )
-                        )}
-                    </div>
-                  </td>
-                  <td className={CONTENT_TABLE_CELL_CLASS}>
-                    <DrawerButton
-                      tone='secondary'
-                      size='sm'
-                      onClick={() => {
-                        void handleSkip(lead.id);
-                      }}
-                      disabled={skippingId === lead.id}
-                      className='h-8 px-3 text-xs'
-                    >
-                      {skippingId === lead.id ? (
-                        <LoadingSpinner
-                          size='sm'
-                          tone='muted'
-                          className='mr-1.5'
-                        />
-                      ) : null}
-                      Skip
-                    </DrawerButton>
-                  </td>
-                </tr>
-              ))
-            )}
-          </tbody>
-        </ContentTable>
+        <AdminDataTable
+          data={leads}
+          columns={columns}
+          isLoading={loading}
+          getRowId={lead => lead.id}
+          enableVirtualization={false}
+          minWidth='980px'
+          emptyState={
+            <TableEmptyState
+              title={
+                loadError ? 'Unable to load manual review' : 'No leads pending'
+              }
+              description={loadError ?? 'No leads pending review'}
+            />
+          }
+        />
 
         {totalPages > 1 && (
-          <div className={CONTENT_TABLE_FOOTER_CLASS}>
+          <div className='border-t border-subtle px-(--linear-app-content-padding-x) py-2'>
             <AdminTablePagination
               page={page}
               totalPages={totalPages}

--- a/apps/web/components/features/admin/outreach/ReviewQueuePanel.tsx
+++ b/apps/web/components/features/admin/outreach/ReviewQueuePanel.tsx
@@ -52,7 +52,7 @@ export function ReviewQueuePanel() {
   const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [skippingId, setSkippingId] = useState<string | null>(null);
+  const [skippingIds, setSkippingIds] = useState<Set<string>>(() => new Set());
   const limit = 50;
 
   const fetchQueue = useCallback(async () => {
@@ -90,7 +90,7 @@ export function ReviewQueuePanel() {
 
   const handleSkip = useCallback(
     async (id: string) => {
-      setSkippingId(id);
+      setSkippingIds(current => new Set(current).add(id));
       try {
         const res = await fetch(`/api/admin/leads/${id}/skip`, {
           method: 'PATCH',
@@ -103,7 +103,11 @@ export function ReviewQueuePanel() {
       } catch {
         toast.error('Failed to skip lead');
       } finally {
-        setSkippingId(null);
+        setSkippingIds(current => {
+          const next = new Set(current);
+          next.delete(id);
+          return next;
+        });
       }
     },
     [fetchQueue]
@@ -192,10 +196,10 @@ export function ReviewQueuePanel() {
             onClick={() => {
               void handleSkip(row.original.id);
             }}
-            disabled={skippingId === row.original.id}
+            disabled={skippingIds.has(row.original.id)}
             className='h-8 px-3 text-xs'
           >
-            {skippingId === row.original.id ? (
+            {skippingIds.has(row.original.id) ? (
               <LoadingSpinner size='sm' tone='muted' className='mr-1.5' />
             ) : null}
             Skip
@@ -204,7 +208,7 @@ export function ReviewQueuePanel() {
         size: 110,
       }) as ColumnDef<ReviewLead, unknown>,
     ],
-    [handleSkip, skippingId]
+    [handleSkip, skippingIds]
   );
 
   const totalPages = Math.ceil(total / limit);

--- a/apps/web/tests/unit/app/outreach-admin-table-normalization.test.ts
+++ b/apps/web/tests/unit/app/outreach-admin-table-normalization.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readSource(path: string): string {
+  return readFileSync(resolve(process.cwd(), path), 'utf8');
+}
+
+describe('outreach admin table normalization', () => {
+  it('keeps outreach queue panels on the canonical admin data table wrapper', () => {
+    const files = [
+      'components/features/admin/outreach/EmailQueuePanel.tsx',
+      'components/features/admin/outreach/ReviewQueuePanel.tsx',
+    ] as const;
+
+    for (const file of files) {
+      const source = readSource(file);
+
+      expect(source).toContain('AdminDataTable');
+      expect(source).toContain('TableEmptyState');
+      expect(source).not.toContain('ContentTable');
+      expect(source).not.toContain('CONTENT_TABLE_');
+      expect(source).not.toMatch(/<table\b/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- replaces legacy ContentTable usage in outreach email/review queue panels with AdminDataTable
- keeps queue fetching, actions, empty states, and pagination behavior intact
- adds a source guard so these panels stay off raw table/ContentTable primitives

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/app/outreach-admin-table-normalization.test.ts tests/unit/app/surface-elevation-guardrails.test.ts tests/unit/components/admin/AdminDataTable.test.tsx --config=vitest.config.mts
- pnpm exec biome check apps/web/components/features/admin/outreach/EmailQueuePanel.tsx apps/web/components/features/admin/outreach/ReviewQueuePanel.tsx apps/web/tests/unit/app/outreach-admin-table-normalization.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- browser route smoke on /app/admin/growth confirmed no mounted outreach queue panel visual delta today; live route remains leads/outreach KPI/campaign sections with no document overflow or console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency and maintainability of admin outreach email and review queue panels through standardized table implementation.

* **Tests**
  * Added test coverage to ensure admin outreach panels maintain consistent implementation standards.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->