### PR TITLE
feat(ios): ship internal alpha foundation

### DIFF
--- a/apps/ios/Jovie.xcodeproj/project.pbxproj
+++ b/apps/ios/Jovie.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		4C46B1496145C062FB2FE978 /* ClerkKit in Frameworks */ = {isa = PBXBuildFile; productRef = 0199C257CC5EA4F6FD36397D /* ClerkKit */; };
 		4CA1C477ECC6B7B40EA17787 /* LaunchMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD30F57584F71E958D8C0514 /* LaunchMode.swift */; };
 		52C5CBF9C24E4C502FA64955 /* MobileMeResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EC2367922F1F00AB0AF1164 /* MobileMeResponse.swift */; };
+		61A81E78D0B448B6A68F45AD /* MobileAuthReturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EBA07D5CBE04B0BBF053706 /* MobileAuthReturn.swift */; };
 		6853DA69F7459FE14462F48F /* Jovie-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = 969C5D08D3E71A2D9824375A /* Jovie-logo.png */; };
 		6E62396A29D88F275920CA48 /* JovieTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = D03E6B0F83EC74031D75DCFB /* JovieTheme.swift */; };
 		70003B11B0FA1692B2017553 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6FDEFEB6D7C1D0251FDA1E61 /* Foundation.framework */; };
@@ -71,6 +72,7 @@
 		191669F70597A1039C74C0B1 /* MeRepositoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeRepositoryTests.swift; sourceTree = "<group>"; };
 		28FBA9F0D12E0BD1CB8B0B09 /* MeRepository.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MeRepository.swift; sourceTree = "<group>"; };
 		2E13A897DB2C3D06E845EC58 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2EBA07D5CBE04B0BBF053706 /* MobileAuthReturn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileAuthReturn.swift; sourceTree = "<group>"; };
 		3EC2367922F1F00AB0AF1164 /* MobileMeResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileMeResponse.swift; sourceTree = "<group>"; };
 		3FA81B967152B211E5988375 /* ScreenBrightnessManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScreenBrightnessManager.swift; sourceTree = "<group>"; };
 		448ADF9C21BB11784C6AD119 /* QRCodeRendererTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QRCodeRendererTests.swift; sourceTree = "<group>"; };
@@ -308,6 +310,7 @@
 				E4EAFC467F76300BCFC2659F /* Configuration.swift */,
 				00BCF42EFB99B5DAB4E0F400 /* JovieApp.swift */,
 				DD30F57584F71E958D8C0514 /* LaunchMode.swift */,
+				2EBA07D5CBE04B0BBF053706 /* MobileAuthReturn.swift */,
 				969DB5F8041C9A004CDB5234 /* RootView.swift */,
 			);
 			name = App;
@@ -488,6 +491,7 @@
 				EBDA8137B767F16402C41C24 /* Configuration.swift in Sources */,
 				89B2D98342D65781B5E80A72 /* JovieApp.swift in Sources */,
 				4CA1C477ECC6B7B40EA17787 /* LaunchMode.swift in Sources */,
+				61A81E78D0B448B6A68F45AD /* MobileAuthReturn.swift in Sources */,
 				964DEFE0F4D4206832B6888E /* RootView.swift in Sources */,
 				E26FB0F0CBAA2DE24B6BC572 /* APIClient.swift in Sources */,
 				D9CF5232BCCF1F895975D7B7 /* ClerkTokenProvider.swift in Sources */,

--- a/apps/ios/Jovie/App/AppState.swift
+++ b/apps/ios/Jovie/App/AppState.swift
@@ -61,7 +61,7 @@ final class AppState {
     case .uiTestingSignedOut:
       route = .signedOut
       dashboardState = .idle
-    case .uiTestingReady, .uiTestingSettings, .uiTestingVenueMode:
+    case .uiTestingReady, .uiTestingChat, .uiTestingSettings, .uiTestingVenueMode:
       route = .ready
       dashboardState = .loaded(.previewReady)
       isOffline = false
@@ -162,5 +162,9 @@ final class AppState {
     case .idle, .loading, .error:
       return configuration.webBaseURL.appending(path: "app")
     }
+  }
+
+  var billingURL: URL {
+    continueOnWebURL.appending(path: "settings/billing")
   }
 }

--- a/apps/ios/Jovie/App/Configuration.swift
+++ b/apps/ios/Jovie/App/Configuration.swift
@@ -23,12 +23,18 @@ struct AppConfiguration: Sendable {
       envKey: String,
       fallback: String? = nil
     ) -> String {
-      if let value = values?[key] as? String, !value.isEmpty {
-        return value
+      if let value = values?[key] as? String {
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedValue.isEmpty {
+          return trimmedValue
+        }
       }
 
-      if let value = ProcessInfo.processInfo.environment[envKey], !value.isEmpty {
-        return value
+      if let value = ProcessInfo.processInfo.environment[envKey] {
+        let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedValue.isEmpty {
+          return trimmedValue
+        }
       }
 
       if let fallback {

--- a/apps/ios/Jovie/App/JovieApp.swift
+++ b/apps/ios/Jovie/App/JovieApp.swift
@@ -50,8 +50,8 @@ struct JovieApp: App {
           RootView(
             appState: appState,
             liveUserID: nil,
-            onLogout: { await appState.signOut() },
-            onAuthenticated: { _ in }
+            authErrorMessage: nil,
+            onLogout: { await appState.signOut() }
           )
         }
       }

--- a/apps/ios/Jovie/App/LaunchMode.swift
+++ b/apps/ios/Jovie/App/LaunchMode.swift
@@ -7,6 +7,7 @@ enum LaunchMode: Equatable {
   case uiTestingLiveAuth
   case uiTestingSignedOut
   case uiTestingReady
+  case uiTestingChat
   case uiTestingSettings
   case uiTestingVenueMode
   case uiTestingNeedsOnboarding
@@ -19,6 +20,7 @@ enum LaunchMode: Equatable {
     case .unitTesting,
          .uiTestingSignedOut,
          .uiTestingReady,
+         .uiTestingChat,
          .uiTestingSettings,
          .uiTestingVenueMode,
          .uiTestingNeedsOnboarding,
@@ -33,6 +35,10 @@ enum LaunchMode: Equatable {
 
   var opensSettingsOnLaunch: Bool {
     self == .uiTestingSettings
+  }
+
+  var opensChatOnLaunch: Bool {
+    self == .uiTestingChat
   }
 
   var opensVenueModeOnLaunch: Bool {
@@ -56,6 +62,10 @@ enum LaunchMode: Equatable {
 
     if arguments.contains("-ui-testing-ready") {
       return .uiTestingReady
+    }
+
+    if arguments.contains("-ui-testing-chat") {
+      return .uiTestingChat
     }
 
     if arguments.contains("-ui-testing-settings") {

--- a/apps/ios/Jovie/App/MobileAuthReturn.swift
+++ b/apps/ios/Jovie/App/MobileAuthReturn.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+struct MobileAuthReturn: Equatable {
+  let ticket: String
+  let route: String
+}
+
+enum MobileAuthReturnParser {
+  static func parse(_ url: URL) -> MobileAuthReturn? {
+    guard isSupportedCallback(url) else { return nil }
+
+    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    let ticket = components?.queryItems?.first { $0.name == "ticket" }?.value?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    let route = components?.queryItems?.first { $0.name == "route" }?.value?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+
+    guard let ticket, !ticket.isEmpty else { return nil }
+
+    return MobileAuthReturn(
+      ticket: ticket,
+      route: route.flatMap(Self.sanitizeReturnRoute) ?? "/app"
+    )
+  }
+
+  private static func isSupportedCallback(_ url: URL) -> Bool {
+    guard url.scheme?.lowercased() == "ie.jov.jovie" else { return false }
+
+    if url.host == "auth-return" {
+      return true
+    }
+
+    return url.path == "/auth-return"
+  }
+
+  private static func sanitizeReturnRoute(_ route: String) -> String? {
+    guard route.starts(with: "/"), !route.starts(with: "//") else {
+      return nil
+    }
+
+    guard !route.contains("\\") else {
+      return nil
+    }
+
+    guard let components = URLComponents(string: route) else {
+      return nil
+    }
+
+    let path = components.path
+    guard path != "/",
+          !path.hasPrefix("/signin"),
+          !path.hasPrefix("/signup"),
+          !path.hasPrefix("/sign-in"),
+          !path.hasPrefix("/sign-up"),
+          !path.hasPrefix("/sso-callback"),
+          !path.hasPrefix("/auth-return"),
+          !path.hasPrefix("/mobile-auth-return"),
+          !path.hasPrefix("/api")
+    else {
+      return nil
+    }
+
+    return route
+  }
+}

--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -20,6 +20,17 @@ private enum LiveAuthBootstrapError: LocalizedError {
   }
 }
 
+private enum MobileAuthReturnError: LocalizedError {
+  case missingSignedInUser
+
+  var errorDescription: String? {
+    switch self {
+    case .missingSignedInUser:
+      "You're signed in, but we couldn't load your profile. Try again."
+    }
+  }
+}
+
 private enum LiveAuthBootstrapper {
   @MainActor
   static func signInFromEnvironment(
@@ -106,8 +117,8 @@ private enum LiveAuthBootstrapper {
 
 private struct AppContentView: View {
   @Bindable var appState: AppState
+  let authErrorMessage: String?
   let onLogout: @MainActor () async -> Void
-  let onAuthenticated: @MainActor (String) async -> Void
 
   var body: some View {
     Group {
@@ -118,22 +129,28 @@ private struct AppContentView: View {
         AuthScreen(
           isMock: !appState.launchMode.usesLiveClerk,
           webBaseURL: appState.configuration.webBaseURL,
-          onAuthenticated: onAuthenticated
+          errorMessage: authErrorMessage
         )
       case .needsOnboarding:
         AppShellView(
           profile: AppShellProfile(response: nil),
           isOffline: false,
-          initialPanel: appState.launchMode.opensSettingsOnLaunch ? .settings : .main,
+          initialTab: .profile,
+          opensSettingsOnLaunch: appState.launchMode.opensSettingsOnLaunch,
+          billingURL: appState.billingURL,
           onLogout: onLogout
         ) {
           NeedsOnboardingView(continueURL: appState.continueOnWebURL)
+        } chatContent: {
+          MobileChatHomeView(isOffline: false)
         }
       case .ready:
         AppShellView(
           profile: AppShellProfile(response: appState.loadedDashboardResponse),
           isOffline: appState.isOffline,
-          initialPanel: appState.launchMode.opensSettingsOnLaunch ? .settings : .main,
+          initialTab: appState.launchMode.opensChatOnLaunch ? .chat : .profile,
+          opensSettingsOnLaunch: appState.launchMode.opensSettingsOnLaunch,
+          billingURL: appState.billingURL,
           onLogout: onLogout
         ) {
           DashboardView(
@@ -143,24 +160,109 @@ private struct AppContentView: View {
             showVenueModeOnLaunch: appState.launchMode.opensVenueModeOnLaunch,
             onRetry: { await appState.retry() }
           )
+        } chatContent: {
+          MobileChatHomeView(isOffline: appState.isOffline)
         }
       }
     }
   }
 }
 
+private struct MobileChatHomeView: View {
+  let isOffline: Bool
+
+  @State private var draft = ""
+
+  var body: some View {
+    ZStack {
+      JovieColor.backgroundBase.ignoresSafeArea()
+
+      VStack(spacing: 0) {
+        Spacer(minLength: 120)
+
+        VStack(spacing: JovieSpacing.large) {
+          JovieLogoMark(size: 34)
+
+          VStack(spacing: JovieSpacing.small) {
+            Text("Ask Jovie")
+              .font(JovieFont.display(size: 28))
+              .foregroundStyle(JovieColor.textPrimary)
+              .multilineTextAlignment(.center)
+
+            Text(isOffline ? "Offline. Drafts stay on this device." : "Native chat is in alpha for internal testers.")
+              .font(JovieFont.body(size: 15))
+              .foregroundStyle(JovieColor.textTertiary)
+              .multilineTextAlignment(.center)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+        }
+        .frame(maxWidth: 330)
+        .padding(.horizontal, JovieSpacing.xLarge)
+
+        Spacer(minLength: 48)
+
+        ChatComposerPreview(draft: $draft)
+          .padding(.horizontal, JovieSpacing.large)
+          .padding(.bottom, JovieSpacing.medium)
+      }
+    }
+    .accessibilityIdentifier("mobile-chat")
+  }
+}
+
+private struct ChatComposerPreview: View {
+  @Binding var draft: String
+
+  var body: some View {
+    let trimmedDraft = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    HStack(spacing: JovieSpacing.medium) {
+      TextField("Ask Jovie", text: $draft)
+        .textInputAutocapitalization(.sentences)
+        .disableAutocorrection(false)
+        .font(JovieFont.body(size: 16))
+        .foregroundStyle(JovieColor.textPrimary)
+        .frame(height: 52)
+
+      Button {
+        draft = ""
+      } label: {
+        Image(systemName: "arrow.up")
+          .font(.system(size: 16, weight: .bold))
+          .foregroundStyle(trimmedDraft.isEmpty ? JovieColor.textTertiary : JovieColor.backgroundBase)
+          .frame(width: 36, height: 36)
+          .background(
+            trimmedDraft.isEmpty ? JovieColor.surface2 : Color.white,
+            in: Circle()
+          )
+      }
+      .buttonStyle(.plain)
+      .disabled(trimmedDraft.isEmpty)
+      .accessibilityLabel("Send")
+    }
+    .padding(.horizontal, JovieSpacing.large)
+    .frame(height: 64)
+    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+    .overlay {
+      RoundedRectangle(cornerRadius: 28, style: .continuous)
+        .stroke(JovieColor.borderDefault, lineWidth: 1)
+    }
+    .accessibilityIdentifier("chat-composer")
+  }
+}
+
 struct RootView: View {
   @Bindable var appState: AppState
   let liveUserID: String?
+  let authErrorMessage: String?
   let onLogout: @MainActor () async -> Void
-  let onAuthenticated: @MainActor (String) async -> Void
 
   var body: some View {
     ZStack {
       AppContentView(
         appState: appState,
-        onLogout: onLogout,
-        onAuthenticated: onAuthenticated
+        authErrorMessage: authErrorMessage,
+        onLogout: onLogout
       )
 
 #if DEBUG
@@ -213,19 +315,22 @@ struct LiveRootContainer: View {
   @Environment(Clerk.self) private var clerk
   @Bindable var appState: AppState
   @State private var didBootstrapLiveAuth = false
+  @State private var authReturnTask: Task<Void, Never>?
+  @State private var authErrorMessage: String?
 
   var body: some View {
     RootView(
       appState: appState,
       liveUserID: clerk.user?.id,
+      authErrorMessage: authErrorMessage,
       onLogout: {
         try? await clerk.auth.signOut()
         await appState.signOut()
-      },
-      onAuthenticated: { userID in
-        await appState.handleSignedInUserChange(userID)
       }
     )
+      .onOpenURL { url in
+        handleAuthReturn(url)
+      }
       .task(id: appState.launchMode.requiresAutoAuth) {
         guard appState.launchMode.requiresAutoAuth, didBootstrapLiveAuth == false else {
           return
@@ -245,6 +350,48 @@ struct LiveRootContainer: View {
           )
         }
       }
+      .onDisappear {
+        authReturnTask?.cancel()
+        authReturnTask = nil
+      }
+  }
+
+  @MainActor
+  private func handleAuthReturn(_ url: URL) {
+    guard let authReturn = MobileAuthReturnParser.parse(url) else { return }
+
+    authReturnTask?.cancel()
+    authErrorMessage = nil
+    appState.route = .launching
+
+    authReturnTask = Task { @MainActor in
+      defer {
+        authReturnTask = nil
+      }
+
+      do {
+        let signIn = try await clerk.auth.signInWithTicket(authReturn.ticket)
+
+        if let sessionID = signIn.createdSessionId,
+           clerk.session?.id != sessionID
+        {
+          try await clerk.auth.setActive(sessionId: sessionID)
+        }
+
+        _ = try await clerk.refreshClient()
+        _ = try await ClerkTokenProvider().bearerToken(forceRefresh: false)
+
+        guard let userID = clerk.user?.id else {
+          throw MobileAuthReturnError.missingSignedInUser
+        }
+
+        await appState.handleSignedInUserChange(userID)
+      } catch {
+        try? await clerk.auth.signOut()
+        await appState.signOut()
+        authErrorMessage = "Couldn't finish sign-in. Try again."
+      }
+    }
   }
 }
 

--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -387,8 +387,23 @@ struct LiveRootContainer: View {
 
         await appState.handleSignedInUserChange(userID)
       } catch {
-        try? await clerk.auth.signOut()
-        await appState.signOut()
+        guard !(error is CancellationError), !Task.isCancelled else {
+          return
+        }
+
+        if error is MobileAuthReturnError {
+          try? await clerk.auth.signOut()
+          await appState.signOut()
+          authErrorMessage = "Couldn't finish sign-in. Try again."
+          return
+        }
+
+        if let existingUserID = clerk.user?.id {
+          await appState.handleSignedInUserChange(existingUserID)
+        } else {
+          await appState.signOut()
+        }
+
         authErrorMessage = "Couldn't finish sign-in. Try again."
       }
     }

--- a/apps/ios/Jovie/Features/AppShell/AppShellView.swift
+++ b/apps/ios/Jovie/Features/AppShell/AppShellView.swift
@@ -1,8 +1,29 @@
 import SwiftUI
 
-enum AppShellPanel: Equatable {
-  case sidebar
-  case main
+enum AppShellTab: Equatable {
+  case chat
+  case profile
+
+  var title: String {
+    switch self {
+    case .chat:
+      return "Chat"
+    case .profile:
+      return "Profile"
+    }
+  }
+
+  var systemImage: String {
+    switch self {
+    case .chat:
+      return "sparkles"
+    case .profile:
+      return "qrcode.viewfinder"
+    }
+  }
+}
+
+private enum AppShellRoute: Hashable {
   case settings
 }
 
@@ -28,240 +49,292 @@ struct AppShellProfile: Equatable {
   }
 }
 
-struct AppShellView<MainContent: View>: View {
+struct AppShellView<ProfileContent: View, ChatContent: View>: View {
   let profile: AppShellProfile
   let isOffline: Bool
-  let initialPanel: AppShellPanel
+  let opensSettingsOnLaunch: Bool
+  let billingURL: URL
   let onLogout: @MainActor () async -> Void
-  @ViewBuilder let mainContent: MainContent
+  @ViewBuilder let profileContent: ProfileContent
+  @ViewBuilder let chatContent: ChatContent
 
-  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-  @State private var compactPanel: AppShellPanel
+  @State private var selectedTab: AppShellTab
+  @State private var navigationPath: [AppShellRoute] = []
+  @State private var isShowingMenu = false
+  @State private var didOpenLaunchSettings = false
 
   init(
     profile: AppShellProfile,
     isOffline: Bool,
-    initialPanel: AppShellPanel = .main,
+    initialTab: AppShellTab = .profile,
+    opensSettingsOnLaunch: Bool = false,
+    billingURL: URL,
     onLogout: @escaping @MainActor () async -> Void,
-    @ViewBuilder mainContent: () -> MainContent
+    @ViewBuilder profileContent: () -> ProfileContent,
+    @ViewBuilder chatContent: () -> ChatContent
   ) {
     self.profile = profile
     self.isOffline = isOffline
-    self.initialPanel = initialPanel
+    self.opensSettingsOnLaunch = opensSettingsOnLaunch
+    self.billingURL = billingURL
     self.onLogout = onLogout
-    self.mainContent = mainContent()
-    _compactPanel = State(initialValue: initialPanel)
+    self.profileContent = profileContent()
+    self.chatContent = chatContent()
+    _selectedTab = State(initialValue: initialTab)
   }
 
   var body: some View {
-    GeometryReader { geometry in
-      if usesRegularLayout(width: geometry.size.width) {
-        regularLayout
-      } else {
-        compactLayout(width: geometry.size.width)
+    NavigationStack(path: $navigationPath) {
+      ZStack {
+        JovieColor.backgroundBase.ignoresSafeArea()
+
+        activeContent
+          .safeAreaInset(edge: .top, spacing: 0) {
+            shellToolbar
+          }
+          .safeAreaInset(edge: .bottom, spacing: 0) {
+            bottomNavigation
+          }
       }
-    }
-    .background(JovieColor.backgroundBase)
-  }
-
-  private var regularLayout: some View {
-    HStack(spacing: 0) {
-      AppSidebarView(profile: profile, isOffline: isOffline)
-        .frame(width: 232)
-
-      shellDivider
-
-      mainContent
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-      shellDivider
-
-      SettingsView(
-        profile: profile,
-        buildInfo: .current(),
-        onLogout: onLogout
-      )
-      .frame(width: 320)
-    }
-    .ignoresSafeArea(.keyboard)
-  }
-
-  private func compactLayout(width: CGFloat) -> some View {
-    ZStack {
-      mainContent
-        .safeAreaInset(edge: .top, spacing: 0) {
-          compactToolbar
-        }
-        .accessibilityIdentifier("shell-main")
-
-      compactScrim
-
-      if compactPanel == .sidebar {
-        HStack(spacing: 0) {
-          AppSidebarView(
-            profile: profile,
-            isOffline: isOffline,
-            onClose: { setCompactPanel(.main) }
-          )
-          .frame(width: min(width * 0.82, 320))
-          .transition(.move(edge: .leading))
-
-          Spacer(minLength: 0)
-        }
-        .zIndex(2)
-      }
-
-      if compactPanel == .settings {
-        HStack(spacing: 0) {
-          Spacer(minLength: 0)
-
+      .navigationBarHidden(true)
+      .navigationDestination(for: AppShellRoute.self) { route in
+        switch route {
+        case .settings:
           SettingsView(
             profile: profile,
             buildInfo: .current(),
-            onClose: { setCompactPanel(.main) },
+            billingURL: billingURL,
             onLogout: onLogout
           )
-          .frame(width: min(width * 0.86, 360))
-          .transition(.move(edge: .trailing))
+          .navigationBarBackButtonHidden()
         }
-        .zIndex(2)
       }
     }
+    .background(JovieColor.backgroundBase)
     .contentShape(Rectangle())
-    .simultaneousGesture(edgeSwipe(width: width))
-  }
-
-  private var compactToolbar: some View {
-    HStack {
-      Button {
-        setCompactPanel(.sidebar)
-      } label: {
-        Image(systemName: "sidebar.left")
-      }
-      .buttonStyle(JovieIconButtonStyle())
-      .accessibilityLabel("Open Sidebar")
-
-      Spacer()
-
-      Button {
-        setCompactPanel(.settings)
-      } label: {
-        Image(systemName: "gearshape")
-      }
-      .buttonStyle(JovieIconButtonStyle())
-      .accessibilityLabel("Open Settings")
+    .simultaneousGesture(edgeSwipe)
+    .fullScreenCover(isPresented: $isShowingMenu) {
+      AppNavigationMenu(
+        profile: profile,
+        isOffline: isOffline,
+        selectedTab: selectedTab,
+        onSelectTab: { tab in
+          selectedTab = tab
+          isShowingMenu = false
+        },
+        onOpenSettings: {
+          isShowingMenu = false
+          navigationPath.append(.settings)
+        },
+        onClose: { isShowingMenu = false }
+      )
     }
-    .padding(.horizontal, JovieSpacing.large)
-    .padding(.vertical, JovieSpacing.small)
-    .background(JovieColor.backgroundBase.opacity(0.94))
+    .task(id: opensSettingsOnLaunch) {
+      guard opensSettingsOnLaunch, didOpenLaunchSettings == false else { return }
+      didOpenLaunchSettings = true
+      await Task.yield()
+      navigationPath.append(.settings)
+    }
   }
 
   @ViewBuilder
-  private var compactScrim: some View {
-    if compactPanel != .main {
-      Color.black.opacity(0.48)
-        .ignoresSafeArea()
-        .onTapGesture {
-          setCompactPanel(.main)
-        }
-        .transition(.opacity)
-        .zIndex(1)
+  private var activeContent: some View {
+    switch selectedTab {
+    case .chat:
+      chatContent
+    case .profile:
+      profileContent
     }
   }
 
-  private var shellDivider: some View {
-    Rectangle()
-      .fill(JovieColor.borderSubtle)
-      .frame(width: 1)
+  private var shellToolbar: some View {
+    HStack(spacing: JovieSpacing.medium) {
+      Button {
+        isShowingMenu = true
+      } label: {
+        Image(systemName: "line.3.horizontal")
+      }
+      .buttonStyle(JovieIconButtonStyle())
+      .accessibilityLabel("Open Menu")
+
+      VStack(spacing: 2) {
+        Text(selectedTab.title)
+          .font(JovieFont.body(size: 16, weight: .semibold))
+          .foregroundStyle(JovieColor.textPrimary)
+          .lineLimit(1)
+
+        if isOffline {
+          Text("Offline")
+            .font(JovieFont.body(size: 11, weight: .medium))
+            .foregroundStyle(JovieColor.textTertiary)
+        }
+      }
+      .frame(maxWidth: .infinity)
+
+      Button {
+        if selectedTab == .chat {
+          selectedTab = .profile
+        } else {
+          navigationPath.append(.settings)
+        }
+      } label: {
+        Image(systemName: selectedTab == .chat ? "qrcode.viewfinder" : "gearshape")
+      }
+      .buttonStyle(JovieIconButtonStyle())
+      .accessibilityLabel(selectedTab == .chat ? "Open Profile" : "Open Settings")
+    }
+    .padding(.horizontal, JovieSpacing.large)
+    .padding(.vertical, JovieSpacing.small)
+    .background(JovieColor.backgroundBase.opacity(0.96))
   }
 
-  private func edgeSwipe(width: CGFloat) -> some Gesture {
-    DragGesture(minimumDistance: 28)
+  private var bottomNavigation: some View {
+    HStack(spacing: JovieSpacing.small) {
+      tabButton(.chat)
+      tabButton(.profile)
+    }
+    .padding(6)
+    .frame(width: 236)
+    .background {
+      if #available(iOS 26.0, *) {
+        Capsule(style: .continuous)
+          .fill(JovieColor.surface1.opacity(0.54))
+          .glassEffect(.regular.tint(JovieColor.surface1.opacity(0.54)), in: .rect(cornerRadius: 28))
+      } else {
+        Capsule(style: .continuous)
+          .fill(.ultraThinMaterial)
+          .overlay {
+            Capsule(style: .continuous)
+              .stroke(JovieColor.borderDefault, lineWidth: 1)
+          }
+      }
+    }
+    .padding(.bottom, JovieSpacing.medium)
+    .accessibilityIdentifier("shell-bottom-navigation")
+  }
+
+  private func tabButton(_ tab: AppShellTab) -> some View {
+    let isSelected = selectedTab == tab
+
+    return Button {
+      selectedTab = tab
+    } label: {
+      HStack(spacing: JovieSpacing.small) {
+        Image(systemName: tab.systemImage)
+          .font(.system(size: 15, weight: .semibold))
+
+        Text(tab.title)
+          .font(JovieFont.body(size: 14, weight: .semibold))
+          .lineLimit(1)
+      }
+      .foregroundStyle(isSelected ? JovieColor.backgroundBase : JovieColor.textSecondary)
+      .frame(maxWidth: .infinity)
+      .frame(height: 42)
+      .background(
+        isSelected ? Color.white : Color.clear,
+        in: Capsule(style: .continuous)
+      )
+      .contentShape(Capsule(style: .continuous))
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel(tab.title)
+  }
+
+  private var edgeSwipe: some Gesture {
+    DragGesture(minimumDistance: 30)
       .onEnded { value in
         let horizontal = value.translation.width
-        guard abs(horizontal) > 64, abs(horizontal) > abs(value.translation.height) else {
+        guard abs(horizontal) > 72, abs(horizontal) > abs(value.translation.height) else {
           return
         }
 
-        if horizontal > 0 {
-          if compactPanel == .settings {
-            setCompactPanel(.main)
-          } else if value.startLocation.x <= 44 || compactPanel == .main {
-            setCompactPanel(.sidebar)
-          }
+        if horizontal > 0, value.startLocation.x <= 52 {
+          isShowingMenu = true
         } else if horizontal < 0 {
-          if compactPanel == .sidebar {
-            setCompactPanel(.main)
-          } else if value.startLocation.x >= width - 44 || compactPanel == .main {
-            setCompactPanel(.settings)
-          }
+          selectedTab = .profile
         }
       }
   }
-
-  private func setCompactPanel(_ panel: AppShellPanel) {
-    withAnimation(.easeOut(duration: 0.18)) {
-      compactPanel = panel
-    }
-  }
-
-  private func usesRegularLayout(width: CGFloat) -> Bool {
-    horizontalSizeClass == .regular && width >= 820
-  }
 }
 
-private struct AppSidebarView: View {
+private struct AppNavigationMenu: View {
   let profile: AppShellProfile
   let isOffline: Bool
-  var onClose: (() -> Void)?
-
-  @Environment(\.openURL) private var openURL
+  let selectedTab: AppShellTab
+  let onSelectTab: (AppShellTab) -> Void
+  let onOpenSettings: () -> Void
+  let onClose: () -> Void
 
   var body: some View {
-    VStack(alignment: .leading, spacing: JovieSpacing.large) {
-      HStack(spacing: JovieSpacing.medium) {
-        JovieLogoMark(size: 28)
+    ZStack {
+      JovieColor.backgroundBase.ignoresSafeArea()
 
-        Text("Jovie")
-          .font(JovieFont.display(size: 18))
-          .foregroundStyle(JovieColor.textPrimary)
+      VStack(alignment: .leading, spacing: JovieSpacing.xLarge) {
+        HStack {
+          Text("Jovie")
+            .font(JovieFont.display(size: 30))
+            .foregroundStyle(JovieColor.textPrimary)
 
-        Spacer()
+          Spacer()
 
-        if let onClose {
           Button(action: onClose) {
             Image(systemName: "xmark")
           }
           .buttonStyle(JovieIconButtonStyle())
-          .accessibilityLabel("Close Sidebar")
+          .accessibilityLabel("Close Menu")
         }
-      }
 
-      SidebarAccountView(profile: profile, isOffline: isOffline)
+        MenuAccountView(profile: profile, isOffline: isOffline)
 
-      VStack(spacing: JovieSpacing.small) {
-        SidebarRow(title: "Dashboard", systemImage: "qrcode.viewfinder", isSelected: true) {}
-
-        SidebarRow(title: "Profile", systemImage: "person.crop.circle", isSelected: false) {
-          guard let value = profile.publicProfileURL, let url = URL(string: value) else {
-            return
+        VStack(spacing: JovieSpacing.small) {
+          MenuRow(
+            title: "Chat",
+            systemImage: AppShellTab.chat.systemImage,
+            isSelected: selectedTab == .chat
+          ) {
+            onSelectTab(.chat)
           }
 
-          openURL(url)
-        }
-        .disabled(profile.publicProfileURL == nil)
-      }
+          MenuRow(
+            title: "Profile",
+            systemImage: AppShellTab.profile.systemImage,
+            isSelected: selectedTab == .profile
+          ) {
+            onSelectTab(.profile)
+          }
 
-      Spacer(minLength: 0)
+          MenuRow(
+            title: "Settings",
+            systemImage: "gearshape",
+            isSelected: false,
+            action: onOpenSettings
+          )
+        }
+
+        VStack(alignment: .leading, spacing: JovieSpacing.medium) {
+          Text("Recent")
+            .font(JovieFont.body(size: 13, weight: .semibold))
+            .foregroundStyle(JovieColor.textTertiary)
+
+          Text("Conversations will appear here when mobile chat is enabled.")
+            .font(JovieFont.body(size: 15))
+            .foregroundStyle(JovieColor.textTertiary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(.top, JovieSpacing.medium)
+
+        Spacer(minLength: 0)
+      }
+      .padding(.horizontal, JovieSpacing.xLarge)
+      .padding(.top, JovieSpacing.xxLarge)
+      .padding(.bottom, JovieSpacing.xLarge)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
-    .padding(JovieSpacing.large)
-    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    .background(JovieColor.surface0)
-    .accessibilityIdentifier("shell-sidebar")
+    .accessibilityIdentifier("shell-menu")
   }
 }
 
-private struct SidebarAccountView: View {
+private struct MenuAccountView: View {
   let profile: AppShellProfile
   let isOffline: Bool
 
@@ -271,25 +344,26 @@ private struct SidebarAccountView: View {
         name: profile.displayName,
         avatarURL: profile.avatarURL
       )
+      .frame(width: 36, height: 36)
 
       VStack(alignment: .leading, spacing: JovieSpacing.xSmall) {
         Text(profile.displayName)
-          .font(JovieFont.body(size: 14, weight: .semibold))
+          .font(JovieFont.body(size: 15, weight: .semibold))
           .foregroundStyle(JovieColor.textPrimary)
           .lineLimit(1)
 
         Text(isOffline ? "Offline" : profile.secondaryText)
-          .font(JovieFont.body(size: 12, weight: .medium))
+          .font(JovieFont.body(size: 13, weight: .medium))
           .foregroundStyle(JovieColor.textTertiary)
           .lineLimit(1)
       }
+
+      Spacer(minLength: 0)
     }
-    .padding(JovieSpacing.medium)
-    .jovieSurface(radius: JovieRadius.medium)
   }
 }
 
-private struct SidebarRow: View {
+private struct MenuRow: View {
   let title: String
   let systemImage: String
   let isSelected: Bool
@@ -299,22 +373,23 @@ private struct SidebarRow: View {
     Button(action: action) {
       HStack(spacing: JovieSpacing.medium) {
         Image(systemName: systemImage)
-          .frame(width: 18)
+          .frame(width: 22)
 
         Text(title)
           .lineLimit(1)
 
         Spacer(minLength: 0)
       }
-      .font(JovieFont.body(size: 14, weight: .semibold))
+      .font(JovieFont.body(size: 18, weight: .semibold))
       .foregroundStyle(isSelected ? JovieColor.textPrimary : JovieColor.textSecondary)
+      .padding(.vertical, 13)
       .padding(.horizontal, JovieSpacing.medium)
-      .padding(.vertical, 11)
       .background(
         isSelected ? JovieColor.surface1 : Color.clear,
         in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous)
       )
     }
     .buttonStyle(.plain)
+    .accessibilityLabel(title)
   }
 }

--- a/apps/ios/Jovie/Features/Auth/AuthScreen.swift
+++ b/apps/ios/Jovie/Features/Auth/AuthScreen.swift
@@ -1,5 +1,3 @@
-import AuthenticationServices
-import ClerkKit
 import OSLog
 import SwiftUI
 
@@ -11,7 +9,10 @@ private let authLogger = Logger(
 struct AuthScreen: View {
   let isMock: Bool
   let webBaseURL: URL
-  let onAuthenticated: @MainActor (String) async -> Void
+  let errorMessage: String?
+
+  @Environment(\.openURL) private var openURL
+  @State private var didRequestBrowserAuth = false
 
   var body: some View {
     ZStack {
@@ -35,165 +36,60 @@ struct AuthScreen: View {
 
         Spacer(minLength: 72)
 
-        if isMock {
-          MockSSOAuthActions()
-        } else {
-          LiveSSOAuthActions(onAuthenticated: onAuthenticated)
-        }
+        BrowserAuthActions(
+          isOpening: didRequestBrowserAuth,
+          errorMessage: errorMessage,
+          action: startBrowserAuth
+        )
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     .accessibilityIdentifier("auth-screen")
   }
-}
 
-private enum SSOProvider: Hashable, Identifiable {
-  case google
-  case apple
-
-  var id: Self { self }
-
-  var title: String {
-    switch self {
-    case .google:
-      "Continue with Google"
-    case .apple:
-      "Continue with Apple"
+  private func startBrowserAuth() {
+    guard !isMock,
+          let authURL = MobileBrowserAuthURLBuilder.signInURL(baseURL: webBaseURL)
+    else {
+      return
     }
-  }
 
-  var clerkProvider: OAuthProvider {
-    switch self {
-    case .google:
-      .google
-    case .apple:
-      .apple
-    }
-  }
+    didRequestBrowserAuth = true
 
-  var accessibilityIdentifier: String {
-    switch self {
-    case .google:
-      "auth-google-button"
-    case .apple:
-      "auth-apple-button"
+    openURL(authURL) { accepted in
+      if !accepted {
+        authLogger.error("System refused to open mobile browser auth URL.")
+        didRequestBrowserAuth = false
+      }
     }
   }
 }
 
-private struct MockSSOAuthActions: View {
-  var body: some View {
-    SSOProviderButtons(
-      activeProvider: nil,
-      errorMessage: nil,
-      onSelect: { _ in }
-    )
+enum MobileBrowserAuthURLBuilder {
+  static func signInURL(baseURL: URL, returnRoute: String = "/app") -> URL? {
+    guard var components = URLComponents(
+      url: baseURL.appending(path: "signin"),
+      resolvingAgainstBaseURL: false
+    ) else {
+      return nil
+    }
+
+    components.queryItems = [
+      URLQueryItem(name: "mobile_return", value: returnRoute),
+    ]
+
+    return components.url
   }
 }
 
-private struct LiveSSOAuthActions: View {
-  @Environment(Clerk.self) private var clerk
-
-  let onAuthenticated: @MainActor (String) async -> Void
-
-  @State private var activeProvider: SSOProvider?
-  @State private var errorMessage: String?
-  @State private var authTask: Task<Void, Never>?
-
-  var body: some View {
-    SSOProviderButtons(
-      activeProvider: activeProvider,
-      errorMessage: errorMessage,
-      onSelect: startAuth
-    )
-    .onDisappear {
-      authTask?.cancel()
-      authTask = nil
-      activeProvider = nil
-    }
-  }
-
-  @MainActor
-  private func startAuth(with provider: SSOProvider) {
-    guard activeProvider == nil else { return }
-
-    authTask?.cancel()
-    activeProvider = provider
-    errorMessage = nil
-
-    authTask = Task { @MainActor in
-      defer {
-        activeProvider = nil
-        authTask = nil
-      }
-
-      do {
-        let result = try await clerk.auth.signInWithOAuth(
-          provider: provider.clerkProvider,
-          prefersEphemeralWebBrowserSession: false,
-          transferable: true
-        )
-
-        guard !Task.isCancelled else { return }
-        try await finishAuthentication(result)
-      } catch {
-        guard !Task.isCancelled else { return }
-
-        if let message = AuthErrorMapper.message(for: error) {
-          errorMessage = message
-        }
-      }
-    }
-  }
-
-  @MainActor
-  private func finishAuthentication(_ result: TransferFlowResult) async throws {
-    switch result {
-    case let .signIn(signIn):
-      if let sessionID = signIn.createdSessionId,
-         clerk.session?.id != sessionID
-      {
-        try await clerk.auth.setActive(sessionId: sessionID)
-      }
-    case let .signUp(signUp):
-      if let sessionID = signUp.createdSessionId,
-         clerk.session?.id != sessionID
-      {
-        try await clerk.auth.setActive(sessionId: sessionID)
-      }
-    }
-
-    _ = try await clerk.refreshClient()
-    _ = try await ClerkTokenProvider().bearerToken(forceRefresh: false)
-
-    guard let userID = clerk.user?.id else {
-      authLogger.error("Clerk user missing after successful OAuth verification.")
-      throw AuthPresentationError.missingSignedInUser
-    }
-
-    await onAuthenticated(userID)
-  }
-}
-
-private struct SSOProviderButtons: View {
-  let activeProvider: SSOProvider?
+private struct BrowserAuthActions: View {
+  let isOpening: Bool
   let errorMessage: String?
-  let onSelect: (SSOProvider) -> Void
-
-  private let providers: [SSOProvider] = [.google, .apple]
+  let action: () -> Void
 
   var body: some View {
     VStack(spacing: JovieSpacing.large) {
-      VStack(spacing: JovieSpacing.medium) {
-        ForEach(providers) { provider in
-          SSOProviderButton(
-            provider: provider,
-            isLoading: activeProvider == provider,
-            isDisabled: activeProvider != nil,
-            action: { onSelect(provider) }
-          )
-        }
-      }
+      GetStartedButton(isOpening: isOpening, action: action)
 
       AuthErrorText(message: errorMessage)
     }
@@ -203,47 +99,35 @@ private struct SSOProviderButtons: View {
   }
 }
 
-private struct SSOProviderButton: View {
-  let provider: SSOProvider
-  let isLoading: Bool
-  let isDisabled: Bool
+private struct GetStartedButton: View {
+  let isOpening: Bool
   let action: () -> Void
-
-  private var isPrimary: Bool {
-    provider == .google
-  }
 
   var body: some View {
     Button(action: action) {
       HStack(spacing: JovieSpacing.small) {
-        if isLoading {
+        if isOpening {
           ProgressView()
             .controlSize(.small)
-            .tint(isPrimary ? JovieColor.backgroundBase : JovieColor.textPrimary)
+            .tint(JovieColor.backgroundBase)
         }
 
-        Text(provider.title)
+        Text(isOpening ? "Opening..." : "Get started")
           .lineLimit(1)
           .minimumScaleFactor(0.82)
       }
       .font(JovieFont.body(size: 16, weight: .semibold))
-      .foregroundStyle(isPrimary ? JovieColor.backgroundBase : JovieColor.textPrimary)
+      .foregroundStyle(JovieColor.backgroundBase)
       .frame(maxWidth: .infinity)
       .frame(height: 56)
       .contentShape(Rectangle())
     }
     .buttonStyle(.plain)
-    .disabled(isDisabled)
     .background(
       Capsule(style: .continuous)
-        .fill(isPrimary ? Color.white : JovieColor.surface1)
+        .fill(Color.white)
     )
-    .overlay {
-      Capsule(style: .continuous)
-        .stroke(isPrimary ? Color.clear : JovieColor.borderDefault, lineWidth: 1)
-    }
-    .opacity(isDisabled && !isLoading ? 0.62 : 1)
-    .accessibilityIdentifier(provider.accessibilityIdentifier)
+    .accessibilityIdentifier("auth-get-started-button")
   }
 }
 
@@ -259,52 +143,5 @@ private struct AuthErrorText: View {
       .frame(minHeight: 36)
       .frame(maxWidth: .infinity)
       .accessibilityHidden(message == nil)
-  }
-}
-
-private enum AuthPresentationError: LocalizedError {
-  case missingSignedInUser
-
-  var errorDescription: String? {
-    switch self {
-    case .missingSignedInUser:
-      "You're signed in, but we couldn't load your profile. Try again."
-    }
-  }
-}
-
-enum AuthErrorMapper {
-  static func message(for error: Error) -> String? {
-    if let authError = error as? ASWebAuthenticationSessionError,
-       authError.code == .canceledLogin
-    {
-      return nil
-    }
-
-    let rawMessage = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
-    let lowercased = rawMessage.lowercased()
-
-    if lowercased.contains("cancel") {
-      return nil
-    }
-
-    if lowercased.contains("network") ||
-      lowercased.contains("offline") ||
-      lowercased.contains("internet") ||
-      lowercased.contains("timed out")
-    {
-      return "We couldn't reach Jovie. Check your connection and try again."
-    }
-
-    if lowercased.contains("not allowed") ||
-      lowercased.contains("strategy") ||
-      lowercased.contains("oauth")
-    {
-      return "This sign-in method is not available yet. Try another option."
-    }
-
-    return rawMessage.isEmpty
-      ? "Sign in failed. Try again."
-      : rawMessage
   }
 }

--- a/apps/ios/Jovie/Features/Auth/AuthScreen.swift
+++ b/apps/ios/Jovie/Features/Auth/AuthScreen.swift
@@ -67,6 +67,7 @@ struct AuthScreen: View {
 
 enum MobileBrowserAuthURLBuilder {
   static func signInURL(baseURL: URL, returnRoute: String = "/app") -> URL? {
+    let safeReturnRoute = sanitizeReturnRoute(returnRoute) ?? "/app"
     guard var components = URLComponents(
       url: baseURL.appending(path: "signin"),
       resolvingAgainstBaseURL: false
@@ -75,10 +76,30 @@ enum MobileBrowserAuthURLBuilder {
     }
 
     components.queryItems = [
-      URLQueryItem(name: "mobile_return", value: returnRoute),
+      URLQueryItem(name: "mobile_return", value: safeReturnRoute),
     ]
 
     return components.url
+  }
+
+  private static func sanitizeReturnRoute(_ route: String) -> String? {
+    let trimmed = route.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.starts(with: "/"),
+          !trimmed.starts(with: "//"),
+          !trimmed.contains("://"),
+          !trimmed.contains("\\")
+    else {
+      return nil
+    }
+
+    guard let components = URLComponents(string: trimmed),
+          components.scheme == nil,
+          components.host == nil
+    else {
+      return nil
+    }
+
+    return trimmed
   }
 }
 

--- a/apps/ios/Jovie/Features/NeedsOnboarding/NeedsOnboardingView.swift
+++ b/apps/ios/Jovie/Features/NeedsOnboarding/NeedsOnboardingView.swift
@@ -9,7 +9,7 @@ struct NeedsOnboardingView: View {
       JovieColor.backgroundBase.ignoresSafeArea()
 
       VStack(alignment: .leading, spacing: JovieSpacing.large) {
-        Text("Complete Your Profile On Web")
+        Text("Complete Your Profile on Web")
           .font(JovieFont.display(size: 28))
           .foregroundStyle(JovieColor.textPrimary)
 
@@ -17,7 +17,7 @@ struct NeedsOnboardingView: View {
           .font(JovieFont.body(size: 16))
           .foregroundStyle(JovieColor.textSecondary)
 
-        Button("Continue On Web") {
+        Button("Continue on Web") {
           openURL(continueURL)
         }
         .buttonStyle(JoviePillButtonStyle(filled: true))

--- a/apps/ios/Jovie/Features/Settings/SettingsView.swift
+++ b/apps/ios/Jovie/Features/Settings/SettingsView.swift
@@ -15,6 +15,7 @@ struct AppBuildInfo: Equatable {
 struct SettingsView: View {
   let profile: AppShellProfile
   let buildInfo: AppBuildInfo
+  let billingURL: URL
   var onClose: (() -> Void)?
   let onLogout: @MainActor () async -> Void
 
@@ -34,7 +35,7 @@ struct SettingsView: View {
     }
     .scrollIndicators(.hidden)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-    .background(JovieColor.surface0)
+    .background(JovieColor.backgroundBase)
     .accessibilityIdentifier("settings-view")
   }
 
@@ -82,7 +83,7 @@ struct SettingsView: View {
         Spacer(minLength: 0)
       }
       .padding(JovieSpacing.medium)
-      .jovieSurface(radius: JovieRadius.medium)
+      .background(JovieColor.surface0, in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous))
     }
   }
 
@@ -93,6 +94,12 @@ struct SettingsView: View {
       VStack(spacing: 0) {
         SettingsLinkRow(title: "Support", systemImage: "questionmark.circle") {
           openURL(URL(string: "https://jov.ie/support")!)
+        }
+
+        SettingsDivider()
+
+        SettingsLinkRow(title: "Billing", systemImage: "creditcard") {
+          openURL(billingURL)
         }
 
         SettingsDivider()
@@ -108,7 +115,7 @@ struct SettingsView: View {
         }
       }
       .padding(.vertical, JovieSpacing.xSmall)
-      .jovieSurface(radius: JovieRadius.medium)
+      .background(JovieColor.surface0, in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous))
     }
   }
 
@@ -122,7 +129,7 @@ struct SettingsView: View {
         SettingsValueRow(title: "Build", value: buildInfo.build)
       }
       .padding(.vertical, JovieSpacing.xSmall)
-      .jovieSurface(radius: JovieRadius.medium)
+      .background(JovieColor.surface0, in: RoundedRectangle(cornerRadius: JovieRadius.medium, style: .continuous))
     }
   }
 

--- a/apps/ios/JovieTests/AppStateTests.swift
+++ b/apps/ios/JovieTests/AppStateTests.swift
@@ -159,23 +159,63 @@ struct AppStateTests {
     #expect(await repository.clearedUsers() == ["user_123"])
   }
 
-  @Test func authErrorMapperKeepsSpecificFallbackMessage() {
-    let error = NSError(
-      domain: "Clerk",
-      code: 429,
-      userInfo: [NSLocalizedDescriptionKey: "Too many attempts. Try again later."]
+  @Test func mobileBrowserAuthURLUsesWebSignInWithMobileReturn() {
+    let url = MobileBrowserAuthURLBuilder.signInURL(
+      baseURL: URL(string: "https://jov.ie")!
     )
 
-    #expect(AuthErrorMapper.message(for: error) == "Too many attempts. Try again later.")
+    #expect(url?.absoluteString == "https://jov.ie/signin?mobile_return=/app")
   }
 
-  @Test func authErrorMapperHidesUserCancelledBrowserSession() {
-    let error = NSError(
-      domain: "AuthenticationServices.WebAuthenticationSession",
-      code: 1,
-      userInfo: [NSLocalizedDescriptionKey: "The operation was canceled."]
+  @Test func mobileAuthReturnParserAcceptsTicketCallback() {
+    let result = MobileAuthReturnParser.parse(
+      URL(string: "ie.jov.Jovie://auth-return?ticket=ticket_123&route=%2Fapp%2Fsettings")!
     )
 
-    #expect(AuthErrorMapper.message(for: error) == nil)
+    #expect(result == MobileAuthReturn(ticket: "ticket_123", route: "/app/settings"))
+  }
+
+  @Test func mobileAuthReturnParserRejectsUnsafeReturnRoutes() {
+    let result = MobileAuthReturnParser.parse(
+      URL(string: "ie.jov.Jovie://auth-return?ticket=ticket_123&route=%2F%2Fevil.com")!
+    )
+
+    #expect(result == MobileAuthReturn(ticket: "ticket_123", route: "/app"))
+  }
+
+  @Test func chatLaunchModeOpensChatWithoutChangingReadyState() async throws {
+    let repository = MockRepository(
+      nextResult: .success(
+        MeRepositoryResult(response: .previewReady, isStale: false)
+      )
+    )
+    let appState = AppState(
+      configuration: configuration,
+      launchMode: .uiTestingChat,
+      repository: repository,
+      brightnessManager: MockBrightnessController()
+    )
+
+    await appState.completeLaunch()
+
+    #expect(appState.route == .ready)
+    #expect(appState.dashboardState == .loaded(.previewReady))
+    #expect(appState.launchMode.opensChatOnLaunch == true)
+  }
+
+  @Test func billingURLRedirectsToWebBillingSettings() {
+    let repository = MockRepository(
+      nextResult: .success(
+        MeRepositoryResult(response: .previewReady, isStale: false)
+      )
+    )
+    let appState = AppState(
+      configuration: configuration,
+      launchMode: .live,
+      repository: repository,
+      brightnessManager: MockBrightnessController()
+    )
+
+    #expect(appState.billingURL.absoluteString == "https://jov.ie/app/settings/billing")
   }
 }

--- a/apps/ios/JovieTests/AppStateTests.swift
+++ b/apps/ios/JovieTests/AppStateTests.swift
@@ -167,6 +167,15 @@ struct AppStateTests {
     #expect(url?.absoluteString == "https://jov.ie/signin?mobile_return=/app")
   }
 
+  @Test func mobileBrowserAuthURLFallsBackForUnsafeMobileReturn() {
+    let url = MobileBrowserAuthURLBuilder.signInURL(
+      baseURL: URL(string: "https://jov.ie")!,
+      returnRoute: "https://evil.example/app"
+    )
+
+    #expect(url?.absoluteString == "https://jov.ie/signin?mobile_return=/app")
+  }
+
   @Test func mobileAuthReturnParserAcceptsTicketCallback() {
     let result = MobileAuthReturnParser.parse(
       URL(string: "ie.jov.Jovie://auth-return?ticket=ticket_123&route=%2Fapp%2Fsettings")!

--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -20,34 +20,38 @@ final class JovieUITests: XCTestCase {
       $0.staticTexts["Sign in to Jovie"]
     }
 
-    XCTAssertTrue(app.buttons["Continue with Google"].exists)
-    XCTAssertTrue(app.buttons["Continue with Apple"].exists)
+    XCTAssertTrue(app.buttons["Get started"].exists)
+    XCTAssertFalse(app.buttons["Continue with Google"].exists)
+    XCTAssertFalse(app.buttons["Continue with Apple"].exists)
     XCTAssertFalse(app.staticTexts["Email"].exists)
     XCTAssertFalse(app.buttons["Open Jovie on web"].exists)
     attachScreenshot(named: "signed-out", app: app)
   }
 
-  func testReadyLaunchShowsDashboard() {
+  func testReadyLaunchShowsProfileTab() {
     let app = launchMockApp(launchArgument: "-ui-testing-ready", expectedElementDescription: "\"Copy URL\"") {
       $0.buttons["Copy URL"]
     }
 
     XCTAssertTrue(app.staticTexts["Tim White"].exists)
-    attachScreenshot(named: "dashboard", app: app)
+    XCTAssertTrue(app.buttons["Chat"].exists)
+    XCTAssertTrue(app.buttons["Profile"].exists)
+    XCTAssertTrue(app.buttons["Open Settings"].exists)
+    attachScreenshot(named: "profile", app: app)
   }
 
   func testNeedsOnboardingLaunchShowsContinueOnWeb() {
     let app = launchMockApp(
       launchArgument: "-ui-testing-needs-onboarding",
-      expectedElementDescription: "\"Continue On Web\""
+      expectedElementDescription: "\"Continue on Web\""
     ) {
-      $0.buttons["Continue On Web"]
+      $0.buttons["Continue on Web"]
     }
 
     attachScreenshot(named: "needs-onboarding", app: app)
   }
 
-  func testSettingsPanelLogsOutToSignedOut() {
+  func testFullScreenSettingsLogsOutToSignedOut() {
     let app = launchMockApp(launchArgument: "-ui-testing-settings", expectedElementDescription: "\"Settings\"") {
       $0.staticTexts["Settings"]
     }
@@ -61,23 +65,40 @@ final class JovieUITests: XCTestCase {
     )
   }
 
-  func testShellNavigationRevealsSidebarAndSettings() {
+  func testBottomNavigationSwitchesBetweenChatAndProfile() {
+    let app = launchMockApp(launchArgument: "-ui-testing-chat", expectedElementDescription: "\"Ask Jovie\"") {
+      $0.staticTexts["Ask Jovie"]
+    }
+
+    XCTAssertTrue(app.textFields["Ask Jovie"].exists)
+    XCTAssertTrue(app.buttons["Profile"].exists)
+    attachScreenshot(named: "chat", app: app)
+
+    app.buttons["Profile"].tap()
+
+    XCTAssertTrue(
+      app.buttons["Copy URL"].waitForExistence(timeout: 3),
+      "Bottom nav did not switch to Profile.\n\(app.debugDescription)"
+    )
+
+  }
+
+  func testShellMenuAndSettingsNavigationAreFullScreen() {
     let app = launchMockApp(launchArgument: "-ui-testing-ready", expectedElementDescription: "\"Copy URL\"") {
       $0.buttons["Copy URL"]
     }
-    let window = app.windows.element(boundBy: 0)
 
-    guard revealSidebar(app: app, window: window) else { return }
+    app.buttons["Open Menu"].tap()
     XCTAssertTrue(
-      app.buttons["Dashboard"].waitForExistence(timeout: 3),
-      "Shell navigation did not reveal sidebar.\n\(app.debugDescription)"
+      app.staticTexts["Jovie"].waitForExistence(timeout: 3),
+      "Shell navigation did not reveal the menu.\n\(app.debugDescription)"
     )
 
-    app.buttons["Close Sidebar"].tap()
-    guard revealSettings(app: app, window: window) else { return }
+    app.buttons["Close Menu"].tap()
+    app.buttons["Open Settings"].tap()
     XCTAssertTrue(
       app.staticTexts["Settings"].waitForExistence(timeout: 3),
-      "Shell navigation did not reveal settings.\n\(app.debugDescription)"
+      "Shell navigation did not open settings.\n\(app.debugDescription)"
     )
   }
 
@@ -111,12 +132,8 @@ final class JovieUITests: XCTestCase {
       "Native auth heading did not appear.\n\(app.debugDescription)"
     )
     XCTAssertTrue(
-      app.buttons["Continue with Google"].waitForExistence(timeout: 10),
-      "Native auth Google SSO button did not appear.\n\(app.debugDescription)"
-    )
-    XCTAssertTrue(
-      app.buttons["Continue with Apple"].waitForExistence(timeout: 10),
-      "Native auth Apple SSO button did not appear.\n\(app.debugDescription)"
+      app.buttons["Get started"].waitForExistence(timeout: 10),
+      "Browser auth entry button did not appear.\n\(app.debugDescription)"
     )
   }
 
@@ -129,7 +146,7 @@ final class JovieUITests: XCTestCase {
     app.launch()
 
     let copyURLButton = app.buttons["Copy URL"]
-    let continueOnWebButton = app.buttons["Continue On Web"]
+    let continueOnWebButton = app.buttons["Continue on Web"]
     let deadline = Date().addingTimeInterval(25)
 
     while Date() < deadline {
@@ -236,61 +253,4 @@ final class JovieUITests: XCTestCase {
     add(attachment)
   }
 
-  private func edgeDrag(in element: XCUIElement, from start: CGVector, to end: CGVector) {
-    let startCoordinate = element.coordinate(withNormalizedOffset: start)
-    let endCoordinate = element.coordinate(withNormalizedOffset: end)
-    startCoordinate.press(forDuration: 0.08, thenDragTo: endCoordinate)
-  }
-
-  private func revealSidebar(
-    app: XCUIApplication,
-    window: XCUIElement,
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) -> Bool {
-    edgeDrag(in: window, from: CGVector(dx: 0.01, dy: 0.5), to: CGVector(dx: 0.72, dy: 0.5))
-    if app.buttons["Dashboard"].waitForExistence(timeout: 1) { return true }
-
-    edgeDrag(in: window, from: CGVector(dx: 0.05, dy: 0.5), to: CGVector(dx: 0.82, dy: 0.5))
-    if app.buttons["Dashboard"].waitForExistence(timeout: 1) { return true }
-
-    let openSidebarButton = app.buttons["Open Sidebar"]
-    guard openSidebarButton.waitForExistence(timeout: 2) else {
-      XCTFail(
-        "Open Sidebar did not appear after the sidebar edge-swipe attempts.\n\(app.debugDescription)",
-        file: file,
-        line: line
-      )
-      return false
-    }
-
-    openSidebarButton.tap()
-    return true
-  }
-
-  private func revealSettings(
-    app: XCUIApplication,
-    window: XCUIElement,
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) -> Bool {
-    edgeDrag(in: window, from: CGVector(dx: 0.99, dy: 0.5), to: CGVector(dx: 0.28, dy: 0.5))
-    if app.staticTexts["Settings"].waitForExistence(timeout: 1) { return true }
-
-    edgeDrag(in: window, from: CGVector(dx: 0.95, dy: 0.5), to: CGVector(dx: 0.18, dy: 0.5))
-    if app.staticTexts["Settings"].waitForExistence(timeout: 1) { return true }
-
-    let openSettingsButton = app.buttons["Open Settings"]
-    guard openSettingsButton.waitForExistence(timeout: 2) else {
-      XCTFail(
-        "Open Settings did not appear after the settings edge-swipe attempts.\n\(app.debugDescription)",
-        file: file,
-        line: line
-      )
-      return false
-    }
-
-    openSettingsButton.tap()
-    return true
-  }
 }

--- a/apps/ios/scripts/capture-screenshots.sh
+++ b/apps/ios/scripts/capture-screenshots.sh
@@ -41,9 +41,10 @@ run_with_timeout() {
 "$SCRIPT_DIR/ensure-configuration.sh"
 
 APP_PATH="$DERIVED_DATA_PATH/Build/Products/Debug-iphonesimulator/Jovie.app"
-if [[ -d "$APP_PATH" ]]; then
+if [[ -d "$APP_PATH" && "${IOS_SCREENSHOT_REUSE_BUILD:-0}" == "1" ]]; then
   echo "Using existing built app at $APP_PATH"
 else
+  rm -rf "$DERIVED_DATA_PATH"
   run_with_timeout "${IOS_SCREENSHOT_BUILD_TIMEOUT:-300}" xcodebuild build \
     -project "$PROJECT_PATH" \
     -scheme "$SCHEME" \
@@ -183,10 +184,11 @@ fi
 prepare_device "$IPHONE_UDID"
 capture "$IPHONE_UDID" "00-loading" "-ui-testing-splash"
 capture "$IPHONE_UDID" "01-signed-out" "-ui-testing-signed-out"
-capture "$IPHONE_UDID" "02-dashboard" "-ui-testing-ready"
+capture "$IPHONE_UDID" "02-profile" "-ui-testing-ready"
 capture "$IPHONE_UDID" "03-fullscreen-qr" "-ui-testing-venue-mode"
 capture "$IPHONE_UDID" "04-settings" "-ui-testing-settings"
 capture "$IPHONE_UDID" "05-needs-onboarding" "-ui-testing-needs-onboarding"
+capture "$IPHONE_UDID" "06-chat" "-ui-testing-chat"
 
 IPAD_UDID="$(pick_device "^iPad")"
 if [[ -n "$IPAD_UDID" ]]; then
@@ -195,7 +197,7 @@ if [[ -n "$IPAD_UDID" ]]; then
     [[ -z "$candidate_udid" ]] && continue
 
     if IOS_SCREENSHOT_BOOT_TIMEOUT="${IOS_SCREENSHOT_IPAD_BOOT_TIMEOUT:-90}" prepare_device "$candidate_udid" &&
-      capture "$candidate_udid" "06-ipad-shell" "-ui-testing-ready"; then
+      capture "$candidate_udid" "07-ipad-shell" "-ui-testing-ready"; then
       captured_ipad=true
       break
     fi

--- a/apps/web/app/(auth)/signin/SignInPageClient.tsx
+++ b/apps/web/app/(auth)/signin/SignInPageClient.tsx
@@ -12,6 +12,11 @@ import {
   buildDesktopAuthReturnPath,
   sanitizeDesktopReturnRoute,
 } from '@/lib/desktop/auth-return';
+import {
+  buildAuthRouteUrlWithMobileReturn,
+  buildMobileAuthReturnPath,
+  sanitizeMobileReturnRoute,
+} from '@/lib/mobile/auth-return';
 
 /**
  * Shows a banner when the OAuth provider returned an error code.
@@ -103,12 +108,19 @@ export function SignInPageClient() {
   const desktopReturnRoute = sanitizeDesktopReturnRoute(
     searchParams.get('desktop_return')
   );
-  const signUpUrl = desktopReturnRoute
-    ? buildAuthRouteUrlWithDesktopReturn(APP_ROUTES.SIGNUP, searchParams)
-    : buildAuthRouteUrl(APP_ROUTES.SIGNUP, searchParams);
-  const fallbackRedirectUrl = desktopReturnRoute
-    ? buildDesktopAuthReturnPath(desktopReturnRoute)
-    : undefined;
+  const mobileReturnRoute = sanitizeMobileReturnRoute(
+    searchParams.get('mobile_return')
+  );
+  const signUpUrl = mobileReturnRoute
+    ? buildAuthRouteUrlWithMobileReturn(APP_ROUTES.SIGNUP, searchParams)
+    : desktopReturnRoute
+      ? buildAuthRouteUrlWithDesktopReturn(APP_ROUTES.SIGNUP, searchParams)
+      : buildAuthRouteUrl(APP_ROUTES.SIGNUP, searchParams);
+  const fallbackRedirectUrl = mobileReturnRoute
+    ? buildMobileAuthReturnPath(mobileReturnRoute)
+    : desktopReturnRoute
+      ? buildDesktopAuthReturnPath(desktopReturnRoute)
+      : undefined;
   const initialValues = useMemo(
     () => (isValidEmail(email) ? { emailAddress: email } : undefined),
     [email]
@@ -134,7 +146,9 @@ export function SignInPageClient() {
       <AuthShell
         mode='sign-in'
         forceOppositeModeHardNavigation
-        oppositeModeUrl={desktopReturnRoute ? signUpUrl : undefined}
+        oppositeModeUrl={
+          desktopReturnRoute || mobileReturnRoute ? signUpUrl : undefined
+        }
         fallbackRedirectUrl={fallbackRedirectUrl}
         initialValues={initialValues}
       />

--- a/apps/web/app/(auth)/signup/SignUpPageClient.tsx
+++ b/apps/web/app/(auth)/signup/SignUpPageClient.tsx
@@ -21,6 +21,11 @@ import {
   buildDesktopAuthReturnPath,
   sanitizeDesktopReturnRoute,
 } from '@/lib/desktop/auth-return';
+import {
+  buildAuthRouteUrlWithMobileReturn,
+  buildMobileAuthReturnPath,
+  sanitizeMobileReturnRoute,
+} from '@/lib/mobile/auth-return';
 
 /**
  * Persist pre-signup claim data from the homepage hero into sessionStorage,
@@ -206,12 +211,19 @@ export function SignUpPageClient() {
   const desktopReturnRoute = sanitizeDesktopReturnRoute(
     searchParams.get('desktop_return')
   );
-  const signInUrl = desktopReturnRoute
-    ? buildAuthRouteUrlWithDesktopReturn(APP_ROUTES.SIGNIN, searchParams)
-    : buildAuthRouteUrl(APP_ROUTES.SIGNIN, searchParams);
-  const fallbackRedirectUrl = desktopReturnRoute
-    ? buildDesktopAuthReturnPath(desktopReturnRoute)
-    : undefined;
+  const mobileReturnRoute = sanitizeMobileReturnRoute(
+    searchParams.get('mobile_return')
+  );
+  const signInUrl = mobileReturnRoute
+    ? buildAuthRouteUrlWithMobileReturn(APP_ROUTES.SIGNIN, searchParams)
+    : desktopReturnRoute
+      ? buildAuthRouteUrlWithDesktopReturn(APP_ROUTES.SIGNIN, searchParams)
+      : buildAuthRouteUrl(APP_ROUTES.SIGNIN, searchParams);
+  const fallbackRedirectUrl = mobileReturnRoute
+    ? buildMobileAuthReturnPath(mobileReturnRoute)
+    : desktopReturnRoute
+      ? buildDesktopAuthReturnPath(desktopReturnRoute)
+      : undefined;
 
   return (
     <AuthLayout

--- a/apps/web/app/(marketing)/download/page.tsx
+++ b/apps/web/app/(marketing)/download/page.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@jovie/ui';
-import { ArrowDownToLine } from 'lucide-react';
+import { ArrowDownToLine, Smartphone } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import {
@@ -53,7 +53,7 @@ const FAQ_ITEMS = [
 ];
 
 export const metadata: Metadata = {
-  title: 'Download Jovie for Mac',
+  title: 'Download Jovie',
   description: `Download the ${APP_NAME} desktop app for macOS. Code-signed, notarized by Apple, and updates itself in the background.`,
   alternates: {
     canonical: `${BASE_URL}/download`,
@@ -127,6 +127,30 @@ export default async function DownloadPage() {
           </p>
         </div>
       </MarketingHero>
+
+      <MarketingContainer width='prose' className='pb-20'>
+        <section id='ios' className='border-y border-subtle py-10 sm:py-12'>
+          <div className='flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between'>
+            <div>
+              <div className='inline-flex items-center gap-2 text-sm font-medium text-tertiary-token'>
+                <Smartphone className='size-4' aria-hidden='true' />
+                iOS alpha
+              </div>
+              <h2 className='mt-3 text-2xl font-semibold tracking-normal text-primary-token'>
+                Jovie for iPhone is in internal TestFlight.
+              </h2>
+              <p className='mt-3 max-w-[56ch] text-sm leading-6 text-secondary-token'>
+                We are keeping the mobile app private while the internal alpha
+                proves install, auth, Profile QR, Settings, and TestFlight
+                reliability.
+              </p>
+            </div>
+            <div className='inline-flex h-11 shrink-0 items-center justify-center rounded-full border border-subtle px-5 text-sm font-medium text-tertiary-token'>
+              Internal alpha only
+            </div>
+          </div>
+        </section>
+      </MarketingContainer>
 
       <MarketingContainer width='prose' className='pb-20'>
         <section>

--- a/apps/web/app/api/mobile/v1/auth/ticket/route.ts
+++ b/apps/web/app/api/mobile/v1/auth/ticket/route.ts
@@ -1,0 +1,60 @@
+import { auth, clerkClient } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+import { captureError } from '@/lib/error-tracking';
+import { NO_STORE_HEADERS } from '@/lib/http/headers';
+import {
+  buildMobileAuthDeepLink,
+  sanitizeMobileReturnRoute,
+} from '@/lib/mobile/auth-return';
+
+export const runtime = 'nodejs';
+
+const SIGN_IN_TOKEN_TTL_SECONDS = 60;
+
+interface MobileAuthTicketRequest {
+  route?: unknown;
+}
+
+export async function POST(request: Request) {
+  let route = '/app';
+
+  try {
+    const payload = (await request
+      .json()
+      .catch(() => ({}))) as MobileAuthTicketRequest;
+    if (typeof payload.route === 'string') {
+      route = sanitizeMobileReturnRoute(payload.route) ?? '/app';
+    }
+
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const clerk = await clerkClient();
+    const signInToken = await clerk.signInTokens.createSignInToken({
+      userId,
+      expiresInSeconds: SIGN_IN_TOKEN_TTL_SECONDS,
+    });
+
+    return NextResponse.json(
+      {
+        deepLink: buildMobileAuthDeepLink(signInToken.token, route),
+        expiresInSeconds: SIGN_IN_TOKEN_TTL_SECONDS,
+      },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  } catch (error) {
+    await captureError('Mobile auth ticket route failed', error, {
+      route: '/api/mobile/v1/auth/ticket',
+    });
+
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/api/mobile/v1/auth/ticket/route.ts
+++ b/apps/web/app/api/mobile/v1/auth/ticket/route.ts
@@ -6,6 +6,7 @@ import {
   buildMobileAuthDeepLink,
   sanitizeMobileReturnRoute,
 } from '@/lib/mobile/auth-return';
+import { createRateLimitHeaders, generalLimiter } from '@/lib/rate-limit';
 
 export const runtime = 'nodejs';
 
@@ -31,6 +32,22 @@ export async function POST(request: Request) {
       return NextResponse.json(
         { error: 'Unauthorized' },
         { status: 401, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const rateLimit = await generalLimiter.limit(
+      `mobile-auth-ticket:${userId}`
+    );
+    if (!rateLimit.success) {
+      return NextResponse.json(
+        { error: rateLimit.reason ?? 'Rate limit exceeded' },
+        {
+          status: 429,
+          headers: {
+            ...NO_STORE_HEADERS,
+            ...createRateLimitHeaders(rateLimit),
+          },
+        }
       );
     }
 

--- a/apps/web/app/api/mobile/v1/chat/turns/route.ts
+++ b/apps/web/app/api/mobile/v1/chat/turns/route.ts
@@ -1,0 +1,95 @@
+import { auth } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+import { NO_STORE_HEADERS } from '@/lib/http/headers';
+
+export const runtime = 'nodejs';
+
+const NDJSON_HEADERS = {
+  ...NO_STORE_HEADERS,
+  'Content-Type': 'application/x-ndjson; charset=utf-8',
+} as const;
+
+const MAX_TEXT_LENGTH = 4000;
+
+interface MobileChatTurnRequest {
+  readonly conversationId?: unknown;
+  readonly clientTurnId?: unknown;
+  readonly clientMessageId?: unknown;
+  readonly text?: unknown;
+  readonly source?: unknown;
+}
+
+function isValidSource(source: unknown): source is 'typed' {
+  return source === 'typed';
+}
+
+function isValidOptionalString(value: unknown): value is string | undefined {
+  return value === undefined || (typeof value === 'string' && value.length > 0);
+}
+
+function parseMobileChatTurnRequest(value: MobileChatTurnRequest): {
+  readonly conversationId?: string;
+  readonly clientTurnId: string;
+  readonly clientMessageId: string;
+  readonly text: string;
+  readonly source: 'typed';
+} | null {
+  if (
+    !isValidOptionalString(value.conversationId) ||
+    typeof value.clientTurnId !== 'string' ||
+    value.clientTurnId.length === 0 ||
+    typeof value.clientMessageId !== 'string' ||
+    value.clientMessageId.length === 0 ||
+    typeof value.text !== 'string' ||
+    value.text.trim().length === 0 ||
+    value.text.length > MAX_TEXT_LENGTH ||
+    !isValidSource(value.source)
+  ) {
+    return null;
+  }
+
+  return {
+    conversationId: value.conversationId,
+    clientTurnId: value.clientTurnId,
+    clientMessageId: value.clientMessageId,
+    text: value.text.trim(),
+    source: value.source,
+  };
+}
+
+function ndjsonEvent(event: Record<string, unknown>): string {
+  return `${JSON.stringify(event)}\n`;
+}
+
+export async function POST(request: Request) {
+  const { userId } = await auth({ acceptsToken: 'session_token' });
+  if (!userId) {
+    return NextResponse.json(
+      { error: 'Unauthorized' },
+      { status: 401, headers: NO_STORE_HEADERS }
+    );
+  }
+
+  const payload = (await request
+    .json()
+    .catch(() => ({}))) as MobileChatTurnRequest;
+  const parsed = parseMobileChatTurnRequest(payload);
+  if (!parsed) {
+    return NextResponse.json(
+      { error: 'Invalid request body' },
+      { status: 400, headers: NO_STORE_HEADERS }
+    );
+  }
+
+  return new Response(
+    ndjsonEvent({
+      type: 'error',
+      errorCode: 'MOBILE_CHAT_RUNTIME_DISABLED',
+      message: 'Native chat is not enabled for this build.',
+    }),
+    {
+      status: 501,
+      headers: NDJSON_HEADERS,
+    }
+  );
+}

--- a/apps/web/app/api/mobile/v1/ios-access/route.ts
+++ b/apps/web/app/api/mobile/v1/ios-access/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import { env } from '@/lib/env-server';
+import { getAppFlagValue } from '@/lib/flags/server';
+import { NO_STORE_HEADERS } from '@/lib/http/headers';
+import { resolveIOSAlphaAccess } from '@/lib/mobile/ios-alpha-access';
+
+export const runtime = 'nodejs';
+
+export async function GET() {
+  const entitlements = await getCurrentUserEntitlements();
+
+  if (!entitlements.isAuthenticated) {
+    return NextResponse.json(
+      { hasAccess: false, installUrl: null },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  }
+
+  const flagEnabled = await getAppFlagValue('IOS_APP_ALPHA_ACCESS', {
+    userId: entitlements.userId,
+  });
+
+  return NextResponse.json(
+    resolveIOSAlphaAccess({
+      isAuthenticated: entitlements.isAuthenticated,
+      isAdmin: entitlements.isAdmin,
+      flagEnabled,
+      installUrl: env.IOS_TESTFLIGHT_PUBLIC_LINK,
+    }),
+    { status: 200, headers: NO_STORE_HEADERS }
+  );
+}

--- a/apps/web/app/mobile-auth-return/page.tsx
+++ b/apps/web/app/mobile-auth-return/page.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useMemo, useState } from 'react';
+import {
+  buildAuthRouteUrlWithMobileReturn,
+  sanitizeMobileReturnRoute,
+} from '@/lib/mobile/auth-return';
+
+type TicketState =
+  | { status: 'loading' }
+  | { status: 'ready'; deepLink: string }
+  | { status: 'unauthorized'; signInUrl: string }
+  | { status: 'error'; signInUrl: string };
+
+function MobileAuthReturnContent() {
+  const searchParams = useSearchParams();
+  const returnRoute = useMemo(
+    () => sanitizeMobileReturnRoute(searchParams.get('route')) ?? '/app',
+    [searchParams]
+  );
+  const signInUrl = useMemo(
+    () =>
+      buildAuthRouteUrlWithMobileReturn(
+        '/signin',
+        new URLSearchParams({ mobile_return: returnRoute })
+      ),
+    [returnRoute]
+  );
+  const [ticketState, setTicketState] = useState<TicketState>({
+    status: 'loading',
+  });
+
+  useEffect(() => {
+    let isActive = true;
+
+    async function createTicket() {
+      try {
+        const response = await fetch('/api/mobile/v1/auth/ticket', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ route: returnRoute }),
+        });
+
+        if (!isActive) return;
+
+        if (response.status === 401) {
+          setTicketState({ status: 'unauthorized', signInUrl });
+          return;
+        }
+
+        if (!response.ok) {
+          setTicketState({ status: 'error', signInUrl });
+          return;
+        }
+
+        const payload = (await response.json()) as { deepLink?: unknown };
+        if (typeof payload.deepLink !== 'string') {
+          setTicketState({ status: 'error', signInUrl });
+          return;
+        }
+
+        setTicketState({ status: 'ready', deepLink: payload.deepLink });
+        window.location.href = payload.deepLink;
+      } catch {
+        if (isActive) {
+          setTicketState({ status: 'error', signInUrl });
+        }
+      }
+    }
+
+    void createTicket();
+
+    return () => {
+      isActive = false;
+    };
+  }, [returnRoute, signInUrl]);
+
+  const deepLink = ticketState.status === 'ready' ? ticketState.deepLink : null;
+  const signInLink =
+    ticketState.status === 'unauthorized' || ticketState.status === 'error'
+      ? ticketState.signInUrl
+      : null;
+
+  return (
+    <main className='grid min-h-dvh place-items-center bg-[#06070a] px-6 text-white [color-scheme:dark]'>
+      <section className='w-full max-w-sm px-6 py-7 text-center'>
+        <p className='text-[13px] leading-5 text-white/60'>Jovie</p>
+        <h1 className='mt-2 text-[22px] font-semibold leading-7'>
+          Return to the app
+        </h1>
+        <p className='mt-3 text-[14px] leading-5 text-white/64'>
+          {signInLink
+            ? 'Open sign in again to continue.'
+            : 'Authentication is complete. Continue in the Jovie app.'}
+        </p>
+        {deepLink ? (
+          <Link
+            href={deepLink}
+            className='mt-6 inline-flex h-10 w-full items-center justify-center rounded-full bg-white px-4 text-[13px] font-medium text-black transition-colors hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/35'
+          >
+            Open Jovie
+          </Link>
+        ) : null}
+        {signInLink ? (
+          <Link
+            href={signInLink}
+            className='mt-6 inline-flex h-10 w-full items-center justify-center rounded-full bg-white px-4 text-[13px] font-medium text-black transition-colors hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/35'
+          >
+            Sign in
+          </Link>
+        ) : null}
+      </section>
+    </main>
+  );
+}
+
+export default function MobileAuthReturnPage() {
+  return (
+    <Suspense fallback={null}>
+      <MobileAuthReturnContent />
+    </Suspense>
+  );
+}

--- a/apps/web/components/organisms/user-button/UserButton.tsx
+++ b/apps/web/components/organisms/user-button/UserButton.tsx
@@ -13,10 +13,11 @@ import {
   Monitor,
   Settings,
   Shield,
+  Smartphone,
   Sparkles,
 } from 'lucide-react';
 import dynamic from 'next/dynamic';
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Badge } from '@/components/atoms/Badge';
 import { APP_ROUTES } from '@/constants/routes';
 import { useKeyboardShortcutsSafe } from '@/contexts/KeyboardShortcutsContext';
@@ -55,6 +56,10 @@ interface BuildDropdownItemsParams {
   formattedUsername: string | null;
   handleProfile: () => void;
   handleSettings: () => void;
+  iosAlphaAccess: {
+    hasAccess: boolean;
+    installUrl: string | null;
+  };
   handleUsageStats: () => void;
   handleManageBilling: () => void;
   handleUpgrade: () => void;
@@ -74,6 +79,7 @@ function buildDropdownItems({
   formattedUsername,
   handleProfile,
   handleSettings,
+  iosAlphaAccess,
   handleUsageStats,
   handleManageBilling,
   handleUpgrade,
@@ -136,14 +142,28 @@ function buildDropdownItems({
       onClick: handleSettings,
       shortcut: 'G S',
     },
-    {
-      type: 'action',
-      id: 'usage-stats',
-      label: 'Usage Stats',
-      icon: Gauge,
-      onClick: handleUsageStats,
-    },
   ];
+
+  if (iosAlphaAccess.hasAccess) {
+    items.push({
+      type: 'action',
+      id: 'download-ios',
+      label: 'Install iOS Alpha',
+      icon: Smartphone,
+      onClick: () => {
+        const href = iosAlphaAccess.installUrl ?? APP_ROUTES.DOWNLOAD;
+        window.open(href, '_blank', 'noopener,noreferrer');
+      },
+    });
+  }
+
+  items.push({
+    type: 'action',
+    id: 'usage-stats',
+    label: 'Usage Stats',
+    icon: Gauge,
+    onClick: handleUsageStats,
+  });
 
   if (!isElectronRuntime) {
     items.push({
@@ -309,6 +329,13 @@ export function UserButton({
 }: UserButtonProps) {
   const keyboardShortcuts = useKeyboardShortcutsSafe();
   const isElectronRuntime = useIsElectronRuntime();
+  const [iosAlphaAccess, setIOSAlphaAccess] = useState<{
+    hasAccess: boolean;
+    installUrl: string | null;
+  }>({
+    hasAccess: false,
+    installUrl: null,
+  });
   const handleFeedbackSubmit = useCallback(async (feedback: string) => {
     const trimmedFeedback = feedback.trim();
 
@@ -354,6 +381,46 @@ export function UserButton({
 
   const { userImageUrl, displayName, userInitials, formattedUsername } =
     userInfo;
+
+  useEffect(() => {
+    if (!isElectronRuntime || !isLoaded || !user) {
+      setIOSAlphaAccess({ hasAccess: false, installUrl: null });
+      return;
+    }
+
+    let isActive = true;
+
+    async function loadIOSAlphaAccess() {
+      try {
+        const response = await fetch('/api/mobile/v1/ios-access', {
+          cache: 'no-store',
+        });
+        if (!response.ok) return;
+
+        const payload = (await response.json()) as {
+          hasAccess?: unknown;
+          installUrl?: unknown;
+        };
+        if (!isActive) return;
+
+        setIOSAlphaAccess({
+          hasAccess: payload.hasAccess === true,
+          installUrl:
+            typeof payload.installUrl === 'string' ? payload.installUrl : null,
+        });
+      } catch {
+        if (isActive) {
+          setIOSAlphaAccess({ hasAccess: false, installUrl: null });
+        }
+      }
+    }
+
+    void loadIOSAlphaAccess();
+
+    return () => {
+      isActive = false;
+    };
+  }, [isElectronRuntime, isLoaded, user]);
 
   // Handle loading state or no user
   if (!isLoaded || !user) {
@@ -401,6 +468,7 @@ export function UserButton({
     formattedUsername,
     handleProfile,
     handleSettings,
+    iosAlphaAccess,
     handleUsageStats,
     handleManageBilling,
     handleUpgrade,

--- a/apps/web/components/organisms/user-button/UserButton.tsx
+++ b/apps/web/components/organisms/user-button/UserButton.tsx
@@ -70,6 +70,17 @@ interface BuildDropdownItemsParams {
   isElectronRuntime: boolean;
 }
 
+function sanitizeInstallUrl(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
 function buildDropdownItems({
   billingStatus,
   loading,
@@ -151,7 +162,8 @@ function buildDropdownItems({
       label: 'Install iOS Alpha',
       icon: Smartphone,
       onClick: () => {
-        const href = iosAlphaAccess.installUrl ?? APP_ROUTES.DOWNLOAD;
+        const href =
+          sanitizeInstallUrl(iosAlphaAccess.installUrl) ?? APP_ROUTES.DOWNLOAD;
         window.open(href, '_blank', 'noopener,noreferrer');
       },
     });
@@ -395,7 +407,12 @@ export function UserButton({
         const response = await fetch('/api/mobile/v1/ios-access', {
           cache: 'no-store',
         });
-        if (!response.ok) return;
+        if (!response.ok) {
+          if (isActive) {
+            setIOSAlphaAccess({ hasAccess: false, installUrl: null });
+          }
+          return;
+        }
 
         const payload = (await response.json()) as {
           hasAccess?: unknown;
@@ -405,8 +422,7 @@ export function UserButton({
 
         setIOSAlphaAccess({
           hasAccess: payload.hasAccess === true,
-          installUrl:
-            typeof payload.installUrl === 'string' ? payload.installUrl : null,
+          installUrl: sanitizeInstallUrl(payload.installUrl),
         });
       } catch {
         if (isActive) {

--- a/apps/web/lib/desktop/auth-return.test.ts
+++ b/apps/web/lib/desktop/auth-return.test.ts
@@ -23,6 +23,9 @@ describe('desktop auth return helpers', () => {
     expect(sanitizeDesktopReturnRoute('/signin')).toBeNull();
     expect(sanitizeDesktopReturnRoute('/signup/sso-callback')).toBeNull();
     expect(sanitizeDesktopReturnRoute('/auth-return?route=/app')).toBeNull();
+    expect(
+      sanitizeDesktopReturnRoute('/mobile-auth-return?route=/app')
+    ).toBeNull();
     expect(sanitizeDesktopReturnRoute('/api/auth/reset')).toBeNull();
   });
 

--- a/apps/web/lib/desktop/auth-return.ts
+++ b/apps/web/lib/desktop/auth-return.ts
@@ -14,6 +14,7 @@ const AUTH_ROUTE_PREFIXES = [
   '/sso-callback',
   DESKTOP_AUTH_RETURN_PATH,
   DESKTOP_AUTH_HANDOFF_PATH,
+  '/mobile-auth-return',
   '/__clerk',
   '/clerk',
   '/api',

--- a/apps/web/lib/env-server-schema.ts
+++ b/apps/web/lib/env-server-schema.ts
@@ -72,6 +72,7 @@ export const ServerEnvSchema = z.object({
   SPOTIFY_CLIENT_SECRET: z.string().optional(),
   JOVIE_SYSTEM_CLERK_USER_ID: z.string().optional(),
   APPLE_MUSIC_DEVELOPER_TOKEN: z.string().optional(),
+  IOS_TESTFLIGHT_PUBLIC_LINK: z.string().url().optional(),
 
   // Bandsintown configuration
   BANDSINTOWN_APP_ID: z.string().optional(),
@@ -308,6 +309,7 @@ export const ENV_KEYS = [
   'SPOTIFY_CLIENT_SECRET',
   'JOVIE_SYSTEM_CLERK_USER_ID',
   'APPLE_MUSIC_DEVELOPER_TOKEN',
+  'IOS_TESTFLIGHT_PUBLIC_LINK',
   'BANDSINTOWN_APP_ID',
   'BLOB_READ_WRITE_TOKEN',
   'STRIPE_SECRET_KEY',

--- a/apps/web/lib/flags/contracts.ts
+++ b/apps/web/lib/flags/contracts.ts
@@ -19,6 +19,7 @@ export const LEGACY_STATSIG_GATE_KEYS = {
   DESIGN_V1_ONBOARDING: 'design_v1_onboarding',
   CHAT_JANK_MONITOR: 'chat_jank_monitor',
   AI_CONNECTORS_BETA: 'ai_connectors_beta',
+  IOS_APP_ALPHA_ACCESS: 'ios_app_alpha_access',
 } as const;
 
 export type StatsigGateKey =
@@ -41,6 +42,7 @@ export const APP_FLAG_DEFAULTS = {
   CHAT_JANK_MONITOR: false,
   RELEASE_PLAN_DEMO: false,
   AI_CONNECTORS_BETA: false,
+  IOS_APP_ALPHA_ACCESS: false,
   // DESIGN_V1 and all its surface aliases are permanently enabled.
   // Statsig gate "design_v1" is also set to 100% rollout.
   // The true default here ensures the new design is on even if Statsig is
@@ -70,6 +72,7 @@ export const APP_FLAG_KEYS = {
   CHAT_JANK_MONITOR: 'chat_jank_monitor',
   RELEASE_PLAN_DEMO: 'release_plan_demo',
   AI_CONNECTORS_BETA: 'ai_connectors_beta',
+  IOS_APP_ALPHA_ACCESS: 'ios_app_alpha_access',
   DESIGN_V1: 'design_v1',
   SHELL_CHAT_V1: LEGACY_STATSIG_GATE_KEYS.DESIGN_V1,
   DESIGN_V1_RELEASES: LEGACY_STATSIG_GATE_KEYS.DESIGN_V1,
@@ -92,6 +95,7 @@ export const APP_FLAG_OVERRIDE_KEYS = {
   CHAT_JANK_MONITOR: 'code:CHAT_JANK_MONITOR',
   RELEASE_PLAN_DEMO: 'code:RELEASE_PLAN_DEMO',
   AI_CONNECTORS_BETA: 'code:AI_CONNECTORS_BETA',
+  IOS_APP_ALPHA_ACCESS: 'code:IOS_APP_ALPHA_ACCESS',
   DESIGN_V1: 'code:DESIGN_V1',
   SHELL_CHAT_V1: 'code:DESIGN_V1',
   DESIGN_V1_RELEASES: 'code:DESIGN_V1',
@@ -111,6 +115,7 @@ export const APP_FLAG_TO_STATSIG_GATE = {
   STRIPE_CONNECT_ENABLED: LEGACY_STATSIG_GATE_KEYS.STRIPE_CONNECT_ENABLED,
   CHAT_JANK_MONITOR: LEGACY_STATSIG_GATE_KEYS.CHAT_JANK_MONITOR,
   AI_CONNECTORS_BETA: LEGACY_STATSIG_GATE_KEYS.AI_CONNECTORS_BETA,
+  IOS_APP_ALPHA_ACCESS: LEGACY_STATSIG_GATE_KEYS.IOS_APP_ALPHA_ACCESS,
 } as const satisfies Partial<Record<AppFlagName, StatsigGateKey>>;
 
 export type StatsigBackedAppFlagName = keyof typeof APP_FLAG_TO_STATSIG_GATE;
@@ -128,6 +133,7 @@ export const APP_FLAG_DESCRIPTIONS = {
   RELEASE_PLAN_DEMO: 'Release plan demo page (YC wedge)',
   AI_CONNECTORS_BETA:
     'AI Connectors v1 beta (Gmail booking extraction → calendar)',
+  IOS_APP_ALPHA_ACCESS: 'Internal iOS TestFlight alpha install access',
   DESIGN_V1: 'New production design',
   SHELL_CHAT_V1: 'New production design alias for shell and chat',
   DESIGN_V1_RELEASES: 'New production design alias for releases',

--- a/apps/web/lib/flags/registry.ts
+++ b/apps/web/lib/flags/registry.ts
@@ -67,6 +67,7 @@ export const APP_FLAG_REGISTRY = {
   PLAYLIST_ENGINE: buildBooleanFlag('PLAYLIST_ENGINE'),
   ALBUM_ART_GENERATION: buildBooleanFlag('ALBUM_ART_GENERATION'),
   CHAT_JANK_MONITOR: buildBooleanFlag('CHAT_JANK_MONITOR'),
+  IOS_APP_ALPHA_ACCESS: buildBooleanFlag('IOS_APP_ALPHA_ACCESS'),
   // RELEASE_PLAN_DEMO is on by default in dev/preview so QA and the demo
   // recorder can visit /app/dashboard/release-plan without a manual override.
   // Production keeps it off (default=false) — enable via localStorage override

--- a/apps/web/lib/mobile/auth-return.ts
+++ b/apps/web/lib/mobile/auth-return.ts
@@ -1,0 +1,61 @@
+import { APP_ROUTES } from '@/constants/routes';
+import { sanitizeDesktopReturnRoute } from '@/lib/desktop/auth-return';
+
+export const MOBILE_RETURN_PARAM = 'mobile_return';
+export const MOBILE_AUTH_RETURN_PATH = '/mobile-auth-return';
+export const JOVIE_IOS_AUTH_RETURN_URL = 'ie.jov.jovie://auth-return';
+
+interface SearchParamReader {
+  get(key: string): string | null;
+}
+
+function isMobileAuthRoute(route: string): boolean {
+  try {
+    const parsed = new URL(route, 'https://jov.ie');
+    return parsed.pathname === MOBILE_AUTH_RETURN_PATH;
+  } catch {
+    return false;
+  }
+}
+
+export function sanitizeMobileReturnRoute(
+  route: string | null | undefined
+): string | null {
+  const sanitizedRoute = sanitizeDesktopReturnRoute(route);
+  if (!sanitizedRoute || isMobileAuthRoute(sanitizedRoute)) return null;
+
+  return sanitizedRoute;
+}
+
+export function buildMobileAuthReturnPath(route: string): string {
+  const sanitizedRoute =
+    sanitizeMobileReturnRoute(route) ?? APP_ROUTES.DASHBOARD;
+  const url = new URL(MOBILE_AUTH_RETURN_PATH, 'https://jov.ie');
+  url.searchParams.set('route', sanitizedRoute);
+  return `${url.pathname}${url.search}`;
+}
+
+export function buildMobileAuthDeepLink(ticket: string, route: string): string {
+  const sanitizedRoute =
+    sanitizeMobileReturnRoute(route) ?? APP_ROUTES.DASHBOARD;
+  const url = new URL(JOVIE_IOS_AUTH_RETURN_URL);
+  url.searchParams.set('ticket', ticket);
+  url.searchParams.set('route', sanitizedRoute);
+  return url.toString();
+}
+
+export function buildAuthRouteUrlWithMobileReturn(
+  pathname: string,
+  searchParams: SearchParamReader
+): string {
+  const routeUrl = new URL(pathname, 'https://jov.ie');
+  const mobileReturn = sanitizeMobileReturnRoute(
+    searchParams.get(MOBILE_RETURN_PARAM)
+  );
+
+  if (mobileReturn) {
+    routeUrl.searchParams.set(MOBILE_RETURN_PARAM, mobileReturn);
+  }
+
+  return routeUrl.pathname + routeUrl.search;
+}

--- a/apps/web/lib/mobile/ios-alpha-access.ts
+++ b/apps/web/lib/mobile/ios-alpha-access.ts
@@ -1,0 +1,26 @@
+export interface IOSAlphaAccessInput {
+  readonly isAuthenticated: boolean;
+  readonly isAdmin: boolean;
+  readonly flagEnabled: boolean;
+  readonly installUrl: string | null | undefined;
+}
+
+export interface IOSAlphaAccess {
+  readonly hasAccess: boolean;
+  readonly installUrl: string | null;
+}
+
+export function resolveIOSAlphaAccess({
+  isAuthenticated,
+  isAdmin,
+  flagEnabled,
+  installUrl,
+}: IOSAlphaAccessInput): IOSAlphaAccess {
+  const hasAccess = isAuthenticated && (isAdmin || flagEnabled);
+  const trimmedInstallUrl = installUrl?.trim() ?? '';
+
+  return {
+    hasAccess,
+    installUrl: hasAccess && trimmedInstallUrl ? trimmedInstallUrl : null,
+  };
+}

--- a/apps/web/lib/routing/proxy-routing.ts
+++ b/apps/web/lib/routing/proxy-routing.ts
@@ -80,6 +80,9 @@ const AUTH_RESERVED_SEGMENTS = new Set([
   'sign-in',
   'sign-up',
   'sso-callback',
+  'auth-return',
+  'desktop-auth',
+  'mobile-auth-return',
 ]);
 
 const ALL_RESERVED_ROOT_SEGMENTS = new Set<string>([
@@ -131,6 +134,7 @@ export function isProxyRewriteExempt(pathname: string): boolean {
   if (pathname === APP_ROUTES.START) return true;
   if (pathname === APP_ROUTES.ONBOARDING) return true;
   if (pathname === APP_ROUTES.ONBOARDING_CHECKOUT) return true;
+  if (pathname === '/mobile-auth-return') return true;
   return false;
 }
 

--- a/apps/web/tests/components/user-button.test.tsx
+++ b/apps/web/tests/components/user-button.test.tsx
@@ -87,6 +87,7 @@ describe('UserButton billing actions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.sessionStorage.clear();
+    delete document.documentElement.dataset.desktopRuntime;
 
     fetchMock = vi.fn();
     vi.spyOn(globalThis, 'fetch').mockImplementation(fetchMock);
@@ -363,6 +364,36 @@ describe('UserButton billing actions', () => {
     expect(track).toHaveBeenCalledWith(
       'billing_manage_billing_redirected',
       expect.any(Object)
+    );
+  });
+
+  it('falls back to the download page when the iOS alpha install URL is unsafe', async () => {
+    document.documentElement.dataset.desktopRuntime = 'electron';
+    mockUseBillingStatusQuery.mockReturnValue({
+      data: { isPro: true, plan: 'pro', hasStripeCustomer: true },
+      isLoading: false,
+      error: null,
+    } as any);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        hasAccess: true,
+        installUrl: 'javascript:alert(1)',
+      }),
+    });
+    const openMock = vi.spyOn(window, 'open').mockReturnValue(null);
+
+    const user = userEvent.setup();
+    render(<UserButton showUserInfo />);
+    await flushMicrotasks();
+
+    await user.click(screen.getByText('Adele Adkins'));
+    await user.click(await screen.findByText('Install iOS Alpha'));
+
+    expect(openMock).toHaveBeenCalledWith(
+      APP_ROUTES.DOWNLOAD,
+      '_blank',
+      'noopener,noreferrer'
     );
   });
 

--- a/apps/web/tests/e2e/utils/dashboard-route-matrix.ts
+++ b/apps/web/tests/e2e/utils/dashboard-route-matrix.ts
@@ -591,6 +591,7 @@ export const EXCLUDED_ROUTES: Record<string, string> = {
   '/signup/sso-callback': 'Clerk internal',
   '/auth-return': 'Desktop auth return page',
   '/desktop-auth': 'Desktop auth handoff page',
+  '/mobile-auth-return': 'Mobile auth return page',
   '/account': 'Clerk account page',
   '/investor-portal': 'Investor portal (admin-managed)',
   '/investor-portal/:slug': 'Investor portal detail',

--- a/apps/web/tests/unit/api/mobile/v1/auth-ticket.test.ts
+++ b/apps/web/tests/unit/api/mobile/v1/auth-ticket.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  authMock: vi.fn(),
+  captureErrorMock: vi.fn(),
+  createSignInTokenMock: vi.fn(),
+}));
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: hoisted.authMock,
+  clerkClient: vi.fn(async () => ({
+    signInTokens: {
+      createSignInToken: hoisted.createSignInTokenMock,
+    },
+  })),
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: hoisted.captureErrorMock,
+}));
+
+const routeModulePromise = import('@/app/api/mobile/v1/auth/ticket/route');
+
+describe('POST /api/mobile/v1/auth/ticket', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.authMock.mockResolvedValue({ userId: 'user_123' });
+    hoisted.createSignInTokenMock.mockResolvedValue({
+      token: 'ticket_123',
+    });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    hoisted.authMock.mockResolvedValue({ userId: null });
+
+    const { POST } = await routeModulePromise;
+    const response = await POST(
+      new Request('https://jov.ie/api/mobile/v1/auth/ticket', {
+        method: 'POST',
+        body: JSON.stringify({ route: '/app/settings' }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Unauthorized',
+    });
+  });
+
+  it('creates a short-lived sign-in ticket and returns a native deep link', async () => {
+    const { POST } = await routeModulePromise;
+    const response = await POST(
+      new Request('https://jov.ie/api/mobile/v1/auth/ticket', {
+        method: 'POST',
+        body: JSON.stringify({ route: '/app/settings' }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(hoisted.createSignInTokenMock).toHaveBeenCalledWith({
+      userId: 'user_123',
+      expiresInSeconds: 60,
+    });
+    await expect(response.json()).resolves.toEqual({
+      deepLink:
+        'ie.jov.jovie://auth-return?ticket=ticket_123&route=%2Fapp%2Fsettings',
+      expiresInSeconds: 60,
+    });
+  });
+
+  it('falls back to the dashboard for unsafe return routes', async () => {
+    const { POST } = await routeModulePromise;
+    const response = await POST(
+      new Request('https://jov.ie/api/mobile/v1/auth/ticket', {
+        method: 'POST',
+        body: JSON.stringify({ route: 'https://evil.com' }),
+      })
+    );
+
+    await expect(response.json()).resolves.toMatchObject({
+      deepLink: 'ie.jov.jovie://auth-return?ticket=ticket_123&route=%2Fapp',
+    });
+  });
+
+  it('returns 500 when Clerk ticket creation fails', async () => {
+    hoisted.createSignInTokenMock.mockRejectedValue(new Error('Clerk failed'));
+
+    const { POST } = await routeModulePromise;
+    const response = await POST(
+      new Request('https://jov.ie/api/mobile/v1/auth/ticket', {
+        method: 'POST',
+        body: JSON.stringify({ route: '/app' }),
+      })
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Internal server error',
+    });
+    expect(hoisted.captureErrorMock).toHaveBeenCalledWith(
+      'Mobile auth ticket route failed',
+      expect.any(Error),
+      { route: '/api/mobile/v1/auth/ticket' }
+    );
+  });
+});

--- a/apps/web/tests/unit/api/mobile/v1/auth-ticket.test.ts
+++ b/apps/web/tests/unit/api/mobile/v1/auth-ticket.test.ts
@@ -3,7 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const hoisted = vi.hoisted(() => ({
   authMock: vi.fn(),
   captureErrorMock: vi.fn(),
+  createRateLimitHeadersMock: vi.fn(),
   createSignInTokenMock: vi.fn(),
+  rateLimitMock: vi.fn(),
 }));
 
 vi.mock('@clerk/nextjs/server', () => ({
@@ -19,6 +21,13 @@ vi.mock('@/lib/error-tracking', () => ({
   captureError: hoisted.captureErrorMock,
 }));
 
+vi.mock('@/lib/rate-limit', () => ({
+  createRateLimitHeaders: hoisted.createRateLimitHeadersMock,
+  generalLimiter: {
+    limit: hoisted.rateLimitMock,
+  },
+}));
+
 const routeModulePromise = import('@/app/api/mobile/v1/auth/ticket/route');
 
 describe('POST /api/mobile/v1/auth/ticket', () => {
@@ -27,6 +36,15 @@ describe('POST /api/mobile/v1/auth/ticket', () => {
     hoisted.authMock.mockResolvedValue({ userId: 'user_123' });
     hoisted.createSignInTokenMock.mockResolvedValue({
       token: 'ticket_123',
+    });
+    hoisted.createRateLimitHeadersMock.mockReturnValue({
+      'X-RateLimit-Limit': '10',
+    });
+    hoisted.rateLimitMock.mockResolvedValue({
+      success: true,
+      limit: 10,
+      remaining: 9,
+      reset: new Date(Date.now() + 60_000),
     });
   });
 
@@ -62,10 +80,38 @@ describe('POST /api/mobile/v1/auth/ticket', () => {
       userId: 'user_123',
       expiresInSeconds: 60,
     });
+    expect(hoisted.rateLimitMock).toHaveBeenCalledWith(
+      'mobile-auth-ticket:user_123'
+    );
     await expect(response.json()).resolves.toEqual({
       deepLink:
         'ie.jov.jovie://auth-return?ticket=ticket_123&route=%2Fapp%2Fsettings',
       expiresInSeconds: 60,
+    });
+  });
+
+  it('rate limits ticket creation before calling Clerk', async () => {
+    hoisted.rateLimitMock.mockResolvedValue({
+      success: false,
+      limit: 10,
+      remaining: 0,
+      reset: new Date(Date.now() + 60_000),
+      reason: 'Too many sign-in attempts',
+    });
+
+    const { POST } = await routeModulePromise;
+    const response = await POST(
+      new Request('https://jov.ie/api/mobile/v1/auth/ticket', {
+        method: 'POST',
+        body: JSON.stringify({ route: '/app/settings' }),
+      })
+    );
+
+    expect(response.status).toBe(429);
+    expect(hoisted.createSignInTokenMock).not.toHaveBeenCalled();
+    expect(hoisted.createRateLimitHeadersMock).toHaveBeenCalled();
+    await expect(response.json()).resolves.toEqual({
+      error: 'Too many sign-in attempts',
     });
   });
 

--- a/apps/web/tests/unit/api/mobile/v1/chat-turns.test.ts
+++ b/apps/web/tests/unit/api/mobile/v1/chat-turns.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  authMock: vi.fn(),
+}));
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: hoisted.authMock,
+}));
+
+const routeModulePromise = import('@/app/api/mobile/v1/chat/turns/route');
+
+async function text(response: Response) {
+  return response.text();
+}
+
+describe('POST /api/mobile/v1/chat/turns', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.authMock.mockResolvedValue({ userId: 'user_123' });
+  });
+
+  it('returns 401 when the mobile session token is missing', async () => {
+    hoisted.authMock.mockResolvedValue({ userId: null });
+
+    const { POST } = await routeModulePromise;
+    const response = await POST(
+      new Request('https://jov.ie/api/mobile/v1/chat/turns', {
+        method: 'POST',
+        body: JSON.stringify({
+          clientTurnId: 'turn_123',
+          clientMessageId: 'msg_123',
+          text: 'Help me launch my release',
+          source: 'typed',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    await expect(response.json()).resolves.toEqual({
+      error: 'Unauthorized',
+    });
+  });
+
+  it('validates required mobile turn ids before the runtime starts', async () => {
+    const { POST } = await routeModulePromise;
+    const response = await POST(
+      new Request('https://jov.ie/api/mobile/v1/chat/turns', {
+        method: 'POST',
+        body: JSON.stringify({
+          text: 'Help me launch my release',
+          source: 'typed',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Invalid request body',
+    });
+  });
+
+  it('fails closed with an NDJSON error event until native chat runtime is enabled', async () => {
+    const { POST } = await routeModulePromise;
+    const response = await POST(
+      new Request('https://jov.ie/api/mobile/v1/chat/turns', {
+        method: 'POST',
+        body: JSON.stringify({
+          clientTurnId: 'turn_123',
+          clientMessageId: 'msg_123',
+          text: 'Help me launch my release',
+          source: 'typed',
+        }),
+      })
+    );
+
+    expect(response.status).toBe(501);
+    expect(response.headers.get('Content-Type')).toBe(
+      'application/x-ndjson; charset=utf-8'
+    );
+    await expect(text(response)).resolves.toBe(
+      '{"type":"error","errorCode":"MOBILE_CHAT_RUNTIME_DISABLED","message":"Native chat is not enabled for this build."}\n'
+    );
+  });
+});

--- a/apps/web/tests/unit/api/mobile/v1/ios-access.test.ts
+++ b/apps/web/tests/unit/api/mobile/v1/ios-access.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  getCurrentUserEntitlementsMock: vi.fn(),
+  getAppFlagValueMock: vi.fn(),
+}));
+
+vi.mock('@/lib/entitlements/server', () => ({
+  getCurrentUserEntitlements: hoisted.getCurrentUserEntitlementsMock,
+}));
+
+vi.mock('@/lib/flags/server', () => ({
+  getAppFlagValue: hoisted.getAppFlagValueMock,
+}));
+
+const routeModulePromise = import('@/app/api/mobile/v1/ios-access/route');
+
+describe('GET /api/mobile/v1/ios-access', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.IOS_TESTFLIGHT_PUBLIC_LINK;
+    hoisted.getCurrentUserEntitlementsMock.mockResolvedValue({
+      isAuthenticated: true,
+      userId: 'user_123',
+      isAdmin: false,
+    });
+    hoisted.getAppFlagValueMock.mockResolvedValue(false);
+  });
+
+  it('returns no-store signed-out access state', async () => {
+    hoisted.getCurrentUserEntitlementsMock.mockResolvedValue({
+      isAuthenticated: false,
+      userId: null,
+      isAdmin: false,
+    });
+
+    const { GET } = await routeModulePromise;
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    await expect(response.json()).resolves.toEqual({
+      hasAccess: false,
+      installUrl: null,
+    });
+    expect(hoisted.getAppFlagValueMock).not.toHaveBeenCalled();
+  });
+
+  it('allows admins through even when the rollout gate is off', async () => {
+    process.env.IOS_TESTFLIGHT_PUBLIC_LINK =
+      'https://testflight.apple.com/join/example';
+    hoisted.getCurrentUserEntitlementsMock.mockResolvedValue({
+      isAuthenticated: true,
+      userId: 'admin_123',
+      isAdmin: true,
+    });
+
+    const { GET } = await routeModulePromise;
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      hasAccess: true,
+      installUrl: 'https://testflight.apple.com/join/example',
+    });
+    expect(hoisted.getAppFlagValueMock).toHaveBeenCalledWith(
+      'IOS_APP_ALPHA_ACCESS',
+      { userId: 'admin_123' }
+    );
+  });
+
+  it('allows rollout-gated alpha users', async () => {
+    process.env.IOS_TESTFLIGHT_PUBLIC_LINK =
+      'https://testflight.apple.com/join/example';
+    hoisted.getAppFlagValueMock.mockResolvedValue(true);
+
+    const { GET } = await routeModulePromise;
+    const response = await GET();
+
+    await expect(response.json()).resolves.toEqual({
+      hasAccess: true,
+      installUrl: 'https://testflight.apple.com/join/example',
+    });
+  });
+});

--- a/apps/web/tests/unit/app/signin-page.test.tsx
+++ b/apps/web/tests/unit/app/signin-page.test.tsx
@@ -214,4 +214,24 @@ describe('signin page', () => {
       '/signup?desktop_return=%2Fapp%2Fsettings%3Ftab%3Dbilling'
     );
   });
+
+  it('uses mobile_return for mobile browser auth fallback and cross-link', async () => {
+    searchParamsState.value = 'mobile_return=%2Fapp%2Fsettings';
+
+    render(<SignInPage />);
+
+    await waitFor(() => {
+      expect(clerkSignInMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(clerkSignInMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signUpUrl: fullAuthUrl('/signup?mobile_return=%2Fapp%2Fsettings'),
+        fallbackRedirectUrl: '/mobile-auth-return?route=%2Fapp%2Fsettings',
+      })
+    );
+    expect(routerPrefetchMock).toHaveBeenCalledWith(
+      '/signup?mobile_return=%2Fapp%2Fsettings'
+    );
+  });
 });

--- a/apps/web/tests/unit/app/signup-page.test.tsx
+++ b/apps/web/tests/unit/app/signup-page.test.tsx
@@ -247,6 +247,23 @@ describe('signup page', () => {
     );
   });
 
+  it('uses mobile_return for mobile browser auth fallback and sign-in link', async () => {
+    searchParamsState.value = 'mobile_return=%2Fapp';
+
+    render(<SignUpPage />);
+
+    await waitFor(() => {
+      expect(clerkSignUpMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(clerkSignUpMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signInUrl: fullAuthUrl('/signin?mobile_return=%2Fapp'),
+        fallbackRedirectUrl: '/mobile-auth-return?route=%2Fapp',
+      })
+    );
+  });
+
   it('ignores invalid plan values and does not track plan intent', async () => {
     searchParamsState.value = 'plan=not-a-plan&handle=TestHandle';
     validatePlanMock.mockReturnValue(null);

--- a/apps/web/tests/unit/lib/mobile/auth-return.test.ts
+++ b/apps/web/tests/unit/lib/mobile/auth-return.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAuthRouteUrlWithMobileReturn,
+  buildMobileAuthDeepLink,
+  buildMobileAuthReturnPath,
+  sanitizeMobileReturnRoute,
+} from '@/lib/mobile/auth-return';
+
+describe('mobile auth return helpers', () => {
+  it('keeps same-app relative mobile return routes', () => {
+    expect(sanitizeMobileReturnRoute('/app/settings?tab=billing')).toBe(
+      '/app/settings?tab=billing'
+    );
+  });
+
+  it('rejects unsafe and auth-loop mobile return routes', () => {
+    expect(sanitizeMobileReturnRoute('https://evil.com/app')).toBeNull();
+    expect(sanitizeMobileReturnRoute('//evil.com/app')).toBeNull();
+    expect(sanitizeMobileReturnRoute('/%2F%2Fevil.com')).toBeNull();
+    expect(
+      sanitizeMobileReturnRoute('/mobile-auth-return?route=/app')
+    ).toBeNull();
+    expect(sanitizeMobileReturnRoute('/signin')).toBeNull();
+    expect(sanitizeMobileReturnRoute('/api/mobile/v1/me')).toBeNull();
+  });
+
+  it('builds the mobile auth-return page and app deep link', () => {
+    expect(buildMobileAuthReturnPath('/app/settings')).toBe(
+      '/mobile-auth-return?route=%2Fapp%2Fsettings'
+    );
+    expect(buildMobileAuthDeepLink('ticket_123', '/app/settings')).toBe(
+      'ie.jov.jovie://auth-return?ticket=ticket_123&route=%2Fapp%2Fsettings'
+    );
+  });
+
+  it('preserves only sanitized mobile_return on auth cross-links', () => {
+    expect(
+      buildAuthRouteUrlWithMobileReturn(
+        '/signup',
+        new URLSearchParams(
+          'mobile_return=%2Fapp%2Fsettings&redirect_url=%2Fignored'
+        )
+      )
+    ).toBe('/signup?mobile_return=%2Fapp%2Fsettings');
+
+    expect(
+      buildAuthRouteUrlWithMobileReturn(
+        '/signin',
+        new URLSearchParams('mobile_return=https%3A%2F%2Fevil.com')
+      )
+    ).toBe('/signin');
+  });
+});

--- a/apps/web/tests/unit/lib/mobile/ios-alpha-access.test.ts
+++ b/apps/web/tests/unit/lib/mobile/ios-alpha-access.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { resolveIOSAlphaAccess } from '@/lib/mobile/ios-alpha-access';
+
+describe('resolveIOSAlphaAccess', () => {
+  it('keeps signed-out users out of the iOS alpha', () => {
+    expect(
+      resolveIOSAlphaAccess({
+        isAuthenticated: false,
+        isAdmin: false,
+        flagEnabled: true,
+        installUrl: 'https://testflight.apple.com/join/example',
+      })
+    ).toEqual({
+      hasAccess: false,
+      installUrl: null,
+    });
+  });
+
+  it('allows recently reverified admins even when the rollout gate is off', () => {
+    expect(
+      resolveIOSAlphaAccess({
+        isAuthenticated: true,
+        isAdmin: true,
+        flagEnabled: false,
+        installUrl: 'https://testflight.apple.com/join/example',
+      })
+    ).toEqual({
+      hasAccess: true,
+      installUrl: 'https://testflight.apple.com/join/example',
+    });
+  });
+
+  it('allows signed-in users when the iOS alpha rollout gate is on', () => {
+    expect(
+      resolveIOSAlphaAccess({
+        isAuthenticated: true,
+        isAdmin: false,
+        flagEnabled: true,
+        installUrl: 'https://testflight.apple.com/join/example',
+      })
+    ).toEqual({
+      hasAccess: true,
+      installUrl: 'https://testflight.apple.com/join/example',
+    });
+  });
+
+  it('does not expose an install URL until release plumbing provides one', () => {
+    expect(
+      resolveIOSAlphaAccess({
+        isAuthenticated: true,
+        isAdmin: true,
+        flagEnabled: true,
+        installUrl: '',
+      })
+    ).toEqual({
+      hasAccess: true,
+      installUrl: null,
+    });
+  });
+});

--- a/apps/web/tests/unit/lib/proxy-url-mapping.test.ts
+++ b/apps/web/tests/unit/lib/proxy-url-mapping.test.ts
@@ -58,6 +58,9 @@ describe('proxy routing helpers', () => {
       expect(categorizePath('/').isProtectedPath).toBe(false);
       expect(categorizePath('/pricing').isProtectedPath).toBe(false);
       expect(categorizePath('/tim').isProtectedPath).toBe(false);
+      expect(
+        categorizePath('/mobile-auth-return').publicProfileCandidate
+      ).toBeNull();
     });
 
     it('recognizes auth entrypoints and callback aliases', () => {

--- a/docs/FEATURE_REGISTRY.md
+++ b/docs/FEATURE_REGISTRY.md
@@ -59,6 +59,7 @@ This document is the canonical feature list for Jovie. It is designed for onboar
 | Monetization | Earnings dashboard | Shipped | Pro+ | None | /dashboard/earnings |
 | AI Assistant | AI assistant (daily message limits by plan) | Shipped | Free+/Pro+/Growth | None | Plan limits: 25/100/500 msgs |
 | AI Connectors | Gmail booking email to Google Calendar auto-add | Shipped (flagged) | Flag-gated | `ai_connectors_beta` | Closed beta; default off; allowlist design-partner DJs post-merge |
+| Mobile App | iOS internal TestFlight alpha | Shipped (flagged) | Admin / flag-gated | `ios_app_alpha_access` | Internal install access only; public marketing remains off |
 | Brand | Remove Jovie branding | Shipped | Pro+ | None | Entitlement-backed (`canRemoveBranding`) |
 | Growth (Coming Soon) | A/B testing | Planned | Growth | None | Smart link variant testing |
 | Growth (Coming Soon) | Automated follow-ups | Planned | Growth | None | Auto-follow-up emails to fans |

--- a/docs/STATSIG_FEATURE_GATES.md
+++ b/docs/STATSIG_FEATURE_GATES.md
@@ -23,6 +23,7 @@ experiments used by the web app.
 | `stripe-connect-enabled` | `LEGACY_STATSIG_GATE_KEYS.STRIPE_CONNECT_ENABLED` | `false` | Stripe Connect payouts (settings + payment routes) | Active |
 | `chat_jank_monitor` | `LEGACY_STATSIG_GATE_KEYS.CHAT_JANK_MONITOR` | `false` | Chat jank instrumentation (message continuity + streaming) | Active |
 | `ai_connectors_beta` | `LEGACY_STATSIG_GATE_KEYS.AI_CONNECTORS_BETA` | `false` | AI Connector v1 closed beta — Gmail booking email → Google Calendar event flow | Active |
+| `ios_app_alpha_access` | `LEGACY_STATSIG_GATE_KEYS.IOS_APP_ALPHA_ACCESS` | `false` | Internal iOS TestFlight install access | Active |
 | `ai_chat_disabled` | `CHAT_KILL_SWITCH_GATES.DISABLED` | `false` | Emergency kill switch for `/api/chat` | Active |
 | `ai_chat_force_light` | `CHAT_KILL_SWITCH_GATES.FORCE_LIGHT` | `false` | Runtime switch to route `/api/chat` to the lighter model | Active |
 

--- a/docs/env.md
+++ b/docs/env.md
@@ -59,6 +59,12 @@ The public URL of your application.
 
 **Default:** `https://jov.ie`
 
+### `IOS_TESTFLIGHT_PUBLIC_LINK`
+
+Optional internal TestFlight install URL used by authenticated, alpha-gated iOS
+download surfaces. Leave unset to keep the iOS alpha visible but not directly
+installable from web UI.
+
 ## Feature Flags (Statsig)
 
 ### `STATSIG_SERVER_SECRET`

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -272,7 +272,8 @@ platform :ios do
       api_key: api_key,
       app_identifier: APP_IDENTIFIER,
       ipa: File.join(DEFAULT_ARTIFACT_DIR, "Jovie.ipa"),
-      skip_waiting_for_build_processing: true,
+      skip_waiting_for_build_processing: false,
+      wait_processing_timeout_duration: ENV.fetch("TESTFLIGHT_PROCESSING_TIMEOUT", "3600").to_i,
       distribute_external: false,
       changelog: ENV.fetch("TESTFLIGHT_CHANGELOG", "Internal iOS foundation build #{current_build_number}")
     )


### PR DESCRIPTION
## Summary
- JOV-2549: ship the internal iOS alpha foundation: browser-owned auth return, full-screen dark native shell, Profile QR tab, full-screen Settings/logout, screenshot launch modes, and Track B native chat shell/contract stub.
- Gate iOS install surfaces behind `ios_app_alpha_access`, add the Electron install affordance, and keep `/download` public-safe/static.
- JOV-2550: public launch re-evaluation issue created with the launch metrics from the reviewed plan.
- Fastlane `beta` now waits for TestFlight processing instead of returning immediately after upload.

## Verification
- `pnpm biome check --write apps/web docs`
- `pnpm --filter @jovie/web exec vitest run tests/unit/lib/mobile/ios-alpha-access.test.ts tests/unit/api/mobile/v1/ios-access.test.ts tests/unit/api/mobile/v1/chat-turns.test.ts tests/unit/lib/feature-flags-registry.test.ts tests/unit/lib/flag-registration-guardrail.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/components/user-button.test.tsx tests/unit/api/mobile/v1/me.test.ts tests/unit/api/mobile/v1/auth-ticket.test.ts tests/unit/lib/mobile/auth-return.test.ts tests/unit/app/signin-page.test.tsx tests/unit/app/signup-page.test.tsx tests/unit/lib/proxy-url-mapping.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm run ios:test`
- `pnpm run ios:screenshots`
- `bundle exec fastlane ios ios_tests`
- `bundle exec fastlane ios screenshots`
- push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Screenshot Evidence
Generated locally in `artifacts/ios-screenshots/`:
- `00-loading.png`
- `01-signed-out.png`
- `02-profile.png`
- `03-fullscreen-qr.png`
- `04-settings.png`
- `05-needs-onboarding.png`
- `06-chat.png`
- `07-ipad-shell.png`

## Release Notes
- GitHub repo secrets for Apple/match are present for the `ios-testflight.yml` main-branch upload path.
- Local signed `beta` is covered by JOV-2549 because this Mac is on `/usr/bin/ruby` 2.6 while CI uses Ruby 3.1 with the checked-in Fastlane lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser-driven mobile sign-in flow with deep-link return support
  * iOS TestFlight alpha access via gated install link
  * Mobile UI: Chat and Profile tabs, bottom navigation, and chat composer preview
  * Billing link added to app Settings
  * iOS download option and “iOS alpha” section on the web download page

* **Documentation**
  * Docs updated for iOS TestFlight alpha and env var for TestFlight link

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->