### PR TITLE
fix(admin): unify growth leads table chrome

### DIFF
--- a/apps/web/components/features/admin/leads/LeadTable.tsx
+++ b/apps/web/components/features/admin/leads/LeadTable.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { Badge } from '@jovie/ui';
+import { Badge, Button } from '@jovie/ui';
 import { useQueryClient } from '@tanstack/react-query';
 import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { AlertTriangle, Check, ExternalLink, Loader2, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { HeaderSearchAction } from '@/components/molecules/HeaderSearchAction';
 import {
   createMultiFieldFilterFn,
@@ -16,6 +17,7 @@ import {
 import { APP_ROUTES } from '@/constants/routes';
 import { AdminDataTable } from '@/features/admin/table/AdminDataTable';
 import { useSearchUrlSync } from '@/hooks/useSearchUrlSync';
+import { SKELETON_ROW_COUNT, TABLE_ROW_HEIGHTS } from '@/lib/constants/layout';
 import {
   type AdminLead,
   type AdminLeadsSortBy,
@@ -265,6 +267,7 @@ export function LeadTable({
     hasNextPage,
     isFetchingNextPage,
     fetchNextPage,
+    refetch,
   } = useLeadsInfiniteQuery({
     sortBy,
     status: statusFilter || undefined,
@@ -345,9 +348,19 @@ export function LeadTable({
     fetchNextPage().catch(() => {}); // NOSONAR — fire-and-forget, errors handled by React Query
   }, [fetchNextPage]);
 
+  const handleRetry = useCallback(() => {
+    refetch().catch(() => {});
+  }, [refetch]);
+
+  const getRowClassName = useCallback(
+    () => 'group bg-transparent hover:bg-(--linear-row-hover)',
+    []
+  );
+
   return (
-    <section className='flex flex-col'>
+    <ContentSurfaceCard surface='table' className='overflow-hidden'>
       <PageToolbar
+        className='border-b border-subtle'
         start={STATUS_OPTIONS.map(opt => {
           const count =
             funnelCounts && opt.value ? funnelCounts[opt.value] : undefined;
@@ -376,7 +389,17 @@ export function LeadTable({
       {isError && leads.length > 0 && (
         <div className='flex items-center gap-2 border-b border-subtle bg-warning/5 px-4 py-2 text-app text-warning'>
           <AlertTriangle className='h-3.5 w-3.5 shrink-0' />
-          Unable to refresh leads. Showing cached data.
+          <span className='min-w-0 flex-1'>
+            Unable to refresh leads. Showing cached data.
+          </span>
+          <Button
+            type='button'
+            variant='secondary'
+            size='sm'
+            onClick={handleRetry}
+          >
+            Retry
+          </Button>
         </div>
       )}
       <AdminDataTable
@@ -388,6 +411,9 @@ export function LeadTable({
         enableFiltering
         globalFilterFn={leadFilterFn}
         getRowId={row => row.id}
+        getRowClassName={getRowClassName}
+        rowHeight={TABLE_ROW_HEIGHTS.STANDARD}
+        skeletonRows={SKELETON_ROW_COUNT.TABLE}
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}
         onLoadMore={handleLoadMore}
@@ -396,6 +422,17 @@ export function LeadTable({
             <TableEmptyState
               title='Unable to load leads'
               description='Try again in a moment.'
+              icon={<AlertTriangle className='h-4 w-4' />}
+              action={
+                <Button
+                  type='button'
+                  variant='secondary'
+                  size='sm'
+                  onClick={handleRetry}
+                >
+                  Retry
+                </Button>
+              }
             />
           ) : (
             <TableEmptyState
@@ -405,6 +442,6 @@ export function LeadTable({
           )
         }
       />
-    </section>
+    </ContentSurfaceCard>
   );
 }

--- a/apps/web/tests/unit/admin/LeadTable.test.tsx
+++ b/apps/web/tests/unit/admin/LeadTable.test.tsx
@@ -109,6 +109,7 @@ describe('LeadTable', () => {
       hasNextPage: false,
       isFetchingNextPage: false,
       fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
     });
 
     const LeadTable = await getLeadTable();
@@ -128,6 +129,7 @@ describe('LeadTable', () => {
       hasNextPage: false,
       isFetchingNextPage: false,
       fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
     });
 
     const LeadTable = await getLeadTable();
@@ -146,6 +148,7 @@ describe('LeadTable', () => {
       hasNextPage: false,
       isFetchingNextPage: false,
       fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
     });
 
     const LeadTable = await getLeadTable();
@@ -158,6 +161,10 @@ describe('LeadTable', () => {
     expect(screen.getByText('Spotify')).toBeInTheDocument();
     expect(screen.getByText('Paid')).toBeInTheDocument();
     expect(screen.getByText('DistroKid')).toBeInTheDocument();
+
+    const row = document.querySelector('tbody tr');
+    expect(row).toHaveClass('group');
+    expect(row).toHaveClass('hover:bg-(--linear-row-hover)');
   });
 
   it('renders status filter tabs', async () => {
@@ -167,6 +174,7 @@ describe('LeadTable', () => {
       hasNextPage: false,
       isFetchingNextPage: false,
       fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
     });
 
     const LeadTable = await getLeadTable();
@@ -186,6 +194,7 @@ describe('LeadTable', () => {
       hasNextPage: false,
       isFetchingNextPage: false,
       fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
     });
 
     const LeadTable = await getLeadTable();
@@ -210,6 +219,7 @@ describe('LeadTable', () => {
       hasNextPage: false,
       isFetchingNextPage: false,
       fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
     });
 
     const LeadTable = await getLeadTable();
@@ -227,6 +237,7 @@ describe('LeadTable', () => {
       hasNextPage: false,
       isFetchingNextPage: false,
       fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
     });
 
     const LeadTable = await getLeadTable();
@@ -251,6 +262,7 @@ describe('LeadTable', () => {
       hasNextPage: false,
       isFetchingNextPage: false,
       fetchNextPage: vi.fn(),
+      refetch: vi.fn(),
     });
 
     const LeadTable = await getLeadTable();
@@ -260,5 +272,29 @@ describe('LeadTable', () => {
     expect(screen.getByText('IG')).toBeInTheDocument();
     expect(screen.queryByText('Paid')).not.toBeInTheDocument();
     expect(screen.queryByText('Email')).not.toBeInTheDocument();
+  });
+
+  it('renders a retryable error state when the lead query fails', async () => {
+    const refetch = vi.fn().mockResolvedValue(undefined);
+    mockLeadsInfiniteQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      refetch,
+    });
+
+    const LeadTable = await getLeadTable();
+    renderWithProviders(<LeadTable />);
+
+    expect(screen.getByText('Unable to load leads')).toBeInTheDocument();
+    const retryButton = screen.getByRole('button', { name: 'Retry' });
+    expect(retryButton).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(retryButton);
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Wrapped the growth leads table in the shared content surface chrome.
- Aligned lead rows to the canonical 40px row height and hover token.
- Added retryable empty/error handling for lead query failures.

## Files
- /Users/timwhite/.codex/worktrees/3880/jovie-v1-jov-2470/apps/web/components/features/admin/leads/LeadTable.tsx
- /Users/timwhite/.codex/worktrees/3880/jovie-v1-jov-2470/apps/web/tests/unit/admin/LeadTable.test.tsx

## Verification
- pnpm run test:web -- tests/unit/admin/LeadTable.test.tsx
- pnpm --filter @jovie/web exec biome check components/features/admin/leads/LeadTable.tsx tests/unit/admin/LeadTable.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check origin/main...HEAD
- local browser visual QA: /app/admin/growth?view=leads via dev admin persona, screenshot /tmp/jov-2470-admin-growth-leads.png, no console errors
- pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added retry action to lead-table error UI and a warning banner when cached data exists.

* **Improvements**
  * Enhanced table row styling, row height and loading skeletons.
  * Improved empty-state messaging with an alert icon and actionable retry button.

* **Tests**
  * Added/updated tests to cover retry behavior, error UI, and row styling classes (including retry click asserting refetch).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
