### PR TITLE
fix(sonar): flatten signup settings smells

### DIFF
--- a/apps/web/app/(auth)/signup/SignUpPageClient.tsx
+++ b/apps/web/app/(auth)/signup/SignUpPageClient.tsx
@@ -199,6 +199,42 @@ function SignUpOauthErrorBanner({
   );
 }
 
+function getSignInUrl(
+  params: URLSearchParams,
+  options: {
+    readonly mobileReturnRoute: string | null;
+    readonly desktopReturnRoute: string | null;
+  }
+): string {
+  if (options.mobileReturnRoute) {
+    return buildAuthRouteUrlWithMobileReturn(APP_ROUTES.SIGNIN, params);
+  }
+
+  if (options.desktopReturnRoute) {
+    return buildAuthRouteUrlWithDesktopReturn(APP_ROUTES.SIGNIN, params);
+  }
+
+  return buildAuthRouteUrl(APP_ROUTES.SIGNIN, params);
+}
+
+function getFallbackRedirectUrl(
+  params: URLSearchParams,
+  options: {
+    readonly mobileReturnRoute: string | null;
+    readonly desktopReturnRoute: string | null;
+  }
+): string | undefined {
+  if (options.mobileReturnRoute) {
+    return buildMobileAuthReturnPath(options.mobileReturnRoute);
+  }
+
+  if (options.desktopReturnRoute) {
+    return buildDesktopAuthReturnPath(options.desktopReturnRoute);
+  }
+
+  return getCentralAuthCallbackPath(params) ?? undefined;
+}
+
 /**
  * Sign-up page using the canonical AuthShell (JOV-2064).
  *
@@ -215,16 +251,12 @@ export function SignUpPageClient() {
   const mobileReturnRoute = sanitizeMobileReturnRoute(
     searchParams.get('mobile_return')
   );
-  const signInUrl = mobileReturnRoute
-    ? buildAuthRouteUrlWithMobileReturn(APP_ROUTES.SIGNIN, searchParams)
-    : desktopReturnRoute
-      ? buildAuthRouteUrlWithDesktopReturn(APP_ROUTES.SIGNIN, searchParams)
-      : buildAuthRouteUrl(APP_ROUTES.SIGNIN, searchParams);
-  const fallbackRedirectUrl = mobileReturnRoute
-    ? buildMobileAuthReturnPath(mobileReturnRoute)
-    : desktopReturnRoute
-      ? buildDesktopAuthReturnPath(desktopReturnRoute)
-      : (getCentralAuthCallbackPath(searchParams) ?? undefined);
+  const authReturnRoutes = { mobileReturnRoute, desktopReturnRoute };
+  const signInUrl = getSignInUrl(searchParams, authReturnRoutes);
+  const fallbackRedirectUrl = getFallbackRedirectUrl(
+    searchParams,
+    authReturnRoutes
+  );
 
   return (
     <AuthLayout

--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
@@ -270,21 +270,21 @@ export default function PromoDownloadsPage() {
               className='sr-only'
               aria-label='Upload promo download audio file'
             />
-            <div
+            <output
               className='min-h-9 border-t border-transparent px-3 py-2.5 text-xs sm:px-4'
-              role='status'
+              aria-live='polite'
             >
               {uploadError ? <p className='text-error'>{uploadError}</p> : null}
-            </div>
+            </output>
           </ContentSurfaceCard>
 
-          <div className='min-h-10' role='status'>
+          <output className='block min-h-10' aria-live='polite'>
             {listError || operationError ? (
               <ContentSurfaceCard className='border-error/20 bg-error-subtle px-3 py-2.5 text-xs text-error'>
                 {operationError ?? listError}
               </ContentSurfaceCard>
             ) : null}
-          </div>
+          </output>
 
           <PromoDownloadsTable
             files={files}

--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
@@ -271,7 +271,7 @@ export default function PromoDownloadsPage() {
               aria-label='Upload promo download audio file'
             />
             <output
-              className='min-h-9 border-t border-transparent px-3 py-2.5 text-xs sm:px-4'
+              className='block min-h-9 border-t border-transparent px-3 py-2.5 text-xs sm:px-4'
               aria-live='polite'
             >
               {uploadError ? <p className='text-error'>{uploadError}</p> : null}

--- a/apps/web/app/app/(shell)/settings/retargeting-ads/page.tsx
+++ b/apps/web/app/app/(shell)/settings/retargeting-ads/page.tsx
@@ -22,6 +22,11 @@ interface SummaryCardProps {
   readonly description: string;
 }
 
+type RetargetingPlatform = {
+  readonly key: keyof AttributionStats['byPlatform'];
+  readonly label: string;
+};
+
 function SummaryCard({
   value,
   label,
@@ -34,6 +39,70 @@ function SummaryCard({
       <p className='mt-1 text-app leading-5 text-secondary-token'>
         {description}
       </p>
+    </div>
+  );
+}
+
+function renderAttributionContent(
+  loaded: boolean,
+  stats: AttributionStats | null,
+  platforms: readonly RetargetingPlatform[]
+) {
+  if (loaded) {
+    if (stats && stats.total > 0) {
+      return (
+        <div className='space-y-3'>
+          <div>
+            <p className='text-2xl font-semibold text-primary-token'>
+              {stats.total}
+            </p>
+            <p className='text-app text-secondary-token'>
+              {stats.total === 1 ? 'Subscriber' : 'Subscribers'} attributed to
+              retargeting campaigns this month.
+            </p>
+          </div>
+          <div className='flex flex-wrap gap-2'>
+            {platforms
+              .filter(platform => stats.byPlatform[platform.key] > 0)
+              .map(platform => (
+                <div
+                  key={platform.key}
+                  className='min-w-20 rounded-md border border-subtle bg-surface-0 px-3 py-2'
+                >
+                  <p className='text-xs font-semibold text-primary-token'>
+                    {platform.label}
+                  </p>
+                  <p className='text-xs text-secondary-token'>
+                    {stats.byPlatform[platform.key]}
+                  </p>
+                </div>
+              ))}
+          </div>
+        </div>
+      );
+    }
+
+    return (
+      <div className='flex min-h-[92px] flex-col justify-center'>
+        <p className='text-app font-medium text-primary-token'>
+          No attributed subscribers yet
+        </p>
+        <p className='mt-1 max-w-prose text-app text-secondary-token'>
+          Attribution appears here once a retargeting campaign starts sending
+          subscribers back to Jovie.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className='space-y-3'>
+      <div className='h-7 w-10 rounded-md skeleton motion-reduce:animate-none' />
+      <div className='h-4 w-72 max-w-full rounded-md skeleton motion-reduce:animate-none' />
+      <div className='flex gap-2'>
+        <div className='h-12 w-20 rounded-md skeleton motion-reduce:animate-none' />
+        <div className='h-12 w-20 rounded-md skeleton motion-reduce:animate-none' />
+      </div>
     </div>
   );
 }
@@ -64,10 +133,10 @@ function AttributionStatsCard() {
     };
   }, []);
 
-  const platforms = [
-    { key: 'retargeting_meta' as const, label: 'Meta' },
-    { key: 'retargeting_google' as const, label: 'Google' },
-    { key: 'retargeting_tiktok' as const, label: 'TikTok' },
+  const platforms: RetargetingPlatform[] = [
+    { key: 'retargeting_meta', label: 'Meta' },
+    { key: 'retargeting_google', label: 'Google' },
+    { key: 'retargeting_tiktok', label: 'TikTok' },
   ];
 
   return (
@@ -77,55 +146,7 @@ function AttributionStatsCard() {
       title='Retargeting attribution'
       description='Subscribers attributed to these ads this month.'
     >
-      {!loaded ? (
-        <div className='space-y-3'>
-          <div className='h-7 w-10 rounded-md skeleton motion-reduce:animate-none' />
-          <div className='h-4 w-72 max-w-full rounded-md skeleton motion-reduce:animate-none' />
-          <div className='flex gap-2'>
-            <div className='h-12 w-20 rounded-md skeleton motion-reduce:animate-none' />
-            <div className='h-12 w-20 rounded-md skeleton motion-reduce:animate-none' />
-          </div>
-        </div>
-      ) : stats && stats.total > 0 ? (
-        <div className='space-y-3'>
-          <div>
-            <p className='text-2xl font-semibold text-primary-token'>
-              {stats.total}
-            </p>
-            <p className='text-app text-secondary-token'>
-              {stats.total === 1 ? 'Subscriber' : 'Subscribers'} attributed to
-              retargeting campaigns this month.
-            </p>
-          </div>
-          <div className='flex flex-wrap gap-2'>
-            {platforms
-              .filter(platform => stats.byPlatform[platform.key] > 0)
-              .map(platform => (
-                <div
-                  key={platform.key}
-                  className='min-w-20 rounded-md border border-subtle bg-surface-0 px-3 py-2'
-                >
-                  <p className='text-xs font-semibold text-primary-token'>
-                    {platform.label}
-                  </p>
-                  <p className='text-xs text-secondary-token'>
-                    {stats.byPlatform[platform.key]}
-                  </p>
-                </div>
-              ))}
-          </div>
-        </div>
-      ) : (
-        <div className='flex min-h-[92px] flex-col justify-center'>
-          <p className='text-app font-medium text-primary-token'>
-            No attributed subscribers yet
-          </p>
-          <p className='mt-1 max-w-prose text-app text-secondary-token'>
-            Attribution appears here once a retargeting campaign starts sending
-            subscribers back to Jovie.
-          </p>
-        </div>
-      )}
+      {renderAttributionContent(loaded, stats, platforms)}
     </SettingsPanel>
   );
 }

--- a/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
@@ -50,11 +50,6 @@ function formatResetAt(value: string | null | undefined): string {
   }).format(resetAt);
 }
 
-function getProgressValue(used: number, limit: number): number {
-  if (limit <= 0) return 0;
-  return Math.min(100, Math.max(0, Math.round((used / limit) * 100)));
-}
-
 function getMonthlyUsage(data: ChatUsageData): {
   readonly limit: number;
   readonly used: number;
@@ -89,8 +84,8 @@ function UsageMeterRow({
   remaining,
   resetAt,
 }: UsageMeterRowProps) {
-  const progress = getProgressValue(used, limit);
   const clampedUsed = Math.min(Math.max(0, used), Math.max(0, limit));
+  const progressMax = Math.max(1, limit);
 
   return (
     <div className='px-4 py-4 sm:px-5'>
@@ -109,14 +104,11 @@ function UsageMeterRow({
         </div>
       </div>
       <div className='mt-3 h-2 rounded-full bg-surface-0'>
-        <div
-          role='progressbar'
+        <progress
           aria-label={`${title} usage`}
-          aria-valuemin={0}
-          aria-valuemax={limit}
-          aria-valuenow={clampedUsed}
-          className='h-2 rounded-full bg-primary-token'
-          style={{ width: `${progress}%` }}
+          value={clampedUsed}
+          max={progressMax}
+          className='block h-2 w-full appearance-none overflow-hidden rounded-full bg-surface-0 [&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-primary-token [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-bar]:bg-surface-0 [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-primary-token'
         />
       </div>
       <p className='mt-2 text-2xs text-tertiary-token'>

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -747,8 +747,8 @@ export function useJovieChat({
       try {
         const result = sendMessage(payload, sendOptions);
         setInput('');
-        void Promise.resolve(result).catch(value => {
-          handleChatFailure(toError(value), 'send', clientTurnId);
+        void Promise.resolve(result).catch(error_ => {
+          handleChatFailure(toError(error_), 'send', clientTurnId);
         });
         return true;
       } catch (error) {

--- a/apps/web/tests/unit/app/release-downloads-shell.test.ts
+++ b/apps/web/tests/unit/app/release-downloads-shell.test.ts
@@ -99,7 +99,7 @@ describe('release downloads shell contract', () => {
     const tableSource = readPromoDownloadsTableSource();
 
     expect(source).toContain("className='min-h-9");
-    expect(source).toContain("className='min-h-10'");
+    expect(source).toContain('min-h-10');
     expect(tableSource).toContain("className='min-h-[220px]");
   });
 });

--- a/apps/web/tests/unit/app/release-downloads-shell.test.ts
+++ b/apps/web/tests/unit/app/release-downloads-shell.test.ts
@@ -98,7 +98,7 @@ describe('release downloads shell contract', () => {
     const source = readReleaseDownloadsSource();
     const tableSource = readPromoDownloadsTableSource();
 
-    expect(source).toContain("className='min-h-9");
+    expect(source).toContain("className='block min-h-9");
     expect(source).toContain('min-h-10');
     expect(tableSource).toContain("className='min-h-[220px]");
   });

--- a/apps/web/tests/unit/dashboard/SettingsUsageStatsSection.test.tsx
+++ b/apps/web/tests/unit/dashboard/SettingsUsageStatsSection.test.tsx
@@ -89,10 +89,10 @@ describe('SettingsUsageStatsSection', () => {
     expect(screen.getByText('Free')).toBeInTheDocument();
     expect(
       screen.getByRole('progressbar', { name: 'Daily Messages usage' })
-    ).toHaveAttribute('aria-valuenow', '4');
+    ).toHaveAttribute('value', '4');
     expect(
       screen.getByRole('progressbar', { name: 'Monthly Capacity usage' })
-    ).toHaveAttribute('aria-valuenow', '24');
+    ).toHaveAttribute('value', '24');
     expect(screen.getByText('6 left')).toBeInTheDocument();
     expect(screen.getByText('286 left')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- Extract signup auth-return URL selection into helpers to remove nested ternaries.
- Rename the async send rejection parameter in useJovieChat.
- Switch settings usage meters to native progress elements and update tests.
- Extract retargeting attribution content rendering to remove nested/negated conditionals.
- Switch promo download feedback regions to native output elements and update shell contract tests.

## Verification
- pnpm install (required because this fresh worktree lacked node_modules after setup skipped install)
- pnpm biome check --write apps/web/app/(auth)/signup/SignUpPageClient.tsx apps/web/components/jovie/hooks/useJovieChat.ts apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx apps/web/app/app/(shell)/settings/retargeting-ads/page.tsx apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx apps/web/tests/unit/dashboard/SettingsUsageStatsSection.test.tsx apps/web/tests/unit/app/release-downloads-shell.test.ts
- pnpm --filter web exec vitest run tests/unit/app/auth-shell-contract-guard.test.ts tests/unit/chat/useJovieChat.rate-limit.test.tsx tests/unit/dashboard/SettingsUsageStatsSection.test.tsx tests/unit/app/settings-shell-normalization.test.ts tests/unit/app/settings-retargeting-shell.test.ts tests/unit/app/release-downloads-shell.test.ts (32 tests passed)
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, biome lint

## Risk
Low. The UI changes preserve existing reserved heights and swap ARIA-role shims for native elements with equivalent visible states.