### PR TITLE
fix(sonar): explain gated e2e skips

### DIFF
--- a/apps/web/tests/e2e/admin-navigation-role-gate.spec.ts
+++ b/apps/web/tests/e2e/admin-navigation-role-gate.spec.ts
@@ -9,6 +9,7 @@ test.describe('Admin navigation role gate', () => {
     page,
   }) => {
     test.setTimeout(180_000);
+    // Skip outside the explicit dev-auth E2E lane; this test needs the admin bypass persona.
     test.skip(
       process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
       'dev-auth bypass not enabled'

--- a/apps/web/tests/e2e/chat-timeline-regression.spec.ts
+++ b/apps/web/tests/e2e/chat-timeline-regression.spec.ts
@@ -124,6 +124,7 @@ test.use({ storageState: { cookies: [], origins: [] } });
 test('send and stream stay visible through stale refetch without skeleton cascade', async ({
   page,
 }) => {
+  // Skip outside the explicit dev-auth E2E lane; chat shell entry needs a bypassed Clerk session.
   test.skip(
     process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
     'Requires E2E_USE_TEST_AUTH_BYPASS=1'

--- a/apps/web/tests/e2e/electron-titlebar-geometry.spec.ts
+++ b/apps/web/tests/e2e/electron-titlebar-geometry.spec.ts
@@ -118,6 +118,7 @@ async function assertElectronShellControls(
 test('titlebar DOM has a single sidebar toggle and an empty main-cell drag region', async ({
   page,
 }) => {
+  // Skip outside the explicit dev-auth E2E lane; Electron shell setup needs a bypassed Clerk session.
   test.skip(
     process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
     'Requires E2E_USE_TEST_AUTH_BYPASS=1'
@@ -178,6 +179,7 @@ test('titlebar DOM has a single sidebar toggle and an empty main-cell drag regio
 test('no duplicate sidebar dock button and titlebar toggle on the same page', async ({
   page,
 }) => {
+  // Skip outside the explicit dev-auth E2E lane; duplicate-control checks need a bypassed Clerk session.
   test.skip(
     process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
     'Requires E2E_USE_TEST_AUTH_BYPASS=1'
@@ -211,6 +213,7 @@ test('no duplicate sidebar dock button and titlebar toggle on the same page', as
 test('titlebar sidebar-cell width matches CSS sidebar-width token (rail alignment)', async ({
   page,
 }) => {
+  // Skip outside the explicit dev-auth E2E lane; titlebar token checks need a bypassed Clerk session.
   test.skip(
     process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
     'Requires E2E_USE_TEST_AUTH_BYPASS=1'
@@ -278,6 +281,7 @@ test('titlebar sidebar-cell width matches CSS sidebar-width token (rail alignmen
 test('Electron shell keeps one control contract across chat, calendar, tasks, releases, settings, and admin routes', async ({
   page,
 }) => {
+  // Skip outside the explicit dev-auth E2E lane; cross-route Electron controls need bypassed personas.
   test.skip(
     process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
     'Requires E2E_USE_TEST_AUTH_BYPASS=1'

--- a/apps/web/tests/e2e/shell-chat-v1.spec.ts
+++ b/apps/web/tests/e2e/shell-chat-v1.spec.ts
@@ -296,6 +296,7 @@ async function assertSlashMenuClearsThreadContent(page: Page) {
 test('chat route renders the Shell V1 app frame when forced on', async ({
   page,
 }) => {
+  // Skip outside the explicit dev-auth E2E lane; this route needs a bypassed Clerk session.
   test.skip(
     process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
     'Requires E2E_USE_TEST_AUTH_BYPASS=1'
@@ -324,6 +325,7 @@ test('chat route renders the Shell V1 app frame when forced on', async ({
 test('chat route picker opens without moving the shell or composer', async ({
   page,
 }) => {
+  // Skip outside the explicit dev-auth E2E lane; picker geometry needs a bypassed Clerk session.
   test.skip(
     process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
     'Requires E2E_USE_TEST_AUTH_BYPASS=1'
@@ -369,6 +371,7 @@ test('chat route picker opens without moving the shell or composer', async ({
 test('chat route slash picker clears active transcript content in populated threads', async ({
   page,
 }) => {
+  // Skip outside the explicit dev-auth E2E lane; populated thread fixtures need a bypassed Clerk session.
   test.skip(
     process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
     'Requires E2E_USE_TEST_AUTH_BYPASS=1'
@@ -427,6 +430,7 @@ test('chat route slash picker clears active transcript content in populated thre
 test('chat composer clears mobile shell tabs on tablet and phone', async ({
   page,
 }) => {
+  // Skip outside the explicit dev-auth E2E lane; mobile shell tabs need a bypassed Clerk session.
   test.skip(
     process.env.E2E_USE_TEST_AUTH_BYPASS !== '1',
     'Requires E2E_USE_TEST_AUTH_BYPASS=1'


### PR DESCRIPTION
## Summary
- Added concise reasons next to dev-auth-gated E2E `test.skip` calls so Sonar can distinguish intentional lane gating from unexplained skipped tests.
- Kept every skip condition and test body unchanged.

Linear: JOV-2570

## Verification
- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/tests/e2e/shell-chat-v1.spec.ts apps/web/tests/e2e/chat-timeline-regression.spec.ts apps/web/tests/e2e/electron-titlebar-geometry.spec.ts apps/web/tests/e2e/admin-navigation-role-gate.spec.ts`
- `JOVIE_AGENT_PROFILE=coder git diff --check -- apps/web/tests/e2e/shell-chat-v1.spec.ts apps/web/tests/e2e/chat-timeline-regression.spec.ts apps/web/tests/e2e/electron-titlebar-geometry.spec.ts apps/web/tests/e2e/admin-navigation-role-gate.spec.ts`
- commit hook: proxy guard, Biome, ESLint, web typecheck
- pre-push hook: Biome, proxy guard, Tailwind guard, web typecheck, web lint

## Remaining Risks
No E2E execution was run because this patch only adds skip explanations and does not change skip conditions or assertions.
