### PR TITLE
fix(ci): skip missing unit coverage uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2267,8 +2267,21 @@ jobs:
         if: steps.check_changes.outputs.run_full_ci == 'true'
         run: pnpm turbo test --filter=@jovie/ui
 
-      - name: Upload coverage to Codecov
+      - name: Detect coverage reports
         if: steps.check_changes.outputs.run_full_ci == 'true' && github.ref == 'refs/heads/main'
+        id: coverage_reports
+        shell: bash
+        run: |
+          if find apps/web/coverage -type f \( -name '*.json' -o -name '*.xml' -o -name '*.info' -o -name '*.lcov' \) -print -quit 2>/dev/null | grep -q .; then
+            echo "has_coverage=true" >> "$GITHUB_OUTPUT"
+            echo "Coverage reports found for this shard."
+          else
+            echo "has_coverage=false" >> "$GITHUB_OUTPUT"
+            echo "No coverage reports produced for this shard; skipping Codecov coverage upload."
+          fi
+
+      - name: Upload coverage to Codecov
+        if: steps.check_changes.outputs.run_full_ci == 'true' && github.ref == 'refs/heads/main' && steps.coverage_reports.outputs.has_coverage == 'true'
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v5
         with:
           directory: apps/web/coverage


### PR DESCRIPTION
## Summary\n- JOV-2626\n- Skip Codecov coverage upload when a unit shard produces no coverage artifact on main.\n- Keep Codecov test-result uploads unchanged.\n\n## Verification\n- node --version => v22.22.1\n- pnpm --version => 9.15.4\n- pnpm exec actionlint -ignore 'SC2034|SC2086|SC2129|SC2028' .github/workflows/ci.yml\n- git diff --check\n- pre-push hook: biome check ., next proxy guard, tailwind guard, web typecheck, web lint\n\n## Context\nMain CI run 26441735867 deployed and verified production successfully, but finished cancelled because Unit Tests (3/6) hit the 30-minute timeout during Codecov coverage upload after finding no coverage reports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD coverage reporting workflow to conditionally upload coverage data only when coverage artifacts are available on the main branch, enhancing test pipeline efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->