### PR TITLE
fix(security): clear remaining code scanning alerts

### DIFF
--- a/.agents/skills/gstack/.github/docker/Dockerfile.ci
+++ b/.agents/skills/gstack/.github/docker/Dockerfile.ci
@@ -36,7 +36,9 @@ RUN curl -fsSL https://bun.sh/install -o /tmp/bun-install.sh \
 # Claude CLI
 RUN curl -fsSL https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.150.tgz -o /tmp/claude-code.tgz \
     && echo "9f278eca873fa661864697dfc8f535eafe5c6a6a73b64ca7c9115c34aa83ee906f23468f7e58c6562dc28b329bbbbfddc753228de13d5e2434907935b66c791a  /tmp/claude-code.tgz" | sha512sum -c - \
-    && npm install -g /tmp/claude-code.tgz \
+    && mkdir -p /usr/local/lib/claude-code \
+    && tar -xzf /tmp/claude-code.tgz --strip-components=1 -C /usr/local/lib/claude-code \
+    && ln -sf /usr/local/lib/claude-code/bin/claude.exe /usr/local/bin/claude \
     && rm -f /tmp/claude-code.tgz
 
 # Playwright system deps (Chromium) — needed for browse E2E tests

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "lodash-es": ">=4.18.1",
       "handlebars": ">=4.7.9",
       "@xmldom/xmldom": ">=0.9.10",
-      "brace-expansion": "5.0.5",
+      "brace-expansion": "5.0.6",
       "@isaacs/brace-expansion": ">=5.0.1",
       "minimatch@^10.0.0": "10.2.4",
       "minimatch@^9.0.0": "^9.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ overrides:
   lodash-es: '>=4.18.1'
   handlebars: '>=4.7.9'
   '@xmldom/xmldom': '>=0.9.10'
-  brace-expansion: 5.0.5
+  brace-expansion: 5.0.6
   '@isaacs/brace-expansion': '>=5.0.1'
   minimatch@^10.0.0: 10.2.4
   minimatch@^9.0.0: ^9.0.7
@@ -185,7 +185,7 @@ importers:
     dependencies:
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       next:
         specifier: ^16.2.6
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -339,7 +339,7 @@ importers:
         version: 1.37.0
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/blob':
         specifier: ^2.4.0
         version: 2.4.0
@@ -8338,8 +8338,8 @@ packages:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -23453,7 +23453,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -23661,7 +23661,7 @@ snapshots:
       path-to-regexp: 8.4.2
       semver: 7.8.0
     optionalDependencies:
-      '@vercel/analytics': 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@vercel/analytics': 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@vercel/speed-insights': 1.3.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@19.1.0-rc.3)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -25217,7 +25217,7 @@ snapshots:
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -30555,19 +30555,19 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimist@1.2.7: {}
 


### PR DESCRIPTION
## Summary
- Bump the pnpm override for brace-expansion from 5.0.5 to 5.0.6 to clear the remaining Trivy pnpm-lock alert.
- Replace the gstack CI Dockerfile npm global install with direct extraction of the checksum-verified Claude CLI tarball.
- Keep the existing tarball hash verification and binary path validation intact.

## Verification
- pnpm install --lockfile-only
- pnpm install --frozen-lockfile
- pnpm biome check --write package.json pnpm-lock.yaml
- git diff --check
- Claude CLI tarball checksum/bin-path verification script
- pre-push: biome check ., next:proxy-guard, tailwind:check, typecheck, biome lint

## Risk
Low. The lockfile change is a security override bump, and the Dockerfile still verifies the downloaded tarball before installing the same Claude CLI payload without npm.

Linear: ad-hoc GitHub code scanning drain



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI environment Docker image configuration for CLI installation
  * Updated transitive dependency to patch version for enhanced stability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->