### PR TITLE
fix(screenshots): wait for compact profile shell on desktop captures

### DIFF
--- a/apps/web/lib/screenshots/registry.ts
+++ b/apps/web/lib/screenshots/registry.ts
@@ -30,7 +30,6 @@ const ADMIN_MARKETING_AND_INVESTOR = [
   'marketing-export',
   'investor-ready',
 ] as const satisfies readonly ScreenshotConsumer[];
-const DESKTOP_PROFILE_LAYOUT_SELECTOR = '[data-layout="desktop"]';
 
 const ARTIST_PROFILE_SECTION_SCREENSHOT_SCENARIOS =
   ARTIST_PROFILE_SECTION_SCREENSHOT_ORDER.map(section => {
@@ -245,14 +244,14 @@ export const SCREENSHOT_SCENARIOS: readonly ScreenshotScenario[] = [
       id: 'tim-white-profile-live-desktop',
       title: 'Tim White Profile — Latest Release Desktop',
       route: '/demo/showcase/tim-white-profile?release=live',
-      waitFor: DESKTOP_PROFILE_LAYOUT_SELECTOR,
+      waitFor: '[data-testid="profile-compact-shell"]',
       publicExportPath: 'tim-white-profile-live-desktop.png',
     },
     {
       id: 'tim-white-profile-mainstream-desktop',
       title: 'Tim White Profile — Mainstream Desktop',
       route: '/demo/showcase/tim-white-profile?archetype=mainstream',
-      waitFor: DESKTOP_PROFILE_LAYOUT_SELECTOR,
+      waitFor: '[data-testid="profile-compact-shell"]',
       publicExportPath: 'tim-white-profile-mainstream-desktop.png',
     },
     {
@@ -525,10 +524,9 @@ export const SCREENSHOT_SCENARIOS: readonly ScreenshotScenario[] = [
       id: 'public-profile-desktop',
       title: 'Public Profile',
       route: '/demo/showcase/public-profile',
-      // The desktop-layout switch happens in a useEffect (matchMedia >=1180px)
-      // after first paint. Wait for the layout state specifically so the
-      // capture isn't of the pre-hydration phone-shaped fallback.
-      waitFor: DESKTOP_PROFILE_LAYOUT_SELECTOR,
+      // StaticArtistPage now renders the compact public shell at every width.
+      // Wait on that stable shell instead of the removed desktop-only surface.
+      waitFor: '[data-testid="profile-compact-shell"]',
       publicExportPath: 'profile-desktop.png',
     },
     {

--- a/apps/web/tests/unit/product-screenshots/screenshot-registry.test.ts
+++ b/apps/web/tests/unit/product-screenshots/screenshot-registry.test.ts
@@ -138,7 +138,7 @@ describe('screenshot registry', () => {
     }
   });
 
-  it('waits for hydrated desktop profile layout before desktop captures', () => {
+  it('waits for compact public profile shell on desktop profile captures', () => {
     const desktopProfileIds = [
       'tim-white-profile-live-desktop',
       'tim-white-profile-mainstream-desktop',
@@ -150,7 +150,7 @@ describe('screenshot registry', () => {
         currentScenario => currentScenario.id === id
       );
 
-      expect(scenario?.waitFor).toBe('[data-layout="desktop"]');
+      expect(scenario?.waitFor).toBe('[data-testid="profile-compact-shell"]');
     }
   });
 


### PR DESCRIPTION

## Summary
Updates product screenshot scenarios for the new compact profile shell. The Tim White desktop (live/mainstream) and public-profile-desktop captures now wait for `[data-testid="profile-compact-shell"]` (via ProfileCompactTemplate / StaticArtistPage) instead of the removed desktop layout fallback.

This fulfills the intent of Cursor bot PR #9361 without landing the bot branch — integrated cleanly as the 7th parallel shell migration + UI/UX slice.

## Changed Files (HOT ZONE only)
- `apps/web/lib/screenshots/registry.ts` (remove stale selector + update 3 scenarios + comment)
- `apps/web/tests/unit/product-screenshots/screenshot-registry.test.ts` (update test name + expectation)

## Verification (all gates passed)
- `JOVIE_AGENT_PROFILE=coder` set
- Bootstrap: `./scripts/setup.sh` ✅
- Biome check --write + full pre-push biome ✅
- Focused vitest: screenshot-registry.test.ts (15/15) + profile-compact-template (31/31) ✅
- Web typecheck (singleflight + turbo) ✅
- Full pre-push: proxy-guard, tailwind-guard, typecheck, lint ✅
- Rebase on main + push clean
- 2 files, 7 insertions / 9 deletions — well under limits
- No other files touched (no e2e profile edits, no shell chrome edits)

## Visual QA / Screenshots
- Desktop (1440x900 per registry), tablet, mobile views for affected: tim-white profile desktop states + public profile desktop now correctly wait on compact shell.
- Confirmed via registry + unit test that waitFor aligns with current `ProfileCompactTemplate` rendering the shell div for all demo showcase widths.
- No content overlap issues (public profile demo surfaces are self-contained; no app composer/audio in marketing captures).
- Compact sidebar states covered by UnifiedSidebar (unchanged here).
- Profile pages in shell (dashboard/profile, settings/artist-profile) are redirects or use canonical shell; no regression.
- Premium fallbacks: album art, etc. unchanged.
- Would recommend `/design-review` + `/qa --exhaustive` + gstack `/browse` captures of `/demo/showcase/tim-white-profile?release=live` (desktop 1440x1000), `/demo/showcase/public-profile` (desktop), and mobile variants + /app/dashboard for shell consistency.

## Risks
- Low: only wait selector for marketing exports; actual rendering unchanged. If profile demo changes again, test will catch.
- E2E profile tests referencing legacy desktop-surface remain for their transition coverage (out of this HOT ZONE slice).
- No Linear issue attached (ad-hoc dispatch for screenshots-compact wave slot); follow-up if needed.

## Next
- Ready for design review + exhaustive QA on marketing static + profile surfaces.
- Then promote draft, run `/ship` for final.

Refs: shell-v1-unified-app-shell-agent-handoff (Wave 0/3/8 visual), DESIGN.md, .claude/rules/ui.md, UnifiedSidebar + AppShellFrame, PR #9361, JOV-2496 context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated screenshot capture readiness for profile pages to wait on a stable, compact profile surface, ensuring consistent captures across viewport widths.
  * Adjusted unit tests and assertions and refreshed related comments to reflect the new readiness condition, improving reliability of automated screenshot testing.

* **Bug Fixes**
  * Removed reliance on a fragile desktop-layout readiness condition to prevent intermittent capture failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->