### PR TITLE
fix(ios): fail closed on invalid live config

### DIFF
--- a/apps/ios/Jovie/App/JovieApp.swift
+++ b/apps/ios/Jovie/App/JovieApp.swift
@@ -279,25 +279,64 @@ func makeJovieClerkOptions(
   )
 }
 
+struct LiveLaunchConfiguration: Sendable {
+  let configuration: AppConfiguration
+  let shouldConfigureClerk: Bool
+  let authErrorMessage: String?
+}
+
+enum LiveLaunchConfigurationResolver {
+  private static let unavailableMessage =
+    "Sign-in is unavailable in this build. Install the latest TestFlight build or try again later."
+
+  static func resolve(
+    launchMode: LaunchMode,
+    loadLiveConfiguration: () throws -> AppConfiguration = {
+      try AppConfiguration.loadForLiveLaunch()
+    },
+    loadUnvalidatedConfiguration: () -> AppConfiguration = {
+      AppConfiguration.load()
+    }
+  ) -> LiveLaunchConfiguration {
+    guard launchMode.usesLiveClerk else {
+      return LiveLaunchConfiguration(
+        configuration: .mock,
+        shouldConfigureClerk: false,
+        authErrorMessage: nil
+      )
+    }
+
+    do {
+      return LiveLaunchConfiguration(
+        configuration: try loadLiveConfiguration(),
+        shouldConfigureClerk: true,
+        authErrorMessage: nil
+      )
+    } catch {
+      return LiveLaunchConfiguration(
+        configuration: loadUnvalidatedConfiguration(),
+        shouldConfigureClerk: false,
+        authErrorMessage: unavailableMessage
+      )
+    }
+  }
+}
+
 @main
 struct JovieApp: App {
   @UIApplicationDelegateAdaptor(JovieAppDelegate.self) private var appDelegate
   @State private var appState: AppState
+  private let isLiveAuthAvailable: Bool
+  private let launchAuthErrorMessage: String?
 
   init() {
     let launchMode = LaunchMode.current()
-    let configuration: AppConfiguration
-    if launchMode.usesLiveClerk {
-      do {
-        configuration = try AppConfiguration.loadForLiveLaunch()
-      } catch {
-        fatalError(
-          "Invalid Clerk publishable key configuration for live launch: \(error.localizedDescription)"
-        )
-      }
-    } else {
-      configuration = .mock
-    }
+    let launchConfiguration = LiveLaunchConfigurationResolver.resolve(
+      launchMode: launchMode
+    )
+    let configuration = launchConfiguration.configuration
+    isLiveAuthAvailable = launchConfiguration.shouldConfigureClerk
+    launchAuthErrorMessage = launchConfiguration.authErrorMessage
 
     Observability.configure(
       environment: configuration.observabilityEnvironment,
@@ -310,7 +349,7 @@ struct JovieApp: App {
       value: String(describing: launchMode)
     )
 
-    if launchMode.usesLiveClerk {
+    if launchConfiguration.shouldConfigureClerk {
       Clerk.configure(
         publishableKey: configuration.clerkPublishableKey,
         options: makeJovieClerkOptions(
@@ -349,28 +388,30 @@ struct JovieApp: App {
 #if DEBUG
         if appState.launchMode == .uiTestingAuthCallback {
           UITestingAuthCallbackRoot(appState: appState)
-        } else if appState.launchMode.usesLiveClerk {
+        } else if appState.launchMode.usesLiveClerk, isLiveAuthAvailable {
           LiveRootContainer(appState: appState)
             .environment(Clerk.shared)
         } else {
           RootView(
             appState: appState,
+            isAuthAvailable: isLiveAuthAvailable,
             liveUserID: nil,
-            authErrorMessage: nil,
+            authErrorMessage: launchAuthErrorMessage,
             onLogout: { await appState.signOut() },
             onAuthReturn: { _ in },
             onAuthError: { _ in }
           )
         }
 #else
-        if appState.launchMode.usesLiveClerk {
+        if appState.launchMode.usesLiveClerk, isLiveAuthAvailable {
           LiveRootContainer(appState: appState)
             .environment(Clerk.shared)
         } else {
           RootView(
             appState: appState,
+            isAuthAvailable: isLiveAuthAvailable,
             liveUserID: nil,
-            authErrorMessage: nil,
+            authErrorMessage: launchAuthErrorMessage,
             onLogout: { await appState.signOut() },
             onAuthReturn: { _ in },
             onAuthError: { _ in }

--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -164,6 +164,7 @@ private enum LiveAuthBootstrapper {
 
 private struct AppContentView: View {
   @Bindable var appState: AppState
+  let isAuthAvailable: Bool
   let authErrorMessage: String?
   let onLogout: @MainActor () async -> Void
   let onAuthReturn: @MainActor (MobileAuthReturn) -> Void
@@ -176,7 +177,7 @@ private struct AppContentView: View {
         SplashView()
       case .signedOut:
         AuthScreen(
-          isMock: !appState.launchMode.usesLiveClerk,
+          isMock: !isAuthAvailable,
           webBaseURL: appState.configuration.webBaseURL,
           errorMessage: authErrorMessage,
           onAuthReturn: onAuthReturn,
@@ -303,6 +304,7 @@ private struct ChatComposerPreview: View {
 
 struct RootView: View {
   @Bindable var appState: AppState
+  let isAuthAvailable: Bool
   let liveUserID: String?
   let authErrorMessage: String?
   let onLogout: @MainActor () async -> Void
@@ -313,6 +315,7 @@ struct RootView: View {
     ZStack {
       AppContentView(
         appState: appState,
+        isAuthAvailable: isAuthAvailable,
         authErrorMessage: authErrorMessage,
         onLogout: onLogout,
         onAuthReturn: onAuthReturn,
@@ -456,6 +459,7 @@ struct UITestingAuthCallbackRoot: View {
   var body: some View {
     RootView(
       appState: appState,
+      isAuthAvailable: false,
       liveUserID: liveUserID,
       authErrorMessage: authErrorMessage,
       onLogout: { await appState.signOut() },
@@ -560,6 +564,7 @@ struct LiveRootContainer: View {
   var body: some View {
     RootView(
       appState: appState,
+      isAuthAvailable: true,
       liveUserID: clerk.user?.id,
       authErrorMessage: authErrorMessage,
       onLogout: {

--- a/apps/ios/Jovie/Features/Auth/AuthScreen.swift
+++ b/apps/ios/Jovie/Features/Auth/AuthScreen.swift
@@ -33,6 +33,7 @@ struct AuthScreen: View {
 
           BrowserAuthActions(
             isOpening: didRequestBrowserAuth,
+            isDisabled: isMock,
             errorMessage: errorMessage,
             action: startBrowserAuth
           )
@@ -383,12 +384,13 @@ private extension Data {
 
 private struct BrowserAuthActions: View {
   let isOpening: Bool
+  let isDisabled: Bool
   let errorMessage: String?
   let action: () -> Void
 
   var body: some View {
     VStack(spacing: JovieSpacing.large) {
-      ContinueInBrowserButton(isOpening: isOpening, action: action)
+      ContinueInBrowserButton(isOpening: isOpening, isDisabled: isDisabled, action: action)
 
       AuthErrorText(message: errorMessage)
     }
@@ -398,33 +400,43 @@ private struct BrowserAuthActions: View {
 
 private struct ContinueInBrowserButton: View {
   let isOpening: Bool
+  let isDisabled: Bool
   let action: () -> Void
 
   var body: some View {
     Button(action: action) {
       HStack(spacing: JovieSpacing.small) {
-        if isOpening {
+        if isOpening, !isDisabled {
           ProgressView()
             .controlSize(.small)
             .tint(JovieColor.backgroundBase)
         }
 
-        Text(isOpening ? "Opening Browser..." : "Continue in Browser")
+        Text(buttonTitle)
           .lineLimit(1)
           .minimumScaleFactor(0.82)
       }
       .font(JovieFont.body(size: 16, weight: .semibold))
-      .foregroundStyle(JovieColor.backgroundBase)
+      .foregroundStyle(isDisabled ? JovieColor.textSecondary : JovieColor.backgroundBase)
       .frame(maxWidth: .infinity)
       .frame(height: 56)
       .contentShape(Rectangle())
     }
+    .disabled(isDisabled)
     .buttonStyle(.plain)
     .background(
       Capsule(style: .continuous)
-        .fill(Color.white)
+        .fill(isDisabled ? JovieColor.surface2 : Color.white)
     )
     .accessibilityIdentifier("auth-continue-browser-button")
+  }
+
+  private var buttonTitle: String {
+    if isDisabled {
+      return "Sign-in Unavailable"
+    }
+
+    return isOpening ? "Opening Browser..." : "Continue in Browser"
   }
 }
 

--- a/apps/ios/JovieTests/MobileAuthFinalizationTests.swift
+++ b/apps/ios/JovieTests/MobileAuthFinalizationTests.swift
@@ -40,6 +40,59 @@ struct MobileAuthFinalizationTests {
     #expect(plan == .requiresClerkTicketFlow(ticket: "ticket_only"))
   }
 
+  @Test func liveLaunchConfigurationUsesMockForNonLiveModes() {
+    let result = LiveLaunchConfigurationResolver.resolve(
+      launchMode: .uiTestingSignedOut,
+      loadLiveConfiguration: {
+        throw ClerkPublishableKeyValidationError.developmentKeyInDistribution
+      },
+      loadUnvalidatedConfiguration: {
+        testConfiguration(clerkPublishableKey: "pk_test_fallback")
+      }
+    )
+
+    #expect(result.configuration.clerkPublishableKey == AppConfiguration.mock.clerkPublishableKey)
+    #expect(result.shouldConfigureClerk == false)
+    #expect(result.authErrorMessage == nil)
+  }
+
+  @Test func liveLaunchConfigurationEnablesClerkForValidLiveConfig() {
+    let configuration = testConfiguration(clerkPublishableKey: "pk_live_prod")
+
+    let result = LiveLaunchConfigurationResolver.resolve(
+      launchMode: .live,
+      loadLiveConfiguration: { configuration },
+      loadUnvalidatedConfiguration: {
+        testConfiguration(clerkPublishableKey: "pk_test_fallback")
+      }
+    )
+
+    #expect(result.configuration.clerkPublishableKey == "pk_live_prod")
+    #expect(result.shouldConfigureClerk == true)
+    #expect(result.authErrorMessage == nil)
+  }
+
+  @Test func liveLaunchConfigurationFailsClosedForInvalidDistributionConfig() {
+    let fallbackConfiguration = testConfiguration(
+      clerkPublishableKey: "pk_test_bW9zdC1rb2FsYS04NC5jbGVyay5hY2NvdW50cy5kZXYk"
+    )
+
+    let result = LiveLaunchConfigurationResolver.resolve(
+      launchMode: .live,
+      loadLiveConfiguration: {
+        throw ClerkPublishableKeyValidationError.developmentKeyInDistribution
+      },
+      loadUnvalidatedConfiguration: { fallbackConfiguration }
+    )
+
+    #expect(result.configuration.clerkPublishableKey == fallbackConfiguration.clerkPublishableKey)
+    #expect(result.shouldConfigureClerk == false)
+    #expect(
+      result.authErrorMessage ==
+        "Sign-in is unavailable in this build. Install the latest TestFlight build or try again later."
+    )
+  }
+
   @Test func rejectsPlaceholderClerkKeyInDistributionBuilds() {
 #if DEBUG
     // Development builds may use pk_test keys locally.
@@ -70,5 +123,17 @@ struct MobileAuthFinalizationTests {
       "pk_live_production_instance.clerk.accounts.dev"
     )
 #endif
+  }
+
+  private func testConfiguration(clerkPublishableKey: String) -> AppConfiguration {
+    AppConfiguration(
+      clerkPublishableKey: clerkPublishableKey,
+      apiBaseURL: URL(string: "https://jov.ie")!,
+      webBaseURL: URL(string: "https://jov.ie")!,
+      sentryDSN: nil,
+      observabilityEnvironment: "test",
+      clerkRedirectUrl: "ie.jov.jovie://callback",
+      clerkCallbackUrlScheme: "ie.jov.jovie"
+    )
   }
 }


### PR DESCRIPTION
## Summary
- Replace the iOS launch-time `fatalError` for invalid live Clerk config with a tested launch resolver.
- Preserve distribution key validation, but fail closed by skipping Clerk configuration and routing to signed-out UI with an auth error.
- Disable the browser auth action when live auth is unavailable so the app stays coherent instead of presenting an actionable no-op.

## RCA
Installed TestFlight build `1.0 (40)` had four local crash reports on 2026-06-02 with `EXC_BREAKPOINT` / `SIGTRAP` on the main thread and top frame `libswiftCore _assertionFailure`. The installed TestFlight wrapper embeds a `pk_test_...clerk.accounts.dev` key in `Configuration.local.plist`; source matched this because `JovieApp.init` called `fatalError(...)` when `AppConfiguration.loadForLiveLaunch()` rejected that key for distribution launch.

## Verification
- `mcp__xcodebuildmcp.test_sim` with `-only-testing:JovieTests/MobileAuthFinalizationTests`: 7 passed, 0 failed
- `xcodebuild build -project apps/ios/Jovie.xcodeproj -scheme Jovie -configuration Release -destination 'platform=iOS Simulator,id=7A8ECED1-02CF-40F6-BD43-0A2F127D6A74' CODE_SIGNING_ALLOWED=NO`: `BUILD SUCCEEDED`
- Installed and launched the Release simulator app with the current invalid `pk_test` config; `simctl launch` returned PID `98993`
- No fresh local `Jovie*.ips` crash reports after launch; only the four original Retired TestFlight reports remain
- Final simulator screenshot: `/var/folders/94/18gm8rr177124d51gsv4qj4m0000gn/T/screenshot_optimized_db423cb9-e69b-490e-8e95-7bd6c805605c.jpg`
- Pre-push hook passed: Biome, Tailwind guard, web typecheck, web lint

Linear: JOV-2712


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * App no longer crashes when authentication configuration fails; gracefully falls back with a user-facing error message
  * Sign-in button now properly disables and displays "Sign-in Unavailable" when authentication is unavailable

* **Improvements**
  * Enhanced authentication state handling across different app modes with clearer UI feedback during sign-in flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->