### PR TITLE
fix(marketing): normalize download page System B primitives

### DIFF
--- a/apps/web/app/(marketing)/download/page.tsx
+++ b/apps/web/app/(marketing)/download/page.tsx
@@ -152,12 +152,12 @@ export default async function DownloadPage() {
       <script type='application/ld+json'>{FAQ_SCHEMA}</script>
       <script type='application/ld+json'>{BREADCRUMB_SCHEMA}</script>
 
-      <main className='overflow-x-clip bg-black text-white'>
+      <main className='system-b-download-page'>
         <section
           className='homepage-hero-stage relative'
           aria-labelledby='download-hero-heading'
         >
-          <div className='homepage-hero-shell relative flex min-h-[100svh] flex-col overflow-hidden pt-[calc(var(--linear-header-height)+clamp(4.5rem,8vw,7rem))]'>
+          <div className='homepage-hero-shell system-b-download-hero-shell'>
             <div
               aria-hidden='true'
               className='homepage-hero-shell__layer homepage-hero-shell__beam'
@@ -168,20 +168,20 @@ export default async function DownloadPage() {
 
             <MarketingContainer
               width='page'
-              className='relative z-[3] flex flex-1 flex-col'
+              className='system-b-download-hero-container'
             >
-              <div className='grid min-h-0 flex-1 items-center gap-12 pb-[clamp(3.5rem,7vw,6rem)] lg:grid-cols-[minmax(0,0.78fr)_minmax(0,1fr)] lg:gap-16'>
-                <div className='max-w-[45rem]'>
+              <div className='system-b-download-hero-grid'>
+                <div className='system-b-download-hero-copy'>
                   <p className='homepage-section-eyebrow'>
                     Mac app available now / iPhone alpha in TestFlight
                   </p>
                   <h1
                     id='download-hero-heading'
-                    className='mt-5 text-balance text-[clamp(3.3rem,7vw,7.5rem)] font-[680] leading-[0.92] tracking-[-0.055em] text-white'
+                    className='system-b-download-hero-title'
                   >
                     Jovie, installed where you work.
                   </h1>
-                  <p className='mt-6 max-w-[40rem] text-balance text-[clamp(1.08rem,1.55vw,1.35rem)] leading-[1.45] tracking-[-0.015em] text-white/66'>
+                  <p className='system-b-download-hero-lead'>
                     Run the native Mac workspace today. Keep the iPhone build
                     internal while we harden auth, Profile QR, and TestFlight.
                   </p>
@@ -189,7 +189,7 @@ export default async function DownloadPage() {
                     <Button
                       asChild
                       variant='whitePill'
-                      className='h-11 gap-2 px-6 text-[15px] font-semibold'
+                      className='system-b-download-hero-button'
                     >
                       <a
                         href={DOWNLOAD_URL}
@@ -205,20 +205,20 @@ export default async function DownloadPage() {
                     </Button>
                     <Link
                       href='#ios-alpha'
-                      className='inline-flex h-11 items-center rounded-full px-4 text-[15px] font-semibold text-white/72 transition-colors duration-subtle hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/35 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
+                      className='system-b-download-secondary-link'
                     >
                       iPhone status
                     </Link>
                   </div>
-                  <div className='mt-6 flex flex-wrap gap-x-5 gap-y-2 text-[13px] leading-5 text-white/48'>
+                  <div className='system-b-download-meta'>
                     <span>Developer ID signed</span>
                     <span>Apple notarized</span>
                     {meta ? <span>{meta}</span> : null}
                   </div>
                 </div>
 
-                <div className='relative min-h-[24rem] lg:min-h-[36rem]'>
-                  <div className='absolute inset-x-0 bottom-0 top-[8%] overflow-hidden rounded-[10px] border border-white/[0.08] bg-white/[0.035] shadow-[0_44px_140px_rgba(0,0,0,0.52)]'>
+                <div className='system-b-download-media-stage'>
+                  <div className='system-b-download-desktop-frame'>
                     <Image
                       src={DESKTOP_IMAGE.publicUrl}
                       alt='Jovie native desktop workspace showing releases and release planning'
@@ -227,10 +227,10 @@ export default async function DownloadPage() {
                       priority
                       sizes='(min-width: 1024px) 54vw, 92vw'
                       quality={85}
-                      className='h-full w-full object-cover object-left-top opacity-92'
+                      className='system-b-download-desktop-image'
                     />
                   </div>
-                  <div className='absolute right-0 top-0 w-[min(34vw,13rem)] overflow-hidden rounded-[28px] border border-white/[0.1] bg-black shadow-[0_28px_90px_rgba(0,0,0,0.65)] max-sm:hidden'>
+                  <div className='system-b-download-phone-frame max-sm:hidden'>
                     <Image
                       src={PROFILE_IMAGE.publicUrl}
                       alt='Jovie iPhone alpha profile QR and public profile surface'
@@ -248,9 +248,9 @@ export default async function DownloadPage() {
           </div>
         </section>
 
-        <section className='border-y border-white/[0.08] bg-black'>
+        <section className='system-b-download-platform-section'>
           <MarketingContainer width='page'>
-            <div className='grid divide-y divide-white/[0.08] lg:grid-cols-2 lg:divide-x lg:divide-y-0'>
+            <div className='system-b-download-platform-grid'>
               {PLATFORM_ROWS.map(platform => {
                 const Icon = platform.icon;
                 const isMac = platform.label === 'Mac';
@@ -258,24 +258,22 @@ export default async function DownloadPage() {
                   <div
                     key={platform.label}
                     id={isMac ? undefined : 'ios-alpha'}
-                    className='py-[clamp(2.5rem,5vw,4.5rem)] lg:px-[clamp(2rem,4vw,4rem)] first:lg:pl-0 last:lg:pr-0'
+                    className='system-b-download-platform-card'
                   >
-                    <div className='flex items-center gap-3 text-white/46'>
+                    <div className='system-b-download-platform-kicker'>
                       <Icon className='size-4' aria-hidden='true' />
-                      <span className='text-[12px] font-semibold uppercase tracking-[0.18em]'>
-                        {platform.label}
-                      </span>
+                      <span>{platform.label}</span>
                     </div>
-                    <h2 className='mt-5 max-w-[16ch] text-balance text-[clamp(2rem,3.2vw,3.2rem)] font-[650] leading-[1.02] tracking-[-0.04em] text-white'>
+                    <h2 className='system-b-download-platform-title'>
                       {platform.title}
                     </h2>
-                    <p className='mt-4 max-w-[34rem] text-[16px] leading-7 text-white/58'>
+                    <p className='system-b-download-platform-body'>
                       {platform.body}
                     </p>
                     {isMac ? (
                       <a
                         href={platform.href}
-                        className='mt-7 inline-flex h-10 items-center gap-2 rounded-full bg-white px-5 text-[14px] font-semibold text-black transition-opacity duration-subtle hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40 focus-visible:ring-offset-2 focus-visible:ring-offset-black'
+                        className='system-b-download-platform-action'
                         data-analytics-event='download_mac_dmg'
                         data-analytics-source='download_page_platform'
                       >
@@ -286,7 +284,7 @@ export default async function DownloadPage() {
                         {platform.action}
                       </a>
                     ) : (
-                      <div className='mt-7 inline-flex h-10 items-center rounded-full border border-white/[0.14] px-5 text-[14px] font-semibold text-white/48'>
+                      <div className='system-b-download-platform-inactive'>
                         {platform.action}
                       </div>
                     )}
@@ -297,83 +295,75 @@ export default async function DownloadPage() {
           </MarketingContainer>
         </section>
 
-        <MarketingContainer width='page' className='py-[clamp(5rem,9vw,8rem)]'>
-          <div className='grid gap-14 lg:grid-cols-[0.72fr_1fr] lg:gap-20'>
+        <MarketingContainer width='page' className='system-b-download-workflow'>
+          <div className='system-b-download-workflow-grid'>
             <div>
               <p className='homepage-section-eyebrow'>Release workflow</p>
-              <h2 className='mt-4 max-w-[13ch] text-balance text-[clamp(2.5rem,4.6vw,4.8rem)] font-[650] leading-[0.98] tracking-[-0.05em] text-white'>
+              <h2 className='system-b-download-section-title'>
                 Everything in Jovie, closer.
               </h2>
             </div>
             <div className='grid gap-x-10 gap-y-10 sm:grid-cols-2'>
               {FEATURE_ROWS.map(row => (
                 <section key={row.title}>
-                  <div className='mb-4 flex size-8 items-center justify-center rounded-full bg-white/[0.08] text-white/82'>
+                  <div className='system-b-download-feature-icon'>
                     <Check className='size-4' aria-hidden='true' />
                   </div>
-                  <h3 className='text-[1.35rem] font-semibold tracking-[-0.03em] text-white'>
+                  <h3 className='system-b-download-feature-title'>
                     {row.title}
                   </h3>
-                  <p className='mt-3 text-[15px] leading-7 text-white/55'>
-                    {row.body}
-                  </p>
+                  <p className='system-b-download-feature-body'>{row.body}</p>
                 </section>
               ))}
             </div>
           </div>
         </MarketingContainer>
 
-        <section className='border-y border-white/[0.08] bg-[#050506]'>
+        <section className='system-b-download-details-section'>
           <MarketingContainer
             width='page'
-            className='py-[clamp(4rem,7vw,6rem)]'
+            className='system-b-download-details-container'
           >
-            <div className='grid gap-12 lg:grid-cols-[0.78fr_1fr] lg:items-start'>
+            <div className='system-b-download-details-grid'>
               <div>
                 <p className='homepage-section-eyebrow'>Install details</p>
-                <h2 className='mt-4 max-w-[13ch] text-balance text-[clamp(2.25rem,3.8vw,4rem)] font-[650] leading-[1] tracking-[-0.045em] text-white'>
+                <h2 className='system-b-download-details-title'>
                   Built to stay out of the way.
                 </h2>
               </div>
               <div className='grid gap-8 sm:grid-cols-3'>
                 <div>
-                  <ShieldCheck className='mb-4 size-5 text-white/72' />
-                  <h3 className='text-[17px] font-semibold text-white'>
-                    Signed
-                  </h3>
-                  <p className='mt-2 text-sm leading-6 text-white/52'>
+                  <ShieldCheck className='system-b-download-detail-icon' />
+                  <h3 className='system-b-download-detail-title'>Signed</h3>
+                  <p className='system-b-download-detail-body'>
                     Developer ID signed and notarized before release.
                   </p>
                 </div>
                 <div>
-                  <Sparkles className='mb-4 size-5 text-white/72' />
-                  <h3 className='text-[17px] font-semibold text-white'>
-                    Updating
-                  </h3>
-                  <p className='mt-2 text-sm leading-6 text-white/52'>
+                  <Sparkles className='system-b-download-detail-icon' />
+                  <h3 className='system-b-download-detail-title'>Updating</h3>
+                  <p className='system-b-download-detail-body'>
                     New builds install automatically after you quit.
                   </p>
                 </div>
                 <div>
-                  <QrCode className='mb-4 size-5 text-white/72' />
-                  <h3 className='text-[17px] font-semibold text-white'>
-                    Connected
-                  </h3>
-                  <p className='mt-2 text-sm leading-6 text-white/52'>
+                  <QrCode className='system-b-download-detail-icon' />
+                  <h3 className='system-b-download-detail-title'>Connected</h3>
+                  <p className='system-b-download-detail-body'>
                     Same account, profile, QR, and workspace data.
                   </p>
                 </div>
               </div>
             </div>
 
-            <dl className='mt-14 grid border-t border-white/[0.08] text-[15px]'>
+            <dl className='system-b-download-requirements'>
               {REQUIREMENTS.map(row => (
                 <div
                   key={row.label}
-                  className='grid gap-2 border-b border-white/[0.08] py-4 sm:grid-cols-[minmax(9rem,0.35fr)_1fr]'
+                  className='system-b-download-requirement-row'
                 >
-                  <dt className='text-white/42'>{row.label}</dt>
-                  <dd className='text-white/82'>{row.value}</dd>
+                  <dt>{row.label}</dt>
+                  <dd>{row.value}</dd>
                 </div>
               ))}
             </dl>
@@ -383,8 +373,8 @@ export default async function DownloadPage() {
         <FaqSection
           items={FAQ_ITEMS}
           heading='Questions'
-          headingClassName='homepage-story-heading text-white'
-          className='mx-auto w-full max-w-[760px] px-[var(--homepage-page-gutter)] py-[var(--homepage-section-space)]'
+          headingClassName='system-b-download-faq-heading'
+          className='system-b-download-faq'
           analyticsEventName='download_faq_opened'
           analyticsProperties={{ source: 'download' }}
         />
@@ -399,27 +389,27 @@ export default async function DownloadPage() {
         />
 
         <MarketingContainer width='page' className='py-8'>
-          <p className='text-[12px] leading-5 text-white/42'>
+          <p className='system-b-download-legal'>
             Releases are hosted on{' '}
             <a
               href={DESKTOP_RELEASES_HTML_URL}
               target='_blank'
               rel='noopener noreferrer'
-              className='underline decoration-white/30 underline-offset-4 transition-colors hover:text-white/70'
+              className='system-b-download-legal-link'
             >
               GitHub
             </a>
             . By downloading the app you agree to the {APP_NAME}{' '}
             <Link
               href={APP_ROUTES.LEGAL_TERMS}
-              className='underline decoration-white/30 underline-offset-4 transition-colors hover:text-white/70'
+              className='system-b-download-legal-link'
             >
               Terms of Service
             </Link>{' '}
             and{' '}
             <Link
               href={APP_ROUTES.LEGAL_PRIVACY}
-              className='underline decoration-white/30 underline-offset-4 transition-colors hover:text-white/70'
+              className='system-b-download-legal-link'
             >
               Privacy Policy
             </Link>

--- a/apps/web/components/organisms/HeaderNav.css
+++ b/apps/web/components/organisms/HeaderNav.css
@@ -135,30 +135,43 @@
 
 .marketing-glass-header__cta {
   display: inline-flex;
-  min-height: 2rem;
+  min-height: var(--space-8);
   align-items: center;
   justify-content: center;
-  padding-inline: 0.94rem;
-  border: 1px solid rgba(255, 255, 255, 0.92);
-  border-radius: 999px;
-  background: #ffffff;
-  color: #050506;
+  padding-inline: var(--space-4);
+  border: 1px solid
+    color-mix(in oklab, var(--color-text-primary-token) 16%, transparent);
+  border-radius: var(--system-b-radius-pill);
+  background: color-mix(
+    in oklab,
+    var(--color-text-primary-token) 6%,
+    transparent
+  );
+  color: var(--color-text-primary-token);
   font-family: var(--marketing-font-body);
-  font-size: 0.79rem;
-  font-weight: 600;
+  font-size: var(--text-app);
+  font-weight: var(--font-weight-semibold);
   letter-spacing: 0;
   line-height: 1;
   text-decoration: none;
-  box-shadow: 0 8px 24px rgba(255, 255, 255, 0.1);
+  box-shadow: none;
   transition:
-    background-color 140ms ease,
-    border-color 140ms ease;
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    border-color var(--system-b-duration-fast) var(--system-b-ease);
 }
 
 .marketing-glass-header__cta:hover,
 .marketing-glass-header__cta:focus-visible {
-  border-color: #ffffff;
-  background: rgba(255, 255, 255, 0.9);
+  border-color: color-mix(
+    in oklab,
+    var(--color-text-primary-token) 24%,
+    transparent
+  );
+  background: color-mix(
+    in oklab,
+    var(--color-text-primary-token) 10%,
+    transparent
+  );
 }
 
 .marketing-glass-header__flyout {

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -73,6 +73,17 @@
   --app-shell-audio-bar-max-height: var(--linear-app-audio-bar-max-height);
   --app-shell-audio-compact-height: var(--linear-app-audio-compact-height);
 
+  /* System B semantic aliases for public app surfaces. Keep page-level recipes
+     on these names instead of route-local Tailwind literals. */
+  --system-b-cinematic-black: #06070a;
+  --system-b-text-primary: var(--color-text-primary-token);
+  --system-b-primary-bg: var(--linear-btn-primary-bg);
+  --system-b-primary-fg: var(--linear-btn-primary-fg);
+  --system-b-header-height: var(--linear-header-height);
+  --system-b-duration-fast: var(--ds-motion-subtle-duration);
+  --system-b-ease: var(--ds-motion-subtle-easing);
+  --system-b-radius-pill: var(--radius-full);
+
   --ds-motion-subtle-duration: 150ms;
   --ds-motion-subtle-easing: cubic-bezier(0.4, 0, 0.2, 1);
   --ds-motion-cinematic-duration: 420ms;
@@ -1598,6 +1609,463 @@
 :where(.system-b-artist-notifications-card-position) {
   width: 100%;
   min-width: 0;
+}
+
+:where(.system-b-download-page) {
+  overflow-x: clip;
+  background: var(--system-b-cinematic-black);
+  color: var(--system-b-text-primary);
+}
+
+:where(.system-b-download-hero-shell) {
+  position: relative;
+  display: flex;
+  min-height: 100svh;
+  flex-direction: column;
+  overflow: hidden;
+  padding-top: calc(var(--system-b-header-height) + clamp(4.5rem, 8vw, 7rem));
+}
+
+:where(.system-b-download-hero-container) {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+:where(.system-b-download-hero-grid) {
+  display: grid;
+  min-height: 0;
+  flex: 1;
+  align-items: center;
+  gap: var(--space-12);
+  padding-bottom: clamp(3.5rem, 7vw, 6rem);
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-download-hero-grid) {
+    grid-template-columns: minmax(0, 0.78fr) minmax(0, 1fr);
+    gap: var(--space-16);
+  }
+}
+
+:where(.system-b-download-hero-copy) {
+  max-width: 45rem;
+}
+
+:where(.system-b-download-hero-title) {
+  margin-top: var(--space-5);
+  color: var(--system-b-text-primary);
+  font-size: var(--text-5xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
+  line-height: 0.92;
+  text-wrap: balance;
+}
+
+@media (min-width: 640px) {
+  :where(.system-b-download-hero-title) {
+    font-size: calc(var(--text-5xl) + var(--space-4));
+  }
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-download-hero-title) {
+    font-size: calc(var(--text-5xl) + var(--space-16));
+  }
+}
+
+:where(.system-b-download-hero-lead) {
+  max-width: 40rem;
+  margin-top: var(--space-6);
+  color: color-mix(in oklab, var(--system-b-text-primary) 66%, transparent);
+  font-size: var(--text-lg);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-relaxed);
+  text-wrap: balance;
+}
+
+:where(.system-b-download-hero-button) {
+  height: calc(var(--space-10) + var(--space-1));
+  gap: var(--space-2);
+  padding-inline: var(--space-6);
+  font-size: var(--text-mid);
+  font-weight: var(--font-weight-semibold);
+}
+
+:where(.system-b-download-secondary-link) {
+  display: inline-flex;
+  height: calc(var(--space-10) + var(--space-1));
+  align-items: center;
+  border-radius: var(--system-b-radius-pill);
+  color: color-mix(in oklab, var(--system-b-text-primary) 72%, transparent);
+  font-size: var(--text-mid);
+  font-weight: var(--font-weight-semibold);
+  padding-inline: var(--space-4);
+  transition: color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-download-secondary-link:hover) {
+  color: var(--system-b-text-primary);
+}
+
+:where(.system-b-download-secondary-link:focus-visible) {
+  box-shadow:
+    0 0 0 2px var(--system-b-cinematic-black),
+    0 0 0 4px color-mix(in oklab, var(--system-b-text-primary) 35%, transparent);
+  outline: none;
+}
+
+:where(.system-b-download-meta) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2) var(--space-5);
+  margin-top: var(--space-6);
+  color: color-mix(in oklab, var(--system-b-text-primary) 48%, transparent);
+  font-size: var(--text-app);
+  line-height: var(--space-5);
+}
+
+:where(.system-b-download-media-stage) {
+  position: relative;
+  min-height: 24rem;
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-download-media-stage) {
+    min-height: 36rem;
+  }
+}
+
+:where(.system-b-download-desktop-frame) {
+  position: absolute;
+  inset-inline: 0;
+  top: 8%;
+  bottom: 0;
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, white 8%, transparent);
+  border-radius: var(--radius-xl);
+  background: color-mix(in oklab, white 3.5%, transparent);
+  box-shadow: 0 44px 140px color-mix(in oklab, black 52%, transparent);
+}
+
+:where(.system-b-download-desktop-image) {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: left top;
+  opacity: 0.92;
+}
+
+:where(.system-b-download-phone-frame) {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: min(34vw, 13rem);
+  overflow: hidden;
+  border: 1px solid color-mix(in oklab, white 10%, transparent);
+  border-radius: var(--radius-3xl);
+  background: var(--system-b-cinematic-black);
+  box-shadow: 0 28px 90px color-mix(in oklab, black 65%, transparent);
+}
+
+:where(.system-b-download-platform-section) {
+  border-block: 1px solid color-mix(in oklab, white 8%, transparent);
+  background: var(--system-b-cinematic-black);
+}
+
+:where(.system-b-download-platform-grid) {
+  display: grid;
+}
+
+@media (max-width: 1023px) {
+  :where(.system-b-download-platform-card + .system-b-download-platform-card) {
+    border-top: 1px solid color-mix(in oklab, white 8%, transparent);
+  }
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-download-platform-grid) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  :where(.system-b-download-platform-card + .system-b-download-platform-card) {
+    border-left: 1px solid color-mix(in oklab, white 8%, transparent);
+  }
+
+  :where(.system-b-download-platform-card:first-child) {
+    padding-left: 0;
+  }
+
+  :where(.system-b-download-platform-card:last-child) {
+    padding-right: 0;
+  }
+}
+
+:where(.system-b-download-platform-card) {
+  padding-block: clamp(2.5rem, 5vw, 4.5rem);
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-download-platform-card) {
+    padding-inline: clamp(2rem, 4vw, 4rem);
+  }
+}
+
+:where(.system-b-download-platform-kicker) {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  color: color-mix(in oklab, var(--system-b-text-primary) 46%, transparent);
+}
+
+:where(.system-b-download-platform-kicker span) {
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+:where(.system-b-download-platform-title) {
+  max-width: 16ch;
+  margin-top: var(--space-5);
+  color: var(--system-b-text-primary);
+  font-size: var(--text-3xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight);
+  text-wrap: balance;
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-download-platform-title) {
+    font-size: var(--text-5xl);
+  }
+}
+
+:where(.system-b-download-platform-body) {
+  max-width: 34rem;
+  margin-top: var(--space-4);
+  color: color-mix(in oklab, var(--system-b-text-primary) 58%, transparent);
+  font-size: var(--text-base);
+  line-height: var(--leading-relaxed);
+}
+
+:where(.system-b-download-platform-action),
+:where(.system-b-download-platform-inactive) {
+  display: inline-flex;
+  height: var(--space-10);
+  align-items: center;
+  border-radius: var(--system-b-radius-pill);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-semibold);
+  margin-top: calc(var(--space-6) + var(--space-1));
+  padding-inline: var(--space-5);
+}
+
+:where(.system-b-download-platform-action) {
+  gap: var(--space-2);
+  background: var(--system-b-primary-bg);
+  color: var(--system-b-primary-fg);
+  transition: opacity var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-download-platform-action:hover) {
+  opacity: 0.9;
+}
+
+:where(.system-b-download-platform-action:focus-visible) {
+  box-shadow:
+    0 0 0 2px var(--system-b-cinematic-black),
+    0 0 0 4px color-mix(in oklab, var(--system-b-text-primary) 40%, transparent);
+  outline: none;
+}
+
+:where(.system-b-download-platform-inactive) {
+  border: 1px solid color-mix(in oklab, white 14%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 48%, transparent);
+}
+
+:where(.system-b-download-workflow) {
+  padding-block: clamp(5rem, 9vw, 8rem);
+}
+
+:where(.system-b-download-workflow-grid) {
+  display: grid;
+  gap: var(--space-12);
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-download-workflow-grid) {
+    grid-template-columns: 0.72fr 1fr;
+    gap: var(--space-20);
+  }
+}
+
+:where(.system-b-download-section-title) {
+  max-width: 13ch;
+  margin-top: var(--space-4);
+  color: var(--system-b-text-primary);
+  font-size: var(--text-4xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight);
+  text-wrap: balance;
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-download-section-title) {
+    font-size: calc(var(--text-5xl) + var(--space-5));
+  }
+}
+
+:where(.system-b-download-feature-icon) {
+  display: flex;
+  width: var(--space-8);
+  height: var(--space-8);
+  align-items: center;
+  justify-content: center;
+  margin-bottom: var(--space-4);
+  border-radius: var(--system-b-radius-pill);
+  background: color-mix(in oklab, white 8%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 82%, transparent);
+}
+
+:where(.system-b-download-feature-title) {
+  color: var(--system-b-text-primary);
+  font-size: var(--text-xl);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+}
+
+:where(.system-b-download-feature-body) {
+  margin-top: var(--space-3);
+  color: color-mix(in oklab, var(--system-b-text-primary) 55%, transparent);
+  font-size: var(--text-mid);
+  line-height: var(--leading-relaxed);
+}
+
+:where(.system-b-download-details-section) {
+  border-block: 1px solid color-mix(in oklab, white 8%, transparent);
+  background: var(--system-b-cinematic-black);
+}
+
+:where(.system-b-download-details-container) {
+  padding-block: clamp(4rem, 7vw, 6rem);
+}
+
+:where(.system-b-download-details-grid) {
+  display: grid;
+  gap: var(--space-12);
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-download-details-grid) {
+    grid-template-columns: 0.78fr 1fr;
+    align-items: start;
+  }
+}
+
+:where(.system-b-download-details-title) {
+  max-width: 13ch;
+  margin-top: var(--space-4);
+  color: var(--system-b-text-primary);
+  font-size: var(--text-4xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight);
+  text-wrap: balance;
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-download-details-title) {
+    font-size: calc(var(--text-5xl) + var(--space-4));
+  }
+}
+
+:where(.system-b-download-detail-icon) {
+  width: var(--space-5);
+  height: var(--space-5);
+  margin-bottom: var(--space-4);
+  color: color-mix(in oklab, var(--system-b-text-primary) 72%, transparent);
+}
+
+:where(.system-b-download-detail-title) {
+  color: var(--system-b-text-primary);
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+}
+
+:where(.system-b-download-detail-body) {
+  margin-top: var(--space-2);
+  color: color-mix(in oklab, var(--system-b-text-primary) 52%, transparent);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+}
+
+:where(.system-b-download-requirements) {
+  display: grid;
+  margin-top: var(--space-12);
+  border-top: 1px solid color-mix(in oklab, white 8%, transparent);
+  font-size: var(--text-mid);
+}
+
+:where(.system-b-download-requirement-row) {
+  display: grid;
+  gap: var(--space-2);
+  border-bottom: 1px solid color-mix(in oklab, white 8%, transparent);
+  padding-block: var(--space-4);
+}
+
+@media (min-width: 640px) {
+  :where(.system-b-download-requirement-row) {
+    grid-template-columns: minmax(9rem, 0.35fr) 1fr;
+  }
+}
+
+:where(.system-b-download-requirement-row dt) {
+  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+}
+
+:where(.system-b-download-requirement-row dd) {
+  color: color-mix(in oklab, var(--system-b-text-primary) 82%, transparent);
+}
+
+:where(.system-b-download-faq) {
+  width: 100%;
+  max-width: 760px;
+  margin-inline: auto;
+  padding: var(--homepage-section-space) var(--homepage-page-gutter);
+}
+
+:where(.system-b-download-faq-heading) {
+  color: var(--system-b-text-primary);
+  font-size: var(--text-4xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight);
+}
+
+:where(.system-b-download-legal) {
+  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  font-size: var(--text-xs);
+  line-height: var(--space-5);
+}
+
+:where(.system-b-download-legal-link) {
+  text-decoration: underline;
+  text-decoration-color: color-mix(
+    in oklab,
+    var(--system-b-text-primary) 30%,
+    transparent
+  );
+  text-underline-offset: var(--space-1);
+  transition: color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-download-legal-link:hover) {
+  color: color-mix(in oklab, var(--system-b-text-primary) 70%, transparent);
 }
 
 /* ============================================

--- a/apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sourcePath = 'app/(marketing)/download/page.tsx';
+
+const forbiddenVisualPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
+] as const;
+
+describe('download page System B source contract', () => {
+  it('keeps download page visuals on named System B primitives', () => {
+    const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+
+    for (const pattern of forbiddenVisualPatterns) {
+      expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Move `/download` route-local visual values onto named `system-b-download-*` primitives.
- Demote the shared marketing-glass header CTA from a filled primary pill to secondary chrome so `/download` has one clear first-viewport primary action.
- Add a focused source guard for `/download` against raw colors, gradients, arbitrary visual utilities, and negative tracking.

## Verification
- `./scripts/setup.sh`
- `pnpm biome check --write apps/web/app/(marketing)/download/page.tsx apps/web/components/organisms/HeaderNav.css apps/web/styles/design-system.css apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/marketing/download-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Pre-commit hook: proxy guard, Biome, ESLint, web typecheck
- Pre-push hook: Biome check, proxy guard, Tailwind guard, web typecheck, web lint

## Screenshot Proof
- `.gstack/design-reports/screenshots/download-system-b-desktop-after-20260603.png`
- `.gstack/design-reports/screenshots/download-system-b-narrow-after-20260603.png`
- `.gstack/design-reports/screenshots/download-system-b-mobile-after-20260603.png`

Runtime proof on mobile: `CLS 0`, no horizontal overflow, one visible `Download for Mac` primary, and the header CTA computed as transparent secondary chrome with no shadow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated download page layout and styling across hero, platform selection, workflow details, and FAQ sections.

* **Style**
  * Modernized header navigation button styling with improved design tokens and dynamic color handling for better visual consistency.

* **Tests**
  * Added automated validation to ensure styling consistency and prevent visual regressions on the download page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->