### PR TITLE
JOV-2535: Use shared releases header action group

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
@@ -31,6 +31,7 @@ import {
   useRegisterHeaderActions,
   useRegisterHeaderSearch,
 } from '@/contexts/HeaderActionsContext';
+import { DashboardHeaderActionGroup } from '@/features/dashboard/atoms/DashboardHeaderActionGroup';
 import { buildReleaseActions } from '@/features/dashboard/organisms/releases/release-actions';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import { openChatWithPrompt } from '@/lib/chat/open-chat-with-prompt';
@@ -851,14 +852,14 @@ export function ShellReleasesView({
 
   const headerActions = useMemo(() => {
     return (
-      <div className='flex items-center gap-2'>
+      <DashboardHeaderActionGroup>
         <NewReleaseHeaderAction
           canCreateManualReleases={canCreateManualReleases}
           isSyncing={isSyncing}
           onSyncSpotify={handleSync}
           onCreateManual={handleNewRelease}
         />
-      </div>
+      </DashboardHeaderActionGroup>
     );
   }, [canCreateManualReleases, handleNewRelease, handleSync, isSyncing]);
 


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2535 -->

## Summary
- Replace the shell releases header action wrapper with `DashboardHeaderActionGroup`.
- Preserve the existing `NewReleaseHeaderAction` props and release behavior.

## Layout Shift Audit
- Checked header states by inspection: manual creation allowed vs not allowed, sync idle vs syncing, desktop vs mobile overflow.
- The shared group keeps a stable flex/min-width/overflow header slot and does not add conditional content.

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx` - passed, checked 1 file with no fixes applied.
- `pnpm --filter @jovie/web exec vitest run tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx tests/unit/dashboard/NewReleaseHeaderAction.test.tsx` - passed, 2 files and 28 tests.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` - passed.
- Pre-push gate passed: `biome check . && pnpm --filter=@jovie/web run pre-push`.