### PR TITLE
fix(db): defensive error handling for profile_views/workflow_runs/profile_photos

### DIFF
--- a/apps/web/app/api/cron/process-workflow-runs/route.ts
+++ b/apps/web/app/api/cron/process-workflow-runs/route.ts
@@ -37,7 +37,7 @@ import {
 import { db } from '@/lib/db';
 import { workflowRuns } from '@/lib/db/schema/connectors';
 import { env } from '@/lib/env-server';
-import { captureError } from '@/lib/error-tracking';
+import { captureError, captureWarning } from '@/lib/error-tracking';
 import { logger } from '@/lib/utils/logger';
 
 export const maxDuration = 300;
@@ -142,8 +142,16 @@ export async function GET(request: Request): Promise<Response> {
       failed,
     });
   } catch (err) {
-    logger.error('[process-workflow-runs] cron tick failed', err);
-    await captureError('process-workflow-runs cron tick failed', err, {});
+    // JOV-2326: a failed cron tick is self-healing — the next tick (6 min) will retry
+    // any pending rows. Log at warn level to avoid Sentry noise from transient Neon
+    // connection failures; escalate only if the error recurs persistently.
+    logger.warn(
+      '[process-workflow-runs] cron tick failed (transient, will retry)',
+      {
+        err,
+      }
+    );
+    await captureWarning('process-workflow-runs cron tick failed', err, {});
     return NextResponse.json({ error: 'internal-error' }, { status: 500 });
   }
 }

--- a/apps/web/lib/db/queries/avatar-quality.ts
+++ b/apps/web/lib/db/queries/avatar-quality.ts
@@ -7,6 +7,7 @@ import {
   resolveAvatarQuality,
   UNKNOWN_AVATAR_QUALITY,
 } from '@/lib/profile/avatar-quality';
+import { logger } from '@/lib/utils/logger';
 
 function isAvatarQualitySchemaUnavailableError(error: unknown): boolean {
   const directCode =
@@ -27,6 +28,29 @@ function isAvatarQualitySchemaUnavailableError(error: unknown): boolean {
     directCode === '42703' ||
     causeCode === '42P01' ||
     causeCode === '42703'
+  );
+}
+
+/**
+ * JOV-2285: detect transient Neon/pg connection failures that resolve on retry.
+ * These occur during cold-start, autosuspend wake, or connection-limit exhaustion
+ * and should degrade gracefully rather than propagating to Sentry as errors.
+ * Avatar quality is supplementary metadata — returning UNKNOWN is always safe.
+ */
+function isTransientDbConnectionError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message.toLowerCase()
+      : String(error).toLowerCase();
+  return (
+    message.includes('connection') ||
+    message.includes('socket') ||
+    message.includes('econnreset') ||
+    message.includes('endpoint is disabled') ||
+    message.includes('too many connections') ||
+    message.includes('connection timeout') ||
+    message.includes('connection refused') ||
+    message.includes('fetch failed')
   );
 }
 
@@ -65,6 +89,19 @@ export async function getAvatarQualityForProfile(
         '[avatar-quality] profile_photos metadata unavailable, returning unknown',
         error,
         { creatorProfileId }
+      );
+      return UNKNOWN_AVATAR_QUALITY;
+    }
+
+    // JOV-2285: transient Neon connection failures degrade gracefully.
+    // Avatar quality is supplementary — UNKNOWN is the safe fallback.
+    if (isTransientDbConnectionError(error)) {
+      logger.warn(
+        '[avatar-quality] transient DB connection error, returning unknown quality',
+        {
+          creatorProfileId,
+          error: error instanceof Error ? error.message : String(error),
+        }
       );
       return UNKNOWN_AVATAR_QUALITY;
     }

--- a/apps/web/lib/services/profile/mutations.ts
+++ b/apps/web/lib/services/profile/mutations.ts
@@ -13,6 +13,7 @@ import { captureError, captureWarning } from '@/lib/error-tracking';
 import { mergeProfileTheme } from '@/lib/profile/profile-theme';
 import { buildThemeWithProfileAccent } from '@/lib/profile/profile-theme.server';
 import { getRedis } from '@/lib/redis';
+import { logger } from '@/lib/utils/logger';
 import type { ProfileData, ProfileUpdateData } from './types';
 
 // Redis key prefix for view count batching
@@ -213,7 +214,9 @@ async function flushViewsToDatabase(
     }
   }
 
-  captureWarning('Profile view flush failed after retries', {
+  // JOV-2388: view counts are non-critical telemetry — log only, do not send to Sentry.
+  // Neon connection failures under traffic spikes are transient; the next flush will succeed.
+  logger.warn('[profile/mutations] profile view flush failed after retries', {
     username: normalizedUsername,
     count: sanitizedCount,
     maxRetries,
@@ -255,11 +258,17 @@ async function incrementViewsDirectly(
     }
   }
 
-  captureWarning('Profile view increment failed after retries', {
-    username: normalizedUsername,
-    maxRetries,
-    error: lastError?.message,
-  });
+  // JOV-2388: view counts are non-critical telemetry — log only, do not send to Sentry.
+  // Neon connection failures under traffic spikes are transient; Redis batching reduces
+  // direct-DB path frequency. A failed increment is acceptable data loss.
+  logger.warn(
+    '[profile/mutations] profile view increment failed after retries',
+    {
+      username: normalizedUsername,
+      maxRetries,
+      error: lastError?.message,
+    }
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes three Sentry issues caused by transient Neon DB connection failures generating Sentry noise for non-critical operations.

- **JOV-2388** (`profile_views` update): `flushViewsToDatabase` and `incrementViewsDirectly` called `captureWarning` (→ Sentry) after exhausting retries. View counts are telemetry — replaced with `logger.warn`. A failed flush is silent, non-blocking, and self-healing (Redis batching means the next threshold flush will pick up the gap).

- **JOV-2326** (`workflow_runs` SELECT): The cron outer-catch used `captureError` (Sentry error level). A failed cron tick is self-healing — the next tick (6 min) retries any still-pending rows. Downgraded to `captureWarning`. The `workflow_runs_status_run_at_idx` index already exists in migration 0048.

- **JOV-2285** (`profile_photos` width/height SELECT): `getAvatarQualityForProfile` only caught schema-unavailable errors (42P01/42703); transient connection errors (ECONNRESET, too many connections, fetch failed) propagated up. Added `isTransientDbConnectionError` guard that degrades to `UNKNOWN_AVATAR_QUALITY` with `logger.warn`. Avatar quality is supplementary metadata; UNKNOWN is always safe.

## Changes

- `/apps/web/lib/services/profile/mutations.ts` — `flushViewsToDatabase` + `incrementViewsDirectly`: `captureWarning` → `logger.warn`
- `/apps/web/app/api/cron/process-workflow-runs/route.ts` — outer catch: `captureError` → `captureWarning`
- `/apps/web/lib/db/queries/avatar-quality.ts` — add `isTransientDbConnectionError` fallback returning `UNKNOWN_AVATAR_QUALITY`

## Verification

- `pnpm --filter @jovie/web run typecheck` — passed (0 errors)
- `pnpm biome check --write` — passed (0 errors)
- `tests/unit/profile/profile-service-mutations.test.ts` — 19/19 passed
- `tests/unit/db/queries/press-photos.test.ts` — 4/4 passed
- Full pre-push hook suite (biome, ESLint, typecheck, lint) — passed

## Risk

Low. All changes are error-handling path only. No business logic changed. All three operations already had graceful degradation at their call sites; these changes stop non-critical failures from reaching Sentry.

Closes JOV-2388, JOV-2326, JOV-2285

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for transient database connectivity issues to enhance system reliability and reduce service interruptions
  * Enhanced system resilience in workflow processing and profile operations during temporary failures
  * Implemented better recovery mechanisms to minimize user impact from temporary service disruptions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->