### PR TITLE
Polish public profile native shell

### DIFF
--- a/apps/web/components/features/profile/ProfileHomeRail.tsx
+++ b/apps/web/components/features/profile/ProfileHomeRail.tsx
@@ -2,6 +2,7 @@
 
 import { Bell } from 'lucide-react';
 import { useMemo } from 'react';
+import type { NotificationSourceContext } from '@/features/profile/artist-notifications-cta/types';
 import type { ProfileRenderMode } from '@/features/profile/contracts';
 import {
   ProfilePrimaryActionCard,
@@ -19,7 +20,6 @@ import { useUserLocation } from '@/hooks/useUserLocation';
 import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
 import { getProfileReleaseVisibility } from '@/lib/profile/release-visibility';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
-import { cn } from '@/lib/utils';
 import type { Artist } from '@/types/db';
 
 interface ProfileHomeRailProps {
@@ -34,7 +34,7 @@ interface ProfileHomeRailProps {
   readonly renderMode?: ProfileRenderMode;
   readonly previewActionLabel?: string;
   readonly onPlayClick?: () => void;
-  readonly onAlertsClick?: () => void;
+  readonly onAlertsClick?: (context: NotificationSourceContext) => void;
   readonly isSubscribed?: boolean;
   readonly viewerLocation?: UserLocation | null;
   readonly resolveNearbyTour?: boolean;
@@ -66,12 +66,14 @@ function HomeAlertsCard({
   onAlertsClick,
   renderMode,
   variant,
+  sourceContext,
 }: Readonly<{
   artist: Artist;
   isSubscribed: boolean;
-  onAlertsClick?: () => void;
+  onAlertsClick?: (context: NotificationSourceContext) => void;
   renderMode: ProfileRenderMode;
   variant: 'row' | 'bento';
+  sourceContext: NotificationSourceContext;
 }>) {
   const title = isSubscribed ? 'Alerts On' : `Get ${artist.name} alerts`;
   const description = isSubscribed
@@ -121,26 +123,10 @@ function HomeAlertsCard({
         </span>
       </span>
       <span
-        className={
-          isSubscribed
-            ? cn(
-                'relative h-6 w-10 shrink-0 rounded-full border border-white/42 bg-white p-0.5 transition-colors duration-subtle',
-                variant === 'bento' && 'self-center'
-              )
-            : cn(
-                'relative h-6 w-10 shrink-0 rounded-full border border-white/16 bg-white/10 p-0.5 transition-colors duration-subtle',
-                variant === 'bento' && 'self-center'
-              )
-        }
+        className='inline-flex h-8 shrink-0 items-center rounded-full bg-white px-3 text-[12px] font-[680] tracking-[-0.01em] text-black'
         aria-hidden='true'
       >
-        <span
-          className={
-            isSubscribed
-              ? 'block h-5 w-5 translate-x-4 rounded-full bg-black shadow-[0_4px_10px_rgba(0,0,0,0.22)] transition-transform duration-subtle'
-              : 'block h-5 w-5 translate-x-0 rounded-full bg-white shadow-[0_4px_10px_rgba(0,0,0,0.22)] transition-transform duration-subtle'
-          }
-        />
+        {isSubscribed ? 'Manage' : 'Get alerts'}
       </span>
     </>
   );
@@ -149,9 +135,7 @@ function HomeAlertsCard({
     return (
       <button
         type='button'
-        onClick={onAlertsClick}
-        role='switch'
-        aria-checked={isSubscribed}
+        onClick={() => onAlertsClick(sourceContext)}
         aria-label={ariaLabel}
         {...sharedProps}
       >
@@ -241,6 +225,14 @@ export function ProfileHomeRail({
       onAlertsClick={onAlertsClick}
       renderMode={renderMode}
       variant={hasPrimaryFeature ? 'row' : 'bento'}
+      sourceContext={{
+        artistId: artist.id,
+        profileId: artist.id,
+        profileSlug: artist.handle,
+        currentTab: 'home',
+        ctaLocation: 'home_alerts_card',
+        intent: 'general_alerts',
+      }}
     />
   );
 

--- a/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
@@ -229,6 +229,8 @@ function SubscribePanel({
             autoOpen
             forceExpanded
             hideListenFallback
+            source={sourceContext?.ctaLocation ?? 'subscribe_tab'}
+            sourceContext={sourceContext}
             portalContainer={notificationsPortalContainer}
             onFlowClosed={onFlowClosed}
             onSubscriptionActivated={onSubscriptionActivated}

--- a/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
@@ -5,13 +5,13 @@ import { useCallback, useEffect, useState } from 'react';
 import { AboutSection } from '@/features/profile/AboutSection';
 import { ArtistNotificationsCTA } from '@/features/profile/artist-notifications-cta/ArtistNotificationsCTA';
 import { TwoStepNotificationsCTA } from '@/features/profile/artist-notifications-cta/TwoStepNotificationsCTA';
+import type { NotificationSourceContext } from '@/features/profile/artist-notifications-cta/types';
 import type {
   ProfilePreviewNotificationsState,
   ProfilePrimaryTab,
   ProfileRenderMode,
 } from '@/features/profile/contracts';
 import type { PublicRelease } from '@/features/profile/releases/types';
-import { StaticListenInterface } from '@/features/profile/StaticListenInterface';
 import { TourDrawerContent } from '@/features/profile/TourModePanel';
 import { ReleasesView } from '@/features/profile/views/ReleasesView';
 import type { AvailableDSP } from '@/lib/dsp';
@@ -46,6 +46,7 @@ interface ProfilePrimaryTabPanelProps {
   readonly allowPhotoDownloads?: boolean;
   readonly tourDates?: readonly TourDateViewModel[];
   readonly releases?: readonly PublicRelease[];
+  readonly alertSourceContext?: NotificationSourceContext;
   readonly previewNotificationsState?: ProfilePreviewNotificationsState;
   readonly onFlowClosed?: () => void;
   readonly onSubscriptionActivated?: () => void;
@@ -169,6 +170,7 @@ function SubscribePanel({
   onFlowClosed,
   onSubscriptionActivated,
   keepSubscribeFlowMounted = false,
+  sourceContext,
 }: Readonly<{
   artist: Artist;
   isSubscribed: boolean;
@@ -184,6 +186,7 @@ function SubscribePanel({
   onFlowClosed?: () => void;
   onSubscriptionActivated?: () => void;
   keepSubscribeFlowMounted?: boolean;
+  sourceContext?: NotificationSourceContext;
 }>) {
   if (renderMode === 'preview') {
     return (
@@ -215,6 +218,8 @@ function SubscribePanel({
             onFlowClosed={onFlowClosed}
             onSubscriptionActivated={onSubscriptionActivated}
             experimentVariant={alertOptInVariant}
+            source={sourceContext?.ctaLocation ?? 'subscribe_tab'}
+            sourceContext={sourceContext}
           />
         ) : (
           <ArtistNotificationsCTA
@@ -242,6 +247,42 @@ function SubscribePanel({
       onUnsubscribe={onUnsubscribe}
       isUnsubscribing={isUnsubscribing}
     />
+  );
+}
+
+function ProfileEmptyState({
+  artist,
+  title,
+  body,
+  triggerLabel,
+  sourceContext,
+}: Readonly<{
+  artist: Artist;
+  title: string;
+  body: string;
+  triggerLabel: string;
+  sourceContext: NotificationSourceContext;
+}>) {
+  return (
+    <div className='flex min-h-[42vh] flex-col items-center justify-center px-6 py-14 text-center'>
+      <p className='text-[18px] font-[650] tracking-[-0.035em] text-white'>
+        {title}
+      </p>
+      <p className='mt-2 max-w-[25ch] text-[13px] leading-5 text-white/52'>
+        {body}
+      </p>
+      <div className='mt-5'>
+        <ArtistNotificationsCTA
+          artist={artist}
+          variant='button'
+          presentation='overlay'
+          hideListenFallback
+          source={sourceContext.ctaLocation}
+          sourceContext={sourceContext}
+          triggerLabel={triggerLabel}
+        />
+      </div>
+    </div>
   );
 }
 
@@ -405,9 +446,7 @@ export function ProfilePrimaryTabPanel({
   mode,
   renderMode = 'interactive',
   artist,
-  dsps,
   notificationsPortalContainer,
-  enableDynamicEngagement = false,
   subscribeTwoStep = false,
   alertOptInVariant,
   isSubscribed,
@@ -420,6 +459,7 @@ export function ProfilePrimaryTabPanel({
   allowPhotoDownloads = false,
   tourDates = [],
   releases = [],
+  alertSourceContext,
   previewNotificationsState,
   onFlowClosed,
   onSubscriptionActivated,
@@ -442,6 +482,31 @@ export function ProfilePrimaryTabPanel({
     setKeepSubscribeFlowMounted(true);
     onSubscriptionActivated?.();
   }, [onSubscriptionActivated]);
+  const musicEmptySourceContext: NotificationSourceContext = {
+    artistId: artist.id,
+    profileId: artist.id,
+    profileSlug: artist.handle,
+    currentTab: 'music',
+    ctaLocation: 'music_empty_state',
+    intent: 'music_alerts',
+  };
+  const eventsEmptySourceContext: NotificationSourceContext = {
+    artistId: artist.id,
+    profileId: artist.id,
+    profileSlug: artist.handle,
+    currentTab: 'events',
+    ctaLocation: 'events_empty_state',
+    intent: 'event_alerts',
+  };
+  const subscribeSourceContext: NotificationSourceContext =
+    alertSourceContext ?? {
+      artistId: artist.id,
+      profileId: artist.id,
+      profileSlug: artist.handle,
+      currentTab: 'alerts',
+      ctaLocation: 'subscribe_tab',
+      intent: 'general_alerts',
+    };
 
   if (mode === 'listen') {
     const visibleReleases = releases.filter(release => Boolean(release.slug));
@@ -460,21 +525,11 @@ export function ProfilePrimaryTabPanel({
             </div>
             <ReleasesView
               releases={visibleReleases}
+              artistId={artist.id}
               artistHandle={artist.handle}
               artistName={artist.name}
             />
           </div>
-          <StaticListenInterface
-            artist={artist}
-            handle={artist.handle}
-            dspsOverride={dsps}
-            enableDynamicEngagement={enableDynamicEngagement}
-            renderMode={renderMode}
-            containerClassName='max-w-none px-4'
-            providerButtonClassName='rounded-[22px] border-white/8 bg-white/[0.045] px-4 py-3.5 text-white hover:bg-white/[0.08]'
-            emptyStateClassName='border-white/8 bg-white/[0.04] shadow-none'
-            hideHelpText
-          />
         </div>
       );
     }
@@ -489,16 +544,12 @@ export function ProfilePrimaryTabPanel({
             Music
           </h2>
         </div>
-        <StaticListenInterface
+        <ProfileEmptyState
           artist={artist}
-          handle={artist.handle}
-          dspsOverride={dsps}
-          enableDynamicEngagement={enableDynamicEngagement}
-          renderMode={renderMode}
-          containerClassName='max-w-none'
-          providerButtonClassName='rounded-[22px] border-white/8 bg-white/[0.045] px-4 py-3.5 text-white hover:bg-white/[0.08]'
-          emptyStateClassName='border-white/8 bg-white/[0.04] shadow-none'
-          hideHelpText
+          title='No music yet.'
+          body='Get a note when the first release lands.'
+          triggerLabel='Get alerts'
+          sourceContext={musicEmptySourceContext}
         />
       </div>
     );
@@ -515,7 +566,11 @@ export function ProfilePrimaryTabPanel({
             Events
           </h2>
         </div>
-        <TourDrawerContent artist={artist} tourDates={[...tourDates]} />
+        <TourDrawerContent
+          artist={artist}
+          tourDates={[...tourDates]}
+          emptyStateSourceContext={eventsEmptySourceContext}
+        />
       </div>
     );
   }
@@ -537,6 +592,7 @@ export function ProfilePrimaryTabPanel({
         onFlowClosed={handleSubscribeFlowClosed}
         onSubscriptionActivated={handleSubscriptionActivated}
         keepSubscribeFlowMounted={keepSubscribeFlowMounted}
+        sourceContext={subscribeSourceContext}
       />
     );
   }

--- a/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
@@ -570,6 +570,7 @@ export function ProfilePrimaryTabPanel({
           artist={artist}
           tourDates={[...tourDates]}
           emptyStateSourceContext={eventsEmptySourceContext}
+          renderMode={renderMode}
         />
       </div>
     );

--- a/apps/web/components/features/profile/ProfileUnifiedDrawer.tsx
+++ b/apps/web/components/features/profile/ProfileUnifiedDrawer.tsx
@@ -484,6 +484,7 @@ export function ProfileUnifiedDrawer({
           {renderedView === 'releases' && canOpenReleasesDrawer && (
             <ReleasesView
               releases={visibleReleases}
+              artistId={artist.id}
               artistHandle={artist.handle}
               artistName={artist.name}
             />

--- a/apps/web/components/features/profile/ProfileViewTracker.tsx
+++ b/apps/web/components/features/profile/ProfileViewTracker.tsx
@@ -40,6 +40,8 @@ export function ProfileViewTracker({
       track('profile_view', {
         handle,
         artist_id: artistId,
+        profile_id: artistId,
+        profile_slug: handle,
         source: source ?? (document.referrer || 'direct'),
       });
 

--- a/apps/web/components/features/profile/StaticListenInterface.tsx
+++ b/apps/web/components/features/profile/StaticListenInterface.tsx
@@ -116,6 +116,11 @@ export const StaticListenInterface = React.memo(function StaticListenInterface({
       try {
         track('listen_click', {
           handle,
+          artist_id: artist.id,
+          profile_id: artist.id,
+          profile_slug: artist.handle,
+          current_route_tab: 'music',
+          cta_location: 'listen_provider_row',
           linkType: 'listen',
           platform: dsp.key,
         });

--- a/apps/web/components/features/profile/TourModePanel.tsx
+++ b/apps/web/components/features/profile/TourModePanel.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Bell, MapPin } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
 import { useBreakpointDown } from '@/hooks/useBreakpoint';
@@ -10,11 +9,13 @@ import {
 } from '@/hooks/useTourDateProximity';
 import { useTourDateTicketClick } from '@/hooks/useTourDateTicketClick';
 import { useUserLocation } from '@/hooks/useUserLocation';
+import { track } from '@/lib/analytics';
 import type { TourDateViewModel } from '@/lib/tour-dates/types';
 import { cn } from '@/lib/utils';
 import { formatLocationString } from '@/lib/utils/string-utils';
 import type { Artist } from '@/types/db';
 import { ArtistNotificationsCTA } from './artist-notifications-cta/ArtistNotificationsCTA';
+import type { NotificationSourceContext } from './artist-notifications-cta/types';
 import { ProfileDrawerShell } from './ProfileDrawerShell';
 
 interface TourModePanelProps {
@@ -87,15 +88,13 @@ function DateBox({
 }
 
 function TourDateRow({
+  artistId,
   artistHandle,
   item,
-  featured,
-  nearby,
 }: Readonly<{
+  readonly artistId: string;
   readonly artistHandle: string;
   readonly item: TourDateWithProximity;
-  readonly featured: boolean;
-  readonly nearby: boolean;
 }>) {
   const location = formatLocationString([
     item.date.city,
@@ -120,16 +119,9 @@ function TourDateRow({
         item.date.ticketStatus === 'cancelled' && 'opacity-50'
       )}
     >
-      <DateBox date={item.date.startDate} featured={featured} />
+      <DateBox date={item.date.startDate} featured={false} />
 
       <div className='min-w-0'>
-        {featured ? (
-          <div className='mb-1 inline-flex items-center gap-1 text-[10px] font-[680] uppercase tracking-[0.12em] text-sky-300'>
-            <MapPin className='h-[10px] w-[10px]' />
-            <span>{nearby ? 'Near You' : 'Upcoming'}</span>
-          </div>
-        ) : null}
-
         <p className='min-w-0 truncate text-[15px] font-medium tracking-[-0.03em] text-white'>
           {item.date.venueName}
         </p>
@@ -141,7 +133,19 @@ function TourDateRow({
       {canBuyTickets ? (
         <a
           href={item.date.ticketUrl ?? undefined}
-          onClick={handleTicketClick}
+          onClick={event => {
+            track('event_click', {
+              artist_id: artistId,
+              profile_id: artistId,
+              profile_slug: artistHandle,
+              handle: artistHandle,
+              current_route_tab: 'events',
+              event_id: item.date.id,
+              venue_name: item.date.venueName,
+              target_url: item.date.ticketUrl,
+            });
+            handleTicketClick(event);
+          }}
           target='_blank'
           rel='noopener noreferrer'
           className={cn(
@@ -169,57 +173,75 @@ function TourDatesContent({
   artist,
   nearby,
   allDates,
+  emptyStateSourceContext,
 }: Readonly<{
   readonly artist: Artist;
   readonly nearby: TourDateWithProximity[];
   readonly allDates: TourDateWithProximity[];
+  readonly emptyStateSourceContext: NotificationSourceContext;
 }>) {
   if (allDates.length === 0) {
     return (
-      <div className='px-4 py-3'>
-        <div className='rounded-[18px] border border-white/[0.075] bg-white/[0.035] p-4'>
-          <div className='flex items-start gap-3'>
-            <span className='flex h-10 w-10 shrink-0 items-center justify-center rounded-[14px] border border-white/8 bg-white/[0.05] text-white/72'>
-              <Bell className='h-4 w-4' />
-            </span>
-            <div className='min-w-0 flex-1'>
-              <p className='text-[16px] font-medium tracking-[-0.03em] text-white'>
-                No upcoming events.
-              </p>
-              <p className='mt-1 max-w-[30ch] text-[13px] leading-5 text-white/52'>
-                Turn on alerts to hear when new shows are announced.
-              </p>
-            </div>
-          </div>
-          <div className='mt-4'>
-            <ArtistNotificationsCTA
-              artist={artist}
-              hideListenFallback
-              source='tour_drawer'
-              presentation='overlay'
-            />
-          </div>
+      <div className='flex min-h-[42vh] flex-col items-center justify-center px-6 py-14 text-center'>
+        <p className='text-[18px] font-[650] tracking-[-0.035em] text-white'>
+          No upcoming events.
+        </p>
+        <p className='mt-2 max-w-[25ch] text-[13px] leading-5 text-white/52'>
+          Get a note when new shows are announced.
+        </p>
+        <div className='mt-5'>
+          <ArtistNotificationsCTA
+            artist={artist}
+            variant='button'
+            hideListenFallback
+            source={emptyStateSourceContext.ctaLocation}
+            sourceContext={emptyStateSourceContext}
+            triggerLabel='Get event alerts'
+            presentation='overlay'
+          />
         </div>
       </div>
     );
   }
 
   const nearbyIds = new Set(nearby.map(item => item.date.id));
-  const featuredId = nearby[0]?.date.id ?? allDates[0]?.date.id ?? null;
+  const sortedDates = [...allDates].sort(
+    (left, right) =>
+      Date.parse(left.date.startDate) - Date.parse(right.date.startDate)
+  );
+  const nearbyDates = sortedDates.filter(item => nearbyIds.has(item.date.id));
+  const upcomingDates = sortedDates.filter(
+    item => !nearbyIds.has(item.date.id)
+  );
+  const groups = [
+    nearbyDates.length > 0 ? { label: 'Nearby', items: nearbyDates } : null,
+    {
+      label: 'Upcoming',
+      items: nearbyDates.length > 0 ? upcomingDates : sortedDates,
+    },
+  ].filter(
+    (group): group is { label: string; items: TourDateWithProximity[] } =>
+      Boolean(group && group.items.length > 0)
+  );
 
   return (
-    <div
-      className='border-y border-white/[0.075]'
-      data-testid='tour-drawer-list'
-    >
-      {allDates.map(item => (
-        <TourDateRow
-          key={item.date.id}
-          artistHandle={artist.handle}
-          item={item}
-          featured={item.date.id === featuredId}
-          nearby={nearbyIds.has(item.date.id)}
-        />
+    <div data-testid='tour-drawer-list'>
+      {groups.map(group => (
+        <section key={group.label} className='pb-4'>
+          <div className='px-4 pb-2 pt-3 text-[11px] font-[680] uppercase tracking-[0.16em] text-white/32'>
+            {group.label}
+          </div>
+          <div className='border-y border-white/[0.075]'>
+            {group.items.map(item => (
+              <TourDateRow
+                key={item.date.id}
+                artistId={artist.id}
+                artistHandle={artist.handle}
+                item={item}
+              />
+            ))}
+          </div>
+        </section>
       ))}
     </div>
   );
@@ -228,12 +250,23 @@ function TourDatesContent({
 export function TourDrawerContent({
   artist,
   tourDates,
+  emptyStateSourceContext,
 }: Readonly<{
   readonly artist: Artist;
   readonly tourDates: TourDateViewModel[];
+  readonly emptyStateSourceContext?: NotificationSourceContext;
 }>) {
   const { location } = useUserLocation();
   const { nearbyDates, allDates } = useTourDateProximity(tourDates, location);
+  const resolvedEmptyStateSourceContext: NotificationSourceContext =
+    emptyStateSourceContext ?? {
+      artistId: artist.id,
+      profileId: artist.id,
+      profileSlug: artist.handle,
+      currentTab: 'events',
+      ctaLocation: 'events_empty_state',
+      intent: 'event_alerts',
+    };
 
   return (
     <div data-testid='tour-drawer-content'>
@@ -241,6 +274,7 @@ export function TourDrawerContent({
         artist={artist}
         nearby={nearbyDates}
         allDates={allDates}
+        emptyStateSourceContext={resolvedEmptyStateSourceContext}
       />
     </div>
   );

--- a/apps/web/components/features/profile/TourModePanel.tsx
+++ b/apps/web/components/features/profile/TourModePanel.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
+import type { ProfileRenderMode } from '@/features/profile/contracts';
 import { useBreakpointDown } from '@/hooks/useBreakpoint';
 import {
   type TourDateWithProximity,
@@ -174,13 +175,36 @@ function TourDatesContent({
   nearby,
   allDates,
   emptyStateSourceContext,
+  renderMode,
 }: Readonly<{
   readonly artist: Artist;
   readonly nearby: TourDateWithProximity[];
   readonly allDates: TourDateWithProximity[];
   readonly emptyStateSourceContext: NotificationSourceContext;
+  readonly renderMode: ProfileRenderMode;
 }>) {
   if (allDates.length === 0) {
+    const action =
+      renderMode === 'preview' ? (
+        <button
+          type='button'
+          className='inline-flex h-12 items-center rounded-full bg-white px-5 text-[15px] font-[680] tracking-[-0.02em] text-black'
+          disabled
+        >
+          Get event alerts
+        </button>
+      ) : (
+        <ArtistNotificationsCTA
+          artist={artist}
+          variant='button'
+          hideListenFallback
+          source={emptyStateSourceContext.ctaLocation}
+          sourceContext={emptyStateSourceContext}
+          triggerLabel='Get event alerts'
+          presentation='overlay'
+        />
+      );
+
     return (
       <div className='flex min-h-[42vh] flex-col items-center justify-center px-6 py-14 text-center'>
         <p className='text-[18px] font-[650] tracking-[-0.035em] text-white'>
@@ -189,17 +213,7 @@ function TourDatesContent({
         <p className='mt-2 max-w-[25ch] text-[13px] leading-5 text-white/52'>
           Get a note when new shows are announced.
         </p>
-        <div className='mt-5'>
-          <ArtistNotificationsCTA
-            artist={artist}
-            variant='button'
-            hideListenFallback
-            source={emptyStateSourceContext.ctaLocation}
-            sourceContext={emptyStateSourceContext}
-            triggerLabel='Get event alerts'
-            presentation='overlay'
-          />
-        </div>
+        <div className='mt-5'>{action}</div>
       </div>
     );
   }
@@ -251,10 +265,12 @@ export function TourDrawerContent({
   artist,
   tourDates,
   emptyStateSourceContext,
+  renderMode = 'interactive',
 }: Readonly<{
   readonly artist: Artist;
   readonly tourDates: TourDateViewModel[];
   readonly emptyStateSourceContext?: NotificationSourceContext;
+  readonly renderMode?: ProfileRenderMode;
 }>) {
   const { location } = useUserLocation();
   const { nearbyDates, allDates } = useTourDateProximity(tourDates, location);
@@ -275,6 +291,7 @@ export function TourDrawerContent({
         nearby={nearbyDates}
         allDates={allDates}
         emptyStateSourceContext={resolvedEmptyStateSourceContext}
+        renderMode={renderMode}
       />
     </div>
   );

--- a/apps/web/components/features/profile/artist-notifications-cta/ArtistNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ArtistNotificationsCTA.tsx
@@ -15,6 +15,8 @@ export function ArtistNotificationsCTA({
   onSubscriptionActivated,
   experimentVariant,
   source,
+  sourceContext,
+  triggerLabel,
 }: ArtistNotificationsCTAProps) {
   const resolvedPresentation =
     presentation ?? (autoOpen || forceExpanded ? 'inline' : 'overlay');
@@ -31,6 +33,8 @@ export function ArtistNotificationsCTA({
       onSubscriptionActivated={onSubscriptionActivated}
       experimentVariant={experimentVariant}
       source={source}
+      sourceContext={sourceContext}
+      triggerLabel={triggerLabel}
     />
   );
 }

--- a/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/ProfileInlineNotificationsCTA.tsx
@@ -26,7 +26,12 @@ import {
   subscriptionPrimaryActionClassName,
   subscriptionPrimaryLinkClassName,
 } from './shared';
-import type { NotificationSource } from './types';
+import {
+  buildNotificationSourceContext,
+  type NotificationSource,
+  type NotificationSourceContext,
+  resolveNotificationSource,
+} from './types';
 import { useSubscriptionForm } from './useSubscriptionForm';
 
 type FlowOrigin = 'manage' | 'subscribe';
@@ -43,6 +48,8 @@ export interface ProfileInlineNotificationsCTAProps {
   readonly onFlowClosed?: () => void;
   readonly onSubscriptionActivated?: () => void;
   readonly source?: NotificationSource;
+  readonly sourceContext?: NotificationSourceContext;
+  readonly triggerLabel?: string;
   readonly experimentVariant?: ProfileAlertOptInVariant;
 }
 
@@ -136,6 +143,8 @@ export function ProfileInlineNotificationsCTA({
   onFlowClosed,
   onSubscriptionActivated,
   source,
+  sourceContext,
+  triggerLabel: triggerLabelProp,
   experimentVariant,
 }: ProfileInlineNotificationsCTAProps) {
   const { contentPreferences, artistEmail, subscriptionDetails } =
@@ -158,7 +167,12 @@ export function ProfileInlineNotificationsCTA({
     subscribedChannels,
     openSubscription,
     hydrationStatus,
-  } = useSubscriptionForm({ artist, source, experimentVariant });
+  } = useSubscriptionForm({
+    artist,
+    source,
+    sourceContext,
+    experimentVariant,
+  });
   const { user } = useUserSafe();
   const nameMutation = useUpdateSubscriberNameMutation();
   const birthdayMutation = useUpdateSubscriberBirthdayMutation();
@@ -218,6 +232,31 @@ export function ProfileInlineNotificationsCTA({
   const flowChannel = isSmsOnlyManageFlow ? 'sms' : 'email';
   const showArtistEmailSection = flowChannel === 'email';
   const primaryUserEmail = user?.primaryEmailAddress?.emailAddress ?? '';
+  const resolvedSource = resolveNotificationSource(source, sourceContext);
+  const analyticsBase = useMemo(
+    () =>
+      buildNotificationSourceContext(artist, {
+        artistId: sourceContext?.artistId,
+        profileId: sourceContext?.profileId,
+        profileSlug: sourceContext?.profileSlug,
+        currentTab: sourceContext?.currentTab ?? 'home',
+        ctaLocation: resolvedSource,
+        intent: sourceContext?.intent ?? 'general_alerts',
+        releaseId: sourceContext?.releaseId,
+        eventId: sourceContext?.eventId,
+      }),
+    [
+      artist,
+      resolvedSource,
+      sourceContext?.artistId,
+      sourceContext?.currentTab,
+      sourceContext?.eventId,
+      sourceContext?.intent,
+      sourceContext?.profileId,
+      sourceContext?.profileSlug,
+      sourceContext?.releaseId,
+    ]
+  );
 
   const markSubscriptionActivated = useCallback(() => {
     activatedInCurrentFlowRef.current = true;
@@ -262,12 +301,25 @@ export function ProfileInlineNotificationsCTA({
     }
 
     setIsFlowOpen(true);
+    track('alert_cta_click', {
+      ...analyticsBase,
+      source: resolvedSource,
+      alert_opt_in_variant: experimentVariant,
+      flow_origin: isSubscribed ? 'manage' : 'subscribe',
+    });
+    track('alert_signup_start', {
+      ...analyticsBase,
+      source: resolvedSource,
+      alert_opt_in_variant: experimentVariant,
+      flow_origin: isSubscribed ? 'manage' : 'subscribe',
+    });
     track('subscribe_step_reveal', {
       handle: artist.handle,
-      source: source ?? 'profile_inline',
+      source: resolvedSource,
       alert_opt_in_variant: experimentVariant,
     });
   }, [
+    analyticsBase,
     artist.handle,
     emailInput,
     experimentVariant,
@@ -277,7 +329,7 @@ export function ProfileInlineNotificationsCTA({
     onManageNotifications,
     openSubscription,
     primaryUserEmail,
-    source,
+    resolvedSource,
     syncPreferencesFromStatus,
   ]);
 
@@ -610,16 +662,30 @@ export function ProfileInlineNotificationsCTA({
       }
     }
 
+    const selectedAlertToggles = Object.entries(alertPrefs)
+      .filter(([, enabled]) => enabled)
+      .map(([key]) => key);
+
+    track('alert_signup_complete', {
+      ...analyticsBase,
+      source: resolvedSource,
+      alert_opt_in_variant: experimentVariant,
+      selected_alert_toggles: selectedAlertToggles,
+      artist_email_opt_in: artistEmailOptIn,
+      signup_completion_result: 'success',
+    });
+
     setStep('done');
   }, [
     activeEmail,
-    alertPrefs.merch,
-    alertPrefs.newMusic,
-    alertPrefs.tourDates,
+    alertPrefs,
+    analyticsBase,
     artist.id,
     artistEmailOptIn,
     canEditPreferences,
+    experimentVariant,
     prefsMutation,
+    resolvedSource,
     showArtistEmailSection,
     subscriptionDetails.sms,
   ]);
@@ -639,7 +705,9 @@ export function ProfileInlineNotificationsCTA({
     return null;
   }
 
-  const triggerLabel = isSubscribed ? 'Manage alerts' : 'Get alerts';
+  const triggerLabel = isSubscribed
+    ? 'Manage alerts'
+    : (triggerLabelProp ?? 'Get alerts');
   const triggerClassName = getTriggerClassName(variant);
   const trigger =
     isInline || hideTrigger ? null : (

--- a/apps/web/components/features/profile/artist-notifications-cta/TwoStepNotificationsCTA.tsx
+++ b/apps/web/components/features/profile/artist-notifications-cta/TwoStepNotificationsCTA.tsx
@@ -3,7 +3,7 @@
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
 import type { Artist } from '@/types/db';
 import { ProfileInlineNotificationsCTA } from './ProfileInlineNotificationsCTA';
-import type { NotificationSource } from './types';
+import type { NotificationSource, NotificationSourceContext } from './types';
 
 interface TwoStepNotificationsCTAProps {
   readonly artist: Artist;
@@ -14,6 +14,7 @@ interface TwoStepNotificationsCTAProps {
   readonly onSubscriptionActivated?: () => void;
   readonly experimentVariant?: ProfileAlertOptInVariant;
   readonly source?: NotificationSource;
+  readonly sourceContext?: NotificationSourceContext;
 }
 
 export function TwoStepNotificationsCTA({
@@ -25,6 +26,7 @@ export function TwoStepNotificationsCTA({
   onSubscriptionActivated,
   experimentVariant,
   source,
+  sourceContext,
 }: TwoStepNotificationsCTAProps) {
   return (
     <ProfileInlineNotificationsCTA
@@ -37,6 +39,7 @@ export function TwoStepNotificationsCTA({
       onSubscriptionActivated={onSubscriptionActivated}
       experimentVariant={experimentVariant}
       source={source}
+      sourceContext={sourceContext}
     />
   );
 }

--- a/apps/web/components/features/profile/artist-notifications-cta/types.ts
+++ b/apps/web/components/features/profile/artist-notifications-cta/types.ts
@@ -1,7 +1,56 @@
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
 import type { Artist } from '@/types/db';
 
-export type NotificationSource = 'profile_inline' | 'tour_drawer';
+export type NotificationSource =
+  | 'profile_inline'
+  | 'tour_drawer'
+  | 'home_alerts_card'
+  | 'hero_alerts_button'
+  | 'music_empty_state'
+  | 'events_empty_state'
+  | 'subscribe_tab';
+
+export type NotificationSourceTab = 'home' | 'music' | 'events' | 'alerts';
+
+export type NotificationIntent =
+  | 'music_alerts'
+  | 'event_alerts'
+  | 'general_alerts';
+
+export interface NotificationSourceContext {
+  readonly artistId?: string;
+  readonly profileId?: string;
+  readonly profileSlug?: string;
+  readonly currentTab: NotificationSourceTab;
+  readonly ctaLocation: NotificationSource;
+  readonly intent: NotificationIntent;
+  readonly releaseId?: string;
+  readonly eventId?: string;
+}
+
+export function buildNotificationSourceContext(
+  artist: Artist,
+  context: NotificationSourceContext
+) {
+  return {
+    artist_id: context.artistId ?? artist.id,
+    profile_id: context.profileId ?? artist.id,
+    profile_slug: context.profileSlug ?? artist.handle,
+    handle: artist.handle,
+    current_route_tab: context.currentTab,
+    cta_location: context.ctaLocation,
+    intent: context.intent,
+    release_id: context.releaseId,
+    event_id: context.eventId,
+  };
+}
+
+export function resolveNotificationSource(
+  source: NotificationSource | undefined,
+  context: NotificationSourceContext | undefined
+): NotificationSource {
+  return source ?? context?.ctaLocation ?? 'profile_inline';
+}
 
 export interface ArtistNotificationsCTAProps {
   readonly artist: Artist;
@@ -36,4 +85,6 @@ export interface ArtistNotificationsCTAProps {
    * Defaults to 'profile_inline'. Tour drawer passes 'tour_drawer'.
    */
   readonly source?: NotificationSource;
+  readonly sourceContext?: NotificationSourceContext;
+  readonly triggerLabel?: string;
 }

--- a/apps/web/components/features/profile/artist-notifications-cta/useSubscriptionForm.ts
+++ b/apps/web/components/features/profile/artist-notifications-cta/useSubscriptionForm.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useProfileNotifications } from '@/components/organisms/profile-shell/ProfileNotificationsContext';
 import {
   COUNTRY_OPTIONS,
@@ -24,12 +24,18 @@ import {
 } from '@/lib/queries/useNotificationStatusQuery';
 import type { Artist } from '@/types/db';
 import type { NotificationChannel } from '@/types/notifications';
-import type { NotificationSource } from './types';
+import {
+  buildNotificationSourceContext,
+  type NotificationSource,
+  type NotificationSourceContext,
+  resolveNotificationSource,
+} from './types';
 import { buildPhoneE164, getMaxNationalDigits } from './utils';
 
 interface UseSubscriptionFormOptions {
   artist: Artist;
   source?: NotificationSource;
+  sourceContext?: NotificationSourceContext;
   experimentVariant?: ProfileAlertOptInVariant;
 }
 
@@ -96,9 +102,34 @@ const resolveInlineErrorMessage = (
 export function useSubscriptionForm({
   artist,
   source: sourceProp,
+  sourceContext,
   experimentVariant,
 }: UseSubscriptionFormOptions): UseSubscriptionFormReturn {
-  const source = sourceProp ?? 'profile_inline';
+  const source = resolveNotificationSource(sourceProp, sourceContext);
+  const analyticsBase = useMemo(
+    () =>
+      buildNotificationSourceContext(artist, {
+        artistId: sourceContext?.artistId,
+        profileId: sourceContext?.profileId,
+        profileSlug: sourceContext?.profileSlug,
+        currentTab: sourceContext?.currentTab ?? 'home',
+        ctaLocation: source,
+        intent: sourceContext?.intent ?? 'general_alerts',
+        releaseId: sourceContext?.releaseId,
+        eventId: sourceContext?.eventId,
+      }),
+    [
+      artist,
+      source,
+      sourceContext?.artistId,
+      sourceContext?.currentTab,
+      sourceContext?.eventId,
+      sourceContext?.intent,
+      sourceContext?.profileId,
+      sourceContext?.profileSlug,
+      sourceContext?.releaseId,
+    ]
+  );
   const {
     state: notificationsState,
     setState: setNotificationsState,
@@ -277,12 +308,13 @@ export function useSubscriptionForm({
         phone: channel === 'sms' ? phoneE164 : undefined,
         countryCode: channel === 'sms' ? country.code : undefined,
         source,
+        sourceContext: analyticsBase,
       });
 
       track('notifications_subscribe_success', {
+        ...analyticsBase,
         channel,
         source,
-        handle: artist.handle,
         alert_opt_in_variant: experimentVariant,
         pending_confirmation: response.pendingConfirmation ?? false,
       });
@@ -323,10 +355,10 @@ export function useSubscriptionForm({
       });
 
       track('notifications_subscribe_error', {
+        ...analyticsBase,
         error_type: 'submission_error',
         channel,
         source,
-        handle: artist.handle,
         alert_opt_in_variant: experimentVariant,
       });
       return 'error';
@@ -336,6 +368,7 @@ export function useSubscriptionForm({
   }, [
     artist.handle,
     artist.id,
+    analyticsBase,
     channel,
     clearError,
     country.code,
@@ -431,8 +464,8 @@ export function useSubscriptionForm({
     clearError();
 
     track('otp_resend_attempt', {
+      ...analyticsBase,
       source,
-      handle: artist.handle,
       alert_opt_in_variant: experimentVariant,
     });
 
@@ -440,8 +473,8 @@ export function useSubscriptionForm({
 
     if (result !== 'error') {
       track('otp_resend_success', {
+        ...analyticsBase,
         source,
-        handle: artist.handle,
         alert_opt_in_variant: experimentVariant,
       });
 
@@ -454,7 +487,7 @@ export function useSubscriptionForm({
     setIsResending(false);
     return result !== 'error';
   }, [
-    artist.handle,
+    analyticsBase,
     clearError,
     experimentVariant,
     handleConfirmSubscription,
@@ -476,33 +509,39 @@ export function useSubscriptionForm({
 
     // Track button click intent (before validation)
     track('subscribe_click', {
+      ...analyticsBase,
       channel,
       source,
-      handle: artist.handle,
+      alert_opt_in_variant: experimentVariant,
+    });
+    track('alert_signup_submit', {
+      ...analyticsBase,
+      channel,
+      source,
       alert_opt_in_variant: experimentVariant,
     });
 
     if (!validateCurrent('submit')) {
       track('notifications_subscribe_error', {
+        ...analyticsBase,
         error_type: 'validation_error',
         channel,
         source,
-        handle: artist.handle,
         alert_opt_in_variant: experimentVariant,
       });
       return 'error' as const;
     }
 
     track('notifications_subscribe_attempt', {
+      ...analyticsBase,
       channel,
       source,
-      handle: artist.handle,
       alert_opt_in_variant: experimentVariant,
     });
 
     return await handleConfirmSubscription();
   }, [
-    artist.handle,
+    analyticsBase,
     channel,
     experimentVariant,
     handleConfirmSubscription,

--- a/apps/web/components/features/profile/nav/BottomTabBar.test.tsx
+++ b/apps/web/components/features/profile/nav/BottomTabBar.test.tsx
@@ -2,8 +2,7 @@
  * Unit tests for BottomTabBar (JOV-2022)
  *
  * Covers:
- *  - All four tabs render when hasTourDates = true
- *  - Three tabs render when hasTourDates = false (Events omitted)
+ *  - All four tabs render whether or not events exist
  *  - Active tab is marked with aria-current="page"
  *  - Active tab uses correct text/icon colour class (font-semibold)
  *  - Inactive tabs do not have aria-current
@@ -15,8 +14,7 @@
  *  - Grid column count matches visible tab count
  *  - No horizontal overflow at narrow viewports (320px) — structural check
  *  - 44×44pt touch target minimum via min-h-[52px] class
- *  - Active state: Events tab falls back to profile when hasTourDates=false but activeTab='tour'
- *    (caller resolves this before passing — BottomTabBar just renders what it receives)
+ *  - Empty Events tabs remain reachable so the surface can show alert signup
  */
 
 import { fireEvent, render, screen } from '@testing-library/react';
@@ -53,13 +51,11 @@ describe('BottomTabBar — tab rendering', () => {
     expect(screen.getByRole('button', { name: 'Alerts' })).toBeInTheDocument();
   });
 
-  it('omits the Events tab when hasTourDates is false', () => {
+  it('keeps the Events tab when hasTourDates is false', () => {
     render(<BottomTabBar {...makeProps({ hasTourDates: false })} />);
-    expect(
-      screen.queryByRole('button', { name: 'Events' })
-    ).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Home' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Music' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Events' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Alerts' })).toBeInTheDocument();
   });
 
@@ -231,14 +227,14 @@ describe('BottomTabBar — grid layout', () => {
     expect(grid?.getAttribute('style')).toContain('repeat(5,');
   });
 
-  it('has 4 columns when hasTourDates=false and hideMoreMenu=false', () => {
+  it('has 5 columns when hasTourDates=false and hideMoreMenu=false', () => {
     const { container } = render(
       <BottomTabBar
         {...makeProps({ hasTourDates: false, hideMoreMenu: false })}
       />
     );
     const grid = container.querySelector('[style*="grid-template-columns"]');
-    expect(grid?.getAttribute('style')).toContain('repeat(4,');
+    expect(grid?.getAttribute('style')).toContain('repeat(5,');
   });
 
   it('has 4 columns when hasTourDates=true and hideMoreMenu=true', () => {
@@ -251,14 +247,14 @@ describe('BottomTabBar — grid layout', () => {
     expect(grid?.getAttribute('style')).toContain('repeat(4,');
   });
 
-  it('has 3 columns when hasTourDates=false and hideMoreMenu=true', () => {
+  it('has 4 columns when hasTourDates=false and hideMoreMenu=true', () => {
     const { container } = render(
       <BottomTabBar
         {...makeProps({ hasTourDates: false, hideMoreMenu: true })}
       />
     );
     const grid = container.querySelector('[style*="grid-template-columns"]');
-    expect(grid?.getAttribute('style')).toContain('repeat(3,');
+    expect(grid?.getAttribute('style')).toContain('repeat(4,');
   });
 
   it('all primary tab buttons have min-h-[52px] for 44pt touch target compliance', () => {

--- a/apps/web/components/features/profile/nav/BottomTabBar.tsx
+++ b/apps/web/components/features/profile/nav/BottomTabBar.tsx
@@ -14,15 +14,14 @@
  * Tab definitions (spec §2.1, fixed order):
  *   1. Home     (mode: profile)   — UserRound icon
  *   2. Music    (mode: listen)    — Music2 icon
- *   3. Events   (mode: tour)      — CalendarDays icon  [conditional: only when hasTourDates]
+ *   3. Events   (mode: tour)      — CalendarDays icon
  *   4. Alerts   (mode: subscribe) — Bell icon
  *
  * A fifth "More" item follows the tabs when `hideMoreMenu` is false.
  * "More" is not a tab — it opens the menu drawer (aria-haspopup="dialog").
  *
- * Desktop / tablet behaviour: JOV-2024 owns desktop surface changes.
- * On screens > 1180px the shell loads ProfileDesktopSurface (which has no
- * bottom tab bar), so this component is naturally never mounted there.
+ * Desktop / tablet behaviour: the public profile shell may center this
+ * compact experience on larger screens, so the tab bar remains canonical.
  */
 
 import {
@@ -48,7 +47,6 @@ interface TabDefinition {
 
 /**
  * All four primary tab definitions, in canonical order.
- * Events (tour) is filtered out when `hasTourDates` is false (spec §2.3).
  */
 const ALL_PRIMARY_TABS: ReadonlyArray<TabDefinition> = [
   { mode: 'profile', label: 'Home', icon: UserRound },
@@ -69,8 +67,8 @@ export interface BottomTabBarProps {
   readonly activeTab: ProfilePrimaryTab;
 
   /**
-   * When false, the Events (tour) tab is omitted from the tab bar.
-   * The grid shrinks from 5 to 4 columns (spec §2.3 + §2.8).
+   * Retained for API compatibility; Events now remains visible so the tab can
+   * show a native empty state when no upcoming dates exist.
    */
   readonly hasTourDates: boolean;
 
@@ -112,16 +110,14 @@ export interface BottomTabBarProps {
  */
 export function BottomTabBar({
   activeTab,
-  hasTourDates,
+  hasTourDates: _hasTourDates,
   hideMoreMenu = false,
   isMenuOpen = false,
   onTabSelect,
   onOpenMenu,
   className,
 }: BottomTabBarProps) {
-  const visibleTabs = hasTourDates
-    ? ALL_PRIMARY_TABS
-    : ALL_PRIMARY_TABS.filter(tab => tab.mode !== 'tour');
+  const visibleTabs = ALL_PRIMARY_TABS;
 
   // Total column count = tabs + (More button ? 1 : 0)
   const columnCount = visibleTabs.length + (hideMoreMenu ? 0 : 1);

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -25,6 +25,7 @@ import { getProfileModeDefinition } from '@/features/profile/registry';
 import type { PublicRelease } from '@/features/profile/releases/types';
 import { SubscriptionConfirmedBanner } from '@/features/profile/SubscriptionConfirmedBanner';
 import type { UserLocation } from '@/hooks/useUserLocation';
+import { track } from '@/lib/analytics';
 import { sortDSPsByGeoPopularity } from '@/lib/dsp';
 import type { ProfileAlertOptInVariant } from '@/lib/flags/contracts';
 import type { ConfirmedFeaturedPlaylistFallback } from '@/lib/profile/featured-playlist-fallback';
@@ -39,6 +40,7 @@ import type { PublicContact } from '@/types/contacts';
 import type { Artist, LegacySocialLink } from '@/types/db';
 import type { NotificationContentType } from '@/types/notifications';
 import type { PressPhoto } from '@/types/press-photos';
+import type { NotificationSourceContext } from '../artist-notifications-cta/types';
 
 const ProfileUnifiedDrawer = dynamic(() =>
   import('@/features/profile/ProfileUnifiedDrawer').then(mod => ({
@@ -60,6 +62,74 @@ const DEFAULT_CONTENT_PREFS: Record<NotificationContentType, boolean> = {
   merch: true,
   general: true,
 };
+
+function mapPrimaryTabToAnalyticsTab(
+  tab: ProfilePrimaryTab
+): NotificationSourceContext['currentTab'] {
+  switch (tab) {
+    case 'listen':
+      return 'music';
+    case 'tour':
+      return 'events';
+    case 'subscribe':
+      return 'alerts';
+    case 'profile':
+    default:
+      return 'home';
+  }
+}
+
+function mapPrimaryTabToAlertIntent(
+  tab: ProfilePrimaryTab
+): NotificationSourceContext['intent'] {
+  switch (tab) {
+    case 'listen':
+      return 'music_alerts';
+    case 'tour':
+      return 'event_alerts';
+    case 'profile':
+    case 'subscribe':
+    default:
+      return 'general_alerts';
+  }
+}
+
+function toHomeLatestRelease(
+  release: PublicRelease | null | undefined
+): ProfilePrimaryActionCardRelease | null {
+  if (!release) {
+    return null;
+  }
+
+  return {
+    title: release.title,
+    slug: release.slug,
+    artworkUrl: release.artworkUrl,
+    releaseDate: release.releaseDate,
+    releaseType: release.releaseType,
+    metadata: {
+      artistNames: release.artistNames,
+      publicReleaseId: release.id,
+    },
+  };
+}
+
+function getNewestPublicRelease(
+  releases: readonly PublicRelease[]
+): PublicRelease | null {
+  return (
+    [...releases].sort((left, right) => {
+      const leftTime = left.releaseDate
+        ? new Date(left.releaseDate).getTime()
+        : Number.NEGATIVE_INFINITY;
+      const rightTime = right.releaseDate
+        ? new Date(right.releaseDate).getTime()
+        : Number.NEGATIVE_INFINITY;
+
+      return rightTime - leftTime;
+    })[0] ?? null
+  );
+}
 
 interface ProfileCompactSurfaceProps {
   readonly renderMode?: ProfileRenderMode;
@@ -208,6 +278,8 @@ export function ProfileCompactSurface({
   const [notificationsPortalContainer, setNotificationsPortalContainer] =
     useState<HTMLDivElement | null>(null);
   const [showRecentActivationRow, setShowRecentActivationRow] = useState(false);
+  const [notificationSourceContext, setNotificationSourceContext] =
+    useState<NotificationSourceContext | null>(null);
   const notificationsRevealRef = useRef<(() => void) | null>(null);
   const pendingNotificationsOpenRef = useRef(false);
   const mergedDSPs = useMemo(
@@ -233,8 +305,26 @@ export function ProfileCompactSurface({
     drawerView,
   });
   const hasTourDates = tourDates.length > 0;
-  const activeVisiblePrimaryTab =
-    activePrimaryTab === 'tour' && !hasTourDates ? 'profile' : activePrimaryTab;
+  const activeVisiblePrimaryTab = activePrimaryTab;
+  const currentAnalyticsTab = mapPrimaryTabToAnalyticsTab(
+    activeVisiblePrimaryTab
+  );
+  const defaultNotificationSourceContext = useMemo<NotificationSourceContext>(
+    () => ({
+      artistId: artist.id,
+      profileId: artist.id,
+      profileSlug: artist.handle,
+      currentTab: currentAnalyticsTab,
+      ctaLocation:
+        activeVisiblePrimaryTab === 'subscribe'
+          ? 'subscribe_tab'
+          : 'hero_alerts_button',
+      intent: mapPrimaryTabToAlertIntent(activeVisiblePrimaryTab),
+    }),
+    [activeVisiblePrimaryTab, artist.handle, artist.id, currentAnalyticsTab]
+  );
+  const activeNotificationSourceContext =
+    notificationSourceContext ?? defaultNotificationSourceContext;
   const isHomeMode = activeVisiblePrimaryTab === 'profile';
   const showBottomNav = true;
   const isPreviewEmbedded =
@@ -328,19 +418,68 @@ export function ProfileCompactSurface({
   const returnToProfileAfterNotifications = useCallback(() => {
     onModeSelect('profile');
   }, [onModeSelect]);
-  const openNotifications = useCallback(() => {
-    const reveal = notificationsRevealRef.current;
-    if (reveal) {
-      reveal();
-      return;
-    }
-    pendingNotificationsOpenRef.current = true;
-    onModeSelect('subscribe');
-    onRevealNotifications?.();
-  }, [onModeSelect, onRevealNotifications]);
+  const openNotifications = useCallback(
+    (sourceContext?: NotificationSourceContext) => {
+      setNotificationSourceContext(
+        sourceContext ?? defaultNotificationSourceContext
+      );
+      const revealLater = (reveal: () => void) => {
+        if (typeof window === 'undefined') {
+          reveal();
+          return;
+        }
+        window.setTimeout(reveal, 0);
+      };
+
+      const reveal = notificationsRevealRef.current;
+      if (reveal) {
+        revealLater(reveal);
+        return;
+      }
+      pendingNotificationsOpenRef.current = true;
+      onModeSelect('subscribe');
+      onRevealNotifications?.();
+    },
+    [defaultNotificationSourceContext, onModeSelect, onRevealNotifications]
+  );
+  const handleTabSelect = useCallback(
+    (tab: ProfilePrimaryTab) => {
+      const nextTab = mapPrimaryTabToAnalyticsTab(tab);
+      track('profile_tab_click', {
+        artist_id: artist.id,
+        profile_id: artist.id,
+        profile_slug: artist.handle,
+        handle: artist.handle,
+        tab: nextTab,
+        mode: tab,
+        previous_tab: currentAnalyticsTab,
+      });
+      onModeSelect(tab);
+    },
+    [artist.handle, artist.id, currentAnalyticsTab, onModeSelect]
+  );
+  const handleSocialClick = useCallback(
+    (link: LegacySocialLink) => {
+      track('social_click', {
+        artist_id: artist.id,
+        profile_id: artist.id,
+        profile_slug: artist.handle,
+        handle: artist.handle,
+        current_route_tab: currentAnalyticsTab,
+        platform: link.platform,
+        target_url: link.url,
+      });
+    },
+    [artist.handle, artist.id, currentAnalyticsTab]
+  );
   const homeAlertsSubscribed = isSubscribed || showRecentActivationRow;
   const shouldRenderInteractiveOverlays =
     renderMode === 'interactive' && renderInteractiveOverlays;
+  const homeLatestRelease =
+    latestRelease ?? toHomeLatestRelease(getNewestPublicRelease(releases));
+  const homeProfileSettings = homeLatestRelease
+    ? { ...profileSettings, showOldReleases: true }
+    : profileSettings;
 
   return (
     <div
@@ -434,7 +573,7 @@ export function ProfileCompactSurface({
               ) : null}
 
               <CircleIconButton
-                onClick={openNotifications}
+                onClick={() => openNotifications()}
                 size='lg'
                 variant='pearl'
                 className={topChromeButtonClassName}
@@ -506,6 +645,7 @@ export function ProfileCompactSurface({
                             href={link.url}
                             target='_blank'
                             rel='noopener noreferrer'
+                            onClick={() => handleSocialClick(link)}
                             className={socialIconClassName}
                             aria-label={link.platform}
                           >
@@ -540,6 +680,8 @@ export function ProfileCompactSurface({
               autoOpen={activeVisiblePrimaryTab === 'subscribe'}
               hideTrigger
               experimentVariant={alertOptInVariant}
+              source={activeNotificationSourceContext.ctaLocation}
+              sourceContext={activeNotificationSourceContext}
               onFlowClosed={returnToProfileAfterNotifications}
               onSubscriptionActivated={handleSubscriptionActivated}
             />
@@ -566,8 +708,8 @@ export function ProfileCompactSurface({
             {isHomeMode ? (
               <ProfileHomeRail
                 artist={artist}
-                latestRelease={latestRelease}
-                profileSettings={profileSettings}
+                latestRelease={homeLatestRelease}
+                profileSettings={homeProfileSettings}
                 featuredPlaylistFallback={featuredPlaylistFallback}
                 tourDates={tourDates}
                 hasPlayableDestinations={mergedDSPs.length > 0}
@@ -600,6 +742,7 @@ export function ProfileCompactSurface({
                 allowPhotoDownloads={allowPhotoDownloads}
                 tourDates={tourDates}
                 releases={releases}
+                alertSourceContext={defaultNotificationSourceContext}
                 previewNotificationsState={previewNotificationsState}
                 onFlowClosed={returnToProfileAfterNotifications}
                 onSubscriptionActivated={handleSubscriptionActivated}
@@ -613,7 +756,7 @@ export function ProfileCompactSurface({
               hasTourDates={hasTourDates}
               hideMoreMenu={hideMoreMenu}
               isMenuOpen={isMenuActive}
-              onTabSelect={onModeSelect}
+              onTabSelect={handleTabSelect}
               onOpenMenu={onOpenMenu}
             />
           ) : null}

--- a/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactTemplate.tsx
@@ -46,20 +46,7 @@ import type { Artist, LegacySocialLink } from '@/types/db';
 import type { NotificationContentType } from '@/types/notifications';
 import type { PressPhoto } from '@/types/press-photos';
 import { ProfileCompactSurface } from './ProfileCompactSurface';
-import { ProfileDesktopSurface } from './ProfileDesktopSurface';
 import { PublicProfileLayoutShell } from './PublicProfileLayoutShell';
-
-// Previously imported via `dynamic({ ssr: false })`. That bailed the parent
-// SSR tree to client-side rendering and emitted
-// `<template data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING">` in the streaming
-// payload, forcing the animated skeleton from `loading.tsx` to be the initial
-// visible HTML for every cold visit (JOV-2273).
-//
-// `ProfileDesktopSurface` is only rendered when `isDesktopLayout === true`,
-// which starts as `false` during SSR and is set in `useEffect` from
-// `matchMedia('(min-width: 1180px)')`. So the component is never rendered
-// server-side anyway — the `ssr: false` deferral was costing us a visible
-// CSR bailout for no rendering benefit.
 
 interface ProfileCompactTemplateProps {
   readonly mode: ProfileMode;
@@ -675,17 +662,16 @@ export function ProfileCompactTemplate({
     setRequestedMode('profile');
   }, [artist.handle, artist.name]);
 
-  const hasTourDates = tourDates.length > 0;
   const compactSurfaceShowsModeHeading = drawerOpen
     ? drawerView === 'listen' ||
       drawerView === 'releases' ||
       drawerView === 'subscribe' ||
       drawerView === 'notifications' ||
-      (drawerView === 'tour' && hasTourDates)
+      drawerView === 'tour'
     : requestedMode === 'listen' ||
       requestedMode === 'releases' ||
       requestedMode === 'subscribe' ||
-      (requestedMode === 'tour' && hasTourDates);
+      requestedMode === 'tour';
   const shouldRenderTemplateHeading = isDesktopLayout
     ? true
     : compactSurfaceShowsModeHeading;
@@ -703,46 +689,6 @@ export function ProfileCompactTemplate({
         isDesktopLayout={isDesktopLayout}
         shouldRenderHeading={shouldRenderTemplateHeading}
         profileAccentStyle={profileAccentStyle}
-        desktopSurface={
-          <ProfileDesktopSurface
-            presentation={drawerPresentation}
-            artist={artist}
-            socialLinks={socialLinks}
-            contacts={contacts}
-            showPayButton={showPayButton}
-            latestRelease={latestRelease}
-            profileSettings={profileSettings}
-            alertOptInVariant={resolvedAlertOptInVariant}
-            genres={genres}
-            pressPhotos={pressPhotos}
-            allowPhotoDownloads={allowPhotoDownloads}
-            photoDownloadSizes={photoDownloadSizes}
-            tourDates={tourDates}
-            viewerCountryCode={viewerCountryCode}
-            drawerOpen={drawerOpen}
-            drawerView={drawerView}
-            activeMode={requestedMode}
-            onModeSelect={nextMode => {
-              clearCloseResetTimer();
-              setRequestedMode(nextMode);
-            }}
-            onAlertsModalClose={() => {
-              clearCloseResetTimer();
-              setRequestedMode(lastPrimaryModeRef.current);
-            }}
-            onDrawerOpenChange={handleDrawerOpenChange}
-            onDrawerViewChange={handleDrawerViewChange}
-            onOpenMenu={() => openDrawerMode('menu')}
-            onPlayClick={handlePlayClick}
-            profileHref={profileHref}
-            isSubscribed={isSubscribed}
-            contentPrefs={contentPrefs}
-            onTogglePref={handleTogglePref}
-            onUnsubscribe={handleUnsubscribe}
-            isUnsubscribing={unsubMutation.isPending}
-            releases={releases}
-          />
-        }
         compactSurface={
           <div
             className='public-profile-compact-shell relative flex h-full min-w-0 w-full flex-col overflow-hidden bg-[color:var(--profile-content-bg)] md:mx-auto md:rounded-[var(--profile-shell-card-radius)] md:border md:border-[color:var(--profile-panel-border)] md:shadow-[var(--profile-panel-shadow)]'
@@ -770,7 +716,7 @@ export function ProfileCompactTemplate({
               viewerCountryCode={viewerCountryCode}
               hideJovieBranding={hideJovieBranding}
               hideMoreMenu={hideMoreMenu}
-              renderInteractiveOverlays={!isDesktopLayout}
+              renderInteractiveOverlays
               renderSemanticHeading={!isDesktopLayout}
               drawerOpen={drawerOpen}
               drawerView={drawerView}

--- a/apps/web/components/features/profile/templates/ProfileDesktopSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileDesktopSurface.tsx
@@ -679,6 +679,7 @@ export function ProfileDesktopSurface({
           {visibleReleases.length > 0 ? (
             <ReleasesView
               releases={visibleReleases}
+              artistId={artist.id}
               artistHandle={artist.handle}
               artistName={artist.name}
             />

--- a/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
+++ b/apps/web/components/features/profile/templates/PublicProfileLayoutShell.tsx
@@ -13,7 +13,6 @@ interface PublicProfileLayoutShellProps {
   readonly isDesktopLayout: boolean;
   readonly shouldRenderHeading: boolean;
   readonly profileAccentStyle: CSSProperties;
-  readonly desktopSurface: ReactNode;
   readonly compactSurface: ReactNode;
 }
 
@@ -24,7 +23,6 @@ export function PublicProfileLayoutShell({
   isDesktopLayout,
   shouldRenderHeading,
   profileAccentStyle,
-  desktopSurface,
   compactSurface,
 }: Readonly<PublicProfileLayoutShellProps>) {
   // The background blur stage is 84px blurred and 28% opaque — a CSS radial
@@ -70,14 +68,6 @@ export function PublicProfileLayoutShell({
         <main className='relative flex h-full min-w-0 w-full items-stretch md:items-center'>
           {shouldRenderHeading ? (
             <h1 className='sr-only'>{artistName}</h1>
-          ) : null}
-          {isDesktopLayout ? (
-            <div
-              className='public-profile-layout-desktop-shell'
-              data-testid='profile-desktop-shell'
-            >
-              {desktopSurface}
-            </div>
           ) : null}
           <div className='public-profile-layout-compact-slot'>
             {compactSurface}

--- a/apps/web/components/features/profile/views/ReleasesView.tsx
+++ b/apps/web/components/features/profile/views/ReleasesView.tsx
@@ -1,41 +1,12 @@
 'use client';
 
 import { Play } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { ImageWithFallback } from '@/components/atoms/ImageWithFallback';
-import { cn } from '@/lib/utils';
+import { track } from '@/lib/analytics';
 import type { PublicRelease } from '../releases/types';
 
 const YEAR_HEADER_THRESHOLD = 15;
-const AUDIO_RELEASE_TYPES = new Set([
-  'single',
-  'album',
-  'compilation',
-  'live',
-  'mixtape',
-]);
-const RELEASE_FILTERS = [
-  { key: 'all', label: 'All' },
-  { key: 'songs', label: 'Music' },
-  { key: 'eps', label: 'EPs' },
-  { key: 'videos', label: 'Videos' },
-] as const;
-
-type ReleaseFilter = (typeof RELEASE_FILTERS)[number]['key'];
-
-function getMoreReleasesHeading(activeFilter: ReleaseFilter): string {
-  switch (activeFilter) {
-    case 'songs':
-      return 'More Music';
-    case 'eps':
-      return 'More EPs';
-    case 'videos':
-      return 'More Videos';
-    case 'all':
-    default:
-      return 'More Releases';
-  }
-}
 
 function formatReleaseType(type: string): string {
   switch (type) {
@@ -58,66 +29,45 @@ function formatReleaseType(type: string): string {
   }
 }
 
+function getReleaseSortTime(release: PublicRelease): number {
+  if (!release.releaseDate) {
+    return 0;
+  }
+
+  const parsed = Date.parse(release.releaseDate);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
 export interface ReleasesViewProps {
   readonly releases: readonly PublicRelease[];
+  readonly artistId: string;
   readonly artistHandle: string;
   readonly artistName: string;
 }
 
 export function ReleasesView({
   releases,
+  artistId,
   artistHandle,
   artistName,
 }: ReleasesViewProps) {
-  const [activeFilter, setActiveFilter] = useState<ReleaseFilter>('all');
   const ownerNameLower = artistName.toLowerCase();
-  const availableFilters = useMemo(() => {
-    const types = new Set(releases.map(release => release.releaseType));
-    return RELEASE_FILTERS.filter(filter => {
-      switch (filter.key) {
-        case 'songs':
-          return [...AUDIO_RELEASE_TYPES].some(type => types.has(type));
-        case 'eps':
-          return types.has('ep');
-        case 'videos':
-          return types.has('music_video');
-        case 'all':
-        default:
-          return true;
-      }
-    });
-  }, [releases]);
-
-  useEffect(() => {
-    if (!availableFilters.some(filter => filter.key === activeFilter)) {
-      setActiveFilter('all');
-    }
-  }, [activeFilter, availableFilters]);
-
   const visibleReleases = useMemo(
     () =>
-      releases.filter(release => {
-        switch (activeFilter) {
-          case 'songs':
-            return AUDIO_RELEASE_TYPES.has(release.releaseType);
-          case 'eps':
-            return release.releaseType === 'ep';
-          case 'videos':
-            return release.releaseType === 'music_video';
-          case 'all':
-          default:
-            return true;
-        }
-      }),
-    [activeFilter, releases]
+      [...releases]
+        .filter(release => Boolean(release.slug))
+        .sort(
+          (left, right) => getReleaseSortTime(right) - getReleaseSortTime(left)
+        ),
+    [releases]
   );
 
   const yearHeaderSet = useMemo(() => {
     const years = new Set(
       visibleReleases
-        .map(r =>
-          r.releaseDate
-            ? new Date(r.releaseDate).getUTCFullYear().toString()
+        .map(release =>
+          release.releaseDate
+            ? new Date(release.releaseDate).getUTCFullYear().toString()
             : null
         )
         .filter(Boolean)
@@ -167,164 +117,91 @@ export function ReleasesView({
       ? `View ${release.title} by ${collaborators.join(', ')}`
       : `View ${release.title}`;
   };
-  const moreReleasesHeading = getMoreReleasesHeading(activeFilter);
 
   return (
-    <div className='flex flex-col' data-testid='profile-mode-drawer-releases'>
-      {availableFilters.length > 2 ? (
-        <div className='flex gap-2 overflow-x-auto px-4 pb-3 pt-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
-          {availableFilters.map(filter => {
-            const isActive = activeFilter === filter.key;
-            return (
-              <button
-                key={filter.key}
-                type='button'
-                onClick={() => setActiveFilter(filter.key)}
-                aria-pressed={isActive}
-                className={cn(
-                  'inline-flex h-8 shrink-0 items-center rounded-full border px-3 text-[12px] font-semibold transition-colors duration-subtle',
-                  isActive
-                    ? 'border-white bg-white text-black'
-                    : 'border-white/10 bg-white/[0.035] text-white/58 hover:text-white'
-                )}
-              >
-                {filter.label}
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
+    <div
+      className='border-y border-white/[0.075]'
+      data-testid='profile-mode-drawer-releases'
+    >
+      {visibleReleases.map((release, index) => {
+        if (!release.slug) {
+          return null;
+        }
 
-      {visibleReleases[0]?.slug ? (
-        <a
-          href={`/${artistHandle}/${visibleReleases[0].slug}`}
-          className='group flex items-center gap-3 border-y border-white/[0.075] px-4 py-3.5 transition-colors duration-subtle hover:bg-white/[0.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
-          aria-label={getReleaseAriaLabel(visibleReleases[0])}
-        >
-          <div className='relative h-[72px] w-[72px] shrink-0 overflow-hidden rounded-[8px] bg-white/[0.04] shadow-[0_8px_20px_-10px_rgba(0,0,0,0.55)]'>
-            <ImageWithFallback
-              src={visibleReleases[0].artworkUrl}
-              alt={visibleReleases[0].title}
-              fill
-              sizes='72px'
-              className='object-cover grayscale contrast-[1.04]'
-              fallbackVariant='release'
-            />
-          </div>
-          <div className='min-w-0 flex-1'>
-            <p className='text-[10px] font-[680] uppercase tracking-[0.18em] text-violet-300'>
-              Latest Release
-            </p>
-            <p className='mt-1 truncate text-[17px] font-[680] leading-tight tracking-[-0.014em] text-white'>
-              {visibleReleases[0].title}
-            </p>
-            <p className='text-2xs mt-0.5 truncate text-[13px] text-white/64'>
-              {getReleaseMeta(visibleReleases[0])}
-            </p>
-            {visibleReleases[0].releaseType === 'music_video' ? (
-              <span className='mt-1.5 inline-flex h-[17px] items-center rounded-full border border-white/8 bg-white/[0.04] px-1.5 text-[9px] font-semibold uppercase tracking-[0.04em] text-white/64'>
-                Video
-              </span>
+        const year = release.releaseDate
+          ? new Date(release.releaseDate).getUTCFullYear().toString()
+          : null;
+        const showHeader = yearHeaderSet.has(release.id);
+        const meta = getReleaseMeta(release);
+
+        return (
+          <div key={release.id}>
+            {showHeader ? (
+              <div
+                className='font-caption px-4 pb-2 pt-5 text-[11px] font-medium uppercase tracking-[0.18em] text-white/24'
+                data-testid='release-year-header'
+              >
+                {year}
+              </div>
             ) : null}
-          </div>
-          <span className='inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full bg-white px-3 text-[13px] font-[680] tracking-[-0.01em] text-black'>
-            <Play className='h-3 w-3 fill-current' />
-            Listen
-          </span>
-        </a>
-      ) : null}
 
-      {visibleReleases.length > 1 ? (
-        <div className='px-4 pb-2 pt-5'>
-          <h3 className='text-[22px] font-[680] leading-none tracking-[-0.025em] text-white'>
-            {moreReleasesHeading}
-          </h3>
-        </div>
-      ) : null}
+            <a
+              href={`/${artistHandle}/${release.slug}`}
+              onClick={() =>
+                track('release_click', {
+                  artist_id: artistId,
+                  profile_id: artistId,
+                  profile_slug: artistHandle,
+                  handle: artistHandle,
+                  current_route_tab: 'music',
+                  release_id: release.id,
+                  release_slug: release.slug,
+                  release_title: release.title,
+                  is_latest: index === 0,
+                })
+              }
+              className='group flex min-h-[64px] items-center gap-3 border-t border-white/[0.075] px-4 py-2.5 first:border-t-0 transition-colors duration-subtle hover:bg-white/[0.03] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
+              aria-label={getReleaseAriaLabel(release)}
+            >
+              <div className='relative h-11 w-11 shrink-0 overflow-hidden rounded-[7px] bg-white/[0.04]'>
+                <ImageWithFallback
+                  src={release.artworkUrl}
+                  alt={release.title}
+                  fill
+                  sizes='44px'
+                  className='object-cover grayscale contrast-[1.04]'
+                  fallbackVariant='release'
+                />
+              </div>
 
-      <div
-        className={cn(
-          visibleReleases.length > 1 && 'border-y border-white/[0.075]'
-        )}
-      >
-        {visibleReleases.slice(1).map((release, index) => {
-          if (!release.slug) {
-            return null;
-          }
-
-          const year = release.releaseDate
-            ? new Date(release.releaseDate).getUTCFullYear().toString()
-            : null;
-          const showHeader = yearHeaderSet.has(release.id);
-          const meta = getReleaseMeta(release);
-          const ariaLabel = getReleaseAriaLabel(release);
-
-          return (
-            <div key={release.id}>
-              {showHeader ? (
-                <div className='font-caption px-1 pb-2 pt-5 text-[11px] font-medium uppercase tracking-[0.18em] text-white/24'>
-                  {year}
-                </div>
-              ) : null}
-
-              <a
-                href={`/${artistHandle}/${release.slug}`}
-                className={cn(
-                  'group flex min-h-[60px] items-center gap-3 px-4 py-2.5 transition-colors duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent hover:bg-white/[0.03]',
-                  index > 0 && 'border-t border-white/[0.075]'
-                )}
-                aria-label={ariaLabel}
-              >
-                <div className='relative h-11 w-11 shrink-0 overflow-hidden rounded-[6px] bg-white/[0.04]'>
-                  <ImageWithFallback
-                    src={release.artworkUrl}
-                    alt={release.title}
-                    fill
-                    sizes='44px'
-                    className='object-cover grayscale contrast-[1.04]'
-                    fallbackVariant='release'
-                  />
-                </div>
-
-                <div className='min-w-0 flex-1 space-y-px'>
-                  <div className='flex items-center gap-1.25'>
-                    <span className='truncate text-[15px] font-medium leading-tight tracking-[-0.028em] text-white'>
-                      {release.title}
+              <div className='min-w-0 flex-1 space-y-px'>
+                <div className='flex min-w-0 items-center gap-1.5'>
+                  <span className='truncate text-[15px] font-medium leading-tight tracking-[-0.028em] text-white'>
+                    {release.title}
+                  </span>
+                  {index === 0 ? (
+                    <span className='inline-flex h-[16px] shrink-0 items-center rounded-full bg-white px-1.5 text-[8px] font-semibold uppercase tracking-[0.04em] text-black'>
+                      Latest
                     </span>
-                    {index === 0 ? (
-                      <span className='inline-flex h-[15px] items-center rounded-full border border-white/8 bg-white px-1.25 text-[8px] font-semibold uppercase tracking-[0.04em] text-black'>
-                        New
-                      </span>
-                    ) : null}
-                    {release.releaseType === 'music_video' ? (
-                      <span className='inline-flex h-[15px] items-center rounded-full border border-white/8 bg-white/[0.04] px-1.25 text-[8px] font-semibold uppercase tracking-[0.04em] text-white/64'>
-                        Video
-                      </span>
-                    ) : null}
-                  </div>
-                  <p className='text-2xs truncate text-[11.5px] font-medium tracking-[-0.01em] text-white/38'>
-                    {meta}
-                  </p>
+                  ) : null}
+                  {release.releaseType === 'music_video' ? (
+                    <span className='inline-flex h-[16px] shrink-0 items-center rounded-full border border-white/8 bg-white/[0.04] px-1.5 text-[8px] font-semibold uppercase tracking-[0.04em] text-white/64'>
+                      Video
+                    </span>
+                  ) : null}
                 </div>
+                <p className='text-2xs truncate text-[11.5px] font-medium tracking-[-0.01em] text-white/42'>
+                  {meta}
+                </p>
+              </div>
 
-                <div className='ml-1 flex shrink-0 items-center gap-3'>
-                  <span className='flex h-8 w-8 items-center justify-center rounded-full border border-white/8 bg-white/[0.02] text-white/78 transition-[border-color,background-color] duration-subtle group-hover:border-white/14 group-hover:bg-white/[0.05]'>
-                    <Play className='ml-0.5 h-3 w-3 fill-current' />
-                  </span>
-                  <span
-                    aria-hidden='true'
-                    className='flex items-center gap-[3px] text-white/24 transition-colors duration-subtle group-hover:text-white/36'
-                  >
-                    <span className='h-[3px] w-[3px] rounded-full bg-current' />
-                    <span className='h-[3px] w-[3px] rounded-full bg-current' />
-                    <span className='h-[3px] w-[3px] rounded-full bg-current' />
-                  </span>
-                </div>
-              </a>
-            </div>
-          );
-        })}
-      </div>
+              <span className='flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white text-black transition-opacity duration-subtle group-hover:opacity-90'>
+                <Play className='ml-0.5 h-3 w-3 fill-current' />
+              </span>
+            </a>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/lib/notifications/analytics.ts
+++ b/apps/web/lib/notifications/analytics.ts
@@ -5,6 +5,7 @@ type BaseEventProps = {
   readonly artist_id: string | null;
   readonly channel?: string;
   readonly source?: string;
+  readonly source_context?: Record<string, unknown>;
 };
 
 type ErrorEventProps = BaseEventProps & {
@@ -21,6 +22,7 @@ type SubscribeSuccessProps = {
   readonly phone_present: boolean;
   readonly country_code?: string;
   readonly source: string;
+  readonly source_context?: Record<string, unknown>;
   readonly creator_is_pro: boolean;
   readonly dynamic_enabled: boolean;
 };
@@ -43,6 +45,7 @@ export const extractPayloadProps = (
   phone_length: number;
   source: string;
   method: string;
+  source_context?: Record<string, unknown>;
 } => ({
   artist_id: typeof payload.artist_id === 'string' ? payload.artist_id : null,
   channel: typeof payload.channel === 'string' ? payload.channel : 'email',
@@ -50,6 +53,12 @@ export const extractPayloadProps = (
   phone_length: typeof payload.phone === 'string' ? payload.phone.length : 0,
   source: typeof payload.source === 'string' ? payload.source : 'unknown',
   method: typeof payload.method === 'string' ? payload.method : 'api',
+  source_context:
+    payload.source_context &&
+    typeof payload.source_context === 'object' &&
+    !Array.isArray(payload.source_context)
+      ? (payload.source_context as Record<string, unknown>)
+      : undefined,
 });
 
 /**
@@ -73,6 +82,7 @@ export const trackSubscribeAttempt = async (
     email_length: props.email_length,
     phone_length: props.phone_length,
     source: props.source,
+    source_context: props.source_context,
   });
 };
 
@@ -87,6 +97,7 @@ export const trackSubscribeError = async (
     error_type: props.error_type,
     validation_errors: props.validation_errors,
     source: props.source,
+    source_context: props.source_context,
   });
 };
 
@@ -103,6 +114,7 @@ export const trackSubscribeSuccess = async (
     phone_present: props.phone_present,
     country_code: props.country_code,
     source: props.source,
+    source_context: props.source_context,
     creator_is_pro: props.creator_is_pro,
     dynamic_enabled: props.dynamic_enabled,
   });

--- a/apps/web/lib/notifications/client.ts
+++ b/apps/web/lib/notifications/client.ts
@@ -17,6 +17,7 @@ export type NotificationSubscribePayload = {
   countryCode?: string;
   city?: string;
   source?: string;
+  sourceContext?: Record<string, unknown>;
 };
 
 export type NotificationUnsubscribePayload = {
@@ -138,6 +139,7 @@ export const subscribeToNotifications = async (
       country_code: payload.countryCode,
       city: payload.city,
       source: payload.source,
+      source_context: payload.sourceContext,
     },
     NOTIFICATION_COPY.errors.subscribe
   );

--- a/apps/web/lib/notifications/domain.ts
+++ b/apps/web/lib/notifications/domain.ts
@@ -619,12 +619,21 @@ export const subscribeToNotificationsDomain = async (
         error_type: 'validation_error',
         validation_errors: result.error.format()._errors,
         source: props.source,
+        source_context: props.source_context,
       });
       return buildSubscribeValidationError();
     }
 
-    const { artist_id, email, phone, channel, source, country_code, city } =
-      result.data;
+    const {
+      artist_id,
+      email,
+      phone,
+      channel,
+      source,
+      source_context,
+      country_code,
+      city,
+    } = result.data;
 
     const artistResult = await fetchArtistProfile(artist_id, source);
     if (!isArtistProfileResult(artistResult)) {
@@ -645,6 +654,7 @@ export const subscribeToNotificationsDomain = async (
         artist_id,
         error_type: 'sms_requires_pro',
         source,
+        source_context,
       });
       return buildSubscribeValidationError(
         'SMS notifications are only available for Pro creators.'
@@ -657,6 +667,7 @@ export const subscribeToNotificationsDomain = async (
         artist_id,
         error_type: 'sms_us_only',
         source,
+        source_context,
       });
       return buildSubscribeValidationError(
         'SMS notifications are currently available in the US only.'
@@ -749,6 +760,7 @@ export const subscribeToNotificationsDomain = async (
       phone_present: Boolean(normalizedPhone),
       country_code: countryCode ?? undefined,
       source,
+      source_context,
       creator_is_pro: creatorIsPro,
       dynamic_enabled: dynamicEnabled,
     });

--- a/apps/web/lib/validation/schemas/notifications.ts
+++ b/apps/web/lib/validation/schemas/notifications.ts
@@ -71,6 +71,7 @@ export const subscribeSchema = z
       .optional(),
     city: z.string().max(120).optional(),
     source: z.string().min(1).max(80).default('profile_bell'),
+    source_context: z.record(z.string(), z.unknown()).optional(),
   })
   .superRefine((data, ctx) => {
     if (data.channel === 'email' && !data.email) {

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -98,7 +98,10 @@
 }
 
 .public-profile-layout-frame--desktop {
-  max-width: 1540px;
+  max-width: min(
+    100%,
+    calc(var(--profile-shell-max-width) + (var(--page-pad) * 2))
+  );
   padding-block: clamp(16px, 2vw, 24px);
 }
 
@@ -118,14 +121,6 @@
   display: none;
   min-width: 0;
   width: 100%;
-}
-
-.public-profile-layout-frame--desktop .public-profile-layout-compact-slot {
-  display: none;
-}
-
-.public-profile-layout-frame--desktop .public-profile-layout-desktop-shell {
-  display: block;
 }
 
 .public-profile-layout-desktop-placeholder {

--- a/apps/web/tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx
+++ b/apps/web/tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx
@@ -5,23 +5,41 @@ import type { AvailableDSP } from '@/lib/dsp';
 import type { Artist } from '@/types/db';
 import type { NotificationContentType } from '@/types/notifications';
 
-vi.mock('@/features/profile/views/ReleasesView', () => ({
-  ReleasesView: () => <div data-testid='mock-releases-view'>Releases</div>,
+const { releasesViewMock } = vi.hoisted(() => ({
+  releasesViewMock: vi.fn(),
 }));
 
+vi.mock('@/features/profile/views/ReleasesView', () => ({
+  ReleasesView: (props: { readonly artistId: string }) => {
+    releasesViewMock(props);
+    return (
+      <div data-artist-id={props.artistId} data-testid='mock-releases-view'>
+        Releases
+      </div>
+    );
+  },
+}));
+
+vi.mock(
+  '@/features/profile/artist-notifications-cta/ArtistNotificationsCTA',
+  () => ({
+    ArtistNotificationsCTA: ({
+      triggerLabel,
+      source,
+    }: {
+      readonly triggerLabel?: string;
+      readonly source?: string;
+    }) => (
+      <button data-source={source} data-testid='mock-alert-cta' type='button'>
+        {triggerLabel ?? 'Get alerts'}
+      </button>
+    ),
+  })
+);
+
 vi.mock('@/features/profile/StaticListenInterface', () => ({
-  StaticListenInterface: ({
-    dspsOverride = [],
-  }: {
-    readonly dspsOverride?: ReadonlyArray<AvailableDSP>;
-  }) => (
-    <div data-testid='mock-static-listen-interface'>
-      {dspsOverride.map(dsp => (
-        <button key={dsp.key} type='button'>
-          {dsp.name}
-        </button>
-      ))}
-    </div>
+  StaticListenInterface: () => (
+    <div data-testid='mock-static-listen-interface'>Listen providers</div>
   ),
 }));
 
@@ -67,7 +85,7 @@ const dsps: AvailableDSP[] = [
 ];
 
 describe('ProfilePrimaryTabPanel listen mode', () => {
-  it('renders releases and DSP actions together', () => {
+  it('renders releases as the Music tab surface without redundant DSP actions', () => {
     render(
       <ProfilePrimaryTabPanel
         mode='listen'
@@ -93,7 +111,37 @@ describe('ProfilePrimaryTabPanel listen mode', () => {
     );
 
     expect(screen.getByTestId('mock-releases-view')).toBeVisible();
-    expect(screen.getByTestId('mock-static-listen-interface')).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Spotify' })).toBeVisible();
+    expect(screen.getByTestId('mock-releases-view')).toHaveAttribute(
+      'data-artist-id',
+      'artist-1'
+    );
+    expect(
+      screen.queryByTestId('mock-static-listen-interface')
+    ).not.toBeInTheDocument();
+    expect(releasesViewMock).toHaveBeenCalledWith(
+      expect.objectContaining({ artistId: 'artist-1' })
+    );
+  });
+
+  it('renders a sparse no-music alert empty state', () => {
+    render(
+      <ProfilePrimaryTabPanel
+        mode='listen'
+        artist={artist}
+        dsps={dsps}
+        isSubscribed={false}
+        contentPrefs={contentPrefs}
+        onTogglePref={vi.fn()}
+        onUnsubscribe={vi.fn()}
+        isUnsubscribing={false}
+        releases={[]}
+      />
+    );
+
+    expect(screen.getByText('No music yet.')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Get alerts' })).toHaveAttribute(
+      'data-source',
+      'music_empty_state'
+    );
   });
 });

--- a/apps/web/tests/unit/profile/ReleasesView.test.tsx
+++ b/apps/web/tests/unit/profile/ReleasesView.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { PublicRelease } from '@/features/profile/releases/types';
+import { ReleasesView } from '@/features/profile/views/ReleasesView';
+
+const { trackMock } = vi.hoisted(() => ({
+  trackMock: vi.fn(),
+}));
+
+vi.mock('@/lib/analytics', () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
+vi.mock('@/components/atoms/ImageWithFallback', () => ({
+  ImageWithFallback: ({
+    alt,
+    src,
+  }: {
+    readonly alt: string;
+    readonly src?: string | null;
+  }) => <img alt={alt} src={src ?? undefined} />,
+}));
+
+const releases: PublicRelease[] = [
+  {
+    id: 'older-release',
+    title: 'Older Song',
+    slug: 'older-song',
+    releaseType: 'single',
+    releaseDate: '2024-01-01T00:00:00.000Z',
+    artworkUrl: null,
+    artistNames: ['Tim White'],
+  },
+  {
+    id: 'newest-release',
+    title: 'Newest Song',
+    slug: 'newest-song',
+    releaseType: 'album',
+    releaseDate: '2026-01-01T00:00:00.000Z',
+    artworkUrl: null,
+    artistNames: ['Tim White'],
+  },
+];
+
+describe('ReleasesView', () => {
+  it('renders a chronological Music list with the latest item first', () => {
+    render(
+      <ReleasesView
+        releases={releases}
+        artistId='artist-1'
+        artistHandle='tim'
+        artistName='Tim White'
+      />
+    );
+
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', '/tim/newest-song');
+    expect(links[1]).toHaveAttribute('href', '/tim/older-song');
+    expect(screen.getByText('Latest')).toBeVisible();
+    expect(screen.queryByText('Latest Release')).not.toBeInTheDocument();
+    expect(screen.queryByText('More Releases')).not.toBeInTheDocument();
+  });
+
+  it('tracks release clicks with profile context', () => {
+    render(
+      <ReleasesView
+        releases={releases}
+        artistId='artist-1'
+        artistHandle='tim'
+        artistName='Tim White'
+      />
+    );
+
+    const link = screen.getByRole('link', { name: 'View Newest Song' });
+    link.addEventListener('click', event => event.preventDefault());
+    fireEvent.click(link);
+
+    expect(trackMock).toHaveBeenCalledWith(
+      'release_click',
+      expect.objectContaining({
+        artist_id: 'artist-1',
+        profile_id: 'artist-1',
+        profile_slug: 'tim',
+        release_id: 'newest-release',
+        current_route_tab: 'music',
+        is_latest: true,
+      })
+    );
+  });
+});

--- a/apps/web/tests/unit/profile/TourModePanel.test.tsx
+++ b/apps/web/tests/unit/profile/TourModePanel.test.tsx
@@ -139,6 +139,10 @@ describe('TourModePanel', () => {
     render(<TourModePanel artist={artist} tourDates={[]} />);
     expect(screen.getByTestId('tour-drawer-content')).toBeInTheDocument();
     expect(screen.getByText('No upcoming events.')).toBeInTheDocument();
+    expect(screen.getByTestId('mock-notifications-cta')).toHaveAttribute(
+      'data-source',
+      'events_empty_state'
+    );
   });
 
   it('renders the styled all-shows list when no geolocation is available', () => {
@@ -151,20 +155,22 @@ describe('TourModePanel', () => {
     expect(screen.getByText('Upcoming')).toBeInTheDocument();
   });
 
-  it('highlights the nearest upcoming show when the user has nearby dates', () => {
+  it('renders a nearby group before upcoming shows when the user has nearby dates', () => {
     locationMock.location = { latitude: 51.507, longitude: -0.128 }; // London
     render(<TourModePanel artist={artist} tourDates={[londonDate, nycDate]} />);
 
-    expect(screen.getByText('Near You')).toBeInTheDocument();
+    expect(screen.getByText('Nearby')).toBeInTheDocument();
+    expect(screen.getByText('Upcoming')).toBeInTheDocument();
     expect(screen.getByText('The O2')).toBeInTheDocument();
     expect(screen.getByText('Madison Square Garden')).toBeInTheDocument();
   });
 
-  it('falls back to an upcoming highlight when no nearby dates exist', () => {
+  it('hides the nearby group when no nearby dates exist', () => {
     locationMock.location = { latitude: 0, longitude: -160 };
     render(<TourModePanel artist={artist} tourDates={[londonDate, nycDate]} />);
 
     expect(screen.getByText('Upcoming')).toBeInTheDocument();
+    expect(screen.queryByText('Nearby')).not.toBeInTheDocument();
     expect(screen.getByText('The O2')).toBeInTheDocument();
     expect(
       screen.queryByTestId('mock-notifications-cta')

--- a/apps/web/tests/unit/profile/profile-compact-template.test.tsx
+++ b/apps/web/tests/unit/profile/profile-compact-template.test.tsx
@@ -430,14 +430,11 @@ describe('ProfileCompactTemplate', () => {
     );
 
     const bottomNav = screen.getByTestId('profile-bottom-nav');
-    for (const label of ['Home', 'Music', 'Alerts', 'More options']) {
+    for (const label of ['Home', 'Music', 'Events', 'Alerts', 'More options']) {
       expect(
         within(bottomNav).getByRole('button', { name: label })
       ).toBeInTheDocument();
     }
-    expect(
-      within(bottomNav).queryByRole('button', { name: 'Events' })
-    ).not.toBeInTheDocument();
     expect(
       within(bottomNav).queryByRole('button', { name: 'Profile' })
     ).not.toBeInTheDocument();
@@ -664,6 +661,23 @@ describe('ProfileCompactTemplate', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('shows the newest catalog release on Home when latestRelease is not provided', async () => {
+    render(
+      <ProfileCompactTemplate
+        mode='profile'
+        artist={mockArtist}
+        socialLinks={[]}
+        contacts={[]}
+        releases={mockReleases}
+      />
+    );
+
+    const homeCard = screen.getByTestId('profile-home-primary-action-card');
+    expect(homeCard).toHaveAttribute('data-state', 'release_live');
+    expect(homeCard).toHaveTextContent("Don't Look Down");
+    expect(homeCard).not.toHaveTextContent('Holding On');
+  });
+
   it('opens the alerts tab from the compact hero alerts row', async () => {
     render(
       <ProfileCompactTemplate
@@ -719,7 +733,9 @@ describe('ProfileCompactTemplate', () => {
 
     fireEvent.click(screen.getByTestId('profile-home-alerts-fallback-card'));
 
-    expect(revealNotifications).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(revealNotifications).toHaveBeenCalledTimes(1);
+    });
     expect(
       screen.queryByTestId('mock-primary-tab-panel')
     ).not.toBeInTheDocument();
@@ -1157,7 +1173,7 @@ describe('ProfileCompactTemplate', () => {
     });
   });
 
-  it('renders the drawer at desktop widths', async () => {
+  it('renders the compact profile shell at desktop widths', async () => {
     const restoreViewport = mockViewport('desktop');
 
     render(
@@ -1170,13 +1186,14 @@ describe('ProfileCompactTemplate', () => {
     );
 
     await waitFor(() => {
-      expect(mockProfileDesktopSurface).toHaveBeenCalled();
+      expect(screen.getByTestId('profile-compact-shell')).toBeInTheDocument();
+      expect(mockProfileDesktopSurface).not.toHaveBeenCalled();
     });
 
     restoreViewport();
   });
 
-  it('passes pay, contact, tour, subscribe, and release variants into the desktop smoke surface', async () => {
+  it('keeps desktop widths on the compact surface across profile variants', async () => {
     const restoreViewport = mockViewport('desktop');
 
     const variantProps = {
@@ -1230,24 +1247,8 @@ describe('ProfileCompactTemplate', () => {
     );
 
     await waitFor(() => {
-      expect(mockProfileDesktopSurface).toHaveBeenCalledWith(
-        expect.objectContaining({
-          activeMode: 'pay',
-          contacts: mockContacts,
-          latestRelease: expect.objectContaining({
-            title: "Don't Look Down",
-            slug: 'dont-look-down',
-          }),
-          showPayButton: true,
-          tourDates: expect.arrayContaining([
-            expect.objectContaining({
-              venueName: 'The Echo',
-              ticketUrl: 'https://tickets.example.com/show',
-            }),
-          ]),
-          releases: mockReleases,
-        })
-      );
+      expect(screen.getByTestId('profile-compact-shell')).toBeInTheDocument();
+      expect(mockProfileDesktopSurface).not.toHaveBeenCalled();
     });
 
     view.rerender(
@@ -1255,20 +1256,12 @@ describe('ProfileCompactTemplate', () => {
     );
 
     await waitFor(() => {
-      expect(mockProfileDesktopSurface).toHaveBeenCalledWith(
+      expect(mockProfilePrimaryTabPanel).toHaveBeenCalledWith(
         expect.objectContaining({
-          activeMode: 'subscribe',
-          contacts: mockContacts,
-          latestRelease: expect.objectContaining({
-            title: "Don't Look Down",
-          }),
-          tourDates: expect.arrayContaining([
-            expect.objectContaining({
-              venueName: 'The Echo',
-            }),
-          ]),
+          mode: 'subscribe',
         })
       );
+      expect(mockProfileDesktopSurface).not.toHaveBeenCalled();
     });
 
     restoreViewport();

--- a/apps/web/tests/unit/profile/profile-components.test.tsx
+++ b/apps/web/tests/unit/profile/profile-components.test.tsx
@@ -217,6 +217,8 @@ describe('ProfileViewTracker', () => {
     expect(mockTrack).toHaveBeenCalledWith('profile_view', {
       handle: 'testartist',
       artist_id: 'artist-123',
+      profile_id: 'artist-123',
+      profile_slug: 'testartist',
       source: 'https://google.com',
     });
   });
@@ -289,6 +291,8 @@ describe('ProfileViewTracker', () => {
     expect(mockTrack).toHaveBeenCalledWith('profile_view', {
       handle: 'testartist',
       artist_id: 'artist-123',
+      profile_id: 'artist-123',
+      profile_slug: 'testartist',
       source: 'qr-code',
     });
   });


### PR DESCRIPTION
## Summary
- Refactors public profiles onto the compact native profile shell on desktop and mobile, using the existing profile tokens/surfaces instead of the legacy stretched desktop surface.
- Simplifies Home/Music/Events IA: Home shows alerts plus the latest release card, Music is a chronological release list, Events is grouped simply with a sparse alert empty state.
- Threads source intent through alert CTAs and subscription submits/completion analytics, including artist/profile/slug/current tab/CTA location/intent and selected alert toggles.
- Adds profile action analytics for profile view, tab clicks, release clicks, listen clicks, social clicks, and event clicks.

Linear: Fixes JOV-2359. Canary OTP/source-intent validation is tracked in JOV-2360.

## QA
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/profile apps/web/lib/notifications apps/web/lib/validation/schemas/notifications.ts apps/web/styles/design-system.css apps/web/tests/unit/profile`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run components/features/profile/nav/BottomTabBar.test.tsx tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx tests/unit/profile/TourModePanel.test.tsx tests/unit/profile/ReleasesView.test.tsx tests/unit/profile/profile-compact-template.test.tsx tests/unit/profile/ProfileUnifiedDrawerReleases.test.tsx tests/unit/profile/ProfileInlineNotificationsCTA.test.tsx` — 95 passed
- `BASE_URL=http://localhost:3000 E2E_SKIP_WEB_SERVER=1 E2E_USE_TEST_AUTH_BYPASS=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec playwright test tests/e2e/profile-mobile-viewport-stability.spec.ts --project=chromium --reporter=line` — 83 passed
- Browser QA on `/tim`, `/tim?mode=listen`, `/tim?mode=tour`, and desktop `/tim`: zero horizontal overflow, compact shell rendered, desktop legacy shell not rendered, no `Latest Release`/`More Releases` heading in Music, Events empty CTA present.
- `BASE_URL=http://localhost:3000 JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run test:lighthouse:pr` ran 3x `/` and 3x `/tim`; command exited 1 on existing homepage/dev assertions before surfacing `/tim` assertions. `/tim` local LHR evidence: CLS 0, TBT 154-204ms, accessibility 0.94, best-practices 0.93-0.96. LCP remains high in local dev Lighthouse against remote imagery, so CI/preview Lighthouse should be treated as the source of truth.

## Screenshots
- `/tmp/jovie-tim-final-mobile-home.png`
- `/tmp/jovie-tim-final-mobile-music.png`
- `/tmp/jovie-tim-final-mobile-events.png`
- `/tmp/jovie-tim-final-desktop.png`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Events tab is now always visible in profile navigation.
  - "Get alerts" CTAs and empty states across profile, music, and events support richer source/context and customizable trigger labels.

* **Updates**
  - Releases list simplified and re-ordered to show newest items first; release interactions include fuller profile context.
  - Subscription flows and analytics now include enhanced source_context and profile identifiers.
  - Compact/desktop profile layout and notification reveal behavior refined.

* **Tests**
  - Unit tests updated for navigation, releases, empty states, and analytics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9030?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->