### PR TITLE
fix(releases): keep task drawer navigation in app shell

### DIFF
--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -9,6 +9,7 @@
 
 import type { CommonDropdownItem } from '@jovie/ui';
 import { Activity, Pause, Play, Plus, RefreshCw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import {
   type ReactNode,
   useCallback,
@@ -561,6 +562,7 @@ export function ReleaseSidebar({
   designV1 = false,
   onTrackClick,
 }: ReleaseSidebarProps) {
+  const router = useRouter();
   const {
     isAddingLink,
     setIsAddingLink,
@@ -805,8 +807,8 @@ export function ReleaseSidebar({
       return;
     }
 
-    globalThis.location.href = buildReleaseTasksRoute(release.id);
-  }, [release]);
+    router.push(buildReleaseTasksRoute(release.id));
+  }, [release, router]);
 
   const handleDismissTasksUpgrade = useCallback(() => {
     setShowTasksUpgrade(false);

--- a/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
@@ -7,6 +7,13 @@ const mockUsePlanGate = vi.fn(() => ({
   isLoading: false,
 }));
 const mockFetchReleaseCreditsAction = vi.fn();
+const mockRouterPush = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockRouterPush,
+  }),
+}));
 
 // ReleaseSidebar directly uses SegmentControl from @jovie/ui for tab navigation.
 // All other sub-components that use additional @jovie/ui parts are mocked below,
@@ -415,7 +422,18 @@ vi.mock(
 );
 
 vi.mock('@/components/features/dashboard/release-tasks', () => ({
-  ReleaseTaskChecklist: () => <div data-testid='task-checklist'>Tasks</div>,
+  ReleaseTaskChecklist: ({
+    onNavigateToFullPage,
+  }: {
+    onNavigateToFullPage?: () => void;
+  }) => (
+    <div data-testid='task-checklist'>
+      Tasks
+      <button type='button' onClick={onNavigateToFullPage}>
+        Open full tasks page
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('@/lib/queries', () => ({
@@ -427,6 +445,8 @@ vi.mock('@/constants/routes', () => ({
     DASHBOARD_RELEASES: '/dashboard/releases',
     DASHBOARD_RELEASE_TASKS: '/dashboard/releases/[releaseId]/tasks',
   },
+  buildReleaseTasksRoute: (releaseId: string) =>
+    `/dashboard/releases/${releaseId}/tasks`,
 }));
 
 vi.mock(
@@ -580,6 +600,20 @@ describe('ReleaseSidebar inspector cards', () => {
       screen.queryByTestId('compact-release-plan-upgrade-card')
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId('task-checklist')).not.toBeInTheDocument();
+  });
+
+  it('uses app router navigation for the full release tasks page', async () => {
+    const user = userEvent.setup();
+
+    render(<ReleaseSidebar release={mockRelease} {...defaultProps} />);
+    await user.click(screen.getByTestId('drawer-tab-tasks'));
+    await user.click(
+      screen.getByRole('button', { name: 'Open full tasks page' })
+    );
+
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      '/dashboard/releases/release_1/tasks'
+    );
   });
 
   it('does not render the generic Releases title row above the entity card', () => {


### PR DESCRIPTION
## Summary
- Use Next App Router navigation for the release task drawer full-page link so shell chrome persists.
- Add focused coverage for the drawer callback routing path.

Linear: https://linear.app/jovie/issue/JOV-2375/use-app-router-navigation-for-release-task-drawer-links

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm exec biome check --write apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- commit hook: proxy guard, Biome, staged a11y check, ESLint, web typecheck
- pre-push: Biome, proxy guard, Tailwind guard, web typecheck, web lint