### PR TITLE
fix(admin): fail softly for status data

### DIFF
--- a/apps/web/app/app/(shell)/admin/costs/CostsTable.tsx
+++ b/apps/web/app/app/(shell)/admin/costs/CostsTable.tsx
@@ -1,10 +1,8 @@
 'use client';
 
-import { Button } from '@jovie/ui';
 import { type ColumnDef, createColumnHelper } from '@tanstack/react-table';
-import { ExternalLink, RefreshCw } from 'lucide-react';
-import { useMemo, useState } from 'react';
-import { toast } from 'sonner';
+import { ExternalLink } from 'lucide-react';
+import { useMemo } from 'react';
 import { PageToolbar, TableEmptyState } from '@/components/organisms/table';
 import { AdminDataTable } from '@/features/admin/table/AdminDataTable';
 import { AdminTableShell } from '@/features/admin/table/AdminTableShell';
@@ -28,20 +26,24 @@ interface CostsTableProps {
 const columnHelper = createColumnHelper<AdminCostRow>();
 
 export function CostsTable({ items, lastRefreshedLabel }: CostsTableProps) {
-  const [localRefreshed, setLocalRefreshed] = useState(lastRefreshedLabel);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-
   const columns = useMemo(
     () =>
       [
         columnHelper.accessor('label', {
-          header: 'Line Item / Provider',
+          header: 'Provider',
           cell: info => (
-            <span className='font-medium text-primary-token'>
-              {info.getValue()}
-            </span>
+            <div className='min-w-0 space-y-1'>
+              <span className='block truncate font-medium text-primary-token'>
+                {info.getValue()}
+              </span>
+              {info.row.original.notes ? (
+                <span className='line-clamp-2 block max-w-[34rem] text-xs leading-[17px] text-secondary-token'>
+                  {info.row.original.notes}
+                </span>
+              ) : null}
+            </div>
           ),
-          meta: { className: 'min-w-[220px]' },
+          meta: { className: 'min-w-[280px]' },
         }),
         columnHelper.accessor('observed30dUsd', {
           header: '30d Spend (USD)',
@@ -75,15 +77,6 @@ export function CostsTable({ items, lastRefreshedLabel }: CostsTableProps) {
           header: 'Last Updated',
           cell: info => info.getValue(),
         }),
-        columnHelper.accessor('notes', {
-          header: 'Notes',
-          cell: info => (
-            <span className='line-clamp-2 text-tertiary-token text-xs'>
-              {info.getValue() || '—'}
-            </span>
-          ),
-          meta: { className: 'max-w-[320px]' },
-        }),
         columnHelper.accessor('externalUrl', {
           header: '',
           cell: info => {
@@ -113,22 +106,6 @@ export function CostsTable({ items, lastRefreshedLabel }: CostsTableProps) {
     0
   );
 
-  async function handleMarkRefreshed() {
-    setIsRefreshing(true);
-    // v1: client-side only bump (no real persistence required per charter)
-    const now = new Date().toLocaleString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    });
-    setLocalRefreshed(now);
-    setIsRefreshing(false);
-    toast.success(
-      'Marked refreshed (v1 manual — copy real numbers from dashboards)'
-    );
-  }
-
   const toolbar = (
     <PageToolbar
       start={
@@ -137,22 +114,8 @@ export function CostsTable({ items, lastRefreshedLabel }: CostsTableProps) {
             {items.length} items • ${total30d.toFixed(2)} in last 30d
           </span>
           <span className='opacity-60'>•</span>
-          <span>Last refreshed: {localRefreshed}</span>
+          <span>Last refreshed: {lastRefreshedLabel}</span>
         </div>
-      }
-      end={
-        <Button
-          variant='outline'
-          size='sm'
-          onClick={handleMarkRefreshed}
-          disabled={isRefreshing}
-          className='gap-1.5'
-        >
-          <RefreshCw
-            className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`}
-          />
-          Mark refreshed
-        </Button>
       }
     />
   );
@@ -166,7 +129,7 @@ export function CostsTable({ items, lastRefreshedLabel }: CostsTableProps) {
           emptyState={
             <TableEmptyState
               title='No cost items'
-              description='Seed data will appear on first load.'
+              description='Cost data is unavailable in this environment.'
             />
           }
         />

--- a/apps/web/app/app/(shell)/admin/costs/page.tsx
+++ b/apps/web/app/app/(shell)/admin/costs/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { getAdminCosts, getCostsLastRefreshedAt } from '@/lib/admin/costs';
+import { captureError } from '@/lib/error-tracking';
 import { CostsTable } from './CostsTable';
 
 export const metadata: Metadata = {
@@ -10,10 +11,19 @@ export const metadata: Metadata = {
 export const runtime = 'nodejs';
 
 export default async function AdminCostsPage() {
-  const [items, lastRefreshed] = await Promise.all([
-    getAdminCosts(),
-    getCostsLastRefreshedAt(),
-  ]);
+  let items: Awaited<ReturnType<typeof getAdminCosts>> = [];
+  let lastRefreshed: Awaited<ReturnType<typeof getCostsLastRefreshedAt>> = null;
+
+  try {
+    [items, lastRefreshed] = await Promise.all([
+      getAdminCosts(),
+      getCostsLastRefreshedAt(),
+    ]);
+  } catch (error) {
+    await captureError('Admin costs page failed to load optional data', error, {
+      route: 'admin/costs',
+    });
+  }
 
   const refreshedLabel = lastRefreshed
     ? lastRefreshed.toLocaleString('en-US', {
@@ -22,7 +32,7 @@ export default async function AdminCostsPage() {
         hour: 'numeric',
         minute: '2-digit',
       })
-    : 'never (seed on load)';
+    : 'Not recorded';
 
   return (
     <AdminPage

--- a/apps/web/app/app/(shell)/admin/platform-connections/PlatformConnectionsClient.tsx
+++ b/apps/web/app/app/(shell)/admin/platform-connections/PlatformConnectionsClient.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { Badge, Button, Input, Switch } from '@jovie/ui';
-import { CheckCircle2, Loader2, RefreshCw, ShieldCheck } from 'lucide-react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Loader2,
+  RefreshCw,
+  ShieldCheck,
+} from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState, useTransition } from 'react';
 import { ConfirmDialog } from '@/components/molecules/ConfirmDialog';
@@ -66,6 +72,59 @@ function StatusBadge({ ok, label }: Readonly<{ ok: boolean; label: string }>) {
       {ok ? <CheckCircle2 className='size-3.5' aria-hidden /> : null}
       {label}
     </Badge>
+  );
+}
+
+function getSpotifySourceLabel(source: SpotifyStatus['source']) {
+  switch (source) {
+    case 'database':
+      return 'Settings Row';
+    case 'env fallback':
+      return 'Environment Fallback';
+    case 'missing':
+      return 'Configuration Not Set';
+  }
+}
+
+function StatusSummaryItem({
+  label,
+  value,
+  ok,
+}: Readonly<{ label: string; value: string; ok: boolean }>) {
+  return (
+    <div className='min-w-[11rem] flex-1 rounded-md bg-surface-0 px-3 py-2'>
+      <div className='flex items-center gap-2 text-xs font-medium text-primary-token'>
+        {ok ? (
+          <CheckCircle2 className='size-3.5 text-success' aria-hidden />
+        ) : (
+          <AlertTriangle className='size-3.5 text-warning' aria-hidden />
+        )}
+        {label}
+      </div>
+      <p className='mt-1 text-xs text-secondary-token'>{value}</p>
+    </div>
+  );
+}
+
+function MissingScopesList({
+  scopes,
+}: Readonly<{ scopes: readonly string[] }>) {
+  if (scopes.length === 0) return null;
+
+  return (
+    <div className='mt-2 space-y-1.5'>
+      <p className='text-xs font-medium text-warning'>Missing scopes</p>
+      <div className='flex flex-wrap gap-1.5'>
+        {scopes.map(scope => (
+          <code
+            key={scope}
+            className='rounded-full border border-warning/20 bg-warning/10 px-2 py-0.5 text-[11px] leading-4 text-warning'
+          >
+            {scope}
+          </code>
+        ))}
+      </div>
+    </div>
   );
 }
 
@@ -165,19 +224,27 @@ function SpotifyTabContent({
 
   return (
     <div className='divide-y divide-(--linear-app-frame-seam) rounded-lg border border-(--linear-app-frame-seam) bg-surface-1'>
-      <div className='flex flex-wrap items-center justify-between gap-3 px-4 py-3'>
-        <div className='flex min-w-0 flex-wrap items-center gap-2'>
-          <StatusBadge
+      <div className='flex flex-wrap items-start justify-between gap-3 px-4 py-3'>
+        <div className='flex min-w-0 flex-1 flex-wrap gap-2'>
+          <StatusSummaryItem
+            label='Publisher'
+            value={
+              spotifyStatus.connected ? 'Account linked' : 'No account linked'
+            }
             ok={spotifyStatus.connected}
-            label={spotifyStatus.connected ? 'Connected' : 'Disconnected'}
           />
-          <StatusBadge
+          <StatusSummaryItem
+            label='Health'
+            value={
+              spotifyStatus.healthy ? 'Ready for publishing' : 'Action required'
+            }
             ok={spotifyStatus.healthy}
-            label={spotifyStatus.healthy ? 'Healthy' : 'Needs attention'}
           />
-          <Badge variant='secondary' size='sm'>
-            Source: {spotifyStatus.source}
-          </Badge>
+          <StatusSummaryItem
+            label='Configuration'
+            value={getSpotifySourceLabel(spotifyStatus.source)}
+            ok={spotifyStatus.source !== 'missing'}
+          />
         </div>
         <Button
           type='button'
@@ -214,17 +281,15 @@ function SpotifyTabContent({
               ? (currentUser.label ?? 'Spotify connected')
               : 'Spotify is not connected'}
           </p>
-          {currentUser.missingScopes.length > 0 ? (
-            <p className='mt-1 text-xs text-red-300'>
-              Missing scopes: {currentUser.missingScopes.join(', ')}
-            </p>
-          ) : null}
+          <MissingScopesList scopes={currentUser.missingScopes} />
         </div>
       </div>
 
       {spotifyStatus.error ? (
-        <div className='px-4 py-3 text-xs text-red-300'>
-          {spotifyStatus.error}
+        <div className='px-4 py-3'>
+          <p className='rounded-lg border border-warning/20 bg-warning/10 px-3 py-2 text-xs text-warning'>
+            {spotifyStatus.error}
+          </p>
         </div>
       ) : null}
 
@@ -346,10 +411,7 @@ function EngineTabContent({
       <div className='divide-y divide-(--linear-app-frame-seam) rounded-lg border border-(--linear-app-frame-seam) bg-surface-1'>
         <div className='flex flex-wrap items-center justify-between gap-3 px-4 py-3'>
           <div className='flex min-w-0 flex-wrap items-center gap-2'>
-            <StatusBadge
-              ok={enabled}
-              label={enabled ? 'Enabled' : 'Disabled'}
-            />
+            <StatusBadge ok={enabled} label={enabled ? 'Enabled' : 'Paused'} />
             <Badge variant='secondary' size='sm'>
               Minimum interval
             </Badge>

--- a/apps/web/app/app/(shell)/admin/platform-connections/page.tsx
+++ b/apps/web/app/app/(shell)/admin/platform-connections/page.tsx
@@ -1,7 +1,11 @@
 import type { Metadata } from 'next';
 import { AdminPage } from '@/components/features/admin/layout/AdminPage';
+import { captureError } from '@/lib/error-tracking';
 import { PlatformConnectionsClient } from './PlatformConnectionsClient';
-import { loadAdminPlatformConnectionsData } from './platform-connections-data';
+import {
+  type AdminPlatformConnectionsData,
+  loadAdminPlatformConnectionsData,
+} from './platform-connections-data';
 
 export const metadata: Metadata = { title: 'Platform Connections — Admin' };
 export const runtime = 'nodejs';
@@ -14,6 +18,33 @@ const TAB_OPTIONS = [
   { value: 'engine' as const, label: 'Playlist Engine' },
 ] as const;
 
+const FALLBACK_PLATFORM_CONNECTIONS_DATA: AdminPlatformConnectionsData = {
+  spotifyStatus: {
+    connected: false,
+    healthy: false,
+    source: 'missing',
+    clerkUserId: null,
+    accountLabel: null,
+    approvedScopes: [],
+    missingScopes: [],
+    updatedAt: null,
+    updatedByUserId: null,
+    error: null,
+  },
+  engineSettings: {
+    enabled: false,
+    intervalValue: 3,
+    intervalUnit: 'days',
+    lastGeneratedAt: null,
+    nextEligibleAt: null,
+  },
+  currentUser: {
+    hasSpotify: false,
+    label: null,
+    missingScopes: [],
+  },
+};
+
 export default async function AdminPlatformConnectionsPage({
   searchParams,
 }: Readonly<{
@@ -24,7 +55,18 @@ export default async function AdminPlatformConnectionsPage({
     ['spotify', 'engine'].includes(tab) ? tab : 'spotify'
   ) as PlatformConnectionsTab;
 
-  const data = await loadAdminPlatformConnectionsData();
+  let data = FALLBACK_PLATFORM_CONNECTIONS_DATA;
+  try {
+    data = await loadAdminPlatformConnectionsData();
+  } catch (error) {
+    await captureError(
+      'Admin platform connections failed to load optional settings',
+      error,
+      {
+        route: 'admin/platform-connections',
+      }
+    );
+  }
 
   return (
     <AdminPage

--- a/apps/web/app/app/(shell)/admin/platform-connections/platform-connections-data.ts
+++ b/apps/web/app/app/(shell)/admin/platform-connections/platform-connections-data.ts
@@ -39,7 +39,7 @@ export async function loadAdminPlatformConnectionsData(): Promise<AdminPlatformC
   ]);
 
   const currentSpotifyAccount =
-    user?.externalAccounts.find(isSpotifyAccount) ?? null;
+    user?.externalAccounts?.find(isSpotifyAccount) ?? null;
   const approvedScopes = readExternalAccountScopes(currentSpotifyAccount);
   const missingScopes = REQUIRED_PLAYLIST_SPOTIFY_SCOPES.filter(
     scope => !approvedScopes.includes(scope)

--- a/apps/web/tests/unit/app/admin-costs-page.test.tsx
+++ b/apps/web/tests/unit/app/admin-costs-page.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockCaptureError,
+  mockCostsTable,
+  mockGetAdminCosts,
+  mockGetLastRefreshed,
+} = vi.hoisted(() => ({
+  mockCaptureError: vi.fn(),
+  mockCostsTable: vi.fn(() => <div data-testid='admin-costs-table-probe' />),
+  mockGetAdminCosts: vi.fn(),
+  mockGetLastRefreshed: vi.fn(),
+}));
+
+vi.mock('@/components/features/admin/layout/AdminPage', () => ({
+  AdminPage: ({
+    children,
+    title,
+    description,
+    testId,
+  }: {
+    children: ReactNode;
+    title: string;
+    description: string;
+    testId: string;
+  }) => (
+    <section data-testid={testId}>
+      <h1>{title}</h1>
+      <p>{description}</p>
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('@/lib/admin/costs', () => ({
+  getAdminCosts: mockGetAdminCosts,
+  getCostsLastRefreshedAt: mockGetLastRefreshed,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: mockCaptureError,
+}));
+
+vi.mock('@/app/app/(shell)/admin/costs/CostsTable', () => ({
+  CostsTable: mockCostsTable,
+}));
+
+describe('AdminCostsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAdminCosts.mockResolvedValue([]);
+    mockGetLastRefreshed.mockResolvedValue(null);
+  });
+
+  it('renders the costs table with empty fallback data when optional loaders fail', async () => {
+    mockGetAdminCosts.mockRejectedValueOnce(new Error('cost loader failed'));
+
+    const { default: AdminCostsPage } = await import(
+      '@/app/app/(shell)/admin/costs/page'
+    );
+
+    render(await AdminCostsPage());
+
+    expect(screen.getByTestId('admin-costs-page')).toBeInTheDocument();
+    expect(screen.getByText('Costs')).toBeInTheDocument();
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      'Admin costs page failed to load optional data',
+      expect.any(Error),
+      expect.objectContaining({ route: 'admin/costs' })
+    );
+    expect(mockCostsTable).toHaveBeenCalledWith(
+      expect.objectContaining({
+        items: [],
+        lastRefreshedLabel: 'Not recorded',
+      }),
+      undefined
+    );
+  });
+});

--- a/apps/web/tests/unit/app/admin-platform-connections-client.test.tsx
+++ b/apps/web/tests/unit/app/admin-platform-connections-client.test.tsx
@@ -130,7 +130,9 @@ describe('PlatformConnectionsClient', () => {
       />
     );
 
-    expect(screen.getByText('Disconnected')).toBeInTheDocument();
+    expect(screen.getByText('No account linked')).toBeInTheDocument();
+    expect(screen.getByText('Action required')).toBeInTheDocument();
+    expect(screen.getByText('Configuration Not Set')).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /Use This Account/i })
     ).toBeDisabled();
@@ -151,7 +153,7 @@ describe('PlatformConnectionsClient', () => {
       />
     );
 
-    expect(screen.getByText('Disabled')).toBeInTheDocument();
+    expect(screen.getByText('Paused')).toBeInTheDocument();
     await user.click(
       screen.getByRole('button', { name: 'Generate Test Playlist' })
     );

--- a/apps/web/tests/unit/app/admin-platform-connections-page.test.tsx
+++ b/apps/web/tests/unit/app/admin-platform-connections-page.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockCaptureError,
+  mockLoadAdminPlatformConnectionsData,
+  mockPlatformConnectionsClient,
+} = vi.hoisted(() => ({
+  mockCaptureError: vi.fn(),
+  mockLoadAdminPlatformConnectionsData: vi.fn(),
+  mockPlatformConnectionsClient: vi.fn(() => (
+    <div data-testid='admin-platform-connections-client-probe' />
+  )),
+}));
+
+vi.mock('@/components/features/admin/layout/AdminPage', () => ({
+  AdminPage: ({
+    children,
+    title,
+    description,
+    testId,
+  }: {
+    children: ReactNode;
+    title: string;
+    description: string;
+    testId: string;
+  }) => (
+    <section data-testid={testId}>
+      <h1>{title}</h1>
+      <p>{description}</p>
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: mockCaptureError,
+}));
+
+vi.mock(
+  '@/app/app/(shell)/admin/platform-connections/platform-connections-data',
+  () => ({
+    loadAdminPlatformConnectionsData: mockLoadAdminPlatformConnectionsData,
+  })
+);
+
+vi.mock(
+  '@/app/app/(shell)/admin/platform-connections/PlatformConnectionsClient',
+  () => ({
+    PlatformConnectionsClient: mockPlatformConnectionsClient,
+  })
+);
+
+describe('AdminPlatformConnectionsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadAdminPlatformConnectionsData.mockResolvedValue({
+      spotifyStatus: {
+        connected: true,
+        healthy: true,
+        source: 'database',
+        clerkUserId: 'user_123',
+        accountLabel: 'Jovie Publisher',
+        approvedScopes: ['playlist-read-private'],
+        missingScopes: [],
+        updatedAt: null,
+        updatedByUserId: null,
+        error: null,
+      },
+      engineSettings: {
+        enabled: true,
+        intervalValue: 3,
+        intervalUnit: 'days',
+        lastGeneratedAt: null,
+        nextEligibleAt: null,
+      },
+      currentUser: {
+        hasSpotify: true,
+        label: 'Jovie Publisher',
+        missingScopes: [],
+      },
+    });
+  });
+
+  it('renders safe fallback props when optional platform status loading fails', async () => {
+    mockLoadAdminPlatformConnectionsData.mockRejectedValueOnce(
+      new Error('platform connections unavailable')
+    );
+
+    const { default: AdminPlatformConnectionsPage } = await import(
+      '@/app/app/(shell)/admin/platform-connections/page'
+    );
+
+    render(
+      await AdminPlatformConnectionsPage({
+        searchParams: Promise.resolve({ tab: 'engine' }),
+      })
+    );
+
+    expect(
+      screen.getByTestId('admin-platform-connections')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Platform Connections')).toBeInTheDocument();
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      'Admin platform connections failed to load optional settings',
+      expect.any(Error),
+      expect.objectContaining({ route: 'admin/platform-connections' })
+    );
+    expect(mockPlatformConnectionsClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentTab: 'engine',
+        spotifyStatus: expect.objectContaining({
+          connected: false,
+          healthy: false,
+          source: 'missing',
+          accountLabel: null,
+          approvedScopes: [],
+          missingScopes: [],
+          error: null,
+        }),
+        engineSettings: expect.objectContaining({
+          enabled: false,
+          intervalValue: 3,
+          intervalUnit: 'days',
+          lastGeneratedAt: null,
+          nextEligibleAt: null,
+        }),
+        currentUser: expect.objectContaining({
+          hasSpotify: false,
+          label: null,
+          missingScopes: [],
+        }),
+      }),
+      undefined
+    );
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2563 -->

## Summary
- Makes Platform Connections and Costs fail softly when optional admin data is unavailable.
- Replaces raw/debug status copy with designed status and empty-state language.

## QA
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write ...` passed for the five edited files.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- Commit hook and pre-push gate passed.
- Browser QA passed for `/app/admin/platform-connections` and `/app/admin/costs` with status 200, no error boundary, and no horizontal overflow.
- `chat_turns` was confirmed as local DB drift; existing migration `0049_lyrical_korvac.sql` applied successfully via `JOVIE_AGENT_PROFILE=coder pnpm run db:web:migrate`.