### PR TITLE
fix(shell): persist sidebar section state

### DIFF
--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -468,10 +468,18 @@ export function DashboardNav(_: DashboardNavProps) {
     <nav className='flex flex-1 flex-col' aria-label='Dashboard navigation'>
       {isInSettings ? (
         <>
-          <SidebarCollapsibleGroup label='General' defaultOpen>
+          <SidebarCollapsibleGroup
+            label='General'
+            defaultOpen
+            storageKey='settings.general'
+          >
             {renderSection(userSettingsNavigation)}
           </SidebarCollapsibleGroup>
-          <SidebarCollapsibleGroup label={artistSettingsLabel} defaultOpen>
+          <SidebarCollapsibleGroup
+            label={artistSettingsLabel}
+            defaultOpen={false}
+            storageKey='settings.artist'
+          >
             {renderSection(artistSettingsNavigation)}
           </SidebarCollapsibleGroup>
         </>
@@ -483,7 +491,11 @@ export function DashboardNav(_: DashboardNavProps) {
                 {/* Section divider for visual separation (except for first section) */}
                 {index > 0 && <div className='my-1.5' />}
                 {section.label ? (
-                  <SidebarCollapsibleGroup label={section.label} defaultOpen>
+                  <SidebarCollapsibleGroup
+                    label={section.label}
+                    defaultOpen
+                    storageKey={`dashboard.${section.key}`}
+                  >
                     {renderSection(section.items)}
                   </SidebarCollapsibleGroup>
                 ) : (
@@ -519,7 +531,8 @@ export function DashboardNav(_: DashboardNavProps) {
         <div data-nav-section={artistWorkspaceSection.key} className='mt-3'>
           <SidebarCollapsibleGroup
             label={artistWorkspaceSection.label}
-            defaultOpen
+            defaultOpen={false}
+            storageKey={artistWorkspaceSection.key}
           >
             {renderSection(artistWorkspaceSection.items)}
           </SidebarCollapsibleGroup>
@@ -528,7 +541,11 @@ export function DashboardNav(_: DashboardNavProps) {
 
       {isAdmin && !isInSettings && (
         <div data-testid='admin-nav-section' className='mt-3'>
-          <SidebarCollapsibleGroup label='Admin' defaultOpen>
+          <SidebarCollapsibleGroup
+            label='Admin'
+            defaultOpen={false}
+            storageKey='dashboard.admin'
+          >
             {adminNavigationSections.map(section => (
               <div
                 key={section.label}

--- a/apps/web/components/organisms/SidebarCollapsibleGroup.tsx
+++ b/apps/web/components/organisms/SidebarCollapsibleGroup.tsx
@@ -2,7 +2,7 @@
 
 import type { LucideIcon } from 'lucide-react';
 import { ChevronRight } from 'lucide-react';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -10,6 +10,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from '@/components/organisms/Sidebar';
+import { useIsomorphicLayoutEffect } from '@/hooks/useIsomorphicLayoutEffect';
 import { cn } from '@/lib/utils';
 
 export interface SidebarCollapsibleGroupProps {
@@ -18,6 +19,33 @@ export interface SidebarCollapsibleGroupProps {
   readonly defaultOpen?: boolean;
   readonly className?: string;
   readonly icon?: LucideIcon;
+  readonly storageKey?: string;
+}
+
+const SIDEBAR_GROUP_STORAGE_PREFIX = 'jovie:sidebar-section';
+
+function getStoredOpen(storageKey: string): boolean | null {
+  try {
+    const stored = globalThis.localStorage?.getItem(
+      `${SIDEBAR_GROUP_STORAGE_PREFIX}:${storageKey}`
+    );
+    if (stored === 'open') return true;
+    if (stored === 'closed') return false;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function setStoredOpen(storageKey: string, open: boolean) {
+  try {
+    globalThis.localStorage?.setItem(
+      `${SIDEBAR_GROUP_STORAGE_PREFIX}:${storageKey}`,
+      open ? 'open' : 'closed'
+    );
+  } catch {
+    // Storage can be unavailable in restricted browsers; the default state still works.
+  }
 }
 
 export function SidebarCollapsibleGroup({
@@ -26,10 +54,30 @@ export function SidebarCollapsibleGroup({
   defaultOpen = true,
   className,
   icon: GroupIcon,
+  storageKey,
 }: SidebarCollapsibleGroupProps) {
   const [open, setOpen] = useState<boolean>(defaultOpen);
+  const hasLoadedStoredStateRef = useRef(false);
 
   const tooltip = useMemo(() => label, [label]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!storageKey) {
+      hasLoadedStoredStateRef.current = true;
+      return;
+    }
+
+    const storedOpen = getStoredOpen(storageKey);
+    if (storedOpen !== null) {
+      setOpen(storedOpen);
+    }
+    hasLoadedStoredStateRef.current = true;
+  }, [storageKey]);
+
+  useEffect(() => {
+    if (!storageKey || !hasLoadedStoredStateRef.current) return;
+    setStoredOpen(storageKey, open);
+  }, [open, storageKey]);
 
   return (
     <SidebarGroup className={cn('space-y-0', className)}>
@@ -67,6 +115,7 @@ export function SidebarCollapsibleGroup({
       </SidebarMenu>
 
       <div
+        inert={!open ? true : undefined}
         className={cn(
           'grid transition-[grid-template-rows,opacity] duration-[160ms] [transition-timing-function:cubic-bezier(0.25,0.46,0.45,0.94)]',
           open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -145,6 +145,51 @@ describe('DashboardNav', () => {
     );
   });
 
+  it('defaults artist workspace and admin groups collapsed', () => {
+    const { getByRole } = renderDashboardNav({
+      renderFn: fastRender,
+      overrides: {
+        isAdmin: true,
+        selectedProfile: {
+          id: 'profile_123',
+          displayName: 'Tim White',
+          username: 'tim',
+          usernameNormalized: 'tim',
+        } as DashboardData['selectedProfile'],
+      },
+    });
+
+    expect(getByRole('button', { name: 'Tim White' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    expect(getByRole('button', { name: 'Admin' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+  });
+
+  it('remembers an expanded artist workspace group', () => {
+    localStorage.setItem('jovie:sidebar-section:artist-workspace', 'open');
+
+    const { getByRole } = renderDashboardNav({
+      renderFn: fastRender,
+      overrides: {
+        selectedProfile: {
+          id: 'profile_123',
+          displayName: 'Tim White',
+          username: 'tim',
+          usernameNormalized: 'tim',
+        } as DashboardData['selectedProfile'],
+      },
+    });
+
+    expect(getByRole('button', { name: 'Tim White' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+  });
+
   it('renders with different pathname', () => {
     mockUsePathname.mockReturnValueOnce('/app/audience');
 

--- a/apps/web/tests/unit/sidebar-row-alignment.test.tsx
+++ b/apps/web/tests/unit/sidebar-row-alignment.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { ComponentProps, PropsWithChildren } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SidebarCollapsibleGroup } from '@/components/organisms/SidebarCollapsibleGroup';
 import { SidebarGroupLabel } from '@/components/organisms/sidebar/group';
 import {
@@ -47,6 +47,10 @@ vi.mock('@/components/organisms/Sidebar', () => ({
 }));
 
 describe('Sidebar row alignment', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
   it('uses px-2.5 for section labels', () => {
     render(<SidebarGroupLabel>General</SidebarGroupLabel>);
 
@@ -63,6 +67,59 @@ describe('Sidebar row alignment', () => {
     expect(
       screen.getByRole('button', { name: /general/i }).className
     ).toContain('px-2.5');
+  });
+
+  it('can default a persisted collapsible section closed without removing its slot', () => {
+    const { container } = render(
+      <SidebarCollapsibleGroup
+        label='Admin'
+        defaultOpen={false}
+        storageKey='dashboard.admin'
+      >
+        <div>People</div>
+      </SidebarCollapsibleGroup>
+    );
+
+    const button = screen.getByRole('button', { name: /admin/i });
+    const body = container.querySelector('[inert]');
+
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(body?.className).toContain('grid-rows-[0fr]');
+    expect(body?.className).toContain('opacity-0');
+  });
+
+  it('persists collapsible section state by storage key', () => {
+    const { unmount } = render(
+      <SidebarCollapsibleGroup
+        label='Artist'
+        defaultOpen={false}
+        storageKey='dashboard.artist-workspace'
+      >
+        <div>Profile</div>
+      </SidebarCollapsibleGroup>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /artist/i }));
+    expect(
+      localStorage.getItem('jovie:sidebar-section:dashboard.artist-workspace')
+    ).toBe('open');
+
+    unmount();
+
+    render(
+      <SidebarCollapsibleGroup
+        label='Artist'
+        defaultOpen={false}
+        storageKey='dashboard.artist-workspace'
+      >
+        <div>Profile</div>
+      </SidebarCollapsibleGroup>
+    );
+
+    expect(screen.getByRole('button', { name: /artist/i })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
   });
 
   it('keeps shell sidebar wrapper spacing on the same token grid', () => {

--- a/apps/web/tests/utils/dashboard-nav-test-support.tsx
+++ b/apps/web/tests/utils/dashboard-nav-test-support.tsx
@@ -150,6 +150,7 @@ const baseDashboardData: DashboardData = {
 type RenderDashboardNavFn = (ui: ReactElement) => ReturnType<typeof render>;
 
 export function resetDashboardNavTestMocks() {
+  localStorage.clear();
   mockUsePathname.mockReset();
   mockUsePathname.mockReturnValue(APP_ROUTES.CHAT);
   mockUseTaskStatsQuery.mockReset();


### PR DESCRIPTION
## Summary
- Linear: JOV-2541
- Persist dashboard sidebar collapsible group state in localStorage with stable shell section keys.
- Default Artist workspace and Admin groups collapsed while preserving existing active-state and nested-link behavior.
- Keep collapsed content in a stable grid wrapper with inert hidden state so reveal/dismiss transitions do not resize surrounding shell chrome unexpectedly.

## Verification
- pnpm biome check --write apps/web/components/organisms/SidebarCollapsibleGroup.tsx apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx apps/web/tests/unit/sidebar-row-alignment.test.tsx apps/web/tests/unit/dashboard/DashboardNav.test.tsx apps/web/tests/utils/dashboard-nav-test-support.tsx
- pnpm --filter web exec vitest run tests/unit/sidebar-row-alignment.test.tsx tests/unit/dashboard/DashboardNav.test.tsx
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push
