### PR TITLE
fix(web): add CSRF header injection to shared fetch wrapper

### DIFF
--- a/apps/web/lib/queries/fetch.ts
+++ b/apps/web/lib/queries/fetch.ts
@@ -9,6 +9,12 @@
  * TanStack Query is used with server data.
  */
 
+import {
+  CSRF_HEADER_NAME,
+  getBrowserCsrfToken,
+  shouldAttachCsrfHeader,
+} from '@/lib/security/csrf';
+
 interface FetchOptions extends RequestInit {
   /**
    * Timeout in milliseconds. Defaults to 10 seconds.
@@ -91,8 +97,20 @@ export async function fetchWithTimeoutResponse(
   linkSignal(controller, externalSignal ?? undefined);
 
   try {
+    const headers = new Headers(fetchOptions.headers);
+    if (
+      shouldAttachCsrfHeader(url, fetchOptions.method) &&
+      !headers.has(CSRF_HEADER_NAME)
+    ) {
+      const csrfToken = getBrowserCsrfToken();
+      if (csrfToken) {
+        headers.set(CSRF_HEADER_NAME, csrfToken);
+      }
+    }
+
     const response = await fetch(url, {
       ...fetchOptions,
+      headers,
       signal: controller.signal,
     });
 

--- a/apps/web/lib/queries/fetch.ts
+++ b/apps/web/lib/queries/fetch.ts
@@ -97,22 +97,27 @@ export async function fetchWithTimeoutResponse(
   linkSignal(controller, externalSignal ?? undefined);
 
   try {
-    const headers = new Headers(fetchOptions.headers);
-    if (
-      shouldAttachCsrfHeader(url, fetchOptions.method) &&
-      !headers.has(CSRF_HEADER_NAME)
-    ) {
+    let headers = fetchOptions.headers;
+    if (shouldAttachCsrfHeader(url, fetchOptions.method)) {
       const csrfToken = getBrowserCsrfToken();
       if (csrfToken) {
-        headers.set(CSRF_HEADER_NAME, csrfToken);
+        const csrfHeaders = new Headers(fetchOptions.headers);
+        if (!csrfHeaders.has(CSRF_HEADER_NAME)) {
+          csrfHeaders.set(CSRF_HEADER_NAME, csrfToken);
+          headers = csrfHeaders;
+        }
       }
     }
 
-    const response = await fetch(url, {
+    const requestInit: RequestInit = {
       ...fetchOptions,
-      headers,
       signal: controller.signal,
-    });
+    };
+    if (headers !== undefined) {
+      requestInit.headers = headers;
+    }
+
+    const response = await fetch(url, requestInit);
 
     if (!response.ok) {
       let message = getFetchErrorMessage(response);

--- a/apps/web/lib/security/csrf.ts
+++ b/apps/web/lib/security/csrf.ts
@@ -31,15 +31,19 @@ export function getBrowserCsrfToken(): string | null {
 }
 
 export function isSameOriginApiRequest(url: string): boolean {
-  if (typeof globalThis.location === 'undefined') {
+  const origin = globalThis.location?.origin;
+  if (typeof origin !== 'string' || origin.length === 0) {
     return false;
   }
 
-  const requestUrl = new URL(url, globalThis.location.origin);
-  return (
-    requestUrl.origin === globalThis.location.origin &&
-    requestUrl.pathname.startsWith('/api/')
-  );
+  try {
+    const requestUrl = new URL(url, origin);
+    return (
+      requestUrl.origin === origin && requestUrl.pathname.startsWith('/api/')
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function shouldAttachCsrfHeader(

--- a/apps/web/lib/security/csrf.ts
+++ b/apps/web/lib/security/csrf.ts
@@ -1,0 +1,50 @@
+export const CSRF_COOKIE_NAME = 'jovie_csrf';
+export const CSRF_HEADER_NAME = 'x-jovie-csrf';
+
+export function isUnsafeMethod(method: string | undefined): boolean {
+  switch ((method ?? '').toUpperCase()) {
+    case 'POST':
+    case 'PUT':
+    case 'PATCH':
+    case 'DELETE':
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function getBrowserCsrfToken(): string | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  const prefix = `${CSRF_COOKIE_NAME}=`;
+  for (const entry of document.cookie.split(';')) {
+    const trimmed = entry.trim();
+    if (trimmed.startsWith(prefix)) {
+      const token = trimmed.slice(prefix.length);
+      return token.length > 0 ? token : null;
+    }
+  }
+
+  return null;
+}
+
+export function isSameOriginApiRequest(url: string): boolean {
+  if (typeof globalThis.location === 'undefined') {
+    return false;
+  }
+
+  const requestUrl = new URL(url, globalThis.location.origin);
+  return (
+    requestUrl.origin === globalThis.location.origin &&
+    requestUrl.pathname.startsWith('/api/')
+  );
+}
+
+export function shouldAttachCsrfHeader(
+  url: string,
+  method: string | undefined
+): boolean {
+  return isUnsafeMethod(method) && isSameOriginApiRequest(url);
+}

--- a/apps/web/tests/lib/queries/fetch-csrf.test.ts
+++ b/apps/web/tests/lib/queries/fetch-csrf.test.ts
@@ -33,7 +33,6 @@ describe('fetchWithTimeoutResponse CSRF header injection', () => {
       headers: { 'Content-Type': 'application/json' },
     });
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
     const [, options] = mockFetch.mock.calls[0] as [
       string,
       RequestInit & { headers?: HeadersInit },
@@ -55,6 +54,55 @@ describe('fetchWithTimeoutResponse CSRF header injection', () => {
 
     await fetchWithTimeoutResponse('/api/stripe/checkout');
 
+    const [, options] = mockFetch.mock.calls[0] as [
+      string,
+      RequestInit & { headers?: HeadersInit },
+    ];
+    const headers = new Headers(options.headers);
+
+    expect(headers.get(CSRF_HEADER_NAME)).toBeNull();
+  });
+
+  it('does not attach the CSRF token when location origin is missing', async () => {
+    document.cookie = 'jovie_csrf=session-token-123';
+    vi.stubGlobal('location', { origin: undefined } as Location);
+    mockFetch.mockResolvedValueOnce(
+      new Response('{"ok":true}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    await fetchWithTimeoutResponse('/api/stripe/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, options] = mockFetch.mock.calls[0] as [
+      string,
+      RequestInit & { headers?: HeadersInit },
+    ];
+    const headers = new Headers(options.headers);
+
+    expect(headers.get(CSRF_HEADER_NAME)).toBeNull();
+  });
+
+  it('does not attach the CSRF token when URL parsing throws', async () => {
+    document.cookie = 'jovie_csrf=session-token-123';
+    mockFetch.mockResolvedValueOnce(
+      new Response('{"ok":true}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    await fetchWithTimeoutResponse('http://[::1', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     const [, options] = mockFetch.mock.calls[0] as [
       string,
       RequestInit & { headers?: HeadersInit },

--- a/apps/web/tests/lib/queries/fetch-csrf.test.ts
+++ b/apps/web/tests/lib/queries/fetch-csrf.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchWithTimeoutResponse } from '@/lib/queries/fetch';
+import { CSRF_HEADER_NAME } from '@/lib/security/csrf';
+
+describe('fetchWithTimeoutResponse CSRF header injection', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+    document.cookie = 'jovie_csrf=';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('attaches the CSRF token to same-origin mutating API requests', async () => {
+    document.cookie = 'jovie_csrf=session-token-123';
+    mockFetch.mockResolvedValueOnce(
+      new Response('{"ok":true}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    await fetchWithTimeoutResponse('/api/stripe/checkout', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, options] = mockFetch.mock.calls[0] as [
+      string,
+      RequestInit & { headers?: HeadersInit },
+    ];
+    const headers = new Headers(options.headers);
+
+    expect(headers.get('content-type')).toBe('application/json');
+    expect(headers.get(CSRF_HEADER_NAME)).toBe('session-token-123');
+  });
+
+  it('does not attach the CSRF token to safe requests', async () => {
+    document.cookie = 'jovie_csrf=session-token-123';
+    mockFetch.mockResolvedValueOnce(
+      new Response('{"ok":true}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    await fetchWithTimeoutResponse('/api/stripe/checkout');
+
+    const [, options] = mockFetch.mock.calls[0] as [
+      string,
+      RequestInit & { headers?: HeadersInit },
+    ];
+    const headers = new Headers(options.headers);
+
+    expect(headers.get(CSRF_HEADER_NAME)).toBeNull();
+  });
+
+  it('preserves an explicitly provided CSRF header', async () => {
+    document.cookie = 'jovie_csrf=session-token-123';
+    mockFetch.mockResolvedValueOnce(
+      new Response('{"ok":true}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    );
+
+    await fetchWithTimeoutResponse('/api/stripe/checkout', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [CSRF_HEADER_NAME]: 'explicit-token',
+      },
+    });
+
+    const [, options] = mockFetch.mock.calls[0] as [
+      string,
+      RequestInit & { headers?: HeadersInit },
+    ];
+    const headers = new Headers(options.headers);
+
+    expect(headers.get(CSRF_HEADER_NAME)).toBe('explicit-token');
+  });
+});

--- a/apps/web/tests/lib/queries/fetch.test.ts
+++ b/apps/web/tests/lib/queries/fetch.test.ts
@@ -9,6 +9,15 @@ import {
 // Mock global fetch with proper isolation
 const mockFetch = vi.fn();
 
+function getCalledHeaders(callIndex = 0): Headers {
+  const [, options] = mockFetch.mock.calls[callIndex] as [
+    string,
+    RequestInit & { headers?: HeadersInit },
+  ];
+
+  return new Headers(options.headers);
+}
+
 describe('fetch utilities', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', mockFetch);
@@ -174,11 +183,12 @@ describe('fetch utilities', () => {
         body: JSON.stringify({ data: 'test' }),
       });
 
+      const headers = getCalledHeaders();
+      expect(headers.get('X-Custom')).toBe('value');
       expect(mockFetch).toHaveBeenCalledWith(
         '/api/test',
         expect.objectContaining({
           method: 'POST',
-          headers: { 'X-Custom': 'value' },
           body: JSON.stringify({ data: 'test' }),
         })
       );
@@ -233,12 +243,9 @@ describe('fetch utilities', () => {
       });
       await queryFn({});
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        '/api/test',
-        expect.objectContaining({
-          headers: { Authorization: 'Bearer token' },
-        })
-      );
+      const headers = getCalledHeaders();
+      expect(headers.get('Authorization')).toBe('Bearer token');
+      expect(mockFetch).toHaveBeenCalledWith('/api/test', expect.any(Object));
     });
   });
 
@@ -257,11 +264,12 @@ describe('fetch utilities', () => {
       const result = await mutationFn({ name: 'Test' });
 
       expect(result).toEqual(mockResponse);
+      const headers = getCalledHeaders();
+      expect(headers.get('Content-Type')).toBe('application/json');
       expect(mockFetch).toHaveBeenCalledWith(
         '/api/create',
         expect.objectContaining({
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ name: 'Test' }),
         })
       );
@@ -329,15 +337,10 @@ describe('fetch utilities', () => {
       });
       await mutationFn({ data: 'test' });
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        '/api/test',
-        expect.objectContaining({
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: 'Bearer token',
-          },
-        })
-      );
+      const headers = getCalledHeaders();
+      expect(headers.get('Content-Type')).toBe('application/json');
+      expect(headers.get('Authorization')).toBe('Bearer token');
+      expect(mockFetch).toHaveBeenCalledWith('/api/test', expect.any(Object));
     });
 
     it('propagates FetchError on failure', async () => {

--- a/apps/web/tests/unit/lib/security/csrf.test.ts
+++ b/apps/web/tests/unit/lib/security/csrf.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  isSameOriginApiRequest,
+  shouldAttachCsrfHeader,
+} from '@/lib/security/csrf';
+
+describe('csrf helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('recognizes same-origin API requests', () => {
+    const origin = globalThis.location?.origin;
+
+    expect(typeof origin).toBe('string');
+    expect(isSameOriginApiRequest('/api/stripe/checkout')).toBe(true);
+    expect(shouldAttachCsrfHeader('/api/stripe/checkout', 'POST')).toBe(true);
+  });
+
+  it('fails closed when location origin is missing', () => {
+    vi.stubGlobal('location', { origin: undefined } as Location);
+
+    expect(isSameOriginApiRequest('/api/stripe/checkout')).toBe(false);
+    expect(shouldAttachCsrfHeader('/api/stripe/checkout', 'POST')).toBe(false);
+  });
+
+  it('fails closed when URL parsing throws', () => {
+    expect(isSameOriginApiRequest('http://[::1')).toBe(false);
+    expect(shouldAttachCsrfHeader('http://[::1', 'POST')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Inject the CSRF header from the browser cookie into same-origin mutating `/api/*` requests in the shared fetch wrapper.
- Preserve explicitly supplied CSRF headers.
- Add focused regression coverage for unsafe requests, safe requests, and explicit-header preservation.

## Verification
- `pnpm --filter web exec vitest run tests/lib/queries/fetch.test.ts tests/lib/queries/fetch-csrf.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write apps/web/lib/queries/fetch.ts apps/web/lib/security/csrf.ts apps/web/tests/lib/queries/fetch.test.ts apps/web/tests/lib/queries/fetch-csrf.test.ts`

Fixes #1405


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic CSRF token attachment for mutating API requests to enhance security.

* **Tests**
  * Added comprehensive test suite for CSRF header injection and updated existing tests to validate header handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9512?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->