### PR TITLE
fix(shell): memoize lyric row + canonical focus rings (rot 9)

### DIFF
--- a/apps/web/components/shell/LyricRow.tsx
+++ b/apps/web/components/shell/LyricRow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { GripVertical } from 'lucide-react';
+import React from 'react';
 import { formatTime } from '@/lib/format-time';
 import { cn } from '@/lib/utils';
 import type { LyricLine } from './LyricsView.types';
@@ -28,8 +29,12 @@ const SELECTED_ROW_CLASSES = [
  * focus event drives the row's `onFocus`; no row-level click handler.
  *
  * Pure presentational — caller owns line state, focus, edit mode.
+ *
+ * Memoized for shell handoff rot 9 (high-churn over real timed LyricLine
+ * data from prod tracks). DS subtle motion + canonical focus rings applied
+ * to interactive controls.
  */
-export function LyricRow({
+export const LyricRow = React.memo(function LyricRow({
   line,
   index,
   isActive,
@@ -71,7 +76,7 @@ export function LyricRow({
           data-focused={isFocused && !isActive ? '' : undefined}
           className={cn(
             'group/lyric block w-full text-center cursor-pointer select-none bg-transparent border-0 p-0',
-            'transition-[color,opacity,transform] duration-subtle ease-subtle',
+            'transition-[color,opacity,transform] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
             isActive
               ? 'text-primary-token text-[28px] leading-[1.25] font-display opacity-100'
               : 'text-tertiary-token text-[20px] leading-[1.35] font-display opacity-60 hover:opacity-90 hover:text-secondary-token'
@@ -106,7 +111,7 @@ export function LyricRow({
         type='button'
         onClick={onStamp}
         className={cn(
-          'shrink-0 h-6 px-1.5 rounded text-[10.5px] tabular-nums font-caption transition-colors duration-subtle ease-subtle',
+          'shrink-0 h-6 px-1.5 rounded text-[10.5px] tabular-nums font-caption transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
           isActive
             ? 'bg-cyan-500/15 text-cyan-300 border border-cyan-500/30'
             : 'text-tertiary-token bg-surface-1 border border-(--linear-app-shell-border) hover:text-primary-token hover:border-cyan-500/40'
@@ -129,4 +134,4 @@ export function LyricRow({
       />
     </li>
   );
-}
+});


### PR DESCRIPTION
## Shell handoff rotation 9

**Surface:** `LyricRow` (lyrics list high-churn row renderer over real prod `LyricLine` data from track lyrics)

- `React.memo` on `LyricRow` to stabilize re-renders during playback ticks, seek, and edit/stamp mode (matches rot3–8 pattern for list/row/cell surfaces).
- Upgraded interactive controls (seek button, stamp button) to canonical focus rings: `focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55` + `outline-none`.
- Motion already on `duration-subtle ease-subtle` per DESIGN.md.
- 1 file changed (test file has no class assertions on focus rings).
- Follows exact prior rotation contract: auto-memo + DS subtle + canonical focus + subtraction/container-aware + real prod data + no layout shift.

**Source:** just-freed from shell handoff rotation 8 (`SidebarThreadsSection` + `SidebarThreadRow` memo, PR #9404).

**Verification (all green in worktree):**
- biome check --write + lint: pass
- typecheck (web): pass
- vitest (LyricRow.test.tsx): 4/4 pass
- pre-push guards (tailwind, proxy, full lint/type): pass
- layout shift: none (pure internal + a11y focus enhancement)
- real data path: `/app/lyrics/[trackId]` + `LyricsList` + prod lyrics from discog

**PR contract honored:** smallest correct change in HOT ZONE, 1 file preferred, early draft, agent-run-artifact created post-push.

Ready for /qa /review /ship per gstack when lead rotates.

Rotation 9 of 10-parallel drain swarm for shell migration velocity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved keyboard accessibility in the lyric editor with enhanced visual focus indicators on action buttons, including the seek button during playback and the stamp button while editing, providing clearer feedback when navigating with a keyboard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->