### PR TITLE
test(promptfoo): cover bio import url guardrails

### DIFF
--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -207,7 +207,13 @@ const ADVANCED_TOOL_SCHEMAS = {
     inputSchema: z.object({
       field: z.enum(['displayName', 'bio']),
       newValue: z.string().min(1).max(500),
-      sourceUrl: z.string().url().optional(),
+      sourceUrl: z
+        .string()
+        .url()
+        .refine(value => value.startsWith('https://'), {
+          message: 'sourceUrl must be https',
+        })
+        .optional(),
       sourceTitle: z.string().max(200).optional(),
     }),
   },
@@ -432,6 +438,7 @@ const REQUIRED_ONBOARDING_UNAVAILABLE_TOOL_NAMES = [
   'submitFeedback',
 ] as const;
 const REQUIRED_SEMANTIC_INVALID_TOOL_NAMES = [
+  'importBioFromUrl',
   'proposeSocialLink',
   'proposeSocialLinkRemoval',
 ] as const;
@@ -4445,6 +4452,38 @@ function schemaErrorMessages(result: { error?: { issues?: unknown[] } }) {
   });
 }
 
+function isBlockedBioImportHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  if (
+    normalized === 'localhost' ||
+    normalized === '0.0.0.0' ||
+    normalized === '::1' ||
+    normalized === '[::1]' ||
+    normalized.endsWith('.local')
+  ) {
+    return true;
+  }
+
+  const ipv4Match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(
+    normalized
+  );
+  if (!ipv4Match) return false;
+
+  const octets = ipv4Match.slice(1).map(Number);
+  if (octets.some(octet => !Number.isInteger(octet) || octet > 255)) {
+    return true;
+  }
+
+  const [first = 0, second = 0] = octets;
+  return (
+    first === 10 ||
+    first === 127 ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168)
+  );
+}
+
 function semanticToolInputErrors(toolName: string, input: unknown): string[] {
   const args = toObject(input);
 
@@ -4459,6 +4498,27 @@ function semanticToolInputErrors(toolName: string, input: unknown): string[] {
       }
     } catch {
       return ['url: Provide a valid full URL'];
+    }
+  }
+
+  if (toolName === 'importBioFromUrl') {
+    const url = typeof args.url === 'string' ? args.url.trim() : '';
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol !== 'https:') {
+        return ['url: Provide a public https URL'];
+      }
+      if (parsed.username || parsed.password) {
+        return ['url: Userinfo is not allowed in bio import URLs'];
+      }
+      if (
+        parsed.hostname.endsWith('.') ||
+        isBlockedBioImportHostname(parsed.hostname)
+      ) {
+        return ['url: Provide a public https URL'];
+      }
+    } catch {
+      return ['url: Provide a valid public https URL'];
     }
   }
 

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -3469,6 +3469,74 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertToolSchemaInvalid
 
+  - description: Non-HTTPS profile edit provenance URL does not execute
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Preview this imported bio with provenance."
+      target: tool-contract
+      toolName: proposeProfileEdit
+      mode: app
+      plan: pro
+      toolInput:
+        field: bio
+        newValue: "Luna Waves makes ambient electronic songs for late-night drives."
+        sourceUrl: http://lunawaves.example/press
+        sourceTitle: "Luna Waves press kit"
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaInvalid
+
+  - description: Non-HTTPS bio import URL does not execute
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Import my bio from this press kit."
+      target: tool-contract
+      toolName: importBioFromUrl
+      mode: app
+      plan: pro
+      toolInput:
+        url: http://lunawaves.example/press
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolSemanticInvalid
+      - type: javascript
+        value: file://assertions.cjs:assertToolDidNotExecute
+
+  - description: Internal bio import URL does not execute
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Import my bio from this local press kit."
+      target: tool-contract
+      toolName: importBioFromUrl
+      mode: app
+      plan: pro
+      toolInput:
+        url: https://localhost/press
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolSemanticInvalid
+      - type: javascript
+        value: file://assertions.cjs:assertToolDidNotExecute
+
   - description: Unsafe social link argument does not execute
     metadata:
       cost: deterministic


### PR DESCRIPTION
## Summary
- Fixes JOV-2600.
- Aligns the eval-only `proposeProfileEdit.sourceUrl` schema with production's HTTPS provenance rule.
- Adds deterministic no-execute guardrail cases for non-HTTPS and internal-style `importBioFromUrl` inputs.
- Keeps production prompts, model settings, retrieval, routes, tool schemas, DB, Clerk, Spotify, Stripe, and live services unchanged.

## Cost decision
Ship now: URL provenance and bio import are high-risk user-supplied inputs, and this adds no-cost deterministic Promptfoo coverage without model/provider calls.
Re-evaluate when: default deterministic eval runtime rises above 90 seconds locally or URL guardrail drift recurs twice in 30 days.
Then: extract shared eval validators from production-safe URL helpers under a tracked Linear issue.

## Verification
- `pnpm biome check --write apps/web/tests/eval/promptfoo/jovie-chat-provider.ts apps/web/tests/eval/promptfoo/promptfooconfig.yaml`
- `unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY XAI_API_KEY; pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern 'profile edit provenance|bio import URL|Eval case inventory' --no-cache` (4/4)
- `unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY XAI_API_KEY; pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml`
- `unset AI_GATEWAY_API_KEY OPENAI_API_KEY ANTHROPIC_API_KEY XAI_API_KEY; pnpm run evals` (173/173)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml && git diff --check`
- pre-push hook: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint

<!-- agent-run-artifact
{
  "id": "run-jov-2600-bio-import-url-guardrails",
  "source": "github",
  "sourceRunId": "e792cc72eb24879f9c64f8fa491db88e52a018d2",
  "kind": "deploy_readiness",
  "status": "done",
  "title": "Promptfoo bio import URL guardrail gates",
  "summary": "Recorded deterministic QA, review, and ship evidence for the JOV-2600 Promptfoo URL guardrail coverage PR.",
  "modelRoute": "deterministic",
  "allowedActions": ["read", "open_pr", "ready_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_linear", "send_outbound", "mutate_production_data", "change_auth", "change_billing", "change_security"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2600",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2600/add-promptfoo-url-guardrail-coverage-for-bio-import-tools",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9728",
  "adminSurface": "/app/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9728",
      "summary": "Deterministic Promptfoo QA passed locally with AI keys unset: focused URL guardrail slice 4/4, full pnpm run evals 173/173, promptfoo validate, web typecheck, Biome/diff check, and pre-push hook.",
      "checkedAt": "2026-05-26T00:25:30.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9728",
      "summary": "Reviewed the eval-only diff against production profile-edit and bio-import URL guardrails; production behavior was intentionally unchanged.",
      "checkedAt": "2026-05-26T00:26:00.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": "https://github.com/JovieInc/Jovie/pull/9728",
      "summary": "Shipped via draft PR with no-cost deterministic eval evidence; default eval path remains deterministic-only.",
      "checkedAt": "2026-05-26T00:26:15.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": "No live model call was made for deterministic Promptfoo evals; AI provider keys were unset locally."
  },
  "blockedReason": null,
  "createdAt": "2026-05-26T00:25:30.000Z",
  "updatedAt": "2026-05-26T00:26:15.000Z",
  "metadata": {
    "branch": "codex/jov-2600-bio-import-url-guardrails",
    "commit": "e792cc72eb24879f9c64f8fa491db88e52a018d2",
    "localPromptfooDeterministic": "173/173",
    "focusedPromptfoo": "4/4"
  }
}
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Restricted profile and bio imports to public HTTPS URLs only.
  * Added validation to prevent imports from private, local, or internal network addresses.
  * Enhanced URL format validation to reject unsafe import sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9728?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->