### PR TITLE
refactor(shell): remove duplicate admin child auth

### DIFF
--- a/apps/web/app/app/(shell)/admin/interviews/page.tsx
+++ b/apps/web/app/app/(shell)/admin/interviews/page.tsx
@@ -1,12 +1,8 @@
 import { Badge } from '@jovie/ui';
 import { desc, eq } from 'drizzle-orm';
 import type { Metadata } from 'next';
-import { redirect } from 'next/navigation';
 import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
-import { APP_ROUTES } from '@/constants/routes';
-import { isAdmin as checkAdminRole } from '@/lib/admin/roles';
-import { getCachedAuth } from '@/lib/auth/cached';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema/auth';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
@@ -18,13 +14,6 @@ import { capitalizeFirst } from '@/lib/utils/string-utils';
 
 export const metadata: Metadata = { title: 'Interviews — Admin' };
 export const runtime = 'nodejs';
-
-async function requireAdminOrRedirect(): Promise<void> {
-  const { userId } = await getCachedAuth();
-  if (!userId || !(await checkAdminRole(userId))) {
-    redirect(APP_ROUTES.DASHBOARD);
-  }
-}
 
 function formatDate(iso: Date | string): string {
   const d = typeof iso === 'string' ? new Date(iso) : iso;
@@ -49,8 +38,6 @@ function statusBadgeTone(status: string) {
 }
 
 export default async function AdminInterviewsPage() {
-  await requireAdminOrRedirect();
-
   const rows = await db
     .select({
       id: userInterviews.id,

--- a/apps/web/app/app/(shell)/admin/platform-connections/page.tsx
+++ b/apps/web/app/app/(shell)/admin/platform-connections/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { notFound } from 'next/navigation';
 import { AdminWorkspacePage } from '@/components/features/admin/layout/AdminWorkspacePage';
 import {
   getPlaylistEngineSettings,
@@ -8,8 +7,7 @@ import {
   readAccountLabel,
   readExternalAccountScopes,
 } from '@/lib/admin/platform-connections';
-import { isAdmin as checkAdminRole } from '@/lib/admin/roles';
-import { getCachedAuth, getCachedCurrentUser } from '@/lib/auth/cached';
+import { getCachedCurrentUser } from '@/lib/auth/cached';
 import { REQUIRED_PLAYLIST_SPOTIFY_SCOPES } from '@/lib/spotify/system-account';
 import { PlatformConnectionsClient } from './PlatformConnectionsClient';
 
@@ -24,19 +22,11 @@ const TAB_OPTIONS = [
   { value: 'engine' as const, label: 'Playlist Engine' },
 ] as const;
 
-async function requireAdmin(): Promise<void> {
-  const { userId } = await getCachedAuth();
-  if (!userId || !(await checkAdminRole(userId))) {
-    notFound();
-  }
-}
-
 export default async function AdminPlatformConnectionsPage({
   searchParams,
 }: Readonly<{
   searchParams: Promise<{ tab?: string }>;
 }>) {
-  await requireAdmin();
   const { tab = 'spotify' } = await searchParams;
   const currentTab = (
     ['spotify', 'engine'].includes(tab) ? tab : 'spotify'

--- a/apps/web/tests/unit/app/admin-child-auth-normalization.test.ts
+++ b/apps/web/tests/unit/app/admin-child-auth-normalization.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ADMIN_INTERVIEWS_PAGE = resolve(
+  process.cwd(),
+  'app/app/(shell)/admin/interviews/page.tsx'
+);
+const ADMIN_PLATFORM_CONNECTIONS_PAGE = resolve(
+  process.cwd(),
+  'app/app/(shell)/admin/platform-connections/page.tsx'
+);
+
+describe('admin child route auth normalization', () => {
+  it('keeps read-only admin child pages on the parent admin layout gate', () => {
+    for (const filePath of [
+      ADMIN_INTERVIEWS_PAGE,
+      ADMIN_PLATFORM_CONNECTIONS_PAGE,
+    ]) {
+      const source = readFileSync(filePath, 'utf8');
+
+      expect(source).not.toContain('getCachedAuth');
+      expect(source).not.toContain('checkAdminRole');
+      expect(source).not.toContain('requireAdminOrRedirect');
+      expect(source).not.toMatch(/\brequireAdmin\(\)/);
+    }
+  });
+});

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -21,6 +21,7 @@ const INTENTIONAL_INTERNAL_ROUTES: Record<string, string> = {
   '/app/admin/investors/links': 'Sub-tool reached from Investors workspace',
   '/app/admin/investors/settings':
     'Sub-tool reached from Investors workspace actions',
+  '/app/admin/interviews': 'Internal admin review workspace (manual entry)',
   '/app/admin/playlists': 'Internal admin workflow (manual entry)',
   '/app/dashboard/releases/[releaseId]/tasks':
     'Dynamic workflow route reached from releases actions',


### PR DESCRIPTION
## Summary

- Remove duplicate page-level Clerk/admin checks from read-only admin child pages already covered by `(shell)/admin/layout.tsx`.
- Keep server-action admin guards untouched.
- Add a source contract to prevent read-only admin child routes from reintroducing duplicate auth checks.

## Verification

- `pnpm biome check --write 'apps/web/app/app/(shell)/admin/interviews/page.tsx' 'apps/web/app/app/(shell)/admin/platform-connections/page.tsx' apps/web/tests/unit/app/admin-child-auth-normalization.test.ts apps/web/tests/unit/app/admin-interviews-shell-normalization.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/routes/shell-nav-coverage.test.ts tests/unit/app/admin-child-auth-normalization.test.ts tests/unit/app/admin-interviews-shell-normalization.test.ts tests/unit/app/admin-platform-connections-client.test.tsx` — 10 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2432-admin-child-auth",
  "source": "github",
  "sourceRunId": "5bb07645490072e69f11a4276f851da89e986e42",
  "kind": "workflow",
  "status": "done",
  "title": "Remove duplicate admin child auth checks",
  "summary": "Read-only admin child pages now rely on the parent admin layout gate instead of repeating Clerk/admin checks, while server-action guards remain intact.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2432",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2432/remove-duplicate-admin-auth-checks-from-admin-child-pages",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9170",
  "adminSurface": "/app/admin/interviews",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused shell nav coverage, admin child auth, interviews shell, platform connections client, typecheck, Biome, diff-check, and pre-push verification passed.",
      "checkedAt": "2026-05-18T16:56:30.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for read-only admin child scope, parent layout gate ownership, server-action guard preservation, and no visual surface changes.",
      "checkedAt": "2026-05-18T16:56:30.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch pushed with conventional commit and PR artifact prepared.",
      "checkedAt": "2026-05-18T16:56:30.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T16:56:30.000Z",
  "updatedAt": "2026-05-18T16:56:30.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/admin/interviews", "/app/admin/platform-connections"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Admin Interviews and Platform Connections pages no longer perform page-local admin gating and now render directly without awaiting a local admin-check helper.
* **Tests**
  * Added a unit test to verify admin child pages do not include page-local auth/role gating.
  * Updated a test allowlist to mark the admin interviews route as an intentional internal route.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

