### PR TITLE
JOV-2583: Cover Promptfoo tool events

### DIFF
--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -835,6 +835,192 @@ function assertToolUiRegistryCovered(output) {
   return pass();
 }
 
+function firstEvent(payload) {
+  return Array.isArray(payload.events) ? payload.events[0] : undefined;
+}
+
+function firstMessagePart(payload) {
+  return Array.isArray(payload.messageParts)
+    ? payload.messageParts[0]
+    : undefined;
+}
+
+function assertToolEventInventoryCovered(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'tool-event-contract') {
+    return fail('case did not run through the tool-event-contract adapter');
+  }
+  if (payload.source !== 'v2') {
+    return fail(`expected v2 tool events, got ${String(payload.source)}`);
+  }
+  if (payload.schemaValid !== true) {
+    return fail('tool events did not pass persisted schema validation');
+  }
+  if (
+    Array.isArray(payload.missingEventToolNames) &&
+    payload.missingEventToolNames.length > 0
+  ) {
+    return fail(
+      `missing persisted tool events: ${payload.missingEventToolNames.join(', ')}`
+    );
+  }
+  if (
+    Array.isArray(payload.missingHydratedToolNames) &&
+    payload.missingHydratedToolNames.length > 0
+  ) {
+    return fail(
+      `missing hydrated tool parts: ${payload.missingHydratedToolNames.join(', ')}`
+    );
+  }
+
+  return pass();
+}
+
+function assertToolEventHydratesSuccess(output) {
+  const payload = parseOutput(output);
+  const event = firstEvent(payload);
+  const part = firstMessagePart(payload);
+
+  if (payload.target !== 'tool-event-contract') {
+    return fail('case did not run through the tool-event-contract adapter');
+  }
+  if (payload.schemaValid !== true) {
+    return fail('tool event schema was invalid');
+  }
+  if (event?.state !== 'succeeded') {
+    return fail(`expected succeeded event, got ${String(event?.state)}`);
+  }
+  if (part?.state !== 'output-available') {
+    return fail(`expected output-available part, got ${String(part?.state)}`);
+  }
+  if (part?.toolName !== payload.toolName) {
+    return fail('hydrated part tool name did not match');
+  }
+
+  return pass();
+}
+
+function assertToolEventFailurePreserved(output) {
+  const payload = parseOutput(output);
+  const event = firstEvent(payload);
+  const part = firstMessagePart(payload);
+
+  if (payload.source !== 'legacy') {
+    return fail(`expected legacy source, got ${String(payload.source)}`);
+  }
+  if (event?.state !== 'failed') {
+    return fail(`expected failed event, got ${String(event?.state)}`);
+  }
+  if (!/provider unavailable/i.test(event?.errorMessage ?? '')) {
+    return fail('failed event did not preserve provider error text');
+  }
+  if (part?.state !== 'output-error') {
+    return fail(`expected output-error part, got ${String(part?.state)}`);
+  }
+  if (!/provider unavailable/i.test(part?.errorText ?? '')) {
+    return fail('hydrated failed part did not preserve provider error text');
+  }
+
+  return pass();
+}
+
+function assertToolEventApprovalRequested(output) {
+  const payload = parseOutput(output);
+  const event = firstEvent(payload);
+  const part = firstMessagePart(payload);
+
+  if (event?.state !== 'needs-approval') {
+    return fail(`expected needs-approval event, got ${String(event?.state)}`);
+  }
+  if (part?.state !== 'approval-requested') {
+    return fail(`expected approval-requested part, got ${String(part?.state)}`);
+  }
+  if (!part?.approval?.id) {
+    return fail('approval-requested part is missing approval id');
+  }
+
+  return pass();
+}
+
+function assertToolEventApprovalResponded(output) {
+  const payload = parseOutput(output);
+  const event = firstEvent(payload);
+  const part = firstMessagePart(payload);
+
+  if (event?.approval?.approved !== true) {
+    return fail('event did not preserve approved=true');
+  }
+  if (part?.state !== 'approval-responded') {
+    return fail(`expected approval-responded part, got ${String(part?.state)}`);
+  }
+  if (part?.approval?.approved !== true) {
+    return fail('hydrated part did not preserve approved=true');
+  }
+
+  return pass();
+}
+
+function assertToolEventDeniedHydrated(output) {
+  const payload = parseOutput(output);
+  const event = firstEvent(payload);
+  const part = firstMessagePart(payload);
+
+  if (event?.state !== 'denied') {
+    return fail(`expected denied event, got ${String(event?.state)}`);
+  }
+  if (part?.state !== 'output-denied') {
+    return fail(`expected output-denied part, got ${String(part?.state)}`);
+  }
+  if (part?.approval?.approved !== false) {
+    return fail('hydrated denied part did not preserve approved=false');
+  }
+
+  return pass();
+}
+
+function assertToolEventDedupeUsesLatest(output) {
+  const payload = parseOutput(output);
+  const event = firstEvent(payload);
+  const part = firstMessagePart(payload);
+
+  if (!Array.isArray(payload.events) || payload.events.length !== 1) {
+    return fail(`expected one deduped event, got ${payload.events?.length}`);
+  }
+  if (event?.state !== 'succeeded') {
+    return fail(`expected latest succeeded event, got ${String(event?.state)}`);
+  }
+  if (!/latest synthetic result/i.test(event?.summary ?? '')) {
+    return fail('deduped event did not keep latest summary');
+  }
+  if (part?.state !== 'output-available') {
+    return fail(`expected output-available part, got ${String(part?.state)}`);
+  }
+
+  return pass();
+}
+
+function assertToolEventInvalidRejected(output) {
+  const payload = parseOutput(output);
+
+  if (payload.source !== 'invalid') {
+    return fail(`expected invalid source, got ${String(payload.source)}`);
+  }
+  if (payload.schemaValid !== true) {
+    return fail(
+      'empty invalid decode result should still satisfy event schema'
+    );
+  }
+  if (Array.isArray(payload.events) && payload.events.length > 0) {
+    return fail('invalid payload produced persisted tool events');
+  }
+  if (Array.isArray(payload.messageParts) && payload.messageParts.length > 0) {
+    return fail('invalid payload produced hydrated message parts');
+  }
+
+  return pass();
+}
+
 module.exports = {
   assertNoPromptLeak,
   assertGroundedReleaseLeadTime,
@@ -873,4 +1059,12 @@ module.exports = {
   assertFailedToolResultPreserved,
   assertToolInventoryCovered,
   assertToolUiRegistryCovered,
+  assertToolEventInventoryCovered,
+  assertToolEventHydratesSuccess,
+  assertToolEventFailurePreserved,
+  assertToolEventApprovalRequested,
+  assertToolEventApprovalResponded,
+  assertToolEventDeniedHydrated,
+  assertToolEventDedupeUsesLatest,
+  assertToolEventInvalidRejected,
 };

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -3,6 +3,12 @@ import { z } from 'zod';
 import { APP_ROUTES } from '@/constants/routes';
 import { executeChatTurn, selectKnowledgeContextForTurn } from '@/lib/chat/run';
 import {
+  decodeToolEvents,
+  type PersistedToolEvent,
+  persistedToolEventsSchema,
+  toolEventToMessagePart,
+} from '@/lib/chat/tool-events';
+import {
   FREE_TIER_TOOLS,
   ONBOARDING_TOOLS,
   TOOL_SCHEMAS,
@@ -21,6 +27,7 @@ type EvalTarget =
   | 'chat-turn'
   | 'mobile-chat-route'
   | 'tool-contract'
+  | 'tool-event-contract'
   | 'tool-inventory'
   | 'web-chat-route';
 
@@ -293,6 +300,7 @@ function toTarget(value: unknown): EvalTarget {
   if (
     value === 'mobile-chat-route' ||
     value === 'tool-contract' ||
+    value === 'tool-event-contract' ||
     value === 'tool-inventory' ||
     value === 'web-chat-route'
   ) {
@@ -1183,6 +1191,182 @@ function evaluateToolInventory(vars: EvalVars) {
   };
 }
 
+function getToolUiHint(toolName: string) {
+  return TOOL_UI_REGISTRY[toolName as keyof typeof TOOL_UI_REGISTRY]?.uiHint;
+}
+
+function toolEvent(
+  toolName: string,
+  overrides: Partial<PersistedToolEvent> = {}
+): PersistedToolEvent {
+  return {
+    schemaVersion: 2,
+    toolCallId: `${toolName}-event`,
+    toolName,
+    state: 'succeeded',
+    input: { synthetic: true },
+    output: {
+      success: true,
+      title: `${toolName} completed`,
+      summary: `${toolName} completed`,
+    },
+    summary: `${toolName} completed`,
+    uiHint: getToolUiHint(toolName) ?? 'status',
+    ...overrides,
+  };
+}
+
+function buildToolEventInput(eventCase: string, toolName: string): unknown[] {
+  switch (eventCase) {
+    case 'inventory':
+      return ALL_EVAL_TOOL_NAMES.map(name => toolEvent(name));
+    case 'legacy-success':
+      return [
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            toolCallId: 'legacy-success-1',
+            toolName,
+            state: 'result',
+            args: { synthetic: true },
+            result: {
+              success: true,
+              title: 'Synthetic tool result',
+              summary: 'Synthetic tool result',
+            },
+          },
+        },
+      ];
+    case 'legacy-failure':
+      return [
+        {
+          type: 'tool-invocation',
+          toolInvocation: {
+            toolCallId: 'legacy-failure-1',
+            toolName,
+            state: 'result',
+            args: { synthetic: true },
+            result: {
+              success: false,
+              error: 'Synthetic provider unavailable',
+            },
+          },
+        },
+      ];
+    case 'approval-requested':
+      return [
+        toolEvent(toolName, {
+          toolCallId: 'approval-requested-1',
+          state: 'needs-approval',
+          output: undefined,
+          summary: undefined,
+          approval: { id: 'approval-requested-1-state' },
+        }),
+      ];
+    case 'approval-responded':
+      return [
+        toolEvent(toolName, {
+          toolCallId: 'approval-responded-1',
+          state: 'needs-approval',
+          output: undefined,
+          summary: undefined,
+          approval: {
+            id: 'approval-responded-1-state',
+            approved: true,
+            reason: 'Synthetic approval granted',
+          },
+        }),
+      ];
+    case 'denied':
+      return [
+        toolEvent(toolName, {
+          toolCallId: 'denied-1',
+          state: 'denied',
+          output: undefined,
+          summary: 'Synthetic approval denied',
+          errorMessage: 'Synthetic approval denied',
+          approval: {
+            id: 'denied-1-state',
+            approved: false,
+            reason: 'Synthetic approval denied',
+          },
+        }),
+      ];
+    case 'dedupe-latest':
+      return [
+        toolEvent(toolName, {
+          toolCallId: 'dedupe-1',
+          state: 'running',
+          output: undefined,
+          summary: undefined,
+        }),
+        toolEvent(toolName, {
+          toolCallId: 'dedupe-1',
+          state: 'succeeded',
+          output: {
+            success: true,
+            title: 'Latest synthetic result',
+          },
+          summary: 'Latest synthetic result',
+        }),
+      ];
+    case 'invalid':
+      return [{ type: 'not-a-tool-event', value: true }];
+    default:
+      throw new RangeError(`Invalid eval vars.eventCase: ${eventCase}`);
+  }
+}
+
+function evaluateToolEventContract(vars: EvalVars) {
+  const eventCase =
+    typeof vars.eventCase === 'string' ? vars.eventCase : 'legacy-success';
+  const toolName = toToolName(vars.toolName ?? 'showTopInsights');
+  const toolCalls = buildToolEventInput(eventCase, toolName);
+  const decoded = decodeToolEvents(toolCalls);
+  const schemaResult = persistedToolEventsSchema.safeParse(decoded.events);
+  const messageParts = schemaResult.success
+    ? schemaResult.data.map(event => toolEventToMessagePart(event))
+    : [];
+  const eventToolNames = decoded.events.map(event => event.toolName);
+  const hydratedToolNames = messageParts
+    .map(part => ('toolName' in part ? part.toolName : null))
+    .filter((name): name is string => typeof name === 'string');
+  const missingEventToolNames =
+    eventCase === 'inventory'
+      ? ALL_EVAL_TOOL_NAMES.filter(name => !eventToolNames.includes(name))
+      : [];
+  const missingHydratedToolNames =
+    eventCase === 'inventory'
+      ? ALL_EVAL_TOOL_NAMES.filter(name => !hydratedToolNames.includes(name))
+      : [];
+
+  return {
+    target: 'tool-event-contract',
+    adapter: 'tool-event-contract',
+    costTier: 'deterministic',
+    text: '',
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    toolName,
+    eventCase,
+    source: decoded.source,
+    schemaValid: schemaResult.success,
+    schemaErrors: schemaResult.success ? [] : schemaErrorMessages(schemaResult),
+    toolCalls,
+    events: decoded.events,
+    messageParts,
+    eventStates: decoded.events.map(event => event.state),
+    hydratedStates: messageParts.map(part =>
+      'state' in part ? part.state : null
+    ),
+    eventToolNames,
+    hydratedToolNames,
+    missingEventToolNames,
+    missingHydratedToolNames,
+  };
+}
+
 function toPromptfooUsage(usage: Record<string, unknown> | null | undefined) {
   if (!usage) return undefined;
 
@@ -1254,6 +1438,16 @@ export default class JovieChatPromptfooProvider {
 
     if (target === 'tool-contract') {
       const payload = evaluateToolContract(vars);
+      return {
+        output: JSON.stringify(payload),
+        raw: payload,
+        format: 'json',
+        latencyMs: Date.now() - startedAt,
+      };
+    }
+
+    if (target === 'tool-event-contract') {
+      const payload = evaluateToolEventContract(vars);
       return {
         output: JSON.stringify(payload),
         raw: payload,

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -651,6 +651,118 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertToolUiRegistryCovered
 
+  - description: Tool event inventory hydrates every eval tool
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Tool event inventory check"
+      target: tool-event-contract
+      toolName: showTopInsights
+      eventCase: inventory
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolEventInventoryCovered
+
+  - description: Legacy successful tool result hydrates to output card
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Hydrate a successful release pitch result."
+      target: tool-event-contract
+      toolName: generateReleasePitch
+      eventCase: legacy-success
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolEventHydratesSuccess
+
+  - description: Legacy failed tool result persists as failed event
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Hydrate a failed social removal result."
+      target: tool-event-contract
+      toolName: proposeSocialLinkRemoval
+      eventCase: legacy-failure
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolEventFailurePreserved
+
+  - description: Approval request hydrates without implying completion
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Hydrate a feedback approval request."
+      target: tool-event-contract
+      toolName: submitFeedback
+      eventCase: approval-requested
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolEventApprovalRequested
+
+  - description: Approval response preserves approved state
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Hydrate an approved feedback action."
+      target: tool-event-contract
+      toolName: submitFeedback
+      eventCase: approval-responded
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolEventApprovalResponded
+
+  - description: Denied tool action hydrates as denied
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Hydrate a denied profile edit."
+      target: tool-event-contract
+      toolName: proposeProfileEdit
+      eventCase: denied
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolEventDeniedHydrated
+
+  - description: Duplicate tool events keep latest state
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Hydrate duplicate merch events."
+      target: tool-event-contract
+      toolName: createMerch
+      eventCase: dedupe-latest
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolEventDedupeUsesLatest
+
+  - description: Invalid tool event payload is rejected without hydration
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Reject invalid tool event payload."
+      target: tool-event-contract
+      toolName: showUsage
+      eventCase: invalid
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolEventInvalidRejected
+
   - description: Tool contract accepts free avatar upload
     metadata:
       cost: deterministic


### PR DESCRIPTION
## Summary

Adds deterministic Promptfoo coverage for chat tool event persistence and hydration.

## Changes

- Adds a `tool-event-contract` Promptfoo provider target that exercises existing `decodeToolEvents`, `persistedToolEventsSchema`, and `toolEventToMessagePart` behavior with synthetic payloads.
- Adds inventory coverage proving every eval tool can produce a persisted event and hydrated UI message part.
- Adds seed cases for legacy success, failed `success: false`, approval requested, approval responded, denied, duplicate event dedupe, and invalid payload rejection.

## Verification

- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml`
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 pnpm run evals` — 94/94 passing
- `pnpm biome check apps/web/tests/eval/promptfoo`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-push hook: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint

<!-- agent-run-artifact
{
  "id": "jov-2583-promptfoo-tool-events",
  "source": "github",
  "sourceRunId": "f799cd72b2a44847745592e8af3a78b54af953ec",
  "kind": "workflow",
  "status": "review",
  "title": "Add deterministic Promptfoo tool-event persistence coverage",
  "summary": "Deterministic Promptfoo coverage now verifies synthetic chat tool results normalize into persisted tool events and hydrate back into UI message parts without losing success, failure, approval, denied, dedupe, or inventory state.",
  "modelRoute": "deterministic",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr",
    "ready_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2583",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2583/add-deterministic-promptfoo-tool-event-persistence-coverage",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9659",
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9659",
      "summary": "Local deterministic Promptfoo evals passed 94/94 with all model API keys unset and JOVIE_RUN_LIVE_EVALS=0.",
      "checkedAt": "2026-05-25T07:55:00.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9659",
      "summary": "Reviewed the diff for deterministic-only tool-event normalization and hydration coverage with no model, persistence, or production behavior path.",
      "checkedAt": "2026-05-25T07:55:00.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9659",
      "summary": "Branch codex/jov-2583-promptfoo-tool-events was committed and pushed with pre-push checks passing.",
      "checkedAt": "2026-05-25T07:55:00.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": "Verification used deterministic local commands and GitHub checks only; no live LLM evals ran."
  },
  "blockedReason": null,
  "createdAt": "2026-05-25T07:55:00.000Z",
  "updatedAt": "2026-05-25T07:55:00.000Z",
  "metadata": {
    "changedFiles": [
      "apps/web/tests/eval/promptfoo/jovie-chat-provider.ts",
      "apps/web/tests/eval/promptfoo/assertions.cjs",
      "apps/web/tests/eval/promptfoo/promptfooconfig.yaml"
    ],
    "checksRun": [
      "pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml",
      "env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 pnpm run evals",
      "pnpm biome check apps/web/tests/eval/promptfoo",
      "pnpm --filter @jovie/web run typecheck -- --pretty false",
      "git diff --check",
      "pre-push hook"
    ],
    "promptfooCases": 94,
    "liveEvalPolicy": "deterministic-only; no model call path in tool-event-contract target"
  }
}
-->
