### PR TITLE
fix: pin Ruby for iOS release workflows

### DIFF
--- a/.github/workflows/ios-signing-bootstrap.yml
+++ b/.github/workflows/ios-signing-bootstrap.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.3"
           bundler-cache: true
 
       - name: Validate signing bootstrap secrets

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.3"
           bundler-cache: true
 
       - name: Validate TestFlight secrets


### PR DESCRIPTION
## Summary
- Pin Ruby 3.3 for iOS signing bootstrap and TestFlight workflows so ruby/setup-ruby can run on macos-26 without a repo .ruby-version file.

## Verification
- actionlint .github/workflows/ios-signing-bootstrap.yml .github/workflows/ios-testflight.yml
- git diff --check
- pre-push hook: Biome, proxy guard, Tailwind guard, typecheck, lint