### PR TITLE
test(health): isolate build-info env warnings

### DIFF
--- a/apps/web/tests/unit/api/health/build-info.critical.test.ts
+++ b/apps/web/tests/unit/api/health/build-info.critical.test.ts
@@ -1,5 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@/lib/env', () => ({
+  env: new Proxy(
+    {},
+    {
+      get: (_target, prop) => {
+        if (typeof prop !== 'string') return undefined;
+        if (prop === 'NODE_ENV') return process.env.NODE_ENV ?? 'development';
+        return process.env[prop];
+      },
+    }
+  ),
+}));
+
 const mockConsoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 let cwdSpy: ReturnType<typeof vi.spyOn> | undefined;
 


### PR DESCRIPTION
## Summary
- mock the build-info route env dependency in its critical unit test
- keep unrelated env-server validation warnings from failing the development build-id assertion

## Verification
- pnpm --filter @jovie/web exec vitest run tests/unit/api/health/build-info.critical.test.ts
- UPSTASH_REDIS_REST_URL=not-a-url pnpm --filter @jovie/web exec vitest run tests/unit/api/health/build-info.critical.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pre-push: biome, proxy guard, tailwind guard, web typecheck, web lint