### PR TITLE
test(promptfoo): cover knowledge routing contracts

### DIFF
--- a/apps/web/tests/eval/promptfoo/README.md
+++ b/apps/web/tests/eval/promptfoo/README.md
@@ -2,7 +2,7 @@
 
 Runs a small Promptfoo suite against local adapters:
 
-- A deterministic tool-contract adapter for chat and onboarding tool availability, schemas, tool UI registry coverage, model-routing scenario inventory, stubbed outputs, and no-spend guarantees.
+- Deterministic contract adapters for chat and onboarding tool availability, schemas, tool UI registry coverage, model-routing scenario inventory, knowledge-topic routing, onboarding next-step state decisions, stubbed outputs, and no-spend guarantees.
 - The production `executeChatTurn()` path used by `/api/chat`, with synthetic Luna Waves fixtures and eval-only tool stubs. This live path is manual-only because it calls the model provider.
 - A deterministic route-contract adapter for `POST /api/chat`, covering unauthenticated requests, branch-ordering for the chat kill switch, invalid JSON, message validation, missing profile context, client-turn preconditions, rate-limit responses, and contract-only pre-dispatch success without starting Next, Clerk, or the database.
 - A deterministic route-contract adapter for `POST /api/mobile/v1/chat/turns`, covering unauthenticated, invalid JSON, invalid-body variants, and `MOBILE_CHAT_RUNTIME_DISABLED` responses without starting Next or Clerk.

--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -88,6 +88,21 @@ function containsExpected(actual, expected, path = '') {
   return null;
 }
 
+function sortedStringArray(value) {
+  return Array.isArray(value)
+    ? value.filter(item => typeof item === 'string').sort()
+    : [];
+}
+
+function sameStringArray(actual, expected) {
+  const actualValues = sortedStringArray(actual);
+  const expectedValues = sortedStringArray(expected);
+  return (
+    actualValues.length === expectedValues.length &&
+    actualValues.every((value, index) => value === expectedValues[index])
+  );
+}
+
 function toolNames(payload) {
   return allCalls(payload)
     .map(call => call.toolName)
@@ -1449,6 +1464,130 @@ function assertOnboardingStateDecision(output) {
   return pass();
 }
 
+function assertKnowledgeContractNoSpend(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'knowledge-contract') {
+    return fail('case did not run through the knowledge adapter');
+  }
+  if (payload.costTier !== 'deterministic') {
+    return fail('knowledge case is not marked deterministic');
+  }
+  if (payload.modelCalled !== false || payload.selectedModel !== null) {
+    return fail('knowledge case crossed the model boundary');
+  }
+  if (payload.persistenceAttempted !== false || payload.dbAttempted !== false) {
+    return fail('knowledge case crossed the persistence boundary');
+  }
+  if (payload.networkAttempted !== false) {
+    return fail('knowledge case crossed the network boundary');
+  }
+
+  return pass();
+}
+
+function assertKnowledgeTopicsSelected(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'knowledge-contract') {
+    return fail('case did not run through the knowledge adapter');
+  }
+
+  if (!sameStringArray(payload.selectedTopicIds, payload.expectedTopicIds)) {
+    return fail(
+      `selectedTopicIds expected ${JSON.stringify(sortedStringArray(payload.expectedTopicIds))}, got ${JSON.stringify(sortedStringArray(payload.selectedTopicIds))}`
+    );
+  }
+
+  for (const topicId of sortedStringArray(payload.unexpectedTopicIds)) {
+    if (sortedStringArray(payload.selectedTopicIds).includes(topicId)) {
+      return fail(`unexpected topic selected: ${topicId}`);
+    }
+  }
+
+  if (
+    typeof payload.expectedHasContext === 'boolean' &&
+    payload.knowledgeContextSelected !== payload.expectedHasContext
+  ) {
+    return fail(
+      `knowledgeContextSelected expected ${payload.expectedHasContext}, got ${payload.knowledgeContextSelected}`
+    );
+  }
+
+  return pass();
+}
+
+function assertKnowledgeTopicCap(output) {
+  const payload = parseOutput(output);
+  const maxTopicCount =
+    typeof payload.expectedMaxTopicCount === 'number'
+      ? payload.expectedMaxTopicCount
+      : 2;
+
+  if (payload.target !== 'knowledge-contract') {
+    return fail('case did not run through the knowledge adapter');
+  }
+  if (payload.selectedTopicCount > maxTopicCount) {
+    return fail(
+      `selectedTopicCount expected at most ${maxTopicCount}, got ${payload.selectedTopicCount}`
+    );
+  }
+
+  return pass();
+}
+
+function assertKnowledgeNoFalsePositive(output) {
+  const payload = parseOutput(output);
+
+  if (payload.knowledgeCase !== 'no-false-positive-had') {
+    return fail('knowledge case is not the false-positive guard');
+  }
+  if (payload.knowledgeContextSelected || payload.selectedTopicCount !== 0) {
+    return fail(
+      `false-positive guard selected topics: ${JSON.stringify(payload.selectedTopicIds)}`
+    );
+  }
+
+  return pass();
+}
+
+function assertKnowledgeUsesRecentUserTurns(output) {
+  const payload = parseOutput(output);
+
+  if (payload.knowledgeCase !== 'recent-user-turn-window') {
+    return fail('knowledge case is not the recent-turn window guard');
+  }
+  if (String(payload.recentUserText ?? '').includes('copyright')) {
+    return fail('recentUserText included the fourth-most-recent user turn');
+  }
+  if (sortedStringArray(payload.selectedTopicIds).includes('music-rights')) {
+    return fail('music-rights was selected from an older user turn');
+  }
+
+  return pass();
+}
+
+function assertKnowledgeOnboardingSkipsContext(output) {
+  const payload = parseOutput(output);
+
+  if (payload.mode !== 'onboarding') {
+    return fail('knowledge onboarding guard did not run in onboarding mode');
+  }
+  if (
+    payload.knowledgeContextSelected ||
+    payload.knowledgeContextLength !== 0
+  ) {
+    return fail('onboarding mode selected knowledge context');
+  }
+  if (payload.selectedTopicCount !== 0) {
+    return fail(
+      `onboarding mode selected topics: ${JSON.stringify(payload.selectedTopicIds)}`
+    );
+  }
+
+  return pass();
+}
+
 function assertSafeSocialUrl(output) {
   const payload = parseOutput(output);
   const input = payload.parsedInput ?? payload.input ?? {};
@@ -2016,6 +2155,7 @@ function assertEvalCaseInventoryCovered(output) {
     'missingSemanticInvalidCaseNames',
     'missingModelRoutingScenarioNames',
     'missingModelRoutingBoundaryNames',
+    'missingKnowledgeCaseNames',
     'missingOnboardingStateCaseNames',
   ]) {
     const values = payload[field];
@@ -2081,6 +2221,12 @@ module.exports = {
   assertToolDidNotExecute,
   assertOnboardingStateNoSpend,
   assertOnboardingStateDecision,
+  assertKnowledgeContractNoSpend,
+  assertKnowledgeTopicsSelected,
+  assertKnowledgeTopicCap,
+  assertKnowledgeNoFalsePositive,
+  assertKnowledgeUsesRecentUserTurns,
+  assertKnowledgeOnboardingSkipsContext,
   assertSafeSocialUrl,
   assertFailedToolResultPreserved,
   assertToolInventoryCovered,

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -12,6 +12,7 @@ import {
   TEST_MODE_HEADER,
   TEST_USER_ID_HEADER,
 } from '@/lib/auth/test-mode-constants';
+import { KNOWLEDGE_TOPICS } from '@/lib/chat/knowledge/topics';
 import {
   canUseLightModel,
   executeChatTurn,
@@ -58,6 +59,7 @@ type EvalVars = Record<string, unknown>;
 type EvalTarget =
   | 'chat-turn'
   | 'eval-case-inventory'
+  | 'knowledge-contract'
   | 'model-contract'
   | 'mobile-chat-route'
   | 'onboarding-state-contract'
@@ -381,6 +383,13 @@ const REQUIRED_ONBOARDING_STATE_CASES = [
   'weak-signal-force-waitlist',
   'weak-signal-needs-more-info',
 ] as const;
+const REQUIRED_KNOWLEDGE_CASES = [
+  'monetization-only',
+  'no-false-positive-had',
+  'onboarding-skips-knowledge',
+  'recent-user-turn-window',
+  'release-playlist-topic-cap',
+] as const;
 const CHAT_SLASH_SKILL_NAMES = commandsForSurface('chat-slash')
   .filter(command => command.kind === 'skill')
   .map(command => command.id)
@@ -433,6 +442,7 @@ function toMode(value: unknown): 'app' | 'onboarding' {
 function toTarget(value: unknown): EvalTarget {
   if (
     value === 'eval-case-inventory' ||
+    value === 'knowledge-contract' ||
     value === 'mobile-chat-route' ||
     value === 'model-contract' ||
     value === 'onboarding-state-contract' ||
@@ -1960,6 +1970,96 @@ function toUiMessages(prompt: string, vars: EvalVars): UIMessage[] {
   });
 }
 
+function stringArrayValue(value: unknown): string[] {
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map(item => item.trim())
+      .filter(item => item.length > 0)
+      .sort();
+  }
+
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string').sort()
+    : [];
+}
+
+function userTextFromMessages(uiMessages: readonly UIMessage[]): string[] {
+  return uiMessages
+    .filter(message => message.role === 'user')
+    .flatMap(message =>
+      message.parts
+        .filter(
+          (part): part is { type: 'text'; text: string } =>
+            part.type === 'text' && typeof part.text === 'string'
+        )
+        .map(part => part.text)
+    );
+}
+
+function selectedKnowledgeTopicIds(knowledgeContext: string): string[] {
+  if (knowledgeContext.length === 0) return [];
+
+  return KNOWLEDGE_TOPICS.filter(
+    topic =>
+      topic.content.length > 0 && knowledgeContext.includes(topic.content)
+  )
+    .map(topic => topic.id)
+    .sort();
+}
+
+function evaluateKnowledgeContract(prompt: string, vars: EvalVars) {
+  const knowledgeCase =
+    typeof vars.knowledgeCase === 'string' ? vars.knowledgeCase : 'unspecified';
+  const mode = toMode(vars.mode);
+  const uiMessages = toUiMessages(prompt, vars);
+  const userTexts = userTextFromMessages(uiMessages);
+  const recentUserText = [...userTexts].reverse().slice(0, 3).join(' ');
+  const knowledgeContext =
+    mode === 'onboarding' ? '' : selectKnowledgeContextForTurn(uiMessages);
+  const selectedTopicIds = selectedKnowledgeTopicIds(knowledgeContext);
+
+  return {
+    target: 'knowledge-contract',
+    adapter: 'knowledge-contract',
+    costTier: 'deterministic',
+    text: '',
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    dbAttempted: false,
+    networkAttempted: false,
+    mode,
+    knowledgeCase,
+    messageCount: uiMessages.length,
+    userText: userTexts.join('\n'),
+    recentUserText,
+    knowledgeContextSelected: knowledgeContext.length > 0,
+    knowledgeContextLength: knowledgeContext.length,
+    selectedTopicIds,
+    selectedTopicCount: selectedTopicIds.length,
+    selectedTopicPreviews: KNOWLEDGE_TOPICS.filter(topic =>
+      selectedTopicIds.includes(topic.id)
+    ).map(topic => ({
+      id: topic.id,
+      preview: topic.content.slice(0, 180),
+    })),
+    expectedTopicIds: stringArrayValue(vars.expectedTopicIds),
+    unexpectedTopicIds: stringArrayValue(vars.unexpectedTopicIds),
+    expectedHasContext:
+      typeof vars.expectedHasContext === 'boolean'
+        ? vars.expectedHasContext
+        : null,
+    expectedMaxTopicCount:
+      typeof vars.expectedMaxTopicCount === 'number'
+        ? vars.expectedMaxTopicCount
+        : 2,
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
 function buildEvalReleases(vars: EvalVars): ReleaseContext[] {
   const overrides = Array.isArray(vars.releaseOverrides)
     ? (vars.releaseOverrides as Parameters<typeof buildTestReleases>[0])
@@ -3143,6 +3243,7 @@ type EvalCaseSummary = {
   readonly modelScenario: string | null;
   readonly expectedModel: string | null;
   readonly eventCase: string | null;
+  readonly knowledgeCase: string | null;
   readonly renderCase: string | null;
   readonly stateCase: string | null;
   readonly mode: string | null;
@@ -3229,6 +3330,7 @@ function parseEvalCaseSummary(block: string): EvalCaseSummary {
     modelScenario: scalarValue(block, 'modelScenario'),
     expectedModel: scalarValue(block, 'expectedModel'),
     eventCase: scalarValue(block, 'eventCase'),
+    knowledgeCase: scalarValue(block, 'knowledgeCase'),
     renderCase: scalarValue(block, 'renderCase'),
     stateCase: scalarValue(block, 'stateCase'),
     mode: scalarValue(block, 'mode') ?? 'app',
@@ -3350,6 +3452,15 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
           expectedModel === 'light' || expectedModel === 'primary'
       )
   );
+  const knowledgeCaseNames = uniqueSorted(
+    deterministicCases
+      .filter(testCase => testCase.target === 'knowledge-contract')
+      .map(testCase => testCase.knowledgeCase)
+      .filter(
+        (knowledgeCase): knowledgeCase is string =>
+          typeof knowledgeCase === 'string'
+      )
+  );
   const onboardingStateCaseNames = uniqueSorted(
     deterministicCases
       .filter(testCase => testCase.target === 'onboarding-state-contract')
@@ -3440,6 +3551,12 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
     missingModelRoutingBoundaryNames: missingNames(
       ['light', 'primary'],
       modelRoutingBoundaryNames
+    ),
+    requiredKnowledgeCaseNames: [...REQUIRED_KNOWLEDGE_CASES],
+    knowledgeCaseNames,
+    missingKnowledgeCaseNames: missingNames(
+      REQUIRED_KNOWLEDGE_CASES,
+      knowledgeCaseNames
     ),
     requiredOnboardingStateCaseNames: [...REQUIRED_ONBOARDING_STATE_CASES],
     onboardingStateCaseNames,
@@ -3551,6 +3668,16 @@ export default class JovieChatPromptfooProvider {
 
     if (target === 'model-contract') {
       const payload = evaluateModelContract(prompt, vars);
+      return {
+        output: JSON.stringify(payload),
+        raw: payload,
+        format: 'json',
+        latencyMs: Date.now() - startedAt,
+      };
+    }
+
+    if (target === 'knowledge-contract') {
+      const payload = evaluateKnowledgeContract(prompt, vars);
       return {
         output: JSON.stringify(payload),
         raw: payload,

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -958,6 +958,115 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertEvalCaseInventoryCovered
 
+  - description: Knowledge routing selects release and playlist topics with cap
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Help me plan my single release date, pre-save, countdown, and Spotify playlist pitch for editorial playlists. I also need revenue ideas from merch."
+      target: knowledge-contract
+      knowledgeCase: release-playlist-topic-cap
+      mode: app
+      expectedTopicIds: "playlist-strategy,release-strategy"
+      unexpectedTopicIds: "monetization"
+      expectedHasContext: true
+      expectedMaxTopicCount: 2
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeContractNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeTopicsSelected
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeTopicCap
+
+  - description: Knowledge routing selects monetization for revenue and payout questions
+    metadata:
+      cost: deterministic
+    vars:
+      input: "How much do streams pay, and can merch revenue or artist payouts help Luna Waves make money?"
+      target: knowledge-contract
+      knowledgeCase: monetization-only
+      mode: app
+      expectedTopicIds: "monetization"
+      unexpectedTopicIds: "streaming-metrics"
+      expectedHasContext: true
+      expectedMaxTopicCount: 2
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeContractNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeTopicsSelected
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeTopicCap
+
+  - description: Knowledge routing avoids false positives from ordinary words
+    metadata:
+      cost: deterministic
+    vars:
+      input: "I had a rough week and need a simple pep talk before rehearsal."
+      target: knowledge-contract
+      knowledgeCase: no-false-positive-had
+      mode: app
+      expectedTopicIds: ""
+      expectedHasContext: false
+      expectedMaxTopicCount: 2
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeContractNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeTopicsSelected
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeNoFalsePositive
+
+  - description: Knowledge routing uses only the last three user turns
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Recent-turn window check"
+      target: knowledge-contract
+      knowledgeCase: recent-user-turn-window
+      mode: app
+      messages:
+        - role: user
+          text: "I need help with copyright, publishing, splits, and who owns the master recording."
+        - role: assistant
+          text: "Got it."
+        - role: user
+          text: "Thanks, unrelated check in."
+        - role: user
+          text: "What should I do today?"
+        - role: user
+          text: "Can you keep this simple?"
+      expectedTopicIds: ""
+      unexpectedTopicIds: "music-rights"
+      expectedHasContext: false
+      expectedMaxTopicCount: 2
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeContractNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeTopicsSelected
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeUsesRecentUserTurns
+
+  - description: Knowledge routing skips context for onboarding mode
+    metadata:
+      cost: deterministic
+    vars:
+      input: "I want to schedule a release, make a pre-save, and pitch Spotify editorial playlists."
+      target: knowledge-contract
+      knowledgeCase: onboarding-skips-knowledge
+      mode: onboarding
+      expectedTopicIds: ""
+      expectedHasContext: false
+      expectedMaxTopicCount: 2
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeContractNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeTopicsSelected
+      - type: javascript
+        value: file://assertions.cjs:assertKnowledgeOnboardingSkipsContext
+
   - description: Tool event inventory hydrates every eval tool
     metadata:
       cost: deterministic


### PR DESCRIPTION
## Summary
- add deterministic Promptfoo `knowledge-contract` coverage around the real `selectKnowledgeContextForTurn()` helper
- cover topic selection, topic cap, no false positives, last-three-user-turn windowing, and onboarding-mode context skipping
- extend eval-case inventory so the knowledge-routing cases are required in the deterministic suite

## Cost control
Ship now: default `pnpm run evals` remains deterministic and ran with model/provider keys explicitly unset. No model, DB, Clerk, Spotify, Stripe, Slack, or local Next server calls are required.
Re-evaluate when: live eval failures catch a release-blocking regression twice in 30 days or manual live-eval runtime cost stays below the agreed per-run budget.
Then: add a capped live subset with concurrency 1 under the existing JOV-2596 eval lane.

## Verification
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml`
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u XAI_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 JOVIE_RUN_LIVE_HTTP_EVALS=0 JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=0 JOVIE_RUN_LIVE_HTTP_MODEL_ERROR_EVALS=0 JOVIE_AGENT_PROFILE=coder pnpm run evals` (128/128)
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml`
- `git diff --check`
- pre-commit hooks passed
- pre-push hooks passed

## Known blocker
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck:tests -- --pretty false` still fails on the existing repo-wide test TypeScript backlog tracked by JOV-2582; failures are outside `apps/web/tests/eval/promptfoo`.

Linear: JOV-2596