### PR TITLE
fix(infra): wire chat_jank_monitor gate; downgrade circuit breaker errors

### DIFF
--- a/apps/web/app/api/audience/visit/route.ts
+++ b/apps/web/app/api/audience/visit/route.ts
@@ -715,12 +715,12 @@ export async function POST(request: NextRequest) {
         { headers: NO_STORE_HEADERS }
       );
     } catch (error) {
-      logger.error('[Audience Visit] Optional persistence degraded', {
+      logger.warn('[Audience Visit] Optional persistence degraded', {
         error,
         fingerprint,
         profileId,
       });
-      await captureError('Audience visit persistence degraded', error, {
+      await captureWarning('Audience visit persistence degraded', error, {
         route: '/api/audience/visit',
         method: 'POST',
         fingerprint,

--- a/apps/web/lib/flags/contracts.ts
+++ b/apps/web/lib/flags/contracts.ts
@@ -164,7 +164,6 @@ export type DesignV1AliasFlagName = (typeof DESIGN_V1_ALIAS_FLAGS)[number];
 export const LOCAL_DEFAULT_ONLY_FLAGS = new Set<AppFlagName>([
   'PLAYLIST_ENGINE', // early prototype; not ready for remote control
   'ALBUM_ART_GENERATION', // default-true feature; controlled by Statsig experiment separately in usage, not a gate
-  'CHAT_JANK_MONITOR', // monitoring-only flag; was missing Statsig gate (bug fixed in #8271 — kept here for local-dev override support)
   'RELEASE_PLAN_DEMO', // YC wedge demo page; on by default in dev/preview, off in production — see registry.ts for env-aware decide()
   'DESIGN_V1', // permanently enabled — new design is the only design
   'SHELL_CHAT_V1', // alias of DESIGN_V1 — permanently enabled

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -35,7 +35,7 @@ import {
   isTestAuthBypassEnabled,
   resolveTestBypassUserId,
 } from '@/lib/auth/test-mode';
-import { captureError } from '@/lib/error-tracking';
+import { captureError, captureWarning } from '@/lib/error-tracking';
 import {
   analyzeHost,
   categorizePath,
@@ -532,7 +532,7 @@ async function handleRequest(req: NextRequest, userId: string | null) {
           '/waitlist'
         );
         if (waitlistRewrite === null) {
-          await captureError(
+          await captureWarning(
             '[proxy] Redirect loop circuit breaker triggered',
             new Error('Redirect loop detected'),
             {
@@ -566,7 +566,7 @@ async function handleRequest(req: NextRequest, userId: string | null) {
             APP_ROUTES.START
           );
           if (rewriteRes === null) {
-            await captureError(
+            await captureWarning(
               '[proxy] Redirect loop circuit breaker triggered',
               new Error('Redirect loop detected'),
               {

--- a/apps/web/tests/unit/api/audience/visit.test.ts
+++ b/apps/web/tests/unit/api/audience/visit.test.ts
@@ -86,6 +86,7 @@ describe('POST /api/audience/visit', () => {
     mockCheckVisitRateLimit.mockResolvedValue({ success: true });
     mockDoesColumnExist.mockResolvedValue(true);
     mockDoesTableExist.mockResolvedValue(true);
+    mockCaptureWarning.mockReset();
     mockCaptureError.mockReset();
   });
 
@@ -653,7 +654,7 @@ describe('POST /api/audience/visit', () => {
     expect(data.success).toBe(true);
     expect(data.degraded).toBe(true);
     expect(data.fingerprint).toBeDefined();
-    expect(mockCaptureError).toHaveBeenCalledWith(
+    expect(mockCaptureWarning).toHaveBeenCalledWith(
       'Audience visit persistence degraded',
       expect.any(Error),
       expect.objectContaining({
@@ -972,6 +973,11 @@ describe('POST /api/audience/visit', () => {
             onConflictDoNothing: vi.fn().mockReturnValue({
               returning: vi.fn().mockResolvedValue([{ id: 'inserted_member' }]),
             }),
+          }),
+        }),
+        update: vi.fn().mockReturnValue({
+          set: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue(undefined),
           }),
         }),
       });

--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -32,6 +32,7 @@ const mocks = vi.hoisted(() => ({
       (countryCode: string | null, regionCode?: string | null) => boolean
     >(),
   captureError: vi.fn(),
+  captureWarning: vi.fn(),
   ensureSentry: vi.fn().mockResolvedValue(undefined),
   buildContentSecurityPolicy: vi.fn().mockReturnValue("default-src 'self'"),
   buildContentSecurityPolicyReportOnly: vi.fn().mockReturnValue(null),
@@ -69,6 +70,7 @@ vi.mock('@/lib/cookies/consent-regions', () => ({
 }));
 vi.mock('@/lib/error-tracking', () => ({
   captureError: mocks.captureError,
+  captureWarning: mocks.captureWarning,
 }));
 vi.mock('@/lib/sentry/ensure', () => ({
   ensureSentry: mocks.ensureSentry,
@@ -935,7 +937,7 @@ describe('proxy.ts middleware', () => {
       const res = await callMiddleware(req);
 
       expect(res.status).toBeLessThan(300);
-      expect(mocks.captureError).toHaveBeenCalledWith(
+      expect(mocks.captureWarning).toHaveBeenCalledWith(
         expect.stringContaining('circuit breaker'),
         expect.any(Error),
         expect.objectContaining({ redirectCount: 3 })
@@ -997,7 +999,7 @@ describe('proxy.ts middleware', () => {
       const res = await callMiddleware(req);
 
       expect(res.status).toBeLessThan(300);
-      expect(mocks.captureError).toHaveBeenCalledWith(
+      expect(mocks.captureWarning).toHaveBeenCalledWith(
         expect.stringContaining('circuit breaker'),
         expect.any(Error),
         expect.objectContaining({ target: '/waitlist', redirectCount: 3 })


### PR DESCRIPTION
## Summary

- **JOV-1969**: Remove `CHAT_JANK_MONITOR` from `LOCAL_DEFAULT_ONLY_FLAGS` — the flag already has a Statsig gate mapping in `APP_FLAG_TO_STATSIG_GATE` since #8271. Keeping it in the exemption set was inaccurate and could confuse future maintainers. The code change is a cleanup; the 10% rollout itself requires a **tim-action** in the Statsig dashboard (see below).
- **JOV-2454**: Downgrade proxy.ts redirect-loop circuit breaker from `captureError` → `captureWarning`. The breaker triggers correctly — logging a successful intervention as an error inflated Sentry counts unnecessarily.
- **JOV-2509**: Downgrade `apps/web/app/api/audience/visit/route.ts` persistence-degraded path from `captureError` → `captureWarning`. The handler already returns `{ success: true, degraded: true }` — it's a graceful fallback, not an error.

## Tim-action required

**JOV-1969 is not fully resolved by this PR.** The code correctly reads from the `chat_jank_monitor` Statsig gate. To activate monitoring for 10% of users, open the Statsig dashboard and set the `chat_jank_monitor` gate to 10% rollout. The code change here removes the stale exemption that was masking this gap.

## Files changed

- `apps/web/lib/flags/contracts.ts` — remove `CHAT_JANK_MONITOR` from `LOCAL_DEFAULT_ONLY_FLAGS`
- `apps/web/proxy.ts` — circuit breaker calls use `captureWarning`; add import
- `apps/web/app/api/audience/visit/route.ts` — persistence-degraded uses `captureWarning` + `logger.warn`
- `apps/web/tests/unit/middleware/proxy-behavioral.test.ts` — update circuit breaker assertions to `captureWarning`

## Test plan

- [x] `vitest run tests/unit/middleware/proxy-behavioral.test.ts` — 71 tests passed
- [x] `vitest run tests/unit/lib/flag-registration-guardrail.test.ts` — 2 tests passed
- [x] Typecheck passes
- [x] Biome passes
- [x] Pre-push hooks pass (biome, typecheck, lint, proxy-guard)

<!-- linear-issue-id:JOV-1969,JOV-2509,JOV-2454 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Downgraded error reporting to warnings for degraded persistence in the audience visit endpoint
  * Downgraded error reporting to warnings for redirect-loop prevention in proxy middleware

* **Chores**
  * Moved a flag out of local-only defaults so it follows standard gate resolution

* **Tests**
  * Updated unit tests and mocks to expect warnings instead of errors for the adjusted behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->