### PR TITLE
fix(app): polish workspace route controls

### DIFF
--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -23,11 +23,11 @@ import {
   rejectEvents,
   undoRejectEvent,
 } from '@/app/app/(shell)/dashboard/tour-dates/events-actions';
+import { PageContent, PageShell } from '@/components/organisms/PageShell';
 import {
-  PageContent,
-  PageHeader,
-  PageShell,
-} from '@/components/organisms/PageShell';
+  PAGE_TOOLBAR_META_TEXT_CLASS,
+  PageToolbar,
+} from '@/components/organisms/table';
 import { getEventLocalDateKey } from '@/lib/events/date';
 import { normalizeTicketUrl } from '@/lib/events/ticket-url';
 import { queryKeys } from '@/lib/queries';
@@ -413,72 +413,81 @@ export function CalendarPageClient() {
   const isLoading = isLoadingReleases || isLoadingEvents;
 
   return (
-    <PageShell>
-      <PageHeader
-        title='Calendar'
-        description='Releases and events at a glance.'
-        action={
-          <div className='flex flex-wrap items-center justify-end gap-1'>
-            <FilterPill
-              label='All'
-              active={filter === 'all'}
-              onClick={() => setFilter('all')}
-            />
-            <FilterPill
-              label='Releases'
-              active={filter === 'releases'}
-              onClick={() => setFilter('releases')}
-            />
-            <FilterPill
-              label='Events'
-              active={filter === 'events'}
-              onClick={() => setFilter('events')}
-            />
-            <FilterPill
-              label={
-                'Needs review' + (pendingCount > 0 ? ' · ' + pendingCount : '')
-              }
-              active={filter === 'needs_review'}
-              onClick={() => setFilter('needs_review')}
-              tone={pendingCount > 0 ? 'warn' : 'default'}
-            />
-          </div>
-        }
-      />
+    <PageShell
+      toolbar={
+        <PageToolbar
+          start={
+            <span className={PAGE_TOOLBAR_META_TEXT_CLASS}>
+              Releases and events at a glance.
+            </span>
+          }
+          end={
+            <div className='flex flex-wrap items-center justify-end gap-1'>
+              <FilterPill
+                label='All'
+                active={filter === 'all'}
+                onClick={() => setFilter('all')}
+              />
+              <FilterPill
+                label='Releases'
+                active={filter === 'releases'}
+                onClick={() => setFilter('releases')}
+              />
+              <FilterPill
+                label='Events'
+                active={filter === 'events'}
+                onClick={() => setFilter('events')}
+              />
+              <FilterPill
+                label={
+                  'Needs review' +
+                  (pendingCount > 0 ? ' · ' + pendingCount : '')
+                }
+                active={filter === 'needs_review'}
+                onClick={() => setFilter('needs_review')}
+                tone={pendingCount > 0 ? 'warn' : 'default'}
+              />
+            </div>
+          }
+        />
+      }
+    >
       <PageContent>
         <div className='flex h-full min-h-0 flex-col gap-4'>
-          <div className='flex flex-wrap items-center gap-3'>
-            <button
-              type='button'
-              onClick={() => {
-                const next = new Date(cursor);
-                next.setMonth(cursor.getMonth() - 1);
-                setCursor(startOfMonth(next));
-              }}
-              className='grid h-7 w-7 place-items-center rounded-md text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token'
-              aria-label='Previous month'
-            >
-              <ChevronLeft className='h-4 w-4' strokeWidth={2.25} />
-            </button>
-            <h2 className='text-[15px] font-medium text-primary-token tabular-nums'>
-              {MONTH_NAMES[cursor.getMonth()]} {cursor.getFullYear()}
-            </h2>
-            <button
-              type='button'
-              onClick={() => {
-                const next = new Date(cursor);
-                next.setMonth(cursor.getMonth() + 1);
-                setCursor(startOfMonth(next));
-              }}
-              className='grid h-7 w-7 place-items-center rounded-md text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token'
-              aria-label='Next month'
-            >
-              <ChevronRight className='h-4 w-4' strokeWidth={2.25} />
-            </button>
+          <div className='flex flex-wrap items-center justify-between gap-2'>
+            <div className='inline-flex min-w-0 items-center gap-1 rounded-full bg-surface-1 p-0.5'>
+              <button
+                type='button'
+                onClick={() => {
+                  const next = new Date(cursor);
+                  next.setMonth(cursor.getMonth() - 1);
+                  setCursor(startOfMonth(next));
+                }}
+                className='grid h-7 w-7 place-items-center rounded-full text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-surface-0 hover:text-primary-token'
+                aria-label='Previous month'
+              >
+                <ChevronLeft className='h-4 w-4' strokeWidth={2.25} />
+              </button>
+              <h2 className='min-w-[9.5rem] text-center text-[15px] font-medium text-primary-token tabular-nums'>
+                {MONTH_NAMES[cursor.getMonth()]} {cursor.getFullYear()}
+              </h2>
+              <button
+                type='button'
+                onClick={() => {
+                  const next = new Date(cursor);
+                  next.setMonth(cursor.getMonth() + 1);
+                  setCursor(startOfMonth(next));
+                }}
+                className='grid h-7 w-7 place-items-center rounded-full text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-surface-0 hover:text-primary-token'
+                aria-label='Next month'
+              >
+                <ChevronRight className='h-4 w-4' strokeWidth={2.25} />
+              </button>
+            </div>
             <button
               type='button'
               onClick={() => setCursor(startOfMonth(new Date()))}
-              className='h-7 rounded-md px-3 text-[12px] font-caption text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token'
+              className='h-7 rounded-full bg-surface-1 px-3 text-[12px] font-caption text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-surface-0 hover:text-primary-token'
             >
               Today
             </button>
@@ -782,7 +791,7 @@ function FilterPill(props: FilterPillProps) {
       onClick={props.onClick}
       aria-pressed={props.active}
       className={cn(
-        'h-7 rounded-md px-3 text-[11.5px] font-caption transition-colors duration-subtle ease-subtle',
+        'h-7 rounded-full px-3 text-[11.5px] font-caption transition-colors duration-subtle ease-subtle',
         props.active
           ? props.tone === 'warn'
             ? 'bg-amber-400/15 text-amber-300'

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -65,7 +65,6 @@ import type { FilterPill } from '@/components/shell/pill-search.types';
 import { ShellDropdown } from '@/components/shell/ShellDropdown';
 import { APP_ROUTES } from '@/constants/routes';
 import { useRegisterHeaderSearch } from '@/contexts/HeaderActionsContext';
-import { useRegisterShellSidebarOverride } from '@/contexts/ShellSidebarOverrideContext';
 import { useBreakpoint } from '@/hooks/useBreakpoint';
 import { SKELETON_ROW_COUNT } from '@/lib/constants/layout';
 import { cn } from '@/lib/utils';
@@ -600,9 +599,11 @@ function LibraryRail({
       asset.providers.map(provider => [provider.key, provider.label] as const)
     )
   );
-  const assetKinds = uniqueSorted(
-    assets.flatMap(asset => asset.assetKinds)
-  ) as LibraryAssetKind[];
+  const assetKinds = (
+    uniqueSorted(
+      assets.flatMap(asset => asset.assetKinds)
+    ) as LibraryAssetKind[]
+  ).filter(kind => kind !== 'providers' || providerKeys.length === 0);
   const counts = {
     releaseTypes: countBy(assets, asset => [asset.releaseType]),
     statuses: countBy(assets, asset => [asset.status]),
@@ -665,7 +666,7 @@ function LibraryRail({
               onClick={onClearFilters}
               className='rounded px-1.5 py-0.5 text-2xs text-tertiary-token transition-colors duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token'
             >
-              Clear {activeFilterCount}
+              Clear Filters ({activeFilterCount})
             </button>
           ) : null}
         </div>
@@ -911,6 +912,7 @@ function LibraryToolbar({
   totalCount,
   mobileFiltersOpen,
   onToggleMobileFilters,
+  activeFilterCount,
 }: {
   readonly sort: LibrarySortKey;
   readonly onSort: (sort: LibrarySortKey) => void;
@@ -920,6 +922,7 @@ function LibraryToolbar({
   readonly totalCount: number;
   readonly mobileFiltersOpen: boolean;
   readonly onToggleMobileFilters: () => void;
+  readonly activeFilterCount: number;
 }) {
   return (
     <PageToolbar
@@ -932,11 +935,16 @@ function LibraryToolbar({
       end={
         <>
           <PageToolbarActionButton
-            label='Filters'
+            label={
+              activeFilterCount > 0
+                ? `Show Filters (${activeFilterCount})`
+                : 'Show Filters'
+            }
             icon={<Filter className={PAGE_TOOLBAR_ICON_CLASS} />}
             onClick={onToggleMobileFilters}
             aria-expanded={mobileFiltersOpen}
             ariaPressed={mobileFiltersOpen}
+            tooltipLabel={mobileFiltersOpen ? 'Hide filters' : 'Show filters'}
             className='lg:hidden'
           />
           <SortDropdown sort={sort} onSort={onSort} />
@@ -1885,31 +1893,11 @@ export function LibrarySurface({
     setDrawerOpen(true);
   }
 
-  const sidebarNavigation = useMemo(
-    () => (
-      <LibraryRail
-        assets={effectiveAssets}
-        preset={preset}
-        filters={filters}
-        onPreset={setPreset}
-        onFilters={setFilters}
-        onClearFilters={() => setFilters(emptyFilters())}
-      />
-    ),
-    [effectiveAssets, filters, preset]
-  );
-
-  const sidebarOverride = useMemo(
-    () => ({
-      key: 'library',
-      backHref: APP_ROUTES.CHAT,
-      backLabel: 'Back to App',
-      content: sidebarNavigation,
-    }),
-    [sidebarNavigation]
-  );
-
-  useRegisterShellSidebarOverride(sidebarOverride);
+  const activeFilterCount =
+    filters.statuses.size +
+    filters.releaseTypes.size +
+    filters.assetKinds.size +
+    filters.providers.size;
 
   const headerSearchAdapter = useMemo(
     () =>
@@ -1926,9 +1914,12 @@ export function LibrarySurface({
             hasOptions,
             totalCount: effectiveAssets.length,
             visibleCount: visibleAssets.length,
-            triggerLabel: 'Filter',
+            triggerLabel:
+              pills.length > 0
+                ? `Filter Library (${pills.length})`
+                : 'Filter Library',
             ariaLabel: 'Filter library assets',
-            placeholder: 'Filter library',
+            placeholder: 'Search library',
             allowedFields: ['artist', 'title', 'status', 'has'] as const,
           },
     [
@@ -1975,6 +1966,7 @@ export function LibrarySurface({
           totalCount={effectiveAssets.length}
           mobileFiltersOpen={mobileFiltersOpen}
           onToggleMobileFilters={() => setMobileFiltersOpen(value => !value)}
+          activeFilterCount={activeFilterCount}
         />
       }
     >

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -33,6 +33,7 @@ import { useRouter } from 'next/navigation';
 import {
   type ChangeEvent,
   type CSSProperties,
+  cloneElement,
   createContext,
   type DragEvent,
   type MouseEvent,
@@ -1935,6 +1936,20 @@ export function LibrarySurface({
 
   useRegisterHeaderSearch(headerSearchAdapter);
 
+  const libraryRail = useMemo(
+    () => (
+      <LibraryRail
+        assets={effectiveAssets}
+        preset={preset}
+        filters={filters}
+        onPreset={setPreset}
+        onFilters={setFilters}
+        onClearFilters={() => setFilters(emptyFilters())}
+      />
+    ),
+    [effectiveAssets, filters, preset]
+  );
+
   const handleAudioUploaded = useCallback(
     (assetId: string, previewUrl: string) => {
       setAudioOverrides(previous => ({
@@ -1971,15 +1986,11 @@ export function LibrarySurface({
       }
     >
       {mobileFiltersOpen ? (
-        <LibraryRail
-          assets={effectiveAssets}
-          preset={preset}
-          filters={filters}
-          onPreset={setPreset}
-          onFilters={setFilters}
-          onClearFilters={() => setFilters(emptyFilters())}
-          className='max-h-[45svh] shrink-0 border-b border-subtle lg:hidden'
-        />
+        <div className='lg:hidden'>
+          {cloneElement(libraryRail, {
+            className: 'max-h-[45svh] shrink-0 border-b border-subtle',
+          })}
+        </div>
       ) : null}
 
       <div
@@ -1987,13 +1998,19 @@ export function LibrarySurface({
         style={
           {
             gridTemplateColumns: isDesktopLayout
-              ? `minmax(0, 1fr) ${drawerOpen ? '360px' : '0px'}`
+              ? `minmax(16rem,17.5rem) minmax(0,1fr) ${drawerOpen ? '360px' : '0px'}`
               : 'minmax(0, 1fr)',
             transition:
               'grid-template-columns var(--duration-cinematic) var(--ease-cinematic)',
           } as CSSProperties
         }
       >
+        {isDesktopLayout
+          ? cloneElement(libraryRail, {
+              className:
+                'hidden min-h-0 border-r border-subtle lg:flex lg:h-full',
+            })
+          : null}
         <div className='flex min-h-0 min-w-0 flex-col overflow-hidden'>
           <div className='min-h-0 flex-1 overflow-y-auto pb-20 lg:pb-0'>
             {visibleAssets.length === 0 ? (

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/NewReleaseHeaderAction.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/NewReleaseHeaderAction.tsx
@@ -62,6 +62,7 @@ export function NewReleaseHeaderAction({
         label={isSyncing ? 'Syncing...' : 'Sync from Spotify'}
         hideLabelOnMobile
         tooltipLabel='Sync from Spotify'
+        className='bg-primary-token text-on-primary hover:bg-primary-token/90 hover:text-on-primary'
       />
     );
   }
@@ -74,13 +75,16 @@ export function NewReleaseHeaderAction({
           variant='ghost'
           size='sm'
           aria-label='Create a new release'
-          className={cn(DASHBOARD_HEADER_ACTION_TEXT_BUTTON_CLASS, 'pr-1.5')}
+          className={cn(
+            DASHBOARD_HEADER_ACTION_TEXT_BUTTON_CLASS,
+            'bg-primary-token pr-1.5 text-on-primary hover:bg-primary-token/90 hover:text-on-primary'
+          )}
           data-testid='new-release-header-trigger'
         >
           <Icon name='Plus' className='h-3.5 w-3.5' strokeWidth={2} />
           <span className='max-sm:hidden sm:inline'>New release</span>
           <ChevronDown
-            className='h-3 w-3 text-tertiary-token'
+            className='h-3 w-3 text-on-primary/80'
             strokeWidth={2}
             aria-hidden='true'
           />

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseFilterDropdown.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseFilterDropdown.tsx
@@ -274,6 +274,12 @@ export function ReleaseFilterDropdown({
   const labelFilterCount = filters.labels.length;
   const hasAnyFilter =
     typeFilterCount > 0 || popularityFilterCount > 0 || labelFilterCount > 0;
+  const activeFilterCount =
+    typeFilterCount + popularityFilterCount + labelFilterCount;
+  const triggerLabel =
+    activeFilterCount > 0
+      ? `Filter Releases (${activeFilterCount})`
+      : 'Filter Releases';
 
   // Reset searches when dropdown closes
   const handleOpenChange = useCallback((open: boolean) => {
@@ -296,13 +302,14 @@ export function ReleaseFilterDropdown({
                 buttonClassName,
                 (isOpen || hasAnyFilter) && FILTER_TRIGGER_ACTIVE_CLASS
               )}
+              aria-label={triggerLabel}
               aria-pressed={isOpen || hasAnyFilter}
             >
               <Icon name='Filter' className='h-3.5 w-3.5' strokeWidth={2} />
               <span
                 className={cn(iconOnly ? 'sr-only' : 'sr-only md:not-sr-only')}
               >
-                Filter
+                {triggerLabel}
               </span>
             </Button>
           </DropdownMenuTrigger>

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
@@ -307,8 +307,11 @@ export const ShellReleaseRow = memo(function ShellReleaseRow({
         smartLinkPath={smartLinkPath}
       />
 
-      <div className='h-7 w-7 shrink-0'>
-        {actionMenuItems && actionMenuItems.length > 0 ? (
+      {actionMenuItems && actionMenuItems.length > 0 ? (
+        <div
+          className='h-7 w-7 shrink-0'
+          data-testid='shell-release-row-actions'
+        >
           <TableActionMenu items={actionMenuItems} trigger='custom' align='end'>
             <button
               type='button'
@@ -324,8 +327,8 @@ export const ShellReleaseRow = memo(function ShellReleaseRow({
               <MoreHorizontal className='h-3 w-3' strokeWidth={2.25} />
             </button>
           </TableActionMenu>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
     </ShellListRowFrame>
   );
 });

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.tsx
@@ -285,17 +285,19 @@ export const ShellReleaseRow = memo(function ShellReleaseRow({
         <div className={shellReleaseRowTypography.subtitle}>{artistLabel}</div>
       </div>
 
-      <div className='hidden md:inline-flex shrink-0'>
+      <div className='hidden w-24 shrink-0 justify-start md:inline-flex'>
         <StatusBadge status={status} />
       </div>
 
       {dropMeta ? (
-        <div className='hidden lg:inline-flex shrink-0'>
+        <div className='hidden w-28 shrink-0 justify-start lg:inline-flex'>
           <DropDateChip tone={dropMeta.tone} label={dropMeta.label} />
         </div>
-      ) : null}
+      ) : (
+        <span className='hidden w-28 shrink-0 lg:block' aria-hidden='true' />
+      )}
 
-      <div className='hidden md:inline-flex shrink-0'>
+      <div className='hidden w-20 shrink-0 justify-start md:inline-flex'>
         <DspAvatarStack dsps={dspItems} />
       </div>
 
@@ -305,23 +307,25 @@ export const ShellReleaseRow = memo(function ShellReleaseRow({
         smartLinkPath={smartLinkPath}
       />
 
-      {actionMenuItems && actionMenuItems.length > 0 ? (
-        <TableActionMenu items={actionMenuItems} trigger='custom' align='end'>
-          <button
-            type='button'
-            onClick={e => e.stopPropagation()}
-            onKeyDown={e => e.stopPropagation()}
-            aria-label={`Release actions for ${release.title}`}
-            className={cn(
-              'shrink-0 h-7 w-7 rounded-md grid place-items-center text-quaternary-token hover:text-primary-token hover:bg-surface-2/70 transition-[opacity,color,background-color] duration-subtle ease-subtle',
-              'opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100',
-              isSelected && 'opacity-100'
-            )}
-          >
-            <MoreHorizontal className='h-3 w-3' strokeWidth={2.25} />
-          </button>
-        </TableActionMenu>
-      ) : null}
+      <div className='h-7 w-7 shrink-0'>
+        {actionMenuItems && actionMenuItems.length > 0 ? (
+          <TableActionMenu items={actionMenuItems} trigger='custom' align='end'>
+            <button
+              type='button'
+              onClick={e => e.stopPropagation()}
+              onKeyDown={e => e.stopPropagation()}
+              aria-label={`Release actions for ${release.title}`}
+              className={cn(
+                'shrink-0 h-7 w-7 rounded-md grid place-items-center text-quaternary-token hover:text-primary-token hover:bg-surface-2/70 transition-[opacity,color,background-color] duration-subtle ease-subtle',
+                'opacity-0 group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100',
+                isSelected && 'opacity-100'
+              )}
+            >
+              <MoreHorizontal className='h-3 w-3' strokeWidth={2.25} />
+            </button>
+          </TableActionMenu>
+        ) : null}
+      </div>
     </ShellListRowFrame>
   );
 });

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.tsx
@@ -833,9 +833,12 @@ export function ShellReleasesView({
       albumOptions,
       totalCount: rows.length,
       visibleCount: visibleReleases.length,
-      triggerLabel: 'Filter',
+      triggerLabel:
+        pills.length > 0
+          ? `Filter Releases (${pills.length})`
+          : 'Filter Releases',
       ariaLabel: 'Filter releases',
-      placeholder: 'Filter releases',
+      placeholder: 'Search releases',
       allowedFields: ['artist', 'title', 'album', 'status', 'has'] as const,
     }),
     [

--- a/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
@@ -348,7 +348,7 @@ function TaskBoardColumn({
           'border-[color-mix(in_oklab,var(--linear-border-focus)_70%,transparent)] bg-[color-mix(in_oklab,var(--linear-row-hover)_36%,var(--linear-app-content-surface))]'
       )}
     >
-      <div className='flex h-10 min-h-10 items-center justify-between gap-2 border-b border-subtle px-3'>
+      <div className='sticky top-0 z-10 flex h-10 min-h-10 items-center justify-between gap-2 border-b border-subtle bg-surface-0 px-3'>
         <div className='flex min-w-0 items-center gap-2'>
           <StatusIcon
             className={cn(
@@ -517,32 +517,6 @@ const TaskBoardCard = memo(function TaskBoardCard({
         {task.title}
       </p>
 
-      <div className='mt-2.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1.5 text-[10.5px] leading-none text-secondary-token'>
-        <span className='inline-flex items-center gap-1 text-secondary-token'>
-          <PriorityBars
-            bars={priority.bars}
-            accentColor={priorityAccent.solid}
-          />
-          <span>{priority.label}</span>
-        </span>
-        <span className='inline-flex min-w-0 items-center gap-1.5'>
-          <UserAvatar name={assignee.avatarName} size='xs' />
-          <span className='truncate'>{assignee.label}</span>
-        </span>
-        {agentLabel ? (
-          <span
-            className={cn(
-              'rounded-full border px-1.5 py-0.5 text-[10px] font-semibold',
-              task.agentStatus === 'failed'
-                ? 'border-error/30 text-error'
-                : 'border-subtle text-tertiary-token'
-            )}
-          >
-            {agentLabel}
-          </span>
-        ) : null}
-      </div>
-
       <div className='mt-2.5 flex min-h-5 min-w-0 items-center justify-between gap-2'>
         <div className='min-w-0 flex-1'>
           {task.releaseTitle ? (
@@ -561,6 +535,32 @@ const TaskBoardCard = memo(function TaskBoardCard({
             dueDaysOffset={null}
             isCompleted={task.status === 'done' || task.status === 'cancelled'}
           />
+        ) : null}
+      </div>
+
+      <div className='mt-2.5 flex min-w-0 flex-wrap items-center gap-1.5 text-[10.5px] leading-none text-secondary-token'>
+        <span className='inline-flex items-center gap-1 rounded-full border border-subtle px-1.5 py-0.5 text-tertiary-token'>
+          <PriorityBars
+            bars={priority.bars}
+            accentColor={priorityAccent.solid}
+          />
+          <span>{priority.label}</span>
+        </span>
+        <span className='inline-flex min-w-0 items-center gap-1.5 rounded-full border border-subtle px-1.5 py-0.5 text-tertiary-token'>
+          <UserAvatar name={assignee.avatarName} size='xs' />
+          <span className='truncate'>{assignee.label}</span>
+        </span>
+        {agentLabel ? (
+          <span
+            className={cn(
+              'rounded-full border px-1.5 py-0.5 text-[10px] font-semibold',
+              task.agentStatus === 'failed'
+                ? 'border-error/30 text-error'
+                : 'border-subtle text-tertiary-token'
+            )}
+          >
+            {agentLabel}
+          </span>
         ) : null}
       </div>
     </div>

--- a/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskWorkspaceHeaderBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button, Input } from '@jovie/ui';
-import { ArrowDown, ArrowUp, Settings2 } from 'lucide-react';
+import { ArrowDown, ArrowUp, Plus, Settings2 } from 'lucide-react';
 import type { FormEvent } from 'react';
 import {
   TableFilterDropdown,
@@ -43,6 +43,7 @@ export interface TaskWorkspaceHeaderBarProps {
   readonly onClearSearch: () => void;
   readonly filterCategories: ReadonlyArray<TableFilterDropdownCategory>;
   readonly onClearFilters: () => void;
+  readonly onCreateTask: () => void;
   readonly viewMode: ViewMode;
   readonly onViewModeChange: (viewMode: ViewMode) => void;
   readonly showCancelledColumn: boolean;
@@ -67,6 +68,7 @@ export function TaskWorkspaceHeaderBar({
   onClearSearch,
   filterCategories,
   onClearFilters,
+  onCreateTask,
   viewMode,
   onViewModeChange,
   showCancelledColumn,
@@ -148,6 +150,13 @@ export function TaskWorkspaceHeaderBar({
           align='end'
           shortcutHint='S'
         />
+        <PageToolbarActionButton
+          ariaLabel='Create task'
+          label='New Task'
+          onClick={onCreateTask}
+          icon={<Plus className='h-3.5 w-3.5' />}
+          className='hidden bg-primary-token px-2.5 text-on-primary hover:bg-primary-token/90 hover:text-on-primary lg:inline-flex'
+        />
         <DisplayMenuDropdown
           viewMode={viewMode}
           availableViewModes={['board', 'list']}
@@ -201,6 +210,7 @@ export function TaskWorkspaceHeaderBar({
         end={toolbarEnd}
         className='h-[var(--linear-app-header-height-compact)] min-h-[var(--linear-app-header-height-compact)]'
         startClassName={mode === 'create' ? 'overflow-visible' : undefined}
+        endClassName='gap-0.5'
       />
     </div>
   );
@@ -238,8 +248,8 @@ export function TaskSubviewTabs({
       ariaLabel='Task subviews'
       overflowMode='scroll'
       variant='segment'
-      className={cn('pl-0.5', className)}
-      triggerClassName='gap-1.5 px-2.5 text-[12.5px]'
+      className={cn('pl-0', className)}
+      triggerClassName='gap-1.5 px-2 text-[12px]'
       options={subviews.map(subview => ({
         value: subview.id,
         label: (

--- a/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
+++ b/apps/web/components/features/dashboard/tasks/TasksPageClient.tsx
@@ -1913,6 +1913,7 @@ export function TasksPageClient() {
           onClick={() => setHeaderMode('create')}
           pressed={headerMode === 'create'}
           hideLabelOnMobile
+          className='lg:hidden'
         />
       </DashboardHeaderActionGroup>
     ),
@@ -2114,6 +2115,7 @@ export function TasksPageClient() {
               onClearSearch={() => setSearch('')}
               filterCategories={taskFilterCategories}
               onClearFilters={clearFilters}
+              onCreateTask={() => setHeaderMode('create')}
               viewMode={viewMode}
               onViewModeChange={setViewMode}
               showCancelledColumn={showCancelledColumn}

--- a/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.test.tsx
+++ b/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.test.tsx
@@ -116,6 +116,24 @@ describe('ShellReleaseRow audio affordance', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('does not reserve a row action slot when the release has no actions', () => {
+    render(
+      <ShellReleaseRow
+        release={fakeRelease({
+          id: 'r1',
+          title: 'No Actions',
+          previewUrl: null,
+        })}
+        isSelected={false}
+        onSelect={() => undefined}
+      />
+    );
+
+    expect(
+      screen.queryByTestId('shell-release-row-actions')
+    ).not.toBeInTheDocument();
+  });
+
   it('renders a production-backed play overlay when previewUrl exists', () => {
     render(
       <ShellReleaseRow

--- a/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
+++ b/apps/web/tests/unit/app/surface-elevation-guardrails.test.ts
@@ -300,7 +300,7 @@ describe('surface elevation guardrails', () => {
 
     expect(shellReleasesView).toContain('useRegisterHeaderSearch');
     expect(shellReleasesView).toContain("key: 'shell-releases'");
-    expect(shellReleasesView).toContain("triggerLabel: 'Filter'");
+    expect(shellReleasesView).toContain('Filter Releases');
     expect(shellReleasesView).not.toMatch(
       /const\s*\[\s*searchOpen\s*,\s*setSearchOpen\s*\]\s*=\s*useState/
     );
@@ -352,7 +352,7 @@ describe('surface elevation guardrails', () => {
 
     expect(librarySurface).toContain('useRegisterHeaderSearch');
     expect(librarySurface).toContain("key: 'library'");
-    expect(librarySurface).toContain("triggerLabel: 'Filter'");
+    expect(librarySurface).toContain('Filter Library');
     expect(librarySurface).not.toContain('OPEN_COMMAND_PALETTE_EVENT');
     expect(appShellLoading).toContain('isLibraryShellRoute');
     expect(appShellLoading).toContain('LibraryLoadingState');

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -1,5 +1,5 @@
 import { TooltipProvider } from '@jovie/ui';
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { APP_ROUTES } from '@/constants/routes';
@@ -1240,7 +1240,7 @@ describe('TasksPageClient', () => {
       headerActions.querySelector('[aria-label="Search tasks"]')
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: 'Create task' })
+      within(headerActions).getByRole('button', { name: 'Create task' })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Search tasks' })
@@ -1313,7 +1313,11 @@ describe('TasksPageClient', () => {
   it('promotes the header into create mode when new task is triggered', () => {
     renderPage();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Create task' }));
+    fireEvent.click(
+      within(screen.getByTestId('header-actions-host')).getByRole('button', {
+        name: 'Create task',
+      })
+    );
 
     expect(screen.getByLabelText('New task name')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument();

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -1485,6 +1485,18 @@ describe('TasksPageClient', () => {
     expect(screen.getByTestId('mobile-task-list')).toBeInTheDocument();
   });
 
+  it('keeps a create-task affordance visible below the desktop breakpoint', () => {
+    mockIsXlUp = false;
+
+    renderPage();
+
+    expect(
+      within(screen.getByTestId('header-actions-host')).getByRole('button', {
+        name: 'Create task',
+      })
+    ).toBeInTheDocument();
+  });
+
   it('renders the mobile list shell without duplicate search and opens task detail on tap', () => {
     mockIsXlUp = false;
 

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -170,6 +170,8 @@ function renderLibraryWithSidebarOverride(
 }
 
 describe('LibrarySurface', () => {
+  const baseMatchMedia = window.matchMedia;
+
   beforeEach(() => {
     audioMock.playbackState = { ...audioMock.basePlaybackState };
     audioMock.toggleTrack.mockClear();
@@ -182,6 +184,7 @@ describe('LibrarySurface', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    window.matchMedia = baseMatchMedia;
   });
 
   it('renders an empty read-only library state with a releases escape hatch', () => {
@@ -520,6 +523,41 @@ describe('LibrarySurface', () => {
     expect(contract).not.toHaveAttribute('data-back-href');
     expect(contract).not.toHaveAttribute('data-back-label');
     fireEvent.click(screen.getByRole('button', { name: 'Show filters' }));
+    expect(
+      screen.getByRole('navigation', { name: 'Library navigation' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /All Releases/u })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Needs Assets/u })
+    ).toBeInTheDocument();
+  });
+
+  it('keeps library filters reachable on desktop without taking over the shell sidebar', async () => {
+    window.matchMedia = vi.fn().mockImplementation(query => ({
+      matches: query === '(min-width: 1024px)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    renderLibraryWithSidebarOverride([
+      buildAsset(),
+      buildAsset({
+        id: 'release-2',
+        title: 'Never Say A Word',
+        artist: 'Other Artist',
+      }),
+    ]);
+
+    const contract = await screen.findByTestId('library-sidebar-override');
+
+    expect(contract).toHaveTextContent('missing');
     expect(
       screen.getByRole('navigation', { name: 'Library navigation' })
     ).toBeInTheDocument();

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -483,7 +483,7 @@ describe('LibrarySurface', () => {
       }),
     ]);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show filters' }));
     fireEvent.click(screen.getByRole('button', { name: /Needs Assets/u }));
 
     expect(
@@ -503,7 +503,7 @@ describe('LibrarySurface', () => {
     ).toBeInTheDocument();
   });
 
-  it('registers the route sidebar takeover contract', async () => {
+  it('keeps Library inside the standard app shell without a route sidebar takeover', async () => {
     renderLibraryWithSidebarOverride([
       buildAsset(),
       buildAsset({
@@ -515,10 +515,11 @@ describe('LibrarySurface', () => {
 
     const contract = await screen.findByTestId('library-sidebar-override');
 
-    expect(contract).toHaveTextContent('registered');
-    expect(contract).toHaveAttribute('data-key', 'library');
-    expect(contract).toHaveAttribute('data-back-href', APP_ROUTES.CHAT);
-    expect(contract).toHaveAttribute('data-back-label', 'Back to App');
+    expect(contract).toHaveTextContent('missing');
+    expect(contract).not.toHaveAttribute('data-key');
+    expect(contract).not.toHaveAttribute('data-back-href');
+    expect(contract).not.toHaveAttribute('data-back-label');
+    fireEvent.click(screen.getByRole('button', { name: 'Show filters' }));
     expect(
       screen.getByRole('navigation', { name: 'Library navigation' })
     ).toBeInTheDocument();


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2563 -->

## Summary
- Cleans up Calendar filters/month controls, Tasks toolbar/sticky board headers, Library shell/filter labels, and Releases row/CTA alignment.
- Keeps Audience duplicate visible heading removed while preserving route semantics already present on main.

## QA
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write ...` passed for the nine edited files.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.test.tsx tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView.test.tsx tests/components/release-provider-matrix/ReleaseFilterDropdown.test.tsx` passed, 45 tests.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- Commit hook and pre-push gate passed.
- Browser QA passed for `/app/calendar`, `/app/tasks`, `/app/library`, `/app/releases`, and `/app/audience` on desktop and mobile with no route error boundary or horizontal overflow.