### PR TITLE
test(shell): guard search nav command palette

### DIFF
--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -1,7 +1,10 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { DashboardData } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
+import { OPEN_COMMAND_PALETTE_EVENT } from '@/components/organisms/command-palette-events';
 import { APP_ROUTES } from '@/constants/routes';
 import {
+  mockRouterPush,
   mockUseChatConversationsQuery,
   mockUsePathname,
   mockUsePlanGate,
@@ -70,6 +73,28 @@ describe('DashboardNav', () => {
     expect(
       getByRole('link', { name: 'New thread' }).getAttribute('aria-current')
     ).toBeNull();
+  });
+
+  it('opens the global command palette from Search instead of navigating', () => {
+    const onOpenPalette = vi.fn();
+    globalThis.addEventListener(OPEN_COMMAND_PALETTE_EVENT, onOpenPalette);
+
+    try {
+      const { getByRole, queryByRole } = renderDashboardNav({
+        renderFn: fastRender,
+        appFlags: { DESIGN_V1: true },
+      });
+
+      const searchButton = getByRole('button', { name: 'Search' });
+      expect(queryByRole('link', { name: 'Search' })).toBeNull();
+
+      fireEvent.click(searchButton);
+
+      expect(onOpenPalette).toHaveBeenCalledTimes(1);
+      expect(mockRouterPush).not.toHaveBeenCalled();
+    } finally {
+      globalThis.removeEventListener(OPEN_COMMAND_PALETTE_EVENT, onOpenPalette);
+    }
   });
 
   it('handles collapsed state', () => {


### PR DESCRIPTION
## Summary
- add a DashboardNav regression test for the shell Search item
- assert Search renders as a button, dispatches the global command-palette event, and does not navigate

## Checks
- pnpm --filter web exec vitest run tests/unit/dashboard/DashboardNav.test.tsx
- pnpm biome check apps/web/tests/unit/dashboard/DashboardNav.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm turbo typecheck
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push