### PR TITLE
fix(release): ignore empty match ssh key

### DIFF
--- a/.github/workflows/ios-signing-bootstrap.yml
+++ b/.github/workflows/ios-signing-bootstrap.yml
@@ -60,10 +60,19 @@ jobs:
             fi
           done
 
-          if [[ -z "${MATCH_GIT_PRIVATE_KEY:-}" && -z "${MATCH_GIT_BASIC_AUTHORIZATION:-}" ]]; then
+          match_git_private_key="${MATCH_GIT_PRIVATE_KEY:-}"
+          match_git_basic_authorization="${MATCH_GIT_BASIC_AUTHORIZATION:-}"
+          if [[ -z "${match_git_private_key//[[:space:]]/}" && -z "${match_git_basic_authorization//[[:space:]]/}" ]]; then
             echo "Missing match git authentication: set MATCH_GIT_PRIVATE_KEY or MATCH_GIT_BASIC_AUTHORIZATION"
             exit 1
           fi
 
       - name: Bootstrap App Store signing
-        run: bundle exec fastlane ios bootstrap_signing
+        shell: bash
+        run: |
+          set -euo pipefail
+          match_git_private_key="${MATCH_GIT_PRIVATE_KEY:-}"
+          if [[ -z "${match_git_private_key//[[:space:]]/}" ]]; then
+            unset MATCH_GIT_PRIVATE_KEY
+          fi
+          bundle exec fastlane ios bootstrap_signing

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -83,7 +83,9 @@ jobs:
             fi
           done
 
-          if [[ -z "${MATCH_GIT_PRIVATE_KEY:-}" && -z "${MATCH_GIT_BASIC_AUTHORIZATION:-}" ]]; then
+          match_git_private_key="${MATCH_GIT_PRIVATE_KEY:-}"
+          match_git_basic_authorization="${MATCH_GIT_BASIC_AUTHORIZATION:-}"
+          if [[ -z "${match_git_private_key//[[:space:]]/}" && -z "${match_git_basic_authorization//[[:space:]]/}" ]]; then
             echo "Missing match git authentication: set MATCH_GIT_PRIVATE_KEY or MATCH_GIT_BASIC_AUTHORIZATION"
             exit 1
           fi
@@ -92,4 +94,11 @@ jobs:
         run: bundle exec fastlane ios ios_tests
 
       - name: Upload internal TestFlight build
-        run: bundle exec fastlane ios beta
+        shell: bash
+        run: |
+          set -euo pipefail
+          match_git_private_key="${MATCH_GIT_PRIVATE_KEY:-}"
+          if [[ -z "${match_git_private_key//[[:space:]]/}" ]]; then
+            unset MATCH_GIT_PRIVATE_KEY
+          fi
+          bundle exec fastlane ios beta

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -20,6 +20,10 @@ def require_env!(name)
   value
 end
 
+def env_present?(name)
+  !ENV[name].to_s.strip.empty?
+end
+
 def repo_path(path)
   File.join(REPO_ROOT, path)
 end
@@ -37,15 +41,15 @@ def app_store_api_key_from_env
 end
 
 def require_match_git_auth!
-  return unless ENV["MATCH_GIT_PRIVATE_KEY"].to_s.empty? && ENV["MATCH_GIT_BASIC_AUTHORIZATION"].to_s.empty?
+  return if env_present?("MATCH_GIT_PRIVATE_KEY") || env_present?("MATCH_GIT_BASIC_AUTHORIZATION")
 
   UI.user_error!("Missing match git authentication: set MATCH_GIT_PRIVATE_KEY or MATCH_GIT_BASIC_AUTHORIZATION")
 end
 
 def match_git_auth_options
   options = {}
-  options[:git_private_key] = ENV["MATCH_GIT_PRIVATE_KEY"] unless ENV["MATCH_GIT_PRIVATE_KEY"].to_s.empty?
-  options[:git_basic_authorization] = ENV["MATCH_GIT_BASIC_AUTHORIZATION"] unless ENV["MATCH_GIT_BASIC_AUTHORIZATION"].to_s.empty?
+  options[:git_private_key] = ENV["MATCH_GIT_PRIVATE_KEY"] if env_present?("MATCH_GIT_PRIVATE_KEY")
+  options[:git_basic_authorization] = ENV["MATCH_GIT_BASIC_AUTHORIZATION"] if env_present?("MATCH_GIT_BASIC_AUTHORIZATION")
   options
 end
 

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -4,6 +4,6 @@ type("appstore")
 app_identifier(["ie.jov.Jovie"])
 
 team_id(ENV["APPLE_TEAM_ID"]) if ENV["APPLE_TEAM_ID"]
-git_private_key(ENV["MATCH_GIT_PRIVATE_KEY"]) if ENV["MATCH_GIT_PRIVATE_KEY"]
-git_basic_authorization(ENV["MATCH_GIT_BASIC_AUTHORIZATION"]) if ENV["MATCH_GIT_BASIC_AUTHORIZATION"]
+git_private_key(ENV["MATCH_GIT_PRIVATE_KEY"]) unless ENV["MATCH_GIT_PRIVATE_KEY"].to_s.strip.empty?
+git_basic_authorization(ENV["MATCH_GIT_BASIC_AUTHORIZATION"]) unless ENV["MATCH_GIT_BASIC_AUTHORIZATION"].to_s.strip.empty?
 readonly(ENV["CI"].to_s.downcase == "true")


### PR DESCRIPTION
## Summary\n- Ignore empty and whitespace-only MATCH_GIT_PRIVATE_KEY values in Fastlane match config\n- Unset empty/whitespace-only MATCH_GIT_PRIVATE_KEY before signing/TestFlight lanes so Fastlane uses HTTPS match auth\n- Keep HTTPS match auth active when no SSH key is configured\n\n## Verification\n- ruby -c fastlane/Fastfile\n- ruby -c fastlane/Matchfile\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-signing-bootstrap.yml"); YAML.load_file(".github/workflows/ios-testflight.yml")'\n- iOS Signing Bootstrap on branch passed before whitespace hardening: https://github.com/JovieInc/Jovie/actions/runs/26268278979\n- git push pre-push hook: biome check, proxy guard, tailwind guard, typecheck, biome lint\n\nJOV-2530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improve handling of empty authentication values so empty/whitespace credentials are ignored rather than treated as present.
  * Prevent build steps from failing when at least one valid auth method exists; only fail when both are missing.
  * Unset empty auth environment variables before invoking signing/upload tooling.
  * Use stricter shell execution for upload steps to reduce unintended failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->