### PR TITLE
fix(marketing): move artist notifications hero to System B primitives

### DIFF
--- a/apps/web/components/marketing/artist-notifications/ArtistNotificationsHero.tsx
+++ b/apps/web/components/marketing/artist-notifications/ArtistNotificationsHero.tsx
@@ -12,15 +12,11 @@ const CARD_POSITIONS: Record<
   ArtistNotificationsLandingCopy['hero']['floatingCards'][number]['kind'],
   string
 > = {
-  capture:
-    'lg:absolute lg:left-[2%] lg:top-[2%] lg:w-[17rem] lg:-rotate-[2deg]',
-  subscribe:
-    'lg:absolute lg:right-[4%] lg:top-[18%] lg:w-[16rem] lg:rotate-[1.5deg]',
-  email: 'lg:absolute lg:left-[8%] lg:top-[40%] lg:w-[18rem] lg:rotate-[1deg]',
-  click:
-    'lg:absolute lg:right-[6%] lg:top-[58%] lg:w-[16rem] lg:-rotate-[1.5deg]',
-  outcome:
-    'lg:absolute lg:left-[14%] lg:bottom-[2%] lg:w-[17rem] lg:rotate-[2deg]',
+  capture: 'system-b-artist-notifications-card-capture',
+  subscribe: 'system-b-artist-notifications-card-subscribe',
+  email: 'system-b-artist-notifications-card-email',
+  click: 'system-b-artist-notifications-card-click',
+  outcome: 'system-b-artist-notifications-card-outcome',
 };
 
 export function ArtistNotificationsHero({
@@ -30,16 +26,19 @@ export function ArtistNotificationsHero({
     <section className='relative overflow-hidden pb-20 pt-14 sm:pb-24 sm:pt-20 lg:pb-28 lg:pt-24'>
       <div
         aria-hidden='true'
-        className='absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(255,255,255,0.14),transparent_42%),radial-gradient(circle_at_80%_18%,rgba(86,182,255,0.16),transparent_24%),linear-gradient(180deg,rgba(255,255,255,0.02),transparent_48%)]'
+        className='system-b-artist-notifications-hero-backdrop'
       />
       <MarketingContainer width='landing' className='relative'>
-        <div className='grid min-w-0 gap-12 lg:grid-cols-[minmax(0,0.92fr)_minmax(0,1.08fr)] lg:items-center'>
-          <div className='w-full min-w-0 max-w-[38rem]'>
-            <h1 className='max-w-full text-[clamp(3rem,15vw,3.6rem)] font-semibold leading-[0.92] tracking-[-0.045em] text-primary-token sm:max-w-[10ch] sm:text-[clamp(3.6rem,8.4vw,7.2rem)] sm:leading-[0.88] sm:tracking-[-0.085em]'>
+        <div className='system-b-artist-notifications-hero-grid'>
+          <div className='system-b-artist-notifications-hero-copy'>
+            <h1 className='system-b-artist-notifications-hero-title'>
               {hero.headlineLines?.length
                 ? hero.headlineLines.map(line =>
                     line ? (
-                      <span key={line} className='block max-w-full break-words'>
+                      <span
+                        key={line}
+                        className='system-b-artist-notifications-hero-title-line'
+                      >
                         {line}
                       </span>
                     ) : null
@@ -47,7 +46,7 @@ export function ArtistNotificationsHero({
                 : hero.headline}
             </h1>
             {hero.subhead ? (
-              <p className='mt-6 max-w-[36rem] text-[clamp(1.05rem,1.9vw,1.5rem)] leading-[1.3] tracking-[-0.03em] text-secondary-token'>
+              <p className='system-b-artist-notifications-hero-subhead'>
                 {hero.subhead}
               </p>
             ) : null}
@@ -56,18 +55,18 @@ export function ArtistNotificationsHero({
               <Button
                 asChild
                 variant='whitePill'
-                className='h-11 px-5 sm:text-[14px]'
+                className='system-b-artist-notifications-hero-cta'
               >
                 <Link href={hero.primaryCtaHref}>{hero.primaryCtaLabel}</Link>
               </Button>
             </div>
           </div>
 
-          <div className='relative flex min-w-0 flex-col gap-3 lg:block lg:h-[32rem]'>
+          <div className='system-b-artist-notifications-card-stage'>
             {hero.floatingCards.map(card => (
               <div
                 key={card.id}
-                className={`${CARD_POSITIONS[card.kind]} w-full min-w-0`}
+                className={`system-b-artist-notifications-card-position ${CARD_POSITIONS[card.kind]}`}
               >
                 <ArtistNotificationFloatingCardView card={card} />
               </div>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1457,6 +1457,149 @@
   box-shadow: none;
 }
 
+:where(.system-b-artist-notifications-hero-backdrop) {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(
+      circle at top left,
+      color-mix(in oklab, var(--color-text-primary-token) 14%, transparent),
+      transparent 42%
+    ),
+    radial-gradient(
+      circle at 80% 18%,
+      color-mix(in oklab, var(--geist-blue-solid) 16%, transparent),
+      transparent 24%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-text-primary-token) 2%, transparent),
+      transparent 48%
+    );
+}
+
+:where(.system-b-artist-notifications-hero-grid) {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-12);
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-artist-notifications-hero-grid) {
+    grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+    align-items: center;
+  }
+}
+
+:where(.system-b-artist-notifications-hero-copy) {
+  width: 100%;
+  min-width: 0;
+  max-width: 38rem;
+}
+
+:where(.system-b-artist-notifications-hero-title) {
+  max-width: 100%;
+  color: var(--color-text-primary-token);
+  font-size: clamp(3rem, 15vw, 3.6rem);
+  font-weight: var(--font-weight-semibold);
+  line-height: 0.92;
+  letter-spacing: -0.045em;
+}
+
+@media (min-width: 640px) {
+  :where(.system-b-artist-notifications-hero-title) {
+    max-width: 10ch;
+    font-size: clamp(3.6rem, 8.4vw, 7.2rem);
+    line-height: 0.88;
+    letter-spacing: -0.085em;
+  }
+}
+
+:where(.system-b-artist-notifications-hero-title-line) {
+  display: block;
+  max-width: 100%;
+  overflow-wrap: break-word;
+}
+
+:where(.system-b-artist-notifications-hero-subhead) {
+  max-width: 36rem;
+  margin-top: var(--space-6);
+  color: var(--color-text-secondary-token);
+  font-size: clamp(1.05rem, 1.9vw, 1.5rem);
+  line-height: 1.3;
+  letter-spacing: -0.03em;
+}
+
+:where(.system-b-artist-notifications-hero-cta) {
+  height: calc(var(--space-10) + var(--space-1));
+  padding-inline: var(--space-5);
+}
+
+@media (min-width: 640px) {
+  :where(.system-b-artist-notifications-hero-cta) {
+    font-size: 14px;
+  }
+}
+
+:where(.system-b-artist-notifications-card-stage) {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-artist-notifications-card-stage) {
+    display: block;
+    height: calc(var(--space-16) * 8);
+  }
+
+  :where(.system-b-artist-notifications-card-position) {
+    position: absolute;
+  }
+
+  :where(.system-b-artist-notifications-card-capture) {
+    top: 2%;
+    left: 2%;
+    width: 17rem;
+    transform: rotate(-2deg);
+  }
+
+  :where(.system-b-artist-notifications-card-subscribe) {
+    top: 18%;
+    right: 4%;
+    width: 16rem;
+    transform: rotate(1.5deg);
+  }
+
+  :where(.system-b-artist-notifications-card-email) {
+    top: 40%;
+    left: 8%;
+    width: 18rem;
+    transform: rotate(1deg);
+  }
+
+  :where(.system-b-artist-notifications-card-click) {
+    top: 58%;
+    right: 6%;
+    width: 16rem;
+    transform: rotate(-1.5deg);
+  }
+
+  :where(.system-b-artist-notifications-card-outcome) {
+    bottom: 2%;
+    left: 14%;
+    width: 17rem;
+    transform: rotate(2deg);
+  }
+}
+
+:where(.system-b-artist-notifications-card-position) {
+  width: 100%;
+  min-width: 0;
+}
+
 /* ============================================
    GEIST ACCENT PALETTE — feature-surface accents
    ============================================

--- a/apps/web/tests/unit/marketing/artist-notifications-hero-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/artist-notifications-hero-system-b-style-guard.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sourcePath =
+  'components/marketing/artist-notifications/ArtistNotificationsHero.tsx';
+
+const gradientPattern = ['linear', 'gradient|radial', 'gradient'].join('-');
+
+const forbiddenVisualPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  new RegExp(gradientPattern),
+  /\b(?:bg|border|text|ring|shadow)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|min-w|tracking|leading|px|py|pt|pb|top|left|inset|translate)-\[/,
+] as const;
+
+describe('artist notifications hero System B source contract', () => {
+  it('keeps fixed hero visuals on named System B primitives', () => {
+    const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+
+    for (const pattern of forbiddenVisualPatterns) {
+      expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Moves the artist notifications hero backdrop, responsive grid, headline, CTA sizing, and floating card placement onto named System B CSS primitives.
- Adds a focused source guard so the hero does not regain raw gradients, rgba values, or arbitrary visual utilities.

## Verification
- `./scripts/setup.sh`
- `pnpm biome check --write apps/web/components/marketing/artist-notifications/ArtistNotificationsHero.tsx apps/web/tests/unit/marketing/artist-notifications-hero-system-b-style-guard.test.ts apps/web/styles/design-system.css`
- raw source-token scan for the hero and guard
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/artist-notifications-page.test.tsx tests/unit/marketing/artist-notifications-hero-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write apps/web`
- Playwright render check at `http://localhost:3102/artist-notifications` for desktop 1440px and mobile 390px; no page-level horizontal scroll.
- pre-commit hook passed staged Biome, ESLint, a11y lint, and web typecheck.
- pre-push hook passed full Biome, proxy guard, Tailwind guard, web typecheck, and web lint.

## Layout Shift Notes
Visual states checked: default headline lines, hero CTA, five floating cards, desktop positioned-card stage, and mobile stacked-card stage. The PR preserves the existing layout dimensions while moving visual recipes into CSS primitives.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the artist notifications marketing section styling for improved code organization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->