### PR TITLE
fix(web): normalize lyrics route shell and audio handoff

### DIFF
--- a/apps/web/app/app/(shell)/lyrics/[trackId]/LyricsPageClient.tsx
+++ b/apps/web/app/app/(shell)/lyrics/[trackId]/LyricsPageClient.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useMemo } from 'react';
 import { useTrackAudioPlayer } from '@/components/organisms/release-sidebar/useTrackAudioPlayer';
 import {
   type LyricLine,
   LyricsView,
   type LyricsViewTrack,
 } from '@/components/shell/LyricsView';
-import { APP_ROUTES } from '@/constants/routes';
+import { APP_ROUTES, resolveLyricsReturnRoute } from '@/constants/routes';
 import { isFormElement } from '@/lib/utils/keyboard';
 
 /**
@@ -30,8 +30,14 @@ export function LyricsPageClient({
   readonly trackId: string;
 }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { playbackState, seek } = useTrackAudioPlayer();
   const isActive = playbackState.activeTrackId === trackId;
+  const returnRoute = useMemo(
+    () =>
+      resolveLyricsReturnRoute(searchParams.get('from'), APP_ROUTES.LIBRARY),
+    [searchParams]
+  );
 
   useEffect(() => {
     if (isActive) return;
@@ -46,12 +52,12 @@ export function LyricsPageClient({
       }
 
       event.preventDefault();
-      router.push(APP_ROUTES.LIBRARY);
+      router.push(returnRoute);
     }
 
     globalThis.addEventListener('keydown', handleKeyDown);
     return () => globalThis.removeEventListener('keydown', handleKeyDown);
-  }, [isActive, router]);
+  }, [isActive, returnRoute, router]);
 
   const track = {
     title:

--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -2,8 +2,8 @@
 
 import { Pause, Play, X } from 'lucide-react';
 import Image from 'next/image';
-import { usePathname, useRouter } from 'next/navigation';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { SeekBar } from '@/components/atoms/SeekBar';
 import { TruncatedText } from '@/components/atoms/TruncatedText';
@@ -11,7 +11,11 @@ import { useTrackAudioPlayer } from '@/components/organisms/release-sidebar/useT
 import { AudioBar, type AudioBarTrack } from '@/components/shell/AudioBar';
 import { SidebarBottomNowPlaying } from '@/components/shell/SidebarBottomNowPlaying';
 import { SidebarNowPlaying } from '@/components/shell/SidebarNowPlaying';
-import { APP_ROUTES, buildLyricsRoute } from '@/constants/routes';
+import {
+  APP_ROUTES,
+  buildLyricsRoute,
+  resolveLyricsReturnRoute,
+} from '@/constants/routes';
 import { useAppFlag } from '@/lib/flags/client';
 import { cn } from '@/lib/utils';
 import { formatDuration } from '@/lib/utils/formatDuration';
@@ -42,6 +46,7 @@ export function PersistentAudioBar({
 }: Readonly<PersistentAudioBarProps>) {
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const designV1LyricsEnabled = useAppFlag('DESIGN_V1');
   const { playbackState, toggleTrack, seek, stop, onError } =
     useTrackAudioPlayer();
@@ -49,6 +54,12 @@ export function PersistentAudioBar({
   const [barCollapsed, setBarCollapsed] = useState(false);
   const [waveformOn, setWaveformOn] = useState(true);
   const lastNonLyricsPathRef = useRef<string>(APP_ROUTES.LIBRARY);
+  const currentPathWithSearch = useMemo(() => {
+    if (!pathname) return APP_ROUTES.LIBRARY;
+
+    const query = searchParams.toString();
+    return query ? `${pathname}?${query}` : pathname;
+  }, [pathname, searchParams]);
 
   useEffect(() => {
     return onError(() => {
@@ -66,9 +77,9 @@ export function PersistentAudioBar({
 
   useEffect(() => {
     if (!isLyricsRoutePath(pathname) && pathname) {
-      lastNonLyricsPathRef.current = pathname;
+      lastNonLyricsPathRef.current = currentPathWithSearch;
     }
-  }, [pathname]);
+  }, [currentPathWithSearch, pathname]);
 
   const handleToggle = useCallback(() => {
     if (playbackState.playbackStatus === 'loading') return;
@@ -85,18 +96,33 @@ export function PersistentAudioBar({
   ]);
 
   const handleCloseLyrics = useCallback(() => {
-    router.push(lastNonLyricsPathRef.current);
-  }, [router]);
+    router.push(
+      resolveLyricsReturnRoute(
+        searchParams.get('from'),
+        lastNonLyricsPathRef.current
+      )
+    );
+  }, [router, searchParams]);
 
   const handleOpenLyrics = useCallback(() => {
     if (!playbackState.activeTrackId) return;
-    const lyricsPath = buildLyricsRoute(playbackState.activeTrackId);
-    if (pathname === lyricsPath) {
+    const lyricsBasePath = buildLyricsRoute(playbackState.activeTrackId);
+    if (pathname === lyricsBasePath) {
       handleCloseLyrics();
       return;
     }
-    router.push(lyricsPath);
-  }, [handleCloseLyrics, pathname, playbackState.activeTrackId, router]);
+    router.push(
+      buildLyricsRoute(playbackState.activeTrackId, {
+        from: currentPathWithSearch,
+      })
+    );
+  }, [
+    currentPathWithSearch,
+    handleCloseLyrics,
+    pathname,
+    playbackState.activeTrackId,
+    router,
+  ]);
 
   const activeTrackId = playbackState.activeTrackId;
   const isShellAudioBar = variant === 'shellChatV1';

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -164,8 +164,53 @@ export const APP_ROUTES = {
 
 export type AppRoute = (typeof APP_ROUTES)[keyof typeof APP_ROUTES];
 
-export function buildLyricsRoute(trackId: string): string {
-  return `${APP_ROUTES.LYRICS}/${encodeURIComponent(trackId)}`;
+function normalizeLyricsReturnRoute(
+  candidate: string | null | undefined
+): string | null {
+  if (!candidate) return null;
+
+  try {
+    const url = new URL(candidate, 'https://jovie.local');
+    const route = `${url.pathname}${url.search}`;
+
+    if (!url.pathname.startsWith('/app')) {
+      return null;
+    }
+
+    if (
+      url.pathname === APP_ROUTES.LYRICS ||
+      url.pathname.startsWith(`${APP_ROUTES.LYRICS}/`)
+    ) {
+      return null;
+    }
+
+    return route;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveLyricsReturnRoute(
+  candidate: string | null | undefined,
+  fallback: string = APP_ROUTES.LIBRARY
+): string {
+  return normalizeLyricsReturnRoute(candidate) ?? fallback;
+}
+
+export function buildLyricsRoute(
+  trackId: string,
+  options?: {
+    readonly from?: string | null;
+  }
+): string {
+  const route = `${APP_ROUTES.LYRICS}/${encodeURIComponent(trackId)}`;
+  const returnTo = normalizeLyricsReturnRoute(options?.from);
+
+  if (!returnTo) {
+    return route;
+  }
+
+  return `${route}?from=${encodeURIComponent(returnTo)}`;
 }
 
 export function buildReleaseTasksRoute(releaseId: string): string {

--- a/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
+++ b/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
@@ -6,7 +6,11 @@ import {
   getAudioChromeSnapshot,
   resetAudioChromeSnapshot,
 } from '@/components/organisms/audio-chrome-state';
-import { APP_ROUTES, buildLyricsRoute } from '@/constants/routes';
+import {
+  APP_ROUTES,
+  buildLyricsRoute,
+  resolveLyricsReturnRoute,
+} from '@/constants/routes';
 import { AppFlagProvider } from '@/lib/flags/client';
 import { APP_FLAG_DEFAULTS } from '@/lib/flags/contracts';
 
@@ -16,6 +20,7 @@ const seek = vi.fn();
 const onError = vi.fn().mockReturnValue(() => {});
 const push = vi.fn();
 let pathname = '/app';
+let searchParams = new URLSearchParams();
 
 const basePlaybackState = {
   activeTrackId: null as string | null,
@@ -50,6 +55,7 @@ vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
 
 vi.mock('next/navigation', () => ({
   usePathname: () => pathname,
+  useSearchParams: () => searchParams,
   useRouter: () => ({ push }),
 }));
 
@@ -112,6 +118,7 @@ describe('PersistentAudioBar', () => {
     onError.mockClear().mockReturnValue(() => {});
     push.mockClear();
     pathname = '/app';
+    searchParams = new URLSearchParams();
     mockPlaybackState = { ...basePlaybackState };
     resetAudioChromeSnapshot();
   });
@@ -275,6 +282,8 @@ describe('PersistentAudioBar', () => {
   it('links the shell V1 lyrics button to the active track when DESIGN_V1 is enabled', async () => {
     const user = userEvent.setup();
     setPlaying({ artistName: 'DJ Cool', hasLyrics: true });
+    pathname = '/app/chat/thread-1';
+    searchParams = new URLSearchParams('panel=profile');
 
     render(
       <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, DESIGN_V1: true }}>
@@ -284,7 +293,11 @@ describe('PersistentAudioBar', () => {
 
     await user.click(screen.getByRole('button', { name: 'Lyrics' }));
 
-    expect(push).toHaveBeenCalledWith(buildLyricsRoute('track-1'));
+    expect(push).toHaveBeenCalledWith(
+      buildLyricsRoute('track-1', {
+        from: '/app/chat/thread-1?panel=profile',
+      })
+    );
   });
 
   it('closes the shell V1 lyrics button back to the last non-lyrics route', async () => {
@@ -299,6 +312,9 @@ describe('PersistentAudioBar', () => {
     );
 
     pathname = buildLyricsRoute('track-1');
+    searchParams = new URLSearchParams(
+      `from=${encodeURIComponent(APP_ROUTES.RELEASES)}`
+    );
     rerender(
       <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, DESIGN_V1: true }}>
         <PersistentAudioBar variant='shellChatV1' />
@@ -308,6 +324,32 @@ describe('PersistentAudioBar', () => {
     await user.click(screen.getByRole('button', { name: 'Close lyrics' }));
 
     expect(push).toHaveBeenCalledWith(APP_ROUTES.RELEASES);
+  });
+
+  it('prefers the explicit lyrics return route when closing from the shell V1 player', async () => {
+    const user = userEvent.setup();
+    setPlaying({ artistName: 'DJ Cool', hasLyrics: true });
+    pathname = APP_ROUTES.CHAT;
+
+    const { rerender } = render(
+      <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, DESIGN_V1: true }}>
+        <PersistentAudioBar variant='shellChatV1' />
+      </AppFlagProvider>
+    );
+
+    pathname = buildLyricsRoute('track-1');
+    searchParams = new URLSearchParams(
+      'from=%2Fapp%2Freleases%3Ftab%3Dscheduled'
+    );
+    rerender(
+      <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, DESIGN_V1: true }}>
+        <PersistentAudioBar variant='shellChatV1' />
+      </AppFlagProvider>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Close lyrics' }));
+
+    expect(push).toHaveBeenCalledWith('/app/releases?tab=scheduled');
   });
 
   it('keeps the shell V1 lyrics button hidden when the active track has no lyrics', () => {
@@ -385,6 +427,7 @@ describe('PersistentAudioBar', () => {
 
   it('handles shell V1 active-track keyboard shortcuts', () => {
     setPlaying({ artistName: 'DJ Cool', hasLyrics: true });
+    pathname = APP_ROUTES.CHAT;
 
     render(
       <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, DESIGN_V1: true }}>
@@ -404,7 +447,9 @@ describe('PersistentAudioBar', () => {
     ).toBeInTheDocument();
 
     fireEvent.keyDown(globalThis, { key: 'l' });
-    expect(push).toHaveBeenCalledWith(buildLyricsRoute('track-1'));
+    expect(push).toHaveBeenCalledWith(
+      buildLyricsRoute('track-1', { from: APP_ROUTES.CHAT })
+    );
 
     fireEvent.keyDown(globalThis, { key: '`' });
     expect(screen.getByRole('button', { name: 'Pause' })).toBeInTheDocument();
@@ -421,6 +466,9 @@ describe('PersistentAudioBar', () => {
     );
 
     pathname = buildLyricsRoute('track-1');
+    searchParams = new URLSearchParams(
+      `from=${encodeURIComponent(APP_ROUTES.CHAT)}`
+    );
     rerender(
       <AppFlagProvider initialFlags={{ ...APP_FLAG_DEFAULTS, DESIGN_V1: true }}>
         <PersistentAudioBar variant='shellChatV1' />
@@ -429,6 +477,8 @@ describe('PersistentAudioBar', () => {
 
     fireEvent.keyDown(globalThis, { key: 'Escape' });
 
-    expect(push).toHaveBeenCalledWith(APP_ROUTES.CHAT);
+    expect(push).toHaveBeenCalledWith(
+      resolveLyricsReturnRoute(searchParams.get('from'), APP_ROUTES.CHAT)
+    );
   });
 });

--- a/apps/web/tests/unit/constants/routes.test.ts
+++ b/apps/web/tests/unit/constants/routes.test.ts
@@ -1,9 +1,40 @@
 import { describe, expect, it } from 'vitest';
 import {
   APP_ROUTES,
+  buildLyricsRoute,
   buildReleaseTasksRoute,
   isDemoRoutePath,
+  resolveLyricsReturnRoute,
 } from '@/constants/routes';
+
+describe('buildLyricsRoute', () => {
+  it('builds the canonical lyrics path', () => {
+    expect(buildLyricsRoute('track_1')).toBe('/app/lyrics/track_1');
+  });
+
+  it('encodes track ids and preserves a valid shell return route', () => {
+    expect(
+      buildLyricsRoute('track 1/alt', {
+        from: '/app/chat/thread-1?panel=profile',
+      })
+    ).toBe(
+      '/app/lyrics/track%201%2Falt?from=%2Fapp%2Fchat%2Fthread-1%3Fpanel%3Dprofile'
+    );
+  });
+
+  it('drops invalid or self-referential return routes', () => {
+    expect(
+      buildLyricsRoute('track_1', {
+        from: '/app/lyrics/track_2?from=%2Fapp%2Fchat',
+      })
+    ).toBe('/app/lyrics/track_1');
+    expect(
+      buildLyricsRoute('track_1', {
+        from: 'https://example.com/phish',
+      })
+    ).toBe('/app/lyrics/track_1');
+  });
+});
 
 describe('buildReleaseTasksRoute', () => {
   it('builds the canonical release tasks path', () => {
@@ -15,6 +46,24 @@ describe('buildReleaseTasksRoute', () => {
   it('encodes release ids for path-safe navigation', () => {
     expect(buildReleaseTasksRoute('release 1/alt')).toBe(
       '/app/releases/release%201%2Falt/tasks'
+    );
+  });
+});
+
+describe('resolveLyricsReturnRoute', () => {
+  it('returns a safe in-app fallback when the route is missing or invalid', () => {
+    expect(resolveLyricsReturnRoute(null)).toBe(APP_ROUTES.LIBRARY);
+    expect(resolveLyricsReturnRoute('/app/lyrics/track-1')).toBe(
+      APP_ROUTES.LIBRARY
+    );
+    expect(resolveLyricsReturnRoute('https://example.com/phish')).toBe(
+      APP_ROUTES.LIBRARY
+    );
+  });
+
+  it('preserves valid non-lyrics app routes with search params', () => {
+    expect(resolveLyricsReturnRoute('/app/chat/thread-1?panel=profile')).toBe(
+      '/app/chat/thread-1?panel=profile'
     );
   });
 });

--- a/apps/web/tests/unit/lyrics/LyricsPageClient.test.tsx
+++ b/apps/web/tests/unit/lyrics/LyricsPageClient.test.tsx
@@ -6,6 +6,7 @@ import { APP_ROUTES } from '@/constants/routes';
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   seek: vi.fn(),
+  searchParams: new URLSearchParams(),
   playbackState: {
     activeTrackId: null as string | null,
     trackTitle: null as string | null,
@@ -17,6 +18,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mocks.push }),
+  useSearchParams: () => mocks.searchParams,
 }));
 
 vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
@@ -65,6 +67,7 @@ describe('LyricsPageClient', () => {
   beforeEach(() => {
     mocks.push.mockClear();
     mocks.seek.mockClear();
+    mocks.searchParams = new URLSearchParams();
     mocks.playbackState.activeTrackId = null;
     mocks.playbackState.trackTitle = null;
     mocks.playbackState.artistName = null;
@@ -83,7 +86,23 @@ describe('LyricsPageClient', () => {
     expect(screen.getByTestId('auto-focus')).toHaveTextContent('true');
   });
 
-  it('closes direct lyrics entry to the library on Escape', () => {
+  it('closes direct lyrics entry to the return route on Escape', () => {
+    mocks.searchParams = new URLSearchParams(
+      'from=%2Fapp%2Fchat%2Fthread-1%3Fpanel%3Dprofile'
+    );
+
+    render(<LyricsPageClient {...baseProps} />);
+
+    fireEvent.keyDown(globalThis, { key: 'Escape' });
+
+    expect(mocks.push).toHaveBeenCalledWith('/app/chat/thread-1?panel=profile');
+  });
+
+  it('falls back to the library when the return route is missing or loops back into lyrics', () => {
+    mocks.searchParams = new URLSearchParams(
+      'from=%2Fapp%2Flyrics%2Ftrack-2%3Ffrom%3D%252Fapp%252Fchat'
+    );
+
     render(<LyricsPageClient {...baseProps} />);
 
     fireEvent.keyDown(globalThis, { key: 'Escape' });


### PR DESCRIPTION
## Summary
- add an explicit `from` return-path contract for lyrics navigation so shell handoff stays consistent across route entry and close actions
- preserve the persistent audio player state while routing into and out of lyrics, including `Escape` and the shell player lyrics toggle
- cover the handoff with focused lyrics route, route helper, and persistent audio bar tests

## Changed Paths
- `apps/web/constants/routes.ts`
- `apps/web/app/app/(shell)/lyrics/[trackId]/LyricsPageClient.tsx`
- `apps/web/components/organisms/PersistentAudioBar.tsx`
- `apps/web/tests/unit/constants/routes.test.ts`
- `apps/web/tests/unit/lyrics/LyricsPageClient.test.tsx`
- `apps/web/tests/components/organisms/PersistentAudioBar.test.tsx`

## Verification
- `pnpm --filter @jovie/web run test -- tests/unit/lyrics/LyricsPageClient.test.tsx`
- `pnpm --filter @jovie/web run test -- tests/unit/lyrics/lyrics-page.test.tsx`
- `pnpm --filter @jovie/web run test -- tests/unit/constants/routes.test.ts`
- `pnpm --filter @jovie/web run test -- tests/components/organisms/PersistentAudioBar.test.tsx`
- `pnpm biome check --write apps/web/constants/routes.ts 'apps/web/app/app/(shell)/lyrics/[trackId]/LyricsPageClient.tsx' apps/web/components/organisms/PersistentAudioBar.tsx apps/web/tests/unit/lyrics/LyricsPageClient.test.tsx apps/web/tests/unit/constants/routes.test.ts apps/web/tests/components/organisms/PersistentAudioBar.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- local smoke check on `http://localhost:3000/demo/showcase/shell-lyrics`

## Linear
- JOV-2479