### PR TITLE
fix(sonar): flatten library cmdk smells

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -1745,9 +1745,11 @@ function LibraryStatusBar({
   readonly view: LibraryViewMode;
   readonly activePreviewTitle: string | null;
 }) {
+  const viewLabel = view === 'grid' ? 'Grid' : 'List';
+  const idleSummary = `${SORT_LABELS[sort]} - ${viewLabel}`;
   const playbackSummary = activePreviewTitle
     ? `Playing ${activePreviewTitle}`
-    : `${SORT_LABELS[sort]} - ${view === 'grid' ? 'Grid' : 'List'}`;
+    : idleSummary;
 
   return (
     <div className='hidden h-8 shrink-0 items-center justify-between gap-3 border-t border-subtle bg-(--linear-app-content-surface) px-3 text-[11px] text-tertiary-token sm:flex'>

--- a/apps/web/components/organisms/SharedCommandPalette.tsx
+++ b/apps/web/components/organisms/SharedCommandPalette.tsx
@@ -163,14 +163,14 @@ function CmdKPaletteRow({
   shortcutLabel,
 }: CmdKPaletteRowProps) {
   return (
-    <button
-      type='button'
+    <div
       role='option'
       id={rowId}
+      tabIndex={-1}
       aria-selected={isActive ? 'true' : 'false'}
       aria-current={isActive ? 'true' : undefined}
       data-selected={isActive ? 'true' : undefined}
-      cmdk-item=''
+      data-cmdk-item=''
       onMouseEnter={() => onMouseEnter(index)}
       onMouseDown={e => {
         e.preventDefault();
@@ -190,7 +190,7 @@ function CmdKPaletteRow({
           {shortcutLabel}
         </span>
       ) : null}
-    </button>
+    </div>
   );
 }
 

--- a/apps/web/tests/e2e/cmdk-palette.spec.ts
+++ b/apps/web/tests/e2e/cmdk-palette.spec.ts
@@ -54,9 +54,9 @@ test.describe('Command palette — Cmd+K contract', () => {
     // Type a query that matches the Releases nav item.
     await paletteInput.fill('Releases');
 
-    // Verify at least one cmdk option surfaces. cmdk renders items with
-    // `cmdk-item` data attributes; prefer that to a brittle text selector.
-    const matches = page.locator('[cmdk-item]');
+    // Verify at least one cmdk option surfaces. cmdk renders rows with a
+    // stable data marker; prefer that to a brittle text selector.
+    const matches = page.locator('[data-cmdk-item]');
     await expect(matches.first()).toBeVisible({ timeout: 5_000 });
 
     // Enter commits the highlighted item — should navigate to releases.


### PR DESCRIPTION
## Summary
- Split LibraryStatusBar idle summary construction so Sonar no longer sees nested ternaries.
- Render cmd+k rows as listbox option elements with a stable data marker instead of a custom `cmdk-item` prop.
- Update the cmd+k E2E selector to use the stable data marker.

## Verification
- pnpm install (required because this fresh worktree lacked node_modules after setup skipped install)
- pnpm biome check --write apps/web/app/app/(shell)/library/LibrarySurface.tsx apps/web/components/organisms/SharedCommandPalette.tsx apps/web/tests/e2e/cmdk-palette.spec.ts
- pnpm --filter web exec vitest run tests/unit/library/LibrarySurface.test.tsx tests/unit/commands/SharedCommandPalette.test.tsx tests/unit/chat/SlashCommandMenu.keyboard.test.tsx tests/unit/chat/ChatInput.aria.test.tsx (47 tests passed)
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, biome lint

## Risk
Low. The status bar keeps the same layout/classes. Cmd+k rows keep the same active/inactive classes and listbox option contract; only the element tag and data marker changed.