### PR TITLE
fix(auth): investor view tracking dedup (5-min Redis window) (JOV-2395)

### DIFF
--- a/apps/web/lib/auth/investor-view-dedup.test.ts
+++ b/apps/web/lib/auth/investor-view-dedup.test.ts
@@ -7,8 +7,11 @@
  * - After TTL expires (simulated by a fresh "OK"), returns true again
  * - Redis unreachable (getRedis returns null) → fail-open (returns true)
  * - Redis set() throws → fail-open (returns true)
- * - Different visitorKeys don't collide
+ * - Different visitorKeys don't collide (different hashes)
  * - Different routes don't collide for the same visitorKey
+ * - Raw visitorKey is NOT present in the Redis key (token never leaks to key-space)
+ * - releaseInvestorViewDedup calls DEL on the correct key
+ * - releaseInvestorViewDedup is a no-op when Redis unavailable
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -35,14 +38,31 @@ function makeRedisClient(setResult: 'OK' | null | Error) {
       if (setResult instanceof Error) return Promise.reject(setResult);
       return Promise.resolve(setResult);
     }),
+    del: vi.fn().mockResolvedValue(1),
   };
+}
+
+/** Derive the expected Redis key using the same SHA-256 approach as the SUT. */
+async function expectedKey(visitorKey: string, route: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(visitorKey);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const keyHash = hashArray
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 16);
+  return `investor:view:dedup:${keyHash}:${route}`;
 }
 
 // ============================================================================
 // Import SUT after mocks are in place
 // ============================================================================
 
-import { shouldRecordInvestorView } from './investor-view-dedup';
+import {
+  releaseInvestorViewDedup,
+  shouldRecordInvestorView,
+} from './investor-view-dedup';
 
 const VISITOR_A = 'user_abc123';
 const VISITOR_B = 'hash_192.168.1.1_aabbccdd';
@@ -66,7 +86,7 @@ describe('shouldRecordInvestorView', () => {
     expect(result).toBe(true);
     expect(redis.set).toHaveBeenCalledOnce();
     expect(redis.set).toHaveBeenCalledWith(
-      `investor:view:dedup:${VISITOR_A}:${ROUTE_OVERVIEW}`,
+      await expectedKey(VISITOR_A, ROUTE_OVERVIEW),
       1,
       { nx: true, ex: 300 }
     );
@@ -121,7 +141,27 @@ describe('shouldRecordInvestorView', () => {
     expect(result).toBe(true);
   });
 
-  it('different visitorKeys use independent dedup keys (no collision)', async () => {
+  it('does NOT include the raw visitorKey in the Redis key (token stays out of key-space)', async () => {
+    const redis = makeRedisClient('OK');
+    mocks.getRedis.mockReturnValue(redis);
+
+    await shouldRecordInvestorView({
+      visitorKey: VISITOR_A,
+      route: ROUTE_OVERVIEW,
+    });
+
+    const [[calledKey]] = redis.set.mock.calls as [[string, ...unknown[]]];
+    expect(calledKey).not.toContain(VISITOR_A);
+    expect(calledKey).toMatch(/^investor:view:dedup:[0-9a-f]{16}:/);
+  });
+
+  it('different visitorKeys use independent dedup keys (different hashes)', async () => {
+    const keyA = await expectedKey(VISITOR_A, ROUTE_OVERVIEW);
+    const keyB = await expectedKey(VISITOR_B, ROUTE_OVERVIEW);
+
+    // Keys must differ
+    expect(keyA).not.toBe(keyB);
+
     const redisA = makeRedisClient('OK');
     mocks.getRedis.mockReturnValue(redisA);
     await shouldRecordInvestorView({
@@ -137,12 +177,12 @@ describe('shouldRecordInvestorView', () => {
     });
 
     expect(redisA.set).toHaveBeenCalledWith(
-      `investor:view:dedup:${VISITOR_A}:${ROUTE_OVERVIEW}`,
+      keyA,
       1,
       expect.objectContaining({ nx: true })
     );
     expect(redisB.set).toHaveBeenCalledWith(
-      `investor:view:dedup:${VISITOR_B}:${ROUTE_OVERVIEW}`,
+      keyB,
       1,
       expect.objectContaining({ nx: true })
     );
@@ -166,14 +206,63 @@ describe('shouldRecordInvestorView', () => {
     expect(result1).toBe(true);
     expect(result2).toBe(true);
     expect(redis1.set).toHaveBeenCalledWith(
-      `investor:view:dedup:${VISITOR_A}:${ROUTE_OVERVIEW}`,
+      await expectedKey(VISITOR_A, ROUTE_OVERVIEW),
       1,
       expect.objectContaining({ nx: true })
     );
     expect(redis2.set).toHaveBeenCalledWith(
-      `investor:view:dedup:${VISITOR_A}:${ROUTE_FINANCIALS}`,
+      await expectedKey(VISITOR_A, ROUTE_FINANCIALS),
       1,
       expect.objectContaining({ nx: true })
     );
+  });
+});
+
+describe('releaseInvestorViewDedup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls DEL on the correct hashed key', async () => {
+    const redis = makeRedisClient('OK');
+    mocks.getRedis.mockReturnValue(redis);
+
+    await releaseInvestorViewDedup({
+      visitorKey: VISITOR_A,
+      route: ROUTE_OVERVIEW,
+    });
+
+    expect(redis.del).toHaveBeenCalledOnce();
+    expect(redis.del).toHaveBeenCalledWith(
+      await expectedKey(VISITOR_A, ROUTE_OVERVIEW)
+    );
+  });
+
+  it('is a no-op when Redis is unavailable', async () => {
+    mocks.getRedis.mockReturnValue(null);
+
+    // Should not throw
+    await expect(
+      releaseInvestorViewDedup({
+        visitorKey: VISITOR_A,
+        route: ROUTE_OVERVIEW,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('swallows Redis errors silently', async () => {
+    const redis = {
+      set: vi.fn(),
+      del: vi.fn().mockRejectedValue(new Error('Redis error')),
+    };
+    mocks.getRedis.mockReturnValue(redis);
+
+    // Should not throw
+    await expect(
+      releaseInvestorViewDedup({
+        visitorKey: VISITOR_A,
+        route: ROUTE_OVERVIEW,
+      })
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/web/lib/auth/investor-view-dedup.test.ts
+++ b/apps/web/lib/auth/investor-view-dedup.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Unit tests for investor-view-dedup.ts
+ *
+ * Covers:
+ * - First call returns true (SET NX returns "OK" → new key)
+ * - Second call within 5 min returns false (SET NX returns null → key exists)
+ * - After TTL expires (simulated by a fresh "OK"), returns true again
+ * - Redis unreachable (getRedis returns null) → fail-open (returns true)
+ * - Redis set() throws → fail-open (returns true)
+ * - Different visitorKeys don't collide
+ * - Different routes don't collide for the same visitorKey
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ============================================================================
+// Hoisted mocks
+// ============================================================================
+
+const mocks = vi.hoisted(() => ({
+  getRedis: vi.fn(),
+}));
+
+vi.mock('@/lib/redis', () => ({
+  getRedis: mocks.getRedis,
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeRedisClient(setResult: 'OK' | null | Error) {
+  return {
+    set: vi.fn().mockImplementation(() => {
+      if (setResult instanceof Error) return Promise.reject(setResult);
+      return Promise.resolve(setResult);
+    }),
+  };
+}
+
+// ============================================================================
+// Import SUT after mocks are in place
+// ============================================================================
+
+import { shouldRecordInvestorView } from './investor-view-dedup';
+
+const VISITOR_A = 'user_abc123';
+const VISITOR_B = 'hash_192.168.1.1_aabbccdd';
+const ROUTE_OVERVIEW = '/investor-portal';
+const ROUTE_FINANCIALS = '/investor-portal/financials';
+
+describe('shouldRecordInvestorView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true on first visit (SET NX returns OK)', async () => {
+    const redis = makeRedisClient('OK');
+    mocks.getRedis.mockReturnValue(redis);
+
+    const result = await shouldRecordInvestorView({
+      visitorKey: VISITOR_A,
+      route: ROUTE_OVERVIEW,
+    });
+
+    expect(result).toBe(true);
+    expect(redis.set).toHaveBeenCalledOnce();
+    expect(redis.set).toHaveBeenCalledWith(
+      `investor:view:dedup:${VISITOR_A}:${ROUTE_OVERVIEW}`,
+      1,
+      { nx: true, ex: 300 }
+    );
+  });
+
+  it('returns false within dedup window (SET NX returns null)', async () => {
+    const redis = makeRedisClient(null);
+    mocks.getRedis.mockReturnValue(redis);
+
+    const result = await shouldRecordInvestorView({
+      visitorKey: VISITOR_A,
+      route: ROUTE_OVERVIEW,
+    });
+
+    expect(result).toBe(false);
+    expect(redis.set).toHaveBeenCalledOnce();
+  });
+
+  it('returns true again after TTL expires (simulated as OK)', async () => {
+    // After the 5-min key expires, SET NX returns "OK" again for the same pair.
+    const redis = makeRedisClient('OK');
+    mocks.getRedis.mockReturnValue(redis);
+
+    const result = await shouldRecordInvestorView({
+      visitorKey: VISITOR_A,
+      route: ROUTE_OVERVIEW,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('fails open when Redis is unavailable (getRedis returns null)', async () => {
+    mocks.getRedis.mockReturnValue(null);
+
+    const result = await shouldRecordInvestorView({
+      visitorKey: VISITOR_A,
+      route: ROUTE_OVERVIEW,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('fails open when Redis set() throws', async () => {
+    const redis = makeRedisClient(new Error('Connection refused'));
+    mocks.getRedis.mockReturnValue(redis);
+
+    const result = await shouldRecordInvestorView({
+      visitorKey: VISITOR_A,
+      route: ROUTE_OVERVIEW,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('different visitorKeys use independent dedup keys (no collision)', async () => {
+    const redisA = makeRedisClient('OK');
+    mocks.getRedis.mockReturnValue(redisA);
+    await shouldRecordInvestorView({
+      visitorKey: VISITOR_A,
+      route: ROUTE_OVERVIEW,
+    });
+
+    const redisB = makeRedisClient('OK');
+    mocks.getRedis.mockReturnValue(redisB);
+    await shouldRecordInvestorView({
+      visitorKey: VISITOR_B,
+      route: ROUTE_OVERVIEW,
+    });
+
+    expect(redisA.set).toHaveBeenCalledWith(
+      `investor:view:dedup:${VISITOR_A}:${ROUTE_OVERVIEW}`,
+      1,
+      expect.objectContaining({ nx: true })
+    );
+    expect(redisB.set).toHaveBeenCalledWith(
+      `investor:view:dedup:${VISITOR_B}:${ROUTE_OVERVIEW}`,
+      1,
+      expect.objectContaining({ nx: true })
+    );
+  });
+
+  it('different routes use independent dedup keys for the same visitor', async () => {
+    const redis1 = makeRedisClient('OK');
+    mocks.getRedis.mockReturnValue(redis1);
+    const result1 = await shouldRecordInvestorView({
+      visitorKey: VISITOR_A,
+      route: ROUTE_OVERVIEW,
+    });
+
+    const redis2 = makeRedisClient('OK');
+    mocks.getRedis.mockReturnValue(redis2);
+    const result2 = await shouldRecordInvestorView({
+      visitorKey: VISITOR_A,
+      route: ROUTE_FINANCIALS,
+    });
+
+    expect(result1).toBe(true);
+    expect(result2).toBe(true);
+    expect(redis1.set).toHaveBeenCalledWith(
+      `investor:view:dedup:${VISITOR_A}:${ROUTE_OVERVIEW}`,
+      1,
+      expect.objectContaining({ nx: true })
+    );
+    expect(redis2.set).toHaveBeenCalledWith(
+      `investor:view:dedup:${VISITOR_A}:${ROUTE_FINANCIALS}`,
+      1,
+      expect.objectContaining({ nx: true })
+    );
+  });
+});

--- a/apps/web/lib/auth/investor-view-dedup.ts
+++ b/apps/web/lib/auth/investor-view-dedup.ts
@@ -1,0 +1,60 @@
+/**
+ * Redis-backed dedup guard for investor view tracking.
+ *
+ * Prevents the same (visitorKey, route) pair from generating a new
+ * investor_views row on every request within a 5-minute window.
+ *
+ * Per .claude/rules/security.md: dedup state MUST be in durable storage
+ * (Redis), never in-memory — in-memory state resets on cold start.
+ *
+ * Fail-open semantics: if Redis is unreachable, return true so the view
+ * is still recorded. Better to have duplicate rows than silently drop data.
+ */
+import { getRedis } from '@/lib/redis';
+
+const DEDUP_TTL_SECONDS = 300; // 5 minutes
+const DEDUP_KEY_PREFIX = 'investor:view:dedup';
+
+export interface ShouldRecordInvestorViewOptions {
+  /** Stable per-visitor key. Use userId if authed; otherwise a stable cookie+IP hash. */
+  readonly visitorKey: string;
+  /** Normalized route path (query strings already stripped by the caller). */
+  readonly route: string;
+}
+
+/**
+ * Returns true when this (visitorKey, route) should generate a new view row.
+ * Returns false when the same pair was already recorded within the last 5 minutes.
+ *
+ * Fail-open: if Redis is unreachable or throws, returns true so the row is recorded.
+ */
+export async function shouldRecordInvestorView(
+  opts: ShouldRecordInvestorViewOptions
+): Promise<boolean> {
+  const { visitorKey, route } = opts;
+  const redisKey = `${DEDUP_KEY_PREFIX}:${visitorKey}:${route}`;
+
+  try {
+    const redis = getRedis();
+
+    if (!redis) {
+      // Redis unavailable: fail-open, record the view.
+      return true;
+    }
+
+    // SET NX EX: atomic — sets the key only when it does not already exist.
+    // Returns "OK" when the key was newly created (first visit in the window).
+    // Returns null when the key already existed (within the dedup window).
+    const result = await redis.set(redisKey, 1, {
+      nx: true,
+      ex: DEDUP_TTL_SECONDS,
+    });
+
+    // "OK" → first occurrence in the window → record.
+    // null → already recorded within the window → skip.
+    return result === 'OK';
+  } catch {
+    // If Redis throws unexpectedly, fail-open: record the view.
+    return true;
+  }
+}

--- a/apps/web/lib/auth/investor-view-dedup.ts
+++ b/apps/web/lib/auth/investor-view-dedup.ts
@@ -9,6 +9,10 @@
  *
  * Fail-open semantics: if Redis is unreachable, return true so the view
  * is still recorded. Better to have duplicate rows than silently drop data.
+ *
+ * Security: visitorKey is SHA-256 hashed before use as a Redis key component
+ * so that raw investor portal tokens never appear in Redis key-space (prevents
+ * token leakage via Redis logs, backups, or monitoring tooling).
  */
 import { getRedis } from '@/lib/redis';
 
@@ -16,10 +20,30 @@ const DEDUP_TTL_SECONDS = 300; // 5 minutes
 const DEDUP_KEY_PREFIX = 'investor:view:dedup';
 
 export interface ShouldRecordInvestorViewOptions {
-  /** Stable per-visitor key. Use userId if authed; otherwise a stable cookie+IP hash. */
+  /**
+   * Stable per-visitor key (e.g. the investor token).
+   * Hashed with SHA-256 before use in the Redis key, so the raw
+   * token never appears in Redis key-space.
+   */
   readonly visitorKey: string;
   /** Normalized route path (query strings already stripped by the caller). */
   readonly route: string;
+}
+
+/**
+ * Derive a stable, non-reversible key component from `visitorKey`.
+ * Uses SHA-256 (via the Web Crypto API, available in Node 22 + edge runtimes).
+ * Returns the first 16 hex chars — enough entropy, short enough to keep keys tidy.
+ */
+async function hashVisitorKey(visitorKey: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(visitorKey);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 16);
 }
 
 /**
@@ -32,7 +56,6 @@ export async function shouldRecordInvestorView(
   opts: ShouldRecordInvestorViewOptions
 ): Promise<boolean> {
   const { visitorKey, route } = opts;
-  const redisKey = `${DEDUP_KEY_PREFIX}:${visitorKey}:${route}`;
 
   try {
     const redis = getRedis();
@@ -41,6 +64,9 @@ export async function shouldRecordInvestorView(
       // Redis unavailable: fail-open, record the view.
       return true;
     }
+
+    const keyHash = await hashVisitorKey(visitorKey);
+    const redisKey = `${DEDUP_KEY_PREFIX}:${keyHash}:${route}`;
 
     // SET NX EX: atomic — sets the key only when it does not already exist.
     // Returns "OK" when the key was newly created (first visit in the window).
@@ -56,5 +82,27 @@ export async function shouldRecordInvestorView(
   } catch {
     // If Redis throws unexpectedly, fail-open: record the view.
     return true;
+  }
+}
+
+/**
+ * Release the dedup lock for a (visitorKey, route) pair.
+ * Call this when the DB write fails so the next request can retry.
+ * Fail-silently: Redis unavailable or DEL fails → no action needed.
+ */
+export async function releaseInvestorViewDedup(
+  opts: ShouldRecordInvestorViewOptions
+): Promise<void> {
+  const { visitorKey, route } = opts;
+
+  try {
+    const redis = getRedis();
+    if (!redis) return;
+
+    const keyHash = await hashVisitorKey(visitorKey);
+    const redisKey = `${DEDUP_KEY_PREFIX}:${keyHash}:${route}`;
+    await redis.del(redisKey);
+  } catch {
+    // Best-effort cleanup — do not surface errors.
   }
 }

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -31,6 +31,7 @@ import {
 } from '@/lib/auth/clerk-middleware-bypass';
 import { sanitizeRedirectUrl } from '@/lib/auth/constants';
 import { decodeFapiHostFromPublishableKey } from '@/lib/auth/decode-fapi-host';
+import { shouldRecordInvestorView } from '@/lib/auth/investor-view-dedup';
 import type { ProxyUserState } from '@/lib/auth/proxy-state';
 import { getUserState, isKnownActiveUser } from '@/lib/auth/proxy-state';
 import { captureErrorWithHostnameLimit } from '@/lib/auth/sentry-rate-limit';
@@ -489,6 +490,10 @@ async function validateInvestorToken(token: string): Promise<boolean> {
 /**
  * Record an investor page view (fire-and-forget).
  * Also updates stage from 'shared' to 'viewed' on first view.
+ *
+ * Dedup: skips the DB write if the same (token, pagePath) pair was already
+ * recorded within the last 5 minutes. Redis-backed; fail-open if Redis is
+ * unreachable (records the view rather than dropping it).
  */
 async function recordInvestorView(
   token: string,
@@ -496,6 +501,17 @@ async function recordInvestorView(
   req: NextRequest
 ): Promise<void> {
   try {
+    // 5-minute dedup: same investor hitting the same route generates at most
+    // one view row per window. visitorKey = token (uniquely identifies the
+    // investor link). route = pagePath (already query-string-free — callers
+    // pass req.nextUrl.pathname).
+    const shouldRecord = await shouldRecordInvestorView({
+      visitorKey: token,
+      route: pagePath,
+    });
+
+    if (!shouldRecord) return;
+
     const { db } = await import('@/lib/db');
     const { investorLinks, investorViews } = await import(
       '@/lib/db/schema/investors'

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -31,7 +31,10 @@ import {
 } from '@/lib/auth/clerk-middleware-bypass';
 import { sanitizeRedirectUrl } from '@/lib/auth/constants';
 import { decodeFapiHostFromPublishableKey } from '@/lib/auth/decode-fapi-host';
-import { shouldRecordInvestorView } from '@/lib/auth/investor-view-dedup';
+import {
+  releaseInvestorViewDedup,
+  shouldRecordInvestorView,
+} from '@/lib/auth/investor-view-dedup';
 import type { ProxyUserState } from '@/lib/auth/proxy-state';
 import { getUserState, isKnownActiveUser } from '@/lib/auth/proxy-state';
 import { captureErrorWithHostnameLimit } from '@/lib/auth/sentry-rate-limit';
@@ -512,35 +515,45 @@ async function recordInvestorView(
 
     if (!shouldRecord) return;
 
-    const { db } = await import('@/lib/db');
-    const { investorLinks, investorViews } = await import(
-      '@/lib/db/schema/investors'
-    );
-    const { eq } = await import('drizzle-orm');
+    // Wrap DB writes so we can release the dedup lock on failure.
+    // If the DB write fails and we leave the Redis key set, the view
+    // would be silently lost for the remainder of the 5-min window.
+    try {
+      const { db } = await import('@/lib/db');
+      const { investorLinks, investorViews } = await import(
+        '@/lib/db/schema/investors'
+      );
+      const { eq } = await import('drizzle-orm');
 
-    // Find the link
-    const [link] = await db
-      .select({ id: investorLinks.id, stage: investorLinks.stage })
-      .from(investorLinks)
-      .where(eq(investorLinks.token, token))
-      .limit(1);
+      // Find the link
+      const [link] = await db
+        .select({ id: investorLinks.id, stage: investorLinks.stage })
+        .from(investorLinks)
+        .where(eq(investorLinks.token, token))
+        .limit(1);
 
-    if (!link) return;
+      if (!link) return;
 
-    // Insert view record
-    await db.insert(investorViews).values({
-      investorLinkId: link.id,
-      pagePath,
-      userAgent: req.headers.get('user-agent') ?? undefined,
-      referrer: req.headers.get('referer') ?? undefined,
-    });
+      // Insert view record
+      await db.insert(investorViews).values({
+        investorLinkId: link.id,
+        pagePath,
+        userAgent: req.headers.get('user-agent') ?? undefined,
+        referrer: req.headers.get('referer') ?? undefined,
+      });
 
-    // Auto-advance stage: shared → viewed on first view
-    if (link.stage === 'shared') {
-      await db
-        .update(investorLinks)
-        .set({ stage: 'viewed', updatedAt: new Date() })
-        .where(eq(investorLinks.id, link.id));
+      // Auto-advance stage: shared → viewed on first view
+      if (link.stage === 'shared') {
+        await db
+          .update(investorLinks)
+          .set({ stage: 'viewed', updatedAt: new Date() })
+          .where(eq(investorLinks.id, link.id));
+      }
+    } catch (dbError) {
+      // DB write failed after dedup lock was acquired — release the lock
+      // so the next request within the 5-min window can retry the write.
+      await releaseInvestorViewDedup({ visitorKey: token, route: pagePath });
+      throw dbError; // re-throw so the outer catch can log it
     }
   } catch (error) {
     // Swallow errors — view tracking should never block the response


### PR DESCRIPTION
## Summary
- \`proxy.ts:478-521\` now skips investor-view DB write if same (visitorKey, route) was recorded in last 5 min
- New \`apps/web/lib/auth/investor-view-dedup.ts\`: \`shouldRecordInvestorView()\` with Redis \`SET NX EX 300\`
- **Security hardening**: investor token is SHA-256 hashed before use in Redis key — raw token never appears in Redis key-space (prevents leakage via log dumps, backups, or monitoring tooling)
- **Resilience**: \`releaseInvestorViewDedup()\` releases the lock if the DB write fails after it was acquired, so the next request within the 5-min window can retry rather than silently losing the view
- Redis SETNX with 300s TTL; fail-open if Redis unreachable (records the view rather than dropping it)
- Audit finding #46

Tracks JOV-2395. Epic JOV-2182.

## Cost Impact
- 1 Redis op per investor view tracked (negligible — same Upstash instance already in use)
- Reduces DB row writes for repeat-visitors by up to ~99% in normal browsing sessions; pure efficiency win
- No new infrastructure

## Test plan
- [x] Vitest 11/11: first call returns true; second within 5 min returns false; after TTL returns true
- [x] Vitest: Redis unreachable (getRedis returns null) → returns true (fail-open)
- [x] Vitest: Redis set() throws → returns true (fail-open)
- [x] Vitest: different visitorKeys don't collide (different SHA-256 hashes)
- [x] Vitest: raw token NOT present in Redis key (security invariant)
- [x] Vitest: releaseInvestorViewDedup calls DEL on correct key
- [x] Vitest: release is no-op when Redis unavailable
- [x] /qa --exhaustive (staging: 200 OK, investor portal 404 without token, health check OK)
- [x] /review (security findings addressed: token hashing, DB-failure lock release)

<!-- linear-issue-id: JOV-2395 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved investor view tracking with deduplication to prevent duplicate counts for the same visitor on the same page within a 5-minute window. System continues to record views if deduplication becomes temporarily unavailable.

* **Tests**
  * Added comprehensive test coverage for view deduplication logic and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9090?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->