### PR TITLE
perf(shell): memo + DS subtle + canonical focus on TaskBoardCard (rot 14)

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
@@ -21,7 +21,7 @@ import {
 import { CSS } from '@dnd-kit/utilities';
 import { UserAvatar } from '@jovie/ui';
 import { Disc3, Plus } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { ReleaseDueBadge } from '@/components/molecules/ReleaseDueBadge';
 import { type ContextMenuItemType } from '@/components/organisms/table';
 import { TASK_BOARD_STATUSES } from '@/lib/tasks/task-board';
@@ -449,7 +449,7 @@ function SortableTaskBoardCard({
         {...listeners}
         data-testid={`task-board-card-${task.id}`}
         onClick={() => onOpenTask(task)}
-        className='block w-full cursor-grab text-left active:cursor-grabbing focus-visible:outline-none'
+        className='block w-full cursor-grab text-left active:cursor-grabbing focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
       >
         <TaskBoardCard
           task={task}
@@ -468,7 +468,7 @@ function SortableTaskBoardCard({
   );
 }
 
-function TaskBoardCard({
+const TaskBoardCard = memo(function TaskBoardCard({
   task,
   artistName,
   selected,
@@ -490,7 +490,7 @@ function TaskBoardCard({
   return (
     <div
       className={cn(
-        'group/task-board-card min-h-[7.25rem] w-full rounded-lg border border-subtle bg-surface-1 px-3 py-2.5 text-left shadow-card transition-[background-color,border-color,box-shadow,opacity]',
+        'group/task-board-card min-h-[7.25rem] w-full rounded-lg border border-subtle bg-surface-1 px-3 py-2.5 text-left shadow-card transition-[background-color,border-color,box-shadow,opacity] duration-subtle ease-subtle',
         draggingOverlay ? 'cursor-grabbing' : 'cursor-grab',
         'hover:border-subtle hover:bg-surface-2 hover:shadow-card-elevated',
         'focus-visible:outline-none focus-visible:border-[color-mix(in_oklab,var(--linear-border-focus)_74%,transparent)] focus-visible:shadow-[inset_0_0_0_1px_var(--linear-border-focus)]',
@@ -565,7 +565,7 @@ function TaskBoardCard({
       </div>
     </div>
   );
-}
+});
 
 function TaskBoardSkeleton() {
   return (


### PR DESCRIPTION
**Shell handoff rotation 14**

Surface: dashboard task board card renderer (TaskBoardCard in TaskBoard.tsx)

- React.memo on high-churn board card over real prod `TaskView` data (sibling surface to TaskListRow list renderer from rot 13)
- DS `duration-subtle ease-subtle` on transitions
- Canonical focus rings on interactive targets (matches established rot 3-13 pattern exactly)
- 1 file changed (precise HOT ZONE)
- Source: freed from shell handoff rotation 13 (TaskListRow, PR #9415)

**Verification**
- biome: clean (check+write)
- typecheck: pass (singleflight + hook segments)
- tailwind guard: pass
- proxy guard: pass
- tests: covered via TasksPageClient (no new breakage)
- layout shift: none (memo + additive token class on pre-existing transition; focus ring is outline-only, no size/reflow impact; enumerated states: normal/selected/dragging/hover/focus/done/agent/empty-release/due all preserve dimensions)
- real prod data: TaskView + board DnD from dashboard tasks (prod queries)
- gstack-equivalent: pre-push hook green segments + manual
- subtraction / container-aware: no new chrome; edit only inside existing card
- All AGENTS.md + DESIGN.md + .claude/rules/ui.md + scoped rules (no new commands, no migration edits, etc.) honored.

**PR**
Ready for /ship or direct land after lead review. Opens draft early per contract for CI signal.

🤖 Rotation 14 complete. Report win (this PR) for immediate dispatch to rot 15 / next coverage gap / UI/UX support / stuck PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Enhanced visual feedback on draggable task cards with improved focus styling
  * Refined card transition animations for smoother interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->