### PR TITLE
refactor(shell): isolate release task route data

### DIFF
--- a/apps/web/app/app/(shell)/releases/[releaseId]/tasks/ReleaseTasksRoute.tsx
+++ b/apps/web/app/app/(shell)/releases/[releaseId]/tasks/ReleaseTasksRoute.tsx
@@ -1,4 +1,3 @@
-import { and, eq } from 'drizzle-orm';
 import { notFound, redirect } from 'next/navigation';
 import { Suspense } from 'react';
 import { loadAppShellRouteContext } from '@/app/app/(shell)/app-shell-route-context';
@@ -8,9 +7,8 @@ import {
 } from '@/components/features/dashboard/release-tasks';
 import { ReleasePlanUpgradeInterstitial } from '@/components/features/dashboard/tasks/TasksUpgradeInterstitial';
 import { APP_ROUTES, buildReleaseTasksRoute } from '@/constants/routes';
-import { db } from '@/lib/db';
-import { discogReleases } from '@/lib/db/schema/content';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import { loadReleaseTaskRouteRelease } from './release-tasks-data';
 
 interface ReleaseTasksRouteProps {
   readonly params: Promise<{ releaseId: string }>;
@@ -50,19 +48,7 @@ async function ReleaseTasksContent({
     redirect(APP_ROUTES.START);
   }
 
-  const [release] = await db
-    .select({
-      title: discogReleases.title,
-      releaseDate: discogReleases.releaseDate,
-    })
-    .from(discogReleases)
-    .where(
-      and(
-        eq(discogReleases.id, releaseId),
-        eq(discogReleases.creatorProfileId, profileId)
-      )
-    )
-    .limit(1);
+  const release = await loadReleaseTaskRouteRelease({ releaseId, profileId });
 
   if (!release) {
     notFound();

--- a/apps/web/app/app/(shell)/releases/[releaseId]/tasks/release-tasks-data.ts
+++ b/apps/web/app/app/(shell)/releases/[releaseId]/tasks/release-tasks-data.ts
@@ -1,0 +1,35 @@
+import 'server-only';
+
+import { and, eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { discogReleases } from '@/lib/db/schema/content';
+
+interface LoadReleaseTaskRouteReleaseOptions {
+  readonly releaseId: string;
+  readonly profileId: string;
+}
+
+export type ReleaseTaskRouteRelease = NonNullable<
+  Awaited<ReturnType<typeof loadReleaseTaskRouteRelease>>
+>;
+
+export async function loadReleaseTaskRouteRelease({
+  releaseId,
+  profileId,
+}: LoadReleaseTaskRouteReleaseOptions) {
+  const [release] = await db
+    .select({
+      title: discogReleases.title,
+      releaseDate: discogReleases.releaseDate,
+    })
+    .from(discogReleases)
+    .where(
+      and(
+        eq(discogReleases.id, releaseId),
+        eq(discogReleases.creatorProfileId, profileId)
+      )
+    )
+    .limit(1);
+
+  return release ?? null;
+}

--- a/apps/web/tests/unit/app/release-tasks-page.test.tsx
+++ b/apps/web/tests/unit/app/release-tasks-page.test.tsx
@@ -30,6 +30,8 @@ vi.mock('next/navigation', () => ({
   redirect: mockRedirect,
 }));
 
+vi.mock('server-only', () => ({}));
+
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => args),
   eq: vi.fn((...args: unknown[]) => args),
@@ -186,8 +188,13 @@ describe('release tasks page', () => {
 
     expect(source).toContain('loadAppShellRouteContext');
     expect(source).toContain('buildReleaseTasksRoute');
+    expect(source).toContain('loadReleaseTaskRouteRelease');
     expect(source).not.toContain('getCurrentUserProfile');
     expect(source).not.toContain('getDashboardShellData');
     expect(source).not.toContain('getDashboardDataEssential');
+    expect(source).not.toContain('drizzle-orm');
+    expect(source).not.toContain('@/lib/db');
+    expect(source).not.toContain('@/lib/db/schema/content');
+    expect(source).not.toContain('discogReleases');
   });
 });


### PR DESCRIPTION
## Summary

- Move the release task route release lookup into a server-only `loadReleaseTaskRouteRelease()` helper.
- Keep `ReleaseTasksRoute.tsx` focused on shell route context, profile redirect, entitlement branching, and rendering.
- Extend release-task source-guard coverage so Drizzle/DB/schema imports stay out of the route component.

## Verification

- `pnpm biome check 'apps/web/app/app/(shell)/releases/[releaseId]/tasks/ReleaseTasksRoute.tsx' 'apps/web/app/app/(shell)/releases/[releaseId]/tasks/release-tasks-data.ts' apps/web/tests/unit/app/release-tasks-page.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/release-tasks-page.test.tsx` -- 4 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hook: proxy guard, Biome, ESLint, affected web typecheck
- pre-push hook: `biome check .`, web pre-push proxy guard, tailwind guard, typecheck, lint

<!-- agent-run-artifact
{
  "id": "jov-2465-release-task-route-data",
  "source": "github",
  "sourceRunId": "a566b83d104a82ca28245793773a4c193a0f0202",
  "kind": "workflow",
  "status": "done",
  "title": "Isolate release task route data lookup",
  "summary": "The canonical release task route now delegates release lookup to a server-only route-data helper while preserving not-found, upgrade, title/date, and metadata-agent behavior.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2465",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2465/isolate-release-task-route-data-lookup",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9227",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused release-task route behavior/source guard, web typecheck, Biome, diff-check, commit hook, and pre-push verification passed.",
      "checkedAt": "2026-05-18T20:51:00.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff reviewed for route/data ownership only: ReleaseTasksRoute no longer imports Drizzle, db, or content schema and visible UI remains unchanged.",
      "checkedAt": "2026-05-18T20:51:00.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Branch pushed with conventional commit and PR artifact prepared.",
      "checkedAt": "2026-05-18T20:51:00.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-05-18T20:51:00.000Z",
  "updatedAt": "2026-05-18T20:51:00.000Z",
  "metadata": {
    "visualChange": false,
    "routes": ["/app/releases/[releaseId]/tasks"]
  }
}
-->
