### PR TITLE
fix(extension): normalize sidepanel System B chrome

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -3,7 +3,7 @@
   "version": "26.6.2",
   "private": true,
   "scripts": {
-    "build": "rm -rf dist && tsc -p tsconfig.build.json && node scripts/copy-static.mjs",
+    "build": "rm -rf dist .cache/tsbuildinfo && tsc -p tsconfig.build.json && node scripts/copy-static.mjs",
     "dev": "tsc -p tsconfig.build.json --watch",
     "test": "node scripts/vitest-wrapper.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/apps/extension/src/sidepanel.ts
+++ b/apps/extension/src/sidepanel.ts
@@ -397,6 +397,12 @@ function renderShell(children: HTMLElement[]) {
 
   const shell = document.createElement('div');
   shell.className = 'shell';
+  const isDockChild = (child: HTMLElement) =>
+    child.classList.contains('action-tray') ||
+    child.classList.contains('signed-out-actions');
+  const contentChildren = children.filter(child => !isDockChild(child));
+  const dockChildren = children.filter(isDockChild);
+  const hasActionDock = dockChildren.length > 0;
 
   const header = document.createElement('header');
   header.className = 'top-rail';
@@ -421,14 +427,20 @@ function renderShell(children: HTMLElement[]) {
 
   const main = document.createElement('main');
   main.className = 'panel-scroll';
-  for (const child of children) {
+  for (const child of contentChildren) {
     main.appendChild(child);
   }
 
   shell.appendChild(main);
-  const promptDock = renderPromptDock();
+  const promptDock = renderPromptDock({ hasActionDock });
   if (promptDock) {
+    if (hasActionDock) {
+      promptDock.classList.add('prompt-dock-stacked');
+    }
     shell.appendChild(promptDock);
+  }
+  for (const child of dockChildren) {
+    shell.appendChild(child);
   }
   root.appendChild(shell);
 }
@@ -507,7 +519,7 @@ function renderSummaryCard(summary: ExtensionSummaryResponse) {
 
   const eyebrow = document.createElement('p');
   eyebrow.className = 'eyebrow';
-  eyebrow.textContent = 'Suggested For This Page';
+  eyebrow.textContent = 'Page Context';
 
   const title = document.createElement('h2');
   title.className = 'section-title';
@@ -739,7 +751,7 @@ function renderPermissionCard(host: string) {
 
   const eyebrow = document.createElement('p');
   eyebrow.className = 'eyebrow';
-  eyebrow.textContent = 'Enable This Domain';
+  eyebrow.textContent = 'Domain Access';
 
   const title = document.createElement('h3');
   title.className = 'section-title';
@@ -768,8 +780,16 @@ function renderPermissionCard(host: string) {
   return card;
 }
 
-function renderPromptDock() {
+function renderPromptDock({
+  hasActionDock,
+}: {
+  readonly hasActionDock: boolean;
+}) {
   if (!state.statusMessage && !state.flags?.chatPromptEnabled) {
+    return null;
+  }
+
+  if (hasActionDock && !state.statusMessage) {
     return null;
   }
 
@@ -783,7 +803,7 @@ function renderPromptDock() {
     dock.appendChild(status);
   }
 
-  if (state.flags?.chatPromptEnabled) {
+  if (state.flags?.chatPromptEnabled && !hasActionDock) {
     const prompt = document.createElement('button');
     prompt.type = 'button';
     prompt.className = 'prompt-button';

--- a/apps/extension/src/styles.css
+++ b/apps/extension/src/styles.css
@@ -1,10 +1,52 @@
 :root {
   color-scheme: light;
   font-family:
-    "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont,
+    Inter, "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;
-  background: #f3f4f7;
-  color: #12131a;
+
+  /* Local System B bridge tokens for the Chrome extension runtime. */
+  --extension-system-b-bg-base: #f5f5f5;
+  --extension-system-b-bg-surface-0: #f2f3f5;
+  --extension-system-b-bg-surface-1: #ffffff;
+  --extension-system-b-bg-surface-2: #ebecef;
+  --extension-system-b-text-primary: #0c0c0c;
+  --extension-system-b-text-secondary: #2e2f31;
+  --extension-system-b-text-tertiary: #5a5b5d;
+  --extension-system-b-text-quaternary: #8b8d92;
+  --extension-system-b-border-subtle: rgb(12 12 12 / 0.08);
+  --extension-system-b-border-default: rgb(12 12 12 / 0.12);
+  --extension-system-b-border-strong: rgb(12 12 12 / 0.18);
+  --extension-system-b-focus: #7170ff;
+  --extension-system-b-shadow-card: 0 1px 2px rgb(12 12 12 / 0.04);
+  --extension-system-b-shadow-dock: 0 8px 24px rgb(12 12 12 / 0.08);
+  --extension-system-b-radius-xs: 6px;
+  --extension-system-b-radius-sm: 8px;
+  --extension-system-b-radius-md: 10px;
+  --extension-system-b-radius-lg: 12px;
+  --extension-system-b-radius-xl: 14px;
+  --extension-system-b-space-1: 4px;
+  --extension-system-b-space-2: 8px;
+  --extension-system-b-space-3: 10px;
+  --extension-system-b-space-4: 12px;
+  --extension-system-b-space-5: 14px;
+  --extension-system-b-space-6: 16px;
+  --extension-system-b-space-7: 20px;
+  --extension-system-b-space-8: 24px;
+  --extension-system-b-text-2xs: 11px;
+  --extension-system-b-text-xs: 12px;
+  --extension-system-b-text-sm: 13px;
+  --extension-system-b-text-md: 15px;
+  --extension-system-b-action-height: 34px;
+  --extension-system-b-field-thumb: 44px;
+  --extension-system-b-header-height: 57px;
+  --extension-system-b-dock-offset: 16px;
+  --extension-system-b-dock-min-height: 58px;
+  --extension-system-b-motion-fast: 140ms;
+  --extension-system-b-motion-base: 1.4s;
+  --extension-system-b-ease: cubic-bezier(0.2, 0, 0, 1);
+
+  background: var(--extension-system-b-bg-base);
+  color: var(--extension-system-b-text-primary);
 }
 
 * {
@@ -15,9 +57,7 @@ html,
 body {
   margin: 0;
   min-height: 100%;
-  background:
-    radial-gradient(circle at top, rgba(0, 0, 0, 0.04), transparent 42%),
-    #f3f4f7;
+  background: var(--extension-system-b-bg-base);
 }
 
 body {
@@ -30,25 +70,32 @@ textarea {
   font: inherit;
 }
 
+button {
+  appearance: none;
+}
+
 .shell {
   display: flex;
+  height: 100vh;
   min-height: 100vh;
   flex-direction: column;
+  overflow: hidden;
+  background: var(--extension-system-b-bg-base);
 }
 
 .top-rail {
   display: flex;
+  min-height: var(--extension-system-b-header-height);
   align-items: center;
-  gap: 12px;
-  border-bottom: 1px solid rgba(18, 19, 26, 0.08);
-  background: rgba(255, 255, 255, 0.82);
-  padding: 14px 16px 12px;
-  backdrop-filter: blur(20px);
+  gap: var(--extension-system-b-space-4);
+  border-bottom: 1px solid var(--extension-system-b-border-subtle);
+  background: var(--extension-system-b-bg-surface-1);
+  padding: var(--extension-system-b-space-4) var(--extension-system-b-space-6);
 }
 
 .logo-mark {
   display: inline-flex;
-  color: rgba(18, 19, 26, 0.68);
+  color: var(--extension-system-b-text-secondary);
 }
 
 .top-rail-copy {
@@ -57,11 +104,10 @@ textarea {
 
 .eyebrow {
   margin: 0;
-  color: rgba(18, 19, 26, 0.52);
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
+  color: var(--extension-system-b-text-tertiary);
+  font-size: var(--extension-system-b-text-xs);
+  font-weight: 510;
+  line-height: 1.35;
 }
 
 .rail-title,
@@ -69,9 +115,9 @@ textarea {
 .entity-detail-title,
 .empty-title {
   margin: 0;
-  color: #12131a;
-  font-size: 15px;
-  font-weight: 620;
+  color: var(--extension-system-b-text-primary);
+  font-size: var(--extension-system-b-text-md);
+  font-weight: 590;
   line-height: 1.25;
 }
 
@@ -82,8 +128,8 @@ textarea {
 .status-message,
 .discovery-action {
   margin: 0;
-  color: rgba(18, 19, 26, 0.64);
-  font-size: 13px;
+  color: var(--extension-system-b-text-tertiary);
+  font-size: var(--extension-system-b-text-sm);
   line-height: 1.45;
 }
 
@@ -91,10 +137,9 @@ textarea {
   display: flex;
   flex: 1;
   flex-direction: column;
-  gap: 14px;
+  gap: var(--extension-system-b-space-4);
   overflow-y: auto;
-  padding: 16px;
-  padding-bottom: 132px;
+  padding: var(--extension-system-b-space-6);
 }
 
 .section,
@@ -106,33 +151,33 @@ textarea {
 }
 
 .stack-xs {
-  gap: 4px;
+  gap: var(--extension-system-b-space-1);
 }
 
 .stack-sm {
-  gap: 8px;
+  gap: var(--extension-system-b-space-2);
 }
 
 .stack-md {
-  gap: 12px;
+  gap: var(--extension-system-b-space-4);
 }
 
 .card,
 .entity-card,
 .action-tray,
 .prompt-dock {
-  border: 1px solid rgba(18, 19, 26, 0.08);
-  background: rgba(255, 255, 255, 0.92);
-  box-shadow: 0 12px 30px rgba(18, 19, 26, 0.06);
+  border: 1px solid var(--extension-system-b-border-subtle);
+  background: var(--extension-system-b-bg-surface-1);
+  box-shadow: var(--extension-system-b-shadow-card);
 }
 
 .card,
 .entity-card {
-  border-radius: 18px;
+  border-radius: var(--extension-system-b-radius-lg);
 }
 
 .card {
-  padding: 14px;
+  padding: var(--extension-system-b-space-5);
 }
 
 .entity-card {
@@ -140,34 +185,52 @@ textarea {
   width: 100%;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 12px;
+  gap: var(--extension-system-b-space-4);
+  padding: var(--extension-system-b-space-4);
   color: inherit;
   text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--extension-system-b-motion-fast)
+      var(--extension-system-b-ease),
+    background-color var(--extension-system-b-motion-fast)
+      var(--extension-system-b-ease);
+}
+
+.entity-card:hover {
+  border-color: var(--extension-system-b-border-default);
+  background: var(--extension-system-b-bg-surface-0);
+}
+
+.entity-card:focus-visible,
+.button:focus-visible,
+.prompt-button:focus-visible {
+  outline: 2px solid var(--extension-system-b-focus);
+  outline-offset: 2px;
 }
 
 .entity-card-active {
-  border-color: rgba(18, 19, 26, 0.18);
-  background: #ffffff;
+  border-color: var(--extension-system-b-border-strong);
+  background: var(--extension-system-b-bg-surface-1);
 }
 
 .entity-card-left {
   display: flex;
   min-width: 0;
   align-items: center;
-  gap: 12px;
+  gap: var(--extension-system-b-space-4);
 }
 
 .entity-image {
   display: flex;
-  height: 48px;
-  width: 48px;
+  height: var(--extension-system-b-field-thumb);
+  width: var(--extension-system-b-field-thumb);
   flex: none;
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  border-radius: 14px;
-  background: rgba(18, 19, 26, 0.05);
+  border-radius: var(--extension-system-b-radius-md);
+  background: var(--extension-system-b-bg-surface-0);
 }
 
 .entity-image img {
@@ -186,38 +249,38 @@ textarea {
 .entity-card-title,
 .field-label {
   margin: 0;
-  color: #12131a;
-  font-size: 13px;
-  font-weight: 600;
+  color: var(--extension-system-b-text-primary);
+  font-size: var(--extension-system-b-text-sm);
+  font-weight: 590;
   line-height: 1.35;
 }
 
 .entity-card-action {
-  color: rgba(18, 19, 26, 0.54);
-  font-size: 12px;
-  font-weight: 600;
+  color: var(--extension-system-b-text-quaternary);
+  font-size: var(--extension-system-b-text-xs);
+  font-weight: 510;
   white-space: nowrap;
 }
 
 .entity-detail-header {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: var(--extension-system-b-space-4);
 }
 
 .field-list {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: var(--extension-system-b-space-3);
 }
 
 .field-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding-top: 10px;
-  border-top: 1px solid rgba(18, 19, 26, 0.08);
+  gap: var(--extension-system-b-space-4);
+  border-top: 1px solid var(--extension-system-b-border-subtle);
+  padding-top: var(--extension-system-b-space-3);
 }
 
 .field-row:first-child {
@@ -230,8 +293,7 @@ textarea {
 }
 
 .preview-card {
-  border-color: rgba(18, 19, 26, 0.12);
-  background: #ffffff;
+  border-color: var(--extension-system-b-border-default);
 }
 
 .permission-card {
@@ -240,18 +302,22 @@ textarea {
 
 .permission-actions {
   display: flex;
-  gap: 10px;
+  gap: var(--extension-system-b-space-3);
+}
+
+.permission-actions .button {
+  flex: 1;
 }
 
 .preview-diff {
-  border-radius: 14px;
-  background: rgba(18, 19, 26, 0.04);
-  padding: 12px;
+  border-radius: var(--extension-system-b-radius-md);
+  background: var(--extension-system-b-bg-surface-0);
+  padding: var(--extension-system-b-space-4);
 }
 
 .preview-value {
-  margin: 6px 0 0;
-  color: #12131a;
+  margin: var(--extension-system-b-space-2) 0 0;
+  color: var(--extension-system-b-text-primary);
   font-size: 14px;
   line-height: 1.45;
   word-break: break-word;
@@ -264,36 +330,53 @@ textarea {
 
 .field-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--extension-system-b-space-2);
 }
 
 .button {
   display: inline-flex;
-  min-height: 40px;
+  min-height: var(--extension-system-b-action-height);
   align-items: center;
   justify-content: center;
-  border-radius: 12px;
-  border: 0;
-  padding: 0 14px;
-  font-size: 13px;
-  font-weight: 600;
+  border-radius: var(--extension-system-b-radius-sm);
+  border: 1px solid transparent;
+  padding: 0 var(--extension-system-b-space-4);
+  font-size: var(--extension-system-b-text-sm);
+  font-weight: 590;
   cursor: pointer;
+  transition:
+    border-color var(--extension-system-b-motion-fast)
+      var(--extension-system-b-ease),
+    background-color var(--extension-system-b-motion-fast)
+      var(--extension-system-b-ease),
+    color var(--extension-system-b-motion-fast) var(--extension-system-b-ease);
 }
 
 .button-primary {
-  background: #12131a;
-  color: #ffffff;
+  background: var(--extension-system-b-text-primary);
+  color: var(--extension-system-b-bg-surface-1);
+}
+
+.button-primary:hover {
+  background: var(--extension-system-b-text-secondary);
 }
 
 .button-secondary {
-  background: rgba(18, 19, 26, 0.08);
-  color: #12131a;
+  background: var(--extension-system-b-bg-surface-0);
+  color: var(--extension-system-b-text-primary);
+}
+
+.button-secondary:hover,
+.button-ghost:hover {
+  border-color: var(--extension-system-b-border-default);
+  background: var(--extension-system-b-bg-surface-2);
+  color: var(--extension-system-b-text-primary);
 }
 
 .button-ghost {
+  border-color: var(--extension-system-b-border-subtle);
   background: transparent;
-  color: rgba(18, 19, 26, 0.64);
-  border: 1px solid rgba(18, 19, 26, 0.08);
+  color: var(--extension-system-b-text-secondary);
 }
 
 .signed-out {
@@ -305,53 +388,78 @@ textarea {
 
 .signed-out-actions,
 .action-tray {
-  position: fixed;
-  right: 16px;
-  bottom: 16px;
-  left: 16px;
   display: flex;
-  gap: 10px;
-  border-radius: 18px;
-  padding: 12px;
+  min-height: var(--extension-system-b-dock-min-height);
+  gap: var(--extension-system-b-space-3);
+  border-radius: var(--extension-system-b-radius-lg);
+  margin: 0 var(--extension-system-b-dock-offset)
+    var(--extension-system-b-dock-offset);
+  padding: var(--extension-system-b-space-4);
+}
+
+.signed-out-actions .button,
+.action-tray .button {
+  flex: 1;
 }
 
 .action-tray {
-  background: rgba(255, 255, 255, 0.96);
+  box-shadow: var(--extension-system-b-shadow-dock);
+}
+
+.prompt-dock-stacked {
+  margin-bottom: var(--extension-system-b-space-3);
 }
 
 .prompt-dock {
-  position: fixed;
-  right: 16px;
-  bottom: 16px;
-  left: 16px;
-  border-radius: 20px;
-  background: rgba(255, 255, 255, 0.95);
-  padding: 10px 12px 12px;
+  display: flex;
+  min-height: var(--extension-system-b-dock-min-height);
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--extension-system-b-space-2);
+  border-radius: var(--extension-system-b-radius-lg);
+  margin: 0 var(--extension-system-b-dock-offset)
+    var(--extension-system-b-dock-offset);
+  padding: var(--extension-system-b-space-3) var(--extension-system-b-space-4);
+  box-shadow: var(--extension-system-b-shadow-dock);
 }
 
 .prompt-button {
   width: 100%;
-  border: 0;
-  border-radius: 14px;
-  background: rgba(18, 19, 26, 0.05);
-  padding: 14px;
-  color: rgba(18, 19, 26, 0.58);
+  border: 1px solid var(--extension-system-b-border-subtle);
+  border-radius: var(--extension-system-b-radius-sm);
+  background: var(--extension-system-b-bg-surface-0);
+  padding: var(--extension-system-b-space-4);
+  color: var(--extension-system-b-text-secondary);
   text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--extension-system-b-motion-fast)
+      var(--extension-system-b-ease),
+    background-color var(--extension-system-b-motion-fast)
+      var(--extension-system-b-ease);
+}
+
+.prompt-button:hover {
+  border-color: var(--extension-system-b-border-default);
+  background: var(--extension-system-b-bg-surface-2);
 }
 
 .empty-hero {
   display: flex;
-  min-height: 240px;
+  min-height: 220px;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  border-radius: 24px;
-  background:
-    radial-gradient(circle at center, rgba(18, 19, 26, 0.06), transparent 58%),
-    rgba(255, 255, 255, 0.6);
-  padding: 24px;
+  gap: var(--extension-system-b-space-3);
+  border: 1px solid var(--extension-system-b-border-subtle);
+  border-radius: var(--extension-system-b-radius-xl);
+  background: var(--extension-system-b-bg-surface-1);
+  padding: var(--extension-system-b-space-8);
   text-align: center;
+}
+
+.empty-hero .logo-mark {
+  color: var(--extension-system-b-text-quaternary);
 }
 
 .discovery-card {
@@ -360,22 +468,13 @@ textarea {
 
 .skeleton-card {
   min-height: 84px;
-  background: linear-gradient(
-    90deg,
-    rgba(18, 19, 26, 0.04),
-    rgba(18, 19, 26, 0.08),
-    rgba(18, 19, 26, 0.04)
-  );
-  background-size: 200% 100%;
-  animation: pulse 1.6s ease infinite;
+  background: var(--extension-system-b-bg-surface-1);
+  animation: pulse var(--extension-system-b-motion-base)
+    var(--extension-system-b-ease) infinite;
 }
 
 @keyframes pulse {
-  0% {
-    background-position: 200% 0;
-  }
-
-  100% {
-    background-position: -200% 0;
+  50% {
+    opacity: 0.56;
   }
 }

--- a/apps/extension/src/styles.test.ts
+++ b/apps/extension/src/styles.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const stylesPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  'styles.css'
+);
+const styles = readFileSync(stylesPath, 'utf8');
+const stylesWithoutComments = styles.replace(/\/\*[\s\S]*?\*\//g, '');
+const rootBlockMatch = stylesWithoutComments.match(/:root\s*{[\s\S]*?\n}/);
+const stylesOutsideRoot = stylesWithoutComments.replace(
+  /:root\s*{[\s\S]*?\n}/,
+  ''
+);
+
+describe('extension sidepanel System B styles', () => {
+  it('declares a local System B bridge token block', () => {
+    expect(rootBlockMatch?.[0]).toContain('--extension-system-b-bg-base');
+    expect(rootBlockMatch?.[0]).toContain('--extension-system-b-bg-surface-1');
+    expect(rootBlockMatch?.[0]).toContain('--extension-system-b-text-primary');
+    expect(rootBlockMatch?.[0]).toContain('--extension-system-b-border-subtle');
+    expect(rootBlockMatch?.[0]).toContain('--extension-system-b-radius-lg');
+    expect(rootBlockMatch?.[0]).toContain('--extension-system-b-dock-min-height');
+  });
+
+  it('keeps raw color literals inside the token bridge only', () => {
+    expect(stylesOutsideRoot).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    expect(stylesOutsideRoot).not.toMatch(/\brgba?\(/);
+  });
+
+  it('does not use decorative gradients or uppercase label styling', () => {
+    expect(stylesOutsideRoot).not.toMatch(/\b(?:linear|radial)-gradient\(/);
+    expect(stylesOutsideRoot).not.toMatch(/text-transform:\s*uppercase/);
+    expect(stylesOutsideRoot).not.toMatch(/letter-spacing:(?!\s*0\b)/);
+  });
+
+  it('uses tokens for radius and shadow recipes outside the token bridge', () => {
+    expect(stylesOutsideRoot).not.toMatch(/border-radius:(?!\s*var\()/);
+    expect(stylesOutsideRoot).not.toMatch(/box-shadow:(?!\s*var\()/);
+  });
+
+  it('reserves stable shell space for action and prompt docks', () => {
+    expect(styles).toContain('--extension-system-b-dock-min-height');
+    expect(styles).toContain(
+      'min-height: var(--extension-system-b-dock-min-height)'
+    );
+    expect(styles).toContain('.prompt-dock-stacked');
+    expect(stylesOutsideRoot).not.toMatch(/position:\s*fixed/);
+  });
+});

--- a/apps/extension/src/test-node-builtins.d.ts
+++ b/apps/extension/src/test-node-builtins.d.ts
@@ -1,0 +1,15 @@
+declare module 'node:fs' {
+  export function readFileSync(
+    path: string | URL,
+    encoding: 'utf8'
+  ): string;
+}
+
+declare module 'node:path' {
+  export function dirname(path: string): string;
+  export function resolve(...paths: string[]): string;
+}
+
+declare module 'node:url' {
+  export function fileURLToPath(url: string | URL): string;
+}


### PR DESCRIPTION
Refs JOV-2717.

Summary:
- Normalizes the Chrome extension sidepanel onto local System B bridge tokens for colors, borders, radii, spacing, typography, shadows, and motion.
- Removes decorative gradients, uppercase label styling, raw repeated visual literals, and fixed overlay docks.
- Moves action/sign-in docks into reserved bottom shell chrome so prompt/status UI does not collide with primary actions or content.
- Fixes the extension build script to clear stale tsbuildinfo when rebuilding `dist`, preventing a passing build with missing top-level extension JS.
- Adds an extension style guard test for raw visual drift and dock stability.

Verification:
- `./scripts/setup.sh`
- `pnpm --filter @jovie/extension test`
- `pnpm --filter @jovie/extension run typecheck`
- `pnpm --filter @jovie/extension run build && test -f apps/extension/dist/sidepanel.js && test -f apps/extension/dist/background.js && test -f apps/extension/dist/content.js`
- `pnpm turbo typecheck`
- `git diff --check`
- Pre-push hook: `biome check .`, proxy guard, Tailwind guard, web typecheck, web lint

Visual QA:
- Captured signed-out, ready, and insert-preview sidepanel states at 360x640 via Playwright against the built `dist/sidepanel.html` with mocked Chrome APIs.
- Metrics: no horizontal overflow; signed-out actions present with no prompt dock; ready/preview action dock bottom 624px in a 640px viewport; stable 504px scroll region; preview count 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidepanel layout with better content and action dock organization
  * Updated UI labels for clarity: "Page Context" and "Domain Access"

* **Style**
  * Refreshed extension UI styling with design system tokens
  * Updated loading and skeleton visual animations

* **Tests**
  * Added CSS validation test suite

* **Chores**
  * Updated build configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->