### PR TITLE
JOV-2381 Share release task row primitives

### DIFF
--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
@@ -1,6 +1,14 @@
 'use client';
 import type { ReleaseTaskView } from '@/lib/release-tasks/types';
+import { cn } from '@/lib/utils';
 import { ReleaseTaskDueBadge } from './ReleaseTaskDueBadge';
+import {
+  isReleaseTaskAutomated,
+  isReleaseTaskDone,
+  ReleaseTaskAutoBadge,
+  ReleaseTaskCheckbox,
+  ReleaseTaskTitleText,
+} from './ReleaseTaskRowPrimitives';
 
 interface ReleaseTaskCompactRowProps {
   readonly task: ReleaseTaskView;
@@ -13,30 +21,33 @@ export function ReleaseTaskCompactRow({
   onToggle,
   onNavigate,
 }: ReleaseTaskCompactRowProps) {
-  const isDone = task.status === 'done';
-  const isAi = task.assigneeType === 'ai_workflow';
+  const isDone = isReleaseTaskDone(task);
+  const isAi = isReleaseTaskAutomated(task);
 
   return (
     <div className='flex items-center gap-2 px-3 py-0.5 min-h-[28px] group hover:bg-surface-1 rounded transition-colors'>
-      <input
-        type='checkbox'
-        checked={isDone}
-        disabled={isAi}
-        onChange={() => onToggle(task.id, !isDone)}
-        className='h-3 w-3 flex-shrink-0 rounded accent-accent cursor-pointer disabled:cursor-default disabled:opacity-60'
-        aria-label={`Mark "${task.title}" as ${isDone ? 'incomplete' : 'complete'}`}
+      <ReleaseTaskCheckbox
+        task={task}
+        isDone={isDone}
+        onToggle={onToggle}
+        className='h-3 w-3'
       />
       <button
         type='button'
         onClick={() => onNavigate(task.id)}
-        className={`flex-1 text-left text-[11.5px] truncate transition-colors ${
-          isDone
-            ? 'text-tertiary-token line-through opacity-60'
-            : 'text-primary-token'
-        } ${isAi ? 'opacity-70' : 'hover:text-accent'}`}
+        className={cn(
+          'flex-1 text-left text-[11.5px] truncate transition-colors',
+          isAi ? 'opacity-70' : 'hover:text-accent'
+        )}
       >
-        {task.title}
-        {isAi && <span className='ml-1 text-3xs text-purple-500'>AI</span>}
+        <ReleaseTaskTitleText className='block' isDone={isDone}>
+          {task.title}
+          {isAi && (
+            <ReleaseTaskAutoBadge className='ml-1 text-purple-500'>
+              AI
+            </ReleaseTaskAutoBadge>
+          )}
+        </ReleaseTaskTitleText>
       </button>
       <ReleaseTaskDueBadge
         dueDate={task.dueDate}

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRow.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRow.tsx
@@ -8,6 +8,13 @@ import {
 import { ReleaseTaskAssigneeBadge } from './ReleaseTaskAssigneeBadge';
 import { ReleaseTaskDueBadge } from './ReleaseTaskDueBadge';
 import { ReleaseTaskExplainerPopover } from './ReleaseTaskExplainerPopover';
+import {
+  isReleaseTaskAutomated,
+  isReleaseTaskDone,
+  ReleaseTaskAutoBadge,
+  ReleaseTaskCheckbox,
+  ReleaseTaskTitleText,
+} from './ReleaseTaskRowPrimitives';
 
 interface ReleaseTaskRowProps {
   readonly task: ReleaseTaskView;
@@ -23,8 +30,8 @@ const PRIORITY_DISPLAY: Record<string, { dots: string }> = {
 };
 
 export function ReleaseTaskRow({ task, onToggle }: ReleaseTaskRowProps) {
-  const isDone = task.status === 'done';
-  const isAi = task.assigneeType === 'ai_workflow';
+  const isDone = isReleaseTaskDone(task);
+  const isAi = isReleaseTaskAutomated(task);
   const priority = PRIORITY_DISPLAY[task.priority] ?? PRIORITY_DISPLAY.medium;
   const priorityAccent =
     task.priority === 'none'
@@ -34,34 +41,24 @@ export function ReleaseTaskRow({ task, onToggle }: ReleaseTaskRowProps) {
 
   return (
     <div className='flex items-center gap-2 px-4 py-1 min-h-[32px] group hover:bg-surface-1 rounded transition-colors'>
-      {/* Checkbox */}
-      <input
-        type='checkbox'
-        checked={isDone}
-        disabled={isAi}
-        onChange={() => onToggle(task.id, !isDone)}
-        className='h-3.5 w-3.5 flex-shrink-0 rounded accent-accent cursor-pointer disabled:cursor-default disabled:opacity-60'
-        aria-label={`Mark "${task.title}" as ${isDone ? 'incomplete' : 'complete'}`}
+      <ReleaseTaskCheckbox
+        task={task}
+        isDone={isDone}
+        onToggle={onToggle}
+        className='h-3.5 w-3.5'
       />
 
-      {/* Title */}
-      <span
-        className={`flex-1 text-[11.5px] truncate transition-colors ${
-          isDone
-            ? 'text-tertiary-token line-through opacity-60'
-            : 'text-primary-token'
-        }`}
-      >
+      <ReleaseTaskTitleText className='flex-1 text-[11.5px]' isDone={isDone}>
         {task.title}
         {isAi && (
-          <span
+          <ReleaseTaskAutoBadge
             className='ml-1.5 text-3xs font-medium'
             style={{ color: aiAccent.solid }}
           >
             Auto
-          </span>
+          </ReleaseTaskAutoBadge>
         )}
-      </span>
+      </ReleaseTaskTitleText>
 
       {/* Assignee badge */}
       <div className='flex-shrink-0 max-md:hidden'>

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRowPrimitives.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRowPrimitives.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import type { CSSProperties, ReactNode } from 'react';
+import type { ReleaseTaskView } from '@/lib/release-tasks/types';
+import { cn } from '@/lib/utils';
+
+interface ReleaseTaskCheckboxProps {
+  readonly task: ReleaseTaskView;
+  readonly isDone: boolean;
+  readonly onToggle: (taskId: string, done: boolean) => void;
+  readonly className?: string;
+}
+
+interface ReleaseTaskTitleTextProps {
+  readonly children: ReactNode;
+  readonly className?: string;
+  readonly isDone: boolean;
+}
+
+interface ReleaseTaskAutoBadgeProps {
+  readonly children: ReactNode;
+  readonly className?: string;
+  readonly style?: CSSProperties;
+}
+
+export function isReleaseTaskDone(task: ReleaseTaskView): boolean {
+  return task.status === 'done';
+}
+
+export function isReleaseTaskAutomated(task: ReleaseTaskView): boolean {
+  return task.assigneeType === 'ai_workflow';
+}
+
+export function ReleaseTaskCheckbox({
+  task,
+  isDone,
+  onToggle,
+  className,
+}: ReleaseTaskCheckboxProps) {
+  const isAutomated = isReleaseTaskAutomated(task);
+
+  return (
+    <input
+      type='checkbox'
+      checked={isDone}
+      disabled={isAutomated}
+      onChange={() => onToggle(task.id, !isDone)}
+      className={cn(
+        'flex-shrink-0 rounded accent-accent cursor-pointer disabled:cursor-default disabled:opacity-60',
+        className
+      )}
+      aria-label={`Mark "${task.title}" as ${isDone ? 'incomplete' : 'complete'}`}
+    />
+  );
+}
+
+export function ReleaseTaskTitleText({
+  children,
+  className,
+  isDone,
+}: ReleaseTaskTitleTextProps) {
+  return (
+    <span
+      className={cn(
+        'truncate transition-colors',
+        isDone
+          ? 'text-tertiary-token line-through opacity-60'
+          : 'text-primary-token',
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function ReleaseTaskAutoBadge({
+  children,
+  className,
+  style,
+}: ReleaseTaskAutoBadgeProps) {
+  return (
+    <span className={cn('text-3xs', className)} style={style}>
+      {children}
+    </span>
+  );
+}

--- a/apps/web/tests/unit/dashboard/ReleaseTaskRow.test.tsx
+++ b/apps/web/tests/unit/dashboard/ReleaseTaskRow.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ReleaseTaskCompactRow } from '@/components/features/dashboard/release-tasks/ReleaseTaskCompactRow';
+import { ReleaseTaskRow } from '@/components/features/dashboard/release-tasks/ReleaseTaskRow';
+import type { ReleaseTaskView } from '@/lib/release-tasks/types';
+
+function createTask(overrides: Partial<ReleaseTaskView> = {}): ReleaseTaskView {
+  return {
+    id: 'task_1',
+    releaseId: 'release_1',
+    creatorProfileId: 'profile_1',
+    templateItemId: 'template_1',
+    title: 'Pitch playlist editors',
+    description: null,
+    explainerText: null,
+    learnMoreUrl: null,
+    videoUrl: null,
+    category: 'Marketing',
+    status: 'todo',
+    priority: 'medium',
+    position: 1,
+    assigneeType: 'human',
+    assigneeUserId: null,
+    aiWorkflowId: null,
+    dueDaysOffset: 3,
+    dueDate: new Date('2026-06-01T00:00:00.000Z'),
+    completedAt: null,
+    metadata: null,
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-01T00:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+describe('ReleaseTaskRow', () => {
+  it('toggles the shared checkbox control from the full row', () => {
+    const onToggle = vi.fn();
+
+    render(<ReleaseTaskRow task={createTask()} onToggle={onToggle} />);
+
+    fireEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'Mark "Pitch playlist editors" as complete',
+      })
+    );
+
+    expect(onToggle).toHaveBeenCalledWith('task_1', true);
+  });
+
+  it('disables the shared checkbox for automated tasks', () => {
+    render(
+      <ReleaseTaskRow
+        task={createTask({ assigneeType: 'ai_workflow' })}
+        onToggle={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Mark "Pitch playlist editors" as complete',
+      })
+    ).toBeDisabled();
+    expect(screen.getByText('Auto')).toBeInTheDocument();
+  });
+});
+
+describe('ReleaseTaskCompactRow', () => {
+  it('keeps compact navigation and checkbox behavior separate', () => {
+    const onNavigate = vi.fn();
+    const onToggle = vi.fn();
+
+    render(
+      <ReleaseTaskCompactRow
+        task={createTask()}
+        onNavigate={onNavigate}
+        onToggle={onToggle}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Pitch playlist/ }));
+    expect(onNavigate).toHaveBeenCalledWith('task_1');
+    expect(onToggle).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole('checkbox', {
+        name: 'Mark "Pitch playlist editors" as complete',
+      })
+    );
+    expect(onToggle).toHaveBeenCalledWith('task_1', true);
+  });
+});


### PR DESCRIPTION
## Summary
- extracts shared release task checkbox/title/auto-badge primitives
- keeps full and compact release task row layout classes stable
- adds focused tests for shared checkbox behavior and compact navigation separation

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm exec biome check --write apps/web/components/features/dashboard/release-tasks/ReleaseTaskRow.tsx apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx apps/web/components/features/dashboard/release-tasks/ReleaseTaskRowPrimitives.tsx apps/web/tests/unit/dashboard/ReleaseTaskRow.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run test -- tests/unit/dashboard/ReleaseTaskRow.test.tsx tests/unit/dashboard/ReleaseTaskChecklist.test.tsx tests/unit/dashboard/ReleaseTaskPage.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false

## Notes
- No intended visual changes; this only removes duplicated row primitives.

Linear: JOV-2381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Release task row components refactored to consolidate repetitive UI logic into reusable shared primitives for improved maintainability, consistency, and code organization.

* **Tests**
  * Added unit tests for release task row components, verifying checkbox interactions, task completion workflows, and proper handling of automated task states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9056?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->