### PR TITLE
test(promptfoo): cover tool access matrix

### DIFF
--- a/apps/web/tests/eval/promptfoo/README.md
+++ b/apps/web/tests/eval/promptfoo/README.md
@@ -2,7 +2,7 @@
 
 Runs a small Promptfoo suite against local adapters:
 
-- Deterministic contract adapters for chat and onboarding tool availability, schemas, tool UI registry coverage, model-routing scenario inventory, knowledge-topic routing, onboarding next-step state decisions, stubbed outputs, and no-spend guarantees.
+- Deterministic contract adapters for chat and onboarding tool availability, production tool-access gating, schemas, tool UI registry coverage, model-routing scenario inventory, knowledge-topic routing, onboarding next-step state decisions, stubbed outputs, and no-spend guarantees.
 - The production `executeChatTurn()` path used by `/api/chat`, with synthetic Luna Waves fixtures and eval-only tool stubs. This live path is manual-only because it calls the model provider.
 - A deterministic route-contract adapter for `POST /api/chat`, covering unauthenticated requests, branch-ordering for the chat kill switch, invalid JSON, message validation, missing profile context, client-turn preconditions, rate-limit responses, and contract-only pre-dispatch success without starting Next, Clerk, or the database.
 - A deterministic route-contract adapter for `POST /api/mobile/v1/chat/turns`, covering unauthenticated, invalid JSON, invalid-body variants, and `MOBILE_CHAT_RUNTIME_DISABLED` responses without starting Next or Clerk.

--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -1588,6 +1588,81 @@ function assertKnowledgeOnboardingSkipsContext(output) {
   return pass();
 }
 
+function assertToolAccessContractNoSpend(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'tool-access-contract') {
+    return fail('case did not run through the tool-access adapter');
+  }
+  if (payload.costTier !== 'deterministic') {
+    return fail('tool access case is not marked deterministic');
+  }
+  if (payload.modelCalled !== false || payload.selectedModel !== null) {
+    return fail('tool access case crossed the model boundary');
+  }
+  if (payload.persistenceAttempted !== false || payload.dbAttempted !== false) {
+    return fail('tool access case crossed the persistence boundary');
+  }
+  if (payload.networkAttempted !== false) {
+    return fail('tool access case crossed the network boundary');
+  }
+
+  return pass();
+}
+
+function assertToolAccessMatrix(output) {
+  const payload = parseOutput(output);
+  const scenarios = Array.isArray(payload.scenarios) ? payload.scenarios : [];
+  const scenarioNames = scenarios
+    .map(scenario => scenario.name)
+    .filter(name => typeof name === 'string');
+
+  if (payload.target !== 'tool-access-contract') {
+    return fail('case did not run through the tool-access adapter');
+  }
+  if (payload.accessCase !== 'billing-mode-matrix') {
+    return fail('tool access case is not the billing/mode matrix');
+  }
+  if (scenarios.length === 0) {
+    return fail('tool access matrix produced no scenarios');
+  }
+
+  for (const requiredName of sortedStringArray(payload.requiredScenarioNames)) {
+    if (!scenarioNames.includes(requiredName)) {
+      return fail(`missing tool access scenario: ${requiredName}`);
+    }
+  }
+
+  for (const scenario of scenarios) {
+    if (
+      scenario.paidToolAccess !== scenario.expectedPaidToolAccess ||
+      scenario.turnAiCanUseTools !== scenario.expectedTurnAiCanUseTools
+    ) {
+      return fail(
+        `${scenario.name} gating mismatch: paidToolAccess=${String(scenario.paidToolAccess)}, turnAiCanUseTools=${String(scenario.turnAiCanUseTools)}`
+      );
+    }
+    if (
+      Array.isArray(scenario.missingToolNames) &&
+      scenario.missingToolNames.length > 0
+    ) {
+      return fail(
+        `${scenario.name} missing tools: ${scenario.missingToolNames.join(', ')}`
+      );
+    }
+    if (
+      Array.isArray(scenario.unexpectedToolNames) &&
+      scenario.unexpectedToolNames.length > 0
+    ) {
+      return fail(
+        `${scenario.name} unexpected tools: ${scenario.unexpectedToolNames.join(', ')}`
+      );
+    }
+  }
+
+  return pass();
+}
+
 function assertSafeSocialUrl(output) {
   const payload = parseOutput(output);
   const input = payload.parsedInput ?? payload.input ?? {};
@@ -2156,6 +2231,7 @@ function assertEvalCaseInventoryCovered(output) {
     'missingModelRoutingScenarioNames',
     'missingModelRoutingBoundaryNames',
     'missingKnowledgeCaseNames',
+    'missingToolAccessCaseNames',
     'missingOnboardingStateCaseNames',
   ]) {
     const values = payload[field];
@@ -2227,6 +2303,8 @@ module.exports = {
   assertKnowledgeNoFalsePositive,
   assertKnowledgeUsesRecentUserTurns,
   assertKnowledgeOnboardingSkipsContext,
+  assertToolAccessContractNoSpend,
+  assertToolAccessMatrix,
   assertSafeSocialUrl,
   assertFailedToolResultPreserved,
   assertToolInventoryCovered,

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -2147,7 +2147,7 @@ type ToolAccessScenarioInput = {
   readonly name: string;
   readonly mode: 'app' | 'onboarding';
   readonly plan: PlanId;
-  readonly billingVerification?: 'verified' | 'unavailable';
+  readonly billingVerification?: 'verified' | 'missing_user' | 'unavailable';
   readonly aiCanUseTools?: boolean;
   readonly expectedPaidToolAccess: boolean | null;
   readonly expectedTurnAiCanUseTools: boolean | null;
@@ -2241,6 +2241,33 @@ function evaluateToolAccessContract(vars: EvalVars) {
       expectedToolNames: PAID_TOOL_NAMES,
     }),
     buildToolAccessScenario({
+      name: 'app-trial-verified',
+      mode: 'app',
+      plan: 'trial',
+      billingVerification: 'verified',
+      expectedPaidToolAccess: true,
+      expectedTurnAiCanUseTools: true,
+      expectedToolNames: PAID_TOOL_NAMES,
+    }),
+    buildToolAccessScenario({
+      name: 'app-max-verified',
+      mode: 'app',
+      plan: 'max',
+      billingVerification: 'verified',
+      expectedPaidToolAccess: true,
+      expectedTurnAiCanUseTools: true,
+      expectedToolNames: PAID_TOOL_NAMES,
+    }),
+    buildToolAccessScenario({
+      name: 'app-pro-billing-missing-user',
+      mode: 'app',
+      plan: 'pro',
+      billingVerification: 'missing_user',
+      expectedPaidToolAccess: false,
+      expectedTurnAiCanUseTools: false,
+      expectedToolNames: FREE_APP_TOOL_NAMES,
+    }),
+    buildToolAccessScenario({
       name: 'app-pro-billing-unavailable',
       mode: 'app',
       plan: 'pro',
@@ -2284,6 +2311,9 @@ function evaluateToolAccessContract(vars: EvalVars) {
     requiredScenarioNames: [
       'app-free-verified',
       'app-pro-verified',
+      'app-trial-verified',
+      'app-max-verified',
+      'app-pro-billing-missing-user',
       'app-pro-billing-unavailable',
       'app-pro-ai-tools-disabled',
       'onboarding-free',

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -19,6 +19,10 @@ import {
   selectKnowledgeContextForTurn,
 } from '@/lib/chat/run';
 import {
+  canUsePaidChatTools,
+  resolveChatTurnPlanLimits,
+} from '@/lib/chat/tool-access';
+import {
   decodeToolEvents,
   type PersistedToolEvent,
   persistedToolEventsSchema,
@@ -63,6 +67,7 @@ type EvalTarget =
   | 'model-contract'
   | 'mobile-chat-route'
   | 'onboarding-state-contract'
+  | 'tool-access-contract'
   | 'tool-contract'
   | 'tool-event-contract'
   | 'tool-render-contract'
@@ -390,6 +395,7 @@ const REQUIRED_KNOWLEDGE_CASES = [
   'recent-user-turn-window',
   'release-playlist-topic-cap',
 ] as const;
+const REQUIRED_TOOL_ACCESS_CASES = ['billing-mode-matrix'] as const;
 const CHAT_SLASH_SKILL_NAMES = commandsForSurface('chat-slash')
   .filter(command => command.kind === 'skill')
   .map(command => command.id)
@@ -446,6 +452,7 @@ function toTarget(value: unknown): EvalTarget {
     value === 'mobile-chat-route' ||
     value === 'model-contract' ||
     value === 'onboarding-state-contract' ||
+    value === 'tool-access-contract' ||
     value === 'tool-contract' ||
     value === 'tool-event-contract' ||
     value === 'tool-render-contract' ||
@@ -2136,6 +2143,158 @@ function getToolNamesForTurn(
   return toolNames;
 }
 
+type ToolAccessScenarioInput = {
+  readonly name: string;
+  readonly mode: 'app' | 'onboarding';
+  readonly plan: PlanId;
+  readonly billingVerification?: 'verified' | 'unavailable';
+  readonly aiCanUseTools?: boolean;
+  readonly expectedPaidToolAccess: boolean | null;
+  readonly expectedTurnAiCanUseTools: boolean | null;
+  readonly expectedToolNames: readonly string[];
+};
+
+function syntheticAccountContext(
+  scenario: ToolAccessScenarioInput
+): Parameters<typeof canUsePaidChatTools>[0] {
+  const planLimits = getEntitlements(scenario.plan);
+
+  return {
+    billingVerification: scenario.billingVerification ?? 'verified',
+    isPro: scenario.plan !== 'free',
+    planLimits: {
+      ...planLimits,
+      booleans: {
+        ...planLimits.booleans,
+        aiCanUseTools:
+          scenario.aiCanUseTools ?? planLimits.booleans.aiCanUseTools,
+      },
+    },
+  } as Parameters<typeof canUsePaidChatTools>[0];
+}
+
+function buildToolAccessScenario(scenario: ToolAccessScenarioInput) {
+  const expectedToolNames = [...scenario.expectedToolNames].sort();
+  const accountContext =
+    scenario.mode === 'app' ? syntheticAccountContext(scenario) : null;
+  const paidToolAccess = accountContext
+    ? canUsePaidChatTools(accountContext)
+    : null;
+  const turnPlanLimits = accountContext
+    ? resolveChatTurnPlanLimits(accountContext)
+    : null;
+  const availableToolNames = [
+    ...getToolNamesForTurn(scenario.mode, scenario.plan, {
+      billingVerification: scenario.billingVerification,
+      aiCanUseTools:
+        turnPlanLimits?.booleans.aiCanUseTools ?? scenario.aiCanUseTools,
+    }),
+  ].sort();
+  const availableSet = new Set(availableToolNames);
+  const expectedSet = new Set(expectedToolNames);
+  const missingToolNames = expectedToolNames.filter(
+    toolName => !availableSet.has(toolName)
+  );
+  const unexpectedToolNames = availableToolNames.filter(
+    toolName => !expectedSet.has(toolName)
+  );
+
+  return {
+    name: scenario.name,
+    mode: scenario.mode,
+    plan: scenario.plan,
+    billingVerification: scenario.billingVerification ?? 'verified',
+    inputAiCanUseTools:
+      scenario.aiCanUseTools ??
+      getEntitlements(scenario.plan).booleans.aiCanUseTools,
+    paidToolAccess,
+    expectedPaidToolAccess: scenario.expectedPaidToolAccess,
+    turnAiCanUseTools: turnPlanLimits?.booleans.aiCanUseTools ?? null,
+    expectedTurnAiCanUseTools: scenario.expectedTurnAiCanUseTools,
+    availableToolNames,
+    expectedToolNames,
+    missingToolNames,
+    unexpectedToolNames,
+  };
+}
+
+function evaluateToolAccessContract(vars: EvalVars) {
+  const accessCase =
+    typeof vars.accessCase === 'string' ? vars.accessCase : 'unspecified';
+  const scenarios = [
+    buildToolAccessScenario({
+      name: 'app-free-verified',
+      mode: 'app',
+      plan: 'free',
+      billingVerification: 'verified',
+      expectedPaidToolAccess: false,
+      expectedTurnAiCanUseTools: false,
+      expectedToolNames: FREE_APP_TOOL_NAMES,
+    }),
+    buildToolAccessScenario({
+      name: 'app-pro-verified',
+      mode: 'app',
+      plan: 'pro',
+      billingVerification: 'verified',
+      expectedPaidToolAccess: true,
+      expectedTurnAiCanUseTools: true,
+      expectedToolNames: PAID_TOOL_NAMES,
+    }),
+    buildToolAccessScenario({
+      name: 'app-pro-billing-unavailable',
+      mode: 'app',
+      plan: 'pro',
+      billingVerification: 'unavailable',
+      expectedPaidToolAccess: false,
+      expectedTurnAiCanUseTools: false,
+      expectedToolNames: FREE_APP_TOOL_NAMES,
+    }),
+    buildToolAccessScenario({
+      name: 'app-pro-ai-tools-disabled',
+      mode: 'app',
+      plan: 'pro',
+      billingVerification: 'verified',
+      aiCanUseTools: false,
+      expectedPaidToolAccess: false,
+      expectedTurnAiCanUseTools: false,
+      expectedToolNames: FREE_APP_TOOL_NAMES,
+    }),
+    buildToolAccessScenario({
+      name: 'onboarding-free',
+      mode: 'onboarding',
+      plan: 'free',
+      expectedPaidToolAccess: null,
+      expectedTurnAiCanUseTools: null,
+      expectedToolNames: ONBOARDING_TOOLS,
+    }),
+  ];
+
+  return {
+    target: 'tool-access-contract',
+    adapter: 'tool-access-contract',
+    costTier: 'deterministic',
+    text: '',
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    dbAttempted: false,
+    networkAttempted: false,
+    accessCase,
+    scenarioNames: scenarios.map(scenario => scenario.name),
+    requiredScenarioNames: [
+      'app-free-verified',
+      'app-pro-verified',
+      'app-pro-billing-unavailable',
+      'app-pro-ai-tools-disabled',
+      'onboarding-free',
+    ],
+    scenarios,
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
 function configuredToolResult(
   vars: EvalVars,
   toolName: string
@@ -3239,6 +3398,7 @@ type EvalCaseSummary = {
   readonly description: string;
   readonly cost: string | null;
   readonly target: string | null;
+  readonly accessCase: string | null;
   readonly toolName: string | null;
   readonly modelScenario: string | null;
   readonly expectedModel: string | null;
@@ -3326,6 +3486,7 @@ function parseEvalCaseSummary(block: string): EvalCaseSummary {
     description,
     cost: scalarValue(block, 'cost'),
     target: scalarValue(block, 'target') ?? 'chat-turn',
+    accessCase: scalarValue(block, 'accessCase'),
     toolName: scalarValue(block, 'toolName'),
     modelScenario: scalarValue(block, 'modelScenario'),
     expectedModel: scalarValue(block, 'expectedModel'),
@@ -3461,6 +3622,14 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
           typeof knowledgeCase === 'string'
       )
   );
+  const toolAccessCaseNames = uniqueSorted(
+    deterministicCases
+      .filter(testCase => testCase.target === 'tool-access-contract')
+      .map(testCase => testCase.accessCase)
+      .filter(
+        (accessCase): accessCase is string => typeof accessCase === 'string'
+      )
+  );
   const onboardingStateCaseNames = uniqueSorted(
     deterministicCases
       .filter(testCase => testCase.target === 'onboarding-state-contract')
@@ -3557,6 +3726,12 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
     missingKnowledgeCaseNames: missingNames(
       REQUIRED_KNOWLEDGE_CASES,
       knowledgeCaseNames
+    ),
+    requiredToolAccessCaseNames: [...REQUIRED_TOOL_ACCESS_CASES],
+    toolAccessCaseNames,
+    missingToolAccessCaseNames: missingNames(
+      REQUIRED_TOOL_ACCESS_CASES,
+      toolAccessCaseNames
     ),
     requiredOnboardingStateCaseNames: [...REQUIRED_ONBOARDING_STATE_CASES],
     onboardingStateCaseNames,
@@ -3688,6 +3863,16 @@ export default class JovieChatPromptfooProvider {
 
     if (target === 'onboarding-state-contract') {
       const payload = evaluateOnboardingStateContract(vars);
+      return {
+        output: JSON.stringify(payload),
+        raw: payload,
+        format: 'json',
+        latencyMs: Date.now() - startedAt,
+      };
+    }
+
+    if (target === 'tool-access-contract') {
+      const payload = evaluateToolAccessContract(vars);
       return {
         output: JSON.stringify(payload),
         raw: payload,

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -1067,6 +1067,19 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertKnowledgeOnboardingSkipsContext
 
+  - description: Tool access matrix matches billing and mode gates
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Validate tool access without dispatching a model."
+      target: tool-access-contract
+      accessCase: billing-mode-matrix
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertToolAccessContractNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAccessMatrix
+
   - description: Tool event inventory hydrates every eval tool
     metadata:
       cost: deterministic


### PR DESCRIPTION
## Summary
- add a deterministic Promptfoo tool-access contract that imports the production paid-tool gate and verifies Free, Trial, Pro, Max, billing-missing-user, billing-unavailable, AI-tools-disabled, and onboarding palettes
- add assertions and inventory coverage so the tool-access matrix stays in the no-cost Promptfoo lane
- document production tool-access gating in the Promptfoo eval README

## Test plan
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml`
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u XAI_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 JOVIE_RUN_LIVE_HTTP_EVALS=0 JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=0 JOVIE_RUN_LIVE_HTTP_MODEL_ERROR_EVALS=0 JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern "Tool access matrix" --no-cache --no-share --no-write --no-table`
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u XAI_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 JOVIE_RUN_LIVE_HTTP_EVALS=0 JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=0 JOVIE_RUN_LIVE_HTTP_MODEL_ERROR_EVALS=0 JOVIE_AGENT_PROFILE=coder pnpm run evals`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml`
- `git diff --check`
- `git push` pre-push hook: repo Biome, web proxy guard, Tailwind guard, typecheck, lint

## Known blocker outside this slice
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck:tests -- --pretty false` still fails on the existing repo-wide TS test backlog tracked by JOV-2582, with failures in scripts, dashboard/profile/release tests, and related fixtures outside `apps/web/tests/eval/promptfoo`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added new evaluation assertions for tool-access contract validation and billing/mode matrix verification scenarios.
  * Introduced deterministic eval case for comprehensive tool-access gating coverage.

* **Documentation**
  * Updated Promptfoo Chat Baseline documentation with enhanced coverage details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->