### PR TITLE
fix(security): rate limit account email sync

### DIFF
--- a/apps/web/app/api/account/email/route.ts
+++ b/apps/web/app/api/account/email/route.ts
@@ -7,6 +7,11 @@ import { getUserByClerkId } from '@/lib/db/queries/shared';
 import { users } from '@/lib/db/schema/auth';
 import { captureError } from '@/lib/error-tracking';
 import { parseJsonBody } from '@/lib/http/parse-json';
+import {
+  checkAccountEmailRateLimit,
+  createRateLimitHeaders,
+  getClientIP,
+} from '@/lib/rate-limit';
 import { logger } from '@/lib/utils/logger';
 import { accountEmailSyncSchema } from '@/lib/validation/schemas';
 
@@ -16,6 +21,21 @@ const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
 
 export async function POST(request: Request) {
   try {
+    const clientIp = getClientIP(request);
+    const rateLimitResult = await checkAccountEmailRateLimit(clientIp);
+    if (!rateLimitResult.success) {
+      return NextResponse.json(
+        { error: rateLimitResult.reason ?? 'Rate limit exceeded' },
+        {
+          status: 429,
+          headers: {
+            ...NO_STORE_HEADERS,
+            ...createRateLimitHeaders(rateLimitResult),
+          },
+        }
+      );
+    }
+
     const parsedBody = await parseJsonBody<unknown>(request, {
       route: 'POST /api/account/email',
       headers: NO_STORE_HEADERS,

--- a/apps/web/lib/rate-limit/config.ts
+++ b/apps/web/lib/rate-limit/config.ts
@@ -601,6 +601,15 @@ export const RATE_LIMITERS = {
     analytics: true,
   } satisfies RateLimitConfig,
 
+  /** Account email sync: 5 requests per minute per IP - prevents abuse */
+  accountEmail: {
+    name: 'Account Email',
+    limit: 5,
+    window: '1 m',
+    prefix: 'account:email',
+    analytics: true,
+  } satisfies RateLimitConfig,
+
   // ---------------------------------------------------------------------------
   // Verification Operations
   // ---------------------------------------------------------------------------

--- a/apps/web/lib/rate-limit/index.ts
+++ b/apps/web/lib/rate-limit/index.ts
@@ -37,6 +37,7 @@ export { parseWindowToMs, RATE_LIMITERS } from './config';
 // Pre-configured Limiter Instances
 export {
   accountDeleteLimiter,
+  accountEmailLimiter,
   accountExportLimiter,
   adminCreatorIngestLimiter,
   adminFitScoresLimiter,
@@ -62,6 +63,7 @@ export {
   bioImportFromUrlLimiter,
   changelogSubscribeLimiter,
   checkAccountDeleteRateLimit,
+  checkAccountEmailRateLimit,
   checkAccountExportRateLimit,
   checkAdminCreatorIngestRateLimit,
   checkAdminFitScoresRateLimit,

--- a/apps/web/lib/rate-limit/limiters.ts
+++ b/apps/web/lib/rate-limit/limiters.ts
@@ -885,6 +885,14 @@ export const accountExportLimiter = createRateLimiter(
 );
 
 /**
+ * Rate limiter for account email sync
+ * Limit: 5 requests per minute per IP - prevents abuse and enumeration
+ */
+export const accountEmailLimiter = createRateLimiter(
+  RATE_LIMITERS.accountEmail
+);
+
+/**
  * Check account deletion rate limit
  * Returns the first failure or success if pass
  */
@@ -909,6 +917,20 @@ export async function checkAccountExportRateLimit(
     accountExportLimiter,
     userId,
     'Too many export requests. Please try again later.'
+  );
+}
+
+/**
+ * Check account email sync rate limit.
+ * Returns the first failure or success if pass.
+ */
+export async function checkAccountEmailRateLimit(
+  clientIp: string
+): Promise<RateLimitResult> {
+  return checkRateLimit(
+    accountEmailLimiter,
+    clientIp,
+    'Too many email sync requests. Please try again later.'
   );
 }
 
@@ -1027,6 +1049,7 @@ export function getAllLimiters(): Record<string, RateLimiter> {
     releaseRefreshPaid: _releaseRefreshPaidLimiter,
     accountDelete: accountDeleteLimiter,
     accountExport: accountExportLimiter,
+    accountEmail: accountEmailLimiter,
     wrapLink: wrapLinkLimiter,
     wrapLinkAnonymous: wrapLinkAnonymousLimiter,
     verificationRequest: verificationRequestLimiter,

--- a/apps/web/tests/unit/api/account/email.test.ts
+++ b/apps/web/tests/unit/api/account/email.test.ts
@@ -2,6 +2,10 @@ import { NextRequest } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { POST } from '@/app/api/account/email/route';
 
+const mockRateLimitHeaders = vi.hoisted(() => vi.fn(() => ({})));
+const mockCheckAccountEmailRateLimit = vi.hoisted(() => vi.fn());
+const mockGetClientIP = vi.hoisted(() => vi.fn(() => '203.0.113.1'));
+
 const dbMock = vi.hoisted(() => {
   const where = vi.fn().mockResolvedValue(undefined);
   const set = vi.fn(() => ({ where }));
@@ -30,6 +34,12 @@ vi.mock('@/lib/auth/session', () => ({
   ),
 }));
 
+vi.mock('@/lib/rate-limit', () => ({
+  checkAccountEmailRateLimit: mockCheckAccountEmailRateLimit,
+  createRateLimitHeaders: mockRateLimitHeaders,
+  getClientIP: mockGetClientIP,
+}));
+
 vi.mock('@/lib/db', () => ({
   db: {
     update: dbMock.update,
@@ -49,6 +59,13 @@ describe('POST /api/account/email', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCheckAccountEmailRateLimit.mockResolvedValue({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: Date.now() + 60_000,
+    });
+    mockRateLimitHeaders.mockReturnValue({});
   });
 
   it('returns 400 for invalid payloads', async () => {
@@ -62,6 +79,34 @@ describe('POST /api/account/email', () => {
 
     const response = await POST(request);
     expect(response.status).toBe(400);
+  });
+
+  it('returns 429 when rate limited', async () => {
+    mockCheckAccountEmailRateLimit.mockResolvedValue({
+      success: false,
+      limit: 5,
+      remaining: 0,
+      reset: Date.now() + 60_000,
+      reason: 'Too many email sync requests. Please try again later.',
+    });
+    mockRateLimitHeaders.mockReturnValue({
+      'X-RateLimit-Limit': '5',
+      'X-RateLimit-Remaining': '0',
+    });
+
+    const request = new NextRequest('http://localhost/api/account/email', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ email: 'hello@example.com' }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(429);
+    expect(response.headers.get('X-RateLimit-Limit')).toBe('5');
+    expect(mockGetUser).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
   });
 
   it('requires the email to exist on the Clerk user', async () => {

--- a/apps/web/tests/unit/lib/rate-limit/limiters.test.ts
+++ b/apps/web/tests/unit/lib/rate-limit/limiters.test.ts
@@ -237,6 +237,12 @@ vi.mock('@/lib/rate-limit/config', () => ({
       window: '1 h',
       prefix: 'account:export',
     },
+    accountEmail: {
+      name: 'Account Email',
+      limit: 5,
+      window: '1 m',
+      prefix: 'account:email',
+    },
     appleMusicRescanFree: {
       name: 'Apple Music Rescan (Free)',
       limit: 1,
@@ -349,6 +355,7 @@ describe('limiters.ts', () => {
         'releaseRefreshPaid',
         'accountDelete',
         'accountExport',
+        'accountEmail',
       ];
 
       for (const key of expectedKeys) {


### PR DESCRIPTION
Implements the `/api/account/email` slice of GitHub issue #1424 by adding IP-based rate limiting before body parsing.

## What changed
- Added `accountEmail` rate-limit config and limiter wiring.
- Enforced the limit at the start of `/api/account/email` with a 429 response and rate-limit headers.
- Added unit coverage for the rate-limited short-circuit path and limiter registry coverage.

## Verification
- `pnpm --filter web exec vitest run tests/unit/api/account/email.test.ts tests/unit/lib/rate-limit/limiters.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Commit hook also ran `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome check .`, and `biome lint .` successfully.

## Notes
- This is a small slice of the broader `#1424` security sweep; the remaining public endpoints stay in follow-up PRs.
