### PR TITLE
fix(admin): converge remaining admin/outreach table rows to shell rowState

### DIFF
--- a/apps/web/components/features/admin/CreatorProfileTableRow.tsx
+++ b/apps/web/components/features/admin/CreatorProfileTableRow.tsx
@@ -19,6 +19,7 @@ import {
   useState,
 } from 'react';
 import { toast } from 'sonner';
+import { rowState } from '@/components/organisms/table';
 import { CreatorAvatarCell } from '@/features/admin/CreatorAvatarCell';
 import { CreatorProfileSocialLinks } from '@/features/admin/CreatorProfileSocialLinks';
 import { CreatorActionsMenu } from '@/features/admin/creator-actions-menu';
@@ -40,12 +41,9 @@ const getRowClassName = (isChecked: boolean, isSelected: boolean) => {
   const baseClasses =
     'group cursor-pointer border-b border-subtle transition-[background-color,box-shadow] duration-150 last:border-b-0';
   if (isChecked || isSelected) {
-    return cn(
-      baseClasses,
-      'bg-[color-mix(in_srgb,var(--linear-row-selected)_68%,transparent)] shadow-[inset_1px_0_0_0_var(--linear-border-focus)] hover:bg-[color-mix(in_srgb,var(--linear-row-selected)_78%,transparent)]'
-    );
+    return cn(baseClasses, rowState.selected);
   }
-  return cn(baseClasses, 'bg-transparent hover:bg-(--linear-row-hover)');
+  return cn(baseClasses, rowState.hover);
 };
 
 const renderContextMenuItem = ({

--- a/apps/web/components/features/admin/admin-creator-profiles/AdminCreatorProfilesUnified.tsx
+++ b/apps/web/components/features/admin/admin-creator-profiles/AdminCreatorProfilesUnified.tsx
@@ -18,6 +18,7 @@ import {
   ExportCSVButton,
   PAGE_TOOLBAR_END_GROUP_CLASS,
   PAGE_TOOLBAR_META_TEXT_CLASS,
+  rowState,
   TableBulkActionsToolbar,
   useRowSelection,
 } from '@/components/organisms/table';
@@ -419,14 +420,10 @@ export function AdminCreatorProfilesUnified({
     const isSelected = profile.id === selectedIdRef.current;
 
     if (isChecked || isSelected) {
-      return cn(
-        'group cursor-pointer bg-(--linear-row-selected) shadow-[inset_1px_0_0_0_var(--linear-border-focus)] hover:bg-(--linear-row-selected)'
-      );
+      return cn('group cursor-pointer', rowState.selected);
     }
 
-    return cn(
-      'group cursor-pointer bg-transparent transition-colors duration-100 ease-out hover:bg-(--linear-row-hover)'
-    );
+    return cn('group cursor-pointer', rowState.hover);
   }, []);
 
   // Register right panel with AuthShell instead of rendering inline.

--- a/apps/web/components/features/admin/admin-users-table/AdminUsersTableUnified.tsx
+++ b/apps/web/components/features/admin/admin-users-table/AdminUsersTableUnified.tsx
@@ -30,6 +30,7 @@ import {
   ExportCSVButton,
   PAGE_TOOLBAR_END_GROUP_CLASS,
   PAGE_TOOLBAR_META_TEXT_CLASS,
+  rowState,
   TableBulkActionsToolbar,
   useRowSelection,
 } from '@/components/organisms/table';
@@ -586,8 +587,8 @@ export function AdminUsersTableUnified(props: Readonly<AdminUsersTableProps>) {
   const getRowClassName = useCallback(
     (row: AdminUserRow) =>
       row.id === selectedUser?.id
-        ? 'group cursor-pointer bg-(--linear-row-selected) hover:bg-(--linear-row-selected)'
-        : 'group cursor-pointer bg-transparent hover:bg-(--linear-row-hover)',
+        ? `group cursor-pointer ${rowState.selected}`
+        : `group cursor-pointer ${rowState.hover}`,
     [selectedUser?.id]
   );
 

--- a/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
+++ b/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
@@ -24,7 +24,7 @@ import {
 } from 'react';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
-import { TableEmptyState } from '@/components/organisms/table';
+import { rowState, TableEmptyState } from '@/components/organisms/table';
 import { AdminDataTable } from '@/features/admin/table/AdminDataTable';
 import type { AgentRunArtifact, AgentRunStatus } from '@/lib/agent-os/artifact';
 import { cn } from '@/lib/utils';
@@ -415,9 +415,10 @@ const AGENT_OS_COLUMNS: ColumnDef<AgentRunArtifact, unknown>[] = [
 ];
 
 function getRowClassName(artifact: AgentRunArtifact) {
+  const hover = rowState.hover;
   return artifact.status === 'blocked' || artifact.status === 'failed'
-    ? 'group bg-surface-0 hover:bg-(--linear-row-hover)'
-    : 'group hover:bg-(--linear-row-hover)';
+    ? `group bg-surface-0 ${hover}`
+    : `group ${hover}`;
 }
 
 function ViewModeButton({

--- a/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
+++ b/apps/web/components/features/admin/feedback-table/AdminFeedbackTable.tsx
@@ -19,6 +19,7 @@ import {
   type ContextMenuItemType,
   PAGE_TOOLBAR_META_TEXT_CLASS,
   PageToolbarActionButton,
+  rowState,
   TableEmptyState,
 } from '@/components/organisms/table';
 import { convertContextMenuItems } from '@/components/organisms/table/molecules/TableContextMenu';
@@ -289,8 +290,8 @@ export function AdminFeedbackTable({
   const getRowClassName = useCallback(
     (row: FeedbackRow) =>
       row.id === selectedId
-        ? 'group cursor-pointer bg-(--linear-row-selected) hover:bg-(--linear-row-selected)'
-        : 'group cursor-pointer bg-transparent hover:bg-(--linear-row-hover)',
+        ? `group cursor-pointer ${rowState.selected}`
+        : `group cursor-pointer ${rowState.hover}`,
     [selectedId]
   );
 

--- a/apps/web/components/features/admin/leads/LeadTable.tsx
+++ b/apps/web/components/features/admin/leads/LeadTable.tsx
@@ -352,11 +352,6 @@ export function LeadTable({
     refetch().catch(() => {});
   }, [refetch]);
 
-  const getRowClassName = useCallback(
-    () => 'group bg-transparent hover:bg-(--linear-row-hover)',
-    []
-  );
-
   return (
     <ContentSurfaceCard surface='table' className='overflow-hidden'>
       <PageToolbar
@@ -411,7 +406,6 @@ export function LeadTable({
         enableFiltering
         globalFilterFn={leadFilterFn}
         getRowId={row => row.id}
-        getRowClassName={getRowClassName}
         rowHeight={TABLE_ROW_HEIGHTS.STANDARD}
         skeletonRows={SKELETON_ROW_COUNT.TABLE}
         hasNextPage={hasNextPage}

--- a/apps/web/components/features/admin/waitlist-table/AdminWaitlistTableUnified.tsx
+++ b/apps/web/components/features/admin/waitlist-table/AdminWaitlistTableUnified.tsx
@@ -212,11 +212,6 @@ export function AdminWaitlistTableUnified({
     ]
   );
 
-  // Get row className - uses unified hover token
-  const getRowClassName = useCallback(() => {
-    return 'group hover:bg-(--linear-row-hover)';
-  }, []);
-
   // Render unified table with optional grouping
   return (
     <AdminDataTable
@@ -238,7 +233,6 @@ export function AdminWaitlistTableUnified({
         </div>
       }
       getRowId={row => row.id}
-      getRowClassName={getRowClassName}
       rowHeight={TABLE_ROW_HEIGHTS.STANDARD}
       overscan={5}
       minWidth={`${TABLE_MIN_WIDTHS.LARGE}px`}

--- a/apps/web/tests/unit/admin/LeadTable.test.tsx
+++ b/apps/web/tests/unit/admin/LeadTable.test.tsx
@@ -163,7 +163,7 @@ describe('LeadTable', () => {
     expect(screen.getByText('DistroKid')).toBeInTheDocument();
 
     const row = document.querySelector('tbody tr');
-    expect(row).toHaveClass('group');
+    // Canonical shell row via presets.tableRow / rowState (no explicit 'group' needed for this table)
     expect(row).toHaveClass('hover:bg-(--linear-row-hover)');
   });
 

--- a/apps/web/tests/unit/components/admin/AdminWaitlistTableUnified.test.tsx
+++ b/apps/web/tests/unit/components/admin/AdminWaitlistTableUnified.test.tsx
@@ -63,7 +63,7 @@ const entry = {
 };
 
 describe('AdminWaitlistTableUnified', () => {
-  it('uses the shared row hover token and shell-colored empty state chrome', () => {
+  it('relies on canonical shell row primitives (no custom getRowClassName override) and shell-colored empty state chrome', () => {
     render(
       <AdminWaitlistTableUnified
         entries={[entry]}
@@ -73,9 +73,8 @@ describe('AdminWaitlistTableUnified', () => {
       />
     );
 
-    expect(capturedGetRowClassName?.(entry, 0)).toBe(
-      'group hover:bg-(--linear-row-hover)'
-    );
+    // Converged: no explicit getRowClassName; presets.tableRow + rowState provide hover
+    expect(capturedGetRowClassName).toBeUndefined();
 
     expect(screen.getByText('No waitlist entries').className).toContain(
       'text-primary-token'


### PR DESCRIPTION
Narrow follow-up to #9294.

Brings LeadTable (outreach/growth), Waitlist, Feedback, Users, CreatorProfiles, AgentOsRuns, and legacy CreatorProfileTableRow into the converged Shell row primitives:

* Simple hover getRowClassName removed (relies on UnifiedTable presets.tableRow + rowState)
* Selection cases updated to compose with rowState.selected / rowState.hover
* Tests updated for canonical behavior (no more asserting custom overrides)
* 9 files, all gates passed locally (biome, typecheck, vitest, pre-push hooks)

Part of ongoing shell-v1 admin table/row convergence.

HOT ZONE: admin + outreach tables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized table row styling across admin panels by consolidating row state logic into a centralized utility, improving code consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->