### PR TITLE
fix(chat): harden shell actions and token titles

### DIFF
--- a/apps/web/app/api/chat/conversations/[id]/messages/route.ts
+++ b/apps/web/app/api/chat/conversations/[id]/messages/route.ts
@@ -3,6 +3,7 @@ import { and, eq, isNull } from 'drizzle-orm';
 import { after, NextResponse } from 'next/server';
 import { generateText } from '@/lib/ai/sdk';
 import { getSessionContext } from '@/lib/auth/session';
+import { sanitizeConversationTitle } from '@/lib/chat/title';
 import {
   type ChatPersistenceMessage,
   chatPersistenceBatchSchema,
@@ -32,11 +33,16 @@ async function maybeGenerateTitle(
   messages: ChatPersistenceMessage[]
 ): Promise<void> {
   const userMessage = messages.find(m => m.role === 'user');
-  if (!userMessage?.content) return;
+  const titleSource = sanitizeConversationTitle(userMessage?.content, 200);
+  if (!titleSource) return;
 
   try {
     const context = messages
-      .map(m => `${m.role}: ${m.content.slice(0, 200)}`)
+      .map(m => {
+        const content = sanitizeConversationTitle(m.content, 200);
+        return content ? `${m.role}: ${content}` : null;
+      })
+      .filter((line): line is string => line !== null)
       .join('\n');
 
     const { text } = await generateText({
@@ -54,10 +60,7 @@ async function maybeGenerateTitle(
       },
     });
 
-    const title = text
-      .trim()
-      .replaceAll(/(?:^["'])|(?:["']$)/g, '')
-      .slice(0, 80);
+    const title = sanitizeConversationTitle(text);
 
     if (!title) throw new Error('Empty title generated');
 
@@ -72,13 +75,11 @@ async function maybeGenerateTitle(
       );
   } catch (error) {
     logger.error('AI title generation failed, using fallback:', error);
-    const raw = userMessage.content.trim();
-    if (!raw) return;
-    const fallback = raw.slice(0, 50);
-    const suffix = raw.length > 50 ? '...' : '';
+    const fallback = sanitizeConversationTitle(titleSource, 50);
+    if (!fallback) return;
     await db
       .update(chatConversations)
-      .set({ title: fallback + suffix })
+      .set({ title: fallback })
       .where(
         and(
           eq(chatConversations.id, conversationId),

--- a/apps/web/app/api/chat/conversations/[id]/route.ts
+++ b/apps/web/app/api/chat/conversations/[id]/route.ts
@@ -1,6 +1,10 @@
 import { and, desc, eq, lt } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { getSessionContext } from '@/lib/auth/session';
+import {
+  sanitizeConversationTitle,
+  withSanitizedConversationTitle,
+} from '@/lib/chat/title';
 import { decodeToolEvents } from '@/lib/chat/tool-events';
 import { db } from '@/lib/db';
 import { chatConversations, chatMessages } from '@/lib/db/schema/chat';
@@ -113,7 +117,11 @@ export async function GET(req: Request, { params }: RouteParams) {
     });
 
     return NextResponse.json(
-      { conversation, messages, hasMore },
+      {
+        conversation: withSanitizedConversationTitle(conversation),
+        messages,
+        hasMore,
+      },
       { status: 200, headers: NO_STORE_HEADERS }
     );
   } catch (error) {
@@ -166,12 +174,13 @@ export async function PATCH(req: Request, { params }: RouteParams) {
     }
 
     const { title } = body;
+    const sanitizedTitle = sanitizeConversationTitle(title);
 
     // Update the conversation, ensuring it belongs to the user's profile
     const [updated] = await db
       .update(chatConversations)
       .set({
-        title: title ?? null,
+        title: sanitizedTitle,
         updatedAt: new Date(),
       })
       .where(
@@ -190,7 +199,9 @@ export async function PATCH(req: Request, { params }: RouteParams) {
     }
 
     return NextResponse.json(
-      { conversation: updated },
+      {
+        conversation: withSanitizedConversationTitle(updated),
+      },
       { status: 200, headers: NO_STORE_HEADERS }
     );
   } catch (error) {

--- a/apps/web/app/api/chat/conversations/route.ts
+++ b/apps/web/app/api/chat/conversations/route.ts
@@ -1,6 +1,10 @@
 import { count, desc, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { getSessionContext } from '@/lib/auth/session';
+import {
+  sanitizeConversationTitle,
+  withSanitizedConversationTitles,
+} from '@/lib/chat/title';
 import { db } from '@/lib/db';
 import { chatConversations, chatMessages } from '@/lib/db/schema/chat';
 import { captureError } from '@/lib/error-tracking';
@@ -55,7 +59,9 @@ export async function GET(req: Request) {
       .limit(limit);
 
     return NextResponse.json(
-      { conversations },
+      {
+        conversations: withSanitizedConversationTitles(conversations),
+      },
       { status: 200, headers: NO_STORE_HEADERS }
     );
   } catch (error) {
@@ -119,6 +125,7 @@ export async function POST(req: Request) {
     }
 
     const { title, initialMessage } = body;
+    const sanitizedTitle = sanitizeConversationTitle(title);
 
     // Validate initial message length
     if (
@@ -139,7 +146,7 @@ export async function POST(req: Request) {
       .values({
         userId: user.id,
         creatorProfileId: profile.id,
-        title: title ?? null,
+        title: sanitizedTitle,
       })
       .returning();
 

--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -139,15 +139,7 @@ function buildChatActionCards({
     ];
   }
 
-  return [
-    {
-      id: 'plan-next-move',
-      title: 'Plan Your Next Move',
-      body: `Use ${artistName}'s profile and catalog context to choose one concrete action for this week.`,
-      actionLabel: 'Plan Move',
-      prompt: `Use my artist profile, music catalog, and dashboard context for ${artistName} to recommend the single most useful action I should take this week. Include the first step.`,
-    },
-  ];
+  return [];
 }
 
 export function shouldRetryWelcomeChatBootstrap(

--- a/apps/web/app/app/(shell)/chat/[id]/chat-thread-metadata-data.ts
+++ b/apps/web/app/app/(shell)/chat/[id]/chat-thread-metadata-data.ts
@@ -2,21 +2,22 @@ import 'server-only';
 
 import { and, eq } from 'drizzle-orm';
 import { getSessionContext } from '@/lib/auth/session';
+import { sanitizeConversationTitle } from '@/lib/chat/title';
 import { db } from '@/lib/db';
 import { chatConversations } from '@/lib/db/schema/chat';
 
 export const CHAT_THREAD_TITLE_FALLBACK = 'Thread | Jovie';
 
-export async function loadChatThreadMetadataTitle(
+export async function loadChatThreadTitle(
   conversationId: string
-): Promise<string> {
+): Promise<string | null> {
   try {
     const { user } = await getSessionContext({
       requireUser: false,
       requireProfile: false,
     });
 
-    if (!user) return CHAT_THREAD_TITLE_FALLBACK;
+    if (!user) return null;
 
     const [conversation] = await db
       .select({ title: chatConversations.title })
@@ -29,12 +30,19 @@ export async function loadChatThreadMetadataTitle(
       )
       .limit(1);
 
-    const conversationTitle = conversation?.title?.trim();
+    const conversationTitle = sanitizeConversationTitle(conversation?.title);
 
-    return conversationTitle
-      ? `${conversationTitle} | Jovie`
-      : CHAT_THREAD_TITLE_FALLBACK;
+    return conversationTitle;
   } catch {
-    return CHAT_THREAD_TITLE_FALLBACK;
+    return null;
   }
+}
+
+export async function loadChatThreadMetadataTitle(
+  conversationId: string
+): Promise<string> {
+  const conversationTitle = await loadChatThreadTitle(conversationId);
+  return conversationTitle
+    ? `${conversationTitle} | Jovie`
+    : CHAT_THREAD_TITLE_FALLBACK;
 }

--- a/apps/web/app/app/(shell)/chat/[id]/page.tsx
+++ b/apps/web/app/app/(shell)/chat/[id]/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from 'next';
 import { DeferredChatPageClient } from '../DeferredChatPageClient';
-import { loadChatThreadMetadataTitle } from './chat-thread-metadata-data';
+import {
+  loadChatThreadMetadataTitle,
+  loadChatThreadTitle,
+} from './chat-thread-metadata-data';
 
 interface Props {
   readonly params: Promise<{
@@ -31,7 +34,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
  */
 export default async function ChatConversationPage({ params }: Props) {
   const { id } = await params;
-  const initialConversationTitle = await loadChatThreadMetadataTitle(id);
+  const initialConversationTitle = await loadChatThreadTitle(id);
 
   return (
     <DeferredChatPageClient

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -5,7 +5,6 @@ import { ImagePlus } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { JovieMarkElectric } from '@/components/atoms/JovieMarkElectric';
-import { SuggestionCard } from '@/components/shell/SuggestionCard';
 import { useAppFlag } from '@/lib/flags/client';
 import { SUPPORTED_IMAGE_MIME_TYPES } from '@/lib/images/config';
 import { cn } from '@/lib/utils';
@@ -18,9 +17,11 @@ import {
   ErrorDisplay,
   ScrollToBottom,
 } from './components';
+import { ChatActionCard } from './components/ChatActionCard';
 import { ChatProvidersRegistrar } from './components/ChatProvidersRegistrar';
 import { ChatUsageAlert } from './components/ChatUsageAlert';
 import { EntityResolutionProvider } from './components/EntityResolutionProvider';
+import { SuggestedPrompts } from './components/SuggestedPrompts';
 import {
   useChatImageAttachments,
   useChatJankMonitor,
@@ -78,6 +79,9 @@ export function JovieChat({
   const imageFileInputRef = useRef<HTMLInputElement>(null);
   // Track message IDs that were loaded from persistence to skip entrance animation
   const knownMessageIdsRef = useRef<Set<string>>(new Set());
+  const [dismissedActionCardIds, setDismissedActionCardIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
   // Hide neighbouring affordances while the slash picker owns the composer.
   const [composerPickerOpen, setComposerPickerOpen] = useState(false);
   const {
@@ -318,6 +322,14 @@ export function JovieChat({
   const isStreaming = status === 'streaming';
   const showThreadView = hasMessages || showPendingBootstrap;
 
+  const handleDismissActionCard = useCallback((cardId: string) => {
+    setDismissedActionCardIds(prev => {
+      const next = new Set(prev);
+      next.add(cardId);
+      return next;
+    });
+  }, []);
+
   // Show skeleton while fetching existing conversation
   if (isLoadingConversation) {
     return (
@@ -372,14 +384,23 @@ export function JovieChat({
 
   const greetingName =
     getFirstNameForGreeting(displayName) ?? getFirstNameForGreeting(username);
-  const primaryActionCard = actionCards[0] ?? null;
+  const primaryActionCard =
+    actionCards.find(card => !dismissedActionCardIds.has(card.id)) ?? null;
   const hasActionCardEmptyLayout = primaryActionCard !== null;
+  const hasComposerActivity =
+    input.trim().length > 0 ||
+    (pendingImages?.length ?? 0) > 0 ||
+    chipTray.chips.length > 0;
   const showActionCardContent =
     primaryActionCard !== null &&
-    input.trim().length === 0 &&
+    !hasComposerActivity &&
     !composerPickerOpen &&
-    (pendingImages?.length ?? 0) === 0 &&
-    chipTray.chips.length === 0;
+    !showThreadView;
+  const showSoftSuggestions =
+    !showThreadView &&
+    primaryActionCard === null &&
+    !hasComposerActivity &&
+    !composerPickerOpen;
   let emptyStateHeading: string;
   if (isFirstSession) {
     emptyStateHeading = "Hey, I'm Jovie.";
@@ -532,7 +553,7 @@ export function JovieChat({
                         data-testid='chat-empty-state-action-card-slot'
                       >
                         {showActionCardContent ? (
-                          <SuggestionCard
+                          <ChatActionCard
                             className='h-full'
                             title={primaryActionCard.title}
                             body={primaryActionCard.body}
@@ -541,6 +562,9 @@ export function JovieChat({
                               handleSuggestedPromptWithJank(
                                 primaryActionCard.prompt
                               )
+                            }
+                            onDismiss={() =>
+                              handleDismissActionCard(primaryActionCard.id)
                             }
                           />
                         ) : null}
@@ -562,6 +586,18 @@ export function JovieChat({
                           data-testid='chat-empty-state-centered-composer'
                         >
                           {composerSurface}
+                        </div>
+                        <div
+                          className='min-h-[38px] w-full'
+                          data-testid='chat-empty-state-soft-suggestions-slot'
+                        >
+                          {showSoftSuggestions ? (
+                            <SuggestedPrompts
+                              onSelect={handleSuggestedPromptWithJank}
+                              isFirstSession={isFirstSession}
+                              layout='rail'
+                            />
+                          ) : null}
                         </div>
                       </>
                     )}

--- a/apps/web/components/jovie/components/ChatActionCard.tsx
+++ b/apps/web/components/jovie/components/ChatActionCard.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { AlertCircle, ArrowRight, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface ChatActionCardProps {
+  readonly title: string;
+  readonly body: string;
+  readonly actionLabel: string;
+  readonly onAct: () => void;
+  readonly onDismiss: () => void;
+  readonly className?: string;
+}
+
+export function ChatActionCard({
+  title,
+  body,
+  actionLabel,
+  onAct,
+  onDismiss,
+  className,
+}: ChatActionCardProps) {
+  return (
+    <article
+      className={cn(
+        'relative grid min-h-[148px] w-full grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3 rounded-[16px] border border-[color-mix(in_oklab,var(--linear-border-focus)_22%,var(--linear-app-frame-seam))] bg-[linear-gradient(180deg,rgba(255,255,255,0.052)_0%,rgba(255,255,255,0.016)_100%),var(--linear-app-content-surface)] px-4 py-4 text-left shadow-none sm:min-h-[132px] sm:items-center sm:px-5',
+        className
+      )}
+      data-testid='chat-action-card'
+    >
+      <span
+        className='mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/[0.08] bg-white/[0.035] text-secondary-token sm:mt-0'
+        aria-hidden='true'
+      >
+        <AlertCircle className='h-4 w-4' strokeWidth={2.2} />
+      </span>
+
+      <div className='min-w-0 pr-1'>
+        <h2 className='text-pretty text-[15px] font-semibold leading-5 text-primary-token sm:text-[15.5px]'>
+          {title}
+        </h2>
+        <p className='mt-1.5 max-w-[48ch] text-pretty text-[12.5px] leading-5 text-tertiary-token'>
+          {body}
+        </p>
+        <button
+          type='button'
+          onClick={onAct}
+          className='mt-3 inline-flex h-8 items-center gap-1.5 rounded-full bg-white px-3.5 text-[12px] font-medium text-black shadow-[0_6px_18px_rgba(0,0,0,0.22),inset_0_1px_0_rgba(255,255,255,0.45)] transition-[filter,box-shadow] duration-subtle ease-out hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface)'
+        >
+          {actionLabel}
+          <ArrowRight className='h-3.5 w-3.5' strokeWidth={2.5} />
+        </button>
+      </div>
+
+      <button
+        type='button'
+        onClick={onDismiss}
+        className='inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-tertiary-token transition-colors duration-subtle hover:bg-white/[0.06] hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/45'
+        aria-label={`Dismiss ${title}`}
+      >
+        <X className='h-3.5 w-3.5' strokeWidth={2.25} />
+      </button>
+    </article>
+  );
+}

--- a/apps/web/components/jovie/components/ChatAlbumArtCard.tsx
+++ b/apps/web/components/jovie/components/ChatAlbumArtCard.tsx
@@ -24,7 +24,7 @@ function insertReleaseChips(
   release: { id: string; title: string },
   { createRelease = false }: { readonly createRelease?: boolean } = {}
 ): void {
-  // Skill chip first so the transcript reads "/skill:... @release:..."
+  // Skill chip first so the transcript keeps action context before the release.
   globalThis.dispatchEvent(
     new CustomEvent('jovie-chat-insert-mention', {
       detail: { skillId: 'generateAlbumArt' },

--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -71,6 +71,11 @@ export function ChatMessage({
     });
   })();
   const hasAssistantContent = Boolean(messageText) || toolEvents.length > 0;
+  const useUserPillBubble =
+    isUser &&
+    imageChips.length === 0 &&
+    !messageText.includes('\n') &&
+    messageText.length <= 72;
 
   return (
     <motion.div
@@ -86,7 +91,13 @@ export function ChatMessage({
       {isUser ? (
         <div
           data-testid='chat-user-bubble'
-          className='flex min-h-7 max-w-[78%] flex-col justify-center rounded-full border border-white/80 bg-white px-3 py-1.5 text-[#111216] shadow-[0_12px_38px_-28px_rgba(0,0,0,0.85),inset_0_1px_0_rgba(255,255,255,0.9)]'
+          data-bubble-shape={useUserPillBubble ? 'pill' : 'rectangle'}
+          className={cn(
+            'flex min-h-7 max-w-[78%] flex-col justify-center border border-white/80 bg-white text-[#111216] shadow-[0_12px_38px_-28px_rgba(0,0,0,0.85),inset_0_1px_0_rgba(255,255,255,0.9)]',
+            useUserPillBubble
+              ? 'rounded-full px-3 py-1.5'
+              : 'rounded-[18px] px-3.5 py-2'
+          )}
         >
           {imageChips.length > 0 && (
             <div

--- a/apps/web/components/jovie/components/TokenizedText.tsx
+++ b/apps/web/components/jovie/components/TokenizedText.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useMemo } from 'react';
 import { type ChatToken, parseTokens } from '@/lib/chat/tokens';
+import { skillById } from '@/lib/commands/registry';
 import { cn } from '@/lib/utils';
 import { EntityChip, type EntityChipTone } from './EntityChip';
 import { EntityChipPopover } from './EntityChipPopover';
@@ -75,16 +76,38 @@ export function TokenizedText({
             />
           );
         }
-        return (
-          <span
-            key={key}
-            className='inline-flex items-center rounded bg-surface-2 px-1.5 py-0.5 align-baseline text-xs font-medium text-secondary-token'
-            title={`Skill: ${token.id}`}
-          >
-            /{token.id}
-          </span>
-        );
+        return <TranscriptSkillChip key={key} id={token.id} tone={tone} />;
       })}
+    </span>
+  );
+}
+
+interface TranscriptSkillChipProps {
+  readonly id: string;
+  readonly tone: EntityChipTone;
+}
+
+function TranscriptSkillChip({ id, tone }: TranscriptSkillChipProps) {
+  const label = skillById(id)?.label ?? id;
+  return (
+    <span
+      className={cn(
+        'mx-0.5 inline-flex h-6 max-w-[220px] items-center gap-1.5 rounded-[8px] border px-2 align-[-0.2em] text-[12px] font-medium leading-none shadow-none',
+        tone === 'onLight'
+          ? 'border-black/10 bg-black/[0.055] text-[#111216]'
+          : 'border-white/[0.085] bg-white/[0.035] text-primary-token'
+      )}
+      title={label}
+      data-testid='transcript-skill-chip'
+    >
+      <span
+        aria-hidden
+        className={cn(
+          'h-1.5 w-1.5 shrink-0 rounded-full',
+          tone === 'onLight' ? 'bg-black/45' : 'bg-tertiary-token'
+        )}
+      />
+      <span className='min-w-0 truncate'>{label}</span>
     </span>
   );
 }

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -99,6 +99,10 @@ function inferToolIntentFromPrompt(text: string): string | null {
     : null;
 }
 
+function inferToolIntentFromSkill(id: string): string | null {
+  return id === 'generateAlbumArt' ? 'album_art_generation' : id;
+}
+
 function getTitlePollIntervalMs(
   titlePollingSince: number | null,
   currentTime: number
@@ -116,6 +120,10 @@ function getTitlePollIntervalMs(
   return elapsed < TITLE_POLL_FAST_WINDOW_MS
     ? TITLE_POLL_FAST_INTERVAL_MS
     : TITLE_POLL_BACKOFF_INTERVAL_MS;
+}
+
+function toError(value: unknown): Error {
+  return value instanceof Error ? value : new Error('Chat send failed');
 }
 
 export function useJovieChat({
@@ -228,6 +236,41 @@ export function useJovieChat({
     );
   }, [existingConversation]);
 
+  const handleChatFailure = useCallback(
+    (error: Error, errorType: 'send' | 'stream') => {
+      captureException(error, {
+        tags: {
+          feature: 'ai-chat',
+          source: 'useJovieChat',
+          errorType,
+        },
+        extra: {
+          profileId: profileId ?? null,
+          conversationId: activeConversationId,
+        },
+      });
+
+      const chatErrorType = getErrorType(error);
+      const metadata = extractErrorMetadata(error);
+
+      setChatError({
+        type: chatErrorType,
+        message: getPreferredErrorMessage(error, chatErrorType, metadata),
+        retryAfter: metadata.retryAfter,
+        errorCode: metadata.errorCode,
+        requestId: metadata.requestId,
+        failedMessage: lastAttemptedMessageRef.current,
+      });
+
+      if (lastAttemptedMessageRef.current) {
+        setInput(lastAttemptedMessageRef.current);
+      }
+
+      setIsSubmitting(false);
+    },
+    [activeConversationId, profileId]
+  );
+
   const {
     messages,
     sendMessage,
@@ -261,40 +304,11 @@ export function useJovieChat({
       setIsSubmitting(false);
     },
     onError: error => {
-      captureException(error, {
-        tags: {
-          feature: 'ai-chat',
-          source: 'useJovieChat',
-          errorType: 'stream',
-        },
-        extra: {
-          profileId: profileId ?? null,
-          conversationId: activeConversationId,
-        },
-      });
-
-      const errorType = getErrorType(error);
-      const metadata = extractErrorMetadata(error);
-
-      setChatError({
-        type: errorType,
-        message: getPreferredErrorMessage(error, errorType, metadata),
-        retryAfter: metadata.retryAfter,
-        errorCode: metadata.errorCode,
-        requestId: metadata.requestId,
-        failedMessage: lastAttemptedMessageRef.current,
-      });
-
-      // Restore the user's message so they don't lose it
-      if (lastAttemptedMessageRef.current) {
-        setInput(lastAttemptedMessageRef.current);
-      }
+      handleChatFailure(error, 'stream');
 
       queryClient.invalidateQueries({
         queryKey: queryKeys.chat.usage(),
       });
-
-      setIsSubmitting(false);
     },
   });
 
@@ -372,7 +386,11 @@ export function useJovieChat({
 
   // Clear error when user starts typing
   useEffect(() => {
-    if (input && chatError) {
+    if (
+      input &&
+      chatError &&
+      (!chatError.failedMessage || input !== chatError.failedMessage)
+    ) {
       setChatError(null);
     }
   }, [input, chatError]);
@@ -415,10 +433,10 @@ export function useJovieChat({
       text: string,
       files?: FileUIPart[],
       options?: SubmitChatMessageOptions
-    ) => {
+    ): Promise<boolean> => {
       const hasFiles = files && files.length > 0;
-      if (!text.trim() && !hasFiles) return;
-      if (isLoading || isSubmitting) return;
+      if (!text.trim() && !hasFiles) return false;
+      if (isLoading || isSubmitting) return false;
 
       // Validate message length
       if (text.length > MAX_MESSAGE_LENGTH) {
@@ -426,13 +444,13 @@ export function useJovieChat({
           type: 'unknown',
           message: `Message is too long. Maximum is ${MAX_MESSAGE_LENGTH} characters.`,
         });
-        return;
+        return false;
       }
 
       const trimmedText = text.trim();
 
       // Check for deterministic commands before hitting AI
-      if (!hasFiles && tryHandleCommand(trimmedText)) return;
+      if (!hasFiles && tryHandleCommand(trimmedText)) return true;
 
       const payload = {
         text: trimmedText,
@@ -448,17 +466,28 @@ export function useJovieChat({
       const toolIntent =
         options?.toolIntent ?? inferToolIntentFromPrompt(trimmedText);
 
-      sendMessage(payload, {
+      const sendOptions = {
         body: {
           clientTurnId,
           clientMessageId: `${clientTurnId}:user`,
           source: options?.source ?? 'typed',
           ...(toolIntent ? { toolIntent } : {}),
         },
-      });
-      setInput('');
+      };
+
+      try {
+        const result = sendMessage(payload, sendOptions);
+        setInput('');
+        void Promise.resolve(result).catch(value => {
+          handleChatFailure(toError(value), 'send');
+        });
+        return true;
+      } catch (error) {
+        handleChatFailure(toError(error), 'send');
+        return false;
+      }
     },
-    [isLoading, isSubmitting, sendMessage, tryHandleCommand]
+    [handleChatFailure, isLoading, isSubmitting, sendMessage, tryHandleCommand]
   );
 
   // Retry the last failed message
@@ -476,7 +505,10 @@ export function useJovieChat({
       source,
       toolIntent,
     }: { text: string; files?: FileUIPart[] } & SubmitChatMessageOptions) => {
-      await doSubmit(text, files, { source, toolIntent });
+      const submitted = await doSubmit(text, files, { source, toolIntent });
+      if (submitted) {
+        chipTray.clear();
+      }
     },
     {
       limit: 1,
@@ -509,8 +541,13 @@ export function useJovieChat({
     (e?: React.FormEvent, files?: FileUIPart[]) => {
       e?.preventDefault();
       const composed = composeMessage(chipTray.chips, input);
-      rateLimitedSubmitter.maybeExecute({ text: composed, files });
-      chipTray.clear();
+      const skillChip = chipTray.chips.find(chip => chip.type === 'skill');
+      rateLimitedSubmitter.maybeExecute({
+        text: composed,
+        files,
+        source: skillChip ? 'slash_command' : 'typed',
+        toolIntent: skillChip ? inferToolIntentFromSkill(skillChip.id) : null,
+      });
     },
     [chipTray, input, rateLimitedSubmitter]
   );

--- a/apps/web/lib/chat/title.test.ts
+++ b/apps/web/lib/chat/title.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  sanitizeConversationTitle,
+  withSanitizedConversationTitle,
+  withSanitizedConversationTitles,
+} from './title';
+
+describe('sanitizeConversationTitle', () => {
+  it('renders skill and entity tokens as readable title text', () => {
+    expect(
+      sanitizeConversationTitle(
+        '/skill:generateAlbumArt @release:rel_1[Midnight Drive] please'
+      )
+    ).toBe('Generate album art Midnight Drive please');
+  });
+
+  it('removes raw token syntax from fallback titles', () => {
+    const title = sanitizeConversationTitle(
+      'skill /skill:generateAlbumArt for @release:rel_1[Midnight Drive]'
+    );
+
+    expect(title).toBe('Generate album art for Midnight Drive');
+    expect(title).not.toContain('/skill:');
+    expect(title?.toLowerCase()).not.toContain('skill');
+    expect(title).not.toContain('@release:');
+  });
+
+  it('sanitizes conversation records without duplicating response mapping', () => {
+    expect(
+      withSanitizedConversationTitle({
+        id: 'conversation_1',
+        title: '/skill:generateAlbumArt @release:rel_1[Midnight Drive]',
+      })
+    ).toEqual({
+      id: 'conversation_1',
+      title: 'Generate album art Midnight Drive',
+    });
+
+    expect(
+      withSanitizedConversationTitles([
+        { id: 'conversation_2', title: 'skill /skill:openTask' },
+      ])
+    ).toEqual([{ id: 'conversation_2', title: 'Open task' }]);
+  });
+});

--- a/apps/web/lib/chat/title.ts
+++ b/apps/web/lib/chat/title.ts
@@ -1,0 +1,78 @@
+import { skillById } from '@/lib/commands/registry';
+import { parseTokens } from './tokens';
+
+const DEFAULT_MAX_TITLE_LENGTH = 80;
+
+interface ConversationTitleRecord {
+  readonly title: string | null;
+}
+
+function humanizeIdentifier(value: string): string {
+  const spaced = value
+    .replaceAll(/[_-]+/g, ' ')
+    .replaceAll(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replaceAll(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+
+  return spaced ? spaced[0].toUpperCase() + spaced.slice(1) : '';
+}
+
+function stripResidualTokenSyntax(value: string): string {
+  return value
+    .replaceAll(/\/skill:[A-Za-z]\w*/g, ' ')
+    .replaceAll(/\bskill\b/gi, ' ')
+    .replaceAll(
+      /@(release|artist|track|event):[^\s[\]]+\[((?:\\.|[^\]\\])*)\]/g,
+      '$2'
+    )
+    .replaceAll(/[\\/[\]{}]+/g, ' ');
+}
+
+function truncateTitle(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, Math.max(0, maxLength - 3)).trimEnd()}...`;
+}
+
+export function sanitizeConversationTitle(
+  value: string | null | undefined,
+  maxLength = DEFAULT_MAX_TITLE_LENGTH
+): string | null {
+  const input = value?.trim();
+  if (!input) return null;
+
+  const rendered = parseTokens(input)
+    .map(token => {
+      if (token.type === 'text') return token.value;
+      if (token.type === 'entity') return token.label;
+      return skillById(token.id)?.label ?? humanizeIdentifier(token.id);
+    })
+    .join(' ');
+
+  const normalized = stripResidualTokenSyntax(rendered)
+    .replaceAll(/\s+/g, ' ')
+    .trim()
+    .replaceAll(/(?:^["'])|(?:["']$)/g, '');
+
+  if (!normalized) return null;
+  return truncateTitle(normalized, maxLength);
+}
+
+export function withSanitizedConversationTitle<
+  TConversation extends ConversationTitleRecord,
+>(
+  conversation: TConversation
+): Omit<TConversation, 'title'> & { readonly title: string | null } {
+  return {
+    ...conversation,
+    title: sanitizeConversationTitle(conversation.title),
+  };
+}
+
+export function withSanitizedConversationTitles<
+  TConversation extends ConversationTitleRecord,
+>(
+  conversations: readonly TConversation[]
+): Array<Omit<TConversation, 'title'> & { readonly title: string | null }> {
+  return conversations.map(withSanitizedConversationTitle);
+}

--- a/apps/web/lib/chat/turns.ts
+++ b/apps/web/lib/chat/turns.ts
@@ -7,6 +7,7 @@ import {
   chatMessages,
   chatTurns,
 } from '@/lib/db/schema/chat';
+import { sanitizeConversationTitle } from './title';
 import type { PersistedToolEvent } from './tool-events';
 
 export type ChatTurnSource = 'typed' | 'quick_action' | 'slash_command';
@@ -28,10 +29,7 @@ const IN_FLIGHT_STATUSES = new Set<ChatTurn['status']>([
 ]);
 
 function toConversationTitle(text: string): string | null {
-  const trimmed = text.trim();
-  if (!trimmed) return null;
-  const collapsed = trimmed.replace(/\s+/g, ' ');
-  return collapsed.length > 50 ? `${collapsed.slice(0, 50)}...` : collapsed;
+  return sanitizeConversationTitle(text, 50);
 }
 
 async function fetchTurnMessages(turnId: string): Promise<ChatMessage[]> {

--- a/apps/web/tests/unit/chat/ChatMessage.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.test.tsx
@@ -52,5 +52,26 @@ describe('ChatMessage', () => {
     expect(bubble.className).toContain('py-1.5');
     expect(bubble.className).not.toContain('py-3.5');
     expect(bubble.className).not.toContain('min-h-8');
+    expect(bubble).toHaveAttribute('data-bubble-shape', 'pill');
+  });
+
+  it('renders long or multiline user messages as rounded rectangles', () => {
+    const messageProps = {
+      id: 'user-2',
+      role: 'user' as const,
+      parts: [
+        {
+          type: 'text' as const,
+          text: 'Generate album art for this release with a long direction note that will wrap in the transcript.',
+        },
+      ],
+    };
+
+    fastRender(<ChatMessage {...messageProps} />);
+
+    const bubble = screen.getByTestId('chat-user-bubble');
+    expect(bubble).toHaveAttribute('data-bubble-shape', 'rectangle');
+    expect(bubble.className).toContain('rounded-[18px]');
+    expect(bubble.className).toContain('py-2');
   });
 });

--- a/apps/web/tests/unit/chat/ChatPageClient.test.tsx
+++ b/apps/web/tests/unit/chat/ChatPageClient.test.tsx
@@ -258,15 +258,7 @@ describe('ChatPageClient', () => {
       </DashboardDataProvider>
     );
 
-    expect(capturedActionCards?.[0]).toEqual(
-      expect.objectContaining({
-        id: 'plan-next-move',
-        title: 'Plan Your Next Move',
-        actionLabel: 'Plan Move',
-        prompt:
-          'Use my artist profile, music catalog, and dashboard context for Test Artist to recommend the single most useful action I should take this week. Include the first step.',
-      })
-    );
+    expect(capturedActionCards).toEqual([]);
   });
 
   it('passes conversationId to JovieChat', () => {

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -24,7 +24,7 @@ const mockChatState = {
   isRateLimited: false,
   stop: vi.fn(),
   chipTray: {
-    chips: [],
+    chips: [] as Array<{ type: 'skill'; id: string; uid: string }>,
     addSkill: vi.fn(),
     addEntity: vi.fn(),
     removeAt: vi.fn(),
@@ -137,6 +137,7 @@ describe('JovieChat empty state', () => {
     mockChatState.hasMessages = false;
     mockChatState.isLoading = false;
     mockChatState.isSubmitting = false;
+    mockChatState.chipTray.chips = [];
   });
 
   it('centers the welcome composer when there are no action cards', () => {
@@ -157,7 +158,8 @@ describe('JovieChat empty state', () => {
     expect(getByTestId('chat-empty-state-centered-composer')).toBeTruthy();
     expect(queryByTestId('chat-empty-state-action-card-slot')).toBeNull();
     expect(queryByTestId('chat-composer-dock')).toBeNull();
-    expect(queryByTestId('chat-empty-state-prompt-rail')).toBeNull();
+    expect(getByTestId('chat-empty-state-soft-suggestions-slot')).toBeTruthy();
+    expect(getByTestId('suggested-prompts-rail')).toBeTruthy();
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(getByTestId('chat-input').getAttribute('data-placeholder')).toBe(
       'Ask Jovie...'
@@ -166,9 +168,9 @@ describe('JovieChat empty state', () => {
     expect(
       getByTestId('chat-input').getAttribute('data-quick-actions')
     ).toBeNull();
-    expect(queryByText('Plan a release')).toBeNull();
-    expect(queryByText('Generate album art')).toBeNull();
-    expect(queryByText('Pitch playlists')).toBeNull();
+    expect(queryByText('Plan a release')).toBeTruthy();
+    expect(queryByText('Generate album art')).toBeTruthy();
+    expect(queryByText('Pitch playlists')).toBeTruthy();
     // Old task-list-style actions should NOT appear — they belong in the profile switcher.
     expect(queryByText('Preview profile')).toBeNull();
     expect(queryByText('Change photo')).toBeNull();
@@ -201,12 +203,22 @@ describe('JovieChat empty state', () => {
       screen.queryByTestId('chat-empty-state-centered-composer')
     ).toBeNull();
     expect(screen.getByTestId('chat-composer-dock')).toBeTruthy();
+    expect(screen.queryByTestId('suggested-prompts-rail')).toBeNull();
 
     fireEvent.click(screen.getByRole('button', { name: /Plan Setup/ }));
 
     expect(mockChatState.handleSuggestedPrompt).toHaveBeenCalledWith(
       'Help me connect my music catalog.'
     );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /Dismiss Connect Your Music Catalog/i,
+      })
+    );
+
+    expect(screen.queryByText('Connect Your Music Catalog')).toBeNull();
+    expect(screen.getByTestId('suggested-prompts-rail')).toBeTruthy();
   });
 
   it('hides the contextual action card while the empty composer has typed text', () => {
@@ -233,6 +245,24 @@ describe('JovieChat empty state', () => {
     expect(queryByTestId('chat-empty-state-top-signals')).toBeNull();
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(queryByText('Connect Your Music Catalog')).toBeNull();
+    expect(queryByTestId('suggested-prompts-rail')).toBeNull();
+  });
+
+  it('hides soft suggestions while a chip is active', () => {
+    mockChatState.chipTray.chips = [
+      {
+        type: 'skill',
+        id: 'generateAlbumArt',
+        uid: 'chip-skill-1',
+      },
+    ];
+
+    const { getByTestId, queryByTestId } = renderWithQueryClient(
+      <JovieChat profileId='profile-1' />
+    );
+
+    expect(getByTestId('chat-empty-state-soft-suggestions-slot')).toBeTruthy();
+    expect(queryByTestId('suggested-prompts-rail')).toBeNull();
   });
 
   it('renders first-session greeting for new users', () => {

--- a/apps/web/tests/unit/chat/TokenizedText.test.tsx
+++ b/apps/web/tests/unit/chat/TokenizedText.test.tsx
@@ -1,0 +1,18 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { TokenizedText } from '@/components/jovie/components/TokenizedText';
+import { fastRender } from '@/tests/utils/fast-render';
+
+describe('TokenizedText', () => {
+  it('renders skill tokens as rich transcript chips', () => {
+    fastRender(
+      <TokenizedText content='/skill:generateAlbumArt please' tone='onLight' />
+    );
+
+    expect(screen.getByTestId('transcript-skill-chip')).toHaveTextContent(
+      'Generate album art'
+    );
+    expect(screen.queryByText('/skill:generateAlbumArt')).toBeNull();
+    expect(screen.queryByText('generateAlbumArt')).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/chat/useJovieChat.rate-limit.test.tsx
+++ b/apps/web/tests/unit/chat/useJovieChat.rate-limit.test.tsx
@@ -27,6 +27,7 @@ let onFinishHandler:
       isError: boolean;
     }) => void)
   | undefined;
+let onErrorHandler: ((error: Error) => void) | undefined;
 let mockStatus: 'ready' | 'streaming' = 'ready';
 let currentChatId = 'new-chat';
 let currentTransportConversationId: string | null = null;
@@ -53,12 +54,15 @@ vi.mock('@ai-sdk/react', () => ({
     id,
     transport,
     onFinish,
+    onError,
   }: {
     id?: string;
     transport: { body?: { conversationId?: string } };
     onFinish?: typeof onFinishHandler;
+    onError?: typeof onErrorHandler;
   }) => {
     onFinishHandler = onFinish;
+    onErrorHandler = onError;
     if (id && id !== currentChatId) {
       currentChatId = id;
       currentTransportConversationId = transport.body?.conversationId ?? null;
@@ -76,6 +80,7 @@ vi.mock('@ai-sdk/react', () => ({
         }),
       status: mockStatus,
       setMessages: setMessagesMock,
+      stop: vi.fn(),
     };
   },
 }));
@@ -87,10 +92,26 @@ vi.mock('@tanstack/react-query', () => ({
 }));
 
 vi.mock('@tanstack/react-pacer', () => ({
-  useAsyncRateLimiter: (_fn: unknown, options: { onReject?: () => void }) => {
+  useAsyncRateLimiter: (
+    fn: (args: {
+      text: string;
+      files?: unknown;
+      source?: string;
+      toolIntent?: string | null;
+    }) => Promise<void>,
+    options: { onReject?: () => void }
+  ) => {
     onRejectHandler = options.onReject;
     return {
-      maybeExecute: maybeExecuteMock,
+      maybeExecute: (args: {
+        text: string;
+        files?: unknown;
+        source?: string;
+        toolIntent?: string | null;
+      }) => {
+        maybeExecuteMock(args);
+        return fn(args);
+      },
       getRemainingInWindow: () => 1,
       state: { isExecuting: false },
     };
@@ -121,11 +142,13 @@ describe('useJovieChat', () => {
     mutateAsyncMock.mockReset();
     addMessagesMutateMock.mockReset();
     setMessagesMock.mockReset();
+    sendMessageMock.mockImplementation(() => undefined);
     mutateAsyncMock.mockResolvedValue({
       conversation: { id: 'conv_123' },
     });
     onRejectHandler = undefined;
     onFinishHandler = undefined;
+    onErrorHandler = undefined;
     mockStatus = 'ready';
     currentChatId = 'new-chat';
     currentTransportConversationId = null;
@@ -153,6 +176,8 @@ describe('useJovieChat', () => {
     expect(maybeExecuteMock).toHaveBeenCalledWith({
       text: 'Hello Jovie',
       files: undefined,
+      source: 'typed',
+      toolIntent: null,
     });
 
     act(() => {
@@ -226,6 +251,156 @@ describe('useJovieChat', () => {
         },
       })
     );
+  });
+
+  it('sends plain composer messages and re-enables after finish', async () => {
+    const { result } = renderHook(() =>
+      useJovieChat({ profileId: 'profile_1' })
+    );
+
+    act(() => {
+      result.current.setInput('Hello Jovie');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: 'Hello Jovie' },
+        options: {
+          body: expect.objectContaining({
+            source: 'typed',
+          }),
+        },
+      })
+    );
+    expect(result.current.isSubmitting).toBe(true);
+
+    act(() => {
+      onFinishHandler?.({
+        message: {
+          metadata: {
+            conversationId: 'conv_server',
+            turnId: 'turn_server',
+            requestId: 'req_1',
+          },
+        },
+        messages: [],
+        isAbort: false,
+        isDisconnect: false,
+        isError: false,
+      });
+    });
+
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('sends a skill-only composer turn as a slash command', async () => {
+    const { result } = renderHook(() =>
+      useJovieChat({ profileId: 'profile_1' })
+    );
+
+    await act(async () => {
+      result.current.chipTray.addSkill('generateAlbumArt');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { text: '/skill:generateAlbumArt' },
+        options: {
+          body: expect.objectContaining({
+            source: 'slash_command',
+            toolIntent: 'album_art_generation',
+          }),
+        },
+      })
+    );
+    expect(result.current.chipTray.chips).toHaveLength(0);
+  });
+
+  it('sends skill and entity chips together before free text', async () => {
+    const { result } = renderHook(() =>
+      useJovieChat({ profileId: 'profile_1' })
+    );
+
+    await act(async () => {
+      result.current.chipTray.addSkill('generateAlbumArt');
+      result.current.chipTray.addEntity({
+        kind: 'release',
+        id: 'rel_1',
+        label: 'Midnight Drive',
+      });
+      result.current.setInput('please');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: {
+          text: '/skill:generateAlbumArt @release:rel_1[Midnight Drive] please',
+        },
+        options: {
+          body: expect.objectContaining({
+            source: 'slash_command',
+            toolIntent: 'album_art_generation',
+          }),
+        },
+      })
+    );
+  });
+
+  it('clears the loader and restores input when send throws', async () => {
+    sendMessageMock.mockImplementationOnce(() => {
+      throw new Error('Network failed');
+    });
+    const { result } = renderHook(() =>
+      useJovieChat({ profileId: 'profile_1' })
+    );
+
+    act(() => {
+      result.current.setInput('Retry this');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.input).toBe('Retry this');
+    expect(result.current.chatError?.message).toBe('Network failed');
+  });
+
+  it('clears the loader when the stream reports an error', async () => {
+    const { result } = renderHook(() =>
+      useJovieChat({ profileId: 'profile_1' })
+    );
+
+    act(() => {
+      result.current.setInput('Try this');
+    });
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(result.current.isSubmitting).toBe(true);
+
+    act(() => {
+      onErrorHandler?.(new Error('Server failed'));
+    });
+
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.input).toBe('Try this');
+    expect(result.current.chatError?.message).toBe('Server failed');
   });
 
   it('marks album art generation prompts with a tool intent', async () => {


### PR DESCRIPTION
## Summary
- Replace the empty-thread SuggestionCard path with a dismissible ChatActionCard and remove the completed-profile `plan-next-move` action.
- Gate soft prompt pills behind the inactive state only: no action card, chip, picker, input, image, or transcript.
- Harden plain, skill, and skill+entity sends, keep failed-send errors visible after input restore, and sanitize tokenized conversation titles before display/persistence.

## Verification
- `./scripts/setup.sh`
- `pnpm --filter web exec vitest run tests/unit/chat/useJovieChat.rate-limit.test.tsx tests/unit/chat/JovieChat.empty-state.test.tsx tests/unit/chat/TokenizedText.test.tsx tests/unit/chat/ChatMessage.test.tsx lib/chat/title.test.ts tests/unit/chat/ChatPageClient.test.tsx tests/unit/app/dashboard-metadata.test.ts`
- `pnpm biome check apps/web/app/api/chat/conversations/route.ts apps/web/app/api/chat/conversations/[id]/route.ts apps/web/app/api/chat/conversations/[id]/messages/route.ts apps/web/app/app/(shell)/chat/ChatPageClient.tsx apps/web/app/app/(shell)/chat/[id]/chat-thread-metadata-data.ts apps/web/app/app/(shell)/chat/[id]/page.tsx apps/web/components/jovie/JovieChat.tsx apps/web/components/jovie/components/ChatActionCard.tsx apps/web/components/jovie/components/ChatAlbumArtCard.tsx apps/web/components/jovie/components/ChatMessage.tsx apps/web/components/jovie/components/TokenizedText.tsx apps/web/components/jovie/hooks/useJovieChat.ts apps/web/lib/chat/title.ts apps/web/lib/chat/title.test.ts apps/web/lib/chat/turns.ts apps/web/tests/unit/chat/useJovieChat.rate-limit.test.tsx apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx apps/web/tests/unit/chat/TokenizedText.test.tsx apps/web/tests/unit/chat/ChatMessage.test.tsx apps/web/tests/unit/chat/ChatPageClient.test.tsx apps/web/tests/unit/app/dashboard-metadata.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: `next:proxy-guard`, lint-staged Biome, ESLint, staged a11y, web typecheck
- pre-push hook: repo Biome, web proxy guard, Tailwind guard, typecheck, lint

JOV-2219
