### PR TITLE
test(artists): cwd-robust path for page config test (smallwin pattern)

### DIFF
--- a/apps/web/tests/unit/artists-page-config.test.ts
+++ b/apps/web/tests/unit/artists-page-config.test.ts
@@ -1,10 +1,15 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 describe('/artists route segment config', () => {
   it('keeps ISR revalidate and does not force dynamic rendering', () => {
-    const pagePath = resolve(process.cwd(), 'app/artists/page.tsx');
+    // Robust path: resolve relative to this test file (not process.cwd()).
+    // Prevents cwd-dependent breakage (package vs repo root invocation contexts).
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    const pagePath = resolve(__dirname, '../../app/artists/page.tsx');
     const pageSource = readFileSync(pagePath, 'utf8');
 
     // Match revalidate export with any valid formatting


### PR DESCRIPTION
test(artists): cwd-robust path for page config test (smallwin pattern)

This is the 5th small/easy-win mechanical hygiene item in the current capacity-farming wave (JOVIE_AGENT_PROFILE=coder), while the main core-journey re-measure (core journey re-measure agent) remains the sequential focus.

**Exact fix (copy of proven pattern from EntityPopover win):**
- Replaced brittle `resolve(process.cwd(), 'app/artists/page.tsx')` (breaks when invoked from repo root vs inside apps/web, common in CI/turbo/pnpm --filter).
- Switched to `import { fileURLToPath } from 'node:url'` + `dirname` + simulated `__dirname` (const __filename = ...; const __dirname=... inside it()) + `resolve(__dirname, '../../app/artists/page.tsx')`.
- Added the exact 2-line comment:
  // Robust path: resolve relative to this test file (not process.cwd()).
  // Prevents cwd-dependent breakage (package vs repo root invocation contexts).
- Matches the EntityPopover source contract test fix (commit 1ea36cecd) for pattern continuity. 1-file only.

**Verification (all green):**
- Bootstrap: ./scripts/setup.sh
- `pnpm biome check --write` on *the file only* (pre-push hygiene).
- `pnpm --filter @jovie/web run typecheck` + `pnpm turbo typecheck --filter=@jovie/web` (gate).
- Specific test passes from **both** contexts:
  - Inside apps/web
  - From repo root (pnpm exec vitest ... with cwd=root, which would have failed the old process.cwd() path)
- Full pre-push gates (biome check ., web pre-push typecheck/lint/tailwind/proxy-guard) on push.
- Lint-staged stashes explicitly dropped before every commit.
- No other files touched (strict adherence to HOT ZONE).

References previous EntityPopover cwd-robust win for continuity. Pure mechanical debt repayment — no design, no new behavior.

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test robustness for the artists page configuration by improving file path resolution across different invocation contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->