### PR TITLE
fix(admin): investor table token/row alignment using canonical shell row primitives

### DIFF
--- a/apps/web/app/app/(shell)/admin/investors/TokenCopyButton.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/TokenCopyButton.tsx
@@ -15,7 +15,7 @@ export function TokenCopyButton({ token }: Readonly<TokenCopyButtonProps>) {
           // Ignore clipboard failures in insecure/local contexts.
         });
       }}
-      className='inline-flex items-center gap-1 text-2xs text-tertiary-token transition-colors hover:text-secondary-token'
+      className='inline-flex items-center gap-1 font-mono text-2xs text-tertiary-token transition-[color,opacity] hover:text-secondary-token'
       title='Click to copy full token'
     >
       {token.slice(0, 8)}&hellip;

--- a/apps/web/app/app/(shell)/admin/investors/_components/InvestorTablePrimitives.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/_components/InvestorTablePrimitives.tsx
@@ -8,6 +8,7 @@ import {
   TableRoot,
   TableRow,
 } from '@/components/organisms/table';
+import { rowState } from '@/components/organisms/table/table.styles';
 import { cn } from '@/lib/utils';
 
 export function InvestorTable({
@@ -61,7 +62,7 @@ export function InvestorTableHeaderCell({
     <TableHeaderCell
       align={align}
       sticky={false}
-      className={cn('px-4 py-2.5 font-medium', className)}
+      className={cn('px-3 py-1.5 font-medium', className)}
     >
       {children}
     </TableHeaderCell>
@@ -72,7 +73,13 @@ export function InvestorTableRow({
   children,
 }: Readonly<{ children: ReactNode }>) {
   return (
-    <TableRow className='border-b border-subtle bg-transparent transition-colors duration-subtle hover:bg-surface-0'>
+    <TableRow
+      className={cn(
+        'border-b border-subtle bg-transparent',
+        rowState.base,
+        rowState.hover
+      )}
+    >
       {children}
     </TableRow>
   );
@@ -90,7 +97,7 @@ export function InvestorTableCell({
   return (
     <TableCell
       align={align}
-      className={cn('px-4 py-3 align-middle', className)}
+      className={cn('px-3 py-1 align-middle', className)}
     >
       {children}
     </TableCell>

--- a/apps/web/app/app/(shell)/admin/investors/page.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/page.tsx
@@ -215,7 +215,7 @@ async function InvestorPipelineTable() {
           {links.map(link => (
             <InvestorTableRow key={link.id}>
               <InvestorTableCell className='w-[200px]'>
-                <div className='flex min-w-0 flex-col'>
+                <div className='flex min-w-0 flex-col gap-0.5'>
                   <span className='truncate font-semibold text-primary-token'>
                     {link.label}
                   </span>


### PR DESCRIPTION
## Summary
Polish for admin investor tables (pipeline + links manager) from shell-v1 handoff Wave 0 item.

- Final token/row alignment to canonical shell row primitives (`rowState` from `components/organisms/table/table.styles`).
- Row hover/transition now uses Linear `--linear-row-hover` tokens + base transition for consistency with all shell tables (ops, waitlist, dashboard, etc.).
- Cell/header paddings converged to canonical `px-3 py-1*` (from `alignment` + `TableCell`/`TableHeaderCell`).
- Token display in first column (`TokenCopyButton`) uses `font-mono` for glyph alignment across rows.
- Minor `gap-0.5` on stacked label+token content to fit new tighter cell padding.

3 files, 7 net LOC. Smallest correct change.

## Pre-Landing Review
- No SQL, no data writes, no auth/trust changes.
- Uses existing canonical imports only (no new tokens, no new primitives).
- Normalization test, unit table row tests, biome, eslint, typecheck all green.
- Visual: row chrome now matches shell list rows; token chars monospaced for vertical alignment in column.

## Design Review
N/A (internal table token polish; no new UI surfaces, no color/pixel changes beyond convergence to existing design tokens).

## Test plan
- [x] `vitest run .../admin-investors-shell-normalization.test.ts` — PASS
- [x] `vitest run .../ShellListRowFrame.test.tsx` + canonical-row-guard — PASS
- [x] `pnpm turbo typecheck --filter=@jovie/web` — PASS
- [x] `pnpm biome check .../investors/` — PASS
- [x] Local visual inspection of row hover, padding consistency, mono token in pipeline table.

🤖 Small-win subagent (JOVIE_AGENT_PROFILE=coder, isolated worktree)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined investor table appearance with improved row styling and more consistent spacing.
  * Enhanced token copy button with improved visual layout and smoother color transitions.
  * Adjusted table cell padding and text styling for better visual organization in the investor section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->