### PR TITLE
test(promptfoo): cover chat title generation

### DIFF
--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -3871,6 +3871,89 @@ function assertOnboardingSystemPromptContractCovered(output) {
   return pass();
 }
 
+function assertChatTitleContractCovered(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'chat-title-contract') {
+    return fail('case did not run through the chat-title-contract adapter');
+  }
+  if (payload.titleCase !== 'prompt-and-fallback') {
+    return fail(
+      `expected prompt-and-fallback title case, got ${String(payload.titleCase)}`
+    );
+  }
+  if (payload.costTier !== 'deterministic') {
+    return fail('chat title case is not marked deterministic');
+  }
+  for (const field of [
+    'modelCalled',
+    'persistenceAttempted',
+    'dbAttempted',
+    'networkAttempted',
+  ]) {
+    if (payload[field] !== false) {
+      return fail(`${field} should be false for chat title coverage`);
+    }
+  }
+  if (
+    payload.productionEntrypoint !==
+    'apps/web/app/api/chat/conversations/[id]/messages/route.ts:maybeGenerateTitle'
+  ) {
+    return fail('chat title contract did not inspect the production route');
+  }
+  if (payload.titleModel !== 'google/gemini-2.0-flash') {
+    return fail(`unexpected title model: ${String(payload.titleModel)}`);
+  }
+  if (
+    typeof payload.routeSourceLength !== 'number' ||
+    payload.routeSourceLength < 5000
+  ) {
+    return fail('chat title route source was unexpectedly short');
+  }
+  if (
+    typeof payload.systemPromptLength !== 'number' ||
+    payload.systemPromptLength < 100
+  ) {
+    return fail('chat title system prompt was unexpectedly short');
+  }
+  if (payload.guardedNullUpdateCount < 2) {
+    return fail('chat title route did not guard both title update paths');
+  }
+
+  for (const field of ['missingSourceFacts', 'missingRuntimeFacts']) {
+    const values = Array.isArray(payload[field]) ? payload[field] : null;
+    if (!values) {
+      return fail(`chat title contract missing ${field}`);
+    }
+    if (values.length > 0) {
+      return fail(`${field}: ${values.join(', ')}`);
+    }
+  }
+
+  const synthetic = payload.synthetic ?? {};
+  if (synthetic.generatedTitle !== 'Neon Reef Launch Plan') {
+    return fail('synthetic generated title was not sanitized');
+  }
+  if (
+    typeof synthetic.fallbackTitle !== 'string' ||
+    synthetic.fallbackTitle.length > 50 ||
+    !synthetic.fallbackTitle.endsWith('...')
+  ) {
+    return fail('synthetic fallback title was not truncated safely');
+  }
+
+  const leakPatterns = Array.isArray(payload.promptLeakPatterns)
+    ? payload.promptLeakPatterns
+    : [];
+  if (leakPatterns.length > 0) {
+    return fail(
+      `chat title prompt leaked patterns: ${leakPatterns.join(', ')}`
+    );
+  }
+
+  return pass();
+}
+
 function firstEvent(payload) {
   return Array.isArray(payload.events) ? payload.events[0] : undefined;
 }
@@ -4430,6 +4513,7 @@ function assertEvalCaseInventoryCovered(output) {
     'missingPromptContextCaseNames',
     'missingToolAccessCaseNames',
     'missingAiToolPromptCaseNames',
+    'missingChatTitleCaseNames',
     'missingInsightPromptCaseNames',
     'missingOnboardingSystemPromptCaseNames',
     'missingReleaseTaskClassifierCaseNames',
@@ -4568,6 +4652,7 @@ module.exports = {
   assertSkillCommandContractCovered,
   assertSkillPromptContractCovered,
   assertAiToolPromptContractCovered,
+  assertChatTitleContractCovered,
   assertInsightPromptContractCovered,
   assertOnboardingSystemPromptContractCovered,
   assertReleaseTaskClassifierContractCovered,

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -29,6 +29,7 @@ import {
   selectKnowledgeContextForTurn,
 } from '@/lib/chat/run';
 import { buildSystemPrompt } from '@/lib/chat/system-prompt';
+import { sanitizeConversationTitle } from '@/lib/chat/title';
 import {
   extractSkill,
   parseTokens,
@@ -65,7 +66,11 @@ import {
   commandsForSurface,
   HIDDEN_TOOLS,
 } from '@/lib/commands/registry';
-import { CHAT_MODEL, CHAT_MODEL_LIGHT } from '@/lib/constants/ai-models';
+import {
+  CHAT_MODEL,
+  CHAT_MODEL_LIGHT,
+  TITLE_MODEL,
+} from '@/lib/constants/ai-models';
 import {
   insertSkillsCatalogSchema,
   insertToolsCatalogSchema,
@@ -116,6 +121,7 @@ type EvalVars = Record<string, unknown>;
 type EvalTarget =
   | 'ai-tool-prompt-contract'
   | 'chat-confirm-route'
+  | 'chat-title-contract'
   | 'chat-turn'
   | 'eval-case-inventory'
   | 'insight-prompt-contract'
@@ -589,6 +595,7 @@ const REQUIRED_AI_TOOL_PROMPT_CASES = ['album-art-canvas-bio-prompts'] as const;
 const REQUIRED_INSIGHT_PROMPT_CASES = ['analytics-grounding-prompts'] as const;
 const REQUIRED_ONBOARDING_SYSTEM_PROMPT_CASES = ['prompt-rules'] as const;
 const REQUIRED_RELEASE_TASK_CLASSIFIER_CASES = ['prompt-and-coercion'] as const;
+const REQUIRED_CHAT_TITLE_CASES = ['prompt-and-fallback'] as const;
 let serverOnlyEvalShimRegistered = false;
 const AI_TOOL_PROMPT_TOOL_NAMES = [
   'generateAlbumArt',
@@ -733,6 +740,7 @@ function toTarget(value: unknown): EvalTarget {
   if (
     value === 'ai-tool-prompt-contract' ||
     value === 'chat-confirm-route' ||
+    value === 'chat-title-contract' ||
     value === 'chat-turn' ||
     value === 'eval-case-inventory' ||
     value === 'insight-prompt-contract' ||
@@ -6129,6 +6137,123 @@ function evaluateOnboardingSystemPromptContract(vars: EvalVars) {
   };
 }
 
+function evaluateChatTitleContract(vars: EvalVars) {
+  const titleCase =
+    typeof vars.chatTitleCase === 'string'
+      ? vars.chatTitleCase
+      : 'prompt-and-fallback';
+  const routeSourcePath = 'app/api/chat/conversations/[id]/messages/route.ts';
+  const routeSource = readFileSync(
+    resolve(process.cwd(), routeSourcePath),
+    'utf8'
+  );
+  const systemPrompt =
+    routeSource.match(/system:\s*'([^']+)'/)?.[1]?.trim() ?? '';
+  const guardedNullUpdateCount = [
+    ...routeSource.matchAll(/isNull\(chatConversations\.title\)/g),
+  ].length;
+  const sourceTitle = sanitizeConversationTitle(
+    'Help Luna Waves title a launch plan for Neon Reef, playlist pitching, and profile cleanup before release week.',
+    200
+  );
+  const fallbackTitle = sanitizeConversationTitle(sourceTitle, 50);
+  const generatedTitle = sanitizeConversationTitle('"Neon Reef Launch Plan"');
+  const sourceFacts = {
+    importsUserFacingRouteDependencies: textIncludesAll(routeSource, [
+      "import { gateway } from '@ai-sdk/gateway'",
+      "import { generateText } from '@/lib/ai/sdk'",
+      "import { TITLE_MODEL } from '@/lib/constants/ai-models'",
+    ]),
+    usesTitleModelConstant:
+      TITLE_MODEL === 'google/gemini-2.0-flash' &&
+      routeSource.includes('gateway(TITLE_MODEL)'),
+    keepsTitleOnlyPrompt: textIncludesAll(systemPrompt, [
+      'Generate a short, descriptive title',
+      '2-6 words',
+      'Return only the title text',
+      'no quotes',
+      'extra punctuation',
+    ]),
+    capsModelOutputAndDuration: textIncludesAll(routeSource, [
+      'maxOutputTokens: 30',
+      'AbortSignal.timeout(5000)',
+    ]),
+    redactsTitleTelemetryInputsAndOutputs: textIncludesAll(routeSource, [
+      'experimental_telemetry',
+      'recordInputs: false',
+      'recordOutputs: false',
+      "functionId: 'jovie-chat-title'",
+    ]),
+    sanitizesAllTitleInputsAndOutputs: textIncludesAll(routeSource, [
+      'sanitizeConversationTitle(userMessage?.content, 200)',
+      'sanitizeConversationTitle(m.content, 200)',
+      'sanitizeConversationTitle(text)',
+    ]),
+    guardsGeneratedAndFallbackUpdates: guardedNullUpdateCount >= 2,
+    fallsBackToSanitizedUserMessage: textIncludesAll(routeSource, [
+      'const fallback = sanitizeConversationTitle(titleSource, 50)',
+      'if (!fallback) return',
+    ]),
+    schedulesTitleGenerationAfterPersistence: textIncludesAll(routeSource, [
+      'const titlePending = hasUserMessage && !conversation.title',
+      'after(async () =>',
+      'await maybeGenerateTitle(conversationId, messagesToInsert)',
+    ]),
+  };
+  const runtimeFacts = {
+    syntheticGeneratedTitleSanitized:
+      generatedTitle === 'Neon Reef Launch Plan',
+    syntheticFallbackExists: typeof fallbackTitle === 'string',
+    syntheticFallbackTruncated:
+      typeof fallbackTitle === 'string' &&
+      fallbackTitle.length <= 50 &&
+      fallbackTitle.endsWith('...'),
+    syntheticSourceTitleSanitized:
+      typeof sourceTitle === 'string' &&
+      sourceTitle.includes('Luna Waves') &&
+      sourceTitle.includes('Neon Reef'),
+  };
+  const titlePromptLeakPatterns = promptLeakPatterns(systemPrompt);
+
+  return {
+    target: 'chat-title-contract',
+    adapter: 'chat-title-contract',
+    productionEntrypoint:
+      'apps/web/app/api/chat/conversations/[id]/messages/route.ts:maybeGenerateTitle',
+    costTier: 'deterministic',
+    text: '',
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    dbAttempted: false,
+    networkAttempted: false,
+    titleCase,
+    titleModel: TITLE_MODEL,
+    routeSourcePath,
+    routeSourceLength: routeSource.length,
+    systemPrompt,
+    systemPromptLength: systemPrompt.length,
+    guardedNullUpdateCount,
+    sourceFacts,
+    missingSourceFacts: Object.entries(sourceFacts)
+      .filter(([, passed]) => !passed)
+      .map(([name]) => name),
+    runtimeFacts,
+    missingRuntimeFacts: Object.entries(runtimeFacts)
+      .filter(([, passed]) => !passed)
+      .map(([name]) => name),
+    synthetic: {
+      generatedTitle,
+      sourceTitle,
+      fallbackTitle,
+    },
+    promptLeakPatterns: titlePromptLeakPatterns,
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
 async function evaluateReleaseTaskClassifierContract(vars: EvalVars) {
   const { classifyTaskCluster, CLASSIFIER_MIN_CONFIDENCE } =
     await importReleaseTaskClassifierModule();
@@ -7130,6 +7255,7 @@ type EvalCaseSummary = {
   readonly expectedModel: string | null;
   readonly eventCase: string | null;
   readonly aiToolPromptCase: string | null;
+  readonly chatTitleCase: string | null;
   readonly insightPromptCase: string | null;
   readonly onboardingSystemPromptCase: string | null;
   readonly releaseTaskClassifierCase: string | null;
@@ -7234,6 +7360,7 @@ function parseEvalCaseSummary(block: string): EvalCaseSummary {
     expectedModel: scalarValue(block, 'expectedModel'),
     eventCase: scalarValue(block, 'eventCase'),
     aiToolPromptCase: scalarValue(block, 'aiToolPromptCase'),
+    chatTitleCase: scalarValue(block, 'chatTitleCase'),
     insightPromptCase: scalarValue(block, 'insightPromptCase'),
     onboardingSystemPromptCase: scalarValue(
       block,
@@ -7468,6 +7595,15 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
       .filter(
         (aiToolPromptCase): aiToolPromptCase is string =>
           typeof aiToolPromptCase === 'string'
+      )
+  );
+  const chatTitleCaseNames = uniqueSorted(
+    deterministicCases
+      .filter(testCase => testCase.target === 'chat-title-contract')
+      .map(testCase => testCase.chatTitleCase)
+      .filter(
+        (chatTitleCase): chatTitleCase is string =>
+          typeof chatTitleCase === 'string'
       )
   );
   const insightPromptCaseNames = uniqueSorted(
@@ -7736,6 +7872,12 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
     missingAiToolPromptCaseNames: missingNames(
       REQUIRED_AI_TOOL_PROMPT_CASES,
       aiToolPromptCaseNames
+    ),
+    requiredChatTitleCaseNames: [...REQUIRED_CHAT_TITLE_CASES],
+    chatTitleCaseNames,
+    missingChatTitleCaseNames: missingNames(
+      REQUIRED_CHAT_TITLE_CASES,
+      chatTitleCaseNames
     ),
     requiredInsightPromptCaseNames: [...REQUIRED_INSIGHT_PROMPT_CASES],
     insightPromptCaseNames,
@@ -8020,6 +8162,11 @@ export default class JovieChatPromptfooProvider {
 
     if (target === 'onboarding-system-prompt-contract') {
       const payload = evaluateOnboardingSystemPromptContract(vars);
+      return jsonProviderResponse(payload, startedAt);
+    }
+
+    if (target === 'chat-title-contract') {
+      const payload = evaluateChatTitleContract(vars);
       return jsonProviderResponse(payload, startedAt);
     }
 

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -1665,6 +1665,19 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertOnboardingSystemPromptContractCovered
 
+  - description: Chat title generation preserves low-cost prompt and fallback
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Chat title generation contract check"
+      target: chat-title-contract
+      chatTitleCase: prompt-and-fallback
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertChatTitleContractCovered
+
   - description: Release task classifier uses stubbed prompt and coercion path
     metadata:
       cost: deterministic


### PR DESCRIPTION
## Summary
- Add a deterministic Promptfoo target for the chat title generation path in `/api/chat/conversations/[id]/messages`.
- Assert the route keeps the low-cost title model, short title-only prompt, token/time caps, telemetry redaction, sanitized fallback, and guarded title updates.
- Add eval inventory coverage so the no-cost gate fails if the chat-title case is removed.

## Cost control
Default `pnpm run evals` remains deterministic and no-cost. This case reads production route source and pure sanitization helpers only; it does not call models, DB, Clerk, Stripe, Spotify, or external services.

## Verification
- `PROMPTFOO_DISABLE_TELEMETRY=1 pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern "Chat title generation" --no-share --no-progress-bar --no-cache` passed 1/1.
- `PROMPTFOO_DISABLE_TELEMETRY=1 pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern "Eval case inventory" --no-share --no-progress-bar --no-cache` passed 1/1.
- `pnpm --filter @jovie/web run evals:validate` passed.
- `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml` passed; Promptfoo emitted a shutdown timeout message after successful validation.
- `pnpm run evals` passed 190/190.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml` passed.
- `git diff --check` passed.
- Commit and pre-push hooks passed.
- `pnpm --filter @jovie/web run typecheck:tests` still fails on the existing broad test type backlog tracked by JOV-2612; first failures are in `scripts/drizzle-migrate.ts`, `scripts/drizzle-seed.ts`, and unrelated dashboard/profile/release tests, not Promptfoo eval files.

Closes JOV-2616.

<!-- agent-run-artifact
{
  "id": "codex-jov-2616-e9c93fbd98c2",
  "source": "github",
  "sourceRunId": "e9c93fbd98c256bfcb18abe6a7841195e7601111",
  "kind": "qa",
  "status": "done",
  "title": "Promptfoo chat title deterministic eval",
  "summary": "Added no-cost Promptfoo coverage for the chat title generation route contract and verified the deterministic suite locally.",
  "modelRoute": "deterministic",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr",
    "ready_pr",
    "merge",
    "mutate_linear"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2616",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2616/add-deterministic-promptfoo-coverage-for-chat-title-generation",
  "pullRequestUrl": null,
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Scoped QA passed for this no-UI eval slice: focused chat-title Promptfoo case, inventory case, and full deterministic Promptfoo suite all passed.",
      "checkedAt": "2026-05-26T05:47:42Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed the Promptfoo-only diff for no production prompt/model/schema/route behavior changes and no live service usage.",
      "checkedAt": "2026-05-26T05:47:42Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Ship checks passed: Promptfoo validate, pnpm run evals, web typecheck, Biome, diff check, commit hook, and pre-push hook. typecheck:tests remains blocked by JOV-2612.",
      "checkedAt": "2026-05-26T05:47:42Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": "Default eval path unsets model and service credentials and runs deterministic cases only."
  },
  "blockedReason": null,
  "createdAt": "2026-05-26T05:47:42Z",
  "updatedAt": "2026-05-26T05:47:42Z",
  "metadata": {
    "localChecks": [
      "PROMPTFOO_DISABLE_TELEMETRY=1 pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern \"Chat title generation\" --no-share --no-progress-bar --no-cache",
      "PROMPTFOO_DISABLE_TELEMETRY=1 pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern \"Eval case inventory\" --no-share --no-progress-bar --no-cache",
      "pnpm --filter @jovie/web run evals:validate",
      "pnpm run evals",
      "pnpm --filter @jovie/web run typecheck -- --pretty false",
      "pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml",
      "git diff --check"
    ],
    "knownNonBlockingCheck": "pnpm --filter @jovie/web run typecheck:tests fails on pre-existing JOV-2612 backlog outside promptfoo eval files."
  }
}
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive validation tests for chat title generation contracts, verifying system prompt coverage, title formatting standards, and execution boundaries
  * Extended test inventory tracking to measure chat title test case completeness

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->