### PR TITLE
fix: resolve SonarCloud S3776 (cognitive complexity) batch 01

### DIFF
--- a/apps/web/lib/chat/jank-monitor.ts
+++ b/apps/web/lib/chat/jank-monitor.ts
@@ -330,17 +330,15 @@ export function createJankMonitor(opts: CreateJankMonitorOptions): JankMonitor {
     emit(event, payload);
   }
 
-  function observeMessages(
-    conversationId: string | null,
-    snapshot: readonly MessageSnapshot[],
-    status?: string
-  ): void {
-    const s = state(conversationId);
-    s.snapshotIndex += 1;
-    const nowTs = now();
-    const effective = snapshot.filter(m => !IGNORED_IDS.has(m.id));
+  // --- Sonar S3776 cognitive complexity reductions: extracted phase handlers ---
+  // These keep identical behavior and side-effects. Main observeMessages is now a thin
+  // orchestrator, dropping its cognitive complexity below the 15 threshold.
 
-    // ── Duplicates ─────────────────────────────────────────────
+  function handleDuplicates(
+    conversationId: string | null,
+    effective: readonly MessageSnapshot[],
+    s: ConvState
+  ): void {
     const seenInSnapshot = new Set<string>();
     for (const m of effective) {
       if (seenInSnapshot.has(m.id)) {
@@ -353,8 +351,13 @@ export function createJankMonitor(opts: CreateJankMonitorOptions): JankMonitor {
       }
       seenInSnapshot.add(m.id);
     }
+  }
 
-    // ── Reorder ────────────────────────────────────────────────
+  function handleReorder(
+    conversationId: string | null,
+    effective: readonly MessageSnapshot[],
+    s: ConvState
+  ): string[] {
     const nextIdOrder = effective.map(m => m.id);
     if (s.lastIdOrder.length > 0 && detectReorder(s.lastIdOrder, nextIdOrder)) {
       s.counts.reorderCount += 1;
@@ -363,13 +366,20 @@ export function createJankMonitor(opts: CreateJankMonitorOptions): JankMonitor {
         nextState: nextIdOrder.join(','),
       });
     }
+    return nextIdOrder;
+  }
 
-    // ── Disappear / reappear ───────────────────────────────────
+  function handleDisappearReappear(
+    conversationId: string | null,
+    effective: readonly MessageSnapshot[],
+    s: ConvState,
+    nowTs: number,
+    nextIdOrder: string[]
+  ): void {
     const currentIds = new Set(nextIdOrder);
     // Confirm any previously-pending disappears that are STILL missing.
     for (const [id, meta] of s.pendingDisappear) {
       if (!currentIds.has(id)) {
-        // Confirm — emit disappear.
         s.counts.messageDisappearCount += 1;
         fire(conversationId, JANK_EVENT_NAMES.MESSAGE_DISAPPEARED, {
           messageId: id,
@@ -415,9 +425,15 @@ export function createJankMonitor(opts: CreateJankMonitorOptions): JankMonitor {
     for (const [id, meta] of s.recentlyRemoved) {
       if (nowTs - meta.at > reappearWindowMs) s.recentlyRemoved.delete(id);
     }
+  }
 
-    // ── Token rollback (per (id, partIndex)) ───────────────────
-    // Progress bookkeeping (any part delta = progress).
+  function handleTokenRollbacks(
+    conversationId: string | null,
+    effective: readonly MessageSnapshot[],
+    s: ConvState,
+    nowTs: number,
+    status: string | undefined
+  ): boolean {
     let anyProgress = false;
     for (const m of effective) {
       const prev = s.lastSeen.get(m.id);
@@ -445,8 +461,14 @@ export function createJankMonitor(opts: CreateJankMonitorOptions): JankMonitor {
         }
       }
     }
+    return anyProgress;
+  }
 
-    // ── Update lastSeen ────────────────────────────────────────
+  function updateLastSeenState(
+    s: ConvState,
+    effective: readonly MessageSnapshot[],
+    nextIdOrder: string[]
+  ): void {
     s.lastSeen.clear();
     effective.forEach((m, idx) => {
       s.lastSeen.set(m.id, {
@@ -458,11 +480,16 @@ export function createJankMonitor(opts: CreateJankMonitorOptions): JankMonitor {
     });
     s.lastIdOrder = nextIdOrder;
     s.sequenceIndex = effective.length;
+  }
 
-    // ── Stream revision / progress ─────────────────────────────
+  function handleStreamRevisionAndProgress(
+    s: ConvState,
+    status: string | undefined,
+    anyProgress: boolean,
+    nowTs: number
+  ): void {
     if (status !== s.lastStatus) {
       if (status === 'streaming' || status === 'submitted') {
-        // New stream: reset per-stream counters.
         s.streamRevision = 0;
         s.stallEmitted = false;
         s.lastProgressAt = nowTs;
@@ -474,14 +501,20 @@ export function createJankMonitor(opts: CreateJankMonitorOptions): JankMonitor {
       s.streamRevision += 1;
       s.stallEmitted = false;
     }
+  }
 
-    // ── Feedback after send ────────────────────────────────────
+  function handleFeedbackAfterSend(
+    conversationId: string | null,
+    s: ConvState,
+    effective: readonly MessageSnapshot[],
+    snapshot: readonly MessageSnapshot[],
+    nowTs: number
+  ): void {
     if (
       s.onSendPendingAt !== null &&
       !s.feedbackEmittedForSend &&
       nowTs - s.onSendPendingAt >= feedbackTimeoutMs
     ) {
-      // Look for a NEW user bubble or assistant placeholder vs baseline.
       const newUserIds = effective
         .filter(m => m.role === 'user' && !s.onSendUserIds.has(m.id))
         .map(m => m.id);
@@ -499,7 +532,6 @@ export function createJankMonitor(opts: CreateJankMonitorOptions): JankMonitor {
       s.feedbackEmittedForSend = true;
       s.onSendPendingAt = null;
     } else if (s.onSendPendingAt !== null) {
-      // Check for satisfied feedback.
       const newUserBubble = effective.some(
         m => m.role === 'user' && !s.onSendUserIds.has(m.id)
       );
@@ -511,6 +543,44 @@ export function createJankMonitor(opts: CreateJankMonitorOptions): JankMonitor {
         s.feedbackEmittedForSend = true;
       }
     }
+  }
+
+  function observeMessages(
+    conversationId: string | null,
+    snapshot: readonly MessageSnapshot[],
+    status?: string
+  ): void {
+    const s = state(conversationId);
+    s.snapshotIndex += 1;
+    const nowTs = now();
+    const effective = snapshot.filter(m => !IGNORED_IDS.has(m.id));
+
+    // ── Duplicates ─────────────────────────────────────────────
+    handleDuplicates(conversationId, effective, s);
+
+    // ── Reorder ────────────────────────────────────────────────
+    const nextIdOrder = handleReorder(conversationId, effective, s);
+
+    // ── Disappear / reappear ───────────────────────────────────
+    handleDisappearReappear(conversationId, effective, s, nowTs, nextIdOrder);
+
+    // ── Token rollback (per (id, partIndex)) ───────────────────
+    const anyProgress = handleTokenRollbacks(
+      conversationId,
+      effective,
+      s,
+      nowTs,
+      status
+    );
+
+    // ── Update lastSeen ────────────────────────────────────────
+    updateLastSeenState(s, effective, nextIdOrder);
+
+    // ── Stream revision / progress ─────────────────────────────
+    handleStreamRevisionAndProgress(s, status, anyProgress, nowTs);
+
+    // ── Feedback after send ────────────────────────────────────
+    handleFeedbackAfterSend(conversationId, s, effective, snapshot, nowTs);
   }
 
   function onSend(


### PR DESCRIPTION
## Summary
Fixes **1** SonarCloud **CRITICAL** issue (highest-priority S3776 batch).

**File changed:**
- `apps/web/lib/chat/jank-monitor.ts` — refactored the `observeMessages` function (previously 44 cognitive complexity) by extracting 7 focused phase handlers:
  - handleDuplicates
  - handleReorder
  - handleDisappearReappear
  - handleTokenRollbacks
  - updateLastSeenState
  - handleStreamRevisionAndProgress
  - handleFeedbackAfterSend

The main `observeMessages` is now a thin, linear orchestrator. Complexity is now well below Sonar's 15 threshold. **Zero behavior change.**

## SonarCloud Rules Addressed
- typescript:S3776 (Cognitive Complexity)

## Test plan
- [x] TypeScript compiles (`pnpm --filter @jovie/web typecheck`)
- [x] Biome lint + format passes (`pnpm biome check --write` + pre-push)
- [x] All 23 unit tests for jank-monitor pass (exact behavior preserved)
- [x] No other files touched in the commit
- [x] Addresses the #1 CRITICAL S3776 violation reported at start of run (jank-monitor:333, complexity 44)

This is the first of many incremental S3776 fixes. Subsequent batches will target the remaining ~59 S3776 + other rules until zero issues.

🤖 Generated with Claude Code (Sonar-Fix Runner)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for message observation handling to enhance maintainability.

**Note:** This update contains no visible changes to end-user functionality. All existing features and behavior remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->