### PR TITLE
fix(chat): keep dictation control stable

### DIFF
--- a/apps/web/components/jovie/components/ChatComposerToolbar.tsx
+++ b/apps/web/components/jovie/components/ChatComposerToolbar.tsx
@@ -182,6 +182,7 @@ export interface ComposerMicButtonProps {
   readonly isListening: boolean;
   readonly isLoading: boolean;
   readonly isSubmitting: boolean;
+  readonly isSupported: boolean;
   readonly onMouseDown: (event: React.MouseEvent<HTMLButtonElement>) => void;
   readonly onToggle: () => void;
 }
@@ -190,24 +191,33 @@ export function ComposerMicButton({
   isListening,
   isLoading,
   isSubmitting,
+  isSupported,
   onMouseDown,
   onToggle,
 }: ComposerMicButtonProps) {
+  const label = isSupported
+    ? isListening
+      ? 'Stop dictation'
+      : 'Dictate message'
+    : 'Dictation unavailable';
+
   return (
-    <SimpleTooltip content={isListening ? 'Stop dictation' : 'Dictate message'}>
+    <SimpleTooltip content={label}>
       <button
         type='button'
         onMouseDown={onMouseDown}
         onClick={onToggle}
-        disabled={isLoading || isSubmitting}
+        disabled={isLoading || isSubmitting || !isSupported}
         className={cn(
           'flex h-9 w-9 shrink-0 items-center justify-center rounded-full transition-[background-color,color,box-shadow] duration-fast',
-          isListening
-            ? 'bg-red-500/15 text-red-400 hover:bg-red-500/20'
-            : 'text-tertiary-token hover:bg-white/[0.055] hover:text-primary-token hover:shadow-[inset_0_0_0_0.5px_rgba(255,255,255,0.055)]',
+          !isSupported
+            ? 'text-quaternary-token'
+            : isListening
+              ? 'bg-red-500/15 text-red-400 hover:bg-red-500/20'
+              : 'text-tertiary-token hover:bg-white/[0.055] hover:text-primary-token hover:shadow-[inset_0_0_0_0.5px_rgba(255,255,255,0.055)]',
           'disabled:cursor-not-allowed disabled:opacity-50'
         )}
-        aria-label={isListening ? 'Stop dictation' : 'Dictate message'}
+        aria-label={label}
         aria-pressed={isListening}
       >
         {isListening ? (

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -304,7 +304,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
     );
 
     const {
-      isSupported: hasDictation,
+      isSupported: isDictationSupported,
       isListening,
       toggle: toggleDictation,
     } = useSpeechRecognition({
@@ -525,7 +525,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                       plusMenuOpen={plusMenuOpen}
                       setPlusMenuOpen={setPlusMenuOpen}
                       handlePreserveFocus={handlePreserveFocus}
-                      hasDictation={hasDictation}
+                      isDictationSupported={isDictationSupported}
                       isListening={isListening}
                       handleMicToggle={handleMicToggle}
                       canSend={canSend}
@@ -599,7 +599,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                   plusMenuOpen={plusMenuOpen}
                   setPlusMenuOpen={setPlusMenuOpen}
                   handlePreserveFocus={handlePreserveFocus}
-                  hasDictation={hasDictation}
+                  isDictationSupported={isDictationSupported}
                   isListening={isListening}
                   handleMicToggle={handleMicToggle}
                   canSend={canSend}
@@ -703,7 +703,7 @@ interface InputRowProps {
   readonly handlePreserveFocus: (
     event: React.MouseEvent<HTMLButtonElement>
   ) => void;
-  readonly hasDictation: boolean;
+  readonly isDictationSupported: boolean;
   readonly isListening: boolean;
   readonly handleMicToggle: () => void;
   readonly canSend: boolean;
@@ -748,7 +748,7 @@ function InputRow({
   plusMenuOpen,
   setPlusMenuOpen,
   handlePreserveFocus,
-  hasDictation,
+  isDictationSupported,
   isListening,
   handleMicToggle,
   canSend,
@@ -856,15 +856,14 @@ function InputRow({
           </div>
 
           <div className='flex shrink-0 items-center gap-2'>
-            {hasDictation ? (
-              <ComposerMicButton
-                isListening={isListening}
-                isLoading={isLoading}
-                isSubmitting={isSubmitting}
-                onMouseDown={handlePreserveFocus}
-                onToggle={handleMicToggle}
-              />
-            ) : null}
+            <ComposerMicButton
+              isListening={isListening}
+              isLoading={isLoading}
+              isSubmitting={isSubmitting}
+              isSupported={isDictationSupported}
+              onMouseDown={handlePreserveFocus}
+              onToggle={handleMicToggle}
+            />
 
             <ComposerSendButton
               canSend={canSend}

--- a/apps/web/tests/unit/chat/ChatInput.test.tsx
+++ b/apps/web/tests/unit/chat/ChatInput.test.tsx
@@ -1,9 +1,9 @@
 import { TooltipProvider } from '@jovie/ui';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, screen, within } from '@testing-library/react';
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentProps, ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { ChatInput } from '@/components/jovie/components/ChatInput';
 import { fastRender } from '@/tests/utils/fast-render';
@@ -76,6 +76,41 @@ vi.mock('motion/react', () => ({
   AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
   useReducedMotion: () => false,
 }));
+
+class MockSpeechRecognition extends EventTarget {
+  static instances: MockSpeechRecognition[] = [];
+
+  continuous = false;
+  interimResults = false;
+  lang = '';
+  onresult: ((event: Event) => void) | null = null;
+  onend: (() => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  start = vi.fn();
+  stop = vi.fn();
+
+  constructor() {
+    super();
+    MockSpeechRecognition.instances.push(this);
+  }
+}
+
+function installMockSpeechRecognition() {
+  Object.defineProperty(window, 'SpeechRecognition', {
+    configurable: true,
+    value: MockSpeechRecognition,
+  });
+}
+
+function removeMockSpeechRecognition() {
+  MockSpeechRecognition.instances = [];
+  Reflect.deleteProperty(window, 'SpeechRecognition');
+  Reflect.deleteProperty(window, 'webkitSpeechRecognition');
+}
+
+afterEach(() => {
+  removeMockSpeechRecognition();
+});
 
 describe('ChatInput', () => {
   const baseProps = {
@@ -174,11 +209,53 @@ describe('ChatInput', () => {
       outline: 'none',
     });
 
-    for (const buttonName of [/attachment options/i, /send message/i]) {
+    for (const buttonName of [
+      /attachment options/i,
+      /dictation unavailable/i,
+      /send message/i,
+    ]) {
       expect(
         screen.getByRole('button', { name: buttonName }).className
       ).toMatch(/h-9 w-9/);
     }
+  });
+
+  it('keeps a quiet disabled dictation control when speech input is unavailable', () => {
+    fastRender(withProviders(<ChatInput {...baseProps} />));
+
+    const dictationButton = screen.getByRole('button', {
+      name: /dictation unavailable/i,
+    });
+
+    expect(dictationButton).toBeDisabled();
+    expect(screen.getByRole('button', { name: /send message/i })).toBeEnabled();
+  });
+
+  it('toggles dictation when speech input is supported', async () => {
+    const user = userEvent.setup();
+    installMockSpeechRecognition();
+
+    fastRender(withProviders(<ChatInput {...baseProps} />));
+
+    const dictationButton = await screen.findByRole('button', {
+      name: /dictate message/i,
+    });
+    await waitFor(() => expect(dictationButton).toBeEnabled());
+
+    await user.click(dictationButton);
+
+    expect(MockSpeechRecognition.instances).toHaveLength(1);
+    expect(MockSpeechRecognition.instances[0]?.start).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole('button', { name: /stop dictation/i })
+    ).toBeEnabled();
+
+    await user.click(screen.getByRole('button', { name: /stop dictation/i }));
+
+    expect(MockSpeechRecognition.instances[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole('button', { name: /dictate message/i })
+    ).toBeEnabled();
   });
 
   it('keeps structured chips inline with the editable text field', () => {


### PR DESCRIPTION
## Summary
- keep the shared chat mic slot rendered when speech input is unavailable
- show a quiet disabled `Dictation unavailable` state instead of removing the control
- add ChatInput coverage for unsupported and supported dictation toggles

## Design Review
- Checked /start desktop and mobile screenshots at 1280x900 and 390x844.
- Composer stays at the same pill geometry; mic and send controls remain 36px and aligned.
- Mobile composer remains above the viewport bottom with no chat overlap introduced by this slice.

## Verification
- `pnpm exec biome check --write apps/web/components/jovie/components/ChatComposerToolbar.tsx apps/web/components/jovie/components/ChatInput.tsx apps/web/tests/unit/chat/ChatInput.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/chat/ChatInput.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`

Linear: JOV-2397
GitHub issue: #9081

<!-- agent-run-artifact
{
  "id": "pr-jov-2397-cfb0deb99df7-gstack-gates",
  "source": "github",
  "sourceRunId": "cfb0deb99df7b076da755c38af2f0241b5383e60",
  "kind": "qa",
  "status": "done",
  "title": "Stable dictation affordance gate evidence",
  "summary": "Recorded QA, design review, and ship evidence for the shared chat dictation control.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr",
    "ready_pr",
    "merge",
    "mutate_linear"
  ],
  "forbiddenActions": [
    "deploy",
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2397",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2397/keep-chat-dictation-affordance-stable-when-speech-input-is-unavailable",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9086",
  "adminSurface": "/app/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9086",
      "summary": "Focused QA after rebase on post-#9085 main: ChatInput test suite passed and @jovie/web typecheck passed. Pre-push passed.",
      "checkedAt": "2026-05-18T06:15:29.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9086",
      "summary": "Design review checked /start desktop and mobile screenshots. Mic and send controls remain 36px, no composer shift or chat overlap observed.",
      "checkedAt": "2026-05-18T06:15:29.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9086",
      "summary": "Ship gate recorded: branch rebased on current main after #9085, local verification passed, and ready for CI.",
      "checkedAt": "2026-05-18T06:15:29.000Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-05-18T06:15:29.000Z",
  "updatedAt": "2026-05-18T06:15:29.000Z",
  "metadata": {
    "screenshots": [
      "/tmp/jov-2397-supported-desktop.png",
      "/tmp/jov-2397-supported-mobile.png"
    ],
    "localVerification": [
      "pnpm exec biome check --write apps/web/components/jovie/components/ChatComposerToolbar.tsx apps/web/components/jovie/components/ChatInput.tsx apps/web/tests/unit/chat/ChatInput.test.tsx",
      "pnpm --filter @jovie/web exec vitest run tests/unit/chat/ChatInput.test.tsx",
      "pnpm --filter @jovie/web run typecheck -- --pretty false"
    ]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the dictation feature with clearer feedback when voice input is unavailable. The microphone button now displays an "unavailable" state with appropriate messaging instead of hiding, providing better visibility into feature support on your device or browser.

* **Tests**
  * Added comprehensive tests for dictation availability and voice input functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9086?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->