### PR TITLE
test(promptfoo): harden eval inventory provider

### DIFF
--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 import { type ToolSet, tool, type UIMessage } from 'ai';
 import { z } from 'zod';
 import { APP_ROUTES } from '@/constants/routes';
@@ -1936,7 +1936,7 @@ function listValuesAfter(block: string, key: string): string[] {
 
 function extractPromptfooTestBlocks(configText: string): string[] {
   const testsStart = configText.match(/^tests:\s*$/m);
-  if (!testsStart?.index) return [];
+  if (testsStart?.index === undefined) return [];
 
   const lines = configText.slice(testsStart.index).split('\n');
   const blocks: string[] = [];
@@ -2025,7 +2025,12 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
     typeof vars.configPath === 'string' && vars.configPath.trim().length > 0
       ? vars.configPath.trim()
       : PROMPTFOO_CONFIG_PATH;
-  const configText = readFileSync(resolve(process.cwd(), configPath), 'utf8');
+  const resolvedConfigPath = resolve(process.cwd(), configPath);
+  const allowedConfigRoot = resolve(process.cwd(), 'tests/eval/promptfoo');
+  if (!resolvedConfigPath.startsWith(`${allowedConfigRoot}${sep}`)) {
+    throw new RangeError(`Invalid eval vars.configPath: ${configPath}`);
+  }
+  const configText = readFileSync(resolvedConfigPath, 'utf8');
   const cases = parsePromptfooCaseSummaries(configText);
   const deterministicCases = cases.filter(
     testCase => testCase.cost === 'deterministic'


### PR DESCRIPTION
## Summary
- Fix the Promptfoo eval inventory parser so a `tests:` anchor at index 0 is treated as valid.
- Constrain eval-only `vars.configPath` reads to `tests/eval/promptfoo` before calling `readFileSync`.

## Verification
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml`
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_AGENT_PROFILE=coder JOVIE_RUN_LIVE_EVALS=0 pnpm run evals` (115/115 deterministic cases passed)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml`
- `git diff --check`

Live LLM evals were not run. This PR keeps default evals no-cost and does not change production chat behavior.

Linear: JOV-2590


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed YAML test-block extraction in the evaluation framework when the test marker appears at the start.

* **Chores**
  * Improved security for test configuration file loading with path validation and directory restrictions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->