### PR TITLE
test(promptfoo): cover onboarding tool sequence

### DIFF
--- a/apps/web/tests/eval/promptfoo/README.md
+++ b/apps/web/tests/eval/promptfoo/README.md
@@ -3,6 +3,7 @@
 Runs a small Promptfoo suite against local adapters:
 
 - Deterministic contract adapters for chat and onboarding tool availability, production tool-access gating, schemas, tool UI registry coverage, model-routing scenario inventory, knowledge-topic routing, prompt/context assembly safety, onboarding next-step state decisions, stubbed outputs, and no-spend guarantees.
+- A deterministic onboarding tool-sequence adapter, covering Spotify confirmation before observation, observation before next-step evaluation, checkout only after instant access, waitlist without checkout, and blocking premature next-step attempts before artist identity.
 - The production `executeChatTurn()` path used by `/api/chat`, with synthetic Luna Waves fixtures and eval-only tool stubs. This live path is manual-only because it calls the model provider.
 - A deterministic route-contract adapter for `POST /api/chat`, covering unauthenticated requests, branch-ordering for the chat kill switch, invalid JSON, message validation, missing profile context, client-turn preconditions, rate-limit responses, and contract-only pre-dispatch success without starting Next, Clerk, or the database.
 - A deterministic route-contract adapter for `POST /api/mobile/v1/chat/turns`, covering unauthenticated, invalid JSON, invalid-body variants, and `MOBILE_CHAT_RUNTIME_DISABLED` responses without starting Next or Clerk.

--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -1464,6 +1464,185 @@ function assertOnboardingStateDecision(output) {
   return pass();
 }
 
+function onboardingSequencePayload(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'onboarding-tool-sequence-contract') {
+    return {
+      payload,
+      error: 'case did not run through the onboarding tool-sequence adapter',
+    };
+  }
+
+  return { payload, error: null };
+}
+
+function sequenceToolOrder(payload) {
+  return Array.isArray(payload.toolCallOrder) ? payload.toolCallOrder : [];
+}
+
+function sequenceToolResults(payload) {
+  return Array.isArray(payload.toolResults) ? payload.toolResults : [];
+}
+
+function sequenceIndex(payload, toolName) {
+  return sequenceToolOrder(payload).indexOf(toolName);
+}
+
+function assertOnboardingSequenceNoSpend(output) {
+  const { payload, error } = onboardingSequencePayload(output);
+  if (error) return fail(error);
+
+  if (payload.costTier !== 'deterministic') {
+    return fail('onboarding sequence case is not marked deterministic');
+  }
+  if (payload.modelCalled !== false || payload.selectedModel !== null) {
+    return fail('onboarding sequence crossed the model boundary');
+  }
+  if (payload.persistenceAttempted !== false || payload.dbAttempted !== false) {
+    return fail('onboarding sequence crossed the persistence boundary');
+  }
+  if (payload.networkAttempted !== false) {
+    return fail('onboarding sequence crossed the network boundary');
+  }
+
+  return pass();
+}
+
+function assertOnboardingSequenceOrder(output) {
+  const { payload, error } = onboardingSequencePayload(output);
+  if (error) return fail(error);
+
+  const order = sequenceToolOrder(payload);
+  if (
+    order.length === 0 &&
+    payload.sequenceCase !== 'premature-next-step-blocked-before-identity'
+  ) {
+    return fail('onboarding sequence did not execute any tools');
+  }
+  if (order.some(toolName => !payload.availableToolNames?.includes(toolName))) {
+    return fail(`sequence used unavailable tool: ${order.join(', ')}`);
+  }
+
+  return pass();
+}
+
+function assertOnboardingObservationAfterSpotify(output) {
+  const { payload, error } = onboardingSequencePayload(output);
+  if (error) return fail(error);
+
+  if (payload.sequenceCase !== 'spotify-confirmation-observation-next-step') {
+    return fail(
+      'sequence case is not spotify-confirmation-observation-next-step'
+    );
+  }
+  const confirmIndex = sequenceIndex(payload, 'confirmSpotifyArtist');
+  const signalIndex = sequenceIndex(payload, 'recordInterviewSignal');
+  const nextStepIndex = sequenceIndex(payload, 'proposeNextStep');
+  if (
+    !(
+      confirmIndex >= 0 &&
+      signalIndex > confirmIndex &&
+      nextStepIndex > signalIndex
+    )
+  ) {
+    return fail('Spotify confirmation, signal, and next step were not ordered');
+  }
+  if (payload.stateAfter?.spotifyArtistId !== 'spotify-luna-123') {
+    return fail('Spotify confirmation did not update onboarding state');
+  }
+  if (payload.stateAfter?.signals?.length !== 1) {
+    return fail('Spotify observation did not record exactly one signal');
+  }
+  if (payload.nextStepDecision?.kind !== 'instant_access') {
+    return fail('confirmed Spotify sequence did not reach instant access');
+  }
+
+  return pass();
+}
+
+function assertOnboardingCheckoutAfterInstantAccess(output) {
+  const { payload, error } = onboardingSequencePayload(output);
+  if (error) return fail(error);
+
+  if (payload.sequenceCase !== 'instant-access-next-step-before-checkout') {
+    return fail(
+      'sequence case is not instant-access-next-step-before-checkout'
+    );
+  }
+  const nextStepIndex = sequenceIndex(payload, 'proposeNextStep');
+  const checkoutIndex = sequenceIndex(payload, 'proposeCheckout');
+  if (payload.nextStepDecision?.kind !== 'instant_access') {
+    return fail('checkout sequence did not first produce instant access');
+  }
+  if (!(checkoutIndex > nextStepIndex && nextStepIndex >= 0)) {
+    return fail('checkout was not called after proposeNextStep');
+  }
+  const checkoutResult = sequenceToolResults(payload).find(
+    result => result.toolName === 'proposeCheckout'
+  );
+  if (
+    !/\/onboarding\/checkout\?plan=pro/.test(
+      checkoutResult?.output?.handoffUrl ?? ''
+    )
+  ) {
+    return fail('checkout handoff URL is missing the Pro onboarding route');
+  }
+
+  return pass();
+}
+
+function assertOnboardingNoCheckoutForWaitlist(output) {
+  const { payload, error } = onboardingSequencePayload(output);
+  if (error) return fail(error);
+
+  if (payload.sequenceCase !== 'waitlist-outcome-no-checkout') {
+    return fail('sequence case is not waitlist-outcome-no-checkout');
+  }
+  if (payload.nextStepDecision?.kind !== 'waitlist') {
+    return fail('waitlist sequence did not produce a waitlist decision');
+  }
+  if (payload.checkoutCalled !== false) {
+    return fail('waitlist sequence called checkout');
+  }
+  if (sequenceToolOrder(payload).includes('proposeCheckout')) {
+    return fail('waitlist sequence included proposeCheckout in order');
+  }
+
+  return pass();
+}
+
+function assertOnboardingBlocksPrematureNextStep(output) {
+  const { payload, error } = onboardingSequencePayload(output);
+  if (error) return fail(error);
+
+  if (payload.sequenceCase !== 'premature-next-step-blocked-before-identity') {
+    return fail(
+      'sequence case is not premature-next-step-blocked-before-identity'
+    );
+  }
+  const blocked = Array.isArray(payload.blockedSteps)
+    ? payload.blockedSteps
+    : [];
+  if (
+    !blocked.some(
+      step =>
+        step.toolName === 'proposeNextStep' &&
+        step.reason === 'spotify_identity_missing'
+    )
+  ) {
+    return fail('premature next step was not blocked on Spotify identity');
+  }
+  if (sequenceToolOrder(payload).includes('proposeNextStep')) {
+    return fail('blocked sequence still executed proposeNextStep');
+  }
+  if (sequenceToolOrder(payload)[0] !== 'searchSpotifyArtist') {
+    return fail('blocked sequence did not route back to Spotify search');
+  }
+
+  return pass();
+}
+
 function assertKnowledgeContractNoSpend(output) {
   const payload = parseOutput(output);
 
@@ -2745,6 +2924,7 @@ function assertEvalCaseInventoryCovered(output) {
     'missingPromptContextCaseNames',
     'missingToolAccessCaseNames',
     'missingOnboardingStateCaseNames',
+    'missingOnboardingToolSequenceCaseNames',
     'missingWelcomeChatCaseNames',
   ]) {
     const values = payload[field];
@@ -2810,6 +2990,12 @@ module.exports = {
   assertToolDidNotExecute,
   assertOnboardingStateNoSpend,
   assertOnboardingStateDecision,
+  assertOnboardingSequenceNoSpend,
+  assertOnboardingSequenceOrder,
+  assertOnboardingObservationAfterSpotify,
+  assertOnboardingCheckoutAfterInstantAccess,
+  assertOnboardingNoCheckoutForWaitlist,
+  assertOnboardingBlocksPrematureNextStep,
   assertKnowledgeContractNoSpend,
   assertKnowledgeTopicsSelected,
   assertKnowledgeTopicCap,

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -70,6 +70,7 @@ type EvalTarget =
   | 'mobile-chat-route'
   | 'onboarding-welcome-chat-contract'
   | 'onboarding-state-contract'
+  | 'onboarding-tool-sequence-contract'
   | 'prompt-context-contract'
   | 'tool-access-contract'
   | 'tool-contract'
@@ -394,6 +395,12 @@ const REQUIRED_ONBOARDING_STATE_CASES = [
   'weak-signal-force-waitlist',
   'weak-signal-needs-more-info',
 ] as const;
+const REQUIRED_ONBOARDING_TOOL_SEQUENCE_CASES = [
+  'instant-access-next-step-before-checkout',
+  'premature-next-step-blocked-before-identity',
+  'spotify-confirmation-observation-next-step',
+  'waitlist-outcome-no-checkout',
+] as const;
 const REQUIRED_WELCOME_CHAT_CASES = [
   'claims-current-session-orphan-before-creating-new',
   'creates-new-welcome-chat-with-route-panel-profile-from-onboarding',
@@ -477,6 +484,7 @@ function toTarget(value: unknown): EvalTarget {
     value === 'model-contract' ||
     value === 'onboarding-welcome-chat-contract' ||
     value === 'onboarding-state-contract' ||
+    value === 'onboarding-tool-sequence-contract' ||
     value === 'prompt-context-contract' ||
     value === 'tool-access-contract' ||
     value === 'tool-contract' ||
@@ -3232,6 +3240,209 @@ function evaluateOnboardingStateContract(vars: EvalVars) {
   };
 }
 
+function executeSequenceSpotifyConfirmation(
+  state: EvalOnboardingState,
+  spotifyArtistId = 'spotify-luna-123'
+): ToolExecution {
+  const input = { spotifyArtistId };
+  const output = defaultToolResult('confirmSpotifyArtist', input);
+  const artist = toObject(toObject(output).artist);
+
+  state.spotifyArtistId = spotifyArtistId;
+  state.spotifyArtistName =
+    typeof artist.name === 'string' ? artist.name : 'Luna Waves';
+  state.spotifyImageUrl =
+    typeof artist.imageUrl === 'string' ? artist.imageUrl : null;
+  state.spotifyGenres = Array.isArray(artist.genres)
+    ? artist.genres.filter(
+        (genre): genre is string => typeof genre === 'string'
+      )
+    : [];
+  state.spotifyPopularity = nullableNumber(artist.popularity);
+  state.spotifyFollowers = nullableNumber(artist.followers);
+
+  return { name: 'confirmSpotifyArtist', input, output };
+}
+
+function executeSequenceHandleCheck(handle = 'lunawaves'): ToolExecution {
+  const input = { handle };
+
+  return {
+    name: 'checkHandle',
+    input,
+    output: defaultToolResult('checkHandle', input),
+  };
+}
+
+function executeSequenceSignal(
+  state: EvalOnboardingState,
+  signal: EvalInterviewSignal
+): ToolExecution {
+  const parsed = interviewSignalSchema.parse(signal);
+  state.signals.push(parsed);
+
+  return {
+    name: 'recordInterviewSignal',
+    input: parsed,
+    output: {
+      action: 'signal_recorded',
+      signalCount: state.signals.length,
+      summary: 'Signal noted.',
+    },
+  };
+}
+
+function sequenceNextStepDecision(state: EvalOnboardingState) {
+  const timestampBase = WEB_CHAT_EVAL_EPOCH_SECONDS * 1000;
+  const collapsedSignal = collapseInterviewSignals(
+    state.signals.map((signal, index) => ({
+      ...signal,
+      recordedAt: new Date(timestampBase + index * 1000).toISOString(),
+    }))
+  );
+  const nextStepDecision = evaluateAccessSignal({
+    signal: collapsedSignal,
+    spotifyFollowers: state.spotifyFollowers,
+    turnCount: state.turnCount,
+  });
+
+  return { collapsedSignal, nextStepDecision };
+}
+
+function executeSequenceNextStep(state: EvalOnboardingState): {
+  readonly execution: ToolExecution;
+  readonly collapsedSignal: EvalInterviewSignal;
+  readonly nextStepDecision: ReturnType<typeof evaluateAccessSignal>;
+} {
+  const { collapsedSignal, nextStepDecision } = sequenceNextStepDecision(state);
+  const output = {
+    action: 'propose_next_step',
+    decision: nextStepDecision,
+    summary: `Next step: ${nextStepDecision.kind.replaceAll('_', ' ')}.`,
+  };
+
+  return {
+    execution: {
+      name: 'proposeNextStep',
+      input: {},
+      output,
+    },
+    collapsedSignal,
+    nextStepDecision,
+  };
+}
+
+function executeSequenceCheckout(plan: 'pro' | 'max' | 'free' = 'pro') {
+  const input = { plan };
+
+  return {
+    name: 'proposeCheckout',
+    input,
+    output: defaultToolResult('proposeCheckout', input),
+  };
+}
+
+function evaluateOnboardingToolSequenceContract(vars: EvalVars) {
+  const sequenceCase =
+    typeof vars.sequenceCase === 'string'
+      ? vars.sequenceCase
+      : 'spotify-confirmation-observation-next-step';
+  const state = createEvalOnboardingState(vars);
+  const stateBefore = cloneJson(state);
+  const toolExecutions: ToolExecution[] = [];
+  const blockedSteps: Array<{
+    readonly toolName: string;
+    readonly reason: string;
+  }> = [];
+  let collapsedSignal: EvalInterviewSignal = {};
+  let nextStepDecision: ReturnType<typeof evaluateAccessSignal> | null = null;
+
+  if (sequenceCase === 'premature-next-step-blocked-before-identity') {
+    blockedSteps.push({
+      toolName: 'proposeNextStep',
+      reason: 'spotify_identity_missing',
+    });
+    toolExecutions.push({
+      name: 'searchSpotifyArtist',
+      input: { query: 'Luna Waves' },
+      output: defaultToolResult('searchSpotifyArtist', { query: 'Luna Waves' }),
+    });
+  } else if (sequenceCase === 'waitlist-outcome-no-checkout') {
+    state.turnCount = MAX_INTERVIEW_TURNS_BEFORE_FORCE;
+    toolExecutions.push(
+      executeSequenceSignal(state, { audienceBand: 'under_500' })
+    );
+    const nextStep = executeSequenceNextStep(state);
+    collapsedSignal = nextStep.collapsedSignal;
+    nextStepDecision = nextStep.nextStepDecision;
+    toolExecutions.push(nextStep.execution);
+  } else {
+    toolExecutions.push(executeSequenceSpotifyConfirmation(state));
+
+    if (sequenceCase === 'instant-access-next-step-before-checkout') {
+      toolExecutions.push(executeSequenceHandleCheck());
+      toolExecutions.push(
+        executeSequenceSignal(state, {
+          releaseStage: 'announced_unreleased',
+          audienceBand: '500_to_5k',
+        })
+      );
+    } else {
+      toolExecutions.push(
+        executeSequenceSignal(state, {
+          audienceBand: '5k_to_50k',
+          freeNote: 'Spotify profile confirmed with 12500 followers.',
+        })
+      );
+    }
+
+    const nextStep = executeSequenceNextStep(state);
+    collapsedSignal = nextStep.collapsedSignal;
+    nextStepDecision = nextStep.nextStepDecision;
+    toolExecutions.push(nextStep.execution);
+
+    if (
+      sequenceCase === 'instant-access-next-step-before-checkout' &&
+      nextStepDecision.kind === 'instant_access'
+    ) {
+      toolExecutions.push(executeSequenceCheckout('pro'));
+    }
+  }
+
+  const toolCallOrder = toolExecutions.map(execution => execution.name);
+
+  return {
+    target: 'onboarding-tool-sequence-contract',
+    adapter: 'onboarding-tool-sequence-contract',
+    costTier: 'deterministic',
+    text: '',
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    dbAttempted: false,
+    networkAttempted: false,
+    sequenceCase,
+    mode: 'onboarding',
+    availableToolNames: [...ONBOARDING_TOOLS],
+    stateBefore,
+    stateAfter: cloneJson(state),
+    blockedSteps,
+    toolCallOrder,
+    collapsedSignal,
+    nextStepDecision,
+    checkoutCalled: toolCallOrder.includes('proposeCheckout'),
+    toolCalls: toolExecutions.map(execution => ({
+      toolName: execution.name,
+      input: execution.input,
+    })),
+    toolResults: toolExecutions.map(execution => ({
+      toolName: execution.name,
+      output: execution.output,
+    })),
+    toolExecutions,
+  };
+}
+
 function buildEvalTools(
   toolNames: readonly string[],
   vars: EvalVars,
@@ -3989,6 +4200,7 @@ type EvalCaseSummary = {
   readonly knowledgeCase: string | null;
   readonly promptCase: string | null;
   readonly renderCase: string | null;
+  readonly sequenceCase: string | null;
   readonly stateCase: string | null;
   readonly welcomeCase: string | null;
   readonly mode: string | null;
@@ -4079,6 +4291,7 @@ function parseEvalCaseSummary(block: string): EvalCaseSummary {
     knowledgeCase: scalarValue(block, 'knowledgeCase'),
     promptCase: scalarValue(block, 'promptCase'),
     renderCase: scalarValue(block, 'renderCase'),
+    sequenceCase: scalarValue(block, 'sequenceCase'),
     stateCase: scalarValue(block, 'stateCase'),
     welcomeCase: scalarValue(block, 'welcomeCase'),
     mode: scalarValue(block, 'mode') ?? 'app',
@@ -4231,6 +4444,17 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
       .map(testCase => testCase.stateCase)
       .filter((stateCase): stateCase is string => typeof stateCase === 'string')
   );
+  const onboardingToolSequenceCaseNames = uniqueSorted(
+    deterministicCases
+      .filter(
+        testCase => testCase.target === 'onboarding-tool-sequence-contract'
+      )
+      .map(testCase => testCase.sequenceCase)
+      .filter(
+        (sequenceCase): sequenceCase is string =>
+          typeof sequenceCase === 'string'
+      )
+  );
   const welcomeChatCaseNames = uniqueSorted(
     deterministicCases
       .filter(
@@ -4349,6 +4573,14 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
     missingOnboardingStateCaseNames: missingNames(
       REQUIRED_ONBOARDING_STATE_CASES,
       onboardingStateCaseNames
+    ),
+    requiredOnboardingToolSequenceCaseNames: [
+      ...REQUIRED_ONBOARDING_TOOL_SEQUENCE_CASES,
+    ],
+    onboardingToolSequenceCaseNames,
+    missingOnboardingToolSequenceCaseNames: missingNames(
+      REQUIRED_ONBOARDING_TOOL_SEQUENCE_CASES,
+      onboardingToolSequenceCaseNames
     ),
     requiredWelcomeChatCaseNames: [...REQUIRED_WELCOME_CHAT_CASES],
     welcomeChatCaseNames,
@@ -4490,6 +4722,16 @@ export default class JovieChatPromptfooProvider {
 
     if (target === 'onboarding-state-contract') {
       const payload = evaluateOnboardingStateContract(vars);
+      return {
+        output: JSON.stringify(payload),
+        raw: payload,
+        format: 'json',
+        latencyMs: Date.now() - startedAt,
+      };
+    }
+
+    if (target === 'onboarding-tool-sequence-contract') {
+      const payload = evaluateOnboardingToolSequenceContract(vars);
       return {
         output: JSON.stringify(payload),
         raw: payload,

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -2516,6 +2516,70 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertOnboardingStateDecision
 
+  - description: Onboarding sequence records Spotify observation before next step
+    metadata:
+      cost: deterministic
+    vars:
+      input: "I selected Luna Waves on Spotify."
+      target: onboarding-tool-sequence-contract
+      sequenceCase: spotify-confirmation-observation-next-step
+      turnCount: 1
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingSequenceNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingSequenceOrder
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingObservationAfterSpotify
+
+  - description: Onboarding sequence calls checkout only after instant access
+    metadata:
+      cost: deterministic
+    vars:
+      input: "I have a single announced and want to join now."
+      target: onboarding-tool-sequence-contract
+      sequenceCase: instant-access-next-step-before-checkout
+      turnCount: 1
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingSequenceNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingSequenceOrder
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingCheckoutAfterInstantAccess
+
+  - description: Onboarding sequence never checks out waitlist outcome
+    metadata:
+      cost: deterministic
+    vars:
+      input: "I'm still early and do not have much audience yet."
+      target: onboarding-tool-sequence-contract
+      sequenceCase: waitlist-outcome-no-checkout
+      turnCount: 3
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingSequenceNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingSequenceOrder
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingNoCheckoutForWaitlist
+
+  - description: Onboarding sequence blocks next step before artist identity
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Can I sign up now?"
+      target: onboarding-tool-sequence-contract
+      sequenceCase: premature-next-step-blocked-before-identity
+      turnCount: 1
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingSequenceNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingSequenceOrder
+      - type: javascript
+        value: file://assertions.cjs:assertOnboardingBlocksPrematureNextStep
+
   - description: Free plan blocks paid album art tool
     metadata:
       cost: deterministic


### PR DESCRIPTION
## Summary
- Add a deterministic Promptfoo adapter for onboarding tool sequencing.
- Cover Spotify confirmation before observation, observation before next-step evaluation, checkout only after instant access, waitlist without checkout, and blocking premature next-step attempts before artist identity.
- Add inventory coverage so required onboarding sequence cases cannot silently drop out of the default deterministic suite.

## Cost Decision
Ship now: deterministic sequence coverage raises the default no-cost gate from 143 to 147 cases and keeps model, DB, Clerk, Spotify, Stripe, Vercel, and local Next out of `pnpm run evals`.

Re-evaluate when: live/manual onboarding eval failures catch a release-blocking sequence regression twice in 30 days, or the observed live eval cost stays under the agreed per-run budget for a full release cycle.

Then: add a PR-gated or scheduled live subset with capped case count, concurrency 1, and explicit `JOVIE_RUN_LIVE_EVALS=1` opt-in.

## Verification
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml`
- `unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY XAI_API_KEY; pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern '^Onboarding sequence' --no-cache` - 4/4 passed
- `unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY XAI_API_KEY; pnpm run evals` - 147/147 passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml`
- Pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, web `typecheck`, web `lint`

## Notes
- `typecheck:tests` remains blocked by the existing broad test-typecheck backlog tracked in JOV-2582; this PR only touches the Promptfoo eval harness.

Refs JOV-2596