### PR TITLE
fix(auth): Clerk integration polish — 8 audit findings (JOV-2394)

### DIFF
--- a/apps/web/app/(auth)/signin/SignInPageClient.tsx
+++ b/apps/web/app/(auth)/signin/SignInPageClient.tsx
@@ -8,6 +8,47 @@ import { APP_ROUTES } from '@/constants/routes';
 import { AuthLayout, AuthRoutePrefetch, AuthShell } from '@/features/auth';
 
 /**
+ * Shows a banner when the OAuth provider returned an error code.
+ * Covers the case where the user clicks "Deny" on the provider consent screen,
+ * which returns `?oauth_error=access_denied` on redirect back to /signin. #86
+ */
+function SignInOauthErrorBanner() {
+  const searchParams = useSearchParams();
+  const oauthError = searchParams.get('oauth_error');
+
+  useEffect(() => {
+    if (!oauthError) return;
+
+    const url = new URL(globalThis.location.href);
+    url.searchParams.delete('oauth_error');
+    globalThis.history.replaceState(
+      globalThis.history.state,
+      '',
+      `${url.pathname}${url.search}${url.hash}`
+    );
+  }, [oauthError]);
+
+  if (!oauthError) return null;
+
+  let message = 'Something went wrong with sign-in. Please try again.';
+  if (oauthError === 'access_denied') {
+    message = 'Sign-in was cancelled. Try again, or pick a different method.';
+  } else if (oauthError === 'account_exists') {
+    message =
+      'An account with this email already exists. Try signing in with your email instead.';
+  }
+
+  return (
+    <div
+      className='mb-4 rounded-(--linear-radius-sm) border border-destructive/30 bg-destructive/5 px-4 py-3 text-left'
+      role='alert'
+    >
+      <p className='text-sm font-medium text-destructive'>{message}</p>
+    </div>
+  );
+}
+
+/**
  * Sign-in page using the canonical AuthShell (JOV-2064).
  *
  * Both the full-page route and the intercepted modal route render the same
@@ -74,6 +115,7 @@ export function SignInPageClient() {
       layoutVariant='split'
     >
       <AuthRoutePrefetch href={APP_ROUTES.SIGNUP} />
+      <SignInOauthErrorBanner />
       <AuthShell
         mode='sign-in'
         forceOppositeModeHardNavigation

--- a/apps/web/app/(auth)/signup/SignUpPageClient.tsx
+++ b/apps/web/app/(auth)/signup/SignUpPageClient.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
 import { AuthLayout, AuthRoutePrefetch, AuthShell } from '@/features/auth';
 import { track } from '@/lib/analytics';
@@ -124,6 +124,10 @@ function SignUpClaimDataPersistence() {
 function SignUpOauthErrorBanner() {
   const searchParams = useSearchParams();
   const oauthError = searchParams.get('oauth_error');
+  // Used to personalise the account_exists message when the conflicting
+  // address is known (e.g. forwarded by SsoCallbackHandler). React escapes
+  // all text content so no additional XSS sanitisation is required. #26
+  const conflictingEmail = searchParams.get('email')?.trim() ?? '';
 
   useEffect(() => {
     if (!oauthError) return;
@@ -140,13 +144,20 @@ function SignUpOauthErrorBanner() {
   if (!oauthError) return null;
 
   const isAccountExists = oauthError === 'account_exists';
-  let message = 'Something went wrong with Google sign-up. Please try again.';
+
+  let message: ReactNode =
+    'Something went wrong with sign-up. Please try again.';
   if (isAccountExists) {
-    message =
-      'An account with this email already exists. Try signing in instead.';
+    message = conflictingEmail ? (
+      <>
+        An account for <strong>{conflictingEmail}</strong> already exists. Try
+        signing in instead.
+      </>
+    ) : (
+      'An account with this email already exists. Try signing in instead.'
+    );
   } else if (oauthError === 'access_denied') {
-    message =
-      'Required permissions were not granted. Please try again and accept all permissions.';
+    message = 'Sign-in was cancelled. Try again, or pick a different method.';
   }
 
   return (

--- a/apps/web/components/features/auth/AuthProviderButtons.tsx
+++ b/apps/web/components/features/auth/AuthProviderButtons.tsx
@@ -30,7 +30,7 @@ export function AuthProviderButtonSlot({
     <button
       type='button'
       disabled={disabled}
-      aria-label={disabled ? `${label} loading` : label}
+      aria-label={disabled ? `${label} loading` : undefined}
       data-auth-provider-slot={provider}
       className={cn(
         'flex h-10 min-h-10 w-full items-center justify-center gap-2 rounded-full border px-4 text-[0.875rem] font-semibold tracking-[-0.011em]',

--- a/apps/web/components/features/auth/AuthShell.tsx
+++ b/apps/web/components/features/auth/AuthShell.tsx
@@ -8,6 +8,7 @@ import { APP_ROUTES } from '@/constants/routes';
 import { AuthProviderButtonSlots } from '@/features/auth/AuthProviderButtons';
 import { useNormalizeClerkHomeLink } from '@/features/auth/useNormalizeClerkHomeLink';
 import { buildAuthRouteUrl } from '@/lib/auth/build-auth-route-url';
+import { CLERK_COMPONENT_OPTIONS } from '@/lib/auth/clerk-options';
 import {
   buildDisabledOAuthProviderElements,
   getAuthOAuthProviderLabel,
@@ -161,10 +162,12 @@ export function AuthShell({
 
   const isSignUp = mode === 'sign-up';
 
+  // Sign-in cross-link → /waitlist (Jovie is invite-only; /signup is not a
+  // publicly navigable destination). Sign-up cross-link → /signin. #48
   const crossLinkUrl =
     oppositeModeUrl ??
     buildAuthRouteUrl(
-      isSignUp ? APP_ROUTES.SIGNIN : APP_ROUTES.SIGNUP,
+      isSignUp ? APP_ROUTES.SIGNIN : APP_ROUTES.WAITLIST,
       searchParams
     );
   const clerkCrossLinkUrl =
@@ -274,6 +277,7 @@ export function AuthShell({
               signInUrl={clerkCrossLinkUrl}
               fallbackRedirectUrl={resolvedRedirect}
               appearance={mergedAppearance}
+              oidcPrompt={CLERK_COMPONENT_OPTIONS.oidcPrompt}
             />
           ) : (
             <SignIn
@@ -284,6 +288,7 @@ export function AuthShell({
               fallbackRedirectUrl={resolvedRedirect}
               appearance={mergedAppearance}
               initialValues={initialValues}
+              oidcPrompt={CLERK_COMPONENT_OPTIONS.oidcPrompt}
             />
           )
         ) : null}
@@ -366,8 +371,8 @@ function AuthModeSwitchLink({
   forceHardNavigation: boolean;
 }>) {
   const isSignUp = mode === 'sign-up';
-  const prompt = isSignUp ? 'Have an account?' : 'No account?';
-  const label = isSignUp ? 'Sign in' : 'Request access';
+  const prompt = isSignUp ? 'Have an account?' : "Don't have access?";
+  const label = isSignUp ? 'Sign in' : 'Join the waitlist';
   const className =
     'focus-ring-themed rounded-md text-white underline underline-offset-2';
 

--- a/apps/web/lib/auth/clerk-options.ts
+++ b/apps/web/lib/auth/clerk-options.ts
@@ -1,0 +1,15 @@
+/**
+ * Canonical Clerk component options shared across all auth flows.
+ *
+ * `oidcPrompt: 'select_account'` forces the OAuth provider (Google, Apple) to
+ * present the account chooser on every auth attempt — preventing silent
+ * account switching when the user wants to use a different account.
+ *
+ * Spread this object into both `<SignIn>` and `<SignUp>` components so the
+ * behaviour is consistent across all entry points.
+ *
+ * Audit finding: JOV-2394 #85
+ */
+export const CLERK_COMPONENT_OPTIONS = {
+  oidcPrompt: 'select_account',
+} as const satisfies { oidcPrompt: string };

--- a/apps/web/tests/unit/app/signin-page.test.tsx
+++ b/apps/web/tests/unit/app/signin-page.test.tsx
@@ -79,14 +79,14 @@ describe('signin page', () => {
     expect(
       screen.queryByText('Welcome back to Jovie.')
     ).not.toBeInTheDocument();
-    expect(screen.queryByText("Don't have access?")).not.toBeInTheDocument();
     expect(routerPrefetchMock).toHaveBeenCalledWith(APP_ROUTES.SIGNUP);
     expect(clerkSignInMock).toHaveBeenCalledWith(
       expect.objectContaining({
         routing: 'path',
         path: '/signin',
         oauthFlow: 'redirect',
-        signUpUrl: fullAuthUrl(APP_ROUTES.SIGNUP),
+        // Cross-link for sign-in → /waitlist (Jovie is invite-only). #48
+        signUpUrl: fullAuthUrl(APP_ROUTES.WAITLIST),
         fallbackRedirectUrl: APP_ROUTES.DASHBOARD,
         initialValues: undefined,
       })
@@ -125,6 +125,54 @@ describe('signin page', () => {
     );
   });
 
+  it('passes oidcPrompt=select_account to Clerk SignIn so account chooser always appears', async () => {
+    render(<SignInPage />);
+
+    await waitFor(() => {
+      expect(clerkSignInMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(clerkSignInMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        oidcPrompt: 'select_account',
+      })
+    );
+  });
+
+  it('shows access_denied banner when oauth_error=access_denied', async () => {
+    searchParamsState.value = 'oauth_error=access_denied';
+    globalThis.history.replaceState(
+      null,
+      '',
+      '/signin?oauth_error=access_denied'
+    );
+
+    render(<SignInPage />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Sign-in was cancelled. Try again, or pick a different method.'
+    );
+
+    await waitFor(() => {
+      expect(globalThis.location.search).not.toContain('oauth_error');
+    });
+  });
+
+  it('shows a generic banner for unknown oauth_error values', async () => {
+    searchParamsState.value = 'oauth_error=server_error';
+    globalThis.history.replaceState(
+      null,
+      '',
+      '/signin?oauth_error=server_error'
+    );
+
+    render(<SignInPage />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Something went wrong with sign-in. Please try again.'
+    );
+  });
+
   it('preserves redirect_url when linking from sign in to sign up', async () => {
     searchParamsState.value = 'redirect_url=%2Fonboarding';
 
@@ -136,7 +184,8 @@ describe('signin page', () => {
 
     expect(clerkSignInMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        signUpUrl: fullAuthUrl('/signup?redirect_url=%2Fonboarding'),
+        // Cross-link for sign-in preserves redirect params toward /waitlist. #48
+        signUpUrl: fullAuthUrl('/waitlist?redirect_url=%2Fonboarding'),
       })
     );
   });

--- a/apps/web/tests/unit/app/signup-page.test.tsx
+++ b/apps/web/tests/unit/app/signup-page.test.tsx
@@ -294,7 +294,7 @@ describe('signup page', () => {
     render(<SignUpPage />);
 
     expect(screen.getByRole('alert')).toHaveTextContent(
-      'Required permissions were not granted. Please try again and accept all permissions.'
+      'Sign-in was cancelled. Try again, or pick a different method.'
     );
 
     await waitFor(() => {
@@ -308,6 +308,36 @@ describe('signup page', () => {
         signInUrl: fullAuthUrl(
           '/signin?redirect_url=%2Fonboarding%3Fhandle%3Dartist'
         ),
+      })
+    );
+  });
+
+  it('interpolates the conflicting email into the account_exists banner when ?email= is present', async () => {
+    searchParamsState.value =
+      'oauth_error=account_exists&email=artist%40example.com';
+    globalThis.history.replaceState(
+      null,
+      '',
+      '/signup?oauth_error=account_exists&email=artist%40example.com'
+    );
+
+    render(<SignUpPage />);
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('artist@example.com');
+    expect(alert).toHaveTextContent('already exists');
+  });
+
+  it('passes oidcPrompt=select_account to Clerk SignUp so account chooser always appears', async () => {
+    render(<SignUpPage />);
+
+    await waitFor(() => {
+      expect(clerkSignUpMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(clerkSignUpMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        oidcPrompt: 'select_account',
       })
     );
   });

--- a/apps/web/tests/unit/lib/auth/clerk-options.test.ts
+++ b/apps/web/tests/unit/lib/auth/clerk-options.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { CLERK_COMPONENT_OPTIONS } from '@/lib/auth/clerk-options';
+
+describe('CLERK_COMPONENT_OPTIONS', () => {
+  it('includes oidcPrompt: select_account to force the provider account chooser', () => {
+    expect(CLERK_COMPONENT_OPTIONS.oidcPrompt).toBe('select_account');
+  });
+
+  it('is a plain object (safe to spread into Clerk SignIn / SignUp props)', () => {
+    expect(typeof CLERK_COMPONENT_OPTIONS).toBe('object');
+    expect(Array.isArray(CLERK_COMPONENT_OPTIONS)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- All Clerk OAuth flows now include `oidcPrompt: 'select_account'` via canonical `CLERK_COMPONENT_OPTIONS` in `lib/auth/clerk-options.ts` (forces account chooser on every OAuth attempt) — #85
- Sign-in cross-link updated: "Don't have access? Join the waitlist" → `/waitlist` (was `/signup`; Jovie is invite-only) — #48
- OAuth button accessible names deduplicated: `aria-label` removed from enabled `AuthProviderButtonSlot` buttons; visible text is the accessible name; `aria-label` only added when `disabled=true` to append "loading" suffix — #89
- `?oauth_error=access_denied` renders a `[role=alert]` banner on both `/signin` and `/signup` — #86
- `account_exists` banner on `/signup` interpolates `?email=` when present (e.g. from future SsoCallbackHandler forwarding) — #26
- `access_denied` copy standardised across both pages to "Sign-in was cancelled. Try again, or pick a different method." — #86
- `/signup` already correctly renders `<SignUp>` component (localization `Continue with {{provider|titleize}}` is in place) — #88
- SSO callback pages verified clean: `SsoCallbackHandler` uses explicit `fallbackRedirectUrl` props with no double `#/` fragments — #92

Tracks JOV-2394. Epic JOV-2182.

## Test plan
- [x] Vitest: 26 tests across 5 test files — all pass
- [x] Typecheck: zero errors
- [x] Biome lint: zero errors
- [x] Pre-push hooks: all pass
- [x] `/qa --exhaustive` — auth layout renders AuthUnavailableCard in mock mode; 26 unit tests across sign-in/sign-up/clerk-options cover all observable behaviors including oauth banners, oidcPrompt prop, and cross-link targets

## Cost Impact
None — code-level Clerk configuration changes only. No new external calls.

<!-- linear-issue-id: JOV-2394 -->