### PR TITLE
fix(shell): polish missing artwork fallback

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -342,7 +342,7 @@ function Artwork({
     >
       <ArtworkFallbackTile
         seed={asset.title}
-        iconClassName={size === 'row' ? 'h-4 w-4' : 'h-[18%] w-[18%]'}
+        iconClassName={size === 'row' ? 'h-4 w-4' : 'h-[36%] w-[36%]'}
       />
     </div>
   );

--- a/apps/web/components/atoms/ArtworkFallbackTile.tsx
+++ b/apps/web/components/atoms/ArtworkFallbackTile.tsx
@@ -27,26 +27,34 @@ export function ArtworkFallbackTile({
   return (
     <div
       className={cn(
-        'relative flex h-full w-full items-center justify-center overflow-hidden text-white/25',
+        'relative flex h-full w-full items-center justify-center overflow-hidden text-white/40',
         className
       )}
       data-artwork-fallback='true'
       style={getArtworkFallbackSurfaceStyle(seed)}
     >
+      <span
+        aria-hidden='true'
+        className='absolute inset-[8%] rounded-[7%] border border-white/[0.07] bg-[linear-gradient(135deg,rgba(255,255,255,0.09),rgba(255,255,255,0.012)_52%,rgba(0,0,0,0.13))] shadow-[inset_0_1px_0_rgba(255,255,255,0.08),inset_0_-24px_48px_rgba(0,0,0,0.14)]'
+        data-artwork-fallback-sleeve='true'
+      />
       <Disc3
         aria-hidden='true'
-        className={cn('relative z-10', iconClassName)}
+        className={cn(
+          'relative z-10 drop-shadow-[0_8px_28px_rgba(0,0,0,0.28)]',
+          iconClassName
+        )}
         data-artwork-fallback-icon='true'
-        strokeWidth={1.85}
+        strokeWidth={2.1}
       />
       <span
         aria-hidden='true'
-        className={cn('absolute inset-x-0 bottom-0', accentClassName)}
+        className={cn('absolute inset-x-0 bottom-0 z-10', accentClassName)}
         style={getArtworkFallbackAccentStyle(seed)}
       />
       <span
         aria-hidden='true'
-        className='absolute inset-[1px] rounded-[3px] border border-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.08)]'
+        className='absolute inset-[1px] rounded-[3px] border border-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.1)]'
       />
       {label ? <span className='sr-only'>{label}</span> : null}
     </div>

--- a/apps/web/lib/artwork-fallback.ts
+++ b/apps/web/lib/artwork-fallback.ts
@@ -13,25 +13,25 @@ function hashArtworkSeed(seed: string): number {
 
 const FALLBACK_PALETTES = [
   {
-    base: 'oklch(0.19 0.012 282)',
-    depth: 'oklch(0.1 0.008 282)',
-    panel: 'oklch(0.25 0.014 282)',
-    rule: 'rgba(255,255,255,0.065)',
-    accent: 'oklch(0.78 0.012 282 / 0.32)',
+    base: 'oklch(0.25 0.04 286)',
+    depth: 'oklch(0.12 0.024 286)',
+    panel: 'oklch(0.34 0.05 286)',
+    rule: 'rgba(255,255,255,0.09)',
+    accent: 'oklch(0.77 0.11 322 / 0.5)',
   },
   {
-    base: 'oklch(0.18 0.01 292)',
-    depth: 'oklch(0.095 0.007 292)',
-    panel: 'oklch(0.24 0.012 292)',
-    rule: 'rgba(255,255,255,0.058)',
-    accent: 'oklch(0.75 0.014 292 / 0.3)',
+    base: 'oklch(0.24 0.038 302)',
+    depth: 'oklch(0.11 0.022 302)',
+    panel: 'oklch(0.33 0.052 302)',
+    rule: 'rgba(255,255,255,0.082)',
+    accent: 'oklch(0.74 0.12 342 / 0.46)',
   },
   {
-    base: 'oklch(0.17 0.009 266)',
-    depth: 'oklch(0.09 0.006 266)',
-    panel: 'oklch(0.23 0.011 266)',
-    rule: 'rgba(255,255,255,0.052)',
-    accent: 'oklch(0.72 0.012 266 / 0.28)',
+    base: 'oklch(0.23 0.036 272)',
+    depth: 'oklch(0.105 0.022 272)',
+    panel: 'oklch(0.32 0.046 272)',
+    rule: 'rgba(255,255,255,0.078)',
+    accent: 'oklch(0.72 0.1 255 / 0.44)',
   },
 ] as const;
 
@@ -57,9 +57,10 @@ export function getArtworkFallbackSurfaceStyle(
     '--artwork-fallback-rule': palette.rule,
     '--artwork-fallback-accent': palette.accent,
     background: [
-      `linear-gradient(var(--artwork-fallback-angle), var(--artwork-fallback-panel), var(--artwork-fallback-depth) 62%, var(--artwork-fallback-base))`,
-      `linear-gradient(${angle + 86}deg, transparent 0 46%, var(--artwork-fallback-rule) 46% 47%, transparent 47% 100%)`,
-      'repeating-linear-gradient(90deg, rgba(255,255,255,0.026) 0 1px, transparent 1px 8px)',
+      `linear-gradient(var(--artwork-fallback-angle), color-mix(in oklab, var(--artwork-fallback-panel) 88%, white 12%), var(--artwork-fallback-depth) 58%, var(--artwork-fallback-base))`,
+      `linear-gradient(${angle + 92}deg, transparent 0 39%, var(--artwork-fallback-rule) 39% 40%, transparent 40% 100%)`,
+      'linear-gradient(180deg, rgba(255,255,255,0.08), transparent 34%, rgba(0,0,0,0.16) 100%)',
+      'repeating-linear-gradient(90deg, rgba(255,255,255,0.034) 0 1px, transparent 1px 10px)',
     ].join(', '),
   };
 }

--- a/apps/web/tests/unit/atoms/ReleaseArtworkThumb.test.tsx
+++ b/apps/web/tests/unit/atoms/ReleaseArtworkThumb.test.tsx
@@ -32,6 +32,9 @@ describe('ReleaseArtworkThumb', () => {
     expect(
       document.querySelector('[data-artwork-fallback-icon="true"]')
     ).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-artwork-fallback-sleeve="true"]')
+    ).toBeInTheDocument();
   });
 
   it('renders fallback icon when src is undefined', () => {

--- a/apps/web/tests/unit/lib/artwork-fallback.test.ts
+++ b/apps/web/tests/unit/lib/artwork-fallback.test.ts
@@ -11,7 +11,9 @@ describe('artwork fallback styles', () => {
 
     expect(background).toContain('linear-gradient');
     expect(background).toContain('repeating-linear-gradient');
+    expect(background).toContain('color-mix');
     expect(background).toContain('--artwork-fallback-panel');
+    expect(background).not.toMatch(/cyan|teal|green/u);
     expect(background).not.toContain('radial-gradient');
     expect(background).not.toContain('#');
   });


### PR DESCRIPTION
## Summary
- make missing artwork render as a deliberate dark purple/rose sleeve instead of a nearly black empty tile
- add a reusable fallback sleeve layer and increase card-scale icon contrast
- cover the fallback style and sleeve marker in focused unit tests

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/lib/artwork-fallback.test.ts tests/unit/atoms/ReleaseArtworkThumb.test.tsx components/shell/ArtworkThumb.test.tsx --config vitest.config.mts
- pnpm --filter @jovie/web exec biome check components/atoms/ArtworkFallbackTile.tsx lib/artwork-fallback.ts 'app/app/(shell)/library/LibrarySurface.tsx' tests/unit/lib/artwork-fallback.test.ts tests/unit/atoms/ReleaseArtworkThumb.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, biome lint
- screenshot: /tmp/jovie-artwork-fallback-premium-mobile-library-v2.png