### PR TITLE
fix(marketing): repair download system b header scope

### DIFF
--- a/apps/web/components/organisms/HeaderNav.css
+++ b/apps/web/components/organisms/HeaderNav.css
@@ -135,43 +135,30 @@
 
 .marketing-glass-header__cta {
   display: inline-flex;
-  min-height: var(--space-8);
+  min-height: 2rem;
   align-items: center;
   justify-content: center;
-  padding-inline: var(--space-4);
-  border: 1px solid
-    color-mix(in oklab, var(--color-text-primary-token) 16%, transparent);
-  border-radius: var(--system-b-radius-pill);
-  background: color-mix(
-    in oklab,
-    var(--color-text-primary-token) 6%,
-    transparent
-  );
-  color: var(--color-text-primary-token);
+  padding-inline: 0.94rem;
+  border: 1px solid rgba(255, 255, 255, 0.92);
+  border-radius: 999px;
+  background: #ffffff;
+  color: #050506;
   font-family: var(--marketing-font-body);
-  font-size: var(--text-app);
-  font-weight: var(--font-weight-semibold);
+  font-size: 0.79rem;
+  font-weight: 600;
   letter-spacing: 0;
   line-height: 1;
   text-decoration: none;
-  box-shadow: none;
+  box-shadow: 0 8px 24px rgba(255, 255, 255, 0.1);
   transition:
-    background-color var(--system-b-duration-fast) var(--system-b-ease),
-    border-color var(--system-b-duration-fast) var(--system-b-ease);
+    background-color 140ms ease,
+    border-color 140ms ease;
 }
 
 .marketing-glass-header__cta:hover,
 .marketing-glass-header__cta:focus-visible {
-  border-color: color-mix(
-    in oklab,
-    var(--color-text-primary-token) 24%,
-    transparent
-  );
-  background: color-mix(
-    in oklab,
-    var(--color-text-primary-token) 10%,
-    transparent
-  );
+  border-color: #ffffff;
+  background: rgba(255, 255, 255, 0.9);
 }
 
 .marketing-glass-header__flyout {

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -1617,13 +1617,49 @@
   color: var(--system-b-text-primary);
 }
 
+body:has(.system-b-download-page) .marketing-glass-header__cta {
+  min-height: var(--space-8);
+  padding-inline: var(--space-4);
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-text-primary) 16%,
+    transparent
+  );
+  background: color-mix(in oklab, var(--system-b-text-primary) 6%, transparent);
+  color: var(--system-b-text-primary);
+  font-size: var(--text-app);
+  font-weight: var(--font-weight-semibold);
+  border-radius: var(--system-b-radius-pill);
+  box-shadow: none;
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    border-color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+body:has(.system-b-download-page) .marketing-glass-header__cta:hover,
+body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-text-primary) 24%,
+    transparent
+  );
+  background: color-mix(
+    in oklab,
+    var(--system-b-text-primary) 10%,
+    transparent
+  );
+}
+
 :where(.system-b-download-hero-shell) {
   position: relative;
   display: flex;
   min-height: 100svh;
   flex-direction: column;
   overflow: hidden;
-  padding-top: calc(var(--system-b-header-height) + clamp(4.5rem, 8vw, 7rem));
+  padding-top: calc(
+    var(--system-b-header-height) +
+    clamp(3.75rem, 6vw, 5.5rem)
+  );
 }
 
 :where(.system-b-download-hero-container) {
@@ -1672,7 +1708,13 @@
 
 @media (min-width: 1024px) {
   :where(.system-b-download-hero-title) {
-    font-size: calc(var(--text-5xl) + var(--space-16));
+    font-size: calc(var(--text-5xl) + var(--space-4));
+  }
+}
+
+@media (min-width: 1280px) {
+  :where(.system-b-download-hero-title) {
+    font-size: calc(var(--text-5xl) + var(--space-12));
   }
 }
 
@@ -1744,10 +1786,16 @@
   top: 8%;
   bottom: 0;
   overflow: hidden;
-  border: 1px solid color-mix(in oklab, white 8%, transparent);
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
   border-radius: var(--radius-xl);
-  background: color-mix(in oklab, white 3.5%, transparent);
-  box-shadow: 0 44px 140px color-mix(in oklab, black 52%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--system-b-text-primary) 3.5%,
+    transparent
+  );
+  box-shadow: 0 44px 140px
+    color-mix(in oklab, var(--system-b-cinematic-black) 52%, transparent);
 }
 
 :where(.system-b-download-desktop-image) {
@@ -1764,14 +1812,17 @@
   right: 0;
   width: min(34vw, 13rem);
   overflow: hidden;
-  border: 1px solid color-mix(in oklab, white 10%, transparent);
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 10%, transparent);
   border-radius: var(--radius-3xl);
   background: var(--system-b-cinematic-black);
-  box-shadow: 0 28px 90px color-mix(in oklab, black 65%, transparent);
+  box-shadow: 0 28px 90px
+    color-mix(in oklab, var(--system-b-cinematic-black) 65%, transparent);
 }
 
 :where(.system-b-download-platform-section) {
-  border-block: 1px solid color-mix(in oklab, white 8%, transparent);
+  border-block: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
   background: var(--system-b-cinematic-black);
 }
 
@@ -1781,7 +1832,8 @@
 
 @media (max-width: 1023px) {
   :where(.system-b-download-platform-card + .system-b-download-platform-card) {
-    border-top: 1px solid color-mix(in oklab, white 8%, transparent);
+    border-top: 1px solid
+      color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
   }
 }
 
@@ -1791,7 +1843,8 @@
   }
 
   :where(.system-b-download-platform-card + .system-b-download-platform-card) {
-    border-left: 1px solid color-mix(in oklab, white 8%, transparent);
+    border-left: 1px solid
+      color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
   }
 
   :where(.system-b-download-platform-card:first-child) {
@@ -1883,7 +1936,8 @@
 }
 
 :where(.system-b-download-platform-inactive) {
-  border: 1px solid color-mix(in oklab, white 14%, transparent);
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 14%, transparent);
   color: color-mix(in oklab, var(--system-b-text-primary) 48%, transparent);
 }
 
@@ -1928,7 +1982,7 @@
   justify-content: center;
   margin-bottom: var(--space-4);
   border-radius: var(--system-b-radius-pill);
-  background: color-mix(in oklab, white 8%, transparent);
+  background: color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
   color: color-mix(in oklab, var(--system-b-text-primary) 82%, transparent);
 }
 
@@ -1947,7 +2001,8 @@
 }
 
 :where(.system-b-download-details-section) {
-  border-block: 1px solid color-mix(in oklab, white 8%, transparent);
+  border-block: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
   background: var(--system-b-cinematic-black);
 }
 
@@ -2007,14 +2062,16 @@
 :where(.system-b-download-requirements) {
   display: grid;
   margin-top: var(--space-12);
-  border-top: 1px solid color-mix(in oklab, white 8%, transparent);
+  border-top: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
   font-size: var(--text-mid);
 }
 
 :where(.system-b-download-requirement-row) {
   display: grid;
   gap: var(--space-2);
-  border-bottom: 1px solid color-mix(in oklab, white 8%, transparent);
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
   padding-block: var(--space-4);
 }
 

--- a/apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts
@@ -2,9 +2,10 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-const sourcePath = 'app/(marketing)/download/page.tsx';
+const pageSourcePath = 'app/(marketing)/download/page.tsx';
+const designSystemPath = 'styles/design-system.css';
 
-const forbiddenVisualPatterns = [
+const forbiddenRouteVisualPatterns = [
   /#[0-9a-fA-F]{3,8}/,
   /rgba?\(/,
   /hsla?\(/,
@@ -14,12 +15,53 @@ const forbiddenVisualPatterns = [
   /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
 ] as const;
 
+const forbiddenDownloadCssPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /letter-spacing:\s*-[^;]+/,
+  /font-size:\s*calc\(var\(--text-5xl\)\s*\+\s*var\(--space-16\)\)/,
+  /color-mix\(in oklab,\s*(?:white|black)\b/,
+  /(?:background|color|border(?:-[^:]+)?|box-shadow|text-decoration-color):[^;]*(?<!-)\b(?:white|black)\b/,
+] as const;
+
+function extractDownloadCss(source: string): string {
+  const start = source.indexOf(':where(.system-b-download-page)');
+  const end = source.indexOf(
+    '/* ============================================\n   GEIST ACCENT PALETTE',
+    start
+  );
+
+  expect(start, 'download CSS block exists').toBeGreaterThanOrEqual(0);
+  expect(
+    end,
+    'download CSS block is bounded before the next section'
+  ).toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
 describe('download page System B source contract', () => {
   it('keeps download page visuals on named System B primitives', () => {
-    const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+    const source = readFileSync(resolve(process.cwd(), pageSourcePath), 'utf8');
 
-    for (const pattern of forbiddenVisualPatterns) {
-      expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+    for (const pattern of forbiddenRouteVisualPatterns) {
+      expect(source, `${pageSourcePath} matched ${pattern}`).not.toMatch(
+        pattern
+      );
+    }
+  });
+
+  it('keeps download System B CSS within stable tokenized bounds', () => {
+    const source = extractDownloadCss(
+      readFileSync(resolve(process.cwd(), designSystemPath), 'utf8')
+    );
+
+    for (const pattern of forbiddenDownloadCssPatterns) {
+      expect(source, `${designSystemPath} matched ${pattern}`).not.toMatch(
+        pattern
+      );
     }
   });
 });


### PR DESCRIPTION
## Summary
- Scope the demoted `/download` header CTA to `body:has(.system-b-download-page)` so other marketing pages keep their filled shared header CTA.
- Reduce the `/download` 1024px hero title jump and top padding so `Download for Mac` remains visible above the fold.
- Expand the JOV-2548 source guard to scan the extracted `system-b-download-*` CSS block for raw color/gradient regressions and the oversized `space-16` title jump.

## Verification
- `pnpm biome check --write apps/web/components/organisms/HeaderNav.css apps/web/styles/design-system.css apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/marketing/download-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-commit hook: proxy guard, Biome, ESLint, staged-file typecheck
- pre-push hook: `biome check .`, proxy guard, Tailwind guard, web typecheck, web lint

## Visual proof
- `/download` 1440x1000, 1024x768, 390x844: no horizontal overflow, CLS 0, hero `Download for Mac` visible in viewport, header CTA secondary chrome.
- `/pricing` 1440x900: shared marketing header CTA remains filled white with shadow.
- Local screenshots:
  - `.gstack/design-reports/screenshots/download-system-b-review-fix-desktop-20260603.png`
  - `.gstack/design-reports/screenshots/download-system-b-review-fix-tablet-20260603.png`
  - `.gstack/design-reports/screenshots/download-system-b-review-fix-mobile-20260603.png`

JOV-2548


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated call-to-action button styling with refined visual appearance and improved hover interactions
  * Refreshed design system styling for the download page with enhanced semantic token consistency
  * Improved color and spacing consistency across marketing interface elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->