### PR TITLE
Polish chat empty state and task board shell

### DIFF
--- a/apps/web/components/atoms/JovieMarkElectric.tsx
+++ b/apps/web/components/atoms/JovieMarkElectric.tsx
@@ -41,6 +41,8 @@ export function JovieMarkElectric({
 
   const prefersReducedMotion = useReducedMotion();
   const showSpark = spark && !prefersReducedMotion;
+  const sparkDuration = 'calc(var(--ds-motion-cinematic-duration) * 3.5)';
+  const sparkDelay = 'calc(var(--ds-motion-subtle-duration) * 1.6)';
 
   return (
     <span
@@ -51,10 +53,10 @@ export function JovieMarkElectric({
       {showSpark && (
         <style id={styleId}>{`
           @keyframes ${sparkAnimationName} {
-            0%   { stroke-dashoffset: 0;     opacity: 0; }
-            8%   { stroke-dashoffset: -80;   opacity: 0.9; }
-            55%  { stroke-dashoffset: -700;  opacity: 0.9; }
-            70%  { stroke-dashoffset: -950;  opacity: 0; }
+            0%   { stroke-dashoffset: 45;    opacity: 0; }
+            14%  { stroke-dashoffset: -120;  opacity: 0.56; }
+            48%  { stroke-dashoffset: -520;  opacity: 0.68; }
+            78%  { stroke-dashoffset: -820;  opacity: 0.22; }
             100% { stroke-dashoffset: -1000; opacity: 0; }
           }
         `}</style>
@@ -75,8 +77,8 @@ export function JovieMarkElectric({
         <path
           d={JOVIE_ICON_PATH}
           fill='none'
-          stroke='rgba(255,255,255,0.085)'
-          strokeWidth='1.2'
+          stroke='rgba(255,255,255,0.04)'
+          strokeWidth='1'
         />
         {showSpark && (
           <>
@@ -84,25 +86,35 @@ export function JovieMarkElectric({
               pathLength='1000'
               d={JOVIE_ICON_PATH}
               fill='none'
-              stroke='rgba(255,255,255,0.85)'
+              stroke='rgba(78,190,255,0.76)'
               strokeWidth='1.4'
-              strokeDasharray='55 945'
+              strokeDasharray='50 950'
               strokeLinecap='round'
               filter={`url(#${filterId})`}
               style={{
-                animation: `${sparkAnimationName} 18s var(--ds-motion-subtle-easing) infinite`,
+                animationName: sparkAnimationName,
+                animationDuration: sparkDuration,
+                animationTimingFunction: 'var(--ds-motion-subtle-easing)',
+                animationIterationCount: 2,
+                animationFillMode: 'both',
+                animationDelay: sparkDelay,
               }}
             />
             <path
               pathLength='1000'
               d={JOVIE_ICON_PATH}
               fill='none'
-              stroke='rgba(255,255,255,0.95)'
+              stroke='rgba(236,250,255,0.88)'
               strokeWidth='0.55'
-              strokeDasharray='22 978'
+              strokeDasharray='20 980'
               strokeLinecap='round'
               style={{
-                animation: `${sparkAnimationName} 18s var(--ds-motion-subtle-easing) infinite`,
+                animationName: sparkAnimationName,
+                animationDuration: sparkDuration,
+                animationTimingFunction: 'var(--ds-motion-subtle-easing)',
+                animationIterationCount: 2,
+                animationFillMode: 'both',
+                animationDelay: sparkDelay,
               }}
             />
           </>

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -46,6 +46,18 @@ const searchNavItem: NavItem = {
   description: 'Search routes, releases, artists, and threads',
 };
 
+type DashboardNavSection = {
+  readonly key: string;
+  readonly label?: string;
+  readonly items: NavItem[];
+};
+
+type ArtistWorkspaceNavSection = {
+  readonly key: 'artist-workspace';
+  readonly label: string;
+  readonly items: NavItem[];
+};
+
 function isItemActive(pathname: string, item: NavItem): boolean {
   const normalizedPathname = (() => {
     if (
@@ -119,8 +131,7 @@ export function DashboardNav(_: DashboardNavProps) {
     [publicProfileHref]
   );
 
-  // Replace "Profile" label with artist display name when available
-  const artistName = selectedProfile?.displayName;
+  const artistName = selectedProfile?.displayName?.trim();
   const profileId = selectedProfile?.id ?? '';
   const isDemo = isDemoRoutePath(pathname);
   const { canAccessTasksWorkspace, isLoading: isPlanGateLoading } =
@@ -146,9 +157,13 @@ export function DashboardNav(_: DashboardNavProps) {
 
   // Settings nav: "General" (user) and artist name (or "Artist") groups
   const artistSettingsLabel = artistName || 'Artist';
+  const artistWorkspaceLabel = artistName || 'Artist';
 
   // Memoize nav sections for dashboard (non-settings) mode
-  const navSections = useMemo(() => {
+  const { artistWorkspaceSection, navSections } = useMemo<{
+    readonly artistWorkspaceSection: ArtistWorkspaceNavSection | null;
+    readonly navSections: DashboardNavSection[];
+  }>(() => {
     const decorateItem = (item: NavItem): NavItem =>
       item.id === 'tasks'
         ? {
@@ -182,33 +197,39 @@ export function DashboardNav(_: DashboardNavProps) {
       );
       const tasksItem = primaryNavigation.find(item => item.id === 'tasks');
 
-      return [
-        {
-          key: 'user-work',
-          items: [
-            newThreadNavItem,
-            searchNavItem,
-            ...(tasksItem ? [decorateItem(tasksItem)] : []),
-            ...(shellChatLibraryEnabled ? [libraryNavItem] : []),
-          ],
-        },
-        {
+      return {
+        artistWorkspaceSection: {
           key: 'artist-workspace',
-          label: 'Artist Workspace',
+          label: artistWorkspaceLabel,
           items: [profileItem, releaseItem, audienceItem]
             .filter((item): item is NavItem => Boolean(item))
             .map(decorateItem),
         },
-      ];
+        navSections: [
+          {
+            key: 'user-work',
+            items: [
+              newThreadNavItem,
+              searchNavItem,
+              ...(tasksItem ? [decorateItem(tasksItem)] : []),
+              ...(shellChatLibraryEnabled ? [libraryNavItem] : []),
+            ],
+          },
+        ],
+      };
     }
 
-    return [
-      {
-        key: 'primary',
-        items: primaryItems.map(decorateItem),
-      },
-    ];
+    return {
+      artistWorkspaceSection: null,
+      navSections: [
+        {
+          key: 'primary',
+          items: primaryItems.map(decorateItem),
+        },
+      ],
+    };
   }, [
+    artistWorkspaceLabel,
     canAccessTasksWorkspace,
     isPlanGateLoading,
     shellChatV1Enabled,
@@ -460,6 +481,18 @@ export function DashboardNav(_: DashboardNavProps) {
             tight
             collapsed={false}
           />
+        </div>
+      ) : null}
+
+      {artistWorkspaceSection ? (
+        <div data-nav-section={artistWorkspaceSection.key} className='mt-3'>
+          <SidebarCollapsibleGroup
+            label={artistWorkspaceSection.label}
+            defaultOpen
+            className='-mx-0.5'
+          >
+            {renderSection(artistWorkspaceSection.items)}
+          </SidebarCollapsibleGroup>
         </div>
       ) : null}
 

--- a/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
@@ -285,8 +285,11 @@ export function TaskBoard({
       onDragCancel={() => setActiveTaskId(null)}
     >
       <div
-        className='flex h-full min-h-0 gap-3 overflow-x-auto overflow-y-hidden px-3 pb-3 pt-1.5'
+        className='grid h-full min-h-0 min-w-full gap-3 overflow-x-auto overflow-y-hidden px-3 pb-3 pt-1.5'
         data-testid='tasks-board'
+        style={{
+          gridTemplateColumns: `repeat(${Math.max(columns.length, 1)}, minmax(17.5rem, 1fr))`,
+        }}
       >
         {columns.map(column => (
           <TaskBoardColumn
@@ -343,7 +346,7 @@ function TaskBoardColumn({
       aria-label={`${visual.label} tasks`}
       data-testid={`tasks-board-column-${column.status}`}
       className={cn(
-        'flex h-full min-h-0 w-[19.5rem] shrink-0 flex-col rounded-lg border border-subtle bg-surface-0',
+        'flex h-full min-h-0 w-full min-w-0 flex-col rounded-lg border border-subtle bg-surface-0',
         isOver &&
           'border-[color-mix(in_oklab,var(--linear-border-focus)_70%,transparent)] bg-[color-mix(in_oklab,var(--linear-row-hover)_36%,var(--linear-app-content-surface))]'
       )}
@@ -578,11 +581,14 @@ function TaskBoardCard({
 
 function TaskBoardSkeleton() {
   return (
-    <div className='flex h-full min-h-0 gap-3 overflow-hidden px-3 pb-3 pt-1.5'>
+    <div
+      className='grid h-full min-h-0 min-w-full gap-3 overflow-hidden px-3 pb-3 pt-1.5'
+      style={{ gridTemplateColumns: 'repeat(4, minmax(17.5rem, 1fr))' }}
+    >
       {[0, 1, 2, 3].map(column => (
         <div
           key={column}
-          className='flex h-full min-h-0 w-[19.5rem] shrink-0 flex-col rounded-lg border border-subtle bg-surface-0'
+          className='flex h-full min-h-0 w-full min-w-0 flex-col rounded-lg border border-subtle bg-surface-0'
         >
           <div className='h-10 border-b border-subtle px-3 py-3'>
             <div className='h-3 w-24 rounded bg-surface-2' />

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -635,10 +635,11 @@ export function JovieChat({
               >
                 {shellChatV1Enabled ? (
                   <JovieMarkElectric
+                    className='opacity-70'
                     style={{
-                      width: 'clamp(220px, 44vw, 440px)',
-                      height: 'clamp(220px, 44vw, 440px)',
-                      transform: 'translateY(-12px)',
+                      width: 'clamp(180px, 34vw, 360px)',
+                      height: 'clamp(180px, 34vw, 360px)',
+                      transform: 'translateY(-16px)',
                       WebkitMaskImage:
                         'radial-gradient(circle, rgba(0,0,0,1) 55%, rgba(0,0,0,0.75) 75%, rgba(0,0,0,0) 95%)',
                       maskImage:

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -427,7 +427,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                   width: geometry.width,
                   maxWidth: geometry.maxWidth,
                 }}
-                className='overflow-hidden rounded-[24px] border border-white/[0.08] bg-[linear-gradient(180deg,rgba(255,255,255,0.035)_0%,rgba(255,255,255,0.012)_42%,transparent_100%),#16171b] shadow-[0_18px_56px_-28px_rgba(0,0,0,0.9),inset_0_1px_0_rgba(255,255,255,0.055)]'
+                className='overflow-hidden rounded-[24px] border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_84%,transparent)] bg-[linear-gradient(180deg,rgba(255,255,255,0.04)_0%,rgba(255,255,255,0.012)_100%),var(--linear-app-content-surface)] shadow-none'
               >
                 <SlashCommandMenu
                   profileId={pickerProfileId}
@@ -465,10 +465,10 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
               maxHeight: 'min(42vh, 280px)',
             }}
             className={cn(
-              'overflow-hidden border border-white/[0.08] bg-[linear-gradient(180deg,rgba(255,255,255,0.035)_0%,rgba(255,255,255,0.014)_45%,transparent_100%),#16171b] text-primary-token shadow-[0_18px_56px_-30px_rgba(0,0,0,0.86),inset_0_1px_0_rgba(255,255,255,0.055)]',
+              'overflow-hidden border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_84%,transparent)] bg-[linear-gradient(180deg,rgba(255,255,255,0.04)_0%,rgba(255,255,255,0.012)_100%),var(--linear-app-content-surface)] text-primary-token shadow-none',
               isExpanded &&
-                'border-white/[0.12] shadow-[0_24px_68px_-32px_rgba(0,0,0,0.95),inset_0_1px_0_rgba(255,255,255,0.07)]',
-              'outline-none focus-within:border-white/[0.18] focus-within:shadow-[0_0_0_3px_rgba(255,255,255,0.05),0_24px_68px_-32px_rgba(0,0,0,0.95),inset_0_1px_0_rgba(255,255,255,0.07)] focus-within:outline-none',
+                'border-[color-mix(in_oklab,var(--linear-border-focus)_46%,var(--linear-app-frame-seam))] bg-[linear-gradient(180deg,rgba(255,255,255,0.052)_0%,rgba(255,255,255,0.016)_100%),var(--linear-app-content-surface)]',
+              'outline-none ring-0 focus-within:border-[color-mix(in_oklab,var(--linear-border-focus)_78%,transparent)] focus-within:ring-1 focus-within:ring-[color-mix(in_oklab,var(--linear-border-focus)_42%,transparent)] focus-within:outline-none',
               isOverLimit && 'border-error',
               showEntitySurface && !isStacked ? 'flex' : 'flex flex-col'
             )}

--- a/apps/web/components/organisms/AuthShellWrapper.tsx
+++ b/apps/web/components/organisms/AuthShellWrapper.tsx
@@ -30,7 +30,6 @@ import {
   useTableMeta,
 } from '@/contexts/TableMetaContext';
 import { HeaderChatUsageIndicator } from '@/features/dashboard/atoms/HeaderChatUsageIndicator';
-import { HeaderProfileProgress } from '@/features/dashboard/atoms/HeaderProfileProgress';
 import { useAuthRouteConfig } from '@/hooks/useAuthRouteConfig';
 import { useDashboardShortcuts } from '@/hooks/useDashboardShortcuts';
 import { useGlobalShortcutActions } from '@/hooks/useGlobalShortcutActions';
@@ -113,7 +112,6 @@ function AuthShellWrapperInner({
         {config.showChatUsageIndicator && !config.isDemoRoute ? (
           <HeaderChatUsageIndicator />
         ) : null}
-        <HeaderProfileProgress />
         {isElectron ? null : <UpdateAvailablePill />}
       </>
     ),

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -182,15 +182,30 @@ describe('DashboardNav interactions', () => {
     expect(screen.getByLabelText('Command palette search')).toBeInTheDocument();
   });
 
-  it('groups artist-owned routes under Artist Workspace in Design V1', () => {
-    renderDashboardNav({
+  it('groups artist-owned routes under the artist name after Threads in Design V1', () => {
+    const { container } = renderDashboardNav({
       renderFn: render,
       appFlags: { DESIGN_V1: true },
+      overrides: {
+        selectedProfile: {
+          id: 'profile_123',
+          displayName: 'Tim White',
+          username: 'tim',
+          usernameNormalized: 'tim',
+        } as DashboardData['selectedProfile'],
+      },
     });
 
+    const threadsHeading = screen.getByText('Threads');
+    const artistGroupButton = screen.getByRole('button', {
+      name: 'Tim White',
+    });
+    expect(artistGroupButton).toBeInTheDocument();
+    expect(screen.queryByText('Artist Workspace')).not.toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Artist Workspace' })
-    ).toBeInTheDocument();
+      threadsHeading.compareDocumentPosition(artistGroupButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Profile' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
@@ -201,6 +216,9 @@ describe('DashboardNav interactions', () => {
       'href',
       APP_ROUTES.AUDIENCE
     );
+    expect(
+      container.querySelector('[data-nav-section="artist-workspace"]')
+    ).toBeInTheDocument();
   });
 
   it('renders recent threads in the Design V1 sidebar as App Router links', () => {

--- a/apps/web/tests/unit/chat/ChatInput.test.tsx
+++ b/apps/web/tests/unit/chat/ChatInput.test.tsx
@@ -149,7 +149,7 @@ describe('ChatInput', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the hardened dark composer geometry', () => {
+  it('renders the elevated no-shadow composer geometry', () => {
     fastRender(
       withProviders(
         <ChatInput {...baseProps} value='' onImageAttach={vi.fn()} />
@@ -157,8 +157,10 @@ describe('ChatInput', () => {
     );
 
     const surface = screen.getByTestId('chat-composer-surface');
-    expect(surface.className).toContain('#16171b');
-    expect(surface.className).toContain('border-white');
+    expect(surface.className).toContain('--linear-app-content-surface');
+    expect(surface.className).toContain('--linear-app-frame-seam');
+    expect(surface.className).toContain('shadow-none');
+    expect(surface.className).toContain('--linear-border-focus');
 
     const textarea = screen.getByRole('textbox', {
       name: /chat message input/i,


### PR DESCRIPTION
## Summary
- Subtle chat empty-state Jovie mark with finite electric spark motion that runs twice and stops.
- Equal-width task board columns across visible statuses.
- Elevated no-shadow chat composer surface with Linear-style focus ring.
- Sidebar cleanup: remove header profile-completion score, move artist routes under Threads, and label the group with the selected artist name.

## Screenshots
- Chat: `/tmp/jovie-qa-screenshots/JOV-2385/after-cleanup-chat.png`
- Tasks: `/tmp/jovie-qa-screenshots/JOV-2385/after-cleanup-tasks.png`

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/chat/ChatInput.test.tsx tests/unit/chat/ChatInput.aria.test.tsx tests/components/dashboard/DashboardNav.interaction.test.tsx tests/unit/dashboard/DashboardNav.test.tsx tests/unit/components/organisms/AuthShellWrapper.test.tsx tests/unit/components/AuthShellWrapper.test.tsx tests/unit/chat/JovieChat.empty-state.test.tsx tests/unit/chat/JovieChat.styling.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `doppler run --project jovie-web --config dev -- env E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 E2E_SKIP_WEB_SERVER=1 BASE_URL=http://localhost:3113 pnpm --filter @jovie/web exec playwright test tests/e2e/tasks-layout.spec.ts --project=chromium --grep "keeps the board contained at desktop-1440"`
- Clean-branch screenshot checks: spark opacity `0` after two iterations, no profile-score text visible, task columns measured `429px` each.
- Pre-push: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`

JOV-2385


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat usage indicator now displays in the application header.

* **Style**
  * Jovie electric spark animation and empty-thread sizing refined for smoother visuals.
  * Task board layout converted to a responsive CSS grid for improved display.
  * Artist workspace nav reorganized into a standalone collapsible section.
  * Chat input and composer visuals updated with improved borders, focus, and surface styling.

* **Tests**
  * Nav and chat input tests updated to reflect visual and structural changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9071?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->