### PR TITLE
refactor(shell): isolate admin playlist route boundary

### DIFF
--- a/apps/web/app/app/(shell)/admin/playlists/page.tsx
+++ b/apps/web/app/app/(shell)/admin/playlists/page.tsx
@@ -1,212 +1,13 @@
 import { Button } from '@jovie/ui';
-import { and, desc, eq } from 'drizzle-orm';
 import { ExternalLink } from 'lucide-react';
 import type { Metadata } from 'next';
-import { revalidatePath } from 'next/cache';
 import { AdminWorkspacePage } from '@/components/features/admin/layout/AdminWorkspacePage';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
-import { APP_ROUTES } from '@/constants/routes';
-import { isAdmin as checkAdminRole } from '@/lib/admin/roles';
-import { getCachedAuth } from '@/lib/auth/cached';
-import { db } from '@/lib/db';
-import { joviePlaylists, joviePlaylistTracks } from '@/lib/db/schema/playlists';
-import { captureError } from '@/lib/error-tracking';
-import { generateCoverArt } from '@/lib/playlists/generate-cover';
-import { publishToSpotify } from '@/lib/playlists/publish-spotify';
-import { uploadPlaylistCoverImage } from '@/lib/playlists/upload-cover-image';
-import { getJovieSpotifyUserId } from '@/lib/spotify/jovie-account';
-
-async function requireAdmin(): Promise<void> {
-  const { userId } = await getCachedAuth();
-  if (!userId || !(await checkAdminRole(userId))) {
-    throw new Error('Unauthorized');
-  }
-}
+import { approvePlaylist, rejectPlaylist } from './playlist-actions';
+import { type AdminPlaylistTab, loadAdminPlaylists } from './playlists-data';
 
 export const metadata: Metadata = { title: 'Playlists — Admin' };
 export const runtime = 'nodejs';
-
-// ============================================================================
-// Server Actions
-// ============================================================================
-
-async function approvePlaylist(formData: FormData) {
-  'use server';
-
-  await requireAdmin();
-
-  const playlistId = formData.get('playlistId') as string;
-  if (!playlistId) return;
-
-  // Atomic claim: only proceed if status is still 'pending'
-  const [playlist] = await db
-    .update(joviePlaylists)
-    .set({
-      status: 'approved',
-      statusChangedAt: new Date(),
-      updatedAt: new Date(),
-    })
-    .where(
-      and(
-        eq(joviePlaylists.id, playlistId),
-        eq(joviePlaylists.status, 'pending')
-      )
-    )
-    .returning();
-
-  if (!playlist) return; // already claimed by another request
-
-  try {
-    const tracks = await db
-      .select()
-      .from(joviePlaylistTracks)
-      .where(eq(joviePlaylistTracks.playlistId, playlistId))
-      .orderBy(joviePlaylistTracks.position);
-
-    const trackIds = tracks
-      .map(t => t.spotifyTrackId)
-      .filter((id): id is string => id != null);
-
-    // Generate cover art using LLM-generated queries from the pipeline
-    const promptData = (() => {
-      try {
-        return playlist.llmPrompt
-          ? (JSON.parse(playlist.llmPrompt) as {
-              unsplashQuery?: string;
-              coverTextWords?: string;
-            })
-          : {};
-      } catch {
-        return {};
-      }
-    })();
-    const coverArt = await generateCoverArt({
-      unsplashQuery:
-        promptData.unsplashQuery ?? playlist.theme ?? playlist.title,
-      coverText:
-        promptData.coverTextWords ??
-        playlist.title.split(' ').slice(0, 4).join(' '),
-    });
-    const coverImageUrl = await uploadPlaylistCoverImage({
-      slug: playlist.slug,
-      imageBuffer: coverArt.fullResBuffer,
-    });
-
-    // Publish to Spotify
-    const result = await publishToSpotify({
-      title: playlist.title,
-      description: playlist.description ?? '',
-      trackIds,
-      coverBase64: coverArt.spotifyBase64,
-      slug: playlist.slug,
-    });
-
-    // Get Spotify user ID for audit trail
-    const spotifyUserId = await getJovieSpotifyUserId();
-
-    // Update playlist status to published
-    await db
-      .update(joviePlaylists)
-      .set({
-        status: 'published',
-        statusChangedAt: new Date(),
-        publishedAt: new Date(),
-        spotifyPlaylistId: result.spotifyPlaylistId,
-        curatorSpotifyUserId: spotifyUserId,
-        trackCount: result.tracksAdded,
-        coverImageUrl,
-        coverImageFullUrl: coverImageUrl,
-        updatedAt: new Date(),
-      })
-      .where(eq(joviePlaylists.id, playlistId));
-
-    revalidatePath('/playlists');
-    revalidatePath(`/playlists/${playlist.slug}`);
-  } catch (error) {
-    // Revert to pending so the admin can retry (prevents "approved" limbo).
-    // Preserve the original publish error if the revert itself fails.
-    try {
-      await db
-        .update(joviePlaylists)
-        .set({
-          status: 'pending',
-          statusChangedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(eq(joviePlaylists.id, playlistId));
-    } catch (revertError) {
-      captureError('[Admin Playlists] Revert to pending failed', revertError, {
-        playlistId,
-        originalError: error instanceof Error ? error.message : String(error),
-      });
-    }
-
-    throw error;
-  }
-
-  revalidatePath(APP_ROUTES.ADMIN_PLAYLISTS);
-}
-
-async function rejectPlaylist(formData: FormData) {
-  'use server';
-
-  await requireAdmin();
-
-  const playlistId = formData.get('playlistId') as string;
-  const note = formData.get('note') as string;
-  if (!playlistId) return;
-
-  const [rejectedPlaylist] = await db
-    .update(joviePlaylists)
-    .set({
-      status: 'rejected',
-      statusChangedAt: new Date(),
-      rejectionNote: note || null,
-      updatedAt: new Date(),
-    })
-    .where(
-      and(
-        eq(joviePlaylists.id, playlistId),
-        eq(joviePlaylists.status, 'pending')
-      )
-    )
-    .returning({ id: joviePlaylists.id });
-
-  if (!rejectedPlaylist) return;
-
-  revalidatePath(APP_ROUTES.ADMIN_PLAYLISTS);
-}
-
-// ============================================================================
-// Data
-// ============================================================================
-
-async function getPlaylists(status: string) {
-  return db
-    .select({
-      id: joviePlaylists.id,
-      title: joviePlaylists.title,
-      slug: joviePlaylists.slug,
-      status: joviePlaylists.status,
-      trackCount: joviePlaylists.trackCount,
-      genreTags: joviePlaylists.genreTags,
-      createdAt: joviePlaylists.createdAt,
-      publishedAt: joviePlaylists.publishedAt,
-      spotifyPlaylistId: joviePlaylists.spotifyPlaylistId,
-    })
-    .from(joviePlaylists)
-    .where(
-      eq(joviePlaylists.status, status as 'pending' | 'published' | 'rejected')
-    )
-    .orderBy(desc(joviePlaylists.createdAt))
-    .limit(50);
-}
-
-// ============================================================================
-// Page
-// ============================================================================
-
-type PlaylistTab = 'pending' | 'published' | 'rejected';
 
 const TAB_OPTIONS = [
   { value: 'pending' as const, label: 'Pending' },
@@ -222,8 +23,8 @@ export default async function AdminPlaylistsPage({
   const { tab = 'pending' } = await searchParams;
   const currentTab = (
     ['pending', 'published', 'rejected'].includes(tab) ? tab : 'pending'
-  ) as PlaylistTab;
-  const playlists = await getPlaylists(currentTab);
+  ) as AdminPlaylistTab;
+  const playlists = await loadAdminPlaylists(currentTab);
 
   return (
     <AdminWorkspacePage

--- a/apps/web/app/app/(shell)/admin/playlists/playlist-actions.ts
+++ b/apps/web/app/app/(shell)/admin/playlists/playlist-actions.ts
@@ -1,0 +1,158 @@
+'use server';
+
+import { and, eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { APP_ROUTES } from '@/constants/routes';
+import { isAdmin as checkAdminRole } from '@/lib/admin/roles';
+import { getCachedAuth } from '@/lib/auth/cached';
+import { db } from '@/lib/db';
+import { joviePlaylists, joviePlaylistTracks } from '@/lib/db/schema/playlists';
+import { captureError } from '@/lib/error-tracking';
+import { generateCoverArt } from '@/lib/playlists/generate-cover';
+import { publishToSpotify } from '@/lib/playlists/publish-spotify';
+import { uploadPlaylistCoverImage } from '@/lib/playlists/upload-cover-image';
+import { getJovieSpotifyUserId } from '@/lib/spotify/jovie-account';
+
+async function requireAdminAction(): Promise<void> {
+  const { userId } = await getCachedAuth();
+  if (!userId || !(await checkAdminRole(userId))) {
+    throw new Error('Unauthorized');
+  }
+}
+
+export async function approvePlaylist(formData: FormData) {
+  await requireAdminAction();
+
+  const playlistId = formData.get('playlistId') as string;
+  if (!playlistId) return;
+
+  // Atomic claim: only proceed if status is still 'pending'.
+  const [playlist] = await db
+    .update(joviePlaylists)
+    .set({
+      status: 'approved',
+      statusChangedAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(joviePlaylists.id, playlistId),
+        eq(joviePlaylists.status, 'pending')
+      )
+    )
+    .returning();
+
+  if (!playlist) return;
+
+  try {
+    const tracks = await db
+      .select()
+      .from(joviePlaylistTracks)
+      .where(eq(joviePlaylistTracks.playlistId, playlistId))
+      .orderBy(joviePlaylistTracks.position);
+
+    const trackIds = tracks
+      .map(t => t.spotifyTrackId)
+      .filter((id): id is string => id != null);
+
+    const promptData = (() => {
+      try {
+        return playlist.llmPrompt
+          ? (JSON.parse(playlist.llmPrompt) as {
+              unsplashQuery?: string;
+              coverTextWords?: string;
+            })
+          : {};
+      } catch {
+        return {};
+      }
+    })();
+    const coverArt = await generateCoverArt({
+      unsplashQuery:
+        promptData.unsplashQuery ?? playlist.theme ?? playlist.title,
+      coverText:
+        promptData.coverTextWords ??
+        playlist.title.split(' ').slice(0, 4).join(' '),
+    });
+    const coverImageUrl = await uploadPlaylistCoverImage({
+      slug: playlist.slug,
+      imageBuffer: coverArt.fullResBuffer,
+    });
+
+    const result = await publishToSpotify({
+      title: playlist.title,
+      description: playlist.description ?? '',
+      trackIds,
+      coverBase64: coverArt.spotifyBase64,
+      slug: playlist.slug,
+    });
+
+    const spotifyUserId = await getJovieSpotifyUserId();
+
+    await db
+      .update(joviePlaylists)
+      .set({
+        status: 'published',
+        statusChangedAt: new Date(),
+        publishedAt: new Date(),
+        spotifyPlaylistId: result.spotifyPlaylistId,
+        curatorSpotifyUserId: spotifyUserId,
+        trackCount: result.tracksAdded,
+        coverImageUrl,
+        coverImageFullUrl: coverImageUrl,
+        updatedAt: new Date(),
+      })
+      .where(eq(joviePlaylists.id, playlistId));
+
+    revalidatePath('/playlists');
+    revalidatePath(`/playlists/${playlist.slug}`);
+  } catch (error) {
+    try {
+      await db
+        .update(joviePlaylists)
+        .set({
+          status: 'pending',
+          statusChangedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(joviePlaylists.id, playlistId));
+    } catch (revertError) {
+      captureError('[Admin Playlists] Revert to pending failed', revertError, {
+        playlistId,
+        originalError: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    throw error;
+  }
+
+  revalidatePath(APP_ROUTES.ADMIN_PLAYLISTS);
+}
+
+export async function rejectPlaylist(formData: FormData) {
+  await requireAdminAction();
+
+  const playlistId = formData.get('playlistId') as string;
+  const note = formData.get('note') as string;
+  if (!playlistId) return;
+
+  const [rejectedPlaylist] = await db
+    .update(joviePlaylists)
+    .set({
+      status: 'rejected',
+      statusChangedAt: new Date(),
+      rejectionNote: note || null,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(joviePlaylists.id, playlistId),
+        eq(joviePlaylists.status, 'pending')
+      )
+    )
+    .returning({ id: joviePlaylists.id });
+
+  if (!rejectedPlaylist) return;
+
+  revalidatePath(APP_ROUTES.ADMIN_PLAYLISTS);
+}

--- a/apps/web/app/app/(shell)/admin/playlists/playlists-data.ts
+++ b/apps/web/app/app/(shell)/admin/playlists/playlists-data.ts
@@ -1,0 +1,30 @@
+import 'server-only';
+
+import { desc, eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { joviePlaylists } from '@/lib/db/schema/playlists';
+
+export type AdminPlaylistTab = 'pending' | 'published' | 'rejected';
+
+export type AdminPlaylistRow = Awaited<
+  ReturnType<typeof loadAdminPlaylists>
+>[number];
+
+export async function loadAdminPlaylists(status: AdminPlaylistTab) {
+  return db
+    .select({
+      id: joviePlaylists.id,
+      title: joviePlaylists.title,
+      slug: joviePlaylists.slug,
+      status: joviePlaylists.status,
+      trackCount: joviePlaylists.trackCount,
+      genreTags: joviePlaylists.genreTags,
+      createdAt: joviePlaylists.createdAt,
+      publishedAt: joviePlaylists.publishedAt,
+      spotifyPlaylistId: joviePlaylists.spotifyPlaylistId,
+    })
+    .from(joviePlaylists)
+    .where(eq(joviePlaylists.status, status))
+    .orderBy(desc(joviePlaylists.createdAt))
+    .limit(50);
+}

--- a/apps/web/tests/unit/app/admin-child-auth-normalization.test.ts
+++ b/apps/web/tests/unit/app/admin-child-auth-normalization.test.ts
@@ -10,6 +10,10 @@ const ADMIN_PLATFORM_CONNECTIONS_PAGE = resolve(
   process.cwd(),
   'app/app/(shell)/admin/platform-connections/page.tsx'
 );
+const ADMIN_PLAYLISTS_PAGE = resolve(
+  process.cwd(),
+  'app/app/(shell)/admin/playlists/page.tsx'
+);
 
 describe('admin child route auth normalization', () => {
   it('keeps read-only admin child pages on the parent admin layout gate', () => {
@@ -35,5 +39,21 @@ describe('admin child route auth normalization', () => {
     expect(source).not.toContain('REQUIRED_PLAYLIST_SPOTIFY_SCOPES');
     expect(source).not.toContain('readExternalAccountScopes');
     expect(source).not.toContain('readAccountLabel');
+  });
+
+  it('keeps admin playlist data and actions outside the page module', () => {
+    const source = readFileSync(ADMIN_PLAYLISTS_PAGE, 'utf8');
+
+    expect(source).toContain('loadAdminPlaylists');
+    expect(source).toContain('approvePlaylist');
+    expect(source).toContain('rejectPlaylist');
+    expect(source).not.toContain('getCachedAuth');
+    expect(source).not.toContain('@/lib/db');
+    expect(source).not.toContain('joviePlaylists');
+    expect(source).not.toContain('joviePlaylistTracks');
+    expect(source).not.toContain('generateCoverArt');
+    expect(source).not.toContain('publishToSpotify');
+    expect(source).not.toContain('captureError');
+    expect(source).not.toMatch(/\brequireAdmin\(\)/);
   });
 });


### PR DESCRIPTION
## Summary

- Move `/app/admin/playlists` playlist list loading into a server-only `loadAdminPlaylists()` route-data module.
- Move approve/reject server actions and their independent admin action guard into `playlist-actions.ts`.
- Keep the page module focused on metadata, tab parsing, and rendering the existing admin workspace UI.

## Verification

- `pnpm biome check 'apps/web/app/app/(shell)/admin/playlists/page.tsx' 'apps/web/app/app/(shell)/admin/playlists/playlists-data.ts' 'apps/web/app/app/(shell)/admin/playlists/playlist-actions.ts' apps/web/tests/unit/app/admin-child-auth-normalization.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/admin-child-auth-normalization.test.ts tests/unit/app/admin-platform-connections-client.test.tsx` -- 5 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hook: proxy guard, Biome, ESLint, affected web typecheck
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2440-admin-playlists-boundary",
  "source": "github",
  "sourceRunId": "bdf3c532d0df2548fa7cb63d41590091b37c800f",
  "kind": "workflow",
  "status": "done",
  "title": "Isolate admin playlists route data and actions",
  "summary": "Admin playlists page now delegates DB reads to a server-only route loader and mutating forms to a server-action module while preserving the existing UI contract.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2440",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2440/isolate-admin-playlists-route-data-and-actions",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9188",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused admin shell tests, platform regression test, web typecheck, Biome, diff-check, commit hook, and pre-push verification passed.",
      "checkedAt": "2026-05-18T19:03:28.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for route/data/action ownership only: page now handles render, data loader owns playlist reads, action module owns mutating guards and side effects.",
      "checkedAt": "2026-05-18T19:03:28.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch rebased onto current main, pushed with conventional commit, and PR artifact prepared.",
      "checkedAt": "2026-05-18T19:03:28.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T19:03:28.000Z",
  "updatedAt": "2026-05-18T19:03:28.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/admin/playlists"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized admin playlist management code by separating server actions for playlist approval/rejection and data loading into dedicated modules for improved maintainability.

* **Tests**
  * Added test coverage to validate proper code organization and module separation for admin playlist functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->