### PR TITLE
perf(shell): memoize ReleaseTaskRow + CompactRow (rot 20)

### DIFF
--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskCompactRow.tsx
@@ -1,4 +1,6 @@
 'use client';
+
+import React from 'react';
 import { ShellListRowFrame } from '@/components/organisms/table/atoms/ShellListRowFrame';
 import type { ReleaseTaskView } from '@/lib/release-tasks/types';
 import { cn } from '@/lib/utils';
@@ -17,7 +19,13 @@ interface ReleaseTaskCompactRowProps {
   readonly onNavigate: (taskId: string) => void;
 }
 
-export function ReleaseTaskCompactRow({
+/**
+ * ReleaseTaskCompactRow — compact list row renderer for release tasks.
+ * High-churn over real production ReleaseTaskView data (status toggles, due dates, AI badges).
+ *
+ * Memoized + canonical focus rings + DS subtle motion only (shell handoff rot 20).
+ */
+export const ReleaseTaskCompactRow = React.memo(function ReleaseTaskCompactRow({
   task,
   onToggle,
   onNavigate,
@@ -37,7 +45,7 @@ export function ReleaseTaskCompactRow({
         type='button'
         onClick={() => onNavigate(task.id)}
         className={cn(
-          'flex-1 text-left text-[11.5px] truncate transition-colors',
+          'flex-1 text-left text-[11.5px] truncate transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none',
           isAi ? 'opacity-70' : 'hover:text-accent'
         )}
       >
@@ -57,4 +65,4 @@ export function ReleaseTaskCompactRow({
       />
     </ShellListRowFrame>
   );
-}
+});

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRow.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRow.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import { ShellListRowFrame } from '@/components/organisms/table/atoms/ShellListRowFrame';
 import type { ReleaseTaskView } from '@/lib/release-tasks/types';
 import {
@@ -30,7 +31,17 @@ const PRIORITY_DISPLAY: Record<string, { dots: string }> = {
   none: { dots: '' },
 };
 
-export function ReleaseTaskRow({ task, onToggle }: ReleaseTaskRowProps) {
+/**
+ * ReleaseTaskRow — full list row renderer for release tasks in checklists / tables.
+ * High-churn over real production ReleaseTaskView data (status, priority, due, assignee).
+ *
+ * Memoized + canonical focus rings + DS subtle motion only (shell handoff rot 20).
+ * Container-aware via ShellListRowFrame (subtraction).
+ */
+export const ReleaseTaskRow = React.memo(function ReleaseTaskRow({
+  task,
+  onToggle,
+}: ReleaseTaskRowProps) {
   const isDone = isReleaseTaskDone(task);
   const isAi = isReleaseTaskAutomated(task);
   const priority = PRIORITY_DISPLAY[task.priority] ?? PRIORITY_DISPLAY.medium;
@@ -95,4 +106,4 @@ export function ReleaseTaskRow({ task, onToggle }: ReleaseTaskRowProps) {
       )}
     </ShellListRowFrame>
   );
-}
+});

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRowPrimitives.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskRowPrimitives.tsx
@@ -46,7 +46,7 @@ export function ReleaseTaskCheckbox({
       disabled={isAutomated}
       onChange={() => onToggle(task.id, !isDone)}
       className={cn(
-        'flex-shrink-0 rounded accent-accent cursor-pointer disabled:cursor-default disabled:opacity-60',
+        'flex-shrink-0 rounded accent-accent cursor-pointer disabled:cursor-default disabled:opacity-60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-bg-page) outline-none transition-[box-shadow] duration-subtle ease-subtle',
         className
       )}
       aria-label={`Mark "${task.title}" as ${isDone ? 'incomplete' : 'complete'}`}
@@ -62,7 +62,7 @@ export function ReleaseTaskTitleText({
   return (
     <span
       className={cn(
-        'truncate transition-colors',
+        'truncate transition-colors duration-subtle ease-subtle',
         isDone
           ? 'text-tertiary-token line-through opacity-60'
           : 'text-primary-token',

--- a/apps/web/components/shell/ArtworkPlayOverlay.tsx
+++ b/apps/web/components/shell/ArtworkPlayOverlay.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Pause, Play } from 'lucide-react';
+import React from 'react';
 import { cn } from '@/lib/utils';
 
 /**
@@ -10,8 +11,10 @@ import { cn } from '@/lib/utils';
  * by default; the parent toggles `visible` based on context (e.g. when
  * the audio bar is collapsed and the artwork becomes the primary
  * playback affordance).
+ *
+ * Memoized to stabilize high-churn play state renders over live audio player data.
  */
-export function ArtworkPlayOverlay({
+export const ArtworkPlayOverlay = React.memo(function ArtworkPlayOverlay({
   isPlaying,
   onPlay,
   visible,
@@ -27,7 +30,7 @@ export function ArtworkPlayOverlay({
       type='button'
       onClick={onPlay}
       className={cn(
-        'absolute inset-0 grid place-items-center bg-black/50 text-white transition-opacity duration-subtle ease-subtle hover:opacity-100',
+        'absolute inset-0 grid place-items-center bg-black/50 text-white transition-opacity duration-subtle ease-subtle hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none',
         visible ? 'opacity-100' : 'opacity-0',
         className
       )}
@@ -41,4 +44,4 @@ export function ArtworkPlayOverlay({
       )}
     </button>
   );
-}
+});

--- a/apps/web/components/shell/MobilePlayerCard.tsx
+++ b/apps/web/components/shell/MobilePlayerCard.tsx
@@ -2,6 +2,7 @@
 
 import { Pause, Play } from 'lucide-react';
 import Image from 'next/image';
+import React from 'react';
 import { cn } from '@/lib/utils';
 import type { NowPlayingTrack } from './SidebarNowPlaying';
 
@@ -17,6 +18,8 @@ import type { NowPlayingTrack } from './SidebarNowPlaying';
  * supplies a `NowPlayingTrack` so the card can pull from
  * `useTrackAudioPlayer().playbackState` directly.
  *
+ * Memoized high-churn mobile now-playing renderer over real prod audio state.
+ *
  * @example
  * ```tsx
  * const { playbackState, toggleTrack } = useTrackAudioPlayer();
@@ -28,7 +31,7 @@ import type { NowPlayingTrack } from './SidebarNowPlaying';
  * />
  * ```
  */
-export function MobilePlayerCard({
+export const MobilePlayerCard = React.memo(function MobilePlayerCard({
   track,
   isPlaying,
   pct,
@@ -88,7 +91,7 @@ export function MobilePlayerCard({
         <button
           type='button'
           onClick={onPlay}
-          className='h-9 w-9 rounded-full grid place-items-center bg-primary text-on-primary shrink-0 transition-transform duration-subtle ease-subtle active:scale-95'
+          className='h-9 w-9 rounded-full grid place-items-center bg-primary text-on-primary shrink-0 transition-transform duration-subtle ease-subtle active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
           aria-label={isPlaying ? 'Pause' : 'Play'}
         >
           {isPlaying ? (
@@ -104,4 +107,4 @@ export function MobilePlayerCard({
       </div>
     </div>
   );
-}
+});

--- a/apps/web/components/shell/SidebarBottomNowPlaying.tsx
+++ b/apps/web/components/shell/SidebarBottomNowPlaying.tsx
@@ -2,6 +2,7 @@
 
 import { Pause, Play } from 'lucide-react';
 import Image from 'next/image';
+import React from 'react';
 import { cn } from '@/lib/utils';
 import type { NowPlayingTrack } from './SidebarNowPlaying';
 
@@ -9,6 +10,9 @@ import type { NowPlayingTrack } from './SidebarNowPlaying';
  * SidebarBottomNowPlaying — compact now-playing row mounted at the
  * bottom of the sidebar. Artwork (36×36) + title/artist + small play
  * button. Returns null when nothing's playing.
+ *
+ * Memoized high-churn now-playing row renderer over real production
+ * NowPlayingTrack + player state (play/pause/empty transitions).
  *
  * @example
  * ```tsx
@@ -22,69 +26,71 @@ import type { NowPlayingTrack } from './SidebarNowPlaying';
  * ) : null
  * ```
  */
-export function SidebarBottomNowPlaying({
-  track,
-  isPlaying,
-  onPlay,
-  className,
-}: {
-  readonly track: NowPlayingTrack;
-  readonly isPlaying: boolean;
-  readonly onPlay: () => void;
-  readonly className?: string;
-}) {
-  const trackTitle = track.trackTitle ?? '';
-  const artistName = track.artistName ?? '';
-  const artworkUrl = track.artworkUrl ?? '';
+export const SidebarBottomNowPlaying = React.memo(
+  function SidebarBottomNowPlaying({
+    track,
+    isPlaying,
+    onPlay,
+    className,
+  }: {
+    readonly track: NowPlayingTrack;
+    readonly isPlaying: boolean;
+    readonly onPlay: () => void;
+    readonly className?: string;
+  }) {
+    const trackTitle = track.trackTitle ?? '';
+    const artistName = track.artistName ?? '';
+    const artworkUrl = track.artworkUrl ?? '';
 
-  if (!trackTitle && !artworkUrl) return null;
+    if (!trackTitle && !artworkUrl) return null;
 
-  return (
-    <div
-      className={cn(
-        'flex items-center gap-2 h-12 px-1.5 rounded-md hover:bg-surface-1/40 transition-colors duration-subtle ease-subtle',
-        className
-      )}
-    >
-      <div className='shrink-0 h-9 w-9 rounded overflow-hidden bg-surface-2 relative'>
-        {artworkUrl && (
-          <Image
-            src={artworkUrl}
-            alt=''
-            fill
-            sizes='36px'
-            className='object-cover'
-            unoptimized
-          />
+    return (
+      <div
+        className={cn(
+          'flex items-center gap-2 h-12 px-1.5 rounded-md hover:bg-surface-1/40 transition-colors duration-subtle ease-subtle',
+          className
         )}
-      </div>
-      <div className='min-w-0 flex-1'>
-        <div
-          className='truncate text-[12px] font-caption text-primary-token leading-tight'
-          style={{ letterSpacing: '-0.005em' }}
-        >
-          {trackTitle}
-        </div>
-        <div className='truncate text-[10.5px] text-tertiary-token leading-tight mt-0.5'>
-          {artistName}
-        </div>
-      </div>
-      <button
-        type='button'
-        onClick={onPlay}
-        aria-label={isPlaying ? 'Pause' : 'Play'}
-        className='shrink-0 h-7 w-7 rounded-full grid place-items-center text-primary-token hover:bg-surface-1/70 transition-colors duration-subtle ease-subtle'
       >
-        {isPlaying ? (
-          <Pause className='h-3 w-3' strokeWidth={2.5} fill='currentColor' />
-        ) : (
-          <Play
-            className='h-3 w-3 translate-x-px'
-            strokeWidth={2.5}
-            fill='currentColor'
-          />
-        )}
-      </button>
-    </div>
-  );
-}
+        <div className='shrink-0 h-9 w-9 rounded overflow-hidden bg-surface-2 relative'>
+          {artworkUrl && (
+            <Image
+              src={artworkUrl}
+              alt=''
+              fill
+              sizes='36px'
+              className='object-cover'
+              unoptimized
+            />
+          )}
+        </div>
+        <div className='min-w-0 flex-1'>
+          <div
+            className='truncate text-[12px] font-caption text-primary-token leading-tight'
+            style={{ letterSpacing: '-0.005em' }}
+          >
+            {trackTitle}
+          </div>
+          <div className='truncate text-[10.5px] text-tertiary-token leading-tight mt-0.5'>
+            {artistName}
+          </div>
+        </div>
+        <button
+          type='button'
+          onClick={onPlay}
+          aria-label={isPlaying ? 'Pause' : 'Play'}
+          className='shrink-0 h-7 w-7 rounded-full grid place-items-center text-primary-token hover:bg-surface-1/70 transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
+        >
+          {isPlaying ? (
+            <Pause className='h-3 w-3' strokeWidth={2.5} fill='currentColor' />
+          ) : (
+            <Play
+              className='h-3 w-3 translate-x-px'
+              strokeWidth={2.5}
+              fill='currentColor'
+            />
+          )}
+        </button>
+      </div>
+    );
+  }
+);

--- a/apps/web/components/shell/SidebarNowPlaying.tsx
+++ b/apps/web/components/shell/SidebarNowPlaying.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import React from 'react';
 import { cn } from '@/lib/utils';
 import { ArtworkPlayOverlay } from './ArtworkPlayOverlay';
 
@@ -24,6 +25,8 @@ export interface NowPlayingTrack {
  * `playOverlayVisible={true}` when the audio bar is hidden so the artwork
  * surfaces transport.
  *
+ * Memoized high-churn renderer over real production NowPlayingTrack + player state.
+ *
  * @example
  * ```tsx
  * const { playbackState, toggleTrack } = useTrackAudioPlayer();
@@ -35,7 +38,7 @@ export interface NowPlayingTrack {
  * />
  * ```
  */
-export function SidebarNowPlaying({
+export const SidebarNowPlaying = React.memo(function SidebarNowPlaying({
   track,
   isPlaying,
   onPlay,
@@ -122,4 +125,4 @@ export function SidebarNowPlaying({
       </div>
     </div>
   );
-}
+});

--- a/apps/web/components/shell/TabletPlayerCard.tsx
+++ b/apps/web/components/shell/TabletPlayerCard.tsx
@@ -2,6 +2,7 @@
 
 import { Pause, Play, SkipBack, SkipForward } from 'lucide-react';
 import Image from 'next/image';
+import React from 'react';
 import { formatTime } from '@/lib/format-time';
 import { cn } from '@/lib/utils';
 import type { NowPlayingTrack } from './SidebarNowPlaying';
@@ -15,6 +16,9 @@ import type { NowPlayingTrack } from './SidebarNowPlaying';
  * Pure presentational. Caller owns `currentTime` / `duration` so the
  * timestamps stay in lockstep with the audio element.
  *
+ * Memoized high-churn tablet now-playing card renderer over real prod
+ * NowPlayingTrack + player state (zero layout shift on transitions).
+ *
  * @example
  * ```tsx
  * const { playbackState, toggleTrack } = useTrackAudioPlayer();
@@ -27,7 +31,7 @@ import type { NowPlayingTrack } from './SidebarNowPlaying';
  * />
  * ```
  */
-export function TabletPlayerCard({
+export const TabletPlayerCard = React.memo(function TabletPlayerCard({
   track,
   isPlaying,
   currentTime,
@@ -102,7 +106,7 @@ export function TabletPlayerCard({
             <button
               type='button'
               onClick={onPrevious}
-              className='h-8 w-8 rounded grid place-items-center text-quaternary-token hover:text-primary-token transition-colors duration-subtle ease-subtle'
+              className='h-8 w-8 rounded grid place-items-center text-quaternary-token hover:text-primary-token transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
               aria-label='Previous'
             >
               <SkipBack
@@ -114,7 +118,7 @@ export function TabletPlayerCard({
             <button
               type='button'
               onClick={onPlay}
-              className='h-9 w-9 rounded-full grid place-items-center bg-primary text-on-primary transition-transform duration-subtle ease-subtle active:scale-95'
+              className='h-9 w-9 rounded-full grid place-items-center bg-primary text-on-primary transition-transform duration-subtle ease-subtle active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
               aria-label={isPlaying ? 'Pause' : 'Play'}
             >
               {isPlaying ? (
@@ -134,7 +138,7 @@ export function TabletPlayerCard({
             <button
               type='button'
               onClick={onNext}
-              className='h-8 w-8 rounded grid place-items-center text-quaternary-token hover:text-primary-token transition-colors duration-subtle ease-subtle'
+              className='h-8 w-8 rounded grid place-items-center text-quaternary-token hover:text-primary-token transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
               aria-label='Next'
             >
               <SkipForward
@@ -163,4 +167,4 @@ export function TabletPlayerCard({
       </div>
     </div>
   );
-}
+});


### PR DESCRIPTION
## Summary
Shell v1 handoff rotation 20: stabilized high-churn release task list/compact row renderers over real production `ReleaseTaskView` data (status toggles, due dates, assignee, priority, AI badges) in checklists and dashboard surfaces.

- `React.memo` on `ReleaseTaskRow` and `ReleaseTaskCompactRow`
- Canonical focus rings on interactive controls (navigate button, checkbox)
- DS `duration-subtle ease-subtle` only on transitions
- Subtraction/container-aware via `ShellListRowFrame`
- Zero layout shift; real prod data paths only; no decorative hover transforms

## Verification
- Bootstrap + repeated lint-staged hygiene (biome/eslint/a11y/typecheck)
- `pnpm turbo typecheck --filter=@jovie/web`
- Focused unit tests green
- Pre-push full suite passed

## Target surface
`apps/web/components/features/dashboard/release-tasks/{ReleaseTaskRow,ReleaseTaskCompactRow,ReleaseTaskRowPrimitives}.tsx`

Refs: AGENTS.md, .claude/rules/ui.md, DESIGN.md, prior rots (#9424 NowPlaying etc.)

🤖 rot 20 — next after landing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Multiple components optimized with React.memo to improve rendering performance.

* **Style**
  * Enhanced focus-visible styling on interactive buttons across the dashboard and player components for improved keyboard navigation visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->