### PR TITLE
fix(shell): release task list DS subtle motion + row memoization (handoff rotation 4)

### DIFF
--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskChecklist.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskChecklist.tsx
@@ -242,7 +242,7 @@ export function ReleaseTaskChecklist({
         className='flex shrink-0 items-center gap-2 px-4 py-2'
         initial={animateEntrance ? { opacity: 0, y: -8 } : false}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.3 }}
+        transition={{ duration: 0.15, ease: [0.4, 0, 0.2, 1] }}
       >
         <ReleaseTaskProgressBar
           done={totalDone}
@@ -315,9 +315,9 @@ export function ReleaseTaskChecklist({
               initial={animateEntrance ? { opacity: 0, y: 12 } : false}
               animate={{ opacity: 1, y: 0 }}
               transition={{
-                duration: 0.25,
+                duration: 0.15,
                 delay: groupDelay,
-                ease: 'easeOut',
+                ease: [0.4, 0, 0.2, 1],
               }}
             >
               <ReleaseTaskCategoryGroup
@@ -345,9 +345,9 @@ export function ReleaseTaskChecklist({
                         ...(animateEntrance && { filter: 'blur(0px)' }),
                       }}
                       transition={{
-                        duration: 0.25,
+                        duration: 0.15,
                         delay: taskDelay,
-                        ease: 'easeOut',
+                        ease: [0.4, 0, 0.2, 1],
                       }}
                     >
                       {variant === 'compact' ? (

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { memo } from 'react';
 import { ShellListRowFrame } from '@/components/organisms/table/atoms/ShellListRowFrame';
 import type { ReleaseTaskView } from '@/lib/release-tasks/types';
 import { cn } from '@/lib/utils';
@@ -17,7 +18,7 @@ interface ReleaseTaskCompactRowProps {
   readonly onNavigate: (taskId: string) => void;
 }
 
-export function ReleaseTaskCompactRow({
+export const ReleaseTaskCompactRow = memo(function ReleaseTaskCompactRow({
   task,
   onToggle,
   onNavigate,
@@ -57,4 +58,4 @@ export function ReleaseTaskCompactRow({
       />
     </ShellListRowFrame>
   );
-}
+});

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRow.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRow.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { memo } from 'react';
 import { ShellListRowFrame } from '@/components/organisms/table/atoms/ShellListRowFrame';
 import type { ReleaseTaskView } from '@/lib/release-tasks/types';
 import {
@@ -30,7 +31,10 @@ const PRIORITY_DISPLAY: Record<string, { dots: string }> = {
   none: { dots: '' },
 };
 
-export function ReleaseTaskRow({ task, onToggle }: ReleaseTaskRowProps) {
+export const ReleaseTaskRow = memo(function ReleaseTaskRow({
+  task,
+  onToggle,
+}: ReleaseTaskRowProps) {
   const isDone = isReleaseTaskDone(task);
   const isAi = isReleaseTaskAutomated(task);
   const priority = PRIORITY_DISPLAY[task.priority] ?? PRIORITY_DISPLAY.medium;
@@ -95,4 +99,4 @@ export function ReleaseTaskRow({ task, onToggle }: ReleaseTaskRowProps) {
       )}
     </ShellListRowFrame>
   );
-}
+});


### PR DESCRIPTION
## Summary
- **Surface**: Release tasks checklist + rows (under `/app/dashboard/releases/[releaseId]/tasks` and compact variants; real production task data, high-churn list rendering for release planning workflow).
- **Changes (minimal, 3 files)**: 
  - Memoized `ReleaseTaskRow` and `ReleaseTaskCompactRow` (React.memo) for auto-stabilization / quick-win perf on list churn (parent filter, entrance, toggle updates no longer re-render all siblings).
  - Restrained all motion transitions (progress bar, group entrance, per-task staggered reveal) to exact `DESIGN.md` DS_FOUNDATION_V1 subtle token: `duration: 0.15`, `ease: [0.4, 0, 0.2, 1]` (was raw 0.25/0.3 + easeOut). Matches Waves 0-8 handoff, recent shell polish (#9374 etc), reduced-motion, and "restrained DS subtle motion ~150ms".
- Fits post-audience/table rotation (similar table/list surface with stabilization + canonical shell rules: focus rings via ShellListRowFrame, safe areas/container via PageShell + cn, subtraction, no layout shift, real data only).
- No new deps, no schema, no exp imports, production contracts preserved.

## Verification
- Biome clean (pre-commit + manual)
- Typecheck clean (turbo local + tsc)
- Vitest: ReleaseTaskRow.test + ReleaseTaskChecklist.test (7/7 pass)
- Visual: real data, staggered but now tokenized motion, list stable.
- Per handoff doc + DESIGN.md + ui.md + AGENTS.md.

Refs: shell handoff Waves 0–8, DESIGN.md motion taxonomy, prior rotations (audience/table auto-memo, command-palette focus, SidebarSection restraint).

## Next
Run /qa --exhaustive + /review + /design-review + /ship per gstack pipeline; land when green to advance shell migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined animation transitions in the dashboard release tasks interface with faster, smoother easing behavior.
  * Optimized performance of task list components to reduce unnecessary re-renders during interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->