### PR TITLE
Normalize profile alert CTA copy

### DIFF
--- a/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
+++ b/apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx
@@ -550,7 +550,7 @@ export function ProfilePrimaryTabPanel({
           artist={artist}
           title='No music yet.'
           body='Get a note when the first release lands.'
-          triggerLabel='Get alerts'
+          triggerLabel='Turn on alerts'
           sourceContext={musicEmptySourceContext}
         />
       </div>

--- a/apps/web/tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx
+++ b/apps/web/tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx
@@ -139,9 +139,8 @@ describe('ProfilePrimaryTabPanel listen mode', () => {
     );
 
     expect(screen.getByText('No music yet.')).toBeVisible();
-    expect(screen.getByRole('button', { name: 'Get alerts' })).toHaveAttribute(
-      'data-source',
-      'music_empty_state'
-    );
+    expect(
+      screen.getByRole('button', { name: 'Turn on alerts' })
+    ).toHaveAttribute('data-source', 'music_empty_state');
   });
 });


### PR DESCRIPTION
## Summary
- normalize the empty-music public profile alert CTA from `Get alerts` to `Turn on alerts`
- update the listen-mode regression test for the canonical CTA label

## Linear
- JOV-2374

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm exec biome check --write apps/web/components/features/profile/ProfilePrimaryTabPanel.tsx apps/web/tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/profile/ProfilePrimaryTabPanel.listen.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- commit hook: proxy guard, staged a11y guard, ESLint, Biome, web typecheck
- pre-push: Biome, proxy guard, Tailwind guard, web typecheck, web lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Updated the alerts button label in the profile section from "Get alerts" to "Turn on alerts" for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9040?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->