### PR TITLE
ci(auth): retry staging auth canary smoke

### DIFF
--- a/.github/workflows/canary-health-gate.yml
+++ b/.github/workflows/canary-health-gate.yml
@@ -537,7 +537,20 @@ jobs:
           cd apps/web
           mkdir -p tests/.auth
           echo '{"cookies":[],"origins":[]}' > tests/.auth/user.json
-          CI=true SMOKE_ONLY=1 BASE_URL="${DEPLOYMENT_URL}" pnpm exec playwright test tests/e2e/auth-public-ready.spec.ts --project=chromium --reporter=line
+          auth_smoke_attempt=1
+          auth_smoke_max_attempts=3
+
+          until CI=true SMOKE_ONLY=1 BASE_URL="${DEPLOYMENT_URL}" pnpm exec playwright test tests/e2e/auth-public-ready.spec.ts --project=chromium --reporter=line; do
+            if [ "$auth_smoke_attempt" -ge "$auth_smoke_max_attempts" ]; then
+              echo "❌ Public auth controls failed after ${auth_smoke_max_attempts} attempts."
+              exit 1
+            fi
+
+            sleep_seconds=$((auth_smoke_attempt * 30))
+            echo "⚠ Public auth controls were not interactive on attempt ${auth_smoke_attempt}/${auth_smoke_max_attempts}. Retrying in ${sleep_seconds}s..."
+            sleep "$sleep_seconds"
+            auth_smoke_attempt=$((auth_smoke_attempt + 1))
+          done
         env:
           DEPLOYMENT_URL: ${{ steps.canary-check.outputs.verified_deployment_url || inputs.deployment_url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -312,6 +312,17 @@ describe('canary health gate workflow', () => {
     expect(authSmokeStep).toContain(
       'DEPLOYMENT_URL: ${{ steps.canary-check.outputs.verified_deployment_url || inputs.deployment_url }}'
     );
+    expect(authSmokeStep).toContain('auth_smoke_attempt=1');
+    expect(authSmokeStep).toContain('auth_smoke_max_attempts=3');
+    expect(authSmokeStep).toContain(
+      'until CI=true SMOKE_ONLY=1 BASE_URL="${DEPLOYMENT_URL}" pnpm exec playwright test tests/e2e/auth-public-ready.spec.ts --project=chromium --reporter=line; do'
+    );
+    expect(authSmokeStep).toContain(
+      'Public auth controls failed after ${auth_smoke_max_attempts} attempts.'
+    );
+    expect(authSmokeStep).toContain(
+      'sleep_seconds=$((auth_smoke_attempt * 30))'
+    );
 
     expect(canaryCurlProbes.length).toBeGreaterThanOrEqual(9);
     for (const probe of canaryCurlProbes) {


### PR DESCRIPTION
## Summary
- retry the staging public-auth Playwright smoke up to 3 times after build-info verifies the public alias is serving the target commit
- keep the auth readiness assertion fail-closed; persistent unclickable auth still blocks production promotion
- add workflow-unit coverage for the bounded retry behavior

## Verification
- `pnpm biome check .github/workflows/canary-health-gate.yml apps/web/tests/unit/ci/deploy-workflow.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts`
- `pnpm exec actionlint .github/workflows/canary-health-gate.yml`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`
- live staging smoke passed manually on landed build `9d4ef7b`: `CI=true SMOKE_ONLY=1 BASE_URL=https://staging.jov.ie pnpm --filter @jovie/web exec playwright test tests/e2e/auth-public-ready.spec.ts --project=chromium --reporter=line`

Linear: JOV-2437


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to include retry mechanism for authentication verification tests with configurable attempt limits and backoff delays.

* **Tests**
  * Extended test assertions to verify retry configuration parameters and execution logic in canary health gate workflow validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->