### PR TITLE
test(marketing): stabilize artist notifications source guard

### DIFF
--- a/apps/web/tests/unit/marketing/artist-notifications-hero-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/artist-notifications-hero-system-b-style-guard.test.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const sourcePath =
   'components/marketing/artist-notifications/ArtistNotificationsHero.tsx';
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
 const gradientPattern = ['linear', 'gradient|radial', 'gradient'].join('-');
 
@@ -18,7 +20,7 @@ const forbiddenVisualPatterns = [
 
 describe('artist notifications hero System B source contract', () => {
   it('keeps fixed hero visuals on named System B primitives', () => {
-    const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+    const source = readFileSync(resolve(appRoot, sourcePath), 'utf8');
 
     for (const pattern of forbiddenVisualPatterns) {
       expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);


### PR DESCRIPTION
## Summary
- Anchors the artist notifications System B source guard to the test file directory instead of process.cwd().
- Keeps the guard deterministic when Vitest is run from different working directories.

Linear: JOV-2548

## Verification
- `./scripts/setup.sh`
- `pnpm biome check --write apps/web/tests/unit/marketing/artist-notifications-hero-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/marketing/artist-notifications-hero-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-commit hook: passed
- pre-push hook: passed (`biome check .`, proxy guard, Tailwind guard, web typecheck, web lint)

## Agent evidence
- gstack.ship: `/ship` gate used for this shipping lane.
- gstack.review: narrow review of the CodeRabbit-reported determinism issue; fix is constrained to one guard test.
- gstack.qa.exhaustive: focused source inspection plus guard test/typecheck/pre-push coverage for this one-file test-only PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for marketing component validation to ensure more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->