### PR TITLE
JOV-2420: Normalize app shell sign-in redirects

### DIFF
--- a/apps/web/app/app/(shell)/app-shell-route-context.test.tsx
+++ b/apps/web/app/app/(shell)/app-shell-route-context.test.tsx
@@ -89,6 +89,19 @@ describe('loadAppShellRouteContext', () => {
     expect(getDashboardShellDataMock).not.toHaveBeenCalled();
   });
 
+  it('preserves route search params in shared signin redirects', async () => {
+    getCachedAuthMock.mockResolvedValue({ userId: null });
+
+    await expect(
+      loadAppShellRouteContext({
+        route: '/app/audience?view=list',
+        dashboardErrorMessage: 'Failed to load audience data.',
+      })
+    ).rejects.toThrow(
+      'NEXT_REDIRECT:/signin?redirect_url=%2Fapp%2Faudience%3Fview%3Dlist'
+    );
+  });
+
   it('uses notFound for gated routes that should not expose auth state', async () => {
     getCachedAuthMock.mockResolvedValue({ userId: null });
 

--- a/apps/web/app/app/(shell)/app-shell-route-context.tsx
+++ b/apps/web/app/app/(shell)/app-shell-route-context.tsx
@@ -4,6 +4,7 @@ import { notFound, redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
+import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
 import { getCachedAuth } from '@/lib/auth/cached';
 import { captureError } from '@/lib/error-tracking';
 import type { AppFlagName } from '@/lib/flags/contracts';
@@ -35,13 +36,6 @@ export type AppShellRouteContextResult =
   | AppShellRouteContext
   | AppShellRouteError;
 
-function signInRouteFor(route: string): string {
-  const signInParams = new URLSearchParams({
-    redirect_url: route,
-  });
-  return `${APP_ROUTES.SIGNIN}?${signInParams.toString()}`;
-}
-
 export async function loadAppShellRouteContext({
   route,
   dashboardErrorMessage,
@@ -56,7 +50,7 @@ export async function loadAppShellRouteContext({
       notFound();
     }
 
-    redirect(signInRouteFor(route));
+    redirect(buildAppShellSignInUrl(route));
   }
 
   if (requiredFlag) {

--- a/apps/web/app/app/(shell)/audience/page.tsx
+++ b/apps/web/app/app/(shell)/audience/page.tsx
@@ -7,6 +7,7 @@ import { DashboardAudienceClient } from '@/features/dashboard/organisms/Dashboar
 import { AudienceTableLoadingShell } from '@/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell';
 import type { AudienceSegment } from '@/features/dashboard/organisms/dashboard-audience-table/types';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
+import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
 import { getCachedAuth } from '@/lib/auth/cached';
 import { captureError } from '@/lib/error-tracking';
 import { audienceFilters, audienceSearchParams } from '@/lib/nuqs';
@@ -37,7 +38,7 @@ export default async function AudiencePage({
 }>) {
   const { userId } = await getCachedAuth();
   if (!userId) {
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.AUDIENCE}`);
+    redirect(buildAppShellSignInUrl(APP_ROUTES.AUDIENCE));
   }
 
   return (
@@ -83,7 +84,7 @@ async function AudienceContent({
     }
 
     if (!dashboardData.user?.id) {
-      redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.AUDIENCE}`);
+      redirect(buildAppShellSignInUrl(APP_ROUTES.AUDIENCE));
     }
 
     const artist = dashboardData.selectedProfile

--- a/apps/web/app/app/(shell)/calendar/page.tsx
+++ b/apps/web/app/app/(shell)/calendar/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
+import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
 import { getCachedAuth } from '@/lib/auth/cached';
 import { captureError } from '@/lib/error-tracking';
 import { queryKeys } from '@/lib/queries';
@@ -102,7 +103,7 @@ async function prefetchCalendarQueries(profileId: string) {
 export default async function CalendarPage() {
   const { userId } = await getCachedAuth();
   if (!userId) {
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${CALENDAR_ROUTE}`);
+    redirect(buildAppShellSignInUrl(CALENDAR_ROUTE));
   }
 
   const dashboardData = await getDashboardShellData(userId);

--- a/apps/web/app/app/(shell)/dashboard/tour-dates/actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/tour-dates/actions.ts
@@ -11,6 +11,7 @@ import { isRedirectError } from 'next/dist/client/components/redirect-error';
 import { redirect } from 'next/navigation';
 import { cache } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
+import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
 import { getCachedAuth } from '@/lib/auth/cached';
 import {
   fetchBandsintownEvents,
@@ -176,9 +177,7 @@ async function resolveTourDates(
   const { userId } = await getCachedAuth();
 
   if (!userId) {
-    redirect(
-      `${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.SETTINGS_TOURING}`
-    );
+    redirect(buildAppShellSignInUrl(APP_ROUTES.SETTINGS_TOURING));
   }
 
   const profile = await requireProfile();

--- a/apps/web/app/app/(shell)/earnings/earnings-route.ts
+++ b/apps/web/app/app/(shell)/earnings/earnings-route.ts
@@ -1,13 +1,13 @@
 import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
+import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
 import { getCachedAuth } from '@/lib/auth/cached';
 
 export async function redirectFromEarningsRoute(returnPath: string) {
   const { userId } = await getCachedAuth();
 
   if (!userId) {
-    const redirectUrl = encodeURIComponent(returnPath);
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${redirectUrl}`);
+    redirect(buildAppShellSignInUrl(returnPath));
   }
 
   redirect(`${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`);

--- a/apps/web/app/app/(shell)/insights/page.tsx
+++ b/apps/web/app/app/(shell)/insights/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
 import { InsightsPanel } from '@/features/dashboard/insights/InsightsPanel';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
+import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
 import { getCachedAuth } from '@/lib/auth/cached';
 import { captureError } from '@/lib/error-tracking';
 import { throwIfRedirect } from '@/lib/utils/redirect-error';
@@ -124,7 +125,7 @@ export default async function InsightsPage() {
   const { userId } = await getCachedAuth();
 
   if (!userId) {
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.INSIGHTS}`);
+    redirect(buildAppShellSignInUrl(APP_ROUTES.INSIGHTS));
   }
 
   return (

--- a/apps/web/lib/releases/release-matrix-loader.ts
+++ b/apps/web/lib/releases/release-matrix-loader.ts
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation';
 import { cache } from 'react';
 import { getDashboardDataEssential } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
 import { APP_ROUTES } from '@/constants/routes';
+import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
 import { getCachedAuth } from '@/lib/auth/cached';
 import { CACHE_TTL } from '@/lib/cache/tags';
 import {
@@ -77,7 +78,7 @@ async function resolveReleaseMatrix(
   const { userId } = await getCachedAuth();
 
   if (!userId) {
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.RELEASES}`);
+    redirect(buildAppShellSignInUrl(APP_ROUTES.RELEASES));
   }
 
   const profile = await requireProfile(profileId);
@@ -107,7 +108,7 @@ async function resolveReleaseEntity(params: {
   const { userId } = await getCachedAuth();
 
   if (!userId) {
-    redirect(`${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.RELEASES}`);
+    redirect(buildAppShellSignInUrl(APP_ROUTES.RELEASES));
   }
 
   const profile = await requireProfile(params.profileId);

--- a/apps/web/tests/unit/calendar/calendar-page.test.tsx
+++ b/apps/web/tests/unit/calendar/calendar-page.test.tsx
@@ -130,7 +130,7 @@ describe('CalendarPage', () => {
     mocks.getCachedAuth.mockResolvedValueOnce({ userId: null });
 
     await expect(CalendarPage()).rejects.toThrow(
-      `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${APP_ROUTES.CALENDAR}`
+      `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=%2Fapp%2Fcalendar`
     );
 
     expect(mocks.getDashboardShellData).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Reuse the shared app-shell sign-in URL builder from the route-context helper instead of keeping private redirect builders.
- Move app-shell unauthenticated redirects in audience, insights, releases, calendar, earnings, and tour dates onto the same shell redirect contract.
- Add route-context coverage for redirect query-string preservation.

## Verification
- `pnpm --filter @jovie/web exec vitest run 'app/app/(shell)/app-shell-route-context.test.tsx' tests/unit/lib/auth/build-app-shell-signin-url.test.ts` — 11 tests passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `pnpm biome check --write 'apps/web/app/app/(shell)/app-shell-route-context.tsx' 'apps/web/app/app/(shell)/app-shell-route-context.test.tsx' 'apps/web/app/app/(shell)/audience/page.tsx' 'apps/web/app/app/(shell)/insights/page.tsx' 'apps/web/app/app/(shell)/calendar/page.tsx' 'apps/web/app/app/(shell)/earnings/earnings-route.ts' 'apps/web/app/app/(shell)/dashboard/tour-dates/actions.ts' apps/web/lib/releases/release-matrix-loader.ts` — passed.
- `pnpm --filter /web exec vitest run tests/unit/calendar/calendar-page.test.tsx` — 4 tests passed.
- `git diff --check` — passed.

<!-- agent-run-artifact
{
  "id": "jov-2420-shell-signin-streamed-routes-20260518",
  "source": "github",
  "sourceRunId": "cecc26cae045afcd0a21937f46f917628f908c7e",
  "kind": "workflow",
  "status": "done",
  "title": "Normalize app shell sign-in redirects",
  "summary": "Shared the app-shell sign-in URL builder across app-shell redirect paths without changing visual UI or streamed route data boundaries.",
  "modelRoute": "codex-cli",
  "allowedActions": ["write_code", "open_pr", "ready_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "User approved continued nonvisual shell migration slices without per-section approval.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2420",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2420/normalize-shell-sign-in-redirects-for-streamed-app-routes",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9132",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Redirect-only QA: focused route-context and auth URL tests passed, plus grep confirmed no hardcoded app-shell redirect_url construction remains under app-shell app/lib paths.",
      "checkedAt": "2026-05-18T14:08:17Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed changed imports and preserved audience/insights Suspense boundaries; no exp imports, loader changes, or visual changes introduced.",
      "checkedAt": "2026-05-18T14:08:17Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Local gates passed: focused Vitest, web typecheck, Biome on touched files, git diff whitespace check, and commit hook typecheck/eslint.",
      "checkedAt": "2026-05-18T14:08:17Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic verification only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T14:03:12Z",
  "updatedAt": "2026-05-18T14:08:17Z",
  "metadata": {
    "visualChange": false,
    "basePr": 9130,
    "routes": ["/app/audience", "/app/insights", "/app/releases", "/app/calendar", "/app/earnings", "/app/settings/touring"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
- Added test coverage for unauthenticated redirect scenarios, including preservation of query parameters in redirect URLs.

## Refactor
- Standardized sign-in redirect handling across multiple app pages (Audience, Insights, Calendar, Earnings, Releases) using a shared utility for consistent authentication behavior when users are not authenticated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->