### PR TITLE
fix(lint): prevent ESLint crash on module configs

### DIFF
--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,6 +1,7 @@
 const nextConfig = require('eslint-config-next');
 const nextCoreWebVitals = require('eslint-config-next/core-web-vitals');
 const boundariesPlugin = require('eslint-plugin-boundaries');
+const tsParser = require('@typescript-eslint/parser');
 const iconUsageRule = require('./eslint-rules/icon-usage');
 const edgeRuntimeNodeImportsRule = require('./eslint-rules/edge-runtime-node-imports');
 const noHandlerInitializationRule = require('./eslint-rules/no-handler-initialization');
@@ -402,6 +403,17 @@ module.exports = [
     ],
     rules: {
       '@jovie/no-ad-hoc-currency': 'off',
+    },
+  },
+  {
+    files: ['**/*.{js,jsx,mjs,mts,cts}'],
+    languageOptions: {
+      // Next's default parser crashes on module-style config and support files
+      // under ESLint 10.2.1. Reuse the TypeScript parser here so plain JS/ESM
+      // scripts keep lint coverage.
+      parser: tsParser,
+      ecmaVersion: 'latest',
+      sourceType: 'module',
     },
   },
 ];

--- a/apps/web/stryker.config.mjs
+++ b/apps/web/stryker.config.mjs
@@ -1,5 +1,5 @@
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
-export default {
+const strykerConfig = {
   packageManager: 'pnpm',
   plugins: ['@stryker-mutator/vitest-runner'],
   testRunner: 'vitest',
@@ -85,3 +85,5 @@ export default {
   timeoutMS: 15000,
   dryRunTimeoutMinutes: 10,
 };
+
+export default strykerConfig;


### PR DESCRIPTION
## Summary
- Fix the ESLint 10 parser crash on module-style config/support files by routing `*.js`, `*.jsx`, `*.mjs`, `*.mts`, and `*.cts` through `@typescript-eslint/parser`.
- Normalize `apps/web/stryker.config.mjs` to a named export so the repo-wide lint gate does not trip on an anonymous default-export warning.

## Verification
- `pnpm --filter=@jovie/web exec eslint --no-cache scripts/analyze-issues.mjs --max-warnings=0`
- `pnpm --filter=@jovie/web exec eslint --no-cache vitest.config.storybook.mts --max-warnings=99999`
- `pnpm --filter=@jovie/web exec eslint --no-cache plopfile.js --max-warnings=0`
- `pnpm --filter web lint:eslint` now gets past the original parser crash and surfaces a separate pre-existing repo-wide lint baseline.

## Files Changed
- `apps/web/eslint.config.js`
- `apps/web/stryker.config.mjs`
