### PR TITLE
fix(settings): flatten usage and cookie preferences

### DIFF
--- a/apps/web/app/api/chat/usage/route.ts
+++ b/apps/web/app/api/chat/usage/route.ts
@@ -17,6 +17,11 @@ type ChatUsageSnapshot = {
   dailyLimit: number;
   used: number;
   remaining: number;
+  resetAt: string | null;
+  monthlyLimit: number;
+  monthlyUsed: number;
+  monthlyRemaining: number;
+  monthlyResetAt: string;
   isExhausted: boolean;
   warningThreshold: number;
   isNearLimit: boolean;
@@ -63,6 +68,26 @@ function writeChatUsageCache(
 const CACHE_HEADERS = {
   'Cache-Control': 'private, max-age=30, stale-while-revalidate=120',
 } as const;
+
+function resolveMonthlyUsageWindow(now = new Date()): {
+  readonly daysInMonth: number;
+  readonly resetAt: string;
+} {
+  const year = now.getUTCFullYear();
+  const month = now.getUTCMonth();
+  const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  const resetAt = new Date(Date.UTC(year, month + 1, 1, 0, 0, 0, 0));
+
+  return {
+    daysInMonth,
+    resetAt: resetAt.toISOString(),
+  };
+}
+
+function formatResetAt(resetTime: number): string | null {
+  if (!Number.isFinite(resetTime)) return null;
+  return new Date(resetTime).toISOString();
+}
 
 export async function GET() {
   let userId: string | null;
@@ -112,12 +137,20 @@ export async function GET() {
   const remaining = Math.max(0, Math.min(dailyLimit, status.remaining));
   const used = Math.max(0, dailyLimit - remaining);
   const warningThreshold = plan === 'free' ? 2 : 5;
+  const monthlyWindow = resolveMonthlyUsageWindow();
+  const monthlyLimit = dailyLimit * monthlyWindow.daysInMonth;
+  const monthlyUsed = Math.min(used, monthlyLimit);
 
   const response: ChatUsageSnapshot = {
     plan,
     dailyLimit,
     used,
     remaining,
+    resetAt: formatResetAt(status.resetTime),
+    monthlyLimit,
+    monthlyUsed,
+    monthlyRemaining: Math.max(0, monthlyLimit - monthlyUsed),
+    monthlyResetAt: monthlyWindow.resetAt,
     isExhausted: remaining <= 0,
     warningThreshold,
     isNearLimit: remaining > 0 && remaining <= warningThreshold,

--- a/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
@@ -1,24 +1,201 @@
 'use client';
 
-import { Button } from '@jovie/ui';
+import { Badge, Button } from '@jovie/ui';
+import { AlertCircle } from 'lucide-react';
 import Link from 'next/link';
+import type { ReactNode } from 'react';
+import { SettingsPanel } from '@/components/molecules/settings/SettingsPanel';
 import { UpgradeButton } from '@/components/molecules/UpgradeButton';
 import { APP_ROUTES } from '@/constants/routes';
 import { getChatUsageCopy } from '@/lib/chat-usage/copy';
 import { env } from '@/lib/env-client';
 import { useChatUsageQuery } from '@/lib/queries';
+import type { ChatUsageData } from '@/lib/queries/useChatUsageQuery';
+import { cn } from '@/lib/utils';
 
-interface UsageStatProps {
-  readonly label: string;
-  readonly value: string | number;
+const USAGE_PANEL_MIN_HEIGHT_CLASS = 'min-h-[342px]';
+
+interface UsagePanelShellProps {
+  readonly children: ReactNode;
+  readonly className?: string;
 }
 
-function UsageStat({ label, value }: UsageStatProps) {
+function UsagePanelShell({ children, className }: UsagePanelShellProps) {
   return (
-    <div className='rounded-[14px] border border-subtle bg-surface-0 px-3 py-3'>
-      <p className='text-2xs text-secondary-token'>{label}</p>
-      <p className='mt-1 text-sm font-caption text-primary-token'>{value}</p>
+    <SettingsPanel cardClassName='border border-subtle bg-surface-1 shadow-none'>
+      <div
+        className={cn(USAGE_PANEL_MIN_HEIGHT_CLASS, 'flex flex-col', className)}
+        data-testid='settings-usage-panel'
+      >
+        {children}
+      </div>
+    </SettingsPanel>
+  );
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+function formatResetAt(value: string | null | undefined): string {
+  if (!value) return 'Reset timing unavailable';
+  const resetAt = new Date(value);
+  if (Number.isNaN(resetAt.getTime())) return 'Reset timing unavailable';
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(resetAt);
+}
+
+function getProgressValue(used: number, limit: number): number {
+  if (limit <= 0) return 0;
+  return Math.min(100, Math.max(0, Math.round((used / limit) * 100)));
+}
+
+function getMonthlyUsage(data: ChatUsageData): {
+  readonly limit: number;
+  readonly used: number;
+  readonly remaining: number;
+  readonly resetAt: string | null | undefined;
+} {
+  const limit = data.monthlyLimit ?? data.dailyLimit * 30;
+  const used = data.monthlyUsed ?? data.used;
+
+  return {
+    limit,
+    used,
+    remaining: data.monthlyRemaining ?? Math.max(0, limit - used),
+    resetAt: data.monthlyResetAt,
+  };
+}
+
+interface UsageMeterRowProps {
+  readonly title: string;
+  readonly description: string;
+  readonly used: number;
+  readonly limit: number;
+  readonly remaining: number;
+  readonly resetAt: string | null | undefined;
+}
+
+function UsageMeterRow({
+  title,
+  description,
+  used,
+  limit,
+  remaining,
+  resetAt,
+}: UsageMeterRowProps) {
+  const progress = getProgressValue(used, limit);
+  const clampedUsed = Math.min(Math.max(0, used), Math.max(0, limit));
+
+  return (
+    <div className='px-4 py-4 sm:px-5'>
+      <div className='flex flex-wrap items-start justify-between gap-3'>
+        <div className='min-w-0 space-y-1'>
+          <p className='text-app font-caption text-primary-token'>{title}</p>
+          <p className='text-xs leading-[17px] text-secondary-token'>
+            {description}
+          </p>
+        </div>
+        <div className='text-right text-xs leading-[17px] text-secondary-token'>
+          <p className='font-caption text-primary-token'>
+            {formatNumber(remaining)} left
+          </p>
+          <p>Resets {formatResetAt(resetAt)}</p>
+        </div>
+      </div>
+      <div className='mt-3 h-2 rounded-full bg-surface-0'>
+        <div
+          role='progressbar'
+          aria-label={`${title} usage`}
+          aria-valuemin={0}
+          aria-valuemax={limit}
+          aria-valuenow={clampedUsed}
+          className='h-2 rounded-full bg-primary-token'
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      <p className='mt-2 text-2xs text-tertiary-token'>
+        {formatNumber(clampedUsed)} of {formatNumber(limit)} messages used
+      </p>
     </div>
+  );
+}
+
+interface UsageSummaryRowProps {
+  readonly label: string;
+  readonly value: string;
+  readonly detail?: string;
+}
+
+function UsageSummaryRow({ label, value, detail }: UsageSummaryRowProps) {
+  return (
+    <div className='flex min-h-14 items-center justify-between gap-4 px-4 py-3 sm:px-5'>
+      <div className='min-w-0'>
+        <p className='text-xs font-caption text-primary-token'>{label}</p>
+        {detail ? (
+          <p className='mt-0.5 text-2xs leading-[15px] text-secondary-token'>
+            {detail}
+          </p>
+        ) : null}
+      </div>
+      <p className='shrink-0 text-right text-xs font-caption text-primary-token'>
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function UsageLoadingState() {
+  return (
+    <UsagePanelShell>
+      <div className='border-b border-(--linear-app-frame-seam) px-4 py-4 sm:px-5'>
+        <div className='h-4 w-32 animate-pulse rounded bg-surface-2 motion-reduce:animate-none' />
+        <div className='mt-2 h-3 w-64 max-w-full animate-pulse rounded bg-surface-2 motion-reduce:animate-none' />
+      </div>
+      <div className='divide-y divide-(--linear-app-frame-seam)'>
+        {['daily', 'monthly'].map(key => (
+          <div key={key} className='px-4 py-4 sm:px-5'>
+            <div className='flex justify-between gap-4'>
+              <div className='space-y-2'>
+                <div className='h-3 w-28 animate-pulse rounded bg-surface-2 motion-reduce:animate-none' />
+                <div className='h-3 w-44 animate-pulse rounded bg-surface-2 motion-reduce:animate-none' />
+              </div>
+              <div className='h-3 w-24 animate-pulse rounded bg-surface-2 motion-reduce:animate-none' />
+            </div>
+            <div className='mt-3 h-2 rounded-full bg-surface-0'>
+              <div className='h-2 w-1/3 animate-pulse rounded-full bg-surface-2 motion-reduce:animate-none' />
+            </div>
+          </div>
+        ))}
+      </div>
+    </UsagePanelShell>
+  );
+}
+
+function UsageMessageState({
+  title,
+  description,
+}: Readonly<{
+  title: string;
+  description: string;
+}>) {
+  return (
+    <UsagePanelShell className='justify-center'>
+      <div className='mx-auto flex max-w-[28rem] flex-col items-center px-4 text-center'>
+        <div className='flex h-8 w-8 items-center justify-center rounded-full bg-surface-0 text-secondary-token'>
+          <AlertCircle className='h-4 w-4' aria-hidden />
+        </div>
+        <p className='mt-3 text-app font-caption text-primary-token'>{title}</p>
+        <p className='mt-1 text-xs leading-[17px] text-secondary-token'>
+          {description}
+        </p>
+      </div>
+    </UsagePanelShell>
   );
 }
 
@@ -29,72 +206,102 @@ export function SettingsUsageStatsSection() {
 
   if (env.IS_E2E) {
     return (
-      <p className='text-app text-secondary-token'>
-        Usage stats are unavailable in the passive runtime.
-      </p>
+      <UsageMessageState
+        title='Usage unavailable'
+        description='Usage stats are unavailable in the passive runtime.'
+      />
     );
   }
 
   if (isLoading) {
+    return <UsageLoadingState />;
+  }
+
+  if (error) {
     return (
-      <div className='grid gap-3 sm:grid-cols-2 xl:grid-cols-5'>
-        {['Plan', 'Daily Limit', 'Used', 'Remaining', 'Status'].map(label => (
-          <div
-            key={label}
-            className='rounded-[14px] border border-subtle bg-surface-0 px-3 py-3'
-          >
-            <div className='h-3 w-16 animate-pulse rounded bg-surface-2 motion-reduce:animate-none' />
-            <div className='mt-2 h-4 w-20 animate-pulse rounded bg-surface-2 motion-reduce:animate-none' />
-          </div>
-        ))}
-      </div>
+      <UsageMessageState
+        title='Usage unavailable'
+        description="We couldn't load your usage stats right now. Please refresh and try again."
+      />
     );
   }
 
-  if (!data || error) {
+  if (!data) {
     return (
-      <p className='text-app text-secondary-token'>
-        We couldn&apos;t load your usage stats right now. Please refresh and try
-        again.
-      </p>
+      <UsageMessageState
+        title='No usage recorded'
+        description='Message quota appears here after the first chat request in this billing window.'
+      />
     );
   }
 
   const copy = getChatUsageCopy(data);
   const showUpgradeCta = copy.state !== 'healthy';
+  const monthly = getMonthlyUsage(data);
 
   return (
-    <div className='space-y-4'>
-      <div className='rounded-[16px] border border-subtle bg-surface-0 px-4 py-4'>
-        <div className='flex flex-wrap items-start justify-between gap-3'>
-          <div className='space-y-1'>
-            <p className='text-sm font-caption text-primary-token'>
+    <UsagePanelShell>
+      <div className='flex flex-wrap items-start justify-between gap-3 border-b border-(--linear-app-frame-seam) px-4 py-4 sm:px-5'>
+        <div className='min-w-0 space-y-1'>
+          <div className='flex flex-wrap items-center gap-2'>
+            <p className='text-app font-caption text-primary-token'>
               {copy.summaryTitle}
             </p>
-            <p className='max-w-[44rem] text-app text-secondary-token'>
-              {copy.summaryDescription}
-            </p>
+            <Badge
+              variant={copy.state === 'healthy' ? 'success' : 'warning'}
+              size='sm'
+              className='rounded-md px-1.5 text-3xs'
+            >
+              {copy.statusLabel}
+            </Badge>
           </div>
-          {showUpgradeCta &&
-            (data.plan === 'free' ? (
-              <UpgradeButton size='sm' variant='primary'>
-                {copy.ctaLabel}
-              </UpgradeButton>
-            ) : (
-              <Button asChild size='sm' variant='secondary'>
-                <Link href={APP_ROUTES.PRICING}>{copy.ctaLabel}</Link>
-              </Button>
-            ))}
+          <p className='max-w-[42rem] text-xs leading-[17px] text-secondary-token'>
+            {copy.summaryDescription}
+          </p>
         </div>
+        {showUpgradeCta &&
+          (data.plan === 'free' ? (
+            <UpgradeButton size='sm' variant='primary'>
+              {copy.ctaLabel}
+            </UpgradeButton>
+          ) : (
+            <Button asChild size='sm' variant='secondary'>
+              <Link href={APP_ROUTES.PRICING}>{copy.ctaLabel}</Link>
+            </Button>
+          ))}
       </div>
 
-      <div className='grid gap-3 sm:grid-cols-2 xl:grid-cols-5'>
-        <UsageStat label='Plan' value={copy.planLabel} />
-        <UsageStat label='Daily Limit' value={data.dailyLimit} />
-        <UsageStat label='Used' value={data.used} />
-        <UsageStat label='Remaining' value={data.remaining} />
-        <UsageStat label='Status' value={copy.statusLabel} />
+      <div className='divide-y divide-(--linear-app-frame-seam)'>
+        <UsageMeterRow
+          title='Daily Messages'
+          description='Quota for the current 24-hour window.'
+          used={data.used}
+          limit={data.dailyLimit}
+          remaining={data.remaining}
+          resetAt={data.resetAt}
+        />
+        <UsageMeterRow
+          title='Monthly Capacity'
+          description='Plan capacity across the current calendar month.'
+          used={monthly.used}
+          limit={monthly.limit}
+          remaining={monthly.remaining}
+          resetAt={monthly.resetAt}
+        />
       </div>
-    </div>
+
+      <div className='mt-auto divide-y divide-(--linear-app-frame-seam) border-t border-(--linear-app-frame-seam)'>
+        <UsageSummaryRow
+          label='Plan'
+          value={copy.planLabel}
+          detail='Current chat entitlement'
+        />
+        <UsageSummaryRow
+          label='Remaining Today'
+          value={formatNumber(data.remaining)}
+          detail={`${formatNumber(data.dailyLimit)} daily messages included`}
+        />
+      </div>
+    </UsagePanelShell>
   );
 }

--- a/apps/web/components/organisms/CookieBannerMount.tsx
+++ b/apps/web/components/organisms/CookieBannerMount.tsx
@@ -1,7 +1,31 @@
 'use client';
 
-import { type ComponentType, useEffect, useState } from 'react';
+import {
+  type ComponentType,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import type { Consent } from '@/lib/cookies/consent';
 import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
+import { setConsentState } from '@/lib/tracking/consent';
+
+type CookieModalComponent = ComponentType<{
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly onSave?: (consent: Consent) => void;
+}>;
+
+declare global {
+  var JVConsent:
+    | {
+        onChange: (cb: (v: unknown) => void) => () => void;
+        _emit: (v: unknown) => void;
+        openModal: () => void;
+      }
+    | undefined;
+}
 
 function shouldMountCookieBanner(pathname: string): boolean {
   if (pathname.startsWith('/app') || pathname.startsWith('/demo')) {
@@ -27,18 +51,77 @@ function shouldMountCookieBanner(pathname: string): boolean {
 
 export function CookieBannerMount() {
   const [Banner, setBanner] = useState<ComponentType | null>(null);
+  const [Modal, setModal] = useState<CookieModalComponent | null>(null);
+  const [preferencesOpen, setPreferencesOpen] = useState(false);
+  const listenersRef = useRef(new Set<(v: unknown) => void>());
 
-  useEffect(() => {
-    if (!shouldMountCookieBanner(globalThis.location.pathname)) {
-      return;
-    }
-
-    void import('@/components/organisms/CookieBannerSection').then(mod => {
-      setBanner(() => mod.CookieBannerSection);
+  const openPreferences = useCallback(() => {
+    void import('@/components/organisms/CookieModal').then(mod => {
+      setModal(() => mod.CookieModal);
+      setPreferencesOpen(true);
     });
   }, []);
 
-  return Banner ? <Banner /> : null;
+  useEffect(() => {
+    const listeners = listenersRef.current;
+    const consentApi = {
+      onChange(cb: (v: unknown) => void) {
+        listeners.add(cb);
+        return () => listeners.delete(cb);
+      },
+      _emit(value: unknown) {
+        listeners.forEach(listener => listener(value));
+      },
+      openModal: openPreferences,
+    };
+
+    globalThis.JVConsent = consentApi;
+    globalThis.dispatchEvent(new Event('jvconsent:ready'));
+
+    const handleOpen = () => openPreferences();
+    globalThis.addEventListener('jv:cookie:open', handleOpen);
+
+    return () => {
+      globalThis.removeEventListener('jv:cookie:open', handleOpen);
+      if (globalThis.JVConsent === consentApi) {
+        globalThis.JVConsent = undefined;
+      }
+      listeners.clear();
+    };
+  }, [openPreferences]);
+
+  useEffect(() => {
+    if (shouldMountCookieBanner(globalThis.location.pathname)) {
+      void import('@/components/organisms/CookieBannerSection').then(mod => {
+        setBanner(() => mod.CookieBannerSection);
+      });
+    }
+  }, []);
+
+  const applyConsentLocally = (consent: Consent) => {
+    setConsentState(
+      consent.analytics || consent.marketing ? 'accepted' : 'rejected'
+    );
+    try {
+      localStorage.setItem('jv_cc', JSON.stringify(consent));
+    } catch {
+      // ignore — restricted browsing context
+    }
+    globalThis.JVConsent?._emit(consent);
+  };
+
+  return (
+    <>
+      {Banner ? <Banner /> : null}
+      {Modal ? (
+        <Modal
+          open={preferencesOpen}
+          onClose={() => setPreferencesOpen(false)}
+          onSave={applyConsentLocally}
+        />
+      ) : null}
+    </>
+  );
 }
 
 // Note: The rendered banner is a compact floating bottom-right card (see CookieBannerSection).

--- a/apps/web/components/organisms/CookieBannerSection.tsx
+++ b/apps/web/components/organisms/CookieBannerSection.tsx
@@ -6,22 +6,13 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { CookieActions } from '@/components/molecules/CookieActions';
 import { CookieModal } from '@/components/organisms/CookieModal';
+import { APP_ROUTES } from '@/constants/routes';
 import { saveConsent } from '@/lib/cookies/consent';
 import { COOKIE_BANNER_REQUIRED_COOKIE } from '@/lib/cookies/consent-regions';
 import { setConsentState } from '@/lib/tracking/consent';
 
 const CONSENT_SAVE_ERROR =
   'We could not save preferences. Check your connection and try again.';
-
-declare global {
-  var JVConsent:
-    | {
-        onChange: (cb: (v: unknown) => void) => () => void;
-        _emit: (v: unknown) => void;
-        openModal: () => void;
-      }
-    | undefined;
-}
 
 /**
  * Read the cookie-banner-required flag from document.cookie.
@@ -67,27 +58,6 @@ export function CookieBannerSection() {
       setVisible(true);
     }
   }, [isDashboard, isDemo]);
-
-  useEffect(() => {
-    if (globalThis.window && !globalThis.JVConsent) {
-      const listeners = new Set<(v: unknown) => void>();
-      globalThis.JVConsent = {
-        onChange(cb: (v: unknown) => void) {
-          listeners.add(cb);
-          return () => listeners.delete(cb);
-        },
-        _emit(value: unknown) {
-          listeners.forEach(l => l(value));
-        },
-        openModal() {
-          setCustomize(true);
-        },
-      };
-      if (globalThis.window !== undefined) {
-        globalThis.dispatchEvent(new Event('jvconsent:ready'));
-      }
-    }
-  }, []);
 
   useEffect(() => {
     if (!visible) {
@@ -136,9 +106,20 @@ export function CookieBannerSection() {
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
-    const handleOpen = () => setCustomize(true);
-    globalThis.addEventListener('jv:cookie:open', handleOpen);
-    return () => globalThis.removeEventListener('jv:cookie:open', handleOpen);
+    let unsubscribe: (() => void) | undefined;
+
+    const subscribe = () => {
+      unsubscribe?.();
+      unsubscribe = globalThis.JVConsent?.onChange(() => setVisible(false));
+    };
+
+    subscribe();
+    globalThis.addEventListener('jvconsent:ready', subscribe);
+
+    return () => {
+      unsubscribe?.();
+      globalThis.removeEventListener('jvconsent:ready', subscribe);
+    };
   }, []);
 
   const applyConsentLocally = (consent: {
@@ -213,7 +194,7 @@ export function CookieBannerSection() {
                   We use cookies for essential functionality and to improve your
                   experience.{' '}
                   <Link
-                    href='/privacy'
+                    href={APP_ROUTES.LEGAL_PRIVACY}
                     className='underline hover:opacity-80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent'
                   >
                     Privacy

--- a/apps/web/lib/queries/useChatUsageQuery.ts
+++ b/apps/web/lib/queries/useChatUsageQuery.ts
@@ -10,6 +10,11 @@ export interface ChatUsageData {
   dailyLimit: number;
   used: number;
   remaining: number;
+  resetAt?: string | null;
+  monthlyLimit?: number | null;
+  monthlyUsed?: number | null;
+  monthlyRemaining?: number | null;
+  monthlyResetAt?: string | null;
   isExhausted: boolean;
   warningThreshold: number;
   isNearLimit: boolean;

--- a/apps/web/tests/unit/api/chat/usage.test.ts
+++ b/apps/web/tests/unit/api/chat/usage.test.ts
@@ -72,7 +72,10 @@ describe('GET /api/chat/usage', () => {
     hoisted.getEntitlementsMock.mockReturnValue({
       limits: { aiDailyMessageLimit: 10 },
     });
-    hoisted.getStatusMock.mockReturnValue({ remaining: 7 });
+    hoisted.getStatusMock.mockReturnValue({
+      remaining: 7,
+      resetTime: Date.UTC(2026, 4, 23, 7, 0, 0),
+    });
 
     const { GET } = await import('@/app/api/chat/usage/route');
     const response = await GET();
@@ -83,6 +86,11 @@ describe('GET /api/chat/usage', () => {
     expect(body.dailyLimit).toBe(10);
     expect(body.remaining).toBe(7);
     expect(body.used).toBe(3);
+    expect(body.resetAt).toBe('2026-05-23T07:00:00.000Z');
+    expect(body.monthlyLimit).toBeGreaterThanOrEqual(280);
+    expect(body.monthlyUsed).toBe(3);
+    expect(body.monthlyRemaining).toBe(body.monthlyLimit - 3);
+    expect(body.monthlyResetAt).toMatch(/T00:00:00\.000Z$/);
     expect(body.isExhausted).toBe(false);
   });
 

--- a/apps/web/tests/unit/constants/routes.test.ts
+++ b/apps/web/tests/unit/constants/routes.test.ts
@@ -7,6 +7,12 @@ import {
   resolveLyricsReturnRoute,
 } from '@/constants/routes';
 
+describe('APP_ROUTES settings', () => {
+  it('exposes the canonical settings usage route', () => {
+    expect(APP_ROUTES.SETTINGS_USAGE).toBe('/app/settings/usage');
+  });
+});
+
 describe('buildLyricsRoute', () => {
   it('builds the canonical lyrics path', () => {
     expect(buildLyricsRoute('track_1')).toBe('/app/lyrics/track_1');

--- a/apps/web/tests/unit/cookie-banner-fixes.test.tsx
+++ b/apps/web/tests/unit/cookie-banner-fixes.test.tsx
@@ -37,6 +37,7 @@ describe('CookieBannerSection consent sync', () => {
 
   afterEach(() => {
     setCookie('');
+    globalThis.JVConsent = undefined;
   });
 
   it('calls setConsentState accepted on acceptAll', async () => {
@@ -144,6 +145,7 @@ describe('CookieModal loads saved preferences', () => {
 
   afterEach(() => {
     localStorage.clear();
+    globalThis.JVConsent = undefined;
   });
 
   it('initializes with saved preferences from localStorage', async () => {
@@ -217,9 +219,76 @@ describe('CookieModal loads saved preferences', () => {
   });
 });
 
+describe('CookieBannerMount global preferences controller', () => {
+  beforeEach(() => {
+    mockSaveConsent.mockClear();
+    mockSaveConsent.mockResolvedValue(undefined);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    setCookie('');
+    localStorage.clear();
+    globalThis.JVConsent = undefined;
+  });
+
+  it('opens cookie preferences from the global menu event without a mounted banner', async () => {
+    setCookie('jv_cc_required=0');
+    const { CookieBannerMount } = await import(
+      '@/components/organisms/CookieBannerMount'
+    );
+
+    render(<CookieBannerMount />);
+
+    await vi.waitFor(() => {
+      expect(globalThis.JVConsent).toBeDefined();
+    });
+    expect(screen.queryByTestId('cookie-banner')).not.toBeInTheDocument();
+
+    globalThis.dispatchEvent(new CustomEvent('jv:cookie:open'));
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole('dialog', { name: /cookie preferences/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('persists preferences opened from the global controller', async () => {
+    setCookie('jv_cc_required=0');
+    const { setConsentState } = await import('@/lib/tracking/consent');
+    const { CookieBannerMount } = await import(
+      '@/components/organisms/CookieBannerMount'
+    );
+
+    render(<CookieBannerMount />);
+
+    await vi.waitFor(() => {
+      expect(globalThis.JVConsent).toBeDefined();
+    });
+
+    globalThis.JVConsent?.openModal();
+
+    await vi.waitFor(() => {
+      expect(
+        screen.getByRole('dialog', { name: /cookie preferences/i })
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /save preferences/i }));
+
+    await vi.waitFor(() => {
+      expect(mockSaveConsent).toHaveBeenCalledTimes(1);
+      expect(setConsentState).toHaveBeenCalledWith('rejected');
+      expect(localStorage.getItem('jv_cc')).toContain('"essential":true');
+    });
+  });
+});
+
 describe('CookieSettingsFooterButton visibility', () => {
   afterEach(() => {
     setCookie('');
+    globalThis.JVConsent = undefined;
   });
 
   it('renders nothing when jv_cc_required is 0', async () => {

--- a/apps/web/tests/unit/cookie-banner.test.tsx
+++ b/apps/web/tests/unit/cookie-banner.test.tsx
@@ -71,7 +71,7 @@ describe('CookieBannerSection', () => {
     expect(banner.textContent).toContain('essential functionality');
     expect(screen.getByRole('link', { name: /privacy/i })).toHaveAttribute(
       'href',
-      '/privacy'
+      '/legal/privacy'
     );
   });
 

--- a/apps/web/tests/unit/dashboard/SettingsUsageStatsSection.test.tsx
+++ b/apps/web/tests/unit/dashboard/SettingsUsageStatsSection.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SettingsUsageStatsSection } from '@/features/dashboard/organisms/SettingsUsageStatsSection';
+import type { ChatUsageData } from '@/lib/queries/useChatUsageQuery';
+
+const mockUseChatUsageQuery = vi.fn();
+
+vi.mock('@/lib/queries', () => ({
+  useCheckoutMutation: () => ({
+    error: null,
+    isPending: false,
+    mutate: vi.fn(),
+  }),
+  useChatUsageQuery: () => mockUseChatUsageQuery(),
+}));
+
+const baseUsage: ChatUsageData = {
+  plan: 'free',
+  dailyLimit: 10,
+  used: 4,
+  remaining: 6,
+  resetAt: '2026-05-23T07:00:00.000Z',
+  monthlyLimit: 310,
+  monthlyUsed: 24,
+  monthlyRemaining: 286,
+  monthlyResetAt: '2026-06-01T00:00:00.000Z',
+  isExhausted: false,
+  warningThreshold: 2,
+  isNearLimit: false,
+};
+
+describe('SettingsUsageStatsSection', () => {
+  it('reserves one stable usage panel while loading', () => {
+    mockUseChatUsageQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+
+    render(<SettingsUsageStatsSection />);
+
+    expect(screen.getByTestId('settings-usage-panel').className).toContain(
+      'min-h-[342px]'
+    );
+  });
+
+  it('renders an empty state without changing the panel geometry', () => {
+    mockUseChatUsageQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<SettingsUsageStatsSection />);
+
+    expect(screen.getByText('No usage recorded')).toBeInTheDocument();
+    expect(screen.getByTestId('settings-usage-panel').className).toContain(
+      'min-h-[342px]'
+    );
+  });
+
+  it('renders an error state without changing the panel geometry', () => {
+    mockUseChatUsageQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('No usage'),
+    });
+
+    render(<SettingsUsageStatsSection />);
+
+    expect(screen.getByText('Usage unavailable')).toBeInTheDocument();
+    expect(screen.getByTestId('settings-usage-panel').className).toContain(
+      'min-h-[342px]'
+    );
+  });
+
+  it('renders daily and monthly progress for a free plan', () => {
+    mockUseChatUsageQuery.mockReturnValue({
+      data: baseUsage,
+      isLoading: false,
+      error: null,
+    });
+
+    render(<SettingsUsageStatsSection />);
+
+    expect(
+      screen.getByText("You're within today's chat limit")
+    ).toBeInTheDocument();
+    expect(screen.getByText('Free')).toBeInTheDocument();
+    expect(
+      screen.getByRole('progressbar', { name: 'Daily Messages usage' })
+    ).toHaveAttribute('aria-valuenow', '4');
+    expect(
+      screen.getByRole('progressbar', { name: 'Monthly Capacity usage' })
+    ).toHaveAttribute('aria-valuenow', '24');
+    expect(screen.getByText('6 left')).toBeInTheDocument();
+    expect(screen.getByText('286 left')).toBeInTheDocument();
+  });
+
+  it('renders pro plan state and plan action when near the limit', () => {
+    mockUseChatUsageQuery.mockReturnValue({
+      data: {
+        ...baseUsage,
+        plan: 'pro',
+        dailyLimit: 100,
+        used: 96,
+        remaining: 4,
+        monthlyLimit: 3100,
+        monthlyUsed: 1400,
+        monthlyRemaining: 1700,
+        warningThreshold: 5,
+        isNearLimit: true,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<SettingsUsageStatsSection />);
+
+    expect(
+      screen.getByText("You're almost out of messages")
+    ).toBeInTheDocument();
+    expect(screen.getByText('Pro')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /view plans/i })).toHaveAttribute(
+      'href',
+      '/pricing'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Flattened the Settings Usage page into one dense settings surface with stable loading, empty, error, and success geometry.
- Added daily and monthly usage progress rows with remaining quota, reset timing, and plan state.
- Moved cookie preference opening into the root cookie mount so global menu events open the modal even when the visible banner is absent.
- Updated the cookie banner privacy link to the canonical `/legal/privacy` route.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/SettingsUsageStatsSection.test.tsx tests/unit/cookie-banner.test.tsx tests/unit/cookie-banner-fixes.test.tsx tests/unit/api/chat/usage.test.ts tests/unit/constants/routes.test.ts` — 43 tests passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `pnpm exec biome check apps/web/app/api/chat/usage/route.ts apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx apps/web/components/organisms/CookieBannerMount.tsx apps/web/components/organisms/CookieBannerSection.tsx apps/web/lib/queries/useChatUsageQuery.ts apps/web/tests/unit/api/chat/usage.test.ts apps/web/tests/unit/constants/routes.test.ts apps/web/tests/unit/cookie-banner-fixes.test.tsx apps/web/tests/unit/cookie-banner.test.tsx apps/web/tests/unit/dashboard/SettingsUsageStatsSection.test.tsx` — passed.
- Browser smoke on `http://localhost:3100/` with banner hidden: `bannerCountBefore: 0`, `cookieDialogVisible: true`.
- Browser smoke on `http://localhost:3100/app/settings/usage`: route loaded with one usage panel plus daily and monthly progress bars.
- Pre-commit hook: proxy guard, lint-staged Biome/ESLint/a11y, and staged typecheck passed.
- Pre-push hook: full Biome, proxy guard, Tailwind guard, typecheck, and lint passed.

## Blockers
None.