### PR TITLE
fix(ios): preserve mock auth button state

### DIFF
--- a/apps/ios/Jovie/App/JovieApp.swift
+++ b/apps/ios/Jovie/App/JovieApp.swift
@@ -395,6 +395,7 @@ struct JovieApp: App {
           RootView(
             appState: appState,
             isAuthAvailable: isLiveAuthAvailable,
+            isSignInUnavailable: launchAuthErrorMessage != nil,
             liveUserID: nil,
             authErrorMessage: launchAuthErrorMessage,
             onLogout: { await appState.signOut() },
@@ -410,6 +411,7 @@ struct JovieApp: App {
           RootView(
             appState: appState,
             isAuthAvailable: isLiveAuthAvailable,
+            isSignInUnavailable: launchAuthErrorMessage != nil,
             liveUserID: nil,
             authErrorMessage: launchAuthErrorMessage,
             onLogout: { await appState.signOut() },

--- a/apps/ios/Jovie/App/RootView.swift
+++ b/apps/ios/Jovie/App/RootView.swift
@@ -165,6 +165,7 @@ private enum LiveAuthBootstrapper {
 private struct AppContentView: View {
   @Bindable var appState: AppState
   let isAuthAvailable: Bool
+  let isSignInUnavailable: Bool
   let authErrorMessage: String?
   let onLogout: @MainActor () async -> Void
   let onAuthReturn: @MainActor (MobileAuthReturn) -> Void
@@ -178,6 +179,7 @@ private struct AppContentView: View {
       case .signedOut:
         AuthScreen(
           isMock: !isAuthAvailable,
+          isSignInUnavailable: isSignInUnavailable,
           webBaseURL: appState.configuration.webBaseURL,
           errorMessage: authErrorMessage,
           onAuthReturn: onAuthReturn,
@@ -305,6 +307,7 @@ private struct ChatComposerPreview: View {
 struct RootView: View {
   @Bindable var appState: AppState
   let isAuthAvailable: Bool
+  let isSignInUnavailable: Bool
   let liveUserID: String?
   let authErrorMessage: String?
   let onLogout: @MainActor () async -> Void
@@ -316,6 +319,7 @@ struct RootView: View {
       AppContentView(
         appState: appState,
         isAuthAvailable: isAuthAvailable,
+        isSignInUnavailable: isSignInUnavailable,
         authErrorMessage: authErrorMessage,
         onLogout: onLogout,
         onAuthReturn: onAuthReturn,
@@ -460,6 +464,7 @@ struct UITestingAuthCallbackRoot: View {
     RootView(
       appState: appState,
       isAuthAvailable: false,
+      isSignInUnavailable: false,
       liveUserID: liveUserID,
       authErrorMessage: authErrorMessage,
       onLogout: { await appState.signOut() },
@@ -565,6 +570,7 @@ struct LiveRootContainer: View {
     RootView(
       appState: appState,
       isAuthAvailable: true,
+      isSignInUnavailable: false,
       liveUserID: clerk.user?.id,
       authErrorMessage: authErrorMessage,
       onLogout: {

--- a/apps/ios/Jovie/Features/Auth/AuthScreen.swift
+++ b/apps/ios/Jovie/Features/Auth/AuthScreen.swift
@@ -12,6 +12,7 @@ private let authLogger = Logger(
 
 struct AuthScreen: View {
   let isMock: Bool
+  let isSignInUnavailable: Bool
   let webBaseURL: URL
   let errorMessage: String?
   let onAuthReturn: @MainActor (MobileAuthReturn) -> Void
@@ -33,7 +34,7 @@ struct AuthScreen: View {
 
           BrowserAuthActions(
             isOpening: didRequestBrowserAuth,
-            isDisabled: isMock,
+            isDisabled: isSignInUnavailable,
             errorMessage: errorMessage,
             action: startBrowserAuth
           )


### PR DESCRIPTION
## Summary
- keep mock UI-test auth screens visually on the normal `Continue in Browser` state
- reserve the disabled `Sign-in Unavailable` state for invalid live launch configuration only
- keeps the JOV-2712 crash hardening intact while restoring the iOS CI UI-test contract

## Verification
- XcodeBuildMCP `test_sim -only-testing:JovieUITests/JovieUITests/testSignedOutLaunchShowsAuthScreen -only-testing:JovieUITests/JovieUITests/testFullScreenSettingsLogsOutToSignedOut -only-testing:JovieUITests/JovieUITests/testAuthCallbackDeepLinkCompletesHarness -only-testing:JovieUITests/JovieUITests/testAuthCallbackProviderErrorShowsAuthError` → 4 passed, 0 failed
- XcodeBuildMCP `test_sim -only-testing:JovieTests/MobileAuthFinalizationTests` → 7 passed, 0 failed
- `git diff --check origin/main...HEAD`
- pre-push hook: `biome check .`, `@jovie/web` proxy guard, tailwind guard, typecheck, lint

Linear: JOV-2712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sign-in availability state handling to properly reflect build configuration throughout the authentication flow, ensuring users see accurate status on the sign-in screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->