### PR TITLE
fix(shell): normalize sidebar spacing, collapsed behavior, hover (no decorative motion) to converged primitives

### DIFF
--- a/apps/web/components/organisms/sidebar/controls.tsx
+++ b/apps/web/components/organisms/sidebar/controls.tsx
@@ -71,7 +71,7 @@ export const SidebarRail = React.forwardRef<
       onClick={toggleSidebar}
       title='Toggle Sidebar'
       className={cn(
-        'absolute inset-y-0 z-20 max-sm:hidden w-4 -translate-x-1/2 transition-[transform] duration-subtle ease-subtle after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] after:transition-colors after:duration-subtle after:ease-subtle hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
+        'absolute inset-y-0 z-20 max-sm:hidden w-4 -translate-x-1/2 transition-[transform] duration-fast ease-interactive after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] after:transition-colors after:duration-fast after:ease-interactive hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
         'focus-visible:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35',
         'in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize',
         'in-data-[side=left][data-state=closed]:cursor-e-resize in-data-[side=right][data-state=closed]:cursor-w-resize',

--- a/apps/web/components/shell/SidebarBottomNowPlaying.tsx
+++ b/apps/web/components/shell/SidebarBottomNowPlaying.tsx
@@ -42,7 +42,7 @@ export function SidebarBottomNowPlaying({
   return (
     <div
       className={cn(
-        'flex items-center gap-2 h-12 px-1.5 rounded-md hover:bg-surface-1/40 transition-colors duration-150 ease-out',
+        'flex items-center gap-2.5 h-11 px-2.5 rounded-[10px] hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] transition-[background-color] duration-fast ease-interactive',
         className
       )}
     >
@@ -73,7 +73,7 @@ export function SidebarBottomNowPlaying({
         type='button'
         onClick={onPlay}
         aria-label={isPlaying ? 'Pause' : 'Play'}
-        className='shrink-0 h-7 w-7 rounded-full grid place-items-center text-primary-token hover:bg-surface-1/70 transition-colors duration-150 ease-out'
+        className='shrink-0 h-7 w-7 rounded-md grid place-items-center text-primary-token hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] transition-[background-color] duration-fast ease-interactive'
       >
         {isPlaying ? (
           <Pause className='h-3 w-3' strokeWidth={2.5} fill='currentColor' />

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -30,10 +30,10 @@ export function SidebarNavItem({
   nested,
   tight,
 }: SidebarNavItemProps) {
-  const nonCollapsedSize = tight ? 'h-6 pl-2.5 pr-2' : 'h-7 pl-3 pr-2';
+  const nonCollapsedSize = tight ? 'h-6 pl-2.5 pr-2' : 'h-6.5 pl-2.5 pr-2';
   const inactiveColor = nested
-    ? 'text-tertiary-token hover:bg-surface-1/40 hover:text-primary-token'
-    : 'text-secondary-token hover:bg-surface-1/60 hover:text-primary-token';
+    ? 'text-tertiary-token hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] hover:text-primary-token'
+    : 'text-secondary-token hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] hover:text-primary-token';
   const inactiveIconColor = nested
     ? 'text-quaternary-token'
     : 'text-tertiary-token';
@@ -43,9 +43,9 @@ export function SidebarNavItem({
       type='button'
       onClick={item.onActivate}
       className={cn(
-        'relative flex items-center rounded-md w-full transition-colors duration-subtle ease-out',
-        tight ? 'gap-2 text-[12.5px]' : 'gap-2.5 text-[13px]',
-        collapsed ? 'h-8 w-10 mx-auto justify-center' : nonCollapsedSize,
+        'relative flex items-center rounded-md w-full transition-[background-color] duration-fast ease-interactive',
+        tight ? 'gap-2 text-[12px]' : 'gap-2.5 text-[12.5px]',
+        collapsed ? 'h-7 w-10 mx-auto justify-center' : nonCollapsedSize,
         item.active ? 'text-primary-token bg-surface-1' : inactiveColor
       )}
     >

--- a/apps/web/components/shell/SidebarSection.tsx
+++ b/apps/web/components/shell/SidebarSection.tsx
@@ -71,8 +71,8 @@ export function SidebarSection({
         type='button'
         onClick={onToggle}
         className={cn(
-          'relative w-full flex items-center gap-2.5 pl-3 pr-2 rounded-md hover:bg-surface-1/70 transition-colors duration-subtle ease-out',
-          tight ? 'h-6' : 'h-7'
+          'relative w-full flex items-center gap-2.5 pl-2.5 pr-2 rounded-md hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] transition-[background-color] duration-fast ease-interactive',
+          tight ? 'h-6' : 'h-6.5'
         )}
         aria-expanded={open}
       >

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -108,7 +108,7 @@ export function SidebarThreadsSection({
 
   return (
     <div className='space-y-1'>
-      <div className='flex items-center justify-between px-3 pb-1 pt-1.5'>
+      <div className='flex items-center justify-between px-2.5 pb-1 pt-1.5'>
         <span className='text-[11px] font-medium text-quaternary-token'>
           Threads
         </span>
@@ -144,7 +144,7 @@ export function SidebarThreadsSection({
           <div
             className={cn(
               'flex items-center gap-2 rounded-md px-3 text-tertiary-token',
-              tight ? 'h-6 text-[12px]' : 'h-7 text-[12.5px]'
+              tight ? 'h-6 text-[12px]' : 'h-6.5 text-[12.5px]'
             )}
           >
             <span className='min-w-0 flex-1 truncate'>Threads unavailable</span>
@@ -153,7 +153,7 @@ export function SidebarThreadsSection({
                 type='button'
                 onClick={onRetry}
                 aria-label='Retry threads'
-                className='grid h-5 w-5 shrink-0 place-items-center rounded text-quaternary-token transition-colors duration-subtle ease-out hover:bg-sidebar-accent/55 hover:text-primary-token'
+                className='grid h-5 w-5 shrink-0 place-items-center rounded text-quaternary-token transition-[background-color] duration-fast ease-interactive hover:bg-sidebar-accent/55 hover:text-primary-token'
               >
                 <RefreshCw
                   className='h-3 w-3'
@@ -169,8 +169,8 @@ export function SidebarThreadsSection({
             type='button'
             onClick={onNewThread}
             className={cn(
-              'flex items-center gap-2 rounded-md px-3 text-left text-tertiary-token transition-colors duration-subtle ease-out hover:bg-sidebar-accent/55 hover:text-primary-token',
-              tight ? 'h-6 text-[12px]' : 'h-7 text-[12.5px]'
+              'flex items-center gap-2 rounded-md px-3 text-left text-tertiary-token transition-[background-color] duration-fast ease-interactive hover:bg-sidebar-accent/55 hover:text-primary-token',
+              tight ? 'h-6 text-[12px]' : 'h-6.5 text-[12.5px]'
             )}
           >
             <MessageSquarePlus
@@ -186,8 +186,8 @@ export function SidebarThreadsSection({
           const unread = !!t.unread && !active;
           const hasThreadActions = Boolean(onThreadContextMenu);
           const rowClasses = cn(
-            'flex w-full min-w-0 items-center gap-2 rounded-md text-left transition-colors duration-subtle ease-out focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35',
-            tight ? 'h-6 pl-2.5' : 'h-7 pl-3',
+            'flex w-full min-w-0 items-center gap-2 rounded-md text-left transition-[background-color] duration-fast ease-interactive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35',
+            tight ? 'h-6 pl-2.5' : 'h-6.5 pl-2.5',
             hasThreadActions ? 'pr-7' : 'pr-2',
             active
               ? 'bg-surface-1 text-primary-token'
@@ -278,7 +278,7 @@ export function SidebarThreadsSection({
         <button
           type='button'
           onClick={() => setExpanded(v => !v)}
-          className='w-full px-3 py-1 text-left text-[11px] font-medium text-quaternary-token transition-colors duration-subtle ease-out hover:text-secondary-token'
+          className='w-full px-3 py-1 text-left text-[11px] font-medium text-quaternary-token transition-[background-color] duration-fast ease-interactive hover:text-secondary-token'
         >
           {expanded ? 'Show less' : 'View all'}
         </button>


### PR DESCRIPTION
JOVIE_AGENT_PROFILE=coder

**Wave 3 small follow-up from shell-v1 handoff (high-confidence, no-ask):**

- Normalize spacing (h-6.5, px-2.5, text-[12.5px], gap-2.5, rounded-[10px]) in shell/Sidebar* components (BottomNowPlaying, ThreadsSection, NavItem, Section) to match converged sidebar primitives.
- Normalize hover transitions: removed `duration-subtle ease-out` (decorative) → `duration-fast ease-interactive` + color-mix hovers per menu button.
- Rail hover in primitives normalized.
- Collapsed/open item heights aligned (h-7 icon mode).
- State persists across warm (client) route nav because `SidebarProvider` + `useSidebarCookieState` live in the stable `AuthShell` tree (mounted once in `(shell)/layout` via `AuthShellWrapper`); cookie + DB for cold loads + server action sync.
- Floating/collapsed variants in primitives untouched (usage is offcanvas/sidebar); keyboard (Cmd+B / `[`) already wired in context, persists with provider.
- HOT ZONE only: shell/Sidebar*, organisms/sidebar/controls, no other files.

**Verification (autonomous):**
- `pnpm biome check --write` + full pre-push (biome/lint/type/tailwind/proxy) ✅
- Focused vitest on edited: 13/13 pass ✅
- `pnpm typecheck:web:fast` ✅
- 5 files, -19/+19 net zero mechanical.
- No decorative hover motion left in touched sidebar surfaces.
- Evidence: git diff shows exact token/hover/height alignments.

Ready for /design-review + /qa --exhaustive on sidebar (open/collapsed/threads/nowplaying persistence + keyboard toggle + mobile/desktop).

Will address any bot comments, then /ship + auto land.

🤖 coder sub-agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced sidebar transitions and hover animations for smoother user interactions across the interface
  * Updated navigation item spacing and visual styling in sidebar components
  * Improved hover background color effects and transition timing for better responsive feedback
  * Refined sidebar section header styling and layout spacing
  * Adjusted thread row styling and expand/collapse button interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->