### PR TITLE
fix(sonar): flatten routing helper smells

### DIFF
--- a/apps/web/app/(auth)/signin/SignInPageClient.tsx
+++ b/apps/web/app/(auth)/signin/SignInPageClient.tsx
@@ -102,6 +102,42 @@ function isValidEmail(value: string): boolean {
   return true;
 }
 
+function getSignUpUrl(
+  params: URLSearchParams,
+  options: {
+    readonly mobileReturnRoute: string | null;
+    readonly desktopReturnRoute: string | null;
+  }
+): string {
+  if (options.mobileReturnRoute) {
+    return buildAuthRouteUrlWithMobileReturn(APP_ROUTES.SIGNUP, params);
+  }
+
+  if (options.desktopReturnRoute) {
+    return buildAuthRouteUrlWithDesktopReturn(APP_ROUTES.SIGNUP, params);
+  }
+
+  return buildAuthRouteUrl(APP_ROUTES.SIGNUP, params);
+}
+
+function getFallbackRedirectUrl(
+  params: URLSearchParams,
+  options: {
+    readonly mobileReturnRoute: string | null;
+    readonly desktopReturnRoute: string | null;
+  }
+): string | undefined {
+  if (options.mobileReturnRoute) {
+    return buildMobileAuthReturnPath(options.mobileReturnRoute);
+  }
+
+  if (options.desktopReturnRoute) {
+    return buildDesktopAuthReturnPath(options.desktopReturnRoute);
+  }
+
+  return getCentralAuthCallbackPath(params) ?? undefined;
+}
+
 export function SignInPageClient() {
   const searchParams = useSearchParams();
   const email = searchParams.get('email')?.trim() ?? '';
@@ -112,16 +148,12 @@ export function SignInPageClient() {
   const mobileReturnRoute = sanitizeMobileReturnRoute(
     searchParams.get('mobile_return')
   );
-  const signUpUrl = mobileReturnRoute
-    ? buildAuthRouteUrlWithMobileReturn(APP_ROUTES.SIGNUP, searchParams)
-    : desktopReturnRoute
-      ? buildAuthRouteUrlWithDesktopReturn(APP_ROUTES.SIGNUP, searchParams)
-      : buildAuthRouteUrl(APP_ROUTES.SIGNUP, searchParams);
-  const fallbackRedirectUrl = mobileReturnRoute
-    ? buildMobileAuthReturnPath(mobileReturnRoute)
-    : desktopReturnRoute
-      ? buildDesktopAuthReturnPath(desktopReturnRoute)
-      : (getCentralAuthCallbackPath(searchParams) ?? undefined);
+  const authReturnRoutes = { mobileReturnRoute, desktopReturnRoute };
+  const signUpUrl = getSignUpUrl(searchParams, authReturnRoutes);
+  const fallbackRedirectUrl = getFallbackRedirectUrl(
+    searchParams,
+    authReturnRoutes
+  );
   const initialValues = useMemo(
     () => (isValidEmail(email) ? { emailAddress: email } : undefined),
     [email]

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1277,6 +1277,20 @@ function createSelectMerchDesignTool(params: {
   });
 }
 
+function getMerchCardUpdateStatus(
+  action: 'pause' | 'unpause' | 'archive'
+): 'paused' | 'archived' | 'live' {
+  if (action === 'pause') {
+    return 'paused';
+  }
+
+  if (action === 'archive') {
+    return 'archived';
+  }
+
+  return 'live';
+}
+
 function createMerchStatusTool(params: {
   readonly action: 'publish' | 'pause' | 'unpause' | 'archive';
   readonly profileId: string | null;
@@ -1307,12 +1321,7 @@ function createMerchStatusTool(params: {
         };
       }
 
-      const status =
-        params.action === 'pause'
-          ? 'paused'
-          : params.action === 'archive'
-            ? 'archived'
-            : 'live';
+      const status = getMerchCardUpdateStatus(params.action);
       const card = await updateMerchCardStatus({
         cardId: merchCardId,
         profileId: params.profileId,

--- a/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
+++ b/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
@@ -544,12 +544,14 @@ function createE2EDashboardCoreData(clerkUserId: string): CoreData {
     updatedAt: now,
   } as CreatorProfile;
 
+  const fallbackUser = {
+    id: userId,
+    email: 'e2e-chat-smoke@example.test',
+    clerkUserId,
+  };
+
   return {
-    user: { id: userId, email: 'e2e-chat-smoke@example.test', clerkUserId } as {
-      id: string;
-      email: string;
-      clerkUserId: string;
-    },
+    user: fallbackUser,
     creatorProfiles: [profile],
     selectedProfile: profile,
     avatarQuality: UNKNOWN_AVATAR_QUALITY,

--- a/apps/web/app/auth/callback/route.ts
+++ b/apps/web/app/auth/callback/route.ts
@@ -64,11 +64,13 @@ export async function GET(request: Request) {
     });
 
     let exchangeCode: string | undefined;
-    if (stateRecord.client !== 'web') {
+    const nativeClient: NativeAuthClient | null =
+      stateRecord.client === 'web' ? null : stateRecord.client;
+    if (nativeClient) {
       exchangeCode = createExchangeCode();
       await createStoredNativeExchangeCode({
         code: exchangeCode,
-        client: stateRecord.client as NativeAuthClient,
+        client: nativeClient,
         state: stateRecord.state,
         userId,
         returnTo: stateRecord.returnTo,

--- a/apps/web/app/auth/start/route.ts
+++ b/apps/web/app/auth/start/route.ts
@@ -33,7 +33,7 @@ function getAuthPageForIntent(intent: AuthIntent): string {
 
 function getStringParam(url: URL, key: string): string | null {
   const trimmed = url.searchParams.get(key)?.trim();
-  return trimmed ? trimmed : null;
+  return trimmed || null;
 }
 
 async function trackAuthEvent(

--- a/apps/web/components/features/dashboard/organisms/InlineChatArea.tsx
+++ b/apps/web/components/features/dashboard/organisms/InlineChatArea.tsx
@@ -272,7 +272,7 @@ export const InlineChatArea = forwardRef<
             )}
 
             {/* Loading indicator — rendered outside virtualizer */}
-            {isLoading && messages[messages.length - 1]?.role === 'user' && (
+            {isLoading && messages.at(-1)?.role === 'user' && (
               <div className='flex gap-3 pb-4'>
                 <div className='flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-surface-2'>
                   <BrandLogo size={14} tone='auto' />

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -382,10 +382,7 @@ export function useJovieChat({
       }): ChatTimelineServerMessage => ({
         id: msg.id,
         role: msg.role as 'user' | 'assistant',
-        parts: hydratePersistedMessageParts(
-          msg.content,
-          msg.toolCalls
-        ) as ChatTimelineServerMessage['parts'],
+        parts: hydratePersistedMessageParts(msg.content, msg.toolCalls),
         createdAt: new Date(msg.createdAt),
         clientMessageId: msg.clientMessageId ?? null,
         turnId: msg.turnId ?? null,

--- a/apps/web/components/jovie/timeline/chat-timeline.ts
+++ b/apps/web/components/jovie/timeline/chat-timeline.ts
@@ -186,6 +186,7 @@ export function reduceChatTimeline(
         lastEventAt: now,
       };
     case 'conversation.load.succeeded':
+    case 'conversation.refetch.succeeded':
       return mergeServerMessages(state, event.messages, {
         type: event.type,
         conversationId: event.conversationId,
@@ -198,13 +199,6 @@ export function reduceChatTimeline(
         phase: state.messages.length > 0 ? 'ready' : 'error',
         lastEventAt: now,
       };
-    case 'conversation.refetch.succeeded':
-      return mergeServerMessages(state, event.messages, {
-        type: event.type,
-        conversationId: event.conversationId,
-        receivedAt: event.receivedAt ?? now,
-        phase: 'ready',
-      });
     case 'conversation.refetch.failed':
       return { ...state, lastEventAt: now };
     case 'message.send.started':

--- a/apps/web/components/organisms/WorkspaceTabsSurface.tsx
+++ b/apps/web/components/organisms/WorkspaceTabsSurface.tsx
@@ -216,7 +216,7 @@ function LinkedTabBar<T extends string>({
                   }
 
                   event.preventDefault();
-                  window.location.assign(href);
+                  globalThis.location.assign(href);
                 }}
                 className={cn(
                   TAB_BAR_SEGMENT_TRIGGER_CLASSNAME,


### PR DESCRIPTION
## Summary
- Flattened small auth/sign-in/chat route ternaries into named helpers.
- Collapsed duplicate chat timeline merge cases and removed unnecessary inline assertions.
- Swapped small Sonar-preferred idioms like `.at(-1)` and `globalThis.location`.

Linear: JOV-2570

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/api/chat/route.ts apps/web/components/features/dashboard/organisms/InlineChatArea.tsx apps/web/components/jovie/timeline/chat-timeline.ts apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts apps/web/components/jovie/hooks/useJovieChat.ts apps/web/app/auth/callback/route.ts apps/web/app/auth/start/route.ts apps/web/components/organisms/WorkspaceTabsSurface.tsx apps/web/app/(auth)/signin/SignInPageClient.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/chat/chat-timeline-reducer.test.ts tests/unit/lib/auth/routing-state.server.test.ts tests/unit/app/signin-page.test.tsx tests/unit/dashboard/dashboard-data-prefetch.test.ts tests/unit/chat/useJovieChat.rate-limit.test.tsx tests/unit/chat/InlineChatArea.tool-rendering.test.tsx` — 52 tests passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/dashboard-data-prefetch.test.ts tests/unit/chat/chat-timeline-reducer.test.ts tests/unit/app/signin-page.test.tsx` — 25 tests passed after the fallback-user type fix
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder git diff --check`
- commit hook: proxy guard, Biome, ESLint, staged a11y check, web typecheck
- pre-push hook: Biome, proxy guard, Tailwind guard, web typecheck, web lint

## Remaining Risks
None identified in branch-scoped verification.
