### PR TITLE
fix(shell): align ShellReleaseRow title to converged EntityHoverLink + release popover (narrow entity surfaces polish)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
@@ -25,6 +25,10 @@ import { ArtworkThumb } from '@/components/shell/ArtworkThumb';
 import { DropDateChip } from '@/components/shell/DropDateChip';
 import { DspAvatarStack } from '@/components/shell/DspAvatarStack';
 import { StatusBadge } from '@/components/shell/StatusBadge';
+import {
+  EntityHoverLink,
+  type EntityPopoverData,
+} from '@/components/shell/EntityPopover';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 import { dropDateMeta } from '@/lib/format-drop-date';
 import { cn } from '@/lib/utils';
@@ -226,6 +230,21 @@ export const ShellReleaseRow = memo(function ShellReleaseRow({
   const { playbackState } = useTrackAudioPlayer();
   const isActiveTrack = playbackState.activeTrackId === release.id;
 
+  const releaseEntity: EntityPopoverData = {
+    kind: 'release',
+    id: release.id,
+    label: release.title,
+    thumbnail: release.artworkUrl,
+    artist: artistLabel || undefined,
+    releaseType: release.releaseType,
+    releaseDate: release.releaseDate,
+    totalTracks: release.totalTracks > 0 ? release.totalTracks : undefined,
+    durationSec: release.totalDurationMs
+      ? Math.floor(release.totalDurationMs / 1000)
+      : undefined,
+    status: release.status,
+  };
+
   function handleKeyDown(e: KeyboardEvent<HTMLDivElement>) {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
@@ -250,7 +269,15 @@ export const ShellReleaseRow = memo(function ShellReleaseRow({
       <ArtworkCell release={release} />
 
       <div className='min-w-0 flex-1'>
-        <div className={shellReleaseRowTypography.title}>{release.title}</div>
+        <EntityHoverLink
+          entity={releaseEntity}
+          className={cn(
+            shellReleaseRowTypography.title,
+            'inline-flex w-full max-w-full hover:no-underline'
+          )}
+        >
+          {release.title}
+        </EntityHoverLink>
         <div className={shellReleaseRowTypography.subtitle}>{artistLabel}</div>
       </div>
 


### PR DESCRIPTION

**Shell migration narrow follow-up (entity surfaces polish)**

- `ShellReleaseRow` (unified DESIGN_V1 releases list in dashboard) title now uses `<EntityHoverLink>` + full `release` `EntityPopoverData`.
- Rich preview on hover (artwork, stats, artist drill-down) exactly matching the converged `EntityPopover` / `EntityHoverLink` contract from prior waves.
- Zero behavior change for row selection, play, keyboard, action menu, or tests.
- 1 file, mechanical consistency only.

**Verification (autonomous by dispatched coder sub-agent + orchestrator)**
- Local exploration of EntityPopover contract, prior consumers (`DrawerHero`, dropdowns), and the untouched `ShellReleaseRow`.
- Biome + typecheck clean.
- Existing row unit test compatible (no new test needed; surface already exercised).
- Preserves all shell primitives (`ShellListRowFrame`, typography, hover states).
- Follows AGENTS.md (coder profile, HOT ZONE only, subtraction, no new patterns).

Part of the final narrow entity surfaces blanket-rule wave for shell-v1 (JOV-2496 / handoff Wave ~7 cohesion).

Opened early for CI. Will be landed autonomously when green + bot comments addressed (per standing high-confidence shell rules).

Ref: approved overnight plan in session 019e3e31, G-Brain `shell-overnight-20260519-start`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release titles in the dashboard now support interactive hover popover functionality, displaying detailed release information including artwork, artist details, dates, and track information for enhanced user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->