### PR TITLE
feat(shell): complete releases surface into unified v1 shell (ShellReleasesView)

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/ReleasesPageClient.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/ReleasesPageClient.tsx
@@ -2,7 +2,9 @@
 
 import dynamic from 'next/dynamic';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
+import { ShellReleasesView } from '@/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
+import { useAppFlag } from '@/lib/flags/client';
 import { useReleasesQuery } from '@/lib/queries/useReleasesQuery';
 import { primaryProviderKeys, providerConfig } from './config';
 import { ReleaseTableSkeleton } from './loading';
@@ -30,6 +32,7 @@ export function ReleasesPageClient() {
   const { selectedProfile } = useDashboardData();
   const profileId = selectedProfile?.id ?? '';
   const { data: releases, isError } = useReleasesQuery(profileId);
+  const designV1ReleasesEnabled = useAppFlag('DESIGN_V1');
 
   const settings =
     (selectedProfile?.settings as Record<string, unknown> | null) ?? {};
@@ -60,6 +63,22 @@ export function ReleasesPageClient() {
 
   if (releases === undefined) {
     return <ReleaseTableSkeleton showHeader={false} />;
+  }
+
+  if (designV1ReleasesEnabled) {
+    return (
+      <ShellReleasesView
+        releases={releases ?? []}
+        providerConfig={providerConfig}
+        primaryProviders={primaryProviderKeys}
+        artistName={spotifyArtistName ?? appleMusicArtistName ?? null}
+        allowArtworkDownloads={allowArtworkDownloads}
+        spotifyConnected={spotifyConnected}
+        appleMusicConnected={appleMusicConnected}
+        initialImporting={spotifyImportStatus === 'importing'}
+        initialTotalCount={spotifyImportTotal}
+      />
+    );
   }
 
   return (

--- a/apps/web/tests/unit/dashboard/ReleasesPageClient-skeleton.test.tsx
+++ b/apps/web/tests/unit/dashboard/ReleasesPageClient-skeleton.test.tsx
@@ -40,6 +40,10 @@ vi.mock('@/features/feedback/PageErrorState', () => ({
   PageErrorState: () => <div data-testid='page-error-state' />,
 }));
 
+vi.mock('@/lib/flags/client', () => ({
+  useAppFlag: () => false,
+}));
+
 describe('ReleasesPageClient skeleton behavior', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/tests/unit/dashboard/releases-page-client.test.tsx
+++ b/apps/web/tests/unit/dashboard/releases-page-client.test.tsx
@@ -63,6 +63,10 @@ vi.mock('@/app/app/(shell)/dashboard/releases/config', () => ({
   providerConfig: {},
 }));
 
+vi.mock('@/lib/flags/client', () => ({
+  useAppFlag: () => false,
+}));
+
 vi.mock('@/app/app/(shell)/dashboard/releases/loading', () => ({
   ReleaseTableSkeleton: () => (
     <div data-testid='release-skeleton'>Loading...</div>


### PR DESCRIPTION
## Summary
Wires the canonical `ShellReleasesView` (real production data via `useReleasesQuery` + `loadReleaseMatrix`, `ShellListRowFrame` + `ArtworkThumb` deterministic fallback, pill filters, action rows/menus, right rail via `useRegisterRightPanel`, empty/loading states, mobile-responsive cells) into the releases routes when `DESIGN_V1` (which enables `DESIGN_V1_RELEASES`) is on.

- Legacy `ReleaseProviderMatrix` / table preserved when flag off.
- Aligns to shared shell (UnifiedSidebar via `AuthShellWrapper`, `DashboardHeader` actions/search, `PageShell` content-container frame).
- HOT ZONE only. No fake data, no blobs, no new migrations, production contracts.
- Part of parallel shell-v1 migration wave (per handoff).

## Changed files
- `apps/web/app/app/(shell)/dashboard/releases/ReleasesPageClient.tsx` (+19/-0)

## Verification
- `pnpm turbo typecheck --filter=@jovie/web` ✅
- `pnpm biome check --write ...` + lint ✅
- Focused vitest on `ShellReleasesView.test.tsx` (18/18) ✅
- Pre-push full suite (biome, tailwind-guard, typecheck, lint) ✅
- Rebased on main

## Screenshots / QA
Pending local / gstack /browse + /design-review + /qa --exhaustive on `/app/releases` and `/app/dashboard/releases` (desktop/tablet/mobile).

## Follow-up
If needed, Linear issue for any polish.

🤖 Part of shell migration chunks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * A redesigned releases page is available behind a feature flag; enabling it shows the new layout while preserving artist name display, error states, and loading skeletons.

* **Tests**
  * Unit tests updated to stabilize behavior when the feature flag is present or absent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->