### PR TITLE
fix(shell): remove remaining legacy '/ for fields' hints from pill filter placeholders

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -1385,7 +1385,7 @@ export function LibrarySurface({
             visibleCount: visibleAssets.length,
             triggerLabel: 'Filter',
             ariaLabel: 'Filter library assets',
-            placeholder: 'Filter library - / for fields',
+            placeholder: 'Filter library',
             allowedFields: ['artist', 'title', 'status', 'has'] as const,
           },
     [

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
@@ -800,7 +800,7 @@ export function ShellReleasesView({
       visibleCount: visibleReleases.length,
       triggerLabel: 'Filter',
       ariaLabel: 'Filter releases',
-      placeholder: 'Filter releases - / for fields',
+      placeholder: 'Filter releases',
       allowedFields: ['artist', 'title', 'album', 'status', 'has'] as const,
     }),
     [

--- a/apps/web/components/shell/HeaderSearchSurface.tsx
+++ b/apps/web/components/shell/HeaderSearchSurface.tsx
@@ -87,7 +87,7 @@ export function HeaderSearchSurface({
         statusOptions={adapter.statusOptions}
         hasOptions={adapter.hasOptions}
         ariaLabel={adapter.ariaLabel ?? `Filter ${adapter.triggerLabel}`}
-        placeholder={adapter.placeholder ?? 'Type to filter — / for fields'}
+        placeholder={adapter.placeholder ?? 'Type to filter'}
         allowedFields={adapter.allowedFields}
         onClose={handleCloseAndClear}
       />

--- a/apps/web/components/shell/PillSearch.test.tsx
+++ b/apps/web/components/shell/PillSearch.test.tsx
@@ -25,9 +25,7 @@ function setup(
 describe('PillSearch', () => {
   it('renders the search input with the empty placeholder', () => {
     setup();
-    expect(
-      screen.getByPlaceholderText('Type to filter — / for fields')
-    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Type to filter')).toBeInTheDocument();
   });
 
   it('uses a quiet tokenized focus ring instead of the cyan input ring', () => {
@@ -44,9 +42,7 @@ describe('PillSearch', () => {
     setup({
       pills: [{ id: '1', field: 'artist', op: 'is', values: ['Frank Ocean'] }],
     });
-    expect(
-      screen.getByPlaceholderText('and… (/ for fields)')
-    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('and…')).toBeInTheDocument();
   });
 
   it('opens suggestions and commits a fuzzy artist match on Enter', () => {

--- a/apps/web/components/shell/PillSearch.tsx
+++ b/apps/web/components/shell/PillSearch.tsx
@@ -157,7 +157,7 @@ export function PillSearch({
   hasOptions = HAS_VALUES,
   onClose,
   ariaLabel = 'Filter tracks',
-  placeholder = 'Type to filter — / for fields',
+  placeholder = 'Type to filter',
   allowedFields,
 }: PillSearchProps) {
   const [text, setText] = useState('');
@@ -401,7 +401,7 @@ export function PillSearch({
           aria-controls={listboxId}
           aria-autocomplete='list'
           aria-activedescendant={activeOptionId}
-          placeholder={pills.length === 0 ? placeholder : 'and… (/ for fields)'}
+          placeholder={pills.length === 0 ? placeholder : 'and…'}
           className='flex-1 min-w-[120px] rounded-sm bg-transparent text-[13px] text-primary-token outline-none placeholder:text-tertiary-token focus:outline-none focus:ring-0 focus:shadow-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/25 focus-visible:ring-offset-0 focus-visible:shadow-none'
         />
         <button


### PR DESCRIPTION
**Command palette final ownership sweep (smallwin-21 slice)**

Ensures Cmd+K (command palette) is the *absolute single global search / action entry point* with literally zero competing search chrome, hints, or behaviors in the authenticated shell surfaces.

## Change
- Removed all remaining legacy ` / for fields` (and dash variants) advertising the pill-filter slash syntax from:
  - Shared `PillSearch` component defaults + "and…" state
  - `HeaderSearchSurface` fallback
  - `LibrarySurface` and `ShellReleasesView` (shell v1 releases) `HeaderSearchAdapter` registrations
- Updated corresponding unit test expectations.

This is the mechanical follow-up to #9299 ("drop legacy / hint from filter trigger").

## Rationale
Per shell-v1 + command-palette unification charter: the palette owns global navigation, skills, entity search, and actions. Page-specific filters (Linear-style pill search in header) remain for in-view refinement but no longer surface legacy `/` hints in their chrome.

`/` shortcut for "Search current view" remains functional and documented in the keyboard shortcuts sheet for the pages that register a header filter adapter. No behavior or shortcut change.

## Verification (full autonomous gstack-equivalent)
- `pnpm biome check --write` + full `biome check apps/web` (clean)
- `pnpm --filter @jovie/web run typecheck` (clean)
- `pnpm --filter @jovie/web exec eslint` (via hook) (clean)
- Targeted vitest: PillSearch, command-palette-search-guard, LibrarySurface, ShellReleasesView (all green)
- Pre-push hook: biome + next:proxy-guard + tailwind:check + typecheck + lint (all passed)
- Rebased on main, pushed
- No new migrations, no new tokens, no new services, no API changes
- Size: 5 files, -4 net LOC (text cleanup only)

## Follow-ups
None. This closes the final hint surface for the palette ownership slice.

JOVIE_AGENT_PROFILE=coder
Slice: command-palette-final
Branch: tim/smallwin-shell-palette-final
Worktree: isolated