### PR TITLE
docs: seed hardening audit deliverables

### DIFF
--- a/AUTH_AUDIT.md
+++ b/AUTH_AUDIT.md
@@ -1,0 +1,36 @@
+# Auth Audit
+
+Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platform-hardening-deliverables-and-ios-evidence-baseline)
+
+## Scope
+
+This audit tracks sign-up, sign-in, sign-out, session refresh, session
+expiration, deep linking, browser redirects, mobile redirects, Clerk
+integration, Supabase integration, protected routes, and permission enforcement
+across Web, iOS, Electron, and Chrome Extension.
+
+## iOS Evidence
+
+| Flow | Evidence | Result |
+| --- | --- | --- |
+| Live Clerk email-code bootstrap | PR [#9907](https://github.com/JovieInc/Jovie/pull/9907) merged as `9e9200348e`. The branch isolated live and auto-auth UI test keychains, cleared stored live-auth sessions for the signed-out launch mode, and forwarded live-auth env into XCTest via `TEST_RUNNER_*`. | Passed and merged |
+| Default iOS auth/test suite | `pnpm run ios:test` passed before PR #9907 merge; iOS CI `Build And Test` passed in 24m58s on PR #9907. | Passed |
+| Native custom-scheme auth callback | `pnpm test:auth:ios` passed on `origin/main` `9e9200348e`. It ran 18 `AppStateTests` and 2 deterministic XCUITests: `testAuthCallbackDeepLinkCompletesHarness` and `testAuthCallbackProviderErrorShowsAuthError`. | Passed |
+| Native exchange live-auth smoke | Local live run before PR #9907 merge passed with `CODE_SIGNING_ALLOWED=YES`, `JOVIE_IOS_LIVE_AUTH=1`, and `JOVIE_IOS_LIVE_AUTH_UI=1`; the unit integration and live UI tests passed. | Passed for dev credentials |
+| Real browser auth mode | `pnpm test:auth:ios` kept this mode gated because `JOVIE_IOS_REAL_BROWSER_AUTH=1` was not set for this evidence pass. | Evidence required under JOV-2712 |
+
+## Current Platform Status
+
+| Platform | Status |
+| --- | --- |
+| iOS | Local auth callback, live-auth PR verification, and CI evidence are current for `9e9200348e`. |
+| Web | Evidence required under JOV-2712. |
+| Electron | Evidence required under JOV-2712. |
+| Chrome Extension | Evidence required under JOV-2712. |
+
+## Acceptance Checks
+
+- No iOS auth dead end reproduced in the deterministic callback flows.
+- No iOS redirect loop reproduced in the deterministic callback flows.
+- No iOS stuck loading state observed in the generated signed-out/profile/chat screenshots.
+- Remaining platform evidence is tracked by JOV-2712 rather than untracked notes.

--- a/AUTH_AUDIT.md
+++ b/AUTH_AUDIT.md
@@ -17,13 +17,13 @@ across Web, iOS, Electron, and Chrome Extension.
 | Default iOS auth/test suite | `pnpm run ios:test` passed before PR #9907 merge; iOS CI `Build And Test` passed in 24m58s on PR #9907. | Passed |
 | Native custom-scheme auth callback | `pnpm test:auth:ios` passed on `origin/main` `9e9200348e`. It ran 18 `AppStateTests` and 2 deterministic XCUITests: `testAuthCallbackDeepLinkCompletesHarness` and `testAuthCallbackProviderErrorShowsAuthError`. | Passed |
 | Native exchange live-auth smoke | Local live run before PR #9907 merge passed with `CODE_SIGNING_ALLOWED=YES`, `JOVIE_IOS_LIVE_AUTH=1`, and `JOVIE_IOS_LIVE_AUTH_UI=1`; the unit integration and live UI tests passed. | Passed for dev credentials |
-| Real browser auth mode | `pnpm test:auth:ios` kept this mode gated because `JOVIE_IOS_REAL_BROWSER_AUTH=1` was not set for this evidence pass. | Evidence required under JOV-2712 |
+| Real browser auth mode | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` passed through Doppler dev config against a temporary Cloudflare tunnel to local dev. It ran the HTTPS ASWebAuthenticationSession test `testRealBrowserAuthProviderCompleteReachesAuthenticatedShell`. | Passed |
 
 ## Current Platform Status
 
 | Platform | Status |
 | --- | --- |
-| iOS | Local auth callback, live-auth PR verification, and CI evidence are current for `9e9200348e`. |
+| iOS | Local auth callback, real-browser auth callback, live-auth PR verification, and CI evidence are current for `9e9200348e`. |
 | Web | Evidence required under JOV-2712. |
 | Electron | Evidence required under JOV-2712. |
 | Chrome Extension | Evidence required under JOV-2712. |
@@ -32,5 +32,6 @@ across Web, iOS, Electron, and Chrome Extension.
 
 - No iOS auth dead end reproduced in the deterministic callback flows.
 - No iOS redirect loop reproduced in the deterministic callback flows.
+- No iOS real-browser auth dead end reproduced in the HTTPS ASWebAuthenticationSession flow.
 - No iOS stuck loading state observed in the generated signed-out/profile/chat screenshots.
 - Remaining platform evidence is tracked by JOV-2712 rather than untracked notes.

--- a/CHAT_AUDIT.md
+++ b/CHAT_AUDIT.md
@@ -1,0 +1,29 @@
+# Chat Audit
+
+Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platform-hardening-deliverables-and-ios-evidence-baseline)
+
+## Scope
+
+This audit tracks streaming, message rendering, markdown rendering, tool
+invocation rendering, retry behavior, error recovery, context persistence,
+scroll behavior, message ordering, optimistic updates, and reconnection
+behavior across Web, iOS, Electron, and Chrome Extension.
+
+## Current Evidence
+
+| Platform | Evidence | Result |
+| --- | --- | --- |
+| iOS | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e` and produced `artifacts/ios-screenshots/06-chat.png`. The screenshot rendered the chat shell, empty state, input, and controls without obvious clipping or blank content. | Visual smoke passed |
+| Web | Evidence required under JOV-2712. | Open |
+| Electron | Evidence required under JOV-2712. | Open |
+| Chrome Extension | Evidence required under JOV-2712. | Open |
+
+## Acceptance Checks
+
+| Check | Status |
+| --- | --- |
+| Stable streaming | Evidence required under JOV-2712 |
+| Smooth scrolling | Evidence required under JOV-2712 |
+| No lost conversations | Evidence required under JOV-2712 |
+| No duplicate messages | Evidence required under JOV-2712 |
+| Consistent platform behavior | Evidence required under JOV-2712 |

--- a/CRITICAL_BUGS.md
+++ b/CRITICAL_BUGS.md
@@ -1,0 +1,27 @@
+# Critical Bugs
+
+Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platform-hardening-deliverables-and-ios-evidence-baseline)
+
+## Severity Definitions
+
+| Severity | Definition |
+| --- | --- |
+| Critical | Blocks sign-up, sign-in, onboarding, chat, billing, data integrity, deployment, or production observability on a required platform. |
+| High | Causes repeated user-visible failure, lost work, or platform inconsistency on a core workflow. |
+| Medium | Degrades a core workflow with a recovery path. |
+| Low | Cosmetic or non-core issue with no workflow loss. |
+
+## Current Ledger
+
+| ID | Area | Evidence | Status |
+| --- | --- | --- | --- |
+| JOV-2712-AUTH-REAL-BROWSER | iOS real browser auth mode | `pnpm test:auth:ios` keeps real browser auth gated unless `JOVIE_IOS_REAL_BROWSER_AUTH=1` is set. | Evidence required under JOV-2712 |
+| JOV-2712-WEB-AUDIT | Web auth, chat, performance, reliability, parity | Required hardening evidence has no current report entry beyond this baseline. | Evidence required under JOV-2712 |
+| JOV-2712-ELECTRON-AUDIT | Electron auth, redirects, startup, reliability, parity | Required hardening evidence has no current report entry beyond this baseline. | Evidence required under JOV-2712 |
+| JOV-2712-EXTENSION-AUDIT | Chrome Extension auth, messaging, popup/background performance, reliability, parity | Required hardening evidence has no current report entry beyond this baseline. | Evidence required under JOV-2712 |
+
+## Current iOS Result
+
+No critical iOS auth callback failure was reproduced by `pnpm test:auth:ios` on
+`origin/main` `9e9200348e`. The deterministic callback suite and app-state suite
+passed, and the known live Clerk auth hardening PR merged as #9907.

--- a/CRITICAL_BUGS.md
+++ b/CRITICAL_BUGS.md
@@ -15,7 +15,6 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 
 | ID | Area | Evidence | Status |
 | --- | --- | --- | --- |
-| JOV-2712-AUTH-REAL-BROWSER | iOS real browser auth mode | `pnpm test:auth:ios` keeps real browser auth gated unless `JOVIE_IOS_REAL_BROWSER_AUTH=1` is set. | Evidence required under JOV-2712 |
 | JOV-2712-WEB-AUDIT | Web auth, chat, performance, reliability, parity | Required hardening evidence has no current report entry beyond this baseline. | Evidence required under JOV-2712 |
 | JOV-2712-ELECTRON-AUDIT | Electron auth, redirects, startup, reliability, parity | Required hardening evidence has no current report entry beyond this baseline. | Evidence required under JOV-2712 |
 | JOV-2712-EXTENSION-AUDIT | Chrome Extension auth, messaging, popup/background performance, reliability, parity | Required hardening evidence has no current report entry beyond this baseline. | Evidence required under JOV-2712 |
@@ -23,5 +22,6 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 ## Current iOS Result
 
 No critical iOS auth callback failure was reproduced by `pnpm test:auth:ios` on
-`origin/main` `9e9200348e`. The deterministic callback suite and app-state suite
-passed, and the known live Clerk auth hardening PR merged as #9907.
+`origin/main` `9e9200348e`. The deterministic callback suite, real-browser auth
+suite, and app-state suite passed, and the known live Clerk auth hardening PR
+merged as #9907.

--- a/DESIGN_SYSTEM_AUDIT.md
+++ b/DESIGN_SYSTEM_AUDIT.md
@@ -1,0 +1,28 @@
+# Design System Audit
+
+Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platform-hardening-deliverables-and-ios-evidence-baseline)
+
+## Scope
+
+This audit tracks canonical primitives, duplicate components, spacing,
+typography, colors, button styles, loading states, empty states, navigation
+patterns, modals, drawers, cards, tables, lists, right rails, and error states.
+
+## Current Evidence
+
+| Surface | Evidence | Result |
+| --- | --- | --- |
+| iOS signed-out/profile/settings/onboarding/chat | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e`; screenshots are in `artifacts/ios-screenshots`. | Rendered and legible |
+| iOS iPad shell | `pnpm run ios:screenshots` produced `07-ipad-shell.png` at `1640x2360`. | Rendered and legible |
+| Web app shell and marketing surfaces | Evidence required under JOV-2712. | Open |
+| Electron shell | Evidence required under JOV-2712. | Open |
+| Chrome Extension UI | Evidence required under JOV-2712. | Open |
+
+## Acceptance Checks
+
+| Check | Status |
+| --- | --- |
+| Every screen uses canonical design system primitives | Evidence required under JOV-2712 |
+| No duplicated component systems | Evidence required under JOV-2712 |
+| No legacy UI patterns | Evidence required under JOV-2712 |
+| Loading, empty, and error states are consistent | Evidence required under JOV-2712 |

--- a/HARDENING.md
+++ b/HARDENING.md
@@ -1,0 +1,30 @@
+# Jovie Platform Hardening
+
+Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platform-hardening-deliverables-and-ios-evidence-baseline)
+
+This file is the index for the production-readiness deliverables requested in
+the June 2 hardening brief. Each linked artifact distinguishes verified,
+failing, and evidence-required areas, with evidence from local checks, CI,
+staging, or production as appropriate.
+
+## Current Evidence
+
+| Area | Current evidence | Status |
+| --- | --- | --- |
+| iOS live Clerk auth | PR [#9907](https://github.com/JovieInc/Jovie/pull/9907) merged as `9e9200348e`; iOS CI `Build And Test` passed; live-auth local run passed before merge. | Verified for the PR scope |
+| iOS custom-scheme auth callback | `pnpm test:auth:ios` passed on `origin/main` `9e9200348e`: 18 `AppStateTests` and 2 deterministic XCUITests passed. | Verified locally |
+| iOS core screenshots | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e`, producing loading, signed-out, profile, fullscreen QR, settings, needs-onboarding, chat, and iPad shell screenshots. | Verified locally |
+
+## Deliverables
+
+| Deliverable | Status |
+| --- | --- |
+| `AUTH_AUDIT.md` | Created with iOS auth evidence and JOV-2712 evidence gaps |
+| `CHAT_AUDIT.md` | Created with iOS chat screenshot baseline and JOV-2712 evidence gaps |
+| `PERFORMANCE.md` | Created with measurement plan and JOV-2712 evidence gaps |
+| `DESIGN_SYSTEM_AUDIT.md` | Created with iOS screenshot baseline and JOV-2712 evidence gaps |
+| `RELIABILITY_AUDIT.md` | Created with iOS callback reliability baseline and JOV-2712 evidence gaps |
+| `PLATFORM_PARITY_AUDIT.md` | Created with cross-platform parity matrix and JOV-2712 evidence gaps |
+| `TEST_COVERAGE_REPORT.md` | Created with current iOS test evidence and JOV-2712 evidence gaps |
+| `RELEASE_CHECKLIST.md` | Created with release gates and JOV-2712 evidence gaps |
+| `CRITICAL_BUGS.md` | Created with critical-risk ledger and JOV-2712 evidence gaps |

--- a/HARDENING.md
+++ b/HARDENING.md
@@ -13,6 +13,7 @@ staging, or production as appropriate.
 | --- | --- | --- |
 | iOS live Clerk auth | PR [#9907](https://github.com/JovieInc/Jovie/pull/9907) merged as `9e9200348e`; iOS CI `Build And Test` passed; live-auth local run passed before merge. | Verified for the PR scope |
 | iOS custom-scheme auth callback | `pnpm test:auth:ios` passed on `origin/main` `9e9200348e`: 18 `AppStateTests` and 2 deterministic XCUITests passed. | Verified locally |
+| iOS real-browser auth callback | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` passed through Doppler dev config against a temporary Cloudflare tunnel to local dev. | Verified locally |
 | iOS core screenshots | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e`, producing loading, signed-out, profile, fullscreen QR, settings, needs-onboarding, chat, and iPad shell screenshots. | Verified locally |
 
 ## Deliverables

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,29 @@
+# Performance Audit
+
+Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platform-hardening-deliverables-and-ios-evidence-baseline)
+
+## Scope
+
+This audit tracks cold start, warm start, route transitions, chat rendering,
+profile loading, search performance, memory usage, CPU usage, network requests,
+bundle size, rerenders, queries, data fetching, image loading, caching,
+hydration, and virtualization.
+
+## Current Evidence
+
+| Area | Evidence | Status |
+| --- | --- | --- |
+| iOS launch/render smoke | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e` and captured loading, signed-out, profile, settings, onboarding, chat, and iPad shell states. | Visual smoke passed |
+| iOS auth test runtime | `pnpm test:auth:ios` passed deterministic auth coverage on `origin/main` `9e9200348e`. | Test runtime captured in command output |
+| Web first load and Lighthouse | Evidence required under JOV-2712. | Open |
+| Electron startup and memory | Evidence required under JOV-2712. | Open |
+| Chrome Extension popup/background performance | Evidence required under JOV-2712. | Open |
+
+## Targets
+
+| Platform | Target | Current status |
+| --- | --- | --- |
+| Web | First load under 2 seconds, no unnecessary rerenders, Lighthouse over 90. | Evidence required under JOV-2712 |
+| iOS | Launch under 2 seconds, no frame drops, no memory leaks. | Evidence required under JOV-2712 |
+| Electron | Startup under 3 seconds, stable memory footprint, no renderer crashes. | Evidence required under JOV-2712 |
+| Chrome Extension | Fast popup open, fast background execution, minimal memory usage. | Evidence required under JOV-2712 |

--- a/PLATFORM_PARITY_AUDIT.md
+++ b/PLATFORM_PARITY_AUDIT.md
@@ -13,7 +13,7 @@ constraints.
 
 | Capability | Web | iOS | Electron | Chrome Extension |
 | --- | --- | --- | --- | --- |
-| Sign in and sign out | Evidence required under JOV-2712 | Deterministic callback and live-auth evidence current for `9e9200348e` | Evidence required under JOV-2712 | Evidence required under JOV-2712 |
+| Sign in and sign out | Evidence required under JOV-2712 | Deterministic callback, real-browser callback, and live-auth evidence current for `9e9200348e` | Evidence required under JOV-2712 | Evidence required under JOV-2712 |
 | Account creation and onboarding | Evidence required under JOV-2712 | Screenshot smoke includes needs-onboarding state | Evidence required under JOV-2712 | Evidence required under JOV-2712 |
 | Profile rendering | Evidence required under JOV-2712 | Screenshot smoke includes profile state | Evidence required under JOV-2712 | Evidence required under JOV-2712 |
 | Chat shell | Evidence required under JOV-2712 | Screenshot smoke includes chat state | Evidence required under JOV-2712 | Evidence required under JOV-2712 |

--- a/PLATFORM_PARITY_AUDIT.md
+++ b/PLATFORM_PARITY_AUDIT.md
@@ -1,0 +1,29 @@
+# Platform Parity Audit
+
+Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platform-hardening-deliverables-and-ios-evidence-baseline)
+
+## Scope
+
+This audit compares functional parity across Web, iOS, Electron, and Chrome
+Extension for authentication, chat, artist onboarding, profile management,
+links, alerts, tipping, account management, billing, and platform-specific
+constraints.
+
+## Current Matrix
+
+| Capability | Web | iOS | Electron | Chrome Extension |
+| --- | --- | --- | --- | --- |
+| Sign in and sign out | Evidence required under JOV-2712 | Deterministic callback and live-auth evidence current for `9e9200348e` | Evidence required under JOV-2712 | Evidence required under JOV-2712 |
+| Account creation and onboarding | Evidence required under JOV-2712 | Screenshot smoke includes needs-onboarding state | Evidence required under JOV-2712 | Evidence required under JOV-2712 |
+| Profile rendering | Evidence required under JOV-2712 | Screenshot smoke includes profile state | Evidence required under JOV-2712 | Evidence required under JOV-2712 |
+| Chat shell | Evidence required under JOV-2712 | Screenshot smoke includes chat state | Evidence required under JOV-2712 | Evidence required under JOV-2712 |
+| Settings/account management | Evidence required under JOV-2712 | Screenshot smoke includes settings state | Evidence required under JOV-2712 | Evidence required under JOV-2712 |
+| Billing and subscription management | Evidence required under JOV-2712 | Evidence required under JOV-2712 | Evidence required under JOV-2712 | Evidence required under JOV-2712 |
+
+## Acceptance Checks
+
+| Check | Status |
+| --- | --- |
+| Functionally equivalent behavior where platform constraints allow it | Evidence required under JOV-2712 |
+| Platform-specific limitations are documented | Evidence required under JOV-2712 |
+| Auth and chat behave consistently across clients | Evidence required under JOV-2712 |

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -20,5 +20,6 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Check | Evidence | Result |
 | --- | --- | --- |
 | Auth callback suite | `pnpm test:auth:ios` passed on `origin/main` `9e9200348e`. | Passed |
+| Real-browser auth suite | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` passed against a temporary HTTPS tunnel to local dev. | Passed |
 | Screenshot smoke | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e`. | Passed |
 | Live Clerk auth PR | PR #9907 merged as `9e9200348e` after local and CI verification. | Passed |

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,24 @@
+# Release Checklist
+
+Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platform-hardening-deliverables-and-ios-evidence-baseline)
+
+## Required Gates
+
+| Gate | Status |
+| --- | --- |
+| Web typecheck, lint, unit, integration, and Playwright evidence | Evidence required under JOV-2712 |
+| iOS XCTest and XCUITest evidence | Auth callback and screenshot smoke evidence recorded for `9e9200348e` |
+| Electron build, auth, deep link, and end-to-end evidence | Evidence required under JOV-2712 |
+| Chrome Extension popup, background, auth, and messaging evidence | Evidence required under JOV-2712 |
+| Staging verification | Evidence required under JOV-2712 |
+| Production verification | Evidence required under JOV-2712 |
+| Critical bug ledger clear or explicitly accepted | Evidence required under JOV-2712 |
+| Bot review comments addressed before merge | Required by `.claude/rules/release.md` |
+
+## Current iOS Evidence
+
+| Check | Evidence | Result |
+| --- | --- | --- |
+| Auth callback suite | `pnpm test:auth:ios` passed on `origin/main` `9e9200348e`. | Passed |
+| Screenshot smoke | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e`. | Passed |
+| Live Clerk auth PR | PR #9907 merged as `9e9200348e` after local and CI verification. | Passed |

--- a/RELIABILITY_AUDIT.md
+++ b/RELIABILITY_AUDIT.md
@@ -1,0 +1,29 @@
+# Reliability Audit
+
+Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platform-hardening-deliverables-and-ios-evidence-baseline)
+
+## Scope
+
+This audit tracks behavior under slow internet, offline mode, API failures,
+database failures, authentication failures, rate limiting, network
+interruptions, browser refreshes, app restarts, and extension reloads.
+
+## Current Evidence
+
+| Scenario | Evidence | Result |
+| --- | --- | --- |
+| iOS auth callback success | `pnpm test:auth:ios` passed `testAuthCallbackDeepLinkCompletesHarness` on `origin/main` `9e9200348e`. | Passed |
+| iOS auth callback provider error | `pnpm test:auth:ios` passed `testAuthCallbackProviderErrorShowsAuthError` on `origin/main` `9e9200348e`. | Passed |
+| iOS app state transitions | `pnpm test:auth:ios` passed 18 `AppStateTests` on `origin/main` `9e9200348e`. | Passed |
+| Slow internet and offline behavior | Evidence required under JOV-2712. | Open |
+| API, database, and rate-limit failures | Evidence required under JOV-2712. | Open |
+| Electron and Chrome Extension restart/reload recovery | Evidence required under JOV-2712. | Open |
+
+## Acceptance Checks
+
+| Check | Status |
+| --- | --- |
+| Graceful degradation | Evidence required under JOV-2712 |
+| Meaningful error messages | iOS provider-error callback covered; cross-platform evidence required under JOV-2712 |
+| Automatic recovery where possible | Evidence required under JOV-2712 |
+| User recovery paths where automatic recovery is unavailable | Evidence required under JOV-2712 |

--- a/RELIABILITY_AUDIT.md
+++ b/RELIABILITY_AUDIT.md
@@ -14,6 +14,7 @@ interruptions, browser refreshes, app restarts, and extension reloads.
 | --- | --- | --- |
 | iOS auth callback success | `pnpm test:auth:ios` passed `testAuthCallbackDeepLinkCompletesHarness` on `origin/main` `9e9200348e`. | Passed |
 | iOS auth callback provider error | `pnpm test:auth:ios` passed `testAuthCallbackProviderErrorShowsAuthError` on `origin/main` `9e9200348e`. | Passed |
+| iOS real-browser auth callback | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` passed `testRealBrowserAuthProviderCompleteReachesAuthenticatedShell` against a temporary HTTPS tunnel to local dev. | Passed |
 | iOS app state transitions | `pnpm test:auth:ios` passed 18 `AppStateTests` on `origin/main` `9e9200348e`. | Passed |
 | Slow internet and offline behavior | Evidence required under JOV-2712. | Open |
 | API, database, and rate-limit failures | Evidence required under JOV-2712. | Open |

--- a/TEST_COVERAGE_REPORT.md
+++ b/TEST_COVERAGE_REPORT.md
@@ -24,7 +24,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 
 | Artifact | Path |
 | --- | --- |
-| iOS auth callback test result | `/Users/timwhite/Library/Developer/Xcode/DerivedData/Jovie-hiiryvawzddnbedsbmbafcsminho/Logs/Test/Test-Jovie-2026.06.02_05-12-56--0700.xcresult` |
-| iOS app state test result | `/Users/timwhite/Library/Developer/Xcode/DerivedData/Jovie-hiiryvawzddnbedsbmbafcsminho/Logs/Test/Test-Jovie-2026.06.02_05-12-21--0700.xcresult` |
-| iOS real-browser auth test result | `/Users/timwhite/Library/Developer/Xcode/DerivedData/Jovie-hiiryvawzddnbedsbmbafcsminho/Logs/Test/Test-Jovie-2026.06.02_05-30-14--0700.xcresult` |
+| iOS auth callback test result | `artifacts/ios-test-results/auth-callback/Test-Jovie-2026.06.02_05-12-56--0700.xcresult` |
+| iOS app state test result | `artifacts/ios-test-results/app-state/Test-Jovie-2026.06.02_05-12-21--0700.xcresult` |
+| iOS real-browser auth test result | `artifacts/ios-test-results/real-browser-auth/Test-Jovie-2026.06.02_05-30-14--0700.xcresult` |
 | iOS screenshots | `artifacts/ios-screenshots` |

--- a/TEST_COVERAGE_REPORT.md
+++ b/TEST_COVERAGE_REPORT.md
@@ -1,0 +1,28 @@
+# Test Coverage Report
+
+Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platform-hardening-deliverables-and-ios-evidence-baseline)
+
+## Current Evidence
+
+| Command | Evidence | Result |
+| --- | --- | --- |
+| `pnpm test:auth:ios` | Passed on `origin/main` `9e9200348e`. Ran 18 `AppStateTests` and 2 deterministic XCUITests: `testAuthCallbackDeepLinkCompletesHarness` and `testAuthCallbackProviderErrorShowsAuthError`. | Passed |
+| `pnpm run ios:screenshots` | Passed on `origin/main` `9e9200348e`. Produced 7 screenshots in `artifacts/ios-screenshots`. | Passed |
+| PR #9907 iOS CI `Build And Test` | Passed before merge of `9e9200348e`. | Passed |
+
+## Platform Coverage Matrix
+
+| Platform | Required coverage | Current status |
+| --- | --- | --- |
+| Web | Playwright, unit tests, integration tests. | Evidence required under JOV-2712 |
+| iOS | XCTest and XCUITest. | Current auth callback and screenshot smoke evidence recorded |
+| Electron | End-to-end tests, auth flow tests, deep link tests. | Evidence required under JOV-2712 |
+| Chrome Extension | Popup tests, background script tests, authentication tests, messaging tests. | Evidence required under JOV-2712 |
+
+## Artifacts
+
+| Artifact | Path |
+| --- | --- |
+| iOS auth callback test result | `/Users/timwhite/Library/Developer/Xcode/DerivedData/Jovie-hiiryvawzddnbedsbmbafcsminho/Logs/Test/Test-Jovie-2026.06.02_05-12-56--0700.xcresult` |
+| iOS app state test result | `/Users/timwhite/Library/Developer/Xcode/DerivedData/Jovie-hiiryvawzddnbedsbmbafcsminho/Logs/Test/Test-Jovie-2026.06.02_05-12-21--0700.xcresult` |
+| iOS screenshots | `artifacts/ios-screenshots` |

--- a/TEST_COVERAGE_REPORT.md
+++ b/TEST_COVERAGE_REPORT.md
@@ -7,6 +7,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Command | Evidence | Result |
 | --- | --- | --- |
 | `pnpm test:auth:ios` | Passed on `origin/main` `9e9200348e`. Ran 18 `AppStateTests` and 2 deterministic XCUITests: `testAuthCallbackDeepLinkCompletesHarness` and `testAuthCallbackProviderErrorShowsAuthError`. | Passed |
+| `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` | Passed through Doppler dev config against a temporary Cloudflare tunnel to local dev. Ran 18 `AppStateTests`, 2 deterministic XCUITests, and `testRealBrowserAuthProviderCompleteReachesAuthenticatedShell`. | Passed |
 | `pnpm run ios:screenshots` | Passed on `origin/main` `9e9200348e`. Produced 7 screenshots in `artifacts/ios-screenshots`. | Passed |
 | PR #9907 iOS CI `Build And Test` | Passed before merge of `9e9200348e`. | Passed |
 
@@ -15,7 +16,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Platform | Required coverage | Current status |
 | --- | --- | --- |
 | Web | Playwright, unit tests, integration tests. | Evidence required under JOV-2712 |
-| iOS | XCTest and XCUITest. | Current auth callback and screenshot smoke evidence recorded |
+| iOS | XCTest and XCUITest. | Current auth callback, real-browser auth, and screenshot smoke evidence recorded |
 | Electron | End-to-end tests, auth flow tests, deep link tests. | Evidence required under JOV-2712 |
 | Chrome Extension | Popup tests, background script tests, authentication tests, messaging tests. | Evidence required under JOV-2712 |
 
@@ -25,4 +26,5 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | --- | --- |
 | iOS auth callback test result | `/Users/timwhite/Library/Developer/Xcode/DerivedData/Jovie-hiiryvawzddnbedsbmbafcsminho/Logs/Test/Test-Jovie-2026.06.02_05-12-56--0700.xcresult` |
 | iOS app state test result | `/Users/timwhite/Library/Developer/Xcode/DerivedData/Jovie-hiiryvawzddnbedsbmbafcsminho/Logs/Test/Test-Jovie-2026.06.02_05-12-21--0700.xcresult` |
+| iOS real-browser auth test result | `/Users/timwhite/Library/Developer/Xcode/DerivedData/Jovie-hiiryvawzddnbedsbmbafcsminho/Logs/Test/Test-Jovie-2026.06.02_05-30-14--0700.xcresult` |
 | iOS screenshots | `artifacts/ios-screenshots` |


### PR DESCRIPTION
## Summary

- Creates the ten required hardening deliverables from the June 2 production-readiness brief.
- Seeds the current iOS auth, callback, real-browser auth, screenshot, test, and release-gate evidence from `origin/main` `9e9200348e`.
- Keeps open cross-platform evidence explicitly tracked by JOV-2712 rather than loose notes.

## Tracking

- Linear: JOV-2712

## Verification

- `node --version` -> `v22.22.1`
- `pnpm --version` -> `9.15.4`
- `git diff --cached --check` -> passed before both docs commits
- `pnpm biome check --write HARDENING.md AUTH_AUDIT.md CHAT_AUDIT.md PERFORMANCE.md DESIGN_SYSTEM_AUDIT.md RELIABILITY_AUDIT.md PLATFORM_PARITY_AUDIT.md TEST_COVERAGE_REPORT.md RELEASE_CHECKLIST.md CRITICAL_BUGS.md` -> root Markdown files are ignored by Biome config
- `pnpm biome check --write apps/web` -> checked 5874 files, no fixes applied
- `pnpm turbo typecheck` -> 8 successful, 8 total
- `git push` pre-push hook -> `biome check .`, web proxy guard, Tailwind guard, web typecheck, and web lint passed
- `pnpm test:auth:ios` -> passed on `origin/main` `9e9200348e` before this docs branch: 18 `AppStateTests` and 2 deterministic XCUITests passed
- `doppler run --project jovie-web --config dev -- env CODE_SIGNING_ALLOWED=YES JOVIE_IOS_REAL_BROWSER_AUTH=1 API_BASE_URL=<temporary HTTPS tunnel> WEB_BASE_URL=<temporary HTTPS tunnel> pnpm test:auth:ios` -> passed locally: 18 `AppStateTests`, 2 deterministic XCUITests, and `testRealBrowserAuthProviderCompleteReachesAuthenticatedShell`
- `pnpm run ios:screenshots` -> passed on `origin/main` `9e9200348e` before this docs branch and produced the iOS screenshot baseline
