### PR TITLE
test: cover iOS cold offline recovery

### DIFF
--- a/CRITICAL_BUGS.md
+++ b/CRITICAL_BUGS.md
@@ -45,11 +45,16 @@ to Chat navigation in the focused XCUITest
 `testChatComposerPreservesDraftAcrossShellNavigation`, so no iOS draft-loss
 critical bug is currently reproduced for that shell-navigation case.
 The iOS profile shell now shows a recoverable dashboard error for a profile API
-transport failure and restores `.previewReady` after retry in the focused
+server failure and restores `.previewReady` after retry in the focused
 `AppStateTests` case `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard`,
 so no iOS profile-load dead-end critical bug is currently reproduced for that
-covered API failure and retry path.
+covered API server-failure and retry path.
 The iOS profile shell now keeps stale cached profile data loaded while setting
 the offline state, then clears offline after retry returns fresh data in
 `staleProfileSnapshotShowsOfflineStateAndRetryClearsIt`, so no iOS blank-profile
 critical bug is currently reproduced for that covered stale-cache path.
+The iOS profile shell now marks a cold transport failure offline while showing a
+recoverable dashboard error, then clears offline after retry returns fresh data
+in `coldOfflineProfileLoadShowsOfflineStateAndRetryClearsIt`, so no iOS
+cold-offline dead-end critical bug is currently reproduced for that covered
+retry path.

--- a/HARDENING.md
+++ b/HARDENING.md
@@ -16,8 +16,9 @@ staging, or production as appropriate.
 | iOS real-browser auth callback | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` passed through Doppler dev config against a temporary Cloudflare tunnel to local dev. | Verified locally |
 | iOS core screenshots | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e`, producing loading, signed-out, profile, fullscreen QR, settings, needs-onboarding, chat, and iPad shell screenshots. | Verified locally |
 | iOS chat draft stability | `bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieUITests/JovieUITests/testChatComposerPreservesDraftAcrossShellNavigation` passed on `codex/ios-chat-draft-hardening` after `86ba0c65f9`. | Verified locally |
-| iOS profile API retry | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-profile-retry-hardening` with 19 `AppStateTests`, including the profile failure and retry recovery case. | Verified locally |
+| iOS profile API retry | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-profile-retry-hardening` with 19 `AppStateTests`, including the profile API server failure and retry recovery case. | Verified locally |
 | iOS stale profile cache recovery | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-offline-stale-cache` with 20 `AppStateTests`, including stale profile offline state and retry-clear coverage. | Verified locally |
+| iOS cold offline profile recovery | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-cold-offline-recovery` with 21 `AppStateTests`, including cold transport-failure offline state and retry-clear coverage. | Verified locally |
 
 ## Deliverables
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -7,7 +7,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Gate | Status |
 | --- | --- |
 | Web typecheck, lint, unit, integration, and Playwright evidence | Evidence required under JOV-2712 |
-| iOS XCTest and XCUITest evidence | Auth callback, screenshot smoke, chat draft, profile API retry, and stale-cache offline evidence recorded |
+| iOS XCTest and XCUITest evidence | Auth callback, screenshot smoke, chat draft, profile API retry, stale-cache offline, and cold-offline retry evidence recorded |
 | Electron build, auth, deep link, and end-to-end evidence | Evidence required under JOV-2712 |
 | Chrome Extension popup, background, auth, and messaging evidence | Evidence required under JOV-2712 |
 | Staging verification | Evidence required under JOV-2712 |
@@ -23,8 +23,9 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Real-browser auth suite | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` passed against a temporary HTTPS tunnel to local dev. | Passed |
 | Screenshot smoke | `pnpm run ios:screenshots` passed on `origin/main` `9e9200348e`. | Passed |
 | Chat draft stability | `bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieUITests/JovieUITests/testChatComposerPreservesDraftAcrossShellNavigation` passed on `codex/ios-chat-draft-hardening` after `86ba0c65f9`; it verifies one composer input and draft preservation through Chat to Profile to Chat shell navigation. | Passed |
-| Profile API retry recovery | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-profile-retry-hardening`; `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard` verifies a profile API transport failure shows a recoverable dashboard error and retry restores `.previewReady`. | Passed |
+| Profile API retry recovery | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-profile-retry-hardening`; `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard` verifies a profile API server failure shows a recoverable dashboard error and retry restores `.previewReady`. | Passed |
 | Stale cache offline recovery | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-offline-stale-cache`; `staleProfileSnapshotShowsOfflineStateAndRetryClearsIt` verifies stale cached profile data keeps the dashboard loaded in offline state and retry clears offline when fresh data returns. | Passed |
+| Cold offline profile recovery | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` passed on `codex/ios-cold-offline-recovery`; `coldOfflineProfileLoadShowsOfflineStateAndRetryClearsIt` verifies a cold transport failure shows a recoverable dashboard error, marks the shell offline, and retry clears offline when fresh data returns. | Passed |
 | Launch performance baseline | `pnpm run ios:performance` passed on `origin/main` `546e2af1f4`; average signed-out shell readiness was `3.01s` under UI-test automation. | Baseline captured under JOV-2712 |
 | Runtime performance baseline | `pnpm run ios:runtime-performance` passed locally on `codex/ios-frame-hitch-evidence` after `c9be9b797a`; average Chat to Profile to Chat shell transition was `0.687s` monotonic time with `0.093s` CPU time and `60036.557 kB` peak physical memory. The run requested `XCTHitchMetric(application:)` on the iOS 26+ simulator, but emitted no measured hitch or frame metric lines. | Baseline captured under JOV-2712 |
 | Memory/leak baseline command | `pnpm run ios:memory` writes a run summary, raw `leaks` output, and `sample` footprint. Local evidence at `artifacts/ios-test-results/memory-baseline/Jovie-memory-baseline-2026.06.02_06-27-15--0700/summary.md` recorded `36.6M` physical footprint and a blocked `.memgraph` because Developer Tools security is disabled. | Command captured under JOV-2712 |

--- a/RELIABILITY_AUDIT.md
+++ b/RELIABILITY_AUDIT.md
@@ -18,15 +18,16 @@ interruptions, browser refreshes, app restarts, and extension reloads.
 | iOS app state transitions | `pnpm test:auth:ios` passed 18 `AppStateTests` on `origin/main` `9e9200348e`. | Passed |
 | iOS profile API failure retry | XcodeBuildMCP `test_sim` passed 19 `AppStateTests`, including `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard`, on `codex/ios-profile-retry-hardening`. | Passed |
 | iOS stale profile cache recovery | XcodeBuildMCP `test_sim` passed 20 `AppStateTests`, including `staleProfileSnapshotShowsOfflineStateAndRetryClearsIt`, on `codex/ios-offline-stale-cache`. | Passed |
-| Slow internet and offline behavior | iOS stale profile cache now has offline-state and retry-clear evidence; slow-network, no-cache offline, and cross-platform evidence required under JOV-2712. | Partial |
-| API, database, and rate-limit failures | iOS profile API transport failure now has retry evidence; database, rate-limit, and cross-platform evidence required under JOV-2712. | Partial |
+| iOS cold offline profile recovery | XcodeBuildMCP `test_sim` passed 21 `AppStateTests`, including `coldOfflineProfileLoadShowsOfflineStateAndRetryClearsIt`, on `codex/ios-cold-offline-recovery`. | Passed |
+| Slow internet and offline behavior | iOS stale-cache and no-cache offline profile paths now have offline-state and retry-clear evidence; slow-network and cross-platform evidence required under JOV-2712. | Partial |
+| API, database, and rate-limit failures | iOS profile API server failure now has retry evidence; database, rate-limit, and cross-platform evidence required under JOV-2712. | Partial |
 | Electron and Chrome Extension restart/reload recovery | Evidence required under JOV-2712. | Open |
 
 ## Acceptance Checks
 
 | Check | Status |
 | --- | --- |
-| Graceful degradation | iOS profile API failure falls back to a dashboard error state, and stale profile cache keeps the ready shell usable offline; broader evidence required under JOV-2712 |
+| Graceful degradation | iOS profile API failure falls back to a dashboard error state, stale profile cache keeps the ready shell usable offline, and cold transport failure marks the dashboard offline with retry; broader evidence required under JOV-2712 |
 | Meaningful error messages | iOS provider-error callback covered; cross-platform evidence required under JOV-2712 |
 | Automatic recovery where possible | iOS stale profile retry clears the offline state after fresh profile data; broader evidence required under JOV-2712 |
-| User recovery paths where automatic recovery is unavailable | iOS profile API failure retry restores the dashboard; broader evidence required under JOV-2712 |
+| User recovery paths where automatic recovery is unavailable | iOS profile API failure and cold offline retry restore the dashboard; broader evidence required under JOV-2712 |

--- a/TEST_COVERAGE_REPORT.md
+++ b/TEST_COVERAGE_REPORT.md
@@ -10,8 +10,9 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | `JOVIE_IOS_REAL_BROWSER_AUTH=1 pnpm test:auth:ios` | Passed through Doppler dev config against a temporary Cloudflare tunnel to local dev. Ran 18 `AppStateTests`, 2 deterministic XCUITests, and `testRealBrowserAuthProviderCompleteReachesAuthenticatedShell`. | Passed |
 | `pnpm run ios:screenshots` | Passed on `origin/main` `9e9200348e`. Produced 7 screenshots in `artifacts/ios-screenshots`. | Passed |
 | `bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieUITests/JovieUITests/testChatComposerPreservesDraftAcrossShellNavigation` | Passed on `codex/ios-chat-draft-hardening` after `86ba0c65f9`. Verified one iOS chat composer input, typed a draft, navigated Chat to Profile to Chat, and asserted the draft value was preserved. | Passed |
-| XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` | Passed on `codex/ios-profile-retry-hardening`. Ran 19 `AppStateTests`, including `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard`, which verifies a profile API transport failure shows a recoverable dashboard error and retry restores `.previewReady`. | Passed |
+| XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` | Passed on `codex/ios-profile-retry-hardening`. Ran 19 `AppStateTests`, including `profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard`, which verifies a profile API server failure shows a recoverable dashboard error and retry restores `.previewReady`. | Passed |
 | XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` | Passed on `codex/ios-offline-stale-cache`. Ran 20 `AppStateTests`, including `staleProfileSnapshotShowsOfflineStateAndRetryClearsIt`, which verifies stale cached profile data keeps the dashboard loaded in offline state and retry clears offline when fresh data returns. | Passed |
+| XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests` | Passed on `codex/ios-cold-offline-recovery`. Ran 21 `AppStateTests`, including `coldOfflineProfileLoadShowsOfflineStateAndRetryClearsIt`, which verifies a cold transport failure shows a recoverable dashboard error, marks the shell offline, and retry clears offline when fresh data returns. | Passed |
 | `pnpm run ios:performance` | Passed on `origin/main` `546e2af1f4`. Ran the opt-in `testSignedOutLaunchPerformance()` XCUITest with `XCTApplicationLaunchMetric(waitUntilResponsive: true)`. | Passed |
 | `pnpm run ios:runtime-performance` | Passed locally on `codex/ios-frame-hitch-evidence` after `c9be9b797a`. Ran opt-in `testShellNavigationRuntimePerformance()` for the deterministic Chat to Profile to Chat bottom-navigation transition with clock, CPU, memory, and iOS 26+ hitch metric requests; the xcodebuild log emitted no measured hitch or frame metric lines. | Passed |
 | `pnpm run ios:memory` | Passed locally after `318557208f`. Captured a `sample` footprint for the `-ui-testing-ready` shell and recorded the local `leaks --outputGraph` blocker in the run summary. Strict mode `JOVIE_IOS_MEMORY_REQUIRE_MEMGRAPH=1` exits nonzero when memgraph capture is blocked. | Evidence captured; memgraph blocked locally |
@@ -22,7 +23,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | Platform | Required coverage | Current status |
 | --- | --- | --- |
 | Web | Playwright, unit tests, integration tests. | Evidence required under JOV-2712 |
-| iOS | XCTest and XCUITest. | Current auth callback, real-browser auth, screenshot smoke, chat draft stability, profile API retry, and stale-cache offline evidence recorded |
+| iOS | XCTest and XCUITest. | Current auth callback, real-browser auth, screenshot smoke, chat draft stability, profile API retry, stale-cache offline, and cold-offline retry evidence recorded |
 | Electron | End-to-end tests, auth flow tests, deep link tests. | Evidence required under JOV-2712 |
 | Chrome Extension | Popup tests, background script tests, authentication tests, messaging tests. | Evidence required under JOV-2712 |
 
@@ -36,6 +37,7 @@ Tracking issue: [JOV-2712](https://linear.app/jovie/issue/JOV-2712/track-platfor
 | iOS chat draft focused XCUITest result | `artifacts/ios-test-results/chat-draft/Test-Jovie-chat-draft-2026.06.02_09-00-00-0700.xcresult` |
 | iOS profile API retry AppState result | `artifacts/ios-test-results/profile-retry/Test-Jovie-profile-retry-2026.06.02_09-16-34-0700.xcresult` |
 | iOS stale cache offline AppState result | `artifacts/ios-test-results/offline-cache/Test-Jovie-offline-cache-2026.06.02_09-35-29-0700.xcresult` |
+| iOS cold offline AppState result | `artifacts/ios-test-results/cold-offline/Test-Jovie-cold-offline-2026.06.02_10-06-26-0700.xcresult` |
 | iOS launch performance test result | `artifacts/ios-test-results/launch-performance/Test-Jovie-launch-performance-2026.06.02_05-52-46-0700.xcresult` |
 | iOS launch performance log | `artifacts/ios-test-results/launch-performance/Test-Jovie-launch-performance-2026.06.02_05-52-46-0700.log` |
 | iOS runtime performance summary | `artifacts/ios-test-results/runtime-performance/Test-Jovie-runtime-performance-2026.06.02_08-27-31-0700-summary.md` |

--- a/apps/ios/Jovie/App/AppState.swift
+++ b/apps/ios/Jovie/App/AppState.swift
@@ -142,6 +142,8 @@ final class AppState {
     } catch {
       guard activeUserID == userID, loadingUserID == userID else { return }
 
+      var didTransportFail = false
+
       if let error = error as? APIClientError {
         switch error {
         case .missingToken, .requestFailed(statusCode: 401):
@@ -151,14 +153,16 @@ final class AppState {
           isOffline = false
           MobileAuthDiagnostics.record("route_signed_out", detail: error.localizedDescription)
           return
-        case .decodingFailed, .invalidResponse, .transportFailed, .requestFailed:
+        case .transportFailed:
+          didTransportFail = true
+        case .decodingFailed, .invalidResponse, .requestFailed:
           break
         }
       }
 
       route = .ready
       dashboardState = .error("Couldn't load your profile.")
-      isOffline = false
+      isOffline = didTransportFail
       MobileAuthDiagnostics.record("mobile_me_error", detail: error.localizedDescription)
     }
   }

--- a/apps/ios/JovieTests/AppStateTests.swift
+++ b/apps/ios/JovieTests/AppStateTests.swift
@@ -218,7 +218,7 @@ struct AppStateTests {
 
   @Test func profileLoadFailureShowsRecoveryStateAndRetryRestoresDashboard() async throws {
     let repository = MockRepository(
-      nextResult: .failure(APIClientError.transportFailed(code: URLError.notConnectedToInternet.rawValue))
+      nextResult: .failure(APIClientError.requestFailed(statusCode: 500))
     )
     let appState = AppState(
       configuration: configuration,
@@ -234,6 +234,39 @@ struct AppStateTests {
     #expect(appState.route == .ready)
     #expect(appState.dashboardState == .error("Couldn't load your profile."))
     #expect(appState.isOffline == false)
+
+    await repository.updateResult(
+      .success(
+        MeRepositoryResult(response: .previewReady, isStale: false)
+      )
+    )
+    await appState.retry()
+
+    #expect(appState.activeUserID == "user_123")
+    #expect(appState.route == .ready)
+    #expect(appState.dashboardState == .loaded(.previewReady))
+    #expect(appState.isOffline == false)
+    #expect(await repository.loadCount() == 2)
+  }
+
+  @Test func coldOfflineProfileLoadShowsOfflineStateAndRetryClearsIt() async throws {
+    let repository = MockRepository(
+      nextResult: .failure(APIClientError.transportFailed(code: URLError.notConnectedToInternet.rawValue))
+    )
+    let appState = AppState(
+      configuration: configuration,
+      launchMode: .live,
+      repository: repository,
+      brightnessManager: MockBrightnessController()
+    )
+    appState.didLoadClerk = true
+
+    await appState.handleSignedInUserChange("user_123")
+
+    #expect(appState.activeUserID == "user_123")
+    #expect(appState.route == .ready)
+    #expect(appState.dashboardState == .error("Couldn't load your profile."))
+    #expect(appState.isOffline == true)
 
     await repository.updateResult(
       .success(


### PR DESCRIPTION
## Summary
- mark cold iOS profile transport failures as offline while keeping the dashboard retry path
- split AppState coverage for API server failure, cold offline transport failure, and stale-cache offline recovery
- update JOV-2712 hardening evidence docs with the new cold-offline artifact

## Verification
- XcodeBuildMCP `test_sim -only-testing:JovieTests/AppStateTests -resultBundlePath artifacts/ios-test-results/cold-offline/Test-Jovie-cold-offline-2026.06.02_10-06-26-0700.xcresult` passed: 21 passed, 0 failed, 0 skipped
- `git diff --check`
- pre-push hook passed: `biome check .`, `pnpm --filter=@jovie/web run next:proxy-guard`, `pnpm --filter=@jovie/web run tailwind:check`, `pnpm --filter=@jovie/web run typecheck`, `pnpm --filter=@jovie/web run lint`

Tracking: JOV-2712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline state handling during profile loading to accurately distinguish between different error types and properly track network connectivity.

* **Tests**
  * Added and updated tests to verify offline recovery behavior and automatic retry mechanisms for offline scenarios.

* **Documentation**
  * Updated hardening, reliability, and test coverage documentation to reflect offline state management and recovery evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->