### PR TITLE
Polish Electron header and upgrade banner

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -80,6 +80,25 @@ html[data-desktop-runtime="electron"] [data-electron-titlebar="true"] {
   background: rgb(var(--sidebar-background));
 }
 
+html[data-desktop-runtime="electron"]
+  [data-shell-design="shellChatV1"]
+  [data-app-shell-body="true"] {
+  padding-top: 0;
+}
+
+html[data-desktop-runtime="electron"]
+  [data-shell-design="shellChatV1"]
+  #main-content {
+  border-top-width: 0;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  padding-top: 0;
+}
+
+html[data-desktop-runtime="electron"] [data-electron-main-header="body"] {
+  display: none;
+}
+
 html[data-desktop-runtime="electron"] [data-electron-drag-region="true"] {
   -webkit-app-region: drag;
 }

--- a/apps/web/components/atoms/DesktopTitlebar.tsx
+++ b/apps/web/components/atoms/DesktopTitlebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ArrowLeft, ArrowRight, PanelLeft } from 'lucide-react';
+import type { CSSProperties, ReactNode } from 'react';
 import { useContext } from 'react';
 import { UpdateAvailablePill } from '@/components/atoms/UpdateAvailablePill';
 import { SidebarContext } from '@/components/organisms/sidebar/context';
@@ -9,6 +10,10 @@ import {
   useIsElectronRuntime,
 } from '@/lib/desktop/electron-bridge';
 import { cn } from '@/lib/utils';
+
+interface DesktopTitlebarProps {
+  readonly mainSlot?: ReactNode;
+}
 
 /**
  * DesktopTitlebar — Electron-only titlebar grid with traffic-light spacer,
@@ -21,7 +26,7 @@ import { cn } from '@/lib/utils';
  * Renders as a zero-height invisible element in the browser; CSS on
  * [data-electron-titlebar="true"] makes it visible only inside Electron.
  */
-export function DesktopTitlebar() {
+export function DesktopTitlebar({ mainSlot }: DesktopTitlebarProps) {
   const isDesktop = useIsElectronRuntime();
   const { canGoBack, canGoForward, goBack, goForward } = useDesktopNavigation();
   // useContext (not useSidebar) so this is safe outside SidebarProvider (e.g. demo shell)
@@ -37,7 +42,7 @@ export function DesktopTitlebar() {
       data-electron-titlebar='true'
       data-testid='electron-titlebar-row'
       data-electron-drag-region='true'
-      style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+      style={{ WebkitAppRegion: 'drag' } as CSSProperties}
     >
       {isDesktop ? (
         <>
@@ -60,7 +65,7 @@ export function DesktopTitlebar() {
                 'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30',
                 'disabled:pointer-events-none disabled:opacity-30'
               )}
-              style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+              style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}
             >
               <PanelLeft className='h-3.5 w-3.5' strokeWidth={2} />
             </button>
@@ -77,7 +82,7 @@ export function DesktopTitlebar() {
                 'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30',
                 'disabled:pointer-events-none disabled:opacity-30'
               )}
-              style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+              style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}
             >
               <ArrowLeft className='h-3.5 w-3.5' strokeWidth={2} />
             </button>
@@ -94,13 +99,13 @@ export function DesktopTitlebar() {
                 'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30',
                 'disabled:pointer-events-none disabled:opacity-30'
               )}
-              style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+              style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}
             >
               <ArrowRight className='h-3.5 w-3.5' strokeWidth={2} />
             </button>
             <div
               className='ml-auto min-w-0 shrink-0'
-              style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
+              style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}
             >
               <UpdateAvailablePill compact={sidebarOpen} />
             </div>
@@ -108,13 +113,23 @@ export function DesktopTitlebar() {
 
           <div
             data-testid='electron-titlebar-main-cell'
-            className='flex min-w-0 items-center self-stretch rounded-t-[var(--linear-app-shell-radius)] border border-b-0 border-(--linear-app-shell-border) bg-(--linear-app-content-surface) px-2.5'
-            style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
+            className='flex min-w-0 items-center self-stretch overflow-hidden rounded-t-[var(--linear-app-shell-radius)] border border-b-0 border-(--linear-app-shell-border) bg-(--linear-app-content-surface) px-0'
+            style={{ WebkitAppRegion: 'drag' } as CSSProperties}
           >
-            <div
-              className='min-w-0 flex-1 self-stretch'
-              style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
-            />
+            {mainSlot ? (
+              <div
+                data-testid='electron-titlebar-main-slot'
+                className='min-w-0 flex-1'
+                style={{ WebkitAppRegion: 'drag' } as CSSProperties}
+              >
+                {mainSlot}
+              </div>
+            ) : (
+              <div
+                className='min-w-0 flex-1 self-stretch'
+                style={{ WebkitAppRegion: 'drag' } as CSSProperties}
+              />
+            )}
           </div>
         </>
       ) : null}

--- a/apps/web/components/features/feedback/SidebarUpgradeBanner.tsx
+++ b/apps/web/components/features/feedback/SidebarUpgradeBanner.tsx
@@ -2,9 +2,10 @@
 
 import type { LucideIcon } from 'lucide-react';
 import { AlarmClock, Bell, Clock, Sparkles } from 'lucide-react';
-import { usePathname } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { isDemoRoutePath } from '@/constants/routes';
+import { usePathname, useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { InstallBanner } from '@/components/shell/InstallBanner';
+import { APP_ROUTES, isDemoRoutePath } from '@/constants/routes';
 import { track } from '@/lib/analytics';
 import {
   formatVerifiedPriceLabel,
@@ -14,7 +15,6 @@ import { TRIAL_NOTIFICATION_RECIPIENT_LIMIT } from '@/lib/entitlements/registry'
 import { env } from '@/lib/env-client';
 import { useCheckoutMutation, usePricingOptionsQuery } from '@/lib/queries';
 import { type NudgeState, usePlanGate } from '@/lib/queries/usePlanGate';
-import { cn } from '@/lib/utils';
 
 type Urgency = 'calm' | 'building' | 'high';
 
@@ -37,6 +37,11 @@ const TRIAL_NOTIFICATION_CAP = TRIAL_NOTIFICATION_RECIPIENT_LIMIT;
 const TRIAL_NOTIFICATION_WARNING_THRESHOLD = Math.floor(
   TRIAL_NOTIFICATION_CAP * 0.8
 );
+const DISMISSAL_KEY_PREFIX = 'jovie-sidebar-upgrade-dismissed';
+
+function getDismissalKey(state: NudgeState): string {
+  return `${DISMISSAL_KEY_PREFIX}:${state}`;
+}
 
 function buildVariant(input: {
   state: NudgeState;
@@ -163,20 +168,15 @@ function buildVariant(input: {
   }
 }
 
-const URGENCY_CLASSES: Record<Urgency, string> = {
-  calm: 'border-sidebar-border/70 bg-sidebar-accent/12',
-  building: 'border-(--linear-accent)/30 bg-(--linear-accent)/5',
-  high: 'border-(--linear-accent)/50 bg-(--linear-accent)/8',
-};
-
-const TEXT_TONE: Record<Urgency, string> = {
-  calm: 'text-sidebar-item-foreground/75',
-  building: 'text-sidebar-item-foreground',
-  high: 'text-sidebar-item-foreground',
+const ICON_TONE: Record<Urgency, string> = {
+  calm: 'text-cyan-300/85',
+  building: 'text-(--linear-accent)',
+  high: 'text-(--linear-accent)',
 };
 
 export function SidebarUpgradeBanner() {
   const pathname = usePathname();
+  const router = useRouter();
   // Only gate render on NODE_ENV=test (unit tests). IS_E2E mode (dev:local:browse,
   // playwright runs) needs the banner visible so we can verify it. The pricing
   // query keeps its own gate to skip the network call under test runtimes.
@@ -188,6 +188,7 @@ export function SidebarUpgradeBanner() {
     enabled: !isPassiveRuntime && !isDemoRoute && !env.IS_E2E,
   });
   const checkoutMutation = useCheckoutMutation();
+  const [dismissedState, setDismissedState] = useState<NudgeState | null>(null);
 
   const selectedPrice = useMemo(
     () => getPreferredVerifiedPrice(pricing.data?.options ?? []),
@@ -213,20 +214,34 @@ export function SidebarUpgradeBanner() {
     ]
   );
 
+  useEffect(() => {
+    if (!variant) return;
+    try {
+      setDismissedState(
+        sessionStorage.getItem(getDismissalKey(variant.state)) === 'true'
+          ? variant.state
+          : null
+      );
+    } catch {
+      setDismissedState(null);
+    }
+  }, [variant]);
+
   // Fire impression once per state transition while the banner is mounted.
   const lastImpressionState = useRef<NudgeState | null>(null);
   useEffect(() => {
     if (!variant) return;
+    if (dismissedState === variant.state) return;
     if (lastImpressionState.current === variant.state) return;
     lastImpressionState.current = variant.state;
     track('billing_upgrade_banner_impression', {
       surface: 'sidebar_upgrade_banner',
       state: variant.state,
     });
-  }, [variant]);
+  }, [dismissedState, variant]);
 
   const handleUpgrade = useCallback(async () => {
-    if (!selectedPrice?.priceId || checkoutMutation.isPending || !variant) {
+    if (checkoutMutation.isPending || !variant) {
       return;
     }
 
@@ -235,6 +250,11 @@ export function SidebarUpgradeBanner() {
       placement: 'sidebar_bottom',
       state: variant.state,
     });
+
+    if (!selectedPrice?.priceId) {
+      router.push(APP_ROUTES.PRICING);
+      return;
+    }
 
     const checkout = await checkoutMutation.mutateAsync({
       priceId: selectedPrice.priceId,
@@ -248,7 +268,21 @@ export function SidebarUpgradeBanner() {
     });
 
     globalThis.location.href = checkout.url;
-  }, [checkoutMutation, selectedPrice, variant]);
+  }, [checkoutMutation, router, selectedPrice, variant]);
+
+  const handleDismiss = useCallback(() => {
+    if (!variant) return;
+    try {
+      sessionStorage.setItem(getDismissalKey(variant.state), 'true');
+    } catch {
+      // Session storage may be unavailable in restricted browsers.
+    }
+    setDismissedState(variant.state);
+    track('billing_upgrade_banner_dismissed', {
+      surface: 'sidebar_upgrade_banner',
+      state: variant.state,
+    });
+  }, [variant]);
 
   // isError → hide the banner. Otherwise paid Pro/Max users would see
   // "Try Pro free for 14 days" during a billing API outage because nudgeState
@@ -258,54 +292,31 @@ export function SidebarUpgradeBanner() {
     isDemoRoute ||
     planGate.isLoading ||
     planGate.isError ||
-    !variant
+    !variant ||
+    dismissedState === variant.state
   ) {
     return null;
   }
 
   const Icon = variant.icon;
+  const title =
+    variant.showPrice && priceLabel
+      ? `${variant.headline} - ${priceLabel}`
+      : variant.headline;
 
   return (
-    <div className='group-data-[collapsible=icon]:hidden px-2.5 pb-1.5'>
-      <div
-        className={cn(
-          'rounded-xl border px-2.5 py-2 text-sidebar-muted',
-          URGENCY_CLASSES[variant.urgency]
-        )}
-      >
-        <div className='flex items-start gap-1.5'>
-          <Icon
-            className={cn(
-              'mt-0.5 size-3 shrink-0',
-              variant.urgency === 'calm'
-                ? 'text-sidebar-item-icon/60'
-                : 'text-(--linear-accent)'
-            )}
-          />
-          <div className='min-w-0'>
-            <p
-              className={cn(
-                'text-2xs font-medium tracking-[-0.01em]',
-                TEXT_TONE[variant.urgency]
-              )}
-            >
-              {variant.headline}
-              {variant.showPrice && priceLabel ? ` — ${priceLabel}` : null}
-            </p>
-            <p className='mt-0.5 text-[10px] leading-[1.35] text-sidebar-muted/80'>
-              {variant.body}
-            </p>
-            <button
-              type='button'
-              onClick={() => handleUpgrade()}
-              disabled={!selectedPrice?.priceId || checkoutMutation.isPending}
-              className='mt-1 inline-flex min-h-6 items-center rounded-full bg-transparent px-1.5 text-[10px] font-medium text-sidebar-item-foreground/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sidebar-ring disabled:cursor-not-allowed disabled:opacity-60'
-            >
-              {checkoutMutation.isPending ? 'Opening…' : variant.cta}
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+    <InstallBanner
+      open
+      icon={Icon}
+      title={title}
+      description={variant.body}
+      ctaLabel={checkoutMutation.isPending ? 'Opening…' : variant.cta}
+      ctaIcon={null}
+      onCta={handleUpgrade}
+      onDismiss={handleDismiss}
+      ctaDisabled={checkoutMutation.isPending}
+      iconClassName={ICON_TONE[variant.urgency]}
+      className='group-data-[collapsible=icon]:hidden'
+    />
   );
 }

--- a/apps/web/components/organisms/AppShellFrame.tsx
+++ b/apps/web/components/organisms/AppShellFrame.tsx
@@ -58,7 +58,7 @@ export const AppShellFrame = memo(function AppShellFrame({
         containerClassName
       )}
     >
-      <DesktopTitlebar />
+      <DesktopTitlebar mainSlot={isShellChatV1 ? header : undefined} />
       <div
         data-app-shell-body='true'
         className={cn(
@@ -79,7 +79,13 @@ export const AppShellFrame = memo(function AppShellFrame({
           )}
         >
           {isEnabled('CANVAS_GRAIN') && <CanvasGrain />}
-          {header}
+          {isShellChatV1 ? (
+            <div className='contents' data-electron-main-header='body'>
+              {header}
+            </div>
+          ) : (
+            header
+          )}
           <div
             className={cn(
               'flex flex-1 min-h-0 min-w-0 overflow-hidden',

--- a/apps/web/components/shell/InstallBanner.test.tsx
+++ b/apps/web/components/shell/InstallBanner.test.tsx
@@ -47,4 +47,19 @@ describe('InstallBanner', () => {
     fireEvent.click(screen.getByText('Install'));
     expect(onCta).toHaveBeenCalledOnce();
   });
+
+  it('supports disabling the primary action', () => {
+    const onCta = vi.fn();
+    render(
+      <InstallBanner
+        open
+        onDismiss={() => undefined}
+        onCta={onCta}
+        ctaDisabled
+      />
+    );
+    fireEvent.click(screen.getByText('Install'));
+    expect(screen.getByText('Install')).toBeDisabled();
+    expect(onCta).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/components/shell/InstallBanner.tsx
+++ b/apps/web/components/shell/InstallBanner.tsx
@@ -37,6 +37,8 @@ export function InstallBanner({
   ctaLabel = 'Install',
   ctaIcon: CtaIcon = ArrowDown,
   onCta,
+  ctaDisabled = false,
+  iconClassName,
   className,
 }: {
   readonly open: boolean;
@@ -47,6 +49,8 @@ export function InstallBanner({
   readonly ctaLabel?: ReactNode;
   readonly ctaIcon?: LucideIcon | null;
   readonly onCta?: () => void;
+  readonly ctaDisabled?: boolean;
+  readonly iconClassName?: string;
   readonly className?: string;
 }) {
   return (
@@ -64,13 +68,16 @@ export function InstallBanner({
           type='button'
           onClick={onDismiss}
           aria-label='Dismiss prompt'
-          className='absolute top-1.5 right-1.5 h-5 w-5 rounded grid place-items-center text-quaternary-token hover:text-primary-token hover:bg-surface-1 transition-colors duration-150 ease-out'
+          className='absolute top-1.5 right-1.5 h-5 w-5 rounded grid place-items-center text-quaternary-token hover:text-primary-token hover:bg-surface-1 transition-colors duration-subtle ease-out'
         >
           <X className='h-3 w-3' strokeWidth={2.25} />
         </button>
         <div className='flex items-center gap-1.5 mb-1 pr-5'>
           <Icon
-            className='h-3 w-3 text-cyan-300/85 shrink-0'
+            className={cn(
+              'h-3 w-3 shrink-0',
+              iconClassName ?? 'text-cyan-300/85'
+            )}
             strokeWidth={2.25}
           />
           <span className='text-[12px] font-medium text-primary-token tracking-[-0.005em]'>
@@ -83,7 +90,8 @@ export function InstallBanner({
         <button
           type='button'
           onClick={onCta}
-          className='w-full inline-flex items-center justify-center gap-1.5 h-7 rounded-full text-[12px] font-medium bg-white text-black hover:brightness-110 active:scale-[0.99] transition-all duration-150 ease-out'
+          disabled={ctaDisabled}
+          className='w-full inline-flex items-center justify-center gap-1.5 h-7 rounded-full text-[12px] font-medium bg-white text-black hover:brightness-110 transition-[filter,background-color,color] duration-subtle ease-out disabled:cursor-not-allowed disabled:opacity-60'
         >
           {ctaLabel}
           {CtaIcon ? <CtaIcon className='h-3 w-3' strokeWidth={2.5} /> : null}

--- a/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
+++ b/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
@@ -68,4 +68,12 @@ describe('DesktopTitlebar', () => {
       screen.getByRole('button', { name: 'Go forward' })
     ).toBeInTheDocument();
   });
+
+  it('renders an optional main titlebar slot', () => {
+    render(<DesktopTitlebar mainSlot={<div>Route header</div>} />);
+
+    expect(screen.getByTestId('electron-titlebar-main-slot')).toHaveTextContent(
+      'Route header'
+    );
+  });
 });

--- a/apps/web/tests/unit/components/feedback/sidebar-lower-shell-visual-hierarchy.test.tsx
+++ b/apps/web/tests/unit/components/feedback/sidebar-lower-shell-visual-hierarchy.test.tsx
@@ -1,11 +1,12 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SidebarUpgradeBanner } from '@/features/feedback/SidebarUpgradeBanner';
 
 const mockUsePathname = vi.fn(() => '/app/chat');
 
 vi.mock('next/navigation', () => ({
   usePathname: () => mockUsePathname(),
+  useRouter: () => ({ push: vi.fn() }),
 }));
 
 vi.mock('@/lib/env-client', () => ({
@@ -57,16 +58,31 @@ vi.mock('@/lib/hooks/useVersionMonitor', () => ({
 }));
 
 describe('Sidebar lower shell visual hierarchy', () => {
-  it('keeps upgrade banner visually quieter than nav rows', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    mockUsePathname.mockReturnValue('/app/chat');
+  });
+
+  it('uses the shell install banner treatment for upgrade nudges', () => {
     const { container } = render(<SidebarUpgradeBanner />);
 
     const card = container.querySelector('[class*="rounded-xl"]');
     expect(card).toBeTruthy();
-    expect(card?.className).toContain('bg-sidebar-accent/12');
+    expect(card?.className).toContain('bg-(--surface-1)/60');
 
     expect(
       screen.getByRole('button', { name: 'Start trial' })
     ).toBeInTheDocument();
+  });
+
+  it('lets users dismiss the current upgrade nudge for the session', () => {
+    render(<SidebarUpgradeBanner />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss prompt' }));
+
+    expect(
+      screen.queryByRole('button', { name: 'Start trial' })
+    ).not.toBeInTheDocument();
   });
 
   it('suppresses the upgrade banner on nested demo routes', () => {


### PR DESCRIPTION
Closes JOV-2385.

## Summary
- Moves the Electron app route header into the native titlebar main cell so the shell no longer renders an empty duplicate header strip.
- Joins the Electron titlebar frame to the main content frame for the shell-v1 layout.
- Reuses the newer InstallBanner treatment for the sidebar upgrade nudge, including session dismiss and pricing-page fallback when checkout pricing is unavailable.

## Screenshots
- Before header: /tmp/jovie-qa-screenshots/JOV-2385/before-electron-tasks.png
- After header: /tmp/jovie-qa-screenshots/JOV-2385/after-electron-tasks.png
- Before upgrade banner: /tmp/jovie-qa-screenshots/JOV-2385/before-electron-chat-admin.png
- After upgrade banner: /tmp/jovie-qa-screenshots/JOV-2385/after-electron-chat-upgrade-banner.png

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/components/atoms/DesktopTitlebar.test.tsx components/shell/InstallBanner.test.tsx tests/unit/components/feedback/sidebar-lower-shell-visual-hierarchy.test.tsx tests/unit/components/organisms/AppShellFrame.test.tsx
- pnpm --filter @jovie/desktop run test:desktop-shell
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm biome check apps/web
- git diff --check
- pre-push hook: biome check . && pnpm --filter=@jovie/web run pre-push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgrade banner can now be dismissed within the session, with dismissal state persisted
  * Enhanced banner component with improved visual styling and better CTA control

* **Bug Fixes**
  * Improved pricing page navigation when pricing information is unavailable

* **Enhancements**
  * Refined desktop app layout for better visual hierarchy and spacing
  * Updated titlebar to support customizable header content

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->