### PR TITLE
test(ios): add memory baseline capture

### DIFF
--- a/CRITICAL_BUGS.md
+++ b/CRITICAL_BUGS.md
@@ -27,4 +27,7 @@ suite, and app-state suite passed, and the known live Clerk auth hardening PR
 merged as #9907. The iOS launch-performance baseline passed as an opt-in
 XCUITest on `origin/main` `546e2af1f4`; it averaged `3.01s` to the signed-out
 shell under UI-test automation, so the 2s target remains tracked by JOV-2712
-and is not classified as a critical bug in this ledger.
+and is not classified as a critical bug in this ledger. The iOS memory command
+captured the deterministic profile shell at `36.6M` physical footprint and
+recorded the local `leaks --outputGraph` blocker; memgraph-backed leak proof is
+tracked by JOV-2712 rather than classified as a reproduced critical bug here.

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -16,6 +16,7 @@ hydration, and virtualization.
 | iOS launch/render smoke | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e` and captured loading, signed-out, profile, settings, onboarding, chat, and iPad shell states. | Visual smoke passed |
 | iOS auth test runtime | `pnpm test:auth:ios` passed deterministic auth coverage on `origin/main` `9e9200348e`. | Test runtime captured in command output |
 | iOS signed-out launch performance | `pnpm run ios:performance` passed on `origin/main` `546e2af1f4` using `XCTApplicationLaunchMetric(waitUntilResponsive: true)`. The iPhone 17 simulator run observed launch-to-`Continue in Browser` timings of `3.59`, `2.98`, `2.89`, `2.88`, `2.86`, and `2.86` seconds from the xcodebuild activity log, average `3.01s`; artifacts are in `artifacts/ios-test-results/launch-performance/Test-Jovie-launch-performance-2026.06.02_05-52-46-0700.{log,xcresult}`. | Baseline captured; 2s target is not met under JOV-2712 |
+| iOS memory/leak baseline command | `pnpm run ios:memory` passed locally after `318557208f` and wrote `artifacts/ios-test-results/memory-baseline/Jovie-memory-baseline-2026.06.02_06-27-15--0700/summary.md`. The deterministic `-ui-testing-ready` shell reported a `sample` physical footprint of `36.6M`; `leaks --outputGraph` returned status `255` because local Developer Tools security is disabled, so no `.memgraph` was created. Strict mode `JOVIE_IOS_MEMORY_REQUIRE_MEMGRAPH=1` exits nonzero and writes a summary when the memgraph is blocked. | Repeatable command captured; leak proof remains required under JOV-2712 |
 | Web first load and Lighthouse | Evidence required under JOV-2712. | Open |
 | Electron startup and memory | Evidence required under JOV-2712. | Open |
 | Chrome Extension popup/background performance | Evidence required under JOV-2712. | Open |
@@ -25,6 +26,6 @@ hydration, and virtualization.
 | Platform | Target | Current status |
 | --- | --- | --- |
 | Web | First load under 2 seconds, no unnecessary rerenders, Lighthouse over 90. | Evidence required under JOV-2712 |
-| iOS | Launch under 2 seconds, no frame drops, no memory leaks. | Launch baseline captured at average `3.01s` to signed-out shell under UI-test automation; frame-drop and leak evidence required under JOV-2712 |
+| iOS | Launch under 2 seconds, no frame drops, no memory leaks. | Launch baseline captured at average `3.01s` to signed-out shell under UI-test automation; memory command captured `36.6M` sample footprint and exact local `leaks` blocker; frame-drop and leak evidence required under JOV-2712 |
 | Electron | Startup under 3 seconds, stable memory footprint, no renderer crashes. | Evidence required under JOV-2712 |
 | Chrome Extension | Fast popup open, fast background execution, minimal memory usage. | Evidence required under JOV-2712 |

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -23,4 +23,5 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Real-browser auth suite | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` passed against a temporary HTTPS tunnel to local dev. | Passed |
 | Screenshot smoke | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e`. | Passed |
 | Launch performance baseline | `pnpm run ios:performance` passed on `origin/main` `546e2af1f4`; average signed-out shell readiness was `3.01s` under UI-test automation. | Baseline captured under JOV-2712 |
+| Memory/leak baseline command | `pnpm run ios:memory` writes a run summary, raw `leaks` output, and `sample` footprint. Local evidence at `artifacts/ios-test-results/memory-baseline/Jovie-memory-baseline-2026.06.02_06-27-15--0700/summary.md` recorded `36.6M` physical footprint and a blocked `.memgraph` because Developer Tools security is disabled. | Command captured under JOV-2712 |
 | Live Clerk auth PR | PR #9907 merged as `9e9200348e` after local and CI verification. | Passed |

--- a/TEST_COVERAGE_REPORT.md
+++ b/TEST_COVERAGE_REPORT.md
@@ -10,6 +10,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` | Passed through Doppler dev config against a temporary Cloudflare tunnel to local dev. Ran 18 `AppStateTests`, 2 deterministic XCUITests, and `testRealBrowserAuthProviderCompleteReachesAuthenticatedShell`. | Passed |
 | `pnpm run ios:screenshots` | Passed on `origin/main` `9e9200348e`. Produced 7 screenshots in `artifacts/ios-screenshots`. | Passed |
 | `pnpm run ios:performance` | Passed on `origin/main` `546e2af1f4`. Ran the opt-in `testSignedOutLaunchPerformance()` XCUITest with `XCTApplicationLaunchMetric(waitUntilResponsive: true)`. | Passed |
+| `pnpm run ios:memory` | Passed locally after `318557208f`. Captured a `sample` footprint for the `-ui-testing-ready` shell and recorded the local `leaks --outputGraph` blocker in the run summary. Strict mode `JOVIE_IOS_MEMORY_REQUIRE_MEMGRAPH=1` exits nonzero when memgraph capture is blocked. | Evidence captured; memgraph blocked locally |
 | PR #9907 iOS CI `Build And Test` | Passed before merge of `9e9200348e`. | Passed |
 
 ## Platform Coverage Matrix
@@ -30,4 +31,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | iOS real-browser auth test result | `artifacts/ios-test-results/real-browser-auth/Test-Jovie-2026.06.02_05-30-14--0700.xcresult` |
 | iOS launch performance test result | `artifacts/ios-test-results/launch-performance/Test-Jovie-launch-performance-2026.06.02_05-52-46-0700.xcresult` |
 | iOS launch performance log | `artifacts/ios-test-results/launch-performance/Test-Jovie-launch-performance-2026.06.02_05-52-46-0700.log` |
+| iOS memory baseline summary | `artifacts/ios-test-results/memory-baseline/Jovie-memory-baseline-2026.06.02_06-27-15--0700/summary.md` |
+| iOS memory baseline sample | `artifacts/ios-test-results/memory-baseline/Jovie-memory-baseline-2026.06.02_06-27-15--0700/ie.jov.Jovie-88803-2026.06.02_06-27-15--0700.sample.txt` |
+| iOS memory strict-mode summary | `artifacts/ios-test-results/memory-baseline/Jovie-memory-baseline-2026.06.02_06-25-54--0700/summary.md` |
 | iOS screenshots | `artifacts/ios-screenshots` |

--- a/apps/ios/README.md
+++ b/apps/ios/README.md
@@ -84,6 +84,21 @@ Native iOS foundation for Jovie. The app is dark-only, simulator-tested, and wir
    `JOVIE_IOS_LAUNCH_TIMEOUT_SECONDS` only when recording an explicit readiness
    timeout.
 
+8. Capture memory/leak baseline evidence:
+
+   ```bash
+   pnpm run ios:memory
+   ```
+
+   This builds the debug simulator app, launches the deterministic profile shell,
+   attempts to capture a `.memgraph` with Apple's `leaks` tool, and writes
+   metadata plus a markdown summary under
+   `artifacts/ios-test-results/memory-baseline`. The default run records a
+   `sample` footprint even when local Developer Tools settings block memgraph
+   capture. Set `JOVIE_IOS_MEMORY_REQUIRE_MEMGRAPH=1` for strict leak-gate runs,
+   and override `JOVIE_IOS_MEMORY_LAUNCH_ARGUMENTS` only when recording a
+   specific UI-test flow such as `-ui-testing-chat`.
+
 ## Release
 
 Fastlane lives at the repo root.

--- a/apps/ios/scripts/capture-memory-baseline.sh
+++ b/apps/ios/scripts/capture-memory-baseline.sh
@@ -100,8 +100,8 @@ list_devices() {
     ranked = candidates.sort_by do |device|
       name = device.fetch("name")
       [
-        device.fetch("state") == "Booted" ? 0 : 1,
         name == "iPhone 17" ? 0 : 1,
+        device.fetch("state") == "Booted" ? 0 : 1,
         name
       ]
     end
@@ -130,6 +130,7 @@ write_metadata() {
     echo "require_memgraph: $REQUIRE_MEMGRAPH"
     echo "devtools_security_status: $DEVTOOLS_SECURITY_STATUS"
     echo "pid: $PID"
+    echo "pid_source: $PID_SOURCE"
     echo "process_label: $PROCESS_LABEL"
     echo "memgraph: $MEMGRAPH_PATH"
     echo "memgraph_created: $MEMGRAPH_CREATED"
@@ -167,6 +168,7 @@ render_summary() {
     echo "- Require memgraph: $REQUIRE_MEMGRAPH"
     echo "- Developer Tools security: $DEVTOOLS_SECURITY_STATUS"
     echo "- PID: $PID"
+    echo "- PID source: $PID_SOURCE"
     echo "- Memgraph created: $MEMGRAPH_CREATED"
     echo "- Memgraph: \`$MEMGRAPH_PATH\`"
     echo "- Raw leaks output: \`$LEAKS_OUTPUT\`"
@@ -233,8 +235,13 @@ mkdir -p "$RUN_DIR"
 
 "$SCRIPT_DIR/ensure-configuration.sh"
 
+CURRENT_GIT_HEAD="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+BUILD_STAMP_PATH="$DERIVED_DATA_PATH/.memory-baseline-build-stamp"
 APP_PATH="$DERIVED_DATA_PATH/Build/Products/Debug-iphonesimulator/Jovie.app"
-if [[ -d "$APP_PATH" && "${JOVIE_IOS_MEMORY_REUSE_BUILD:-0}" == "1" ]]; then
+if [[ -d "$APP_PATH" &&
+  "${JOVIE_IOS_MEMORY_REUSE_BUILD:-0}" == "1" &&
+  -f "$BUILD_STAMP_PATH" &&
+  "$(cat "$BUILD_STAMP_PATH")" == "$CURRENT_GIT_HEAD" ]]; then
   echo "Using existing built app at $APP_PATH"
 else
   rm -rf "$DERIVED_DATA_PATH"
@@ -250,6 +257,7 @@ else
     exit 1
   fi
   echo "Build log: $RUN_DIR/build.log"
+  printf "%s\n" "$CURRENT_GIT_HEAD" >"$BUILD_STAMP_PATH"
 fi
 
 if [[ ! -d "$APP_PATH" ]]; then
@@ -275,13 +283,25 @@ run_with_timeout "${JOVIE_IOS_MEMORY_TERMINATE_TIMEOUT:-15}" xcrun simctl termin
 read -r -a LAUNCH_ARGS <<<"$LAUNCH_ARGUMENTS"
 
 echo "Launching $BUNDLE_ID with arguments: $LAUNCH_ARGUMENTS"
-if ! run_with_timeout "${JOVIE_IOS_MEMORY_LAUNCH_TIMEOUT:-30}" xcrun simctl launch "$IPHONE_UDID" "$BUNDLE_ID" "${LAUNCH_ARGS[@]}" >"$RUN_DIR/launch.txt" 2>&1; then
-  cat "$RUN_DIR/launch.txt"
+LAUNCH_OUTPUT="$RUN_DIR/launch.txt"
+if ! run_with_timeout "${JOVIE_IOS_MEMORY_LAUNCH_TIMEOUT:-30}" xcrun simctl launch "$IPHONE_UDID" "$BUNDLE_ID" "${LAUNCH_ARGS[@]}" >"$LAUNCH_OUTPUT" 2>&1; then
+  cat "$LAUNCH_OUTPUT"
   echo "Failed to launch $BUNDLE_ID on $IPHONE_UDID"
   exit 1
 fi
 
 sleep "$SETTLE_SECONDS"
+
+SIMCTL_LAUNCH_PID="$(
+  awk -F": " -v bundle_id="$BUNDLE_ID" '
+    $1 == bundle_id && $2 ~ /^[0-9]+$/ {
+      pid = $2
+    }
+    END {
+      print pid
+    }
+  ' "$LAUNCH_OUTPUT"
+)"
 
 LAUNCHCTL_LIST="$RUN_DIR/launchctl-list.txt"
 if ! run_with_timeout "${JOVIE_IOS_MEMORY_PROCESS_TIMEOUT:-30}" xcrun simctl spawn "$IPHONE_UDID" launchctl list >"$LAUNCHCTL_LIST"; then
@@ -304,19 +324,31 @@ MATCHING_PROCESSES="$(
   ' "$LAUNCHCTL_LIST"
 )"
 
-if [[ -z "$MATCHING_PROCESSES" ]]; then
+if [[ -n "$SIMCTL_LAUNCH_PID" ]]; then
+  PID="$SIMCTL_LAUNCH_PID"
+  PID_SOURCE="simctl launch"
+  PROCESS_LABEL="$(
+    awk -v pid="$PID" '
+      $1 == pid {
+        print $3
+        exit
+      }
+    ' "$LAUNCHCTL_LIST"
+  )"
+  PROCESS_LABEL="${PROCESS_LABEL:-$BUNDLE_ID}"
+elif [[ -z "$MATCHING_PROCESSES" ]]; then
   echo "Could not find a running PID for $BUNDLE_ID on $IPHONE_UDID."
   exit 1
-fi
-
-if [[ "$(printf "%s\n" "$MATCHING_PROCESSES" | wc -l | tr -d " ")" -ne 1 ]]; then
+elif [[ "$(printf "%s\n" "$MATCHING_PROCESSES" | wc -l | tr -d " ")" -ne 1 ]]; then
   echo "Found multiple running PIDs for $BUNDLE_ID on $IPHONE_UDID:"
   printf "%s\n" "$MATCHING_PROCESSES"
   exit 1
+else
+  PID="$(printf "%s\n" "$MATCHING_PROCESSES" | awk "{ print \$1 }")"
+  PID_SOURCE="launchctl list"
+  PROCESS_LABEL="$(printf "%s\n" "$MATCHING_PROCESSES" | cut -f2-)"
 fi
 
-PID="$(printf "%s\n" "$MATCHING_PROCESSES" | awk "{ print \$1 }")"
-PROCESS_LABEL="$(printf "%s\n" "$MATCHING_PROCESSES" | cut -f2-)"
 SAFE_BUNDLE="$(printf "%s" "$BUNDLE_ID" | tr -c "A-Za-z0-9_.-" "_")"
 MEMGRAPH_PATH="$RUN_DIR/$SAFE_BUNDLE-$PID-$TIMESTAMP.memgraph"
 LEAKS_OUTPUT="$RUN_DIR/$SAFE_BUNDLE-$PID-$TIMESTAMP.leaks.txt"

--- a/apps/ios/scripts/capture-memory-baseline.sh
+++ b/apps/ios/scripts/capture-memory-baseline.sh
@@ -63,7 +63,11 @@ wait_for_boot() {
     elapsed=$((elapsed + 1))
   done
 
-  wait "$boot_pid"
+  if ! wait "$boot_pid"; then
+    cat "$boot_log"
+    echo "Simulator $udid bootstatus failed." >&2
+    return 1
+  fi
 }
 
 list_devices() {
@@ -274,7 +278,10 @@ fi
 
 echo "Preparing simulator $IPHONE_UDID"
 run_with_timeout "${JOVIE_IOS_MEMORY_BOOT_COMMAND_TIMEOUT:-120}" xcrun simctl boot "$IPHONE_UDID" >/dev/null 2>&1 || true
-wait_for_boot "$IPHONE_UDID"
+if ! wait_for_boot "$IPHONE_UDID"; then
+  echo "Failed to boot simulator $IPHONE_UDID." >&2
+  exit 1
+fi
 run_with_timeout "${JOVIE_IOS_MEMORY_UI_TIMEOUT:-10}" xcrun simctl ui "$IPHONE_UDID" appearance dark >/dev/null 2>&1 || true
 run_with_timeout "${JOVIE_IOS_MEMORY_UNINSTALL_TIMEOUT:-30}" xcrun simctl uninstall "$IPHONE_UDID" "$BUNDLE_ID" >/dev/null 2>&1 || true
 run_with_timeout "${JOVIE_IOS_MEMORY_INSTALL_TIMEOUT:-60}" xcrun simctl install "$IPHONE_UDID" "$APP_PATH"

--- a/apps/ios/scripts/capture-memory-baseline.sh
+++ b/apps/ios/scripts/capture-memory-baseline.sh
@@ -117,7 +117,17 @@ list_devices() {
 }
 
 pick_device() {
-  list_devices "$1" | head -n 1
+  local devices=""
+
+  if ! devices="$(list_devices "$1")"; then
+    return 1
+  fi
+
+  if [[ -z "$devices" ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "${devices%%$'\n'*}"
 }
 
 write_metadata() {

--- a/apps/ios/scripts/capture-memory-baseline.sh
+++ b/apps/ios/scripts/capture-memory-baseline.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$IOS_DIR/../.." && pwd)"
+PROJECT_PATH="$IOS_DIR/Jovie.xcodeproj"
+SCHEME="Jovie"
+BUNDLE_ID="ie.jov.Jovie"
+CODE_SIGNING_ALLOWED_VALUE="${CODE_SIGNING_ALLOWED:-YES}"
+RESULTS_DIR="${JOVIE_IOS_MEMORY_RESULTS_DIR:-$REPO_ROOT/artifacts/ios-test-results/memory-baseline}"
+DERIVED_DATA_PATH="${JOVIE_IOS_MEMORY_DERIVED_DATA:-$REPO_ROOT/.build/ios-memory-baseline}"
+LAUNCH_ARGUMENTS="${JOVIE_IOS_MEMORY_LAUNCH_ARGUMENTS:--ui-testing-ready}"
+SETTLE_SECONDS="${JOVIE_IOS_MEMORY_SETTLE_SECONDS:-5}"
+TIMESTAMP="$(date +%Y.%m.%d_%H-%M-%S-%z)"
+RUN_DIR="$RESULTS_DIR/Jovie-memory-baseline-$TIMESTAMP"
+REQUIRE_MEMGRAPH="${JOVIE_IOS_MEMORY_REQUIRE_MEMGRAPH:-0}"
+
+run_with_timeout() {
+  local timeout_seconds="$1"
+  shift
+
+  "$@" &
+  local command_pid=$!
+  local elapsed=0
+
+  while kill -0 "$command_pid" >/dev/null 2>&1; do
+    if ((elapsed >= timeout_seconds)); then
+      kill "$command_pid" >/dev/null 2>&1 || true
+      sleep 1
+      kill -9 "$command_pid" >/dev/null 2>&1 || true
+      wait "$command_pid" >/dev/null 2>&1 || true
+      echo "Command timed out after ${timeout_seconds}s: $*"
+      return 124
+    fi
+
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  wait "$command_pid"
+}
+
+wait_for_boot() {
+  local udid="$1"
+  local timeout_seconds="${JOVIE_IOS_MEMORY_BOOT_TIMEOUT:-180}"
+  local boot_log="$RUN_DIR/bootstatus-$udid.log"
+  local elapsed=0
+
+  xcrun simctl bootstatus "$udid" -b >"$boot_log" 2>&1 &
+  local boot_pid=$!
+
+  while kill -0 "$boot_pid" >/dev/null 2>&1; do
+    if ((elapsed >= timeout_seconds)); then
+      kill "$boot_pid" >/dev/null 2>&1 || true
+      wait "$boot_pid" >/dev/null 2>&1 || true
+      cat "$boot_log"
+      echo "Simulator $udid did not finish booting within ${timeout_seconds}s."
+      return 1
+    fi
+
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  wait "$boot_pid"
+}
+
+list_devices() {
+  local name_pattern="$1"
+  local devices_file
+  devices_file="$(mktemp)"
+
+  if ! run_with_timeout "${JOVIE_IOS_MEMORY_SIMCTL_LIST_TIMEOUT:-30}" xcrun simctl list devices available -j >"$devices_file"; then
+    echo "Timed out listing available simulators."
+    rm -f "$devices_file"
+    return 1
+  fi
+
+  RUBYOPT= ruby -rjson -e '
+    pattern = Regexp.new(ARGV.fetch(0))
+    devices_by_runtime = JSON.parse(STDIN.read).fetch("devices", {})
+    candidates = []
+
+    devices_by_runtime.each do |runtime, devices|
+      next unless runtime.include?("com.apple.CoreSimulator.SimRuntime.iOS")
+
+      devices.each do |device|
+        next unless device["isAvailable"]
+        next unless device["name"].to_s.match?(pattern)
+
+        candidates << {
+          "udid" => device["udid"].to_s,
+          "name" => device["name"].to_s,
+          "state" => device["state"].to_s
+        }
+      end
+    end
+
+    ranked = candidates.sort_by do |device|
+      name = device.fetch("name")
+      [
+        device.fetch("state") == "Booted" ? 0 : 1,
+        name == "iPhone 17" ? 0 : 1,
+        name
+      ]
+    end
+
+    puts(ranked.map { |device| device.fetch("udid") })
+  ' "$name_pattern" <"$devices_file"
+
+  rm -f "$devices_file"
+}
+
+pick_device() {
+  list_devices "$1" | head -n 1
+}
+
+write_metadata() {
+  local path="$RUN_DIR/metadata.txt"
+
+  {
+    echo "date: $(date)"
+    echo "git_head: $(git -C "$REPO_ROOT" rev-parse HEAD)"
+    echo "udid: $IPHONE_UDID"
+    echo "bundle_id: $BUNDLE_ID"
+    echo "code_signing_allowed: $CODE_SIGNING_ALLOWED_VALUE"
+    echo "launch_arguments: $LAUNCH_ARGUMENTS"
+    echo "settle_seconds: $SETTLE_SECONDS"
+    echo "require_memgraph: $REQUIRE_MEMGRAPH"
+    echo "devtools_security_status: $DEVTOOLS_SECURITY_STATUS"
+    echo "pid: $PID"
+    echo "process_label: $PROCESS_LABEL"
+    echo "memgraph: $MEMGRAPH_PATH"
+    echo "memgraph_created: $MEMGRAPH_CREATED"
+    echo "leaks_output: $LEAKS_OUTPUT"
+    echo "leaks_list_output: $LEAKS_LIST_OUTPUT"
+    echo "leaks_group_output: $LEAKS_GROUP_OUTPUT"
+    echo "leaks_trace_output: ${LEAKS_TRACE_OUTPUT:-}"
+    echo "sample_output: $SAMPLE_OUTPUT"
+    echo "sample_status: $SAMPLE_STATUS"
+    echo "leaks_capture_status: $LEAKS_CAPTURE_STATUS"
+    echo "leaks_list_status: $LEAKS_LIST_STATUS"
+    echo "leaks_group_status: $LEAKS_GROUP_STATUS"
+    echo "app_owned_leak_count: $APP_OWNED_LEAK_COUNT"
+  } >"$path"
+}
+
+render_summary() {
+  local total_line
+  local leak_entry_count
+  local physical_footprint
+  total_line="$(grep -E "Process .*: [0-9]+ leaks? for [0-9]+ total leaked bytes" "$LEAKS_LIST_OUTPUT" | tail -n 1 || true)"
+  leak_entry_count="$(grep -c "^Leak:" "$LEAKS_LIST_OUTPUT" || true)"
+  physical_footprint="$(grep -E "^Physical footprint:" "$SAMPLE_OUTPUT" | head -n 1 || true)"
+
+  {
+    echo "# iOS Memory Baseline"
+    echo
+    echo "- Date: $(date)"
+    echo "- Git head: $(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+    echo "- Simulator UDID: $IPHONE_UDID"
+    echo "- Bundle ID: $BUNDLE_ID"
+    echo "- Code signing allowed: $CODE_SIGNING_ALLOWED_VALUE"
+    echo "- Launch arguments: \`$LAUNCH_ARGUMENTS\`"
+    echo "- Settle seconds: $SETTLE_SECONDS"
+    echo "- Require memgraph: $REQUIRE_MEMGRAPH"
+    echo "- Developer Tools security: $DEVTOOLS_SECURITY_STATUS"
+    echo "- PID: $PID"
+    echo "- Memgraph created: $MEMGRAPH_CREATED"
+    echo "- Memgraph: \`$MEMGRAPH_PATH\`"
+    echo "- Raw leaks output: \`$LEAKS_OUTPUT\`"
+    echo "- List output: \`$LEAKS_LIST_OUTPUT\`"
+    echo "- Grouped output: \`$LEAKS_GROUP_OUTPUT\`"
+    echo "- Sample output: \`$SAMPLE_OUTPUT\`"
+    echo
+    echo "## Leak Totals"
+    echo
+    echo "- sample status: $SAMPLE_STATUS"
+    echo "- sample footprint: ${physical_footprint:-not found}"
+    echo "- leaks capture status: $LEAKS_CAPTURE_STATUS"
+    echo "- leaks list status: $LEAKS_LIST_STATUS"
+    echo "- leaks group status: $LEAKS_GROUP_STATUS"
+    echo "- reported total: ${total_line:-not found}"
+    echo "- parsed leak entries: $leak_entry_count"
+    echo "- app-owned leak entries containing Jovie: $APP_OWNED_LEAK_COUNT"
+    echo
+
+    if [[ "$MEMGRAPH_CREATED" != "yes" ]]; then
+      echo "## Memgraph Capture"
+      echo
+      echo "\`\`\`text"
+      sed -n "1,80p" "$LEAKS_OUTPUT"
+      echo "\`\`\`"
+      echo
+    fi
+
+    echo "## Sample Output"
+    echo
+    echo "\`\`\`text"
+    sed -n "1,80p" "$SAMPLE_OUTPUT"
+    echo "\`\`\`"
+    echo
+
+    if [[ -n "${LEAKS_TRACE_OUTPUT:-}" ]]; then
+      echo "## First App-Owned Trace"
+      echo
+      echo "\`\`\`text"
+      sed -n "1,80p" "$LEAKS_TRACE_OUTPUT"
+      echo "\`\`\`"
+      echo
+    fi
+
+    echo "## Grouped Leak Output"
+    echo
+    echo "\`\`\`text"
+    sed -n "1,120p" "$LEAKS_GROUP_OUTPUT"
+    echo "\`\`\`"
+    echo
+    echo "## Raw Commands"
+    echo
+    echo "\`\`\`bash"
+    echo "leaks --list $MEMGRAPH_PATH"
+    echo "leaks --groupByType $MEMGRAPH_PATH"
+    if [[ -n "$FIRST_APP_OWNED_LEAK_ADDRESS" ]]; then
+      echo "leaks --traceTree=$FIRST_APP_OWNED_LEAK_ADDRESS $MEMGRAPH_PATH"
+    fi
+    echo "\`\`\`"
+  } >"$SUMMARY_PATH"
+}
+
+mkdir -p "$RUN_DIR"
+
+"$SCRIPT_DIR/ensure-configuration.sh"
+
+APP_PATH="$DERIVED_DATA_PATH/Build/Products/Debug-iphonesimulator/Jovie.app"
+if [[ -d "$APP_PATH" && "${JOVIE_IOS_MEMORY_REUSE_BUILD:-0}" == "1" ]]; then
+  echo "Using existing built app at $APP_PATH"
+else
+  rm -rf "$DERIVED_DATA_PATH"
+  if ! run_with_timeout "${JOVIE_IOS_MEMORY_BUILD_TIMEOUT:-300}" xcodebuild build \
+    -project "$PROJECT_PATH" \
+    -scheme "$SCHEME" \
+    -configuration Debug \
+    -destination "generic/platform=iOS Simulator" \
+    -derivedDataPath "$DERIVED_DATA_PATH" \
+    CODE_SIGNING_ALLOWED="$CODE_SIGNING_ALLOWED_VALUE" \
+    ENABLE_DEBUG_DYLIB=NO >"$RUN_DIR/build.log" 2>&1; then
+    tail -n 200 "$RUN_DIR/build.log"
+    exit 1
+  fi
+  echo "Build log: $RUN_DIR/build.log"
+fi
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "Built app not found at $APP_PATH"
+  exit 1
+fi
+
+IPHONE_UDID="$(pick_device "^iPhone")"
+if [[ -z "$IPHONE_UDID" ]]; then
+  echo "Unable to find an available iPhone simulator."
+  xcrun simctl list devices available
+  exit 1
+fi
+
+echo "Preparing simulator $IPHONE_UDID"
+run_with_timeout "${JOVIE_IOS_MEMORY_BOOT_COMMAND_TIMEOUT:-120}" xcrun simctl boot "$IPHONE_UDID" >/dev/null 2>&1 || true
+wait_for_boot "$IPHONE_UDID"
+run_with_timeout "${JOVIE_IOS_MEMORY_UI_TIMEOUT:-10}" xcrun simctl ui "$IPHONE_UDID" appearance dark >/dev/null 2>&1 || true
+run_with_timeout "${JOVIE_IOS_MEMORY_UNINSTALL_TIMEOUT:-30}" xcrun simctl uninstall "$IPHONE_UDID" "$BUNDLE_ID" >/dev/null 2>&1 || true
+run_with_timeout "${JOVIE_IOS_MEMORY_INSTALL_TIMEOUT:-60}" xcrun simctl install "$IPHONE_UDID" "$APP_PATH"
+run_with_timeout "${JOVIE_IOS_MEMORY_TERMINATE_TIMEOUT:-15}" xcrun simctl terminate "$IPHONE_UDID" "$BUNDLE_ID" >/dev/null 2>&1 || true
+
+read -r -a LAUNCH_ARGS <<<"$LAUNCH_ARGUMENTS"
+
+echo "Launching $BUNDLE_ID with arguments: $LAUNCH_ARGUMENTS"
+if ! run_with_timeout "${JOVIE_IOS_MEMORY_LAUNCH_TIMEOUT:-30}" xcrun simctl launch "$IPHONE_UDID" "$BUNDLE_ID" "${LAUNCH_ARGS[@]}" >"$RUN_DIR/launch.txt" 2>&1; then
+  cat "$RUN_DIR/launch.txt"
+  echo "Failed to launch $BUNDLE_ID on $IPHONE_UDID"
+  exit 1
+fi
+
+sleep "$SETTLE_SECONDS"
+
+LAUNCHCTL_LIST="$RUN_DIR/launchctl-list.txt"
+if ! run_with_timeout "${JOVIE_IOS_MEMORY_PROCESS_TIMEOUT:-30}" xcrun simctl spawn "$IPHONE_UDID" launchctl list >"$LAUNCHCTL_LIST"; then
+  echo "Failed to list simulator processes."
+  exit 1
+fi
+
+MATCHING_PROCESSES="$(
+  awk -v bundle_id="$BUNDLE_ID" '
+    $1 == "-" {
+      next
+    }
+    $3 == bundle_id {
+      print $1 "\t" $3
+      next
+    }
+    index($3, "UIKitApplication:" bundle_id "[") == 1 {
+      print $1 "\t" $3
+    }
+  ' "$LAUNCHCTL_LIST"
+)"
+
+if [[ -z "$MATCHING_PROCESSES" ]]; then
+  echo "Could not find a running PID for $BUNDLE_ID on $IPHONE_UDID."
+  exit 1
+fi
+
+if [[ "$(printf "%s\n" "$MATCHING_PROCESSES" | wc -l | tr -d " ")" -ne 1 ]]; then
+  echo "Found multiple running PIDs for $BUNDLE_ID on $IPHONE_UDID:"
+  printf "%s\n" "$MATCHING_PROCESSES"
+  exit 1
+fi
+
+PID="$(printf "%s\n" "$MATCHING_PROCESSES" | awk "{ print \$1 }")"
+PROCESS_LABEL="$(printf "%s\n" "$MATCHING_PROCESSES" | cut -f2-)"
+SAFE_BUNDLE="$(printf "%s" "$BUNDLE_ID" | tr -c "A-Za-z0-9_.-" "_")"
+MEMGRAPH_PATH="$RUN_DIR/$SAFE_BUNDLE-$PID-$TIMESTAMP.memgraph"
+LEAKS_OUTPUT="$RUN_DIR/$SAFE_BUNDLE-$PID-$TIMESTAMP.leaks.txt"
+LEAKS_LIST_OUTPUT="$RUN_DIR/$SAFE_BUNDLE-$PID-$TIMESTAMP.list.txt"
+LEAKS_GROUP_OUTPUT="$RUN_DIR/$SAFE_BUNDLE-$PID-$TIMESTAMP.grouped.txt"
+SAMPLE_OUTPUT="$RUN_DIR/$SAFE_BUNDLE-$PID-$TIMESTAMP.sample.txt"
+SUMMARY_PATH="$RUN_DIR/summary.md"
+DEVTOOLS_SECURITY_STATUS="$(DevToolsSecurity -status 2>&1 || true)"
+
+echo "Capturing memgraph for PID $PID"
+set +e
+sample "$PID" 1 1 -file "$SAMPLE_OUTPUT" >"$RUN_DIR/sample-command.txt" 2>&1
+SAMPLE_STATUS=$?
+set -e
+[[ -f "$SAMPLE_OUTPUT" ]] || : >"$SAMPLE_OUTPUT"
+
+set +e
+leaks "--outputGraph=$MEMGRAPH_PATH" "$PID" >"$LEAKS_OUTPUT" 2>&1
+LEAKS_CAPTURE_STATUS=$?
+set -e
+
+if [[ ! -f "$MEMGRAPH_PATH" ]]; then
+  echo "leaks failed to create a memgraph; see $LEAKS_OUTPUT"
+  MEMGRAPH_CREATED="no"
+  LEAKS_LIST_STATUS="not_run"
+  LEAKS_GROUP_STATUS="not_run"
+  APP_OWNED_LEAK_COUNT="not_run"
+  FIRST_APP_OWNED_LEAK_ADDRESS=""
+  LEAKS_TRACE_OUTPUT=""
+  : >"$LEAKS_LIST_OUTPUT"
+  : >"$LEAKS_GROUP_OUTPUT"
+  write_metadata
+  render_summary
+
+  echo "summary: $SUMMARY_PATH"
+  if [[ "$REQUIRE_MEMGRAPH" == "1" ]]; then
+    exit 1
+  fi
+
+  echo "Set JOVIE_IOS_MEMORY_REQUIRE_MEMGRAPH=1 to fail when memgraph capture is blocked."
+  exit 0
+fi
+
+MEMGRAPH_CREATED="yes"
+
+set +e
+leaks --list "$MEMGRAPH_PATH" >"$LEAKS_LIST_OUTPUT" 2>&1
+LEAKS_LIST_STATUS=$?
+leaks --groupByType "$MEMGRAPH_PATH" >"$LEAKS_GROUP_OUTPUT" 2>&1
+LEAKS_GROUP_STATUS=$?
+set -e
+
+APP_OWNED_LEAK_COUNT="$(awk '/^Leak:/ && /Jovie/ { count++ } END { print count + 0 }' "$LEAKS_LIST_OUTPUT")"
+FIRST_APP_OWNED_LEAK_ADDRESS="$(awk '/^Leak:/ && /Jovie/ { print $2; exit }' "$LEAKS_LIST_OUTPUT")"
+LEAKS_TRACE_OUTPUT=""
+
+if [[ -n "$FIRST_APP_OWNED_LEAK_ADDRESS" ]]; then
+  LEAKS_TRACE_OUTPUT="$RUN_DIR/$SAFE_BUNDLE-$PID-$TIMESTAMP.trace.txt"
+  set +e
+  leaks "--traceTree=$FIRST_APP_OWNED_LEAK_ADDRESS" "$MEMGRAPH_PATH" >"$LEAKS_TRACE_OUTPUT" 2>&1
+  set -e
+fi
+
+write_metadata
+render_summary
+
+echo "Memory baseline written to $RUN_DIR"
+echo "summary: $SUMMARY_PATH"
+echo "memgraph: $MEMGRAPH_PATH"

--- a/apps/ios/scripts/capture-memory-baseline.sh
+++ b/apps/ios/scripts/capture-memory-baseline.sh
@@ -287,11 +287,24 @@ run_with_timeout "${JOVIE_IOS_MEMORY_UNINSTALL_TIMEOUT:-30}" xcrun simctl uninst
 run_with_timeout "${JOVIE_IOS_MEMORY_INSTALL_TIMEOUT:-60}" xcrun simctl install "$IPHONE_UDID" "$APP_PATH"
 run_with_timeout "${JOVIE_IOS_MEMORY_TERMINATE_TIMEOUT:-15}" xcrun simctl terminate "$IPHONE_UDID" "$BUNDLE_ID" >/dev/null 2>&1 || true
 
-read -r -a LAUNCH_ARGS <<<"$LAUNCH_ARGUMENTS"
+LAUNCH_ARGS=()
+if [[ "$LAUNCH_ARGUMENTS" =~ [^[:space:]] ]]; then
+  read -r -a LAUNCH_ARGS <<<"$LAUNCH_ARGUMENTS"
+fi
 
 echo "Launching $BUNDLE_ID with arguments: $LAUNCH_ARGUMENTS"
 LAUNCH_OUTPUT="$RUN_DIR/launch.txt"
-if ! run_with_timeout "${JOVIE_IOS_MEMORY_LAUNCH_TIMEOUT:-30}" xcrun simctl launch "$IPHONE_UDID" "$BUNDLE_ID" "${LAUNCH_ARGS[@]}" >"$LAUNCH_OUTPUT" 2>&1; then
+set +e
+if [[ "${#LAUNCH_ARGS[@]}" -gt 0 ]]; then
+  run_with_timeout "${JOVIE_IOS_MEMORY_LAUNCH_TIMEOUT:-30}" xcrun simctl launch "$IPHONE_UDID" "$BUNDLE_ID" "${LAUNCH_ARGS[@]}" >"$LAUNCH_OUTPUT" 2>&1
+  LAUNCH_STATUS=$?
+else
+  run_with_timeout "${JOVIE_IOS_MEMORY_LAUNCH_TIMEOUT:-30}" xcrun simctl launch "$IPHONE_UDID" "$BUNDLE_ID" >"$LAUNCH_OUTPUT" 2>&1
+  LAUNCH_STATUS=$?
+fi
+set -e
+
+if [[ "$LAUNCH_STATUS" -ne 0 ]]; then
   cat "$LAUNCH_OUTPUT"
   echo "Failed to launch $BUNDLE_ID on $IPHONE_UDID"
   exit 1

--- a/apps/ios/scripts/capture-memory-baseline.sh
+++ b/apps/ios/scripts/capture-memory-baseline.sh
@@ -344,18 +344,25 @@ MATCHING_PROCESSES="$(
   ' "$LAUNCHCTL_LIST"
 )"
 
+SIMCTL_PROCESS_LINE=""
 if [[ -n "$SIMCTL_LAUNCH_PID" ]]; then
-  PID="$SIMCTL_LAUNCH_PID"
-  PID_SOURCE="simctl launch"
-  PROCESS_LABEL="$(
-    awk -v pid="$PID" '
+  SIMCTL_PROCESS_LINE="$(
+    printf "%s\n" "$MATCHING_PROCESSES" | awk -v pid="$SIMCTL_LAUNCH_PID" '
       $1 == pid {
-        print $3
+        print
         exit
       }
-    ' "$LAUNCHCTL_LIST"
+    '
   )"
-  PROCESS_LABEL="${PROCESS_LABEL:-$BUNDLE_ID}"
+fi
+
+if [[ -n "$SIMCTL_PROCESS_LINE" ]]; then
+  PID="$SIMCTL_LAUNCH_PID"
+  PID_SOURCE="simctl launch"
+  PROCESS_LABEL="$(printf "%s\n" "$SIMCTL_PROCESS_LINE" | cut -f2-)"
+elif [[ -n "$SIMCTL_LAUNCH_PID" && -z "$MATCHING_PROCESSES" ]]; then
+  echo "Launch reported PID $SIMCTL_LAUNCH_PID, but $BUNDLE_ID is no longer running on $IPHONE_UDID." >&2
+  exit 1
 elif [[ -z "$MATCHING_PROCESSES" ]]; then
   echo "Could not find a running PID for $BUNDLE_ID on $IPHONE_UDID."
   exit 1

--- a/apps/ios/scripts/capture-screenshots.sh
+++ b/apps/ios/scripts/capture-screenshots.sh
@@ -108,7 +108,17 @@ list_devices() {
 }
 
 pick_device() {
-  list_devices "$1" | head -n 1
+  local devices=""
+
+  if ! devices="$(list_devices "$1")"; then
+    return 1
+  fi
+
+  if [[ -z "$devices" ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "${devices%%$'\n'*}"
 }
 
 prepare_device() {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "ios:build": "bash apps/ios/scripts/run-xcodebuild.sh build",
     "ios:test": "bash apps/ios/scripts/run-xcodebuild.sh test",
     "ios:performance": "bash apps/ios/scripts/measure-launch-performance.sh",
+    "ios:memory": "bash apps/ios/scripts/capture-memory-baseline.sh",
     "test:auth:ios": "bash apps/ios/scripts/test-auth-callback.sh",
     "test:auth:native": "pnpm --filter @jovie/web exec vitest run tests/unit/desktop/native-complete.test.ts tests/unit/dashboard/session-device-name.test.ts tests/unit/auth/AuthUnavailableCard.compact.test.tsx tests/unit/customer-facing-vendor-copy.test.ts tests/unit/api/auth/native-exchange.test.ts tests/unit/api/dev/test-auth-routes.test.ts && pnpm --filter @jovie/desktop run test && pnpm run test:auth:ios",
     "ios:screenshots": "bash apps/ios/scripts/capture-screenshots.sh",


### PR DESCRIPTION
## Summary
- Adds an opt-in iOS simulator memory baseline command and script that builds, launches, samples, and attempts memgraph capture for `ie.jov.Jovie`.
- Hardens simulator ranking, build-stamp reuse, boot diagnostics, launch argument handling, PID validation, and device selection so captured evidence stays tied to the intended app process.
- Documents `pnpm run ios:memory` and updates the iOS hardening audit docs with the memory baseline path.

## Verification
- `JOVIE_IOS_MEMORY_REUSE_BUILD=1 pnpm run ios:memory` -> pass; latest summary: `artifacts/ios-test-results/memory-baseline/Jovie-memory-baseline-2026.06.02_07-17-10--0700/summary.md`; sample footprint: `36.6M`; PID source: `simctl launch`; memgraph capture remained blocked by local Developer Tools security with `leaks` status `255`, non-strict mode exited 0.
- `JOVIE_IOS_MEMORY_REUSE_BUILD=1 JOVIE_IOS_MEMORY_LAUNCH_ARGUMENTS='   ' pnpm run ios:memory` -> pass; summary: `artifacts/ios-test-results/memory-baseline/Jovie-memory-baseline-2026.06.02_07-06-06--0700/summary.md`; sample footprint: `31.1M`; PID source: `simctl launch`.
- `JOVIE_IOS_MEMORY_REUSE_BUILD=1 JOVIE_IOS_MEMORY_REQUIRE_MEMGRAPH=1 pnpm run ios:memory` -> exits 1 as intended when local Developer Tools security blocks memgraph capture; summary: `artifacts/ios-test-results/memory-baseline/Jovie-memory-baseline-2026.06.02_06-46-26--0700/summary.md`.
- `bash -n apps/ios/scripts/capture-memory-baseline.sh` -> pass.
- `bash -n apps/ios/scripts/capture-screenshots.sh` -> pass.
- `git diff --check` -> pass.
- `git push` pre-push hook -> pass: `biome check .`, web proxy guard, Tailwind guard, web typecheck, web lint.

## Tracking
- Linear: JOV-2712