### PR TITLE
refactor(shell): use route context for earnings

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/earnings/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/earnings/page.tsx
@@ -4,5 +4,5 @@ import { redirectFromEarningsRoute } from '../../earnings/earnings-route';
 export const runtime = 'nodejs';
 
 export default async function EarningsPage() {
-  await redirectFromEarningsRoute(APP_ROUTES.DASHBOARD_EARNINGS);
+  return redirectFromEarningsRoute(APP_ROUTES.DASHBOARD_EARNINGS);
 }

--- a/apps/web/app/app/(shell)/earnings/earnings-route.ts
+++ b/apps/web/app/app/(shell)/earnings/earnings-route.ts
@@ -1,13 +1,16 @@
 import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
-import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
-import { getCachedAuth } from '@/lib/auth/cached';
+import { loadAppShellRouteContext } from '../app-shell-route-context';
 
 export async function redirectFromEarningsRoute(returnPath: string) {
-  const { userId } = await getCachedAuth();
-
-  if (!userId) {
-    redirect(buildAppShellSignInUrl(returnPath));
+  const routeContext = await loadAppShellRouteContext({
+    route: returnPath,
+    dashboardErrorLogMessage: 'Dashboard data load failed on earnings page',
+    dashboardErrorMessage:
+      'Failed to load earnings settings. Please refresh the page.',
+  });
+  if (!routeContext.ok) {
+    return routeContext.error;
   }
 
   redirect(`${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`);

--- a/apps/web/app/app/(shell)/earnings/page.tsx
+++ b/apps/web/app/app/(shell)/earnings/page.tsx
@@ -4,5 +4,5 @@ import { redirectFromEarningsRoute } from './earnings-route';
 export const runtime = 'nodejs';
 
 export default async function EarningsPage() {
-  await redirectFromEarningsRoute(APP_ROUTES.EARNINGS);
+  return redirectFromEarningsRoute(APP_ROUTES.EARNINGS);
 }

--- a/apps/web/tests/unit/app/dashboard-earnings-page.test.tsx
+++ b/apps/web/tests/unit/app/dashboard-earnings-page.test.tsx
@@ -1,19 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
 
-const { redirectMock, getCachedAuthMock } = vi.hoisted(() => ({
+const { loadAppShellRouteContextMock, redirectMock } = vi.hoisted(() => ({
+  loadAppShellRouteContextMock: vi.fn(),
   redirectMock: vi.fn((url: string) => {
     throw new Error(`REDIRECT:${url}`);
   }),
-  getCachedAuthMock: vi.fn(),
 }));
 
 vi.mock('next/navigation', () => ({
   redirect: redirectMock,
 }));
 
-vi.mock('@/lib/auth/cached', () => ({
-  getCachedAuth: getCachedAuthMock,
+vi.mock('@/app/app/(shell)/app-shell-route-context', () => ({
+  loadAppShellRouteContext: loadAppShellRouteContextMock,
 }));
 
 import EarningsPage from '@/app/app/(shell)/dashboard/earnings/page';
@@ -21,26 +23,38 @@ import CanonicalEarningsPage from '@/app/app/(shell)/earnings/page';
 
 beforeEach(() => {
   redirectMock.mockClear();
-  getCachedAuthMock.mockReset();
+  loadAppShellRouteContextMock.mockReset();
+  loadAppShellRouteContextMock.mockResolvedValue({
+    ok: true,
+    userId: 'user_123',
+    profileId: 'profile_123',
+    dashboardData: {},
+  });
 });
 
 describe('dashboard earnings page', () => {
   it('redirects unauthenticated users to sign-in with the legacy route as the return target', async () => {
-    getCachedAuthMock.mockResolvedValueOnce({ userId: null });
     const encodedReturnPath = encodeURIComponent(APP_ROUTES.DASHBOARD_EARNINGS);
+    loadAppShellRouteContextMock.mockRejectedValueOnce(
+      new Error(
+        `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${encodedReturnPath}`
+      )
+    );
 
     await expect(EarningsPage()).rejects.toThrow(
       `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${encodedReturnPath}`
     );
 
-    expect(redirectMock).toHaveBeenCalledWith(
-      `${APP_ROUTES.SIGNIN}?redirect_url=${encodedReturnPath}`
-    );
+    expect(loadAppShellRouteContextMock).toHaveBeenCalledWith({
+      route: APP_ROUTES.DASHBOARD_EARNINGS,
+      dashboardErrorLogMessage: 'Dashboard data load failed on earnings page',
+      dashboardErrorMessage:
+        'Failed to load earnings settings. Please refresh the page.',
+    });
+    expect(redirectMock).not.toHaveBeenCalled();
   });
 
   it('redirects authenticated users to artist profile tips', async () => {
-    getCachedAuthMock.mockResolvedValueOnce({ userId: 'user_123' });
-
     await expect(EarningsPage()).rejects.toThrow(
       `REDIRECT:${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`
     );
@@ -53,21 +67,27 @@ describe('dashboard earnings page', () => {
 
 describe('canonical earnings page', () => {
   it('redirects unauthenticated users to sign-in with the canonical route as the return target', async () => {
-    getCachedAuthMock.mockResolvedValueOnce({ userId: null });
     const encodedReturnPath = encodeURIComponent(APP_ROUTES.EARNINGS);
+    loadAppShellRouteContextMock.mockRejectedValueOnce(
+      new Error(
+        `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${encodedReturnPath}`
+      )
+    );
 
     await expect(CanonicalEarningsPage()).rejects.toThrow(
       `REDIRECT:${APP_ROUTES.SIGNIN}?redirect_url=${encodedReturnPath}`
     );
 
-    expect(redirectMock).toHaveBeenCalledWith(
-      `${APP_ROUTES.SIGNIN}?redirect_url=${encodedReturnPath}`
-    );
+    expect(loadAppShellRouteContextMock).toHaveBeenCalledWith({
+      route: APP_ROUTES.EARNINGS,
+      dashboardErrorLogMessage: 'Dashboard data load failed on earnings page',
+      dashboardErrorMessage:
+        'Failed to load earnings settings. Please refresh the page.',
+    });
+    expect(redirectMock).not.toHaveBeenCalled();
   });
 
   it('redirects authenticated users to artist profile tips', async () => {
-    getCachedAuthMock.mockResolvedValueOnce({ userId: 'user_123' });
-
     await expect(CanonicalEarningsPage()).rejects.toThrow(
       `REDIRECT:${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`
     );
@@ -75,5 +95,17 @@ describe('canonical earnings page', () => {
     expect(redirectMock).toHaveBeenCalledWith(
       `${APP_ROUTES.SETTINGS_ARTIST_PROFILE}?tab=earn#pay`
     );
+  });
+
+  it('keeps earnings route auth on the shared route context', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), 'app/app/(shell)/earnings/earnings-route.ts'),
+      'utf8'
+    );
+
+    expect(source).toContain('loadAppShellRouteContext');
+    expect(source).not.toContain('getCachedAuth');
+    expect(source).not.toContain('buildAppShellSignInUrl');
+    expect(source).not.toContain('getDashboardShellData');
   });
 });


### PR DESCRIPTION
## Summary

- Move `/app/earnings` and the legacy `/app/dashboard/earnings` alias onto `loadAppShellRouteContext()` for auth, onboarding, and dashboard load errors.
- Preserve the existing authenticated redirect to `/app/settings/artist-profile?tab=earn#pay`.
- Return the shared error state from both page aliases when shell context loading fails.

## Verification

- `pnpm biome check --write 'apps/web/app/app/(shell)/earnings/earnings-route.ts' 'apps/web/app/app/(shell)/earnings/page.tsx' 'apps/web/app/app/(shell)/dashboard/earnings/page.tsx' apps/web/tests/unit/app/dashboard-earnings-page.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/dashboard-earnings-page.test.tsx tests/unit/routes/shell-nav-coverage.test.ts tests/unit/app/shell-route-matches.test.ts` — 54 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2430-earnings-route-context",
  "source": "github",
  "sourceRunId": "d200f54f38699ae406cc42921c92c4ceed9191dd",
  "kind": "workflow",
  "status": "done",
  "title": "Move earnings redirect route onto shared shell context",
  "summary": "Earnings route aliases now use loadAppShellRouteContext for auth, onboarding, and dashboard load errors while preserving the artist-profile earnings redirect.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2430",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2430/move-earnings-route-redirect-onto-shared-shell-route-context",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9166",
  "adminSurface": "/app/earnings",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused earnings route tests, shell nav coverage, shell route matching, typecheck, Biome, diff-check, and pre-push verification passed.",
      "checkedAt": "2026-05-18T16:17:30.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for route-context scope, legacy alias preservation, shared error return behavior, and no visual surface changes.",
      "checkedAt": "2026-05-18T16:17:30.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch pushed with conventional commit and PR artifact prepared.",
      "checkedAt": "2026-05-18T16:17:30.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T16:17:30.000Z",
  "updatedAt": "2026-05-18T16:17:30.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/earnings", "/app/dashboard/earnings"]
  }
}
-->
