### PR TITLE
feat(admin): minimal Costs page v1 (/app/admin/costs) — JOV-2498

### DIFF
--- a/apps/web/app/app/(shell)/admin/costs/CostsTable.tsx
+++ b/apps/web/app/app/(shell)/admin/costs/CostsTable.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { Button } from '@jovie/ui';
+import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import { ExternalLink, RefreshCw } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { PageToolbar, TableEmptyState } from '@/components/organisms/table';
+import { AdminDataTable } from '@/features/admin/table/AdminDataTable';
+import { AdminTableShell } from '@/features/admin/table/AdminTableShell';
+import type { AdminCostRow } from '@/lib/admin/costs';
+
+interface CostsTableProps {
+  readonly items: AdminCostRow[];
+  readonly lastRefreshedLabel: string;
+}
+
+const columnHelper = createColumnHelper<AdminCostRow>();
+
+export function CostsTable({ items, lastRefreshedLabel }: CostsTableProps) {
+  const [localRefreshed, setLocalRefreshed] = useState(lastRefreshedLabel);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const columns = useMemo<ColumnDef<AdminCostRow, unknown>[]>(
+    () => [
+      columnHelper.accessor('label', {
+        header: 'Line Item / Provider',
+        cell: info => (
+          <span className='font-medium text-primary-token'>
+            {info.getValue()}
+          </span>
+        ),
+        meta: { className: 'min-w-[220px]' },
+      }),
+      columnHelper.accessor('observed30dUsd', {
+        header: '30d Spend (USD)',
+        cell: info => {
+          const v = info.getValue();
+          const n = Number(v ?? 0);
+          return `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+        },
+        meta: { className: 'tabular-nums text-right' },
+      }),
+      columnHelper.accessor('monthlyUsd', {
+        header: 'Est. Monthly',
+        cell: info => {
+          const v = info.getValue();
+          const n = Number(v ?? 0);
+          return n > 0
+            ? `$${n.toLocaleString('en-US', { minimumFractionDigits: 0 })}`
+            : 'usage';
+        },
+        meta: { className: 'tabular-nums' },
+      }),
+      columnHelper.accessor('period', {
+        header: 'Period',
+        cell: info => (
+          <span className='text-tertiary-token text-3xs uppercase tracking-wide'>
+            {info.getValue()}
+          </span>
+        ),
+      }),
+      columnHelper.accessor('lastUpdatedLabel', {
+        header: 'Last Updated',
+        cell: info => info.getValue(),
+      }),
+      columnHelper.accessor('notes', {
+        header: 'Notes',
+        cell: info => (
+          <span className='line-clamp-2 text-tertiary-token text-xs'>
+            {info.getValue() || '—'}
+          </span>
+        ),
+        meta: { className: 'max-w-[320px]' },
+      }),
+      columnHelper.accessor('externalUrl', {
+        header: '',
+        cell: info => {
+          const url = info.getValue();
+          if (!url) return null;
+          return (
+            <a
+              href={url}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='inline-flex text-primary-token hover:text-primary-token/80'
+              aria-label={`Open ${info.row.original.label} dashboard`}
+            >
+              <ExternalLink className='h-3.5 w-3.5' />
+            </a>
+          );
+        },
+        enableSorting: false,
+        meta: { className: 'w-8 text-right' },
+      }),
+    ],
+    []
+  );
+
+  const total30d = items.reduce(
+    (sum, r) => sum + Number(r.observed30dUsd ?? 0),
+    0
+  );
+
+  async function handleMarkRefreshed() {
+    setIsRefreshing(true);
+    // v1: client-side only bump (no real persistence required per charter)
+    const now = new Date().toLocaleString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    });
+    setLocalRefreshed(now);
+    setIsRefreshing(false);
+    toast.success(
+      'Marked refreshed (v1 manual — copy real numbers from dashboards)'
+    );
+  }
+
+  const toolbar = (
+    <PageToolbar
+      meta={
+        <div className='flex items-center gap-3 text-tertiary-token text-xs'>
+          <span>
+            {items.length} items • ${total30d.toFixed(2)} in last 30d
+          </span>
+          <span className='opacity-60'>•</span>
+          <span>Last refreshed: {localRefreshed}</span>
+        </div>
+      }
+      actions={
+        <Button
+          variant='outline'
+          size='sm'
+          onClick={handleMarkRefreshed}
+          disabled={isRefreshing}
+          className='gap-1.5'
+        >
+          <RefreshCw
+            className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`}
+          />
+          Mark refreshed
+        </Button>
+      }
+    />
+  );
+
+  return (
+    <AdminTableShell testId='admin-costs-table' toolbar={toolbar}>
+      {() => (
+        <AdminDataTable
+          data={items}
+          columns={columns}
+          emptyState={
+            <TableEmptyState
+              title='No cost items'
+              description='Seed data will appear on first load.'
+            />
+          }
+        />
+      )}
+    </AdminTableShell>
+  );
+}

--- a/apps/web/app/app/(shell)/admin/costs/CostsTable.tsx
+++ b/apps/web/app/app/(shell)/admin/costs/CostsTable.tsx
@@ -15,7 +15,7 @@ interface AdminCostRow {
   readonly monthlyUsd: string | number | null;
   readonly observed30dUsd: string | number | null;
   readonly period: string;
-  readonly notes: string | null;
+  readonly notes: string;
   readonly externalUrl?: string | null;
   readonly lastUpdatedLabel: string;
 }

--- a/apps/web/app/app/(shell)/admin/costs/CostsTable.tsx
+++ b/apps/web/app/app/(shell)/admin/costs/CostsTable.tsx
@@ -8,7 +8,17 @@ import { toast } from 'sonner';
 import { PageToolbar, TableEmptyState } from '@/components/organisms/table';
 import { AdminDataTable } from '@/features/admin/table/AdminDataTable';
 import { AdminTableShell } from '@/features/admin/table/AdminTableShell';
-import type { AdminCostRow } from '@/lib/admin/costs';
+
+// Local row shape (avoid server-only import from @/lib/admin/costs in client component)
+interface AdminCostRow {
+  readonly label: string;
+  readonly monthlyUsd: string | number | null;
+  readonly observed30dUsd: string | number | null;
+  readonly period: string;
+  readonly notes: string | null;
+  readonly externalUrl?: string | null;
+  readonly lastUpdatedLabel: string;
+}
 
 interface CostsTableProps {
   readonly items: AdminCostRow[];
@@ -21,79 +31,80 @@ export function CostsTable({ items, lastRefreshedLabel }: CostsTableProps) {
   const [localRefreshed, setLocalRefreshed] = useState(lastRefreshedLabel);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
-  const columns = useMemo<ColumnDef<AdminCostRow, unknown>[]>(
-    () => [
-      columnHelper.accessor('label', {
-        header: 'Line Item / Provider',
-        cell: info => (
-          <span className='font-medium text-primary-token'>
-            {info.getValue()}
-          </span>
-        ),
-        meta: { className: 'min-w-[220px]' },
-      }),
-      columnHelper.accessor('observed30dUsd', {
-        header: '30d Spend (USD)',
-        cell: info => {
-          const v = info.getValue();
-          const n = Number(v ?? 0);
-          return `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-        },
-        meta: { className: 'tabular-nums text-right' },
-      }),
-      columnHelper.accessor('monthlyUsd', {
-        header: 'Est. Monthly',
-        cell: info => {
-          const v = info.getValue();
-          const n = Number(v ?? 0);
-          return n > 0
-            ? `$${n.toLocaleString('en-US', { minimumFractionDigits: 0 })}`
-            : 'usage';
-        },
-        meta: { className: 'tabular-nums' },
-      }),
-      columnHelper.accessor('period', {
-        header: 'Period',
-        cell: info => (
-          <span className='text-tertiary-token text-3xs uppercase tracking-wide'>
-            {info.getValue()}
-          </span>
-        ),
-      }),
-      columnHelper.accessor('lastUpdatedLabel', {
-        header: 'Last Updated',
-        cell: info => info.getValue(),
-      }),
-      columnHelper.accessor('notes', {
-        header: 'Notes',
-        cell: info => (
-          <span className='line-clamp-2 text-tertiary-token text-xs'>
-            {info.getValue() || '—'}
-          </span>
-        ),
-        meta: { className: 'max-w-[320px]' },
-      }),
-      columnHelper.accessor('externalUrl', {
-        header: '',
-        cell: info => {
-          const url = info.getValue();
-          if (!url) return null;
-          return (
-            <a
-              href={url}
-              target='_blank'
-              rel='noopener noreferrer'
-              className='inline-flex text-primary-token hover:text-primary-token/80'
-              aria-label={`Open ${info.row.original.label} dashboard`}
-            >
-              <ExternalLink className='h-3.5 w-3.5' />
-            </a>
-          );
-        },
-        enableSorting: false,
-        meta: { className: 'w-8 text-right' },
-      }),
-    ],
+  const columns = useMemo(
+    () =>
+      [
+        columnHelper.accessor('label', {
+          header: 'Line Item / Provider',
+          cell: info => (
+            <span className='font-medium text-primary-token'>
+              {info.getValue()}
+            </span>
+          ),
+          meta: { className: 'min-w-[220px]' },
+        }),
+        columnHelper.accessor('observed30dUsd', {
+          header: '30d Spend (USD)',
+          cell: info => {
+            const v = info.getValue();
+            const n = Number(v ?? 0);
+            return `$${n.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+          },
+          meta: { className: 'tabular-nums text-right' },
+        }),
+        columnHelper.accessor('monthlyUsd', {
+          header: 'Est. Monthly',
+          cell: info => {
+            const v = info.getValue();
+            const n = Number(v ?? 0);
+            return n > 0
+              ? `$${n.toLocaleString('en-US', { minimumFractionDigits: 0 })}`
+              : 'usage';
+          },
+          meta: { className: 'tabular-nums' },
+        }),
+        columnHelper.accessor('period', {
+          header: 'Period',
+          cell: info => (
+            <span className='text-tertiary-token text-3xs uppercase tracking-wide'>
+              {info.getValue()}
+            </span>
+          ),
+        }),
+        columnHelper.accessor('lastUpdatedLabel', {
+          header: 'Last Updated',
+          cell: info => info.getValue(),
+        }),
+        columnHelper.accessor('notes', {
+          header: 'Notes',
+          cell: info => (
+            <span className='line-clamp-2 text-tertiary-token text-xs'>
+              {info.getValue() || '—'}
+            </span>
+          ),
+          meta: { className: 'max-w-[320px]' },
+        }),
+        columnHelper.accessor('externalUrl', {
+          header: '',
+          cell: info => {
+            const url = info.getValue();
+            if (!url) return null;
+            return (
+              <a
+                href={url}
+                target='_blank'
+                rel='noopener noreferrer'
+                className='inline-flex text-primary-token hover:text-primary-token/80'
+                aria-label={`Open ${info.row.original.label} dashboard`}
+              >
+                <ExternalLink className='h-3.5 w-3.5' />
+              </a>
+            );
+          },
+          enableSorting: false,
+          meta: { className: 'w-8 text-right' },
+        }),
+      ] as ColumnDef<AdminCostRow, unknown>[],
     []
   );
 
@@ -120,7 +131,7 @@ export function CostsTable({ items, lastRefreshedLabel }: CostsTableProps) {
 
   const toolbar = (
     <PageToolbar
-      meta={
+      start={
         <div className='flex items-center gap-3 text-tertiary-token text-xs'>
           <span>
             {items.length} items • ${total30d.toFixed(2)} in last 30d
@@ -129,7 +140,7 @@ export function CostsTable({ items, lastRefreshedLabel }: CostsTableProps) {
           <span>Last refreshed: {localRefreshed}</span>
         </div>
       }
-      actions={
+      end={
         <Button
           variant='outline'
           size='sm'

--- a/apps/web/app/app/(shell)/admin/costs/page.tsx
+++ b/apps/web/app/app/(shell)/admin/costs/page.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
+import { getAdminCosts, getCostsLastRefreshedAt } from '@/lib/admin/costs';
+import { CostsTable } from './CostsTable';
+
+export const metadata: Metadata = {
+  title: 'Costs | Admin',
+};
+
+export const runtime = 'nodejs';
+
+export default async function AdminCostsPage() {
+  const [items, lastRefreshed] = await Promise.all([
+    getAdminCosts(),
+    getCostsLastRefreshedAt(),
+  ]);
+
+  const refreshedLabel = lastRefreshed
+    ? lastRefreshed.toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+    : 'never (seed on load)';
+
+  return (
+    <AdminToolPage
+      title='Costs'
+      description='Manual 30-day line-item view of company infra + AI spend. Lagging data only (v1).'
+      testId='admin-costs-page'
+    >
+      <CostsTable items={items} lastRefreshedLabel={refreshedLabel} />
+    </AdminToolPage>
+  );
+}

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -181,6 +181,8 @@ export const settingsNavigation: NavItem[] = [
   ...artistSettingsNavigation,
 ];
 
+/** Admin settings item — shown only to admin users */
+
 const adminIconById = {
   overview: LayoutDashboard,
   ops: Gauge,
@@ -190,6 +192,7 @@ const adminIconById = {
   activity: Activity,
   investors: Briefcase,
   screenshots: ImageIcon,
+  costs: Banknote,
   share_studio: Share2,
 } as const;
 

--- a/apps/web/constants/admin-navigation.ts
+++ b/apps/web/constants/admin-navigation.ts
@@ -37,6 +37,7 @@ export type AdminWorkspaceId =
   | 'activity'
   | 'investors'
   | 'screenshots'
+  | 'costs'
   | 'share_studio';
 
 export type AdminNavigationSection = 'workspaces' | 'utilities';
@@ -62,6 +63,7 @@ export const ADMIN_SETTINGS_TOOL_IDS = [
   'investors',
   'screenshots',
   'share_studio',
+  'costs',
 ] as const satisfies readonly AdminWorkspaceId[];
 
 export const ADMIN_NAV_REGISTRY: readonly AdminNavRegistryItem[] = [
@@ -119,6 +121,14 @@ export const ADMIN_NAV_REGISTRY: readonly AdminNavRegistryItem[] = [
     label: 'Screenshots',
     href: APP_ROUTES.ADMIN_SCREENSHOTS,
     description: 'Generated docs and QA screenshots',
+    section: 'utilities',
+  },
+  {
+    id: 'costs',
+    label: 'Costs',
+    href: APP_ROUTES.ADMIN_COSTS,
+    description:
+      'Company infra, AI gateway, Neon, and vendor spend (30-day view)',
     section: 'utilities',
   },
   {

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -105,6 +105,7 @@ export const APP_ROUTES = {
   ADMIN_PLATFORM_CONNECTIONS: '/app/admin/platform-connections',
   ADMIN_AGENT_RUN: '/app/admin/agent-runs',
   ADMIN_AGENT_RUN_DETAIL: '/app/admin/agent-runs/[id]',
+  ADMIN_COSTS: '/app/admin/costs',
   FEATURE_FLAGS: '/app/feature-flags',
 
   // System

--- a/apps/web/drizzle/migrations/0052_silent_costs.sql
+++ b/apps/web/drizzle/migrations/0052_silent_costs.sql
@@ -1,0 +1,19 @@
+-- Migration: add admin_costs table + costs_last_refreshed_at to admin_system_settings
+-- v1 manual costs tracking per G-Brain naming.admin-operational-surfaces
+
+ALTER TABLE "admin_system_settings" ADD COLUMN IF NOT EXISTS "costs_last_refreshed_at" timestamp;
+
+CREATE TABLE IF NOT EXISTS "admin_costs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"label" text NOT NULL,
+	"monthly_usd" numeric(12, 2) DEFAULT '0' NOT NULL,
+	"observed_30d_usd" numeric(12, 2) DEFAULT '0' NOT NULL,
+	"period" text DEFAULT 'monthly' NOT NULL,
+	"notes" text DEFAULT '' NOT NULL,
+	"external_url" text,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "idx_admin_costs_label" ON "admin_costs" ("label");
+CREATE INDEX IF NOT EXISTS "idx_admin_costs_is_active" ON "admin_costs" ("is_active");

--- a/apps/web/drizzle/migrations/meta/_journal.json
+++ b/apps/web/drizzle/migrations/meta/_journal.json
@@ -365,6 +365,13 @@
       "when": 1778996928720,
       "tag": "0051_yielding_iron_man",
       "breakpoints": true
+    },
+    {
+      "idx": 52,
+      "version": "7",
+      "when": 1779216199072,
+      "tag": "0052_silent_costs",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/lib/admin/costs.ts
+++ b/apps/web/lib/admin/costs.ts
@@ -139,8 +139,20 @@ export async function upsertAdminCost(input: {
   externalUrl?: string | null;
 }): Promise<void> {
   const now = new Date();
+
+  // Validate decimal strings for numeric columns (per CodeRabbit review)
+  const decimalRe = /^-?\d+(\.\d+)?$/;
+  if (
+    !decimalRe.test(input.monthlyUsd) ||
+    !decimalRe.test(input.observed30dUsd)
+  ) {
+    throw new Error(
+      'monthlyUsd and observed30dUsd must be valid decimal strings (e.g. "0", "123.45")'
+    );
+  }
+
   if (input.id) {
-    await db
+    const result = await db
       .update(adminCosts)
       .set({
         label: input.label,
@@ -152,6 +164,11 @@ export async function upsertAdminCost(input: {
         updatedAt: now,
       })
       .where(eq(adminCosts.id, input.id));
+
+    // Verify update affected a row (per CodeRabbit); throw on missing id
+    if ((result as { rowCount?: number | null }).rowCount === 0) {
+      throw new Error(`Admin cost with id ${input.id} not found`);
+    }
   } else {
     await db.insert(adminCosts).values({
       label: input.label,

--- a/apps/web/lib/admin/costs.ts
+++ b/apps/web/lib/admin/costs.ts
@@ -1,0 +1,167 @@
+import { eq } from 'drizzle-orm';
+
+import { db } from '@/lib/db';
+import {
+  type AdminCost,
+  adminCosts,
+  adminSystemSettings,
+} from '@/lib/db/schema/admin';
+
+export type AdminCostRow = AdminCost & {
+  readonly lastUpdatedLabel: string;
+};
+
+const DEFAULT_COST_SEEDS: Array<{
+  label: string;
+  monthlyUsd: string;
+  observed30dUsd: string;
+  period: string;
+  notes: string;
+  externalUrl?: string;
+}> = [
+  {
+    label: 'Vercel AI Gateway',
+    monthlyUsd: '0',
+    observed30dUsd: '0',
+    period: 'usage-based',
+    notes:
+      'Primary LLM + image gen spend (album art, pitches, etc.). Check Vercel team usage dashboard.',
+    externalUrl: 'https://vercel.com/dashboard',
+  },
+  {
+    label: 'Neon Postgres (prod + preview)',
+    monthlyUsd: '0',
+    observed30dUsd: '0',
+    period: 'monthly',
+    notes: 'Primary database. Includes compute + storage.',
+    externalUrl: 'https://console.neon.tech',
+  },
+  {
+    label: 'Anthropic / Claude',
+    monthlyUsd: '0',
+    observed30dUsd: '0',
+    period: 'monthly',
+    notes: 'API + console seats for agent orchestration and evals.',
+    externalUrl: 'https://console.anthropic.com',
+  },
+  {
+    label: 'OpenAI',
+    monthlyUsd: '0',
+    observed30dUsd: '0',
+    period: 'usage-based',
+    notes: 'API spend for legacy/backup paths and evals.',
+    externalUrl: 'https://platform.openai.com/usage',
+  },
+  {
+    label: 'OpenRouter',
+    monthlyUsd: '0',
+    observed30dUsd: '0',
+    period: 'usage-based',
+    notes: 'Routed LLM calls (fallback + model mixing).',
+    externalUrl: 'https://openrouter.ai/activity',
+  },
+];
+
+function mapRow(row: AdminCost): AdminCostRow {
+  return {
+    ...row,
+    lastUpdatedLabel: row.updatedAt
+      ? new Date(row.updatedAt).toLocaleDateString('en-US', {
+          month: 'short',
+          day: 'numeric',
+        })
+      : '—',
+  };
+}
+
+export async function getAdminCosts(): Promise<AdminCostRow[]> {
+  const rows = await db
+    .select()
+    .from(adminCosts)
+    .where(eq(adminCosts.isActive, true))
+    .orderBy(adminCosts.label);
+
+  if (rows.length === 0) {
+    // Seed on first access (manual v1; idempotent-ish for demo)
+    await seedDefaultCosts();
+    const seeded = await db
+      .select()
+      .from(adminCosts)
+      .where(eq(adminCosts.isActive, true))
+      .orderBy(adminCosts.label);
+    return seeded.map(mapRow);
+  }
+
+  return rows.map(mapRow);
+}
+
+async function seedDefaultCosts(): Promise<void> {
+  const now = new Date();
+  const values = DEFAULT_COST_SEEDS.map(seed => ({
+    label: seed.label,
+    monthlyUsd: seed.monthlyUsd,
+    observed30dUsd: seed.observed30dUsd,
+    period: seed.period,
+    notes: seed.notes,
+    externalUrl: seed.externalUrl ?? null,
+    isActive: true,
+    updatedAt: now,
+  }));
+
+  await db.insert(adminCosts).values(values).onConflictDoNothing();
+}
+
+export async function getCostsLastRefreshedAt(): Promise<Date | null> {
+  const [row] = await db
+    .select({ ts: adminSystemSettings.costsLastRefreshedAt })
+    .from(adminSystemSettings)
+    .limit(1);
+  return row?.ts ?? null;
+}
+
+export async function markCostsRefreshed(): Promise<Date> {
+  const now = new Date();
+  await db
+    .update(adminSystemSettings)
+    .set({ costsLastRefreshedAt: now, updatedAt: now })
+    .where(eq(adminSystemSettings.id, 1));
+  return now;
+}
+
+/** For v1 manual edit surface (server action friendly). */
+export async function upsertAdminCost(input: {
+  id?: string;
+  label: string;
+  monthlyUsd: string;
+  observed30dUsd: string;
+  period?: string;
+  notes?: string;
+  externalUrl?: string | null;
+}): Promise<void> {
+  const now = new Date();
+  if (input.id) {
+    await db
+      .update(adminCosts)
+      .set({
+        label: input.label,
+        monthlyUsd: input.monthlyUsd,
+        observed30dUsd: input.observed30dUsd,
+        period: input.period ?? 'monthly',
+        notes: input.notes ?? '',
+        externalUrl: input.externalUrl ?? null,
+        updatedAt: now,
+      })
+      .where(eq(adminCosts.id, input.id));
+  } else {
+    await db.insert(adminCosts).values({
+      label: input.label,
+      monthlyUsd: input.monthlyUsd,
+      observed30dUsd: input.observed30dUsd,
+      period: input.period ?? 'monthly',
+      notes: input.notes ?? '',
+      externalUrl: input.externalUrl ?? null,
+      isActive: true,
+      updatedAt: now,
+    });
+  }
+}

--- a/apps/web/lib/db/schema/admin.ts
+++ b/apps/web/lib/db/schema/admin.ts
@@ -85,9 +85,34 @@ export const adminSystemSettings = pgTable('admin_system_settings', {
     .notNull(),
   playlistLastGeneratedAt: timestamp('playlist_last_generated_at'),
   playlistNextEligibleAt: timestamp('playlist_next_eligible_at'),
+  costsLastRefreshedAt: timestamp('costs_last_refreshed_at'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 });
+
+// Admin costs (manual/lagging line items for v1 per G-Brain naming.admin-operational-surfaces)
+export const adminCosts = pgTable(
+  'admin_costs',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    label: text('label').notNull(),
+    monthlyUsd: numeric('monthly_usd', { precision: 12, scale: 2 })
+      .default('0')
+      .notNull(),
+    observed30dUsd: numeric('observed_30d_usd', { precision: 12, scale: 2 })
+      .default('0')
+      .notNull(),
+    period: text('period').default('monthly').notNull(),
+    notes: text('notes').default(''),
+    externalUrl: text('external_url'),
+    isActive: boolean('is_active').default(true).notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  table => ({
+    labelIdx: index('idx_admin_costs_label').on(table.label),
+    activeIdx: index('idx_admin_costs_is_active').on(table.isActive),
+  })
+);
 
 // Schema validations
 export const insertAdminAuditLogSchema = createInsertSchema(adminAuditLog);
@@ -102,6 +127,9 @@ export const insertAdminSystemSettingsSchema =
 export const selectAdminSystemSettingsSchema =
   createSelectSchema(adminSystemSettings);
 
+export const insertAdminCostsSchema = createInsertSchema(adminCosts);
+export const selectAdminCostsSchema = createSelectSchema(adminCosts);
+
 // Types
 export type AdminAuditLog = typeof adminAuditLog.$inferSelect;
 export type NewAdminAuditLog = typeof adminAuditLog.$inferInsert;
@@ -110,3 +138,6 @@ export type CampaignSettings = typeof campaignSettings.$inferSelect;
 export type NewCampaignSettings = typeof campaignSettings.$inferInsert;
 export type AdminSystemSettings = typeof adminSystemSettings.$inferSelect;
 export type NewAdminSystemSettings = typeof adminSystemSettings.$inferInsert;
+
+export type AdminCost = typeof adminCosts.$inferSelect;
+export type NewAdminCost = typeof adminCosts.$inferInsert;

--- a/apps/web/lib/db/schema/admin.ts
+++ b/apps/web/lib/db/schema/admin.ts
@@ -103,7 +103,7 @@ export const adminCosts = pgTable(
       .default('0')
       .notNull(),
     period: text('period').default('monthly').notNull(),
-    notes: text('notes').default(''),
+    notes: text('notes').default('').notNull(),
     externalUrl: text('external_url'),
     isActive: boolean('is_active').default(true).notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),

--- a/apps/web/lib/db/schema/index.ts
+++ b/apps/web/lib/db/schema/index.ts
@@ -8,18 +8,23 @@
 // Admin
 export {
   type AdminAuditLog,
+  type AdminCost,
   type AdminSystemSettings,
   adminAuditLog,
+  adminCosts,
   adminSystemSettings,
   type CampaignSettings,
   campaignSettings,
   insertAdminAuditLogSchema,
+  insertAdminCostsSchema,
   insertAdminSystemSettingsSchema,
   insertCampaignSettingsSchema,
   type NewAdminAuditLog,
+  type NewAdminCost,
   type NewAdminSystemSettings,
   type NewCampaignSettings,
   selectAdminAuditLogSchema,
+  selectAdminCostsSchema,
   selectAdminSystemSettingsSchema,
   selectCampaignSettingsSchema,
 } from './admin';


### PR DESCRIPTION
## Summary
Minimal v1 Admin Costs page at `/app/admin/costs` per JOV-2498 and G-Brain `naming.admin-operational-surfaces` rule.

**Exactly follows the rule:**
- Route: `/app/admin/costs`
- DB: `admin_costs` (plural)
- Primary module: `lib/admin/costs.ts`
- Nav: exclusively through `ADMIN_NAV_REGISTRY` + `AdminWorkspaceId: 'costs'`
- Page: `app/app/(shell)/admin/costs/page.tsx`

**Implementation (charter constraints):**
- Built **only** on `AdminTableShell` + `AdminDataTable`/`UnifiedTable` + existing patterns (LeadTable/FeedbackTable columnHelper style). Zero new chrome or custom shells.
- Seeded obvious items with **Vercel AI Gateway spend as #1**.
- 30-day view, totals, notes, external links, last-updated per row.
- Manual/lagging only: "Mark refreshed" is client bump (v1); copy real numbers from provider dashboards.
- Data access + seed in `lib/admin/costs.ts`; server actions/editing deferred.
- One append-only migration (0052) + journal.

**Verification performed:**
- Biome clean.
- Typecheck clean on surface (full turbo pending CI).
- Follows all AGENTS.md / .claude rules (smallest change, server patterns, no invented tokens/routes, immutable migrations respected).

**Next (per JOV-2498 non-goals):**
- Real server action + form for manual edits.
- Snapshot + full migration guard validation.
- `/qa` diff-aware on admin surfaces + gstack ship.
- Future ingest automation in separate issue.

Closes JOV-2498.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Costs" admin tool and page (Costs | Admin) accessible from Admin navigation.
  * Admin costs dashboard showing observed 30‑day spend, estimated monthly costs, period, last‑updated labels, notes, and optional external dashboard links.
  * Toolbar displays aggregated 30‑day total, item count, and a "Last refreshed" label with a manual "Mark refreshed" action that disables while refreshing and shows a success toast.

* **Chores / Data**
  * Added database migration and schemas to persist admin cost items and a last-refreshed timestamp.
* **UI**
  * Added navigation entry and icon for the new Costs admin tool.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->