### PR TITLE
test(promptfoo): cover chat model routing

### DIFF
--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -408,6 +408,49 @@ function assertDeterministicRouteNoSideEffects(output) {
   return assertNoRoutePersistence(output);
 }
 
+function assertModelContractNoSpend(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'model-contract') {
+    return fail('case did not run through the model-contract adapter');
+  }
+  if (payload.costTier !== 'deterministic') {
+    return fail('case is not marked as deterministic');
+  }
+  if (payload.modelCalled !== false) {
+    return fail('model-contract case attempted a model call');
+  }
+  if (payload.persistenceAttempted !== false) {
+    return fail('model-contract case attempted persistence');
+  }
+  if (toolNames(payload).length > 0 || allExecutions(payload).length > 0) {
+    return fail('model-contract case should not call or execute tools');
+  }
+
+  return pass();
+}
+
+function assertModelContractExpectedModel(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'model-contract') {
+    return fail('case did not run through the model-contract adapter');
+  }
+  if (typeof payload.selectedModel !== 'string') {
+    return fail('model-contract did not expose selectedModel');
+  }
+  if (typeof payload.expectedModel !== 'string') {
+    return fail('model-contract case did not include expectedModel');
+  }
+  if (payload.selectedModel !== payload.expectedModel) {
+    return fail(
+      `expected ${payload.expectedBoundary} model ${payload.expectedModel}, got ${payload.modelBoundary} model ${payload.selectedModel}`
+    );
+  }
+
+  return pass();
+}
+
 function assertWebRouteUnauthorized(output) {
   const payload = parseOutput(output);
   const responseText = String(payload.responseText ?? '');
@@ -1103,6 +1146,8 @@ module.exports = {
   assertPitchingConflictReconciled,
   assertOnboardingSpotifyObservation,
   assertConciseJovieVoice,
+  assertModelContractNoSpend,
+  assertModelContractExpectedModel,
   assertMobileRouteUnauthorized,
   assertMobileRouteInvalidBody,
   assertMobileRouteRuntimeDisabled,

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -1,7 +1,11 @@
 import { type ToolSet, tool, type UIMessage } from 'ai';
 import { z } from 'zod';
 import { APP_ROUTES } from '@/constants/routes';
-import { executeChatTurn, selectKnowledgeContextForTurn } from '@/lib/chat/run';
+import {
+  canUseLightModel,
+  executeChatTurn,
+  selectKnowledgeContextForTurn,
+} from '@/lib/chat/run';
 import {
   decodeToolEvents,
   type PersistedToolEvent,
@@ -20,6 +24,7 @@ import {
   commandsForSurface,
   HIDDEN_TOOLS,
 } from '@/lib/commands/registry';
+import { CHAT_MODEL, CHAT_MODEL_LIGHT } from '@/lib/constants/ai-models';
 import { getEntitlements, type PlanId } from '@/lib/entitlements/registry';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
 import {
@@ -30,6 +35,7 @@ import {
 type EvalVars = Record<string, unknown>;
 type EvalTarget =
   | 'chat-turn'
+  | 'model-contract'
   | 'mobile-chat-route'
   | 'tool-contract'
   | 'tool-event-contract'
@@ -325,6 +331,7 @@ function toMode(value: unknown): 'app' | 'onboarding' {
 function toTarget(value: unknown): EvalTarget {
   if (
     value === 'mobile-chat-route' ||
+    value === 'model-contract' ||
     value === 'tool-contract' ||
     value === 'tool-event-contract' ||
     value === 'tool-inventory' ||
@@ -735,6 +742,68 @@ function evaluateMobileChatRouteContract(prompt: string, vars: EvalVars) {
     headers: MOBILE_CHAT_NDJSON_HEADERS,
     events: [MOBILE_CHAT_RUNTIME_DISABLED_EVENT],
     responseText: ndjsonEvent(MOBILE_CHAT_RUNTIME_DISABLED_EVENT),
+  };
+}
+
+function evaluateModelContract(prompt: string, vars: EvalVars) {
+  const uiMessages = toUiMessages(prompt, vars);
+  const mode = toMode(vars.mode);
+  const plan = toPlanId(vars.plan);
+  const planLimits = getEntitlements(plan);
+  const aiCanUseTools = toBoolean(
+    vars.aiCanUseTools,
+    planLimits.booleans.aiCanUseTools
+  );
+  const forceLightModel = toBoolean(vars.forceLightModel, false);
+  const heuristicLightModel = canUseLightModel(uiMessages, aiCanUseTools);
+  const selectedModel =
+    forceLightModel || heuristicLightModel ? CHAT_MODEL_LIGHT : CHAT_MODEL;
+  const expectedModel =
+    vars.expectedModel === 'light'
+      ? CHAT_MODEL_LIGHT
+      : vars.expectedModel === 'primary'
+        ? CHAT_MODEL
+        : null;
+
+  return {
+    target: 'model-contract',
+    adapter: 'model-contract',
+    productionEntrypoint: 'apps/web/lib/chat/run.ts:executeChatTurn',
+    costTier: 'deterministic',
+    text: '',
+    selectedModel,
+    expectedModel,
+    modelBoundary: selectedModel === CHAT_MODEL_LIGHT ? 'light' : 'primary',
+    expectedBoundary:
+      expectedModel === CHAT_MODEL_LIGHT
+        ? 'light'
+        : expectedModel === CHAT_MODEL
+          ? 'primary'
+          : null,
+    lightModel: CHAT_MODEL_LIGHT,
+    primaryModel: CHAT_MODEL,
+    modelCalled: false,
+    persistenceAttempted: false,
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+    mode,
+    plan,
+    aiCanUseTools,
+    forceLightModel,
+    heuristicLightModel,
+    messageCount: uiMessages.length,
+    userText: uiMessages
+      .filter(message => message.role === 'user')
+      .flatMap(message =>
+        message.parts
+          .filter(
+            (part): part is { type: 'text'; text: string } =>
+              part.type === 'text' && typeof part.text === 'string'
+          )
+          .map(part => part.text)
+      )
+      .join('\n'),
   };
 }
 
@@ -1487,6 +1556,16 @@ export default class JovieChatPromptfooProvider {
 
     if (target === 'web-chat-route') {
       const payload = evaluateWebChatRouteContract(prompt, vars);
+      return {
+        output: JSON.stringify(payload),
+        raw: payload,
+        format: 'json',
+        latencyMs: Date.now() - startedAt,
+      };
+    }
+
+    if (target === 'model-contract') {
+      const payload = evaluateModelContract(prompt, vars);
       return {
         output: JSON.stringify(payload),
         raw: payload,

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -598,6 +598,93 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertMobileRouteInvalidBody
 
+  - description: Model routing keeps no-tool entitlement turns on the light model
+    metadata:
+      cost: deterministic
+    vars:
+      input: "How should I set up my pre-save?"
+      target: model-contract
+      plan: free
+      aiCanUseTools: false
+      expectedModel: light
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertModelContractNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertModelContractExpectedModel
+
+  - description: Model routing sends simple pro tool intents to the light model
+    metadata:
+      cost: deterministic
+    vars:
+      input: "add my instagram https://instagram.com/lunawaves"
+      target: model-contract
+      plan: pro
+      expectedModel: light
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertModelContractNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertModelContractExpectedModel
+
+  - description: Model routing keeps complex pro strategy on the primary model
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Build a detailed six-week campaign strategy for my next release, including audience segments, content themes, playlist pitching, merch timing, and what to measure each week."
+      target: model-contract
+      plan: pro
+      expectedModel: primary
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertModelContractNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertModelContractExpectedModel
+
+  - description: Model routing force-light override uses the light model
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Build a detailed six-week campaign strategy for my next release, including audience segments, content themes, playlist pitching, merch timing, and what to measure each week."
+      target: model-contract
+      plan: pro
+      forceLightModel: true
+      expectedModel: light
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertModelContractNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertModelContractExpectedModel
+
+  - description: Model routing long pro conversations stay on the primary model
+    metadata:
+      cost: deterministic
+    vars:
+      input: "add my instagram https://instagram.com/lunawaves"
+      target: model-contract
+      plan: pro
+      expectedModel: primary
+      messages:
+        - role: user
+          text: "I am planning a release."
+        - role: assistant
+          text: "What release are you focused on?"
+        - role: user
+          text: "Tidal Drift."
+        - role: assistant
+          text: "What date are you aiming for?"
+        - role: user
+          text: "Four weeks from Friday."
+        - role: assistant
+          text: "What do you want to handle next?"
+        - role: user
+          text: "add my instagram https://instagram.com/lunawaves"
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertModelContractNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertModelContractExpectedModel
+
   - description: Tool inventory covers every chat and onboarding adapter
     metadata:
       cost: deterministic


### PR DESCRIPTION
## Summary
- Adds a deterministic `model-contract` Promptfoo target for chat model routing.
- Covers no-tool entitlement turns, simple tool-intent turns, complex pro turns, force-light incident mode, and long-conversation routing.
- Uses production `canUseLightModel()` and model constants, but stops before `streamText`, persistence, tools, DB, Clerk, Stripe, Spotify, or any live model call.

## Cost control
Ship now: deterministic model-routing coverage catches expensive-model drift without LLM calls or external services.
Re-evaluate when: model-selection changes cause more than two false positives in 30 days or token-cost telemetry shows simple turns exceed the agreed per-turn budget.
Then: add a capped live routing smoke only if the deterministic gate misses a release-blocking routing regression twice in 30 days.

## Verification
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml` ✅
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 pnpm run evals` ✅ 99/99 deterministic cases
- `pnpm --filter @jovie/web run typecheck -- --pretty false` ✅
- `pnpm biome check apps/web/tests/eval/promptfoo` ✅
- `git diff --check` ✅
- `git push` pre-push hook ✅ repo Biome, proxy guard, Tailwind guard, web typecheck, web lint

## Known blocker
- `pnpm --filter @jovie/web run typecheck:tests` remains a repo-wide failure outside this Promptfoo harness and is tracked in JOV-2582.

## Linear
- JOV-2585
