### PR TITLE
fix(sonar): migrate admin pages to admin page

### DIFF
--- a/apps/web/app/app/(shell)/admin/agent-runs/[id]/page.tsx
+++ b/apps/web/app/app/(shell)/admin/agent-runs/[id]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
-import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
+import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { APP_ROUTES } from '@/constants/routes';
@@ -59,7 +59,7 @@ export default async function AgentRunDebugPage({
   const costDisplay = run.cost ? formatUsd(Number(run.cost)) : '—';
 
   return (
-    <AdminToolPage
+    <AdminPage
       title='Agent Run Debug'
       description={run.id}
       testId='admin-agent-run-detail-page'
@@ -141,7 +141,7 @@ export default async function AgentRunDebugPage({
           </pre>
         </DebugSection>
       )}
-    </AdminToolPage>
+    </AdminPage>
   );
 }
 

--- a/apps/web/app/app/(shell)/admin/interviews/page.tsx
+++ b/apps/web/app/app/(shell)/admin/interviews/page.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@jovie/ui';
 import type { Metadata } from 'next';
-import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
+import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { capitalizeFirst } from '@/lib/utils/string-utils';
 import { loadAdminInterviewRows } from './interviews-data';
@@ -34,7 +34,7 @@ export default async function AdminInterviewsPage() {
   const rows = await loadAdminInterviewRows();
 
   return (
-    <AdminToolPage
+    <AdminPage
       title='User Interviews'
       description='Mom Test interviews captured after onboarding.'
       testId='admin-interviews-page'
@@ -109,6 +109,6 @@ export default async function AdminInterviewsPage() {
           </div>
         )}
       </ContentSurfaceCard>
-    </AdminToolPage>
+    </AdminPage>
   );
 }

--- a/apps/web/app/app/(shell)/admin/investors/page.tsx
+++ b/apps/web/app/app/(shell)/admin/investors/page.tsx
@@ -10,7 +10,7 @@ import {
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Suspense } from 'react';
-import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
+import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { ContentSectionHeader } from '@/components/molecules/ContentSectionHeader';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { UnifiedTableSkeleton } from '@/components/organisms/table';
@@ -108,7 +108,7 @@ const INVESTOR_TABLE_SKELETON_COLUMN_CONFIG = [
  */
 export default function InvestorPipelinePage() {
   return (
-    <AdminToolPage
+    <AdminPage
       title='Investors'
       description='Track investor links, view signals, and active fundraising conversations.'
       testId='admin-investors-page'
@@ -127,7 +127,7 @@ export default function InvestorPipelinePage() {
       <Suspense fallback={<TableSkeleton />}>
         <InvestorPipelineTable />
       </Suspense>
-    </AdminToolPage>
+    </AdminPage>
   );
 }
 

--- a/apps/web/app/app/(shell)/admin/ops/page.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/page.tsx
@@ -6,7 +6,7 @@ import type {
   DailyBucket,
   ShippingVelocityResponse,
 } from '@/app/api/admin/hud/shipping-velocity/route';
-import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
+import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { APP_ROUTES } from '@/constants/routes';
 import { getPublicProfileCanaryStatus } from '@/lib/admin/ops-queries';
 import { env } from '@/lib/env-server';
@@ -119,7 +119,7 @@ export default async function AdminOpsPage({
     : null;
 
   return (
-    <AdminToolPage
+    <AdminPage
       title='Ops'
       description='Live operations: deploys, AI ops, runway, blockers.'
       testId='admin-ops-page'
@@ -185,6 +185,6 @@ export default async function AdminOpsPage({
         initialShippingData={shippingPrefetch?.data}
         initialShippingCachedAt={shippingPrefetch?.cachedAt}
       />
-    </AdminToolPage>
+    </AdminPage>
   );
 }

--- a/apps/web/app/app/(shell)/admin/share-studio/page.tsx
+++ b/apps/web/app/app/(shell)/admin/share-studio/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Image from 'next/image';
 import Link from 'next/link';
-import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
+import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { APP_ROUTES } from '@/constants/routes';
 import {
@@ -232,7 +232,7 @@ export default async function AdminShareStudioPage({
 
   if (!data) {
     return (
-      <AdminToolPage
+      <AdminPage
         title='Share Studio'
         description='Preview share payloads once blog, profile, release, and playlist content exists.'
         testId='admin-share-studio-page'
@@ -241,12 +241,12 @@ export default async function AdminShareStudioPage({
           Share Studio needs at least one real blog post, public profile,
           release, and published playlist to render previews.
         </ContentSurfaceCard>
-      </AdminToolPage>
+      </AdminPage>
     );
   }
 
   return (
-    <AdminToolPage
+    <AdminPage
       title='Share Studio'
       description='Preview public share payloads, download story assets, and inspect tracked-link outputs across all public surfaces.'
       testId='admin-share-studio-page'
@@ -297,6 +297,6 @@ export default async function AdminShareStudioPage({
           context={data.playlistContext}
         />
       </div>
-    </AdminToolPage>
+    </AdminPage>
   );
 }

--- a/apps/web/app/app/(shell)/feature-flags/page.tsx
+++ b/apps/web/app/app/(shell)/feature-flags/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { loadAppShellRouteContext } from '@/app/app/(shell)/app-shell-route-context';
-import { AdminToolPage } from '@/components/features/admin/layout/AdminToolPage';
+import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { APP_ROUTES } from '@/constants/routes';
 import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 import {
@@ -57,8 +57,8 @@ export default async function FeatureFlagsPage() {
   }));
 
   return (
-    <AdminToolPage testId='feature-flags-page'>
+    <AdminPage title='' testId='feature-flags-page'>
       <FeatureFlagsTable flags={[...flags]} />
-    </AdminToolPage>
+    </AdminPage>
   );
 }

--- a/apps/web/tests/unit/admin-shell-deprecation.test.ts
+++ b/apps/web/tests/unit/admin-shell-deprecation.test.ts
@@ -111,10 +111,10 @@ function countImporters(): { files: string[]; count: number } {
  * RATCHET — only ever decrement this value.
  *
  * Update the date and Linear issue ID when you decrement. Current ceiling
- * lowered by JOV-2544 on 2026-05-21: 6 importers remain after migrating
- * simple `AdminToolPage` callers to `AdminPage` directly.
+ * lowered by JOV-2570 on 2026-05-24: no direct importers remain after
+ * migrating the remaining `AdminToolPage` callers to `AdminPage` directly.
  */
-const MAX_DEPRECATED_IMPORTERS = 6;
+const MAX_DEPRECATED_IMPORTERS = 0;
 
 describe('admin shell deprecation ratchet', () => {
   it(`has at most ${MAX_DEPRECATED_IMPORTERS} importers of AdminToolPage/AdminWorkspacePage`, () => {

--- a/apps/web/tests/unit/app/admin-agent-run-detail-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/admin-agent-run-detail-shell-normalization.test.ts
@@ -21,8 +21,8 @@ describe('admin agent run detail shell normalization', () => {
   it('keeps the run detail route inside the shared admin shell', () => {
     const source = readFileSync(AGENT_RUN_DETAIL_ROUTE, 'utf8');
 
-    expect(source).toContain('import { AdminToolPage }');
-    expect(source).toContain('<AdminToolPage');
+    expect(source).toContain('import { AdminPage }');
+    expect(source).toContain('<AdminPage');
     expect(source).toContain("testId='admin-agent-run-detail-page'");
     expect(source).toContain('max-w-(--app-shell-content-max-reading)');
     expect(source).not.toMatch(/className=['"][^'"]*\bp-6\b[^'"]*['"]/);

--- a/apps/web/tests/unit/app/admin-interviews-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/admin-interviews-shell-normalization.test.ts
@@ -17,8 +17,8 @@ describe('admin interviews shell normalization', () => {
   it('keeps the route inside the canonical admin shell', () => {
     const source = readFileSync(ADMIN_INTERVIEWS_ROUTE, 'utf8');
 
-    expect(source).toContain('import { AdminToolPage }');
-    expect(source).toContain('<AdminToolPage');
+    expect(source).toContain('import { AdminPage }');
+    expect(source).toContain('<AdminPage');
     expect(source).toContain("testId='admin-interviews-page'");
     expect(source).not.toContain("className='space-y-4 p-6'");
     expect(source).not.toContain('<header>');

--- a/apps/web/tests/unit/app/admin-ops-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/admin-ops-shell-normalization.test.ts
@@ -30,11 +30,11 @@ function readSource(filePath: string): string {
 }
 
 describe('admin ops shell normalization', () => {
-  it('keeps the ops route inside AdminToolPage while preserving kiosk mode', () => {
+  it('keeps the ops route inside AdminPage while preserving kiosk mode', () => {
     const source = readSource(OPS_PAGE);
 
-    expect(source).toContain('import { AdminToolPage }');
-    expect(source).toContain('<AdminToolPage');
+    expect(source).toContain('import { AdminPage }');
+    expect(source).toContain('<AdminPage');
     expect(source).toContain("value === 'kiosk' ? 'admin-kiosk' : 'shell'");
     expect(source).toContain("presentationMode='admin-kiosk'");
     expect(source).toContain("density='kiosk'");

--- a/apps/web/tests/unit/app/feature-flags-shell-normalization.test.ts
+++ b/apps/web/tests/unit/app/feature-flags-shell-normalization.test.ts
@@ -25,13 +25,13 @@ const FEATURE_FLAGS_TABLE = findSourceFile(
 );
 
 describe('feature flags shell normalization', () => {
-  it('keeps feature flags in the shared admin tool shell', () => {
+  it('keeps feature flags in the shared admin page shell', () => {
     const source = readFileSync(FEATURE_FLAGS_PAGE, 'utf8');
 
-    expect(source).toContain('AdminToolPage');
+    expect(source).toContain('AdminPage');
     expect(source).toContain("testId='feature-flags-page'");
     expect(source).toContain('loadAppShellRouteContext');
-    expect(source).not.toContain('title=');
+    expect(source).toContain("title=''");
     expect(source).not.toContain('description=');
     expect(source).not.toContain('getCachedAuth');
     expect(source).not.toContain('getDashboardDataEssential');


### PR DESCRIPTION
## Summary
- Replace remaining direct admin route usages of deprecated AdminToolPage with AdminPage.
- Update shell-normalization tests to assert the canonical AdminPage shell.
- Ratchet deprecated admin shell importer ceiling to zero.

## Verification
- pnpm biome check --write apps/web/app/app/(shell)/admin/agent-runs/[id]/page.tsx apps/web/app/app/(shell)/admin/interviews/page.tsx apps/web/app/app/(shell)/admin/investors/page.tsx apps/web/app/app/(shell)/admin/ops/page.tsx apps/web/app/app/(shell)/admin/share-studio/page.tsx apps/web/app/app/(shell)/feature-flags/page.tsx
- pnpm biome check --write apps/web/tests/unit/app/admin-agent-run-detail-shell-normalization.test.ts apps/web/tests/unit/app/admin-ops-shell-normalization.test.ts apps/web/tests/unit/app/admin-interviews-shell-normalization.test.ts apps/web/tests/unit/app/feature-flags-shell-normalization.test.ts apps/web/tests/unit/admin-shell-deprecation.test.ts
- pnpm --filter web exec vitest run tests/unit/admin-shell-deprecation.test.ts tests/unit/app/admin-agent-run-detail-shell-normalization.test.ts tests/unit/app/admin-ops-shell-normalization.test.ts tests/unit/app/admin-interviews-shell-normalization.test.ts tests/unit/app/feature-flags-shell-normalization.test.ts (15 tests passed)
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, biome lint

## Layout Shift Audit
- AdminToolPage is a thin shim over AdminPage. Direct imports keep the same props and render path, including title, description, actions, test IDs, children, and className.

## Risk
Low. This is a direct wrapper removal with test ratchet updates.

Linear: ad-hoc (Linear MCP unavailable during this lane)
