### PR TITLE
chore(test): relative date polish >1y coverage (no 2193d ago; shell-v1 handoff + JOV-2496)

### DIFF
--- a/apps/web/lib/format-relative-date.test.ts
+++ b/apps/web/lib/format-relative-date.test.ts
@@ -21,11 +21,13 @@ describe('relativeDate', () => {
   it('formats older past dates without raw multi-year day counts', () => {
     expect(relativeDate('2026-04-04T12:00:00Z', NOW)).toBe('3w ago');
     expect(relativeDate('2026-01-15T12:00:00Z', NOW)).toBe('3mo ago');
-    // >1y uses exact month+year per convention (truthful label, no approx "Ny ago")
+    // >1y uses exact month+year per convention (truthful label, no approx "Ny ago"; never "2193d ago" per handoff)
     expect(relativeDate('2024-04-19T12:00:00Z', NOW)).toBe('Apr 2024');
     const multiYear = relativeDate('2020-04-24T12:00:00Z', NOW);
     expect(multiYear).toBe('Apr 2020');
     expect(multiYear).not.toMatch(/^\d{4,}d ago$/u);
+    // extra >1y case for coverage (JOV-2496 wave / shell-v1 relative-date polish)
+    expect(relativeDate('2023-06-10T12:00:00Z', NOW)).toBe('Jun 2023');
   });
 
   it('formats short future inside a week as "in Nd"', () => {


### PR DESCRIPTION
## Summary
Small mechanical verification + test coverage expansion for the relativeDate utility (HOT ZONE: only `apps/web/lib/format-relative-date.ts` + `.test.ts`).

This `codex/smallwin-relative-date-polish` branch isolates the polish flagged in the shell-v1 handoff manifest for the JOV-2496 wave (easy high-confidence win alongside layout-shift and Stryker items dispatched in parallel).

The core handling for dates >~365d (exact "Apr 2024" short date, never raw day counts like 2193d ago) was already correct per product convention in main; this PR adds one extra >1y assertion for explicit coverage + handoff reference.

## Changes (strict HOT ZONE only)
- Updated the existing test block to include additional >1y case ("Jun 2023") and reference to handoff language in comment.
- **Zero** changes to implementation logic or *any* files outside the two allowed HOT ZONE files. (Callers in shell-v1 etc. untouched per boundary.)

## Verification (all strictly on the two files / web package)
- Bootstrap: `./scripts/setup.sh` + dropped lint-staged/autostash/other stashes + clean `git status`
- Read the two HOT ZONE files + limited grep for direct tests/usages (identified shell-v1 re-export + other formatters but reported only, no edits)
- Identified current >1y behavior: for `pastDays >= 365` returns `toLocaleDateString` short "MMM YYYY" (e.g. "Apr 2024", "Jun 2023"). Matches the handoff directive ("handle more than a year as years/months or exact date per existing product convention") and the explicit "never show huge day counts like 2193D AGO".
- Biome: `pnpm biome check --write ...` (twice) + read-only check on *only* the two files: clean, no fixes
- Test: `pnpm --filter @jovie/web exec vitest run lib/format-relative-date.test.ts` — 8/8 passed (all cases including the not-toMatch huge d-ago regex and the new coverage line)
- Typecheck: `pnpm --filter @jovie/web run typecheck` (web) — exit 0, no errors
- Pre-push hygiene: full `pnpm run pre-push` (biome ., web guards, tailwind, typecheck, lint) green on push
- Commit hygiene: respected hooks (husky pre-commit + commitlint); amended to short header <=100 chars after initial long-msg failure; no permanent --no-verify

## Exact Diff (3 insertions, 1 deletion in test only)
```diff
diff --git a/apps/web/lib/format-relative-date.test.ts b/apps/web/lib/format-relative-date.test.ts
index ... 
--- a/apps/web/lib/format-relative-date.test.ts
+++ b/apps/web/lib/format-relative-date.test.ts
@@ -21,10 +21,13 @@ describe('relativeDate', () => {
   it('formats older past dates without raw multi-year day counts', () => {
     expect(relativeDate('2026-04-04T12:00:00Z', NOW)).toBe('3w ago');
     expect(relativeDate('2026-01-15T12:00:00Z', NOW)).toBe('3mo ago');
-    // >1y uses exact month+year per convention (truthful label, no approx "Ny ago")
+    // >1y uses exact month+year per convention (truthful label, no approx "Ny ago"; never "2193d ago" per handoff)
     expect(relativeDate('2024-04-19T12:00:00Z', NOW)).toBe('Apr 2024');
     const multiYear = relativeDate('2020-04-24T12:00:00Z', NOW);
     expect(multiYear).toBe('Apr 2020');
     expect(multiYear).not.toMatch(/^\d{4,}d ago$/u);
+    // extra >1y case for coverage (JOV-2496 wave / shell-v1 relative-date polish)
+    expect(relativeDate('2023-06-10T12:00:00Z', NOW)).toBe('Jun 2023');
   });
 
   it('formats short future inside a week as "in Nd"', () => {
```

## Risk / Scope
- **Zero risk.** Pure additive test coverage on a pure utility that already prevented the blast-radius bug ("2193d ago" in e.g. DropDateChip, activity feeds, etc.).
- No UI, no tokens, no DB, no callers modified, no new exports.
- Follows all AGENTS.md / .claude/rules (HOT ZONE absolute, server/lib only, decisions documented, hooks honored).

Refs: shell-v1 handoff manifest, JOV-2496 orchestration wave, parallel smallwin agents (layout-shift + Stryker).

## Next (per task)
- Run full gstack: `/qa --exhaustive` (narrowed to this test surface), `/review`, `/ship`
- Land via auto-merge when clean.

This is the contained mechanical win while core journey waits on re-measure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for relative date formatting, adding validation for dates older than one year to ensure proper month and year display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->