### PR TITLE
JOV-2488 Canonicalize tasks shell rows and loading

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskRowActionMenu.test.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskRowActionMenu.test.tsx
@@ -17,6 +17,7 @@ describe('TaskRowActionMenu', () => {
     expect(className).toContain(
       'group-hover/task-board-card-shell:opacity-100'
     );
+    expect(className).toContain('group-hover/task-row:opacity-100');
     expect(className).toContain('data-[state=open]:opacity-100');
   });
 

--- a/apps/web/components/features/dashboard/tasks/TaskRowActionMenu.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskRowActionMenu.tsx
@@ -22,7 +22,7 @@ export function getTaskRowActionTriggerClassName({
     'hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_68%,transparent)] hover:text-primary-token',
     'focus-visible:outline-none focus-visible:bg-[color-mix(in_oklab,var(--linear-row-hover)_70%,transparent)] focus-visible:text-primary-token',
     visibility === 'hover' && [
-      'opacity-0 group-hover/task-board-card-shell:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100',
+      'opacity-0 group-hover/task-board-card-shell:opacity-100 group-focus-visible/task-board-card-shell:opacity-100 group-hover/task-row:opacity-100 group-focus-visible/task-row:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100',
       selected && 'opacity-100',
     ]
   );

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -60,6 +60,8 @@ import { ReleaseSidebar } from '@/components/organisms/release-sidebar';
 import {
   type ContextMenuItemType,
   ShellListRowButton,
+  ShellListRowFrame,
+  TableEmptyState,
 } from '@/components/organisms/table';
 import { rowState } from '@/components/organisms/table/table.styles';
 import {
@@ -177,6 +179,13 @@ const MOBILE_TASK_SCOPE_OPTIONS = [
   ['open', 'Open'],
   ['done', 'Closed'],
 ] as const satisfies ReadonlyArray<readonly [MobileTaskScope, string]>;
+
+const TASK_LOADING_ROWS = [
+  { key: 'task-loading-1', titleWidth: '72%', metaWidth: '40%' },
+  { key: 'task-loading-2', titleWidth: '56%', metaWidth: '30%' },
+  { key: 'task-loading-3', titleWidth: '84%', metaWidth: '48%' },
+  { key: 'task-loading-4', titleWidth: '64%', metaWidth: '34%' },
+] as const;
 
 function getTaskSubviewForAssigneeFilter(
   assigneeFilter: TaskAssigneeKind | 'all'
@@ -900,21 +909,18 @@ function TaskEmptyState({
   onOpenReleases: () => void;
 }>) {
   return (
-    <div className='flex min-h-[360px] flex-col items-center justify-center gap-3 px-6 text-center'>
-      <div className='space-y-1'>
-        <h2 className='text-lg font-semibold tracking-[-0.025em] text-primary-token'>
-          {hasFilters
-            ? 'No tasks match your filters'
-            : 'Your task list is empty'}
-        </h2>
-        <p className='max-w-[520px] text-app text-secondary-token'>
-          {hasFilters
-            ? 'Try widening the filters or search query.'
-            : 'Create your first task, or tasks will appear automatically when you set up a release.'}
-        </p>
-      </div>
-      <div className='flex items-center gap-2'>
-        {hasFilters ? (
+    <TableEmptyState
+      title={
+        hasFilters ? 'No Tasks Match Your Filters' : 'Your Task List Is Empty'
+      }
+      description={
+        hasFilters
+          ? 'Try widening the filters or search query.'
+          : 'Create your first task, or tasks will appear automatically when you set up a release.'
+      }
+      className='min-h-[360px]'
+      action={
+        hasFilters ? (
           <Button
             type='button'
             variant='secondary'
@@ -924,21 +930,76 @@ function TaskEmptyState({
             Clear Filters
           </Button>
         ) : (
-          <>
-            <Button type='button' size='sm' onClick={onOpenComposer}>
-              New Task
-            </Button>
-            <Button
-              type='button'
-              variant='secondary'
-              size='sm'
-              onClick={onOpenReleases}
-            >
-              Set Up Release
-            </Button>
-          </>
-        )}
-      </div>
+          <Button type='button' size='sm' onClick={onOpenComposer}>
+            New Task
+          </Button>
+        )
+      }
+      secondaryAction={
+        hasFilters ? null : (
+          <Button
+            type='button'
+            variant='secondary'
+            size='sm'
+            onClick={onOpenReleases}
+          >
+            Set Up Release
+          </Button>
+        )
+      }
+    />
+  );
+}
+
+function TaskLoadingState() {
+  return (
+    <div
+      role='status'
+      aria-busy='true'
+      className='flex min-h-0 flex-1 flex-col gap-1.5 px-3 pb-4 pt-2'
+    >
+      <span className='sr-only'>Loading tasks</span>
+      {TASK_LOADING_ROWS.map(row => (
+        <ShellListRowFrame
+          key={row.key}
+          interaction='none'
+          className='grid min-h-16 grid-cols-[1.25rem_minmax(0,1fr)_auto] items-center gap-3 px-2.5 py-1.5'
+        >
+          <div className='skeleton h-4 w-4 rounded-full' />
+          <div className='min-w-0 space-y-2'>
+            <div
+              className='skeleton h-3.5 rounded'
+              style={{ width: row.titleWidth }}
+            />
+            <div
+              className='skeleton h-3 rounded'
+              style={{ width: row.metaWidth }}
+            />
+          </div>
+          <div className='skeleton h-5 w-14 rounded-full' />
+        </ShellListRowFrame>
+      ))}
+    </div>
+  );
+}
+
+function TaskErrorState({
+  onRetry,
+}: Readonly<{
+  onRetry: () => void;
+}>) {
+  return (
+    <div className='flex min-h-0 flex-1 items-center justify-center px-3 py-4'>
+      <TableEmptyState
+        title="Couldn't Load Tasks"
+        description='Try reloading the task list.'
+        className='min-h-[240px] max-w-[28rem]'
+        action={
+          <Button type='button' variant='secondary' size='sm' onClick={onRetry}>
+            Retry
+          </Button>
+        }
+      />
     </div>
   );
 }
@@ -1870,6 +1931,8 @@ export function TasksPageClient() {
         actionSlot={
           <TaskRowActionMenu
             items={getTaskContextMenuItems(info.row.original)}
+            selected={info.row.original.id === effectiveSelectedTaskId}
+            visibility='hover'
           />
         }
       />
@@ -1953,7 +2016,7 @@ export function TasksPageClient() {
       <TaskDataTable
         data={visibleTasks}
         columns={columns}
-        isLoading={isLoading}
+        isLoading={isActiveListLoading}
         getRowId={row => row.id}
         onRowClick={row => openTaskDocument(row)}
         getRowClassName={getTaskRowClassName}
@@ -1973,7 +2036,9 @@ export function TasksPageClient() {
   }
 
   let mobileTaskContent: React.ReactNode;
-  if (mobileScopedTasks.length === 0) {
+  if (isActiveListLoading) {
+    mobileTaskContent = <TaskLoadingState />;
+  } else if (mobileScopedTasks.length === 0) {
     mobileTaskContent = (
       <div className='px-4 pt-6'>
         <TaskEmptyState
@@ -2071,24 +2136,7 @@ export function TasksPageClient() {
           data-testid='tasks-content-panel'
         >
           {activeIsError ? (
-            <div className='flex min-h-[240px] flex-1 flex-col items-center justify-center gap-3 px-6 text-center'>
-              <div className='space-y-1'>
-                <h2 className='text-mid font-semibold text-primary-token'>
-                  Couldn&apos;t Load Tasks
-                </h2>
-                <p className='text-app text-secondary-token'>
-                  Try reloading the task list.
-                </p>
-              </div>
-              <Button
-                type='button'
-                variant='secondary'
-                size='sm'
-                onClick={() => refetchActiveTasks()}
-              >
-                Retry
-              </Button>
-            </div>
+            <TaskErrorState onRetry={() => void refetchActiveTasks()} />
           ) : (
             <div className='flex min-h-0 flex-1 overflow-hidden'>
               <div

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -202,12 +202,18 @@ let mockIsXlUp = true;
 let mockIs2xlUp = true;
 let mockTasksData: TaskView[] = [mockTask, mockTaskTwo];
 let mockListQueryData: TaskView[] | undefined | null = null;
+let mockListQueryIsLoading = false;
+let mockListQueryIsError = false;
+let mockBoardQueryIsLoading = false;
+let mockBoardQueryIsError = false;
 let mockViewMode: 'board' | 'list' = 'list';
 let mockCanShowTaskDocumentAlongsideReleaseSidebar = true;
 const mockUnifiedTable = vi.fn();
 const mockSetViewMode = vi.fn((viewMode: 'board' | 'list') => {
   mockViewMode = viewMode;
 });
+const mockRefetchTasks = vi.fn();
+const mockRefetchTaskBoard = vi.fn();
 
 function createMockTaskBoardResult(
   tasks: ReadonlyArray<TaskView>
@@ -334,9 +340,9 @@ vi.mock('@/lib/queries/useTasksQuery', () => ({
           : mockListQueryData
             ? { tasks: mockListQueryData }
             : undefined,
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
+      isLoading: mockListQueryIsLoading,
+      isError: mockListQueryIsError,
+      refetch: mockRefetchTasks,
     };
   },
   useTaskBoardQuery: (
@@ -348,9 +354,9 @@ vi.mock('@/lib/queries/useTasksQuery', () => ({
 
     return {
       data: createMockTaskBoardResult(mockTasksData as TaskView[]),
-      isLoading: false,
-      isError: false,
-      refetch: vi.fn(),
+      isLoading: mockBoardQueryIsLoading,
+      isError: mockBoardQueryIsError,
+      refetch: mockRefetchTaskBoard,
     };
   },
   useTaskQuery: (taskId: string | null) => ({
@@ -517,13 +523,53 @@ vi.mock('@/components/organisms/table', () => ({
       {children}
     </button>
   ),
-  UnifiedTable: (props: { minWidth?: string; containerClassName?: string }) => {
+  ShellListRowFrame: ({
+    children,
+    className,
+    isSelected,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement> & {
+    isSelected?: boolean;
+  }) => (
+    <div
+      data-shell-list-row='true'
+      data-selected={isSelected ? 'true' : undefined}
+      className={className}
+      {...props}
+    >
+      {children}
+    </div>
+  ),
+  TableEmptyState: ({
+    title,
+    description,
+    action,
+    secondaryAction,
+  }: {
+    title: string;
+    description?: string;
+    action?: React.ReactNode;
+    secondaryAction?: React.ReactNode;
+  }) => (
+    <div>
+      <p>{title}</p>
+      {description ? <p>{description}</p> : null}
+      {action}
+      {secondaryAction}
+    </div>
+  ),
+  UnifiedTable: (props: {
+    minWidth?: string;
+    containerClassName?: string;
+    isLoading?: boolean;
+  }) => {
     mockUnifiedTable(props);
     return (
       <div
         data-testid='tasks-table'
         data-min-width={props.minWidth ?? ''}
         data-container-class-name={props.containerClassName ?? ''}
+        data-loading={props.isLoading ? 'true' : 'false'}
       />
     );
   },
@@ -605,12 +651,18 @@ describe('TasksPageClient', () => {
     mockUseReleaseEntityQuery.mockClear();
     mockUseTaskBoardQuery.mockClear();
     mockUseTasksQuery.mockClear();
+    mockRefetchTasks.mockReset();
+    mockRefetchTaskBoard.mockReset();
     mockUseAppFlag.mockReturnValue(false);
     mockUnifiedTable.mockReset();
     mockIsXlUp = true;
     mockIs2xlUp = true;
     mockTasksData = [mockTask, mockTaskTwo];
     mockListQueryData = null;
+    mockListQueryIsLoading = false;
+    mockListQueryIsError = false;
+    mockBoardQueryIsLoading = false;
+    mockBoardQueryIsError = false;
     mockViewMode = 'list';
     mockCanShowTaskDocumentAlongsideReleaseSidebar = true;
   });
@@ -878,6 +930,46 @@ describe('TasksPageClient', () => {
       'data-container-class-name',
       'h-full overflow-y-auto overflow-x-hidden px-2.5 pb-2 pt-0.5'
     );
+  });
+
+  it('keeps the list pane in loading mode through the responsive-layout handoff', () => {
+    mockListQueryData = undefined;
+
+    renderPage();
+
+    const firstTableProps = mockUnifiedTable.mock.calls[0]?.[0] as
+      | {
+          readonly isLoading?: boolean;
+        }
+      | undefined;
+
+    expect(firstTableProps?.isLoading).toBe(true);
+  });
+
+  it('shows shell loading rows on mobile instead of flashing the empty state', () => {
+    mockIsXlUp = false;
+    mockListQueryData = undefined;
+    mockListQueryIsLoading = true;
+
+    renderPage();
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText('Loading tasks')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Your Task List Is Empty')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the shared retry state when the task query fails', () => {
+    mockListQueryIsError = true;
+
+    renderPage();
+
+    expect(screen.getByText("Couldn't Load Tasks")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(mockRefetchTasks).toHaveBeenCalledTimes(1);
   });
 
   it('hides the task document when the right panel opens on constrained desktop widths', () => {


### PR DESCRIPTION
## Summary
- align task row actions with the shared shell row hover/focus group so list rows use the same visibility contract as the board
- keep the task list pane in loading mode through the responsive-layout handoff and render shell-row loading placeholders on mobile instead of flashing empty state copy
- reuse the shared table empty-state primitive for task empty and error states and cover the loading/error contracts in focused tests

## Verification
- `pnpm exec biome check --write apps/web/components/features/dashboard/tasks/TaskRowActionMenu.tsx apps/web/components/features/dashboard/tasks/TasksPageClient.tsx apps/web/components/features/dashboard/tasks/TaskRowActionMenu.test.tsx apps/web/tests/unit/dashboard/TasksPageClient.test.tsx`
- `pnpm exec vitest run apps/web/components/features/dashboard/tasks/TaskRowActionMenu.test.tsx apps/web/tests/unit/dashboard/TasksPageClient.test.tsx apps/web/tests/unit/dashboard/TaskListRow.test.tsx apps/web/tests/unit/app/dashboard-tasks-page.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git push -u origin codex/jov-2488-tasks-shell` (pre-push hooks passed: repo biome check, web proxy guard, tailwind guard, typecheck, lint)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added loading skeleton UI for task lists with improved visual feedback during data loading.
  * Introduced consistent empty and error state components with clearer messaging and retry functionality.

* **Bug Fixes**
  * Improved task row action menu visibility behavior on hover and focus interactions.
  * Enhanced mobile responsiveness to properly display loading states instead of flashing empty content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->