### PR TITLE
fix(ci): use build-time sha in deploy health checks

### DIFF
--- a/apps/web/app/api/health/build-info/route.ts
+++ b/apps/web/app/api/health/build-info/route.ts
@@ -11,6 +11,8 @@ export function GET() {
   const version = process.env.NEXT_PUBLIC_APP_VERSION ?? '0.0.0';
   const environment = process.env.VERCEL_ENV;
   const isDevelopment = process.env.NODE_ENV !== 'production';
+  const buildSha = process.env.NEXT_PUBLIC_BUILD_SHA?.trim();
+  const runtimeCommitSha = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7);
 
   if (_cachedBuildId === undefined) {
     try {
@@ -32,7 +34,7 @@ export function GET() {
     buildId: _cachedBuildId,
     version,
     deployedAt: process.env.VERCEL_DEPLOYMENT_TIME || Date.now(),
-    commitSha: process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7),
+    commitSha: buildSha || runtimeCommitSha,
     environment,
   });
 }

--- a/apps/web/app/api/version/route.ts
+++ b/apps/web/app/api/version/route.ts
@@ -10,8 +10,13 @@ import { NextResponse } from 'next/server';
  * Cache-Control: no-store ensures each poll sees the live value.
  */
 export function GET() {
+  const buildId =
+    process.env.NEXT_PUBLIC_BUILD_SHA?.trim() ||
+    process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 7) ||
+    'dev';
+
   return NextResponse.json(
-    { buildId: process.env.VERCEL_GIT_COMMIT_SHA ?? 'dev' },
+    { buildId },
     { headers: { 'Cache-Control': 'no-store' } }
   );
 }

--- a/apps/web/tests/unit/api/health/build-info.critical.test.ts
+++ b/apps/web/tests/unit/api/health/build-info.critical.test.ts
@@ -1,32 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-const mutableEnv = process.env as Record<string, string | undefined>;
-let originalNodeEnv: string | undefined;
 let cwdSpy: ReturnType<typeof vi.spyOn> | undefined;
 
 describe('@critical GET /api/health/build-info', () => {
   beforeEach(() => {
-    originalNodeEnv = mutableEnv.NODE_ENV;
     vi.clearAllMocks();
     vi.resetModules();
+    vi.unstubAllEnvs();
     cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/__missing-build-id__');
   });
 
   afterEach(() => {
     cwdSpy?.mockRestore();
     cwdSpy = undefined;
-
-    if (originalNodeEnv === undefined) {
-      delete mutableEnv.NODE_ENV;
-      return;
-    }
-
-    mutableEnv.NODE_ENV = originalNodeEnv;
+    vi.unstubAllEnvs();
   });
 
   it('logs warning and returns fallback when build info read fails in production', async () => {
-    mutableEnv.NODE_ENV = 'production';
+    vi.stubEnv('NODE_ENV', 'production');
 
     const { GET } = await import('@/app/api/health/build-info/route');
     const response = GET();
@@ -38,8 +30,21 @@ describe('@critical GET /api/health/build-info', () => {
     );
   });
 
+  it('prefers build-time commit sha when available in production', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_BUILD_SHA', 'abcdef1');
+    vi.stubEnv('VERCEL_GIT_COMMIT_SHA', '1234567890abcdef');
+
+    const { GET } = await import('@/app/api/health/build-info/route');
+    const response = GET();
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body.commitSha).toBe('abcdef1');
+  });
+
   it('returns development build id without warning in development', async () => {
-    mutableEnv.NODE_ENV = 'development';
+    vi.stubEnv('NODE_ENV', 'development');
 
     const { GET } = await import('@/app/api/health/build-info/route');
     const response = GET();

--- a/apps/web/tests/unit/api/version.test.ts
+++ b/apps/web/tests/unit/api/version.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('GET /api/version', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('prefers the build-time SHA when available', async () => {
+    vi.stubEnv('NEXT_PUBLIC_BUILD_SHA', 'abcdef1');
+    vi.stubEnv('VERCEL_GIT_COMMIT_SHA', '1234567890abcdef');
+
+    const { GET } = await import('@/app/api/version/route');
+    const response = GET();
+
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(await response.json()).toEqual({ buildId: 'abcdef1' });
+  });
+
+  it('falls back to the runtime SHA when build-time SHA is missing', async () => {
+    vi.stubEnv('NEXT_PUBLIC_BUILD_SHA', '');
+    vi.stubEnv('VERCEL_GIT_COMMIT_SHA', '1234567890abcdef');
+
+    const { GET } = await import('@/app/api/version/route');
+    const response = GET();
+
+    expect(await response.json()).toEqual({ buildId: '1234567' });
+  });
+});


### PR DESCRIPTION
## Summary
- Make /api/health/build-info and /api/version prefer the build-time SHA (NEXT_PUBLIC_BUILD_SHA) before falling back to runtime Vercel metadata.
- Add unit coverage for build-time SHA precedence and the version route fallback.

## Verification
- pnpm biome check --write apps/web/app/api/health/build-info/route.ts apps/web/app/api/version/route.ts apps/web/tests/unit/api/health/build-info.critical.test.ts apps/web/tests/unit/api/version.test.ts
- pnpm --filter web exec vitest run tests/unit/api/health/build-info.critical.test.ts tests/unit/api/version.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false

## Context
This unblocks the staging canary by making the deploy health signal reflect the build that was actually produced in CI, instead of depending on runtime Vercel commit metadata that was serving older SHAs.