### PR TITLE
refactor(shell): server gate settings subroutes

### DIFF
--- a/apps/web/app/app/(shell)/settings/admin/page.tsx
+++ b/apps/web/app/app/(shell)/settings/admin/page.tsx
@@ -1,23 +1,26 @@
-'use client';
-
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
-import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
+import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
 import { SettingsAdminSection } from '@/features/dashboard/organisms/SettingsAdminSection';
 import { SettingsSection } from '@/features/dashboard/organisms/SettingsSection';
+import { loadAppShellRouteContext } from '../../app-shell-route-context';
 
-export default function SettingsAdminPage() {
-  const { isAdmin } = useDashboardData();
-  const router = useRouter();
+export const runtime = 'nodejs';
 
-  useEffect(() => {
-    if (!isAdmin) {
-      router.replace(APP_ROUTES.SETTINGS_ARTIST_PROFILE);
-    }
-  }, [isAdmin, router]);
+export default async function SettingsAdminPage() {
+  const routeContext = await loadAppShellRouteContext({
+    route: APP_ROUTES.SETTINGS_ADMIN,
+    dashboardErrorLogMessage:
+      'Dashboard data load failed on settings admin page',
+    dashboardErrorMessage:
+      'Failed to load admin settings. Please refresh the page.',
+  });
+  if (!routeContext.ok) {
+    return routeContext.error;
+  }
 
-  if (!isAdmin) return null;
+  if (!routeContext.dashboardData.isAdmin) {
+    redirect(APP_ROUTES.SETTINGS_ARTIST_PROFILE);
+  }
 
   return (
     <SettingsSection

--- a/apps/web/app/app/(shell)/settings/payments/page.tsx
+++ b/apps/web/app/app/(shell)/settings/payments/page.tsx
@@ -1,23 +1,31 @@
-'use client';
-
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
 import { SettingsPaymentsSection } from '@/features/dashboard/organisms/SettingsPaymentsSection';
 import { SettingsSection } from '@/features/dashboard/organisms/SettingsSection';
-import { useAppFlag } from '@/lib/flags/client';
+import { getAppFlagValue } from '@/lib/flags/server';
+import { loadAppShellRouteContext } from '../../app-shell-route-context';
 
-export default function SettingsPaymentsPage() {
-  const isStripeConnectEnabled = useAppFlag('STRIPE_CONNECT_ENABLED');
-  const router = useRouter();
+export const runtime = 'nodejs';
 
-  useEffect(() => {
-    if (!isStripeConnectEnabled) {
-      router.replace(APP_ROUTES.SETTINGS_BILLING);
-    }
-  }, [isStripeConnectEnabled, router]);
+export default async function SettingsPaymentsPage() {
+  const routeContext = await loadAppShellRouteContext({
+    route: APP_ROUTES.SETTINGS_PAYMENTS,
+    dashboardErrorLogMessage:
+      'Dashboard data load failed on settings payments page',
+    dashboardErrorMessage:
+      'Failed to load payment settings. Please refresh the page.',
+  });
+  if (!routeContext.ok) {
+    return routeContext.error;
+  }
 
-  if (!isStripeConnectEnabled) return null;
+  const isStripeConnectEnabled = await getAppFlagValue(
+    'STRIPE_CONNECT_ENABLED',
+    { userId: routeContext.userId }
+  );
+  if (!isStripeConnectEnabled) {
+    redirect(APP_ROUTES.SETTINGS_BILLING);
+  }
 
   return (
     <SettingsSection

--- a/apps/web/tests/unit/app/settings-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/settings-shell-normalization.test.ts
@@ -120,6 +120,17 @@ const SETTINGS_SHARED_ROUTE_CONTEXT_FILES = [
       'apps/web/app/app/(shell)/settings/artist-profile/page.tsx'
     )
   ),
+  findSourceFile(
+    resolve(process.cwd(), 'app/app/(shell)/settings/admin/page.tsx'),
+    resolve(process.cwd(), 'apps/web/app/app/(shell)/settings/admin/page.tsx')
+  ),
+  findSourceFile(
+    resolve(process.cwd(), 'app/app/(shell)/settings/payments/page.tsx'),
+    resolve(
+      process.cwd(),
+      'apps/web/app/app/(shell)/settings/payments/page.tsx'
+    )
+  ),
 ] as const;
 
 const SETTINGS_SHARED_ROUTE_CONTEXT_CANDIDATES = [
@@ -127,6 +138,32 @@ const SETTINGS_SHARED_ROUTE_CONTEXT_CANDIDATES = [
   resolve(process.cwd(), 'app/app/(shell)/settings/touring/page.tsx'),
   resolve(process.cwd(), 'app/app/(shell)/settings/connectors/page.tsx'),
   resolve(process.cwd(), 'app/app/(shell)/settings/artist-profile/page.tsx'),
+  resolve(process.cwd(), 'app/app/(shell)/settings/admin/page.tsx'),
+  resolve(process.cwd(), 'app/app/(shell)/settings/payments/page.tsx'),
+] as const;
+
+const GATED_SETTINGS_ROUTE_FILES = [
+  {
+    route: 'settings admin',
+    filePath: findSourceFile(
+      resolve(process.cwd(), 'app/app/(shell)/settings/admin/page.tsx'),
+      resolve(process.cwd(), 'apps/web/app/app/(shell)/settings/admin/page.tsx')
+    ),
+    expectedGate: 'routeContext.dashboardData.isAdmin',
+    expectedDestination: 'APP_ROUTES.SETTINGS_ARTIST_PROFILE',
+  },
+  {
+    route: 'settings payments',
+    filePath: findSourceFile(
+      resolve(process.cwd(), 'app/app/(shell)/settings/payments/page.tsx'),
+      resolve(
+        process.cwd(),
+        'apps/web/app/app/(shell)/settings/payments/page.tsx'
+      )
+    ),
+    expectedGate: 'getAppFlagValue',
+    expectedDestination: 'APP_ROUTES.SETTINGS_BILLING',
+  },
 ] as const;
 
 describe('settings shell normalization', () => {
@@ -210,6 +247,26 @@ describe('settings shell normalization', () => {
       expect(source).not.toContain('getDashboardData');
       expect(source).not.toContain('getCachedAuth');
       expect(source).not.toContain('getDashboardShellData');
+    }
+  });
+
+  it('keeps gated settings pages on server redirects instead of client effects', () => {
+    for (const gatedRoute of GATED_SETTINGS_ROUTE_FILES) {
+      expect(gatedRoute.filePath).toBeDefined();
+
+      if (!gatedRoute.filePath) {
+        throw new Error(`Could not find ${gatedRoute.route} source`);
+      }
+
+      const source = readFileSync(gatedRoute.filePath, 'utf8');
+      expect(source).toContain('loadAppShellRouteContext');
+      expect(source).toContain(gatedRoute.expectedGate);
+      expect(source).toContain(`redirect(${gatedRoute.expectedDestination})`);
+      expect(source).not.toContain("'use client'");
+      expect(source).not.toContain('useRouter');
+      expect(source).not.toContain('useEffect');
+      expect(source).not.toContain('router.replace');
+      expect(source).not.toContain('useAppFlag');
     }
   });
 });


### PR DESCRIPTION
## Summary

- Move `/app/settings/admin` from a client `useEffect` redirect to a server shell-route check against `dashboardData.isAdmin`.
- Move `/app/settings/payments` from a client flag redirect to a server shell-route check plus server Stripe Connect flag read.
- Expand settings shell normalization coverage so gated settings pages stay on server redirects and shared shell route context.

## Verification

- `pnpm biome check 'apps/web/app/app/(shell)/settings/admin/page.tsx' 'apps/web/app/app/(shell)/settings/payments/page.tsx' apps/web/tests/unit/app/settings-shell-normalization.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/settings-shell-normalization.test.ts tests/unit/app/settings-page.test.tsx tests/unit/app/settings-route-error-guard.test.ts` — 9 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2434-settings-server-gates",
  "source": "github",
  "sourceRunId": "0f85cd92d4e009f6e469e6efe0e098012bb078bf",
  "kind": "workflow",
  "status": "done",
  "title": "Move gated settings subroutes onto server shell route checks",
  "summary": "Settings admin and payments routes now gate on the server through the shared shell route context, removing client redirect effects and route flash.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2434",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2434/move-gated-settings-subroutes-onto-server-shell-route-checks",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9174",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused settings normalization tests, typecheck, Biome, diff-check, and pre-push verification passed.",
      "checkedAt": "2026-05-18T17:03:30.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for server route ownership, preserved redirect destinations, and no visible settings content changes.",
      "checkedAt": "2026-05-18T17:03:30.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch pushed with conventional commit and PR artifact prepared.",
      "checkedAt": "2026-05-18T17:03:30.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T17:03:30.000Z",
  "updatedAt": "2026-05-18T17:03:30.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/settings/admin", "/app/settings/payments"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the settings admin and payments pages for improved server-side performance and security.

* **Tests**
  * Added comprehensive test coverage for gated settings page functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9174?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->