### PR TITLE
JOV-2422: Move settings prefetches onto shell route context

### DIFF
--- a/apps/web/app/app/(shell)/settings/contacts/page.tsx
+++ b/apps/web/app/app/(shell)/settings/contacts/page.tsx
@@ -1,19 +1,27 @@
-import { getCachedAuth } from '@/lib/auth/cached';
+import { APP_ROUTES } from '@/constants/routes';
 import { queryKeys } from '@/lib/queries';
 import { getQueryClient } from '@/lib/queries/server';
-import { getDashboardShellData } from '../../dashboard/actions';
+import { loadAppShellRouteContext } from '../../app-shell-route-context';
 import { getProfileContactsForOwner } from '../../dashboard/contacts/actions';
 import { ContactsContent } from './ContactsContent';
 
 export const runtime = 'nodejs';
 
 export default async function SettingsContactsPage() {
-  const { userId } = await getCachedAuth();
-  const dashboardData = userId ? await getDashboardShellData(userId) : null;
+  const routeContext = await loadAppShellRouteContext({
+    route: APP_ROUTES.SETTINGS_CONTACTS,
+    dashboardErrorLogMessage:
+      'Dashboard data load failed on settings contacts page',
+    dashboardErrorMessage:
+      'Failed to load contacts settings. Please refresh the page.',
+  });
+  if (!routeContext.ok) {
+    return routeContext.error;
+  }
 
   // Prefetch contacts into the shared QueryClient so the client component
   // gets an instant cache hit instead of showing a loading skeleton.
-  const profileId = dashboardData?.selectedProfile?.id;
+  const profileId = routeContext.profileId;
   if (profileId) {
     const queryClient = getQueryClient();
     await queryClient.prefetchQuery({

--- a/apps/web/app/app/(shell)/settings/touring/page.tsx
+++ b/apps/web/app/app/(shell)/settings/touring/page.tsx
@@ -1,19 +1,27 @@
-import { getCachedAuth } from '@/lib/auth/cached';
+import { APP_ROUTES } from '@/constants/routes';
 import { queryKeys } from '@/lib/queries';
 import { getQueryClient } from '@/lib/queries/server';
-import { getDashboardShellData } from '../../dashboard/actions';
+import { loadAppShellRouteContext } from '../../app-shell-route-context';
 import { checkBandsintownConnection } from '../../dashboard/tour-dates/actions';
 import { TouringContent } from './TouringContent';
 
 export const runtime = 'nodejs';
 
 export default async function SettingsTouringPage() {
-  const { userId } = await getCachedAuth();
-  const dashboardData = userId ? await getDashboardShellData(userId) : null;
+  const routeContext = await loadAppShellRouteContext({
+    route: APP_ROUTES.SETTINGS_TOURING,
+    dashboardErrorLogMessage:
+      'Dashboard data load failed on settings touring page',
+    dashboardErrorMessage:
+      'Failed to load touring settings. Please refresh the page.',
+  });
+  if (!routeContext.ok) {
+    return routeContext.error;
+  }
 
   // Prefetch Bandsintown connection status so the client component
   // gets an instant cache hit instead of showing a loading skeleton.
-  const profileId = dashboardData?.selectedProfile?.id;
+  const profileId = routeContext.profileId;
   if (profileId) {
     const queryClient = getQueryClient();
     await queryClient.prefetchQuery({

--- a/apps/web/tests/unit/app/settings-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/settings-shell-normalization.test.ts
@@ -153,7 +153,7 @@ describe('settings shell normalization', () => {
     }
   });
 
-  it('keeps profile-scoped settings prefetches on the shell data path', () => {
+  it('keeps profile-scoped settings prefetches on the shared shell route context path', () => {
     const missingFiles = SETTINGS_PROFILE_SCOPED_PREFETCH_ROUTES.filter(
       filePath => !filePath
     );
@@ -167,9 +167,10 @@ describe('settings shell normalization', () => {
       }
 
       const source = readFileSync(filePath, 'utf8');
-      expect(source).toContain('getCachedAuth');
-      expect(source).toContain('getDashboardShellData');
+      expect(source).toContain('loadAppShellRouteContext');
       expect(source).not.toContain('getDashboardData');
+      expect(source).not.toContain('getCachedAuth');
+      expect(source).not.toContain('getDashboardShellData');
     }
   });
 });


### PR DESCRIPTION
## Summary
- Move `/app/settings/contacts` and `/app/settings/touring` onto the shared `loadAppShellRouteContext` helper.
- Preserve contacts and Bandsintown connection prefetching after profile resolution.
- Update the settings shell normalization guard to lock profile-scoped settings pages to the shared route-context path.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/settings-shell-normalization.test.ts 'app/app/(shell)/app-shell-route-context.test.tsx'` — 11 tests passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `pnpm biome check --write 'apps/web/app/app/(shell)/settings/contacts/page.tsx' 'apps/web/app/app/(shell)/settings/touring/page.tsx' apps/web/tests/unit/app/settings-shell-normalization.test.ts` — passed.
- `git diff --check` — passed.

<!-- agent-run-artifact
{
  "id": "jov-2422-settings-route-context-20260518",
  "source": "github",
  "sourceRunId": "e7e80e6ba5deac07d6e39b4fd55e0a1fa6be211c",
  "kind": "workflow",
  "status": "done",
  "title": "Move profile-scoped settings pages onto shared shell route context",
  "summary": "Contacts and touring settings pages now use the shared app-shell route context while preserving profile-scoped prefetch behavior and parent settings shell ownership.",
  "modelRoute": "codex-cli",
  "allowedActions": ["write_code", "open_pr", "ready_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "User approved continued nonvisual shell migration slices without per-section approval.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2422",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2422/move-profile-scoped-settings-pages-onto-shared-shell-route-context",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9136",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Settings normalization QA: focused guard and route-context tests passed; pages remain inside the parent settings shell with no visual changes.",
      "checkedAt": "2026-05-18T14:29:02Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed contacts/touring prefetch flow; route context replaces only duplicated auth/dashboard loading and preserves query keys and client components.",
      "checkedAt": "2026-05-18T14:29:02Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Local gates passed: focused Vitest, web typecheck, Biome on touched files, git diff whitespace check, and commit hook typecheck/eslint.",
      "checkedAt": "2026-05-18T14:29:02Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic verification only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T14:29:02Z",
  "updatedAt": "2026-05-18T14:45:12Z",
  "metadata": {
    "visualChange": false,
    "basePr": 9134,
    "routes": ["/app/settings/contacts", "/app/settings/touring"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the data loading architecture for Settings Contacts and Settings Touring pages using a unified route context approach, enhancing consistency and maintainability across the application.

* **Tests**
  * Updated unit tests to validate alignment with the new data loading pattern.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->