### PR TITLE
fix(shell): trim dashboard overview data load

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/DashboardOverviewSection.tsx
+++ b/apps/web/app/app/(shell)/dashboard/DashboardOverviewSection.tsx
@@ -24,8 +24,9 @@ export async function DashboardOverviewSection() {
     : null;
 
   const [overviewSupplement, linkClickStats] = await Promise.all([
-    dashboardData.selectedProfile && dashboardData.user?.id
+    dashboardData.selectedProfile && dashboardData.user?.id && auth.userId
       ? getDashboardOverviewSupplement({
+          clerkUserId: auth.userId,
           onboardingCompletedAt:
             dashboardData.selectedProfile.onboardingCompletedAt?.toISOString() ??
             null,

--- a/apps/web/app/app/(shell)/dashboard/DashboardOverviewSection.tsx
+++ b/apps/web/app/app/(shell)/dashboard/DashboardOverviewSection.tsx
@@ -3,12 +3,15 @@ import { APP_ROUTES } from '@/constants/routes';
 import { DashboardOverview } from '@/features/dashboard/organisms/DashboardOverview';
 import { getCachedAuth } from '@/lib/auth/cached';
 import { convertDrizzleCreatorProfileToArtist } from '@/types/db';
-import { getDashboardData } from './actions';
+import {
+  getDashboardDataEssential,
+  getDashboardOverviewSupplement,
+} from './actions';
 import { getLinkClicksByPlatform } from './actions/link-clicks';
 
 export async function DashboardOverviewSection() {
   const [dashboardData, auth] = await Promise.all([
-    getDashboardData(),
+    getDashboardDataEssential(),
     getCachedAuth(),
   ]);
 
@@ -20,25 +23,37 @@ export async function DashboardOverviewSection() {
     ? convertDrizzleCreatorProfileToArtist(dashboardData.selectedProfile)
     : null;
 
-  // Fetch link click stats (non-blocking, errors resolve to empty)
-  let linkClickStats = {
-    stats: [] as { platform: string; clicks: number }[],
-    total: 0,
-  };
-  if (auth.userId) {
-    try {
-      linkClickStats = await getLinkClicksByPlatform(auth.userId);
-    } catch {
-      // Silent failure — card shows empty state
-    }
-  }
+  const [overviewSupplement, linkClickStats] = await Promise.all([
+    dashboardData.selectedProfile && dashboardData.user?.id
+      ? getDashboardOverviewSupplement({
+          onboardingCompletedAt:
+            dashboardData.selectedProfile.onboardingCompletedAt?.toISOString() ??
+            null,
+          profileId: dashboardData.selectedProfile.id,
+          userId: dashboardData.user.id,
+        })
+      : Promise.resolve({
+          hasSocialLinks: false,
+          hasMusicLinks: false,
+          bioLinkActivation: null,
+        }),
+    auth.userId
+      ? getLinkClicksByPlatform(auth.userId).catch(() => ({
+          stats: [] as { platform: string; clicks: number }[],
+          total: 0,
+        }))
+      : Promise.resolve({
+          stats: [] as { platform: string; clicks: number }[],
+          total: 0,
+        }),
+  ]);
 
   return (
     <DashboardOverview
       artist={artist}
-      bioLinkActivation={dashboardData.bioLinkActivation}
-      hasSocialLinks={dashboardData.hasSocialLinks}
-      hasMusicLinks={dashboardData.hasMusicLinks}
+      bioLinkActivation={overviewSupplement.bioLinkActivation}
+      hasSocialLinks={overviewSupplement.hasSocialLinks}
+      hasMusicLinks={overviewSupplement.hasMusicLinks}
       linkClickStats={linkClickStats.stats}
       linkClickTotal={linkClickStats.total}
     />

--- a/apps/web/app/app/(shell)/dashboard/actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/actions.ts
@@ -30,6 +30,7 @@ export {
   getDashboardDataCached,
   getDashboardDataEssential,
   getDashboardDataFresh,
+  getDashboardOverviewSupplement,
   getDashboardShellData,
   getProfileSocialLinks,
   prefetchDashboardData,

--- a/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
+++ b/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
@@ -165,6 +165,7 @@ export interface DashboardOverviewSupplement {
 }
 
 interface DashboardOverviewSupplementArgs {
+  clerkUserId: string;
   onboardingCompletedAt: string | null;
   profileId: string;
   userId: string;
@@ -360,33 +361,37 @@ async function fetchSocialLinkExistence(
 }
 
 async function fetchDashboardOverviewSupplementWithSession({
+  clerkUserId,
   onboardingCompletedAt,
   profileId,
   userId,
 }: DashboardOverviewSupplementArgs): Promise<DashboardOverviewSupplement> {
   try {
-    return await withDbSessionTx(async tx => {
-      const linkCounts = await fetchSocialLinkExistence(tx, {
-        context: 'dashboard_overview_supplement',
-        operation: 'dashboard_overview_social_links_existence',
-        profileId,
-        queryLabel: 'Dashboard overview social links existence query',
-        userId,
-      });
+    return await withDbSessionTx(
+      async tx => {
+        const linkCounts = await fetchSocialLinkExistence(tx, {
+          context: 'dashboard_overview_supplement',
+          operation: 'dashboard_overview_social_links_existence',
+          profileId,
+          queryLabel: 'Dashboard overview social links existence query',
+          userId,
+        });
 
-      const bioLinkActivation = await buildBioLinkActivation(tx, {
-        id: profileId,
-        onboardingCompletedAt: onboardingCompletedAt
-          ? new Date(onboardingCompletedAt)
-          : null,
-      });
+        const bioLinkActivation = await buildBioLinkActivation(tx, {
+          id: profileId,
+          onboardingCompletedAt: onboardingCompletedAt
+            ? new Date(onboardingCompletedAt)
+            : null,
+        });
 
-      return {
-        hasSocialLinks: linkCounts.hasLinks,
-        hasMusicLinks: linkCounts.hasMusicLinks,
-        bioLinkActivation,
-      };
-    });
+        return {
+          hasSocialLinks: linkCounts.hasLinks,
+          hasMusicLinks: linkCounts.hasMusicLinks,
+          bioLinkActivation,
+        };
+      },
+      { clerkUserId }
+    );
   } catch (error) {
     Sentry.captureException(error, {
       level: 'warning',

--- a/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
+++ b/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
@@ -155,6 +155,29 @@ export interface ProfileCompletion {
   profileIsLive: boolean;
 }
 
+export interface DashboardOverviewSupplement {
+  /** Whether the selected profile has any active social links */
+  hasSocialLinks: boolean;
+  /** Whether the selected profile has any active music/DSP links */
+  hasMusicLinks: boolean;
+  /** Instagram bio-link activation state for the dashboard overview */
+  bioLinkActivation: BioLinkActivation | null;
+}
+
+interface DashboardOverviewSupplementArgs {
+  onboardingCompletedAt: string | null;
+  profileId: string;
+  userId: string;
+}
+
+interface SocialLinkExistenceQueryOptions {
+  context: string;
+  operation: string;
+  profileId: string;
+  queryLabel: string;
+  userId: string;
+}
+
 function hasText(value: string | null | undefined): boolean {
   return typeof value === 'string' && value.trim().length > 0;
 }
@@ -184,7 +207,7 @@ type BioLinkActivationEventType =
 
 async function buildBioLinkActivation(
   tx: DbOrTransaction,
-  profile: CreatorProfile
+  profile: Pick<CreatorProfile, 'id' | 'onboardingCompletedAt'>
 ): Promise<BioLinkActivation | null> {
   const windowEndsAt = getBioLinkActivationWindowEnd(
     profile.onboardingCompletedAt
@@ -258,6 +281,120 @@ async function buildBioLinkActivation(
     }),
     windowEndsAt: serializeNullableDate(windowEndsAt),
   };
+}
+
+function createEmptyDashboardOverviewSupplement(): DashboardOverviewSupplement {
+  return {
+    hasSocialLinks: false,
+    hasMusicLinks: false,
+    bioLinkActivation: null,
+  };
+}
+
+async function fetchSocialLinkExistence(
+  tx: DbOrTransaction,
+  {
+    context,
+    operation,
+    profileId,
+    queryLabel,
+    userId,
+  }: SocialLinkExistenceQueryOptions
+): Promise<{ hasLinks: boolean; hasMusicLinks: boolean }> {
+  return dashboardQuery(
+    () =>
+      tx
+        .select({
+          hasLinks: drizzleSql<boolean>`
+            exists (
+              select 1
+              from ${socialLinks}
+              where ${and(
+                eq(socialLinks.creatorProfileId, profileId),
+                eq(socialLinks.state, 'active'),
+                eq(socialLinks.isActive, true)
+              )}
+            )
+          `,
+          hasMusicLinks: drizzleSql<boolean>`
+            exists (
+              select 1
+              from ${socialLinks}
+              where ${and(
+                eq(socialLinks.creatorProfileId, profileId),
+                eq(socialLinks.state, 'active'),
+                eq(socialLinks.isActive, true),
+                or(
+                  eq(socialLinks.platformType, 'dsp'),
+                  eq(socialLinks.platform, sqlAny(DSP_PLATFORMS))
+                )
+              )}
+            )
+          `,
+        })
+        .from(users)
+        .where(eq(users.id, userId))
+        .limit(1),
+    queryLabel
+  )
+    .then(result => mapSocialLinkExistence(result?.[0]))
+    .catch((error: unknown) => {
+      const migrationResult = handleMigrationErrors(error, {
+        userId,
+        operation,
+      });
+
+      if (!migrationResult.shouldRetry) {
+        return { hasLinks: false, hasMusicLinks: false };
+      }
+
+      Sentry.captureException(error, {
+        level: 'warning',
+        tags: {
+          query: operation,
+          context,
+        },
+      });
+      return { hasLinks: false, hasMusicLinks: false };
+    });
+}
+
+async function fetchDashboardOverviewSupplementWithSession({
+  onboardingCompletedAt,
+  profileId,
+  userId,
+}: DashboardOverviewSupplementArgs): Promise<DashboardOverviewSupplement> {
+  try {
+    return await withDbSessionTx(async tx => {
+      const linkCounts = await fetchSocialLinkExistence(tx, {
+        context: 'dashboard_overview_supplement',
+        operation: 'dashboard_overview_social_links_existence',
+        profileId,
+        queryLabel: 'Dashboard overview social links existence query',
+        userId,
+      });
+
+      const bioLinkActivation = await buildBioLinkActivation(tx, {
+        id: profileId,
+        onboardingCompletedAt: onboardingCompletedAt
+          ? new Date(onboardingCompletedAt)
+          : null,
+      });
+
+      return {
+        hasSocialLinks: linkCounts.hasLinks,
+        hasMusicLinks: linkCounts.hasMusicLinks,
+        bioLinkActivation,
+      };
+    });
+  } catch (error) {
+    Sentry.captureException(error, {
+      level: 'warning',
+      tags: { context: 'dashboard_overview_supplement' },
+      extra: { profileId, userId },
+    });
+    return createEmptyDashboardOverviewSupplement();
+  }
 }
 
 function buildProfileCompletion(
@@ -561,62 +698,13 @@ async function fetchDashboardCoreWithSession(
         // These share a single transaction connection (pg serializes queries
         // on one connection), so parallel dispatch would just queue them
         // while starting all timeout timers simultaneously.
-        const linkCounts = await dashboardQuery(
-          () =>
-            tx
-              .select({
-                hasLinks: drizzleSql<boolean>`
-                exists (
-                  select 1
-                  from ${socialLinks}
-                  where ${and(
-                    eq(socialLinks.creatorProfileId, selected.id),
-                    eq(socialLinks.state, 'active'),
-                    eq(socialLinks.isActive, true)
-                  )}
-                )
-              `,
-                hasMusicLinks: drizzleSql<boolean>`
-                exists (
-                  select 1
-                  from ${socialLinks}
-                  where ${and(
-                    eq(socialLinks.creatorProfileId, selected.id),
-                    eq(socialLinks.state, 'active'),
-                    eq(socialLinks.isActive, true),
-                    or(
-                      eq(socialLinks.platformType, 'dsp'),
-                      eq(socialLinks.platform, sqlAny(DSP_PLATFORMS))
-                    )
-                  )}
-                )
-              `,
-              })
-              .from(users)
-              .where(eq(users.id, userId))
-              .limit(1),
-          'Social links existence query'
-        )
-          .then(result => mapSocialLinkExistence(result?.[0]))
-          .catch((error: unknown) => {
-            const migrationResult = handleMigrationErrors(error, {
-              userId,
-              operation: 'social_links_existence',
-            });
-
-            if (!migrationResult.shouldRetry) {
-              return { hasLinks: false, hasMusicLinks: false };
-            }
-
-            Sentry.captureException(error, {
-              level: 'warning',
-              tags: {
-                query: 'social_links_existence',
-                context: 'dashboard_data_settled',
-              },
-            });
-            return { hasLinks: false, hasMusicLinks: false };
-          });
+        const linkCounts = await fetchSocialLinkExistence(tx, {
+          context: 'dashboard_data_settled',
+          operation: 'social_links_existence',
+          profileId: selected.id,
+          queryLabel: 'Social links existence query',
+          userId,
+        });
 
         const avatarQuality = await getAvatarQualityForProfile(
           selected.id,
@@ -932,6 +1020,16 @@ const getCachedDashboardEssential = unstableCache(
   }
 );
 
+const getCachedDashboardOverviewSupplement = unstableCache(
+  async (args: DashboardOverviewSupplementArgs) =>
+    fetchDashboardOverviewSupplementWithSession(args),
+  ['dashboard-overview-supplement'],
+  {
+    revalidate: CACHE_TTL.MEDIUM,
+    tags: [CACHE_TAGS.DASHBOARD_DATA],
+  }
+);
+
 const getCachedDashboardShell = unstableCache(
   async (clerkUserId: string) => fetchDashboardShellWithSession(clerkUserId),
   ['dashboard-shell'],
@@ -1079,6 +1177,10 @@ async function resolveDashboardShellData(
  */
 const loadDashboardData = cache(resolveDashboardData);
 const loadDashboardDataEssential = cache(resolveDashboardDataEssential);
+const loadDashboardOverviewSupplement = cache(
+  async (args: DashboardOverviewSupplementArgs) =>
+    getCachedDashboardOverviewSupplement(args)
+);
 const loadDashboardShellData = cache(resolveDashboardShellData);
 
 /**
@@ -1115,6 +1217,20 @@ export async function getDashboardData(): Promise<DashboardData> {
  */
 export async function getDashboardDataEssential(): Promise<DashboardData> {
   return loadDashboardDataEssential();
+}
+
+/**
+ * Gets dashboard overview-only supplementary data.
+ *
+ * Use this with getDashboardDataEssential() when a route needs selected-profile
+ * shell data plus social/music link existence and the Instagram activation nudge,
+ * but does not need slower full-dashboard fields like tipping stats or avatar
+ * review metadata.
+ */
+export async function getDashboardOverviewSupplement(
+  args: DashboardOverviewSupplementArgs
+): Promise<DashboardOverviewSupplement> {
+  return loadDashboardOverviewSupplement(args);
 }
 
 /**

--- a/apps/web/app/app/(shell)/dashboard/actions/index.ts
+++ b/apps/web/app/app/(shell)/dashboard/actions/index.ts
@@ -32,6 +32,7 @@ export {
   getDashboardDataCached,
   getDashboardDataEssential,
   getDashboardDataFresh,
+  getDashboardOverviewSupplement,
   getDashboardShellData,
   prefetchDashboardData,
 } from './dashboard-data';

--- a/apps/web/tests/unit/app/dashboard-overview-fast-path.test.ts
+++ b/apps/web/tests/unit/app/dashboard-overview-fast-path.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = join(__dirname, '../../..');
+
+function readSource(path: string): string {
+  return readFileSync(join(ROOT, path), 'utf-8');
+}
+
+describe('dashboard overview fast path', () => {
+  it('uses essential dashboard data plus an overview supplement', () => {
+    const source = readSource(
+      'app/app/(shell)/dashboard/DashboardOverviewSection.tsx'
+    );
+
+    expect(source).toContain('getDashboardDataEssential');
+    expect(source).toContain('getDashboardOverviewSupplement');
+    expect(source).not.toContain('getDashboardData()');
+  });
+});

--- a/apps/web/tests/unit/app/dashboard-overview-fast-path.test.ts
+++ b/apps/web/tests/unit/app/dashboard-overview-fast-path.test.ts
@@ -16,6 +16,6 @@ describe('dashboard overview fast path', () => {
 
     expect(source).toContain('getDashboardDataEssential');
     expect(source).toContain('getDashboardOverviewSupplement');
-    expect(source).not.toContain('getDashboardData()');
+    expect(source).not.toMatch(/\bgetDashboardData\s*\(/);
   });
 });

--- a/apps/web/tests/unit/dashboard/dashboard-data-prefetch.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-data-prefetch.test.ts
@@ -161,6 +161,7 @@ vi.mock('@/lib/db', () => ({
     }),
     execute: vi.fn().mockResolvedValue({}),
   },
+  doesTableExist: vi.fn(async () => false),
 }));
 
 vi.mock('@/lib/db/query-timeout', () => ({
@@ -189,6 +190,7 @@ vi.mock('@/lib/db/schema/auth', () => ({
 vi.mock('@/lib/db/schema/links', () => ({
   socialLinks: {
     creatorProfileId: 'creatorProfileId',
+    isActive: 'isActive',
     state: 'state',
     platformType: 'platformType',
     platform: 'platform',
@@ -196,6 +198,12 @@ vi.mock('@/lib/db/schema/links', () => ({
 }));
 
 vi.mock('@/lib/db/schema/profiles', () => ({
+  creatorDistributionEvents: {
+    createdAt: 'createdAt',
+    creatorProfileId: 'creatorProfileId',
+    eventType: 'eventType',
+    platform: 'platform',
+  },
   creatorProfiles: { userId: 'userId', id: 'id', createdAt: 'createdAt' },
 }));
 
@@ -433,6 +441,39 @@ describe('dashboard data prefetch', () => {
 
     expect(result.isAdmin).toBe(true);
     expect(result.needsOnboarding).toBe(false);
+  });
+
+  it('loads dashboard overview supplement without full dashboard fields', async () => {
+    const selectMock = vi.fn().mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi
+            .fn()
+            .mockResolvedValue([{ hasLinks: 't', hasMusicLinks: '0' }]),
+        }),
+      }),
+    } as never);
+
+    withDbSessionTxMock.mockImplementationOnce(async handler =>
+      handler({ select: selectMock }, 'user_123')
+    );
+
+    const { getDashboardOverviewSupplement } = await import(
+      '@/app/app/(shell)/dashboard/actions/dashboard-data'
+    );
+
+    const result = await getDashboardOverviewSupplement({
+      onboardingCompletedAt: null,
+      profileId: 'profile_1',
+      userId: 'user_db_1',
+    });
+
+    expect(withDbSessionTxMock).toHaveBeenCalledWith(expect.any(Function));
+    expect(result).toEqual({
+      hasSocialLinks: true,
+      hasMusicLinks: false,
+      bioLinkActivation: null,
+    });
   });
 });
 

--- a/apps/web/tests/unit/dashboard/dashboard-data-prefetch.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-data-prefetch.test.ts
@@ -463,12 +463,18 @@ describe('dashboard data prefetch', () => {
     );
 
     const result = await getDashboardOverviewSupplement({
+      clerkUserId: 'user_123',
       onboardingCompletedAt: null,
       profileId: 'profile_1',
       userId: 'user_db_1',
     });
 
-    expect(withDbSessionTxMock).toHaveBeenCalledWith(expect.any(Function));
+    expect(withDbSessionTxMock).toHaveBeenCalledTimes(1);
+    expect(withDbSessionTxMock).toHaveBeenCalledWith(expect.any(Function), {
+      clerkUserId: 'user_123',
+    });
+    expect(withDbSessionMock).not.toHaveBeenCalled();
+    expect(selectMock).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       hasSocialLinks: true,
       hasMusicLinks: false,


### PR DESCRIPTION
## Summary
- switches `DashboardOverviewSection` from the full dashboard payload to the essential dashboard loader
- adds a narrow cached dashboard overview supplement for social/music link existence and Instagram bio-link activation
- shares the social-link existence query between the full dashboard loader and the overview supplement to keep behavior aligned
- adds a source guard preventing the overview section from regressing to `getDashboardData()`

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/dashboard-data-prefetch.test.ts tests/unit/app/dashboard-overview-fast-path.test.ts --config=vitest.config.mts`
- `pnpm exec biome check apps/web/app/app/(shell)/dashboard/DashboardOverviewSection.tsx apps/web/app/app/(shell)/dashboard/actions.ts apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts apps/web/app/app/(shell)/dashboard/actions/index.ts apps/web/tests/unit/dashboard/dashboard-data-prefetch.test.ts apps/web/tests/unit/app/dashboard-overview-fast-path.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`
- design/QA smoke: `http://127.0.0.1:3118/api/dev/test-auth/enter?persona=creator-ready&redirect=/app` returned 200 on `/app`, no console/page errors, no horizontal overflow, shell content present

## Visual
No intentional visual change. Screenshot artifact: `/tmp/dashboard-overview-essential-app-auth-final.png`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized dashboard loading: core and supplemental overview data (social/music/bio link state) now load separately and in parallel, with safer fallbacks when profile/auth info is missing, reduced unnecessary data fetching, improved caching and request deduplication, and more resilient error handling.

* **Tests**
  * Added unit tests covering the dashboard overview fast-path and supplemental data prefetch behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8980?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->