### PR TITLE
fix(shell): normalize global keyboard shortcuts + command palette ownership polish

### DIFF
--- a/apps/web/components/features/dashboard/layout/PreviewToggleButton.tsx
+++ b/apps/web/components/features/dashboard/layout/PreviewToggleButton.tsx
@@ -11,7 +11,7 @@ export function PreviewToggleButton() {
   const Icon = isOpen ? PanelRightOpen : PanelRight;
 
   return (
-    <TooltipShortcut label={label} shortcut='Space' side='bottom'>
+    <TooltipShortcut label={label} side='bottom'>
       <DashboardHeaderActionButton
         ariaLabel={label}
         pressed={isOpen}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseFilterDropdown.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseFilterDropdown.tsx
@@ -286,7 +286,7 @@ export function ReleaseFilterDropdown({
   return (
     <div className='flex items-center gap-2'>
       <DropdownMenu open={isOpen} onOpenChange={handleOpenChange}>
-        <TooltipShortcut label='Filter' shortcut='F' side='bottom'>
+        <TooltipShortcut label='Filter' side='bottom'>
           <DropdownMenuTrigger asChild>
             <Button
               variant='ghost'

--- a/apps/web/components/molecules/filters/TableFilterDropdown.tsx
+++ b/apps/web/components/molecules/filters/TableFilterDropdown.tsx
@@ -212,7 +212,7 @@ export function TableFilterDropdown<T extends string = string>({
 
   return (
     <DropdownMenu open={isOpen} onOpenChange={handleOpenChange}>
-      <TooltipShortcut label='Filter' shortcut='F' side='bottom'>
+      <TooltipShortcut label='Filter' side='bottom'>
         <DropdownMenuTrigger asChild>
           <Button
             variant='ghost'

--- a/apps/web/lib/keyboard-shortcuts.ts
+++ b/apps/web/lib/keyboard-shortcuts.ts
@@ -124,10 +124,10 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
   {
     id: 'toggle-sidebar',
     label: 'Toggle sidebar',
-    keys: `[ · ${GLYPH_CMD} B`,
+    keys: `${GLYPH_CMD} B · [`,
     category: 'general',
     icon: PanelLeft,
-    shortcutKey: '[',
+    shortcutKey: 'Meta+b',
     decision: { status: 'required', binding: 'useSidebarKeyboardShortcut' },
   },
 


### PR DESCRIPTION
## Summary
Smallest correct normalization for shell-v1 global keyboard + Cmd+K palette ownership final polish (assigned slice of smallwin-17).

**Changes (4 files, 5+5 lines):**
- Removed vestigial decorative `F` shortcut hints from both `Filter` dropdown triggers (`TableFilterDropdown`, `ReleaseFilterDropdown`). No `F` handler was ever wired (consistent with prior #9299 `/` hint removal from filter trigger).
- Removed inconsistent `Space` hint from `PreviewToggleButton` (Space is player-scoped play/pause only).
- Normalized `toggle-sidebar` registry entry:
  - Keys now lead with primary `⌘ B · [` (Cmd/Ctrl + B documented as requested).
  - `shortcutKey: "Meta+b"` (was bare `[`; now matches global chord validation + hook).
- `useSidebarKeyboardShortcut` (wired in `SidebarProvider` + `UnifiedSidebar` contexts) + `KEYBOARD_SHORTCUTS` + `CommandPalette` (Cmd+K) + `DashboardNav` sidebar Search (opens palette via event) remain the single source of truth.
- No new raw page-level key listeners or hints introduced; all competing decorative ones removed from shell surfaces.
- Sidebar "Search" nav item continues to be the uniform entry to the global command palette (no change).

**Gates passed locally:**
- `pnpm biome check apps/web`
- `pnpm turbo typecheck --filter=./apps/web`
- 70+ targeted vitest runs: `keyboard-shortcuts*`, `useSidebarKeyboardShortcut`, `CommandPalette*`, `DashboardNav`, `command-palette-search-guard`, `useSequentialShortcuts`, `UnifiedSidebar*`
- Pre-commit proxy-guard (biome + eslint + a11y + typecheck) clean on the 4 files.
- Rebased on latest main; only HOT ZONE files touched (shell keyboard handlers, palette wiring, hints in shell surfaces, sidebar search action).

**Refs:**
- shell-v1-unified-app-shell handoff (Wave 3: "search is uniform: sidebar Search opens command palette", "Cmd+K the single unambiguous global search + action entry point", "no competing shortcuts").
- DESIGN.md / ui.md (consistent keyboard, no raw behaviors).
- Prior smallwins: #9299 (drop / hint), #9295 (sidebar normalize), #9300 (converge polish).

No product behavior change — purely consistency + removal of misleading docs/hints. Palette (Cmd+K) is now unambiguously the global search/action surface; / remains documented only for current-view filters; [ / ⌘B both wired for sidebar via the hook.

Ready for /qa --exhaustive + design review + /ship (per blanket shell migration rule).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated keyboard shortcut configurations across dashboard and filter components; removed explicit shortcut indicators from tooltips while preserving core functionality.
  * Modified the sidebar toggle shortcut key combination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->