### PR TITLE
refactor(shell): use route context for insights

### DIFF
--- a/apps/web/app/app/(shell)/insights/page.tsx
+++ b/apps/web/app/app/(shell)/insights/page.tsx
@@ -1,154 +1,18 @@
-import { redirect } from 'next/navigation';
-import { Suspense } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
 import { InsightsPanel } from '@/features/dashboard/insights/InsightsPanel';
-import { PageErrorState } from '@/features/feedback/PageErrorState';
-import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
-import { getCachedAuth } from '@/lib/auth/cached';
-import { captureError } from '@/lib/error-tracking';
-import { throwIfRedirect } from '@/lib/utils/redirect-error';
-import { getDashboardDataEssential } from '../dashboard/actions';
+import { loadAppShellRouteContext } from '../app-shell-route-context';
 
 export const runtime = 'nodejs';
 
-/* -------------------------------------------------------------------------- */
-/*  Independent async sections — each in its own Suspense boundary so they    */
-/*  stream to the client as they resolve, instead of blocking behind one.     */
-/* -------------------------------------------------------------------------- */
-
-/**
- * Lightweight onboarding guard that streams independently.
- *
- * getDashboardDataEssential() is request-deduped via React cache() and already
- * pre-fetched by the shell layout, so this resolves near-instantly.
- * Separated into its own boundary so the redirect fires without
- * blocking the content skeleton from being displayed.
- */
-async function InsightsOnboardingGuard() {
-  try {
-    const dashboardData = await getDashboardDataEssential();
-    if (dashboardData.needsOnboarding && !dashboardData.dashboardLoadError) {
-      redirect(APP_ROUTES.START);
-    }
-  } catch (error) {
-    throwIfRedirect(error);
-    // Swallow — the layout's ProfileCompletionRedirect is the client-side safety net.
-  }
-  return null;
-}
-
-/**
- * Insights content: header with generate button, category filter pills,
- * and priority-grouped insight cards. The InsightsPanel client component
- * manages its own loading states via TanStack Query, so this section
- * streams the component shell while client-side data fetching runs in
- * parallel.
- */
-async function InsightsContentSection() {
-  try {
-    const dashboardData = await getDashboardDataEssential();
-
-    if (dashboardData.dashboardLoadError) {
-      void captureError(
-        'Dashboard data load failed on insights page',
-        dashboardData.dashboardLoadError,
-        { route: APP_ROUTES.INSIGHTS }
-      );
-      return (
-        <PageErrorState message='Failed to load insights. Please refresh the page.' />
-      );
-    }
-
-    if (dashboardData.needsOnboarding) return null;
-    return <InsightsPanel />;
-  } catch (error) {
-    throwIfRedirect(error);
-    void captureError('Insights page failed', error, {
-      route: APP_ROUTES.INSIGHTS,
-    });
-    return (
-      <PageErrorState message='Failed to load insights. Please refresh the page.' />
-    );
-  }
-}
-
-/* -------------------------------------------------------------------------- */
-/*  Section-specific skeleton fallbacks                                       */
-/* -------------------------------------------------------------------------- */
-
-const FILTER_SKELETON_KEYS = Array.from({ length: 5 }, (_, i) => `filter-${i}`);
-const SKELETON_KEYS = Array.from({ length: 4 }, (_, i) => `insight-${i}`);
-
-function InsightsHeaderSkeleton() {
-  return (
-    <div className='flex items-center justify-between'>
-      <div className='space-y-1.5'>
-        <div className='h-5 w-28 skeleton motion-reduce:animate-none rounded' />
-        <div className='h-3 w-48 skeleton motion-reduce:animate-none rounded' />
-      </div>
-      <div className='h-8 w-28 skeleton motion-reduce:animate-none rounded-lg' />
-    </div>
-  );
-}
-
-function InsightsFiltersSkeleton() {
-  return (
-    <div className='flex gap-1.5'>
-      {FILTER_SKELETON_KEYS.map(key => (
-        <div
-          key={key}
-          className='h-7 w-20 skeleton motion-reduce:animate-none rounded-full'
-        />
-      ))}
-    </div>
-  );
-}
-
-function InsightsCardsSkeleton() {
-  return (
-    <div className='space-y-3'>
-      {SKELETON_KEYS.map(key => (
-        <div
-          key={key}
-          className='h-28 skeleton motion-reduce:animate-none rounded-xl border border-subtle'
-        />
-      ))}
-    </div>
-  );
-}
-
-/* -------------------------------------------------------------------------- */
-/*  Page — sync shell with independent Suspense streaming boundaries          */
-/* -------------------------------------------------------------------------- */
-
 export default async function InsightsPage() {
-  const { userId } = await getCachedAuth();
-
-  if (!userId) {
-    redirect(buildAppShellSignInUrl(APP_ROUTES.INSIGHTS));
+  const routeContext = await loadAppShellRouteContext({
+    route: APP_ROUTES.INSIGHTS,
+    dashboardErrorLogMessage: 'Dashboard data load failed on insights page',
+    dashboardErrorMessage: 'Failed to load insights. Please refresh the page.',
+  });
+  if (!routeContext.ok) {
+    return routeContext.error;
   }
 
-  return (
-    <>
-      {/* Guard: invisible, triggers onboarding redirect independently */}
-      <Suspense fallback={null}>
-        <InsightsOnboardingGuard />
-      </Suspense>
-
-      {/* Content: header, filter pills, priority-grouped insight cards.
-          The skeleton is split into visual sections so the page layout
-          remains stable while streaming. */}
-      <Suspense
-        fallback={
-          <div className='space-y-6'>
-            <InsightsHeaderSkeleton />
-            <InsightsFiltersSkeleton />
-            <InsightsCardsSkeleton />
-          </div>
-        }
-      >
-        <InsightsContentSection />
-      </Suspense>
-    </>
-  );
+  return <InsightsPanel />;
 }

--- a/apps/web/tests/unit/app/insights-page.test.tsx
+++ b/apps/web/tests/unit/app/insights-page.test.tsx
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('insights page route contract', () => {
+  it('uses the shared app shell route context instead of local dashboard loaders', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'app/app/(shell)/insights/page.tsx'),
+      'utf8'
+    );
+
+    expect(source).toContain('loadAppShellRouteContext');
+    expect(source).not.toContain('getCachedAuth');
+    expect(source).not.toContain('getDashboardDataEssential');
+    expect(source).not.toMatch(/\bgetDashboardData\(/);
+  });
+});


### PR DESCRIPTION
## Summary
- Move `/app/insights` onto the shared app-shell route context for auth, dashboard load errors, and onboarding redirects.
- Remove duplicated page-local `getDashboardDataEssential()` calls and custom sign-in handling.
- Add focused source coverage so the insights page stays on the shared route-context path.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/insights-page.test.tsx tests/unit/dashboard/LegacyInsightsPage.test.ts tests/unit/app/shell-route-matches.test.ts` — 47 tests passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `pnpm biome check --write 'apps/web/app/app/(shell)/insights/page.tsx' apps/web/tests/unit/app/insights-page.test.tsx` — passed.
- `git diff --check` — passed.
- pre-push hook: Biome, proxy guard, Tailwind guard, typecheck, and lint — passed.

<!-- agent-run-artifact
{
  "id": "jov-2427-insights-route-context-20260518",
  "source": "github",
  "sourceRunId": "7c6bc3fae9b4bffbebd940955bece9e6e3a95d85",
  "kind": "workflow",
  "status": "done",
  "title": "Move insights page onto shared shell route context",
  "summary": "The insights route now uses loadAppShellRouteContext for auth, dashboard error handling, and onboarding redirects, removing repeated page-local dashboard essential loads while preserving the InsightsPanel surface.",
  "modelRoute": "codex-cli",
  "allowedActions": ["write_code", "open_pr", "ready_pr"],
  "forbiddenActions": ["mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": "User approved continued nonvisual shell migration slices without per-section approval.",
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2427",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2427/move-insights-page-onto-shared-shell-route-context",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9145",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused route QA passed: insights route contract, legacy insights redirect, and shell route matching tests.",
      "checkedAt": "2026-05-18T15:46:30Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed nonvisual scope: insights keeps the same client panel while auth, dashboard error, and onboarding handling move to the shared app-shell route context.",
      "checkedAt": "2026-05-18T15:46:30Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Local gates passed: focused Vitest, web typecheck, Biome on touched files, git diff whitespace check, commit hooks, and pre-push hooks.",
      "checkedAt": "2026-05-18T15:46:30Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic verification only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T15:46:30Z",
  "updatedAt": "2026-05-18T15:46:30Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/insights"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the insights page implementation by consolidating request-time data loading logic into a single unified entry point.
  * Simplified error handling and authentication flow.

* **Tests**
  * Added unit test coverage to verify the updated insights page structure and dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->