### PR TITLE
JOV-2474: keep audio player mounted through shell fallbacks

### DIFF
--- a/apps/web/app/app/(shell)/layout.tsx
+++ b/apps/web/app/app/(shell)/layout.tsx
@@ -3,6 +3,7 @@ import { headers } from 'next/headers';
 import { redirect, unstable_rethrow } from 'next/navigation';
 import { Suspense } from 'react';
 import { CinematicAppBoot } from '@/components/organisms/CinematicAppBoot';
+import { PersistentAudioBar } from '@/components/organisms/PersistentAudioBar';
 import { LyricsRouteSkeleton } from '@/components/shell/LyricsRouteSkeleton';
 import { TasksRouteSkeleton } from '@/components/shell/TasksRouteSkeleton';
 import { APP_ROUTES } from '@/constants/routes';
@@ -57,6 +58,7 @@ export default async function AppShellLayout({
       userId: auth.userId,
     });
     const shellVariant = shellChatV1 ? 'shellChatV1' : 'legacy';
+    const audioPlayer = <PersistentAudioBar variant={shellVariant} />;
 
     // Pick the route-specific skeleton main slot.
     let routeMain: React.ReactNode = undefined;
@@ -78,7 +80,11 @@ export default async function AppShellLayout({
     // cinematic timeline before the underlying tree resolves. Per-tab gate
     // via sessionStorage flag `jovie:cinematic-boot-played`.
     const shellFallback = (
-      <CinematicAppBoot main={routeMain} variant={shellVariant} />
+      <CinematicAppBoot
+        main={routeMain}
+        audioPlayer={audioPlayer}
+        variant={shellVariant}
+      />
     );
 
     // Ban check moved inside DashboardShellContent (runs in parallel with

--- a/apps/web/components/organisms/AppShellSkeleton.tsx
+++ b/apps/web/components/organisms/AppShellSkeleton.tsx
@@ -20,9 +20,11 @@ const NAV_ITEMS_2 = [
 
 export function AppShellSkeleton({
   main: mainOverride,
+  audioPlayer,
   variant,
 }: {
   readonly main?: ReactNode;
+  readonly audioPlayer?: ReactNode;
   /**
    * Match the AppShellFrame variant the post-skeleton render will use so the
    * Suspense fallback doesn't flash a different layout while data loads.
@@ -122,6 +124,7 @@ export function AppShellSkeleton({
           <div className='skeleton h-4 w-28 rounded' />
         </header>
       }
+      audioPlayer={audioPlayer}
       main={
         mainOverride ?? (
           <div className='mx-auto flex h-full w-full max-w-5xl p-4 sm:p-6'>

--- a/apps/web/components/organisms/CinematicAppBoot.test.tsx
+++ b/apps/web/components/organisms/CinematicAppBoot.test.tsx
@@ -9,13 +9,16 @@ vi.mock('@/lib/hooks/useReducedMotion', () => ({
 vi.mock('@/components/organisms/AppShellSkeleton', () => ({
   AppShellSkeleton: ({
     main,
+    audioPlayer,
     variant,
   }: {
     main?: React.ReactNode;
+    audioPlayer?: React.ReactNode;
     variant?: string;
   }) => (
     <div data-testid='app-shell-skeleton' data-variant={variant}>
       {main}
+      {audioPlayer}
     </div>
   ),
 }));
@@ -88,5 +91,19 @@ describe('CinematicAppBoot', () => {
       <CinematicAppBoot main={undefined} variant='shellChatV1' />
     );
     expect(queryByTestId('app-shell-skeleton')).not.toBeNull();
+  });
+
+  it('passes the audio player through to the direct skeleton fallback', () => {
+    globalThis.sessionStorage.setItem(STORAGE_KEY, '1');
+    const { getByTestId } = render(
+      <CinematicAppBoot
+        audioPlayer={<div data-testid='audio-player' />}
+        variant='shellChatV1'
+      />
+    );
+
+    expect(getByTestId('app-shell-skeleton')).toContainElement(
+      getByTestId('audio-player')
+    );
   });
 });

--- a/apps/web/components/organisms/CinematicAppBoot.tsx
+++ b/apps/web/components/organisms/CinematicAppBoot.tsx
@@ -29,6 +29,8 @@ interface CinematicAppBootProps {
    * renders its default skeleton body.
    */
   readonly main?: ReactNode;
+  /** Existing shell audio player node passed through the direct skeleton path. */
+  readonly audioPlayer?: ReactNode;
   /** AppShellSkeleton variant — preserved across cinematic + skeleton fallbacks. */
   readonly variant: AppShellFrameVariant;
 }
@@ -50,7 +52,11 @@ interface CinematicAppBootProps {
  * cinematic is skipped and the route-specific AppShellSkeleton renders
  * directly — identical to today's loading state.
  */
-export function CinematicAppBoot({ main, variant }: CinematicAppBootProps) {
+export function CinematicAppBoot({
+  main,
+  audioPlayer,
+  variant,
+}: CinematicAppBootProps) {
   const [mounted, setMounted] = useState(false);
   const [shouldPlay, setShouldPlay] = useState(false);
   const prefersReducedMotion = useReducedMotion();
@@ -79,7 +85,13 @@ export function CinematicAppBoot({ main, variant }: CinematicAppBootProps) {
   }, []);
 
   if (!mounted || prefersReducedMotion || !shouldPlay) {
-    return <AppShellSkeleton main={main} variant={variant} />;
+    return (
+      <AppShellSkeleton
+        main={main}
+        audioPlayer={audioPlayer}
+        variant={variant}
+      />
+    );
   }
 
   const kfLogo = `jvf-logo-${safeId}`;

--- a/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
@@ -70,4 +70,20 @@ describe('AppShellFrame', () => {
       'lg:gap-[var(--linear-app-shell-gap)]'
     );
   });
+
+  it('renders the shared audio player slot inside the shell frame', () => {
+    render(
+      <AppShellFrame
+        sidebar={<aside>Sidebar</aside>}
+        header={<header>Header</header>}
+        main={<div>Main Content</div>}
+        audioPlayer={<div data-testid='audio-player'>Player</div>}
+      />
+    );
+
+    expect(screen.getByTestId('audio-player')).toBeInTheDocument();
+    expect(screen.getByRole('main')).toContainElement(
+      screen.getByTestId('audio-player')
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- thread the shell audio player node through `CinematicAppBoot` into `AppShellSkeleton`
- pass the existing `PersistentAudioBar` into the `(shell)` layout suspense fallback so the frame keeps its audio slot during shell loading
- add focused coverage for the skeleton audio prop path and the shared `AppShellFrame` audio slot

## Verification
- `pnpm exec biome check --write "apps/web/app/app/(shell)/layout.tsx" apps/web/components/organisms/AppShellSkeleton.tsx apps/web/components/organisms/CinematicAppBoot.tsx apps/web/components/organisms/CinematicAppBoot.test.tsx apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm exec vitest run apps/web/tests/components/organisms/PersistentAudioBar.test.tsx apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx apps/web/components/organisms/CinematicAppBoot.test.tsx`
- `git push -u origin codex/jov-2474-persistent-audio-shell-fallback` (passed repo pre-push hooks: `biome check .`, `pnpm --filter=@jovie/web run pre-push`)

## Linear
- JOV-2474


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio player now persists across application navigation.

* **Tests**
  * Added test coverage for audio player integration and rendering within the app shell.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->