### PR TITLE
fix(ui): increase cookie banner tap targets + redirect /[username]/music (JOV-2518, JOV-2520)

### DIFF
--- a/apps/web/app/[username]/music/page.tsx
+++ b/apps/web/app/[username]/music/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+import { REDIRECT_SINK_METADATA } from '@/lib/profile/metadata';
+import { redirectToProfileMode } from '../_lib/mode-route-redirect';
+
+interface Props {
+  readonly params: Promise<{
+    readonly username: string;
+  }>;
+}
+
+// Redirect sink — issues HTTP 307 to /{username}?mode=listen before any HTML
+// renders. The Music tab uses mode=listen. Marked noindex so crawlers follow
+// the canonical URL instead.
+export function generateMetadata(): Metadata {
+  return REDIRECT_SINK_METADATA;
+}
+
+export default async function MusicPage({ params }: Props) {
+  return redirectToProfileMode(params, 'listen');
+}

--- a/apps/web/components/molecules/CookieActions.tsx
+++ b/apps/web/components/molecules/CookieActions.tsx
@@ -51,17 +51,17 @@ export function CookieActions({
   const secStyle: CSSProperties = compact
     ? {
         ...secondaryButtonStyle,
-        fontSize: '11px',
-        padding: '4px 8px',
-        height: '26px',
+        fontSize: '12px',
+        padding: '6px 10px',
+        height: '36px',
       }
     : secondaryButtonStyle;
   const priStyle: CSSProperties = compact
     ? {
         ...primaryButtonStyle,
-        fontSize: '11px',
-        padding: '4px 10px',
-        height: '26px',
+        fontSize: '12px',
+        padding: '6px 12px',
+        height: '36px',
       }
     : primaryButtonStyle;
 


### PR DESCRIPTION
## Summary

- **JOV-2518**: Compact cookie banner buttons (`Reject`, `Customize`, `Accept All`) height increased from `26px` → `36px`. Padding adjusted from `4px 8px/10px` → `6px 10px/12px`. Font-size restored from `11px` → `12px`. Mobile tap targets now meet the 36px ergonomic bar while keeping the compact card design intact.
- **JOV-2520**: Added `/[username]/music` route (`app/[username]/music/page.tsx`) that HTTP 307 redirects to `/{username}?mode=listen`. The Music tab maps to `mode=listen` throughout the profile nav (confirmed via `BottomTabBar.tsx`). Mirrors the existing `/[username]/listen` redirect pattern.

## Button heights before/after

| State | Before | After |
|-------|--------|-------|
| Compact `secStyle` (Reject, Customize) | `26px` / `4px 8px` / `11px` | `36px` / `6px 10px` / `12px` |
| Compact `priStyle` (Accept All) | `26px` / `4px 10px` / `11px` | `36px` / `6px 12px` / `12px` |
| Default (full bar, unchanged) | `28px` | `28px` |

## `/[username]/music` routing decision

The Music tab in the profile bottom nav (`BottomTabBar.tsx` line 53) uses `mode: 'listen'`. The URL pattern `/{username}/music` was not previously a registered route, returning "Content Not Found". The fix adds a redirect sink that issues a 307 to `/{username}?mode=listen` before any HTML renders, consistent with the existing `/listen`, `/tour`, `/releases` etc. redirect pattern. Marked `noindex` via `REDIRECT_SINK_METADATA`.

## Test plan

- [ ] Verify compact cookie banner buttons on mobile have adequate tap area (≥36px tall)
- [ ] Confirm `/tim/music` redirects to `/tim?mode=listen` (HTTP 307, then renders Music tab)
- [ ] Confirm `/tim/listen` still works (unchanged)
- [ ] Typecheck, Biome lint, ESLint, a11y check all passed in pre-commit and pre-push hooks

<!-- linear-issue-id:JOV-2518 -->
<!-- linear-issue-id:JOV-2520 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new redirect route for user music profiles.

* **Style**
  * Improved button styling in the cookie consent dialog for compact mode with increased font size, padding, and height.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->