### PR TITLE
fix(ci): validate canary deploy env directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3674,8 +3674,8 @@ jobs:
               mv "${env_file}.tmp" "$env_file"
             fi
           done
-      - name: Check signup readiness (production env file)
-        run: pnpm --filter=@jovie/web exec tsx scripts/check-signup-readiness.ts --target=prd --source=vercel-file --file=.vercel/.env.production.local
+      - name: Check signup readiness (production deploy env)
+        run: pnpm --filter=@jovie/web exec tsx scripts/check-signup-readiness.ts --target=prd --source=env
       - name: Build (preview target for staging verification)
         run: |
           scope_args=()

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -174,6 +174,19 @@ describe('deploy workflow Vercel env resolution', () => {
     }
   });
 
+  it('checks production signup readiness against the deploy env instead of the pulled Vercel file', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const readinessStep = getStepBlock(
+      workflow,
+      'Check signup readiness (production deploy env)'
+    );
+
+    expect(readinessStep).toContain('--target=prd');
+    expect(readinessStep).toContain('--source=env');
+    expect(readinessStep).not.toContain('--source=vercel-file');
+    expect(readinessStep).not.toContain('.vercel/.env.production.local');
+  });
+
   it('verifies production promotion through the canonical public alias', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const promoteStep = getStepBlock(


### PR DESCRIPTION
## Summary
- change production signup readiness to validate the exported deploy environment instead of `.vercel/.env.production.local`
- add a workflow unit test so the gate cannot regress back to checking Vercel's pulled/redacted env file

## Why
The main deploy now syncs the required production signup keys into Vercel successfully, but `vercel pull --environment=production` does not expose those sensitive values in `.vercel/.env.production.local`. The build and deploy steps already inherit the exported Doppler/GitHub env, so the blocking readiness gate should validate that same deploy env.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write .github/workflows/ci.yml apps/web/tests/unit/ci/deploy-workflow.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm exec actionlint -shellcheck= .github/workflows/ci.yml`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder git diff --check`
- pre-push hook: Biome, proxy guard, Tailwind guard, typecheck, lint

Refs JOV-2332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment verification process to source configuration from the deployment environment instead of local files, enhancing deployment consistency.

* **Tests**
  * Added validation tests for production deployment environment verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9009?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->