### PR TITLE
test: cover sidebar workspace refresh

### DIFF
--- a/apps/web/tests/unit/components/organisms/ProfileSwitcher.test.tsx
+++ b/apps/web/tests/unit/components/organisms/ProfileSwitcher.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProfileSwitcher } from '@/components/organisms/ProfileSwitcher';
+
+const {
+  mockRefresh,
+  mockSwitchActiveProfile,
+  mockToastError,
+  mockUseDashboardData,
+} = vi.hoisted(() => ({
+  mockRefresh: vi.fn(),
+  mockSwitchActiveProfile: vi.fn(),
+  mockToastError: vi.fn(),
+  mockUseDashboardData: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: mockRefresh }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: mockToastError },
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/actions/switch-profile', () => ({
+  switchActiveProfile: mockSwitchActiveProfile,
+}));
+
+vi.mock('@/app/app/(shell)/dashboard/DashboardDataContext', () => ({
+  useDashboardData: () => mockUseDashboardData(),
+}));
+
+vi.mock('@/components/molecules/Avatar', () => ({
+  Avatar: ({ alt }: { alt: string }) => <span data-avatar-alt={alt} />,
+}));
+
+vi.mock('@/components/organisms/CreateProfileDialog', () => ({
+  CreateProfileDialog: () => null,
+}));
+
+vi.mock('@jovie/ui', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onSelect,
+  }: {
+    children: ReactNode;
+    disabled?: boolean;
+    onSelect?: () => void;
+  }) => (
+    <button type='button' disabled={disabled} onClick={onSelect}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+describe('ProfileSwitcher sidebar workspace selection', () => {
+  const originalLocation = globalThis.location;
+  const mockReload = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(globalThis, 'location', {
+      value: {
+        ...originalLocation,
+        reload: mockReload,
+      },
+      writable: true,
+      configurable: true,
+    });
+    mockSwitchActiveProfile.mockResolvedValue({ success: true });
+    mockUseDashboardData.mockReturnValue({
+      creatorProfiles: [
+        {
+          id: '11111111-1111-4111-8111-111111111111',
+          avatarUrl: null,
+          displayName: 'Alpha Artist',
+          username: 'alpha',
+        },
+        {
+          id: '22222222-2222-4222-8222-222222222222',
+          avatarUrl: null,
+          displayName: 'Beta Artist',
+          username: 'beta',
+        },
+      ],
+      selectedProfile: {
+        id: '11111111-1111-4111-8111-111111111111',
+        avatarUrl: null,
+        displayName: 'Alpha Artist',
+        username: 'alpha',
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('refreshes App Router data instead of forcing a document reload', async () => {
+    render(<ProfileSwitcher />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Beta Artist/ }));
+
+    await waitFor(() => {
+      expect(mockSwitchActiveProfile).toHaveBeenCalledWith(
+        '22222222-2222-4222-8222-222222222222'
+      );
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+    });
+    expect(mockReload).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/components/organisms/ProfileSwitcher.test.tsx
+++ b/apps/web/tests/unit/components/organisms/ProfileSwitcher.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProfileSwitcher } from '@/components/organisms/ProfileSwitcher';
@@ -113,9 +114,11 @@ describe('ProfileSwitcher sidebar workspace selection', () => {
   });
 
   it('refreshes App Router data instead of forcing a document reload', async () => {
+    const user = userEvent.setup();
+
     render(<ProfileSwitcher />);
 
-    fireEvent.click(screen.getByRole('button', { name: /Beta Artist/ }));
+    await user.click(screen.getByRole('button', { name: /Beta Artist/ }));
 
     await waitFor(() => {
       expect(mockSwitchActiveProfile).toHaveBeenCalledWith(
@@ -123,6 +126,30 @@ describe('ProfileSwitcher sidebar workspace selection', () => {
       );
       expect(mockRefresh).toHaveBeenCalledTimes(1);
     });
+    expect(mockToastError).not.toHaveBeenCalled();
+    expect(mockReload).not.toHaveBeenCalled();
+  });
+
+  it('keeps the shell in place when profile switching fails', async () => {
+    const user = userEvent.setup();
+    mockSwitchActiveProfile.mockResolvedValue({
+      error: "Couldn't switch profile. Try again.",
+      success: false,
+    });
+
+    render(<ProfileSwitcher />);
+
+    await user.click(screen.getByRole('button', { name: /Beta Artist/ }));
+
+    await waitFor(() => {
+      expect(mockSwitchActiveProfile).toHaveBeenCalledWith(
+        '22222222-2222-4222-8222-222222222222'
+      );
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Couldn't switch profile. Try again."
+      );
+    });
+    expect(mockRefresh).not.toHaveBeenCalled();
     expect(mockReload).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Adds focused sidebar profile-switcher coverage for JOV-2386.
- Asserts workspace selection persists through switchActiveProfile() and App Router refresh without calling window.location.reload().
- Adds the failure-path regression: failed profile switching shows an error and does not refresh or reload the shell.
- Production code on current origin/main already uses the canonical App Router refresh path for this sidebar selection flow.

## Verification
- pnpm --filter @jovie/web run test -- tests/unit/components/organisms/ProfileSwitcher.test.tsx
- pnpm exec biome check --write apps/web/tests/unit/components/organisms/ProfileSwitcher.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git push (pre-push ran biome check ., @jovie/web pre-push, proxy guard, Tailwind guard, web typecheck, and web Biome lint)

<!-- agent-run-artifact
{"id":"jov-2386-sidebar-refresh-d4519d9773694f4e11ee8968002cb50db67ff114","source":"github","sourceRunId":"d4519d9773694f4e11ee8968002cb50db67ff114","kind":"qa","status":"done","title":"JOV-2386 sidebar workspace refresh regression coverage","summary":"Added focused coverage proving sidebar workspace selection uses switchActiveProfile plus App Router refresh, does not force a full document reload, and keeps the shell in place on switch failures.","modelRoute":"codex-cli","allowedActions":["write_code","open_pr"],"forbiddenActions":["mutate_production_data","change_auth","change_billing","change_security"],"humanApprovalRequired":false,"humanGate":{"required":false,"status":"not_required","reason":"No visual change; user approved autonomous shell migration slices.","reviewer":null,"reviewedAt":null},"linearIssueId":"JOV-2386","linearIssueUrl":"https://linear.app/jovie/issue/JOV-2386/remove-shell-workspace-reload-from-sidebar-selection","pullRequestUrl":"https://github.com/JovieInc/Jovie/pull/9064","adminSurface":null,"verificationGates":[{"name":"gstack.qa.exhaustive","required":true,"status":"passed","evidenceUrl":"https://github.com/JovieInc/Jovie/commit/d4519d9773694f4e11ee8968002cb50db67ff114","summary":"Focused ProfileSwitcher tests cover success and failure without full document reload.","checkedAt":"2026-05-18T04:32:11Z"},{"name":"gstack.review","required":true,"status":"passed","evidenceUrl":"https://github.com/JovieInc/Jovie/commit/d4519d9773694f4e11ee8968002cb50db67ff114","summary":"CodeRabbit actionable failure-path coverage was implemented locally.","checkedAt":"2026-05-18T04:32:11Z"},{"name":"gstack.ship","required":true,"status":"passed","evidenceUrl":"https://github.com/JovieInc/Jovie/commit/d4519d9773694f4e11ee8968002cb50db67ff114","summary":"Biome, web typecheck, targeted unit test, and pre-push hooks passed.","checkedAt":"2026-05-18T04:32:11Z"}],"costEstimate":null,"blockedReason":null,"createdAt":"2026-05-18T04:32:11Z","updatedAt":"2026-05-18T04:32:11Z","metadata":{"commands":["pnpm --filter @jovie/web run test -- tests/unit/components/organisms/ProfileSwitcher.test.tsx","pnpm exec biome check --write apps/web/tests/unit/components/organisms/ProfileSwitcher.test.tsx","pnpm --filter @jovie/web run typecheck -- --pretty false","git push"],"visualChange":false}}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for profile switching covering successful and failed switches: verifies profile selection updates trigger app data refresh without a full page reload, and that a user-facing error toast is shown when switching fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->