### PR TITLE
fix(chat): keep profile retry inside app shell

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/profile/ProfilePageChat.tsx
+++ b/apps/web/app/app/(shell)/dashboard/profile/ProfilePageChat.tsx
@@ -11,6 +11,8 @@ import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
 import { DashboardHeaderActionButton } from '@/features/dashboard/atoms/DashboardHeaderActionButton';
 
 function ProfilePageChatFallback() {
+  const router = useRouter();
+
   return (
     <ChatWorkspaceSurface>
       <div className='flex h-full items-center justify-center p-6'>
@@ -23,7 +25,7 @@ function ProfilePageChatFallback() {
           </p>
           <DashboardHeaderActionButton
             ariaLabel='Reload chat'
-            onClick={() => globalThis.location.reload()}
+            onClick={() => router.refresh()}
             icon={<RefreshCw className='h-4 w-4' />}
             label='Reload'
           />

--- a/apps/web/tests/unit/chat/ProfilePageChat.test.tsx
+++ b/apps/web/tests/unit/chat/ProfilePageChat.test.tsx
@@ -1,15 +1,19 @@
+import { fireEvent } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { DashboardData } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
 import { DashboardDataProvider } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 import { ProfilePageChat } from '@/app/app/(shell)/dashboard/profile/ProfilePageChat';
 import { fastRender } from '@/tests/utils/fast-render';
 
+const mockRouterRefresh = vi.fn();
+let shouldThrowChatRender = false;
+
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: vi.fn(),
     replace: vi.fn(),
-    refresh: vi.fn(),
+    refresh: mockRouterRefresh,
     back: vi.fn(),
   }),
   useSearchParams: () => new URLSearchParams(),
@@ -22,14 +26,19 @@ vi.mock('@/components/jovie/JovieChat', () => ({
     displayName?: string;
     avatarUrl?: string | null;
     username?: string;
-  }) =>
-    React.createElement('div', {
+  }) => {
+    if (shouldThrowChatRender) {
+      throw new Error('chat render failed');
+    }
+
+    return React.createElement('div', {
       'data-testid': 'jovie-chat',
       'data-profile-id': props.profileId,
       'data-display-name': props.displayName ?? '',
       'data-avatar-url': props.avatarUrl ?? '',
       'data-username': props.username ?? '',
-    }),
+    });
+  },
 }));
 
 const baseDashboardData: DashboardData = {
@@ -78,6 +87,15 @@ function renderProfilePageChat(data: DashboardData = baseDashboardData) {
 }
 
 describe('ProfilePageChat', () => {
+  beforeEach(() => {
+    mockRouterRefresh.mockClear();
+    shouldThrowChatRender = false;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('passes selected profile identity props to JovieChat', () => {
     const { getByTestId } = renderProfilePageChat();
 
@@ -126,5 +144,16 @@ describe('ProfilePageChat', () => {
     const retryButton = container.querySelector('button');
     expect(retryButton).not.toBeNull();
     expect(retryButton?.textContent).toContain('Retry');
+  });
+
+  it('refreshes the app route instead of reloading the document from the error fallback', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    shouldThrowChatRender = true;
+
+    const { getByRole } = renderProfilePageChat();
+
+    fireEvent.click(getByRole('button', { name: 'Reload chat' }));
+
+    expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Replace the dashboard profile chat error-boundary document reload with App Router refresh.
- Add coverage that the fallback retry uses route refresh when chat rendering fails.

Linear: https://linear.app/jovie/issue/JOV-2376/use-app-router-refresh-for-profile-chat-fallback

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm exec biome check --write apps/web/app/app/(shell)/dashboard/profile/ProfilePageChat.tsx apps/web/tests/unit/chat/ProfilePageChat.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run test -- tests/unit/chat/ProfilePageChat.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false