### PR TITLE
fix(ui): pure opacity reveal for shell Tooltip (no decorative motion) — 8th support

### DIFF
--- a/apps/web/components/shell/Tooltip.tsx
+++ b/apps/web/components/shell/Tooltip.tsx
@@ -4,7 +4,9 @@ import { cn } from '@/lib/utils';
 // Tooltip — small, dark, glassy popover with the action label + an
 // optional kbd chip on the right. Pass a `shortcut` object to surface the
 // key combo. CSS-only (no portal); uses group/tip + delay for a Linear-
-// feeling late reveal that snaps in over 150ms once it commits.
+// feeling late reveal via pure opacity fade (no decorative translate/slide
+// motion per DESIGN.md + .claude/rules/ui.md "no decorative hover motion").
+// z raised to sit above new shell chrome.
 
 export interface TooltipProps {
   readonly children: React.ReactNode;
@@ -27,12 +29,12 @@ export function Tooltip({
 }: TooltipProps) {
   const sideClasses =
     side === 'bottom'
-      ? 'top-full left-1/2 -translate-x-1/2 mt-1.5 translate-y-0.5 group-hover/tip:translate-y-0 group-focus-within/tip:translate-y-0'
+      ? 'top-full left-1/2 -translate-x-1/2 mt-1.5'
       : side === 'top'
-        ? 'bottom-full left-1/2 -translate-x-1/2 mb-1.5 -translate-y-0.5 group-hover/tip:translate-y-0 group-focus-within/tip:translate-y-0'
+        ? 'bottom-full left-1/2 -translate-x-1/2 mb-1.5'
         : side === 'right'
-          ? 'left-full top-1/2 -translate-y-1/2 ml-1.5 -translate-x-0.5 group-hover/tip:translate-x-0 group-focus-within/tip:translate-x-0'
-          : 'right-full top-1/2 -translate-y-1/2 mr-1.5 translate-x-0.5 group-hover/tip:translate-x-0 group-focus-within/tip:translate-x-0';
+          ? 'left-full top-1/2 -translate-y-1/2 ml-1.5'
+          : 'right-full top-1/2 -translate-y-1/2 mr-1.5';
 
   return (
     <span
@@ -46,9 +48,11 @@ export function Tooltip({
       <span
         role='tooltip'
         className={cn(
-          'pointer-events-none absolute z-50 whitespace-nowrap',
+          // z-[100] to sit above new shell chrome (UnifiedSidebar z-~10-40, PersistentAudioBar/NowPlaying ~z-30, drawers ~z-50) while near cursor.
+          'pointer-events-none absolute z-[100] whitespace-nowrap',
           'opacity-0 group-hover/tip:opacity-100 group-focus-within/tip:opacity-100',
-          'transition-[opacity,transform] duration-subtle ease-subtle delay-[400ms] group-hover/tip:delay-[400ms] group-focus-within/tip:delay-[80ms]',
+          'transition-opacity duration-subtle ease-subtle delay-[400ms] group-hover/tip:delay-[400ms] group-focus-within/tip:delay-[80ms]',
+          'motion-reduce:transition-none motion-reduce:delay-0',
           sideClasses
         )}
       >


### PR DESCRIPTION
## Summary
Complementary 8th dedicated high-performer support on high-priority UI/UX visual fixes (#9391 drain).

**Change (HOT ZONE only):**
- apps/web/components/shell/Tooltip.tsx: removed decorative translate-y/x slide-in reveals on hover/focus (now pure opacity fade at final anchored position, per DESIGN.md "no decorative hover motion" + .claude/rules/ui.md).
- z raised to z-[100] (consistent with EntityPopover z-[120], dropdowns z-[90], ContextMenu z-[110], Dsp/Tooltip in sibling supports).
- Added explicit reduced-motion parity (transition-none on prefers-reduced-motion).
- Structural centering (-translate-x-1/2 etc.) preserved; no layout shift; canonical focus rings untouched on triggers.
- 1 file, net small diff.

**Complementary to prior 7 supports:**
- EntityPopover smart center + clamp + z
- ContextMenuOverlay full vertical (incl top-edge) clamp + z
- EntityChipPopover z + center align
- DspAvatarStack pure opacity (translate removed)
- ShellDropdown z + reduced-motion
- Base dropdown-styles + ui tooltip z + tests
- Various popout families covered; this finishes the shell Tooltip motion cleanup.

**Verification (executed in worktree):**
- Bootstrap: setup.sh, pnpm install, no stashes, rebase on main, clean.
- pnpm biome check --write apps/web (green)
- pnpm --filter @jovie/web typecheck (green)
- Focused vitest on tooltip/popover surfaces (all pass)
- Pre-push gates on commit+push: biome, tailwind-guard, typecheck, lint (all ✅)
- Push created branch; this PR opened.

**Gates:**
- Follows AGENTS.md, .claude/rules/* (ui.md, code-style, release), DESIGN.md strictly.
- Smallest correct change.
- No duplicate chrome, real data unaffected, container-aware.
- Prepares for /qa --exhaustive + /design-review + /review + /ship rotation.

Ready for visual QA (desktop/tablet/mobile, edges, reduced-motion, cursor-near, above UnifiedSidebar/AppShellFrame/PersistentAudioBar/NowPlaying). 

Next after land: rotate to next shell handoff or Priority Queue coverage gap (per bare prompt scheduler).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined tooltip animation behavior for improved visual timing
  * Improved tooltip layering for better visibility
  * Enhanced support for reduced motion preferences

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->