### PR TITLE
fix(shell): keep sidebar now-playing production-backed

### DIFF
--- a/apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx
+++ b/apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx
@@ -3,13 +3,14 @@
 import { useCallback } from 'react';
 import { useTrackAudioPlayer } from '@/components/organisms/release-sidebar/useTrackAudioPlayer';
 import { SidebarBottomNowPlaying } from '@/components/shell/SidebarBottomNowPlaying';
-import { useAppFlag } from '@/lib/flags/client';
+import { cn } from '@/lib/utils';
 import { useAudioChromeSnapshot } from './audio-chrome-state';
 
 /**
- * SidebarBottomNowPlayingBridge — flag-gated mount of the shell
+ * SidebarBottomNowPlayingBridge — production audio adapter for the shell
  * `SidebarBottomNowPlaying` atom inside `UnifiedSidebar`. Renders only when
- * DESIGN_V1 is on AND there's an active track.
+ * there's an active track and the persistent compact player does not already
+ * own the same now-playing surface.
  *
  * Adapter: production `useTrackAudioPlayer().playbackState` →
  * `NowPlayingTrack` (trackTitle / artistName / artworkUrl). Tap-to-play
@@ -17,7 +18,6 @@ import { useAudioChromeSnapshot } from './audio-chrome-state';
  * sidebar mini-player and the persistent bar stay in sync.
  */
 export function SidebarBottomNowPlayingBridge() {
-  const shellChatV1Enabled = useAppFlag('DESIGN_V1');
   const audioChrome = useAudioChromeSnapshot();
   const { playbackState, toggleTrack } = useTrackAudioPlayer();
 
@@ -29,19 +29,26 @@ export function SidebarBottomNowPlayingBridge() {
     }).catch(() => {});
   }, [playbackState.activeTrackId, playbackState.trackTitle, toggleTrack]);
 
-  if (!shellChatV1Enabled) return null;
-  if (!playbackState.activeTrackId || !playbackState.trackTitle) return null;
-  if (
+  const hasActiveTrack = Boolean(
+    playbackState.activeTrackId && playbackState.trackTitle
+  );
+  if (!hasActiveTrack) return null;
+
+  const compactPlayerOwnsTrack =
     audioChrome.compactPlayerVisible &&
-    audioChrome.activeTrackId === playbackState.activeTrackId
-  ) {
-    return null;
-  }
+    audioChrome.activeTrackId === playbackState.activeTrackId;
 
   return (
     <div
       data-shell-audio-surface='sidebar-compact'
-      className='px-2 pb-2 pt-1 transition-[opacity,transform] duration-cinematic ease-cinematic'
+      data-state={compactPlayerOwnsTrack ? 'reserved' : 'visible'}
+      aria-hidden={compactPlayerOwnsTrack}
+      className={cn(
+        'h-(--linear-app-audio-compact-height) overflow-hidden px-2 pb-2 pt-1 transition-[opacity,transform] duration-cinematic ease-cinematic',
+        compactPlayerOwnsTrack
+          ? 'pointer-events-none invisible opacity-0'
+          : 'opacity-100'
+      )}
     >
       <SidebarBottomNowPlaying
         track={{

--- a/apps/web/tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx
+++ b/apps/web/tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx
@@ -5,7 +5,6 @@ import {
   setAudioChromeSnapshot,
 } from '@/components/organisms/audio-chrome-state';
 
-let _flag = false;
 let _state: Record<string, unknown> = {
   activeTrackId: null,
   isPlaying: false,
@@ -18,10 +17,6 @@ let _state: Record<string, unknown> = {
   artistName: null,
   artworkUrl: null,
 };
-
-vi.mock('@/lib/flags/client', () => ({
-  useAppFlag: () => _flag,
-}));
 
 vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
   useTrackAudioPlayer: () => ({
@@ -37,7 +32,6 @@ import { SidebarBottomNowPlayingBridge } from '@/components/organisms/SidebarBot
 
 beforeEach(() => {
   resetAudioChromeSnapshot();
-  _flag = false;
   _state = {
     activeTrackId: null,
     isPlaying: false,
@@ -58,25 +52,12 @@ afterEach(() => {
 });
 
 describe('SidebarBottomNowPlayingBridge', () => {
-  it('renders nothing when DESIGN_V1 is off', () => {
-    _flag = false;
-    _state = {
-      ..._state,
-      activeTrackId: 'track-1',
-      trackTitle: 'Lost in the Light',
-    };
+  it('renders nothing when no active track is present', () => {
     const { container } = render(<SidebarBottomNowPlayingBridge />);
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders nothing when no active track even with flag on', () => {
-    _flag = true;
-    const { container } = render(<SidebarBottomNowPlayingBridge />);
-    expect(container.firstChild).toBeNull();
-  });
-
-  it('renders when flag on and a track is active', () => {
-    _flag = true;
+  it('renders when a production track is active', () => {
     _state = {
       ..._state,
       activeTrackId: 'track-1',
@@ -85,13 +66,15 @@ describe('SidebarBottomNowPlayingBridge', () => {
       isPlaying: false,
     };
     render(<SidebarBottomNowPlayingBridge />);
+    expect(
+      document.querySelector('[data-shell-audio-surface="sidebar-compact"]')
+    ).toHaveAttribute('data-state', 'visible');
     expect(screen.getByText('Lost in the Light')).toBeInTheDocument();
     expect(screen.getByText('Bahamas')).toBeInTheDocument();
     expect(screen.getByLabelText('Play')).toBeInTheDocument();
   });
 
-  it('hides when the persistent compact player owns the active track', () => {
-    _flag = true;
+  it('reserves the slot when the persistent compact player owns the active track', () => {
     _state = {
       ..._state,
       activeTrackId: 'track-1',
@@ -105,13 +88,19 @@ describe('SidebarBottomNowPlayingBridge', () => {
       fullPlayerVisible: false,
     });
 
-    const { container } = render(<SidebarBottomNowPlayingBridge />);
+    render(<SidebarBottomNowPlayingBridge />);
 
-    expect(container.firstChild).toBeNull();
+    const slot = document.querySelector(
+      '[data-shell-audio-surface="sidebar-compact"]'
+    );
+    expect(slot).toHaveAttribute('data-state', 'reserved');
+    expect(slot).toHaveAttribute('aria-hidden', 'true');
+    expect(
+      screen.queryByRole('button', { name: 'Play' })
+    ).not.toBeInTheDocument();
   });
 
   it('still renders when compact state belongs to a different track', () => {
-    _flag = true;
     _state = {
       ..._state,
       activeTrackId: 'track-1',


### PR DESCRIPTION
## Summary
- remove the stale DESIGN_V1 gate from the sidebar now-playing audio bridge
- keep the production active-track guard and duplicate compact-player guard
- reserve the compact now-playing slot while the persistent compact player owns the same track, preventing footer chrome shift during collapse/reveal

## Verification
- pnpm --filter web exec vitest run tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx
- pnpm --filter web exec vitest run tests/components/organisms/PersistentAudioBar.test.tsx tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx
- pnpm biome check --write apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx apps/web/tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

<!-- linear-issue-id:JOV-2538 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar now-playing display coordination to properly show/hide based on active audio playback state rather than relying on feature flags.

* **Accessibility**
  * Enhanced accessibility attributes for the now-playing sidebar section to ensure proper interaction handling with the compact player.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->