### PR TITLE
fix(i18n): migrate 6 ad-hoc currency patterns to canonical formatters (JOV-2168)

### DIFF
--- a/apps/web/app/investor-portal/_components/FundraiseProgress.tsx
+++ b/apps/web/app/investor-portal/_components/FundraiseProgress.tsx
@@ -1,24 +1,9 @@
+import { formatCompactUsd } from '@/lib/utils/format-number';
+
 interface FundraiseProgressProps {
   readonly raiseTarget: number;
   readonly committedAmount: number;
   readonly investorCount: number;
-}
-
-/**
- * Format cents to human-readable dollar amount.
- * $500, $25K, $1.2M, etc.
- */
-function formatAmount(cents: number): string {
-  const dollars = cents / 100;
-  if (dollars >= 1_000_000) {
-    const m = dollars / 1_000_000;
-    return m % 1 === 0 ? `$${m}M` : `$${m.toFixed(1)}M`;
-  }
-  if (dollars >= 1_000) {
-    const k = dollars / 1_000;
-    return k % 1 === 0 ? `$${k}K` : `$${k.toFixed(1)}K`;
-  }
-  return `$${Math.round(dollars).toLocaleString()}`;
 }
 
 /**
@@ -38,16 +23,17 @@ export function FundraiseProgress({
     <div className='flex flex-1 flex-col gap-1.5'>
       {/* Progress bar — 4px thin, accent fill */}
       <progress
-        className='h-1 w-full appearance-none overflow-hidden rounded-full [&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-[var(--color-accent)] [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-bar]:bg-[var(--color-bg-surface-2)] [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-[var(--color-accent)] [&::-webkit-progress-value]:transition-all'
+        className='h-1 w-full appearance-none overflow-hidden rounded-full [&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-[var(--color-accent)] [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-bar]:bg-[var(--color-bg-surface-2)] [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-[var(--color-accent)] [&::-webkit-progress-value]:transition-colors'
         style={{ background: 'var(--color-bg-surface-2)' }}
         value={percentage}
         max={100}
-        aria-label={`${formatAmount(committedAmount)} of ${formatAmount(raiseTarget)} committed`}
+        aria-label={`${formatCompactUsd(committedAmount)} of ${formatCompactUsd(raiseTarget)} committed`}
       />
 
       {/* Text */}
       <p className='text-[length:var(--text-xs)] font-medium text-[var(--color-text-tertiary-token)]'>
-        {formatAmount(committedAmount)} / {formatAmount(raiseTarget)} committed
+        {formatCompactUsd(committedAmount)} / {formatCompactUsd(raiseTarget)}{' '}
+        committed
         {investorCount > 0 &&
           ` · ${investorCount} investor${investorCount === 1 ? '' : 's'}`}
       </p>

--- a/apps/web/components/molecules/PaySelector.tsx
+++ b/apps/web/components/molecules/PaySelector.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AmountSelector } from '@/components/atoms/AmountSelector';
 import { SocialIcon } from '@/components/atoms/SocialIcon';
 import { cn } from '@/lib/utils';
+import { formatDollarAmount } from '@/lib/utils/format-number';
 
 type PaySelectorPresentation = 'default' | 'drawer';
 
@@ -22,7 +23,7 @@ interface PaySelectorProps {
 }
 
 function formatAmountForScreenReader(amount: number): string {
-  return amount % 1 === 0 ? `$${amount}` : `$${amount.toFixed(2)}`;
+  return formatDollarAmount(amount);
 }
 
 function sanitizeCurrencyInput(value: string): string {
@@ -178,7 +179,7 @@ export function PaySelector({
                         aria-label={`Select ${formatAmountForScreenReader(amount)} payment amount`}
                         onClick={() => handleAmountSelect(idx)}
                         className={cn(
-                          'flex h-[92px] items-center justify-center rounded-[22px] border text-center transition-[border-color,background-color,color,transform] duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+                          'flex h-[92px] items-center justify-center rounded-[22px] border text-center transition-[border-color,background-color,color,transform] duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
                           isSelected
                             ? 'border-white bg-white text-[#121216] shadow-[0_20px_40px_rgba(255,255,255,0.08)]'
                             : 'border-white/10 bg-white/[0.02] text-white hover:border-white/18 hover:bg-white/[0.04]'
@@ -198,7 +199,7 @@ export function PaySelector({
               <button
                 type='button'
                 onClick={handleCustomToggle}
-                className='inline-flex items-center gap-1.5 text-[13px] font-medium tracking-[-0.015em] text-white/52 transition-colors duration-200 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
+                className='inline-flex items-center gap-1.5 text-[13px] font-medium tracking-[-0.015em] text-white/52 transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
                 aria-pressed={customMode}
                 aria-controls='pay-selector-heading'
               >
@@ -212,7 +213,7 @@ export function PaySelector({
             type='button'
             onClick={handleContinue}
             disabled={isLoading || !canContinue}
-            className='flex h-[50px] w-full items-center justify-center rounded-full bg-white px-5 text-[16px] font-semibold tracking-[-0.025em] text-[#101013] transition-[opacity,transform] duration-200 hover:opacity-96 disabled:cursor-not-allowed disabled:opacity-50'
+            className='flex h-[50px] w-full items-center justify-center rounded-full bg-white px-5 text-[16px] font-semibold tracking-[-0.025em] text-[#101013] transition-[opacity,transform] duration-subtle hover:opacity-96 disabled:cursor-not-allowed disabled:opacity-50'
             aria-label={`${primaryLabel} for ${formatAmountForScreenReader(selectedAmount)}`}
           >
             {isLoading ? 'Processing...' : primaryLabel}
@@ -223,14 +224,14 @@ export function PaySelector({
               <button
                 type='button'
                 onClick={() => setShowOtherOptions(open => !open)}
-                className='flex w-full items-center gap-3.5 text-[13px] font-medium tracking-[-0.015em] text-white/48 transition-colors duration-200 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
+                className='flex w-full items-center gap-3.5 text-[13px] font-medium tracking-[-0.015em] text-white/48 transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent'
                 aria-expanded={showOtherOptions}
               >
                 <span className='h-px flex-1 bg-white/8' />
                 <span>{otherPaymentOptionsLabel}</span>
                 <ChevronDown
                   className={cn(
-                    'h-4 w-4 shrink-0 transition-transform duration-200',
+                    'h-4 w-4 shrink-0 transition-transform duration-subtle',
                     showOtherOptions && 'rotate-180'
                   )}
                 />
@@ -239,7 +240,7 @@ export function PaySelector({
 
               <div
                 className={cn(
-                  'overflow-hidden transition-[max-height,opacity] duration-200',
+                  'overflow-hidden transition-[max-height,opacity] duration-subtle',
                   showOtherOptions
                     ? 'max-h-24 opacity-100'
                     : 'max-h-0 opacity-0'
@@ -250,7 +251,7 @@ export function PaySelector({
                     type='button'
                     onClick={handleContinue}
                     disabled={isLoading || !canContinue}
-                    className='flex h-[48px] w-full items-center justify-center gap-3 rounded-full border border-white/10 bg-white/[0.02] px-5 text-[14px] font-medium tracking-[-0.015em] text-white transition-[border-color,background-color,opacity] duration-200 hover:border-white/16 hover:bg-white/[0.04] disabled:cursor-not-allowed disabled:opacity-50'
+                    className='flex h-[48px] w-full items-center justify-center gap-3 rounded-full border border-white/10 bg-white/[0.02] px-5 text-[14px] font-medium tracking-[-0.015em] text-white transition-[border-color,background-color,opacity] duration-subtle hover:border-white/16 hover:bg-white/[0.04] disabled:cursor-not-allowed disabled:opacity-50'
                     aria-label={`Continue with ${paymentLabel} for ${formatAmountForScreenReader(selectedAmount)}`}
                   >
                     {paymentLabel === 'Venmo' ? (
@@ -310,7 +311,7 @@ export function PaySelector({
 
       <Button
         onClick={handleContinue}
-        className='mt-4 flex w-full items-center justify-center gap-2.5 rounded-full border border-white/8 text-[15px] font-semibold tracking-[-0.015em] text-btn-primary-foreground shadow-none transition-[opacity,border-color] duration-200 hover:border-white/14'
+        className='mt-4 flex w-full items-center justify-center gap-2.5 rounded-full border border-white/8 text-[15px] font-semibold tracking-[-0.015em] text-btn-primary-foreground shadow-none transition-[opacity,border-color] duration-subtle hover:border-white/14'
         size='lg'
         disabled={isLoading}
         variant='primary'

--- a/apps/web/components/organisms/billing/PlanComparisonSection.tsx
+++ b/apps/web/components/organisms/billing/PlanComparisonSection.tsx
@@ -9,6 +9,7 @@ import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { UpgradeButton } from '@/components/molecules/UpgradeButton';
 import type { PricingOption } from '@/lib/queries';
 import { cn } from '@/lib/utils';
+import { formatAmountNoCents } from '@/lib/utils/format-number';
 import {
   LINEAR_EASE,
   PLAN_FEATURES,
@@ -125,7 +126,7 @@ export function PlanComparisonSection({
           let priceDisplay: string | null = '$0';
           if (planKey !== 'free') {
             priceDisplay = priceOption
-              ? `$${(priceOption.amount / 100).toFixed(0)}`
+              ? formatAmountNoCents(priceOption.amount)
               : null;
           }
 
@@ -140,7 +141,7 @@ export function PlanComparisonSection({
             <ContentSurfaceCard
               key={planKey}
               className={cn(
-                'relative flex flex-col overflow-hidden p-0 transition-[border-color,box-shadow] duration-200',
+                'relative flex flex-col overflow-hidden p-0 transition-[border-color,box-shadow] duration-subtle',
                 isCurrentPlan && 'border-(--linear-border-focus)'
               )}
             >

--- a/apps/web/lib/chat/system-prompt.ts
+++ b/apps/web/lib/chat/system-prompt.ts
@@ -1,3 +1,5 @@
+import { formatAmount } from '@/lib/utils/format-number';
+
 interface ArtistContext {
   readonly displayName: string;
   readonly username: string;
@@ -57,8 +59,6 @@ export function buildSystemPrompt(
     knowledgeContext?: string;
   }
 ): string {
-  const formatMoney = (cents: number) => `$${(cents / 100).toFixed(2)}`;
-
   return `You are Jovie, an AI music career assistant. You help independent artists understand their data and make smart career decisions.
 
 ## About This Artist
@@ -82,8 +82,8 @@ ${buildDiscographySection(releases)}
 ## Tipping & Monetization
 - **Tip Link Clicks:** ${context.tippingStats.tipClicks}
 - **Tips Received:** ${context.tippingStats.tipsSubmitted}
-- **Total Earned:** ${formatMoney(context.tippingStats.totalReceivedCents)}
-- **This Month:** ${formatMoney(context.tippingStats.monthReceivedCents)}
+- **Total Earned:** ${formatAmount(context.tippingStats.totalReceivedCents)}
+- **This Month:** ${formatAmount(context.tippingStats.monthReceivedCents)}
 ${buildKnowledgeSection(options?.knowledgeContext)}
 ## Entity & Skill Tokens
 Messages may contain structured tokens the UI attached before sending:

--- a/apps/web/lib/utils/format-number.ts
+++ b/apps/web/lib/utils/format-number.ts
@@ -28,3 +28,72 @@ export function formatAmount(amountCents: number, currency = 'USD'): string {
     currency: currency.toUpperCase(),
   }).format(amountCents / 100);
 }
+
+/**
+ * Format an amount in cents as a whole-dollar currency string (no cents shown).
+ *
+ * Useful for displaying plan prices like "$39" or "$149" where fractional cents
+ * are not meaningful.
+ *
+ * @param amountCents - The amount in cents (e.g., 3900 = $39)
+ * @returns Formatted currency string with no decimal places (e.g., "$39")
+ */
+export function formatAmountNoCents(amountCents: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(amountCents / 100);
+}
+
+/**
+ * Format a dollar amount (not cents) as a locale-aware currency string.
+ *
+ * Shows two decimal places for fractional amounts, zero decimals for whole numbers.
+ * Client-safe (no server-only imports).
+ *
+ * @param dollarAmount - The amount in dollars (e.g., 5.5 = $5.50, 10 = $10)
+ * @returns Formatted currency string (e.g., "$5.50", "$10")
+ */
+export function formatDollarAmount(dollarAmount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: dollarAmount % 1 === 0 ? 0 : 2,
+    minimumFractionDigits: dollarAmount % 1 === 0 ? 0 : 2,
+  }).format(dollarAmount);
+}
+
+/**
+ * Format an amount in cents as a compact human-readable string.
+ *
+ * Uses M/K suffixes for large values: $1.2M, $500K, $250.
+ * Whole-number M/K values omit the decimal: $2M, $500K.
+ *
+ * @param amountCents - The amount in cents (e.g., 100000000 = $1,000,000)
+ * @returns Compact currency string (e.g., "$1.2M", "$500K", "$250")
+ */
+export function formatCompactUsd(amountCents: number): string {
+  const dollars = amountCents / 100;
+  if (dollars >= 1_000_000) {
+    const m = dollars / 1_000_000;
+    const formatted = new Intl.NumberFormat('en-US', {
+      maximumFractionDigits: m % 1 === 0 ? 0 : 1,
+      minimumFractionDigits: 0,
+    }).format(m);
+    return `$${formatted}M`;
+  }
+  if (dollars >= 1_000) {
+    const k = dollars / 1_000;
+    const formatted = new Intl.NumberFormat('en-US', {
+      maximumFractionDigits: k % 1 === 0 ? 0 : 1,
+      minimumFractionDigits: 0,
+    }).format(k);
+    return `$${formatted}K`;
+  }
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(Math.round(dollars));
+}


### PR DESCRIPTION
## Summary

Resolves all `@jovie/no-ad-hoc-currency` ESLint violations deferred from the rule introduction (JOV-2168).

**New helpers added to `lib/utils/format-number.ts`:**
- `formatAmountNoCents(cents)` — whole-dollar display (e.g. `$39`) via `Intl.NumberFormat`
- `formatDollarAmount(dollars)` — client-safe dollar-value formatter, 0 or 2 decimals depending on fractional part
- `formatCompactUsd(cents)` — M/K suffix compact display (e.g. `$1.2M`) via `Intl.NumberFormat`

**Violations fixed (5 errors resolved):**

| File | Line | Old | New |
|------|------|-----|-----|
| `lib/chat/system-prompt.ts` | 60 | Local `formatMoney` lambda with `toFixed(2)` | Imported `formatAmount(cents)` |
| `components/organisms/billing/PlanComparisonSection.tsx` | 128 | `` `$${(priceOption.amount / 100).toFixed(0)}` `` | `formatAmountNoCents(priceOption.amount)` |
| `components/molecules/PaySelector.tsx` | 25 | `` `$${amount.toFixed(2)}` `` | `formatDollarAmount(amount)` (client-safe, from `format-number`) |
| `app/investor-portal/_components/FundraiseProgress.tsx` | 15, 19 | Local `formatAmount` function with `toFixed` | `formatCompactUsd(cents)` from shared lib |

Note: `OnboardingCheckoutClient.tsx` was listed in the original issue but was already fixed prior to this PR (commented out).

**Also fixed:** Pre-existing `no-raw-motion-values` warnings in all touched files (`duration-200` → `duration-subtle`, `transition-all` → `transition-colors`) to satisfy the `--max-warnings=0` pre-commit gate.

## Verification

- ESLint: 0 errors, 0 warnings across all modified files
- TypeScript: clean
- Biome: clean
- Pre-commit hooks: all passed
- Pre-push hooks: all passed (full lint + typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)