### PR TITLE
fix(chat): strengthen entity popover primitive specificity

### DIFF
--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2137,7 +2137,7 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
    SYSTEM B CHAT ENTITY PREVIEW PRIMITIVES
    ============================================ */
 
-:where(.system-b-entity-chip-popover-content) {
+.system-b-entity-chip-popover-content {
   z-index: 150;
   width: min(272px, calc(100vw - var(--space-6)));
   overflow: hidden;


### PR DESCRIPTION
Refs JOV-2716.

Summary:
- Strengthens the System B entity chip popover selector from zero-specificity `:where()` to a normal class selector so package `PopoverContent` defaults cannot override its sizing, z-index, overflow, padding, or radius contract.

Verification:
- `pnpm biome check --write apps/web/styles/design-system.css`
- `pnpm --filter @jovie/web exec vitest run components/jovie/components/EntityChipPopover.test.tsx tests/unit/chat/entity-rich-chip-style-guard.test.ts tests/unit/marketing/download-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check origin/main..HEAD`
- pre-push hook: `biome check .`, proxy guard, Tailwind guard, typecheck, lint