### PR TITLE
test(library): cover sidebar takeover contract

### DIFF
--- a/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
+++ b/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
@@ -1,0 +1,138 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { DashboardData } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
+import { DashboardDataProvider } from '@/app/app/(shell)/dashboard/DashboardDataContext';
+import { SidebarProvider } from '@/components/organisms/Sidebar';
+import { UnifiedSidebar } from '@/components/organisms/UnifiedSidebar';
+import { APP_ROUTES } from '@/constants/routes';
+import {
+  ShellSidebarOverrideProvider,
+  useRegisterShellSidebarOverride,
+} from '@/contexts/ShellSidebarOverrideContext';
+import { AppFlagProvider } from '@/lib/flags/client';
+import { APP_FLAG_DEFAULTS } from '@/lib/flags/contracts';
+import {
+  mockUsePathname,
+  resetDashboardNavTestMocks,
+} from '@/tests/utils/dashboard-nav-test-support';
+
+const dashboardData: DashboardData = {
+  user: { id: 'user_123' },
+  creatorProfiles: [],
+  selectedProfile: null,
+  needsOnboarding: false,
+  sidebarCollapsed: false,
+  hasSocialLinks: false,
+  hasMusicLinks: false,
+  isAdmin: false,
+  tippingStats: {
+    tipClicks: 0,
+    qrTipClicks: 0,
+    linkTipClicks: 0,
+    tipsSubmitted: 0,
+    totalReceivedCents: 0,
+    monthReceivedCents: 0,
+  },
+  profileCompletion: {
+    percentage: 0,
+    completedCount: 0,
+    totalCount: 6,
+    steps: [],
+    profileIsLive: false,
+  },
+};
+
+function LibrarySidebarOverride({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  useRegisterShellSidebarOverride({
+    key: 'library',
+    backHref: APP_ROUTES.CHAT,
+    backLabel: 'Back to App',
+    content: (
+      <nav aria-label='Library navigation'>
+        <button type='button'>All Releases</button>
+        {children}
+      </nav>
+    ),
+  });
+
+  return null;
+}
+
+function renderUnifiedSidebar({
+  overrideContent,
+}: {
+  readonly overrideContent?: ReactNode;
+} = {}) {
+  mockUsePathname.mockReturnValue(APP_ROUTES.LIBRARY);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, DESIGN_V1: true }}>
+        <DashboardDataProvider value={dashboardData}>
+          <SidebarProvider>
+            <ShellSidebarOverrideProvider>
+              {overrideContent ? (
+                <LibrarySidebarOverride>
+                  {overrideContent}
+                </LibrarySidebarOverride>
+              ) : null}
+              <UnifiedSidebar section='library' />
+            </ShellSidebarOverrideProvider>
+          </SidebarProvider>
+        </DashboardDataProvider>
+      </AppFlagProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('UnifiedSidebar library route', () => {
+  afterEach(() => {
+    resetDashboardNavTestMocks();
+  });
+
+  it('keeps the library route out of the default dashboard navigation', () => {
+    renderUnifiedSidebar();
+
+    expect(screen.getByText('Loading Library')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to App' })).toBeDefined();
+    expect(
+      screen.queryByRole('link', { name: 'Releases' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Tasks' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the registered library navigation with the app back target', async () => {
+    renderUnifiedSidebar({
+      overrideContent: <button type='button'>Needs Assets</button>,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('navigation', { name: 'Library navigation' })
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'All Releases' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Needs Assets' })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Loading Library')).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to App' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.CHAT
+    );
+  });
+});

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -7,6 +7,10 @@ import type { LibraryReleaseAsset } from '@/app/app/(shell)/library/library-data
 import { HeaderSearchSurfaceFromContext } from '@/components/shell/HeaderSearchSurface';
 import { APP_ROUTES } from '@/constants/routes';
 import { HeaderActionsProvider } from '@/contexts/HeaderActionsContext';
+import {
+  ShellSidebarOverrideProvider,
+  useShellSidebarOverride,
+} from '@/contexts/ShellSidebarOverrideContext';
 
 Element.prototype.scrollIntoView = vi.fn();
 
@@ -72,6 +76,38 @@ function renderLibrary(assets: readonly LibraryReleaseAsset[]) {
   return render(
     <TooltipProvider>
       <LibrarySurface assets={assets} />
+    </TooltipProvider>
+  );
+}
+
+function SidebarOverrideProbe() {
+  const override = useShellSidebarOverride();
+
+  return (
+    <>
+      <output
+        aria-label='Sidebar override contract'
+        data-testid='library-sidebar-override'
+        data-back-href={override?.backHref}
+        data-back-label={override?.backLabel}
+        data-key={override?.key}
+      >
+        {override?.content ? 'registered' : 'missing'}
+      </output>
+      {override?.content}
+    </>
+  );
+}
+
+function renderLibraryWithSidebarOverride(
+  assets: readonly LibraryReleaseAsset[]
+) {
+  return render(
+    <TooltipProvider>
+      <ShellSidebarOverrideProvider>
+        <LibrarySurface assets={assets} />
+        <SidebarOverrideProbe />
+      </ShellSidebarOverrideProvider>
     </TooltipProvider>
   );
 }
@@ -244,6 +280,33 @@ describe('LibrarySurface', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: 'Never Say A Word' })
+    ).toBeInTheDocument();
+  });
+
+  it('registers the route sidebar takeover contract', async () => {
+    renderLibraryWithSidebarOverride([
+      buildAsset(),
+      buildAsset({
+        id: 'release-2',
+        title: 'Never Say A Word',
+        artist: 'Other Artist',
+      }),
+    ]);
+
+    const contract = await screen.findByTestId('library-sidebar-override');
+
+    expect(contract).toHaveTextContent('registered');
+    expect(contract).toHaveAttribute('data-key', 'library');
+    expect(contract).toHaveAttribute('data-back-href', APP_ROUTES.CHAT);
+    expect(contract).toHaveAttribute('data-back-label', 'Back to App');
+    expect(
+      screen.getByRole('navigation', { name: 'Library navigation' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /All Releases/u })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Needs Assets/u })
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- cover the `/app/library` sidebar override registration from `LibrarySurface`
- cover `UnifiedSidebar section="library"` using the route sidebar instead of default dashboard nav
- lock the Back to App target to the canonical chat route

## Verification
- `pnpm exec biome check --write apps/web/tests/unit/library/LibrarySurface.test.tsx apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/library/LibrarySurface.test.tsx tests/unit/components/organisms/UnifiedSidebar.library.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`

Linear: JOV-2389

<!-- agent-run-artifact: {"sourceRunId":"6a78235f47c1489a9ede5bedee6f2c12bc38472e","branch":"codex/jov-2389-library-sidebar-contract","issue":"JOV-2389"} -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for library navigation and sidebar override functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9072?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->