### PR TITLE
fix(shell): canonicalize /app/tasks route, redirect legacy dashboard path

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/tasks/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/tasks/page.tsx
@@ -1,5 +1,6 @@
-import { TasksRoute } from './TasksRoute';
+import { redirect } from 'next/navigation';
+import { APP_ROUTES } from '@/constants/routes';
 
-export default async function TasksPage() {
-  return TasksRoute();
+export default function LegacyDashboardTasksPage() {
+  redirect(APP_ROUTES.TASKS);
 }

--- a/apps/web/tests/unit/app/dashboard-tasks-page.test.tsx
+++ b/apps/web/tests/unit/app/dashboard-tasks-page.test.tsx
@@ -152,10 +152,10 @@ describe('tasks page routes', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('keeps the legacy dashboard entry point on the same task contract', async () => {
-    render(await LegacyTasksPage());
+  it('redirects the legacy dashboard entry point to the canonical /app/tasks route', () => {
+    expect(() => LegacyTasksPage()).toThrow(`REDIRECT:${APP_ROUTES.TASKS}`);
 
-    expect(screen.getByTestId('tasks-page-client')).toBeInTheDocument();
+    expect(mockRedirect).toHaveBeenCalledWith(APP_ROUTES.TASKS);
   });
 
   it('redirects onboarding-required users back to start', async () => {


### PR DESCRIPTION
## Summary
- Changes `/app/dashboard/tasks` from rendering the tasks workspace to a `redirect()` to `/app/tasks` (the canonical route)
- Updates the test to assert redirect behaviour for the legacy entry point
- All navigation already pointed to `APP_ROUTES.TASKS` (`/app/tasks`); this closes the gap where hitting the old URL served content instead of redirecting

## What changed
| File | Change |
|------|--------|
| `apps/web/app/app/(shell)/dashboard/tasks/page.tsx` | Replaced render-delegate with `redirect(APP_ROUTES.TASKS)` |
| `apps/web/tests/unit/app/dashboard-tasks-page.test.tsx` | Updated legacy test case to assert redirect to `/app/tasks` |

## Routing after this PR
- `/app/tasks` — canonical route (unchanged, already existed)
- `/app/dashboard/tasks` — now redirects to `/app/tasks`
- Nav `Tasks` item already pointed to `APP_ROUTES.TASKS` (no nav change needed)
- `task-actions.ts` stays at `(shell)/dashboard/tasks/task-actions.ts` (imported from canonical TasksRoute.tsx — no change needed)

## Test plan
- [x] `tests/unit/app/dashboard-tasks-page.test.tsx` — 5 tests pass
- [x] Typecheck clean (exit 0)
- [x] Biome lint clean
- [x] Pre-push hooks all pass

Closes JOV-2354

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated legacy dashboard tasks entry point to automatically redirect to the canonical tasks page, ensuring consistent navigation and simplified route management across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->