### PR TITLE
fix(chat): make entity provider cleanup idempotent

### DIFF
--- a/apps/web/lib/commands/entities.test.ts
+++ b/apps/web/lib/commands/entities.test.ts
@@ -76,6 +76,24 @@ describe('entity provider registry', () => {
     expect(getEntityProvider('artist')).toBeUndefined();
   });
 
+  it('keeps a duplicate provider registered when one cleanup runs twice', () => {
+    const provider = makeProvider('artist', 'Artists');
+    const unregisterFirst = registerEntityProvider(provider);
+    const unregisterSecond = registerEntityProvider(provider);
+
+    unregisterFirst();
+
+    expect(getEntityProvider('artist')).toBe(provider);
+
+    unregisterFirst();
+
+    expect(getEntityProvider('artist')).toBe(provider);
+
+    unregisterSecond();
+
+    expect(getEntityProvider('artist')).toBeUndefined();
+  });
+
   it('ref-counts providers with the same registry key', () => {
     const firstProvider = makeProvider('release', 'Releases', 'release:p1');
     const secondProvider = makeProvider('release', 'Releases', 'release:p1');

--- a/apps/web/lib/commands/entities.ts
+++ b/apps/web/lib/commands/entities.ts
@@ -128,13 +128,26 @@ function isSameProvider(
   );
 }
 
+function createProviderDisposer(provider: EntityProvider): () => void {
+  let disposed = false;
+
+  return () => {
+    if (disposed) {
+      return;
+    }
+
+    disposed = true;
+    unregisterEntityProvider(provider);
+  };
+}
+
 export function registerEntityProvider(provider: EntityProvider): () => void {
   const existing = PROVIDERS[provider.kind];
 
   if (existing && isSameProvider(existing.provider, provider)) {
     existing.provider = provider;
     existing.registrations += 1;
-    return () => unregisterEntityProvider(provider);
+    return createProviderDisposer(provider);
   }
 
   if (existing) {
@@ -149,7 +162,7 @@ export function registerEntityProvider(provider: EntityProvider): () => void {
   }
   PROVIDERS[provider.kind] = { provider, registrations: 1 };
 
-  return () => unregisterEntityProvider(provider);
+  return createProviderDisposer(provider);
 }
 
 export function unregisterEntityProvider(provider: EntityProvider): void {


### PR DESCRIPTION
## Summary
- make entity provider registration cleanup callbacks idempotent
- keep duplicate provider registrations active if one disposer is invoked more than once
- add a regression test covering the double-dispose case from the #9015 review

## Checks
- JOVIE_AGENT_PROFILE=coder pnpm exec biome check --write apps/web/lib/commands/entities.ts apps/web/lib/commands/entities.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run lib/commands/entities.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- JOVIE_AGENT_PROFILE=coder git diff --check
- pre-push: biome check ., proxy guard, tailwind guard, typecheck, biome lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for duplicate provider cleanup scenarios.

* **Bug Fixes**
  * Improved robustness of provider cleanup logic to prevent unintended behavior when cleanup is invoked multiple times.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->