### PR TITLE
fix(shell): normalize release plan empty surface

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/release-plan/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/release-plan/page.tsx
@@ -5,12 +5,17 @@ import { notFound } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import { ReleaseCalendar } from '@/components/jovie/release-calendar/ReleaseCalendar';
 import { ReleaseMomentDrawer } from '@/components/jovie/release-calendar/ReleaseMomentDrawer';
+import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
+import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { useAppFlag } from '@/lib/flags/client';
 import {
   type DemoMoment,
   EP_TRACKS,
   generateDemoPlan,
 } from '@/lib/release-planning/demo-plan';
+
+const RELEASE_PLAN_SUBTITLE =
+  "Four tracks. We'll generate the singles, remix, visualizer, acoustic, lyric video, merch drop, tour tie-in, media moment, and anniversary - Friday-locked.";
 
 export default function ReleasePlanPage() {
   const enabled = useAppFlag('RELEASE_PLAN_DEMO');
@@ -26,50 +31,46 @@ export default function ReleasePlanPage() {
   }
 
   return (
-    <div className='flex min-h-0 flex-1 flex-col gap-6 p-6'>
+    <div className='flex min-h-0 flex-1 flex-col gap-4 px-3 py-3 sm:px-4 sm:py-4'>
       {plan === null ? (
-        <section
+        <ContentSurfaceCard
+          as='section'
           data-testid='release-plan-empty-state'
-          className='flex flex-col gap-6 rounded-lg border border-(--linear-border-subtle) bg-(--linear-bg-surface-0) p-8'
+          className='overflow-hidden p-0'
         >
-          <div className='flex flex-col gap-1'>
-            <h2 className='text-lg font-semibold text-(--linear-text-primary)'>
-              Plan the next EP
-            </h2>
-            <p className='text-sm text-(--linear-text-secondary)'>
-              Four tracks. We&rsquo;ll generate the singles, remix, visualizer,
-              acoustic, lyric video, merch drop, tour tie-in, media moment, and
-              anniversary — Friday-locked.
-            </p>
-          </div>
+          <ContentSectionHeader
+            title='Plan the next EP'
+            subtitle={RELEASE_PLAN_SUBTITLE}
+            actions={
+              <Button
+                type='button'
+                data-testid='release-plan-generate-button'
+                onClick={() => setPlan(generateDemoPlan())}
+                size='sm'
+              >
+                Generate plan
+              </Button>
+            }
+            subtitleClassName='whitespace-normal'
+          />
 
-          <div className='grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4'>
+          <div className='grid grid-cols-1 gap-2.5 p-3 sm:grid-cols-2 sm:p-4 lg:grid-cols-4'>
             {EP_TRACKS.map((track, index) => (
               <div
                 key={track.slug}
                 data-testid={`release-plan-track-${index}`}
-                className='flex flex-col gap-1 rounded-md border border-(--linear-border-subtle) bg-(--linear-bg-surface-1) px-3 py-3'
+                className='flex flex-col gap-1 rounded-md border border-subtle bg-surface-0 px-3 py-3'
               >
-                <span className='text-[10px] font-semibold text-(--linear-text-tertiary)'>
+                <span className='text-[11px] font-caption text-tertiary-token'>
                   Track {index + 1}
                 </span>
-                <span className='text-sm font-medium text-(--linear-text-primary)'>
+                <span className='text-[13px] font-medium text-primary-token'>
                   {track.title}
                 </span>
               </div>
             ))}
           </div>
-
-          <Button
-            type='button'
-            data-testid='release-plan-generate-button'
-            onClick={() => setPlan(generateDemoPlan())}
-            size='sm'
-            className='self-start'
-          >
-            Generate plan
-          </Button>
-        </section>
+        </ContentSurfaceCard>
       ) : (
         <ReleaseCalendar
           plan={plan}

--- a/apps/web/tests/unit/app/release-plan-shell.test.ts
+++ b/apps/web/tests/unit/app/release-plan-shell.test.ts
@@ -42,4 +42,28 @@ describe('release plan shell contract', () => {
     expect(source).toContain('<Button');
     expect(source).not.toMatch(/(?:bg-fuchsia|hover:bg-fuchsia|bg-fuchsia-)/);
   });
+
+  it('uses shared app-shell surfaces and compact token typography', () => {
+    expect(RELEASE_PLAN_PAGE).toBeDefined();
+
+    if (!RELEASE_PLAN_PAGE) {
+      throw new Error('Could not find release plan page source');
+    }
+
+    const source = readFileSync(RELEASE_PLAN_PAGE, 'utf8');
+    expect(source).toContain(
+      "import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';"
+    );
+    expect(source).toContain(
+      "import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';"
+    );
+    expect(source).toContain('<ContentSurfaceCard');
+    expect(source).toContain('<ContentSectionHeader');
+    expect(source).toContain('font-caption text-tertiary-token');
+    expect(source).not.toContain('flex min-h-0 flex-1 flex-col gap-6 p-6');
+    expect(source).not.toContain('border-(--linear-border-subtle)');
+    expect(source).not.toContain('bg-(--linear-bg-surface-0)');
+    expect(source).not.toContain('text-(--linear-text-primary)');
+    expect(source).not.toContain('text-(--linear-text-secondary)');
+  });
 });


### PR DESCRIPTION
## Summary
- move the gated release-plan empty state onto shared ContentSurfaceCard and ContentSectionHeader primitives
- replace route-local shell padding/surface classes with compact app-shell token classes
- expand the release-plan shell contract guard for shared surfaces and compact typography

## Checks
- pnpm --filter web exec vitest run tests/unit/app/release-plan-shell.test.ts
- pnpm biome check apps/web/app/app/(shell)/dashboard/release-plan/page.tsx apps/web/tests/unit/app/release-plan-shell.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm turbo typecheck
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated release plan interface with refined component structure and improved layout consistency. Reorganized primary action button placement for better navigation.

* **Style**
  * Enhanced typography and spacing throughout the release plan page for improved visual consistency and readability.

* **Tests**
  * Added test assertions for UI component usage standards and styling compliance verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/8998?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->