### PR TITLE
refactor(shell): share sidebar nav row chrome

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
@@ -10,7 +10,6 @@ import {
 import { Copy, ExternalLink } from 'lucide-react';
 import Link from 'next/link';
 import {
-  type ComponentType,
   type MouseEvent,
   type ReactNode,
   useCallback,
@@ -24,12 +23,15 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@/components/organisms/Sidebar';
+import {
+  getSidebarNavIconClassName,
+  getSidebarNavRowClassName,
+} from '@/components/shell/SidebarNavItem';
 import { Tooltip } from '@/components/shell/Tooltip';
 import { BASE_URL } from '@/constants/domains';
 import { copyToClipboard } from '@/hooks/useClipboard';
 import { useIsElectronRuntime } from '@/lib/desktop/electron-bridge';
 import type { KeyboardShortcut } from '@/lib/keyboard-shortcuts';
-import { cn } from '@/lib/utils';
 import type { NavItem } from './types';
 
 interface NavMenuItemProps {
@@ -270,25 +272,16 @@ export function NavMenuItem({
     showPendingShell,
   ]);
 
-  const ShellIcon = item.icon as ComponentType<{
-    readonly className?: string;
-    readonly strokeWidth?: number;
-  }>;
   const shellNavItem = useShellNavItem;
-  const shellNavClassName = cn(
-    'relative flex h-6 w-full items-center gap-2 rounded-md pl-2.5 pr-2 text-[12.5px] tracking-[-0.005em] transition-colors duration-subtle ease-out',
-    isActive
-      ? 'bg-surface-1 text-primary-token'
-      : 'text-secondary-token hover:bg-surface-1 hover:text-primary-token',
-    'group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:h-8 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0'
-  );
+  const shellNavClassName = getSidebarNavRowClassName({
+    active: isActive,
+    className:
+      'group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:h-8 group-data-[collapsible=icon]:w-10 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0',
+  });
   const shellInnerContent = (
     <>
-      <ShellIcon
-        className={cn(
-          'h-3 w-3 shrink-0',
-          isActive ? 'text-primary-token' : 'text-tertiary-token'
-        )}
+      <item.icon
+        className={getSidebarNavIconClassName({ active: isActive })}
         strokeWidth={2.25}
         aria-hidden='true'
       />

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -24,37 +24,76 @@ export interface SidebarNavItemProps {
   readonly tight?: boolean;
 }
 
+interface SidebarNavChromeOptions {
+  readonly active?: boolean;
+  readonly collapsed?: boolean;
+  readonly nested?: boolean;
+  readonly tight?: boolean;
+  readonly className?: string;
+}
+
+export function getSidebarNavRowClassName({
+  active,
+  collapsed,
+  nested,
+  tight,
+  className,
+}: SidebarNavChromeOptions) {
+  const nonCollapsedSize = tight ? 'h-6 pl-2.5 pr-2' : 'h-6.5 pl-2.5 pr-2';
+  const inactiveColor = nested
+    ? 'text-tertiary-token hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] hover:text-primary-token'
+    : 'text-secondary-token hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] hover:text-primary-token';
+
+  return cn(
+    'relative flex items-center rounded-md w-full transition-[background-color] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+    tight ? 'gap-2 text-[12px]' : 'gap-2.5 text-[12.5px]',
+    collapsed ? 'h-7 w-10 mx-auto justify-center' : nonCollapsedSize,
+    active ? 'text-primary-token bg-surface-1' : inactiveColor,
+    className
+  );
+}
+
+export function getSidebarNavIconClassName({
+  active,
+  nested,
+  tight,
+  className,
+}: SidebarNavChromeOptions) {
+  const inactiveIconColor = nested
+    ? 'text-quaternary-token'
+    : 'text-tertiary-token';
+
+  return cn(
+    'shrink-0',
+    tight ? 'h-3 w-3' : 'h-3.5 w-3.5',
+    active ? 'text-primary-token' : inactiveIconColor,
+    className
+  );
+}
+
 export function SidebarNavItem({
   item,
   collapsed,
   nested,
   tight,
 }: SidebarNavItemProps) {
-  const nonCollapsedSize = tight ? 'h-6 pl-2.5 pr-2' : 'h-6.5 pl-2.5 pr-2';
-  const inactiveColor = nested
-    ? 'text-tertiary-token hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] hover:text-primary-token'
-    : 'text-secondary-token hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] hover:text-primary-token';
-  const inactiveIconColor = nested
-    ? 'text-quaternary-token'
-    : 'text-tertiary-token';
-
   const button = (
     <button
       type='button'
       onClick={item.onActivate}
-      className={cn(
-        'relative flex items-center rounded-md w-full transition-[background-color] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
-        tight ? 'gap-2 text-[12px]' : 'gap-2.5 text-[12.5px]',
-        collapsed ? 'h-7 w-10 mx-auto justify-center' : nonCollapsedSize,
-        item.active ? 'text-primary-token bg-surface-1' : inactiveColor
-      )}
+      className={getSidebarNavRowClassName({
+        active: item.active,
+        collapsed,
+        nested,
+        tight,
+      })}
     >
       <item.icon
-        className={cn(
-          'shrink-0',
-          tight ? 'h-3 w-3' : 'h-3.5 w-3.5',
-          item.active ? 'text-primary-token' : inactiveIconColor
-        )}
+        className={getSidebarNavIconClassName({
+          active: item.active,
+          nested,
+          tight,
+        })}
         strokeWidth={2.25}
       />
       {!collapsed && <span className='truncate'>{item.label}</span>}

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -245,7 +245,8 @@ describe('DashboardNav', () => {
     });
 
     const tasksLink = getByRole('link', { name: 'Tasks 7' });
-    expect(tasksLink.className).toContain('h-6');
+    expect(tasksLink.className).toContain('h-6.5');
+    expect(tasksLink.className).toContain('gap-2.5');
     expect(tasksLink.className).toContain('text-[12.5px]');
     expect(getByText('7')).toBeDefined();
   });

--- a/apps/web/tests/unit/sidebar-row-alignment.test.tsx
+++ b/apps/web/tests/unit/sidebar-row-alignment.test.tsx
@@ -8,6 +8,10 @@ import {
   SidebarHeader,
   SidebarSeparator,
 } from '@/components/organisms/sidebar/layout';
+import {
+  getSidebarNavIconClassName,
+  getSidebarNavRowClassName,
+} from '@/components/shell/SidebarNavItem';
 
 type SidebarGroupProps = PropsWithChildren<{ className?: string }>;
 type SidebarGroupContentProps = PropsWithChildren<{ className?: string }>;
@@ -77,5 +81,22 @@ describe('Sidebar row alignment', () => {
     expect(header?.getAttribute('class')).toContain('px-2.5');
     expect(content?.getAttribute('class')).toContain('px-0');
     expect(separator?.getAttribute('class')).toContain('mx-2.5');
+  });
+
+  it('shares the shell nav row and icon chrome helpers', () => {
+    const rowClassName = getSidebarNavRowClassName({});
+    const activeRowClassName = getSidebarNavRowClassName({ active: true });
+    const iconClassName = getSidebarNavIconClassName({});
+
+    expect(rowClassName).toContain('h-6.5');
+    expect(rowClassName).toContain('pl-2.5');
+    expect(rowClassName).toContain('gap-2.5');
+    expect(rowClassName).toContain('text-[12.5px]');
+    expect(rowClassName).toContain(
+      'hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)]'
+    );
+    expect(activeRowClassName).toContain('bg-surface-1');
+    expect(iconClassName).toContain('h-3.5');
+    expect(iconClassName).toContain('text-tertiary-token');
   });
 });


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2534 -->

## Summary
- Export shared shell sidebar row and icon class helpers from `SidebarNavItem`.
- Use the shared helpers in `NavMenuItem` only for the Design V1 shell branch while preserving existing link/button markup, handlers, badges, and context menu wiring.
- Add focused assertions for shared row chrome and Design V1 badge alignment.

## Verification
- PASS `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/DashboardNav.test.tsx tests/components/dashboard/DashboardNav.interaction.test.tsx components/shell/SidebarThreadsSection.test.tsx tests/unit/sidebar-row-alignment.test.tsx` (4 files, 42 tests)
- PASS `pnpm biome check --write apps/web/components/shell/SidebarNavItem.tsx apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx apps/web/tests/unit/sidebar-row-alignment.test.tsx apps/web/tests/unit/dashboard/DashboardNav.test.tsx`
- PASS `pnpm --filter @jovie/web run typecheck -- --pretty false`
- PASS `pnpm turbo typecheck` (7 tasks)
- PASS pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Layout Shift Audit
- States checked by inspection and focused tests: active/inactive rows, link/button rows, badge rows, collapsed icon mode, and pending navigation callbacks.
- DOM structure and handler wiring are unchanged for Design V1 rows; only the row/icon class source is shared.