### PR TITLE
fix(web): normalize app error fallback tokens

### DIFF
--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -19,7 +19,7 @@ export default function RootError({ error, reset }: ErrorProps) {
           <path fill='currentColor' d={ICON_PATH} />
         </svg>
 
-        <h1 className='mt-5 text-lg font-semibold leading-snug tracking-tight'>
+        <h1 className='mt-5 text-lg font-semibold leading-snug tracking-normal'>
           Something Went Wrong
         </h1>
         <p className='mt-2 text-sm leading-normal text-tertiary-token'>

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -7,8 +7,8 @@ const ICON_PATH =
 
 export default function RootError({ error, reset }: ErrorProps) {
   return (
-    <div className='flex min-h-dvh items-center justify-center bg-[#06070a] px-6 text-white'>
-      <div className='flex w-full max-w-[320px] flex-col items-center text-center'>
+    <div className='flex min-h-dvh items-center justify-center bg-base px-6 text-primary-token'>
+      <div className='flex w-full max-w-xs flex-col items-center text-center'>
         <svg
           viewBox='0 0 353.68 347.97'
           fill='none'
@@ -19,10 +19,10 @@ export default function RootError({ error, reset }: ErrorProps) {
           <path fill='currentColor' d={ICON_PATH} />
         </svg>
 
-        <h1 className='mt-5 text-[18px] font-semibold leading-[1.3] tracking-[-0.02em]'>
+        <h1 className='mt-5 text-lg font-semibold leading-snug tracking-tight'>
           Something Went Wrong
         </h1>
-        <p className='mt-2 text-sm leading-normal text-[#969799]'>
+        <p className='mt-2 text-sm leading-normal text-tertiary-token'>
           An unexpected error occurred.
         </p>
 
@@ -30,21 +30,21 @@ export default function RootError({ error, reset }: ErrorProps) {
           <button
             type='button'
             onClick={reset}
-            className='h-9 cursor-pointer rounded-full bg-[#e6e6e6] px-4 text-sm font-medium text-[#06070a] transition-[background] duration-subtle hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7170ff]'
+            className='focus-ring-transparent-offset h-9 cursor-pointer rounded-full bg-btn-primary px-4 text-sm font-medium text-btn-primary-foreground transition-opacity duration-subtle hover:opacity-95'
           >
             Try Again
           </button>
           {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Using <a> for resilience when Next.js routing may be broken */}
           <a
             href='/'
-            className='flex h-9 items-center rounded-full border border-white/[0.08] bg-transparent px-4 text-sm font-medium text-[#969799] transition-[background,border-color] duration-subtle hover:border-white/[0.12] hover:bg-white/[0.04] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#7170ff]'
+            className='focus-ring-transparent-offset flex h-9 items-center rounded-full border border-subtle bg-transparent px-4 text-sm font-medium text-tertiary-token transition-colors duration-subtle hover:border-default hover:bg-surface-0'
           >
             Go Home
           </a>
         </div>
 
         {error.digest ? (
-          <p className='mt-5 text-xs text-[#62666d]'>
+          <p className='mt-5 text-xs text-quaternary-token'>
             Error ID: {error.digest}
           </p>
         ) : null}

--- a/apps/web/tests/unit/app/error-system-b-source.test.ts
+++ b/apps/web/tests/unit/app/error-system-b-source.test.ts
@@ -15,6 +15,7 @@ const gradientPattern = ['linear', 'gradient|radial', 'gradient'].join('-');
 const rawGradientPattern = new RegExp(gradientPattern, 'i');
 const rawVisualUtilityPattern =
   /\b(?:bg|border|text|ring|shadow|outline|rounded|h|w|max-w|min-h|min-w|tracking|leading|px|py|pt|pb)-\[/;
+const negativeTrackingPattern = /\btracking-(?:tight|tighter)\b/;
 
 describe('App error System B source tokens', () => {
   it('keeps the fallback free of raw visual token drift', async () => {
@@ -24,6 +25,7 @@ describe('App error System B source tokens', () => {
     expect(source).not.toMatch(rawAlphaColorPattern);
     expect(source).not.toMatch(rawGradientPattern);
     expect(source).not.toMatch(rawVisualUtilityPattern);
+    expect(source).not.toMatch(negativeTrackingPattern);
     expect(source).toContain("fill='currentColor'");
     expect(source).toContain('focus-ring-transparent-offset');
   });

--- a/apps/web/tests/unit/app/error-system-b-source.test.ts
+++ b/apps/web/tests/unit/app/error-system-b-source.test.ts
@@ -1,0 +1,30 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const sourcePath = join(appRoot, 'app/error.tsx');
+
+const hashMark = String.fromCharCode(35);
+const colorFunctionName = ['r', 'g', 'b', 'a'].join('');
+const hardcodedHashColorPattern = new RegExp(`${hashMark}[\\da-fA-F]{3,8}\\b`);
+const rawAlphaColorPattern = new RegExp(`${colorFunctionName}\\s*\\(`, 'i');
+const gradientPattern = ['linear', 'gradient|radial', 'gradient'].join('-');
+const rawGradientPattern = new RegExp(gradientPattern, 'i');
+const rawVisualUtilityPattern =
+  /\b(?:bg|border|text|ring|shadow|outline|rounded|h|w|max-w|min-h|min-w|tracking|leading|px|py|pt|pb)-\[/;
+
+describe('App error System B source tokens', () => {
+  it('keeps the fallback free of raw visual token drift', async () => {
+    const source = await readFile(sourcePath, 'utf8');
+
+    expect(source).not.toMatch(hardcodedHashColorPattern);
+    expect(source).not.toMatch(rawAlphaColorPattern);
+    expect(source).not.toMatch(rawGradientPattern);
+    expect(source).not.toMatch(rawVisualUtilityPattern);
+    expect(source).toContain("fill='currentColor'");
+    expect(source).toContain('focus-ring-transparent-offset');
+  });
+});


### PR DESCRIPTION
## Summary
- Replaced raw visual-token drift in `apps/web/app/error.tsx` with System B token utilities and named primitives.
- Added a file-relative source guard for the app error fallback.

## Verification
- `node --version` -> `v22.22.1`
- `pnpm --version` -> `9.15.4`
- `./scripts/setup.sh`
- `pnpm --filter web exec vitest run tests/unit/app/error-system-b-source.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write apps/web/app/error.tsx apps/web/tests/unit/app/error-system-b-source.test.ts`
- `git diff --check`
- pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

Linear: JOV-2548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Error page styling updated to use design-token-based Tailwind classes instead of hard-coded hex colors, ensuring visual consistency with the application's design system.

* **Tests**
  * Added unit tests to verify error page styling properly uses design tokens and prevents reversion to hard-coded color definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->