### PR TITLE
JOV-2491 normalize admin waitlist table chrome

### DIFF
--- a/apps/web/components/features/admin/waitlist-table/AdminWaitlistTableUnified.tsx
+++ b/apps/web/components/features/admin/waitlist-table/AdminWaitlistTableUnified.tsx
@@ -214,7 +214,7 @@ export function AdminWaitlistTableUnified({
 
   // Get row className - uses unified hover token
   const getRowClassName = useCallback(() => {
-    return 'group bg-transparent hover:bg-(--linear-row-hover)';
+    return 'group hover:bg-(--linear-row-hover)';
   }, []);
 
   // Render unified table with optional grouping
@@ -225,11 +225,13 @@ export function AdminWaitlistTableUnified({
       isLoading={false}
       getContextMenuItems={createContextMenuItems}
       emptyState={
-        <div className='px-4 py-10 text-center text-sm text-secondary-token flex flex-col items-center gap-3'>
-          <ClipboardList className='h-6 w-6' />
+        <div className='flex flex-col items-center gap-3 px-4 py-10 text-center text-sm text-secondary-token'>
+          <ClipboardList className='h-6 w-6 text-tertiary-token' />
           <div>
-            <div className='font-medium'>No waitlist entries</div>
-            <div className='text-xs'>
+            <div className='font-medium text-primary-token'>
+              No waitlist entries
+            </div>
+            <div className='text-xs text-secondary-token'>
               New waitlist signups will appear here.
             </div>
           </div>

--- a/apps/web/tests/unit/components/admin/AdminWaitlistTableUnified.test.tsx
+++ b/apps/web/tests/unit/components/admin/AdminWaitlistTableUnified.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { AdminWaitlistTableUnified } from '@/features/admin/waitlist-table/AdminWaitlistTableUnified';
+
+let capturedGetRowClassName:
+  | ((row: unknown, index: number) => string)
+  | undefined;
+
+vi.mock('@/features/admin/table/AdminDataTable', () => ({
+  AdminDataTable: ({
+    children,
+    emptyState,
+    getRowClassName,
+  }: {
+    readonly children?: ReactNode;
+    readonly emptyState?: ReactNode;
+    readonly getRowClassName?: (row: unknown, index: number) => string;
+  }) => {
+    capturedGetRowClassName = getRowClassName;
+
+    return (
+      <div data-testid='admin-data-table'>
+        {children}
+        <div data-testid='waitlist-empty-state'>{emptyState}</div>
+      </div>
+    );
+  },
+}));
+
+vi.mock('@/components/organisms/table', () => ({
+  useRowSelection: () => ({
+    selectedIds: new Set<string>(),
+    headerCheckboxState: false,
+    toggleSelect: vi.fn(),
+    toggleSelectAll: vi.fn(),
+  }),
+}));
+
+vi.mock('@/features/admin/waitlist-table/useApproveEntry', () => ({
+  useApproveEntry: () => ({
+    approveEntry: vi.fn().mockResolvedValue(undefined),
+    resendInvite: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+const entry = {
+  id: 'waitlist_1',
+  fullName: 'Ari Lane',
+  email: 'ari@example.com',
+  primaryGoal: null,
+  primarySocialUrl: 'https://instagram.com/ari',
+  primarySocialPlatform: 'instagram',
+  primarySocialUrlNormalized: 'https://instagram.com/ari',
+  spotifyUrl: null,
+  spotifyUrlNormalized: null,
+  spotifyArtistName: null,
+  heardAbout: null,
+  status: 'new' as const,
+  primarySocialFollowerCount: null,
+  createdAt: new Date('2026-01-10T00:00:00.000Z'),
+  updatedAt: new Date('2026-01-10T00:00:00.000Z'),
+};
+
+describe('AdminWaitlistTableUnified', () => {
+  it('uses the shared row hover token and shell-colored empty state chrome', () => {
+    render(
+      <AdminWaitlistTableUnified
+        entries={[entry]}
+        page={1}
+        pageSize={20}
+        total={1}
+      />
+    );
+
+    expect(capturedGetRowClassName?.(entry, 0)).toBe(
+      'group hover:bg-(--linear-row-hover)'
+    );
+
+    expect(screen.getByText('No waitlist entries').className).toContain(
+      'text-primary-token'
+    );
+    expect(
+      screen.getByText('New waitlist signups will appear here.').className
+    ).toContain('text-secondary-token');
+    expect(
+      screen.getByTestId('waitlist-empty-state').querySelector('svg')
+    ).not.toBeNull();
+    expect(
+      screen
+        .getByTestId('waitlist-empty-state')
+        .querySelector('svg')
+        ?.getAttribute('class') ?? ''
+    ).toContain('text-tertiary-token');
+  });
+});

--- a/apps/web/tests/unit/components/admin/waitlist-column-renderers.test.tsx
+++ b/apps/web/tests/unit/components/admin/waitlist-column-renderers.test.tsx
@@ -1,8 +1,39 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { renderStatusCell } from '@/features/admin/waitlist-table/utils/column-renderers';
+import {
+  renderEmailCell,
+  renderHeardAboutCell,
+  renderNameCell,
+  renderStatusCell,
+} from '@/features/admin/waitlist-table/utils/column-renderers';
 
-describe('renderStatusCell', () => {
+describe('waitlist column renderers', () => {
+  it('renders name and email cells with canonical table tokens', () => {
+    const { rerender } = render(renderNameCell('Ari Lane'));
+
+    expect(screen.getByText('Ari Lane').className).toContain(
+      'text-primary-token'
+    );
+
+    rerender(renderEmailCell('ari@example.com'));
+
+    const emailLink = screen.getByRole('link', { name: 'ari@example.com' });
+    expect(emailLink.className).toContain('text-secondary-token');
+    expect(emailLink).toHaveAttribute('href', 'mailto:ari@example.com');
+  });
+
+  it('renders heard-about cells with secondary text and a tertiary empty state', () => {
+    const { rerender } = render(renderHeardAboutCell('Instagram'));
+
+    expect(screen.getByText('Instagram').className).toContain(
+      'text-secondary-token'
+    );
+
+    rerender(renderHeardAboutCell(null));
+
+    expect(screen.getByText('—').className).toContain('text-tertiary-token');
+  });
+
   it.each([
     ['new', 'Waitlisted', 'text-(--linear-text-tertiary)'],
     ['chat_started', 'Chat started', 'text-(--linear-text-tertiary)'],


### PR DESCRIPTION
## Summary
- normalize admin waitlist row hover chrome to the shared shell row hover token
- retokenize the waitlist empty state with shell primary/secondary/tertiary colors
- add focused tests for waitlist table chrome and column renderer token behavior

## Verification
- `pnpm --filter web exec vitest run tests/unit/components/admin/waitlist-column-renderers.test.tsx tests/unit/components/admin/AdminWaitlistTableUnified.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git push` pre-push hook: repo Biome plus `@jovie/web` pre-push checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved admin waitlist empty state layout and visual clarity — updated text and icon colors and centralized spacing
  * Refined unified waitlist row hover styling for more consistent hover feedback

* **Tests**
  * Added unit coverage to verify empty state visuals, icon presence, text styling, and row hover behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->