### PR TITLE
test(promptfoo): cover prompt context contracts

### DIFF
--- a/apps/web/tests/eval/promptfoo/README.md
+++ b/apps/web/tests/eval/promptfoo/README.md
@@ -2,7 +2,7 @@
 
 Runs a small Promptfoo suite against local adapters:
 
-- Deterministic contract adapters for chat and onboarding tool availability, production tool-access gating, schemas, tool UI registry coverage, model-routing scenario inventory, knowledge-topic routing, onboarding next-step state decisions, stubbed outputs, and no-spend guarantees.
+- Deterministic contract adapters for chat and onboarding tool availability, production tool-access gating, schemas, tool UI registry coverage, model-routing scenario inventory, knowledge-topic routing, prompt/context assembly safety, onboarding next-step state decisions, stubbed outputs, and no-spend guarantees.
 - The production `executeChatTurn()` path used by `/api/chat`, with synthetic Luna Waves fixtures and eval-only tool stubs. This live path is manual-only because it calls the model provider.
 - A deterministic route-contract adapter for `POST /api/chat`, covering unauthenticated requests, branch-ordering for the chat kill switch, invalid JSON, message validation, missing profile context, client-turn preconditions, rate-limit responses, and contract-only pre-dispatch success without starting Next, Clerk, or the database.
 - A deterministic route-contract adapter for `POST /api/mobile/v1/chat/turns`, covering unauthenticated, invalid JSON, invalid-body variants, and `MOBILE_CHAT_RUNTIME_DISABLED` responses without starting Next or Clerk.

--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -1588,6 +1588,258 @@ function assertKnowledgeOnboardingSkipsContext(output) {
   return pass();
 }
 
+function promptContextPayload(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'prompt-context-contract') {
+    return {
+      payload,
+      error: 'case did not run through the prompt-context adapter',
+    };
+  }
+
+  return { payload, error: null };
+}
+
+function systemPromptOf(payload) {
+  return String(payload.systemPrompt ?? '');
+}
+
+function assertPromptContextNoSpend(output) {
+  const { payload, error } = promptContextPayload(output);
+  if (error) return fail(error);
+  if (payload.costTier !== 'deterministic') {
+    return fail('prompt-context case is not marked deterministic');
+  }
+  if (payload.modelCalled !== false || payload.selectedModel !== null) {
+    return fail('prompt-context case crossed the model boundary');
+  }
+  if (payload.persistenceAttempted !== false || payload.dbAttempted !== false) {
+    return fail('prompt-context case crossed the persistence boundary');
+  }
+  if (payload.networkAttempted !== false) {
+    return fail('prompt-context case crossed the network boundary');
+  }
+  if (toolNames(payload).length > 0 || allExecutions(payload).length > 0) {
+    return fail('prompt-context case should not call or execute tools');
+  }
+
+  return pass();
+}
+
+function assertPromptContextNoSensitiveData(output) {
+  const { payload, error } = promptContextPayload(output);
+  if (error) return fail(error);
+  const systemPrompt = systemPromptOf(payload);
+  const emails = [
+    ...systemPrompt.matchAll(/\b[A-Z0-9._%+-]+@([A-Z0-9.-]+\.[A-Z]{2,})\b/gi),
+  ].map(match => match[0]);
+  const unexpectedEmails = emails.filter(
+    email => !/@(?:example\.test|example\.com)$/i.test(email)
+  );
+
+  if (
+    Array.isArray(payload.sensitiveDiagnosticMatches) &&
+    payload.sensitiveDiagnosticMatches.length > 0
+  ) {
+    return fail(
+      `prompt contained sensitive diagnostics: ${payload.sensitiveDiagnosticMatches.join(', ')}`
+    );
+  }
+  if (unexpectedEmails.length > 0) {
+    return fail(
+      `prompt contained non-synthetic email addresses: ${unexpectedEmails.join(', ')}`
+    );
+  }
+  if (
+    /(cus_[A-Za-z0-9]+|sub_[A-Za-z0-9]+|clerk_[A-Za-z0-9_]+)/i.test(
+      systemPrompt
+    )
+  ) {
+    return fail('prompt contained internal customer/subscription/user ids');
+  }
+  if (
+    Array.isArray(payload.presentDisallowedPromptText) &&
+    payload.presentDisallowedPromptText.length > 0
+  ) {
+    return fail(
+      `prompt contained disallowed text: ${payload.presentDisallowedPromptText.join(', ')}`
+    );
+  }
+
+  return pass();
+}
+
+function assertPromptContextAccountSummary(output) {
+  const { payload, error } = promptContextPayload(output);
+  if (error) return fail(error);
+  const systemPrompt = systemPromptOf(payload);
+
+  if (!payload.hasAccountAccessSection) {
+    return fail('prompt did not include account access section');
+  }
+  if (!/- \*\*Plan:\*\* Pro/i.test(systemPrompt)) {
+    return fail('prompt did not include safe Pro plan summary');
+  }
+  if (!/- \*\*Billing Verification:\*\* verified/i.test(systemPrompt)) {
+    return fail('prompt did not include verified billing state');
+  }
+  if (
+    !/- \*\*AI Usage Today:\*\* 7 used, 93 remaining of 100/i.test(systemPrompt)
+  ) {
+    return fail('prompt did not include deterministic usage summary');
+  }
+  if (!payload.hasSafeAccountActions) {
+    return fail('prompt did not include safe account action boundaries');
+  }
+
+  return pass();
+}
+
+function assertPromptContextBillingUnavailableSafe(output) {
+  const { payload, error } = promptContextPayload(output);
+  if (error) return fail(error);
+  const systemPrompt = systemPromptOf(payload);
+
+  if (payload.promptCase !== 'billing-unavailable-guard') {
+    return fail('prompt case is not billing-unavailable-guard');
+  }
+  if (!payload.hasBillingUnavailableGuidance) {
+    return fail('missing billing-unavailable guidance');
+  }
+  if (
+    !/Unavailable while billing verification is unavailable/i.test(systemPrompt)
+  ) {
+    return fail('missing unavailable usage copy');
+  }
+  if (/This artist is on the Free plan/i.test(systemPrompt)) {
+    return fail('billing outage prompt downgraded the artist to Free');
+  }
+  if (payload.hasPlanLimitationsSection) {
+    return fail('billing outage prompt included Free plan limitations');
+  }
+
+  return pass();
+}
+
+function assertPromptContextMissingAccountOmitted(output) {
+  const { payload, error } = promptContextPayload(output);
+  if (error) return fail(error);
+  const systemPrompt = systemPromptOf(payload);
+
+  if (payload.hasAccountAccessSection) {
+    return fail('missing-account prompt included account access section');
+  }
+  if (
+    /Account Email|Billing Portal|Billing Verification|AI Usage Today/i.test(
+      systemPrompt
+    )
+  ) {
+    return fail('missing-account prompt leaked account or billing fields');
+  }
+  if (!/## About This Artist|## Discography Context/i.test(systemPrompt)) {
+    return fail('missing-account prompt did not render artist context');
+  }
+
+  return pass();
+}
+
+function assertPromptContextFreePlanLimitations(output) {
+  const { payload, error } = promptContextPayload(output);
+  if (error) return fail(error);
+  const systemPrompt = systemPromptOf(payload);
+
+  if (payload.plan !== 'free') {
+    return fail(`expected free plan, got ${String(payload.plan)}`);
+  }
+  if (!payload.hasPlanLimitationsSection) {
+    return fail('free prompt did not include plan limitations');
+  }
+  if (!/Free plan with 10 messages per day/i.test(systemPrompt)) {
+    return fail('free prompt did not include the free daily limit');
+  }
+  if (
+    !/proposeAvatarUpload|proposeSocialLink|proposeSocialLinkRemoval/i.test(
+      systemPrompt
+    )
+  ) {
+    return fail('free prompt did not list safe free tools');
+  }
+  if (!/do NOT have access to advanced tools/i.test(systemPrompt)) {
+    return fail('free prompt did not block advanced tools');
+  }
+
+  return pass();
+}
+
+function assertPromptContextPlanMismatchSafe(output) {
+  const { payload, error } = promptContextPayload(output);
+  if (error) return fail(error);
+  const systemPrompt = systemPromptOf(payload);
+
+  if (payload.promptCase !== 'billing-drift-guidance') {
+    return fail('prompt case is not billing-drift-guidance');
+  }
+  if (!payload.hasBillingDriftGuidance) {
+    return fail('missing billing drift guidance');
+  }
+  if (
+    /legacy_alias|planMismatch|entitlements|planLimits|booleans/i.test(
+      systemPrompt
+    )
+  ) {
+    return fail('billing drift prompt exposed internal diagnostic fields');
+  }
+
+  return pass();
+}
+
+function assertPromptContextKnowledgeNoUserPii(output) {
+  const { payload, error } = promptContextPayload(output);
+  if (error) return fail(error);
+  const systemPrompt = systemPromptOf(payload);
+
+  if (payload.promptCase !== 'analytics-guardrails') {
+    return fail('prompt case is not analytics-guardrails');
+  }
+  if (!payload.knowledgeContextSelected) {
+    return fail('knowledge context was not selected');
+  }
+  if (/private@example\.test/i.test(systemPrompt)) {
+    return fail('system prompt copied user-provided private email');
+  }
+  if (!payload.hasAnalyticsGuardrails) {
+    return fail('missing analytics fabrication/internal-scoring guardrails');
+  }
+
+  return pass();
+}
+
+function assertPromptContextReleaseOverflowCap(output) {
+  const { payload, error } = promptContextPayload(output);
+  if (error) return fail(error);
+
+  if (payload.promptCase !== 'release-overflow-cap') {
+    return fail('prompt case is not release-overflow-cap');
+  }
+  if (payload.releaseCount !== 30) {
+    return fail(`expected 30 releases, got ${String(payload.releaseCount)}`);
+  }
+  if (!payload.releaseOverflowLinePresent) {
+    return fail('release overflow line was not rendered');
+  }
+  if (
+    Array.isArray(payload.releaseTitlesIncluded) &&
+    payload.releaseTitlesIncluded.length !== 25
+  ) {
+    return fail(
+      `expected 25 release titles in prompt, got ${payload.releaseTitlesIncluded.length}`
+    );
+  }
+
+  return pass();
+}
+
 function assertToolAccessContractNoSpend(output) {
   const payload = parseOutput(output);
 
@@ -2231,6 +2483,7 @@ function assertEvalCaseInventoryCovered(output) {
     'missingModelRoutingScenarioNames',
     'missingModelRoutingBoundaryNames',
     'missingKnowledgeCaseNames',
+    'missingPromptContextCaseNames',
     'missingToolAccessCaseNames',
     'missingOnboardingStateCaseNames',
   ]) {
@@ -2303,6 +2556,15 @@ module.exports = {
   assertKnowledgeNoFalsePositive,
   assertKnowledgeUsesRecentUserTurns,
   assertKnowledgeOnboardingSkipsContext,
+  assertPromptContextNoSpend,
+  assertPromptContextNoSensitiveData,
+  assertPromptContextAccountSummary,
+  assertPromptContextBillingUnavailableSafe,
+  assertPromptContextMissingAccountOmitted,
+  assertPromptContextFreePlanLimitations,
+  assertPromptContextPlanMismatchSafe,
+  assertPromptContextKnowledgeNoUserPii,
+  assertPromptContextReleaseOverflowCap,
   assertToolAccessContractNoSpend,
   assertToolAccessMatrix,
   assertSafeSocialUrl,

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -18,6 +18,7 @@ import {
   executeChatTurn,
   selectKnowledgeContextForTurn,
 } from '@/lib/chat/run';
+import { buildSystemPrompt } from '@/lib/chat/system-prompt';
 import {
   canUsePaidChatTools,
   resolveChatTurnPlanLimits,
@@ -67,6 +68,7 @@ type EvalTarget =
   | 'model-contract'
   | 'mobile-chat-route'
   | 'onboarding-state-contract'
+  | 'prompt-context-contract'
   | 'tool-access-contract'
   | 'tool-contract'
   | 'tool-event-contract'
@@ -395,6 +397,15 @@ const REQUIRED_KNOWLEDGE_CASES = [
   'recent-user-turn-window',
   'release-playlist-topic-cap',
 ] as const;
+const REQUIRED_PROMPT_CONTEXT_CASES = [
+  'analytics-guardrails',
+  'billing-drift-guidance',
+  'billing-unavailable-guard',
+  'free-plan-limitations',
+  'no-account-context',
+  'pro-verified-account',
+  'release-overflow-cap',
+] as const;
 const REQUIRED_TOOL_ACCESS_CASES = ['billing-mode-matrix'] as const;
 const CHAT_SLASH_SKILL_NAMES = commandsForSurface('chat-slash')
   .filter(command => command.kind === 'skill')
@@ -452,6 +463,7 @@ function toTarget(value: unknown): EvalTarget {
     value === 'mobile-chat-route' ||
     value === 'model-contract' ||
     value === 'onboarding-state-contract' ||
+    value === 'prompt-context-contract' ||
     value === 'tool-access-contract' ||
     value === 'tool-contract' ||
     value === 'tool-event-contract' ||
@@ -2085,6 +2097,218 @@ function buildEvalReleases(vars: EvalVars): ReleaseContext[] {
   }));
 }
 
+type SystemPromptOptions = NonNullable<Parameters<typeof buildSystemPrompt>[2]>;
+type EvalAccountPromptContext = NonNullable<
+  SystemPromptOptions['accountContext']
+>;
+type EvalSystemPromptReleases = Parameters<typeof buildSystemPrompt>[1];
+type EvalBillingVerification = EvalAccountPromptContext['billingVerification'];
+
+const SYSTEM_PROMPT_SECRET_PATTERN =
+  /(AI_GATEWAY_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|XAI_API_KEY|VERCEL_OIDC_TOKEN|DATABASE_URL|CLERK_|UPSTASH_|bearer\s+[a-z0-9._-]+|sk-[a-z0-9_-]+|postgres(?:ql)?:\/\/|stack trace|at\s+[A-Za-z0-9_.$]+\s*\()/gi;
+
+function toPromptBillingVerification(value: unknown): EvalBillingVerification {
+  if (
+    value === 'verified' ||
+    value === 'missing_user' ||
+    value === 'unavailable'
+  ) {
+    return value;
+  }
+
+  return 'verified';
+}
+
+function displayPlanForPrompt(
+  plan: PlanId,
+  billingVerification: EvalBillingVerification
+): string {
+  if (billingVerification === 'unavailable') return 'Unverified';
+  if (plan === 'trial') return 'Pro Trial';
+  if (plan === 'max') return 'Max';
+  if (plan === 'pro') return 'Pro';
+  return 'Free';
+}
+
+function buildEvalPromptAccountContext(
+  vars: EvalVars
+): EvalAccountPromptContext | undefined {
+  if (vars.includeAccountContext === false) return undefined;
+
+  const plan = toPlanId(vars.plan);
+  const planLimits = getEntitlements(plan);
+  const billingVerification = toPromptBillingVerification(
+    vars.billingVerification
+  );
+  const dailyLimit = planLimits.limits.aiDailyMessageLimit;
+  const used = typeof vars.usageUsed === 'number' ? vars.usageUsed : 7;
+  const monthlyLimit =
+    typeof vars.monthlyLimit === 'number' ? vars.monthlyLimit : dailyLimit * 30;
+  const monthlyUsed =
+    typeof vars.monthlyUsed === 'number' ? vars.monthlyUsed : used * 4;
+  const planMismatch =
+    vars.planMismatch === 'legacy-founding'
+      ? {
+          rawPlan: 'founding',
+          normalizedPlan: 'pro',
+          reason: 'legacy_alias',
+        }
+      : null;
+
+  return {
+    email:
+      typeof vars.accountEmail === 'string'
+        ? vars.accountEmail
+        : 'luna.billing@example.test',
+    plan,
+    displayPlan: displayPlanForPrompt(plan, billingVerification),
+    isPro: plan !== 'free',
+    billingVerification,
+    planMismatch,
+    usage:
+      billingVerification === 'unavailable'
+        ? null
+        : {
+            dailyLimit,
+            used,
+            remaining: Math.max(dailyLimit - used, 0),
+            resetAt: '2026-05-26T07:00:00.000Z',
+            monthlyLimit,
+            monthlyUsed,
+            monthlyRemaining: Math.max(monthlyLimit - monthlyUsed, 0),
+            monthlyResetAt: '2026-06-01T07:00:00.000Z',
+          },
+    entitlements: {
+      aiCanUseTools:
+        plan !== 'free' &&
+        billingVerification === 'verified' &&
+        toBoolean(vars.aiCanUseTools, planLimits.booleans.aiCanUseTools),
+      canAccessMerchCreation: planLimits.booleans.canAccessMerchCreation,
+      canGenerateAlbumArt: planLimits.booleans.canGenerateAlbumArt,
+      canAccessAdvancedAnalytics:
+        planLimits.booleans.canAccessAdvancedAnalytics,
+    },
+    flags: {
+      merchMvp: true,
+    },
+    billing: {
+      hasStripeCustomer: toBoolean(vars.hasStripeCustomer, plan !== 'free'),
+      hasStripeSubscription: toBoolean(
+        vars.hasStripeSubscription,
+        plan !== 'free'
+      ),
+    },
+  };
+}
+
+function buildSystemPromptContractReleases(
+  promptCase: string,
+  vars: EvalVars
+): EvalSystemPromptReleases {
+  if (promptCase !== 'release-overflow-cap') {
+    return buildEvalReleases(vars);
+  }
+
+  return Array.from({ length: 30 }, (_, index) => ({
+    title: `Overflow Release ${index + 1}`,
+    releaseType: index % 3 === 0 ? 'album' : 'single',
+    releaseDate: `2025-${String((index % 12) + 1).padStart(2, '0')}-15T00:00:00Z`,
+    totalTracks: index % 3 === 0 ? 10 : 1,
+  }));
+}
+
+function evaluateSystemPromptContract(prompt: string, vars: EvalVars) {
+  const promptCase =
+    typeof vars.promptCase === 'string' ? vars.promptCase : 'unspecified';
+  const plan = toPlanId(vars.plan);
+  const accountContext = buildEvalPromptAccountContext(vars);
+  const planLimits = getEntitlements(plan);
+  const aiCanUseTools =
+    accountContext?.entitlements.aiCanUseTools ??
+    (plan !== 'free' && planLimits.booleans.aiCanUseTools);
+  const artistContext = buildTestArtistContext(
+    toObject(vars.artistOverrides) as Parameters<
+      typeof buildTestArtistContext
+    >[0]
+  );
+  const releases = buildSystemPromptContractReleases(promptCase, vars);
+  const uiMessages = toUiMessages(prompt, vars);
+  const knowledgeContext =
+    typeof vars.knowledgeContext === 'string' &&
+    vars.knowledgeContext.trim().length > 0
+      ? vars.knowledgeContext.trim()
+      : toBoolean(vars.selectKnowledgeContext, false)
+        ? selectKnowledgeContextForTurn(uiMessages)
+        : undefined;
+  const systemPrompt = buildSystemPrompt(artistContext, releases, {
+    aiCanUseTools,
+    aiDailyMessageLimit: planLimits.limits.aiDailyMessageLimit,
+    insightsEnabled: toBoolean(vars.insightsEnabled, plan !== 'free'),
+    knowledgeContext,
+    accountContext,
+  });
+  const disallowedPromptText = stringArrayValue(vars.disallowedPromptText);
+  const releaseTitles = releases.map(release => release.title);
+
+  return {
+    target: 'prompt-context-contract',
+    adapter: 'prompt-context-contract',
+    productionEntrypoint:
+      'apps/web/lib/chat/system-prompt.ts:buildSystemPrompt',
+    costTier: 'deterministic',
+    text: '',
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    dbAttempted: false,
+    networkAttempted: false,
+    promptCase,
+    mode: 'app',
+    plan,
+    billingVerification: accountContext?.billingVerification ?? null,
+    aiCanUseTools,
+    systemPrompt,
+    systemPromptChars: systemPrompt.length,
+    knowledgeContextSelected: Boolean(knowledgeContext),
+    selectedTopicIds: selectedKnowledgeTopicIds(knowledgeContext ?? ''),
+    hasAccountAccessSection: systemPrompt.includes('## Account & Access'),
+    hasPlanLimitationsSection: systemPrompt.includes(
+      '## Plan Limitations (Free Tier)'
+    ),
+    hasAnalyticsGuardrails:
+      /Never invent downstream DSP performance or revenue figures/i.test(
+        systemPrompt
+      ) && /hidden internal scoring/i.test(systemPrompt),
+    hasBillingUnavailableGuidance:
+      /could not verify billing right now/i.test(systemPrompt) &&
+      /Do not tell the artist they are on Free/i.test(systemPrompt),
+    hasBillingDriftGuidance:
+      /Billing row mismatch detected/i.test(systemPrompt) &&
+      /Do not ask the artist to fix this manually/i.test(systemPrompt),
+    hasSafeAccountActions:
+      /Never change subscriptions, email, username, connected accounts, or OAuth providers from chat/i.test(
+        systemPrompt
+      ),
+    releaseCount: releases.length,
+    releaseTitles,
+    releaseTitlesIncluded: releaseTitles.filter(title =>
+      systemPrompt.includes(title)
+    ),
+    releaseOverflowLinePresent:
+      /\.\.\.and 5 more releases in the catalog/i.test(systemPrompt),
+    sensitiveDiagnosticMatches: [
+      ...systemPrompt.matchAll(SYSTEM_PROMPT_SECRET_PATTERN),
+    ].map(match => match[0]),
+    disallowedPromptText,
+    presentDisallowedPromptText: disallowedPromptText.filter(value =>
+      systemPrompt.includes(value)
+    ),
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
 function toBillingVerification(value: unknown) {
   return typeof value === 'string' && value.trim().length > 0
     ? value.trim()
@@ -3434,6 +3658,7 @@ type EvalCaseSummary = {
   readonly expectedModel: string | null;
   readonly eventCase: string | null;
   readonly knowledgeCase: string | null;
+  readonly promptCase: string | null;
   readonly renderCase: string | null;
   readonly stateCase: string | null;
   readonly mode: string | null;
@@ -3522,6 +3747,7 @@ function parseEvalCaseSummary(block: string): EvalCaseSummary {
     expectedModel: scalarValue(block, 'expectedModel'),
     eventCase: scalarValue(block, 'eventCase'),
     knowledgeCase: scalarValue(block, 'knowledgeCase'),
+    promptCase: scalarValue(block, 'promptCase'),
     renderCase: scalarValue(block, 'renderCase'),
     stateCase: scalarValue(block, 'stateCase'),
     mode: scalarValue(block, 'mode') ?? 'app',
@@ -3652,6 +3878,14 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
           typeof knowledgeCase === 'string'
       )
   );
+  const promptContextCaseNames = uniqueSorted(
+    deterministicCases
+      .filter(testCase => testCase.target === 'prompt-context-contract')
+      .map(testCase => testCase.promptCase)
+      .filter(
+        (promptCase): promptCase is string => typeof promptCase === 'string'
+      )
+  );
   const toolAccessCaseNames = uniqueSorted(
     deterministicCases
       .filter(testCase => testCase.target === 'tool-access-contract')
@@ -3756,6 +3990,12 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
     missingKnowledgeCaseNames: missingNames(
       REQUIRED_KNOWLEDGE_CASES,
       knowledgeCaseNames
+    ),
+    requiredPromptContextCaseNames: [...REQUIRED_PROMPT_CONTEXT_CASES],
+    promptContextCaseNames,
+    missingPromptContextCaseNames: missingNames(
+      REQUIRED_PROMPT_CONTEXT_CASES,
+      promptContextCaseNames
     ),
     requiredToolAccessCaseNames: [...REQUIRED_TOOL_ACCESS_CASES],
     toolAccessCaseNames,
@@ -3893,6 +4133,16 @@ export default class JovieChatPromptfooProvider {
 
     if (target === 'onboarding-state-contract') {
       const payload = evaluateOnboardingStateContract(vars);
+      return {
+        output: JSON.stringify(payload),
+        raw: payload,
+        format: 'json',
+        latencyMs: Date.now() - startedAt,
+      };
+    }
+
+    if (target === 'prompt-context-contract') {
+      const payload = evaluateSystemPromptContract(prompt, vars);
       return {
         output: JSON.stringify(payload),
         raw: payload,

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -1067,6 +1067,128 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertKnowledgeOnboardingSkipsContext
 
+  - description: Prompt context summarizes verified Pro account safely
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Summarize my account."
+      target: prompt-context-contract
+      promptCase: pro-verified-account
+      plan: pro
+      billingVerification: verified
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSensitiveData
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextAccountSummary
+
+  - description: Prompt context handles billing verification outage safely
+    metadata:
+      cost: deterministic
+    vars:
+      input: "What plan am I on?"
+      target: prompt-context-contract
+      promptCase: billing-unavailable-guard
+      plan: pro
+      billingVerification: unavailable
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSensitiveData
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextBillingUnavailableSafe
+
+  - description: Prompt context omits account section when account context is missing
+    metadata:
+      cost: deterministic
+    vars:
+      input: "What should I do with my next release?"
+      target: prompt-context-contract
+      promptCase: no-account-context
+      plan: pro
+      includeAccountContext: false
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSensitiveData
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextMissingAccountOmitted
+
+  - description: Prompt context explains Free plan tool limits
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Can you generate album art and merch for me?"
+      target: prompt-context-contract
+      promptCase: free-plan-limitations
+      plan: free
+      billingVerification: verified
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSensitiveData
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextFreePlanLimitations
+
+  - description: Prompt context keeps billing drift guidance safe
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Why does billing look different from my plan?"
+      target: prompt-context-contract
+      promptCase: billing-drift-guidance
+      plan: pro
+      billingVerification: verified
+      planMismatch: legacy-founding
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSensitiveData
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextPlanMismatchSafe
+
+  - description: Prompt context selects knowledge without copying user PII
+    metadata:
+      cost: deterministic
+    vars:
+      input: "My private email is private@example.test. For Neon Reef, how should I plan the release date, pre-save countdown, playlist pitching, and editorial playlist submission?"
+      target: prompt-context-contract
+      promptCase: analytics-guardrails
+      plan: pro
+      selectKnowledgeContext: true
+      insightsEnabled: true
+      disallowedPromptText:
+        - private@example.test
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSensitiveData
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextKnowledgeNoUserPii
+
+  - description: Prompt context caps large release catalogs
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Summarize my release catalog."
+      target: prompt-context-contract
+      promptCase: release-overflow-cap
+      plan: pro
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextNoSensitiveData
+      - type: javascript
+        value: file://assertions.cjs:assertPromptContextReleaseOverflowCap
+
   - description: Tool access matrix matches billing and mode gates
     metadata:
       cost: deterministic


### PR DESCRIPTION
## Summary
- Add deterministic Promptfoo `prompt-context-contract` coverage around production `buildSystemPrompt()` assembly.
- Cover account/access prompt sections, billing-unavailable guidance, Free-plan limitations, billing drift guidance, knowledge selection without raw user PII, and large-release catalog caps.
- Keep default evals no-cost: no model dispatch, persistence, DB, network, Clerk, Stripe, Spotify, or local server.

## Cost decision
Ship now: deterministic prompt/context contract coverage for the chat prompt boundary, using synthetic Luna Waves fixtures only.
Re-evaluate when live Promptfoo answer-quality failures catch a release-blocking prompt/context regression twice in 30 days or manual live eval runtime cost stays under the agreed per-run budget.
Then: add a capped manual live subset for the highest-risk prompt/context cases under JOV-2596, concurrency 1, still excluded from PR CI by default.

## Verification
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml` passed
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u XAI_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 JOVIE_RUN_LIVE_HTTP_EVALS=0 JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=0 JOVIE_RUN_LIVE_HTTP_MODEL_ERROR_EVALS=0 JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern "Prompt context" --no-cache --no-share --no-write --no-table` passed: 7/7
- `env -u AI_GATEWAY_API_KEY -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u XAI_API_KEY -u BRAINTRUST_API_KEY JOVIE_RUN_LIVE_EVALS=0 JOVIE_RUN_LIVE_HTTP_EVALS=0 JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS=0 JOVIE_RUN_LIVE_HTTP_MODEL_ERROR_EVALS=0 JOVIE_AGENT_PROFILE=coder pnpm run evals` passed: 136/136
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` passed
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml` passed
- `git diff --check` passed
- pre-commit hook passed: proxy guard, Biome, ESLint, web typecheck
- pre-push hook passed: repo Biome, web proxy guard, Tailwind guard, web typecheck, web lint

## Known blocker
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck:tests -- --pretty false` still fails in the existing broad repo-wide test TS backlog tracked by JOV-2582. First failures remain in `scripts/drizzle-migrate.ts`, `scripts/drizzle-seed.ts`, `scripts/generate-brand-assets.ts`, overnight/performance scripts, and profile/release tests; no Promptfoo eval files appeared in the failure set.

Refs JOV-2596.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive evaluation tests for prompt context generation, validating proper handling of account summaries, billing unavailability, sensitive data filtering, free plan limitations, knowledge context selection, and large release catalogs.

* **Documentation**
  * Updated baseline test documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9714?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->