### PR TITLE
refactor(shell): isolate admin platform route data

### DIFF
--- a/apps/web/app/app/(shell)/admin/platform-connections/page.tsx
+++ b/apps/web/app/app/(shell)/admin/platform-connections/page.tsx
@@ -1,15 +1,7 @@
 import type { Metadata } from 'next';
 import { AdminWorkspacePage } from '@/components/features/admin/layout/AdminWorkspacePage';
-import {
-  getPlaylistEngineSettings,
-  getPlaylistSpotifyStatus,
-  isSpotifyAccount,
-  readAccountLabel,
-  readExternalAccountScopes,
-} from '@/lib/admin/platform-connections';
-import { getCachedCurrentUser } from '@/lib/auth/cached';
-import { REQUIRED_PLAYLIST_SPOTIFY_SCOPES } from '@/lib/spotify/system-account';
 import { PlatformConnectionsClient } from './PlatformConnectionsClient';
+import { loadAdminPlatformConnectionsData } from './platform-connections-data';
 
 export const metadata: Metadata = { title: 'Platform Connections — Admin' };
 export const runtime = 'nodejs';
@@ -32,18 +24,7 @@ export default async function AdminPlatformConnectionsPage({
     ['spotify', 'engine'].includes(tab) ? tab : 'spotify'
   ) as PlatformConnectionsTab;
 
-  const [spotifyStatus, engineSettings, user] = await Promise.all([
-    getPlaylistSpotifyStatus(),
-    getPlaylistEngineSettings(),
-    getCachedCurrentUser(),
-  ]);
-
-  const currentSpotifyAccount =
-    user?.externalAccounts.find(isSpotifyAccount) ?? null;
-  const approvedScopes = readExternalAccountScopes(currentSpotifyAccount);
-  const missingScopes = REQUIRED_PLAYLIST_SPOTIFY_SCOPES.filter(
-    scope => !approvedScopes.includes(scope)
-  );
+  const data = await loadAdminPlatformConnectionsData();
 
   return (
     <AdminWorkspacePage
@@ -57,21 +38,9 @@ export default async function AdminPlatformConnectionsPage({
     >
       <PlatformConnectionsClient
         currentTab={currentTab}
-        spotifyStatus={{
-          ...spotifyStatus,
-          updatedAt: spotifyStatus.updatedAt?.toISOString() ?? null,
-        }}
-        engineSettings={{
-          ...engineSettings,
-          lastGeneratedAt:
-            engineSettings.lastGeneratedAt?.toISOString() ?? null,
-          nextEligibleAt: engineSettings.nextEligibleAt?.toISOString() ?? null,
-        }}
-        currentUser={{
-          hasSpotify: Boolean(currentSpotifyAccount),
-          label: readAccountLabel(currentSpotifyAccount),
-          missingScopes,
-        }}
+        spotifyStatus={data.spotifyStatus}
+        engineSettings={data.engineSettings}
+        currentUser={data.currentUser}
       />
     </AdminWorkspacePage>
   );

--- a/apps/web/app/app/(shell)/admin/platform-connections/platform-connections-data.ts
+++ b/apps/web/app/app/(shell)/admin/platform-connections/platform-connections-data.ts
@@ -1,0 +1,64 @@
+import 'server-only';
+
+import {
+  getPlaylistEngineSettings,
+  getPlaylistSpotifyStatus,
+  isSpotifyAccount,
+  readAccountLabel,
+  readExternalAccountScopes,
+} from '@/lib/admin/platform-connections';
+import { getCachedCurrentUser } from '@/lib/auth/cached';
+import { REQUIRED_PLAYLIST_SPOTIFY_SCOPES } from '@/lib/spotify/system-account';
+
+export interface AdminPlatformConnectionsData {
+  readonly spotifyStatus: Omit<
+    Awaited<ReturnType<typeof getPlaylistSpotifyStatus>>,
+    'updatedAt'
+  > & {
+    readonly updatedAt: string | null;
+  };
+  readonly engineSettings: Omit<
+    Awaited<ReturnType<typeof getPlaylistEngineSettings>>,
+    'lastGeneratedAt' | 'nextEligibleAt'
+  > & {
+    readonly lastGeneratedAt: string | null;
+    readonly nextEligibleAt: string | null;
+  };
+  readonly currentUser: {
+    readonly hasSpotify: boolean;
+    readonly label: string | null;
+    readonly missingScopes: readonly string[];
+  };
+}
+
+export async function loadAdminPlatformConnectionsData(): Promise<AdminPlatformConnectionsData> {
+  const [spotifyStatus, engineSettings, user] = await Promise.all([
+    getPlaylistSpotifyStatus(),
+    getPlaylistEngineSettings(),
+    getCachedCurrentUser(),
+  ]);
+
+  const currentSpotifyAccount =
+    user?.externalAccounts.find(isSpotifyAccount) ?? null;
+  const approvedScopes = readExternalAccountScopes(currentSpotifyAccount);
+  const missingScopes = REQUIRED_PLAYLIST_SPOTIFY_SCOPES.filter(
+    scope => !approvedScopes.includes(scope)
+  );
+
+  return {
+    spotifyStatus: {
+      ...spotifyStatus,
+      updatedAt: spotifyStatus.updatedAt?.toISOString() ?? null,
+    },
+    engineSettings: {
+      ...engineSettings,
+      lastGeneratedAt: engineSettings.lastGeneratedAt?.toISOString() ?? null,
+      nextEligibleAt: engineSettings.nextEligibleAt?.toISOString() ?? null,
+    },
+    currentUser: {
+      hasSpotify: Boolean(currentSpotifyAccount),
+      label: readAccountLabel(currentSpotifyAccount),
+      missingScopes,
+    },
+  };
+}

--- a/apps/web/tests/unit/app/admin-child-auth-normalization.test.ts
+++ b/apps/web/tests/unit/app/admin-child-auth-normalization.test.ts
@@ -25,4 +25,15 @@ describe('admin child route auth normalization', () => {
       expect(source).not.toMatch(/\brequireAdmin\(\)/);
     }
   });
+
+  it('keeps admin platform route data outside the page module', () => {
+    const source = readFileSync(ADMIN_PLATFORM_CONNECTIONS_PAGE, 'utf8');
+
+    expect(source).toContain('loadAdminPlatformConnectionsData');
+    expect(source).not.toContain('getCachedCurrentUser');
+    expect(source).not.toContain('@/lib/admin/platform-connections');
+    expect(source).not.toContain('REQUIRED_PLAYLIST_SPOTIFY_SCOPES');
+    expect(source).not.toContain('readExternalAccountScopes');
+    expect(source).not.toContain('readAccountLabel');
+  });
 });


### PR DESCRIPTION
## Summary

- Move admin platform connection status, engine settings, and Spotify account scope shaping out of `admin/platform-connections/page.tsx`.
- Add a server-only `loadAdminPlatformConnectionsData()` route loader that returns the exact `PlatformConnectionsClient` contract with serialized timestamps.
- Extend admin shell normalization coverage so the page stays on shared shell route context without importing account/status/auth helpers directly.

## Verification

- `pnpm biome check 'apps/web/app/app/(shell)/admin/platform-connections/page.tsx' 'apps/web/app/app/(shell)/admin/platform-connections/platform-connections-data.ts' apps/web/tests/unit/app/admin-child-auth-normalization.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/admin-child-auth-normalization.test.ts tests/unit/app/admin-platform-connections-client.test.tsx` -- 4 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hook: proxy guard, Biome, ESLint, affected web typecheck
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2439-admin-platform-route-data",
  "source": "github",
  "sourceRunId": "ee3b8a2a142f526fca1e6ce88c026a94bd749390",
  "kind": "workflow",
  "status": "done",
  "title": "Isolate admin platform connections route data",
  "summary": "Admin platform connections page now delegates auth/account/status data shaping to a server-only route loader while preserving the existing shell route context and render contract.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2439",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2439/isolate-admin-platform-connections-route-data",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9186",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused admin shell tests, web typecheck, Biome, diff-check, commit hook, and pre-push verification passed.",
      "checkedAt": "2026-05-18T18:38:34.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for route/data ownership only: page now handles shell context and render, loader owns auth/account/status reads.",
      "checkedAt": "2026-05-18T18:38:34.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch pushed with conventional commit and PR artifact prepared.",
      "checkedAt": "2026-05-18T18:38:34.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T18:38:34.000Z",
  "updatedAt": "2026-05-18T18:38:34.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/admin/platform-connections"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated data loading for admin platform connections to improve efficiency and maintainability.

* **Tests**
  * Added unit tests to verify proper separation of concerns in the admin platform module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->