### PR TITLE
fix(release): update ios bundler pin JOV-2530

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,4 +231,4 @@ RUBY VERSION
    ruby 2.6.10p210
 
 BUNDLED WITH
-   1.17.2
+   2.4.22


### PR DESCRIPTION
## Summary
- Updates the root Bundler lockfile pin from 1.17.2 to 2.4.22 so GitHub macOS runners using Ruby 3.3 can run Fastlane workflows.
- Keeps the change scoped to release tooling after the iOS signing bootstrap failed in ruby/setup-ruby.

## Verification
- `GEM_HOME="$PWD/.tmp-ruby-gems" GEM_PATH="$PWD/.tmp-ruby-gems" gem install bundler -v 2.4.22 --no-document`
- `GEM_HOME="$PWD/.tmp-ruby-gems" GEM_PATH="$PWD/.tmp-ruby-gems" .tmp-ruby-gems/bin/bundle _2.4.22_ lock --local`
- `actionlint .github/workflows/ios-signing-bootstrap.yml .github/workflows/ios-testflight.yml`
- `git diff --check`
- pre-push hook: `biome check .`, proxy guard, Tailwind guard, typecheck, lint

## Release Note
- Required for JOV-2530 iOS TestFlight signing bootstrap.