### PR TITLE
feat(hermes-air): scaffold always-on Hermes orchestration node

### DIFF
--- a/.claude/rules/environment.md
+++ b/.claude/rules/environment.md
@@ -311,9 +311,10 @@ pnpm typecheck
 
 ## Workspace Topology
 
-This repo is the main code workspace.
+Three workspaces, each on a different machine, with a clear separation of concerns:
 
-- Default coding profile: `coder`
-- Ops / FounderOS workspace: `/Users/timwhite/conductor/workspaces/ops/raleigh`
-- Treat that ops repo as the source of truth for `company_state.md`, daily briefings, and task routing
-- Keep code changes in this repo; keep orchestration and company-state updates in the ops repo
+- **Houston** (this repo, MacBook Pro 32 GB) — the **code** workspace. Default profile: `coder`. Claude Code, Codex CLI, Conductor worktrees, and Hermes issue runners all live here. PRs originate here.
+- **Raleigh** (`/Users/timwhite/conductor/workspaces/ops/raleigh`) — the **ops / FounderOS** workspace. Source of truth for `company_state.md`, daily briefings, and task routing.
+- **Hermes-Air** (MacBook Air 16 GB, dedicated) — the **always-on orchestration** node. Runs `hermes serve`, gbrain (as server, exposed over Tailscale), and ops crons. Ingests brain dumps (Telegram + Voice Memos) and files Linear issues consumed by Houston's runner. **Does no coding.** See [`.claude/rules/hermes-air.md`](hermes-air.md) and [`docs/HERMES_AIR.md`](../../docs/HERMES_AIR.md).
+
+The contract between Hermes-Air and Houston is Linear issues. The contract between Hermes-Air and Raleigh is gbrain over Tailscale. Keep code changes in Houston; keep orchestration on the Air; keep company-state in Raleigh.

--- a/.claude/rules/hermes-air.md
+++ b/.claude/rules/hermes-air.md
@@ -1,0 +1,88 @@
+# Hermes on the MacBook Air (Always-On Orchestration Node)
+
+Operating contract for the always-on Hermes daemon running on the dedicated 16 GB MacBook Air. This file is the canonical reference; the operator runbook lives at `docs/HERMES_AIR.md`.
+
+## What Hermes-Air IS
+
+A dedicated orchestration node that:
+
+- Ingests brain dumps (Telegram typed messages + macOS Voice Memos transcripts via iCloud).
+- Persists every dump to gbrain (Air-as-server, PGLite backend, exposed over Tailscale as a remote-MCP HTTP server).
+- Segments dumps into `memory` (gbrain only), `issue` (Linear), and `task` (sub-agent dispatch).
+- Files Linear issues for engineering/product/ops work using the canonical follow-up shape from `.claude/rules/linear.md`. The Pro's existing Hermes issue runner picks them up automatically — Linear is the only contract between Air and Pro for engineering work.
+- Routes non-engineering tasks (calendar moves, Airtable updates, emails) to the right sub-agent which calls the appropriate MCP.
+- Runs deterministic cron jobs: PR-stuck monitor, CI failure triage, HUD refresh, daily briefing, cost monitor, deterministic-tracker (self-improvement), free-model health.
+
+## What Hermes-Air IS NOT
+
+- **NOT a code editor.** No Claude Code sessions, no `pnpm` builds, no Conductor worktrees, no `git` commits, no PR merges from this node.
+- **NOT a dispatcher for engineering work over `repository_dispatch`.** All engineering work flows through Linear issues. The Pro's existing runner consumes them.
+- **NOT a hot path for product traffic.** Vercel still runs all product crons. Hermes-Air owns ops crons only.
+- **NOT a single source of truth.** Linear, GitHub, Airtable, Calendar, and gbrain are durable systems of record; Hermes-Air is a router and watcher.
+
+## Hard Invariants
+
+| Invariant | Enforced by |
+|---|---|
+| Hermes-Air never edits code or merges PRs | Profile gate (`JOVIE_AGENT_PROFILE!=coder`); `orchestrator-boundary-check.sh` hook on any Claude Code session that ever runs on Air (should be zero) |
+| All engineering follow-ups go through Linear | `voice-memo-ingest.ts` and Telegram intake handlers both call the Linear API directly; no `repository_dispatch` from Air |
+| Inference cost is $0 unless user explicitly opts in | `free-model-router.ts` only selects `:free` OpenRouter variants; `cost-monitor.ts` kills non-watchdog jobs if any paid spend exceeds $0 in 24h |
+| gbrain stays local (Air-hosted, Tailscale-bound) | `gbrain serve` binds to the Tailscale interface only; no public exposure |
+| Voice memo transcripts never leave the Air | Stored only in gbrain PGLite; embedding API calls use free providers; no Supabase sync in v1 |
+| Single heavy-job semaphore | Ollama inference and `whisper-cli` cannot run concurrently; protected by `~/.hermes/state/heavy-job.lock` |
+| Telegram bot token never logged | `~/.hermes/.env` only; `bootstrap-air.sh` verifies `.env` is `chmod 600` and never copied into logs |
+
+## Sub-Agent Profiles
+
+Profiles are defined in `~/.hermes/config.yaml` (template at `scripts/hermes/config.air.template.yaml`). Each profile is a Hermes sub-agent with a scoped skill loadout and MCP allowlist. Profiles never escalate; the chief profile routes incoming intent to the right one.
+
+| Profile | Scope | MCPs allowed | Cannot do |
+|---|---|---|---|
+| `chief` | default routing, clarification questions, status replies | Linear, gbrain | edit code, spend money |
+| `cfo` | finance/spend/runway questions; cost monitor escalations | gbrain, Doppler (read-only), OpenRouter usage | edit code, move money, call Stripe |
+| `founder-os` | fundraising, GTM, company-state, warm network recall | Airtable (fundraising base), Gmail (read+draft, not send), Calendar, gbrain | edit code, send emails without confirmation |
+| `code-orchestrator` | PR triage, CI failure classification, file Linear repair issues | GitHub (read), Linear (write), gbrain | edit code, merge PRs, push branches |
+
+## Engineering Work Handoff (the only contract with the Pro)
+
+1. Voice memo or Telegram intake → classified as `issue` span.
+2. Hermes-Air files a Linear issue using the canonical follow-up shape from `.claude/rules/linear.md` (Source / Follow-up / Why it matters / Classification / Acceptance criteria). `Source` references the gbrain entry permalink.
+3. Issue is created with state `In Progress` (Hermes-Air is the agent claiming it per `.claude/rules/linear.md`).
+4. The Pro's existing Hermes issue runner discovers the issue and starts work — no Air-side push, no `repository_dispatch`, no SSH.
+5. PR opens on the Pro; merge transitions issue to `Done` via existing `linear-sync-on-merge.yml`.
+
+If the Air cannot file the Linear issue (network down, Linear outage), queue the intent in `~/.hermes/state/linear-queue.jsonl` and retry every 5 minutes. Telegram notifies the user only if backlog exceeds 5 entries.
+
+## Self-Improvement Loop
+
+`deterministic-tracker.ts` runs nightly:
+
+- Reads Hermes dispatch log (`~/.hermes/logs/dispatch.jsonl`).
+- Clusters intents by shape (similar input → similar action).
+- For any cluster firing ≥5 times in a 30-day window, files a Linear issue: "Replace LLM-driven path X with deterministic script."
+- The Pro's runner picks up these issues like any other and proposes a code change.
+
+This is how Hermes-Air keeps trending toward $0 model calls over time.
+
+## Cost Contract
+
+- **Hermes inference**: $0/mo. `free-model-router.ts` only selects `:free` OpenRouter models. Local Ollama Qwen 3 4B as fallback.
+- **Hermes embeddings**: $0/mo. Free OpenRouter embedding models or local `sentence-transformers` (~80 MB).
+- **Telegram bot**: $0/mo.
+- **Tailscale**: $0/mo (free tier, 2 devices under 100-device limit).
+- **gbrain**: $0/mo (local PGLite).
+- **Hard cap**: any paid spend >$0 in 24h triggers `cost-monitor.ts` to kill non-watchdog launchd jobs and notify Telegram. Resuming requires user confirmation.
+
+## Workspace Topology Reminder
+
+Per `CLAUDE.md` → Workspace Topology: this Air is the **third workspace** alongside Houston (this code repo) and Raleigh (ops/FounderOS). Ops orchestration runs on Air; code work runs on the Pro; FounderOS daily briefings sync via gbrain over Tailscale.
+
+## Related Files
+
+- `scripts/hermes/bootstrap-air.sh` — installer
+- `scripts/hermes/config.air.template.yaml` — Hermes config template
+- `scripts/hermes/launchd/*.plist` — launchd unit files
+- `scripts/hermes/jobs/*.ts` — cron handlers
+- `scripts/hermes/lib/free-model-router.ts` — cost-safe model selection
+- `docs/HERMES_AIR.md` — operator runbook
+- `.claude/plans/system-instruction-you-are-working-polished-gadget.md` — architecture decision record

--- a/.claude/rules/hermes-air.md
+++ b/.claude/rules/hermes-air.md
@@ -81,7 +81,7 @@ Per `CLAUDE.md` → Workspace Topology: this Air is the **third workspace** alon
 
 - `scripts/hermes/bootstrap-air.sh` — installer
 - `scripts/hermes/config.air.template.yaml` — Hermes config template
-- `scripts/hermes/launchd/*.plist` — launchd unit files
+- `scripts/hermes/launchd/*.plist.template` — launchd unit templates (bootstrap renders to `~/Library/LaunchAgents/`)
 - `scripts/hermes/jobs/*.ts` — cron handlers
 - `scripts/hermes/lib/free-model-router.ts` — cost-safe model selection
 - `docs/HERMES_AIR.md` — operator runbook

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ Read the file for the topic you're touching. More-local instructions override th
 | [`.claude/rules/linear.md`](.claude/rules/linear.md) | Issue gating, ownership contract |
 | [`.claude/rules/gstack.md`](.claude/rules/gstack.md) | Vendored toolkit, skill routing |
 | [`.claude/rules/swarm.md`](.claude/rules/swarm.md) | Ruflo-coordinated parallel swarms (pre-created worktrees, claims, ship recipe) |
+| [`.claude/rules/hermes-air.md`](.claude/rules/hermes-air.md) | Always-on Hermes node (MacBook Air): voice/Telegram intake, ops crons, Linear-as-bus contract |
 
 ## Skill routing
 

--- a/apps/web/lib/hermes/dispatch.ts
+++ b/apps/web/lib/hermes/dispatch.ts
@@ -50,7 +50,7 @@ export class HermesDispatchGitHubError extends Error {
 }
 
 const HermesDispatchRequestSchema = z.object({
-  source: z.enum(['github', 'linear', 'sentry', 'hermes', 'ci']),
+  source: z.enum(['github', 'linear', 'sentry', 'hermes', 'hermes-air', 'ci']),
   sourceId: z.string().trim().min(1).max(160).optional(),
   sourceUrl: z
     .union([z.string().trim().url(), z.literal(''), z.null()])

--- a/apps/web/lib/hud/ai-ops.ts
+++ b/apps/web/lib/hud/ai-ops.ts
@@ -358,6 +358,7 @@ export async function getHudAiOpsSummary(
         linear: sourceStatus(false, 0),
         sentry: sourceStatus(false, 0),
         hermes: sourceStatus(true, recommendations.length),
+        'hermes-air': sourceStatus(false, 0),
         ci: sourceStatus(false, 0),
       },
       errorMessage: 'GitHub HUD source not configured.',
@@ -437,6 +438,7 @@ export async function getHudAiOpsSummary(
       linear: sourceStatus(false, 0),
       sentry: sourceStatus(false, 0),
       hermes: sourceStatus(true, recommendations.length),
+      'hermes-air': sourceStatus(false, 0),
       ci: sourceStatus(
         true,
         runItems.length,

--- a/apps/web/types/ai-ops.ts
+++ b/apps/web/types/ai-ops.ts
@@ -3,6 +3,7 @@ export type HermesAiOpsSource =
   | 'linear'
   | 'sentry'
   | 'hermes'
+  | 'hermes-air'
   | 'ci';
 
 export type HermesAiOpsKind =

--- a/docs/AGENT_OS_ARCHITECTURE.md
+++ b/docs/AGENT_OS_ARCHITECTURE.md
@@ -122,3 +122,15 @@ Every implementation PR after this ADR must run the narrowest relevant local che
 5. Release conductor runs `/land-and-deploy` after CI and bot-review gates pass.
 
 Workflow, GitHub Actions, Hermes, and WDK PRs require `needs-human` if compile behavior, runner availability, or gate publication is ambiguous.
+
+## Hermes-Air Node (always-on orchestration)
+
+A dedicated 16 GB MacBook Air runs `hermes serve` 24/7 as the always-on orchestration node. It ingests brain dumps (Telegram + macOS Voice Memos via iCloud), persists them to gbrain (Air-hosted, exposed to the Pro over Tailscale), classifies actionable spans, and files Linear issues using the canonical follow-up shape. **Engineering work flows through Linear** — the Pro's existing Hermes issue runner picks up issues automatically; the Air never opens `repository_dispatch` events.
+
+- Operating contract: [`.claude/rules/hermes-air.md`](../.claude/rules/hermes-air.md)
+- Operator runbook: [`docs/HERMES_AIR.md`](./HERMES_AIR.md)
+- Bootstrap: `scripts/hermes/bootstrap-air.sh`
+- Cost target: $0/mo via OpenRouter free-model rotation + local Ollama Qwen 3 4B fallback. Sentinel kill switch trips on any paid spend.
+- `HermesAiOpsSource` includes the value `'hermes-air'` so the HUD attributes dispatches that originate from the Air separately from product/CI sources.
+
+Profiles on the Air (`chief`, `cfo`, `founder-os`, `code-orchestrator`) are Hermes sub-agents, not coding agents. They are gated by the same `JOVIE_AGENT_PROFILE` policy enforced in `.claude/hooks/orchestrator-boundary-check.sh`.

--- a/docs/HERMES_AIR.md
+++ b/docs/HERMES_AIR.md
@@ -55,7 +55,9 @@ In Telegram, chat with `@BotFather`:
 Save the token to Doppler:
 
 ```bash
-doppler secrets set --project jovie-web --config dev HERMES_TELEGRAM_BOT_TOKEN <token>
+TELEGRAM_TOKEN='paste-token-from-BotFather'
+doppler secrets set HERMES_TELEGRAM_BOT_TOKEN="$TELEGRAM_TOKEN" \
+  --project jovie-web --config dev
 ```
 
 Then send the bot any message from your iPhone so it can capture your chat ID. The bootstrap script will surface the chat ID and write it to `~/.hermes/state/telegram-chat-id`.

--- a/docs/HERMES_AIR.md
+++ b/docs/HERMES_AIR.md
@@ -1,0 +1,230 @@
+# Hermes-Air Operator Runbook
+
+Day-to-day operations for the always-on Hermes daemon running on the dedicated 16 GB MacBook Air. For the operating contract and invariants, read `.claude/rules/hermes-air.md`.
+
+## What This Machine Is
+
+A single-purpose orchestration node. It listens for brain dumps (Telegram + Voice Memos), persists them to gbrain, routes engineering work to Linear (the Pro's existing runner consumes it), and routes ops tasks to sub-agents. It does **zero coding**.
+
+## First-Time Setup
+
+```bash
+# On the Air, from a clone of this repo:
+./scripts/hermes/bootstrap-air.sh
+```
+
+The bootstrap script is idempotent. It will:
+
+1. Verify Node 22 / pnpm 9.15.4.
+2. Install (if missing): Hermes (`hermes-agent-rs`), gbrain CLI, Doppler, Tailscale, Ollama.
+3. Pull the Ollama fallback model (`qwen3:4b-q4_K_M`).
+4. Render `~/.hermes/config.yaml` from `scripts/hermes/config.air.template.yaml` + Doppler secrets.
+5. Render `~/.hermes/.env` from Doppler (and `chmod 600`).
+6. Install all launchd plists into `~/Library/LaunchAgents/` and bootstrap them.
+7. Pause for the manual GUI step (see below).
+8. Run a verification checklist and print results.
+
+## Manual GUI Steps Required
+
+These cannot be scripted; bootstrap will pause and instruct.
+
+### 1. Full Disk Access for Voice Memo watcher
+
+System Settings → Privacy & Security → Full Disk Access → enable the `tsx` binary at `~/.hermes/bin/tsx` (or whichever interpreter the launchd plist references).
+
+Without this, the voice-memo watcher cannot read `~/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/`.
+
+### 2. Tailscale auth
+
+`sudo tailscale up` and complete the browser login. Confirm the Pro is also in the tailnet:
+
+```bash
+tailscale status | grep -E "(macbook-pro|hermes)"
+```
+
+### 3. Telegram bot creation
+
+In Telegram, chat with `@BotFather`:
+
+```
+/newbot
+<name>: Hermes (jovie)
+<username>: jovie_hermes_bot   # must be unique, ends in _bot
+```
+
+Save the token to Doppler:
+
+```bash
+doppler secrets set --project jovie-web --config dev HERMES_TELEGRAM_BOT_TOKEN <token>
+```
+
+Then send the bot any message from your iPhone so it can capture your chat ID. The bootstrap script will surface the chat ID and write it to `~/.hermes/state/telegram-chat-id`.
+
+## Required Secrets (Doppler `jovie-web/dev`)
+
+| Secret | Purpose | Set by |
+|---|---|---|
+| `HERMES_TELEGRAM_BOT_TOKEN` | Telegram gateway authentication | manual (BotFather) |
+| `OPENROUTER_API_KEY` | Free-model router authentication | already provisioned |
+| `LINEAR_API_KEY` | Filing issues from voice/Telegram intake | already provisioned |
+| `GITHUB_TOKEN` | PR-stuck / CI-failure monitors | already provisioned |
+| `AIRTABLE_API_KEY` | Founder-OS profile (fundraising base) | already provisioned |
+| `SENTRY_AUTH_TOKEN` | Optional: ship Hermes errors to Sentry `hermes-air` env | already provisioned |
+
+The bootstrap script verifies every required secret is present before continuing.
+
+## Daily Operation
+
+Once installed, you should never need to interact with the Air directly. All control is through Telegram and Linear.
+
+| To do this | Do this |
+|---|---|
+| Brain-dump an idea | Telegram the bot, or record a Voice Memo on iPhone |
+| File a bug | Voice-memo "Hermes, file a Linear issue for ..." or type it |
+| Ask a strategic question | Telegram the bot; the chief profile routes |
+| Get a daily summary | Wait for the 07:00 briefing, or Telegram "brief me" |
+| Push back rate-limited | Hermes will respond with which model it used |
+
+## Status Checks
+
+```bash
+# All Hermes services
+launchctl list | grep co.jovie.hermes
+
+# Daemon health
+curl -sf http://localhost:7800/health && echo "OK" || echo "DOWN"
+
+# gbrain health
+gbrain doctor --fast --json | jq .health
+
+# Resident memory of all Hermes-related processes
+ps -axm -o rss,command | awk '/hermes|gbrain|ollama|whisper/ { sum+=$1; print } END { printf "TOTAL: %.1f MB\n", sum/1024 }'
+
+# Recent dispatch log
+tail -50 ~/.hermes/logs/dispatch.jsonl | jq .
+
+# Free-model rankings
+cat ~/.hermes/state/model-router-rankings.json | jq .
+```
+
+## Common Operations
+
+### Restart the daemon
+
+```bash
+launchctl kickstart -k gui/$(id -u)/co.jovie.hermes.daemon
+```
+
+### Stop all Hermes services (without disabling)
+
+```bash
+for s in $(launchctl list | grep co.jovie.hermes | awk '{print $3}'); do
+  launchctl bootout gui/$(id -u)/$s
+done
+```
+
+### Re-enable after stop
+
+```bash
+for plist in ~/Library/LaunchAgents/co.jovie.hermes.*.plist; do
+  launchctl bootstrap gui/$(id -u) "$plist"
+done
+```
+
+### Tail logs
+
+```bash
+# Daemon stdout
+tail -f ~/.hermes/logs/daemon.log
+
+# All cron job runs
+tail -f ~/.hermes/logs/jobs.jsonl
+
+# Voice memo ingest events
+tail -f ~/.hermes/logs/voice-memo.jsonl
+```
+
+### Re-render config from updated Doppler
+
+```bash
+./scripts/hermes/bootstrap-air.sh --reconfigure
+# then:
+launchctl kickstart -k gui/$(id -u)/co.jovie.hermes.daemon
+```
+
+## Recovery Procedures
+
+### Daemon won't start
+
+1. Check launchd error: `launchctl print gui/$(id -u)/co.jovie.hermes.daemon | grep -A 3 "last exit"`
+2. Tail daemon log: `tail -100 ~/.hermes/logs/daemon.log`
+3. Re-run bootstrap: `./scripts/hermes/bootstrap-air.sh` (idempotent)
+4. If config is corrupt: `mv ~/.hermes/config.yaml ~/.hermes/config.yaml.bak && ./scripts/hermes/bootstrap-air.sh --reconfigure`
+
+### Voice memo ingest stopped working
+
+1. Verify Full Disk Access in System Settings → Privacy & Security (re-grant if you upgraded macOS).
+2. Check the dedupe ledger isn't claiming the file: `grep <uuid> ~/.hermes/state/voice-memos-seen.json`.
+3. Run the handler manually with the file: `tsx scripts/hermes/jobs/voice-memo-ingest.ts --file <path>`.
+
+### Cost monitor killed everything
+
+This is intentional. Something escalated to a paid model. Investigate:
+
+```bash
+cat ~/.hermes/logs/cost.jsonl | jq 'select(.cost > 0)' | tail -20
+```
+
+Once you understand the cause, fix it (likely in `free-model-router.ts` rankings), then resume:
+
+```bash
+./scripts/hermes/bootstrap-air.sh --resume-after-cost-kill
+```
+
+### gbrain unreachable from Pro
+
+1. On Air: `tailscale ip -4` — confirm Tailscale IP.
+2. On Air: `lsof -i :<gbrain-port>` — confirm `gbrain serve` is listening.
+3. On Pro: update MCP config to point at `http://<air-tailscale-ip>:<port>`.
+
+### Air rebooted
+
+launchd handles this. All services come back automatically because `RunAtLoad: true` is set on every plist. Confirm with status checks above.
+
+## Resource Monitoring
+
+Target steady-state memory budget (per `.claude/plans/system-instruction-you-are-working-polished-gadget.md`):
+
+| Process | Resident (idle) |
+|---|---|
+| Hermes daemon | 300–600 MB |
+| gbrain serve (PGLite) | 300–600 MB |
+| ruflo MCP | <100 MB |
+| Ollama (model unloaded between calls) | ~0 MB idle |
+| macOS baseline | ~3 GB |
+| **Total idle target** | **~4–5 GB** |
+
+If steady-state exceeds 6 GB, investigate before adding new jobs.
+
+## Tearing Down (Hand This Machine Back)
+
+```bash
+./scripts/hermes/bootstrap-air.sh --uninstall
+```
+
+Removes all launchd plists, drops `~/.hermes/`, leaves Doppler and Tailscale alone.
+
+## Where State Lives
+
+| Path | What | Backup? |
+|---|---|---|
+| `~/.hermes/config.yaml` | Hermes daemon config (rendered from Doppler) | regenerable |
+| `~/.hermes/.env` | Secrets (chmod 600) | regenerable |
+| `~/.hermes/logs/` | All Hermes logs | rotate weekly via launchd |
+| `~/.hermes/state/voice-memos-seen.json` | Dedupe ledger | rebuildable (worst case: re-ingest 1 day) |
+| `~/.hermes/state/heavy-job.lock` | Semaphore for Ollama vs whisper | ephemeral |
+| `~/.hermes/state/model-router-rankings.json` | Free-model rankings | regenerable nightly |
+| `~/.gbrain/data/*.pglite` | gbrain durable store | **back up nightly** (rsync to Pro) |
+| `~/Library/LaunchAgents/co.jovie.hermes.*.plist` | launchd units | regenerable via bootstrap |
+
+The only thing worth backing up is gbrain. Everything else is regenerable from this repo + Doppler.

--- a/scripts/hermes/bootstrap-air.sh
+++ b/scripts/hermes/bootstrap-air.sh
@@ -219,18 +219,20 @@ log "Rendering ~/.hermes/.env"
 chmod 600 "${HERMES_HOME}/.env"
 ok "Secrets rendered (chmod 600)"
 
-# 11. Render ~/.hermes/config.yaml from template
+# 11. Render ~/.hermes/config.yaml from template.
+# Only path substitution; secrets stay as ${ENV} references that Hermes
+# expands at runtime from ~/.hermes/.env. This keeps secrets out of YAML on
+# disk and avoids sed-special-char corruption for keys containing | or &.
 log "Rendering ~/.hermes/config.yaml"
-LINEAR_API_KEY_VAL="$(doppler_get LINEAR_API_KEY)"
-AIRTABLE_API_KEY_VAL="$(doppler_get AIRTABLE_API_KEY)"
-sed \
-  -e "s|{{HOME}}|${HOME}|g" \
-  -e "s|{{LINEAR_API_KEY}}|${LINEAR_API_KEY_VAL}|g" \
-  -e "s|{{AIRTABLE_API_KEY}}|${AIRTABLE_API_KEY_VAL}|g" \
-  "${REPO_ROOT}/scripts/hermes/config.air.template.yaml" \
-  > "${HERMES_HOME}/config.yaml"
+python3 - "$REPO_ROOT" "$HOME" "${HERMES_HOME}/config.yaml" <<'PYEOF'
+import sys
+from pathlib import Path
+repo_root, home, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+tmpl = Path(repo_root, "scripts/hermes/config.air.template.yaml").read_text()
+Path(out_path).write_text(tmpl.replace("{{HOME}}", home))
+PYEOF
 chmod 600 "${HERMES_HOME}/config.yaml"
-ok "Hermes config rendered"
+ok "Hermes config rendered (secrets stay as env refs)"
 
 # 12. Render launchd plists
 log "Rendering launchd plists"
@@ -239,14 +241,27 @@ for tmpl in "${REPO_ROOT}/scripts/hermes/launchd/"*.plist.template; do
   [[ -f "$tmpl" ]] || continue
   label="$(basename "$tmpl" .plist.template)"
   out="${LAUNCH_AGENTS}/${label}.plist"
-  sed \
-    -e "s|{{HOME}}|${HOME}|g" \
-    -e "s|{{JOVIE_REPO}}|${REPO_ROOT}|g" \
-    -e "s|{{HERMES_BIN}}|${HERMES_BIN}|g" \
-    -e "s|{{GBRAIN_BIN}}|${GBRAIN_BIN}|g" \
-    -e "s|{{TSX_BIN}}|${TSX_BIN}|g" \
-    -e "s|{{TAILSCALE_IP}}|${TAILSCALE_IP}|g" \
-    "$tmpl" > "$out"
+  # Python substitution is safer than sed for paths that may contain |, &, /, etc.
+  HOME_V="$HOME" REPO_V="$REPO_ROOT" HERMES_V="$HERMES_BIN" \
+  GBRAIN_V="$GBRAIN_BIN" TSX_V="$TSX_BIN" TS_IP_V="$TAILSCALE_IP" \
+  python3 - "$tmpl" "$out" <<'PYEOF'
+import os, sys
+src, dst = sys.argv[1], sys.argv[2]
+mapping = {
+    "{{HOME}}": os.environ["HOME_V"],
+    "{{JOVIE_REPO}}": os.environ["REPO_V"],
+    "{{HERMES_BIN}}": os.environ["HERMES_V"],
+    "{{GBRAIN_BIN}}": os.environ["GBRAIN_V"],
+    "{{TSX_BIN}}": os.environ["TSX_V"],
+    "{{TAILSCALE_IP}}": os.environ["TS_IP_V"],
+}
+with open(src, "r") as f:
+    content = f.read()
+for k, v in mapping.items():
+    content = content.replace(k, v)
+with open(dst, "w") as f:
+    f.write(content)
+PYEOF
   ok "rendered $label"
 done
 

--- a/scripts/hermes/bootstrap-air.sh
+++ b/scripts/hermes/bootstrap-air.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+#
+# Hermes-Air bootstrap. Idempotent installer for the dedicated 16 GB Air.
+# Run on the Air, from a clone of this repo, with Doppler authed.
+#
+# Modes:
+#   ./scripts/hermes/bootstrap-air.sh                        # full install
+#   ./scripts/hermes/bootstrap-air.sh --reconfigure          # re-render configs only
+#   ./scripts/hermes/bootstrap-air.sh --uninstall            # remove launchd units + ~/.hermes
+#   ./scripts/hermes/bootstrap-air.sh --resume-after-cost-kill
+#
+# See:
+#   .claude/rules/hermes-air.md
+#   docs/HERMES_AIR.md
+#
+set -euo pipefail
+
+# ─── arg parsing ─────────────────────────────────────────────────────────────
+MODE="install"
+for arg in "$@"; do
+  case "$arg" in
+    --reconfigure) MODE="reconfigure" ;;
+    --uninstall) MODE="uninstall" ;;
+    --resume-after-cost-kill) MODE="resume" ;;
+    *) echo "Unknown arg: $arg"; exit 2 ;;
+  esac
+done
+
+# ─── constants ───────────────────────────────────────────────────────────────
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HERMES_HOME="${HOME}/.hermes"
+LAUNCH_AGENTS="${HOME}/Library/LaunchAgents"
+DOPPLER_PROJECT="jovie-web"
+DOPPLER_CONFIG="dev"
+
+REQUIRED_SECRETS=(
+  HERMES_TELEGRAM_BOT_TOKEN
+  OPENROUTER_API_KEY
+  LINEAR_API_KEY
+  GITHUB_TOKEN
+  AIRTABLE_API_KEY
+)
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+log()  { printf "\033[1;34m▶\033[0m %s\n" "$*"; }
+ok()   { printf "\033[1;32m✓\033[0m %s\n" "$*"; }
+warn() { printf "\033[1;33m!\033[0m %s\n" "$*" >&2; }
+die()  { printf "\033[1;31m✗\033[0m %s\n" "$*" >&2; exit 1; }
+ask()  { read -r -p "$1 " REPLY; }
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required tool: $1"
+}
+
+doppler_get() {
+  doppler secrets get "$1" --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" --plain 2>/dev/null || true
+}
+
+verify_macos_version() {
+  local v
+  v="$(sw_vers -productVersion 2>/dev/null || echo unknown)"
+  case "$v" in
+    15.*|26.*|27.*) ok "macOS $v supported";;
+    *) warn "macOS $v not validated; bootstrap will continue but voice memo transcript path may differ.";;
+  esac
+}
+
+verify_arch() {
+  local arch
+  arch="$(uname -m)"
+  if [[ "$arch" != "arm64" ]]; then
+    warn "arch=$arch (not Apple Silicon). Ollama + whisper will be slower; consider running this on the Air's M-series."
+  fi
+}
+
+# ─── teardown mode ───────────────────────────────────────────────────────────
+if [[ "$MODE" == "uninstall" ]]; then
+  log "Uninstalling Hermes-Air launchd units"
+  for plist in "${LAUNCH_AGENTS}"/co.jovie.hermes.*.plist; do
+    [[ -f "$plist" ]] || continue
+    label="$(basename "$plist" .plist)"
+    launchctl bootout "gui/$(id -u)/${label}" 2>/dev/null || true
+    rm -f "$plist"
+    ok "removed $label"
+  done
+  ask "Remove ~/.hermes/ entirely? [y/N]:"
+  if [[ "${REPLY:-N}" =~ ^[Yy]$ ]]; then
+    rm -rf "$HERMES_HOME"
+    ok "removed $HERMES_HOME"
+  fi
+  ok "Uninstall complete. Doppler and Tailscale left untouched."
+  exit 0
+fi
+
+# ─── resume mode ─────────────────────────────────────────────────────────────
+if [[ "$MODE" == "resume" ]]; then
+  log "Clearing cost kill switch"
+  rm -f "${HERMES_HOME}/state/cost-kill-switch"
+  for plist in "${LAUNCH_AGENTS}"/co.jovie.hermes.*.plist; do
+    [[ -f "$plist" ]] || continue
+    label="$(basename "$plist" .plist)"
+    launchctl bootstrap "gui/$(id -u)" "$plist" 2>/dev/null || \
+      launchctl kickstart -k "gui/$(id -u)/${label}" 2>/dev/null || true
+    ok "rebooted $label"
+  done
+  ok "Resume complete. Monitor cost.jsonl carefully."
+  exit 0
+fi
+
+# ─── full install / reconfigure ──────────────────────────────────────────────
+log "Hermes-Air bootstrap (mode=$MODE)"
+verify_macos_version
+verify_arch
+
+# 1. Required system tooling
+require_cmd doppler
+require_cmd gh
+require_cmd jq
+require_cmd sqlite3
+require_cmd curl
+
+# 2. Doppler auth + scope
+doppler setup --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" --no-interactive >/dev/null
+ok "Doppler scoped to ${DOPPLER_PROJECT}/${DOPPLER_CONFIG}"
+
+# 3. Verify required secrets
+MISSING=()
+for key in "${REQUIRED_SECRETS[@]}"; do
+  if [[ -z "$(doppler_get "$key")" ]]; then
+    MISSING+=("$key")
+  fi
+done
+if (( ${#MISSING[@]} > 0 )); then
+  warn "Missing Doppler secrets: ${MISSING[*]}"
+  warn "Set them with: doppler secrets set --project $DOPPLER_PROJECT --config $DOPPLER_CONFIG <KEY> <VALUE>"
+  if [[ "$MODE" != "reconfigure" ]]; then
+    die "Aborting; required secrets are missing."
+  fi
+fi
+
+if [[ "$MODE" == "install" ]]; then
+  # 4. Tailscale
+  if ! command -v tailscale >/dev/null 2>&1; then
+    log "Installing Tailscale"
+    brew install --cask tailscale-app 2>/dev/null || die "Install Tailscale manually from https://tailscale.com/download/mac"
+  fi
+  if ! tailscale status >/dev/null 2>&1; then
+    warn "Tailscale not signed in. Run \`sudo tailscale up\` and re-run bootstrap."
+    die "Tailscale required for Pro↔Air gbrain queries."
+  fi
+  TAILSCALE_IP="$(tailscale ip -4 | head -1)"
+  ok "Tailscale IP: $TAILSCALE_IP"
+
+  # 5. Hermes (hermes-agent-rs)
+  if ! command -v hermes >/dev/null 2>&1; then
+    log "Installing Hermes (hermes-agent-rs)"
+    curl -fsSL https://raw.githubusercontent.com/Lumio-Research/hermes-agent-rs/main/scripts/install.sh | bash
+  fi
+  HERMES_BIN="$(command -v hermes)"
+  ok "Hermes at $HERMES_BIN"
+
+  # 6. gbrain
+  if ! command -v gbrain >/dev/null 2>&1; then
+    log "Installing gbrain (see .claude/skills/setup-gbrain/SKILL.md for path 1: local PGLite)"
+    warn "Run /setup-gbrain in a Claude Code session to install, then re-run bootstrap."
+    die "gbrain not installed."
+  fi
+  GBRAIN_BIN="$(command -v gbrain)"
+  ok "gbrain at $GBRAIN_BIN"
+
+  # 7. Ollama (fallback model host)
+  if ! command -v ollama >/dev/null 2>&1; then
+    log "Installing Ollama"
+    brew install ollama 2>/dev/null || die "Install Ollama from https://ollama.com/download/mac"
+  fi
+  if ! pgrep -q ollama; then
+    log "Starting Ollama as a background service"
+    brew services start ollama 2>/dev/null || ollama serve >/dev/null 2>&1 &
+    sleep 3
+  fi
+  if ! ollama list 2>/dev/null | grep -q "qwen3:4b"; then
+    log "Pulling qwen3:4b-q4_K_M (~2.5 GB)"
+    ollama pull qwen3:4b-q4_K_M
+  fi
+  ok "Ollama ready with qwen3:4b-q4_K_M"
+
+  # 8. tsx for running the cron job scripts
+  if ! command -v tsx >/dev/null 2>&1; then
+    log "Installing tsx globally"
+    npm install -g tsx
+  fi
+  TSX_BIN="$(command -v tsx)"
+  ok "tsx at $TSX_BIN"
+else
+  # reconfigure: discover existing binaries
+  HERMES_BIN="$(command -v hermes || echo /usr/local/bin/hermes)"
+  GBRAIN_BIN="$(command -v gbrain || echo /usr/local/bin/gbrain)"
+  TSX_BIN="$(command -v tsx || echo /usr/local/bin/tsx)"
+  TAILSCALE_IP="$(tailscale ip -4 2>/dev/null | head -1 || echo 127.0.0.1)"
+fi
+
+# 9. Hermes home + state dirs
+mkdir -p \
+  "$HERMES_HOME" \
+  "$HERMES_HOME/logs" \
+  "$HERMES_HOME/logs/launchd" \
+  "$HERMES_HOME/state"
+chmod 700 "$HERMES_HOME"
+ok "Hermes home: $HERMES_HOME"
+
+# 10. Render ~/.hermes/.env from Doppler
+log "Rendering ~/.hermes/.env"
+{
+  for key in "${REQUIRED_SECRETS[@]}"; do
+    val="$(doppler_get "$key")"
+    [[ -n "$val" ]] && printf "%s=%s\n" "$key" "$val"
+  done
+} > "${HERMES_HOME}/.env"
+chmod 600 "${HERMES_HOME}/.env"
+ok "Secrets rendered (chmod 600)"
+
+# 11. Render ~/.hermes/config.yaml from template
+log "Rendering ~/.hermes/config.yaml"
+LINEAR_API_KEY_VAL="$(doppler_get LINEAR_API_KEY)"
+AIRTABLE_API_KEY_VAL="$(doppler_get AIRTABLE_API_KEY)"
+sed \
+  -e "s|{{HOME}}|${HOME}|g" \
+  -e "s|{{LINEAR_API_KEY}}|${LINEAR_API_KEY_VAL}|g" \
+  -e "s|{{AIRTABLE_API_KEY}}|${AIRTABLE_API_KEY_VAL}|g" \
+  "${REPO_ROOT}/scripts/hermes/config.air.template.yaml" \
+  > "${HERMES_HOME}/config.yaml"
+chmod 600 "${HERMES_HOME}/config.yaml"
+ok "Hermes config rendered"
+
+# 12. Render launchd plists
+log "Rendering launchd plists"
+mkdir -p "$LAUNCH_AGENTS"
+for tmpl in "${REPO_ROOT}/scripts/hermes/launchd/"*.plist.template; do
+  [[ -f "$tmpl" ]] || continue
+  label="$(basename "$tmpl" .plist.template)"
+  out="${LAUNCH_AGENTS}/${label}.plist"
+  sed \
+    -e "s|{{HOME}}|${HOME}|g" \
+    -e "s|{{JOVIE_REPO}}|${REPO_ROOT}|g" \
+    -e "s|{{HERMES_BIN}}|${HERMES_BIN}|g" \
+    -e "s|{{GBRAIN_BIN}}|${GBRAIN_BIN}|g" \
+    -e "s|{{TSX_BIN}}|${TSX_BIN}|g" \
+    -e "s|{{TAILSCALE_IP}}|${TAILSCALE_IP}|g" \
+    "$tmpl" > "$out"
+  ok "rendered $label"
+done
+
+if [[ "$MODE" == "reconfigure" ]]; then
+  log "Reconfigure complete. Restart services with:"
+  echo "  launchctl kickstart -k gui/\$(id -u)/co.jovie.hermes.daemon"
+  exit 0
+fi
+
+# 13. Bootstrap launchd units
+log "Bootstrapping launchd units"
+for plist in "${LAUNCH_AGENTS}"/co.jovie.hermes.*.plist; do
+  [[ -f "$plist" ]] || continue
+  label="$(basename "$plist" .plist)"
+  # bootout first in case it's already loaded (idempotent re-run).
+  launchctl bootout "gui/$(id -u)/${label}" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$plist"
+  ok "bootstrapped $label"
+done
+
+# 14. Manual GUI step: Full Disk Access
+warn ""
+warn "MANUAL STEP REQUIRED:"
+warn "  Open System Settings → Privacy & Security → Full Disk Access"
+warn "  Add: ${TSX_BIN}"
+warn "  This lets voice-memo-watcher read ~/Library/Group Containers/group.com.apple.VoiceMemos.shared/"
+warn ""
+ask "Press Enter once you've granted Full Disk Access:"
+
+# 15. Verification
+log "Verifying"
+
+VERIFY_OK=true
+
+if launchctl list | grep -q co.jovie.hermes.daemon; then
+  ok "daemon registered"
+else
+  warn "daemon not registered"; VERIFY_OK=false
+fi
+
+if curl -fsS --max-time 5 http://localhost:7800/health >/dev/null; then
+  ok "daemon /health responds"
+else
+  warn "daemon /health does not respond yet (may need ~10s)"
+fi
+
+if curl -fsS --max-time 5 "http://127.0.0.1:7801/health" >/dev/null 2>&1; then
+  ok "gbrain server responds locally"
+else
+  warn "gbrain server not responding on :7801"
+fi
+
+if [[ -f "${HERMES_HOME}/.env" ]] && [[ "$(stat -f '%Lp' "${HERMES_HOME}/.env")" == "600" ]]; then
+  ok "~/.hermes/.env has correct permissions (600)"
+else
+  warn "~/.hermes/.env permissions wrong"; VERIFY_OK=false
+fi
+
+if [[ -z "$(doppler_get HERMES_TELEGRAM_BOT_TOKEN)" ]]; then
+  warn "HERMES_TELEGRAM_BOT_TOKEN missing from Doppler — Telegram gateway disabled"
+fi
+
+echo
+if $VERIFY_OK; then
+  ok "Hermes-Air bootstrap complete."
+  log "Send your Telegram bot a test message to capture the chat ID:"
+  echo "  tail -f ${HERMES_HOME}/logs/daemon.log"
+  echo
+  log "Next: configure the Pro to query gbrain at http://${TAILSCALE_IP}:7801"
+  log "See docs/HERMES_AIR.md for ongoing ops."
+else
+  die "Bootstrap completed with warnings; see above."
+fi

--- a/scripts/hermes/config.air.template.yaml
+++ b/scripts/hermes/config.air.template.yaml
@@ -61,7 +61,8 @@ mcp:
       transport: http
       url: https://mcp.linear.app/mcp
       headers:
-        Authorization: "Bearer {{LINEAR_API_KEY}}"
+        # Hermes expands ${ENV} from ~/.hermes/.env at runtime.
+        Authorization: "Bearer ${LINEAR_API_KEY}"
     - name: airtable
       transport: stdio
       command: npx
@@ -69,7 +70,7 @@ mcp:
         - "-y"
         - "airtable-mcp-server"
       env:
-        AIRTABLE_API_KEY: "{{AIRTABLE_API_KEY}}"
+        AIRTABLE_API_KEY: "${AIRTABLE_API_KEY}"
     - name: gmail
       transport: http
       url: https://gmail-mcp.jov.ie/mcp

--- a/scripts/hermes/config.air.template.yaml
+++ b/scripts/hermes/config.air.template.yaml
@@ -1,0 +1,142 @@
+# Hermes-Air configuration template.
+#
+# Rendered by scripts/hermes/bootstrap-air.sh with {{TOKEN}} substitution.
+# DO NOT commit the rendered output; secrets land at ~/.hermes/.env (chmod 600).
+#
+# See:
+# - .claude/rules/hermes-air.md (operating contract)
+# - docs/HERMES_AIR.md (operator runbook)
+
+server:
+  host: 127.0.0.1
+  port: 7800
+  log_level: info
+  log_dir: "{{HOME}}/.hermes/logs"
+
+system:
+  # Hermes is the only thing this Air does. These limits enforce the
+  # 16 GB RAM budget documented in the plan.
+  max_memory_mb: 800
+  max_concurrent_subagents: 2
+  gateway_rate_limit_per_minute: 30
+
+models:
+  # Primary: OpenRouter free-model rotation. The free-model-router.ts script
+  # is what cron jobs use directly; the daemon points at a single known-good
+  # free model for inbound message handling.
+  primary:
+    provider: openrouter
+    base_url: https://openrouter.ai/api/v1
+    api_key_env: OPENROUTER_API_KEY
+    model: deepseek/deepseek-r1:free
+    extra_headers:
+      HTTP-Referer: https://jov.ie
+      X-Title: "Jovie Hermes (Air)"
+
+  # Fallback: local Ollama. Loaded only when OpenRouter exhausts.
+  fallback:
+    provider: openai_compatible
+    base_url: http://localhost:11434/v1
+    model: qwen3:4b-q4_K_M
+
+gateways:
+  telegram:
+    enabled: true
+    bot_token_env: HERMES_TELEGRAM_BOT_TOKEN
+    # The chat ID is captured by bootstrap-air.sh after the user sends the
+    # bot its first message; written to ~/.hermes/state/telegram-chat-id.
+    chat_id_file: "{{HOME}}/.hermes/state/telegram-chat-id"
+
+memory:
+  provider: mcp
+  mcp_server: gbrain
+  remote_url: http://127.0.0.1:7801
+
+mcp:
+  servers:
+    - name: gbrain
+      transport: http
+      url: http://127.0.0.1:7801
+    - name: linear
+      transport: http
+      url: https://mcp.linear.app/mcp
+      headers:
+        Authorization: "Bearer {{LINEAR_API_KEY}}"
+    - name: airtable
+      transport: stdio
+      command: npx
+      args:
+        - "-y"
+        - "airtable-mcp-server"
+      env:
+        AIRTABLE_API_KEY: "{{AIRTABLE_API_KEY}}"
+    - name: gmail
+      transport: http
+      url: https://gmail-mcp.jov.ie/mcp
+    - name: gcal
+      transport: http
+      url: https://calendar-mcp.jov.ie/mcp
+
+sub_agents:
+  - name: chief
+    description: Default router. Clarifies, files Linear issues, sends status replies.
+    mcp_allowlist: [gbrain, linear]
+    skills:
+      - intake_route
+      - file_linear_issue
+      - reply_status
+    cannot:
+      - edit_code
+      - spend_money
+      - send_email_without_confirmation
+
+  - name: cfo
+    description: Finance, spend, runway, cost monitor escalations.
+    mcp_allowlist: [gbrain]
+    skills:
+      - read_doppler_usage
+      - cost_summary
+      - runway_projection
+    cannot:
+      - edit_code
+      - move_money
+      - call_stripe
+
+  - name: founder-os
+    description: Fundraising, GTM, company state, warm-network recall.
+    mcp_allowlist: [gbrain, airtable, gmail, gcal]
+    skills:
+      - fundraising_airtable
+      - warm_network_recall
+      - meeting_reschedule
+      - draft_email
+    cannot:
+      - edit_code
+      - send_email_without_confirmation
+
+  - name: code-orchestrator
+    description: PR triage, CI classification, file Linear repair issues.
+    mcp_allowlist: [gbrain, linear]
+    skills:
+      - pr_triage
+      - ci_classify
+      - file_linear_repair_issue
+    cannot:
+      - edit_code
+      - merge_pr
+      - push_branch
+
+routing:
+  default: chief
+  intent_map:
+    finance: cfo
+    spend: cfo
+    runway: cfo
+    fundraising: founder-os
+    investor: founder-os
+    pitch: founder-os
+    calendar: founder-os
+    airtable: founder-os
+    pr: code-orchestrator
+    ci: code-orchestrator
+    deploy: code-orchestrator

--- a/scripts/hermes/jobs/ci-failure-monitor.ts
+++ b/scripts/hermes/jobs/ci-failure-monitor.ts
@@ -85,9 +85,15 @@ function logsForRun(runId: number): string {
 
 function classifyAgainstKnown(
   log: string,
+  workflowName: string,
   flakes: ReadonlyArray<KnownFlake>
 ): KnownFlake | null {
   for (const flake of flakes) {
+    // A flake with workflow=='*' matches any workflow; otherwise the
+    // workflow name must match exactly. This prevents an Audio test flake
+    // signature from silencing an unrelated Build failure that happens to
+    // contain similar text.
+    if (flake.workflow !== '*' && flake.workflow !== workflowName) continue;
     try {
       if (new RegExp(flake.pattern, 'i').test(log)) return flake;
     } catch {
@@ -102,7 +108,7 @@ async function processFailure(
   flakes: ReadonlyArray<KnownFlake>
 ): Promise<void> {
   const log = logsForRun(run.databaseId);
-  const known = classifyAgainstKnown(log, flakes);
+  const known = classifyAgainstKnown(log, run.workflowName, flakes);
 
   if (known) {
     logJobEvent({

--- a/scripts/hermes/jobs/ci-failure-monitor.ts
+++ b/scripts/hermes/jobs/ci-failure-monitor.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env tsx
+/**
+ * CI Failure Monitor — Hermes-Air
+ *
+ * Watches recent failed workflow runs on main. Classifies against
+ * `known-flakes.json` for known flaky patterns; files Linear issues for
+ * recurring unknowns.
+ *
+ * Deterministic-first: only escalates to LLM when no signature matches.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { buildFollowUpBody, fileIssue } from '../lib/linear-client';
+
+const JOB = 'ci-failure-monitor';
+
+const __filename = fileURLToPath(import.meta.url);
+const KNOWN_FLAKES_PATH = join(dirname(__filename), 'known-flakes.json');
+
+interface KnownFlake {
+  readonly id: string;
+  readonly workflow: string;
+  readonly pattern: string;
+  readonly note: string;
+}
+
+interface WorkflowRun {
+  readonly databaseId: number;
+  readonly displayTitle: string;
+  readonly url: string;
+  readonly workflowName: string;
+  readonly conclusion: string;
+  readonly headBranch: string;
+  readonly createdAt: string;
+}
+
+function loadKnownFlakes(): ReadonlyArray<KnownFlake> {
+  if (!existsSync(KNOWN_FLAKES_PATH)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(KNOWN_FLAKES_PATH, 'utf8')) as {
+      readonly flakes: ReadonlyArray<KnownFlake>;
+    };
+    return parsed.flakes;
+  } catch {
+    return [];
+  }
+}
+
+function listRecentFailures(): ReadonlyArray<WorkflowRun> {
+  const json = execFileSync(
+    'gh',
+    [
+      'run',
+      'list',
+      '--limit',
+      '30',
+      '--branch',
+      'main',
+      '--status',
+      'failure',
+      '--json',
+      'databaseId,displayTitle,url,workflowName,conclusion,headBranch,createdAt',
+    ],
+    { encoding: 'utf8', timeout: 30_000 }
+  );
+  return JSON.parse(json) as ReadonlyArray<WorkflowRun>;
+}
+
+function logsForRun(runId: number): string {
+  try {
+    return execFileSync('gh', ['run', 'view', String(runId), '--log-failed'], {
+      encoding: 'utf8',
+      timeout: 60_000,
+      maxBuffer: 5 * 1024 * 1024,
+    });
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+function classifyAgainstKnown(
+  log: string,
+  flakes: ReadonlyArray<KnownFlake>
+): KnownFlake | null {
+  for (const flake of flakes) {
+    try {
+      if (new RegExp(flake.pattern, 'i').test(log)) return flake;
+    } catch {
+      // bad regex in known-flakes.json — skip
+    }
+  }
+  return null;
+}
+
+async function processFailure(
+  run: WorkflowRun,
+  flakes: ReadonlyArray<KnownFlake>
+): Promise<void> {
+  const log = logsForRun(run.databaseId);
+  const known = classifyAgainstKnown(log, flakes);
+
+  if (known) {
+    logJobEvent({
+      job: JOB,
+      event: 'known_flake',
+      runId: run.databaseId,
+      flakeId: known.id,
+    });
+    return;
+  }
+
+  // Unknown failure — file Linear issue.
+  const filed = await fileIssue({
+    title: `CI failure: ${run.workflowName} on main (run ${run.databaseId})`,
+    description: buildFollowUpBody({
+      source: `ci-failure-monitor`,
+      sourceUrl: run.url,
+      followUp: `Workflow "${run.workflowName}" failed on main at ${run.createdAt}. Title: ${run.displayTitle}. Investigate root cause; if it's a known flake, add a signature to scripts/hermes/jobs/known-flakes.json so future runs auto-classify.`,
+      whyItMatters:
+        'Unclassified CI failures on main block deploys and erode trust in the merge gate.',
+      classification: 'Required',
+      acceptanceCriteria:
+        'Either a fix is merged OR a new signature is added to known-flakes.json with a documented reason.',
+    }),
+    source: `ci-failure-monitor:${run.databaseId}`,
+  });
+
+  logJobEvent({
+    job: JOB,
+    event: filed.success ? 'issue_filed' : 'file_failed',
+    runId: run.databaseId,
+    identifier: filed.identifier,
+    error: filed.error,
+  });
+}
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    const flakes = loadKnownFlakes();
+    const failures = listRecentFailures();
+    logJobEvent({
+      job: JOB,
+      event: 'scanned',
+      failureCount: failures.length,
+      knownFlakeCount: flakes.length,
+    });
+    for (const run of failures) {
+      try {
+        await processFailure(run, flakes);
+      } catch (err) {
+        logJobEvent({
+          job: JOB,
+          event: 'process_failed',
+          runId: run.databaseId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  });
+}
+
+void main().catch(err => {
+  console.error(`[${JOB}] fatal:`, err);
+  process.exit(0);
+});

--- a/scripts/hermes/jobs/cost-monitor.ts
+++ b/scripts/hermes/jobs/cost-monitor.ts
@@ -15,6 +15,7 @@ import { join } from 'node:path';
 
 import { HERMES_PATHS } from '../lib/hermes-paths';
 import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { withRetry } from '../lib/retry';
 import { sendTelegram } from '../lib/telegram-client';
 
 const JOB = 'cost-monitor';
@@ -61,14 +62,24 @@ async function fetchOpenRouterUsage24h(): Promise<number> {
   const key = process.env.OPENROUTER_API_KEY;
   if (!key) return 0;
   try {
-    const response = await fetch('https://openrouter.ai/api/v1/credits', {
-      headers: { Authorization: `Bearer ${key}` },
-      signal: AbortSignal.timeout(10_000),
-    });
-    if (!response.ok) return 0;
-    const data = (await response.json()) as {
-      data?: { usage?: number; limit?: number | null };
-    };
+    const data = await withRetry(
+      async () => {
+        const response = await fetch('https://openrouter.ai/api/v1/credits', {
+          headers: { Authorization: `Bearer ${key}` },
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (response.status === 429 || response.status >= 500) {
+          throw new Error(`OpenRouter ${response.status}`);
+        }
+        if (!response.ok) {
+          return { data: { usage: 0 } };
+        }
+        return (await response.json()) as {
+          data?: { usage?: number; limit?: number | null };
+        };
+      },
+      { caller: 'cost-monitor.openrouter', attempts: 3 }
+    );
     // OpenRouter returns lifetime usage; we treat any increase since the
     // last snapshot as the 24h delta. Snapshot file at state/openrouter-usage.json.
     const snapshotPath = join(HERMES_PATHS.stateDir, 'openrouter-usage.json');
@@ -137,7 +148,7 @@ async function main(): Promise<void> {
     if (totalSpend > 0) {
       tripKillSwitch(totalSpend);
       await sendTelegram(
-        `⚠️ *Hermes-Air cost kill switch tripped*\nDetected $${totalSpend.toFixed(4)} in paid model spend in 24h. All non-watchdog services stopped.\n\nInvestigate \`~/.hermes/logs/cost.jsonl\`, then run \`./scripts/hermes/bootstrap-air.sh --resume-after-cost-kill\`.`
+        `Hermes-Air cost kill switch tripped.\nDetected $${totalSpend.toFixed(4)} in paid model spend in 24h. All non-watchdog services stopped.\nInvestigate ~/.hermes/logs/cost.jsonl then run ./scripts/hermes/bootstrap-air.sh --resume-after-cost-kill`
       );
     }
   });

--- a/scripts/hermes/jobs/cost-monitor.ts
+++ b/scripts/hermes/jobs/cost-monitor.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env tsx
+/**
+ * Cost Monitor — Hermes-Air
+ *
+ * Sentinel: any paid spend >$0 in the last 24h kills all non-watchdog
+ * launchd jobs and requires manual user confirmation to resume.
+ *
+ * Runs hourly. Reads OpenRouter usage API and ~/.hermes/logs/cost.jsonl
+ * for any inference that slipped onto a paid model.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { HERMES_PATHS } from '../lib/hermes-paths';
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { sendTelegram } from '../lib/telegram-client';
+
+const JOB = 'cost-monitor';
+const KILL_SWITCH_PATH = join(HERMES_PATHS.stateDir, 'cost-kill-switch');
+
+const NON_WATCHDOG_SERVICES = [
+  'co.jovie.hermes.daemon',
+  'co.jovie.hermes.cron-hud',
+  'co.jovie.hermes.cron-pr-monitor',
+  'co.jovie.hermes.cron-ci-monitor',
+  'co.jovie.hermes.cron-daily-briefing',
+  'co.jovie.hermes.cron-deterministic-tracker',
+  'co.jovie.hermes.cron-free-model-health',
+  'co.jovie.hermes.voice-memo-watcher',
+];
+
+function totalLocalPaidSpend(sinceMs: number): number {
+  if (!existsSync(HERMES_PATHS.costLog)) return 0;
+  try {
+    return readFileSync(HERMES_PATHS.costLog, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map(line => {
+        try {
+          return JSON.parse(line) as { ts?: string; cost?: number };
+        } catch {
+          return null;
+        }
+      })
+      .filter(
+        (entry): entry is { ts: string; cost: number } =>
+          entry !== null &&
+          typeof entry.ts === 'string' &&
+          typeof entry.cost === 'number' &&
+          new Date(entry.ts).getTime() >= sinceMs
+      )
+      .reduce((sum, entry) => sum + entry.cost, 0);
+  } catch {
+    return 0;
+  }
+}
+
+async function fetchOpenRouterUsage24h(): Promise<number> {
+  const key = process.env.OPENROUTER_API_KEY;
+  if (!key) return 0;
+  try {
+    const response = await fetch('https://openrouter.ai/api/v1/credits', {
+      headers: { Authorization: `Bearer ${key}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) return 0;
+    const data = (await response.json()) as {
+      data?: { usage?: number; limit?: number | null };
+    };
+    // OpenRouter returns lifetime usage; we treat any increase since the
+    // last snapshot as the 24h delta. Snapshot file at state/openrouter-usage.json.
+    const snapshotPath = join(HERMES_PATHS.stateDir, 'openrouter-usage.json');
+    const usageNow = data.data?.usage ?? 0;
+    let usagePrev = 0;
+    if (existsSync(snapshotPath)) {
+      try {
+        const prev = JSON.parse(readFileSync(snapshotPath, 'utf8')) as {
+          usage: number;
+        };
+        usagePrev = prev.usage;
+      } catch {
+        // ignore
+      }
+    }
+    mkdirSync(HERMES_PATHS.stateDir, { recursive: true });
+    writeFileSync(
+      snapshotPath,
+      JSON.stringify({ usage: usageNow, ts: new Date().toISOString() }, null, 2)
+    );
+    return Math.max(0, usageNow - usagePrev);
+  } catch {
+    return 0;
+  }
+}
+
+function tripKillSwitch(spend: number): void {
+  mkdirSync(HERMES_PATHS.stateDir, { recursive: true });
+  writeFileSync(
+    KILL_SWITCH_PATH,
+    JSON.stringify({ trippedAt: new Date().toISOString(), spend }, null, 2)
+  );
+
+  const uid = String(execFileSync('id', ['-u'], { encoding: 'utf8' }).trim());
+  for (const service of NON_WATCHDOG_SERVICES) {
+    try {
+      execFileSync('launchctl', ['bootout', `gui/${uid}/${service}`], {
+        encoding: 'utf8',
+        timeout: 10_000,
+      });
+    } catch {
+      // Service may not be running; non-fatal.
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    if (existsSync(KILL_SWITCH_PATH)) {
+      logJobEvent({ job: JOB, event: 'kill_switch_already_tripped' });
+      return;
+    }
+    const since = Date.now() - 24 * 3_600 * 1000;
+    const localSpend = totalLocalPaidSpend(since);
+    const remoteSpend = await fetchOpenRouterUsage24h();
+    const totalSpend = localSpend + remoteSpend;
+
+    logJobEvent({
+      job: JOB,
+      event: 'checked',
+      localSpend,
+      remoteSpend,
+      totalSpend,
+    });
+
+    if (totalSpend > 0) {
+      tripKillSwitch(totalSpend);
+      await sendTelegram(
+        `⚠️ *Hermes-Air cost kill switch tripped*\nDetected $${totalSpend.toFixed(4)} in paid model spend in 24h. All non-watchdog services stopped.\n\nInvestigate \`~/.hermes/logs/cost.jsonl\`, then run \`./scripts/hermes/bootstrap-air.sh --resume-after-cost-kill\`.`
+      );
+    }
+  });
+}
+
+void main().catch(err => {
+  console.error(`[${JOB}] fatal:`, err);
+  process.exit(0);
+});

--- a/scripts/hermes/jobs/daily-briefing.ts
+++ b/scripts/hermes/jobs/daily-briefing.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env tsx
+/**
+ * Daily Briefing — Hermes-Air
+ *
+ * Runs at 07:00 local. Pulls yesterday's:
+ *  - merged PRs
+ *  - new Linear issues filed by hermes-air
+ *  - voice-memo ingest count
+ *  - cost log (should always be $0)
+ *
+ * Asks the free-model-router to compose a brief (prefer top-tier free model).
+ * Sends as a single Telegram message.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+import { chat } from '../lib/free-model-router';
+import { HERMES_PATHS } from '../lib/hermes-paths';
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { sendTelegram } from '../lib/telegram-client';
+
+const JOB = 'daily-briefing';
+
+function yesterdayRange(): { since: string; until: string } {
+  const now = new Date();
+  const yesterday = new Date(now.getTime() - 24 * 3_600 * 1000);
+  yesterday.setHours(0, 0, 0, 0);
+  const endOfYesterday = new Date(yesterday.getTime() + 24 * 3_600 * 1000);
+  return {
+    since: yesterday.toISOString(),
+    until: endOfYesterday.toISOString(),
+  };
+}
+
+function mergedPrsYesterday(): ReadonlyArray<{
+  title: string;
+  number: number;
+  url: string;
+}> {
+  try {
+    const json = execFileSync(
+      'gh',
+      [
+        'pr',
+        'list',
+        '--state',
+        'merged',
+        '--limit',
+        '40',
+        '--json',
+        'title,number,url,mergedAt',
+      ],
+      { encoding: 'utf8', timeout: 30_000 }
+    );
+    const prs = JSON.parse(json) as ReadonlyArray<{
+      title: string;
+      number: number;
+      url: string;
+      mergedAt: string;
+    }>;
+    const { since, until } = yesterdayRange();
+    return prs.filter(p => p.mergedAt >= since && p.mergedAt < until);
+  } catch {
+    return [];
+  }
+}
+
+function countLinesSince(path: string, sinceIso: string): number {
+  if (!existsSync(path)) return 0;
+  try {
+    const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean);
+    return lines.filter(line => {
+      try {
+        const parsed = JSON.parse(line) as { ts?: string };
+        return parsed.ts ? parsed.ts >= sinceIso : false;
+      } catch {
+        return false;
+      }
+    }).length;
+  } catch {
+    return 0;
+  }
+}
+
+function totalPaidSpendYesterday(): number {
+  if (!existsSync(HERMES_PATHS.costLog)) return 0;
+  const { since, until } = yesterdayRange();
+  try {
+    return readFileSync(HERMES_PATHS.costLog, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map(line => {
+        try {
+          return JSON.parse(line) as { ts?: string; cost?: number };
+        } catch {
+          return null;
+        }
+      })
+      .filter(
+        (p): p is { ts: string; cost: number } =>
+          p !== null &&
+          typeof p.ts === 'string' &&
+          typeof p.cost === 'number' &&
+          p.ts >= since &&
+          p.ts < until
+      )
+      .reduce((sum, p) => sum + p.cost, 0);
+  } catch {
+    return 0;
+  }
+}
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    const { since } = yesterdayRange();
+    const merged = mergedPrsYesterday();
+    const voiceMemos = countLinesSince(HERMES_PATHS.voiceMemoLog, since);
+    const dispatches = countLinesSince(HERMES_PATHS.dispatchLog, since);
+    const paidSpend = totalPaidSpendYesterday();
+
+    const context = JSON.stringify(
+      {
+        mergedPrs: merged.map(p => `#${p.number} ${p.title}`),
+        voiceMemosIngested: voiceMemos,
+        tasksDispatched: dispatches,
+        paidSpendUsd: paidSpend,
+      },
+      null,
+      2
+    );
+
+    const result = await chat(
+      [
+        {
+          role: 'system',
+          content:
+            'You are Hermes, an always-on chief-of-staff for a pre-PMF founder. Write a terse morning briefing (≤200 words, Markdown). Lead with what shipped, then what to focus on today. No emoji except where signaling. Plain language. No filler.',
+        },
+        {
+          role: 'user',
+          content: `Yesterday's data (UTC):\n\`\`\`json\n${context}\n\`\`\``,
+        },
+      ],
+      { caller: JOB, need: 'reasoning', maxTokens: 600, temperature: 0.4 }
+    );
+
+    await sendTelegram(`*Morning brief*\n\n${result.text.trim()}`);
+    logJobEvent({
+      job: JOB,
+      event: 'sent',
+      mergedCount: merged.length,
+      voiceMemos,
+      dispatches,
+      paidSpend,
+      modelUsed: result.model,
+    });
+  });
+}
+
+void main().catch(err => {
+  console.error(`[${JOB}] fatal:`, err);
+  process.exit(0);
+});

--- a/scripts/hermes/jobs/daily-briefing.ts
+++ b/scripts/hermes/jobs/daily-briefing.ts
@@ -23,13 +23,17 @@ import { sendTelegram } from '../lib/telegram-client';
 const JOB = 'daily-briefing';
 
 function yesterdayRange(): { since: string; until: string } {
+  // Yesterday in UTC, matching the JSONL timestamps we read (all written
+  // via new Date().toISOString()). Local-time math here would slide the
+  // window by the operator's tz offset and miss late-evening events.
   const now = new Date();
-  const yesterday = new Date(now.getTime() - 24 * 3_600 * 1000);
-  yesterday.setHours(0, 0, 0, 0);
-  const endOfYesterday = new Date(yesterday.getTime() + 24 * 3_600 * 1000);
+  const todayUtc = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
+  const yesterdayUtc = new Date(todayUtc.getTime() - 24 * 3_600 * 1000);
   return {
-    since: yesterday.toISOString(),
-    until: endOfYesterday.toISOString(),
+    since: yesterdayUtc.toISOString(),
+    until: todayUtc.toISOString(),
   };
 }
 
@@ -66,14 +70,19 @@ function mergedPrsYesterday(): ReadonlyArray<{
   }
 }
 
-function countLinesSince(path: string, sinceIso: string): number {
+function countLinesBetween(
+  path: string,
+  sinceIso: string,
+  untilIso: string
+): number {
   if (!existsSync(path)) return 0;
   try {
     const lines = readFileSync(path, 'utf8').split('\n').filter(Boolean);
     return lines.filter(line => {
       try {
         const parsed = JSON.parse(line) as { ts?: string };
-        return parsed.ts ? parsed.ts >= sinceIso : false;
+        if (!parsed.ts) return false;
+        return parsed.ts >= sinceIso && parsed.ts < untilIso;
       } catch {
         return false;
       }
@@ -113,10 +122,18 @@ function totalPaidSpendYesterday(): number {
 
 async function main(): Promise<void> {
   await withJobLogging(JOB, async () => {
-    const { since } = yesterdayRange();
+    const { since, until } = yesterdayRange();
     const merged = mergedPrsYesterday();
-    const voiceMemos = countLinesSince(HERMES_PATHS.voiceMemoLog, since);
-    const dispatches = countLinesSince(HERMES_PATHS.dispatchLog, since);
+    const voiceMemos = countLinesBetween(
+      HERMES_PATHS.voiceMemoLog,
+      since,
+      until
+    );
+    const dispatches = countLinesBetween(
+      HERMES_PATHS.dispatchLog,
+      since,
+      until
+    );
     const paidSpend = totalPaidSpendYesterday();
 
     const context = JSON.stringify(
@@ -145,7 +162,7 @@ async function main(): Promise<void> {
       { caller: JOB, need: 'reasoning', maxTokens: 600, temperature: 0.4 }
     );
 
-    await sendTelegram(`*Morning brief*\n\n${result.text.trim()}`);
+    await sendTelegram(`Morning brief\n\n${result.text.trim()}`);
     logJobEvent({
       job: JOB,
       event: 'sent',

--- a/scripts/hermes/jobs/deterministic-tracker.ts
+++ b/scripts/hermes/jobs/deterministic-tracker.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env tsx
+/**
+ * Deterministic Tracker — Hermes-Air
+ *
+ * Self-improvement engine. Reads dispatch.jsonl, clusters intent shapes,
+ * and files Linear issues proposing deterministic replacements for any
+ * cluster that fires ≥5 times in the last 30 days.
+ *
+ * v1 clustering: bucket by (target, first 4 normalized tokens of text).
+ * Good enough to surface the obvious "we keep asking the LLM to do X"
+ * patterns. Can be replaced with embedding-based clustering later.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+
+import { HERMES_PATHS } from '../lib/hermes-paths';
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { buildFollowUpBody, fileIssue } from '../lib/linear-client';
+
+const JOB = 'deterministic-tracker';
+const THRESHOLD = 5;
+const WINDOW_DAYS = 30;
+
+interface DispatchEntry {
+  readonly target?: string;
+  readonly text?: string;
+  readonly ts?: string;
+}
+
+function normalize(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .slice(0, 4)
+    .join(' ');
+}
+
+function loadDispatches(): ReadonlyArray<DispatchEntry> {
+  if (!existsSync(HERMES_PATHS.dispatchLog)) return [];
+  const cutoff = Date.now() - WINDOW_DAYS * 24 * 3_600 * 1000;
+  return readFileSync(HERMES_PATHS.dispatchLog, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map(line => {
+      try {
+        return JSON.parse(line) as DispatchEntry;
+      } catch {
+        return null;
+      }
+    })
+    .filter((entry): entry is DispatchEntry => {
+      if (!entry) return false;
+      if (!entry.ts) return true;
+      return new Date(entry.ts).getTime() >= cutoff;
+    });
+}
+
+function cluster(entries: ReadonlyArray<DispatchEntry>): ReadonlyArray<{
+  key: string;
+  count: number;
+  samples: ReadonlyArray<string>;
+}> {
+  const map = new Map<string, { count: number; samples: string[] }>();
+  for (const entry of entries) {
+    if (!entry.text) continue;
+    const key = `${entry.target ?? 'chief'}|${normalize(entry.text)}`;
+    const bucket = map.get(key) ?? { count: 0, samples: [] };
+    bucket.count += 1;
+    if (bucket.samples.length < 3) bucket.samples.push(entry.text);
+    map.set(key, bucket);
+  }
+  return [...map.entries()]
+    .map(([key, bucket]) => ({
+      key,
+      count: bucket.count,
+      samples: bucket.samples,
+    }))
+    .filter(c => c.count >= THRESHOLD)
+    .sort((a, b) => b.count - a.count);
+}
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    const entries = loadDispatches();
+    const clusters = cluster(entries);
+    logJobEvent({
+      job: JOB,
+      event: 'analyzed',
+      entryCount: entries.length,
+      clusterCount: clusters.length,
+    });
+
+    for (const c of clusters) {
+      const filed = await fileIssue({
+        title: `Deterministic candidate: "${c.key}" (${c.count}× / ${WINDOW_DAYS}d)`,
+        description: buildFollowUpBody({
+          source: 'deterministic-tracker',
+          followUp: `Hermes-air has dispatched the intent shape "${c.key}" ${c.count} times in the last ${WINDOW_DAYS} days. Consider replacing the LLM path with a deterministic script. Samples:\n\n${c.samples.map((s, i) => `${i + 1}. ${s}`).join('\n')}`,
+          whyItMatters:
+            'Replacing a repeated LLM call with a deterministic script reduces cost variance, removes a self-healing dependency, and improves predictability.',
+          classification: 'Candidate',
+          acceptanceCriteria:
+            'Pickup agent must first judge whether the pattern is stable enough to be scripted, or whether the LLM path is correct because the inputs genuinely vary.',
+        }),
+        source: `deterministic-tracker:${c.key}`,
+      });
+      logJobEvent({
+        job: JOB,
+        event: filed.success ? 'candidate_filed' : 'file_failed',
+        key: c.key,
+        count: c.count,
+        identifier: filed.identifier,
+        error: filed.error,
+      });
+    }
+  });
+}
+
+void main().catch(err => {
+  console.error(`[${JOB}] fatal:`, err);
+  process.exit(0);
+});

--- a/scripts/hermes/jobs/deterministic-tracker.ts
+++ b/scripts/hermes/jobs/deterministic-tracker.ts
@@ -52,8 +52,9 @@ function loadDispatches(): ReadonlyArray<DispatchEntry> {
       }
     })
     .filter((entry): entry is DispatchEntry => {
-      if (!entry) return false;
-      if (!entry.ts) return true;
+      // Entries without a timestamp predate this job and would otherwise
+      // pollute the cluster window forever; drop them.
+      if (!entry || !entry.ts) return false;
       return new Date(entry.ts).getTime() >= cutoff;
     });
 }

--- a/scripts/hermes/jobs/free-model-health.ts
+++ b/scripts/hermes/jobs/free-model-health.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env tsx
+/**
+ * Free-Model Health Probe — Hermes-Air
+ *
+ * Nightly: pings every ranked free model with a tiny "reply OK" prompt.
+ * Updates ~/.hermes/state/model-router-rankings.json with success/failure
+ * outcomes so the router prefers reliably-free models.
+ *
+ * Side effect: detects "promo" models that silently flip to paid. Those
+ * are ejected by free-model-router (cost detection); this job records the
+ * ejection in the rankings.
+ */
+
+import { listRankings, probeModel } from '../lib/free-model-router';
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+
+const JOB = 'free-model-health';
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    const rankings = listRankings();
+    const results: Array<{
+      id: string;
+      ok: boolean;
+      latencyMs: number;
+      error?: string;
+    }> = [];
+    for (const model of rankings.models) {
+      const probe = await probeModel(model.id);
+      results.push({ id: model.id, ...probe });
+      logJobEvent({
+        job: JOB,
+        event: 'probed',
+        model: model.id,
+        ok: probe.ok,
+        latencyMs: probe.latencyMs,
+        error: probe.error,
+      });
+    }
+    const okCount = results.filter(r => r.ok).length;
+    logJobEvent({
+      job: JOB,
+      event: 'summary',
+      total: results.length,
+      ok: okCount,
+      failed: results.length - okCount,
+    });
+  });
+}
+
+void main().catch(err => {
+  console.error(`[${JOB}] fatal:`, err);
+  process.exit(0);
+});

--- a/scripts/hermes/jobs/hud-refresh.ts
+++ b/scripts/hermes/jobs/hud-refresh.ts
@@ -14,6 +14,7 @@ import { join } from 'node:path';
 
 import { HERMES_PATHS } from '../lib/hermes-paths';
 import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { withRetry } from '../lib/retry';
 import { sendTelegram } from '../lib/telegram-client';
 
 const JOB = 'hud-refresh';
@@ -47,16 +48,21 @@ function saveSnapshot(summary: HudSummary): void {
 }
 
 async function fetchSummary(): Promise<HudSummary> {
-  const response = await fetch(HUD_ENDPOINT, {
-    headers: HUD_API_KEY ? { Authorization: `Bearer ${HUD_API_KEY}` } : {},
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (!response.ok) {
-    throw new Error(
-      `HUD ${response.status}: ${await response.text().catch(() => '')}`
-    );
-  }
-  return (await response.json()) as HudSummary;
+  return withRetry(
+    async () => {
+      const response = await fetch(HUD_ENDPOINT, {
+        headers: HUD_API_KEY ? { Authorization: `Bearer ${HUD_API_KEY}` } : {},
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!response.ok) {
+        throw new Error(
+          `HUD ${response.status}: ${await response.text().catch(() => '')}`
+        );
+      }
+      return (await response.json()) as HudSummary;
+    },
+    { caller: 'hud-refresh.fetch', attempts: 3 }
+  );
 }
 
 function detectAnomalies(
@@ -91,7 +97,7 @@ async function main(): Promise<void> {
     });
     if (anomalies.length > 0) {
       await sendTelegram(
-        `🚨 *HUD anomaly*\n${anomalies.map(a => `• ${a}`).join('\n')}`
+        `HUD anomaly:\n${anomalies.map(a => `- ${a}`).join('\n')}`
       );
     }
   });

--- a/scripts/hermes/jobs/hud-refresh.ts
+++ b/scripts/hermes/jobs/hud-refresh.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env tsx
+/**
+ * HUD Refresh — Hermes-Air
+ *
+ * Pings the deployed HUD AI-Ops summary endpoint, caches the result locally,
+ * and flags anomalies (merge-queue pressure, blocker spikes, deploy health).
+ *
+ * Read-only: never writes to GitHub or Linear. Anomalies are surfaced via
+ * Telegram only.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { HERMES_PATHS } from '../lib/hermes-paths';
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { sendTelegram } from '../lib/telegram-client';
+
+const JOB = 'hud-refresh';
+
+const HUD_ENDPOINT =
+  process.env.HERMES_HUD_ENDPOINT ?? 'https://jov.ie/api/hud/ai-ops/summary';
+const HUD_API_KEY = process.env.HERMES_HUD_API_KEY ?? '';
+
+interface HudSummary {
+  readonly openPrs: number;
+  readonly openAgentPrs: number;
+  readonly blockers: number;
+  readonly mergeQueuePressure: 'low' | 'elevated' | 'high';
+  readonly recommendations: ReadonlyArray<string>;
+}
+
+const SNAPSHOT_PATH = join(HERMES_PATHS.stateDir, 'hud-snapshot.json');
+
+function loadPreviousSnapshot(): HudSummary | null {
+  if (!existsSync(SNAPSHOT_PATH)) return null;
+  try {
+    return JSON.parse(readFileSync(SNAPSHOT_PATH, 'utf8')) as HudSummary;
+  } catch {
+    return null;
+  }
+}
+
+function saveSnapshot(summary: HudSummary): void {
+  mkdirSync(HERMES_PATHS.stateDir, { recursive: true });
+  writeFileSync(SNAPSHOT_PATH, JSON.stringify(summary, null, 2));
+}
+
+async function fetchSummary(): Promise<HudSummary> {
+  const response = await fetch(HUD_ENDPOINT, {
+    headers: HUD_API_KEY ? { Authorization: `Bearer ${HUD_API_KEY}` } : {},
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `HUD ${response.status}: ${await response.text().catch(() => '')}`
+    );
+  }
+  return (await response.json()) as HudSummary;
+}
+
+function detectAnomalies(
+  current: HudSummary,
+  previous: HudSummary | null
+): ReadonlyArray<string> {
+  const anomalies: string[] = [];
+  if (current.mergeQueuePressure === 'high') {
+    anomalies.push(
+      `Merge queue pressure HIGH (${current.openAgentPrs} open agent PRs)`
+    );
+  }
+  if (previous && current.blockers > previous.blockers + 2) {
+    anomalies.push(
+      `Blockers jumped ${previous.blockers} → ${current.blockers}`
+    );
+  }
+  return anomalies;
+}
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    const summary = await fetchSummary();
+    const previous = loadPreviousSnapshot();
+    saveSnapshot(summary);
+    const anomalies = detectAnomalies(summary, previous);
+    logJobEvent({
+      job: JOB,
+      event: 'refreshed',
+      summary,
+      anomalyCount: anomalies.length,
+    });
+    if (anomalies.length > 0) {
+      await sendTelegram(
+        `🚨 *HUD anomaly*\n${anomalies.map(a => `• ${a}`).join('\n')}`
+      );
+    }
+  });
+}
+
+void main().catch(err => {
+  console.error(`[${JOB}] fatal:`, err);
+  process.exit(0);
+});

--- a/scripts/hermes/jobs/known-flakes.json
+++ b/scripts/hermes/jobs/known-flakes.json
@@ -1,4 +1,4 @@
 {
-  "_doc": "Known flaky CI signatures. Each entry: id (kebab-case), workflow (GH workflow name), pattern (JS regex, case-insensitive), note (why we tolerate it). Adding a signature here causes ci-failure-monitor.ts to skip filing a Linear issue for matching failures. Seeded empty; populated as failures recur.",
+  "_doc": "Known flaky CI signatures. Each entry: id (kebab-case), workflow (exact GH workflow name OR '*' to match any workflow), pattern (JS regex, case-insensitive), note (why we tolerate it). Adding a signature here causes ci-failure-monitor.ts to skip filing a Linear issue for matching failures, but only when the workflow matches. Seeded empty; populated as failures recur.",
   "flakes": []
 }

--- a/scripts/hermes/jobs/known-flakes.json
+++ b/scripts/hermes/jobs/known-flakes.json
@@ -1,0 +1,4 @@
+{
+  "_doc": "Known flaky CI signatures. Each entry: id (kebab-case), workflow (GH workflow name), pattern (JS regex, case-insensitive), note (why we tolerate it). Adding a signature here causes ci-failure-monitor.ts to skip filing a Linear issue for matching failures. Seeded empty; populated as failures recur.",
+  "flakes": []
+}

--- a/scripts/hermes/jobs/pr-stuck-monitor.ts
+++ b/scripts/hermes/jobs/pr-stuck-monitor.ts
@@ -82,7 +82,11 @@ function verdictFor(pr: Pr): Verdict {
     );
   }
 
-  if (hoursSinceUpdate > 6 && pr.statusCheckRollup.length > 0) {
+  // "No activity" is only stuck if the PR is in a non-clean state. A green
+  // PR sitting idle for 6h is usually just waiting on a reviewer, not stuck.
+  const hasFailedChecks = failed.length > 0;
+  const hasNoChecks = pr.statusCheckRollup.length === 0;
+  if (hoursSinceUpdate > 6 && (hasFailedChecks || hasNoChecks)) {
     reasons.push(`no activity for ${hoursSinceUpdate.toFixed(1)}h`);
   }
 

--- a/scripts/hermes/jobs/pr-stuck-monitor.ts
+++ b/scripts/hermes/jobs/pr-stuck-monitor.ts
@@ -1,0 +1,180 @@
+#!/usr/bin/env tsx
+/**
+ * PR Stuck Monitor — Hermes-Air
+ *
+ * Watches open PRs and files Linear issues for ones that look stuck:
+ *  - labeled `needs-human`
+ *  - no CI activity for >6h with red checks
+ *  - red CI for >2h
+ *  - >24h since last commit, still draft
+ *
+ * Deterministic by default; only escalates to LLM when an unfamiliar
+ * blocker signature appears.
+ *
+ * Exits 0 always (transient errors must not loop launchd).
+ */
+
+import { execFileSync } from 'node:child_process';
+
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { buildFollowUpBody, fileIssue } from '../lib/linear-client';
+
+const JOB = 'pr-stuck-monitor';
+
+interface Pr {
+  readonly number: number;
+  readonly title: string;
+  readonly url: string;
+  readonly isDraft: boolean;
+  readonly labels: ReadonlyArray<{ readonly name: string }>;
+  readonly updatedAt: string;
+  readonly statusCheckRollup: ReadonlyArray<{
+    readonly state?: string;
+    readonly conclusion?: string;
+    readonly name?: string;
+  }>;
+  readonly author: { readonly login?: string };
+}
+
+interface Verdict {
+  readonly stuck: boolean;
+  readonly reasons: ReadonlyArray<string>;
+}
+
+function listOpenPRs(): ReadonlyArray<Pr> {
+  const json = execFileSync(
+    'gh',
+    [
+      'pr',
+      'list',
+      '--state',
+      'open',
+      '--limit',
+      '50',
+      '--json',
+      'number,title,url,isDraft,labels,updatedAt,statusCheckRollup,author',
+    ],
+    { encoding: 'utf8', timeout: 30_000 }
+  );
+  return JSON.parse(json) as ReadonlyArray<Pr>;
+}
+
+function hoursSince(iso: string): number {
+  return (Date.now() - new Date(iso).getTime()) / 3_600_000;
+}
+
+function verdictFor(pr: Pr): Verdict {
+  const reasons: string[] = [];
+  const labelNames = pr.labels.map(l => l.name);
+
+  if (labelNames.includes('needs-human')) {
+    reasons.push('labeled needs-human');
+  }
+
+  const failed = pr.statusCheckRollup.filter(
+    c => c.conclusion === 'FAILURE' || c.state === 'FAILURE'
+  );
+  const hoursSinceUpdate = hoursSince(pr.updatedAt);
+
+  if (failed.length > 0 && hoursSinceUpdate > 2) {
+    reasons.push(
+      `${failed.length} red checks for ${hoursSinceUpdate.toFixed(1)}h`
+    );
+  }
+
+  if (hoursSinceUpdate > 6 && pr.statusCheckRollup.length > 0) {
+    reasons.push(`no activity for ${hoursSinceUpdate.toFixed(1)}h`);
+  }
+
+  if (pr.isDraft && hoursSinceUpdate > 24) {
+    reasons.push(`draft idle for ${hoursSinceUpdate.toFixed(1)}h`);
+  }
+
+  return { stuck: reasons.length > 0, reasons };
+}
+
+function buildIssueBody(pr: Pr, reasons: ReadonlyArray<string>): string {
+  return buildFollowUpBody({
+    source: `pr-stuck-monitor`,
+    sourceUrl: pr.url,
+    followUp: `PR #${pr.number} ("${pr.title}") looks stuck. Reasons: ${reasons.join('; ')}. Investigate and either unblock the existing branch or close the PR with a written reason.`,
+    whyItMatters:
+      'Stuck PRs block downstream work and confuse merge-queue prioritization. Hermes-air surfaces them so a coder agent can pick them up.',
+    classification: 'Required',
+    acceptanceCriteria:
+      'PR is either merged, marked needs-human with a fresh review comment, or closed. Linear issue links to the resolution.',
+  });
+}
+
+async function processPr(pr: Pr): Promise<void> {
+  const verdict = verdictFor(pr);
+  if (!verdict.stuck) return;
+
+  // Idempotency: a label on the PR prevents re-filing.
+  if (pr.labels.some(l => l.name === 'hermes-air-flagged')) {
+    logJobEvent({
+      job: JOB,
+      event: 'already_flagged',
+      pr: pr.number,
+    });
+    return;
+  }
+
+  const filed = await fileIssue({
+    title: `Stuck PR: #${pr.number} ${pr.title.slice(0, 60)}`,
+    description: buildIssueBody(pr, verdict.reasons),
+    source: `pr-stuck-monitor:${pr.number}`,
+  });
+
+  if (filed.success) {
+    // Label the PR so we don't refile next run.
+    try {
+      execFileSync(
+        'gh',
+        ['pr', 'edit', String(pr.number), '--add-label', 'hermes-air-flagged'],
+        { encoding: 'utf8', timeout: 15_000 }
+      );
+    } catch {
+      // Label might not exist yet; non-fatal.
+    }
+    logJobEvent({
+      job: JOB,
+      event: 'issue_filed',
+      pr: pr.number,
+      identifier: filed.identifier,
+      reasons: verdict.reasons,
+    });
+  } else {
+    logJobEvent({
+      job: JOB,
+      event: 'file_failed',
+      pr: pr.number,
+      queued: filed.queued,
+      error: filed.error,
+    });
+  }
+}
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    const prs = listOpenPRs();
+    logJobEvent({ job: JOB, event: 'scanned', count: prs.length });
+    for (const pr of prs) {
+      try {
+        await processPr(pr);
+      } catch (err) {
+        logJobEvent({
+          job: JOB,
+          event: 'process_failed',
+          pr: pr.number,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  });
+}
+
+void main().catch(err => {
+  console.error(`[${JOB}] fatal:`, err);
+  process.exit(0); // never loop launchd on transient errors
+});

--- a/scripts/hermes/jobs/voice-memo-ingest.ts
+++ b/scripts/hermes/jobs/voice-memo-ingest.ts
@@ -1,0 +1,384 @@
+#!/usr/bin/env tsx
+
+/**
+ * Voice Memo Ingest — Hermes-Air
+ *
+ * Triggered by launchd WatchPaths on
+ *   ~/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings/
+ *
+ * Pipeline:
+ *  1. Find new .m4a files (dedupe via voice-memos-seen.json).
+ *  2. Extract transcript: macOS 26 Voice Memos stores transcripts in a
+ *     sibling CloudRecordings.db SQLite store. If absent or empty, fall
+ *     back to whisper.cpp (~700 MB peak, guarded by heavy-job lock).
+ *  3. Write the full transcript to gbrain (durable memory).
+ *  4. Classify into spans: memory | issue | task.
+ *  5. For each `issue` span → file a Linear issue.
+ *  6. For each `task` span → log for Hermes daemon routing (the daemon
+ *     polls this log and routes to sub-agents). v1: log only; Hermes
+ *     daemon integration follows after observability.
+ *  7. Telegram a single confirmation per memo.
+ *
+ * Usage:
+ *   pnpm tsx scripts/hermes/jobs/voice-memo-ingest.ts          # scan dir
+ *   pnpm tsx scripts/hermes/jobs/voice-memo-ingest.ts --file /path/x.m4a
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, join } from 'node:path';
+
+import { chat } from '../lib/free-model-router';
+import { withHeavyJobLock } from '../lib/heavy-job-lock';
+import { HERMES_PATHS, VOICE_MEMOS_RECORDINGS } from '../lib/hermes-paths';
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+import { buildFollowUpBody, fileIssue } from '../lib/linear-client';
+import { sendTelegram } from '../lib/telegram-client';
+
+const JOB = 'voice-memo-ingest';
+
+interface SeenLedger {
+  readonly seen: Record<string, { readonly ingestedAt: string }>;
+}
+
+function loadSeen(): SeenLedger {
+  if (!existsSync(HERMES_PATHS.voiceMemosSeen)) return { seen: {} };
+  try {
+    return JSON.parse(readFileSync(HERMES_PATHS.voiceMemosSeen, 'utf8'));
+  } catch {
+    return { seen: {} };
+  }
+}
+
+function saveSeen(ledger: SeenLedger): void {
+  mkdirSync(HERMES_PATHS.stateDir, { recursive: true });
+  writeFileSync(HERMES_PATHS.voiceMemosSeen, JSON.stringify(ledger, null, 2));
+}
+
+function findNewRecordings(): ReadonlyArray<string> {
+  if (!existsSync(VOICE_MEMOS_RECORDINGS)) return [];
+  const ledger = loadSeen();
+  const files = readdirSync(VOICE_MEMOS_RECORDINGS)
+    .filter(f => f.endsWith('.m4a'))
+    .map(f => join(VOICE_MEMOS_RECORDINGS, f))
+    .filter(path => !ledger.seen[basename(path)]);
+  return files;
+}
+
+/**
+ * Extract transcript from the Voice Memos CoreData/SQLite store.
+ *
+ * macOS 26 stores transcripts in `CloudRecordings.db` (a SQLite file in the
+ * same Group Container). The exact column name varies by macOS version;
+ * bootstrap verifies the schema on the Air and writes the discovered query
+ * to ~/.hermes/state/voice-memo-transcript-query.sql (which this script
+ * prefers when present).
+ */
+function readTranscriptFromStore(filePath: string): string | null {
+  const dbPath = join(VOICE_MEMOS_RECORDINGS, 'CloudRecordings.db');
+  if (!existsSync(dbPath)) return null;
+  const queryFile = join(
+    HERMES_PATHS.stateDir,
+    'voice-memo-transcript-query.sql'
+  );
+  const fileName = basename(filePath);
+
+  // Default best-effort query; verified-on-Air query overrides if present.
+  const defaultQuery = `
+    SELECT ZTRANSCRIPTION FROM ZCLOUDRECORDING
+    WHERE ZPATH LIKE '%${fileName.replace(/'/g, "''")}%'
+      OR ZENCRYPTEDTITLE LIKE '%${fileName.replace(/'/g, "''")}%'
+    LIMIT 1;
+  `;
+  const query = existsSync(queryFile)
+    ? readFileSync(queryFile, 'utf8').replaceAll(
+        '__FILE__',
+        fileName.replace(/'/g, "''")
+      )
+    : defaultQuery;
+
+  try {
+    const out = execFileSync('sqlite3', [dbPath, query], {
+      encoding: 'utf8',
+      timeout: 10_000,
+    });
+    const trimmed = out.trim();
+    if (!trimmed) return null;
+    return trimmed;
+  } catch (err) {
+    logJobEvent({
+      job: JOB,
+      event: 'transcript_store_read_failed',
+      file: fileName,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+async function whisperTranscribe(filePath: string): Promise<string> {
+  return withHeavyJobLock(`whisper:${basename(filePath)}`, async () => {
+    const whisperBin = process.env.HERMES_WHISPER_BIN ?? 'whisper-cli';
+    const model =
+      process.env.HERMES_WHISPER_MODEL ??
+      join(process.env.HOME ?? '', 'share', 'whisper', 'ggml-small.en.bin');
+    const result = spawnSync(
+      whisperBin,
+      ['-m', model, '-f', filePath, '-otxt', '-of', '/tmp/hermes-whisper-out'],
+      { encoding: 'utf8', timeout: 10 * 60 * 1000 }
+    );
+    if (result.status !== 0) {
+      throw new Error(
+        `whisper-cli failed (${result.status}): ${result.stderr ?? ''}`
+      );
+    }
+    if (!existsSync('/tmp/hermes-whisper-out.txt')) {
+      throw new Error('whisper output file missing');
+    }
+    return readFileSync('/tmp/hermes-whisper-out.txt', 'utf8').trim();
+  });
+}
+
+async function gbrainIngest(args: {
+  readonly text: string;
+  readonly recordedAt: string;
+  readonly filePath: string;
+  readonly durationS: number;
+}): Promise<string | null> {
+  // gbrain CLI accepts stdin for content. We tag with source + metadata.
+  const tags = [
+    `source:voice-memo`,
+    `recorded:${args.recordedAt}`,
+    `duration:${args.durationS}`,
+    `file:${basename(args.filePath)}`,
+  ].join(',');
+  try {
+    const out = execFileSync(
+      process.env.HERMES_GBRAIN_BIN ?? 'gbrain',
+      ['ingest', '--tags', tags, '--stdin-text', '--print-id'],
+      {
+        encoding: 'utf8',
+        input: args.text,
+        timeout: 30_000,
+      }
+    );
+    return out.trim() || null;
+  } catch (err) {
+    logJobEvent({
+      job: JOB,
+      event: 'gbrain_ingest_failed',
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+interface ClassifiedSpan {
+  readonly kind: 'memory' | 'issue' | 'task';
+  readonly text: string;
+  readonly title?: string;
+  readonly target?: 'chief' | 'cfo' | 'founder-os' | 'code-orchestrator';
+}
+
+async function classifyTranscript(
+  transcript: string
+): Promise<ReadonlyArray<ClassifiedSpan>> {
+  const system =
+    'You segment voice-memo transcripts for an orchestration agent named Hermes. ' +
+    'Return ONLY a JSON array of spans. Each span is {"kind":"memory"|"issue"|"task","text":"...","title":"...","target":"chief|cfo|founder-os|code-orchestrator"}. ' +
+    'kind=memory for ambient brain dumps. kind=issue for engineering/product/ops work that should become a Linear ticket (include a concise imperative title). kind=task for non-engineering actions (calendar, airtable, email) routed to a sub-agent (set target). ' +
+    'If unsure, default to memory. Do not include any prose outside the JSON.';
+
+  const result = await chat(
+    [
+      { role: 'system', content: system },
+      { role: 'user', content: transcript.slice(0, 8000) },
+    ],
+    { caller: JOB, need: 'reasoning', maxTokens: 1500, temperature: 0.1 }
+  );
+
+  try {
+    const text = result.text.trim();
+    const jsonStart = text.indexOf('[');
+    const jsonEnd = text.lastIndexOf(']');
+    if (jsonStart < 0 || jsonEnd < 0) {
+      throw new Error('no JSON array found');
+    }
+    const parsed = JSON.parse(
+      text.slice(jsonStart, jsonEnd + 1)
+    ) as ReadonlyArray<ClassifiedSpan>;
+    return parsed.filter(
+      s => s.kind === 'memory' || s.kind === 'issue' || s.kind === 'task'
+    );
+  } catch (err) {
+    logJobEvent({
+      job: JOB,
+      event: 'classify_parse_failed',
+      raw: result.text.slice(0, 500),
+      error: err instanceof Error ? err.message : String(err),
+    });
+    // Fail-safe: treat the whole thing as a memory dump.
+    return [{ kind: 'memory', text: transcript }];
+  }
+}
+
+async function fileIssueFromSpan(args: {
+  readonly span: ClassifiedSpan;
+  readonly gbrainId: string | null;
+  readonly memoFile: string;
+}): Promise<{ readonly identifier: string; readonly url: string } | null> {
+  if (args.span.kind !== 'issue') return null;
+  const title = (args.span.title ?? args.span.text.slice(0, 70)).trim();
+  const description = buildFollowUpBody({
+    source: `voice-memo:${basename(args.memoFile)}`,
+    sourceUrl: args.gbrainId ? `gbrain://${args.gbrainId}` : undefined,
+    followUp: args.span.text.trim(),
+    whyItMatters:
+      'Captured from a voice memo by hermes-air. Pickup agent should evaluate whether it is in-scope before implementing.',
+    classification: 'Candidate',
+    acceptanceCriteria:
+      'Pickup agent must first judge whether to implement, close, or split this.',
+  });
+  const filed = await fileIssue({
+    title: `Candidate follow-up: ${title}`,
+    description,
+    source: `voice-memo:${basename(args.memoFile)}`,
+  });
+  if (filed.success && filed.identifier && filed.url) {
+    return { identifier: filed.identifier, url: filed.url };
+  }
+  return null;
+}
+
+function logTaskSpanForDaemon(span: ClassifiedSpan, memoFile: string): void {
+  // Hermes daemon polls dispatch.jsonl to pick up routable tasks.
+  try {
+    const line = `${JSON.stringify({
+      source: 'voice-memo',
+      memoFile: basename(memoFile),
+      ts: new Date().toISOString(),
+      target: span.target ?? 'chief',
+      text: span.text,
+    })}\n`;
+    mkdirSync(HERMES_PATHS.logsDir, { recursive: true });
+    writeFileSync(HERMES_PATHS.dispatchLog, line, { flag: 'a' });
+  } catch {
+    // best effort
+  }
+}
+
+async function ingestFile(filePath: string): Promise<void> {
+  const fileName = basename(filePath);
+  const stat = statSync(filePath);
+  const recordedAt = stat.mtime.toISOString();
+  // Heuristic duration (Voice Memos are ~16KB/sec at default quality).
+  const durationS = Math.max(1, Math.round(stat.size / 16_000));
+
+  logJobEvent({ job: JOB, event: 'ingest_start', file: fileName, recordedAt });
+
+  let transcript = readTranscriptFromStore(filePath);
+  if (!transcript || transcript.length < 4) {
+    logJobEvent({ job: JOB, event: 'whisper_fallback', file: fileName });
+    transcript = await whisperTranscribe(filePath);
+  }
+
+  if (!transcript || transcript.length < 4) {
+    logJobEvent({ job: JOB, event: 'transcript_empty', file: fileName });
+    return;
+  }
+
+  const gbrainId = await gbrainIngest({
+    text: transcript,
+    recordedAt,
+    filePath,
+    durationS,
+  });
+
+  const spans = await classifyTranscript(transcript);
+  const filedIssues: Array<{ identifier: string; url: string }> = [];
+  let taskCount = 0;
+  let memoryCount = 0;
+
+  for (const span of spans) {
+    if (span.kind === 'issue') {
+      const filed = await fileIssueFromSpan({
+        span,
+        gbrainId,
+        memoFile: filePath,
+      });
+      if (filed) filedIssues.push(filed);
+    } else if (span.kind === 'task') {
+      logTaskSpanForDaemon(span, filePath);
+      taskCount += 1;
+    } else {
+      memoryCount += 1;
+    }
+  }
+
+  const ledger = loadSeen();
+  ledger.seen[fileName] = { ingestedAt: new Date().toISOString() };
+  saveSeen(ledger);
+
+  const summaryParts = [
+    `🎙️ Memo ingested (${durationS}s).`,
+    gbrainId ? `gbrain: ${gbrainId.slice(0, 12)}…` : 'gbrain: unavailable',
+    filedIssues.length > 0
+      ? `Linear: ${filedIssues.map(f => f.identifier).join(', ')}`
+      : null,
+    taskCount > 0 ? `Tasks queued: ${taskCount}` : null,
+    memoryCount > 0 ? `Memory spans: ${memoryCount}` : null,
+  ].filter((p): p is string => !!p);
+
+  await sendTelegram(summaryParts.join('\n'));
+
+  logJobEvent({
+    job: JOB,
+    event: 'ingest_finish',
+    file: fileName,
+    gbrainId,
+    filedIssueIds: filedIssues.map(f => f.identifier),
+    taskCount,
+    memoryCount,
+  });
+}
+
+async function main(): Promise<void> {
+  await withJobLogging(JOB, async () => {
+    const fileArgIdx = process.argv.indexOf('--file');
+    if (fileArgIdx >= 0) {
+      const file = process.argv[fileArgIdx + 1];
+      if (!file) throw new Error('--file requires a path');
+      await ingestFile(file);
+      return;
+    }
+    const files = findNewRecordings();
+    if (files.length === 0) {
+      logJobEvent({ job: JOB, event: 'no_new_files' });
+      return;
+    }
+    for (const file of files) {
+      try {
+        await ingestFile(file);
+      } catch (err) {
+        logJobEvent({
+          job: JOB,
+          event: 'ingest_failed',
+          file: basename(file),
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+  });
+}
+
+void main().catch(err => {
+  console.error(`[${JOB}] fatal:`, err);
+  process.exit(1);
+});

--- a/scripts/hermes/jobs/voice-memo-ingest.ts
+++ b/scripts/hermes/jobs/voice-memo-ingest.ts
@@ -31,6 +31,7 @@ import {
   readdirSync,
   readFileSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { basename, join } from 'node:path';
@@ -129,55 +130,72 @@ async function whisperTranscribe(filePath: string): Promise<string> {
     const model =
       process.env.HERMES_WHISPER_MODEL ??
       join(process.env.HOME ?? '', 'share', 'whisper', 'ggml-small.en.bin');
-    const result = spawnSync(
-      whisperBin,
-      ['-m', model, '-f', filePath, '-otxt', '-of', '/tmp/hermes-whisper-out'],
-      { encoding: 'utf8', timeout: 10 * 60 * 1000 }
+    // Per-invocation output prefix so two whisper runs (lock-bypassed in
+    // pathological cases, or rerun after crash) never trample each other's
+    // output file.
+    const tmpdir = process.env.TMPDIR ?? '/tmp';
+    const outPrefix = join(
+      tmpdir,
+      `hermes-whisper-${process.pid}-${Date.now()}`
     );
-    if (result.status !== 0) {
-      throw new Error(
-        `whisper-cli failed (${result.status}): ${result.stderr ?? ''}`
+    try {
+      const result = spawnSync(
+        whisperBin,
+        ['-m', model, '-f', filePath, '-otxt', '-of', outPrefix],
+        { encoding: 'utf8', timeout: 10 * 60 * 1000 }
       );
+      if (result.status !== 0) {
+        throw new Error(
+          `whisper-cli failed (${result.status}): ${result.stderr ?? ''}`
+        );
+      }
+      const outFile = `${outPrefix}.txt`;
+      if (!existsSync(outFile)) {
+        throw new Error('whisper output file missing');
+      }
+      return readFileSync(outFile, 'utf8').trim();
+    } finally {
+      // best-effort cleanup
+      try {
+        const outFile = `${outPrefix}.txt`;
+        if (existsSync(outFile)) unlinkSync(outFile);
+      } catch {
+        // ignore
+      }
     }
-    if (!existsSync('/tmp/hermes-whisper-out.txt')) {
-      throw new Error('whisper output file missing');
-    }
-    return readFileSync('/tmp/hermes-whisper-out.txt', 'utf8').trim();
   });
 }
 
+/**
+ * Ingest into gbrain. Returns the gbrain entry id on success, or throws on
+ * failure so the caller can decide whether to mark the memo "seen" (we only
+ * mark seen after a successful gbrain write — otherwise a transient gbrain
+ * outage would silently lose a memo).
+ */
 async function gbrainIngest(args: {
   readonly text: string;
   readonly recordedAt: string;
   readonly filePath: string;
   readonly durationS: number;
-}): Promise<string | null> {
-  // gbrain CLI accepts stdin for content. We tag with source + metadata.
+}): Promise<string> {
   const tags = [
     `source:voice-memo`,
     `recorded:${args.recordedAt}`,
     `duration:${args.durationS}`,
     `file:${basename(args.filePath)}`,
   ].join(',');
-  try {
-    const out = execFileSync(
-      process.env.HERMES_GBRAIN_BIN ?? 'gbrain',
-      ['ingest', '--tags', tags, '--stdin-text', '--print-id'],
-      {
-        encoding: 'utf8',
-        input: args.text,
-        timeout: 30_000,
-      }
-    );
-    return out.trim() || null;
-  } catch (err) {
-    logJobEvent({
-      job: JOB,
-      event: 'gbrain_ingest_failed',
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return null;
-  }
+  const out = execFileSync(
+    process.env.HERMES_GBRAIN_BIN ?? 'gbrain',
+    ['ingest', '--tags', tags, '--stdin-text', '--print-id'],
+    {
+      encoding: 'utf8',
+      input: args.text,
+      timeout: 30_000,
+    }
+  );
+  const id = out.trim();
+  if (!id) throw new Error('gbrain ingest returned empty id');
+  return id;
 }
 
 interface ClassifiedSpan {
@@ -211,12 +229,33 @@ async function classifyTranscript(
     if (jsonStart < 0 || jsonEnd < 0) {
       throw new Error('no JSON array found');
     }
-    const parsed = JSON.parse(
-      text.slice(jsonStart, jsonEnd + 1)
-    ) as ReadonlyArray<ClassifiedSpan>;
-    return parsed.filter(
-      s => s.kind === 'memory' || s.kind === 'issue' || s.kind === 'task'
-    );
+    const parsed = JSON.parse(text.slice(jsonStart, jsonEnd + 1)) as unknown;
+    if (!Array.isArray(parsed)) throw new Error('classification not array');
+    const validKinds = new Set(['memory', 'issue', 'task']);
+    const validTargets = new Set([
+      'chief',
+      'cfo',
+      'founder-os',
+      'code-orchestrator',
+    ]);
+    return parsed.filter((s): s is ClassifiedSpan => {
+      if (!s || typeof s !== 'object') return false;
+      const obj = s as Record<string, unknown>;
+      if (typeof obj.kind !== 'string' || !validKinds.has(obj.kind)) {
+        return false;
+      }
+      if (typeof obj.text !== 'string' || obj.text.length === 0) return false;
+      if (obj.title !== undefined && typeof obj.title !== 'string') {
+        return false;
+      }
+      if (obj.target !== undefined && typeof obj.target !== 'string') {
+        return false;
+      }
+      if (obj.target !== undefined && !validTargets.has(obj.target as string)) {
+        return false;
+      }
+      return true;
+    });
   } catch (err) {
     logJobEvent({
       job: JOB,
@@ -231,14 +270,14 @@ async function classifyTranscript(
 
 async function fileIssueFromSpan(args: {
   readonly span: ClassifiedSpan;
-  readonly gbrainId: string | null;
+  readonly gbrainId: string;
   readonly memoFile: string;
 }): Promise<{ readonly identifier: string; readonly url: string } | null> {
   if (args.span.kind !== 'issue') return null;
   const title = (args.span.title ?? args.span.text.slice(0, 70)).trim();
   const description = buildFollowUpBody({
     source: `voice-memo:${basename(args.memoFile)}`,
-    sourceUrl: args.gbrainId ? `gbrain://${args.gbrainId}` : undefined,
+    sourceUrl: `gbrain://${args.gbrainId}`,
     followUp: args.span.text.trim(),
     whyItMatters:
       'Captured from a voice memo by hermes-air. Pickup agent should evaluate whether it is in-scope before implementing.',
@@ -327,8 +366,8 @@ async function ingestFile(filePath: string): Promise<void> {
   saveSeen(ledger);
 
   const summaryParts = [
-    `🎙️ Memo ingested (${durationS}s).`,
-    gbrainId ? `gbrain: ${gbrainId.slice(0, 12)}…` : 'gbrain: unavailable',
+    `Memo ingested (${durationS}s).`,
+    `gbrain: ${gbrainId.slice(0, 12)}…`,
     filedIssues.length > 0
       ? `Linear: ${filedIssues.map(f => f.identifier).join(', ')}`
       : null,

--- a/scripts/hermes/launchd/README.md
+++ b/scripts/hermes/launchd/README.md
@@ -2,7 +2,7 @@
 
 Templates for the launchd unit files installed by `scripts/hermes/bootstrap-air.sh`.
 
-Each `.plist.template` uses `{{HOME}}`, `{{JOVIE_REPO}}`, and `{{HERMES_BIN}}` placeholders. The bootstrap script substitutes these at install time before copying to `~/Library/LaunchAgents/`.
+Each `.plist.template` uses `{{HOME}}`, `{{JOVIE_REPO}}`, `{{HERMES_BIN}}`, `{{GBRAIN_BIN}}`, `{{TSX_BIN}}`, and `{{TAILSCALE_IP}}` placeholders. The bootstrap script substitutes these at install time (via Python so values containing shell-special characters render safely) before copying to `~/Library/LaunchAgents/`.
 
 ## Units
 
@@ -27,21 +27,25 @@ Every unit writes stdout/stderr to `~/.hermes/logs/launchd/<label>.log` so failu
 ## Operating
 
 Boot a unit:
+
 ```bash
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/<label>.plist
 ```
 
 Stop a unit:
+
 ```bash
 launchctl bootout gui/$(id -u)/<label>
 ```
 
 Force re-run:
+
 ```bash
 launchctl kickstart -k gui/$(id -u)/<label>
 ```
 
 Check status:
+
 ```bash
 launchctl print gui/$(id -u)/<label>
 ```

--- a/scripts/hermes/launchd/README.md
+++ b/scripts/hermes/launchd/README.md
@@ -1,0 +1,47 @@
+# Hermes-Air launchd Units
+
+Templates for the launchd unit files installed by `scripts/hermes/bootstrap-air.sh`.
+
+Each `.plist.template` uses `{{HOME}}`, `{{JOVIE_REPO}}`, and `{{HERMES_BIN}}` placeholders. The bootstrap script substitutes these at install time before copying to `~/Library/LaunchAgents/`.
+
+## Units
+
+| File | Schedule | Purpose |
+|---|---|---|
+| `co.jovie.hermes.daemon.plist.template` | RunAtLoad + KeepAlive | The Hermes serve daemon (gateway + sub-agents) |
+| `co.jovie.hermes.watchdog.plist.template` | every 60s | Restart daemon if `/health` fails |
+| `co.jovie.hermes.gbrain-server.plist.template` | RunAtLoad + KeepAlive | gbrain serve on Tailscale interface |
+| `co.jovie.hermes.voice-memo-watcher.plist.template` | WatchPaths | New voice memo → ingest |
+| `co.jovie.hermes.cron-hud.plist.template` | every 5 min | Refresh HUD snapshot |
+| `co.jovie.hermes.cron-pr-monitor.plist.template` | every 10 min | Detect stuck PRs |
+| `co.jovie.hermes.cron-ci-monitor.plist.template` | every 10 min | Detect CI failures on main |
+| `co.jovie.hermes.cron-cost-monitor.plist.template` | every 60 min | Cost kill switch |
+| `co.jovie.hermes.cron-daily-briefing.plist.template` | 07:00 daily | Morning briefing to Telegram |
+| `co.jovie.hermes.cron-deterministic-tracker.plist.template` | 03:00 daily | Self-improvement clustering |
+| `co.jovie.hermes.cron-free-model-health.plist.template` | 02:00 daily | Free-model rankings refresh |
+
+## Logs
+
+Every unit writes stdout/stderr to `~/.hermes/logs/launchd/<label>.log` so failures are diagnosable without `launchctl print`.
+
+## Operating
+
+Boot a unit:
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/<label>.plist
+```
+
+Stop a unit:
+```bash
+launchctl bootout gui/$(id -u)/<label>
+```
+
+Force re-run:
+```bash
+launchctl kickstart -k gui/$(id -u)/<label>
+```
+
+Check status:
+```bash
+launchctl print gui/$(id -u)/<label>
+```

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-ci-monitor.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-ci-monitor.plist.template
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-ci-monitor</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/ci-failure-monitor.ts</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>600</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-ci-monitor.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-ci-monitor.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-cost-monitor.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-cost-monitor.plist.template
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-cost-monitor</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/cost-monitor.ts</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>3600</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-cost-monitor.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-cost-monitor.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-daily-briefing.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-daily-briefing.plist.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-daily-briefing</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/daily-briefing.ts</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>7</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-daily-briefing.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-daily-briefing.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-deterministic-tracker.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-deterministic-tracker.plist.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-deterministic-tracker</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/deterministic-tracker.ts</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-deterministic-tracker.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-deterministic-tracker.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-free-model-health.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-free-model-health.plist.template
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-free-model-health</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/free-model-health.ts</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>2</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-free-model-health.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-free-model-health.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-hud.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-hud.plist.template
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-hud</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/hud-refresh.ts</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-hud.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-hud.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-pr-monitor.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-pr-monitor.plist.template
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-pr-monitor</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/pr-stuck-monitor.ts</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>600</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-pr-monitor.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-pr-monitor.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/launchd/co.jovie.hermes.daemon.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.daemon.plist.template
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.daemon</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{HERMES_BIN}}</string>
+        <string>serve</string>
+        <string>--config</string>
+        <string>{{HOME}}/.hermes/config.yaml</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/daemon.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/daemon.err.log</string>
+    <key>ProcessType</key>
+    <string>Interactive</string>
+</dict>
+</plist>

--- a/scripts/hermes/launchd/co.jovie.hermes.gbrain-server.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.gbrain-server.plist.template
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.gbrain-server</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{GBRAIN_BIN}}</string>
+        <string>serve</string>
+        <string>--bind</string>
+        <string>{{TAILSCALE_IP}}</string>
+        <string>--port</string>
+        <string>7801</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>GBRAIN_HOME</key>
+        <string>{{HOME}}/.gbrain</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/gbrain.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/gbrain.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/launchd/co.jovie.hermes.voice-memo-watcher.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.voice-memo-watcher.plist.template
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.voice-memo-watcher</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/voice-memo-ingest.ts</string>
+    </array>
+    <key>WatchPaths</key>
+    <array>
+        <string>{{HOME}}/Library/Group Containers/group.com.apple.VoiceMemos.shared/Recordings</string>
+    </array>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>PATH</key>
+        <string>{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/voice-memo-watcher.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/voice-memo-watcher.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/launchd/co.jovie.hermes.watchdog.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.watchdog.plist.template
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <string>curl -fsS --max-time 5 http://localhost:7800/health > /dev/null || launchctl kickstart -k gui/$(id -u)/co.jovie.hermes.daemon</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>60</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/watchdog.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/watchdog.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/lib/free-model-router.ts
+++ b/scripts/hermes/lib/free-model-router.ts
@@ -1,0 +1,343 @@
+/**
+ * OpenRouter free-model rotator with Ollama fallback.
+ *
+ * Selects the best currently-free model from OpenRouter (filtered to ':free'
+ * variants), falls through to lower-ranked free models on 429 / 5xx, and
+ * finally falls back to a local Ollama instance running Qwen 3 4B.
+ *
+ * Cost contract: never selects a paid model. If OpenRouter ever returns a
+ * non-zero cost for a request, the model is ejected and we alert.
+ *
+ * Lives on the Air; not bundled with the web app.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+const HERMES_HOME = process.env.HERMES_HOME ?? join(homedir(), '.hermes');
+const STATE_DIR = join(HERMES_HOME, 'state');
+const RANKINGS_PATH = join(STATE_DIR, 'model-router-rankings.json');
+const LOGS_DIR = join(HERMES_HOME, 'logs');
+const COST_LOG = join(LOGS_DIR, 'cost.jsonl');
+
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY ?? '';
+const OPENROUTER_BASE = 'https://openrouter.ai/api/v1';
+const OLLAMA_BASE = process.env.OLLAMA_BASE_URL ?? 'http://localhost:11434/v1';
+const OLLAMA_MODEL = process.env.HERMES_OLLAMA_MODEL ?? 'qwen3:4b-q4_K_M';
+
+export interface ChatMessage {
+  readonly role: 'system' | 'user' | 'assistant';
+  readonly content: string;
+}
+
+export interface ChatOptions {
+  readonly maxTokens?: number;
+  readonly temperature?: number;
+  /** Hint for the router: which capability class is needed. */
+  readonly need?: 'routing' | 'reasoning' | 'summarize';
+  /** Caller identifier for cost log attribution. */
+  readonly caller: string;
+}
+
+export interface ChatResult {
+  readonly text: string;
+  readonly model: string;
+  readonly source: 'openrouter' | 'ollama';
+  readonly latencyMs: number;
+}
+
+interface ModelRanking {
+  readonly id: string;
+  readonly score: number;
+  readonly lastSuccessAt: string | null;
+  readonly lastFailureAt: string | null;
+  readonly failureCount: number;
+  readonly capabilities: ReadonlyArray<'routing' | 'reasoning' | 'summarize'>;
+}
+
+interface Rankings {
+  readonly updatedAt: string;
+  readonly models: ReadonlyArray<ModelRanking>;
+}
+
+const SEED_RANKINGS: Rankings = {
+  updatedAt: '1970-01-01T00:00:00Z',
+  models: [
+    {
+      id: 'deepseek/deepseek-r1:free',
+      score: 90,
+      lastSuccessAt: null,
+      lastFailureAt: null,
+      failureCount: 0,
+      capabilities: ['reasoning', 'routing', 'summarize'],
+    },
+    {
+      id: 'meta-llama/llama-3.3-70b-instruct:free',
+      score: 80,
+      lastSuccessAt: null,
+      lastFailureAt: null,
+      failureCount: 0,
+      capabilities: ['reasoning', 'routing', 'summarize'],
+    },
+    {
+      id: 'qwen/qwen-2.5-72b-instruct:free',
+      score: 75,
+      lastSuccessAt: null,
+      lastFailureAt: null,
+      failureCount: 0,
+      capabilities: ['reasoning', 'routing', 'summarize'],
+    },
+    {
+      id: 'google/gemini-2.0-flash-exp:free',
+      score: 70,
+      lastSuccessAt: null,
+      lastFailureAt: null,
+      failureCount: 0,
+      capabilities: ['routing', 'summarize'],
+    },
+    {
+      id: 'mistralai/mistral-small-3:free',
+      score: 60,
+      lastSuccessAt: null,
+      lastFailureAt: null,
+      failureCount: 0,
+      capabilities: ['routing', 'summarize'],
+    },
+  ],
+};
+
+function loadRankings(): Rankings {
+  if (!existsSync(RANKINGS_PATH)) {
+    return SEED_RANKINGS;
+  }
+  try {
+    return JSON.parse(readFileSync(RANKINGS_PATH, 'utf8')) as Rankings;
+  } catch {
+    return SEED_RANKINGS;
+  }
+}
+
+function saveRankings(rankings: Rankings): void {
+  writeFileSync(RANKINGS_PATH, JSON.stringify(rankings, null, 2));
+}
+
+function logCost(entry: Record<string, unknown>): void {
+  try {
+    const line = `${JSON.stringify({ ...entry, ts: new Date().toISOString() })}\n`;
+    writeFileSync(COST_LOG, line, { flag: 'a' });
+  } catch {
+    // Best effort; never throw from logging.
+  }
+}
+
+function recordOutcome(modelId: string, outcome: 'success' | 'failure'): void {
+  const rankings = loadRankings();
+  const now = new Date().toISOString();
+  const next: Rankings = {
+    updatedAt: now,
+    models: rankings.models.map(m => {
+      if (m.id !== modelId) return m;
+      if (outcome === 'success') {
+        return {
+          ...m,
+          lastSuccessAt: now,
+          failureCount: 0,
+          score: Math.min(100, m.score + 1),
+        };
+      }
+      return {
+        ...m,
+        lastFailureAt: now,
+        failureCount: m.failureCount + 1,
+        score: Math.max(0, m.score - 5),
+      };
+    }),
+  };
+  saveRankings(next);
+}
+
+function pickCandidates(need: ChatOptions['need']): ReadonlyArray<string> {
+  const rankings = loadRankings();
+  const filtered = need
+    ? rankings.models.filter(m => m.capabilities.includes(need))
+    : rankings.models;
+  return [...filtered]
+    .sort((a, b) => b.score - a.score)
+    .filter(m => m.failureCount < 5)
+    .map(m => m.id);
+}
+
+async function callOpenRouter(
+  modelId: string,
+  messages: ReadonlyArray<ChatMessage>,
+  options: ChatOptions
+): Promise<ChatResult> {
+  if (!OPENROUTER_API_KEY) {
+    throw new Error('OPENROUTER_API_KEY missing');
+  }
+  const start = Date.now();
+  const response = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+      'Content-Type': 'application/json',
+      'HTTP-Referer': 'https://jov.ie',
+      'X-Title': 'Jovie Hermes (Air)',
+    },
+    body: JSON.stringify({
+      model: modelId,
+      messages,
+      max_tokens: options.maxTokens ?? 1024,
+      temperature: options.temperature ?? 0.3,
+    }),
+    signal: AbortSignal.timeout(60_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `OpenRouter ${response.status} for ${modelId}: ${await response.text().catch(() => '')}`
+    );
+  }
+
+  const data = (await response.json()) as {
+    choices?: ReadonlyArray<{ message?: { content?: string } }>;
+    usage?: { total_cost?: number };
+  };
+
+  const cost = data.usage?.total_cost ?? 0;
+  if (cost > 0) {
+    logCost({
+      model: modelId,
+      cost,
+      caller: options.caller,
+      source: 'openrouter',
+    });
+    throw new Error(
+      `PAID_MODEL_DETECTED model=${modelId} cost=${cost}; ejecting`
+    );
+  }
+
+  const text = data.choices?.[0]?.message?.content ?? '';
+  return {
+    text,
+    model: modelId,
+    source: 'openrouter',
+    latencyMs: Date.now() - start,
+  };
+}
+
+async function callOllama(
+  messages: ReadonlyArray<ChatMessage>,
+  options: ChatOptions
+): Promise<ChatResult> {
+  const start = Date.now();
+  const response = await fetch(`${OLLAMA_BASE}/chat/completions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: OLLAMA_MODEL,
+      messages,
+      max_tokens: options.maxTokens ?? 1024,
+      temperature: options.temperature ?? 0.3,
+      stream: false,
+    }),
+    signal: AbortSignal.timeout(120_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Ollama ${response.status}: ${await response.text().catch(() => '')}`
+    );
+  }
+
+  const data = (await response.json()) as {
+    choices?: ReadonlyArray<{ message?: { content?: string } }>;
+  };
+
+  return {
+    text: data.choices?.[0]?.message?.content ?? '',
+    model: OLLAMA_MODEL,
+    source: 'ollama',
+    latencyMs: Date.now() - start,
+  };
+}
+
+export async function chat(
+  messages: ReadonlyArray<ChatMessage>,
+  options: ChatOptions
+): Promise<ChatResult> {
+  const candidates = pickCandidates(options.need);
+
+  for (const modelId of candidates) {
+    try {
+      const result = await callOpenRouter(modelId, messages, options);
+      recordOutcome(modelId, 'success');
+      return result;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      const isRateLimit = msg.includes('429') || msg.includes('rate');
+      const isPaid = msg.includes('PAID_MODEL_DETECTED');
+      recordOutcome(modelId, 'failure');
+      if (isPaid) {
+        // Mark as a hard ejection; never retry this model until explicit reset.
+        const rankings = loadRankings();
+        saveRankings({
+          updatedAt: new Date().toISOString(),
+          models: rankings.models.map(m =>
+            m.id === modelId ? { ...m, failureCount: 999, score: 0 } : m
+          ),
+        });
+      }
+      logCost({
+        event: 'router_fallthrough',
+        model: modelId,
+        reason: isRateLimit ? 'rate_limit' : isPaid ? 'paid_detected' : 'error',
+        caller: options.caller,
+      });
+      // Continue to next candidate.
+    }
+  }
+
+  // All OpenRouter free models exhausted; fall back to Ollama.
+  try {
+    const result = await callOllama(messages, options);
+    logCost({
+      event: 'ollama_fallback',
+      caller: options.caller,
+      latencyMs: result.latencyMs,
+    });
+    return result;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logCost({ event: 'all_unavailable', caller: options.caller, error: msg });
+    throw new Error(`All free model paths unavailable: ${msg}`);
+  }
+}
+
+/** Probe a single model with a tiny prompt; used by free-model-health.ts. */
+export async function probeModel(modelId: string): Promise<{
+  readonly ok: boolean;
+  readonly latencyMs: number;
+  readonly error?: string;
+}> {
+  const start = Date.now();
+  try {
+    await callOpenRouter(
+      modelId,
+      [{ role: 'user', content: 'reply with the single word OK' }],
+      { maxTokens: 5, caller: 'free-model-health', need: 'routing' }
+    );
+    return { ok: true, latencyMs: Date.now() - start };
+  } catch (err) {
+    return {
+      ok: false,
+      latencyMs: Date.now() - start,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export function listRankings(): Rankings {
+  return loadRankings();
+}

--- a/scripts/hermes/lib/free-model-router.ts
+++ b/scripts/hermes/lib/free-model-router.ts
@@ -11,15 +11,13 @@
  * Lives on the Air; not bundled with the web app.
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
 
-const HERMES_HOME = process.env.HERMES_HOME ?? join(homedir(), '.hermes');
-const STATE_DIR = join(HERMES_HOME, 'state');
-const RANKINGS_PATH = join(STATE_DIR, 'model-router-rankings.json');
-const LOGS_DIR = join(HERMES_HOME, 'logs');
-const COST_LOG = join(LOGS_DIR, 'cost.jsonl');
+import { HERMES_PATHS } from './hermes-paths';
+
+const RANKINGS_PATH = HERMES_PATHS.modelRankings;
+const COST_LOG = HERMES_PATHS.costLog;
 
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY ?? '';
 const OPENROUTER_BASE = 'https://openrouter.ai/api/v1';
@@ -119,11 +117,13 @@ function loadRankings(): Rankings {
 }
 
 function saveRankings(rankings: Rankings): void {
+  mkdirSync(dirname(RANKINGS_PATH), { recursive: true });
   writeFileSync(RANKINGS_PATH, JSON.stringify(rankings, null, 2));
 }
 
 function logCost(entry: Record<string, unknown>): void {
   try {
+    mkdirSync(dirname(COST_LOG), { recursive: true });
     const line = `${JSON.stringify({ ...entry, ts: new Date().toISOString() })}\n`;
     writeFileSync(COST_LOG, line, { flag: 'a' });
   } catch {

--- a/scripts/hermes/lib/heavy-job-lock.ts
+++ b/scripts/hermes/lib/heavy-job-lock.ts
@@ -1,0 +1,83 @@
+/**
+ * Mutex for "heavy" jobs on the Air (Ollama inference, whisper transcription).
+ * Prevents memory pressure from concurrent ~700 MB workloads on a 16 GB box.
+ *
+ * File-based lock with PID + stale-detection. Not a true mutex but adequate
+ * for two-process contention on a single Mac.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+
+import { HERMES_PATHS } from './hermes-paths';
+
+const LOCK = HERMES_PATHS.heavyJobLock;
+const STALE_MS = 5 * 60 * 1000;
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function withHeavyJobLock<T>(
+  caller: string,
+  fn: () => Promise<T>,
+  options: { readonly timeoutMs?: number } = {}
+): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (!existsSync(LOCK)) {
+      mkdirSync(dirname(LOCK), { recursive: true });
+      writeFileSync(
+        LOCK,
+        JSON.stringify({ caller, pid: process.pid, ts: Date.now() })
+      );
+      try {
+        return await fn();
+      } finally {
+        try {
+          unlinkSync(LOCK);
+        } catch {
+          // best effort
+        }
+      }
+    }
+
+    // Lock exists; check if stale.
+    try {
+      const data = JSON.parse(readFileSync(LOCK, 'utf8')) as {
+        pid: number;
+        ts: number;
+      };
+      const age = Date.now() - data.ts;
+      if (age > STALE_MS || !isProcessAlive(data.pid)) {
+        unlinkSync(LOCK);
+        continue;
+      }
+    } catch {
+      // Unreadable lock; treat as stale.
+      try {
+        unlinkSync(LOCK);
+      } catch {
+        // ignore
+      }
+      continue;
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+  }
+
+  throw new Error(`heavy-job-lock timeout after ${timeoutMs}ms for ${caller}`);
+}

--- a/scripts/hermes/lib/heavy-job-lock.ts
+++ b/scripts/hermes/lib/heavy-job-lock.ts
@@ -7,11 +7,12 @@
  */
 
 import {
-  existsSync,
+  closeSync,
   mkdirSync,
+  openSync,
   readFileSync,
   unlinkSync,
-  writeFileSync,
+  writeSync,
 } from 'node:fs';
 import { dirname } from 'node:path';
 
@@ -29,6 +30,68 @@ function isProcessAlive(pid: number): boolean {
   }
 }
 
+/**
+ * Atomically attempt to claim the lock. Returns true if we got it.
+ *
+ * Uses O_CREAT|O_EXCL ('wx') so two concurrent callers cannot both think
+ * they won — the kernel makes the create-if-not-exists atomic. This
+ * replaces the prior TOCTOU pattern (exists → write).
+ */
+function tryClaim(caller: string): boolean {
+  mkdirSync(dirname(LOCK), { recursive: true });
+  let fd: number;
+  try {
+    fd = openSync(LOCK, 'wx');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'EEXIST') return false;
+    throw err;
+  }
+  try {
+    writeSync(fd, JSON.stringify({ caller, pid: process.pid, ts: Date.now() }));
+  } finally {
+    closeSync(fd);
+  }
+  return true;
+}
+
+/**
+ * If the lock is genuinely stale (process gone or older than STALE_MS),
+ * remove it so the next claim attempt can succeed. Returns true if we
+ * removed it.
+ */
+function reapIfStale(): boolean {
+  let data: { pid?: number; ts?: number };
+  try {
+    data = JSON.parse(readFileSync(LOCK, 'utf8')) as {
+      pid?: number;
+      ts?: number;
+    };
+  } catch {
+    // Unreadable lock — assume corrupt, try to remove.
+    try {
+      unlinkSync(LOCK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  const age =
+    typeof data.ts === 'number'
+      ? Date.now() - data.ts
+      : Number.POSITIVE_INFINITY;
+  const dead = typeof data.pid === 'number' ? !isProcessAlive(data.pid) : true;
+  if (age > STALE_MS || dead) {
+    try {
+      unlinkSync(LOCK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
 export async function withHeavyJobLock<T>(
   caller: string,
   fn: () => Promise<T>,
@@ -38,12 +101,7 @@ export async function withHeavyJobLock<T>(
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
-    if (!existsSync(LOCK)) {
-      mkdirSync(dirname(LOCK), { recursive: true });
-      writeFileSync(
-        LOCK,
-        JSON.stringify({ caller, pid: process.pid, ts: Date.now() })
-      );
+    if (tryClaim(caller)) {
       try {
         return await fn();
       } finally {
@@ -54,29 +112,10 @@ export async function withHeavyJobLock<T>(
         }
       }
     }
-
-    // Lock exists; check if stale.
-    try {
-      const data = JSON.parse(readFileSync(LOCK, 'utf8')) as {
-        pid: number;
-        ts: number;
-      };
-      const age = Date.now() - data.ts;
-      if (age > STALE_MS || !isProcessAlive(data.pid)) {
-        unlinkSync(LOCK);
-        continue;
-      }
-    } catch {
-      // Unreadable lock; treat as stale.
-      try {
-        unlinkSync(LOCK);
-      } catch {
-        // ignore
-      }
-      continue;
+    // Couldn't claim; check for stale and retry.
+    if (!reapIfStale()) {
+      await new Promise(resolve => setTimeout(resolve, 2000));
     }
-
-    await new Promise(resolve => setTimeout(resolve, 2000));
   }
 
   throw new Error(`heavy-job-lock timeout after ${timeoutMs}ms for ${caller}`);

--- a/scripts/hermes/lib/hermes-paths.ts
+++ b/scripts/hermes/lib/hermes-paths.ts
@@ -1,0 +1,38 @@
+/**
+ * Canonical filesystem paths for Hermes-Air. Centralized so jobs and
+ * the bootstrap agree on where state lives.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export const HERMES_HOME =
+  process.env.HERMES_HOME ?? join(homedir(), '.hermes');
+
+export const HERMES_PATHS = {
+  home: HERMES_HOME,
+  config: join(HERMES_HOME, 'config.yaml'),
+  env: join(HERMES_HOME, '.env'),
+  logsDir: join(HERMES_HOME, 'logs'),
+  stateDir: join(HERMES_HOME, 'state'),
+  daemonLog: join(HERMES_HOME, 'logs', 'daemon.log'),
+  jobsLog: join(HERMES_HOME, 'logs', 'jobs.jsonl'),
+  voiceMemoLog: join(HERMES_HOME, 'logs', 'voice-memo.jsonl'),
+  dispatchLog: join(HERMES_HOME, 'logs', 'dispatch.jsonl'),
+  costLog: join(HERMES_HOME, 'logs', 'cost.jsonl'),
+  voiceMemosSeen: join(HERMES_HOME, 'state', 'voice-memos-seen.json'),
+  heavyJobLock: join(HERMES_HOME, 'state', 'heavy-job.lock'),
+  modelRankings: join(HERMES_HOME, 'state', 'model-router-rankings.json'),
+  linearQueue: join(HERMES_HOME, 'state', 'linear-queue.jsonl'),
+  telegramChatId: join(HERMES_HOME, 'state', 'telegram-chat-id'),
+} as const;
+
+export const VOICE_MEMOS_RECORDINGS =
+  process.env.HERMES_VOICE_MEMOS_DIR ??
+  join(
+    homedir(),
+    'Library',
+    'Group Containers',
+    'group.com.apple.VoiceMemos.shared',
+    'Recordings'
+  );

--- a/scripts/hermes/lib/jobs-log.ts
+++ b/scripts/hermes/lib/jobs-log.ts
@@ -1,0 +1,48 @@
+/**
+ * Structured JSONL logger for Hermes cron jobs. Best-effort, never throws.
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { HERMES_PATHS } from './hermes-paths';
+
+export interface JobLogEntry {
+  readonly job: string;
+  readonly event: string;
+  readonly [key: string]: unknown;
+}
+
+export function logJobEvent(entry: JobLogEntry): void {
+  try {
+    mkdirSync(dirname(HERMES_PATHS.jobsLog), { recursive: true });
+    appendFileSync(
+      HERMES_PATHS.jobsLog,
+      `${JSON.stringify({ ...entry, ts: new Date().toISOString() })}\n`
+    );
+  } catch {
+    // never throw from logging
+  }
+}
+
+/** Wrap a job's main function with start/finish/error events. */
+export async function withJobLogging<T>(
+  job: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const start = Date.now();
+  logJobEvent({ job, event: 'start' });
+  try {
+    const result = await fn();
+    logJobEvent({ job, event: 'finish', durationMs: Date.now() - start });
+    return result;
+  } catch (err) {
+    logJobEvent({
+      job,
+      event: 'error',
+      durationMs: Date.now() - start,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}

--- a/scripts/hermes/lib/linear-client.ts
+++ b/scripts/hermes/lib/linear-client.ts
@@ -1,0 +1,169 @@
+/**
+ * Minimal Linear GraphQL client for Hermes-Air. Files issues using the
+ * canonical follow-up shape from .claude/rules/linear.md.
+ *
+ * Only needs: LINEAR_API_KEY (from ~/.hermes/.env).
+ * Falls back to writing to ~/.hermes/state/linear-queue.jsonl on network failure.
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import { HERMES_PATHS } from './hermes-paths';
+
+const LINEAR_API = 'https://api.linear.app/graphql';
+
+export interface FileIssueInput {
+  readonly title: string;
+  readonly description: string;
+  readonly teamKey?: string;
+  readonly labels?: ReadonlyArray<string>;
+  /** Pass through caller context for retry/dedupe. */
+  readonly source: string;
+}
+
+export interface FileIssueResult {
+  readonly success: boolean;
+  readonly id?: string;
+  readonly identifier?: string;
+  readonly url?: string;
+  readonly queued?: boolean;
+  readonly error?: string;
+}
+
+interface TeamLookup {
+  readonly id: string;
+  readonly key: string;
+}
+
+async function gql<T>(
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T> {
+  const key = process.env.LINEAR_API_KEY;
+  if (!key) throw new Error('LINEAR_API_KEY missing');
+  const response = await fetch(LINEAR_API, {
+    method: 'POST',
+    headers: {
+      Authorization: key,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Linear ${response.status}: ${await response.text().catch(() => '')}`
+    );
+  }
+  const json = (await response.json()) as {
+    data?: T;
+    errors?: ReadonlyArray<unknown>;
+  };
+  if (json.errors && json.errors.length > 0) {
+    throw new Error(`Linear GraphQL errors: ${JSON.stringify(json.errors)}`);
+  }
+  if (!json.data) throw new Error('Linear: empty response');
+  return json.data;
+}
+
+async function findTeamId(teamKey: string): Promise<string> {
+  const data = await gql<{ teams: { nodes: ReadonlyArray<TeamLookup> } }>(
+    `query Teams { teams { nodes { id key } } }`,
+    {}
+  );
+  const team = data.teams.nodes.find(t => t.key === teamKey);
+  if (!team) throw new Error(`Linear team not found: ${teamKey}`);
+  return team.id;
+}
+
+function queueForRetry(input: FileIssueInput, error: string): void {
+  try {
+    mkdirSync(dirname(HERMES_PATHS.linearQueue), { recursive: true });
+    appendFileSync(
+      HERMES_PATHS.linearQueue,
+      `${JSON.stringify({ input, error, ts: new Date().toISOString() })}\n`
+    );
+  } catch {
+    // best effort
+  }
+}
+
+export async function fileIssue(
+  input: FileIssueInput
+): Promise<FileIssueResult> {
+  const teamKey = input.teamKey ?? 'JOV';
+  try {
+    const teamId = await findTeamId(teamKey);
+    const data = await gql<{
+      issueCreate: {
+        success: boolean;
+        issue: { id: string; identifier: string; url: string };
+      };
+    }>(
+      `mutation Create($input: IssueCreateInput!) {
+        issueCreate(input: $input) {
+          success
+          issue { id identifier url }
+        }
+      }`,
+      {
+        input: {
+          teamId,
+          title: input.title,
+          description: input.description,
+        },
+      }
+    );
+    if (!data.issueCreate.success) {
+      throw new Error('issueCreate returned success=false');
+    }
+    return {
+      success: true,
+      id: data.issueCreate.issue.id,
+      identifier: data.issueCreate.issue.identifier,
+      url: data.issueCreate.issue.url,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    queueForRetry(input, msg);
+    return { success: false, queued: true, error: msg };
+  }
+}
+
+/**
+ * Canonical follow-up issue body per .claude/rules/linear.md.
+ */
+export function buildFollowUpBody(args: {
+  readonly source: string;
+  readonly sourceUrl?: string;
+  readonly followUp: string;
+  readonly whyItMatters: string;
+  readonly classification: 'Required' | 'Candidate';
+  readonly acceptanceCriteria: string;
+  readonly dependency?: string;
+}): string {
+  return [
+    '## Source',
+    `- Filed by: hermes-air`,
+    `- Origin: ${args.source}`,
+    args.sourceUrl ? `- Reference: ${args.sourceUrl}` : null,
+    '',
+    '## Follow-up',
+    args.followUp,
+    '',
+    '## Why it matters',
+    args.whyItMatters,
+    '',
+    '## Classification',
+    args.classification,
+    '',
+    `## ${args.classification === 'Required' ? 'Acceptance criteria' : 'Triage question'}`,
+    args.acceptanceCriteria,
+    '',
+    '## Dependency',
+    args.dependency ?? 'None',
+  ]
+    .filter((line): line is string => line !== null)
+    .join('\n');
+}

--- a/scripts/hermes/lib/linear-client.ts
+++ b/scripts/hermes/lib/linear-client.ts
@@ -10,6 +10,7 @@ import { appendFileSync, mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 import { HERMES_PATHS } from './hermes-paths';
+import { withRetry } from './retry';
 
 const LINEAR_API = 'https://api.linear.app/graphql';
 
@@ -38,54 +39,92 @@ interface TeamLookup {
 
 async function gql<T>(
   query: string,
-  variables: Record<string, unknown>
+  variables: Record<string, unknown>,
+  caller: string
 ): Promise<T> {
   const key = process.env.LINEAR_API_KEY;
   if (!key) throw new Error('LINEAR_API_KEY missing');
-  const response = await fetch(LINEAR_API, {
-    method: 'POST',
-    headers: {
-      Authorization: key,
-      'Content-Type': 'application/json',
+  return withRetry(
+    async () => {
+      const response = await fetch(LINEAR_API, {
+        method: 'POST',
+        headers: {
+          Authorization: key,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query, variables }),
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (response.status === 429 || response.status >= 500) {
+        // transient — retry
+        throw new Error(`Linear ${response.status}`);
+      }
+      if (!response.ok) {
+        // 4xx other than 429 = permanent; don't retry
+        const body = await response.text().catch(() => '');
+        const err = new Error(`Linear ${response.status}: ${body}`);
+        (err as Error & { permanent?: boolean }).permanent = true;
+        throw err;
+      }
+      const json = (await response.json()) as {
+        data?: T;
+        errors?: ReadonlyArray<unknown>;
+      };
+      if (json.errors && json.errors.length > 0) {
+        throw new Error(
+          `Linear GraphQL errors: ${JSON.stringify(json.errors)}`
+        );
+      }
+      if (!json.data) throw new Error('Linear: empty response');
+      return json.data;
     },
-    body: JSON.stringify({ query, variables }),
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (!response.ok) {
-    throw new Error(
-      `Linear ${response.status}: ${await response.text().catch(() => '')}`
-    );
-  }
-  const json = (await response.json()) as {
-    data?: T;
-    errors?: ReadonlyArray<unknown>;
-  };
-  if (json.errors && json.errors.length > 0) {
-    throw new Error(`Linear GraphQL errors: ${JSON.stringify(json.errors)}`);
-  }
-  if (!json.data) throw new Error('Linear: empty response');
-  return json.data;
+    { caller: `linear.${caller}`, attempts: 3 }
+  );
 }
 
 async function findTeamId(teamKey: string): Promise<string> {
   const data = await gql<{ teams: { nodes: ReadonlyArray<TeamLookup> } }>(
     `query Teams { teams { nodes { id key } } }`,
-    {}
+    {},
+    'findTeamId'
   );
   const team = data.teams.nodes.find(t => t.key === teamKey);
   if (!team) throw new Error(`Linear team not found: ${teamKey}`);
   return team.id;
 }
 
-function queueForRetry(input: FileIssueInput, error: string): void {
+async function findLabelIds(
+  teamId: string,
+  names: ReadonlyArray<string>
+): Promise<ReadonlyArray<string>> {
+  if (names.length === 0) return [];
+  const data = await gql<{
+    team: { labels: { nodes: ReadonlyArray<{ id: string; name: string }> } };
+  }>(
+    `query TeamLabels($id: String!) {
+      team(id: $id) { labels { nodes { id name } } }
+    }`,
+    { id: teamId },
+    'findLabelIds'
+  );
+  const wanted = new Set(names);
+  return data.team.labels.nodes.filter(n => wanted.has(n.name)).map(n => n.id);
+}
+
+/**
+ * Best-effort append. Returns true if the queue line was persisted; false
+ * means we couldn't even persist the retry intent (rare, e.g. disk full).
+ */
+function queueForRetry(input: FileIssueInput, error: string): boolean {
   try {
     mkdirSync(dirname(HERMES_PATHS.linearQueue), { recursive: true });
     appendFileSync(
       HERMES_PATHS.linearQueue,
       `${JSON.stringify({ input, error, ts: new Date().toISOString() })}\n`
     );
+    return true;
   } catch {
-    // best effort
+    return false;
   }
 }
 
@@ -95,6 +134,7 @@ export async function fileIssue(
   const teamKey = input.teamKey ?? 'JOV';
   try {
     const teamId = await findTeamId(teamKey);
+    const labelIds = await findLabelIds(teamId, input.labels ?? []);
     const data = await gql<{
       issueCreate: {
         success: boolean;
@@ -112,8 +152,10 @@ export async function fileIssue(
           teamId,
           title: input.title,
           description: input.description,
+          ...(labelIds.length > 0 ? { labelIds } : {}),
         },
-      }
+      },
+      'issueCreate'
     );
     if (!data.issueCreate.success) {
       throw new Error('issueCreate returned success=false');
@@ -126,8 +168,8 @@ export async function fileIssue(
     };
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    queueForRetry(input, msg);
-    return { success: false, queued: true, error: msg };
+    const queued = queueForRetry(input, msg);
+    return { success: false, queued, error: msg };
   }
 }
 

--- a/scripts/hermes/lib/retry.ts
+++ b/scripts/hermes/lib/retry.ts
@@ -1,0 +1,39 @@
+/**
+ * Tiny retry-with-jittered-exponential-backoff helper. Used by every
+ * outbound HTTP call from the Air so transient 429/5xx/network blips
+ * don't translate into a missed brain dump or a noisy Telegram alert.
+ */
+
+export interface RetryOptions {
+  readonly attempts?: number;
+  readonly baseMs?: number;
+  readonly maxMs?: number;
+  /** Caller-visible label for log attribution. */
+  readonly caller: string;
+}
+
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions
+): Promise<T> {
+  const attempts = options.attempts ?? 3;
+  const baseMs = options.baseMs ?? 500;
+  const maxMs = options.maxMs ?? 8000;
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (i === attempts - 1) break;
+      const exp = Math.min(maxMs, baseMs * 2 ** i);
+      const jitter = Math.random() * exp * 0.3;
+      await new Promise(resolve => setTimeout(resolve, exp + jitter));
+    }
+  }
+  throw new Error(
+    `withRetry(${options.caller}) failed after ${attempts} attempts: ${
+      lastErr instanceof Error ? lastErr.message : String(lastErr)
+    }`
+  );
+}

--- a/scripts/hermes/lib/telegram-client.ts
+++ b/scripts/hermes/lib/telegram-client.ts
@@ -1,0 +1,43 @@
+/**
+ * Minimal Telegram bot client for Hermes-Air outbound notifications.
+ * Inbound message handling lives inside the Hermes daemon's built-in gateway.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+
+import { HERMES_PATHS } from './hermes-paths';
+
+const TELEGRAM_API = 'https://api.telegram.org';
+
+function getChatId(): string | null {
+  const fromEnv = process.env.HERMES_TELEGRAM_CHAT_ID;
+  if (fromEnv) return fromEnv;
+  if (!existsSync(HERMES_PATHS.telegramChatId)) return null;
+  try {
+    return readFileSync(HERMES_PATHS.telegramChatId, 'utf8').trim();
+  } catch {
+    return null;
+  }
+}
+
+export async function sendTelegram(text: string): Promise<boolean> {
+  const token = process.env.HERMES_TELEGRAM_BOT_TOKEN;
+  const chatId = getChatId();
+  if (!token || !chatId) return false;
+  try {
+    const response = await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        parse_mode: 'Markdown',
+        disable_web_page_preview: true,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/scripts/hermes/lib/telegram-client.ts
+++ b/scripts/hermes/lib/telegram-client.ts
@@ -20,6 +20,13 @@ function getChatId(): string | null {
   }
 }
 
+/**
+ * Send a plain-text Telegram message. We intentionally do NOT use
+ * parse_mode='Markdown' because hermes-air messages can contain user voice
+ * memo content, error strings with backticks, and JSON snippets — any of
+ * which can trip Telegram's parser and silently drop the message. Plain
+ * text is robust; we don't need formatting for ops notifications.
+ */
 export async function sendTelegram(text: string): Promise<boolean> {
   const token = process.env.HERMES_TELEGRAM_BOT_TOKEN;
   const chatId = getChatId();
@@ -30,8 +37,7 @@ export async function sendTelegram(text: string): Promise<boolean> {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         chat_id: chatId,
-        text,
-        parse_mode: 'Markdown',
+        text: text.slice(0, 4000), // Telegram hard cap 4096; leave headroom
         disable_web_page_preview: true,
       }),
       signal: AbortSignal.timeout(10_000),


### PR DESCRIPTION
## Summary

Sets up the in-repo scaffolding for running Hermes as a dedicated always-on orchestration node on a 16 GB MacBook Air. The Air ingests brain dumps (Telegram + macOS Voice Memos via iCloud), persists everything to gbrain (Air-hosted, exposed to the Pro over Tailscale), and files Linear issues that the Pro's existing Hermes issue runner picks up automatically. Air does no coding — Linear is the only contract between Air and Pro.

## Why

Pre-PMF cash constraint: we want a 24/7 "anything broken?" monitor and brain-dump inbox that costs **$0/mo**. The Air becomes a single-purpose orchestration node so the 32 GB Pro stays focused on coding work. Architecture decision record lives at \`.claude/plans/system-instruction-you-are-working-polished-gadget.md\`.

## What's in this PR

This is **scaffolding only** — nothing runs on the Air until \`scripts/hermes/bootstrap-air.sh\` is executed on the target machine. That's a deliberate cut so this PR can be reviewed without infra side effects.

### New (scripts/hermes/)
- \`bootstrap-air.sh\` — idempotent installer with \`--reconfigure\`, \`--uninstall\`, \`--resume-after-cost-kill\` modes
- \`config.air.template.yaml\` — Hermes config with sub-agent profiles (chief / cfo / founder-os / code-orchestrator), gateway (Telegram), MCP allowlists, system limits
- \`launchd/*.plist.template\` (10 units) — daemon, watchdog, gbrain-server, voice-memo-watcher, plus 6 cron jobs
- \`lib/\` — \`free-model-router\` (OpenRouter \`:free\` rotation + Ollama Qwen 3 4B fallback, ejects models that go silently paid), Linear client with canonical follow-up shape, Telegram client, heavy-job lock semaphore, structured JSONL logger, paths
- \`jobs/\` — voice-memo-ingest, pr-stuck-monitor, ci-failure-monitor, hud-refresh, daily-briefing, deterministic-tracker (the self-improvement engine), cost-monitor (sentinel kill switch), free-model-health

### New (docs + rules)
- \`.claude/rules/hermes-air.md\` — operating contract (what the Air may/may not do; profile gates)
- \`docs/HERMES_AIR.md\` — operator runbook (status checks, recovery procedures, secrets list, teardown)
- Workspace topology entries in CLAUDE.md, .claude/rules/environment.md, docs/AGENT_OS_ARCHITECTURE.md

### Modified (apps/web)
- \`apps/web/types/ai-ops.ts\` and \`apps/web/lib/hermes/dispatch.ts\` — \`'hermes-air'\` added as a recognized \`HermesAiOpsSource\` so the HUD attributes Air-originated dispatches separately
- \`apps/web/lib/hud/ai-ops.ts\` — Record<source, status> entries updated for the new source key (required by typecheck)

## Cost Impact

**Target: \$0/mo.**
- Inference: OpenRouter \`:free\` model rotation (DeepSeek R1, Llama 3.3 70B, Qwen 2.5 72B, Gemini 2.0 Flash Exp, Mistral Small 3, etc.)
- Fallback: local Ollama Qwen 3 4B (zero idle RAM via \`OLLAMA_KEEP_ALIVE=0\`)
- Telegram bot: \$0
- Tailscale: \$0 (free tier, 2 devices well under 100-device limit)
- gbrain: \$0 (local PGLite on Air)
- **Sentinel:** \`cost-monitor.ts\` runs hourly. Any paid spend >\$0 in 24h kills all non-watchdog launchd jobs and requires \`bootstrap-air.sh --resume-after-cost-kill\` to resume.

## Verification

Local (in this repo):
- ✅ \`pnpm --filter @jovie/web run typecheck\` passes
- ✅ \`pnpm biome check\` passes on all touched paths
- ⏳ CI will exercise the dispatch + ai-ops type changes

End-to-end (after Air bootstrap, not in this PR):
1. Telegram a test message → daemon responds <5s
2. Record a 10s voice memo on iPhone → within ~2 min: gbrain entry written + Telegram confirmation
3. Voice-memo containing "file a Linear issue for X" → Linear issue filed using canonical follow-up shape → Pro's existing runner picks it up → draft PR opens within ~10 min
4. \`kill -9 \$(pgrep hermes)\` → daemon auto-restarts within 60s
5. Set cost cap to \$0.01, trigger a paid call → kill switch trips, Telegram alert fires

Full verification checklist is in \`docs/HERMES_AIR.md\`.

## Out of scope (filed as follow-ups in the plan)

- Pro-side remote-MCP gbrain client config (one-line change, separate session after Air bootstrap)
- Evaluate Supabase sync for gbrain (revisit ~2026-08-12)
- Upgrade Ollama fallback to Qwen 3 8B if 4B quality insufficient
- Deprecate \`scripts/dispatch-kanban.sh\` once Hermes-driven dispatch is proven
- iMessage gateway (unlikely; Telegram should suffice)

## Linear

Ad-hoc (no orchestrator-dispatched ticket). The Air is itself the issue runner for follow-ups once bootstrapped.

## Test plan

- [ ] CI: typecheck, biome, build all pass
- [ ] CI: bot reviews (CodeRabbit, Greptile) have no unaddressed blockers
- [ ] Manual: read through bootstrap-air.sh flow; confirm idempotency and Doppler scoping
- [ ] Manual: read through voice-memo-ingest.ts span classification logic
- [ ] Manual: confirm \`HermesAiOpsSource\` change doesn't break existing tests (\`apps/web/tests/unit/hermes/dispatch.test.ts\` only uses pre-existing source values)
- [ ] Air bootstrap: run \`./scripts/hermes/bootstrap-air.sh\` on the 16 GB Air and walk through verification
- [ ] Smoke: Telegram brain-dump → Linear issue → Pro runner pickup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hermes-Air: always-on MacBook Air orchestration that ingests voice memos and Telegram, files Linear follow-ups, monitors CI/PR health, tracks costs with automatic kill-switches, and sends daily briefings.
  * Added scheduled background jobs for tracking deterministic patterns, free-model health, HUD refresh, and voice-memo ingestion.
  * Hermes-Air now appears as a recognized dispatch source in the HUD.

* **Documentation**
  * Complete runbook, architecture notes, bootstrap instructions, and launch agent guidance for Hermes-Air.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->