### PR TITLE
fix(shell): prevent transient audio snapshot reset

### DIFF
--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -175,7 +175,7 @@ export function PersistentAudioBar({
   useEffect(() => {
     if (!isShellAudioBar || !activeTrackId) {
       resetAudioChromeSnapshot();
-      return resetAudioChromeSnapshot;
+      return;
     }
 
     setAudioChromeSnapshot({
@@ -183,9 +183,11 @@ export function PersistentAudioBar({
       compactPlayerVisible,
       fullPlayerVisible: !compactPlayerVisible,
     });
-
-    return resetAudioChromeSnapshot;
   }, [activeTrackId, compactPlayerVisible, isShellAudioBar]);
+
+  useEffect(() => {
+    return resetAudioChromeSnapshot;
+  }, []);
 
   if (!activeTrackId) return null;
 


### PR DESCRIPTION
## Summary
- prevent the audio chrome snapshot from clearing during active player state updates
- keep the inactive/no-track reset behavior intact
- isolate reset-on-unmount in a cleanup-only effect

## Verification
- `pnpm exec biome check --write apps/web/components/organisms/PersistentAudioBar.tsx apps/web/tests/components/organisms/PersistentAudioBar.test.tsx apps/web/tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/components/organisms/PersistentAudioBar.test.tsx tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`

Linear: JOV-2398

<!-- agent-run-artifact
{
  "id": "pr-jov-2398-9dc32d08d90b-gstack-gates",
  "source": "github",
  "sourceRunId": "9dc32d08d90b799b8f6ee77558f81387dc8684b1",
  "kind": "qa",
  "status": "done",
  "title": "Audio snapshot cleanup gate evidence",
  "summary": "Recorded QA, review, and ship gate evidence for the transient audio snapshot reset fix.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr",
    "ready_pr",
    "merge",
    "mutate_linear"
  ],
  "forbiddenActions": [
    "deploy",
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2398",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2398/prevent-transient-audio-chrome-snapshot-reset-during-player-updates",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9085",
  "adminSurface": "/app/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9085",
      "summary": "Focused QA after rebase: 24 audio chrome component tests passed and @jovie/web typecheck passed. Pre-push passed before rebase.",
      "checkedAt": "2026-05-18T06:14:12.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9085/files",
      "summary": "Manual review verified reset-on-dependency-change is removed and reset-on-unmount is isolated.",
      "checkedAt": "2026-05-18T06:14:12.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9085",
      "summary": "Ship gate recorded: branch rebased on current main, local verification passed, and ready for CI/merge queue.",
      "checkedAt": "2026-05-18T06:14:12.000Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-05-18T06:14:12.000Z",
  "updatedAt": "2026-05-18T06:14:12.000Z",
  "metadata": {
    "sourceReview": "Follow-up to CodeRabbit discussion_r3256559753 on PR #9080."
  }
}
-->
