### PR TITLE
refactor(proxy): isolate audience block lookup (JOV-2185)

### DIFF
--- a/apps/web/lib/audience/public-profile-block.ts
+++ b/apps/web/lib/audience/public-profile-block.ts
@@ -1,0 +1,65 @@
+import 'server-only';
+
+import { createFingerprintEdge } from '@/lib/audience/fingerprint';
+
+/**
+ * Mirror extractClientIP() priority for the middleware audience-block check.
+ */
+export function getAudienceBlockIpFromHeaders(headers: Headers): string | null {
+  return (
+    headers.get('cf-connecting-ip') ||
+    headers.get('x-real-ip') ||
+    (headers.get('x-forwarded-for') || '').split(',')[0].trim() ||
+    headers.get('true-client-ip') ||
+    null
+  );
+}
+
+/**
+ * Check if a public profile visitor should be blocked.
+ *
+ * Uses a single JOIN query (creator_profiles x audience_blocks) so no round-trip
+ * is wasted when the profile exists but the visitor isn't blocked.
+ *
+ * Fails open on any error. A blocked user slipping through once is preferable
+ * to locking out all visitors during a DB hiccup.
+ */
+export async function checkProfileVisitorBlocked(
+  username: string,
+  ip: string | null,
+  ua: string | null
+): Promise<boolean> {
+  if (process.env.NODE_ENV === 'test') return false;
+  if (process.env.PUBLIC_NOAUTH_SMOKE === '1') return false;
+
+  try {
+    const fingerprint = await createFingerprintEdge(ip, ua);
+
+    // Lazy imports keep DB modules out of middleware invocations that do not
+    // hit a valid public-profile candidate.
+    const { db } = await import('@/lib/db');
+    const { and, eq, isNull } = await import('drizzle-orm');
+    const { audienceBlocks } = await import('@/lib/db/schema/analytics');
+    const { creatorProfiles } = await import('@/lib/db/schema/profiles');
+
+    const [result] = await db
+      .select({ blockId: audienceBlocks.id })
+      .from(creatorProfiles)
+      .innerJoin(
+        audienceBlocks,
+        eq(audienceBlocks.creatorProfileId, creatorProfiles.id)
+      )
+      .where(
+        and(
+          eq(creatorProfiles.username, username.toLowerCase()),
+          eq(audienceBlocks.fingerprint, fingerprint),
+          isNull(audienceBlocks.unblockedAt)
+        )
+      )
+      .limit(1);
+
+    return !!result;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/lib/audience/public-profile-block.ts
+++ b/apps/web/lib/audience/public-profile-block.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { createFingerprintEdge } from '@/lib/audience/fingerprint';
+import { env } from '@/lib/env-server';
 
 /**
  * Mirror extractClientIP() priority for the middleware audience-block check.
@@ -29,8 +30,8 @@ export async function checkProfileVisitorBlocked(
   ip: string | null,
   ua: string | null
 ): Promise<boolean> {
-  if (process.env.NODE_ENV === 'test') return false;
-  if (process.env.PUBLIC_NOAUTH_SMOKE === '1') return false;
+  if (env.NODE_ENV === 'test') return false;
+  if (env.PUBLIC_NOAUTH_SMOKE === '1') return false;
 
   try {
     const fingerprint = await createFingerprintEdge(ip, ua);

--- a/apps/web/lib/auth/investor-portal.ts
+++ b/apps/web/lib/auth/investor-portal.ts
@@ -29,6 +29,7 @@ export async function handleInvestorRequest(
   const hostname = req.nextUrl.hostname;
   const hostInfo = analyzeHost(hostname);
   const pathname = req.nextUrl.pathname;
+  const isResponseActionPath = pathname === '/investor-portal/respond';
 
   // --- Legacy subdomain redirect ---
   if (hostInfo.isInvestorPortal) {
@@ -66,6 +67,19 @@ export async function handleInvestorRequest(
   const tokenParam = req.nextUrl.searchParams.get(INVESTOR_TOKEN_PARAM);
 
   if (tokenParam) {
+    // Response links consume the token and action together in the page handler.
+    // Stripping ?t= here turns valid email links into 404s, and falling
+    // through to Clerk would make token-only links depend on session state.
+    if (isResponseActionPath) {
+      const res = NextResponse.next();
+      res.headers.set(
+        'X-Robots-Tag',
+        'noindex, nofollow, noarchive, nosnippet'
+      );
+      res.headers.set('Cache-Control', 'private, no-store');
+      return res;
+    }
+
     const isValid = await validateInvestorToken(tokenParam);
     if (!isValid) {
       return new NextResponse(null, { status: 404 });

--- a/apps/web/lib/env-server-schema.ts
+++ b/apps/web/lib/env-server-schema.ts
@@ -46,6 +46,7 @@ export const ServerEnvSchema = z.object({
     })
     .optional(),
   VERCEL_AUTOMATION_BYPASS_SECRET: z.string().optional(),
+  PUBLIC_NOAUTH_SMOKE: z.string().optional(),
 
   // Clerk server-side configuration
   CLERK_SECRET_KEY: z.string().optional(),
@@ -291,6 +292,7 @@ export const ENV_KEYS = [
   'VERCEL_ENV',
   'VERCEL_URL',
   'VERCEL_AUTOMATION_BYPASS_SECRET',
+  'PUBLIC_NOAUTH_SMOKE',
   'CLERK_SECRET_KEY',
   'CLERK_WEBHOOK_SECRET',
   'CLERK_PUBLISHABLE_KEY_STAGING',

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -12,7 +12,10 @@ import {
 } from '@/components/providers/clerkAvailability';
 import { BASE_URL } from '@/constants/domains';
 import { APP_ROUTES } from '@/constants/routes';
-import { createFingerprintEdge } from '@/lib/audience/fingerprint';
+import {
+  checkProfileVisitorBlocked,
+  getAudienceBlockIpFromHeaders,
+} from '@/lib/audience/public-profile-block';
 import {
   buildAuthDegradedHtmlResponse,
   isBrowserNavigation,
@@ -121,74 +124,6 @@ function applyStateRewrite(
   return res;
 }
 
-// ============================================================================
-// Public Profile Audience Block Check
-// ============================================================================
-// Runs in middleware so ISR-cached profile pages don't need headers() in the
-// page component. On Vercel, middleware executes before the CDN cache is served,
-// so this gate applies even to cache hits.
-// ============================================================================
-
-/**
- * Mask an IP address for fingerprinting.
- * Mirrors maskIpAddress() in app/api/audience/lib/audience-utils.ts.
- * Edge-compatible (no Node.js modules).
- */
-
-/**
- * Check if a public profile visitor should be blocked.
- *
- * Uses a single JOIN query (creator_profiles ⋈ audience_blocks) so no round-trip
- * is wasted when the profile exists but the visitor isn't blocked (the common case).
- *
- * Fails open on any error — a blocked user slipping through once is preferable
- * to locking out all visitors during a DB hiccup.
- */
-async function checkProfileVisitorBlocked(
-  username: string,
-  ip: string | null,
-  ua: string | null
-): Promise<boolean> {
-  // Skip in unit-test environments and public smoke-test mode
-  if (process.env.NODE_ENV === 'test') return false;
-  if (process.env.PUBLIC_NOAUTH_SMOKE === '1') return false;
-
-  try {
-    const fingerprint = await createFingerprintEdge(ip, ua);
-
-    // Lazy imports mirror the investor-portal pattern in this file.
-    const { db } = await import('@/lib/db');
-    const { and, eq, isNull } = await import('drizzle-orm');
-    const { audienceBlocks } = await import('@/lib/db/schema/analytics');
-    const { creatorProfiles } = await import('@/lib/db/schema/profiles');
-
-    // Single round-trip: join profile + block table. Returns a row only when
-    // the username exists AND the fingerprint is in the block list.
-    // Profile owners cannot block themselves, so no owner-skip is needed here.
-    const [result] = await db
-      .select({ blockId: audienceBlocks.id })
-      .from(creatorProfiles)
-      .innerJoin(
-        audienceBlocks,
-        eq(audienceBlocks.creatorProfileId, creatorProfiles.id)
-      )
-      .where(
-        and(
-          eq(creatorProfiles.username, username.toLowerCase()),
-          eq(audienceBlocks.fingerprint, fingerprint),
-          isNull(audienceBlocks.unblockedAt)
-        )
-      )
-      .limit(1);
-
-    return !!result;
-  } catch {
-    // Fail open: don't lock out visitors on DB errors.
-    return false;
-  }
-}
-
-// ============================================================================
 const CLERK_SENSITIVE_PATTERNS = [
   'dummy',
   'mock',
@@ -346,13 +281,7 @@ async function handleRequest(req: NextRequest, userId: string | null) {
     if (isNavigationMethod) {
       const profileUsername = pathInfo.publicProfileCandidate;
       if (profileUsername) {
-        // Mirror extractClientIP() priority: cf-connecting-ip > x-real-ip > x-forwarded-for > true-client-ip
-        const rawIp =
-          req.headers.get('cf-connecting-ip') ||
-          req.headers.get('x-real-ip') ||
-          (req.headers.get('x-forwarded-for') || '').split(',')[0].trim() ||
-          req.headers.get('true-client-ip') ||
-          null;
+        const rawIp = getAudienceBlockIpFromHeaders(req.headers);
         const ua = req.headers.get('user-agent');
         const isBlocked = await checkProfileVisitorBlocked(
           profileUsername,

--- a/apps/web/tests/unit/lib/audience/public-profile-block.test.ts
+++ b/apps/web/tests/unit/lib/audience/public-profile-block.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  createFingerprintEdge: vi.fn(),
+  select: vi.fn(),
+  and: vi.fn(() => 'and-clause'),
+  eq: vi.fn(() => 'eq-clause'),
+  isNull: vi.fn(() => 'is-null-clause'),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/audience/fingerprint', () => ({
+  createFingerprintEdge: mocks.createFingerprintEdge,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mocks.select,
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: mocks.and,
+  eq: mocks.eq,
+  isNull: mocks.isNull,
+}));
+
+vi.mock('@/lib/db/schema/analytics', () => ({
+  audienceBlocks: {
+    id: 'audienceBlocks.id',
+    creatorProfileId: 'audienceBlocks.creatorProfileId',
+    fingerprint: 'audienceBlocks.fingerprint',
+    unblockedAt: 'audienceBlocks.unblockedAt',
+  },
+}));
+
+vi.mock('@/lib/db/schema/profiles', () => ({
+  creatorProfiles: {
+    id: 'creatorProfiles.id',
+    username: 'creatorProfiles.username',
+  },
+}));
+
+import {
+  checkProfileVisitorBlocked,
+  getAudienceBlockIpFromHeaders,
+} from '@/lib/audience/public-profile-block';
+
+function mockAudienceBlockRows(rows: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn(() => ({ limit }));
+  const innerJoin = vi.fn(() => ({ where }));
+  const from = vi.fn(() => ({ innerJoin }));
+  mocks.select.mockReturnValue({ from });
+
+  return { from, innerJoin, where, limit };
+}
+
+describe('public profile audience block helper', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalSmoke = process.env.PUBLIC_NOAUTH_SMOKE;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = originalNodeEnv;
+    if (originalSmoke === undefined) {
+      delete process.env.PUBLIC_NOAUTH_SMOKE;
+    } else {
+      process.env.PUBLIC_NOAUTH_SMOKE = originalSmoke;
+    }
+  });
+
+  it('extracts the client IP with the same priority as audience tracking', () => {
+    expect(
+      getAudienceBlockIpFromHeaders(
+        new Headers({
+          'cf-connecting-ip': '1.1.1.1',
+          'x-real-ip': '2.2.2.2',
+          'x-forwarded-for': '3.3.3.3, 4.4.4.4',
+          'true-client-ip': '5.5.5.5',
+        })
+      )
+    ).toBe('1.1.1.1');
+
+    expect(
+      getAudienceBlockIpFromHeaders(
+        new Headers({
+          'x-forwarded-for': '3.3.3.3, 4.4.4.4',
+          'true-client-ip': '5.5.5.5',
+        })
+      )
+    ).toBe('3.3.3.3');
+  });
+
+  it('skips DB work in test mode', async () => {
+    process.env.NODE_ENV = 'test';
+
+    await expect(
+      checkProfileVisitorBlocked('tim', '1.2.3.4', 'Mozilla')
+    ).resolves.toBe(false);
+
+    expect(mocks.createFingerprintEdge).not.toHaveBeenCalled();
+    expect(mocks.select).not.toHaveBeenCalled();
+  });
+
+  it('skips DB work in public no-auth smoke mode', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.PUBLIC_NOAUTH_SMOKE = '1';
+
+    await expect(
+      checkProfileVisitorBlocked('tim', '1.2.3.4', 'Mozilla')
+    ).resolves.toBe(false);
+
+    expect(mocks.createFingerprintEdge).not.toHaveBeenCalled();
+    expect(mocks.select).not.toHaveBeenCalled();
+  });
+
+  it('returns true when the joined block query finds a row', async () => {
+    process.env.NODE_ENV = 'production';
+    mocks.createFingerprintEdge.mockResolvedValue('fingerprint-1');
+    mockAudienceBlockRows([{ blockId: 'block-1' }]);
+
+    await expect(
+      checkProfileVisitorBlocked('TimWhite', '1.2.3.4', 'Mozilla')
+    ).resolves.toBe(true);
+
+    expect(mocks.createFingerprintEdge).toHaveBeenCalledWith(
+      '1.2.3.4',
+      'Mozilla'
+    );
+    expect(mocks.eq).toHaveBeenCalledWith(
+      'creatorProfiles.username',
+      'timwhite'
+    );
+    expect(mocks.eq).toHaveBeenCalledWith(
+      'audienceBlocks.fingerprint',
+      'fingerprint-1'
+    );
+  });
+
+  it('fails open when the DB query throws', async () => {
+    process.env.NODE_ENV = 'production';
+    mocks.createFingerprintEdge.mockResolvedValue('fingerprint-1');
+    mocks.select.mockImplementation(() => {
+      throw new Error('db unavailable');
+    });
+
+    await expect(
+      checkProfileVisitorBlocked('tim', '1.2.3.4', 'Mozilla')
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/web/tests/unit/lib/auth/investor-portal.test.ts
+++ b/apps/web/tests/unit/lib/auth/investor-portal.test.ts
@@ -86,6 +86,17 @@ describe('investor portal proxy helper', () => {
     expect(mocks.select).not.toHaveBeenCalled();
   });
 
+  it('lets token-only response links reach the page before DB validation', async () => {
+    const res = await handleInvestorRequest(
+      createInvestorRequest('/investor-portal/respond?t=token-123')
+    );
+
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get('X-Robots-Tag')).toContain('noindex');
+    expect(res?.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(mocks.select).not.toHaveBeenCalled();
+  });
+
   it('still validates regular portal token links and strips the token into a cookie', async () => {
     mockSelectRows([{ id: 'link-1', isActive: true, expiresAt: null }]);
 

--- a/apps/web/tests/unit/lib/auth/investor-portal.test.ts
+++ b/apps/web/tests/unit/lib/auth/investor-portal.test.ts
@@ -1,0 +1,103 @@
+import { NextRequest } from 'next/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  insert: vi.fn(),
+  update: vi.fn(),
+  and: vi.fn(() => 'and-clause'),
+  eq: vi.fn(() => 'eq-clause'),
+  captureError: vi.fn(),
+  releaseInvestorViewDedup: vi.fn(),
+  shouldRecordInvestorView: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mocks.select,
+    insert: mocks.insert,
+    update: mocks.update,
+  },
+}));
+
+vi.mock('@/lib/db/schema/investors', () => ({
+  investorLinks: {
+    id: 'investorLinks.id',
+    token: 'investorLinks.token',
+    isActive: 'investorLinks.isActive',
+    expiresAt: 'investorLinks.expiresAt',
+    stage: 'investorLinks.stage',
+    updatedAt: 'investorLinks.updatedAt',
+  },
+  investorViews: {
+    investorLinkId: 'investorViews.investorLinkId',
+    pagePath: 'investorViews.pagePath',
+    userAgent: 'investorViews.userAgent',
+    referrer: 'investorViews.referrer',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: mocks.and,
+  eq: mocks.eq,
+}));
+
+vi.mock('@/lib/auth/investor-view-dedup', () => ({
+  releaseInvestorViewDedup: mocks.releaseInvestorViewDedup,
+  shouldRecordInvestorView: mocks.shouldRecordInvestorView,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: mocks.captureError,
+}));
+
+import { handleInvestorRequest } from '@/lib/auth/investor-portal';
+
+function createInvestorRequest(path: string) {
+  return new NextRequest(`https://jov.ie${path}`);
+}
+
+function mockSelectRows(rows: unknown[]) {
+  const limit = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn(() => ({ limit }));
+  const from = vi.fn(() => ({ where }));
+  mocks.select.mockReturnValue({ from });
+
+  return { from, where, limit };
+}
+
+describe('investor portal proxy helper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.select.mockReset();
+    mocks.shouldRecordInvestorView.mockResolvedValue(true);
+  });
+
+  it('lets response action links reach the page with token and action intact before DB validation', async () => {
+    const res = await handleInvestorRequest(
+      createInvestorRequest(
+        '/investor-portal/respond?t=token-123&action=interested'
+      )
+    );
+
+    expect(res?.status).toBe(200);
+    expect(res?.headers.get('X-Robots-Tag')).toContain('noindex');
+    expect(res?.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(mocks.select).not.toHaveBeenCalled();
+  });
+
+  it('still validates regular portal token links and strips the token into a cookie', async () => {
+    mockSelectRows([{ id: 'link-1', isActive: true, expiresAt: null }]);
+
+    const res = await handleInvestorRequest(
+      createInvestorRequest('/investor-portal?t=token-123&utm=x')
+    );
+
+    expect(res?.status).toBe(307);
+    expect(res?.headers.get('location')).toBe(
+      'https://jov.ie/investor-portal?utm=x'
+    );
+    expect(res?.cookies.get('__investor_token')?.value).toBe('token-123');
+    expect(mocks.select).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -1487,7 +1487,7 @@ describe('proxy.ts middleware', () => {
     });
   });
 
-  describe('investors.jov.ie legacy subdomain (proxy investor 301 early returns)', () => {
+  describe('path-based investor portal (proxy investor early returns)', () => {
     it('lets investor response links bypass Clerk without stripping token params', async () => {
       const req = createUnauthenticatedRequest({
         pathname: '/investor-portal/respond',
@@ -1504,7 +1504,9 @@ describe('proxy.ts middleware', () => {
       expect(res.headers.get('Cache-Control')).toBe('private, no-store');
       expect(mocks.clerkMiddleware).not.toHaveBeenCalled();
     });
+  });
 
+  describe('investors.jov.ie legacy subdomain (proxy investor 301 early returns)', () => {
     it('301 redirects investors.jov.ie non-static paths to jov.ie/investor-portal preserving token', async () => {
       const req = createUnauthenticatedRequest({
         pathname: '/foo/bar',

--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -48,6 +48,8 @@ const mocks = vi.hoisted(() => ({
   shouldBypassClerkForRequest: vi.fn().mockReturnValue(true),
   isTestAuthBypassEnabled: vi.fn().mockReturnValue(true),
   resolveTestBypassUserId: vi.fn().mockReturnValue(null),
+  checkProfileVisitorBlocked: vi.fn().mockResolvedValue(false),
+  getAudienceBlockIpFromHeaders: vi.fn().mockReturnValue('masked-ip'),
   createBotResponse: vi.fn(),
   clerkMiddleware: vi.fn(),
   buildProtectedAuthRedirectUrl: vi.fn(
@@ -97,6 +99,10 @@ vi.mock('@/lib/auth/test-mode', () => ({
   TEST_AUTH_BYPASS_MODE: 'test-auth-bypass',
   TEST_MODE_HEADER: 'x-test-mode',
   resolveTestBypassUserId: mocks.resolveTestBypassUserId,
+}));
+vi.mock('@/lib/audience/public-profile-block', () => ({
+  checkProfileVisitorBlocked: mocks.checkProfileVisitorBlocked,
+  getAudienceBlockIpFromHeaders: mocks.getAudienceBlockIpFromHeaders,
 }));
 vi.mock('@/lib/utils/bot-detection', () => ({
   createBotResponse: mocks.createBotResponse,
@@ -181,6 +187,8 @@ function resetMocks() {
   mocks.getUserState.mockResolvedValue(null);
   mocks.isKnownActiveUser.mockReturnValue(false);
   mocks.isStagingHost.mockReturnValue(false);
+  mocks.checkProfileVisitorBlocked.mockResolvedValue(false);
+  mocks.getAudienceBlockIpFromHeaders.mockReturnValue('masked-ip');
   mocks.createBotResponse.mockReturnValue(undefined);
   mocks.fetch.mockResolvedValue(
     new Response('ok', {
@@ -514,6 +522,61 @@ describe('proxy.ts middleware', () => {
       const res = await callMiddleware(req);
 
       expect(res.status).toBeLessThan(300);
+    });
+
+    it('does not run the audience block lookup for reserved public routes', async () => {
+      const reservedRoutes = ['/start', '/pricing', '/about', '/investors'];
+
+      for (const pathname of reservedRoutes) {
+        const req = createUnauthenticatedRequest({ pathname });
+        const res = await callMiddleware(req);
+
+        expect(res.status).toBeLessThan(300);
+      }
+
+      expect(mocks.checkProfileVisitorBlocked).not.toHaveBeenCalled();
+      expect(mocks.getAudienceBlockIpFromHeaders).not.toHaveBeenCalled();
+    });
+
+    it('runs the audience block lookup for public profile root paths only', async () => {
+      const req = createUnauthenticatedRequest({
+        pathname: '/timwhite',
+        headers: {
+          'x-forwarded-for': '203.0.113.7, 198.51.100.8',
+          'user-agent': 'Mozilla/5.0',
+        },
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBeLessThan(300);
+      expect(mocks.getAudienceBlockIpFromHeaders).toHaveBeenCalledWith(
+        req.headers
+      );
+      expect(mocks.checkProfileVisitorBlocked).toHaveBeenCalledWith(
+        'timwhite',
+        'masked-ip',
+        'Mozilla/5.0'
+      );
+    });
+
+    it('redirects blocked public profile visitors before route handling continues', async () => {
+      mocks.checkProfileVisitorBlocked.mockResolvedValue(true);
+
+      const req = createUnauthenticatedRequest({
+        pathname: '/timwhite',
+        headers: {
+          'user-agent': 'Mozilla/5.0',
+        },
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBe(307);
+      expect(res.headers.get('location')).toBe('https://jov.ie/');
+      expect(mocks.checkProfileVisitorBlocked).toHaveBeenCalledWith(
+        'timwhite',
+        'masked-ip',
+        'Mozilla/5.0'
+      );
     });
 
     it('normalizes /sign-in to /signin', async () => {
@@ -1425,6 +1488,23 @@ describe('proxy.ts middleware', () => {
   });
 
   describe('investors.jov.ie legacy subdomain (proxy investor 301 early returns)', () => {
+    it('lets investor response links bypass Clerk without stripping token params', async () => {
+      const req = createUnauthenticatedRequest({
+        pathname: '/investor-portal/respond',
+        searchParams: {
+          t: 'token-123',
+          action: 'interested',
+        },
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('location')).toBeNull();
+      expect(res.headers.get('X-Robots-Tag')).toContain('noindex');
+      expect(res.headers.get('Cache-Control')).toBe('private, no-store');
+      expect(mocks.clerkMiddleware).not.toHaveBeenCalled();
+    });
+
     it('301 redirects investors.jov.ie non-static paths to jov.ie/investor-portal preserving token', async () => {
       const req = createUnauthenticatedRequest({
         pathname: '/foo/bar',

--- a/apps/web/tests/unit/middleware/route-policy.test.ts
+++ b/apps/web/tests/unit/middleware/route-policy.test.ts
@@ -7,6 +7,7 @@
  * /investors etc NEVER trigger the public-profile audience block DB path.
  */
 import { describe, expect, it } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
 import {
   categorizePath,
   getPublicProfileCandidate,
@@ -39,6 +40,19 @@ describe('route-policy (proxy-routing)', () => {
       expect(getPublicProfileCandidate('/_next/static')).toBeNull(); // multi but first seg
       expect(getPublicProfileCandidate('/__clerk')).toBeNull();
       expect(getPublicProfileCandidate('/api/foo')).toBeNull();
+    });
+
+    it('reserves every single-segment APP_ROUTES value from public-profile lookup', () => {
+      const topLevelRoutes = Object.values(APP_ROUTES).filter(route => {
+        if (typeof route !== 'string' || !route.startsWith('/')) return false;
+        const rest = route.slice(1);
+        return rest.length > 0 && !rest.includes('/');
+      });
+
+      for (const route of topLevelRoutes) {
+        expect(getPublicProfileCandidate(route), route).toBeNull();
+        expect(isPublicProfileAudienceBlockCandidate(route), route).toBe(false);
+      }
     });
 
     it('returns the username for valid single-segment profile-shaped paths', () => {


### PR DESCRIPTION
## Summary
- Extracted public-profile audience blocking out of `apps/web/proxy.ts` into `apps/web/lib/audience/public-profile-block.ts`.
- Added middleware and route-policy regressions so reserved public routes never enter the profile block DB path, blocked profile visitors redirect, and investor response links bypass Clerk without losing token params.
- Fixed `/investor-portal/respond?t=...&action=...` proxy handling to preserve token-only email actions while keeping noindex/no-store headers.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/middleware tests/unit/lib/audience/public-profile-block.test.ts tests/unit/lib/auth/investor-portal.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/proxy.ts apps/web/lib/audience/public-profile-block.ts apps/web/lib/auth/investor-portal.ts apps/web/tests/unit/lib/audience/public-profile-block.test.ts apps/web/tests/unit/lib/auth/investor-portal.test.ts apps/web/tests/unit/middleware/proxy-behavioral.test.ts apps/web/tests/unit/middleware/route-policy.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run next:proxy-guard`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run build`
- Push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Notes
- `pnpm --filter @jovie/web run typecheck:tests -- --pretty false` still fails on existing broad test-project errors beginning with `scripts/drizzle-migrate.ts:213` and unrelated profile/release fixture type errors.
- JOV-2531 tracks the scanner-triggered GET investor response mutation risk identified during review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized public-profile visitor blocking with IP extraction and fingerprint checks; added optional PUBLIC_NOAUTH_SMOKE env flag.

* **Bug Fixes**
  * Investor-portal respond path now bypasses token redirect while returning privacy headers.
  * Proxy middleware now uses centralized audience-block logic and correctly redirects blocked profile visitors early.

* **Tests**
  * Added unit tests covering profile blocking, investor-portal behavior, proxy middleware, and route policy classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->