### PR TITLE
JOV-2490 polish chat empty state composer and prompt rail

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -21,6 +21,10 @@ import {
 } from './components';
 import { ChatProvidersRegistrar } from './components/ChatProvidersRegistrar';
 import { ChatUsageAlert } from './components/ChatUsageAlert';
+import {
+  CHAT_PROMPT_RAIL_MASK_STYLE,
+  CHAT_PROMPT_RAIL_SCROLL_CLASS,
+} from './components/chat-prompt-styles';
 import { EntityResolutionProvider } from './components/EntityResolutionProvider';
 import {
   useChatImageAttachments,
@@ -33,6 +37,61 @@ import type { JovieChatProps, MessagePart } from './types';
 /** Sentinel ID for the synthetic thinking placeholder */
 const THINKING_PLACEHOLDER_ID = 'thinking-placeholder';
 const VIRTUALIZATION_THRESHOLD = 12;
+const EMPTY_STATE_SIGNAL_CARDS = [
+  {
+    headline: 'Release plan',
+    body: 'Rollout, timing, and blockers at a glance.',
+  },
+  {
+    headline: 'Asset brief',
+    body: 'Creative direction, copy, and next steps.',
+  },
+  {
+    headline: 'Context',
+    body: 'Releases, contacts, and references stay attached.',
+  },
+] as const;
+
+function EmptyStateSignalCards({
+  dimmed = false,
+}: {
+  readonly dimmed?: boolean;
+}) {
+  return (
+    <div
+      className={cn('w-full max-w-[52rem]', dimmed && 'pointer-events-none')}
+      aria-hidden={dimmed ? 'true' : undefined}
+      data-testid='chat-empty-state-top-signals'
+    >
+      <div
+        className={cn(
+          CHAT_PROMPT_RAIL_SCROLL_CLASS,
+          'overscroll-x-contain px-1 sm:px-0 lg:overflow-visible'
+        )}
+        style={CHAT_PROMPT_RAIL_MASK_STYLE}
+      >
+        <div
+          className='flex flex-nowrap gap-3 lg:grid lg:grid-cols-3'
+          data-testid='chat-empty-state-top-signals-row'
+        >
+          {EMPTY_STATE_SIGNAL_CARDS.map(card => (
+            <article
+              key={card.headline}
+              className='min-h-[108px] min-w-[16.5rem] flex-1 rounded-[20px] border border-subtle bg-surface-1 px-4 py-4 shadow-[0_16px_40px_-28px_rgba(0,0,0,0.9)] lg:min-w-0'
+            >
+              <p className='text-[15px] font-semibold leading-5 text-primary-token'>
+                {card.headline}
+              </p>
+              <p className='mt-2 max-w-[22ch] text-[12.5px] leading-5 text-secondary-token'>
+                {card.body}
+              </p>
+            </article>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export function getFirstNameForGreeting(
   name: string | null | undefined
@@ -691,9 +750,11 @@ export function JovieChat({
                 )}
               </div>
               <div
-                className='relative mx-auto flex min-h-full w-full max-w-[48rem] flex-col items-center justify-center gap-5 py-8'
+                className='relative mx-auto flex min-h-full w-full max-w-[52rem] flex-col items-center justify-center gap-6 py-8'
                 data-testid='chat-empty-state-composer-region'
               >
+                <EmptyStateSignalCards dimmed={composerPickerOpen} />
+
                 <h1
                   className={cn(
                     'text-balance text-center text-[2rem] font-semibold leading-[1.1] text-primary-token sm:text-[2.5rem] md:text-[3rem]',
@@ -738,13 +799,18 @@ export function JovieChat({
                   )}
 
                   {showStarterPrompts ? (
-                    <SuggestedPrompts
-                      onSelect={handleSuggestedPromptWithJank}
-                      isFirstSession={isFirstSession}
-                      latestReleaseTitle={latestReleaseTitle}
-                      albumArtCapability={albumArtCapability}
-                      layout='rail'
-                    />
+                    <div
+                      className='w-full'
+                      data-testid='chat-empty-state-prompt-rail'
+                    >
+                      <SuggestedPrompts
+                        onSelect={handleSuggestedPromptWithJank}
+                        isFirstSession={isFirstSession}
+                        latestReleaseTitle={latestReleaseTitle}
+                        albumArtCapability={albumArtCapability}
+                        layout='rail'
+                      />
+                    </div>
                   ) : null}
                 </div>
               </div>

--- a/apps/web/components/jovie/components/chat-prompt-styles.ts
+++ b/apps/web/components/jovie/components/chat-prompt-styles.ts
@@ -1,7 +1,8 @@
 export const CHAT_PROMPT_RAIL_SCROLL_CLASS =
   'w-full overflow-x-auto overflow-y-hidden scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
 
-export const CHAT_PROMPT_RAIL_CLASS = 'flex min-w-full items-stretch gap-1.5';
+export const CHAT_PROMPT_RAIL_CLASS =
+  'flex min-w-full flex-nowrap items-stretch gap-1.5';
 
 export const CHAT_PROMPT_RAIL_MASK_STYLE = {
   WebkitMaskImage:

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -168,6 +168,13 @@ describe('JovieChat empty state', () => {
     const { getByRole, getByTestId, getByText, queryByText } =
       renderWithQueryClient(<JovieChat profileId='profile-1' />);
 
+    expect(getByTestId('chat-empty-state-top-signals')).toBeTruthy();
+    expect(getByTestId('chat-empty-state-top-signals-row').className).toContain(
+      'lg:grid-cols-3'
+    );
+    expect(getByText('Release plan')).toBeTruthy();
+    expect(getByText('Asset brief')).toBeTruthy();
+    expect(getByText('Context')).toBeTruthy();
     expect(getByText('What are we working on?')).toBeTruthy();
     expect(queryByText('Welcome back')).toBeNull();
     expect(queryByText('Welcome back, Tim')).toBeNull();
@@ -175,6 +182,7 @@ describe('JovieChat empty state', () => {
     expect(queryByText('Jovie Assistant')).toBeNull();
     expect(queryByText('Ask anything or tell Jovie what you need')).toBeNull();
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
+    expect(getByTestId('chat-empty-state-prompt-rail')).toBeTruthy();
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(getByTestId('chat-input').getAttribute('data-placeholder')).toBe(
       'Ask Jovie...'
@@ -196,12 +204,14 @@ describe('JovieChat empty state', () => {
   it('hides starter prompt pills while the empty composer has typed text', () => {
     mockChatState.input = 'Help me with';
 
-    const { getByTestId, queryByText } = renderWithQueryClient(
+    const { getByTestId, queryByTestId, queryByText } = renderWithQueryClient(
       <JovieChat profileId='profile-1' />
     );
 
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
+    expect(getByTestId('chat-empty-state-top-signals')).toBeTruthy();
     expect(getByTestId('chat-input')).toBeTruthy();
+    expect(queryByTestId('chat-empty-state-prompt-rail')).toBeNull();
     expect(queryByText('Plan a release')).toBeNull();
     expect(queryByText('Pitch playlists')).toBeNull();
   });

--- a/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
+++ b/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
@@ -36,6 +36,7 @@ describe('SuggestedPrompts', () => {
     expect(rail.className).not.toContain('md:overflow-visible');
     const row = rail.firstElementChild;
     expect(row?.className).toContain('snap-x');
+    expect(row?.className).toContain('flex-nowrap');
     expect(row?.className).not.toContain('flex-wrap');
     expect(row?.className).toContain('whitespace-nowrap');
   });


### PR DESCRIPTION
## Summary
- center the empty chat composer in the main canvas and add a restrained top-signal card rail that becomes a 3-card layout when space allows
- keep suggested prompts below the empty composer as a single manual horizontal rail, with no second suggestion row while typing
- extend focused chat empty-state tests around the new signal-card and prompt-rail structure

## Verification
- `pnpm exec biome check --write apps/web/components/jovie/JovieChat.tsx apps/web/components/jovie/components/chat-prompt-styles.ts apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx apps/web/tests/unit/chat/SuggestedPrompts.test.tsx`
- `pnpm --filter web exec vitest run tests/unit/chat/JovieChat.empty-state.test.tsx tests/unit/chat/SuggestedPrompts.test.tsx tests/unit/chat/ChatInput.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git push` pre-push hook: repo Biome plus `@jovie/web` pre-push checks

## Visual Coverage
- Reviewed the empty-state diff for centered hero composer geometry, single-row prompt rail behavior, and responsive bento/card hierarchy.
- Local Playwright visual run reached auth/bootstrap warmup and stalled before empty-state assertions executed, so ship evidence is focused unit/typecheck plus direct design review of the changed surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added signal cards section to empty chat state with three suggested prompt suggestions for users to get started.

* **Style**
  * Improved empty chat layout spacing and adjusted styling for better prompt rail presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->