### PR TITLE
test(promptfoo): cover slash skill visibility

### DIFF
--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -23,22 +23,64 @@ import type { ToolSchemaKey } from '@/lib/chat/tool-schemas';
  * or here (intentionally hidden) — no orphans.
  */
 export const HIDDEN_TOOLS: Readonly<Record<string, string>> = {
-  proposeProfileEdit:
-    'Triggered conversationally; surfacing as a slash command would duplicate proposeAvatarUpload + proposeSocialLink.',
-  showTopInsights: 'Surfaced as a home-screen card, not a slash command.',
+  checkHandle:
+    'Onboarding-only follow-up after Spotify identity; not useful as a standalone slash command.',
   checkCanvasStatus:
     'Diagnostic; results surface inside writeWorldClassBio / createPromoStrategy.',
-  suggestRelatedArtists:
-    'Always part of createPromoStrategy; never a standalone user action.',
-  writeWorldClassBio:
-    'Pro-only; chat surfaces it conversationally rather than via slash.',
-  generateCanvasPlan: 'Pro-only; surfaced via the release detail surface.',
+  confirmSpotifyArtist:
+    'Onboarding-only continuation from the Spotify picker; requires a selected candidate.',
+  createMerch:
+    'Conversational merch creation is gated by plan and rollout flags before broader slash exposure.',
   createPromoStrategy: 'Pro-only; surfaced via the release detail surface.',
+  createRelease: 'Surfaced in the releases dashboard; chat tool is a fallback.',
+  deleteOrArchiveMerchCard:
+    'Merch lifecycle action shown from merch cards, not the root slash menu.',
+  formatLyrics: 'Pro-only; surfaced via the lyrics surface, not slash.',
+  generateCanvasPlan: 'Pro-only; surfaced via the release detail surface.',
+  generateReleasePitch: 'Pro-only; surfaced via the release detail surface.',
+  importBioFromUrl:
+    'Triggered conversationally from an explicit URL import request before profile-edit preview.',
   markCanvasUploaded:
     'CRUD-style follow-up; surfaced inside the checkCanvasStatus card.',
-  formatLyrics: 'Pro-only; surfaced via the lyrics surface, not slash.',
-  createRelease: 'Surfaced in the releases dashboard; chat tool is a fallback.',
-  generateReleasePitch: 'Pro-only; surfaced via the release detail surface.',
+  openBillingPortal:
+    'Account handoff exposed from billing/account surfaces rather than chat slash.',
+  optimizeMerchCards:
+    'Merch optimization is an advanced card-level action, not a root slash command.',
+  pauseMerchCard:
+    'Merch lifecycle action shown from merch cards, not the root slash menu.',
+  previewMerchOptions:
+    'Conversational merch preview is gated by plan and rollout flags before broader slash exposure.',
+  proposeCheckout:
+    'Onboarding-only output from proposeNextStep; direct slash access would skip qualification.',
+  proposeNextStep:
+    'Onboarding evaluator trigger; direct slash access would bypass required intake signal.',
+  proposeProfileEdit:
+    'Triggered conversationally; surfacing as a slash command would duplicate proposeAvatarUpload + proposeSocialLink.',
+  publishMerchCard:
+    'Merch lifecycle action shown from merch cards, not the root slash menu.',
+  recordInterviewSignal:
+    'Silent onboarding telemetry; never user-visible as a command.',
+  reorderMerchCards:
+    'Merch ordering requires concrete card IDs from the merch UI, not a root slash command.',
+  searchSpotifyArtist:
+    'Onboarding-first identity picker; the authenticated chat slash menu should not expose it.',
+  selectMerchDesign:
+    'Follow-up after generated merch options; direct slash access would lack generation context.',
+  showAccountStatus:
+    'Account summary is triggered conversationally or from settings surfaces, not slash.',
+  showArtistPayouts:
+    'Internal merch payout liability is advanced/account-adjacent and not a root slash command.',
+  showMerchSales:
+    'Merch reporting belongs with merch/account cards rather than the root slash menu.',
+  showTopInsights: 'Surfaced as a home-screen card, not a slash command.',
+  showUsage:
+    'Usage details are triggered conversationally or from settings surfaces, not slash.',
+  suggestRelatedArtists:
+    'Always part of createPromoStrategy; never a standalone user action.',
+  unpauseMerchCard:
+    'Merch lifecycle action shown from merch cards, not the root slash menu.',
+  writeWorldClassBio:
+    'Pro-only; chat surfaces it conversationally rather than via slash.',
 } as const;
 
 export type CommandSurface = 'chat-slash' | 'cmdk';

--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -835,6 +835,76 @@ function assertToolUiRegistryCovered(output) {
   return pass();
 }
 
+function assertSlashSkillVisibilityCovered(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'tool-inventory') {
+    return fail('case did not run through the tool-inventory adapter');
+  }
+  if (!Array.isArray(payload.chatSlashSkillNames)) {
+    return fail('missing tool-inventory field: chatSlashSkillNames');
+  }
+  if (payload.chatSlashSkillNames.length === 0) {
+    return fail('chat slash exposes no skills');
+  }
+  if (!Array.isArray(payload.cmdkSkillNames)) {
+    return fail('missing tool-inventory field: cmdkSkillNames');
+  }
+  if (payload.cmdkSkillNames.length === 0) {
+    return fail('cmd+k exposes no skills');
+  }
+  if (
+    Array.isArray(payload.missingSkillCommandSchemaNames) &&
+    payload.missingSkillCommandSchemaNames.length > 0
+  ) {
+    return fail(
+      `slash skill commands missing schemas: ${payload.missingSkillCommandSchemaNames.join(', ')}`
+    );
+  }
+  if (
+    Array.isArray(payload.missingSkillCommandCaseNames) &&
+    payload.missingSkillCommandCaseNames.length > 0
+  ) {
+    return fail(
+      `slash skill commands missing eval cases: ${payload.missingSkillCommandCaseNames.join(', ')}`
+    );
+  }
+  if (
+    Array.isArray(payload.missingCmdkSkillNames) &&
+    payload.missingCmdkSkillNames.length > 0
+  ) {
+    return fail(
+      `chat slash skills missing from cmd+k: ${payload.missingCmdkSkillNames.join(', ')}`
+    );
+  }
+  if (
+    Array.isArray(payload.staleHiddenToolNames) &&
+    payload.staleHiddenToolNames.length > 0
+  ) {
+    return fail(
+      `hidden tool decisions reference unknown tools: ${payload.staleHiddenToolNames.join(', ')}`
+    );
+  }
+  if (
+    Array.isArray(payload.hiddenToolsWithoutReason) &&
+    payload.hiddenToolsWithoutReason.length > 0
+  ) {
+    return fail(
+      `hidden tools missing rationale: ${payload.hiddenToolsWithoutReason.join(', ')}`
+    );
+  }
+  if (
+    Array.isArray(payload.missingVisibilityDecisionNames) &&
+    payload.missingVisibilityDecisionNames.length > 0
+  ) {
+    return fail(
+      `tools missing visible/hidden command decision: ${payload.missingVisibilityDecisionNames.join(', ')}`
+    );
+  }
+
+  return pass();
+}
+
 function firstEvent(payload) {
   return Array.isArray(payload.events) ? payload.events[0] : undefined;
 }
@@ -1059,6 +1129,7 @@ module.exports = {
   assertFailedToolResultPreserved,
   assertToolInventoryCovered,
   assertToolUiRegistryCovered,
+  assertSlashSkillVisibilityCovered,
   assertToolEventInventoryCovered,
   assertToolEventHydratesSuccess,
   assertToolEventFailurePreserved,

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -15,6 +15,11 @@ import {
 } from '@/lib/chat/tool-schemas';
 import { TOOL_UI_REGISTRY } from '@/lib/chat/tool-ui-registry';
 import type { ReleaseContext } from '@/lib/chat/types';
+import {
+  COMMANDS,
+  commandsForSurface,
+  HIDDEN_TOOLS,
+} from '@/lib/commands/registry';
 import { getEntitlements, type PlanId } from '@/lib/entitlements/registry';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
 import {
@@ -268,6 +273,27 @@ const FREE_APP_TOOL_NAMES = [
 
 const ALL_EVAL_TOOL_NAMES = Object.keys(ALL_EVAL_TOOL_SCHEMAS).sort();
 const TOOL_UI_REGISTRY_NAMES = Object.keys(TOOL_UI_REGISTRY).sort();
+const CHAT_SLASH_SKILL_NAMES = commandsForSurface('chat-slash')
+  .filter(command => command.kind === 'skill')
+  .map(command => command.id)
+  .sort();
+const CMDK_SKILL_NAMES = commandsForSurface('cmdk')
+  .filter(command => command.kind === 'skill')
+  .map(command => command.id)
+  .sort();
+const ALL_COMMAND_SKILL_NAMES = COMMANDS.filter(
+  command => command.kind === 'skill'
+)
+  .map(command => command.id)
+  .sort();
+const HIDDEN_TOOL_NAMES = Object.keys(HIDDEN_TOOLS).sort();
+const HIDDEN_TOOL_REASONS = HIDDEN_TOOL_NAMES.reduce<Record<string, string>>(
+  (reasons, toolName) => {
+    reasons[toolName] = HIDDEN_TOOLS[toolName] ?? '';
+    return reasons;
+  },
+  {}
+);
 
 function toObject(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -1169,6 +1195,28 @@ function evaluateToolInventory(vars: EvalVars) {
   const staleToolUiRegistryNames = TOOL_UI_REGISTRY_NAMES.filter(
     toolName => !Object.hasOwn(ALL_EVAL_TOOL_SCHEMAS, toolName)
   );
+  const missingSkillCommandSchemaNames = ALL_COMMAND_SKILL_NAMES.filter(
+    toolName => !Object.hasOwn(ALL_EVAL_TOOL_SCHEMAS, toolName)
+  );
+  const missingSkillCommandCaseNames = ALL_COMMAND_SKILL_NAMES.filter(
+    toolName => !coveredSet.has(toolName)
+  );
+  const missingCmdkSkillNames = CHAT_SLASH_SKILL_NAMES.filter(
+    toolName => !CMDK_SKILL_NAMES.includes(toolName)
+  );
+  const staleHiddenToolNames = HIDDEN_TOOL_NAMES.filter(
+    toolName => !Object.hasOwn(ALL_EVAL_TOOL_SCHEMAS, toolName)
+  );
+  const hiddenToolsWithoutReason = HIDDEN_TOOL_NAMES.filter(
+    toolName => !HIDDEN_TOOL_REASONS[toolName]?.trim()
+  );
+  const visibleOrHiddenToolNames = new Set([
+    ...ALL_COMMAND_SKILL_NAMES,
+    ...HIDDEN_TOOL_NAMES,
+  ]);
+  const missingVisibilityDecisionNames = ALL_EVAL_TOOL_NAMES.filter(
+    toolName => !visibleOrHiddenToolNames.has(toolName)
+  );
 
   return {
     target: 'tool-inventory',
@@ -1188,6 +1236,17 @@ function evaluateToolInventory(vars: EvalVars) {
     freeAppToolNames: [...FREE_APP_TOOL_NAMES],
     onboardingToolNames: [...ONBOARDING_TOOLS],
     paidToolNames: [...PAID_TOOL_NAMES],
+    chatSlashSkillNames: CHAT_SLASH_SKILL_NAMES,
+    cmdkSkillNames: CMDK_SKILL_NAMES,
+    commandSkillNames: ALL_COMMAND_SKILL_NAMES,
+    hiddenToolNames: HIDDEN_TOOL_NAMES,
+    hiddenToolReasons: HIDDEN_TOOL_REASONS,
+    missingSkillCommandSchemaNames,
+    missingSkillCommandCaseNames,
+    missingCmdkSkillNames,
+    staleHiddenToolNames,
+    hiddenToolsWithoutReason,
+    missingVisibilityDecisionNames,
   };
 }
 

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -650,6 +650,8 @@ tests:
         value: file://assertions.cjs:assertToolInventoryCovered
       - type: javascript
         value: file://assertions.cjs:assertToolUiRegistryCovered
+      - type: javascript
+        value: file://assertions.cjs:assertSlashSkillVisibilityCovered
 
   - description: Tool event inventory hydrates every eval tool
     metadata:


### PR DESCRIPTION
## Summary
- Adds deterministic Promptfoo inventory fields for chat slash skills, cmd+k skills, hidden tool decisions, and missing visible/hidden coverage.
- Adds a Promptfoo assertion that every user-facing slash skill maps to a covered tool schema and every eval tool has either a visible command or a hidden-tool rationale.
- Expands `HIDDEN_TOOLS` rationale metadata for onboarding, merch, account, billing, and follow-up tools so command/tool drift fails deterministically without changing app behavior.

## Cost control
Ship now: this PR adds no-cost deterministic coverage only. `pnpm run evals` runs with model keys unset and does not call LLMs, DB, Clerk, Stripe, Spotify, or persistence.
Re-evaluate when: command registry churn causes more than two false positives in 30 days, measured as CI failures that require only fixture/rationale updates.
Then: split command-visibility coverage by app mode and entitlement tier if the single inventory gate becomes noisy.

## Verification
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml` ✅
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 pnpm run evals` ✅ 94/94 deterministic cases
- `pnpm --filter @jovie/web run typecheck -- --pretty false` ✅
- `pnpm biome check apps/web/lib/commands/registry.ts apps/web/tests/eval/promptfoo` ✅
- `git diff --check` ✅
- `git push` pre-push hook ✅ repo Biome, proxy guard, Tailwind guard, web typecheck, web lint
- `pnpm --filter @jovie/web run typecheck:tests` ❌ known repo-wide test type drift tracked in JOV-2582; failures are outside this Promptfoo/command-registry slice.

## Linear
- JOV-2584
