### PR TITLE
fix(chat): tighten message bubble spacing

### DIFF
--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -84,7 +84,10 @@ export function ChatMessage({
       transition={{ duration: 0.2, ease: 'easeOut' }}
     >
       {isUser ? (
-        <div className='max-w-[78%] rounded-[18px] border border-white/80 bg-white px-4 py-3.5 text-[#111216] shadow-[0_12px_38px_-28px_rgba(0,0,0,0.85),inset_0_1px_0_rgba(255,255,255,0.9)]'>
+        <div
+          data-testid='chat-user-bubble'
+          className='flex min-h-8 max-w-[78%] flex-col justify-center rounded-full border border-white/80 bg-white px-3 py-1.5 text-[#111216] shadow-[0_12px_38px_-28px_rgba(0,0,0,0.85),inset_0_1px_0_rgba(255,255,255,0.9)]'
+        >
           {imageChips.length > 0 && (
             <div
               className={cn(
@@ -103,7 +106,7 @@ export function ChatMessage({
             </div>
           )}
           {messageText && (
-            <div className='text-[15px] leading-6 tracking-normal'>
+            <div className='text-[13px] leading-5 tracking-[-0.011em]'>
               <TokenizedText content={messageText} tone='onLight' />
             </div>
           )}

--- a/apps/web/components/jovie/components/ChatMessageSkeleton.tsx
+++ b/apps/web/components/jovie/components/ChatMessageSkeleton.tsx
@@ -13,8 +13,8 @@ export function ChatMessageSkeleton() {
     >
       {/* User message skeleton */}
       <div className='flex justify-end'>
-        <div className='max-w-[78%] rounded-[18px] border border-(--linear-app-frame-seam) bg-surface-2 px-4 py-3.5'>
-          <Skeleton className='h-4 w-40' rounded='lg' />
+        <div className='flex min-h-8 max-w-[78%] items-center rounded-full border border-(--linear-app-frame-seam) bg-surface-2 px-3 py-1.5'>
+          <Skeleton className='h-3.5 w-36' rounded='full' />
         </div>
       </div>
 

--- a/apps/web/tests/unit/chat/ChatMessage.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.test.tsx
@@ -1,0 +1,55 @@
+import { screen } from '@testing-library/react';
+import type { ComponentProps, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ChatMessage } from '@/components/jovie/components/ChatMessage';
+import { fastRender } from '@/tests/utils/fast-render';
+
+vi.mock('motion/react', () => ({
+  motion: {
+    div: ({
+      children,
+      initial: _initial,
+      animate: _animate,
+      transition: _transition,
+      ...props
+    }: ComponentProps<'div'> & {
+      initial?: unknown;
+      animate?: unknown;
+      transition?: unknown;
+    }) => <div {...props}>{children}</div>,
+  },
+  useReducedMotion: () => true,
+}));
+
+vi.mock('@jovie/ui', () => ({
+  SimpleTooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('next/dynamic', () => ({
+  default:
+    () =>
+    ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+vi.mock('@/components/jovie/components/ChatMarkdown', () => ({
+  ChatMarkdown: ({ content }: { content: string }) => <div>{content}</div>,
+}));
+
+describe('ChatMessage', () => {
+  it('renders user messages as compact CTA-style pills', () => {
+    const messageProps = {
+      id: 'user-1',
+      role: 'user' as const,
+      parts: [{ type: 'text' as const, text: 'Yes music artist and writer' }],
+    };
+
+    fastRender(<ChatMessage {...messageProps} />);
+
+    const bubble = screen.getByTestId('chat-user-bubble');
+    expect(bubble.className).toContain('rounded-full');
+    expect(bubble.className).toContain('min-h-8');
+    expect(bubble.className).toContain('px-3');
+    expect(bubble.className).toContain('py-1.5');
+    expect(bubble.className).not.toContain('py-3.5');
+  });
+});

--- a/apps/web/tests/unit/chat/__snapshots__/ChatMessageSkeleton.test.tsx.snap
+++ b/apps/web/tests/unit/chat/__snapshots__/ChatMessageSkeleton.test.tsx.snap
@@ -9,11 +9,11 @@ exports[`ChatMessageSkeleton > matches snapshot 1`] = `
     class="flex justify-end"
   >
     <div
-      class="max-w-[78%] rounded-[18px] border border-(--linear-app-frame-seam) bg-surface-2 px-4 py-3.5"
+      class="flex min-h-8 max-w-[78%] items-center rounded-full border border-(--linear-app-frame-seam) bg-surface-2 px-3 py-1.5"
     >
       <div
         aria-hidden="true"
-        class="skeleton motion-reduce:animate-none rounded-lg h-4 w-40"
+        class="skeleton motion-reduce:animate-none rounded-full h-3.5 w-36"
       />
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Tighten user chat bubbles to CTA-style pill geometry with reduced vertical padding.
- Match chat loading skeleton user bubble to the same compact pill shape.
- Add focused regression coverage for user bubble geometry.

## Verification
- pnpm --filter web exec vitest run tests/unit/chat/ChatMessage.test.tsx tests/unit/chat/ChatMessageSkeleton.test.tsx -u
- pnpm exec biome check apps/web/components/jovie/components/ChatMessage.tsx apps/web/components/jovie/components/ChatMessageSkeleton.tsx apps/web/tests/unit/chat/ChatMessage.test.tsx apps/web/tests/unit/chat/ChatMessageSkeleton.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- E2E_SKIP_WEB_SERVER=1 BASE_URL=http://localhost:3121 E2E_USE_TEST_AUTH_BYPASS=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 pnpm --filter web exec playwright test tests/e2e/shell-chat-v1.spec.ts --project=chromium --reporter=line
- pre-push: biome check ., @jovie/web next:proxy-guard, tailwind:check, typecheck, lint

## Visual QA
- Captured /start desktop, tablet, mobile and /app/chat desktop, mobile against http://localhost:3121.
- User bubble measured 34px high across checked viewports, aligned with compact CTA pill sizing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined user message bubble styling with improved layout and visual appearance
  * Updated loading skeleton styling for chat messages

* **Tests**
  * Added unit tests for chat message components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->