### PR TITLE
fix(releases): normalize promo downloads shell

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
@@ -7,10 +7,14 @@
  * Pro-only feature. Lists existing downloads with active toggle and delete.
  */
 
+import { buttonVariants } from '@jovie/ui';
 import { upload } from '@vercel/blob/client';
 import { useParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Icon } from '@/components/atoms/Icon';
+import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
+import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
+import { cn } from '@/lib/utils';
 
 interface PromoDownloadFile {
   id: string;
@@ -55,7 +59,10 @@ export default function PromoDownloadsPage() {
   const { releaseId } = useParams<{ releaseId: string }>();
   const [files, setFiles] = useState<PromoDownloadFile[]>([]);
   const [uploading, setUploading] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [listError, setListError] = useState<string | null>(null);
+  const [operationError, setOperationError] = useState<string | null>(null);
   const [loaded, setLoaded] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -65,14 +72,18 @@ export default function PromoDownloadsPage() {
       const res = await fetch(
         `/api/promo-downloads/confirm?releaseId=${releaseId}&list=true`
       );
-      if (res.ok) {
-        const data = await res.json();
-        if (Array.isArray(data.files)) {
-          setFiles(data.files);
-        }
+      if (!res.ok) {
+        setListError('Unable to load promo downloads right now.');
+        return;
       }
+
+      const data = await res.json();
+      if (Array.isArray(data.files)) {
+        setFiles(data.files);
+      }
+      setListError(null);
     } catch {
-      // Silently fail — files just won't load
+      setListError('Unable to load promo downloads right now.');
     } finally {
       setLoaded(true);
     }
@@ -85,11 +96,8 @@ export default function PromoDownloadsPage() {
     }
   }, [loaded, loadFiles]);
 
-  const handleFileSelect = useCallback(
-    async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
-      if (!file) return;
-
+  const uploadFile = useCallback(
+    async (file: File) => {
       if (!ALLOWED_TYPES.has(file.type)) {
         setUploadError(
           'Invalid file type. Supported: MP3, WAV, FLAC, AIFF, M4A.'
@@ -104,6 +112,7 @@ export default function PromoDownloadsPage() {
 
       setUploading(true);
       setUploadError(null);
+      setOperationError(null);
 
       try {
         // Client-side upload to Vercel Blob
@@ -130,14 +139,18 @@ export default function PromoDownloadsPage() {
 
         if (!res.ok) {
           const data = await res.json();
-          setUploadError(data.error ?? 'Upload failed');
+          setUploadError(data.error ?? 'Upload failed. Please try again.');
           return;
         }
 
         const data = await res.json();
         setFiles(prev => [...prev, data.promoDownload]);
       } catch (err) {
-        setUploadError(err instanceof Error ? err.message : 'Upload failed');
+        setUploadError(
+          err instanceof Error
+            ? err.message
+            : 'Upload failed. Please try again.'
+        );
       } finally {
         setUploading(false);
         // Reset file input
@@ -147,19 +160,45 @@ export default function PromoDownloadsPage() {
     [releaseId]
   );
 
+  const handleFileSelect = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      await uploadFile(file);
+    },
+    [uploadFile]
+  );
+
+  const handleDrop = useCallback(
+    async (e: React.DragEvent<HTMLButtonElement>) => {
+      e.preventDefault();
+      setIsDragging(false);
+      const file = e.dataTransfer.files?.[0];
+      if (!file || uploading) return;
+      await uploadFile(file);
+    },
+    [uploadFile, uploading]
+  );
+
   const handleToggleActive = useCallback(
     async (fileId: string, isActive: boolean) => {
       try {
-        await fetch(`/api/promo-downloads/${fileId}`, {
+        setOperationError(null);
+        const res = await fetch(`/api/promo-downloads/${fileId}`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ isActive }),
         });
+        if (!res.ok) {
+          throw new Error('Unable to update file visibility.');
+        }
         setFiles(prev =>
           prev.map(f => (f.id === fileId ? { ...f, isActive } : f))
         );
       } catch {
-        // Revert on error
+        setOperationError(
+          'Unable to update file visibility. Please try again.'
+        );
       }
     },
     []
@@ -167,67 +206,118 @@ export default function PromoDownloadsPage() {
 
   const handleDelete = useCallback(async (fileId: string) => {
     try {
-      await fetch(`/api/promo-downloads/${fileId}`, {
+      setOperationError(null);
+      const res = await fetch(`/api/promo-downloads/${fileId}`, {
         method: 'DELETE',
       });
+      if (!res.ok) {
+        throw new Error('Unable to delete file.');
+      }
       setFiles(prev => prev.filter(f => f.id !== fileId));
     } catch {
-      // Silently fail
+      setOperationError('Unable to delete this file. Please try again.');
     }
   }, []);
 
   return (
-    <div className='space-y-6'>
-      <div>
-        <h2 className='text-foreground text-sm font-semibold'>
-          Promo Downloads
-        </h2>
-        <p className='text-muted-foreground mt-1 text-xs'>
-          Upload audio files for email-gated downloads. Fans enter their email
-          to get the files.
-        </p>
-      </div>
-
-      {/* Upload area */}
-      <div className='rounded-xl border border-dashed border-white/10 p-6 text-center'>
-        <Icon
-          name='Upload'
-          className='text-muted-foreground mx-auto h-8 w-8'
-          aria-hidden='true'
+    <div className='flex min-h-0 flex-1 flex-col gap-4 px-3 py-3 sm:px-4 sm:py-4'>
+      <ContentSurfaceCard as='section' className='overflow-hidden p-0'>
+        <ContentSectionHeader
+          title='Promo downloads'
+          subtitle='Upload audio files for email-gated fan downloads.'
+          subtitleClassName='whitespace-normal'
         />
-        <p className='text-muted-foreground mt-2 text-sm'>
-          {uploading ? 'Uploading...' : 'Drop an audio file or click to upload'}
-        </p>
-        <p className='text-muted-foreground/60 mt-1 text-2xs'>
-          MP3, WAV, FLAC, AIFF, M4A — max 150 MB
-        </p>
+        <div className='p-3 sm:p-4'>
+          <button
+            type='button'
+            aria-disabled={uploading || undefined}
+            aria-label='Drop or choose a promo download audio file'
+            onClick={() => {
+              if (!uploading) {
+                fileInputRef.current?.click();
+              }
+            }}
+            onDragEnter={e => {
+              e.preventDefault();
+              setIsDragging(true);
+            }}
+            onDragOver={e => {
+              e.preventDefault();
+              setIsDragging(true);
+            }}
+            onDragLeave={e => {
+              e.preventDefault();
+              setIsDragging(false);
+            }}
+            onDrop={handleDrop}
+            className={cn(
+              'flex min-h-[154px] flex-col items-center justify-center rounded-lg border border-dashed border-(--linear-app-frame-seam) bg-surface-0 px-4 py-6 text-center transition-[background-color,border-color]',
+              isDragging &&
+                'border-(--linear-border-focus) bg-[color-mix(in_oklab,var(--linear-border-focus)_8%,var(--linear-bg-surface-0))]'
+            )}
+            data-testid='promo-download-dropzone'
+          >
+            <Icon
+              name='Upload'
+              className='h-8 w-8 text-tertiary-token'
+              aria-hidden='true'
+            />
+            <p className='mt-3 text-sm font-medium text-primary-token'>
+              {uploading ? 'Uploading audio...' : 'Drop an audio file here'}
+            </p>
+            <p className='mt-1 text-2xs text-tertiary-token'>
+              MP3, WAV, FLAC, AIFF, M4A. Max 150 MB.
+            </p>
+            <span
+              className={buttonVariants({
+                variant: 'secondary',
+                size: 'sm',
+                className: 'mt-3',
+              })}
+            >
+              Choose file
+            </span>
+          </button>
+        </div>
         <input
           ref={fileInputRef}
           type='file'
           accept='audio/mpeg,audio/wav,audio/flac,audio/aiff,audio/mp4,audio/x-m4a'
           onChange={handleFileSelect}
           disabled={uploading}
-          className='absolute inset-0 cursor-pointer opacity-0'
-          style={{ position: 'relative' }}
+          className='sr-only'
+          aria-label='Upload promo download audio file'
         />
         {uploadError && (
-          <p className='mt-2 text-xs text-red-400'>{uploadError}</p>
+          <p
+            className='border-t border-subtle px-3 py-2.5 text-xs text-error sm:px-4'
+            role='status'
+          >
+            {uploadError}
+          </p>
         )}
-      </div>
+      </ContentSurfaceCard>
+
+      {(listError || operationError) && (
+        <ContentSurfaceCard className='border-error/20 bg-error-subtle px-3 py-2.5 text-xs text-error'>
+          {operationError ?? listError}
+        </ContentSurfaceCard>
+      )}
 
       {/* File list */}
       {files.length > 0 ? (
         <div className='space-y-2'>
           {files.map(file => (
-            <div
+            <ContentSurfaceCard
               key={file.id}
-              className='flex items-center gap-3 rounded-lg bg-surface-1 px-3 py-2.5 ring-1 ring-inset ring-white/[0.06]'
+              surface='nested'
+              className='flex items-center gap-3 px-3 py-2.5'
             >
               <div className='min-w-0 flex-1'>
-                <p className='text-foreground truncate text-sm font-medium'>
+                <p className='truncate text-sm font-medium text-primary-token'>
                   {file.title}
                 </p>
-                <p className='text-muted-foreground text-2xs'>
+                <p className='text-2xs text-tertiary-token'>
                   {formatExtension(file.fileMimeType)}
                   {file.fileSizeBytes
                     ? ` · ${formatFileSize(file.fileSizeBytes)}`
@@ -239,11 +329,12 @@ export default function PromoDownloadsPage() {
               <button
                 type='button'
                 onClick={() => handleToggleActive(file.id, !file.isActive)}
-                className={`shrink-0 rounded-full px-2 py-0.5 text-2xs font-medium transition-colors ${
+                className={cn(
+                  'inline-flex h-7 shrink-0 items-center rounded-full border px-2.5 text-2xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
                   file.isActive
-                    ? 'bg-green-500/15 text-green-400'
-                    : 'bg-white/5 text-white/40'
-                }`}
+                    ? 'border-success/20 bg-success-subtle text-success hover:bg-success/10'
+                    : 'border-(--linear-app-frame-seam) bg-surface-0 text-tertiary-token hover:bg-surface-1 hover:text-secondary-token'
+                )}
               >
                 {file.isActive ? 'Active' : 'Hidden'}
               </button>
@@ -252,30 +343,30 @@ export default function PromoDownloadsPage() {
               <button
                 type='button'
                 onClick={() => handleDelete(file.id)}
-                className='text-muted-foreground hover:text-red-400 shrink-0 transition-colors'
+                className='inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-tertiary-token transition-colors hover:bg-error/10 hover:text-error focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
                 aria-label={`Delete ${file.title}`}
               >
                 <Icon name='Trash2' className='h-4 w-4' aria-hidden='true' />
               </button>
-            </div>
+            </ContentSurfaceCard>
           ))}
         </div>
       ) : (
         loaded && (
-          <div className='rounded-xl bg-surface-1 p-8 text-center'>
+          <ContentSurfaceCard className='flex flex-col items-center justify-center px-6 py-8 text-center'>
             <Icon
               name='Music'
-              className='text-muted-foreground mx-auto h-10 w-10'
+              className='h-8 w-8 text-tertiary-token'
               aria-hidden='true'
             />
-            <p className='text-muted-foreground mt-3 text-sm'>
-              No download files yet
+            <p className='mt-3 text-sm font-medium text-primary-token'>
+              No download files yet.
             </p>
-            <p className='text-muted-foreground/60 mt-1 text-xs'>
+            <p className='mt-1 max-w-sm text-xs text-tertiary-token'>
               Upload audio files to create an email-gated download page for this
               release.
             </p>
-          </div>
+          </ContentSurfaceCard>
         )
       )}
     </div>

--- a/apps/web/tests/unit/app/release-downloads-shell.test.ts
+++ b/apps/web/tests/unit/app/release-downloads-shell.test.ts
@@ -1,0 +1,66 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function findSourceFile(...candidates: string[]): string | undefined {
+  return candidates.find(candidate => existsSync(candidate));
+}
+
+const RELEASE_DOWNLOADS_PAGE = findSourceFile(
+  resolve(
+    process.cwd(),
+    'app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx'
+  ),
+  resolve(
+    process.cwd(),
+    'apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx'
+  )
+);
+
+function readReleaseDownloadsSource(): string {
+  expect(RELEASE_DOWNLOADS_PAGE).toBeDefined();
+
+  if (!RELEASE_DOWNLOADS_PAGE) {
+    throw new Error('Could not find release downloads page source');
+  }
+
+  return readFileSync(RELEASE_DOWNLOADS_PAGE, 'utf8');
+}
+
+describe('release downloads shell contract', () => {
+  it('uses shared shell surfaces and header chrome', () => {
+    const source = readReleaseDownloadsSource();
+
+    expect(source).toContain(
+      "import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';"
+    );
+    expect(source).toContain(
+      "import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';"
+    );
+    expect(source).toContain('<ContentSectionHeader');
+    expect(source).toContain('<ContentSurfaceCard');
+    expect(source).not.toContain("className='space-y-6'");
+    expect(source).not.toContain('border-white/10');
+    expect(source).not.toContain('ring-white');
+  });
+
+  it('keeps the upload target drag/drop capable without invisible overlay hacks', () => {
+    const source = readReleaseDownloadsSource();
+
+    expect(source).toContain("data-testid='promo-download-dropzone'");
+    expect(source).toContain('onDrop={handleDrop}');
+    expect(source).toContain("className='sr-only'");
+    expect(source).not.toContain("className='absolute inset-0");
+    expect(source).not.toContain("style={{ position: 'relative' }}");
+  });
+
+  it('surfaces network failures instead of silently swallowing them', () => {
+    const source = readReleaseDownloadsSource();
+
+    expect(source).toContain('Unable to load promo downloads right now.');
+    expect(source).toContain('Unable to update file visibility.');
+    expect(source).toContain('Unable to delete this file.');
+    expect(source).not.toContain('Silently fail');
+    expect(source).not.toContain('Revert on error');
+  });
+});


### PR DESCRIPTION
## Summary\n- move promo downloads onto shared app-shell card/header surfaces\n- replace the invisible upload overlay with an accessible drag/drop target plus choose-file action\n- surface load, update, delete, and upload failures with tokenized error states\n- add a source contract guard for shell tokens, drag/drop behavior, and non-silent failures\n\n## Checks\n- pnpm --filter @jovie/web run test -- tests/unit/app/release-downloads-shell.test.ts\n- pnpm biome check --write 'apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx' apps/web/tests/unit/app/release-downloads-shell.test.ts\n- pnpm --filter @jovie/web run typecheck -- --pretty false\n- pnpm turbo typecheck\n- gstack /design-review preamble + source pass\n- pre-push hook