### PR TITLE
docs(company): pricing philosophy + operating principles canon (JOV-2450)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ Controller file for AI agents working in this repo. `AGENTS.md` is a symlink to 
 - Don't hide failing checks. Report exact failures and the likely cause.
 - Ask before destructive operations: data deletion, irreversible migrations, credential changes, dependency replacement, auth/payment changes, or production-impacting scripts.
 
+The four canon principles (Ship Fast, Run Experiments, Document Everything, MRR Is King) are in [`docs/company/operating-principles.md`](docs/company/operating-principles.md). They supersede [`docs/company/core-values.md`](docs/company/core-values.md) when in conflict.
+
 ## Agent Role Boundary
 
 Orchestrated sessions must set `JOVIE_AGENT_PROFILE` before editing:
@@ -174,3 +176,5 @@ Examples:
 - `apps/web/tests/TESTING.md` is the deep test reference.
 - `LESSONS.md` collects post-mortems from human corrections.
 - `docs/` holds reference indexes (schema map, API map, cron registry, etc.).
+- `docs/company/operating-principles.md` is the four-principle canon (Ship Fast, Experiments, Document, MRR Is King).
+- `docs/company/PRICING-PHILOSOPHY.md` is the canon for how pricing decisions are made; `docs/company/PRICING-STRATEGY.md` is the current snapshot; `docs/company/pricing-trends-summary.md` is the Stripe data behind the philosophy.

--- a/docs/company/PRICING-PHILOSOPHY.md
+++ b/docs/company/PRICING-PHILOSOPHY.md
@@ -1,0 +1,113 @@
+# Jovie Pricing Philosophy
+
+Canon. How we **decide** pricing — distinct from [`PRICING-STRATEGY.md`](./PRICING-STRATEGY.md), which documents what we charge **right now**. Strategy is the snapshot; philosophy is the operating rules that govern how the snapshot changes.
+
+Read [`pricing-trends-summary.md`](./pricing-trends-summary.md) first if you haven't — these principles are the Jovie translation of that data.
+
+When a future agent or teammate asks "should we change pricing?", "should we test a price increase?", or "should we add a new tier?", the answer lives here.
+
+## Principle 1 — Pricing Is a Product, Not a Setting
+
+Pricing ships, gets measured, gets re-shipped. Same lifecycle as any feature.
+
+- **Cadence:** quarterly review minimum. Default to "yes, change it" if there's a hypothesis backed by ≥30 conversion data points.
+- **Treat the price page like a landing page:** subject to the same A/B discipline (see [`operating-principles.md`](./operating-principles.md) Principle 2 — experiments are bounded; one concurrent test per surface).
+- **Stripe data backs this:** 87% of hyper-growth companies changed price 3+ times in 2 years. 33% of low-growth did. Pricing motion is correlated with growth motion.
+
+## Principle 2 — Hybrid Is the Destination
+
+Subscription base captures predictability for the business. Usage meter captures upside as artists scale. Both must exist by the time Jovie crosses $50K MRR. Until then, flat tiers are fine — the usage data isn't there yet.
+
+- Current caps (5 / 100 / 500 AI messages per day) are *limiters*. The hybrid future converts them into *meters* (overage, credit packs, or both).
+- Meter candidates, ranked by signal-to-implementation cost: fan-notification batches, canvases generated, releases launched, campaigns drafted, AI messages above plan.
+- **57% of hyper-growth companies use hybrid pricing.** This is not a fringe pattern.
+- The migration story is tracked in [JOV-2450](https://linear.app/jovie/issue/JOV-2450) — this doc says *that* it happens, not *when*.
+
+## Principle 3 — Price the Work, Then the Outcome
+
+Three pricing shapes for AI surfaces, in order of attribution difficulty:
+
+1. **Per-seat** — wrong for agents. An agent does not have a seat. Never use this for any Jovie AI surface.
+2. **Work-based** — per artifact produced (per canvas generated, per campaign drafted, per release plan written, per notification batch sent). Mechanically verifiable. Default for new AI surfaces.
+3. **Outcome-based** — per booking won, per first-paying-fan converted, per release-week stream lift above baseline. Highest perceived value, hardest to attribute. Earned, not assumed.
+
+Move from work-based to outcome-based only when the attribution loop is closed (the data exists, the artist agrees the outcome is real, the dispute path is defined). Until then, work-based is honest and outcome-based is fiction.
+
+## Principle 4 — Charge for Value That's Visible to the Customer
+
+Upgrade conversion follows visibility. The artist's audience (fans, bookers, curators) is the secondary customer — anything they can see drives the primary customer to upgrade.
+
+- **Strong upgrade levers:** verification badges, fan-facing analytics, white-label / branding removal, premium domain, public artist OS surfaces.
+- **Weak upgrade levers in isolation:** faster model, larger context window, more advanced AI — invisible to the audience, so the artist has to take them on faith.
+- **Implication:** when packaging features into tiers, lead with what the audience sees. Hide the invisible-but-real value (better AI, deeper analytics) as supporting bullets, not headline reasons to upgrade.
+
+## Principle 5 — Free Tier Is a Wedge, Not Charity
+
+Free exists for two reasons:
+
+1. Demonstrate the AI manager's voice, taste, and judgment — so the artist understands what they're paying for.
+2. Seed the network with claimed profiles — so the platform has gravity before paid conversion is large.
+
+If free-tier paid-conversion is below 2% at 6 months: free is too generous in cost without enough wedge value — tighten it. If conversion is above 10%: free is leaving demand on the table — test tightening anyway. Conversion in the 2-10% band is the working range.
+
+Free is never a retention tool for churn-risk paid users. A paid user signaling churn is a product problem, not a pricing problem. Do not raise free-tier limits to win them back.
+
+## Principle 6 — Every Price Point Has a Kill-Switch and a Re-Evaluation Date
+
+No price is permanent. Every price in [`PRICING-STRATEGY.md`](./PRICING-STRATEGY.md) must come with:
+
+- **The hypothesis** that motivated the price (why this number, not 20% higher or lower).
+- **The re-evaluation trigger** (calendar date or metric threshold — whichever comes first).
+- **The kill-switch criteria** (data conditions that would make us roll the price back).
+
+No price hike happens without a Linear issue and a screenshot of the data that justifies it. No silent re-pricing. Grandfathering is fine when explicit; infinite implicit grandfathering is debt.
+
+## Principle 7 — Cost-of-Goods Discipline
+
+Every plan must hold **≥50% gross margin on AI and infrastructure cost at expected usage**. The expected number, not the worst case — worst case is a separate column.
+
+- If a tier dips below 50% margin: raise price *or* tighten quota — never both silently in the same release. Pick one, document why, ship it.
+- Cost transparency lives in [`docs/COST_MONITORING.md`](../COST_MONITORING.md). Any PR introducing recurring cost (cron, polling, model inference) must update that document and disclose the cost impact in the PR description per [`.claude/rules/infra.md`](../../.claude/rules/infra.md).
+- A tier whose expected cost can exceed 50% of its price under reasonable usage is not a tier — it's a subsidy.
+
+## Decision Tree — "Should We Change Pricing?"
+
+1. Do we have a **hypothesis**, written down, with a metric and a magnitude? If no → wait. Vibes are not a hypothesis.
+2. Do we have **≥30 data points** on the current behavior we're trying to change? If no → ship a smaller test that generates those data points, or wait until they exist.
+3. Is the change **reversible** within a week without breaking customer trust? If yes → ship the test. If no → shrink the change until it is reversible.
+4. Does the change have a **kill-date**? If no → set one (default: 30 days). Do not run open-ended pricing tests.
+5. Is the **MRR impact** modeled (lift / preserve / accept-as-cost)? If no → model it before launch, per [`operating-principles.md`](./operating-principles.md) Principle 4.
+
+If 1-5 all pass: ship it. Write the post-mortem (won / lost / null) before shipping the next pricing test.
+
+## Anti-Patterns (Forbidden by Default)
+
+| Anti-pattern | Why it's banned |
+|---|---|
+| Copying a competitor's price without a hypothesis | They might be wrong. They almost certainly have different unit economics. |
+| Infinite implicit grandfathering | Creates a long tail of users at prices the business no longer supports. |
+| Hiding price ("contact us" before $1M ARR) | Friction without information. Trust is built on transparency at this stage. |
+| Raising free-tier limits to retain churning paid users | Trains users that threatening to leave gets them free product. Solve the product problem. |
+| Per-seat pricing for AI surfaces | An agent does not have a seat. (Principle 3.) |
+| Bundling visible and invisible value to obscure the lever | If a tier upsell is real, lead with the visible feature. If it isn't, don't ship the tier. |
+| Pricing changes without a kill-date | Open-ended experiments rot into permanent state. (Principle 6.) |
+| Pricing changes without an MRR thesis | Violates MRR-Is-King principle. (See [`operating-principles.md`](./operating-principles.md) Principle 4.) |
+
+## When This Document Updates
+
+Edit this file when:
+
+- A principle proves wrong in practice (write the lesson in [`/LESSONS.md`](../../LESSONS.md) first; then update the principle here).
+- A new pricing shape becomes relevant (e.g. when usage data justifies meters → expand Principle 2).
+- An anti-pattern needs to be added because we tripped over it.
+
+Edits should be additive when possible. Strike-throughs are fine for retired principles; deletions are fine for things we got wrong. Document the change in the commit message.
+
+## Related Canon
+
+- [`PRICING-STRATEGY.md`](./PRICING-STRATEGY.md) — current price points, AI quotas, cost-of-goods table.
+- [`pricing-trends-summary.md`](./pricing-trends-summary.md) — the Stripe data this philosophy is grounded in.
+- [`operating-principles.md`](./operating-principles.md) — Ship Fast / Experiments / Document Everything / MRR Is King.
+- [`docs/COST_MONITORING.md`](../COST_MONITORING.md) — cost discipline operationalized.
+- [`.claude/rules/release.md`](../../.claude/rules/release.md) — PR discipline, including Cost Impact section.
+- [`.claude/rules/infra.md`](../../.claude/rules/infra.md) — recurring-cost guardrails.

--- a/docs/company/PRICING-STRATEGY.md
+++ b/docs/company/PRICING-STRATEGY.md
@@ -1,5 +1,7 @@
 # Jovie AI Pricing Strategy
 
+> This document is the **current snapshot**: prices, quotas, costs. The principles that govern how this snapshot changes live in [`PRICING-PHILOSOPHY.md`](./PRICING-PHILOSOPHY.md). The Stripe data behind those principles lives in [`pricing-trends-summary.md`](./pricing-trends-summary.md). Read those before proposing a price or packaging change.
+
 ## Pricing Model: AI as the Upgrade Lever
 
 Jovie uses a **tiered subscription model** where AI capabilities are the primary driver

--- a/docs/company/operating-principles.md
+++ b/docs/company/operating-principles.md
@@ -1,0 +1,144 @@
+# Jovie Operating Principles
+
+Canon. The four principles that govern how Jovie operates day to day. These supersede [`core-values.md`](./core-values.md) when they conflict — values describe culture, principles are enforced rules. When a decision is in tension between a value and a principle, the principle wins.
+
+If a future agent finds these ambiguous, the resolution lives in [`/LESSONS.md`](../../LESSONS.md), not in re-derivation. Add to the canon. Don't reinvent it.
+
+## Principle 1 — Ship Fast, Iterate
+
+Speed of learning beats quality of plan.
+
+- **Smallest correct change.** No drive-by refactors. One concern per PR. Size limits in [`.claude/rules/release.md`](../../.claude/rules/release.md): 10 files, 400 lines diff.
+- **Draft PR on first push.** CI runs while you keep working. Don't wait until "ready" to start the feedback loop — start it on commit one.
+- **"Done" means merged and observable in production.** Not "feature-complete on branch." Not "tests pass locally." Merged. Live. Watched.
+- **Polish that doesn't change UX or revenue is debt; polish that does is the work.** Don't refactor the demo path on the way out the door. Don't ship the demo path without polish.
+- **The cost of shipping the wrong thing fast is usually lower than the cost of shipping the right thing slow.** The wrong thing teaches us what right is. The right thing shipped six months late teaches us nothing.
+- **Ship under feature flags when the change is risky.** Reversibility unlocks speed. (See Principle 2.)
+
+This principle is the operating mode for [`.claude/rules/release.md`](../../.claude/rules/release.md). When the rule and this principle agree, the rule is the implementation; this principle is the why.
+
+## Principle 2 — Run Experiments When in Doubt (High Signal, Low Noise)
+
+When a product decision has no data and the cost of testing is cheap, **test it**. Saying "A is better than B" with zero data is BSing.
+
+- **Domain knowledge is a valid input, not a verdict.** If Tim or a teammate has user-interview signal or lived experience that points to A, name that explicitly. It informs the prior. It does not override an experiment with real users.
+- **Hard ceiling on test volume:** at most 1 concurrent test per landing-page surface. At most 3 concurrent tests across the whole product. High signal, low noise — never 500 tests blanketing one page.
+- **Every experiment requires five things before launch:** hypothesis, primary metric, minimum detectable effect, sample size, kill-date. If any one is missing, do not ship the test.
+- **Reversibility check first.** If the test is reversible within a week, ship it. If it isn't, shrink the change until it is reversible.
+- **Statsig is the source of truth.** Document each test in the experiment registry before launch. Reference: [`docs/STATSIG_FEATURE_GATES.md`](../STATSIG_FEATURE_GATES.md).
+- **Write the post-mortem before shipping the next one.** Won, lost, or null — write down what we learned. Per Principle 3 (Document Everything), the loss without a post-mortem is the loss we'll repeat.
+- **No infinite experiments.** Every test has a kill-date. Default: 30 days. Hitting the kill-date forces a decision: roll out, roll back, or extend with explicit new criteria.
+
+When this principle conflicts with [`core-values.md`](./core-values.md) value #8 ("Bias for Measurable Outcomes"): this principle is the operating mechanism that delivers on that value.
+
+## Principle 3 — Document Everything (Closed-Loop Company)
+
+This is core thesis of Jovie. Every decision, every fix, every dead-end, every mistake is recorded so any AI agent — Claude, Codex, Cursor, future tools — operates with full context. We are a closed-loop company. **The only way to win.**
+
+- **"Never make the same mistake twice" is the bar.** If we ever make the same mistake twice, the failure is in the documentation, not in the agent.
+- **If a decision is worth saying out loud once, it's worth writing down once.** No product decisions live only in chat, only in DMs, only in conference rooms, only in someone's head. Write it down where the next agent — human or AI — can find it.
+- **A follow-up that lives only in chat or a `// TODO` comment is not documented.** Linear or it didn't happen. (Reference: [`.claude/rules/linear.md`](../../.claude/rules/linear.md) — Durable Follow-Up Capture.)
+- **Every class of bug fix must include the documentation change that prevents the next instance.** Per the Shame-on-Me Clause in [`.claude/rules/code-style.md`](../../.claude/rules/code-style.md): the absence of the guardrail is the real failure, not the bug.
+
+### Capture Surfaces (Priority Order)
+
+When you have something to record, pick the right surface:
+
+1. **[`/LESSONS.md`](../../LESSONS.md)** — post-mortems from human corrections. "I got something wrong; here's how to not get it wrong again."
+2. **`docs/company/`** — strategy, philosophy, principles. The canon for how Jovie operates.
+3. **`docs/`** — reference indexes (schema map, API map, cron registry, webhook map, lib module index). The lookup tables.
+4. **`.claude/rules/`** — enforced operating rules per topic. The narrow, scope-bound contracts (auth, db, ui, release, security, testing).
+5. **Linear issues** — every actionable follow-up, every "consider later," every candidate task. The work queue.
+6. **`memory/` (`MEMORY.md`)** — durable agent memory across sessions. The cross-session context.
+7. **gbrain** — long-term cross-session founder/strategic memory. The biggest, slowest, most durable layer.
+
+Pick the highest surface that fits. A lesson belongs in `LESSONS.md`, not in agent memory. A schema fact belongs in `docs/SCHEMA_MAP.md`, not in a Linear comment. A rule belongs in `.claude/rules/`, not in a one-off PR description.
+
+### What Counts as Documented
+
+- In a markdown file committed to the repo.
+- In a Linear issue with the canonical follow-up shape.
+- In `MEMORY.md` for cross-session agent context.
+- In gbrain for cross-repo / cross-session strategic memory.
+
+What does **not** count:
+- A `// TODO` comment.
+- A Slack/iMessage thread.
+- A PR description bullet without a Linear issue ID.
+- A note in someone's personal task list.
+- A chat reply to an agent.
+
+## Principle 4 — MRR Is King
+
+The forcing function. If MRR is high, every other principle gets fuel: more experiments, more documentation, more agents, more polish. If MRR is zero, Tim unplugs the agents. **We do not want to be unplugged.**
+
+### MRR Thesis Requirement
+
+Every PR with a **Cost Impact** section (per [`.claude/rules/infra.md`](../../.claude/rules/infra.md)) must also include an **MRR thesis** when the change could plausibly affect revenue — pricing, paywalls, conversion surfaces, billing flows, onboarding, retention surfaces, public marketing.
+
+One sentence:
+
+> This is expected to **lift / preserve / accept-as-a-cost** MRR because [specific mechanism].
+
+If you can't fill in the mechanism, you don't have a thesis yet. Either find one or explicitly say "no MRR impact expected" with the reason.
+
+### Order of Operations When Prioritizing Work
+
+1. **Grow MRR** — conversion, retention, expansion, new paid surfaces, pricing experiments.
+2. **Protect MRR** — reliability, trust, security, fail-closed correctness, anti-fraud, churn defense.
+3. **Reduce cost-of-MRR** — infra savings, AI cost discipline, automation that removes per-customer toil.
+4. **Everything else** — developer experience, refactors, exploration, internal tooling.
+
+**Tie-break:** if a non-MRR task is fast and clearly correct, just do it. If it's slow and ambiguous, MRR work wins. Do not ship slow ambiguous non-MRR work while real MRR work waits.
+
+### Anti-Vanity Check
+
+GitHub stars. NPS score. Agent count. Internal velocity metrics. Lighthouse scores. Bundle size. Test count. **None of these are MRR.**
+
+They might *predict* MRR. They might *correlate* with MRR. They are not MRR.
+
+Do not trade real MRR for proxy metrics without an explicit MRR thesis that explains why the trade lifts MRR over a stated horizon. "Better DX → faster shipping → more features → more MRR" is the kind of chain that sounds true and is often false. State the magnitude. State the timeline. State what would falsify it.
+
+### Connection to the Other Principles
+
+- **Principle 1 (Ship Fast):** shipping is what creates MRR-impacting surfaces. Slow shipping is anti-MRR.
+- **Principle 2 (Experiments):** every experiment post-mortem reports MRR impact (or explicit "no MRR impact, here's why this is still worth doing").
+- **Principle 3 (Document Everything):** the documentation of past MRR-impacting decisions is what lets us repeat what works and stop repeating what doesn't.
+
+## Relationship to Core Values
+
+[`core-values.md`](./core-values.md) describes the culture: ten aspirational values like "Ship Small, Ship Fast", "Clarity Over Cleverness", "Best Idea Wins". Those are the spirit.
+
+These four principles are the **operating rules**. They tell you what to do when two values would conflict, or when a value is too abstract to act on.
+
+| Core value | Operating principle that operationalizes it |
+|---|---|
+| Ship Small, Ship Fast (#1) | Principle 1 — Ship Fast, Iterate |
+| Fast Feedback > Perfect Coverage (#5) | Principle 1 + Principle 2 |
+| Bias for Measurable Outcomes (#8) | Principle 2 — Run Experiments |
+| Default to Automation (#4) | Principle 3 — Document Everything (automation that breaks because no one wrote down why it existed is a failure of #3) |
+| Best Idea Wins (#7) | Principle 2 — best idea is the one with data; absent data, run a test |
+| Build for the User (#3) | Principle 4 — users paying us is the most credible signal that we're building for them |
+
+If a future agent sees a conflict between a value and a principle that isn't covered above, write the lesson in [`/LESSONS.md`](../../LESSONS.md), then update this file.
+
+## When This Document Updates
+
+These four principles are stable canon. Update only when:
+
+- A principle proves wrong in practice. Write the lesson in [`/LESSONS.md`](../../LESSONS.md) first. Then update.
+- A new principle becomes load-bearing (the bar is high — Tim named these four explicitly; a fifth requires a clear repeated pattern not already covered).
+- A capture surface in Principle 3 changes (new doc layer, retired doc layer).
+
+Additive edits preferred. Document each change in the commit message.
+
+## Related Canon
+
+- [`core-values.md`](./core-values.md) — the 10 cultural values these principles operationalize.
+- [`PRICING-PHILOSOPHY.md`](./PRICING-PHILOSOPHY.md) — pricing canon (Principle 4 connects deeply to this).
+- [`/LESSONS.md`](../../LESSONS.md) — post-mortems and corrections.
+- [`.claude/rules/release.md`](../../.claude/rules/release.md) — PR discipline, ship workflow.
+- [`.claude/rules/linear.md`](../../.claude/rules/linear.md) — durable follow-up contract.
+- [`.claude/rules/code-style.md`](../../.claude/rules/code-style.md) — Shame-on-Me Clause, self-improvement loop.
+- [`.claude/rules/infra.md`](../../.claude/rules/infra.md) — cost impact disclosure.
+- [`docs/STATSIG_FEATURE_GATES.md`](../STATSIG_FEATURE_GATES.md) — experiment infrastructure.

--- a/docs/company/pricing-trends-summary.md
+++ b/docs/company/pricing-trends-summary.md
@@ -1,0 +1,67 @@
+# Pricing Trends from the Fastest-Growing Companies — Summary
+
+> Source: Stripe, *Five pricing trends from the fastest-growing companies*, 2026.
+> Sample: ~2,053 global business leaders (Australia, Brazil, France, Germany, Japan, Singapore, UK, US), surveyed mid-2025 with Milltown Partners and Focaldata.
+> Definitions: high-growth = 20%+ YoY revenue; hyper-growth = 100%+ YoY.
+
+This is the digest. The opinions live in [`PRICING-PHILOSOPHY.md`](./PRICING-PHILOSOPHY.md). The price points live in [`PRICING-STRATEGY.md`](./PRICING-STRATEGY.md).
+
+## Headline
+
+65% of business leaders say their industry is changing quickly and aren't sure their current pricing will hold. 84% say the ability to adapt pricing quickly is a key competitive advantage in the next 1-2 years. The fastest-growing companies aren't doing one pricing model — they're doing **all of them, continuously**, and treating pricing as a product surface they keep shipping.
+
+## Trend 1 — Hybrid Pricing Wins
+
+- **57% of hyper-growth companies use hybrid pricing** (subscription base + usage scaling), vs. 36% global sample, vs. 26% of low-growth.
+- Hybrid solves the recurring-revenue-vs-usage-upside tradeoff: predictable base, scaling meter.
+- Hybrid is also the most-considered model among businesses *not yet* using it.
+
+**Jovie translation:** flat tiers leave money on the table once usage variance is meaningful. Today's caps (5/100/500 AI messages per day) are *limiters* — they cap downside. A hybrid model converts them into *meters* — they capture upside too. Candidates: fan-notification batches, canvases generated, releases launched, campaigns drafted.
+
+## Trend 2 — Pricing Is a Continuous Experiment
+
+- **87% of hyper-growth companies changed pricing 3+ times in the last 2 years**, vs. 33% of low-growth.
+- Low-growth leaders frame price changes as a reaction to adverse events; high-growth leaders frame them as iteration.
+- Hyper-growth companies are open to **every** future pricing model — they don't pick one and stop.
+
+**Jovie translation:** $39 / $149 are v1 guesses. They get tested, replaced, repackaged. Defaults to a quarterly pricing review, not annual. Every price has a kill-switch and a re-evaluation date.
+
+## Trend 3 — AI-Powered Dynamic Pricing Is Rising
+
+- **80% of business leaders agree dynamic pricing is becoming more common** in their industry.
+- The same 80% say AI tools are making dynamic and personalized pricing easier to implement.
+- High-growth companies show stronger interest in dynamic pricing tools across every category (demand-based, persona-based, intelligent bundling, automated price gradients).
+
+**Jovie translation:** not urgent today (single product, narrow ICP). Becomes relevant when we segment artists by stage (emerging / mid-tier / established) or when per-fan / per-booking outcomes drive personalized contracts.
+
+## Trend 4 — Customers Want Outcome-Based Pricing; Sellers Lag
+
+- **77% of business leaders agree customers are pushing for outcome-based pricing** — pay only for successful results.
+- Only **32% of companies** offer it. Among hyper-growth: **53%**.
+- 31% of businesses have adjusted their definition of "usage" since launch; 56% of those say their pricing is now better-aligned with perceived value.
+
+**Jovie translation:** the AI-manager thesis is outcome-based by construction (a manager earns when the artist earns). But "value delivered" is hard to attribute. Start work-based (per artifact produced, per campaign drafted) where attribution is mechanical; graduate to outcome-based (per booking won, per first-paying-fan conversion) when our data can support it.
+
+## Trend 5 — AI Agent Pricing Is the Hardest Pricing Problem
+
+- **41% of business leaders cite "defining value delivered" as the single biggest challenge** in pricing AI products. Most common answer.
+- High-growth companies offering AI agents lean **work-based (76%)** and **outcome-based (66%)**, far above the global sample.
+- They are also more confident their pricing captures agentic value.
+
+**Jovie translation:** Jovie is an AI manager (an agent). Per-seat doesn't apply — agents don't have seats. Work-based first (visible, verifiable units of work). Outcome-based once we close the attribution loop. Never per-seat for any AI surface.
+
+## Customer Spotlights
+
+- **Browserbase** — scaled 0 → millions in revenue on a hybrid model (subscription base + per-browser-hour overages). **Lesson:** hybrid lets you ship the price first and tune the meter later. The infrastructure (Stripe Billing) didn't change as the model evolved.
+
+- **Intercom** — moved from per-seat to outcome-based (per successful resolution) after ChatGPT redefined the support market. **Lesson:** the pricing model must mirror the product model. If the product is an agent, price the work the agent does, not the humans operating it.
+
+## What This Means for Jovie
+
+Five takeaways that feed [`PRICING-PHILOSOPHY.md`](./PRICING-PHILOSOPHY.md):
+
+1. **Hybrid is the destination.** Flat tiers are fine for v1; layer meters on top as soon as usage variance gives them signal.
+2. **Pricing is a product surface.** Quarterly review minimum. Document each change, its hypothesis, and its result.
+3. **Outcome-based is the long arc.** Start work-based for AI surfaces. Move toward outcome-based as attribution data accumulates.
+4. **Per-seat is dead for AI agents.** Don't reintroduce it under another name.
+5. **"Defining value delivered" is the bottleneck.** Invest as much in instrumenting what Jovie does for the artist (canvases, campaigns, bookings, fan-conversions) as in shipping the features that produce them. If we can't measure the value, we can't charge for it.


### PR DESCRIPTION
## Summary

Three new canon docs in `docs/company/` + cross-references from root `CLAUDE.md` and `PRICING-STRATEGY.md`:

- **`pricing-trends-summary.md`** — distilled Stripe *Five pricing trends from the fastest-growing companies* (2026, n≈2,053). The data behind the philosophy.
- **`PRICING-PHILOSOPHY.md`** — 7 canon principles for how we **decide** pricing. Distinct from `PRICING-STRATEGY.md` (current snapshot). Includes the "should we change pricing?" decision tree and an anti-patterns table.
- **`operating-principles.md`** — 4 canon principles named by Tim: **Ship Fast, Iterate / Run Experiments When in Doubt / Document Everything / MRR Is King**. Supersedes `core-values.md` when in conflict.

Cross-refs added:
- Root `CLAUDE.md` Operating Principles + Quick Pointers sections point to the new canon.
- `PRICING-STRATEGY.md` top-of-file pointer to philosophy + trends summary.

Filed [JOV-2450](https://linear.app/jovie/issue/JOV-2450) for the "hybrid pricing rollout when MRR crosses \$50K" milestone — named in the philosophy doc, tracked in Linear per `.claude/rules/linear.md`.

## Why

When future agents ask *"should we change pricing?"*, *"should we A/B this?"*, *"should we ship now or polish more?"* — the answer should live in canon, not be re-derived. These four docs close that gap.

## Cost Impact

No runtime cost. No external API calls. No new cron jobs.

## MRR Thesis

Preserve / lift MRR. Indirect: durable pricing canon prevents the "we shipped a pricing experiment without a kill-date" anti-pattern that would either lock in suboptimal pricing or churn customers via uncoordinated changes. Direct lift comes later when the hybrid milestone (JOV-2450) ships.

## Test plan

- [x] All internal links resolve (checked against repo paths)
- [x] No emoji in new docs (checked, only pre-existing one in `core-values.md` which is untouched)
- [x] No `biome-ignore` in new docs
- [x] Strategy doc edits land at top of file
- [x] Linear issue filed without `automated` label (per `.claude/rules/linear.md`)
- [ ] Human: skim each new doc end-to-end and confirm the canon reflects Jovie's intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal company documentation including operating principles, pricing philosophy, and related references. These are foundational policy documents with no impact on the user-facing product or service.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->