### PR TITLE
fix(ci): stabilize JOV-2617 landing checks

### DIFF
--- a/.github/workflows/canary-health-gate.yml
+++ b/.github/workflows/canary-health-gate.yml
@@ -565,9 +565,9 @@ jobs:
           auth_smoke_attempt=1
           auth_smoke_max_attempts=3
 
-          # The HTTP canary uses Vercel bypass headers above, but this browser
-          # smoke must match real public user traffic. Passing bypass headers into
-          # Playwright keeps Clerk from reaching an interactive ready state.
+          # The HTTP canary uses Vercel bypass headers above. This browser smoke
+          # primes Vercel's bypass cookie by URL query instead of headers so
+          # Clerk still reaches its normal interactive ready state.
           until CI=true SMOKE_ONLY=1 BASE_URL="${DEPLOYMENT_URL}" pnpm exec playwright test tests/e2e/auth-public-ready.spec.ts --project=chromium --reporter=line; do
             if [ "$auth_smoke_attempt" -ge "$auth_smoke_max_attempts" ]; then
               echo "❌ Public auth controls failed after ${auth_smoke_max_attempts} attempts."
@@ -581,6 +581,7 @@ jobs:
           done
         env:
           DEPLOYMENT_URL: ${{ steps.canary-check.outputs.verified_deployment_url || inputs.deployment_url }}
+          PLAYWRIGHT_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
 
       - name: Mark canary verified
         id: canary-status

--- a/apps/web/lib/testing/test-user-provision.server.ts
+++ b/apps/web/lib/testing/test-user-provision.server.ts
@@ -69,6 +69,11 @@ interface MatchedSeedUser {
   readonly email: string | null;
 }
 
+interface ResolvedSeedUserMatch {
+  readonly user: MatchedSeedUser | undefined;
+  readonly staleClerkIdUsers: readonly MatchedSeedUser[];
+}
+
 interface EnsureClerkTestUserOptions {
   readonly email: string;
   readonly username: string;
@@ -193,7 +198,7 @@ function shouldUseDeterministicClerkTestUser(): boolean {
 function resolveMatchedSeedUser(
   matchedUsers: readonly MatchedSeedUser[],
   values: SeededUserValues
-): MatchedSeedUser | undefined {
+): ResolvedSeedUserMatch {
   const normalizedEmail = values.email ? normalizeEmail(values.email) : null;
   const clerkIdMatches = matchedUsers.filter(
     matchedUser => matchedUser.clerkId === values.clerkId
@@ -212,12 +217,22 @@ function resolveMatchedSeedUser(
   const emailMatch = emailMatches[0];
 
   if (clerkIdMatch && emailMatch && clerkIdMatch.id !== emailMatch.id) {
+    if (isAllowlistedTestAccountEmail(normalizedEmail)) {
+      return {
+        user: emailMatch,
+        staleClerkIdUsers: [clerkIdMatch],
+      };
+    }
+
     throw new Error(
       `Conflicting test user matches for ${values.email ?? 'unknown email'}`
     );
   }
 
-  return clerkIdMatch ?? emailMatch ?? matchedUsers[0];
+  return {
+    user: clerkIdMatch ?? emailMatch ?? matchedUsers[0],
+    staleClerkIdUsers: [],
+  };
 }
 
 function buildSeedUserLookupCondition(values: SeededUserValues) {
@@ -234,6 +249,28 @@ function buildSeedUserLookupCondition(values: SeededUserValues) {
     normalizedEmail,
     userLookupCondition,
   };
+}
+
+function getRetiredTestClerkId(matchedUser: MatchedSeedUser): string {
+  const stableSuffix =
+    matchedUser.id.replaceAll(/[^a-z0-9]+/gi, '_').slice(0, 24) || 'row';
+
+  return `${matchedUser.clerkId ?? 'user_dev_test'}__stale_${stableSuffix}`;
+}
+
+async function retireStaleSeedUserClerkIds(
+  database: DbOrTransaction,
+  matchedUsers: readonly MatchedSeedUser[]
+) {
+  for (const matchedUser of matchedUsers) {
+    await database
+      .update(users)
+      .set({
+        clerkId: getRetiredTestClerkId(matchedUser),
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, matchedUser.id));
+  }
 }
 
 export async function resolveClerkTestUserId(
@@ -438,7 +475,8 @@ export async function ensureUserRecord(
     .select({ id: users.id, clerkId: users.clerkId, email: users.email })
     .from(users)
     .where(userLookupCondition);
-  const existingUser = resolveMatchedSeedUser(matchedUsers, values);
+  const existingMatch = resolveMatchedSeedUser(matchedUsers, values);
+  const existingUser = existingMatch.user;
 
   const normalizedValues = {
     ...values,
@@ -446,6 +484,11 @@ export async function ensureUserRecord(
   };
 
   if (existingUser) {
+    await retireStaleSeedUserClerkIds(
+      database,
+      existingMatch.staleClerkIdUsers
+    );
+
     await database
       .update(users)
       .set({ ...normalizedValues, updatedAt: new Date() })
@@ -479,11 +522,14 @@ export async function ensureUserRecord(
       .select({ id: users.id, clerkId: users.clerkId, email: users.email })
       .from(users)
       .where(userLookupCondition);
-    const racedUser = resolveMatchedSeedUser(racedUsers, normalizedValues);
+    const racedMatch = resolveMatchedSeedUser(racedUsers, normalizedValues);
+    const racedUser = racedMatch.user;
 
     if (!racedUser) {
       throw error;
     }
+
+    await retireStaleSeedUserClerkIds(database, racedMatch.staleClerkIdUsers);
 
     await database
       .update(users)

--- a/apps/web/tests/e2e/auth-public-ready.spec.ts
+++ b/apps/web/tests/e2e/auth-public-ready.spec.ts
@@ -1,5 +1,6 @@
 import { expect, type Page, test } from '@playwright/test';
 import { APP_ROUTES } from '@/constants/routes';
+import { primeVercelBypassCookie } from '../helpers/vercel-preview';
 import { SMOKE_TIMEOUTS } from './utils/smoke-test-utils';
 
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -17,6 +18,8 @@ test.beforeEach(() => {
 
 function expectPublicAuthReady(pathname: string) {
   return async ({ page }: { page: Page }) => {
+    await primeVercelBypassCookie(page, process.env.BASE_URL, pathname);
+
     await page.goto(pathname, {
       waitUntil: 'domcontentloaded',
       timeout: SMOKE_TIMEOUTS.NAVIGATION,

--- a/apps/web/tests/helpers/vercel-preview.ts
+++ b/apps/web/tests/helpers/vercel-preview.ts
@@ -30,7 +30,9 @@ export function buildVercelBypassUrl(
   baseURL: string,
   pathname: string = '/'
 ): string | null {
-  const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  const bypassSecret =
+    process.env.PLAYWRIGHT_VERCEL_BYPASS_SECRET ||
+    process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
   if (!bypassSecret || !isSafePreviewBaseUrl(baseURL)) {
     return null;
   }

--- a/apps/web/tests/unit/ci/deploy-workflow.test.ts
+++ b/apps/web/tests/unit/ci/deploy-workflow.test.ts
@@ -318,9 +318,14 @@ describe('canary health gate workflow', () => {
     expect(authSmokeStep).toContain(
       'DEPLOYMENT_URL: ${{ steps.canary-check.outputs.verified_deployment_url || inputs.deployment_url }}'
     );
-    expect(authSmokeStep).not.toContain('VERCEL_AUTOMATION_BYPASS_SECRET');
     expect(authSmokeStep).toContain(
-      'this browser\n          # smoke must match real public user traffic'
+      'PLAYWRIGHT_VERCEL_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}'
+    );
+    expect(authSmokeStep).not.toContain(
+      'VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}'
+    );
+    expect(authSmokeStep).toContain(
+      "primes Vercel's bypass cookie by URL query instead of headers"
     );
     expect(authSmokeStep).toContain('auth_smoke_attempt=1');
     expect(authSmokeStep).toContain('auth_smoke_max_attempts=3');

--- a/apps/web/tests/unit/helpers/vercel-preview.test.ts
+++ b/apps/web/tests/unit/helpers/vercel-preview.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildVercelBypassUrl } from '../../helpers/vercel-preview';
+
+describe('vercel preview helpers', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses the Playwright-specific bypass secret without requiring global bypass headers', () => {
+    vi.stubEnv('PLAYWRIGHT_VERCEL_BYPASS_SECRET', 'preview-secret');
+
+    const bypassUrl = buildVercelBypassUrl(
+      'https://jovie-git-main.vercel.app',
+      '/signin'
+    );
+
+    expect(bypassUrl).toBe(
+      'https://jovie-git-main.vercel.app/signin?x-vercel-set-bypass-cookie=true&x-vercel-protection-bypass=preview-secret'
+    );
+  });
+
+  it('does not append bypass params for non-preview hosts', () => {
+    vi.stubEnv('PLAYWRIGHT_VERCEL_BYPASS_SECRET', 'preview-secret');
+
+    expect(buildVercelBypassUrl('https://jov.ie', '/signin')).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/lib/testing/test-user-provision.server.test.ts
+++ b/apps/web/tests/unit/lib/testing/test-user-provision.server.test.ts
@@ -182,6 +182,73 @@ describe('test-user-provision.server', () => {
     ).toBe(true);
   });
 
+  it('adopts the allowlisted email row when the current Clerk id belongs to a stale test row', async () => {
+    const updateValues: Array<Record<string, unknown>> = [];
+    const selectQueue = [
+      [
+        {
+          id: 'user_clerk_match',
+          clerkId: 'user_live_e2e',
+          email: 'stale-e2e@jov.ie',
+        },
+        {
+          id: 'user_email_match',
+          clerkId: 'user_old_e2e',
+          email: 'e2e@jov.ie',
+        },
+      ],
+    ];
+    const database = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(async () => selectQueue.shift() ?? []),
+        })),
+      })),
+      update: vi.fn(() => ({
+        set: vi.fn((values: Record<string, unknown>) => {
+          updateValues.push(values);
+          return {
+            where: vi.fn(async () => undefined),
+          };
+        }),
+      })),
+      insert: vi.fn(),
+    };
+
+    const { ensureUserRecord } = await import(
+      '@/lib/testing/test-user-provision.server'
+    );
+
+    await expect(
+      ensureUserRecord(database as never, {
+        clerkId: 'user_live_e2e',
+        email: 'e2e@jov.ie',
+        name: 'E2E Test',
+        userStatus: 'active',
+        isAdmin: true,
+        plan: 'max',
+        isPro: true,
+        billingUpdatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      })
+    ).resolves.toEqual({
+      id: 'user_email_match',
+      previousClerkId: 'user_old_e2e',
+    });
+
+    expect(database.insert).not.toHaveBeenCalled();
+    expect(updateValues).toHaveLength(2);
+    expect(updateValues[0]).toMatchObject({
+      clerkId: 'user_live_e2e__stale_user_clerk_match',
+    });
+    expect(updateValues[1]).toMatchObject({
+      clerkId: 'user_live_e2e',
+      email: 'e2e@jov.ie',
+      isAdmin: true,
+      plan: 'max',
+      userStatus: 'active',
+    });
+  });
+
   it('updates the existing claimed profile for the same user when one already exists', async () => {
     const updateValues: Array<Record<string, unknown>> = [];
     const selectQueue = [[{ id: 'profile_existing', userId: 'user_123' }]];

--- a/knip.json
+++ b/knip.json
@@ -44,7 +44,8 @@
         "@radix-ui/react-toggle",
         "@radix-ui/react-toggle-group",
         "@radix-ui/react-tooltip",
-        "@sentry/node"
+        "@sentry/node",
+        "promptfoo"
       ],
       "playwright": {
         "config": [


### PR DESCRIPTION
## Summary
- JOV-2617: allow E2E seeding to reconcile allowlisted stale test-user Clerk id conflicts by retiring the stale id before adopting the current id onto the email-owned row
- JOV-2617: mark promptfoo as an intentional web workspace dependency for Knip because CI and shell scripts invoke the binary
- JOV-2617: keep staging canary auth smoke usable when GitHub masks deploy_url by priming Vercel preview protection with a Playwright-only bypass cookie query, without sending bypass headers into Clerk pages

## Verification
- node --version -> v22.22.1
- pnpm --version -> 9.15.4
- pnpm --filter @jovie/web exec vitest run tests/unit/lib/testing/test-user-provision.server.test.ts tests/unit/helpers/vercel-preview.test.ts tests/unit/ci/deploy-workflow.test.ts
- pnpm knip
- pnpm biome check .github/workflows/canary-health-gate.yml apps/web/tests/e2e/auth-public-ready.spec.ts apps/web/tests/helpers/vercel-preview.ts apps/web/tests/unit/helpers/vercel-preview.test.ts apps/web/tests/unit/ci/deploy-workflow.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- pnpm exec actionlint .github/workflows/canary-health-gate.yml
- pre-push hook: biome check ., next proxy guard, tailwind guard, web typecheck, web lint
