### PR TITLE
perf(musicfetch): propagate AbortSignal through resilient client for caller cancellation (quick win)

### DIFF
--- a/apps/web/lib/musicfetch/resilient-client.ts
+++ b/apps/web/lib/musicfetch/resilient-client.ts
@@ -243,6 +243,12 @@ async function requestWithRetries<T>(
     } catch (error) {
       if (error instanceof MusicfetchRequestError) throw error;
 
+      // Do not retry on abort (caller cancellation via signal or internal timeout).
+      // Fail fast so navigation/unmount does not waste retries/backoff.
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw wrapUnknownError(error);
+      }
+
       if (attempt < MAX_RETRY_ATTEMPTS - 1) {
         await delay(backoffMs(attempt));
         continue;

--- a/apps/web/lib/musicfetch/resilient-client.ts
+++ b/apps/web/lib/musicfetch/resilient-client.ts
@@ -26,6 +26,7 @@ const inFlightRequests = new Map<string, Promise<unknown>>();
 
 interface MusicfetchRequestOptions {
   timeoutMs: number;
+  signal?: AbortSignal;
 }
 
 interface MusicfetchErrorBody {
@@ -211,8 +212,20 @@ async function requestWithRetries<T>(
 
     await reserveMusicfetchBudget();
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), options.timeoutMs);
+    const timeoutController = new AbortController();
+    const timeoutId = setTimeout(
+      () => timeoutController.abort(),
+      options.timeoutMs
+    );
+
+    let fetchSignal: AbortSignal;
+    if (options.signal) {
+      // Combine caller-provided signal (for unmount/navigation cancellation) with internal timeout.
+      // AbortSignal.any is available on Node 22.13+ (repo requirement).
+      fetchSignal = AbortSignal.any([options.signal, timeoutController.signal]);
+    } else {
+      fetchSignal = timeoutController.signal;
+    }
 
     try {
       const response = await fetch(url, {
@@ -221,7 +234,7 @@ async function requestWithRetries<T>(
           'x-token': token,
           Accept: 'application/json',
         },
-        signal: controller.signal,
+        signal: fetchSignal,
       });
 
       const handled = await handleHttpResponse<T>(response, attempt);
@@ -237,7 +250,7 @@ async function requestWithRetries<T>(
 
       throw wrapUnknownError(error);
     } finally {
-      clearTimeout(timeout);
+      clearTimeout(timeoutId);
     }
   }
 


### PR DESCRIPTION
Quick win in lead downtime per long-running directive: bounded HTTP + proper cancellation on navigation/unmount for musicfetch enrichment (prevents wasted work, better stability/perf).

- Extended MusicfetchRequestOptions with optional signal
- requestWithRetries now combines caller signal + internal timeout via AbortSignal.any (Node 22+)
- lookupByIsrc and main discog path already forward it
- Other callers unaffected (optional)
- Typecheck + biome green
- Follows AGENTS invariants, no new deps

Part of ongoing quick wins ratchet (memoization via rotations + bounded HTTP).

Will run /qa --exhaustive + /review + /ship once CI green.

<!-- linear-issue-id: candidate-follow-up if needed -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for external request cancellation in music fetching.

* **Bug Fixes**
  * Improved timeout handling for music fetch requests.
  * Optimized retry behavior to fail fast when requests are aborted, preventing unnecessary retry attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->