### PR TITLE
feat(shell): restore chat logo and library audio upload

### DIFF
--- a/apps/web/app/api/chat/conversations/route.ts
+++ b/apps/web/app/api/chat/conversations/route.ts
@@ -1,4 +1,4 @@
-import { count, desc, eq } from 'drizzle-orm';
+import { count, desc, sql as drizzleSql, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { getSessionContext } from '@/lib/auth/session';
 import {
@@ -6,7 +6,11 @@ import {
   withSanitizedConversationTitles,
 } from '@/lib/chat/title';
 import { db } from '@/lib/db';
-import { chatConversations, chatMessages } from '@/lib/db/schema/chat';
+import {
+  chatConversations,
+  chatMessages,
+  chatTurns,
+} from '@/lib/db/schema/chat';
 import { captureError } from '@/lib/error-tracking';
 import { logger } from '@/lib/utils/logger';
 import { getSessionErrorResponse } from '../session-error-response';
@@ -52,6 +56,14 @@ export async function GET(req: Request) {
         title: chatConversations.title,
         createdAt: chatConversations.createdAt,
         updatedAt: chatConversations.updatedAt,
+        latestMessageRole:
+          drizzleSql<string>`(SELECT ${chatMessages.role} FROM ${chatMessages} WHERE ${chatMessages.conversationId} = ${chatConversations.id} ORDER BY ${chatMessages.createdAt} DESC LIMIT 1)`.as(
+            'latest_message_role'
+          ),
+        latestTurnStatus:
+          drizzleSql<string>`(SELECT ${chatTurns.status} FROM ${chatTurns} WHERE ${chatTurns.conversationId} = ${chatConversations.id} ORDER BY ${chatTurns.updatedAt} DESC LIMIT 1)`.as(
+            'latest_turn_status'
+          ),
       })
       .from(chatConversations)
       .where(eq(chatConversations.creatorProfileId, profile.id))

--- a/apps/web/app/api/library/audio/confirm/route.ts
+++ b/apps/web/app/api/library/audio/confirm/route.ts
@@ -1,0 +1,149 @@
+/**
+ * Library Audio Confirm
+ *
+ * Called after a client-side Blob upload completes. Verifies release ownership
+ * and attaches the public audio URL to the first recording on the release when
+ * the catalog is missing audio.
+ */
+
+import { and, eq } from 'drizzle-orm';
+import { revalidateTag } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { requireAuth } from '@/lib/auth/require-auth';
+import { getSessionContext } from '@/lib/auth/session';
+import { createSmartLinkContentTag } from '@/lib/cache/tags';
+import { db } from '@/lib/db';
+import {
+  discogRecordings,
+  discogReleases,
+  discogReleaseTracks,
+} from '@/lib/db/schema/content';
+import { captureError } from '@/lib/error-tracking';
+import { NO_STORE_HEADERS } from '@/lib/http/headers';
+
+export const runtime = 'nodejs';
+
+const ALLOWED_AUDIO_MIME_TYPES = new Set([
+  'audio/aac',
+  'audio/aiff',
+  'audio/flac',
+  'audio/mp4',
+  'audio/mpeg',
+  'audio/wav',
+  'audio/x-aiff',
+  'audio/x-flac',
+  'audio/x-m4a',
+  'audio/x-wav',
+]);
+
+const confirmSchema = z.object({
+  releaseId: z.string().uuid(),
+  blobUrl: z.string().url(),
+  blobPathname: z.string().min(1),
+  fileName: z.string().min(1),
+  fileMimeType: z.string().min(1),
+  fileSizeBytes: z.number().int().positive().optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const { userId: clerkUserId, error } = await requireAuth();
+  if (error) return error;
+
+  try {
+    const parsed = confirmSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'Invalid request', details: parsed.error.format() },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const { releaseId, blobUrl, fileMimeType } = parsed.data;
+    if (!ALLOWED_AUDIO_MIME_TYPES.has(fileMimeType)) {
+      return NextResponse.json(
+        { error: 'Unsupported audio file type' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const { profile } = await getSessionContext({
+      clerkUserId,
+      requireUser: true,
+      requireProfile: false,
+    });
+
+    if (!profile) {
+      return NextResponse.json(
+        { error: 'Creator profile not found' },
+        { status: 403, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const [row] = await db
+      .select({
+        recordingId: discogRecordings.id,
+        currentPreviewUrl: discogRecordings.previewUrl,
+      })
+      .from(discogReleases)
+      .innerJoin(
+        discogReleaseTracks,
+        eq(discogReleaseTracks.releaseId, discogReleases.id)
+      )
+      .innerJoin(
+        discogRecordings,
+        eq(discogRecordings.id, discogReleaseTracks.recordingId)
+      )
+      .where(
+        and(
+          eq(discogReleases.id, releaseId),
+          eq(discogReleases.creatorProfileId, profile.id)
+        )
+      )
+      .orderBy(discogReleaseTracks.discNumber, discogReleaseTracks.trackNumber)
+      .limit(1);
+
+    if (!row) {
+      return NextResponse.json(
+        { error: 'Release recording not found' },
+        { status: 404, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    if (row.currentPreviewUrl) {
+      return NextResponse.json(
+        { error: 'Release already has audio' },
+        { status: 409, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    await db
+      .update(discogRecordings)
+      .set({
+        previewUrl: blobUrl,
+        audioUrl: blobUrl,
+        audioFormat: fileMimeType,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(discogRecordings.id, row.recordingId),
+          eq(discogRecordings.creatorProfileId, profile.id)
+        )
+      );
+
+    revalidateTag(`releases:${clerkUserId}:${profile.id}`, 'max');
+    revalidateTag(createSmartLinkContentTag(profile.id), 'max');
+
+    return NextResponse.json(
+      { success: true, previewUrl: blobUrl },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  } catch (err) {
+    captureError('Library audio confirm error', err);
+    return NextResponse.json(
+      { error: 'Failed to confirm audio upload' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/api/library/audio/upload-token/route.ts
+++ b/apps/web/app/api/library/audio/upload-token/route.ts
@@ -1,0 +1,75 @@
+/**
+ * Library Audio Upload Token
+ *
+ * Generates a Vercel Blob client upload token so the browser can attach audio
+ * to a catalog release without routing large audio bodies through Next.js.
+ */
+
+import { type HandleUploadBody, handleUpload } from '@vercel/blob/client';
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/auth/require-auth';
+import { getSessionContext } from '@/lib/auth/session';
+import { NO_STORE_HEADERS } from '@/lib/http/headers';
+
+export const runtime = 'nodejs';
+
+const MAX_FILE_SIZE_BYTES = 150 * 1024 * 1024;
+
+const ALLOWED_AUDIO_MIME_TYPES = new Set([
+  'audio/aac',
+  'audio/aiff',
+  'audio/flac',
+  'audio/mp4',
+  'audio/mpeg',
+  'audio/wav',
+  'audio/x-aiff',
+  'audio/x-flac',
+  'audio/x-m4a',
+  'audio/x-wav',
+]);
+
+export async function POST(request: NextRequest) {
+  const { userId: clerkUserId, error } = await requireAuth();
+  if (error) return error;
+
+  try {
+    const body = (await request.json()) as HandleUploadBody;
+
+    const jsonResponse = await handleUpload({
+      body,
+      request,
+      onBeforeGenerateToken: async _pathname => {
+        const { profile } = await getSessionContext({
+          clerkUserId,
+          requireUser: true,
+          requireProfile: false,
+        });
+
+        if (!profile) {
+          throw new Error('Creator profile not found');
+        }
+
+        return {
+          allowedContentTypes: [...ALLOWED_AUDIO_MIME_TYPES],
+          maximumSizeInBytes: MAX_FILE_SIZE_BYTES,
+          tokenPayload: JSON.stringify({
+            creatorProfileId: profile.id,
+            userId: clerkUserId,
+          }),
+        };
+      },
+      onUploadCompleted: async () => {
+        // The client calls /api/library/audio/confirm after upload so the DB
+        // update can verify release ownership before attaching the blob URL.
+      },
+    });
+
+    return NextResponse.json(jsonResponse, { headers: NO_STORE_HEADERS });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Upload failed';
+    return NextResponse.json(
+      { error: message },
+      { status: 400, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -5,6 +5,7 @@ import {
   createColumnHelper,
   type RowSelectionState,
 } from '@tanstack/react-table';
+import { upload } from '@vercel/blob/client';
 import {
   ArrowUpDown,
   Check,
@@ -17,18 +18,23 @@ import {
   Grid3x3,
   ImageIcon,
   LayoutList,
+  Loader2,
   type LucideIcon,
   Music2,
   Pause,
   PlayCircle,
+  Upload,
   Video,
   X,
 } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import {
+  type ChangeEvent,
   type CSSProperties,
   createContext,
+  type DragEvent,
   type MouseEvent,
   memo,
   type ReactNode,
@@ -37,6 +43,7 @@ import {
   useEffect,
   useId,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { toast } from 'sonner';
@@ -78,6 +85,21 @@ const LIBRARY_BUTTON_FOCUS_CLASS =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface) outline-none';
 const LIBRARY_ICON_FOCUS_CLASS =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface) outline-none';
+const LIBRARY_AUDIO_MAX_FILE_SIZE = 150 * 1024 * 1024;
+const LIBRARY_AUDIO_ACCEPT =
+  'audio/aac,audio/aiff,audio/flac,audio/mp4,audio/mpeg,audio/wav,audio/x-aiff,audio/x-flac,audio/x-m4a,audio/x-wav';
+const LIBRARY_AUDIO_MIME_TYPES = new Set([
+  'audio/aac',
+  'audio/aiff',
+  'audio/flac',
+  'audio/mp4',
+  'audio/mpeg',
+  'audio/wav',
+  'audio/x-aiff',
+  'audio/x-flac',
+  'audio/x-m4a',
+  'audio/x-wav',
+]);
 
 const LIBRARY_TABLE_SKELETON_CONFIG: Array<{
   readonly width?: string;
@@ -1204,14 +1226,26 @@ function PreviewActionButton({
   onTogglePreview,
   compact = false,
   disabledTabIndex,
+  reserveSpace = false,
 }: {
   readonly asset: LibraryReleaseAsset;
   readonly isPreviewPlaying: boolean;
   readonly onTogglePreview: LibraryPreviewToggle;
   readonly compact?: boolean;
   readonly disabledTabIndex?: number;
+  readonly reserveSpace?: boolean;
 }) {
-  if (!asset.previewUrl) return null;
+  if (!asset.previewUrl) {
+    return reserveSpace ? (
+      <span
+        aria-hidden='true'
+        className={cn(
+          'pointer-events-none inline-flex shrink-0 opacity-0',
+          compact ? 'h-7 w-7' : 'h-8 w-[92px]'
+        )}
+      />
+    ) : null;
+  }
 
   const label = isPreviewPlaying ? 'Pause Preview' : 'Play Preview';
 
@@ -1238,20 +1272,245 @@ function PreviewActionButton({
   );
 }
 
+function isSupportedAudioFile(file: File): boolean {
+  if (LIBRARY_AUDIO_MIME_TYPES.has(file.type)) return true;
+  return /\.(aac|aiff?|flac|m4a|mp3|wav)$/i.test(file.name);
+}
+
+function LibraryAudioDropzone({
+  asset,
+  onUploaded,
+  disabledTabIndex,
+}: {
+  readonly asset: LibraryReleaseAsset;
+  readonly onUploaded: (assetId: string, previewUrl: string) => void;
+  readonly disabledTabIndex?: number;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const uploadFile = useCallback(
+    async (file: File) => {
+      if (!isSupportedAudioFile(file)) {
+        setUploadError('Use MP3, WAV, FLAC, AIFF, AAC, or M4A audio.');
+        return;
+      }
+
+      if (file.size > LIBRARY_AUDIO_MAX_FILE_SIZE) {
+        setUploadError('Audio must be 150 MB or smaller.');
+        return;
+      }
+
+      setUploading(true);
+      setUploadError(null);
+
+      try {
+        const blob = await upload(file.name, file, {
+          access: 'public',
+          handleUploadUrl: '/api/library/audio/upload-token',
+        });
+        const response = await fetch('/api/library/audio/confirm', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            releaseId: asset.id,
+            blobUrl: blob.url,
+            blobPathname: blob.pathname,
+            fileName: file.name,
+            fileMimeType: file.type,
+            fileSizeBytes: file.size,
+          }),
+        });
+        const body = (await response.json().catch(() => ({}))) as {
+          readonly previewUrl?: string;
+          readonly error?: string;
+        };
+
+        if (!response.ok || !body.previewUrl) {
+          throw new Error(body.error ?? 'Audio upload failed');
+        }
+
+        onUploaded(asset.id, body.previewUrl);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Audio upload failed';
+        setUploadError(message);
+        toast.error(message);
+      } finally {
+        setUploading(false);
+        if (inputRef.current) {
+          inputRef.current.value = '';
+        }
+      }
+    },
+    [asset.id, onUploaded]
+  );
+
+  const handleInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file) void uploadFile(file);
+    },
+    [uploadFile]
+  );
+
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      setIsDragging(false);
+      const file = event.dataTransfer.files?.[0];
+      if (file) void uploadFile(file);
+    },
+    [uploadFile]
+  );
+
+  return (
+    <div>
+      <button
+        type='button'
+        onClick={() => inputRef.current?.click()}
+        onDragEnter={event => {
+          event.preventDefault();
+          setIsDragging(true);
+        }}
+        onDragOver={event => {
+          event.preventDefault();
+          setIsDragging(true);
+        }}
+        onDragLeave={event => {
+          event.preventDefault();
+          setIsDragging(false);
+        }}
+        onDrop={handleDrop}
+        disabled={uploading}
+        tabIndex={disabledTabIndex}
+        data-testid='library-audio-dropzone'
+        className={cn(
+          'flex min-h-[118px] w-full flex-col items-center justify-center rounded-lg border border-dashed border-subtle bg-surface-0 px-3 py-4 text-center transition-[background-color,border-color,color] duration-subtle ease-subtle',
+          isDragging &&
+            'border-(--linear-border-focus) bg-[color-mix(in_oklab,var(--linear-border-focus)_8%,var(--linear-bg-surface-0))]',
+          !uploading &&
+            'hover:border-default hover:bg-surface-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface)'
+        )}
+        aria-busy={uploading || undefined}
+      >
+        {uploading ? (
+          <Loader2
+            className='h-5 w-5 animate-spin text-secondary-token motion-reduce:animate-none'
+            aria-hidden='true'
+            strokeWidth={2.25}
+          />
+        ) : (
+          <Upload
+            className='h-5 w-5 text-tertiary-token'
+            aria-hidden='true'
+            strokeWidth={2.25}
+          />
+        )}
+        <span className='mt-2 text-xs font-medium text-primary-token'>
+          {uploading ? 'Uploading audio' : 'Drop audio'}
+        </span>
+        <span className='mt-1 text-2xs leading-4 text-tertiary-token'>
+          MP3, WAV, FLAC, AIFF, AAC, or M4A. Max 150 MB.
+        </span>
+      </button>
+      <input
+        ref={inputRef}
+        type='file'
+        accept={LIBRARY_AUDIO_ACCEPT}
+        onChange={handleInputChange}
+        disabled={uploading}
+        tabIndex={disabledTabIndex}
+        className='sr-only'
+        aria-label={`Upload audio for ${asset.title}`}
+      />
+      <div className='min-h-5 pt-1.5 text-2xs' role='status'>
+        {uploadError ? <p className='text-error'>{uploadError}</p> : null}
+      </div>
+    </div>
+  );
+}
+
+function LibraryAudioPanel({
+  asset,
+  isPreviewPlaying,
+  onTogglePreview,
+  onUploaded,
+  disabledTabIndex,
+}: {
+  readonly asset: LibraryReleaseAsset;
+  readonly isPreviewPlaying: boolean;
+  readonly onTogglePreview: LibraryPreviewToggle;
+  readonly onUploaded: (assetId: string, previewUrl: string) => void;
+  readonly disabledTabIndex?: number;
+}) {
+  return (
+    <div className='mt-4 border-t border-subtle pt-3'>
+      <div className='mb-2 flex h-7 items-center justify-between gap-2'>
+        <div className='flex min-w-0 items-center gap-2'>
+          <FileAudio2 className='h-3.5 w-3.5 shrink-0 text-tertiary-token' />
+          <h3 className='truncate text-xs font-semibold text-primary-token'>
+            Audio
+          </h3>
+        </div>
+        {asset.previewUrl ? (
+          <PreviewActionButton
+            asset={asset}
+            isPreviewPlaying={isPreviewPlaying}
+            onTogglePreview={onTogglePreview}
+            compact
+            disabledTabIndex={disabledTabIndex}
+          />
+        ) : null}
+      </div>
+      {asset.previewUrl ? (
+        <div
+          className='flex min-h-[118px] items-center gap-3 rounded-lg border border-subtle bg-surface-0 px-3 py-3'
+          data-testid='library-audio-ready'
+        >
+          <span className='grid h-8 w-8 shrink-0 place-items-center rounded-md bg-surface-1 text-secondary-token'>
+            <FileAudio2 className='h-4 w-4' strokeWidth={2.25} />
+          </span>
+          <div className='min-w-0'>
+            <p className='truncate text-xs font-medium text-primary-token'>
+              Audio attached
+            </p>
+            <p className='mt-0.5 text-2xs leading-4 text-tertiary-token'>
+              Preview playback is available in the persistent player.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <LibraryAudioDropzone
+          asset={asset}
+          onUploaded={onUploaded}
+          disabledTabIndex={disabledTabIndex}
+        />
+      )}
+    </div>
+  );
+}
+
 function AssetDrawer({
   asset,
   open,
   onClose,
   activePreviewId,
   playingPreviewId,
+  isDesktopLayout,
   onTogglePreview,
+  onAudioUploaded,
 }: {
   readonly asset: LibraryReleaseAsset | null;
   readonly open: boolean;
   readonly onClose: () => void;
   readonly activePreviewId: string | null;
   readonly playingPreviewId: string | null;
+  readonly isDesktopLayout: boolean;
   readonly onTogglePreview: LibraryPreviewToggle;
+  readonly onAudioUploaded: (assetId: string, previewUrl: string) => void;
 }) {
   const [stickyAsset, setStickyAsset] = useState<LibraryReleaseAsset | null>(
     asset
@@ -1273,11 +1532,16 @@ function AssetDrawer({
       aria-hidden={!open}
       inert={open ? undefined : true}
       className={cn(
-        'overflow-hidden border-l border-subtle bg-surface-0 transition-[opacity,transform] duration-cinematic ease-cinematic',
-        'fixed inset-x-3 bottom-20 top-16 z-40 rounded-lg border shadow-[0_18px_48px_rgba(0,0,0,0.28)] lg:bottom-3 lg:static lg:z-auto lg:rounded-none lg:border-y-0 lg:border-r-0 lg:shadow-none',
+        'h-full min-h-0 overflow-hidden border-l border-subtle bg-surface-0 transition-[opacity,transform] duration-cinematic ease-cinematic',
+        isDesktopLayout
+          ? 'static z-auto rounded-none border-y-0 border-r-0 shadow-none'
+          : 'fixed inset-x-3 bottom-20 top-16 z-40 rounded-lg border shadow-[0_18px_48px_rgba(0,0,0,0.28)]',
         open
           ? 'translate-y-0 opacity-100'
-          : 'pointer-events-none translate-y-2 opacity-0 max-lg:hidden'
+          : cn(
+              'pointer-events-none opacity-0',
+              isDesktopLayout ? null : 'translate-y-2 hidden'
+            )
       )}
       data-testid='library-asset-drawer'
     >
@@ -1294,6 +1558,7 @@ function AssetDrawer({
                 onTogglePreview={onTogglePreview}
                 compact
                 disabledTabIndex={closedTabIndex}
+                reserveSpace
               />
               <Link
                 href={current.smartLinkPath}
@@ -1323,7 +1588,7 @@ function AssetDrawer({
 
           <div className='min-h-0 flex-1 overflow-y-auto p-3'>
             <div className='overflow-hidden rounded-lg bg-black'>
-              <div className='aspect-square'>
+              <div className='mx-auto aspect-square w-full max-w-80'>
                 <Artwork asset={current} size='drawer' />
               </div>
             </div>
@@ -1363,13 +1628,15 @@ function AssetDrawer({
                 Open Release
                 <ExternalLink className='h-3 w-3' />
               </Link>
-              <PreviewActionButton
-                asset={current}
-                isPreviewPlaying={isPreviewPlaying}
-                onTogglePreview={onTogglePreview}
-                disabledTabIndex={closedTabIndex}
-              />
             </div>
+
+            <LibraryAudioPanel
+              asset={current}
+              isPreviewPlaying={isPreviewPlaying}
+              onTogglePreview={onTogglePreview}
+              onUploaded={onAudioUploaded}
+              disabledTabIndex={closedTabIndex}
+            />
 
             <dl className='mt-4'>
               <MetadataRow
@@ -1483,7 +1750,11 @@ export function LibrarySurface({
 }: {
   readonly assets: readonly LibraryReleaseAsset[];
 }) {
+  const router = useRouter();
   const { playbackState, toggleTrack } = useTrackAudioPlayer();
+  const [audioOverrides, setAudioOverrides] = useState<Record<string, string>>(
+    {}
+  );
   const [preset, setPreset] = useState<LibraryPresetId>('all');
   const [filters, setFilters] = useState<LibraryFilters>(() => emptyFilters());
   const [sort, setSort] = useState<LibrarySortKey>('releaseDate');
@@ -1494,38 +1765,58 @@ export function LibrarySurface({
   const [pills, setPills] = useState<FilterPill[]>([]);
   const isDesktopLayout = useBreakpoint('lg');
 
+  const effectiveAssets = useMemo<readonly LibraryReleaseAsset[]>(
+    () =>
+      assets.map((asset): LibraryReleaseAsset => {
+        const previewUrl = audioOverrides[asset.id];
+        if (!previewUrl) return asset;
+        const assetKinds: readonly LibraryAssetKind[] =
+          asset.assetKinds.includes('preview')
+            ? asset.assetKinds
+            : [...asset.assetKinds, 'preview'];
+
+        return {
+          ...asset,
+          previewUrl,
+          assetKinds,
+        };
+      }),
+    [assets, audioOverrides]
+  );
+
   const visibleAssets = useMemo(() => {
     const presetPredicate =
       PRESETS.find(item => item.id === preset)?.predicate ?? (() => true);
 
-    return assets
+    return effectiveAssets
       .filter(presetPredicate)
       .filter(asset => assetMatchesFilters(asset, filters))
       .filter(asset => assetMatchesPills(asset, pills))
       .toSorted(compareAssets(sort));
-  }, [assets, filters, pills, preset, sort]);
+  }, [effectiveAssets, filters, pills, preset, sort]);
 
   const artistOptions = useMemo(
-    () => uniqueSorted(assets.map(asset => asset.artist)),
-    [assets]
+    () => uniqueSorted(effectiveAssets.map(asset => asset.artist)),
+    [effectiveAssets]
   );
   const titleOptions = useMemo(
-    () => uniqueSorted(assets.map(asset => asset.title)),
-    [assets]
+    () => uniqueSorted(effectiveAssets.map(asset => asset.title)),
+    [effectiveAssets]
   );
   const statusOptions = useMemo(
-    () => uniqueSorted(assets.map(asset => asset.status)),
-    [assets]
+    () => uniqueSorted(effectiveAssets.map(asset => asset.status)),
+    [effectiveAssets]
   );
   const hasOptions = useMemo(
-    () => uniqueSorted(assets.flatMap(asset => asset.assetKinds)),
-    [assets]
+    () => uniqueSorted(effectiveAssets.flatMap(asset => asset.assetKinds)),
+    [effectiveAssets]
   );
 
   const selectedAsset =
     visibleAssets.find(asset => asset.id === selectedId) ?? null;
   const activePreviewAsset =
-    assets.find(asset => asset.id === playbackState.activeTrackId) ?? null;
+    effectiveAssets.find(asset => asset.id === playbackState.activeTrackId) ??
+    null;
   const activePreviewId = activePreviewAsset?.id ?? null;
   const playingPreviewId = playbackState.isPlaying ? activePreviewId : null;
   const activePreviewTitle =
@@ -1597,7 +1888,7 @@ export function LibrarySurface({
   const sidebarNavigation = useMemo(
     () => (
       <LibraryRail
-        assets={assets}
+        assets={effectiveAssets}
         preset={preset}
         filters={filters}
         onPreset={setPreset}
@@ -1605,7 +1896,7 @@ export function LibrarySurface({
         onClearFilters={() => setFilters(emptyFilters())}
       />
     ),
-    [assets, filters, preset]
+    [effectiveAssets, filters, preset]
   );
 
   const sidebarOverride = useMemo(
@@ -1622,7 +1913,7 @@ export function LibrarySurface({
 
   const headerSearchAdapter = useMemo(
     () =>
-      assets.length === 0
+      effectiveAssets.length === 0
         ? null
         : {
             key: 'library',
@@ -1633,7 +1924,7 @@ export function LibrarySurface({
             albumOptions: [],
             statusOptions,
             hasOptions,
-            totalCount: assets.length,
+            totalCount: effectiveAssets.length,
             visibleCount: visibleAssets.length,
             triggerLabel: 'Filter',
             ariaLabel: 'Filter library assets',
@@ -1642,7 +1933,7 @@ export function LibrarySurface({
           },
     [
       artistOptions,
-      assets.length,
+      effectiveAssets.length,
       hasOptions,
       pills,
       statusOptions,
@@ -1653,7 +1944,18 @@ export function LibrarySurface({
 
   useRegisterHeaderSearch(headerSearchAdapter);
 
-  if (assets.length === 0) {
+  const handleAudioUploaded = useCallback(
+    (assetId: string, previewUrl: string) => {
+      setAudioOverrides(previous => ({
+        ...previous,
+        [assetId]: previewUrl,
+      }));
+      router.refresh();
+    },
+    [router]
+  );
+
+  if (effectiveAssets.length === 0) {
     return <EmptyCatalog />;
   }
 
@@ -1670,7 +1972,7 @@ export function LibrarySurface({
           view={view}
           onView={setView}
           visibleCount={visibleAssets.length}
-          totalCount={assets.length}
+          totalCount={effectiveAssets.length}
           mobileFiltersOpen={mobileFiltersOpen}
           onToggleMobileFilters={() => setMobileFiltersOpen(value => !value)}
         />
@@ -1678,7 +1980,7 @@ export function LibrarySurface({
     >
       {mobileFiltersOpen ? (
         <LibraryRail
-          assets={assets}
+          assets={effectiveAssets}
           preset={preset}
           filters={filters}
           onPreset={setPreset}
@@ -1689,7 +1991,7 @@ export function LibrarySurface({
       ) : null}
 
       <div
-        className='grid min-h-0 flex-1 overflow-hidden'
+        className='grid h-full min-h-0 flex-1 overflow-hidden'
         style={
           {
             gridTemplateColumns: isDesktopLayout
@@ -1725,7 +2027,7 @@ export function LibrarySurface({
           </div>
           <LibraryStatusBar
             visibleCount={visibleAssets.length}
-            totalCount={assets.length}
+            totalCount={effectiveAssets.length}
             sort={sort}
             view={view}
             activePreviewTitle={activePreviewTitle}
@@ -1737,7 +2039,9 @@ export function LibrarySurface({
           onClose={() => setDrawerOpen(false)}
           activePreviewId={activePreviewId}
           playingPreviewId={playingPreviewId}
+          isDesktopLayout={isDesktopLayout}
           onTogglePreview={handleTogglePreview}
+          onAudioUploaded={handleAudioUploaded}
         />
       </div>
     </PageShell>

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -3,7 +3,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { Search } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useDashboardData } from '@/app/app/(shell)/dashboard/DashboardDataContext';
 import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
@@ -46,6 +46,60 @@ const searchNavItem: NavItem = {
   icon: Search,
   description: 'Search routes, releases, artists, and threads',
 };
+
+const THREAD_READ_STORAGE_KEY = 'jovie:sidebar-thread-read-at';
+const IN_PROGRESS_CHAT_TURN_STATUSES = new Set([
+  'reserved',
+  'running',
+  'streaming',
+]);
+const FAILED_CHAT_TURN_STATUSES = new Set([
+  'failed_tool_unavailable',
+  'failed_model_error',
+  'failed_timeout',
+  'failed_network',
+]);
+
+function readThreadReadState(): Record<string, string> {
+  try {
+    const stored = globalThis.localStorage?.getItem(THREAD_READ_STORAGE_KEY);
+    if (!stored) return {};
+    const parsed = JSON.parse(stored) as unknown;
+    if (!parsed || typeof parsed !== 'object') return {};
+
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).filter(
+        (entry): entry is [string, string] => typeof entry[1] === 'string'
+      )
+    );
+  } catch {
+    return {};
+  }
+}
+
+function writeThreadReadState(value: Record<string, string>): void {
+  try {
+    globalThis.localStorage?.setItem(
+      THREAD_READ_STORAGE_KEY,
+      JSON.stringify(value)
+    );
+  } catch {
+    // Storage can be unavailable in restricted browsers; row state still works.
+  }
+}
+
+function isTimestampAfter(
+  candidate: string | null | undefined,
+  baseline: string | null | undefined
+): boolean {
+  if (!candidate) return false;
+  if (!baseline) return true;
+  const candidateMs = Date.parse(candidate);
+  const baselineMs = Date.parse(baseline);
+  return Number.isFinite(candidateMs) && Number.isFinite(baselineMs)
+    ? candidateMs > baselineMs
+    : candidate > baseline;
+}
 
 type DashboardNavSection = {
   readonly key: string;
@@ -113,6 +167,8 @@ export function DashboardNav(_: DashboardNavProps) {
   const queryClient = useQueryClient();
   const shellChatV1Enabled = useAppFlag('DESIGN_V1');
   const shellChatLibraryEnabled = useAppFlag('SHELL_CHAT_V1');
+  const [threadReadAtById, setThreadReadAtById] =
+    useState<Record<string, string>>(readThreadReadState);
   const {
     isOpen: isPreviewOpen,
     open: openPreviewPanel,
@@ -155,6 +211,23 @@ export function DashboardNav(_: DashboardNavProps) {
     limit: 10,
     enabled: threadsVisible,
   });
+
+  useEffect(() => {
+    if (!conversations || conversations.length === 0) return;
+
+    setThreadReadAtById(previous => {
+      if (Object.keys(previous).length > 0) return previous;
+
+      const baseline = Object.fromEntries(
+        conversations.map(conversation => [
+          conversation.id,
+          conversation.updatedAt,
+        ])
+      );
+      writeThreadReadState(baseline);
+      return baseline;
+    });
+  }, [conversations]);
 
   // Settings nav: "General" (user) and artist name (or "Artist") groups
   const artistSettingsLabel = artistName || 'Artist';
@@ -365,24 +438,64 @@ export function DashboardNav(_: DashboardNavProps) {
     openCommandPalette();
   }, []);
 
-  const sidebarThreads = useMemo<SidebarThread[]>(
-    () =>
-      (conversations ?? []).map(conversation => ({
-        id: conversation.id,
-        href: `${APP_ROUTES.CHAT}/${encodeURIComponent(conversation.id)}`,
-        title: conversation.title?.trim() || 'Untitled thread',
-        status: 'complete',
-        updatedAt: conversation.updatedAt,
-      })),
-    [conversations]
-  );
-
   const activeThreadId = useMemo(() => {
     const chatPrefix = `${APP_ROUTES.CHAT}/`;
     if (!pathname.startsWith(chatPrefix)) return null;
     const [id] = pathname.slice(chatPrefix.length).split('/');
     return id ? decodeURIComponent(id) : null;
   }, [pathname]);
+
+  useEffect(() => {
+    if (!activeThreadId || !conversations) return;
+
+    const activeConversation = conversations.find(
+      conversation => conversation.id === activeThreadId
+    );
+    if (!activeConversation) return;
+
+    setThreadReadAtById(previous => {
+      if (previous[activeThreadId] === activeConversation.updatedAt) {
+        return previous;
+      }
+
+      const next = {
+        ...previous,
+        [activeThreadId]: activeConversation.updatedAt,
+      };
+      writeThreadReadState(next);
+      return next;
+    });
+  }, [activeThreadId, conversations]);
+
+  const sidebarThreads = useMemo<SidebarThread[]>(
+    () =>
+      (conversations ?? []).map(conversation => {
+        const latestTurnStatus = conversation.latestTurnStatus ?? null;
+        const isRunning = latestTurnStatus
+          ? IN_PROGRESS_CHAT_TURN_STATUSES.has(latestTurnStatus)
+          : false;
+        const isFailed = latestTurnStatus
+          ? FAILED_CHAT_TURN_STATUSES.has(latestTurnStatus)
+          : false;
+        const isUnread =
+          activeThreadId !== conversation.id &&
+          conversation.latestMessageRole === 'assistant' &&
+          isTimestampAfter(
+            conversation.updatedAt,
+            threadReadAtById[conversation.id]
+          );
+
+        return {
+          id: conversation.id,
+          href: `${APP_ROUTES.CHAT}/${encodeURIComponent(conversation.id)}`,
+          title: conversation.title?.trim() || 'Untitled thread',
+          status: isRunning ? 'running' : isFailed ? 'errored' : 'complete',
+          updatedAt: conversation.updatedAt,
+          unread: isUnread,
+        };
+      }),
+    [activeThreadId, conversations, threadReadAtById]
+  );
 
   const handleNewThread = useCallback(() => {
     router.push(APP_ROUTES.CHAT);

--- a/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
@@ -291,7 +291,7 @@ export function NavMenuItem({
         strokeWidth={2.25}
         aria-hidden='true'
       />
-      <span className='truncate group-data-[collapsible=icon]:hidden'>
+      <span className='min-w-0 truncate text-left justify-self-start group-data-[collapsible=icon]:hidden'>
         {item.name}
       </span>
       {item.badge != null ? (

--- a/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
+++ b/apps/web/components/features/dashboard/organisms/DashboardHeader.tsx
@@ -115,7 +115,9 @@ function BreadcrumbTrail({
         </>
       )}
       {showInlineSearch ? (
-        <div className='ml-1.5 flex min-w-0 items-center'>{searchSurface}</div>
+        <div className='ml-1.5 flex min-w-0 items-center justify-start'>
+          {searchSurface}
+        </div>
       ) : null}
     </>
   );
@@ -170,7 +172,7 @@ export function DashboardHeader({
           data-search-active={searchTakesOver ? 'true' : 'false'}
         >
           {searchTakesOver ? (
-            <div className='min-w-0 flex-1 flex items-center'>
+            <div className='flex min-w-0 flex-1 items-center justify-start'>
               {searchSurface}
             </div>
           ) : (

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -4,6 +4,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { ImagePlus } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { useCallback, useEffect, useRef } from 'react';
+import { JovieMarkElectric } from '@/components/atoms/JovieMarkElectric';
 import { useAppFlag } from '@/lib/flags/client';
 import { SUPPORTED_IMAGE_MIME_TYPES } from '@/lib/images/config';
 
@@ -444,11 +445,17 @@ export function JovieChat({
                   className='relative min-h-full'
                 >
                   <div
-                    className='relative mx-auto flex min-h-full w-full max-w-[52rem] flex-col items-center justify-center py-8'
+                    className='relative mx-auto flex min-h-full w-full max-w-[52rem] flex-col items-center justify-center px-1 py-8'
                     data-testid='chat-empty-state-composer-region'
                   >
                     <div
-                      className='w-full'
+                      className='pointer-events-none absolute left-1/2 top-1/2 h-[min(46vw,28rem)] w-[min(46vw,28rem)] -translate-x-1/2 -translate-y-[60%] opacity-80 max-sm:h-[min(72vw,18rem)] max-sm:w-[min(72vw,18rem)]'
+                      data-testid='chat-empty-state-logo'
+                    >
+                      <JovieMarkElectric className='h-full w-full' />
+                    </div>
+                    <div
+                      className='relative z-10 w-full'
                       data-testid='chat-empty-state-centered-composer'
                     >
                       {composerSurface}

--- a/apps/web/components/shell/HeaderSearchSurface.test.tsx
+++ b/apps/web/components/shell/HeaderSearchSurface.test.tsx
@@ -34,6 +34,8 @@ describe('HeaderSearchSurface', () => {
     const trigger = screen.getByRole('button', { name: 'Search Releases' });
     expect(trigger.className).toContain('h-7');
     expect(trigger.className).toContain('min-h-7');
+    expect(trigger.className).toContain('justify-start');
+    expect(trigger.className).toContain('text-left');
   });
 
   it('keeps the open search surface on the same compact header height', () => {
@@ -50,6 +52,8 @@ describe('HeaderSearchSurface', () => {
     expect(surface?.className).toContain('h-7');
     expect(surface?.className).toContain('min-h-7');
     expect(surface?.className).toContain('items-center');
+    expect(surface?.className).toContain('justify-start');
+    expect(surface?.className).toContain('text-left');
     expect(screen.getByLabelText('Filter Search Releases')).toBeInTheDocument();
   });
 });

--- a/apps/web/components/shell/HeaderSearchSurface.tsx
+++ b/apps/web/components/shell/HeaderSearchSurface.tsx
@@ -54,7 +54,7 @@ export function HeaderSearchSurface({
         onClick={onOpen}
         className={cn(
           headerSearchSurfaceChrome,
-          'inline-flex h-7 min-h-7 min-w-0 items-center gap-1.5 px-2.5 text-[12px] text-secondary-token transition-[background-color,border-color,color,box-shadow] duration-cinematic ease-cinematic hover:border-default hover:bg-surface-1 hover:text-primary-token focus-ring-themed',
+          'inline-flex h-7 min-h-7 min-w-0 items-center justify-start gap-1.5 px-2.5 text-left text-[12px] text-secondary-token transition-[background-color,border-color,color,box-shadow] duration-cinematic ease-cinematic hover:border-default hover:bg-surface-1 hover:text-primary-token focus-ring-themed',
           className
         )}
         aria-label={adapter.ariaLabel ?? adapter.triggerLabel}
@@ -73,7 +73,7 @@ export function HeaderSearchSurface({
     <div
       className={cn(
         headerSearchSurfaceChrome,
-        'flex h-7 min-h-7 w-full max-w-[min(560px,calc(100vw-2rem))] items-center px-2 py-0 shadow-popover sm:w-[440px] lg:w-[520px]',
+        'flex h-7 min-h-7 w-full max-w-[min(560px,calc(100vw-2rem))] items-center justify-start px-2 py-0 text-left shadow-popover sm:w-[440px] lg:w-[520px]',
         className
       )}
     >

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -108,7 +108,11 @@ export function SidebarNavItem({
         })}
         strokeWidth={2.25}
       />
-      {!collapsed && <span className='truncate'>{item.label}</span>}
+      {!collapsed && (
+        <span className='min-w-0 truncate text-left justify-self-start'>
+          {item.label}
+        </span>
+      )}
     </button>
   );
 

--- a/apps/web/lib/queries/useChatConversationsQuery.ts
+++ b/apps/web/lib/queries/useChatConversationsQuery.ts
@@ -9,6 +9,18 @@ export interface ChatConversation {
   title: string | null;
   createdAt: string;
   updatedAt: string;
+  latestMessageRole?: 'user' | 'assistant' | 'system' | null;
+  latestTurnStatus?:
+    | 'reserved'
+    | 'running'
+    | 'streaming'
+    | 'completed'
+    | 'failed_tool_unavailable'
+    | 'failed_model_error'
+    | 'failed_timeout'
+    | 'failed_network'
+    | 'canceled'
+    | null;
 }
 
 interface ConversationsResponse {

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -222,7 +222,7 @@ describe('DashboardNav interactions', () => {
   });
 
   it('renders recent threads in the Design V1 sidebar as App Router links', () => {
-    mockUseChatConversationsQuery.mockReturnValueOnce({
+    mockUseChatConversationsQuery.mockReturnValue({
       data: [
         {
           id: 'thread-older',
@@ -262,7 +262,7 @@ describe('DashboardNav interactions', () => {
   it('renders compact thread loading and empty states from the real conversations query', async () => {
     const user = userEvent.setup();
 
-    mockUseChatConversationsQuery.mockReturnValueOnce({
+    mockUseChatConversationsQuery.mockReturnValue({
       data: undefined,
       isLoading: true,
     });
@@ -276,7 +276,7 @@ describe('DashboardNav interactions', () => {
     expect(screen.queryByText('Loading threads')).not.toBeInTheDocument();
     unmount();
 
-    mockUseChatConversationsQuery.mockReturnValueOnce({
+    mockUseChatConversationsQuery.mockReturnValue({
       data: [],
       isLoading: false,
       isError: false,

--- a/apps/web/tests/unit/api/chat/conversations.test.ts
+++ b/apps/web/tests/unit/api/chat/conversations.test.ts
@@ -59,6 +59,12 @@ vi.mock('@/lib/db/schema/chat', () => ({
     conversationId: 'conversationId',
     role: 'role',
     content: 'content',
+    createdAt: 'createdAt',
+  },
+  chatTurns: {
+    conversationId: 'conversationId',
+    status: 'status',
+    updatedAt: 'updatedAt',
   },
 }));
 
@@ -66,6 +72,7 @@ vi.mock('drizzle-orm', () => ({
   count: vi.fn(),
   desc: vi.fn(),
   eq: vi.fn(),
+  sql: vi.fn(() => ({ as: vi.fn(() => 'subquery') })),
 }));
 
 vi.mock('@/lib/error-tracking', () => ({
@@ -123,6 +130,8 @@ describe('GET /api/chat/conversations', () => {
         title: 'Test Conv',
         createdAt: new Date(),
         updatedAt: new Date(),
+        latestMessageRole: 'assistant',
+        latestTurnStatus: 'streaming',
       },
     ];
     hoisted.getSessionContextMock.mockResolvedValue({
@@ -139,6 +148,8 @@ describe('GET /api/chat/conversations', () => {
     expect(body.conversations).toHaveLength(1);
     expect(body.conversations[0].id).toBe('conv_1');
     expect(body.conversations[0].title).toBe('Test Conv');
+    expect(body.conversations[0].latestMessageRole).toBe('assistant');
+    expect(body.conversations[0].latestTurnStatus).toBe('streaming');
   });
 
   it('respects limit query parameter', async () => {

--- a/apps/web/tests/unit/api/library-audio.test.ts
+++ b/apps/web/tests/unit/api/library-audio.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => {
+  const selectLimitMock = vi.fn();
+  const selectOrderByMock = vi.fn().mockReturnValue({ limit: selectLimitMock });
+  const selectWhereMock = vi
+    .fn()
+    .mockReturnValue({ orderBy: selectOrderByMock });
+  const selectInnerJoinSecondMock = vi
+    .fn()
+    .mockReturnValue({ where: selectWhereMock });
+  const selectInnerJoinFirstMock = vi.fn().mockReturnValue({
+    innerJoin: selectInnerJoinSecondMock,
+  });
+  const selectFromMock = vi.fn().mockReturnValue({
+    innerJoin: selectInnerJoinFirstMock,
+  });
+  const selectMock = vi.fn().mockReturnValue({ from: selectFromMock });
+
+  const updateWhereMock = vi.fn();
+  const updateSetMock = vi.fn().mockReturnValue({ where: updateWhereMock });
+  const updateMock = vi.fn().mockReturnValue({ set: updateSetMock });
+
+  return {
+    requireAuthMock: vi.fn(),
+    getSessionContextMock: vi.fn(),
+    handleUploadMock: vi.fn(),
+    selectMock,
+    selectLimitMock,
+    updateMock,
+    updateSetMock,
+    updateWhereMock,
+    revalidateTagMock: vi.fn(),
+    captureErrorMock: vi.fn(),
+  };
+});
+
+vi.mock('@vercel/blob/client', () => ({
+  handleUpload: hoisted.handleUploadMock,
+}));
+
+vi.mock('next/cache', () => ({
+  revalidateTag: hoisted.revalidateTagMock,
+}));
+
+vi.mock('@/lib/auth/require-auth', () => ({
+  requireAuth: hoisted.requireAuthMock,
+}));
+
+vi.mock('@/lib/auth/session', () => ({
+  getSessionContext: hoisted.getSessionContextMock,
+}));
+
+vi.mock('@/lib/cache/tags', () => ({
+  createSmartLinkContentTag: (profileId: string) =>
+    `smart-link-content:${profileId}`,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: hoisted.selectMock,
+    update: hoisted.updateMock,
+  },
+}));
+
+vi.mock('@/lib/db/schema/content', () => ({
+  discogReleases: {
+    id: 'release.id',
+    creatorProfileId: 'release.creatorProfileId',
+  },
+  discogReleaseTracks: {
+    releaseId: 'releaseTrack.releaseId',
+    recordingId: 'releaseTrack.recordingId',
+    discNumber: 'releaseTrack.discNumber',
+    trackNumber: 'releaseTrack.trackNumber',
+  },
+  discogRecordings: {
+    id: 'recording.id',
+    creatorProfileId: 'recording.creatorProfileId',
+    previewUrl: 'recording.previewUrl',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: hoisted.captureErrorMock,
+}));
+
+describe('library audio upload API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.requireAuthMock.mockResolvedValue({
+      userId: 'clerk_user_123',
+      error: null,
+    });
+    hoisted.getSessionContextMock.mockResolvedValue({
+      profile: { id: 'profile_123' },
+    });
+  });
+
+  it('generates a Blob client upload token for authenticated creators', async () => {
+    hoisted.handleUploadMock.mockResolvedValue({
+      type: 'blob.generate-client-token',
+    });
+
+    const { POST } = await import('@/app/api/library/audio/upload-token/route');
+    const response = await POST(
+      new Request('http://localhost/api/library/audio/upload-token', {
+        method: 'POST',
+        body: JSON.stringify({ type: 'blob.generate-client-token' }),
+      }) as never
+    );
+
+    expect(response.status).toBe(200);
+    expect(hoisted.handleUploadMock).toHaveBeenCalledTimes(1);
+    const options = hoisted.handleUploadMock.mock.calls[0][0];
+    const token = await options.onBeforeGenerateToken('take-me-over.mp3');
+    expect(token.maximumSizeInBytes).toBe(150 * 1024 * 1024);
+    expect(token.allowedContentTypes).toContain('audio/mpeg');
+  });
+
+  it('attaches uploaded audio to the first recording for an owned release', async () => {
+    hoisted.selectLimitMock.mockResolvedValue([
+      {
+        recordingId: 'recording_123',
+        currentPreviewUrl: null,
+      },
+    ]);
+    hoisted.updateWhereMock.mockResolvedValue({ rowCount: 1 });
+
+    const { POST } = await import('@/app/api/library/audio/confirm/route');
+    const response = await POST(
+      new Request('http://localhost/api/library/audio/confirm', {
+        method: 'POST',
+        body: JSON.stringify({
+          releaseId: '00000000-0000-4000-8000-000000000001',
+          blobUrl: 'https://cdn.example.com/take-me-over.mp3',
+          blobPathname: 'library/audio/take-me-over.mp3',
+          fileName: 'take-me-over.mp3',
+          fileMimeType: 'audio/mpeg',
+          fileSizeBytes: 1024,
+        }),
+      }) as never
+    );
+
+    expect(response.status).toBe(200);
+    expect(hoisted.updateSetMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        previewUrl: 'https://cdn.example.com/take-me-over.mp3',
+        audioUrl: 'https://cdn.example.com/take-me-over.mp3',
+        audioFormat: 'audio/mpeg',
+      })
+    );
+    expect(hoisted.revalidateTagMock).toHaveBeenCalledWith(
+      'releases:clerk_user_123:profile_123',
+      'max'
+    );
+  });
+
+  it('refuses to overwrite existing release audio', async () => {
+    hoisted.selectLimitMock.mockResolvedValue([
+      {
+        recordingId: 'recording_123',
+        currentPreviewUrl: 'https://cdn.example.com/existing.mp3',
+      },
+    ]);
+
+    const { POST } = await import('@/app/api/library/audio/confirm/route');
+    const response = await POST(
+      new Request('http://localhost/api/library/audio/confirm', {
+        method: 'POST',
+        body: JSON.stringify({
+          releaseId: '00000000-0000-4000-8000-000000000001',
+          blobUrl: 'https://cdn.example.com/take-me-over.mp3',
+          blobPathname: 'library/audio/take-me-over.mp3',
+          fileName: 'take-me-over.mp3',
+          fileMimeType: 'audio/mpeg',
+          fileSizeBytes: 1024,
+        }),
+      }) as never
+    );
+
+    expect(response.status).toBe(409);
+    expect(hoisted.updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -140,7 +140,7 @@ describe('JovieChat empty state', () => {
     mockChatState.chipTray.chips = [];
   });
 
-  it('renders only the simple composer when empty', () => {
+  it('renders only the logo and simple composer when empty', () => {
     const { getByTestId, queryByTestId, queryByText } = renderWithQueryClient(
       <JovieChat profileId='profile-1' />
     );
@@ -157,6 +157,7 @@ describe('JovieChat empty state', () => {
     expect(queryByText('Jovie Assistant')).toBeNull();
     expect(queryByText('Ask anything or tell Jovie what you need')).toBeNull();
     expect(getByTestId('chat-empty-state-composer-region')).toBeTruthy();
+    expect(getByTestId('chat-empty-state-logo')).toBeTruthy();
     expect(getByTestId('chat-empty-state-centered-composer')).toBeTruthy();
     expect(queryByTestId('chat-empty-state-action-card-slot')).toBeNull();
     expect(queryByTestId('chat-composer-dock')).toBeNull();

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -113,6 +113,53 @@ describe('DashboardNav', () => {
     }
   });
 
+  it('maps real conversation metadata into unread and running thread rows', () => {
+    localStorage.setItem(
+      'jovie:sidebar-thread-read-at',
+      JSON.stringify({
+        'conv-unread': '2026-05-22T08:00:00.000Z',
+        'conv-running': '2026-05-22T09:00:00.000Z',
+      })
+    );
+    mockUseChatConversationsQuery.mockReturnValue({
+      data: [
+        {
+          id: 'conv-unread',
+          title: 'Unread answer',
+          createdAt: '2026-05-22T07:00:00.000Z',
+          updatedAt: '2026-05-22T10:00:00.000Z',
+          latestMessageRole: 'assistant',
+          latestTurnStatus: 'completed',
+        },
+        {
+          id: 'conv-running',
+          title: 'Running task',
+          createdAt: '2026-05-22T07:00:00.000Z',
+          updatedAt: '2026-05-22T10:30:00.000Z',
+          latestMessageRole: 'user',
+          latestTurnStatus: 'streaming',
+        },
+      ],
+      isError: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    });
+
+    const { container, getByRole } = renderDashboardNav({
+      renderFn: fastRender,
+      appFlags: { DESIGN_V1: true },
+    });
+
+    expect(getByRole('link', { name: 'Unread answer' })).toHaveClass(
+      'text-primary-token'
+    );
+    expect(getByRole('link', { name: 'Running task' })).toHaveAttribute(
+      'href',
+      `${APP_ROUTES.CHAT}/conv-running`
+    );
+    expect(container.querySelector('.anim-calm-breath')).toBeTruthy();
+  });
+
   it('handles collapsed state', () => {
     const { container } = renderDashboardNav({
       renderFn: fastRender,

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -1,7 +1,13 @@
 import { TooltipProvider } from '@jovie/ui';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import type { ComponentProps } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LibrarySurface } from '@/app/app/(shell)/library/LibrarySurface';
 import type { LibraryReleaseAsset } from '@/app/app/(shell)/library/library-data';
 import { HeaderSearchSurfaceFromContext } from '@/components/shell/HeaderSearchSurface';
@@ -13,6 +19,12 @@ import {
 } from '@/contexts/ShellSidebarOverrideContext';
 
 Element.prototype.scrollIntoView = vi.fn();
+
+const navigationMock = vi.hoisted(() => ({
+  refresh: vi.fn(),
+}));
+
+const blobUploadMock = vi.hoisted(() => vi.fn());
 
 const audioMock = vi.hoisted(() => {
   const basePlaybackState = {
@@ -41,6 +53,16 @@ const audioMock = vi.hoisted(() => {
 
 vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
   useTrackAudioPlayer: () => audioMock,
+}));
+
+vi.mock('@vercel/blob/client', () => ({
+  upload: blobUploadMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    refresh: navigationMock.refresh,
+  }),
 }));
 
 vi.mock('sonner', () => ({
@@ -154,6 +176,12 @@ describe('LibrarySurface', () => {
     audioMock.seek.mockClear();
     audioMock.stop.mockClear();
     audioMock.onError.mockClear();
+    navigationMock.refresh.mockClear();
+    blobUploadMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('renders an empty read-only library state with a releases escape hatch', () => {
@@ -303,6 +331,83 @@ describe('LibrarySurface', () => {
       artworkUrl: 'https://cdn.example.com/artwork.jpg',
       hasLyrics: true,
     });
+  });
+
+  it('renders a right-rail audio dropzone when a release is missing audio', () => {
+    renderLibrary([
+      buildAsset({
+        previewUrl: null,
+        assetKinds: ['artwork', 'lyrics', 'providers'],
+      }),
+    ]);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Inspect Take Me Over/u })
+    );
+
+    expect(screen.getByTestId('library-audio-dropzone')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Upload audio for Take Me Over')
+    ).toHaveAttribute('accept', expect.stringContaining('audio/mpeg'));
+    expect(screen.queryByTestId('library-audio-ready')).not.toBeInTheDocument();
+  });
+
+  it('uploads missing drawer audio and reveals persistent-player controls', async () => {
+    const previewUrl = 'https://cdn.example.com/uploaded-preview.mp3';
+    blobUploadMock.mockResolvedValue({
+      url: previewUrl,
+      pathname: 'library/audio/uploaded-preview.mp3',
+    });
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ success: true, previewUrl }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderLibrary([
+      buildAsset({
+        previewUrl: null,
+        assetKinds: ['artwork', 'lyrics', 'providers'],
+      }),
+    ]);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Inspect Take Me Over/u })
+    );
+    fireEvent.change(screen.getByLabelText('Upload audio for Take Me Over'), {
+      target: {
+        files: [
+          new File(['audio'], 'take-me-over.mp3', { type: 'audio/mpeg' }),
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('library-audio-ready')).toBeInTheDocument();
+    });
+    expect(blobUploadMock).toHaveBeenCalledWith(
+      'take-me-over.mp3',
+      expect.any(File),
+      {
+        access: 'public',
+        handleUploadUrl: '/api/library/audio/upload-token',
+      }
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/library/audio/confirm',
+      expect.objectContaining({
+        method: 'POST',
+      })
+    );
+    expect(navigationMock.refresh).toHaveBeenCalledTimes(1);
+    expect(
+      within(screen.getByTestId('library-asset-drawer')).getAllByRole(
+        'button',
+        { name: /Play Preview for Take Me Over/u }
+      ).length
+    ).toBeGreaterThan(0);
   });
 
   it('opens the read-only asset drawer from list rows', () => {


### PR DESCRIPTION
## Summary
- restore the large empty-chat Jovie mark while keeping welcome copy, suggestion pills, and empty-state cards hidden
- left-align shell search/nav labels and port real thread unread/running/error metadata into the sidebar
- add authenticated library audio upload/confirm APIs and a visible right-rail audio dropzone for releases missing audio

## Verification
- pnpm biome check --write apps/web/app/api/chat/conversations/route.ts "apps/web/app/app/(shell)/library/LibrarySurface.tsx" apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx apps/web/components/features/dashboard/organisms/DashboardHeader.tsx apps/web/components/jovie/JovieChat.tsx apps/web/components/shell/HeaderSearchSurface.test.tsx apps/web/components/shell/HeaderSearchSurface.tsx apps/web/components/shell/SidebarNavItem.tsx apps/web/lib/queries/useChatConversationsQuery.ts apps/web/tests/unit/api/chat/conversations.test.ts apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx apps/web/tests/unit/dashboard/DashboardNav.test.tsx apps/web/tests/unit/library/LibrarySurface.test.tsx apps/web/app/api/library/audio/upload-token/route.ts apps/web/app/api/library/audio/confirm/route.ts apps/web/tests/unit/api/library-audio.test.ts
- pnpm --filter @jovie/web exec vitest run tests/unit/chat/JovieChat.empty-state.test.tsx components/shell/HeaderSearchSurface.test.tsx tests/unit/dashboard/DashboardNav.test.tsx tests/unit/api/chat/conversations.test.ts tests/unit/library/LibrarySurface.test.tsx tests/unit/api/library-audio.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pre-commit hook: proxy guard, lint-staged Biome/a11y, ESLint, web typecheck
- pre-push hook: full Biome check, proxy guard, tailwind guard, web typecheck, web lint
- browser smoke on localhost:3000 with creator-ready dev auth: /app/chat logo visible with no welcome/suggestions, sidebar search left aligned, /app/library drawer opens as right rail with audio dropzone visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio file uploads for library release previews with drag-and-drop support
  * Chat conversations now display latest message role and thread status information

* **Improvements**
  * Unread chat thread indicators based on conversation activity
  * Navigation and search interface layout refinements
  * Enhanced visual branding in empty chat state

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9565?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->