### PR TITLE
test(onboarding): lock compact chat bubble layout

### DIFF
--- a/apps/web/tests/e2e/start-onboarding-chat.spec.ts
+++ b/apps/web/tests/e2e/start-onboarding-chat.spec.ts
@@ -345,6 +345,45 @@ test.describe('canonical /start onboarding chat', () => {
     ).toBeEnabled();
   });
 
+  test('submitted user turn stays compact and clear of the composer on mobile', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockOnboardingChat(page);
+    await page.goto('/start', { waitUntil: 'domcontentloaded' });
+    await waitForHydration(page);
+
+    await page.locator(COMPOSER_TEXTAREA).fill('yes music artist and writer');
+    await page.getByRole('button', { name: 'Send message' }).click();
+
+    const bubble = page.getByTestId('chat-user-bubble').first();
+    await expect(bubble).toBeVisible();
+    await expect(bubble).toHaveCSS('padding-top', '6px');
+    await expect(bubble).toHaveCSS('padding-right', '12px');
+    await expect(bubble).toHaveCSS('padding-bottom', '6px');
+    await expect(bubble).toHaveCSS('padding-left', '12px');
+
+    const bubbleBox = await bubble.boundingBox();
+    const composerBox = await page.locator(COMPOSER_SURFACE).boundingBox();
+    expect(bubbleBox).not.toBeNull();
+    expect(composerBox).not.toBeNull();
+    if (bubbleBox && composerBox) {
+      expect(bubbleBox.height).toBeLessThanOrEqual(40);
+      expect(bubbleBox.y + bubbleBox.height).toBeLessThan(composerBox.y);
+    }
+
+    const overflow = await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth -
+        document.documentElement.clientWidth
+    );
+    expect(overflow).toBeLessThanOrEqual(0);
+    await expect(page.getByTestId('onboarding-profile-rail')).toHaveCount(0);
+    await expect(
+      page.getByTestId('onboarding-profile-rail-inline')
+    ).toHaveCount(0);
+  });
+
   test('auth error and slash picker do not collide at narrow desktop size', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
- Adds a `/start` mobile regression that submits a user turn through the real composer path.
- Locks the CTA-sized user bubble contract: 6px/12px padding, <=40px height, no composer overlap, no horizontal overflow.
- Verifies the default onboarding chat keeps the profile rail closed after a normal chat turn.

## Verification
- passed: `pnpm biome check --write apps/web/tests/e2e/start-onboarding-chat.spec.ts`
- passed: `pnpm --filter @jovie/web exec playwright test tests/e2e/start-onboarding-chat.spec.ts --project=chromium --grep "submitted user turn"`
- passed: `pnpm --filter @jovie/web run typecheck -- --pretty false`
- passed: `git diff --check`
- screenshots reviewed: `/private/tmp/jov-2414-start-desktop.png`, `/private/tmp/jov-2414-start-tablet-sent.png`, `/private/tmp/jov-2414-start-mobile-sent.png`

Linear: JOV-2414

<!-- agent-run-artifact
{
  "id": "jov-2414-onboarding-chat-bubbles",
  "source": "github",
  "sourceRunId": "94038f535d4fabdffe8ab3ee52e581318c1caaf8",
  "kind": "qa",
  "status": "done",
  "title": "Lock onboarding chat bubble geometry",
  "summary": "Recorded focused QA, review, and ship evidence for the /start compact user bubble regression guard.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2414",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2414/tighten-onboarding-chat-bubble-pill-geometry",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9121",
  "adminSurface": "/start",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused Playwright covered the submitted /start mobile turn, asserting compact bubble padding, composer clearance, zero horizontal overflow, and closed profile rail state.",
      "checkedAt": "2026-05-18T12:49:24.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review is constrained to a regression test in start-onboarding-chat.spec.ts; no production UI path or route behavior changed.",
      "checkedAt": "2026-05-18T12:49:24.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Formatting, focused E2E, typecheck, and whitespace checks passed before opening the PR.",
      "checkedAt": "2026-05-18T12:49:24.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T12:49:24.000Z",
  "updatedAt": "2026-05-18T12:49:24.000Z",
  "metadata": {
    "screenshots": [
      "/private/tmp/jov-2414-start-desktop.png",
      "/private/tmp/jov-2414-start-tablet-sent.png",
      "/private/tmp/jov-2414-start-mobile-sent.png"
    ]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for mobile viewport behavior, including chat bubble positioning, padding, overflow handling, and onboarding profile rail rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->