### PR TITLE
test(shell): guard drop date chip casing

### DIFF
--- a/apps/web/components/shell/DropDateChip.test.tsx
+++ b/apps/web/components/shell/DropDateChip.test.tsx
@@ -14,6 +14,15 @@ describe('DropDateChip', () => {
     expect(screen.queryByText('2193d ago')).not.toBeInTheDocument();
   });
 
+  it('preserves compact date casing instead of forcing uppercase labels', () => {
+    const { container } = render(<DropDateChip label='2y ago' tone='past' />);
+
+    const chip = container.firstElementChild as HTMLElement;
+    expect(screen.getByText('2y ago')).toBeInTheDocument();
+    expect(chip.className).not.toContain('uppercase');
+    expect(chip.className).not.toContain('tracking-[');
+  });
+
   it('lights up cyan when tone is soon', () => {
     const { container } = render(
       <DropDateChip label='Drops in 4 days' tone='soon' />


### PR DESCRIPTION
## Summary
- add a regression guard that compact release date chips preserve lowercase labels like 2y ago
- keep the existing multi-year day-count normalization covered so raw labels like 2193d ago stay collapsed

## Checks
- pnpm --filter web exec vitest run components/shell/DropDateChip.test.tsx
- pnpm biome check apps/web/components/shell/DropDateChip.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm turbo typecheck
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push