### PR TITLE
fix(profile): reduce public profile sonar duplication

### DIFF
--- a/apps/web/app/[username]/_lib/profile-intent-route.ts
+++ b/apps/web/app/[username]/_lib/profile-intent-route.ts
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { BASE_URL } from '@/constants/app';
+import { buildViewMetadata } from '@/features/profile/views/metadata';
+import type { ProfileViewKey } from '@/features/profile/views/registry';
+import { convertCreatorProfileToArtist } from '@/types/db';
+import { getProfileAndLinks } from './public-profile-loader';
+
+export interface ProfileIntentRouteProps {
+  readonly params: Promise<{
+    readonly username: string;
+  }>;
+}
+
+export function createProfileIntentMetadata(view: ProfileViewKey) {
+  return async function generateProfileIntentMetadata({
+    params,
+  }: ProfileIntentRouteProps): Promise<Metadata> {
+    const { username } = await params;
+    const result = await getProfileAndLinks(username);
+    if (result.status !== 'ok' || !result.profile) {
+      return {};
+    }
+
+    const artist = convertCreatorProfileToArtist(result.profile);
+    return buildViewMetadata(view, {
+      artistName: artist.name,
+      artistHandle: artist.handle,
+      baseUrl: BASE_URL,
+    });
+  };
+}
+
+export async function loadProfileIntentContext(username: string) {
+  const result = await getProfileAndLinks(username);
+  if (result.status !== 'ok' || !result.profile) {
+    notFound();
+  }
+
+  return {
+    artist: convertCreatorProfileToArtist(result.profile),
+    result,
+  };
+}

--- a/apps/web/app/[username]/contact/page.tsx
+++ b/apps/web/app/[username]/contact/page.tsx
@@ -1,44 +1,20 @@
-import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { BASE_URL } from '@/constants/app';
 import { ContactView } from '@/features/profile/views/ContactView';
-import { buildViewMetadata } from '@/features/profile/views/metadata';
 import { ProfileIntentPage } from '@/features/profile/views/ProfileIntentPage';
 import { toPublicContacts } from '@/lib/contacts/mapper';
-import { convertCreatorProfileToArtist } from '@/types/db';
-import { getProfileAndLinks } from '../_lib/public-profile-loader';
+import {
+  createProfileIntentMetadata,
+  loadProfileIntentContext,
+  type ProfileIntentRouteProps,
+} from '../_lib/profile-intent-route';
 
 export const dynamic = 'force-dynamic';
 
-interface Props {
-  readonly params: Promise<{
-    readonly username: string;
-  }>;
-}
+export const generateMetadata = createProfileIntentMetadata('contact');
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
+export default async function ContactPage({ params }: ProfileIntentRouteProps) {
   const { username } = await params;
-  const result = await getProfileAndLinks(username);
-  if (result.status !== 'ok' || !result.profile) {
-    return {};
-  }
-
-  const artist = convertCreatorProfileToArtist(result.profile);
-  return buildViewMetadata('contact', {
-    artistName: artist.name,
-    artistHandle: artist.handle,
-    baseUrl: BASE_URL,
-  });
-}
-
-export default async function ContactPage({ params }: Props) {
-  const { username } = await params;
-  const result = await getProfileAndLinks(username);
-  if (result.status !== 'ok' || !result.profile) {
-    notFound();
-  }
-
-  const artist = convertCreatorProfileToArtist(result.profile);
+  const { artist, result } = await loadProfileIntentContext(username);
   const contacts = toPublicContacts(result.contacts, artist.name);
   const availableContacts = contacts.filter(
     contact => contact.channels.length > 0

--- a/apps/web/app/[username]/pay/page.tsx
+++ b/apps/web/app/[username]/pay/page.tsx
@@ -1,48 +1,24 @@
-import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { BASE_URL } from '@/constants/app';
 import {
   extractVenmoUsername,
   findVenmoLink,
   isAllowedVenmoUrl,
 } from '@/features/profile/utils/venmo';
-import { buildViewMetadata } from '@/features/profile/views/metadata';
 import { PayView } from '@/features/profile/views/PayView';
 import { ProfileIntentPage } from '@/features/profile/views/ProfileIntentPage';
-import { convertCreatorProfileToArtist } from '@/types/db';
-import { getProfileAndLinks } from '../_lib/public-profile-loader';
+import {
+  createProfileIntentMetadata,
+  loadProfileIntentContext,
+  type ProfileIntentRouteProps,
+} from '../_lib/profile-intent-route';
 
 export const dynamic = 'force-dynamic';
 
-interface Props {
-  readonly params: Promise<{
-    readonly username: string;
-  }>;
-}
+export const generateMetadata = createProfileIntentMetadata('pay');
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
+export default async function PayPage({ params }: ProfileIntentRouteProps) {
   const { username } = await params;
-  const result = await getProfileAndLinks(username);
-  if (result.status !== 'ok' || !result.profile) {
-    return {};
-  }
-
-  const artist = convertCreatorProfileToArtist(result.profile);
-  return buildViewMetadata('pay', {
-    artistName: artist.name,
-    artistHandle: artist.handle,
-    baseUrl: BASE_URL,
-  });
-}
-
-export default async function PayPage({ params }: Readonly<Props>) {
-  const { username } = await params;
-  const result = await getProfileAndLinks(username);
-  if (result.status !== 'ok' || !result.profile) {
-    notFound();
-  }
-
-  const artist = convertCreatorProfileToArtist(result.profile);
+  const { artist, result } = await loadProfileIntentContext(username);
   const venmoLink = findVenmoLink(result.links);
   if (!venmoLink || !isAllowedVenmoUrl(venmoLink)) {
     notFound();

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/AddReleaseSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/AddReleaseSidebar.tsx
@@ -95,8 +95,6 @@ export function AddReleaseSidebar({
     return parsedReleaseDate ? parsedReleaseDate > startOfToday() : false;
   }, [releaseDate]);
 
-  const [, setRevealDateManuallySet] = useState(false);
-
   const replaceStagedArtworkPreview = useCallback((nextUrl: string | null) => {
     setStagedArtworkPreviewUrl(nextUrl);
   }, []);
@@ -106,7 +104,6 @@ export function AddReleaseSidebar({
     setReleaseType('single');
     setReleaseDate('');
     setRevealDate('');
-    setRevealDateManuallySet(false);
     setGenres([]);
     setIsExplicit(false);
     setStagedArtworkFile(null);
@@ -373,7 +370,6 @@ export function AddReleaseSidebar({
                   onSelect={date => {
                     if (!date) return;
                     setReleaseDate(format(date, 'yyyy-MM-dd'));
-                    setRevealDateManuallySet(false);
                   }}
                   autoFocus
                 />
@@ -405,7 +401,6 @@ export function AddReleaseSidebar({
                     onSelect={date => {
                       if (!date) return;
                       setRevealDate(format(date, 'yyyy-MM-dd'));
-                      setRevealDateManuallySet(true);
                     }}
                     autoFocus
                   />

--- a/apps/web/components/features/profile/nav/BottomTabBar.test.tsx
+++ b/apps/web/components/features/profile/nav/BottomTabBar.test.tsx
@@ -28,7 +28,6 @@ function makeProps(overrides?: Partial<BottomTabBarProps>): BottomTabBarProps {
     hasTourDates: true,
     isMenuOpen: false,
     onTabSelect: vi.fn(),
-    onOpenMenu: vi.fn(),
     ...overrides,
   };
 }

--- a/apps/web/components/features/profile/nav/BottomTabBar.tsx
+++ b/apps/web/components/features/profile/nav/BottomTabBar.tsx
@@ -68,20 +68,12 @@ export interface BottomTabBarProps {
   readonly hasTourDates: boolean;
 
   /**
-   * Retained for API compatibility. More now lives in the profile header.
-   */
-  readonly hideMoreMenu?: boolean;
-
-  /**
    * Whether the header menu is currently open.
    */
   readonly isMenuOpen?: boolean;
 
   /** Called when the user taps a primary tab. */
   readonly onTabSelect: (mode: ProfilePrimaryTab) => void;
-
-  /** Retained for API compatibility. */
-  readonly onOpenMenu: () => void;
 
   /** Optional extra className applied to the outermost wrapper. */
   readonly className?: string;

--- a/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
+++ b/apps/web/components/features/profile/templates/ProfileCompactSurface.tsx
@@ -762,10 +762,8 @@ export function ProfileCompactSurface({
             <BottomTabBar
               activeTab={activeVisiblePrimaryTab}
               hasTourDates={hasTourDates}
-              hideMoreMenu={hideMoreMenu}
               isMenuOpen={isMenuActive}
               onTabSelect={handleTabSelect}
-              onOpenMenu={onOpenMenu}
             />
           ) : null}
         </div>

--- a/apps/web/components/features/release/SmartLinkShell.tsx
+++ b/apps/web/components/features/release/SmartLinkShell.tsx
@@ -11,7 +11,7 @@
 import { ChevronLeft } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useCallback } from 'react';
+import { type ReactNode, useCallback } from 'react';
 import { Icon } from '@/components/atoms/Icon';
 import {
   PublicSurfaceHeader,
@@ -81,6 +81,43 @@ function ArtworkFallback() {
   );
 }
 
+function SmartLinkHeaderRightSlot({
+  onMenuOpen,
+  showBrandMark,
+  showMenuButton,
+}: {
+  readonly onMenuOpen?: () => void;
+  readonly showBrandMark: boolean;
+  readonly showMenuButton: boolean;
+}): ReactNode {
+  if (showMenuButton && onMenuOpen) {
+    return (
+      <button
+        type='button'
+        onClick={onMenuOpen}
+        className='flex h-8 w-8 items-center justify-center rounded-full border border-white/[0.08] bg-black/25 text-white/70 backdrop-blur-2xl transition-colors duration-subtle hover:bg-black/40'
+        aria-label='Menu'
+        aria-haspopup='dialog'
+      >
+        <Mark size={17} className='h-[17px] w-[17px]' />
+      </button>
+    );
+  }
+
+  if (!showBrandMark) {
+    return null;
+  }
+
+  return (
+    <span
+      className='flex h-8 w-8 items-center justify-center text-white/48 drop-shadow-[0_1px_4px_rgba(0,0,0,0.4)]'
+      data-testid='smart-link-brand-mark'
+    >
+      <Mark size={17} className='h-[17px] w-[17px]' />
+    </span>
+  );
+}
+
 export function SmartLinkShell({
   artworkUrl,
   artworkAlt = 'Artwork',
@@ -133,26 +170,11 @@ export function SmartLinkShell({
                 </Link>
               ) : null
             }
-            rightSlot={
-              showMenuButton && onMenuOpen ? (
-                <button
-                  type='button'
-                  onClick={onMenuOpen}
-                  className='flex h-8 w-8 items-center justify-center rounded-full border border-white/[0.08] bg-black/25 text-white/70 backdrop-blur-2xl transition-colors duration-subtle hover:bg-black/40'
-                  aria-label='Menu'
-                  aria-haspopup='dialog'
-                >
-                  <Mark size={17} className='h-[17px] w-[17px]' />
-                </button>
-              ) : showBrandMark ? (
-                <span
-                  className='flex h-8 w-8 items-center justify-center text-white/48 drop-shadow-[0_1px_4px_rgba(0,0,0,0.4)]'
-                  data-testid='smart-link-brand-mark'
-                >
-                  <Mark size={17} className='h-[17px] w-[17px]' />
-                </span>
-              ) : null
-            }
+            rightSlot={SmartLinkHeaderRightSlot({
+              onMenuOpen,
+              showBrandMark,
+              showMenuButton,
+            })}
           />
 
           {/* Hero overlay */}

--- a/apps/web/lib/profile/release-visibility.ts
+++ b/apps/web/lib/profile/release-visibility.ts
@@ -11,6 +11,15 @@ export interface ProfileReleaseVisibility {
   isRetired: boolean;
 }
 
+type ProfileReleaseVisibilityInput = {
+  releaseDate: Date | string | null;
+  revealDate?: Date | string | null;
+  artworkUrl: string | null;
+  status?: string | null;
+  deletedAt?: Date | string | null;
+  hasProviderLinks?: boolean;
+};
+
 /**
  * Determines whether and how the latest release card should display
  * on an artist's public profile page.
@@ -18,17 +27,7 @@ export interface ProfileReleaseVisibility {
  * Returns null when there is no release to show at all.
  */
 export function getProfileReleaseVisibility(
-  release:
-    | {
-        releaseDate: Date | string | null;
-        revealDate?: Date | string | null;
-        artworkUrl: string | null;
-        status?: string | null;
-        deletedAt?: Date | string | null;
-        hasProviderLinks?: boolean;
-      }
-    | null
-    | undefined,
+  release: ProfileReleaseVisibilityInput | null | undefined,
   settings: { showOldReleases?: boolean } | null | undefined,
   now?: Date
 ): ProfileReleaseVisibility | null {


### PR DESCRIPTION
## Summary
- Move duplicated public profile intent route metadata/loading into a shared helper
- Remove dead bottom-nav and reveal-date state props flagged by Sonar
- Flatten smart-link header menu/brand branching

## Verification
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm biome check apps/web/app/'[username]'/_lib/profile-intent-route.ts apps/web/app/'[username]'/contact/page.tsx apps/web/app/'[username]'/pay/page.tsx apps/web/components/features/profile/nav/BottomTabBar.tsx apps/web/components/features/profile/nav/BottomTabBar.test.tsx apps/web/components/features/profile/templates/ProfileCompactSurface.tsx apps/web/components/features/dashboard/organisms/release-provider-matrix/AddReleaseSidebar.tsx apps/web/lib/profile/release-visibility.ts apps/web/components/features/release/SmartLinkShell.tsx
- pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/ReleasesPageClient-skeleton.test.tsx tests/unit/lib/profile/release-visibility.test.ts tests/components/release-provider-matrix/AddReleaseSidebar.test.tsx tests/unit/release/smart-link-shell.test.tsx tests/unit/profile/profile-compact-template.test.tsx components/features/profile/nav/BottomTabBar.test.tsx
- pre-push: biome check . && pnpm --filter=@jovie/web run pre-push