### PR TITLE
refactor(jov-2489): normalize admin ops HUD rows

### DIFF
--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -28,6 +28,7 @@ import { ContentMetricCard } from '@/components/molecules/ContentMetricCard';
 import { ContentMetricRow } from '@/components/molecules/ContentMetricRow';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { QRCode } from '@/components/molecules/QRCode';
+import { ShellListRowFrame } from '@/components/organisms/table';
 import { AGENT_OS_ADMIN_FIXTURE_ARTIFACTS } from '@/lib/agent-os/fixtures';
 import {
   getDefaultStatusTone,
@@ -239,7 +240,7 @@ function CompactDeploymentRow({
   readonly run: HudMetrics['deployments']['recent'][number];
 }>) {
   return (
-    <div className='grid gap-1.5 border-subtle border-b py-2.5 last:border-b-0'>
+    <ShellListRowFrame className='grid gap-1.5 border-b border-subtle px-0 py-2.5 last:border-b-0'>
       <div className='flex min-w-0 items-center justify-between gap-3'>
         <div className='flex min-w-0 items-center gap-2'>
           <span
@@ -266,7 +267,7 @@ function CompactDeploymentRow({
       <p className='text-[11px] text-tertiary-token'>
         {formatDeploymentTime(run.createdAtIso)}
       </p>
-    </div>
+    </ShellListRowFrame>
   );
 }
 
@@ -276,7 +277,7 @@ function DeploymentRow({
   readonly run: HudMetrics['deployments']['recent'][number];
 }>) {
   return (
-    <div className='flex items-center justify-between gap-3 rounded-xl border border-subtle bg-surface-0 px-3 py-2.5'>
+    <ShellListRowFrame className='flex items-center justify-between gap-3 border border-subtle bg-surface-0 px-3 py-2.5'>
       <div className='min-w-0'>
         <p className='truncate text-[13px] font-semibold text-primary-token'>
           #{run.runNumber}
@@ -296,7 +297,7 @@ function DeploymentRow({
         </div>
         <DeploymentActionsMenu run={run} />
       </div>
-    </div>
+    </ShellListRowFrame>
   );
 }
 
@@ -345,7 +346,7 @@ function AiOpsItemRow({
   readonly onUndismiss?: () => void;
 }>) {
   return (
-    <div className='flex items-start justify-between gap-3 rounded-xl border border-subtle bg-surface-0 px-3 py-2.5'>
+    <ShellListRowFrame className='flex items-start justify-between gap-3 border border-subtle bg-surface-0 px-3 py-2.5'>
       <div className='min-w-0'>
         <p className='truncate text-[13px] font-semibold text-primary-token'>
           {item.summary}
@@ -376,7 +377,7 @@ function AiOpsItemRow({
           </button>
         ) : null}
       </div>
-    </div>
+    </ShellListRowFrame>
   );
 }
 

--- a/apps/web/components/features/admin/TimActionRequiredSection.tsx
+++ b/apps/web/components/features/admin/TimActionRequiredSection.tsx
@@ -4,6 +4,7 @@ import { Check, ExternalLink } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
+import { ShellListRowFrame } from '@/components/organisms/table';
 import type {
   TimActionIssue,
   TimActionsResponse,
@@ -67,7 +68,7 @@ function ActionRow({ issue, onClose, isClosing }: Readonly<ActionRowProps>) {
   const priorityConfig = getPriorityConfig(issue.priority);
 
   return (
-    <div className='flex items-center gap-3 rounded-xl border border-subtle bg-surface-0 px-3 py-2.5'>
+    <ShellListRowFrame className='flex items-center gap-3 border border-subtle bg-surface-0 px-3 py-2.5'>
       {/* Title + Linear link */}
       <div className='min-w-0 flex-1'>
         <a
@@ -109,7 +110,7 @@ function ActionRow({ issue, onClose, isClosing }: Readonly<ActionRowProps>) {
       >
         <Check className='h-3.5 w-3.5' aria-hidden='true' />
       </button>
-    </div>
+    </ShellListRowFrame>
   );
 }
 

--- a/apps/web/tests/unit/app/admin-ops-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/admin-ops-shell-normalization.test.ts
@@ -13,6 +13,10 @@ const OPS_ROUTE_DIR = join(TEST_DIR, '../../../app/app/(shell)/admin/ops');
 const OPS_PAGE = join(OPS_ROUTE_DIR, 'page.tsx');
 const HUD_DASHBOARD_CLIENT = join(OPS_ROUTE_DIR, 'HudDashboardClient.tsx');
 const HUD_STATUS_PILL = join(OPS_ROUTE_DIR, 'HudStatusPill.tsx');
+const TIM_ACTION_REQUIRED_SECTION = join(
+  TEST_DIR,
+  '../../../components/features/admin/TimActionRequiredSection.tsx'
+);
 
 const OPS_COMPONENT_FILES = [
   OPS_PAGE,
@@ -42,6 +46,27 @@ describe('admin ops shell normalization', () => {
     expect(source).not.toContain('SectionEyebrow');
     expect(source).not.toMatch(
       /className=['"][^'"]*(uppercase[^'"]*tracking|tracking[^'"]*uppercase)[^'"]*['"]/
+    );
+  });
+
+  it('normalizes admin ops list rows onto the shared shell row frame', () => {
+    const hudSource = readSource(HUD_DASHBOARD_CLIENT);
+    const actionSource = readSource(TIM_ACTION_REQUIRED_SECTION);
+
+    expect(hudSource).toContain(
+      "import { ShellListRowFrame } from '@/components/organisms/table';"
+    );
+    expect(actionSource).toContain(
+      "import { ShellListRowFrame } from '@/components/organisms/table';"
+    );
+    expect(hudSource).not.toContain(
+      'grid gap-1.5 border-subtle border-b py-2.5 last:border-b-0'
+    );
+    expect(hudSource).not.toContain(
+      'rounded-xl border border-subtle bg-surface-0 px-3 py-2.5'
+    );
+    expect(actionSource).not.toContain(
+      'rounded-xl border border-subtle bg-surface-0 px-3 py-2.5'
     );
   });
 


### PR DESCRIPTION
## Summary
- Replaced HUD deployment and AI ops row wrappers with the shared `ShellListRowFrame` primitive.
- Normalized the Tim action-required rows onto the same shell list frame.
- Added a source-level normalization test to lock the shared primitive contract.

## Verification
- `pnpm --filter @jovie/web exec biome check --write app/app/(shell)/admin/ops/HudDashboardClient.tsx components/features/admin/TimActionRequiredSection.tsx tests/unit/app/admin-ops-shell-normalization.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/admin-ops-shell-normalization.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`

## Notes
- Operations copy, polling, actions, and data ownership were left unchanged.