### PR TITLE
fix(ops): agentOS board full-width layout + remove redundant status badges

### DIFF
--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -310,7 +310,7 @@ function DeploymentsPanel({
 }>) {
   return (
     <div
-      className='max-w-[560px] space-y-2 border-subtle border-t pt-3'
+      className='space-y-2 border-subtle border-t pt-3'
       data-testid='ops-deployments-panel'
     >
       <div className='flex items-center justify-between gap-3'>
@@ -586,8 +586,10 @@ export function HudDashboardClient({
 
   // Outer layout: kiosk gets the wide centered TV layout; shell defers width
   // to the AdminToolPage container that already provides app-shell padding.
+  // Shell uses full width — no max-w constraint; the board benefits from all
+  // available horizontal space at wide monitor widths.
   const outerClass = isShell
-    ? 'mx-auto flex w-full max-w-[1680px] flex-col gap-3'
+    ? 'flex w-full flex-col gap-3'
     : 'mx-auto flex w-full max-w-[1560px] flex-col gap-3 px-4 py-4 sm:px-6 sm:py-6 xl:px-8';
 
   // MRR scale: shell matches Overview KPIs (~28-32px); kiosk keeps the

--- a/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
+++ b/apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx
@@ -237,7 +237,6 @@ function AgentOsBoardCard({
           </div>
         </button>
         <div className='flex shrink-0 items-center gap-1'>
-          <WorkflowStatusPill status={artifact.status} />
           <AgentRunDetailPopover artifact={artifact} />
         </div>
       </div>
@@ -269,7 +268,7 @@ function AgentOsBoard({
   }
 
   return (
-    <div className='grid gap-2 md:grid-cols-2 xl:grid-cols-3'>
+    <div className='grid gap-2 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4'>
       {BOARD_STATUSES.map(status => {
         const laneRows = rows.filter(artifact => artifact.status === status);
 


### PR DESCRIPTION
## Summary

Removes width constraints and redundant status badges from the Ops AgentOS board, following the subtraction principle.

- **Full-width layout**: removed `max-w-[1680px]` cap from the shell outer container in `HudDashboardClient.tsx` so the board fills the viewport on wide displays
- **Deployments panel uncapped**: removed `max-w-[560px]` from the deployments section so it scales with the page width
- **Removed redundant `WorkflowStatusPill` from board cards**: each card lives inside a labeled status lane (`Queued`, `Running`, `Review`, `Blocked`, `Failed`, `Stale`, `Done`) — the per-card pill duplicated that context; kept in table view where lane labels don't exist
- **`2xl:grid-cols-4`**: added fourth column breakpoint at 2xl so wide displays pack the board more efficiently (4+3 from 7 lanes vs old 3+3+1)

## Files changed

- `apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx` — remove width caps
- `apps/web/components/features/admin/agent-os/AgentOsRunsPanel.tsx` — remove redundant status pill, add 2xl grid column

## Test plan

- [ ] Open `/app/admin/ops` on a wide display — board should fill viewport with no horizontal centering gap
- [ ] Confirm status lane headers still show (Queued, Running, Review, Blocked, Failed, Stale, Done)
- [ ] Confirm no `WorkflowStatusPill` renders inside board cards
- [ ] Switch to table view — confirm status column still renders `WorkflowStatusPill` correctly
- [ ] Verify no layout shift between board and table views

Closes JOV-2114

🤖 Generated with [Claude Code](https://claude.com/claude-code)