### PR TITLE
fix(chat): simplify action card empty state

### DIFF
--- a/apps/web/app/(dynamic)/start/loading.tsx
+++ b/apps/web/app/(dynamic)/start/loading.tsx
@@ -62,13 +62,6 @@ export default function StartLoading() {
               </div>
             </div>
           </div>
-
-          {/* Subtle prompt hint row to match empty state density */}
-          <div className='flex flex-wrap justify-center gap-2 pt-1'>
-            <Skeleton className='h-8 w-28 rounded-full' rounded='full' />
-            <Skeleton className='h-8 w-24 rounded-full' rounded='full' />
-            <Skeleton className='h-8 w-32 rounded-full' rounded='full' />
-          </div>
         </div>
       </div>
     </div>

--- a/apps/web/app/app/(shell)/chat/loading.tsx
+++ b/apps/web/app/app/(shell)/chat/loading.tsx
@@ -21,11 +21,13 @@ export default function ChatLoading() {
             <Skeleton className='h-6 w-48' rounded='lg' />
 
             {/* Action card skeleton */}
-            <div className='w-full max-w-[32rem] rounded-[18px] border border-white/[0.05] bg-(--linear-app-content-surface) px-7 py-6 shadow-[0_16px_40px_-24px_rgba(0,0,0,0.45)]'>
-              <Skeleton className='h-4 w-56' rounded='lg' />
-              <Skeleton className='mt-3 h-3 w-full' rounded='lg' />
-              <Skeleton className='mt-2 h-3 w-4/5' rounded='lg' />
-              <div className='mt-6 flex justify-end'>
+            <div className='grid min-h-[148px] w-full max-w-[32rem] grid-cols-1 items-center gap-4 rounded-[18px] border border-white/[0.05] bg-(--linear-app-content-surface) px-5 py-5 shadow-[0_16px_40px_-24px_rgba(0,0,0,0.45)] sm:grid-cols-[minmax(0,1fr)_auto] sm:px-7'>
+              <div className='min-w-0'>
+                <Skeleton className='h-4 w-56' rounded='lg' />
+                <Skeleton className='mt-3 h-3 w-full' rounded='lg' />
+                <Skeleton className='mt-2 h-3 w-4/5' rounded='lg' />
+              </div>
+              <div className='flex justify-start sm:justify-end'>
                 <Skeleton className='h-7 w-24 rounded-full' rounded='full' />
               </div>
             </div>

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -20,10 +20,6 @@ import {
 } from './components';
 import { ChatProvidersRegistrar } from './components/ChatProvidersRegistrar';
 import { ChatUsageAlert } from './components/ChatUsageAlert';
-import {
-  CHAT_PROMPT_RAIL_MASK_STYLE,
-  CHAT_PROMPT_RAIL_SCROLL_CLASS,
-} from './components/chat-prompt-styles';
 import { EntityResolutionProvider } from './components/EntityResolutionProvider';
 import {
   useChatImageAttachments,
@@ -36,61 +32,6 @@ import type { JovieChatProps, MessagePart } from './types';
 /** Sentinel ID for the synthetic thinking placeholder */
 const THINKING_PLACEHOLDER_ID = 'thinking-placeholder';
 const VIRTUALIZATION_THRESHOLD = 12;
-const EMPTY_STATE_SIGNAL_CARDS = [
-  {
-    headline: 'Release plan',
-    body: 'Turn a song into a launch sequence.',
-  },
-  {
-    headline: 'Asset brief',
-    body: 'Creative direction and copy, ready to use.',
-  },
-  {
-    headline: 'Context',
-    body: 'Releases, contacts, and references stay attached.',
-  },
-] as const;
-
-function EmptyStateSignalCards({
-  dimmed = false,
-}: {
-  readonly dimmed?: boolean;
-}) {
-  return (
-    <div
-      className={cn('w-full max-w-[52rem]', dimmed && 'pointer-events-none')}
-      aria-hidden={dimmed ? 'true' : undefined}
-      data-testid='chat-empty-state-top-signals'
-    >
-      <div
-        className={cn(
-          CHAT_PROMPT_RAIL_SCROLL_CLASS,
-          'overscroll-x-contain px-1 sm:px-0 lg:overflow-visible'
-        )}
-        style={CHAT_PROMPT_RAIL_MASK_STYLE}
-      >
-        <div
-          className='flex snap-x snap-mandatory flex-nowrap gap-3 lg:grid lg:grid-cols-3'
-          data-testid='chat-empty-state-top-signals-row'
-        >
-          {EMPTY_STATE_SIGNAL_CARDS.map(card => (
-            <article
-              key={card.headline}
-              className='min-h-[124px] min-w-[min(19rem,84vw)] flex-1 snap-start rounded-[22px] border border-subtle bg-surface-1 px-4 py-4 shadow-[0_16px_44px_-30px_rgba(0,0,0,0.92)] lg:min-w-0'
-            >
-              <p className='text-pretty text-[17px] font-semibold leading-[1.2] text-primary-token'>
-                {card.headline}
-              </p>
-              <p className='mt-3 max-w-[24ch] text-[12.5px] leading-5 text-tertiary-token'>
-                {card.body}
-              </p>
-            </article>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-}
 
 /**
  * Extracts the first name token for use in the empty-state greeting (e.g. "What are we working on, Alex?").
@@ -137,8 +78,7 @@ export function JovieChat({
   const imageFileInputRef = useRef<HTMLInputElement>(null);
   // Track message IDs that were loaded from persistence to skip entrance animation
   const knownMessageIdsRef = useRef<Set<string>>(new Set());
-  // Variant F: dim suggestion chips while the slash picker is open so they
-  // don't compete with the morphing surface.
+  // Hide neighbouring affordances while the slash picker owns the composer.
   const [composerPickerOpen, setComposerPickerOpen] = useState(false);
   const {
     input,
@@ -434,7 +374,7 @@ export function JovieChat({
   const greetingName =
     getFirstNameForGreeting(displayName) ?? getFirstNameForGreeting(username);
   const primaryActionCard = actionCards[0] ?? null;
-  const showActionCard =
+  const showActionCardContent =
     primaryActionCard !== null &&
     input.trim().length === 0 &&
     !composerPickerOpen &&
@@ -559,14 +499,12 @@ export function JovieChat({
                   </div>
 
                   <div
-                    className='relative mx-auto flex min-h-full w-full max-w-[52rem] flex-col gap-6 py-8'
+                    className='relative mx-auto flex min-h-full w-full max-w-[52rem] flex-col items-center justify-center gap-5 py-8'
                     data-testid='chat-empty-state-composer-region'
                   >
-                    <EmptyStateSignalCards dimmed={composerPickerOpen} />
-
                     <h1
                       className={cn(
-                        'text-balance text-center text-[2rem] font-semibold leading-[1.1] text-primary-token sm:text-[2.5rem] md:text-[3rem]',
+                        'text-balance text-center text-[2rem] font-semibold leading-[1.1] text-primary-token sm:text-[2.35rem] md:text-[2.65rem]',
                         composerPickerOpen && 'pointer-events-none opacity-0'
                       )}
                       aria-hidden={composerPickerOpen ? 'true' : undefined}
@@ -574,9 +512,13 @@ export function JovieChat({
                       {emptyStateHeading}
                     </h1>
 
-                    <div className='mx-auto flex w-full max-w-[38rem] flex-col items-center gap-3'>
-                      {showActionCard ? (
+                    <div
+                      className='mx-auto flex h-[172px] w-full max-w-[38rem] items-center justify-center sm:h-[148px]'
+                      data-testid='chat-empty-state-action-card-slot'
+                    >
+                      {showActionCardContent ? (
                         <SuggestionCard
+                          className='h-full'
                           title={primaryActionCard.title}
                           body={primaryActionCard.body}
                           actionLabel={primaryActionCard.actionLabel}

--- a/apps/web/components/shell/SuggestionCard.tsx
+++ b/apps/web/components/shell/SuggestionCard.tsx
@@ -53,7 +53,7 @@ export function SuggestionCard({
   return (
     <article
       className={cn(
-        'group/sug relative w-full rounded-[18px] overflow-hidden border border-white/[0.05] bg-(--linear-app-content-surface)',
+        'group/sug relative min-h-[148px] w-full overflow-hidden rounded-[18px] border border-white/[0.05] bg-(--linear-app-content-surface)',
         className
       )}
       style={{
@@ -62,15 +62,17 @@ export function SuggestionCard({
         transition: `box-shadow var(--ds-motion-cinematic-duration) ${EASE_CINEMATIC}`,
       }}
     >
-      <div className='px-7 py-6'>
-        <h2 className='text-[17px] font-semibold leading-[1.3] text-primary-token'>
-          {title}
-        </h2>
-        <p className='mt-2 text-[12.5px] leading-[1.6] text-tertiary-token'>
-          {body}
-        </p>
+      <div className='grid min-h-[inherit] grid-cols-1 items-center gap-4 px-5 py-5 sm:grid-cols-[minmax(0,1fr)_auto] sm:px-7'>
+        <div className='min-w-0'>
+          <h2 className='text-pretty text-[16px] font-semibold leading-[1.3] text-primary-token sm:text-[17px]'>
+            {title}
+          </h2>
+          <p className='mt-2 max-w-[48ch] text-pretty text-[12.5px] leading-[1.55] text-tertiary-token'>
+            {body}
+          </p>
+        </div>
 
-        <div className='mt-6 flex items-center justify-end gap-1'>
+        <div className='flex shrink-0 items-center justify-start gap-1 sm:justify-end'>
           {onDismiss && (
             <button
               type='button'

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -139,20 +139,14 @@ describe('JovieChat empty state', () => {
     mockChatState.isSubmitting = false;
   });
 
-  it('renders the minimal welcome state without prompt pills', () => {
+  it('renders the minimal welcome state without prompt pills or competing suggestion cards', () => {
     const { getByTestId, getByText, queryByTestId, queryByText } =
       renderWithQueryClient(<JovieChat profileId='profile-1' />);
 
-    expect(getByTestId('chat-empty-state-top-signals')).toBeTruthy();
-    expect(getByTestId('chat-empty-state-top-signals-row').className).toContain(
-      'lg:grid-cols-3'
-    );
-    expect(getByTestId('chat-empty-state-top-signals-row').className).toContain(
-      'snap-x'
-    );
-    expect(getByText('Release plan')).toBeTruthy();
-    expect(getByText('Asset brief')).toBeTruthy();
-    expect(getByText('Context')).toBeTruthy();
+    expect(queryByTestId('chat-empty-state-top-signals')).toBeNull();
+    expect(queryByText('Release plan')).toBeNull();
+    expect(queryByText('Asset brief')).toBeNull();
+    expect(queryByText('Context')).toBeNull();
     expect(getByText('What are we working on?')).toBeTruthy();
     expect(queryByText('Welcome back')).toBeNull();
     expect(queryByText('Welcome back, Tim')).toBeNull();
@@ -160,6 +154,10 @@ describe('JovieChat empty state', () => {
     expect(queryByText('Jovie Assistant')).toBeNull();
     expect(queryByText('Ask anything or tell Jovie what you need')).toBeNull();
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
+    expect(getByTestId('chat-empty-state-action-card-slot')).toBeTruthy();
+    expect(
+      getByTestId('chat-empty-state-action-card-slot').className
+    ).toContain('h-[172px]');
     expect(queryByTestId('chat-empty-state-prompt-rail')).toBeNull();
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(getByTestId('chat-input').getAttribute('data-placeholder')).toBe(
@@ -207,7 +205,7 @@ describe('JovieChat empty state', () => {
   it('hides the contextual action card while the empty composer has typed text', () => {
     mockChatState.input = 'Help me with';
 
-    const { getByTestId, queryByText } = renderWithQueryClient(
+    const { getByTestId, queryByTestId, queryByText } = renderWithQueryClient(
       <JovieChat
         profileId='profile-1'
         actionCards={[
@@ -223,7 +221,8 @@ describe('JovieChat empty state', () => {
     );
 
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
-    expect(getByTestId('chat-empty-state-top-signals')).toBeTruthy();
+    expect(getByTestId('chat-empty-state-action-card-slot')).toBeTruthy();
+    expect(queryByTestId('chat-empty-state-top-signals')).toBeNull();
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(queryByText('Connect Your Music Catalog')).toBeNull();
   });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2526 -->

## Summary
- Remove the competing top signal/suggestion-card stack from the chat empty state.
- Keep one reserved action-card slot so the action card can hide/reveal without moving the layout.
- Align the action-card and loading skeleton geometry around the same compact, vertically centered card treatment.
- Remove the /start loading prompt-pill skeleton row so prompt pills stay out of this wave.

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/jovie/JovieChat.tsx apps/web/components/shell/SuggestionCard.tsx apps/web/app/app/\(shell\)/chat/loading.tsx apps/web/app/\(dynamic\)/start/loading.tsx apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/chat/JovieChat.empty-state.test.tsx components/shell/SuggestionCard.test.tsx tests/unit/chat/ChatLoading.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- Playwright local QA on http://localhost:3001: desktop/mobile /app/chat, no top signal cards, one action card, action-card slot bbox stable before/after typing
- Pre-push hook: repo Biome, proxy guard, Tailwind guard, typecheck, lint

Screenshots: /tmp/shell-v1-cleanup-20260521/desktop-app-chat.png and /tmp/shell-v1-cleanup-20260521/mobile-app-chat.png