### PR TITLE
chore(ci): autoplan impl — Dependabot skip + conditional-decision rule

### DIFF
--- a/.claude/hooks/conditional-decision-lint.sh
+++ b/.claude/hooks/conditional-decision-lint.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# conditional-decision-lint.sh
+#
+# Enforces the conditional-decision rule (CLAUDE.md → Operating Principles, added 2026-05-18).
+# Scans the agent's final-answer text for phrases that defer work without a trigger
+# (Linear ID) or an EVENT: tag. Same shape as `.claude/rules/linear.md` follow-up rule,
+# promoted to a runtime hook.
+#
+# Mode: warn through 2026-06-01, then error (controlled by CONDITIONAL_DECISION_LINT_MODE).
+#
+# Input: agent transcript text on STDIN (or in $CLAUDE_PROJECT_DIR/.claude/last-output if set).
+# Exit codes:
+#   0 — clean OR warn-mode hit
+#   1 — error-mode hit (blocks task completion)
+
+set -euo pipefail
+
+MODE="${CONDITIONAL_DECISION_LINT_MODE:-warn}"
+# Auto-promote to error after 2026-06-01 unless explicitly overridden
+TODAY="$(date +%Y-%m-%d)"
+if [[ "$MODE" == "warn" && "$TODAY" > "2026-06-01" ]]; then
+  MODE="error"
+fi
+
+INPUT="${1:-/dev/stdin}"
+
+# Phrases that indicate deferred work
+DEFER_PATTERNS=(
+  "future work"
+  "follow-up"
+  "follow up"
+  "consider later"
+  "consider after"
+  "deferred"
+  "not in scope"
+  "out of scope for now"
+  "revisit later"
+  "we should later"
+  "when we grow"
+  "too early"
+  "premature"
+)
+
+# Build a single grep alternation
+PATTERN=""
+for p in "${DEFER_PATTERNS[@]}"; do
+  if [[ -z "$PATTERN" ]]; then
+    PATTERN="$p"
+  else
+    PATTERN="$PATTERN|$p"
+  fi
+done
+
+# Read input
+if [[ "$INPUT" == "/dev/stdin" ]]; then
+  TEXT="$(cat)"
+else
+  TEXT="$(cat "$INPUT")"
+fi
+
+# Empty input is a pass
+[[ -z "$TEXT" ]] && exit 0
+
+# Find candidate lines (case-insensitive)
+HITS="$(printf '%s\n' "$TEXT" | grep -niE "$PATTERN" || true)"
+[[ -z "$HITS" ]] && exit 0
+
+# For each hit, check if it has an adjacent Linear ID (JOV-NNNN), an EVENT: tag,
+# or an explicit-trigger phrase (Ship now / Re-evaluate when / Then).
+VIOLATIONS=""
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  # Match Linear ID, EVENT: tag, or conditional-decision-format markers in the same line
+  if echo "$line" | grep -qiE '(JOV-[0-9]+|EVENT:|Re-evaluate when|Ship now|trigger:)'; then
+    continue
+  fi
+  VIOLATIONS="${VIOLATIONS}${line}"$'\n'
+done <<< "$HITS"
+
+[[ -z "$VIOLATIONS" ]] && exit 0
+
+# Report
+echo "============================================================"
+echo "conditional-decision-lint: deferred work without trigger or Linear ID"
+echo "============================================================"
+echo "Rule (CLAUDE.md → Operating Principles): every deferred SYSTEM decision must"
+echo "include either a Linear issue ID (JOV-NNNN), an EVENT: tag for permanent/taste"
+echo "decisions, or an explicit Ship-now/Re-evaluate-when/Then format."
+echo ""
+echo "Violations:"
+echo "$VIOLATIONS"
+echo "Fix one of:"
+echo "  - File a Linear issue using the shape in .claude/rules/linear.md and cite the ID"
+echo "  - Tag the decision EVENT: <one-line reason it's permanent>"
+echo "  - Reformat as Ship now / Re-evaluate when / Then with a measurable trigger"
+echo "============================================================"
+
+if [[ "$MODE" == "error" ]]; then
+  exit 1
+fi
+echo "(warn mode — not blocking; promotes to error on 2026-06-02)"
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -826,7 +826,7 @@ jobs:
   ci-mobile-overflow:
     name: Mobile Overflow Guard (${{ matrix.width }}px)
     needs: [ci-fast, ci-path-changes, neon-db]
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.ci-path-changes.outputs.run_e2e == 'true' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && needs.ci-path-changes.outputs.run_e2e == 'true' && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -2224,7 +2224,7 @@ jobs:
     name: A11y (axe)
     # Runs axe-core WCAG 2.1 AA audit on public routes — uses shared build artifact.
     needs: [ci-build-public, ci-path-changes, neon-db]
-    if: ${{ ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || github.event_name == 'workflow_dispatch') && needs.ci-build-public.outputs.has_artifact == 'true' }}
+    if: ${{ ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false) || github.event_name == 'workflow_dispatch') && needs.ci-build-public.outputs.has_artifact == 'true' && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,45 @@
+name: Dependabot Auto-Merge
+
+# Auto-merges Dependabot PRs for semver patch + minor bumps after CI green.
+# Major bumps still route to Tim manually (per .github/dependabot.yml ignore list).
+# Re-evaluate (per CLAUDE.md conditional-decision rule): if any patch/minor
+# auto-merge causes a Sentry-gated rollback, narrow scope to patch-only OR
+# require manual review. Added 2026-05-18 per autoplan R2.3.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (squash) for patch and minor
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          echo "Dependency: ${{ steps.meta.outputs.dependency-names }}"
+          echo "Update type: ${{ steps.meta.outputs.update-type }}"
+          gh pr merge --auto --squash "$PR_URL"
+
+      - name: Note major bump requires manual review
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          echo "Major bump for ${{ steps.meta.outputs.dependency-names }} — manual review required"
+          gh pr comment "$PR_URL" --body "Major version bump detected. Auto-merge skipped — manual review required per CLAUDE.md conditional-decision rule (re-evaluate trigger: if any major bump auto-merge causes a Sentry-gated rollback)."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ Controller file for AI agents working in this repo. `AGENTS.md` is a symlink to 
 - Don't invent commands, env vars, routes, tables, services, or design tokens.
 - Don't hide failing checks. Report exact failures and the likely cause.
 - Ask before destructive operations: data deletion, irreversible migrations, credential changes, dependency replacement, auth/payment changes, or production-impacting scripts.
+- **Decisions are systems, not events** (when quantifiable). For decisions whose cost or benefit is measurable, format as **Ship now / Re-evaluate when / Then** with the trigger tied to revenue/cost/perf unit economics (per-unit cost OR build cost = CI minutes × runner $/min + agent minutes × $/hr-of-intelligence). For taste, identity, security, or "this is just wrong" decisions, tag `EVENT:` and skip the trigger — some decisions are permanent. Reject phrasing like "premature", "later", "future work" without a Linear ID. See `.claude/rules/code-style.md` → "Conditional decisions" (added 2026-05-18) and `~/.claude/projects/.../memory/feedback_conditional_decisions.md`. Enforcement hook: `.claude/hooks/conditional-decision-lint.sh` (warn-mode through 2026-06-01, then error).
 
 ## Agent Role Boundary
 


### PR DESCRIPTION
## Summary

Implementation of the CI/Jovie-bot autoplan (2026-05-18). Four changes:

1. **`.github/workflows/ci.yml`** — adds `github.actor != 'dependabot[bot]'` skip to `ci-mobile-overflow` and `ci-a11y` jobs. **Unblocks JOV-2466 Failure B**: these jobs need Neon ephemeral branches but fail silently in Dependabot security context. 7 dependency PRs are currently piled up unmergeable (#9154, #9155, #9158, #9161, #9163, #9164, #9212).
2. **`.github/workflows/dependabot-auto-merge.yml`** — new ~30-line workflow that squash-merges Dependabot patch + non-breaking minor bumps after CI green. Major bumps route to manual review per JOV-2461. Implements R2 item 3 of the autoplan.
3. **`.claude/hooks/conditional-decision-lint.sh`** — new hook scanning agent final-answer text for `future work` / `follow-up` / `consider later` without a Linear ID OR `EVENT:` tag. Warn-mode through 2026-06-01, then auto-promotes to error. Implements R7. Not wired into `settings.json` yet — see JOV-2459.
4. **`CLAUDE.md` → Operating Principles** — adds the conditional-decision rule (SYSTEM vs EVENT). Quantifiable decisions need a `Ship-now / Re-evaluate-when / Then` trigger. Taste, identity, security decisions get `EVENT:` and skip the rule. Established by dual-voice review (Claude subagent + Codex). Premise gate D2.

## Related Linear

JOV-2455 (Lighthouse subtract), JOV-2456 (CI caches), JOV-2457 (Neon mutation audit), JOV-2458 (PR-yield HUD), JOV-2459 (hook wiring), JOV-2466 (Dependabot CI infra).

## Plan

\`~/.claude/plans/system-instruction-you-are-working-atomic-lake.md\`

## Test plan

- [ ] CI passes on this PR (typecheck, biome, eslint, unit tests, build)
- [ ] After merge, retrigger CI on any Dependabot PR (e.g. #9155 axe-core patch); confirm `Mobile Overflow Guard` and `A11y (axe)` are SKIPPED (not FAIL)
- [ ] Confirm a Dependabot patch PR auto-merges via `dependabot-auto-merge.yml` once CI is green
- [ ] Synthetic test of `conditional-decision-lint.sh`: pipe text with "follow-up later" → warn output; with "follow-up later JOV-1234" → pass; with "follow-up later EVENT: permanent" → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI pipeline for Dependabot pull requests by skipping expensive checks (accessibility audits, mobile overflow guard).
  * Automated merging of Dependabot patch and minor version updates; manual review required for major updates.

* **Documentation**
  * Added conditional decision-making patterns to operating guidelines with enforcement rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->