### PR TITLE
fix(billing): suppress clean-session status toast

### DIFF
--- a/apps/web/components/organisms/user-button/useUserButton.ts
+++ b/apps/web/components/organisms/user-button/useUserButton.ts
@@ -135,10 +135,14 @@ export function useUserButton({
   };
 
   useEffect(() => {
-    if (
+    const shouldNotifyBillingStatusError =
       hasLoadedUser &&
-      billingStatus.error &&
-      shouldSurfaceBillingStatusError &&
+      !billingStatus.loading &&
+      Boolean(billingStatus.error) &&
+      shouldSurfaceBillingStatusError;
+
+    if (
+      shouldNotifyBillingStatusError &&
       !hasNotifiedBillingErrorThisSession(billingStatusErrorToastSessionKey)
     ) {
       toast.error(
@@ -149,6 +153,7 @@ export function useUserButton({
     }
   }, [
     billingStatus.error,
+    billingStatus.loading,
     billingStatusErrorToastSessionKey,
     hasLoadedUser,
     shouldSurfaceBillingStatusError,

--- a/apps/web/tests/components/user-button.test.tsx
+++ b/apps/web/tests/components/user-button.test.tsx
@@ -410,11 +410,42 @@ describe('UserButton billing actions', () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
+  it('does not show the passive billing-status toast after a clean admin login with a healthy subscription', () => {
+    mockUsePathname.mockReturnValue('/app/admin/ops');
+    mockUseBillingStatusQuery.mockReturnValue({
+      data: { isPro: true, plan: 'pro', hasStripeCustomer: true },
+      isLoading: false,
+      error: null,
+    } as any);
+
+    render(<UserButton showUserInfo />);
+
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(
+      window.sessionStorage.getItem(
+        'jovie:billing-status-error-toast-shown:user_123'
+      )
+    ).toBeNull();
+  });
+
   it('does not show the passive billing-status toast while the pathname is unavailable', () => {
     mockUsePathname.mockReturnValue(null);
     mockUseBillingStatusQuery.mockReturnValue({
       data: null,
       isLoading: false,
+      error: new Error('Billing unavailable'),
+    } as any);
+
+    render(<UserButton showUserInfo />);
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('waits for billing status to settle before showing the passive billing-status toast', () => {
+    mockUsePathname.mockReturnValue('/billing');
+    mockUseBillingStatusQuery.mockReturnValue({
+      data: null,
+      isLoading: true,
       error: new Error('Billing unavailable'),
     } as any);
 


### PR DESCRIPTION
## Summary
- Fixes JOV-2092 by requiring the passive billing-status toast to wait for billing status to finish loading.
- Keeps the toast scoped to billing-owned surfaces and real billing-status errors.
- Adds regressions for clean admin login with a healthy subscription and loading-state suppression.

## Verification
- `./scripts/setup.sh`
- `pnpm biome check --write apps/web/components/organisms/user-button/useUserButton.ts apps/web/tests/components/user-button.test.tsx`
- `pnpm --filter web exec vitest run tests/components/user-button.test.tsx` (15 tests)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-commit: proxy guard, Biome, ESLint, staged a11y, typecheck
- pre-push: full Biome, proxy guard, Tailwind guard, typecheck, Biome lint

Linear: JOV-2092