### PR TITLE
fix(cron): reduce every-minute cron cadence to */6 (JOV-2500)

### DIFF
--- a/apps/web/app/api/cron/process-ingestion-jobs/route.ts
+++ b/apps/web/app/api/cron/process-ingestion-jobs/route.ts
@@ -1,10 +1,15 @@
 /**
  * Cron handler for processing ingestion jobs.
  *
- * Runs every minute to claim and process pending ingestion jobs (e.g. MusicFetch enrichment).
+ * Runs every 6 minutes to claim and process pending ingestion jobs (e.g. MusicFetch enrichment).
  * Mirrors the logic in /api/ingestion/jobs but triggered by Vercel Cron instead of manual POST.
  *
- * Schedule: every 1 minute (configured in vercel.json)
+ * Schedule: every 6 minutes (configured in vercel.json). The 6-minute cadence
+ * lets Neon's 5-minute autosuspend reclaim the production compute between
+ * ticks instead of keeping it warm 24/7 (JOV-2500). Latency cost: up to
+ * ~6 minutes between enqueue and processing — acceptable for background
+ * enrichment. If a workflow needs faster turnaround, prefer event-driven
+ * enqueue over reducing this cadence.
  */
 
 import { NextResponse } from 'next/server';

--- a/apps/web/app/api/cron/process-workflow-runs/route.ts
+++ b/apps/web/app/api/cron/process-workflow-runs/route.ts
@@ -1,5 +1,5 @@
 /**
- * Cron: /api/cron/process-workflow-runs (every minute)
+ * Cron: /api/cron/process-workflow-runs (every 6 minutes)
  *
  * Decision hierarchy compliance (per .claude/rules/infra.md):
  * 1. Webhook/event: N/A — workflow runs are triggered by the approve endpoint
@@ -11,13 +11,20 @@
  *    workflow_runs has different semantics (concurrent, multi-step).
  * 5. New cron: Required here because calendar API calls are external and slow.
  *
+ * Cadence: 6 minutes (JOV-2500). The original every-minute cadence kept Neon's
+ * production compute warm 24/7 (5-minute autosuspend never fired between ticks),
+ * adding ~$10-25/month of compute overage at zero users. The 6-minute cadence
+ * gives the compute a ~1-minute idle window to autosuspend between ticks. The
+ * tradeoff is up to ~6 minutes between approval and execution; acceptable until
+ * we move to event-driven enqueue (see JOV-2500 follow-on).
+ *
  * Design:
  * - CAS claim: UPDATE ... SET status='running' WHERE status='pending' AND runAt<=now()
  * - Process MAX_RUNS_PER_TICK runs, MAX_CONCURRENT_RUNS in parallel
  * - Unknown workflow kinds are failed immediately (fail-closed)
  *
  * Cost impact: 1 DB query/tick + up to 20 Google Calendar API calls/tick
- * at 1440 ticks/day = max 28,800 Google API calls/day at full load.
+ * at 240 ticks/day = max 4,800 Google API calls/day at full load.
  * In practice: only runs when there are pending workflow_runs rows.
  */
 

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "/api/cron/process-ingestion-jobs",
-      "schedule": "* * * * *"
+      "schedule": "*/6 * * * *"
     },
     {
       "path": "/api/cron/summarize-interviews",
@@ -46,7 +46,7 @@
     },
     {
       "path": "/api/cron/process-workflow-runs",
-      "schedule": "* * * * *"
+      "schedule": "*/6 * * * *"
     }
   ],
   "functions": {

--- a/docs/CRON_REGISTRY.md
+++ b/docs/CRON_REGISTRY.md
@@ -26,7 +26,7 @@ Scheduled workflows in `.github/workflows/`. Not Vercel crons — these run on G
 
 ## Production Schedule
 
-Source of truth: `vercel.json` (repo root — Vercel reads this file; `apps/web/vercel.json` has been deleted per JOV-1901 / AUTOMATION_AUDIT.md)
+Source of truth: `apps/web/vercel.json`. The Vercel project's Root Directory is set to `apps/web/` (verified via `vercel project inspect jovie`), so Vercel reads that file, not the repo-root `vercel.json`. The root-level `vercel.json` exists for historical reasons and is **not** what Vercel consumes — keep both in sync until it can be deleted (see JOV-1901 / AUTOMATION_AUDIT.md for the original deletion intent).
 
 | Cron Path | Schedule | Frequency |
 |-----------|----------|-----------|

--- a/docs/CRON_REGISTRY.md
+++ b/docs/CRON_REGISTRY.md
@@ -33,7 +33,7 @@ Source of truth: `vercel.json` (repo root — Vercel reads this file; `apps/web/
 | `/api/cron/frequent` | `*/15 * * * *` | Every 15 minutes |
 | `/api/cron/daily-maintenance` | `0 0 * * *` | Daily at midnight UTC |
 | `/api/cron/generate-insights` | `0 5 * * *` | Daily at 05:00 UTC |
-| `/api/cron/process-ingestion-jobs` | `* * * * *` | Every minute |
+| `/api/cron/process-ingestion-jobs` | `*/6 * * * *` | Every 6 minutes (JOV-2500: lets Neon 5min autosuspend reclaim compute) |
 | `/api/cron/purge-pixel-ips` | `0 3 * * *` | Daily at 03:00 UTC |
 | `/api/cron/summarize-interviews` | `*/5 * * * *` | Every 5 minutes |
 | `/api/cron/generate-playlist` | `0 6 * * *` | Daily at 06:00 UTC |

--- a/vercel.json
+++ b/vercel.json
@@ -22,7 +22,7 @@
     },
     {
       "path": "/api/cron/process-ingestion-jobs",
-      "schedule": "* * * * *"
+      "schedule": "*/6 * * * *"
     },
     {
       "path": "/api/cron/summarize-interviews",
@@ -46,7 +46,7 @@
     },
     {
       "path": "/api/cron/process-workflow-runs",
-      "schedule": "* * * * *"
+      "schedule": "*/6 * * * *"
     },
     {
       "path": "/api/cron/public-profile-canary",


### PR DESCRIPTION
## Summary

Drops two every-minute crons (`process-ingestion-jobs`, `process-workflow-runs`) to `*/6 * * * *`. The original 60-second cadence prevented Neon's 5-minute autosuspend from ever firing, keeping the production compute warm 24/7 at zero users.

Cost impact: estimated $10-25/month saved on Neon compute overage.

## Why this change

Both crons unconditionally hit the production DB regardless of whether work is pending. At a 60-second cadence vs Neon's 5-minute autosuspend, the compute never gets to suspend → 720 CU-hours/month of compute on Launch plan's 300 CU-hour quota.

`*/6` gives a ~1-minute idle window between ticks so the autosuspend can fire. Tradeoff: up to ~6 minutes between enqueue and processing. Acceptable today (zero users) and explicitly documented as a step toward event-driven enqueue (next iteration).

## Test plan

- [x] `vercel.json` schedules updated and validated as JSON
- [x] Header comments in both handlers updated to reflect new cadence + reasoning
- [x] `docs/CRON_REGISTRY.md` row updated
- [x] Pre-commit (biome + typecheck + a11y check + eslint) passed
- [ ] Post-deploy: verify Neon dashboard → Monitoring → Compute time shows regular autosuspend cycles (compute drops to 0 CU during low-traffic windows)
- [ ] Post-deploy: verify no growing backlog of `ingestionJobs` (`status='pending'`, runAt < now() - 6min) or `workflow_runs`

## Linear

Closes [JOV-2500](https://linear.app/jovie/issue/JOV-2500) (option 3 — cadence reduction). Sibling: JOV-2501 (CI Neon fan-out), JOV-2502 (compute sizing — dashboard action).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated scheduled background jobs for ingestion and workflow processing to run every 6 minutes (was every minute), reducing compute churn.
* **Documentation**
  * Updated docs and cron registry to reflect the new cadence and noted enqueue-to-processing latency may be up to ~6 minutes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->