### PR TITLE
refactor(releases): use shared row selection state

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import {
+  type ColumnDef,
+  createColumnHelper,
+  type RowSelectionState,
+} from '@tanstack/react-table';
 import { lazy, Suspense, useCallback, useMemo } from 'react';
 import { Icon } from '@/components/atoms/Icon';
 import { TableEmptyState, UnifiedTable } from '@/components/organisms/table';
@@ -100,6 +104,10 @@ export function ReleaseTable({
       index === 0 ? 'release-row' : undefined,
     []
   );
+  const rowSelection = useMemo<RowSelectionState>(
+    () => (selectedReleaseId ? { [selectedReleaseId]: true } : {}),
+    [selectedReleaseId]
+  );
   const getRowClassName = useCallback(
     (row: ReleaseViewModel) => {
       const isSelected = selectedReleaseId === row.id;
@@ -107,15 +115,11 @@ export function ReleaseTable({
       const isFlashed = flashedReleaseId === row.id;
 
       let baseClassName: string;
-      if (designV1 && isSelected) {
-        baseClassName =
-          'border-transparent bg-(--linear-bg-surface-1)/80 shadow-[inset_3px_0_0_0_var(--linear-accent),inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_24%,transparent)] hover:bg-(--linear-bg-surface-1)/90 focus-within:bg-(--linear-bg-surface-1)';
+      if (isSelected) {
+        baseClassName = designV1 ? 'border-transparent' : '';
       } else if (designV1) {
         baseClassName =
           'border-transparent bg-transparent hover:bg-(--linear-bg-surface-1)/55 focus-within:bg-(--linear-bg-surface-1)/65 transition-[background-color,box-shadow,color] duration-150 ease-out [&:hover_span]:text-primary-token [&:hover_p]:text-primary-token';
-      } else if (isSelected) {
-        baseClassName =
-          'bg-[color-mix(in_oklab,var(--linear-row-selected)_55%,transparent)] shadow-[inset_3px_0_0_0_var(--linear-accent)] hover:bg-[color-mix(in_oklab,var(--linear-row-selected)_65%,transparent)] focus-within:bg-[color-mix(in_oklab,var(--linear-row-selected)_72%,transparent)] focus-within:shadow-[inset_3px_0_0_0_var(--linear-accent),inset_0_0_0_1px_var(--linear-border-focus)]';
       } else {
         baseClassName =
           'bg-transparent hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_78%,transparent)] focus-within:bg-[color-mix(in_oklab,var(--linear-row-hover)_84%,transparent)] transition-[background-color,box-shadow,color] duration-150 ease-out [&:hover_span]:text-primary-token [&:hover_p]:text-primary-token';
@@ -279,6 +283,7 @@ export function ReleaseTable({
     <UnifiedTable
       data={releases}
       columns={columns as ColumnDef<ReleaseViewModel, unknown>[]}
+      rowSelection={rowSelection}
       sorting={sorting}
       onSortingChange={onSortingChange}
       isLoading={isSorting && isLargeDataset}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import {
+  type ColumnDef,
+  createColumnHelper,
+  type RowSelectionState,
+} from '@tanstack/react-table';
 import { lazy, Suspense, useCallback, useMemo } from 'react';
 import { Icon } from '@/components/atoms/Icon';
 import { TableEmptyState, UnifiedTable } from '@/components/organisms/table';
@@ -100,6 +104,10 @@ export function ReleaseTableWithTracks({
       index === 0 ? 'release-row' : undefined,
     []
   );
+  const rowSelection = useMemo<RowSelectionState>(
+    () => (selectedReleaseId ? { [selectedReleaseId]: true } : {}),
+    [selectedReleaseId]
+  );
 
   const getRowClassName = useCallback(
     (row: ReleaseViewModel) => {
@@ -109,18 +117,14 @@ export function ReleaseTableWithTracks({
       const isFlashed = flashedReleaseId === row.id;
 
       let baseClassName: string;
-      if (designV1 && isSelected) {
-        baseClassName =
-          'border-transparent bg-(--linear-bg-surface-1)/80 shadow-[inset_3px_0_0_0_var(--linear-accent),inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_24%,transparent)] hover:bg-(--linear-bg-surface-1)/90 focus-within:bg-(--linear-bg-surface-1)';
+      if (isSelected) {
+        baseClassName = designV1 ? 'border-transparent' : '';
       } else if (designV1 && isRowExpanded) {
         baseClassName =
           'border-transparent bg-(--linear-bg-surface-1)/58 hover:bg-(--linear-bg-surface-1)/64 focus-within:bg-(--linear-bg-surface-1)/70';
       } else if (designV1) {
         baseClassName =
           'border-transparent bg-transparent hover:bg-(--linear-bg-surface-1)/55 focus-within:bg-(--linear-bg-surface-1)/65 transition-[background-color,box-shadow,color] duration-150 ease-out [&:hover_span]:text-primary-token [&:hover_p]:text-primary-token';
-      } else if (isSelected) {
-        baseClassName =
-          'bg-[color-mix(in_oklab,var(--linear-row-selected)_55%,transparent)] shadow-[inset_3px_0_0_0_var(--linear-accent)] hover:bg-[color-mix(in_oklab,var(--linear-row-selected)_65%,transparent)] focus-within:bg-[color-mix(in_oklab,var(--linear-row-selected)_72%,transparent)] focus-within:shadow-[inset_3px_0_0_0_var(--linear-accent),inset_0_0_0_1px_var(--linear-border-focus)]';
       } else if (isRowExpanded) {
         baseClassName =
           'bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_52%,transparent)] hover:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_58%,transparent)] focus-within:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_62%,transparent)]';
@@ -319,6 +323,7 @@ export function ReleaseTableWithTracks({
     <UnifiedTable
       data={releases}
       columns={columns as ColumnDef<ReleaseViewModel, unknown>[]}
+      rowSelection={rowSelection}
       sorting={sorting}
       onSortingChange={onSortingChange}
       isLoading={isSorting && isLargeDataset}

--- a/apps/web/tests/components/release-provider-matrix/ReleaseTable.test.tsx
+++ b/apps/web/tests/components/release-provider-matrix/ReleaseTable.test.tsx
@@ -97,6 +97,7 @@ vi.mock('@/components/organisms/table', () => ({
     getRowId,
     getRowClassName,
     getRowTestId,
+    rowSelection,
     expandedRowIds,
     renderExpandedContent,
   }: {
@@ -105,6 +106,7 @@ vi.mock('@/components/organisms/table', () => ({
     getRowId: (row: { id: string }) => string;
     getRowClassName: (row: { id: string }) => string;
     getRowTestId?: (row: { id: string }, index: number) => string | undefined;
+    rowSelection?: Record<string, boolean>;
     expandedRowIds?: Set<string>;
     renderExpandedContent?: (
       row: { id: string },
@@ -118,7 +120,14 @@ vi.mock('@/components/organisms/table', () => ({
           <div key={rowId} data-testid={`release-row-wrapper-${rowId}`}>
             <div
               data-testid={getRowTestId?.(row, index)}
-              className={getRowClassName(row)}
+              className={[
+                rowSelection?.[rowId]
+                  ? 'bg-(--linear-row-selected) shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_24%,transparent)]'
+                  : '',
+                getRowClassName(row),
+              ]
+                .filter(Boolean)
+                .join(' ')}
             />
             {expandedRowIds?.has(rowId) ? (
               <div data-testid={`expanded-row-${rowId}`}>
@@ -172,6 +181,33 @@ describe('ReleaseTable', () => {
     expect(expandedRow).toBeInTheDocument();
     expect(selectedRow).toBeInTheDocument();
     expect(expandedRow).not.toBe(selectedRow);
+    expect(expandedRow?.className).not.toContain('bg-(--linear-row-selected)');
+    expect(selectedRow?.className).toContain('bg-(--linear-row-selected)');
+    expect(selectedRow?.className).not.toContain(
+      'shadow-[inset_3px_0_0_0_var(--linear-accent)'
+    );
+  });
+
+  it('uses the shared selected state in design v1 table rows', () => {
+    render(
+      <ReleaseTable
+        {...commonProps}
+        designV1={true}
+        showTracks={false}
+        selectedReleaseId='release_1'
+      />
+    );
+
+    const selectedRow = screen
+      .getByTestId('release-row-wrapper-release_1')
+      .querySelector('div');
+
+    expect(selectedRow).toBeInTheDocument();
+    expect(selectedRow?.className).toContain('bg-(--linear-row-selected)');
+    expect(selectedRow?.className).toContain('border-transparent');
+    expect(selectedRow?.className).not.toContain(
+      'shadow-[inset_3px_0_0_0_var(--linear-accent)'
+    );
   });
 
   it('gives idle release rows the same visible rounded hover silhouette', () => {


### PR DESCRIPTION
## Summary

- Route selected release row state through `UnifiedTable` row selection instead of local inset-accent shadows.
- Keep release expanded-row, hover, refresh, and flash classes route-local while letting the shared shell table own selected state.
- Add focused component coverage for design v1 and expanded-row interaction so the old left accent cannot drift back.

## Verification

- `pnpm biome check --write apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx apps/web/tests/components/release-provider-matrix/ReleaseTable.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/components/release-provider-matrix/ReleaseTable.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- gstack browse desktop: `/app/releases`, no horizontal overflow, old release selected accent absent, screenshot `/private/tmp/jov-2412-releases-shell-desktop.png`
- gstack browse mobile: `/app/releases`, no horizontal overflow, old release selected accent absent, screenshot `/private/tmp/jov-2412-releases-mobile-loaded.png`

<!-- agent-run-artifact
{
  "id": "jov-2412-release-row-state-20260518",
  "source": "ruflo",
  "sourceRunId": "7cc9465d5454cbf08ff87858e45041b9e4cadf51",
  "kind": "workflow",
  "status": "done",
  "title": "JOV-2412 release row state unification",
  "summary": "Release provider matrix rows now use the shared UnifiedTable row selection contract while preserving release-specific expanded, hover, refresh, and flash states. Focused component tests and desktop/mobile route smoke passed.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "User granted approval to continue shipping shell migration slices without additional visual approvals when there is no visual change.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2412",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2412/unify-release-matrix-row-state-with-shell-table-tokens",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9117",
  "adminSurface": "/app/releases",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused route smoke covered desktop and mobile /app/releases screenshots, overflow checks, and absence of the old release selected accent class.",
      "checkedAt": "2026-05-18T12:13:07Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review confirmed the change is scoped to ReleaseTable, ReleaseTableWithTracks, and focused component coverage; no production imports from exp routes.",
      "checkedAt": "2026-05-18T12:13:07Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, focused Vitest, typecheck, git diff check, commit hooks, and route smoke passed before PR creation.",
      "checkedAt": "2026-05-18T12:13:07Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local Codex execution only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T12:13:07Z",
  "updatedAt": "2026-05-18T12:13:07Z",
  "metadata": {
    "screenshots": [
      "/private/tmp/jov-2412-releases-shell-desktop.png",
      "/private/tmp/jov-2412-releases-mobile-loaded.png"
    ],
    "changedFiles": [
      "apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx",
      "apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx",
      "apps/web/tests/components/release-provider-matrix/ReleaseTable.test.tsx"
    ]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved row selection control in release tables.
  * Refined visual styling for selected rows in design v1 mode.

* **Tests**
  * Updated tests to verify correct visual distinction between expanded and selected row states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9117?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->