### PR TITLE
feat(chat): add contextual shell action cards

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -19,6 +19,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChatEntityPanelProvider } from '@/app/app/(shell)/chat/ChatEntityPanelContext';
 import { ChatEntityRightPanelHost } from '@/app/app/(shell)/chat/ChatEntityRightPanelHost';
+import type { DashboardData } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 import {
   type PreviewPanelLink,
@@ -28,6 +29,7 @@ import {
 import { AppIconButton } from '@/components/atoms/AppIconButton';
 import { ChatWorkspaceSurface } from '@/components/jovie/ChatWorkspaceSurface';
 import { JovieChat } from '@/components/jovie/JovieChat';
+import type { ChatActionCard } from '@/components/jovie/types';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
 import { APP_ROUTES } from '@/constants/routes';
@@ -62,6 +64,91 @@ type WelcomeChatBootstrapState =
   | 'scheduled'
   | 'done'
   | 'failed';
+
+type ChatActionProfile = NonNullable<DashboardData['selectedProfile']>;
+type ChatActionProfileCompletionSteps =
+  DashboardData['profileCompletion']['steps'];
+
+function normalizeCompletionPercentage(percentage: number): number {
+  if (!Number.isFinite(percentage)) {
+    return 0;
+  }
+
+  return Math.min(100, Math.max(0, Math.round(percentage)));
+}
+
+function profileDisplayName(profile: ChatActionProfile): string {
+  return (
+    profile.displayName?.trim() || profile.username?.trim() || 'this artist'
+  );
+}
+
+function hasProfileValue(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasConnectedMusicCatalog(profile: ChatActionProfile): boolean {
+  return (
+    hasProfileValue(profile.spotifyUrl) ||
+    hasProfileValue(profile.appleMusicUrl) ||
+    hasProfileValue(profile.youtubeUrl) ||
+    hasProfileValue(profile.spotifyId) ||
+    hasProfileValue(profile.appleMusicId) ||
+    hasProfileValue(profile.youtubeMusicId)
+  );
+}
+
+function buildChatActionCards({
+  profile,
+  profileCompletionPercentage,
+  profileCompletionSteps,
+}: {
+  readonly profile: ChatActionProfile;
+  readonly profileCompletionPercentage: number;
+  readonly profileCompletionSteps: ChatActionProfileCompletionSteps;
+}): readonly ChatActionCard[] {
+  const artistName = profileDisplayName(profile);
+  const completion = normalizeCompletionPercentage(profileCompletionPercentage);
+  const nextSetupStep = profileCompletionSteps[0]?.label;
+
+  if (!hasConnectedMusicCatalog(profile)) {
+    return [
+      {
+        id: 'connect-music-catalog',
+        title: 'Connect Your Music Catalog',
+        body: 'Add Spotify, Apple Music, or YouTube Music so Jovie can plan from real releases.',
+        actionLabel: 'Plan Setup',
+        prompt: `Help me connect my music catalog for ${artistName}. Use the current profile context and give me the next setup step.`,
+      },
+    ];
+  }
+
+  if (completion < 100) {
+    const body = nextSetupStep
+      ? `Your profile is ${completion}% complete. Next setup step: ${nextSetupStep}.`
+      : `Your profile is ${completion}% complete. Tighten the missing setup steps before the next share.`;
+
+    return [
+      {
+        id: 'finish-artist-profile',
+        title: 'Complete Your Artist Profile',
+        body,
+        actionLabel: 'Review Gaps',
+        prompt: `Review my artist profile for ${artistName}. Prioritize the missing setup steps and tell me the single highest-impact update to make next.`,
+      },
+    ];
+  }
+
+  return [
+    {
+      id: 'plan-next-move',
+      title: 'Plan Your Next Move',
+      body: `Use ${artistName}'s profile and catalog context to choose one concrete action for this week.`,
+      actionLabel: 'Plan Move',
+      prompt: `Use my artist profile, music catalog, and dashboard context for ${artistName} to recommend the single most useful action I should take this week. Include the first step.`,
+    },
+  ];
+}
 
 export function shouldRetryWelcomeChatBootstrap(
   status: number | null
@@ -191,6 +278,7 @@ export function ChatPageClient({
     needsOnboarding,
     dashboardLoadError,
     isFirstSession: dashboardIsFirstSession,
+    profileCompletion,
   } = useDashboardData();
   const { setPreviewData } = usePreviewPanelData();
   const { open: openPreviewPanel } = usePreviewPanelState();
@@ -463,6 +551,18 @@ export function ChatPageClient({
   // We pass it as initialQuery so JovieChat can auto-submit it.
   const initialQuery =
     !env.IS_E2E && !initialQueryHandled && !conversationId ? rawQuery : null;
+
+  const chatActionCards = useMemo(
+    () =>
+      activeProfile
+        ? buildChatActionCards({
+            profile: activeProfile,
+            profileCompletionPercentage: profileCompletion.percentage,
+            profileCompletionSteps: profileCompletion.steps,
+          })
+        : [],
+    [activeProfile, profileCompletion.percentage, profileCompletion.steps]
+  );
 
   // Mark as handled after first render so re-renders don't re-submit
   useEffect(() => {
@@ -741,6 +841,7 @@ export function ChatPageClient({
             avatarUrl={activeProfile.avatarUrl}
             username={activeProfile.username ?? undefined}
             isFirstSession={isFirstSession || dashboardIsFirstSession || false}
+            actionCards={chatActionCards}
           />
         </ChatWorkspaceSurface>
       </ErrorBoundary>

--- a/apps/web/app/app/(shell)/chat/loading.tsx
+++ b/apps/web/app/app/(shell)/chat/loading.tsx
@@ -4,7 +4,7 @@ import { LoadingSkeleton } from '@/components/molecules/LoadingSkeleton';
 
 /**
  * Chat page loading skeleton.
- * Matches the JovieChat empty state layout: centered heading, input, and suggested prompts.
+ * Matches the JovieChat empty state layout: centered heading, action card, and input.
  */
 export default function ChatLoading() {
   return (
@@ -19,6 +19,16 @@ export default function ChatLoading() {
           <div className='mx-auto flex w-full max-w-[34rem] flex-1 flex-col items-center justify-center gap-5'>
             {/* Heading skeleton */}
             <Skeleton className='h-6 w-48' rounded='lg' />
+
+            {/* Action card skeleton */}
+            <div className='w-full max-w-[32rem] rounded-[18px] border border-white/[0.05] bg-(--linear-app-content-surface) px-7 py-6 shadow-[0_16px_40px_-24px_rgba(0,0,0,0.45)]'>
+              <Skeleton className='h-4 w-56' rounded='lg' />
+              <Skeleton className='mt-3 h-3 w-full' rounded='lg' />
+              <Skeleton className='mt-2 h-3 w-4/5' rounded='lg' />
+              <div className='mt-6 flex justify-end'>
+                <Skeleton className='h-7 w-24 rounded-full' rounded='full' />
+              </div>
+            </div>
 
             {/* Input area skeleton */}
             <div className='w-full max-w-[35rem] space-y-2'>
@@ -48,13 +58,6 @@ export default function ChatLoading() {
                     <LoadingSkeleton height='h-4' width='w-4' rounded='full' />
                   </button>
                 </div>
-              </div>
-
-              {/* Suggested prompts skeleton */}
-              <div className='flex flex-wrap justify-center gap-2 pt-1'>
-                <Skeleton className='h-8 w-28 rounded-full' rounded='full' />
-                <Skeleton className='h-8 w-24 rounded-full' rounded='full' />
-                <Skeleton className='h-8 w-32 rounded-full' rounded='full' />
               </div>
             </div>
           </div>

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -3,11 +3,11 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { ImagePlus } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { JovieMarkElectric } from '@/components/atoms/JovieMarkElectric';
+import { SuggestionCard } from '@/components/shell/SuggestionCard';
 import { useAppFlag } from '@/lib/flags/client';
 import { SUPPORTED_IMAGE_MIME_TYPES } from '@/lib/images/config';
-import { useChatCapabilitiesQuery } from '@/lib/queries';
 import { cn } from '@/lib/utils';
 
 import { CHAT_COMPOSER_DOCK_CLASSNAME } from './chat-layout';
@@ -17,7 +17,6 @@ import {
   ChatMessageSkeleton,
   ErrorDisplay,
   ScrollToBottom,
-  SuggestedPrompts,
 } from './components';
 import { ChatProvidersRegistrar } from './components/ChatProvidersRegistrar';
 import { ChatUsageAlert } from './components/ChatUsageAlert';
@@ -131,7 +130,7 @@ export function JovieChat({
   username,
   displayName,
   isFirstSession = false,
-  latestReleaseTitle,
+  actionCards = [],
 }: JovieChatProps) {
   const initialQuerySubmitted = useRef(false);
   const initialSkillApplied = useRef(false);
@@ -169,71 +168,6 @@ export function JovieChat({
     onConversationCreate,
     username,
   });
-  const {
-    data: chatCapabilities,
-    isLoading: isLoadingCapabilities,
-    isError: isCapabilitiesError,
-  } = useChatCapabilitiesQuery({
-    profileId,
-    enabled: Boolean(profileId),
-  });
-  const albumArtCapability =
-    chatCapabilities?.tools.albumArt ??
-    (isCapabilitiesError
-      ? {
-          availability: 'unavailable' as const,
-          reason: 'Album art availability could not be verified.',
-          reasonCode: 'CAPABILITY_CHECK_FAILED',
-        }
-      : {
-          availability:
-            profileId && isLoadingCapabilities
-              ? ('unknown' as const)
-              : ('unavailable' as const),
-          reason: profileId
-            ? 'Checking album art availability...'
-            : 'Album art generation needs an artist profile.',
-          reasonCode: profileId ? 'CHECKING' : 'PROFILE_REQUIRED',
-        });
-
-  const followUpQuickActions = useMemo(
-    () => [
-      {
-        label: 'Summarize this thread',
-        prompt: 'Summarize this thread in three concise bullets.',
-      },
-      {
-        label: 'What should I do next?',
-        prompt: 'Based on this conversation, what should I do next?',
-      },
-      {
-        label: 'Turn it into a checklist',
-        prompt: 'Turn this conversation into a short checklist I can follow.',
-      },
-    ],
-    []
-  );
-  const starterQuickActions = useMemo(
-    () => [
-      {
-        label: 'Plan a release',
-        prompt: 'Help me plan my next release.',
-      },
-      {
-        label: 'Generate album art',
-        prompt: 'Generate album art ideas for my next release.',
-      },
-      {
-        label: 'Pitch playlists',
-        prompt: 'Help me pitch this release to playlists.',
-      },
-      {
-        label: 'Send feedback',
-        prompt: '/feedback ',
-      },
-    ],
-    []
-  );
 
   // Image attachments for chat messages
   const {
@@ -499,7 +433,9 @@ export function JovieChat({
 
   const greetingName =
     getFirstNameForGreeting(displayName) ?? getFirstNameForGreeting(username);
-  const showStarterPrompts =
+  const primaryActionCard = actionCards[0] ?? null;
+  const showActionCard =
+    primaryActionCard !== null &&
     input.trim().length === 0 &&
     !composerPickerOpen &&
     (pendingImages?.length ?? 0) === 0 &&
@@ -638,23 +574,18 @@ export function JovieChat({
                       {emptyStateHeading}
                     </h1>
 
-                    <div className='mx-auto flex w-full max-w-[45rem] flex-col items-center gap-3'>
-                      {/* Suggested prompts rail lives in upper morph area (above persistent dock).
-                          Alerts, rate-limit, and errors are unified into the always-rendered dock
-                          below for parity with thread view and to remove duplicate composer chrome. */}
-                      {showStarterPrompts ? (
-                        <div
-                          className='w-full'
-                          data-testid='chat-empty-state-prompt-rail'
-                        >
-                          <SuggestedPrompts
-                            onSelect={handleSuggestedPromptWithJank}
-                            isFirstSession={isFirstSession}
-                            latestReleaseTitle={latestReleaseTitle}
-                            albumArtCapability={albumArtCapability}
-                            layout='rail'
-                          />
-                        </div>
+                    <div className='mx-auto flex w-full max-w-[38rem] flex-col items-center gap-3'>
+                      {showActionCard ? (
+                        <SuggestionCard
+                          title={primaryActionCard.title}
+                          body={primaryActionCard.body}
+                          actionLabel={primaryActionCard.actionLabel}
+                          onAct={() =>
+                            handleSuggestedPromptWithJank(
+                              primaryActionCard.prompt
+                            )
+                          }
+                        />
                       ) : null}
                     </div>
                   </div>
@@ -798,10 +729,6 @@ export function JovieChat({
                 }
                 variant={showThreadView ? 'compact' : 'hero'}
                 shellChatV1={shellChatV1Enabled}
-                quickActions={
-                  showThreadView ? followUpQuickActions : starterQuickActions
-                }
-                onQuickActionSelect={handleSuggestedPromptWithJank}
               />
             </div>
           </div>

--- a/apps/web/components/jovie/types.ts
+++ b/apps/web/components/jovie/types.ts
@@ -55,8 +55,16 @@ export interface JovieChatProps {
   readonly username?: string;
   /** Whether the user is in their first post-onboarding chat session */
   readonly isFirstSession?: boolean;
-  /** Optional latest release title for contextual first-session prompts */
-  readonly latestReleaseTitle?: string | null;
+  /** Contextual, production-backed actions surfaced in an empty thread */
+  readonly actionCards?: readonly ChatActionCard[];
+}
+
+export interface ChatActionCard {
+  readonly id: string;
+  readonly title: string;
+  readonly body: string;
+  readonly actionLabel: string;
+  readonly prompt: string;
 }
 
 export type ChatConversationCreatePhase = 'reserved' | 'completed';

--- a/apps/web/components/shell/SuggestionCard.tsx
+++ b/apps/web/components/shell/SuggestionCard.tsx
@@ -59,7 +59,7 @@ export function SuggestionCard({
       style={{
         boxShadow:
           'inset 0 1px 0 rgba(255,255,255,0.04), 0 1px 2px rgba(0,0,0,0.18), 0 16px 40px -16px rgba(0,0,0,0.4)',
-        transition: `transform var(--ds-motion-cinematic-duration) ${EASE_CINEMATIC}, box-shadow var(--ds-motion-cinematic-duration) ${EASE_CINEMATIC}`,
+        transition: `box-shadow var(--ds-motion-cinematic-duration) ${EASE_CINEMATIC}`,
       }}
     >
       <div className='px-7 py-6'>
@@ -84,7 +84,7 @@ export function SuggestionCard({
             type='button'
             onClick={onAct}
             disabled={!onAct}
-            className='inline-flex items-center gap-1.5 h-7 px-3.5 rounded-full text-[12px] font-medium bg-white text-black hover:brightness-110 active:scale-[0.99] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) disabled:cursor-not-allowed disabled:opacity-60 shadow-[0_4px_14px_rgba(0,0,0,0.35),inset_0_1px_0_rgba(255,255,255,0.45)] transition-[filter,transform,box-shadow,opacity] duration-subtle ease-out'
+            className='inline-flex items-center gap-1.5 h-7 px-3.5 rounded-full text-[12px] font-medium bg-white text-black hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) disabled:cursor-not-allowed disabled:opacity-60 shadow-[0_4px_14px_rgba(0,0,0,0.35),inset_0_1px_0_rgba(255,255,255,0.45)] transition-[filter,box-shadow,opacity] duration-subtle ease-out'
           >
             {actionLabel}
             <ArrowRight className='h-3 w-3' strokeWidth={2.5} />

--- a/apps/web/tests/e2e/chat-pitch-generation.spec.ts
+++ b/apps/web/tests/e2e/chat-pitch-generation.spec.ts
@@ -1,7 +1,7 @@
 /**
  * E2E: Chat Pitch Generation (paid-tier feature)
  *
- * Tests the "Generate pitches" suggested prompt and the generateReleasePitch
+ * Tests pitch-generation access through the composer and the generateReleasePitch
  * chat tool, which are gated behind paid plans (aiCanUseTools).
  *
  * Run:
@@ -39,7 +39,7 @@ test.describe
     test('pitch suggestion hidden on free plan', async ({ page }) => {
       await ensureSignedInUser(page);
 
-      // Navigate to new chat thread (empty state shows suggested prompts)
+      // Navigate to new chat thread.
       await smokeNavigateWithRetry(page, APP_ROUTES.CHAT, { timeout: 60_000 });
       await waitForHydration(page);
 
@@ -48,7 +48,9 @@ test.describe
       await expect(pitchSuggestion).not.toBeVisible({ timeout: 5_000 });
     });
 
-    test('upgrade to pro enables pitch suggestion', async ({ page }) => {
+    test('upgrade to pro keeps pitch requests available through the composer', async ({
+      page,
+    }) => {
       await ensureSignedInUser(page);
 
       // Upgrade test user to pro
@@ -65,29 +67,13 @@ test.describe
         await waitForHydration(page);
       }
 
-      // The pitch suggestion should now be visible (if profile is complete enough)
-      // Note: The test user may not have 100% profile completion, which hides
-      // suggested prompts entirely. Check for either the suggestion OR the
-      // profile completion card.
+      // Prompt suggestion pills are not part of this shell convergence wave.
+      // The paid tool remains reachable through the composer.
       const pitchSuggestion = page.getByText(/generate pitches/i);
-      const profileCompletionGate = page.getByRole('button', {
-        name: /profile \d+% complete/i,
-      });
       const chatInput = page.getByPlaceholder(/ask jovie|chat message/i);
 
-      // At minimum, the chat input should be present
       await expect(chatInput).toBeVisible({ timeout: 15_000 });
-
-      // If the profile completion card is showing, pitch suggestion is hidden
-      // because SuggestedPrompts only renders when profile is 100% complete.
-      // This is correct behavior — not a test failure.
-      const isProfileIncomplete = await profileCompletionGate
-        .isVisible()
-        .catch(() => false);
-      if (!isProfileIncomplete) {
-        // Profile is complete — pitch suggestion should be visible for pro users
-        await expect(pitchSuggestion).toBeVisible({ timeout: 10_000 });
-      }
+      await expect(pitchSuggestion).not.toBeVisible({ timeout: 5_000 });
     });
 
     test('can type and send a pitch request via chat', async ({ page }) => {

--- a/apps/web/tests/unit/chat/ChatPageClient.test.tsx
+++ b/apps/web/tests/unit/chat/ChatPageClient.test.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/app/app/(shell)/chat/ChatPageClient';
 import type { DashboardData } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
 import { DashboardDataProvider } from '@/app/app/(shell)/dashboard/DashboardDataContext';
+import type { ChatActionCard } from '@/components/jovie/types';
 import { fastRender } from '@/tests/utils/fast-render';
 
 // Controllable mocks
@@ -81,15 +82,7 @@ vi.mock('@/contexts/HeaderActionsContext', () => ({
 
 // Track the onTitleChange callback from JovieChat
 let capturedOnTitleChange: ((title: string | null) => void) | undefined;
-let capturedActionCards:
-  | readonly {
-      readonly id: string;
-      readonly title: string;
-      readonly body: string;
-      readonly actionLabel: string;
-      readonly prompt: string;
-    }[]
-  | undefined;
+let capturedActionCards: readonly ChatActionCard[] | undefined;
 
 vi.mock('@/components/jovie/JovieChat', () => ({
   JovieChat: (props: {
@@ -99,13 +92,7 @@ vi.mock('@/components/jovie/JovieChat', () => ({
     onTitleChange?: (title: string | null) => void;
     initialQuery?: string;
     isFirstSession?: boolean;
-    actionCards?: readonly {
-      readonly id: string;
-      readonly title: string;
-      readonly body: string;
-      readonly actionLabel: string;
-      readonly prompt: string;
-    }[];
+    actionCards?: readonly ChatActionCard[];
   }) => {
     capturedOnTitleChange = props.onTitleChange;
     capturedActionCards = props.actionCards;
@@ -242,6 +229,8 @@ describe('ChatPageClient', () => {
         id: 'connect-music-catalog',
         title: 'Connect Your Music Catalog',
         actionLabel: 'Plan Setup',
+        prompt:
+          'Help me connect my music catalog for Test Artist. Use the current profile context and give me the next setup step.',
       })
     );
   });
@@ -273,6 +262,9 @@ describe('ChatPageClient', () => {
       expect.objectContaining({
         id: 'plan-next-move',
         title: 'Plan Your Next Move',
+        actionLabel: 'Plan Move',
+        prompt:
+          'Use my artist profile, music catalog, and dashboard context for Test Artist to recommend the single most useful action I should take this week. Include the first step.',
       })
     );
   });

--- a/apps/web/tests/unit/chat/ChatPageClient.test.tsx
+++ b/apps/web/tests/unit/chat/ChatPageClient.test.tsx
@@ -81,6 +81,15 @@ vi.mock('@/contexts/HeaderActionsContext', () => ({
 
 // Track the onTitleChange callback from JovieChat
 let capturedOnTitleChange: ((title: string | null) => void) | undefined;
+let capturedActionCards:
+  | readonly {
+      readonly id: string;
+      readonly title: string;
+      readonly body: string;
+      readonly actionLabel: string;
+      readonly prompt: string;
+    }[]
+  | undefined;
 
 vi.mock('@/components/jovie/JovieChat', () => ({
   JovieChat: (props: {
@@ -90,13 +99,22 @@ vi.mock('@/components/jovie/JovieChat', () => ({
     onTitleChange?: (title: string | null) => void;
     initialQuery?: string;
     isFirstSession?: boolean;
+    actionCards?: readonly {
+      readonly id: string;
+      readonly title: string;
+      readonly body: string;
+      readonly actionLabel: string;
+      readonly prompt: string;
+    }[];
   }) => {
     capturedOnTitleChange = props.onTitleChange;
+    capturedActionCards = props.actionCards;
     return React.createElement('div', {
       'data-testid': 'jovie-chat',
       'data-profile-id': props.profileId,
       'data-conversation-id': props.conversationId ?? '',
       'data-is-first-session': props.isFirstSession ? 'true' : 'false',
+      'data-action-card-count': String(props.actionCards?.length ?? 0),
     });
   },
 }));
@@ -200,6 +218,7 @@ describe('ChatPageClient', () => {
     vi.useRealTimers();
     mockSearchParams = new URLSearchParams();
     capturedOnTitleChange = undefined;
+    capturedActionCards = undefined;
     mockSuccessNotification.mockReset();
     mockErrorNotification.mockReset();
     mockSetPreviewData.mockReset();
@@ -211,6 +230,51 @@ describe('ChatPageClient', () => {
     const { getByTestId } = renderChatPage();
     const chat = getByTestId('jovie-chat');
     expect(chat.getAttribute('data-profile-id')).toBe('profile-1');
+  });
+
+  it('passes a production-backed action card to new chat threads', () => {
+    const { getByTestId } = renderChatPage();
+    const chat = getByTestId('jovie-chat');
+
+    expect(chat.getAttribute('data-action-card-count')).toBe('1');
+    expect(capturedActionCards?.[0]).toEqual(
+      expect.objectContaining({
+        id: 'connect-music-catalog',
+        title: 'Connect Your Music Catalog',
+        actionLabel: 'Plan Setup',
+      })
+    );
+  });
+
+  it('derives music catalog context from selectedProfile fields', () => {
+    const dataWithConnectedMusic: DashboardData = {
+      ...baseDashboardData,
+      hasMusicLinks: false,
+      selectedProfile: {
+        ...baseDashboardData.selectedProfile!,
+        spotifyId: 'spotify-artist-123',
+      } as DashboardData['selectedProfile'],
+      profileCompletion: {
+        percentage: 100,
+        completedCount: 4,
+        totalCount: 4,
+        steps: [],
+        profileIsLive: true,
+      },
+    };
+
+    fastRender(
+      <DashboardDataProvider value={dataWithConnectedMusic}>
+        <ChatPageClient />
+      </DashboardDataProvider>
+    );
+
+    expect(capturedActionCards?.[0]).toEqual(
+      expect.objectContaining({
+        id: 'plan-next-move',
+        title: 'Plan Your Next Move',
+      })
+    );
   });
 
   it('passes conversationId to JovieChat', () => {

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -1,22 +1,8 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { JovieChat } from '@/components/jovie/JovieChat';
 import { renderWithQueryClient } from '@/tests/utils/test-utils';
-
-const mockCapabilitiesQueryState = vi.hoisted(() => ({
-  data: {
-    tools: {
-      albumArt: {
-        availability: 'unavailable' as const,
-        reason: 'Album art generation is not available for this profile.',
-        reasonCode: 'PROFILE_REQUIRED',
-      },
-    },
-  },
-  isLoading: false,
-  isError: false,
-}));
 
 const mockChatState = {
   input: '',
@@ -107,7 +93,6 @@ vi.mock('@/lib/queries', () => ({
       list: (profileId: string) => ['events', 'list', profileId],
     },
   },
-  useChatCapabilitiesQuery: () => mockCapabilitiesQueryState,
 }));
 
 vi.mock('@/components/jovie/components', async () => {
@@ -146,26 +131,16 @@ vi.mock('@/components/jovie/components/ChatUsageAlert', () => ({
 
 describe('JovieChat empty state', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     mockChatState.input = '';
     mockChatState.messages = [];
     mockChatState.hasMessages = false;
     mockChatState.isLoading = false;
     mockChatState.isSubmitting = false;
-    mockCapabilitiesQueryState.data = {
-      tools: {
-        albumArt: {
-          availability: 'unavailable',
-          reason: 'Album art generation is not available for this profile.',
-          reasonCode: 'PROFILE_REQUIRED',
-        },
-      },
-    };
-    mockCapabilitiesQueryState.isLoading = false;
-    mockCapabilitiesQueryState.isError = false;
   });
 
-  it('renders the minimal welcome state with hero-style heading, pills, and composer', () => {
-    const { getByRole, getByTestId, getByText, queryByText } =
+  it('renders the minimal welcome state without prompt pills', () => {
+    const { getByTestId, getByText, queryByTestId, queryByText } =
       renderWithQueryClient(<JovieChat profileId='profile-1' />);
 
     expect(getByTestId('chat-empty-state-top-signals')).toBeTruthy();
@@ -185,49 +160,72 @@ describe('JovieChat empty state', () => {
     expect(queryByText('Jovie Assistant')).toBeNull();
     expect(queryByText('Ask anything or tell Jovie what you need')).toBeNull();
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
-    expect(getByTestId('chat-empty-state-prompt-rail')).toBeTruthy();
+    expect(queryByTestId('chat-empty-state-prompt-rail')).toBeNull();
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(getByTestId('chat-input').getAttribute('data-placeholder')).toBe(
       'Ask Jovie...'
     );
     expect(getByTestId('chat-input').getAttribute('data-variant')).toBe('hero');
-    expect(getByTestId('chat-input').getAttribute('data-quick-actions')).toBe(
-      'Plan a release|Generate album art|Pitch playlists|Send feedback'
-    );
-    // New hero-style pills sourced from DEFAULT_SUGGESTIONS (mirrors homepage).
-    expect(getByText('Plan a release')).toBeTruthy();
-    expect(getByRole('button', { name: 'Generate album art' })).toBeDisabled();
-    expect(getByText('Pitch playlists')).toBeTruthy();
+    expect(
+      getByTestId('chat-input').getAttribute('data-quick-actions')
+    ).toBeNull();
+    expect(queryByText('Plan a release')).toBeNull();
+    expect(queryByText('Generate album art')).toBeNull();
+    expect(queryByText('Pitch playlists')).toBeNull();
     // Old task-list-style actions should NOT appear — they belong in the profile switcher.
     expect(queryByText('Preview profile')).toBeNull();
     expect(queryByText('Change photo')).toBeNull();
     expect(queryByText('Release link')).toBeNull();
   });
 
-  it('hides starter prompt pills while the empty composer has typed text', () => {
+  it('renders a contextual action card and submits its prompt', () => {
+    renderWithQueryClient(
+      <JovieChat
+        profileId='profile-1'
+        actionCards={[
+          {
+            id: 'connect-music-catalog',
+            title: 'Connect Your Music Catalog',
+            body: 'Add Spotify, Apple Music, or YouTube Music so Jovie can plan from real releases.',
+            actionLabel: 'Plan Setup',
+            prompt: 'Help me connect my music catalog.',
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('Connect Your Music Catalog')).toBeTruthy();
+    expect(screen.getByText(/Add Spotify/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /Plan Setup/ }));
+
+    expect(mockChatState.handleSuggestedPrompt).toHaveBeenCalledWith(
+      'Help me connect my music catalog.'
+    );
+  });
+
+  it('hides the contextual action card while the empty composer has typed text', () => {
     mockChatState.input = 'Help me with';
 
-    const { getByTestId, queryByTestId, queryByText } = renderWithQueryClient(
-      <JovieChat profileId='profile-1' />
+    const { getByTestId, queryByText } = renderWithQueryClient(
+      <JovieChat
+        profileId='profile-1'
+        actionCards={[
+          {
+            id: 'connect-music-catalog',
+            title: 'Connect Your Music Catalog',
+            body: 'Add Spotify, Apple Music, or YouTube Music so Jovie can plan from real releases.',
+            actionLabel: 'Plan Setup',
+            prompt: 'Help me connect my music catalog.',
+          },
+        ]}
+      />
     );
 
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
     expect(getByTestId('chat-empty-state-top-signals')).toBeTruthy();
     expect(getByTestId('chat-input')).toBeTruthy();
-    expect(queryByTestId('chat-empty-state-prompt-rail')).toBeNull();
-    expect(queryByText('Plan a release')).toBeNull();
-    expect(queryByText('Pitch playlists')).toBeNull();
-  });
-
-  it('shows an enabled draft brief action when album art is unavailable', () => {
-    const { getByRole } = renderWithQueryClient(
-      <JovieChat profileId='profile-1' />
-    );
-
-    expect(getByRole('button', { name: 'Generate album art' })).toBeDisabled();
-    expect(
-      getByRole('button', { name: 'Draft album-art brief' })
-    ).toBeEnabled();
+    expect(queryByText('Connect Your Music Catalog')).toBeNull();
   });
 
   it('renders first-session greeting for new users', () => {
@@ -247,18 +245,6 @@ describe('JovieChat empty state', () => {
     expect(queryByText('Welcome back')).toBeNull();
     expect(queryByText('Welcome back, Tim')).toBeNull();
     expect(queryByText('Welcome back, Tim White')).toBeNull();
-  });
-
-  it('disables album art while capability is unknown without showing the draft brief action', () => {
-    mockCapabilitiesQueryState.data = undefined;
-    mockCapabilitiesQueryState.isLoading = true;
-
-    const { getByRole, queryByRole } = renderWithQueryClient(
-      <JovieChat profileId='profile-1' />
-    );
-
-    expect(getByRole('button', { name: 'Generate album art' })).toBeDisabled();
-    expect(queryByRole('button', { name: 'Draft album-art brief' })).toBeNull();
   });
 
   it('renders chat messages after in-place message array updates', () => {
@@ -297,5 +283,8 @@ describe('JovieChat empty state', () => {
     expect(screen.getByTestId('chat-input').getAttribute('data-variant')).toBe(
       'compact'
     );
+    expect(
+      screen.getByTestId('chat-input').getAttribute('data-quick-actions')
+    ).toBeNull();
   });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2526 -->

## Summary
- Adds production-backed empty-thread action cards to `/app/chat` from selected profile/catalog/completion context.
- Removes the chat prompt-pill rail from this wave while keeping real action cards.
- Updates loading, unit, and pitch E2E expectations so prompt pills are not treated as the shipping surface.

Supersedes #9487; this branch is rebuilt from current `origin/main` after the first branch was based on stale local history.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/app/(shell)/chat/ChatPageClient.tsx apps/web/app/app/(shell)/chat/loading.tsx apps/web/components/jovie/JovieChat.tsx apps/web/components/jovie/types.ts apps/web/components/shell/SuggestionCard.tsx apps/web/tests/e2e/chat-pitch-generation.spec.ts apps/web/tests/unit/chat/ChatPageClient.test.tsx apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/chat/JovieChat.empty-state.test.tsx tests/unit/chat/ChatPageClient.test.tsx components/shell/SuggestionCard.test.tsx` (33 passed)
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --cached --check`
- Pre-commit hook passed: proxy guard, Biome, ESLint, staged a11y, typecheck
- Pre-push hook passed: repo Biome, web proxy guard, Tailwind guard, typecheck, lint
- `PORT=3001 JOVIE_AGENT_PROFILE=no_agent pnpm run dev:web:browse`
- Screenshot matrix with `creator-ready`: `/tmp/shell-v1-final-20260521-v2-fresh` (15 captures across `/exp/shell-v1`, `/start`, `/app/chat`, `/app/dashboard/releases`, `/app/dashboard/tasks`; desktop/tablet/mobile; zero assertion problems)

## Notes
GBrain page write is blocked by JOV-2528 due the local embedding-dimension mismatch; Linear has the verification comment and this PR carries the shippable product slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contextual action cards in chat empty state driven by profile completion and music-catalog connection status.

* **UI Updates**
  * Empty state shows a single action card (and updated loading skeleton) instead of the suggested prompt rail; composer quick-action rail is no longer shown.
  * Tweaked action card transition and primary button styling.

* **Tests**
  * Added/updated unit and e2e tests for action card generation, selection, and empty-state behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->