### PR TITLE
fix(app-shell): tighten shell table geometry

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -48,6 +48,10 @@ body {
   overscroll-behavior: none;
 }
 
+:root {
+  --jovie-shell-overlay-z-index: 180;
+}
+
 html[data-desktop-runtime="electron"] {
   --electron-titlebar-height: 40px;
 }

--- a/apps/web/components/atoms/DesktopTitlebar.tsx
+++ b/apps/web/components/atoms/DesktopTitlebar.tsx
@@ -57,6 +57,25 @@ export function DesktopTitlebar() {
           >
             {/* Traffic-light clearance — macOS hiddenInset reserves ~72px on the left */}
             <div className='w-[72px] shrink-0' aria-hidden='true' />
+            {/* Single canonical sidebar toggle for Electron — the in-sidebar
+                SidebarDockButton is not rendered in desktop runtime */}
+            <button
+              type='button'
+              onClick={toggleSidebar}
+              disabled={!toggleSidebar}
+              aria-label={sidebarToggleLabel}
+              data-testid='electron-sidebar-toggle'
+              className={cn(
+                'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-secondary-token',
+                'transition-colors duration-subtle',
+                'hover:bg-white/[0.06] hover:text-primary-token',
+                'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30',
+                'disabled:pointer-events-none disabled:opacity-30'
+              )}
+              style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}
+            >
+              <PanelLeft className='h-3.5 w-3.5' strokeWidth={2} />
+            </button>
             <div
               data-testid='electron-nav-pill'
               className='flex shrink-0 items-center gap-0.5'
@@ -91,25 +110,6 @@ export function DesktopTitlebar() {
                 <ChevronRight className='h-3.5 w-3.5' strokeWidth={2} />
               </button>
             </div>
-            {/* Single canonical sidebar toggle for Electron — the in-sidebar
-                SidebarDockButton is not rendered in desktop runtime */}
-            <button
-              type='button'
-              onClick={toggleSidebar}
-              disabled={!toggleSidebar}
-              aria-label={sidebarToggleLabel}
-              data-testid='electron-sidebar-toggle'
-              className={cn(
-                'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-secondary-token',
-                'transition-colors duration-subtle',
-                'hover:bg-white/[0.06] hover:text-primary-token',
-                'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30',
-                'disabled:pointer-events-none disabled:opacity-30'
-              )}
-              style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}
-            >
-              <PanelLeft className='h-3.5 w-3.5' strokeWidth={2} />
-            </button>
             <div
               className='ml-auto min-w-0 shrink-0'
               style={{ WebkitAppRegion: 'no-drag' } as CSSProperties}

--- a/apps/web/components/atoms/UpdateAvailablePill.tsx
+++ b/apps/web/components/atoms/UpdateAvailablePill.tsx
@@ -37,19 +37,16 @@ export function UpdateAvailablePill() {
       aria-label='Update available — click to install'
       style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
       className={cn(
-        'inline-flex h-7 items-center justify-center gap-1.5 rounded-full bg-white px-3 text-black',
+        'inline-flex h-6 items-center justify-center gap-1 rounded-full bg-white px-2.5 text-black',
         'hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 focus-visible:ring-offset-1 disabled:opacity-70'
       )}
     >
       {updating ? (
-        <Loader2
-          className='h-3.5 w-3.5 shrink-0 animate-spin'
-          aria-hidden='true'
-        />
+        <Loader2 className='h-3 w-3 shrink-0 animate-spin' aria-hidden='true' />
       ) : (
-        <Download className='h-3.5 w-3.5 shrink-0' aria-hidden='true' />
+        <Download className='h-3 w-3 shrink-0' aria-hidden='true' />
       )}
-      <span className='whitespace-nowrap text-[12px] font-medium'>
+      <span className='whitespace-nowrap text-[11.5px] font-medium leading-none'>
         {updating ? 'Updating…' : 'Update'}
       </span>
     </button>

--- a/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
@@ -289,7 +289,7 @@ export function NavMenuItem({
         {item.name}
       </span>
       {item.badge != null ? (
-        <span className='ml-auto shrink-0 group-data-[collapsible=icon]:hidden'>
+        <span className='justify-self-end shrink-0 group-data-[collapsible=icon]:hidden'>
           {item.badge}
         </span>
       ) : null}

--- a/apps/web/components/features/dashboard/organisms/ReleaseTablePendingShell.tsx
+++ b/apps/web/components/features/dashboard/organisms/ReleaseTablePendingShell.tsx
@@ -78,6 +78,7 @@ export function ReleaseTablePendingShell({
       frame='content-container'
       contentPadding='none'
       data-testid={testId}
+      surfaceMode='table'
       toolbar={
         showHeader ? (
           <PageToolbar
@@ -99,7 +100,7 @@ export function ReleaseTablePendingShell({
         skeletonColumnConfig={RELEASE_LOADING_SKELETON_CONFIG}
         rowHeight={56}
         minWidth='0'
-        containerClassName='h-full px-2.5 pb-2.5 pt-1'
+        containerClassName='h-full'
       />
     </PageShell>
   );

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/AudienceTableLoadingShell.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { ContentSectionHeaderSkeleton } from '@/components/molecules/ContentSectionHeaderSkeleton';
 import { LoadingSkeleton } from '@/components/molecules/LoadingSkeleton';
+import { PageShell } from '@/components/organisms/PageShell';
 import {
   PageToolbar,
   UnifiedTableSkeleton,
@@ -22,36 +22,34 @@ const AUDIENCE_LOADING_COLUMNS = buildAudienceMemberColumns('members');
 
 export function AudienceTableLoadingShell() {
   return (
-    <div className='flex h-full min-h-0 flex-col' aria-busy='true'>
-      <ContentSectionHeaderSkeleton
-        titleWidth='w-32'
-        actionWidths={['w-8', 'w-8']}
-        className='bg-(--linear-app-content-surface)'
-      />
-
-      <PageToolbar
-        start={
-          <div className='flex flex-wrap items-center gap-1'>
-            {AUDIENCE_LOADING_TAB_KEYS.map(key => (
-              <LoadingSkeleton
-                key={key}
-                height='h-8'
-                width='w-24'
-                rounded='md'
-              />
-            ))}
-          </div>
-        }
-        end={
-          <>
-            <LoadingSkeleton height='h-8' width='w-8' rounded='md' />
-            <LoadingSkeleton height='h-8' width='w-8' rounded='md' />
-            <LoadingSkeleton height='h-8' width='w-8' rounded='md' />
-            <LoadingSkeleton height='h-8' width='w-8' rounded='md' />
-          </>
-        }
-      />
-
+    <PageShell
+      aria-busy='true'
+      aria-label='Loading Audience'
+      data-testid='dashboard-audience-loading'
+      surfaceMode='table'
+      toolbar={
+        <PageToolbar
+          start={
+            <div className='flex flex-wrap items-center gap-1'>
+              {AUDIENCE_LOADING_TAB_KEYS.map(key => (
+                <LoadingSkeleton
+                  key={key}
+                  height='h-8'
+                  width='w-24'
+                  rounded='md'
+                />
+              ))}
+            </div>
+          }
+          end={
+            <>
+              <LoadingSkeleton height='h-8' width='w-8' rounded='md' />
+              <LoadingSkeleton height='h-8' width='w-8' rounded='md' />
+            </>
+          }
+        />
+      }
+    >
       <div className='flex-1 min-h-0 overflow-hidden bg-(--linear-app-content-surface)'>
         <div className='flex h-full min-h-0 flex-col'>
           <div className='flex-1 min-h-0 overflow-hidden sm:hidden'>
@@ -90,35 +88,8 @@ export function AudienceTableLoadingShell() {
               containerClassName={AUDIENCE_TABLE_CONTAINER_CLASS}
             />
           </div>
-
-          <div className='sticky bottom-0 z-20 flex flex-wrap items-center justify-between gap-3 border-t border-subtle bg-(--linear-app-content-surface)/95 px-4 py-2 text-xs text-secondary-token backdrop-blur-md sm:px-6 supports-[backdrop-filter]:bg-(--linear-app-content-surface)/85'>
-            <LoadingSkeleton
-              height='h-4'
-              width='w-48'
-              rounded='md'
-              className='max-sm:hidden'
-            />
-            <LoadingSkeleton
-              height='h-4'
-              width='w-24'
-              rounded='md'
-              className='sm:hidden'
-            />
-            <div className='flex items-center gap-3'>
-              <LoadingSkeleton
-                height='h-8'
-                width='w-28'
-                rounded='md'
-                className='max-sm:hidden'
-              />
-              <div className='flex gap-2'>
-                <LoadingSkeleton height='h-8' width='w-20' rounded='md' />
-                <LoadingSkeleton height='h-8' width='w-16' rounded='md' />
-              </div>
-            </div>
-          </div>
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/DashboardAudienceTableUnified.tsx
@@ -843,6 +843,7 @@ export const DashboardAudienceTableUnified = memo(
             <PageShell
               className='overflow-hidden'
               data-testid={testId}
+              surfaceMode='table'
               toolbar={
                 <AudienceTableSubheader
                   view={view}

--- a/apps/web/components/features/dashboard/organisms/dashboard-audience-table/table-config.tsx
+++ b/apps/web/components/features/dashboard/organisms/dashboard-audience-table/table-config.tsx
@@ -19,8 +19,7 @@ import { SelectCell } from './utils/column-renderers';
 
 const memberColumnHelper = createColumnHelper<AudienceMember>();
 
-export const AUDIENCE_TABLE_CONTAINER_CLASS =
-  'h-full px-2.5 pb-2.5 pt-0 md:px-3 md:pb-3 md:pt-0';
+export const AUDIENCE_TABLE_CONTAINER_CLASS = 'h-full';
 
 export const AUDIENCE_TABLE_SKELETON_COLUMN_CONFIG: Array<{
   readonly width?: string;

--- a/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/dsp-presence/DspPresenceTable.tsx
@@ -173,7 +173,7 @@ export const DspPresenceTable = memo(function DspPresenceTable({
       rowHeight={44}
       minWidth='720px'
       className='text-[12.5px] text-primary-token'
-      containerClassName='h-full px-2.5 pb-2.5 pt-0.5 md:px-3 md:pb-3 md:pt-1'
+      containerClassName='h-full'
     />
   );
 });

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
@@ -622,7 +622,11 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
           onAppleMusicMatchStatusChange={handleMatchStatusChange}
         />
         {showEmptyState && (
-          <PageShell className='mt-2.5' data-testid='release-table-shell'>
+          <PageShell
+            className='mt-2.5'
+            data-testid='release-table-shell'
+            surfaceMode='table'
+          >
             <ReleasesEmptyState
               onConnectSpotify={() => setSpotifySearchOpen(true)}
             />
@@ -635,6 +639,7 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
             <PageShell
               className='mt-2.5'
               data-testid='release-table-shell'
+              surfaceMode='table'
               toolbar={
                 <ReleaseTableSubheader
                   releases={filteredRows}
@@ -677,7 +682,11 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
 
         {/* Show "No releases" state when connected but no releases and not importing */}
         {isConnected && rows.length === 0 && !isImporting && (
-          <PageShell className='mt-2.5' data-testid='release-table-shell'>
+          <PageShell
+            className='mt-2.5'
+            data-testid='release-table-shell'
+            surfaceMode='table'
+          >
             <DrawerSurfaceCard
               variant='card'
               className='flex min-h-[212px] flex-col items-center justify-center px-5 py-9 text-center'

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
@@ -303,7 +303,7 @@ export function ReleaseTable({
       }
       containerClassName={
         designV1
-          ? 'h-full px-2 py-1.5 md:px-2.5 md:py-2' /* aligned to shell releases grid padding */
+          ? 'h-full'
           : 'h-full px-2.5 pb-2.5 pt-0.5 md:px-3 md:pb-3 md:pt-1'
       }
       columnVisibility={tanstackColumnVisibility}
@@ -319,7 +319,7 @@ export function ReleaseTable({
           icon={<Icon name='Disc3' className='h-6 w-6' />}
           title='No releases'
           description='Your releases will appear here once synced.'
-          className='m-3 min-h-[160px]'
+          className={designV1 ? 'm-0 min-h-[160px]' : 'm-3 min-h-[160px]'}
         />
       }
     />

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
@@ -339,7 +339,7 @@ export function ReleaseTableWithTracks({
       className='text-[12.5px] text-primary-token'
       containerClassName={
         designV1
-          ? 'h-full px-2 pb-2 pt-1 md:px-2.5 md:pb-2.5 md:pt-1.5'
+          ? 'h-full'
           : 'h-full px-2.5 pb-2.5 pt-0.5 md:px-3 md:pb-3 md:pt-1'
       }
       columnVisibility={tanstackColumnVisibility}
@@ -358,7 +358,7 @@ export function ReleaseTableWithTracks({
           icon={<Icon name='Disc3' className='h-6 w-6' />}
           title='No releases'
           description='Your releases will appear here once synced.'
-          className='m-3 min-h-[160px]'
+          className={designV1 ? 'm-0 min-h-[160px]' : 'm-3 min-h-[160px]'}
         />
       }
     />

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
@@ -891,6 +891,7 @@ export function ShellReleasesView({
         className='h-full focus:outline-none'
         data-design-v1-releases='true'
         data-testid='shell-releases-view'
+        surfaceMode='table'
       >
         <ReleaseStateBanners
           rows={rows}

--- a/apps/web/components/organisms/AppShellContentPanel.tsx
+++ b/apps/web/components/organisms/AppShellContentPanel.tsx
@@ -9,6 +9,7 @@ export interface AppShellContentPanelProps
   readonly maxWidth?: 'full' | 'wide' | 'reading' | 'form';
   readonly frame?: 'none' | 'content-container';
   readonly contentPadding?: 'none' | 'compact' | 'default';
+  readonly surfaceMode?: 'default' | 'table';
   readonly scroll?: 'panel' | 'page';
   readonly className?: string;
   readonly surfaceClassName?: string;
@@ -24,6 +25,7 @@ const PANEL_MAX_WIDTH_CLASSNAME = {
 } as const;
 
 const PANEL_OUTER_INSET_CLASSNAME = 'px-2.5 py-2.5 sm:px-3 sm:py-3';
+const PANEL_TABLE_SURFACE_CLASSNAME = 'p-0 bg-(--linear-app-content-surface)';
 
 const PANEL_CONTENT_PADDING_CLASSNAME = {
   none: '',
@@ -38,6 +40,7 @@ export function AppShellContentPanel({
   maxWidth = 'full',
   frame = 'content-container',
   contentPadding = 'default',
+  surfaceMode = 'default',
   scroll = 'panel',
   className,
   surfaceClassName,
@@ -47,6 +50,7 @@ export function AppShellContentPanel({
 }: Readonly<AppShellContentPanelProps>) {
   const panelScrollClassName =
     scroll === 'panel' ? 'min-h-0 overflow-hidden' : 'overflow-visible';
+  const isTableSurface = surfaceMode === 'table';
 
   return (
     <section
@@ -56,13 +60,16 @@ export function AppShellContentPanel({
         className
       )}
       data-testid={testId}
+      data-shell-surface-mode={isTableSurface ? 'table' : undefined}
       {...sectionProps}
     >
       <div
         className={cn(
-          'mx-auto flex min-h-0 w-full flex-1 flex-col',
+          'mx-auto flex min-h-0 w-full max-w-full flex-1 flex-col',
           PANEL_MAX_WIDTH_CLASSNAME[maxWidth],
-          PANEL_OUTER_INSET_CLASSNAME,
+          isTableSurface
+            ? PANEL_TABLE_SURFACE_CLASSNAME
+            : PANEL_OUTER_INSET_CLASSNAME,
           panelScrollClassName,
           surfaceClassName
         )}
@@ -72,7 +79,9 @@ export function AppShellContentPanel({
           className={cn(
             'flex min-h-0 min-w-0 flex-1 flex-col',
             frame === 'content-container' &&
-              cn(LINEAR_SURFACE.contentContainer, 'overflow-hidden')
+              (isTableSurface
+                ? 'overflow-hidden bg-(--linear-app-content-surface)'
+                : cn(LINEAR_SURFACE.contentContainer, 'overflow-hidden'))
           )}
         >
           <div

--- a/apps/web/components/organisms/PageShell.tsx
+++ b/apps/web/components/organisms/PageShell.tsx
@@ -10,6 +10,7 @@ export interface PageShellProps
   readonly maxWidth?: 'full' | 'wide' | 'reading' | 'form';
   readonly frame?: 'none' | 'content-container';
   readonly contentPadding?: 'none' | 'compact' | 'default';
+  readonly surfaceMode?: 'default' | 'table';
   readonly scroll?: 'panel' | 'page';
   readonly className?: string;
   readonly surfaceClassName?: string;
@@ -59,6 +60,7 @@ export function PageShell({
   maxWidth = 'full',
   frame = 'none',
   contentPadding = 'none',
+  surfaceMode = 'default',
   scroll = 'panel',
   className,
   surfaceClassName,
@@ -72,6 +74,7 @@ export function PageShell({
       maxWidth={maxWidth}
       frame={frame}
       contentPadding={contentPadding}
+      surfaceMode={surfaceMode}
       scroll={scroll}
       className={className}
       surfaceClassName={surfaceClassName}

--- a/apps/web/components/shell/EntityPopover.tsx
+++ b/apps/web/components/shell/EntityPopover.tsx
@@ -675,9 +675,9 @@ export function EntityPopover({
         top: pos?.top ?? -9999,
         width: POPOVER_WIDTH,
         visibility: pos ? 'visible' : 'hidden',
+        zIndex: 'var(--jovie-shell-overlay-z-index)',
       }}
       className={cn(
-        'z-[120]',
         LINEAR_SURFACE.popover,
         'text-primary-token',
         'animate-in fade-in-0 zoom-in-95 duration-subtle ease-subtle',

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -41,11 +41,11 @@ export function getSidebarNavRowClassName({
 }: SidebarNavChromeOptions) {
   const nonCollapsedSize = tight ? 'h-6 px-2.5' : 'h-6.5 px-2.5';
   const inactiveColor = nested
-    ? 'text-tertiary-token hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] hover:text-primary-token'
-    : 'text-secondary-token hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)] hover:text-primary-token';
+    ? 'text-sidebar-muted/70 hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_88%,transparent)] hover:text-sidebar-item-foreground'
+    : 'text-sidebar-muted hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_88%,transparent)] hover:text-sidebar-item-foreground';
 
   return cn(
-    'relative grid items-center rounded-md w-full transition-[background-color] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+    'relative grid items-center rounded-md w-full border border-transparent transition-[background-color,border-color,box-shadow,color] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
     'before:pointer-events-none before:absolute before:inset-y-1 before:left-[20px] before:w-px before:bg-[color-mix(in_oklab,var(--linear-app-frame-seam)_42%,transparent)]',
     'after:pointer-events-none after:absolute after:inset-y-1 after:left-[34px] after:w-px after:bg-[color-mix(in_oklab,var(--linear-app-frame-seam)_42%,transparent)]',
     'group-data-[collapsible=icon]:before:hidden group-data-[collapsible=icon]:after:hidden',
@@ -53,11 +53,13 @@ export function getSidebarNavRowClassName({
     collapsed
       ? 'h-7 w-10 mx-auto grid-cols-1 place-items-center before:hidden after:hidden'
       : cn(
-          'grid-cols-[20px_minmax(0,1fr)_auto]',
+          'grid-cols-[20px_minmax(0,1fr)_40px]',
           nonCollapsedSize,
           'group-data-[collapsible=icon]:grid-cols-1 group-data-[collapsible=icon]:place-items-center'
         ),
-    active ? 'text-primary-token bg-surface-1' : inactiveColor,
+    active
+      ? 'border-[color-mix(in_oklab,var(--linear-app-frame-seam)_80%,transparent)] bg-[color-mix(in_oklab,var(--color-sidebar-accent-active)_90%,var(--linear-app-content-surface))] text-sidebar-item-foreground shadow-[inset_0_1px_0_rgba(255,255,255,0.03),inset_0_0_0_1px_color-mix(in_oklab,var(--linear-app-frame-seam)_58%,transparent)]'
+      : inactiveColor,
     className
   );
 }
@@ -69,13 +71,13 @@ export function getSidebarNavIconClassName({
   className,
 }: SidebarNavChromeOptions) {
   const inactiveIconColor = nested
-    ? 'text-quaternary-token'
-    : 'text-tertiary-token';
+    ? 'text-sidebar-muted/60'
+    : 'text-sidebar-muted/80';
 
   return cn(
-    'shrink-0',
+    'shrink-0 justify-self-center',
     tight ? 'h-3 w-3' : 'h-3.5 w-3.5',
-    active ? 'text-primary-token' : inactiveIconColor,
+    active ? 'text-sidebar-item-foreground' : inactiveIconColor,
     className
   );
 }

--- a/apps/web/components/shell/Tooltip.tsx
+++ b/apps/web/components/shell/Tooltip.tsx
@@ -79,6 +79,7 @@ export function Tooltip({
         <TooltipContent
           side={side}
           sideOffset={6}
+          style={{ zIndex: 'var(--jovie-shell-overlay-z-index)' }}
           className='flex items-center gap-2 whitespace-nowrap'
         >
           <span>{label}</span>

--- a/apps/web/tests/unit/components/shell/Tooltip.test.tsx
+++ b/apps/web/tests/unit/components/shell/Tooltip.test.tsx
@@ -23,6 +23,8 @@ describe('shell Tooltip', () => {
     const content = screen.getByTestId('tooltip-content');
     expect(content).toHaveTextContent('Full truncated row name');
     expect(content).toHaveTextContent('G A');
-    expect(content.className).toContain('z-[150]');
+    expect(content).toHaveStyle({
+      zIndex: 'var(--jovie-shell-overlay-z-index)',
+    });
   });
 });

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -292,7 +292,7 @@ describe('DashboardNav', () => {
     const tasksLink = getByRole('link', { name: 'Tasks 7' });
     expect(tasksLink.className).toContain('h-6.5');
     expect(tasksLink.className).toContain(
-      'grid-cols-[20px_minmax(0,1fr)_auto]'
+      'grid-cols-[20px_minmax(0,1fr)_40px]'
     );
     expect(tasksLink.className).toContain('text-[12.5px]');
     expect(getByText('7')).toBeDefined();

--- a/apps/web/tests/unit/sidebar-row-alignment.test.tsx
+++ b/apps/web/tests/unit/sidebar-row-alignment.test.tsx
@@ -148,15 +148,15 @@ describe('Sidebar row alignment', () => {
     expect(rowClassName).toContain('h-6.5');
     expect(rowClassName).toContain('px-2.5');
     expect(rowClassName).toContain('gap-x-2.5');
-    expect(rowClassName).toContain('grid-cols-[20px_minmax(0,1fr)_auto]');
+    expect(rowClassName).toContain('grid-cols-[20px_minmax(0,1fr)_40px]');
     expect(rowClassName).toContain('before:left-[20px]');
     expect(rowClassName).toContain('after:left-[34px]');
     expect(rowClassName).toContain('text-[12.5px]');
     expect(rowClassName).toContain(
-      'hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_82%,transparent)]'
+      'hover:bg-[color-mix(in_oklab,var(--color-sidebar-accent)_88%,transparent)]'
     );
-    expect(activeRowClassName).toContain('bg-surface-1');
+    expect(activeRowClassName).toContain('color-sidebar-accent-active');
     expect(iconClassName).toContain('h-3.5');
-    expect(iconClassName).toContain('text-tertiary-token');
+    expect(iconClassName).toContain('text-sidebar-muted/80');
   });
 });


### PR DESCRIPTION
## Summary
- Add a `surfaceMode="table"` shell path so table pages can render flush to the content panel edges without nested card inset.
- Apply the table surface mode to audience, release, pending, DSP presence, and shell release tables.
- Tighten sidebar row grid geometry, titlebar controls, update pill scale, and shell overlay z-index token usage.

## Verification
- `pnpm biome check --write` on touched files
- `pnpm --filter @jovie/web exec vitest run tests/unit/sidebar-row-alignment.test.tsx tests/unit/dashboard/DashboardNav.test.tsx tests/unit/components/shell/Tooltip.test.tsx tests/components/release-provider-matrix/ReleaseTable.test.tsx tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `E2E_USE_TEST_AUTH_BYPASS=1 pnpm --filter @jovie/web exec playwright test tests/e2e/electron-titlebar-geometry.spec.ts --project=chromium`
- Pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Linear
- JOV-2219


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced visual footprint of the update available indicator with compact sizing.
  * Refined z-index layering for overlay components to ensure consistent stacking behavior.
  * Improved sidebar navigation styling, badge alignment, and icon appearance.
  * Streamlined table surface styling and spacing adjustments across dashboard views.

* **Bug Fixes**
  * Fixed desktop app titlebar button positioning for better layout organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->