### PR TITLE
fix(chat): strengthen composer hierarchy

### DIFF
--- a/apps/web/components/atoms/JovieMarkElectric.tsx
+++ b/apps/web/components/atoms/JovieMarkElectric.tsx
@@ -54,9 +54,9 @@ export function JovieMarkElectric({
         <style id={styleId}>{`
           @keyframes ${sparkAnimationName} {
             0%   { stroke-dashoffset: 45;    opacity: 0; }
-            14%  { stroke-dashoffset: -120;  opacity: 0.56; }
-            48%  { stroke-dashoffset: -520;  opacity: 0.68; }
-            78%  { stroke-dashoffset: -820;  opacity: 0.22; }
+            12%  { stroke-dashoffset: -110;  opacity: 0.42; }
+            42%  { stroke-dashoffset: -500;  opacity: 0.72; }
+            76%  { stroke-dashoffset: -820;  opacity: 0.34; }
             100% { stroke-dashoffset: -1000; opacity: 0; }
           }
         `}</style>
@@ -71,14 +71,14 @@ export function JovieMarkElectric({
       >
         <defs>
           <filter id={filterId} x='-30%' y='-30%' width='160%' height='160%'>
-            <feGaussianBlur stdDeviation='2.5' />
+            <feGaussianBlur stdDeviation='4.5' />
           </filter>
         </defs>
         <path
           d={JOVIE_ICON_PATH}
           fill='none'
-          stroke='rgba(255,255,255,0.04)'
-          strokeWidth='1'
+          stroke='rgba(255,255,255,0.065)'
+          strokeWidth='1.15'
         />
         {showSpark && (
           <>
@@ -86,9 +86,9 @@ export function JovieMarkElectric({
               pathLength='1000'
               d={JOVIE_ICON_PATH}
               fill='none'
-              stroke='rgba(78,190,255,0.76)'
-              strokeWidth='1.4'
-              strokeDasharray='50 950'
+              stroke='rgba(78,190,255,0.82)'
+              strokeWidth='3.2'
+              strokeDasharray='86 914'
               strokeLinecap='round'
               filter={`url(#${filterId})`}
               style={{
@@ -105,8 +105,8 @@ export function JovieMarkElectric({
               d={JOVIE_ICON_PATH}
               fill='none'
               stroke='rgba(236,250,255,0.88)'
-              strokeWidth='0.55'
-              strokeDasharray='20 980'
+              strokeWidth='1.05'
+              strokeDasharray='34 966'
               strokeLinecap='round'
               style={{
                 animationName: sparkAnimationName,

--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -335,7 +335,7 @@ export function JovieChat({
 
       <ChatInput
         {...chatInputProps}
-        placeholder={showThreadView ? 'Ask a follow-up...' : 'Ask Jovie...'}
+        placeholder='Ask Jovie...'
         variant={showThreadView ? 'compact' : 'hero'}
         shellChatV1
       />
@@ -416,7 +416,13 @@ export function JovieChat({
                     data-testid='chat-empty-state-composer-region'
                   >
                     <div
-                      className='pointer-events-none absolute left-1/2 top-1/2 h-[min(46vw,28rem)] w-[min(46vw,28rem)] -translate-x-1/2 -translate-y-[60%] opacity-80 max-sm:h-[min(72vw,18rem)] max-sm:w-[min(72vw,18rem)]'
+                      className='pointer-events-none absolute left-1/2 top-1/2 h-[min(46vw,28rem)] w-[min(46vw,28rem)] -translate-x-1/2 -translate-y-[60%] opacity-85 drop-shadow-[0_0_34px_rgba(68,188,255,0.18)] max-sm:h-[min(72vw,18rem)] max-sm:w-[min(72vw,18rem)]'
+                      style={{
+                        maskImage:
+                          'radial-gradient(ellipse at center, black 54%, rgba(0,0,0,0.72) 68%, transparent 88%)',
+                        WebkitMaskImage:
+                          'radial-gradient(ellipse at center, black 54%, rgba(0,0,0,0.72) 68%, transparent 88%)',
+                      }}
                       data-testid='chat-empty-state-logo'
                     >
                       <JovieMarkElectric className='h-full w-full' />

--- a/apps/web/components/jovie/components/ChatInput.tsx
+++ b/apps/web/components/jovie/components/ChatInput.tsx
@@ -506,8 +506,13 @@ export const ChatInput = forwardRef<HTMLTextAreaElement, ChatInputProps>(
             }}
             className={cn(
               'overflow-hidden border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_84%,transparent)] bg-[linear-gradient(180deg,rgba(255,255,255,0.04)_0%,rgba(255,255,255,0.012)_100%),var(--linear-app-content-surface)] text-primary-token shadow-none',
+              isHero &&
+                'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_88%,black_12%)] shadow-[0_18px_68px_-34px_rgba(0,0,0,0.96),inset_0_1px_0_rgba(255,255,255,0.08)]',
               isExpanded &&
                 'border-[color-mix(in_oklab,var(--linear-border-focus)_46%,var(--linear-app-frame-seam))] bg-[linear-gradient(180deg,rgba(255,255,255,0.052)_0%,rgba(255,255,255,0.016)_100%),var(--linear-app-content-surface)]',
+              isHero &&
+                isExpanded &&
+                'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_82%,white_6%)]',
               'outline-none ring-0 focus-within:border-[color-mix(in_oklab,var(--linear-border-focus)_78%,transparent)] focus-within:ring-1 focus-within:ring-[color-mix(in_oklab,var(--linear-border-focus)_42%,transparent)] focus-within:outline-none',
               isOverLimit && 'border-error',
               showEntitySurface && !isStacked ? 'flex' : 'flex flex-col'
@@ -810,6 +815,18 @@ function InputRow({
         )}
       >
         <div ref={hiddenDivRef} style={HIDDEN_DIV_STYLES} aria-hidden />
+        {useHeroPill && hasAttachButton && onImageAttach ? (
+          <ComposerAttachButton
+            isImageProcessing={isImageProcessing}
+            isLoading={isLoading}
+            isSubmitting={isSubmitting}
+            disabled={attachDisabledForPicker}
+            plusMenuOpen={plusMenuOpen}
+            onOpenChange={setPlusMenuOpen}
+            onMouseDown={handlePreserveFocus}
+            onImageAttach={onImageAttach}
+          />
+        ) : null}
         <div
           data-testid='chat-input-inline-field'
           className={cn(
@@ -883,7 +900,7 @@ function InputRow({
           )}
         >
           <div className='flex min-w-0 items-center gap-2'>
-            {hasAttachButton && onImageAttach ? (
+            {!useHeroPill && hasAttachButton && onImageAttach ? (
               <ComposerAttachButton
                 isImageProcessing={isImageProcessing}
                 isLoading={isLoading}

--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -81,7 +81,10 @@ export function ChatMessage({
     <motion.div
       data-message-id={id}
       data-role={role}
-      className={cn('flex gap-3.5', isUser ? 'justify-end' : 'justify-start')}
+      className={cn(
+        'group/message flex gap-3.5',
+        isUser ? 'justify-end' : 'justify-start'
+      )}
       initial={
         skipEntrance || shouldReduceMotion ? false : { opacity: 0, y: 8 }
       }
@@ -177,7 +180,7 @@ export function ChatMessage({
           ) : null}
 
           {!isThinking && !isStreaming && messageText ? (
-            <div className='mt-1.5 flex items-center justify-start'>
+            <div className='mt-1.5 flex h-7 items-center justify-start opacity-0 transition-opacity duration-subtle ease-subtle group-hover/message:opacity-100 group-focus-within/message:opacity-100'>
               <SimpleTooltip content={isSuccess ? 'Copied!' : 'Copy response'}>
                 <button
                   type='button'

--- a/apps/web/tests/unit/chat/ChatInput.test.tsx
+++ b/apps/web/tests/unit/chat/ChatInput.test.tsx
@@ -260,6 +260,28 @@ describe('ChatInput', () => {
     }
   });
 
+  it('keeps the hero attach button ahead of the input field', () => {
+    fastRender(
+      withProviders(
+        <ChatInput
+          {...baseProps}
+          value=''
+          variant='hero'
+          onImageAttach={vi.fn()}
+        />
+      )
+    );
+
+    const attachButton = screen.getByRole('button', {
+      name: /attachment options/i,
+    });
+    const inlineField = screen.getByTestId('chat-input-inline-field');
+
+    expect(attachButton.compareDocumentPosition(inlineField)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
+    );
+  });
+
   it('renders the larger hero composer geometry for the empty state', () => {
     fastRender(
       withProviders(

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -307,7 +307,7 @@ describe('JovieChat empty state', () => {
     expect(getAllByTestId('chat-message')).toHaveLength(2);
     expect(
       screen.getByTestId('chat-input').getAttribute('data-placeholder')
-    ).toBe('Ask a follow-up...');
+    ).toBe('Ask Jovie...');
     expect(screen.getByTestId('chat-input').getAttribute('data-variant')).toBe(
       'compact'
     );


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2563 -->

## Summary
- Polishes the Jovie empty-state mark with smoother glow/fade.
- Makes the chat composer read as a solid primary control, moves attachment left, standardizes the placeholder, and hides assistant copy controls until hover/focus.

## QA
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write ...` passed for the four edited files.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/chat/ChatInput.test.tsx` passed, 16 tests.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- Commit hook and pre-push gate passed.
- Browser QA confirmed composer geometry, left attachment placement, opaque composer background, and no focus/CmdK layout shift.