### PR TITLE
fix(shell): releases list DS motion + cell memo (rotation 5)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
@@ -91,7 +91,11 @@ function useArtworkPlayback(release: ReleaseViewModel) {
   return { previewUrl, isActiveTrack, isTrackPlaying, handleTogglePlayback };
 }
 
-function ArtworkCell({ release }: { readonly release: ReleaseViewModel }) {
+const ArtworkCell = memo(function ArtworkCell({
+  release,
+}: {
+  readonly release: ReleaseViewModel;
+}) {
   const { previewUrl, isTrackPlaying, handleTogglePlayback } =
     useArtworkPlayback(release);
   const hasPreview = Boolean(previewUrl);
@@ -114,7 +118,7 @@ function ArtworkCell({ release }: { readonly release: ReleaseViewModel }) {
           aria-pressed={isTrackPlaying}
           data-testid={`shell-release-play-${release.id}`}
           className={cn(
-            'absolute inset-0 grid place-items-center rounded-sm bg-black/50 text-white transition-opacity duration-subtle ease-out focus-visible:outline-none focus-visible:opacity-100 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
+            'absolute inset-0 grid place-items-center rounded-sm bg-black/50 text-white transition-opacity duration-subtle ease-subtle focus-visible:outline-none focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
             isTrackPlaying
               ? 'opacity-100'
               : 'opacity-0 group-hover/row:opacity-100'
@@ -139,9 +143,9 @@ function ArtworkCell({ release }: { readonly release: ReleaseViewModel }) {
       ) : null}
     </div>
   );
-}
+});
 
-function SmartLinkCell({
+const SmartLinkCell = memo(function SmartLinkCell({
   release,
   smartLinkLockReason,
   smartLinkPath,
@@ -188,12 +192,12 @@ function SmartLinkCell({
       onClick={e => e.stopPropagation()}
       title={`Open smart link · ${smartLinkPath}`}
       aria-label={`Open smart link for ${release.title}`}
-      className='shrink-0 h-7 w-7 rounded-md grid place-items-center text-quaternary-token hover:text-primary-token hover:bg-surface-2/70 transition-colors duration-subtle ease-out'
+      className='shrink-0 h-7 w-7 rounded-md grid place-items-center text-quaternary-token hover:text-primary-token hover:bg-surface-2/70 transition-colors duration-subtle ease-subtle'
     >
       <ExternalLink className='h-3 w-3' strokeWidth={2.25} />
     </Link>
   );
-}
+});
 
 // ── Main row component ─────────────────────────────────────────────────────────
 
@@ -309,7 +313,7 @@ export const ShellReleaseRow = memo(function ShellReleaseRow({
             onKeyDown={e => e.stopPropagation()}
             aria-label={`Release actions for ${release.title}`}
             className={cn(
-              'shrink-0 h-7 w-7 rounded-md grid place-items-center text-quaternary-token hover:text-primary-token hover:bg-surface-2/70 transition-[opacity,color,background-color] duration-subtle ease-out',
+              'shrink-0 h-7 w-7 rounded-md grid place-items-center text-quaternary-token hover:text-primary-token hover:bg-surface-2/70 transition-[opacity,color,background-color] duration-subtle ease-subtle',
               'opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100',
               isSelected && 'opacity-100'
             )}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
@@ -268,7 +268,7 @@ function ReleasesListContent({
             <button
               type='button'
               onClick={onClearFilters}
-              className='mt-2 text-[11px] text-cyan-400 hover:text-cyan-300 transition-colors duration-subtle ease-out'
+              className='mt-2 text-[11px] text-cyan-400 hover:text-cyan-300 transition-colors duration-subtle ease-subtle'
             >
               Clear filters
             </button>


### PR DESCRIPTION
## Summary
Shell handoff rotation 5: the releases list surface (ShellReleasesView + ShellReleaseRow / ArtworkCell / SmartLinkCell under `release-provider-matrix/shell-releases/`).

Chose this as the next highest-impact uncompleted surface after:
- Reading the canonical shell handoff doc (Waves 0–8) + surface coverage crawler findings (G-Brain `shell-v1-gap-closure-crawl-20260519`)
- DESIGN.md (subtle 150ms + `[0.4,0,0.2,1]` tokens, no raw easings post-Wave 4)
- .claude/rules/ui.md (subtraction / container-aware via ShellListRowFrame, no decorative motion, canonical focus rings, layout-shift guards)
- Prior rotation outputs: rot3 (audience/table + auto-memo on columns/context/rows), rot4 (ReleaseTaskChecklist/Row/CompactRow + DS subtle motion restraint + React.memo on rows; PR #9396)

Releases list is golden-path critical (high traffic dashboard surface, real production ReleaseViewModel data, filter/pill/search/sort/high-churn selection), partially shell-migrated (already using Shell* primitives + some useMemo), now brought to full parity with the just-landed task list and audience patterns.

## Changes (minimal, 2 files, 12 net lines)
- Canonical DS subtle motion: all `duration-subtle ease-out` → `duration-subtle ease-subtle` (4 sites: play overlay, smart link, more actions, clear-filters). Matches rot4 precedent and DESIGN.md motion taxonomy.
- Quick-win stabilization (auto-memoization on high-churn logic): wrapped pure cell renderers `ArtworkCell` and `SmartLinkCell` with `React.memo` (main `ShellReleaseRow` was already memoized). Prevents re-renders on filter/selection/hover/player state churn in long release lists.
- Canonical focus rings (per recent UI/UX waves + command-palette #9394): upgraded play button from `ring-1` to `ring-2` + `ring-(--linear-border-focus)/55` for consistency against new shell chrome.
- All real data, ShellListRowFrame container (subtraction/container-aware), no layout shift, no decorative transforms/scales.

No new tables, no schema, no routes, no flags, no duplication of chrome.

## Verification
- Local: `pnpm biome check --write`, full pre-push (biome + tailwind guard + typecheck + lint) green on push.
- Will run full gstack pipeline immediately: `/qa --exhaustive`, `/review`, `/design-review`, `/ship`.
- Draft PR opened early for bot triage (CodeRabbit/Greptile) + parallel 10-owner pressure.

## Follow-up (if any)
None required in this rotation — surface now matches the post-rot4 standard. Future waves can tackle legacy non-shell releases cells if flag rollout requires.

Refs: scheduler "Shell Migrations", rot3/4 handoffs, Waves 0–8 doc, PRs #9396/#9397/#9395/#9394.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined transition animations throughout the dashboard for improved visual smoothness.

* **Refactor**
  * Optimized rendering performance of dashboard table components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->