### PR TITLE
fix(sonar): clear onboarding helper smells

### DIFF
--- a/apps/web/app/desktop-auth/page.tsx
+++ b/apps/web/app/desktop-auth/page.tsx
@@ -63,7 +63,7 @@ async function openWithTimeout(authUrl: string) {
 }
 
 function getAppOrigin(): string {
-  return typeof globalThis.window === 'undefined'
+  return globalThis.window === undefined
     ? 'https://jov.ie'
     : globalThis.window.location.origin;
 }

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -87,10 +87,9 @@ const ONBOARDING_INTRO_MESSAGE = {
   ],
 } satisfies UIMessage;
 
-const BLOCKED_TURNSTILE_TOKEN_STATUSES: readonly (
-  | OnboardingTurnstileStatus
-  | undefined
-)[] = ['expired', 'timeout', 'error', 'unsupported', 'unconfigured'];
+const BLOCKED_TURNSTILE_TOKEN_STATUSES: ReadonlySet<
+  OnboardingTurnstileStatus | undefined
+> = new Set(['expired', 'timeout', 'error', 'unsupported', 'unconfigured']);
 
 function getMessageText(message: UIMessage): string {
   return (message.parts ?? [])
@@ -553,7 +552,7 @@ function isTurnstileTokenUsable(
   status: OnboardingTurnstileStatus | undefined
 ): boolean {
   if (!token) return false;
-  return !BLOCKED_TURNSTILE_TOKEN_STATUSES.includes(status);
+  return !BLOCKED_TURNSTILE_TOKEN_STATUSES.has(status);
 }
 
 function getDisplayMessages(

--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -87,6 +87,11 @@ const ONBOARDING_INTRO_MESSAGE = {
   ],
 } satisfies UIMessage;
 
+const BLOCKED_TURNSTILE_TOKEN_STATUSES: readonly (
+  | OnboardingTurnstileStatus
+  | undefined
+)[] = ['expired', 'timeout', 'error', 'unsupported', 'unconfigured'];
+
 function getMessageText(message: UIMessage): string {
   return (message.parts ?? [])
     .filter(
@@ -548,9 +553,7 @@ function isTurnstileTokenUsable(
   status: OnboardingTurnstileStatus | undefined
 ): boolean {
   if (!token) return false;
-  return !['expired', 'timeout', 'error', 'unsupported', 'unconfigured'].some(
-    blockedStatus => blockedStatus === status
-  );
+  return !BLOCKED_TURNSTILE_TOKEN_STATUSES.includes(status);
 }
 
 function getDisplayMessages(

--- a/apps/web/lib/desktop/electron-bridge.ts
+++ b/apps/web/lib/desktop/electron-bridge.ts
@@ -125,7 +125,7 @@ function reportMissingBridgeMethod(method: keyof ElectronAPI): void {
 }
 
 function getRawElectronAPI(): Partial<ElectronAPI> | undefined {
-  if (typeof globalThis.window === 'undefined') return undefined;
+  if (globalThis.window === undefined) return undefined;
   const raw = (
     globalThis.window as Window & { electronAPI?: Partial<ElectronAPI> }
   ).electronAPI;
@@ -190,7 +190,7 @@ function openManualDownload(): void {
   // Fallback: open the releases page in the system browser (or in-app).
   // window.open is safe in both browser and Electron contexts; Electron's
   // shell handler will route it via shell.openExternal.
-  if (typeof globalThis.window !== 'undefined') {
+  if (globalThis.window !== undefined) {
     globalThis.window.open(
       RELEASE_DOWNLOAD_URL,
       '_blank',
@@ -200,7 +200,7 @@ function openManualDownload(): void {
 }
 
 function openBrowserFallback(url: string): DesktopAuthActionResult {
-  if (typeof globalThis.window !== 'undefined') {
+  if (globalThis.window !== undefined) {
     const opened = globalThis.window.open(url, '_blank', 'noopener,noreferrer');
     return opened
       ? { ok: true }
@@ -254,7 +254,7 @@ function safeInstallUpdateAndRestart(): void {
 }
 
 export function isElectronRuntime(): boolean {
-  if (typeof globalThis.window === 'undefined') return false;
+  if (globalThis.window === undefined) return false;
   if (isDesktopEnvironment()) return true;
   return (
     globalThis.document.documentElement.dataset.desktopRuntime === 'electron'


### PR DESCRIPTION
## Summary
- Clear Sonar new-code findings from the merged onboarding helper refactor.
- Replace global window typeof checks with direct undefined comparisons.
- Use includes for Turnstile blocked status lookup.

## Verification
- pnpm biome check --write apps/web/components/features/onboarding/OnboardingChat.tsx apps/web/app/desktop-auth/page.tsx apps/web/lib/desktop/electron-bridge.ts
- pnpm --filter web exec vitest run tests/unit/onboarding/OnboardingChat.turnstile.test.tsx tests/unit/app/desktop-auth-page.test.tsx tests/unit/desktop/electron-runtime.test.tsx (9 tests passed)
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, biome lint

## Risk
Low. This is mechanical cleanup of Sonar feedback from #9619.

Linear: ad-hoc (Linear MCP unavailable during this lane)
