### PR TITLE
test(promptfoo): align album art contract eval

### DIFF
--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -986,7 +986,7 @@ function evaluateChatConfirmRouteContract(vars: EvalVars) {
   if (!parsed.success) {
     return response(400, {
       error: 'Invalid request',
-      details: parsed.error.flatten(),
+      details: parsed.error.flatten().fieldErrors,
     });
   }
 


### PR DESCRIPTION
## Summary
- Fixes JOV-2599.
- Aligns the deterministic Promptfoo album-art apply invalid-request stub with the production route helper by returning Zod field errors only.
- Keeps production prompts, model settings, retrieval, tool schemas, route behavior, persistence, and app behavior unchanged.

## Cost decision
Ship now: land the one-line deterministic contract fix because CodeRabbit identified a real eval-vs-route mismatch and the run cost is no-cost local/CI Promptfoo coverage.
Re-evaluate when: deterministic route-contract mismatches recur twice in 30 days or fixing them costs more than 15 CI minutes plus 15 agent minutes per occurrence.
Then: add an automated parity helper for shared route error shapes under a tracked Linear issue.

## Verification
- `pnpm biome check --write apps/web/tests/eval/promptfoo/jovie-chat-provider.ts`
- `unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY XAI_API_KEY; pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern 'Album-art apply|Eval case inventory' --no-cache` (5/5)
- `unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY XAI_API_KEY; pnpm run evals` (170/170)
- `unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY XAI_API_KEY; pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml && git diff --check`
- pre-push hook: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint
