### PR TITLE
fix(legal): tighten document-first legal pages

### DIFF
--- a/apps/web/app/(dynamic)/legal/loading.tsx
+++ b/apps/web/app/(dynamic)/legal/loading.tsx
@@ -13,9 +13,8 @@ export default function LegalLoading() {
         <div className='w-full max-w-3xl border-b border-neutral-200 pb-8 dark:border-white/10'>
           <div className='h-10 w-56 skeleton rounded-md' />
           <div className='mt-3 h-4 w-44 skeleton rounded-md' />
-          <div className='mt-7 border-l border-neutral-300 pl-4 dark:border-white/15'>
-            <div className='h-4 w-36 skeleton rounded-md' />
-            <div className='mt-3 h-4 w-full max-w-xl skeleton rounded-md' />
+          <div className='mt-6 space-y-2'>
+            <div className='h-4 w-full max-w-xl skeleton rounded-md' />
             <div className='mt-2 h-4 w-4/5 max-w-lg skeleton rounded-md' />
           </div>
         </div>

--- a/apps/web/components/molecules/LegalHero.tsx
+++ b/apps/web/components/molecules/LegalHero.tsx
@@ -19,20 +19,9 @@ export function LegalHero({
           Last updated: {lastUpdated}
         </p>
       ) : null}
-      <section
-        aria-labelledby='legal-practical-summary'
-        className='mt-7 border-l border-neutral-300 pl-4 dark:border-white/15'
-      >
-        <h2
-          id='legal-practical-summary'
-          className='text-sm font-medium text-neutral-950 dark:text-white'
-        >
-          Practical Summary
-        </h2>
-        <p className='mt-2 max-w-2xl text-[15px] leading-7 text-neutral-600 dark:text-neutral-400'>
-          {practicalSummary}
-        </p>
-      </section>
+      <p className='mt-6 max-w-2xl text-[15px] leading-7 text-neutral-600 dark:text-neutral-400'>
+        {practicalSummary}
+      </p>
     </header>
   );
 }

--- a/apps/web/tests/e2e/legal.spec.ts
+++ b/apps/web/tests/e2e/legal.spec.ts
@@ -39,7 +39,14 @@ test.describe('Legal Pages', () => {
       await expect(page.locator('h1')).toContainText('Privacy Policy');
       await expect(page.getByText('Last updated: February 2026')).toBeVisible();
       await expect(
-        page.getByRole('heading', { name: 'Practical Summary' })
+        page.getByText('We collect only what is essential')
+      ).toBeVisible();
+      await expect(page.getByRole('button', { name: 'Print' })).toBeVisible();
+      await expect(
+        page.getByRole('button', { name: 'Download PDF' })
+      ).toBeVisible();
+      await expect(
+        page.getByRole('navigation', { name: 'Document navigation' }).first()
       ).toBeVisible();
 
       // Check main section headings (must match actual markdown content)
@@ -107,7 +114,7 @@ test.describe('Legal Pages', () => {
       await expect(page.locator('h1')).toContainText('Terms of Service');
       await expect(page.getByText('Last updated: February 2026')).toBeVisible();
       await expect(
-        page.getByRole('heading', { name: 'Practical Summary' })
+        page.getByText('Jovie is governed by clear policies')
       ).toBeVisible();
 
       // Check main section headings (must match actual markdown content)
@@ -154,6 +161,55 @@ test.describe('Legal Pages', () => {
       await expect(
         page.getByRole('heading', { name: 'Acceptance of Terms' })
       ).toBeVisible();
+    });
+  });
+
+  test.describe('Cookie Policy', () => {
+    test('keeps GFM tables readable without page-level mobile overflow', async ({
+      page,
+    }) => {
+      await page.route('**/api/profile/view', r =>
+        r.fulfill({ status: 200, body: '{}' })
+      );
+      await page.route('**/api/audience/visit', r =>
+        r.fulfill({ status: 200, body: '{}' })
+      );
+      await page.route('**/api/track', r =>
+        r.fulfill({ status: 200, body: '{}' })
+      );
+      await page.setViewportSize({ width: 375, height: 667 });
+      await page.goto('/legal/cookies', { timeout: 180_000 });
+
+      const table = page.locator('table').first();
+      await expect(table).toBeVisible();
+      await expect(
+        page.locator('code').filter({ hasText: 'jv_cc' }).first()
+      ).toBeVisible();
+
+      const overflow = await page.evaluate(() => {
+        const firstTable = document.querySelector('table');
+        const previousScrollLeft = firstTable?.scrollLeft ?? 0;
+        if (firstTable) {
+          firstTable.scrollLeft = 50;
+        }
+        const nextScrollLeft = firstTable?.scrollLeft ?? 0;
+        if (firstTable) {
+          firstTable.scrollLeft = previousScrollLeft;
+        }
+
+        return {
+          documentWidth: document.documentElement.scrollWidth,
+          tableCanScroll: nextScrollLeft > previousScrollLeft,
+          tableFits:
+            (firstTable?.scrollWidth ?? 0) <= (firstTable?.clientWidth ?? 0),
+          viewportWidth: window.innerWidth,
+        };
+      });
+
+      expect(overflow.documentWidth).toBeLessThanOrEqual(
+        overflow.viewportWidth + 2
+      );
+      expect(overflow.tableCanScroll || overflow.tableFits).toBe(true);
     });
   });
 

--- a/apps/web/tests/lib/legal/getLegalDocument.test.ts
+++ b/apps/web/tests/lib/legal/getLegalDocument.test.ts
@@ -21,4 +21,21 @@ describe('getLegalDocument', () => {
     expect(doc.html).toContain('<th>Cookie Name</th>');
     expect(doc.html).toContain('<code>jv_cc</code>');
   });
+
+  it('keeps legal routes fully static', async () => {
+    const layout = await import('@/app/(dynamic)/legal/layout');
+    const routeModules = await Promise.all([
+      import('@/app/(dynamic)/legal/privacy/page'),
+      import('@/app/(dynamic)/legal/terms/page'),
+      import('@/app/(dynamic)/legal/cookies/page'),
+      import('@/app/(dynamic)/legal/dmca/page'),
+    ]);
+
+    expect(layout.revalidate).toBe(false);
+
+    for (const routeModule of routeModules) {
+      expect(routeModule.dynamic).toBe('force-static');
+      expect(routeModule.revalidate).toBe(false);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Simplified the legal hero to title, last updated, and one practical sentence without an extra summary heading.
- Aligned the legal loading skeleton with the final document-first hero shape.
- Added tests for static legal route exports and mobile-safe GFM cookie table behavior.

## Verification
- `pnpm biome check --write 'apps/web/app/(dynamic)/legal/loading.tsx' apps/web/components/molecules/LegalHero.tsx apps/web/tests/lib/legal/getLegalDocument.test.ts apps/web/tests/e2e/legal.spec.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web exec vitest run tests/lib/docs/getMarkdownDocument.test.ts tests/lib/legal/getLegalDocument.test.ts --reporter=verbose`
- `pnpm --filter @jovie/web exec playwright test tests/e2e/legal.spec.ts --project=chromium --reporter=line`
- Pre-push gate: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Risk
- Low. Changes are scoped to legal presentation and tests. Legal markdown content and meaning were not changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined legal page layouts with improved spacing and text presentation.
  * Enhanced Cookie Policy page mobile responsiveness to prevent horizontal overflow on smaller screens.

* **Tests**
  * Added comprehensive Cookie Policy page test coverage.
  * Added verification tests for static legal page routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9552?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->