### PR TITLE
fix(sonar): flatten chat and shell code smells

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -1439,9 +1439,9 @@ function LibraryAudioDropzone({
         className='sr-only'
         aria-label={`Upload audio for ${asset.title}`}
       />
-      <div className='min-h-5 pt-1.5 text-2xs' role='status'>
+      <output className='min-h-5 pt-1.5 text-2xs'>
         {uploadError ? <p className='text-error'>{uploadError}</p> : null}
-      </div>
+      </output>
     </div>
   );
 }
@@ -1536,8 +1536,14 @@ function AssetDrawer({
   const current = asset ?? stickyAsset;
   const closedInteractiveProps = open ? {} : { tabIndex: -1 };
   const closedTabIndex = open ? undefined : -1;
-  const isPreviewPlaying = Boolean(
-    current && playingPreviewId === current.id && activePreviewId === current.id
+  const currentId = current?.id ?? null;
+  const isPreviewPlaying =
+    currentId !== null &&
+    currentId === playingPreviewId &&
+    currentId === activePreviewId;
+  const closedDrawerClassName = cn(
+    'pointer-events-none opacity-0',
+    isDesktopLayout ? null : 'translate-y-2 hidden'
   );
 
   return (
@@ -1549,12 +1555,7 @@ function AssetDrawer({
         isDesktopLayout
           ? 'static z-auto rounded-none border-y-0 border-r-0 shadow-none'
           : 'fixed inset-x-3 bottom-20 top-16 z-40 rounded-lg border shadow-[0_18px_48px_rgba(0,0,0,0.28)]',
-        open
-          ? 'translate-y-0 opacity-100'
-          : cn(
-              'pointer-events-none opacity-0',
-              isDesktopLayout ? null : 'translate-y-2 hidden'
-            )
+        open ? 'translate-y-0 opacity-100' : closedDrawerClassName
       )}
       data-testid='library-asset-drawer'
     >
@@ -1744,16 +1745,16 @@ function LibraryStatusBar({
   readonly view: LibraryViewMode;
   readonly activePreviewTitle: string | null;
 }) {
+  const playbackSummary = activePreviewTitle
+    ? `Playing ${activePreviewTitle}`
+    : `${SORT_LABELS[sort]} - ${view === 'grid' ? 'Grid' : 'List'}`;
+
   return (
     <div className='hidden h-8 shrink-0 items-center justify-between gap-3 border-t border-subtle bg-(--linear-app-content-surface) px-3 text-[11px] text-tertiary-token sm:flex'>
       <span className='min-w-0 truncate'>
         {visibleCount} of {totalCount} Releases
       </span>
-      <span className='min-w-0 truncate text-right'>
-        {activePreviewTitle
-          ? `Playing ${activePreviewTitle}`
-          : `${SORT_LABELS[sort]} - ${view === 'grid' ? 'Grid' : 'List'}`}
-      </span>
+      <span className='min-w-0 truncate text-right'>{playbackSummary}</span>
     </div>
   );
 }
@@ -1965,6 +1966,11 @@ export function LibrarySurface({
     [router]
   );
 
+  const drawerColumnWidth = drawerOpen ? '360px' : '0px';
+  const libraryGridTemplateColumns = isDesktopLayout
+    ? `minmax(16rem,17.5rem) minmax(0,1fr) ${drawerColumnWidth}`
+    : 'minmax(0, 1fr)';
+
   if (effectiveAssets.length === 0) {
     return <EmptyCatalog />;
   }
@@ -2001,9 +2007,7 @@ export function LibrarySurface({
         className='grid h-full min-h-0 flex-1 overflow-hidden'
         style={
           {
-            gridTemplateColumns: isDesktopLayout
-              ? `minmax(16rem,17.5rem) minmax(0,1fr) ${drawerOpen ? '360px' : '0px'}`
-              : 'minmax(0, 1fr)',
+            gridTemplateColumns: libraryGridTemplateColumns,
             transition:
               'grid-template-columns var(--duration-cinematic) var(--ease-cinematic)',
           } as CSSProperties

--- a/apps/web/app/desktop-auth/page.tsx
+++ b/apps/web/app/desktop-auth/page.tsx
@@ -28,6 +28,21 @@ function formatOpenError(reason?: string): string {
   return 'The browser did not open. Try again, or close this window and start sign-in again.';
 }
 
+function formatBrowserOpenStatus(
+  openState: BrowserOpenState,
+  openError: string | null
+): string | null {
+  if (openState === 'opening') {
+    return 'Opening your browser...';
+  }
+
+  if (openState === 'opened') {
+    return 'Continue sign-in in your browser.';
+  }
+
+  return openError;
+}
+
 async function openWithTimeout(authUrl: string) {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
@@ -96,12 +111,7 @@ function DesktopAuthContent() {
     };
   }, [authUrl, canAutoOpen]);
 
-  const statusText =
-    openState === 'opening'
-      ? 'Opening your browser...'
-      : openState === 'opened'
-        ? 'Continue sign-in in your browser.'
-        : openError;
+  const statusText = formatBrowserOpenStatus(openState, openError);
 
   return (
     <main className='grid min-h-dvh place-items-center bg-[#06070a] px-6 text-white [color-scheme:dark]'>

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -23,7 +23,10 @@ import { APP_ROUTES, isDemoRoutePath } from '@/constants/routes';
 import { useAppFlag } from '@/lib/flags/client';
 import { NAV_SHORTCUTS } from '@/lib/keyboard-shortcuts';
 import { usePlanGate } from '@/lib/queries';
-import { useChatConversationsQuery } from '@/lib/queries/useChatConversationsQuery';
+import {
+  type ChatConversation,
+  useChatConversationsQuery,
+} from '@/lib/queries/useChatConversationsQuery';
 import { useTaskStatsQuery } from '@/lib/queries/useTasksQuery';
 import {
   adminNavigationSections,
@@ -58,6 +61,24 @@ const FAILED_CHAT_TURN_STATUSES = new Set([
   'failed_timeout',
   'failed_network',
 ]);
+
+function getSidebarThreadStatus(
+  latestTurnStatus: ChatConversation['latestTurnStatus']
+): SidebarThread['status'] {
+  if (!latestTurnStatus) {
+    return 'complete';
+  }
+
+  if (IN_PROGRESS_CHAT_TURN_STATUSES.has(latestTurnStatus)) {
+    return 'running';
+  }
+
+  if (FAILED_CHAT_TURN_STATUSES.has(latestTurnStatus)) {
+    return 'errored';
+  }
+
+  return 'complete';
+}
 
 function readThreadReadState(): Record<string, string> {
   try {
@@ -452,12 +473,6 @@ export function DashboardNav(_: DashboardNavProps) {
     () =>
       (conversations ?? []).map(conversation => {
         const latestTurnStatus = conversation.latestTurnStatus ?? null;
-        const isRunning = latestTurnStatus
-          ? IN_PROGRESS_CHAT_TURN_STATUSES.has(latestTurnStatus)
-          : false;
-        const isFailed = latestTurnStatus
-          ? FAILED_CHAT_TURN_STATUSES.has(latestTurnStatus)
-          : false;
         const isUnread =
           activeThreadId !== conversation.id &&
           conversation.latestMessageRole === 'assistant' &&
@@ -470,7 +485,7 @@ export function DashboardNav(_: DashboardNavProps) {
           id: conversation.id,
           href: `${APP_ROUTES.CHAT}/${encodeURIComponent(conversation.id)}`,
           title: conversation.title?.trim() || 'Untitled thread',
-          status: isRunning ? 'running' : isFailed ? 'errored' : 'complete',
+          status: getSidebarThreadStatus(latestTurnStatus),
           updatedAt: conversation.updatedAt,
           unread: isUnread,
         };

--- a/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx
@@ -101,6 +101,66 @@ function buildTooltip(
   };
 }
 
+interface NavMenuInteractiveElementProps {
+  readonly item: NavItem;
+  readonly isActive: boolean;
+  readonly prefetch?: boolean;
+  readonly preventNavigation: boolean;
+  readonly renderAsButton: boolean;
+  readonly className: string;
+  readonly onButtonClick: () => void;
+  readonly onLinkClick: (event: MouseEvent<HTMLAnchorElement>) => void;
+  readonly onPressStart: () => void;
+  readonly onPrefetch?: () => void;
+  readonly children: ReactNode;
+}
+
+function NavMenuInteractiveElement({
+  item,
+  isActive,
+  prefetch,
+  preventNavigation,
+  renderAsButton,
+  className,
+  onButtonClick,
+  onLinkClick,
+  onPressStart,
+  onPrefetch,
+  children,
+}: NavMenuInteractiveElementProps) {
+  if (renderAsButton) {
+    return (
+      <button
+        type='button'
+        onClick={onButtonClick}
+        onPointerDown={onPressStart}
+        onMouseEnter={onPrefetch}
+        onFocus={onPrefetch}
+        aria-pressed={isActive}
+        className={className}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  return (
+    <Link
+      href={item.href}
+      prefetch={prefetch}
+      onClick={onLinkClick}
+      onPointerDown={onPressStart}
+      onMouseEnter={onPrefetch}
+      onFocus={onPrefetch}
+      aria-current={isActive ? 'page' : undefined}
+      aria-disabled={preventNavigation || undefined}
+      className={className}
+    >
+      {children}
+    </Link>
+  );
+}
+
 export function NavMenuItem({
   item,
   isActive,
@@ -317,63 +377,37 @@ export function NavMenuItem({
               side='right'
               block
             >
-              {renderAsButton ? (
-                <button
-                  type='button'
-                  onClick={handleButtonClick}
-                  onPointerDown={handlePressStart}
-                  onMouseEnter={onPrefetch}
-                  onFocus={onPrefetch}
-                  aria-pressed={isActive}
-                  className={shellNavClassName}
-                >
-                  {shellInnerContent}
-                </button>
-              ) : (
-                <Link
-                  href={item.href}
-                  prefetch={prefetch}
-                  onClick={handleLinkClick}
-                  onPointerDown={handlePressStart}
-                  onMouseEnter={onPrefetch}
-                  onFocus={onPrefetch}
-                  aria-current={isActive ? 'page' : undefined}
-                  aria-disabled={preventNavigation || undefined}
-                  className={shellNavClassName}
-                >
-                  {shellInnerContent}
-                </Link>
-              )}
+              <NavMenuInteractiveElement
+                item={item}
+                isActive={isActive}
+                prefetch={prefetch}
+                preventNavigation={preventNavigation}
+                renderAsButton={renderAsButton}
+                className={shellNavClassName}
+                onButtonClick={handleButtonClick}
+                onLinkClick={handleLinkClick}
+                onPressStart={handlePressStart}
+                onPrefetch={onPrefetch}
+              >
+                {shellInnerContent}
+              </NavMenuInteractiveElement>
             </Tooltip>
           ) : (
             <SidebarMenuButton asChild isActive={isActive} tooltip={tooltip}>
-              {renderAsButton ? (
-                <button
-                  type='button'
-                  onClick={handleButtonClick}
-                  onPointerDown={handlePressStart}
-                  onMouseEnter={onPrefetch}
-                  onFocus={onPrefetch}
-                  aria-pressed={isActive}
-                  className='flex w-full min-w-0 items-center group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center'
-                >
-                  {innerContent}
-                </button>
-              ) : (
-                <Link
-                  href={item.href}
-                  prefetch={prefetch}
-                  onClick={handleLinkClick}
-                  onPointerDown={handlePressStart}
-                  onMouseEnter={onPrefetch}
-                  onFocus={onPrefetch}
-                  aria-current={isActive ? 'page' : undefined}
-                  aria-disabled={preventNavigation || undefined}
-                  className='flex w-full min-w-0 items-center group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center'
-                >
-                  {innerContent}
-                </Link>
-              )}
+              <NavMenuInteractiveElement
+                item={item}
+                isActive={isActive}
+                prefetch={prefetch}
+                preventNavigation={preventNavigation}
+                renderAsButton={renderAsButton}
+                className='flex w-full min-w-0 items-center group-data-[collapsible=icon]:mx-auto group-data-[collapsible=icon]:justify-center'
+                onButtonClick={handleButtonClick}
+                onLinkClick={handleLinkClick}
+                onPressStart={handlePressStart}
+                onPrefetch={onPrefetch}
+              >
+                {innerContent}
+              </NavMenuInteractiveElement>
             </SidebarMenuButton>
           )}
           {!shellNavItem && item.badge != null && (

--- a/apps/web/components/shell/SidebarNavItem.tsx
+++ b/apps/web/components/shell/SidebarNavItem.tsx
@@ -33,6 +33,36 @@ interface SidebarNavChromeOptions {
   readonly className?: string;
 }
 
+const SIDEBAR_PRIMARY_CHROME =
+  'border-[color-mix(in_oklab,var(--linear-app-frame-seam)_78%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,white_8%)] text-primary-token shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:bg-[color-mix(in_oklab,var(--linear-app-content-surface)_86%,white_14%)]';
+
+const SIDEBAR_ACTIVE_CHROME =
+  'border-sidebar-border bg-sidebar-accent-active text-primary-token font-medium shadow-[inset_0_1px_0_rgba(255,255,255,0.04),inset_0_0_0_1px_color-mix(in_oklab,var(--linear-app-frame-seam)_62%,transparent)]';
+
+function getInactiveColor(nested?: boolean): string {
+  if (nested) {
+    return 'text-sidebar-muted/65 hover:bg-sidebar-accent hover:text-sidebar-item-foreground';
+  }
+
+  return 'text-sidebar-muted/80 hover:bg-sidebar-accent hover:text-sidebar-item-foreground';
+}
+
+function getToneClassName({
+  active,
+  nested,
+  tone,
+}: Pick<SidebarNavChromeOptions, 'active' | 'nested' | 'tone'>): string {
+  if (active) {
+    return SIDEBAR_ACTIVE_CHROME;
+  }
+
+  if (tone === 'primary') {
+    return SIDEBAR_PRIMARY_CHROME;
+  }
+
+  return getInactiveColor(nested);
+}
+
 export function getSidebarNavRowClassName({
   active,
   collapsed,
@@ -42,11 +72,6 @@ export function getSidebarNavRowClassName({
   className,
 }: SidebarNavChromeOptions) {
   const nonCollapsedSize = tight ? 'h-6 px-2.5' : 'h-7 px-2.5';
-  const inactiveColor = nested
-    ? 'text-sidebar-muted/65 hover:bg-sidebar-accent hover:text-sidebar-item-foreground'
-    : 'text-sidebar-muted/80 hover:bg-sidebar-accent hover:text-sidebar-item-foreground';
-  const primaryChrome =
-    'border-[color-mix(in_oklab,var(--linear-app-frame-seam)_78%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,white_8%)] text-primary-token shadow-[inset_0_1px_0_rgba(255,255,255,0.06)] hover:bg-[color-mix(in_oklab,var(--linear-app-content-surface)_86%,white_14%)]';
 
   return cn(
     'relative grid items-center rounded-full w-full border border-transparent transition-[background-color,border-color,box-shadow,color] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
@@ -62,11 +87,7 @@ export function getSidebarNavRowClassName({
           nonCollapsedSize,
           'group-data-[collapsible=icon]:grid-cols-1 group-data-[collapsible=icon]:place-items-center'
         ),
-    active
-      ? 'border-sidebar-border bg-sidebar-accent-active text-primary-token font-medium shadow-[inset_0_1px_0_rgba(255,255,255,0.04),inset_0_0_0_1px_color-mix(in_oklab,var(--linear-app-frame-seam)_62%,transparent)]'
-      : tone === 'primary'
-        ? primaryChrome
-        : inactiveColor,
+    getToneClassName({ active, nested, tone }),
     className
   );
 }

--- a/apps/web/lib/chat/account-tools.ts
+++ b/apps/web/lib/chat/account-tools.ts
@@ -13,6 +13,18 @@ function buildAbsoluteUrl(path: string): string {
   return new URL(path, baseUrl).toString();
 }
 
+function getAccountNextAction(accountContext: ChatAccountContext): string {
+  if (accountContext.billingVerification === 'unavailable') {
+    return 'Retry billing verification before changing paid-feature access.';
+  }
+
+  if (accountContext.merchAccess.available) {
+    return 'Merch creation is available when the merch rollout flag is enabled.';
+  }
+
+  return 'Use billing settings to manage plan access.';
+}
+
 export function buildAccountStatusPayload(accountContext: ChatAccountContext) {
   return {
     success: true as const,
@@ -25,12 +37,7 @@ export function buildAccountStatusPayload(accountContext: ChatAccountContext) {
     merchAccess: accountContext.merchAccess,
     entitlements: accountContext.entitlements,
     billing: accountContext.billing,
-    nextAction:
-      accountContext.billingVerification === 'unavailable'
-        ? 'Retry billing verification before changing paid-feature access.'
-        : accountContext.merchAccess.available
-          ? 'Merch creation is available when the merch rollout flag is enabled.'
-          : 'Use billing settings to manage plan access.',
+    nextAction: getAccountNextAction(accountContext),
   };
 }
 

--- a/apps/web/lib/chat/system-prompt.ts
+++ b/apps/web/lib/chat/system-prompt.ts
@@ -217,17 +217,7 @@ function buildAccountAccessSection(
 ): string {
   if (!accountContext) return '';
 
-  const merchAvailable =
-    accountContext.billingVerification !== 'unavailable' &&
-    accountContext.flags.merchMvp &&
-    accountContext.entitlements.canAccessMerchCreation;
-  const merchLine = merchAvailable
-    ? 'Available'
-    : accountContext.billingVerification === 'unavailable'
-      ? 'Unavailable because billing verification is temporarily unavailable'
-      : accountContext.flags.merchMvp
-        ? 'Unavailable on this plan'
-        : 'Unavailable because the merch rollout flag is off';
+  const merchLine = buildMerchAccessLine(accountContext);
   const usageLine = accountContext.usage
     ? `${accountContext.usage.used} used, ${accountContext.usage.remaining} remaining of ${accountContext.usage.dailyLimit}`
     : 'Unavailable while billing verification is unavailable';
@@ -254,6 +244,22 @@ Safe account actions:
 - Use openBillingPortal for billing management handoff. Never change subscriptions, email, username, connected accounts, or OAuth providers from chat.${mismatchLine}
 
 `;
+}
+
+function buildMerchAccessLine(accountContext: AccountPromptContext): string {
+  if (accountContext.billingVerification === 'unavailable') {
+    return 'Unavailable because billing verification is temporarily unavailable';
+  }
+
+  if (!accountContext.flags.merchMvp) {
+    return 'Unavailable because the merch rollout flag is off';
+  }
+
+  if (!accountContext.entitlements.canAccessMerchCreation) {
+    return 'Unavailable on this plan';
+  }
+
+  return 'Available';
 }
 
 function buildAnalyticsSection(options?: {


### PR DESCRIPTION
## Summary
- Extracted chat account/access status helpers and shell nav rendering helpers to remove nested ternaries and reduce component complexity.
- Flattened DashboardNav thread status mapping and desktop-auth browser-open status copy.
- Flattened LibrarySurface status/drawer/grid display helpers while preserving reserved sizing and existing visual states.

Linear: JOV-2570

## Layout Shift Audit
- Sidebar nav active/inactive/collapsed/button/link states keep the same class names and dimensions through `NavMenuInteractiveElement`; only the duplicated render branches moved.
- Library upload status keeps the existing `min-h-5` wrapper and drawer grid keeps explicit `360px`/`0px` reserved column widths.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/lib/chat/account-tools.ts apps/web/lib/chat/system-prompt.ts apps/web/components/shell/SidebarNavItem.tsx apps/web/app/desktop-auth/page.tsx apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx apps/web/components/features/dashboard/dashboard-nav/NavMenuItem.tsx apps/web/app/app/(shell)/library/LibrarySurface.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/chat/account-tools.test.ts tests/unit/lib/chat/system-prompt.test.ts tests/unit/app/desktop-auth-page.test.tsx tests/unit/dashboard/DashboardNav.test.tsx tests/components/dashboard/DashboardNav.interaction.test.tsx tests/unit/library/LibrarySurface.test.tsx` — 66 tests passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder git diff --check`
- commit hook: proxy guard, Biome, ESLint, staged a11y check, web typecheck
- pre-push hook: Biome, proxy guard, Tailwind guard, web typecheck, web lint

## Remaining Risks
None identified in branch-scoped verification.
