### PR TITLE
fix(shell): normalize player card shell tokens

### DIFF
--- a/apps/web/components/shell/MobilePlayerCard.test.tsx
+++ b/apps/web/components/shell/MobilePlayerCard.test.tsx
@@ -22,7 +22,7 @@ describe('MobilePlayerCard', () => {
   });
 
   it('renders title + artist from the NowPlayingTrack shape', () => {
-    render(
+    const { container } = render(
       <MobilePlayerCard
         track={TRACK}
         isPlaying={false}
@@ -32,6 +32,11 @@ describe('MobilePlayerCard', () => {
     );
     expect(screen.getByText('Lost in the Light')).toBeInTheDocument();
     expect(screen.getByText('Bahamas')).toBeInTheDocument();
+    expect(container.innerHTML).toContain('border-(--linear-app-frame-seam)');
+    expect(container.innerHTML).toContain(
+      'bg-(--linear-app-content-surface)/70'
+    );
+    expect(container.innerHTML).not.toContain('border-white/10');
   });
 
   it('shows the play label when not playing and pause when playing', () => {

--- a/apps/web/components/shell/MobilePlayerCard.tsx
+++ b/apps/web/components/shell/MobilePlayerCard.tsx
@@ -52,7 +52,7 @@ export function MobilePlayerCard({
 
   return (
     <div className={cn('md:hidden fixed inset-x-3 z-40 bottom-3', className)}>
-      <div className='rounded-2xl px-2.5 py-2 flex items-center gap-2.5 backdrop-blur-2xl bg-(--linear-app-content-surface)/70 border border-white/10 shadow-[0_10px_40px_rgba(0,0,0,0.18)] relative overflow-hidden'>
+      <div className='rounded-2xl px-2.5 py-2 flex items-center gap-2.5 backdrop-blur-2xl bg-(--linear-app-content-surface)/70 border border-(--linear-app-frame-seam) shadow-[0_10px_40px_rgba(0,0,0,0.18)] relative overflow-hidden'>
         <span
           aria-hidden='true'
           className='absolute top-0 left-0 right-0 h-px bg-tertiary-token/30'
@@ -88,7 +88,7 @@ export function MobilePlayerCard({
         <button
           type='button'
           onClick={onPlay}
-          className='h-9 w-9 rounded-full grid place-items-center bg-primary text-on-primary shrink-0 transition-transform duration-150 ease-out active:scale-95'
+          className='h-9 w-9 rounded-full grid place-items-center bg-primary text-on-primary shrink-0 transition-transform duration-subtle ease-out active:scale-95'
           aria-label={isPlaying ? 'Pause' : 'Play'}
         >
           {isPlaying ? (

--- a/apps/web/components/shell/TabletPlayerCard.test.tsx
+++ b/apps/web/components/shell/TabletPlayerCard.test.tsx
@@ -23,7 +23,7 @@ describe('TabletPlayerCard', () => {
   });
 
   it('renders title, artist, and formatted timestamps', () => {
-    render(
+    const { container } = render(
       <TabletPlayerCard
         track={TRACK}
         isPlaying
@@ -36,6 +36,11 @@ describe('TabletPlayerCard', () => {
     expect(screen.getByText('Bahamas')).toBeInTheDocument();
     expect(screen.getByText('1:18')).toBeInTheDocument();
     expect(screen.getByText('3:33')).toBeInTheDocument();
+    expect(container.innerHTML).toContain('border-(--linear-app-frame-seam)');
+    expect(container.innerHTML).toContain(
+      'bg-(--linear-app-content-surface)/70'
+    );
+    expect(container.innerHTML).not.toContain('border-white/10');
   });
 
   it('coerces NaN duration to 0:00', () => {

--- a/apps/web/components/shell/TabletPlayerCard.tsx
+++ b/apps/web/components/shell/TabletPlayerCard.tsx
@@ -63,7 +63,7 @@ export function TabletPlayerCard({
         className
       )}
     >
-      <div className='rounded-2xl backdrop-blur-2xl bg-(--linear-app-content-surface)/70 border border-white/10 shadow-[0_10px_40px_rgba(0,0,0,0.18)] relative overflow-hidden'>
+      <div className='rounded-2xl backdrop-blur-2xl bg-(--linear-app-content-surface)/70 border border-(--linear-app-frame-seam) shadow-[0_10px_40px_rgba(0,0,0,0.18)] relative overflow-hidden'>
         <span
           aria-hidden='true'
           className='absolute top-0 left-0 right-0 h-px bg-tertiary-token/30'
@@ -102,7 +102,7 @@ export function TabletPlayerCard({
             <button
               type='button'
               onClick={onPrevious}
-              className='h-8 w-8 rounded grid place-items-center text-quaternary-token hover:text-primary-token transition-colors duration-150 ease-out'
+              className='h-8 w-8 rounded grid place-items-center text-quaternary-token hover:text-primary-token transition-colors duration-subtle ease-out'
               aria-label='Previous'
             >
               <SkipBack
@@ -114,7 +114,7 @@ export function TabletPlayerCard({
             <button
               type='button'
               onClick={onPlay}
-              className='h-9 w-9 rounded-full grid place-items-center bg-primary text-on-primary transition-transform duration-150 ease-out active:scale-95'
+              className='h-9 w-9 rounded-full grid place-items-center bg-primary text-on-primary transition-transform duration-subtle ease-out active:scale-95'
               aria-label={isPlaying ? 'Pause' : 'Play'}
             >
               {isPlaying ? (
@@ -134,7 +134,7 @@ export function TabletPlayerCard({
             <button
               type='button'
               onClick={onNext}
-              className='h-8 w-8 rounded grid place-items-center text-quaternary-token hover:text-primary-token transition-colors duration-150 ease-out'
+              className='h-8 w-8 rounded grid place-items-center text-quaternary-token hover:text-primary-token transition-colors duration-subtle ease-out'
               aria-label='Next'
             >
               <SkipForward


### PR DESCRIPTION
## Summary
- Replaced persistent mobile/tablet player card raw white borders with the app shell frame seam token.
- Kept the existing frosted shell content surface, sizing, fixed positioning, progress bars, and transport controls intact.
- Added focused source assertions for the player card shell token contract.

## Checks
- pnpm --filter web exec vitest run components/shell/MobilePlayerCard.test.tsx components/shell/TabletPlayerCard.test.tsx
- pnpm biome check --write apps/web/components/shell/MobilePlayerCard.tsx apps/web/components/shell/TabletPlayerCard.tsx apps/web/components/shell/MobilePlayerCard.test.tsx apps/web/components/shell/TabletPlayerCard.test.tsx
- pnpm eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored apps/web/components/shell/MobilePlayerCard.tsx apps/web/components/shell/TabletPlayerCard.tsx apps/web/components/shell/MobilePlayerCard.test.tsx apps/web/components/shell/TabletPlayerCard.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm turbo typecheck
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push