### PR TITLE
fix(admin): normalize investor table actions

### DIFF
--- a/apps/web/app/app/(shell)/admin/investors/_components/InvestorTablePrimitives.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/_components/InvestorTablePrimitives.tsx
@@ -27,7 +27,7 @@ export function InvestorTableHeaderRow({
   children,
 }: Readonly<{ children: ReactNode }>) {
   return (
-    <tr className='border-b border-subtle text-left text-2xs text-tertiary-token'>
+    <tr className='border-b border-subtle text-left text-2xs font-caption text-secondary-token'>
       {children}
     </tr>
   );

--- a/apps/web/app/app/(shell)/admin/investors/links/InvestorLinksManager.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/links/InvestorLinksManager.tsx
@@ -26,6 +26,7 @@ import {
   DrawerSurfaceCard,
 } from '@/components/molecules/drawer';
 import { Dialog, DialogBody, DialogTitle } from '@/components/organisms/Dialog';
+import { TableIconButton } from '@/components/organisms/table';
 import { BASE_URL } from '@/constants/app';
 import { APP_ROUTES } from '@/constants/routes';
 import {
@@ -381,6 +382,7 @@ function LinkActions({
       icon: link.isActive ? CircleSlash : CheckCircle2,
       onClick: () => onToggleActive(link.id, !link.isActive),
     },
+    { id: 'separator', label: '' },
     {
       id: 'delete',
       label: 'Delete',
@@ -402,19 +404,19 @@ function LinkActions({
 
   return (
     <div className='flex items-center gap-2'>
-      <Button
-        variant='ghost'
-        size='sm'
+      <TableIconButton
+        ariaLabel='Copy shareable URL'
+        className='text-tertiary-token'
+        icon={
+          copied ? (
+            <Check className='h-3.5 w-3.5 text-success' />
+          ) : (
+            <Copy className='h-3.5 w-3.5' />
+          )
+        }
         onClick={handleCopy}
-        title='Copy shareable URL'
-        className='h-8 px-2'
-      >
-        {copied ? (
-          <Check className='h-3.5 w-3.5 text-success' />
-        ) : (
-          <Copy className='h-3.5 w-3.5' />
-        )}
-      </Button>
+        tooltip='Copy shareable URL'
+      />
       <TableActionMenu items={actionItems} align='end' />
     </div>
   );
@@ -538,6 +540,9 @@ export function InvestorLinksManager() {
       <ContentSurfaceCard className='overflow-hidden p-0'>
         <ContentSectionHeader
           title='Manage investor links'
+          className='flex-col items-start gap-2 py-3 sm:flex-row sm:items-center sm:gap-2 sm:py-1.5'
+          titleClassName='overflow-visible whitespace-normal sm:overflow-hidden sm:whitespace-nowrap'
+          actionsClassName='ml-0 w-full justify-end sm:ml-auto sm:w-auto'
           subtitle={(() => {
             if (links.length === 0)
               return 'Create shareable entry points into the investor portal.';


### PR DESCRIPTION
## Summary
- normalize investor table header typography to shell caption tokens
- replace the investor link copy action with the shared table icon primitive
- preserve the existing dropdown action behavior with a separator before Delete
- keep the investor links header readable on mobile while preserving the compact desktop row

## Checks
- JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh
- JOVIE_AGENT_PROFILE=coder pnpm exec biome check --write apps/web/app/app/(shell)/admin/investors/_components/InvestorTablePrimitives.tsx apps/web/app/app/(shell)/admin/investors/links/InvestorLinksManager.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck
- JOVIE_AGENT_PROFILE=coder git diff --check
- pre-push: biome check ., proxy guard, tailwind guard, typecheck, biome lint

## Visual QA
- Local auth-bypass screenshots captured for /app/admin/investors/links at 1440x1000 and 390x844.
- Browser QA measured 0px horizontal overflow on both viewports.
- Mobile header/title/action row was inspected after the responsive fix.
