### PR TITLE
fix(auth): require clerk on central auth routes

### DIFF
--- a/apps/web/lib/auth/clerk-middleware-bypass.ts
+++ b/apps/web/lib/auth/clerk-middleware-bypass.ts
@@ -13,6 +13,8 @@ interface ClerkCookieLike {
 
 const CLERK_REQUIRED_EXACT_PATHS = [
   APP_ROUTES.DASHBOARD,
+  '/auth/callback',
+  '/auth/start',
   '/__clerk',
   '/monitoring',
 ] as const;

--- a/apps/web/tests/unit/lib/auth/clerk-middleware-bypass.test.ts
+++ b/apps/web/tests/unit/lib/auth/clerk-middleware-bypass.test.ts
@@ -119,6 +119,22 @@ describe('shouldBypassClerkForRequest', () => {
       shouldBypassClerkForRequest({
         cookies: [],
         pathInfo: PUBLIC_PATH_INFO,
+        pathname: '/auth/start',
+      })
+    ).toBe(false);
+
+    expect(
+      shouldBypassClerkForRequest({
+        cookies: [],
+        pathInfo: PUBLIC_PATH_INFO,
+        pathname: '/auth/callback',
+      })
+    ).toBe(false);
+
+    expect(
+      shouldBypassClerkForRequest({
+        cookies: [],
+        pathInfo: PUBLIC_PATH_INFO,
         pathname: '/__clerk/v1/client',
       })
     ).toBe(false);


### PR DESCRIPTION
## Summary
- keep Clerk middleware enabled for /auth/start and /auth/callback
- prevents signed-out iOS/Electron central auth starts from bypassing Clerk and then throwing inside auth()
- adds regression assertions for central auth routes in the Clerk bypass policy

## Root Cause
/auth/start and /auth/callback were added as central auth routes in #9558, but the proxy bypass policy still classified them as public routes. Signed-out native auth launches have no Clerk cookies, so proxy bypassed Clerk middleware and the route handler called auth() without Clerk request context. That produced the production Sentry error and the user-visible JSON 503.

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/lib/auth/clerk-middleware-bypass.test.ts --config=vitest.config.mjs
- pnpm --filter @jovie/web exec vitest run tests/unit/lib/auth/clerk-middleware-bypass.test.ts tests/unit/lib/proxy-url-mapping.test.ts tests/unit/middleware/route-policy.test.ts --config=vitest.config.mjs
- pnpm --filter @jovie/auth-routing run test
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm biome check --write apps/web/lib/auth/clerk-middleware-bypass.ts apps/web/tests/unit/lib/auth/clerk-middleware-bypass.test.ts
- git diff --check
- pre-push: Biome, proxy guard, Tailwind guard, typecheck, lint

## Production Repro
Current production before this patch returns HTTP/2 503 with {"error":"Auth is temporarily unavailable"} for /auth/start?client=ios&intent=sign_in&return_to=%2Fapp&code_challenge=...&code_challenge_method=S256.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved authentication bypass issue by ensuring Clerk authentication is properly enforced on authentication endpoints.

* **Tests**
  * Added test assertions to verify Clerk authentication is correctly required for protected authentication routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->