### PR TITLE
fix(shell): command palette as single global search (remove legacy / hint in filter trigger)

### DIFF
--- a/apps/web/components/shell/HeaderSearchSurface.tsx
+++ b/apps/web/components/shell/HeaderSearchSurface.tsx
@@ -65,7 +65,6 @@ export function HeaderSearchSurface({
           {visibleCount}
           {showFilteredOf ? ` of ${adapter.totalCount}` : ''}
         </span>
-        <span className='hidden text-tertiary-token lg:inline'>/</span>
       </button>
     );
   }


### PR DESCRIPTION
## Summary
- Removed the legacy '/' visual hint from the closed state of the route-specific header filter search trigger ().
- The command palette (Cmd+K / sidebar Search) is now the unambiguous single global search path for routes, releases, artists, threads, skills.
- Route-specific filters (library, releases via  + PillSearch) remain for their allowed facets; no global-search duplicate chrome left in the authenticated shell.
- Smallest subtraction; no behavior change.

## QA
- Focused tests + typecheck + biome passed.
- Change isolated to search-related shell chrome in HOT ZONE.
- Pre-push hooks clean.

## Follow-up
From shell-v1 Wave 3 handoff. No Linear JOV yet (ad-hoc smallwin); created for tracking if needed.

## Evidence
- Before: filter trigger showed 'Filter 123 /'
- After: clean 'Filter 123' (palette owns global search entry points and shortcuts).

Gates will be run via /ship.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined search results counter display by removing unnecessary separators in the search interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->