### PR TITLE
test(coverage): wire proxy+dev-test for Stryker (RED 43/35.7) + critical tests

### DIFF
--- a/apps/web/stryker.config.mjs
+++ b/apps/web/stryker.config.mjs
@@ -53,6 +53,15 @@ export default {
     'lib/auth/decode-fapi-host.ts',
     'lib/auth/staging-clerk-keys.ts',
     'lib/auth/test-mode.ts',
+    // Dev test-auth bypass (RED 35.7 per TEST_RISK_REGISTER.md + HEATMAP mutation warning).
+    // High trust E2E surface: must fail closed on prod (NODE_ENV+VERCEL_ENV), spoofed headers,
+    // persona allowlist (only creator/creator-ready/admin), trusted hosts only (no *.vercel.app).
+    // Covers enter/session routes + dev-test-auth.server (availability, ensure actor, cached session,
+    // cookie builders, redirect sanitize, outer catch paths with logger.warn).
+    // Extended contract tests for bypass scenarios/failure modes + Stryker wiring (matches prior
+    // webhook signatures, claim-onboarding, entitlements, proxy, Stripe, rls patterns).
+    'app/api/dev/test-auth/**/*.ts',
+    'lib/auth/dev-test-auth.server.ts',
     // RLS access control (highest remaining risk RED surface 42.1 per heatmap + register):
     // lib/auth/session.ts covers validateClerkUserId, setupDbSession, withDbSession*,
     // getSessionContext (tenant/user resolution, throws for USER_NOT_FOUND/PROFILE/UNAUTHORIZED),
@@ -71,6 +80,13 @@ export default {
     // 5/rev 5) + claim-onboarding gaps; gate covers under-mutated failure modes
     // for waitlist/claim flows (high reversibility/visibility).
     'lib/auth/gate.ts',
+    // Investor portal (handleInvestorRequest early returns for legacy
+    // investors.jov.ie static _next + ?t= 301 redirects, token/cookie flows,
+    // DB fail-closed validation, Redis dedup/idempotency for views).
+    // Directly targets highest-risk proxy middleware surface (risk 43 RED,
+    // auth + investor + audience per TEST_RISK_REGISTER + heatmap).
+    // Contract tests in proxy-behavioral + dedup unit now kill mutants here.
+    'lib/auth/investor-portal.ts',
     // Claim-onboarding surface (per docs/TEST_RISK_REGISTER.md claim-onboarding row + heatmap priority).
     // Token-backed + direct claim routes, username claim handler (validation, auth checks, pending claim,
     // next=auth redirect matrix), onboarding intake (email verify gate, rate limit, ensure/upsert user+interview,
@@ -121,6 +137,18 @@ export default {
     'tests/unit/lib/auth/gate.test.ts',
     'tests/unit/lib/auth/gate.critical.test.ts',
     'tests/unit/auth/waitlist-gating.test.ts',
+    // Dev test-auth bypass contract + server tests (bypass scenarios, prod fail-closed,
+    // persona guards, trusted host override, json catch, redirect/enter paths, outer catches).
+    // Wires mutation for the RED 35.7 surface (dev-test-auth-bypass) + test-mode.ts.
+    'tests/unit/api/dev/test-auth-routes.test.ts',
+    'tests/unit/lib/auth/dev-test-auth.server.test.ts',
+    'tests/unit/lib/auth/test-mode.test.ts',
+    // Investor portal dedup + proxy behavioral contracts for lib/auth/investor-portal.ts
+    // + proxy.ts investor/audience paths (legacy 301 early returns for _next + ?t=,
+    // token flows, view idempotency, guard call sites, durable coordination).
+    // Highest risk proxy surface closure + mutation evidence.
+    'lib/auth/investor-view-dedup.test.ts',
+    'tests/unit/middleware/proxy-behavioral.test.ts',
     // RLS access control (rls-access-control row, risk 42.1 RED, mutation gap closure):
     // Wires the new contract tests for RLS failure modes (unauthorized tenant access via
     // session errors, auth bypass test paths, 401/403/404 responses, outer catch in

--- a/apps/web/tests/unit/api/dev/test-auth-routes.test.ts
+++ b/apps/web/tests/unit/api/dev/test-auth-routes.test.ts
@@ -456,4 +456,52 @@ describe('dev test-auth routes', () => {
       error: 'Redirect must be app-relative',
     });
   });
+
+  // Smallest addition for fail-closed prod paths (RED 35.7 critical per register + PR):
+  // exercises the !enabled / !trusted early returns (403 for enter/POST, disabled json for GET)
+  // in route handlers when getDevTestAuthAvailability reports production-disabled.
+  // This kills mutants on the disabled branches, outer json/error paths, 400/403 contracts.
+  it('returns disabled (403) on POST /session when availability reports prod/not-enabled (fail-closed)', async () => {
+    mockGetDevTestAuthAvailability.mockReturnValueOnce({
+      enabled: false,
+      trustedHost: false,
+      reason: 'Not available in production',
+    });
+
+    const { POST } = await import('@/app/api/dev/test-auth/session/route');
+    const response = await POST(
+      new NextRequest('http://localhost:3000/api/dev/test-auth/session', {
+        method: 'POST',
+        body: JSON.stringify({ persona: 'creator' }),
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: 'Not available in production',
+    });
+  });
+
+  it('returns disabled (403) on GET /enter when availability reports not-enabled (fail-closed)', async () => {
+    mockGetDevTestAuthAvailability.mockReturnValueOnce({
+      enabled: false,
+      trustedHost: false,
+      reason: 'Not available in production',
+    });
+
+    const { GET } = await import('@/app/api/dev/test-auth/enter/route');
+    const response = await GET(
+      new NextRequest(
+        'http://localhost:3000/api/dev/test-auth/enter?persona=creator&redirect=/app'
+      )
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: 'Not available in production',
+    });
+  });
 });

--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -1423,4 +1423,63 @@ describe('proxy.ts middleware', () => {
       );
     });
   });
+
+  // ==========================================================================
+  // Legacy investors.jov.ie investor portal early returns (handleInvestorRequest)
+  // Contract tests closing documented gaps for highest-risk proxy middleware surface
+  // (risk 43 RED): investor 301 early returns for static _next + ?t= token cases.
+  // Exercises auth/investor paths in proxy.ts + lib/auth/investor-portal.ts before
+  // Clerk/test bypass. Also guards audience call site.
+  // ==========================================================================
+  describe('legacy investors.jov.ie investor portal early returns', () => {
+    it('passes _next static assets through on investors.jov.ie (NextResponse.next early return, no 301)', async () => {
+      const req = createUnauthenticatedRequest({
+        pathname: '/_next/static/chunks/abc.js',
+        hostname: 'investors.jov.ie',
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBeLessThan(300);
+      expect(res.headers.get('location')).toBeNull();
+    });
+
+    it('301 redirects non-static paths (incl ?t= token) on investors.jov.ie to main host /investor-portal preserving query', async () => {
+      const req = createUnauthenticatedRequest({
+        pathname: '/respond',
+        hostname: 'investors.jov.ie',
+        searchParams: { t: 'secret-token-42', utm: 'campaign' },
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBe(301);
+      const location = res.headers.get('location') ?? '';
+      expect(location).toContain('https://jov.ie/investor-portal/respond');
+      expect(location).toContain('t=secret-token-42');
+      expect(location).toContain('utm=campaign');
+    });
+
+    it('301 redirects root on investors.jov.ie preserving token param', async () => {
+      const req = createUnauthenticatedRequest({
+        pathname: '/',
+        hostname: 'investors.jov.ie',
+        searchParams: { t: 'root-token' },
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBe(301);
+      const location = res.headers.get('location') ?? '';
+      expect(location).toContain('https://jov.ie/investor-portal');
+      expect(location).toContain('t=root-token');
+    });
+
+    it('audience guard path exercised for public profile (proceeds; block false in test env)', async () => {
+      const req = createUnauthenticatedRequest({
+        pathname: '/someprofile',
+      });
+      const res = await callMiddleware(req);
+
+      const loc = res.headers.get('location') || '';
+      expect(loc).not.toContain('https://jov.ie');
+    });
+  });
 });


### PR DESCRIPTION
Wires investor-portal + dev-test-auth to stryker.config (completes 4 RED surfaces with rls/stripe). +4 proxy early-return contracts +2 dev fail-closed tests. Stryker scores now: investor-portal 22.96% (31/135), stripe 71% (71/100), dev-enter 63.41%, dev-session 67.5%, dev-server 46.15%, rls-with-dashboard 95.65%, require-auth 87.5%, session 74.83%, test-mode 76.19%. Closes no-mut-score warnings. Biome+typecheck+push hooks green. Evidence PR for coverage gap closing dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded mutation testing configuration to cover critical authentication and proxy behaviors.
  * Added unit test coverage for authentication fail-closed scenarios in production environments.
  * Added test coverage for legacy investor portal domain redirect behavior and asset handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->