### PR TITLE
fix(a11y): stabilize public axe fixtures

### DIFF
--- a/apps/web/app/r/[slug]/ReleaseLandingPage.tsx
+++ b/apps/web/app/r/[slug]/ReleaseLandingPage.tsx
@@ -373,6 +373,11 @@ export function ReleaseLandingPage({
     >
       {/* Content — streaming buttons (scrollable) */}
       <div className='relative z-10 flex min-h-0 flex-1 flex-col px-5 pt-3'>
+        <p className='sr-only'>
+          {parentRelease
+            ? `${release.title} by ${artist.name}, from ${parentRelease.title}. Choose a streaming service.`
+            : `${release.title} by ${artist.name}. Choose a streaming service.`}
+        </p>
         <div className='min-h-0 flex-1 overflow-y-auto overscroll-contain scrollbar-hide'>
           {claimBanner && (
             <SmartLinkClaimBanner

--- a/apps/web/components/features/profile/views/PayView.tsx
+++ b/apps/web/components/features/profile/views/PayView.tsx
@@ -74,6 +74,7 @@ export function PayView({
       primaryLabel='Continue with Venmo'
       paymentLabel='Venmo'
       showOtherPaymentOptions={false}
+      screenReaderDescription={`Send support to ${artistHandle} with Venmo.`}
     />
   );
 }

--- a/apps/web/components/features/release/UnreleasedReleaseHero.tsx
+++ b/apps/web/components/features/release/UnreleasedReleaseHero.tsx
@@ -97,6 +97,10 @@ export function UnreleasedReleaseHero({
       >
         {/* Content — countdown + notification signup */}
         <div className='relative z-10 flex min-h-0 flex-1 flex-col px-5 pt-3'>
+          <p className='sr-only'>
+            {release.title} by {artist.name} is coming soon. Get notified when
+            it drops.
+          </p>
           <div className='min-h-0 flex-1 overflow-y-auto overscroll-contain scrollbar-hide'>
             <PreSaveActions
               releaseId={release.id}

--- a/apps/web/components/molecules/PaySelector.tsx
+++ b/apps/web/components/molecules/PaySelector.tsx
@@ -20,6 +20,7 @@ interface PaySelectorProps {
   readonly primaryLabel?: string;
   readonly otherPaymentOptionsLabel?: string;
   readonly showOtherPaymentOptions?: boolean;
+  readonly screenReaderDescription?: string;
 }
 
 function formatAmountForScreenReader(amount: number): string {
@@ -56,6 +57,7 @@ export function PaySelector({
   primaryLabel = 'Continue',
   otherPaymentOptionsLabel = 'Other payment methods',
   showOtherPaymentOptions = false,
+  screenReaderDescription,
 }: PaySelectorProps) {
   const defaultIdx = Math.floor(Math.max(0, amounts.length - 1) / 2);
   const [selectedIdx, setSelectedIdx] = useState<number>(defaultIdx);
@@ -133,6 +135,9 @@ export function PaySelector({
         <h3 id='pay-selector-heading' className='sr-only'>
           Select amount
         </h3>
+        {screenReaderDescription ? (
+          <p className='sr-only'>{screenReaderDescription}</p>
+        ) : null}
 
         <div className='sr-only' aria-live='polite' ref={statusRef}></div>
 
@@ -295,6 +300,9 @@ export function PaySelector({
       <h3 id='pay-selector-heading' className='sr-only'>
         Select amount
       </h3>
+      {screenReaderDescription ? (
+        <p className='sr-only'>{screenReaderDescription}</p>
+      ) : null}
 
       <div className='sr-only' aria-live='polite' ref={statusRef}></div>
 

--- a/apps/web/tests/seed-test-data.ts
+++ b/apps/web/tests/seed-test-data.ts
@@ -287,6 +287,7 @@ type SeededReleaseValues = Pick<
   | 'slug'
   | 'releaseType'
   | 'releaseDate'
+  | 'revealDate'
   | 'artworkUrl'
   | 'totalTracks'
   | 'upc'
@@ -365,6 +366,7 @@ interface TestRelease {
   slug: string;
   releaseType: 'single' | 'album' | 'ep' | 'compilation';
   releaseDate: Date;
+  revealDate?: Date | null;
   artworkUrl: string;
   spotifyUrl: string;
   totalTracks: number;
@@ -869,6 +871,7 @@ const TEST_RELEASES: TestRelease[] = [
     slug: 'future-glow',
     releaseType: 'single',
     releaseDate: getFutureReleaseDate(),
+    revealDate: new Date('2024-01-01T00:00:00.000Z'),
     artworkUrl: DEFAULT_TEST_RELEASE_ARTWORK_URL,
     spotifyUrl: 'https://open.spotify.com/album/2BB4d3cOWNNsVw41Gqt2aa',
     totalTracks: 1,
@@ -927,28 +930,30 @@ async function seedReleasesForProfile(
   }
 
   for (const release of TEST_RELEASES) {
-    let releaseId = existingBySlug.get(release.slug);
+    const existingReleaseId = existingBySlug.get(release.slug);
+    const releaseValues = {
+      creatorProfileId: profileId,
+      title: release.title,
+      slug: release.slug,
+      releaseType: release.releaseType,
+      releaseDate: release.releaseDate,
+      revealDate: release.revealDate ?? null,
+      artworkUrl: release.artworkUrl,
+      totalTracks: release.totalTracks,
+      upc: release.upc,
+      label: release.label,
+      sourceType: 'manual' as const,
+    } satisfies SeededReleaseValues;
 
-    // Create release if it doesn't exist
-    if (!releaseId) {
-      releaseId = await ensureRelease({
-        creatorProfileId: profileId,
-        title: release.title,
-        slug: release.slug,
-        releaseType: release.releaseType,
-        releaseDate: release.releaseDate,
-        artworkUrl: release.artworkUrl,
-        totalTracks: release.totalTracks,
-        upc: release.upc,
-        label: release.label,
-        sourceType: 'manual',
-      });
+    const releaseId = await ensureRelease(releaseValues);
+
+    if (!existingReleaseId) {
       console.log(
         `    ✓ Created release: ${release.title} (${release.releaseType}, ${release.totalTracks} tracks)`
       );
       existingBySlug.set(release.slug, releaseId);
     } else {
-      console.log(`    ✓ Release exists: ${release.title}`);
+      console.log(`    ✓ Ensured release: ${release.title}`);
     }
 
     // Add Spotify provider link with upsert behavior (onConflictDoNothing)
@@ -998,7 +1003,13 @@ async function seedReleasesForProfile(
 
     // Seed tracks if provided
     if (release.tracks && release.tracks.length > 0) {
-      await seedTracksForRelease(db, releaseId, profileId, release.tracks);
+      await seedTracksForRelease(
+        db,
+        releaseId,
+        profileId,
+        release.tracks,
+        release.spotifyUrl
+      );
     }
 
     console.log(`    ✓ Ensured Spotify link for ${release.title}`);
@@ -1050,7 +1061,8 @@ async function seedTracksForRelease(
   db: ReturnType<typeof drizzle>,
   releaseId: string,
   profileId: string,
-  tracks: TestTrack[]
+  tracks: TestTrack[],
+  releaseSpotifyUrl: string
 ) {
   const trackValues = tracks.map(track => ({
     releaseId,
@@ -1066,6 +1078,31 @@ async function seedTracksForRelease(
   }));
 
   await db.insert(discogTracks).values(trackValues).onConflictDoNothing();
+
+  const seededTracks = await db
+    .select({ id: discogTracks.id, slug: discogTracks.slug })
+    .from(discogTracks)
+    .where(eq(discogTracks.releaseId, releaseId));
+  const expectedTrackSlugs = new Set(tracks.map(track => track.slug));
+
+  for (const track of seededTracks) {
+    if (!expectedTrackSlugs.has(track.slug)) {
+      continue;
+    }
+
+    await db
+      .insert(providerLinks)
+      .values({
+        providerId: 'spotify',
+        ownerType: 'track',
+        trackId: track.id,
+        url: `${releaseSpotifyUrl}?track=${encodeURIComponent(track.slug)}`,
+        isPrimary: true,
+        sourceType: 'manual',
+      })
+      .onConflictDoNothing();
+  }
+
   console.log(`      ✓ Ensured ${tracks.length} tracks`);
 }
 


### PR DESCRIPTION
Linear: JOV-2554

## Summary
- Refresh public smart-link seed data on every E2E seed run so countdown and track surfaces stay eligible.
- Seed track-level Spotify links for public track pages.
- Add screen-reader context to pay, released smart-link, and countdown smart-link surfaces without changing visible layout.

## Verification
- `pnpm biome check --write apps/web/tests/seed-test-data.ts 'apps/web/app/r/[slug]/ReleaseLandingPage.tsx' apps/web/components/molecules/PaySelector.tsx apps/web/components/features/profile/views/PayView.tsx apps/web/components/features/release/UnreleasedReleaseHero.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web exec vitest run tests/unit/profile/ProfileIntentPage.test.tsx tests/unit/app/public-surface-guardrails.test.ts`
- `PUBLIC_SURFACE_FILTER=public-countdown BASE_URL=http://localhost:3001 E2E_SKIP_WEB_SERVER=1 E2E_SKIP_WARMUP=1 PLAYWRIGHT_WORKERS=1 pnpm --filter @jovie/web exec playwright test tests/e2e/axe-audit.spec.ts --config=playwright.config.ts --project=chromium --reporter=line`
- `PUBLIC_SURFACE_FILTER=profile-pay,public-release,public-track,public-countdown BASE_URL=http://localhost:3001 E2E_SKIP_WEB_SERVER=1 E2E_SKIP_WARMUP=1 PLAYWRIGHT_WORKERS=1 pnpm --filter @jovie/web exec playwright test tests/e2e/axe-audit.spec.ts --config=playwright.config.ts --project=chromium --reporter=line`
- `git push -u origin codex/public-a11y-fixtures` pre-push hook: Biome, proxy guard, Tailwind guard, typecheck, lint