### PR TITLE
refactor(tasks): use shell row button on mobile

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -61,6 +61,7 @@ import { ReleaseSidebar } from '@/components/organisms/release-sidebar';
 import {
   type ContextMenuItemType,
   convertContextMenuItems,
+  ShellListRowButton,
 } from '@/components/organisms/table';
 import { rowState } from '@/components/organisms/table/table.styles';
 import {
@@ -1009,7 +1010,7 @@ function MobileTaskSection({
         <h2 className='text-2xs font-semibold text-tertiary-token'>{title}</h2>
         <span className='text-3xs text-tertiary-token'>{tasks.length}</span>
       </div>
-      <div className='overflow-hidden rounded-[18px] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_98%,transparent)] shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-app-shell-border)_65%,transparent)]'>
+      <div className='space-y-1 overflow-hidden rounded-[18px] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_98%,transparent)] p-1 shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-app-shell-border)_65%,transparent)]'>
         {tasks.map(task => (
           <MobileTaskListItem
             key={task.id}
@@ -1046,16 +1047,11 @@ function MobileTaskListItem({
   const StageIcon = stage.icon;
 
   return (
-    <button
-      type='button'
+    <ShellListRowButton
       onClick={() => onOpenTask(task)}
       data-testid='mobile-task-row'
-      className={cn(
-        'flex w-full items-start gap-3 border-b border-[color-mix(in_oklab,var(--linear-app-shell-border)_58%,transparent)] px-4 py-3 text-left transition-[background-color,color] duration-subtle last:border-b-0',
-        isSelected
-          ? 'bg-[color-mix(in_oklab,var(--linear-row-hover)_68%,var(--linear-app-content-surface))]'
-          : 'bg-transparent hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_56%,transparent)]'
-      )}
+      isSelected={isSelected}
+      className='flex w-full items-start gap-3 px-3 py-2.5 text-left'
     >
       <span
         className='mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center'
@@ -1107,7 +1103,7 @@ function MobileTaskListItem({
           </span>
         ) : null}
       </span>
-    </button>
+    </ShellListRowButton>
   );
 }
 

--- a/apps/web/components/organisms/table/atoms/ShellListRowFrame.test.tsx
+++ b/apps/web/components/organisms/table/atoms/ShellListRowFrame.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import {
   getShellListRowFrameClassName,
+  ShellListRowButton,
   ShellListRowFrame,
 } from './ShellListRowFrame';
 
@@ -33,5 +34,22 @@ describe('ShellListRowFrame', () => {
     expect(className).toContain('group-hover/task-row:bg-(--linear-row-hover)');
     expect(className).toContain('group-focus-visible/task-row:bg-');
     expect(className).not.toContain('cursor-pointer');
+  });
+
+  it('uses button semantics for clickable shell rows', () => {
+    const { getByTestId } = render(
+      <ShellListRowButton data-testid='row-button' isSelected className='px-3'>
+        Open
+      </ShellListRowButton>
+    );
+
+    const row = getByTestId('row-button');
+    expect(row.tagName).toBe('BUTTON');
+    expect(row).toHaveAttribute('type', 'button');
+    expect(row).toHaveAttribute('data-shell-list-row', 'true');
+    expect(row).toHaveAttribute('data-selected', 'true');
+    expect(row.className).toContain('bg-(--linear-row-selected)');
+    expect(row.className).toContain('cursor-pointer');
+    expect(row.className).toContain('px-3');
   });
 });

--- a/apps/web/components/organisms/table/atoms/ShellListRowFrame.tsx
+++ b/apps/web/components/organisms/table/atoms/ShellListRowFrame.tsx
@@ -10,6 +10,13 @@ export interface ShellListRowFrameProps
   readonly interactive?: boolean;
 }
 
+export interface ShellListRowButtonProps
+  extends ComponentPropsWithoutRef<'button'> {
+  readonly isSelected?: boolean;
+  readonly interaction?: ShellListRowInteraction;
+  readonly interactive?: boolean;
+}
+
 function getTaskRowGroupState(isSelected: boolean): string {
   if (isSelected) {
     return cn(
@@ -60,6 +67,30 @@ export function ShellListRowFrame({
 }: Readonly<ShellListRowFrameProps>) {
   return (
     <div
+      data-shell-list-row='true'
+      data-selected={isSelected ? 'true' : undefined}
+      className={getShellListRowFrameClassName({
+        className,
+        interaction,
+        interactive,
+        isSelected,
+      })}
+      {...props}
+    />
+  );
+}
+
+export function ShellListRowButton({
+  className,
+  interaction = 'self',
+  interactive = true,
+  isSelected = false,
+  type = 'button',
+  ...props
+}: Readonly<ShellListRowButtonProps>) {
+  return (
+    <button
+      type={type}
       data-shell-list-row='true'
       data-selected={isSelected ? 'true' : undefined}
       className={getShellListRowFrameClassName({

--- a/apps/web/components/organisms/table/index.ts
+++ b/apps/web/components/organisms/table/index.ts
@@ -84,11 +84,13 @@ export { AvatarCell } from './atoms/AvatarCell';
 export { DateCell } from './atoms/DateCell';
 export { GroupHeader } from './atoms/GroupHeader';
 export type {
+  ShellListRowButtonProps,
   ShellListRowFrameProps,
   ShellListRowInteraction,
 } from './atoms/ShellListRowFrame';
 export {
   getShellListRowFrameClassName,
+  ShellListRowButton,
   ShellListRowFrame,
 } from './atoms/ShellListRowFrame';
 export { SkeletonCell } from './atoms/SkeletonCell';

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -498,6 +498,25 @@ vi.mock('@/components/organisms/table', () => ({
       {end}
     </div>
   ),
+  ShellListRowButton: ({
+    children,
+    className,
+    isSelected,
+    type = 'button',
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    isSelected?: boolean;
+  }) => (
+    <button
+      type={type}
+      data-shell-list-row='true'
+      data-selected={isSelected ? 'true' : undefined}
+      className={className}
+      {...props}
+    >
+      {children}
+    </button>
+  ),
   UnifiedTable: (props: { minWidth?: string; containerClassName?: string }) => {
     mockUnifiedTable(props);
     return (
@@ -1380,7 +1399,10 @@ describe('TasksPageClient', () => {
       screen.queryByRole('searchbox', { name: 'Search tasks' })
     ).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getAllByTestId('mobile-task-row')[0]!);
+    const firstMobileRow = screen.getAllByTestId('mobile-task-row')[0]!;
+    expect(firstMobileRow).toHaveAttribute('data-shell-list-row', 'true');
+
+    fireEvent.click(firstMobileRow);
 
     expect(screen.getByLabelText('Task title')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- Added `ShellListRowButton`, a button-backed variant of the shared shell row primitive.
- Moved mobile task rows onto the shared shell row state/token path instead of bespoke mobile row hover/selected classes.
- Added focused coverage for clickable shell rows and the mobile task-row contract.

## Verification
- `pnpm biome check --write apps/web/components/organisms/table/atoms/ShellListRowFrame.tsx apps/web/components/organisms/table/atoms/ShellListRowFrame.test.tsx apps/web/components/organisms/table/index.ts apps/web/components/features/dashboard/tasks/TasksPageClient.tsx apps/web/tests/unit/dashboard/TasksPageClient.test.tsx`
- `pnpm --filter @jovie/web exec vitest run components/organisms/table/atoms/ShellListRowFrame.test.tsx tests/unit/dashboard/TasksPageClient.test.tsx tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Browser smoke on `http://localhost:3001/app/tasks` through `/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/tasks`; desktop screenshot `/private/tmp/jov-2410-tasks-desktop.png` and mobile screenshot `/private/tmp/jov-2410-tasks-mobile.png`.
- Mobile browser smoke confirmed `shellRows: 2`, `selectedRows: 0`, `scrollWidth: 375`, `clientWidth: 375`, and no console errors.
- Commit hook: proxy guard, lint-staged Biome, ESLint, staged a11y check, and local web typecheck passed.
- Pre-push hook: full repo Biome, web proxy guard, Tailwind guard, web typecheck, and web lint passed.

<!-- linear-issue-id:JOV-2410 -->

<!-- agent-run-artifact
{
  "id": "jov-2410-mobile-task-shell-row-20260518",
  "source": "github",
  "sourceRunId": "5ab32fd18c5e2947b36bc66c17468de3eaa5e1f4",
  "kind": "workflow",
  "status": "done",
  "title": "JOV-2410 mobile task shell row primitive",
  "summary": "Added a button-backed shared shell row primitive and moved mobile task rows onto it to reduce row styling drift across task layouts.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2410",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2410/unify-mobile-task-rows-with-shell-row-primitive",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9113",
  "adminSurface": "/app/tasks",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused shell-row and task-page unit tests plus desktop and mobile browser smoke confirmed mobile task rows render through the shared shell row primitive with no console errors or mobile horizontal overflow.",
      "checkedAt": "2026-05-18T11:31:07Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review confirms this slice adds a shared button row primitive and swaps mobile task row state styling to it; task queries, mutations, filters, detail routing, and release/due metadata behavior are unchanged.",
      "checkedAt": "2026-05-18T11:31:07Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, focused Vitest, web typecheck, diff check, commit hook, and pre-push hook passed before PR creation.",
      "checkedAt": "2026-05-18T11:31:07Z"
    }
  ],
  "costEstimate": null,
  "blockedReason": null,
  "createdAt": "2026-05-18T11:31:07Z",
  "updatedAt": "2026-05-18T11:31:07Z",
  "metadata": {
    "branch": "codex/jov-2410-mobile-task-shell-row",
    "screenshots": [
      "/private/tmp/jov-2410-tasks-desktop.png",
      "/private/tmp/jov-2410-tasks-mobile.png"
    ]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated mobile task list component structure for improved consistency and maintainability

* **Tests**
  * Expanded test coverage for interactive list row components to verify proper button semantics and styling behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->