### PR TITLE
feat(admin): consolidate admin overview shell

### DIFF
--- a/apps/web/app/app/(shell)/admin/_components/AdminScoreboardSection.tsx
+++ b/apps/web/app/app/(shell)/admin/_components/AdminScoreboardSection.tsx
@@ -1,5 +1,6 @@
 import { ChevronRight } from 'lucide-react';
 import { WeeklyTrendChart } from '@/components/features/admin/WeeklyTrendChart';
+import { AnalyticsCard } from '@/components/features/dashboard/atoms/AnalyticsCard';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSectionHeaderSkeleton } from '@/components/molecules/ContentSectionHeaderSkeleton';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
@@ -22,32 +23,11 @@ function formatWowGrowth(rate: number | null): {
   label: string;
   className: string;
 } {
-  if (rate === null)
-    return { label: '\u2014', className: 'text-tertiary-token' };
-  if (!Number.isFinite(rate))
-    return { label: '+\u221E', className: 'text-success' };
+  if (rate === null) return { label: '—', className: 'text-tertiary-token' };
+  if (!Number.isFinite(rate)) return { label: '+∞', className: 'text-success' };
   const pct = (rate * 100).toFixed(1);
   if (rate >= 0) return { label: `+${pct}%`, className: 'text-success' };
   return { label: `${pct}%`, className: 'text-error' };
-}
-
-interface HeroMetricProps {
-  readonly label: string;
-  readonly value: string;
-  readonly ariaLabel: string;
-  readonly subtitle?: React.ReactNode;
-}
-
-function HeroMetric({ label, value, ariaLabel, subtitle }: HeroMetricProps) {
-  return (
-    <section aria-label={ariaLabel}>
-      <p className='text-[36px] font-bold leading-none tracking-[-0.03em] text-primary-token tabular-nums'>
-        {value}
-      </p>
-      <p className='mt-1.5 text-app font-book text-tertiary-token'>{label}</p>
-      {subtitle}
-    </section>
-  );
 }
 
 interface FunnelStepProps {
@@ -77,10 +57,70 @@ function FunnelStep({
           {count.toLocaleString('en-US')}
         </p>
         <p className='mt-0.5 text-xs text-tertiary-token'>
-          {conversionRate === null ? '\u2014' : formatPercent(conversionRate)}
+          {conversionRate === null ? '—' : formatPercent(conversionRate)}
         </p>
       </li>
     </>
+  );
+}
+
+/**
+ * Renders the hero metric row (MRR / paying customers / WoW growth) used at
+ * the top of the admin Overview. Exported so `/app/admin/page.tsx` can mount
+ * it inside `AdminPage`'s `hero` slot.
+ */
+export async function AdminHeroMetrics() {
+  const metrics = await getAdminFunnelMetrics();
+
+  const mrrDisplay = metrics.stripeAvailable ? formatUsd(metrics.mrrUsd) : '—';
+  const payingDisplay = metrics.stripeAvailable
+    ? metrics.payingCustomers.toLocaleString('en-US')
+    : '—';
+  const wowGrowth = formatWowGrowth(metrics.wowGrowthRate);
+
+  return (
+    <div className='grid grid-cols-3 gap-4' data-testid='admin-hero-metrics'>
+      <AnalyticsCard
+        variant='hero'
+        title='Monthly Recurring Revenue'
+        value={mrrDisplay}
+        ariaLabel={`Monthly recurring revenue: ${mrrDisplay}`}
+      />
+      <AnalyticsCard
+        variant='hero'
+        title='Paying Customers'
+        value={payingDisplay}
+        ariaLabel={`Paying customers: ${payingDisplay}`}
+      />
+      <AnalyticsCard
+        variant='hero'
+        title='WoW Growth'
+        value={wowGrowth.label}
+        ariaLabel={`Week over week growth: ${wowGrowth.label}`}
+      >
+        {wowGrowth.label === '—' ? null : (
+          <span className={wowGrowth.className}>vs. prior week</span>
+        )}
+      </AnalyticsCard>
+    </div>
+  );
+}
+
+export function AdminHeroMetricsSkeleton() {
+  // Each hero column reserves ~75px so the row matches its resolved height
+  // and no layout shift occurs when Suspense resolves (per .claude/rules/ui.md).
+  return (
+    <div
+      className='grid grid-cols-3 gap-4'
+      data-testid='admin-hero-metrics-skeleton'
+    >
+      {['mrr', 'customers', 'growth'].map(key => (
+        <div key={key} className='min-h-[75px]'>
+          <div className='h-9 w-24 animate-pulse rounded-md bg-surface-1' />
+          <div className='mt-1.5 h-4 w-32 animate-pulse rounded-md bg-surface-1' />
+        </div>
+      ))}
+    </div>
   );
 }
 
@@ -98,14 +138,6 @@ export async function AdminScoreboardSection() {
     metrics.claimClicks7d === 0 &&
     metrics.signups7d === 0 &&
     metrics.paidConversions7d === 0;
-
-  const mrrDisplay = metrics.stripeAvailable
-    ? formatUsd(metrics.mrrUsd)
-    : '\u2014';
-  const payingDisplay = metrics.stripeAvailable
-    ? metrics.payingCustomers.toLocaleString('en-US')
-    : '\u2014';
-  const wowGrowth = formatWowGrowth(metrics.wowGrowthRate);
 
   // Funnel steps — left to right
   const funnelSteps: Array<{
@@ -139,34 +171,10 @@ export async function AdminScoreboardSection() {
 
   return (
     <div className='space-y-4' data-testid='admin-scoreboard'>
-      {/* Hero Metrics — no card wrapper */}
-      <div className='grid grid-cols-3 gap-4'>
-        <HeroMetric
-          label='Monthly Recurring Revenue'
-          value={mrrDisplay}
-          ariaLabel={`Monthly recurring revenue: ${mrrDisplay}`}
-        />
-        <HeroMetric
-          label='Paying Customers'
-          value={payingDisplay}
-          ariaLabel={`Paying customers: ${payingDisplay}`}
-        />
-        <HeroMetric
-          label='WoW Growth'
-          value={wowGrowth.label}
-          ariaLabel={`Week over week growth: ${wowGrowth.label}`}
-          subtitle={
-            <p className={`mt-0.5 text-app font-book ${wowGrowth.className}`}>
-              {wowGrowth.label === '\u2014' ? '' : 'vs. prior week'}
-            </p>
-          }
-        />
-      </div>
-
       {/* Error state */}
       {metrics.errors.length > 0 && (
         <p className='text-xs text-secondary-token'>
-          {metrics.errors.join(' \u2014 ')}
+          {metrics.errors.join(' — ')}
         </p>
       )}
 
@@ -243,16 +251,6 @@ export async function AdminScoreboardSection() {
 export function AdminScoreboardSectionSkeleton() {
   return (
     <div className='space-y-4' data-testid='admin-scoreboard-skeleton'>
-      {/* Hero skeletons */}
-      <div className='grid grid-cols-3 gap-4'>
-        {['mrr', 'customers', 'growth'].map(key => (
-          <div key={key}>
-            <div className='h-9 w-24 animate-pulse rounded-md bg-surface-1' />
-            <div className='mt-1.5 h-4 w-32 animate-pulse rounded-md bg-surface-1' />
-          </div>
-        ))}
-      </div>
-
       {/* Funnel skeleton */}
       <ContentSurfaceCard className='overflow-hidden p-0'>
         <ContentSectionHeaderSkeleton

--- a/apps/web/app/app/(shell)/admin/_components/index.ts
+++ b/apps/web/app/app/(shell)/admin/_components/index.ts
@@ -19,6 +19,8 @@ export {
   AdminPlatformStatsSectionSkeleton,
 } from './AdminPlatformStatsSection';
 export {
+  AdminHeroMetrics,
+  AdminHeroMetricsSkeleton,
   AdminScoreboardSection,
   AdminScoreboardSectionSkeleton,
 } from './AdminScoreboardSection';

--- a/apps/web/app/app/(shell)/admin/page.tsx
+++ b/apps/web/app/app/(shell)/admin/page.tsx
@@ -1,17 +1,9 @@
-import {
-  Activity,
-  ArrowRight,
-  FolderKanban,
-  ImageIcon,
-  Users,
-} from 'lucide-react';
 import type { Metadata } from 'next';
-import Link from 'next/link';
 import { Suspense } from 'react';
-import { AdminWorkspacePage } from '@/components/features/admin/layout/AdminWorkspacePage';
-import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
-import { APP_ROUTES } from '@/constants/routes';
+import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import {
+  AdminHeroMetrics,
+  AdminHeroMetricsSkeleton,
   AdminKpiSection,
   AdminKpiSectionSkeleton,
   AdminOutreachSection,
@@ -23,129 +15,45 @@ import {
 } from './_components';
 
 export const metadata: Metadata = {
-  title: 'Admin Scoreboard',
+  title: 'Admin Overview',
   description: 'Funnel scoreboard and operator tools.',
 };
 
 export const runtime = 'nodejs';
 
-const overviewCards = [
-  {
-    title: 'People workspace',
-    description:
-      'Waitlist triage, creator management, signed-up users, releases, and feedback in one place.',
-    href: APP_ROUTES.ADMIN_PEOPLE,
-    icon: Users,
-  },
-  {
-    title: 'Growth workspace',
-    description:
-      'Lead discovery, outreach queues, campaign review, and ingest operations.',
-    href: APP_ROUTES.ADMIN_GROWTH,
-    icon: FolderKanban,
-  },
-  {
-    title: 'Operational activity',
-    description: 'Recent actions, admin interventions, and platform events.',
-    href: APP_ROUTES.ADMIN_ACTIVITY,
-    icon: Activity,
-  },
-  {
-    title: 'Utility tools',
-    description:
-      'Investor pipeline and screenshot QA tools live here when you need them.',
-    href: APP_ROUTES.ADMIN_SCREENSHOTS,
-    icon: ImageIcon,
-  },
-] as const;
-
-type AdminView = 'scoreboard' | 'workspaces';
-
-const adminTabs = [
-  { value: 'scoreboard' as const, label: 'Scoreboard' },
-  { value: 'workspaces' as const, label: 'Workspaces' },
-] as const;
-
-function isAdminView(value: string): value is AdminView {
-  return value === 'scoreboard' || value === 'workspaces';
-}
-
-interface AdminPageProps {
-  readonly searchParams: Promise<Record<string, string | string[] | undefined>>;
-}
-
-export default async function AdminPage({ searchParams }: AdminPageProps) {
-  const params = await searchParams;
-  const rawView = typeof params.view === 'string' ? params.view : 'scoreboard';
-  const view: AdminView = isAdminView(rawView) ? rawView : 'scoreboard';
-
+export default function AdminOverviewPage() {
   return (
-    <AdminWorkspacePage
-      title={view === 'scoreboard' ? 'Scoreboard' : 'Workspaces'}
+    <AdminPage
+      title='Overview'
       description='Funnel scoreboard and operator tools.'
-      primaryParam='view'
-      primaryValue={view}
-      primaryOptions={adminTabs}
       testId='admin-overview-page'
-      viewTestId='admin-overview-view'
-    >
-      {view === 'scoreboard' ? (
-        <Suspense fallback={<AdminScoreboardSectionSkeleton />}>
-          <AdminScoreboardSection />
+      viewTestId='admin-dashboard-content'
+      hero={
+        <Suspense fallback={<AdminHeroMetricsSkeleton />}>
+          <AdminHeroMetrics />
         </Suspense>
-      ) : (
-        <div
-          className='flex h-full flex-col gap-4'
-          data-testid='admin-dashboard-content'
-        >
-          <div className='grid gap-4 lg:grid-cols-2 xl:grid-cols-4'>
-            {overviewCards.map(card => (
-              <Link
-                key={card.href}
-                href={card.href}
-                className='group block h-full'
-              >
-                <ContentSurfaceCard className='flex h-full flex-col justify-between gap-4 p-4 transition-colors hover:bg-surface-0'>
-                  <div className='space-y-3'>
-                    <div className='flex h-10 w-10 items-center justify-center rounded-full bg-surface-0 text-secondary-token'>
-                      <card.icon className='h-4 w-4' aria-hidden='true' />
-                    </div>
-                    <div>
-                      <p className='text-sm font-semibold tracking-[-0.01em] text-primary-token'>
-                        {card.title}
-                      </p>
-                      <p className='mt-1 text-app leading-[19px] text-secondary-token'>
-                        {card.description}
-                      </p>
-                    </div>
-                  </div>
-                  <span className='inline-flex items-center gap-2 text-xs font-semibold text-secondary-token transition-colors group-hover:text-primary-token'>
-                    Open
-                    <ArrowRight className='h-3.5 w-3.5' aria-hidden='true' />
-                  </span>
-                </ContentSurfaceCard>
-              </Link>
-            ))}
-          </div>
+      }
+    >
+      <Suspense fallback={<AdminScoreboardSectionSkeleton />}>
+        <AdminScoreboardSection />
+      </Suspense>
 
-          <Suspense fallback={<AdminKpiSectionSkeleton />}>
-            <AdminKpiSection />
+      <Suspense fallback={<AdminKpiSectionSkeleton />}>
+        <AdminKpiSection />
+      </Suspense>
+
+      <div className='grid min-h-0 flex-1 gap-4 lg:grid-cols-3'>
+        <div className='lg:col-span-2'>
+          <Suspense fallback={<AdminOutreachSectionSkeleton />}>
+            <AdminOutreachSection />
           </Suspense>
-
-          <div className='grid min-h-0 flex-1 gap-4 lg:grid-cols-3'>
-            <div className='lg:col-span-2'>
-              <Suspense fallback={<AdminOutreachSectionSkeleton />}>
-                <AdminOutreachSection />
-              </Suspense>
-            </div>
-            <div>
-              <Suspense fallback={<AdminUsageSectionSkeleton />}>
-                <AdminUsageSection />
-              </Suspense>
-            </div>
-          </div>
         </div>
-      )}
-    </AdminWorkspacePage>
+        <div>
+          <Suspense fallback={<AdminUsageSectionSkeleton />}>
+            <AdminUsageSection />
+          </Suspense>
+        </div>
+      </div>
+    </AdminPage>
   );
 }

--- a/apps/web/components/features/admin/layout/AdminPage.tsx
+++ b/apps/web/components/features/admin/layout/AdminPage.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from 'react';
+import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
+import { PageContent, PageShell } from '@/components/organisms/PageShell';
+import {
+  type WorkspaceTabOption,
+  WorkspaceTabsSurface,
+} from '@/components/organisms/WorkspaceTabsSurface';
+import { cn } from '@/lib/utils';
+
+export interface AdminPageTabsConfig<
+  TPrimary extends string,
+  TSecondary extends string = never,
+> {
+  readonly param: string;
+  readonly value: TPrimary;
+  readonly options: readonly WorkspaceTabOption<TPrimary>[];
+  readonly secondaryParam?: string;
+  readonly secondaryValue?: TSecondary | null;
+  readonly secondaryOptions?: readonly WorkspaceTabOption<TSecondary>[];
+  readonly clearOnPrimaryChange?: readonly string[];
+}
+
+export interface AdminPageProps<
+  TPrimary extends string = string,
+  TSecondary extends string = never,
+> {
+  readonly title: string;
+  readonly description?: string;
+  /**
+   * Hero slot renders flush above the first section, no card wrapper. Use for
+   * "default alive" metrics (MRR, paying customers, runway, etc.) that should
+   * lead the page. When `hero` and `tabs` are both provided, the tabs surface
+   * renders headerless to avoid stacking competing titles.
+   */
+  readonly hero?: ReactNode;
+  readonly tabs?: AdminPageTabsConfig<TPrimary, TSecondary>;
+  readonly actions?: ReactNode;
+  readonly testId: string;
+  readonly viewTestId?: string;
+  readonly children: ReactNode;
+  readonly className?: string;
+}
+
+/**
+ * Canonical shell for every admin page.
+ *
+ * Replaces the legacy `AdminToolPage` (header-in-card) and `AdminWorkspacePage`
+ * (always-on tabs) wrappers. Provides:
+ * - Flat page header (title + description + actions), no `ContentSurfaceCard`
+ *   wrapper — the route already lives inside the dashboard shell.
+ * - Optional `hero` slot directly under the header for primary metrics.
+ * - Optional `tabs` slot that delegates to `WorkspaceTabsSurface`. When `hero`
+ *   is also present, the surface's title/description is suppressed
+ *   (`headerless={true}`).
+ * - `space-y-6` outer rhythm matching the canonical dashboard.
+ *
+ * Use this for new admin pages. Existing pages can migrate incrementally — the
+ * legacy `AdminToolPage`/`AdminWorkspacePage` wrappers re-export this shell.
+ */
+export function AdminPage<
+  TPrimary extends string = string,
+  TSecondary extends string = never,
+>({
+  title,
+  description,
+  hero,
+  tabs,
+  actions,
+  testId,
+  viewTestId,
+  children,
+  className,
+}: Readonly<AdminPageProps<TPrimary, TSecondary>>) {
+  const headerless = Boolean(hero);
+
+  return (
+    <PageShell>
+      <PageContent noPadding>
+        <div
+          className={cn(
+            'space-y-6 px-(--linear-app-content-padding-x) py-(--linear-app-content-padding-y)',
+            className
+          )}
+          data-testid={testId}
+        >
+          <ContentSectionHeader
+            title={title}
+            subtitle={description}
+            actions={actions}
+            variant='plain'
+            density='compact'
+            className='min-h-0'
+            actionsClassName='shrink-0'
+          />
+
+          {hero ? <div data-testid='admin-page-hero'>{hero}</div> : null}
+
+          {tabs ? (
+            <WorkspaceTabsSurface
+              title={title}
+              description={description ?? ''}
+              primaryParam={tabs.param}
+              primaryValue={tabs.value}
+              primaryOptions={tabs.options}
+              secondaryParam={tabs.secondaryParam}
+              secondaryValue={tabs.secondaryValue}
+              secondaryOptions={tabs.secondaryOptions}
+              clearOnPrimaryChange={tabs.clearOnPrimaryChange}
+              headerless={headerless}
+            >
+              <div className='space-y-4' data-testid={viewTestId}>
+                {children}
+              </div>
+            </WorkspaceTabsSurface>
+          ) : (
+            <div className='space-y-4' data-testid={viewTestId}>
+              {children}
+            </div>
+          )}
+        </div>
+      </PageContent>
+    </PageShell>
+  );
+}

--- a/apps/web/components/features/admin/layout/AdminToolPage.tsx
+++ b/apps/web/components/features/admin/layout/AdminToolPage.tsx
@@ -1,8 +1,5 @@
 import type { ReactNode } from 'react';
-import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
-import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
-import { PageContent, PageShell } from '@/components/organisms/PageShell';
-import { cn } from '@/lib/utils';
+import { AdminPage } from './AdminPage';
 
 interface AdminToolPageProps {
   readonly title?: string;
@@ -13,6 +10,15 @@ interface AdminToolPageProps {
   readonly className?: string;
 }
 
+/**
+ * @deprecated Use `AdminPage` from `@/components/features/admin/layout/AdminPage` instead.
+ *
+ * `AdminToolPage` is preserved as a thin shim so the 17+ existing admin pages
+ * continue to render while they migrate. New code MUST import `AdminPage`
+ * directly. The deprecation ratchet
+ * (`apps/web/tests/unit/admin-shell-deprecation.test.ts`) enforces that the
+ * importer count of this module only decreases.
+ */
 export function AdminToolPage({
   title,
   description,
@@ -22,29 +28,14 @@ export function AdminToolPage({
   className,
 }: AdminToolPageProps) {
   return (
-    <PageShell>
-      <PageContent noPadding>
-        <div
-          className={cn(
-            'space-y-4 px-(--linear-app-content-padding-x) py-(--linear-app-content-padding-y)',
-            className
-          )}
-          data-testid={testId}
-        >
-          {title || description ? (
-            <ContentSurfaceCard className='overflow-hidden'>
-              <ContentSectionHeader
-                title={title}
-                subtitle={description}
-                actions={actions}
-                className='min-h-0 px-(--linear-app-header-padding-x) py-3'
-                actionsClassName='shrink-0'
-              />
-            </ContentSurfaceCard>
-          ) : null}
-          {children}
-        </div>
-      </PageContent>
-    </PageShell>
+    <AdminPage
+      title={title ?? ''}
+      description={description}
+      actions={actions}
+      testId={testId}
+      className={className}
+    >
+      {children}
+    </AdminPage>
   );
 }

--- a/apps/web/components/features/admin/layout/AdminWorkspacePage.tsx
+++ b/apps/web/components/features/admin/layout/AdminWorkspacePage.tsx
@@ -1,10 +1,6 @@
 import type { ReactNode } from 'react';
-import { PageContent, PageShell } from '@/components/organisms/PageShell';
-import {
-  type WorkspaceTabOption,
-  WorkspaceTabsSurface,
-} from '@/components/organisms/WorkspaceTabsSurface';
-import { cn } from '@/lib/utils';
+import type { WorkspaceTabOption } from '@/components/organisms/WorkspaceTabsSurface';
+import { AdminPage } from './AdminPage';
 
 interface AdminWorkspacePageProps<
   TPrimary extends string,
@@ -26,6 +22,16 @@ interface AdminWorkspacePageProps<
   readonly className?: string;
 }
 
+/**
+ * @deprecated Use `AdminPage` from `@/components/features/admin/layout/AdminPage`
+ * with the `tabs` prop instead.
+ *
+ * Preserved as a thin shim so the 4+ existing tabbed admin pages continue to
+ * render while they migrate. New code MUST import `AdminPage` directly. The
+ * deprecation ratchet
+ * (`apps/web/tests/unit/admin-shell-deprecation.test.ts`) enforces that the
+ * importer count of this module only decreases.
+ */
 export function AdminWorkspacePage<
   TPrimary extends string,
   TSecondary extends string = never,
@@ -46,33 +52,24 @@ export function AdminWorkspacePage<
   className,
 }: Readonly<AdminWorkspacePageProps<TPrimary, TSecondary>>) {
   return (
-    <PageShell>
-      <PageContent noPadding>
-        <div
-          className={cn(
-            'space-y-4 px-(--linear-app-content-padding-x) py-(--linear-app-content-padding-y)',
-            className
-          )}
-          data-testid={testId}
-        >
-          <WorkspaceTabsSurface
-            title={title}
-            description={description}
-            primaryParam={primaryParam}
-            primaryValue={primaryValue}
-            primaryOptions={primaryOptions}
-            secondaryParam={secondaryParam}
-            secondaryValue={secondaryValue}
-            secondaryOptions={secondaryOptions}
-            clearOnPrimaryChange={clearOnPrimaryChange}
-            actions={actions}
-          >
-            <div className='space-y-4' data-testid={viewTestId}>
-              {children}
-            </div>
-          </WorkspaceTabsSurface>
-        </div>
-      </PageContent>
-    </PageShell>
+    <AdminPage<TPrimary, TSecondary>
+      title={title}
+      description={description}
+      actions={actions}
+      testId={testId}
+      viewTestId={viewTestId}
+      className={className}
+      tabs={{
+        param: primaryParam,
+        value: primaryValue,
+        options: primaryOptions,
+        secondaryParam,
+        secondaryValue,
+        secondaryOptions,
+        clearOnPrimaryChange,
+      }}
+    >
+      {children}
+    </AdminPage>
   );
 }

--- a/apps/web/components/features/dashboard/atoms/AnalyticsCard.tsx
+++ b/apps/web/components/features/dashboard/atoms/AnalyticsCard.tsx
@@ -1,6 +1,9 @@
 import { BarChart3 } from 'lucide-react';
 import type { ComponentType, ReactNode, SVGProps } from 'react';
 import { ContentMetricCard } from '@/components/molecules/ContentMetricCard';
+import { cn } from '@/lib/utils';
+
+export type AnalyticsCardVariant = 'card' | 'hero';
 
 interface AnalyticsCardProps {
   readonly title: string;
@@ -9,9 +12,18 @@ interface AnalyticsCardProps {
   readonly order?: string;
   readonly icon?: ComponentType<SVGProps<SVGSVGElement>>;
   readonly iconClassName?: string;
+  /** Accepted for call-site compatibility; not currently rendered. */
   readonly iconChipClassName?: string;
   readonly headerRight?: ReactNode;
   readonly children?: ReactNode;
+  /**
+   * Visual treatment.
+   * - `card` (default): wrapped `ContentMetricCard` — for compact KPI grids.
+   * - `hero`: flat `<section>` (no card wrapper), 36px bold number — for
+   *   page-leading "default alive" metrics like MRR, ARR, or paying customers.
+   */
+  readonly variant?: AnalyticsCardVariant;
+  readonly ariaLabel?: string;
 }
 
 const FallbackIcon = BarChart3;
@@ -26,7 +38,26 @@ export function AnalyticsCard({
   iconChipClassName,
   headerRight,
   children,
+  variant = 'card',
+  ariaLabel,
 }: AnalyticsCardProps) {
+  if (variant === 'hero') {
+    const subtitle = children ?? metadata;
+    return (
+      <section className={order} aria-label={ariaLabel ?? `${title} metric`}>
+        <p className='text-[36px] font-bold leading-none tracking-[-0.03em] text-primary-token tabular-nums'>
+          {value}
+        </p>
+        <p className='mt-1.5 text-app font-book text-tertiary-token'>{title}</p>
+        {subtitle ? (
+          <div className='mt-0.5 text-app font-book text-tertiary-token'>
+            {subtitle}
+          </div>
+        ) : null}
+      </section>
+    );
+  }
+
   const IconToRender = IconComponent ?? FallbackIcon;
 
   return (
@@ -37,13 +68,13 @@ export function AnalyticsCard({
       value={value}
       subtitle={children ?? metadata}
       icon={IconToRender}
-      iconClassName={iconClassName ?? 'text-accent-token'}
+      iconClassName={cn('text-accent-token', iconClassName)}
       headerRight={headerRight}
       headerClassName='gap-2'
       labelClassName='text-app text-secondary-token tracking-[-0.01em]'
       valueClassName='text-3xl font-semibold tracking-[-0.022em]'
       subtitleClassName='text-app text-tertiary-token'
-      aria-label={`${title} metric`}
+      aria-label={ariaLabel ?? `${title} metric`}
     />
   );
 }

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -14,6 +14,7 @@ import {
   LayoutDashboard,
   Library as LibraryIcon,
   Lock,
+  type LucideIcon,
   MailCheck,
   Music,
   PieChart,
@@ -183,7 +184,11 @@ export const settingsNavigation: NavItem[] = [
 
 /** Admin settings item — shown only to admin users */
 
-const adminIconById = {
+// Exhaustive map of AdminWorkspaceId → icon. Typed as Record so adding a new
+// workspace id to `AdminWorkspaceId` without a matching icon entry fails
+// typecheck — silent `undefined` returns would otherwise show up as missing
+// icons in the admin sidebar at runtime.
+const adminIconById: Record<AdminWorkspaceId, LucideIcon> = {
   overview: LayoutDashboard,
   ops: Gauge,
   people: Users,
@@ -194,7 +199,7 @@ const adminIconById = {
   screenshots: ImageIcon,
   costs: Banknote,
   share_studio: Share2,
-} as const;
+};
 
 function buildAdminNavigationItems(
   ids: readonly AdminWorkspaceId[]

--- a/apps/web/components/organisms/WorkspaceTabsSurface.tsx
+++ b/apps/web/components/organisms/WorkspaceTabsSurface.tsx
@@ -28,6 +28,13 @@ interface WorkspaceTabsSurfaceProps<
   readonly secondaryOptions?: readonly WorkspaceTabOption<TSecondary>[];
   readonly clearOnPrimaryChange?: readonly string[];
   readonly actions?: ReactNode;
+  /**
+   * Suppress the title/description row inside the surface card. The parent
+   * shell is rendering its own page header (e.g. `AdminPage` with a `hero`
+   * slot). Tab controls still render. Used to avoid stacking competing
+   * headers above tabbed admin workspaces.
+   */
+  readonly headerless?: boolean;
   readonly children: ReactNode;
 }
 
@@ -45,6 +52,7 @@ export function WorkspaceTabsSurface<
   secondaryOptions,
   clearOnPrimaryChange = [],
   actions,
+  headerless = false,
   children,
 }: Readonly<WorkspaceTabsSurfaceProps<TPrimary, TSecondary>>) {
   const pathname = usePathname();
@@ -98,18 +106,34 @@ export function WorkspaceTabsSurface<
   const shouldShowPrimaryControl = primaryOptions.length > 1;
   const shouldShowTabControls = shouldShowPrimaryControl || secondaryControl;
 
+  // When the parent renders its own header (e.g. AdminPage hero) we suppress
+  // the surface's title/description but keep the tab card. If there are also
+  // no tabs to show, omit the card entirely — the surface has nothing to
+  // contribute beyond the children.
+  if (headerless && !shouldShowTabControls) {
+    return <div className='space-y-4'>{children}</div>;
+  }
+
   return (
     <div className='space-y-4'>
       <ContentSurfaceCard className='overflow-hidden'>
-        <ContentSectionHeader
-          title={title}
-          subtitle={description}
-          actions={actions}
-          className='min-h-0 px-(--linear-app-header-padding-x) py-3'
-          actionsClassName='shrink-0'
-        />
+        {headerless ? null : (
+          <ContentSectionHeader
+            title={title}
+            subtitle={description}
+            actions={actions}
+            className='min-h-0 px-(--linear-app-header-padding-x) py-3'
+            actionsClassName='shrink-0'
+          />
+        )}
         {shouldShowTabControls ? (
-          <div className='border-t border-subtle px-(--linear-app-content-padding-x) py-3'>
+          <div
+            className={
+              headerless
+                ? 'px-(--linear-app-content-padding-x) py-3'
+                : 'border-t border-subtle px-(--linear-app-content-padding-x) py-3'
+            }
+          >
             <div className='flex flex-col gap-3'>
               {shouldShowPrimaryControl ? (
                 <AppSegmentControl

--- a/apps/web/tests/unit/admin-shell-deprecation.test.ts
+++ b/apps/web/tests/unit/admin-shell-deprecation.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Admin shell deprecation ratchet (JOV-2525).
+ *
+ * `AdminToolPage` and `AdminWorkspacePage` are `@deprecated` shims that
+ * re-export the canonical `AdminPage`. They exist only so the ~20 admin pages
+ * that still import them can continue to render while they migrate.
+ *
+ * This test enforces that the importer count of the deprecated wrappers
+ * monotonically decreases. Each follow-up Linear issue that migrates a route
+ * is required to decrement `MAX_DEPRECATED_IMPORTERS` by one. When the count
+ * reaches zero, both shim files can be deleted.
+ *
+ * If this test fails because the count went UP, you added a new import of
+ * `AdminToolPage`/`AdminWorkspacePage`. Don't. Use `AdminPage` directly:
+ *
+ *   import { AdminPage } from '@/components/features/admin/layout/AdminPage';
+ *
+ * If this test fails because the count went DOWN (because you successfully
+ * migrated a route), great — decrement `MAX_DEPRECATED_IMPORTERS` in this
+ * file as part of the same PR.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const APPS_WEB_ROOT = resolve(__dirname, '../..');
+
+// Files that ARE the deprecated wrappers themselves — they reference their own
+// names and obviously don't count as importers.
+const SELF_REFERENCING = new Set([
+  resolve(APPS_WEB_ROOT, 'components/features/admin/layout/AdminToolPage.tsx'),
+  resolve(
+    APPS_WEB_ROOT,
+    'components/features/admin/layout/AdminWorkspacePage.tsx'
+  ),
+]);
+
+// Skip directories that aren't worth walking — keeps the test fast and avoids
+// false positives from generated artifacts or third-party code.
+const SKIP_DIRS = new Set([
+  'node_modules',
+  '.next',
+  '.turbo',
+  'dist',
+  'build',
+  '.git',
+]);
+
+// Match actual ES module imports of the deprecated wrappers. Matches both
+// named imports (`import { AdminToolPage }`) and renamed imports
+// (`import { AdminToolPage as X }`). Plain mentions in comments, JSDoc, or
+// test assertions don't count — those names appear deliberately in this very
+// test file, in shell-normalization specs that lock in the deprecated usage,
+// and in the canonical `AdminPage.tsx` JSDoc.
+const DEPRECATED_IMPORT_PATTERN =
+  /import\s*(?:type\s+)?\{[^}]*\b(?:AdminToolPage|AdminWorkspacePage)\b[^}]*\}\s*from/;
+
+function walk(dir: string, results: string[]): void {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    let stats: ReturnType<typeof statSync>;
+    try {
+      stats = statSync(full);
+    } catch {
+      continue;
+    }
+    if (stats.isDirectory()) {
+      walk(full, results);
+    } else if (
+      stats.isFile() &&
+      (entry.endsWith('.ts') || entry.endsWith('.tsx'))
+    ) {
+      results.push(full);
+    }
+  }
+}
+
+function countImporters(): { files: string[]; count: number } {
+  const all: string[] = [];
+  walk(APPS_WEB_ROOT, all);
+
+  const importers: string[] = [];
+  for (const file of all) {
+    if (SELF_REFERENCING.has(file)) continue;
+    let source: string;
+    try {
+      source = readFileSync(file, 'utf8');
+    } catch {
+      continue;
+    }
+    if (DEPRECATED_IMPORT_PATTERN.test(source)) {
+      importers.push(file);
+    }
+  }
+  return { files: importers, count: importers.length };
+}
+
+/**
+ * RATCHET — only ever decrement this value.
+ *
+ * Update the date and Linear issue ID when you decrement. Current ceiling
+ * established by JOV-2525 on 2026-05-21: 16 importers remain after PR-1
+ * migrates `/app/admin/page.tsx` to `AdminPage` directly.
+ */
+const MAX_DEPRECATED_IMPORTERS = 16;
+
+describe('admin shell deprecation ratchet', () => {
+  it(`has at most ${MAX_DEPRECATED_IMPORTERS} importers of AdminToolPage/AdminWorkspacePage`, () => {
+    const { files, count } = countImporters();
+    if (count > MAX_DEPRECATED_IMPORTERS) {
+      throw new Error(
+        `Importer count went UP. Found ${count} importers (ceiling: ${MAX_DEPRECATED_IMPORTERS}). ` +
+          `Use AdminPage from '@/components/features/admin/layout/AdminPage' for new admin pages. ` +
+          `Importers:\n${files.map(f => `  - ${f.replace(`${APPS_WEB_ROOT}/`, '')}`).join('\n')}`
+      );
+    }
+    expect(count).toBeLessThanOrEqual(MAX_DEPRECATED_IMPORTERS);
+  });
+
+  it('reminds maintainers to decrement the ratchet when migrations land', () => {
+    const { count } = countImporters();
+    // If the count has dropped below the ceiling, the ratchet is stale.
+    // Decrement MAX_DEPRECATED_IMPORTERS in the same PR that migrated the
+    // route.
+    expect(count).toBeGreaterThanOrEqual(
+      Math.max(0, MAX_DEPRECATED_IMPORTERS - 4),
+      `Ratchet ceiling (${MAX_DEPRECATED_IMPORTERS}) is more than 4 ahead of actual ` +
+        `count (${count}). Decrement MAX_DEPRECATED_IMPORTERS in admin-shell-deprecation.test.ts.`
+    );
+  });
+});

--- a/apps/web/tests/unit/components/admin/AdminScoreboardSection.test.tsx
+++ b/apps/web/tests/unit/components/admin/AdminScoreboardSection.test.tsx
@@ -25,9 +25,11 @@ vi.mock('@/lib/admin/funnel-metrics', () => ({
   getAllTimeFunnelTotals: hoisted.getAllTimeFunnelTotals,
 }));
 
-const { AdminScoreboardSection, AdminScoreboardSectionSkeleton } = await import(
-  '@/app/app/(shell)/admin/_components/AdminScoreboardSection'
-);
+const {
+  AdminHeroMetrics,
+  AdminScoreboardSection,
+  AdminScoreboardSectionSkeleton,
+} = await import('@/app/app/(shell)/admin/_components/AdminScoreboardSection');
 
 function buildDefaultMetrics(
   overrides: Partial<AdminFunnelMetrics> = {}
@@ -103,10 +105,8 @@ const defaultTrend = [
 describe('AdminScoreboardSection', () => {
   it('renders hero metrics with correct formatting', async () => {
     hoisted.getAdminFunnelMetrics.mockResolvedValue(buildDefaultMetrics());
-    hoisted.getWeeklyFunnelTrend.mockResolvedValue(defaultTrend);
-    hoisted.getAllTimeFunnelTotals.mockResolvedValue(buildDefaultTotals());
 
-    const Component = await AdminScoreboardSection();
+    const Component = await AdminHeroMetrics();
     render(Component);
 
     // MRR
@@ -155,10 +155,8 @@ describe('AdminScoreboardSection', () => {
     hoisted.getAdminFunnelMetrics.mockResolvedValue(
       buildDefaultMetrics({ wowGrowthRate: -0.05 })
     );
-    hoisted.getWeeklyFunnelTrend.mockResolvedValue(defaultTrend);
-    hoisted.getAllTimeFunnelTotals.mockResolvedValue(buildDefaultTotals());
 
-    const Component = await AdminScoreboardSection();
+    const Component = await AdminHeroMetrics();
     render(Component);
 
     expect(screen.getByText('-5.0%')).toBeInTheDocument();
@@ -168,10 +166,8 @@ describe('AdminScoreboardSection', () => {
     hoisted.getAdminFunnelMetrics.mockResolvedValue(
       buildDefaultMetrics({ wowGrowthRate: null })
     );
-    hoisted.getWeeklyFunnelTrend.mockResolvedValue(defaultTrend);
-    hoisted.getAllTimeFunnelTotals.mockResolvedValue(buildDefaultTotals());
 
-    const Component = await AdminScoreboardSection();
+    const Component = await AdminHeroMetrics();
     render(Component);
 
     // The WoW Growth hero metric should show em dash


### PR DESCRIPTION
## Summary
- Add a canonical AdminPage shell with hero, tabs, and action slots for admin pages.
- Rework /app/admin around a top-down operator hierarchy: hero MRR/customer/growth metrics, funnel/trend, KPIs, then activation and usage detail.
- Keep AdminToolPage/AdminWorkspacePage as deprecated shims and add a ratchet test for importer reduction.

## Screenshot
- Local capture: .context/screenshots/admin-overview-pr1.png

## Verification
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm --filter @jovie/web exec vitest run tests/unit/components/admin/AdminScoreboardSection.test.tsx tests/unit/admin-shell-deprecation.test.ts
- pnpm biome check apps/web/app/app/(shell)/admin apps/web/components/features/admin/layout apps/web/components/features/dashboard/atoms/AnalyticsCard.tsx apps/web/components/features/dashboard/dashboard-nav/config.ts apps/web/components/organisms/WorkspaceTabsSurface.tsx apps/web/tests/unit/admin-shell-deprecation.test.ts apps/web/tests/unit/components/admin/AdminScoreboardSection.test.tsx
- git push pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint
- Local screenshot via admin test-auth bypass at http://localhost:3000/app/admin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin page now displays hero metrics prominently at the top
  * Analytics cards support a new hero visual variant for enhanced prominence

* **Refactor**
  * Admin interface layout reorganized with improved component structure
  * Admin dashboard sections now load independently with better performance handling

* **Tests**
  * Added enforcement tests to track deprecated component usage

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->