### PR TITLE
fix(chat): normalize rich entity previews to System B

### DIFF
--- a/apps/web/components/jovie/components/ChatGenerationArtifactSurface.test.tsx
+++ b/apps/web/components/jovie/components/ChatGenerationArtifactSurface.test.tsx
@@ -16,6 +16,11 @@ describe('ChatGenerationArtifactSurface', () => {
     expect(screen.getByTestId('chat-generation-artifact-surface')).toHaveClass(
       'system-b-chat-generation-artifact-surface'
     );
+    expect(
+      screen
+        .getByText('Merch Options')
+        .closest('.system-b-chat-generation-artifact-header')
+    ).toHaveClass('system-b-chat-generation-artifact-header');
     expect(screen.getByText('Merch Options')).toHaveClass(
       'system-b-chat-generation-artifact-title'
     );
@@ -46,7 +51,7 @@ describe('ChatGenerationArtifactSurface', () => {
       expect(source).not.toMatch(/\brgba?\([^)]+\)/);
       expect(source).not.toMatch(/\b(?:linear|radial)-gradient\([^)]+\)/);
       expect(source).not.toMatch(
-        /\b(?:bg|text|border|shadow|rounded|p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr|gap|space-x|space-y|w|h|min-w|min-h|max-w|max-h|leading|tracking|top|bottom|left|right|inset|translate|scale)-\[[^\]]+\]/
+        /\b(?:bg|text|border|shadow|rounded|p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr|gap|space-x|space-y|w|h|min-w|min-h|max-w|max-h|leading|tracking|top|bottom|left|right|inset|translate|scale)-(?:\[[^\]]+\]|\(--[^)]+\))/
       );
       expect(source).not.toMatch(/\btext-red-\d{2,3}\b/);
     }

--- a/apps/web/components/jovie/components/ChatGenerationArtifactSurface.test.tsx
+++ b/apps/web/components/jovie/components/ChatGenerationArtifactSurface.test.tsx
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ChatGenerationArtifactSurface } from './ChatGenerationArtifactSurface';
+
+describe('ChatGenerationArtifactSurface', () => {
+  it('renders artifact chrome on System B primitives', () => {
+    render(
+      <ChatGenerationArtifactSurface title='Merch Options' subtitle='Pick one'>
+        <div>Option grid</div>
+      </ChatGenerationArtifactSurface>
+    );
+
+    expect(screen.getByTestId('chat-generation-artifact-surface')).toHaveClass(
+      'system-b-chat-generation-artifact-surface'
+    );
+    expect(screen.getByText('Merch Options')).toHaveClass(
+      'system-b-chat-generation-artifact-title'
+    );
+    expect(screen.getByText('Pick one')).toHaveClass(
+      'system-b-chat-generation-artifact-subtitle'
+    );
+  });
+
+  it('keeps artifact visuals and shimmer on System B classes', () => {
+    const filename = fileURLToPath(import.meta.url);
+    const testDir = dirname(filename);
+    const artifactSource = readFileSync(
+      resolve(testDir, 'ChatGenerationArtifactSurface.tsx'),
+      'utf8'
+    );
+    const pitchSource = readFileSync(
+      resolve(testDir, 'ChatPitchCard.tsx'),
+      'utf8'
+    );
+
+    expect(artifactSource).toContain(
+      'system-b-chat-generation-artifact-surface'
+    );
+    expect(pitchSource).toContain('system-b-chat-generation-shimmer');
+
+    for (const source of [artifactSource, pitchSource]) {
+      expect(source).not.toMatch(/#[0-9A-Fa-f]{3,8}\b/);
+      expect(source).not.toMatch(/\brgba?\([^)]+\)/);
+      expect(source).not.toMatch(/\b(?:linear|radial)-gradient\([^)]+\)/);
+      expect(source).not.toMatch(
+        /\b(?:bg|text|border|shadow|rounded|p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr|gap|space-x|space-y|w|h|min-w|min-h|max-w|max-h|leading|tracking|top|bottom|left|right|inset|translate|scale)-\[[^\]]+\]/
+      );
+      expect(source).not.toMatch(/\btext-red-\d{2,3}\b/);
+    }
+  });
+});

--- a/apps/web/components/jovie/components/ChatGenerationArtifactSurface.tsx
+++ b/apps/web/components/jovie/components/ChatGenerationArtifactSurface.tsx
@@ -22,7 +22,7 @@ export function ChatGenerationArtifactSurface({
       data-testid='chat-generation-artifact-surface'
       className={cn('system-b-chat-generation-artifact-surface', className)}
     >
-      <div className='flex h-9 items-center gap-2 border-b border-(--system-b-app-shell-border)/60 px-3'>
+      <div className='system-b-chat-generation-artifact-header flex h-9 items-center gap-2 px-3'>
         <Sparkles
           className='system-b-chat-generation-artifact-icon h-3.5 w-3.5'
           strokeWidth={2.25}

--- a/apps/web/components/jovie/components/ChatGenerationArtifactSurface.tsx
+++ b/apps/web/components/jovie/components/ChatGenerationArtifactSurface.tsx
@@ -4,9 +4,6 @@ import { Sparkles } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { cn } from '@/lib/utils';
 
-export const CHAT_GENERATION_SHIMMER_BG =
-  'linear-gradient(110deg, transparent 0%, rgba(255,255,255,0.04) 35%, rgba(103,232,249,0.06) 50%, rgba(255,255,255,0.04) 65%, transparent 100%)';
-
 interface ChatGenerationArtifactSurfaceProps {
   readonly title: string;
   readonly subtitle?: string | null;
@@ -23,19 +20,17 @@ export function ChatGenerationArtifactSurface({
   return (
     <section
       data-testid='chat-generation-artifact-surface'
-      className={cn(
-        'w-full max-w-[520px] overflow-hidden rounded-xl border border-(--linear-app-shell-border) bg-(--surface-0)/40',
-        className
-      )}
+      className={cn('system-b-chat-generation-artifact-surface', className)}
     >
-      <div className='flex h-9 items-center gap-2 border-b border-(--linear-app-shell-border)/60 px-3'>
-        <Sparkles className='h-3.5 w-3.5 text-cyan-300/80' strokeWidth={2.25} />
+      <div className='flex h-9 items-center gap-2 border-b border-(--system-b-app-shell-border)/60 px-3'>
+        <Sparkles
+          className='system-b-chat-generation-artifact-icon h-3.5 w-3.5'
+          strokeWidth={2.25}
+        />
         <div className='min-w-0 flex-1'>
-          <p className='truncate text-[12px] font-medium text-secondary-token'>
-            {title}
-          </p>
+          <p className='system-b-chat-generation-artifact-title'>{title}</p>
           {subtitle ? (
-            <p className='truncate text-[11px] text-tertiary-token'>
+            <p className='system-b-chat-generation-artifact-subtitle'>
               {subtitle}
             </p>
           ) : null}

--- a/apps/web/components/jovie/components/ChatPitchCard.tsx
+++ b/apps/web/components/jovie/components/ChatPitchCard.tsx
@@ -5,10 +5,7 @@ import { toast } from 'sonner';
 import { CopyToggleIcon } from '@/components/atoms/CopyToggleIcon';
 import { PLATFORM_LIMITS } from '@/lib/services/pitch/types';
 import { cn } from '@/lib/utils';
-import {
-  CHAT_GENERATION_SHIMMER_BG,
-  ChatGenerationArtifactSurface,
-} from './ChatGenerationArtifactSurface';
+import { ChatGenerationArtifactSurface } from './ChatGenerationArtifactSurface';
 
 const PLATFORM_CONFIG = [
   { key: 'spotify' as const, label: 'Spotify', limit: PLATFORM_LIMITS.spotify },
@@ -103,10 +100,8 @@ function PitchBlock({
         <div className='flex items-center gap-1.5'>
           {limit ? (
             <span
-              className={cn(
-                'text-[10px] tabular-nums',
-                text.length > limit ? 'text-red-500' : 'text-tertiary-token'
-              )}
+              className='system-b-chat-pitch-count'
+              data-over-limit={text.length > limit ? 'true' : undefined}
             >
               {text.length}/{limit}
             </span>
@@ -148,12 +143,7 @@ export function ChatPitchCard({
         <div className='relative overflow-hidden rounded-lg bg-surface-0 p-2'>
           <div
             aria-hidden='true'
-            className='absolute inset-0'
-            style={{
-              backgroundImage: CHAT_GENERATION_SHIMMER_BG,
-              backgroundSize: '200% 100%',
-              animation: 'shimmer 2.4s ease-in-out infinite',
-            }}
+            className='system-b-chat-generation-shimmer absolute inset-0'
           />
           <div className='relative space-y-2'>
             {[1, 2, 3, 4].map(i => (
@@ -177,7 +167,7 @@ export function ChatPitchCard({
   if (state === 'error') {
     return (
       <output className='block text-app text-primary-token'>
-        <span className='block font-medium text-red-500'>
+        <span className='block font-medium text-error'>
           Pitch Generation Failed
         </span>
         {error && (

--- a/apps/web/components/jovie/components/EntityChipPopover.test.tsx
+++ b/apps/web/components/jovie/components/EntityChipPopover.test.tsx
@@ -130,9 +130,6 @@ describe('EntityChipPopover', () => {
     await user.click(screen.getByTestId('entity-chip-popover-trigger'));
     const content = await screen.findByTestId('entity-chip-popover-content');
 
-    expect(content.className).toContain('z-[150]');
-    expect(content.className).toContain('bg-surface-1');
-    expect(content.className).toContain('shadow-popover');
-    expect(content.className).toContain('calc(100vw-24px)');
+    expect(content).toHaveClass('system-b-entity-chip-popover-content');
   });
 });

--- a/apps/web/components/jovie/components/EntityChipPopover.tsx
+++ b/apps/web/components/jovie/components/EntityChipPopover.tsx
@@ -162,7 +162,7 @@ export function EntityChipPopover({
         </button>
       </PopoverTrigger>
       <PopoverContent
-        className='z-[150] w-[min(272px,calc(100vw-24px))] overflow-hidden rounded-xl border border-(--linear-app-frame-seam) bg-surface-1 p-0 shadow-popover'
+        className='system-b-entity-chip-popover-content'
         side='top'
         sideOffset={6}
         align='start'

--- a/apps/web/components/jovie/components/EntityPreviewPane.test.tsx
+++ b/apps/web/components/jovie/components/EntityPreviewPane.test.tsx
@@ -1,0 +1,64 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { fastRender } from '@/tests/utils/fast-render';
+import { EntityPreviewPane } from './EntityPreviewPane';
+
+describe('EntityPreviewPane', () => {
+  it('uses System B primitives for the event date fallback and stat strip', () => {
+    fastRender(
+      <EntityPreviewPane
+        entity={{
+          kind: 'event',
+          id: 'event_1',
+          label: 'Club Night',
+          meta: {
+            kind: 'event',
+            eventDate: '2026-06-12',
+            city: 'Los Angeles',
+            capacity: 1200,
+            eventType: 'tour',
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByTestId('entity-preview-pane')).toHaveClass(
+      'system-b-entity-preview-pane'
+    );
+    expect(screen.getByTestId('entity-preview-event-art')).toHaveClass(
+      'system-b-entity-preview-artwork',
+      'system-b-entity-preview-event-art'
+    );
+    expect(screen.getByText('JUN')).toHaveClass(
+      'system-b-entity-preview-event-month'
+    );
+    expect(screen.getByText('12')).toHaveClass(
+      'system-b-entity-preview-event-day'
+    );
+    expect(screen.getByText('1,200')).toHaveClass(
+      'system-b-entity-preview-stat-strong'
+    );
+  });
+
+  it('uses the shared artwork shell for no-thumbnail placeholders', () => {
+    fastRender(
+      <EntityPreviewPane
+        entity={{
+          kind: 'release',
+          id: 'release_1',
+          label: 'Sober Summer',
+          meta: {
+            kind: 'release',
+            releaseType: 'single',
+            totalTracks: 1,
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText('SS')).toHaveClass(
+      'system-b-entity-preview-artwork',
+      'system-b-entity-preview-placeholder-art'
+    );
+  });
+});

--- a/apps/web/components/jovie/components/EntityPreviewPane.tsx
+++ b/apps/web/components/jovie/components/EntityPreviewPane.tsx
@@ -80,8 +80,8 @@ function buildReleaseStats(
     out.push({
       key: 'tracks',
       label: (
-        <span className='inline-flex items-center gap-[3px]'>
-          <strong className='font-semibold tabular-nums text-primary-token'>
+        <span className='system-b-entity-preview-stat-pair'>
+          <strong className='system-b-entity-preview-stat-strong'>
             {meta.totalTracks}
           </strong>
           tracks
@@ -100,9 +100,9 @@ function buildReleaseStats(
     out.push({
       key: 'spotify',
       label: (
-        <span className='inline-flex items-center gap-[3px]'>
+        <span className='system-b-entity-preview-stat-pair'>
           Spotify
-          <strong className='font-semibold tabular-nums text-primary-token'>
+          <strong className='system-b-entity-preview-stat-strong'>
             {meta.spotifyPopularity}
           </strong>
         </span>
@@ -123,8 +123,8 @@ function buildArtistStats(
     out.push({
       key: 'followers',
       label: (
-        <span className='inline-flex items-center gap-[3px]'>
-          <strong className='font-semibold tabular-nums text-primary-token'>
+        <span className='system-b-entity-preview-stat-pair'>
+          <strong className='system-b-entity-preview-stat-strong'>
             {followers}
           </strong>
           followers
@@ -140,9 +140,9 @@ function buildArtistStats(
     out.push({
       key: 'popularity',
       label: (
-        <span className='inline-flex items-center gap-[3px]'>
+        <span className='system-b-entity-preview-stat-pair'>
           Spotify
-          <strong className='font-semibold tabular-nums text-primary-token'>
+          <strong className='system-b-entity-preview-stat-strong'>
             {meta.popularity}
           </strong>
         </span>
@@ -197,9 +197,9 @@ function buildEventStats(
     out.push({
       key: 'doors',
       label: (
-        <span className='inline-flex items-center gap-[3px]'>
+        <span className='system-b-entity-preview-stat-pair'>
           Doors
-          <strong className='font-semibold tabular-nums text-primary-token'>
+          <strong className='system-b-entity-preview-stat-strong'>
             {doors}
           </strong>
         </span>
@@ -209,9 +209,9 @@ function buildEventStats(
     out.push({
       key: 'capacity',
       label: (
-        <span className='inline-flex items-center gap-[3px]'>
+        <span className='system-b-entity-preview-stat-pair'>
           Capacity
-          <strong className='font-semibold tabular-nums text-primary-token'>
+          <strong className='system-b-entity-preview-stat-strong'>
             {meta.capacity.toLocaleString()}
           </strong>
         </span>
@@ -255,16 +255,11 @@ function dateStampParts(iso: string | undefined): DateStampParts | null {
 function EventDateArtwork({ stamp }: { readonly stamp: DateStampParts }) {
   return (
     <div
-      className='flex h-[72px] w-[72px] shrink-0 flex-col items-center justify-center rounded-[10px] shadow-[0_0_0_0.5px_rgba(255,255,255,0.06),inset_0_0.5px_0_rgba(255,255,255,0.08),0_12px_24px_-8px_rgba(0,0,0,0.55)]'
-      style={{ background: 'linear-gradient(180deg,#1a1a1f,#0a0a0c)' }}
+      className='system-b-entity-preview-artwork system-b-entity-preview-event-art'
       data-testid='entity-preview-event-art'
     >
-      <span className='font-display text-[10px] font-semibold uppercase tracking-[0.12em] text-tertiary-token'>
-        {stamp.month}
-      </span>
-      <span className='font-display text-[28px] font-bold leading-none tracking-[-0.02em] text-primary-token'>
-        {stamp.day}
-      </span>
+      <span className='system-b-entity-preview-event-month'>{stamp.month}</span>
+      <span className='system-b-entity-preview-event-day'>{stamp.day}</span>
     </div>
   );
 }
@@ -280,7 +275,7 @@ function PreviewArtwork({ entity }: { readonly entity: EntityRef }) {
   }
   if (entity.thumbnail) {
     return (
-      <div className='relative h-[72px] w-[72px] shrink-0 overflow-hidden rounded-[10px] shadow-[0_0_0_0.5px_rgba(255,255,255,0.06),inset_0_0.5px_0_rgba(255,255,255,0.08),0_12px_24px_-8px_rgba(0,0,0,0.55)]'>
+      <div className='system-b-entity-preview-artwork system-b-entity-preview-media-art'>
         <Image
           src={entity.thumbnail}
           alt=''
@@ -299,7 +294,7 @@ function PreviewArtwork({ entity }: { readonly entity: EntityRef }) {
     .join('')
     .toUpperCase();
   return (
-    <div className='flex h-[72px] w-[72px] shrink-0 items-center justify-center rounded-[10px] bg-gradient-to-br from-[#2a2a2f] to-[#16161a] text-[22px] font-semibold tracking-[-0.02em] text-primary-token shadow-[0_0_0_0.5px_rgba(255,255,255,0.06),inset_0_0.5px_0_rgba(255,255,255,0.08),0_12px_24px_-8px_rgba(0,0,0,0.55)]'>
+    <div className='system-b-entity-preview-artwork system-b-entity-preview-placeholder-art'>
       {initials || '·'}
     </div>
   );
@@ -314,39 +309,36 @@ export function EntityPreviewPane({
   return (
     <section
       aria-label='Selected entity preview'
-      className={cn(
-        'flex flex-1 flex-col bg-gradient-to-b from-white/[0.022] to-transparent px-6 py-[22px]',
-        className
-      )}
+      className={cn('system-b-entity-preview-pane', className)}
       data-testid='entity-preview-pane'
     >
-      <div className='flex items-start gap-4'>
+      <div className='system-b-entity-preview-layout'>
         <PreviewArtwork entity={entity} />
-        <div className='min-w-0 flex-1 pt-px'>
-          <div className='mb-2 font-display text-[9.5px] font-semibold uppercase tracking-[0.12em] text-quaternary-token'>
-            {eyebrow}
-          </div>
+        <div className='system-b-entity-preview-content'>
+          <div className='system-b-entity-preview-eyebrow'>{eyebrow}</div>
           <h3
             aria-live='polite'
             aria-atomic='true'
-            className='m-0 mb-3.5 font-display text-[19px] font-semibold leading-[1.15] tracking-[-0.022em] text-primary-token'
+            className='system-b-entity-preview-title'
           >
             {entity.label}
           </h3>
           {stats.length > 0 ? (
-            <div className='flex flex-wrap items-center text-[12px] leading-[1.5] tracking-[-0.002em] text-tertiary-token'>
+            <div className='system-b-entity-preview-stats'>
               {stats.map((stat, i) => (
                 <span
                   key={stat.key}
                   className={cn(
-                    'relative inline-flex items-center whitespace-nowrap',
+                    'system-b-entity-preview-stat',
                     stat.emphasis === 'solid'
-                      ? 'ml-2 rounded-[3px] bg-white/10 px-[7px] py-px font-display text-[9.5px] font-semibold uppercase tracking-[0.1em] text-primary-token'
-                      : 'px-[10px]',
-                    i === 0 && stat.emphasis !== 'solid' && 'pl-0',
+                      ? 'system-b-entity-preview-stat-solid'
+                      : 'system-b-entity-preview-stat-muted',
+                    i === 0 &&
+                      stat.emphasis !== 'solid' &&
+                      'system-b-entity-preview-stat-first',
                     i > 0 &&
                       stat.emphasis !== 'solid' &&
-                      "before:absolute before:left-0 before:top-1/2 before:h-[2px] before:w-[2px] before:-translate-y-1/2 before:rounded-full before:bg-quaternary-token before:content-['']"
+                      'system-b-entity-preview-stat-separated'
                   )}
                 >
                   {stat.label}

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2330,6 +2330,11 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   );
 }
 
+:where(.system-b-chat-generation-artifact-header) {
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--system-b-app-shell-border) 60%, transparent);
+}
+
 :where(.system-b-chat-generation-artifact-icon) {
   color: color-mix(in oklab, var(--system-b-accent-cyan) 80%, transparent);
 }
@@ -2362,6 +2367,12 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   );
   background-size: 200% 100%;
   animation: shimmer 2.4s var(--ease-in-out) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :where(.system-b-chat-generation-shimmer) {
+    animation: none;
+  }
 }
 
 :where(.system-b-chat-pitch-count) {

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -77,9 +77,17 @@
      on these names instead of route-local Tailwind literals. */
   --system-b-cinematic-black: #06070a;
   --system-b-text-primary: var(--color-text-primary-token);
+  --system-b-bg-page: var(--color-bg-base);
+  --system-b-bg-surface-0: var(--color-bg-surface-0);
+  --system-b-bg-surface-1: var(--color-bg-surface-1);
+  --system-b-bg-surface-2: var(--color-bg-surface-2);
   --system-b-primary-bg: var(--linear-btn-primary-bg);
   --system-b-primary-fg: var(--linear-btn-primary-fg);
   --system-b-header-height: var(--linear-header-height);
+  --system-b-app-shell-border: var(--app-shell-border);
+  --system-b-app-frame-seam: var(--app-shell-frame-seam);
+  --system-b-app-content-surface: var(--app-shell-content-surface);
+  --system-b-accent-cyan: var(--geist-cyan-solid);
   --system-b-duration-fast: var(--ds-motion-subtle-duration);
   --system-b-ease: var(--ds-motion-subtle-easing);
   --system-b-radius-pill: var(--radius-full);
@@ -2123,6 +2131,247 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
 
 :where(.system-b-download-legal-link:hover) {
   color: color-mix(in oklab, var(--system-b-text-primary) 70%, transparent);
+}
+
+/* ============================================
+   SYSTEM B CHAT ENTITY PREVIEW PRIMITIVES
+   ============================================ */
+
+:where(.system-b-entity-chip-popover-content) {
+  z-index: 150;
+  width: min(272px, calc(100vw - var(--space-6)));
+  overflow: hidden;
+  border: 1px solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-xl);
+  background: var(--system-b-bg-surface-1);
+  padding: 0;
+  box-shadow: var(--shadow-popover);
+}
+
+:where(.system-b-entity-preview-stat-pair) {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+:where(.system-b-entity-preview-stat-strong) {
+  color: var(--color-text-primary-token);
+  font-weight: var(--font-weight-semibold);
+  font-variant-numeric: tabular-nums;
+}
+
+:where(.system-b-entity-preview-artwork) {
+  position: relative;
+  width: 72px;
+  height: 72px;
+  flex-shrink: 0;
+  overflow: hidden;
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-button-inset);
+}
+
+:where(.system-b-entity-preview-event-art) {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(
+    180deg,
+    var(--system-b-bg-surface-2),
+    var(--system-b-bg-page)
+  );
+}
+
+:where(.system-b-entity-preview-event-month) {
+  color: var(--color-text-tertiary-token);
+  font-family: var(--font-display);
+  font-size: var(--text-3xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+  text-transform: uppercase;
+}
+
+:where(.system-b-entity-preview-event-day) {
+  color: var(--color-text-primary-token);
+  font-family: var(--font-display);
+  font-size: var(--text-2xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-none);
+}
+
+:where(.system-b-entity-preview-media-art img) {
+  object-fit: cover;
+}
+
+:where(.system-b-entity-preview-placeholder-art) {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-2) 82%,
+    var(--system-b-bg-page)
+  );
+  color: var(--color-text-primary-token);
+  font-size: var(--text-xl);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+}
+
+:where(.system-b-entity-preview-pane) {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  background: linear-gradient(
+    180deg,
+    color-mix(in oklab, var(--color-text-primary-token) 2%, transparent),
+    transparent
+  );
+  padding: calc(var(--space-5) + var(--space-0-5)) var(--space-6);
+}
+
+:where(.system-b-entity-preview-layout) {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-4);
+}
+
+:where(.system-b-entity-preview-content) {
+  min-width: 0;
+  flex: 1;
+  padding-top: var(--space-px);
+}
+
+:where(.system-b-entity-preview-eyebrow) {
+  margin-bottom: var(--space-2);
+  color: var(--color-text-quaternary-token);
+  font-family: var(--font-display);
+  font-size: var(--text-3xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+  text-transform: uppercase;
+}
+
+:where(.system-b-entity-preview-title) {
+  margin: 0 0 calc(var(--space-3) + var(--space-0-5));
+  color: var(--color-text-primary-token);
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight);
+}
+
+:where(.system-b-entity-preview-stats) {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-normal);
+}
+
+:where(.system-b-entity-preview-stat) {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+:where(.system-b-entity-preview-stat-muted) {
+  padding-inline: var(--space-2-5);
+}
+
+:where(.system-b-entity-preview-stat-first) {
+  padding-left: 0;
+}
+
+:where(.system-b-entity-preview-stat-separated)::before {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: var(--space-0-5);
+  height: var(--space-0-5);
+  border-radius: var(--radius-full);
+  background: var(--color-text-quaternary-token);
+  content: "";
+  transform: translateY(-50%);
+}
+
+:where(.system-b-entity-preview-stat-solid) {
+  margin-left: var(--space-2);
+  border-radius: var(--radius-full);
+  background: color-mix(
+    in oklab,
+    var(--color-text-primary-token) 10%,
+    transparent
+  );
+  padding: var(--space-0-5) var(--space-2);
+  color: var(--color-text-primary-token);
+  font-family: var(--font-display);
+  font-size: var(--text-3xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+  text-transform: uppercase;
+}
+
+:where(.system-b-chat-generation-artifact-surface) {
+  width: 100%;
+  max-width: 520px;
+  overflow: hidden;
+  border: 1px solid var(--system-b-app-shell-border);
+  border-radius: var(--radius-xl);
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-0) 40%,
+    transparent
+  );
+}
+
+:where(.system-b-chat-generation-artifact-icon) {
+  color: color-mix(in oklab, var(--system-b-accent-cyan) 80%, transparent);
+}
+
+:where(.system-b-chat-generation-artifact-title) {
+  overflow: hidden;
+  color: var(--color-text-secondary-token);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:where(.system-b-chat-generation-artifact-subtitle) {
+  overflow: hidden;
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-2xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:where(.system-b-chat-generation-shimmer) {
+  background-image: linear-gradient(
+    110deg,
+    transparent 0%,
+    color-mix(in oklab, var(--color-text-primary-token) 4%, transparent) 35%,
+    color-mix(in oklab, var(--system-b-accent-cyan) 6%, transparent) 50%,
+    color-mix(in oklab, var(--color-text-primary-token) 4%, transparent) 65%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 2.4s var(--ease-in-out) infinite;
+}
+
+:where(.system-b-chat-pitch-count) {
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-3xs);
+  font-variant-numeric: tabular-nums;
+}
+
+:where(.system-b-chat-pitch-count[data-over-limit="true"]) {
+  color: var(--color-error);
 }
 
 /* ============================================

--- a/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+
+const guardedFiles = [
+  'components/jovie/components/ChatGenerationArtifactSurface.tsx',
+  'components/jovie/components/ChatPitchCard.tsx',
+  'components/jovie/components/EntityChipPopover.tsx',
+  'components/jovie/components/EntityPreviewPane.tsx',
+];
+
+const rawVisualPatterns = [
+  /\b(?:text|rounded|shadow|border|bg|px|py|min-w|min-h|max-w|max-h|w|h|tracking|duration|z)-\[[^\]]+\]/,
+  /\bfont-\[[^\]]+\]/,
+  /tracking-\[-/,
+  /color-mix\(in_srgb/,
+  /\brgba?\(/,
+  /#[0-9A-Fa-f]{3,8}\b/,
+  /\btext-red-\d{2,3}\b/,
+];
+
+describe('entity rich chip System B style guard', () => {
+  it('keeps touched chip, preview, and artifact visuals on named primitives', () => {
+    for (const file of guardedFiles) {
+      const source = readFileSync(path.join(webRoot, file), 'utf8');
+      const offenders = rawVisualPatterns
+        .filter(pattern => pattern.test(source))
+        .map(pattern => pattern.toString());
+
+      expect(offenders, `${file} leaked ${offenders.join(', ')}`).toEqual([]);
+    }
+  });
+});

--- a/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
@@ -15,7 +15,7 @@ const rawVisualPatterns = [
   /\b(?:text|rounded|shadow|border|bg|px|py|min-w|min-h|max-w|max-h|w|h|tracking|duration|z)-\[[^\]]+\]/,
   /\bfont-\[[^\]]+\]/,
   /tracking-\[-/,
-  /color-mix\(in_srgb/,
+  /color-mix\s*\(\s*in\s+srgb/i,
   /\brgba?\(/,
   /#[0-9A-Fa-f]{3,8}\b/,
   /\btext-red-\d{2,3}\b/,

--- a/apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts
@@ -28,10 +28,14 @@ const forbiddenDownloadCssPatterns = [
 
 function extractDownloadCss(source: string): string {
   const start = source.indexOf(':where(.system-b-download-page)');
-  const end = source.indexOf(
+  const nextSectionMarkers = [
+    '/* ============================================\n   SYSTEM B CHAT ENTITY PREVIEW PRIMITIVES',
     '/* ============================================\n   GEIST ACCENT PALETTE',
-    start
-  );
+  ];
+  const end = nextSectionMarkers
+    .map(marker => source.indexOf(marker, start))
+    .filter(index => index > start)
+    .sort((a, b) => a - b)[0];
 
   expect(start, 'download CSS block exists').toBeGreaterThanOrEqual(0);
   expect(


### PR DESCRIPTION
## Summary

- Move chat generation artifact chrome, pitch loading shimmer/count text, entity chip popover chrome, and entity preview pane visuals onto named System B primitives.
- Add focused System B CSS primitives for chat artifact surfaces, entity preview artwork/stat strips, and bounded chip popovers.
- Add render tests plus a touched-file style guard to block raw RGB/hex/arbitrary visual recipes from returning to these chat/entity primitives.

## Verification

- `./scripts/setup.sh`
- `pnpm biome check --write apps/web/components/jovie/components/ChatGenerationArtifactSurface.tsx apps/web/components/jovie/components/ChatPitchCard.tsx apps/web/components/jovie/components/EntityChipPopover.tsx apps/web/components/jovie/components/EntityChipPopover.test.tsx apps/web/components/jovie/components/EntityPreviewPane.tsx apps/web/components/jovie/components/EntityPreviewPane.test.tsx apps/web/components/jovie/components/ChatGenerationArtifactSurface.test.tsx apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts apps/web/styles/design-system.css`
- `pnpm --filter @jovie/web exec vitest run components/jovie/components/ChatGenerationArtifactSurface.test.tsx components/jovie/components/EntityPreviewPane.test.tsx components/jovie/components/EntityChipPopover.test.tsx tests/unit/chat/entity-rich-chip-style-guard.test.ts` — 4 files, 14 tests
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Pre-commit hook: proxy guard, Biome, ESLint, staged a11y, staged web typecheck
- Pre-push hook: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint

## Visual Proof

- Authenticated `/app/chat` entity preview desktop: `.gstack/design-reports/screenshots/jov-2716-app-chat-entity-preview-desktop-20260603.png`
- Authenticated `/app/chat` entity preview mobile: `.gstack/design-reports/screenshots/jov-2716-app-chat-entity-preview-mobile-20260603.png`
- Authenticated `/app/chat` empty desktop: `.gstack/design-reports/screenshots/jov-2716-app-chat-empty-desktop-20260603.png`
- Authenticated `/app/chat` slash root desktop: `.gstack/design-reports/screenshots/jov-2716-app-chat-slash-root-desktop-20260603.png`

Visual metrics from the authenticated `/app/chat` run: entity mode rendered one `entity-preview-pane`, CLS was `0`, and horizontal overflow was `false` on desktop and mobile.

Note: root `pnpm run dev:web:fast` failed locally before starting Next with `ENV_UNSET_ARGS[@]: unbound variable`; visual QA used the equivalent Doppler-wrapped web dev command on port `3102`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new System B design system CSS variables and classes for entity preview and chat UI components.

* **Style**
  * Updated styling across chat generation artifacts, pitch cards, entity chip popovers, and entity preview panes to use CSS class-based approach.

* **Tests**
  * Added test coverage to verify System B styling compliance and component rendering accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->