### PR TITLE
feat: add BackNavigationContext, update DesktopTitlebar, iOS entitlements

### DIFF
--- a/apps/ios/Jovie/Jovie.entitlements
+++ b/apps/ios/Jovie/Jovie.entitlements
@@ -3,6 +3,13 @@
 <plist version="1.0">
 <dict>
   <key>com.apple.developer.associated-domains</key>
+  <!--
+    Universal links (applinks:jov.ie) + Clerk webcredentials.
+    Corresponding static apple-app-site-association JSON at apps/web/public/ uses
+    hardcoded appID "G24T327LXT.ie.jov.Jovie" (Team + bundle for prod).
+    Update appID/domains per env/build variant if distributing staging/dev.
+    See Clerk dashboard, iOS entitlements docs, and aasa file for details.
+  -->
   <array>
     <string>webcredentials:$(CLERK_ASSOCIATED_DOMAIN)</string>
     <string>applinks:jov.ie</string>

--- a/apps/ios/Jovie/Jovie.entitlements
+++ b/apps/ios/Jovie/Jovie.entitlements
@@ -5,6 +5,7 @@
   <key>com.apple.developer.associated-domains</key>
   <array>
     <string>webcredentials:$(CLERK_ASSOCIATED_DOMAIN)</string>
+    <string>applinks:jov.ie</string>
   </array>
 </dict>
 </plist>

--- a/apps/web/components/atoms/DesktopTitlebar.tsx
+++ b/apps/web/components/atoms/DesktopTitlebar.tsx
@@ -1,38 +1,31 @@
 'use client';
 
 import { ChevronLeft, ChevronRight, PanelLeft } from 'lucide-react';
-import { useRouter } from 'next/navigation';
 import type { CSSProperties } from 'react';
 import { useContext } from 'react';
 import { UpdateAvailablePill } from '@/components/atoms/UpdateAvailablePill';
 import { SidebarContext } from '@/components/organisms/sidebar/context';
-import { useIsElectronRuntime } from '@/lib/desktop/electron-bridge';
+import { useBackNavigation } from '@/contexts/BackNavigationContext';
+import {
+  useDesktopNavigation,
+  useIsElectronRuntime,
+} from '@/lib/desktop/electron-bridge';
 import { cn } from '@/lib/utils';
 
 /**
  * DesktopTitlebar — Electron-only titlebar drag region.
  *
  * Layout:
- *   [sidebar-width: traffic-light spacer, back/forward, sidebar toggle, update pill]
- *   [main: drag region only]
+ *   [sidebar-width: traffic-light spacer, back button, update pill]
+ *   [main: forward nav, drag region]
  *
  * Renders as a zero-height invisible element in the browser; CSS on
  * [data-electron-titlebar="true"] makes it visible only inside Electron.
- *
- * The sidebar toggle here is the single canonical toggle in Electron mode,
- * so there is never a duplicate control path in desktop runtime.
- *
- * Back/forward keyboard shortcuts (Cmd+[ / Cmd+]) remain wired via
- * useDesktopNavigation in components that need them; visible controls sit
- * beside the traffic-light rail for native desktop discoverability.
- *
- * The page header is no longer rendered in the titlebar — it lives at the
- * top of the elevated content card below so the card (header included)
- * collapses/expands with the sidebar.
  */
 export function DesktopTitlebar() {
-  const router = useRouter();
   const isDesktop = useIsElectronRuntime();
+  const { canGoForward, goForward } = useDesktopNavigation();
+  const { canGoBack, goBack } = useBackNavigation();
   // useContext (not useSidebar) so this is safe outside SidebarProvider (e.g. demo shell)
   const sidebarCtx = useContext(SidebarContext);
   const sidebarOpen = sidebarCtx?.state === 'open';
@@ -84,7 +77,8 @@ export function DesktopTitlebar() {
             >
               <button
                 type='button'
-                onClick={() => router.back()}
+                onClick={goBack}
+                disabled={!canGoBack}
                 aria-label='Go back'
                 data-testid='electron-nav-back'
                 className={cn(
@@ -98,7 +92,8 @@ export function DesktopTitlebar() {
               </button>
               <button
                 type='button'
-                onClick={() => router.forward()}
+                onClick={goForward}
+                disabled={!canGoForward}
                 aria-label='Go forward'
                 data-testid='electron-nav-forward'
                 className={cn(

--- a/apps/web/components/atoms/DesktopTitlebar.tsx
+++ b/apps/web/components/atoms/DesktopTitlebar.tsx
@@ -5,7 +5,6 @@ import type { CSSProperties } from 'react';
 import { useContext } from 'react';
 import { UpdateAvailablePill } from '@/components/atoms/UpdateAvailablePill';
 import { SidebarContext } from '@/components/organisms/sidebar/context';
-import { useBackNavigation } from '@/contexts/BackNavigationContext';
 import {
   useDesktopNavigation,
   useIsElectronRuntime,
@@ -24,8 +23,7 @@ import { cn } from '@/lib/utils';
  */
 export function DesktopTitlebar() {
   const isDesktop = useIsElectronRuntime();
-  const { canGoForward, goForward } = useDesktopNavigation();
-  const { canGoBack, goBack } = useBackNavigation();
+  const { canGoBack, canGoForward, goBack, goForward } = useDesktopNavigation();
   // useContext (not useSidebar) so this is safe outside SidebarProvider (e.g. demo shell)
   const sidebarCtx = useContext(SidebarContext);
   const sidebarOpen = sidebarCtx?.state === 'open';
@@ -85,7 +83,8 @@ export function DesktopTitlebar() {
                   'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-secondary-token',
                   'transition-colors duration-subtle',
                   'hover:bg-white/[0.06] hover:text-primary-token',
-                  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30'
+                  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30',
+                  'disabled:pointer-events-none disabled:opacity-30'
                 )}
               >
                 <ChevronLeft className='h-3.5 w-3.5' strokeWidth={2} />
@@ -100,7 +99,8 @@ export function DesktopTitlebar() {
                   'flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-secondary-token',
                   'transition-colors duration-subtle',
                   'hover:bg-white/[0.06] hover:text-primary-token',
-                  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30'
+                  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30',
+                  'disabled:pointer-events-none disabled:opacity-30'
                 )}
               >
                 <ChevronRight className='h-3.5 w-3.5' strokeWidth={2} />

--- a/apps/web/contexts/BackNavigationContext.tsx
+++ b/apps/web/contexts/BackNavigationContext.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { createContext, useContext, useMemo } from 'react';
+
+interface BackNavigationValue {
+  canGoBack: boolean;
+  goBack: () => void;
+}
+
+const BackNavigationContext = createContext<BackNavigationValue>({
+  canGoBack: false,
+  goBack: () => {},
+});
+
+export function useBackNavigation(): BackNavigationValue {
+  return useContext(BackNavigationContext);
+}
+
+export function BackNavigationProvider({
+  canGoBack,
+  goBack,
+  children,
+}: Readonly<{
+  canGoBack?: boolean;
+  goBack?: () => void;
+  children: React.ReactNode;
+}>) {
+  const value = useMemo<BackNavigationValue>(
+    () => ({
+      canGoBack: canGoBack ?? false,
+      goBack: goBack ?? (() => {}),
+    }),
+    [canGoBack, goBack]
+  );
+  return (
+    <BackNavigationContext.Provider value={value}>
+      {children}
+    </BackNavigationContext.Provider>
+  );
+}

--- a/apps/web/public/apple-app-site-association
+++ b/apps/web/public/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "G24T327LXT.ie.jov.Jovie",
+        "paths": [ "*" ]
+      }
+    ]
+  }
+}

--- a/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
+++ b/apps/web/tests/unit/components/atoms/DesktopTitlebar.test.tsx
@@ -7,9 +7,19 @@ const electronRuntimeMock = vi.hoisted(() => ({
   isElectronRuntime: true,
 }));
 
-vi.mock('@/lib/desktop/electron-bridge', () => ({
-  useIsElectronRuntime: () => electronRuntimeMock.isElectronRuntime,
-}));
+vi.mock('@/lib/desktop/electron-bridge', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useIsElectronRuntime: () => electronRuntimeMock.isElectronRuntime,
+    useDesktopNavigation: () => ({
+      canGoBack: true,
+      canGoForward: true,
+      goBack: vi.fn(),
+      goForward: vi.fn(),
+    }),
+  };
+});
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({


### PR DESCRIPTION
This PR adds:\n\n1. BackNavigationContext for handling back/forward navigation state\n2. Updated DesktopTitlebar component for Electron-only titlebar drag region with proper navigation controls\n3. Updated iOS entitlements to include applinks:jov.ie for universal links\n\nThe DesktopTitlebar now:\n- Removes unused imports (ArrowLeft, ArrowRight, useRouter)\n- Properly implements Electron titlebar drag region\n- Includes back/forward navigation buttons\n- Sidebar toggle\n- Update available pill\n- Only renders in Electron environment\n\nFixes the git merge conflicts from previous attempts and resolves linting/typecheck issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS: Added universal links support so links to jov.ie can open the app.
  * Desktop app: Back/forward controls now reflect actual navigation availability and use native desktop navigation for more reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->