### PR TITLE
JOV-2593 Accept Library releases redirect in mobile guard

### DIFF
--- a/apps/web/tests/e2e/mobile-overflow.spec.ts
+++ b/apps/web/tests/e2e/mobile-overflow.spec.ts
@@ -103,6 +103,7 @@ const AUTHENTICATED_ROUTES = [
     id: 'app-releases',
     path: APP_ROUTES.RELEASES,
     readySelectors: [
+      '[data-testid="library-surface"]',
       '[data-testid="shell-releases-view"]',
       '[data-testid="releases-matrix"]',
       '[data-testid="releases-empty-state-enriching"]',


### PR DESCRIPTION
## Summary
- Allow the mobile overflow guard to treat the unified Library surface as the ready state for /app/releases.
- Keeps the legacy /app/releases redirect compatible with the existing overflow suite after #9699/#9700 landed.

## Verification
- E2E_SKIP_WEB_SERVER=1 BASE_URL=http://localhost:3100 MOBILE_OVERFLOW_WIDTHS=320 E2E_USE_TEST_AUTH_BYPASS=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 PLAYWRIGHT_WORKERS=1 pnpm --filter @jovie/web exec playwright test tests/e2e/mobile-overflow.spec.ts --project=chromium --reporter=line --grep "authenticated app-releases"
- git push pre-push: biome check ., next proxy guard, tailwind guard, typecheck, biome lint

JOV-2593