### PR TITLE
JOV-2486: Migrate admin investor tables to shared primitives

### DIFF
--- a/apps/web/app/app/(shell)/admin/investors/_components/InvestorTablePrimitives.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/_components/InvestorTablePrimitives.tsx
@@ -1,4 +1,13 @@
 import type { ReactNode } from 'react';
+import {
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableHeaderRow,
+  TableRoot,
+  TableRow,
+} from '@/components/organisms/table';
 import { cn } from '@/lib/utils';
 
 export function InvestorTable({
@@ -10,9 +19,9 @@ export function InvestorTable({
 }>) {
   return (
     <div className='overflow-x-auto'>
-      <table className={cn('w-full border-collapse text-app', minWidth)}>
+      <TableRoot className={cn('w-full border-collapse text-app', minWidth)}>
         {children}
-      </table>
+      </TableRoot>
     </div>
   );
 }
@@ -20,16 +29,22 @@ export function InvestorTable({
 export function InvestorTableHead({
   children,
 }: Readonly<{ children: ReactNode }>) {
-  return <thead className='bg-surface-0'>{children}</thead>;
+  return <TableHead className='bg-surface-0'>{children}</TableHead>;
+}
+
+export function InvestorTableBody({
+  children,
+}: Readonly<{ children: ReactNode }>) {
+  return <TableBody>{children}</TableBody>;
 }
 
 export function InvestorTableHeaderRow({
   children,
 }: Readonly<{ children: ReactNode }>) {
   return (
-    <tr className='border-b border-subtle text-left text-2xs font-caption text-secondary-token'>
+    <TableHeaderRow className='border-b border-subtle text-left text-2xs font-caption text-secondary-token'>
       {children}
-    </tr>
+    </TableHeaderRow>
   );
 }
 
@@ -43,15 +58,13 @@ export function InvestorTableHeaderCell({
   className?: string;
 }>) {
   return (
-    <th
-      className={cn(
-        'px-4 py-2.5 font-medium',
-        align === 'right' && 'text-right',
-        className
-      )}
+    <TableHeaderCell
+      align={align}
+      sticky={false}
+      className={cn('px-4 py-2.5 font-medium', className)}
     >
       {children}
-    </th>
+    </TableHeaderCell>
   );
 }
 
@@ -59,9 +72,9 @@ export function InvestorTableRow({
   children,
 }: Readonly<{ children: ReactNode }>) {
   return (
-    <tr className='border-b border-subtle bg-transparent transition-colors duration-subtle hover:bg-surface-0'>
+    <TableRow className='border-b border-subtle bg-transparent transition-colors duration-subtle hover:bg-surface-0'>
       {children}
-    </tr>
+    </TableRow>
   );
 }
 
@@ -75,14 +88,11 @@ export function InvestorTableCell({
   className?: string;
 }>) {
   return (
-    <td
-      className={cn(
-        'px-4 py-3 align-middle',
-        align === 'right' && 'text-right',
-        className
-      )}
+    <TableCell
+      align={align}
+      className={cn('px-4 py-3 align-middle', className)}
     >
       {children}
-    </td>
+    </TableCell>
   );
 }

--- a/apps/web/app/app/(shell)/admin/investors/links/InvestorLinksManager.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/links/InvestorLinksManager.tsx
@@ -31,6 +31,7 @@ import { BASE_URL } from '@/constants/app';
 import { APP_ROUTES } from '@/constants/routes';
 import {
   InvestorTable,
+  InvestorTableBody,
   InvestorTableCell,
   InvestorTableHead,
   InvestorTableHeaderCell,
@@ -593,7 +594,7 @@ export function InvestorLinksManager() {
                 </InvestorTableHeaderCell>
               </InvestorTableHeaderRow>
             </InvestorTableHead>
-            <tbody>
+            <InvestorTableBody>
               {links.map(link => (
                 <InvestorTableRow key={link.id}>
                   <InvestorTableCell>
@@ -631,7 +632,7 @@ export function InvestorLinksManager() {
                   </InvestorTableCell>
                 </InvestorTableRow>
               ))}
-            </tbody>
+            </InvestorTableBody>
           </InvestorTable>
         )}
       </ContentSurfaceCard>

--- a/apps/web/app/app/(shell)/admin/investors/page.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/page.tsx
@@ -18,6 +18,7 @@ import { APP_ROUTES } from '@/constants/routes';
 import { cn } from '@/lib/utils';
 import {
   InvestorTable,
+  InvestorTableBody,
   InvestorTableCell,
   InvestorTableHead,
   InvestorTableHeaderCell,
@@ -210,7 +211,7 @@ async function InvestorPipelineTable() {
             </InvestorTableHeaderCell>
           </InvestorTableHeaderRow>
         </InvestorTableHead>
-        <tbody>
+        <InvestorTableBody>
           {links.map(link => (
             <InvestorTableRow key={link.id}>
               <InvestorTableCell className='w-[200px]'>
@@ -243,7 +244,7 @@ async function InvestorPipelineTable() {
               </InvestorTableCell>
             </InvestorTableRow>
           ))}
-        </tbody>
+        </InvestorTableBody>
       </InvestorTable>
     </ContentSurfaceCard>
   );

--- a/apps/web/components/organisms/table/index.ts
+++ b/apps/web/components/organisms/table/index.ts
@@ -159,6 +159,12 @@ export {
 export type { PageToolbarSearchFormProps } from './molecules/PageToolbarSearchForm';
 export { PageToolbarSearchForm } from './molecules/PageToolbarSearchForm';
 export { ResponsiveActionsCell } from './molecules/ResponsiveActionsCell';
+export {
+  TableBody,
+  TableHead,
+  TableRoot,
+  TableRow,
+} from './molecules/SemanticTable';
 export { SocialLinksCell } from './molecules/SocialLinksCell';
 export type { BulkAction } from './molecules/TableBulkActionsToolbar';
 export { TableBulkActionsToolbar } from './molecules/TableBulkActionsToolbar';

--- a/apps/web/components/organisms/table/molecules/SemanticTable.tsx
+++ b/apps/web/components/organisms/table/molecules/SemanticTable.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export function TableRoot({
+  children,
+  className,
+}: Readonly<{
+  children: ReactNode;
+  className?: string;
+}>) {
+  return <table className={className}>{children}</table>;
+}
+
+export function TableHead({
+  children,
+  className,
+}: Readonly<{
+  children: ReactNode;
+  className?: string;
+}>) {
+  return <thead className={className}>{children}</thead>;
+}
+
+export function TableBody({
+  children,
+  className,
+}: Readonly<{
+  children: ReactNode;
+  className?: string;
+}>) {
+  return <tbody className={className}>{children}</tbody>;
+}
+
+export function TableRow({
+  children,
+  className,
+}: Readonly<{
+  children: ReactNode;
+  className?: string;
+}>) {
+  return <tr className={cn(className)}>{children}</tr>;
+}


### PR DESCRIPTION
## Summary
- replace remaining local investor table markup with shared table primitives
- add shared semantic table wrappers to the canonical table package for server-rendered table surfaces
- preserve investor pipeline/link rows, actions, badges, and empty states

## Verification
- `rg -n "<(table|thead|tbody|tr|td|th)(\\s|>)" apps/web/app/app/(shell)/admin/investors/page.tsx apps/web/app/app/(shell)/admin/investors/links/InvestorLinksManager.tsx apps/web/app/app/(shell)/admin/investors/_components/InvestorTablePrimitives.tsx || true`
- `pnpm biome check --write apps/web/components/organisms/table/index.ts apps/web/components/organisms/table/molecules/SemanticTable.tsx apps/web/app/app/(shell)/admin/investors/_components/InvestorTablePrimitives.tsx apps/web/app/app/(shell)/admin/investors/page.tsx apps/web/app/app/(shell)/admin/investors/links/InvestorLinksManager.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/admin-investors-shell-normalization.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`

Linear: JOV-2486