### PR TITLE
JOV-2380 Canonicalize release task route tests

### DIFF
--- a/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
@@ -444,11 +444,12 @@ vi.mock('@/lib/queries', () => ({
 
 vi.mock('@/constants/routes', () => ({
   APP_ROUTES: {
-    DASHBOARD_RELEASES: '/dashboard/releases',
-    DASHBOARD_RELEASE_TASKS: '/dashboard/releases/[releaseId]/tasks',
+    DASHBOARD_RELEASES: '/app/dashboard/releases',
+    DASHBOARD_RELEASE_TASKS: '/app/dashboard/releases/[releaseId]/tasks',
+    RELEASES: '/app/releases',
   },
   buildReleaseTasksRoute: (releaseId: string) =>
-    `/dashboard/releases/${releaseId}/tasks`,
+    `/app/releases/${releaseId}/tasks`,
 }));
 
 vi.mock(
@@ -614,7 +615,7 @@ describe('ReleaseSidebar inspector cards', () => {
     );
 
     expect(mockRouterPush).toHaveBeenCalledWith(
-      '/dashboard/releases/release_1/tasks'
+      '/app/releases/release_1/tasks'
     );
   });
 

--- a/apps/web/tests/e2e/utils/dashboard-route-matrix.ts
+++ b/apps/web/tests/e2e/utils/dashboard-route-matrix.ts
@@ -53,7 +53,7 @@ const PUBLIC_DEFAULT_BUDGET_MS = 15_000;
 
 const CHAT_CONTENT_SELECTOR =
   '[placeholder*="ask jovie" i], [placeholder*="Ask Jovie" i], button[aria-label="New thread"], textarea, [contenteditable="true"], main';
-const DASHBOARD_RELEASE_TASKS_ROUTE = `${APP_ROUTES.DASHBOARD_RELEASES}/[releaseId]/tasks`;
+const RELEASE_TASKS_ROUTE = `${APP_ROUTES.RELEASES}/[releaseId]/tasks`;
 const DASHBOARD_TIPPING_ROUTE = `${APP_ROUTES.DASHBOARD}/tipping`;
 const DASHBOARD_CONTACTS_ROUTE = `${APP_ROUTES.DASHBOARD}/contacts`;
 const DASHBOARD_TOUR_DATES_ROUTE = `${APP_ROUTES.DASHBOARD}/tour-dates`;
@@ -136,7 +136,7 @@ const creatorRoutes = [
     performanceBudgetMs: CREATOR_DEFAULT_BUDGET_MS,
   },
   {
-    path: DASHBOARD_RELEASE_TASKS_ROUTE,
+    path: RELEASE_TASKS_ROUTE,
     name: 'Release Tasks',
     kind: 'dynamic',
     surface: 'creator',

--- a/apps/web/tests/unit/app/release-tasks-page.test.tsx
+++ b/apps/web/tests/unit/app/release-tasks-page.test.tsx
@@ -100,7 +100,7 @@ function setupReleaseQueryRows(rows: Array<Record<string, unknown>>) {
 }
 
 async function renderResolvedTasksContent() {
-  const tree = await LegacyReleaseTasksPage({
+  const tree = await CanonicalReleaseTasksPage({
     params: Promise.resolve({ releaseId: 'release_1' }),
   });
   const tasksContentElement = (tree as React.ReactElement).props.children;
@@ -155,7 +155,7 @@ describe('release tasks page', () => {
     );
   });
 
-  it('uses the same implementation for the canonical release route', () => {
-    expect(CanonicalReleaseTasksPage).toBe(LegacyReleaseTasksPage);
+  it('keeps the legacy dashboard route aliased to the canonical release route', () => {
+    expect(LegacyReleaseTasksPage).toBe(CanonicalReleaseTasksPage);
   });
 });

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -147,4 +147,18 @@ describe('shell route coverage', () => {
 
     expect(staleAllowlistEntries).toEqual([]);
   });
+
+  it('keeps release task implementation owned by the canonical shell route', () => {
+    const canonicalPage = pageByRoute.get('/app/releases/[releaseId]/tasks');
+    const legacyPage = pageByRoute.get(
+      '/app/dashboard/releases/[releaseId]/tasks'
+    );
+
+    expect(canonicalPage?.source).toContain(
+      "import { ReleaseTasksRoute } from './ReleaseTasksRoute';"
+    );
+    expect(legacyPage?.source).toContain(
+      '@/app/app/(shell)/releases/[releaseId]/tasks/ReleaseTasksRoute'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- updates release task route tests so `/app/releases/[releaseId]/tasks` is the canonical owner
- keeps `/app/dashboard/releases/[releaseId]/tasks` covered as a legacy alias
- aligns release sidebar and dashboard route-matrix expectations with canonical app-shell routing

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run test -- tests/unit/app/release-tasks-page.test.tsx tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx tests/unit/routes/shell-nav-coverage.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec biome check tests/unit/app/release-tasks-page.test.tsx tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx tests/e2e/utils/dashboard-route-matrix.ts tests/unit/routes/shell-nav-coverage.test.ts
- pre-commit hook: next:proxy-guard, lint-staged Biome/ESLint, @jovie/web typecheck
- pre-push hook: full Biome check, next:proxy-guard, tailwind:check, @jovie/web typecheck, @jovie/web lint

## Notes
- No visual UI changes; design review not applicable for this test-only route ownership slice.

Linear: JOV-2380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for application routing and navigation behavior
  * Added verification for route implementation ownership and structure across application sections
  * Enhanced test assertions to validate routing paths and page transitions

* **Refactor**
  * Reorganized application routing structure to improve consistency and maintainability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->