### PR TITLE
fix(dates): polish relative date year labels for >1y items

### DIFF
--- a/apps/web/lib/format-relative-date.test.ts
+++ b/apps/web/lib/format-relative-date.test.ts
@@ -21,9 +21,10 @@ describe('relativeDate', () => {
   it('formats older past dates without raw multi-year day counts', () => {
     expect(relativeDate('2026-04-04T12:00:00Z', NOW)).toBe('3w ago');
     expect(relativeDate('2026-01-15T12:00:00Z', NOW)).toBe('3mo ago');
-    expect(relativeDate('2024-04-19T12:00:00Z', NOW)).toBe('2y ago');
+    // >1y uses exact month+year per convention (truthful label, no approx "Ny ago")
+    expect(relativeDate('2024-04-19T12:00:00Z', NOW)).toBe('Apr 2024');
     const multiYear = relativeDate('2020-04-24T12:00:00Z', NOW);
-    expect(multiYear).toBe('6y ago');
+    expect(multiYear).toBe('Apr 2020');
     expect(multiYear).not.toMatch(/^\d{4,}d ago$/u);
   });
 

--- a/apps/web/lib/format-relative-date.ts
+++ b/apps/web/lib/format-relative-date.ts
@@ -1,8 +1,8 @@
 /**
  * Format an ISO date relative to `now`, returning short English phrasing.
- * Past: `"3d ago"` / `"Yesterday"` / `"2y ago"`. Future: `"in 3d"` /
- * `"Tomorrow"` / `"Today"`. Older past dates collapse to weeks, months, or
- * years instead of raw multi-year day counts.
+ * Past: `"3d ago"` / `"Yesterday"` / `"Mar 2024"`. Future: `"in 3d"` /
+ * `"Tomorrow"` / `"Today"`. Older past dates (>1y) use exact month+year
+ * per product convention instead of rounded year counts or raw day counts.
  *
  * `now` defaults to `new Date()` so the function is deterministic-by-call —
  * pass a fixed instant for snapshot tests, fixed-time previews, or design
@@ -26,7 +26,12 @@ export function relativeDate(iso: string, now: Date = new Date()): string {
     if (pastDays < 365) {
       return `${Math.max(1, Math.round(pastDays / 30))}mo ago`;
     }
-    return `${Math.max(1, Math.round(pastDays / 365))}y ago`;
+    // >1 year past: exact "Mar 2024" (month+year) — human, truthful,
+    // never emits huge day counts; follows date label conventions.
+    return new Date(iso).toLocaleDateString(undefined, {
+      month: 'short',
+      year: 'numeric',
+    });
   }
   if (days > 0 && days <= 7) return `in ${days}d`;
   return new Date(iso).toLocaleDateString(undefined, {


### PR DESCRIPTION
## Summary
Small polish to `relativeDate` in shell-v1 surfaces (releases list, task updated timestamps).

- For dates >1 year old: now renders exact month+year (e.g. `Apr 2024`, `May 2014`) instead of rounded `Ny ago` or (never) huge `2193d ago`.
- Keeps all <1y behavior (`3d ago`, `3w ago`, `3mo ago`) and future absolute dates unchanged.
- Matches existing product date conventions for casing (`Apr`) and format (short month + year).
- Only touches HOT ZONE files per charter.
- Tests, typecheck, biome, lint, pre-push all green.

This eliminates the bad old-date labels reported in the shell-v1 handoff.

## Files
- apps/web/lib/format-relative-date.ts
- apps/web/lib/format-relative-date.test.ts

## QA
- Unit tests pass
- Manual verification of old dates produces human labels
- Local dev server + auth bypass + visual inspection of shell surfaces (releases/tasks in exp demo)
- Design review: no visual/layout impact (text content only); labels now more truthful/exact
- Ready for /ship

Refs: shell-v1 handoff Wave 0/5, Linear follow-up on relative date year labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date display for past dates older than 1 year. Previously showed approximate durations (e.g., "5y ago"), now displays exact month and year (e.g., Apr 2024) for greater clarity and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->