### PR TITLE
refactor(shell): isolate admin investors route data

### DIFF
--- a/apps/web/app/app/(shell)/admin/investors/investors-data.ts
+++ b/apps/web/app/app/(shell)/admin/investors/investors-data.ts
@@ -1,0 +1,37 @@
+import 'server-only';
+
+import { desc, sql as drizzleSql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { investorLinks, investorViews } from '@/lib/db/schema/investors';
+
+export type AdminInvestorPipelineRow = Awaited<
+  ReturnType<typeof loadAdminInvestorPipelineData>
+>[number];
+
+export async function loadAdminInvestorPipelineData() {
+  return db
+    .select({
+      id: investorLinks.id,
+      token: investorLinks.token,
+      label: investorLinks.label,
+      investorName: investorLinks.investorName,
+      email: investorLinks.email,
+      stage: investorLinks.stage,
+      engagementScore: investorLinks.engagementScore,
+      isActive: investorLinks.isActive,
+      notes: investorLinks.notes,
+      createdAt: investorLinks.createdAt,
+      updatedAt: investorLinks.updatedAt,
+      viewCount:
+        drizzleSql<number>`(SELECT COUNT(*) FROM ${investorViews} WHERE ${investorViews.investorLinkId} = ${investorLinks.id})`.as(
+          'view_count'
+        ),
+      lastViewed: drizzleSql<
+        string | null
+      >`(SELECT MAX(${investorViews.viewedAt}) FROM ${investorViews} WHERE ${investorViews.investorLinkId} = ${investorLinks.id})`.as(
+        'last_viewed'
+      ),
+    })
+    .from(investorLinks)
+    .orderBy(desc(investorLinks.createdAt));
+}

--- a/apps/web/app/app/(shell)/admin/investors/page.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/page.tsx
@@ -1,5 +1,4 @@
 import { Badge, Button } from '@jovie/ui';
-import { desc, sql as drizzleSql } from 'drizzle-orm';
 import {
   CheckCircle2,
   CircleSlash,
@@ -14,8 +13,6 @@ import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage'
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { APP_ROUTES } from '@/constants/routes';
-import { db } from '@/lib/db';
-import { investorLinks } from '@/lib/db/schema/investors';
 import { cn } from '@/lib/utils';
 import {
   InvestorTable,
@@ -25,6 +22,7 @@ import {
   InvestorTableHeaderRow,
   InvestorTableRow,
 } from './_components/InvestorTablePrimitives';
+import { loadAdminInvestorPipelineData } from './investors-data';
 import { TokenCopyButton } from './TokenCopyButton';
 
 export const metadata: Metadata = {
@@ -85,31 +83,7 @@ export default function InvestorPipelinePage() {
 }
 
 async function InvestorPipelineTable() {
-  const links = await db
-    .select({
-      id: investorLinks.id,
-      token: investorLinks.token,
-      label: investorLinks.label,
-      investorName: investorLinks.investorName,
-      email: investorLinks.email,
-      stage: investorLinks.stage,
-      engagementScore: investorLinks.engagementScore,
-      isActive: investorLinks.isActive,
-      notes: investorLinks.notes,
-      createdAt: investorLinks.createdAt,
-      updatedAt: investorLinks.updatedAt,
-      viewCount:
-        drizzleSql<number>`(SELECT COUNT(*) FROM investor_views WHERE investor_link_id = ${investorLinks.id})`.as(
-          'view_count'
-        ),
-      lastViewed: drizzleSql<
-        string | null
-      >`(SELECT MAX(viewed_at) FROM investor_views WHERE investor_link_id = ${investorLinks.id})`.as(
-        'last_viewed'
-      ),
-    })
-    .from(investorLinks)
-    .orderBy(desc(investorLinks.createdAt));
+  const links = await loadAdminInvestorPipelineData();
 
   if (links.length === 0) {
     return (

--- a/apps/web/tests/unit/app/admin-investors-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/admin-investors-shell-normalization.test.ts
@@ -55,6 +55,17 @@ describe('admin investor shell normalization', () => {
     expect(primitivesSource).toContain('export function InvestorTableRow');
   });
 
+  it('keeps investor route data outside the page module', () => {
+    const pageSource = readFileSync(INVESTORS_PAGE, 'utf8');
+
+    expect(pageSource).toContain('loadAdminInvestorPipelineData');
+    expect(pageSource).not.toContain('@/lib/db');
+    expect(pageSource).not.toContain('@/lib/db/schema/investors');
+    expect(pageSource).not.toContain('investorLinks');
+    expect(pageSource).not.toContain('investorViews');
+    expect(pageSource).not.toContain('drizzleSql');
+  });
+
   it('uses the canonical table action menu instead of a bespoke row dropdown', () => {
     const managerSource = readFileSync(INVESTOR_LINKS_MANAGER, 'utf8');
 


### PR DESCRIPTION
## Summary

- Move admin investor pipeline DB loading and view-count derivation into a server-only `loadAdminInvestorPipelineData()` route loader.
- Keep `admin/investors/page.tsx` focused on the route shell, summary cards, empty state, and existing table render.
- Preserve the current local investor table primitive contract shared with the investor links manager.

## Verification

- `pnpm biome check 'apps/web/app/app/(shell)/admin/investors/page.tsx' 'apps/web/app/app/(shell)/admin/investors/investors-data.ts' apps/web/tests/unit/app/admin-investors-shell-normalization.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/admin-investors-shell-normalization.test.ts` -- 4 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hook: proxy guard, Biome, ESLint, affected web typecheck
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2442-admin-investors-boundary",
  "source": "github",
  "sourceRunId": "e8d0a1bdc0240490b5667c45ace60ed11c0ffdae",
  "kind": "workflow",
  "status": "done",
  "title": "Isolate admin investors route data and table surface",
  "summary": "Admin investors page now delegates DB and view-count data shaping to a server-only route loader while preserving the existing route and table render contract.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2442",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2442/isolate-admin-investors-route-data-and-table-surface",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9194",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused admin investor normalization tests, web typecheck, Biome, diff-check, commit hook, and pre-push verification passed.",
      "checkedAt": "2026-05-18T19:14:27.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for route/data ownership only: page no longer imports DB/schema helpers and table primitives were intentionally preserved.",
      "checkedAt": "2026-05-18T19:14:27.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch pushed with conventional commit and PR artifact prepared.",
      "checkedAt": "2026-05-18T19:14:27.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T19:14:27.000Z",
  "updatedAt": "2026-05-18T19:14:27.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/admin/investors"]
  }
}
-->
