### PR TITLE
refactor(shell): isolate admin share studio loader

### DIFF
--- a/apps/web/app/app/(shell)/admin/share-studio/loader.ts
+++ b/apps/web/app/app/(shell)/admin/share-studio/loader.ts
@@ -1,0 +1,278 @@
+import 'server-only';
+
+import { and, desc, eq, isNull } from 'drizzle-orm';
+import { getBlogPosts } from '@/lib/blog/getBlogPosts';
+import { db } from '@/lib/db';
+import { discogReleases } from '@/lib/db/schema/content';
+import { joviePlaylists } from '@/lib/db/schema/playlists';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import {
+  getProfileByUsername,
+  getTopProfilesForStaticGeneration,
+} from '@/lib/services/profile';
+import {
+  buildBlogShareContext,
+  buildPlaylistShareContext,
+  buildProfileShareContext,
+  buildReleaseShareContext,
+} from '@/lib/share/context';
+import type { ShareContext } from '@/lib/share/types';
+
+export type ShareStudioSearchParams = Record<
+  string,
+  string | string[] | undefined
+>;
+
+type BlogPost = Awaited<ReturnType<typeof getBlogPosts>>[number];
+
+interface ProfileSample {
+  readonly username: string;
+  readonly name: string;
+  readonly avatarUrl: string | null;
+  readonly bio: string | null;
+}
+
+interface ReleaseSample {
+  readonly username: string;
+  readonly artistName: string;
+  readonly slug: string;
+  readonly title: string;
+  readonly artworkUrl: string | null;
+}
+
+interface PlaylistSample {
+  readonly slug: string;
+  readonly title: string;
+  readonly coverImageUrl: string | null;
+  readonly editorialNote: string | null;
+}
+
+export interface SamplePickerItem {
+  readonly key: string;
+  readonly label: string;
+}
+
+export interface ShareStudioData {
+  readonly urlSearchParams: URLSearchParams;
+  readonly blogItems: readonly SamplePickerItem[];
+  readonly profileItems: readonly SamplePickerItem[];
+  readonly releaseItems: readonly SamplePickerItem[];
+  readonly playlistItems: readonly SamplePickerItem[];
+  readonly selectedBlogKey: string;
+  readonly selectedProfileKey: string;
+  readonly selectedReleaseKey: string;
+  readonly selectedPlaylistKey: string;
+  readonly blogContext: ShareContext;
+  readonly profileContext: ShareContext;
+  readonly releaseContext: ShareContext;
+  readonly playlistContext: ShareContext;
+}
+
+export function getShareStudioParamValue(
+  value: string | string[] | undefined
+): string | null {
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+
+  return null;
+}
+
+function buildUrlSearchParams(params: ShareStudioSearchParams) {
+  const urlSearchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(params)) {
+    const normalizedValue = getShareStudioParamValue(value);
+    if (normalizedValue) {
+      urlSearchParams.set(key, normalizedValue);
+    }
+  }
+
+  return urlSearchParams;
+}
+
+async function getProfileSamples(limit = 4): Promise<ProfileSample[]> {
+  const usernames = await getTopProfilesForStaticGeneration(limit);
+  const profiles = await Promise.all(
+    usernames.map(async entry => getProfileByUsername(entry.username))
+  );
+
+  return profiles
+    .filter((profile): profile is NonNullable<typeof profile> =>
+      Boolean(profile?.usernameNormalized && profile.isPublic)
+    )
+    .map(profile => ({
+      username: profile.usernameNormalized,
+      name: profile.displayName ?? profile.username,
+      avatarUrl: profile.avatarUrl,
+      bio: profile.bio,
+    }));
+}
+
+async function getReleaseSamples(limit = 4): Promise<ReleaseSample[]> {
+  return db
+    .select({
+      username: creatorProfiles.usernameNormalized,
+      artistName: creatorProfiles.displayName,
+      fallbackArtistName: creatorProfiles.username,
+      slug: discogReleases.slug,
+      title: discogReleases.title,
+      artworkUrl: discogReleases.artworkUrl,
+    })
+    .from(discogReleases)
+    .innerJoin(
+      creatorProfiles,
+      eq(discogReleases.creatorProfileId, creatorProfiles.id)
+    )
+    .where(
+      and(eq(creatorProfiles.isPublic, true), isNull(discogReleases.deletedAt))
+    )
+    .orderBy(desc(discogReleases.releaseDate), desc(discogReleases.createdAt))
+    .limit(limit)
+    .then(rows =>
+      rows.map(row => ({
+        username: row.username,
+        artistName: row.artistName ?? row.fallbackArtistName,
+        slug: row.slug,
+        title: row.title,
+        artworkUrl: row.artworkUrl,
+      }))
+    );
+}
+
+async function getPlaylistSamples(limit = 4): Promise<PlaylistSample[]> {
+  return db
+    .select({
+      slug: joviePlaylists.slug,
+      title: joviePlaylists.title,
+      coverImageUrl: joviePlaylists.coverImageUrl,
+      editorialNote: joviePlaylists.editorialNote,
+    })
+    .from(joviePlaylists)
+    .where(eq(joviePlaylists.status, 'published'))
+    .orderBy(desc(joviePlaylists.publishedAt), desc(joviePlaylists.createdAt))
+    .limit(limit);
+}
+
+function selectBlogSample(
+  blogPosts: readonly BlogPost[],
+  params: ShareStudioSearchParams
+) {
+  return (
+    blogPosts.find(
+      post => post.slug === getShareStudioParamValue(params.blog)
+    ) ?? blogPosts[0]
+  );
+}
+
+function selectProfileSample(
+  profileSamples: readonly ProfileSample[],
+  params: ShareStudioSearchParams
+) {
+  return (
+    profileSamples.find(
+      profile => profile.username === getShareStudioParamValue(params.profile)
+    ) ?? profileSamples[0]
+  );
+}
+
+function selectReleaseSample(
+  releaseSamples: readonly ReleaseSample[],
+  params: ShareStudioSearchParams
+) {
+  return (
+    releaseSamples.find(
+      release =>
+        `${release.username}:${release.slug}` ===
+        getShareStudioParamValue(params.release)
+    ) ?? releaseSamples[0]
+  );
+}
+
+function selectPlaylistSample(
+  playlistSamples: readonly PlaylistSample[],
+  params: ShareStudioSearchParams
+) {
+  return (
+    playlistSamples.find(
+      playlist => playlist.slug === getShareStudioParamValue(params.playlist)
+    ) ?? playlistSamples[0]
+  );
+}
+
+export async function loadShareStudioData(
+  params: ShareStudioSearchParams
+): Promise<ShareStudioData | null> {
+  const [blogPosts, profileSamples, releaseSamples, playlistSamples] =
+    await Promise.all([
+      getBlogPosts(),
+      getProfileSamples(),
+      getReleaseSamples(),
+      getPlaylistSamples(),
+    ]);
+
+  const selectedBlog = selectBlogSample(blogPosts, params);
+  const selectedProfile = selectProfileSample(profileSamples, params);
+  const selectedRelease = selectReleaseSample(releaseSamples, params);
+  const selectedPlaylist = selectPlaylistSample(playlistSamples, params);
+
+  if (
+    !selectedBlog ||
+    !selectedProfile ||
+    !selectedRelease ||
+    !selectedPlaylist
+  ) {
+    return null;
+  }
+
+  const selectedReleaseKey = `${selectedRelease.username}:${selectedRelease.slug}`;
+
+  return {
+    urlSearchParams: buildUrlSearchParams(params),
+    blogItems: blogPosts.slice(0, 4).map(post => ({
+      key: post.slug,
+      label: post.title,
+    })),
+    profileItems: profileSamples.map(profile => ({
+      key: profile.username,
+      label: profile.name,
+    })),
+    releaseItems: releaseSamples.map(release => ({
+      key: `${release.username}:${release.slug}`,
+      label: `${release.artistName} \u2014 ${release.title}`,
+    })),
+    playlistItems: playlistSamples.map(playlist => ({
+      key: playlist.slug,
+      label: playlist.title,
+    })),
+    selectedBlogKey: selectedBlog.slug,
+    selectedProfileKey: selectedProfile.username,
+    selectedReleaseKey,
+    selectedPlaylistKey: selectedPlaylist.slug,
+    blogContext: buildBlogShareContext({
+      slug: selectedBlog.slug,
+      title: selectedBlog.title,
+      excerpt: selectedBlog.excerpt,
+    }),
+    profileContext: buildProfileShareContext({
+      username: selectedProfile.username,
+      artistName: selectedProfile.name,
+      avatarUrl: selectedProfile.avatarUrl,
+      bio: selectedProfile.bio,
+    }),
+    releaseContext: buildReleaseShareContext({
+      username: selectedRelease.username,
+      slug: selectedRelease.slug,
+      title: selectedRelease.title,
+      artistName: selectedRelease.artistName,
+      artworkUrl: selectedRelease.artworkUrl,
+      pathname: `/${selectedRelease.username}/${selectedRelease.slug}`,
+    }),
+    playlistContext: buildPlaylistShareContext({
+      slug: selectedPlaylist.slug,
+      title: selectedPlaylist.title,
+      coverImageUrl: selectedPlaylist.coverImageUrl,
+      editorialNote: selectedPlaylist.editorialNote,
+    }),
+  };
+}

--- a/apps/web/app/app/(shell)/admin/share-studio/page.tsx
+++ b/apps/web/app/app/(shell)/admin/share-studio/page.tsx
@@ -1,31 +1,20 @@
-import { and, desc, eq, isNull } from 'drizzle-orm';
 import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
 import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { APP_ROUTES } from '@/constants/routes';
-import { getBlogPosts } from '@/lib/blog/getBlogPosts';
-import { db } from '@/lib/db';
-import { discogReleases } from '@/lib/db/schema/content';
-import { joviePlaylists } from '@/lib/db/schema/playlists';
-import { creatorProfiles } from '@/lib/db/schema/profiles';
-import {
-  getProfileByUsername,
-  getTopProfilesForStaticGeneration,
-} from '@/lib/services/profile';
-import {
-  buildBlogShareContext,
-  buildPlaylistShareContext,
-  buildProfileShareContext,
-  buildReleaseShareContext,
-} from '@/lib/share/context';
 import {
   buildDisplayUrl,
   buildMailtoHref,
   buildTrackedShareUrl,
 } from '@/lib/share/copy';
 import type { ShareContext } from '@/lib/share/types';
+import {
+  loadShareStudioData,
+  type SamplePickerItem,
+  type ShareStudioSearchParams,
+} from './loader';
 
 export const metadata: Metadata = {
   title: 'Share Studio | Admin',
@@ -35,37 +24,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 interface ShareStudioPageProps {
-  readonly searchParams: Promise<Record<string, string | string[] | undefined>>;
-}
-
-interface ProfileSample {
-  readonly username: string;
-  readonly name: string;
-  readonly avatarUrl: string | null;
-  readonly bio: string | null;
-}
-
-interface ReleaseSample {
-  readonly username: string;
-  readonly artistName: string;
-  readonly slug: string;
-  readonly title: string;
-  readonly artworkUrl: string | null;
-}
-
-interface PlaylistSample {
-  readonly slug: string;
-  readonly title: string;
-  readonly coverImageUrl: string | null;
-  readonly editorialNote: string | null;
-}
-
-function getParamValue(value: string | string[] | undefined): string | null {
-  if (typeof value === 'string' && value.length > 0) {
-    return value;
-  }
-
-  return null;
+  readonly searchParams: Promise<ShareStudioSearchParams>;
 }
 
 function buildPickerHref(
@@ -136,7 +95,7 @@ function buildTrackedPreviewLinks(context: ShareContext) {
 function SamplePicker(
   props: Readonly<{
     readonly label: string;
-    readonly items: readonly { key: string; label: string }[];
+    readonly items: readonly SamplePickerItem[];
     readonly selectedKey: string;
     readonly paramKey: string;
     readonly searchParams: URLSearchParams;
@@ -265,113 +224,13 @@ function PayloadBlock(props: Readonly<{ label: string; value: string }>) {
   );
 }
 
-async function getProfileSamples(limit = 4): Promise<ProfileSample[]> {
-  const usernames = await getTopProfilesForStaticGeneration(limit);
-  const profiles = await Promise.all(
-    usernames.map(async entry => getProfileByUsername(entry.username))
-  );
-
-  return profiles
-    .filter((profile): profile is NonNullable<typeof profile> =>
-      Boolean(profile?.usernameNormalized && profile.isPublic)
-    )
-    .map(profile => ({
-      username: profile.usernameNormalized,
-      name: profile.displayName ?? profile.username,
-      avatarUrl: profile.avatarUrl,
-      bio: profile.bio,
-    }));
-}
-
-async function getReleaseSamples(limit = 4): Promise<ReleaseSample[]> {
-  return db
-    .select({
-      username: creatorProfiles.usernameNormalized,
-      artistName: creatorProfiles.displayName,
-      fallbackArtistName: creatorProfiles.username,
-      slug: discogReleases.slug,
-      title: discogReleases.title,
-      artworkUrl: discogReleases.artworkUrl,
-    })
-    .from(discogReleases)
-    .innerJoin(
-      creatorProfiles,
-      eq(discogReleases.creatorProfileId, creatorProfiles.id)
-    )
-    .where(
-      and(eq(creatorProfiles.isPublic, true), isNull(discogReleases.deletedAt))
-    )
-    .orderBy(desc(discogReleases.releaseDate), desc(discogReleases.createdAt))
-    .limit(limit)
-    .then(rows =>
-      rows.map(row => ({
-        username: row.username,
-        artistName: row.artistName ?? row.fallbackArtistName,
-        slug: row.slug,
-        title: row.title,
-        artworkUrl: row.artworkUrl,
-      }))
-    );
-}
-
-async function getPlaylistSamples(limit = 4): Promise<PlaylistSample[]> {
-  return db
-    .select({
-      slug: joviePlaylists.slug,
-      title: joviePlaylists.title,
-      coverImageUrl: joviePlaylists.coverImageUrl,
-      editorialNote: joviePlaylists.editorialNote,
-    })
-    .from(joviePlaylists)
-    .where(eq(joviePlaylists.status, 'published'))
-    .orderBy(desc(joviePlaylists.publishedAt), desc(joviePlaylists.createdAt))
-    .limit(limit);
-}
-
 export default async function AdminShareStudioPage({
   searchParams,
 }: ShareStudioPageProps) {
   const params = await searchParams;
-  const urlSearchParams = new URLSearchParams();
+  const data = await loadShareStudioData(params);
 
-  for (const [key, value] of Object.entries(params)) {
-    const normalizedValue = getParamValue(value);
-    if (normalizedValue) {
-      urlSearchParams.set(key, normalizedValue);
-    }
-  }
-
-  const [blogPosts, profileSamples, releaseSamples, playlistSamples] =
-    await Promise.all([
-      getBlogPosts(),
-      getProfileSamples(),
-      getReleaseSamples(),
-      getPlaylistSamples(),
-    ]);
-
-  const selectedBlog =
-    blogPosts.find(post => post.slug === getParamValue(params.blog)) ??
-    blogPosts[0];
-  const selectedProfile =
-    profileSamples.find(
-      profile => profile.username === getParamValue(params.profile)
-    ) ?? profileSamples[0];
-  const selectedRelease =
-    releaseSamples.find(
-      release =>
-        `${release.username}:${release.slug}` === getParamValue(params.release)
-    ) ?? releaseSamples[0];
-  const selectedPlaylist =
-    playlistSamples.find(
-      playlist => playlist.slug === getParamValue(params.playlist)
-    ) ?? playlistSamples[0];
-
-  if (
-    !selectedBlog ||
-    !selectedProfile ||
-    !selectedRelease ||
-    !selectedPlaylist
-  ) {
+  if (!data) {
     return (
       <AdminToolPage
         title='Share Studio'
@@ -386,32 +245,6 @@ export default async function AdminShareStudioPage({
     );
   }
 
-  const blogContext = buildBlogShareContext({
-    slug: selectedBlog.slug,
-    title: selectedBlog.title,
-    excerpt: selectedBlog.excerpt,
-  });
-  const profileContext = buildProfileShareContext({
-    username: selectedProfile.username,
-    artistName: selectedProfile.name,
-    avatarUrl: selectedProfile.avatarUrl,
-    bio: selectedProfile.bio,
-  });
-  const releaseContext = buildReleaseShareContext({
-    username: selectedRelease.username,
-    slug: selectedRelease.slug,
-    title: selectedRelease.title,
-    artistName: selectedRelease.artistName,
-    artworkUrl: selectedRelease.artworkUrl,
-    pathname: `/${selectedRelease.username}/${selectedRelease.slug}`,
-  });
-  const playlistContext = buildPlaylistShareContext({
-    slug: selectedPlaylist.slug,
-    title: selectedPlaylist.title,
-    coverImageUrl: selectedPlaylist.coverImageUrl,
-    editorialNote: selectedPlaylist.editorialNote,
-  });
-
   return (
     <AdminToolPage
       title='Share Studio'
@@ -421,51 +254,48 @@ export default async function AdminShareStudioPage({
       <div className='grid gap-3 xl:grid-cols-2'>
         <SamplePicker
           label='Blog Sample'
-          items={blogPosts.slice(0, 4).map(post => ({
-            key: post.slug,
-            label: post.title,
-          }))}
-          selectedKey={selectedBlog.slug}
+          items={data.blogItems}
+          selectedKey={data.selectedBlogKey}
           paramKey='blog'
-          searchParams={urlSearchParams}
+          searchParams={data.urlSearchParams}
         />
         <SamplePicker
           label='Profile Sample'
-          items={profileSamples.map(profile => ({
-            key: profile.username,
-            label: profile.name,
-          }))}
-          selectedKey={selectedProfile.username}
+          items={data.profileItems}
+          selectedKey={data.selectedProfileKey}
           paramKey='profile'
-          searchParams={urlSearchParams}
+          searchParams={data.urlSearchParams}
         />
         <SamplePicker
           label='Release Sample'
-          items={releaseSamples.map(release => ({
-            key: `${release.username}:${release.slug}`,
-            label: `${release.artistName} — ${release.title}`,
-          }))}
-          selectedKey={`${selectedRelease.username}:${selectedRelease.slug}`}
+          items={data.releaseItems}
+          selectedKey={data.selectedReleaseKey}
           paramKey='release'
-          searchParams={urlSearchParams}
+          searchParams={data.urlSearchParams}
         />
         <SamplePicker
           label='Playlist Sample'
-          items={playlistSamples.map(playlist => ({
-            key: playlist.slug,
-            label: playlist.title,
-          }))}
-          selectedKey={selectedPlaylist.slug}
+          items={data.playlistItems}
+          selectedKey={data.selectedPlaylistKey}
           paramKey='playlist'
-          searchParams={urlSearchParams}
+          searchParams={data.urlSearchParams}
         />
       </div>
 
       <div className='grid gap-4'>
-        <PayloadCard title='Blog Share Payload' context={blogContext} />
-        <PayloadCard title='Profile Share Payload' context={profileContext} />
-        <PayloadCard title='Release Share Payload' context={releaseContext} />
-        <PayloadCard title='Playlist Share Payload' context={playlistContext} />
+        <PayloadCard title='Blog Share Payload' context={data.blogContext} />
+        <PayloadCard
+          title='Profile Share Payload'
+          context={data.profileContext}
+        />
+        <PayloadCard
+          title='Release Share Payload'
+          context={data.releaseContext}
+        />
+        <PayloadCard
+          title='Playlist Share Payload'
+          context={data.playlistContext}
+        />
       </div>
     </AdminToolPage>
   );

--- a/apps/web/tests/unit/app/admin-share-studio-loader-guard.test.ts
+++ b/apps/web/tests/unit/app/admin-share-studio-loader-guard.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const SHARE_STUDIO_DIR = join(
+  TEST_DIR,
+  '../../../app/app/(shell)/admin/share-studio'
+);
+
+function readShareStudioSource(fileName: string) {
+  return readFileSync(join(SHARE_STUDIO_DIR, fileName), 'utf8');
+}
+
+describe('Admin Share Studio route loader boundary', () => {
+  it('keeps route data loading and share-context construction in the server loader', () => {
+    const pageSource = readShareStudioSource('page.tsx');
+    const loaderSource = readShareStudioSource('loader.ts');
+
+    expect(loaderSource.startsWith("import 'server-only';")).toBe(true);
+    expect(pageSource).toContain("from './loader'");
+    expect(loaderSource).toContain('export async function loadShareStudioData');
+
+    expect(pageSource).not.toContain("from '@/lib/db'");
+    expect(pageSource).not.toContain("from '@/lib/blog/getBlogPosts'");
+    expect(pageSource).not.toContain("from '@/lib/services/profile'");
+    expect(pageSource).not.toContain("from '@/lib/share/context'");
+  });
+});


### PR DESCRIPTION
## Summary

- Move Share Studio sample loading, query-param normalization, and share-context construction into a server-only `loadShareStudioData()` loader.
- Keep `admin/share-studio/page.tsx` focused on rendering the existing picker and payload cards.
- Add a focused source guard so DB/blog/profile/share-context imports stay out of the page module.

## Verification

- `pnpm biome check 'apps/web/app/app/(shell)/admin/share-studio/page.tsx' 'apps/web/app/app/(shell)/admin/share-studio/loader.ts' apps/web/tests/unit/app/admin-share-studio-loader-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/admin-share-studio-loader-guard.test.ts` -- 1 test passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hook: proxy guard, Biome, ESLint, affected web typecheck
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2447-share-studio-loader",
  "source": "github",
  "sourceRunId": "5d8c454d23179b5637c8e32ce7d99e9cef148bca",
  "kind": "workflow",
  "status": "done",
  "title": "Isolate admin share studio route loader",
  "summary": "Admin Share Studio now delegates sample loading, route parameter normalization, and share-context construction to a server-only loader while preserving the existing page UI.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2447",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2447/isolate-admin-share-studio-route-loader",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9201",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused Share Studio route-loader guard, web typecheck, Biome, diff-check, commit hook, and pre-push verification passed.",
      "checkedAt": "2026-05-18T19:43:54.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for route/data ownership only: page no longer imports DB/blog/profile/share-context helpers and visible UI remains unchanged.",
      "checkedAt": "2026-05-18T19:43:54.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch pushed with conventional commit and PR artifact prepared.",
      "checkedAt": "2026-05-18T19:43:54.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T19:43:54.000Z",
  "updatedAt": "2026-05-18T19:43:54.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/admin/share-studio"]
  }
}
-->
