### PR TITLE
test(promptfoo): address chat confirmation review

### DIFF
--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -996,7 +996,8 @@ function assertChatConfirmRouteUnauthorized(output) {
   if (payload.responseJson?.error !== 'Unauthorized') {
     return fail('missing Unauthorized response body');
   }
-  if (/luna\.private@example\.com/i.test(payload.responseText ?? '')) {
+  const publicResponseSurface = `${String(payload.responseText ?? '')}\n${JSON.stringify(payload.responseJson ?? {})}`;
+  if (/luna\.private@example\.com/i.test(publicResponseSurface)) {
     return fail(
       'unauthorized confirmation route echoed sensitive request data'
     );

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -986,7 +986,7 @@ function evaluateChatConfirmRouteContract(vars: EvalVars) {
   if (!parsed.success) {
     return response(400, {
       error: 'Invalid request',
-      details: parsed.error.flatten().fieldErrors,
+      details: parsed.error.flatten(),
     });
   }
 

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -822,7 +822,7 @@ tests:
       confirmRouteCase: confirm-edit-unauthorized
       authenticated: false
       body:
-        profileId: 00000000-0000-4000-8000-000000002561
+        profileId: not-a-uuid
         field: displayName
         newValue: "Luna private contact luna.private@example.com"
     assert:


### PR DESCRIPTION
## Summary
- Addresses JOV-2598 by landing the Promptfoo chat-confirmation review fixes that arrived after PR #9721 merged.
- Scans structured unauthorized responses for synthetic sensitive data, normalizes album-art invalid-request details, and makes the auth-before-parse fixture parse-invalid.
- Keeps the suite deterministic and no-cost; no production prompts, models, retrieval, route handlers, tool schemas, auth, billing, or persistence behavior changed.

## Cost Decision
Ship now: land the three deterministic Promptfoo harness fixes with zero model calls and no external services.
Re-evaluate when: CodeRabbit or CI reports the same confirmation-route assertion gap again within 30 days.
Then: fold the repeated gap into the JOV-2587 live HTTP fixture plan with capped manual cases.

## Verification
- `unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY XAI_API_KEY; pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml`
- `unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY XAI_API_KEY; pnpm run evals`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml && git diff --check`
- pre-push hook: repo Biome, web proxy guard, Tailwind guard, web typecheck, web lint

## Notes
- `typecheck:tests` remains tracked by JOV-2582 and was not part of this narrow review-fix PR.

Linear: JOV-2598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation coverage for sensitive data handling in responses
  * Increased error response detail levels for invalid request payloads
  * Strengthened authentication validation test requirements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->