### PR TITLE
docs(shell): align design v1 token contract

### DIFF
--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -59,6 +59,20 @@
   --ds-public-content-max: 1298px; /* canonical public/marketing width */
   --ds-prose-max: 680px; /* prose exception */
 
+  /* Shell V1 semantic aliases — app chrome should prefer these names when
+     touching shared shell geometry. They intentionally resolve to the current
+     Linear-derived values so this pass changes the token contract, not visuals. */
+  --app-shell-sidebar-width: var(--linear-app-sidebar-width);
+  --app-shell-header-height: var(--linear-app-header-height);
+  --app-shell-header-height-compact: var(--linear-app-header-height-compact);
+  --app-shell-gap: var(--linear-app-shell-gap);
+  --app-shell-radius: var(--linear-app-shell-radius);
+  --app-shell-border: var(--linear-app-shell-border);
+  --app-shell-frame-seam: var(--linear-app-frame-seam);
+  --app-shell-content-surface: var(--linear-app-content-surface);
+  --app-shell-audio-bar-max-height: var(--linear-app-audio-bar-max-height);
+  --app-shell-audio-compact-height: var(--linear-app-audio-compact-height);
+
   --ds-motion-subtle-duration: 150ms;
   --ds-motion-subtle-easing: cubic-bezier(0.4, 0, 0.2, 1);
   --ds-motion-cinematic-duration: 420ms;

--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -30,6 +30,7 @@ This is the repo-owned source of truth for:
 - button tokens
 - focus tokens
 - duration tokens
+- shell V1 semantic aliases for app chrome geometry and audio/sidebar chrome
 
 Add new core tokens here.
 
@@ -99,6 +100,21 @@ tests, but they are not the live production path.
 Dashboard and authenticated app surfaces use the same token layer, but their
 component structure remains under the app and dashboard feature families. They
 are not described by the marketing or public-surface shell libraries.
+
+Shell V1 app chrome should prefer the semantic `--app-shell-*` aliases for
+shared geometry and surfaces. These aliases live in `design-system.css` and
+resolve to the current Linear-derived values:
+
+- `--app-shell-sidebar-width`
+- `--app-shell-header-height`
+- `--app-shell-header-height-compact`
+- `--app-shell-gap`
+- `--app-shell-radius`
+- `--app-shell-border`
+- `--app-shell-frame-seam`
+- `--app-shell-content-surface`
+- `--app-shell-audio-bar-max-height`
+- `--app-shell-audio-compact-height`
 
 ## Canonical Surface Contract
 

--- a/docs/DESIGN_V1_ROLLOUT_MATRIX.md
+++ b/docs/DESIGN_V1_ROLLOUT_MATRIX.md
@@ -1,32 +1,34 @@
 # Design V1 Rollout Matrix
 
-This is the operating contract for moving the experimental Design V1 surfaces
-into production behind default-off app flags. It covers the full flag set,
-supported combinations, rollout order, and rollback paths. Product code must
-keep using production data adapters and must not import from `app/exp/*`.
+This is the operating contract for the now-permanent Design V1 production
+surfaces. It records the runtime aliases that remain for callsite clarity, the
+static marketing/public preview flags that still exist, and the cleanup rules
+for retiring old branches. Product code must keep using production data
+adapters and must not import from `app/exp/*`.
 
 ## Flag Inventory
 
 | Flag | Type | Owner | Surface | Default | Rollback |
 | --- | --- | --- | --- | --- | --- |
-| `SHELL_CHAT_V1` | Runtime app flag backed by Statsig gate `design_v1` | Shell | Authenticated shell frame, chat composer geometry, shell sidebar/audio primitives | `false` | Disable `design_v1` in Statsig or remove dev override |
-| `DESIGN_V1_RELEASES` | Runtime app flag backed by Statsig gate `design_v1` | Releases | Releases table/list styling, row treatment, drawer metadata polish | `false` | Disable `design_v1` in Statsig or remove dev override |
-| `DESIGN_V1_TASKS` | Runtime app flag backed by Statsig gate `design_v1` | Tasks | Tasks workspace subviews, V1 task list/detail behavior | `false` | Disable `design_v1` in Statsig or remove dev override |
-| `DESIGN_V1_CHAT_ENTITIES` | Runtime app flag backed by Statsig gate `design_v1` | Chat | Chat entity chips and right-panel adapters | `false` | Disable `design_v1` in Statsig or remove dev override |
-| `DESIGN_V1_LYRICS` | Runtime app flag backed by Statsig gate `design_v1` | Lyrics | `/app/lyrics/[trackId]`, lyrics button/link affordances | `false` | Disable `design_v1` in Statsig or remove dev override |
-| `DESIGN_V1_LIBRARY` | Runtime app flag backed by Statsig gate `design_v1` | Library | Read-only library route from existing release/artwork data | `false` | Disable `design_v1` in Statsig or remove dev override |
-| `DESIGN_V1_AUTH` | Runtime app flag backed by Statsig gate `design_v1` | Auth | Visual wrapper around existing Clerk sign-in/sign-up flows | `false` | Disable `design_v1` in Statsig or remove dev override |
-| `DESIGN_V1_ONBOARDING` | Runtime app flag backed by Statsig gate `design_v1` | Onboarding | Visual wrapper around existing production onboarding actions | `false` | Disable `design_v1` in Statsig or remove dev override |
+| `SHELL_CHAT_V1` | Runtime app alias of permanent `DESIGN_V1` default | Shell | Authenticated shell frame, chat composer geometry, shell sidebar/audio primitives | `true` | Revert the code branch or ship a targeted disabling flag |
+| `DESIGN_V1_RELEASES` | Runtime app alias of permanent `DESIGN_V1` default | Releases | Releases table/list styling, row treatment, drawer metadata polish | `true` | Revert the code branch or ship a targeted disabling flag |
+| `DESIGN_V1_TASKS` | Runtime app alias of permanent `DESIGN_V1` default | Tasks | Tasks workspace subviews, V1 task list/detail behavior | `true` | Revert the code branch or ship a targeted disabling flag |
+| `DESIGN_V1_CHAT_ENTITIES` | Runtime app alias of permanent `DESIGN_V1` default | Chat | Chat entity chips and right-panel adapters | `true` | Revert the code branch or ship a targeted disabling flag |
+| `DESIGN_V1_LYRICS` | Runtime app alias of permanent `DESIGN_V1` default | Lyrics | `/app/lyrics/[trackId]`, lyrics button/link affordances | `true` | Revert the code branch or ship a targeted disabling flag |
+| `DESIGN_V1_LIBRARY` | Runtime app alias of permanent `DESIGN_V1` default | Library | Read-only library route from existing release/artwork data | `true` | Revert the code branch or ship a targeted disabling flag |
+| `DESIGN_V1_AUTH` | Runtime app alias of permanent `DESIGN_V1` default | Auth | Visual wrapper around existing Clerk sign-in/sign-up flows | `true` | Revert the code branch or ship a targeted disabling flag |
+| `DESIGN_V1_ONBOARDING` | Runtime app alias of permanent `DESIGN_V1` default | Onboarding | Visual wrapper around existing production onboarding actions | `true` | Revert the code branch or ship a targeted disabling flag |
 | `SHOW_HOME_V1_DESIGN` | Static build-time flag | Marketing | Homepage V1 design | `false` | Revert flag and redeploy |
 | `SHOW_PUBLIC_PROFILE_V1_DESIGN` | Static build-time flag | Public Profile | Public profile V1 design | `false` | Revert flag and redeploy |
 
-Runtime app flags are defined in `apps/web/lib/flags/contracts.ts` and
+Runtime app aliases are defined in `apps/web/lib/flags/contracts.ts` and
 resolved through `apps/web/lib/flags/server.ts` / `AppFlagProvider`. All
-runtime Design V1 app flags currently resolve through the single remote
-Statsig gate `design_v1`; the per-surface names are app-level aliases for
-callsite clarity, not independent Statsig rollout controls. Static marketing
-flags are defined in `apps/web/lib/flags/marketing-static.ts` and must stay
-build-time constants so marketing pages remain fully static.
+runtime Design V1 app flags now live in `LOCAL_DEFAULT_ONLY_FLAGS` with
+default `true`; they are not backed by `APP_FLAG_TO_STATSIG_GATE`. The
+per-surface names remain app-level aliases for callsite clarity, not
+independent remote rollout controls. Static marketing flags are defined in
+`apps/web/lib/flags/marketing-static.ts` and must stay build-time constants so
+marketing pages remain fully static.
 
 Static marketing flags are not remote rollout controls. The value imported from
 `marketing-static.ts` is bundled into the deployed build, so changing either
@@ -38,8 +40,8 @@ toolbar override harness, cookies, request headers, or query parameters.
 
 | Combination | Expected Behavior | Status |
 | --- | --- | --- |
-| All flags `false` | Current production UI and behavior. This is the default safety baseline. | Required |
-| `design_v1=true` | All runtime Design V1 alias flags resolve `true`. This is the supported remote rollout shape. | Supported |
+| Runtime aliases at default | Design V1 production UI and behavior. This is the current baseline. | Required |
+| Dev/test override `code:DESIGN_V1=false` | Compatibility smoke only for remaining cleanup branches. Do not treat this as a production rollback path. | Temporary |
 | Per-surface alias override in dev/test | Local dev tooling may present alias labels, but the stored override key is `code:DESIGN_V1`; aliases move together. | Supported for local QA labels only |
 | Static public flags `true` with runtime flags `false` | Homepage/public profile V1 can ship independently because they are build-time static surfaces. | Supported after static QA |
 | Runtime flags `true` with static public flags `false` | Authenticated app rollout without marketing/public profile changes. | Supported |
@@ -66,15 +68,16 @@ Console gates in the same PR.
 
 ## Rollout Order
 
-1. Keep `design_v1` default `false` and land infrastructure/tests first.
-2. Validate `design_v1` with chat, sidebar, audio, releases, tasks, lyrics,
-   library, auth, and onboarding smoke coverage.
+1. Keep the permanent runtime aliases default `true` in
+   `apps/web/lib/flags/contracts.ts`.
+2. Remove stale fallback branches in small PRs only when focused tests prove no
+   behavior loss.
 3. Validate auth and onboarding carefully because they touch entry and resume
    flows.
 4. Validate static homepage/public profile flags in preview builds. Static flags
    require a redeploy for rollback, so do not batch them with runtime flips.
-5. Ramp `design_v1` by cohort only after flag-off parity and flag-on smoke are
-   both green for the affected routes.
+5. Keep remaining dev/test override coverage until the old branches are fully
+   retired, then delete the compatibility tests with the branch removal.
 
 ## Static Marketing Preview Procedure
 
@@ -140,12 +143,13 @@ then repeat this procedure from a fresh preview deployment.
 
 ## Rollback
 
-Runtime app flags:
+Runtime app aliases:
 
-1. Disable the `design_v1` Statsig gate or remove the local dev override.
-2. Confirm the route returns to the flag-off screenshot/smoke baseline.
-3. Leave follow-up code in place if flag-off parity is intact; revert only if
-   the disabled code still affects production.
+1. Revert the product-code branch that caused the regression, or ship a
+   targeted disabling flag with an owner and expiry.
+2. Confirm the affected route returns to the previous production screenshot or
+   smoke baseline.
+3. Remove any temporary disabling flag as soon as the product-code fix lands.
 
 Static build-time flags:
 
@@ -166,10 +170,12 @@ Static build-time flags:
 
 ## Required Verification
 
-Every Design V1 PR must name the flags it touches and verify:
+Every Design V1 PR must name the runtime aliases or static flags it touches and
+verify:
 
-- Flag-off parity for every touched route.
-- Flag-on smoke for the touched surface.
+- Production-baseline smoke for every touched route.
+- Dev/test override compatibility only when the PR edits a remaining fallback
+  branch.
 - No `app/exp/*` imports in production paths.
 - No schema migration unless the Linear issue explicitly assigns schema work.
 - `./scripts/setup.sh` in the worktree.
@@ -192,19 +198,19 @@ The nightly workflow runs a targeted Chromium canary via:
 pnpm --filter @jovie/web run test:e2e:design-v1-flags
 ```
 
-The canary covers flagged dashboard, auth, and onboarding surfaces in
-`apps/web/tests/e2e/design-v1-flagged-surfaces.spec.ts`. It verifies every
-runtime Design V1 flag remains default-off, then forces each surface on through
-the browser override harness. It is also available manually from **Nightly
-Tests** with suite `design-v1` before a staged rollout.
+The canary covers dashboard, auth, and onboarding surfaces in
+`apps/web/tests/e2e/design-v1-flagged-surfaces.spec.ts`. During the cleanup
+period it may still exercise the browser override harness so stale fallback
+branches fail loudly before they are removed. It is also available manually
+from **Nightly Tests** with suite `design-v1`.
 
 Interpret failures this way:
 
-- Default-off failures mean a flag default, route fallback, or production
-  baseline changed. Treat this as a rollout blocker.
-- Flag-on failures mean the gated surface, auth bypass, seed data, or route
-  contract regressed. Fix or explicitly defer that surface before widening the
-  cohort.
+- Production-baseline failures mean a route fallback, seeded data contract, or
+  shell surface changed. Treat this as a release blocker.
+- Override-harness failures mean a stale fallback branch or cleanup assumption
+  regressed. Fix the branch or remove the obsolete test in the same PR that
+  removes the branch.
 - A11y and Lighthouse coverage stays in the existing public/PR lanes unless the
   changed flagged surface has a known accessibility or performance risk that
   justifies the extra runtime.

--- a/docs/SHELL_V1_ARCHITECTURE.md
+++ b/docs/SHELL_V1_ARCHITECTURE.md
@@ -1,6 +1,9 @@
 # Shell V1 Architecture
 
-The "shell v1" port (commit `9d4ec67c2`) introduced a new authenticated app layout under `apps/web/app/app/(shell)/`. It coexists with the legacy flat `apps/web/app/app/*` structure during a flag-gated rollout. New code should target the shell layout.
+The "shell v1" port (commit `9d4ec67c2`) introduced the authenticated app
+layout under `apps/web/app/app/(shell)/`. It coexists with a shrinking set of
+legacy fallback branches while those branches are retired. New code should
+target the shell layout.
 
 ## Why
 
@@ -30,42 +33,46 @@ apps/web/app/app/layout.tsx                   # ResolvedClientProviders
 - `(shell)/settings/` — account, contacts, retargeting-ads
 - `(shell)/lyrics/`, `(shell)/contact/` — domain surfaces
 
-## Feature flag: `SHELL_CHAT_V1`
+## Design V1 Runtime Aliases
 
-Defined in `apps/web/lib/flags/contracts.ts` as the `SHELL_CHAT_V1` app flag
-(default `false`). It is currently backed by the unified Statsig gate
-`design_v1`, resolved server-side once in `apps/web/app/app/(shell)/layout.tsx`,
-then provided to every consumer via `AppFlagProvider`. Read in client
-components with `useAppFlag('SHELL_CHAT_V1')`.
+`DESIGN_V1` and its app-surface aliases, including `SHELL_CHAT_V1`, are
+permanent local-default flags in `apps/web/lib/flags/contracts.ts`. They
+resolve server-side once in `apps/web/app/app/(shell)/layout.tsx`, then flow to
+client consumers through `AppFlagProvider`. They are not backed by Statsig
+rollout gates.
 
-When `true`:
+At the current default:
 
-- `AppShellSkeleton` switches to the v1 chrome (so the skeleton frame matches what the rendered shell will look like).
+- `AppShellSkeleton` uses the v1 chrome so the skeleton frame matches the
+  rendered shell.
 - `DashboardNav` and `AuthShell` use v1 navigation/audio primitives.
+- Shell geometry and audio/sidebar chrome resolve through the shared shell
+  token contract in `apps/web/styles/design-system.css` and
+  `apps/web/styles/linear-tokens.css`.
 
-When `false`:
-
-- The shell layout still renders, but consumers fall through to legacy primitives — so the flag is purely a visual rollout control. No traffic ever bypasses `(shell)/layout.tsx`.
-
-Flag plumbing: `apps/web/lib/flags/server.ts:getAppFlagValue` /
+Flag plumbing: `apps/web/lib/flags/server.ts:getAppFlagValue` and
 `getAppFlagsSnapshot` resolve through `APP_FLAG_REGISTRY`, with dev/test
-overrides honored. Remote rollout uses `design_v1`; the legacy
-`feature_shell_chat_v1` key is not an active runtime control.
+overrides still honored for compatibility tests while old branches are removed.
+The legacy `feature_shell_chat_v1` and `design_v1` Statsig keys are not active
+runtime controls.
 
 ## Releases flag boundary
 
-`SHELL_CHAT_V1` does not own the releases route implementation. It only controls the authenticated shell frame and shared navigation/audio chrome around `/app/dashboard/releases`.
+`SHELL_CHAT_V1` is now an alias for the permanent shell baseline. It does not
+own the releases route implementation; it only names the authenticated shell
+frame and shared navigation/audio chrome around `/app/dashboard/releases`.
 
-`DESIGN_V1_RELEASES` owns releases-specific Design V1 behavior. `ShellReleasesView` is the gated Design V1 releases view; the legacy `ReleasesExperience`/`ReleaseProviderMatrix` remains the default when `DESIGN_V1_RELEASES` is off.
+`DESIGN_V1_RELEASES` names releases-specific Design V1 behavior.
+`ShellReleasesView` is the production releases view; any remaining
+`ReleasesExperience`/`ReleaseProviderMatrix` fallback should be treated as
+cleanup debt and removed in a focused PR when tests prove parity.
 
 Mixed-state contract:
 
-| `SHELL_CHAT_V1` | `DESIGN_V1_RELEASES` | Releases behavior |
-|---|---|---|
-| `false` | `false` | Legacy shell frame with `ReleasesExperience` |
-| `true` | `false` | Shell/chat V1 frame with `ReleasesExperience` |
-| `false` | `true` | Legacy shell frame with `ShellReleasesView` |
-| `true` | `true` | Shell/chat V1 frame with `ShellReleasesView` |
+| Runtime alias state | Releases behavior |
+|---|---|
+| Defaults | Shell/chat V1 frame with `ShellReleasesView` |
+| Dev/test override forced off | Compatibility path only, used to catch stale branch assumptions before removal |
 
 ## /exp/shell-v1
 
@@ -73,7 +80,7 @@ Mixed-state contract:
 
 ## Migration path
 
-For new code, always target `(shell)/` — the legacy `/app/*` paths will be removed once `SHELL_CHAT_V1` ramps to 100% and bakes (DESIGN.md notes the timeline is TBD). Concretely:
+For new code, always target `(shell)/`. Concretely:
 
 - New dashboard surface → `(shell)/dashboard/<name>/page.tsx`
 - New settings surface → `(shell)/settings/<name>/page.tsx`
@@ -81,4 +88,5 @@ For new code, always target `(shell)/` — the legacy `/app/*` paths will be rem
 
 `DashboardShellContent` decides whether to fetch the full dashboard payload or a lightweight shell payload via `shouldUseEssentialShellData(pathname)` — chat and standalone surfaces should be added there if they don't need the full dashboard.
 
-When you add a v1-only primitive, gate it on `useAppFlag('SHELL_CHAT_V1')` until the flag retires.
+When you add shell primitives, wire them to production data and shared shell
+tokens. Do not add new `SHELL_CHAT_V1` branches for purely visual chrome.

--- a/docs/STATSIG_FEATURE_GATES.md
+++ b/docs/STATSIG_FEATURE_GATES.md
@@ -22,7 +22,6 @@ experiments used by the web app.
 | `feature_spotify_oauth` | `LEGACY_STATSIG_GATE_KEYS.SPOTIFY_OAUTH` | `false` | Auth and onboarding login method selector | Active |
 | `stripe-connect-enabled` | `LEGACY_STATSIG_GATE_KEYS.STRIPE_CONNECT_ENABLED` | `false` | Stripe Connect payouts (settings + payment routes) | Active |
 | `chat_jank_monitor` | `LEGACY_STATSIG_GATE_KEYS.CHAT_JANK_MONITOR` | `false` | Chat jank instrumentation (message continuity + streaming) | Active |
-| `design_v1` | `LEGACY_STATSIG_GATE_KEYS.DESIGN_V1` | `false` | Unified Design V1 rollout for shell, releases, tasks, chat entities, lyrics, library, auth, and onboarding app flags | Active |
 | `ai_connectors_beta` | `LEGACY_STATSIG_GATE_KEYS.AI_CONNECTORS_BETA` | `false` | AI Connector v1 closed beta — Gmail booking email → Google Calendar event flow | Active |
 | `ai_chat_disabled` | `CHAT_KILL_SWITCH_GATES.DISABLED` | `false` | Emergency kill switch for `/api/chat` | Active |
 | `ai_chat_force_light` | `CHAT_KILL_SWITCH_GATES.FORCE_LIGHT` | `false` | Runtime switch to route `/api/chat` to the lighter model | Active |
@@ -41,12 +40,12 @@ experiments used by the web app.
   browser SDK.
 - If `STATSIG_SERVER_SECRET` is not configured, the app degrades gracefully to
   safe defaults.
-- `SHELL_CHAT_V1`, `DESIGN_V1_RELEASES`, `DESIGN_V1_TASKS`,
-  `DESIGN_V1_CHAT_ENTITIES`, `DESIGN_V1_LYRICS`, `DESIGN_V1_LIBRARY`,
-  `DESIGN_V1_AUTH`, and `DESIGN_V1_ONBOARDING` are app-level aliases backed by
-  the single remote `design_v1` gate. The legacy per-surface key constants are
-  compatibility names only; changing those keys in Statsig does not affect the
-  current runtime.
+- `DESIGN_V1` and its aliases (`SHELL_CHAT_V1`, `DESIGN_V1_RELEASES`,
+  `DESIGN_V1_TASKS`, `DESIGN_V1_CHAT_ENTITIES`, `DESIGN_V1_LYRICS`,
+  `DESIGN_V1_LIBRARY`, `DESIGN_V1_AUTH`, and `DESIGN_V1_ONBOARDING`) are
+  permanent local-default app flags, not Statsig-backed rollout gates. The
+  legacy `design_v1` and per-surface key constants remain compatibility names
+  only; changing those keys in Statsig does not affect the current runtime.
 - Security-sensitive authorization must still rely on server-side entitlement checks; gates are rollout controls, not permission boundaries.
 - The Design V1 rollout contract, valid flag combinations, and rollback paths live in `docs/DESIGN_V1_ROLLOUT_MATRIX.md`.
 

--- a/docs/design-system/token-inventory.md
+++ b/docs/design-system/token-inventory.md
@@ -198,11 +198,15 @@ Defined primarily in `apps/web/styles/linear-tokens.css` and consumed through cl
 
 #### Existing app-shell layout tokens
 
-- `--linear-app-sidebar-width: 244px`
+- `--linear-app-sidebar-width: 224px`
 - `--linear-app-header-height: 40px`
 - `--linear-app-header-height-compact: 36px`
 - `--linear-app-shell-gap: 8px`
 - `--linear-app-shell-radius: 12px`
+- `--linear-app-content-surface: var(--linear-bg-surface-0)` in light mode,
+  `#0a0c0f` in dark mode
+- `--linear-app-audio-bar-max-height: 120px`
+- `--linear-app-audio-compact-height: 64px`
 
 ### Semantic aliases added during consolidation
 
@@ -225,6 +229,16 @@ These aliases keep current values but give public surfaces a single shared contr
 - `--profile-drawer-radius-mobile`
 - `--profile-drawer-radius-desktop`
 - `--profile-action-radius`
+- `--app-shell-sidebar-width`
+- `--app-shell-header-height`
+- `--app-shell-header-height-compact`
+- `--app-shell-gap`
+- `--app-shell-radius`
+- `--app-shell-border`
+- `--app-shell-frame-seam`
+- `--app-shell-content-surface`
+- `--app-shell-audio-bar-max-height`
+- `--app-shell-audio-compact-height`
 
 ## Canonical template mapping
 


### PR DESCRIPTION
## Summary
- add semantic `--app-shell-*` aliases for shell/sidebar/audio geometry in `design-system.css`
- update Design V1 rollout docs so runtime aliases are described as permanent default-on local flags, not default-off Statsig gates
- update shell architecture and token inventory docs to point at the current shell token source of truth

## Verification
- pnpm biome check --write apps/web/styles/design-system.css docs/DESIGN_TOKENS.md docs/DESIGN_V1_ROLLOUT_MATRIX.md docs/SHELL_V1_ARCHITECTURE.md docs/STATSIG_FEATURE_GATES.md docs/design-system/token-inventory.md
- pnpm --filter web exec vitest run tests/unit/lib/feature-flags-registry.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

<!-- linear-issue-id:JOV-2539 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New Shell V1 semantic design tokens available for app chrome layout (sidebar width, header heights, audio bar dimensions, content surface).

* **Documentation**
  * Updated design token inventory and Shell V1 architecture guidelines.
  * Design V1 transitions to permanent production contract with revised rollout specifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->