### PR TITLE
JOV-2477: Migrate promo downloads list to shared shell table primitives

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/PromoDownloadsTable.test.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/PromoDownloadsTable.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PromoDownloadsTable } from './PromoDownloadsTable';
+
+describe('PromoDownloadsTable', () => {
+  it('renders shared table rows for promo downloads', () => {
+    const onToggleActive = vi.fn();
+    const onDelete = vi.fn();
+
+    render(
+      <PromoDownloadsTable
+        loaded={true}
+        files={[
+          {
+            id: 'download_1',
+            title: 'Radio Edit',
+            fileName: 'radio-edit.mp3',
+            fileMimeType: 'audio/mpeg',
+            fileSizeBytes: 2_048_000,
+            isActive: true,
+            position: 1,
+          },
+          {
+            id: 'download_2',
+            title: 'Instrumental',
+            fileName: 'instrumental.wav',
+            fileMimeType: 'audio/wav',
+            fileSizeBytes: null,
+            isActive: false,
+            position: 2,
+          },
+        ]}
+        onToggleActive={onToggleActive}
+        onDelete={onDelete}
+      />
+    );
+
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'File' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Status' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', { name: 'Actions' })
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Radio Edit')).toBeInTheDocument();
+    expect(screen.getByText('MP3 · 2.0 MB')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Active' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Delete Radio Edit' })
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Instrumental')).toBeInTheDocument();
+    expect(screen.getByText('WAV')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Hidden' })).toBeInTheDocument();
+  });
+
+  it('renders the shared empty state after loading with no files', () => {
+    render(
+      <PromoDownloadsTable
+        loaded={true}
+        files={[]}
+        onToggleActive={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('No Downloads Yet')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Upload audio files to create an email-gated download page for this release.'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/PromoDownloadsTable.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/PromoDownloadsTable.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { Music, Trash2 } from 'lucide-react';
+import {
+  TableCell,
+  TableEmptyState,
+  TableHeaderCell,
+  TableHeaderRow,
+} from '@/components/organisms/table';
+import { cn } from '@/lib/utils';
+
+export interface PromoDownloadFile {
+  readonly id: string;
+  readonly title: string;
+  readonly fileName: string;
+  readonly fileMimeType: string;
+  readonly fileSizeBytes: number | null;
+  readonly isActive: boolean;
+  readonly position: number;
+}
+
+export interface PromoDownloadsTableProps {
+  readonly files: PromoDownloadFile[];
+  readonly loaded: boolean;
+  readonly onToggleActive: (fileId: string, isActive: boolean) => void;
+  readonly onDelete: (fileId: string) => void;
+}
+
+const FILE_TYPE_LABELS: Record<string, string> = {
+  'audio/mpeg': 'MP3',
+  'audio/wav': 'WAV',
+  'audio/flac': 'FLAC',
+  'audio/aiff': 'AIFF',
+  'audio/mp4': 'M4A',
+  'audio/x-m4a': 'M4A',
+};
+
+function formatFileSize(bytes: number | null): string {
+  if (!bytes) return '';
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatExtension(mimeType: string): string {
+  return FILE_TYPE_LABELS[mimeType] ?? 'Audio';
+}
+
+function getFileMeta(file: PromoDownloadFile): string {
+  const fileType = formatExtension(file.fileMimeType);
+  const fileSize = formatFileSize(file.fileSizeBytes);
+  return fileSize ? `${fileType} · ${fileSize}` : fileType;
+}
+
+export function PromoDownloadsTable({
+  files,
+  loaded,
+  onToggleActive,
+  onDelete,
+}: Readonly<PromoDownloadsTableProps>) {
+  if (!loaded && files.length === 0) {
+    return null;
+  }
+
+  if (loaded && files.length === 0) {
+    return (
+      <TableEmptyState
+        icon={<Music className='h-6 w-6' aria-hidden='true' />}
+        title='No Downloads Yet'
+        description='Upload audio files to create an email-gated download page for this release.'
+        className='max-w-none'
+      />
+    );
+  }
+
+  return (
+    <div className='overflow-hidden rounded-xl border border-subtle bg-surface-1'>
+      <table className='min-w-full border-separate border-spacing-0'>
+        <thead>
+          <TableHeaderRow>
+            <TableHeaderCell sticky={false} className='w-[68%] pl-4'>
+              File
+            </TableHeaderCell>
+            <TableHeaderCell sticky={false} className='w-[16%]'>
+              Status
+            </TableHeaderCell>
+            <TableHeaderCell
+              sticky={false}
+              align='right'
+              className='w-[16%] pr-4'
+            >
+              Actions
+            </TableHeaderCell>
+          </TableHeaderRow>
+        </thead>
+        <tbody>
+          {files.map(file => {
+            const fileMeta = getFileMeta(file);
+
+            return (
+              <tr key={file.id} className='group'>
+                <TableCell className='pl-4 pr-2'>
+                  <div className='flex min-w-0 items-center gap-2'>
+                    <span className='truncate font-medium text-primary-token'>
+                      {file.title}
+                    </span>
+                    <span className='shrink-0 text-tertiary-token'>·</span>
+                    <span className='shrink-0 text-2xs text-tertiary-token'>
+                      {fileMeta}
+                    </span>
+                  </div>
+                </TableCell>
+
+                <TableCell className='px-2'>
+                  <button
+                    type='button'
+                    onClick={() => onToggleActive(file.id, !file.isActive)}
+                    aria-pressed={file.isActive}
+                    className={cn(
+                      'inline-flex h-6 items-center rounded-full border px-2 text-2xs font-medium transition-colors',
+                      file.isActive
+                        ? 'border-emerald-500/25 bg-emerald-500/10 text-emerald-500'
+                        : 'border-subtle bg-surface-0 text-tertiary-token'
+                    )}
+                  >
+                    {file.isActive ? 'Active' : 'Hidden'}
+                  </button>
+                </TableCell>
+
+                <TableCell className='pr-4 text-right'>
+                  <button
+                    type='button'
+                    onClick={() => onDelete(file.id)}
+                    className='inline-flex h-6 w-6 items-center justify-center rounded-full text-tertiary-token transition-colors hover:text-red-400'
+                    aria-label={`Delete ${file.title}`}
+                  >
+                    <Trash2 className='h-3.5 w-3.5' aria-hidden='true' />
+                  </button>
+                </TableCell>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
@@ -15,20 +15,14 @@ import { Icon } from '@/components/atoms/Icon';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { cn } from '@/lib/utils';
-
-interface PromoDownloadFile {
-  id: string;
-  title: string;
-  fileName: string;
-  fileMimeType: string;
-  fileSizeBytes: number | null;
-  isActive: boolean;
-  position: number;
-}
+import {
+  type PromoDownloadFile,
+  PromoDownloadsTable,
+} from './PromoDownloadsTable';
 
 const MAX_FILE_SIZE = 150 * 1024 * 1024; // 150MB
 
-const ALLOWED_TYPES = new Set([
+const ALLOWED_TYPES = new Set<PromoDownloadFile['fileMimeType']>([
   'audio/mpeg',
   'audio/wav',
   'audio/flac',
@@ -36,24 +30,6 @@ const ALLOWED_TYPES = new Set([
   'audio/mp4',
   'audio/x-m4a',
 ]);
-
-function formatFileSize(bytes: number | null): string {
-  if (!bytes) return '';
-  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
-
-function formatExtension(mimeType: string): string {
-  const map: Record<string, string> = {
-    'audio/mpeg': 'MP3',
-    'audio/wav': 'WAV',
-    'audio/flac': 'FLAC',
-    'audio/aiff': 'AIFF',
-    'audio/mp4': 'M4A',
-    'audio/x-m4a': 'M4A',
-  };
-  return map[mimeType] ?? 'Audio';
-}
 
 export default function PromoDownloadsPage() {
   const { releaseId } = useParams<{ releaseId: string }>();
@@ -304,71 +280,12 @@ export default function PromoDownloadsPage() {
         </ContentSurfaceCard>
       )}
 
-      {/* File list */}
-      {files.length > 0 ? (
-        <div className='space-y-2'>
-          {files.map(file => (
-            <ContentSurfaceCard
-              key={file.id}
-              surface='nested'
-              className='flex items-center gap-3 px-3 py-2.5'
-            >
-              <div className='min-w-0 flex-1'>
-                <p className='truncate text-sm font-medium text-primary-token'>
-                  {file.title}
-                </p>
-                <p className='text-2xs text-tertiary-token'>
-                  {formatExtension(file.fileMimeType)}
-                  {file.fileSizeBytes
-                    ? ` · ${formatFileSize(file.fileSizeBytes)}`
-                    : ''}
-                </p>
-              </div>
-
-              {/* Active toggle */}
-              <button
-                type='button'
-                onClick={() => handleToggleActive(file.id, !file.isActive)}
-                className={cn(
-                  'inline-flex h-7 shrink-0 items-center rounded-full border px-2.5 text-2xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
-                  file.isActive
-                    ? 'border-success/20 bg-success-subtle text-success hover:bg-success/10'
-                    : 'border-(--linear-app-frame-seam) bg-surface-0 text-tertiary-token hover:bg-surface-1 hover:text-secondary-token'
-                )}
-              >
-                {file.isActive ? 'Active' : 'Hidden'}
-              </button>
-
-              {/* Delete */}
-              <button
-                type='button'
-                onClick={() => handleDelete(file.id)}
-                className='inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-tertiary-token transition-colors hover:bg-error/10 hover:text-error focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
-                aria-label={`Delete ${file.title}`}
-              >
-                <Icon name='Trash2' className='h-4 w-4' aria-hidden='true' />
-              </button>
-            </ContentSurfaceCard>
-          ))}
-        </div>
-      ) : (
-        loaded && (
-          <ContentSurfaceCard className='flex flex-col items-center justify-center px-6 py-8 text-center'>
-            <Icon
-              name='Music'
-              className='h-8 w-8 text-tertiary-token'
-              aria-hidden='true'
-            />
-            <p className='mt-3 text-sm font-medium text-primary-token'>
-              No download files yet.
-            </p>
-            <p className='mt-1 max-w-sm text-xs text-tertiary-token'>
-              Upload audio files to create an email-gated download page for this
-              release.
-            </p>
-          </ContentSurfaceCard>
-        )
-      )}
+      <PromoDownloadsTable
+        files={files}
+        loaded={loaded}
+        onToggleActive={handleToggleActive}
+        onDelete={handleDelete}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replaced the bespoke promo downloads row chrome under `app/(shell)/dashboard/releases/[releaseId]/downloads` with a route-local table component built from the shared table primitives.
- Kept the upload, list, toggle, and delete data flow intact; only the file-list presentation changed.

## Changed files
- `apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx`
- `apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/PromoDownloadsTable.tsx`
- `apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/PromoDownloadsTable.test.tsx`

## Verification
- `pnpm exec biome check --write 'apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx' 'apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/PromoDownloadsTable.tsx' 'apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/PromoDownloadsTable.test.tsx'`
- `pnpm --filter @jovie/web exec vitest run 'app/app/(shell)/dashboard/releases/[releaseId]/downloads/PromoDownloadsTable.test.tsx'`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Local browser check hit the expected Clerk sign-in redirect because auth is not configured in this environment; the protected route itself did not surface a render error.