### PR TITLE
fix(lint): sort imports in ShellReleaseRow (unblock main CI)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
@@ -24,11 +24,11 @@ import { ShellListRowFrame } from '@/components/organisms/table';
 import { ArtworkThumb } from '@/components/shell/ArtworkThumb';
 import { DropDateChip } from '@/components/shell/DropDateChip';
 import { DspAvatarStack } from '@/components/shell/DspAvatarStack';
-import { StatusBadge } from '@/components/shell/StatusBadge';
 import {
   EntityHoverLink,
   type EntityPopoverData,
 } from '@/components/shell/EntityPopover';
+import { StatusBadge } from '@/components/shell/StatusBadge';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 import { dropDateMeta } from '@/lib/format-drop-date';
 import { cn } from '@/lib/utils';


### PR DESCRIPTION
## Summary

Main CI has been failing for ~9h on the **Lint** job because of an unsorted-imports violation in `ShellReleaseRow.tsx`. That single Biome error cascades into the **PR Ready** check failing on **12 of 15** open PRs.

Fix: run \`biome check --write\` on the file — one-line reorder so \`EntityPopover\` comes alphabetically before \`StatusBadge\` within the import group.

## Why it matters

This is the root systemic blocker for the entire PR queue. Until this lands, no PR can clear the \`PR Ready\` aggregate gate, so nothing else can auto-merge.

## Test plan

- [x] \`pnpm biome ci .\` passes locally (5852 files, 0 errors)
- [x] CI \`Lint\` job goes green on this branch
- [x] Pre-commit hook (biome + eslint + typecheck on staged) passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reorganized import statements for improved code formatting and readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->