### PR TITLE
JOV-2421: Move calendar onto shell route context

### DIFF
--- a/apps/web/app/app/(shell)/calendar/page.tsx
+++ b/apps/web/app/app/(shell)/calendar/page.tsx
@@ -1,9 +1,5 @@
 import type { Metadata } from 'next';
-import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
-import { PageErrorState } from '@/features/feedback/PageErrorState';
-import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
-import { getCachedAuth } from '@/lib/auth/cached';
 import { captureError } from '@/lib/error-tracking';
 import { queryKeys } from '@/lib/queries';
 import { HydrateClient } from '@/lib/queries/HydrateClient';
@@ -15,7 +11,7 @@ import type {
   TourDateProviderValue,
   TourDateViewModel,
 } from '@/lib/tour-dates/types';
-import { getDashboardShellData } from '../dashboard/actions';
+import { loadAppShellRouteContext } from '../app-shell-route-context';
 import { loadTourDates } from '../dashboard/tour-dates/actions';
 import { CalendarPageClient } from './CalendarPageClient';
 
@@ -101,28 +97,17 @@ async function prefetchCalendarQueries(profileId: string) {
  * notifications until the creator confirms.
  */
 export default async function CalendarPage() {
-  const { userId } = await getCachedAuth();
-  if (!userId) {
-    redirect(buildAppShellSignInUrl(CALENDAR_ROUTE));
+  const routeContext = await loadAppShellRouteContext({
+    route: CALENDAR_ROUTE,
+    dashboardErrorLogMessage: 'Dashboard data load failed on calendar page',
+    dashboardErrorMessage:
+      'Failed to load calendar data. Please refresh the page.',
+  });
+  if (!routeContext.ok) {
+    return routeContext.error;
   }
 
-  const dashboardData = await getDashboardShellData(userId);
-  if (dashboardData.dashboardLoadError) {
-    void captureError(
-      'Dashboard data load failed on calendar page',
-      dashboardData.dashboardLoadError,
-      { route: CALENDAR_ROUTE }
-    );
-    return (
-      <PageErrorState message='Failed to load calendar data. Please refresh the page.' />
-    );
-  }
-
-  if (dashboardData.needsOnboarding) {
-    redirect(APP_ROUTES.START);
-  }
-
-  const profileId = dashboardData.selectedProfile?.id;
+  const profileId = routeContext.profileId;
   if (profileId) {
     try {
       await prefetchCalendarQueries(profileId);


### PR DESCRIPTION
## Summary
- Move `/app/calendar` onto the shared `loadAppShellRouteContext` helper for auth, dashboard-load failure, onboarding redirects, and profile id access.
- Preserve existing release/event prefetching, prefetch error capture, hydration, and calendar client rendering.
- Remove page-local duplicate auth/dashboard boilerplate from the calendar route.

## Verification
- `pnpm --filter @jovie/web exec vitest run 'app/app/(shell)/app-shell-route-context.test.tsx'` — 7 tests passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `pnpm biome check --write 'apps/web/app/app/(shell)/calendar/page.tsx'` — passed.
- `git diff --check` — passed.

<!-- agent-run-artifact
{
  "id": "jov-2421-calendar-route-context-20260518",
  "source": "github",
  "sourceRunId": "995438edf58aa273ddb0be747822f3fa59890aae",
  "kind": "workflow",
  "status": "done",
  "title": "Move calendar page onto shared app shell route context",
  "summary": "Calendar now enters through the shared app-shell route context while preserving existing calendar prefetching and client rendering.",
  "modelRoute": "codex-cli",
  "allowedActions": ["write_code", "open_pr", "ready_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "User approved continued nonvisual shell migration slices without per-section approval.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2421",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2421/move-calendar-page-onto-shared-app-shell-route-context",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9134",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Route-context QA: focused unit coverage passed and the calendar diff preserves the existing hydrate/client path without visual changes.",
      "checkedAt": "2026-05-18T14:14:19Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed calendar import and prefetch flow; only page-local auth/dashboard boilerplate moved to the shared helper.",
      "checkedAt": "2026-05-18T14:14:19Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Local gates passed: focused Vitest, web typecheck, Biome on touched file, git diff whitespace check, and commit hook typecheck/eslint.",
      "checkedAt": "2026-05-18T14:14:19Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic verification only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T14:14:19Z",
  "updatedAt": "2026-05-18T14:14:19Z",
  "metadata": {
    "visualChange": false,
    "basePr": 9132,
    "route": "/app/calendar"
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal server-side routing and authentication handling in the calendar page for enhanced code maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->