### PR TITLE
JOV-2593 Shell chats cleanup

### DIFF
--- a/apps/web/app/app/(shell)/chats/page.tsx
+++ b/apps/web/app/app/(shell)/chats/page.tsx
@@ -1,0 +1,25 @@
+import { APP_ROUTES } from '@/constants/routes';
+import { HydrateClient } from '@/lib/queries/HydrateClient';
+import { getDehydratedState } from '@/lib/queries/server';
+import { loadAppShellRouteContext } from '../app-shell-route-context';
+import { ChatsPageClient } from '../threads/ThreadsPageClient';
+
+export const runtime = 'nodejs';
+
+export default async function ChatsPage() {
+  const routeContext = await loadAppShellRouteContext({
+    route: APP_ROUTES.CHATS,
+    dashboardErrorLogMessage: 'Dashboard data load failed on chats page',
+    dashboardErrorMessage:
+      'Failed to load chats data. Please refresh the page.',
+  });
+  if (!routeContext.ok) {
+    return routeContext.error;
+  }
+
+  return (
+    <HydrateClient state={getDehydratedState()}>
+      <ChatsPageClient />
+    </HydrateClient>
+  );
+}

--- a/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
+++ b/apps/web/app/app/(shell)/dashboard/tasks/task-actions.ts
@@ -6,6 +6,7 @@ import {
   count,
   sql as drizzleSql,
   eq,
+  gt,
   ilike,
   inArray,
   isNull,
@@ -129,6 +130,7 @@ function formatTaskStats(
     done,
     cancelled,
     activeTodoCount: backlog + todo + inProgress,
+    newActiveTodoCount: 0,
   };
 }
 
@@ -881,7 +883,9 @@ export async function bulkUpdateTasks(
   return { success: true };
 }
 
-export async function getTaskStats(): Promise<TaskStats> {
+export async function getTaskStats(
+  options: { readonly newerThan?: string | null } = {}
+): Promise<TaskStats> {
   await requireTasksWorkspaceAccess();
   const profileId = await requireProfileId();
 
@@ -894,5 +898,26 @@ export async function getTaskStats(): Promise<TaskStats> {
     .where(and(eq(tasks.creatorProfileId, profileId), isNull(tasks.deletedAt)))
     .groupBy(tasks.status);
 
-  return formatTaskStats(rows);
+  const stats = formatTaskStats(rows);
+  const newerThan = options.newerThan ? new Date(options.newerThan) : null;
+  if (!newerThan || Number.isNaN(newerThan.getTime())) {
+    return stats;
+  }
+
+  const [newActive] = await db
+    .select({ count: count() })
+    .from(tasks)
+    .where(
+      and(
+        eq(tasks.creatorProfileId, profileId),
+        isNull(tasks.deletedAt),
+        inArray(tasks.status, ['backlog', 'todo', 'in_progress']),
+        gt(tasks.updatedAt, newerThan)
+      )
+    );
+
+  return {
+    ...stats,
+    newActiveTodoCount: Number(newActive?.count ?? 0),
+  };
 }

--- a/apps/web/app/app/(shell)/shell-route-matches.ts
+++ b/apps/web/app/app/(shell)/shell-route-matches.ts
@@ -73,12 +73,13 @@ export function isChatShellRoute(pathname: string | null): boolean {
   return (
     matchesExactRoute(pathname, APP_ROUTES.DASHBOARD) ||
     matchesRoutePrefix(pathname, APP_ROUTES.CHAT) ||
+    matchesRoutePrefix(pathname, APP_ROUTES.CHATS) ||
     matchesRoutePrefix(pathname, APP_ROUTES.THREADS)
   );
 }
 
 export function isThreadsShellRoute(pathname: string | null): boolean {
-  return matchesRoutePrefix(pathname, APP_ROUTES.THREADS);
+  return matchesRoutePrefix(pathname, APP_ROUTES.CHATS, APP_ROUTES.THREADS);
 }
 
 export function isReleasesShellRoute(pathname: string | null): boolean {

--- a/apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx
+++ b/apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx
@@ -5,7 +5,7 @@ import { Search } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { AppSearchField } from '@/components/molecules/AppSearchField';
-import { PageHeader, PageShell } from '@/components/organisms/PageShell';
+import { PageShell } from '@/components/organisms/PageShell';
 import {
   readThreadReadState,
   type SidebarThread,
@@ -19,14 +19,14 @@ import { useChatConversationsQuery } from '@/lib/queries/useChatConversationsQue
 
 const THREAD_LIMIT = 50;
 
-function ThreadListSkeleton() {
+function ChatListSkeleton() {
   const skeletonRows = ['a', 'b', 'c', 'd', 'e', 'f'];
 
   return (
     <div className='space-y-1.5'>
       {skeletonRows.map(rowId => (
         <div
-          key={`thread-skeleton-${rowId}`}
+          key={`chat-skeleton-${rowId}`}
           className='flex h-7 items-center gap-2 rounded-full px-2.5'
         >
           <div className='h-1.5 w-1.5 shrink-0 rounded-full skeleton motion-reduce:animate-none' />
@@ -37,7 +37,7 @@ function ThreadListSkeleton() {
   );
 }
 
-export function ThreadsPageClient() {
+export function ChatsPageClient() {
   const [query, setQuery] = useState('');
   const [threadReadAtById, setThreadReadAtById] =
     useState<Record<string, string>>(readThreadReadState);
@@ -98,38 +98,32 @@ export function ThreadsPageClient() {
 
   return (
     <PageShell
-      data-testid='threads-page'
+      data-testid='chats-page'
       className='h-full'
       frame='content-container'
       contentPadding='none'
       surfaceMode='default'
     >
       <div className='flex h-full min-h-0 flex-col'>
-        <PageHeader
-          title='Threads'
-          description='Recent conversations, sorted by the last update.'
-          action={
-            <Button asChild variant='secondary' size='sm'>
-              <Link href={APP_ROUTES.CHAT}>New thread</Link>
-            </Button>
-          }
-          className='shrink-0'
-        />
-
         <div className='shrink-0 border-b border-[color-mix(in_oklab,var(--linear-app-frame-seam)_44%,transparent)] px-4 py-3 sm:px-6'>
-          <AppSearchField
-            value={query}
-            onChange={setQuery}
-            placeholder='Search threads'
-            ariaLabel='Search threads'
-            className='max-w-2xl'
-            inputClassName='text-[13px]'
-          />
+          <div className='flex items-center gap-2'>
+            <AppSearchField
+              value={query}
+              onChange={setQuery}
+              placeholder='Search chats'
+              ariaLabel='Search chats'
+              className='max-w-2xl flex-1'
+              inputClassName='text-[13px]'
+            />
+            <Button asChild variant='secondary' size='sm'>
+              <Link href={APP_ROUTES.CHAT}>New Chat</Link>
+            </Button>
+          </div>
           <div className='mt-2 flex items-center gap-3 text-[11px] text-tertiary-token'>
-            <span>{sidebarThreads.length} threads</span>
+            <span>{sidebarThreads.length} chats</span>
             <span className='inline-flex items-center gap-1'>
               <Search className='h-3 w-3' />
-              Search is local to thread titles and statuses
+              Search is local to chat titles and statuses
             </span>
             {unreadCount > 0 ? <span>{unreadCount} unread</span> : null}
           </div>
@@ -137,11 +131,11 @@ export function ThreadsPageClient() {
 
         <div className='min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6'>
           {isLoading ? (
-            <ThreadListSkeleton />
+            <ChatListSkeleton />
           ) : isError ? (
             <PageErrorState
-              title='Unable to load threads'
-              message='We could not load your recent threads. Retry the request or refresh the page.'
+              title='Unable to load chats'
+              message='We could not load your recent chats. Retry the request or refresh the page.'
               error={error instanceof Error ? error : undefined}
               actionLabel='Retry load'
               onRetry={() => {
@@ -157,16 +151,16 @@ export function ThreadsPageClient() {
               <div className='max-w-sm space-y-3'>
                 <p className='text-[14px] font-semibold text-primary-token'>
                   {normalizedQuery
-                    ? `No threads match "${trimmedQuery}".`
-                    : 'No threads yet'}
+                    ? `No chats match "${trimmedQuery}".`
+                    : 'No chats yet'}
                 </p>
                 <p className='text-[13px] leading-6 text-secondary-token'>
                   {normalizedQuery
                     ? 'Clear the search or try a different phrase.'
-                    : 'Start a new thread to see conversations appear here.'}
+                    : 'Start a new chat to see conversations appear here.'}
                 </p>
                 <Button asChild variant='secondary' size='sm'>
-                  <Link href={APP_ROUTES.CHAT}>New thread</Link>
+                  <Link href={APP_ROUTES.CHAT}>New Chat</Link>
                 </Button>
               </div>
             </div>
@@ -188,3 +182,5 @@ export function ThreadsPageClient() {
     </PageShell>
   );
 }
+
+export { ChatsPageClient as ThreadsPageClient };

--- a/apps/web/app/app/(shell)/threads/page.tsx
+++ b/apps/web/app/app/(shell)/threads/page.tsx
@@ -1,25 +1,8 @@
+import { redirect } from 'next/navigation';
 import { APP_ROUTES } from '@/constants/routes';
-import { HydrateClient } from '@/lib/queries/HydrateClient';
-import { getDehydratedState } from '@/lib/queries/server';
-import { loadAppShellRouteContext } from '../app-shell-route-context';
-import { ThreadsPageClient } from './ThreadsPageClient';
 
 export const runtime = 'nodejs';
 
 export default async function ThreadsPage() {
-  const routeContext = await loadAppShellRouteContext({
-    route: APP_ROUTES.THREADS,
-    dashboardErrorLogMessage: 'Dashboard data load failed on threads page',
-    dashboardErrorMessage:
-      'Failed to load threads data. Please refresh the page.',
-  });
-  if (!routeContext.ok) {
-    return routeContext.error;
-  }
-
-  return (
-    <HydrateClient state={getDehydratedState()}>
-      <ThreadsPageClient />
-    </HydrateClient>
-  );
+  redirect(APP_ROUTES.CHATS);
 }

--- a/apps/web/components/atoms/DesktopTitlebar.tsx
+++ b/apps/web/components/atoms/DesktopTitlebar.tsx
@@ -67,7 +67,7 @@ export function DesktopTitlebar() {
               aria-label={sidebarToggleLabel}
               data-testid='electron-sidebar-toggle'
               className={cn(
-                'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-secondary-token',
+                'flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-secondary-token',
                 'transition-colors duration-subtle',
                 'hover:bg-white/[0.06] hover:text-primary-token',
                 'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30',

--- a/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
+++ b/apps/web/components/features/dashboard/dashboard-nav/DashboardNav.tsx
@@ -31,7 +31,7 @@ import { useTaskStatsQuery } from '@/lib/queries/useTasksQuery';
 import {
   adminNavigationSections,
   artistSettingsNavigation,
-  calendarNavItem,
+  libraryNavItem,
   newThreadNavItem,
   primaryNavigation,
   profileNavItem,
@@ -48,7 +48,7 @@ const searchNavItem: NavItem = {
   id: 'search',
   icon: Search,
   description:
-    'Search app content across threads, releases, artists, tasks, and more',
+    'Search app content across chats, releases, artists, tasks, and more',
 };
 
 type DashboardNavSection = {
@@ -101,11 +101,36 @@ function normalizeTrailingSlash(pathname: string): string {
   return pathname === '/' ? pathname : pathname.replace(/\/$/, '');
 }
 
+const TASKS_SEEN_STORAGE_KEY = 'jovie:tasks-seen-at';
+
+function readTasksSeenAt(): string | null {
+  try {
+    return globalThis.localStorage?.getItem(TASKS_SEEN_STORAGE_KEY) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeTasksSeenAt(value: string): void {
+  try {
+    globalThis.localStorage?.setItem(TASKS_SEEN_STORAGE_KEY, value);
+  } catch {
+    // Storage can be unavailable in restricted browsers; the badge still works.
+  }
+}
+
 function formatTaskBadge(
-  taskStats: { activeTodoCount: number } | undefined
+  taskStats:
+    | { activeTodoCount: number; newActiveTodoCount?: number }
+    | undefined,
+  seenAt: string | null
 ): string | number | undefined {
   if (!taskStats || taskStats.activeTodoCount <= 0) return undefined;
-  return taskStats.activeTodoCount > 99 ? '99+' : taskStats.activeTodoCount;
+  const count = seenAt
+    ? (taskStats.newActiveTodoCount ?? 0)
+    : taskStats.activeTodoCount;
+  if (count <= 0) return undefined;
+  return count > 99 ? '99+' : count;
 }
 
 export function DashboardNav(_: DashboardNavProps) {
@@ -118,6 +143,9 @@ export function DashboardNav(_: DashboardNavProps) {
   const shellChatV1Enabled = useAppFlag('DESIGN_V1');
   const [threadReadAtById, setThreadReadAtById] =
     useState<Record<string, string>>(readThreadReadState);
+  const [tasksSeenAt, setTasksSeenAt] = useState<string | null>(
+    readTasksSeenAt
+  );
   const username =
     selectedProfile?.usernameNormalized ?? selectedProfile?.username;
   const publicProfileHref = username ? `/${username}` : undefined;
@@ -138,6 +166,7 @@ export function DashboardNav(_: DashboardNavProps) {
     usePlanGate();
   const { data: taskStats } = useTaskStatsQuery(profileId, {
     enabled: !isDemo && canAccessTasksWorkspace,
+    seenAt: tasksSeenAt,
   });
   const isInSettings = pathname.startsWith(APP_ROUTES.SETTINGS);
   const threadsVisible =
@@ -172,6 +201,13 @@ export function DashboardNav(_: DashboardNavProps) {
     });
   }, [conversations]);
 
+  useEffect(() => {
+    if (normalizeTrailingSlash(pathname) !== APP_ROUTES.TASKS) return;
+    const nextSeenAt = new Date().toISOString();
+    writeTasksSeenAt(nextSeenAt);
+    setTasksSeenAt(nextSeenAt);
+  }, [pathname]);
+
   // Settings nav: "General" (user) and artist name (or "Artist") groups
   const artistSettingsLabel = artistName || 'Artist';
   const moreLabel = 'More';
@@ -187,7 +223,8 @@ export function DashboardNav(_: DashboardNavProps) {
             ...item,
             badge: (() => {
               if (isPlanGateLoading) return undefined;
-              if (canAccessTasksWorkspace) return formatTaskBadge(taskStats);
+              if (canAccessTasksWorkspace)
+                return formatTaskBadge(taskStats, tasksSeenAt);
               return (
                 <span className='rounded-full border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_76%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_90%,transparent)] px-1.5 py-0.5 text-[9px] font-semibold tracking-[0.02em] text-secondary-token'>
                   Pro
@@ -200,34 +237,35 @@ export function DashboardNav(_: DashboardNavProps) {
     const releaseItem = primaryNavigation.find(item => item.id === 'releases');
     const audienceItem = primaryNavigation.find(item => item.id === 'audience');
     const tasksItem = primaryNavigation.find(item => item.id === 'tasks');
+    const artistProfileItem: NavItem = {
+      ...profileNavItem,
+      name: artistSettingsLabel,
+    };
 
     if (shellChatV1Enabled) {
       return {
         moreSection: {
           key: 'more',
           label: moreLabel,
-          items: [profileNavItem, settingsNavItem].map(decorateItem),
+          items: [artistProfileItem, settingsNavItem].map(decorateItem),
         },
         navSections: [
           {
-            key: 'work',
-            label: 'Work',
+            key: 'top',
             items: [
               decorateItem(newThreadNavItem),
               searchNavItem,
-              ...(tasksItem ? [decorateItem(tasksItem)] : []),
-              decorateItem(calendarNavItem),
+              decorateItem(libraryNavItem),
             ],
           },
           {
-            key: 'catalog',
-            label: 'Catalog',
-            items: releaseItem ? [decorateItem(releaseItem)] : [],
-          },
-          {
-            key: 'growth',
-            label: 'Growth',
-            items: audienceItem ? [decorateItem(audienceItem)] : [],
+            key: 'artist',
+            label: artistSettingsLabel,
+            items: [
+              ...(releaseItem ? [decorateItem(releaseItem)] : []),
+              ...(audienceItem ? [decorateItem(audienceItem)] : []),
+              ...(tasksItem ? [decorateItem(tasksItem)] : []),
+            ],
           },
         ],
       };
@@ -245,9 +283,11 @@ export function DashboardNav(_: DashboardNavProps) {
   }, [
     canAccessTasksWorkspace,
     isPlanGateLoading,
+    artistSettingsLabel,
     moreLabel,
     shellChatV1Enabled,
     taskStats,
+    tasksSeenAt,
   ]);
 
   // Debounced prefetch: avoid firing on fast mouse sweeps across nav items
@@ -527,7 +567,7 @@ export function DashboardNav(_: DashboardNavProps) {
             threads={sidebarThreads}
             activeThreadId={activeThreadId}
             allThreadsActive={
-              normalizeTrailingSlash(pathname) === APP_ROUTES.THREADS
+              normalizeTrailingSlash(pathname) === APP_ROUTES.CHATS
             }
             onNewThread={() => {
               router.push(APP_ROUTES.CHAT);

--- a/apps/web/components/features/dashboard/dashboard-nav/config.ts
+++ b/apps/web/components/features/dashboard/dashboard-nav/config.ts
@@ -12,6 +12,7 @@ import {
   IdCard,
   Image as ImageIcon,
   LayoutDashboard,
+  Library as LibraryIcon,
   Lock,
   type LucideIcon,
   MailCheck,
@@ -44,27 +45,36 @@ export const dashboardHome: NavItem = {
   href: APP_ROUTES.CHAT,
   id: 'overview',
   icon: Home,
-  description: 'Start a new thread',
+  description: 'Start a new chat',
 };
 
 export const newThreadNavItem: NavItem = {
-  name: 'New thread',
+  name: 'New Chat',
   href: APP_ROUTES.CHAT,
   id: 'chat',
   icon: SquarePen,
-  description: 'Start a new thread',
+  description: 'Start a new chat',
 };
 
 export const profileNavItem: NavItem = {
   name: 'Profile',
-  href: APP_ROUTES.SETTINGS_ARTIST_PROFILE,
+  href: APP_ROUTES.CHAT_PROFILE_PANEL,
   id: 'profile',
   icon: UserCircle,
-  description: 'Update your profile and links',
+  description: 'Open profile preview and links',
+};
+
+export const libraryNavItem: NavItem = {
+  name: 'Library',
+  href: APP_ROUTES.LIBRARY,
+  id: 'library',
+  icon: LibraryIcon,
+  description: 'Browse releases, merch, images, videos, and audio',
 };
 
 export const primaryNavigation: NavItem[] = [
   newThreadNavItem,
+  libraryNavItem,
   profileNavItem,
   {
     name: 'Releases',
@@ -264,7 +274,7 @@ export const mobileHome: NavItem = {
   href: APP_ROUTES.CHAT,
   id: 'home',
   icon: SquarePen,
-  description: 'Start a new thread',
+  description: 'Start a new chat',
 };
 
 /** Items shown as icons in the bottom tab bar (max 3). */

--- a/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
@@ -368,7 +368,7 @@ export function LiquidGlassMenu({
                 </div>
                 <span
                   className={cn(
-                    'text-3xs leading-tight',
+                    'sr-only',
                     active ? 'font-semibold' : 'font-caption'
                   )}
                 >
@@ -399,7 +399,7 @@ export function LiquidGlassMenu({
             <MoreHorizontal className='h-5 w-5' aria-hidden='true' />
             <span
               className={cn(
-                'text-3xs leading-tight',
+                'sr-only',
                 isExpanded ? 'font-semibold' : 'font-caption'
               )}
             >
@@ -416,9 +416,7 @@ export function LiquidGlassMenu({
               className='relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 text-tertiary-token transition-[color,transform] duration-subtle hover:text-secondary-token active:scale-95'
             >
               <Search className='h-5 w-5' aria-hidden='true' />
-              <span className='text-3xs leading-tight font-caption'>
-                Search
-              </span>
+              <span className='sr-only'>Search</span>
             </button>
           )}
         </div>

--- a/apps/web/components/molecules/sidebar-collapse-button/SidebarCollapseButton.tsx
+++ b/apps/web/components/molecules/sidebar-collapse-button/SidebarCollapseButton.tsx
@@ -2,9 +2,9 @@
 
 import { TooltipShortcut } from '@jovie/ui';
 import { PanelLeft } from 'lucide-react';
-import { CircleIconButton } from '@/components/atoms/CircleIconButton';
 import { useSidebar } from '@/components/organisms/Sidebar';
 import { SIDEBAR_KEYBOARD_SHORTCUT_BARE } from '@/hooks/useSidebarKeyboardShortcut';
+import { cn } from '@/lib/utils';
 
 interface SidebarCollapseButtonProps {
   readonly className?: string;
@@ -20,15 +20,17 @@ export function SidebarCollapseButton({
 
   return (
     <TooltipShortcut label={label} shortcut={shortcut} side='right'>
-      <CircleIconButton
-        size='xs'
-        variant='secondary'
+      <button
+        type='button'
         onClick={toggleSidebar}
-        ariaLabel={label}
-        className={className}
+        aria-label={label}
+        className={cn(
+          'inline-flex h-7 w-7 items-center justify-center rounded-md border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_76%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_86%,transparent)] text-secondary-token transition-[background-color,border-color,color,box-shadow] duration-subtle hover:border-default hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
+          className
+        )}
       >
         <PanelLeft className='h-3.5 w-3.5' strokeWidth={2} aria-hidden='true' />
-      </CircleIconButton>
+      </button>
     </TooltipShortcut>
   );
 }

--- a/apps/web/components/organisms/AuthShell.tsx
+++ b/apps/web/components/organisms/AuthShell.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
+import { SidebarCollapseButton } from '@/components/molecules/sidebar-collapse-button/SidebarCollapseButton';
 import {
   SidebarProvider,
   SidebarTrigger,
@@ -47,14 +48,19 @@ function AuthShellInner({
   isLyricsRoute = false,
   children,
 }: Readonly<Omit<AuthShellProps, 'children'> & { children: ReactNode }>) {
-  const { isMobile } = useSidebar();
+  const { isMobile, state: sidebarState } = useSidebar();
   const rightPanel = useRightPanel();
   const previewPanelState = usePreviewPanelState();
   const headerActionsState = useOptionalHeaderActions();
   const shellChatV1Enabled = useAppFlag('DESIGN_V1');
 
-  const sidebarTrigger =
-    isMobile || shellChatV1Enabled ? null : <SidebarTrigger />;
+  const sidebarTrigger = isMobile ? null : shellChatV1Enabled ? (
+    sidebarState === 'closed' ? (
+      <SidebarCollapseButton />
+    ) : null
+  ) : (
+    <SidebarTrigger />
+  );
 
   const isInSettings = section === 'settings';
   const hideTopHeader = isInSettings || isLyricsRoute;

--- a/apps/web/components/organisms/CmdKPalette.tsx
+++ b/apps/web/components/organisms/CmdKPalette.tsx
@@ -9,7 +9,7 @@
  *   - skill → router.push(/app/chat?skill=<id>) — chat picks up the chip
  *   - entity (release) → its detail surface (currently `/.../tasks`)
  *   - entity (artist/track) → no-op (no detail page yet)
- *   - additional-section item (e.g. recent thread) → caller-handled via
+ *   - additional-section item (e.g. recent chat) → caller-handled via
  *     `onAdditionalSelect`
  */
 
@@ -50,7 +50,7 @@ interface CmdKPaletteProps {
   readonly onOpenChange: (open: boolean) => void;
   /**
    * Optional extra sections appended after the registry-driven sections.
-   * Used by `CommandPalette` to surface "Recent threads" + "Actions"
+   * Used by `CommandPalette` to surface "Recent chats" + "Actions"
    * without baking them into the registry.
    */
   readonly additionalSectionsAfter?: PaletteSection[];
@@ -248,7 +248,7 @@ export function CmdKPalette({
           Command palette
         </DialogPrimitive.Title>
         <DialogPrimitive.Description className='sr-only'>
-          Search routes, skills, releases, artists, and recent threads.
+          Search routes, skills, releases, artists, and recent chats.
         </DialogPrimitive.Description>
         <div
           className='flex flex-col'
@@ -268,7 +268,7 @@ export function CmdKPalette({
                 setQuery(e.target.value);
                 setSelectedIndex(0);
               }}
-              placeholder='Jump to a page, skill, release, or thread…'
+              placeholder='Jump to a page, skill, release, or chat...'
               className='flex-1 appearance-none bg-transparent text-sm text-primary-token outline-none placeholder:text-tertiary-token focus:outline-none focus-visible:outline-none focus-visible:shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_45%,transparent)]'
               aria-label='Command palette search'
             />

--- a/apps/web/components/organisms/CommandPalette.tsx
+++ b/apps/web/components/organisms/CommandPalette.tsx
@@ -8,7 +8,7 @@
  * `SharedCommandPalette` (`CmdKPalette`). This file owns:
  *   - the `Cmd+K` global keydown trigger,
  *   - feeding the palette its `profileId` from `DashboardDataContext`,
- *   - injecting the "Recent threads" section as an additional source.
+ *   - injecting the "Recent chats" section as an additional source.
  */
 
 import { useRouter } from 'next/navigation';
@@ -22,7 +22,7 @@ import { useChatConversationsQuery } from '@/lib/queries';
 import { isFormElement } from '@/lib/utils/keyboard';
 import { OPEN_COMMAND_PALETTE_EVENT } from './command-palette-events';
 
-const RECENT_THREAD_LIMIT = 10;
+const RECENT_CHAT_LIMIT = 10;
 
 export function CommandPalette() {
   // Read the context directly so we don't hit the throwing useDashboardData
@@ -75,27 +75,27 @@ function CommandPaletteInner({ profileId }: CommandPaletteInnerProps) {
   }, []);
 
   const { data: conversations } = useChatConversationsQuery({
-    limit: RECENT_THREAD_LIMIT,
+    limit: RECENT_CHAT_LIMIT,
     enabled: open,
   });
 
-  // Recent threads + standalone "New thread" action are not part of the
+  // Recent chats are not part of the
   // command registry — they're palette-local. We fold them into a synthetic
   // entity section so the shared list+keyboard machinery picks them up.
   const additionalSections = useMemo<PaletteSection[]>(() => {
     const sections: PaletteSection[] = [];
     if (conversations && conversations.length > 0) {
       sections.push({
-        id: 'recent-threads',
-        label: 'Recent threads',
+        id: 'recent-chats',
+        label: 'Recent chats',
         items: conversations.map(convo => {
           const entity: EntityRef = {
             kind: 'track', // Reuses the generic Music2 fallback art.
             id: `thread:${convo.id}`,
-            label: convo.title || 'Untitled thread',
+            label: convo.title || 'Untitled chat',
             meta: {
               kind: 'track',
-              subtitle: 'Thread',
+              subtitle: 'Chat',
             },
           };
           return { kind: 'entity', entity };

--- a/apps/web/components/shell/README.md
+++ b/apps/web/components/shell/README.md
@@ -17,7 +17,7 @@ ledger and delete-later inventory.
 | `IconBtn` | Square icon button with hover/active tones (ghost/primary/danger). Wraps `Tooltip`. | Yes |
 | `StatusBadge` | Release / track status pill (`live`, `scheduled`, `draft`, `announced`, `hidden`). | Yes |
 | `SidebarNavItem` | Single sidebar nav row — icon, label, badge, active state. Server-safe. | Yes |
-| `SidebarThreadsSection` | Threads section in the sidebar — top 5 inline, plus an "All threads" link to the full index. | Yes |
+| `SidebarThreadsSection` | Chats section in the sidebar — top 5 inline, plus an "All Chats" link to the full index. | Yes |
 | `EntityPopover` | Hover-anchored entity preview (release/artist/track/event/contact/teammate). Includes `EntityHoverLink`, `lookupArtistEntity`, `lookupReleaseEntityByAlbum`. | Yes — DrawerHero, lyrics breadcrumb, etc. |
 | `ShellDropdown` | Radix-backed dropdown with compound parts: `Header`, `Label`, `Item`, `EntityItem`, `CheckboxItem`, `RadioGroup`/`RadioItem`, `Sub`/`SubTrigger`/`SubContent`, `Separator`. Optional `searchable`. | Yes — overflow menus, sort/filter, palette switcher |
 

--- a/apps/web/components/shell/SidebarThreadsSection.test.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.test.tsx
@@ -64,7 +64,7 @@ describe('SidebarThreadsSection', () => {
 
     const threadLink = screen.getByRole('link', { name: 'Pitch tasks' });
     const actionsButton = screen.getByRole('button', {
-      name: 'Thread actions for Pitch tasks',
+      name: 'Chat actions for Pitch tasks',
     });
 
     fireEvent.contextMenu(threadLink);
@@ -79,7 +79,7 @@ describe('SidebarThreadsSection', () => {
     });
   });
 
-  it('shows an all threads link when threads are present', () => {
+  it('shows an all chats link when chats are present', () => {
     render(
       <SidebarThreadsSection
         threads={threads}
@@ -90,9 +90,9 @@ describe('SidebarThreadsSection', () => {
       />
     );
 
-    const allThreadsLink = screen.getByRole('link', { name: 'All threads' });
+    const allThreadsLink = screen.getByRole('link', { name: 'All Chats' });
 
-    expect(allThreadsLink).toHaveAttribute('href', APP_ROUTES.THREADS);
+    expect(allThreadsLink).toHaveAttribute('href', APP_ROUTES.CHATS);
     expect(allThreadsLink).toHaveAttribute('aria-current', 'page');
   });
 
@@ -123,7 +123,7 @@ describe('SidebarThreadsSection', () => {
     expect(onSelect).toHaveBeenCalledWith('draft-thread');
   });
 
-  it('shows a new thread empty-state action when no threads are available', () => {
+  it('shows a new chat empty-state action when no chats are available', () => {
     const onNewThread = vi.fn();
 
     render(
@@ -136,7 +136,7 @@ describe('SidebarThreadsSection', () => {
       />
     );
 
-    const newThreadButton = screen.getByRole('button', { name: 'New thread' });
+    const newThreadButton = screen.getByRole('button', { name: 'New Chat' });
 
     fireEvent.click(newThreadButton);
     expect(onNewThread).toHaveBeenCalledTimes(1);

--- a/apps/web/components/shell/SidebarThreadsSection.tsx
+++ b/apps/web/components/shell/SidebarThreadsSection.tsx
@@ -15,7 +15,7 @@ import { cn } from '@/lib/utils';
 import { getSidebarNavRowClassName } from './SidebarNavItem';
 import { Tooltip } from './Tooltip';
 
-// Thread types — co-located so consumers import from one place. Production
+// Chat list types — co-located so consumers import from one place. Production
 // adapters should map real conversation records into this flat shell contract.
 
 export type ThreadStatus = 'running' | 'complete' | 'errored';
@@ -146,7 +146,7 @@ export function toSidebarThread(
   return {
     id: conversation.id,
     href: `${APP_ROUTES.CHAT}/${encodeURIComponent(conversation.id)}`,
-    title: conversation.title?.trim() || 'Untitled thread',
+    title: conversation.title?.trim() || 'Untitled chat',
     status: getSidebarThreadStatus(latestTurnStatus),
     updatedAt: conversation.updatedAt,
     unread,
@@ -268,11 +268,11 @@ const SidebarThreadRow = React.memo(function SidebarThreadRow({
         )}
       </Tooltip>
       {onThreadContextMenu ? (
-        <Tooltip label='Thread actions' side='right'>
+        <Tooltip label='Chat actions' side='right'>
           <button
             type='button'
             onClick={e => onThreadContextMenu(e, thread)}
-            aria-label={`Thread actions for ${thread.title}`}
+            aria-label={`Chat actions for ${thread.title}`}
             className={cn(
               'absolute right-1 top-1/2 grid h-5 w-5 -translate-y-1/2 place-items-center rounded-full text-quaternary-token transition-[background-color,color,opacity] duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55',
               'opacity-0 group-hover/thread:opacity-100 focus-visible:opacity-100'
@@ -325,7 +325,7 @@ export function SidebarThreadsSection({
     <div className='space-y-1.5'>
       <div className='flex items-center justify-between border-t border-[color-mix(in_oklab,var(--linear-app-frame-seam)_44%,transparent)] px-2.5 pb-0.5 pt-2'>
         <span className='text-[10.5px] font-semibold uppercase tracking-[0.08em] text-quaternary-token'>
-          Threads
+          Chats
         </span>
         {unreadCount > 0 && (
           <span className='inline-flex items-center gap-1 text-[11px] font-medium text-quaternary-token'>
@@ -359,12 +359,12 @@ export function SidebarThreadsSection({
               tight ? 'h-6 text-[12px]' : 'h-6.5 text-[12.5px]'
             )}
           >
-            <span className='min-w-0 flex-1 truncate'>Threads unavailable</span>
+            <span className='min-w-0 flex-1 truncate'>Chats unavailable</span>
             {onRetry ? (
               <button
                 type='button'
                 onClick={onRetry}
-                aria-label='Retry threads'
+                aria-label='Retry chats'
                 className='grid h-5 w-5 shrink-0 place-items-center rounded text-quaternary-token transition-[background-color] duration-subtle ease-subtle hover:bg-sidebar-accent/55 hover:text-primary-token'
               >
                 <RefreshCw
@@ -394,7 +394,7 @@ export function SidebarThreadsSection({
               strokeWidth={2.25}
             />
             <span className='min-w-0 truncate justify-self-start'>
-              New thread
+              New Chat
             </span>
           </button>
         ) : null}
@@ -417,13 +417,12 @@ export function SidebarThreadsSection({
         })}
         {hasThreads ? (
           <Link
-            href={APP_ROUTES.THREADS}
+            href={APP_ROUTES.CHATS}
             aria-current={allThreadsActive ? 'page' : undefined}
             className={cn(
               getSidebarNavRowClassName({
                 active: allThreadsActive,
                 tight,
-                tone: 'primary',
               }),
               'text-left'
             )}
@@ -434,7 +433,7 @@ export function SidebarThreadsSection({
               strokeWidth={2.25}
             />
             <span className='min-w-0 truncate justify-self-start'>
-              All threads
+              All Chats
             </span>
           </Link>
         ) : null}

--- a/apps/web/components/shell/ThreadView.tsx
+++ b/apps/web/components/shell/ThreadView.tsx
@@ -17,7 +17,7 @@ export interface ThreadViewProps {
   readonly thread: ThreadViewData;
   /** Rendered turns / cards (typically `<ThreadTurn>`s and `<Thread*Card>`s). */
   readonly children: ReactNode;
-  /** Composer slot — defaults to `<ThreadComposer placeholder="Reply to this thread…" />`. */
+  /** Composer slot — defaults to `<ThreadComposer placeholder="Reply to this chat..." />`. */
   readonly composer?: ReactNode;
   /** Submit handler forwarded to the default ThreadComposer. */
   readonly onComposerSubmit?: (text: string) => void;
@@ -26,7 +26,7 @@ export interface ThreadViewProps {
 }
 
 /**
- * ThreadView — ChatGPT/Claude-style thread layout.
+ * ThreadView — ChatGPT/Claude-style chat layout.
  *
  * The article is the height-bound parent; the inner div is the scroll
  * boundary; the composer floats over the messages with a gradient fade
@@ -60,7 +60,7 @@ export function ThreadView({
   children,
   composer,
   onComposerSubmit,
-  composerPlaceholder = 'Reply to this thread…',
+  composerPlaceholder = 'Reply to this chat...',
 }: ThreadViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [atBottom, setAtBottom] = useState(true);

--- a/apps/web/constants/routes.ts
+++ b/apps/web/constants/routes.ts
@@ -24,6 +24,8 @@ export const APP_ROUTES = {
   /** Legacy library path. Keep as a redirect source only. */
   LEGACY_DASHBOARD_LIBRARY: '/app/dashboard/library',
   DASHBOARD_LIBRARY: '/app/library',
+  CHATS: '/app/chats',
+  /** Legacy chat list path. Keep for old bookmarks; use CHATS for navigation. */
   THREADS: '/app/threads',
   /** Legacy release workspace route. Keep for old bookmarks and nested task aliases; use RELEASES for navigation. */
   DASHBOARD_RELEASES: '/app/dashboard/releases',

--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -213,11 +213,11 @@ export const COMMANDS: readonly Command[] = [
     APP_ROUTES.CHAT_PROFILE_PANEL
   ),
   nav(
-    'go-threads',
-    'Threads',
-    'Open the all-threads workspace.',
+    'go-chats',
+    'Chats',
+    'Open the all-chats workspace.',
     'MessageSquare',
-    APP_ROUTES.THREADS
+    APP_ROUTES.CHATS
   ),
   nav(
     'go-releases',

--- a/apps/web/lib/constants/breadcrumb-labels.ts
+++ b/apps/web/lib/constants/breadcrumb-labels.ts
@@ -9,13 +9,14 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   dashboard: 'Dashboard',
   profile: 'Profile',
   contacts: 'Contacts',
-  library: 'Assets readiness',
+  library: 'Library',
   releases: 'Releases',
   audience: 'Audience',
   earnings: 'Earnings',
   analytics: 'Analytics',
-  chat: 'New thread',
-  threads: 'Threads',
+  chat: 'New chat',
+  chats: 'Chats',
+  threads: 'Chats',
   'tour-dates': 'Tour dates',
 
   // Settings routes
@@ -40,7 +41,7 @@ export const BREADCRUMB_LABELS: Record<string, string> = {
   feedback: 'Feedback',
 
   // Root routes
-  app: 'New thread',
+  app: 'New chat',
 } as const;
 
 /**

--- a/apps/web/lib/queries/useTaskMutations.ts
+++ b/apps/web/lib/queries/useTaskMutations.ts
@@ -24,7 +24,10 @@ import type {
 } from '@/lib/tasks/types';
 import { queryKeys } from './keys';
 
-type TaskStatsStatusKey = Exclude<keyof TaskStats, 'activeTodoCount'>;
+type TaskStatsStatusKey = Exclude<
+  keyof TaskStats,
+  'activeTodoCount' | 'newActiveTodoCount'
+>;
 type TaskListCacheEntry = readonly [
   readonly unknown[],
   TaskListResult | undefined,

--- a/apps/web/lib/queries/useTasksQuery.ts
+++ b/apps/web/lib/queries/useTasksQuery.ts
@@ -61,12 +61,12 @@ export function useTaskQuery(taskId: string | null, profileId?: string) {
 
 export function useTaskStatsQuery(
   profileId?: string,
-  options?: { readonly enabled?: boolean }
+  options?: { readonly enabled?: boolean; readonly seenAt?: string | null }
 ) {
   return useQuery({
-    queryKey: queryKeys.tasks.stats(profileId),
+    queryKey: [...queryKeys.tasks.stats(profileId), options?.seenAt ?? null],
     // eslint-disable-next-line @jovie/require-abort-signal -- server action, signal not passable
-    queryFn: () => getTaskStats(),
+    queryFn: () => getTaskStats({ newerThan: options?.seenAt ?? null }),
     ...TASK_STATS_CACHE,
     enabled: Boolean(profileId) && (options?.enabled ?? true),
   });

--- a/apps/web/lib/tasks/types.ts
+++ b/apps/web/lib/tasks/types.ts
@@ -93,6 +93,7 @@ export interface TaskStats {
   readonly done: number;
   readonly cancelled: number;
   readonly activeTodoCount: number;
+  readonly newActiveTodoCount: number;
 }
 
 export interface CreateTaskInput {

--- a/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/DashboardNav.interaction.test.tsx
@@ -51,13 +51,13 @@ describe('DashboardNav interactions', () => {
   it('renders the full primary navigation config', () => {
     renderDashboardNav({ renderFn: render });
 
-    expect(screen.getByRole('link', { name: 'New thread' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'New Chat' })).toHaveAttribute(
       'href',
       APP_ROUTES.CHAT
     );
-    expect(screen.getByRole('link', { name: 'Profile' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Library' })).toHaveAttribute(
       'href',
-      APP_ROUTES.SETTINGS_ARTIST_PROFILE
+      APP_ROUTES.LIBRARY
     );
     expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
       'href',
@@ -67,21 +67,20 @@ describe('DashboardNav interactions', () => {
       'href',
       APP_ROUTES.AUDIENCE
     );
-    expect(
-      screen.queryByRole('link', { name: 'Library' })
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Profile' })).toBeNull();
   });
 
-  it('keeps Library out of the grouped navigation when the design flag is enabled', () => {
+  it('keeps Library in the grouped top navigation when the design flag is enabled', () => {
     renderDashboardNav({
       renderFn: render,
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(
-      screen.queryByRole('link', { name: 'Library' })
-    ).not.toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'New thread' })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Library' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.LIBRARY
+    );
+    expect(screen.getByRole('link', { name: 'New Chat' })).toHaveAttribute(
       'href',
       APP_ROUTES.CHAT
     );
@@ -113,7 +112,7 @@ describe('DashboardNav interactions', () => {
       'aria-current',
       'page'
     );
-    expect(screen.getByRole('link', { name: 'Profile' })).not.toHaveAttribute(
+    expect(screen.getByRole('link', { name: 'Library' })).not.toHaveAttribute(
       'aria-current'
     );
   });
@@ -136,24 +135,35 @@ describe('DashboardNav interactions', () => {
   it('exposes icon and label content for each navigation item', () => {
     renderDashboardNav({ renderFn: render });
 
-    const profileLink = screen.getByRole('link', { name: 'Profile' });
+    const profileLink = screen.getByRole('link', { name: 'Library' });
     // In the new shell nav design (DESIGN_V1 on by default), the icon is rendered
     // directly as an SVG element rather than inside a data-sidebar-icon wrapper span.
     const iconNode = profileLink.querySelector('svg');
     const labelNode = profileLink.querySelector('span.truncate');
 
     expect(iconNode).toBeTruthy();
-    expect(labelNode).toHaveTextContent('Profile');
+    expect(labelNode).toHaveTextContent('Library');
     expect(labelNode).toHaveClass('group-data-[collapsible=icon]:hidden');
   });
 
-  it('profile row navigates directly to profile settings on chat routes', () => {
+  it('artist profile row opens the profile right rail on chat routes', () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.CHAT);
-    renderDashboardNav({ renderFn: render });
+    renderDashboardNav({
+      renderFn: render,
+      overrides: {
+        selectedProfile: {
+          id: 'profile_123',
+          displayName: 'Tim White',
+          username: 'tim',
+          usernameNormalized: 'tim',
+        } as DashboardData['selectedProfile'],
+      },
+    });
 
-    expect(screen.getByRole('link', { name: 'Profile' })).toHaveAttribute(
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+    expect(screen.getByRole('link', { name: 'Tim White' })).toHaveAttribute(
       'href',
-      APP_ROUTES.SETTINGS_ARTIST_PROFILE
+      APP_ROUTES.CHAT_PROFILE_PANEL
     );
     expect(mockRouterPush).not.toHaveBeenCalled();
   });
@@ -173,9 +183,10 @@ describe('DashboardNav interactions', () => {
       },
     });
 
-    expect(screen.getByRole('link', { name: 'Profile' })).toHaveAttribute(
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+    expect(screen.getByRole('link', { name: 'Tim White' })).toHaveAttribute(
       'href',
-      APP_ROUTES.SETTINGS_ARTIST_PROFILE
+      APP_ROUTES.CHAT_PROFILE_PANEL
     );
     expect(
       screen.getByRole('button', { name: 'More actions' })
@@ -212,7 +223,7 @@ describe('DashboardNav interactions', () => {
     expect(screen.getByLabelText('Command palette search')).toBeInTheDocument();
   });
 
-  it('groups the Design V1 shell into Work, Catalog, Growth, and More sections', () => {
+  it('groups the Design V1 shell into top nav, artist group, and More sections', () => {
     const { container } = renderDashboardNav({
       renderFn: render,
       appFlags: { DESIGN_V1: true },
@@ -228,12 +239,16 @@ describe('DashboardNav interactions', () => {
 
     const primarySection = container.querySelector('[data-nav-section="true"]');
     expect(primarySection).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Work' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Catalog' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Growth' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Work' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Catalog' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Growth' })).toBeNull();
     expect(screen.getByRole('button', { name: 'More' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Search' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Profile' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Library' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Tim White' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
     expect(screen.getByRole('link', { name: 'Releases' })).toHaveAttribute(
       'href',
       APP_ROUTES.RELEASES
@@ -247,7 +262,7 @@ describe('DashboardNav interactions', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders recent threads in the Design V1 sidebar as App Router links', () => {
+  it('renders recent chats in the Design V1 sidebar as App Router links', () => {
     mockUseChatConversationsQuery.mockReturnValue({
       data: [
         {
@@ -270,7 +285,7 @@ describe('DashboardNav interactions', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(screen.getByText('Threads')).toBeInTheDocument();
+    expect(screen.getByText('Chats')).toBeInTheDocument();
     expect(mockUseChatConversationsQuery).toHaveBeenCalledWith({
       limit: 10,
       enabled: true,
@@ -281,11 +296,11 @@ describe('DashboardNav interactions', () => {
       '/app/chat/thread-newer'
     );
     expect(
-      screen.queryByRole('button', { name: 'Thread actions' })
+      screen.queryByRole('button', { name: 'Chat actions' })
     ).not.toBeInTheDocument();
   });
 
-  it('renders compact thread loading without adding duplicate empty-state chat controls', () => {
+  it('renders compact chat loading without adding duplicate empty-state chat controls', () => {
     mockUseChatConversationsQuery.mockReturnValue({
       data: undefined,
       isLoading: true,
@@ -297,7 +312,7 @@ describe('DashboardNav interactions', () => {
     });
 
     expect(document.querySelector('.skeleton')).toBeInTheDocument();
-    expect(screen.queryByText('Loading threads')).not.toBeInTheDocument();
+    expect(screen.queryByText('Loading chats')).not.toBeInTheDocument();
     unmount();
 
     mockUseChatConversationsQuery.mockReturnValue({
@@ -311,19 +326,30 @@ describe('DashboardNav interactions', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(screen.getAllByRole('link', { name: 'New thread' })).toHaveLength(1);
+    expect(screen.getAllByRole('link', { name: 'New Chat' })).toHaveLength(1);
     expect(
-      screen.getByRole('button', { name: 'New thread' })
+      screen.getByRole('button', { name: 'New Chat' })
     ).toBeInTheDocument();
   });
 
-  it('profile row remains a direct settings link off chat routes', () => {
+  it('profile row remains a rail link off chat routes', () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.AUDIENCE);
-    renderDashboardNav({ renderFn: render });
+    renderDashboardNav({
+      renderFn: render,
+      overrides: {
+        selectedProfile: {
+          id: 'profile_123',
+          displayName: 'Tim White',
+          username: 'tim',
+          usernameNormalized: 'tim',
+        } as DashboardData['selectedProfile'],
+      },
+    });
 
-    expect(screen.getByRole('link', { name: 'Profile' })).toHaveAttribute(
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+    expect(screen.getByRole('link', { name: 'Tim White' })).toHaveAttribute(
       'href',
-      APP_ROUTES.SETTINGS_ARTIST_PROFILE
+      APP_ROUTES.CHAT_PROFILE_PANEL
     );
     expect(mockRouterPush).not.toHaveBeenCalled();
   });

--- a/apps/web/tests/e2e/cmdk-palette.spec.ts
+++ b/apps/web/tests/e2e/cmdk-palette.spec.ts
@@ -21,7 +21,7 @@ import {
 } from './utils/smoke-test-utils';
 
 const PALETTE_INPUT =
-  'input[placeholder="Jump to a page, skill, release, or thread…"]';
+  'input[placeholder="Jump to a page, skill, release, or chat..."]';
 
 test.describe('Command palette — Cmd+K contract', () => {
   test.beforeAll(() => {

--- a/apps/web/tests/e2e/electron-titlebar-geometry.spec.ts
+++ b/apps/web/tests/e2e/electron-titlebar-geometry.spec.ts
@@ -102,11 +102,9 @@ async function assertElectronShellControls(
     page.locator('[data-testid="electron-sidebar-toggle"]')
   ).toHaveCount(1);
   await expect(page.locator('[data-sidebar="trigger"]')).toHaveCount(0);
-  await expect(page.locator('header a[aria-label="New thread"]')).toHaveCount(
-    0
-  );
+  await expect(page.locator('header a[aria-label="New Chat"]')).toHaveCount(0);
   const newChatRowCount = await page
-    .getByRole('link', { name: 'New thread' })
+    .getByRole('link', { name: 'New Chat' })
     .count();
   expect(newChatRowCount).toBeLessThanOrEqual(1);
   if (expectedNewChatRows === 1) {
@@ -193,13 +191,11 @@ test('no duplicate sidebar dock button and titlebar toggle on the same page', as
   });
 
   await expect(page.locator('[data-sidebar="trigger"]')).toHaveCount(0);
-  await expect(page.locator('header a[aria-label="New thread"]')).toHaveCount(
-    0
-  );
+  await expect(page.locator('header a[aria-label="New Chat"]')).toHaveCount(0);
   await expect(
     page.locator('[data-testid="electron-sidebar-toggle"]')
   ).toHaveCount(1);
-  await expect(page.getByRole('link', { name: 'New thread' })).toHaveCount(1);
+  await expect(page.getByRole('link', { name: 'New Chat' })).toHaveCount(1);
 
   // The titlebar sidebar toggle must be present (it is the canonical one in Electron).
   const titlebarToggle = page.locator(

--- a/apps/web/tests/unit/app/shell-route-matches.test.ts
+++ b/apps/web/tests/unit/app/shell-route-matches.test.ts
@@ -82,7 +82,8 @@ describe('isChatShellRoute', () => {
     expect(isChatShellRoute(`${APP_ROUTES.CHAT}/thread-abc`)).toBe(true);
   });
 
-  it('matches the all threads route', () => {
+  it('matches the all chats route', () => {
+    expect(isChatShellRoute(APP_ROUTES.CHATS)).toBe(true);
     expect(isChatShellRoute(APP_ROUTES.THREADS)).toBe(true);
   });
 
@@ -117,11 +118,13 @@ describe('isLibraryShellRoute', () => {
 });
 
 describe('isThreadsShellRoute', () => {
-  it('matches the canonical threads route', () => {
+  it('matches the canonical chats route and legacy threads route', () => {
+    expect(isThreadsShellRoute(APP_ROUTES.CHATS)).toBe(true);
     expect(isThreadsShellRoute(APP_ROUTES.THREADS)).toBe(true);
   });
 
-  it('matches nested threads subroutes', () => {
+  it('matches nested chats and legacy threads subroutes', () => {
+    expect(isThreadsShellRoute(`${APP_ROUTES.CHATS}/recent`)).toBe(true);
     expect(isThreadsShellRoute(`${APP_ROUTES.THREADS}/recent`)).toBe(true);
   });
 });
@@ -259,6 +262,7 @@ describe('shouldUseEssentialShellData', () => {
 describe('shouldRedirectToOnboarding', () => {
   it('returns true for lightweight shell routes', () => {
     expect(shouldRedirectToOnboarding(APP_ROUTES.CHAT)).toBe(true);
+    expect(shouldRedirectToOnboarding(APP_ROUTES.CHATS)).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.THREADS)).toBe(true);
     expect(shouldRedirectToOnboarding('/app/dashboard/releases')).toBe(true);
     expect(shouldRedirectToOnboarding(APP_ROUTES.LYRICS)).toBe(true);
@@ -287,12 +291,13 @@ describe('shouldRedirectToOnboarding', () => {
 });
 
 describe('shell foundation Wave 3 — route persistence + request budgets (no full reload / blank frame on warm nav)', () => {
-  it('lightweight shell routes (chat, threads, releases, library, tasks, etc.) use essential shell data for minimal request count and stable HydrateClient root', () => {
+  it('lightweight shell routes (chat, chats, releases, library, tasks, etc.) use essential shell data for minimal request count and stable HydrateClient root', () => {
     // These routes return true → getDashboardShellData only (no full dashboardData)
     // Combined with always-on HydrateClient in DashboardShellContent, guarantees
     // AppShellFrame / sidebar / audio / header chrome do not remount on client nav.
     // Sidebar collapsed state (cookie), audio playback, and focus all persist.
     expect(shouldUseEssentialShellData(APP_ROUTES.CHAT)).toBe(true);
+    expect(shouldUseEssentialShellData(APP_ROUTES.CHATS)).toBe(true);
     expect(shouldUseEssentialShellData(APP_ROUTES.THREADS)).toBe(true);
     expect(shouldUseEssentialShellData('/app/dashboard/releases')).toBe(true);
     expect(shouldUseEssentialShellData(APP_ROUTES.LIBRARY)).toBe(true);

--- a/apps/web/tests/unit/chat/breadcrumb-uuid.test.ts
+++ b/apps/web/tests/unit/chat/breadcrumb-uuid.test.ts
@@ -3,16 +3,16 @@ import { getDemoBreadcrumbSegment } from '@/hooks/useAuthRouteConfig';
 import { getBreadcrumbLabel } from '@/lib/constants/breadcrumb-labels';
 
 describe('getBreadcrumbLabel', () => {
-  it('returns "New thread" for the chat segment', () => {
-    expect(getBreadcrumbLabel('chat')).toBe('New thread');
+  it('returns "New chat" for the chat segment', () => {
+    expect(getBreadcrumbLabel('chat')).toBe('New chat');
   });
 
   it('returns "Dashboard" for the dashboard segment', () => {
     expect(getBreadcrumbLabel('dashboard')).toBe('Dashboard');
   });
 
-  it('returns "New thread" for the app root segment', () => {
-    expect(getBreadcrumbLabel('app')).toBe('New thread');
+  it('returns "New chat" for the app root segment', () => {
+    expect(getBreadcrumbLabel('app')).toBe('New chat');
   });
 
   it('converts unknown kebab-case to sentence case', () => {

--- a/apps/web/tests/unit/chat/useAuthRouteConfig.test.tsx
+++ b/apps/web/tests/unit/chat/useAuthRouteConfig.test.tsx
@@ -17,14 +17,14 @@ describe('useAuthRouteConfig', () => {
     mockUseSearchParams.mockReturnValue(new URLSearchParams());
   });
 
-  it('keeps chat thread detail breadcrumbs pinned to the shared thread label', () => {
+  it('keeps chat detail breadcrumbs pinned to the shared chat label', () => {
     mockUsePathname.mockReturnValue('/app/chat/conv-123');
 
     const { result } = renderHook(() => useAuthRouteConfig());
 
     expect(result.current.breadcrumbs).toEqual([
       {
-        label: 'New thread',
+        label: 'New chat',
         href: '/app/chat/conv-123',
       },
     ]);

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -2,7 +2,7 @@
  * Tests for the cmd+k surface of SharedCommandPalette.
  *
  * Asserts surface filtering (cmdk includes nav + skills, chat-slash skips
- * nav), commit routing for nav and skill items, and recent-thread injection
+ * nav), commit routing for nav and skill items, and recent-chat injection
  * via the additional-sections slot.
  */
 
@@ -129,14 +129,14 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
     );
   });
 
-  it('adds Threads as a cmd+k-only nav route', () => {
+  it('adds Chats as a cmd+k-only nav route', () => {
     expect(commandsForSurface('cmdk')).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           kind: 'nav',
-          id: 'go-threads',
-          label: 'Threads',
-          href: APP_ROUTES.THREADS,
+          id: 'go-chats',
+          label: 'Chats',
+          href: APP_ROUTES.CHATS,
         }),
       ])
     );
@@ -144,7 +144,7 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
       expect.arrayContaining([
         expect.objectContaining({
           kind: 'nav',
-          id: 'go-threads',
+          id: 'go-chats',
         }),
       ])
     );
@@ -246,7 +246,7 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
     expect(pushMock).toHaveBeenCalledWith('/app/releases/rel-1/tasks');
   });
 
-  it('renders additional sections (e.g. recent threads) and routes via callback', () => {
+  it('renders additional sections (e.g. recent chats) and routes via callback', () => {
     pushMock.mockClear();
     const onAdditionalSelect = vi.fn();
     render(
@@ -256,8 +256,8 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
         onOpenChange={vi.fn()}
         additionalSectionsAfter={[
           {
-            id: 'recent-threads',
-            label: 'Recent threads',
+            id: 'recent-chats',
+            label: 'Recent chats',
             items: [
               {
                 kind: 'entity',
@@ -265,7 +265,7 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
                   kind: 'track',
                   id: 'thread:abc',
                   label: 'Album planning',
-                  meta: { kind: 'track', subtitle: 'Thread' },
+                  meta: { kind: 'track', subtitle: 'Chat' },
                 },
               },
             ],
@@ -274,7 +274,7 @@ describe('SharedCommandPalette (cmd+k surface)', () => {
         onAdditionalSelect={onAdditionalSelect}
       />
     );
-    expect(screen.getByText('Recent threads')).toBeInTheDocument();
+    expect(screen.getByText('Recent chats')).toBeInTheDocument();
     const threadRow = screen
       .getAllByRole('option')
       .find(el => el.textContent?.includes('Album planning'));

--- a/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
+++ b/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
@@ -83,7 +83,7 @@ describe('DesktopTitlebar', () => {
       screen.getByTestId('electron-sidebar-toggle').querySelector('svg')
     ).toBeTruthy();
     expect(
-      screen.queryByRole('link', { name: 'New thread' })
+      screen.queryByRole('link', { name: 'New Chat' })
     ).not.toBeInTheDocument();
   });
 

--- a/apps/web/tests/unit/components/organisms/AuthShell.flag.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AuthShell.flag.test.tsx
@@ -36,7 +36,7 @@ vi.mock('@/components/organisms/Sidebar', () => ({
     <div>{children}</div>
   ),
   SidebarTrigger: () => <button type='button'>Toggle Sidebar</button>,
-  useSidebar: () => ({ isMobile: false }),
+  useSidebar: () => ({ isMobile: false, state: 'open' }),
 }));
 
 vi.mock('@/components/organisms/UnifiedSidebar', () => ({

--- a/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
+++ b/apps/web/tests/unit/components/organisms/UnifiedSidebar.library.test.tsx
@@ -84,7 +84,7 @@ function LibrarySidebarOverride({
     backLabel: 'Back to App',
     content: (
       <nav aria-label='Library navigation'>
-        <button type='button'>All Releases</button>
+        <button type='button'>All</button>
         {children}
       </nav>
     ),
@@ -166,9 +166,7 @@ describe('UnifiedSidebar library route', () => {
       ).toBeInTheDocument();
     });
 
-    expect(
-      screen.getByRole('button', { name: 'All Releases' })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: 'Needs Assets' })
     ).toBeInTheDocument();
@@ -179,7 +177,7 @@ describe('UnifiedSidebar library route', () => {
     );
   });
 
-  it('omits header New thread and the web collapse control in Electron dashboard mode', () => {
+  it('omits header New Chat and the web collapse control in Electron dashboard mode', () => {
     renderUnifiedSidebar({
       designV1: false,
       pathname: APP_ROUTES.DASHBOARD,
@@ -188,7 +186,7 @@ describe('UnifiedSidebar library route', () => {
 
     expect(screen.getByText('Jovie', { selector: 'span' })).toBeInTheDocument();
     expect(
-      screen.queryByRole('link', { name: 'New thread' })
+      screen.queryByRole('link', { name: 'New Chat' })
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: 'Collapse sidebar' })
@@ -207,7 +205,7 @@ describe('UnifiedSidebar library route', () => {
       screen.getByRole('button', { name: 'Collapse sidebar' })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('link', { name: 'New thread' })
+      screen.queryByRole('link', { name: 'New Chat' })
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/tests/unit/constants/routes.test.ts
+++ b/apps/web/tests/unit/constants/routes.test.ts
@@ -11,6 +11,11 @@ describe('APP_ROUTES settings', () => {
   it('exposes the canonical settings usage route', () => {
     expect(APP_ROUTES.SETTINGS_USAGE).toBe('/app/settings/usage');
   });
+
+  it('exposes Chats as the canonical chat index route', () => {
+    expect(APP_ROUTES.CHATS).toBe('/app/chats');
+    expect(APP_ROUTES.THREADS).toBe('/app/threads');
+  });
 });
 
 describe('buildLyricsRoute', () => {

--- a/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardHeader.test.tsx
@@ -70,7 +70,7 @@ describe('DashboardHeader', () => {
   it('prefers the breadcrumb suffix for the mobile title when present', () => {
     const { container } = render(
       <DashboardHeader
-        breadcrumbs={[{ label: 'New thread', href: '/app/chat/conv-123' }]}
+        breadcrumbs={[{ label: 'New chat', href: '/app/chat/conv-123' }]}
         breadcrumbSuffix={<span>Release planning thread</span>}
       />
     );
@@ -81,7 +81,7 @@ describe('DashboardHeader', () => {
     expect(
       within(mobileHeader!).getByText('Release planning thread')
     ).toBeInTheDocument();
-    expect(within(mobileHeader!).queryByText('New thread')).toBeNull();
+    expect(within(mobileHeader!).queryByText('New chat')).toBeNull();
   });
 
   it('collapses the breadcrumb when the search surface takes over', () => {

--- a/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
+++ b/apps/web/tests/unit/dashboard/DashboardNav.test.tsx
@@ -24,44 +24,57 @@ describe('DashboardNav', () => {
       renderFn: fastRender,
     });
 
-    expect(getByRole('link', { name: 'New thread' }).getAttribute('href')).toBe(
+    expect(getByRole('link', { name: 'New Chat' }).getAttribute('href')).toBe(
       APP_ROUTES.CHAT
     );
-    expect(getByRole('link', { name: 'Profile' }).getAttribute('href')).toBe(
-      APP_ROUTES.SETTINGS_ARTIST_PROFILE
+    expect(getByRole('button', { name: 'Search' })).toBeDefined();
+    expect(getByRole('link', { name: 'Library' }).getAttribute('href')).toBe(
+      APP_ROUTES.LIBRARY
     );
     expect(getByRole('link', { name: 'Releases' })).toBeDefined();
-    expect(getByRole('link', { name: 'Calendar' }).getAttribute('href')).toBe(
-      APP_ROUTES.CALENDAR
-    );
     expect(getByRole('link', { name: 'Tasks' }).getAttribute('href')).toBe(
       APP_ROUTES.TASKS
     );
     expect(getByRole('link', { name: 'Audience' })).toBeDefined();
-    expect(queryByRole('link', { name: 'Library' })).toBeNull();
+    expect(queryByRole('link', { name: 'Calendar' })).toBeNull();
     expect(queryByRole('link', { name: 'Earnings' })).toBeNull();
   });
 
-  it('does not render Library navigation in the grouped shell', () => {
-    const { queryByRole } = renderDashboardNav({
-      renderFn: fastRender,
-      appFlags: { DESIGN_V1: true },
-    });
-
-    expect(queryByRole('link', { name: 'Library' })).toBeNull();
-  });
-
-  it('renders Calendar in the Design V1 user work section', () => {
+  it('renders Library in the grouped shell top nav', () => {
     const { getByRole } = renderDashboardNav({
       renderFn: fastRender,
       appFlags: { DESIGN_V1: true },
     });
 
-    const calendarLink = getByRole('link', { name: 'Calendar' });
-    expect(calendarLink.getAttribute('href')).toBe(APP_ROUTES.CALENDAR);
-    expect(calendarLink.className).toContain(
+    expect(getByRole('link', { name: 'Library' }).getAttribute('href')).toBe(
+      APP_ROUTES.LIBRARY
+    );
+  });
+
+  it('renders artist work under the artist group in Design V1', () => {
+    const { getByRole, queryByRole } = renderDashboardNav({
+      renderFn: fastRender,
+      appFlags: { DESIGN_V1: true },
+      overrides: {
+        selectedProfile: {
+          id: 'profile_123',
+          displayName: 'Tim White',
+          username: 'tim',
+          usernameNormalized: 'tim',
+        } as DashboardData['selectedProfile'],
+      },
+    });
+
+    expect(getByRole('button', { name: 'Tim White' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+    const releasesLink = getByRole('link', { name: 'Releases' });
+    expect(releasesLink.getAttribute('href')).toBe(APP_ROUTES.RELEASES);
+    expect(releasesLink.className).toContain(
       'grid-cols-[22px_minmax(0,1fr)_34px]'
     );
+    expect(queryByRole('link', { name: 'Calendar' })).toBeNull();
   });
 
   it('applies active state to current page', () => {
@@ -81,7 +94,7 @@ describe('DashboardNav', () => {
     expect(releasesLink.getAttribute('aria-current')).toBe('page');
   });
 
-  it('only marks New thread active on the chat root', () => {
+  it('only marks New Chat active on the chat root', () => {
     mockUsePathname.mockReturnValueOnce(`${APP_ROUTES.CHAT}/thread-123`);
 
     const { getByRole } = renderDashboardNav({
@@ -90,11 +103,11 @@ describe('DashboardNav', () => {
     });
 
     expect(
-      getByRole('link', { name: 'New thread' }).getAttribute('aria-current')
+      getByRole('link', { name: 'New Chat' }).getAttribute('aria-current')
     ).toBeNull();
   });
 
-  it('keeps New thread on the default shell tone when it is inactive', () => {
+  it('keeps New Chat on the default shell tone when it is inactive', () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.RELEASES);
 
     const { getByRole } = renderDashboardNav({
@@ -102,20 +115,20 @@ describe('DashboardNav', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    const newThreadLink = getByRole('link', { name: 'New thread' });
+    const newThreadLink = getByRole('link', { name: 'New Chat' });
     expect(newThreadLink.className).toContain('text-sidebar-muted/80');
     expect(newThreadLink.className).not.toContain(
       'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,white_8%)]'
     );
   });
 
-  it('renders one canonical New thread nav row in Design V1', () => {
+  it('renders one canonical New Chat nav row in Design V1', () => {
     const { getAllByRole } = renderDashboardNav({
       renderFn: fastRender,
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(getAllByRole('link', { name: 'New thread' })).toHaveLength(1);
+    expect(getAllByRole('link', { name: 'New Chat' })).toHaveLength(1);
   });
 
   it('opens the global command palette from Search instead of navigating', () => {
@@ -194,7 +207,7 @@ describe('DashboardNav', () => {
       appFlags: { DESIGN_V1: true },
     });
 
-    const newThreadLink = getByRole('link', { name: 'New thread' });
+    const newThreadLink = getByRole('link', { name: 'New Chat' });
     expect(newThreadLink.className).toContain(
       'group-data-[collapsible=icon]:justify-center'
     );
@@ -204,21 +217,21 @@ describe('DashboardNav', () => {
     });
   });
 
-  it('renders the grouped Work, Catalog, Growth, and More sections', () => {
+  it('renders the grouped top nav, artist group, and More section', () => {
     const { getByRole, queryByRole } = renderDashboardNav({
       renderFn: fastRender,
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(getByRole('button', { name: 'Work' })).toHaveAttribute(
-      'aria-expanded',
-      'true'
+    expect(getByRole('link', { name: 'New Chat' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.CHAT
     );
-    expect(getByRole('button', { name: 'Catalog' })).toHaveAttribute(
-      'aria-expanded',
-      'true'
+    expect(getByRole('link', { name: 'Library' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.LIBRARY
     );
-    expect(getByRole('button', { name: 'Growth' })).toHaveAttribute(
+    expect(getByRole('button', { name: 'Artist' })).toHaveAttribute(
       'aria-expanded',
       'true'
     );
@@ -226,7 +239,9 @@ describe('DashboardNav', () => {
       'aria-expanded',
       'false'
     );
-    expect(queryByRole('link', { name: 'Library' })).toBeNull();
+    expect(queryByRole('button', { name: 'Work' })).toBeNull();
+    expect(queryByRole('button', { name: 'Catalog' })).toBeNull();
+    expect(queryByRole('button', { name: 'Growth' })).toBeNull();
   });
 
   it('renders full admin navigation for admin users', () => {
@@ -300,15 +315,18 @@ describe('DashboardNav', () => {
     expect(audienceLink.getAttribute('aria-current')).toBe('page');
   });
 
-  it('does not surface Library as a nav item even when the legacy route is current', () => {
+  it('surfaces Library as a nav item when the legacy route is current', () => {
     mockUsePathname.mockReturnValueOnce(APP_ROUTES.DASHBOARD_LIBRARY);
 
-    const { queryByRole } = renderDashboardNav({
+    const { getByRole } = renderDashboardNav({
       renderFn: fastRender,
       appFlags: { DESIGN_V1: true },
     });
 
-    expect(queryByRole('link', { name: 'Library' })).toBeNull();
+    expect(getByRole('link', { name: 'Library' })).toHaveAttribute(
+      'href',
+      APP_ROUTES.LIBRARY
+    );
   });
 
   it('renders settings groups with the selected artist name', () => {
@@ -351,6 +369,7 @@ describe('DashboardNav', () => {
 
     expect(mockUseTaskStatsQuery).toHaveBeenCalledWith('profile_123', {
       enabled: false,
+      seenAt: null,
     });
   });
 
@@ -369,6 +388,40 @@ describe('DashboardNav', () => {
     const { getByText } = renderDashboardNav({ renderFn: fastRender });
 
     expect(getByText('7')).toBeDefined();
+  });
+
+  it('uses the new task count after Tasks has been opened', () => {
+    localStorage.setItem('jovie:tasks-seen-at', '2026-05-24T00:00:00.000Z');
+    mockUseTaskStatsQuery.mockReturnValueOnce({
+      data: {
+        backlog: 1,
+        todo: 2,
+        inProgress: 4,
+        done: 0,
+        cancelled: 0,
+        activeTodoCount: 7,
+        newActiveTodoCount: 2,
+      },
+    });
+
+    const { getByText, queryByText } = renderDashboardNav({
+      renderFn: fastRender,
+      overrides: {
+        selectedProfile: {
+          id: 'profile_123',
+          displayName: 'Tim White',
+          username: 'tim',
+          usernameNormalized: 'tim',
+        } as DashboardData['selectedProfile'],
+      },
+    });
+
+    expect(getByText('2')).toBeDefined();
+    expect(queryByText('7')).toBeNull();
+    expect(mockUseTaskStatsQuery).toHaveBeenCalledWith('profile_123', {
+      enabled: true,
+      seenAt: '2026-05-24T00:00:00.000Z',
+    });
   });
 
   it('keeps task badges inline with Design V1 shell nav rows', () => {
@@ -408,6 +461,7 @@ describe('DashboardNav', () => {
     expect(getByText('Pro')).toBeDefined();
     expect(mockUseTaskStatsQuery).toHaveBeenCalledWith('', {
       enabled: false,
+      seenAt: null,
     });
   });
 

--- a/apps/web/tests/unit/organisms/CommandPalette.test.tsx
+++ b/apps/web/tests/unit/organisms/CommandPalette.test.tsx
@@ -2,7 +2,7 @@
  * Tests for the global Cmd+K shell that wraps CmdKPalette.
  *
  * Asserts: the palette stays mounted (no-op) when there's no DashboardData
- * context, opens on Cmd+K, surfaces recent threads from the conversations
+ * context, opens on Cmd+K, surfaces recent chats from the conversations
  * query, and renders the autofocused search input.
  */
 
@@ -116,15 +116,15 @@ describe('CommandPalette', () => {
     expect(input).toHaveFocus();
   });
 
-  it('lists recent threads with safe fallback titles', () => {
+  it('lists recent chats with safe fallback titles', () => {
     render(withDashboard(<CommandPalette />));
     fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });
-    expect(screen.getByText('Recent threads')).toBeInTheDocument();
+    expect(screen.getByText('Recent chats')).toBeInTheDocument();
     expect(screen.getByText('Q1 release plan')).toBeInTheDocument();
-    expect(screen.getByText('Untitled thread')).toBeInTheDocument();
+    expect(screen.getByText('Untitled chat')).toBeInTheDocument();
   });
 
-  it('routes a recent-thread commit to the chat route', () => {
+  it('routes a recent-chat commit to the chat route', () => {
     pushMock.mockClear();
     render(withDashboard(<CommandPalette />));
     fireEvent.keyDown(globalThis, { key: 'k', metaKey: true });

--- a/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
+++ b/apps/web/tests/unit/routes/shell-nav-coverage.test.ts
@@ -16,10 +16,11 @@ const SHELL_ROOT = path.resolve(__dirname, '../../../app/app/(shell)');
 
 const INTENTIONAL_INTERNAL_ROUTES: Record<string, string> = {
   '/app': 'Shell root entry page',
+  '/app/chats': 'Canonical chat index reached from the sidebar link',
   '/app/chat/[id]': 'Thread detail is reached from chat history',
   '/app/library':
-    'Canonical library page retained as the assets readiness surface',
-  '/app/threads': 'All threads index reached from the sidebar link',
+    'Canonical library page for releases, merch, images, videos, and audio',
+  '/app/threads': 'Legacy all threads route redirects to chats',
   '/app/admin/investors/links': 'Sub-tool reached from Investors workspace',
   '/app/admin/investors/settings':
     'Sub-tool reached from Investors workspace actions',
@@ -110,7 +111,9 @@ function getNavRoutePaths(): Set<string> {
     ...adminSettingsNavigation,
   ];
 
-  return new Set(navItems.map(item => item.href));
+  return new Set(
+    navItems.map(item => new URL(item.href, 'https://jovie.local').pathname)
+  );
 }
 
 describe('shell route coverage', () => {

--- a/apps/web/tests/unit/threads/ThreadsPageClient.test.tsx
+++ b/apps/web/tests/unit/threads/ThreadsPageClient.test.tsx
@@ -12,7 +12,7 @@ vi.mock('@/lib/queries/useChatConversationsQuery', () => ({
     mockUseChatConversationsQuery(...args),
 }));
 
-describe('ThreadsPageClient', () => {
+describe('ChatsPageClient', () => {
   beforeEach(() => {
     localStorage.clear();
     mockUseChatConversationsQuery.mockReset();
@@ -22,7 +22,7 @@ describe('ThreadsPageClient', () => {
     localStorage.clear();
   });
 
-  it('renders the threads shell and keeps the new thread CTA visible', () => {
+  it('renders the chats shell and keeps the new chat CTA visible', () => {
     mockUseChatConversationsQuery.mockReturnValue({
       data: [
         {
@@ -52,10 +52,8 @@ describe('ThreadsPageClient', () => {
     expect(mockUseChatConversationsQuery).toHaveBeenCalledWith({
       limit: 50,
     });
-    expect(
-      screen.getByRole('heading', { name: 'Threads' })
-    ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'New thread' })).toHaveAttribute(
+    expect(screen.queryByRole('heading', { name: 'Threads' })).toBeNull();
+    expect(screen.getByRole('link', { name: 'New Chat' })).toHaveAttribute(
       'href',
       APP_ROUTES.CHAT
     );
@@ -69,7 +67,7 @@ describe('ThreadsPageClient', () => {
     expect(threadLinks[1]).toHaveTextContent('Release rollout');
   });
 
-  it('filters thread rows locally and preserves unread styling', () => {
+  it('filters chat rows locally and preserves unread styling', () => {
     localStorage.setItem(
       'jovie:sidebar-thread-read-at',
       JSON.stringify({
@@ -107,12 +105,9 @@ describe('ThreadsPageClient', () => {
     );
     expect(document.querySelector('.anim-calm-breath')).toBeInTheDocument();
 
-    fireEvent.change(
-      screen.getByRole('searchbox', { name: 'Search threads' }),
-      {
-        target: { value: 'Pitch' },
-      }
-    );
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search chats' }), {
+      target: { value: 'Pitch' },
+    });
 
     expect(screen.queryByRole('link', { name: 'Unread answer' })).toBeNull();
     expect(
@@ -139,14 +134,11 @@ describe('ThreadsPageClient', () => {
 
     render(<ThreadsPageClient />);
 
-    fireEvent.change(
-      screen.getByRole('searchbox', { name: 'Search threads' }),
-      {
-        target: { value: 'Missing' },
-      }
-    );
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search chats' }), {
+      target: { value: 'Missing' },
+    });
 
-    expect(screen.getByText('No threads match "Missing".')).toBeInTheDocument();
-    expect(screen.getAllByRole('link', { name: 'New thread' })).toHaveLength(2);
+    expect(screen.getByText('No chats match "Missing".')).toBeInTheDocument();
+    expect(screen.getAllByRole('link', { name: 'New Chat' })).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- Add /app/chats as the canonical chat index and keep /app/threads as a redirect.
- Update visible copy from Threads to Chats across shell, command palette, breadcrumbs, and tests.
- Flatten dashboard nav into New Chat, Search, Library, plus the Tim White artist group with Releases, Audience, and Tasks.
- Clear task backlog badge after Tasks is opened, then show only newly updated tasks.
- Add the flat collapsed-sidebar header toggle and make the profile nav entry open the profile rail by artist name.

## Verification
- node --version -> v22.22.1
- pnpm --version -> 9.15.4
- pnpm --filter @jovie/web exec vitest run focused chat/library/shell suites: 23 files, 260 tests passed
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm biome check apps/web
- git push pre-push: biome check ., next proxy guard, tailwind guard, typecheck, biome lint

## QA Evidence
- .gstack/qa-reports/jov-2593/screenshots/chat-desktop.png
- .gstack/qa-reports/jov-2593/screenshots/chat-collapsed-sidebar.png
- .gstack/qa-reports/jov-2593/screenshots/chats-list-desktop.png
- .gstack/qa-reports/jov-2593/screenshots/tasks-badge-cleared.png
- .gstack/qa-reports/jov-2593/screenshots/library-merch-mobile-final3.png

JOV-2593