### PR TITLE
ci(auth): wait for canary build before auth smoke

### DIFF
--- a/.github/workflows/canary-health-gate.yml
+++ b/.github/workflows/canary-health-gate.yml
@@ -44,6 +44,7 @@ jobs:
     timeout-minutes: 20
     outputs:
       canary_status: ${{ steps.canary-status.outputs.canary_status || steps.canary-check.outputs.canary_status }}
+      verified_deployment_url: ${{ steps.canary-check.outputs.verified_deployment_url }}
     steps:
       - name: Canary health check
         id: canary-check
@@ -147,9 +148,8 @@ jobs:
           attempt=1
           max_attempts=8
           response_code="000"
-          canary_inconclusive="false"
           while [ $attempt -le $max_attempts ]; do
-            response=$(curl -s -L -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || echo "\n000")
+            response=$(curl -s -L -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
             response_code="${response##*$'\n'}"
 
             if [ "$response_code" = "200" ]; then
@@ -194,7 +194,7 @@ jobs:
             max_attempts=5
             response_code="000"
             while [ $attempt -le $max_attempts ]; do
-              response=$(curl -s -L -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || echo "\n000")
+              response=$(curl -s -L -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
               response_code="${response##*$'\n'}"
 
               if [ "$response_code" = "200" ]; then
@@ -232,7 +232,7 @@ jobs:
               max_attempts=5
               response_code="000"
               while [ $attempt -le $max_attempts ]; do
-                response=$(curl -s -L -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || echo "\n000")
+                response=$(curl -s -L -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
                 response_code="${response##*$'\n'}"
 
                 if [ "$response_code" = "200" ]; then
@@ -281,7 +281,77 @@ jobs:
             fi
           fi
 
-          # Note: canary_inconclusive is no longer used - we fail fast on unverified deployments
+          verify_build_info_serves_commit() {
+            local base_url="$1"
+            local expected_commit="${COMMIT_SHA:0:7}"
+            local build_info_url="${base_url%/}/api/health/build-info"
+            local attempt=1
+            local max_attempts=30
+            local response status body actual
+
+            echo "Verifying ${base_url%/} serves commit ${expected_commit}..."
+
+            while [ "$attempt" -le "$max_attempts" ]; do
+              if [ "$attempt" -gt 1 ]; then
+                sleep 10
+              fi
+
+              response=$(curl -sS -L \
+                --connect-timeout 5 \
+                --max-time 10 \
+                -A "$USER_AGENT" \
+                -H "Accept: application/json" \
+                -H "Cache-Control: no-cache, no-store, must-revalidate" \
+                -H "Pragma: no-cache" \
+                "${BYPASS_ARGS[@]}" \
+                -w "\n%{http_code}" \
+                "${build_info_url}?_cb=$(date +%s%N)" 2>/dev/null || printf '\n000')
+              status="${response##*$'\n'}"
+              body="${response%$'\n'*}"
+
+              if [ "$status" != "200" ]; then
+                echo "  attempt ${attempt}/${max_attempts}: build-info returned HTTP ${status}"
+                attempt=$((attempt + 1))
+                continue
+              fi
+
+              actual=$(BODY="$body" python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          try:
+              payload = json.loads(os.environ.get("BODY", ""))
+          except json.JSONDecodeError:
+              print("", end="")
+              sys.exit(0)
+
+          print(payload.get("commitSha") or "", end="")
+          PY
+              )
+
+              if [ -z "$actual" ]; then
+                echo "  attempt ${attempt}/${max_attempts}: build-info returned 200 without commitSha"
+                attempt=$((attempt + 1))
+                continue
+              fi
+
+              echo "  attempt ${attempt}/${max_attempts}: build-info commitSha=${actual}"
+              if [ "$actual" = "$expected_commit" ]; then
+                echo "✅ ${base_url%/} serves ${expected_commit}"
+                return 0
+              fi
+
+              attempt=$((attempt + 1))
+            done
+
+            echo "❌ Canary failed: ${base_url%/} did not serve commit ${expected_commit} within the retry window."
+            echo "canary_status=failed_build_info" >> "$GITHUB_OUTPUT"
+            exit 1
+          }
+
+          verify_build_info_serves_commit "$deployment_url"
+          echo "verified_deployment_url=${deployment_url%/}" >> "$GITHUB_OUTPUT"
 
           health_content=$(curl -s -L -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || echo "")
           if [[ "$health_content" != *'"status":"ok"'* ]]; then
@@ -313,7 +383,7 @@ jobs:
           # CRITICAL: Verify homepage renders (not just API health)
           echo "Checking homepage renders..."
           homepage_url="${deployment_url%/}/"
-          homepage_response=$(curl -s -L -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${homepage_url}$( [[ "$homepage_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || echo "\n000")
+          homepage_response=$(curl -s -L -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${homepage_url}$( [[ "$homepage_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
           homepage_code="${homepage_response##*$'\n'}"
           homepage_body="${homepage_response%$'\n'*}"
 
@@ -352,7 +422,7 @@ jobs:
             echo "Checking ${route_label} route renders..."
 
             while [ "$attempt" -le "$max_attempts" ]; do
-              response=$(curl -s -L -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${route_url}$( [[ "$route_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || echo "\n000")
+              response=$(curl -s -L -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${route_url}$( [[ "$route_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
               route_code="${response##*$'\n'}"
               route_body="${response%$'\n'*}"
 
@@ -417,7 +487,7 @@ jobs:
           # not a code regression), so only block on 5xx or actual error pages.
           echo "Checking public profile route renders..."
           profile_url="${deployment_url%/}/tim"
-          profile_response=$(curl -s -L -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${profile_url}$( [[ "$profile_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || echo "\n000")
+          profile_response=$(curl -s -L -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${profile_url}$( [[ "$profile_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
           profile_code="${profile_response##*$'\n'}"
           profile_body="${profile_response%$'\n'*}"
 
@@ -471,7 +541,7 @@ jobs:
           echo '{"cookies":[],"origins":[]}' > tests/.auth/user.json
           CI=true SMOKE_ONLY=1 BASE_URL="${DEPLOYMENT_URL}" pnpm exec playwright test tests/e2e/auth-public-ready.spec.ts --project=chromium --reporter=line
         env:
-          DEPLOYMENT_URL: ${{ inputs.deployment_url }}
+          DEPLOYMENT_URL: ${{ steps.canary-check.outputs.verified_deployment_url || inputs.deployment_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Mark canary verified

--- a/.github/workflows/canary-health-gate.yml
+++ b/.github/workflows/canary-health-gate.yml
@@ -117,6 +117,7 @@ jobs:
             echo "canary_status=failed" >> "$GITHUB_OUTPUT"
             exit 1
           fi
+          public_deployment_url="${deployment_url%/}"
 
           if [[ "$health_url_fallback" = /* ]]; then
             health_url_fallback="${deployment_url%/}${health_url_fallback}"
@@ -183,22 +184,15 @@ jobs:
 
           if [ "$response_code" != "200" ] && [ -n "$resolved_commit_deployment_url" ] && [ "${deployment_url%/}" != "${resolved_commit_deployment_url%/}" ]; then
             echo "⚠ Canary primary URL failed with HTTP $response_code. Retrying commit deployment URL ${resolved_commit_deployment_url}..."
-            deployment_url="$resolved_commit_deployment_url"
+            diagnostic_deployment_url="$resolved_commit_deployment_url"
 
-            if [[ "$FALLBACK_HEALTH_URL" = /* ]]; then
-              health_url_fallback="${deployment_url%/}${FALLBACK_HEALTH_URL}"
-            else
-              health_url_fallback="${FALLBACK_HEALTH_URL}"
-            fi
-
-            health_url_primary="${deployment_url%/}/api/health"
-            health_url="$health_url_primary"
+            diagnostic_health_url="${diagnostic_deployment_url%/}/api/health"
 
             attempt=1
             max_attempts=5
             response_code="000"
             while [ $attempt -le $max_attempts ]; do
-              response=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
+              response=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${diagnostic_health_url}$( [[ "$diagnostic_health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
               response_code="${response##*$'\n'}"
 
               if [ "$response_code" = "200" ]; then
@@ -354,8 +348,8 @@ jobs:
             exit 1
           }
 
-          verify_build_info_serves_commit "$deployment_url"
-          echo "verified_deployment_url=${deployment_url%/}" >> "$GITHUB_OUTPUT"
+          verify_build_info_serves_commit "$public_deployment_url"
+          echo "verified_deployment_url=${public_deployment_url}" >> "$GITHUB_OUTPUT"
 
           health_content=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || echo "")
           if [[ "$health_content" != *'"status":"ok"'* ]]; then

--- a/.github/workflows/canary-health-gate.yml
+++ b/.github/workflows/canary-health-gate.yml
@@ -27,6 +27,9 @@ on:
       canary_status:
         description: 'Canary verification status: verified, failed'
         value: ${{ jobs.canary-health-gate.outputs.canary_status }}
+      verified_deployment_url:
+        description: Verified deployment URL after build-info commit verification.
+        value: ${{ jobs.canary-health-gate.outputs.verified_deployment_url }}
     secrets:
       VERCEL_AUTOMATION_BYPASS_SECRET:
         required: false
@@ -144,12 +147,13 @@ jobs:
             echo "canary_status=failed_config" >> "$GITHUB_OUTPUT"
             exit 1
           fi
+          CURL_TIMEOUT_ARGS=(--connect-timeout 5 --max-time 15)
 
           attempt=1
           max_attempts=8
           response_code="000"
           while [ $attempt -le $max_attempts ]; do
-            response=$(curl -s -L -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
+            response=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
             response_code="${response##*$'\n'}"
 
             if [ "$response_code" = "200" ]; then
@@ -194,7 +198,7 @@ jobs:
             max_attempts=5
             response_code="000"
             while [ $attempt -le $max_attempts ]; do
-              response=$(curl -s -L -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
+              response=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
               response_code="${response##*$'\n'}"
 
               if [ "$response_code" = "200" ]; then
@@ -232,7 +236,7 @@ jobs:
               max_attempts=5
               response_code="000"
               while [ $attempt -le $max_attempts ]; do
-                response=$(curl -s -L -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
+                response=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
                 response_code="${response##*$'\n'}"
 
                 if [ "$response_code" = "200" ]; then
@@ -353,7 +357,7 @@ jobs:
           verify_build_info_serves_commit "$deployment_url"
           echo "verified_deployment_url=${deployment_url%/}" >> "$GITHUB_OUTPUT"
 
-          health_content=$(curl -s -L -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || echo "")
+          health_content=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -H "Accept: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" "${health_url}$( [[ "$health_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || echo "")
           if [[ "$health_content" != *'"status":"ok"'* ]]; then
             echo "❌ Canary failed: Health status not ok"
             echo "Health response: $health_content"
@@ -383,7 +387,7 @@ jobs:
           # CRITICAL: Verify homepage renders (not just API health)
           echo "Checking homepage renders..."
           homepage_url="${deployment_url%/}/"
-          homepage_response=$(curl -s -L -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${homepage_url}$( [[ "$homepage_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
+          homepage_response=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${homepage_url}$( [[ "$homepage_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
           homepage_code="${homepage_response##*$'\n'}"
           homepage_body="${homepage_response%$'\n'*}"
 
@@ -422,7 +426,7 @@ jobs:
             echo "Checking ${route_label} route renders..."
 
             while [ "$attempt" -le "$max_attempts" ]; do
-              response=$(curl -s -L -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${route_url}$( [[ "$route_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
+              response=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${route_url}$( [[ "$route_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
               route_code="${response##*$'\n'}"
               route_body="${response%$'\n'*}"
 
@@ -471,7 +475,7 @@ jobs:
           # this check informational so canary does not block healthy deployments.
           echo "Checking /api/chat is reachable and auth-gated (informational)..."
           chat_url="${deployment_url%/}/api/chat"
-          chat_response=$(curl -s -L -A "$USER_AGENT" -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"hi"}]}]}' -w "\n%{http_code}" "${chat_url}" || printf '\n000')
+          chat_response=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -X POST -H "Content-Type: application/json" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -d '{"messages":[{"id":"1","role":"user","parts":[{"type":"text","text":"hi"}]}]}' -w "\n%{http_code}" "${chat_url}" || printf '\n000')
           chat_code="${chat_response##*$'\n'}"
 
           # The chat route checks auth before body parsing, so unauthenticated
@@ -487,7 +491,7 @@ jobs:
           # not a code regression), so only block on 5xx or actual error pages.
           echo "Checking public profile route renders..."
           profile_url="${deployment_url%/}/tim"
-          profile_response=$(curl -s -L -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${profile_url}$( [[ "$profile_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
+          profile_response=$(curl -s -L "${CURL_TIMEOUT_ARGS[@]}" -A "$USER_AGENT" -H "Cache-Control: no-cache, no-store, must-revalidate" -H "Pragma: no-cache" "${BYPASS_ARGS[@]}" -w "\n%{http_code}" "${profile_url}$( [[ "$profile_url" == *"?"* ]] && echo '&' || echo '?' )_cb=$(date +%s%N)" || printf '\n000')
           profile_code="${profile_response##*$'\n'}"
           profile_body="${profile_response%$'\n'*}"
 

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -268,8 +268,24 @@ describe('canary health gate workflow', () => {
       workflow,
       'Verify public auth controls are interactive'
     );
-    const canaryCurlProbes = canaryStep.match(/curl -s -L [^\n]+/g) ?? [];
+    const directFallbackStart = canaryStep.indexOf(
+      'Retrying commit deployment URL'
+    );
+    const directFallbackEnd = canaryStep.indexOf(
+      'if [ "$response_code" != "200" ]; then',
+      directFallbackStart
+    );
+    const directFallbackBlock = canaryStep.slice(
+      directFallbackStart,
+      directFallbackEnd
+    );
+    const canaryCurlProbes =
+      canaryStep.match(
+        /curl -sS? -L[\s\S]*?(?:\|\| printf '\\n000'|\|\| echo "")/g
+      ) ?? [];
 
+    expect(directFallbackStart).toBeGreaterThanOrEqual(0);
+    expect(directFallbackEnd).toBeGreaterThan(directFallbackStart);
     expect(workflow).toContain('verified_deployment_url:');
     expect(workflow).toContain(
       'value: ${{ jobs.canary-health-gate.outputs.verified_deployment_url }}'
@@ -279,15 +295,29 @@ describe('canary health gate workflow', () => {
     expect(canaryStep).toContain(
       'CURL_TIMEOUT_ARGS=(--connect-timeout 5 --max-time 15)'
     );
+    expect(canaryStep).toContain('public_deployment_url="${deployment_url%/}"');
+    expect(directFallbackBlock).toContain(
+      'diagnostic_deployment_url="$resolved_commit_deployment_url"'
+    );
+    expect(directFallbackBlock).not.toMatch(
+      /^\s*deployment_url="\$resolved_commit_deployment_url"/m
+    );
+    expect(canaryStep).toContain(
+      'verify_build_info_serves_commit "$public_deployment_url"'
+    );
     expect(canaryStep).toContain('canary_status=failed_build_info');
-    expect(canaryStep).toContain('verified_deployment_url=');
+    expect(canaryStep).toContain(
+      'verified_deployment_url=${public_deployment_url}'
+    );
     expect(authSmokeStep).toContain(
       'DEPLOYMENT_URL: ${{ steps.canary-check.outputs.verified_deployment_url || inputs.deployment_url }}'
     );
 
-    expect(canaryCurlProbes.length).toBeGreaterThanOrEqual(8);
+    expect(canaryCurlProbes.length).toBeGreaterThanOrEqual(9);
     for (const probe of canaryCurlProbes) {
-      expect(probe).toContain('"${CURL_TIMEOUT_ARGS[@]}"');
+      expect(probe).toMatch(
+        /("\$\{CURL_TIMEOUT_ARGS\[@\]\}"|--connect-timeout 5[\s\S]*--max-time (10|15))/
+      );
     }
   });
 });

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -260,6 +260,23 @@ describe('canary health gate workflow', () => {
       'canary_status=verified" >> "$GITHUB_OUTPUT"\n                    exit 0'
     );
   });
+
+  it('waits for the public alias to serve the target build before auth smoke', () => {
+    const workflow = readFileSync(canaryWorkflowPath, 'utf8');
+    const canaryStep = getStepBlock(workflow, 'Canary health check');
+    const authSmokeStep = getStepBlock(
+      workflow,
+      'Verify public auth controls are interactive'
+    );
+
+    expect(canaryStep).toContain('/api/health/build-info');
+    expect(canaryStep).toContain('local max_attempts=30');
+    expect(canaryStep).toContain('canary_status=failed_build_info');
+    expect(canaryStep).toContain('verified_deployment_url=');
+    expect(authSmokeStep).toContain(
+      'DEPLOYMENT_URL: ${{ steps.canary-check.outputs.verified_deployment_url || inputs.deployment_url }}'
+    );
+  });
 });
 
 describe('CI public a11y workflow', () => {

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -268,14 +268,27 @@ describe('canary health gate workflow', () => {
       workflow,
       'Verify public auth controls are interactive'
     );
+    const canaryCurlProbes = canaryStep.match(/curl -s -L [^\n]+/g) ?? [];
 
+    expect(workflow).toContain('verified_deployment_url:');
+    expect(workflow).toContain(
+      'value: ${{ jobs.canary-health-gate.outputs.verified_deployment_url }}'
+    );
     expect(canaryStep).toContain('/api/health/build-info');
     expect(canaryStep).toContain('local max_attempts=30');
+    expect(canaryStep).toContain(
+      'CURL_TIMEOUT_ARGS=(--connect-timeout 5 --max-time 15)'
+    );
     expect(canaryStep).toContain('canary_status=failed_build_info');
     expect(canaryStep).toContain('verified_deployment_url=');
     expect(authSmokeStep).toContain(
       'DEPLOYMENT_URL: ${{ steps.canary-check.outputs.verified_deployment_url || inputs.deployment_url }}'
     );
+
+    expect(canaryCurlProbes.length).toBeGreaterThanOrEqual(8);
+    for (const probe of canaryCurlProbes) {
+      expect(probe).toContain('"${CURL_TIMEOUT_ARGS[@]}"');
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Wait for `/api/health/build-info` to serve the target commit before the canary browser auth smoke runs.
- Pass the verified deployment URL into the Playwright auth-readiness smoke.
- Add a unit guard for the canary build-info contract.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check .github/workflows/canary-health-gate.yml apps/web/tests/unit/ci/deploy-workflow.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm exec actionlint .github/workflows/canary-health-gate.yml`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder CI=true SMOKE_ONLY=1 BASE_URL=https://staging.jov.ie pnpm --filter @jovie/web exec playwright test tests/e2e/auth-public-ready.spec.ts --project=chromium --reporter=line`

Linear: JOV-2437


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a verified deployment URL output and stricter "fail fast" gating so smoke tests run only after deployment commit is confirmed.
  * Unified probe failure handling (consistent timeout args and stable failure response) across health and content checks.

* **Tests**
  * Added unit tests validating the canary health gate waits for deployment verification, exposes the verified URL, passes it to smoke tests (with fallback), and enforces probe timeout behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->