### PR TITLE
test(shell): guard premium artwork fallback

### DIFF
--- a/apps/web/tests/unit/lib/artwork-fallback.test.ts
+++ b/apps/web/tests/unit/lib/artwork-fallback.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getArtworkFallbackAccentStyle,
+  getArtworkFallbackSurfaceStyle,
+} from '@/lib/artwork-fallback';
+
+describe('artwork fallback styles', () => {
+  it('uses restrained sleeve planes instead of blob or orb artwork', () => {
+    const style = getArtworkFallbackSurfaceStyle('All This Noise');
+    const background = String(style.background);
+
+    expect(background).toContain('linear-gradient');
+    expect(background).toContain('repeating-linear-gradient');
+    expect(background).toContain('--artwork-fallback-panel');
+    expect(background).not.toContain('radial-gradient');
+    expect(background).not.toContain('#');
+  });
+
+  it('keeps the accent as a subtle rule instead of a full-card gradient', () => {
+    const style = getArtworkFallbackAccentStyle('All This Noise');
+    const background = String(style.background);
+
+    expect(background).toContain('transparent');
+    expect(background).toContain('--artwork-fallback-accent');
+    expect(background).not.toContain('radial-gradient');
+  });
+});


### PR DESCRIPTION
## Summary
- add a regression guard for the shared artwork fallback sleeve style
- prevent radial/blob/orb placeholder backgrounds from returning
- keep the fallback accent constrained to a subtle rule

## Checks
- pnpm --filter web exec vitest run tests/unit/lib/artwork-fallback.test.ts
- pnpm biome check apps/web/tests/unit/lib/artwork-fallback.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm turbo typecheck
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push