### PR TITLE
test(promptfoo): add live HTTP chat route evals

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -56,12 +56,13 @@ Promptfoo has two explicit cost lanes:
 
 - **Deterministic evals** run through `pnpm run evals` and the `Promptfoo Evals (deterministic)` CI job. They unset live model keys, set `JOVIE_RUN_LIVE_EVALS=0`, use `cost=deterministic`, and run with `--no-share --no-write`.
 - **Live evals** run only from `pnpm run evals:live`, which is wrapped by Doppler at the repo root and still fails unless `JOVIE_RUN_LIVE_EVALS=1` and `AI_GATEWAY_API_KEY` are present. The live Promptfoo lane is manual-only, concurrency 1, and uses `--no-share --no-write`.
+- **Live HTTP evals** run only from `pnpm run evals:live:http`, require `JOVIE_RUN_LIVE_HTTP_EVALS=1` plus a loopback `JOVIE_PROMPTFOO_BASE_URL`, and unset model keys before running Promptfoo. This lane exercises real `/api/chat` HTTP auth and persistence with deterministic no-model chat paths.
 
 The legacy `evals-periodic.yml` workflow is also manual-only. It has no scheduled trigger, requires typing `RUN_LIVE_EVALS` into `confirm_live_llm_evals`, and runs at concurrency 1 if explicitly invoked.
 
 Ship now / Re-evaluate when / Then:
 
-- Ship now: deterministic PR evals stay free, while every live LLM eval surface requires manual intent and concurrency 1.
+- Ship now: deterministic PR evals stay free, every live LLM eval surface requires manual intent and concurrency 1, and live HTTP route evals stay manual plus no-model.
 - Re-evaluate when: manual live evals catch a release-blocking regression twice in 30 days or observed live eval cost stays below the agreed per-run budget for 10 consecutive runs.
 - Then: add a capped scheduled or PR-gated live subset with explicit case count, concurrency 1, and per-run cost reporting.
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
     "evals": "PROMPTFOO_DISABLE_TELEMETRY=1 PROMPTFOO_DISABLE_UPDATE=1 PROMPTFOO_NO_TESTCASE_ASSERT_WARNING=1 promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-metadata cost=deterministic --no-cache --no-share --no-write --no-table",
     "evals:live": "bash scripts/run-live-promptfoo-evals.sh smoke",
     "evals:live:all": "bash scripts/run-live-promptfoo-evals.sh all",
+    "evals:live:http": "bash scripts/run-live-promptfoo-http-evals.sh",
     "test": "NODE_OPTIONS=--max-old-space-size=8192 node scripts/vitest-wrapper.mjs",
     "test:ci": "NODE_OPTIONS=--max-old-space-size=8192 vitest run --pool=forks --maxWorkers=2",
     "test:coverage": "vitest run --coverage",

--- a/apps/web/scripts/run-live-promptfoo-http-evals.sh
+++ b/apps/web/scripts/run-live-promptfoo-http-evals.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${JOVIE_RUN_LIVE_HTTP_EVALS:-}" != "1" ]; then
+  echo "Set JOVIE_RUN_LIVE_HTTP_EVALS=1 to run live HTTP Promptfoo evals" >&2
+  exit 1
+fi
+
+if [ -z "${JOVIE_PROMPTFOO_BASE_URL:-}" ]; then
+  echo "JOVIE_PROMPTFOO_BASE_URL is required for live HTTP Promptfoo evals" >&2
+  exit 1
+fi
+
+case "${JOVIE_PROMPTFOO_BASE_URL}" in
+  http://localhost:* | http://127.0.0.1:* | http://[[]::1[]]:* | http://*.localhost:* | https://localhost:* | https://127.0.0.1:* | https://[[]::1[]]:* | https://*.localhost:*)
+    ;;
+  *)
+    echo "Live HTTP Promptfoo evals only run against loopback hosts" >&2
+    exit 1
+    ;;
+esac
+
+echo "Running live HTTP Promptfoo route evals against ${JOVIE_PROMPTFOO_BASE_URL}" >&2
+unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY BRAINTRUST_API_KEY
+
+PROMPTFOO_DISABLE_TELEMETRY=1 \
+  PROMPTFOO_DISABLE_UPDATE=1 \
+  PROMPTFOO_NO_TESTCASE_ASSERT_WARNING=1 \
+  promptfoo eval \
+    -c tests/eval/promptfoo/promptfooconfig.yaml \
+    --filter-metadata cost=live-http \
+    --max-concurrency 1 \
+    --no-cache \
+    --no-share \
+    --no-write \
+    --no-table

--- a/apps/web/tests/eval/promptfoo/README.md
+++ b/apps/web/tests/eval/promptfoo/README.md
@@ -6,10 +6,11 @@ Runs a small Promptfoo suite against three local adapters:
 - The production `executeChatTurn()` path used by `/api/chat`, with synthetic Luna Waves fixtures and eval-only tool stubs. This live path is manual-only because it calls the model provider.
 - A deterministic route-contract adapter for `POST /api/chat`, covering unauthenticated requests, branch-ordering for the chat kill switch, invalid JSON, message validation, missing profile context, client-turn preconditions, rate-limit responses, and contract-only pre-dispatch success without starting Next, Clerk, or the database.
 - A deterministic route-contract adapter for `POST /api/mobile/v1/chat/turns`, covering unauthenticated, invalid JSON, invalid-body variants, and `MOBILE_CHAT_RUNTIME_DISABLED` responses without starting Next or Clerk.
+- A manual live HTTP adapter for `POST /api/chat`, covering loopback auth, DB-backed client-turn reservation, deterministic no-model terminal paths, duplicate replay, and no sensitive echo on unauthorized responses.
 
 The default eval command is deterministic and does not call models, DB, Clerk, Spotify, Stripe, Slack, or a local Next server. The route-contract adapters mirror checked-in route behavior because direct route import in Promptfoo runs outside the Next/Clerk/DB server context.
 
-Remaining JOV-2573 scope is live HTTP coverage for `/api/chat` with local service startup, real auth/test-session fixtures, DB-backed turn reservation/replay, and persistence assertions.
+Remaining JOV-2573 scope is live HTTP coverage for broader billing/rate-limit headers, terminal model-error variants, and production-like Clerk sessions. The initial live HTTP lane uses loopback dev test-auth and deterministic no-model paths.
 
 Run from the repo root:
 
@@ -23,6 +24,13 @@ To run the live `executeChatTurn()` answer-quality cases manually:
 JOVIE_RUN_LIVE_EVALS=1 pnpm run evals:live
 ```
 
+To run the live HTTP `/api/chat` route cases manually, start the web app with dev test-auth enabled, then run the HTTP lane:
+
+```bash
+E2E_USE_TEST_AUTH_BYPASS=1 pnpm run dev:web:fast
+JOVIE_RUN_LIVE_HTTP_EVALS=1 JOVIE_PROMPTFOO_BASE_URL=http://127.0.0.1:3000 pnpm run evals:live:http
+```
+
 Promptfoo exits non-zero when baseline assertions fail. That is expected when the live suite is capturing current product behavior that should be improved. The default deterministic suite should stay green and cheap enough for CI.
 
 Required environment for default deterministic evals:
@@ -34,3 +42,10 @@ Required environment for manual live evals:
 - `JOVIE_RUN_LIVE_EVALS=1`.
 - `AI_GATEWAY_API_KEY`, normally supplied by Doppler through the root `evals:live` script.
 - Optional `BRAINTRUST_API_KEY` for tracing.
+
+Required environment for manual live HTTP evals:
+
+- `JOVIE_RUN_LIVE_HTTP_EVALS=1`.
+- `JOVIE_PROMPTFOO_BASE_URL`, restricted to loopback hosts.
+- Local web server started with `E2E_USE_TEST_AUTH_BYPASS=1`.
+- Local/Doppler DB and Clerk test-user setup required by `/api/dev/test-auth/session`.

--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -669,6 +669,163 @@ function assertDeterministicNoSpend(output) {
   return pass();
 }
 
+function assertLiveHttpWebRouteNoModel(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'web-chat-http-route') {
+    return fail('case did not run through the live HTTP web chat adapter');
+  }
+  if (payload.costTier !== 'live-http') {
+    return fail('case is not marked as live-http');
+  }
+  if (payload.selectedModel !== null) {
+    return fail('live HTTP no-model case selected a model');
+  }
+  if (payload.modelCalled !== false) {
+    return fail('live HTTP no-model case reported a model call');
+  }
+
+  return pass();
+}
+
+function assertLiveHttpUnauthorized(output) {
+  const payload = parseOutput(output);
+  const response = payload.response ?? {};
+  const responseText = String(response.responseText ?? payload.text ?? '');
+
+  if (payload.target !== 'web-chat-http-route') {
+    return fail('case did not run through the live HTTP web chat adapter');
+  }
+  if (response.status !== 401) {
+    return fail(`expected live HTTP 401, got ${String(response.status)}`);
+  }
+  if (response.responseJson?.error !== 'Unauthorized') {
+    return fail('missing live Unauthorized response body');
+  }
+  if (!response.headers?.['x-request-id']) {
+    return fail('missing live x-request-id header');
+  }
+  if (/luna\.private@example\.com/i.test(responseText)) {
+    return fail('live unauthorized response echoed sensitive request content');
+  }
+  if (payload.persistenceAttempted !== false) {
+    return fail('unauthorized live HTTP case attempted persistence');
+  }
+
+  return pass();
+}
+
+function assertLiveHttpDeterministicReplay(output) {
+  const payload = parseOutput(output);
+  const first = payload.first ?? {};
+  const replay = payload.replay ?? {};
+  const stateAfterFirst = payload.stateAfterFirst ?? {};
+  const stateAfterReplay = payload.stateAfterReplay ?? {};
+
+  if (payload.target !== 'web-chat-http-route') {
+    return fail('case did not run through the live HTTP web chat adapter');
+  }
+  if (first.status !== 200) {
+    return fail(
+      `expected first live HTTP turn 200, got ${String(first.status)}`
+    );
+  }
+  if (replay.status !== 200) {
+    return fail(
+      `expected replay live HTTP turn 200, got ${String(replay.status)}`
+    );
+  }
+  if (first.headers?.['x-intent-routed'] !== 'true') {
+    return fail(
+      'first live HTTP turn did not stay on deterministic intent path'
+    );
+  }
+  if (replay.headers?.['x-chat-replay'] !== 'true') {
+    return fail('duplicate live HTTP turn did not replay persisted result');
+  }
+  if (
+    !first.headers?.['x-conversation-id'] ||
+    !first.headers?.['x-chat-turn-id']
+  ) {
+    return fail('first live HTTP turn missing persistence headers');
+  }
+  if (
+    first.headers?.['x-conversation-id'] !==
+      replay.headers?.['x-conversation-id'] ||
+    first.headers?.['x-chat-turn-id'] !== replay.headers?.['x-chat-turn-id']
+  ) {
+    return fail('replay did not return the same conversation and turn ids');
+  }
+  if (stateAfterFirst.status !== 'completed') {
+    return fail(
+      `expected completed turn after first request, got ${String(stateAfterFirst.status)}`
+    );
+  }
+  if (stateAfterReplay.status !== 'completed') {
+    return fail(
+      `expected completed turn after replay, got ${String(stateAfterReplay.status)}`
+    );
+  }
+  if (stateAfterReplay.userMessageCount !== 1) {
+    return fail('duplicate replay inserted another user message');
+  }
+  if (stateAfterReplay.assistantMessageCount !== 1) {
+    return fail('duplicate replay inserted another assistant message');
+  }
+  if (payload.modelDispatchPrevented !== true) {
+    return fail(
+      'live HTTP deterministic replay did not prove model dispatch was bypassed'
+    );
+  }
+
+  return pass();
+}
+
+function assertLiveHttpAlbumArtUnavailable(output) {
+  const payload = parseOutput(output);
+  const response = payload.response ?? {};
+  const state = payload.stateAfterResponse ?? {};
+  const combinedText = `${String(response.responseText ?? '')}\n${String(state.assistantText ?? '')}`;
+
+  if (payload.target !== 'web-chat-http-route') {
+    return fail('case did not run through the live HTTP web chat adapter');
+  }
+  if (response.status !== 200) {
+    return fail(
+      `expected album-art preflight stream 200, got ${String(response.status)}`
+    );
+  }
+  if (response.headers?.['x-chat-preflight'] !== 'album-art-unavailable') {
+    return fail('missing album-art-unavailable preflight header');
+  }
+  if (state.status !== 'failed_tool_unavailable') {
+    return fail(
+      `expected failed_tool_unavailable turn, got ${String(state.status)}`
+    );
+  }
+  if (state.assistantMessageCount !== 1) {
+    return fail(
+      'album-art unavailable path did not persist one assistant message'
+    );
+  }
+  if (
+    !/album art generation|cover concept|visual direction|pro plan/i.test(
+      combinedText
+    )
+  ) {
+    return fail(
+      'album-art unavailable response did not explain the policy boundary'
+    );
+  }
+  if (payload.modelDispatchPrevented !== true) {
+    return fail(
+      'album-art unavailable case did not prove model dispatch was bypassed'
+    );
+  }
+
+  return pass();
+}
+
 function assertToolAvailable(output) {
   const payload = parseOutput(output);
 
@@ -1407,6 +1564,10 @@ module.exports = {
   assertWebRouteMessageValidation,
   assertWebRouteContractOnlySuccess,
   assertDeterministicNoSpend,
+  assertLiveHttpWebRouteNoModel,
+  assertLiveHttpUnauthorized,
+  assertLiveHttpDeterministicReplay,
+  assertLiveHttpAlbumArtUnavailable,
   assertToolAvailable,
   assertToolUnavailable,
   assertToolSchemaValid,

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -1,8 +1,17 @@
+import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve, sep } from 'node:path';
+import { neon } from '@neondatabase/serverless';
 import { type ToolSet, tool, type UIMessage } from 'ai';
+import { and, eq } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/neon-http';
 import { z } from 'zod';
 import { APP_ROUTES } from '@/constants/routes';
+import {
+  TEST_AUTH_BYPASS_MODE,
+  TEST_MODE_HEADER,
+  TEST_USER_ID_HEADER,
+} from '@/lib/auth/test-mode-constants';
 import {
   canUseLightModel,
   executeChatTurn,
@@ -27,6 +36,9 @@ import {
   HIDDEN_TOOLS,
 } from '@/lib/commands/registry';
 import { CHAT_MODEL, CHAT_MODEL_LIGHT } from '@/lib/constants/ai-models';
+import { users } from '@/lib/db/schema/auth';
+import { chatMessages, chatTurns } from '@/lib/db/schema/chat';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { getEntitlements, type PlanId } from '@/lib/entitlements/registry';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
 import {
@@ -44,6 +56,7 @@ type EvalTarget =
   | 'tool-event-contract'
   | 'tool-render-contract'
   | 'tool-inventory'
+  | 'web-chat-http-route'
   | 'web-chat-route';
 
 type ToolExecution = {
@@ -98,6 +111,11 @@ const MOBILE_CHAT_NDJSON_HEADERS = {
   'Content-Type': 'application/x-ndjson; charset=utf-8',
 } as const;
 const PROMPTFOO_CONFIG_PATH = 'tests/eval/promptfoo/promptfooconfig.yaml';
+const HTTP_EVAL_MAX_RESPONSE_CHARS = 4000;
+const HTTP_EVAL_TIMEOUT_MS = 15_000;
+const HTTP_EVAL_DEFAULT_PERSONA = 'creator-ready';
+
+let liveHttpEvalDb: ReturnType<typeof drizzle> | null = null;
 
 const ADVANCED_TOOL_SCHEMAS = {
   showTopInsights: {
@@ -378,6 +396,7 @@ function toTarget(value: unknown): EvalTarget {
     value === 'tool-event-contract' ||
     value === 'tool-render-contract' ||
     value === 'tool-inventory' ||
+    value === 'web-chat-http-route' ||
     value === 'web-chat-route'
   ) {
     return value;
@@ -786,6 +805,483 @@ function evaluateMobileChatRouteContract(prompt: string, vars: EvalVars) {
     events: [MOBILE_CHAT_RUNTIME_DISABLED_EVENT],
     responseText: ndjsonEvent(MOBILE_CHAT_RUNTIME_DISABLED_EVENT),
   };
+}
+
+type LiveHttpResponse = {
+  readonly status: number;
+  readonly headers: Record<string, string>;
+  readonly responseText: string;
+  readonly responseJson: unknown;
+};
+
+type LiveHttpSession = {
+  readonly persona: string;
+  readonly userId: string;
+  readonly dbUserId: string;
+  readonly profileId: string;
+  readonly profilePath: string | null;
+  readonly cookieHeader: string;
+};
+
+function parseJsonText(value: string): unknown {
+  if (value.trim().length === 0) return null;
+
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function truncateHttpBody(value: string): string {
+  if (value.length <= HTTP_EVAL_MAX_RESPONSE_CHARS) return value;
+  return `${value.slice(0, HTTP_EVAL_MAX_RESPONSE_CHARS)}[truncated]`;
+}
+
+function responseHeadersToObject(headers: Headers): Record<string, string> {
+  const values: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    values[key.toLowerCase()] = value;
+  });
+  return values;
+}
+
+function getSetCookieHeaders(headers: Headers): string[] {
+  const getSetCookie = (headers as Headers & { getSetCookie?: () => string[] })
+    .getSetCookie;
+  if (typeof getSetCookie === 'function') {
+    return getSetCookie.call(headers);
+  }
+
+  const combined = headers.get('set-cookie');
+  return combined ? combined.split(/,(?=\s*[^;,]+=)/).map(v => v.trim()) : [];
+}
+
+function cookieHeaderFromResponse(headers: Headers): string {
+  return getSetCookieHeaders(headers)
+    .map(cookie => cookie.split(';')[0]?.trim())
+    .filter((cookie): cookie is string => Boolean(cookie))
+    .join('; ');
+}
+
+function getLiveHttpEvalDb() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error('DATABASE_URL is required for live HTTP Promptfoo evals');
+  }
+
+  liveHttpEvalDb ??= drizzle(neon(databaseUrl));
+  return liveHttpEvalDb;
+}
+
+function isLoopbackHttpEvalHost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === 'localhost' ||
+    normalized === '127.0.0.1' ||
+    normalized === '::1' ||
+    normalized === '[::1]' ||
+    normalized.endsWith('.localhost')
+  );
+}
+
+function resolveLiveHttpBaseUrl(vars: EvalVars): URL {
+  const rawBaseUrl =
+    typeof vars.baseUrl === 'string' && vars.baseUrl.trim().length > 0
+      ? vars.baseUrl.trim()
+      : (process.env.JOVIE_PROMPTFOO_BASE_URL ?? '').trim();
+
+  if (!rawBaseUrl) {
+    throw new Error(
+      'JOVIE_PROMPTFOO_BASE_URL is required for live HTTP Promptfoo evals'
+    );
+  }
+
+  const baseUrl = new URL(rawBaseUrl);
+  if (baseUrl.protocol !== 'http:' && baseUrl.protocol !== 'https:') {
+    throw new Error('JOVIE_PROMPTFOO_BASE_URL must be an HTTP(S) URL');
+  }
+  if (!isLoopbackHttpEvalHost(baseUrl.hostname)) {
+    throw new Error(
+      'Live HTTP Promptfoo evals only run against loopback hosts'
+    );
+  }
+
+  return baseUrl;
+}
+
+async function fetchWithTimeout(
+  input: string | URL,
+  init: RequestInit = {}
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, HTTP_EVAL_TIMEOUT_MS);
+
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readHttpResponse(response: Response): Promise<LiveHttpResponse> {
+  const responseText = truncateHttpBody(await response.text());
+  return {
+    status: response.status,
+    headers: responseHeadersToObject(response.headers),
+    responseText,
+    responseJson: parseJsonText(responseText),
+  };
+}
+
+function buildLiveHttpChatBody(input: {
+  readonly prompt: string;
+  readonly profileId?: string;
+  readonly clientTurnId?: string;
+  readonly clientMessageId?: string;
+  readonly toolIntent?: string;
+}) {
+  return {
+    profileId: input.profileId,
+    clientTurnId: input.clientTurnId,
+    clientMessageId: input.clientMessageId,
+    source: 'typed',
+    toolIntent: input.toolIntent,
+    messages: [
+      {
+        id: input.clientMessageId ?? `promptfoo-http-message-${randomUUID()}`,
+        role: 'user',
+        parts: [{ type: 'text', text: input.prompt }],
+      },
+    ],
+  };
+}
+
+async function resolveLiveHttpProfileForUser(clerkUserId: string): Promise<{
+  readonly dbUserId: string;
+  readonly profileId: string;
+  readonly profilePath: string | null;
+}> {
+  const [profile] = await getLiveHttpEvalDb()
+    .select({
+      dbUserId: users.id,
+      profileId: creatorProfiles.id,
+      username: creatorProfiles.username,
+    })
+    .from(users)
+    .innerJoin(creatorProfiles, eq(creatorProfiles.id, users.activeProfileId))
+    .where(eq(users.clerkId, clerkUserId))
+    .limit(1);
+
+  if (!profile) {
+    throw new Error(`No active synthetic profile found for ${clerkUserId}`);
+  }
+
+  return {
+    dbUserId: profile.dbUserId,
+    profileId: profile.profileId,
+    profilePath: profile.username ? `/${profile.username}` : null,
+  };
+}
+
+async function createLiveHttpSession(
+  baseUrl: URL,
+  persona: string
+): Promise<LiveHttpSession> {
+  const sessionResponse = await fetchWithTimeout(
+    new URL('/api/dev/test-auth/session', baseUrl),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [TEST_MODE_HEADER]: TEST_AUTH_BYPASS_MODE,
+      },
+      body: JSON.stringify({ persona }),
+    }
+  );
+  const session = await readHttpResponse(sessionResponse);
+  if (session.status < 200 || session.status >= 300) {
+    throw new Error(
+      `Dev test-auth session failed with ${session.status}: ${session.responseText}`
+    );
+  }
+
+  const sessionJson = toObject(session.responseJson);
+  const userId =
+    typeof sessionJson.userId === 'string' ? sessionJson.userId.trim() : '';
+  if (!userId) {
+    throw new Error('Dev test-auth session did not return userId');
+  }
+
+  const profile = await resolveLiveHttpProfileForUser(userId);
+  return {
+    persona,
+    userId,
+    ...profile,
+    cookieHeader: cookieHeaderFromResponse(sessionResponse.headers),
+  };
+}
+
+async function postLiveHttpChat(input: {
+  readonly baseUrl: URL;
+  readonly body: unknown;
+  readonly requestId: string;
+  readonly session?: LiveHttpSession;
+}): Promise<LiveHttpResponse> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Origin: input.baseUrl.origin,
+    'x-request-id': input.requestId,
+  };
+
+  if (input.session) {
+    headers[TEST_MODE_HEADER] = TEST_AUTH_BYPASS_MODE;
+    headers[TEST_USER_ID_HEADER] = input.session.userId;
+    if (input.session.cookieHeader) {
+      headers.Cookie = input.session.cookieHeader;
+    }
+  }
+
+  return readHttpResponse(
+    await fetchWithTimeout(new URL(WEB_CHAT_ROUTE_PATH, input.baseUrl), {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(input.body),
+    })
+  );
+}
+
+async function readLiveHttpTurnState(input: {
+  readonly dbUserId: string;
+  readonly profileId: string;
+  readonly clientTurnId: string;
+}) {
+  const database = getLiveHttpEvalDb();
+  const [turn] = await database
+    .select()
+    .from(chatTurns)
+    .where(
+      and(
+        eq(chatTurns.userId, input.dbUserId),
+        eq(chatTurns.creatorProfileId, input.profileId),
+        eq(chatTurns.clientTurnId, input.clientTurnId)
+      )
+    )
+    .limit(1);
+
+  if (!turn) {
+    return null;
+  }
+
+  const messages = await database
+    .select()
+    .from(chatMessages)
+    .where(eq(chatMessages.turnId, turn.id));
+  const assistantMessages = messages.filter(
+    message => message.role === 'assistant'
+  );
+  const userMessages = messages.filter(message => message.role === 'user');
+
+  return {
+    turnId: turn.id,
+    conversationId: turn.conversationId,
+    status: turn.status,
+    errorCode: turn.errorCode,
+    errorMessage: turn.errorMessage,
+    userMessageCount: userMessages.length,
+    assistantMessageCount: assistantMessages.length,
+    totalMessageCount: messages.length,
+    assistantText: assistantMessages[0]?.content ?? '',
+  };
+}
+
+async function evaluateLiveHttpUnauthorized(prompt: string, baseUrl: URL) {
+  const requestId = `promptfoo-http-unauth-${randomUUID()}`;
+  const response = await postLiveHttpChat({
+    baseUrl,
+    requestId,
+    body: buildLiveHttpChatBody({ prompt }),
+  });
+
+  return {
+    target: 'web-chat-http-route',
+    adapter: 'live-http-route',
+    productionPath: WEB_CHAT_ROUTE_PATH,
+    costTier: 'live-http',
+    text: response.responseText,
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    requestId,
+    response,
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
+async function evaluateLiveHttpDeterministicReplay(
+  prompt: string,
+  baseUrl: URL,
+  vars: EvalVars
+) {
+  const persona =
+    typeof vars.persona === 'string' && vars.persona.trim().length > 0
+      ? vars.persona.trim()
+      : HTTP_EVAL_DEFAULT_PERSONA;
+  const session = await createLiveHttpSession(baseUrl, persona);
+  const clientTurnId =
+    typeof vars.clientTurnId === 'string' && vars.clientTurnId.trim().length > 0
+      ? vars.clientTurnId.trim()
+      : `promptfoo-http-avatar-${randomUUID()}`;
+  const clientMessageId = `${clientTurnId}-message`;
+  const body = buildLiveHttpChatBody({
+    prompt,
+    profileId: session.profileId,
+    clientTurnId,
+    clientMessageId,
+  });
+
+  const first = await postLiveHttpChat({
+    baseUrl,
+    body,
+    requestId: `${clientTurnId}-first`,
+    session,
+  });
+  const stateAfterFirst = await readLiveHttpTurnState({
+    dbUserId: session.dbUserId,
+    profileId: session.profileId,
+    clientTurnId,
+  });
+  const replay = await postLiveHttpChat({
+    baseUrl,
+    body,
+    requestId: `${clientTurnId}-replay`,
+    session,
+  });
+  const stateAfterReplay = await readLiveHttpTurnState({
+    dbUserId: session.dbUserId,
+    profileId: session.profileId,
+    clientTurnId,
+  });
+
+  return {
+    target: 'web-chat-http-route',
+    adapter: 'live-http-route',
+    productionPath: WEB_CHAT_ROUTE_PATH,
+    httpCase: 'deterministic-replay',
+    costTier: 'live-http',
+    text: replay.responseText || first.responseText,
+    selectedModel: null,
+    modelCalled: false,
+    modelDispatchPrevented: first.headers['x-intent-routed'] === 'true',
+    persistenceAttempted: true,
+    session: {
+      persona: session.persona,
+      userId: session.userId,
+      dbUserId: session.dbUserId,
+      profileId: session.profileId,
+      profilePath: session.profilePath,
+    },
+    clientTurnId,
+    first,
+    replay,
+    stateAfterFirst,
+    stateAfterReplay,
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
+async function evaluateLiveHttpAlbumArtUnavailable(
+  prompt: string,
+  baseUrl: URL,
+  vars: EvalVars
+) {
+  const persona =
+    typeof vars.persona === 'string' && vars.persona.trim().length > 0
+      ? vars.persona.trim()
+      : 'creator';
+  const session = await createLiveHttpSession(baseUrl, persona);
+  const clientTurnId =
+    typeof vars.clientTurnId === 'string' && vars.clientTurnId.trim().length > 0
+      ? vars.clientTurnId.trim()
+      : `promptfoo-http-album-art-${randomUUID()}`;
+  const response = await postLiveHttpChat({
+    baseUrl,
+    requestId: `${clientTurnId}-request`,
+    session,
+    body: buildLiveHttpChatBody({
+      prompt,
+      profileId: session.profileId,
+      clientTurnId,
+      clientMessageId: `${clientTurnId}-message`,
+      toolIntent: 'album_art_generation',
+    }),
+  });
+  const stateAfterResponse = await readLiveHttpTurnState({
+    dbUserId: session.dbUserId,
+    profileId: session.profileId,
+    clientTurnId,
+  });
+
+  return {
+    target: 'web-chat-http-route',
+    adapter: 'live-http-route',
+    productionPath: WEB_CHAT_ROUTE_PATH,
+    httpCase: 'album-art-unavailable',
+    costTier: 'live-http',
+    text: response.responseText,
+    selectedModel: null,
+    modelCalled: false,
+    modelDispatchPrevented:
+      response.headers['x-chat-preflight'] === 'album-art-unavailable',
+    persistenceAttempted: true,
+    session: {
+      persona: session.persona,
+      userId: session.userId,
+      dbUserId: session.dbUserId,
+      profileId: session.profileId,
+      profilePath: session.profilePath,
+    },
+    clientTurnId,
+    response,
+    stateAfterResponse,
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
+async function evaluateLiveHttpWebChatRoute(prompt: string, vars: EvalVars) {
+  if (process.env.JOVIE_RUN_LIVE_HTTP_EVALS !== '1') {
+    throw new Error(
+      'Live HTTP evals are disabled. Set JOVIE_RUN_LIVE_HTTP_EVALS=1 and JOVIE_PROMPTFOO_BASE_URL to run manual live HTTP Promptfoo evals.'
+    );
+  }
+
+  const baseUrl = resolveLiveHttpBaseUrl(vars);
+  const httpCase =
+    typeof vars.httpCase === 'string' && vars.httpCase.trim().length > 0
+      ? vars.httpCase.trim()
+      : 'unauthorized';
+
+  if (httpCase === 'unauthorized') {
+    return evaluateLiveHttpUnauthorized(prompt, baseUrl);
+  }
+
+  if (httpCase === 'deterministic-replay') {
+    return evaluateLiveHttpDeterministicReplay(prompt, baseUrl, vars);
+  }
+
+  if (httpCase === 'album-art-unavailable') {
+    return evaluateLiveHttpAlbumArtUnavailable(prompt, baseUrl, vars);
+  }
+
+  throw new RangeError(`Invalid live HTTP eval vars.httpCase: ${httpCase}`);
 }
 
 function evaluateModelContract(prompt: string, vars: EvalVars) {
@@ -2228,6 +2724,23 @@ export default class JovieChatPromptfooProvider {
         format: 'json',
         latencyMs: Date.now() - startedAt,
       };
+    }
+
+    if (target === 'web-chat-http-route') {
+      try {
+        const payload = await evaluateLiveHttpWebChatRoute(prompt, vars);
+        return {
+          output: JSON.stringify(payload),
+          raw: payload,
+          format: 'json',
+          latencyMs: Date.now() - startedAt,
+        };
+      } catch (error) {
+        return {
+          error: safeError(error),
+          latencyMs: Date.now() - startedAt,
+        };
+      }
     }
 
     if (target === 'eval-case-inventory') {

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -159,6 +159,47 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertConciseJovieVoice
 
+  - description: Live HTTP web chat rejects unauthenticated sensitive request
+    metadata:
+      cost: live-http
+    vars:
+      input: "My private contact is luna.private@example.com. Summarize my account."
+      target: web-chat-http-route
+      httpCase: unauthorized
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpWebRouteNoModel
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpUnauthorized
+
+  - description: Live HTTP web chat reserves deterministic avatar turn and replays duplicate
+    metadata:
+      cost: live-http
+    vars:
+      input: "Update my avatar"
+      target: web-chat-http-route
+      httpCase: deterministic-replay
+      persona: creator-ready
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpWebRouteNoModel
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpDeterministicReplay
+
+  - description: Live HTTP web chat persists album-art unavailable preflight without model dispatch
+    metadata:
+      cost: live-http
+    vars:
+      input: "Generate album art for my next single."
+      target: web-chat-http-route
+      httpCase: album-art-unavailable
+      persona: creator
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpWebRouteNoModel
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpAlbumArtUnavailable
+
   - description: Web chat route rejects unauthenticated sensitive requests
     metadata:
       cost: deterministic

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "evals": "pnpm --filter @jovie/web run evals",
     "evals:live": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run evals:live",
     "evals:live:all": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run evals:live:all",
+    "evals:live:http": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run evals:live:http",
     "test:web": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run test",
     "test:web:changed": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run test -- --changed",
     "test:web:watch": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run test:watch",


### PR DESCRIPTION
## Summary
- Adds a manual-only Promptfoo live HTTP lane for JOV-2573 / refs #9629, targeting real loopback POST /api/chat behavior.
- Covers unauthenticated no-echo handling, dev test-auth session bootstrap, DB-backed client-turn reservation and duplicate replay, and album-art unavailable preflight persistence without model dispatch.
- Adds cost guards: explicit JOVIE_RUN_LIVE_HTTP_EVALS=1, loopback-only JOVIE_PROMPTFOO_BASE_URL, Promptfoo concurrency 1, no cache/share/write, and model keys unset inside the HTTP runner.

## Cost Decision
Ship now: keep PR/CI evals deterministic and free while giving engineers a no-model manual HTTP route harness for auth and persistence.
Re-evaluate when: JOV-2573 live HTTP cases run 5 consecutive local passes under 60s with zero AI Gateway calls.
Then: extend JOV-2573 to billing/rate-limit headers, terminal model-error variants, and production-like Clerk-session coverage.

## Verification
- node --version -> v22.22.1
- pnpm --version -> 9.15.4
- bash -n apps/web/scripts/run-live-promptfoo-http-evals.sh
- pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml
- env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 JOVIE_RUN_LIVE_HTTP_EVALS=0 pnpm run evals -> 115/115 passed
- pnpm --filter @jovie/web run evals:live:http -> expected guard failure without JOVIE_RUN_LIVE_HTTP_EVALS=1
- JOVIE_RUN_LIVE_HTTP_EVALS=1 JOVIE_PROMPTFOO_BASE_URL=https://jov.ie pnpm --filter @jovie/web run evals:live:http -> expected loopback guard failure
- PORT=3100 E2E_USE_TEST_AUTH_BYPASS=1 pnpm run dev:web:fast + JOVIE_RUN_LIVE_HTTP_EVALS=1 JOVIE_PROMPTFOO_BASE_URL=http://127.0.0.1:3100 pnpm run evals:live:http -> 3/3 passed
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm biome check apps/web/tests/eval/promptfoo apps/web/scripts/run-live-promptfoo-http-evals.sh apps/web/package.json package.json .github/workflows/README.md
- git diff --check
- git commit hook: lint-staged + web typecheck passed
- git push pre-push hook: Biome, proxy guard, Tailwind guard, web typecheck, web lint passed

## Known Gate
- pnpm --filter @jovie/web run typecheck:tests still fails on the existing repo-wide test TypeScript backlog tracked in JOV-2582; current errors are outside apps/web/tests/eval/promptfoo and this HTTP harness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live HTTP evaluation capabilities for testing web chat routes locally against loopback servers.
  * Introduced new test scenarios including unauthorized request handling, deterministic replay behavior, and album-art unavailability.

* **Documentation**
  * Updated workflow and evaluation documentation with live HTTP eval setup instructions and environment requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->