### PR TITLE
fix(shell): preserve sidebar audio fade

### DIFF
--- a/apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx
+++ b/apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx
@@ -43,11 +43,10 @@ export function SidebarBottomNowPlayingBridge() {
       data-shell-audio-surface='sidebar-compact'
       data-state={compactPlayerOwnsTrack ? 'reserved' : 'visible'}
       aria-hidden={compactPlayerOwnsTrack}
+      inert={compactPlayerOwnsTrack ? true : undefined}
       className={cn(
         'h-(--linear-app-audio-compact-height) overflow-hidden px-2 pb-2 pt-1 transition-[opacity,transform] duration-cinematic ease-cinematic',
-        compactPlayerOwnsTrack
-          ? 'pointer-events-none invisible opacity-0'
-          : 'opacity-100'
+        compactPlayerOwnsTrack ? 'pointer-events-none opacity-0' : 'opacity-100'
       )}
     >
       <SidebarBottomNowPlaying

--- a/apps/web/tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx
+++ b/apps/web/tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx
@@ -95,6 +95,9 @@ describe('SidebarBottomNowPlayingBridge', () => {
     );
     expect(slot).toHaveAttribute('data-state', 'reserved');
     expect(slot).toHaveAttribute('aria-hidden', 'true');
+    expect(slot).toHaveAttribute('inert');
+    expect(slot).toHaveClass('opacity-0');
+    expect(slot).not.toHaveClass('invisible');
     expect(
       screen.queryByRole('button', { name: 'Play' })
     ).not.toBeInTheDocument();


### PR DESCRIPTION
Linear: JOV-2540
Parent: JOV-2219
Related: JOV-2538, #9517

## Summary

- remove the immediate `invisible` hide from the reserved sidebar now-playing slot
- keep zero layout shift with the fixed reserved audio slot height
- make the transparent reserved subtree non-interactive with `inert`, `aria-hidden`, and pointer suppression
- assert the reserved state does not use `invisible`

## Verification

- `pnpm biome check --write apps/web/components/organisms/SidebarBottomNowPlayingBridge.tsx apps/web/tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx`
- `pnpm --filter web exec vitest run tests/components/organisms/SidebarBottomNowPlayingBridge.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction between the sidebar and compact player when the compact player is actively playing a track.
  * Enhanced visual and interaction behavior for the sidebar's reserved state.

* **Tests**
  * Updated test coverage to verify improved component coordination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9522?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->