### PR TITLE
JOV-2494: seal releases warm navigation path for shell persistence

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/ReleasesClientBoundary.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/ReleasesClientBoundary.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useEffect } from 'react';
+import { useLayoutEffect } from 'react';
 import { usePendingShell } from '@/components/organisms/PendingShellContext';
 
 interface ReleasesClientBoundaryProps {
@@ -13,7 +13,7 @@ export function ReleasesClientBoundary({
 }: ReleasesClientBoundaryProps) {
   const { clearPendingShell } = usePendingShell();
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     clearPendingShell('releases');
   }, [clearPendingShell]);
 

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -252,6 +252,7 @@ export function DashboardNav(_: DashboardNavProps) {
   // Debounced prefetch: avoid firing on fast mouse sweeps across nav items
   const prefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const releasesPrefetchedProfileIdRef = useRef<string | null>(null);
+  const releasesWarmReadyProfileIdRef = useRef<string | null>(null);
   useEffect(
     () => () => {
       if (prefetchTimerRef.current) clearTimeout(prefetchTimerRef.current);
@@ -260,11 +261,47 @@ export function DashboardNav(_: DashboardNavProps) {
   );
 
   useEffect(() => {
+    releasesPrefetchedProfileIdRef.current = null;
+    releasesWarmReadyProfileIdRef.current = null;
+  }, [profileId]);
+
+  const warmReleasesRoute = useCallback(async () => {
+    if (isDemo || !profileId) {
+      return;
+    }
+
+    if (releasesPrefetchedProfileIdRef.current === profileId) {
+      router.prefetch(APP_ROUTES.RELEASES);
+      return;
+    }
+
+    releasesPrefetchedProfileIdRef.current = profileId;
+    router.prefetch(APP_ROUTES.RELEASES);
+
+    try {
+      await Promise.all([
+        import('@/features/dashboard/organisms/release-provider-matrix'),
+        import('@/lib/queries/prefetch-dashboard').then(
+          ({ prefetchForRoute }) =>
+            prefetchForRoute('releases', queryClient, profileId)
+        ),
+      ]);
+
+      releasesPrefetchedProfileIdRef.current = profileId;
+      releasesWarmReadyProfileIdRef.current = profileId;
+    } catch {
+      releasesPrefetchedProfileIdRef.current = null;
+      releasesWarmReadyProfileIdRef.current = null;
+    }
+  }, [isDemo, profileId, queryClient, router]);
+
+  useEffect(() => {
     if (
       isDemo ||
       !profileId ||
-      releasesPrefetchedProfileIdRef.current === profileId ||
-      pathname !== APP_ROUTES.DASHBOARD
+      releasesWarmReadyProfileIdRef.current === profileId ||
+      pathname === APP_ROUTES.RELEASES ||
+      pathname === APP_ROUTES.DASHBOARD_RELEASES
     ) {
       return;
     }
@@ -276,24 +313,11 @@ export function DashboardNav(_: DashboardNavProps) {
     // the timer so a cleanup that fires before the timer runs (fast route
     // change) leaves the ref null and a later visit will retry.
     const handle = setTimeout(() => {
-      releasesPrefetchedProfileIdRef.current = profileId;
-      router.prefetch(APP_ROUTES.RELEASES);
-      void import(
-        '@/features/dashboard/organisms/release-provider-matrix'
-      ).catch(() => {
-        releasesPrefetchedProfileIdRef.current = null;
-      });
-      void import('@/lib/queries/prefetch-dashboard')
-        .then(({ prefetchForRoute }) =>
-          prefetchForRoute('releases', queryClient, profileId)
-        )
-        .catch(() => {
-          releasesPrefetchedProfileIdRef.current = null;
-        });
+      void warmReleasesRoute();
     }, 300);
 
     return () => clearTimeout(handle);
-  }, [isDemo, pathname, profileId, queryClient, router]);
+  }, [isDemo, pathname, profileId, warmReleasesRoute]);
 
   const handlePrefetch = useCallback(
     (itemId: string) => {
@@ -301,9 +325,8 @@ export function DashboardNav(_: DashboardNavProps) {
       const prefetchDelayMs = itemId === 'releases' ? 0 : 150;
       prefetchTimerRef.current = setTimeout(() => {
         if (itemId === 'releases') {
-          void import(
-            '@/features/dashboard/organisms/release-provider-matrix'
-          ).catch(() => {});
+          void warmReleasesRoute();
+          return;
         }
         void import('@/lib/queries/prefetch-dashboard')
           .then(({ prefetchForRoute }) =>
@@ -312,8 +335,24 @@ export function DashboardNav(_: DashboardNavProps) {
           .catch(() => {});
       }, prefetchDelayMs);
     },
-    [queryClient, profileId]
+    [profileId, queryClient, warmReleasesRoute]
   );
+
+  const showPendingReleasesShell = useCallback(() => {
+    if (releasesWarmReadyProfileIdRef.current === profileId) {
+      return;
+    }
+
+    showPendingShell('releases');
+  }, [profileId, showPendingShell]);
+
+  const clearPendingReleasesShell = useCallback(() => {
+    if (releasesWarmReadyProfileIdRef.current === profileId) {
+      return;
+    }
+
+    clearPendingShell('releases');
+  }, [clearPendingShell, profileId]);
 
   // In demo mode, intercept nav clicks for tabs without demo data
   const handleDemoNavClick = useCallback((item: NavItem) => {
@@ -391,14 +430,10 @@ export function DashboardNav(_: DashboardNavProps) {
           renderAsButton={renderAsButton}
           useShellNavItem={shellChatV1Enabled}
           onNavigate={
-            isReleasesItem && !isActive
-              ? () => showPendingShell('releases')
-              : undefined
+            isReleasesItem && !isActive ? showPendingReleasesShell : undefined
           }
           onCancelNavigate={
-            isReleasesItem && !isActive
-              ? () => clearPendingShell('releases')
-              : undefined
+            isReleasesItem && !isActive ? clearPendingReleasesShell : undefined
           }
           onPrefetch={() => handlePrefetch(item.id)}
         />
@@ -411,8 +446,8 @@ export function DashboardNav(_: DashboardNavProps) {
       handleDemoNavClick,
       handlePrefetch,
       handleSearchClick,
-      clearPendingShell,
-      showPendingShell,
+      clearPendingReleasesShell,
+      showPendingReleasesShell,
       isPreviewOpen,
       isDemo,
       shellChatV1Enabled,

--- a/apps/web/scripts/performance-route-manifest.ts
+++ b/apps/web/scripts/performance-route-manifest.ts
@@ -1050,7 +1050,7 @@ const CREATOR_SHELL_ROUTES = [
     warmupStrategy: 'authenticated-shell',
     measureMode: 'warm-navigation',
     readySelectors: {
-      shell: ['[data-testid="releases-shell-ready"]'],
+      shell: ['[data-app-shell-frame="true"]'],
       content: [
         '[data-testid="releases-loading"]',
         '[data-testid="releases-matrix"]',

--- a/apps/web/tests/e2e/shell-route-persistence.spec.ts
+++ b/apps/web/tests/e2e/shell-route-persistence.spec.ts
@@ -130,6 +130,83 @@ async function markPersistentShellFrame(page: Page): Promise<void> {
   }, PERSISTENCE_PROBE_VALUE);
 }
 
+async function attachReleasesOverlayProbe(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    type ReleasesOverlayProbe = {
+      readonly activations: number;
+      readonly disconnect: () => void;
+    };
+    const probeWindow = globalThis as typeof globalThis & {
+      __JOVIE_RELEASES_OVERLAY_PROBE__?: ReleasesOverlayProbe;
+    };
+    const target = document.querySelector<HTMLElement>(
+      '[data-testid="releases-shell-ready"]'
+    );
+
+    if (!target) {
+      probeWindow.__JOVIE_RELEASES_OVERLAY_PROBE__ = {
+        activations: 0,
+        disconnect: () => {},
+      };
+      return;
+    }
+
+    let activations = 0;
+    const countIfVisible = () => {
+      const visible =
+        target.getAttribute('aria-hidden') === 'false' &&
+        globalThis.getComputedStyle(target).display !== 'none';
+
+      if (visible) {
+        activations += 1;
+      }
+    };
+
+    countIfVisible();
+
+    const observer = new MutationObserver(() => {
+      countIfVisible();
+    });
+
+    observer.observe(target, {
+      attributes: true,
+      attributeFilter: ['aria-hidden', 'class', 'style'],
+    });
+
+    probeWindow.__JOVIE_RELEASES_OVERLAY_PROBE__ = {
+      get activations() {
+        return activations;
+      },
+      disconnect: () => observer.disconnect(),
+    };
+  });
+}
+
+async function readReleasesOverlayActivations(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const probeWindow = globalThis as typeof globalThis & {
+      __JOVIE_RELEASES_OVERLAY_PROBE__?: {
+        readonly activations: number;
+      };
+    };
+
+    return probeWindow.__JOVIE_RELEASES_OVERLAY_PROBE__?.activations ?? 0;
+  });
+}
+
+async function detachReleasesOverlayProbe(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const probeWindow = globalThis as typeof globalThis & {
+      __JOVIE_RELEASES_OVERLAY_PROBE__?: {
+        readonly disconnect?: () => void;
+      };
+    };
+
+    probeWindow.__JOVIE_RELEASES_OVERLAY_PROBE__?.disconnect?.();
+    delete probeWindow.__JOVIE_RELEASES_OVERLAY_PROBE__;
+  });
+}
+
 async function assertPersistentShellFrame(
   page: Page,
   label: string
@@ -345,6 +422,7 @@ test('app shell persists across core app routes without duplicate request bursts
 
   await markPersistentShellFrame(page);
   const baselineLoadCount = await readDocumentLoadCount(page);
+  await attachReleasesOverlayProbe(page);
 
   await clickFirstVisibleAppLink(
     page,
@@ -361,6 +439,8 @@ test('app shell persists across core app routes without duplicate request bursts
     return;
   }
   await assertNoDocumentReloadSince(page, baselineLoadCount, 'releases route');
+  expect(await readReleasesOverlayActivations(page)).toBe(0);
+  await detachReleasesOverlayProbe(page);
 
   await clickFirstVisibleAppLink(
     page,


### PR DESCRIPTION
## Summary
- warm the releases route across shell surfaces so warm navigation carries both route and releases query state
- skip the releases pending-shell overlay once the route is warm and clear residual pending state before paint
- tighten the shell persistence regression to fail if the releases overlay activates during warm navigation

## Verification
- `pnpm exec vitest run apps/web/tests/unit/app/shell-route-matches.test.ts apps/web/tests/unit/dashboard/ReleasesClientBoundary.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm exec playwright test apps/web/tests/e2e/shell-route-persistence.spec.ts` (skipped in this environment)
- `git push` pre-push hook: repo Biome plus `@jovie/web` pre-push checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized releases route prefetching and navigation shell behavior for improved responsiveness.

* **Tests**
  * Added detection mechanism to verify overlay visibility during releases route navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->