### PR TITLE
JOV-2407: Unify task toolbar search

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { Button, Input } from '@jovie/ui';
-import { ArrowDown, ArrowUp, Search, Settings2, X } from 'lucide-react';
+import { ArrowDown, ArrowUp, Settings2 } from 'lucide-react';
 import type { FormEvent } from 'react';
 import {
   TableFilterDropdown,
   type TableFilterDropdownCategory,
 } from '@/components/molecules/filters';
+import { HeaderSearchAction } from '@/components/molecules/HeaderSearchAction';
 import { TabBar } from '@/components/molecules/tab-bar/TabBar';
 import {
   PageToolbar,
@@ -130,30 +131,16 @@ export function TaskWorkspaceHeaderBar({
       </>
     ) : (
       <>
-        <div className='relative hidden h-7 w-[min(12rem,24vw)] min-w-[9rem] items-center lg:flex'>
-          <Search
-            className='pointer-events-none absolute bottom-0 left-2 top-0 my-auto h-3.5 w-3.5 text-quaternary-token'
-            aria-hidden='true'
-          />
-          <Input
-            type='search'
-            value={searchValue}
-            onChange={event => onSearchValueChange(event.target.value)}
-            placeholder='Search tasks'
-            aria-label='Search tasks'
-            className='h-7 w-full rounded-md border-border-token bg-surface-0 py-0 pl-7 pr-7 text-[12.5px] text-primary-token placeholder:text-quaternary-token'
-          />
-          {searchValue ? (
-            <button
-              type='button'
-              aria-label='Clear task search'
-              onClick={onClearSearch}
-              className='absolute bottom-0 right-1 top-0 my-auto inline-flex h-5 w-5 items-center justify-center rounded text-quaternary-token transition-[background-color,color] hover:bg-surface-1 hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-token'
-            >
-              <X className='h-3 w-3' aria-hidden='true' />
-            </button>
-          ) : null}
-        </div>
+        <HeaderSearchAction
+          searchValue={searchValue}
+          onSearchValueChange={onSearchValueChange}
+          onClearAction={onClearSearch}
+          placeholder='Search tasks'
+          ariaLabel='Search tasks'
+          submitAriaLabel='Search tasks'
+          tooltipLabel='Search'
+          className='hidden h-7 text-xs text-tertiary-token hover:text-primary-token lg:flex'
+        />
         <TableFilterDropdown
           categories={filterCategories}
           onClearAll={onClearFilters}

--- a/apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
@@ -21,6 +21,42 @@ vi.mock('@/components/molecules/filters', () => ({
   TableFilterDropdown: () => <button type='button'>Filters</button>,
 }));
 
+vi.mock('@/components/molecules/HeaderSearchAction', () => ({
+  HeaderSearchAction: ({
+    searchValue,
+    onSearchValueChange,
+    onClearAction,
+    ariaLabel,
+    submitAriaLabel,
+    placeholder,
+  }: {
+    readonly searchValue: string;
+    readonly onSearchValueChange: (value: string) => void;
+    readonly onClearAction?: () => void;
+    readonly ariaLabel: string;
+    readonly submitAriaLabel: string;
+    readonly placeholder: string;
+  }) =>
+    searchValue.length > 0 ? (
+      <div>
+        <input
+          type='search'
+          value={searchValue}
+          onChange={event => onSearchValueChange(event.target.value)}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+        />
+        <button type='button' aria-label='Close search' onClick={onClearAction}>
+          Close search
+        </button>
+      </div>
+    ) : (
+      <button type='button' aria-label={submitAriaLabel}>
+        Search
+      </button>
+    ),
+}));
+
 vi.mock('@/components/molecules/tab-bar/TabBar', () => ({
   TabBar: ({
     value,
@@ -148,7 +184,7 @@ describe('TaskWorkspaceHeaderBar', () => {
       screen.getByRole('tab', { name: 'Assigned To Me 1' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('searchbox', { name: 'Search tasks' })
+      screen.getByRole('button', { name: 'Search tasks' })
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Filters' })).toBeInTheDocument();
     expect(
@@ -186,7 +222,7 @@ describe('TaskWorkspaceHeaderBar', () => {
     fireEvent.change(screen.getByRole('searchbox', { name: 'Search tasks' }), {
       target: { value: 'metadata' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Clear task search' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Close search' }));
 
     expect(props.onSearchValueChange).toHaveBeenCalledWith('metadata');
     expect(props.onClearSearch).toHaveBeenCalledTimes(1);

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -563,6 +563,11 @@ function getLatestTableProps() {
     | undefined;
 }
 
+function openDesktopTaskSearch() {
+  fireEvent.click(screen.getByRole('button', { name: 'Search tasks' }));
+  return screen.getByRole('searchbox', { name: 'Search tasks' });
+}
+
 function enableDesignV1Tasks() {
   mockUseAppFlag.mockImplementation(flagName => flagName === 'DESIGN_V1');
 }
@@ -1115,7 +1120,7 @@ describe('TasksPageClient', () => {
     expect(screen.getByRole('button', { name: 'Next task' })).toBeEnabled();
   });
 
-  it('keeps task search local to the workspace controls', () => {
+  it('keeps task search collapsed in the workspace toolbar by default', () => {
     renderPage();
 
     const headerActions = screen.getByTestId('header-actions-host');
@@ -1127,6 +1132,15 @@ describe('TasksPageClient', () => {
       screen.getByRole('button', { name: 'Create task' })
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('button', { name: 'Search tasks' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('searchbox', { name: 'Search tasks' })
+    ).toBeNull();
+
+    openDesktopTaskSearch();
+
+    expect(
       screen.getByRole('searchbox', { name: 'Search tasks' })
     ).toBeInTheDocument();
   });
@@ -1134,21 +1148,35 @@ describe('TasksPageClient', () => {
   it('does not open or focus task search with the slash key', () => {
     renderPage();
 
-    const searchBox = screen.getByRole('searchbox', { name: 'Search tasks' });
+    const searchButton = screen.getByRole('button', { name: 'Search tasks' });
 
     fireEvent.keyDown(screen.getByLabelText('Task title'), { key: '/' });
 
-    expect(document.activeElement).not.toBe(searchBox);
+    expect(
+      screen.queryByRole('searchbox', { name: 'Search tasks' })
+    ).toBeNull();
+    expect(document.activeElement).not.toBe(searchButton);
 
     fireEvent.keyDown(window, { key: '/' });
 
-    expect(document.activeElement).not.toBe(searchBox);
+    expect(
+      screen.queryByRole('searchbox', { name: 'Search tasks' })
+    ).toBeNull();
+    expect(document.activeElement).not.toBe(searchButton);
+  });
+
+  it('focuses task search when the shared search action opens it', () => {
+    renderPage();
+
+    const searchBox = openDesktopTaskSearch();
+
+    expect(document.activeElement).toBe(searchBox);
   });
 
   it('keeps task title search wired into list filters', () => {
     renderPage();
 
-    fireEvent.change(screen.getByRole('searchbox', { name: 'Search tasks' }), {
+    fireEvent.change(openDesktopTaskSearch(), {
       target: { value: 'metadata' },
     });
 
@@ -1162,7 +1190,7 @@ describe('TasksPageClient', () => {
 
     renderPage();
 
-    fireEvent.change(screen.getByRole('searchbox', { name: 'Search tasks' }), {
+    fireEvent.change(openDesktopTaskSearch(), {
       target: { value: 'press' },
     });
 


### PR DESCRIPTION
## Summary
- Replaced the task toolbar's bespoke desktop search input with the shared `HeaderSearchAction` primitive used by releases and admin table surfaces.
- Preserved the existing task search state, clear handler, labels, and route-local filtering behavior.
- Updated focused task toolbar coverage for the shared collapsed/open search behavior.

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx tests/unit/components/table/PageToolbar.test.tsx --pool=forks --maxWorkers=2`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Browser smoke on `http://localhost:3001/app/tasks` at desktop `1440x960` and mobile `390x844`; desktop opened, typed into, and closed the shared search action; screenshots in `/private/tmp/jov-2407-task-search`.
- Commit hook: proxy guard, lint-staged Biome, ESLint, a11y staged check, and local web typecheck passed.

<!-- agent-run-artifact
{
  "id": "jov-2407-task-toolbar-search-20260518",
  "source": "github",
  "sourceRunId": "9d8617f9028099dd0a9266f2e1ee9f5f27864667",
  "kind": "workflow",
  "status": "done",
  "title": "JOV-2407 task toolbar search",
  "summary": "Moved the task workspace desktop search control onto the shared HeaderSearchAction primitive to reduce route-local toolbar drift while preserving task search behavior.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2407",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2407/unify-task-toolbar-search-with-shared-header-search-action",
  "pullRequestUrl": null,
  "adminSurface": "/app/tasks",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused task toolbar unit tests plus desktop and mobile browser smoke on /app/tasks confirmed shared search open/type/close behavior and no horizontal overflow.",
      "checkedAt": "2026-05-18T10:09:43Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review confirms the slice only replaces route-local task search chrome with HeaderSearchAction; task filtering, data fetching, mutations, and routing behavior are unchanged.",
      "checkedAt": "2026-05-18T10:09:43Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, focused Vitest, web typecheck, and commit hook passed before PR creation.",
      "checkedAt": "2026-05-18T10:09:43Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-05-18T10:09:43Z",
  "updatedAt": "2026-05-18T10:09:43Z",
  "metadata": {
    "branch": "codex/jov-2407-task-toolbar-search",
    "screenshotsDir": "/private/tmp/jov-2407-task-search"
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured task search UI implementation for better code reusability while maintaining all existing search functionality.

* **Tests**
  * Updated test suite to verify task search behavior continues to work as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->