### PR TITLE
refactor(shell): use route context for admin utilities

### DIFF
--- a/apps/web/app/app/(shell)/feature-flags/page.tsx
+++ b/apps/web/app/app/(shell)/feature-flags/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
+import { loadAppShellRouteContext } from '@/app/app/(shell)/app-shell-route-context';
 import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
 import { APP_ROUTES } from '@/constants/routes';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
@@ -25,7 +26,20 @@ export interface FlagRow {
 }
 
 export default async function FeatureFlagsPage() {
-  const entitlements = await getCurrentUserEntitlements();
+  const [routeContext, entitlements] = await Promise.all([
+    loadAppShellRouteContext({
+      route: APP_ROUTES.FEATURE_FLAGS,
+      dashboardErrorLogMessage:
+        'Dashboard data load failed on feature flags page',
+      dashboardErrorMessage:
+        'Failed to load feature flags. Please refresh the page.',
+    }),
+    getCurrentUserEntitlements(),
+  ]);
+  if (!routeContext.ok) {
+    return routeContext.error;
+  }
+
   if (
     !entitlements.isAuthenticated ||
     !entitlements.userId ||

--- a/apps/web/app/app/(shell)/settings/retargeting-ads/layout.tsx
+++ b/apps/web/app/app/(shell)/settings/retargeting-ads/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
+import { loadAppShellRouteContext } from '@/app/app/(shell)/app-shell-route-context';
 import { APP_ROUTES } from '@/constants/routes';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 
@@ -12,13 +13,25 @@ export default async function RetargetingAdsLayout({
 }) {
   // getCurrentUserEntitlements degrades gracefully on billing failure --
   // admin status is fetched independently and preserved even when billing is down.
-  const entitlements = await getCurrentUserEntitlements();
-
-  if (!entitlements.isAuthenticated || !entitlements.userId) {
-    redirect(APP_ROUTES.SIGNIN);
+  const [routeContext, entitlements] = await Promise.all([
+    loadAppShellRouteContext({
+      route: APP_ROUTES.SETTINGS_RETARGETING_ADS,
+      dashboardErrorLogMessage:
+        'Dashboard data load failed on retargeting ads settings page',
+      dashboardErrorMessage:
+        'Failed to load retargeting ads settings. Please refresh the page.',
+    }),
+    getCurrentUserEntitlements(),
+  ]);
+  if (!routeContext.ok) {
+    return routeContext.error;
   }
 
-  if (!entitlements.isAdmin) {
+  if (
+    !entitlements.isAuthenticated ||
+    !entitlements.userId ||
+    !entitlements.isAdmin
+  ) {
     redirect(APP_ROUTES.DASHBOARD);
   }
 

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -63,6 +63,7 @@ export const APP_ROUTES = {
   SETTINGS_AUDIENCE: '/app/settings/audience',
   SETTINGS_ANALYTICS: '/app/settings/analytics',
   SETTINGS_ADMIN: '/app/settings/admin',
+  SETTINGS_RETARGETING_ADS: '/app/settings/retargeting-ads',
   /** @deprecated Use SETTINGS_DATA_PRIVACY instead */
   SETTINGS_DELETE_ACCOUNT: '/app/settings/delete-account',
 
@@ -104,6 +105,7 @@ export const APP_ROUTES = {
   ADMIN_PLATFORM_CONNECTIONS: '/app/admin/platform-connections',
   ADMIN_AGENT_RUN: '/app/admin/agent-runs',
   ADMIN_AGENT_RUN_DETAIL: '/app/admin/agent-runs/[id]',
+  FEATURE_FLAGS: '/app/feature-flags',
 
   // System
   UNAVAILABLE: '/unavailable',

--- a/apps/web/tests/unit/app/feature-flags-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/feature-flags-shell-normalization.test.ts
@@ -30,8 +30,12 @@ describe('feature flags shell normalization', () => {
 
     expect(source).toContain('AdminToolPage');
     expect(source).toContain("testId='feature-flags-page'");
+    expect(source).toContain('loadAppShellRouteContext');
     expect(source).not.toContain('title=');
     expect(source).not.toContain('description=');
+    expect(source).not.toContain('getCachedAuth');
+    expect(source).not.toContain('getDashboardDataEssential');
+    expect(source).not.toContain('getDashboardShellData');
   });
 
   it('uses shared admin table primitives instead of bespoke table chrome', () => {

--- a/apps/web/tests/unit/app/settings-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/settings-shell-normalization.test.ts
@@ -39,6 +39,14 @@ const RETARGETING_ROUTE_CANDIDATES = [
   ),
 ] as const;
 
+const RETARGETING_LAYOUT = findSourceFile(
+  resolve(process.cwd(), 'app/app/(shell)/settings/retargeting-ads/layout.tsx'),
+  resolve(
+    process.cwd(),
+    'apps/web/app/app/(shell)/settings/retargeting-ads/layout.tsx'
+  )
+);
+
 const SETTINGS_ALIAS_ROUTES = [
   {
     route: 'settings root',
@@ -149,6 +157,21 @@ describe('settings shell normalization', () => {
       expect(source).not.toMatch(/<PageContent\b/);
       expect(source).not.toMatch(/import\s*\{[^}]*PageContent/);
     }
+  });
+
+  it('keeps retargeting admin auth on the shared shell route context path', () => {
+    expect(RETARGETING_LAYOUT).toBeDefined();
+
+    if (!RETARGETING_LAYOUT) {
+      throw new Error('Could not find retargeting settings layout source');
+    }
+
+    const source = readFileSync(RETARGETING_LAYOUT, 'utf8');
+    expect(source).toContain('loadAppShellRouteContext');
+    expect(source).toContain('getCurrentUserEntitlements');
+    expect(source).not.toContain('getCachedAuth');
+    expect(source).not.toContain('getDashboardDataEssential');
+    expect(source).not.toContain('getDashboardShellData');
   });
 
   it('keeps legacy settings aliases as lightweight route redirects', () => {


### PR DESCRIPTION
## Summary

- Move feature flags and retargeting ads settings routes onto `loadAppShellRouteContext()` for auth, onboarding, and dashboard load errors.
- Preserve admin-only gating through `getCurrentUserEntitlements()`.
- Add route constants for the existing utility paths so shell context calls avoid local hardcoded URLs.

## Verification

- `pnpm biome check --write apps/web/constants/routes.ts 'apps/web/app/app/(shell)/feature-flags/page.tsx' 'apps/web/app/app/(shell)/settings/retargeting-ads/layout.tsx' apps/web/tests/unit/app/feature-flags-shell-normalization.test.ts apps/web/tests/unit/app/settings-shell-normalization.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/feature-flags-shell-normalization.test.ts tests/unit/app/settings-shell-normalization.test.ts tests/unit/app/settings-retargeting-shell.test.ts tests/unit/routes/shell-nav-coverage.test.ts tests/unit/constants/routes.test.ts` — 18 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2431-admin-utility-route-context",
  "source": "github",
  "sourceRunId": "d6f7cf05e870eef0a7108be266087bad209e0c8c",
  "kind": "workflow",
  "status": "done",
  "title": "Move admin utility routes onto shared shell context",
  "summary": "Feature flags and retargeting ads settings now use loadAppShellRouteContext for auth, onboarding, and dashboard load errors while preserving admin entitlement gates.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2431",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2431/move-admin-gated-settings-utility-routes-onto-shared-shell-route",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9168",
  "adminSurface": "/app/feature-flags",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused feature-flags, settings shell, retargeting shell, nav coverage, constants route tests, typecheck, Biome, diff-check, and pre-push verification passed.",
      "checkedAt": "2026-05-18T16:27:30.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for route-context scope, admin entitlement preservation, hardcoded route guard compliance, and no visual surface changes.",
      "checkedAt": "2026-05-18T16:27:30.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch pushed with conventional commit and PR artifact prepared.",
      "checkedAt": "2026-05-18T16:27:30.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T16:27:30.000Z",
  "updatedAt": "2026-05-18T16:27:30.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/feature-flags", "/app/settings/retargeting-ads"]
  }
}
-->
