### PR TITLE
test: harden web test config resolution

### DIFF
--- a/apps/web/tests/e2e/utils/dashboard-route-resolvers.ts
+++ b/apps/web/tests/e2e/utils/dashboard-route-resolvers.ts
@@ -60,21 +60,25 @@ interface ConversationsListResponse {
   }>;
 }
 
-interface BrowserFetchInit {
+interface PlaywrightRequestInit {
   readonly method?: string;
   readonly headers?: Record<string, string>;
-  readonly body?: string;
+  readonly data?: string;
+}
+
+interface FetchJsonResult<T> {
+  readonly ok: boolean;
+  readonly status: number;
+  readonly data: T;
+  readonly parseError?: string;
+  readonly rawBody?: string;
 }
 
 async function fetchJsonFromPage<T>(
   page: Page,
   input: string,
-  init?: BrowserFetchInit
-): Promise<{
-  readonly ok: boolean;
-  readonly status: number;
-  readonly data: T;
-}> {
+  init?: PlaywrightRequestInit
+): Promise<FetchJsonResult<T>> {
   const baseUrl = process.env.BASE_URL ?? 'http://localhost:3100';
   const resolvedTarget = /^[a-z]+:\/\//i.test(input)
     ? input
@@ -82,15 +86,18 @@ async function fetchJsonFromPage<T>(
   const response = await page.context().request.fetch(resolvedTarget, {
     method: init?.method,
     headers: init?.headers,
-    data: init?.body,
+    data: init?.data,
     timeout: 15_000,
   });
   const rawBody = await response.text().catch(() => '');
   let data = {} as T;
+  let parseError: string | undefined;
   if (rawBody.trim().length > 0) {
     try {
       data = JSON.parse(rawBody) as T;
-    } catch {
+    } catch (error) {
+      parseError =
+        error instanceof Error ? error.message : 'Unknown JSON parse error';
       data = {} as T;
     }
   }
@@ -99,6 +106,8 @@ async function fetchJsonFromPage<T>(
     ok: response.ok(),
     status: response.status(),
     data,
+    parseError,
+    rawBody: parseError ? rawBody : undefined,
   };
 }
 
@@ -121,7 +130,7 @@ export async function resolveChatConversationPath(page: Page): Promise<string> {
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({
+      data: JSON.stringify({
         title: 'Dashboard QA thread',
       }),
     }
@@ -129,8 +138,11 @@ export async function resolveChatConversationPath(page: Page): Promise<string> {
 
   const createdConversationId = created.data.conversation?.id;
   if (!created.ok || !createdConversationId) {
+    const parseDetails = created.parseError
+      ? `; response was not valid JSON (${created.parseError})`
+      : '';
     throw new Error(
-      `Unable to resolve chat conversation route (status ${created.status})`
+      `Unable to resolve chat conversation route (status ${created.status}${parseDetails})`
     );
   }
 

--- a/apps/web/vitest.config.mjs
+++ b/apps/web/vitest.config.mjs
@@ -1,16 +1,27 @@
 import dotenv from 'dotenv';
+import fs from 'fs';
 import path from 'path';
 import { defineConfig } from 'vitest/config';
 
-// Load environment variables from .env.test if it exists
-dotenv.config({ path: '.env.test' });
+const realRoot = (() => {
+  try {
+    return fs.realpathSync(path.resolve(__dirname));
+  } catch {
+    return path.resolve(__dirname);
+  }
+})();
+const workspaceRoot = realRoot.includes(`${path.sep}.stryker-tmp${path.sep}`)
+  ? path.resolve(realRoot, '../../../..')
+  : path.resolve(realRoot, '../..');
 
-const workspaceRoot = path.resolve(__dirname, '../..');
+// Load environment variables from .env.test if it exists
+dotenv.config({ path: path.resolve(realRoot, '.env.test') });
 
 export default defineConfig({
+  root: realRoot,
   test: {
     environment: 'jsdom',
-    setupFiles: ['./tests/setup.ts'],
+    setupFiles: [path.resolve(realRoot, 'tests/setup.ts')],
     exclude: [
       'tests/e2e/**',
       'tests/performance/**',
@@ -46,10 +57,52 @@ export default defineConfig({
     globals: true,
   },
   resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './'),
-      '@jovie/ui': path.resolve(workspaceRoot, 'packages/ui'),
-    },
+    alias: [
+      {
+        find: /^@\/app\/app\//,
+        replacement: `${path.resolve(realRoot, './app/app')}/`,
+      },
+      {
+        find: /^@\/app\/api\//,
+        replacement: `${path.resolve(realRoot, './app/api')}/`,
+      },
+      {
+        find: /^@\/app\/\(marketing\)\//,
+        replacement: `${path.resolve(realRoot, './app/(marketing)')}/`,
+      },
+      {
+        find: /^@\/app\/\(shell\)\//,
+        replacement: `${path.resolve(realRoot, './app/app/(shell)')}/`,
+      },
+      {
+        find: /^@\/app\//,
+        replacement: `${path.resolve(realRoot, './app')}/`,
+      },
+      {
+        find: /^@\/features\//,
+        replacement: `${path.resolve(realRoot, './components/features')}/`,
+      },
+      {
+        find: /^@\//,
+        replacement: `${path.resolve(realRoot, './')}/`,
+      },
+      {
+        find: /^@jovie\/auth-routing$/,
+        replacement: path.resolve(workspaceRoot, 'packages/auth-routing'),
+      },
+      {
+        find: /^@jovie\/auth-routing\//,
+        replacement: `${path.resolve(workspaceRoot, 'packages/auth-routing')}/`,
+      },
+      {
+        find: /^@jovie\/ui\//,
+        replacement: `${path.resolve(workspaceRoot, 'packages/ui')}/`,
+      },
+      {
+        find: /^@jovie\/ui$/,
+        replacement: path.resolve(workspaceRoot, 'packages/ui'),
+      },
+    ],
   },
   // Build optimizations
   build: {


### PR DESCRIPTION
## Summary
- surface malformed JSON responses in the dashboard E2E route resolver instead of collapsing parse failures into empty objects
- align the standard Vitest config with the fast config for realpath/Stryker workspace resolution and @/feature, @jovie/auth-routing, and @jovie/ui aliases

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/tests/e2e/utils/dashboard-route-resolvers.ts apps/web/vitest.config.mjs
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/chat/useChatMutations.test.tsx --config=vitest.config.mjs
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/lib/auth/routing-state.server.test.ts --config=vitest.config.mjs
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push hook: biome check . && pnpm --filter=@jovie/web run pre-push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced error handling in test utilities with detailed JSON parsing failure reporting.

* **Chores**
  * Updated test environment configuration with improved path resolution and module aliasing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->