### PR TITLE
fix(ci): guard production domain project wiring

### DIFF
--- a/.github/scripts/verify-vercel-production-domains.mjs
+++ b/.github/scripts/verify-vercel-production-domains.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+import { pathToFileURL } from 'node:url';
+
+export const PRODUCTION_DOMAIN_EXPECTATIONS = Object.freeze([
+  { name: 'jov.ie', redirect: null, redirectStatusCode: null },
+  { name: 'www.jov.ie', redirect: 'jov.ie', redirectStatusCode: 301 },
+  { name: 'jovie.app', redirect: 'jov.ie', redirectStatusCode: 301 },
+  { name: 'meetjovie.com', redirect: 'jov.ie', redirectStatusCode: 301 },
+  { name: 'www.meetjovie.com', redirect: 'jov.ie', redirectStatusCode: 301 },
+  { name: 'jovie.fm', redirect: 'jov.ie', redirectStatusCode: 308 },
+]);
+
+export function buildProjectDomainsUrl({ projectId, orgId }) {
+  const url = new URL(
+    `https://api.vercel.com/v9/projects/${encodeURIComponent(projectId)}/domains`
+  );
+
+  if (orgId) {
+    if (orgId.startsWith('team_')) {
+      url.searchParams.set('teamId', orgId);
+    } else {
+      url.searchParams.set('slug', orgId);
+    }
+  }
+
+  return url;
+}
+
+export async function fetchProjectDomains({
+  fetchImpl = fetch,
+  orgId,
+  projectId,
+  token,
+}) {
+  const response = await fetchImpl(
+    buildProjectDomainsUrl({ projectId, orgId }),
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(
+      `Vercel domains API failed: HTTP ${response.status} ${body}`.trim()
+    );
+  }
+
+  const payload = await response.json();
+  return Array.isArray(payload.domains) ? payload.domains : [];
+}
+
+export function validateProductionDomains({
+  domains,
+  expectedProjectId,
+  expectations = PRODUCTION_DOMAIN_EXPECTATIONS,
+}) {
+  const domainByName = new Map(domains.map(domain => [domain.name, domain]));
+  const failures = [];
+
+  for (const expectation of expectations) {
+    const domain = domainByName.get(expectation.name);
+
+    if (!domain) {
+      failures.push(
+        `${expectation.name}: missing from canonical Vercel project ${expectedProjectId}`
+      );
+      continue;
+    }
+
+    if (domain.projectId !== expectedProjectId) {
+      failures.push(
+        `${expectation.name}: projectId=${domain.projectId ?? '<empty>'}, expected ${expectedProjectId}`
+      );
+    }
+
+    if (domain.verified !== true) {
+      failures.push(`${expectation.name}: domain is not verified`);
+    }
+
+    const actualRedirect = domain.redirect ?? null;
+    if (actualRedirect !== expectation.redirect) {
+      failures.push(
+        `${expectation.name}: redirect=${actualRedirect ?? '<none>'}, expected ${
+          expectation.redirect ?? '<none>'
+        }`
+      );
+    }
+
+    const actualRedirectStatus =
+      domain.redirectStatusCode === null ||
+      domain.redirectStatusCode === undefined
+        ? null
+        : Number(domain.redirectStatusCode);
+    if (actualRedirectStatus !== expectation.redirectStatusCode) {
+      failures.push(
+        `${expectation.name}: redirectStatusCode=${
+          actualRedirectStatus ?? '<none>'
+        }, expected ${expectation.redirectStatusCode ?? '<none>'}`
+      );
+    }
+  }
+
+  return {
+    checked: expectations.map(expectation => expectation.name),
+    failures,
+    ok: failures.length === 0,
+  };
+}
+
+async function main() {
+  const token = process.env.VERCEL_TOKEN;
+  const orgId = process.env.VERCEL_ORG_ID;
+  const projectId = process.env.VERCEL_PROJECT_ID;
+
+  if (!token || !projectId) {
+    throw new Error('VERCEL_TOKEN and VERCEL_PROJECT_ID are required');
+  }
+
+  const domains = await fetchProjectDomains({ orgId, projectId, token });
+  const result = validateProductionDomains({
+    domains,
+    expectedProjectId: projectId,
+  });
+
+  if (!result.ok) {
+    console.error('Production domain guard failed:');
+    for (const failure of result.failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `Production domain guard passed for ${result.checked.join(', ')}`
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch(error => {
+    console.error(
+      `Production domain guard crashed: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    process.exit(1);
+  });
+}

--- a/.github/scripts/verify-vercel-production-domains.test.mjs
+++ b/.github/scripts/verify-vercel-production-domains.test.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  buildProjectDomainsUrl,
+  PRODUCTION_DOMAIN_EXPECTATIONS,
+  validateProductionDomains,
+} from './verify-vercel-production-domains.mjs';
+
+const canonicalProjectId = 'prj_canonical';
+
+function buildDomain(overrides) {
+  return {
+    name: overrides.name,
+    projectId: canonicalProjectId,
+    redirect: null,
+    redirectStatusCode: null,
+    verified: true,
+    ...overrides,
+  };
+}
+
+function validDomains() {
+  return PRODUCTION_DOMAIN_EXPECTATIONS.map(expectation =>
+    buildDomain({
+      name: expectation.name,
+      redirect: expectation.redirect,
+      redirectStatusCode: expectation.redirectStatusCode,
+    })
+  );
+}
+
+test('buildProjectDomainsUrl scopes team ids as teamId', () => {
+  const url = buildProjectDomainsUrl({
+    orgId: 'team_123',
+    projectId: canonicalProjectId,
+  });
+
+  assert.equal(
+    url.toString(),
+    'https://api.vercel.com/v9/projects/prj_canonical/domains?teamId=team_123'
+  );
+});
+
+test('buildProjectDomainsUrl scopes non-team ids as slugs', () => {
+  const url = buildProjectDomainsUrl({
+    orgId: 'jovie',
+    projectId: canonicalProjectId,
+  });
+
+  assert.equal(
+    url.toString(),
+    'https://api.vercel.com/v9/projects/prj_canonical/domains?slug=jovie'
+  );
+});
+
+test('validateProductionDomains passes for the canonical public domain set', () => {
+  const result = validateProductionDomains({
+    domains: validDomains(),
+    expectedProjectId: canonicalProjectId,
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.failures, []);
+});
+
+test('validateProductionDomains fails when jov.ie is missing from the canonical project', () => {
+  const result = validateProductionDomains({
+    domains: validDomains().filter(domain => domain.name !== 'jov.ie'),
+    expectedProjectId: canonicalProjectId,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(
+    result.failures.join('\n'),
+    /jov\.ie: missing from canonical Vercel project prj_canonical/
+  );
+});
+
+test('validateProductionDomains fails when a public domain belongs to another project', () => {
+  const domains = validDomains();
+  domains[0] = {
+    ...domains[0],
+    projectId: 'prj_stale',
+  };
+
+  const result = validateProductionDomains({
+    domains,
+    expectedProjectId: canonicalProjectId,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(
+    result.failures.join('\n'),
+    /jov\.ie: projectId=prj_stale, expected prj_canonical/
+  );
+});
+
+test('validateProductionDomains fails when redirect aliases drift', () => {
+  const domains = validDomains();
+  domains[1] = {
+    ...domains[1],
+    redirect: null,
+    redirectStatusCode: null,
+  };
+
+  const result = validateProductionDomains({
+    domains,
+    expectedProjectId: canonicalProjectId,
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(
+    result.failures.join('\n'),
+    /www\.jov\.ie: redirect=<none>, expected jov\.ie/
+  );
+  assert.match(
+    result.failures.join('\n'),
+    /www\.jov\.ie: redirectStatusCode=<none>, expected 301/
+  );
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3784,12 +3784,25 @@ jobs:
     outputs:
       # Emitted when promote-production exits non-zero so deploy-notify can
       # distinguish silent-no-op regressions from generic promote failures.
-      # Values: "no_match" (no Vercel deployment for github.sha) | "verify_mismatch"
-      # (production keeps serving the old commit after promote).
-      failure_subtype: ${{ steps.promote.outputs.failure_subtype }}
+      # Values: "domain_project_mismatch" (public domains are not on the
+      # canonical Vercel project) | "no_match" (no Vercel deployment for
+      # github.sha) | "verify_mismatch" (production keeps serving the old
+      # commit after promote).
+      failure_subtype: ${{ steps.domain-guard.outputs.failure_subtype || steps.promote.outputs.failure_subtype }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node-pnpm
+      - name: Verify production domains are on canonical Vercel project
+        id: domain-guard
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          if ! node .github/scripts/verify-vercel-production-domains.mjs; then
+            echo "failure_subtype=domain_project_mismatch" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
       - name: Promote specific deployment for this SHA
         id: promote
         env:
@@ -4115,6 +4128,14 @@ jobs:
           # Distinguish the silent-no-op regression (production kept old SHA
           # even though vercel promote exited 0) from a generic promote failure.
           PROMOTE_SUBTYPE="${{ needs.promote-production.outputs.failure_subtype }}"
+          if [ "$PROMOTE_RESULT" = "failure" ] && [ "$PROMOTE_SUBTYPE" = "domain_project_mismatch" ]; then
+            echo "failure_type=promote_domain_project_mismatch" >> "$GITHUB_OUTPUT"
+            echo "failure_emoji=🧭" >> "$GITHUB_OUTPUT"
+            echo "failure_title=Production domains are on the wrong Vercel project" >> "$GITHUB_OUTPUT"
+            echo "failure_detail=One or more public production domains are missing from the canonical Vercel project or have incorrect redirect wiring. Production promotion was blocked before deploy." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [ "$PROMOTE_RESULT" = "failure" ] && [ "$PROMOTE_SUBTYPE" = "no_match" ]; then
             echo "failure_type=promote_no_match" >> "$GITHUB_OUTPUT"
             echo "failure_emoji=🕳️" >> "$GITHUB_OUTPUT"

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -189,16 +189,55 @@ describe('deploy workflow Vercel env resolution', () => {
 
   it('verifies production promotion through the canonical public alias', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
+    const promoteJob = getJobBlock(workflow, 'promote-production');
+    const domainGuardStep = getStepBlock(
+      promoteJob,
+      'Verify production domains are on canonical Vercel project'
+    );
     const promoteStep = getStepBlock(
-      workflow,
+      promoteJob,
       'Promote specific deployment for this SHA'
     );
+    const domainGuardIndex = promoteJob.indexOf(
+      '- name: Verify production domains are on canonical Vercel project'
+    );
+    const promoteIndex = promoteJob.indexOf(
+      '- name: Promote specific deployment for this SHA'
+    );
 
+    expect(domainGuardIndex).toBeGreaterThanOrEqual(0);
+    expect(promoteIndex).toBeGreaterThan(domainGuardIndex);
+    expect(promoteJob).toContain(
+      'failure_subtype: ${{ steps.domain-guard.outputs.failure_subtype || steps.promote.outputs.failure_subtype }}'
+    );
+    expect(domainGuardStep).toContain('id: domain-guard');
+    expect(domainGuardStep).toContain(
+      'node .github/scripts/verify-vercel-production-domains.mjs'
+    );
+    expect(domainGuardStep).toContain(
+      'VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}'
+    );
+    expect(domainGuardStep).toContain(
+      'failure_subtype=domain_project_mismatch'
+    );
     expect(promoteStep).toContain('"https://jov.ie/api/health/build-info"');
     expect(promoteStep).toContain('probe_labels=(');
     expect(promoteStep).toContain('"production-alias"');
     expect(promoteStep).toContain('max_attempts=30');
     expect(promoteStep).toContain('URLs can return 401');
+  });
+
+  it('alerts specifically when production domains drift off the canonical Vercel project', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const classifyStep = getStepBlock(workflow, 'Classify failure type');
+
+    expect(classifyStep).toContain('domain_project_mismatch');
+    expect(classifyStep).toContain(
+      'Production domains are on the wrong Vercel project'
+    );
+    expect(classifyStep).toContain(
+      'Production promotion was blocked before deploy.'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add a Vercel production-domain guard that verifies public domains live on the canonical project before production promotion
- block promotion with a specific `domain_project_mismatch` failure subtype when `jov.ie` or redirect aliases drift
- add workflow and script coverage for missing domains, stale project ids, and redirect drift

## Why
Production was deploying the canonical `jovie` project while `jov.ie` still pointed at stale project `jovie-v1`. This makes that state fail closed before promotion instead of relying on manual build-info checks after users are already routed to the wrong project.

## Verification
- `JOVIE_AGENT_PROFILE=coder node --test .github/scripts/verify-vercel-production-domains.test.mjs`
- `JOVIE_AGENT_PROFILE=coder pnpm exec actionlint -shellcheck= .github/workflows/ci.yml`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder git diff --check`
- live Vercel domain list validated against `prj_HPZm5iGtARQ2qef6g2xtjgFIGDVY` via the new guard logic
- pre-push hook: Biome, proxy guard, Tailwind guard, typecheck, lint

Refs JOV-2332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added production domain verification checks to the deployment pipeline to ensure domains are correctly assigned to the canonical infrastructure before promotion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9023?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->