### PR TITLE
fix(app): align table toolbar system b chrome

### DIFF
--- a/apps/web/components/organisms/table/index.ts
+++ b/apps/web/components/organisms/table/index.ts
@@ -138,6 +138,7 @@ export type {
 } from './molecules/HeaderBulkActions';
 export { HeaderBulkActions } from './molecules/HeaderBulkActions';
 export { LoadingTableBody } from './molecules/LoadingTableBody';
+export type { TableToolbarBulkAction } from './molecules/PageToolbar';
 export {
   PAGE_TOOLBAR_ACTION_ACTIVE_CLASS,
   PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
@@ -155,6 +156,11 @@ export {
   PageToolbar,
   PageToolbarActionButton,
   PageToolbarTabButton,
+  TABLE_TOOLBAR_LEFT_CLASS,
+  TABLE_TOOLBAR_MENU_BUTTON_CLASS,
+  TABLE_TOOLBAR_OVERLAY_CLASS,
+  TABLE_TOOLBAR_RIGHT_CLASS,
+  TABLE_TOOLBAR_SHELL_CLASS,
 } from './molecules/PageToolbar';
 export type { PageToolbarSearchFormProps } from './molecules/PageToolbarSearchForm';
 export { PageToolbarSearchForm } from './molecules/PageToolbarSearchForm';

--- a/apps/web/components/organisms/table/molecules/PageToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/PageToolbar.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 import { ACTION_BAR_BUTTON_CLASS, ActionBar } from './ActionBar';
 
 export const PAGE_TOOLBAR_CONTAINER_CLASS =
-  'flex min-w-0 items-center gap-1.5 bg-transparent px-app-header py-1.5 md:min-h-[40px]';
+  'flex min-h-[40px] min-w-0 items-center gap-1.5 bg-transparent px-app-header py-1.5';
 
 export const PAGE_TOOLBAR_START_CLASS =
   'flex min-w-0 flex-1 items-center gap-1 overflow-x-auto overflow-y-hidden scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
@@ -23,15 +23,15 @@ export const PAGE_TOOLBAR_META_TEXT_CLASS =
 
 export const PAGE_TOOLBAR_TAB_BUTTON_CLASS = cn(
   APP_CONTROL_BUTTON_CLASS,
-  'h-7.5 rounded-[10px] px-2.5 text-[11.5px] font-[540] text-secondary-token [&_svg]:h-3.5 [&_svg]:w-3.5'
+  'h-7.5 rounded-pill px-2.5 text-[11.5px] font-[540] text-secondary-token [&_svg]:h-3.5 [&_svg]:w-3.5'
 );
 
 export const PAGE_TOOLBAR_TAB_ACTIVE_CLASS =
-  'border-default bg-[color-mix(in_oklab,var(--linear-app-content-surface)_96%,white_4%)] text-primary-token shadow-[0_1px_1px_rgba(0,0,0,0.04),0_6px_12px_-10px_rgba(0,0,0,0.14),inset_0_1px_0_rgba(255,255,255,0.03)]';
+  'border-default bg-surface-0 text-primary-token shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-app-shell-border)_68%,transparent)]';
 
 export const PAGE_TOOLBAR_ACTION_BUTTON_CLASS = cn(
   ACTION_BAR_BUTTON_CLASS,
-  'h-7 rounded-full border-0 bg-transparent px-2 text-[11.5px] font-[540] text-tertiary-token shadow-none hover:border-0 hover:bg-[color-mix(in_oklab,var(--linear-row-hover)_56%,transparent)] hover:text-primary-token hover:shadow-none focus-visible:border-0 focus-visible:bg-[color-mix(in_oklab,var(--linear-row-hover)_62%,transparent)] focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-0 active:border-0 active:bg-[color-mix(in_oklab,var(--linear-row-hover)_68%,transparent)] active:text-primary-token active:shadow-none disabled:pointer-events-none disabled:opacity-35 disabled:bg-transparent [&_svg]:h-3.5 [&_svg]:w-3.5'
+  'h-7 rounded-full border-0 bg-transparent px-2 text-[11.5px] font-[540] text-tertiary-token shadow-none hover:border-0 hover:bg-(--linear-row-hover) hover:text-primary-token hover:shadow-none focus-visible:border-0 focus-visible:bg-(--linear-row-hover) focus-visible:text-primary-token focus-visible:outline-none focus-visible:ring-0 active:border-0 active:bg-(--linear-row-hover) active:text-primary-token active:shadow-none disabled:pointer-events-none disabled:bg-transparent disabled:opacity-35 [&_svg]:h-3.5 [&_svg]:w-3.5'
 );
 
 export const PAGE_TOOLBAR_ACTION_ICON_ONLY_BUTTON_CLASS =

--- a/apps/web/components/organisms/table/molecules/PageToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/PageToolbar.tsx
@@ -37,6 +37,24 @@ export const PAGE_TOOLBAR_ACTION_BUTTON_CLASS = cn(
 export const PAGE_TOOLBAR_ACTION_ICON_ONLY_BUTTON_CLASS =
   'w-7 justify-center px-0 text-tertiary-token';
 
+export const TABLE_TOOLBAR_SHELL_CLASS =
+  'flex h-11 min-h-[44px] min-w-0 items-center gap-2 overflow-x-auto overflow-y-hidden border-b border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-3.5 py-2 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
+
+export const TABLE_TOOLBAR_OVERLAY_CLASS = cn(
+  'absolute inset-x-0 top-0 z-10',
+  TABLE_TOOLBAR_SHELL_CLASS
+);
+
+export const TABLE_TOOLBAR_LEFT_CLASS = 'flex shrink-0 items-center gap-2';
+
+export const TABLE_TOOLBAR_RIGHT_CLASS =
+  'ml-auto flex shrink-0 items-center gap-2';
+
+export const TABLE_TOOLBAR_MENU_BUTTON_CLASS = cn(
+  PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
+  'min-w-[88px] justify-center text-secondary-token'
+);
+
 export const PAGE_TOOLBAR_MENU_TRIGGER_CLASS = cn(
   PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
   'min-w-[112px] justify-between gap-1.5 rounded-full px-2.5 text-secondary-token'
@@ -47,6 +65,14 @@ export const PAGE_TOOLBAR_ACTION_ACTIVE_CLASS =
 
 export const PAGE_TOOLBAR_ICON_CLASS = 'h-3.5 w-3.5';
 export const PAGE_TOOLBAR_ICON_STROKE_WIDTH = 2;
+
+export interface TableToolbarBulkAction {
+  readonly label: string;
+  readonly icon?: ReactNode;
+  readonly onClick: () => void;
+  readonly disabled?: boolean;
+  readonly variant?: 'default' | 'destructive';
+}
 
 interface PageToolbarProps {
   readonly start: ReactNode;

--- a/apps/web/components/organisms/table/molecules/TableBulkActionsToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/TableBulkActionsToolbar.tsx
@@ -8,18 +8,16 @@ import {
   DropdownMenuTrigger,
 } from '@jovie/ui';
 import { X } from 'lucide-react';
-import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import { TableCountBadge } from '../atoms/TableCountBadge';
-import { PAGE_TOOLBAR_ACTION_BUTTON_CLASS } from './PageToolbar';
+import {
+  PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
+  TABLE_TOOLBAR_MENU_BUTTON_CLASS,
+  TABLE_TOOLBAR_OVERLAY_CLASS,
+  type TableToolbarBulkAction,
+} from './PageToolbar';
 
-export interface BulkAction {
-  readonly label: string;
-  readonly icon?: ReactNode;
-  readonly onClick: () => void;
-  readonly disabled?: boolean;
-  readonly variant?: 'default' | 'destructive';
-}
+export type BulkAction = TableToolbarBulkAction;
 
 export interface TableBulkActionsToolbarProps {
   readonly selectedCount: number;
@@ -27,14 +25,6 @@ export interface TableBulkActionsToolbarProps {
   readonly actions: BulkAction[];
   readonly className?: string;
 }
-
-const TABLE_BULK_ACTIONS_TOOLBAR_CLASS =
-  'absolute inset-x-0 top-0 z-10 flex h-11 min-h-[44px] min-w-0 items-center gap-2 overflow-x-auto overflow-y-hidden border-b border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-3.5 py-2 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
-
-const TABLE_BULK_ACTIONS_MENU_BUTTON_CLASS = cn(
-  PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
-  'min-w-[88px] justify-center text-secondary-token'
-);
 
 export function TableBulkActionsToolbar({
   selectedCount,
@@ -50,7 +40,7 @@ export function TableBulkActionsToolbar({
         aria-hidden='true'
         data-state='hidden'
         className={cn(
-          TABLE_BULK_ACTIONS_TOOLBAR_CLASS,
+          TABLE_TOOLBAR_OVERLAY_CLASS,
           'pointer-events-none opacity-0',
           className
         )}
@@ -64,7 +54,7 @@ export function TableBulkActionsToolbar({
     <div
       aria-hidden='false'
       data-state='visible'
-      className={cn(TABLE_BULK_ACTIONS_TOOLBAR_CLASS, 'opacity-100', className)}
+      className={cn(TABLE_TOOLBAR_OVERLAY_CLASS, 'opacity-100', className)}
     >
       {/* Selected count - totalCount is unused since this toolbar only renders when selectedCount > 0 */}
       <TableCountBadge
@@ -80,7 +70,7 @@ export function TableBulkActionsToolbar({
             <Button
               variant='ghost'
               size='sm'
-              className={TABLE_BULK_ACTIONS_MENU_BUTTON_CLASS}
+              className={TABLE_TOOLBAR_MENU_BUTTON_CLASS}
             >
               Actions
             </Button>

--- a/apps/web/components/organisms/table/molecules/TableBulkActionsToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/TableBulkActionsToolbar.tsx
@@ -8,14 +8,17 @@ import {
   DropdownMenuTrigger,
 } from '@jovie/ui';
 import { X } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import { TableCountBadge } from '../atoms/TableCountBadge';
+import { PAGE_TOOLBAR_ACTION_BUTTON_CLASS } from './PageToolbar';
 
 export interface BulkAction {
-  label: string;
-  icon?: React.ReactNode;
-  onClick: () => void;
-  variant?: 'default' | 'destructive';
+  readonly label: string;
+  readonly icon?: ReactNode;
+  readonly onClick: () => void;
+  readonly disabled?: boolean;
+  readonly variant?: 'default' | 'destructive';
 }
 
 export interface TableBulkActionsToolbarProps {
@@ -25,20 +28,43 @@ export interface TableBulkActionsToolbarProps {
   readonly className?: string;
 }
 
+const TABLE_BULK_ACTIONS_TOOLBAR_CLASS =
+  'absolute inset-x-0 top-0 z-10 flex h-11 min-h-[44px] min-w-0 items-center gap-2 overflow-x-auto overflow-y-hidden border-b border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-3.5 py-2 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
+
+const TABLE_BULK_ACTIONS_MENU_BUTTON_CLASS = cn(
+  PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
+  'min-w-[88px] justify-center text-secondary-token'
+);
+
 export function TableBulkActionsToolbar({
   selectedCount,
   onClearSelection,
   actions,
   className,
 }: TableBulkActionsToolbarProps) {
-  if (selectedCount === 0) return null;
+  const hasSelection = selectedCount > 0;
+
+  if (!hasSelection) {
+    return (
+      <div
+        aria-hidden='true'
+        data-state='hidden'
+        className={cn(
+          TABLE_BULK_ACTIONS_TOOLBAR_CLASS,
+          'pointer-events-none opacity-0',
+          className
+        )}
+      >
+        <span className='h-7 w-px' />
+      </div>
+    );
+  }
 
   return (
     <div
-      className={cn(
-        'flex flex-wrap items-center gap-2 bg-surface-1 px-3 py-2.5 sm:gap-3 sm:px-4 sm:py-3',
-        className
-      )}
+      aria-hidden='false'
+      data-state='visible'
+      className={cn(TABLE_BULK_ACTIONS_TOOLBAR_CLASS, 'opacity-100', className)}
     >
       {/* Selected count - totalCount is unused since this toolbar only renders when selectedCount > 0 */}
       <TableCountBadge
@@ -51,7 +77,11 @@ export function TableBulkActionsToolbar({
       {actions.length > 0 && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant='secondary' size='sm'>
+            <Button
+              variant='ghost'
+              size='sm'
+              className={TABLE_BULK_ACTIONS_MENU_BUTTON_CLASS}
+            >
               Actions
             </Button>
           </DropdownMenuTrigger>
@@ -60,6 +90,7 @@ export function TableBulkActionsToolbar({
               <DropdownMenuItem
                 key={action.label}
                 onClick={action.onClick}
+                disabled={action.disabled}
                 className={
                   action.variant === 'destructive'
                     ? 'text-destructive focus:text-destructive'
@@ -67,7 +98,7 @@ export function TableBulkActionsToolbar({
                 }
               >
                 {action.icon && (
-                  <span className='h-4 w-4 flex items-center justify-center [&>svg]:h-4 [&>svg]:w-4'>
+                  <span className='flex h-3.5 w-3.5 items-center justify-center [&>svg]:h-3.5 [&>svg]:w-3.5'>
                     {action.icon}
                   </span>
                 )}
@@ -83,9 +114,9 @@ export function TableBulkActionsToolbar({
         variant='ghost'
         size='sm'
         onClick={onClearSelection}
-        className='ml-auto h-7 rounded-full border border-transparent px-2 text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-0 hover:text-primary-token'
+        className={cn(PAGE_TOOLBAR_ACTION_BUTTON_CLASS, 'ml-auto')}
       >
-        <X className='h-4 w-4 mr-1' />
+        <X className='h-3.5 w-3.5' />
         Clear
       </Button>
     </div>

--- a/apps/web/components/organisms/table/molecules/TableStandardToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/TableStandardToolbar.tsx
@@ -12,28 +12,16 @@ import { X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import { TableCountBadge } from '../atoms/TableCountBadge';
-import { PAGE_TOOLBAR_ACTION_BUTTON_CLASS } from './PageToolbar';
-
-const TABLE_STANDARD_TOOLBAR_CLASS =
-  'flex min-h-[44px] min-w-0 items-center gap-2 overflow-x-auto overflow-y-hidden border-b border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-3.5 py-2 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
-
-const TABLE_STANDARD_TOOLBAR_LEFT_CLASS = 'flex shrink-0 items-center gap-2';
-
-const TABLE_STANDARD_TOOLBAR_RIGHT_CLASS =
-  'ml-auto flex shrink-0 items-center gap-2';
-
-const TABLE_STANDARD_TOOLBAR_MENU_BUTTON_CLASS = cn(
+import {
   PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
-  'min-w-[88px] justify-center text-secondary-token'
-);
+  TABLE_TOOLBAR_LEFT_CLASS,
+  TABLE_TOOLBAR_MENU_BUTTON_CLASS,
+  TABLE_TOOLBAR_RIGHT_CLASS,
+  TABLE_TOOLBAR_SHELL_CLASS,
+  type TableToolbarBulkAction,
+} from './PageToolbar';
 
-export interface BulkAction {
-  readonly label: string;
-  readonly icon?: ReactNode;
-  readonly onClick: () => void;
-  readonly disabled?: boolean;
-  readonly variant?: 'default' | 'destructive';
-}
+export type BulkAction = TableToolbarBulkAction;
 
 export interface TableStandardToolbarProps {
   /** Number of selected items */
@@ -96,9 +84,9 @@ export function TableStandardToolbar({
   const hasSelection = selectedCount > 0;
 
   return (
-    <div className={cn(TABLE_STANDARD_TOOLBAR_CLASS, className)}>
+    <div className={cn(TABLE_TOOLBAR_SHELL_CLASS, className)}>
       {/* Left section: Checkbox + count badge + bulk actions */}
-      <div className={TABLE_STANDARD_TOOLBAR_LEFT_CLASS}>
+      <div className={TABLE_TOOLBAR_LEFT_CLASS}>
         {onToggleSelectAll && (
           <Checkbox
             checked={headerCheckboxState}
@@ -119,7 +107,7 @@ export function TableStandardToolbar({
               <Button
                 variant='ghost'
                 size='sm'
-                className={TABLE_STANDARD_TOOLBAR_MENU_BUTTON_CLASS}
+                className={TABLE_TOOLBAR_MENU_BUTTON_CLASS}
               >
                 Actions
               </Button>
@@ -144,7 +132,7 @@ export function TableStandardToolbar({
       </div>
 
       {/* Right section: Search, export, primary actions, clear */}
-      <div className={TABLE_STANDARD_TOOLBAR_RIGHT_CLASS}>
+      <div className={TABLE_TOOLBAR_RIGHT_CLASS}>
         {/* Search - shown when no selection */}
         {!hasSelection && searchComponent}
 

--- a/apps/web/components/organisms/table/molecules/TableStandardToolbar.tsx
+++ b/apps/web/components/organisms/table/molecules/TableStandardToolbar.tsx
@@ -12,6 +12,20 @@ import { X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 import { TableCountBadge } from '../atoms/TableCountBadge';
+import { PAGE_TOOLBAR_ACTION_BUTTON_CLASS } from './PageToolbar';
+
+const TABLE_STANDARD_TOOLBAR_CLASS =
+  'flex min-h-[44px] min-w-0 items-center gap-2 overflow-x-auto overflow-y-hidden border-b border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) px-3.5 py-2 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
+
+const TABLE_STANDARD_TOOLBAR_LEFT_CLASS = 'flex shrink-0 items-center gap-2';
+
+const TABLE_STANDARD_TOOLBAR_RIGHT_CLASS =
+  'ml-auto flex shrink-0 items-center gap-2';
+
+const TABLE_STANDARD_TOOLBAR_MENU_BUTTON_CLASS = cn(
+  PAGE_TOOLBAR_ACTION_BUTTON_CLASS,
+  'min-w-[88px] justify-center text-secondary-token'
+);
 
 export interface BulkAction {
   readonly label: string;
@@ -82,14 +96,9 @@ export function TableStandardToolbar({
   const hasSelection = selectedCount > 0;
 
   return (
-    <div
-      className={cn(
-        'flex min-w-0 items-center gap-3 overflow-x-auto overflow-y-hidden border-b border-[color-mix(in_oklab,var(--linear-app-shell-border)_72%,transparent)] bg-transparent px-3.5 py-2 scroll-smooth [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
-        className
-      )}
-    >
+    <div className={cn(TABLE_STANDARD_TOOLBAR_CLASS, className)}>
       {/* Left section: Checkbox + count badge + bulk actions */}
-      <div className='flex shrink-0 items-center gap-3'>
+      <div className={TABLE_STANDARD_TOOLBAR_LEFT_CLASS}>
         {onToggleSelectAll && (
           <Checkbox
             checked={headerCheckboxState}
@@ -107,7 +116,11 @@ export function TableStandardToolbar({
         {hasSelection && bulkActions.length > 0 && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant='secondary' size='sm'>
+              <Button
+                variant='ghost'
+                size='sm'
+                className={TABLE_STANDARD_TOOLBAR_MENU_BUTTON_CLASS}
+              >
                 Actions
               </Button>
             </DropdownMenuTrigger>
@@ -131,7 +144,7 @@ export function TableStandardToolbar({
       </div>
 
       {/* Right section: Search, export, primary actions, clear */}
-      <div className='ml-auto flex shrink-0 items-center gap-3'>
+      <div className={TABLE_STANDARD_TOOLBAR_RIGHT_CLASS}>
         {/* Search - shown when no selection */}
         {!hasSelection && searchComponent}
 
@@ -147,9 +160,9 @@ export function TableStandardToolbar({
             variant='ghost'
             size='sm'
             onClick={onClearSelection}
-            className='h-7 gap-1 rounded-full border border-transparent px-2 text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:border-subtle hover:bg-surface-0 hover:text-primary-token'
+            className={PAGE_TOOLBAR_ACTION_BUTTON_CLASS}
           >
-            <X className='h-4 w-4' />
+            <X className='h-3.5 w-3.5' />
             Clear
           </Button>
         )}

--- a/apps/web/tests/unit/app/shared-table-motion-tokens.test.ts
+++ b/apps/web/tests/unit/app/shared-table-motion-tokens.test.ts
@@ -53,4 +53,32 @@ describe('shared table motion tokens', () => {
 
     expect(offenders).toEqual([]);
   });
+
+  it('keeps table primitives on semantic System B color tokens', () => {
+    const offenders = TABLE_ROOTS.flatMap(root =>
+      listSourceFiles(root).flatMap(file => {
+        const source = readFileSync(file, 'utf8');
+        return /color-mix\(in_oklab,[^\]\n]*(?:\bwhite\b|\bblack\b)/.test(
+          source
+        )
+          ? [file.replace(process.cwd(), '')]
+          : [];
+      })
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps the bulk action toolbar mounted for stable selection transitions', () => {
+    const toolbarSource = readFileSync(
+      join(TABLE_ROOTS[0], 'molecules/TableBulkActionsToolbar.tsx'),
+      'utf8'
+    );
+
+    expect(toolbarSource).toContain('data-state');
+    expect(toolbarSource).toContain('min-h-[44px]');
+    expect(toolbarSource).not.toMatch(
+      /selectedCount\s*===\s*0\)\s*return null/
+    );
+  });
 });

--- a/apps/web/tests/unit/app/shared-table-motion-tokens.test.ts
+++ b/apps/web/tests/unit/app/shared-table-motion-tokens.test.ts
@@ -74,9 +74,14 @@ describe('shared table motion tokens', () => {
       join(TABLE_ROOTS[0], 'molecules/TableBulkActionsToolbar.tsx'),
       'utf8'
     );
+    const pageToolbarSource = readFileSync(
+      join(TABLE_ROOTS[0], 'molecules/PageToolbar.tsx'),
+      'utf8'
+    );
 
     expect(toolbarSource).toContain('data-state');
-    expect(toolbarSource).toContain('min-h-[44px]');
+    expect(toolbarSource).toContain('TABLE_TOOLBAR_OVERLAY_CLASS');
+    expect(pageToolbarSource).toContain('min-h-[44px]');
     expect(toolbarSource).not.toMatch(
       /selectedCount\s*===\s*0\)\s*return null/
     );

--- a/apps/web/tests/unit/components/table/TableBulkActionsToolbar.test.tsx
+++ b/apps/web/tests/unit/components/table/TableBulkActionsToolbar.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { TableBulkActionsToolbar } from '@/components/organisms/table/molecules/TableBulkActionsToolbar';
+
+vi.mock('@jovie/ui', () => ({
+  Button: ({ children, ...props }: ComponentProps<'button'>) => (
+    <button type='button' {...props}>
+      {children}
+    </button>
+  ),
+  DropdownMenu: ({ children }: { readonly children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { readonly children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    variant: _variant,
+    ...props
+  }: ComponentProps<'button'> & { readonly variant?: string }) => (
+    <button type='button' {...props}>
+      {children}
+    </button>
+  ),
+  DropdownMenuTrigger: ({ children }: { readonly children: ReactNode }) => (
+    <>{children}</>
+  ),
+  TooltipShortcut: ({ children }: { readonly children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+describe('TableBulkActionsToolbar', () => {
+  it('keeps a hidden mounted overlay when no rows are selected', () => {
+    const { container } = render(
+      <TableBulkActionsToolbar
+        selectedCount={0}
+        onClearSelection={vi.fn()}
+        actions={[]}
+      />
+    );
+
+    const toolbar = container.firstElementChild;
+    expect(toolbar).toBeInTheDocument();
+    expect(toolbar).toHaveAttribute('aria-hidden', 'true');
+    expect(toolbar).toHaveAttribute('data-state', 'hidden');
+    expect(toolbar).toHaveClass('absolute', 'min-h-[44px]', 'opacity-0');
+    expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
+  });
+
+  it('renders selected count and actions in the visible state', () => {
+    render(
+      <TableBulkActionsToolbar
+        selectedCount={2}
+        onClearSelection={vi.fn()}
+        actions={[
+          {
+            label: 'Delete',
+            onClick: vi.fn(),
+            variant: 'destructive',
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Actions' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Clear' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeEnabled();
+  });
+});


### PR DESCRIPTION
## Summary
- Align shared table toolbar chrome with System B tokens: semantic surfaces, pill radius, and named row-hover background tokens.
- Normalize standard and bulk table toolbar controls to the compact 44px shell height and shared PageToolbar action-button treatment.
- Keep the admin bulk-actions toolbar mounted as a hidden absolute overlay so row selection swaps in `1 selected` / `Actions` / `Clear` without moving the table layout.

## Verification
- `pnpm biome check --write apps/web/components/organisms/table/molecules/PageToolbar.tsx apps/web/components/organisms/table/molecules/TableStandardToolbar.tsx apps/web/components/organisms/table/molecules/TableBulkActionsToolbar.tsx apps/web/tests/unit/app/shared-table-motion-tokens.test.ts apps/web/tests/unit/components/table/TableBulkActionsToolbar.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/app/shared-table-motion-tokens.test.ts tests/unit/components/table/PageToolbar.test.tsx tests/unit/components/table/TableBulkActionsToolbar.test.tsx tests/unit/table/TableSearchBar.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Pre-commit hook: proxy guard, Biome, ESLint, staged a11y check, web typecheck
- Pre-push hook: full Biome check, proxy guard, Tailwind guard, web typecheck, web lint

## Visual proof
- Desktop admin before selection: `.gstack/design-reports/screenshots/table-toolbar-system-b-admin-users-before-overlay-20260603.png`
- Desktop admin selected row: `.gstack/design-reports/screenshots/table-toolbar-system-b-admin-users-selected-overlay-20260603.png`
- Mobile admin before selection: `.gstack/design-reports/screenshots/table-toolbar-system-b-admin-users-mobile-before-20260603.png`

Browser metrics on `http://localhost:3100`:
- Desktop admin before selection: horizontal overflow `false`, CLS `0`, mounted bulk overlay `data-state="hidden"`.
- Desktop admin after selecting row 1: horizontal overflow `false`, CLS `0`, mounted bulk overlay `data-state="visible"`, visible text `1 selected`, `Actions`, `Clear`.
- Mobile admin before selection: horizontal overflow `false`, CLS `0`, mounted bulk overlay `data-state="hidden"`.

## Test plan
- Focused unit coverage for toolbar source guards and mounted bulk overlay behavior.
- Browser layout pass for desktop selected/unselected and mobile unselected admin table states.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for disabling individual bulk actions in the table toolbar.

* **Improvements**
  * Enhanced toolbar behavior when no items are selected with improved state management.
  * Updated table toolbar styling for better visual consistency.

* **Tests**
  * Added comprehensive test coverage for bulk actions toolbar functionality and behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->