### PR TITLE
test(promptfoo): cover onboarding state decisions

### DIFF
--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -45,6 +45,26 @@ function allExecutions(payload) {
   return Array.isArray(payload.toolExecutions) ? payload.toolExecutions : [];
 }
 
+function containsExpected(actual, expected, path = '') {
+  if (!expected || typeof expected !== 'object' || Array.isArray(expected)) {
+    return Object.is(actual, expected)
+      ? null
+      : `${path || 'value'} expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`;
+  }
+
+  if (!actual || typeof actual !== 'object' || Array.isArray(actual)) {
+    return `${path || 'value'} expected object, got ${JSON.stringify(actual)}`;
+  }
+
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    const nextPath = path ? `${path}.${key}` : key;
+    const mismatch = containsExpected(actual[key], expectedValue, nextPath);
+    if (mismatch) return mismatch;
+  }
+
+  return null;
+}
+
 function toolNames(payload) {
   return allCalls(payload)
     .map(call => call.toolName)
@@ -1343,6 +1363,69 @@ function assertToolDidNotExecute(output) {
   return pass();
 }
 
+function assertOnboardingStateNoSpend(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'onboarding-state-contract') {
+    return fail('case did not run through the onboarding-state adapter');
+  }
+  if (payload.costTier !== 'deterministic') {
+    return fail('onboarding state case is not marked deterministic');
+  }
+  if (payload.modelCalled !== false || payload.selectedModel !== null) {
+    return fail('onboarding state case crossed the model boundary');
+  }
+  if (payload.persistenceAttempted !== false || payload.dbAttempted !== false) {
+    return fail('onboarding state case crossed the persistence boundary');
+  }
+  if (payload.networkAttempted !== false) {
+    return fail('onboarding state case crossed the network boundary');
+  }
+
+  return pass();
+}
+
+function assertOnboardingStateDecision(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'onboarding-state-contract') {
+    return fail('case did not run through the onboarding-state adapter');
+  }
+  if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+    return fail(`onboarding state errors: ${payload.errors.join('; ')}`);
+  }
+
+  const decisionMismatch = containsExpected(
+    payload.nextStepDecision,
+    payload.expectedDecision ?? {},
+    'nextStepDecision'
+  );
+  if (decisionMismatch) return fail(decisionMismatch);
+
+  const signalMismatch = containsExpected(
+    payload.collapsedSignal,
+    payload.expectedCollapsedSignal ?? {},
+    'collapsedSignal'
+  );
+  if (signalMismatch) return fail(signalMismatch);
+
+  if (
+    typeof payload.expectedSignalCount === 'number' &&
+    payload.signalCount !== payload.expectedSignalCount
+  ) {
+    return fail(
+      `signalCount expected ${payload.expectedSignalCount}, got ${payload.signalCount}`
+    );
+  }
+
+  const executions = allExecutions(payload);
+  if (!executions.some(execution => execution.name === 'proposeNextStep')) {
+    return fail('onboarding state case did not evaluate proposeNextStep');
+  }
+
+  return pass();
+}
+
 function assertSafeSocialUrl(output) {
   const payload = parseOutput(output);
   const input = payload.parsedInput ?? payload.input ?? {};
@@ -1910,6 +1993,7 @@ function assertEvalCaseInventoryCovered(output) {
     'missingSemanticInvalidCaseNames',
     'missingModelRoutingScenarioNames',
     'missingModelRoutingBoundaryNames',
+    'missingOnboardingStateCaseNames',
   ]) {
     const values = payload[field];
     if (!Array.isArray(values)) {
@@ -1972,6 +2056,8 @@ module.exports = {
   assertToolSemanticInvalid,
   assertToolExecuted,
   assertToolDidNotExecute,
+  assertOnboardingStateNoSpend,
+  assertOnboardingStateDecision,
   assertSafeSocialUrl,
   assertFailedToolResultPreserved,
   assertToolInventoryCovered,

--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -46,14 +46,37 @@ function allExecutions(payload) {
 }
 
 function containsExpected(actual, expected, path = '') {
-  if (!expected || typeof expected !== 'object' || Array.isArray(expected)) {
+  const label = path || 'value';
+
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual)) {
+      return `${label} expected array, got ${JSON.stringify(actual)}`;
+    }
+
+    if (actual.length !== expected.length) {
+      return `${label} expected array length ${expected.length}, got ${actual.length}`;
+    }
+
+    for (let index = 0; index < expected.length; index += 1) {
+      const mismatch = containsExpected(
+        actual[index],
+        expected[index],
+        `${label}[${index}]`
+      );
+      if (mismatch) return mismatch;
+    }
+
+    return null;
+  }
+
+  if (!expected || typeof expected !== 'object') {
     return Object.is(actual, expected)
       ? null
-      : `${path || 'value'} expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`;
+      : `${label} expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`;
   }
 
   if (!actual || typeof actual !== 'object' || Array.isArray(actual)) {
-    return `${path || 'value'} expected object, got ${JSON.stringify(actual)}`;
+    return `${label} expected object, got ${JSON.stringify(actual)}`;
   }
 
   for (const [key, expectedValue] of Object.entries(expected)) {

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -29,6 +29,14 @@ import {
   TOOL_SCHEMAS,
 } from '@/lib/chat/tool-schemas';
 import { getToolUiConfig, TOOL_UI_REGISTRY } from '@/lib/chat/tool-ui-registry';
+import {
+  evaluateAccessSignal,
+  MAX_INTERVIEW_TURNS_BEFORE_FORCE,
+} from '@/lib/chat/tools/onboarding-access-eval';
+import {
+  collapseInterviewSignals,
+  interviewSignalSchema,
+} from '@/lib/chat/tools/onboarding-signals';
 import type { ReleaseContext } from '@/lib/chat/types';
 import {
   COMMANDS,
@@ -52,6 +60,7 @@ type EvalTarget =
   | 'eval-case-inventory'
   | 'model-contract'
   | 'mobile-chat-route'
+  | 'onboarding-state-contract'
   | 'tool-contract'
   | 'tool-event-contract'
   | 'tool-render-contract'
@@ -366,6 +375,12 @@ const REQUIRED_MODEL_ROUTING_SCENARIOS = [
   'long-pro-conversation-primary',
   'simple-pro-tool-light',
 ] as const;
+const REQUIRED_ONBOARDING_STATE_CASES = [
+  'latest-signal-instant-access',
+  'spotify-followers-instant-access',
+  'weak-signal-force-waitlist',
+  'weak-signal-needs-more-info',
+] as const;
 const CHAT_SLASH_SKILL_NAMES = commandsForSurface('chat-slash')
   .filter(command => command.kind === 'skill')
   .map(command => command.id)
@@ -420,6 +435,7 @@ function toTarget(value: unknown): EvalTarget {
     value === 'eval-case-inventory' ||
     value === 'mobile-chat-route' ||
     value === 'model-contract' ||
+    value === 'onboarding-state-contract' ||
     value === 'tool-contract' ||
     value === 'tool-event-contract' ||
     value === 'tool-render-contract' ||
@@ -2219,6 +2235,161 @@ function defaultToolResult(toolName: string, input: unknown): unknown {
   }
 }
 
+type EvalInterviewSignal = z.infer<typeof interviewSignalSchema>;
+
+type EvalOnboardingState = {
+  sessionId: string;
+  spotifyArtistId: string | null;
+  spotifyArtistName: string | null;
+  spotifyImageUrl: string | null;
+  spotifyGenres: string[];
+  spotifyPopularity: number | null;
+  spotifyFollowers: number | null;
+  signals: EvalInterviewSignal[];
+  turnCount: number;
+};
+
+function nullableNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function createEvalOnboardingState(vars: EvalVars): EvalOnboardingState {
+  const initialState = toObject(vars.initialState);
+  const turnCount =
+    typeof vars.turnCount === 'number' && Number.isInteger(vars.turnCount)
+      ? vars.turnCount
+      : 1;
+
+  return {
+    sessionId:
+      typeof initialState.sessionId === 'string'
+        ? initialState.sessionId
+        : 'promptfoo-onboarding-state',
+    spotifyArtistId:
+      typeof initialState.spotifyArtistId === 'string'
+        ? initialState.spotifyArtistId
+        : null,
+    spotifyArtistName:
+      typeof initialState.spotifyArtistName === 'string'
+        ? initialState.spotifyArtistName
+        : null,
+    spotifyImageUrl:
+      typeof initialState.spotifyImageUrl === 'string'
+        ? initialState.spotifyImageUrl
+        : null,
+    spotifyGenres: Array.isArray(initialState.spotifyGenres)
+      ? initialState.spotifyGenres.filter(
+          (genre): genre is string => typeof genre === 'string'
+        )
+      : [],
+    spotifyPopularity: nullableNumber(initialState.spotifyPopularity),
+    spotifyFollowers: nullableNumber(initialState.spotifyFollowers),
+    signals: [],
+    turnCount,
+  };
+}
+
+function evaluateOnboardingStateContract(vars: EvalVars) {
+  const stateCase =
+    typeof vars.stateCase === 'string' ? vars.stateCase : 'unspecified';
+  const state = createEvalOnboardingState(vars);
+  const stateBefore = cloneJson(state);
+  const rawSignals = Array.isArray(vars.signals) ? vars.signals : [];
+  const errors: string[] = [];
+  const toolExecutions: ToolExecution[] = [];
+
+  for (const [index, rawSignal] of rawSignals.entries()) {
+    const parsed = interviewSignalSchema.safeParse(rawSignal);
+    if (!parsed.success) {
+      errors.push(
+        ...schemaErrorMessages(parsed).map(
+          message => `signals.${index}: ${message}`
+        )
+      );
+      continue;
+    }
+
+    state.signals.push(parsed.data);
+    toolExecutions.push({
+      name: 'recordInterviewSignal',
+      input: parsed.data,
+      output: {
+        action: 'signal_recorded',
+        signalCount: state.signals.length,
+        summary: 'Signal noted.',
+      },
+    });
+  }
+
+  const timestampBase = WEB_CHAT_EVAL_EPOCH_SECONDS * 1000;
+  const collapsedSignal = collapseInterviewSignals(
+    state.signals.map((signal, index) => ({
+      ...signal,
+      recordedAt: new Date(timestampBase + index * 1000).toISOString(),
+    }))
+  );
+  const nextStepDecision = evaluateAccessSignal({
+    signal: collapsedSignal,
+    spotifyFollowers: state.spotifyFollowers,
+    turnCount: state.turnCount,
+  });
+  const nextStepOutput = {
+    action: 'propose_next_step',
+    decision: nextStepDecision,
+    summary: `Next step: ${nextStepDecision.kind.replaceAll('_', ' ')}.`,
+  };
+  toolExecutions.push({
+    name: 'proposeNextStep',
+    input: {},
+    output: nextStepOutput,
+  });
+
+  return {
+    target: 'onboarding-state-contract',
+    adapter: 'onboarding-state-contract',
+    costTier: 'deterministic',
+    text: '',
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    dbAttempted: false,
+    networkAttempted: false,
+    stateCase,
+    mode: 'onboarding',
+    turnCount: state.turnCount,
+    maxTurnCap: MAX_INTERVIEW_TURNS_BEFORE_FORCE,
+    signalCount: state.signals.length,
+    stateBefore,
+    stateAfter: cloneJson(state),
+    collapsedSignal,
+    nextStepDecision,
+    expectedDecision: toObject(vars.expectedDecision),
+    expectedCollapsedSignal: toObject(vars.expectedCollapsedSignal),
+    expectedSignalCount:
+      typeof vars.expectedSignalCount === 'number'
+        ? vars.expectedSignalCount
+        : null,
+    errors,
+    steps: toolExecutions.map(execution => ({
+      toolCalls: [{ toolName: execution.name, input: execution.input }],
+      toolResults: [{ toolName: execution.name, output: execution.output }],
+    })),
+    toolCalls: toolExecutions.map(execution => ({
+      toolName: execution.name,
+      input: execution.input,
+    })),
+    toolResults: toolExecutions.map(execution => ({
+      toolName: execution.name,
+      output: execution.output,
+    })),
+    toolExecutions,
+  };
+}
+
 function buildEvalTools(
   toolNames: readonly string[],
   vars: EvalVars,
@@ -2973,6 +3144,7 @@ type EvalCaseSummary = {
   readonly expectedModel: string | null;
   readonly eventCase: string | null;
   readonly renderCase: string | null;
+  readonly stateCase: string | null;
   readonly mode: string | null;
   readonly plan: string | null;
   readonly assertions: readonly string[];
@@ -3058,6 +3230,7 @@ function parseEvalCaseSummary(block: string): EvalCaseSummary {
     expectedModel: scalarValue(block, 'expectedModel'),
     eventCase: scalarValue(block, 'eventCase'),
     renderCase: scalarValue(block, 'renderCase'),
+    stateCase: scalarValue(block, 'stateCase'),
     mode: scalarValue(block, 'mode') ?? 'app',
     plan: scalarValue(block, 'plan') ?? 'pro',
     assertions,
@@ -3177,6 +3350,12 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
           expectedModel === 'light' || expectedModel === 'primary'
       )
   );
+  const onboardingStateCaseNames = uniqueSorted(
+    deterministicCases
+      .filter(testCase => testCase.target === 'onboarding-state-contract')
+      .map(testCase => testCase.stateCase)
+      .filter((stateCase): stateCase is string => typeof stateCase === 'string')
+  );
   const knownToolNames = new Set(ALL_EVAL_TOOL_NAMES);
 
   return {
@@ -3261,6 +3440,12 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
     missingModelRoutingBoundaryNames: missingNames(
       ['light', 'primary'],
       modelRoutingBoundaryNames
+    ),
+    requiredOnboardingStateCaseNames: [...REQUIRED_ONBOARDING_STATE_CASES],
+    onboardingStateCaseNames,
+    missingOnboardingStateCaseNames: missingNames(
+      REQUIRED_ONBOARDING_STATE_CASES,
+      onboardingStateCaseNames
     ),
     toolCalls: [],
     toolResults: [],
@@ -3366,6 +3551,16 @@ export default class JovieChatPromptfooProvider {
 
     if (target === 'model-contract') {
       const payload = evaluateModelContract(prompt, vars);
+      return {
+        output: JSON.stringify(payload),
+        raw: payload,
+        format: 'json',
+        latencyMs: Date.now() - startedAt,
+      };
+    }
+
+    if (target === 'onboarding-state-contract') {
+      const payload = evaluateOnboardingStateContract(vars);
       return {
         output: JSON.stringify(payload),
         raw: payload,

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -2068,6 +2068,102 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertToolExecuted
 
+  - description: Onboarding state records latest signal before next-step
+    metadata:
+      cost: deterministic
+    vars:
+      input: "I have about 3,000 fans and my single is announced."
+      target: onboarding-state-contract
+      stateCase: latest-signal-instant-access
+      turnCount: 1
+      signals:
+        - releaseStage: pre_announce
+          audienceBand: under_500
+        - releaseStage: announced_unreleased
+          audienceBand: 500_to_5k
+      expectedSignalCount: 2
+      expectedCollapsedSignal:
+        releaseStage: announced_unreleased
+        audienceBand: 500_to_5k
+      expectedDecision:
+        kind: instant_access
+        rationale: audience_500_to_5k_with_active_release_announced_unreleased
+        score: 70
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingStateNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingStateDecision
+
+  - description: Onboarding state asks for more info before turn cap
+    metadata:
+      cost: deterministic
+    vars:
+      input: "I'm still early, under 500 fans."
+      target: onboarding-state-contract
+      stateCase: weak-signal-needs-more-info
+      turnCount: 2
+      signals:
+        - audienceBand: under_500
+      expectedSignalCount: 1
+      expectedCollapsedSignal:
+        audienceBand: under_500
+      expectedDecision:
+        kind: needs_more_info
+        rationale: insufficient_signal
+        score: 10
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingStateNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingStateDecision
+
+  - description: Onboarding state forces waitlist at max turn cap
+    metadata:
+      cost: deterministic
+    vars:
+      input: "I do not have much audience signal yet."
+      target: onboarding-state-contract
+      stateCase: weak-signal-force-waitlist
+      turnCount: 3
+      signals:
+        - audienceBand: under_500
+      expectedSignalCount: 1
+      expectedCollapsedSignal:
+        audienceBand: under_500
+      expectedDecision:
+        kind: waitlist
+        rationale: max_turns_reached_3
+        score: 30
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingStateNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingStateDecision
+
+  - description: Onboarding state grants instant access from Spotify followers
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Spotify says Luna Waves has enough followers."
+      target: onboarding-state-contract
+      stateCase: spotify-followers-instant-access
+      turnCount: 1
+      initialState:
+        spotifyFollowers: 12500
+      signals: []
+      expectedSignalCount: 0
+      expectedCollapsedSignal: {}
+      expectedDecision:
+        kind: instant_access
+        rationale: spotify_followers_12500
+        score: 90
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingStateNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingStateDecision
+
   - description: Free plan blocks paid album art tool
     metadata:
       cost: deterministic


### PR DESCRIPTION
## Summary
- Add a deterministic Promptfoo `onboarding-state-contract` target for `/start` onboarding state decisions
- Exercise synthetic `recordInterviewSignal` accumulation plus real `collapseInterviewSignals()` and `evaluateAccessSignal()` logic
- Add four no-cost cases for latest-signal instant access, weak-signal needs-more-info, max-turn waitlist, and Spotify-follower instant access
- Extend eval inventory so onboarding-state cases cannot silently disappear

## Cost Decision
Ship now: deterministic state coverage for onboarding decisions, with `modelCalled: false`, `selectedModel: null`, `persistenceAttempted: false`, `dbAttempted: false`, and `networkAttempted: false`.

Re-evaluate when: this lane adds more than 30 seconds to CI wall time or live manual evals catch a release-blocking onboarding regression twice in 30 days.

Then: add a capped live subset behind `JOVIE_RUN_LIVE_EVALS=1`, concurrency 1, and an explicit per-run budget.

## Verification
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml`
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u XAI_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 JOVIE_RUN_LIVE_HTTP_EVALS=0 JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=0 JOVIE_RUN_LIVE_HTTP_MODEL_ERROR_EVALS=0 pnpm run evals` -> 123/123 passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/tests/eval/promptfoo`
- `git diff --check`
- pre-push hook: `biome check .`, web proxy guard, Tailwind guard, typecheck, Biome lint

## Known Check State
- `pnpm --filter @jovie/web run typecheck:tests -- --pretty false` still fails in the existing repo-wide test TS backlog tracked by JOV-2582; the failures are outside `apps/web/tests/eval/promptfoo`.

Linear: JOV-2596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation assertions for onboarding state contract evaluation.
  * Added four new deterministic test cases covering onboarding decision scenarios: instant access decisions, information requests, waitlist enforcement, and follower-based access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->