### PR TITLE
fix(tasks): converge list rows, subview, action menus and alignment to shell-v1 row primitives

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskDataTable.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskDataTable.tsx
@@ -13,7 +13,7 @@ export const TASK_DATA_TABLE_CONTAINER_CLASSNAME =
   'h-full overflow-y-auto overflow-x-hidden px-2.5 pb-2 pt-0.5';
 
 export const TASK_DATA_TABLE_ROW_CLASSNAME =
-  'group/task-row bg-transparent shadow-none hover:bg-transparent focus-within:shadow-none focus-visible:bg-transparent focus-visible:shadow-none';
+  'group/row group/task-row bg-transparent shadow-none hover:bg-transparent focus-within:shadow-none focus-visible:bg-transparent focus-visible:shadow-none';
 
 export type TaskDataTableProps<TData> = UnifiedTableProps<TData>;
 

--- a/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskListRow.tsx
@@ -124,7 +124,7 @@ export function TaskListRow({
       isSelected={isSelected}
       interaction='task-row-group'
       className={cn(
-        'grid h-full grid-cols-[1.25rem_minmax(0,1fr)_auto] items-center gap-3 px-2.5 py-1.5 transition-[opacity]',
+        'group/row grid h-full grid-cols-[1.25rem_minmax(0,1fr)_auto] items-center gap-3 px-3 py-1.5 transition-[opacity]',
         isDone && !isSelected && 'opacity-75',
         isCancelled && !isSelected && 'opacity-60'
       )}

--- a/apps/web/components/features/dashboard/tasks/TaskRowActionMenu.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskRowActionMenu.tsx
@@ -22,7 +22,7 @@ export function getTaskRowActionTriggerClassName({
     'hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_68%,transparent)] hover:text-primary-token',
     'focus-visible:outline-none focus-visible:bg-[color-mix(in_oklab,var(--linear-row-hover)_70%,transparent)] focus-visible:text-primary-token',
     visibility === 'hover' && [
-      'opacity-0 group-hover/task-board-card-shell:opacity-100 group-focus-visible/task-board-card-shell:opacity-100 group-hover/task-row:opacity-100 group-focus-visible/task-row:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100',
+      'opacity-0 group-hover/row:opacity-100 group-focus-visible/row:opacity-100 group-hover/task-board-card-shell:opacity-100 group-focus-visible/task-board-card-shell:opacity-100 group-hover/task-row:opacity-100 group-focus-visible/task-row:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100',
       selected && 'opacity-100',
     ]
   );

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -963,7 +963,7 @@ function TaskLoadingState() {
         <ShellListRowFrame
           key={row.key}
           interaction='none'
-          className='grid min-h-16 grid-cols-[1.25rem_minmax(0,1fr)_auto] items-center gap-3 px-2.5 py-1.5'
+          className='group/row grid min-h-16 grid-cols-[1.25rem_minmax(0,1fr)_auto] items-center gap-3 px-3 py-1.5'
         >
           <div className='skeleton h-4 w-4 rounded-full' />
           <div className='min-w-0 space-y-2'>


### PR DESCRIPTION
## Summary

Converges the tasks surfaces (list rows via TaskListRow + TaskDataTable, action menus, loading, subview-adjacent layout) to the canonical shell row/table patterns landed in releases (ShellReleaseRow) and admin tables.

## Changes (smallest correct)
- Standardized `group/row` + `group/task-row` on table rows and ShellListRowFrames for action hover affordances (matches release `group/row` + hover selectors).
- Updated TaskRowActionMenu hover classes to include canonical `group-hover/row`.
- Aligned padding (`px-3`) on task rows/skeletons to shell list row standard.
- HOT ZONE only: apps/web/app/app/(shell)/dashboard/tasks/** + components/features/dashboard/tasks/** . Reuses primitives exclusively.
- No schema, no new components, no behavior change.

## Verification
- `pnpm biome check --write` (edited files)
- `pnpm --filter @jovie/web run typecheck`
- Unit tests: TaskDataTable, TasksPageClient (51), TaskRowActionMenu (6) — all pass
- Follows AGENTS.md, .claude/rules/* (ui, testing, release, code-style)

## Wave 5 Slice
Per handoff 20260518: Tasks row/detail/action/release-entity hover convergence where APIs support.

Part of shell-v1 unified app shell migration (blanket "just do it" autonomous gstack flow).

## Screenshots / QA
Local exhaustive visual + /qa --exhaustive to follow in comments (desktop 1440x960, tablet 768x1024, mobile 390x844; list/board/detail open states).

Closes: (Wave 5 tasks slice)

---

**PR discipline:** 4 files, <20 lines. One concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined task list layout spacing for improved visual alignment
  * Enhanced visibility of action buttons on hover and focus for task rows
  * Optimized grouping behavior of task row elements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->