### PR TITLE
fix(test): replace readonly Array<T> with ReadonlyArray<T> in TabBar test

### DIFF
--- a/apps/web/tests/unit/components/tab-bar/TabBar.test.tsx
+++ b/apps/web/tests/unit/components/tab-bar/TabBar.test.tsx
@@ -53,7 +53,7 @@ vi.mock('@jovie/ui', () => ({
   useTabOverflow: ({
     options,
   }: {
-    readonly options: readonly Array<{ value: string; label: ReactNode }>;
+    readonly options: ReadonlyArray<{ value: string; label: ReactNode }>;
   }) => ({
     containerRef: { current: null },
     moreButtonRef: { current: null },


### PR DESCRIPTION
## Summary

esbuild (used by Vitest) rejects the `readonly` modifier on generic `Array<T>` form — it only accepts `readonly T[]` and `ReadonlyArray<T>`.

This was introduced by the `readonly-component-props` ESLint auto-fix in a recent PR and broke the **Unit Tests** CI check across all open PRs (#9461, #9473, #9475).

**Fix:** `readonly Array<{ value: string; label: ReactNode }>` → `ReadonlyArray<{ value: string; label: ReactNode }>` in `TabBar.test.tsx:56`

🤖 Generated with [Claude Code](https://claude.com/claude-code)