### PR TITLE
refactor(admin): migrate simple tool pages to AdminPage

### DIFF
--- a/apps/web/app/app/(shell)/admin/costs/page.tsx
+++ b/apps/web/app/app/(shell)/admin/costs/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
+import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { getAdminCosts, getCostsLastRefreshedAt } from '@/lib/admin/costs';
 import { CostsTable } from './CostsTable';
 
@@ -25,12 +25,12 @@ export default async function AdminCostsPage() {
     : 'never (seed on load)';
 
   return (
-    <AdminToolPage
+    <AdminPage
       title='Costs'
       description='Manual 30-day line-item view of company infra + AI spend. Lagging data only (v1).'
       testId='admin-costs-page'
     >
       <CostsTable items={items} lastRefreshedLabel={refreshedLabel} />
-    </AdminToolPage>
+    </AdminPage>
   );
 }

--- a/apps/web/app/app/(shell)/admin/investors/links/page.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/links/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
+import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { InvestorLinksManager } from './InvestorLinksManager';
 
 export const metadata: Metadata = {
@@ -12,12 +12,12 @@ export const metadata: Metadata = {
  */
 export default function InvestorLinksPage() {
   return (
-    <AdminToolPage
+    <AdminPage
       title='Investor Links'
       description='Create, copy, and disable investor links without leaving the admin shell.'
       testId='admin-investors-links-page'
     >
       <InvestorLinksManager />
-    </AdminToolPage>
+    </AdminPage>
   );
 }

--- a/apps/web/app/app/(shell)/admin/investors/settings/page.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/settings/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
+import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { InvestorSettingsForm } from './InvestorSettingsForm';
 
 export const metadata: Metadata = {
@@ -12,12 +12,12 @@ export const metadata: Metadata = {
  */
 export default function InvestorSettingsPage() {
   return (
-    <AdminToolPage
+    <AdminPage
       title='Investor Settings'
       description='Configure the investor portal, progress display, and follow-up defaults.'
       testId='admin-investors-settings-page'
     >
       <InvestorSettingsForm />
-    </AdminToolPage>
+    </AdminPage>
   );
 }

--- a/apps/web/app/app/(shell)/admin/screenshots/page.tsx
+++ b/apps/web/app/app/(shell)/admin/screenshots/page.tsx
@@ -1,7 +1,7 @@
 import { Skeleton } from '@jovie/ui';
 import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
-import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
+import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { APP_ROUTES } from '@/constants/routes';
 import { getScreenshots } from '@/lib/admin/screenshots';
@@ -59,12 +59,12 @@ export default async function AdminScreenshotsPage() {
     : `Review ${CANONICAL_SURFACES.length} canonical surfaces across ${canonicalCaptureCount} canonical captures, plus ${supportingCaptureCount} supporting captures from the latest screenshot catalog.`;
 
   return (
-    <AdminToolPage
+    <AdminPage
       title='Screenshots'
       description={description}
       testId='admin-screenshots-page'
     >
       <ScreenshotGallery screenshots={screenshots} />
-    </AdminToolPage>
+    </AdminPage>
   );
 }

--- a/apps/web/tests/unit/admin-shell-deprecation.test.ts
+++ b/apps/web/tests/unit/admin-shell-deprecation.test.ts
@@ -111,10 +111,10 @@ function countImporters(): { files: string[]; count: number } {
  * RATCHET — only ever decrement this value.
  *
  * Update the date and Linear issue ID when you decrement. Current ceiling
- * lowered by JOV-2542 on 2026-05-21: 10 importers remain after migrating
- * `AdminWorkspacePage` callers to `AdminPage` directly.
+ * lowered by JOV-2544 on 2026-05-21: 6 importers remain after migrating
+ * simple `AdminToolPage` callers to `AdminPage` directly.
  */
-const MAX_DEPRECATED_IMPORTERS = 10;
+const MAX_DEPRECATED_IMPORTERS = 6;
 
 describe('admin shell deprecation ratchet', () => {
   it(`has at most ${MAX_DEPRECATED_IMPORTERS} importers of AdminToolPage/AdminWorkspacePage`, () => {


### PR DESCRIPTION
## Summary
- Linear: JOV-2544
- Migrates low-risk admin utility pages from the deprecated `AdminToolPage` shim to `AdminPage` directly.
- Covers Costs, Screenshots, Investor Links, and Investor Settings without changing data loading or page content.
- Decrements the admin shell deprecation ratchet from 10 to 6 remaining shim importers.

## Verification
- pnpm biome check --write 'apps/web/app/app/(shell)/admin/costs/page.tsx' 'apps/web/app/app/(shell)/admin/screenshots/page.tsx' 'apps/web/app/app/(shell)/admin/investors/links/page.tsx' 'apps/web/app/app/(shell)/admin/investors/settings/page.tsx' apps/web/tests/unit/admin-shell-deprecation.test.ts
- pnpm --filter @jovie/web exec vitest run tests/unit/admin-shell-deprecation.test.ts tests/unit/app/admin-child-auth-normalization.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the admin interface layout structure across multiple pages to use a unified page wrapper component, improving consistency in the admin dashboard architecture.

* **Tests**
  * Adjusted deprecation threshold metrics for admin page component migration tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->