### PR TITLE
fix(security): require MFA for admin access

### DIFF
--- a/apps/web/lib/admin/mfa.ts
+++ b/apps/web/lib/admin/mfa.ts
@@ -1,0 +1,31 @@
+import 'server-only';
+
+const ADMIN_MFA_AFTER_MINUTES = 15;
+
+type AuthWithHas = {
+  has?: (params: {
+    reverification?:
+      | 'strict_mfa'
+      | 'strict'
+      | 'moderate'
+      | 'lax'
+      | {
+          level: 'first_factor' | 'second_factor' | 'multi_factor';
+          afterMinutes: number;
+        };
+  }) => boolean;
+};
+
+export function hasRecentAdminMfaReverification(authResult: unknown): boolean {
+  const has = (authResult as AuthWithHas | null | undefined)?.has;
+  if (typeof has !== 'function') {
+    return false;
+  }
+
+  return has({
+    reverification: {
+      level: 'multi_factor',
+      afterMinutes: ADMIN_MFA_AFTER_MINUTES,
+    },
+  });
+}

--- a/apps/web/lib/admin/middleware.ts
+++ b/apps/web/lib/admin/middleware.ts
@@ -79,7 +79,7 @@ export async function requireAdmin(): Promise<NextResponse | null> {
   const userIsAdmin = await isAdmin(userId);
   const hasRecentMfa = authResult
     ? hasRecentAdminMfaReverification(authResult)
-    : true;
+    : false;
 
   // Mask user ID for logging to prevent PII exposure
   const maskedUserId = maskUserIdForLog(userId);
@@ -141,7 +141,7 @@ export async function checkIsAdmin(): Promise<boolean> {
   }
 
   if (!userId) return false;
-  if (authResult && !hasRecentAdminMfaReverification(authResult)) {
+  if (!authResult || !hasRecentAdminMfaReverification(authResult)) {
     return false;
   }
   return isAdmin(userId);

--- a/apps/web/lib/admin/middleware.ts
+++ b/apps/web/lib/admin/middleware.ts
@@ -9,6 +9,7 @@ import {
   resolveTestBypassUserId,
 } from '@/lib/auth/test-mode';
 import { captureWarning } from '@/lib/error-tracking';
+import { hasRecentAdminMfaReverification } from './mfa';
 import { isAdmin } from './roles';
 
 /**
@@ -33,6 +34,7 @@ import { isAdmin } from './roles';
  */
 export async function requireAdmin(): Promise<NextResponse | null> {
   let userId: string | null = null;
+  let authResult: Awaited<ReturnType<typeof auth>> | null = null;
 
   if (isTestAuthBypassEnabled()) {
     try {
@@ -46,7 +48,7 @@ export async function requireAdmin(): Promise<NextResponse | null> {
 
   if (!userId) {
     try {
-      const authResult = await auth();
+      authResult = await auth();
       userId = authResult.userId;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -75,11 +77,14 @@ export async function requireAdmin(): Promise<NextResponse | null> {
 
   // Check admin status
   const userIsAdmin = await isAdmin(userId);
+  const hasRecentMfa = authResult
+    ? hasRecentAdminMfaReverification(authResult)
+    : true;
 
   // Mask user ID for logging to prevent PII exposure
   const maskedUserId = maskUserIdForLog(userId);
 
-  if (!userIsAdmin) {
+  if (!userIsAdmin || !hasRecentMfa) {
     // Log unauthorized access attempt with masked ID
     captureWarning(
       `[admin/middleware] Forbidden admin access attempt by user: ${maskedUserId}`
@@ -111,6 +116,7 @@ export async function requireAdmin(): Promise<NextResponse | null> {
  */
 export async function checkIsAdmin(): Promise<boolean> {
   let userId: string | null = null;
+  let authResult: Awaited<ReturnType<typeof auth>> | null = null;
 
   if (isTestAuthBypassEnabled()) {
     try {
@@ -124,7 +130,7 @@ export async function checkIsAdmin(): Promise<boolean> {
 
   if (!userId) {
     try {
-      const authResult = await auth();
+      authResult = await auth();
       userId = authResult.userId;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -135,5 +141,8 @@ export async function checkIsAdmin(): Promise<boolean> {
   }
 
   if (!userId) return false;
+  if (authResult && !hasRecentAdminMfaReverification(authResult)) {
+    return false;
+  }
   return isAdmin(userId);
 }

--- a/apps/web/lib/entitlements/server.ts
+++ b/apps/web/lib/entitlements/server.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 
+import { hasRecentAdminMfaReverification } from '@/lib/admin/mfa';
 import { isAdmin as checkAdminRole } from '@/lib/admin/roles';
 import { getCachedAuth, getCachedCurrentUser } from '@/lib/auth/cached';
 import { resolveClerkIdentity } from '@/lib/auth/clerk-identity';
@@ -53,7 +54,8 @@ function isMissingBillingRecord(error?: string): boolean {
 }
 
 export async function getCurrentUserEntitlements(): Promise<UserEntitlements> {
-  const { userId } = await getCachedAuth();
+  const authResult = await getCachedAuth();
+  const { userId } = authResult;
   if (!userId) {
     return UNAUTHENTICATED_ENTITLEMENTS;
   }
@@ -69,10 +71,12 @@ export async function getCurrentUserEntitlements(): Promise<UserEntitlements> {
   // Check admin status independently of billing using the dedicated admin
   // role check (Redis-cached, 60s TTL). This avoids losing admin status when
   // the billing query fails due to transient DB/connection issues.
-  const [adminStatus, billing] = await Promise.all([
+  const [hasAdminRole, billing] = await Promise.all([
     checkAdminRole(userId),
     getUserBillingInfo(),
   ]);
+  const adminStatus =
+    hasAdminRole && hasRecentAdminMfaReverification(authResult);
 
   if (!billing.success) {
     if (isMissingBillingRecord(billing.error)) {

--- a/apps/web/tests/unit/lib/admin/mfa.test.ts
+++ b/apps/web/tests/unit/lib/admin/mfa.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import { hasRecentAdminMfaReverification } from '@/lib/admin/mfa';
+
+describe('hasRecentAdminMfaReverification', () => {
+  it('returns false when authResult does not expose has()', () => {
+    expect(hasRecentAdminMfaReverification(null)).toBe(false);
+    expect(hasRecentAdminMfaReverification({ userId: 'user_admin' })).toBe(
+      false
+    );
+  });
+
+  it('passes the expected reverification requirement to authResult.has()', () => {
+    const has = vi.fn().mockReturnValue(true);
+
+    expect(hasRecentAdminMfaReverification({ has })).toBe(true);
+    expect(has).toHaveBeenCalledWith({
+      reverification: {
+        level: 'multi_factor',
+        afterMinutes: 15,
+      },
+    });
+  });
+
+  it('returns false when authResult.has() reports stale MFA', () => {
+    const has = vi.fn().mockReturnValue(false);
+
+    expect(hasRecentAdminMfaReverification({ has })).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/lib/admin/middleware.test.ts
+++ b/apps/web/tests/unit/lib/admin/middleware.test.ts
@@ -79,4 +79,18 @@ describe('requireAdmin', () => {
 
     expect(response).toBeNull();
   });
+
+  it('fails closed when admin authResult is missing', async () => {
+    mockIsTestAuthBypassEnabled.mockReturnValue(true);
+    mockResolveTestBypassUserId.mockReturnValue('user_admin');
+    mockIsAdmin.mockResolvedValue(true);
+
+    const response = await requireAdmin();
+
+    expect(mockAuth).not.toHaveBeenCalled();
+    expect(response?.status).toBe(403);
+    await expect(response?.json()).resolves.toEqual({
+      error: 'Forbidden. Admin privileges required.',
+    });
+  });
 });

--- a/apps/web/tests/unit/lib/admin/middleware.test.ts
+++ b/apps/web/tests/unit/lib/admin/middleware.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { requireAdmin } from '@/lib/admin/middleware';
+
+const {
+  mockAuth,
+  mockHeaders,
+  mockCookies,
+  mockIsAdmin,
+  mockIsTestAuthBypassEnabled,
+  mockResolveTestBypassUserId,
+  mockCaptureWarning,
+} = vi.hoisted(() => ({
+  mockAuth: vi.fn(),
+  mockHeaders: vi.fn(),
+  mockCookies: vi.fn(),
+  mockIsAdmin: vi.fn(),
+  mockIsTestAuthBypassEnabled: vi.fn(),
+  mockResolveTestBypassUserId: vi.fn(),
+  mockCaptureWarning: vi.fn(),
+}));
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: mockAuth,
+}));
+
+vi.mock('next/headers', () => ({
+  headers: mockHeaders,
+  cookies: mockCookies,
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  addBreadcrumb: vi.fn(),
+}));
+
+vi.mock('@/lib/admin/roles', () => ({
+  isAdmin: mockIsAdmin,
+}));
+
+vi.mock('@/lib/auth/test-mode', () => ({
+  isTestAuthBypassEnabled: mockIsTestAuthBypassEnabled,
+  resolveTestBypassUserId: mockResolveTestBypassUserId,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureWarning: mockCaptureWarning,
+}));
+
+describe('requireAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsTestAuthBypassEnabled.mockReturnValue(false);
+    mockHeaders.mockResolvedValue(new Headers());
+    mockCookies.mockResolvedValue({ get: vi.fn() });
+  });
+
+  it('denies admin role when MFA reverification is stale', async () => {
+    mockAuth.mockResolvedValue({
+      userId: 'user_admin',
+      has: vi.fn().mockReturnValue(false),
+    });
+    mockIsAdmin.mockResolvedValue(true);
+
+    const response = await requireAdmin();
+
+    expect(response?.status).toBe(403);
+    await expect(response?.json()).resolves.toEqual({
+      error: 'Forbidden. Admin privileges required.',
+    });
+  });
+
+  it('allows admin role with fresh MFA reverification', async () => {
+    mockAuth.mockResolvedValue({
+      userId: 'user_admin',
+      has: vi.fn().mockReturnValue(true),
+    });
+    mockIsAdmin.mockResolvedValue(true);
+
+    const response = await requireAdmin();
+
+    expect(response).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/lib/entitlements-billing-negative.test.ts
+++ b/apps/web/tests/unit/lib/entitlements-billing-negative.test.ts
@@ -232,7 +232,10 @@ describe('Entitlements – Billing Failure Safety', () => {
   });
 
   it('billing failure for admin preserves admin flag in degraded result', async () => {
-    mockCachedAuth.mockResolvedValue({ userId: 'user_admin_fail' });
+    mockCachedAuth.mockResolvedValue({
+      userId: 'user_admin_fail',
+      has: vi.fn().mockReturnValue(true),
+    });
     mockCachedCurrentUser.mockResolvedValue({
       primaryEmailAddress: { emailAddress: 'admin@example.com' },
     });

--- a/apps/web/tests/unit/lib/entitlements-concurrency-isolation.test.ts
+++ b/apps/web/tests/unit/lib/entitlements-concurrency-isolation.test.ts
@@ -34,9 +34,18 @@ vi.mock('@/lib/utils/logger', () => ({
 describe('entitlements concurrent access isolation', () => {
   it('keeps per-request data isolated across concurrent calls', async () => {
     const authSequence = [
-      { userId: 'user_free' },
-      { userId: 'user_pro' },
-      { userId: 'user_max' },
+      {
+        userId: 'user_free',
+        has: vi.fn().mockReturnValue(false),
+      },
+      {
+        userId: 'user_pro',
+        has: vi.fn().mockReturnValue(false),
+      },
+      {
+        userId: 'user_max',
+        has: vi.fn().mockReturnValue(true),
+      },
     ];
 
     mockCachedAuth.mockImplementation(async () => authSequence.shift());

--- a/apps/web/tests/unit/lib/entitlements.server.test.ts
+++ b/apps/web/tests/unit/lib/entitlements.server.test.ts
@@ -104,7 +104,10 @@ describe('getCurrentUserEntitlements', () => {
   });
 
   it('billing failure preserves admin status in degraded result', async () => {
-    mockCachedAuth.mockResolvedValue({ userId: 'user_admin' });
+    mockCachedAuth.mockResolvedValue({
+      userId: 'user_admin',
+      has: vi.fn().mockReturnValue(true),
+    });
     mockCachedCurrentUser.mockResolvedValue({
       primaryEmailAddress: { emailAddress: 'admin@example.com' },
     });
@@ -408,7 +411,10 @@ describe('getCurrentUserEntitlements', () => {
   });
 
   it('admin status is fetched independently of billing', async () => {
-    mockCachedAuth.mockResolvedValue({ userId: 'user_admin' });
+    mockCachedAuth.mockResolvedValue({
+      userId: 'user_admin',
+      has: vi.fn().mockReturnValue(true),
+    });
     mockCachedCurrentUser.mockResolvedValue({
       primaryEmailAddress: { emailAddress: 'admin@example.com' },
     });
@@ -430,6 +436,33 @@ describe('getCurrentUserEntitlements', () => {
 
     // isAdmin comes from the role check (Redis), not from billing DB
     expect(entitlements.isAdmin).toBe(true);
+  });
+
+  it('does not treat an admin role as admin without fresh MFA reverification', async () => {
+    mockCachedAuth.mockResolvedValue({
+      userId: 'user_admin',
+      has: vi.fn().mockReturnValue(false),
+    });
+    mockCachedCurrentUser.mockResolvedValue({
+      primaryEmailAddress: { emailAddress: 'admin@example.com' },
+    });
+    mockIsAdmin.mockResolvedValue(true);
+    mockGetUserBillingInfo.mockResolvedValue({
+      success: true,
+      data: {
+        userId: 'db_user_id',
+        email: 'admin@example.com',
+        isAdmin: false,
+        isPro: false,
+        plan: 'free',
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+      },
+    });
+
+    const entitlements = await getCurrentUserEntitlements();
+
+    expect(entitlements.isAdmin).toBe(false);
   });
 
   it('defaults to pro plan when isPro=true but dbPlan is null', async () => {
@@ -544,7 +577,10 @@ describe('getCurrentUserEntitlements', () => {
   });
 
   it('admin who is also a pro subscriber gets both flags', async () => {
-    mockCachedAuth.mockResolvedValue({ userId: 'user_admin_pro' });
+    mockCachedAuth.mockResolvedValue({
+      userId: 'user_admin_pro',
+      has: vi.fn().mockReturnValue(true),
+    });
     mockCachedCurrentUser.mockResolvedValue({
       primaryEmailAddress: { emailAddress: 'adminpro@example.com' },
     });


### PR DESCRIPTION
Implements the smallest safe MFA enforcement cut for GitHub issue #1425.

## What changed
- Added a tiny shared helper for Clerk reverification freshness checks: `hasRecentAdminMfaReverification()`.
- Admin entitlements now require both the existing admin role check and a fresh multi-factor reverification window.
- `requireAdmin()` now denies admin routes when reverification is stale, so route-level admin access cannot bypass the guard.
- Added focused tests for the entitlements path and admin middleware path.

## Verification
- `pnpm --filter web exec vitest run tests/unit/lib/entitlements.server.test.ts tests/unit/lib/admin/middleware.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Commit hook also ran `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome check .`, and `biome lint .` successfully.

## Notes
- This keeps admin access consistent across the two trust boundaries that actually grant it: entitlements resolution and admin route guarding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin users must re-verify multi-factor authentication within 15 minutes to access admin features; users failing this recency check are denied access.

* **Security / Access**
  * Admin checks and entitlement determination now account for recent MFA re-verification when granting admin status.

* **Tests**
  * Added and updated unit tests to cover MFA recency enforcement and related admin/entitlement behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->