### PR TITLE
fix(ci): harden production domain guard notifications

### DIFF
--- a/.github/scripts/verify-vercel-production-domains.mjs
+++ b/.github/scripts/verify-vercel-production-domains.mjs
@@ -10,6 +10,8 @@ export const PRODUCTION_DOMAIN_EXPECTATIONS = Object.freeze([
   { name: 'jovie.fm', redirect: 'jov.ie', redirectStatusCode: 308 },
 ]);
 
+export const VERCEL_DOMAINS_API_TIMEOUT_MS = 10_000;
+
 export function buildProjectDomainsUrl({ projectId, orgId }) {
   const url = new URL(
     `https://api.vercel.com/v9/projects/${encodeURIComponent(projectId)}/domains`
@@ -30,27 +32,42 @@ export async function fetchProjectDomains({
   fetchImpl = fetch,
   orgId,
   projectId,
+  timeoutMs = VERCEL_DOMAINS_API_TIMEOUT_MS,
   token,
 }) {
-  const response = await fetchImpl(
-    buildProjectDomainsUrl({ projectId, orgId }),
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-    }
-  );
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
-  if (!response.ok) {
-    const body = await response.text().catch(() => '');
-    throw new Error(
-      `Vercel domains API failed: HTTP ${response.status} ${body}`.trim()
+  try {
+    const response = await fetchImpl(
+      buildProjectDomainsUrl({ projectId, orgId }),
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        signal: controller.signal,
+      }
     );
-  }
 
-  const payload = await response.json();
-  return Array.isArray(payload.domains) ? payload.domains : [];
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(
+        `Vercel domains API failed: HTTP ${response.status} ${body}`.trim()
+      );
+    }
+
+    const payload = await response.json();
+    return Array.isArray(payload.domains) ? payload.domains : [];
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`Vercel domains API timed out after ${timeoutMs}ms`);
+    }
+
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export function validateProductionDomains({

--- a/.github/scripts/verify-vercel-production-domains.test.mjs
+++ b/.github/scripts/verify-vercel-production-domains.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
   buildProjectDomainsUrl,
+  fetchProjectDomains,
   PRODUCTION_DOMAIN_EXPECTATIONS,
   validateProductionDomains,
 } from './verify-vercel-production-domains.mjs';
@@ -50,6 +51,44 @@ test('buildProjectDomainsUrl scopes non-team ids as slugs', () => {
   assert.equal(
     url.toString(),
     'https://api.vercel.com/v9/projects/prj_canonical/domains?slug=jovie'
+  );
+});
+
+test('fetchProjectDomains passes an abort signal to the Vercel domains API request', async () => {
+  let requestOptions;
+
+  await fetchProjectDomains({
+    fetchImpl: async (_url, options) => {
+      requestOptions = options;
+
+      return {
+        json: async () => ({ domains: [] }),
+        ok: true,
+      };
+    },
+    projectId: canonicalProjectId,
+    token: 'vercel-token',
+  });
+
+  assert.equal(requestOptions.headers.Authorization, 'Bearer vercel-token');
+  assert.ok(requestOptions.signal instanceof AbortSignal);
+  assert.equal(requestOptions.signal.aborted, false);
+});
+
+test('fetchProjectDomains fails fast when the Vercel domains API request times out', async () => {
+  await assert.rejects(
+    fetchProjectDomains({
+      fetchImpl: async (_url, options) =>
+        new Promise((_resolve, reject) => {
+          options.signal.addEventListener('abort', () => {
+            reject(new DOMException('aborted', 'AbortError'));
+          });
+        }),
+      projectId: canonicalProjectId,
+      timeoutMs: 1,
+      token: 'vercel-token',
+    }),
+    /Vercel domains API timed out after 1ms/
   );
 });
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4309,7 +4309,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - name: Slack notify (general deploy failure)
-        if: ${{ always() && (steps.classify-failure.outputs.failure_type == 'deploy' || steps.classify-failure.outputs.failure_type == 'promote' || steps.classify-failure.outputs.failure_type == 'promote_no_match' || steps.classify-failure.outputs.failure_type == 'promote_verify_mismatch' || steps.classify-failure.outputs.failure_type == 'promote_verify_probe_failed' || steps.classify-failure.outputs.failure_type == 'promote_missing_creds' || steps.classify-failure.outputs.failure_type == 'cancelled' || steps.classify-failure.outputs.failure_type == 'unknown') && env.SLACK_WEBHOOK_URL != '' }}
+        if: ${{ always() && (steps.classify-failure.outputs.failure_type == 'deploy' || steps.classify-failure.outputs.failure_type == 'promote' || steps.classify-failure.outputs.failure_type == 'promote_domain_project_mismatch' || steps.classify-failure.outputs.failure_type == 'promote_no_match' || steps.classify-failure.outputs.failure_type == 'promote_verify_mismatch' || steps.classify-failure.outputs.failure_type == 'promote_verify_probe_failed' || steps.classify-failure.outputs.failure_type == 'promote_missing_creds' || steps.classify-failure.outputs.failure_type == 'cancelled' || steps.classify-failure.outputs.failure_type == 'unknown') && env.SLACK_WEBHOOK_URL != '' }}
         uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3.19.0
         with:
           status: custom

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -230,6 +230,10 @@ describe('deploy workflow Vercel env resolution', () => {
   it('alerts specifically when production domains drift off the canonical Vercel project', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const classifyStep = getStepBlock(workflow, 'Classify failure type');
+    const generalSlackStep = getStepBlock(
+      workflow,
+      'Slack notify (general deploy failure)'
+    );
 
     expect(classifyStep).toContain('domain_project_mismatch');
     expect(classifyStep).toContain(
@@ -238,6 +242,7 @@ describe('deploy workflow Vercel env resolution', () => {
     expect(classifyStep).toContain(
       'Production promotion was blocked before deploy.'
     );
+    expect(generalSlackStep).toContain('promote_domain_project_mismatch');
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds a 10s AbortController timeout around the Vercel project-domain API check so production promotion fails fast if the guard request hangs.
- Includes `promote_domain_project_mismatch` in the general deploy failure Slack condition.
- Adds regression coverage for the timeout path and Slack notification wiring.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write .github/scripts/verify-vercel-production-domains.mjs .github/scripts/verify-vercel-production-domains.test.mjs .github/workflows/ci.yml apps/web/tests/unit/ci/deploy-workflow.test.ts`
- `JOVIE_AGENT_PROFILE=coder node --test .github/scripts/verify-vercel-production-domains.test.mjs`
- `JOVIE_AGENT_PROFILE=coder pnpm exec actionlint -shellcheck= .github/workflows/ci.yml`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push hook: `biome check .`, web proxy guard, tailwind guard, typecheck, lint

Follow-up to #9023 CodeRabbit review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced domain verification API calls with configurable timeout protection (10-second default) to prevent indefinite hangs.
  * Expanded deployment failure notifications to include additional failure scenarios for improved alerting coverage.

* **Tests**
  * Added timeout handling and error handling tests for domain verification API calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->