### PR TITLE
JOV-2379 Extract release matrix loader from dashboard actions

### DIFF
--- a/apps/web/app/app/(shell)/calendar/page.tsx
+++ b/apps/web/app/app/(shell)/calendar/page.tsx
@@ -14,7 +14,7 @@ import type {
   TourDateViewModel,
 } from '@/lib/tour-dates/types';
 import { getDashboardShellData } from '../dashboard/actions';
-import { loadReleaseMatrix } from '../dashboard/releases/actions';
+import { loadReleaseMatrix } from '../dashboard/releases/release-matrix-loader';
 import { loadTourDates } from '../dashboard/tour-dates/actions';
 import { CalendarPageClient } from './CalendarPageClient';
 

--- a/apps/web/app/app/(shell)/dashboard/releases/ReleasesRoute.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/ReleasesRoute.tsx
@@ -7,9 +7,9 @@ import { queryKeys } from '@/lib/queries';
 import { HydrateClient } from '@/lib/queries/HydrateClient';
 import { getDehydratedState, getQueryClient } from '@/lib/queries/server';
 import { getDashboardShellData } from '../actions';
-import { loadReleaseMatrix } from './actions';
 import { ReleasesClientBoundary } from './ReleasesClientBoundary';
 import { ReleasesPageClient } from './ReleasesPageClient';
+import { loadReleaseMatrix } from './release-matrix-loader';
 
 /**
  * Releases page — client-first with shell-only server work.

--- a/apps/web/app/app/(shell)/dashboard/releases/actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/actions.ts
@@ -5,13 +5,11 @@ import {
   unstable_noStore as noStore,
   revalidatePath,
   revalidateTag,
-  unstable_cache,
 } from 'next/cache';
 import { redirect } from 'next/navigation';
-import { cache } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
 import { getCachedAuth } from '@/lib/auth/cached';
-import { CACHE_TTL, createSmartLinkContentTag } from '@/lib/cache/tags';
+import { createSmartLinkContentTag } from '@/lib/cache/tags';
 import { db } from '@/lib/db';
 import { isUniqueViolation } from '@/lib/db/errors';
 import {
@@ -27,11 +25,9 @@ import { validateProviderUrl } from '@/lib/discography/provider-domains';
 import {
   getProviderLink,
   getReleaseById,
-  getReleaseForProfileById,
   getReleasesForProfile as getReleasesFromDb,
   getReleaseTracksForReleaseWithProviders,
   getTracksForRelease,
-  type ReleaseWithProviders,
   resetProviderLink as resetProviderLinkDb,
   upsertProviderLink,
   upsertRecording,
@@ -47,12 +43,7 @@ import type {
   ReleaseViewModel,
   TrackViewModel,
 } from '@/lib/discography/types';
-import { buildSmartLinkPath } from '@/lib/discography/utils';
-import { VIDEO_PROVIDER_KEYS } from '@/lib/discography/video-providers';
-import {
-  buildProviderLabels,
-  mapProviderLinksToViewModel,
-} from '@/lib/discography/view-models';
+import { buildProviderLabels } from '@/lib/discography/view-models';
 import {
   type AggregateEnrichmentStatus,
   applyTtlToEnrichmentStatus,
@@ -77,16 +68,21 @@ import {
   formatTimeRemaining,
 } from '@/lib/rate-limit';
 import { trackServerEvent } from '@/lib/server-analytics';
-import {
-  buildCanvasMetadata,
-  getCanvasStatusFromMetadata,
-} from '@/lib/services/canvas/service';
+import { buildCanvasMetadata } from '@/lib/services/canvas/service';
 import type { CanvasStatus } from '@/lib/services/canvas/types';
 import { slugify } from '@/lib/utils';
-import { toISOStringOrNull } from '@/lib/utils/date';
 import { throwIfRedirect } from '@/lib/utils/redirect-error';
 import { targetPlaylistsSchema } from '@/lib/validation/schemas/dashboard/profile';
 import { getDashboardDataEssential, getDashboardShellData } from '../actions';
+import {
+  loadReleaseEntity as loadReleaseEntityFromLoader,
+  loadReleaseMatrixForProfile as loadReleaseMatrixForProfileFromLoader,
+  loadReleaseMatrix as loadReleaseMatrixFromLoader,
+} from './release-matrix-loader';
+import type { ReleaseProfileContext } from './release-types';
+import { mapReleaseToViewModel } from './release-view-models';
+
+export type { ReleaseProfileContext } from './release-types';
 
 const SPOTIFY_ALREADY_CLAIMED_MESSAGE =
   'This Spotify artist is already linked to another Jovie account. Please sign in with the original account or choose a different artist.';
@@ -185,7 +181,7 @@ function deriveSpotifyImportStatus(result: SpotifyImportResult) {
   return 'failed' as const;
 }
 
-async function requireProfile(profileId?: string): Promise<{
+async function requireProfile(): Promise<{
   id: string;
   spotifyId: string | null;
   handle: string;
@@ -196,14 +192,8 @@ async function requireProfile(profileId?: string): Promise<{
     redirect(APP_ROUTES.START);
   }
 
-  let profile = data.selectedProfile;
+  const profile = data.selectedProfile;
 
-  // If a specific profile is requested, ensure the user owns it
-  if (profileId) {
-    profile = data.creatorProfiles.find(p => p.id === profileId) ?? null;
-  }
-
-  // Redirect to onboarding if no profile exists (new users, mid-onboarding, or load errors)
   if (!profile) {
     redirect(APP_ROUTES.START);
   }
@@ -215,207 +205,21 @@ async function requireProfile(profileId?: string): Promise<{
   };
 }
 
-/**
- * Extract genres from release metadata
- */
-function extractGenres(metadata: Record<string, unknown> | null): string[] {
-  if (!metadata) return [];
-
-  // Try common genre field names from various sources
-  const genreField =
-    metadata.genres ??
-    metadata.genre ??
-    metadata.spotifyGenres ??
-    metadata.spotify_genres;
-
-  if (Array.isArray(genreField)) {
-    return genreField.filter((g): g is string => typeof g === 'string');
-  }
-
-  if (typeof genreField === 'string') {
-    return [genreField];
-  }
-
-  return [];
+export async function loadReleaseMatrix(profileId?: string) {
+  return loadReleaseMatrixFromLoader(profileId);
 }
 
-/**
- * Map database release to view model
- */
-function mapReleaseToViewModel(
-  release: ReleaseWithProviders,
-  _providerLabels: Record<ProviderKey, string>,
-  profileId: string,
-  profileHandle: string
-): ReleaseViewModel {
-  // Use the new short URL format: /{handle}/{slug}
-  const slug = release.slug;
-
-  return {
-    profileId,
-    id: release.id,
-    title: release.title,
-    artistNames: release.artistNames,
-    releaseDate: toISOStringOrNull(release.releaseDate) ?? undefined,
-    status: (release.status as ReleaseStatusValue) ?? 'released',
-    revealDate: toISOStringOrNull(release.revealDate) ?? undefined,
-    deletedAt: toISOStringOrNull(release.deletedAt) ?? undefined,
-    artworkUrl: release.artworkUrl ?? undefined,
-    slug,
-    smartLinkPath: buildSmartLinkPath(profileHandle, slug),
-    spotifyPopularity: release.spotifyPopularity,
-    providers: mapProviderLinksToViewModel({
-      providerLinks: release.providerLinks,
-      profileHandle,
-      slug,
-    }),
-    // Extended fields
-    releaseType: release.releaseType,
-    isExplicit: release.isExplicit,
-    upc: release.upc,
-    label: release.label,
-    totalTracks: release.totalTracks,
-    totalDurationMs: release.trackSummary?.totalDurationMs ?? null,
-    primaryIsrc: release.trackSummary?.primaryIsrc ?? null,
-    genres:
-      release.genres && release.genres.length > 0
-        ? release.genres
-        : extractGenres(release.metadata),
-    targetPlaylists: release.targetPlaylists ?? [],
-    copyrightLine: release.copyrightLine ?? null,
-    distributor: release.distributor ?? null,
-    canvasStatus: getCanvasStatusFromMetadata(release.metadata),
-    originalArtworkUrl: (release.metadata as Record<string, unknown> | null)
-      ?.originalArtworkUrl as string | undefined,
-    hasVideoLinks: release.providerLinks.some(link =>
-      (VIDEO_PROVIDER_KEYS as string[]).includes(link.providerId)
-    ),
-    lyrics:
-      (
-        release.metadata as Record<string, unknown> | null
-      )?.lyrics?.toString() || undefined,
-    previewUrl: release.trackSummary?.primaryPreviewUrl || null,
-  };
-}
-
-/**
- * Core release matrix fetch logic (cacheable)
- */
-async function fetchReleaseMatrixCore(
-  profileId: string,
-  profileHandle: string
-): Promise<ReleaseViewModel[]> {
-  const providerLabels = buildProviderLabels();
-  const releases = await getReleasesFromDb(profileId, { includeDrafts: true });
-
-  return releases.map(release =>
-    mapReleaseToViewModel(release, providerLabels, profileId, profileHandle)
-  );
-}
-
-async function fetchReleaseEntityCore(
-  profileId: string,
-  profileHandle: string,
-  releaseId: string
-): Promise<ReleaseViewModel | null> {
-  const providerLabels = buildProviderLabels();
-  const release = await getReleaseForProfileById(profileId, releaseId, {
-    includeDrafts: true,
-  });
-
-  return release
-    ? mapReleaseToViewModel(release, providerLabels, profileId, profileHandle)
-    : null;
-}
-
-export interface ReleaseProfileContext {
-  readonly userId: string;
-  readonly profileId: string;
-  readonly profileHandle: string;
-  readonly spotifyId: string | null;
-  readonly appleMusicId: string | null;
-  readonly settings: Record<string, unknown> | null;
-}
-
-/**
- * Core release matrix loading logic (cacheable).
- * Cache is invalidated on mutations (save/reset provider links, Spotify sync)
- */
-async function resolveReleaseMatrix(
-  profileId?: string
-): Promise<ReleaseViewModel[]> {
-  const { userId } = await getCachedAuth();
-
-  if (!userId) {
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.RELEASES}`);
-  }
-
-  const profile = await requireProfile(profileId);
-
-  // Cache with 5min TTL and tags for invalidation.
-  // Releases only change on import/sync — tag-based invalidation handles mutations.
-  return unstable_cache(
-    () => fetchReleaseMatrixCore(profile.id, profile.handle),
-    ['releases-matrix', userId, profile.id],
-    {
-      revalidate: CACHE_TTL.MEDIUM,
-      tags: [`releases:${userId}:${profile.id}`],
-    }
-  )();
-}
-
-/**
- * Cached loader for release matrix.
- * Uses React's cache() for request-level deduplication.
- */
-export const loadReleaseMatrix = cache(resolveReleaseMatrix);
-
-async function resolveReleaseEntity(params: {
+export async function loadReleaseEntity(params: {
   readonly profileId: string;
   readonly releaseId: string;
-}): Promise<ReleaseViewModel | null> {
-  const { userId } = await getCachedAuth();
-
-  if (!userId) {
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.RELEASES}`);
-  }
-
-  const profile = await requireProfile(params.profileId);
-
-  return unstable_cache(
-    () => fetchReleaseEntityCore(profile.id, profile.handle, params.releaseId),
-    ['release-entity', userId, profile.id, params.releaseId],
-    {
-      revalidate: CACHE_TTL.MEDIUM,
-      tags: [`releases:${userId}:${profile.id}`],
-    }
-  )();
+}) {
+  return loadReleaseEntityFromLoader(params);
 }
-
-export const loadReleaseEntity = cache(resolveReleaseEntity);
 
 export async function loadReleaseMatrixForProfile(
   profile: ReleaseProfileContext
-): Promise<ReleaseViewModel[]> {
-  // Auth guard: verify caller owns this profile
-  const { userId } = await getCachedAuth();
-  if (!userId || userId !== profile.userId) {
-    throw new Error('Unauthorized');
-  }
-
-  return unstable_cache(
-    () => fetchReleaseMatrixCore(profile.profileId, profile.profileHandle),
-    [
-      'releases-matrix',
-      profile.userId,
-      profile.profileId,
-      profile.profileHandle,
-    ],
-    {
-      revalidate: CACHE_TTL.MEDIUM,
-      tags: [`releases:${profile.userId}:${profile.profileId}`],
-    }
-  )();
+) {
+  return loadReleaseMatrixForProfileFromLoader(profile);
 }
 
 export async function saveProviderOverride(params: {

--- a/apps/web/app/app/(shell)/dashboard/releases/release-matrix-loader.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/release-matrix-loader.ts
@@ -1,0 +1,155 @@
+'use server';
+
+import { unstable_cache } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { cache } from 'react';
+import { APP_ROUTES } from '@/constants/routes';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { CACHE_TTL } from '@/lib/cache/tags';
+import {
+  getReleaseForProfileById,
+  getReleasesForProfile as getReleasesFromDb,
+} from '@/lib/discography/queries';
+import type { ReleaseViewModel } from '@/lib/discography/types';
+import { buildProviderLabels } from '@/lib/discography/view-models';
+import { getDashboardDataEssential } from '../actions/dashboard-data';
+import type { ReleaseProfileContext } from './release-types';
+import { mapReleaseToViewModel } from './release-view-models';
+
+async function requireProfile(profileId?: string): Promise<{
+  id: string;
+  spotifyId: string | null;
+  handle: string;
+}> {
+  const data = await getDashboardDataEssential();
+
+  if (data.needsOnboarding && !data.dashboardLoadError) {
+    redirect(APP_ROUTES.START);
+  }
+
+  let profile = data.selectedProfile;
+
+  if (profileId) {
+    profile = data.creatorProfiles.find(p => p.id === profileId) ?? null;
+  }
+
+  if (!profile) {
+    redirect(APP_ROUTES.START);
+  }
+
+  return {
+    id: profile.id,
+    spotifyId: profile.spotifyId ?? null,
+    handle: profile.usernameNormalized ?? profile.username,
+  };
+}
+
+async function fetchReleaseMatrixCore(
+  profileId: string,
+  profileHandle: string
+): Promise<ReleaseViewModel[]> {
+  const providerLabels = buildProviderLabels();
+  const releases = await getReleasesFromDb(profileId, { includeDrafts: true });
+
+  return releases.map(release =>
+    mapReleaseToViewModel(release, providerLabels, profileId, profileHandle)
+  );
+}
+
+async function fetchReleaseEntityCore(
+  profileId: string,
+  profileHandle: string,
+  releaseId: string
+): Promise<ReleaseViewModel | null> {
+  const providerLabels = buildProviderLabels();
+  const release = await getReleaseForProfileById(profileId, releaseId, {
+    includeDrafts: true,
+  });
+
+  return release
+    ? mapReleaseToViewModel(release, providerLabels, profileId, profileHandle)
+    : null;
+}
+
+async function resolveReleaseMatrix(
+  profileId?: string
+): Promise<ReleaseViewModel[]> {
+  const { userId } = await getCachedAuth();
+
+  if (!userId) {
+    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.RELEASES}`);
+  }
+
+  const profile = await requireProfile(profileId);
+
+  return unstable_cache(
+    () => fetchReleaseMatrixCore(profile.id, profile.handle),
+    ['releases-matrix', userId, profile.id],
+    {
+      revalidate: CACHE_TTL.MEDIUM,
+      tags: [`releases:${userId}:${profile.id}`],
+    }
+  )();
+}
+
+const loadReleaseMatrixCached = cache(resolveReleaseMatrix);
+
+export async function loadReleaseMatrix(
+  profileId?: string
+): Promise<ReleaseViewModel[]> {
+  return loadReleaseMatrixCached(profileId);
+}
+
+async function resolveReleaseEntity(params: {
+  readonly profileId: string;
+  readonly releaseId: string;
+}): Promise<ReleaseViewModel | null> {
+  const { userId } = await getCachedAuth();
+
+  if (!userId) {
+    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.RELEASES}`);
+  }
+
+  const profile = await requireProfile(params.profileId);
+
+  return unstable_cache(
+    () => fetchReleaseEntityCore(profile.id, profile.handle, params.releaseId),
+    ['release-entity', userId, profile.id, params.releaseId],
+    {
+      revalidate: CACHE_TTL.MEDIUM,
+      tags: [`releases:${userId}:${profile.id}`],
+    }
+  )();
+}
+
+const loadReleaseEntityCached = cache(resolveReleaseEntity);
+
+export async function loadReleaseEntity(params: {
+  readonly profileId: string;
+  readonly releaseId: string;
+}): Promise<ReleaseViewModel | null> {
+  return loadReleaseEntityCached(params);
+}
+
+export async function loadReleaseMatrixForProfile(
+  profile: ReleaseProfileContext
+): Promise<ReleaseViewModel[]> {
+  const { userId } = await getCachedAuth();
+  if (!userId || userId !== profile.userId) {
+    throw new Error('Unauthorized');
+  }
+
+  return unstable_cache(
+    () => fetchReleaseMatrixCore(profile.profileId, profile.profileHandle),
+    [
+      'releases-matrix',
+      profile.userId,
+      profile.profileId,
+      profile.profileHandle,
+    ],
+    {
+      revalidate: CACHE_TTL.MEDIUM,
+      tags: [`releases:${profile.userId}:${profile.profileId}`],
+    }
+  )();
+}

--- a/apps/web/app/app/(shell)/dashboard/releases/release-types.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/release-types.ts
@@ -1,0 +1,8 @@
+export interface ReleaseProfileContext {
+  readonly userId: string;
+  readonly profileId: string;
+  readonly profileHandle: string;
+  readonly spotifyId: string | null;
+  readonly appleMusicId: string | null;
+  readonly settings: Record<string, unknown> | null;
+}

--- a/apps/web/app/app/(shell)/dashboard/releases/release-view-models.ts
+++ b/apps/web/app/app/(shell)/dashboard/releases/release-view-models.ts
@@ -1,0 +1,83 @@
+import type { ReleaseWithProviders } from '@/lib/discography/queries';
+import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
+import { buildSmartLinkPath } from '@/lib/discography/utils';
+import { VIDEO_PROVIDER_KEYS } from '@/lib/discography/video-providers';
+import { mapProviderLinksToViewModel } from '@/lib/discography/view-models';
+import { getCanvasStatusFromMetadata } from '@/lib/services/canvas/service';
+import { toISOStringOrNull } from '@/lib/utils/date';
+
+type ReleaseStatusValue = 'draft' | 'scheduled' | 'released';
+
+function extractGenres(metadata: Record<string, unknown> | null): string[] {
+  if (!metadata) return [];
+
+  const genreField =
+    metadata.genres ??
+    metadata.genre ??
+    metadata.spotifyGenres ??
+    metadata.spotify_genres;
+
+  if (Array.isArray(genreField)) {
+    return genreField.filter((g): g is string => typeof g === 'string');
+  }
+
+  if (typeof genreField === 'string') {
+    return [genreField];
+  }
+
+  return [];
+}
+
+export function mapReleaseToViewModel(
+  release: ReleaseWithProviders,
+  _providerLabels: Record<ProviderKey, string>,
+  profileId: string,
+  profileHandle: string
+): ReleaseViewModel {
+  const slug = release.slug;
+
+  return {
+    profileId,
+    id: release.id,
+    title: release.title,
+    artistNames: release.artistNames,
+    releaseDate: toISOStringOrNull(release.releaseDate) ?? undefined,
+    status: (release.status as ReleaseStatusValue) ?? 'released',
+    revealDate: toISOStringOrNull(release.revealDate) ?? undefined,
+    deletedAt: toISOStringOrNull(release.deletedAt) ?? undefined,
+    artworkUrl: release.artworkUrl ?? undefined,
+    slug,
+    smartLinkPath: buildSmartLinkPath(profileHandle, slug),
+    spotifyPopularity: release.spotifyPopularity,
+    providers: mapProviderLinksToViewModel({
+      providerLinks: release.providerLinks,
+      profileHandle,
+      slug,
+    }),
+    releaseType: release.releaseType,
+    isExplicit: release.isExplicit,
+    upc: release.upc,
+    label: release.label,
+    totalTracks: release.totalTracks,
+    totalDurationMs: release.trackSummary?.totalDurationMs ?? null,
+    primaryIsrc: release.trackSummary?.primaryIsrc ?? null,
+    genres:
+      release.genres && release.genres.length > 0
+        ? release.genres
+        : extractGenres(release.metadata),
+    targetPlaylists: release.targetPlaylists ?? [],
+    copyrightLine: release.copyrightLine ?? null,
+    distributor: release.distributor ?? null,
+    canvasStatus: getCanvasStatusFromMetadata(release.metadata),
+    originalArtworkUrl: (release.metadata as Record<string, unknown> | null)
+      ?.originalArtworkUrl as string | undefined,
+    hasVideoLinks: release.providerLinks.some(link =>
+      (VIDEO_PROVIDER_KEYS as string[]).includes(link.providerId)
+    ),
+    lyrics:
+      (
+        release.metadata as Record<string, unknown> | null
+      )?.lyrics?.toString() || undefined,
+    previewUrl: release.trackSummary?.primaryPreviewUrl || null,
+  };
+}

--- a/apps/web/app/app/(shell)/library/page.tsx
+++ b/apps/web/app/app/(shell)/library/page.tsx
@@ -8,7 +8,7 @@ import { queryKeys } from '@/lib/queries';
 import { HydrateClient } from '@/lib/queries/HydrateClient';
 import { getDehydratedState, getQueryClient } from '@/lib/queries/server';
 import { getDashboardShellData } from '../dashboard/actions';
-import { loadReleaseMatrix } from '../dashboard/releases/actions';
+import { loadReleaseMatrix } from '../dashboard/releases/release-matrix-loader';
 import { LibraryPageClient } from './LibraryPageClient';
 
 export const runtime = 'nodejs';

--- a/apps/web/lib/queries/prefetch-dashboard.ts
+++ b/apps/web/lib/queries/prefetch-dashboard.ts
@@ -1,6 +1,6 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { loadDspPresenceForProfile } from '@/app/app/(shell)/dashboard/presence/actions';
-import { loadReleaseMatrix } from '@/app/app/(shell)/dashboard/releases/actions';
+import { loadReleaseMatrix } from '@/app/app/(shell)/dashboard/releases/release-matrix-loader';
 import { getTasks } from '@/app/app/(shell)/dashboard/tasks/task-actions';
 import { DEFAULT_TASK_WORKSPACE_FILTERS } from '@/lib/tasks/query-defaults';
 import { FREQUENT_CACHE } from './cache-strategies';

--- a/apps/web/lib/queries/useReleaseEntityQuery.ts
+++ b/apps/web/lib/queries/useReleaseEntityQuery.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { loadReleaseEntity } from '@/app/app/(shell)/dashboard/releases/actions';
+import { loadReleaseEntity } from '@/app/app/(shell)/dashboard/releases/release-matrix-loader';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 import { queryKeys, STANDARD_NO_REMOUNT_CACHE } from '@/lib/queries';
 

--- a/apps/web/lib/queries/useReleasesQuery.ts
+++ b/apps/web/lib/queries/useReleasesQuery.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { loadReleaseMatrix } from '@/app/app/(shell)/dashboard/releases/actions';
+import { loadReleaseMatrix } from '@/app/app/(shell)/dashboard/releases/release-matrix-loader';
 import { queryKeys, STANDARD_NO_REMOUNT_CACHE } from '@/lib/queries';
 
 interface UseReleasesQueryOptions {

--- a/apps/web/tests/lib/queries/gc-time-coverage.test.ts
+++ b/apps/web/tests/lib/queries/gc-time-coverage.test.ts
@@ -13,7 +13,7 @@ vi.mock('@tanstack/react-query', async () => {
   };
 });
 
-vi.mock('@/app/app/(shell)/dashboard/releases/actions', () => ({
+vi.mock('@/app/app/(shell)/dashboard/releases/release-matrix-loader', () => ({
   loadReleaseMatrix: vi.fn(),
 }));
 

--- a/apps/web/tests/unit/app/dashboard-metadata.test.ts
+++ b/apps/web/tests/unit/app/dashboard-metadata.test.ts
@@ -43,6 +43,10 @@ vi.mock('@/app/app/(shell)/dashboard/releases/actions', () => ({
   }),
 }));
 
+vi.mock('@/app/app/(shell)/dashboard/releases/release-matrix-loader', () => ({
+  loadReleaseMatrix: vi.fn().mockResolvedValue([]),
+}));
+
 vi.mock('@/lib/queries/server', () => ({
   getQueryClient: vi.fn(() => ({
     prefetchQuery: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/tests/unit/calendar/calendar-page.test.tsx
+++ b/apps/web/tests/unit/calendar/calendar-page.test.tsx
@@ -62,7 +62,7 @@ vi.mock('@/app/app/(shell)/dashboard/actions', () => ({
   getDashboardShellData: mocks.getDashboardShellData,
 }));
 
-vi.mock('@/app/app/(shell)/dashboard/releases/actions', () => ({
+vi.mock('@/app/app/(shell)/dashboard/releases/release-matrix-loader', () => ({
   loadReleaseMatrix: mocks.loadReleaseMatrix,
 }));
 

--- a/apps/web/tests/unit/chat/useReleaseEntityQuery.test.tsx
+++ b/apps/web/tests/unit/chat/useReleaseEntityQuery.test.tsx
@@ -10,7 +10,7 @@ const { mockLoadReleaseEntity } = vi.hoisted(() => ({
   mockLoadReleaseEntity: vi.fn(),
 }));
 
-vi.mock('@/app/app/(shell)/dashboard/releases/actions', () => ({
+vi.mock('@/app/app/(shell)/dashboard/releases/release-matrix-loader', () => ({
   loadReleaseEntity: mockLoadReleaseEntity,
 }));
 

--- a/apps/web/tests/unit/queries/prefetch-dashboard.test.ts
+++ b/apps/web/tests/unit/queries/prefetch-dashboard.test.ts
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   ]),
 }));
 
-vi.mock('@/app/app/(shell)/dashboard/releases/actions', () => ({
+vi.mock('@/app/app/(shell)/dashboard/releases/release-matrix-loader', () => ({
   loadReleaseMatrix: mocks.loadReleaseMatrix,
 }));
 


### PR DESCRIPTION
## Summary
- moves release matrix/detail loading into a dedicated server-action loader module
- moves release database-to-view-model mapping into a shared mapper
- points library, calendar, releases, prefetch, and release entity hooks at the dedicated loader instead of the dashboard actions bundle
- keeps dashboard release actions compatibility via explicit async wrappers for Next server-action builds

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm exec biome check --write apps/web/app/app/'(shell)'/dashboard/releases/actions.ts apps/web/app/app/'(shell)'/dashboard/releases/release-matrix-loader.ts apps/web/app/app/'(shell)'/dashboard/releases/release-view-models.ts apps/web/app/app/'(shell)'/dashboard/releases/release-types.ts apps/web/lib/queries/useReleasesQuery.ts apps/web/lib/queries/useReleaseEntityQuery.ts apps/web/lib/queries/prefetch-dashboard.ts apps/web/app/app/'(shell)'/library/page.tsx apps/web/app/app/'(shell)'/calendar/page.tsx apps/web/app/app/'(shell)'/dashboard/releases/ReleasesRoute.tsx apps/web/tests/unit/queries/prefetch-dashboard.test.ts apps/web/tests/unit/calendar/calendar-page.test.tsx apps/web/tests/lib/queries/gc-time-coverage.test.ts apps/web/tests/unit/chat/useReleaseEntityQuery.test.tsx apps/web/tests/unit/app/dashboard-metadata.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run test -- tests/unit/queries/prefetch-dashboard.test.ts tests/unit/calendar/calendar-page.test.tsx tests/lib/queries/gc-time-coverage.test.ts tests/unit/chat/useReleaseEntityQuery.test.tsx tests/unit/app/dashboard-metadata.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run test -- tests/unit/app/dashboard-metadata.test.ts tests/unit/demo/demo-releases-experience.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run build

## Notes
- No visual UI changes; design review not applicable for this routing/data-loading slice.
- The nightly release-actions file is excluded by the standard Vitest config, so it was not run directly.

Linear: JOV-2379