### PR TITLE
fix(shell): tokenize entity popover surface

### DIFF
--- a/apps/web/components/shell/EntityPopover.test.tsx
+++ b/apps/web/components/shell/EntityPopover.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { act, fireEvent, screen } from '@testing-library/react';
 import type { ComponentProps } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -54,11 +56,12 @@ describe('EntityHoverLink', () => {
     advanceTimers(200);
 
     const tooltip = screen.getByRole('tooltip');
-    expect(tooltip).toHaveClass('rounded-lg', 'bg-surface-0', 'p-2.5');
+    expect(tooltip).toHaveClass('rounded-xl', 'bg-surface-1', 'p-0');
     expect(tooltip.className).not.toContain('bg-(--linear-bg-surface-0)');
     expect(tooltip.className).not.toContain(
       'rounded-(--linear-app-radius-menu)'
     );
+    expect(tooltip.firstElementChild).toHaveClass('p-3');
   });
 
   it('opens on focus and closes on Escape', () => {
@@ -74,5 +77,22 @@ describe('EntityHoverLink', () => {
     fireEvent.keyDown(trigger, { key: 'Escape' });
 
     expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+});
+
+describe('EntityPopover source contract', () => {
+  it('keeps floating surface chrome on the shared token', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'components/shell/EntityPopover.tsx'),
+      'utf8'
+    );
+
+    expect(source).toContain(
+      "import { LINEAR_SURFACE } from '@/components/tokens/linear-surface';"
+    );
+    expect(source).toContain('LINEAR_SURFACE.popover');
+    expect(source).not.toContain("'rounded-lg border border-default'");
+    expect(source).not.toContain("'bg-surface-0 text-primary-token");
+    expect(source).not.toContain("'p-2.5'");
   });
 });

--- a/apps/web/components/shell/EntityPopover.tsx
+++ b/apps/web/components/shell/EntityPopover.tsx
@@ -24,6 +24,7 @@ import {
   useState,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { LINEAR_SURFACE } from '@/components/tokens/linear-surface';
 import { cn } from '@/lib/utils';
 
 // ---------------------------------------------------------------------------
@@ -485,7 +486,7 @@ function EntityCard({ entity, onActivate }: EntityCardProps) {
       : null;
 
   return (
-    <div className='flex items-start gap-3'>
+    <div className='flex items-start gap-3.5'>
       <CardArtwork entity={entity} />
       <div className='min-w-0 flex-1'>
         <div className='mb-1 text-2xs font-caption text-tertiary-token'>
@@ -621,14 +622,15 @@ export function EntityPopover({
       }}
       className={cn(
         'z-[80]',
-        'rounded-lg border border-default',
-        'bg-surface-0 text-primary-token shadow-card-elevated',
-        'p-2.5',
+        LINEAR_SURFACE.popover,
+        'text-primary-token',
         'animate-in fade-in-0 zoom-in-95 duration-subtle ease-subtle',
         pos?.side === 'left' ? 'slide-in-from-right-1' : 'slide-in-from-left-1'
       )}
     >
-      <EntityCard entity={entity} onActivate={onActivate} />
+      <div className='p-3'>
+        <EntityCard entity={entity} onActivate={onActivate} />
+      </div>
     </div>,
     document.body
   );


### PR DESCRIPTION
## Summary\n- move EntityPopover floating chrome onto LINEAR_SURFACE.popover\n- keep padding inside the popover body so surface and content spacing are separately tokenized\n- add a test/source guard that prevents local rounded/bg/padding drift returning\n\n## Checks\n- pnpm --filter @jovie/web run test -- components/shell/EntityPopover.test.tsx\n- pnpm biome check --write apps/web/components/shell/EntityPopover.tsx apps/web/components/shell/EntityPopover.test.tsx\n- pnpm --filter @jovie/web run typecheck -- --pretty false\n- pnpm turbo typecheck\n- gstack /design-review preamble + source pass\n- pre-push hook