### PR TITLE
JOV-2485: Remove release shell null fallbacks

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
@@ -33,6 +33,7 @@ import { useImportPolling } from './hooks/useImportPolling';
 import { useReleaseTablePreferences } from './hooks/useReleaseTablePreferences';
 import { NewReleaseHeaderAction } from './NewReleaseHeaderAction';
 import { ReleaseStateBanners } from './ReleaseStateBanners';
+import { ReleasesEmptyState } from './ReleasesEmptyState';
 import { ReleaseTable } from './ReleaseTable';
 import {
   DEFAULT_RELEASE_FILTERS,
@@ -49,7 +50,6 @@ import { useReleaseDeletion } from './release-deletion';
 import {
   AddReleaseSidebar,
   ReleaseSidebar,
-  ReleasesEmptyState,
   TrackSidebar,
 } from './release-lazy-components';
 import { usePostCreateReleasePlan } from './release-plan-generation';
@@ -634,11 +634,9 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
         />
         {showEmptyState && (
           <PageShell className='mt-2.5' data-testid='release-table-shell'>
-            <Suspense fallback={null}>
-              <ReleasesEmptyState
-                onConnectSpotify={() => setSpotifySearchOpen(true)}
-              />
-            </Suspense>
+            <ReleasesEmptyState
+              onConnectSpotify={() => setSpotifySearchOpen(true)}
+            />
           </PageShell>
         )}
 

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseStateBanners.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseStateBanners.tsx
@@ -1,26 +1,10 @@
 'use client';
 
-import { lazy, Suspense } from 'react';
 import type { ReleaseViewModel } from '@/lib/discography/types';
+import { AppleMusicSyncBanner } from './AppleMusicSyncBanner';
+import { ImportProgressBanner } from './ImportProgressBanner';
+import { SmartLinkGateBanner } from './SmartLinkGateBanner';
 import { SMART_LINK_SOFT_CAP } from './smart-link-gating';
-
-const ImportProgressBanner = lazy(() =>
-  import('./ImportProgressBanner').then(m => ({
-    default: m.ImportProgressBanner,
-  }))
-);
-
-const AppleMusicSyncBanner = lazy(() =>
-  import('./AppleMusicSyncBanner').then(m => ({
-    default: m.AppleMusicSyncBanner,
-  }))
-);
-
-const SmartLinkGateBanner = lazy(() =>
-  import('./SmartLinkGateBanner').then(m => ({
-    default: m.SmartLinkGateBanner,
-  }))
-);
 
 interface ReleaseStateBannersProps {
   readonly rows: ReleaseViewModel[];
@@ -64,14 +48,12 @@ export function ReleaseStateBanners({
     <>
       {showImportProgress && (
         <div className='mx-3 lg:mx-4 mt-3'>
-          <Suspense fallback={null}>
-            <ImportProgressBanner
-              artistName={artistName}
-              importedCount={importedCount}
-              totalCount={totalCount}
-              visible={showImportProgress}
-            />
-          </Suspense>
+          <ImportProgressBanner
+            artistName={artistName}
+            importedCount={importedCount}
+            totalCount={totalCount}
+            visible={showImportProgress}
+          />
         </div>
       )}
 
@@ -79,39 +61,33 @@ export function ReleaseStateBanners({
         firstProfileId &&
         !isAppleMusicConnected &&
         !isImporting && (
-          <Suspense fallback={null}>
-            <AppleMusicSyncBanner
-              profileId={firstProfileId}
-              spotifyConnected={isSpotifyConnected}
-              releases={rows}
-              onMatchStatusChange={onAppleMusicMatchStatusChange}
-              className='mx-3 lg:mx-4 mt-3'
-            />
-          </Suspense>
+          <AppleMusicSyncBanner
+            profileId={firstProfileId}
+            spotifyConnected={isSpotifyConnected}
+            releases={rows}
+            onMatchStatusChange={onAppleMusicMatchStatusChange}
+            className='mx-3 lg:mx-4 mt-3'
+          />
         )}
 
       {showReleasesTable && !isPro && releasedCount > SMART_LINK_SOFT_CAP && (
-        <Suspense fallback={null}>
-          <SmartLinkGateBanner
-            mode='soft-cap'
-            releasedCount={releasedCount}
-            softCap={SMART_LINK_SOFT_CAP}
-            className='mx-3 lg:mx-4 mt-3'
-          />
-        </Suspense>
+        <SmartLinkGateBanner
+          mode='soft-cap'
+          releasedCount={releasedCount}
+          softCap={SMART_LINK_SOFT_CAP}
+          className='mx-3 lg:mx-4 mt-3'
+        />
       )}
 
       {showReleasesTable &&
         !isPro &&
         !canAccessFutureReleases &&
         unreleasedCount > 0 && (
-          <Suspense fallback={null}>
-            <SmartLinkGateBanner
-              mode='unreleased'
-              unreleasedCount={unreleasedCount}
-              className='mx-3 lg:mx-4 mt-3'
-            />
-          </Suspense>
+          <SmartLinkGateBanner
+            mode='unreleased'
+            unreleasedCount={unreleasedCount}
+            className='mx-3 lg:mx-4 mt-3'
+          />
         )}
     </>
   );


### PR DESCRIPTION
## Summary
- remove lazy null fallbacks from release state banners
- render the release empty state directly inside the shell frame
- keep heavy release sidebars and workflow dialogs lazy-loaded with real fallbacks

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseStateBanners.tsx apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/ReleaseProviderMatrix.test.tsx tests/components/release-provider-matrix/ReleasesEmptyState.test.tsx tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`

Linear: JOV-2485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized component loading behavior by converting lazy-loaded components to direct imports, reducing asynchronous rendering overhead in the release provider and state banner sections. This streamlines the initialization flow while maintaining all existing functionality and UI behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->