### PR TITLE
fix(shell): polish empty states and chrome JOV-2546

### DIFF
--- a/apps/web/app/app/(shell)/DashboardShellContent.tsx
+++ b/apps/web/app/app/(shell)/DashboardShellContent.tsx
@@ -96,7 +96,9 @@ export async function DashboardShellContent({
 
   // Read sidebar cookie server-side so SSR matches client state (no flash)
   const sidebarCookie = cookieStore.get('sidebar:state');
-  const sidebarDefaultOpen = sidebarCookie?.value !== 'false';
+  const sidebarDefaultOpen = sidebarCookie
+    ? sidebarCookie.value !== 'false'
+    : !dashboardData.sidebarCollapsed;
 
   const shellContents = (
     <div className='h-full'>

--- a/apps/web/components/atoms/DesktopTitlebar.tsx
+++ b/apps/web/components/atoms/DesktopTitlebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { PanelLeft } from 'lucide-react';
+import { ChevronLeft, ChevronRight, PanelLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import type { CSSProperties } from 'react';
 import { useContext } from 'react';
 import { UpdateAvailablePill } from '@/components/atoms/UpdateAvailablePill';
@@ -12,7 +13,7 @@ import { cn } from '@/lib/utils';
  * DesktopTitlebar — Electron-only titlebar drag region.
  *
  * Layout:
- *   [sidebar-width: traffic-light spacer, sidebar toggle, update pill]
+ *   [sidebar-width: traffic-light spacer, back/forward, sidebar toggle, update pill]
  *   [main: drag region only]
  *
  * Renders as a zero-height invisible element in the browser; CSS on
@@ -23,14 +24,15 @@ import { cn } from '@/lib/utils';
  * there is never a duplicate.
  *
  * Back/forward keyboard shortcuts (Cmd+[ / Cmd+]) remain wired via
- * useDesktopNavigation in components that need them; no visible nav pill
- * is rendered here.
+ * useDesktopNavigation in components that need them; visible controls sit
+ * beside the traffic-light rail for native desktop discoverability.
  *
  * The page header is no longer rendered in the titlebar — it lives at the
  * top of the elevated content card below so the card (header included)
  * collapses/expands with the sidebar.
  */
 export function DesktopTitlebar() {
+  const router = useRouter();
   const isDesktop = useIsElectronRuntime();
   // useContext (not useSidebar) so this is safe outside SidebarProvider (e.g. demo shell)
   const sidebarCtx = useContext(SidebarContext);
@@ -51,10 +53,44 @@ export function DesktopTitlebar() {
         <>
           <div
             data-testid='electron-titlebar-sidebar-cell'
-            className='flex min-w-0 items-center gap-2 px-2.5'
+            className='flex min-w-0 items-center gap-1.5 px-2.5'
           >
             {/* Traffic-light clearance — macOS hiddenInset reserves ~72px on the left */}
             <div className='w-[72px] shrink-0' aria-hidden='true' />
+            <div
+              data-testid='electron-nav-pill'
+              className='flex shrink-0 items-center gap-0.5'
+              style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}
+            >
+              <button
+                type='button'
+                onClick={() => router.back()}
+                aria-label='Go back'
+                data-testid='electron-nav-back'
+                className={cn(
+                  'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-secondary-token',
+                  'transition-colors duration-subtle',
+                  'hover:bg-white/[0.06] hover:text-primary-token',
+                  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30'
+                )}
+              >
+                <ChevronLeft className='h-3.5 w-3.5' strokeWidth={2} />
+              </button>
+              <button
+                type='button'
+                onClick={() => router.forward()}
+                aria-label='Go forward'
+                data-testid='electron-nav-forward'
+                className={cn(
+                  'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-secondary-token',
+                  'transition-colors duration-subtle',
+                  'hover:bg-white/[0.06] hover:text-primary-token',
+                  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30'
+                )}
+              >
+                <ChevronRight className='h-3.5 w-3.5' strokeWidth={2} />
+              </button>
+            </div>
             {/* Single canonical sidebar toggle for Electron — the in-sidebar
                 SidebarDockButton is not rendered in desktop runtime */}
             <button

--- a/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
@@ -63,9 +63,21 @@ function formatMetricValue(
 }
 
 /** Bar opacity classes that progressively fade to reinforce the narrowing funnel */
-const BAR_OPACITY = ['bg-accent/15', 'bg-accent/10', 'bg-accent/6'] as const;
+const BAR_OPACITY = [
+  'bg-[color-mix(in_oklab,var(--accent-analytics)_52%,transparent)]',
+  'bg-[color-mix(in_oklab,var(--accent-analytics)_36%,transparent)]',
+  'bg-[color-mix(in_oklab,var(--accent-analytics)_24%,transparent)]',
+] as const;
 
 const TRACK_BG = 'bg-surface-2';
+
+function formatRankedLabel(label: string): string {
+  try {
+    return decodeURIComponent(label);
+  } catch {
+    return label;
+  }
+}
 
 /** Single stage in the vertical funnel waterfall */
 function FunnelStage({
@@ -96,9 +108,9 @@ function FunnelStage({
   }
 
   return (
-    <div className='space-y-1.5 px-3 py-2'>
+    <div className='space-y-1.5 px-3.5 py-2.5'>
       <div className='flex items-baseline justify-between gap-2'>
-        <span className='text-[11.5px] font-caption text-secondary-token'>
+        <span className='text-[12px] font-caption text-secondary-token'>
           {label}
         </span>
         <span className='flex items-baseline gap-1.5'>
@@ -221,7 +233,7 @@ function RankedList({
             </span>
             <IconComponent className='h-3.5 w-3.5 text-tertiary-token' />
             <span className='truncate text-app text-secondary-token transition-colors group-hover:text-primary-token'>
-              {item.label}
+              {formatRankedLabel(item.label)}
             </span>
           </div>
           <span className='ml-2 text-app font-semibold text-primary-token tabular-nums'>
@@ -279,6 +291,7 @@ export function AnalyticsSidebarView({
       data-testid={testId}
       headerMode='minimal'
       hideMinimalHeaderBar
+      entityHeaderSurface='flat'
       entityHeader={
         <DrawerSurfaceCard variant='card' className='overflow-hidden'>
           <div className='relative p-3.5'>
@@ -289,9 +302,9 @@ export function AnalyticsSidebarView({
                 onClose={onClose}
               />
             </div>
-            <div className='flex items-start justify-between gap-3 pr-8'>
-              <div className='space-y-0.5'>
-                <p className='text-mid font-semibold tracking-[-0.016em] text-primary-token'>
+            <div className='space-y-3 pr-8'>
+              <div className='space-y-1'>
+                <p className='whitespace-nowrap text-mid font-semibold tracking-[-0.016em] text-primary-token'>
                   Audience funnel
                 </p>
                 <p className='text-xs leading-[16px] text-secondary-token'>
@@ -304,7 +317,8 @@ export function AnalyticsSidebarView({
                   onValueChange={onRangeChange}
                   options={RANGE_OPTIONS}
                   size='sm'
-                  className='shrink-0'
+                  className='w-full'
+                  triggerClassName='flex-1'
                   aria-label='Analytics time range'
                 />
               ) : null}
@@ -324,21 +338,27 @@ export function AnalyticsSidebarView({
           <FunnelCard stages={stages} loading={loading} />
 
           {/* Engagement — compact 2-col, secondary to the funnel */}
-          <DrawerStatGrid variant='card'>
-            <div className='px-3 py-2'>
+          <DrawerStatGrid
+            variant='card'
+            className={cn(
+              'gap-1 divide-x-0 p-2',
+              showTipLinkVisits ? 'grid-cols-3' : 'grid-cols-2'
+            )}
+          >
+            <div className='rounded-lg px-2 py-2'>
               <StatTile
                 label='Link Clicks'
                 value={formatMetricValue(loading, data?.total_clicks)}
               />
             </div>
-            <div className='px-3 py-2'>
+            <div className='rounded-lg px-2 py-2'>
               <StatTile
                 label='Listen Clicks'
                 value={formatMetricValue(loading, data?.listen_clicks)}
               />
             </div>
             {showTipLinkVisits ? (
-              <div className='px-3 py-2'>
+              <div className='rounded-lg px-2 py-2'>
                 <StatTile
                   label='Tip Link Visits'
                   value={formatMetricValue(loading, data?.tip_link_visits)}
@@ -356,7 +376,7 @@ export function AnalyticsSidebarView({
               options={ANALYTICS_TAB_OPTIONS}
               className='w-full'
               ariaLabel='Analytics data tabs'
-              distribution='intrinsic'
+              distribution='fill'
             />
           }
           contentClassName='pt-2'

--- a/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberSidebar.tsx
@@ -15,6 +15,7 @@ import {
   DrawerTabs,
   EntitySidebarShell,
 } from '@/components/molecules/drawer';
+import { DrawerHeaderActions } from '@/components/molecules/drawer-header/DrawerHeaderActions';
 import { DrawerHero } from '@/components/shell/DrawerHero';
 import { AudienceMemberActivityFeed } from './AudienceMemberActivityFeed';
 import { AudienceMemberDetails } from './AudienceMemberDetails';
@@ -56,32 +57,42 @@ export function AudienceMemberSidebar({
       data-testid='audience-member-sidebar'
       onClose={onClose}
       headerMode='minimal'
+      hideMinimalHeaderBar
       entityHeader={
         member ? (
-          <DrawerHero
-            title={primaryLabel}
-            subtitle={secondaryLabel}
-            artwork={
-              <div className='flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] border border-subtle bg-surface-0 text-sm font-semibold text-secondary-token'>
-                {primaryLabel.charAt(0).toUpperCase()}
-              </div>
-            }
-            meta={
-              member.locationLabel || member.visits > 0 ? (
-                <div className='flex flex-wrap items-center gap-2 text-2xs text-tertiary-token'>
-                  {member.locationLabel ? (
-                    <span className='inline-flex items-center gap-1'>
-                      <MapPin className='h-3 w-3' />
-                      {member.locationLabel}
-                    </span>
-                  ) : null}
-                  <span>
-                    {member.visits} visit{member.visits === 1 ? '' : 's'}
-                  </span>
+          <div className='relative'>
+            <div className='absolute right-2.5 top-2.5 z-10'>
+              <DrawerHeaderActions
+                primaryActions={[]}
+                overflowActions={[]}
+                onClose={onClose}
+              />
+            </div>
+            <DrawerHero
+              title={primaryLabel}
+              subtitle={secondaryLabel}
+              artwork={
+                <div className='flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] border border-subtle bg-surface-0 text-sm font-semibold text-secondary-token'>
+                  {primaryLabel.charAt(0).toUpperCase()}
                 </div>
-              ) : undefined
-            }
-          />
+              }
+              meta={
+                member.locationLabel || member.visits > 0 ? (
+                  <div className='flex flex-wrap items-center gap-2 pr-8 text-2xs text-tertiary-token'>
+                    {member.locationLabel ? (
+                      <span className='inline-flex items-center gap-1'>
+                        <MapPin className='h-3 w-3' />
+                        {member.locationLabel}
+                      </span>
+                    ) : null}
+                    <span>
+                      {member.visits} visit{member.visits === 1 ? '' : 's'}
+                    </span>
+                  </div>
+                ) : undefined
+              }
+            />
+          </div>
         ) : undefined
       }
       isEmpty={!member}
@@ -97,7 +108,7 @@ export function AudienceMemberSidebar({
               onValueChange={value => setActiveTab(value as AudienceTab)}
               options={AUDIENCE_TAB_OPTIONS}
               ariaLabel='Audience member tabs'
-              distribution='intrinsic'
+              distribution='fill'
             />
           }
           contentClassName='pt-2'

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/table-config.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/table-config.tsx
@@ -20,7 +20,7 @@ import { SelectCell } from './utils/column-renderers';
 const memberColumnHelper = createColumnHelper<AudienceMember>();
 
 export const AUDIENCE_TABLE_CONTAINER_CLASS =
-  'h-full px-2.5 pb-2.5 pt-0.5 md:px-3 md:pb-3 md:pt-1';
+  'h-full px-2.5 pb-2.5 pt-0 md:px-3 md:pb-3 md:pt-0';
 
 export const AUDIENCE_TABLE_SKELETON_COLUMN_CONFIG: Array<{
   readonly width?: string;

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
@@ -759,7 +759,7 @@ export function ProfileContactSidebar() {
             }
             actionsClassName='h-[26px] w-[26px]'
             overflowMode='scroll'
-            distribution='intrinsic'
+            distribution='fill'
           />
         }
         contentClassName='pt-2'

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -740,9 +740,6 @@ export function OnboardingChat({
       </div>
     ) : null;
 
-  // Persistent bottom dock composer: showInitialComposer now only controls
-  // the *upper* morphing content (intro vs messages). The composer itself is
-  // always rendered in the bottom dock for zero structural jump on first turn.
   const showInitialComposer = messages.length === 0 && !hasSentFirst;
 
   const onboardingChatInputProps = {
@@ -765,6 +762,11 @@ export function OnboardingChat({
     shellChatV1: true,
     statusBanner: composerStatusBanner,
   } as const;
+  const onboardingComposerSurface = (
+    <div className='mx-auto w-full max-w-[45rem]'>
+      <ChatInput {...onboardingChatInputProps} />
+    </div>
+  );
 
   return (
     <section
@@ -795,12 +797,24 @@ export function OnboardingChat({
       >
         <div
           ref={totalSizeRef}
-          className='mx-auto flex min-h-full w-full max-w-[44rem] flex-col'
+          className={cn(
+            'mx-auto flex min-h-full w-full max-w-[44rem] flex-col',
+            showInitialComposer && 'justify-center'
+          )}
         >
           <AnimatePresence mode='popLayout' initial={false}>
             {showInitialComposer ? (
-              <div key='onboarding-empty-upper'>
+              <div
+                key='onboarding-empty-upper'
+                className='flex w-full flex-col items-center justify-center gap-5 py-8'
+              >
                 <OnboardingInitialIntro hidden={composerPickerOpen} />
+                <div
+                  className='w-full'
+                  data-testid='onboarding-centered-composer'
+                >
+                  {onboardingComposerSurface}
+                </div>
               </div>
             ) : (
               <div key='onboarding-messages'>
@@ -818,15 +832,14 @@ export function OnboardingChat({
         </div>
       </div>
 
-      {/* Persistent always-bottom composer dock (Hyp 1 stabilization).
-          No more conditional render or justify-center teleport for the input.
-          The motion surface inside ChatInput (with layoutId) + stable dock
-          position guarantees zero layout shift on first user message. */}
-      <div className='shrink-0 bg-(--linear-app-content-surface) px-4 pb-4 pt-2 sm:px-6 sm:pb-5 sm:pt-2.5 lg:px-8'>
-        <div className='mx-auto w-full max-w-[45rem]'>
-          <ChatInput {...onboardingChatInputProps} />
+      {showInitialComposer ? null : (
+        <div
+          className='shrink-0 bg-(--linear-app-content-surface) px-4 pb-4 pt-2 sm:px-6 sm:pb-5 sm:pt-2.5 lg:px-8'
+          data-testid='onboarding-composer-dock'
+        >
+          {onboardingComposerSurface}
         </div>
-      </div>
+      )}
     </section>
   );
 }

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -373,6 +373,7 @@ export function JovieChat({
   const greetingName =
     getFirstNameForGreeting(displayName) ?? getFirstNameForGreeting(username);
   const primaryActionCard = actionCards[0] ?? null;
+  const hasActionCardEmptyLayout = primaryActionCard !== null;
   const showActionCardContent =
     primaryActionCard !== null &&
     input.trim().length === 0 &&
@@ -387,6 +388,39 @@ export function JovieChat({
       ? `What are we working on, ${greetingName}?`
       : 'What are we working on?';
   }
+  const showBottomComposer = showThreadView || hasActionCardEmptyLayout;
+
+  const composerSurface = (
+    <div className='mx-auto w-full max-w-[45rem]'>
+      {/* Transient alerts stack above the input. Each contributes its
+        own bottom margin only when rendered. */}
+      <ChatUsageAlert />
+
+      {chatError && (
+        <div className='mb-2'>
+          <ErrorDisplay
+            chatError={chatError}
+            onRetry={handleRetry}
+            isLoading={isLoading}
+            isSubmitting={isSubmitting}
+          />
+        </div>
+      )}
+
+      {isRateLimited && (
+        <p className='mb-1.5 text-xs text-tertiary-token' aria-live='polite'>
+          Sending too fast. Please wait a second before your next message.
+        </p>
+      )}
+
+      <ChatInput
+        {...chatInputProps}
+        placeholder={showThreadView ? 'Ask a follow-up...' : 'Ask Jovie...'}
+        variant={showThreadView ? 'compact' : 'hero'}
+        shellChatV1
+      />
+    </div>
+  );
 
   return (
     <EntityResolutionProvider profileId={profileId}>
@@ -457,61 +491,80 @@ export function JovieChat({
           >
             <AnimatePresence mode='popLayout' initial={false}>
               {!showThreadView ? (
-                <div key='joviechat-empty-upper'>
+                <div
+                  key='joviechat-empty-upper'
+                  className='relative min-h-full'
+                >
                   {/* Giant Jovie circle mark behind empty thread.
                       Positioned absolute so it doesn't shift the welcome heading. */}
-                  <div
-                    aria-hidden
-                    className='pointer-events-none absolute inset-0 flex items-center justify-center select-none anim-calm-breath opacity-45'
-                    data-testid='chat-empty-thread-ornament'
-                  >
-                    <JovieMarkElectric
-                      spark={false}
-                      className='opacity-100'
-                      style={{
-                        width: 'clamp(180px, 34vw, 360px)',
-                        height: 'clamp(180px, 34vw, 360px)',
-                        transform: 'translateY(-16px)',
-                        WebkitMaskImage:
-                          'radial-gradient(circle, rgba(0,0,0,1) 55%, rgba(0,0,0,0.75) 75%, rgba(0,0,0,0) 95%)',
-                        maskImage:
-                          'radial-gradient(circle, rgba(0,0,0,1) 55%, rgba(0,0,0,0.75) 75%, rgba(0,0,0,0) 95%)',
-                      }}
-                    />
-                  </div>
+                  {!hasActionCardEmptyLayout ? (
+                    <div
+                      aria-hidden
+                      className='pointer-events-none absolute inset-0 flex items-center justify-center select-none anim-calm-breath opacity-35'
+                      data-testid='chat-empty-thread-ornament'
+                    >
+                      <JovieMarkElectric
+                        spark={false}
+                        className='opacity-100'
+                        style={{
+                          width: 'clamp(180px, 34vw, 360px)',
+                          height: 'clamp(180px, 34vw, 360px)',
+                          transform: 'translateY(-16px)',
+                          WebkitMaskImage:
+                            'radial-gradient(circle, rgba(0,0,0,1) 55%, rgba(0,0,0,0.72) 75%, rgba(0,0,0,0) 95%)',
+                          maskImage:
+                            'radial-gradient(circle, rgba(0,0,0,1) 55%, rgba(0,0,0,0.72) 75%, rgba(0,0,0,0) 95%)',
+                        }}
+                      />
+                    </div>
+                  ) : null}
 
                   <div
-                    className='relative mx-auto flex min-h-full w-full max-w-[52rem] flex-col items-center justify-center gap-5 py-8'
+                    className={cn(
+                      'relative mx-auto flex min-h-full w-full max-w-[52rem] flex-col items-center justify-center py-8',
+                      hasActionCardEmptyLayout ? 'gap-0' : 'gap-5'
+                    )}
                     data-testid='chat-empty-state-composer-region'
                   >
-                    <h1
-                      className={cn(
-                        'text-balance text-center text-[2rem] font-semibold leading-[1.1] text-primary-token sm:text-[2.35rem] md:text-[2.65rem]',
-                        composerPickerOpen && 'pointer-events-none opacity-0'
-                      )}
-                      aria-hidden={composerPickerOpen ? 'true' : undefined}
-                    >
-                      {emptyStateHeading}
-                    </h1>
-
-                    <div
-                      className='mx-auto flex h-[172px] w-full max-w-[38rem] items-center justify-center sm:h-[148px]'
-                      data-testid='chat-empty-state-action-card-slot'
-                    >
-                      {showActionCardContent ? (
-                        <SuggestionCard
-                          className='h-full'
-                          title={primaryActionCard.title}
-                          body={primaryActionCard.body}
-                          actionLabel={primaryActionCard.actionLabel}
-                          onAct={() =>
-                            handleSuggestedPromptWithJank(
-                              primaryActionCard.prompt
-                            )
-                          }
-                        />
-                      ) : null}
-                    </div>
+                    {hasActionCardEmptyLayout ? (
+                      <div
+                        className='mx-auto flex min-h-[172px] w-full max-w-[38rem] items-center justify-center sm:min-h-[148px]'
+                        data-testid='chat-empty-state-action-card-slot'
+                      >
+                        {showActionCardContent ? (
+                          <SuggestionCard
+                            className='h-full'
+                            title={primaryActionCard.title}
+                            body={primaryActionCard.body}
+                            actionLabel={primaryActionCard.actionLabel}
+                            onAct={() =>
+                              handleSuggestedPromptWithJank(
+                                primaryActionCard.prompt
+                              )
+                            }
+                          />
+                        ) : null}
+                      </div>
+                    ) : (
+                      <>
+                        <h1
+                          className={cn(
+                            'text-balance text-center text-[2rem] font-semibold leading-[1.1] text-primary-token sm:text-[2.35rem] md:text-[2.65rem]',
+                            composerPickerOpen &&
+                              'pointer-events-none opacity-0'
+                          )}
+                          aria-hidden={composerPickerOpen ? 'true' : undefined}
+                        >
+                          {emptyStateHeading}
+                        </h1>
+                        <div
+                          className='w-full'
+                          data-testid='chat-empty-state-centered-composer'
+                        >
+                          {composerSurface}
+                        </div>
+                      </>
+                    )}
                   </div>
                 </div>
               ) : (
@@ -619,43 +672,14 @@ export function JovieChat({
             motion surface. All transient chrome (alerts, rate, error) lives here for both
             empty and thread states.
           */}
-          <div className={CHAT_COMPOSER_DOCK_CLASSNAME}>
-            <div className='mx-auto w-full max-w-[45rem]'>
-              {/* Transient alerts stack above the input. Each contributes its
-                own bottom margin only when rendered. */}
-              <ChatUsageAlert />
-
-              {chatError && (
-                <div className='mb-2'>
-                  <ErrorDisplay
-                    chatError={chatError}
-                    onRetry={handleRetry}
-                    isLoading={isLoading}
-                    isSubmitting={isSubmitting}
-                  />
-                </div>
-              )}
-
-              {isRateLimited && (
-                <p
-                  className='mb-1.5 text-xs text-tertiary-token'
-                  aria-live='polite'
-                >
-                  Sending too fast. Please wait a second before your next
-                  message.
-                </p>
-              )}
-
-              <ChatInput
-                {...chatInputProps}
-                placeholder={
-                  showThreadView ? 'Ask a follow-up...' : 'Ask Jovie...'
-                }
-                variant={showThreadView ? 'compact' : 'hero'}
-                shellChatV1
-              />
+          {showBottomComposer ? (
+            <div
+              className={CHAT_COMPOSER_DOCK_CLASSNAME}
+              data-testid='chat-composer-dock'
+            >
+              {composerSurface}
             </div>
-          </div>
+          ) : null}
         </div>
       </div>
     </EntityResolutionProvider>

--- a/apps/web/components/molecules/drawer/DrawerTabs.tsx
+++ b/apps/web/components/molecules/drawer/DrawerTabs.tsx
@@ -36,7 +36,15 @@ export interface DrawerTabsProps<T extends string> {
  */
 export function DrawerTabs<T extends string>({
   overflowMode = 'collapse',
+  distribution = 'fill',
   ...props
 }: DrawerTabsProps<T>) {
-  return <TabBar {...props} overflowMode={overflowMode} variant='drawer' />;
+  return (
+    <TabBar
+      {...props}
+      distribution={distribution}
+      overflowMode={overflowMode}
+      variant='drawer'
+    />
+  );
 }

--- a/apps/web/components/organisms/AuthShell.tsx
+++ b/apps/web/components/organisms/AuthShell.tsx
@@ -15,6 +15,7 @@ import { useRightPanel } from '@/contexts/RightPanelContext';
 import { DashboardHeader } from '@/features/dashboard/organisms/DashboardHeader';
 import { DashboardMobileTabs } from '@/features/dashboard/organisms/DashboardMobileTabs';
 import { MobileProfileDrawer } from '@/features/dashboard/organisms/MobileProfileDrawer';
+import { useIsElectronRuntime } from '@/lib/desktop/electron-bridge';
 import { useAppFlag } from '@/lib/flags/client';
 import type { DashboardBreadcrumbItem } from '@/types/dashboard';
 import { AppShellFrame } from './AppShellFrame';
@@ -52,8 +53,10 @@ function AuthShellInner({
   const previewPanelState = usePreviewPanelState();
   const headerActionsState = useOptionalHeaderActions();
   const shellChatV1Enabled = useAppFlag('DESIGN_V1');
+  const isElectron = useIsElectronRuntime();
 
-  const sidebarTrigger = isMobile ? null : <SidebarTrigger />;
+  const sidebarTrigger =
+    isMobile || (shellChatV1Enabled && isElectron) ? null : <SidebarTrigger />;
 
   const isInSettings = section === 'settings';
   const hideTopHeader = isInSettings || isLyricsRoute;

--- a/apps/web/components/organisms/AuthShellWrapper.tsx
+++ b/apps/web/components/organisms/AuthShellWrapper.tsx
@@ -294,7 +294,7 @@ export function AuthShellWrapper({
   children,
 }: Readonly<AuthShellWrapperProps>) {
   return (
-    <TooltipProvider delayDuration={1200}>
+    <TooltipProvider delayDuration={120} skipDelayDuration={40}>
       <KeyboardShortcutsProvider>
         <HeaderActionsProvider>
           <ShellSidebarOverrideProvider>

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -1087,7 +1087,7 @@ export function ReleaseSidebar({
                 options={releaseTabOptions}
                 ariaLabel='Release sidebar tabs'
                 overflowMode='scroll'
-                distribution='intrinsic'
+                distribution='fill'
               />
             }
             controls={activeTab === 'dsps' ? platformCardActions : undefined}

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -406,7 +406,7 @@ export function TrackSidebar({
               options={TRACK_SIDEBAR_TAB_OPTIONS}
               ariaLabel='Track sidebar tabs'
               overflowMode='scroll'
-              distribution='intrinsic'
+              distribution='fill'
             />
           }
           contentClassName='pt-2'

--- a/apps/web/components/shell/DspAvatarStack.test.tsx
+++ b/apps/web/components/shell/DspAvatarStack.test.tsx
@@ -53,4 +53,9 @@ describe('DspAvatarStack', () => {
     expect(screen.getByText('Apple Music')).toBeInTheDocument();
     expect(screen.getByText('YouTube')).toBeInTheDocument();
   });
+
+  it('keeps the popover above shell chrome', () => {
+    render(<DspAvatarStack dsps={ITEMS} />);
+    expect(screen.getByRole('tooltip').className).toContain('z-[150]');
+  });
 });

--- a/apps/web/components/shell/DspAvatarStack.tsx
+++ b/apps/web/components/shell/DspAvatarStack.tsx
@@ -125,7 +125,7 @@ export function DspAvatarStack({
       <div
         role='tooltip'
         className={cn(
-          'pointer-events-none absolute right-0 top-full mt-1.5 z-[100] w-[220px]',
+          'pointer-events-none absolute right-0 top-full mt-1.5 z-[150] w-[220px]',
           'opacity-0 group-hover/dsps:opacity-100 group-hover/dsps:pointer-events-auto',
           'transition-[opacity] duration-subtle ease-subtle delay-[400ms] group-hover/dsps:delay-[400ms]'
         )}

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -39,15 +39,24 @@ export function getSidebarNavRowClassName({
   tight,
   className,
 }: SidebarNavChromeOptions) {
-  const nonCollapsedSize = tight ? 'h-6 pl-2.5 pr-2' : 'h-6.5 pl-2.5 pr-2';
+  const nonCollapsedSize = tight ? 'h-6 px-2.5' : 'h-6.5 px-2.5';
   const inactiveColor = nested
     ? 'text-tertiary-token hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] hover:text-primary-token'
     : 'text-secondary-token hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] hover:text-primary-token';
 
   return cn(
-    'relative flex items-center rounded-md w-full transition-[background-color] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
-    tight ? 'gap-2 text-[12px]' : 'gap-2.5 text-[12.5px]',
-    collapsed ? 'h-7 w-10 mx-auto justify-center' : nonCollapsedSize,
+    'relative grid items-center rounded-md w-full transition-[background-color] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+    'before:pointer-events-none before:absolute before:inset-y-1 before:left-[20px] before:w-px before:bg-[color-mix(in_oklab,var(--linear-app-frame-seam)_42%,transparent)]',
+    'after:pointer-events-none after:absolute after:inset-y-1 after:left-[34px] after:w-px after:bg-[color-mix(in_oklab,var(--linear-app-frame-seam)_42%,transparent)]',
+    'group-data-[collapsible=icon]:before:hidden group-data-[collapsible=icon]:after:hidden',
+    tight ? 'gap-x-2 text-[12px]' : 'gap-x-2.5 text-[12.5px]',
+    collapsed
+      ? 'h-7 w-10 mx-auto grid-cols-1 place-items-center before:hidden after:hidden'
+      : cn(
+          'grid-cols-[20px_minmax(0,1fr)_auto]',
+          nonCollapsedSize,
+          'group-data-[collapsible=icon]:grid-cols-1 group-data-[collapsible=icon]:place-items-center'
+        ),
     active ? 'text-primary-token bg-surface-1' : inactiveColor,
     className
   );

--- a/apps/web/components/shell/Tooltip.tsx
+++ b/apps/web/components/shell/Tooltip.tsx
@@ -1,15 +1,25 @@
+'use client';
+
+import {
+  Kbd,
+  TooltipContent,
+  TooltipProvider,
+  Tooltip as TooltipRoot,
+  TooltipTrigger,
+} from '@jovie/ui';
+import {
+  Children,
+  cloneElement,
+  Fragment,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 import type { ShortcutHint } from '@/lib/shortcuts';
 import { cn } from '@/lib/utils';
 
-// Tooltip — small, dark, glassy popover with the action label + an
-// optional kbd chip on the right. Pass a `shortcut` object to surface the
-// key combo. CSS-only (no portal); uses group/tip + delay for a Linear-
-// feeling late reveal via pure opacity fade (no decorative translate/slide
-// motion per DESIGN.md + .claude/rules/ui.md "no decorative hover motion").
-// z raised to sit above new shell chrome.
-
 export interface TooltipProps {
-  readonly children: React.ReactNode;
+  readonly children: ReactNode;
   readonly label: string;
   readonly shortcut?: ShortcutHint;
   readonly side?: 'top' | 'bottom' | 'right' | 'left';
@@ -17,6 +27,37 @@ export interface TooltipProps {
   // `block` for full-width triggers (sidebar nav rows). Default is
   // inline-flex which sizes to children — right for icon buttons.
   readonly block?: boolean;
+  readonly open?: boolean;
+  readonly defaultOpen?: boolean;
+}
+
+function isElementWithClassName(
+  child: ReactNode
+): child is ReactElement<{ className?: string }> {
+  return (
+    isValidElement<{ className?: string }>(child) && child.type !== Fragment
+  );
+}
+
+function getTriggerChild({
+  children,
+  className,
+  block,
+}: Pick<TooltipProps, 'children' | 'className' | 'block'>) {
+  if (Children.count(children) === 1) {
+    const onlyChild = Children.only(children);
+    if (isElementWithClassName(onlyChild)) {
+      return cloneElement(onlyChild, {
+        className: cn(onlyChild.props.className, className),
+      });
+    }
+  }
+
+  return (
+    <span className={cn(block ? 'flex w-full' : 'inline-flex', className)}>
+      {children}
+    </span>
+  );
 }
 
 export function Tooltip({
@@ -26,45 +67,24 @@ export function Tooltip({
   side = 'bottom',
   className,
   block,
+  open,
+  defaultOpen,
 }: TooltipProps) {
-  const sideClasses =
-    side === 'bottom'
-      ? 'top-full left-1/2 -translate-x-1/2 mt-1.5'
-      : side === 'top'
-        ? 'bottom-full left-1/2 -translate-x-1/2 mb-1.5'
-        : side === 'right'
-          ? 'left-full top-1/2 -translate-y-1/2 ml-1.5'
-          : 'right-full top-1/2 -translate-y-1/2 mr-1.5';
+  const triggerChild = getTriggerChild({ children, className, block });
 
   return (
-    <span
-      className={cn(
-        'relative group/tip isolate',
-        block ? 'flex w-full' : 'inline-flex',
-        className
-      )}
-    >
-      {children}
-      <span
-        role='tooltip'
-        className={cn(
-          // z-[100] to sit above new shell chrome (UnifiedSidebar z-~10-40, PersistentAudioBar/NowPlaying ~z-30, drawers ~z-50) while near cursor.
-          'pointer-events-none absolute z-[100] whitespace-nowrap',
-          'opacity-0 group-hover/tip:opacity-100 group-focus-within/tip:opacity-100',
-          'transition-opacity duration-subtle ease-subtle delay-[400ms] group-hover/tip:delay-[400ms] group-focus-within/tip:delay-[80ms]',
-          'motion-reduce:transition-none motion-reduce:delay-0',
-          sideClasses
-        )}
-      >
-        <span className='inline-flex items-center gap-2 h-6 px-2 rounded-md text-[11px] font-caption text-primary-token bg-(--linear-app-content-surface)/95 border border-(--linear-app-shell-border) backdrop-blur-xl shadow-[0_6px_20px_rgba(0,0,0,0.28)]'>
-          <span className='leading-none'>{label}</span>
-          {shortcut && (
-            <kbd className='inline-flex items-center h-4 min-w-4 px-1 rounded-[3px] text-[9.5px] font-caption uppercase tracking-[0.04em] text-tertiary-token bg-surface-0/80 border border-(--linear-app-shell-border) leading-none'>
-              {shortcut.keys}
-            </kbd>
-          )}
-        </span>
-      </span>
-    </span>
+    <TooltipProvider delayDuration={120} skipDelayDuration={40}>
+      <TooltipRoot open={open} defaultOpen={defaultOpen}>
+        <TooltipTrigger asChild>{triggerChild}</TooltipTrigger>
+        <TooltipContent
+          side={side}
+          sideOffset={6}
+          className='flex items-center gap-2 whitespace-nowrap'
+        >
+          <span>{label}</span>
+          {shortcut ? <Kbd variant='tooltip'>{shortcut.keys}</Kbd> : null}
+        </TooltipContent>
+      </TooltipRoot>
+    </TooltipProvider>
   );
 }

--- a/apps/web/tests/e2e/electron-titlebar-geometry.spec.ts
+++ b/apps/web/tests/e2e/electron-titlebar-geometry.spec.ts
@@ -2,8 +2,9 @@
  * Geometry tests for the Electron titlebar.
  *
  * These tests run in the browser (not in an actual Electron shell) and verify:
- * 1. The titlebar DOM structure — sidebar-cell contains sidebar toggle + update pill;
- *    main-cell is a plain drag region (no nav pill, no header — those moved into
+ * 1. The titlebar DOM structure — sidebar-cell contains back/forward,
+ *    sidebar toggle + update pill; main-cell is a plain drag region (no header —
+ *    page headers moved into
  *    the elevated content card below).
  * 2. No duplicate sidebar toggles — only one [data-sidebar-dock-button] per page and
  *    it must not also have [data-testid="electron-sidebar-toggle"] as a sibling.
@@ -36,6 +37,11 @@ async function forceDesignV1(page: Page): Promise<void> {
 
   await page.addInitScript(
     ({ cookieName, key, value }) => {
+      Object.defineProperty(window, 'electronAPI', {
+        configurable: true,
+        value: {},
+      });
+      document.documentElement.dataset.desktopRuntime = 'electron';
       localStorage.setItem(key, value);
       document.cookie = `${cookieName}=${encodeURIComponent(value)}; path=/; SameSite=Lax`;
     },
@@ -94,17 +100,26 @@ test('titlebar DOM has a single sidebar toggle and an empty main-cell drag regio
   const titlebarRow = page.locator('[data-testid="electron-titlebar-row"]');
   await expect(titlebarRow).toBeAttached({ timeout: 10_000 });
 
-  // Sidebar cell: must contain the canonical sidebar toggle.
+  // Sidebar cell: must contain browser nav and the canonical sidebar toggle.
   const sidebarCell = titlebarRow.locator(
     '[data-testid="electron-titlebar-sidebar-cell"]'
   );
   await expect(sidebarCell).toBeAttached();
   await expect(
+    sidebarCell.locator('[data-testid="electron-nav-pill"]')
+  ).toBeAttached();
+  await expect(
+    sidebarCell.locator('[data-testid="electron-nav-back"]')
+  ).toBeAttached();
+  await expect(
+    sidebarCell.locator('[data-testid="electron-nav-forward"]')
+  ).toBeAttached();
+  await expect(
     sidebarCell.locator('[data-testid="electron-sidebar-toggle"]')
   ).toBeAttached();
 
   // Main cell exists as a drag region but contains no chrome — the page header
-  // and any nav controls now live inside the elevated content card below.
+  // lives inside the elevated content card below.
   const mainCell = titlebarRow.locator(
     '[data-testid="electron-titlebar-main-cell"]'
   );

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -139,7 +139,7 @@ describe('JovieChat empty state', () => {
     mockChatState.isSubmitting = false;
   });
 
-  it('renders the minimal welcome state without prompt pills or competing suggestion cards', () => {
+  it('centers the welcome composer when there are no action cards', () => {
     const { getByTestId, getByText, queryByTestId, queryByText } =
       renderWithQueryClient(<JovieChat profileId='profile-1' />);
 
@@ -154,10 +154,9 @@ describe('JovieChat empty state', () => {
     expect(queryByText('Jovie Assistant')).toBeNull();
     expect(queryByText('Ask anything or tell Jovie what you need')).toBeNull();
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
-    expect(getByTestId('chat-empty-state-action-card-slot')).toBeTruthy();
-    expect(
-      getByTestId('chat-empty-state-action-card-slot').className
-    ).toContain('h-[172px]');
+    expect(getByTestId('chat-empty-state-centered-composer')).toBeTruthy();
+    expect(queryByTestId('chat-empty-state-action-card-slot')).toBeNull();
+    expect(queryByTestId('chat-composer-dock')).toBeNull();
     expect(queryByTestId('chat-empty-state-prompt-rail')).toBeNull();
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(getByTestId('chat-input').getAttribute('data-placeholder')).toBe(
@@ -176,7 +175,7 @@ describe('JovieChat empty state', () => {
     expect(queryByText('Release link')).toBeNull();
   });
 
-  it('renders a contextual action card and submits its prompt', () => {
+  it('centers a contextual action card, hides welcome text, and docks the composer', () => {
     renderWithQueryClient(
       <JovieChat
         profileId='profile-1'
@@ -194,6 +193,14 @@ describe('JovieChat empty state', () => {
 
     expect(screen.getByText('Connect Your Music Catalog')).toBeTruthy();
     expect(screen.getByText(/Add Spotify/)).toBeTruthy();
+    expect(screen.queryByText('What are we working on?')).toBeNull();
+    expect(
+      screen.getByTestId('chat-empty-state-action-card-slot')
+    ).toBeTruthy();
+    expect(
+      screen.queryByTestId('chat-empty-state-centered-composer')
+    ).toBeNull();
+    expect(screen.getByTestId('chat-composer-dock')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: /Plan Setup/ }));
 
@@ -222,6 +229,7 @@ describe('JovieChat empty state', () => {
 
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
     expect(getByTestId('chat-empty-state-action-card-slot')).toBeTruthy();
+    expect(getByTestId('chat-composer-dock')).toBeTruthy();
     expect(queryByTestId('chat-empty-state-top-signals')).toBeNull();
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(queryByText('Connect Your Music Catalog')).toBeNull();

--- a/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
+++ b/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
@@ -7,6 +7,13 @@ vi.mock('@/lib/desktop/electron-bridge', () => ({
   useIsElectronRuntime: () => true,
 }));
 
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    back: vi.fn(),
+    forward: vi.fn(),
+  }),
+}));
+
 vi.mock('@/components/atoms/UpdateAvailablePill', () => ({
   UpdateAvailablePill: () => (
     <button type='button' data-testid='update-available-pill'>
@@ -16,7 +23,7 @@ vi.mock('@/components/atoms/UpdateAvailablePill', () => ({
 }));
 
 describe('DesktopTitlebar', () => {
-  it('renders Electron titlebar with sidebar toggle and update pill in the sidebar cell', () => {
+  it('renders Electron titlebar with nav controls, sidebar toggle, and update pill in the sidebar cell', () => {
     render(
       <SidebarContext.Provider
         value={{
@@ -39,6 +46,12 @@ describe('DesktopTitlebar', () => {
     expect(
       screen.getByTestId('electron-titlebar-sidebar-cell')
     ).toContainElement(screen.getByTestId('electron-sidebar-toggle'));
+    expect(
+      screen.getByTestId('electron-titlebar-sidebar-cell')
+    ).toContainElement(screen.getByTestId('electron-nav-back'));
+    expect(
+      screen.getByTestId('electron-titlebar-sidebar-cell')
+    ).toContainElement(screen.getByTestId('electron-nav-forward'));
 
     // Update pill is in the sidebar cell
     expect(
@@ -50,7 +63,7 @@ describe('DesktopTitlebar', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not render back/forward nav pill (keyboard shortcuts handle navigation)', () => {
+  it('keeps back/forward nav in the sidebar titlebar cell', () => {
     render(
       <SidebarContext.Provider
         value={{
@@ -67,11 +80,13 @@ describe('DesktopTitlebar', () => {
       </SidebarContext.Provider>
     );
 
-    expect(screen.queryByTestId('electron-nav-pill')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('electron-nav-back')).not.toBeInTheDocument();
+    expect(screen.getByTestId('electron-nav-pill')).toBeInTheDocument();
     expect(
-      screen.queryByTestId('electron-nav-forward')
-    ).not.toBeInTheDocument();
+      screen.getByTestId('electron-titlebar-sidebar-cell')
+    ).toContainElement(screen.getByTestId('electron-nav-pill'));
+    expect(
+      screen.getByTestId('electron-titlebar-main-cell')
+    ).not.toContainElement(screen.getByTestId('electron-nav-pill'));
   });
 
   it('main cell is a plain drag region with no rounded card chrome', () => {

--- a/apps/web/tests/unit/components/molecules/DrawerTabs.test.tsx
+++ b/apps/web/tests/unit/components/molecules/DrawerTabs.test.tsx
@@ -22,6 +22,10 @@ describe('DrawerTabs', () => {
     expect(drawerTabs).toHaveAttribute('data-overflow-mode', 'collapse');
     expect(tablist).toBeInTheDocument();
     expect(tablist).toHaveAttribute('aria-label', 'Drawer tabs');
+    expect(tablist.className).toContain('w-full');
+    expect(screen.getByRole('tab', { name: 'Details' }).className).toContain(
+      'flex-1'
+    );
   });
 
   it('renders active tabs as pills and notifies on selection changes', () => {

--- a/apps/web/tests/unit/components/shell/Tooltip.test.tsx
+++ b/apps/web/tests/unit/components/shell/Tooltip.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Tooltip } from '@/components/shell/Tooltip';
+
+describe('shell Tooltip', () => {
+  it('renders portal content above shell chrome and preserves trigger styling', () => {
+    render(
+      <Tooltip
+        label='Full truncated row name'
+        shortcut={{ keys: 'G A', description: 'Open audience' }}
+        defaultOpen
+      >
+        <button type='button' className='trigger-shell-class'>
+          Audience
+        </button>
+      </Tooltip>
+    );
+
+    expect(screen.getByRole('button', { name: 'Audience' })).toHaveClass(
+      'trigger-shell-class'
+    );
+
+    const content = screen.getByTestId('tooltip-content');
+    expect(content).toHaveTextContent('Full truncated row name');
+    expect(content).toHaveTextContent('G A');
+    expect(content.className).toContain('z-[150]');
+  });
+});

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -291,7 +291,9 @@ describe('DashboardNav', () => {
 
     const tasksLink = getByRole('link', { name: 'Tasks 7' });
     expect(tasksLink.className).toContain('h-6.5');
-    expect(tasksLink.className).toContain('gap-2.5');
+    expect(tasksLink.className).toContain(
+      'grid-cols-[20px_minmax(0,1fr)_auto]'
+    );
     expect(tasksLink.className).toContain('text-[12.5px]');
     expect(getByText('7')).toBeDefined();
   });

--- a/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
+++ b/apps/web/tests/unit/dashboard/dashboard-shell-content.test.ts
@@ -20,6 +20,13 @@ import {
 import { APP_ROUTES } from '@/constants/routes';
 
 describe('@critical DashboardShellContent behavior contracts', () => {
+  function resolveSidebarDefaultOpen(
+    sidebarCookie: { value: string } | undefined,
+    sidebarCollapsed: boolean
+  ) {
+    return sidebarCookie ? sidebarCookie.value !== 'false' : !sidebarCollapsed;
+  }
+
   describe('ban check decision', () => {
     it('banned user should see UnavailablePage (contract: banStatus.isBanned === true)', () => {
       // The component checks banStatus.isBanned early and returns UnavailablePage
@@ -123,20 +130,31 @@ describe('@critical DashboardShellContent behavior contracts', () => {
   describe('sidebar cookie contract', () => {
     it('sidebar defaults to open when cookie is absent', () => {
       const sidebarCookie = undefined;
-      const sidebarDefaultOpen = sidebarCookie?.value !== 'false';
+      const sidebarDefaultOpen = resolveSidebarDefaultOpen(
+        sidebarCookie,
+        false
+      );
       expect(sidebarDefaultOpen).toBe(true);
     });
 
     it('sidebar is closed when cookie is "false"', () => {
       const sidebarCookie = { value: 'false' };
-      const sidebarDefaultOpen = sidebarCookie?.value !== 'false';
+      const sidebarDefaultOpen = resolveSidebarDefaultOpen(
+        sidebarCookie,
+        false
+      );
       expect(sidebarDefaultOpen).toBe(false);
     });
 
     it('sidebar is open when cookie has any other value', () => {
       const sidebarCookie = { value: 'true' };
-      const sidebarDefaultOpen = sidebarCookie?.value !== 'false';
+      const sidebarDefaultOpen = resolveSidebarDefaultOpen(sidebarCookie, true);
       expect(sidebarDefaultOpen).toBe(true);
+    });
+
+    it('falls back to persisted dashboard preference when cookie is absent', () => {
+      expect(resolveSidebarDefaultOpen(undefined, true)).toBe(false);
+      expect(resolveSidebarDefaultOpen(undefined, false)).toBe(true);
     });
   });
 

--- a/apps/web/tests/unit/dashboard/drawer-chrome.test.tsx
+++ b/apps/web/tests/unit/dashboard/drawer-chrome.test.tsx
@@ -55,11 +55,10 @@ describe('dashboard drawer chrome', () => {
     expect(
       screen.getByRole('button', { name: 'More actions' })
     ).toBeInTheDocument();
-    // The ariaLabel is rendered as an sr-only span in the minimal header bar — not as a
-    // visible heading. Confirm it exists only as an accessible label, not a sighted heading.
-    const titleSpan = screen.queryByText('Audience member details');
-    expect(titleSpan).toBeInTheDocument();
-    expect(titleSpan).toHaveClass('sr-only');
+    expect(
+      screen.queryByText('Audience member details')
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Alex Fan')).toBeInTheDocument();
   });
 
   it('audience member drawer uses the tabbed card as the scroll region', () => {

--- a/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
@@ -186,6 +186,25 @@ describe('OnboardingChat Turnstile gating', () => {
     errorMocks.metadata = {};
   });
 
+  it('centers the welcome composer before the first message and docks it after messages exist', () => {
+    const { rerender } = render(<TurnstileHarness />);
+
+    expect(screen.getByTestId('onboarding-centered-composer')).toBeVisible();
+    expect(screen.queryByTestId('onboarding-composer-dock')).toBeNull();
+
+    chatMocks.messages = [
+      {
+        id: 'message-1',
+        role: 'user',
+        parts: [{ type: 'text', text: 'help me launch' }],
+      },
+    ];
+    rerender(<TurnstileHarness />);
+
+    expect(screen.queryByTestId('onboarding-centered-composer')).toBeNull();
+    expect(screen.getByTestId('onboarding-composer-dock')).toBeVisible();
+  });
+
   it('keeps the first message local and shows verification guidance until a token exists', () => {
     const onTurnstileRequired = vi.fn();
     render(<TurnstileHarness onTurnstileRequired={onTurnstileRequired} />);
@@ -220,7 +239,7 @@ describe('OnboardingChat Turnstile gating', () => {
     expect(chatMocks.sendMessage).toHaveBeenCalledWith({
       text: 'I am Test Artist',
     });
-    expect(input).toHaveValue('');
+    expect(screen.getByLabelText('Chat message input')).toHaveValue('');
 
     errorMocks.metadata = {
       errorCode: 'TURNSTILE_REQUIRED',
@@ -232,14 +251,18 @@ describe('OnboardingChat Turnstile gating', () => {
     });
 
     expect(onTurnstileRejected).toHaveBeenCalledTimes(1);
-    expect(input).toHaveValue('I am Test Artist');
+    expect(screen.getByLabelText('Chat message input')).toHaveValue(
+      'I am Test Artist'
+    );
     expect(screen.getByText('Verify you are human to send')).toBeVisible();
 
     chatMocks.sendMessage.mockClear();
     fireEvent.click(screen.getByRole('button', { name: 'Retry message' }));
 
     expect(chatMocks.sendMessage).not.toHaveBeenCalled();
-    expect(input).toHaveValue('I am Test Artist');
+    expect(screen.getByLabelText('Chat message input')).toHaveValue(
+      'I am Test Artist'
+    );
     expect(onTurnstileRequired).toHaveBeenCalledWith(
       'Verify you are human to send'
     );

--- a/apps/web/tests/unit/sidebar-row-alignment.test.tsx
+++ b/apps/web/tests/unit/sidebar-row-alignment.test.tsx
@@ -146,8 +146,11 @@ describe('Sidebar row alignment', () => {
     const iconClassName = getSidebarNavIconClassName({});
 
     expect(rowClassName).toContain('h-6.5');
-    expect(rowClassName).toContain('pl-2.5');
-    expect(rowClassName).toContain('gap-2.5');
+    expect(rowClassName).toContain('px-2.5');
+    expect(rowClassName).toContain('gap-x-2.5');
+    expect(rowClassName).toContain('grid-cols-[20px_minmax(0,1fr)_auto]');
+    expect(rowClassName).toContain('before:left-[20px]');
+    expect(rowClassName).toContain('after:left-[34px]');
     expect(rowClassName).toContain('text-[12.5px]');
     expect(rowClassName).toContain(
       'hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)]'

--- a/packages/ui/atoms/tooltip.test.tsx
+++ b/packages/ui/atoms/tooltip.test.tsx
@@ -180,7 +180,7 @@ describe('Tooltip', () => {
     it('applies base styling classes', () => {
       render(<TestTooltip open={true} />);
       const content = screen.getByTestId('tooltip-content');
-      expect(content.className).toContain('z-[100]');
+      expect(content.className).toContain('z-[150]');
       expect(content.className).toContain('rounded-md');
       expect(content.className).toContain('text-[12px]');
     });

--- a/packages/ui/atoms/tooltip.tsx
+++ b/packages/ui/atoms/tooltip.tsx
@@ -60,7 +60,7 @@ interface TooltipContentProps
 
 /**
  * Tooltip content with tokenized surface styling.
- * z-[100] to sit above new shell chrome (sidebar, audio bar, now playing, drawers).
+ * z-[150] to sit above shell chrome, right rails, popovers, and drawers.
  * Pure opacity reveal only (fade-in/out) — no decorative zoom or slide/translate
  * per DESIGN.md + .claude/rules/ui.md "No Decorative Hover Motion" + subtraction.
  * Complements shell Tooltip (support-8) + DspAvatarStack pure opacity updates.
@@ -88,7 +88,7 @@ const TooltipContent = React.forwardRef<
         data-testid={testId}
         className={cn(
           // Base layout + spacing
-          'z-[100] overflow-hidden rounded-md border border-(--linear-border-subtle)',
+          'z-[150] overflow-hidden rounded-md border border-(--linear-border-subtle)',
           'bg-(--linear-bg-surface-0) px-2 py-1 text-[12px] font-[400] tracking-[-0.011em]',
           'text-(--linear-text-primary) shadow-(--linear-shadow-card-elevated)',
           'max-w-[220px]',


### PR DESCRIPTION
## Summary
- Centers chat/start empty states into one active surface: contextual action cards hide welcome text and keep the composer bottom-docked; no-card start/chat keeps the welcome composer centered.
- Replaces shell tooltip chrome with portal-backed UI tooltips at z-[150], adds direct regression coverage, and lifts DSP hover popovers above shell chrome.
- Cleans Electron titlebar/sidebar chrome, persists sidebar collapsed fallback from dashboard settings, aligns drawer tabs/right-rail hierarchy, and removes the audience drawer empty utility header.

## Verification
- pnpm biome check --write <touched files>
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm --filter @jovie/web exec vitest run tests/unit/chat/JovieChat.empty-state.test.tsx tests/unit/onboarding/OnboardingChat.turnstile.test.tsx tests/unit/components/atoms/DesktopTitlebar.test.tsx tests/unit/components/molecules/DrawerTabs.test.tsx tests/unit/components/shell/Tooltip.test.tsx tests/unit/dashboard/dashboard-shell-content.test.ts tests/unit/dashboard/drawer-chrome.test.tsx tests/unit/sidebar-row-alignment.test.tsx components/shell/DspAvatarStack.test.tsx
- pnpm --filter @jovie/ui exec vitest run atoms/tooltip.test.tsx
- E2E_USE_TEST_AUTH_BYPASS=1 E2E_SKIP_WEB_SERVER=1 BASE_URL=http://localhost:3000 pnpm --filter @jovie/web exec playwright test tests/e2e/electron-titlebar-geometry.spec.ts --project=chromium
- git diff --check
- pnpm pre-push hook passed on push: Biome, proxy guard, Tailwind guard, typecheck, lint

## Visual QA
- Captured /app/chat, /start, and /app/audience at desktop/tablet/mobile from pnpm run dev:web:browse.
- Fresh /start center check: desktop delta 49px, tablet delta 49px, mobile delta 45px from shell center with heading included.
