### PR TITLE
JOV-2476 Normalize shell search trigger and sidebar spacing tokens

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -448,11 +448,7 @@ export function DashboardNav(_: DashboardNavProps) {
                 {/* Section divider for visual separation (except for first section) */}
                 {index > 0 && <div className='my-1.5' />}
                 {section.label ? (
-                  <SidebarCollapsibleGroup
-                    label={section.label}
-                    defaultOpen
-                    className='-mx-0.5'
-                  >
+                  <SidebarCollapsibleGroup label={section.label} defaultOpen>
                     {renderSection(section.items)}
                   </SidebarCollapsibleGroup>
                 ) : (
@@ -489,7 +485,6 @@ export function DashboardNav(_: DashboardNavProps) {
           <SidebarCollapsibleGroup
             label={artistWorkspaceSection.label}
             defaultOpen
-            className='-mx-0.5'
           >
             {renderSection(artistWorkspaceSection.items)}
           </SidebarCollapsibleGroup>

--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -25,6 +25,8 @@ export interface DashboardHeaderProps {
   readonly className?: string;
 }
 
+const MOBILE_HEADER_PADDING = 'px-4 pb-2 pt-3';
+
 function MobileHeader({
   currentLabel,
   action,
@@ -40,12 +42,19 @@ function MobileHeader({
 }) {
   if (searchSurface && isSearchActive) {
     return (
-      <div className='hidden max-sm:flex px-4 pb-2 pt-3'>{searchSurface}</div>
+      <div className={cn('hidden max-sm:flex', MOBILE_HEADER_PADDING)}>
+        {searchSurface}
+      </div>
     );
   }
 
   return (
-    <div className='hidden max-sm:flex items-center justify-between px-4 pb-2 pt-3'>
+    <div
+      className={cn(
+        'hidden max-sm:flex items-center justify-between',
+        MOBILE_HEADER_PADDING
+      )}
+    >
       <h1 className='text-[17px] font-semibold leading-tight tracking-[-0.018em] text-primary-token'>
         {currentLabel}
       </h1>
@@ -104,7 +113,7 @@ function BreadcrumbTrail({
         </>
       )}
       {showInlineSearch ? (
-        <div className='ml-2 flex items-center'>{searchSurface}</div>
+        <div className='ml-1.5 flex min-w-0 items-center'>{searchSurface}</div>
       ) : null}
     </>
   );

--- a/apps/web/components/organisms/sidebar/layout.tsx
+++ b/apps/web/components/organisms/sidebar/layout.tsx
@@ -49,7 +49,7 @@ export const SidebarHeader = React.forwardRef<
     <div
       ref={ref}
       data-sidebar='header'
-      className={cn('flex flex-col gap-1.5 p-2', className)}
+      className={cn('flex flex-col gap-1.5 px-2.5 py-2', className)}
       {...props}
     />
   );
@@ -65,7 +65,7 @@ export const SidebarFooter = React.forwardRef<
       ref={ref}
       data-sidebar='footer'
       className={cn(
-        'shrink-0 flex flex-col gap-1.5 overflow-hidden p-2 transition-[padding] duration-normal ease-interactive',
+        'shrink-0 flex flex-col gap-1.5 overflow-hidden px-2.5 py-2 transition-[padding] duration-normal ease-interactive',
         'group-data-[collapsible=icon]:px-0',
         className
       )}
@@ -82,7 +82,7 @@ export function SidebarSeparator({
   return (
     <Divider
       data-sidebar='separator'
-      className={cn('mx-2 w-auto border-sidebar-border', className)}
+      className={cn('mx-2.5 w-auto border-sidebar-border', className)}
       {...props}
     />
   );
@@ -97,7 +97,7 @@ export const SidebarContent = React.forwardRef<
       ref={ref}
       data-sidebar='content'
       className={cn(
-        'flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto overflow-x-hidden overscroll-contain px-0.5 group-data-[collapsible=icon]:overflow-hidden',
+        'flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto overflow-x-hidden overscroll-contain px-0 group-data-[collapsible=icon]:overflow-hidden',
         className
       )}
       {...props}

--- a/apps/web/components/shell/HeaderSearchSurface.tsx
+++ b/apps/web/components/shell/HeaderSearchSurface.tsx
@@ -17,6 +17,9 @@ interface HeaderSearchSurfaceProps {
   readonly className?: string;
 }
 
+const headerSearchSurfaceChrome =
+  'rounded-[10px] border border-(--linear-app-shell-border) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_96%,var(--linear-bg-surface-0))]';
+
 /**
  * Shell-owned search surface that morphs between a compact trigger button
  * (closed) and a full PillSearch panel (open).
@@ -50,7 +53,8 @@ export function HeaderSearchSurface({
         data-app-search-trigger='true'
         onClick={onOpen}
         className={cn(
-          'inline-flex h-7 items-center gap-1.5 rounded-md border border-(--linear-app-shell-border) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_94%,transparent)] px-2 text-[12px] text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+          headerSearchSurfaceChrome,
+          'inline-flex h-7 min-w-0 items-center gap-1.5 px-2.5 text-[12px] text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
           className
         )}
         aria-label={adapter.ariaLabel ?? adapter.triggerLabel}
@@ -69,7 +73,8 @@ export function HeaderSearchSurface({
   return (
     <div
       className={cn(
-        'w-full max-w-[min(560px,calc(100vw-2rem))] rounded-lg border border-(--linear-app-shell-border) bg-[color-mix(in_oklab,var(--linear-app-content-surface)_96%,var(--linear-bg-surface-0))] px-2 py-1 shadow-[0_10px_32px_rgba(0,0,0,0.16)] sm:w-[440px] lg:w-[520px]',
+        headerSearchSurfaceChrome,
+        'w-full max-w-[min(560px,calc(100vw-2rem))] px-2 py-1 shadow-[0_10px_32px_rgba(0,0,0,0.16)] sm:w-[440px] lg:w-[520px]',
         className
       )}
     >

--- a/apps/web/tests/unit/sidebar-row-alignment.test.tsx
+++ b/apps/web/tests/unit/sidebar-row-alignment.test.tsx
@@ -3,6 +3,11 @@ import type { ComponentProps, PropsWithChildren } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { SidebarCollapsibleGroup } from '@/components/organisms/SidebarCollapsibleGroup';
 import { SidebarGroupLabel } from '@/components/organisms/sidebar/group';
+import {
+  SidebarContent,
+  SidebarHeader,
+  SidebarSeparator,
+} from '@/components/organisms/sidebar/layout';
 
 type SidebarGroupProps = PropsWithChildren<{ className?: string }>;
 type SidebarGroupContentProps = PropsWithChildren<{ className?: string }>;
@@ -54,5 +59,23 @@ describe('Sidebar row alignment', () => {
     expect(
       screen.getByRole('button', { name: /general/i }).className
     ).toContain('px-2.5');
+  });
+
+  it('keeps shell sidebar wrapper spacing on the same token grid', () => {
+    const { container } = render(
+      <>
+        <SidebarHeader>Header</SidebarHeader>
+        <SidebarContent>Content</SidebarContent>
+        <SidebarSeparator />
+      </>
+    );
+
+    const header = container.querySelector('[data-sidebar="header"]');
+    const content = container.querySelector('[data-sidebar="content"]');
+    const separator = container.querySelector('[role="separator"]');
+
+    expect(header?.getAttribute('class')).toContain('px-2.5');
+    expect(content?.getAttribute('class')).toContain('px-0');
+    expect(separator?.getAttribute('class')).toContain('mx-2.5');
   });
 });


### PR DESCRIPTION
## Summary
- keep the left-sidebar Search row event-driven so it opens the command palette without navigation or shell reload
- normalize the shared shell header search chrome and closed-state spacing so the inline trigger and expanded surface use the same shell treatment
- align sidebar header/footer/content/separator spacing tokens on the same inset grid and cover that alignment with a focused regression test

## Verification
- `pnpm exec vitest run apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx apps/web/tests/unit/dashboard/DashboardNav.test.tsx apps/web/tests/unit/dashboard/DashboardHeader.test.tsx apps/web/tests/unit/sidebar-row-alignment.test.tsx apps/web/tests/unit/app/command-palette-search-guard.test.ts`
- `pnpm exec biome check --write apps/web/components/shell/HeaderSearchSurface.tsx apps/web/components/features/dashboard/organisms/DashboardHeader.tsx apps/web/components/organisms/sidebar/layout.tsx apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx apps/web/tests/unit/sidebar-row-alignment.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm turbo typecheck`
- `git push -u origin codex/jov-2476-shell-search-sidebar-tokens` (pre-push hook ran `biome check .`, `pnpm --filter=@jovie/web run pre-push`, `pnpm run next:proxy-guard`, `pnpm run tailwind:check`, `pnpm run typecheck`, and `pnpm run lint`)

Refs JOV-2476
