### PR TITLE
fix(sonar): flatten merch printful helpers

### DIFF
--- a/apps/web/lib/merch/orders.ts
+++ b/apps/web/lib/merch/orders.ts
@@ -670,6 +670,22 @@ export async function processMerchFulfillmentJobs(limit = 5): Promise<{
   return { processed: jobs.length, succeeded, failed };
 }
 
+function resolvePrintfulOrderEventStatus(params: {
+  readonly eventType?: string;
+  readonly orderStatus?: string;
+}): MerchOrder['status'] {
+  switch (params.eventType) {
+    case 'shipment_sent':
+      return 'shipped';
+    case 'shipment_delivered':
+      return 'delivered';
+    case 'order_canceled':
+      return 'cancelled';
+    default:
+      return params.orderStatus === 'failed' ? 'failed' : 'fulfilling';
+  }
+}
+
 export async function handlePrintfulOrderEvent(
   payload: unknown
 ): Promise<void> {
@@ -682,16 +698,10 @@ export async function handlePrintfulOrderEvent(
   const orderPayload = event.data?.order;
   if (!orderPayload?.id && !orderPayload?.external_id) return;
 
-  const status: MerchOrder['status'] =
-    event.type === 'shipment_sent'
-      ? 'shipped'
-      : event.type === 'shipment_delivered'
-        ? 'delivered'
-        : event.type === 'order_canceled'
-          ? 'cancelled'
-          : orderPayload.status === 'failed'
-            ? 'failed'
-            : 'fulfilling';
+  const status = resolvePrintfulOrderEventStatus({
+    eventType: event.type,
+    orderStatus: orderPayload.status,
+  });
 
   const conditions = orderPayload.external_id
     ? eq(merchOrders.printfulExternalId, orderPayload.external_id)

--- a/apps/web/lib/merch/types.ts
+++ b/apps/web/lib/merch/types.ts
@@ -1,12 +1,9 @@
 import type {
   MerchArtistBrief,
   MerchCard,
-  MerchDesignOption,
-  MerchLearningSnapshot,
   MerchPricingSnapshot,
   MerchPrintfulSnapshot,
   MerchShippingAddress,
-  MerchVariantMap,
 } from '@/lib/db/schema/merch';
 
 export type MerchDesignCommand =
@@ -120,4 +117,4 @@ export type {
   MerchPrintfulSnapshot,
   MerchShippingAddress,
   MerchVariantMap,
-};
+} from '@/lib/db/schema/merch';

--- a/apps/web/lib/printful/client.ts
+++ b/apps/web/lib/printful/client.ts
@@ -174,14 +174,13 @@ function extractErrorMessage(payload: unknown): string {
 
 async function requestPrintful<T>(
   path: string,
-  options: RequestInit & { readonly retry?: boolean } = {}
+  options: RequestInit & { readonly retry?: boolean }
 ): Promise<T> {
   const response = await serverFetch(`${getPrintfulBaseUrl()}${path}`, {
     ...options,
-    headers: {
-      ...getAuthHeaders(),
-      ...(options.headers ?? {}),
-    },
+    headers: options.headers
+      ? { ...getAuthHeaders(), ...options.headers }
+      : getAuthHeaders(),
     timeoutMs: PRINTFUL_TIMEOUT_MS,
     context: `Printful ${options.method ?? 'GET'} ${path}`,
     retry: options.retry
@@ -239,9 +238,11 @@ export async function listCatalogProducts(params?: {
     search.set('limit', String(params.limit));
   }
 
+  const catalogProductsPath =
+    search.size > 0 ? `/v2/catalog-products?${search}` : '/v2/catalog-products';
   const payload = await requestPrintful<
     PrintfulListResponse<PrintfulCatalogProduct>
-  >(`/v2/catalog-products${search.size ? `?${search}` : ''}`, {
+  >(catalogProductsPath, {
     method: 'GET',
     retry: true,
   });


### PR DESCRIPTION
## Summary
- Extracted Printful webhook status mapping out of the nested fulfillment ternary.
- Switched merch schema type re-exports to direct type re-export syntax.
- Flattened Printful client header/path helpers to remove useless fallback objects and nested template literals.

Linear: JOV-2570

## Verification
- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/lib/merch/orders.ts apps/web/lib/merch/types.ts apps/web/lib/printful/client.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run lib/printful/client.test.ts` — 2 tests passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder git diff --check -- apps/web/lib/merch/orders.ts apps/web/lib/merch/types.ts apps/web/lib/printful/client.ts`
- commit hook: proxy guard, Biome, ESLint, web typecheck
- pre-push hook: Biome, proxy guard, Tailwind guard, web typecheck, web lint

## Remaining Risks
`handlePrintfulOrderEvent` does not have a focused unit test in this repo; this patch keeps the existing status mapping behavior and is covered by typecheck plus the focused Printful client test.
