### PR TITLE
perf(shell): memo + DS subtle + canonical focus on ContactRow (rot 15)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/SettingsContactsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsContactsSection.tsx
@@ -2,7 +2,7 @@
 
 import { Badge, Button } from '@jovie/ui';
 import { Plus, UserPlus } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 import { SettingsPanel } from '@/components/features/dashboard/molecules/SettingsPanel';
 import { ConfirmDialog } from '@/components/molecules/ConfirmDialog';
@@ -259,7 +259,7 @@ function ContactsListInner({
   );
 }
 
-function ContactRow({
+const ContactRow = memo(function ContactRow({
   contact,
   isSelected,
   onClick,
@@ -278,7 +278,7 @@ function ContactRow({
       type='button'
       onClick={onClick}
       aria-pressed={isSelected}
-      className={`flex w-full items-center gap-3 rounded-lg border px-3 py-3 text-left transition-[background-color,border-color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/35 ${
+      className={`flex w-full items-center gap-3 rounded-lg border px-3 py-3 text-left transition-[background-color,border-color,box-shadow] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) ${
         isSelected
           ? 'border-subtle bg-surface-0'
           : 'border-transparent hover:bg-surface-0'
@@ -310,4 +310,4 @@ function ContactRow({
       )}
     </button>
   );
-}
+});


### PR DESCRIPTION
## Shell handoff rotation 15

**Surface**: `ContactRow` dashboard settings contacts row renderer (over real `EditableContact` data from `useContactsManager` in authenticated shell settings)

**Pattern match (rot 3-14)**:
- `React.memo` on the list row renderer (high-churn `.map` over prod contacts)
- DS `duration-subtle ease-subtle` on the row's transition classes
- Canonical focus ring upgrade on the interactive button target: `focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)`

**HOT ZONE**: 1 file (`apps/web/components/features/dashboard/organisms/SettingsContactsSection.tsx` internal `ContactRow`)

**Source**: Freed high-performer from shell handoff rotation 14 completion (`TaskBoardCard` + PR #9416)

**Verification**:
- `biome check --write` + full pre-push (biome/lint/typecheck/tailwind/guard) ✅
- Scoped typecheck + `SettingsContactsSection.test.tsx` ✅
- Subtraction + container-aware (no new elements)
- No layout shift (token upgrade on existing transition; focus ring is `focus-visible` additive)
- Real production data contract preserved
- Follows DESIGN.md (restraint), `.claude/rules/ui.md` (memo on renderers, DS tokens, no decorative motion), all AGENTS.md + scoped rules

**Next**: Report win (this PR) for immediate rotation 16 / coverage / UI-UX support per long-running directive.

PR opened from dedicated drain worktree per swarm pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined focus state styling for buttons in the Settings Contacts section, including adjustments to transition timing and visual feedback appearance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->