### PR TITLE
feat(chat): refine empty composer and signal cards

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -492,7 +492,7 @@ export function JovieChat({
                   strokeWidth={2.25}
                 />
                 <div>
-                  <p className='text-sm font-semibold tracking-[-0.01em] text-primary-token'>
+                  <p className='text-sm font-semibold text-primary-token'>
                     Drop images to attach
                   </p>
                   <p className='mt-1 text-xs leading-5 text-secondary-token'>
@@ -696,7 +696,7 @@ export function JovieChat({
               >
                 <h1
                   className={cn(
-                    'text-balance text-center text-[2rem] font-semibold leading-[1.1] tracking-[-0.035em] text-primary-token sm:text-[2.5rem] md:text-[3rem]',
+                    'text-balance text-center text-[2rem] font-semibold leading-[1.1] text-primary-token sm:text-[2.5rem] md:text-[3rem]',
                     composerPickerOpen && 'pointer-events-none opacity-0'
                   )}
                   aria-hidden={composerPickerOpen ? 'true' : undefined}
@@ -720,6 +720,7 @@ export function JovieChat({
                   <ChatInput
                     {...chatInputProps}
                     placeholder='Ask Jovie...'
+                    variant='hero'
                     shellChatV1={shellChatV1Enabled}
                     quickActions={starterQuickActions}
                     onQuickActionSelect={handleSuggestedPromptWithJank}

--- a/apps/web/components/jovie/components/ChatAnalyticsCard.tsx
+++ b/apps/web/components/jovie/components/ChatAnalyticsCard.tsx
@@ -21,25 +21,23 @@ export function ChatAnalyticsCard({ result }: ChatAnalyticsCardProps) {
       className='w-full max-w-3xl border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-4'
       data-testid='chat-analytics-card'
     >
-      <div className='flex items-center justify-between gap-3'>
-        <div className='flex items-center gap-2'>
-          <div className='flex h-7 w-7 items-center justify-center rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0'>
-            <Sparkles className='h-3.5 w-3.5 text-secondary-token' />
-          </div>
-          <div>
-            <p className='text-app font-medium text-primary-token'>
-              {result.title}
-            </p>
-            <p className='text-2xs text-tertiary-token'>
-              {result.totalActive} active{' '}
-              {result.totalActive === 1 ? 'signal' : 'signals'}
-            </p>
-          </div>
+      <div className='flex items-start gap-3'>
+        <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] border border-(--linear-app-frame-seam) bg-surface-0'>
+          <Sparkles className='h-3.5 w-3.5 text-secondary-token' />
+        </div>
+        <div className='min-w-0'>
+          <p className='text-app font-medium text-primary-token'>
+            {result.title}
+          </p>
+          <p className='mt-1 text-[12px] leading-5 text-tertiary-token'>
+            {result.totalActive} active{' '}
+            {result.totalActive === 1 ? 'signal' : 'signals'}
+          </p>
         </div>
       </div>
 
       <ul
-        className='mt-3 flex snap-x snap-mandatory gap-2.5 overflow-x-auto overflow-y-hidden overscroll-x-contain pb-1 [-ms-overflow-style:none] [scrollbar-width:none] lg:grid lg:grid-cols-3 lg:overflow-visible lg:pb-0 [&::-webkit-scrollbar]:hidden'
+        className='mt-3 flex snap-x snap-mandatory gap-2.5 overflow-x-auto overflow-y-hidden overscroll-x-contain pb-1 [-ms-overflow-style:none] [scrollbar-width:none] md:grid md:grid-cols-3 md:overflow-visible md:pb-0 [&::-webkit-scrollbar]:hidden'
         data-testid='chat-analytics-signal-carousel'
         aria-label='Top signal cards'
       >
@@ -48,23 +46,23 @@ export function ChatAnalyticsCard({ result }: ChatAnalyticsCardProps) {
             key={insight.id}
             className={cn(
               LINEAR_SURFACE.drawerCardSm,
-              'flex min-h-[142px] min-w-[min(18rem,82vw)] snap-start flex-col justify-between p-3.5 lg:min-w-0'
+              'flex min-h-[148px] min-w-[min(19.5rem,82vw)] snap-start flex-col justify-between p-4 md:min-w-0'
             )}
             data-testid='chat-analytics-signal-card'
           >
-            <div className='flex items-center justify-between gap-3'>
+            <div className='flex items-center gap-2'>
               <span className='flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0'>
                 <InsightCategoryIcon category={insight.category} size='sm' />
               </span>
-              <span className='rounded-full border border-(--linear-app-frame-seam) bg-surface-0 px-2 py-0.5 text-[10.5px] font-medium capitalize leading-4 text-tertiary-token'>
-                {insight.priority}
+              <span className='text-[11px] font-medium capitalize leading-4 text-tertiary-token'>
+                {insight.category.replaceAll('_', ' ')}
               </span>
             </div>
             <div className='mt-5 min-w-0'>
-              <p className='text-pretty text-[15px] font-semibold leading-snug tracking-[-0.015em] text-primary-token'>
+              <p className='text-pretty text-[15px] font-semibold leading-[1.28] text-primary-token'>
                 {insight.title}
               </p>
-              <p className='mt-1.5 line-clamp-2 text-[12.5px] leading-5 text-secondary-token'>
+              <p className='mt-2 line-clamp-2 text-[12.5px] leading-5 text-secondary-token'>
                 {insight.actionSuggestion ?? insight.description}
               </p>
             </div>

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -50,7 +50,7 @@ export interface ChatInputProps {
   readonly isLoading: boolean;
   readonly isSubmitting: boolean;
   readonly placeholder?: string;
-  readonly variant?: 'default' | 'compact';
+  readonly variant?: 'default' | 'compact' | 'hero';
   readonly onImageAttach?: () => void;
   readonly isImageProcessing?: boolean;
   readonly pendingImages?: PendingImage[];
@@ -95,10 +95,18 @@ interface SurfaceGeometry {
   readonly borderRadius: number;
 }
 
-function geometryFor(mode: SurfaceMode, stacked: boolean): SurfaceGeometry {
+function geometryFor(
+  mode: SurfaceMode,
+  stacked: boolean,
+  variant: NonNullable<ChatInputProps['variant']>
+): SurfaceGeometry {
   const width = '100%';
-  const maxWidth = 'min(calc(100vw - 32px), 720px)';
+  const isHero = variant === 'hero';
+  const maxWidth = isHero
+    ? 'min(calc(100vw - 32px), 840px)'
+    : 'min(calc(100vw - 32px), 720px)';
   if (stacked) return { width, maxWidth, borderRadius: 28 };
+  if (isHero && mode === 'empty') return { width, maxWidth, borderRadius: 32 };
   if (mode === 'entity') return { width, maxWidth, borderRadius: 24 };
   return { width, maxWidth, borderRadius: 28 };
 }
@@ -179,6 +187,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
     }, []);
 
     const isCompact = variant === 'compact';
+    const isHero = variant === 'hero';
     const isStacked = isCompact || isViewportNarrow;
     const maxHeight = 168;
     const minHeight = 24;
@@ -373,7 +382,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
     )
       surfaceMode = 'typing';
 
-    const geometry = geometryFor(surfaceMode, isStacked);
+    const geometry = geometryFor(surfaceMode, isStacked, variant);
     const showInlinePicker = picker.state.status === 'root';
     const showEntitySurface = picker.state.status === 'entity';
     const dockClass =
@@ -443,6 +452,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
             data-testid='chat-composer-surface'
             data-surface-mode={surfaceMode}
             data-compact={isCompact ? 'true' : 'false'}
+            data-variant={variant}
             animate={
               reducedMotion
                 ? undefined
@@ -536,6 +546,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                       pickerListId={pickerListId}
                       pickerActiveRowId={pickerActiveRowId}
                       attachDisabledForPicker={isPickerOpen}
+                      isHero={isHero}
                     />
                   </div>
                 </div>
@@ -618,6 +629,7 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
                   pickerListId={pickerListId}
                   pickerActiveRowId={pickerActiveRowId}
                   attachDisabledForPicker={isPickerOpen}
+                  isHero={isHero}
                 />
               </>
             )}
@@ -688,6 +700,7 @@ interface InputRowProps {
   readonly pickerActiveRowId: string | null;
   /** Disable the attach dropdown trigger while the picker owns the keyboard. */
   readonly attachDisabledForPicker: boolean;
+  readonly isHero: boolean;
 }
 
 function InputRow({
@@ -728,6 +741,7 @@ function InputRow({
   pickerListId,
   pickerActiveRowId,
   attachDisabledForPicker,
+  isHero,
 }: InputRowProps) {
   return (
     <div className={cn(hasBorderTop && 'border-t border-white/[0.065]')}>
@@ -743,13 +757,19 @@ function InputRow({
       <div
         ref={containerRef}
         className={cn(
-          'relative grid min-h-[88px] grid-rows-[minmax(24px,auto)_40px] gap-2 px-3 py-2.5'
+          'relative grid gap-2',
+          isHero
+            ? 'min-h-[116px] grid-rows-[minmax(32px,auto)_44px] px-4 py-3'
+            : 'min-h-[88px] grid-rows-[minmax(24px,auto)_40px] px-3 py-2.5'
         )}
       >
         <div ref={hiddenDivRef} style={HIDDEN_DIV_STYLES} aria-hidden />
         <div
           data-testid='chat-input-inline-field'
-          className='flex min-h-7 w-full min-w-0 flex-wrap items-start gap-x-1.5 gap-y-1.5 px-1 pt-0.5'
+          className={cn(
+            'flex w-full min-w-0 flex-wrap items-start gap-x-1.5 gap-y-1.5',
+            isHero ? 'min-h-8 px-2 pt-1' : 'min-h-7 px-1 pt-0.5'
+          )}
         >
           {chips && chips.length > 0 && onRemoveChipAt ? (
             <ChipTray chips={chips} onRemoveAt={onRemoveChipAt} />
@@ -764,8 +784,10 @@ function InputRow({
             animate={reducedMotion ? undefined : { height: measuredHeight }}
             transition={reducedMotion ? undefined : SPRING_HEIGHT}
             className={cn(
-              'min-h-6 min-w-[min(13rem,100%)] flex-[1_1_13rem] resize-none bg-transparent',
-              'px-1 py-[1px] text-[16px] leading-6 text-white/92 placeholder:text-quaternary-token',
+              'min-w-[min(13rem,100%)] flex-[1_1_13rem] resize-none bg-transparent placeholder:text-quaternary-token',
+              isHero
+                ? 'min-h-8 px-2 py-0.5 text-[18px] font-[450] leading-7 text-primary-token sm:text-[19px]'
+                : 'min-h-6 px-1 py-[1px] text-[16px] leading-6 text-white/92',
               // Remove the browser's default focus outline. The surrounding
               // surface provides the focus affordance (border glow via
               // isFocused→isExpanded). Using focus-visible:outline-none keeps
@@ -802,7 +824,12 @@ function InputRow({
           />
         </div>
 
-        <div className='flex min-h-10 items-center justify-between gap-2'>
+        <div
+          className={cn(
+            'flex items-center justify-between gap-2',
+            isHero ? 'min-h-11' : 'min-h-10'
+          )}
+        >
           <div className='flex min-w-0 items-center gap-2'>
             {hasAttachButton && onImageAttach ? (
               <ComposerAttachButton

--- a/apps/web/components/jovie/components/SuggestedPrompts.tsx
+++ b/apps/web/components/jovie/components/SuggestedPrompts.tsx
@@ -296,11 +296,19 @@ export function SuggestedPrompts({
       inert={dimmed}
     >
       <div
-        className={cn(CHAT_PROMPT_RAIL_SCROLL_CLASS, 'overscroll-x-contain')}
+        className={cn(
+          CHAT_PROMPT_RAIL_SCROLL_CLASS,
+          'overscroll-x-contain px-1 sm:px-0'
+        )}
         style={CHAT_PROMPT_RAIL_MASK_STYLE}
         data-testid='suggested-prompts-rail'
       >
-        <div className={cn(CHAT_PROMPT_RAIL_CLASS, 'snap-x snap-mandatory')}>
+        <div
+          className={cn(
+            CHAT_PROMPT_RAIL_CLASS,
+            'snap-x snap-mandatory whitespace-nowrap'
+          )}
+        >
           {promptSuggestionsWithCapabilities.map(suggestion => (
             <SuggestionPill
               key={suggestion.label}

--- a/apps/web/tests/unit/chat/ChatInput.test.tsx
+++ b/apps/web/tests/unit/chat/ChatInput.test.tsx
@@ -246,6 +246,32 @@ describe('ChatInput', () => {
     }
   });
 
+  it('renders the larger hero composer geometry for the empty state', () => {
+    fastRender(
+      withProviders(
+        <ChatInput
+          {...baseProps}
+          value=''
+          onImageAttach={vi.fn()}
+          variant='hero'
+        />
+      )
+    );
+
+    const surface = screen.getByTestId('chat-composer-surface');
+    expect(surface.getAttribute('data-variant')).toBe('hero');
+    expect(surface.style.maxWidth).toBe('min(calc(100vw - 32px), 840px)');
+
+    const inlineField = screen.getByTestId('chat-input-inline-field');
+    expect(inlineField.className).toContain('min-h-8');
+
+    const textarea = screen.getByRole('textbox', {
+      name: /chat message input/i,
+    });
+    expect(textarea.className).toContain('text-[18px]');
+    expect(textarea.className).toContain('leading-7');
+  });
+
   it('keeps a quiet disabled dictation control when speech input is unavailable', () => {
     fastRender(withProviders(<ChatInput {...baseProps} />));
 

--- a/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
@@ -92,12 +92,18 @@ describe('ChatMessage analytics cards', () => {
     fastRender(<ChatMessage {...messageProps} />);
 
     expect(screen.getByTestId('chat-analytics-card')).toBeTruthy();
-    expect(screen.getByTestId('chat-analytics-signal-carousel')).toBeTruthy();
+    const carousel = screen.getByTestId('chat-analytics-signal-carousel');
+    expect(carousel).toBeTruthy();
+    expect(carousel.className).toContain('md:grid-cols-3');
     expect(screen.getByTestId('chat-analytics-signal-card')).toBeTruthy();
     expect(screen.getByText('Top signals')).toBeTruthy();
     expect(
       screen.getByText('Subscribers are picking up in Chicago')
     ).toBeTruthy();
+    expect(
+      screen.getByText('Send your next release update to that segment.')
+    ).toBeTruthy();
+    expect(screen.queryByText('high')).toBeNull();
   });
 
   it('renders a compact error row for unknown failed tools', () => {

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -1,3 +1,4 @@
+import { screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { JovieChat } from '@/components/jovie/JovieChat';
@@ -119,13 +120,16 @@ vi.mock('@/components/jovie/components', async () => {
     ChatInput: ({
       placeholder,
       quickActions,
+      variant,
     }: {
       readonly placeholder?: string;
       readonly quickActions?: readonly { readonly label: string }[];
+      readonly variant?: string;
     }) => (
       <div
         data-placeholder={placeholder}
         data-quick-actions={quickActions?.map(action => action.label).join('|')}
+        data-variant={variant}
         data-testid='chat-input'
       />
     ),
@@ -175,6 +179,7 @@ describe('JovieChat empty state', () => {
     expect(getByTestId('chat-input').getAttribute('data-placeholder')).toBe(
       'Ask Jovie...'
     );
+    expect(getByTestId('chat-input').getAttribute('data-variant')).toBe('hero');
     expect(getByTestId('chat-input').getAttribute('data-quick-actions')).toBe(
       'Plan a release|Generate album art|Pitch playlists|Send feedback'
     );
@@ -273,5 +278,11 @@ describe('JovieChat empty state', () => {
     expect(queryByText('What are we working on?')).toBeNull();
     expect(queryByText('Welcome back')).toBeNull();
     expect(getAllByTestId('chat-message')).toHaveLength(2);
+    expect(
+      screen.getByTestId('chat-input').getAttribute('data-placeholder')
+    ).toBe('Ask a follow-up...');
+    expect(screen.getByTestId('chat-input').getAttribute('data-variant')).toBe(
+      'compact'
+    );
   });
 });

--- a/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
+++ b/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
@@ -37,6 +37,7 @@ describe('SuggestedPrompts', () => {
     const row = rail.firstElementChild;
     expect(row?.className).toContain('snap-x');
     expect(row?.className).not.toContain('flex-wrap');
+    expect(row?.className).toContain('whitespace-nowrap');
   });
 
   it('renders a grid layout when requested', () => {


### PR DESCRIPTION
## Summary
- Adds a `hero` chat composer variant for the empty thread state so the first input is centered, larger, and pill-shaped.
- Keeps the compact composer after a thread has messages.
- Keeps starter prompt pills under the empty composer as a single manual-scroll rail and hides them while typing or while the slash/entity picker is open.
- Simplifies top signal cards into responsive mentor-style bento cards: horizontal carousel below medium widths, 3-up grid when room allows.

## Verification
- `pnpm --filter @jovie/web run test -- tests/unit/chat/JovieChat.empty-state.test.tsx tests/unit/chat/ChatInput.test.tsx tests/unit/chat/SuggestedPrompts.test.tsx tests/unit/chat/ChatMessage.analytics-card.test.tsx` passed: 32 tests.
- `pnpm biome check --write apps/web/components/jovie/JovieChat.tsx apps/web/components/jovie/components/ChatInput.tsx apps/web/components/jovie/components/SuggestedPrompts.tsx apps/web/components/jovie/components/ChatAnalyticsCard.tsx apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx apps/web/tests/unit/chat/ChatInput.test.tsx apps/web/tests/unit/chat/SuggestedPrompts.test.tsx apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx` passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- Pre-push passed: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint.

## Visual QA
- Local dev auth route: `/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/chat`.
- Desktop 1440x900, tablet 834x1112, mobile 390x844: `data-variant="hero"`, `data-surface-mode="empty"`, starter prompt rail present, no horizontal overflow.
- Same viewports while typing: `data-surface-mode="typing"`, starter prompt rail absent, no horizontal overflow.

Linear: JOV-2480
