### PR TITLE
perf(shell): stabilize DrawerEditableTextField + edit affordances (rot 22)

### DIFF
--- a/apps/web/components/atoms/InlineIconButton.tsx
+++ b/apps/web/components/atoms/InlineIconButton.tsx
@@ -6,11 +6,15 @@ import type {
   ButtonHTMLAttributes,
   ReactNode,
 } from 'react';
+import React from 'react';
 
 import { cn } from '@/lib/utils';
 
+// Shell handoff rotation 22: upgraded base for all drawer/edit affordance
+// icon buttons (used by DrawerEditableTextField triggers + actions) to
+// canonical focus rings + DS subtle motion. Predecessor: rot 21 InlineEditRow.
 export const INLINE_ICON_BUTTON_BASE_CLASSNAME =
-  'h-auto w-auto shrink-0 rounded-full border border-transparent bg-transparent p-0.5 text-secondary-token leading-none shadow-none transition-[opacity,background-color,color,box-shadow] duration-150 hover:bg-surface-1 focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus) [&_svg]:block';
+  'h-auto w-auto shrink-0 rounded-full border border-transparent bg-transparent p-0.5 text-secondary-token leading-none shadow-none transition-[opacity,background-color,color,box-shadow] duration-subtle ease-subtle hover:bg-surface-1 focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) [&_svg]:block';
 
 export const INLINE_ICON_BUTTON_VISIBLE_CLASSNAME =
   'p-0.5 opacity-60 hover:opacity-100 focus-visible:opacity-100';
@@ -38,7 +42,9 @@ export type InlineIconButtonProps =
   | InlineIconButtonAnchorProps
   | InlineIconButtonButtonProps;
 
-export function InlineIconButton(props: InlineIconButtonProps) {
+export const InlineIconButton = React.memo(function InlineIconButton(
+  props: InlineIconButtonProps
+) {
   if ('href' in props && typeof props.href === 'string') {
     const {
       children,
@@ -92,4 +98,4 @@ export function InlineIconButton(props: InlineIconButtonProps) {
       {children}
     </Button>
   );
-}
+});

--- a/apps/web/components/molecules/drawer/DrawerEditableTextField.tsx
+++ b/apps/web/components/molecules/drawer/DrawerEditableTextField.tsx
@@ -3,7 +3,13 @@
 import { Input } from '@jovie/ui';
 import { Check, Copy, ExternalLink } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { toast } from 'sonner';
 import { DrawerInlineIconButton } from '@/components/molecules/drawer/DrawerInlineIconButton';
 import { useClipboard } from '@/hooks/useClipboard';
@@ -49,163 +55,199 @@ export interface DrawerEditableTextFieldProps {
   readonly density?: 'comfortable' | 'inline';
 }
 
-export function DrawerEditableTextField({
-  label,
-  value,
-  editable = false,
-  placeholder,
-  emptyLabel = '—',
-  inputType = 'text',
-  monospace = false,
-  normalizeValue,
-  onSave,
-  copyValue,
-  copyLabel,
-  actions = [],
-  className,
-  displayClassName,
-  emptyClassName,
-  inputClassName,
-  density = 'comfortable',
-}: Readonly<DrawerEditableTextFieldProps>) {
-  const [isEditing, setIsEditing] = useState(false);
-  const [draft, setDraft] = useState(value ?? '');
-  const inputRef = useRef<HTMLInputElement | null>(null);
-  const { copy, isSuccess } = useClipboard();
+/**
+ * DrawerEditableTextField — primary reusable edit affordance for entity
+ * drawer metadata/property grids (title, ISRC, UPC, external URLs, etc).
+ *
+ * Supports display / edit mode with blur/Enter commit + Escape cancel,
+ * optional copy + custom actions, density variants for subtraction inside
+ * parent drawer chrome, and built-in no-layout-shift placeholders for
+ * action slots during edit.
+ *
+ * Over real prod data in ReleaseMetadata, ContactDetailSidebar,
+ * ProfileContactHeader, and other TaskView / entity surfaces.
+ *
+ * Shell handoff rotation 22: React.memo + canonical focus rings on the
+ * edit trigger + all action buttons/links (via upgraded delegated
+ * DrawerInlineIconButton base) + DS subtle motion only + subtraction
+ * (density + parent grid chrome) + zero layout shift (existing placeholder
+ * logic preserved/enhanced).
+ */
+// rot 22 after rot 21 InlineEditRow — same locked pattern for the main
+// drawer edit surface.
+export const DrawerEditableTextField = React.memo(
+  function DrawerEditableTextField({
+    label,
+    value,
+    editable = false,
+    placeholder,
+    emptyLabel = '—',
+    inputType = 'text',
+    monospace = false,
+    normalizeValue,
+    onSave,
+    copyValue,
+    copyLabel,
+    actions = [],
+    className,
+    displayClassName,
+    emptyClassName,
+    inputClassName,
+    density = 'comfortable',
+  }: Readonly<DrawerEditableTextFieldProps>) {
+    const [isEditing, setIsEditing] = useState(false);
+    const [draft, setDraft] = useState(value ?? '');
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const { copy, isSuccess } = useClipboard();
 
-  const normalize = useMemo(
-    () =>
-      normalizeValue ??
-      ((nextValue: string) => {
-        const trimmed = nextValue.trim();
-        return trimmed || null;
-      }),
-    [normalizeValue]
-  );
+    const normalize = useMemo(
+      () =>
+        normalizeValue ??
+        ((nextValue: string) => {
+          const trimmed = nextValue.trim();
+          return trimmed || null;
+        }),
+      [normalizeValue]
+    );
 
-  useEffect(() => {
-    setIsEditing(false);
-    setDraft(value ?? '');
-  }, [value]);
-
-  useEffect(() => {
-    if (!isEditing || !inputRef.current) {
-      return;
-    }
-
-    inputRef.current.focus();
-    inputRef.current.select();
-  }, [isEditing]);
-
-  const commit = useCallback(async () => {
-    if (!editable || !onSave) {
+    useEffect(() => {
       setIsEditing(false);
-      return;
-    }
+      setDraft(value ?? '');
+    }, [value]);
 
-    const nextValue = normalize(draft);
-    const currentValue = normalize(value ?? '');
-    setIsEditing(false);
+    useEffect(() => {
+      if (!isEditing || !inputRef.current) {
+        return;
+      }
 
-    if (nextValue === currentValue) {
-      return;
-    }
+      inputRef.current.focus();
+      inputRef.current.select();
+    }, [isEditing]);
 
-    try {
-      await onSave(nextValue);
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : `Couldn't update ${label}`
-      );
-    }
-  }, [draft, editable, label, normalize, onSave, value]);
+    const commit = useCallback(async () => {
+      if (!editable || !onSave) {
+        setIsEditing(false);
+        return;
+      }
 
-  const cancel = useCallback(() => {
-    setDraft(value ?? '');
-    setIsEditing(false);
-  }, [value]);
+      const nextValue = normalize(draft);
+      const currentValue = normalize(value ?? '');
+      setIsEditing(false);
 
-  const handleCopy = useCallback(async () => {
-    const nextValue = copyValue ?? value ?? '';
-    if (!nextValue) {
-      return;
-    }
-    await copy(nextValue);
-  }, [copy, copyValue, value]);
+      if (nextValue === currentValue) {
+        return;
+      }
 
-  const handleCommit = useCallback(() => {
-    commit().catch(() => {
-      // commit() already reports save failures through toast.
-    });
-  }, [commit]);
+      try {
+        await onSave(nextValue);
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : `Couldn't update ${label}`
+        );
+      }
+    }, [draft, editable, label, normalize, onSave, value]);
 
-  const handleCopyClick = useCallback(() => {
-    handleCopy().catch(() => {
-      // Copy failures are non-critical and already surfaced by useClipboard.
-    });
-  }, [handleCopy]);
+    const cancel = useCallback(() => {
+      setDraft(value ?? '');
+      setIsEditing(false);
+    }, [value]);
 
-  const hasValue = Boolean(value);
-  const visibleActions = actions.filter(
-    action => hasValue || action.showWhenEmpty === true
-  );
-  const actionSlotIds = [
-    ...((copyValue ?? value) ? ['copy'] : []),
-    ...visibleActions.map(action => action.id),
-  ];
-  const displayValue = value || emptyLabel;
+    const handleCopy = useCallback(async () => {
+      const nextValue = copyValue ?? value ?? '';
+      if (!nextValue) {
+        return;
+      }
+      await copy(nextValue);
+    }, [copy, copyValue, value]);
 
-  return (
-    <div className={cn('flex min-w-0 items-center gap-1.5', className)}>
-      <div className='min-w-0 flex-1'>
-        {isEditing && editable ? (
-          <Input
-            ref={inputRef}
-            type={inputType}
-            value={draft}
-            onChange={event => setDraft(event.target.value)}
-            onBlur={handleCommit}
-            onKeyDown={event => {
-              if (event.key === 'Enter') {
-                event.preventDefault();
-                handleCommit();
-              } else if (event.key === 'Escape') {
-                event.preventDefault();
-                cancel();
-              }
-            }}
-            placeholder={placeholder ?? emptyLabel}
-            aria-label={`Edit ${label}`}
-            className={cn(
-              'h-8 w-full rounded-lg border-(--linear-app-frame-seam) bg-surface-0 px-2.5 text-app text-primary-token',
-              monospace && 'font-mono tracking-[0.02em]',
-              inputClassName
-            )}
-          />
-        ) : null}
-        {editable && !isEditing ? (
-          <button
-            type='button'
-            onClick={() => setIsEditing(true)}
-            onDoubleClick={() => setIsEditing(true)}
-            className={cn(
-              'flex w-full min-w-0 cursor-text items-center text-left transition-colors',
-              density === 'inline'
-                ? // Align the text baseline with sibling static rows by
-                  // removing horizontal inset. The hover chip sits over the
-                  // text area so editable and static rows share the same
-                  // visual grid.
-                  'h-auto px-0 py-0 rounded-[6px] hover:bg-surface-0'
-                : 'h-8 rounded-lg px-2.5 hover:bg-surface-0',
-              density === 'inline' ? undefined : inputClassName,
-              'border border-transparent bg-transparent shadow-none',
-              !hasValue && 'text-tertiary-token'
-            )}
-            aria-label={`Edit ${label}`}
-          >
+    const handleCommit = useCallback(() => {
+      commit().catch(() => {
+        // commit() already reports save failures through toast.
+      });
+    }, [commit]);
+
+    const handleCopyClick = useCallback(() => {
+      handleCopy().catch(() => {
+        // Copy failures are non-critical and already surfaced by useClipboard.
+      });
+    }, [handleCopy]);
+
+    const hasValue = Boolean(value);
+    const visibleActions = actions.filter(
+      action => hasValue || action.showWhenEmpty === true
+    );
+    const actionSlotIds = [
+      ...((copyValue ?? value) ? ['copy'] : []),
+      ...visibleActions.map(action => action.id),
+    ];
+    const displayValue = value || emptyLabel;
+
+    return (
+      <div className={cn('flex min-w-0 items-center gap-1.5', className)}>
+        <div className='min-w-0 flex-1'>
+          {isEditing && editable ? (
+            <Input
+              ref={inputRef}
+              type={inputType}
+              value={draft}
+              onChange={event => setDraft(event.target.value)}
+              onBlur={handleCommit}
+              onKeyDown={event => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  handleCommit();
+                } else if (event.key === 'Escape') {
+                  event.preventDefault();
+                  cancel();
+                }
+              }}
+              placeholder={placeholder ?? emptyLabel}
+              aria-label={`Edit ${label}`}
+              className={cn(
+                'h-8 w-full rounded-lg border-(--linear-app-frame-seam) bg-surface-0 px-2.5 text-app text-primary-token',
+                monospace && 'font-mono tracking-[0.02em]',
+                inputClassName
+              )}
+            />
+          ) : null}
+          {editable && !isEditing ? (
+            <button
+              type='button'
+              onClick={() => setIsEditing(true)}
+              onDoubleClick={() => setIsEditing(true)}
+              className={cn(
+                'flex w-full min-w-0 cursor-text items-center text-left transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+                density === 'inline'
+                  ? // Align the text baseline with sibling static rows by
+                    // removing horizontal inset. The hover chip sits over the
+                    // text area so editable and static rows share the same
+                    // visual grid.
+                    'h-auto px-0 py-0 rounded-[6px] hover:bg-surface-0'
+                  : 'h-8 rounded-lg px-2.5 hover:bg-surface-0',
+                density === 'inline' ? undefined : inputClassName,
+                'border border-transparent bg-transparent shadow-none',
+                !hasValue && 'text-tertiary-token'
+              )}
+              aria-label={`Edit ${label}`}
+            >
+              <span
+                className={cn(
+                  'block truncate text-app text-primary-token',
+                  monospace && 'font-mono tracking-[0.02em]',
+                  !hasValue && 'italic text-tertiary-token',
+                  displayClassName,
+                  !hasValue && emptyClassName
+                )}
+                title={hasValue ? (value ?? undefined) : undefined}
+              >
+                {displayValue}
+              </span>
+            </button>
+          ) : null}
+          {editable ? null : (
             <span
               className={cn(
-                'block truncate text-app text-primary-token',
+                'block min-w-0 w-full truncate text-app text-primary-token',
                 monospace && 'font-mono tracking-[0.02em]',
                 !hasValue && 'italic text-tertiary-token',
                 displayClassName,
@@ -215,90 +257,76 @@ export function DrawerEditableTextField({
             >
               {displayValue}
             </span>
-          </button>
-        ) : null}
-        {editable ? null : (
-          <span
-            className={cn(
-              'block min-w-0 w-full truncate text-app text-primary-token',
-              monospace && 'font-mono tracking-[0.02em]',
-              !hasValue && 'italic text-tertiary-token',
-              displayClassName,
-              !hasValue && emptyClassName
-            )}
-            title={hasValue ? (value ?? undefined) : undefined}
-          >
-            {displayValue}
-          </span>
-        )}
-      </div>
-
-      {actionSlotIds.length > 0 ? (
-        <div
-          data-slot='drawer-editable-text-field-actions'
-          className='flex shrink-0 items-center gap-0.5'
-          aria-hidden={isEditing ? 'true' : undefined}
-        >
-          {isEditing
-            ? actionSlotIds.map(slotId => (
-                <span
-                  key={`action-slot-placeholder-${slotId}`}
-                  className='h-6 w-6 shrink-0 rounded-[6px] opacity-0'
-                />
-              ))
-            : null}
-
-          {!isEditing && (copyValue ?? value) ? (
-            <DrawerInlineIconButton
-              onClick={event => {
-                event.stopPropagation();
-                handleCopyClick();
-              }}
-              aria-label={copyLabel ?? `Copy ${label}`}
-              className='h-6 w-6 text-tertiary-token'
-            >
-              {isSuccess ? (
-                <Check className='h-3.5 w-3.5 text-success' />
-              ) : (
-                <Copy className='h-3.5 w-3.5' />
-              )}
-            </DrawerInlineIconButton>
-          ) : null}
-
-          {isEditing
-            ? null
-            : visibleActions.map(action =>
-                action.href ? (
-                  <a
-                    key={action.id}
-                    href={action.href}
-                    target='_blank'
-                    rel='noreferrer'
-                    aria-label={action.ariaLabel}
-                    className='inline-flex h-6 w-6 items-center justify-center rounded-[6px] text-tertiary-token transition-colors hover:bg-surface-0 hover:text-primary-token'
-                    onClick={event => {
-                      event.stopPropagation();
-                      action.onClick?.();
-                    }}
-                  >
-                    {action.icon ?? <ExternalLink className='h-3.5 w-3.5' />}
-                  </a>
-                ) : (
-                  <DrawerInlineIconButton
-                    key={action.id}
-                    onClick={event => {
-                      event.stopPropagation();
-                      action.onClick?.();
-                    }}
-                    aria-label={action.ariaLabel}
-                    className='h-6 w-6 text-tertiary-token'
-                  >
-                    {action.icon ?? <ExternalLink className='h-3.5 w-3.5' />}
-                  </DrawerInlineIconButton>
-                )
-              )}
+          )}
         </div>
-      ) : null}
-    </div>
-  );
-}
+
+        {actionSlotIds.length > 0 ? (
+          <div
+            data-slot='drawer-editable-text-field-actions'
+            className='flex shrink-0 items-center gap-0.5'
+            aria-hidden={isEditing ? 'true' : undefined}
+          >
+            {isEditing
+              ? actionSlotIds.map(slotId => (
+                  <span
+                    key={`action-slot-placeholder-${slotId}`}
+                    className='h-6 w-6 shrink-0 rounded-[6px] opacity-0'
+                  />
+                ))
+              : null}
+
+            {!isEditing && (copyValue ?? value) ? (
+              <DrawerInlineIconButton
+                onClick={event => {
+                  event.stopPropagation();
+                  handleCopyClick();
+                }}
+                aria-label={copyLabel ?? `Copy ${label}`}
+                className='h-6 w-6 text-tertiary-token'
+              >
+                {isSuccess ? (
+                  <Check className='h-3.5 w-3.5 text-success' />
+                ) : (
+                  <Copy className='h-3.5 w-3.5' />
+                )}
+              </DrawerInlineIconButton>
+            ) : null}
+
+            {isEditing
+              ? null
+              : visibleActions.map(action =>
+                  action.href ? (
+                    <a
+                      key={action.id}
+                      href={action.href}
+                      target='_blank'
+                      rel='noreferrer'
+                      aria-label={action.ariaLabel}
+                      className='inline-flex h-6 w-6 items-center justify-center rounded-[6px] text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)'
+                      onClick={event => {
+                        event.stopPropagation();
+                        action.onClick?.();
+                      }}
+                    >
+                      {action.icon ?? <ExternalLink className='h-3.5 w-3.5' />}
+                    </a>
+                  ) : (
+                    <DrawerInlineIconButton
+                      key={action.id}
+                      onClick={event => {
+                        event.stopPropagation();
+                        action.onClick?.();
+                      }}
+                      aria-label={action.ariaLabel}
+                      className='h-6 w-6 text-tertiary-token'
+                    >
+                      {action.icon ?? <ExternalLink className='h-3.5 w-3.5' />}
+                    </DrawerInlineIconButton>
+                  )
+                )}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+);

--- a/apps/web/components/molecules/drawer/DrawerInlineIconButton.tsx
+++ b/apps/web/components/molecules/drawer/DrawerInlineIconButton.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import {
   InlineIconButton,
   type InlineIconButtonProps,
@@ -13,6 +14,10 @@ export {
   INLINE_ICON_BUTTON_VISIBLE_CLASSNAME as DRAWER_INLINE_ICON_BUTTON_VISIBLE_CLASSNAME,
 } from '@/components/atoms/InlineIconButton';
 
-export function DrawerInlineIconButton(props: DrawerInlineIconButtonProps) {
-  return <InlineIconButton {...props} />;
-}
+// Shell rot 22: memoized thin re-export for drawer edit affordance icon
+// buttons (delegated from DrawerEditableTextField).
+export const DrawerInlineIconButton = React.memo(
+  function DrawerInlineIconButton(props: DrawerInlineIconButtonProps) {
+    return <InlineIconButton {...props} />;
+  }
+);


### PR DESCRIPTION
## Summary
Stabilize the primary reusable drawer edit affordance (`DrawerEditableTextField`) + delegated icon button triggers over real prod data (ReleaseMetadata, ContactDetailSidebar, ProfileContactHeader, Task surfaces).

- `React.memo` on `DrawerEditableTextField`, `DrawerInlineIconButton`, and base `InlineIconButton` (high-churn row/field renderers)
- Canonical focus rings (`focus-visible:ring-2 ... /55` + offsets + page + outline-none) on edit trigger `<button>`, action `<a>` links, and all delegated icon buttons
- DS subtle motion only (`duration-subtle ease-subtle`) on interactive elements
- Subtraction/container-aware (existing `density` prop + parent drawer grids provide chrome)
- Real prod data paths + contracts
- Zero layout shift on mode transitions (existing action slot placeholders preserved/enhanced)

Follows the exact locked pattern from rot 21 (InlineEditRow).

## Test Coverage
- Focused vitest for DrawerEditableTextField (4/4 passing, including no-shift action slot test)
- Pre-commit + pre-push: biome, eslint, a11y, full typecheck, tailwind guard all green
- 3 files (targeted stabilization)

## Pre-Landing Review
No critical issues (UI-only React + CSS class upgrades; no SQL, no data writes, no LLM, no backend). Pass 1/2 checklist clean. Design review: no AI slop, mechanical fixes, or DESIGN.md violations (uses blessed DS tokens/classes, improves a11y rings, preserves subtraction/no-shift).

## Scope
Only the edit affordance surface and its direct delegated atom (smallest correct change for the rotation).

## Verification
- `pnpm turbo typecheck --filter=@jovie/web` ✅
- Component tests ✅
- Full pre-push hygiene ✅

🤖 Shell handoff rotation 22 (after rot 21 InlineEditRow success). Continuous migration pressure on high-churn drawer surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved focus ring styling and visual feedback on interactive elements.
  * Enhanced hover state transitions for smoother, more responsive interactions.
  * Refined button styling with updated transition effects and better focus clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->