### PR TITLE
JOV-2473 Canonicalize dashboard audience row contract and loading shell

### DIFF
--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell.tsx
@@ -1,25 +1,24 @@
+'use client';
+
 import { ContentSectionHeaderSkeleton } from '@/components/molecules/ContentSectionHeaderSkeleton';
 import { LoadingSkeleton } from '@/components/molecules/LoadingSkeleton';
-import { PageToolbar } from '@/components/organisms/table';
+import {
+  PageToolbar,
+  UnifiedTableSkeleton,
+} from '@/components/organisms/table';
 import { SKELETON_ROW_COUNT, TABLE_ROW_HEIGHTS } from '@/lib/constants/layout';
+import {
+  AUDIENCE_TABLE_CONTAINER_CLASS,
+  AUDIENCE_TABLE_SKELETON_COLUMN_CONFIG,
+  buildAudienceMemberColumns,
+} from './table-config';
 
 const AUDIENCE_LOADING_TAB_KEYS = ['all', 'identified', 'anonymous'] as const;
-const AUDIENCE_TABLE_HEADER_KEYS = Array.from(
-  { length: 7 },
-  (_, i) => `audience-header-${i + 1}`
-);
-const AUDIENCE_TABLE_ROW_KEYS = Array.from(
-  { length: SKELETON_ROW_COUNT.TABLE },
-  (_, i) => `audience-row-${i + 1}`
-);
-const AUDIENCE_TABLE_COL_KEYS = Array.from(
-  { length: 7 },
-  (_, i) => `audience-col-${i + 1}`
-);
 const AUDIENCE_MOBILE_ROW_KEYS = Array.from(
   { length: SKELETON_ROW_COUNT.MOBILE },
   (_, i) => `audience-mobile-${i + 1}`
 );
+const AUDIENCE_LOADING_COLUMNS = buildAudienceMemberColumns('members');
 
 export function AudienceTableLoadingShell() {
   return (
@@ -81,39 +80,15 @@ export function AudienceTableLoadingShell() {
           </div>
 
           <div className='max-sm:hidden flex-1 min-h-0 overflow-hidden'>
-            <div className='px-4 py-4 sm:px-6'>
-              <div className='overflow-hidden rounded-xl border border-subtle bg-(--linear-app-content-surface) shadow-subtle-bottom dark:shadow-inset-highlight'>
-                <div className='grid grid-cols-7 gap-4 border-b border-subtle px-4 py-3'>
-                  {AUDIENCE_TABLE_HEADER_KEYS.map(key => (
-                    <LoadingSkeleton
-                      key={key}
-                      height='h-4'
-                      width='w-24'
-                      rounded='md'
-                    />
-                  ))}
-                </div>
-                <ul>
-                  {AUDIENCE_TABLE_ROW_KEYS.map(rowKey => (
-                    <li
-                      key={rowKey}
-                      className='grid grid-cols-7 items-center gap-4 border-b border-subtle px-4 last:border-b-0'
-                      style={{ height: `${TABLE_ROW_HEIGHTS.STANDARD + 4}px` }}
-                      aria-hidden='true'
-                    >
-                      {AUDIENCE_TABLE_COL_KEYS.map(colKey => (
-                        <LoadingSkeleton
-                          key={`${rowKey}-${colKey}`}
-                          height='h-4'
-                          width='w-full'
-                          rounded='md'
-                        />
-                      ))}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </div>
+            <UnifiedTableSkeleton
+              columns={AUDIENCE_LOADING_COLUMNS}
+              skeletonRows={SKELETON_ROW_COUNT.TABLE}
+              skeletonColumnConfig={AUDIENCE_TABLE_SKELETON_COLUMN_CONFIG}
+              rowHeight={TABLE_ROW_HEIGHTS.STANDARD}
+              minWidth='800px'
+              className='text-app'
+              containerClassName={AUDIENCE_TABLE_CONTAINER_CLASS}
+            />
           </div>
 
           <div className='sticky bottom-0 z-20 flex flex-wrap items-center justify-between gap-3 border-t border-subtle bg-(--linear-app-content-surface)/95 px-4 py-2 text-xs text-secondary-token backdrop-blur-md sm:px-6 supports-[backdrop-filter]:bg-(--linear-app-content-surface)/85'>

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
@@ -2,13 +2,7 @@
 
 import { Button, CommonDropdown, type CommonDropdownItem } from '@jovie/ui';
 import { useQueryClient } from '@tanstack/react-query';
-import {
-  type ColumnDef,
-  createColumnHelper,
-  type OnChangeFn,
-  type SortingState,
-  type VisibilityState,
-} from '@tanstack/react-table';
+import { type OnChangeFn, type SortingState } from '@tanstack/react-table';
 import { Copy, Download, ExternalLink, Users } from 'lucide-react';
 import * as React from 'react';
 import { memo, useMemo } from 'react';
@@ -36,7 +30,6 @@ import {
 import { useAudiencePanel } from '@/features/dashboard/organisms/AudiencePanelContext';
 import { AudienceMemberSidebar } from '@/features/dashboard/organisms/audience-member-sidebar';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
-import { TABLE_MIN_WIDTHS } from '@/lib/constants/layout';
 import { captureError } from '@/lib/error-tracking';
 import { queryKeys } from '@/lib/queries';
 import { cn } from '@/lib/utils';
@@ -56,21 +49,16 @@ import {
 } from './AudienceTableContext';
 import { AudienceTableSubheader } from './AudienceTableSubheader';
 import { buildAudienceActions } from './audience-actions';
+import { NowMsProvider } from './cells';
 import {
-  AudienceActionCell,
-  AudienceAlertsCell,
-  AudienceEngagementBars,
-  AudienceFanCell,
-  AudienceLastCell,
-  AudienceStateCell,
-  NowMsProvider,
-} from './cells';
+  AUDIENCE_TABLE_CONTAINER_CLASS,
+  buildAudienceMemberColumns,
+  getAudienceColumnVisibility,
+  getAudienceTableMinWidth,
+} from './table-config';
 import type { DashboardAudienceTableProps } from './types';
 import { useDashboardAudienceTable } from './useDashboardAudienceTable';
 import { copyTextToClipboard, downloadVCard } from './utils';
-import { SelectCell } from './utils/column-renderers';
-
-const memberColumnHelper = createColumnHelper<AudienceMember>();
 
 function getSrDescription(isEmpty: boolean): string {
   if (isEmpty) {
@@ -118,122 +106,6 @@ function sanitizeQrFilename(value: string): string {
     .toLowerCase()
     .replaceAll(/[^a-z0-9]+/g, '-')
     .replaceAll(/^-|-$/g, '');
-}
-
-/**
- * Compact 6-column layout per the redesigned mockup.
- * Layout: Select | Fan | State | Alerts | Engagement | Last | Action
- */
-function buildMemberColumns(
-  mode: 'members' | 'subscribers'
-): ColumnDef<AudienceMember, any>[] {
-  return [
-    memberColumnHelper.display({
-      id: 'select',
-      header: () => null,
-      cell: SelectCell,
-      size: 40,
-      enableSorting: false,
-    }),
-    memberColumnHelper.accessor('displayName', {
-      id: 'fan',
-      header: 'Fan',
-      cell: ({ row }) => <AudienceFanCell member={row.original} />,
-      size: 9999,
-      minSize: 220,
-      enableSorting: false,
-    }),
-    memberColumnHelper.display({
-      id: 'state',
-      header: 'State',
-      cell: ({ row }) => (
-        <AudienceStateCell member={row.original} mode={mode} />
-      ),
-      size: 96,
-      enableSorting: false,
-    }),
-    memberColumnHelper.display({
-      id: 'alerts',
-      header: 'Alerts',
-      cell: ({ row }) => <AudienceAlertsCell member={row.original} />,
-      size: 96,
-      enableSorting: false,
-    }),
-    memberColumnHelper.accessor('engagementScore', {
-      id: 'engagement',
-      header: 'Engagement',
-      cell: ({ row }) => (
-        <AudienceEngagementBars score={row.original.engagementScore} />
-      ),
-      size: 80,
-      enableSorting: true,
-    }),
-    memberColumnHelper.accessor('lastSeenAt', {
-      id: 'last',
-      header: 'Last',
-      cell: ({ row }) => (
-        <AudienceLastCell lastSeenAt={row.original.lastSeenAt} />
-      ),
-      size: 56,
-      enableSorting: true,
-    }),
-    memberColumnHelper.display({
-      id: 'action',
-      header: () => <div className='text-right'>Action</div>,
-      cell: ({ row }) => <AudienceActionCell member={row.original} />,
-      size: 120,
-      enableSorting: false,
-      meta: { className: 'text-right' },
-    }),
-  ];
-}
-
-type AudienceTableLayout = 'narrow' | 'medium' | 'wide';
-
-function getAudienceTableLayout(width: number): AudienceTableLayout {
-  if (width < 720) {
-    return 'narrow';
-  }
-  if (width < 960) {
-    return 'medium';
-  }
-  return 'wide';
-}
-
-/** Responsive column visibility by viewport width.
- *
- * Progressive hiding is based on the measured desktop table container width,
- * not the window width, so the layout adapts correctly with the shell sidebar
- * and right drawer both open and closed. Hide order at narrow widths:
- * ALERTS → ENGAGEMENT → STATE → LAST. (FAN + ACTION + select always render.)
- */
-function getColumnVisibility(width: number): VisibilityState {
-  switch (getAudienceTableLayout(width)) {
-    case 'narrow':
-      return {
-        alerts: false,
-        engagement: false,
-        state: false,
-        last: false,
-      };
-    case 'medium':
-      return { alerts: false, engagement: false };
-    case 'wide':
-    default:
-      return {};
-  }
-}
-
-function getTableMinWidth(width: number): number {
-  switch (getAudienceTableLayout(width)) {
-    case 'narrow':
-      return 480;
-    case 'medium':
-      return 640;
-    case 'wide':
-    default:
-      return TABLE_MIN_WIDTHS.SMALL;
-  }
 }
 
 /** Mobile card list — plain rendering (no virtualization needed for paginated data). */
@@ -382,7 +254,7 @@ export const DashboardAudienceTableUnified = memo(
     }, [desktopTableNode]);
 
     const columnVisibility = React.useMemo(
-      () => getColumnVisibility(desktopTableWidth),
+      () => getAudienceColumnVisibility(desktopTableWidth),
       [desktopTableWidth]
     );
 
@@ -400,7 +272,7 @@ export const DashboardAudienceTableUnified = memo(
       hiddenMetadataColumns.engagement || hiddenMetadataColumns.lastSeen;
 
     const tableMinWidth = React.useMemo(
-      () => `${getTableMinWidth(desktopTableWidth)}px`,
+      () => `${getAudienceTableMinWidth(desktopTableWidth)}px`,
       [desktopTableWidth]
     );
 
@@ -756,7 +628,7 @@ export const DashboardAudienceTableUnified = memo(
       ]
     );
 
-    const columns = useMemo(() => buildMemberColumns(mode), [mode]);
+    const columns = useMemo(() => buildAudienceMemberColumns(mode), [mode]);
 
     // Stable context: callbacks that rarely change — consumers won't re-render on selection/menu toggle
     const stableContextValue = useMemo(
@@ -1050,7 +922,7 @@ export const DashboardAudienceTableUnified = memo(
                           hasNextPage={hasNextPage}
                           isFetchingNextPage={isFetchingNextPage}
                           onLoadMore={onLoadMore}
-                          containerClassName='h-full px-2.5 pb-2.5 pt-0.5 md:px-3 md:pb-3 md:pt-1'
+                          containerClassName={AUDIENCE_TABLE_CONTAINER_CLASS}
                         />
                       </div>
                     </>

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/audience-actions.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/audience-actions.tsx
@@ -3,6 +3,10 @@
 import { Bell, Copy, Download, Eye, Phone, UserMinus } from 'lucide-react';
 import type { ContextMenuItemType } from '@/components/organisms/table';
 import type { AudienceMember } from '@/types';
+import {
+  getAudienceVisibleEmail,
+  isAudienceMemberReachable,
+} from './row-contract';
 
 // Module-level icon constants — allocated once, reused across all rows and renders.
 const ICON_EYE = <Eye className='h-3.5 w-3.5' />;
@@ -34,6 +38,9 @@ export function buildAudienceActions(
   member: AudienceMember,
   callbacks: BuildAudienceActionsCallbacks
 ): ContextMenuItemType[] {
+  const visibleEmail = getAudienceVisibleEmail(member);
+  const reachable = isAudienceMemberReachable(member);
+
   return [
     // ── View group ──
     {
@@ -48,7 +55,7 @@ export function buildAudienceActions(
       label: 'Copy email',
       icon: ICON_COPY,
       onClick: () => callbacks.onCopyEmail(member),
-      disabled: !member.email,
+      disabled: !visibleEmail,
     },
     {
       id: 'copy-phone',
@@ -62,7 +69,7 @@ export function buildAudienceActions(
       label: 'Send notification',
       icon: ICON_BELL,
       onClick: () => callbacks.onSendNotification(member),
-      disabled: !member.email && !member.phone,
+      disabled: !reachable,
     },
     // ── Export group ──
     { type: 'separator' as const },

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/cells/AudienceActionCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/cells/AudienceActionCell.tsx
@@ -5,6 +5,7 @@ import { memo, useCallback } from 'react';
 import { toast } from 'sonner';
 import type { AudienceMember } from '@/types';
 import { useAudienceTableStableContext } from '../AudienceTableContext';
+import { isAudienceMemberReachable } from '../row-contract';
 
 export interface AudienceActionCellProps {
   readonly member: AudienceMember;
@@ -14,11 +15,7 @@ export const AudienceActionCell = memo(function AudienceActionCell({
   member,
 }: AudienceActionCellProps) {
   const { onSendNotification } = useAudienceTableStableContext();
-  // Gate the email channel on `emailVisibleToArtist` so a fan whose email is
-  // hidden from the artist (e.g. opt-in not confirmed) doesn't get exposed by
-  // the Message button enabling and forwarding `member.email` downstream.
-  const emailVisible = member.emailVisibleToArtist !== false;
-  const reachable = Boolean((emailVisible && member.email) || member.phone);
+  const reachable = isAudienceMemberReachable(member);
 
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/cells/AudienceFanCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/cells/AudienceFanCell.tsx
@@ -4,65 +4,29 @@ import { memo } from 'react';
 import { TruncatedText } from '@/components/atoms/TruncatedText';
 import { cn } from '@/lib/utils';
 import type { AudienceMember } from '@/types';
+import {
+  getAudienceDisplayName,
+  getAudienceIdentityChip,
+  isAudienceMemberAnonymous,
+} from '../row-contract';
 import { getMonogramInitials, getMonogramTone } from './initials';
 
 export interface AudienceFanCellProps {
   readonly member: AudienceMember;
 }
 
-/**
- * Mask a phone number for display.
- *
- * Format: "+CC ••• LAST4" where CC is 1–3 country-code digits and LAST4 is
- * the last four digits. Anything we cannot confidently parse falls back to
- * the raw input rather than an awkward fabricated layout.
- */
-function maskPhone(phone: string): string {
-  const trimmed = phone.trim();
-  const digits = trimmed.replace(/\D/g, '');
-  if (digits.length < 7) return trimmed;
-  const last4 = digits.slice(-4);
-  const hasPlus = trimmed.startsWith('+');
-  // Only emit a country code when the phone genuinely has digits beyond the
-  // standard 10-digit national number. This avoids fabricating a "+5" prefix
-  // for short test numbers like "+5551234".
-  const ccLen = hasPlus ? Math.min(3, Math.max(0, digits.length - 10)) : 0;
-  const cc = ccLen > 0 ? `+${digits.slice(0, ccLen)} ` : '';
-  return `${cc}••• ${last4}`;
-}
-
-function pickIdentityChip(
-  member: AudienceMember,
-  displayName: string
-): string | null {
-  const emailVisible = member.emailVisibleToArtist !== false;
-  if (emailVisible && member.email && member.email !== displayName) {
-    return member.email;
-  }
-  if (member.phone) return maskPhone(member.phone);
-  return null;
-}
-
 export const AudienceFanCell = memo(function AudienceFanCell({
   member,
 }: AudienceFanCellProps) {
-  const name = member.displayName?.trim() ?? '';
-  // Treat email as absent when it's gated from the artist — otherwise we'd
-  // render "Visitor" instead of "Anonymous Fan" and leak that a hidden
-  // identity exists.
-  const visibleEmail =
-    member.emailVisibleToArtist === false ? null : member.email;
-  // A fan is anonymous only when we have no contact channel AND no provider
-  // identity. A Spotify-connected fan without email/phone is still identified.
-  const isAnonymous =
-    !name && !visibleEmail && !member.phone && !member.spotifyConnected;
-
-  const displayName = name || (isAnonymous ? 'Anonymous Fan' : 'Visitor');
+  const isAnonymous = isAudienceMemberAnonymous(member);
+  const displayName = getAudienceDisplayName(member);
   const monogram = isAnonymous ? '◯' : getMonogramInitials(displayName);
   const tone = isAnonymous
     ? 'bg-surface-0 text-tertiary-token'
     : getMonogramTone(displayName);
-  const chip = isAnonymous ? null : pickIdentityChip(member, displayName);
+  const chip = isAnonymous
+    ? null
+    : getAudienceIdentityChip(member, displayName);
 
   return (
     <div className='flex items-center gap-2.5 min-w-0'>

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/cells/AudienceStateCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/cells/AudienceStateCell.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { memo } from 'react';
-import {
-  type AudienceRowState,
-  deriveAudienceState,
-} from '@/lib/audience/derive-state';
 import { cn } from '@/lib/utils';
 import type { AudienceMember } from '@/types';
+import {
+  AUDIENCE_STATE_LABELS,
+  AUDIENCE_STATE_STYLES,
+  getAudienceDisplayState,
+} from '../row-contract';
 import { isSsrNowMs, useNowMs } from './NowMsContext';
 
 export interface AudienceStateCellProps {
@@ -14,46 +15,23 @@ export interface AudienceStateCellProps {
   readonly mode: 'members' | 'subscribers';
 }
 
-type DisplayState = AudienceRowState | 'subscriber';
-
-const STATE_STYLES: Record<DisplayState, string> = {
-  high: 'bg-emerald-500/15 text-emerald-300 ring-emerald-500/25',
-  rising: 'bg-amber-500/15 text-amber-300 ring-amber-500/25',
-  dormant: 'bg-surface-0 text-tertiary-token ring-subtle',
-  subscriber: 'bg-violet-500/15 text-violet-200 ring-violet-500/25',
-};
-
-const STATE_LABEL: Record<DisplayState, string> = {
-  high: 'High',
-  rising: 'Rising',
-  dormant: 'Dormant',
-  subscriber: 'Subscriber',
-};
-
 export const AudienceStateCell = memo(function AudienceStateCell({
   member,
   mode,
 }: AudienceStateCellProps) {
   const nowMs = useNowMs();
-
-  // Subscribers bypass derivation (their visits/intent are server-baked
-  // placeholders that would render every row as Dormant).
-  let state: DisplayState;
-  if (mode === 'subscribers') {
-    state = 'subscriber';
-  } else if (isSsrNowMs(nowMs)) {
-    // Neutral SSR placeholder — flips to real state after mount.
-    state = 'rising';
-  } else {
-    state = deriveAudienceState(member, nowMs);
-  }
-
-  const label = STATE_LABEL[state];
+  const state = getAudienceDisplayState({
+    member,
+    mode,
+    nowMs,
+    isSsr: isSsrNowMs(nowMs),
+  });
+  const label = AUDIENCE_STATE_LABELS[state];
   return (
     <span
       className={cn(
         'inline-flex items-center rounded-md px-1.5 py-0.5 text-2xs font-medium tabular-nums ring-1 ring-inset',
-        STATE_STYLES[state]
+        AUDIENCE_STATE_STYLES[state]
       )}
     >
       <span className='sr-only'>State: </span>

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/row-contract.ts
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/row-contract.ts
@@ -1,0 +1,117 @@
+import {
+  type AudienceRowState,
+  deriveAudienceState,
+} from '@/lib/audience/derive-state';
+import type { AudienceMember } from '@/types';
+
+export type AudienceDisplayState = AudienceRowState | 'subscriber';
+
+export const AUDIENCE_STATE_STYLES: Record<AudienceDisplayState, string> = {
+  high: 'bg-emerald-500/15 text-emerald-300 ring-emerald-500/25',
+  rising: 'bg-amber-500/15 text-amber-300 ring-amber-500/25',
+  dormant: 'bg-surface-0 text-tertiary-token ring-subtle',
+  subscriber: 'bg-violet-500/15 text-violet-200 ring-violet-500/25',
+};
+
+export const AUDIENCE_STATE_LABELS: Record<AudienceDisplayState, string> = {
+  high: 'High',
+  rising: 'Rising',
+  dormant: 'Dormant',
+  subscriber: 'Subscriber',
+};
+
+/**
+ * Format: "+CC ••• LAST4" where CC is 1-3 country-code digits and LAST4 is
+ * the last four digits. Anything we cannot confidently parse falls back to
+ * the raw input rather than an awkward fabricated layout.
+ */
+export function maskAudiencePhone(phone: string): string {
+  const trimmed = phone.trim();
+  const digits = trimmed.replace(/\D/g, '');
+  if (digits.length < 7) return trimmed;
+  const last4 = digits.slice(-4);
+  const hasPlus = trimmed.startsWith('+');
+  const ccLen = hasPlus ? Math.min(3, Math.max(0, digits.length - 10)) : 0;
+  const cc = ccLen > 0 ? `+${digits.slice(0, ccLen)} ` : '';
+  return `${cc}••• ${last4}`;
+}
+
+export function getAudienceVisibleEmail(
+  member: Pick<AudienceMember, 'email' | 'emailVisibleToArtist'>
+): string | null {
+  return member.emailVisibleToArtist === false ? null : member.email;
+}
+
+export function isAudienceMemberAnonymous(
+  member: Pick<
+    AudienceMember,
+    | 'displayName'
+    | 'email'
+    | 'emailVisibleToArtist'
+    | 'phone'
+    | 'spotifyConnected'
+  >
+): boolean {
+  const name = member.displayName?.trim() ?? '';
+  const visibleEmail = getAudienceVisibleEmail(member);
+
+  return !name && !visibleEmail && !member.phone && !member.spotifyConnected;
+}
+
+export function getAudienceDisplayName(
+  member: Pick<
+    AudienceMember,
+    | 'displayName'
+    | 'email'
+    | 'emailVisibleToArtist'
+    | 'phone'
+    | 'spotifyConnected'
+  >
+): string {
+  const name = member.displayName?.trim() ?? '';
+  if (name.length > 0) {
+    return name;
+  }
+
+  return isAudienceMemberAnonymous(member) ? 'Anonymous Fan' : 'Visitor';
+}
+
+export function getAudienceIdentityChip(
+  member: Pick<AudienceMember, 'email' | 'emailVisibleToArtist' | 'phone'>,
+  displayName: string
+): string | null {
+  const visibleEmail = getAudienceVisibleEmail(member);
+  if (visibleEmail && visibleEmail !== displayName) {
+    return visibleEmail;
+  }
+  if (member.phone) {
+    return maskAudiencePhone(member.phone);
+  }
+  return null;
+}
+
+export function isAudienceMemberReachable(
+  member: Pick<AudienceMember, 'email' | 'emailVisibleToArtist' | 'phone'>
+): boolean {
+  return Boolean(getAudienceVisibleEmail(member) || member.phone);
+}
+
+export function getAudienceDisplayState({
+  member,
+  mode,
+  nowMs,
+  isSsr,
+}: Readonly<{
+  member: AudienceMember;
+  mode: 'members' | 'subscribers';
+  nowMs: number;
+  isSsr: boolean;
+}>): AudienceDisplayState {
+  if (mode === 'subscribers') {
+    return 'subscriber';
+  }
+  if (isSsr) {
+    return 'rising';
+  }
+  return deriveAudienceState(member, nowMs);
+}

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/table-config.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/table-config.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import {
+  type ColumnDef,
+  createColumnHelper,
+  type VisibilityState,
+} from '@tanstack/react-table';
+import { TABLE_MIN_WIDTHS } from '@/lib/constants/layout';
+import type { AudienceMember } from '@/types';
+import {
+  AudienceActionCell,
+  AudienceAlertsCell,
+  AudienceEngagementBars,
+  AudienceFanCell,
+  AudienceLastCell,
+  AudienceStateCell,
+} from './cells';
+import { SelectCell } from './utils/column-renderers';
+
+const memberColumnHelper = createColumnHelper<AudienceMember>();
+
+export const AUDIENCE_TABLE_CONTAINER_CLASS =
+  'h-full px-2.5 pb-2.5 pt-0.5 md:px-3 md:pb-3 md:pt-1';
+
+export const AUDIENCE_TABLE_SKELETON_COLUMN_CONFIG: Array<{
+  readonly width?: string;
+  readonly variant?: 'text' | 'avatar' | 'badge' | 'button' | 'meta';
+}> = [
+  { width: '1.25rem', variant: 'text' as const },
+  { width: '14rem', variant: 'avatar' as const },
+  { width: '4.5rem', variant: 'badge' as const },
+  { width: '4.5rem', variant: 'badge' as const },
+  { width: '4rem', variant: 'meta' as const },
+  { width: '3rem', variant: 'meta' as const },
+  { width: '5.5rem', variant: 'button' as const },
+];
+
+export type AudienceTableLayout = 'narrow' | 'medium' | 'wide';
+
+export function buildAudienceMemberColumns(mode: 'members' | 'subscribers') {
+  return [
+    memberColumnHelper.display({
+      id: 'select',
+      header: () => null,
+      cell: SelectCell,
+      size: 40,
+      enableSorting: false,
+    }),
+    memberColumnHelper.accessor('displayName', {
+      id: 'fan',
+      header: 'Fan',
+      cell: ({ row }) => <AudienceFanCell member={row.original} />,
+      size: 9999,
+      minSize: 220,
+      enableSorting: false,
+    }),
+    memberColumnHelper.display({
+      id: 'state',
+      header: 'State',
+      cell: ({ row }) => (
+        <AudienceStateCell member={row.original} mode={mode} />
+      ),
+      size: 96,
+      enableSorting: false,
+    }),
+    memberColumnHelper.display({
+      id: 'alerts',
+      header: 'Alerts',
+      cell: ({ row }) => <AudienceAlertsCell member={row.original} />,
+      size: 96,
+      enableSorting: false,
+    }),
+    memberColumnHelper.accessor('engagementScore', {
+      id: 'engagement',
+      header: 'Engagement',
+      cell: ({ row }) => (
+        <AudienceEngagementBars score={row.original.engagementScore} />
+      ),
+      size: 80,
+      enableSorting: true,
+    }),
+    memberColumnHelper.accessor('lastSeenAt', {
+      id: 'last',
+      header: 'Last',
+      cell: ({ row }) => (
+        <AudienceLastCell lastSeenAt={row.original.lastSeenAt} />
+      ),
+      size: 56,
+      enableSorting: true,
+    }),
+    memberColumnHelper.display({
+      id: 'action',
+      header: () => <div className='text-right'>Action</div>,
+      cell: ({ row }) => <AudienceActionCell member={row.original} />,
+      size: 120,
+      enableSorting: false,
+      meta: { className: 'text-right' },
+    }),
+  ] as Array<ColumnDef<AudienceMember, unknown>>;
+}
+
+export function getAudienceTableLayout(width: number): AudienceTableLayout {
+  if (width < 720) {
+    return 'narrow';
+  }
+  if (width < 960) {
+    return 'medium';
+  }
+  return 'wide';
+}
+
+export function getAudienceColumnVisibility(width: number): VisibilityState {
+  switch (getAudienceTableLayout(width)) {
+    case 'narrow':
+      return {
+        alerts: false,
+        engagement: false,
+        state: false,
+        last: false,
+      };
+    case 'medium':
+      return { alerts: false, engagement: false };
+    case 'wide':
+    default:
+      return {};
+  }
+}
+
+export function getAudienceTableMinWidth(width: number): number {
+  switch (getAudienceTableLayout(width)) {
+    case 'narrow':
+      return 480;
+    case 'medium':
+      return 640;
+    case 'wide':
+    default:
+      return TABLE_MIN_WIDTHS.SMALL;
+  }
+}

--- a/apps/web/components/organisms/table/atoms/AudienceMobileCard.tsx
+++ b/apps/web/components/organisms/table/atoms/AudienceMobileCard.tsx
@@ -12,7 +12,14 @@ import {
   isSsrNowMs,
   useNowMs,
 } from '@/components/features/dashboard/organisms/dashboard-audience-table/cells/NowMsContext';
-import { deriveAudienceState } from '@/lib/audience/derive-state';
+import {
+  AUDIENCE_STATE_LABELS,
+  AUDIENCE_STATE_STYLES,
+  getAudienceDisplayName,
+  getAudienceDisplayState,
+  isAudienceMemberAnonymous,
+  isAudienceMemberReachable,
+} from '@/components/features/dashboard/organisms/dashboard-audience-table/row-contract';
 import { cn } from '@/lib/utils';
 import { formatTimeAgo } from '@/lib/utils/audience';
 import type { AudienceMember } from '@/types';
@@ -23,26 +30,6 @@ export interface AudienceMobileCardProps {
   readonly isSelected?: boolean;
   readonly onTap: (member: AudienceMember) => void;
   readonly onAction?: (member: AudienceMember) => void;
-}
-
-const STATE_PILL = {
-  high: 'bg-emerald-500/15 text-emerald-300 ring-emerald-500/25',
-  rising: 'bg-amber-500/15 text-amber-300 ring-amber-500/25',
-  dormant: 'bg-surface-0 text-tertiary-token ring-subtle',
-  subscriber: 'bg-violet-500/15 text-violet-200 ring-violet-500/25',
-} as const;
-
-const STATE_LABEL = {
-  high: 'High',
-  rising: 'Rising',
-  dormant: 'Dormant',
-  subscriber: 'Subscriber',
-} as const;
-
-function pickFallbackName(type: AudienceMember['type']): string {
-  if (type === 'email') return 'Email Subscriber';
-  if (type === 'sms') return 'SMS Subscriber';
-  return 'Visitor';
 }
 
 /**
@@ -63,15 +50,8 @@ export const AudienceMobileCard = React.memo(function AudienceMobileCard({
   onAction,
 }: AudienceMobileCardProps) {
   const nowMs = useNowMs();
-  const name = member.displayName?.trim() ?? '';
-  // Treat the email channel as absent when it's gated from the artist so the
-  // mobile card mirrors the desktop FanCell + privacy gate.
-  const visibleEmail =
-    member.emailVisibleToArtist === false ? null : member.email;
-  const isAnonymous =
-    !name && !visibleEmail && !member.phone && !member.spotifyConnected;
-  const displayName =
-    name || (isAnonymous ? 'Anonymous Fan' : pickFallbackName(member.type));
+  const isAnonymous = isAudienceMemberAnonymous(member);
+  const displayName = getAudienceDisplayName(member);
   const monogram = isAnonymous ? '◯' : getMonogramInitials(displayName);
   const tone = isAnonymous
     ? 'bg-surface-0 text-tertiary-token'
@@ -81,14 +61,13 @@ export const AudienceMobileCard = React.memo(function AudienceMobileCard({
   // table's hydration behaviour. While SSR_NOW_MS is in effect, every row
   // shows "Rising" until the post-mount tick swaps in the real clock.
   const isSsr = isSsrNowMs(nowMs);
-  const state: keyof typeof STATE_PILL =
-    mode === 'subscribers'
-      ? 'subscriber'
-      : isSsr
-        ? 'rising'
-        : deriveAudienceState(member, nowMs);
-
-  const reachable = Boolean(visibleEmail || member.phone);
+  const state = getAudienceDisplayState({
+    member,
+    mode,
+    nowMs,
+    isSsr,
+  });
+  const reachable = isAudienceMemberReachable(member);
 
   const handleCardClick = useCallback(() => onTap(member), [member, onTap]);
 
@@ -138,10 +117,10 @@ export const AudienceMobileCard = React.memo(function AudienceMobileCard({
           <span
             className={cn(
               'inline-flex shrink-0 items-center rounded-md px-1.5 py-0.5 text-2xs font-medium tabular-nums ring-1 ring-inset',
-              STATE_PILL[state]
+              AUDIENCE_STATE_STYLES[state]
             )}
           >
-            {STATE_LABEL[state]}
+            {AUDIENCE_STATE_LABELS[state]}
           </span>
         </div>
 

--- a/apps/web/tests/unit/dashboard/audience-table/AudienceMobileCard.test.tsx
+++ b/apps/web/tests/unit/dashboard/audience-table/AudienceMobileCard.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { AudienceMobileCard } from '@/components/organisms/table';
+import type { AudienceMember } from '@/types';
+
+const baseMember: AudienceMember = {
+  id: '1',
+  type: 'email',
+  displayName: 'Tim White',
+  locationLabel: '',
+  geoCity: null,
+  geoCountry: null,
+  visits: 1,
+  engagementScore: 50,
+  intentLevel: 'medium',
+  latestActions: [],
+  referrerHistory: [],
+  utmParams: {},
+  email: 'tim@example.com',
+  phone: null,
+  spotifyConnected: false,
+  purchaseCount: 0,
+  tipAmountTotalCents: 0,
+  tipCount: 0,
+  tags: [],
+  deviceType: null,
+  lastSeenAt: null,
+};
+
+describe('AudienceMobileCard', () => {
+  it('uses the same anonymous fallback as the desktop fan cell when the only identity is a gated email', () => {
+    render(
+      <AudienceMobileCard
+        member={{
+          ...baseMember,
+          displayName: null,
+          email: 'hidden@example.com',
+          emailVisibleToArtist: false,
+        }}
+        mode='members'
+        onTap={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Anonymous Fan')).toBeInTheDocument();
+    expect(screen.queryByText('hidden@example.com')).not.toBeInTheDocument();
+  });
+
+  it('disables the message button when the only contact is a gated email', () => {
+    render(
+      <AudienceMobileCard
+        member={{
+          ...baseMember,
+          displayName: null,
+          email: 'hidden@example.com',
+          emailVisibleToArtist: false,
+          phone: null,
+        }}
+        mode='members'
+        onTap={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', { name: /message anonymous fan/i })
+    ).toBeDisabled();
+  });
+
+  it('keeps the primary row tap target active when the message button is disabled', () => {
+    const onTap = vi.fn();
+    const member = {
+      ...baseMember,
+      email: null,
+      phone: null,
+    };
+
+    render(<AudienceMobileCard member={member} mode='members' onTap={onTap} />);
+
+    fireEvent.click(screen.getByLabelText(/view details for tim white/i));
+    expect(onTap).toHaveBeenCalledWith(member);
+  });
+});

--- a/apps/web/tests/unit/dashboard/audience-table/audience-actions.test.tsx
+++ b/apps/web/tests/unit/dashboard/audience-table/audience-actions.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildAudienceActions } from '@/components/features/dashboard/organisms/dashboard-audience-table/audience-actions';
+import type { AudienceMember } from '@/types';
+
+const baseMember: AudienceMember = {
+  id: '1',
+  type: 'email',
+  displayName: 'Tim',
+  locationLabel: '',
+  geoCity: null,
+  geoCountry: null,
+  visits: 1,
+  engagementScore: 50,
+  intentLevel: 'high',
+  latestActions: [],
+  referrerHistory: [],
+  utmParams: {},
+  email: 'tim@example.com',
+  phone: null,
+  spotifyConnected: false,
+  purchaseCount: 0,
+  tipAmountTotalCents: 0,
+  tipCount: 0,
+  tags: [],
+  deviceType: null,
+  lastSeenAt: null,
+};
+
+const callbacks = {
+  onViewDetails: vi.fn(),
+  onCopyEmail: vi.fn(),
+  onCopyPhone: vi.fn(),
+  onSendNotification: vi.fn(),
+  onExportVCard: vi.fn(),
+  onBlock: vi.fn(),
+};
+
+describe('buildAudienceActions', () => {
+  it('disables email-only actions when the email is gated from the artist', () => {
+    const items = buildAudienceActions(
+      {
+        ...baseMember,
+        email: 'hidden@example.com',
+        emailVisibleToArtist: false,
+        phone: null,
+      },
+      callbacks
+    );
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'copy-email', disabled: true }),
+        expect.objectContaining({ id: 'send-notification', disabled: true }),
+      ])
+    );
+  });
+
+  it('keeps notification enabled when a visible fallback channel exists', () => {
+    const items = buildAudienceActions(
+      {
+        ...baseMember,
+        email: 'hidden@example.com',
+        emailVisibleToArtist: false,
+        phone: '+14155550123',
+      },
+      callbacks
+    );
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'copy-email', disabled: true }),
+        expect.objectContaining({ id: 'send-notification', disabled: false }),
+      ])
+    );
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2473 -->
## Summary
- canonicalize the audience row identity, reachability, and state helpers across desktop rows, mobile cards, and action menus
- move shared audience table columns and layout helpers into a single config used by both the live table and the loading shell
- swap the desktop loading shell onto `UnifiedTableSkeleton` and add focused tests for the row contract

## Checks
- `pnpm --filter web exec vitest run tests/unit/dashboard/audience-table/AudienceFanCell.test.tsx tests/unit/dashboard/audience-table/AudienceActionCell.test.tsx tests/unit/dashboard/audience-table/audience-actions.test.tsx tests/unit/dashboard/audience-table/AudienceMobileCard.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated audience member display logic, including name, email visibility, and phone masking rules, across table and mobile card components
  * Standardized member reachability and anonymity detection across audience interfaces
  * Unified loading skeleton components for audience tables with consistent column configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->