### PR TITLE
test(promptfoo): expand live HTTP chat validations

### DIFF
--- a/apps/web/tests/eval/promptfoo/README.md
+++ b/apps/web/tests/eval/promptfoo/README.md
@@ -6,11 +6,13 @@ Runs a small Promptfoo suite against three local adapters:
 - The production `executeChatTurn()` path used by `/api/chat`, with synthetic Luna Waves fixtures and eval-only tool stubs. This live path is manual-only because it calls the model provider.
 - A deterministic route-contract adapter for `POST /api/chat`, covering unauthenticated requests, branch-ordering for the chat kill switch, invalid JSON, message validation, missing profile context, client-turn preconditions, rate-limit responses, and contract-only pre-dispatch success without starting Next, Clerk, or the database.
 - A deterministic route-contract adapter for `POST /api/mobile/v1/chat/turns`, covering unauthenticated, invalid JSON, invalid-body variants, and `MOBILE_CHAT_RUNTIME_DISABLED` responses without starting Next or Clerk.
-- A manual live HTTP adapter for `POST /api/chat`, covering loopback auth, DB-backed client-turn reservation, deterministic no-model terminal paths, duplicate replay, and no sensitive echo on unauthorized responses.
+- A manual live HTTP adapter for `POST /api/chat`, covering loopback auth, authenticated validation errors, client-turn preconditions, DB-backed client-turn reservation, deterministic no-model terminal paths, duplicate replay, and no sensitive echo on unauthorized responses.
 
 The default eval command is deterministic and does not call models, DB, Clerk, Spotify, Stripe, Slack, or a local Next server. The route-contract adapters mirror checked-in route behavior because direct route import in Promptfoo runs outside the Next/Clerk/DB server context.
 
-Remaining JOV-2573 scope is live HTTP coverage for broader billing/rate-limit headers, terminal model-error variants, and production-like Clerk sessions. The initial live HTTP lane uses loopback dev test-auth and deterministic no-model paths.
+Remaining JOV-2573 scope is live HTTP coverage for isolated rate-limit headers, terminal model-error variants, and production-like Clerk sessions. The current live HTTP lane uses loopback dev test-auth and deterministic no-model paths.
+
+Cost decision: Ship now live HTTP validation and persistence coverage that never needs model dispatch. Re-evaluate when a local eval server can reliably start with Redis disabled or namespace-isolated, so rate-limit exhaustion costs zero external quota and cannot poison shared dev state. Then add live HTTP rate-limit exhaustion cases with capped request counts and concurrency 1.
 
 Run from the repo root:
 

--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -715,6 +715,80 @@ function assertLiveHttpUnauthorized(output) {
   return pass();
 }
 
+function assertLiveHttpInvalidJson(output) {
+  const payload = parseOutput(output);
+  const response = payload.response ?? {};
+
+  if (payload.target !== 'web-chat-http-route') {
+    return fail('case did not run through the live HTTP web chat adapter');
+  }
+  if (response.status !== 400) {
+    return fail(`expected live HTTP 400, got ${String(response.status)}`);
+  }
+  if (response.responseJson?.error !== 'Invalid JSON body') {
+    return fail('missing live Invalid JSON body response');
+  }
+  if (!response.headers?.['x-request-id']) {
+    return fail('missing live x-request-id header');
+  }
+  if (payload.persistenceAttempted !== false) {
+    return fail('invalid JSON live HTTP case attempted persistence');
+  }
+
+  return pass();
+}
+
+function assertLiveHttpMissingContext(output) {
+  const payload = parseOutput(output);
+  const response = payload.response ?? {};
+
+  if (payload.target !== 'web-chat-http-route') {
+    return fail('case did not run through the live HTTP web chat adapter');
+  }
+  if (response.status !== 400) {
+    return fail(`expected live HTTP 400, got ${String(response.status)}`);
+  }
+  if (response.responseJson?.error !== 'Missing profileId or artistContext') {
+    return fail('missing live profile-or-context validation error');
+  }
+  if (!response.headers?.['x-request-id']) {
+    return fail('missing live x-request-id header');
+  }
+  if (payload.persistenceAttempted !== false) {
+    return fail('missing-context live HTTP case attempted persistence');
+  }
+
+  return pass();
+}
+
+function assertLiveHttpClientTurnRequiresProfile(output) {
+  const payload = parseOutput(output);
+  const response = payload.response ?? {};
+
+  if (payload.target !== 'web-chat-http-route') {
+    return fail('case did not run through the live HTTP web chat adapter');
+  }
+  if (response.status !== 400) {
+    return fail(`expected live HTTP 400, got ${String(response.status)}`);
+  }
+  if (
+    response.responseJson?.error !==
+    'profileId is required when clientTurnId is provided'
+  ) {
+    return fail('missing live clientTurnId profile validation error');
+  }
+  if (!response.headers?.['x-request-id']) {
+    return fail('missing live x-request-id header');
+  }
+  if (payload.persistenceAttempted !== false) {
+    return fail(
+      'client-turn precondition live HTTP case attempted persistence'
+    );
+  }
+
+  return pass();
+}
+
 function assertLiveHttpDeterministicReplay(output) {
   const payload = parseOutput(output);
   const first = payload.first ?? {};
@@ -1566,6 +1640,9 @@ module.exports = {
   assertDeterministicNoSpend,
   assertLiveHttpWebRouteNoModel,
   assertLiveHttpUnauthorized,
+  assertLiveHttpInvalidJson,
+  assertLiveHttpMissingContext,
+  assertLiveHttpClientTurnRequiresProfile,
   assertLiveHttpDeterministicReplay,
   assertLiveHttpAlbumArtUnavailable,
   assertToolAvailable,

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -1026,7 +1026,8 @@ async function createLiveHttpSession(
 
 async function postLiveHttpChat(input: {
   readonly baseUrl: URL;
-  readonly body: unknown;
+  readonly body?: unknown;
+  readonly rawBody?: string;
   readonly requestId: string;
   readonly session?: LiveHttpSession;
 }): Promise<LiveHttpResponse> {
@@ -1048,7 +1049,7 @@ async function postLiveHttpChat(input: {
     await fetchWithTimeout(new URL(WEB_CHAT_ROUTE_PATH, input.baseUrl), {
       method: 'POST',
       headers,
-      body: JSON.stringify(input.body),
+      body: input.rawBody ?? JSON.stringify(input.body),
     })
   );
 }
@@ -1114,6 +1115,145 @@ async function evaluateLiveHttpUnauthorized(prompt: string, baseUrl: URL) {
     selectedModel: null,
     modelCalled: false,
     persistenceAttempted: false,
+    requestId,
+    response,
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
+async function evaluateLiveHttpInvalidJson(baseUrl: URL, vars: EvalVars) {
+  const persona =
+    typeof vars.persona === 'string' && vars.persona.trim().length > 0
+      ? vars.persona.trim()
+      : HTTP_EVAL_DEFAULT_PERSONA;
+  const session = await createLiveHttpSession(baseUrl, persona);
+  const requestId = `promptfoo-http-invalid-json-${randomUUID()}`;
+  const response = await postLiveHttpChat({
+    baseUrl,
+    requestId,
+    session,
+    rawBody: '{"messages":',
+  });
+
+  return {
+    target: 'web-chat-http-route',
+    adapter: 'live-http-route',
+    productionPath: WEB_CHAT_ROUTE_PATH,
+    httpCase: 'invalid-json',
+    costTier: 'live-http',
+    text: response.responseText,
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    session: {
+      persona: session.persona,
+      userId: session.userId,
+      dbUserId: session.dbUserId,
+      profileId: session.profileId,
+      profilePath: session.profilePath,
+    },
+    requestId,
+    response,
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
+async function evaluateLiveHttpMissingContext(
+  prompt: string,
+  baseUrl: URL,
+  vars: EvalVars
+) {
+  const persona =
+    typeof vars.persona === 'string' && vars.persona.trim().length > 0
+      ? vars.persona.trim()
+      : HTTP_EVAL_DEFAULT_PERSONA;
+  const session = await createLiveHttpSession(baseUrl, persona);
+  const requestId = `promptfoo-http-missing-context-${randomUUID()}`;
+  const response = await postLiveHttpChat({
+    baseUrl,
+    requestId,
+    session,
+    body: {
+      messages: buildLiveHttpChatBody({ prompt }).messages,
+    },
+  });
+
+  return {
+    target: 'web-chat-http-route',
+    adapter: 'live-http-route',
+    productionPath: WEB_CHAT_ROUTE_PATH,
+    httpCase: 'missing-context',
+    costTier: 'live-http',
+    text: response.responseText,
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    session: {
+      persona: session.persona,
+      userId: session.userId,
+      dbUserId: session.dbUserId,
+      profileId: session.profileId,
+      profilePath: session.profilePath,
+    },
+    requestId,
+    response,
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
+async function evaluateLiveHttpClientTurnRequiresProfile(
+  prompt: string,
+  baseUrl: URL,
+  vars: EvalVars
+) {
+  const persona =
+    typeof vars.persona === 'string' && vars.persona.trim().length > 0
+      ? vars.persona.trim()
+      : HTTP_EVAL_DEFAULT_PERSONA;
+  const session = await createLiveHttpSession(baseUrl, persona);
+  const clientTurnId =
+    typeof vars.clientTurnId === 'string' && vars.clientTurnId.trim().length > 0
+      ? vars.clientTurnId.trim()
+      : `promptfoo-http-client-turn-${randomUUID()}`;
+  const requestId = `${clientTurnId}-request`;
+  const response = await postLiveHttpChat({
+    baseUrl,
+    requestId,
+    session,
+    body: {
+      ...buildLiveHttpChatBody({
+        prompt,
+        clientTurnId,
+        clientMessageId: `${clientTurnId}-message`,
+      }),
+      artistContext: buildTestArtistContext(),
+    },
+  });
+
+  return {
+    target: 'web-chat-http-route',
+    adapter: 'live-http-route',
+    productionPath: WEB_CHAT_ROUTE_PATH,
+    httpCase: 'client-turn-requires-profile',
+    costTier: 'live-http',
+    text: response.responseText,
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    session: {
+      persona: session.persona,
+      userId: session.userId,
+      dbUserId: session.dbUserId,
+      profileId: session.profileId,
+      profilePath: session.profilePath,
+    },
+    clientTurnId,
     requestId,
     response,
     toolCalls: [],
@@ -1271,6 +1411,18 @@ async function evaluateLiveHttpWebChatRoute(prompt: string, vars: EvalVars) {
 
   if (httpCase === 'unauthorized') {
     return evaluateLiveHttpUnauthorized(prompt, baseUrl);
+  }
+
+  if (httpCase === 'invalid-json') {
+    return evaluateLiveHttpInvalidJson(baseUrl, vars);
+  }
+
+  if (httpCase === 'missing-context') {
+    return evaluateLiveHttpMissingContext(prompt, baseUrl, vars);
+  }
+
+  if (httpCase === 'client-turn-requires-profile') {
+    return evaluateLiveHttpClientTurnRequiresProfile(prompt, baseUrl, vars);
   }
 
   if (httpCase === 'deterministic-replay') {

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -172,6 +172,48 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertLiveHttpUnauthorized
 
+  - description: Live HTTP web chat validates invalid JSON before model dispatch
+    metadata:
+      cost: live-http
+    vars:
+      input: "This body is intentionally invalid JSON."
+      target: web-chat-http-route
+      httpCase: invalid-json
+      persona: creator-ready
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpWebRouteNoModel
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpInvalidJson
+
+  - description: Live HTTP web chat requires profile context before model dispatch
+    metadata:
+      cost: live-http
+    vars:
+      input: "What should I do next?"
+      target: web-chat-http-route
+      httpCase: missing-context
+      persona: creator-ready
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpWebRouteNoModel
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpMissingContext
+
+  - description: Live HTTP web chat requires profileId before client-turn reservation
+    metadata:
+      cost: live-http
+    vars:
+      input: "Reserve this action without a profile."
+      target: web-chat-http-route
+      httpCase: client-turn-requires-profile
+      persona: creator-ready
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpWebRouteNoModel
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpClientTurnRequiresProfile
+
   - description: Live HTTP web chat reserves deterministic avatar turn and replays duplicate
     metadata:
       cost: live-http


### PR DESCRIPTION
## Summary
- Expands the manual `cost=live-http` Promptfoo lane for `POST /api/chat` from 3 to 6 loopback cases.
- Adds authenticated no-model route checks for invalid JSON, missing profile context, and `clientTurnId` without `profileId`.
- Keeps default `pnpm run evals` deterministic and documents the cost boundary for live rate-limit exhaustion.

## Cost Control
Ship now: live HTTP validation and persistence coverage that never needs model dispatch.
Re-evaluate when: a local eval server can reliably start with Redis disabled or namespace-isolated, so rate-limit exhaustion costs zero external quota and cannot poison shared dev state.
Then: add live HTTP rate-limit exhaustion cases with capped request counts and concurrency 1 under JOV-2573.

## Verification
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml` passed.
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 JOVIE_RUN_LIVE_HTTP_EVALS=0 pnpm run evals` passed, 115/115 deterministic cases.
- `JOVIE_RUN_LIVE_HTTP_EVALS=1 JOVIE_PROMPTFOO_BASE_URL=http://127.0.0.1:3100 pnpm run evals:live:http` passed, 6/6 live HTTP cases.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/README.md` passed.
- `git diff --check` passed.
- Pre-push hook passed: Biome, proxy guard, Tailwind guard, web typecheck, web lint.

## Known Gate
- `pnpm --filter @jovie/web run typecheck:tests` still fails on the existing repo-wide test TypeScript backlog tracked in JOV-2582. Current first failures are outside `apps/web/tests/eval/promptfoo`, starting in `scripts/drizzle-migrate.ts`, `scripts/drizzle-seed.ts`, `scripts/generate-brand-assets.ts`, overnight/perf scripts, and profile/release tests.
