### PR TITLE
test(promptfoo): fail closed on ui registry payloads

### DIFF
--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -815,18 +815,18 @@ function assertToolUiRegistryCovered(output) {
   if (payload.target !== 'tool-inventory') {
     return fail('case did not run through the tool-inventory adapter');
   }
-  if (
-    Array.isArray(payload.missingToolUiRegistryNames) &&
-    payload.missingToolUiRegistryNames.length > 0
-  ) {
+  if (!Array.isArray(payload.missingToolUiRegistryNames)) {
+    return fail('missing tool-inventory field: missingToolUiRegistryNames');
+  }
+  if (!Array.isArray(payload.staleToolUiRegistryNames)) {
+    return fail('missing tool-inventory field: staleToolUiRegistryNames');
+  }
+  if (payload.missingToolUiRegistryNames.length > 0) {
     return fail(
       `missing tool UI registry coverage: ${payload.missingToolUiRegistryNames.join(', ')}`
     );
   }
-  if (
-    Array.isArray(payload.staleToolUiRegistryNames) &&
-    payload.staleToolUiRegistryNames.length > 0
-  ) {
+  if (payload.staleToolUiRegistryNames.length > 0) {
     return fail(
       `stale tool UI registry entries: ${payload.staleToolUiRegistryNames.join(', ')}`
     );


### PR DESCRIPTION
Closes JOV-2579.\n\n## Summary\n- Make the Promptfoo tool UI registry assertion fail when required inventory payload arrays are missing.\n- Keep the default eval path deterministic and no-cost.\n\n## Verification\n- pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml\n- env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 pnpm run evals\n- pnpm biome check apps/web/tests/eval/promptfoo/assertions.cjs\n- pnpm --filter @jovie/web run typecheck -- --pretty false\n- pre-push hook: biome check ., proxy guard, Tailwind guard, web typecheck, web lint\n\n## Cost Control\nShip now: one deterministic assertion hardening prevents a false-green tool inventory gate at CI-second cost.\nRe-evaluate when: Promptfoo provider output becomes typed end-to-end or the deterministic eval suite exceeds 2 minutes in CI.\nThen: replace assertion-specific guards with a shared schema parser for deterministic Promptfoo outputs.