### PR TITLE
fix(admin): tokenize Tim action-required accent

### DIFF
--- a/apps/web/components/features/admin/TimActionRequiredSection.tsx
+++ b/apps/web/components/features/admin/TimActionRequiredSection.tsx
@@ -76,7 +76,7 @@ function ActionRow({ issue, onClose, isClosing }: Readonly<ActionRowProps>) {
           rel='noopener noreferrer'
           className='group flex items-center gap-1.5'
         >
-          <p className='truncate text-[13px] font-semibold text-primary-token transition-colors group-hover:text-[#FACC15]'>
+          <p className='truncate text-[13px] font-semibold text-primary-token transition-colors group-hover:text-warning'>
             {issue.title}
           </p>
           <ExternalLink
@@ -105,7 +105,7 @@ function ActionRow({ issue, onClose, isClosing }: Readonly<ActionRowProps>) {
         onClick={() => void onClose(issue.id)}
         disabled={isClosing}
         aria-label={`Mark "${issue.title}" as done`}
-        className='shrink-0 rounded-lg border border-subtle bg-surface-1 p-1.5 text-tertiary-token transition-colors hover:border-[#FACC15]/30 hover:bg-[#FACC15]/10 hover:text-[#FACC15] disabled:cursor-not-allowed disabled:opacity-40'
+        className='shrink-0 rounded-lg border border-subtle bg-surface-1 p-1.5 text-tertiary-token transition-colors hover:border-warning/30 hover:bg-warning/10 hover:text-warning disabled:cursor-not-allowed disabled:opacity-40'
       >
         <Check className='h-3.5 w-3.5' aria-hidden='true' />
       </button>
@@ -219,13 +219,12 @@ export function TimActionRequiredSection() {
       <div className='space-y-2.5'>
         {/* Section header */}
         <div className='flex items-center gap-2'>
-          {/* Amber accent dot matching the #FACC15 tim-action-required label color */}
+          {/* Warning accent dot for Tim action-required state. */}
           <span
-            className='h-2 w-2 shrink-0 rounded-full'
-            style={{ backgroundColor: '#FACC15' }}
+            className='h-2 w-2 shrink-0 rounded-full bg-warning'
             aria-hidden='true'
           />
-          <p className='text-[11px] font-semibold uppercase tracking-[0.16em] text-tertiary-token'>
+          <p className='text-[12px] font-caption text-tertiary-token'>
             Tim Action Required
           </p>
           {!isLoading && visibleIssues.length > 0 ? (

--- a/apps/web/tests/unit/components/admin/TimActionRequiredSection.tokens.test.ts
+++ b/apps/web/tests/unit/components/admin/TimActionRequiredSection.tokens.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const TEST_DIR = dirname(
+  import.meta.url.startsWith('file:')
+    ? fileURLToPath(import.meta.url)
+    : import.meta.url
+);
+const TIM_ACTION_SECTION = join(
+  TEST_DIR,
+  '../../../../components/features/admin/TimActionRequiredSection.tsx'
+);
+
+describe('TimActionRequiredSection token usage', () => {
+  it('keeps the warning accent on design tokens', () => {
+    const source = readFileSync(TIM_ACTION_SECTION, 'utf8');
+
+    expect(source).toContain('group-hover:text-warning');
+    expect(source).toContain('hover:border-warning/30');
+    expect(source).toContain('hover:bg-warning/10');
+    expect(source).toContain('hover:text-warning');
+    expect(source).toContain('bg-warning');
+    expect(source).not.toContain('#FACC15');
+    expect(source).not.toContain('backgroundColor');
+  });
+
+  it('avoids uppercase tracking on the compact admin shell header', () => {
+    const source = readFileSync(TIM_ACTION_SECTION, 'utf8');
+
+    expect(source).toContain('font-caption text-tertiary-token');
+    expect(source).not.toContain('uppercase tracking');
+    expect(source).not.toContain('tracking-[0.16em]');
+  });
+});


### PR DESCRIPTION
## Summary
- replace hard-coded Tim action-required amber styles with warning design tokens
- remove compact admin header uppercase tracking in favor of caption typography
- add a source guard to keep the accent tokenized

## Checks
- pnpm --filter web exec vitest run tests/unit/components/admin/TimActionRequiredSection.tokens.test.ts
- pnpm biome check apps/web/components/features/admin/TimActionRequiredSection.tsx apps/web/tests/unit/components/admin/TimActionRequiredSection.tokens.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm turbo typecheck
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Tim action-required section styling to use design tokens for improved visual consistency and maintainability.

* **Tests**
  * Added test coverage to verify design token usage in the Tim action-required section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->