### PR TITLE
test(promptfoo): add isolated live HTTP rate-limit eval

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -52,17 +52,18 @@ The main CI workflow `ci.yml` is the gatekeeper for PRs to `main`. It includes:
 
 ## Promptfoo Eval Cost Controls
 
-Promptfoo has two explicit cost lanes:
+Promptfoo has explicit cost lanes:
 
 - **Deterministic evals** run through `pnpm run evals` and the `Promptfoo Evals (deterministic)` CI job. They unset live model keys, set `JOVIE_RUN_LIVE_EVALS=0`, use `cost=deterministic`, and run with `--no-share --no-write`.
 - **Live evals** run only from `pnpm run evals:live`, which is wrapped by Doppler at the repo root and still fails unless `JOVIE_RUN_LIVE_EVALS=1` and `AI_GATEWAY_API_KEY` are present. The live Promptfoo lane is manual-only, concurrency 1, and uses `--no-share --no-write`.
 - **Live HTTP evals** run only from `pnpm run evals:live:http`, require `JOVIE_RUN_LIVE_HTTP_EVALS=1` plus a loopback `JOVIE_PROMPTFOO_BASE_URL`, and unset model keys before running Promptfoo. This lane exercises real `/api/chat` HTTP auth and persistence with deterministic no-model chat paths.
+- **Live HTTP rate-limit evals** run only from `pnpm run evals:live:http:rate-limit`, require `JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=1`, `JOVIE_PROMPTFOO_EXPECT_REDIS_DISABLED=1`, and a loopback `JOVIE_PROMPTFOO_BASE_URL`. Start the local server with `JOVIE_DISABLE_REDIS_FOR_EVALS=1` and `JOVIE_DISABLE_MODEL_KEYS_FOR_EVALS=1`; this lane is manual-only and validates fail-closed 429 headers without touching shared Redis or model providers.
 
 The legacy `evals-periodic.yml` workflow is also manual-only. It has no scheduled trigger, requires typing `RUN_LIVE_EVALS` into `confirm_live_llm_evals`, and runs at concurrency 1 if explicitly invoked.
 
 Ship now / Re-evaluate when / Then:
 
-- Ship now: deterministic PR evals stay free, every live LLM eval surface requires manual intent and concurrency 1, and live HTTP route evals stay manual plus no-model.
+- Ship now: deterministic PR evals stay free, every live LLM eval surface requires manual intent and concurrency 1, live HTTP route evals stay manual plus no-model, and live rate-limit evals require Redis/model-key-disabled local server mode.
 - Re-evaluate when: manual live evals catch a release-blocking regression twice in 30 days or observed live eval cost stays below the agreed per-run budget for 10 consecutive runs.
 - Then: add a capped scheduled or PR-gated live subset with explicit case count, concurrency 1, and per-run cost reporting.
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "evals:live": "bash scripts/run-live-promptfoo-evals.sh smoke",
     "evals:live:all": "bash scripts/run-live-promptfoo-evals.sh all",
     "evals:live:http": "bash scripts/run-live-promptfoo-http-evals.sh",
+    "evals:live:http:rate-limit": "bash scripts/run-live-promptfoo-http-rate-limit-evals.sh",
     "test": "NODE_OPTIONS=--max-old-space-size=8192 node scripts/vitest-wrapper.mjs",
     "test:ci": "NODE_OPTIONS=--max-old-space-size=8192 vitest run --pool=forks --maxWorkers=2",
     "test:coverage": "vitest run --coverage",

--- a/apps/web/scripts/run-live-promptfoo-http-rate-limit-evals.sh
+++ b/apps/web/scripts/run-live-promptfoo-http-rate-limit-evals.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS:-}" != "1" ]; then
+  echo "Set JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=1 to run live HTTP rate-limit Promptfoo evals" >&2
+  exit 1
+fi
+
+if [ "${JOVIE_PROMPTFOO_EXPECT_REDIS_DISABLED:-}" != "1" ]; then
+  echo "Set JOVIE_PROMPTFOO_EXPECT_REDIS_DISABLED=1 after starting the local server with JOVIE_DISABLE_REDIS_FOR_EVALS=1" >&2
+  exit 1
+fi
+
+if [ -z "${JOVIE_PROMPTFOO_BASE_URL:-}" ]; then
+  echo "JOVIE_PROMPTFOO_BASE_URL is required for live HTTP rate-limit Promptfoo evals" >&2
+  exit 1
+fi
+
+case "${JOVIE_PROMPTFOO_BASE_URL}" in
+  http://localhost:* | http://127.0.0.1:* | http://[[]::1[]]:* | http://*.localhost:* | https://localhost:* | https://127.0.0.1:* | https://[[]::1[]]:* | https://*.localhost:*)
+    ;;
+  *)
+    echo "Live HTTP rate-limit Promptfoo evals only run against loopback hosts" >&2
+    exit 1
+    ;;
+esac
+
+echo "Running live HTTP rate-limit Promptfoo evals against ${JOVIE_PROMPTFOO_BASE_URL}" >&2
+unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY BRAINTRUST_API_KEY
+unset UPSTASH_REDIS_REST_URL UPSTASH_REDIS_REST_TOKEN
+export JOVIE_RUN_LIVE_HTTP_EVALS=1
+
+PROMPTFOO_DISABLE_TELEMETRY=1 \
+  PROMPTFOO_DISABLE_UPDATE=1 \
+  PROMPTFOO_NO_TESTCASE_ASSERT_WARNING=1 \
+  promptfoo eval \
+    -c tests/eval/promptfoo/promptfooconfig.yaml \
+    --filter-metadata cost=live-rate-limit \
+    --max-concurrency 1 \
+    --no-cache \
+    --no-share \
+    --no-write \
+    --no-table

--- a/apps/web/tests/eval/promptfoo/README.md
+++ b/apps/web/tests/eval/promptfoo/README.md
@@ -1,18 +1,19 @@
 # Promptfoo Chat Baseline
 
-Runs a small Promptfoo suite against three local adapters:
+Runs a small Promptfoo suite against local adapters:
 
 - A deterministic tool-contract adapter for chat and onboarding tool availability, schemas, tool UI registry coverage, stubbed outputs, and no-spend guarantees.
 - The production `executeChatTurn()` path used by `/api/chat`, with synthetic Luna Waves fixtures and eval-only tool stubs. This live path is manual-only because it calls the model provider.
 - A deterministic route-contract adapter for `POST /api/chat`, covering unauthenticated requests, branch-ordering for the chat kill switch, invalid JSON, message validation, missing profile context, client-turn preconditions, rate-limit responses, and contract-only pre-dispatch success without starting Next, Clerk, or the database.
 - A deterministic route-contract adapter for `POST /api/mobile/v1/chat/turns`, covering unauthenticated, invalid JSON, invalid-body variants, and `MOBILE_CHAT_RUNTIME_DISABLED` responses without starting Next or Clerk.
 - A manual live HTTP adapter for `POST /api/chat`, covering loopback auth, authenticated validation errors, client-turn preconditions, DB-backed client-turn reservation, deterministic no-model terminal paths, duplicate replay, and no sensitive echo on unauthorized responses.
+- A separate manual live HTTP rate-limit adapter for the anonymous `/api/chat` onboarding path, covering fail-closed 429 headers when Redis is intentionally disabled on the local server.
 
 The default eval command is deterministic and does not call models, DB, Clerk, Spotify, Stripe, Slack, or a local Next server. The route-contract adapters mirror checked-in route behavior because direct route import in Promptfoo runs outside the Next/Clerk/DB server context.
 
-Remaining JOV-2573 scope is live HTTP coverage for isolated rate-limit headers, terminal model-error variants, and production-like Clerk sessions. The current live HTTP lane uses loopback dev test-auth and deterministic no-model paths.
+Remaining JOV-2573 scope is live HTTP coverage for terminal model-error variants and production-like Clerk sessions. The current live HTTP lanes use loopback dev test-auth, deterministic no-model paths, and an isolated Redis-disabled local server for rate-limit coverage.
 
-Cost decision: Ship now live HTTP validation and persistence coverage that never needs model dispatch. Re-evaluate when a local eval server can reliably start with Redis disabled or namespace-isolated, so rate-limit exhaustion costs zero external quota and cannot poison shared dev state. Then add live HTTP rate-limit exhaustion cases with capped request counts and concurrency 1.
+Cost decision: Ship now live HTTP validation, persistence, and Redis-disabled rate-limit coverage that never needs model dispatch. Re-evaluate when production-like Clerk sessions can run locally without real customer data or paid auth-provider side effects. Then add Clerk-session live HTTP cases with capped case count and concurrency 1 under JOV-2573.
 
 Run from the repo root:
 
@@ -33,6 +34,13 @@ E2E_USE_TEST_AUTH_BYPASS=1 pnpm run dev:web:fast
 JOVIE_RUN_LIVE_HTTP_EVALS=1 JOVIE_PROMPTFOO_BASE_URL=http://127.0.0.1:3000 pnpm run evals:live:http
 ```
 
+To run the isolated live HTTP rate-limit case, start the local server with Redis and model provider keys disabled. Use a port that is not already owned by another worktree:
+
+```bash
+PORT=3101 JOVIE_DISABLE_REDIS_FOR_EVALS=1 JOVIE_DISABLE_MODEL_KEYS_FOR_EVALS=1 E2E_USE_TEST_AUTH_BYPASS=1 pnpm run dev:web:fast
+JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=1 JOVIE_PROMPTFOO_EXPECT_REDIS_DISABLED=1 JOVIE_PROMPTFOO_BASE_URL=http://127.0.0.1:3101 pnpm run evals:live:http:rate-limit
+```
+
 Promptfoo exits non-zero when baseline assertions fail. That is expected when the live suite is capturing current product behavior that should be improved. The default deterministic suite should stay green and cheap enough for CI.
 
 Required environment for default deterministic evals:
@@ -51,3 +59,10 @@ Required environment for manual live HTTP evals:
 - `JOVIE_PROMPTFOO_BASE_URL`, restricted to loopback hosts.
 - Local web server started with `E2E_USE_TEST_AUTH_BYPASS=1`.
 - Local/Doppler DB and Clerk test-user setup required by `/api/dev/test-auth/session`.
+
+Required environment for manual live HTTP rate-limit evals:
+
+- `JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=1`.
+- `JOVIE_PROMPTFOO_EXPECT_REDIS_DISABLED=1`.
+- `JOVIE_PROMPTFOO_BASE_URL`, restricted to loopback hosts.
+- Local web server started with `JOVIE_DISABLE_REDIS_FOR_EVALS=1` and `JOVIE_DISABLE_MODEL_KEYS_FOR_EVALS=1`.

--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -675,14 +675,56 @@ function assertLiveHttpWebRouteNoModel(output) {
   if (payload.target !== 'web-chat-http-route') {
     return fail('case did not run through the live HTTP web chat adapter');
   }
-  if (payload.costTier !== 'live-http') {
-    return fail('case is not marked as live-http');
+  if (
+    payload.costTier !== 'live-http' &&
+    payload.costTier !== 'live-rate-limit'
+  ) {
+    return fail('case is not marked as a live HTTP cost tier');
   }
   if (payload.selectedModel !== null) {
     return fail('live HTTP no-model case selected a model');
   }
   if (payload.modelCalled !== false) {
     return fail('live HTTP no-model case reported a model call');
+  }
+
+  return pass();
+}
+
+function assertLiveHttpOnboardingRateLimitUnavailable(output) {
+  const payload = parseOutput(output);
+  const response = payload.response ?? {};
+  const responseText = String(response.responseText ?? payload.text ?? '');
+
+  if (payload.target !== 'web-chat-http-route') {
+    return fail('case did not run through the live HTTP web chat adapter');
+  }
+  if (payload.costTier !== 'live-rate-limit') {
+    return fail('case is not marked as live-rate-limit');
+  }
+  if (response.status !== 429) {
+    return fail(`expected live HTTP 429, got ${String(response.status)}`);
+  }
+  if (response.responseJson?.errorCode !== 'RATE_LIMITED') {
+    return fail('missing live RATE_LIMITED error code');
+  }
+  if (!response.headers?.['retry-after']) {
+    return fail('missing live Retry-After header');
+  }
+  if (!response.headers?.['x-ratelimit-limit']) {
+    return fail('missing live X-RateLimit-Limit header');
+  }
+  if (!response.headers?.['x-ratelimit-remaining']) {
+    return fail('missing live X-RateLimit-Remaining header');
+  }
+  if (!/rate limit|temporarily unavailable|too many/i.test(responseText)) {
+    return fail('missing live rate-limit explanation');
+  }
+  if (payload.modelDispatchPrevented !== true) {
+    return fail('rate-limit case did not prove model dispatch was bypassed');
+  }
+  if (payload.persistenceAttempted !== false) {
+    return fail('rate-limit live HTTP case attempted persistence');
   }
 
   return pass();
@@ -1639,6 +1681,7 @@ module.exports = {
   assertWebRouteContractOnlySuccess,
   assertDeterministicNoSpend,
   assertLiveHttpWebRouteNoModel,
+  assertLiveHttpOnboardingRateLimitUnavailable,
   assertLiveHttpUnauthorized,
   assertLiveHttpInvalidJson,
   assertLiveHttpMissingContext,

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -1396,6 +1396,51 @@ async function evaluateLiveHttpAlbumArtUnavailable(
   };
 }
 
+async function evaluateLiveHttpOnboardingRateLimitUnavailable(
+  prompt: string,
+  baseUrl: URL
+) {
+  if (process.env.JOVIE_PROMPTFOO_EXPECT_REDIS_DISABLED !== '1') {
+    throw new Error(
+      'Set JOVIE_PROMPTFOO_EXPECT_REDIS_DISABLED=1 and start the local server with JOVIE_DISABLE_REDIS_FOR_EVALS=1 before running the live HTTP rate-limit eval.'
+    );
+  }
+
+  const requestId = `promptfoo-http-onboarding-rate-limit-${randomUUID()}`;
+  const response = await postLiveHttpChat({
+    baseUrl,
+    requestId,
+    body: {
+      mode: 'onboarding',
+      messages: [
+        {
+          id: `${requestId}-message`,
+          role: 'user',
+          parts: [{ type: 'text', text: prompt }],
+        },
+      ],
+    },
+  });
+
+  return {
+    target: 'web-chat-http-route',
+    adapter: 'live-http-route',
+    productionPath: WEB_CHAT_ROUTE_PATH,
+    httpCase: 'anonymous-onboarding-rate-limit-unavailable',
+    costTier: 'live-rate-limit',
+    text: response.responseText,
+    selectedModel: null,
+    modelCalled: false,
+    modelDispatchPrevented: response.status === 429,
+    persistenceAttempted: false,
+    requestId,
+    response,
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
 async function evaluateLiveHttpWebChatRoute(prompt: string, vars: EvalVars) {
   if (process.env.JOVIE_RUN_LIVE_HTTP_EVALS !== '1') {
     throw new Error(
@@ -1431,6 +1476,10 @@ async function evaluateLiveHttpWebChatRoute(prompt: string, vars: EvalVars) {
 
   if (httpCase === 'album-art-unavailable') {
     return evaluateLiveHttpAlbumArtUnavailable(prompt, baseUrl, vars);
+  }
+
+  if (httpCase === 'anonymous-onboarding-rate-limit-unavailable') {
+    return evaluateLiveHttpOnboardingRateLimitUnavailable(prompt, baseUrl);
   }
 
   throw new RangeError(`Invalid live HTTP eval vars.httpCase: ${httpCase}`);

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -242,6 +242,19 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertLiveHttpAlbumArtUnavailable
 
+  - description: Live HTTP onboarding chat fails closed with rate-limit headers when Redis is disabled
+    metadata:
+      cost: live-rate-limit
+    vars:
+      input: "Help me start my Jovie setup."
+      target: web-chat-http-route
+      httpCase: anonymous-onboarding-rate-limit-unavailable
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpWebRouteNoModel
+      - type: javascript
+        value: file://assertions.cjs:assertLiveHttpOnboardingRateLimitUnavailable
+
   - description: Web chat route rejects unauthenticated sensitive requests
     metadata:
       cost: deterministic

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "evals:live": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run evals:live",
     "evals:live:all": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run evals:live:all",
     "evals:live:http": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run evals:live:http",
+    "evals:live:http:rate-limit": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run evals:live:http:rate-limit",
     "test:web": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run test",
     "test:web:changed": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run test -- --changed",
     "test:web:watch": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run test:watch",

--- a/scripts/dev-web-fast.sh
+++ b/scripts/dev-web-fast.sh
@@ -52,7 +52,23 @@ cleanup() {
 }
 trap cleanup EXIT INT TERM
 
+ENV_UNSET_ARGS=()
+if [ "${JOVIE_DISABLE_REDIS_FOR_EVALS:-0}" = "1" ]; then
+  ENV_UNSET_ARGS+=(-u UPSTASH_REDIS_REST_URL -u UPSTASH_REDIS_REST_TOKEN)
+  echo "Starting dev server with Redis env disabled for isolated evals" >&2
+fi
+if [ "${JOVIE_DISABLE_MODEL_KEYS_FOR_EVALS:-0}" = "1" ]; then
+  ENV_UNSET_ARGS+=(
+    -u AI_GATEWAY_API_KEY
+    -u OPENAI_API_KEY
+    -u ANTHROPIC_API_KEY
+    -u XAI_API_KEY
+  )
+  echo "Starting dev server with model provider env disabled for isolated evals" >&2
+fi
+
 doppler run --project jovie-web --config dev -- env \
+  "${ENV_UNSET_ARGS[@]}" \
   E2E_USE_TEST_AUTH_BYPASS="${E2E_USE_TEST_AUTH_BYPASS:-1}" \
   NEXT_PUBLIC_CLERK_MOCK="${NEXT_PUBLIC_CLERK_MOCK:-1}" \
   NEXT_PUBLIC_CLERK_PROXY_DISABLED="${NEXT_PUBLIC_CLERK_PROXY_DISABLED:-1}" \


### PR DESCRIPTION
## Summary
- Add a separate manual Promptfoo `cost=live-rate-limit` lane for anonymous onboarding `POST /api/chat` rate-limit behavior.
- Add a local runner and dev-server env switches that strip Redis and model-provider keys so the case proves fail-closed 429 headers without shared Redis, DB writes, or model spend.
- Keep default deterministic evals and the normal manual live HTTP lane unchanged.

## Cost Decision
Ship now: default `pnpm run evals` remains deterministic/no-cost, live HTTP rate-limit coverage is manual-only, loopback-only, concurrency 1, and requires Redis plus model keys disabled on the local server.

Re-evaluate when: JOV-2573 live HTTP evals catch a release-blocking chat regression twice in 30 days or this rate-limit lane remains at $0 external-service cost and under 2 local dev-server minutes for 10 consecutive manual runs.

Then: expand JOV-2573 live HTTP coverage to production-like Clerk sessions or capped terminal model-error variants with explicit case count, concurrency 1, and per-run cost reporting.

## Verification
- `bash -n apps/web/scripts/run-live-promptfoo-http-rate-limit-evals.sh scripts/dev-web-fast.sh` passed.
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml` passed.
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u BRAINTRUST_API_KEY JOVIE_AGENT_PROFILE=coder JOVIE_RUN_LIVE_EVALS=0 JOVIE_RUN_LIVE_HTTP_EVALS=0 JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=0 pnpm run evals` passed, 115/115 deterministic.
- Isolated server: `JOVIE_AGENT_PROFILE=coder PORT=3103 JOVIE_DISABLE_REDIS_FOR_EVALS=1 JOVIE_DISABLE_MODEL_KEYS_FOR_EVALS=1 E2E_USE_TEST_AUTH_BYPASS=1 pnpm run dev:web:fast`.
- `JOVIE_AGENT_PROFILE=coder JOVIE_RUN_LIVE_HTTP_EVALS=1 JOVIE_PROMPTFOO_BASE_URL=http://127.0.0.1:3103 pnpm run evals:live:http` passed, 6/6 live HTTP no-model.
- `JOVIE_AGENT_PROFILE=coder JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=1 JOVIE_PROMPTFOO_EXPECT_REDIS_DISABLED=1 JOVIE_PROMPTFOO_BASE_URL=http://127.0.0.1:3103 pnpm run evals:live:http:rate-limit` passed, 1/1 live HTTP rate-limit.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/scripts/run-live-promptfoo-http-rate-limit-evals.sh scripts/dev-web-fast.sh apps/web/package.json package.json .github/workflows/README.md` passed.
- `git diff --check` passed.
- Pre-commit passed `next:proxy-guard`, staged Biome, staged ESLint, and web typecheck.
- Pre-push passed `biome check .`, `next:proxy-guard`, `tailwind:check`, web `typecheck`, and web `lint`.

## Known Gate
- `pnpm --filter @jovie/web run typecheck:tests` still fails on the existing repo-wide TS test backlog tracked by JOV-2582. First failures remain outside this Promptfoo harness: `scripts/drizzle-migrate.ts`, `scripts/drizzle-seed.ts`, `scripts/generate-brand-assets.ts`, `scripts/overnight-qa/*`, perf scripts, profile/release tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP rate-limit evaluation capability with a new command to run isolated rate-limit tests against a local server.

* **Documentation**
  * Updated evaluation guides with instructions for running live HTTP rate-limit tests and required environment configuration.

* **Tests**
  * Added rate-limit scenario validation to test suite with new test cases and assertions for onboarding rate-limit handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->