### PR TITLE
fix(security): harden workflow token scopes

### DIFF
--- a/.github/workflows/auto-pr-on-push.yml
+++ b/.github/workflows/auto-pr-on-push.yml
@@ -37,8 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Stagger start to avoid CI stampede
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3534,12 +3534,10 @@ jobs:
       - name: Check if SHA is still main HEAD
         id: check
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          tip=$(curl -sS -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" \
-            "${{ github.api_url }}/repos/${{ github.repository }}/commits/main" \
-            | python3 -c 'import json,sys; print(json.load(sys.stdin).get("sha",""))')
+          tip=$(gh api "repos/${{ github.repository }}/commits/main" --jq '.sha // ""' 2>/dev/null || true)
           if [ -z "$tip" ]; then
             echo "::warning::Could not resolve origin/main tip; defaulting to proceed"
             echo "is_head=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,14 +10,15 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: meta

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -36,8 +36,7 @@ on:
           - production
         default: production
 
-permissions:
-  contents: write
+permissions: {}
 
 concurrency:
   # On push, github.event.inputs.environment is empty → group becomes
@@ -54,6 +53,8 @@ jobs:
     # those binaries today and building them on every release wastes runner
     # time. To re-enable, restore the matrix strategy with the desired OSes.
     runs-on: macos-latest
+    permissions:
+      contents: write
     env:
       ENVIRONMENT: ${{ github.event.inputs.environment || 'production' }}
       HAS_MAC_SIGNING_CREDENTIALS: ${{ secrets.MAC_CERTIFICATE_BASE64 != '' && secrets.MAC_CERTIFICATE_PASSWORD != '' }}

--- a/.github/workflows/fork-pr-gate.yml
+++ b/.github/workflows/fork-pr-gate.yml
@@ -90,10 +90,7 @@ jobs:
     if: github.event_name != 'pull_request_target' && github.actor != 'copilot-swe-agent[bot]' && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    permissions:
-      contents: read
-      pull-requests: read
-      statuses: write
+    permissions: {}
     steps:
       - name: Generate Jovie Bot token
         id: app-token

--- a/.github/workflows/hermes-cli-worker.yml
+++ b/.github/workflows/hermes-cli-worker.yml
@@ -47,10 +47,7 @@ jobs:
     name: Run Hermes CLI Worker
     runs-on: [self-hosted, hermes]
     timeout-minutes: 120
-    permissions:
-      contents: write
-      pull-requests: write
-      actions: read
+    permissions: {}
     env:
       JOVIE_AGENT_PROFILE: coder
     steps:

--- a/.github/workflows/linear-ai-dispatcher.yml
+++ b/.github/workflows/linear-ai-dispatcher.yml
@@ -38,10 +38,7 @@ jobs:
     name: Dispatch Ready Linear Issues
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: write
-      pull-requests: read
-      actions: write
+    permissions: {}
     env:
       PROJECT_NAME: ${{ inputs.project_name || 'Design V1 Rollout / Flag Hardening' }}
       READY_LABEL: ${{ inputs.ready_label || 'automated' }}

--- a/.github/workflows/scope-judge.yml
+++ b/.github/workflows/scope-judge.yml
@@ -40,8 +40,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: read
-      pull-requests: read
-      statuses: write
     # Only run on agent branches
     if: >-
       !github.event.pull_request.draft &&

--- a/.github/workflows/test-coverage-audit.yml
+++ b/.github/workflows/test-coverage-audit.yml
@@ -25,8 +25,7 @@ on:
         type: boolean
         default: true
 
-permissions:
-  contents: write
+permissions: {}
 
 concurrency:
   group: test-coverage-audit
@@ -37,6 +36,9 @@ jobs:
     name: Regenerate coverage heatmap
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/scripts/hermes/bootstrap-air.sh
+++ b/scripts/hermes/bootstrap-air.sh
@@ -154,7 +154,15 @@ if [[ "$MODE" == "install" ]]; then
   # 5. Hermes (hermes-agent-rs)
   if ! command -v hermes >/dev/null 2>&1; then
     log "Installing Hermes (hermes-agent-rs)"
-    curl -fsSL https://raw.githubusercontent.com/Lumio-Research/hermes-agent-rs/main/scripts/install.sh | bash
+    HERMES_INSTALL_REF="60ee269fe37f5eb29df49378479293a102c2ad07"
+    HERMES_INSTALL_SHA256="3f2404dc8b47414a6c46899a5549dea73a456f9e99d0e3f5ed2da65eee891881"
+    HERMES_VERSION="v0.1.1"
+    HERMES_INSTALLER="$(mktemp)"
+    curl -fsSL "https://raw.githubusercontent.com/Lumio-Research/hermes-agent-rs/${HERMES_INSTALL_REF}/scripts/install.sh" \
+      -o "$HERMES_INSTALLER"
+    printf '%s  %s\n' "$HERMES_INSTALL_SHA256" "$HERMES_INSTALLER" | shasum -a 256 -c -
+    bash "$HERMES_INSTALLER" "$HERMES_VERSION"
+    rm -f "$HERMES_INSTALLER"
   fi
   HERMES_BIN="$(command -v hermes)"
   ok "Hermes at $HERMES_BIN"
@@ -187,7 +195,7 @@ if [[ "$MODE" == "install" ]]; then
   # 8. tsx for running the cron job scripts
   if ! command -v tsx >/dev/null 2>&1; then
     log "Installing tsx globally"
-    npm install -g tsx
+    npm install -g tsx@4.21.0
   fi
   TSX_BIN="$(command -v tsx)"
   ok "tsx at $TSX_BIN"


### PR DESCRIPTION
## Summary
- reduce default GitHub Actions token permissions and move required write scopes down to the specific jobs that need them
- switch main-head lookup to `gh api --jq` instead of ad hoc curl JSON parsing
- pin the Hermes installer script by commit and SHA-256, and pin global tsx installation

## Verification
- bash -n scripts/hermes/bootstrap-air.sh
- git diff --check
- actionlint -shellcheck= on edited workflows
- pinned Hermes installer checksum verified against the configured SHA-256
- git commit hook: next proxy guard
- git push hook: biome check ., web pre-push (proxy guard, Tailwind guard, typecheck, biome lint)

Note: full actionlint with shellcheck still reports existing shellcheck findings in large workflow scripts outside this scoped change.

Linear: JOV-2569