### PR TITLE
fix(release): preserve App Store API token

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,8 +65,6 @@ def write_ios_configuration(api_base_url:, web_base_url:, clerk_publishable_key:
 end
 
 def ensure_app_store_assets!(api_key:, apple_team_id:)
-  Spaceship::ConnectAPI.token = api_key
-
   bundle_id = Spaceship::ConnectAPI::BundleId.find(APP_IDENTIFIER)
   if bundle_id
     UI.message("Found Apple bundle identifier #{APP_IDENTIFIER}")


### PR DESCRIPTION
## Summary
- keep Fastlane's App Store Connect token object installed for direct Spaceship calls
- continue passing the API-key hash to match actions
- unblocks JOV-2530 signing bootstrap after Ruby/Bundler fixes

## Verification
- ruby -c fastlane/Fastfile
- git diff --check
- pre-push hook: biome check ., proxy guard, Tailwind guard, typecheck, lint

## Failure addressed
- iOS Signing Bootstrap run 26263074364 failed in ensure_app_store_assets! with `undefined method in_house` after the Fastfile overwrote Spaceship::ConnectAPI.token with the API-key hash.