### PR TITLE
fix(release): use ruby 3.1 for ios fastlane JOV-2530

### DIFF
--- a/.github/workflows/ios-signing-bootstrap.yml
+++ b/.github/workflows/ios-signing-bootstrap.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: Validate signing bootstrap secrets

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: Validate TestFlight secrets


### PR DESCRIPTION
## Summary
- Pins the iOS signing/bootstrap and TestFlight workflows to Ruby 3.1.
- Keeps Fastlane on the existing lockfile while avoiding `CFPropertyList 3.0.9` rejecting Ruby 3.3 during Bundler install.

## Verification
- `actionlint .github/workflows/ios-signing-bootstrap.yml .github/workflows/ios-testflight.yml`
- `git diff --check`
- pre-push hook: `biome check .`, proxy guard, Tailwind guard, typecheck, lint

## Release Note
- Required for JOV-2530 iOS signing bootstrap and TestFlight lanes.