### PR TITLE
refactor(web): canonicalize dashboard releases route

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/ReleasesPageClient.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/ReleasesPageClient.tsx
@@ -3,42 +3,15 @@
 import dynamic from 'next/dynamic';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
-import { useAppFlag } from '@/lib/flags/client';
 import { useReleasesQuery } from '@/lib/queries/useReleasesQuery';
 import { primaryProviderKeys, providerConfig } from './config';
 import { ReleaseTableSkeleton } from './loading';
-
-export type ReleasesViewMode = 'designV1ShellReleases' | 'legacyProviderMatrix';
-
-export interface ReleasesFlagState {
-  readonly shellChatV1Enabled: boolean;
-  readonly designV1ReleasesEnabled: boolean;
-}
-
-export function resolveReleasesViewMode({
-  designV1ReleasesEnabled,
-}: ReleasesFlagState): ReleasesViewMode {
-  // DESIGN_V1 owns both shell chrome and the releases view selection.
-  return designV1ReleasesEnabled
-    ? 'designV1ShellReleases'
-    : 'legacyProviderMatrix';
-}
 
 const ReleasesExperience = dynamic(
   () =>
     import('@/features/dashboard/organisms/release-provider-matrix').then(
       mod => mod.ReleasesExperience
     ),
-  {
-    loading: () => <ReleaseTableSkeleton showHeader={false} />,
-  }
-);
-
-const ShellReleasesView = dynamic(
-  () =>
-    import(
-      '@/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView'
-    ).then(mod => mod.ShellReleasesView),
   {
     loading: () => <ReleaseTableSkeleton showHeader={false} />,
   }
@@ -56,11 +29,6 @@ const ShellReleasesView = dynamic(
 export function ReleasesPageClient() {
   const { selectedProfile } = useDashboardData();
   const profileId = selectedProfile?.id ?? '';
-  const releasesViewMode = resolveReleasesViewMode({
-    shellChatV1Enabled: useAppFlag('DESIGN_V1'),
-    designV1ReleasesEnabled: useAppFlag('DESIGN_V1'),
-  });
-
   const { data: releases, isError } = useReleasesQuery(profileId);
 
   const settings =
@@ -92,22 +60,6 @@ export function ReleasesPageClient() {
 
   if (releases === undefined) {
     return <ReleaseTableSkeleton showHeader={false} />;
-  }
-
-  if (releasesViewMode === 'designV1ShellReleases') {
-    return (
-      <ShellReleasesView
-        releases={releases ?? []}
-        providerConfig={providerConfig}
-        primaryProviders={primaryProviderKeys}
-        artistName={spotifyArtistName}
-        allowArtworkDownloads={allowArtworkDownloads}
-        spotifyConnected={spotifyConnected}
-        appleMusicConnected={appleMusicConnected}
-        initialImporting={spotifyImportStatus === 'importing'}
-        initialTotalCount={spotifyImportTotal}
-      />
-    );
   }
 
   return (

--- a/apps/web/tests/e2e/dashboard-profile-drawer-stability.spec.ts
+++ b/apps/web/tests/e2e/dashboard-profile-drawer-stability.spec.ts
@@ -22,13 +22,27 @@
  * @stability @smoke
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 import { assertDomStable } from '../helpers/dom-stability';
 
 const BYPASS_URL =
   '/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/releases';
 
 test.use({ storageState: { cookies: [], origins: [] } });
+
+async function findFirstReleaseTrigger(page: Page) {
+  const taggedRow = page.getByTestId('release-row').first();
+  if (await taggedRow.isVisible()) {
+    return taggedRow;
+  }
+
+  const desktopRow = page.locator('tbody tr').first();
+  if (await desktopRow.isVisible()) {
+    return desktopRow;
+  }
+
+  return page.locator('[role="listbox"] [role="option"]').first();
+}
 
 test('release sidebar stays stable during background query invalidation', async ({
   page,
@@ -51,8 +65,7 @@ test('release sidebar stays stable during background query invalidation', async 
   );
 
   // Open the first release row to show the sidebar.
-  // ShellReleasesView renders rows in a listbox; click the first option.
-  const firstRow = page.locator('[role="listbox"] [role="option"]').first();
+  const firstRow = await findFirstReleaseTrigger(page);
   const hasRows = await firstRow.count();
 
   if (hasRows === 0) {

--- a/apps/web/tests/e2e/releases-page-stability.spec.ts
+++ b/apps/web/tests/e2e/releases-page-stability.spec.ts
@@ -40,9 +40,7 @@ test('releases page stays stable during background query invalidation', async ({
   await page.goto(BYPASS_URL, { waitUntil: 'domcontentloaded' });
   await page.waitForURL(/\/app\/dashboard\/releases/, { timeout: 60_000 });
 
-  // Wait for the releases view to be fully rendered (no skeleton)
-  // ShellReleasesView renders data-testid="shell-releases-view" when DESIGN_V1 is on.
-  // ReleasesExperience is the legacy path. Either way, wait for the skeleton to be gone.
+  // Wait for the releases view to be fully rendered (no skeleton).
   await expect(page.locator('[data-testid="releases-loading"]')).toHaveCount(
     0,
     {
@@ -50,16 +48,9 @@ test('releases page stays stable during background query invalidation', async ({
     }
   );
 
-  // Confirm the page has a releases view rendered (shell view or legacy matrix)
-  const hasShellView = await page
-    .locator('[data-testid="shell-releases-view"]')
-    .count();
-  if (hasShellView === 0) {
-    // Legacy provider matrix path — ensure any content container is present
-    await expect(page.locator('[role="main"]')).toBeVisible({
-      timeout: 15_000,
-    });
-  }
+  await expect(page.getByTestId('releases-matrix')).toBeVisible({
+    timeout: 15_000,
+  });
 
   // Trigger a background invalidation via the E2E hook and assert no skeleton appears
   await assertDomStable(page, {

--- a/apps/web/tests/unit/dashboard/ReleasesPageClient-skeleton.test.tsx
+++ b/apps/web/tests/unit/dashboard/ReleasesPageClient-skeleton.test.tsx
@@ -4,7 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const useReleasesQueryMock = vi.fn();
 const useDashboardDataMock = vi.fn();
-const useAppFlagMock = vi.fn();
 
 vi.mock('next/dynamic', () => ({
   default: (
@@ -27,24 +26,11 @@ vi.mock('@/app/app/(shell)/dashboard/DashboardDataContext', () => ({
   useDashboardData: () => useDashboardDataMock(),
 }));
 
-vi.mock('@/lib/flags/client', () => ({
-  useAppFlag: (flag: string) => useAppFlagMock(flag),
-}));
-
 vi.mock('@/features/dashboard/organisms/release-provider-matrix', () => ({
   ReleasesExperience: ({ releases }: { readonly releases: unknown[] }) => (
     <div data-testid='releases-experience' data-count={releases.length} />
   ),
 }));
-
-vi.mock(
-  '@/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView',
-  () => ({
-    ShellReleasesView: ({ releases }: { readonly releases: unknown[] }) => (
-      <div data-testid='shell-releases-view' data-count={releases.length} />
-    ),
-  })
-);
 
 vi.mock('@/app/app/(shell)/dashboard/releases/loading', () => ({
   ReleaseTableSkeleton: () => <div data-testid='release-table-skeleton' />,
@@ -60,7 +46,6 @@ describe('ReleasesPageClient skeleton behavior', () => {
     useDashboardDataMock.mockReturnValue({
       selectedProfile: { id: 'p1', settings: {} },
     });
-    useAppFlagMock.mockReturnValue(false);
   });
 
   afterEach(() => cleanup());

--- a/apps/web/tests/unit/dashboard/releases-page-client.test.tsx
+++ b/apps/web/tests/unit/dashboard/releases-page-client.test.tsx
@@ -5,10 +5,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const appFlagState = vi.hoisted(() => ({
-  DESIGN_V1: false,
-}));
-
 // Mock dashboard context
 const mockProfile = {
   id: 'profile-1',
@@ -18,34 +14,17 @@ const mockProfile = {
 };
 
 vi.mock('next/dynamic', () => {
-  let dynamicComponentIndex = 0;
-
   return {
     default: () => {
-      dynamicComponentIndex += 1;
-
-      if (dynamicComponentIndex === 1) {
-        return function DynamicReleasesExperience(
-          props: Record<string, unknown>
-        ) {
-          return (
-            <div
-              data-testid='releases-experience'
-              data-count={String((props.releases as unknown[])?.length ?? 0)}
-            >
-              Releases
-            </div>
-          );
-        };
-      }
-
-      return function DynamicShellReleasesView(props: Record<string, unknown>) {
+      return function DynamicReleasesExperience(
+        props: Record<string, unknown>
+      ) {
         return (
           <div
-            data-testid='shell-releases-view'
+            data-testid='releases-experience'
             data-count={String((props.releases as unknown[])?.length ?? 0)}
           >
-            Shell Releases
+            Releases
           </div>
         );
       };
@@ -73,10 +52,6 @@ vi.mock('@/lib/queries/useReleasesQuery', () => ({
   useReleasesQuery: () => mockQueryResult,
 }));
 
-vi.mock('@/lib/flags/client', () => ({
-  useAppFlag: (flagName: keyof typeof appFlagState) => appFlagState[flagName],
-}));
-
 vi.mock('@/features/feedback/PageErrorState', () => ({
   PageErrorState: ({ message }: { message: string }) => (
     <div data-testid='page-error'>{message}</div>
@@ -94,29 +69,13 @@ vi.mock('@/app/app/(shell)/dashboard/releases/loading', () => ({
   ),
 }));
 
-import {
-  ReleasesPageClient,
-  resolveReleasesViewMode,
-} from '@/app/app/(shell)/dashboard/releases/ReleasesPageClient';
+import { ReleasesPageClient } from '@/app/app/(shell)/dashboard/releases/ReleasesPageClient';
 
 describe('@critical ReleasesPageClient', () => {
   beforeEach(() => {
-    appFlagState.DESIGN_V1 = false;
     mockQueryResult.data = [];
     mockQueryResult.isLoading = false;
     mockQueryResult.isError = false;
-  });
-
-  it.each([
-    [false, 'legacyProviderMatrix'],
-    [true, 'designV1ShellReleases'],
-  ] as const)('resolves releases view mode for DESIGN_V1=%s', (designV1ReleasesEnabled, expectedMode) => {
-    expect(
-      resolveReleasesViewMode({
-        shellChatV1Enabled: designV1ReleasesEnabled,
-        designV1ReleasesEnabled,
-      })
-    ).toBe(expectedMode);
   });
 
   it('shows skeleton when loading with no cached data', () => {
@@ -176,29 +135,14 @@ describe('@critical ReleasesPageClient', () => {
     );
   });
 
-  it('keeps ReleasesExperience when DESIGN_V1 is off', () => {
-    appFlagState.DESIGN_V1 = false;
-    mockQueryResult.data = [{ id: 'r1' }] as unknown[];
+  it('always renders the canonical releases experience when data is present', () => {
+    mockQueryResult.data = [{ id: 'r1' }, { id: 'r2' }] as unknown[];
 
     render(<ReleasesPageClient />);
 
     expect(screen.getByTestId('releases-experience')).toHaveAttribute(
       'data-count',
-      '1'
-    );
-    expect(screen.queryByTestId('shell-releases-view')).not.toBeInTheDocument();
-  });
-
-  it('renders ShellReleasesView when DESIGN_V1 is on', () => {
-    appFlagState.DESIGN_V1 = true;
-    mockQueryResult.data = [{ id: 'r1' }, { id: 'r2' }] as unknown[];
-
-    render(<ReleasesPageClient />);
-
-    expect(screen.getByTestId('shell-releases-view')).toHaveAttribute(
-      'data-count',
       '2'
     );
-    expect(screen.queryByTestId('releases-experience')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- route dashboard releases through the canonical `ReleasesExperience` path instead of branching between separate releases views
- keep the existing cold-load pending shell contract and server warmup behavior intact
- update focused release page unit and stability specs to assert the unified releases matrix surface

## Verification
- `pnpm --filter web exec vitest run tests/unit/dashboard/releases-page-client.test.tsx tests/unit/dashboard/ReleasesPageClient-skeleton.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm exec biome check apps/web/app/app/\(shell\)/dashboard/releases/ReleasesPageClient.tsx apps/web/tests/unit/dashboard/releases-page-client.test.tsx apps/web/tests/unit/dashboard/ReleasesPageClient-skeleton.test.tsx apps/web/tests/e2e/releases-page-stability.spec.ts apps/web/tests/e2e/dashboard-profile-drawer-stability.spec.ts`
- `git push -u origin codex/jov-2471-dashboard-releases-table` (pre-push ran `biome check .`, `pnpm --filter=@jovie/web run pre-push`, `next:proxy-guard`, `tailwind:check`, `typecheck`, and `lint`)

<!-- linear-issue-id:JOV-2471 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified the releases page to always render a single, canonical releases experience, removing conditional/feature-flag branching while preserving error and loading skeleton behavior.

* **Tests**
  * Updated e2e and unit tests to match the simplified view, improve stability checks for the releases sidebar and page, and simplify test mocks/assertions accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->