### PR TITLE
fix(shell): add canonical route boundary guard

### DIFF
--- a/apps/web/tests/unit/app/shell-route-boundary-guard.test.ts
+++ b/apps/web/tests/unit/app/shell-route-boundary-guard.test.ts
@@ -1,0 +1,68 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const TEST_DIR = dirname(
+  import.meta.url.startsWith('file:')
+    ? fileURLToPath(import.meta.url)
+    : import.meta.url
+);
+
+const SHELL_APP_ROOT = resolve(TEST_DIR, '../../../app/app/(shell)');
+
+const FORBIDDEN_IMPORT_PATTERNS = [
+  {
+    label: 'getDashboardDataEssential',
+    pattern: /\bgetDashboardDataEssential\b/,
+  },
+  {
+    label: 'getDashboardShellData',
+    pattern: /\bgetDashboardShellData\b/,
+  },
+  {
+    label: '@/lib/db',
+    pattern: /from\s+['"]@\/lib\/db['"]/,
+  },
+  {
+    label: '@/lib/db/schema',
+    pattern: /from\s+['"]@\/lib\/db\/schema(?:\/[^'"]+)?['"]/,
+  },
+  {
+    label: 'drizzle-orm',
+    pattern: /from\s+['"]drizzle-orm(?:\/[^'"]+)?['"]/,
+  },
+] as const;
+
+function collectPageFiles(directory: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(directory)) {
+    const filePath = join(directory, entry);
+    const stats = statSync(filePath);
+    if (stats.isDirectory()) {
+      files.push(...collectPageFiles(filePath));
+      continue;
+    }
+
+    if (entry === 'page.tsx') {
+      files.push(filePath);
+    }
+  }
+
+  return files;
+}
+
+describe('canonical shell route boundary guard', () => {
+  it('keeps shell page entrypoints free of low-level bootstrap and db imports', () => {
+    const pageFiles = collectPageFiles(SHELL_APP_ROOT);
+    const offenders = pageFiles.flatMap(filePath => {
+      const source = readFileSync(filePath, 'utf8');
+      const matches = FORBIDDEN_IMPORT_PATTERNS.filter(pattern =>
+        pattern.pattern.test(source)
+      ).map(pattern => `${filePath}: ${pattern.label}`);
+      return matches;
+    });
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a focused unit guard that scans shell page entrypoints for direct imports of low-level bootstrap/data helpers.
- Keeps the forbidden set limited to the app-wide helpers that should stay behind route data helpers or layout adapters.

## Verification
- `pnpm --dir apps/web exec vitest run --config=vitest.config.mts tests/unit/app/shell-route-boundary-guard.test.ts`
- Commit and push hooks passed on this branch: `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation tests to enforce code organization standards and prevent forbidden imports in specific modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->