### PR TITLE
test(promptfoo): cover interview summarization

### DIFF
--- a/apps/web/tests/eval/promptfoo/assertions.cjs
+++ b/apps/web/tests/eval/promptfoo/assertions.cjs
@@ -3707,6 +3707,122 @@ function assertInsightPromptContractCovered(output) {
   return pass();
 }
 
+function assertInterviewSummaryContractCovered(output) {
+  const payload = parseOutput(output);
+
+  if (payload.target !== 'interview-summary-contract') {
+    return fail(
+      'case did not run through the interview-summary-contract adapter'
+    );
+  }
+  if (payload.summaryCase !== 'prompt-schema-timeout') {
+    return fail(
+      `expected prompt-schema-timeout summary case, got ${String(payload.summaryCase)}`
+    );
+  }
+  if (payload.costTier !== 'deterministic') {
+    return fail('interview summary case is not marked deterministic');
+  }
+  for (const field of [
+    'modelCalled',
+    'persistenceAttempted',
+    'dbAttempted',
+    'networkAttempted',
+  ]) {
+    if (payload[field] !== false) {
+      return fail(`${field} should be false for interview summary coverage`);
+    }
+  }
+  if (
+    payload.productionEntrypoint !==
+    'apps/web/lib/interviews/summarize.ts:summarizeInterview'
+  ) {
+    return fail(
+      'interview summary contract did not inspect summarizer entrypoint'
+    );
+  }
+  if (payload.modelId !== 'claude-haiku-4-5-20251001') {
+    return fail(
+      `unexpected interview summary model: ${String(payload.modelId)}`
+    );
+  }
+  if (payload.maxTokens !== 800) {
+    return fail(`expected max tokens 800, got ${String(payload.maxTokens)}`);
+  }
+  if (payload.anthropicRequestTimeoutMs !== 30000) {
+    return fail(
+      `expected Anthropic timeout 30000, got ${String(payload.anthropicRequestTimeoutMs)}`
+    );
+  }
+  if (payload.wrapperTimeoutMs !== 31000) {
+    return fail(
+      `expected wrapper timeout 31000, got ${String(payload.wrapperTimeoutMs)}`
+    );
+  }
+  if (
+    typeof payload.summarizerSourceLength !== 'number' ||
+    payload.summarizerSourceLength < 2500
+  ) {
+    return fail('interview summarizer source was unexpectedly short');
+  }
+  if (
+    typeof payload.cronRouteSourceLength !== 'number' ||
+    payload.cronRouteSourceLength < 3000
+  ) {
+    return fail('interview cron route source was unexpectedly short');
+  }
+
+  for (const field of [
+    'missingPromptFacts',
+    'missingSchemaFacts',
+    'missingCostSafetyFacts',
+  ]) {
+    const values = Array.isArray(payload[field]) ? payload[field] : null;
+    if (!values) {
+      return fail(`interview summary contract missing ${field}`);
+    }
+    if (values.length > 0) {
+      return fail(`${field}: ${values.join(', ')}`);
+    }
+  }
+
+  const synthetic = payload.synthetic ?? {};
+  if (typeof synthetic.transcriptPreview !== 'string') {
+    return fail('interview summary synthetic transcript preview missing');
+  }
+  if (!synthetic.transcriptPreview.includes('Linktree')) {
+    return fail('synthetic transcript did not include current alternative');
+  }
+  if (!synthetic.transcriptPreview.includes('[skipped]')) {
+    return fail('synthetic transcript did not cover skipped answers');
+  }
+  if (hasSecretValue(synthetic.transcriptPreview)) {
+    return fail('synthetic transcript contained a secret-like value');
+  }
+  const missingSyntheticFacts = Array.isArray(synthetic.missingFacts)
+    ? synthetic.missingFacts
+    : [];
+  if (missingSyntheticFacts.length > 0) {
+    return fail(
+      `interview summary synthetic facts missing: ${missingSyntheticFacts.join(', ')}`
+    );
+  }
+
+  const leakPatterns = Array.isArray(payload.promptLeakPatterns)
+    ? payload.promptLeakPatterns
+    : [];
+  if (leakPatterns.length > 0) {
+    return fail(
+      `interview summary contract leaked patterns: ${leakPatterns.join(', ')}`
+    );
+  }
+  if (toolNames(payload).length > 0 || allExecutions(payload).length > 0) {
+    return fail('interview summary contract should not call or execute tools');
+  }
+
+  return pass();
+}
+
 function assertReleaseTaskClassifierContractCovered(output) {
   const payload = parseOutput(output);
 
@@ -4515,6 +4631,7 @@ function assertEvalCaseInventoryCovered(output) {
     'missingAiToolPromptCaseNames',
     'missingChatTitleCaseNames',
     'missingInsightPromptCaseNames',
+    'missingInterviewSummaryCaseNames',
     'missingOnboardingSystemPromptCaseNames',
     'missingReleaseTaskClassifierCaseNames',
     'missingSkillArtifactCaseNames',
@@ -4654,6 +4771,7 @@ module.exports = {
   assertAiToolPromptContractCovered,
   assertChatTitleContractCovered,
   assertInsightPromptContractCovered,
+  assertInterviewSummaryContractCovered,
   assertOnboardingSystemPromptContractCovered,
   assertReleaseTaskClassifierContractCovered,
   assertSkillRegistryInventoryCovered,

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -125,6 +125,7 @@ type EvalTarget =
   | 'chat-turn'
   | 'eval-case-inventory'
   | 'insight-prompt-contract'
+  | 'interview-summary-contract'
   | 'knowledge-contract'
   | 'model-contract'
   | 'onboarding-system-prompt-contract'
@@ -593,6 +594,7 @@ const REQUIRED_SKILL_PROMPT_CASES = ['release-pitch-retouch-prompts'] as const;
 const REQUIRED_SKILL_REGISTRY_CASES = ['registry-inventory'] as const;
 const REQUIRED_AI_TOOL_PROMPT_CASES = ['album-art-canvas-bio-prompts'] as const;
 const REQUIRED_INSIGHT_PROMPT_CASES = ['analytics-grounding-prompts'] as const;
+const REQUIRED_INTERVIEW_SUMMARY_CASES = ['prompt-schema-timeout'] as const;
 const REQUIRED_ONBOARDING_SYSTEM_PROMPT_CASES = ['prompt-rules'] as const;
 const REQUIRED_RELEASE_TASK_CLASSIFIER_CASES = ['prompt-and-coercion'] as const;
 const REQUIRED_CHAT_TITLE_CASES = ['prompt-and-fallback'] as const;
@@ -744,6 +746,7 @@ function toTarget(value: unknown): EvalTarget {
     value === 'chat-turn' ||
     value === 'eval-case-inventory' ||
     value === 'insight-prompt-contract' ||
+    value === 'interview-summary-contract' ||
     value === 'knowledge-contract' ||
     value === 'mobile-chat-route' ||
     value === 'model-contract' ||
@@ -6004,6 +6007,194 @@ function evaluateInsightPromptContract(vars: EvalVars) {
   };
 }
 
+function evaluateInterviewSummaryContract(vars: EvalVars) {
+  const summaryCase =
+    typeof vars.interviewSummaryCase === 'string'
+      ? vars.interviewSummaryCase
+      : 'prompt-schema-timeout';
+  const summarizerSourcePath = 'lib/interviews/summarize.ts';
+  const cronRouteSourcePath = 'app/api/cron/summarize-interviews/route.ts';
+  const summarizerSource = readFileSync(
+    resolve(process.cwd(), summarizerSourcePath),
+    'utf8'
+  );
+  const cronRouteSource = readFileSync(
+    resolve(process.cwd(), cronRouteSourcePath),
+    'utf8'
+  );
+  const syntheticTranscriptPreview = [
+    'Q1 (link_bio_current): What do you use for your link in bio today?',
+    'A1: I keep swapping my Instagram bio link by hand before every release.',
+    '',
+    'Q2 (tools): Which tools are you using now?',
+    'A2: Linktree and DMs.',
+    '',
+    'Q3 (skipped_budget): What are you paying for?',
+    'A3: [skipped]',
+  ].join('\n');
+  const promptFacts = {
+    framesMomTestPastBehavior: textIncludesAll(summarizerSource, [
+      'Mom Test interview',
+      'past-behavior only',
+      'no hypotheticals',
+    ]),
+    identifiesJovieArtistContext: textIncludesAll(summarizerSource, [
+      'musician who just signed up for Jovie',
+      'artist profile and link-in-bio tool',
+    ]),
+    requiresJsonOnlyExactShape: textIncludesAll(summarizerSource, [
+      'Return ONLY a single JSON object',
+      'no prose',
+      'no code fences',
+      '"one_line_summary"',
+      '"top_pain_points"',
+      '"current_alternatives"',
+      '"quotable_line"',
+    ]),
+    blocksInventedDetails: textIncludesAll(summarizerSource, [
+      'Do not invent details not in the transcript',
+    ]),
+    keepsPainAlternativesQuoteRules: textIncludesAll(summarizerSource, [
+      'up to 3 concrete pains',
+      'Skip generic complaints',
+      'Empty array if unstated',
+      'single most vivid phrase',
+      'verbatim',
+      'Empty string if nothing stood out',
+    ]),
+    rendersTranscriptWithQuestionIds: textIncludesAll(summarizerSource, [
+      'Q${idx + 1} (${entry.questionId})',
+      'A${idx + 1}: ${answer}',
+      "join('\\n\\n')",
+    ]),
+    preservesSkippedAndEmptyAnswers: textIncludesAll(summarizerSource, [
+      'entry.skipped',
+      "'[skipped]'",
+      "'[empty]'",
+    ]),
+  };
+  const schemaFacts = {
+    validatesExactSummaryObject: textIncludesAll(summarizerSource, [
+      'SUMMARY_SCHEMA = z.object',
+      'one_line_summary',
+      'top_pain_points',
+      'current_alternatives',
+      'quotable_line',
+    ]),
+    capsSummaryAndQuoteText: textIncludesAll(summarizerSource, ['max(400)']),
+    capsPainAndAlternativeArrays: textIncludesAll(summarizerSource, [
+      'top_pain_points: z.array',
+      '.max(5)',
+      'current_alternatives: z.array',
+      '.max(10)',
+    ]),
+    parsesJsonBeforeSchema: textIncludesAll(summarizerSource, [
+      'JSON.parse(extractJson(responseText))',
+      'SUMMARY_SCHEMA.parse(parsed)',
+    ]),
+    extractsFencedOrBracedJson: textIncludesAll(summarizerSource, [
+      "text.indexOf('```')",
+      "text.indexOf('{')",
+      "text.lastIndexOf('}')",
+    ]),
+    requiresTextBlockBeforeParsing: textIncludesAll(summarizerSource, [
+      "message.content.find(block => block.type === 'text')",
+      'No text response from Claude',
+    ]),
+  };
+  const costSafetyFacts = {
+    usesHaikuModel: textIncludesAll(summarizerSource, [
+      "const MODEL_ID = 'claude-haiku-4-5-20251001'",
+      'model: MODEL_ID',
+    ]),
+    capsOutputTokens: textIncludesAll(summarizerSource, ['max_tokens: 800']),
+    usesBoundedAnthropicTimeout: textIncludesAll(summarizerSource, [
+      'ANTHROPIC_REQUEST_TIMEOUT_MS = 30_000',
+      'withTimeout',
+      'timeoutMs: ANTHROPIC_REQUEST_TIMEOUT_MS + 1_000',
+      "context: 'Anthropic summarizeInterview'",
+    ]),
+    cronLimitsBatchAndAttempts: textIncludesAll(cronRouteSource, [
+      'MAX_INTERVIEWS_PER_RUN = 10',
+      'MAX_ATTEMPTS = 3',
+      "status='pending'",
+    ]),
+    cronClaimsRowsSafely: textIncludesAll(cronRouteSource, [
+      'FOR UPDATE SKIP LOCKED',
+      'summaryAttempts',
+      'pending',
+    ]),
+    cronUsesSummarizeEntrypoint: textIncludesAll(cronRouteSource, [
+      'import { summarizeInterview }',
+      'await summarizeInterview',
+    ]),
+  };
+  const syntheticFacts = {
+    usesSyntheticArtistOnly: textIncludesAll(syntheticTranscriptPreview, [
+      'Instagram',
+      'Linktree',
+      'DMs',
+    ]),
+    demonstratesSkippedAnswer: textIncludesAll(syntheticTranscriptPreview, [
+      'Q3 (skipped_budget)',
+      'A3: [skipped]',
+    ]),
+    containsNoRealCustomerData:
+      promptLeakPatterns(syntheticTranscriptPreview).length === 0 &&
+      !/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i.test(
+        syntheticTranscriptPreview
+      ),
+  };
+
+  return {
+    target: 'interview-summary-contract',
+    adapter: 'interview-summary-contract',
+    productionEntrypoint:
+      'apps/web/lib/interviews/summarize.ts:summarizeInterview',
+    costTier: 'deterministic',
+    text: '',
+    selectedModel: null,
+    modelCalled: false,
+    persistenceAttempted: false,
+    dbAttempted: false,
+    networkAttempted: false,
+    summaryCase,
+    summarizerSourcePath,
+    cronRouteSourcePath,
+    summarizerSourceLength: summarizerSource.length,
+    cronRouteSourceLength: cronRouteSource.length,
+    modelId: 'claude-haiku-4-5-20251001',
+    maxTokens: 800,
+    anthropicRequestTimeoutMs: 30_000,
+    wrapperTimeoutMs: 31_000,
+    promptFacts,
+    missingPromptFacts: Object.entries(promptFacts)
+      .filter(([, passed]) => !passed)
+      .map(([name]) => name),
+    schemaFacts,
+    missingSchemaFacts: Object.entries(schemaFacts)
+      .filter(([, passed]) => !passed)
+      .map(([name]) => name),
+    costSafetyFacts,
+    missingCostSafetyFacts: Object.entries(costSafetyFacts)
+      .filter(([, passed]) => !passed)
+      .map(([name]) => name),
+    synthetic: {
+      transcriptPreview: syntheticTranscriptPreview,
+      facts: syntheticFacts,
+      missingFacts: Object.entries(syntheticFacts)
+        .filter(([, passed]) => !passed)
+        .map(([name]) => name),
+    },
+    promptLeakPatterns: promptLeakPatterns(
+      [summarizerSource, cronRouteSource, syntheticTranscriptPreview].join('\n')
+    ),
+    toolCalls: [],
+    toolResults: [],
+    toolExecutions: [],
+  };
+}
+
 function evaluateOnboardingSystemPromptContract(vars: EvalVars) {
   const promptCase =
     typeof vars.onboardingSystemPromptCase === 'string'
@@ -7257,6 +7448,7 @@ type EvalCaseSummary = {
   readonly aiToolPromptCase: string | null;
   readonly chatTitleCase: string | null;
   readonly insightPromptCase: string | null;
+  readonly interviewSummaryCase: string | null;
   readonly onboardingSystemPromptCase: string | null;
   readonly releaseTaskClassifierCase: string | null;
   readonly knowledgeCase: string | null;
@@ -7362,6 +7554,7 @@ function parseEvalCaseSummary(block: string): EvalCaseSummary {
     aiToolPromptCase: scalarValue(block, 'aiToolPromptCase'),
     chatTitleCase: scalarValue(block, 'chatTitleCase'),
     insightPromptCase: scalarValue(block, 'insightPromptCase'),
+    interviewSummaryCase: scalarValue(block, 'interviewSummaryCase'),
     onboardingSystemPromptCase: scalarValue(
       block,
       'onboardingSystemPromptCase'
@@ -7613,6 +7806,15 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
       .filter(
         (insightPromptCase): insightPromptCase is string =>
           typeof insightPromptCase === 'string'
+      )
+  );
+  const interviewSummaryCaseNames = uniqueSorted(
+    deterministicCases
+      .filter(testCase => testCase.target === 'interview-summary-contract')
+      .map(testCase => testCase.interviewSummaryCase)
+      .filter(
+        (interviewSummaryCase): interviewSummaryCase is string =>
+          typeof interviewSummaryCase === 'string'
       )
   );
   const onboardingSystemPromptCaseNames = uniqueSorted(
@@ -7884,6 +8086,12 @@ function evaluateEvalCaseInventory(vars: EvalVars) {
     missingInsightPromptCaseNames: missingNames(
       REQUIRED_INSIGHT_PROMPT_CASES,
       insightPromptCaseNames
+    ),
+    requiredInterviewSummaryCaseNames: [...REQUIRED_INTERVIEW_SUMMARY_CASES],
+    interviewSummaryCaseNames,
+    missingInterviewSummaryCaseNames: missingNames(
+      REQUIRED_INTERVIEW_SUMMARY_CASES,
+      interviewSummaryCaseNames
     ),
     requiredOnboardingSystemPromptCaseNames: [
       ...REQUIRED_ONBOARDING_SYSTEM_PROMPT_CASES,
@@ -8157,6 +8365,11 @@ export default class JovieChatPromptfooProvider {
 
     if (target === 'insight-prompt-contract') {
       const payload = evaluateInsightPromptContract(vars);
+      return jsonProviderResponse(payload, startedAt);
+    }
+
+    if (target === 'interview-summary-contract') {
+      const payload = evaluateInterviewSummaryContract(vars);
       return jsonProviderResponse(payload, startedAt);
     }
 

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -1652,6 +1652,19 @@ tests:
       - type: javascript
         value: file://assertions.cjs:assertInsightPromptContractCovered
 
+  - description: Interview summarization prompt preserves Mom Test JSON guardrails
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Interview summary prompt contract check"
+      target: interview-summary-contract
+      interviewSummaryCase: prompt-schema-timeout
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertInterviewSummaryContractCovered
+
   - description: Onboarding system prompt preserves intake and access rules
     metadata:
       cost: deterministic


### PR DESCRIPTION
## Summary
- Adds a no-cost Promptfoo target for the production interview summarization path at `apps/web/lib/interviews/summarize.ts:summarizeInterview`.
- Checks the Mom Test JSON-only prompt guardrails, schema validation, synthetic transcript handling, Haiku/max-token/timeout controls, and cron batch/attempt safety.
- Keeps the default eval path deterministic: no model, DB, network, Clerk, Spotify, Stripe, or persistence attempts.

## Cost decision
Ship now: deterministic source-contract coverage for interview summarization because it adds CI-grade guardrails at $0 per run.
Re-evaluate when: manual live eval failures for summarization catch a release-blocking regression twice in 30 days or the agreed per-run budget supports a capped live subset.
Then: add a manual or PR-gated live subset with capped case count and concurrency 1.

## Verification
- PASS `PROMPTFOO_DISABLE_TELEMETRY=1 pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern "Interview summarization" --no-share --no-progress-bar --no-cache` (1/1)
- PASS `PROMPTFOO_DISABLE_TELEMETRY=1 pnpm --filter @jovie/web exec promptfoo eval -c tests/eval/promptfoo/promptfooconfig.yaml --filter-pattern "Eval case inventory" --no-share --no-progress-bar --no-cache` (1/1)
- PASS `pnpm --filter @jovie/web run evals:validate`
- PASS `pnpm --filter @jovie/web exec promptfoo validate -c tests/eval/promptfoo/promptfooconfig.yaml` (config valid; Promptfoo printed telemetry shutdown timeout after success)
- PASS `pnpm run evals` (191/191)
- PASS `pnpm --filter @jovie/web run typecheck -- --pretty false`
- PASS `pnpm biome check apps/web/tests/eval/promptfoo apps/web/package.json package.json .github/workflows/ci.yml`
- PASS `git diff --check`
- PASS pre-push hook: Biome repo check, proxy guard, Tailwind guard, web typecheck, web lint
- KNOWN FAIL `pnpm --filter @jovie/web run typecheck:tests`: broad pre-existing test/script backlog tracked by JOV-2612; first failures remain outside this Promptfoo harness, e.g. `scripts/drizzle-migrate.ts`, `scripts/drizzle-seed.ts`, `scripts/generate-brand-assets.ts`, dashboard/profile/release tests.

Head: 3b008e919b9eb30c8058e2979de1893d7f7972ea
