### PR TITLE
test(promptfoo): cover tool rendering contracts

### DIFF
--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -958,6 +958,12 @@ function firstMessagePart(payload) {
     : undefined;
 }
 
+function firstRenderPlan(payload) {
+  return Array.isArray(payload.renderPlans)
+    ? payload.renderPlans[0]
+    : undefined;
+}
+
 function assertToolEventInventoryCovered(output) {
   const payload = parseOutput(output);
 
@@ -1134,6 +1140,208 @@ function assertToolEventInvalidRejected(output) {
   return pass();
 }
 
+function assertToolRenderInventoryCovered(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'tool-render-contract') {
+    return fail('case did not run through the tool-render-contract adapter');
+  }
+  if (payload.schemaValid !== true) {
+    return fail('tool render events did not pass persisted schema validation');
+  }
+  if (!Array.isArray(payload.renderPlans) || payload.renderPlans.length === 0) {
+    return fail('tool render inventory produced no render plans');
+  }
+  if (
+    Array.isArray(payload.missingRenderPlanToolNames) &&
+    payload.missingRenderPlanToolNames.length > 0
+  ) {
+    return fail(
+      `missing tool render plans: ${payload.missingRenderPlanToolNames.join(', ')}`
+    );
+  }
+  if (
+    Array.isArray(payload.toolUiRegistryNames) &&
+    payload.renderPlans.length < payload.toolUiRegistryNames.length
+  ) {
+    return fail(
+      `expected render plans for ${payload.toolUiRegistryNames.length} UI registry tools, got ${payload.renderPlans.length}`
+    );
+  }
+
+  return pass();
+}
+
+function assertToolRenderSucceededArtifact(output) {
+  const payload = parseOutput(output);
+  const plan = firstRenderPlan(payload);
+
+  if (payload.target !== 'tool-render-contract') {
+    return fail('case did not run through the tool-render-contract adapter');
+  }
+  if (plan?.state !== 'succeeded') {
+    return fail(`expected succeeded render plan, got ${String(plan?.state)}`);
+  }
+  if (plan?.artifactRendered !== true) {
+    return fail('succeeded artifact case did not render an artifact card');
+  }
+  if (plan?.renderKind !== 'artifact-card') {
+    return fail(
+      `expected artifact-card render, got ${String(plan?.renderKind)}`
+    );
+  }
+  if (plan?.claimsSuccess !== true) {
+    return fail('succeeded artifact case did not claim success');
+  }
+
+  return pass();
+}
+
+function assertToolRenderFailureNoSuccess(output) {
+  const payload = parseOutput(output);
+  const plan = firstRenderPlan(payload);
+
+  if (payload.target !== 'tool-render-contract') {
+    return fail('case did not run through the tool-render-contract adapter');
+  }
+  if (plan?.state !== 'failed') {
+    return fail(`expected failed render plan, got ${String(plan?.state)}`);
+  }
+  if (plan?.artifactRendered !== false || plan?.renderKind !== 'status-row') {
+    return fail('failed tool render should fall back to a status row');
+  }
+  if (plan?.claimsSuccess !== false) {
+    return fail('failed tool render claimed success');
+  }
+  if (plan?.statusRole !== 'alert') {
+    return fail(`expected alert status role, got ${String(plan?.statusRole)}`);
+  }
+  if (plan?.statusTitle === plan?.successTitle) {
+    return fail('failed status title matched the success title');
+  }
+
+  return pass();
+}
+
+function assertToolRenderNeedsApprovalNoSuccess(output) {
+  const payload = parseOutput(output);
+  const plan = firstRenderPlan(payload);
+
+  if (payload.target !== 'tool-render-contract') {
+    return fail('case did not run through the tool-render-contract adapter');
+  }
+  if (plan?.state !== 'needs-approval') {
+    return fail(
+      `expected needs-approval render plan, got ${String(plan?.state)}`
+    );
+  }
+  if (plan?.artifactRendered !== false || plan?.renderKind !== 'status-row') {
+    return fail('approval request should render as a status row');
+  }
+  if (plan?.claimsSuccess !== false) {
+    return fail('approval request render claimed success');
+  }
+  if (!/needs your ok|approval required/i.test(plan?.statusTitle ?? '')) {
+    return fail('approval request title did not ask for approval');
+  }
+
+  return pass();
+}
+
+function assertToolRenderDeniedNoSuccess(output) {
+  const payload = parseOutput(output);
+  const plan = firstRenderPlan(payload);
+
+  if (payload.target !== 'tool-render-contract') {
+    return fail('case did not run through the tool-render-contract adapter');
+  }
+  if (plan?.state !== 'denied') {
+    return fail(`expected denied render plan, got ${String(plan?.state)}`);
+  }
+  if (plan?.artifactRendered !== false || plan?.renderKind !== 'status-row') {
+    return fail('denied tool render should fall back to a status row');
+  }
+  if (plan?.claimsSuccess !== false) {
+    return fail('denied tool render claimed success');
+  }
+  if (plan?.statusRole !== 'alert') {
+    return fail(`expected alert status role, got ${String(plan?.statusRole)}`);
+  }
+
+  return pass();
+}
+
+function assertToolRenderStatusSuccess(output) {
+  const payload = parseOutput(output);
+  const plan = firstRenderPlan(payload);
+
+  if (payload.target !== 'tool-render-contract') {
+    return fail('case did not run through the tool-render-contract adapter');
+  }
+  if (plan?.state !== 'succeeded') {
+    return fail(`expected succeeded render plan, got ${String(plan?.state)}`);
+  }
+  if (plan?.registryRenderer !== 'status') {
+    return fail(
+      `expected status registry renderer, got ${plan?.registryRenderer}`
+    );
+  }
+  if (plan?.artifactRendered !== false || plan?.renderKind !== 'status-row') {
+    return fail('status renderer should render a status row');
+  }
+  if (plan?.claimsSuccess !== true) {
+    return fail('successful status row did not claim success');
+  }
+
+  return pass();
+}
+
+function assertToolRenderMissingProfileFallsBack(output) {
+  const payload = parseOutput(output);
+  const plan = firstRenderPlan(payload);
+
+  if (payload.target !== 'tool-render-contract') {
+    return fail('case did not run through the tool-render-contract adapter');
+  }
+  if (plan?.registryRenderer !== 'artifact') {
+    return fail(
+      `expected artifact registry renderer, got ${plan?.registryRenderer}`
+    );
+  }
+  if (plan?.profileIdPresent !== false) {
+    return fail('case did not simulate a missing profile id');
+  }
+  if (plan?.artifactRendered !== false || plan?.renderKind !== 'status-row') {
+    return fail('profile-dependent artifact did not fall back to a status row');
+  }
+
+  return pass();
+}
+
+function assertToolRenderUnimplementedArtifactFallsBack(output) {
+  const payload = parseOutput(output);
+  const plan = firstRenderPlan(payload);
+
+  if (payload.target !== 'tool-render-contract') {
+    return fail('case did not run through the tool-render-contract adapter');
+  }
+  if (plan?.registryRenderer !== 'artifact') {
+    return fail(
+      `expected artifact registry renderer, got ${plan?.registryRenderer}`
+    );
+  }
+  if (plan?.genericArtifactRendererImplemented !== false) {
+    return fail(
+      'case did not exercise a registry artifact without a generic renderer'
+    );
+  }
+  if (plan?.artifactRendered !== false || plan?.renderKind !== 'status-row') {
+    return fail('unimplemented artifact renderer did not fall back to status');
+  }
+
+  return pass();
+}
+
 module.exports = {
   assertNoPromptLeak,
   assertGroundedReleaseLeadTime,
@@ -1183,4 +1391,12 @@ module.exports = {
   assertToolEventDeniedHydrated,
   assertToolEventDedupeUsesLatest,
   assertToolEventInvalidRejected,
+  assertToolRenderInventoryCovered,
+  assertToolRenderSucceededArtifact,
+  assertToolRenderFailureNoSuccess,
+  assertToolRenderNeedsApprovalNoSuccess,
+  assertToolRenderDeniedNoSuccess,
+  assertToolRenderStatusSuccess,
+  assertToolRenderMissingProfileFallsBack,
+  assertToolRenderUnimplementedArtifactFallsBack,
 };

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -17,7 +17,7 @@ import {
   ONBOARDING_TOOLS,
   TOOL_SCHEMAS,
 } from '@/lib/chat/tool-schemas';
-import { TOOL_UI_REGISTRY } from '@/lib/chat/tool-ui-registry';
+import { getToolUiConfig, TOOL_UI_REGISTRY } from '@/lib/chat/tool-ui-registry';
 import type { ReleaseContext } from '@/lib/chat/types';
 import {
   COMMANDS,
@@ -39,6 +39,7 @@ type EvalTarget =
   | 'mobile-chat-route'
   | 'tool-contract'
   | 'tool-event-contract'
+  | 'tool-render-contract'
   | 'tool-inventory'
   | 'web-chat-route';
 
@@ -279,6 +280,18 @@ const FREE_APP_TOOL_NAMES = [
 
 const ALL_EVAL_TOOL_NAMES = Object.keys(ALL_EVAL_TOOL_SCHEMAS).sort();
 const TOOL_UI_REGISTRY_NAMES = Object.keys(TOOL_UI_REGISTRY).sort();
+const GENERIC_ARTIFACT_RENDERER_TOOL_NAMES = [
+  'generateAlbumArt',
+  'generateReleasePitch',
+  'proposeAvatarUpload',
+  'proposeProfileEdit',
+  'proposeSocialLink',
+  'proposeSocialLinkRemoval',
+  'showTopInsights',
+] as const;
+const GENERIC_ARTIFACT_RENDERER_NAME_SET = new Set<string>(
+  GENERIC_ARTIFACT_RENDERER_TOOL_NAMES
+);
 const CHAT_SLASH_SKILL_NAMES = commandsForSurface('chat-slash')
   .filter(command => command.kind === 'skill')
   .map(command => command.id)
@@ -334,6 +347,7 @@ function toTarget(value: unknown): EvalTarget {
     value === 'model-contract' ||
     value === 'tool-contract' ||
     value === 'tool-event-contract' ||
+    value === 'tool-render-contract' ||
     value === 'tool-inventory' ||
     value === 'web-chat-route'
   ) {
@@ -1495,6 +1509,360 @@ function evaluateToolEventContract(vars: EvalVars) {
   };
 }
 
+function renderStatusTitle(event: PersistedToolEvent): string {
+  const config = getToolUiConfig(event.toolName);
+
+  switch (event.state) {
+    case 'running':
+      return config.loadingTitle ?? config.label;
+    case 'failed':
+      return config.errorTitle ?? `${config.label} Failed`;
+    case 'denied':
+      return `${config.label} denied`;
+    case 'needs-approval':
+      return `${config.label} needs your OK`;
+    case 'succeeded':
+      return config.successTitle ?? config.label;
+  }
+}
+
+function renderStatusBody(event: PersistedToolEvent): string | undefined {
+  switch (event.state) {
+    case 'running':
+      return event.summary;
+    case 'failed':
+    case 'denied':
+      return event.errorMessage ?? event.summary;
+    case 'needs-approval':
+      return event.errorMessage ?? 'Approval required before continuing.';
+    case 'succeeded':
+      return event.summary ?? 'Completed';
+  }
+}
+
+function syntheticArtifactOutputFor(toolName: string): Record<string, unknown> {
+  switch (toolName) {
+    case 'generateAlbumArt':
+      return {
+        success: true,
+        state: 'generated',
+        releaseId: '00000000-0000-4000-8000-000000000401',
+        releaseTitle: 'Tidal Drift',
+        artistName: 'Luna Waves',
+        generationId: '00000000-0000-4000-8000-000000000402',
+        hasExistingArtwork: false,
+        candidates: [
+          {
+            id: 'album-art-candidate-1',
+            styleId: 'chromatic-tide',
+            styleLabel: 'Chromatic tide',
+            previewUrl: 'https://cdn.jov.ie/eval/album-art-preview.jpg',
+            fullResUrl: 'https://cdn.jov.ie/eval/album-art-full.jpg',
+          },
+        ],
+      };
+    case 'generateReleasePitch':
+      return {
+        success: true,
+        releaseTitle: 'Tidal Drift',
+        pitches: {
+          spotify: 'Synthetic Spotify pitch for Tidal Drift.',
+          appleMusic: 'Synthetic Apple Music pitch for Tidal Drift.',
+          amazon: 'Synthetic Amazon pitch for Tidal Drift.',
+          generic: 'Synthetic generic pitch for Tidal Drift.',
+        },
+      };
+    case 'proposeAvatarUpload':
+      return { success: true };
+    case 'proposeProfileEdit':
+      return {
+        success: true,
+        preview: {
+          field: 'bio',
+          fieldLabel: 'Bio',
+          currentValue: 'Old synthetic bio.',
+          newValue: 'New synthetic bio.',
+          reason: 'Synthetic eval preview.',
+        },
+      };
+    case 'proposeSocialLink':
+      return {
+        success: true,
+        platform: {
+          id: 'instagram',
+          name: 'Instagram',
+          icon: 'instagram',
+          color: '#E1306C',
+        },
+        normalizedUrl: 'https://instagram.com/lunawaves',
+        originalUrl: 'https://instagram.com/lunawaves',
+      };
+    case 'proposeSocialLinkRemoval':
+      return {
+        success: true,
+        linkId: '00000000-0000-4000-8000-000000000301',
+        platform: 'instagram',
+        url: 'https://instagram.com/lunawaves',
+      };
+    case 'showTopInsights':
+      return {
+        success: true,
+        totalActive: 1,
+        insights: [
+          {
+            id: 'synthetic-insight',
+            title: 'Synthetic insight',
+            body: 'Synthetic audience signal.',
+            priority: 'medium',
+          },
+        ],
+      };
+    default:
+      return {
+        success: true,
+        summary: `${toolName} completed with a synthetic eval result.`,
+      };
+  }
+}
+
+function hasGeneratedAlbumArtOutput(output: Record<string, unknown>): boolean {
+  const candidates = output.candidates;
+
+  return (
+    output.success === true &&
+    output.state === 'generated' &&
+    typeof output.releaseTitle === 'string' &&
+    typeof output.artistName === 'string' &&
+    typeof output.generationId === 'string' &&
+    typeof output.hasExistingArtwork === 'boolean' &&
+    Array.isArray(candidates) &&
+    candidates.every(candidate => {
+      const candidateObject = toObject(candidate);
+      return (
+        typeof candidateObject.id === 'string' &&
+        typeof candidateObject.styleId === 'string' &&
+        typeof candidateObject.styleLabel === 'string' &&
+        typeof candidateObject.previewUrl === 'string' &&
+        typeof candidateObject.fullResUrl === 'string'
+      );
+    })
+  );
+}
+
+function hasReleasePitchOutput(output: Record<string, unknown>): boolean {
+  const pitches = toObject(output.pitches);
+
+  return (
+    output.success === true &&
+    (output.releaseTitle === undefined ||
+      typeof output.releaseTitle === 'string') &&
+    typeof pitches.spotify === 'string' &&
+    typeof pitches.appleMusic === 'string' &&
+    typeof pitches.amazon === 'string' &&
+    typeof pitches.generic === 'string'
+  );
+}
+
+function hasRenderableArtifact(
+  event: PersistedToolEvent,
+  profileIdPresent: boolean
+): boolean {
+  if (
+    event.state !== 'succeeded' ||
+    !GENERIC_ARTIFACT_RENDERER_NAME_SET.has(event.toolName)
+  ) {
+    return false;
+  }
+
+  const output = event.output;
+  if (!output) return false;
+
+  switch (event.toolName) {
+    case 'generateAlbumArt':
+      return profileIdPresent && hasGeneratedAlbumArtOutput(output);
+    case 'generateReleasePitch':
+      return hasReleasePitchOutput(output);
+    case 'proposeAvatarUpload':
+      return output.success === true;
+    case 'proposeProfileEdit':
+      return (
+        profileIdPresent &&
+        output.success === true &&
+        Object.hasOwn(output, 'preview')
+      );
+    case 'proposeSocialLink': {
+      const platform = toObject(output.platform);
+      return (
+        profileIdPresent &&
+        typeof platform.id === 'string' &&
+        typeof platform.name === 'string' &&
+        typeof output.normalizedUrl === 'string' &&
+        typeof output.originalUrl === 'string'
+      );
+    }
+    case 'proposeSocialLinkRemoval':
+      return (
+        profileIdPresent &&
+        typeof output.linkId === 'string' &&
+        typeof output.platform === 'string' &&
+        typeof output.url === 'string'
+      );
+    case 'showTopInsights':
+      return Object.hasOwn(output, 'success');
+    default:
+      return false;
+  }
+}
+
+function buildToolRenderEvent(
+  renderCase: string,
+  toolName: string
+): PersistedToolEvent {
+  const config = getToolUiConfig(toolName);
+
+  switch (renderCase) {
+    case 'artifact-success':
+      return toolEvent(toolName, {
+        output: syntheticArtifactOutputFor(toolName),
+        summary: `${config.successTitle ?? config.label} rendered.`,
+        uiHint: config.uiHint,
+      });
+    case 'status-success':
+      return toolEvent(toolName, {
+        output: {
+          success: true,
+          summary: `${toolName} completed with a synthetic status result.`,
+        },
+        summary: `${toolName} completed with a synthetic status result.`,
+        uiHint: config.uiHint,
+      });
+    case 'failed':
+      return toolEvent(toolName, {
+        state: 'failed',
+        output: {
+          success: false,
+          error: 'Synthetic render failure',
+        },
+        summary: 'Synthetic render failure',
+        errorMessage: 'Synthetic render failure',
+        uiHint: config.uiHint,
+      });
+    case 'needs-approval':
+      return toolEvent(toolName, {
+        state: 'needs-approval',
+        output: undefined,
+        summary: undefined,
+        approval: { id: `${toolName}-render-approval` },
+        uiHint: config.uiHint,
+      });
+    case 'denied':
+      return toolEvent(toolName, {
+        state: 'denied',
+        output: undefined,
+        summary: 'Synthetic approval denied',
+        errorMessage: 'Synthetic approval denied',
+        approval: {
+          id: `${toolName}-render-denied`,
+          approved: false,
+          reason: 'Synthetic approval denied',
+        },
+        uiHint: config.uiHint,
+      });
+    default:
+      throw new RangeError(`Invalid eval vars.renderCase: ${renderCase}`);
+  }
+}
+
+function buildRenderPlan(event: PersistedToolEvent, profileIdPresent: boolean) {
+  const config = getToolUiConfig(event.toolName);
+  const artifactRendered =
+    config.renderer === 'artifact' &&
+    hasRenderableArtifact(event, profileIdPresent);
+  const renderKind = artifactRendered ? 'artifact-card' : 'status-row';
+  const successTitle = config.successTitle ?? config.label;
+
+  return {
+    toolName: event.toolName,
+    state: event.state,
+    registryRenderer: config.renderer,
+    registryUiHint: config.uiHint,
+    genericArtifactRendererImplemented: GENERIC_ARTIFACT_RENDERER_NAME_SET.has(
+      event.toolName
+    ),
+    profileIdPresent,
+    artifactRendered,
+    renderKind,
+    statusTitle: renderStatusTitle(event),
+    statusBody: renderStatusBody(event),
+    statusRole:
+      event.state === 'failed' || event.state === 'denied' ? 'alert' : 'status',
+    successTitle,
+    errorTitle: config.errorTitle ?? `${config.label} Failed`,
+    claimsSuccess:
+      event.state === 'succeeded' &&
+      (artifactRendered || renderStatusTitle(event) === successTitle),
+  };
+}
+
+function evaluateToolRenderContract(vars: EvalVars) {
+  const renderCase =
+    typeof vars.renderCase === 'string' ? vars.renderCase : 'artifact-success';
+  const profileIdPresent = toBoolean(vars.profileIdPresent, true);
+  const events =
+    renderCase === 'inventory'
+      ? TOOL_UI_REGISTRY_NAMES.map(toolName =>
+          buildToolRenderEvent('artifact-success', toolName)
+        )
+      : [
+          buildToolRenderEvent(
+            renderCase,
+            toToolName(vars.toolName ?? 'proposeSocialLink')
+          ),
+        ];
+  const schemaResult = persistedToolEventsSchema.safeParse(events);
+  const messageParts = schemaResult.success
+    ? schemaResult.data.map(event => toolEventToMessagePart(event))
+    : [];
+  const renderPlans = schemaResult.success
+    ? schemaResult.data.map(event => buildRenderPlan(event, profileIdPresent))
+    : [];
+  const renderedToolNames = renderPlans.map(plan => plan.toolName);
+  const missingRenderPlanToolNames =
+    renderCase === 'inventory'
+      ? TOOL_UI_REGISTRY_NAMES.filter(
+          toolName => !renderedToolNames.includes(toolName)
+        )
+      : [];
+  const artifactRegistryToolNames = TOOL_UI_REGISTRY_NAMES.filter(toolName => {
+    const config = getToolUiConfig(toolName);
+    return config.renderer === 'artifact';
+  });
+
+  return {
+    target: 'tool-render-contract',
+    adapter: 'tool-render-contract',
+    costTier: 'deterministic',
+    text: '',
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    renderCase,
+    profileIdPresent,
+    schemaValid: schemaResult.success,
+    schemaErrors: schemaResult.success ? [] : schemaErrorMessages(schemaResult),
+    events,
+    messageParts,
+    renderPlans,
+    toolUiRegistryNames: TOOL_UI_REGISTRY_NAMES,
+    artifactRegistryToolNames,
+    artifactRendererToolNames: [...GENERIC_ARTIFACT_RENDERER_TOOL_NAMES],
+    missingRenderPlanToolNames,
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
 function toPromptfooUsage(usage: Record<string, unknown> | null | undefined) {
   if (!usage) return undefined;
 
@@ -1586,6 +1954,16 @@ export default class JovieChatPromptfooProvider {
 
     if (target === 'tool-event-contract') {
       const payload = evaluateToolEventContract(vars);
+      return {
+        output: JSON.stringify(payload),
+        raw: payload,
+        format: 'json',
+        latencyMs: Date.now() - startedAt,
+      };
+    }
+
+    if (target === 'tool-render-contract') {
+      const payload = evaluateToolRenderContract(vars);
       return {
         output: JSON.stringify(payload),
         raw: payload,

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -852,6 +852,120 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertToolEventInvalidRejected
 
+  - description: Tool rendering inventory covers every UI registry tool
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Tool rendering inventory check"
+      target: tool-render-contract
+      renderCase: inventory
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolRenderInventoryCovered
+
+  - description: Tool rendering shows succeeded social link as artifact card
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Render a succeeded social link artifact."
+      target: tool-render-contract
+      toolName: proposeSocialLink
+      renderCase: artifact-success
+      profileIdPresent: true
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolRenderSucceededArtifact
+
+  - description: Tool rendering failed album art falls back to alert status
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Render a failed album art tool result."
+      target: tool-render-contract
+      toolName: generateAlbumArt
+      renderCase: failed
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolRenderFailureNoSuccess
+
+  - description: Tool rendering approval request does not claim completion
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Render a social link approval request."
+      target: tool-render-contract
+      toolName: proposeSocialLink
+      renderCase: needs-approval
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolRenderNeedsApprovalNoSuccess
+
+  - description: Tool rendering denied profile edit does not claim success
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Render a denied profile edit."
+      target: tool-render-contract
+      toolName: proposeProfileEdit
+      renderCase: denied
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolRenderDeniedNoSuccess
+
+  - description: Tool rendering succeeded usage stays status row
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Render a successful usage status."
+      target: tool-render-contract
+      toolName: showUsage
+      renderCase: status-success
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolRenderStatusSuccess
+
+  - description: Tool rendering profile-dependent artifact without profile falls back
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Render a profile-dependent social link without profile id."
+      target: tool-render-contract
+      toolName: proposeSocialLink
+      renderCase: artifact-success
+      profileIdPresent: false
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolRenderMissingProfileFallsBack
+
+  - description: Tool rendering onboarding artifact without generic renderer falls back
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Render a Spotify picker artifact without a generic renderer."
+      target: tool-render-contract
+      toolName: searchSpotifyArtist
+      renderCase: artifact-success
+      profileIdPresent: true
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolRenderUnimplementedArtifactFallsBack
+
   - description: Tool contract accepts free avatar upload
     metadata:
       cost: deterministic


### PR DESCRIPTION
## Summary
- Add a deterministic Promptfoo tool-render-contract target that mirrors the chat tool renderer's artifact/status decisions from the production tool UI registry.
- Add synthetic render fixtures for artifact cards, status rows, approval, denied, failed, missing-profile fallback, and unimplemented artifact fallback.
- Add eight no-cost Promptfoo cases so default evals cover UI registry rendering contracts without model, persistence, DB, Clerk, Stripe, or Spotify calls.

## Verification
- pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml
- env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 pnpm run evals: 107 passed, 0 failed
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml
- git diff --check
- pre-push: biome check ., @jovie/web next:proxy-guard, tailwind:check, typecheck, lint

## Known gap
- pnpm --filter @jovie/web run typecheck:tests still fails on broad pre-existing script/profile fixture drift tracked by JOV-2582, outside this Promptfoo eval harness.

Fixes JOV-2588

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive evaluation test suite for tool rendering contracts, validating render behavior across success states, failure paths, approval workflows, and fallback scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->