### PR TITLE
fix(chat): stabilize entity provider registry

### DIFF
--- a/apps/web/components/jovie/components/ChatProvidersRegistrar.tsx
+++ b/apps/web/components/jovie/components/ChatProvidersRegistrar.tsx
@@ -1,10 +1,7 @@
 'use client';
 
 import { useEffect, useMemo } from 'react';
-import {
-  registerEntityProvider,
-  unregisterEntityProvider,
-} from '@/lib/commands/entities';
+import { registerEntityProvider } from '@/lib/commands/entities';
 import { artistProvider } from './artist-provider';
 import { createEventProvider } from './event-provider';
 import { createReleaseProvider } from './release-provider';
@@ -33,13 +30,14 @@ export function ChatProvidersRegistrar({
   );
 
   useEffect(() => {
-    registerEntityProvider(releaseProvider);
-    registerEntityProvider(artistProvider);
-    registerEntityProvider(eventProvider);
+    const unregisterReleaseProvider = registerEntityProvider(releaseProvider);
+    const unregisterArtistProvider = registerEntityProvider(artistProvider);
+    const unregisterEventProvider = registerEntityProvider(eventProvider);
+
     return () => {
-      unregisterEntityProvider(releaseProvider);
-      unregisterEntityProvider(artistProvider);
-      unregisterEntityProvider(eventProvider);
+      unregisterEventProvider();
+      unregisterArtistProvider();
+      unregisterReleaseProvider();
     };
   }, [releaseProvider, eventProvider]);
 

--- a/apps/web/components/jovie/components/EntityResolutionProvider.test.tsx
+++ b/apps/web/components/jovie/components/EntityResolutionProvider.test.tsx
@@ -161,6 +161,29 @@ describe('EntityResolutionProvider', () => {
     expect(renderCount).toBe(1);
   });
 
+  it('ignores entity cache updates for other profiles', async () => {
+    const client = new QueryClient();
+    let renderCount = 0;
+    const { result } = renderHook(
+      () => {
+        renderCount += 1;
+        return useEntityResolution('release', 'rel_other_profile');
+      },
+      { wrapper: wrapperWithClient(client, 'p1') }
+    );
+
+    await act(async () => {
+      client.setQueryData(queryKeys.releases.matrix('p2'), [
+        makeRelease('rel_other_profile', { title: 'Wrong profile' }),
+      ]);
+      client.setQueryData(queryKeys.events.list('p2'), [makeEvent('evt_p2')]);
+      await Promise.resolve();
+    });
+
+    expect(result.current.ref).toBeUndefined();
+    expect(renderCount).toBe(1);
+  });
+
   it('defers cache notifications that happen during child render', async () => {
     const client = new QueryClient();
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});

--- a/apps/web/lib/commands/entities.test.ts
+++ b/apps/web/lib/commands/entities.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { EntityKind } from '@/lib/chat/tokens';
+import {
+  type EntityProvider,
+  getEntityProvider,
+  listRegisteredKinds,
+  registerEntityProvider,
+  unregisterEntityProvider,
+} from './entities';
+
+const registeredProviders: EntityProvider[] = [];
+
+function makeProvider(
+  kind: EntityKind,
+  label: string,
+  registryKey?: string
+): EntityProvider {
+  const provider: EntityProvider = {
+    kind,
+    registryKey,
+    label,
+    useSearch: () => ({ items: [], isLoading: false }),
+    renderChip: () => null,
+  };
+  registeredProviders.push(provider);
+  return provider;
+}
+
+afterEach(() => {
+  for (const provider of registeredProviders.splice(0)) {
+    unregisterEntityProvider(provider);
+  }
+  vi.restoreAllMocks();
+});
+
+describe('entity provider registry', () => {
+  it('unregisters the active provider through the registration cleanup', () => {
+    const provider = makeProvider('release', 'Releases');
+    const unregister = registerEntityProvider(provider);
+
+    expect(getEntityProvider('release')).toBe(provider);
+    expect(listRegisteredKinds()).toContain('release');
+
+    unregister();
+
+    expect(getEntityProvider('release')).toBeUndefined();
+    expect(listRegisteredKinds()).not.toContain('release');
+  });
+
+  it('does not let a stale cleanup unregister a newer provider', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const staleProvider = makeProvider('event', 'Old events');
+    const activeProvider = makeProvider('event', 'New events');
+    const unregisterStaleProvider = registerEntityProvider(staleProvider);
+    registerEntityProvider(activeProvider);
+
+    unregisterStaleProvider();
+
+    expect(getEntityProvider('event')).toBe(activeProvider);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Replacing existing EntityProvider')
+    );
+  });
+
+  it('keeps duplicate registrations until each cleanup runs', () => {
+    const provider = makeProvider('artist', 'Artists');
+    const unregisterFirst = registerEntityProvider(provider);
+    const unregisterSecond = registerEntityProvider(provider);
+
+    unregisterFirst();
+
+    expect(getEntityProvider('artist')).toBe(provider);
+
+    unregisterSecond();
+
+    expect(getEntityProvider('artist')).toBeUndefined();
+  });
+
+  it('ref-counts providers with the same registry key', () => {
+    const firstProvider = makeProvider('release', 'Releases', 'release:p1');
+    const secondProvider = makeProvider('release', 'Releases', 'release:p1');
+    const unregisterFirst = registerEntityProvider(firstProvider);
+    const unregisterSecond = registerEntityProvider(secondProvider);
+
+    expect(getEntityProvider('release')).toBe(secondProvider);
+
+    unregisterFirst();
+
+    expect(getEntityProvider('release')).toBe(secondProvider);
+
+    unregisterSecond();
+
+    expect(getEntityProvider('release')).toBeUndefined();
+  });
+});

--- a/apps/web/lib/commands/entities.ts
+++ b/apps/web/lib/commands/entities.ts
@@ -111,16 +111,33 @@ export interface EntityProvider {
  * Kept as a mutable record so providers can register lazily from their own
  * files without forcing this module to import every hook at load time.
  */
-const PROVIDERS: Partial<Record<EntityKind, EntityProvider>> = {};
+interface ProviderRegistryEntry {
+  provider: EntityProvider;
+  registrations: number;
+}
 
-export function registerEntityProvider(provider: EntityProvider): void {
+const PROVIDERS: Partial<Record<EntityKind, ProviderRegistryEntry>> = {};
+
+function isSameProvider(
+  left: EntityProvider | undefined,
+  right: EntityProvider
+): boolean {
+  return (
+    left === right ||
+    (left?.registryKey !== undefined && left.registryKey === right.registryKey)
+  );
+}
+
+export function registerEntityProvider(provider: EntityProvider): () => void {
   const existing = PROVIDERS[provider.kind];
-  const isSameProvider =
-    existing === provider ||
-    (existing?.registryKey !== undefined &&
-      existing.registryKey === provider.registryKey);
 
-  if (existing && !isSameProvider) {
+  if (existing && isSameProvider(existing.provider, provider)) {
+    existing.provider = provider;
+    existing.registrations += 1;
+    return () => unregisterEntityProvider(provider);
+  }
+
+  if (existing) {
     // Dev warning only — multiple mount/unmount cycles (React strict mode,
     // test renders, profile switches) legitimately create new provider
     // instances for the same kind. Overwrite is the sane default; a true
@@ -130,19 +147,30 @@ export function registerEntityProvider(provider: EntityProvider): void {
         `If this is unexpected, check that the registrar is only mounted once.`
     );
   }
-  PROVIDERS[provider.kind] = provider;
+  PROVIDERS[provider.kind] = { provider, registrations: 1 };
+
+  return () => unregisterEntityProvider(provider);
 }
 
 export function unregisterEntityProvider(provider: EntityProvider): void {
-  if (PROVIDERS[provider.kind] === provider) {
-    delete PROVIDERS[provider.kind];
+  const existing = PROVIDERS[provider.kind];
+
+  if (!existing || !isSameProvider(existing.provider, provider)) {
+    return;
   }
+
+  if (existing.registrations > 1) {
+    existing.registrations -= 1;
+    return;
+  }
+
+  delete PROVIDERS[provider.kind];
 }
 
 export function getEntityProvider(
   kind: EntityKind
 ): EntityProvider | undefined {
-  return PROVIDERS[kind];
+  return PROVIDERS[kind]?.provider;
 }
 
 export function listRegisteredKinds(): EntityKind[] {


### PR DESCRIPTION
## Summary
- return cleanup callbacks from entity provider registration
- ref-count duplicate semantic provider registrations so strict-mode and remount cleanup cannot clear active providers
- add focused coverage for registry cleanup and profile-scoped entity cache updates

## Checks
- JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh
- JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run lib/commands/entities.test.ts components/jovie/components/EntityResolutionProvider.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/lib/commands/entities.ts apps/web/lib/commands/entities.test.ts apps/web/components/jovie/components/ChatProvidersRegistrar.tsx apps/web/components/jovie/components/EntityResolutionProvider.test.tsx
- JOVIE_AGENT_PROFILE=coder git diff --check
- pre-push: biome check ., proxy guard, tailwind guard, typecheck, biome lint

## Visual QA
No intended visual change; approval assumed per shell migration guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced entity provider cleanup with improved reference counting and lifecycle management.
  * Strengthened profile isolation to ensure unrelated cache updates don't affect active profiles.

* **Tests**
  * Added comprehensive test suite for entity provider registry functionality and multi-profile scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->