### PR TITLE
fix(infra): statsig native binding + task upgrade error boundary (JOV-2322, JOV-2225)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/release-plan-generation.ts
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/release-plan-generation.ts
@@ -9,6 +9,32 @@ import type { ReleaseViewModel } from '@/lib/discography/types';
 import { captureError } from '@/lib/error-tracking';
 import type { ReleaseContext } from '@/lib/release-tasks/applicability';
 
+/**
+ * Returns true when the error is a TasksUpgradeRequiredError that crossed the
+ * Server Action boundary. instanceof checks are unreliable across that boundary,
+ * so we match on the serialised `name` field that Next.js preserves in the
+ * re-thrown client-side Error, with a fallback on the `code` property for
+ * cases where the error object was constructed directly (e.g. in unit tests).
+ *
+ * These are expected business-logic gates, not bugs — do not report to Sentry.
+ */
+function isUpgradeRequiredError(error: unknown): boolean {
+  if (error instanceof Error && error.name === 'TasksUpgradeRequiredError') {
+    return true;
+  }
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'string' &&
+    ((error as { code: string }).code === 'RELEASE_PLAN_LOCKED' ||
+      (error as { code: string }).code === 'TASKS_WORKSPACE_LOCKED')
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export async function generateReleasePlanTasks(
   releaseId: string,
   context?: ReleaseContext
@@ -69,12 +95,19 @@ export function usePostCreateReleasePlan({
         setPostCreateRelease(null);
         router.push(releaseTasksPath);
       } catch (error) {
-        captureError('Failed to generate release plan', error, {
-          context: captureContext,
-          releaseId: postCreateRelease.id,
-          action: 'generate-release-plan',
-        });
-        toast.error('Failed to generate the release plan. Try again.');
+        if (isUpgradeRequiredError(error)) {
+          // Expected entitlement gate — not a bug, do not report to Sentry.
+          toast.error(
+            'Release plans require a Pro plan. Upgrade to unlock this feature.'
+          );
+        } else {
+          captureError('Failed to generate release plan', error, {
+            context: captureContext,
+            releaseId: postCreateRelease.id,
+            action: 'generate-release-plan',
+          });
+          toast.error('Failed to generate the release plan. Try again.');
+        }
       } finally {
         setIsGeneratingReleasePlan(false);
       }

--- a/apps/web/lib/queries/useReleaseTaskMutations.ts
+++ b/apps/web/lib/queries/useReleaseTaskMutations.ts
@@ -1,14 +1,38 @@
 'use client';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import {
   addReleaseTask,
   deleteReleaseTask,
   instantiateReleaseTasks,
   updateReleaseTask,
 } from '@/app/app/(shell)/dashboard/releases/task-actions';
+import { captureError } from '@/lib/error-tracking';
 import type { ReleaseTaskView } from '@/lib/release-tasks/types';
 import { queryKeys } from './keys';
+
+/**
+ * Returns true when the error is a TasksUpgradeRequiredError that crossed the
+ * Server Action boundary. Matches on the serialised `name` field or the `code`
+ * property to avoid a brittle instanceof check across the boundary.
+ */
+function isUpgradeRequiredError(error: unknown): boolean {
+  if (error instanceof Error && error.name === 'TasksUpgradeRequiredError') {
+    return true;
+  }
+  if (
+    error !== null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    typeof (error as { code: unknown }).code === 'string' &&
+    ((error as { code: string }).code === 'RELEASE_PLAN_LOCKED' ||
+      (error as { code: string }).code === 'TASKS_WORKSPACE_LOCKED')
+  ) {
+    return true;
+  }
+  return false;
+}
 
 function getReleaseTasksQueryKey(releaseId: string) {
   return queryKeys.releaseTasks.byRelease(releaseId);
@@ -99,6 +123,21 @@ export function useInstantiateTasksMutation(releaseId: string) {
 
   return useMutation({
     mutationFn: () => instantiateReleaseTasks(releaseId),
+
+    onError: (error: unknown) => {
+      // Expected entitlement gate — not a bug, do not report to Sentry.
+      if (isUpgradeRequiredError(error)) {
+        toast.error(
+          'Release plans require a Pro plan. Upgrade to unlock this feature.'
+        );
+        return;
+      }
+      captureError('Failed to instantiate release tasks', error, {
+        releaseId,
+        action: 'instantiate-release-tasks',
+      });
+      toast.error('Failed to set up release tasks. Try again.');
+    },
 
     onSettled: async () => {
       await invalidateReleaseTaskQueries(queryClient, releaseId);

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -441,6 +441,15 @@ const nextConfig = {
       }
     })(),
   },
+  // Keep @statsig/statsig-node-core external so Next.js does not webpack-bundle
+  // the NAPI package. When bundled, the hash-prefixed import path that Next.js
+  // generates (`@statsig/statsig-node-core-<hash>`) cannot be resolved at
+  // runtime on Vercel — Vercel file-tracing cannot follow hashed require()
+  // paths to locate the platform-native .node binary. Marking it external
+  // restores the original require path so Vercel's tracer includes the correct
+  // linux-x64 or linux-arm64 binary in the serverless function bundle.
+  // See JOV-2322.
+  serverExternalPackages: ['@statsig/statsig-node-core'],
   experimental: {
     // Note: PPR (ppr: 'incremental') was deprecated in Next.js 15.3
     // cacheComponents: true requires additional configuration, disabled for now


### PR DESCRIPTION
## Summary

- **JOV-2322** — Add `@statsig/statsig-node-core` to `serverExternalPackages` in `next.config.js`. When Next.js webpack-bundles this NAPI package it rewrites the `require()` path to a hash-prefixed specifier (`@statsig/statsig-node-core-<hash>`) that Vercel file-tracing cannot follow to the platform-native `.node` binary. The result is a boot-time `Failed to load external module @statsig/statsig-node-core-6531e5d802c776a1` crash. Marking it external restores the original require path so Vercel's tracer includes the correct `linux-x64` or `linux-arm64` binary in the serverless function bundle.
- **JOV-2225** — `TasksUpgradeRequiredError` is an expected entitlement gate, not a bug. It was propagating to `captureError`/Sentry because the catch blocks in `release-plan-generation.ts` and `useReleaseTaskMutations.ts` treated all errors uniformly. Added `isUpgradeRequiredError()` guards at both boundaries: upgrade-gated errors now show a user-facing upgrade toast and skip Sentry reporting.

## What changed

| File | Change |
|------|--------|
| `apps/web/next.config.js` | Added `serverExternalPackages: ['@statsig/statsig-node-core']` |
| `apps/web/components/features/dashboard/organisms/release-provider-matrix/release-plan-generation.ts` | Added `isUpgradeRequiredError()` guard in catch block; upgrade errors show toast, skip Sentry |
| `apps/web/lib/queries/useReleaseTaskMutations.ts` | Added `onError` to `useInstantiateTasksMutation` with same guard |

## Test plan

- [x] Typecheck passes (`pnpm --filter @jovie/web run typecheck`)
- [x] Biome lint passes (`pnpm biome check --write`)
- [x] Pre-push hooks pass (biome + typecheck + tailwind guard)
- [ ] Verify Statsig initialises cleanly in a Vercel preview deploy (no `Failed to load external module` in function logs)
- [ ] Verify free-plan users who trigger release plan generation see the upgrade toast, not a generic error toast, and Sentry has no new `TasksUpgradeRequiredError` events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging and handling for release plan generation and task operations. When operations fail due to locked plans, locked workspaces, or subscription limits, users receive specific upgrade prompts; all other failures display clearer error information.

* **Chores**
  * Updated Next.js server configuration for improved deployment and module compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->