### PR TITLE
test: cover iOS profile retry recovery

### DIFF
--- a/CRITICAL_BUGS.md
+++ b/CRITICAL_BUGS.md
@@ -44,3 +44,8 @@ The iOS chat shell now preserves a typed composer draft across Chat to Profile
 to Chat navigation in the focused XCUITest
 `testChatComposerPreservesDraftAcrossShellNavigation`, so no iOS draft-loss
 critical bug is currently reproduced for that shell-navigation case.
+The iOS profile shell now shows a recoverable dashboard error for a profile API
+transport failure and restores `.previewReady` after retry in the focused
+`AppStateTests` case `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard`,
+so no iOS profile-load dead-end critical bug is currently reproduced for that
+covered API failure and retry path.

--- a/HARDENING.md
+++ b/HARDENING.md
@@ -16,6 +16,7 @@ staging, or production as appropriate.
 | iOS real-browser auth callback | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` passed through Doppler dev config against a temporary Cloudflare tunnel to local dev. | Verified locally |
 | iOS core screenshots | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e`, producing loading, signed-out, profile, fullscreen QR, settings, needs-onboarding, chat, and iPad shell screenshots. | Verified locally |
 | iOS chat draft stability | `bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieUITests/JovieUITests/testChatComposerPreservesDraftAcrossShellNavigation` passed on `codex/ios-chat-draft-hardening` after `86ba0c65f9`. | Verified locally |
+| iOS profile API retry | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-profile-retry-hardening` with 19 `AppStateTests`, including the profile failure and retry recovery case. | Verified locally |
 
 ## Deliverables
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -7,7 +7,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Gate | Status |
 | --- | --- |
 | Web typecheck, lint, unit, integration, and Playwright evidence | Evidence required under JOV-2712 |
-| iOS XCTest and XCUITest evidence | Auth callback and screenshot smoke evidence recorded for `9e9200348e` |
+| iOS XCTest and XCUITest evidence | Auth callback, screenshot smoke, chat draft, and profile API retry evidence recorded |
 | Electron build, auth, deep link, and end-to-end evidence | Evidence required under JOV-2712 |
 | Chrome Extension popup, background, auth, and messaging evidence | Evidence required under JOV-2712 |
 | Staging verification | Evidence required under JOV-2712 |
@@ -23,6 +23,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Real-browser auth suite | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` passed against a temporary HTTPS tunnel to local dev. | Passed |
 | Screenshot smoke | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e`. | Passed |
 | Chat draft stability | `bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieUITests/JovieUITests/testChatComposerPreservesDraftAcrossShellNavigation` passed on `codex/ios-chat-draft-hardening` after `86ba0c65f9`; it verifies one composer input and draft preservation through Chat to Profile to Chat shell navigation. | Passed |
+| Profile API retry recovery | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-profile-retry-hardening`; `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard` verifies a profile API transport failure shows a recoverable dashboard error and retry restores `.previewReady`. | Passed |
 | Launch performance baseline | `pnpm run ios:performance` passed on `origin/main` `546e2af1f4`; average signed-out shell readiness was `3.01s` under UI-test automation. | Baseline captured under JOV-2712 |
 | Runtime performance baseline | `pnpm run ios:runtime-performance` passed locally on `codex/ios-frame-hitch-evidence` after `c9be9b797a`; average Chat to Profile to Chat shell transition was `0.687s` monotonic time with `0.093s` CPU time and `60036.557 kB` peak physical memory. The run requested `XCTHitchMetric(application:)` on the iOS 26+ simulator, but emitted no measured hitch or frame metric lines. | Baseline captured under JOV-2712 |
 | Memory/leak baseline command | `pnpm run ios:memory` writes a run summary, raw `leaks` output, and `sample` footprint. Local evidence at `artifacts/ios-test-results/memory-baseline/Jovie-memory-baseline-2026.06.02_06-27-15--0700/summary.md` recorded `36.6M` physical footprint and a blocked `.memgraph` because Developer Tools security is disabled. | Command captured under JOV-2712 |

--- a/RELIABILITY_AUDIT.md
+++ b/RELIABILITY_AUDIT.md
@@ -16,15 +16,16 @@ interruptions, browser refreshes, app restarts, and extension reloads.
 | iOS auth callback provider error | `pnpm test:auth:ios` passed `testAuthCallbackProviderErrorShowsAuthError` on `origin/main` `9e9200348e`. | Passed |
 | iOS real-browser auth callback | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` passed `testRealBrowserAuthProviderCompleteReachesAuthenticatedShell` against a temporary HTTPS tunnel to local dev. | Passed |
 | iOS app state transitions | `pnpm test:auth:ios` passed 18 `AppStateTests` on `origin/main` `9e9200348e`. | Passed |
+| iOS profile API failure retry | XcodeBuildMCP `test_sim` passed 19 `AppStateTests`, including `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard`, on `codex/ios-profile-retry-hardening`. | Passed |
 | Slow internet and offline behavior | Evidence required under JOV-2712. | Open |
-| API, database, and rate-limit failures | Evidence required under JOV-2712. | Open |
+| API, database, and rate-limit failures | iOS profile API transport failure now has retry evidence; database, rate-limit, and cross-platform evidence required under JOV-2712. | Partial |
 | Electron and Chrome Extension restart/reload recovery | Evidence required under JOV-2712. | Open |
 
 ## Acceptance Checks
 
 | Check | Status |
 | --- | --- |
-| Graceful degradation | Evidence required under JOV-2712 |
+| Graceful degradation | iOS profile API failure falls back to a dashboard error state; broader evidence required under JOV-2712 |
 | Meaningful error messages | iOS provider-error callback covered; cross-platform evidence required under JOV-2712 |
 | Automatic recovery where possible | Evidence required under JOV-2712 |
-| User recovery paths where automatic recovery is unavailable | Evidence required under JOV-2712 |
+| User recovery paths where automatic recovery is unavailable | iOS profile API failure retry restores the dashboard; broader evidence required under JOV-2712 |

--- a/TEST_COVERAGE_REPORT.md
+++ b/TEST_COVERAGE_REPORT.md
@@ -10,6 +10,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` | Passed through Doppler dev config against a temporary Cloudflare tunnel to local dev. Ran 18 `AppStateTests`, 2 deterministic XCUITests, and `testRealBrowserAuthProviderCompleteReachesAuthenticatedShell`. | Passed |
 | `pnpm run ios:screenshots` | Passed on `origin/main` `9e9200348e`. Produced 7 screenshots in `artifacts/ios-screenshots`. | Passed |
 | `bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieUITests/JovieUITests/testChatComposerPreservesDraftAcrossShellNavigation` | Passed on `codex/ios-chat-draft-hardening` after `86ba0c65f9`. Verified one iOS chat composer input, typed a draft, navigated Chat to Profile to Chat, and asserted the draft value was preserved. | Passed |
+| XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` | Passed on `codex/ios-profile-retry-hardening`. Ran 19 `AppStateTests`, including `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard`, which verifies a profile API transport failure shows a recoverable dashboard error and retry restores `.previewReady`. | Passed |
 | `pnpm run ios:performance` | Passed on `origin/main` `546e2af1f4`. Ran the opt-in `testSignedOutLaunchPerformance()` XCUITest with `XCTApplicationLaunchMetric(waitUntilResponsive: true)`. | Passed |
 | `pnpm run ios:runtime-performance` | Passed locally on `codex/ios-frame-hitch-evidence` after `c9be9b797a`. Ran opt-in `testShellNavigationRuntimePerformance()` for the deterministic Chat to Profile to Chat bottom-navigation transition with clock, CPU, memory, and iOS 26+ hitch metric requests; the xcodebuild log emitted no measured hitch or frame metric lines. | Passed |
 | `pnpm run ios:memory` | Passed locally after `318557208f`. Captured a `sample` footprint for the `-ui-testing-ready` shell and recorded the local `leaks --outputGraph` blocker in the run summary. Strict mode `JOVIE_IOS_MEMORY_REQUIRE_MEMGRAPH=1` exits nonzero when memgraph capture is blocked. | Evidence captured; memgraph blocked locally |
@@ -20,7 +21,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Platform | Required coverage | Current status |
 | --- | --- | --- |
 | Web | Playwright, unit tests, integration tests. | Evidence required under JOV-2712 |
-| iOS | XCTest and XCUITest. | Current auth callback, real-browser auth, screenshot smoke, and chat draft stability evidence recorded |
+| iOS | XCTest and XCUITest. | Current auth callback, real-browser auth, screenshot smoke, chat draft stability, and profile API retry evidence recorded |
 | Electron | End-to-end tests, auth flow tests, deep link tests. | Evidence required under JOV-2712 |
 | Chrome Extension | Popup tests, background script tests, authentication tests, messaging tests. | Evidence required under JOV-2712 |
 
@@ -32,6 +33,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | iOS app state test result | `artifacts/ios-test-results/app-state/Test-Jovie-2026.06.02_05-12-21--0700.xcresult` |
 | iOS real-browser auth test result | `artifacts/ios-test-results/real-browser-auth/Test-Jovie-2026.06.02_05-30-14--0700.xcresult` |
 | iOS chat draft focused XCUITest result | `artifacts/ios-test-results/chat-draft/Test-Jovie-chat-draft-2026.06.02_09-00-00-0700.xcresult` |
+| iOS profile API retry AppState result | `artifacts/ios-test-results/profile-retry/Test-Jovie-profile-retry-2026.06.02_09-16-34-0700.xcresult` |
 | iOS launch performance test result | `artifacts/ios-test-results/launch-performance/Test-Jovie-launch-performance-2026.06.02_05-52-46-0700.xcresult` |
 | iOS launch performance log | `artifacts/ios-test-results/launch-performance/Test-Jovie-launch-performance-2026.06.02_05-52-46-0700.log` |
 | iOS runtime performance summary | `artifacts/ios-test-results/runtime-performance/Test-Jovie-runtime-performance-2026.06.02_08-27-31-0700-summary.md` |

--- a/apps/ios/JovieTests/AppStateTests.swift
+++ b/apps/ios/JovieTests/AppStateTests.swift
@@ -32,6 +32,10 @@ private actor MockRepository: AppStateRepository {
   func loadCount() -> Int {
     loadCallCount
   }
+
+  func updateResult(_ result: Result<MeRepositoryResult, Error>) {
+    nextResult = result
+  }
 }
 
 private final class MockBrightnessController: BrightnessControlling, @unchecked Sendable {
@@ -210,6 +214,39 @@ struct AppStateTests {
     #expect(appState.dashboardState == .idle)
     #expect(appState.activeUserID == nil)
     #expect(await repository.clearedUsers() == ["user_123"])
+  }
+
+  @Test func profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard() async throws {
+    let repository = MockRepository(
+      nextResult: .failure(APIClientError.transportFailed(code: URLError.notConnectedToInternet.rawValue))
+    )
+    let appState = AppState(
+      configuration: configuration,
+      launchMode: .live,
+      repository: repository,
+      brightnessManager: MockBrightnessController()
+    )
+    appState.didLoadClerk = true
+
+    await appState.handleSignedInUserChange("user_123")
+
+    #expect(appState.activeUserID == "user_123")
+    #expect(appState.route == .ready)
+    #expect(appState.dashboardState == .error("Couldn't load your profile."))
+    #expect(appState.isOffline == false)
+
+    await repository.updateResult(
+      .success(
+        MeRepositoryResult(response: .previewReady, isStale: false)
+      )
+    )
+    await appState.retry()
+
+    #expect(appState.activeUserID == "user_123")
+    #expect(appState.route == .ready)
+    #expect(appState.dashboardState == .loaded(.previewReady))
+    #expect(appState.isOffline == false)
+    #expect(await repository.loadCount() == 2)
   }
 
   @Test func mobileBrowserAuthURLUsesCentralAuthStartWithPKCE() {


### PR DESCRIPTION
## Summary
- Add AppState coverage for a profile API transport failure showing a recoverable dashboard error.
- Verify retry restores the ready dashboard after the repository returns `.previewReady`.
- Record the iOS profile API retry evidence in the JOV-2712 hardening docs.

## Checks
- XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed: 19 passed, 0 failed; result bundle `artifacts/ios-test-results/profile-retry/Test-Jovie-profile-retry-2026.06.02_09-16-34-0700.xcresult`.
- `git diff --check`
- Pre-push hook passed: `biome check .`, `pnpm --filter=@jovie/web run next:proxy-guard`, `tailwind:check`, `typecheck`, and `lint`.

## Tracking
- JOV-2712 remains the tracking issue for the broader platform hardening scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect iOS profile API failure recovery behavior, where the app now shows a recoverable error state and restores the dashboard upon retry.

* **Tests**
  * Added test coverage for iOS profile load failure recovery, verifying that automatic retry restores the dashboard after API transport errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->