### PR TITLE
Normalize dashboard task shell and row actions

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
@@ -20,14 +20,10 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { UserAvatar } from '@jovie/ui';
-import { Disc3, MoreHorizontal, Plus } from 'lucide-react';
+import { Disc3, Plus } from 'lucide-react';
 import { useMemo, useState } from 'react';
-import { TableActionMenu } from '@/components/atoms/table-action-menu/TableActionMenu';
 import { ReleaseDueBadge } from '@/components/molecules/ReleaseDueBadge';
-import {
-  type ContextMenuItemType,
-  convertContextMenuItems,
-} from '@/components/organisms/table';
+import { type ContextMenuItemType } from '@/components/organisms/table';
 import { TASK_BOARD_STATUSES } from '@/lib/tasks/task-board';
 import type {
   MoveTaskInput,
@@ -39,6 +35,7 @@ import type {
 import { getAccentCssVars } from '@/lib/ui/accent-palette';
 import { cn } from '@/lib/utils';
 import { PriorityBars } from './TaskListRow';
+import { TaskRowActionMenu } from './TaskRowActionMenu';
 import {
   getTaskAssigneeVisual,
   getTaskPriorityVisual,
@@ -461,20 +458,11 @@ function SortableTaskBoardCard({
         />
       </button>
       <div className='absolute right-2 top-2'>
-        <TableActionMenu
-          items={convertContextMenuItems(getTaskContextMenuItems(task))}
-          trigger='custom'
-        >
-          <button
-            type='button'
-            onClick={event => event.stopPropagation()}
-            onPointerDown={event => event.stopPropagation()}
-            aria-label='Open task actions'
-            className='inline-flex h-7 w-7 items-center justify-center rounded-md text-tertiary-token opacity-0 transition-[background-color,color,opacity] hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_68%,transparent)] hover:text-primary-token focus-visible:opacity-100 focus-visible:outline-none focus-visible:bg-[color-mix(in_oklab,var(--linear-row-hover)_70%,transparent)] group-hover/task-board-card-shell:opacity-100'
-          >
-            <MoreHorizontal className='h-3.5 w-3.5' />
-          </button>
-        </TableActionMenu>
+        <TaskRowActionMenu
+          items={getTaskContextMenuItems(task)}
+          selected={selected}
+          visibility='hover'
+        />
       </div>
     </div>
   );

--- a/apps/web/components/features/dashboard/tasks/TaskRowActionMenu.test.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskRowActionMenu.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getTaskRowActionTriggerClassName,
+  TaskRowActionMenu,
+} from './TaskRowActionMenu';
+
+describe('TaskRowActionMenu', () => {
+  it('includes the hover/open visibility hooks for board cards', () => {
+    const className = getTaskRowActionTriggerClassName({
+      visibility: 'hover',
+    });
+
+    expect(className).toContain('opacity-0');
+    expect(className).toContain(
+      'group-hover/task-board-card-shell:opacity-100'
+    );
+    expect(className).toContain('data-[state=open]:opacity-100');
+  });
+
+  it('forces selected board-card triggers visible', () => {
+    const className = getTaskRowActionTriggerClassName({
+      visibility: 'hover',
+      selected: true,
+    });
+
+    expect(className).toContain('opacity-100');
+  });
+
+  it('keeps always-visible triggers out of hover-only opacity rules', () => {
+    const className = getTaskRowActionTriggerClassName({
+      visibility: 'always',
+    });
+
+    expect(className).not.toContain('opacity-0');
+    expect(className).not.toContain('group-hover/task-board-card-shell');
+    expect(className).toContain('hover:text-primary-token');
+  });
+
+  it('opens the menu from the trigger without bubbling row clicks', async () => {
+    const onParentClick = vi.fn();
+    const onActionClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      createElement(
+        'div',
+        { onClick: onParentClick },
+        <TaskRowActionMenu
+          items={[{ id: 'archive', label: 'Archive', onClick: onActionClick }]}
+        />
+      )
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Open task actions' }));
+
+    expect(onParentClick).not.toHaveBeenCalled();
+    expect(
+      await screen.findByRole('menuitem', { name: 'Archive' })
+    ).toBeInTheDocument();
+  });
+
+  it.each([
+    '{Enter}',
+    ' ',
+  ])('opens the menu with keyboard activation %s', async key => {
+    const user = userEvent.setup();
+
+    render(
+      <TaskRowActionMenu
+        items={[{ id: 'archive', label: 'Archive', onClick: vi.fn() }]}
+      />
+    );
+
+    screen.getByRole('button', { name: 'Open task actions' }).focus();
+    await user.keyboard(key);
+
+    expect(
+      await screen.findByRole('menuitem', { name: 'Archive' })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/features/dashboard/tasks/TaskRowActionMenu.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskRowActionMenu.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { MoreHorizontal } from 'lucide-react';
+import { TableActionMenu } from '@/components/atoms/table-action-menu/TableActionMenu';
+import {
+  type ContextMenuItemType,
+  convertContextMenuItems,
+} from '@/components/organisms/table';
+import { cn } from '@/lib/utils';
+
+type TaskRowActionMenuVisibility = 'always' | 'hover';
+
+export function getTaskRowActionTriggerClassName({
+  visibility,
+  selected = false,
+}: Readonly<{
+  visibility: TaskRowActionMenuVisibility;
+  selected?: boolean;
+}>): string {
+  return cn(
+    'inline-flex h-7 w-7 items-center justify-center rounded-md text-tertiary-token transition-[background-color,color,opacity] duration-subtle',
+    'hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_68%,transparent)] hover:text-primary-token',
+    'focus-visible:outline-none focus-visible:bg-[color-mix(in_oklab,var(--linear-row-hover)_70%,transparent)] focus-visible:text-primary-token',
+    visibility === 'hover' && [
+      'opacity-0 group-hover/task-board-card-shell:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100',
+      selected && 'opacity-100',
+    ]
+  );
+}
+
+export function TaskRowActionMenu({
+  items,
+  selected = false,
+  visibility = 'always',
+}: Readonly<{
+  items: ContextMenuItemType[];
+  selected?: boolean;
+  visibility?: TaskRowActionMenuVisibility;
+}>) {
+  return (
+    <TableActionMenu
+      items={convertContextMenuItems(items)}
+      trigger='custom'
+      align='end'
+    >
+      <button
+        type='button'
+        onClick={event => event.stopPropagation()}
+        onPointerDown={event => event.stopPropagation()}
+        onKeyDown={event => event.stopPropagation()}
+        aria-label='Open task actions'
+        className={getTaskRowActionTriggerClassName({
+          visibility,
+          selected,
+        })}
+      >
+        <MoreHorizontal className='h-3.5 w-3.5' />
+      </button>
+    </TableActionMenu>
+  );
+}

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -14,7 +14,6 @@ import {
   ChevronDown,
   Disc3,
   FileText,
-  MoreHorizontal,
   Plus,
   Trash2,
 } from 'lucide-react';
@@ -34,7 +33,6 @@ import {
 import { toast } from 'sonner';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 import { providerConfig } from '@/app/app/(shell)/dashboard/releases/config';
-import { TableActionMenu } from '@/components/atoms/table-action-menu/TableActionMenu';
 import { DashboardHeaderActionButton } from '@/components/features/dashboard/atoms/DashboardHeaderActionButton';
 import { DashboardHeaderActionGroup } from '@/components/features/dashboard/atoms/DashboardHeaderActionGroup';
 import { ReleaseTaskDueBadge } from '@/components/features/dashboard/release-tasks/ReleaseTaskDueBadge';
@@ -44,6 +42,7 @@ import {
   PriorityBars,
   TaskListRow,
 } from '@/components/features/dashboard/tasks/TaskListRow';
+import { TaskRowActionMenu } from '@/components/features/dashboard/tasks/TaskRowActionMenu';
 import {
   HIDDEN_DIV_STYLES,
   useTextareaAutosize,
@@ -60,7 +59,6 @@ import { PageShell } from '@/components/organisms/PageShell';
 import { ReleaseSidebar } from '@/components/organisms/release-sidebar';
 import {
   type ContextMenuItemType,
-  convertContextMenuItems,
   ShellListRowButton,
 } from '@/components/organisms/table';
 import { rowState } from '@/components/organisms/table/table.styles';
@@ -1870,21 +1868,9 @@ export function TasksPageClient() {
         artistName={artistName}
         isSelected={info.row.original.id === effectiveSelectedTaskId}
         actionSlot={
-          <TableActionMenu
-            items={convertContextMenuItems(
-              getTaskContextMenuItems(info.row.original)
-            )}
-            trigger='custom'
-          >
-            <button
-              type='button'
-              onClick={event => event.stopPropagation()}
-              aria-label='Open task actions'
-              className='inline-flex h-7 w-7 items-center justify-center rounded-md bg-transparent text-tertiary-token transition-[background-color,color] duration-subtle hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_56%,transparent)] hover:text-primary-token focus-visible:outline-none focus-visible:bg-[color-mix(in_oklab,var(--linear-row-hover)_60%,transparent)] focus-visible:text-primary-token'
-            >
-              <MoreHorizontal className='h-3.5 w-3.5' />
-            </button>
-          </TableActionMenu>
+          <TaskRowActionMenu
+            items={getTaskContextMenuItems(info.row.original)}
+          />
         }
       />
     ),

--- a/apps/web/components/shell/TasksRouteSkeleton.tsx
+++ b/apps/web/components/shell/TasksRouteSkeleton.tsx
@@ -1,3 +1,6 @@
+import { PageShell } from '@/components/organisms/PageShell';
+import { PageToolbar } from '@/components/organisms/table';
+
 const TASK_ROWS = [
   { key: 'task-1', titleWidth: '72%', metaWidth: '38%' },
   { key: 'task-2', titleWidth: '84%', metaWidth: '44%' },
@@ -10,25 +13,31 @@ const BOARD_COLUMNS = ['backlog', 'todo', 'progress'] as const;
 
 export function TasksRouteSkeleton() {
   return (
-    <section
+    <PageShell
       aria-label='Loading tasks'
       aria-busy='true'
       aria-live='polite'
-      className='flex h-full min-h-0 flex-col bg-(--linear-app-content-surface)'
+      className='absolute inset-0 overflow-hidden'
+      toolbar={
+        <PageToolbar
+          start={
+            <div className='flex items-center gap-1.5'>
+              <div className='skeleton h-7 w-20 rounded-full' />
+              <div className='skeleton h-7 w-28 rounded-full' />
+              <div className='skeleton h-7 w-32 rounded-full' />
+            </div>
+          }
+          end={
+            <div className='flex items-center gap-1'>
+              <div className='skeleton h-7 w-7 rounded-full' />
+              <div className='skeleton h-7 w-7 rounded-full' />
+            </div>
+          }
+          className='h-[var(--linear-app-header-height-compact)] min-h-[var(--linear-app-header-height-compact)]'
+        />
+      }
     >
-      <div className='flex h-(--linear-app-header-height-compact) shrink-0 items-center justify-between gap-3 px-app-header'>
-        <div className='flex items-center gap-1.5'>
-          <div className='skeleton h-7 w-20 rounded-full' />
-          <div className='skeleton h-7 w-28 rounded-full' />
-          <div className='skeleton h-7 w-32 rounded-full' />
-        </div>
-        <div className='flex items-center gap-1'>
-          <div className='skeleton h-7 w-7 rounded-full' />
-          <div className='skeleton h-7 w-7 rounded-full' />
-        </div>
-      </div>
-
-      <div className='flex min-h-0 flex-1 overflow-hidden pb-2'>
+      <section className='flex min-h-0 flex-1 flex-col overflow-hidden pb-2'>
         <div className='hidden min-h-0 flex-1 gap-2 px-2.5 pt-0.5 lg:flex'>
           {BOARD_COLUMNS.map(column => (
             <div
@@ -76,7 +85,7 @@ export function TasksRouteSkeleton() {
             </div>
           ))}
         </div>
-      </div>
-    </section>
+      </section>
+    </PageShell>
   );
 }


### PR DESCRIPTION
## Summary
- route task row menus through a shared task action menu primitive so board and list rows use the same trigger behavior
- keep board-card action buttons visible when selected or open, while preserving the existing task context menu items
- move the tasks loading shell onto PageShell/PageToolbar and add focused coverage for the shared action trigger classes

## Verification
- pnpm exec biome check --write apps/web/components/features/dashboard/tasks/TaskBoard.tsx apps/web/components/features/dashboard/tasks/TasksPageClient.tsx apps/web/components/features/dashboard/tasks/TaskRowActionMenu.tsx apps/web/components/features/dashboard/tasks/TaskRowActionMenu.test.tsx apps/web/components/shell/TasksRouteSkeleton.tsx
- pnpm exec vitest run apps/web/components/features/dashboard/tasks/task-presentation.test.ts apps/web/components/features/dashboard/tasks/TaskRowActionMenu.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm turbo typecheck
- git push -u origin codex/jov-2472-dashboard-tasks-shell

<!-- linear-issue-id:JOV-2472 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the tasks page loading state layout with improved visual structure and spacing.
  * Refined task action menu interface with updated hover behavior and visibility patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->