### PR TITLE
fix(tasks): remove duplicate mobile search

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -6,7 +6,6 @@ import {
   DropdownMenuContent,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  Input,
   UserAvatar,
 } from '@jovie/ui';
 import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
@@ -17,9 +16,7 @@ import {
   FileText,
   MoreHorizontal,
   Plus,
-  Search,
   Trash2,
-  X,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import {
@@ -2133,30 +2130,6 @@ export function TasksPageClient() {
                       <p className='text-xs text-secondary-token'>
                         {mobileScopeCounts.all} total tasks
                       </p>
-                      <div className='relative w-[min(12rem,48vw)] min-w-[8.5rem]'>
-                        <Search
-                          className='pointer-events-none absolute bottom-0 left-2 top-0 my-auto h-3.5 w-3.5 text-quaternary-token'
-                          aria-hidden='true'
-                        />
-                        <Input
-                          type='search'
-                          value={search}
-                          onChange={event => setSearch(event.target.value)}
-                          placeholder='Search tasks'
-                          aria-label='Search tasks'
-                          className='h-7 w-full rounded-md border-border-token bg-surface-0 py-0 pl-7 pr-7 text-[12.5px] text-primary-token placeholder:text-quaternary-token'
-                        />
-                        {search ? (
-                          <button
-                            type='button'
-                            aria-label='Clear task search'
-                            onClick={() => setSearch('')}
-                            className='absolute bottom-0 right-1 top-0 my-auto inline-flex h-5 w-5 items-center justify-center rounded text-quaternary-token transition-[background-color,color] hover:bg-surface-1 hover:text-secondary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-token'
-                          >
-                            <X className='h-3 w-3' aria-hidden='true' />
-                          </button>
-                        ) : null}
-                      </div>
                     </div>
                     <TaskSubviewTabs
                       subviews={taskSubviewOptions}

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -1370,15 +1370,15 @@ describe('TasksPageClient', () => {
     expect(screen.getByTestId('mobile-task-list')).toBeInTheDocument();
   });
 
-  it('renders the mobile list shell and opens task detail on tap', () => {
+  it('renders the mobile list shell without duplicate search and opens task detail on tap', () => {
     mockIsXlUp = false;
 
     renderPage();
 
     expect(screen.getByText('2 total tasks')).toBeInTheDocument();
     expect(
-      screen.getByRole('searchbox', { name: 'Search tasks' })
-    ).toBeInTheDocument();
+      screen.queryByRole('searchbox', { name: 'Search tasks' })
+    ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getAllByTestId('mobile-task-row')[0]!);
 


### PR DESCRIPTION
## Summary
- Removed the bespoke mobile task-list search input so the tasks route no longer keeps a second local search surface alive.
- Preserved the mobile task count, subview tabs, scope tabs, and tap-to-open detail behavior.
- Updated the mobile tasks unit contract to assert the duplicate searchbox is absent.

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/tasks/TasksPageClient.tsx apps/web/tests/unit/dashboard/TasksPageClient.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/TasksPageClient.test.tsx tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Browser smoke on `http://localhost:3001/app/tasks` through `/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/tasks`; desktop screenshot `/private/tmp/jov-2409-tasks-desktop.png` and mobile screenshot `/private/tmp/jov-2409-tasks-mobile-auth.png`.
- Mobile browser smoke confirmed `searchboxCount: 0`, `scrollWidth: 375`, `clientWidth: 375`, and no console errors.
- Commit hook: proxy guard, lint-staged Biome, ESLint, staged a11y check, and local web typecheck passed.
- Pre-push hook: full repo Biome, web proxy guard, Tailwind guard, web typecheck, and web lint passed.

<!-- linear-issue-id:JOV-2409 -->

<!-- agent-run-artifact
{
  "id": "jov-2409-remove-mobile-task-search-20260518",
  "source": "github",
  "sourceRunId": "6a2c90274ba0f253fc869229aaa2cea600d4e9e6",
  "kind": "workflow",
  "status": "done",
  "title": "JOV-2409 remove duplicate mobile task search",
  "summary": "Removed the tasks route mobile-only inline search input so the route keeps one shared task search pattern instead of a duplicate mobile control.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2409",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2409/remove-duplicate-mobile-task-search-surface",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9111",
  "adminSurface": "/app/tasks",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused task page/header unit tests plus desktop and mobile browser smoke confirmed the task workspace renders, mobile has no duplicate searchbox, no console errors, and no mobile horizontal overflow.",
      "checkedAt": "2026-05-18T11:13:18Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review confirms this slice only deletes the mobile-only task search field and unused imports; task queries, filters, scope tabs, row selection, mutations, and detail routing are unchanged.",
      "checkedAt": "2026-05-18T11:13:18Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, focused Vitest, web typecheck, diff check, commit hook, and pre-push hook passed before PR creation.",
      "checkedAt": "2026-05-18T11:13:18Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-05-18T11:13:18Z",
  "updatedAt": "2026-05-18T11:13:18Z",
  "metadata": {
    "branch": "codex/jov-2409-remove-mobile-task-search",
    "screenshots": [
      "/private/tmp/jov-2409-tasks-desktop.png",
      "/private/tmp/jov-2409-tasks-mobile-auth.png"
    ]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate search input from the mobile task list header, which was incorrectly displaying desktop search functionality on narrow screen widths.

* **Tests**
  * Updated mobile layout tests to verify the search input is not displayed on narrow widths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->