### PR TITLE
test(promptfoo): harden prompt context assertions

### DIFF
--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -1631,6 +1631,20 @@ function assertPromptContextNoSensitiveData(output) {
   const { payload, error } = promptContextPayload(output);
   if (error) return fail(error);
   const systemPrompt = systemPromptOf(payload);
+  const directSensitiveMatches = [
+    ...systemPrompt.matchAll(
+      /(AI_GATEWAY_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|XAI_API_KEY|VERCEL_OIDC_TOKEN|DATABASE_URL|CLERK_|UPSTASH_|bearer\s+[a-z0-9._-]+|sk-[a-z0-9_-]+|postgres(?:ql)?:\/\/|stack trace|at\s+[A-Za-z0-9_.$]+\s*\()/gi
+    ),
+  ].map(match => match[0]);
+  const diagnosticSensitiveMatches = Array.isArray(
+    payload.sensitiveDiagnosticMatches
+  )
+    ? payload.sensitiveDiagnosticMatches.map(String)
+    : [];
+  const sensitiveMatches = [
+    ...directSensitiveMatches,
+    ...diagnosticSensitiveMatches,
+  ];
   const emails = [
     ...systemPrompt.matchAll(/\b[A-Z0-9._%+-]+@([A-Z0-9.-]+\.[A-Z]{2,})\b/gi),
   ].map(match => match[0]);
@@ -1638,12 +1652,9 @@ function assertPromptContextNoSensitiveData(output) {
     email => !/@(?:example\.test|example\.com)$/i.test(email)
   );
 
-  if (
-    Array.isArray(payload.sensitiveDiagnosticMatches) &&
-    payload.sensitiveDiagnosticMatches.length > 0
-  ) {
+  if (sensitiveMatches.length > 0) {
     return fail(
-      `prompt contained sensitive diagnostics: ${payload.sensitiveDiagnosticMatches.join(', ')}`
+      `prompt contained sensitive diagnostics: ${sensitiveMatches.join(', ')}`
     );
   }
   if (unexpectedEmails.length > 0) {
@@ -1758,12 +1769,14 @@ function assertPromptContextFreePlanLimitations(output) {
   if (!/Free plan with 10 messages per day/i.test(systemPrompt)) {
     return fail('free prompt did not include the free daily limit');
   }
-  if (
-    !/proposeAvatarUpload|proposeSocialLink|proposeSocialLinkRemoval/i.test(
-      systemPrompt
-    )
-  ) {
-    return fail('free prompt did not list safe free tools');
+  for (const toolName of [
+    'proposeAvatarUpload',
+    'proposeSocialLink',
+    'proposeSocialLinkRemoval',
+  ]) {
+    if (!systemPrompt.includes(toolName)) {
+      return fail(`free prompt did not list safe free tool: ${toolName}`);
+    }
   }
   if (!/do NOT have access to advanced tools/i.test(systemPrompt)) {
     return fail('free prompt did not block advanced tools');


### PR DESCRIPTION
## Summary
- Harden prompt-context sensitive-data assertion to scan `payload.systemPrompt` directly for secret/debug patterns.
- Require all three safe free-plan tool names in the free-plan prompt contract instead of accepting any one tool.
- Keeps default Promptfoo evals deterministic and no-cost; no production prompt/model/retrieval/tool behavior changes.

## Cost Decision
Ship now: deterministic prompt-context assertions catch secret leakage and free-tool prompt regressions with no model calls, DB, Clerk, Stripe, Spotify, or external services.

Re-evaluate when: deterministic eval runtime exceeds 90 seconds on PR CI or live manual evals catch a release-blocking prompt-context regression twice in 30 days.

Then: split the deterministic Promptfoo gate by metadata target or add a capped live subset with explicit `JOVIE_RUN_LIVE_EVALS=1`, concurrency 1, and a per-run budget.

## Verification
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml`
- `unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY XAI_API_KEY; pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern '^Prompt context' --no-cache` → 7/7 passing
- `unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY XAI_API_KEY; pnpm run evals` → 136/136 passing
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml && git diff --check`
- Pre-push hook: repo Biome, web proxy guard, Tailwind guard, web typecheck, web lint

Refs JOV-2596
