### PR TITLE
test(desktop): exempt contract tests from release guard

### DIFF
--- a/scripts/desktop-release-guard.mjs
+++ b/scripts/desktop-release-guard.mjs
@@ -16,15 +16,21 @@ const RELEASE_HANDLING_PATHS = new Set([
   '.github/workflows/desktop-release.yml',
 ]);
 
+function isDesktopReleaseImpactingFile(file) {
+  if (!file.startsWith(DESKTOP_PATH_PREFIX)) {
+    return false;
+  }
+
+  return !/^apps\/desktop\/scripts\/.+\.test\.mjs$/.test(file);
+}
+
 export function evaluateDesktopReleaseGuard(changedFiles) {
   const normalizedFiles = changedFiles
     .map(file => file.trim())
     .filter(Boolean)
     .map(file => file.replace(/\\/g, '/'));
 
-  const desktopFiles = normalizedFiles.filter(file =>
-    file.startsWith(DESKTOP_PATH_PREFIX)
-  );
+  const desktopFiles = normalizedFiles.filter(isDesktopReleaseImpactingFile);
   const releaseHandlingFiles = normalizedFiles.filter(file =>
     RELEASE_HANDLING_PATHS.has(file)
   );

--- a/scripts/desktop-release-guard.test.mjs
+++ b/scripts/desktop-release-guard.test.mjs
@@ -22,6 +22,26 @@ test('fails when desktop files changed without a release trigger', () => {
   assert.deepEqual(result.releaseHandlingFiles, []);
 });
 
+test('passes when only desktop contract tests changed', () => {
+  const result = evaluateDesktopReleaseGuard([
+    'apps/desktop/scripts/desktop-icon-contract.test.mjs',
+    'apps/web/app/page.tsx',
+  ]);
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.desktopFiles, []);
+});
+
+test('still fails when a desktop test changes with release-impacting desktop code', () => {
+  const result = evaluateDesktopReleaseGuard([
+    'apps/desktop/scripts/desktop-icon-contract.test.mjs',
+    'apps/desktop/src/main.ts',
+  ]);
+
+  assert.equal(result.passed, false);
+  assert.deepEqual(result.desktopFiles, ['apps/desktop/src/main.ts']);
+});
+
 test('passes when desktop changes include a VERSION bump', () => {
   const result = evaluateDesktopReleaseGuard([
     'apps/desktop/src/main.ts',


### PR DESCRIPTION
## Summary
- Allows desktop script contract tests to land without forcing a DMG release trigger.
- Keeps the release guard strict for runtime and package-impacting `apps/desktop` changes.
- Adds guard coverage for both test-only changes and mixed test/runtime desktop changes.

## Verification
- passed: `node --test scripts/desktop-release-guard.test.mjs`
- passed: `node scripts/desktop-release-guard.mjs --base origin/main`
- passed: `git diff --check`

Linear: JOV-2418

<!-- agent-run-artifact
{
  "id": "jov-2418-desktop-test-release-guard",
  "source": "github",
  "sourceRunId": "7ec96f38b5ec7b14e0a82c0e1ca15d70a0965b4a",
  "kind": "qa",
  "status": "done",
  "title": "Allow desktop contract tests without a DMG release trigger",
  "summary": "Recorded QA, review, and ship evidence for keeping the desktop release guard strict for release-impacting files while allowing test-only desktop contract coverage.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2418",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2418/allow-desktop-contract-tests-without-a-dmg-release-trigger",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9128",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Release guard unit coverage passed for no desktop files, release-impacting desktop files, test-only desktop contract files, mixed test/runtime files, VERSION-triggered release handling, and workflow-triggered release handling.",
      "checkedAt": "2026-05-18T13:29:56.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review confirmed the change only adjusts the guard classification and adds focused tests; runtime desktop release paths still require VERSION or desktop-release workflow handling.",
      "checkedAt": "2026-05-18T13:29:56.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch push completed after the guard script passed against origin/main and the workspace diff check passed.",
      "checkedAt": "2026-05-18T13:29:56.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T13:29:56.000Z",
  "updatedAt": "2026-05-18T13:29:56.000Z",
  "metadata": {}
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop release validation now correctly excludes changes limited to script test files from triggering verification steps.

* **Tests**
  * Added test cases validating desktop release behavior when only test files change and when test files change alongside release-impacting code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->