### PR TITLE
fix(sonar): flatten onboarding auth helpers

### DIFF
--- a/apps/web/app/auth-return/page.tsx
+++ b/apps/web/app/auth-return/page.tsx
@@ -20,7 +20,7 @@ function AuthReturnContent() {
   );
 
   useEffect(() => {
-    window.location.href = deepLink;
+    globalThis.location.href = deepLink;
   }, [deepLink]);
 
   return (

--- a/apps/web/app/desktop-auth/page.tsx
+++ b/apps/web/app/desktop-auth/page.tsx
@@ -62,13 +62,18 @@ async function openWithTimeout(authUrl: string) {
   }
 }
 
+function getAppOrigin(): string {
+  return typeof globalThis.window === 'undefined'
+    ? 'https://jov.ie'
+    : globalThis.window.location.origin;
+}
+
 function DesktopAuthContent() {
   const searchParams = useSearchParams();
   const [openState, setOpenState] = useState<BrowserOpenState>('idle');
   const [openError, setOpenError] = useState<string | null>(null);
   const autoOpenedRef = useRef(false);
-  const appOrigin =
-    typeof window === 'undefined' ? 'https://jov.ie' : window.location.origin;
+  const appOrigin = getAppOrigin();
   const authUrl = useMemo(
     () => sanitizeDesktopAuthUrl(searchParams.get('auth_url'), appOrigin),
     [searchParams, appOrigin]

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -543,6 +543,170 @@ function OnboardingInitialIntro({
   );
 }
 
+function isTurnstileTokenUsable(
+  token: string | null,
+  status: OnboardingTurnstileStatus | undefined
+): boolean {
+  if (!token) return false;
+  return !['expired', 'timeout', 'error', 'unsupported', 'unconfigured'].some(
+    blockedStatus => blockedStatus === status
+  );
+}
+
+function getDisplayMessages(
+  messages: readonly UIMessage[],
+  shouldShowThinking: boolean
+): readonly UIMessage[] {
+  if (!shouldShowThinking) {
+    return [ONBOARDING_INTRO_MESSAGE, ...messages];
+  }
+
+  return [
+    ONBOARDING_INTRO_MESSAGE,
+    ...messages,
+    {
+      id: THINKING_PLACEHOLDER_ID,
+      role: 'assistant',
+      parts: [],
+    },
+  ];
+}
+
+interface ChatErrorStatusBannerProps {
+  readonly chatError: ChatError | null;
+  readonly handleRetry: () => void;
+  readonly isBusy: boolean;
+  readonly isSubmitted: boolean;
+}
+
+function ChatErrorStatusBanner({
+  chatError,
+  handleRetry,
+  isBusy,
+  isSubmitted,
+}: ChatErrorStatusBannerProps) {
+  if (!chatError) return null;
+
+  const canRetry = Boolean(chatError.failedMessage) && !chatError.retryAfter;
+
+  return (
+    <div
+      role='alert'
+      aria-live='assertive'
+      aria-atomic='true'
+      className='px-3 py-2.5 text-[12.5px] leading-5'
+    >
+      <p className='font-medium text-primary-token'>Message paused</p>
+      <p className='mt-0.5 text-secondary-token'>{chatError.message}</p>
+      {canRetry ? (
+        <button
+          type='button'
+          onClick={handleRetry}
+          disabled={isBusy || isSubmitted}
+          className='mt-2 inline-flex h-7 items-center rounded-[8px] border border-subtle px-2.5 text-[11.5px] font-medium text-secondary-token transition-colors duration-fast hover:border-white/15 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20 disabled:opacity-50'
+        >
+          Retry message
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+interface ComposerStatusBannerProps extends ChatErrorStatusBannerProps {
+  readonly shouldShowTurnstileBanner: boolean;
+  readonly turnstilePanel: ReactNode;
+}
+
+function ComposerStatusBanner({
+  chatError,
+  handleRetry,
+  isBusy,
+  isSubmitted,
+  shouldShowTurnstileBanner,
+  turnstilePanel,
+}: ComposerStatusBannerProps) {
+  if (!shouldShowTurnstileBanner && !chatError) return null;
+
+  return (
+    <div className='divide-y divide-white/[0.065]'>
+      {shouldShowTurnstileBanner ? (
+        <div data-testid='onboarding-turnstile-slot'>{turnstilePanel}</div>
+      ) : null}
+      <ChatErrorStatusBanner
+        chatError={chatError}
+        handleRetry={handleRetry}
+        isBusy={isBusy}
+        isSubmitted={isSubmitted}
+      />
+    </div>
+  );
+}
+
+interface OnboardingMessageRegionProps {
+  readonly composerPickerOpen: boolean;
+  readonly displayMessages: readonly UIMessage[];
+  readonly hasConversationStarted: boolean;
+  readonly isBusy: boolean;
+  readonly isStreaming: boolean;
+  readonly lastAssistantMessageId: string | null;
+  readonly onboardingComposerSurface: ReactNode;
+  readonly onSelectArtist: (artist: OnboardingArtistSelection) => void;
+  readonly shouldDockComposer: boolean;
+}
+
+function OnboardingMessageRegion({
+  composerPickerOpen,
+  displayMessages,
+  hasConversationStarted,
+  isBusy,
+  isStreaming,
+  lastAssistantMessageId,
+  onboardingComposerSurface,
+  onSelectArtist,
+  shouldDockComposer,
+}: OnboardingMessageRegionProps) {
+  if (shouldDockComposer) {
+    return (
+      <OnboardingMessageList
+        displayMessages={displayMessages}
+        hideIntroMessage={composerPickerOpen}
+        isStreaming={isStreaming}
+        lastAssistantMessageId={lastAssistantMessageId}
+        isBusy={isBusy}
+        onSelectArtist={onSelectArtist}
+      />
+    );
+  }
+
+  return (
+    <div className='flex w-full flex-col items-center justify-center gap-5 py-8'>
+      <div className='relative w-full'>
+        <OnboardingInitialIntro
+          hidden={hasConversationStarted || composerPickerOpen}
+          testId={
+            hasConversationStarted ? undefined : 'onboarding-intro-message'
+          }
+        />
+        {hasConversationStarted ? (
+          <div className='absolute inset-x-0 bottom-0 z-10 max-h-[min(42vh,24rem)] overflow-y-auto overscroll-contain pb-1'>
+            <OnboardingMessageList
+              displayMessages={displayMessages}
+              hideIntroMessage={composerPickerOpen}
+              isStreaming={isStreaming}
+              lastAssistantMessageId={lastAssistantMessageId}
+              isBusy={isBusy}
+              onSelectArtist={onSelectArtist}
+            />
+          </div>
+        ) : null}
+      </div>
+      <div className='w-full' data-testid='onboarding-centered-composer'>
+        {onboardingComposerSurface}
+      </div>
+    </div>
+  );
+}
+
 export function OnboardingChat({
   onConversationActivity,
   onProfileBuilderChange,
@@ -610,28 +774,13 @@ export function OnboardingChat({
   const isStreaming = status === 'streaming';
   const isBusy = isSubmitted || isStreaming;
   const requiresTurnstile = process.env.NODE_ENV !== 'development';
-  const isTurnstileTokenUsable =
-    Boolean(turnstileToken) &&
-    turnstileStatus !== 'expired' &&
-    turnstileStatus !== 'timeout' &&
-    turnstileStatus !== 'error' &&
-    turnstileStatus !== 'unsupported' &&
-    turnstileStatus !== 'unconfigured';
   const isAwaitingFirstToken =
-    requiresTurnstile && !hasSentFirst && !isTurnstileTokenUsable;
+    requiresTurnstile &&
+    !hasSentFirst &&
+    !isTurnstileTokenUsable(turnstileToken, turnstileStatus);
   const lastMessage = messages[messages.length - 1];
   const shouldShowThinking = isBusy && lastMessage?.role === 'user';
-  const displayMessages: readonly UIMessage[] = shouldShowThinking
-    ? [
-        ONBOARDING_INTRO_MESSAGE,
-        ...messages,
-        {
-          id: THINKING_PLACEHOLDER_ID,
-          role: 'assistant',
-          parts: [],
-        },
-      ]
-    : [ONBOARDING_INTRO_MESSAGE, ...messages];
+  const displayMessages = getDisplayMessages(messages, shouldShowThinking);
   const lastAssistantMessageId = findLastAssistantMessageId(displayMessages);
   const { isStuckToBottom, onScroll, totalSizeRef, scrollContainerRef } =
     useStickToBottom({ messageCount: displayMessages.length });
@@ -719,36 +868,18 @@ export function OnboardingChat({
 
   const shouldShowTurnstileBanner =
     Boolean(turnstilePanel) && isAwaitingFirstToken;
-  const chatErrorStatusBanner = chatError ? (
-    <div
-      role='alert'
-      aria-live='assertive'
-      aria-atomic='true'
-      className='px-3 py-2.5 text-[12.5px] leading-5'
-    >
-      <p className='font-medium text-primary-token'>Message paused</p>
-      <p className='mt-0.5 text-secondary-token'>{chatError.message}</p>
-      {chatError.failedMessage && !chatError.retryAfter ? (
-        <button
-          type='button'
-          onClick={handleRetry}
-          disabled={isBusy || isSubmitted}
-          className='mt-2 inline-flex h-7 items-center rounded-[8px] border border-subtle px-2.5 text-[11.5px] font-medium text-secondary-token transition-colors duration-fast hover:border-white/15 hover:text-primary-token focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20 disabled:opacity-50'
-        >
-          Retry message
-        </button>
-      ) : null}
-    </div>
+  const hasComposerStatusBanner =
+    shouldShowTurnstileBanner || chatError !== null;
+  const composerStatusBanner = hasComposerStatusBanner ? (
+    <ComposerStatusBanner
+      chatError={chatError}
+      handleRetry={handleRetry}
+      isBusy={isBusy}
+      isSubmitted={isSubmitted}
+      shouldShowTurnstileBanner={shouldShowTurnstileBanner}
+      turnstilePanel={turnstilePanel}
+    />
   ) : null;
-  const composerStatusBanner =
-    shouldShowTurnstileBanner || chatErrorStatusBanner ? (
-      <div className='divide-y divide-white/[0.065]'>
-        {shouldShowTurnstileBanner ? (
-          <div data-testid='onboarding-turnstile-slot'>{turnstilePanel}</div>
-        ) : null}
-        {chatErrorStatusBanner}
-      </div>
-    ) : null;
 
   const userTurnCount = messages.filter(
     message => message.role === 'user'
@@ -804,47 +935,17 @@ export function OnboardingChat({
             !shouldDockComposer && 'justify-center'
           )}
         >
-          {shouldDockComposer ? (
-            <OnboardingMessageList
-              displayMessages={displayMessages}
-              hideIntroMessage={composerPickerOpen}
-              isStreaming={isStreaming}
-              lastAssistantMessageId={lastAssistantMessageId}
-              isBusy={isBusy}
-              onSelectArtist={handleArtistSelect}
-            />
-          ) : (
-            <div className='flex w-full flex-col items-center justify-center gap-5 py-8'>
-              <div className='relative w-full'>
-                <OnboardingInitialIntro
-                  hidden={hasConversationStarted || composerPickerOpen}
-                  testId={
-                    hasConversationStarted
-                      ? undefined
-                      : 'onboarding-intro-message'
-                  }
-                />
-                {hasConversationStarted ? (
-                  <div className='absolute inset-x-0 bottom-0 z-10 max-h-[min(42vh,24rem)] overflow-y-auto overscroll-contain pb-1'>
-                    <OnboardingMessageList
-                      displayMessages={displayMessages}
-                      hideIntroMessage={composerPickerOpen}
-                      isStreaming={isStreaming}
-                      lastAssistantMessageId={lastAssistantMessageId}
-                      isBusy={isBusy}
-                      onSelectArtist={handleArtistSelect}
-                    />
-                  </div>
-                ) : null}
-              </div>
-              <div
-                className='w-full'
-                data-testid='onboarding-centered-composer'
-              >
-                {onboardingComposerSurface}
-              </div>
-            </div>
-          )}
+          <OnboardingMessageRegion
+            composerPickerOpen={composerPickerOpen}
+            displayMessages={displayMessages}
+            hasConversationStarted={hasConversationStarted}
+            isBusy={isBusy}
+            isStreaming={isStreaming}
+            lastAssistantMessageId={lastAssistantMessageId}
+            onboardingComposerSurface={onboardingComposerSurface}
+            onSelectArtist={handleArtistSelect}
+            shouldDockComposer={shouldDockComposer}
+          />
         </div>
       </div>
 

--- a/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
+++ b/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
@@ -74,6 +74,10 @@ const DEFAULT_STATE: OnboardingTurnstileState = {
   message: 'Checking your browser before your first message.',
 };
 
+function getTurnstile() {
+  return globalThis.window.turnstile;
+}
+
 function getStateCopy(state: OnboardingTurnstileState) {
   if (state.message) return state.message;
   switch (state.status) {
@@ -138,9 +142,10 @@ export function OnboardingTurnstile({
   const resetWidget = useCallback(
     (message = 'Verification reset. Complete the check to retry.') => {
       const widgetId = widgetIdRef.current;
-      if (widgetId && window.turnstile) {
+      const turnstile = getTurnstile();
+      if (widgetId && turnstile) {
         try {
-          window.turnstile.reset(widgetId);
+          turnstile.reset(widgetId);
           commitState({ status: 'loading', message });
           return;
         } catch (err) {
@@ -155,11 +160,12 @@ export function OnboardingTurnstile({
 
   const render = useCallback(() => {
     if (shouldBypassTurnstile || !siteKey) return; // local fallback handled server-side
-    if (!containerRef.current || !window.turnstile) return;
+    const turnstile = getTurnstile();
+    if (!containerRef.current || !turnstile) return;
     if (widgetIdRef.current) return; // already rendered
     try {
       commitState(DEFAULT_STATE);
-      widgetIdRef.current = window.turnstile.render(containerRef.current, {
+      widgetIdRef.current = turnstile.render(containerRef.current, {
         sitekey: siteKey,
         appearance: 'interaction-only',
         size: 'flexible',
@@ -226,14 +232,15 @@ export function OnboardingTurnstile({
       });
       return;
     }
-    if (window.turnstile) {
+    const turnstile = getTurnstile();
+    if (turnstile) {
       render();
     }
     return () => {
       const id = widgetIdRef.current;
-      if (id && window.turnstile) {
+      if (id && turnstile) {
         try {
-          window.turnstile.remove(id);
+          turnstile.remove(id);
         } catch {
           // ignore — widget already torn down
         }

--- a/apps/web/components/organisms/SidebarCollapsibleGroup.tsx
+++ b/apps/web/components/organisms/SidebarCollapsibleGroup.tsx
@@ -115,7 +115,7 @@ export function SidebarCollapsibleGroup({
       </SidebarMenu>
 
       <div
-        inert={!open ? true : undefined}
+        inert={open ? undefined : true}
         className={cn(
           'grid transition-[grid-template-rows,opacity] duration-[160ms] [transition-timing-function:cubic-bezier(0.25,0.46,0.45,0.94)]',
           open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'

--- a/apps/web/lib/chat-usage/copy.ts
+++ b/apps/web/lib/chat-usage/copy.ts
@@ -19,13 +19,15 @@ const PLAN_LABELS: Record<ChatUsageData['plan'], string> = {
   max: 'Max',
 };
 
+function getChatUsageState(data: ChatUsageData): ChatUsageState {
+  if (data.isExhausted) return 'exhausted';
+  if (data.isNearLimit) return 'near_limit';
+  return 'healthy';
+}
+
 export function getChatUsageCopy(data: ChatUsageData): ChatUsageCopy {
   const pluralSuffix = data.remaining === 1 ? '' : 's';
-  const state: ChatUsageState = data.isExhausted
-    ? 'exhausted'
-    : data.isNearLimit
-      ? 'near_limit'
-      : 'healthy';
+  const state = getChatUsageState(data);
 
   if (state === 'exhausted') {
     const summaryDescription =

--- a/apps/web/lib/desktop/electron-bridge.ts
+++ b/apps/web/lib/desktop/electron-bridge.ts
@@ -125,9 +125,10 @@ function reportMissingBridgeMethod(method: keyof ElectronAPI): void {
 }
 
 function getRawElectronAPI(): Partial<ElectronAPI> | undefined {
-  if (typeof window === 'undefined') return undefined;
-  const raw = (window as Window & { electronAPI?: Partial<ElectronAPI> })
-    .electronAPI;
+  if (typeof globalThis.window === 'undefined') return undefined;
+  const raw = (
+    globalThis.window as Window & { electronAPI?: Partial<ElectronAPI> }
+  ).electronAPI;
   if (!raw || typeof raw !== 'object') return undefined;
   return raw;
 }
@@ -189,14 +190,18 @@ function openManualDownload(): void {
   // Fallback: open the releases page in the system browser (or in-app).
   // window.open is safe in both browser and Electron contexts; Electron's
   // shell handler will route it via shell.openExternal.
-  if (typeof window !== 'undefined') {
-    window.open(RELEASE_DOWNLOAD_URL, '_blank', 'noopener,noreferrer');
+  if (typeof globalThis.window !== 'undefined') {
+    globalThis.window.open(
+      RELEASE_DOWNLOAD_URL,
+      '_blank',
+      'noopener,noreferrer'
+    );
   }
 }
 
 function openBrowserFallback(url: string): DesktopAuthActionResult {
-  if (typeof window !== 'undefined') {
-    const opened = window.open(url, '_blank', 'noopener,noreferrer');
+  if (typeof globalThis.window !== 'undefined') {
+    const opened = globalThis.window.open(url, '_blank', 'noopener,noreferrer');
     return opened
       ? { ok: true }
       : { ok: false, reason: 'browser-window-open-blocked' };
@@ -249,9 +254,11 @@ function safeInstallUpdateAndRestart(): void {
 }
 
 export function isElectronRuntime(): boolean {
-  if (typeof window === 'undefined') return false;
+  if (typeof globalThis.window === 'undefined') return false;
   if (isDesktopEnvironment()) return true;
-  return document.documentElement.dataset.desktopRuntime === 'electron';
+  return (
+    globalThis.document.documentElement.dataset.desktopRuntime === 'electron'
+  );
 }
 
 export function useIsElectronRuntime(): boolean {

--- a/apps/web/lib/queries/fetch.ts
+++ b/apps/web/lib/queries/fetch.ts
@@ -86,6 +86,47 @@ async function extractClientErrorMessage(response: Response): Promise<{
   }
 }
 
+function getRequestHeaders(
+  url: string,
+  fetchOptions: RequestInit
+): HeadersInit | undefined {
+  if (!shouldAttachCsrfHeader(url, fetchOptions.method)) {
+    return fetchOptions.headers;
+  }
+
+  const csrfToken = getBrowserCsrfToken();
+  if (!csrfToken) {
+    return fetchOptions.headers;
+  }
+
+  const csrfHeaders = new Headers(fetchOptions.headers);
+  if (!csrfHeaders.has(CSRF_HEADER_NAME)) {
+    csrfHeaders.set(CSRF_HEADER_NAME, csrfToken);
+  }
+  return csrfHeaders;
+}
+
+async function throwFetchErrorForResponse(response: Response): Promise<never> {
+  let message = getFetchErrorMessage(response);
+  let parsedBody: Record<string, unknown> | undefined;
+
+  if (response.status >= 400 && response.status < 500) {
+    const extracted = await extractClientErrorMessage(response);
+    if (extracted.message) message = extracted.message;
+    parsedBody = extracted.parsedBody;
+  }
+
+  throw new FetchError(message, response.status, response, parsedBody);
+}
+
+function normalizeFetchError(error: unknown): never {
+  if (error instanceof FetchError) throw error;
+  if (error instanceof Error && error.name === 'AbortError') {
+    throw new FetchError('Request timeout', 408);
+  }
+  throw error;
+}
+
 export async function fetchWithTimeoutResponse(
   url: string,
   options: FetchOptions = {}
@@ -97,18 +138,7 @@ export async function fetchWithTimeoutResponse(
   linkSignal(controller, externalSignal ?? undefined);
 
   try {
-    let headers = fetchOptions.headers;
-    if (shouldAttachCsrfHeader(url, fetchOptions.method)) {
-      const csrfToken = getBrowserCsrfToken();
-      if (csrfToken) {
-        const csrfHeaders = new Headers(fetchOptions.headers);
-        if (!csrfHeaders.has(CSRF_HEADER_NAME)) {
-          csrfHeaders.set(CSRF_HEADER_NAME, csrfToken);
-          headers = csrfHeaders;
-        }
-      }
-    }
-
+    const headers = getRequestHeaders(url, fetchOptions);
     const requestInit: RequestInit = {
       ...fetchOptions,
       signal: controller.signal,
@@ -120,25 +150,12 @@ export async function fetchWithTimeoutResponse(
     const response = await fetch(url, requestInit);
 
     if (!response.ok) {
-      let message = getFetchErrorMessage(response);
-      let parsedBody: Record<string, unknown> | undefined;
-
-      if (response.status >= 400 && response.status < 500) {
-        const extracted = await extractClientErrorMessage(response);
-        if (extracted.message) message = extracted.message;
-        parsedBody = extracted.parsedBody;
-      }
-
-      throw new FetchError(message, response.status, response, parsedBody);
+      await throwFetchErrorForResponse(response);
     }
 
     return response;
   } catch (error) {
-    if (error instanceof FetchError) throw error;
-    if (error instanceof Error && error.name === 'AbortError') {
-      throw new FetchError('Request timeout', 408);
-    }
-    throw error;
+    normalizeFetchError(error);
   } finally {
     clearTimeout(timeoutId);
   }


### PR DESCRIPTION
## Summary
- Extract OnboardingChat status-banner and message-region rendering helpers to reduce component complexity while preserving composer geometry.
- Move fetch CSRF header/error handling into small helpers.
- Apply Sonar mechanical fixes for native global access, chat-usage state selection, and sidebar inert state.

## Verification
- pnpm biome check --write apps/web/components/features/onboarding/OnboardingChat.tsx apps/web/components/organisms/SidebarCollapsibleGroup.tsx apps/web/app/auth-return/page.tsx apps/web/app/desktop-auth/page.tsx apps/web/lib/chat-usage/copy.ts apps/web/lib/queries/fetch.ts apps/web/lib/desktop/electron-bridge.ts apps/web/components/features/onboarding/OnboardingTurnstile.tsx
- pnpm --filter web exec vitest run tests/unit/onboarding/OnboardingChat.turnstile.test.tsx tests/unit/onboarding/OnboardingTurnstile.test.tsx tests/unit/sidebar-row-alignment.test.tsx tests/unit/app/desktop-auth-page.test.tsx tests/unit/lib/chat-usage-copy.test.ts tests/lib/queries/fetch-csrf.test.ts tests/unit/desktop/electron-runtime.test.tsx (27 tests passed)
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, biome lint

## Layout Shift Audit
- OnboardingChat keeps the same centered/docked composer branches, reserved message containers, and status-banner mounting behavior. The extracted helpers preserve the existing null status-banner path so ChatInput does not allocate banner space when no banner is visible.

## Risk
Low. This is structure-preserving refactor plus direct mechanical Sonar fixes.

Linear: ad-hoc (Linear MCP unavailable during this lane)
