### PR TITLE
refactor(shell): use route context for audience

### DIFF
--- a/apps/web/app/app/(shell)/app-shell-route-context.test.tsx
+++ b/apps/web/app/app/(shell)/app-shell-route-context.test.tsx
@@ -189,4 +189,24 @@ describe('loadAppShellRouteContext', () => {
       profileId: 'profile_2',
     });
   });
+
+  it('uses a caller-provided authenticated user id without a second auth lookup', async () => {
+    const data = shellData({ selectedProfile: { id: 'profile_3' } });
+    getDashboardShellDataMock.mockResolvedValue(data);
+
+    const result = await loadAppShellRouteContext({
+      route: '/app/audience',
+      authenticatedUserId: 'user_from_page',
+      dashboardErrorMessage: 'Failed to load audience data.',
+    });
+
+    expect(getCachedAuthMock).not.toHaveBeenCalled();
+    expect(getDashboardShellDataMock).toHaveBeenCalledWith('user_from_page');
+    expect(result).toMatchObject({
+      ok: true,
+      userId: 'user_from_page',
+      dashboardData: data,
+      profileId: 'profile_3',
+    });
+  });
 });

--- a/apps/web/app/app/(shell)/app-shell-route-context.tsx
+++ b/apps/web/app/app/(shell)/app-shell-route-context.tsx
@@ -30,6 +30,7 @@ export interface LoadAppShellRouteContextOptions {
   readonly dashboardErrorLogMessage?: string;
   readonly authFailure?: 'redirect' | 'notFound';
   readonly requiredFlag?: AppFlagName;
+  readonly authenticatedUserId?: string | null;
 }
 
 export type AppShellRouteContextResult =
@@ -42,8 +43,9 @@ export async function loadAppShellRouteContext({
   dashboardErrorLogMessage = 'Dashboard data load failed on app shell route',
   authFailure = 'redirect',
   requiredFlag,
+  authenticatedUserId = null,
 }: LoadAppShellRouteContextOptions): Promise<AppShellRouteContextResult> {
-  const { userId } = await getCachedAuth();
+  const userId = authenticatedUserId?.trim() || (await getCachedAuth()).userId;
 
   if (!userId) {
     if (authFailure === 'notFound') {

--- a/apps/web/app/app/(shell)/audience/page.tsx
+++ b/apps/web/app/app/(shell)/audience/page.tsx
@@ -17,7 +17,7 @@ import {
   trimTrailingSlashes,
 } from '@/lib/utils/string-utils';
 import { convertDrizzleCreatorProfileToArtist } from '@/types/db';
-import { getDashboardShellData } from '../dashboard/actions';
+import { loadAppShellRouteContext } from '../app-shell-route-context';
 import { getAudienceServerData } from '../dashboard/audience/audience-data';
 import { loadUpcomingTourDates } from '../dashboard/tour-dates/actions';
 
@@ -27,9 +27,8 @@ export const runtime = 'nodejs';
  * Audience page — streams instantly after auth gate.
  *
  * Auth check via getCachedAuth (Clerk JWT, no DB) runs at the page level
- * so unauthenticated users redirect immediately. Uses getDashboardShellData
- * (skips settings/entitlements) for faster shell rendering. Audience data
- * is cached via unstable_cache (5 min TTL) so repeat visits are instant.
+ * so unauthenticated users redirect immediately. The async content uses the
+ * shared shell route context while preserving the Suspense table fallback.
  */
 export default async function AudiencePage({
   searchParams,
@@ -48,10 +47,6 @@ export default async function AudiencePage({
   );
 }
 
-/**
- * Async server component — fetches dashboard shell + audience data.
- * Suspense boundary above shows skeleton instantly while this resolves.
- */
 async function AudienceContent({
   userId,
   searchParams,
@@ -61,28 +56,18 @@ async function AudienceContent({
 }>) {
   try {
     const isE2E = process.env.NEXT_PUBLIC_E2E_MODE === '1';
-
-    // Shell data is faster than essential data (skips settings/entitlements)
-    const dashboardData = await getDashboardShellData(userId);
-
-    if (dashboardData.dashboardLoadError) {
-      void captureError(
-        'Dashboard data load failed on audience page',
-        dashboardData.dashboardLoadError,
-        { route: APP_ROUTES.AUDIENCE }
-      );
-      return (
-        <PageErrorState message='Failed to load audience data. Please refresh the page.' />
-      );
+    const routeContext = await loadAppShellRouteContext({
+      route: APP_ROUTES.AUDIENCE,
+      authenticatedUserId: userId,
+      dashboardErrorLogMessage: 'Dashboard data load failed on audience page',
+      dashboardErrorMessage:
+        'Failed to load audience data. Please refresh the page.',
+    });
+    if (!routeContext.ok) {
+      return routeContext.error;
     }
 
-    // Onboarding check first — during provisioning, user may be null but
-    // needsOnboarding is true. Checking user first would incorrectly redirect
-    // authenticated-but-not-yet-provisioned users to signin.
-    if (dashboardData.needsOnboarding && !dashboardData.dashboardLoadError) {
-      redirect(APP_ROUTES.START);
-    }
-
+    const { dashboardData } = routeContext;
     if (!dashboardData.user?.id) {
       redirect(buildAppShellSignInUrl(APP_ROUTES.AUDIENCE));
     }
@@ -96,16 +81,12 @@ async function AudienceContent({
         ? `${trimTrailingSlashes(BASE_URL)}/${trimLeadingSlashes(artist.handle)}`
         : undefined;
 
-    // Parse search params using nuqs for type-safe URL state
     const parsedParams = await audienceSearchParams.parse(searchParams);
-
-    // Validate segments from URL against known values
     const validSegments = parsedParams.segments.filter(
       (s): s is AudienceSegment =>
         (audienceFilters as readonly string[]).includes(s)
     );
 
-    // Fetch audience data and tour dates in parallel
     const [audienceData, tourDates] = await Promise.all([
       getAudienceServerData({
         userId: dashboardData.user.id,
@@ -125,7 +106,6 @@ async function AudienceContent({
         : Promise.resolve([]),
     ]);
 
-    // Map tour dates to lightweight shape for client-side city matching
     const tourDatesForMatching = tourDates.map(
       (td: { city: string; startDate: string }) => ({
         city: td.city,

--- a/apps/web/tests/unit/app/audience-page.test.tsx
+++ b/apps/web/tests/unit/app/audience-page.test.tsx
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('audience app shell route', () => {
+  it('uses the shared route context without reloading dashboard shell data locally', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'app/app/(shell)/audience/page.tsx'),
+      'utf8'
+    );
+
+    expect(source).toContain('loadAppShellRouteContext');
+    expect(source).toContain('authenticatedUserId: userId');
+    expect(source).not.toContain('getDashboardShellData');
+    expect(source).not.toContain('dashboardLoadError');
+    expect(source).not.toMatch(/\bgetDashboardData(?:Essential)?\(/);
+  });
+});


### PR DESCRIPTION
## Summary

- Extend `loadAppShellRouteContext` with an optional authenticated user id so streamed routes can keep a page-level auth gate without a second Clerk auth lookup.
- Move the audience content dashboard shell load, onboarding redirect, and dashboard error surface onto the shared route context.
- Add focused source-contract and route-context coverage for the audience migration.

## Verification

- `pnpm biome check --write 'apps/web/app/app/(shell)/audience/page.tsx' 'apps/web/app/app/(shell)/app-shell-route-context.tsx' 'apps/web/app/app/(shell)/app-shell-route-context.test.tsx' apps/web/tests/unit/app/audience-page.test.tsx`
- `pnpm --filter @jovie/web exec vitest run 'app/app/(shell)/app-shell-route-context.test.tsx' tests/unit/app/audience-page.test.tsx tests/unit/app/shell-route-matches.test.ts` — 53 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2428-audience-route-context",
  "source": "github",
  "sourceRunId": "f73a19e74cf09aa4e6c090354a2bdc885fcb6684",
  "kind": "workflow",
  "status": "done",
  "title": "Move audience route onto shared shell context",
  "summary": "Audience now uses loadAppShellRouteContext for dashboard shell data, onboarding, and dashboard error handling while preserving the streamed table fallback and audience-specific error state.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2428",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2428/move-audience-content-onto-shared-shell-route-context",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9147",
  "adminSurface": "/app/audience",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused route-context, audience source-contract, shell route matching, typecheck, Biome, diff-check, and pre-push verification passed.",
      "checkedAt": "2026-05-18T16:02:21.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for route-context scope, graceful data failure handling, and no visual surface changes.",
      "checkedAt": "2026-05-18T16:02:21.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch pushed with conventional commit and PR artifact prepared.",
      "checkedAt": "2026-05-18T16:02:21.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T16:02:21.000Z",
  "updatedAt": "2026-05-18T16:02:21.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/audience"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added unit tests for app shell route context validation and audience page routing verification.

* **Refactor**
  * Refactored audience page to utilize centralized app shell route context handling, improving consistency across the application routing layer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->