### PR TITLE
fix(JOV-2493): unify mobile release rows with shell primitives

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/MobileReleaseList.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/MobileReleaseList.tsx
@@ -7,12 +7,14 @@ import {
   SwipeToRevealGroup,
 } from '@/components/atoms/SwipeToReveal';
 import { TruncatedText } from '@/components/atoms/TruncatedText';
+import { ShellListRowButton } from '@/components/organisms/table';
 import { TypeBadge } from '@/components/shell/TypeBadge';
 import { mobileReleaseTokens } from '@/features/dashboard/tokens';
 import { formatCompactReleaseArtistLine } from '@/lib/discography/formatting';
 import { getReleaseTypeStyle } from '@/lib/discography/release-type-styles';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 import { cn } from '@/lib/utils';
+import { shellReleaseRowTypography } from './shell-releases/ShellReleaseRow';
 
 type SmartLinkLockReason = 'scheduled' | 'cap' | null;
 
@@ -225,16 +227,19 @@ const MobileReleaseRow = memo(function MobileReleaseRow({
       className='border-b border-(--linear-app-frame-seam) last:border-b-0'
       contentClassName='bg-transparent'
     >
-      <button
+      <ShellListRowButton
         type='button'
         onClick={() => onEdit(release)}
-        className={mobileReleaseTokens.row.container}
+        className='flex h-14 w-full items-center gap-3 px-4 text-left'
         data-testid={`mobile-release-row-${release.id}`}
       >
         {/* Title + subtitle stacked — artwork hidden on mobile for density */}
         <div className='min-w-0 flex-1'>
           <div className='flex items-center gap-1.5'>
-            <TruncatedText lines={1} className={mobileReleaseTokens.row.title}>
+            <TruncatedText
+              lines={1}
+              className={shellReleaseRowTypography.title}
+            >
               {release.title}
             </TruncatedText>
             {/* Release type badge */}
@@ -243,7 +248,7 @@ const MobileReleaseRow = memo(function MobileReleaseRow({
               className={mobileReleaseTokens.row.typeBadge}
             />
           </div>
-          <div className={mobileReleaseTokens.row.subtitle}>
+          <div className={shellReleaseRowTypography.subtitle}>
             {artistLine && <span>{artistLine}</span>}
             {artistLine && year && (
               <span className={mobileReleaseTokens.row.dot}>{' \u00B7 '}</span>
@@ -258,7 +263,7 @@ const MobileReleaseRow = memo(function MobileReleaseRow({
           className={mobileReleaseTokens.row.chevron}
           aria-hidden='true'
         />
-      </button>
+      </ShellListRowButton>
     </SwipeToReveal>
   );
 });

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
@@ -31,6 +31,10 @@ import { cn } from '@/lib/utils';
 import { releaseStatusToShell, releaseToDspItems } from './release-adapters';
 
 export type ShellRowLockReason = 'scheduled' | 'cap' | null;
+export const shellReleaseRowTypography = {
+  title: 'truncate text-[13px] font-caption text-primary-token leading-[1.2]',
+  subtitle: 'truncate text-[11px] text-tertiary-token leading-[1.3] mt-0.5',
+} as const;
 
 // ── Subcomponents ─────────────────────────────────────────────────────────────
 
@@ -246,12 +250,8 @@ export const ShellReleaseRow = memo(function ShellReleaseRow({
       <ArtworkCell release={release} />
 
       <div className='min-w-0 flex-1'>
-        <div className='truncate text-[13px] font-caption text-primary-token leading-[1.2]'>
-          {release.title}
-        </div>
-        <div className='truncate text-[11px] text-tertiary-token leading-[1.3] mt-0.5'>
-          {artistLabel}
-        </div>
+        <div className={shellReleaseRowTypography.title}>{release.title}</div>
+        <div className={shellReleaseRowTypography.subtitle}>{artistLabel}</div>
       </div>
 
       <div className='hidden md:inline-flex shrink-0'>

--- a/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.test.tsx
+++ b/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.test.tsx
@@ -76,6 +76,28 @@ describe('ShellReleaseRow audio affordance', () => {
     expect(row?.className).toContain('--linear-border-focus');
   });
 
+  it('uses the shell typography tokens for the release title and subtitle', () => {
+    render(
+      <ShellReleaseRow
+        release={fakeRelease({
+          id: 'r1',
+          title: 'Lost in the Light',
+          previewUrl: null,
+        })}
+        isSelected={false}
+        onSelect={() => undefined}
+      />
+    );
+
+    expect(screen.getByText('Lost in the Light').className).toContain(
+      'text-[13px]'
+    );
+    expect(screen.getByText('Lost in the Light').className).toContain(
+      'font-caption'
+    );
+    expect(screen.getByText('Bahamas').className).toContain('text-[11px]');
+  });
+
   it('omits the play overlay when the release has no preview URL', () => {
     render(
       <ShellReleaseRow

--- a/apps/web/tests/components/release-provider-matrix/MobileReleaseList.test.tsx
+++ b/apps/web/tests/components/release-provider-matrix/MobileReleaseList.test.tsx
@@ -24,9 +24,13 @@ vi.mock('@/components/atoms/SwipeToReveal', () => ({
 }));
 
 vi.mock('@/components/atoms/TruncatedText', () => ({
-  TruncatedText: ({ children }: { children: ReactNode }) => (
-    <span>{children}</span>
-  ),
+  TruncatedText: ({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) => <span className={className}>{children}</span>,
 }));
 
 function createRelease(
@@ -94,18 +98,33 @@ describe('MobileReleaseList', () => {
       />
     );
 
-    await user.click(screen.getByTestId('mobile-release-row-release-1'));
+    const row = screen.getByTestId('mobile-release-row-release-1');
+    expect(row).toHaveAttribute('data-shell-list-row', 'true');
+    expect(row.className).toContain('hover:bg-(--linear-row-hover)');
+    expect(row.className).toContain('focus-visible:bg-(--linear-row-hover)');
+
+    await user.click(row);
 
     expect(onEdit).toHaveBeenCalledWith(release);
   });
 
-  it('uses centered badge styling for the release type label', () => {
+  it('uses the shell release typography tokens for mobile scanning', () => {
     render(
       <MobileReleaseList
         releases={[createRelease()]}
         artistName='Jovie Artist'
         onEdit={vi.fn()}
       />
+    );
+
+    expect(screen.getByText('Summer Lights').className).toContain(
+      'font-caption'
+    );
+    expect(screen.getByText('Summer Lights').className).toContain(
+      'text-[13px]'
+    );
+    expect(screen.getByText('Jovie Artist').parentElement?.className).toContain(
+      'text-[11px]'
     );
 
     const badge = screen.getByText('Single');


### PR DESCRIPTION
## Summary
- align mobile release rows with the shared shell list row primitive
- share shell release title/subtitle typography between desktop shell rows and mobile scanning rows
- preserve provider matrix data ownership, filtering, and swipe actions

## Verification
- `pnpm --filter web exec vitest run tests/components/release-provider-matrix/MobileReleaseList.test.tsx tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git push` pre-push hook: repo Biome plus `@jovie/web` pre-push checks