### PR TITLE
fix(ui): raise popout z-indexes + smart EntityPopover vertical clamp

### DIFF
--- a/apps/web/components/shell/ContextMenuOverlay.tsx
+++ b/apps/web/components/shell/ContextMenuOverlay.tsx
@@ -103,7 +103,7 @@ export function ContextMenuOverlay({
   if (!state) return null;
 
   return (
-    <div className='fixed inset-0 z-[60]'>
+    <div className='fixed inset-0 z-[110]'>
       <button
         type='button'
         aria-label='Close menu'

--- a/apps/web/components/shell/DspAvatarStack.tsx
+++ b/apps/web/components/shell/DspAvatarStack.tsx
@@ -125,9 +125,9 @@ export function DspAvatarStack({
       <div
         role='tooltip'
         className={cn(
-          'pointer-events-none absolute right-0 top-full mt-1.5 z-40 w-[220px]',
-          'opacity-0 translate-y-1 group-hover/dsps:opacity-100 group-hover/dsps:translate-y-0 group-hover/dsps:pointer-events-auto',
-          'transition-[opacity,transform] duration-subtle ease-subtle delay-[400ms] group-hover/dsps:delay-[400ms]'
+          'pointer-events-none absolute right-0 top-full mt-1.5 z-[100] w-[220px]',
+          'opacity-0 group-hover/dsps:opacity-100 group-hover/dsps:pointer-events-auto',
+          'transition-[opacity] duration-subtle ease-subtle delay-[400ms] group-hover/dsps:delay-[400ms]'
         )}
       >
         <div className='rounded-md border border-(--linear-app-shell-border) bg-(--linear-app-content-surface)/95 backdrop-blur-xl shadow-[0_8px_28px_rgba(0,0,0,0.32)] overflow-hidden'>

--- a/apps/web/components/shell/EntityPopover.tsx
+++ b/apps/web/components/shell/EntityPopover.tsx
@@ -634,11 +634,15 @@ export function EntityPopover({
       const left = wantsRight
         ? a.right + SIDE_OFFSET
         : Math.max(POPOVER_MARGIN, a.left - SIDE_OFFSET - POPOVER_WIDTH);
-      let top = a.top;
-      if (top + contentHeight > window.innerHeight - POPOVER_MARGIN) {
-        top = window.innerHeight - POPOVER_MARGIN - contentHeight;
+      // Smart vertical positioning: center on anchor (near trigger/cursor) for
+      // tight coupling instead of always pinning to a.top. Minimal clamp keeps
+      // it near the row even near viewport edges (prevents "far jump" bug).
+      let top = a.top + a.height / 2 - contentHeight / 2;
+      const margin = POPOVER_MARGIN;
+      if (top < margin) top = margin;
+      if (top + contentHeight > window.innerHeight - margin) {
+        top = window.innerHeight - margin - contentHeight;
       }
-      if (top < POPOVER_MARGIN) top = POPOVER_MARGIN;
       setPos({ left, top, side: wantsRight ? 'right' : 'left' });
     };
     update();
@@ -673,7 +677,7 @@ export function EntityPopover({
         visibility: pos ? 'visible' : 'hidden',
       }}
       className={cn(
-        'z-[80]',
+        'z-[120]',
         LINEAR_SURFACE.popover,
         'text-primary-token',
         'animate-in fade-in-0 zoom-in-95 duration-subtle ease-subtle',

--- a/apps/web/components/shell/ShellDropdown.tsx
+++ b/apps/web/components/shell/ShellDropdown.tsx
@@ -110,7 +110,7 @@ const ENTITY_CLOSE_DELAY_MS = 120;
 // ---------------------------------------------------------------------------
 
 const CONTENT_CLASSES = cn(
-  'z-[70] min-w-[--w] max-w-[calc(100vw-16px)]',
+  'z-[90] min-w-[--w] max-w-[calc(100vw-16px)]',
   'rounded-xl border border-(--linear-app-shell-border)',
   'bg-(--linear-app-content-surface)/95 backdrop-blur-xl',
   'shadow-[0_12px_40px_rgba(0,0,0,0.32)] p-1',

--- a/packages/ui/lib/dropdown-styles.test.ts
+++ b/packages/ui/lib/dropdown-styles.test.ts
@@ -50,7 +50,7 @@ describe('dropdown-styles', () => {
 
   describe('content base styles', () => {
     it('DROPDOWN_CONTENT_BASE includes z-index, border, and background', () => {
-      expect(DROPDOWN_CONTENT_BASE).toContain('z-[70]');
+      expect(DROPDOWN_CONTENT_BASE).toContain('z-[90]');
       expect(DROPDOWN_CONTENT_BASE).toContain('border');
       expect(DROPDOWN_CONTENT_BASE).toContain('bg-');
       expect(DROPDOWN_CONTENT_BASE).toContain('rounded-');

--- a/packages/ui/lib/dropdown-styles.ts
+++ b/packages/ui/lib/dropdown-styles.ts
@@ -52,7 +52,7 @@ export const DROPDOWN_SLIDE_ANIMATIONS =
  * Border uses --linear-border-default (slightly more opaque than --linear-border-subtle used by separators)
  */
 export const DROPDOWN_CONTENT_BASE =
-  'z-[70] min-w-[184px] overflow-hidden rounded-(--linear-app-radius-menu) border border-(--linear-border-default) bg-(--linear-bg-surface-0) p-0.5 text-(--linear-text-primary) shadow-(--linear-shadow-card-elevated)';
+  'z-[90] min-w-[184px] overflow-hidden rounded-(--linear-app-radius-menu) border border-(--linear-border-default) bg-(--linear-bg-surface-0) p-0.5 text-(--linear-text-primary) shadow-(--linear-shadow-card-elevated)';
 
 /**
  * Shadow effect for elevated appearance


### PR DESCRIPTION
## Summary
High-priority UI/UX visual polish (tooltip/popover final drain):
- Raised z-index on EntityPopover/EntityChipPopover (via Radix base), ShellDropdown, Radix popouts (dropdown/popover/context), ContextMenuOverlay, DspAvatarStack so they layer cleanly above new UnifiedSidebar / AppShellFrame / PersistentAudioBar / shell chrome.
- Implemented vertical smart positioning + clamp in EntityPopover: centers on anchor rect (stays near trigger/cursor) with minimal viewport adjustment instead of jumping far to screen edges.

## HOT ZONE (strict)
Only: EntityPopover.tsx, EntityChipPopover.tsx, ShellDropdown.tsx, ContextMenuOverlay.tsx, DspAvatarStack.tsx, dropdown-styles.ts (Radix), popover.tsx paths.

## Compliance
- DESIGN.md + .claude/rules/ui.md: subtraction, no decorative hover motion (Dsp now pure fade), layout no-shift, focus rings, mobile safe, real data.
- Small diff (5 files, net -+ few LOC).
- Conventional commit on branch codex/drain-ui-ux-tooltip-popover-final.
- Rebased, biome clean.

## QA
- Visual: desktop/tablet/mobile via browser snapshots on shell surfaces, dropdown hovers, entity popovers, context menus, avatar stacks.
- Popouts now above chrome; Entity stays clamped near row.
- /qa --exhaustive + /design-review + /review + /ship executed per task.

PR ready to land + rotate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual layering for UI overlays, dropdown menus, tooltips, and popovers to ensure proper stacking and visibility.
  * Enhanced vertical positioning for popovers to better align with their anchors.

* **Tests**
  * Updated component tests to reflect styling changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->