### PR TITLE
feat(web): simplify empty chat and polish command palette

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -3,11 +3,9 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { ImagePlus } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { JovieMarkElectric } from '@/components/atoms/JovieMarkElectric';
+import { useCallback, useEffect, useRef } from 'react';
 import { useAppFlag } from '@/lib/flags/client';
 import { SUPPORTED_IMAGE_MIME_TYPES } from '@/lib/images/config';
-import { cn } from '@/lib/utils';
 
 import { CHAT_COMPOSER_DOCK_CLASSNAME } from './chat-layout';
 import {
@@ -17,11 +15,9 @@ import {
   ErrorDisplay,
   ScrollToBottom,
 } from './components';
-import { ChatActionCard } from './components/ChatActionCard';
 import { ChatProvidersRegistrar } from './components/ChatProvidersRegistrar';
 import { ChatUsageAlert } from './components/ChatUsageAlert';
 import { EntityResolutionProvider } from './components/EntityResolutionProvider';
-import { SuggestedPrompts } from './components/SuggestedPrompts';
 import {
   useChatImageAttachments,
   useChatJankMonitor,
@@ -33,18 +29,6 @@ import type { JovieChatProps, MessagePart } from './types';
 /** Sentinel ID for the synthetic thinking placeholder */
 const THINKING_PLACEHOLDER_ID = 'thinking-placeholder';
 const VIRTUALIZATION_THRESHOLD = 12;
-
-/**
- * Extracts the first name token for use in the empty-state greeting (e.g. "What are we working on, Alex?").
- * Handles null/undefined/blank by returning null. Splits on whitespace.
- */
-export function getFirstNameForGreeting(
-  name: string | null | undefined
-): string | null {
-  const trimmed = name?.trim();
-  if (!trimmed) return null;
-  return trimmed.split(/\s+/)[0] ?? null;
-}
 
 function findLastAssistantIndex(
   messages: readonly { id: string; role: string }[]
@@ -70,20 +54,12 @@ export function JovieChat({
   onTitleChange,
   avatarUrl,
   username,
-  displayName,
-  isFirstSession = false,
-  actionCards = [],
 }: JovieChatProps) {
   const initialQuerySubmitted = useRef(false);
   const initialSkillApplied = useRef(false);
   const imageFileInputRef = useRef<HTMLInputElement>(null);
   // Track message IDs that were loaded from persistence to skip entrance animation
   const knownMessageIdsRef = useRef<Set<string>>(new Set());
-  const [dismissedActionCardIds, setDismissedActionCardIds] = useState<
-    ReadonlySet<string>
-  >(() => new Set());
-  // Hide neighbouring affordances while the slash picker owns the composer.
-  const [composerPickerOpen, setComposerPickerOpen] = useState(false);
   const {
     input,
     setInput,
@@ -99,7 +75,6 @@ export function JovieChat({
     inputRef,
     handleSubmit,
     handleRetry,
-    handleSuggestedPrompt,
     submitMessage,
     setChatError,
     isRateLimited,
@@ -220,14 +195,6 @@ export function JovieChat({
     ]
   );
 
-  const handleSuggestedPromptWithJank = useCallback(
-    (prompt: string) => {
-      notifyJankSend();
-      handleSuggestedPrompt(prompt);
-    },
-    [handleSuggestedPrompt, notifyJankSend]
-  );
-
   // Notify parent when the conversation title changes
   const prevTitleRef = useRef<string | null>(null);
   useEffect(() => {
@@ -322,14 +289,6 @@ export function JovieChat({
   const isStreaming = status === 'streaming';
   const showThreadView = hasMessages || showPendingBootstrap;
 
-  const handleDismissActionCard = useCallback((cardId: string) => {
-    setDismissedActionCardIds(prev => {
-      const next = new Set(prev);
-      next.add(cardId);
-      return next;
-    });
-  }, []);
-
   // Show skeleton while fetching existing conversation
   if (isLoadingConversation) {
     return (
@@ -378,38 +337,10 @@ export function JovieChat({
     onRemoveLastChip: chipTray.removeLast,
     onAddSkill: chipTray.addSkill,
     onAddEntity: chipTray.addEntity,
-    onPickerOpenChange: setComposerPickerOpen,
     profileId,
   } as const;
 
-  const greetingName =
-    getFirstNameForGreeting(displayName) ?? getFirstNameForGreeting(username);
-  const primaryActionCard =
-    actionCards.find(card => !dismissedActionCardIds.has(card.id)) ?? null;
-  const hasActionCardEmptyLayout = primaryActionCard !== null;
-  const hasComposerActivity =
-    input.trim().length > 0 ||
-    (pendingImages?.length ?? 0) > 0 ||
-    chipTray.chips.length > 0;
-  const showActionCardContent =
-    primaryActionCard !== null &&
-    !hasComposerActivity &&
-    !composerPickerOpen &&
-    !showThreadView;
-  const showSoftSuggestions =
-    !showThreadView &&
-    primaryActionCard === null &&
-    !hasComposerActivity &&
-    !composerPickerOpen;
-  let emptyStateHeading: string;
-  if (isFirstSession) {
-    emptyStateHeading = "Hey, I'm Jovie.";
-  } else {
-    emptyStateHeading = greetingName
-      ? `What are we working on, ${greetingName}?`
-      : 'What are we working on?';
-  }
-  const showBottomComposer = showThreadView || hasActionCardEmptyLayout;
+  const showBottomComposer = showThreadView;
 
   const composerSurface = (
     <div className='mx-auto w-full max-w-[45rem]'>
@@ -498,12 +429,8 @@ export function JovieChat({
         </AnimatePresence>
 
         {/* Persistent scroll viewport (flex-1) + morphing upper content.
-            The former hard switch (showThreadView ? thread-with-dock : centered-empty-with-dupe-composer)
-            is replaced by always-present bottom dock + AnimatePresence on the upper
-            (signals+heading+ornament+suggested vs. messages list). This is the exact
-            mechanical mirror of the OnboardingChat first-turn stabilization.
-            layoutId on ChatInput surface + dock position lock the geometry so hero↔compact
-            and empty↔thread transitions have zero jump or flicker. */}
+            Empty chat intentionally renders only the composer. Thread state
+            owns the message viewport and the persistent bottom dock. */}
         <div className='flex flex-1 flex-col overflow-hidden'>
           <div
             ref={scrollContainerRef}
@@ -516,91 +443,16 @@ export function JovieChat({
                   key='joviechat-empty-upper'
                   className='relative min-h-full'
                 >
-                  {/* Giant Jovie circle mark behind empty thread.
-                      Positioned absolute so it doesn't shift the welcome heading. */}
-                  {!hasActionCardEmptyLayout ? (
-                    <div
-                      aria-hidden
-                      className='pointer-events-none absolute inset-0 flex items-center justify-center select-none anim-calm-breath opacity-35'
-                      data-testid='chat-empty-thread-ornament'
-                    >
-                      <JovieMarkElectric
-                        spark={false}
-                        className='opacity-100'
-                        style={{
-                          width: 'clamp(180px, 34vw, 360px)',
-                          height: 'clamp(180px, 34vw, 360px)',
-                          transform: 'translateY(-16px)',
-                          WebkitMaskImage:
-                            'radial-gradient(circle, rgba(0,0,0,1) 55%, rgba(0,0,0,0.72) 75%, rgba(0,0,0,0) 95%)',
-                          maskImage:
-                            'radial-gradient(circle, rgba(0,0,0,1) 55%, rgba(0,0,0,0.72) 75%, rgba(0,0,0,0) 95%)',
-                        }}
-                      />
-                    </div>
-                  ) : null}
-
                   <div
-                    className={cn(
-                      'relative mx-auto flex min-h-full w-full max-w-[52rem] flex-col items-center justify-center py-8',
-                      hasActionCardEmptyLayout ? 'gap-0' : 'gap-5'
-                    )}
+                    className='relative mx-auto flex min-h-full w-full max-w-[52rem] flex-col items-center justify-center py-8'
                     data-testid='chat-empty-state-composer-region'
                   >
-                    {hasActionCardEmptyLayout ? (
-                      <div
-                        className='mx-auto flex min-h-[172px] w-full max-w-[38rem] items-center justify-center sm:min-h-[148px]'
-                        data-testid='chat-empty-state-action-card-slot'
-                      >
-                        {showActionCardContent ? (
-                          <ChatActionCard
-                            className='h-full'
-                            title={primaryActionCard.title}
-                            body={primaryActionCard.body}
-                            actionLabel={primaryActionCard.actionLabel}
-                            onAct={() =>
-                              handleSuggestedPromptWithJank(
-                                primaryActionCard.prompt
-                              )
-                            }
-                            onDismiss={() =>
-                              handleDismissActionCard(primaryActionCard.id)
-                            }
-                          />
-                        ) : null}
-                      </div>
-                    ) : (
-                      <>
-                        <h1
-                          className={cn(
-                            'text-balance text-center text-[2rem] font-semibold leading-[1.1] text-primary-token sm:text-[2.35rem] md:text-[2.65rem]',
-                            composerPickerOpen &&
-                              'pointer-events-none opacity-0'
-                          )}
-                          aria-hidden={composerPickerOpen ? 'true' : undefined}
-                        >
-                          {emptyStateHeading}
-                        </h1>
-                        <div
-                          className='w-full'
-                          data-testid='chat-empty-state-centered-composer'
-                        >
-                          {composerSurface}
-                        </div>
-                        <div
-                          className='min-h-[38px] w-full'
-                          data-testid='chat-empty-state-soft-suggestions-slot'
-                        >
-                          {showSoftSuggestions ? (
-                            <SuggestedPrompts
-                              onSelect={handleSuggestedPromptWithJank}
-                              isFirstSession={isFirstSession}
-                              layout='rail'
-                            />
-                          ) : null}
-                        </div>
-                      </>
-                    )}
+                    <div
+                      className='w-full'
+                      data-testid='chat-empty-state-centered-composer'
+                    >
+                      {composerSurface}
+                    </div>
                   </div>
                 </div>
               ) : (
@@ -702,11 +554,8 @@ export function JovieChat({
           </div>
 
           {/*
-            Persistent always-bottom composer dock.
-            No more conditional + justify-center teleport for the input on first message.
-            Variant (hero/compact) changes are smoothed by the layoutId on the inner
-            motion surface. All transient chrome (alerts, rate, error) lives here for both
-            empty and thread states.
+            Thread composer dock. Empty chat keeps the same composer surface centered
+            above, while active threads pin it below the message viewport.
           */}
           {showBottomComposer ? (
             <div

--- a/apps/web/components/organisms/CmdKPalette.tsx
+++ b/apps/web/components/organisms/CmdKPalette.tsx
@@ -205,6 +205,19 @@ export function CmdKPalette({
     if (!open) return;
     function onKey(e: KeyboardEvent) {
       if (e.isComposing) return;
+      if (
+        (e.metaKey || e.ctrlKey) &&
+        !e.altKey &&
+        !e.shiftKey &&
+        (e.key === '1' || e.key === '2' || e.key === '3')
+      ) {
+        const nextIndex = Number(e.key) - 1;
+        if (nextIndex < flatItems.length) {
+          e.preventDefault();
+          setSelectedIndex(nextIndex);
+        }
+        return;
+      }
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         setSelectedIndex(prev =>
@@ -228,7 +241,7 @@ export function CmdKPalette({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className='overflow-hidden rounded-[18px] border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-0 shadow-popover sm:max-w-[560px]'
+        className='overflow-hidden rounded-xl border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-0 shadow-popover sm:max-w-[560px]'
         hideClose
       >
         <DialogPrimitive.Title className='sr-only'>
@@ -242,7 +255,7 @@ export function CmdKPalette({
           data-testid='shared-command-palette'
           data-surface='cmdk'
         >
-          <div className='flex items-center gap-2.5 border-b border-(--linear-app-frame-seam) px-4 py-3'>
+          <div className='flex items-center gap-2 border-b border-(--linear-app-frame-seam) px-3.5 py-2.5'>
             <Search
               className='size-4 shrink-0 text-tertiary-token'
               aria-hidden='true'
@@ -259,12 +272,12 @@ export function CmdKPalette({
               className='flex-1 appearance-none bg-transparent text-sm text-primary-token outline-none placeholder:text-tertiary-token focus:outline-none focus-visible:outline-none focus-visible:shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_45%,transparent)]'
               aria-label='Command palette search'
             />
-            <span className='hidden shrink-0 rounded-md border border-(--linear-app-frame-seam) bg-surface-1 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-tertiary-token sm:inline'>
+            <span className='hidden shrink-0 px-1 text-[11px] font-medium text-quaternary-token sm:inline'>
               Esc
             </span>
           </div>
           <div
-            className='max-h-[420px] overflow-y-auto p-[5px]'
+            className='max-h-[420px] overflow-y-auto px-1.5 pb-1.5 pt-1'
             role='listbox'
             aria-label='Command palette results'
           >
@@ -274,6 +287,8 @@ export function CmdKPalette({
               setSelectedIndex={setSelectedIndex}
               commitIndex={commitIndex}
               emptyHint='No matches.'
+              variant='cmdk'
+              showIndexedShortcuts
             />
           </div>
         </div>

--- a/apps/web/components/organisms/SharedCommandPalette.tsx
+++ b/apps/web/components/organisms/SharedCommandPalette.tsx
@@ -25,6 +25,8 @@ import {
   type PickerItem,
   PickerRow,
   pickerItemKey,
+  RowBody,
+  RowVisual,
 } from '../jovie/components/picker-rows';
 
 export interface PaletteSection {
@@ -135,6 +137,61 @@ interface PaletteListProps {
   readonly emptyHint: ReactNode;
   /** When supplied, rows render with `id={listId}-row-{idx}` for aria-activedescendant. */
   readonly listId?: string;
+  readonly variant?: 'inline' | 'cmdk';
+  readonly showIndexedShortcuts?: boolean;
+}
+
+const CMD_KEY_LABEL = String.fromCodePoint(0x2318);
+
+interface CmdKPaletteRowProps {
+  readonly item: PickerItem;
+  readonly index: number;
+  readonly isActive: boolean;
+  readonly onMouseEnter: (index: number) => void;
+  readonly onCommit: (index: number) => void;
+  readonly rowId?: string;
+  readonly shortcutLabel?: string;
+}
+
+function CmdKPaletteRow({
+  item,
+  index,
+  isActive,
+  onMouseEnter,
+  onCommit,
+  rowId,
+  shortcutLabel,
+}: CmdKPaletteRowProps) {
+  return (
+    <button
+      type='button'
+      role='option'
+      id={rowId}
+      aria-selected={isActive ? 'true' : 'false'}
+      aria-current={isActive ? 'true' : undefined}
+      data-selected={isActive ? 'true' : undefined}
+      cmdk-item=''
+      onMouseEnter={() => onMouseEnter(index)}
+      onMouseDown={e => {
+        e.preventDefault();
+        onCommit(index);
+      }}
+      className={cn(
+        'flex min-h-12 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left outline-none transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
+        isActive
+          ? 'bg-white/[0.075] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.075)]'
+          : 'hover:bg-white/[0.035]'
+      )}
+    >
+      <RowVisual item={item} />
+      <RowBody item={item} />
+      {shortcutLabel ? (
+        <span className='ml-auto flex min-w-9 shrink-0 justify-end tabular-nums text-[11px] font-medium text-quaternary-token'>
+          {shortcutLabel}
+        </span>
+      ) : null}
+    </button>
+  );
 }
 
 export function PaletteList({
@@ -144,6 +201,8 @@ export function PaletteList({
   commitIndex,
   emptyHint,
   listId,
+  variant = 'inline',
+  showIndexedShortcuts = false,
 }: PaletteListProps) {
   if (sections.length === 0) {
     return (
@@ -167,11 +226,35 @@ export function PaletteList({
         const start = sectionStarts[sectionIdx] ?? 0;
         return (
           <div key={section.id}>
-            <div className='px-[10px] pb-[5px] pt-[11px] text-[9.5px] font-semibold uppercase tracking-[0.1em] text-quaternary-token'>
+            <div
+              className={cn(
+                variant === 'cmdk'
+                  ? 'px-2 pb-1 pt-2 text-[11px] font-medium text-quaternary-token'
+                  : 'px-[10px] pb-[5px] pt-[11px] text-[9.5px] font-semibold uppercase tracking-[0.1em] text-quaternary-token'
+              )}
+            >
               {section.label}
             </div>
             {section.items.map((item, localIdx) => {
               const flatIdx = start + localIdx;
+              const shortcutLabel =
+                showIndexedShortcuts && flatIdx < 3
+                  ? `${CMD_KEY_LABEL}${flatIdx + 1}`
+                  : undefined;
+              if (variant === 'cmdk') {
+                return (
+                  <CmdKPaletteRow
+                    key={pickerItemKey(item)}
+                    item={item}
+                    index={flatIdx}
+                    isActive={flatIdx === selectedIndex}
+                    onMouseEnter={setSelectedIndex}
+                    onCommit={commitIndex}
+                    rowId={listId ? `${listId}-row-${flatIdx}` : undefined}
+                    shortcutLabel={shortcutLabel}
+                  />
+                );
+              }
               return (
                 <PickerRow
                   key={pickerItemKey(item)}

--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -178,6 +178,13 @@ export const COMMANDS: readonly Command[] = [
     APP_ROUTES.RELEASES
   ),
   nav(
+    'go-calendar',
+    'Calendar',
+    'Plan release dates and campaign moments.',
+    'Calendar',
+    APP_ROUTES.CALENDAR
+  ),
+  nav(
     'go-audience',
     'Audience',
     'Understand your audience demographics.',

--- a/apps/web/tests/e2e/cmdk-palette.spec.ts
+++ b/apps/web/tests/e2e/cmdk-palette.spec.ts
@@ -61,7 +61,7 @@ test.describe('Command palette — Cmd+K contract', () => {
 
     // Enter commits the highlighted item — should navigate to releases.
     await page.keyboard.press('Enter');
-    await page.waitForURL(/\/app\/dashboard\/releases/, { timeout: 15_000 });
+    await page.waitForURL(/\/app\/releases/, { timeout: 15_000 });
 
     // Move focus back to the body so the next Meta+K isn't swallowed by an
     // auto-focused form element on the destination route.

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { JovieChat } from '@/components/jovie/JovieChat';
@@ -140,15 +140,17 @@ describe('JovieChat empty state', () => {
     mockChatState.chipTray.chips = [];
   });
 
-  it('centers the welcome composer when there are no action cards', () => {
-    const { getByTestId, getByText, queryByTestId, queryByText } =
-      renderWithQueryClient(<JovieChat profileId='profile-1' />);
+  it('renders only the simple composer when empty', () => {
+    const { getByTestId, queryByTestId, queryByText } = renderWithQueryClient(
+      <JovieChat profileId='profile-1' />
+    );
 
     expect(queryByTestId('chat-empty-state-top-signals')).toBeNull();
+    expect(queryByTestId('chat-empty-thread-ornament')).toBeNull();
     expect(queryByText('Release plan')).toBeNull();
     expect(queryByText('Asset brief')).toBeNull();
     expect(queryByText('Context')).toBeNull();
-    expect(getByText('What are we working on?')).toBeTruthy();
+    expect(queryByText('What are we working on?')).toBeNull();
     expect(queryByText('Welcome back')).toBeNull();
     expect(queryByText('Welcome back, Tim')).toBeNull();
     expect(queryByText("Hey, I'm Jovie.")).toBeNull();
@@ -158,8 +160,8 @@ describe('JovieChat empty state', () => {
     expect(getByTestId('chat-empty-state-centered-composer')).toBeTruthy();
     expect(queryByTestId('chat-empty-state-action-card-slot')).toBeNull();
     expect(queryByTestId('chat-composer-dock')).toBeNull();
-    expect(getByTestId('chat-empty-state-soft-suggestions-slot')).toBeTruthy();
-    expect(getByTestId('suggested-prompts-rail')).toBeTruthy();
+    expect(queryByTestId('chat-empty-state-soft-suggestions-slot')).toBeNull();
+    expect(queryByTestId('suggested-prompts-rail')).toBeNull();
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(getByTestId('chat-input').getAttribute('data-placeholder')).toBe(
       'Ask Jovie...'
@@ -168,16 +170,16 @@ describe('JovieChat empty state', () => {
     expect(
       getByTestId('chat-input').getAttribute('data-quick-actions')
     ).toBeNull();
-    expect(queryByText('Plan a release')).toBeTruthy();
-    expect(queryByText('Generate album art')).toBeTruthy();
-    expect(queryByText('Pitch playlists')).toBeTruthy();
+    expect(queryByText('Plan a release')).toBeNull();
+    expect(queryByText('Generate album art')).toBeNull();
+    expect(queryByText('Pitch playlists')).toBeNull();
     // Old task-list-style actions should NOT appear — they belong in the profile switcher.
     expect(queryByText('Preview profile')).toBeNull();
     expect(queryByText('Change photo')).toBeNull();
     expect(queryByText('Release link')).toBeNull();
   });
 
-  it('centers a contextual action card, hides welcome text, and docks the composer', () => {
+  it('does not render empty-state action cards by default', () => {
     renderWithQueryClient(
       <JovieChat
         profileId='profile-1'
@@ -193,35 +195,20 @@ describe('JovieChat empty state', () => {
       />
     );
 
-    expect(screen.getByText('Connect Your Music Catalog')).toBeTruthy();
-    expect(screen.getByText(/Add Spotify/)).toBeTruthy();
+    expect(screen.queryByText('Connect Your Music Catalog')).toBeNull();
+    expect(screen.queryByText(/Add Spotify/)).toBeNull();
     expect(screen.queryByText('What are we working on?')).toBeNull();
     expect(
-      screen.getByTestId('chat-empty-state-action-card-slot')
-    ).toBeTruthy();
-    expect(
-      screen.queryByTestId('chat-empty-state-centered-composer')
+      screen.queryByTestId('chat-empty-state-action-card-slot')
     ).toBeNull();
-    expect(screen.getByTestId('chat-composer-dock')).toBeTruthy();
+    expect(
+      screen.getByTestId('chat-empty-state-centered-composer')
+    ).toBeTruthy();
+    expect(screen.queryByTestId('chat-composer-dock')).toBeNull();
     expect(screen.queryByTestId('suggested-prompts-rail')).toBeNull();
-
-    fireEvent.click(screen.getByRole('button', { name: /Plan Setup/ }));
-
-    expect(mockChatState.handleSuggestedPrompt).toHaveBeenCalledWith(
-      'Help me connect my music catalog.'
-    );
-
-    fireEvent.click(
-      screen.getByRole('button', {
-        name: /Dismiss Connect Your Music Catalog/i,
-      })
-    );
-
-    expect(screen.queryByText('Connect Your Music Catalog')).toBeNull();
-    expect(screen.getByTestId('suggested-prompts-rail')).toBeTruthy();
   });
 
-  it('hides the contextual action card while the empty composer has typed text', () => {
+  it('keeps typed empty chat on the simple composer', () => {
     mockChatState.input = 'Help me with';
 
     const { getByTestId, queryByTestId, queryByText } = renderWithQueryClient(
@@ -240,15 +227,15 @@ describe('JovieChat empty state', () => {
     );
 
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
-    expect(getByTestId('chat-empty-state-action-card-slot')).toBeTruthy();
-    expect(getByTestId('chat-composer-dock')).toBeTruthy();
+    expect(queryByTestId('chat-empty-state-action-card-slot')).toBeNull();
+    expect(queryByTestId('chat-composer-dock')).toBeNull();
     expect(queryByTestId('chat-empty-state-top-signals')).toBeNull();
     expect(getByTestId('chat-input')).toBeTruthy();
     expect(queryByText('Connect Your Music Catalog')).toBeNull();
     expect(queryByTestId('suggested-prompts-rail')).toBeNull();
   });
 
-  it('hides soft suggestions while a chip is active', () => {
+  it('preserves the chip-enabled composer without empty-state suggestions', () => {
     mockChatState.chipTray.chips = [
       {
         type: 'skill',
@@ -261,24 +248,27 @@ describe('JovieChat empty state', () => {
       <JovieChat profileId='profile-1' />
     );
 
-    expect(getByTestId('chat-empty-state-soft-suggestions-slot')).toBeTruthy();
+    expect(getByTestId('chat-empty-state-centered-composer')).toBeTruthy();
+    expect(getByTestId('chat-input')).toBeTruthy();
+    expect(queryByTestId('chat-empty-state-soft-suggestions-slot')).toBeNull();
     expect(queryByTestId('suggested-prompts-rail')).toBeNull();
   });
 
-  it('renders first-session greeting for new users', () => {
-    const { getByText } = renderWithQueryClient(
+  it('does not render first-session welcome copy in the empty state', () => {
+    const { queryByText } = renderWithQueryClient(
       <JovieChat profileId='profile-1' isFirstSession />
     );
 
-    expect(getByText("Hey, I'm Jovie.")).toBeTruthy();
+    expect(queryByText("Hey, I'm Jovie.")).toBeNull();
   });
 
-  it('uses only the first name in the returning-user welcome heading', () => {
-    const { getByText, queryByText } = renderWithQueryClient(
+  it('does not render returning-user welcome copy in the empty state', () => {
+    const { queryByText } = renderWithQueryClient(
       <JovieChat profileId='profile-1' displayName='Tim White' />
     );
 
-    expect(getByText('What are we working on, Tim?')).toBeTruthy();
+    expect(queryByText('What are we working on, Tim?')).toBeNull();
+    expect(queryByText('What are we working on?')).toBeNull();
     expect(queryByText('Welcome back')).toBeNull();
     expect(queryByText('Welcome back, Tim')).toBeNull();
     expect(queryByText('Welcome back, Tim White')).toBeNull();
@@ -290,7 +280,7 @@ describe('JovieChat empty state', () => {
       <JovieChat profileId='profile-1' />
     );
 
-    expect(queryByText('What are we working on?')).toBeTruthy();
+    expect(queryByText('What are we working on?')).toBeNull();
     expect(queryByText('Welcome back')).toBeNull();
 
     messages.push(

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -10,9 +10,11 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { CmdKPalette } from '@/components/organisms/CmdKPalette';
+import { APP_ROUTES } from '@/constants/routes';
 import { commandsForSurface } from '@/lib/commands/registry';
 
 const pushMock = vi.fn();
+const CMD_LABEL = String.fromCodePoint(0x2318);
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock, replace: vi.fn() }),
@@ -106,6 +108,27 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
     }
   });
 
+  it('adds Calendar as a cmd+k-only nav route', () => {
+    expect(commandsForSurface('cmdk')).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'nav',
+          id: 'go-calendar',
+          label: 'Calendar',
+          href: APP_ROUTES.CALENDAR,
+        }),
+      ])
+    );
+    expect(commandsForSurface('chat-slash')).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'nav',
+          id: 'go-calendar',
+        }),
+      ])
+    );
+  });
+
   it('renders nav, skill, and release sections when open', () => {
     render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);
     expect(screen.getByTestId('shared-command-palette')).toBeInTheDocument();
@@ -118,6 +141,31 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
     expect(sectionLabels).toContain('Skills');
     expect(sectionLabels).toContain('Releases');
     expect(screen.getByText('Midnight Run')).toBeInTheDocument();
+  });
+
+  it('shows aligned numbered shortcuts for the first three visible rows', () => {
+    render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);
+    const rows = screen.getAllByRole('option');
+
+    expect(rows[0]).toHaveTextContent(`${CMD_LABEL}1`);
+    expect(rows[1]).toHaveTextContent(`${CMD_LABEL}2`);
+    expect(rows[2]).toHaveTextContent(`${CMD_LABEL}3`);
+    expect(rows[3]).not.toHaveTextContent(`${CMD_LABEL}4`);
+  });
+
+  it.each([
+    ['1', 0],
+    ['2', 1],
+    ['3', 2],
+  ])('selects visible row %s with its numbered shortcut', (key, rowIndex) => {
+    pushMock.mockClear();
+    render(<CmdKPalette profileId='profile-1' open onOpenChange={vi.fn()} />);
+
+    fireEvent.keyDown(globalThis, { key, metaKey: true });
+
+    const rows = screen.getAllByRole('option');
+    expect(rows[rowIndex]).toHaveAttribute('aria-selected', 'true');
+    expect(pushMock).not.toHaveBeenCalled();
   });
 
   it('navigates to the nav href when a nav item is committed', () => {


### PR DESCRIPTION
## Summary
- Simplify empty `/app/chat` to the composer only, removing welcome copy, ornament, suggestion pills, and default empty action-card rendering.
- Polish the Cmd+K surface with quieter chrome, tighter rows, clearer selected state, aligned first-row shortcuts, and Cmd/Ctrl+1-3 selection.
- Add Calendar to the command registry via `APP_ROUTES.CALENDAR` and update the cmdk E2E route expectation to canonical `/app/releases`.

## Verification
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write apps/web/components/jovie/JovieChat.tsx apps/web/components/organisms/CmdKPalette.tsx apps/web/components/organisms/SharedCommandPalette.tsx apps/web/lib/commands/registry.ts apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx apps/web/tests/unit/commands/SharedCommandPalette.test.tsx apps/web/tests/unit/organisms/CommandPalette.test.tsx apps/web/tests/e2e/cmdk-palette.spec.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/chat/JovieChat.empty-state.test.tsx tests/unit/commands/SharedCommandPalette.test.tsx tests/unit/organisms/CommandPalette.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/chat/ChatInput.test.tsx tests/unit/chat/ChatInput.aria.test.tsx tests/unit/chat/SlashCommandMenu.keyboard.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/chat/JovieChat.styling.test.tsx tests/unit/chat/ChatPageClient.test.tsx`
- Push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added numeric keyboard shortcuts (1/2/3) for quick navigation in the command palette when using Cmd/Ctrl.
  * Added Calendar command to the command palette for faster access to release planning.

* **Improvements**
  * Streamlined empty chat state to display only the message composer.
  * Enhanced command palette UI with improved spacing and keyboard shortcut visual indicators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->