### PR TITLE
ci(promptfoo): skip previews for eval infra

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -58,13 +58,13 @@ Promptfoo has explicit cost lanes:
 - **Live evals** run only from `pnpm run evals:live`, which is wrapped by Doppler at the repo root and still fails unless `JOVIE_RUN_LIVE_EVALS=1` and `AI_GATEWAY_API_KEY` are present. The live Promptfoo lane is manual-only, concurrency 1, and uses `--no-share --no-write`.
 - **Live HTTP evals** run only from `pnpm run evals:live:http`, require `JOVIE_RUN_LIVE_HTTP_EVALS=1` plus a loopback `JOVIE_PROMPTFOO_BASE_URL`, and unset model keys before running Promptfoo. This lane exercises real `/api/chat` HTTP auth and persistence with deterministic no-model chat paths.
 - **Live HTTP rate-limit evals** run only from `pnpm run evals:live:http:rate-limit`, require `JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=1`, `JOVIE_PROMPTFOO_EXPECT_REDIS_DISABLED=1`, and a loopback `JOVIE_PROMPTFOO_BASE_URL`. Start the local server with `JOVIE_DISABLE_REDIS_FOR_EVALS=1` and `JOVIE_DISABLE_MODEL_KEYS_FOR_EVALS=1`; this lane is manual-only and validates fail-closed 429 headers without touching shared Redis or model providers.
-- **Promptfoo eval-infrastructure-only PRs** short-circuit to deterministic eval CI before the `testing` label can fan out into Neon, Lighthouse, mobile overflow, or Playwright jobs. Use manual `workflow_dispatch` when a full CI run is intentionally needed for eval infrastructure.
+- **Promptfoo eval-infrastructure-only PRs** short-circuit to deterministic eval CI before the `testing` label can fan out into Neon, Lighthouse, mobile overflow, Playwright, or Vercel preview deploy jobs. Use manual `workflow_dispatch` when a full CI run is intentionally needed for eval infrastructure.
 
 The legacy `evals-periodic.yml` workflow is also manual-only. It has no scheduled trigger, requires typing `RUN_LIVE_EVALS` into `confirm_live_llm_evals`, and runs at concurrency 1 if explicitly invoked.
 
 Ship now / Re-evaluate when / Then:
 
-- Ship now: deterministic PR evals stay free, Promptfoo eval-infrastructure-only PRs do not fan out into heavyweight CI even when auto-labeled `testing`, every live LLM eval surface requires manual intent and concurrency 1, live HTTP route evals stay manual plus no-model, and live rate-limit evals require Redis/model-key-disabled local server mode.
+- Ship now: deterministic PR evals stay free, Promptfoo eval-infrastructure-only PRs do not fan out into heavyweight CI or preview deploys even when auto-labeled `testing`, every live LLM eval surface requires manual intent and concurrency 1, live HTTP route evals stay manual plus no-model, and live rate-limit evals require Redis/model-key-disabled local server mode.
 - Re-evaluate when: manual live evals catch a release-blocking regression twice in 30 days or observed live eval cost stays below the agreed per-run budget for 10 consecutive runs.
 - Then: add a capped scheduled or PR-gated live subset with explicit case count, concurrency 1, and per-run cost reporting.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3047,8 +3047,8 @@ jobs:
     name: Preview Deploy (PR)
     # Preview deploys are the default QA surface for internal PRs.
     # Keep this independent from the main deploy gate so review happens before merge.
-    needs: [ci-fast]
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' }}
+    needs: [ci-fast, ci-path-changes]
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' && needs.ci-path-changes.outputs.run_build == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     concurrency:


### PR DESCRIPTION
## Summary

- Gates the Vercel PR preview deploy job on centralized `run_build` path output.
- Keeps Promptfoo eval-infrastructure-only PRs on deterministic Promptfoo CI without Vercel preview build/deploy work.
- Updates workflow cost-control docs to include preview deploys alongside Neon, Lighthouse, mobile overflow, and Playwright.

## Cost decision

- Ship now: Promptfoo eval-infra-only PRs skip preview deployments when `run_build=false`, so the default eval lane avoids model calls and avoids unnecessary Vercel build/deploy minutes.
- Re-evaluate when: a Promptfoo eval-infra-only PR needs a live preview twice in 30 days or reviewers cannot validate a CI-only change from GitHub checks and diff evidence.
- Then: add an explicit `deploy-preview` path override that is compatible with the Promptfoo deterministic short-circuit and reports expected Vercel build minutes.

## Test plan

- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u XAI_API_KEY -u BRAINTRUST_API_KEY JOVIE_AGENT_PROFILE=coder JOVIE_RUN_LIVE_EVALS=0 JOVIE_RUN_LIVE_HTTP_EVALS=0 JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=0 JOVIE_RUN_LIVE_HTTP_MODEL_ERROR_EVALS=0 pnpm run evals` -> 115/115 deterministic cases passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/tests/eval/promptfoo .github/workflows/ci.yml .github/workflows/README.md`
- `git diff --check origin/main...HEAD`
- Pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

Linear: JOV-2596

<!-- linear-issue-id:1fa3e211-cf16-429b-8d43-c554af6ff307 -->
<!-- linear-issue-identifier:JOV-2596 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow efficiency by refining deployment job dependencies
  * Updated cost controls to prevent unnecessary preview builds

* **Documentation**
  * Clarified CI behavior and resource optimization for specific pull request types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->