### PR TITLE
JOV-2581: Cover Promptfoo tool availability flags

### DIFF
--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -226,22 +226,31 @@ const MERCH_TOOL_NAMES = [
   'showArtistPayouts',
 ] as const;
 
-const PAID_TOOL_NAMES = [
-  ...FREE_TIER_TOOLS,
-  ...ACCOUNT_TOOL_NAMES,
-  'showTopInsights',
+const INSIGHT_TOOL_NAMES = ['showTopInsights'] as const;
+const ALBUM_ART_TOOL_NAMES = ['generateAlbumArt'] as const;
+const PROFILE_RELEASE_TOOL_NAMES = [
+  'createRelease',
+  'generateReleasePitch',
+] as const;
+const ALWAYS_PAID_TOOL_NAMES = [
   'proposeProfileEdit',
   'importBioFromUrl',
   'checkCanvasStatus',
   'suggestRelatedArtists',
   'writeWorldClassBio',
   'generateCanvasPlan',
-  'generateAlbumArt',
   'createPromoStrategy',
   'markCanvasUploaded',
   'formatLyrics',
-  'createRelease',
-  'generateReleasePitch',
+] as const;
+
+const PAID_TOOL_NAMES = [
+  ...FREE_TIER_TOOLS,
+  ...ACCOUNT_TOOL_NAMES,
+  ...INSIGHT_TOOL_NAMES,
+  ...ALWAYS_PAID_TOOL_NAMES,
+  ...ALBUM_ART_TOOL_NAMES,
+  ...PROFILE_RELEASE_TOOL_NAMES,
   ...MERCH_TOOL_NAMES,
 ] as const;
 
@@ -744,9 +753,62 @@ function buildEvalReleases(vars: EvalVars): ReleaseContext[] {
   }));
 }
 
-function getToolNamesForTurn(mode: 'app' | 'onboarding', plan: PlanId) {
+function toBillingVerification(value: unknown) {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim()
+    : 'verified';
+}
+
+function resolveToolAvailabilityFlags(plan: PlanId, vars: EvalVars) {
+  const planLimits = getEntitlements(plan);
+  const billingVerification = toBillingVerification(vars.billingVerification);
+  const planAllowsPaidTools = Boolean(planLimits.booleans.aiCanUseTools);
+  const aiCanUseTools =
+    planAllowsPaidTools && toBoolean(vars.aiCanUseTools, true);
+
+  return {
+    billingVerification,
+    paidToolsEnabled:
+      plan !== 'free' && billingVerification === 'verified' && aiCanUseTools,
+    insightsEnabled: toBoolean(vars.insightsEnabled, true),
+    albumArtEnabled: toBoolean(vars.albumArtEnabled, true),
+    canGenerateAlbumArt: toBoolean(vars.canGenerateAlbumArt, true),
+    resolvedProfileIdPresent: toBoolean(vars.resolvedProfileIdPresent, true),
+    merchEnabled: toBoolean(vars.merchEnabled, true),
+    canAccessMerchCreation: toBoolean(
+      vars.canAccessMerchCreation,
+      Boolean(planLimits.booleans.canAccessMerchCreation)
+    ),
+  };
+}
+
+function getToolNamesForTurn(
+  mode: 'app' | 'onboarding',
+  plan: PlanId,
+  vars: EvalVars = {}
+) {
   if (mode === 'onboarding') return ONBOARDING_TOOLS;
-  return plan === 'free' ? FREE_APP_TOOL_NAMES : PAID_TOOL_NAMES;
+
+  const freeTools = [...FREE_APP_TOOL_NAMES];
+  const flags = resolveToolAvailabilityFlags(plan, vars);
+  if (!flags.paidToolsEnabled) return freeTools;
+
+  const toolNames: string[] = [...freeTools, ...ALWAYS_PAID_TOOL_NAMES];
+
+  if (flags.insightsEnabled) {
+    toolNames.push(...INSIGHT_TOOL_NAMES);
+  }
+  if (flags.albumArtEnabled && flags.canGenerateAlbumArt) {
+    toolNames.push(...ALBUM_ART_TOOL_NAMES);
+  }
+  if (flags.resolvedProfileIdPresent) {
+    toolNames.push(...PROFILE_RELEASE_TOOL_NAMES);
+  }
+  if (flags.merchEnabled && flags.canAccessMerchCreation) {
+    toolNames.push(...MERCH_TOOL_NAMES);
+  }
+
+  return toolNames;
 }
 
 function configuredToolResult(
@@ -1030,7 +1092,8 @@ function evaluateToolContract(vars: EvalVars) {
     ALL_EVAL_TOOL_SCHEMAS[toolName as keyof typeof ALL_EVAL_TOOL_SCHEMAS];
   const input = Object.hasOwn(vars, 'toolInput') ? vars.toolInput : {};
   const schemaResult = schema.inputSchema.safeParse(input);
-  const availableToolNames = [...getToolNamesForTurn(mode, plan)];
+  const availabilityFlags = resolveToolAvailabilityFlags(plan, vars);
+  const availableToolNames = [...getToolNamesForTurn(mode, plan, vars)];
   const available = (availableToolNames as readonly string[]).includes(
     toolName
   );
@@ -1062,6 +1125,7 @@ function evaluateToolContract(vars: EvalVars) {
     toolName,
     mode,
     plan,
+    availabilityFlags,
     available,
     availableToolNames,
     schemaValid: schemaResult.success,

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -1551,6 +1551,244 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertToolDidNotExecute
 
+  - description: Onboarding blocks billing portal tool
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Open billing settings."
+      target: tool-contract
+      toolName: openBillingPortal
+      mode: onboarding
+      plan: free
+      toolInput: {}
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolUnavailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolDidNotExecute
+
+  - description: Billing verification outage blocks paid tool execution
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Generate cover art while billing cannot be verified."
+      target: tool-contract
+      toolName: generateAlbumArt
+      mode: app
+      plan: pro
+      billingVerification: unavailable
+      toolInput:
+        releaseTitle: Neon Reef
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolUnavailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolDidNotExecute
+
+  - description: Billing verification outage keeps account tools available
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Show my current usage while billing cannot be verified."
+      target: tool-contract
+      toolName: showUsage
+      mode: app
+      plan: pro
+      billingVerification: unavailable
+      toolInput: {}
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolExecuted
+
+  - description: Paid tool access flag blocks advanced tools
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Show my top insights."
+      target: tool-contract
+      toolName: showTopInsights
+      mode: app
+      plan: pro
+      aiCanUseTools: false
+      toolInput: {}
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolUnavailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolDidNotExecute
+
+  - description: Disabled insights hide top insights tool
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Show my top insights."
+      target: tool-contract
+      toolName: showTopInsights
+      mode: app
+      plan: pro
+      insightsEnabled: false
+      toolInput: {}
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolUnavailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolDidNotExecute
+
+  - description: Disabled album art flag hides album art tool
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Generate cover art."
+      target: tool-contract
+      toolName: generateAlbumArt
+      mode: app
+      plan: pro
+      albumArtEnabled: false
+      toolInput:
+        releaseTitle: Neon Reef
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolUnavailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolDidNotExecute
+
+  - description: Missing album art capability hides album art tool
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Generate cover art."
+      target: tool-contract
+      toolName: generateAlbumArt
+      mode: app
+      plan: pro
+      canGenerateAlbumArt: false
+      toolInput:
+        releaseTitle: Neon Reef
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolUnavailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolDidNotExecute
+
+  - description: Missing resolved profile hides release creation
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Create a release."
+      target: tool-contract
+      toolName: createRelease
+      mode: app
+      plan: pro
+      resolvedProfileIdPresent: false
+      toolInput:
+        title: Neon Reef
+        releaseType: single
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolUnavailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolDidNotExecute
+
+  - description: Missing resolved profile hides release pitch generation
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Write a playlist pitch."
+      target: tool-contract
+      toolName: generateReleasePitch
+      mode: app
+      plan: pro
+      resolvedProfileIdPresent: false
+      toolInput:
+        releaseTitle: Neon Reef
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolUnavailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolDidNotExecute
+
+  - description: Disabled merch flag hides merch creation
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Make merch."
+      target: tool-contract
+      toolName: createMerch
+      mode: app
+      plan: pro
+      merchEnabled: false
+      toolInput:
+        prompt: "Moonlit wave logo"
+        itemType: tee
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolUnavailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolDidNotExecute
+
+  - description: Missing merch entitlement hides payout report
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Show artist payout liability."
+      target: tool-contract
+      toolName: showArtistPayouts
+      mode: app
+      plan: pro
+      canAccessMerchCreation: false
+      toolInput: {}
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolUnavailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolDidNotExecute
+
   - description: Invalid merch selection without option does not execute
     metadata:
       cost: deterministic


### PR DESCRIPTION
## Summary

Extends the deterministic Promptfoo tool-contract suite to cover production-style availability flags for chat tools.

## Changes

- Adds eval-only availability resolution for billing verification, paid tool access, insights, album art capability, resolved profile presence, and merch entitlement flags.
- Exposes the resolved availability flags in deterministic Promptfoo output for debugging.
- Adds 11 deterministic no-spend seed cases that prove blocked tools do not execute while safe account tools remain available during billing verification outages.

## Verification

- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml`
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 pnpm run evals` — 86/86 passing
- `pnpm biome check apps/web/tests/eval/promptfoo`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-push hook: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint

<!-- agent-run-artifact
{
  "id": "jov-2581-promptfoo-tool-availability-flags",
  "source": "github",
  "sourceRunId": "64c5b317bf296a3e221c4cbb74f6086998bf3c6c",
  "kind": "workflow",
  "status": "review",
  "title": "Add deterministic Promptfoo availability-flag coverage for chat tools",
  "summary": "Deterministic Promptfoo tool-contract coverage now exercises production-style availability flags for billing verification, paid tool access, insights, album art, profile-scoped release tools, and merch entitlements without model or persistence calls.",
  "modelRoute": "deterministic",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr",
    "ready_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2581",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2581/add-deterministic-promptfoo-availability-flag-coverage-for-chat-tools",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9656",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9656",
      "summary": "Local deterministic Promptfoo evals passed 86/86 with all model API keys unset and JOVIE_RUN_LIVE_EVALS=0.",
      "checkedAt": "2026-05-25T07:27:38.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9656",
      "summary": "Reviewed the diff for deterministic-only output, no model path, no persistence path, and no production behavior changes.",
      "checkedAt": "2026-05-25T07:27:38.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9656",
      "summary": "Branch codex/jov-2581-promptfoo-tool-availability-flags was committed and pushed with pre-push checks passing.",
      "checkedAt": "2026-05-25T07:27:38.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": "Verification used deterministic local commands and GitHub checks only; no live LLM evals ran."
  },
  "blockedReason": null,
  "createdAt": "2026-05-25T07:27:38.000Z",
  "updatedAt": "2026-05-25T07:27:38.000Z",
  "metadata": {
    "changedFiles": [
      "apps/web/tests/eval/promptfoo/jovie-chat-provider.ts",
      "apps/web/tests/eval/promptfoo/promptfooconfig.yaml"
    ],
    "checksRun": [
      "pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml",
      "env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 pnpm run evals",
      "pnpm biome check apps/web/tests/eval/promptfoo",
      "pnpm --filter @jovie/web run typecheck -- --pretty false",
      "git diff --check",
      "pre-push hook"
    ],
    "promptfooCases": 86,
    "liveEvalPolicy": "deterministic-only; no model call path in tool-contract target"
  }
}
-->
