### PR TITLE
test(promptfoo): enforce model routing inventory

### DIFF
--- a/apps/web/tests/eval/promptfoo/README.md
+++ b/apps/web/tests/eval/promptfoo/README.md
@@ -2,7 +2,7 @@
 
 Runs a small Promptfoo suite against local adapters:
 
-- A deterministic tool-contract adapter for chat and onboarding tool availability, schemas, tool UI registry coverage, stubbed outputs, and no-spend guarantees.
+- A deterministic tool-contract adapter for chat and onboarding tool availability, schemas, tool UI registry coverage, model-routing scenario inventory, stubbed outputs, and no-spend guarantees.
 - The production `executeChatTurn()` path used by `/api/chat`, with synthetic Luna Waves fixtures and eval-only tool stubs. This live path is manual-only because it calls the model provider.
 - A deterministic route-contract adapter for `POST /api/chat`, covering unauthenticated requests, branch-ordering for the chat kill switch, invalid JSON, message validation, missing profile context, client-turn preconditions, rate-limit responses, and contract-only pre-dispatch success without starting Next, Clerk, or the database.
 - A deterministic route-contract adapter for `POST /api/mobile/v1/chat/turns`, covering unauthenticated, invalid JSON, invalid-body variants, and `MOBILE_CHAT_RUNTIME_DISABLED` responses without starting Next or Clerk.

--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -1751,6 +1751,8 @@ function assertEvalCaseInventoryCovered(output) {
     'missingFreeUnavailableCaseNames',
     'missingOnboardingUnavailableCaseNames',
     'missingSemanticInvalidCaseNames',
+    'missingModelRoutingScenarioNames',
+    'missingModelRoutingBoundaryNames',
   ]) {
     const values = payload[field];
     if (!Array.isArray(values)) {

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -339,6 +339,13 @@ const REQUIRED_SEMANTIC_INVALID_TOOL_NAMES = [
   'proposeSocialLink',
   'proposeSocialLinkRemoval',
 ] as const;
+const REQUIRED_MODEL_ROUTING_SCENARIOS = [
+  'complex-pro-strategy-primary',
+  'force-light-override',
+  'free-no-tool-light',
+  'long-pro-conversation-primary',
+  'simple-pro-tool-light',
+] as const;
 const CHAT_SLASH_SKILL_NAMES = commandsForSurface('chat-slash')
   .filter(command => command.kind === 'skill')
   .map(command => command.id)
@@ -2709,6 +2716,8 @@ type EvalCaseSummary = {
   readonly cost: string | null;
   readonly target: string | null;
   readonly toolName: string | null;
+  readonly modelScenario: string | null;
+  readonly expectedModel: string | null;
   readonly eventCase: string | null;
   readonly renderCase: string | null;
   readonly mode: string | null;
@@ -2792,6 +2801,8 @@ function parseEvalCaseSummary(block: string): EvalCaseSummary {
     cost: scalarValue(block, 'cost'),
     target: scalarValue(block, 'target') ?? 'chat-turn',
     toolName: scalarValue(block, 'toolName'),
+    modelScenario: scalarValue(block, 'modelScenario'),
+    expectedModel: scalarValue(block, 'expectedModel'),
     eventCase: scalarValue(block, 'eventCase'),
     renderCase: scalarValue(block, 'renderCase'),
     mode: scalarValue(block, 'mode') ?? 'app',
@@ -2894,6 +2905,25 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
       testCase.target === 'tool-contract' &&
       caseHasAssertion(testCase, 'assertToolSemanticInvalid')
   );
+  const modelContractCases = deterministicCases.filter(
+    testCase => testCase.target === 'model-contract'
+  );
+  const modelRoutingScenarioNames = uniqueSorted(
+    modelContractCases
+      .map(testCase => testCase.modelScenario)
+      .filter(
+        (modelScenario): modelScenario is string =>
+          typeof modelScenario === 'string'
+      )
+  );
+  const modelRoutingBoundaryNames = uniqueSorted(
+    modelContractCases
+      .map(testCase => testCase.expectedModel)
+      .filter(
+        (expectedModel): expectedModel is string =>
+          expectedModel === 'light' || expectedModel === 'primary'
+      )
+  );
   const knownToolNames = new Set(ALL_EVAL_TOOL_NAMES);
 
   return {
@@ -2966,6 +2996,18 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
     missingSemanticInvalidCaseNames: missingNames(
       REQUIRED_SEMANTIC_INVALID_TOOL_NAMES,
       semanticInvalidCaseNames
+    ),
+    requiredModelRoutingScenarioNames: [...REQUIRED_MODEL_ROUTING_SCENARIOS],
+    modelRoutingScenarioNames,
+    missingModelRoutingScenarioNames: missingNames(
+      REQUIRED_MODEL_ROUTING_SCENARIOS,
+      modelRoutingScenarioNames
+    ),
+    requiredModelRoutingBoundaryNames: ['light', 'primary'],
+    modelRoutingBoundaryNames,
+    missingModelRoutingBoundaryNames: missingNames(
+      ['light', 'primary'],
+      modelRoutingBoundaryNames
     ),
     toolCalls: [],
     toolResults: [],

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -715,6 +715,7 @@ tests:
     vars:
       input: "How should I set up my pre-save?"
       target: model-contract
+      modelScenario: free-no-tool-light
       plan: free
       aiCanUseTools: false
       expectedModel: light
@@ -730,6 +731,7 @@ tests:
     vars:
       input: "add my instagram https://instagram.com/lunawaves"
       target: model-contract
+      modelScenario: simple-pro-tool-light
       plan: pro
       expectedModel: light
     assert:
@@ -744,6 +746,7 @@ tests:
     vars:
       input: "Build a detailed six-week campaign strategy for my next release, including audience segments, content themes, playlist pitching, merch timing, and what to measure each week."
       target: model-contract
+      modelScenario: complex-pro-strategy-primary
       plan: pro
       expectedModel: primary
     assert:
@@ -758,6 +761,7 @@ tests:
     vars:
       input: "Build a detailed six-week campaign strategy for my next release, including audience segments, content themes, playlist pitching, merch timing, and what to measure each week."
       target: model-contract
+      modelScenario: force-light-override
       plan: pro
       forceLightModel: true
       expectedModel: light
@@ -773,6 +777,7 @@ tests:
     vars:
       input: "add my instagram https://instagram.com/lunawaves"
       target: model-contract
+      modelScenario: long-pro-conversation-primary
       plan: pro
       expectedModel: primary
       messages:


### PR DESCRIPTION
## Summary
- Adds explicit model-routing scenario metadata to the deterministic Promptfoo model-contract cases.
- Extends the eval inventory adapter/assertion so default evals fail if light/primary routing coverage or required routing scenarios disappear.
- Updates the Promptfoo README to document model-routing inventory coverage.

## Cost decision
Ship now: deterministic model-routing inventory coverage in `pnpm run evals` with no model, DB, Clerk, Spotify, Stripe, or local Next server calls.
Re-evaluate when: deterministic route/tool/model inventory failures block two release regressions in 30 days or manual live eval runtime stays below the agreed per-run budget.
Then: add a capped live subset with concurrency 1 under JOV-2596.

## Verification
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml` passed.
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u XAI_API_KEY -u BRAINTRUST_API_KEY JOVIE_AGENT_PROFILE=coder JOVIE_RUN_LIVE_EVALS=0 JOVIE_RUN_LIVE_HTTP_EVALS=0 JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=0 JOVIE_RUN_LIVE_HTTP_MODEL_ERROR_EVALS=0 pnpm run evals` passed: 115/115.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml` passed.
- Pre-push passed: repo Biome, web proxy guard, Tailwind guard, web typecheck, web lint.

## Known unrelated check
- `pnpm --filter @jovie/web run typecheck:tests` exits 2 on existing broad repo script/profile test typing failures outside the Promptfoo harness; tracked as JOV-2582.

Fixes JOV-2596
