### PR TITLE
test(web): stabilize promptfoo rate-limit eval

### DIFF
--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -54,6 +54,7 @@ const EVAL_CONVERSATION_ID = 'promptfoo-eval-conversation';
 const EVAL_USER_ID = 'promptfoo-eval-user';
 const WEB_CHAT_ROUTE_PATH = '/api/chat';
 const WEB_CHAT_REQUEST_ID = 'promptfoo-web-chat-route';
+const WEB_CHAT_EVAL_EPOCH_SECONDS = 1_700_000_000;
 const MOBILE_CHAT_ROUTE_PATH = '/api/mobile/v1/chat/turns';
 const MAX_WEB_MESSAGES_PER_REQUEST = 50;
 const MAX_WEB_MESSAGE_LENGTH = 4000;
@@ -373,8 +374,11 @@ function toNullableString(value: unknown): string | null {
     : null;
 }
 
-function buildRateLimitHeaders(retryAfterSeconds: number) {
-  const reset = Math.floor((Date.now() + retryAfterSeconds * 1000) / 1000);
+function buildRateLimitHeaders(
+  retryAfterSeconds: number,
+  nowEpochSeconds = WEB_CHAT_EVAL_EPOCH_SECONDS
+) {
+  const reset = nowEpochSeconds + retryAfterSeconds;
   return {
     'X-RateLimit-Limit': '10',
     'X-RateLimit-Remaining': '0',


### PR DESCRIPTION
## Summary
- Make the Promptfoo web-chat route rate-limit reset header deterministic in eval output
- Keep the change scoped to the eval-only provider adapter

## Verification
- `pnpm biome check apps/web/tests/eval/promptfoo/jovie-chat-provider.ts`
- `pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern route --no-cache` (9/9 passed; Promptfoo emitted a PostHog flush warning after success)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`

Fixes JOV-2574

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced web-chat evaluation tests with deterministic rate-limiting calculations for improved testing consistency and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9632?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->