### PR TITLE
feat(chat): normalize thread shell chrome

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -25,14 +25,15 @@ import {
   usePreviewPanelData,
   usePreviewPanelState,
 } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
+import { AppIconButton } from '@/components/atoms/AppIconButton';
 import { LoadingSpinner } from '@/components/atoms/LoadingSpinner';
 import { ChatWorkspaceSurface } from '@/components/jovie/ChatWorkspaceSurface';
 import { JovieChat } from '@/components/jovie/JovieChat';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
-import { DRAWER_HEADER_ICON_BUTTON_CLASSNAME } from '@/components/molecules/drawer-header/DrawerHeaderActions';
 import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
 import { APP_ROUTES } from '@/constants/routes';
 import { useSetHeaderActions } from '@/contexts/HeaderActionsContext';
+import { DASHBOARD_HEADER_ACTION_ICON_BUTTON_CLASS } from '@/features/dashboard/atoms/DashboardHeaderActionButton';
 import { useClipboard } from '@/hooks/useClipboard';
 import { env } from '@/lib/env-client';
 import { useAppFlag } from '@/lib/flags/client';
@@ -50,6 +51,7 @@ import { getHometownFromSettings } from '@/types/db';
 
 interface ChatPageClientProps {
   readonly conversationId?: string;
+  readonly initialConversationTitle?: string | null;
   readonly isFirstSession?: boolean;
 }
 
@@ -89,10 +91,7 @@ export function resetWelcomeChatBootstrapState(
  */
 function ChatTitleBadge({ title }: { readonly title: string }) {
   return (
-    <span
-      className='block max-w-[260px] truncate text-xs font-semibold tracking-[-0.01em] text-primary-token'
-      title={title}
-    >
+    <span className='block max-w-full truncate' title={title}>
       {title}
     </span>
   );
@@ -168,6 +167,7 @@ function ChatProfileFallback({
 
 export function ChatPageClient({
   conversationId,
+  initialConversationTitle = null,
   isFirstSession = false,
 }: ChatPageClientProps) {
   const {
@@ -186,14 +186,14 @@ export function ChatPageClient({
   const { setHeaderBadge, setHeaderActions } = useSetHeaderActions();
   const [autoRetryCount, setAutoRetryCount] = useState(0);
   const [currentThreadTitle, setCurrentThreadTitle] = useState<string | null>(
-    null
+    initialConversationTitle
   );
   // Reset the thread title when the conversation changes so the previous
   // thread's title doesn't leak into a fresh conversation while the new
   // conversation's metadata is loading.
   useEffect(() => {
-    setCurrentThreadTitle(null);
-  }, [conversationId]);
+    setCurrentThreadTitle(initialConversationTitle);
+  }, [conversationId, initialConversationTitle]);
   const [_welcomeChatBootstrapState, setWelcomeChatBootstrapState] =
     useState<WelcomeChatBootstrapState>('idle');
   const welcomeChatBootstrapStateRef =
@@ -351,13 +351,12 @@ export function ChatPageClient({
     return (
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <button
-            type='button'
-            className={DRAWER_HEADER_ICON_BUTTON_CLASSNAME}
-            aria-label='Thread options'
+          <AppIconButton
+            ariaLabel='Thread options'
+            className={DASHBOARD_HEADER_ACTION_ICON_BUTTON_CLASS}
           >
             <Ellipsis aria-hidden='true' className='size-4' />
-          </button>
+          </AppIconButton>
         </DropdownMenuTrigger>
         <DropdownMenuContent align='end'>
           <DropdownMenuItem onClick={handleCopyConversationId}>
@@ -408,17 +407,18 @@ export function ChatPageClient({
   );
 
   // Update the header badge when the conversation title changes
-  const handleTitleChange = useCallback(
-    (title: string | null) => {
-      setCurrentThreadTitle(title);
-      if (title) {
-        setHeaderBadge(<ChatTitleBadge title={title} />);
-      } else {
-        setHeaderBadge(null);
-      }
-    },
-    [setHeaderBadge]
-  );
+  const handleTitleChange = useCallback((title: string | null) => {
+    setCurrentThreadTitle(title);
+  }, []);
+
+  useEffect(() => {
+    if (currentThreadTitle) {
+      setHeaderBadge(<ChatTitleBadge title={currentThreadTitle} />);
+      return;
+    }
+
+    setHeaderBadge(null);
+  }, [currentThreadTitle, setHeaderBadge]);
 
   // Clean up header badge when leaving the chat page
   useEffect(() => {

--- a/apps/web/app/app/(shell)/chat/[id]/page.tsx
+++ b/apps/web/app/app/(shell)/chat/[id]/page.tsx
@@ -31,5 +31,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
  */
 export default async function ChatConversationPage({ params }: Props) {
   const { id } = await params;
-  return <DeferredChatPageClient conversationId={id} />;
+  const initialConversationTitle = await loadChatThreadMetadataTitle(id);
+
+  return (
+    <DeferredChatPageClient
+      conversationId={id}
+      initialConversationTitle={initialConversationTitle}
+    />
+  );
 }

--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -29,12 +29,14 @@ const MOBILE_HEADER_PADDING = 'px-4 pb-2 pt-3';
 
 function MobileHeader({
   currentLabel,
+  breadcrumbSuffix,
   action,
   searchSurface,
   isSearchActive,
   mobileProfileSlot,
 }: {
   readonly currentLabel: string;
+  readonly breadcrumbSuffix?: ReactNode;
   readonly action?: ReactNode;
   readonly searchSurface?: ReactNode;
   readonly isSearchActive: boolean;
@@ -56,7 +58,7 @@ function MobileHeader({
       )}
     >
       <h1 className='text-[17px] font-semibold leading-tight tracking-[-0.018em] text-primary-token'>
-        {currentLabel}
+        {breadcrumbSuffix ?? currentLabel}
       </h1>
       <div className='flex items-center gap-2'>
         {searchSurface ? (
@@ -102,7 +104,7 @@ function BreadcrumbTrail({
           </span>
           <ChevronRight className='size-3 shrink-0 text-quaternary-token/85' />
           {breadcrumbSuffix ? (
-            <div className='min-w-0 truncate text-xs tracking-[-0.01em] text-secondary-token'>
+            <div className='min-w-0 truncate text-xs font-semibold tracking-[-0.01em] text-primary-token'>
               {breadcrumbSuffix}
             </div>
           ) : (
@@ -146,6 +148,7 @@ export function DashboardHeader({
     >
       <MobileHeader
         currentLabel={currentLabel}
+        breadcrumbSuffix={breadcrumbSuffix}
         action={action}
         searchSurface={searchSurface}
         isSearchActive={searchTakesOver}

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -108,12 +108,12 @@ export function SidebarThreadsSection({
 
   return (
     <div className='space-y-1'>
-      <div className='px-3 pt-1 pb-1 flex items-center justify-between'>
-        <span className='text-[9.5px] font-medium uppercase tracking-[0.12em] text-quaternary-token/85'>
+      <div className='flex items-center justify-between px-3 pb-1 pt-1.5'>
+        <span className='text-[11px] font-medium tracking-[-0.01em] text-quaternary-token'>
           Threads
         </span>
         {unreadCount > 0 && (
-          <span className='inline-flex items-center gap-1 text-[9.5px] uppercase tracking-[0.08em] text-quaternary-token'>
+          <span className='inline-flex items-center gap-1 text-[11px] font-medium tracking-[-0.01em] text-quaternary-token'>
             <span className='h-1.5 w-1.5 rounded-full bg-cyan-300/85' />
             {unreadCount}
           </span>
@@ -178,7 +178,7 @@ export function SidebarThreadsSection({
               aria-hidden='true'
               strokeWidth={2.25}
             />
-            <span className='min-w-0 flex-1 truncate'>Start a thread</span>
+            <span className='min-w-0 flex-1 truncate'>New thread</span>
           </button>
         ) : null}
         {visible.map(t => {
@@ -278,7 +278,7 @@ export function SidebarThreadsSection({
         <button
           type='button'
           onClick={() => setExpanded(v => !v)}
-          className='w-full text-left px-3 py-1 text-[10.5px] uppercase tracking-[0.06em] text-quaternary-token hover:text-secondary-token transition-colors duration-subtle ease-out'
+          className='w-full px-3 py-1 text-left text-[11px] font-medium tracking-[-0.01em] text-quaternary-token transition-colors duration-subtle ease-out hover:text-secondary-token'
         >
           {expanded ? 'Show less' : 'View all'}
         </button>

--- a/apps/web/hooks/useAuthRouteConfig.ts
+++ b/apps/web/hooks/useAuthRouteConfig.ts
@@ -24,6 +24,10 @@ export interface AuthRouteConfig {
   showChatUsageIndicator: boolean;
 }
 
+function isChatThreadPath(parts: readonly string[]): boolean {
+  return parts[0] === 'app' && parts[1] === 'chat' && parts.length > 2;
+}
+
 export function getDemoBreadcrumbSegment(pathname: string): string {
   const parts = pathname.split('/').filter(Boolean);
   const demoIndex = parts.indexOf('demo');
@@ -87,7 +91,9 @@ export function useAuthRouteConfig(): AuthRouteConfig {
     const UUID_REGEX =
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     let lastPart = parts[parts.length - 1];
-    if (UUID_REGEX.test(lastPart) && parts.length >= 2) {
+    if (isChatThreadPath(parts)) {
+      lastPart = 'chat';
+    } else if (UUID_REGEX.test(lastPart) && parts.length >= 2) {
       lastPart = parts[parts.length - 2];
     }
 

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -286,7 +286,7 @@ describe('DashboardNav interactions', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    await user.click(screen.getByRole('button', { name: 'Start a thread' }));
+    await user.click(screen.getByRole('button', { name: 'New thread' }));
 
     expect(mockRouterPush).toHaveBeenCalledWith(APP_ROUTES.CHAT);
   });

--- a/apps/web/tests/unit/chat/ChatPageClient.test.tsx
+++ b/apps/web/tests/unit/chat/ChatPageClient.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -235,18 +236,39 @@ describe('ChatPageClient', () => {
     expect(capturedOnTitleChange).toBeDefined();
   });
 
-  it('sets header badge when title changes to non-null', () => {
+  it('seeds the header badge from the server thread title on mount', () => {
+    fastRender(
+      <DashboardDataProvider value={baseDashboardData}>
+        <ChatPageClient
+          conversationId='conv-123'
+          initialConversationTitle='Release Planning Conversation'
+        />
+      </DashboardDataProvider>
+    );
+
+    expect(mockSetHeaderBadge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          title: 'Release Planning Conversation',
+        }),
+      })
+    );
+  });
+
+  it('sets header badge when title changes to non-null', async () => {
     renderChatPage('conv-123');
     expect(capturedOnTitleChange).toBeDefined();
 
     // Simulate title change from the chat hook
     capturedOnTitleChange!('My New Chat Title');
 
-    expect(mockSetHeaderBadge).toHaveBeenCalledWith(
-      expect.objectContaining({
-        props: expect.objectContaining({ title: 'My New Chat Title' }),
-      })
-    );
+    await waitFor(() => {
+      expect(mockSetHeaderBadge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          props: expect.objectContaining({ title: 'My New Chat Title' }),
+        })
+      );
+    });
   });
 
   it('clears header badge when title changes to null', () => {

--- a/apps/web/tests/unit/chat/useAuthRouteConfig.test.tsx
+++ b/apps/web/tests/unit/chat/useAuthRouteConfig.test.tsx
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAuthRouteConfig } from '@/hooks/useAuthRouteConfig';
+
+const { mockUsePathname, mockUseSearchParams } = vi.hoisted(() => ({
+  mockUsePathname: vi.fn(),
+  mockUseSearchParams: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+  useSearchParams: () => mockUseSearchParams(),
+}));
+
+describe('useAuthRouteConfig', () => {
+  beforeEach(() => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams());
+  });
+
+  it('keeps chat thread detail breadcrumbs pinned to the shared chat label', () => {
+    mockUsePathname.mockReturnValue('/app/chat/conv-123');
+
+    const { result } = renderHook(() => useAuthRouteConfig());
+
+    expect(result.current.breadcrumbs).toEqual([
+      {
+        label: 'New thread',
+        href: '/app/chat/conv-123',
+      },
+    ]);
+    expect(result.current.isChatRoute).toBe(true);
+  });
+
+  it('preserves non-chat dynamic-style segments as their own label', () => {
+    mockUsePathname.mockReturnValue('/app/library/thread-123');
+
+    const { result } = renderHook(() => useAuthRouteConfig());
+
+    expect(result.current.breadcrumbs).toEqual([
+      {
+        label: 'Thread 123',
+        href: '/app/library/thread-123',
+      },
+    ]);
+    expect(result.current.section).toBe('library');
+  });
+});

--- a/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
@@ -67,6 +67,23 @@ describe('DashboardHeader', () => {
     ).toBeInTheDocument();
   });
 
+  it('prefers the breadcrumb suffix for the mobile title when present', () => {
+    const { container } = render(
+      <DashboardHeader
+        breadcrumbs={[{ label: 'New thread', href: '/app/chat/conv-123' }]}
+        breadcrumbSuffix={<span>Release planning thread</span>}
+      />
+    );
+
+    const mobileHeader = container.querySelector('.hidden.max-sm\\:flex');
+
+    expect(mobileHeader).not.toBeNull();
+    expect(
+      within(mobileHeader!).getByText('Release planning thread')
+    ).toBeInTheDocument();
+    expect(within(mobileHeader!).queryByText('New thread')).toBeNull();
+  });
+
   it('collapses the breadcrumb when the search surface takes over', () => {
     const { container } = render(
       <DashboardHeader


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2478 -->
## Summary
- align chat thread header chrome with shared app-shell primitives by using the shared header action styling and by surfacing the server-known thread title into the shell on direct detail loads
- normalize dashboard breadcrumb behavior for `/app/chat/[id]` so thread routes use the shared chat label instead of raw ids, including mobile header suffix rendering
- tighten the thread list section typography and labels so it matches the shared shell more closely without changing conversation data, composer behavior, or message rendering

## Changed paths
- `apps/web/app/app/(shell)/chat/ChatPageClient.tsx`
- `apps/web/app/app/(shell)/chat/[id]/page.tsx`
- `apps/web/components/features/dashboard/organisms/DashboardHeader.tsx`
- `apps/web/components/shell/SidebarThreadsSection.tsx`
- `apps/web/hooks/useAuthRouteConfig.ts`
- `apps/web/tests/unit/chat/ChatPageClient.test.tsx`
- `apps/web/tests/unit/chat/useAuthRouteConfig.test.tsx`
- `apps/web/tests/unit/dashboard/DashboardHeader.test.tsx`

## Checks
- `pnpm biome check --write` on touched files
- `pnpm --filter web exec vitest run tests/unit/chat/ChatPageClient.test.tsx tests/unit/chat/useAuthRouteConfig.test.tsx tests/unit/dashboard/DashboardHeader.test.tsx components/shell/SidebarThreadsSection.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- local `/app/chat` QA on desktop and mobile via dev auth bootstrap (`/api/dev/test-auth/enter?persona=creator-ready&redirect=...`)

## Blockers
- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation titles now preload and initialize on page load for faster, consistent header display.

* **Improvements**
  * Improved breadcrumb labeling for chat/thread routes and mobile header suffix behavior.
  * Updated CTA text from "Start a thread" to "New thread".
  * Refined header badge behavior and sidebar/header styling for clearer visual presentation.

* **Tests**
  * Added and updated unit/interaction tests to cover title seeding, breadcrumbs, and CTA text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->