### PR TITLE
refactor(shell): centralize audience user fallback

### DIFF
--- a/apps/web/app/app/(shell)/app-shell-route-context.test.tsx
+++ b/apps/web/app/app/(shell)/app-shell-route-context.test.tsx
@@ -54,6 +54,7 @@ vi.mock('./dashboard/actions', () => ({
 import {
   loadAppShellRouteContext,
   loadAuthenticatedAppShellUserId,
+  requireAppShellDashboardUserId,
 } from './app-shell-route-context';
 
 function shellData(
@@ -61,12 +62,14 @@ function shellData(
     readonly dashboardLoadError: unknown;
     readonly needsOnboarding: boolean;
     readonly selectedProfile: { readonly id: string } | null;
+    readonly user: { readonly id: string } | null;
   }> = {}
 ): DashboardData {
   return {
     dashboardLoadError: undefined,
     needsOnboarding: false,
     selectedProfile: { id: 'profile_1' },
+    user: { id: 'dashboard_user_1' },
     ...overrides,
   } as unknown as DashboardData;
 }
@@ -110,6 +113,40 @@ describe('loadAppShellRouteContext', () => {
     ).resolves.toBe('user_early');
 
     expect(getDashboardShellDataMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the dashboard database user id from shared route context', () => {
+    const dashboardData = shellData({
+      user: { id: 'dashboard_user_2' },
+    });
+
+    expect(
+      requireAppShellDashboardUserId(
+        {
+          ok: true,
+          userId: 'clerk_user_1',
+          dashboardData,
+          profileId: 'profile_1',
+        },
+        '/app/audience'
+      )
+    ).toBe('dashboard_user_2');
+  });
+
+  it('centralizes missing dashboard user signin redirects', () => {
+    const dashboardData = shellData({ user: null });
+
+    expect(() =>
+      requireAppShellDashboardUserId(
+        {
+          ok: true,
+          userId: 'clerk_user_1',
+          dashboardData,
+          profileId: 'profile_1',
+        },
+        '/app/audience'
+      )
+    ).toThrow('NEXT_REDIRECT:/signin?redirect_url=%2Fapp%2Faudience');
   });
 
   it('preserves route search params in shared signin redirects', async () => {

--- a/apps/web/app/app/(shell)/app-shell-route-context.tsx
+++ b/apps/web/app/app/(shell)/app-shell-route-context.tsx
@@ -42,6 +42,18 @@ export type AppShellRouteContextResult =
   | AppShellRouteContext
   | AppShellRouteError;
 
+export function requireAppShellDashboardUserId(
+  context: AppShellRouteContext,
+  route: string
+): string {
+  const dashboardUserId = context.dashboardData.user?.id;
+  if (!dashboardUserId) {
+    redirect(buildAppShellSignInUrl(route));
+  }
+
+  return dashboardUserId;
+}
+
 export async function loadAuthenticatedAppShellUserId({
   route,
   authFailure = 'redirect',

--- a/apps/web/app/app/(shell)/audience/page.tsx
+++ b/apps/web/app/app/(shell)/audience/page.tsx
@@ -1,4 +1,3 @@
-import { redirect } from 'next/navigation';
 import type { SearchParams } from 'nuqs/server';
 import { Suspense } from 'react';
 import { BASE_URL } from '@/constants/app';
@@ -7,7 +6,6 @@ import { DashboardAudienceClient } from '@/features/dashboard/organisms/Dashboar
 import { AudienceTableLoadingShell } from '@/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell';
 import type { AudienceSegment } from '@/features/dashboard/organisms/dashboard-audience-table/types';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
-import { buildAppShellSignInUrl } from '@/lib/auth/build-app-shell-signin-url';
 import { captureError } from '@/lib/error-tracking';
 import { audienceFilters, audienceSearchParams } from '@/lib/nuqs';
 import { throwIfRedirect } from '@/lib/utils/redirect-error';
@@ -19,6 +17,7 @@ import { convertDrizzleCreatorProfileToArtist } from '@/types/db';
 import {
   loadAppShellRouteContext,
   loadAuthenticatedAppShellUserId,
+  requireAppShellDashboardUserId,
 } from '../app-shell-route-context';
 import { getAudienceServerData } from '../dashboard/audience/audience-data';
 import { loadUpcomingTourDates } from '../dashboard/tour-dates/actions';
@@ -68,9 +67,10 @@ async function AudienceContent({
     }
 
     const { dashboardData } = routeContext;
-    if (!dashboardData.user?.id) {
-      redirect(buildAppShellSignInUrl(APP_ROUTES.AUDIENCE));
-    }
+    const dashboardUserId = requireAppShellDashboardUserId(
+      routeContext,
+      APP_ROUTES.AUDIENCE
+    );
 
     const artist = dashboardData.selectedProfile
       ? convertDrizzleCreatorProfileToArtist(dashboardData.selectedProfile)
@@ -89,7 +89,7 @@ async function AudienceContent({
 
     const [audienceData, tourDates] = await Promise.all([
       getAudienceServerData({
-        userId: dashboardData.user.id,
+        userId: dashboardUserId,
         selectedProfileId: artist?.id ?? null,
         searchParams: {
           page: String(parsedParams.page),

--- a/apps/web/tests/unit/app/audience-page.test.tsx
+++ b/apps/web/tests/unit/app/audience-page.test.tsx
@@ -11,7 +11,9 @@ describe('audience app shell route', () => {
 
     expect(source).toContain('loadAppShellRouteContext');
     expect(source).toContain('loadAuthenticatedAppShellUserId');
+    expect(source).toContain('requireAppShellDashboardUserId');
     expect(source).toContain('authenticatedUserId: userId');
+    expect(source).not.toContain('buildAppShellSignInUrl');
     expect(source).not.toContain('getCachedAuth');
     expect(source).not.toContain('getDashboardShellData');
     expect(source).not.toContain('dashboardLoadError');


### PR DESCRIPTION
## Summary

- Add `requireAppShellDashboardUserId()` to the shared app-shell route context.
- Move `/app/audience` missing-dashboard-user sign-in fallback out of the page module.
- Extend route-context and audience source-guard coverage for the shared fallback path.

## Verification

- `pnpm biome check 'apps/web/app/app/(shell)/audience/page.tsx' 'apps/web/app/app/(shell)/app-shell-route-context.tsx' 'apps/web/app/app/(shell)/app-shell-route-context.test.tsx' apps/web/tests/unit/app/audience-page.test.tsx`
- `pnpm --filter @jovie/web exec vitest run 'app/app/(shell)/app-shell-route-context.test.tsx' tests/unit/app/audience-page.test.tsx` -- 13 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hook: proxy guard, Biome, ESLint, affected web typecheck
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2453-audience-route-context-user",
  "source": "github",
  "sourceRunId": "18210ad716ee4fa9394dff0492986b80555b9042",
  "kind": "workflow",
  "status": "done",
  "title": "Centralize audience dashboard-user fallback in shell route context",
  "summary": "Audience now uses a shared route-context helper for missing dashboard-user sign-in fallback instead of constructing auth redirect URLs in the page module.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2453",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2453/centralize-audience-dashboard-user-fallback-in-shell-route-context",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9225",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused route-context helper tests, audience source guard, web typecheck, Biome, diff-check, commit hook, and pre-push verification passed.",
      "checkedAt": "2026-05-18T20:42:00.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for route/auth fallback ownership only: audience no longer imports buildAppShellSignInUrl and visible UI remains unchanged.",
      "checkedAt": "2026-05-18T20:42:00.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch pushed with conventional commit and PR artifact prepared.",
      "checkedAt": "2026-05-18T20:42:00.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T20:42:00.000Z",
  "updatedAt": "2026-05-18T20:42:00.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/audience"]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Extracted authentication validation logic into a reusable helper function.
  * Updated audience page to use centralized authentication handler.

* **Tests**
  * Added tests for the new authentication helper function.
  * Updated audience page tests to verify implementation changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->