### PR TITLE
fix: harden iOS live Clerk auth

### DIFF
--- a/apps/ios/Jovie/App/JovieApp.swift
+++ b/apps/ios/Jovie/App/JovieApp.swift
@@ -252,13 +252,17 @@ enum NativeTicketSignInDiagnostics {
 }
 #endif
 
-func makeJovieClerkOptions(redirectUrl: String, callbackUrlScheme: String) -> Clerk.Options {
+func makeJovieClerkOptions(
+  redirectUrl: String,
+  callbackUrlScheme: String,
+  keychainService: String = "ie.jov.Jovie"
+) -> Clerk.Options {
   let responseMiddleware: [any ClerkResponseMiddleware] = [
     NativeTicketSignInResponseMiddleware(),
   ]
 
   return Clerk.Options(
-    keychainConfig: .init(service: "ie.jov.Jovie"),
+    keychainConfig: .init(service: keychainService),
     // Uses env-driven values from AppConfiguration (gh-9806/JOV-2652).
     // These MUST be registered as allowed redirect URLs in the Clerk dashboard
     // for the matching publishable key (native/iOS app section). Explicit config
@@ -311,9 +315,14 @@ struct JovieApp: App {
         publishableKey: configuration.clerkPublishableKey,
         options: makeJovieClerkOptions(
           redirectUrl: configuration.clerkRedirectUrl,
-          callbackUrlScheme: configuration.clerkCallbackUrlScheme
+          callbackUrlScheme: configuration.clerkCallbackUrlScheme,
+          keychainService: launchMode.clerkKeychainService
         )
       )
+
+      if launchMode.clearsStoredClerkSession {
+        Clerk.clearAllKeychainItems()
+      }
     }
 
     let repository = MeRepository(

--- a/apps/ios/Jovie/App/LaunchMode.swift
+++ b/apps/ios/Jovie/App/LaunchMode.swift
@@ -48,6 +48,31 @@ enum LaunchMode: Equatable {
     self == .uiTestingVenueMode
   }
 
+  var clearsStoredClerkSession: Bool {
+    self == .uiTestingLiveAuth
+  }
+
+  var clerkKeychainService: String {
+    switch self {
+    case .uiTestingAutoAuth:
+      return "ie.jov.Jovie.ui-testing-auto-auth"
+    case .uiTestingLiveAuth:
+      return "ie.jov.Jovie.ui-testing-live-auth"
+    case .live,
+         .unitTesting,
+         .uiTestingRealBrowserAuth,
+         .uiTestingAuthCallback,
+         .uiTestingSignedOut,
+         .uiTestingReady,
+         .uiTestingChat,
+         .uiTestingSettings,
+         .uiTestingVenueMode,
+         .uiTestingNeedsOnboarding,
+         .uiTestingSplash:
+      return "ie.jov.Jovie"
+    }
+  }
+
   static func current(processInfo: ProcessInfo = .processInfo) -> LaunchMode {
     let arguments = processInfo.arguments
 

--- a/apps/ios/JovieTests/APIClientTests.swift
+++ b/apps/ios/JovieTests/APIClientTests.swift
@@ -196,20 +196,15 @@ struct ClerkLiveAuthIntegrationTests {
   }
 
   private func liveAuthConfig() throws -> LiveAuthConfig? {
-    let environment = ProcessInfo.processInfo.environment
-    guard environment["JOVIE_IOS_LIVE_AUTH"] == "1" else {
+    guard Self.forwardedEnvironmentValue("JOVIE_IOS_LIVE_AUTH") == "1" else {
       return nil
     }
 
     let publishableKey =
-      environment["CLERK_PUBLISHABLE_KEY"] ??
-      environment["NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY"] ??
-      ""
-    let emailAddress = environment["E2E_CLERK_USER_USERNAME"] ?? ""
-    let apiBaseURLString =
-      environment["JOVIE_IOS_API_BASE_URL"] ??
-      environment["API_BASE_URL"] ??
-      "http://localhost:3100"
+      Self.forwardedEnvironmentValue("CLERK_PUBLISHABLE_KEY", "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY")
+    let emailAddress = Self.forwardedEnvironmentValue("E2E_CLERK_USER_USERNAME")
+    let configuredAPIBaseURL = Self.forwardedEnvironmentValue("JOVIE_IOS_API_BASE_URL", "API_BASE_URL")
+    let apiBaseURLString = configuredAPIBaseURL.isEmpty ? "http://localhost:3100" : configuredAPIBaseURL
 
     guard !publishableKey.isEmpty else {
       throw LiveAuthConfigurationError.missingPublishableKey
@@ -228,6 +223,22 @@ struct ClerkLiveAuthIntegrationTests {
       apiBaseURL: apiBaseURL,
       emailAddress: emailAddress
     )
+  }
+
+  private static func forwardedEnvironmentValue(_ keys: String...) -> String {
+    let environment = ProcessInfo.processInfo.environment
+
+    for key in keys {
+      if let value = environment[key], !value.isEmpty {
+        return value
+      }
+
+      if let value = environment["TEST_RUNNER_\(key)"], !value.isEmpty {
+        return value
+      }
+    }
+
+    return ""
   }
 
   private func configureClerk(with config: LiveAuthConfig) async throws {

--- a/apps/ios/JovieUITests/JovieUITests.swift
+++ b/apps/ios/JovieUITests/JovieUITests.swift
@@ -126,7 +126,7 @@ final class JovieUITests: XCTestCase {
   }
 
   func testLiveAuthViewRenders() throws {
-    guard ProcessInfo.processInfo.environment["JOVIE_IOS_LIVE_AUTH_UI"] == "1" else {
+    guard testEnvironmentValue("JOVIE_IOS_LIVE_AUTH_UI") == "1" else {
       throw XCTSkip("Set JOVIE_IOS_LIVE_AUTH_UI=1 to run the live Clerk UI spike.")
     }
 
@@ -140,7 +140,7 @@ final class JovieUITests: XCTestCase {
   }
 
   func testLiveNativeSessionCanReachAnAuthenticatedMobileState() throws {
-    guard ProcessInfo.processInfo.environment["JOVIE_IOS_LIVE_AUTH_UI"] == "1" else {
+    guard testEnvironmentValue("JOVIE_IOS_LIVE_AUTH_UI") == "1" else {
       throw XCTSkip("Set JOVIE_IOS_LIVE_AUTH_UI=1 to run the live Clerk UI spike.")
     }
 
@@ -255,9 +255,12 @@ final class JovieUITests: XCTestCase {
       testEnvironmentValue("CLERK_PUBLISHABLE_KEY") ??
       testEnvironmentValue("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY") ??
       ""
-    let apiBaseURL = ProcessInfo.processInfo.environment["API_BASE_URL"] ?? "http://localhost:3003"
+    let apiBaseURL =
+      testEnvironmentValue("JOVIE_IOS_API_BASE_URL") ??
+      testEnvironmentValue("API_BASE_URL") ??
+      "http://localhost:3003"
     let emailAddress = try requiredEnvironmentValue("E2E_CLERK_USER_USERNAME")
-    let verificationCode = ProcessInfo.processInfo.environment["JOVIE_IOS_LIVE_AUTH_CODE"] ?? "424242"
+    let verificationCode = testEnvironmentValue("JOVIE_IOS_LIVE_AUTH_CODE") ?? "424242"
 
     let app = XCUIApplication()
     app.launchArguments.append(launchArgument)
@@ -317,7 +320,7 @@ final class JovieUITests: XCTestCase {
   private func requiredEnvironmentValue(_ key: String) throws -> String {
     let value = testEnvironmentValue(key) ?? ""
     guard !value.isEmpty else {
-      throw XCTSkip("Missing \(key) for live Clerk UI testing.")
+      throw XCTSkip("Missing \(key) or TEST_RUNNER_\(key) for live Clerk UI testing.")
     }
 
     return value
@@ -336,7 +339,13 @@ final class JovieUITests: XCTestCase {
   }
 
   private func testEnvironmentValue(_ key: String) -> String? {
-    if let value = ProcessInfo.processInfo.environment[key], !value.isEmpty {
+    let environment = ProcessInfo.processInfo.environment
+
+    if let value = environment[key], !value.isEmpty {
+      return value
+    }
+
+    if let value = environment["TEST_RUNNER_\(key)"], !value.isEmpty {
       return value
     }
 
@@ -351,7 +360,9 @@ final class JovieUITests: XCTestCase {
 
     for line in contents.split(separator: "\n") {
       let parts = line.split(separator: "=", maxSplits: 1).map(String.init)
-      guard parts.count == 2, parts[0] == key else { continue }
+      guard parts.count == 2, parts[0] == key || parts[0] == "TEST_RUNNER_\(key)" else {
+        continue
+      }
       return parts[1]
     }
 

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -42,6 +42,20 @@ Native iOS foundation for Jovie. The app is dark-only, simulator-tested, and wir
    pnpm run ios:test
    ```
 
+   Live Clerk auth tests are skipped by default. To run them locally, use the
+   dev Doppler config and allow simulator code signing so Clerk can use the
+   keychain. The test wrapper forwards the live-auth environment into XCTest via
+   `TEST_RUNNER_*` so the UI test process can read it:
+
+   ```bash
+   doppler run --project jovie-web --config dev -- env \
+     CODE_SIGNING_ALLOWED=YES \
+     JOVIE_IOS_LIVE_AUTH=1 \
+     JOVIE_IOS_LIVE_AUTH_UI=1 \
+     API_BASE_URL=http://localhost:3100 \
+     pnpm run ios:test
+   ```
+
 5. Run the iOS auth callback close-loop test:
 
    ```bash
@@ -72,7 +86,6 @@ bundle exec fastlane ios beta
 Release CI uses these GitHub secrets: `APPLE_API_KEY`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`, `APPLE_TEAM_ID`, `MATCH_GIT_URL`, `MATCH_PASSWORD`, one of `MATCH_GIT_PRIVATE_KEY` or `MATCH_GIT_BASIC_AUTHORIZATION`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, and `CLERK_ASSOCIATED_DOMAIN`.
 
 `bootstrap_signing` is intentionally manual. It creates or verifies the Apple bundle identifier, enables Associated Domains, creates or verifies the App Store Connect app record, and writes App Store distribution assets into match storage. Normal TestFlight uploads use readonly match in CI.
-
 ## Notes
 
 - `apps/ios/Jovie/Configuration.local.plist` is generated and gitignored.

--- a/apps/ios/scripts/run-xcodebuild.sh
+++ b/apps/ios/scripts/run-xcodebuild.sh
@@ -5,6 +5,7 @@ ACTION="${1:-test}"
 if [[ $# -gt 0 ]]; then
   shift
 fi
+CODE_SIGNING_ALLOWED_VALUE="${CODE_SIGNING_ALLOWED:-NO}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROJECT_PATH="$IOS_DIR/Jovie.xcodeproj"
@@ -248,6 +249,36 @@ if [[ "$ACTION" == "destination" ]]; then
 fi
 
 echo "Using destination: $DESTINATION"
+echo "Using CODE_SIGNING_ALLOWED=$CODE_SIGNING_ALLOWED_VALUE"
+
+FORWARDED_TEST_RUNNER_ENV=0
+
+forward_test_runner_env() {
+  local source_key="$1"
+  local value="${!source_key:-}"
+
+  if [[ -n "$value" ]]; then
+    export "TEST_RUNNER_${source_key}=$value"
+    FORWARDED_TEST_RUNNER_ENV=1
+  fi
+}
+
+for source_key in \
+  API_BASE_URL \
+  CLERK_PUBLISHABLE_KEY \
+  E2E_CLERK_USER_USERNAME \
+  JOVIE_IOS_API_BASE_URL \
+  JOVIE_IOS_LIVE_AUTH \
+  JOVIE_IOS_LIVE_AUTH_CODE \
+  JOVIE_IOS_LIVE_AUTH_UI \
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+do
+  forward_test_runner_env "$source_key"
+done
+
+if [[ "$FORWARDED_TEST_RUNNER_ENV" -eq 1 ]]; then
+  echo "Forwarding XCTest environment via TEST_RUNNER_*"
+fi
 
 DESTINATION_ID="${DESTINATION#*id=}"
 DESTINATION_ID="${DESTINATION_ID%%,*}"
@@ -264,4 +295,4 @@ xcodebuild "$ACTION" \
   -scheme "$SCHEME" \
   -destination "$DESTINATION" \
   "$@" \
-  CODE_SIGNING_ALLOWED=NO
+  CODE_SIGNING_ALLOWED="$CODE_SIGNING_ALLOWED_VALUE"


### PR DESCRIPTION
Linear: JOV-2711

## Summary
- configure Clerk with launch-mode-specific keychain services while preserving the current env-driven native redirect/middleware setup
- clear stored Clerk session for the signed-out live-auth UI launch mode
- allow the iOS test wrapper to opt into simulator code signing and forward live-auth env into XCTest through `TEST_RUNNER_*`
- teach iOS live-auth unit/UI tests to read plain or forwarded test-runner env values

## Verification
- `bash -n apps/ios/scripts/run-xcodebuild.sh`
- `pnpm run ios:test` passed on current `origin/main`: 43 Swift tests in 10 suites passed; 14 UI tests ran with 4 skips for gated/pre-existing cases, 0 failures
- `doppler run --project jovie-web --config dev -- env CODE_SIGNING_ALLOWED=YES JOVIE_IOS_LIVE_AUTH=1 JOVIE_IOS_LIVE_AUTH_UI=1 API_BASE_URL=http://localhost:3100 pnpm run ios:test` passed; wrapper printed `Forwarding XCTest environment via TEST_RUNNER_*`; live unit integration passed; `testLiveAuthViewRenders` and `testLiveNativeSessionCanReachAnAuthenticatedMobileState` both ran and passed; final UI summary was 14 tests, 2 skips, 0 failures
- `git diff origin/main..HEAD --check`
- pre-push hook passed after refreshing local dependencies with `pnpm install --frozen-lockfile`: `biome check .`, web proxy guard, Tailwind guard, web typecheck, web lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Configurable keychain service based on app launch mode, with conditional session clearing for test environments

* **Documentation**
  - Added guide for running live authentication UI tests with proper environment setup

* **Tests & Infrastructure**
  - Enhanced environment variable resolution for test execution
  - Improved test runner environment variable forwarding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->