### PR TITLE
fix(auth): harden iOS auth test flow

### DIFF
--- a/apps/ios/scripts/test-auth-callback.sh
+++ b/apps/ios/scripts/test-auth-callback.sh
@@ -65,7 +65,7 @@ resolve_publishable_key() {
   local web_base_url="$1"
   local existing_key="${CLERK_PUBLISHABLE_KEY:-${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:-}}"
 
-  if [[ -n "$existing_key" ]]; then
+  if [[ -n "$existing_key" && "$existing_key" != "pk_test_ci_placeholder" ]]; then
     printf '%s' "$existing_key"
     return 0
   fi
@@ -143,7 +143,10 @@ run_live_auth_simulator_smoke() {
   local api_base_url="${API_BASE_URL:-http://localhost:3100}"
   local web_base_url="${WEB_BASE_URL:-$api_base_url}"
   local persona="${JOVIE_IOS_LIVE_AUTH_PERSONA:-creator-ready}"
+  local publishable_key
   local callback_response
+
+  publishable_key="$(resolve_publishable_key "$web_base_url")"
 
   echo "Creating dev native auth callback against $api_base_url..."
   callback_response="$(
@@ -210,7 +213,6 @@ NODE
     /usr/libexec/PlistBuddy -c "Delete :liveAuthUITestUserID" "$existing_prefs_file" >/dev/null 2>&1 || true
   fi
 
-  local publishable_key="${CLERK_PUBLISHABLE_KEY:-${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:-}}"
   local launch_env=(
     "SIMCTL_CHILD_API_BASE_URL=$api_base_url"
     "SIMCTL_CHILD_WEB_BASE_URL=$web_base_url"

--- a/apps/ios/scripts/test-auth-callback.sh
+++ b/apps/ios/scripts/test-auth-callback.sh
@@ -108,7 +108,7 @@ require_publishable_key() {
   local publishable_key
 
   publishable_key="$(resolve_publishable_key "$web_base_url" || true)"
-  if [[ -z "$publishable_key" ]]; then
+  if [[ -z "$publishable_key" || "$publishable_key" == "pk_test_ci_placeholder" ]]; then
     echo "Unable to run iOS auth smoke without a real Clerk publishable key." >&2
     echo "Set CLERK_PUBLISHABLE_KEY/NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY, start WEB_BASE_URL, or ensure Doppler dev is available." >&2
     return 1

--- a/apps/ios/scripts/test-auth-callback.sh
+++ b/apps/ios/scripts/test-auth-callback.sh
@@ -103,6 +103,20 @@ NODE
   return 1
 }
 
+require_publishable_key() {
+  local web_base_url="$1"
+  local publishable_key
+
+  publishable_key="$(resolve_publishable_key "$web_base_url" || true)"
+  if [[ -z "$publishable_key" ]]; then
+    echo "Unable to run iOS auth smoke without a real Clerk publishable key." >&2
+    echo "Set CLERK_PUBLISHABLE_KEY/NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY, start WEB_BASE_URL, or ensure Doppler dev is available." >&2
+    return 1
+  fi
+
+  printf '%s' "$publishable_key"
+}
+
 run_real_browser_auth_simulator_test() {
   local api_base_url="${API_BASE_URL:-}"
   local web_base_url="${WEB_BASE_URL:-}"
@@ -111,7 +125,7 @@ run_real_browser_auth_simulator_test() {
   require_https_url "WEB_BASE_URL" "$web_base_url"
 
   local publishable_key
-  publishable_key="$(resolve_publishable_key "$web_base_url")"
+  publishable_key="$(require_publishable_key "$web_base_url")"
   export CLERK_PUBLISHABLE_KEY="$publishable_key"
   export NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="$publishable_key"
   export API_BASE_URL="$api_base_url"
@@ -146,7 +160,7 @@ run_live_auth_simulator_smoke() {
   local publishable_key
   local callback_response
 
-  publishable_key="$(resolve_publishable_key "$web_base_url")"
+  publishable_key="$(require_publishable_key "$web_base_url")"
 
   echo "Creating dev native auth callback against $api_base_url..."
   callback_response="$(

--- a/apps/web/app/api/dev/test-auth/mobile-provider-complete/route.ts
+++ b/apps/web/app/api/dev/test-auth/mobile-provider-complete/route.ts
@@ -22,7 +22,15 @@ function readTrimmedEnv(name: string): string | null {
   return value ? value : null;
 }
 
+function isProductionDeployment(): boolean {
+  return process.env.VERCEL_ENV === 'production';
+}
+
 function hasValidTunnelToken(request: NextRequest): boolean {
+  if (isProductionDeployment()) {
+    return false;
+  }
+
   const expectedToken = readTrimmedEnv('JOVIE_IOS_REAL_BROWSER_AUTH_TOKEN');
   if (!expectedToken) {
     return false;
@@ -32,6 +40,14 @@ function hasValidTunnelToken(request: NextRequest): boolean {
 }
 
 function getRequestDevTestAuthAvailability(request: NextRequest) {
+  if (isProductionDeployment()) {
+    return {
+      enabled: false,
+      trustedHost: false,
+      reason: 'Not available in production',
+    };
+  }
+
   if (hasValidTunnelToken(request)) {
     return {
       enabled: true,

--- a/apps/web/tests/unit/api/dev/test-auth-routes.test.ts
+++ b/apps/web/tests/unit/api/dev/test-auth-routes.test.ts
@@ -76,6 +76,7 @@ describe('dev test-auth routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    vi.unstubAllEnvs();
     vi.stubEnv('E2E_CLERK_USER_ID', '');
     vi.stubEnv('E2E_CLERK_USER_USERNAME', '');
     vi.stubEnv('JOVIE_IOS_LIVE_AUTH_CLERK_USER_ID', '');
@@ -789,7 +790,7 @@ describe('dev test-auth routes', () => {
     });
   });
 
-  it('allows the iOS provider-complete route on HTTPS production only with the configured test token', async () => {
+  it('allows the iOS provider-complete route on HTTPS preview only with the configured test token', async () => {
     vi.stubEnv('JOVIE_IOS_REAL_BROWSER_AUTH_TOKEN', 'test-token');
     mockEnsureLiveDevTestAuthActor.mockResolvedValueOnce({
       persona: 'creator-ready',
@@ -806,7 +807,7 @@ describe('dev test-auth routes', () => {
     );
     const response = await GET(
       new NextRequest(
-        'https://jov.ie/api/dev/test-auth/mobile-provider-complete?persona=creator-ready&return_to=%2Fapp&code_challenge=challenge_123&code_challenge_method=S256&test_token=test-token'
+        'https://preview.jov.ie/api/dev/test-auth/mobile-provider-complete?persona=creator-ready&return_to=%2Fapp&code_challenge=challenge_123&code_challenge_method=S256&test_token=test-token'
       )
     );
 
@@ -822,6 +823,28 @@ describe('dev test-auth routes', () => {
         codeChallenge: 'challenge_123',
       })
     );
+    expect(mockGetDevTestAuthAvailability).not.toHaveBeenCalled();
+  });
+
+  it('rejects the iOS provider-complete token bypass on production deployments', async () => {
+    vi.stubEnv('JOVIE_IOS_REAL_BROWSER_AUTH_TOKEN', 'test-token');
+    vi.stubEnv('VERCEL_ENV', 'production');
+
+    const { GET } = await import(
+      '@/app/api/dev/test-auth/mobile-provider-complete/route'
+    );
+    const response = await GET(
+      new NextRequest(
+        'https://jov.ie/api/dev/test-auth/mobile-provider-complete?persona=creator-ready&return_to=%2Fapp&code_challenge=challenge_123&code_challenge_method=S256&test_token=test-token'
+      )
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      success: false,
+      error: 'Not available in production',
+    });
+    expect(mockCreateStoredNativeExchangeCode).not.toHaveBeenCalled();
     expect(mockGetDevTestAuthAvailability).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2627 -->

## Summary
- Harden the iOS provider-complete test route so token bypass is disabled on production deployments.
- Add regression coverage for the production fail-closed path and keep preview HTTPS token bypass for iOS simulator QA.
- Make the iOS auth test harness resolve a real Clerk publishable key for live native smoke instead of launching with the generated placeholder.
- Guard Clerk publishable-key resolution so missing local/server/Doppler config fails with an explicit iOS smoke-test diagnostic instead of an unhandled `set -e` exit.

## Verification
- `bash -n apps/ios/scripts/test-auth-callback.sh`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/api/dev/test-auth/mobile-provider-complete/route.ts apps/web/tests/unit/api/dev/test-auth-routes.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/api/dev/test-auth-routes.test.ts tests/unit/api/auth/native-exchange.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/desktop run test`
- `JOVIE_AGENT_PROFILE=coder JOVIE_IOS_LIVE_AUTH_UI=1 API_BASE_URL=http://localhost:3101 WEB_BASE_URL=http://localhost:3101 pnpm test:auth:ios`
- `JOVIE_AGENT_PROFILE=coder JOVIE_IOS_REAL_BROWSER_AUTH=1 API_BASE_URL=https://6155241483d008.lhr.life WEB_BASE_URL=https://6155241483d008.lhr.life JOVIE_IOS_REAL_BROWSER_AUTH_TOKEN=<doppler dev token> pnpm test:auth:ios`
- `git diff --check`
- Pre-push hook: Biome full-repo check, web proxy guard, Tailwind guard, typecheck, lint

## Environment
- Confirmed `JOVIE_IOS_REAL_BROWSER_AUTH_TOKEN` present with valid length in Doppler configs: `dev`, `dev_personal`, `test`, `stg`, `prd`.
- Confirmed GitHub Actions secret inventory includes iOS signing, Clerk associated domain/key, and `SENTRY_DSN`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a development placeholder publishable key from being accepted; the system now requires a real publishable key or fails with clear messaging.
  * Disabled the dev native auth tunnel flow in production to block bypasses.

* **Tests**
  * Cleared environment stubs between tests and added coverage for preview host behavior.
  * Added tests asserting the auth tunnel is rejected in production.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->