### PR TITLE
fix(admin): converge ActivityTable to shell row primitives

### DIFF
--- a/apps/web/components/features/admin/ActivityTableUnified.tsx
+++ b/apps/web/components/features/admin/ActivityTableUnified.tsx
@@ -70,9 +70,6 @@ interface ActivityTableUnifiedProps {
   readonly items: AdminActivityItem[];
 }
 
-/** Standard row class for activity table */
-const getRowClassName = () => 'group hover:bg-(--linear-row-hover)';
-
 const columnHelper = createColumnHelper<AdminActivityItem>();
 
 // Column definitions are shared between the live table and its skeleton so that
@@ -165,7 +162,6 @@ export function ActivityTableUnified({
             </div>
           }
           getRowId={row => row.id}
-          getRowClassName={getRowClassName}
         />
       </div>
     </div>


### PR DESCRIPTION
High-confidence narrow table/row convergence from shell-v1 handoff.

Removes a now-redundant `getRowClassName` helper in the Admin Activity table that duplicated the canonical shell primitives (`rowState.hover` via `presets.tableRow` / `ShellListRowFrame` / `UnifiedTable`).

- 1 file, 4 lines deleted
- No behavior or visual change (rows now fully owned by the converged shell system)
- All local gates passed (typecheck, biome, eslint, a11y, targeted table tests)
- Part of the proactive small-wins program for the unified app shell migration

Ready for /ship + autonomous land per standing rules (gates clean + no bot comments expected on this size change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed hover background styling from activity table rows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->