### PR TITLE
fix(shell): dsp presence table DS motion + cell memo (rotation 6)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceTable.tsx
@@ -3,7 +3,7 @@
 import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { ExternalLink } from 'lucide-react';
 import Image from 'next/image';
-import { useCallback } from 'react';
+import { memo, useCallback } from 'react';
 import type { DspPresenceItem } from '@/app/app/(shell)/dashboard/presence/actions';
 import { UnifiedTable } from '@/components/organisms/table';
 import {
@@ -24,10 +24,12 @@ interface DspPresenceTableProps {
 }
 
 // ============================================================================
-// Cell renderers (extracted to module scope to avoid re-creation on render)
+// Cell renderers (extracted to module scope + memoized for shell handoff churn)
 // ============================================================================
 
-function ArtistCell({ item }: Readonly<{ item: DspPresenceItem }>) {
+const ArtistCell = memo(function ArtistCell({
+  item,
+}: Readonly<{ item: DspPresenceItem }>) {
   const label = PROVIDER_LABELS[item.providerId];
   return (
     <div className='flex items-center gap-2.5 min-w-0'>
@@ -52,18 +54,22 @@ function ArtistCell({ item }: Readonly<{ item: DspPresenceItem }>) {
       </span>
     </div>
   );
-}
+});
 
-function StatusCell({ item }: Readonly<{ item: DspPresenceItem }>) {
+const StatusCell = memo(function StatusCell({
+  item,
+}: Readonly<{ item: DspPresenceItem }>) {
   const isManual = item.matchSource === 'manual';
   return isManual ? (
     <span className='text-2xs text-tertiary-token'>Manual</span>
   ) : (
     <MatchStatusBadge status={item.status} size='sm' />
   );
-}
+});
 
-function LinkCell({ item }: Readonly<{ item: DspPresenceItem }>) {
+const LinkCell = memo(function LinkCell({
+  item,
+}: Readonly<{ item: DspPresenceItem }>) {
   const label = PROVIDER_LABELS[item.providerId];
   if (!item.externalArtistUrl) return null;
   return (
@@ -71,14 +77,14 @@ function LinkCell({ item }: Readonly<{ item: DspPresenceItem }>) {
       href={item.externalArtistUrl}
       target='_blank'
       rel='noopener noreferrer'
-      className='flex h-6 w-6 items-center justify-center rounded text-tertiary-token transition-colors hover:text-primary-token'
+      className='flex h-6 w-6 items-center justify-center rounded text-tertiary-token transition-colors duration-subtle ease-subtle hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
       aria-label={`View on ${label}`}
       onClick={e => e.stopPropagation()}
     >
       <ExternalLink className='h-3.5 w-3.5' />
     </a>
   );
-}
+});
 
 // ============================================================================
 // Column definitions
@@ -114,10 +120,10 @@ const columns: ColumnDef<DspPresenceItem, unknown>[] = [
 ] as ColumnDef<DspPresenceItem, unknown>[];
 
 // ============================================================================
-// Component
+// Component (memoized for shell handoff stability)
 // ============================================================================
 
-export function DspPresenceTable({
+export const DspPresenceTable = memo(function DspPresenceTable({
   items,
   selectedMatchId,
   onRowSelect,
@@ -134,19 +140,21 @@ export function DspPresenceTable({
 
       if (isSelected) {
         return [
-          'rounded-[10px] transition-[background-color,box-shadow] duration-150 ease-out cursor-pointer',
+          'rounded-[10px] transition-[background-color,box-shadow] duration-subtle ease-subtle cursor-pointer',
           'bg-[color-mix(in_oklab,var(--linear-row-selected)_24%,var(--linear-bg-surface-0))]',
           'shadow-[inset_2px_0_0_0_var(--linear-border-focus),inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_14%,var(--linear-app-frame-seam))]',
           'hover:bg-[color-mix(in_oklab,var(--linear-row-selected)_28%,var(--linear-bg-surface-0))]',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
         ].join(' ');
       }
 
       return [
-        'rounded-[10px] transition-[background-color,box-shadow] duration-150 ease-out cursor-pointer',
+        'rounded-[10px] transition-[background-color,box-shadow] duration-subtle ease-subtle cursor-pointer',
         'bg-transparent',
         'hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_78%,transparent)]',
         'hover:shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-app-frame-seam)_72%,transparent)]',
         '[&:hover_span]:text-primary-token',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
       ].join(' ');
     },
     [selectedMatchId]
@@ -168,4 +176,4 @@ export function DspPresenceTable({
       containerClassName='h-full px-2.5 pb-2.5 pt-0.5 md:px-3 md:pb-3 md:pt-1'
     />
   );
-}
+});


### PR DESCRIPTION
## Summary
Shell handoff rotation 6: DSP presence table surface (high-churn list in dashboard/presence).

**Changes (minimal, 1 file):**
- React.memo on ArtistCell, StatusCell, LinkCell and DspPresenceTable (quick-win stabilization for churn, matching rotation 4 release-tasks + rotation 5 releases-list).
- Row hover/selection + link transitions updated from raw 150ms ease-out to `duration-subtle ease-subtle` (DESIGN.md restrained subtle motion, subtraction of decorative variance).
- Canonical DS focus rings (`focus-visible:ring-2 ... ring-(--linear-border-focus)/55`) added to rows and link for parity with prior handoffs and a11y.
- Real production data (DspPresenceItem from connected catalog), container-aware classes preserved, no layout shift.

**HOT ZONE:** `apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceTable.tsx`
**Surface:** DSP presence table (fits Wave 5/6 shell dashboard surfaces per handoff doc).

**Refs:**
- Canonical handoff doc: shell-v1-unified-app-shell-agent-handoff-20260518.md (Waves 0–8)
- Prior: rotation 4 (ReleaseTaskRow/CompactRow + motion), rotation 5 (ArtworkCell/SmartLinkCell + ShellReleaseRow), audience/table work
- DESIGN.md (subtle tokens), .claude/rules/ui.md (component boundaries, focus, motion), .claude/rules/code-style.md

**Verification (pre-push + local):**
- biome check --write + lint: clean
- typecheck: clean
- vitest for DspPresenceView.test.tsx: 5/5 passed
- Tailwind/proxy guards: passed
- No other files touched.

Draft PR opened early per instructions. Will run /qa --exhaustive, /review, /design-review, /ship when ready. Bot triage expected.

🤖 Rotation 6 of shell migrations (10-parallel pressure maintained).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized DSP presence table rendering to reduce unnecessary updates.

* **UI/UX Improvements**
  * Enhanced keyboard navigation with improved focus indicators.
  * Refined transition timing for smoother visual interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->