### PR TITLE
fix(shell): optimize artist settings shell route

### DIFF
--- a/apps/web/app/app/(shell)/shell-route-matches.ts
+++ b/apps/web/app/app/(shell)/shell-route-matches.ts
@@ -130,9 +130,6 @@ function isDashboardSubRoute(pathname: string | null): boolean {
 }
 
 function isShellOptimizedSettingsRoute(pathname: string | null): boolean {
-  if (matchesRoutePrefix(pathname, APP_ROUTES.SETTINGS_ARTIST_PROFILE)) {
-    return false;
-  }
   return matchesRoutePrefix(pathname, APP_ROUTES.SETTINGS);
 }
 

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -229,10 +229,10 @@ describe('shouldUseEssentialShellData', () => {
     expect(shouldUseEssentialShellData(APP_ROUTES.SETTINGS_TOURING)).toBe(true);
   });
 
-  it('keeps artist profile settings on the full dashboard data path', () => {
+  it('returns true for artist profile settings after its page owns supplementary data', () => {
     expect(
       shouldUseEssentialShellData(APP_ROUTES.SETTINGS_ARTIST_PROFILE)
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('returns false for null', () => {

--- a/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
@@ -109,10 +109,10 @@ describe('@critical DashboardShellContent behavior contracts', () => {
       );
     });
 
-    it('artist profile settings routes use full dashboard data', () => {
+    it('artist profile settings routes use essential shell data', () => {
       expect(
         shouldUseEssentialShellData(APP_ROUTES.SETTINGS_ARTIST_PROFILE)
-      ).toBe(false);
+      ).toBe(true);
     });
 
     it('null pathname uses full dashboard data', () => {
@@ -154,10 +154,10 @@ describe('@critical DashboardShellContent behavior contracts', () => {
       expect(isChatShellRoute(APP_ROUTES.SETTINGS_CONTACTS)).toBe(false);
     });
 
-    it('artist profile settings route gets full shell hydration', () => {
+    it('artist profile settings route uses route-owned hydration', () => {
       expect(
         shouldUseEssentialShellData(APP_ROUTES.SETTINGS_ARTIST_PROFILE)
-      ).toBe(false);
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary
- lets `/app/settings/artist-profile` use the essential shell data path now that the page owns its supplementary profile/link data
- updates route matcher and shell-content tests to lock the route-owned settings contract

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/shell-route-matches.test.ts tests/unit/dashboard/dashboard-shell-content.test.ts tests/unit/app/settings-page.test.tsx --config=vitest.config.mts`
- `pnpm exec biome check apps/web/app/app/(shell)/shell-route-matches.ts apps/web/tests/unit/app/shell-route-matches.test.ts apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`
- design/QA smoke: `/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/settings/artist-profile` returned 200 on `/app/settings/artist-profile`, no overflow, settings content present

## Visual
No intentional layout change. Screenshot artifact: `/tmp/settings-artist-profile-essential-route.png`

## Notes
Smoke logged existing Next/Image warnings for `/avatars/default-user.png`; no page errors.