### PR TITLE
test(entitlements): Stryker wiring + matrix tests close coverage gap (24%→41% mutation)

### DIFF
--- a/apps/web/stryker.config.mjs
+++ b/apps/web/stryker.config.mjs
@@ -75,6 +75,13 @@ export default {
     'lib/stripe/connect-readiness.test.ts',
     'tests/unit/actions/onboarding/**/*.test.ts',
     'tests/unit/lib/entitlements.server.test.ts',
+    // Expanded wiring for entitlements-registry surface (blast 5, target 95%).
+    // Includes registry consistency + boundary helpers (for resolve/guard mutants)
+    // and state transitions (plan changes, trial paths) so Stryker can kill more
+    // survivors in registry.ts + server.ts + creator-plan.ts.
+    'tests/unit/lib/entitlement-registry.test.ts',
+    'tests/unit/lib/entitlement-boundary-helpers.test.ts',
+    'tests/unit/lib/entitlements-state-transitions.test.ts',
     'tests/unit/lib/queries/useBillingMutations.test.tsx',
     'tests/unit/lib/social-platform.property.test.ts',
     // Gate + waitlist negative-path tests for lib/auth/gate.ts mutate target

--- a/apps/web/tests/unit/lib/entitlement-registry.test.ts
+++ b/apps/web/tests/unit/lib/entitlement-registry.test.ts
@@ -6,8 +6,10 @@ import {
   getEntitlements,
   hasAdvancedFeatures,
   isProPlan,
+  isValidPlanId,
   type NumericEntitlement,
   type PlanId,
+  resolveCanonicalPlanId,
 } from '@/lib/entitlements/registry';
 
 describe('Entitlement Registry Consistency', () => {
@@ -220,5 +222,86 @@ describe('Entitlement Registry Consistency', () => {
 
   it('hasAdvancedFeatures("growth") returns true (backward compat)', () => {
     expect(hasAdvancedFeatures('growth')).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Matrix / property-style + negative-path tests for resolver/guard logic.
+  // Exercises resolveCanonicalPlanId, isValidPlanId, getEntitlements, check paths
+  // for legacy, trial, invalid, nullish, prototype-pollution attempts. Kills
+  // branch/equality/string mutants that happy-path tests miss.
+  // ---------------------------------------------------------------------------
+
+  describe('resolver and guard matrix (edge cases, plan transitions, negative paths)', () => {
+    const matrixInputs = [
+      'free',
+      'trial',
+      'pro',
+      'max',
+      'founding',
+      'growth',
+      null,
+      undefined,
+      '',
+      ' ',
+      'invalid-plan',
+      'enterprise',
+      'toString',
+      '__proto__',
+      'constructor',
+    ] as const;
+
+    it.each(
+      matrixInputs
+    )('getEntitlements / isValidPlanId / resolveCanonicalPlanId handle input %s without throwing and consistently', input => {
+      // All paths must return defined entitlements (never throw, degrade to free)
+      const ents = getEntitlements(input as any);
+      expect(ents).toBeDefined();
+      expect(ents.booleans).toBeDefined();
+      expect(ents.limits).toBeDefined();
+
+      const valid = isValidPlanId(input as any);
+      const canon = resolveCanonicalPlanId(input as any);
+
+      // Property: valid inputs produce non-null canon for canonical/legacy
+      if (valid) {
+        expect(canon).not.toBeNull();
+        if (['founding', 'pro'].includes(input as string)) {
+          expect(canon).toBe('pro');
+        }
+        if (['growth', 'max'].includes(input as string)) {
+          expect(canon).toBe('max');
+        }
+        if (input === 'trial') {
+          expect(canon).toBe('trial');
+        }
+      } else {
+        expect(canon).toBeNull();
+      }
+    });
+
+    it('resolveCanonicalPlanId and isValidPlanId reject non-string and empty falsy', () => {
+      expect(resolveCanonicalPlanId(null)).toBeNull();
+      expect(resolveCanonicalPlanId(undefined)).toBeNull();
+      expect(resolveCanonicalPlanId('')).toBeNull();
+      expect(isValidPlanId(null)).toBe(false);
+      expect(isValidPlanId(undefined)).toBe(false);
+      expect(isValidPlanId('')).toBe(false);
+      // non-string types (guard)
+      expect(resolveCanonicalPlanId(42 as any)).toBeNull();
+      expect(isValidPlanId(42 as any)).toBe(false);
+    });
+
+    it('getEntitlements falls back to free for all unrecognized inputs (negative path)', () => {
+      expect(getEntitlements('foo')).toBe(ENTITLEMENT_REGISTRY.free);
+      expect(getEntitlements('__proto__')).toBe(ENTITLEMENT_REGISTRY.free);
+      expect(getEntitlements(null)).toBe(ENTITLEMENT_REGISTRY.free);
+    });
+
+    it('plan transition aliases resolve correctly (founding→pro, growth→max, trial preserved)', () => {
+      expect(resolveCanonicalPlanId('founding')).toBe('pro');
+      expect(resolveCanonicalPlanId('growth')).toBe('max');
+      expect(resolveCanonicalPlanId('trial')).toBe('trial');
+      expect(isValidPlanId('trial')).toBe(true);
+    });
   });
 });

--- a/apps/web/tests/unit/lib/entitlements.server.test.ts
+++ b/apps/web/tests/unit/lib/entitlements.server.test.ts
@@ -368,6 +368,45 @@ describe('getCurrentUserEntitlements', () => {
     });
   });
 
+  it('maps billing data for a trialing user (plan transition + trial days calc)', async () => {
+    // Use a generous window so tiny execution delay doesn't flip the floor day count
+    const trialEnd = new Date(Date.now() + 1000 * 60 * 60 * 24 * 10 + 3600_000); // ~10.04 days
+    const now = new Date();
+    const expectedDays = Math.max(
+      0,
+      Math.floor((trialEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+    );
+    mockCachedAuth.mockResolvedValue({ userId: 'user_trial' });
+    mockCachedCurrentUser.mockResolvedValue({
+      primaryEmailAddress: { emailAddress: 'trial@example.com' },
+    });
+    mockIsAdmin.mockResolvedValue(false);
+    mockGetUserBillingInfo.mockResolvedValue({
+      success: true,
+      data: {
+        userId: 'db_user_id',
+        email: 'trial@example.com',
+        isAdmin: false,
+        isPro: false, // trials have isPro=false in DB but get pro entitlements
+        plan: 'trial',
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        trialEndsAt: trialEnd,
+      },
+    });
+
+    const entitlements = await getCurrentUserEntitlements();
+
+    expect(entitlements.plan).toBe('trial');
+    expect(entitlements.isTrialing).toBe(true);
+    expect(entitlements.trialEndsAt).toBe(trialEnd.toISOString());
+    expect(entitlements.trialDaysRemaining).toBe(expectedDays);
+    expect(entitlements.isPro).toBe(true); // via isProPlan('trial')
+    expect(entitlements.canAccessTasksWorkspace).toBe(true); // trial gets pro booleans
+    expect(entitlements.aiDailyMessageLimit).toBe(25); // trial-specific limit (not pro's 100)
+    expect(entitlements.contactsLimit).toBe(250); // trial-specific
+  });
+
   it('admin status is fetched independently of billing', async () => {
     mockCachedAuth.mockResolvedValue({ userId: 'user_admin' });
     mockCachedCurrentUser.mockResolvedValue({


### PR DESCRIPTION
## Summary
Expands mutation testing on the high-blast-radius `entitlements-registry` surface (risk 37.7, target 95% per TEST_RISK_REGISTER.md).

## Changes (HOT ZONE only)
* Wired 3 additional test files into `stryker.config.mjs` `testFiles[]` so Stryker exercises registry + server + transitions against `lib/entitlements/**/*.ts`
* Added `it.each` matrix + property-style + negative-path tests in `entitlement-registry.test.ts` for `resolveCanonicalPlanId`, `isValidPlanId`, `getEntitlements` (legacy aliases, trial, invalid inputs, prototype guards)
* Added dedicated trial user + plan-transition test case in `entitlements.server.test.ts` (exercises trial date math, `isTrialing`, trial-specific limits in `getCurrentUserEntitlements`)
* All edits + biome + full typecheck + vitest (63 tests) + targeted Stryker green

## Results
**Targeted Stryker (`lib/entitlements/**/*.ts`):**
- Before: **24.22%** (78 killed / 89 survived)
- After: **40.99%** (132 killed / 79 survived) — **+54 killed**, +16.77pp
- registry.ts: 27.16% → **51.23%**
- server.ts: 42.50% → **61.25%**

Newly killed mutants include resolver branches, legacy alias handling, trial calc paths, guard fallbacks, and negative input cases.

## Verification
- `pnpm biome check --write` (targeted + hook)
- `pnpm turbo typecheck` ✅
- `vitest run` (all entitlement tests) ✅
- Targeted `stryker run --mutate 'lib/entitlements/**/*.ts'` ✅
- Pre-push hooks passed on push

Keeps coverage wave pressure on entitlements in parallel with other shells.

Closes gap toward 95% on money/feature-gating surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit coverage for entitlement plan resolution, validation, legacy-to-canonical mapping, edge cases (including unexpected inputs), and fallback behavior.
  * Added tests for trial-plan handling: billing mapping, trial end serialization, remaining-day calculation, and trial-specific feature/limit behavior.
* **Chores**
  * Broadened test runner configuration to include additional entitlement-focused test targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->