### PR TITLE
fix: stabilize WriteRail header geometry

### DIFF
--- a/apps/web/components/atoms/StableHeaderSlots.tsx
+++ b/apps/web/components/atoms/StableHeaderSlots.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export type StableHeaderLineCount = 1 | 2;
+
+const TEXT_SLOT_HEIGHT_CLASSNAME: Record<
+  'xs' | 'sm' | 'md',
+  Record<StableHeaderLineCount, string>
+> = {
+  xs: {
+    1: 'min-h-[16px]',
+    2: 'min-h-[32px]',
+  },
+  sm: {
+    1: 'min-h-[18px]',
+    2: 'min-h-[36px]',
+  },
+  md: {
+    1: 'min-h-[22px]',
+    2: 'min-h-[44px]',
+  },
+};
+
+export const STABLE_HEADER_LINE_CLAMP_CLASSNAME: Record<
+  StableHeaderLineCount,
+  string
+> = {
+  1: 'line-clamp-1',
+  2: 'line-clamp-2',
+};
+
+export const STABLE_HEADER_TITLE_HEIGHT_CLASSNAME: Record<
+  StableHeaderLineCount,
+  string
+> = {
+  1: TEXT_SLOT_HEIGHT_CLASSNAME.md[1],
+  2: TEXT_SLOT_HEIGHT_CLASSNAME.md[2],
+};
+
+const TEXT_SLOT_OVERFLOW_CLASSNAME: Record<StableHeaderLineCount, string> = {
+  1: 'truncate',
+  2: STABLE_HEADER_LINE_CLAMP_CLASSNAME[2],
+};
+
+interface StableHeaderTextSlotProps {
+  readonly children?: ReactNode;
+  readonly reserve?: boolean;
+  readonly lineCount?: StableHeaderLineCount;
+  readonly size?: 'xs' | 'sm' | 'md';
+  readonly className?: string;
+  readonly testId?: string;
+}
+
+export function StableHeaderTextSlot({
+  children,
+  reserve = false,
+  lineCount,
+  size = 'xs',
+  className,
+  testId,
+}: StableHeaderTextSlotProps) {
+  const hasContent = children != null && children !== false;
+
+  if (!hasContent && !reserve) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-hidden={hasContent ? undefined : true}
+      data-testid={testId}
+      className={cn(
+        'min-w-0',
+        lineCount && TEXT_SLOT_HEIGHT_CLASSNAME[size][lineCount],
+        lineCount && TEXT_SLOT_OVERFLOW_CLASSNAME[lineCount],
+        !hasContent && 'invisible',
+        className
+      )}
+    >
+      {hasContent ? children : '\u00a0'}
+    </div>
+  );
+}
+
+interface StableHeaderChipRailProps {
+  readonly children?: ReactNode;
+  readonly reserve?: boolean;
+  readonly className?: string;
+  readonly contentClassName?: string;
+  readonly testId?: string;
+}
+
+export function StableHeaderChipRail({
+  children,
+  reserve = false,
+  className,
+  contentClassName,
+  testId,
+}: StableHeaderChipRailProps) {
+  const hasContent = children != null && children !== false;
+
+  if (!hasContent && !reserve) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-hidden={hasContent ? undefined : true}
+      data-testid={testId}
+      className={cn('relative min-w-0', !hasContent && 'invisible', className)}
+    >
+      <div
+        className={cn(
+          'flex min-h-[22px] max-w-full items-center gap-1.5 overflow-x-auto overflow-y-hidden whitespace-nowrap pr-5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [&>*]:shrink-0 [&_*]:whitespace-nowrap',
+          '[mask-image:linear-gradient(to_right,black_calc(100%_-_18px),transparent)] [-webkit-mask-image:linear-gradient(to_right,black_calc(100%_-_18px),transparent)]',
+          contentClassName
+        )}
+      >
+        {hasContent ? children : <span>{'\u00a0'}</span>}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/atoms/index.ts
+++ b/apps/web/components/atoms/index.ts
@@ -85,6 +85,13 @@ export {
   SocialIcon,
 } from './SocialIcon';
 export { Spacer } from './Spacer';
+export {
+  STABLE_HEADER_LINE_CLAMP_CLASSNAME,
+  STABLE_HEADER_TITLE_HEIGHT_CLASSNAME,
+  StableHeaderChipRail,
+  type StableHeaderLineCount,
+  StableHeaderTextSlot,
+} from './StableHeaderSlots';
 export type { StatusBadgeProps } from './StatusBadge';
 export { StatusBadge } from './StatusBadge';
 export type { SwipeToRevealProps } from './SwipeToReveal';

--- a/apps/web/components/features/admin/admin-creator-profiles/AdminProfileSidebar.tsx
+++ b/apps/web/components/features/admin/admin-creator-profiles/AdminProfileSidebar.tsx
@@ -110,6 +110,12 @@ export function AdminProfileSidebar({
             <DrawerHero
               title={profile.displayName ?? profile.username}
               subtitle={`@${profile.username}`}
+              stableLayout
+              titleLineClamp={1}
+              subtitleLineClamp={1}
+              reserveSubtitleSlot
+              reserveMetaSlot
+              metaOverflow='scroll'
               artwork={
                 <AvatarUploadable
                   src={profile.avatarUrl}
@@ -120,7 +126,7 @@ export function AdminProfileSidebar({
                 />
               }
               meta={
-                <div className='flex flex-wrap items-center gap-2 text-2xs text-tertiary-token'>
+                <div className='flex items-center gap-2 text-2xs text-tertiary-token'>
                   <span>
                     {links.length} linked destination
                     {links.length === 1 ? '' : 's'}

--- a/apps/web/components/features/dashboard/atoms/AudienceMemberHeader.tsx
+++ b/apps/web/components/features/dashboard/atoms/AudienceMemberHeader.tsx
@@ -30,6 +30,10 @@ export function AudienceMemberHeader({
       }
       title={title}
       subtitle={subtitle}
+      stableLayout
+      titleLineClamp={1}
+      subtitleLineClamp={1}
+      reserveSubtitleSlot
       className={className}
     />
   );

--- a/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/AnalyticsSidebar.tsx
@@ -321,7 +321,9 @@ export function AnalyticsSidebarView({
                   triggerClassName='flex-1'
                   aria-label='Analytics time range'
                 />
-              ) : null}
+              ) : (
+                <div aria-hidden='true' className='h-7 invisible' />
+              )}
             </div>
           </div>
         </DrawerSurfaceCard>

--- a/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/audience-member-sidebar/AudienceMemberSidebar.tsx
@@ -60,7 +60,7 @@ export function AudienceMemberSidebar({
       hideMinimalHeaderBar
       entityHeader={
         member ? (
-          <div className='relative'>
+          <div className='relative' data-testid='audience-member-header-card'>
             <div className='absolute right-2.5 top-2.5 z-10'>
               <DrawerHeaderActions
                 primaryActions={[]}
@@ -71,6 +71,12 @@ export function AudienceMemberSidebar({
             <DrawerHero
               title={primaryLabel}
               subtitle={secondaryLabel}
+              stableLayout
+              titleLineClamp={1}
+              subtitleLineClamp={1}
+              reserveSubtitleSlot
+              reserveMetaSlot
+              metaOverflow='scroll'
               artwork={
                 <div className='flex h-10 w-10 shrink-0 items-center justify-center rounded-[11px] border border-subtle bg-surface-0 text-sm font-semibold text-secondary-token'>
                   {primaryLabel.charAt(0).toUpperCase()}
@@ -78,7 +84,7 @@ export function AudienceMemberSidebar({
               }
               meta={
                 member.locationLabel || member.visits > 0 ? (
-                  <div className='flex flex-wrap items-center gap-2 pr-8 text-2xs text-tertiary-token'>
+                  <div className='flex items-center gap-2 pr-8 text-2xs text-tertiary-token'>
                     {member.locationLabel ? (
                       <span className='inline-flex items-center gap-1'>
                         <MapPin className='h-3 w-3' />
@@ -91,6 +97,7 @@ export function AudienceMemberSidebar({
                   </div>
                 ) : undefined
               }
+              className='[&_h2]:pr-9'
             />
           </div>
         ) : undefined

--- a/apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/contacts-table/ContactDetailSidebar.tsx
@@ -259,9 +259,15 @@ export const ContactDetailSidebar = memo(function ContactDetailSidebar({
               <DrawerHero
                 title={contactDisplayName}
                 subtitle={roleLabel}
+                stableLayout
+                titleLineClamp={1}
+                subtitleLineClamp={1}
+                reserveSubtitleSlot
+                reserveMetaSlot
+                metaOverflow='scroll'
                 meta={
                   territorySummary ? (
-                    <div className='flex flex-wrap items-center gap-1.5 text-2xs text-tertiary-token'>
+                    <div className='flex items-center gap-1.5 text-2xs text-tertiary-token'>
                       <Badge
                         size='sm'
                         className='rounded-md border border-subtle bg-surface-0 px-1.5 text-3xs text-secondary-token'

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileContactSidebar.tsx
@@ -176,6 +176,12 @@ function ProfileSidebarHeaderCard({
         <DrawerHero
           title={primaryLabel}
           subtitle={secondaryLabel}
+          stableLayout
+          titleLineClamp={1}
+          subtitleLineClamp={1}
+          reserveSubtitleSlot
+          reserveMetaSlot
+          metaOverflow='scroll'
           artwork={
             <DrawerMediaThumb
               src={previewData.avatarUrl}
@@ -190,7 +196,7 @@ function ProfileSidebarHeaderCard({
             />
           }
           meta={
-            <div className='flex flex-wrap items-center gap-2 text-2xs text-tertiary-token'>
+            <div className='flex items-center gap-2 text-2xs text-tertiary-token'>
               {detailChips.map(detail => (
                 <span key={detail}>{detail}</span>
               ))}

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileSmartLinkAnalytics.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/ProfileSmartLinkAnalytics.tsx
@@ -98,7 +98,7 @@ export function ProfileSmartLinkAnalytics({
   const content = (
     <>
       {/* Analytics metrics */}
-      <div className='px-3 pb-3 pt-3'>
+      <div className='min-h-[76px] px-3 pb-3 pt-3'>
         {showSkeleton && (
           <div className='grid grid-cols-2 gap-3'>
             <div className='space-y-1'>
@@ -124,7 +124,7 @@ export function ProfileSmartLinkAnalytics({
         {!showSkeleton && !isError && (
           <div
             className={cn(
-              'space-y-3 transition-opacity duration-100',
+              'space-y-3 transition-opacity duration-subtle',
               isFetching && 'opacity-50'
             )}
           >

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/AddReleaseSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/AddReleaseSidebar.tsx
@@ -269,6 +269,12 @@ export function AddReleaseSidebar({
           <div className='p-3'>
             <EntityHeaderCard
               eyebrow='Release preview'
+              stableLayout
+              titleLineClamp={1}
+              subtitleLineClamp={1}
+              reserveSubtitleSlot
+              reserveMetaSlot
+              metaOverflow='scroll'
               image={
                 <AvatarUploadable
                   src={stagedArtworkPreviewUrl}

--- a/apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx
+++ b/apps/web/components/features/dashboard/organisms/tour-dates/TourDateSidebar.tsx
@@ -263,6 +263,13 @@ export function TourDateSidebar({
               <EntityHeaderCard
                 eyebrow='Tour Date'
                 title={tourDate.title?.trim() || tourDate.venueName}
+                stableLayout
+                titleLineClamp={1}
+                subtitleLineClamp={1}
+                reserveSubtitleSlot
+                reserveMetaSlot
+                reserveFooterSlot
+                metaOverflow='scroll'
                 subtitle={
                   <>
                     {formatISODate(tourDate.startDate)} · {tourDate.city}
@@ -484,7 +491,7 @@ export function TourDateSidebar({
                         }
                         disabled={isPending}
                         className={cn(
-                          'flex-1 rounded-full border px-3 py-2 text-xs font-caption transition-[background-color,border-color,color] duration-150',
+                          'flex-1 rounded-full border px-3 py-2 text-xs font-caption transition-[background-color,border-color,color] duration-subtle',
                           formData.ticketStatus === status
                             ? 'border-accent/35 bg-accent/10 text-accent'
                             : 'border-(--linear-app-frame-seam) bg-surface-0 text-secondary-token hover:bg-surface-1 hover:text-primary-token'

--- a/apps/web/components/molecules/drawer/DrawerAnalyticsSummaryCard.spec.tsx
+++ b/apps/web/components/molecules/drawer/DrawerAnalyticsSummaryCard.spec.tsx
@@ -87,4 +87,44 @@ describe('DrawerAnalyticsSummaryCard', () => {
       'true'
     );
   });
+
+  it('reserves stable body and footer space across sparse states', () => {
+    render(
+      <DrawerAnalyticsSummaryCard
+        metrics={[]}
+        state='ready'
+        emptyMessage='No clicks yet.'
+        stableLayout
+        reserveFooterSlot
+        metricSlotCount={2}
+        testId='analytics-card'
+      />
+    );
+
+    expect(screen.getByTestId('analytics-card-body')).toHaveClass(
+      'min-h-[106px]'
+    );
+    expect(screen.getByTestId('analytics-card-footer')).toHaveClass(
+      'invisible',
+      'min-h-[40px]'
+    );
+  });
+
+  it('reserves metric hint rows in stable ready state', () => {
+    render(
+      <DrawerAnalyticsSummaryCard
+        metrics={[
+          { id: 'profile-views', label: 'Profile views', value: '120' },
+        ]}
+        state='ready'
+        stableLayout
+      />
+    );
+
+    const metric = screen.getByTestId('drawer-analytics-metric-profile-views');
+    expect(metric.querySelector('p[aria-hidden="true"]')).toHaveClass(
+      'invisible',
+      'min-h-[13px]'
+    );
+  });
 });

--- a/apps/web/components/molecules/drawer/DrawerAnalyticsSummaryCard.tsx
+++ b/apps/web/components/molecules/drawer/DrawerAnalyticsSummaryCard.tsx
@@ -20,16 +20,24 @@ export interface DrawerAnalyticsSummaryCardProps {
   readonly errorMessage?: string;
   readonly testId?: string;
   readonly variant?: 'card' | 'flat';
+  readonly stableLayout?: boolean;
+  readonly reserveFooterSlot?: boolean;
+  readonly metricSlotCount?: 1 | 2;
 }
 
 const METRIC_TILE_CLASSNAME = 'px-3 py-2.5';
+const STABLE_ANALYTICS_BODY_CLASSNAME = 'min-h-[106px]';
+const STABLE_ANALYTICS_FOOTER_CLASSNAME = 'min-h-[40px]';
 
 function MetricTile({
   label,
   value,
   hint,
   id,
-}: Readonly<DrawerAnalyticsSummaryMetric>) {
+  reserveHint = false,
+}: Readonly<DrawerAnalyticsSummaryMetric> & {
+  readonly reserveHint?: boolean;
+}) {
   return (
     <div
       className={METRIC_TILE_CLASSNAME}
@@ -44,8 +52,14 @@ function MetricTile({
       >
         {value}
       </p>
-      {hint ? (
-        <p className='mt-1 text-[10px] leading-[13px] text-tertiary-token'>
+      {hint || reserveHint ? (
+        <p
+          aria-hidden={hint ? undefined : true}
+          className={cn(
+            'mt-1 min-h-[13px] text-[10px] leading-[13px] text-tertiary-token',
+            !hint && 'invisible'
+          )}
+        >
           {hint}
         </p>
       ) : null}
@@ -63,6 +77,97 @@ function LoadingMetricTile() {
   );
 }
 
+function DrawerAnalyticsSummaryBody({
+  state,
+  metrics,
+  emptyMessage,
+  errorMessage,
+  gridClassName,
+  loadingMetricKeys,
+  stableLayout,
+}: Readonly<{
+  state: DrawerAnalyticsSummaryCardProps['state'];
+  metrics: readonly DrawerAnalyticsSummaryMetric[];
+  emptyMessage?: string;
+  errorMessage: string;
+  gridClassName: string;
+  loadingMetricKeys: readonly string[];
+  stableLayout: boolean;
+}>) {
+  if (state === 'loading') {
+    return (
+      <output
+        aria-label='Loading analytics'
+        className={cn('grid gap-2.5', gridClassName)}
+      >
+        {loadingMetricKeys.map(metricKey => (
+          <LoadingMetricTile key={metricKey} />
+        ))}
+      </output>
+    );
+  }
+
+  if (state === 'error') {
+    return (
+      <div className='flex min-h-[72px] items-center'>
+        <p className='text-xs leading-[18px] tracking-[0.01em] text-secondary-token'>
+          {errorMessage}
+        </p>
+      </div>
+    );
+  }
+
+  if (metrics.length > 0) {
+    return (
+      <div className={cn('grid gap-2.5', gridClassName)}>
+        {metrics.map(metric => (
+          <MetricTile key={metric.id} {...metric} reserveHint={stableLayout} />
+        ))}
+      </div>
+    );
+  }
+
+  if (emptyMessage) {
+    return (
+      <div className='flex min-h-[72px] items-center'>
+        <p className='text-xs leading-[18px] tracking-[0.01em] text-secondary-token'>
+          {emptyMessage}
+        </p>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function DrawerAnalyticsSummaryFooter({
+  footer,
+  reserveFooterSlot,
+  testId,
+}: Readonly<{
+  footer?: ReactNode;
+  reserveFooterSlot: boolean;
+  testId?: string;
+}>) {
+  if (!footer && !reserveFooterSlot) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-hidden={footer ? undefined : true}
+      data-testid={testId ? `${testId}-footer` : undefined}
+      className={cn(
+        'px-3 pb-3',
+        reserveFooterSlot && STABLE_ANALYTICS_FOOTER_CLASSNAME,
+        !footer && 'invisible'
+      )}
+    >
+      {footer ?? '\u00a0'}
+    </div>
+  );
+}
+
 export function DrawerAnalyticsSummaryCard({
   metrics,
   state,
@@ -72,8 +177,12 @@ export function DrawerAnalyticsSummaryCard({
   errorMessage = 'Analytics unavailable',
   testId,
   variant = 'card',
+  stableLayout = false,
+  reserveFooterSlot = false,
+  metricSlotCount,
 }: Readonly<DrawerAnalyticsSummaryCardProps>) {
-  const tileCount = metrics.length > 0 ? metrics.length : 2;
+  const tileCount =
+    metricSlotCount ?? (metrics.length > 0 ? metrics.length : 2);
   const gridClassName = tileCount === 1 ? 'grid-cols-1' : 'grid-cols-2';
   const isBusy = dimmed || state === 'loading';
   const loadingMetricKeys = Array.from(
@@ -90,48 +199,33 @@ export function DrawerAnalyticsSummaryCard({
     >
       <div
         className={cn(
-          'transition-opacity duration-150',
+          'transition-opacity duration-subtle',
           dimmed && 'opacity-60'
         )}
       >
-        <div className='space-y-3 px-3 py-3'>
-          {state === 'loading' ? (
-            <output
-              aria-label='Loading analytics'
-              className={cn('grid gap-2.5', gridClassName)}
-            >
-              {loadingMetricKeys.map(metricKey => (
-                <LoadingMetricTile key={metricKey} />
-              ))}
-            </output>
-          ) : null}
-
-          {state === 'error' ? (
-            <div className='flex min-h-[72px] items-center'>
-              <p className='text-xs leading-[18px] tracking-[0.01em] text-secondary-token'>
-                {errorMessage}
-              </p>
-            </div>
-          ) : null}
-
-          {state === 'ready' && metrics.length > 0 ? (
-            <div className={cn('grid gap-2.5', gridClassName)}>
-              {metrics.map(metric => (
-                <MetricTile key={metric.id} {...metric} />
-              ))}
-            </div>
-          ) : null}
-
-          {state === 'ready' && metrics.length === 0 && emptyMessage ? (
-            <div className='flex min-h-[72px] items-center'>
-              <p className='text-xs leading-[18px] tracking-[0.01em] text-secondary-token'>
-                {emptyMessage}
-              </p>
-            </div>
-          ) : null}
+        <div
+          data-testid={testId ? `${testId}-body` : undefined}
+          className={cn(
+            'space-y-3 px-3 py-3',
+            stableLayout && STABLE_ANALYTICS_BODY_CLASSNAME
+          )}
+        >
+          <DrawerAnalyticsSummaryBody
+            state={state}
+            metrics={metrics}
+            emptyMessage={emptyMessage}
+            errorMessage={errorMessage}
+            gridClassName={gridClassName}
+            loadingMetricKeys={loadingMetricKeys}
+            stableLayout={stableLayout}
+          />
         </div>
 
-        {footer ? <div className='px-3 pb-3'>{footer}</div> : null}
+        <DrawerAnalyticsSummaryFooter
+          footer={footer}
+          reserveFooterSlot={reserveFooterSlot}
+          testId={testId}
+        />
       </div>
     </DrawerSurfaceCard>
   );

--- a/apps/web/components/molecules/drawer/EntityHeaderCard.test.tsx
+++ b/apps/web/components/molecules/drawer/EntityHeaderCard.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { EntityHeaderCard } from './EntityHeaderCard';
+
+describe('EntityHeaderCard', () => {
+  it('does not clamp the subtitle by default outside stable layout', () => {
+    render(<EntityHeaderCard title='Audience member' subtitle='Artist team' />);
+    expect(screen.getByText('Artist team')).not.toHaveClass('line-clamp-1');
+  });
+
+  it('reserves optional slots in stable layout', () => {
+    render(
+      <EntityHeaderCard
+        title='Long entity name'
+        stableLayout
+        reserveFooterSlot
+        data-testid='entity-header'
+      />
+    );
+
+    expect(screen.getByText('Long entity name')).toHaveClass(
+      'line-clamp-1',
+      'min-h-[22px]'
+    );
+    expect(screen.getByTestId('entity-header-meta-slot')).toHaveClass(
+      'invisible'
+    );
+  });
+
+  it('renders stable metadata as a single horizontal rail', () => {
+    render(
+      <EntityHeaderCard
+        title='Track title'
+        stableLayout
+        meta={
+          <>
+            <span>3:42</span>
+            <span>USRC12345678</span>
+            <span>Explicit</span>
+          </>
+        }
+      />
+    );
+
+    const rail = screen.getByTestId(
+      'entity-header-meta-slot'
+    ).firstElementChild;
+    expect(rail).toHaveClass('overflow-x-auto', 'whitespace-nowrap');
+  });
+
+  it('preserves the subtitle row when requested', () => {
+    render(
+      <EntityHeaderCard
+        title='Audience member'
+        stableLayout
+        reserveSubtitleSlot
+      />
+    );
+
+    const title = screen.getByText('Audience member');
+    expect(title).toBeInTheDocument();
+    expect(title.parentElement?.nextElementSibling).toHaveClass(
+      'invisible',
+      'min-h-[16px]'
+    );
+  });
+});

--- a/apps/web/components/molecules/drawer/EntityHeaderCard.tsx
+++ b/apps/web/components/molecules/drawer/EntityHeaderCard.tsx
@@ -1,6 +1,15 @@
 import type { ReactNode } from 'react';
 
+import {
+  STABLE_HEADER_LINE_CLAMP_CLASSNAME,
+  STABLE_HEADER_TITLE_HEIGHT_CLASSNAME,
+  StableHeaderChipRail,
+  type StableHeaderLineCount,
+  StableHeaderTextSlot,
+} from '@/components/atoms/StableHeaderSlots';
 import { cn } from '@/lib/utils';
+
+type EntityHeaderMetaOverflow = 'wrap' | 'scroll';
 
 export interface EntityHeaderCardProps {
   /** Image slot — Avatar, AvatarUploadable, artwork, etc. */
@@ -19,9 +28,98 @@ export interface EntityHeaderCardProps {
   readonly actions?: ReactNode;
   /** Optional footer rendered below the meta block */
   readonly footer?: ReactNode;
+  /** Enables reserved header slots so entity selection changes do not resize the card. */
+  readonly stableLayout?: boolean;
+  /** Max title lines before truncation. Stable layouts reserve this line count. */
+  readonly titleLineClamp?: StableHeaderLineCount;
+  /** Max subtitle lines before truncation. Stable layouts reserve this line count. */
+  readonly subtitleLineClamp?: StableHeaderLineCount;
+  /** Reserve the eyebrow row even when no eyebrow is available. */
+  readonly reserveEyebrowSlot?: boolean;
+  /** Reserve the subtitle row even when no subtitle is available. */
+  readonly reserveSubtitleSlot?: boolean;
+  /** Reserve the metadata row even when no metadata is available. */
+  readonly reserveMetaSlot?: boolean;
+  /** Reserve the footer row even when no footer is available. */
+  readonly reserveFooterSlot?: boolean;
+  /** Metadata can either wrap or stay in a one-line horizontal rail. */
+  readonly metaOverflow?: EntityHeaderMetaOverflow;
   readonly className?: string;
   readonly bodyClassName?: string;
+  readonly titleClassName?: string;
+  readonly subtitleClassName?: string;
+  readonly metaClassName?: string;
+  readonly footerClassName?: string;
   readonly 'data-testid'?: string;
+}
+
+function EntityHeaderMetaSlot({
+  meta,
+  shouldReserveMeta,
+  resolvedMetaOverflow,
+  metaClassName,
+}: Readonly<{
+  meta?: ReactNode;
+  shouldReserveMeta: boolean;
+  resolvedMetaOverflow: EntityHeaderMetaOverflow;
+  metaClassName?: string;
+}>) {
+  if (!meta && !shouldReserveMeta) {
+    return null;
+  }
+
+  if (resolvedMetaOverflow === 'scroll') {
+    return (
+      <StableHeaderChipRail
+        reserve={shouldReserveMeta}
+        className={cn('pt-0.5', metaClassName)}
+        testId='entity-header-meta-slot'
+      >
+        {meta}
+      </StableHeaderChipRail>
+    );
+  }
+
+  return (
+    <div
+      aria-hidden={meta ? undefined : true}
+      className={cn(
+        'flex min-h-[22px] flex-wrap items-center gap-1 pt-0.5',
+        !meta && 'invisible',
+        metaClassName
+      )}
+      data-testid='entity-header-meta-slot'
+    >
+      {meta ?? '\u00a0'}
+    </div>
+  );
+}
+
+function EntityHeaderFooterSlot({
+  footer,
+  shouldReserveFooter,
+  footerClassName,
+}: Readonly<{
+  footer?: ReactNode;
+  shouldReserveFooter: boolean;
+  footerClassName?: string;
+}>) {
+  if (!footer && !shouldReserveFooter) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-hidden={footer ? undefined : true}
+      className={cn(
+        'min-h-[28px] pt-1',
+        !footer && 'invisible',
+        footerClassName
+      )}
+    >
+      {footer ?? '\u00a0'}
+    </div>
+  );
 }
 
 /**
@@ -40,10 +138,33 @@ export function EntityHeaderCard({
   badge,
   actions,
   footer,
+  stableLayout = false,
+  titleLineClamp,
+  subtitleLineClamp,
+  reserveEyebrowSlot,
+  reserveSubtitleSlot,
+  reserveMetaSlot,
+  reserveFooterSlot,
+  metaOverflow,
   className,
   bodyClassName,
+  titleClassName,
+  subtitleClassName,
+  metaClassName,
+  footerClassName,
   'data-testid': testId,
 }: EntityHeaderCardProps) {
+  const resolvedTitleLineClamp =
+    titleLineClamp ?? (stableLayout ? 1 : undefined);
+  const shouldReserveEyebrow = reserveEyebrowSlot ?? false;
+  const shouldReserveSubtitle = reserveSubtitleSlot ?? stableLayout;
+  const shouldReserveMeta = reserveMetaSlot ?? stableLayout;
+  const shouldReserveFooter = reserveFooterSlot ?? false;
+  const resolvedSubtitleLineClamp =
+    subtitleLineClamp ?? (shouldReserveSubtitle ? 1 : undefined);
+  const resolvedMetaOverflow: EntityHeaderMetaOverflow =
+    metaOverflow ?? (stableLayout ? 'scroll' : 'wrap');
+
   return (
     <div
       className={cn('relative flex items-start gap-3', className)}
@@ -52,24 +173,57 @@ export function EntityHeaderCard({
       {actions ? <div className='absolute right-0 top-0'>{actions}</div> : null}
       {image ?? null}
       <div className={cn('min-w-0 flex-1 space-y-1', bodyClassName)}>
-        {eyebrow ? (
-          <div className='text-[10.5px] font-caption leading-none tracking-[0.03em] text-tertiary-token'>
+        {eyebrow || shouldReserveEyebrow ? (
+          <StableHeaderTextSlot
+            reserve={shouldReserveEyebrow}
+            lineCount={1}
+            size='xs'
+            className='text-[10.5px] font-caption leading-none tracking-[0.03em] text-tertiary-token'
+          >
             {eyebrow}
-          </div>
+          </StableHeaderTextSlot>
         ) : null}
-        <div className='flex items-center gap-1'>
-          <span className='truncate text-sm font-semibold leading-[18px] tracking-[-0.015em] text-primary-token'>
+        <div className='flex items-start gap-1'>
+          <span
+            className={cn(
+              'min-w-0 flex-1 text-sm font-semibold leading-[18px] tracking-[-0.015em] text-primary-token',
+              resolvedTitleLineClamp
+                ? STABLE_HEADER_LINE_CLAMP_CLASSNAME[resolvedTitleLineClamp]
+                : 'truncate',
+              stableLayout &&
+                resolvedTitleLineClamp &&
+                STABLE_HEADER_TITLE_HEIGHT_CLASSNAME[resolvedTitleLineClamp],
+              titleClassName
+            )}
+          >
             {title}
           </span>
           {badge}
         </div>
-        {subtitle && (
-          <div className='truncate text-xs leading-[16px] tracking-[-0.005em] text-secondary-token'>
+        {subtitle || shouldReserveSubtitle ? (
+          <StableHeaderTextSlot
+            reserve={shouldReserveSubtitle}
+            lineCount={resolvedSubtitleLineClamp}
+            size='xs'
+            className={cn(
+              'text-xs leading-[16px] tracking-[-0.005em] text-secondary-token',
+              subtitleClassName
+            )}
+          >
             {subtitle}
-          </div>
-        )}
-        {meta ? <div className='pt-0.5'>{meta}</div> : null}
-        {footer ? <div className='pt-1'>{footer}</div> : null}
+          </StableHeaderTextSlot>
+        ) : null}
+        <EntityHeaderMetaSlot
+          meta={meta}
+          shouldReserveMeta={shouldReserveMeta}
+          resolvedMetaOverflow={resolvedMetaOverflow}
+          metaClassName={metaClassName}
+        />
+        <EntityHeaderFooterSlot
+          footer={footer}
+          shouldReserveFooter={shouldReserveFooter}
+          footerClassName={footerClassName}
+        />
       </div>
     </div>
   );

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -346,6 +346,12 @@ function ReleaseEntityHeader({
         ) : null}
         <DrawerHero
           title={release.title}
+          stableLayout
+          titleLineClamp={2}
+          subtitleLineClamp={2}
+          reserveSubtitleSlot
+          reserveMetaSlot
+          metaOverflow='scroll'
           subtitle={
             artistLine ? (
               <span className='line-clamp-2 block'>{artistLine}</span>

--- a/apps/web/components/organisms/release-sidebar/ReleaseSmartLinkAnalytics.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSmartLinkAnalytics.tsx
@@ -292,6 +292,9 @@ export function ReleaseSmartLinkAnalytics({
       errorMessage='Analytics unavailable'
       testId='release-smart-link-analytics'
       variant={variant}
+      stableLayout
+      reserveFooterSlot
+      metricSlotCount={2}
       footer={
         release.smartLinkPath ? (
           <ReleaseSmartLinkControl release={release} artistName={artistName} />

--- a/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/TrackSidebar.tsx
@@ -326,6 +326,13 @@ export function TrackSidebar({
               <EntityHeaderCard
                 eyebrow='Track'
                 title={track.title}
+                stableLayout
+                titleLineClamp={1}
+                subtitleLineClamp={1}
+                reserveSubtitleSlot
+                reserveMetaSlot
+                reserveFooterSlot
+                metaOverflow='scroll'
                 subtitle={
                   <span className='flex items-center gap-1.5'>
                     <span className='tabular-nums'>{trackLabel}.</span>
@@ -349,7 +356,7 @@ export function TrackSidebar({
                   />
                 }
                 meta={
-                  <div className='flex flex-wrap items-center gap-2 text-[10.5px] text-tertiary-token'>
+                  <div className='flex items-center gap-2 text-[10.5px] text-tertiary-token'>
                     {track.durationMs == null ? null : (
                       <span className='tabular-nums'>
                         {formatDuration(track.durationMs)}

--- a/apps/web/components/shell/DrawerHero.test.tsx
+++ b/apps/web/components/shell/DrawerHero.test.tsx
@@ -13,6 +13,19 @@ describe('DrawerHero', () => {
     expect(screen.getByText('Bahamas')).toBeInTheDocument();
   });
 
+  it('does not clamp the subtitle by default outside stable layout', () => {
+    render(<DrawerHero title='Lost in the Light' subtitle='Bahamas' />);
+    expect(screen.getByText('Bahamas')).not.toHaveClass('line-clamp-1');
+  });
+
+  it('uses truncate for one-line stable subtitles without changing child layout display', () => {
+    render(
+      <DrawerHero title='Lost in the Light' subtitle='Bahamas' stableLayout />
+    );
+    expect(screen.getByText('Bahamas')).toHaveClass('truncate');
+    expect(screen.getByText('Bahamas')).not.toHaveClass('line-clamp-1');
+  });
+
   it('renders the menu button only when onMenu is provided', () => {
     const a = render(<DrawerHero title='Test' />);
     expect(a.queryByLabelText('Drawer actions')).toBeNull();
@@ -57,5 +70,40 @@ describe('DrawerHero', () => {
     expect(screen.getByTestId('status')).toBeInTheDocument();
     expect(screen.getByTestId('meta')).toBeInTheDocument();
     expect(screen.getByTestId('trailing')).toBeInTheDocument();
+  });
+
+  it('reserves stable subtitle and metadata slots when optional data is missing', () => {
+    render(<DrawerHero title='Test' stableLayout />);
+
+    expect(screen.getByRole('heading', { name: 'Test' })).toHaveClass(
+      'line-clamp-2',
+      'min-h-[44px]'
+    );
+    expect(screen.getByTestId('drawer-hero-subtitle-slot')).toHaveClass(
+      'invisible',
+      'min-h-[16px]'
+    );
+    expect(screen.getByTestId('drawer-hero-meta-slot')).toHaveClass(
+      'invisible'
+    );
+  });
+
+  it('keeps stable metadata in a single horizontal rail', () => {
+    render(
+      <DrawerHero
+        title='Test'
+        stableLayout
+        meta={
+          <>
+            <span>Scheduled</span>
+            <span>Single</span>
+            <span>Spotify</span>
+          </>
+        }
+      />
+    );
+
+    const rail = screen.getByTestId('drawer-hero-meta-slot').firstElementChild;
+    expect(rail).toHaveClass('overflow-x-auto', 'whitespace-nowrap');
   });
 });

--- a/apps/web/components/shell/DrawerHero.tsx
+++ b/apps/web/components/shell/DrawerHero.tsx
@@ -2,8 +2,17 @@
 
 import { MoreHorizontal, Play } from 'lucide-react';
 import type { ReactNode } from 'react';
+import {
+  STABLE_HEADER_LINE_CLAMP_CLASSNAME,
+  STABLE_HEADER_TITLE_HEIGHT_CLASSNAME,
+  StableHeaderChipRail,
+  type StableHeaderLineCount,
+  StableHeaderTextSlot,
+} from '@/components/atoms/StableHeaderSlots';
 import { cn } from '@/lib/utils';
 import { Tooltip } from './Tooltip';
+
+type DrawerHeroMetaOverflow = 'wrap' | 'scroll';
 
 export interface DrawerHeroProps {
   /** Title row (release title, track title, contact name, etc.). */
@@ -24,6 +33,20 @@ export interface DrawerHeroProps {
   readonly meta?: ReactNode;
   /** Below-meta row for inline actions (smart link copy, etc.). */
   readonly trailing?: ReactNode;
+  /** Enables reserved header slots so entity selection changes do not resize the card. */
+  readonly stableLayout?: boolean;
+  /** Max title lines before truncation. Stable layouts reserve this line count. */
+  readonly titleLineClamp?: StableHeaderLineCount;
+  /** Max subtitle lines before truncation. Stable layouts reserve this line count. */
+  readonly subtitleLineClamp?: StableHeaderLineCount;
+  /** Reserve the subtitle row even when no subtitle is available. */
+  readonly reserveSubtitleSlot?: boolean;
+  /** Reserve the metadata row even when no metadata is available. */
+  readonly reserveMetaSlot?: boolean;
+  /** Reserve the trailing row even when no trailing content is available. */
+  readonly reserveTrailingSlot?: boolean;
+  /** Metadata can either wrap or stay in a one-line horizontal rail. */
+  readonly metaOverflow?: DrawerHeroMetaOverflow;
   /** Optional click handler on the artwork — surfaces a play overlay. */
   readonly onPlay?: () => void;
   readonly playLabel?: string;
@@ -31,6 +54,124 @@ export interface DrawerHeroProps {
   readonly onMenu?: (e: React.MouseEvent<HTMLButtonElement>) => void;
   readonly menuLabel?: string;
   readonly className?: string;
+  readonly titleClassName?: string;
+  readonly subtitleClassName?: string;
+  readonly metaClassName?: string;
+  readonly trailingClassName?: string;
+  readonly testId?: string;
+}
+
+function DrawerHeroArtworkSlot({
+  artwork,
+  onPlay,
+  playLabel,
+  title,
+}: Readonly<{
+  artwork?: ReactNode;
+  onPlay?: () => void;
+  playLabel?: string;
+  title: string;
+}>) {
+  if (!artwork) {
+    return null;
+  }
+
+  if (!onPlay) {
+    return <div className='shrink-0 rounded-lg overflow-hidden'>{artwork}</div>;
+  }
+
+  return (
+    <button
+      type='button'
+      onClick={onPlay}
+      aria-label={playLabel ?? `Play ${title}`}
+      className='shrink-0 relative group/art rounded-lg overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token focus-visible:ring-offset-2'
+    >
+      {artwork}
+      <span
+        aria-hidden='true'
+        className='absolute inset-0 grid place-items-center bg-black/45 opacity-0 group-hover/art:opacity-100 transition-opacity duration-subtle ease-subtle'
+      >
+        <span className='h-8 w-8 rounded-full bg-white text-black grid place-items-center'>
+          <Play
+            className='h-4 w-4 translate-x-px'
+            strokeWidth={2.5}
+            fill='currentColor'
+          />
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function DrawerHeroMetaSlot({
+  meta,
+  shouldReserveMeta,
+  resolvedMetaOverflow,
+  metaClassName,
+}: Readonly<{
+  meta?: ReactNode;
+  shouldReserveMeta: boolean;
+  resolvedMetaOverflow: DrawerHeroMetaOverflow;
+  metaClassName?: string;
+}>) {
+  if (!meta && !shouldReserveMeta) {
+    return null;
+  }
+
+  if (resolvedMetaOverflow === 'scroll') {
+    return (
+      <StableHeaderChipRail
+        reserve={shouldReserveMeta}
+        className={cn('mt-2', metaClassName)}
+        testId='drawer-hero-meta-slot'
+      >
+        {meta}
+      </StableHeaderChipRail>
+    );
+  }
+
+  return (
+    <div
+      aria-hidden={meta ? undefined : true}
+      className={cn(
+        'mt-2 flex min-h-[22px] items-center gap-1.5 flex-wrap',
+        !meta && 'invisible',
+        metaClassName
+      )}
+      data-testid='drawer-hero-meta-slot'
+    >
+      {meta ?? <span>{'\u00a0'}</span>}
+    </div>
+  );
+}
+
+function DrawerHeroTrailingSlot({
+  trailing,
+  shouldReserveTrailing,
+  trailingClassName,
+}: Readonly<{
+  trailing?: ReactNode;
+  shouldReserveTrailing: boolean;
+  trailingClassName?: string;
+}>) {
+  if (!trailing && !shouldReserveTrailing) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-hidden={trailing ? undefined : true}
+      className={cn(
+        'mt-4 min-h-[32px]',
+        !trailing && 'invisible',
+        trailingClassName
+      )}
+      data-testid='drawer-hero-trailing-slot'
+    >
+      {trailing ?? '\u00a0'}
+    </div>
+  );
 }
 
 /**
@@ -81,45 +222,60 @@ export function DrawerHero({
   statusBadge,
   meta,
   trailing,
+  stableLayout = false,
+  titleLineClamp,
+  subtitleLineClamp,
+  reserveSubtitleSlot,
+  reserveMetaSlot,
+  reserveTrailingSlot,
+  metaOverflow,
   onPlay,
   playLabel,
   onMenu,
   menuLabel = 'Drawer actions',
   className,
+  titleClassName,
+  subtitleClassName,
+  metaClassName,
+  trailingClassName,
+  testId,
 }: DrawerHeroProps) {
   const hasTopRight = Boolean(statusBadge || onMenu);
+  const resolvedTitleLineClamp =
+    titleLineClamp ?? (stableLayout ? 2 : undefined);
+  const shouldReserveSubtitle = reserveSubtitleSlot ?? stableLayout;
+  const shouldReserveMeta = reserveMetaSlot ?? stableLayout;
+  const shouldReserveTrailing = reserveTrailingSlot ?? false;
+  const resolvedSubtitleLineClamp =
+    subtitleLineClamp ?? (shouldReserveSubtitle ? 1 : undefined);
+  const resolvedMetaOverflow: DrawerHeroMetaOverflow =
+    metaOverflow ?? (stableLayout ? 'scroll' : 'wrap');
   return (
-    <section className={cn('group/drawer px-3 pt-3 pb-3', className)}>
+    <section
+      className={cn('group/drawer px-3 pt-3 pb-3', className)}
+      data-testid={testId}
+    >
       <div className='flex items-start gap-3'>
-        {artwork &&
-          (onPlay ? (
-            <button
-              type='button'
-              onClick={onPlay}
-              aria-label={playLabel ?? `Play ${title}`}
-              className='shrink-0 relative group/art rounded-lg overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token focus-visible:ring-offset-2'
-            >
-              {artwork}
-              <span
-                aria-hidden='true'
-                className='absolute inset-0 grid place-items-center bg-black/45 opacity-0 group-hover/art:opacity-100 transition-opacity duration-subtle ease-subtle'
-              >
-                <span className='h-8 w-8 rounded-full bg-white text-black grid place-items-center'>
-                  <Play
-                    className='h-4 w-4 translate-x-px'
-                    strokeWidth={2.5}
-                    fill='currentColor'
-                  />
-                </span>
-              </span>
-            </button>
-          ) : (
-            <div className='shrink-0 rounded-lg overflow-hidden'>{artwork}</div>
-          ))}
+        <DrawerHeroArtworkSlot
+          artwork={artwork}
+          onPlay={onPlay}
+          playLabel={playLabel}
+          title={title}
+        />
 
         <div className='flex-1 min-w-0 pt-1'>
           <div className='flex items-start gap-2'>
-            <h2 className='flex-1 min-w-0 text-[17px] font-semibold text-primary-token leading-tight'>
+            <h2
+              className={cn(
+                'flex-1 min-w-0 text-[17px] font-semibold text-primary-token leading-tight',
+                resolvedTitleLineClamp &&
+                  STABLE_HEADER_LINE_CLAMP_CLASSNAME[resolvedTitleLineClamp],
+                stableLayout &&
+                  resolvedTitleLineClamp &&
+                  STABLE_HEADER_TITLE_HEIGHT_CLASSNAME[resolvedTitleLineClamp],
+                titleClassName
+              )}
+            >
               {title}
             </h2>
             {hasTopRight && (
@@ -144,20 +300,34 @@ export function DrawerHero({
               </div>
             )}
           </div>
-          {subtitle && (
-            <div className='mt-1 text-[12px] text-tertiary-token truncate'>
+          {subtitle || shouldReserveSubtitle ? (
+            <StableHeaderTextSlot
+              reserve={shouldReserveSubtitle}
+              lineCount={resolvedSubtitleLineClamp}
+              size='xs'
+              className={cn(
+                'mt-1 text-[12px] leading-[16px] text-tertiary-token',
+                subtitleClassName
+              )}
+              testId='drawer-hero-subtitle-slot'
+            >
               {subtitle}
-            </div>
-          )}
-          {meta && (
-            <div className='mt-2 flex items-center gap-1.5 flex-wrap'>
-              {meta}
-            </div>
-          )}
+            </StableHeaderTextSlot>
+          ) : null}
+          <DrawerHeroMetaSlot
+            meta={meta}
+            shouldReserveMeta={shouldReserveMeta}
+            resolvedMetaOverflow={resolvedMetaOverflow}
+            metaClassName={metaClassName}
+          />
         </div>
       </div>
 
-      {trailing && <div className='mt-4'>{trailing}</div>}
+      <DrawerHeroTrailingSlot
+        trailing={trailing}
+        shouldReserveTrailing={shouldReserveTrailing}
+        trailingClassName={trailingClassName}
+      />
     </section>
   );
 }

--- a/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -639,6 +639,18 @@ describe('ReleaseSidebar inspector cards', () => {
     expect(
       screen.queryByTestId('release-inspector-stack')
     ).not.toBeInTheDocument();
+  });
+
+  it('uses stable release header geometry for text, badges, and analytics', () => {
+    render(<ReleaseSidebar release={mockRelease} {...defaultProps} />);
+
+    const header = screen.getByTestId('release-header-card');
+    expect(
+      within(header).getByRole('heading', { name: mockRelease.title })
+    ).toHaveClass('line-clamp-2', 'min-h-[44px]');
+    expect(
+      screen.getByTestId('drawer-hero-meta-slot').firstElementChild
+    ).toHaveClass('overflow-x-auto', 'whitespace-nowrap');
   });
 
   it('resets the active tab to Details when the release changes', async () => {

--- a/apps/web/tests/e2e/right-rail-header-stability.spec.ts
+++ b/apps/web/tests/e2e/right-rail-header-stability.spec.ts
@@ -1,0 +1,241 @@
+import {
+  expect,
+  type Locator,
+  type Page,
+  type TestInfo,
+  test,
+} from '@playwright/test';
+
+const RELEASES_URL = '/app/releases';
+const AUDIENCE_URL = '/app/audience';
+const LAYOUT_TOLERANCE_PX = 1;
+const DEV_SERVER_NAVIGATION_ATTEMPT_TIMEOUT_MS = 60_000;
+const USE_TEST_AUTH_BYPASS = process.env.E2E_USE_TEST_AUTH_BYPASS === '1';
+
+test.beforeAll(() => {
+  if (!USE_TEST_AUTH_BYPASS) {
+    throw new Error(
+      'Right-rail stability spec requires E2E_USE_TEST_AUTH_BYPASS=1'
+    );
+  }
+});
+
+interface LayoutRect {
+  readonly top: number;
+  readonly height: number;
+}
+
+async function readRect(locator: Locator): Promise<LayoutRect> {
+  await expect(locator).toBeVisible({ timeout: 15_000 });
+
+  return locator.evaluate(element => {
+    const rect = element.getBoundingClientRect();
+    return {
+      top: rect.top,
+      height: rect.height,
+    };
+  });
+}
+
+async function waitForRowsOrSkip(
+  {
+    rows,
+    label,
+  }: {
+    readonly rows: Locator;
+    readonly label: string;
+  },
+  testInfo: TestInfo
+) {
+  await rows
+    .first()
+    .waitFor({ state: 'visible', timeout: 15_000 })
+    .catch(() => undefined);
+
+  const rowCount = await rows.count();
+  testInfo.skip(rowCount < 2, `${label} requires at least two rows`);
+}
+
+async function waitForReleaseSurface(page: Page) {
+  const visibleSurface = page
+    .getByTestId('shell-releases-view')
+    .or(page.getByTestId('releases-matrix'))
+    .first();
+
+  const shellReady = page.getByTestId('releases-shell-ready');
+
+  await Promise.race([
+    visibleSurface
+      .waitFor({ state: 'visible', timeout: 30_000 })
+      .catch(() => undefined),
+    shellReady
+      .waitFor({ state: 'attached', timeout: 30_000 })
+      .catch(() => undefined),
+  ]);
+}
+
+async function gotoWithDevServerRetry(page: Page, url: string) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      await page.goto(url, {
+        timeout: DEV_SERVER_NAVIGATION_ATTEMPT_TIMEOUT_MS,
+        waitUntil: 'domcontentloaded',
+      });
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const isTransientDevServerRestart =
+        /ERR_EMPTY_RESPONSE|ECONNRESET|aborted|page\.goto: Timeout/i.test(
+          message
+        );
+
+      if (!isTransientDevServerRestart || attempt === 2) {
+        throw error;
+      }
+
+      await page.waitForTimeout(2000);
+    }
+  }
+}
+
+function expectStableRect(
+  before: LayoutRect,
+  after: LayoutRect,
+  label: string
+) {
+  expect(
+    Math.abs(after.height - before.height),
+    `${label} height shifted from ${before.height}px to ${after.height}px`
+  ).toBeLessThanOrEqual(LAYOUT_TOLERANCE_PX);
+  expect(
+    Math.abs(after.top - before.top),
+    `${label} top shifted from ${before.top}px to ${after.top}px`
+  ).toBeLessThanOrEqual(LAYOUT_TOLERANCE_PX);
+}
+
+async function measureRightRail({
+  header,
+  body,
+}: {
+  readonly header: Locator;
+  readonly body: Locator;
+}) {
+  return {
+    header: await readRect(header),
+    body: await readRect(body),
+  };
+}
+
+function expectNoRightRailShift({
+  before,
+  after,
+}: {
+  readonly before: Awaited<ReturnType<typeof measureRightRail>>;
+  readonly after: Awaited<ReturnType<typeof measureRightRail>>;
+}) {
+  expectStableRect(before.header, after.header, 'Right rail header');
+  expectStableRect(before.body, after.body, 'First body card');
+}
+
+function expectNoConsoleErrors(consoleErrors: string[]) {
+  const ignorable = [/clerk|handshake|dev-browser/i, /sentry/i, /favicon/i];
+  const relevant = consoleErrors.filter(e => !ignorable.some(rx => rx.test(e)));
+
+  expect(
+    relevant,
+    `Unexpected console errors during right-rail stability check: ${relevant.join('\n')}`
+  ).toEqual([]);
+}
+
+test('release right rail header stays fixed during keyboard selection changes', async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(240_000);
+
+  const consoleErrors: string[] = [];
+  page.on('pageerror', err => consoleErrors.push(String(err)));
+
+  await gotoWithDevServerRetry(page, RELEASES_URL);
+  await page.waitForURL(/\/app\/(?:dashboard\/)?releases/, {
+    timeout: 60_000,
+  });
+  await waitForReleaseSurface(page);
+
+  const rows = page.locator(
+    '[data-shell-release-row], [data-testid="release-row"]'
+  );
+  await waitForRowsOrSkip(
+    { rows, label: 'Release header stability check' },
+    testInfo
+  );
+
+  await rows.nth(0).click();
+  await expect(rows.nth(0)).toHaveAttribute('data-selected', 'true');
+  await expect(page.getByTestId('release-sidebar')).toBeVisible({
+    timeout: 15_000,
+  });
+
+  const before = await measureRightRail({
+    header: page.getByTestId('release-header-card'),
+    body: page.getByTestId('release-tabbed-card'),
+  });
+
+  await page.keyboard.press('ArrowDown');
+  await expect(rows.nth(1)).toHaveAttribute('data-selected', 'true', {
+    timeout: 5_000,
+  });
+
+  const after = await measureRightRail({
+    header: page.getByTestId('release-header-card'),
+    body: page.getByTestId('release-tabbed-card'),
+  });
+
+  expectNoRightRailShift({ before, after });
+  expectNoConsoleErrors(consoleErrors);
+});
+
+test('audience right rail header stays fixed when a contact has sparse data', async ({
+  page,
+}, testInfo) => {
+  test.setTimeout(240_000);
+
+  const consoleErrors: string[] = [];
+  page.on('pageerror', err => consoleErrors.push(String(err)));
+
+  await gotoWithDevServerRetry(page, AUDIENCE_URL);
+  await page.waitForURL(/\/app\/(?:dashboard\/)?audience/, {
+    timeout: 60_000,
+  });
+  await expect(page.getByTestId('dashboard-audience-table')).toBeVisible({
+    timeout: 30_000,
+  });
+
+  const rows = page.locator('tbody tr[data-index]');
+  await waitForRowsOrSkip(
+    { rows, label: 'Audience header stability check' },
+    testInfo
+  );
+
+  await rows.nth(0).click();
+  await expect(page.getByTestId('audience-member-sidebar')).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByTestId('audience-member-header-card')).toBeVisible();
+
+  const before = await measureRightRail({
+    header: page.getByTestId('audience-member-header-card'),
+    body: page.getByTestId('audience-member-tabbed-card'),
+  });
+
+  await rows.nth(0).focus();
+  await page.keyboard.press('ArrowDown');
+  await expect(rows.nth(1)).toBeFocused({ timeout: 5_000 });
+
+  const after = await measureRightRail({
+    header: page.getByTestId('audience-member-header-card'),
+    body: page.getByTestId('audience-member-tabbed-card'),
+  });
+
+  expectNoRightRailShift({ before, after });
+  expectNoConsoleErrors(consoleErrors);
+});

--- a/apps/web/tests/unit/components/features/AudienceMemberSidebar.test.tsx
+++ b/apps/web/tests/unit/components/features/AudienceMemberSidebar.test.tsx
@@ -82,6 +82,22 @@ describe('AudienceMemberSidebar', () => {
     expect(screen.getByText('jordan@example.com')).toBeInTheDocument();
   });
 
+  it('reserves the header contact line when an audience member has no email or phone', () => {
+    render(
+      <AudienceMemberSidebar
+        member={{ ...member, email: null, phone: null }}
+        isOpen
+        onClose={() => undefined}
+      />
+    );
+
+    expect(screen.getByText('Jordan Reyes')).toBeInTheDocument();
+    expect(screen.getByTestId('drawer-hero-subtitle-slot')).toHaveClass(
+      'invisible',
+      'min-h-[16px]'
+    );
+  });
+
   it('renders location and visit count in meta slot', () => {
     render(
       <AudienceMemberSidebar member={member} isOpen onClose={() => undefined} />


### PR DESCRIPTION
## Summary
- Add shared stable header slots for clamped text, reserved optional rows, and one-line chip rails.
- Add stable-layout options to DrawerHero, EntityHeaderCard, and DrawerAnalyticsSummaryCard.
- Opt Audience, Releases, and sibling right-rail sidebar headers into stable geometry so optional data, badges, and analytics states do not resize the top card.

## Test Coverage
- Added unit coverage for DrawerHero, EntityHeaderCard, and DrawerAnalyticsSummaryCard stable slots.
- Added sidebar coverage for Audience missing-email and Release header badge/title behavior.
- Added focused Playwright coverage for right-rail header/body-card bounding-box stability when local row data is available.

## Visual QA
- Local component screenshot harness captured long release title, missing audience email, one-line chip overflow, reserved footer/contact slots, and stable analytics sizing.
- Screenshot artifacts: .gstack/qa-reports/screenshots/writerail-header-2026-05-24/

## Verification Results
- pnpm --filter @jovie/web run typecheck -- --pretty false: passed
- pnpm --filter web exec vitest run components/shell/DrawerHero.test.tsx components/molecules/drawer/EntityHeaderCard.test.tsx components/molecules/drawer/DrawerAnalyticsSummaryCard.spec.tsx tests/unit/components/features/AudienceMemberSidebar.test.tsx tests/components/organisms/release-sidebar/ReleaseSidebar-links.interaction.test.tsx: 39 tests passed
- E2E_SKIP_WEB_SERVER=1 BASE_URL=http://localhost:3001 E2E_USE_TEST_AUTH_BYPASS=1 E2E_TEST_AUTH_PERSONA=creator-ready pnpm --filter web exec playwright test tests/e2e/right-rail-header-stability.spec.ts --project=chromium --reporter=line: passed with row-dependent scenarios skipped under empty local seeded data
- git push pre-push hook: biome check, next proxy guard, tailwind guard, typecheck, lint passed

## Local Data Note
Doppler-backed local dashboard auth fell back to a synthetic empty persona after dev DB connection timeouts. The row-dependent Playwright assertions are present and skip when fewer than two rows exist; component screenshot QA covered the geometry states directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved header and sidebar stability to prevent layout shifts when content loads or changes
  * Headers now maintain consistent sizing across different content states
  * Metadata sections now scroll horizontally when needed

* **Tests**
  * Added comprehensive tests for header layout stability behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9601?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->