### PR TITLE
fix(ios): align native dashboard with System B

### DIFF
--- a/apps/ios/Jovie/DesignSystem/JovieTheme.swift
+++ b/apps/ios/Jovie/DesignSystem/JovieTheme.swift
@@ -2,19 +2,24 @@ import SwiftUI
 import UIKit
 
 enum JovieColor {
-  static let backgroundBase = Color(hex: 0x08090A)
-  static let surface0 = Color(hex: 0x0F1011)
-  static let surface1 = Color(hex: 0x17171A)
-  static let surface2 = Color(hex: 0x23252A)
-  static let surface3 = Color(hex: 0x2A2C32)
+  static let backgroundBase = Color(hex: 0x06070A)
+  static let surface0 = Color(hex: 0x0A0B0E)
+  static let surface1 = Color(hex: 0x101216)
+  static let surface2 = Color(hex: 0x161A20)
+  static let surface3 = Color(hex: 0x1F2430)
   static let textPrimary = Color(hex: 0xFFFFFF)
   static let textSecondary = Color(hex: 0xE3E4E6)
   static let textTertiary = Color(hex: 0x969799)
   static let borderSubtle = Color.white.opacity(0.05)
   static let borderDefault = Color.white.opacity(0.08)
   static let borderStrong = Color.white.opacity(0.10)
-  static let accent = Color(hex: 0x7170FF)
+  static let accentBlue = Color(hex: 0x0070F3)
+  static let accentPurple = Color(hex: 0x8B5CF6)
+  static let accentPink = Color(hex: 0xFF0080)
+  static let accent = accentBlue
+  static let progressTrack = accentBlue.opacity(0.08)
   static let errorText = Color(hex: 0xFF7A73)
+  static let qrSurface = Color.white
 }
 
 enum JovieFont {
@@ -53,6 +58,7 @@ enum JovieRadius {
   static let medium: CGFloat = 8
   static let large: CGFloat = 12
   static let xLarge: CGFloat = 16
+  static let pill: CGFloat = 999
 }
 
 private struct JovieSurfaceModifier: ViewModifier {
@@ -102,11 +108,11 @@ struct JoviePillButtonStyle: ButtonStyle {
       .frame(maxWidth: .infinity)
       .padding(.vertical, 14)
       .background(
-        RoundedRectangle(cornerRadius: 999, style: .continuous)
+        RoundedRectangle(cornerRadius: JovieRadius.pill, style: .continuous)
           .fill(filled ? Color.white : JovieColor.surface1)
       )
       .overlay {
-        RoundedRectangle(cornerRadius: 999, style: .continuous)
+        RoundedRectangle(cornerRadius: JovieRadius.pill, style: .continuous)
           .stroke(
             filled ? Color.clear : JovieColor.borderDefault,
             lineWidth: 1

--- a/apps/ios/Jovie/Features/Auth/AuthScreen.swift
+++ b/apps/ios/Jovie/Features/Auth/AuthScreen.swift
@@ -410,7 +410,7 @@ private struct ContinueInBrowserButton: View {
         if isOpening, !isDisabled {
           ProgressView()
             .controlSize(.small)
-            .tint(JovieColor.backgroundBase)
+            .tint(JovieColor.accentBlue)
         }
 
         Text(buttonTitle)

--- a/apps/ios/Jovie/Features/Dashboard/DashboardView.swift
+++ b/apps/ios/Jovie/Features/Dashboard/DashboardView.swift
@@ -156,17 +156,17 @@ struct DashboardView: View {
 
   private var skeleton: some View {
     VStack(spacing: JovieSpacing.large) {
-      RoundedRectangle(cornerRadius: 28, style: .continuous)
+      RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
         .fill(JovieColor.surface1)
         .frame(width: 280, height: 280)
-      RoundedRectangle(cornerRadius: 8, style: .continuous)
+      RoundedRectangle(cornerRadius: JovieRadius.small, style: .continuous)
         .fill(JovieColor.surface1)
         .frame(width: 180, height: 18)
       HStack(spacing: JovieSpacing.medium) {
-        RoundedRectangle(cornerRadius: 999, style: .continuous)
+        RoundedRectangle(cornerRadius: JovieRadius.pill, style: .continuous)
           .fill(JovieColor.surface1)
           .frame(height: 48)
-        RoundedRectangle(cornerRadius: 999, style: .continuous)
+        RoundedRectangle(cornerRadius: JovieRadius.pill, style: .continuous)
           .fill(JovieColor.surface1)
           .frame(height: 48)
       }
@@ -186,14 +186,20 @@ struct DashboardView: View {
             .resizable()
             .scaledToFit()
             .padding(24)
-            .background(Color.white, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+            .background(
+              JovieColor.qrSurface,
+              in: RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
+            )
             .accessibilityLabel("Profile QR Code")
         } else {
           Text("QR unavailable")
             .font(JovieFont.body(size: 15, weight: .medium))
             .foregroundStyle(JovieColor.textTertiary)
             .frame(width: 280, height: 280)
-            .background(JovieColor.surface1, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+            .background(
+              JovieColor.surface1,
+              in: RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
+            )
         }
       }
       .buttonStyle(.plain)


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2719 -->

## Summary
- Align native iOS System B surfaces with the canonical dark token range.
- Add named accent, QR surface, and pill-radius tokens, then use them in the native dashboard.
- Reapply the native auth opening spinner tint as a restrained System B accent.

## Verification
- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh` passed.
- XcodeBuildMCP `build_sim` passed on `Jovie` / `iPhone 17` / Debug with `CODE_SIGNING_ALLOWED=NO` in 56s, no warnings or errors.
- `CODE_SIGNING_ALLOWED=NO JOVIE_IOS_RESET_SIMULATOR=0 bash apps/ios/scripts/run-xcodebuild.sh test -only-testing:JovieTests` passed, 49 tests.
- `IOS_SCREENSHOT_REUSE_BUILD=1 IOS_SCREENSHOT_DERIVED_DATA=.build/xcodebuildmcp IOS_SCREENSHOT_REQUIRE_IPAD=0 bash apps/ios/scripts/capture-screenshots.sh` passed.
- Pre-push hook passed: `biome check .`, `tailwind:check`, web typecheck, web lint.

## Screenshot Evidence
Captured local artifacts under `artifacts/ios-screenshots/`:
- `00-loading.png` through `06-chat.png`, iPhone 1206 x 2622
- `07-ipad-shell.png`, iPad 1640 x 2360

Visual inspection covered signed-out auth, loaded profile QR, fullscreen QR, and iPad profile. No overlap or layout shift was observed; the dashboard keeps the same fixed QR and button frame dimensions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new accent colors (Blue, Purple, Pink) to the design system for enhanced visual variety.
  * Refined styling for buttons, QR code displays, and loading placeholders with improved design consistency throughout the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->