### PR TITLE
fix(sentry): align workflow run queue status

### DIFF
--- a/apps/web/app/api/connectors/suggested-actions/[id]/approve/route.ts
+++ b/apps/web/app/api/connectors/suggested-actions/[id]/approve/route.ts
@@ -79,7 +79,7 @@ export async function POST(_request: Request, { params }: RouteParams) {
     await db.insert(workflowRuns).values({
       kind: 'execute_approved_action',
       userId,
-      status: 'pending',
+      status: 'queued',
       currentStep: 'create_calendar_event',
       stepOutputs: { approvalId: id, eventPayload },
       runAt: new Date(),

--- a/apps/web/app/api/cron/process-workflow-runs/route.ts
+++ b/apps/web/app/api/cron/process-workflow-runs/route.ts
@@ -19,13 +19,13 @@
  * we move to event-driven enqueue (see JOV-2500 follow-on).
  *
  * Design:
- * - CAS claim: UPDATE ... SET status='running' WHERE status='pending' AND runAt<=now()
+ * - CAS claim: UPDATE ... SET status='running' WHERE status='queued' AND runAt<=now()
  * - Process MAX_RUNS_PER_TICK runs, MAX_CONCURRENT_RUNS in parallel
  * - Unknown workflow kinds are failed immediately (fail-closed)
  *
  * Cost impact: 1 DB query/tick + up to 20 Google Calendar API calls/tick
  * at 240 ticks/day = max 4,800 Google API calls/day at full load.
- * In practice: only runs when there are pending workflow_runs rows.
+ * In practice: only runs when there are queued workflow_runs rows.
  */
 
 import { and, eq, inArray, lte } from 'drizzle-orm';
@@ -55,28 +55,28 @@ export async function GET(request: Request): Promise<Response> {
   const now = new Date();
 
   try {
-    // Step 1: SELECT up to MAX_RUNS_PER_TICK pending runs (uses LIMIT)
-    const pendingRuns = await db
+    // Step 1: SELECT up to MAX_RUNS_PER_TICK queued runs (uses LIMIT)
+    const queuedRuns = await db
       .select({ id: workflowRuns.id, kind: workflowRuns.kind })
       .from(workflowRuns)
       .where(
-        and(eq(workflowRuns.status, 'pending'), lte(workflowRuns.runAt, now))
+        and(eq(workflowRuns.status, 'queued'), lte(workflowRuns.runAt, now))
       )
       .limit(MAX_RUNS_PER_TICK);
 
-    if (pendingRuns.length === 0) {
+    if (queuedRuns.length === 0) {
       return NextResponse.json({ ok: true, processed: 0 });
     }
 
     // Step 2: CAS claim by ID — atomically transition to 'running'
-    const pendingIds = pendingRuns.map(r => r.id);
+    const queuedIds = queuedRuns.map(r => r.id);
     const claimed = await db
       .update(workflowRuns)
       .set({ status: 'running', updatedAt: now })
       .where(
         and(
-          inArray(workflowRuns.id, pendingIds),
-          eq(workflowRuns.status, 'pending')
+          inArray(workflowRuns.id, queuedIds),
+          eq(workflowRuns.status, 'queued')
         )
       )
       .returning({

--- a/apps/web/lib/db/schema/connectors.ts
+++ b/apps/web/lib/db/schema/connectors.ts
@@ -511,7 +511,7 @@ export const workflowRuns = pgTable(
       .notNull()
       .references(() => users.id, { onDelete: 'cascade' }),
 
-    status: workflowRunStatusEnum('status').notNull().default('pending'),
+    status: workflowRunStatusEnum('status').notNull().default('queued'),
 
     /** Name of the step currently executing or next to run on resume. */
     currentStep: text('current_step'),

--- a/apps/web/lib/db/schema/enums.ts
+++ b/apps/web/lib/db/schema/enums.ts
@@ -771,12 +771,11 @@ export const agentRunStatusEnum = pgEnum('agent_run_status', [
 ]);
 
 export const workflowRunStatusEnum = pgEnum('workflow_run_status', [
-  'pending',
+  'queued',
   'running',
   'waiting_for_approval',
   'completed',
   'failed',
-  'cancelled',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/apps/web/tests/integration/connectors/suggested-actions-approve.test.ts
+++ b/apps/web/tests/integration/connectors/suggested-actions-approve.test.ts
@@ -112,7 +112,7 @@ describe('CAS approve: approve → 200 first call, 409 second', () => {
     await db.insert(workflowRuns).values({
       kind: 'execute_approved_action',
       userId: USER_ID,
-      status: 'pending' as const,
+      status: 'queued' as const,
       currentStep: 'create_calendar_event',
       stepOutputs: { approvalId: ACTION_ID },
       runAt: new Date(),
@@ -209,7 +209,7 @@ describe('CAS concurrent approve: exactly one workflow_runs row', () => {
         await db.insert(workflowRuns).values({
           kind: 'execute_approved_action',
           userId: USER_ID,
-          status: 'pending' as const,
+          status: 'queued' as const,
           currentStep: 'create_calendar_event',
           stepOutputs: { approvalId: ACTION_ID },
           runAt: new Date(),

--- a/apps/web/tests/unit/api/cron/process-workflow-runs.test.ts
+++ b/apps/web/tests/unit/api/cron/process-workflow-runs.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockAnd,
+  mockCaptureError,
+  mockCaptureWarning,
+  mockDb,
+  mockEq,
+  mockExecuteApprovedAction,
+  mockInArray,
+  mockLoggerInfo,
+  mockLoggerWarn,
+  mockLte,
+  mockMarkWorkflowFailed,
+} = vi.hoisted(() => ({
+  mockAnd: vi.fn((...conditions: unknown[]) => ({ type: 'and', conditions })),
+  mockCaptureError: vi.fn(),
+  mockCaptureWarning: vi.fn(),
+  mockDb: {
+    select: vi.fn(),
+    update: vi.fn(),
+  },
+  mockEq: vi.fn((column: unknown, value: unknown) => ({
+    type: 'eq',
+    column,
+    value,
+  })),
+  mockExecuteApprovedAction: vi.fn(),
+  mockInArray: vi.fn((column: unknown, values: unknown[]) => ({
+    type: 'inArray',
+    column,
+    values,
+  })),
+  mockLoggerInfo: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+  mockLte: vi.fn((column: unknown, value: unknown) => ({
+    type: 'lte',
+    column,
+    value,
+  })),
+  mockMarkWorkflowFailed: vi.fn(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: mockAnd,
+  eq: mockEq,
+  inArray: mockInArray,
+  lte: mockLte,
+}));
+
+vi.mock('@/lib/connectors/workflows/execute-approved-action', () => ({
+  executeApprovedAction: mockExecuteApprovedAction,
+  markWorkflowFailed: mockMarkWorkflowFailed,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: mockDb,
+}));
+
+vi.mock('@/lib/env-server', () => ({
+  env: { CRON_SECRET: 'test-secret' },
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: mockCaptureError,
+  captureWarning: mockCaptureWarning,
+}));
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    error: vi.fn(),
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
+  },
+}));
+
+function setupDbChains() {
+  const selectChain = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue([
+      {
+        id: 'workflow-run-1',
+        kind: 'execute_approved_action',
+      },
+    ]),
+  };
+  const updateChain = {
+    set: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    returning: vi.fn().mockResolvedValue([
+      {
+        id: 'workflow-run-1',
+        kind: 'execute_approved_action',
+      },
+    ]),
+  };
+
+  mockDb.select.mockReturnValue(selectChain);
+  mockDb.update.mockReturnValue(updateChain);
+
+  return { selectChain, updateChain };
+}
+
+describe('GET /api/cron/process-workflow-runs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockExecuteApprovedAction.mockResolvedValue(undefined);
+    mockMarkWorkflowFailed.mockResolvedValue(undefined);
+  });
+
+  it('claims queued workflow runs before executing them', async () => {
+    const { selectChain, updateChain } = setupDbChains();
+    const { workflowRuns } = await import('@/lib/db/schema/connectors');
+    const { GET } = await import('@/app/api/cron/process-workflow-runs/route');
+
+    const response = await GET(
+      new Request('http://localhost/api/cron/process-workflow-runs', {
+        headers: { authorization: 'Bearer test-secret' },
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({
+      ok: true,
+      claimed: 1,
+      processed: 1,
+      failed: 0,
+    });
+    const queuedStatusChecks = mockEq.mock.calls.filter(
+      ([column, value]) => column === workflowRuns.status && value === 'queued'
+    );
+    expect(queuedStatusChecks).toHaveLength(2);
+    expect(updateChain.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'running' })
+    );
+    expect(selectChain.limit).toHaveBeenCalledWith(20);
+    expect(mockExecuteApprovedAction).toHaveBeenCalledWith({
+      workflowRunId: 'workflow-run-1',
+    });
+    expect(mockCaptureWarning).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Align `workflowRunStatusEnum` and the `workflow_runs.status` default with the production enum: `queued`, `running`, `waiting_for_approval`, `completed`, `failed`.
- Enqueue approved connector actions as `queued`.
- Update `/api/cron/process-workflow-runs` to select and CAS-claim `queued` rows, with a regression test for the processor path.

## Root Cause
Sentry `JOVIE-WEB-KP` was thrown by `/api/cron/process-workflow-runs` because production PostgreSQL rejects `workflow_run_status = 'pending'`. The applied migration and production database both use `queued` as the initial workflow-run state.

Read-only production verification returned:

```json
{
  "workflow_run_status": [
    "queued",
    "running",
    "waiting_for_approval",
    "completed",
    "failed"
  ],
  "status_default": "'queued'::workflow_run_status"
}
```

## Verification
- `pnpm --filter web exec vitest run tests/unit/api/cron/process-workflow-runs.test.ts` passed: 1 file, 1 test.
- `pnpm --filter web exec vitest run --config vitest.config.ci.mts tests/integration/connectors/suggested-actions-approve.test.ts` passed: 1 file, 5 tests.
- `pnpm biome check --write apps/web/lib/db/schema/enums.ts apps/web/lib/db/schema/connectors.ts apps/web/app/api/cron/process-workflow-runs/route.ts 'apps/web/app/api/connectors/suggested-actions/[id]/approve/route.ts' apps/web/tests/integration/connectors/suggested-actions-approve.test.ts apps/web/tests/unit/api/cron/process-workflow-runs.test.ts` passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- `pnpm --filter @jovie/web run drizzle:check` passed.
- `git diff --check` passed.
- Push hook passed: `biome check . && pnpm --filter=@jovie/web run pre-push`.

## Check Notes
- `pnpm --filter @jovie/web run typecheck:tests` is red in the current tree on existing repo-wide script and test fixture types, including `scripts/drizzle-migrate.ts:213`, `scripts/generate-brand-assets.ts:265`, and `tests/unit/profile/ProfileUnifiedDrawerReleases.test.tsx`.
