### PR TITLE
test(commands): guard feedback command handoff

### DIFF
--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -92,6 +92,20 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
     expect(slashNavs).toHaveLength(0);
   });
 
+  it('keeps Feedback available on both command surfaces', () => {
+    for (const surface of ['chat-slash', 'cmdk'] as const) {
+      expect(commandsForSurface(surface)).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'skill',
+            id: 'submitFeedback',
+            label: 'Send feedback',
+          }),
+        ])
+      );
+    }
+  });
+
   it('renders nav, skill, and release sections when open', () => {
     render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);
     expect(screen.getByTestId('shared-command-palette')).toBeInTheDocument();
@@ -139,6 +153,17 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
     expect(skillRow).toBeDefined();
     fireEvent.mouseDown(skillRow!);
     expect(pushMock).toHaveBeenCalledWith('/app/chat?skill=generateAlbumArt');
+  });
+
+  it('routes Feedback from cmd+k through the same skill handoff', () => {
+    pushMock.mockClear();
+    render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);
+    const feedbackRow = screen
+      .getAllByRole('option')
+      .find(el => el.textContent?.includes('Share feedback'));
+    expect(feedbackRow).toBeDefined();
+    fireEvent.mouseDown(feedbackRow!);
+    expect(pushMock).toHaveBeenCalledWith('/app/chat?skill=submitFeedback');
   });
 
   it('routes a release entity commit to its tasks page', () => {


### PR DESCRIPTION
## Summary\n- keep Send feedback available on both chat slash and cmd+k surfaces\n- assert cmd+k routes the feedback skill through the canonical chat ?skill=submitFeedback handoff\n\n## Checks\n- pnpm --filter @jovie/web run test -- tests/unit/commands/SharedCommandPalette.test.tsx tests/unit/chat/SlashCommandMenu.keyboard.test.tsx\n- pnpm biome check --write apps/web/tests/unit/commands/SharedCommandPalette.test.tsx\n- pnpm --filter @jovie/web run typecheck -- --pretty false\n- pnpm turbo typecheck\n- pre-push hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for the feedback submission feature in the command palette across multiple surfaces, ensuring proper routing and functionality of the feedback command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9000?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->