### PR TITLE
JOV-2406: Unify task shell subview tabs

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
@@ -7,6 +7,7 @@ import {
   TableFilterDropdown,
   type TableFilterDropdownCategory,
 } from '@/components/molecules/filters';
+import { TabBar } from '@/components/molecules/tab-bar/TabBar';
 import {
   PageToolbar,
   PageToolbarActionButton,
@@ -244,43 +245,25 @@ export function TaskSubviewTabs({
   }
 
   return (
-    <div
-      role='tablist'
-      aria-label='Task subviews'
-      className={cn(
-        'flex min-w-0 items-center gap-0.5 overflow-x-auto pl-0.5',
-        className
-      )}
-    >
-      {subviews.map(subview => {
-        const isActive = activeSubview === subview.id;
-
-        return (
-          <button
-            key={subview.id}
-            type='button'
-            role='tab'
-            aria-selected={isActive}
-            onClick={() => onSubviewChange(subview.id)}
-            className={cn(
-              'inline-flex h-7 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-[12.5px] font-semibold tracking-[-0.012em] transition-[background-color,color]',
-              isActive
-                ? 'bg-surface-1 text-primary-token'
-                : 'text-tertiary-token hover:bg-surface-1 hover:text-primary-token'
-            )}
-          >
+    <TabBar<TaskSubviewId>
+      value={activeSubview}
+      onValueChange={onSubviewChange}
+      ariaLabel='Task subviews'
+      overflowMode='scroll'
+      variant='segment'
+      className={cn('pl-0.5', className)}
+      triggerClassName='gap-1.5 px-2.5 text-[12.5px]'
+      options={subviews.map(subview => ({
+        value: subview.id,
+        label: (
+          <span className='inline-flex min-w-0 items-center gap-1.5'>
             <span>{subview.label}</span>
-            <span
-              className={cn(
-                'text-[10.5px] tabular-nums',
-                isActive ? 'text-tertiary-token' : 'text-quaternary-token'
-              )}
-            >
+            <span className='text-[10.5px] tabular-nums opacity-70'>
               {subview.count}
             </span>
-          </button>
-        );
-      })}
-    </div>
+          </span>
+        ),
+      }))}
+    />
   );
 }

--- a/apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
@@ -21,6 +21,37 @@ vi.mock('@/components/molecules/filters', () => ({
   TableFilterDropdown: () => <button type='button'>Filters</button>,
 }));
 
+vi.mock('@/components/molecules/tab-bar/TabBar', () => ({
+  TabBar: ({
+    value,
+    onValueChange,
+    options,
+    ariaLabel,
+  }: {
+    readonly value: string;
+    readonly onValueChange: (value: string) => void;
+    readonly options: ReadonlyArray<{
+      readonly value: string;
+      readonly label: ReactNode;
+    }>;
+    readonly ariaLabel: string;
+  }) => (
+    <div role='tablist' aria-label={ariaLabel}>
+      {options.map(option => (
+        <button
+          key={option.value}
+          type='button'
+          role='tab'
+          aria-selected={value === option.value}
+          onClick={() => onValueChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
 vi.mock('@/components/organisms/table', () => ({
   PageToolbar: ({
     start,


### PR DESCRIPTION
## Summary
- Replaced the bespoke `/app/tasks` subview button strip with the shared shell `TabBar` segment primitive.
- Preserved task subview counts, tab semantics, click behavior, and scroll overflow behavior.
- Updated focused task toolbar tests to assert the shared tab lifecycle contract without coupling to route-local styling.

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx tests/unit/components/table/PageToolbar.test.tsx --pool=forks --maxWorkers=2`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Browser smoke on `http://localhost:3001/app/tasks` at desktop `1440x960` and mobile `390x844`; screenshots in `/private/tmp/jov-2406-task-tabs`.
- Commit hook: proxy guard, lint-staged Biome, ESLint, a11y staged check, and local web typecheck passed.

<!-- agent-run-artifact
{
  "id": "jov-2406-task-shell-tabs-20260518",
  "source": "github",
  "sourceRunId": "ee389a653f8dd0d180ee03717386fff0aacd8b96",
  "kind": "workflow",
  "status": "done",
  "title": "JOV-2406 task shell subview tabs",
  "summary": "Moved the task workspace subview tabs onto the shared shell TabBar segment primitive to reduce route-local toolbar drift while preserving task query and selection behavior.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2406",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2406/unify-task-shell-subview-tabs-with-shared-toolbar-tabs",
  "pullRequestUrl": null,
  "adminSurface": "/app/tasks",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused task toolbar unit tests plus desktop and mobile browser smoke on /app/tasks confirmed tab semantics, task workspace render, and no horizontal overflow.",
      "checkedAt": "2026-05-18T09:50:16Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review confirms the slice only replaces task toolbar tab chrome with the shared TabBar primitive; task data fetching, mutation, and routing behavior are unchanged.",
      "checkedAt": "2026-05-18T09:50:16Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, focused Vitest, web typecheck, and commit hook passed before PR creation.",
      "checkedAt": "2026-05-18T09:50:16Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-05-18T09:50:16Z",
  "updatedAt": "2026-05-18T09:50:16Z",
  "metadata": {
    "branch": "codex/jov-2406-shell-table-toolbar",
    "screenshotsDir": "/private/tmp/jov-2406-task-tabs"
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated task subview tab switching implementation to use a shared component for improved code maintainability and consistency.

* **Tests**
  * Enhanced unit test coverage for task workspace header bar with updated mock implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9105?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->