### PR TITLE
JOV-2423: Move connector settings onto shell route context

### DIFF
--- a/apps/web/app/app/(shell)/settings/connectors/page.tsx
+++ b/apps/web/app/app/(shell)/settings/connectors/page.tsx
@@ -3,13 +3,13 @@ import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import type { ConnectorStatus } from '@/components/features/connectors/ConnectorCard';
 import { APP_ROUTES } from '@/constants/routes';
-import { getCachedAuth } from '@/lib/auth/cached';
 import { db } from '@/lib/db';
-import { users } from '@/lib/db/schema/auth';
+import { getUserByClerkId } from '@/lib/db/queries/shared';
 import {
   connectorAccounts,
   suggestedActions,
 } from '@/lib/db/schema/connectors';
+import { loadAppShellRouteContext } from '../../app-shell-route-context';
 import { ConnectorsClient } from './ConnectorsClient';
 
 export const runtime = 'nodejs';
@@ -31,16 +31,18 @@ function toConnectorStatus(
 }
 
 export default async function SettingsConnectorsPage() {
-  const { userId: clerkId } = await getCachedAuth();
-  if (!clerkId) {
-    redirect(APP_ROUTES.DASHBOARD);
+  const routeContext = await loadAppShellRouteContext({
+    route: APP_ROUTES.SETTINGS_CONNECTORS,
+    dashboardErrorLogMessage:
+      'Dashboard data load failed on settings connectors page',
+    dashboardErrorMessage:
+      'Failed to load connector settings. Please refresh the page.',
+  });
+  if (!routeContext.ok) {
+    return routeContext.error;
   }
 
-  const [dbUser] = await db
-    .select({ id: users.id })
-    .from(users)
-    .where(eq(users.clerkId, clerkId))
-    .limit(1);
+  const dbUser = await getUserByClerkId(db, routeContext.userId);
 
   if (!dbUser) {
     redirect(APP_ROUTES.DASHBOARD);

--- a/apps/web/tests/unit/app/settings-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/settings-shell-normalization.test.ts
@@ -86,7 +86,7 @@ const SETTINGS_ALIAS_ROUTES = [
   },
 ] as const;
 
-const SETTINGS_PROFILE_SCOPED_PREFETCH_ROUTES = [
+const SETTINGS_SHARED_ROUTE_CONTEXT_FILES = [
   findSourceFile(
     resolve(process.cwd(), 'app/app/(shell)/settings/contacts/page.tsx'),
     resolve(
@@ -98,11 +98,19 @@ const SETTINGS_PROFILE_SCOPED_PREFETCH_ROUTES = [
     resolve(process.cwd(), 'app/app/(shell)/settings/touring/page.tsx'),
     resolve(process.cwd(), 'apps/web/app/app/(shell)/settings/touring/page.tsx')
   ),
+  findSourceFile(
+    resolve(process.cwd(), 'app/app/(shell)/settings/connectors/page.tsx'),
+    resolve(
+      process.cwd(),
+      'apps/web/app/app/(shell)/settings/connectors/page.tsx'
+    )
+  ),
 ] as const;
 
-const SETTINGS_PROFILE_SCOPED_PREFETCH_CANDIDATES = [
+const SETTINGS_SHARED_ROUTE_CONTEXT_CANDIDATES = [
   resolve(process.cwd(), 'app/app/(shell)/settings/contacts/page.tsx'),
   resolve(process.cwd(), 'app/app/(shell)/settings/touring/page.tsx'),
+  resolve(process.cwd(), 'app/app/(shell)/settings/connectors/page.tsx'),
 ] as const;
 
 describe('settings shell normalization', () => {
@@ -153,16 +161,16 @@ describe('settings shell normalization', () => {
     }
   });
 
-  it('keeps profile-scoped settings prefetches on the shared shell route context path', () => {
-    const missingFiles = SETTINGS_PROFILE_SCOPED_PREFETCH_ROUTES.filter(
+  it('keeps data-backed settings pages on the shared shell route context path', () => {
+    const missingFiles = SETTINGS_SHARED_ROUTE_CONTEXT_FILES.filter(
       filePath => !filePath
     );
     expect(missingFiles).toEqual([]);
 
-    for (const filePath of SETTINGS_PROFILE_SCOPED_PREFETCH_ROUTES) {
+    for (const filePath of SETTINGS_SHARED_ROUTE_CONTEXT_FILES) {
       if (!filePath) {
         throw new Error(
-          `Could not find profile-scoped settings source. Checked: ${SETTINGS_PROFILE_SCOPED_PREFETCH_CANDIDATES.join(', ')}`
+          `Could not find data-backed settings source. Checked: ${SETTINGS_SHARED_ROUTE_CONTEXT_CANDIDATES.join(', ')}`
         );
       }
 


### PR DESCRIPTION
## Summary
- Move `/app/settings/connectors` onto the shared `loadAppShellRouteContext` helper.
- Preserve Gmail, Calendar, and suggested-action queries against the app user record via `getUserByClerkId`.
- Extend the settings normalization guard so data-backed settings pages stay on the shared route-context path.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/settings-shell-normalization.test.ts 'app/app/(shell)/app-shell-route-context.test.tsx'` — 11 tests passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `pnpm biome check --write 'apps/web/app/app/(shell)/settings/connectors/page.tsx' apps/web/tests/unit/app/settings-shell-normalization.test.ts` — passed.
- `git diff --check` — passed.

<!-- agent-run-artifact
{
  "id": "jov-2423-settings-connectors-route-context-20260518",
  "source": "github",
  "sourceRunId": "b264dc176f8b84bea39d6c595aa37da97f3b9e22",
  "kind": "workflow",
  "status": "done",
  "title": "Move settings connectors page onto shared shell route context",
  "summary": "The connectors settings page now uses the shared app-shell route context for auth, dashboard load errors, and onboarding redirects while preserving connector account and suggested action data queries.",
  "modelRoute": "codex-cli",
  "allowedActions": ["write_code", "open_pr", "ready_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "User approved continued nonvisual shell migration slices without per-section approval.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2423",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2423/move-settings-connectors-page-onto-shared-shell-route-context",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9138",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Settings normalization QA: focused guard and route-context tests passed; the page stays inside the parent settings shell with no visual changes.",
      "checkedAt": "2026-05-18T15:00:30Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed connector data flow; route context replaces duplicated auth/dashboard handling and the connector account queries still use the internal app user id.",
      "checkedAt": "2026-05-18T15:00:30Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Local gates passed: focused Vitest, web typecheck, Biome on touched files, git diff whitespace check, and commit hook typecheck/eslint.",
      "checkedAt": "2026-05-18T15:00:30Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic verification only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T15:00:30Z",
  "updatedAt": "2026-05-18T15:00:30Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/settings/connectors"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal architecture of settings pages to improve code organization and maintainability.
  * Updated test coverage to validate architectural improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->