### PR TITLE
feat(marketing): add one-click PDF download to public /pitch (JOV-9010/9321)

### DIFF
--- a/apps/web/app/(marketing)/pitch/page.tsx
+++ b/apps/web/app/(marketing)/pitch/page.tsx
@@ -9,12 +9,19 @@ export const metadata: Metadata = {
 };
 
 const DECK_SRC = '/pitch/index.html';
+const PDF_HREF = '/Jovie-Pitch-Deck.pdf';
+const PDF_FILENAME = 'Jovie-Pitch-Deck.pdf';
 
 /**
  * Public NOINDEX pitch deck. Embeds the canonical HTML deck from
  * apps/web/public/pitch/ as a same-origin iframe. The deck owns its own
  * <html>/<head>/<body>, custom fonts (Manrope/DM Sans/JetBrains Mono),
- * keyboard nav, and native browser print → PDF.
+ * keyboard nav, slide dots, fullscreen, and @media print → PDF.
+ *
+ * Adds a one-click "Download PDF" button (floating control) that serves the
+ * pre-generated static PDF at /Jovie-Pitch-Deck.pdf (regenerated once via
+ * Playwright from the canonical deck source). This is preferred over raw
+ * print() per the original JOV-9010 / JOV-2357 scope.
  *
  * The MarketingHeader chrome stays visible above the iframe per the
  * design decision in JOV-2357. To present the deck full-screen, open
@@ -25,6 +32,33 @@ export default function PitchPage() {
     <main className='flex flex-col bg-base text-primary-token'>
       <h1 className='sr-only'>Jovie Pitch Deck</h1>
       <div className='relative w-full overflow-visible h-[calc(100svh-var(--marketing-header-height,72px))] shadow-[0_0_0_1px_rgba(255,255,255,0.015),0_0_110px_-15px_rgba(77,125,255,0.065),0_0_180px_-25px_rgba(124,58,237,0.055)]'>
+        {/* PDF download control (replaces print() affordance; smallest addition to hero deck) */}
+        <a
+          href={PDF_HREF}
+          download={PDF_FILENAME}
+          className='absolute left-3 top-3 z-10 inline-flex items-center gap-1 rounded-full border border-white/[0.08] bg-black/45 px-2.5 py-1 text-[10px] font-medium tracking-[0.02em] text-white/70 backdrop-blur-md transition-colors duration-subtle hover:border-white/20 hover:bg-black/65 hover:text-white/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/40'
+          aria-label='Download Jovie Pitch Deck as PDF'
+          title='Download PDF'
+        >
+          PDF
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            width='11'
+            height='11'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth='3'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+            className='ml-px -mt-px opacity-85'
+            aria-hidden='true'
+          >
+            <path d='M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4' />
+            <polyline points='7 10 12 15 17 10' />
+            <line x1='12' y1='15' x2='12' y2='3' />
+          </svg>
+        </a>
         <iframe
           src={DECK_SRC}
           title='Jovie Pitch Deck'

--- a/apps/web/tests/e2e/pitch.spec.ts
+++ b/apps/web/tests/e2e/pitch.spec.ts
@@ -34,6 +34,11 @@ test.describe('public /pitch route', () => {
       deck.locator('section[data-label="Meet Jovie"]')
     ).toBeAttached();
 
+    // PDF download button (one-click static asset, replaces print flow)
+    const pdfLink = page.locator('a[download="Jovie-Pitch-Deck.pdf"]');
+    await expect(pdfLink).toBeVisible();
+    await expect(pdfLink).toHaveAttribute('href', '/Jovie-Pitch-Deck.pdf');
+
     expect(consoleErrors, consoleErrors.join('\n')).toHaveLength(0);
   });
 
@@ -57,6 +62,13 @@ test.describe('public /pitch route', () => {
 
   test('deck-stage.js is reachable', async ({ request }) => {
     const res = await request.head('/pitch/deck-stage.js');
+    expect(res.status()).toBe(200);
+  });
+
+  test('static PDF asset serves with 200 (pre-generated once from deck)', async ({
+    request,
+  }) => {
+    const res = await request.head('/Jovie-Pitch-Deck.pdf');
     expect(res.status()).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary
Public `/pitch` page now includes a one-click "PDF" download control (floating, subtle, a11y clean) that serves the committed static `Jovie-Pitch-Deck.pdf` (pre-generated once from the canonical HTML deck source via Playwright).

Reuses the existing investor deck artifacts (`public/pitch/index.html` + `deck-stage.js` + PDF) and the already-landed route constant + marketing footer link. No scope creep; post-HTML migration, no need to revive old DeckViewer/markdown.

Completes the recreation scope from 9010 / follow-up 9321.

## Changes (2 files, +47/-1)
- `apps/web/app/(marketing)/pitch/page.tsx`: add floating PDF anchor + updated JSDoc.
- `apps/web/tests/e2e/pitch.spec.ts`: assert button + new asset HEAD test.

## Verification
- `pnpm exec biome check --write` + eslint + staged typecheck via hooks: clean
- `pnpm turbo typecheck`: 0 errors
- Pitch E2E (`playwright test ...pitch.spec.ts`): 5/5 passed (fresh server)
- Pre-push full suite green

Smallest correct change. Ready to land.

Closes JOV-9321 (follow-up to 9010).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pitch deck can now be downloaded as a PDF file directly from the pitch page.
  * Convenient download button provides one-click access to the pitch deck material.
  * Static PDF asset delivery ensures fast and reliable downloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->