### PR TITLE
refactor(shell): centralize audience auth gate

### DIFF
--- a/apps/web/app/app/(shell)/app-shell-route-context.test.tsx
+++ b/apps/web/app/app/(shell)/app-shell-route-context.test.tsx
@@ -51,7 +51,10 @@ vi.mock('./dashboard/actions', () => ({
   getDashboardShellData: getDashboardShellDataMock,
 }));
 
-import { loadAppShellRouteContext } from './app-shell-route-context';
+import {
+  loadAppShellRouteContext,
+  loadAuthenticatedAppShellUserId,
+} from './app-shell-route-context';
 
 function shellData(
   overrides: Partial<{
@@ -85,6 +88,26 @@ describe('loadAppShellRouteContext', () => {
         dashboardErrorMessage: 'Failed to load releases data.',
       })
     ).rejects.toThrow('NEXT_REDIRECT:/signin?redirect_url=%2Fapp%2Freleases');
+
+    expect(getDashboardShellDataMock).not.toHaveBeenCalled();
+  });
+
+  it('centralizes early auth redirects for routes that stream after auth', async () => {
+    getCachedAuthMock.mockResolvedValue({ userId: null });
+
+    await expect(
+      loadAuthenticatedAppShellUserId({ route: '/app/audience' })
+    ).rejects.toThrow('NEXT_REDIRECT:/signin?redirect_url=%2Fapp%2Faudience');
+
+    expect(getDashboardShellDataMock).not.toHaveBeenCalled();
+  });
+
+  it('returns early authenticated user ids without loading shell data', async () => {
+    getCachedAuthMock.mockResolvedValue({ userId: 'user_early' });
+
+    await expect(
+      loadAuthenticatedAppShellUserId({ route: '/app/audience' })
+    ).resolves.toBe('user_early');
 
     expect(getDashboardShellDataMock).not.toHaveBeenCalled();
   });

--- a/apps/web/app/app/(shell)/app-shell-route-context.tsx
+++ b/apps/web/app/app/(shell)/app-shell-route-context.tsx
@@ -33,9 +33,31 @@ export interface LoadAppShellRouteContextOptions {
   readonly authenticatedUserId?: string | null;
 }
 
+export interface LoadAuthenticatedAppShellUserOptions {
+  readonly route: string;
+  readonly authFailure?: 'redirect' | 'notFound';
+}
+
 export type AppShellRouteContextResult =
   | AppShellRouteContext
   | AppShellRouteError;
+
+export async function loadAuthenticatedAppShellUserId({
+  route,
+  authFailure = 'redirect',
+}: LoadAuthenticatedAppShellUserOptions): Promise<string> {
+  const { userId } = await getCachedAuth();
+
+  if (!userId) {
+    if (authFailure === 'notFound') {
+      notFound();
+    }
+
+    redirect(buildAppShellSignInUrl(route));
+  }
+
+  return userId;
+}
 
 export async function loadAppShellRouteContext({
   route,
@@ -45,15 +67,9 @@ export async function loadAppShellRouteContext({
   requiredFlag,
   authenticatedUserId = null,
 }: LoadAppShellRouteContextOptions): Promise<AppShellRouteContextResult> {
-  const userId = authenticatedUserId?.trim() || (await getCachedAuth()).userId;
-
-  if (!userId) {
-    if (authFailure === 'notFound') {
-      notFound();
-    }
-
-    redirect(buildAppShellSignInUrl(route));
-  }
+  const userId =
+    authenticatedUserId?.trim() ||
+    (await loadAuthenticatedAppShellUserId({ route, authFailure }));
 
   if (requiredFlag) {
     const enabled = await getAppFlagValue(requiredFlag, { userId });

--- a/apps/web/app/app/(shell)/audience/page.tsx
+++ b/apps/web/app/app/(shell)/audience/page.tsx
@@ -8,7 +8,6 @@ import { AudienceTableLoadingShell } from '@/features/dashboard/organisms/dashbo
 import type { AudienceSegment } from '@/features/dashboard/organisms/dashboard-audience-table/types';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
 import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
-import { getCachedAuth } from '@/lib/auth/cached';
 import { captureError } from '@/lib/error-tracking';
 import { audienceFilters, audienceSearchParams } from '@/lib/nuqs';
 import { throwIfRedirect } from '@/lib/utils/redirect-error';
@@ -17,7 +16,10 @@ import {
   trimTrailingSlashes,
 } from '@/lib/utils/string-utils';
 import { convertDrizzleCreatorProfileToArtist } from '@/types/db';
-import { loadAppShellRouteContext } from '../app-shell-route-context';
+import {
+  loadAppShellRouteContext,
+  loadAuthenticatedAppShellUserId,
+} from '../app-shell-route-context';
 import { getAudienceServerData } from '../dashboard/audience/audience-data';
 import { loadUpcomingTourDates } from '../dashboard/tour-dates/actions';
 
@@ -26,19 +28,17 @@ export const runtime = 'nodejs';
 /**
  * Audience page — streams instantly after auth gate.
  *
- * Auth check via getCachedAuth (Clerk JWT, no DB) runs at the page level
- * so unauthenticated users redirect immediately. The async content uses the
- * shared shell route context while preserving the Suspense table fallback.
+ * The shared early auth helper runs before Suspense so unauthenticated users
+ * redirect immediately while the async content keeps the table fallback.
  */
 export default async function AudiencePage({
   searchParams,
 }: Readonly<{
   searchParams: Promise<SearchParams>;
 }>) {
-  const { userId } = await getCachedAuth();
-  if (!userId) {
-    redirect(buildAppShellSignInUrl(APP_ROUTES.AUDIENCE));
-  }
+  const userId = await loadAuthenticatedAppShellUserId({
+    route: APP_ROUTES.AUDIENCE,
+  });
 
   return (
     <Suspense fallback={<AudienceTableLoadingShell />}>

--- a/apps/web/tests/unit/app/audience-page.test.tsx
+++ b/apps/web/tests/unit/app/audience-page.test.tsx
@@ -10,7 +10,9 @@ describe('audience app shell route', () => {
     );
 
     expect(source).toContain('loadAppShellRouteContext');
+    expect(source).toContain('loadAuthenticatedAppShellUserId');
     expect(source).toContain('authenticatedUserId: userId');
+    expect(source).not.toContain('getCachedAuth');
     expect(source).not.toContain('getDashboardShellData');
     expect(source).not.toContain('dashboardLoadError');
     expect(source).not.toMatch(/\bgetDashboardData(?:Essential)?\(/);


### PR DESCRIPTION
## Summary

- Add `loadAuthenticatedAppShellUserId()` to the shared app shell route context module for fast auth-before-Suspense routes.
- Move `/app/audience` off its page-local `getCachedAuth()` gate while preserving the immediate sign-in redirect and Suspense table fallback.
- Extend route-context and audience source guards so the audience page keeps using the canonical shell helper.

## Verification

- `pnpm biome check 'apps/web/app/app/(shell)/audience/page.tsx' 'apps/web/app/app/(shell)/app-shell-route-context.tsx' 'apps/web/app/app/(shell)/app-shell-route-context.test.tsx' apps/web/tests/unit/app/audience-page.test.tsx`
- `pnpm --filter @jovie/web exec vitest run app/app/(shell)/app-shell-route-context.test.tsx tests/unit/app/audience-page.test.tsx tests/unit/app/shell-route-matches.test.ts tests/unit/dashboard/dashboard-shell-content.test.ts` -- 73 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2436-audience-auth-gate",
  "source": "github",
  "sourceRunId": "aba3f04e0f4fb7bafdace0c614ea5e316b53f845",
  "kind": "workflow",
  "status": "done",
  "title": "Centralize audience route early auth gate",
  "summary": "Audience now uses a shared shell route auth helper before Suspense instead of importing getCachedAuth directly at the page level.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2436",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2436/centralize-audience-route-early-auth-gate",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9178",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused route-context, audience source, shell route matching, dashboard shell content, typecheck, Biome, diff-check, and pre-push verification passed.",
      "checkedAt": "2026-05-18T17:33:32.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for auth behavior parity, no route UI changes, and no page-local getCachedAuth import on audience.",
      "checkedAt": "2026-05-18T17:33:32.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch pushed with conventional commit and PR artifact prepared.",
      "checkedAt": "2026-05-18T17:33:32.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T17:22:19.000Z",
  "updatedAt": "2026-05-18T17:33:32.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/audience"]
  }
}
-->
