### PR TITLE
test(promptfoo): cover chat tool ui registry

### DIFF
--- a/apps/web/lib/chat/tool-ui-registry.ts
+++ b/apps/web/lib/chat/tool-ui-registry.ts
@@ -59,6 +59,14 @@ export const TOOL_UI_REGISTRY = {
     successTitle: 'Profile updated',
     errorTitle: "Couldn't update your profile",
   },
+  importBioFromUrl: {
+    label: 'Bio import',
+    uiHint: 'status',
+    renderer: 'status',
+    loadingTitle: 'Importing your bio…',
+    successTitle: 'Bio imported',
+    errorTitle: "Couldn't import that bio",
+  },
   checkCanvasStatus: {
     label: 'Canvas',
     uiHint: 'status',

--- a/apps/web/tests/eval/promptfoo/README.md
+++ b/apps/web/tests/eval/promptfoo/README.md
@@ -2,7 +2,7 @@
 
 Runs a small Promptfoo suite against three local adapters:
 
-- A deterministic tool-contract adapter for chat and onboarding tool availability, schemas, stubbed outputs, and no-spend guarantees.
+- A deterministic tool-contract adapter for chat and onboarding tool availability, schemas, tool UI registry coverage, stubbed outputs, and no-spend guarantees.
 - The production `executeChatTurn()` path used by `/api/chat`, with synthetic Luna Waves fixtures and eval-only tool stubs. This live path is manual-only because it calls the model provider.
 - A deterministic route-contract adapter for `POST /api/chat`, covering unauthenticated requests, branch-ordering for the chat kill switch, invalid JSON, message validation, missing profile context, client-turn preconditions, rate-limit responses, and contract-only pre-dispatch success without starting Next, Clerk, or the database.
 - A deterministic route-contract adapter for `POST /api/mobile/v1/chat/turns`, covering unauthenticated, invalid JSON, invalid-body variants, and `MOBILE_CHAT_RUNTIME_DISABLED` responses without starting Next or Clerk.

--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -809,6 +809,32 @@ function assertToolInventoryCovered(output) {
   return pass();
 }
 
+function assertToolUiRegistryCovered(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'tool-inventory') {
+    return fail('case did not run through the tool-inventory adapter');
+  }
+  if (
+    Array.isArray(payload.missingToolUiRegistryNames) &&
+    payload.missingToolUiRegistryNames.length > 0
+  ) {
+    return fail(
+      `missing tool UI registry coverage: ${payload.missingToolUiRegistryNames.join(', ')}`
+    );
+  }
+  if (
+    Array.isArray(payload.staleToolUiRegistryNames) &&
+    payload.staleToolUiRegistryNames.length > 0
+  ) {
+    return fail(
+      `stale tool UI registry entries: ${payload.staleToolUiRegistryNames.join(', ')}`
+    );
+  }
+
+  return pass();
+}
+
 module.exports = {
   assertNoPromptLeak,
   assertGroundedReleaseLeadTime,
@@ -846,4 +872,5 @@ module.exports = {
   assertSafeSocialUrl,
   assertFailedToolResultPreserved,
   assertToolInventoryCovered,
+  assertToolUiRegistryCovered,
 };

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -7,6 +7,7 @@ import {
   ONBOARDING_TOOLS,
   TOOL_SCHEMAS,
 } from '@/lib/chat/tool-schemas';
+import { TOOL_UI_REGISTRY } from '@/lib/chat/tool-ui-registry';
 import type { ReleaseContext } from '@/lib/chat/types';
 import { getEntitlements, type PlanId } from '@/lib/entitlements/registry';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
@@ -250,6 +251,7 @@ const FREE_APP_TOOL_NAMES = [
 ] as const;
 
 const ALL_EVAL_TOOL_NAMES = Object.keys(ALL_EVAL_TOOL_SCHEMAS).sort();
+const TOOL_UI_REGISTRY_NAMES = Object.keys(TOOL_UI_REGISTRY).sort();
 
 function toObject(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -1089,6 +1091,12 @@ function evaluateToolInventory(vars: EvalVars) {
   const missingToolNames = ALL_EVAL_TOOL_NAMES.filter(
     toolName => !coveredSet.has(toolName)
   );
+  const missingToolUiRegistryNames = ALL_EVAL_TOOL_NAMES.filter(
+    toolName => !Object.hasOwn(TOOL_UI_REGISTRY, toolName)
+  );
+  const staleToolUiRegistryNames = TOOL_UI_REGISTRY_NAMES.filter(
+    toolName => !Object.hasOwn(ALL_EVAL_TOOL_SCHEMAS, toolName)
+  );
 
   return {
     target: 'tool-inventory',
@@ -1102,6 +1110,9 @@ function evaluateToolInventory(vars: EvalVars) {
     coveredToolNames: [...coveredSet].sort(),
     missingToolNames,
     unknownCoveredTools,
+    toolUiRegistryNames: TOOL_UI_REGISTRY_NAMES,
+    missingToolUiRegistryNames,
+    staleToolUiRegistryNames,
     freeAppToolNames: [...FREE_APP_TOOL_NAMES],
     onboardingToolNames: [...ONBOARDING_TOOLS],
     paidToolNames: [...PAID_TOOL_NAMES],

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -648,6 +648,8 @@ tests:
         value: file://assertions.cjs:assertDeterministicNoSpend
       - type: javascript
         value: file://assertions.cjs:assertToolInventoryCovered
+      - type: javascript
+        value: file://assertions.cjs:assertToolUiRegistryCovered
 
   - description: Tool contract accepts free avatar upload
     metadata:

--- a/apps/web/tests/unit/chat/tool-events.test.ts
+++ b/apps/web/tests/unit/chat/tool-events.test.ts
@@ -19,6 +19,7 @@ const CHAT_ROUTE_TOOL_NAMES = [
   'submitFeedback',
   'showTopInsights',
   'proposeProfileEdit',
+  'importBioFromUrl',
   'checkCanvasStatus',
   'suggestRelatedArtists',
   'writeWorldClassBio',


### PR DESCRIPTION
## Summary
- Extend deterministic Promptfoo tool inventory output to include chat tool UI registry coverage.
- Fail the inventory eval when an AI chat/onboarding tool has no explicit UI registry entry or when the registry contains stale tool names.
- Add the missing `importBioFromUrl` UI registry entry and include it in the existing tool-events registry unit coverage.

## Cost Control
Ship now / Re-evaluate when / Then:
- Ship now: this is a zero-model deterministic gate and caught a real current tool UI drift gap.
- Re-evaluate when: default `pnpm run evals` exceeds 2 minutes in CI or tool inventory churn creates repeated false positives.
- Then: split schema, availability, and UI registry inventory into generated fixtures from exported constants.

## Verification
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml`
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 pnpm run evals` -> 75/75 passed
- `pnpm --filter @jovie/web exec vitest run tests/unit/chat/tool-events.test.ts` -> 6/6 passed
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/lib/chat/tool-ui-registry.ts apps/web/tests/unit/chat/tool-events.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Commit hook: proxy guard, Biome, ESLint, web typecheck
- Pre-push hook: full Biome, proxy guard, Tailwind guard, web typecheck, Biome lint

## Known Existing Blocker
- `pnpm --filter @jovie/web run typecheck:tests` still fails on existing broad test/script typing issues tracked by JOV-2564. The filtered run had no hits for `tests/eval/promptfoo`, `tool-ui-registry`, or `tool-events.test`.

Linear: JOV-2578


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new "Bio import" tool with status-based UI configuration.

* **Tests**
  * Added validation to verify all tools include proper UI registry definitions.
  * Extended test coverage to detect missing or outdated tool UI configurations.

* **Documentation**
  * Updated evaluation documentation to clarify tool UI registry coverage scope.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->