### PR TITLE
test: cover iOS stale profile cache recovery

### DIFF
--- a/CRITICAL_BUGS.md
+++ b/CRITICAL_BUGS.md
@@ -49,3 +49,7 @@ transport failure and restores `.previewReady` after retry in the focused
 `AppStateTests` case `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard`,
 so no iOS profile-load dead-end critical bug is currently reproduced for that
 covered API failure and retry path.
+The iOS profile shell now keeps stale cached profile data loaded while setting
+the offline state, then clears offline after retry returns fresh data in
+`staleProfileSnapshotShowsOfflineStateAndRetryClearsIt`, so no iOS blank-profile
+critical bug is currently reproduced for that covered stale-cache path.

--- a/HARDENING.md
+++ b/HARDENING.md
@@ -17,6 +17,7 @@ staging, or production as appropriate.
 | iOS core screenshots | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e`, producing loading, signed-out, profile, fullscreen QR, settings, needs-onboarding, chat, and iPad shell screenshots. | Verified locally |
 | iOS chat draft stability | `bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieUITests/JovieUITests/testChatComposerPreservesDraftAcrossShellNavigation` passed on `codex/ios-chat-draft-hardening` after `86ba0c65f9`. | Verified locally |
 | iOS profile API retry | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-profile-retry-hardening` with 19 `AppStateTests`, including the profile failure and retry recovery case. | Verified locally |
+| iOS stale profile cache recovery | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-offline-stale-cache` with 20 `AppStateTests`, including stale profile offline state and retry-clear coverage. | Verified locally |
 
 ## Deliverables
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -7,7 +7,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Gate | Status |
 | --- | --- |
 | Web typecheck, lint, unit, integration, and Playwright evidence | Evidence required under JOV-2712 |
-| iOS XCTest and XCUITest evidence | Auth callback, screenshot smoke, chat draft, and profile API retry evidence recorded |
+| iOS XCTest and XCUITest evidence | Auth callback, screenshot smoke, chat draft, profile API retry, and stale-cache offline evidence recorded |
 | Electron build, auth, deep link, and end-to-end evidence | Evidence required under JOV-2712 |
 | Chrome Extension popup, background, auth, and messaging evidence | Evidence required under JOV-2712 |
 | Staging verification | Evidence required under JOV-2712 |
@@ -24,6 +24,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Screenshot smoke | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e`. | Passed |
 | Chat draft stability | `bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieUITests/JovieUITests/testChatComposerPreservesDraftAcrossShellNavigation` passed on `codex/ios-chat-draft-hardening` after `86ba0c65f9`; it verifies one composer input and draft preservation through Chat to Profile to Chat shell navigation. | Passed |
 | Profile API retry recovery | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-profile-retry-hardening`; `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard` verifies a profile API transport failure shows a recoverable dashboard error and retry restores `.previewReady`. | Passed |
+| Stale cache offline recovery | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-offline-stale-cache`; `staleProfileSnapshotShowsOfflineStateAndRetryClearsIt` verifies stale cached profile data keeps the dashboard loaded in offline state and retry clears offline when fresh data returns. | Passed |
 | Launch performance baseline | `pnpm run ios:performance` passed on `origin/main` `546e2af1f4`; average signed-out shell readiness was `3.01s` under UI-test automation. | Baseline captured under JOV-2712 |
 | Runtime performance baseline | `pnpm run ios:runtime-performance` passed locally on `codex/ios-frame-hitch-evidence` after `c9be9b797a`; average Chat to Profile to Chat shell transition was `0.687s` monotonic time with `0.093s` CPU time and `60036.557 kB` peak physical memory. The run requested `XCTHitchMetric(application:)` on the iOS 26+ simulator, but emitted no measured hitch or frame metric lines. | Baseline captured under JOV-2712 |
 | Memory/leak baseline command | `pnpm run ios:memory` writes a run summary, raw `leaks` output, and `sample` footprint. Local evidence at `artifacts/ios-test-results/memory-baseline/Jovie-memory-baseline-2026.06.02_06-27-15--0700/summary.md` recorded `36.6M` physical footprint and a blocked `.memgraph` because Developer Tools security is disabled. | Command captured under JOV-2712 |

--- a/RELIABILITY_AUDIT.md
+++ b/RELIABILITY_AUDIT.md
@@ -17,7 +17,8 @@ interruptions, browser refreshes, app restarts, and extension reloads.
 | iOS real-browser auth callback | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` passed `testRealBrowserAuthProviderCompleteReachesAuthenticatedShell` against a temporary HTTPS tunnel to local dev. | Passed |
 | iOS app state transitions | `pnpm test:auth:ios` passed 18 `AppStateTests` on `origin/main` `9e9200348e`. | Passed |
 | iOS profile API failure retry | XcodeBuildMCP `test_sim` passed 19 `AppStateTests`, including `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard`, on `codex/ios-profile-retry-hardening`. | Passed |
-| Slow internet and offline behavior | Evidence required under JOV-2712. | Open |
+| iOS stale profile cache recovery | XcodeBuildMCP `test_sim` passed 20 `AppStateTests`, including `staleProfileSnapshotShowsOfflineStateAndRetryClearsIt`, on `codex/ios-offline-stale-cache`. | Passed |
+| Slow internet and offline behavior | iOS stale profile cache now has offline-state and retry-clear evidence; slow-network, no-cache offline, and cross-platform evidence required under JOV-2712. | Partial |
 | API, database, and rate-limit failures | iOS profile API transport failure now has retry evidence; database, rate-limit, and cross-platform evidence required under JOV-2712. | Partial |
 | Electron and Chrome Extension restart/reload recovery | Evidence required under JOV-2712. | Open |
 
@@ -25,7 +26,7 @@ interruptions, browser refreshes, app restarts, and extension reloads.
 
 | Check | Status |
 | --- | --- |
-| Graceful degradation | iOS profile API failure falls back to a dashboard error state; broader evidence required under JOV-2712 |
+| Graceful degradation | iOS profile API failure falls back to a dashboard error state, and stale profile cache keeps the ready shell usable offline; broader evidence required under JOV-2712 |
 | Meaningful error messages | iOS provider-error callback covered; cross-platform evidence required under JOV-2712 |
-| Automatic recovery where possible | Evidence required under JOV-2712 |
+| Automatic recovery where possible | iOS stale profile retry clears the offline state after fresh profile data; broader evidence required under JOV-2712 |
 | User recovery paths where automatic recovery is unavailable | iOS profile API failure retry restores the dashboard; broader evidence required under JOV-2712 |

--- a/TEST_COVERAGE_REPORT.md
+++ b/TEST_COVERAGE_REPORT.md
@@ -11,6 +11,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | `pnpm run ios:screenshots` | Passed on `origin/main` `9e9200348e`. Produced 7 screenshots in `artifacts/ios-screenshots`. | Passed |
 | `bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieUITests/JovieUITests/testChatComposerPreservesDraftAcrossShellNavigation` | Passed on `codex/ios-chat-draft-hardening` after `86ba0c65f9`. Verified one iOS chat composer input, typed a draft, navigated Chat to Profile to Chat, and asserted the draft value was preserved. | Passed |
 | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` | Passed on `codex/ios-profile-retry-hardening`. Ran 19 `AppStateTests`, including `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard`, which verifies a profile API transport failure shows a recoverable dashboard error and retry restores `.previewReady`. | Passed |
+| XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` | Passed on `codex/ios-offline-stale-cache`. Ran 20 `AppStateTests`, including `staleProfileSnapshotShowsOfflineStateAndRetryClearsIt`, which verifies stale cached profile data keeps the dashboard loaded in offline state and retry clears offline when fresh data returns. | Passed |
 | `pnpm run ios:performance` | Passed on `origin/main` `546e2af1f4`. Ran the opt-in `testSignedOutLaunchPerformance()` XCUITest with `XCTApplicationLaunchMetric(waitUntilResponsive: true)`. | Passed |
 | `pnpm run ios:runtime-performance` | Passed locally on `codex/ios-frame-hitch-evidence` after `c9be9b797a`. Ran opt-in `testShellNavigationRuntimePerformance()` for the deterministic Chat to Profile to Chat bottom-navigation transition with clock, CPU, memory, and iOS 26+ hitch metric requests; the xcodebuild log emitted no measured hitch or frame metric lines. | Passed |
 | `pnpm run ios:memory` | Passed locally after `318557208f`. Captured a `sample` footprint for the `-ui-testing-ready` shell and recorded the local `leaks --outputGraph` blocker in the run summary. Strict mode `JOVIE_IOS_MEMORY_REQUIRE_MEMGRAPH=1` exits nonzero when memgraph capture is blocked. | Evidence captured; memgraph blocked locally |
@@ -21,7 +22,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Platform | Required coverage | Current status |
 | --- | --- | --- |
 | Web | Playwright, unit tests, integration tests. | Evidence required under JOV-2712 |
-| iOS | XCTest and XCUITest. | Current auth callback, real-browser auth, screenshot smoke, chat draft stability, and profile API retry evidence recorded |
+| iOS | XCTest and XCUITest. | Current auth callback, real-browser auth, screenshot smoke, chat draft stability, profile API retry, and stale-cache offline evidence recorded |
 | Electron | End-to-end tests, auth flow tests, deep link tests. | Evidence required under JOV-2712 |
 | Chrome Extension | Popup tests, background script tests, authentication tests, messaging tests. | Evidence required under JOV-2712 |
 
@@ -34,6 +35,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | iOS real-browser auth test result | `artifacts/ios-test-results/real-browser-auth/Test-Jovie-2026.06.02_05-30-14--0700.xcresult` |
 | iOS chat draft focused XCUITest result | `artifacts/ios-test-results/chat-draft/Test-Jovie-chat-draft-2026.06.02_09-00-00-0700.xcresult` |
 | iOS profile API retry AppState result | `artifacts/ios-test-results/profile-retry/Test-Jovie-profile-retry-2026.06.02_09-16-34-0700.xcresult` |
+| iOS stale cache offline AppState result | `artifacts/ios-test-results/offline-cache/Test-Jovie-offline-cache-2026.06.02_09-35-29-0700.xcresult` |
 | iOS launch performance test result | `artifacts/ios-test-results/launch-performance/Test-Jovie-launch-performance-2026.06.02_05-52-46-0700.xcresult` |
 | iOS launch performance log | `artifacts/ios-test-results/launch-performance/Test-Jovie-launch-performance-2026.06.02_05-52-46-0700.log` |
 | iOS runtime performance summary | `artifacts/ios-test-results/runtime-performance/Test-Jovie-runtime-performance-2026.06.02_08-27-31-0700-summary.md` |

--- a/apps/ios/JovieTests/AppStateTests.swift
+++ b/apps/ios/JovieTests/AppStateTests.swift
@@ -249,6 +249,41 @@ struct AppStateTests {
     #expect(await repository.loadCount() == 2)
   }
 
+  @Test func staleProfileSnapshotShowsOfflineStateAndRetryClearsIt() async throws {
+    let repository = MockRepository(
+      nextResult: .success(
+        MeRepositoryResult(response: .previewReady, isStale: true)
+      )
+    )
+    let appState = AppState(
+      configuration: configuration,
+      launchMode: .live,
+      repository: repository,
+      brightnessManager: MockBrightnessController()
+    )
+    appState.didLoadClerk = true
+
+    await appState.handleSignedInUserChange("user_123")
+
+    #expect(appState.activeUserID == "user_123")
+    #expect(appState.route == .ready)
+    #expect(appState.dashboardState == .loaded(.previewReady))
+    #expect(appState.isOffline == true)
+
+    await repository.updateResult(
+      .success(
+        MeRepositoryResult(response: .previewReady, isStale: false)
+      )
+    )
+    await appState.retry()
+
+    #expect(appState.activeUserID == "user_123")
+    #expect(appState.route == .ready)
+    #expect(appState.dashboardState == .loaded(.previewReady))
+    #expect(appState.isOffline == false)
+    #expect(await repository.loadCount() == 2)
+  }
+
   @Test func mobileBrowserAuthURLUsesCentralAuthStartWithPKCE() {
     let url = MobileBrowserAuthURLBuilder.signInURL(
       baseURL: URL(string: "https://jov.ie")!,


### PR DESCRIPTION
## Summary
- Add AppState coverage for stale cached profile data keeping the dashboard loaded while setting the offline state.
- Verify retry clears the offline state once fresh `.previewReady` data returns.
- Record the iOS stale-cache/offline evidence in the JOV-2712 hardening docs.

## Checks
- XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed: 20 passed, 0 failed; result bundle `artifacts/ios-test-results/offline-cache/Test-Jovie-offline-cache-2026.06.02_09-35-29-0700.xcresult`.
- `git diff --check`
- Pre-push hook passed: `biome check .`, `pnpm --filter=@jovie/web run next:proxy-guard`, `tailwind:check`, `typecheck`, and `lint`.

## Tracking
- JOV-2712 remains the tracking issue for the broader platform hardening scope.