### PR TITLE
JOV-2593 Unified Library and entity rails

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -4,23 +4,31 @@ import { Button } from '@jovie/ui';
 import {
   Calendar,
   CheckSquare,
+  Copy,
   Disc3,
+  ExternalLink,
   ImageIcon,
   Link as LinkIcon,
   MessageSquareText,
   Music2,
+  Smartphone,
   UserRound,
   X,
 } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
 import { ReleaseTaskChecklist } from '@/components/features/dashboard/release-tasks/ReleaseTaskChecklist';
 import { CompactReleasePlanUpgradeCard } from '@/components/features/dashboard/tasks/TasksUpgradeInterstitial';
+import {
+  type ContextMenuItemType,
+  TableContextMenu,
+} from '@/components/organisms/table';
 import { ErrorBoundary } from '@/components/providers/ErrorBoundary';
-import { buildReleaseTasksRoute } from '@/constants/routes';
+import { APP_ROUTES, buildReleaseTasksRoute } from '@/constants/routes';
 import { useRegisterRightPanel } from '@/hooks/useRegisterRightPanel';
 import type { ReleaseViewModel } from '@/lib/discography/types';
 import { usePlanGate } from '@/lib/queries';
@@ -220,13 +228,141 @@ function ChatEntityContextCard({
   );
 }
 
+function buildChatContextMenuItems({
+  title,
+  href,
+  onInspect,
+  onDismiss,
+}: Readonly<{
+  title: string;
+  href?: string | null;
+  onInspect?: () => void;
+  onDismiss?: () => void;
+}>): ContextMenuItemType[] {
+  const items: ContextMenuItemType[] = [];
+
+  if (onInspect) {
+    items.push({
+      id: 'inspect',
+      label: `Inspect ${title}`,
+      icon: <ExternalLink className='h-3.5 w-3.5' />,
+      onClick: onInspect,
+    });
+  }
+
+  if (href) {
+    items.push({
+      id: 'open',
+      label: `Open ${title}`,
+      icon: <ExternalLink className='h-3.5 w-3.5' />,
+      onClick: () => {
+        window.location.assign(href);
+      },
+    });
+  }
+
+  items.push({
+    id: 'copy-title',
+    label: 'Copy Title',
+    icon: <Copy className='h-3.5 w-3.5' />,
+    onClick: () => {
+      void globalThis.navigator?.clipboard?.writeText(title);
+    },
+  });
+
+  if (onDismiss) {
+    items.push(
+      { type: 'separator' },
+      {
+        id: 'dismiss',
+        label: 'Dismiss Context',
+        icon: <X className='h-3.5 w-3.5' />,
+        onClick: onDismiss,
+      }
+    );
+  }
+
+  return items;
+}
+
+function ChatReleaseContextCard({
+  target,
+  profileId,
+  onDismiss,
+}: Readonly<{
+  target: ChatRailContextTarget;
+  profileId: string;
+  onDismiss: (focusKey: string) => void;
+}>) {
+  const { data: release = null, isLoading } = useReleaseEntityQuery(
+    profileId,
+    target.id
+  );
+  const title = release?.title ?? target.label?.trim() ?? 'Release';
+  const meta = release
+    ? `${releaseTypeLabel(release.releaseType)} Context`
+    : isLoading
+      ? 'Loading Release'
+      : 'Release Context';
+
+  return (
+    <TableContextMenu
+      items={buildChatContextMenuItems({
+        title,
+        href: release?.smartLinkPath,
+        onDismiss: () => onDismiss(target.focusKey),
+      })}
+    >
+      <div
+        data-testid='chat-rail-context-card'
+        data-context-kind='release'
+        className='group relative flex min-w-0 items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-surface-1'
+      >
+        <div className='relative h-9 w-9 shrink-0 overflow-hidden rounded-lg bg-surface-1 text-tertiary-token'>
+          {release?.artworkUrl ? (
+            <Image
+              src={release.artworkUrl}
+              alt=''
+              fill
+              sizes='36px'
+              className='object-cover'
+            />
+          ) : (
+            <div className='flex h-full w-full items-center justify-center'>
+              <Disc3 className='h-3.5 w-3.5' />
+            </div>
+          )}
+        </div>
+        <div className='min-w-0 flex-1'>
+          <p className='truncate text-[13px] font-semibold text-primary-token'>
+            {title}
+          </p>
+          <p className='truncate text-[11.5px] text-tertiary-token'>{meta}</p>
+        </div>
+        <Button
+          type='button'
+          variant='ghost'
+          size='icon'
+          aria-label='Dismiss release context'
+          onClick={() => onDismiss(target.focusKey)}
+          className='h-7 w-7 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100'
+        >
+          <X className='h-3.5 w-3.5' />
+        </Button>
+      </div>
+    </TableContextMenu>
+  );
+}
+
 function ChatRailContextCards({
   targets,
   profileContext,
+  profileId,
   onDismiss,
 }: Readonly<{
   targets: readonly ChatRailContextTarget[];
   profileContext?: ChatProfileContextSummary | null;
+  profileId?: string | null;
   onDismiss: (focusKey: string) => void;
 }>) {
   if (targets.length === 0) {
@@ -242,6 +378,13 @@ function ChatRailContextCards({
               key={target.focusKey}
               profile={profileContext}
               target={target}
+              onDismiss={onDismiss}
+            />
+          ) : target.kind === 'release' && profileId ? (
+            <ChatReleaseContextCard
+              key={target.focusKey}
+              target={target}
+              profileId={profileId}
               onDismiss={onDismiss}
             />
           ) : (
@@ -302,201 +445,240 @@ function ChatReleaseEntityPanel({
     Boolean(visibleProviders && visibleProviders.length > 0);
   const shouldShowReleaseTasksSection =
     isTasksWorkspaceGateLoading || canAccessTasksWorkspace || showTasksUpgrade;
+  const contextMenuItems = useMemo<ContextMenuItemType[]>(
+    () =>
+      buildChatContextMenuItems({
+        title: release?.title ?? label ?? 'Release',
+        href: release?.smartLinkPath,
+        onInspect: release
+          ? () => router.push(buildReleaseTasksRoute(release.id))
+          : undefined,
+      }),
+    [label, release, router]
+  );
 
   useEffect(() => {
     setShowTasksUpgrade(true);
   }, [release?.id]);
 
   return (
-    <aside
-      className='flex h-full min-h-0 w-full flex-col overflow-hidden bg-(--linear-app-content-surface)'
-      data-testid='chat-release-entity-panel'
-    >
-      <div className='flex shrink-0 items-center justify-between border-b border-[color-mix(in_oklab,var(--linear-app-shell-border)_64%,transparent)] px-4 py-3'>
-        <div className='min-w-0'>
-          <p className='text-[11px] text-tertiary-token'>Release</p>
-          <h2 className='truncate text-[13px] font-semibold text-primary-token'>
-            {release?.title ?? label ?? 'Release'}
-          </h2>
+    <TableContextMenu items={contextMenuItems}>
+      <aside
+        className='flex h-full min-h-0 w-full flex-col overflow-hidden bg-(--linear-app-content-surface)'
+        data-testid='chat-release-entity-panel'
+      >
+        <div className='flex shrink-0 items-center justify-between border-b border-[color-mix(in_oklab,var(--linear-app-shell-border)_64%,transparent)] px-4 py-3'>
+          <div className='min-w-0'>
+            <p className='text-[11px] text-tertiary-token'>Release</p>
+            <h2 className='truncate text-[13px] font-semibold text-primary-token'>
+              {release?.title ?? label ?? 'Release'}
+            </h2>
+          </div>
+          <Button
+            type='button'
+            variant='ghost'
+            size='icon'
+            aria-label='Close entity panel'
+            onClick={onClose}
+            className='h-8 w-8 shrink-0'
+          >
+            <X className='h-4 w-4' />
+          </Button>
         </div>
-        <Button
-          type='button'
-          variant='ghost'
-          size='icon'
-          aria-label='Close entity panel'
-          onClick={onClose}
-          className='h-8 w-8 shrink-0'
-        >
-          <X className='h-4 w-4' />
-        </Button>
-      </div>
 
-      {loading ? (
-        <div
-          className='flex flex-1 items-center justify-center px-6'
-          role='status'
-          aria-live='polite'
-        >
-          <span className='sr-only'>Loading release…</span>
+        {loading ? (
           <div
-            className='h-4 w-28 rounded skeleton motion-reduce:animate-none'
-            aria-hidden='true'
-          />
-        </div>
-      ) : release ? (
-        <div className='min-h-0 flex-1 overflow-y-auto'>
-          <div className='px-4 py-4'>
-            <div className='flex items-start gap-3'>
-              <div className='relative h-16 w-16 shrink-0 overflow-hidden rounded-lg bg-surface-1'>
-                {release.artworkUrl ? (
-                  <Image
-                    src={release.artworkUrl}
-                    alt=''
-                    fill
-                    className='object-cover'
-                    sizes='64px'
-                  />
-                ) : (
-                  <div className='flex h-full w-full items-center justify-center text-tertiary-token'>
-                    <Disc3 className='h-5 w-5' />
-                  </div>
-                )}
-              </div>
-              <div className='min-w-0 flex-1'>
-                <h3 className='text-[17px] font-semibold leading-tight text-primary-token'>
-                  {release.title}
-                </h3>
-                <div className='mt-2 flex flex-wrap items-center gap-1.5 text-[11px] text-secondary-token'>
-                  <span className='inline-flex items-center gap-1 rounded-md bg-surface-1 px-1.5 py-1'>
-                    <Disc3 className='h-3 w-3 text-tertiary-token' />
-                    {releaseTypeLabel(release.releaseType)}
-                  </span>
-                  {releaseDate ? (
+            className='flex flex-1 items-center justify-center px-6'
+            role='status'
+            aria-live='polite'
+          >
+            <span className='sr-only'>Loading release…</span>
+            <div
+              className='h-4 w-28 rounded skeleton motion-reduce:animate-none'
+              aria-hidden='true'
+            />
+          </div>
+        ) : release ? (
+          <div className='min-h-0 flex-1 overflow-y-auto'>
+            <div className='px-4 py-4'>
+              <div className='flex items-start gap-3'>
+                <div className='relative h-16 w-16 shrink-0 overflow-hidden rounded-lg bg-surface-1'>
+                  {release.artworkUrl ? (
+                    <Image
+                      src={release.artworkUrl}
+                      alt=''
+                      fill
+                      className='object-cover'
+                      sizes='64px'
+                    />
+                  ) : (
+                    <div className='flex h-full w-full items-center justify-center text-tertiary-token'>
+                      <Disc3 className='h-5 w-5' />
+                    </div>
+                  )}
+                </div>
+                <div className='min-w-0 flex-1'>
+                  <h3 className='text-[17px] font-semibold leading-tight text-primary-token'>
+                    {release.title}
+                  </h3>
+                  <div className='mt-2 flex flex-wrap items-center gap-1.5 text-[11px] text-secondary-token'>
                     <span className='inline-flex items-center gap-1 rounded-md bg-surface-1 px-1.5 py-1'>
-                      <Calendar className='h-3 w-3 text-tertiary-token' />
-                      {releaseDate}
+                      <Disc3 className='h-3 w-3 text-tertiary-token' />
+                      {releaseTypeLabel(release.releaseType)}
                     </span>
-                  ) : null}
-                  <span className='rounded-md bg-surface-1 px-1.5 py-1'>
-                    {release.status}
-                  </span>
+                    {releaseDate ? (
+                      <span className='inline-flex items-center gap-1 rounded-md bg-surface-1 px-1.5 py-1'>
+                        <Calendar className='h-3 w-3 text-tertiary-token' />
+                        {releaseDate}
+                      </span>
+                    ) : null}
+                    <span className='rounded-md bg-surface-1 px-1.5 py-1'>
+                      {release.status}
+                    </span>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
 
-          {hasMedia ? (
-            <ChatEntityPanelSection
-              title='Media'
-              icon={<ImageIcon className='h-3.5 w-3.5 text-tertiary-token' />}
-            >
-              <div className='space-y-3'>
-                {release.previewUrl ? (
-                  <div className='rounded-lg bg-surface-1 px-3 py-2.5'>
-                    <div className='mb-2 flex items-center gap-2 text-[11.5px] font-semibold text-secondary-token'>
-                      <Music2 className='h-3.5 w-3.5 text-tertiary-token' />
-                      Preview
-                    </div>
-                    <audio
-                      controls
-                      src={release.previewUrl}
-                      className='h-8 w-full'
-                    >
-                      <track kind='captions' />
-                    </audio>
-                  </div>
-                ) : null}
-
-                {visibleProviders && visibleProviders.length > 0 ? (
-                  <div className='space-y-1'>
-                    {visibleProviders.slice(0, 6).map(provider => (
-                      <a
-                        key={`${provider.key}:${provider.url}`}
-                        href={provider.url}
-                        target='_blank'
-                        rel='noreferrer'
-                        className='flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-[12px] text-secondary-token transition-colors hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:outline-none'
-                      >
-                        <LinkIcon className='h-3.5 w-3.5 shrink-0 text-tertiary-token' />
-                        <span className='min-w-0 flex-1 truncate'>
-                          {provider.label}
-                        </span>
-                        <span
-                          className={cn(
-                            'h-1.5 w-1.5 rounded-full',
-                            provider.isPrimary
-                              ? 'bg-green-500'
-                              : 'bg-tertiary-token'
-                          )}
-                        />
-                      </a>
-                    ))}
-                  </div>
-                ) : null}
-              </div>
-            </ChatEntityPanelSection>
-          ) : null}
-
-          {threadTitle ? (
-            <ChatEntityPanelSection
-              title='Thread'
-              icon={
-                <MessageSquareText className='h-3.5 w-3.5 text-tertiary-token' />
-              }
-            >
-              <div className='rounded-lg bg-surface-1 px-3 py-2.5 text-[12px] text-secondary-token'>
-                <p className='truncate font-semibold text-primary-token'>
-                  {threadTitle}
-                </p>
-                <p className='mt-1 text-tertiary-token'>
-                  This release was referenced in the current chat thread.
-                </p>
-              </div>
-            </ChatEntityPanelSection>
-          ) : null}
-
-          {shouldShowReleaseTasksSection ? (
-            <ChatEntityPanelSection
-              title='Tasks'
-              icon={<CheckSquare className='h-3.5 w-3.5 text-tertiary-token' />}
-            >
-              {isTasksWorkspaceGateLoading ? (
-                <div
-                  className='rounded-lg border border-subtle bg-surface-1 px-3 py-3'
-                  data-testid='chat-release-tasks-loading-state'
-                >
-                  <div
-                    className='h-4 w-28 rounded skeleton motion-reduce:animate-none'
-                    aria-hidden='true'
-                  />
-                  <div
-                    className='mt-3 h-20 rounded-md skeleton motion-reduce:animate-none'
-                    aria-hidden='true'
-                  />
-                </div>
-              ) : canAccessTasksWorkspace ? (
-                <ReleaseTaskChecklist
-                  releaseId={release.id}
-                  variant='compact'
-                  releaseDate={release.releaseDate}
-                  onNavigateToFullPage={() =>
+            {release ? (
+              <div className='flex flex-wrap gap-1.5 px-4 pb-4'>
+                <button
+                  type='button'
+                  onClick={() =>
                     router.push(buildReleaseTasksRoute(release.id))
                   }
-                />
-              ) : showTasksUpgrade ? (
-                <CompactReleasePlanUpgradeCard
-                  onDismiss={() => setShowTasksUpgrade(false)}
-                />
-              ) : null}
-            </ChatEntityPanelSection>
-          ) : null}
-        </div>
-      ) : (
-        <div className='flex flex-1 items-center justify-center px-6 text-center text-[13px] text-tertiary-token'>
-          This release is not available in the current profile.
-        </div>
-      )}
-    </aside>
+                  className='inline-flex h-8 items-center gap-1.5 rounded-md border border-subtle bg-surface-1 px-3 text-xs font-medium text-primary-token transition-colors hover:border-default hover:bg-surface-2'
+                >
+                  <CheckSquare className='h-3.5 w-3.5 text-tertiary-token' />
+                  Tasks
+                </button>
+                {release.smartLinkPath ? (
+                  <Link
+                    href={release.smartLinkPath}
+                    className='inline-flex h-8 items-center gap-1.5 rounded-md border border-subtle bg-surface-1 px-3 text-xs font-medium text-primary-token transition-colors hover:border-default hover:bg-surface-2'
+                  >
+                    <ExternalLink className='h-3.5 w-3.5 text-tertiary-token' />
+                    Open
+                  </Link>
+                ) : null}
+              </div>
+            ) : null}
+
+            {hasMedia ? (
+              <ChatEntityPanelSection
+                title='Media'
+                icon={<ImageIcon className='h-3.5 w-3.5 text-tertiary-token' />}
+              >
+                <div className='space-y-3'>
+                  {release.previewUrl ? (
+                    <div className='rounded-lg bg-surface-1 px-3 py-2.5'>
+                      <div className='mb-2 flex items-center gap-2 text-[11.5px] font-semibold text-secondary-token'>
+                        <Music2 className='h-3.5 w-3.5 text-tertiary-token' />
+                        Preview
+                      </div>
+                      <audio
+                        controls
+                        src={release.previewUrl}
+                        className='h-8 w-full'
+                      >
+                        <track kind='captions' />
+                      </audio>
+                    </div>
+                  ) : null}
+
+                  {visibleProviders && visibleProviders.length > 0 ? (
+                    <div className='space-y-1'>
+                      {visibleProviders.slice(0, 6).map(provider => (
+                        <a
+                          key={`${provider.key}:${provider.url}`}
+                          href={provider.url}
+                          target='_blank'
+                          rel='noreferrer'
+                          className='flex min-w-0 items-center gap-2 rounded-md px-2 py-1.5 text-[12px] text-secondary-token transition-colors hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:outline-none'
+                        >
+                          <LinkIcon className='h-3.5 w-3.5 shrink-0 text-tertiary-token' />
+                          <span className='min-w-0 flex-1 truncate'>
+                            {provider.label}
+                          </span>
+                          <span
+                            className={cn(
+                              'h-1.5 w-1.5 rounded-full',
+                              provider.isPrimary
+                                ? 'bg-green-500'
+                                : 'bg-tertiary-token'
+                            )}
+                          />
+                        </a>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              </ChatEntityPanelSection>
+            ) : null}
+
+            {threadTitle ? (
+              <ChatEntityPanelSection
+                title='Chat'
+                icon={
+                  <MessageSquareText className='h-3.5 w-3.5 text-tertiary-token' />
+                }
+              >
+                <div className='rounded-lg bg-surface-1 px-3 py-2.5 text-[12px] text-secondary-token'>
+                  <p className='truncate font-semibold text-primary-token'>
+                    {threadTitle}
+                  </p>
+                  <p className='mt-1 text-tertiary-token'>
+                    This release was referenced in the current chat.
+                  </p>
+                </div>
+              </ChatEntityPanelSection>
+            ) : null}
+
+            {shouldShowReleaseTasksSection ? (
+              <ChatEntityPanelSection
+                title='Tasks'
+                icon={
+                  <CheckSquare className='h-3.5 w-3.5 text-tertiary-token' />
+                }
+              >
+                {isTasksWorkspaceGateLoading ? (
+                  <div
+                    className='rounded-lg border border-subtle bg-surface-1 px-3 py-3'
+                    data-testid='chat-release-tasks-loading-state'
+                  >
+                    <div
+                      className='h-4 w-28 rounded skeleton motion-reduce:animate-none'
+                      aria-hidden='true'
+                    />
+                    <div
+                      className='mt-3 h-20 rounded-md skeleton motion-reduce:animate-none'
+                      aria-hidden='true'
+                    />
+                  </div>
+                ) : canAccessTasksWorkspace ? (
+                  <ReleaseTaskChecklist
+                    releaseId={release.id}
+                    variant='compact'
+                    releaseDate={release.releaseDate}
+                    onNavigateToFullPage={() =>
+                      router.push(buildReleaseTasksRoute(release.id))
+                    }
+                  />
+                ) : showTasksUpgrade ? (
+                  <CompactReleasePlanUpgradeCard
+                    onDismiss={() => setShowTasksUpgrade(false)}
+                  />
+                ) : null}
+              </ChatEntityPanelSection>
+            ) : null}
+          </div>
+        ) : (
+          <div className='flex flex-1 items-center justify-center px-6 text-center text-[13px] text-tertiary-token'>
+            This release is not available in the current profile.
+          </div>
+        )}
+      </aside>
+    </TableContextMenu>
   );
 }
 
@@ -699,6 +881,165 @@ function ChatTourDateEntityPanelLoader({
   );
 }
 
+function ChatProfileBentoPanel({
+  profile,
+  onClose,
+}: Readonly<{
+  profile: ChatProfileContextSummary | null | undefined;
+  onClose: () => void;
+}>) {
+  const displayName =
+    profile?.displayName?.trim() || profile?.username?.trim() || 'Profile';
+  const username = profile?.username?.trim() || null;
+  const publicHref = username ? `/${username}` : APP_ROUTES.PROFILE;
+  const completion =
+    typeof profile?.completionPercentage === 'number'
+      ? Math.round(profile.completionPercentage)
+      : null;
+
+  const contextMenuItems = useMemo<ContextMenuItemType[]>(
+    () =>
+      buildChatContextMenuItems({
+        title: displayName,
+        href: publicHref,
+        onDismiss: onClose,
+      }),
+    [displayName, onClose, publicHref]
+  );
+
+  return (
+    <TableContextMenu items={contextMenuItems}>
+      <aside
+        className='flex h-full min-h-0 w-full flex-col overflow-hidden bg-(--linear-app-content-surface)'
+        data-testid='chat-profile-bento-panel'
+      >
+        <div className='flex shrink-0 items-center justify-between border-b border-[color-mix(in_oklab,var(--linear-app-shell-border)_64%,transparent)] px-4 py-3'>
+          <div className='min-w-0'>
+            <p className='text-[11px] text-tertiary-token'>Profile</p>
+            <h2 className='truncate text-[13px] font-semibold text-primary-token'>
+              {displayName}
+            </h2>
+          </div>
+          <Button
+            type='button'
+            variant='ghost'
+            size='icon'
+            aria-label='Close profile panel'
+            onClick={onClose}
+            className='h-8 w-8 shrink-0'
+          >
+            <X className='h-4 w-4' />
+          </Button>
+        </div>
+
+        <div className='min-h-0 flex-1 overflow-y-auto p-4'>
+          <div className='relative min-h-[300px] overflow-hidden rounded-lg border border-white/12 bg-[linear-gradient(135deg,#11151d_0%,#202735_46%,#121821_100%)] px-4 py-5 text-white shadow-[0_22px_52px_rgba(0,0,0,0.28)]'>
+            <div className='relative z-10 flex items-center gap-3'>
+              <div className='relative h-14 w-14 shrink-0 overflow-hidden rounded-2xl bg-white/14 text-sm font-semibold text-white'>
+                {profile?.avatarUrl ? (
+                  <Image
+                    src={profile.avatarUrl}
+                    alt=''
+                    fill
+                    sizes='56px'
+                    className='object-cover'
+                  />
+                ) : (
+                  <div className='flex h-full w-full items-center justify-center'>
+                    {profile ? getProfileInitials(profile) : 'P'}
+                  </div>
+                )}
+              </div>
+              <div className='min-w-0'>
+                <h3 className='truncate text-[20px] font-semibold leading-6'>
+                  {displayName}
+                </h3>
+                {username ? (
+                  <p className='mt-1 truncate text-xs text-white/68'>
+                    /{username}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+
+            <div className='relative z-10 mt-5 flex flex-wrap gap-1.5 text-[11px] text-white/80'>
+              {completion !== null ? (
+                <span className='rounded-md border border-white/14 bg-white/10 px-2 py-1'>
+                  {completion}% Complete
+                </span>
+              ) : null}
+              <span className='rounded-md border border-white/14 bg-white/10 px-2 py-1'>
+                {profile?.hasMusicLinks ? 'Music Connected' : 'Music Links'}
+              </span>
+              <span className='rounded-md border border-white/14 bg-white/10 px-2 py-1'>
+                {profile?.hasSocialLinks ? 'Social Connected' : 'Social Links'}
+              </span>
+            </div>
+
+            <div className='absolute bottom-[-34px] right-4 h-[212px] w-[106px] rounded-[24px] border border-white/25 bg-black p-1 shadow-2xl'>
+              <div className='relative h-full overflow-hidden rounded-[20px] bg-[#111318]'>
+                <div className='mx-auto mt-2 h-1.5 w-10 rounded-full bg-white/20' />
+                <div className='mx-3 mt-5 overflow-hidden rounded-xl bg-white/10 p-2'>
+                  <div className='relative mx-auto h-12 w-12 overflow-hidden rounded-xl bg-white/12'>
+                    {profile?.avatarUrl ? (
+                      <Image
+                        src={profile.avatarUrl}
+                        alt=''
+                        fill
+                        sizes='48px'
+                        className='object-cover'
+                      />
+                    ) : (
+                      <div className='flex h-full w-full items-center justify-center text-xs text-white/78'>
+                        {profile ? getProfileInitials(profile) : 'P'}
+                      </div>
+                    )}
+                  </div>
+                  <div className='mt-3 h-2 rounded-full bg-white/24' />
+                  <div className='mt-2 h-2 w-2/3 rounded-full bg-white/12' />
+                </div>
+                <div className='absolute bottom-4 left-3 right-3 grid gap-1'>
+                  <div className='h-6 rounded-md bg-white/14' />
+                  <div className='h-6 rounded-md bg-white/8' />
+                </div>
+              </div>
+            </div>
+
+            <Smartphone
+              className='absolute bottom-4 left-4 h-5 w-5 text-white/42'
+              aria-hidden='true'
+            />
+          </div>
+
+          <div className='mt-4 space-y-1'>
+            <Link
+              href={publicHref}
+              className='flex h-9 items-center justify-between rounded-md px-2.5 text-sm text-primary-token transition-colors hover:bg-surface-1'
+            >
+              <span>Open Public Profile</span>
+              <ExternalLink className='h-3.5 w-3.5 text-tertiary-token' />
+            </Link>
+            <Link
+              href={APP_ROUTES.LIBRARY}
+              className='flex h-9 items-center justify-between rounded-md px-2.5 text-sm text-primary-token transition-colors hover:bg-surface-1'
+            >
+              <span>Library</span>
+              <ExternalLink className='h-3.5 w-3.5 text-tertiary-token' />
+            </Link>
+            <Link
+              href={APP_ROUTES.TASKS}
+              className='flex h-9 items-center justify-between rounded-md px-2.5 text-sm text-primary-token transition-colors hover:bg-surface-1'
+            >
+              <span>Tasks</span>
+              <ExternalLink className='h-3.5 w-3.5 text-tertiary-token' />
+            </Link>
+          </div>
+        </div>
+      </aside>
+    </TableContextMenu>
+  );
+}
+
 export function ChatEntityRightPanelHost({
   enablePreviewPanel,
   enableChatEntityPanels = false,
@@ -706,7 +1047,8 @@ export function ChatEntityRightPanelHost({
   profileContext,
   threadTitle,
 }: Readonly<ChatEntityRightPanelHostProps>) {
-  const { isOpen: isPreviewPanelOpen } = usePreviewPanelState();
+  const { close: closePreviewPanel, isOpen: isPreviewPanelOpen } =
+    usePreviewPanelState();
   const { target, contextTargets, close, dismissContext } =
     useChatEntityPanel();
 
@@ -716,6 +1058,7 @@ export function ChatEntityRightPanelHost({
         <ChatRailContextCards
           targets={contextTargets}
           profileContext={profileContext}
+          profileId={profileId}
           onDismiss={dismissContext}
         />
       ) : null;
@@ -800,11 +1143,19 @@ export function ChatEntityRightPanelHost({
 
     return (
       <ErrorBoundary fallback={null}>
-        <ProfileContactSidebar />
+        {profileContext ? (
+          <ChatProfileBentoPanel
+            profile={profileContext}
+            onClose={closePreviewPanel}
+          />
+        ) : (
+          <ProfileContactSidebar />
+        )}
       </ErrorBoundary>
     );
   }, [
     close,
+    closePreviewPanel,
     contextTargets,
     dismissContext,
     enableChatEntityPanels,

--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -368,9 +368,9 @@ export function ChatPageClient({
   const isProfileSetupRace =
     hasProfilesButNoSelection && !hasDashboardLoadFailure;
   const canAutoRetry = isProfileSetupRace && autoRetryCount < 3;
-  const enablePreviewPanel = !env.IS_E2E;
   const fromOnboarding = searchParams.get('from') === 'onboarding';
   const panelParam = searchParams.get('panel');
+  const enablePreviewPanel = !env.IS_E2E || panelParam === 'profile';
   const designV1ChatEntitiesEnabled = useAppFlag('DESIGN_V1');
   // Hydrate the profile panel only for explicit profile entry. Entity mentions
   // use ChatEntityPanelContext and do not need the profile preview fallback.
@@ -546,7 +546,7 @@ export function ChatPageClient({
         );
       }
 
-      // New threads reserve the final URL with history.replaceState as soon as
+      // New chats reserve the final URL with history.replaceState as soon as
       // the server acknowledges the turn. A second router.replace on stream
       // completion remounts the chat surface and can let stale refetch data
       // replace the settled local timeline.

--- a/apps/web/app/app/(shell)/dashboard/releases/ReleaseCatalogPageClient.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/ReleaseCatalogPageClient.tsx
@@ -6,10 +6,14 @@ import {
   LibraryLoadingState,
   LibrarySurface,
 } from '@/app/app/(shell)/library/LibrarySurface';
-import { buildLibraryReleaseAssets } from '@/app/app/(shell)/library/library-data';
+import {
+  buildLibraryMerchAssets,
+  buildLibraryReleaseAssets,
+} from '@/app/app/(shell)/library/library-data';
 import { ShellReleasesView } from '@/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleasesView';
 import { PageErrorState } from '@/features/feedback/PageErrorState';
 import { useAppFlag } from '@/lib/flags/client';
+import type { LibraryMerchCard } from '@/lib/merch/types';
 import { useReleasesQuery } from '@/lib/queries/useReleasesQuery';
 import { primaryProviderKeys, providerConfig } from './config';
 import { ReleaseTableSkeleton } from './loading';
@@ -28,10 +32,12 @@ export type ReleaseCatalogView = 'list' | 'assets';
 
 interface ReleaseCatalogPageClientProps {
   readonly view: ReleaseCatalogView;
+  readonly merchCards?: readonly LibraryMerchCard[];
 }
 
 export function ReleaseCatalogPageClient({
   view,
+  merchCards = [],
 }: ReleaseCatalogPageClientProps) {
   const { selectedProfile } = useDashboardData();
   const profileId = selectedProfile?.id ?? '';
@@ -81,7 +87,21 @@ export function ReleaseCatalogPageClient({
       return <LibraryLoadingState />;
     }
 
-    return <LibrarySurface assets={buildLibraryReleaseAssets(releases)} />;
+    const artistName =
+      spotifyArtistName ??
+      appleMusicArtistName ??
+      selectedProfile?.displayName?.trim() ??
+      selectedProfile?.username ??
+      'Artist';
+
+    return (
+      <LibrarySurface
+        assets={[
+          ...buildLibraryReleaseAssets(releases),
+          ...buildLibraryMerchAssets(merchCards, artistName),
+        ]}
+      />
+    );
   }
 
   if (!releases && isLoading) {

--- a/apps/web/app/app/(shell)/library/LibraryPageClient.tsx
+++ b/apps/web/app/app/(shell)/library/LibraryPageClient.tsx
@@ -1,7 +1,12 @@
 'use client';
 
+import type { LibraryMerchCard } from '@/lib/merch/types';
 import { ReleaseCatalogPageClient } from '../dashboard/releases/ReleaseCatalogPageClient';
 
-export function LibraryPageClient() {
-  return <ReleaseCatalogPageClient view='assets' />;
+export function LibraryPageClient({
+  merchCards,
+}: {
+  readonly merchCards: readonly LibraryMerchCard[];
+}) {
+  return <ReleaseCatalogPageClient view='assets' merchCards={merchCards} />;
 }

--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -10,6 +10,7 @@ import {
   ArrowUpDown,
   Check,
   ChevronDown,
+  Copy,
   Disc3,
   ExternalLink,
   FileAudio2,
@@ -23,13 +24,14 @@ import {
   Music2,
   Pause,
   PlayCircle,
+  Shirt,
   Upload,
   Video,
   X,
 } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import {
   type ChangeEvent,
   type CSSProperties,
@@ -63,6 +65,10 @@ import {
   UnifiedTable,
   UnifiedTableSkeleton,
 } from '@/components/organisms/table';
+import {
+  type ContextMenuItemType,
+  TableContextMenu,
+} from '@/components/organisms/table/molecules/TableContextMenu';
 import type { FilterPill } from '@/components/shell/pill-search.types';
 import { ShellDropdown } from '@/components/shell/ShellDropdown';
 import { APP_ROUTES } from '@/constants/routes';
@@ -75,8 +81,11 @@ import { capitalizeFirst } from '@/lib/utils/string-utils';
 import {
   formatLibraryDuration,
   formatLibraryReleaseDate,
+  getLibraryItemKind,
   type LibraryAssetKind,
   type LibraryReleaseAsset,
+  type LibraryView,
+  libraryAssetMatchesView,
 } from './library-data';
 
 const LIBRARY_TABLE_ROW_HEIGHT = 56;
@@ -122,12 +131,15 @@ const LIBRARY_TABLE_SKELETON_CONFIG: Array<{
 
 type LibraryViewMode = 'grid' | 'list';
 type LibrarySortKey = 'releaseDate' | 'title' | 'status' | 'providers';
-type LibraryPresetId = 'all' | 'ready' | 'needsAssets' | 'scheduled';
+type LibraryPresetId = LibraryView;
 type ArtworkSize = 'card' | 'row' | 'drawer';
 type LibraryPreviewToggle = (
   asset: LibraryReleaseAsset,
   event?: MouseEvent<HTMLElement>
 ) => void;
+type LibraryContextMenuBuilder = (
+  asset: LibraryReleaseAsset
+) => ContextMenuItemType[];
 const noopPreviewToggle: LibraryPreviewToggle = () => undefined;
 const LibraryPreviewContext = createContext<{
   readonly playingPreviewId: string | null;
@@ -177,31 +189,39 @@ const PRESETS: readonly {
 }[] = [
   {
     id: 'all',
-    label: 'All Releases',
-    description: 'Everything in the connected catalog',
+    label: 'All',
+    description: 'Releases, merch, images, videos, and audio',
     predicate: () => true,
   },
   {
-    id: 'ready',
-    label: 'Ready Assets',
-    description: 'Artwork plus at least one provider link',
-    predicate: asset => asset.hasArtwork && asset.providerCount > 0,
+    id: 'releases',
+    label: 'Releases',
+    description: 'Music catalog and provider assets',
+    predicate: asset => libraryAssetMatchesView(asset, 'releases'),
   },
   {
-    id: 'needsAssets',
-    label: 'Needs Assets',
-    description: 'Missing artwork, previews, lyrics, or provider links',
-    predicate: asset =>
-      !asset.hasArtwork ||
-      !asset.previewUrl ||
-      !asset.hasLyrics ||
-      asset.providerCount === 0,
+    id: 'merch',
+    label: 'Merch',
+    description: 'Draft, paused, and live merch cards',
+    predicate: asset => libraryAssetMatchesView(asset, 'merch'),
   },
   {
-    id: 'scheduled',
-    label: 'Scheduled',
-    description: 'Upcoming catalog work',
-    predicate: asset => asset.status === 'scheduled',
+    id: 'images',
+    label: 'Images',
+    description: 'Artwork and merch mockups',
+    predicate: asset => libraryAssetMatchesView(asset, 'images'),
+  },
+  {
+    id: 'videos',
+    label: 'Videos',
+    description: 'Video assets and links',
+    predicate: asset => libraryAssetMatchesView(asset, 'videos'),
+  },
+  {
+    id: 'audio',
+    label: 'Audio',
+    description: 'Playable previews',
+    predicate: asset => libraryAssetMatchesView(asset, 'audio'),
   },
 ];
 
@@ -212,6 +232,12 @@ function emptyFilters(): LibraryFilters {
     assetKinds: new Set(),
     providers: new Set(),
   };
+}
+
+function parseLibraryViewParam(value: string | null): LibraryPresetId {
+  return PRESETS.some(preset => preset.id === value)
+    ? (value as LibraryPresetId)
+    : 'all';
 }
 
 function toggleSet<T>(set: ReadonlySet<T>, value: T): Set<T> {
@@ -228,8 +254,19 @@ function formatReleaseType(type: LibraryReleaseAsset['releaseType']): string {
   return type.split('_').map(capitalizeFirst).join(' ');
 }
 
+function formatLibraryItemType(asset: LibraryReleaseAsset): string {
+  if (getLibraryItemKind(asset) === 'merch') {
+    return asset.productType?.trim() || 'Merch';
+  }
+  return formatReleaseType(asset.releaseType);
+}
+
 function formatReleaseStatus(status: LibraryReleaseAsset['status']): string {
   return capitalizeFirst(status);
+}
+
+function formatLibraryStatus(asset: LibraryReleaseAsset): string {
+  return asset.itemStatusLabel ?? formatReleaseStatus(asset.status);
 }
 
 function releaseStatusClasses(status: LibraryReleaseAsset['status']): string {
@@ -382,6 +419,7 @@ function Artwork({
         width={size === 'row' ? 48 : 320}
         height={size === 'row' ? 48 : 320}
         className={cn('object-cover', sizeClasses[size])}
+        loading={size === 'row' ? 'lazy' : 'eager'}
         unoptimized
       />
     );
@@ -468,7 +506,7 @@ const StatusCell = memo(function StatusCell({
         releaseStatusClasses(asset.status)
       )}
     >
-      {formatReleaseStatus(asset.status)}
+      {formatLibraryStatus(asset)}
     </span>
   );
 });
@@ -490,7 +528,7 @@ const libraryColumnHelper = createColumnHelper<LibraryReleaseAsset>();
 const LIBRARY_TABLE_COLUMNS = [
   libraryColumnHelper.accessor('title', {
     id: 'release',
-    header: 'Release',
+    header: 'Item',
     cell: ({ row }) => <ReleaseCell asset={row.original} />,
     minSize: 220,
     size: 9999,
@@ -510,7 +548,7 @@ const LIBRARY_TABLE_COLUMNS = [
     header: 'Type',
     cell: ({ row }) => (
       <span className='truncate text-xs text-tertiary-token'>
-        {formatReleaseType(row.original.releaseType)}
+        {formatLibraryItemType(row.original)}
       </span>
     ),
     size: 104,
@@ -1021,7 +1059,7 @@ const AssetCard = memo(function AssetCard({
               releaseStatusClasses(asset.status)
             )}
           >
-            {formatReleaseStatus(asset.status)}
+            {formatLibraryStatus(asset)}
           </span>
         </div>
         <div className='min-w-0 p-3'>
@@ -1035,14 +1073,24 @@ const AssetCard = memo(function AssetCard({
               </p>
             </div>
             <span className='shrink-0 text-2xs tabular-nums text-tertiary-token'>
-              {formatCompactCount(asset.providerCount)}
+              {getLibraryItemKind(asset) === 'merch'
+                ? (asset.retailPriceLabel ?? 'Merch')
+                : formatCompactCount(asset.providerCount)}
             </span>
           </div>
           <div className='mt-2 flex min-w-0 items-center gap-1.5 text-xs text-tertiary-token'>
-            <Disc3 className='h-3 w-3 shrink-0' />
-            <span>{formatReleaseType(asset.releaseType)}</span>
-            <span className='opacity-50'>.</span>
-            <span>{asset.trackCount} Tracks</span>
+            {getLibraryItemKind(asset) === 'merch' ? (
+              <Shirt className='h-3 w-3 shrink-0' />
+            ) : (
+              <Disc3 className='h-3 w-3 shrink-0' />
+            )}
+            <span>{formatLibraryItemType(asset)}</span>
+            {getLibraryItemKind(asset) === 'release' ? (
+              <>
+                <span className='opacity-50'>.</span>
+                <span>{asset.trackCount} Tracks</span>
+              </>
+            ) : null}
           </div>
           <div className='mt-3 flex flex-wrap gap-1.5'>
             {asset.assetKinds.slice(0, 3).map(kind => (
@@ -1096,6 +1144,7 @@ function AssetGrid({
   playingPreviewId,
   onSelect,
   onTogglePreview,
+  getContextMenuItems,
 }: {
   readonly assets: readonly LibraryReleaseAsset[];
   readonly selectedId: string | null;
@@ -1103,19 +1152,21 @@ function AssetGrid({
   readonly playingPreviewId: string | null;
   readonly onSelect: (id: string) => void;
   readonly onTogglePreview: LibraryPreviewToggle;
+  readonly getContextMenuItems: LibraryContextMenuBuilder;
 }) {
   return (
     <div className='grid gap-2.5 px-2.5 pb-2.5 pt-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4'>
       {assets.map(asset => (
-        <AssetCard
-          key={asset.id}
-          asset={asset}
-          selected={selectedId === asset.id}
-          isPreviewActive={activePreviewId === asset.id}
-          isPreviewPlaying={playingPreviewId === asset.id}
-          onSelect={() => onSelect(asset.id)}
-          onTogglePreview={onTogglePreview}
-        />
+        <TableContextMenu key={asset.id} items={getContextMenuItems(asset)}>
+          <AssetCard
+            asset={asset}
+            selected={selectedId === asset.id}
+            isPreviewActive={activePreviewId === asset.id}
+            isPreviewPlaying={playingPreviewId === asset.id}
+            onSelect={() => onSelect(asset.id)}
+            onTogglePreview={onTogglePreview}
+          />
+        </TableContextMenu>
       ))}
     </div>
   );
@@ -1127,12 +1178,14 @@ function LibraryDataTable({
   playingPreviewId,
   onSelect,
   onTogglePreview,
+  getContextMenuItems,
 }: {
   readonly assets: readonly LibraryReleaseAsset[];
   readonly selectedId: string | null;
   readonly playingPreviewId: string | null;
   readonly onSelect: (id: string) => void;
   readonly onTogglePreview: LibraryPreviewToggle;
+  readonly getContextMenuItems: LibraryContextMenuBuilder;
 }) {
   const tableData = useMemo(() => [...assets], [assets]);
   const previewContext = useMemo(
@@ -1166,6 +1219,7 @@ function LibraryDataTable({
         getRowTestId={getRowTestId}
         rowSelection={rowSelection}
         getRowClassName={getRowClassName}
+        getContextMenuItems={getContextMenuItems}
         enableVirtualization={assets.length >= 20}
         rowHeight={LIBRARY_TABLE_ROW_HEIGHT}
         minWidth={LIBRARY_TABLE_MIN_WIDTH}
@@ -1189,8 +1243,8 @@ function EmptyCatalog() {
     >
       <TableEmptyState
         icon={<Music2 className='h-5 w-5' strokeWidth={2.25} />}
-        title='No Release Assets'
-        description='Releases and artwork will appear here after your catalog is connected.'
+        title='No Library Items'
+        description='Releases, merch, images, videos, and audio will appear here as they land.'
         className='m-3 min-h-[360px]'
         action={
           <Link
@@ -1212,7 +1266,7 @@ function NoResults({ onReset }: { readonly onReset: () => void }) {
   return (
     <TableEmptyState
       title='No Assets Match'
-      description='No release assets match the selected view or filters.'
+      description='No library items match the selected view or filters.'
       className='m-3 min-h-[300px]'
       action={
         <button
@@ -1531,6 +1585,7 @@ function AssetDrawer({
   isDesktopLayout,
   onTogglePreview,
   onAudioUploaded,
+  getContextMenuItems,
 }: {
   readonly asset: LibraryReleaseAsset | null;
   readonly open: boolean;
@@ -1540,6 +1595,7 @@ function AssetDrawer({
   readonly isDesktopLayout: boolean;
   readonly onTogglePreview: LibraryPreviewToggle;
   readonly onAudioUploaded: (assetId: string, previewUrl: string) => void;
+  readonly getContextMenuItems: LibraryContextMenuBuilder;
 }) {
   const [stickyAsset, setStickyAsset] = useState<LibraryReleaseAsset | null>(
     asset
@@ -1550,6 +1606,7 @@ function AssetDrawer({
   }, [asset]);
 
   const current = asset ?? stickyAsset;
+  const isMerch = current ? getLibraryItemKind(current) === 'merch' : false;
   const closedInteractiveProps = open ? {} : { tabIndex: -1 };
   const closedTabIndex = open ? undefined : -1;
   const currentId = current?.id ?? null;
@@ -1576,173 +1633,212 @@ function AssetDrawer({
       data-testid='library-asset-drawer'
     >
       {current ? (
-        <div className='flex h-full min-h-0 flex-col'>
-          <div className='flex h-10 shrink-0 items-center justify-between gap-2 border-b border-subtle px-3'>
-            <span className='min-w-0 truncate text-xs font-semibold text-primary-token'>
-              Release
-            </span>
-            <div className='flex shrink-0 items-center gap-1'>
-              <PreviewActionButton
-                asset={current}
-                isPreviewPlaying={isPreviewPlaying}
-                onTogglePreview={onTogglePreview}
-                compact
-                disabledTabIndex={closedTabIndex}
-                reserveSpace
-              />
-              <Link
-                href={current.smartLinkPath}
-                {...closedInteractiveProps}
-                aria-label={`Open ${current.title}`}
-                className={cn(
-                  'grid h-7 w-7 place-items-center rounded-md border border-subtle bg-surface-1 text-tertiary-token transition-[background-color,border-color,color,box-shadow] duration-subtle hover:border-default hover:bg-surface-2 hover:text-primary-token',
-                  LIBRARY_ICON_FOCUS_CLASS
-                )}
-              >
-                <ExternalLink className='h-3.5 w-3.5' />
-              </Link>
-              <button
-                type='button'
-                onClick={onClose}
-                aria-label='Close asset details'
-                {...closedInteractiveProps}
-                className={cn(
-                  'grid h-7 w-7 place-items-center rounded-md text-tertiary-token transition-[background-color,color,box-shadow] duration-subtle hover:bg-surface-1 hover:text-primary-token',
-                  LIBRARY_ICON_FOCUS_CLASS
-                )}
-              >
-                <X className='h-3.5 w-3.5' />
-              </button>
-            </div>
-          </div>
-
-          <div className='min-h-0 flex-1 overflow-y-auto p-3'>
-            <div className='overflow-hidden rounded-lg bg-black'>
-              <div className='mx-auto aspect-square w-full max-w-80'>
-                <Artwork asset={current} size='drawer' />
+        <TableContextMenu items={getContextMenuItems(current)}>
+          <div className='flex h-full min-h-0 flex-col'>
+            <div className='flex h-10 shrink-0 items-center justify-between gap-2 border-b border-subtle px-3'>
+              <span className='min-w-0 truncate text-xs font-semibold text-primary-token'>
+                {isMerch ? 'Merch' : 'Release'}
+              </span>
+              <div className='flex shrink-0 items-center gap-1'>
+                <PreviewActionButton
+                  asset={current}
+                  isPreviewPlaying={isPreviewPlaying}
+                  onTogglePreview={onTogglePreview}
+                  compact
+                  disabledTabIndex={closedTabIndex}
+                  reserveSpace
+                />
+                <Link
+                  href={current.primaryActionHref ?? current.smartLinkPath}
+                  {...closedInteractiveProps}
+                  aria-label={`Open ${current.title}`}
+                  className={cn(
+                    'grid h-7 w-7 place-items-center rounded-md border border-subtle bg-surface-1 text-tertiary-token transition-[background-color,border-color,color,box-shadow] duration-subtle hover:border-default hover:bg-surface-2 hover:text-primary-token',
+                    LIBRARY_ICON_FOCUS_CLASS
+                  )}
+                >
+                  <ExternalLink className='h-3.5 w-3.5' />
+                </Link>
+                <button
+                  type='button'
+                  onClick={onClose}
+                  aria-label='Close asset details'
+                  {...closedInteractiveProps}
+                  className={cn(
+                    'grid h-7 w-7 place-items-center rounded-md text-tertiary-token transition-[background-color,color,box-shadow] duration-subtle hover:bg-surface-1 hover:text-primary-token',
+                    LIBRARY_ICON_FOCUS_CLASS
+                  )}
+                >
+                  <X className='h-3.5 w-3.5' />
+                </button>
               </div>
             </div>
 
-            <div className='mt-3'>
-              <h2 className='text-[18px] font-semibold leading-6 text-primary-token'>
-                {current.title}
-              </h2>
-              <p className='mt-1 text-sm text-secondary-token'>
-                {current.artist}
-              </p>
-            </div>
+            <div className='min-h-0 flex-1 overflow-y-auto p-3'>
+              <div className='overflow-hidden rounded-lg bg-black'>
+                <div className='mx-auto aspect-square w-full max-w-80'>
+                  <Artwork asset={current} size='drawer' />
+                </div>
+              </div>
 
-            <div className='mt-3 flex flex-wrap gap-1.5'>
-              <span
-                className={cn(
-                  'inline-flex h-6 items-center rounded-md border px-2 text-xs',
-                  releaseStatusClasses(current.status)
-                )}
-              >
-                {formatReleaseStatus(current.status)}
-              </span>
-              {current.assetKinds.map(kind => (
-                <AssetKindPill key={kind} kind={kind} />
-              ))}
-            </div>
+              <div className='mt-3'>
+                <h2 className='text-[18px] font-semibold leading-6 text-primary-token'>
+                  {current.title}
+                </h2>
+                <p className='mt-1 text-sm text-secondary-token'>
+                  {current.artist}
+                </p>
+              </div>
 
-            <div className='mt-4 flex flex-wrap gap-1.5'>
-              <Link
-                href={current.smartLinkPath}
-                {...closedInteractiveProps}
-                className={cn(
-                  'inline-flex h-8 items-center gap-1.5 rounded-md border border-subtle bg-surface-1 px-3 text-xs font-medium text-primary-token transition-[background-color,border-color,box-shadow] duration-subtle hover:border-default hover:bg-surface-2',
-                  LIBRARY_BUTTON_FOCUS_CLASS
-                )}
-              >
-                Open Release
-                <ExternalLink className='h-3 w-3' />
-              </Link>
-            </div>
+              <div className='mt-3 flex flex-wrap gap-1.5'>
+                <span
+                  className={cn(
+                    'inline-flex h-6 items-center rounded-md border px-2 text-xs',
+                    releaseStatusClasses(current.status)
+                  )}
+                >
+                  {formatLibraryStatus(current)}
+                </span>
+                {current.assetKinds.map(kind => (
+                  <AssetKindPill key={kind} kind={kind} />
+                ))}
+              </div>
 
-            <LibraryAudioPanel
-              asset={current}
-              isPreviewPlaying={isPreviewPlaying}
-              onTogglePreview={onTogglePreview}
-              onUploaded={onAudioUploaded}
-              disabledTabIndex={closedTabIndex}
-            />
+              <div className='mt-4 flex flex-wrap gap-1.5'>
+                <Link
+                  href={current.primaryActionHref ?? current.smartLinkPath}
+                  {...closedInteractiveProps}
+                  className={cn(
+                    'inline-flex h-8 items-center gap-1.5 rounded-md border border-subtle bg-surface-1 px-3 text-xs font-medium text-primary-token transition-[background-color,border-color,box-shadow] duration-subtle hover:border-default hover:bg-surface-2',
+                    LIBRARY_BUTTON_FOCUS_CLASS
+                  )}
+                >
+                  {current.primaryActionLabel ?? 'Open Release'}
+                  <ExternalLink className='h-3 w-3' />
+                </Link>
+              </div>
 
-            <dl className='mt-4'>
-              <MetadataRow
-                label='Release Date'
-                value={formatLibraryReleaseDate(current.releaseDate)}
-              />
-              <MetadataRow
-                label='Type'
-                value={formatReleaseType(current.releaseType)}
-              />
-              <MetadataRow label='Tracks' value={current.trackCount} />
-              <MetadataRow
-                label='Duration'
-                value={formatLibraryDuration(current.totalDurationMs)}
-              />
-              <MetadataRow
-                label='Popularity'
-                value={
-                  current.spotifyPopularity == null
-                    ? 'No Score'
-                    : `${current.spotifyPopularity}/100`
-                }
-              />
-              <MetadataRow
-                label='Genres'
-                value={
-                  current.genres.length > 0
-                    ? current.genres.join(', ')
-                    : 'No Genres'
-                }
-              />
-              <MetadataRow
-                label='Label'
-                value={current.label ?? current.distributor ?? 'No Label'}
-              />
-              <MetadataRow label='UPC' value={current.upc ?? 'No UPC'} />
-              <MetadataRow
-                label='Pitch Targets'
-                value={current.targetPlaylistCount}
-              />
-            </dl>
-
-            <div className='mt-4 border-t border-subtle pt-3'>
-              <h3 className='text-xs font-semibold text-primary-token'>
-                Providers
-              </h3>
-              {current.providers.length > 0 ? (
-                <div className='mt-2 space-y-1'>
-                  {current.providers.map(provider => (
-                    <a
-                      key={`${current.id}-${provider.key}`}
-                      href={provider.url}
-                      target='_blank'
-                      rel='noopener noreferrer'
-                      {...closedInteractiveProps}
-                      className={cn(
-                        'flex h-8 items-center gap-2 rounded-md px-2 text-xs text-secondary-token transition-[background-color,color,box-shadow] duration-subtle hover:bg-surface-1 hover:text-primary-token',
-                        LIBRARY_CARD_FOCUS_CLASS
-                      )}
-                    >
-                      <Music2 className='h-3.5 w-3.5 text-tertiary-token' />
-                      <span className='min-w-0 flex-1 truncate'>
-                        {provider.label}
-                      </span>
-                      <ExternalLink className='h-3 w-3 text-tertiary-token' />
-                    </a>
-                  ))}
+              {isMerch ? (
+                <div className='mt-4 rounded-lg border border-subtle bg-surface-0 px-3 py-3'>
+                  <div className='mb-2 flex items-center gap-2 text-xs font-semibold text-primary-token'>
+                    <Shirt className='h-3.5 w-3.5 text-tertiary-token' />
+                    Merch
+                  </div>
+                  <p className='text-xs leading-5 text-secondary-token'>
+                    {current.description ?? 'Merch card saved from chat.'}
+                  </p>
                 </div>
               ) : (
-                <p className='mt-2 text-xs leading-5 text-secondary-token'>
-                  No provider links are connected for this release yet.
-                </p>
+                <LibraryAudioPanel
+                  asset={current}
+                  isPreviewPlaying={isPreviewPlaying}
+                  onTogglePreview={onTogglePreview}
+                  onUploaded={onAudioUploaded}
+                  disabledTabIndex={closedTabIndex}
+                />
               )}
+
+              <dl className='mt-4'>
+                <MetadataRow
+                  label={isMerch ? 'Updated' : 'Release Date'}
+                  value={formatLibraryReleaseDate(current.releaseDate)}
+                />
+                <MetadataRow
+                  label='Type'
+                  value={formatLibraryItemType(current)}
+                />
+                {isMerch ? (
+                  <>
+                    <MetadataRow
+                      label='Price'
+                      value={current.retailPriceLabel ?? 'No Price'}
+                    />
+                    <MetadataRow
+                      label='Artist Share'
+                      value={current.artistPayoutLabel ?? 'No Estimate'}
+                    />
+                    <MetadataRow
+                      label='Jovie Margin'
+                      value={current.jovieMarginLabel ?? 'No Estimate'}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <MetadataRow label='Tracks' value={current.trackCount} />
+                    <MetadataRow
+                      label='Duration'
+                      value={formatLibraryDuration(current.totalDurationMs)}
+                    />
+                  </>
+                )}
+                {!isMerch ? (
+                  <>
+                    <MetadataRow
+                      label='Popularity'
+                      value={
+                        current.spotifyPopularity == null
+                          ? 'No Score'
+                          : `${current.spotifyPopularity}/100`
+                      }
+                    />
+                    <MetadataRow
+                      label='Genres'
+                      value={
+                        current.genres.length > 0
+                          ? current.genres.join(', ')
+                          : 'No Genres'
+                      }
+                    />
+                    <MetadataRow
+                      label='Label'
+                      value={current.label ?? current.distributor ?? 'No Label'}
+                    />
+                    <MetadataRow label='UPC' value={current.upc ?? 'No UPC'} />
+                    <MetadataRow
+                      label='Pitch Targets'
+                      value={current.targetPlaylistCount}
+                    />
+                  </>
+                ) : null}
+              </dl>
+
+              {!isMerch ? (
+                <div className='mt-4 border-t border-subtle pt-3'>
+                  <h3 className='text-xs font-semibold text-primary-token'>
+                    Providers
+                  </h3>
+                  {current.providers.length > 0 ? (
+                    <div className='mt-2 space-y-1'>
+                      {current.providers.map(provider => (
+                        <a
+                          key={`${current.id}-${provider.key}`}
+                          href={provider.url}
+                          target='_blank'
+                          rel='noopener noreferrer'
+                          {...closedInteractiveProps}
+                          className={cn(
+                            'flex h-8 items-center gap-2 rounded-md px-2 text-xs text-secondary-token transition-[background-color,color,box-shadow] duration-subtle hover:bg-surface-1 hover:text-primary-token',
+                            LIBRARY_CARD_FOCUS_CLASS
+                          )}
+                        >
+                          <Music2 className='h-3.5 w-3.5 text-tertiary-token' />
+                          <span className='min-w-0 flex-1 truncate'>
+                            {provider.label}
+                          </span>
+                          <ExternalLink className='h-3 w-3 text-tertiary-token' />
+                        </a>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className='mt-2 text-xs leading-5 text-secondary-token'>
+                      No provider links are connected for this release yet.
+                    </p>
+                  )}
+                </div>
+              ) : null}
             </div>
           </div>
-        </div>
+        </TableContextMenu>
       ) : null}
     </aside>
   );
@@ -1770,7 +1866,7 @@ function LibraryStatusBar({
   return (
     <div className='hidden h-8 shrink-0 items-center justify-between gap-3 border-t border-subtle bg-(--linear-app-content-surface) px-3 text-[11px] text-tertiary-token sm:flex'>
       <span className='min-w-0 truncate'>
-        {visibleCount} of {totalCount} Releases
+        {visibleCount} of {totalCount} Items
       </span>
       <span className='min-w-0 truncate text-right'>{playbackSummary}</span>
     </div>
@@ -1783,11 +1879,14 @@ export function LibrarySurface({
   readonly assets: readonly LibraryReleaseAsset[];
 }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { playbackState, toggleTrack } = useTrackAudioPlayer();
   const [audioOverrides, setAudioOverrides] = useState<Record<string, string>>(
     {}
   );
-  const [preset, setPreset] = useState<LibraryPresetId>('all');
+  const [preset, setPreset] = useState<LibraryPresetId>(() =>
+    parseLibraryViewParam(searchParams.get('view'))
+  );
   const [filters, setFilters] = useState<LibraryFilters>(() => emptyFilters());
   const [sort, setSort] = useState<LibrarySortKey>('releaseDate');
   const [view, setView] = useState<LibraryViewMode>('grid');
@@ -1800,6 +1899,10 @@ export function LibrarySurface({
   const deferredPreset = useDeferredValue(preset);
   const deferredPills = useDeferredValue(pills);
   const deferredSort = useDeferredValue(sort);
+
+  useEffect(() => {
+    setPreset(parseLibraryViewParam(searchParams.get('view')));
+  }, [searchParams]);
 
   const effectiveAssets = useMemo<readonly LibraryReleaseAsset[]>(
     () =>
@@ -1927,6 +2030,54 @@ export function LibrarySurface({
     setSelectedId(id);
     setDrawerOpen(true);
   }
+
+  const getContextMenuItems = useCallback<LibraryContextMenuBuilder>(
+    asset => {
+      const href = asset.primaryActionHref ?? asset.smartLinkPath;
+      const items: ContextMenuItemType[] = [
+        {
+          id: 'inspect',
+          label: `Inspect ${asset.title}`,
+          icon: <ExternalLink className='h-3.5 w-3.5' />,
+          onClick: () => {
+            setSelectedId(asset.id);
+            setDrawerOpen(true);
+          },
+        },
+        {
+          id: 'open',
+          label:
+            asset.primaryActionLabel ??
+            (getLibraryItemKind(asset) === 'merch'
+              ? 'Open Merch'
+              : 'Open Release'),
+          icon: <ExternalLink className='h-3.5 w-3.5' />,
+          onClick: () => router.push(href),
+        },
+        {
+          id: 'copy-title',
+          label: 'Copy Title',
+          icon: <Copy className='h-3.5 w-3.5' />,
+          onClick: () => {
+            void globalThis.navigator?.clipboard?.writeText(asset.title);
+          },
+        },
+      ];
+
+      if (asset.previewUrl) {
+        items.splice(1, 0, {
+          id: 'play-preview',
+          label:
+            playingPreviewId === asset.id ? 'Pause Preview' : 'Play Preview',
+          icon: <PlayCircle className='h-3.5 w-3.5' />,
+          onClick: () => handleTogglePreview(asset),
+        });
+      }
+
+      return items;
+    },
+    [handleTogglePreview, playingPreviewId, router]
+  );
 
   const activeFilterCount =
     filters.statuses.size +
@@ -2065,6 +2216,7 @@ export function LibrarySurface({
                 playingPreviewId={playingPreviewId}
                 onSelect={openAsset}
                 onTogglePreview={handleTogglePreview}
+                getContextMenuItems={getContextMenuItems}
               />
             ) : (
               <LibraryDataTable
@@ -2073,6 +2225,7 @@ export function LibrarySurface({
                 playingPreviewId={playingPreviewId}
                 onSelect={openAsset}
                 onTogglePreview={handleTogglePreview}
+                getContextMenuItems={getContextMenuItems}
               />
             )}
           </div>
@@ -2093,6 +2246,7 @@ export function LibrarySurface({
           isDesktopLayout={isDesktopLayout}
           onTogglePreview={handleTogglePreview}
           onAudioUploaded={handleAudioUploaded}
+          getContextMenuItems={getContextMenuItems}
         />
       </div>
     </PageShell>

--- a/apps/web/app/app/(shell)/library/library-data.ts
+++ b/apps/web/app/app/(shell)/library/library-data.ts
@@ -1,4 +1,5 @@
 import type { ReleaseViewModel } from '@/lib/discography/types';
+import type { LibraryMerchCard } from '@/lib/merch/types';
 
 export interface LibraryProviderLink {
   readonly key: string;
@@ -13,7 +14,18 @@ export type LibraryAssetKind =
   | 'providers'
   | 'video';
 
+export type LibraryItemKind = 'release' | 'merch' | 'image' | 'video' | 'audio';
+
+export type LibraryView =
+  | 'all'
+  | 'releases'
+  | 'merch'
+  | 'images'
+  | 'videos'
+  | 'audio';
+
 export interface LibraryReleaseAsset {
+  readonly itemKind?: LibraryItemKind;
   readonly id: string;
   readonly title: string;
   readonly artist: string;
@@ -38,6 +50,16 @@ export interface LibraryReleaseAsset {
   readonly upc: string | null;
   readonly distributor: string | null;
   readonly totalDurationMs: number | null;
+  readonly itemStatusLabel?: string;
+  readonly primaryActionLabel?: string;
+  readonly primaryActionHref?: string | null;
+  readonly productType?: string;
+  readonly retailPriceLabel?: string;
+  readonly artistPayoutLabel?: string;
+  readonly jovieMarginLabel?: string;
+  readonly description?: string;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
 }
 
 function normalizeHttpUrl(value: string | null | undefined): string | null {
@@ -105,6 +127,95 @@ export function buildLibraryReleaseAssets(
       totalDurationMs: release.totalDurationMs ?? null,
     };
   });
+}
+
+function formatMerchCents(cents: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(cents / 100);
+}
+
+function merchStatusToReleaseStatus(
+  status: LibraryMerchCard['status']
+): ReleaseViewModel['status'] {
+  if (status === 'live') return 'released';
+  if (status === 'paused') return 'scheduled';
+  return 'draft';
+}
+
+function formatMerchStatus(status: LibraryMerchCard['status']): string {
+  return status
+    .split('_')
+    .map(part => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export function buildLibraryMerchAssets(
+  cards: readonly LibraryMerchCard[],
+  artistName: string
+): LibraryReleaseAsset[] {
+  return cards.map(card => {
+    const imageUrl = normalizeHttpUrl(card.primaryImageUrl);
+    return {
+      itemKind: 'merch',
+      id: `merch-${card.id}`,
+      title: card.title,
+      artist: artistName,
+      artworkUrl: imageUrl,
+      previewUrl: null,
+      smartLinkPath: '/app/library?view=merch',
+      releaseDate: card.publishedAt ?? card.updatedAt,
+      releaseType: 'single',
+      status: merchStatusToReleaseStatus(card.status),
+      trackCount: 0,
+      providerCount: 0,
+      providers: [],
+      hasLyrics: false,
+      hasArtwork: Boolean(imageUrl),
+      hasVideoLinks: false,
+      assetKinds: imageUrl ? ['artwork'] : [],
+      genres: [],
+      spotifyPopularity: null,
+      targetPlaylistCount: 0,
+      isExplicit: false,
+      label: null,
+      upc: null,
+      distributor: null,
+      totalDurationMs: null,
+      itemStatusLabel: formatMerchStatus(card.status),
+      primaryActionLabel: 'Open Merch',
+      primaryActionHref: '/app/library?view=merch',
+      productType: card.productType,
+      retailPriceLabel: formatMerchCents(card.retailPriceCents),
+      artistPayoutLabel: formatMerchCents(
+        card.artistPayoutPerUnitEstimateCents
+      ),
+      jovieMarginLabel: formatMerchCents(card.jovieMarginPerUnitEstimateCents),
+      description: card.description,
+      createdAt: card.createdAt,
+      updatedAt: card.updatedAt,
+    };
+  });
+}
+
+export function getLibraryItemKind(
+  asset: LibraryReleaseAsset
+): LibraryItemKind {
+  return asset.itemKind ?? 'release';
+}
+
+export function libraryAssetMatchesView(
+  asset: LibraryReleaseAsset,
+  view: LibraryView
+): boolean {
+  const itemKind = getLibraryItemKind(asset);
+  if (view === 'all') return true;
+  if (view === 'releases') return itemKind === 'release';
+  if (view === 'merch') return itemKind === 'merch';
+  if (view === 'images') return asset.assetKinds.includes('artwork');
+  if (view === 'videos') return asset.assetKinds.includes('video');
+  return Boolean(asset.previewUrl);
 }
 
 export function formatLibraryReleaseDate(value: string | null): string {

--- a/apps/web/app/app/(shell)/library/page.tsx
+++ b/apps/web/app/app/(shell)/library/page.tsx
@@ -1,5 +1,6 @@
 import { APP_ROUTES } from '@/constants/routes';
 import { captureError } from '@/lib/error-tracking';
+import { getLibraryMerchCardsForProfile } from '@/lib/merch/service';
 import { queryKeys } from '@/lib/queries';
 import { HydrateClient } from '@/lib/queries/HydrateClient';
 import { getDehydratedState, getQueryClient } from '@/lib/queries/server';
@@ -23,13 +24,19 @@ export default async function LibraryPage() {
   }
 
   const profileId = routeContext.profileId;
+  let merchCards: Awaited<ReturnType<typeof getLibraryMerchCardsForProfile>> =
+    [];
   if (profileId) {
     const queryClient = getQueryClient();
     try {
-      await queryClient.fetchQuery({
-        queryKey: queryKeys.releases.matrix(profileId),
-        queryFn: () => loadReleaseMatrix(profileId),
-      });
+      const [_releases, merch] = await Promise.all([
+        queryClient.fetchQuery({
+          queryKey: queryKeys.releases.matrix(profileId),
+          queryFn: () => loadReleaseMatrix(profileId),
+        }),
+        getLibraryMerchCardsForProfile(profileId),
+      ]);
+      merchCards = merch;
     } catch (error) {
       void captureError(
         'Release matrix prefetch failed on library page',
@@ -43,7 +50,7 @@ export default async function LibraryPage() {
 
   return (
     <HydrateClient state={getDehydratedState()}>
-      <LibraryPageClient />
+      <LibraryPageClient merchCards={merchCards} />
     </HydrateClient>
   );
 }

--- a/apps/web/app/app/(shell)/releases/page.tsx
+++ b/apps/web/app/app/(shell)/releases/page.tsx
@@ -1,7 +1,8 @@
-import { ReleasesRoute } from './ReleasesRoute';
+import { redirect } from 'next/navigation';
+import { APP_ROUTES } from '@/constants/routes';
 
 export const runtime = 'nodejs';
 
 export default async function ReleasesPage() {
-  return <ReleasesRoute />;
+  redirect(`${APP_ROUTES.LIBRARY}?view=releases`);
 }

--- a/apps/web/lib/merch/service.ts
+++ b/apps/web/lib/merch/service.ts
@@ -37,6 +37,7 @@ import {
 } from './default-catalog';
 import { buildMerchPricingSnapshot, formatMerchMoney } from './pricing';
 import type {
+  LibraryMerchCard,
   MerchDesignLane,
   MerchGenerationOptionView,
   MerchGenerationResult,
@@ -375,6 +376,27 @@ function toPublicMerchCard(card: MerchCard): PublicMerchCard {
     rankScore: card.rankScore,
     position: card.position,
     pinned: card.pinned,
+  };
+}
+
+function toLibraryMerchCard(card: MerchCard): LibraryMerchCard {
+  return {
+    id: card.id,
+    status: card.status,
+    title: card.title,
+    description: card.description,
+    productType: card.productType,
+    primaryImageUrl: card.primaryImageUrl,
+    mockupUrls: card.mockupUrls,
+    retailPriceCents: card.retailPriceCents,
+    artistPayoutPerUnitEstimateCents: card.artistPayoutPerUnitEstimateCents,
+    jovieMarginPerUnitEstimateCents: card.jovieMarginPerUnitEstimateCents,
+    rankScore: card.rankScore,
+    position: card.position,
+    pinned: card.pinned,
+    createdAt: card.createdAt.toISOString(),
+    updatedAt: card.updatedAt.toISOString(),
+    publishedAt: card.publishedAt?.toISOString() ?? null,
   };
 }
 
@@ -797,6 +819,29 @@ export async function getLiveMerchCardsForProfile(
     .limit(6);
 
   return cards.map(toPublicMerchCard);
+}
+
+export async function getLibraryMerchCardsForProfile(
+  profileId: string
+): Promise<LibraryMerchCard[]> {
+  const cards = await db
+    .select()
+    .from(merchCards)
+    .where(
+      and(
+        eq(merchCards.creatorProfileId, profileId),
+        ne(merchCards.status, 'archived')
+      )
+    )
+    .orderBy(
+      desc(merchCards.pinned),
+      asc(merchCards.position),
+      desc(merchCards.rankScore),
+      desc(merchCards.updatedAt)
+    )
+    .limit(100);
+
+  return cards.map(toLibraryMerchCard);
 }
 
 export async function getPublicMerchCard(params: {

--- a/apps/web/lib/merch/types.ts
+++ b/apps/web/lib/merch/types.ts
@@ -91,6 +91,25 @@ export interface PublicMerchCard {
   readonly pinned: boolean;
 }
 
+export interface LibraryMerchCard {
+  readonly id: string;
+  readonly status: MerchCard['status'];
+  readonly title: string;
+  readonly description: string;
+  readonly productType: string;
+  readonly primaryImageUrl: string;
+  readonly mockupUrls: string[];
+  readonly retailPriceCents: number;
+  readonly artistPayoutPerUnitEstimateCents: number;
+  readonly jovieMarginPerUnitEstimateCents: number;
+  readonly rankScore: number;
+  readonly position: number | null;
+  readonly pinned: boolean;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly publishedAt: string | null;
+}
+
 export interface MerchCheckoutInput {
   readonly merchCardId: string;
   readonly variantKey: string;

--- a/apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx
+++ b/apps/web/tests/unit/chat/ChatEntityRightPanelHost.test.tsx
@@ -270,6 +270,39 @@ describe('ChatEntityRightPanelHost', () => {
     expect(mockUseRegisterRightPanel.mock.calls.at(-1)?.[0]).not.toBeNull();
   });
 
+  it('registers the profile bento rail when preview opens with profile context', () => {
+    mockPreviewPanelOpen = true;
+    mockUseRegisterRightPanel.mockClear();
+
+    render(
+      <ChatEntityPanelProvider>
+        <ChatEntityRightPanelHost
+          enablePreviewPanel
+          profileContext={{
+            id: 'profile-1',
+            displayName: 'Tim White',
+            username: 'tim',
+            avatarUrl: null,
+            completionPercentage: 72,
+            hasMusicLinks: true,
+            hasSocialLinks: false,
+          }}
+        />
+      </ChatEntityPanelProvider>
+    );
+
+    const registeredPanel = mockUseRegisterRightPanel.mock.calls.at(-1)?.[0];
+    expect(registeredPanel).not.toBeNull();
+    render(registeredPanel as React.ReactElement);
+
+    expect(screen.getByTestId('chat-profile-bento-panel')).toBeInTheDocument();
+    expect(screen.getAllByText('Tim White').length).toBeGreaterThan(0);
+    expect(screen.getByText('72% Complete')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Open Public Profile' })
+    ).toHaveAttribute('href', '/tim');
+  });
+
   it('tracks chat-owned entity targets through the provider', () => {
     render(
       <ChatEntityPanelProvider>
@@ -363,7 +396,7 @@ describe('ChatEntityRightPanelHost', () => {
     expect(
       screen.getByTestId('chat-rail-context-only-panel')
     ).toBeInTheDocument();
-    expect(screen.getByText('Tim White')).toBeInTheDocument();
+    expect(screen.getAllByText('Tim White').length).toBeGreaterThan(0);
     expect(screen.getByText('64% Complete')).toBeInTheDocument();
     expect(screen.queryByTestId('profile-contact-sidebar')).toBeNull();
   });

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -22,6 +22,7 @@ Element.prototype.scrollIntoView = vi.fn();
 
 const navigationMock = vi.hoisted(() => ({
   refresh: vi.fn(),
+  searchParams: new URLSearchParams(),
 }));
 
 const blobUploadMock = vi.hoisted(() => vi.fn());
@@ -61,8 +62,10 @@ vi.mock('@vercel/blob/client', () => ({
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({
+    push: vi.fn(),
     refresh: navigationMock.refresh,
   }),
+  useSearchParams: () => navigationMock.searchParams,
 }));
 
 vi.mock('sonner', () => ({
@@ -187,10 +190,10 @@ describe('LibrarySurface', () => {
   it('renders an empty read-only library state with a releases escape hatch', () => {
     renderLibrary([]);
 
-    expect(screen.getByText('No Release Assets')).toBeDefined();
+    expect(screen.getByText('No Library Items')).toBeDefined();
     expect(
       screen.getByText(
-        'Releases and artwork will appear here after your catalog is connected.'
+        'Releases, merch, images, videos, and audio will appear here as they land.'
       )
     ).toBeDefined();
     expect(screen.getByRole('link', { name: 'Open Releases' })).toHaveAttribute(
@@ -241,6 +244,56 @@ describe('LibrarySurface', () => {
       'aria-hidden',
       'true'
     );
+  });
+
+  it('renders merch assets with prices and the shared detail drawer', () => {
+    renderLibrary([
+      buildAsset({
+        id: 'merch-card-1',
+        title: 'Never Say A Word Hoodie',
+        artworkUrl: 'https://cdn.example.com/hoodie.png',
+        smartLinkPath: '/app/library?view=merch',
+        releaseDate: '2026-05-25T00:00:00.000Z',
+        itemKind: 'merch',
+        itemStatusLabel: 'Draft',
+        primaryActionLabel: 'Open Merch',
+        primaryActionHref: '/app/library?view=merch',
+        productType: 'hoodie',
+        retailPriceLabel: '$68.00',
+        artistPayoutLabel: '$22.00',
+        jovieMarginLabel: '$9.00',
+        description: 'Black hoodie with Never Say A Word cover art.',
+        previewUrl: null,
+        providerCount: 0,
+        providers: [],
+        hasLyrics: false,
+        assetKinds: ['artwork'],
+      }),
+    ]);
+
+    expect(
+      screen.getByRole('heading', { name: 'Never Say A Word Hoodie' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('$68.00')).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: /Inspect Never Say A Word Hoodie/u,
+      })
+    );
+
+    const drawer = within(screen.getByTestId('library-asset-drawer'));
+    expect(drawer.getAllByText('Merch').length).toBeGreaterThan(0);
+    expect(
+      drawer.getByText('Black hoodie with Never Say A Word cover art.')
+    ).toBeInTheDocument();
+    expect(drawer.getByText('$22.00')).toBeInTheDocument();
+    expect(drawer.getByText('$9.00')).toBeInTheDocument();
+    expect(drawer.getByRole('link', { name: /Open Merch/u })).toHaveAttribute(
+      'href',
+      '/app/library?view=merch'
+    );
+    expect(screen.queryByTestId('library-audio-dropzone')).toBeNull();
   });
 
   it('uses shell focus tokens for library cards and drawer actions', () => {
@@ -468,7 +521,7 @@ describe('LibrarySurface', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('filters release assets from the Library navigation', () => {
+  it('filters library assets from the Library navigation', async () => {
     renderLibrary([
       buildAsset(),
       buildAsset({
@@ -486,16 +539,18 @@ describe('LibrarySurface', () => {
     ]);
 
     fireEvent.click(screen.getByRole('button', { name: 'Show filters' }));
-    fireEvent.click(screen.getByRole('button', { name: /Needs Assets/u }));
+    fireEvent.click(screen.getByRole('button', { name: /Audio/u }));
 
-    expect(
-      screen.getByRole('heading', { name: 'Never Say A Word' })
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('heading', { name: 'Take Me Over' })
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'Take Me Over' })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('heading', { name: 'Never Say A Word' })
+      ).not.toBeInTheDocument();
+    });
 
-    fireEvent.click(screen.getByRole('button', { name: /All Releases/u }));
+    fireEvent.click(screen.getByRole('button', { name: /^All/u }));
 
     expect(
       screen.getByRole('heading', { name: 'Take Me Over' })
@@ -528,11 +583,10 @@ describe('LibrarySurface', () => {
       screen.getByRole('navigation', { name: 'Library navigation' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /All Releases/u })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /Needs Assets/u })
-    ).toBeInTheDocument();
+      screen.queryByRole('button', { name: /All Releases/u })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Merch/u })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Audio/u })).toBeInTheDocument();
   });
 
   it('keeps library filters reachable on desktop without taking over the shell sidebar', async () => {

--- a/apps/web/tests/unit/library/library-data.test.ts
+++ b/apps/web/tests/unit/library/library-data.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildLibraryMerchAssets,
   buildLibraryReleaseAssets,
   formatLibraryDuration,
   formatLibraryReleaseDate,
 } from '@/app/app/(shell)/library/library-data';
 import type { ReleaseViewModel } from '@/lib/discography/types';
+import type { LibraryMerchCard } from '@/lib/merch/types';
 
 function buildRelease(
   overrides: Partial<ReleaseViewModel> = {}
@@ -109,6 +111,46 @@ describe('library data', () => {
       hasArtwork: false,
       assetKinds: [],
     });
+  });
+
+  it('derives library merch assets from chat-selected merch cards', () => {
+    const cards: LibraryMerchCard[] = [
+      {
+        id: 'merch-1',
+        status: 'draft',
+        title: 'Never Say A Word Hoodie',
+        description: 'Black hoodie with cover art.',
+        productType: 'hoodie',
+        primaryImageUrl: 'https://cdn.example.com/hoodie.png',
+        mockupUrls: ['https://cdn.example.com/mockup.png'],
+        retailPriceCents: 6800,
+        artistPayoutPerUnitEstimateCents: 2200,
+        jovieMarginPerUnitEstimateCents: 900,
+        rankScore: 91,
+        position: 0,
+        pinned: false,
+        createdAt: '2026-05-24T00:00:00.000Z',
+        updatedAt: '2026-05-25T00:00:00.000Z',
+        publishedAt: null,
+      },
+    ];
+
+    expect(buildLibraryMerchAssets(cards, 'Tim White')).toEqual([
+      expect.objectContaining({
+        id: 'merch-merch-1',
+        title: 'Never Say A Word Hoodie',
+        artist: 'Tim White',
+        artworkUrl: 'https://cdn.example.com/hoodie.png',
+        itemKind: 'merch',
+        itemStatusLabel: 'Draft',
+        productType: 'hoodie',
+        primaryActionLabel: 'Open Merch',
+        smartLinkPath: '/app/library?view=merch',
+        retailPriceLabel: '$68.00',
+        artistPayoutLabel: '$22.00',
+        jovieMarginLabel: '$9.00',
+      }),
+    ]);
   });
 
   it('formats release dates without local timezone drift', () => {

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -162,7 +162,7 @@ describe('shell route coverage', () => {
     );
   });
 
-  it('keeps release list data ownership outside the legacy dashboard route', () => {
+  it('keeps release list routes aliased to Library while legacy dashboard keeps matrix ownership', () => {
     const canonicalPage = pageByRoute.get('/app/releases');
     const legacyPage = pageByRoute.get('/app/dashboard/releases');
     const canonicalRoutePath = path.join(
@@ -171,9 +171,8 @@ describe('shell route coverage', () => {
     );
     const canonicalRouteSource = fs.readFileSync(canonicalRoutePath, 'utf8');
 
-    expect(canonicalPage?.source).toContain(
-      "import { ReleasesRoute } from './ReleasesRoute';"
-    );
+    expect(canonicalPage?.source).toContain('redirect(');
+    expect(canonicalPage?.source).toContain('view=releases');
     expect(legacyPage?.source).toContain(
       "import { ReleasesRoute } from '../../releases/ReleasesRoute';"
     );


### PR DESCRIPTION
## Summary
- Make Library support All, Releases, Merch, Images, Videos, and Audio views, with selected draft/live merch included by default.
- Fetch non-archived merch cards for Library and merge them with release assets in all-item mode.
- Redirect /app/releases to Library?view=releases for compatibility.
- Standardize chat and Library entity rails around image/name/status pills, compact actions, profile bento rail, and shared context-menu actions.

## Verification
- node --version -> v22.22.1
- pnpm --version -> 9.15.4
- pnpm --filter @jovie/web exec vitest run focused chat/library/shell suites: 23 files, 260 tests passed
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm biome check apps/web
- git push pre-push: biome check ., next proxy guard, tailwind guard, typecheck, biome lint

## QA Evidence
- .gstack/qa-reports/jov-2593/screenshots/library-all-desktop-final.png
- .gstack/qa-reports/jov-2593/screenshots/library-merch-after-selection.png
- .gstack/qa-reports/jov-2593/screenshots/library-merch-drawer.png
- .gstack/qa-reports/jov-2593/screenshots/profile-bento-desktop-final.png

JOV-2593