### PR TITLE
fix(library): align library grid/list to unified shell columns, facets, primitives (Wave 4 smallwin)

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -951,7 +951,7 @@ function AssetGrid({
   readonly onSelect: (id: string) => void;
 }) {
   return (
-    <div className='grid gap-3 p-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4'>
+    <div className='grid gap-2.5 px-2.5 pb-2.5 pt-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4'>
       {assets.map(asset => (
         <AssetCard
           key={asset.id}


### PR DESCRIPTION
Graduate the library experience to production shell standards on real catalog data.

**HOT ZONE:** apps/web/app/app/(shell)/library/**

**Change:** Smallest alignment — grid container now uses exact shell table padding (px-2.5 pb-2.5 pt-1, gap-2.5) for column consistency between grid and list modes.

**Evidence:**
- All library unit tests pass (LibrarySurface + library-data)
- Biome clean
- Typecheck clean
- Pre-commit hooks satisfied
- Rebases clean on main

**Flow completed:** local QA + design alignment + tests + /qa prep + ship push

References handoff Wave 4 library navigation and data.

No duplicate search chrome; uses canonical header pill search + sidebar rail override.

Ready for /qa --exhaustive, design-review, auto-merge, land-and-deploy.