### PR TITLE
feat(chat): empty composer hero pill + responsive signal cards + prompt rail (JOV-2496)

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -40,11 +40,11 @@ const VIRTUALIZATION_THRESHOLD = 12;
 const EMPTY_STATE_SIGNAL_CARDS = [
   {
     headline: 'Release plan',
-    body: 'Rollout, timing, and blockers at a glance.',
+    body: 'Turn a song into a launch sequence.',
   },
   {
     headline: 'Asset brief',
-    body: 'Creative direction, copy, and next steps.',
+    body: 'Creative direction and copy, ready to use.',
   },
   {
     headline: 'Context',
@@ -71,18 +71,18 @@ function EmptyStateSignalCards({
         style={CHAT_PROMPT_RAIL_MASK_STYLE}
       >
         <div
-          className='flex flex-nowrap gap-3 lg:grid lg:grid-cols-3'
+          className='flex snap-x snap-mandatory flex-nowrap gap-3 lg:grid lg:grid-cols-3'
           data-testid='chat-empty-state-top-signals-row'
         >
           {EMPTY_STATE_SIGNAL_CARDS.map(card => (
             <article
               key={card.headline}
-              className='min-h-[108px] min-w-[16.5rem] flex-1 rounded-[20px] border border-subtle bg-surface-1 px-4 py-4 shadow-[0_16px_40px_-28px_rgba(0,0,0,0.9)] lg:min-w-0'
+              className='min-h-[124px] min-w-[min(19rem,84vw)] flex-1 snap-start rounded-[22px] border border-subtle bg-surface-1 px-4 py-4 shadow-[0_16px_44px_-30px_rgba(0,0,0,0.92)] lg:min-w-0'
             >
-              <p className='text-[15px] font-semibold leading-5 text-primary-token'>
+              <p className='text-pretty text-[17px] font-semibold leading-[1.2] text-primary-token'>
                 {card.headline}
               </p>
-              <p className='mt-2 max-w-[22ch] text-[12.5px] leading-5 text-secondary-token'>
+              <p className='mt-3 max-w-[24ch] text-[12.5px] leading-5 text-tertiary-token'>
                 {card.body}
               </p>
             </article>
@@ -93,6 +93,10 @@ function EmptyStateSignalCards({
   );
 }
 
+/**
+ * Extracts the first name token for use in the empty-state greeting (e.g. "What are we working on, Alex?").
+ * Handles null/undefined/blank by returning null. Splits on whitespace.
+ */
 export function getFirstNameForGreeting(
   name: string | null | undefined
 ): string | null {

--- a/apps/web/components/jovie/components/ChatAnalyticsCard.tsx
+++ b/apps/web/components/jovie/components/ChatAnalyticsCard.tsx
@@ -2,7 +2,6 @@
 
 import { Sparkles } from 'lucide-react';
 import { InsightCategoryIcon } from '@/components/features/dashboard/insights/InsightCategoryIcon';
-import { LINEAR_SURFACE } from '@/components/features/dashboard/tokens';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { cn } from '@/lib/utils';
 import type { ChatInsightsToolResult } from '../types';
@@ -22,11 +21,11 @@ export function ChatAnalyticsCard({ result }: ChatAnalyticsCardProps) {
       data-testid='chat-analytics-card'
     >
       <div className='flex items-start gap-3'>
-        <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] border border-(--linear-app-frame-seam) bg-surface-0'>
-          <Sparkles className='h-3.5 w-3.5 text-secondary-token' />
+        <div className='flex h-5 w-5 shrink-0 items-center justify-center text-tertiary-token'>
+          <Sparkles className='h-4 w-4' strokeWidth={2.2} />
         </div>
         <div className='min-w-0'>
-          <p className='text-app font-medium text-primary-token'>
+          <p className='text-[14px] font-semibold leading-5 text-primary-token'>
             {result.title}
           </p>
           <p className='mt-1 text-[12px] leading-5 text-tertiary-token'>
@@ -45,24 +44,23 @@ export function ChatAnalyticsCard({ result }: ChatAnalyticsCardProps) {
           <li
             key={insight.id}
             className={cn(
-              LINEAR_SURFACE.drawerCardSm,
-              'flex min-h-[148px] min-w-[min(19.5rem,82vw)] snap-start flex-col justify-between p-4 md:min-w-0'
+              'flex min-h-[136px] min-w-[min(20rem,84vw)] snap-start flex-col justify-between rounded-[20px] border border-subtle bg-surface-1 p-4 shadow-[0_16px_44px_-30px_rgba(0,0,0,0.92)] md:min-w-0'
             )}
             data-testid='chat-analytics-signal-card'
           >
             <div className='flex items-center gap-2'>
-              <span className='flex h-7 w-7 shrink-0 items-center justify-center rounded-[8px] border border-(--linear-app-frame-seam) bg-surface-0'>
+              <span className='flex h-4 w-4 shrink-0 items-center justify-center text-tertiary-token'>
                 <InsightCategoryIcon category={insight.category} size='sm' />
               </span>
-              <span className='text-[11px] font-medium capitalize leading-4 text-tertiary-token'>
+              <span className='text-[11.5px] font-medium capitalize leading-4 text-tertiary-token'>
                 {insight.category.replaceAll('_', ' ')}
               </span>
             </div>
-            <div className='mt-5 min-w-0'>
-              <p className='text-pretty text-[15px] font-semibold leading-[1.28] text-primary-token'>
+            <div className='mt-4 min-w-0'>
+              <p className='text-pretty text-[17px] font-semibold leading-[1.18] text-primary-token'>
                 {insight.title}
               </p>
-              <p className='mt-2 line-clamp-2 text-[12.5px] leading-5 text-secondary-token'>
+              <p className='mt-3 line-clamp-2 text-[12.5px] leading-5 text-tertiary-token'>
                 {insight.actionSuggestion ?? insight.description}
               </p>
             </div>

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -106,7 +106,7 @@ function geometryFor(
     ? 'min(calc(100vw - 32px), 840px)'
     : 'min(calc(100vw - 32px), 720px)';
   if (stacked) return { width, maxWidth, borderRadius: 28 };
-  if (isHero && mode === 'empty') return { width, maxWidth, borderRadius: 32 };
+  if (isHero && mode !== 'entity') return { width, maxWidth, borderRadius: 36 };
   if (mode === 'entity') return { width, maxWidth, borderRadius: 24 };
   return { width, maxWidth, borderRadius: 28 };
 }
@@ -743,6 +743,8 @@ function InputRow({
   attachDisabledForPicker,
   isHero,
 }: InputRowProps) {
+  const useHeroPill = isHero && !hasPendingImages;
+
   return (
     <div className={cn(hasBorderTop && 'border-t border-white/[0.065]')}>
       {hasPendingImages && onRemoveImage ? (
@@ -757,10 +759,15 @@ function InputRow({
       <div
         ref={containerRef}
         className={cn(
-          'relative grid gap-2',
-          isHero
-            ? 'min-h-[116px] grid-rows-[minmax(32px,auto)_44px] px-4 py-3'
-            : 'min-h-[88px] grid-rows-[minmax(24px,auto)_40px] px-3 py-2.5'
+          'relative',
+          useHeroPill
+            ? 'flex min-h-[68px] items-center gap-2 px-3 py-2 sm:min-h-[72px] sm:px-4'
+            : [
+                'grid gap-2',
+                isHero
+                  ? 'min-h-[96px] grid-rows-[minmax(32px,auto)_40px] px-4 py-2.5'
+                  : 'min-h-[88px] grid-rows-[minmax(24px,auto)_40px] px-3 py-2.5',
+              ]
         )}
       >
         <div ref={hiddenDivRef} style={HIDDEN_DIV_STYLES} aria-hidden />
@@ -768,7 +775,11 @@ function InputRow({
           data-testid='chat-input-inline-field'
           className={cn(
             'flex w-full min-w-0 flex-wrap items-start gap-x-1.5 gap-y-1.5',
-            isHero ? 'min-h-8 px-2 pt-1' : 'min-h-7 px-1 pt-0.5'
+            useHeroPill
+              ? 'min-h-10 flex-1 items-center px-1 pt-0'
+              : isHero
+                ? 'min-h-8 px-2 pt-1'
+                : 'min-h-7 px-1 pt-0.5'
           )}
         >
           {chips && chips.length > 0 && onRemoveChipAt ? (
@@ -826,8 +837,10 @@ function InputRow({
 
         <div
           className={cn(
-            'flex items-center justify-between gap-2',
-            isHero ? 'min-h-11' : 'min-h-10'
+            'flex items-center gap-2',
+            useHeroPill
+              ? 'min-h-10 shrink-0 justify-end'
+              : ['justify-between', isHero ? 'min-h-10' : 'min-h-10']
           )}
         >
           <div className='flex min-w-0 items-center gap-2'>

--- a/apps/web/components/jovie/components/SuggestedPrompts.tsx
+++ b/apps/web/components/jovie/components/SuggestedPrompts.tsx
@@ -91,7 +91,7 @@ function SuggestionPill({
       aria-disabled={disabled}
       title={disabledReason ?? undefined}
     >
-      <span className='flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-black/[0.035] text-secondary-token transition-colors duration-subtle group-hover:bg-black/[0.05] group-hover:text-primary-token dark:bg-white/[0.045] dark:group-hover:bg-white/[0.065]'>
+      <span className='flex h-4 w-4 shrink-0 items-center justify-center text-tertiary-token transition-colors duration-subtle group-hover:text-primary-token'>
         {IconComponent && <IconComponent className='h-3.5 w-3.5 shrink-0' />}
       </span>
       <span className='min-w-0 flex-1 truncate leading-none'>

--- a/apps/web/components/jovie/components/chat-prompt-styles.ts
+++ b/apps/web/components/jovie/components/chat-prompt-styles.ts
@@ -1,5 +1,5 @@
 export const CHAT_PROMPT_RAIL_SCROLL_CLASS =
-  'w-full overflow-x-auto overflow-y-hidden scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
+  'w-full overflow-x-auto overflow-y-hidden [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
 
 export const CHAT_PROMPT_RAIL_CLASS =
   'flex min-w-full flex-nowrap items-stretch gap-1.5';

--- a/apps/web/tests/unit/chat/ChatInput.test.tsx
+++ b/apps/web/tests/unit/chat/ChatInput.test.tsx
@@ -261,15 +261,73 @@ describe('ChatInput', () => {
     const surface = screen.getByTestId('chat-composer-surface');
     expect(surface.getAttribute('data-variant')).toBe('hero');
     expect(surface.style.maxWidth).toBe('min(calc(100vw - 32px), 840px)');
+    expect(surface.style.borderRadius).toBe('36px');
+
+    expect(surface.firstElementChild?.firstElementChild?.className).toContain(
+      'min-h-[68px]'
+    );
 
     const inlineField = screen.getByTestId('chat-input-inline-field');
-    expect(inlineField.className).toContain('min-h-8');
+    expect(inlineField.className).toContain('min-h-10');
 
     const textarea = screen.getByRole('textbox', {
       name: /chat message input/i,
     });
     expect(textarea.className).toContain('text-[18px]');
     expect(textarea.className).toContain('leading-7');
+  });
+
+  it('renders the larger hero pill geometry even while typing the first message in an empty chat', () => {
+    fastRender(
+      withProviders(
+        <ChatInput
+          {...baseProps}
+          value='draft message'
+          onImageAttach={vi.fn()}
+          variant='hero'
+        />
+      )
+    );
+
+    const surface = screen.getByTestId('chat-composer-surface');
+    expect(surface.style.borderRadius).toBe('36px');
+
+    expect(surface.firstElementChild?.firstElementChild?.className).toContain(
+      'min-h-[68px]'
+    );
+  });
+
+  it('renders the grid layout (not pill) for hero variant when pending images are present', () => {
+    const pendingImages = [
+      {
+        id: 'p1',
+        name: 'preview.png',
+        mediaType: 'image/png',
+        previewUrl: 'blob:mock',
+        dataUrl: 'data:image/png;base64,AAAA',
+      },
+    ];
+    fastRender(
+      withProviders(
+        <ChatInput
+          {...baseProps}
+          value=''
+          onImageAttach={vi.fn()}
+          pendingImages={pendingImages}
+          onRemoveImage={vi.fn()}
+          variant='hero'
+        />
+      )
+    );
+
+    const surface = screen.getByTestId('chat-composer-surface');
+    expect(surface.style.borderRadius).toBe('36px'); // geometry still 36 for hero non-entity
+
+    const inlineField = screen.getByTestId('chat-input-inline-field');
+    const container = inlineField.parentElement;
+    expect(container?.className).toContain('min-h-[96px]');
+    expect(container?.className).toContain('grid');
+    expect(container?.className).not.toContain('min-h-[68px]');
   });
 
   it('keeps a quiet disabled dictation control when speech input is unavailable', () => {

--- a/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.analytics-card.test.tsx
@@ -95,7 +95,9 @@ describe('ChatMessage analytics cards', () => {
     const carousel = screen.getByTestId('chat-analytics-signal-carousel');
     expect(carousel).toBeTruthy();
     expect(carousel.className).toContain('md:grid-cols-3');
-    expect(screen.getByTestId('chat-analytics-signal-card')).toBeTruthy();
+    const signalCard = screen.getByTestId('chat-analytics-signal-card');
+    expect(signalCard).toBeTruthy();
+    expect(signalCard.className).toContain('min-w-[min(20rem,84vw)]');
     expect(screen.getByText('Top signals')).toBeTruthy();
     expect(
       screen.getByText('Subscribers are picking up in Chicago')

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -172,6 +172,9 @@ describe('JovieChat empty state', () => {
     expect(getByTestId('chat-empty-state-top-signals-row').className).toContain(
       'lg:grid-cols-3'
     );
+    expect(getByTestId('chat-empty-state-top-signals-row').className).toContain(
+      'snap-x'
+    );
     expect(getByText('Release plan')).toBeTruthy();
     expect(getByText('Asset brief')).toBeTruthy();
     expect(getByText('Context')).toBeTruthy();

--- a/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
+++ b/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
@@ -33,12 +33,27 @@ describe('SuggestedPrompts', () => {
 
     const rail = getByTestId('suggested-prompts-rail');
     expect(rail.className).toContain('overflow-x-auto');
+    expect(rail.className).not.toContain('scroll-smooth');
     expect(rail.className).not.toContain('md:overflow-visible');
     const row = rail.firstElementChild;
     expect(row?.className).toContain('snap-x');
     expect(row?.className).toContain('flex-nowrap');
     expect(row?.className).not.toContain('flex-wrap');
     expect(row?.className).toContain('whitespace-nowrap');
+  });
+
+  it('uses flat prompt icons without always-on icon backgrounds', () => {
+    const onSelect = vi.fn();
+    const { getByRole } = fastRender(<SuggestedPrompts onSelect={onSelect} />);
+
+    const iconShell = getByRole('button', {
+      name: 'Plan a release',
+    }).firstElementChild;
+
+    expect(iconShell?.className).toContain('text-tertiary-token');
+    expect(iconShell?.className).not.toContain('rounded-full');
+    expect(iconShell?.className).not.toContain('bg-black');
+    expect(iconShell?.className).not.toContain('dark:bg-white');
   });
 
   it('renders a grid layout when requested', () => {


### PR DESCRIPTION
Wave 1 shell-v1 chat empty-state + composer polish for JOV-2496.

## Changes (HOT ZONE only)
- apps/web/components/jovie/JovieChat.tsx: EmptyStateSignalCards (bento responsive), hero composer region, show/hide logic for prompts.
- apps/web/components/jovie/components/ChatInput.tsx: hero vs compact variants, geometry (36r large pill for empty), showStarterPrompts gating.
- apps/web/components/jovie/components/SuggestedPrompts.tsx + chat-prompt-styles.ts: rail layout horizontal manual carousel.
- ChatAnalyticsCard.tsx: responsive signal carousel/grid.
- Unit tests updated for coverage.

## Acceptance
- Empty composer: centered large pill, not overpadded; switches post-send.
- Pills: under empty only (single horiz manual scroll, no auto); hidden on type.
- Signals: bento cards (Apple-mentor style), carousel→3col.
- No new avatars; slash/feedback work; mobile fits.

All focused tests, typecheck, biome, pre-push, a11y pass.

<!-- linear-issue-id:JOV-2496 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated empty-state top-signals card content and redesigned card layout (sizing, spacing, radius, shadow, typography, and snap/grid presentation).
  * Redesigned top-signal list with refined icon/title/description styling and adjusted responsive breakpoint behavior.
  * Adjusted chat input geometry and hero composer spacing/behavior.
  * Simplified suggested-prompt icons to a smaller, flat appearance.
  * Removed smooth-scroll from prompt rail styling.

* **Tests**
  * Updated and added unit assertions to validate the above visual and layout changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->