### PR TITLE
JOV-2405: Unify shell header action registration

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
@@ -6,7 +6,6 @@ import {
   Suspense,
   useCallback,
   useDeferredValue,
-  useEffect,
   useMemo,
   useState,
 } from 'react';
@@ -18,7 +17,7 @@ import {
 } from '@/components/molecules/drawer';
 import { PageShell } from '@/components/organisms/PageShell';
 import type { TrackSidebarData } from '@/components/organisms/release-sidebar';
-import { useSetHeaderActions } from '@/contexts/HeaderActionsContext';
+import { useRegisterHeaderActions } from '@/contexts/HeaderActionsContext';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import { openChatWithPrompt } from '@/lib/chat/open-chat-with-prompt';
 import type { ReleaseViewModel } from '@/lib/discography/types';
@@ -399,8 +398,6 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
     openEditor,
   });
 
-  const { setHeaderActions } = useSetHeaderActions();
-
   const syncAction = experienceAdapter?.onSync ?? handleSync;
 
   const headerActions = useMemo(
@@ -415,13 +412,7 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
     [canCreateManualReleases, handleNewRelease, isSyncing, syncAction]
   );
 
-  useEffect(() => {
-    setHeaderActions(headerActions);
-
-    return () => {
-      setHeaderActions(null);
-    };
-  }, [headerActions, setHeaderActions]);
+  useRegisterHeaderActions(headerActions);
 
   const releaseSidebarHandlers = useMemo(
     () => ({

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { Suspense, useCallback, useMemo, useState } from 'react';
 import { Icon } from '@/components/atoms/Icon';
 import {
   DrawerButton,
@@ -21,8 +21,8 @@ import type {
   FilterPill,
 } from '@/components/shell/pill-search.types';
 import {
+  useRegisterHeaderActions,
   useRegisterHeaderSearch,
-  useSetHeaderActions,
 } from '@/contexts/HeaderActionsContext';
 import { buildReleaseActions } from '@/features/dashboard/organisms/releases/release-actions';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
@@ -346,7 +346,6 @@ export function ShellReleasesView({
     router,
     captureContext: 'shell-releases-view',
   });
-  const { setHeaderActions } = useSetHeaderActions();
   const albumArtFlagEnabled = useAppFlag('ALBUM_ART_GENERATION');
 
   const [pills, setPills] = useState<FilterPill[]>([]);
@@ -829,10 +828,7 @@ export function ShellReleasesView({
     );
   }, [canCreateManualReleases, handleNewRelease, handleSync, isSyncing]);
 
-  useEffect(() => {
-    setHeaderActions(headerActions);
-    return () => setHeaderActions(null);
-  }, [headerActions, setHeaderActions]);
+  useRegisterHeaderActions(headerActions);
 
   useReleaseRightPanelTableMeta({
     rows,

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -73,7 +73,7 @@ import {
 } from '@/components/organisms/table/utils/tableKeyMap';
 import { useViewMode } from '@/components/organisms/table/utils/useViewMode';
 import { APP_ROUTES } from '@/constants/routes';
-import { useSetHeaderActions } from '@/contexts/HeaderActionsContext';
+import { useRegisterHeaderActions } from '@/contexts/HeaderActionsContext';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
@@ -1270,7 +1270,6 @@ export function TasksPageClient() {
   const router = useRouter();
   const designV1TasksEnabled = useAppFlag('DESIGN_V1');
   const { selectedProfile } = useDashboardData();
-  const { setHeaderActions } = useSetHeaderActions();
   const isDesktopTaskLayout = useBreakpoint('lg');
   const [hasResolvedResponsiveLayout, setHasResolvedResponsiveLayout] =
     useState(false);
@@ -1868,13 +1867,7 @@ export function TasksPageClient() {
     [headerMode]
   );
 
-  useEffect(() => {
-    setHeaderActions(headerActions);
-
-    return () => {
-      setHeaderActions(null);
-    };
-  }, [headerActions, setHeaderActions]);
+  useRegisterHeaderActions(headerActions);
 
   const renderTaskCell = useCallback(
     (info: { row: { original: TaskView } }) => (

--- a/apps/web/contexts/HeaderActionsContext.tsx
+++ b/apps/web/contexts/HeaderActionsContext.tsx
@@ -92,23 +92,14 @@ export interface HeaderActionsProviderProps {
 /**
  * HeaderActionsProvider - Allows pages to register custom header actions
  *
- * Pages can use the useSetHeaderActions hook to set custom actions that will
+ * Pages can use `useRegisterHeaderActions` to set custom actions that will
  * appear in the app shell's header instead of the default actions.
  *
  * @example
  * ```tsx
  * function MyPageWrapper() {
- *   const { setHeaderActions } = useSetHeaderActions();
- *
- *   useEffect(() => {
- *     setHeaderActions(
- *       <div className='flex items-center gap-1'>
- *         <CustomButton />
- *         <div className='h-6 w-px bg-border' />
- *         <DrawerToggleButton />
- *       </div>
- *     );
- *   }, [setHeaderActions]);
+ *   const actions = useMemo(() => <CustomButton />, []);
+ *   useRegisterHeaderActions(actions);
  *
  *   return <PageContent />;
  * }
@@ -236,4 +227,23 @@ export function useRegisterHeaderSearch(
     setAdapter(adapter);
     return () => setAdapter(null);
   }, [adapter, setAdapter]);
+}
+
+/**
+ * useRegisterHeaderActions - Register route-owned actions with the shell header.
+ *
+ * Routes own the action semantics; the shell owns placement, error isolation,
+ * and cleanup on navigation. This mirrors `useRegisterHeaderSearch` so shell
+ * routes do not each reimplement the same set-on-mount / clear-on-unmount
+ * lifecycle.
+ */
+export function useRegisterHeaderActions(actions: ReactNode): void {
+  const dispatch = useContext(HeaderActionsDispatchContext);
+  const setActions = dispatch?.setHeaderActions;
+
+  useEffect(() => {
+    if (!setActions) return undefined;
+    setActions(actions);
+    return () => setActions(null);
+  }, [actions, setActions]);
 }

--- a/apps/web/tests/unit/contexts/HeaderActionsContext.test.tsx
+++ b/apps/web/tests/unit/contexts/HeaderActionsContext.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { type ReactNode, useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import {
+  HeaderActionsProvider,
+  useOptionalHeaderActions,
+  useRegisterHeaderActions,
+} from '@/contexts/HeaderActionsContext';
+
+function HeaderActionsProbe() {
+  const state = useOptionalHeaderActions();
+
+  return <div data-testid='header-actions-probe'>{state?.headerActions}</div>;
+}
+
+function RouteActionRegistration({
+  children,
+}: {
+  readonly children: ReactNode;
+}) {
+  useRegisterHeaderActions(children);
+  return null;
+}
+
+function ToggleRouteActions() {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <>
+      <button type='button' onClick={() => setExpanded(value => !value)}>
+        Toggle
+      </button>
+      <RouteActionRegistration>
+        <button type='button'>
+          {expanded ? 'Expanded Action' : 'Base Action'}
+        </button>
+      </RouteActionRegistration>
+    </>
+  );
+}
+
+describe('HeaderActionsContext', () => {
+  it('registers and clears route-owned header actions', () => {
+    const view = render(
+      <HeaderActionsProvider>
+        <RouteActionRegistration>
+          <button type='button'>New Task</button>
+        </RouteActionRegistration>
+        <HeaderActionsProbe />
+      </HeaderActionsProvider>
+    );
+
+    expect(screen.getByRole('button', { name: 'New Task' })).toBeDefined();
+
+    view.rerender(
+      <HeaderActionsProvider>
+        <HeaderActionsProbe />
+      </HeaderActionsProvider>
+    );
+
+    expect(screen.queryByRole('button', { name: 'New Task' })).toBeNull();
+  });
+
+  it('updates the registered actions when route state changes', () => {
+    render(
+      <HeaderActionsProvider>
+        <ToggleRouteActions />
+        <HeaderActionsProbe />
+      </HeaderActionsProvider>
+    );
+
+    expect(screen.getByRole('button', { name: 'Base Action' })).toBeDefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));
+
+    expect(
+      screen.getByRole('button', { name: 'Expanded Action' })
+    ).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Base Action' })).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -255,11 +255,21 @@ vi.mock('@/app/app/(shell)/dashboard/DashboardDataContext', () => ({
   }),
 }));
 
-vi.mock('@/contexts/HeaderActionsContext', () => ({
-  useSetHeaderActions: () => ({
-    setHeaderActions: setHeaderActionsForTest,
-  }),
-}));
+vi.mock('@/contexts/HeaderActionsContext', async () => {
+  const ReactModule = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    useRegisterHeaderActions: (actions: React.ReactNode) => {
+      ReactModule.useEffect(() => {
+        setHeaderActionsForTest(actions);
+        return () => setHeaderActionsForTest(null);
+      }, [actions]);
+    },
+    useSetHeaderActions: () => ({
+      setHeaderActions: setHeaderActionsForTest,
+    }),
+  };
+});
 
 vi.mock('@/hooks/useRegisterRightPanel', () => ({
   useRegisterRightPanel: mockRegisterRightPanel,


### PR DESCRIPTION
## Summary
- Added `useRegisterHeaderActions` so route-owned header actions follow the same shell lifecycle contract as header search.
- Migrated shell releases, legacy releases, and tasks to the shared registration hook.
- Added context coverage proving registered actions update and clear on route unmount.

## Verification
- `pnpm biome check --write apps/web/contexts/HeaderActionsContext.tsx apps/web/components/features/dashboard/tasks/TasksPageClient.tsx apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx apps/web/tests/unit/dashboard/TasksPageClient.test.tsx apps/web/tests/unit/contexts/HeaderActionsContext.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/contexts/HeaderActionsContext.test.tsx tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx tests/unit/dashboard/ReleaseProviderMatrix.test.tsx tests/unit/dashboard/TasksPageClient.test.tsx --pool=forks --maxWorkers=2`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Browser smoke on `http://localhost:3001`: `/app/releases`, `/app/tasks`, `/app/library`, and mobile `/app/tasks`; screenshots in `/private/tmp/jov-2405-shell-header-actions`.
- Push hook: root Biome, web proxy guard, Tailwind guard, typecheck, and Biome lint passed.

<!-- agent-run-artifact
{
  "id": "jov-2405-shell-header-actions-20260518",
  "source": "github",
  "sourceRunId": "963c36db17ddb8800cf9cbe365360995198d2506",
  "kind": "workflow",
  "status": "done",
  "title": "JOV-2405 shell header action registration",
  "summary": "Unified route-owned app shell header action registration across shell releases, legacy releases, and tasks while preserving leaf-route data ownership and visual output.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2405",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2405/unify-shell-page-header-actions-across-app-routes",
  "pullRequestUrl": null,
  "adminSurface": "/app/releases",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused unit route coverage plus browser smoke across releases, tasks, library, and mobile tasks with no auth fallback; screenshots captured in /private/tmp/jov-2405-shell-header-actions.",
      "checkedAt": "2026-05-18T09:29:19Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review confirms route data ownership remains in leaves; change only replaces duplicated set/clear header-action lifecycle with shared hook.",
      "checkedAt": "2026-05-18T09:29:19Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, focused Vitest, web typecheck, commit hook, and push hook passed before PR creation.",
      "checkedAt": "2026-05-18T09:29:19Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-05-18T09:29:19Z",
  "updatedAt": "2026-05-18T09:29:19Z",
  "metadata": {
    "branch": "codex/jov-2405-shell-page-header-actions",
    "screenshotsDir": "/private/tmp/jov-2405-shell-header-actions"
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal header actions management in dashboard components for better code maintainability and lifecycle consistency.

* **Tests**
  * Added comprehensive unit test coverage for header actions registration and lifecycle behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->