### PR TITLE
fix(chat): tighten user message pill padding to shell h-7 standard (JOV-2362)

### DIFF
--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -86,7 +86,7 @@ export function ChatMessage({
       {isUser ? (
         <div
           data-testid='chat-user-bubble'
-          className='flex min-h-8 max-w-[78%] flex-col justify-center rounded-full border border-white/80 bg-white px-3 py-1.5 text-[#111216] shadow-[0_12px_38px_-28px_rgba(0,0,0,0.85),inset_0_1px_0_rgba(255,255,255,0.9)]'
+          className='flex min-h-7 max-w-[78%] flex-col justify-center rounded-full border border-white/80 bg-white px-3 py-1 text-[#111216] shadow-[0_12px_38px_-28px_rgba(0,0,0,0.85),inset_0_1px_0_rgba(255,255,255,0.9)]'
         >
           {imageChips.length > 0 && (
             <div

--- a/apps/web/components/jovie/components/ChatMessageSkeleton.tsx
+++ b/apps/web/components/jovie/components/ChatMessageSkeleton.tsx
@@ -13,7 +13,7 @@ export function ChatMessageSkeleton() {
     >
       {/* User message skeleton */}
       <div className='flex justify-end'>
-        <div className='flex min-h-8 max-w-[78%] items-center rounded-full border border-(--linear-app-frame-seam) bg-surface-2 px-3 py-1.5'>
+        <div className='flex min-h-7 max-w-[78%] items-center rounded-full border border-(--linear-app-frame-seam) bg-surface-2 px-3 py-1'>
           <Skeleton className='h-3.5 w-36' rounded='full' />
         </div>
       </div>

--- a/apps/web/tests/unit/chat/ChatMessage.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.test.tsx
@@ -47,9 +47,10 @@ describe('ChatMessage', () => {
 
     const bubble = screen.getByTestId('chat-user-bubble');
     expect(bubble.className).toContain('rounded-full');
-    expect(bubble.className).toContain('min-h-8');
+    expect(bubble.className).toContain('min-h-7');
     expect(bubble.className).toContain('px-3');
-    expect(bubble.className).toContain('py-1.5');
+    expect(bubble.className).toContain('py-1');
     expect(bubble.className).not.toContain('py-3.5');
+    expect(bubble.className).not.toContain('min-h-8');
   });
 });

--- a/apps/web/tests/unit/chat/__snapshots__/ChatMessageSkeleton.test.tsx.snap
+++ b/apps/web/tests/unit/chat/__snapshots__/ChatMessageSkeleton.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`ChatMessageSkeleton > matches snapshot 1`] = `
     class="flex justify-end"
   >
     <div
-      class="flex min-h-8 max-w-[78%] items-center rounded-full border border-(--linear-app-frame-seam) bg-surface-2 px-3 py-1.5"
+      class="flex min-h-7 max-w-[78%] items-center rounded-full border border-(--linear-app-frame-seam) bg-surface-2 px-3 py-1"
     >
       <div
         aria-hidden="true"


### PR DESCRIPTION
## Summary
Tightens the chat user message "pill" bubbles (and matching skeleton) from `min-h-8 py-1.5` to `min-h-7 py-1` (px-3 preserved) to align with current shell pill standards (ActionPill h-7, button sm variant, compact shell density used across releases/tasks/etc).

## Changes (smallest correct)
- `apps/web/components/jovie/components/ChatMessage.tsx`: user bubble height/padding
- `apps/web/components/jovie/components/ChatMessageSkeleton.tsx`: loading state parity
- `apps/web/tests/unit/chat/ChatMessage.test.tsx`: updated + regression guard

No other surfaces, no token changes, no layout shift, no behavior change.

## Verification
- biome / eslint / a11y / typecheck / vitest (ChatMessage + JovieChat.styling) all green
- pre-push hooks passed
- rebased on main, 1 commit, <400 lines (actually 5 net LOC)

## JOV-2362
Closes the UI/UX polish + shell migration item for chat bubbles / message padding / shell alignment.

Part of ongoing max-throughput shell + journey polish (zero jank path).

## Design note
The white pop pill + heavy shadow treatment for user-sent messages in dark shell is unchanged — only the min height and vertical padding were tightened for visual density consistency with other h-7 shell pills.

🤖 Coder dispatch complete.