### PR TITLE
JOV-2408 Unify release task row frame

### DIFF
--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { ShellListRowFrame } from '@/components/organisms/table/atoms/ShellListRowFrame';
 import type { ReleaseTaskView } from '@/lib/release-tasks/types';
 import { cn } from '@/lib/utils';
 import { ReleaseTaskDueBadge } from './ReleaseTaskDueBadge';
@@ -25,7 +26,7 @@ export function ReleaseTaskCompactRow({
   const isAi = isReleaseTaskAutomated(task);
 
   return (
-    <div className='flex items-center gap-2 px-3 py-0.5 min-h-[28px] group hover:bg-surface-1 rounded transition-colors'>
+    <ShellListRowFrame className='flex min-h-[28px] items-center gap-2 px-3 py-0.5'>
       <ReleaseTaskCheckbox
         task={task}
         isDone={isDone}
@@ -54,6 +55,6 @@ export function ReleaseTaskCompactRow({
         dueDaysOffset={task.dueDaysOffset}
         isCompleted={isDone}
       />
-    </div>
+    </ShellListRowFrame>
   );
 }

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRow.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRow.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ShellListRowFrame } from '@/components/organisms/table/atoms/ShellListRowFrame';
 import type { ReleaseTaskView } from '@/lib/release-tasks/types';
 import {
   getAccentCssVars,
@@ -40,7 +41,7 @@ export function ReleaseTaskRow({ task, onToggle }: ReleaseTaskRowProps) {
   const aiAccent = getAccentCssVars('purple');
 
   return (
-    <div className='flex items-center gap-2 px-4 py-1 min-h-[32px] group hover:bg-surface-1 rounded transition-colors'>
+    <ShellListRowFrame className='flex min-h-[32px] items-center gap-2 px-4 py-1'>
       <ReleaseTaskCheckbox
         task={task}
         isDone={isDone}
@@ -92,6 +93,6 @@ export function ReleaseTaskRow({ task, onToggle }: ReleaseTaskRowProps) {
           learnMoreUrl={task.learnMoreUrl}
         />
       )}
-    </div>
+    </ShellListRowFrame>
   );
 }

--- a/apps/web/tests/unit/dashboard/ReleaseTaskRow.test.tsx
+++ b/apps/web/tests/unit/dashboard/ReleaseTaskRow.test.tsx
@@ -33,6 +33,16 @@ function createTask(overrides: Partial<ReleaseTaskView> = {}): ReleaseTaskView {
 }
 
 describe('ReleaseTaskRow', () => {
+  it('renders the full row through the shared shell list row frame', () => {
+    const { container } = render(
+      <ReleaseTaskRow task={createTask()} onToggle={vi.fn()} />
+    );
+
+    expect(
+      container.querySelectorAll('[data-shell-list-row="true"]')
+    ).toHaveLength(1);
+  });
+
   it('toggles the shared checkbox control from the full row', () => {
     const onToggle = vi.fn();
 
@@ -65,6 +75,20 @@ describe('ReleaseTaskRow', () => {
 });
 
 describe('ReleaseTaskCompactRow', () => {
+  it('renders the compact row through the shared shell list row frame', () => {
+    const { container } = render(
+      <ReleaseTaskCompactRow
+        task={createTask()}
+        onNavigate={vi.fn()}
+        onToggle={vi.fn()}
+      />
+    );
+
+    expect(
+      container.querySelectorAll('[data-shell-list-row="true"]')
+    ).toHaveLength(1);
+  });
+
   it('keeps compact navigation and checkbox behavior separate', () => {
     const onNavigate = vi.fn();
     const onToggle = vi.fn();


### PR DESCRIPTION
## Summary
- Moved full release-task rows onto the shared `ShellListRowFrame` primitive.
- Moved compact release-task rows onto the same shared row frame while preserving checkbox and navigation behavior.
- Added focused coverage to guard that both row variants render through the shell row-frame contract.

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/release-tasks/ReleaseTaskRow.tsx apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx apps/web/tests/unit/dashboard/ReleaseTaskRow.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/ReleaseTaskRow.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/ReleaseTaskPage.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Browser/design smoke on `http://localhost:3001/demo/showcase/release-tasks`; screenshot evidence in `/private/tmp/jov-2408-release-task-row`, including desktop and mobile verified views with no horizontal overflow.
- Commit hook: proxy guard, lint-staged Biome, ESLint, staged a11y check, and local web typecheck passed.
- Pre-push hook: full repo Biome, web proxy guard, Tailwind guard, web typecheck, and web lint passed.

<!-- agent-run-artifact
{
  "id": "jov-2408-release-task-shell-row-20260518",
  "source": "github",
  "sourceRunId": "7c712dc5b64e366f795b3885161a51e2c9af7b65",
  "kind": "workflow",
  "status": "done",
  "title": "JOV-2408 release task shell row frame",
  "summary": "Moved release task full and compact rows onto the shared ShellListRowFrame primitive to reduce shell row styling drift while preserving task behavior.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2408",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2408/unify-release-task-rows-with-shell-row-frame",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9109",
  "adminSurface": "/app/releases/[releaseId]/tasks",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused release-task unit/page tests plus desktop and mobile browser smoke on the release-task demo surface confirmed row rendering and no mobile horizontal overflow.",
      "checkedAt": "2026-05-18T10:49:20Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review confirms this slice only changes release-task row outer frames and adds contract coverage; task data, mutations, navigation, due badges, assignee badges, priority, and explainer behavior are unchanged.",
      "checkedAt": "2026-05-18T10:49:20Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, focused Vitest, page-shell Vitest, web typecheck, diff check, commit hook, and pre-push hook passed before PR creation.",
      "checkedAt": "2026-05-18T10:49:20Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-05-18T10:49:20Z",
  "updatedAt": "2026-05-18T10:49:20Z",
  "metadata": {
    "branch": "codex/jov-2408-release-task-shell-row",
    "screenshotsDir": "/private/tmp/jov-2408-release-task-row"
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dashboard task components to use a standardized structural component for improved consistency.

* **Tests**
  * Added unit tests to verify proper component structure rendering in dashboard task rows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->