### PR TITLE
fix(journey): replace raw loading text, spinners, bouncing dots with skeletons in protected shell chrome

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -126,8 +126,16 @@ function ChatReleaseEntityPanel({
       </div>
 
       {loading ? (
-        <div className='flex flex-1 items-center justify-center px-6 text-center text-[13px] text-tertiary-token'>
-          Loading release…
+        <div
+          className='flex flex-1 items-center justify-center px-6'
+          role='status'
+          aria-live='polite'
+        >
+          <span className='sr-only'>Loading release…</span>
+          <div
+            className='h-4 w-28 rounded skeleton motion-reduce:animate-none'
+            aria-hidden='true'
+          />
         </div>
       ) : release ? (
         <div className='min-h-0 flex-1 overflow-y-auto'>

--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -26,7 +26,6 @@ import {
   usePreviewPanelState,
 } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
 import { AppIconButton } from '@/components/atoms/AppIconButton';
-import { LoadingSpinner } from '@/components/atoms/LoadingSpinner';
 import { ChatWorkspaceSurface } from '@/components/jovie/ChatWorkspaceSurface';
 import { JovieChat } from '@/components/jovie/JovieChat';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
@@ -119,10 +118,14 @@ function ChatProfileFallback({
       <ChatWorkspaceSurface>
         <div className='flex h-full items-center justify-center p-6'>
           <ContentSurfaceCard className='flex max-w-sm flex-col items-center gap-3 px-6 py-8 text-center'>
-            <LoadingSpinner size='lg' tone='muted' />
-            <p className='text-sm text-secondary-token'>
-              Taking you to onboarding…
-            </p>
+            <div
+              className='h-8 w-8 rounded-full skeleton motion-reduce:animate-none'
+              aria-hidden='true'
+            />
+            <div
+              className='h-4 w-44 rounded skeleton motion-reduce:animate-none'
+              aria-hidden='true'
+            />
           </ContentSurfaceCard>
         </div>
       </ChatWorkspaceSurface>
@@ -138,26 +141,38 @@ function ChatProfileFallback({
       <div className='flex h-full items-center justify-center p-6'>
         <ContentSurfaceCard className='flex max-w-sm flex-col items-center gap-3 px-6 py-8 text-center'>
           {isProfileSetupRace ? (
-            <LoadingSpinner size='lg' tone='muted' />
+            <>
+              <div
+                className='h-8 w-8 rounded-full skeleton motion-reduce:animate-none'
+                aria-hidden='true'
+              />
+              <div
+                className='h-4 w-48 rounded skeleton motion-reduce:animate-none'
+                aria-hidden='true'
+              />
+              {canAutoRetry && (
+                <div
+                  className='h-3 w-60 rounded skeleton motion-reduce:animate-none'
+                  aria-hidden='true'
+                />
+              )}
+            </>
           ) : (
             <AlertCircle className='h-8 w-8 text-tertiary-token' />
           )}
-          <p className='text-sm text-secondary-token'>{profileMessage}</p>
-          {isProfileSetupRace && canAutoRetry && (
-            <p className='text-xs text-tertiary-token'>
-              Retrying automatically in 3 seconds ({autoRetryCount + 1}/3)…
-            </p>
-          )}
           {!isProfileSetupRace && (
-            <Button
-              onClick={onRetry}
-              variant='secondary'
-              size='sm'
-              className='gap-2'
-            >
-              <RefreshCw className='h-4 w-4' />
-              Retry
-            </Button>
+            <>
+              <p className='text-sm text-secondary-token'>{profileMessage}</p>
+              <Button
+                onClick={onRetry}
+                variant='secondary'
+                size='sm'
+                className='gap-2'
+              >
+                <RefreshCw className='h-4 w-4' />
+                Retry
+              </Button>
+            </>
           )}
         </ContentSurfaceCard>
       </div>

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -465,7 +465,10 @@ export function LibraryLoadingState() {
         <PageToolbar
           start={
             <span className={PAGE_TOOLBAR_META_TEXT_CLASS}>
-              Loading library assets
+              <span
+                className='inline-block h-3 w-36 rounded-sm skeleton motion-reduce:animate-none align-middle'
+                aria-hidden='true'
+              />
             </span>
           }
         />

--- a/apps/web/components/features/dashboard/organisms/ReleaseTablePendingShell.tsx
+++ b/apps/web/components/features/dashboard/organisms/ReleaseTablePendingShell.tsx
@@ -83,7 +83,10 @@ export function ReleaseTablePendingShell({
           <PageToolbar
             start={
               <span className={PAGE_TOOLBAR_META_TEXT_CLASS}>
-                Loading releases
+                <span
+                  className='inline-block h-3 w-28 rounded-sm skeleton motion-reduce:animate-none align-middle'
+                  aria-hidden='true'
+                />
               </span>
             }
           />

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -106,7 +106,17 @@ function OnboardingShellStatus({
       role={kind === 'error' ? 'alert' : 'status'}
       aria-live={kind === 'error' ? 'assertive' : 'polite'}
     >
-      {message}
+      {kind === 'status' ? (
+        <>
+          <span className='sr-only'>{message}</span>
+          <span
+            className='inline-block h-3 w-44 rounded-full skeleton motion-reduce:animate-none align-middle'
+            aria-hidden='true'
+          />
+        </>
+      ) : (
+        message
+      )}
     </p>
   );
 }

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -971,10 +971,13 @@ export function ReleaseSidebar({
         <div data-testid='release-tasks-card'>
           {isTasksWorkspaceGateLoading ? (
             <div
-              className='animate-pulse px-1 py-1.5 text-xs text-secondary-token'
+              className='px-1 py-1.5'
               data-testid='release-tasks-loading-state'
             >
-              Loading tasks...
+              <div
+                className='h-3 w-24 rounded skeleton motion-reduce:animate-none'
+                aria-hidden='true'
+              />
             </div>
           ) : null}
           {!isTasksWorkspaceGateLoading && canAccessTasksWorkspace ? (

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  Loader2,
-  MessageSquarePlus,
-  MoreHorizontal,
-  RefreshCw,
-} from 'lucide-react';
+import { MessageSquarePlus, MoreHorizontal, RefreshCw } from 'lucide-react';
 import Link from 'next/link';
 import type { ReactNode } from 'react';
 import { useMemo, useState } from 'react';
@@ -130,14 +125,16 @@ export function SidebarThreadsSection({
           <SidebarThreadStatusRow
             tight={tight}
             icon={
-              <Loader2
-                className='h-3 w-3 animate-spin'
+              <div
+                className='h-3.5 w-3.5 rounded-full skeleton motion-reduce:animate-none'
                 aria-hidden='true'
-                strokeWidth={2.25}
               />
             }
           >
-            Loading threads
+            <div
+              className='h-3 w-20 rounded-sm skeleton motion-reduce:animate-none'
+              aria-hidden='true'
+            />
           </SidebarThreadStatusRow>
         ) : null}
         {state === 'error' && !hasThreads ? (

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -272,7 +272,8 @@ describe('DashboardNav interactions', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(screen.getByText('Loading threads')).toBeInTheDocument();
+    expect(document.querySelector('.skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Loading threads')).not.toBeInTheDocument();
     unmount();
 
     mockUseChatConversationsQuery.mockReturnValueOnce({


### PR DESCRIPTION
**Charter follow-up**: After CinematicAppBoot became single source of truth for shell entry, clean raw internal chrome loading states per discovery.

**Changes (8 files, all HOT ZONE)**:
- `apps/web/components/shell/SidebarThreadsSection.tsx`: "Loading threads" + Loader2 → skeleton row
- `apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx`: "Loading tasks..." + pulse → skeleton
- `apps/web/app/app/(shell)/library/LibrarySurface.tsx`: toolbar "Loading library assets" → skeleton
- `apps/web/components/features/dashboard/organisms/ReleaseTablePendingShell.tsx`: toolbar "Loading releases" → skeleton
- `apps/web/app/app/(shell)/chat/ChatPageClient.tsx`: spinners + "Taking you to onboarding…", "Finishing your dashboard setup…", retry text → skeletons in fallbacks (removed unused LoadingSpinner import)
- `apps/web/components/features/onboarding/OnboardingShell.tsx`: "Linking your conversation..." pill → skeleton
- `apps/web/components/jovie/components/ChatMessage.tsx`: "Jovie is thinking" + 3 bouncing dots → skeleton bars (kept testid/a11y)
- `apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx`: "Loading release…" → skeleton

**Verification**:
- Zero layout shift (outer structures + sized placeholders constant)
- Biome check --write passed (fixed 7)
- `pnpm --filter @jovie/web run typecheck` passed
- Relevant unit tests (SidebarThreadsSection, ChatPageClient) 23/23 passed
- No raw "Loading ...", spinners in load paths, or animate-bounce in chat thinking remain in surfaces

**G-Brain**: Locations + before/after logged to core-journey-ux-polish-20260519 (manual due to local PGLite WASM env constraint)

Ready for /qa /review /ship auto-land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Replaced loading state UI elements across the application with skeleton placeholder designs. All text-based loading messages and spinner components have been transitioned to skeleton placeholders throughout chat features, library surfaces, release management, onboarding, and sidebar components for a more consistent visual experience during content loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->