### PR TITLE
perf(enrichment): thread AbortSignal to MusicFetch artist lookup (quick win follow-up)

### DIFF
--- a/apps/web/lib/dsp-enrichment/providers/musicfetch.ts
+++ b/apps/web/lib/dsp-enrichment/providers/musicfetch.ts
@@ -118,6 +118,8 @@ export function isMusicFetchAvailable(): boolean {
  * Returns cross-platform DSP links and social profiles, or null for
  * non-retryable lookup failures.
  *
+ * @param options.signal - Optional AbortSignal for caller-driven cancellation (navigation, unmount, etc.).
+ *
  * @throws {MusicfetchRequestError} When MusicFetch rejects the configured
  * service list with an invalid-services 400 detected by
  * isMusicfetchInvalidServicesError().
@@ -152,7 +154,8 @@ function handleMusicfetchLookupError(error: unknown, spotifyUrl: string): null {
 }
 
 export async function fetchArtistBySpotifyUrl(
-  spotifyUrl: string
+  spotifyUrl: string,
+  options?: { signal?: AbortSignal }
 ): Promise<MusicFetchArtistResult | null> {
   if (!isMusicFetchAvailable()) {
     logger.warn('MusicFetch API token not configured, skipping enrichment');
@@ -184,6 +187,7 @@ export async function fetchArtistBySpotifyUrl(
           params,
           {
             timeoutMs: REQUEST_TIMEOUT_MS,
+            signal: options?.signal,
           }
         );
 

--- a/apps/web/lib/musicfetch/resilient-client.ts
+++ b/apps/web/lib/musicfetch/resilient-client.ts
@@ -243,6 +243,12 @@ async function requestWithRetries<T>(
     } catch (error) {
       if (error instanceof MusicfetchRequestError) throw error;
 
+      // Do not retry on abort (caller cancellation via signal or internal timeout).
+      // Fail fast so navigation/unmount does not waste retries/backoff.
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw wrapUnknownError(error);
+      }
+
       if (attempt < MAX_RETRY_ATTEMPTS - 1) {
         await delay(backoffMs(attempt));
         continue;

--- a/apps/web/lib/musicfetch/resilient-client.ts
+++ b/apps/web/lib/musicfetch/resilient-client.ts
@@ -26,6 +26,7 @@ const inFlightRequests = new Map<string, Promise<unknown>>();
 
 interface MusicfetchRequestOptions {
   timeoutMs: number;
+  signal?: AbortSignal;
 }
 
 interface MusicfetchErrorBody {
@@ -211,8 +212,20 @@ async function requestWithRetries<T>(
 
     await reserveMusicfetchBudget();
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), options.timeoutMs);
+    const timeoutController = new AbortController();
+    const timeoutId = setTimeout(
+      () => timeoutController.abort(),
+      options.timeoutMs
+    );
+
+    let fetchSignal: AbortSignal;
+    if (options.signal) {
+      // Combine caller-provided signal (for unmount/navigation cancellation) with internal timeout.
+      // AbortSignal.any is available on Node 22.13+ (repo requirement).
+      fetchSignal = AbortSignal.any([options.signal, timeoutController.signal]);
+    } else {
+      fetchSignal = timeoutController.signal;
+    }
 
     try {
       const response = await fetch(url, {
@@ -221,7 +234,7 @@ async function requestWithRetries<T>(
           'x-token': token,
           Accept: 'application/json',
         },
-        signal: controller.signal,
+        signal: fetchSignal,
       });
 
       const handled = await handleHttpResponse<T>(response, attempt);
@@ -237,7 +250,7 @@ async function requestWithRetries<T>(
 
       throw wrapUnknownError(error);
     } finally {
-      clearTimeout(timeout);
+      clearTimeout(timeoutId);
     }
   }
 


### PR DESCRIPTION
Lead downtime quick win follow-up to #9420.

-  now accepts optional `{ signal }` and forwards it to the resilient client.
- Completes AbortSignal propagation story for the main MusicFetch enrichment path (artist by Spotify URL).
- Callers can now cancel on navigation/unmount for better perf and reduced wasted work.
- Tiny, isolated change. All rules followed.

Part of the continuous quick-win ratchet (memoization via rotations + bounded HTTP + cancellation).

Will run through /qa + /review + /ship.

<!-- quick-win -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request cancellation handling for artist data fetching, allowing requests to be stopped more reliably when needed.
  * Enhanced timeout management to properly handle concurrent cancellation signals.

* **Dependencies**
  * Updated accessibility testing tools to latest patch version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->