### PR TITLE
fix(ui): sidebar reveal over elevated content + slow ambient logo glow in empty state

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -583,12 +583,13 @@ export function JovieChat({
                       Positioned absolute so it doesn't shift the welcome heading. */}
                   <div
                     aria-hidden
-                    className='pointer-events-none absolute inset-0 flex items-center justify-center select-none'
+                    className='pointer-events-none absolute inset-0 flex items-center justify-center select-none anim-calm-breath opacity-45'
                     data-testid='chat-empty-thread-ornament'
                   >
                     {shellChatV1Enabled ? (
                       <JovieMarkElectric
-                        className='opacity-70'
+                        spark={false}
+                        className='opacity-100'
                         style={{
                           width: 'clamp(180px, 34vw, 360px)',
                           height: 'clamp(180px, 34vw, 360px)',

--- a/apps/web/components/organisms/sidebar/sidebar.tsx
+++ b/apps/web/components/organisms/sidebar/sidebar.tsx
@@ -72,7 +72,7 @@ export const Sidebar = React.forwardRef<
         {!isMobile && (
           <div
             ref={ref}
-            className='group peer max-lg:hidden shrink-0 overflow-visible text-sidebar-foreground lg:sticky lg:top-0'
+            className='group peer max-lg:hidden shrink-0 overflow-visible text-sidebar-foreground lg:sticky lg:top-0 lg:z-10'
             data-state={state}
             data-collapsible={state === 'closed' ? collapsible : ''}
             data-variant={variant}
@@ -105,7 +105,7 @@ export const Sidebar = React.forwardRef<
             >
               <div
                 data-sidebar='sidebar'
-                className='pointer-events-auto flex h-full w-full flex-col overflow-clip bg-sidebar transition-[background-color] duration-normal ease-interactive lg:rounded-[var(--linear-app-shell-radius)] group-data-[variant=floating]:rounded-[14px] group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow group-data-[variant=inset]:border-r group-data-[variant=inset]:border-sidebar-border'
+                className='pointer-events-auto flex h-full w-full flex-col overflow-clip bg-sidebar transition-[background-color] duration-normal ease-interactive lg:rounded-[var(--linear-app-shell-radius)] lg:shadow-[var(--linear-app-sidebar-shadow)] group-data-[variant=floating]:rounded-[14px] group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow group-data-[variant=inset]:border-r group-data-[variant=inset]:border-sidebar-border'
               >
                 {children}
               </div>


### PR DESCRIPTION
## Summary
Visual polish follow-up per explicit user feedback on the offcanvas sidebar reveal feeling inverted and the empty-state logo glow being too fast/sparky.

## Changes (minimal, 2 files)
- `apps/web/components/organisms/sidebar/sidebar.tsx`: Added `lg:z-10` to the desktop sidebar container and `lg:shadow-[var(--linear-app-sidebar-shadow)]` to the inner panel. This makes the sidebar slide *over* an elevated-feeling main content surface (faked layering for offcanvas elevation as discussed).
- `apps/web/components/jovie/JovieChat.tsx`: Empty-state ornament now uses `anim-calm-breath` + `opacity-45` container and `JovieMarkElectric spark={false} opacity-100` for a slow, ambient breathing glow instead of the previous fast spark animation.

## Verification
- Rebased cleanly on latest origin/main.
- `pnpm biome check --write` + full pre-push gates (biome, eslint, a11y, typecheck, tailwind guard, proxy-guard) all green on the two files and full web package.
- Relevant unit tests passed: JovieChat.empty-state, JovieChat.styling, sidebar visual-hierarchy, row alignment, UnifiedSidebar.
- Bootstrap via setup.sh + Doppler + no stashes + rebase completed.

This is the exact minimal targeted change the user requested for the sidebar elevation feel and calm logo in chat empty state.

## PR Checklist
- [x] Typecheck (turbo/web)
- [x] Biome + lint
- [x] Relevant tests
- [x] Draft PR opened

(Will run /qa --exhaustive + /review + /ship per workflow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the welcome empty-state with a gentle breathing animation and reduced visual intensity
  * Adjusted chat mark appearance to remove spark and increase opacity in the updated chat rendering
  * Enhanced sidebar layout with improved spacing and added depth via a larger-screen shadow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->