### PR TITLE
fix(security): drain remaining code scanning alerts

### DIFF
--- a/.agents/skills/gstack/.github/docker/Dockerfile.ci
+++ b/.agents/skills/gstack/.github/docker/Dockerfile.ci
@@ -1,6 +1,6 @@
 # gstack CI eval runner — pre-baked toolchain + deps
 # Rebuild weekly via ci-image.yml, on Dockerfile changes, or on lockfile changes
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -18,19 +18,24 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && rm -rf /var/lib/apt/lists/*
 
 # Node.js 22 LTS (needed for claude CLI)
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x -o /tmp/nodesource-setup.sh \
+    && echo "575583bbac2fccc0b5edd0dbc03e222d9f9dc8d724da996d22754d6411104fd1  /tmp/nodesource-setup.sh" | sha256sum -c - \
+    && bash /tmp/nodesource-setup.sh \
     && apt-get install -y --no-install-recommends nodejs \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /tmp/nodesource-setup.sh /var/lib/apt/lists/*
 
 # Bun (install to /usr/local so non-root users can access it)
 ENV BUN_INSTALL="/usr/local"
-RUN bash -o pipefail -c 'curl -fsSL https://bun.sh/install | BUN_VERSION=1.3.10 bash'
+RUN curl -fsSL https://bun.sh/install -o /tmp/bun-install.sh \
+    && echo "bab8acfb046aac8c72407bdcce903957665d655d7acaa3e11c7c4616beae68dd  /tmp/bun-install.sh" | sha256sum -c - \
+    && BUN_VERSION=1.3.10 bash /tmp/bun-install.sh \
+    && rm -f /tmp/bun-install.sh
 
 # Claude CLI
-RUN npm i -g @anthropic-ai/claude-code
+RUN npm i -g @anthropic-ai/claude-code@2.1.150
 
 # Playwright system deps (Chromium) — needed for browse E2E tests
-RUN npx playwright install-deps chromium
+RUN npx --yes playwright@1.60.0 install-deps chromium
 
 # Pre-install dependencies (cached layer — only rebuilds when package.json changes)
 COPY package.json /workspace/
@@ -39,12 +44,12 @@ RUN bun install && rm -rf /tmp/*
 
 # Install Playwright Chromium to a shared location accessible by all users
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
-RUN npx playwright install chromium \
+RUN npx --yes playwright@1.60.0 install chromium \
     && chmod -R a+rX /opt/playwright-browsers
 
 # Verify everything works
 RUN bun --version && node --version && claude --version && jq --version && gh --version \
-    && npx playwright --version
+    && npx --yes playwright@1.60.0 --version
 
 # At runtime: checkout overwrites /workspace, but node_modules persists
 # if we move it out of the way and symlink back

--- a/.agents/skills/gstack/browse/src/read-commands.ts
+++ b/.agents/skills/gstack/browse/src/read-commands.ts
@@ -44,6 +44,9 @@ const SAFE_DIRECTORIES = [TEMP_DIR, process.cwd()].map(d => {
 });
 
 export function validateReadPath(filePath: string): void {
+  if (path.normalize(filePath).split(path.sep).includes('..')) {
+    throw new Error(`Path must be within: ${SAFE_DIRECTORIES.join(', ')}`);
+  }
   // Always resolve to absolute first (fixes relative path symlink bypass)
   const resolved = path.resolve(filePath);
   // Resolve symlinks — throw on non-ENOENT errors

--- a/.agents/skills/gstack/bun.lock
+++ b/.agents/skills/gstack/bun.lock
@@ -14,6 +14,9 @@
       },
     },
   },
+  "overrides": {
+    "ws": "8.21.0",
+  },
   "packages": {
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.78.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w=="],
 
@@ -181,7 +184,7 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 

--- a/.agents/skills/gstack/package.json
+++ b/.agents/skills/gstack/package.json
@@ -41,6 +41,9 @@
     "playwright": "^1.58.2",
     "puppeteer-core": "^24.40.0"
   },
+  "overrides": {
+    "ws": "8.21.0"
+  },
   "engines": {
     "bun": ">=1.0.0"
   },

--- a/.agents/skills/gstack/setup
+++ b/.agents/skills/gstack/setup
@@ -243,7 +243,7 @@ if ! ensure_playwright_browser; then
     (
       cd "$SOURCE_GSTACK_DIR"
       # Bun's node_modules already has playwright; verify Node can require it
-      node -e "require('playwright')" 2>/dev/null || npm install --no-save playwright
+      node -e "require('playwright')" 2>/dev/null || npm install --no-save playwright@1.60.0
     )
   fi
 fi

--- a/.github/workflows/ios-signing-bootstrap.yml
+++ b/.github/workflows/ios-signing-bootstrap.yml
@@ -34,7 +34,7 @@ jobs:
         run: xcodebuild -version
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: "3.1"
           bundler-cache: true

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -55,7 +55,7 @@ jobs:
         run: xcodebuild -version
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: "3.1"
           bundler-cache: true

--- a/.github/workflows/main-autofix.yml
+++ b/.github/workflows/main-autofix.yml
@@ -134,9 +134,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      contents: write
-      pull-requests: write
-      issues: write
       actions: read
       id-token: write
     steps:

--- a/.github/workflows/main-ci-health-monitor.yml
+++ b/.github/workflows/main-ci-health-monitor.yml
@@ -13,7 +13,7 @@ jobs:
     name: Detect stalled or failing CI on main
     runs-on: ubuntu-latest
     permissions:
-      actions: write
+      actions: read
       contents: read
       pull-requests: read
     outputs:
@@ -33,6 +33,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Generate Jovie Bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.JOVIE_BOT_APP_ID }}
+          private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
+          permission-actions: write
 
       - name: Evaluate main CI health
         id: evaluate
@@ -75,7 +83,7 @@ jobs:
       - name: Auto-rerun failed deploy (self-healing)
         if: ${{ steps.evaluate.outputs.should_alert == 'true' && steps.evaluate.outputs.failed_run_id != '' }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           FAILED_RUN_ID: ${{ steps.evaluate.outputs.failed_run_id }}
           GH_REPO: ${{ github.repository }}
         run: |

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -42,8 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     defaults:
       run:
         working-directory: apps/web
@@ -57,7 +56,16 @@ jobs:
       E2E_CLERK_USER_ID: user_test
 
     steps:
+      - name: Generate Jovie Bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.JOVIE_BOT_APP_ID }}
+          private-key: ${{ secrets.JOVIE_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: ./.github/actions/setup-node-pnpm
 
@@ -104,7 +112,7 @@ jobs:
         if: steps.diff.outputs.changed == 'true'
         working-directory: .
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/scripts/dispatch-kanban.sh
+++ b/scripts/dispatch-kanban.sh
@@ -41,16 +41,63 @@ mark_linear() {
   [ -z "$key" ] && return 0
   local sid="721e032a-fe72-4374-9a61-d9976d079e1e"
   local iid
-  iid=$(curl -s -X POST https://api.linear.app/graphql \
-    -H "Content-Type: application/json" \
-    -H "Authorization: $key" \
-    -d "{\"query\":\"{ issueSearch(term:\\\"$linear_id\\\") { nodes { id identifier } } }\"}" \
-    | python3 -c "import sys,json;d=json.load(sys.stdin);print([n['id'] for n in d['data']['issueSearch']['nodes'] if n['identifier']=='$linear_id'][0] if any(n['identifier']=='$linear_id' for n in d['data']['issueSearch']['nodes']) else '')" 2>/dev/null) || true
+  iid=$(
+    LINEAR_API_KEY="$key" LINEAR_ID="$linear_id" python3 <<'PY' 2>/dev/null
+import json
+import os
+import urllib.request
+
+linear_id = os.environ["LINEAR_ID"]
+payload = {
+    "query": "query($term: String!) { issueSearch(term: $term) { nodes { id identifier } } }",
+    "variables": {"term": linear_id},
+}
+request = urllib.request.Request(
+    "https://api.linear.app/graphql",
+    data=json.dumps(payload).encode("utf-8"),
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": os.environ["LINEAR_API_KEY"],
+    },
+)
+with urllib.request.urlopen(request, timeout=20) as response:
+    data = json.load(response)
+print(
+    next(
+        (
+            node["id"]
+            for node in data["data"]["issueSearch"]["nodes"]
+            if node["identifier"] == linear_id
+        ),
+        "",
+    )
+)
+PY
+  ) || true
   if [ -n "$iid" ]; then
-    curl -s -X POST https://api.linear.app/graphql \
-      -H "Content-Type: application/json" \
-      -H "Authorization: $key" \
-      -d "{\"query\":\"mutation { issueUpdate(id:\\\"$iid\\\", input: { stateId: \\\"$sid\\\" }) { success } }\"}" > /dev/null
+    LINEAR_API_KEY="$key" LINEAR_ISSUE_ID="$iid" LINEAR_STATE_ID="$sid" python3 <<'PY' >/dev/null 2>&1
+import json
+import os
+import urllib.request
+
+payload = {
+    "query": "mutation($id: String!, $stateId: String!) { issueUpdate(id: $id, input: { stateId: $stateId }) { success } }",
+    "variables": {
+        "id": os.environ["LINEAR_ISSUE_ID"],
+        "stateId": os.environ["LINEAR_STATE_ID"],
+    },
+}
+request = urllib.request.Request(
+    "https://api.linear.app/graphql",
+    data=json.dumps(payload).encode("utf-8"),
+    headers={
+        "Content-Type": "application/json",
+        "Authorization": os.environ["LINEAR_API_KEY"],
+    },
+)
+with urllib.request.urlopen(request, timeout=20) as response:
+    response.read()
+PY
     log "linear: $linear_id -> In Progress"
   fi
 }


### PR DESCRIPTION
## Summary
- Pin the remaining unpinned workflow actions/scripts and reduce broad workflow token permissions to app-scoped writes where the job performs mutations.
- Harden vendored gstack dependency/script installation paths, pin transient installs, and force the gstack `ws` dependency override.
- Reject traversal segments in gstack read-path validation and replace Linear API shell `curl` calls with bounded Python requests.

Linear: JOV-2569

## Verification
- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh`
- `bun install --frozen-lockfile` in `.agents/skills/gstack`
- `bun test browse/test/path-validation.test.ts` in `.agents/skills/gstack`
- `bun test` in `.agents/skills/gstack`
- `JOVIE_AGENT_PROFILE=coder actionlint -shellcheck= .github/workflows/ios-testflight.yml .github/workflows/ios-signing-bootstrap.yml .github/workflows/screenshots.yml .github/workflows/main-ci-health-monitor.yml .github/workflows/main-autofix.yml`
- `JOVIE_AGENT_PROFILE=coder bash -n scripts/dispatch-kanban.sh .agents/skills/gstack/setup`
- `JOVIE_AGENT_PROFILE=coder git diff --check`
- pre-push hook: `biome check .`, `pnpm --filter=@jovie/web run next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`

## Remaining Risks
None identified in branch-scoped verification.
