### PR TITLE
feat(shell): integrate lyrics/screening-room into unified app shell (Wave 7)

### DIFF
--- a/apps/web/components/organisms/AuthShell.tsx
+++ b/apps/web/components/organisms/AuthShell.tsx
@@ -26,6 +26,7 @@ export interface AuthShellProps {
   readonly headerAction?: ReactNode;
   readonly showMobileTabs?: boolean;
   readonly isTableRoute?: boolean;
+  readonly isLyricsRoute?: boolean;
   readonly onSidebarOpenChange?: (open: boolean) => void;
   readonly sidebarDefaultOpen?: boolean;
   readonly children: ReactNode;
@@ -43,6 +44,7 @@ function AuthShellInner({
   headerAction,
   showMobileTabs = false,
   isTableRoute = false,
+  isLyricsRoute = false,
   children,
 }: Readonly<Omit<AuthShellProps, 'children'> & { children: ReactNode }>) {
   const { isMobile } = useSidebar();
@@ -54,6 +56,7 @@ function AuthShellInner({
   const sidebarTrigger = isMobile ? null : <SidebarTrigger />;
 
   const isInSettings = section === 'settings';
+  const hideTopHeader = isInSettings || isLyricsRoute;
 
   // Memoize the sidebar so it doesn't re-render on breadcrumb/header changes.
   // The sidebar only depends on `section` — it shouldn't remount when
@@ -85,7 +88,7 @@ function AuthShellInner({
     <AppShellFrame
       sidebar={sidebar}
       header={
-        isInSettings ? null : (
+        hideTopHeader ? null : (
           <DashboardHeader
             breadcrumbs={breadcrumbs}
             sidebarTrigger={sidebarTrigger}

--- a/apps/web/components/organisms/AuthShellWrapper.tsx
+++ b/apps/web/components/organisms/AuthShellWrapper.tsx
@@ -260,6 +260,7 @@ function AuthShellWrapperInner({
               headerAction={headerAction}
               showMobileTabs={config.showMobileTabs}
               isTableRoute={config.isTableRoute}
+              isLyricsRoute={config.isLyricsRoute}
               onSidebarOpenChange={
                 persistSidebarCollapsed ? handleSidebarOpenChange : undefined
               }

--- a/apps/web/hooks/useAuthRouteConfig.ts
+++ b/apps/web/hooks/useAuthRouteConfig.ts
@@ -22,6 +22,7 @@ export interface AuthRouteConfig {
   isChatRoute: boolean;
   isDemoRoute: boolean;
   showChatUsageIndicator: boolean;
+  isLyricsRoute: boolean;
 }
 
 function isChatThreadPath(parts: readonly string[]): boolean {
@@ -173,6 +174,13 @@ export function useAuthRouteConfig(): AuthRouteConfig {
     [pathname]
   );
 
+  const isLyricsRoute = useMemo(
+    () =>
+      pathname === APP_ROUTES.LYRICS ||
+      Boolean(pathname?.startsWith(`${APP_ROUTES.LYRICS}/`)),
+    [pathname]
+  );
+
   return {
     section,
     breadcrumbs,
@@ -182,5 +190,6 @@ export function useAuthRouteConfig(): AuthRouteConfig {
     isChatRoute,
     isDemoRoute,
     showChatUsageIndicator: isChatRoute,
+    isLyricsRoute,
   };
 }

--- a/apps/web/tests/unit/components/AuthShellWrapper.test.tsx
+++ b/apps/web/tests/unit/components/AuthShellWrapper.test.tsx
@@ -12,6 +12,7 @@ vi.mock('@/hooks/useAuthRouteConfig', () => ({
     isDemoRoute: false,
     isChatRoute: false,
     showChatUsageIndicator: false,
+    isLyricsRoute: false,
   }),
 }));
 

--- a/apps/web/tests/unit/components/organisms/AuthShellWrapper.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AuthShellWrapper.test.tsx
@@ -17,6 +17,7 @@ const { previewPanelProviderMock, useAuthRouteConfigMock } = vi.hoisted(() => ({
     isDemoRoute: false,
     isChatRoute: false,
     showChatUsageIndicator: false,
+    isLyricsRoute: false,
   })),
 }));
 // AuthShellWrapper pulls in context providers, @jovie/ui Sheet components,
@@ -126,6 +127,7 @@ describe('AuthShellWrapper', () => {
       isDemoRoute: false,
       isChatRoute: false,
       showChatUsageIndicator: false,
+      isLyricsRoute: false,
     });
   });
 
@@ -163,6 +165,7 @@ describe('AuthShellWrapper', () => {
       isDemoRoute: false,
       isChatRoute: false,
       showChatUsageIndicator: false,
+      isLyricsRoute: false,
     });
 
     render(
@@ -187,6 +190,7 @@ describe('AuthShellWrapper', () => {
       isDemoRoute: false,
       isChatRoute: true,
       showChatUsageIndicator: true,
+      isLyricsRoute: false,
     });
 
     render(


### PR DESCRIPTION
## Summary
Smallest correct integration of the lyrics (screening-room) route into the converged shell-v1 frame:
- Lyrics now renders cleanly inside the shell content surface without duplicate headers (shell DashboardHeader suppressed on /app/lyrics/*, matching the settings pattern).
- `isLyricsRoute` plumbed through `useAuthRouteConfig` → `AuthShell` for route-aware chrome decisions.
- Preserves: global audio player state (no restart on warm nav), Esc/keyboard (existing handlers in `PersistentAudioBar` + `LyricsPageClient`), `?from=` return routing from releases/library/chat, cinematic shell tokens, reduced-motion parity, mobile bottom nav, sidebar.
- Entry via audio bar lyrics button (L key), play from library/releases rows, direct URL all feel native.

## Scope (HOT ZONE only)
- `apps/web/hooks/useAuthRouteConfig.ts`
- `apps/web/components/organisms/AuthShell.tsx`
- `apps/web/components/organisms/AuthShellWrapper.tsx`
- Related test mocks

## Verification
- All lyrics + audio + shell-route unit tests pass.
- `pnpm --filter @jovie/web run typecheck`
- `pnpm biome check --write apps/web`
- Pre-commit hooks (biome, eslint, a11y, typecheck-singleflight) passed on commit.
- Rebased on main.

## Follow-up (if any)
None — this completes the minimal Wave 7 lyrics cohesion per handoff.

Refs: shell-v1-unified-app-shell-agent-handoff-20260518.md (Wave 7)
JOVIE_AGENT_PROFILE=coder (isolated worktree)

## QA Plan
- Visual: desktop/tablet/mobile — confirm single immersive lyrics header at top of rounded content pane, audio bar below timeline, no overlap or cut-off.
- Interaction: enter lyrics from release row play → audio L, from library, from chat context if any; Esc closes to correct return (library or explicit ?from); space toggles playback; L toggles close; warm nav no audio restart.
- Keyboard: predictable, no double handlers.
- Exhaustive via /qa --exhaustive + design review.

(Opened as draft per incremental shipping.)