### PR TITLE
Canonicalize tasks shell data loading

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/tasks/TasksRoute.tsx
+++ b/apps/web/app/app/(shell)/dashboard/tasks/TasksRoute.tsx
@@ -1,13 +1,1 @@
-import { TasksPageClient } from '@/components/features/dashboard/tasks/TasksPageClient';
-import { TasksWorkspaceUpgradeInterstitial } from '@/components/features/dashboard/tasks/TasksUpgradeInterstitial';
-import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
-
-export async function TasksRoute() {
-  const entitlements = await getCurrentUserEntitlements();
-
-  if (!entitlements.canAccessTasksWorkspace) {
-    return <TasksWorkspaceUpgradeInterstitial />;
-  }
-
-  return <TasksPageClient />;
-}
+export { TasksRoute } from '../../tasks/TasksRoute';

--- a/apps/web/app/app/(shell)/tasks/TasksRoute.tsx
+++ b/apps/web/app/app/(shell)/tasks/TasksRoute.tsx
@@ -1,0 +1,78 @@
+import { redirect } from 'next/navigation';
+import { TasksPageClient } from '@/components/features/dashboard/tasks/TasksPageClient';
+import { TasksWorkspaceUpgradeInterstitial } from '@/components/features/dashboard/tasks/TasksUpgradeInterstitial';
+import { APP_ROUTES } from '@/constants/routes';
+import { PageErrorState } from '@/features/feedback/PageErrorState';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import { captureError } from '@/lib/error-tracking';
+import { queryKeys } from '@/lib/queries';
+import { HydrateClient } from '@/lib/queries/HydrateClient';
+import { getDehydratedState, getQueryClient } from '@/lib/queries/server';
+import { DEFAULT_TASK_WORKSPACE_FILTERS } from '@/lib/tasks/query-defaults';
+import { getDashboardShellData } from '../dashboard/actions';
+import { getTaskBoard, getTasks } from '../dashboard/tasks/task-actions';
+
+export async function TasksRoute() {
+  const { userId } = await getCachedAuth();
+  if (!userId) {
+    const signInParams = new URLSearchParams({
+      redirect_url: APP_ROUTES.TASKS,
+    });
+    redirect(`${APP_ROUTES.SIGNIN}?${signInParams.toString()}`);
+  }
+
+  const dashboardData = await getDashboardShellData(userId);
+  if (dashboardData.dashboardLoadError) {
+    void captureError(
+      'Dashboard data load failed on tasks page',
+      dashboardData.dashboardLoadError,
+      { route: APP_ROUTES.TASKS }
+    );
+    return (
+      <PageErrorState message='Failed to load tasks data. Please refresh the page.' />
+    );
+  }
+
+  if (dashboardData.needsOnboarding) {
+    redirect(APP_ROUTES.START);
+  }
+
+  const entitlements = await getCurrentUserEntitlements();
+  if (!entitlements.canAccessTasksWorkspace) {
+    return <TasksWorkspaceUpgradeInterstitial />;
+  }
+
+  const profileId = dashboardData.selectedProfile?.id;
+  if (profileId) {
+    const queryClient = getQueryClient();
+    try {
+      await Promise.all([
+        queryClient.fetchQuery({
+          queryKey: queryKeys.tasks.list(
+            profileId,
+            DEFAULT_TASK_WORKSPACE_FILTERS
+          ),
+          queryFn: () => getTasks(DEFAULT_TASK_WORKSPACE_FILTERS),
+        }),
+        queryClient.fetchQuery({
+          queryKey: queryKeys.tasks.board(
+            profileId,
+            DEFAULT_TASK_WORKSPACE_FILTERS
+          ),
+          queryFn: () => getTaskBoard(DEFAULT_TASK_WORKSPACE_FILTERS),
+        }),
+      ]);
+    } catch (error) {
+      void captureError('Tasks prefetch failed on tasks page', error, {
+        route: APP_ROUTES.TASKS,
+      });
+    }
+  }
+
+  return (
+    <HydrateClient state={getDehydratedState()}>
+      <TasksPageClient />
+    </HydrateClient>
+  );
+}

--- a/apps/web/app/app/(shell)/tasks/page.tsx
+++ b/apps/web/app/app/(shell)/tasks/page.tsx
@@ -1,4 +1,4 @@
-import { TasksRoute } from '../dashboard/tasks/TasksRoute';
+import { TasksRoute } from './TasksRoute';
 
 export default async function TasksPage() {
   return TasksRoute();

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -21,6 +21,7 @@ import {
   Trash2,
   X,
 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import {
   type ComponentPropsWithoutRef,
   type FormEvent,
@@ -894,10 +895,12 @@ function TaskEmptyState({
   hasFilters,
   onClearFilters,
   onOpenComposer,
+  onOpenReleases,
 }: Readonly<{
   hasFilters: boolean;
   onClearFilters: () => void;
   onOpenComposer: () => void;
+  onOpenReleases: () => void;
 }>) {
   return (
     <div className='flex min-h-[360px] flex-col items-center justify-center gap-3 px-6 text-center'>
@@ -932,9 +935,7 @@ function TaskEmptyState({
               type='button'
               variant='secondary'
               size='sm'
-              onClick={() => {
-                globalThis.location.href = APP_ROUTES.RELEASES;
-              }}
+              onClick={onOpenReleases}
             >
               Set Up Release
             </Button>
@@ -1265,6 +1266,7 @@ function useTaskActions({
 }
 
 export function TasksPageClient() {
+  const router = useRouter();
   const designV1TasksEnabled = useAppFlag('DESIGN_V1');
   const { selectedProfile } = useDashboardData();
   const { setHeaderActions } = useSetHeaderActions();
@@ -1483,6 +1485,9 @@ export function TasksPageClient() {
     setAssigneeFilter('all');
     setMobileScope('all');
   }, []);
+  const openReleases = useCallback(() => {
+    router.push(APP_ROUTES.RELEASES);
+  }, [router]);
   const showTaskWorkbenchEmptyState =
     !isBoardMode && !isActiveListLoading && tasks.length === 0;
   const selectedTaskIndex = effectiveSelectedTaskId
@@ -1946,6 +1951,7 @@ export function TasksPageClient() {
             hasFilters={hasFilters}
             onClearFilters={clearFilters}
             onOpenComposer={() => setHeaderMode('create')}
+            onOpenReleases={openReleases}
           />
         </div>
       </div>
@@ -1978,6 +1984,7 @@ export function TasksPageClient() {
             hasFilters={hasFilters}
             onClearFilters={clearFilters}
             onOpenComposer={() => setHeaderMode('create')}
+            onOpenReleases={openReleases}
           />
         }
       />
@@ -1994,6 +2001,7 @@ export function TasksPageClient() {
           hasFilters={hasFilters || mobileScope !== 'all'}
           onClearFilters={clearFilters}
           onOpenComposer={() => setHeaderMode('create')}
+          onOpenReleases={openReleases}
         />
       </div>
     );

--- a/apps/web/lib/queries/prefetch-dashboard.ts
+++ b/apps/web/lib/queries/prefetch-dashboard.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from '@tanstack/react-query';
 import { loadDspPresenceForProfile } from '@/app/app/(shell)/dashboard/presence/actions';
 import { loadReleaseMatrix } from '@/app/app/(shell)/dashboard/releases/actions';
 import { getTasks } from '@/app/app/(shell)/dashboard/tasks/task-actions';
+import { DEFAULT_TASK_WORKSPACE_FILTERS } from '@/lib/tasks/query-defaults';
 import { FREQUENT_CACHE } from './cache-strategies';
 import { createQueryFn, fetchWithTimeout } from './fetch';
 import { queryKeys } from './keys';
@@ -61,8 +62,11 @@ export function prefetchForRoute(
       break;
     case 'tasks':
       queryClient.prefetchQuery({
-        queryKey: queryKeys.tasks.list(profileId),
-        queryFn: () => getTasks(),
+        queryKey: queryKeys.tasks.list(
+          profileId,
+          DEFAULT_TASK_WORKSPACE_FILTERS
+        ),
+        queryFn: () => getTasks(DEFAULT_TASK_WORKSPACE_FILTERS),
         staleTime,
       });
       break;

--- a/apps/web/lib/tasks/query-defaults.ts
+++ b/apps/web/lib/tasks/query-defaults.ts
@@ -1,0 +1,5 @@
+import type { TaskFilters } from './types';
+
+export const DEFAULT_TASK_WORKSPACE_FILTERS = {
+  limit: 100,
+} satisfies TaskFilters;

--- a/apps/web/tests/unit/app/dashboard-tasks-page.test.tsx
+++ b/apps/web/tests/unit/app/dashboard-tasks-page.test.tsx
@@ -1,12 +1,71 @@
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
 
-const { mockGetCurrentUserEntitlements } = vi.hoisted(() => ({
+const {
+  mockCaptureError,
+  mockFetchQuery,
+  mockGetCachedAuth,
+  mockGetCurrentUserEntitlements,
+  mockGetDashboardShellData,
+  mockGetDehydratedState,
+  mockGetQueryClient,
+  mockGetTaskBoard,
+  mockGetTasks,
+  mockRedirect,
+} = vi.hoisted(() => ({
+  mockCaptureError: vi.fn(),
+  mockFetchQuery: vi.fn(),
+  mockGetCachedAuth: vi.fn(),
   mockGetCurrentUserEntitlements: vi.fn(),
+  mockGetDashboardShellData: vi.fn(),
+  mockGetDehydratedState: vi.fn(),
+  mockGetQueryClient: vi.fn(),
+  mockGetTaskBoard: vi.fn(),
+  mockGetTasks: vi.fn(),
+  mockRedirect: vi.fn((url: string) => {
+    throw new Error(`REDIRECT:${url}`);
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: mockRedirect,
+}));
+
+vi.mock('@/lib/auth/cached', () => ({
+  getCachedAuth: mockGetCachedAuth,
 }));
 
 vi.mock('@/lib/entitlements/server', () => ({
   getCurrentUserEntitlements: mockGetCurrentUserEntitlements,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: mockCaptureError,
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/actions', () => ({
+  getDashboardShellData: mockGetDashboardShellData,
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/tasks/task-actions', () => ({
+  getTaskBoard: mockGetTaskBoard,
+  getTasks: mockGetTasks,
+}));
+
+vi.mock('@/lib/queries/server', () => ({
+  getDehydratedState: mockGetDehydratedState,
+  getQueryClient: mockGetQueryClient,
+}));
+
+vi.mock('@/lib/queries/HydrateClient', () => ({
+  HydrateClient: ({
+    children,
+  }: {
+    readonly children: ReactNode;
+    readonly state?: unknown;
+  }) => <div data-testid='hydrate-client'>{children}</div>,
 }));
 
 vi.mock('@/components/features/dashboard/tasks/TasksPageClient', () => ({
@@ -30,6 +89,40 @@ import TasksPage from '@/app/app/(shell)/tasks/page';
 describe('tasks page routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetCachedAuth.mockResolvedValue({ userId: 'user_123' });
+    mockGetCurrentUserEntitlements.mockResolvedValue({
+      canAccessTasksWorkspace: true,
+    });
+    mockGetDashboardShellData.mockResolvedValue({
+      dashboardLoadError: null,
+      needsOnboarding: false,
+      selectedProfile: {
+        id: 'profile-1',
+      },
+    });
+    mockGetDehydratedState.mockReturnValue({ queries: [] });
+    mockGetQueryClient.mockReturnValue({
+      fetchQuery: mockFetchQuery,
+    });
+    mockFetchQuery.mockImplementation(
+      async ({ queryFn }: { readonly queryFn: () => Promise<unknown> }) =>
+        queryFn()
+    );
+    mockGetTasks.mockResolvedValue({ nextCursor: null, tasks: [] });
+    mockGetTaskBoard.mockResolvedValue({ columns: [], totalCount: 0 });
+  });
+
+  it('redirects signed-out users to sign-in with the canonical route as the return target', async () => {
+    mockGetCachedAuth.mockResolvedValueOnce({ userId: null });
+    const encodedReturnPath = encodeURIComponent(APP_ROUTES.TASKS);
+
+    await expect(TasksPage()).rejects.toThrow(
+      `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${encodedReturnPath}`
+    );
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      `${APP_ROUTES.SIGNIN}?redirect_url=${encodedReturnPath}`
+    );
   });
 
   it('renders the upgrade interstitial for users without task access', async () => {
@@ -43,15 +136,16 @@ describe('tasks page routes', () => {
       screen.getByTestId('tasks-upgrade-interstitial')
     ).toBeInTheDocument();
     expect(screen.queryByTestId('tasks-page-client')).not.toBeInTheDocument();
+    expect(mockFetchQuery).not.toHaveBeenCalled();
   });
 
-  it('renders the tasks workspace for users with task access', async () => {
-    mockGetCurrentUserEntitlements.mockResolvedValueOnce({
-      canAccessTasksWorkspace: true,
-    });
-
+  it('server-prefetches default task data before rendering the workspace', async () => {
     render(await TasksPage());
 
+    expect(mockFetchQuery).toHaveBeenCalledTimes(2);
+    expect(mockGetTasks).toHaveBeenCalledWith({ limit: 100 });
+    expect(mockGetTaskBoard).toHaveBeenCalledWith({ limit: 100 });
+    expect(screen.getByTestId('hydrate-client')).toBeInTheDocument();
     expect(screen.getByTestId('tasks-page-client')).toBeInTheDocument();
     expect(
       screen.queryByTestId('tasks-upgrade-interstitial')
@@ -59,12 +153,20 @@ describe('tasks page routes', () => {
   });
 
   it('keeps the legacy dashboard entry point on the same task contract', async () => {
-    mockGetCurrentUserEntitlements.mockResolvedValueOnce({
-      canAccessTasksWorkspace: true,
-    });
-
     render(await LegacyTasksPage());
 
     expect(screen.getByTestId('tasks-page-client')).toBeInTheDocument();
+  });
+
+  it('redirects onboarding-required users back to start', async () => {
+    mockGetDashboardShellData.mockResolvedValueOnce({
+      dashboardLoadError: null,
+      needsOnboarding: true,
+      selectedProfile: null,
+    });
+
+    await expect(TasksPage()).rejects.toThrow(`REDIRECT:${APP_ROUTES.START}`);
+
+    expect(mockRedirect).toHaveBeenCalledWith(APP_ROUTES.START);
   });
 });

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -2,20 +2,29 @@ import { TooltipProvider } from '@jovie/ui';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
 import type { TaskBoardResult, TaskStatus, TaskView } from '@/lib/tasks/types';
 
 const {
+  mockRouterPush,
   mockRegisterRightPanel,
   mockUseAppFlag,
   mockUseReleaseEntityQuery,
   mockUseTaskBoardQuery,
   mockUseTasksQuery,
 } = vi.hoisted(() => ({
+  mockRouterPush: vi.fn(),
   mockRegisterRightPanel: vi.fn(),
   mockUseAppFlag: vi.fn(),
   mockUseReleaseEntityQuery: vi.fn(),
   mockUseTaskBoardQuery: vi.fn(),
   mockUseTasksQuery: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
 }));
 
 vi.mock('@jovie/ui', async () => {
@@ -557,6 +566,7 @@ describe('TasksPageClient', () => {
     mockSetViewMode.mockClear();
     mockSetHeaderActions.mockReset();
     mockRegisterRightPanel.mockReset();
+    mockRouterPush.mockReset();
     mockUseReleaseEntityQuery.mockClear();
     mockUseTaskBoardQuery.mockClear();
     mockUseTasksQuery.mockClear();
@@ -582,6 +592,17 @@ describe('TasksPageClient', () => {
     expect(screen.queryByText('All Statuses')).not.toBeInTheDocument();
     expect(screen.queryByText('All Priorities')).not.toBeInTheDocument();
     expect(screen.queryByText('All Assignees')).not.toBeInTheDocument();
+  });
+
+  it('routes the empty-state release setup CTA through the app router', () => {
+    mockTasksData = [];
+    mockListQueryData = [];
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set Up Release' }));
+
+    expect(mockRouterPush).toHaveBeenCalledWith(APP_ROUTES.RELEASES);
   });
 
   it('keeps release detail loading disabled until a release context is opened', () => {

--- a/apps/web/tests/unit/queries/prefetch-dashboard.test.ts
+++ b/apps/web/tests/unit/queries/prefetch-dashboard.test.ts
@@ -2,8 +2,10 @@ import { QueryClient } from '@tanstack/react-query';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { queryKeys } from '@/lib/queries/keys';
 import { prefetchForRoute } from '@/lib/queries/prefetch-dashboard';
+import { DEFAULT_TASK_WORKSPACE_FILTERS } from '@/lib/tasks/query-defaults';
 
 const mocks = vi.hoisted(() => ({
+  getTasks: vi.fn(async () => ({ nextCursor: null, tasks: [] })),
   loadReleaseMatrix: vi.fn(async (profileId: string) => [
     { id: `release-${profileId}` },
   ]),
@@ -18,11 +20,12 @@ vi.mock('@/app/app/(shell)/dashboard/presence/actions', () => ({
 }));
 
 vi.mock('@/app/app/(shell)/dashboard/tasks/task-actions', () => ({
-  getTasks: vi.fn(async () => []),
+  getTasks: mocks.getTasks,
 }));
 
 describe('prefetchForRoute', () => {
   afterEach(() => {
+    mocks.getTasks.mockClear();
     mocks.loadReleaseMatrix.mockClear();
   });
 
@@ -39,6 +42,26 @@ describe('prefetchForRoute', () => {
       expect(
         queryClient.getQueryData(queryKeys.releases.matrix('profile-123'))
       ).toEqual([{ id: 'release-profile-123' }]);
+    });
+  });
+
+  it('warms the canonical tasks workspace cache for the tasks route', async () => {
+    const queryClient = new QueryClient();
+
+    prefetchForRoute('tasks', queryClient, 'profile-123');
+
+    await vi.waitFor(() => {
+      expect(mocks.getTasks).toHaveBeenCalledWith(
+        DEFAULT_TASK_WORKSPACE_FILTERS
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(
+        queryClient.getQueryData(
+          queryKeys.tasks.list('profile-123', DEFAULT_TASK_WORKSPACE_FILTERS)
+        )
+      ).toEqual({ nextCursor: null, tasks: [] });
     });
   });
 });


### PR DESCRIPTION
## Summary
- move the tasks route owner to canonical `/app/tasks` and keep the legacy dashboard entry point as a re-export
- server-prefetch the default task list and board queries before rendering the tasks workspace
- align nav hover prefetch with the canonical tasks query key and replace the empty-state release setup full reload with App Router navigation

## Linear
- JOV-2372

## Verification
- `pnpm exec biome check --write ...`
- `pnpm --filter web exec vitest run tests/unit/app/dashboard-tasks-page.test.tsx tests/unit/dashboard/TasksPageClient.test.tsx tests/unit/queries/prefetch-dashboard.test.ts`
- `pnpm --filter web exec vitest run tests/unit/app/shell-route-matches.test.ts tests/unit/app/dashboard-tasks-page.test.tsx tests/unit/dashboard/TasksPageClient.test.tsx tests/unit/queries/prefetch-dashboard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- commit hook: proxy guard, staged a11y guard, ESLint, Biome, web typecheck
- pre-push hook: Biome, proxy guard, Tailwind guard, web typecheck, web lint

No visual output changed; this is route/data loading and navigation behavior only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved navigation from the task empty state to releases page using app routing.

* **Bug Fixes**
  * Enhanced authentication redirect flow with proper sign-in and onboarding handling.

* **Improvements**
  * Optimized task data prefetching with default workspace filters for faster loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9036?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->