### PR TITLE
fix(journey): cinematic skeleton for unauth /start frontdoor + no raw loading text

### DIFF
--- a/apps/web/app/(auth)/signup/SignUpPageClient.tsx
+++ b/apps/web/app/(auth)/signup/SignUpPageClient.tsx
@@ -99,6 +99,9 @@ function SignUpClaimDataPersistence() {
       {availability === 'checking' && (
         <div className='flex items-center justify-center lg:justify-start'>
           <Skeleton className='h-5 w-64 rounded' />
+          <span className='sr-only'>
+            Checking if @{normalizedHandle} is available...
+          </span>
         </div>
       )}
       {availability === 'available' && (

--- a/apps/web/app/(auth)/signup/SignUpPageClient.tsx
+++ b/apps/web/app/(auth)/signup/SignUpPageClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Skeleton } from '@jovie/ui';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
@@ -96,9 +97,9 @@ function SignUpClaimDataPersistence() {
       aria-live='polite'
     >
       {availability === 'checking' && (
-        <p className='text-app font-book text-secondary-token'>
-          Checking if @{normalizedHandle} is available...
-        </p>
+        <div className='flex items-center justify-center lg:justify-start'>
+          <Skeleton className='h-5 w-64 rounded' />
+        </div>
       )}
       {availability === 'available' && (
         <p className='text-app font-book text-primary-token'>

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -106,6 +106,7 @@ function OnboardingShellStatus({
         data-testid='onboarding-linking-skeleton'
       >
         <Skeleton className='h-3.5 w-44 rounded' />
+        <span className='sr-only'>{message}</span>
       </div>
     );
   }

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Skeleton } from '@jovie/ui';
 import { useCallback, useState } from 'react';
 import { AppShellFrame } from '@/components/organisms/AppShellFrame';
 import { SidebarProvider } from '@/components/organisms/Sidebar';
@@ -95,16 +96,28 @@ function OnboardingShellStatus({
 }>) {
   if (!visible || !message) return null;
 
+  if (kind === 'status') {
+    return (
+      <div
+        className='pointer-events-none absolute right-3 top-3 z-40 max-w-[min(28rem,calc(100%-1.5rem))] rounded-full border border-subtle bg-surface-0 px-3 py-1.5 shadow-card sm:right-4 sm:top-4'
+        role='status'
+        aria-live='polite'
+        aria-busy='true'
+        data-testid='onboarding-linking-skeleton'
+      >
+        <Skeleton className='h-3.5 w-44 rounded' />
+      </div>
+    );
+  }
+
   return (
     <p
       className={cn(
         'pointer-events-none absolute right-3 top-3 z-40 max-w-[min(28rem,calc(100%-1.5rem))] rounded-full border bg-surface-0 px-3 py-1.5 text-[12px] leading-5 shadow-card sm:right-4 sm:top-4',
-        kind === 'error'
-          ? 'border-red-500/20 text-error'
-          : 'border-subtle text-secondary-token'
+        'border-red-500/20 text-error'
       )}
-      role={kind === 'error' ? 'alert' : 'status'}
-      aria-live={kind === 'error' ? 'assertive' : 'polite'}
+      role='alert'
+      aria-live='assertive'
     >
       {message}
     </p>

--- a/apps/web/components/organisms/AppShellSkeleton.tsx
+++ b/apps/web/components/organisms/AppShellSkeleton.tsx
@@ -18,10 +18,88 @@ const NAV_ITEMS_2 = [
   { key: 'nav-docs', width: '50%' },
 ];
 
+function DefaultSidebarSkeleton({
+  isShellChatV1,
+}: {
+  readonly isShellChatV1: boolean;
+}) {
+  return (
+    <div
+      // Shell V1 mirrors the production sidebar token width (244px) and the
+      // compact header height so the post-resolve UnifiedSidebar slots in
+      // without a width/header reflow.
+      className={cn(
+        'max-lg:hidden bg-sidebar lg:flex lg:shrink-0 lg:flex-col',
+        isShellChatV1 ? 'lg:w-(--linear-app-sidebar-width)' : 'lg:w-[232px]'
+      )}
+    >
+      <div
+        className={cn(
+          'flex items-center gap-2 px-2.5',
+          isShellChatV1
+            ? 'h-(--linear-app-header-height-compact) py-0.5'
+            : 'h-9 pt-2'
+        )}
+      >
+        <div className='skeleton h-6 w-6 rounded-md' />
+        <div className='skeleton h-4 w-24 rounded' />
+      </div>
+
+      <div
+        className={cn(
+          'flex-1 space-y-1',
+          isShellChatV1 ? 'px-2.5 pt-1.5' : 'px-2 pt-4'
+        )}
+      >
+        {NAV_ITEMS.map(item => (
+          <div
+            key={item.key}
+            className='flex h-7 items-center gap-2 rounded-md px-1.5'
+          >
+            <div className='skeleton h-3.5 w-3.5 shrink-0 rounded' />
+            <div
+              className='skeleton h-3 rounded'
+              style={{ width: item.width }}
+            />
+          </div>
+        ))}
+
+        <div className='pb-1 pt-3'>
+          <div className='skeleton ml-1.5 h-3 w-16 rounded' />
+        </div>
+
+        {NAV_ITEMS_2.map(item => (
+          <div
+            key={item.key}
+            className='flex h-7 items-center gap-2 rounded-md px-1.5'
+          >
+            <div className='skeleton h-3.5 w-3.5 shrink-0 rounded' />
+            <div
+              className='skeleton h-3 rounded'
+              style={{ width: item.width }}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div
+        className={cn(
+          'flex items-center gap-2 pb-2 pt-1',
+          isShellChatV1 ? 'px-2.5' : 'px-2'
+        )}
+      >
+        <div className='skeleton h-7 w-7 shrink-0 rounded-full' />
+        <div className='skeleton h-3 w-20 rounded' />
+      </div>
+    </div>
+  );
+}
+
 export function AppShellSkeleton({
   main: mainOverride,
   audioPlayer,
   variant,
+  sidebar: sidebarOverride,
 }: {
   readonly main?: ReactNode;
   readonly audioPlayer?: ReactNode;
@@ -31,82 +109,26 @@ export function AppShellSkeleton({
    * Defaults to 'legacy' to match the production default state.
    */
   readonly variant?: AppShellFrameVariant;
+  /**
+   * Override the sidebar skeleton. Pass `null` for unauthenticated onboarding
+   * surfaces (e.g. /start) that intentionally render without sidebar.
+   * Undefined falls back to the standard nav skeleton.
+   */
+  readonly sidebar?: ReactNode | null;
 } = {}) {
   const isShellChatV1 = variant === 'shellChatV1';
+
+  const resolvedSidebar =
+    sidebarOverride !== undefined ? (
+      sidebarOverride
+    ) : (
+      <DefaultSidebarSkeleton isShellChatV1={isShellChatV1} />
+    );
 
   return (
     <AppShellFrame
       variant={variant}
-      sidebar={
-        <div
-          // Shell V1 mirrors the production sidebar token width (244px) and the
-          // compact header height so the post-resolve UnifiedSidebar slots in
-          // without a width/header reflow.
-          className={cn(
-            'max-lg:hidden bg-sidebar lg:flex lg:shrink-0 lg:flex-col',
-            isShellChatV1 ? 'lg:w-(--linear-app-sidebar-width)' : 'lg:w-[232px]'
-          )}
-        >
-          <div
-            className={cn(
-              'flex items-center gap-2 px-2.5',
-              isShellChatV1
-                ? 'h-(--linear-app-header-height-compact) py-0.5'
-                : 'h-9 pt-2'
-            )}
-          >
-            <div className='skeleton h-6 w-6 rounded-md' />
-            <div className='skeleton h-4 w-24 rounded' />
-          </div>
-
-          <div
-            className={cn(
-              'flex-1 space-y-1',
-              isShellChatV1 ? 'px-2.5 pt-1.5' : 'px-2 pt-4'
-            )}
-          >
-            {NAV_ITEMS.map(item => (
-              <div
-                key={item.key}
-                className='flex h-7 items-center gap-2 rounded-md px-1.5'
-              >
-                <div className='skeleton h-3.5 w-3.5 shrink-0 rounded' />
-                <div
-                  className='skeleton h-3 rounded'
-                  style={{ width: item.width }}
-                />
-              </div>
-            ))}
-
-            <div className='pb-1 pt-3'>
-              <div className='skeleton ml-1.5 h-3 w-16 rounded' />
-            </div>
-
-            {NAV_ITEMS_2.map(item => (
-              <div
-                key={item.key}
-                className='flex h-7 items-center gap-2 rounded-md px-1.5'
-              >
-                <div className='skeleton h-3.5 w-3.5 shrink-0 rounded' />
-                <div
-                  className='skeleton h-3 rounded'
-                  style={{ width: item.width }}
-                />
-              </div>
-            ))}
-          </div>
-
-          <div
-            className={cn(
-              'flex items-center gap-2 pb-2 pt-1',
-              isShellChatV1 ? 'px-2.5' : 'px-2'
-            )}
-          >
-            <div className='skeleton h-7 w-7 shrink-0 rounded-full' />
-            <div className='skeleton h-3 w-20 rounded' />
-          </div>
-        </div>
-      }
+      sidebar={resolvedSidebar}
       header={
         <header
           // Shell V1 header sits on the rounded content surface — no border-b,

--- a/apps/web/components/organisms/CinematicAppBoot.tsx
+++ b/apps/web/components/organisms/CinematicAppBoot.tsx
@@ -33,29 +33,46 @@ interface CinematicAppBootProps {
   readonly audioPlayer?: ReactNode;
   /** AppShellSkeleton variant — preserved across cinematic + skeleton fallbacks. */
   readonly variant: AppShellFrameVariant;
+  /**
+   * Set to false for unauthenticated onboarding front-door surfaces (/start)
+   * that render AppShellFrame with sidebar={null}. When false:
+   * - No sidebar stub is rendered in cinematic mode.
+   * - Frame animation keeps symmetric inset (no left-shift to accommodate sidebar).
+   * - AppShellSkeleton fallback receives sidebar={null}.
+   * Defaults to true for standard authenticated shells.
+   */
+  readonly hasSidebar?: boolean;
 }
 
 /**
  * Cinematic app boot loader.
  *
- * Mounts as the (shell) layout's Suspense fallback. On the FIRST shell mount
- * per tab (no `jovie:cinematic-boot-played` sessionStorage flag), plays a
- * forward-only cinematic timeline (logo cinematic → reverse spin → frame
- * fade-in → sidebar slide-in → welcome content fade-up) over ~2.4s. The
- * underlying tree resolves whenever it resolves — when React unmounts the
- * Suspense fallback, the real shell appears underneath. Because the cinematic
- * ends in a composition that matches the post-resolve AppShellFrame layout,
- * the hard-cut unmount is visually seamless.
+ * Mounts as the (shell) layout's Suspense fallback (or equivalent for
+ * unauth /start via loading.tsx). On the FIRST shell mount per tab (no
+ * `jovie:cinematic-boot-played` sessionStorage flag), plays a forward-only
+ * cinematic timeline (logo cinematic → reverse spin → frame fade-in →
+ * optional sidebar slide-in → welcome content fade-up) over ~2.4s.
+ *
+ * The underlying tree resolves whenever it resolves — when React unmounts
+ * the Suspense fallback, the real shell appears underneath. Because the
+ * cinematic ends in a composition that matches the post-resolve AppShellFrame
+ * layout (respecting hasSidebar), the hard-cut unmount is visually seamless.
  *
  * On SUBSEQUENT shell mounts in the same tab (the flag is set), or under
  * `prefers-reduced-motion`, or during SSR (the hook defaults true), the
  * cinematic is skipped and the route-specific AppShellSkeleton renders
  * directly — identical to today's loading state.
+ *
+ * Supports unauth onboarding entry via hasSidebar={false} for zero layout
+ * shift on the no-sidebar /start path while preserving the premium per-tab
+ * cinematic where it makes sense (lightweight skeleton fallback always
+ * available).
  */
 export function CinematicAppBoot({
   main,
   audioPlayer,
   variant,
+  hasSidebar = true,
 }: CinematicAppBootProps) {
   const [mounted, setMounted] = useState(false);
   const [shouldPlay, setShouldPlay] = useState(false);
@@ -84,20 +101,27 @@ export function CinematicAppBoot({
     }
   }, []);
 
+  const skeletonSidebar = hasSidebar === false ? null : undefined;
+
   if (!mounted || prefersReducedMotion || !shouldPlay) {
     return (
       <AppShellSkeleton
         main={main}
         audioPlayer={audioPlayer}
         variant={variant}
+        sidebar={skeletonSidebar}
       />
     );
   }
 
   const kfLogo = `jvf-logo-${safeId}`;
   const kfFrame = `jvf-frame-${safeId}`;
+  const kfFrameNoSidebar = `jvf-frame-nosb-${safeId}`;
   const kfSidebar = `jvf-sidebar-${safeId}`;
   const kfContent = `jvf-content-${safeId}`;
+
+  const useNoSidebarFrame = !hasSidebar;
+  const frameAnimationName = useNoSidebarFrame ? kfFrameNoSidebar : kfFrame;
 
   return (
     <div
@@ -133,6 +157,11 @@ export function CinematicAppBoot({
           78%      { opacity: 1; left: 252px; }
           100%     { opacity: 1; left: 252px; }
         }
+        @keyframes ${kfFrameNoSidebar} {
+          0%, 56%  { opacity: 0; left: 12px; }
+          66%      { opacity: 1; left: 12px; }
+          100%     { opacity: 1; left: 12px; }
+        }
         @keyframes ${kfSidebar} {
           0%, 70% { opacity: 0; transform: translateX(-14px); }
           84%     { opacity: 1; transform: translateX(0); }
@@ -144,22 +173,24 @@ export function CinematicAppBoot({
         }
       `}</style>
 
-      <div
-        style={{
-          position: 'absolute',
-          left: 0,
-          top: 0,
-          bottom: 0,
-          width: 244,
-          animationName: kfSidebar,
-          animationDuration: `${TIMELINE_MS}ms`,
-          animationTimingFunction: 'var(--ds-motion-subtle-easing)',
-          animationFillMode: 'forwards',
-          willChange: 'opacity, transform',
-        }}
-      >
-        <CinematicSidebarStub />
-      </div>
+      {hasSidebar && (
+        <div
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: 244,
+            animationName: kfSidebar,
+            animationDuration: `${TIMELINE_MS}ms`,
+            animationTimingFunction: 'var(--ds-motion-subtle-easing)',
+            animationFillMode: 'forwards',
+            willChange: 'opacity, transform',
+          }}
+        >
+          <CinematicSidebarStub />
+        </div>
+      )}
 
       <div
         style={{
@@ -174,11 +205,11 @@ export function CinematicAppBoot({
           boxShadow:
             '0 0 0 1px rgba(0,0,0,0.25), inset 0 0 18px rgba(0,0,0,0.25), 0 24px 60px rgba(0,0,0,0.45)',
           overflow: 'hidden',
-          animationName: kfFrame,
+          animationName: frameAnimationName,
           animationDuration: `${TIMELINE_MS}ms`,
           animationTimingFunction: 'var(--ds-motion-subtle-easing)',
           animationFillMode: 'forwards',
-          willChange: 'opacity, left',
+          willChange: hasSidebar ? 'opacity, left' : 'opacity',
         }}
       >
         <div


### PR DESCRIPTION
## Summary
Wires the cinematic loader / skeleton treatment (via reusable `CinematicAppBoot` + extended `AppShellSkeleton`) for the unauthenticated new-user front door at `/start`.

Eliminates all raw loading text on the path:
- "Securing chat..." → skeleton composer during Turnstile handshake
- "Linking your conversation..." → skeleton pill status
- "Jovie is thinking" + bouncing dots (first turn) → reserved skeleton block in `ChatMessage`

Secondary: `SignUpHandleAvailabilityBanner` "Checking..." → skeleton (live region preserved).

## Changes (HOT ZONE)
- `apps/web/app/(dynamic)/start/loading.tsx` (new): reuses `CinematicAppBoot` with `hasSidebar={false}` + onboarding main skeleton for stable first paint + per-tab guard.
- Extended `AppShellSkeleton` + `CinematicAppBoot` for `sidebar={null}` / `hasSidebar` (zero shift, G-Brain naming respected).
- `OnboardingChat.tsx`, `OnboardingShell.tsx`, `ChatMessage.tsx`, `SignUpPageClient.tsx`.

## Verification
- `pnpm biome check --write` (scoped + unsafe)
- `pnpm turbo typecheck --filter=@jovie/web` ✅ clean
- Focused vitest + existing shell/chat tests pass (mocks cover)
- SessionStorage once-per-tab + 2.4s + reduced-motion preserved (lightweight for unauth)
- Zero layout shift / raw text on marketing CTA → /start → first message

G-Brain `core-journey-ux-polish-20260519` progress recorded (cli WASM blocked; details in session).

Ready for /qa --exhaustive, /design-review, /review on unauth entry.

Closes high-severity unauth frontdoor gap from homepage discovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional sidebar customization for startup/cinematic views, including a no-sidebar variant for startup/skeleton screens.

* **Improvements**
  * Replaced textual loading indicators with centered skeleton placeholders for signup availability checks and onboarding "linking" status.
  * More consistent accessibility semantics: polite/busy announcements for loading and assertive alert role for error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->