### PR TITLE
refactor(shell): isolate admin agent run detail data

### DIFF
--- a/apps/web/app/app/(shell)/admin/agent-runs/[id]/agent-run-data.ts
+++ b/apps/web/app/app/(shell)/admin/agent-runs/[id]/agent-run-data.ts
@@ -1,0 +1,19 @@
+import 'server-only';
+
+import { eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { agentRuns } from '@/lib/db/schema/connectors';
+
+export type AdminAgentRun = NonNullable<
+  Awaited<ReturnType<typeof loadAdminAgentRun>>
+>;
+
+export async function loadAdminAgentRun(id: string) {
+  const [run] = await db
+    .select()
+    .from(agentRuns)
+    .where(eq(agentRuns.id, id))
+    .limit(1);
+
+  return run ?? null;
+}

--- a/apps/web/app/app/(shell)/admin/agent-runs/[id]/page.tsx
+++ b/apps/web/app/app/(shell)/admin/agent-runs/[id]/page.tsx
@@ -1,4 +1,3 @@
-import { eq } from 'drizzle-orm';
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
@@ -7,9 +6,8 @@ import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeade
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { APP_ROUTES } from '@/constants/routes';
 import { formatUsd } from '@/lib/admin/format';
-import { db } from '@/lib/db';
-import { agentRuns } from '@/lib/db/schema/connectors';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import { loadAdminAgentRun } from './agent-run-data';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -49,12 +47,7 @@ export default async function AgentRunDebugPage({
   }
 
   const { id } = await params;
-
-  const [run] = await db
-    .select()
-    .from(agentRuns)
-    .where(eq(agentRuns.id, id))
-    .limit(1);
+  const run = await loadAdminAgentRun(id);
 
   if (!run) {
     notFound();

--- a/apps/web/tests/unit/app/admin-agent-run-detail-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/admin-agent-run-detail-shell-normalization.test.ts
@@ -12,6 +12,10 @@ const AGENT_RUN_DETAIL_ROUTE = join(
   TEST_DIR,
   '../../../app/app/(shell)/admin/agent-runs/[id]/page.tsx'
 );
+const AGENT_RUN_DETAIL_DATA = join(
+  TEST_DIR,
+  '../../../app/app/(shell)/admin/agent-runs/[id]/agent-run-data.ts'
+);
 
 describe('admin agent run detail shell normalization', () => {
   it('keeps the run detail route inside the shared admin shell', () => {
@@ -42,5 +46,17 @@ describe('admin agent run detail shell normalization', () => {
       /bg-white\/\[|divide-white\/\[|border-white\/\[/
     );
     expect(source).not.toContain('border-subtle bg-surface-1 p-4');
+  });
+
+  it('keeps agent run route data outside the page module', () => {
+    const pageSource = readFileSync(AGENT_RUN_DETAIL_ROUTE, 'utf8');
+    const dataSource = readFileSync(AGENT_RUN_DETAIL_DATA, 'utf8');
+
+    expect(dataSource.startsWith("import 'server-only';")).toBe(true);
+    expect(pageSource).toContain('loadAdminAgentRun');
+    expect(pageSource).not.toContain("from '@/lib/db'");
+    expect(pageSource).not.toContain("from '@/lib/db/schema/connectors'");
+    expect(pageSource).not.toContain("from 'drizzle-orm'");
+    expect(pageSource).not.toContain('agentRuns');
   });
 });


### PR DESCRIPTION
## Summary

- Move admin agent run detail DB loading into a server-only `loadAdminAgentRun()` loader.
- Keep `admin/agent-runs/[id]/page.tsx` focused on route handling, not Drizzle/schema imports.
- Extend the existing route normalization guard to enforce the page/loader boundary.

## Verification

- `pnpm biome check 'apps/web/app/app/(shell)/admin/agent-runs/[id]/page.tsx' 'apps/web/app/app/(shell)/admin/agent-runs/[id]/agent-run-data.ts' apps/web/tests/unit/app/admin-agent-run-detail-shell-normalization.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/admin-agent-run-detail-shell-normalization.test.ts` -- 3 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hook: proxy guard, Biome, ESLint, affected web typecheck
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2451-agent-run-detail-data",
  "source": "github",
  "sourceRunId": "e65d3f25113e4cb0a31bd6994ef260f7eb042fbc",
  "kind": "workflow",
  "status": "done",
  "title": "Isolate admin agent run detail route data",
  "summary": "Admin agent run detail now delegates direct DB lookup to a server-only loader while preserving the existing detail UI and route behavior.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2451",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2451/isolate-admin-agent-run-detail-route-data",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9208",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused admin agent run route-loader guard, web typecheck, Biome, diff-check, commit hook, and pre-push verification passed.",
      "checkedAt": "2026-05-18T20:05:00.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for route/data ownership only: page no longer imports Drizzle, db, or agentRuns schema and visible UI remains unchanged.",
      "checkedAt": "2026-05-18T20:05:00.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch pushed with conventional commit and PR artifact prepared.",
      "checkedAt": "2026-05-18T20:05:00.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T20:05:00.000Z",
  "updatedAt": "2026-05-18T20:05:00.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/admin/agent-runs/[id]"]
  }
}
-->
