### PR TITLE
JOV-2424: Move artist profile settings onto shell route context

### DIFF
--- a/apps/web/app/app/(shell)/settings/artist-profile/page.tsx
+++ b/apps/web/app/app/(shell)/settings/artist-profile/page.tsx
@@ -1,16 +1,26 @@
+import { APP_ROUTES } from '@/constants/routes';
 import { PreviewDataHydrator } from '@/features/dashboard/organisms/PreviewDataHydrator';
 import { getCanonicalProfileDSPs } from '@/lib/profile-dsps';
-import {
-  getDashboardDataEssential,
-  getProfileSocialLinks,
-} from '../../dashboard/actions';
+import { loadAppShellRouteContext } from '../../app-shell-route-context';
+import { getProfileSocialLinks } from '../../dashboard/actions';
 import { ProfilePreviewOpener } from '../../dashboard/profile/ProfilePreviewOpener';
 import { ArtistProfileContent } from './ArtistProfileContent';
 
 export const runtime = 'nodejs';
 
 export default async function SettingsArtistProfilePage() {
-  const dashboardData = await getDashboardDataEssential();
+  const routeContext = await loadAppShellRouteContext({
+    route: APP_ROUTES.SETTINGS_ARTIST_PROFILE,
+    dashboardErrorLogMessage:
+      'Dashboard data load failed on settings artist profile page',
+    dashboardErrorMessage:
+      'Failed to load artist profile settings. Please refresh the page.',
+  });
+  if (!routeContext.ok) {
+    return routeContext.error;
+  }
+
+  const dashboardData = routeContext.dashboardData;
   const profileId = dashboardData.selectedProfile?.id;
   const initialLinks = profileId
     ? await getProfileSocialLinks(profileId).catch(() => [])

--- a/apps/web/tests/unit/app/settings-page.test.tsx
+++ b/apps/web/tests/unit/app/settings-page.test.tsx
@@ -22,7 +22,7 @@ describe('settings page aliases', () => {
     expect(redirectMock).toHaveBeenCalledWith(APP_ROUTES.SETTINGS_ACCOUNT);
   });
 
-  it('keeps artist profile settings on the essential dashboard data path', () => {
+  it('keeps artist profile settings on the shared shell route context path', () => {
     const source = readFileSync(
       resolve(
         process.cwd(),
@@ -31,7 +31,8 @@ describe('settings page aliases', () => {
       'utf8'
     );
 
-    expect(source).toContain('getDashboardDataEssential');
+    expect(source).toContain('loadAppShellRouteContext');
+    expect(source).not.toContain('getDashboardDataEssential');
     expect(source).not.toMatch(/\bgetDashboardData\(/);
   });
 });

--- a/apps/web/tests/unit/app/settings-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/settings-shell-normalization.test.ts
@@ -105,12 +105,20 @@ const SETTINGS_SHARED_ROUTE_CONTEXT_FILES = [
       'apps/web/app/app/(shell)/settings/connectors/page.tsx'
     )
   ),
+  findSourceFile(
+    resolve(process.cwd(), 'app/app/(shell)/settings/artist-profile/page.tsx'),
+    resolve(
+      process.cwd(),
+      'apps/web/app/app/(shell)/settings/artist-profile/page.tsx'
+    )
+  ),
 ] as const;
 
 const SETTINGS_SHARED_ROUTE_CONTEXT_CANDIDATES = [
   resolve(process.cwd(), 'app/app/(shell)/settings/contacts/page.tsx'),
   resolve(process.cwd(), 'app/app/(shell)/settings/touring/page.tsx'),
   resolve(process.cwd(), 'app/app/(shell)/settings/connectors/page.tsx'),
+  resolve(process.cwd(), 'app/app/(shell)/settings/artist-profile/page.tsx'),
 ] as const;
 
 describe('settings shell normalization', () => {


### PR DESCRIPTION
## Summary
- Move `/app/settings/artist-profile` onto the shared `loadAppShellRouteContext` helper.
- Reuse the returned dashboard data for selected-profile DSP and social-link hydration.
- Update focused settings guards so artist profile settings stays on the shared route-context path.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/settings-page.test.tsx tests/unit/app/settings-shell-normalization.test.ts 'app/app/(shell)/app-shell-route-context.test.tsx'` — 13 tests passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `pnpm biome check --write 'apps/web/app/app/(shell)/settings/artist-profile/page.tsx' apps/web/tests/unit/app/settings-shell-normalization.test.ts apps/web/tests/unit/app/settings-page.test.tsx` — passed.
- `git diff --check` — passed.

<!-- agent-run-artifact
{
  "id": "jov-2424-artist-profile-route-context-20260518",
  "source": "github",
  "sourceRunId": "a00b4d8ae6382835721d6be15edc17661ac95912",
  "kind": "workflow",
  "status": "done",
  "title": "Move artist profile settings page onto shared shell route context",
  "summary": "Artist profile settings now uses the shared app-shell route context for auth, dashboard load errors, and onboarding redirects while preserving preview hydration and profile content behavior.",
  "modelRoute": "codex-cli",
  "allowedActions": ["write_code", "open_pr", "ready_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "User approved continued nonvisual shell migration slices without per-section approval.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2424",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2424/move-artist-profile-settings-page-onto-shared-shell-route-context",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9140",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Settings route QA: focused settings page, normalization, and route-context tests passed; there are no visual changes.",
      "checkedAt": "2026-05-18T15:09:40Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed artist profile settings data flow; route context replaces the page-local dashboard essential load and keeps preview hydration inputs unchanged.",
      "checkedAt": "2026-05-18T15:09:40Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Local gates passed: focused Vitest, web typecheck, Biome on touched files, git diff whitespace check, and commit hook typecheck/eslint.",
      "checkedAt": "2026-05-18T15:09:40Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic verification only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T15:09:40Z",
  "updatedAt": "2026-05-18T15:14:45Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/settings/artist-profile"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated unit tests for artist profile settings page to verify use of shared data-loading mechanism.
  * Enhanced error handling with custom error messages for dashboard loading failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->