### PR TITLE
test(e2e): add explicit CLS guard for /start composer first-message morph (JOV-2496)

### DIFF
--- a/apps/web/tests/e2e/start-onboarding-chat.spec.ts
+++ b/apps/web/tests/e2e/start-onboarding-chat.spec.ts
@@ -441,8 +441,12 @@ test.describe('canonical /start onboarding chat', () => {
     ).toBeEnabled();
 
     const firstChatResponse = page.waitForResponse('**/api/chat');
+    const yBefore =
+      (await page.locator(COMPOSER_SURFACE).boundingBox())?.y ?? 0;
     await page.getByRole('button', { name: 'Send message' }).click();
     await firstChatResponse;
+    const yAfter = (await page.locator(COMPOSER_SURFACE).boundingBox())?.y ?? 0;
+    expect(Math.abs(yAfter - yBefore)).toBeLessThanOrEqual(5); // Addresses journey jank audit 20260519 + testing.md explicit CLS requirement for conditional UI (composer morph, row replace, cinematic fallback)
 
     await expect(
       page.getByText('find the exact Spotify profile')


### PR DESCRIPTION
**One-file mechanical win per smallwin brief + JOV-2496 core journey UX polish.**

## Change
- Added  boundingBox y pre/post guard (delta <=5px) around first user turn send in the canonical /start onboarding chat test.
- Explicitly guards the conditional UI transition (composer/structural morph on first message) that was root cause of jank per audit.
- Comment: "Addresses journey jank audit 20260519 + testing.md explicit CLS requirement for conditional UI (composer morph, row replace, cinematic fallback)"
- **Exactly 1 file touched**: apps/web/tests/e2e/start-onboarding-chat.spec.ts (the narrowest spec exercising /start → first message + unauth cinematic shell load + composer morph). No prod code, no other tests, no snapshots changed.

## Evidence of gates
- ./scripts/setup.sh + pnpm install --frozen
- pnpm --filter @jovie/web run typecheck (green)
- pnpm biome check --write [the file only] (auto-fixed format)
- Specific e2e: playwright test ...start-onboarding-chat.spec.ts -g "first screen..." (2 passed)
- Pre-push hook: full biome + typecheck + lint + tailwind + proxy guards (all green)
- Rebased on main, pushed, hooks clean

## Risk
Zero. Pure additive test guard on existing test surface. No behavior change. Matches explicit requirement in docs/TESTING_GUIDELINES.md and apps/web/tests/TESTING.md for layout shift tests on conditional UI.

## Diff (4 lines added)
```diff
+    const yBefore =
+      (await page.locator(COMPOSER_SURFACE).boundingBox())?.y ?? 0;
     await ...click();
     await firstChatResponse;
+    const yAfter = (await page.locator(COMPOSER_SURFACE).boundingBox())?.y ?? 0;
+    expect(Math.abs(yAfter - yBefore)).toBeLessThanOrEqual(5); // Addresses journey jank audit 20260519 + testing.md explicit CLS requirement for conditional UI (composer morph, row replace, cinematic fallback)
```

Ready for /qa narrow, /review, /ship + auto-merge squash.

🤖 Coder subagent (JOVIE_AGENT_PROFILE=coder) — small/easy disjoint mechanical win while re-measure waits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Tests**
- Enhanced chat composer stability verification to ensure the interface maintains its position during message sending, with a 5-pixel tolerance threshold for detecting layout shifts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->