### PR TITLE
fix(releases): keep sidebar refresh inside app shell

### DIFF
--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -737,7 +737,7 @@ export function ReleaseSidebar({
             onRefresh();
             return;
           }
-          globalThis.location.reload();
+          router.refresh();
         },
         disabled: isRefreshing,
       },
@@ -750,6 +750,7 @@ export function ReleaseSidebar({
     onGenerateAlbumArt,
     isRefreshing,
     onRefresh,
+    router,
     setIsAddingLink,
   ]);
 

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebarHeader.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebarHeader.tsx
@@ -8,6 +8,7 @@
  */
 
 import { Check, Hash, RefreshCw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import type { DrawerHeaderAction } from '@/components/molecules/drawer-header/DrawerHeaderActions';
@@ -37,6 +38,7 @@ export function useReleaseHeaderParts({
   onRefresh,
   isRefreshing = false,
 }: UseReleaseHeaderPartsProps): UseReleaseHeaderResult {
+  const router = useRouter();
   const showActions = hasRelease && release?.smartLinkPath;
   const [isIdCopied, setIsIdCopied] = useState(false);
   const idCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -53,8 +55,8 @@ export function useReleaseHeaderParts({
       onRefresh();
       return;
     }
-    globalThis.location.reload();
-  }, [isRefreshing, onRefresh]);
+    router.refresh();
+  }, [isRefreshing, onRefresh, router]);
 
   const handleCopyReleaseId = useCallback(async () => {
     const releaseId = release?.id ?? '';

--- a/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
@@ -8,10 +8,12 @@ const mockUsePlanGate = vi.fn(() => ({
 }));
 const mockFetchReleaseCreditsAction = vi.fn();
 const mockRouterPush = vi.fn();
+const mockRouterRefresh = vi.fn();
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockRouterPush,
+    refresh: mockRouterRefresh,
   }),
 }));
 
@@ -614,6 +616,15 @@ describe('ReleaseSidebar inspector cards', () => {
     expect(mockRouterPush).toHaveBeenCalledWith(
       '/dashboard/releases/release_1/tasks'
     );
+  });
+
+  it('uses app router refresh for the context menu refresh fallback', async () => {
+    const user = userEvent.setup();
+
+    render(<ReleaseSidebar release={mockRelease} {...defaultProps} />);
+    await user.click(screen.getByTestId('context-menu-refresh-release'));
+
+    expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
   });
 
   it('does not render the generic Releases title row above the entity card', () => {

--- a/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebarHeader.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebarHeader.test.tsx
@@ -2,6 +2,14 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const mockRouterRefresh = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    refresh: mockRouterRefresh,
+  }),
+}));
+
 const { useReleaseHeaderParts } = await import(
   '@/components/organisms/release-sidebar/ReleaseSidebarHeader'
 );
@@ -79,5 +87,14 @@ describe('useReleaseHeaderParts', () => {
     expect(
       screen.getByRole('button', { name: /copy release id/i })
     ).toBeInTheDocument();
+  });
+
+  it('falls back to app router refresh when no refresh callback is provided', async () => {
+    const user = userEvent.setup();
+    render(<TestHarness release={release} hasRelease />);
+
+    await user.click(screen.getByRole('button', { name: /refresh release/i }));
+
+    expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Replace release-sidebar refresh fallback document reloads with App Router refresh.
- Preserve explicit `onRefresh` callbacks and disabled refresh behavior.
- Add focused coverage for header and context-menu fallback refresh paths.

Linear: https://linear.app/jovie/issue/JOV-2378/use-app-router-refresh-for-release-sidebar-fallback-refresh-actions

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm exec biome check --write apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx apps/web/components/organisms/release-sidebar/ReleaseSidebarHeader.tsx apps/web/tests/components/organisms/release-sidebar/ReleaseSidebarHeader.test.tsx apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run test -- tests/components/organisms/release-sidebar/ReleaseSidebarHeader.test.tsx tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * The "Refresh release" action now uses a client-side refresh for faster, smoother updates with less disruption and quicker visibility of release changes.
* **Tests**
  * Updated interaction and unit tests to validate that the refresh action triggers the client-side refresh behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->