### PR TITLE
feat(chat): add contextual shell action cards

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -19,6 +19,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChatEntityPanelProvider } from '@/app/app/(shell)/chat/ChatEntityPanelContext';
 import { ChatEntityRightPanelHost } from '@/app/app/(shell)/chat/ChatEntityRightPanelHost';
+import type { DashboardData } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 import {
   type PreviewPanelLink,
@@ -28,6 +29,7 @@ import {
 import { LoadingSpinner } from '@/components/atoms/LoadingSpinner';
 import { ChatWorkspaceSurface } from '@/components/jovie/ChatWorkspaceSurface';
 import { JovieChat } from '@/components/jovie/JovieChat';
+import type { ChatActionCard } from '@/components/jovie/types';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { DRAWER_HEADER_ICON_BUTTON_CLASSNAME } from '@/components/molecules/drawer-header/DrawerHeaderActions';
 import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
@@ -61,6 +63,91 @@ type WelcomeChatBootstrapState =
   | 'scheduled'
   | 'done'
   | 'failed';
+
+type ChatActionProfile = NonNullable<DashboardData['selectedProfile']>;
+type ChatActionProfileCompletionSteps =
+  DashboardData['profileCompletion']['steps'];
+
+function normalizeCompletionPercentage(percentage: number): number {
+  if (!Number.isFinite(percentage)) {
+    return 0;
+  }
+
+  return Math.min(100, Math.max(0, Math.round(percentage)));
+}
+
+function profileDisplayName(profile: ChatActionProfile): string {
+  return (
+    profile.displayName?.trim() || profile.username?.trim() || 'this artist'
+  );
+}
+
+function hasProfileValue(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasConnectedMusicCatalog(profile: ChatActionProfile): boolean {
+  return (
+    hasProfileValue(profile.spotifyUrl) ||
+    hasProfileValue(profile.appleMusicUrl) ||
+    hasProfileValue(profile.youtubeUrl) ||
+    hasProfileValue(profile.spotifyId) ||
+    hasProfileValue(profile.appleMusicId) ||
+    hasProfileValue(profile.youtubeMusicId)
+  );
+}
+
+function buildChatActionCards({
+  profile,
+  profileCompletionPercentage,
+  profileCompletionSteps,
+}: {
+  readonly profile: ChatActionProfile;
+  readonly profileCompletionPercentage: number;
+  readonly profileCompletionSteps: ChatActionProfileCompletionSteps;
+}): readonly ChatActionCard[] {
+  const artistName = profileDisplayName(profile);
+  const completion = normalizeCompletionPercentage(profileCompletionPercentage);
+  const nextSetupStep = profileCompletionSteps[0]?.label;
+
+  if (!hasConnectedMusicCatalog(profile)) {
+    return [
+      {
+        id: 'connect-music-catalog',
+        title: 'Connect Your Music Catalog',
+        body: 'Add Spotify, Apple Music, or YouTube Music so Jovie can plan from real releases.',
+        actionLabel: 'Plan Setup',
+        prompt: `Help me connect my music catalog for ${artistName}. Use the current profile context and give me the next setup step.`,
+      },
+    ];
+  }
+
+  if (completion < 100) {
+    const body = nextSetupStep
+      ? `Your profile is ${completion}% complete. Next setup step: ${nextSetupStep}.`
+      : `Your profile is ${completion}% complete. Tighten the missing setup steps before the next share.`;
+
+    return [
+      {
+        id: 'finish-artist-profile',
+        title: 'Complete Your Artist Profile',
+        body,
+        actionLabel: 'Review Gaps',
+        prompt: `Review my artist profile for ${artistName}. Prioritize the missing setup steps and tell me the single highest-impact update to make next.`,
+      },
+    ];
+  }
+
+  return [
+    {
+      id: 'plan-next-move',
+      title: 'Plan Your Next Move',
+      body: `Use ${artistName}'s profile and catalog context to choose one concrete action for this week.`,
+      actionLabel: 'Plan Move',
+      prompt: `Use my artist profile, music catalog, and dashboard context for ${artistName} to recommend the single most useful action I should take this week. Include the first step.`,
+    },
+  ];
+}
 
 export function shouldRetryWelcomeChatBootstrap(
   status: number | null
@@ -178,6 +265,7 @@ export function ChatPageClient({
     needsOnboarding,
     dashboardLoadError,
     isFirstSession: dashboardIsFirstSession,
+    profileCompletion,
   } = useDashboardData();
   const { setPreviewData } = usePreviewPanelData();
   const { isOpen: isPreviewPanelOpen, open: openPreviewPanel } =
@@ -436,6 +524,18 @@ export function ChatPageClient({
   // We pass it as initialQuery so JovieChat can auto-submit it.
   const initialQuery =
     !env.IS_E2E && !initialQueryHandled && !conversationId ? rawQuery : null;
+
+  const chatActionCards = useMemo(
+    () =>
+      activeProfile
+        ? buildChatActionCards({
+            profile: activeProfile,
+            profileCompletionPercentage: profileCompletion.percentage,
+            profileCompletionSteps: profileCompletion.steps,
+          })
+        : [],
+    [activeProfile, profileCompletion.percentage, profileCompletion.steps]
+  );
 
   // Mark as handled after first render so re-renders don't re-submit
   useEffect(() => {
@@ -714,6 +814,7 @@ export function ChatPageClient({
             avatarUrl={activeProfile.avatarUrl}
             username={activeProfile.username ?? undefined}
             isFirstSession={isFirstSession || dashboardIsFirstSession || false}
+            actionCards={chatActionCards}
           />
         </ChatWorkspaceSurface>
       </ErrorBoundary>

--- a/apps/web/app/app/(shell)/chat/loading.tsx
+++ b/apps/web/app/app/(shell)/chat/loading.tsx
@@ -4,7 +4,7 @@ import { LoadingSkeleton } from '@/components/molecules/LoadingSkeleton';
 
 /**
  * Chat page loading skeleton.
- * Matches the JovieChat empty state layout: centered heading, input, and suggested prompts.
+ * Matches the JovieChat empty state layout: centered heading, action card, and input.
  */
 export default function ChatLoading() {
   return (
@@ -19,6 +19,16 @@ export default function ChatLoading() {
           <div className='mx-auto flex w-full max-w-[34rem] flex-1 flex-col items-center justify-center gap-5'>
             {/* Heading skeleton */}
             <Skeleton className='h-6 w-48' rounded='lg' />
+
+            {/* Action card skeleton */}
+            <div className='w-full max-w-[32rem] rounded-[18px] border border-white/[0.05] bg-(--linear-app-content-surface) px-7 py-6 shadow-[0_16px_40px_-24px_rgba(0,0,0,0.45)]'>
+              <Skeleton className='h-4 w-56' rounded='lg' />
+              <Skeleton className='mt-3 h-3 w-full' rounded='lg' />
+              <Skeleton className='mt-2 h-3 w-4/5' rounded='lg' />
+              <div className='mt-6 flex justify-end'>
+                <Skeleton className='h-7 w-24 rounded-full' rounded='full' />
+              </div>
+            </div>
 
             {/* Input area skeleton */}
             <div className='w-full max-w-[35rem] space-y-2'>
@@ -48,13 +58,6 @@ export default function ChatLoading() {
                     <LoadingSkeleton height='h-4' width='w-4' rounded='full' />
                   </button>
                 </div>
-              </div>
-
-              {/* Suggested prompts skeleton */}
-              <div className='flex flex-wrap justify-center gap-2 pt-1'>
-                <Skeleton className='h-8 w-28 rounded-full' rounded='full' />
-                <Skeleton className='h-8 w-24 rounded-full' rounded='full' />
-                <Skeleton className='h-8 w-32 rounded-full' rounded='full' />
               </div>
             </div>
           </div>

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -3,17 +3,16 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { ImagePlus } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { SuggestionCard } from '@/components/shell/SuggestionCard';
 import { useAppFlag } from '@/lib/flags/client';
 import { SUPPORTED_IMAGE_MIME_TYPES } from '@/lib/images/config';
-
 import {
   ChatInput,
   ChatMessage,
   ChatMessageSkeleton,
   ErrorDisplay,
   ScrollToBottom,
-  SuggestedPrompts,
 } from './components';
 import { ChatProvidersRegistrar } from './components/ChatProvidersRegistrar';
 import { ChatUsageAlert } from './components/ChatUsageAlert';
@@ -55,7 +54,7 @@ export function JovieChat({
   username,
   displayName,
   isFirstSession = false,
-  latestReleaseTitle,
+  actionCards = [],
 }: JovieChatProps) {
   const initialQuerySubmitted = useRef(false);
   const initialSkillApplied = useRef(false);
@@ -93,24 +92,6 @@ export function JovieChat({
     onConversationCreate,
     username,
   });
-
-  const followUpQuickActions = useMemo(
-    () => [
-      {
-        label: 'Summarize this thread',
-        prompt: 'Summarize this thread in three concise bullets.',
-      },
-      {
-        label: 'What should I do next?',
-        prompt: 'Based on this conversation, what should I do next?',
-      },
-      {
-        label: 'Turn it into a checklist',
-        prompt: 'Turn this conversation into a short checklist I can follow.',
-      },
-    ],
-    []
-  );
 
   // Image attachments for chat messages
   const {
@@ -353,6 +334,7 @@ export function JovieChat({
   } else {
     emptyStateHeading = 'Welcome Back';
   }
+  const primaryActionCard = actionCards[0] ?? null;
 
   return (
     <div
@@ -535,8 +517,6 @@ export function JovieChat({
                 placeholder='Ask a follow-up...'
                 variant='compact'
                 shellChatV1={shellChatV1Enabled}
-                quickActions={followUpQuickActions}
-                onQuickActionSelect={handleSuggestedPromptWithJank}
               />
             </div>
           </div>
@@ -587,13 +567,17 @@ export function JovieChat({
                 {emptyStateHeading}
               </h1>
               <div className='mx-auto flex w-full max-w-[38rem] flex-col items-center gap-3'>
-                <SuggestedPrompts
-                  onSelect={handleSuggestedPromptWithJank}
-                  isFirstSession={isFirstSession}
-                  latestReleaseTitle={latestReleaseTitle}
-                  layout='rail'
-                  dimmed={composerPickerOpen}
-                />
+                {primaryActionCard ? (
+                  <SuggestionCard
+                    title={primaryActionCard.title}
+                    body={primaryActionCard.body}
+                    actionLabel={primaryActionCard.actionLabel}
+                    onAct={() =>
+                      handleSuggestedPromptWithJank(primaryActionCard.prompt)
+                    }
+                    className={composerPickerOpen ? 'opacity-55' : undefined}
+                  />
+                ) : null}
                 {chatError && (
                   <div className='mt-2.5 w-full'>
                     <ErrorDisplay

--- a/apps/web/components/jovie/types.ts
+++ b/apps/web/components/jovie/types.ts
@@ -52,8 +52,16 @@ export interface JovieChatProps {
   readonly username?: string;
   /** Whether the user is in their first post-onboarding chat session */
   readonly isFirstSession?: boolean;
-  /** Optional latest release title for contextual first-session prompts */
-  readonly latestReleaseTitle?: string | null;
+  /** Contextual, production-backed actions surfaced in an empty thread */
+  readonly actionCards?: readonly ChatActionCard[];
+}
+
+export interface ChatActionCard {
+  readonly id: string;
+  readonly title: string;
+  readonly body: string;
+  readonly actionLabel: string;
+  readonly prompt: string;
 }
 
 export type ChatErrorType = 'network' | 'rate_limit' | 'server' | 'unknown';

--- a/apps/web/components/shell/SuggestionCard.tsx
+++ b/apps/web/components/shell/SuggestionCard.tsx
@@ -3,7 +3,7 @@
 import { ArrowRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
-const EASE_CINEMATIC = 'cubic-bezier(0.32, 0.72, 0, 1)';
+const EASE_CINEMATIC = 'var(--ds-motion-cinematic-easing)';
 
 export interface SuggestionCardProps {
   /** Card heading. Renders as an h2 with the cinematic title weight + tracking. */
@@ -59,7 +59,7 @@ export function SuggestionCard({
       style={{
         boxShadow:
           'inset 0 1px 0 rgba(255,255,255,0.04), 0 1px 2px rgba(0,0,0,0.18), 0 16px 40px -16px rgba(0,0,0,0.4)',
-        transition: `transform 240ms ${EASE_CINEMATIC}, box-shadow 240ms ${EASE_CINEMATIC}`,
+        transition: `box-shadow var(--ds-motion-cinematic-duration) ${EASE_CINEMATIC}`,
       }}
     >
       <div className='px-7 py-6'>
@@ -75,7 +75,7 @@ export function SuggestionCard({
             <button
               type='button'
               onClick={onDismiss}
-              className='inline-flex items-center h-7 px-3 rounded-full text-[11.5px] text-quaternary-token hover:text-primary-token hover:bg-surface-1/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token transition-colors duration-150 ease-out'
+              className='inline-flex items-center h-7 px-3 rounded-full text-[11.5px] text-quaternary-token hover:text-primary-token hover:bg-surface-1/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token transition-colors duration-subtle ease-out'
             >
               {dismissLabel}
             </button>
@@ -84,7 +84,7 @@ export function SuggestionCard({
             type='button'
             onClick={onAct}
             disabled={!onAct}
-            className='inline-flex items-center gap-1.5 h-7 px-3.5 rounded-full text-[12px] font-medium bg-white text-black hover:brightness-110 active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 shadow-[0_4px_14px_rgba(0,0,0,0.35),inset_0_1px_0_rgba(255,255,255,0.45)] transition-all duration-150 ease-out'
+            className='inline-flex items-center gap-1.5 h-7 px-3.5 rounded-full text-[12px] font-medium bg-white text-black hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 shadow-[0_4px_14px_rgba(0,0,0,0.35),inset_0_1px_0_rgba(255,255,255,0.45)] transition-colors duration-subtle ease-out'
           >
             {actionLabel}
             <ArrowRight className='h-3 w-3' strokeWidth={2.5} />

--- a/apps/web/tests/e2e/chat-pitch-generation.spec.ts
+++ b/apps/web/tests/e2e/chat-pitch-generation.spec.ts
@@ -1,7 +1,7 @@
 /**
  * E2E: Chat Pitch Generation (paid-tier feature)
  *
- * Tests the "Generate pitches" suggested prompt and the generateReleasePitch
+ * Tests pitch-generation access through the composer and the generateReleasePitch
  * chat tool, which are gated behind paid plans (aiCanUseTools).
  *
  * Run:
@@ -39,7 +39,7 @@ test.describe
     test('pitch suggestion hidden on free plan', async ({ page }) => {
       await ensureSignedInUser(page);
 
-      // Navigate to new chat thread (empty state shows suggested prompts)
+      // Navigate to new chat thread.
       await smokeNavigateWithRetry(page, APP_ROUTES.CHAT, { timeout: 60_000 });
       await waitForHydration(page);
 
@@ -48,7 +48,9 @@ test.describe
       await expect(pitchSuggestion).not.toBeVisible({ timeout: 5_000 });
     });
 
-    test('upgrade to pro enables pitch suggestion', async ({ page }) => {
+    test('upgrade to pro keeps pitch requests available through the composer', async ({
+      page,
+    }) => {
       await ensureSignedInUser(page);
 
       // Upgrade test user to pro
@@ -65,29 +67,13 @@ test.describe
         await waitForHydration(page);
       }
 
-      // The pitch suggestion should now be visible (if profile is complete enough)
-      // Note: The test user may not have 100% profile completion, which hides
-      // suggested prompts entirely. Check for either the suggestion OR the
-      // profile completion card.
+      // Prompt suggestion pills are not part of this shell convergence wave.
+      // The paid tool remains reachable through the composer.
       const pitchSuggestion = page.getByText(/generate pitches/i);
-      const profileCompletionGate = page.getByRole('button', {
-        name: /profile \d+% complete/i,
-      });
       const chatInput = page.getByPlaceholder(/ask jovie|chat message/i);
 
-      // At minimum, the chat input should be present
       await expect(chatInput).toBeVisible({ timeout: 15_000 });
-
-      // If the profile completion card is showing, pitch suggestion is hidden
-      // because SuggestedPrompts only renders when profile is 100% complete.
-      // This is correct behavior — not a test failure.
-      const isProfileIncomplete = await profileCompletionGate
-        .isVisible()
-        .catch(() => false);
-      if (!isProfileIncomplete) {
-        // Profile is complete — pitch suggestion should be visible for pro users
-        await expect(pitchSuggestion).toBeVisible({ timeout: 10_000 });
-      }
+      await expect(pitchSuggestion).not.toBeVisible({ timeout: 5_000 });
     });
 
     test('can type and send a pitch request via chat', async ({ page }) => {

--- a/apps/web/tests/unit/chat/ChatPageClient.test.tsx
+++ b/apps/web/tests/unit/chat/ChatPageClient.test.tsx
@@ -80,6 +80,15 @@ vi.mock('@/contexts/HeaderActionsContext', () => ({
 
 // Track the onTitleChange callback from JovieChat
 let capturedOnTitleChange: ((title: string | null) => void) | undefined;
+let capturedActionCards:
+  | readonly {
+      readonly id: string;
+      readonly title: string;
+      readonly body: string;
+      readonly actionLabel: string;
+      readonly prompt: string;
+    }[]
+  | undefined;
 
 vi.mock('@/components/jovie/JovieChat', () => ({
   JovieChat: (props: {
@@ -89,13 +98,22 @@ vi.mock('@/components/jovie/JovieChat', () => ({
     onTitleChange?: (title: string | null) => void;
     initialQuery?: string;
     isFirstSession?: boolean;
+    actionCards?: readonly {
+      readonly id: string;
+      readonly title: string;
+      readonly body: string;
+      readonly actionLabel: string;
+      readonly prompt: string;
+    }[];
   }) => {
     capturedOnTitleChange = props.onTitleChange;
+    capturedActionCards = props.actionCards;
     return React.createElement('div', {
       'data-testid': 'jovie-chat',
       'data-profile-id': props.profileId,
       'data-conversation-id': props.conversationId ?? '',
       'data-is-first-session': props.isFirstSession ? 'true' : 'false',
+      'data-action-card-count': String(props.actionCards?.length ?? 0),
     });
   },
 }));
@@ -199,6 +217,7 @@ describe('ChatPageClient', () => {
     vi.useRealTimers();
     mockSearchParams = new URLSearchParams();
     capturedOnTitleChange = undefined;
+    capturedActionCards = undefined;
     mockSuccessNotification.mockReset();
     mockErrorNotification.mockReset();
     mockSetPreviewData.mockReset();
@@ -210,6 +229,51 @@ describe('ChatPageClient', () => {
     const { getByTestId } = renderChatPage();
     const chat = getByTestId('jovie-chat');
     expect(chat.getAttribute('data-profile-id')).toBe('profile-1');
+  });
+
+  it('passes a production-backed action card to new chat threads', () => {
+    const { getByTestId } = renderChatPage();
+    const chat = getByTestId('jovie-chat');
+
+    expect(chat.getAttribute('data-action-card-count')).toBe('1');
+    expect(capturedActionCards?.[0]).toEqual(
+      expect.objectContaining({
+        id: 'connect-music-catalog',
+        title: 'Connect Your Music Catalog',
+        actionLabel: 'Plan Setup',
+      })
+    );
+  });
+
+  it('derives music catalog context from selectedProfile fields', () => {
+    const dataWithConnectedMusic: DashboardData = {
+      ...baseDashboardData,
+      hasMusicLinks: false,
+      selectedProfile: {
+        ...baseDashboardData.selectedProfile!,
+        spotifyId: 'spotify-artist-123',
+      } as DashboardData['selectedProfile'],
+      profileCompletion: {
+        percentage: 100,
+        completedCount: 4,
+        totalCount: 4,
+        steps: [],
+        profileIsLive: true,
+      },
+    };
+
+    fastRender(
+      <DashboardDataProvider value={dataWithConnectedMusic}>
+        <ChatPageClient />
+      </DashboardDataProvider>
+    );
+
+    expect(capturedActionCards?.[0]).toEqual(
+      expect.objectContaining({
+        id: 'plan-next-move',
+        title: 'Plan Your Next Move',
+      })
+    );
   });
 
   it('passes conversationId to JovieChat', () => {

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -1,3 +1,4 @@
+import { fireEvent, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { JovieChat } from '@/components/jovie/JovieChat';
@@ -104,13 +105,14 @@ vi.mock('@/components/jovie/components/ChatUsageAlert', () => ({
 
 describe('JovieChat empty state', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mockChatState.messages = [];
     mockChatState.hasMessages = false;
     mockChatState.isLoading = false;
     mockChatState.isSubmitting = false;
   });
 
-  it('renders the minimal welcome state with hero-style heading, pills, and composer', () => {
+  it('renders the minimal welcome state without prompt pills', () => {
     const { getByTestId, getByText, queryByText } = renderWithQueryClient(
       <JovieChat profileId='profile-1' />
     );
@@ -120,14 +122,39 @@ describe('JovieChat empty state', () => {
     expect(queryByText('Jovie Assistant')).toBeNull();
     expect(queryByText('Ask anything or tell Jovie what you need')).toBeNull();
     expect(getByTestId('chat-input')).toBeTruthy();
-    // New hero-style pills sourced from DEFAULT_SUGGESTIONS (mirrors homepage).
-    expect(getByText('Plan a release')).toBeTruthy();
-    expect(getByText('Generate album art')).toBeTruthy();
-    expect(getByText('Pitch playlists')).toBeTruthy();
+    expect(queryByText('Plan a release')).toBeNull();
+    expect(queryByText('Generate album art')).toBeNull();
+    expect(queryByText('Pitch playlists')).toBeNull();
     // Old task-list-style actions should NOT appear — they belong in the profile switcher.
     expect(queryByText('Preview profile')).toBeNull();
     expect(queryByText('Change photo')).toBeNull();
     expect(queryByText('Release link')).toBeNull();
+  });
+
+  it('renders a contextual action card and submits its prompt', () => {
+    renderWithQueryClient(
+      <JovieChat
+        profileId='profile-1'
+        actionCards={[
+          {
+            id: 'connect-music-catalog',
+            title: 'Connect Your Music Catalog',
+            body: 'Add Spotify, Apple Music, or YouTube Music so Jovie can plan from real releases.',
+            actionLabel: 'Plan Setup',
+            prompt: 'Help me connect my music catalog.',
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Connect Your Music Catalog')).toBeTruthy();
+    expect(screen.getByText(/Add Spotify/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /Plan Setup/ }));
+
+    expect(mockChatState.handleSuggestedPrompt).toHaveBeenCalledWith(
+      'Help me connect my music catalog.'
+    );
   });
 
   it('renders first-session greeting for new users', () => {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2526 -->

## Summary
- Removes generic prompt suggestion pills from the `/app/chat` empty state and active-thread quick actions.
- Adds production-backed contextual chat action cards derived from `selectedProfile` DSP fields and `profileCompletion`.
- Keeps action cards on the shared `SuggestionCard` primitive and removes its active scale motion.
- Updates the chat loading skeleton and pitch-generation E2E expectations so pitch access stays composer-driven.

## Verification
- `pnpm biome check --write` on touched files
- `pnpm --filter @jovie/web exec vitest run tests/unit/chat/JovieChat.empty-state.test.tsx tests/unit/chat/ChatPageClient.test.tsx components/shell/SuggestionCard.test.tsx` (30 passed)
- `pnpm biome check` on touched files
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook: staged Biome, ESLint, a11y, local typecheck
- Pre-push hook: repo Biome, web pre-push, Tailwind guard, typecheck, lint
- `pnpm run dev:web:browse` at `http://localhost:3001`
- Screenshot matrix captured under `/tmp/shell-v1-final-20260521b` for `/exp/shell-v1`, `/start`, `/app/chat`, `/app/dashboard/releases`, and `/app/dashboard/tasks` at desktop/tablet/mobile.

## Notes
- `gbrain put shell-v1-final-convergence-20260521` hit an embedding dimension mismatch (`expected 1536 dimensions, not 768`), tracked in Linear as JOV-2528.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat now displays contextual action cards based on your connected music catalogs and profile completion status.

* **Refactor**
  * Replaced suggested prompts with a dynamic action cards system for improved context-awareness.

* **Style**
  * Refined animations and transitions for better visual polish on suggestion elements.

* **Tests**
  * Added comprehensive test coverage for action card functionality and rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->