### PR TITLE
fix(ci): harden production signup canary env sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -163,6 +163,9 @@ E2E_PROD_MAILBOX_CLIENT_ID=
 E2E_PROD_MAILBOX_CLIENT_SECRET=
 E2E_PROD_MAILBOX_REFRESH_TOKEN=
 E2E_PROD_MAILBOX_QUERY_FROM=
+# Preferred no-inbox provider: set E2E_PROD_MAILBOX_PROVIDER=cloudflare-email-routing.
+E2E_PROD_OTP_CHECK_URL=
+E2E_PROD_OTP_CHECK_TOKEN=
 # Instantly.ai API key for outbound email campaigns.
 INSTANTLY_API_KEY=
 # Google Custom Search Engine API key used by discovery flows.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3621,8 +3621,11 @@ jobs:
           fi
 
           for key in "${required_vercel_env[@]}"; do
+            ./node_modules/.bin/vercel env rm "$key" production \
+              --yes \
+              --token "$VERCEL_TOKEN" \
+              --scope "$VERCEL_ORG_ID" >/dev/null 2>&1 || true
             ./node_modules/.bin/vercel env add "$key" production \
-              --force \
               --yes \
               --value "${!key}" \
               --token "$VERCEL_TOKEN" \

--- a/apps/web/lib/env-server-schema.ts
+++ b/apps/web/lib/env-server-schema.ts
@@ -244,11 +244,15 @@ export const ServerEnvSchema = z.object({
   E2E_CLERK_USER_USERNAME: z.string().optional(),
   E2E_PROD_SIGNUP_EMAIL_BASE: z.string().email().optional(),
   E2E_PROD_SIGNUP_PASSWORD: z.string().optional(),
-  E2E_PROD_MAILBOX_PROVIDER: z.enum(['gmail']).optional(),
+  E2E_PROD_MAILBOX_PROVIDER: z
+    .enum(['gmail', 'cloudflare-email-routing'])
+    .optional(),
   E2E_PROD_MAILBOX_CLIENT_ID: z.string().optional(),
   E2E_PROD_MAILBOX_CLIENT_SECRET: z.string().optional(),
   E2E_PROD_MAILBOX_REFRESH_TOKEN: z.string().optional(),
   E2E_PROD_MAILBOX_QUERY_FROM: z.string().optional(),
+  E2E_PROD_OTP_CHECK_URL: z.string().url().optional(),
+  E2E_PROD_OTP_CHECK_TOKEN: z.string().optional(),
   DEMO_RECORDING: z.string().optional(),
   DEMO_CLERK_USER_ID: z.string().optional(),
 

--- a/apps/web/tests/e2e/utils/production-signup-canary.ts
+++ b/apps/web/tests/e2e/utils/production-signup-canary.ts
@@ -4,13 +4,26 @@ export const PRODUCTION_SIGNUP_CANARY_KEYS = [
   'E2E_PROD_SIGNUP_EMAIL_BASE',
   'E2E_PROD_SIGNUP_PASSWORD',
   'E2E_PROD_MAILBOX_PROVIDER',
-  'E2E_PROD_MAILBOX_CLIENT_ID',
-  'E2E_PROD_MAILBOX_CLIENT_SECRET',
-  'E2E_PROD_MAILBOX_REFRESH_TOKEN',
   'CLERK_SECRET_KEY',
 ] as const;
 
-type ProductionSignupCanaryKey = (typeof PRODUCTION_SIGNUP_CANARY_KEYS)[number];
+const GMAIL_SIGNUP_CANARY_KEYS = [
+  'E2E_PROD_MAILBOX_CLIENT_ID',
+  'E2E_PROD_MAILBOX_CLIENT_SECRET',
+  'E2E_PROD_MAILBOX_REFRESH_TOKEN',
+] as const;
+
+const CLOUDFLARE_OTP_SIGNUP_CANARY_KEYS = [
+  'E2E_PROD_OTP_CHECK_URL',
+  'E2E_PROD_OTP_CHECK_TOKEN',
+] as const;
+
+type ProductionSignupCanaryKey =
+  | (typeof PRODUCTION_SIGNUP_CANARY_KEYS)[number]
+  | (typeof GMAIL_SIGNUP_CANARY_KEYS)[number]
+  | (typeof CLOUDFLARE_OTP_SIGNUP_CANARY_KEYS)[number];
+
+type ProductionSignupMailboxProvider = 'gmail' | 'cloudflare-email-routing';
 
 interface CanaryEnv {
   readonly [key: string]: string | undefined;
@@ -47,19 +60,46 @@ interface GmailMessage {
   readonly payload?: GmailMessagePart;
 }
 
+interface CloudflareOtpCheckResponse {
+  readonly otp?: string | null;
+  readonly code?: string | null;
+  readonly text?: string | null;
+  readonly receivedAtMs?: number | null;
+}
+
+function isProductionSignupMailboxProvider(
+  value: string | undefined
+): value is ProductionSignupMailboxProvider {
+  return value === 'gmail' || value === 'cloudflare-email-routing';
+}
+
+function isMissing(env: CanaryEnv, key: ProductionSignupCanaryKey): boolean {
+  const value = env[key];
+  return typeof value !== 'string' || value.trim().length === 0;
+}
+
 export function validateProductionSignupCanaryConfig(
   env: CanaryEnv
 ): ProductionSignupCanaryConfigResult {
-  const missing = PRODUCTION_SIGNUP_CANARY_KEYS.filter(key => {
-    const value = env[key];
-    return typeof value !== 'string' || value.trim().length === 0;
-  });
-  const lines = PRODUCTION_SIGNUP_CANARY_KEYS.map(
+  const commonMissing = PRODUCTION_SIGNUP_CANARY_KEYS.filter(key =>
+    isMissing(env, key)
+  );
+  const provider = env.E2E_PROD_MAILBOX_PROVIDER;
+  const providerKeys: readonly ProductionSignupCanaryKey[] =
+    provider === 'cloudflare-email-routing'
+      ? CLOUDFLARE_OTP_SIGNUP_CANARY_KEYS
+      : GMAIL_SIGNUP_CANARY_KEYS;
+  const providerMissing =
+    !provider || isProductionSignupMailboxProvider(provider)
+      ? providerKeys.filter(key => isMissing(env, key))
+      : [];
+  const missing = [...commonMissing, ...providerMissing];
+  const summaryKeys = [...PRODUCTION_SIGNUP_CANARY_KEYS, ...providerKeys];
+  const lines = summaryKeys.map(
     key => `${key}: ${missing.includes(key) ? 'MISSING' : 'SET'}`
   );
 
-  const provider = env.E2E_PROD_MAILBOX_PROVIDER;
-  if (provider && provider !== 'gmail') {
+  if (provider && !isProductionSignupMailboxProvider(provider)) {
     lines.push('E2E_PROD_MAILBOX_PROVIDER: INVALID');
     return {
       ok: false,
@@ -69,7 +109,7 @@ export function validateProductionSignupCanaryConfig(
   }
 
   return {
-    ok: missing.length === 0,
+    ok: missing.length === 0 && isProductionSignupMailboxProvider(provider),
     missing,
     summary: lines.join('\n'),
   };
@@ -199,7 +239,7 @@ async function getGmailMessage(
   );
 }
 
-export async function waitForProductionSignupOtp({
+async function waitForGmailProductionSignupOtp({
   email,
   env,
   startedAtMs,
@@ -235,6 +275,109 @@ export async function waitForProductionSignupOtp({
   }
 
   throw new Error(`Timed out waiting for production signup OTP for ${email}`);
+}
+
+async function fetchCloudflareOtpCheck({
+  email,
+  env,
+  startedAtMs,
+}: {
+  readonly email: string;
+  readonly env: CanaryEnv;
+  readonly startedAtMs: number;
+}): Promise<string | null> {
+  const url = env.E2E_PROD_OTP_CHECK_URL;
+  const token = env.E2E_PROD_OTP_CHECK_TOKEN;
+  if (!url || !token) {
+    throw new Error(
+      'Cloudflare OTP check is missing E2E_PROD_OTP_CHECK_URL or E2E_PROD_OTP_CHECK_TOKEN'
+    );
+  }
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15_000);
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email, sinceMs: startedAtMs }),
+      signal: controller.signal,
+    });
+
+    if (response.status === 404 || response.status === 204) {
+      return null;
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(
+        `Cloudflare OTP check failed: HTTP ${response.status} ${body}`
+      );
+    }
+
+    const payload = (await response.json()) as CloudflareOtpCheckResponse;
+    const rawCode = payload.otp ?? payload.code;
+    if (rawCode) return extractClerkOtp(rawCode) ?? rawCode;
+    if (payload.text) return extractClerkOtp(payload.text);
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function waitForCloudflareProductionSignupOtp({
+  email,
+  env,
+  startedAtMs,
+  timeoutMs = 90_000,
+}: {
+  readonly email: string;
+  readonly env: CanaryEnv;
+  readonly startedAtMs: number;
+  readonly timeoutMs?: number;
+}): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const code = await fetchCloudflareOtpCheck({ email, env, startedAtMs });
+    if (code) return code;
+    await new Promise(resolve => setTimeout(resolve, 3_000));
+  }
+
+  throw new Error(
+    `Timed out waiting for Cloudflare-routed production signup OTP for ${email}`
+  );
+}
+
+export async function waitForProductionSignupOtp({
+  email,
+  env,
+  startedAtMs,
+  timeoutMs = 90_000,
+}: {
+  readonly email: string;
+  readonly env: CanaryEnv;
+  readonly startedAtMs: number;
+  readonly timeoutMs?: number;
+}): Promise<string> {
+  if (env.E2E_PROD_MAILBOX_PROVIDER === 'cloudflare-email-routing') {
+    return waitForCloudflareProductionSignupOtp({
+      email,
+      env,
+      startedAtMs,
+      timeoutMs,
+    });
+  }
+
+  return waitForGmailProductionSignupOtp({
+    email,
+    env,
+    startedAtMs,
+    timeoutMs,
+  });
 }
 
 export async function fillOtpCode(page: Page, code: string) {

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -123,10 +123,11 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(syncIndex).toBeGreaterThanOrEqual(0);
     expect(pullIndex).toBeGreaterThan(syncIndex);
     expect(syncStep).toContain('required_vercel_env=(');
+    expect(syncStep).toContain('vercel env rm "$key" production');
     expect(syncStep).toContain('vercel env add "$key" production');
-    expect(syncStep).toContain('--force');
     expect(syncStep).toContain('--value "${!key}"');
     expect(syncStep).toContain('>/dev/null');
+    expect(syncStep).toContain('>/dev/null 2>&1 || true');
     expect(syncStep).toContain('set +x');
     expect(syncStep).toContain(
       'VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}'

--- a/apps/web/tests/unit/e2e/production-signup-canary.test.ts
+++ b/apps/web/tests/unit/e2e/production-signup-canary.test.ts
@@ -1,12 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   buildProductionSignupEmail,
   extractClerkOtp,
   isProductionSyntheticSignupEmail,
   validateProductionSignupCanaryConfig,
+  waitForProductionSignupOtp,
 } from '@/tests/e2e/utils/production-signup-canary';
 
 describe('production signup canary helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('builds plus-addressed synthetic signup emails from a dedicated mailbox', () => {
     expect(
       buildProductionSignupEmail('synthetic-signup@jov.ie', 'run_123')
@@ -60,6 +65,22 @@ describe('production signup canary helpers', () => {
     expect(result.missing).toEqual([]);
   });
 
+  it('supports a Cloudflare Email Routing OTP check without Gmail credentials', () => {
+    const result = validateProductionSignupCanaryConfig({
+      E2E_PROD_SIGNUP_EMAIL_BASE: 'synthetic-signup@e2e-jovie-signup.com',
+      E2E_PROD_SIGNUP_PASSWORD: 'secret-pass',
+      E2E_PROD_MAILBOX_PROVIDER: 'cloudflare-email-routing',
+      E2E_PROD_OTP_CHECK_URL: 'https://otp-check.example.workers.dev/latest',
+      E2E_PROD_OTP_CHECK_TOKEN: 'worker-token',
+      CLERK_SECRET_KEY: 'sk_live_123',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.missing).toEqual([]);
+    expect(result.summary).toContain('E2E_PROD_OTP_CHECK_URL: SET');
+    expect(result.summary).not.toContain('worker-token');
+  });
+
   it('reports missing keys without leaking configured values', () => {
     const result = validateProductionSignupCanaryConfig({
       E2E_PROD_SIGNUP_EMAIL_BASE: 'synthetic-signup@jov.ie',
@@ -70,12 +91,75 @@ describe('production signup canary helpers', () => {
     expect(result.ok).toBe(false);
     expect(result.missing).toEqual([
       'E2E_PROD_SIGNUP_PASSWORD',
+      'CLERK_SECRET_KEY',
       'E2E_PROD_MAILBOX_CLIENT_SECRET',
       'E2E_PROD_MAILBOX_REFRESH_TOKEN',
-      'CLERK_SECRET_KEY',
     ]);
     expect(result.summary).toContain('E2E_PROD_SIGNUP_PASSWORD: MISSING');
     expect(result.summary).toContain('E2E_PROD_MAILBOX_CLIENT_ID: SET');
     expect(result.summary).not.toContain('client-id');
+  });
+
+  it('reports missing Cloudflare OTP endpoint keys without requiring Gmail OAuth', () => {
+    const result = validateProductionSignupCanaryConfig({
+      E2E_PROD_SIGNUP_EMAIL_BASE: 'synthetic-signup@e2e-jovie-signup.com',
+      E2E_PROD_SIGNUP_PASSWORD: 'secret-pass',
+      E2E_PROD_MAILBOX_PROVIDER: 'cloudflare-email-routing',
+      CLERK_SECRET_KEY: 'sk_live_123',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.missing).toEqual([
+      'E2E_PROD_OTP_CHECK_URL',
+      'E2E_PROD_OTP_CHECK_TOKEN',
+    ]);
+    expect(result.summary).toContain('E2E_PROD_OTP_CHECK_URL: MISSING');
+    expect(result.summary).not.toContain('E2E_PROD_MAILBOX_CLIENT_ID');
+  });
+
+  it('polls the Cloudflare OTP check endpoint with a bearer token', async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        expect(init?.method).toBe('POST');
+        expect(init?.headers).toMatchObject({
+          Authorization: 'Bearer worker-token',
+          'Content-Type': 'application/json',
+        });
+        expect(JSON.parse(String(init?.body))).toEqual({
+          email: 'synthetic-signup+run-123@e2e-jovie-signup.com',
+          sinceMs: 123,
+        });
+
+        return new Response(
+          JSON.stringify({
+            text: 'Your Jovie verification code is 123456.',
+          }),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
+      }
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      waitForProductionSignupOtp({
+        email: 'synthetic-signup+run-123@e2e-jovie-signup.com',
+        env: {
+          E2E_PROD_MAILBOX_PROVIDER: 'cloudflare-email-routing',
+          E2E_PROD_OTP_CHECK_URL:
+            'https://otp-check.example.workers.dev/latest',
+          E2E_PROD_OTP_CHECK_TOKEN: 'worker-token',
+        },
+        startedAtMs: 123,
+        timeoutMs: 1000,
+      })
+    ).resolves.toBe('123456');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://otp-check.example.workers.dev/latest',
+      expect.any(Object)
+    );
   });
 });

--- a/docs/DOPPLER_SETUP.md
+++ b/docs/DOPPLER_SETUP.md
@@ -209,12 +209,26 @@ The production synthetic signup canary also requires these `prd` secrets:
 ```bash
 E2E_PROD_SIGNUP_EMAIL_BASE
 E2E_PROD_SIGNUP_PASSWORD
-E2E_PROD_MAILBOX_PROVIDER=gmail
+E2E_PROD_MAILBOX_PROVIDER=gmail # or cloudflare-email-routing
 E2E_PROD_MAILBOX_CLIENT_ID
 E2E_PROD_MAILBOX_CLIENT_SECRET
 E2E_PROD_MAILBOX_REFRESH_TOKEN
 E2E_PROD_MAILBOX_QUERY_FROM # optional Gmail query narrowing
 ```
+
+For the preferred no-inbox Cloudflare Email Routing setup, set:
+
+```bash
+E2E_PROD_SIGNUP_EMAIL_BASE=synthetic-signup@<dedicated-e2e-domain>
+E2E_PROD_MAILBOX_PROVIDER=cloudflare-email-routing
+E2E_PROD_OTP_CHECK_URL=https://<otp-worker-host>/latest
+E2E_PROD_OTP_CHECK_TOKEN=<shared bearer token>
+```
+
+The Cloudflare worker should receive the catch-all route for the dedicated e2e
+domain, store only recent Clerk OTP messages for `synthetic-signup+*@...`, and
+serve the latest code from `E2E_PROD_OTP_CHECK_URL` only when called with the
+bearer token.
 
 ### Migrating from .env Files
 

--- a/docs/SYNTHETIC_MONITORING.md
+++ b/docs/SYNTHETIC_MONITORING.md
@@ -15,7 +15,7 @@ The primary test covers the complete front-door journey:
 1. **`/start` onboarding chat** - verifies the first anonymous chat turn can POST without Turnstile configuration errors.
 2. **Homepage CTA** - verifies the primary front-door CTA is visible and routes to `/signup`.
 3. **Clerk sign-up** - creates a plus-addressed synthetic production user through the rendered UI.
-4. **Mailbox OTP** - reads the Clerk code from a dedicated Gmail mailbox and completes verification.
+4. **Mailbox OTP** - reads the Clerk code from a dedicated mailbox provider and completes verification.
 5. **Post-signup app state** - confirms the signed-in user can reach a non-empty usable app/onboarding surface.
 6. **Scoped cleanup** - deletes only the exact plus-addressed synthetic Clerk user created by that run.
 
@@ -97,6 +97,34 @@ E2E_PROD_MAILBOX_PROVIDER=gmail
 E2E_PROD_MAILBOX_CLIENT_ID=...
 E2E_PROD_MAILBOX_CLIENT_SECRET=...
 E2E_PROD_MAILBOX_REFRESH_TOKEN=...
+```
+
+Preferred no-inbox provider:
+
+```bash
+E2E_PROD_SIGNUP_EMAIL_BASE=synthetic-signup@<dedicated-e2e-domain>
+E2E_PROD_MAILBOX_PROVIDER=cloudflare-email-routing
+E2E_PROD_OTP_CHECK_URL=https://<otp-worker-host>/latest
+E2E_PROD_OTP_CHECK_TOKEN=...
+```
+
+Cloudflare Email Routing should be configured on a dedicated e2e domain with a
+catch-all route to an Email Worker. The Worker parses Clerk verification emails,
+stores only short-lived OTP state for the addressed run, and exposes a
+bearer-protected `POST` endpoint. The synthetic canary calls
+`E2E_PROD_OTP_CHECK_URL` with:
+
+```json
+{ "email": "synthetic-signup+run-id@<dedicated-e2e-domain>", "sinceMs": 1770000000000 }
+```
+
+The endpoint should return `404` or `204` while no fresh code is available, or
+`200` with one of:
+
+```json
+{ "otp": "123456" }
+{ "code": "123456" }
+{ "text": "Your verification code is 123456." }
 ```
 
 ### GitHub Secrets


### PR DESCRIPTION
## Summary
- replace Vercel production env values by removing the target before adding it, because `vercel env add --force` still failed on existing production vars
- add `cloudflare-email-routing` as the production signup OTP provider so the canary can use a dedicated catch-all Email Worker instead of Gmail OAuth
- document the no-inbox OTP endpoint contract and Doppler keys, including `.env.example` placeholders for the endpoint/token

## Verification
- `pnpm exec actionlint -shellcheck= .github/workflows/ci.yml`
- `pnpm biome check --write .github/workflows/ci.yml apps/web/tests/unit/ci/deploy-workflow.test.ts apps/web/tests/unit/e2e/production-signup-canary.test.ts apps/web/tests/e2e/utils/production-signup-canary.ts apps/web/lib/env-server-schema.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/e2e/production-signup-canary.test.ts`
- `.env.example` placeholder guard from CI workflow
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Incident Evidence
- Main deploy run `25997001308` failed in `deploy-staging` because Vercel rejected existing `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` despite `--force`.
- This PR makes the sync idempotent for existing canonical-project env vars.

## Cost Impact
- External API calls: existing synthetic canary polling only; Cloudflare OTP mode calls one internal/bearer-protected Worker endpoint during each scheduled signup canary run.
- Monthly projection: same schedule as the existing production synthetic workflow.
- Scaling factor: O(1) per synthetic run.
- Monthly cost estimate: expected to fit Cloudflare Workers/Email Routing free-tier style usage for one synthetic address, subject to account plan limits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Cloudflare Email Routing as an alternative to Gmail for E2E test mailbox and OTP checking functionality.

* **Documentation**
  * Updated setup and synthetic monitoring guides to document Cloudflare Email Routing configuration as a preferred alternative OTP retrieval method.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8994?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->