### PR TITLE
fix(dashboard): tighten contacts shell chrome (JOV-2492)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailSidebar.tsx
@@ -241,6 +241,7 @@ export const ContactDetailSidebar = memo(function ContactDetailSidebar({
       onClose={hasContact ? undefined : handleClose}
       headerMode='minimal'
       hideMinimalHeaderBar={hasContact}
+      entityHeaderSurface='flat'
       contextMenuItems={contextMenuItems}
       isEmpty={!hasContact}
       emptyMessage='Select a contact to view details'
@@ -248,7 +249,6 @@ export const ContactDetailSidebar = memo(function ContactDetailSidebar({
         contact ? (
           <DrawerSurfaceCard variant='card' className='overflow-hidden p-3'>
             <EntityHeaderCard
-              eyebrow='Contact'
               title={contactDisplayName}
               subtitle={roleLabel}
               actions={
@@ -418,7 +418,7 @@ export const ContactDetailSidebar = memo(function ContactDetailSidebar({
                         aria-pressed={isSelected}
                         title={territory}
                         className={cn(
-                          'inline-flex h-6 max-w-full shrink-0 items-center whitespace-nowrap rounded-md border px-2 text-2xs font-caption leading-none transition-[background-color,border-color,color] duration-150 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+                          'inline-flex h-6 max-w-full shrink-0 items-center whitespace-nowrap rounded-md border px-2 text-2xs font-caption leading-none transition-[background-color,border-color,color] duration-subtle focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
                           isSelected
                             ? 'border-(--linear-border-focus)/35 bg-surface-1 text-primary-token'
                             : 'border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token hover:bg-surface-1 hover:text-primary-token'

--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactsTable.tsx
@@ -7,6 +7,7 @@ import {
   convertToCommonDropdownItems,
   PAGE_TOOLBAR_META_TEXT_CLASS,
   PageToolbar,
+  rowState,
   UnifiedTable,
 } from '@/components/organisms/table';
 import { useSetHeaderActions } from '@/contexts/HeaderActionsContext';
@@ -181,8 +182,7 @@ export const ContactsTable = memo(function ContactsTable({
 
   const getRowClassName = useCallback(
     (contact: EditableContact) => {
-      // Selected row: solid bg (override base hover)
-      return selectedContactId === contact.id ? 'bg-white/[0.04]' : '';
+      return selectedContactId === contact.id ? rowState.selected : '';
     },
     [selectedContactId]
   );

--- a/apps/web/tests/unit/dashboard/ContactDetailSidebar.test.tsx
+++ b/apps/web/tests/unit/dashboard/ContactDetailSidebar.test.tsx
@@ -14,15 +14,20 @@ vi.mock('@/components/molecules/drawer', async importOriginal => {
     EntitySidebarShell: ({
       children,
       entityHeader,
+      entityHeaderSurface,
       tabs,
       title,
     }: {
       children: ReactNode;
       entityHeader?: ReactNode;
+      entityHeaderSurface?: string;
       tabs?: ReactNode;
       title: ReactNode;
     }) => (
-      <div>
+      <div
+        data-entity-header-surface={entityHeaderSurface ?? 'card'}
+        data-testid='entity-sidebar-shell'
+      >
         <div>{title}</div>
         {entityHeader}
         {tabs}
@@ -68,6 +73,11 @@ describe('ContactDetailSidebar', () => {
 
     expect(screen.getAllByText('Alex Rivera').length).toBeGreaterThan(0);
     expect(screen.getAllByText('Management').length).toBeGreaterThan(0);
+    expect(screen.getByTestId('entity-sidebar-shell')).toHaveAttribute(
+      'data-entity-header-surface',
+      'flat'
+    );
+    expect(screen.queryByText('Contact')).not.toBeInTheDocument();
     expect(screen.getByText('Contact Info')).toBeInTheDocument();
     expect(screen.getByText('Role')).toBeInTheDocument();
   });

--- a/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
+++ b/apps/web/tests/unit/dashboard/ContactsTable.test.tsx
@@ -1,0 +1,149 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { rowState } from '@/components/organisms/table/table.styles';
+import type { EditableContact } from '@/features/dashboard/hooks/useContactsManager';
+import { ContactsTable } from '@/features/dashboard/organisms/contacts-table/ContactsTable';
+
+const setHeaderActions = vi.fn();
+const setTableMeta = vi.fn();
+
+vi.mock('@/contexts/HeaderActionsContext', () => ({
+  useSetHeaderActions: () => ({
+    setHeaderActions,
+  }),
+}));
+
+vi.mock('@/contexts/TableMetaContext', () => ({
+  useTableMeta: () => ({
+    setTableMeta,
+  }),
+}));
+
+vi.mock('@/components/organisms/table', async importOriginal => {
+  const actual =
+    await importOriginal<typeof import('@/components/organisms/table')>();
+
+  return {
+    ...actual,
+    PAGE_TOOLBAR_META_TEXT_CLASS: 'page-toolbar-meta-text',
+    PageToolbar: ({ start }: { readonly start: ReactNode }) => (
+      <div data-testid='contacts-toolbar'>{start}</div>
+    ),
+    convertToCommonDropdownItems: vi.fn(() => []),
+    UnifiedTable: ({
+      data,
+      getRowClassName,
+      onRowClick,
+    }: {
+      readonly data: EditableContact[];
+      readonly getRowClassName?: (
+        row: EditableContact,
+        index: number
+      ) => string;
+      readonly onRowClick?: (row: EditableContact) => void;
+    }) => {
+      const firstRowClassName = data[0]
+        ? (getRowClassName?.(data[0], 0) ?? '')
+        : '';
+
+      return (
+        <div
+          data-first-row-class={firstRowClassName}
+          data-testid='contacts-unified-table'
+        >
+          {data[0] ? (
+            <button type='button' onClick={() => onRowClick?.(data[0])}>
+              Select first contact
+            </button>
+          ) : null}
+        </div>
+      );
+    },
+  };
+});
+
+vi.mock(
+  '@/features/dashboard/organisms/contacts-table/ContactDetailSidebar',
+  () => ({
+    ContactDetailSidebar: ({
+      contact,
+      entityHeaderSurface,
+      isOpen,
+    }: {
+      readonly contact: EditableContact | null;
+      readonly entityHeaderSurface?: string;
+      readonly isOpen: boolean;
+    }) => (
+      <div
+        data-contact-id={contact?.id ?? ''}
+        data-entity-header-surface={entityHeaderSurface ?? 'card'}
+        data-open={String(isOpen)}
+        data-testid='contact-detail-sidebar'
+      />
+    ),
+  })
+);
+
+const contacts: EditableContact[] = [
+  {
+    id: 'contact-1',
+    creatorProfileId: 'profile-1',
+    role: 'management',
+    customLabel: null,
+    personName: 'Alex Rivera',
+    companyName: 'North Star',
+    territories: ['North America'],
+    email: 'alex@example.com',
+    phone: '+1 555-0101',
+    preferredChannel: 'email',
+    isActive: true,
+    sortOrder: 0,
+    isSaving: false,
+    isDeleting: false,
+    error: null,
+    isExpanded: true,
+    customTerritory: '',
+    isNew: false,
+  },
+];
+
+describe('ContactsTable', () => {
+  it('uses shell-selected row chrome and keeps the detail surface flat', () => {
+    render(
+      <ContactsTable
+        contacts={contacts}
+        artistName='Tim White'
+        onUpdate={() => undefined}
+        onSave={async () => undefined}
+        onDelete={() => undefined}
+        onAddContact={() => undefined}
+      />
+    );
+
+    expect(screen.getByText('1 contact')).toBeInTheDocument();
+    expect(screen.getByTestId('contacts-unified-table')).toHaveAttribute(
+      'data-first-row-class',
+      ''
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select first contact' })
+    );
+
+    expect(screen.getByTestId('contact-detail-sidebar')).toHaveAttribute(
+      'data-open',
+      'true'
+    );
+    expect(screen.getByTestId('contact-detail-sidebar')).toHaveAttribute(
+      'data-contact-id',
+      'contact-1'
+    );
+    expect(screen.getByTestId('contacts-unified-table')).toHaveAttribute(
+      'data-first-row-class',
+      rowState.selected
+    );
+    expect(setHeaderActions).toHaveBeenCalled();
+    expect(setTableMeta).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- switch selected contact row chrome to the shared shell row state token
- flatten the contact detail entity header surface and remove the redundant Contact eyebrow
- align territory chip transition timing with shell motion tokens

## Verification
- `pnpm --filter web exec vitest run tests/unit/dashboard/ContactsTable.test.tsx tests/unit/dashboard/ContactDetailSidebar.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git push` pre-push hook: repo Biome plus `@jovie/web` pre-push checks