### PR TITLE
fix(sonar): clear small quality smells

### DIFF
--- a/apps/web/app/api/cron/clerk-config-audit/route.ts
+++ b/apps/web/app/api/cron/clerk-config-audit/route.ts
@@ -129,32 +129,47 @@ function pickAuthConfig(
   return {};
 }
 
+function getAuthAttributes(
+  authConfig: Record<string, unknown>
+): Record<string, unknown> {
+  const attributes = authConfig['attributes'];
+  return attributes && typeof attributes === 'object'
+    ? (attributes as Record<string, unknown>)
+    : {};
+}
+
+function appendFirstFactor(
+  factors: Set<string>,
+  attribute: string,
+  settings: Record<string, unknown>
+): void {
+  if (settings['used_for_first_factor'] !== true) return;
+
+  const verifications = asStringArray(settings['verifications']);
+  if (verifications.length === 0) {
+    factors.add(attribute);
+    return;
+  }
+
+  for (const verification of verifications) {
+    factors.add(verification);
+  }
+}
+
 function extractFirstFactors(
   authConfig: Record<string, unknown>
 ): readonly string[] {
   const direct = asStringArray(authConfig['first_factors']);
   if (direct.length > 0) return direct;
 
-  const attributes = authConfig['attributes'];
-  if (attributes && typeof attributes === 'object') {
-    const factors = new Set<string>();
-    for (const [attribute, settings] of Object.entries(attributes)) {
-      if (!settings || typeof settings !== 'object') continue;
-      const s = settings as Record<string, unknown>;
-      if (s['used_for_first_factor'] !== true) continue;
-      const verifications = asStringArray(s['verifications']);
-      if (verifications.length === 0) {
-        factors.add(attribute);
-      } else {
-        for (const verification of verifications) {
-          factors.add(verification);
-        }
-      }
-    }
-    return Array.from(factors);
+  const factors = new Set<string>();
+  for (const [attribute, settings] of Object.entries(
+    getAuthAttributes(authConfig)
+  )) {
+    if (!settings || typeof settings !== 'object') continue;
+    appendFirstFactor(factors, attribute, settings as Record<string, unknown>);
   }
-
-  return [];
+  return Array.from(factors);
 }
 
 function extractIdentifications(
@@ -163,20 +178,17 @@ function extractIdentifications(
   const direct = asStringArray(authConfig['identification_requirements']);
   if (direct.length > 0) return direct;
 
-  const attributes = authConfig['attributes'];
-  if (attributes && typeof attributes === 'object') {
-    const required: string[] = [];
-    for (const [attribute, settings] of Object.entries(attributes)) {
-      if (!settings || typeof settings !== 'object') continue;
-      const s = settings as Record<string, unknown>;
-      if (s['used_for_first_factor'] === true && s['enabled'] === true) {
-        required.push(attribute);
-      }
+  const required: string[] = [];
+  for (const [attribute, settings] of Object.entries(
+    getAuthAttributes(authConfig)
+  )) {
+    if (!settings || typeof settings !== 'object') continue;
+    const s = settings as Record<string, unknown>;
+    if (s['used_for_first_factor'] === true && s['enabled'] === true) {
+      required.push(attribute);
     }
-    return required;
   }
-
-  return [];
+  return required;
 }
 
 async function auditInstance(

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/release-plan-generation.ts
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/release-plan-generation.ts
@@ -22,13 +22,13 @@ function isUpgradeRequiredError(error: unknown): boolean {
   if (error instanceof Error && error.name === 'TasksUpgradeRequiredError') {
     return true;
   }
+  const code =
+    error !== null && typeof error === 'object' && 'code' in error
+      ? error.code
+      : undefined;
   if (
-    error !== null &&
-    typeof error === 'object' &&
-    'code' in error &&
-    typeof (error as { code: unknown }).code === 'string' &&
-    ((error as { code: string }).code === 'RELEASE_PLAN_LOCKED' ||
-      (error as { code: string }).code === 'TASKS_WORKSPACE_LOCKED')
+    typeof code === 'string' &&
+    (code === 'RELEASE_PLAN_LOCKED' || code === 'TASKS_WORKSPACE_LOCKED')
   ) {
     return true;
   }

--- a/apps/web/lib/queries/useReleaseTaskMutations.ts
+++ b/apps/web/lib/queries/useReleaseTaskMutations.ts
@@ -21,13 +21,13 @@ function isUpgradeRequiredError(error: unknown): boolean {
   if (error instanceof Error && error.name === 'TasksUpgradeRequiredError') {
     return true;
   }
+  const code =
+    error !== null && typeof error === 'object' && 'code' in error
+      ? error.code
+      : undefined;
   if (
-    error !== null &&
-    typeof error === 'object' &&
-    'code' in error &&
-    typeof (error as { code: unknown }).code === 'string' &&
-    ((error as { code: string }).code === 'RELEASE_PLAN_LOCKED' ||
-      (error as { code: string }).code === 'TASKS_WORKSPACE_LOCKED')
+    typeof code === 'string' &&
+    (code === 'RELEASE_PLAN_LOCKED' || code === 'TASKS_WORKSPACE_LOCKED')
   ) {
     return true;
   }

--- a/apps/web/tests/e2e/synthetic-auth-ui.spec.ts
+++ b/apps/web/tests/e2e/synthetic-auth-ui.spec.ts
@@ -107,7 +107,10 @@ async function assertAuthShellReady(page: Page, expectedMode: string) {
 test.describe('Synthetic Monitoring — Layer A (auth UI, SSO-only)', () => {
   test.beforeEach(async () => {
     if (process.env.E2E_SYNTHETIC_MODE !== 'true') {
-      test.skip();
+      test.skip(
+        true,
+        'Synthetic auth UI canary only runs when E2E_SYNTHETIC_MODE=true.'
+      );
     }
   });
 

--- a/apps/web/tests/e2e/synthetic-legacy-otp.spec.ts
+++ b/apps/web/tests/e2e/synthetic-legacy-otp.spec.ts
@@ -164,7 +164,10 @@ async function verifyPostSignupUsableState(page: Page) {
 test.describe('Synthetic Monitoring - Legacy OTP Signup (JOV-2446 cutover)', () => {
   test.beforeEach(async () => {
     if (process.env.E2E_SYNTHETIC_MODE !== 'true') {
-      test.skip();
+      test.skip(
+        true,
+        'Synthetic legacy OTP canary only runs when E2E_SYNTHETIC_MODE=true.'
+      );
     }
   });
 

--- a/apps/web/tests/unit/middleware/proxy-regions.contract.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-regions.contract.test.ts
@@ -147,7 +147,8 @@ describe('Proxy regions contract (RED 43 — investor / Clerk FAPI / audience / 
       'user-agent': 'curl/8.0',
     });
     // Middleware would hit the degraded path
-    expect(true).toBe(true); // placeholder — real call would exercise the 503 JSON branch
+    expect(mocks.resolveClerkKeys()).toEqual({ status: 'error' });
+    expect(mocks.buildAuthDegradedHtmlResponse()).toBe('<html>degraded</html>');
   });
 
   it('clerkMiddleware mock uses correct (authCallable, req) signature (nit fix)', () => {


### PR DESCRIPTION
## Summary
- Remove unnecessary upgrade-code assertions in release task helpers.
- Split Clerk config audit first-factor extraction into smaller helpers.
- Add explicit skip reasons for synthetic-only E2E canaries.
- Replace a placeholder proxy contract assertion with mock output checks.

## Verification
- pnpm biome check --write apps/web/components/features/dashboard/organisms/release-provider-matrix/release-plan-generation.ts apps/web/lib/queries/useReleaseTaskMutations.ts apps/web/app/api/cron/clerk-config-audit/route.ts apps/web/tests/e2e/synthetic-auth-ui.spec.ts apps/web/tests/e2e/synthetic-legacy-otp.spec.ts apps/web/tests/unit/middleware/proxy-regions.contract.test.ts
- pnpm --filter web exec vitest run tests/unit/cron/clerk-config-audit.test.ts tests/unit/middleware/proxy-regions.contract.test.ts (12 tests passed)
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, biome lint

## Risk
Low. Changes are mechanical quality cleanups with focused unit coverage.

Linear: ad-hoc (Linear MCP unavailable during this lane)
