### PR TITLE
JOV-2487: Remove root app shell null fallback

### DIFF
--- a/apps/web/app/app/(shell)/page.tsx
+++ b/apps/web/app/app/(shell)/page.tsx
@@ -1,5 +1,4 @@
 import type { Metadata } from 'next';
-import { Suspense } from 'react';
 import { OnboardingInterviewModal } from '@/components/onboarding/OnboardingInterviewModal';
 // Must render the same chat UI as /app/chat — see AGENTS.md guardrail #16
 import { HydrateClient } from '@/lib/queries/HydrateClient';
@@ -16,13 +15,26 @@ export function generateMetadata(): Metadata {
   };
 }
 
-export default async function AppRootPage() {
+type AppRootPageProps = Readonly<{
+  readonly searchParams?: Promise<
+    Record<string, string | string[] | undefined>
+  >;
+}>;
+
+function readFirstParam(
+  value: string | string[] | undefined
+): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function AppRootPage({ searchParams }: AppRootPageProps) {
+  const params = (await searchParams) ?? {};
+  const interviewRequested = readFirstParam(params.interview) === '1';
+
   return (
     <HydrateClient state={getDehydratedState()}>
       <DeferredChatPageClient />
-      <Suspense fallback={null}>
-        <OnboardingInterviewModal />
-      </Suspense>
+      <OnboardingInterviewModal initialRequested={interviewRequested} />
     </HydrateClient>
   );
 }

--- a/apps/web/app/app/(shell)/page.tsx
+++ b/apps/web/app/app/(shell)/page.tsx
@@ -27,7 +27,9 @@ function readFirstParam(
   return Array.isArray(value) ? value[0] : value;
 }
 
-export default async function AppRootPage({ searchParams }: AppRootPageProps) {
+export default async function AppRootPage({
+  searchParams,
+}: AppRootPageProps = {}) {
   const params = (await searchParams) ?? {};
   const interviewRequested = readFirstParam(params.interview) === '1';
 

--- a/apps/web/components/onboarding/OnboardingInterviewModal.tsx
+++ b/apps/web/components/onboarding/OnboardingInterviewModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from '@jovie/ui';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   type InterviewQuestion,
@@ -43,16 +43,14 @@ function toTranscript(draft: DraftEntry[]) {
 }
 
 interface OnboardingInterviewModalProps {
-  readonly paramKey?: string;
+  readonly initialRequested?: boolean;
 }
 
 export function OnboardingInterviewModal({
-  paramKey = 'interview',
+  initialRequested = false,
 }: OnboardingInterviewModalProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const isRequested = searchParams.get(paramKey) === '1';
 
   const dialogRef = useRef<HTMLDialogElement>(null);
   const [open, setOpen] = useState(false);
@@ -64,7 +62,7 @@ export function OnboardingInterviewModal({
   // submitted in this tab. Immediately strip the param so refresh/back
   // doesn't resurrect the modal.
   useEffect(() => {
-    if (!isRequested) return;
+    if (!initialRequested) return;
 
     const alreadySubmitted =
       globalThis.window !== undefined &&
@@ -77,7 +75,7 @@ export function OnboardingInterviewModal({
 
     setOpen(true);
     router.replace(pathname);
-  }, [isRequested, pathname, router]);
+  }, [initialRequested, pathname, router]);
 
   useEffect(() => {
     const dialog = dialogRef.current;


### PR DESCRIPTION
## Summary
- move `/app?interview=1` detection from the client modal to the server shell page
- remove the root page `Suspense fallback={null}` edge
- preserve the existing modal behavior that opens once and strips the query param

## Verification
- `rg -n "fallback=\\{null\\}|useSearchParams" apps/web/app/app/(shell)/page.tsx apps/web/components/onboarding/OnboardingInterviewModal.tsx || true`
- `pnpm biome check --write apps/web/app/app/(shell)/page.tsx apps/web/components/onboarding/OnboardingInterviewModal.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- commit hook staged lint/a11y/typecheck
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`

Linear: JOV-2487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding interview modal behavior is now controlled through URL query parameters, enabling seamless navigation and modal state management via shareable links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->