### PR TITLE
fix(chat): normalize rich chips and DSP stack

### DIFF
--- a/apps/web/app/exp/shell-v1/page.tsx
+++ b/apps/web/app/exp/shell-v1/page.tsx
@@ -175,6 +175,7 @@ import { ThreadVideoCard } from '@/components/shell/ThreadVideoCard';
 import { ThreadView as ShellThreadView } from '@/components/shell/ThreadView';
 import { Tooltip } from '@/components/shell/Tooltip';
 import { TypeBadge } from '@/components/shell/TypeBadge';
+import { DSP_CONFIGS } from '@/lib/dsp-registry';
 import { dropDateMeta } from '@/lib/format-drop-date';
 import { relativeDate as formatRelativeDate } from '@/lib/format-relative-date';
 // ---------------------------------------------------------------------------
@@ -853,10 +854,10 @@ const DSP_GLYPH: Record<DspKey, string> = {
   tidal: 'T',
 };
 const DSP_COLOR: Record<DspKey, string> = {
-  spotify: 'bg-emerald-500/90',
-  apple: 'bg-rose-400/90',
-  youtube: 'bg-red-500/90',
-  tidal: 'bg-sky-400/90',
+  spotify: DSP_CONFIGS.spotify.color,
+  apple: DSP_CONFIGS.apple_music.color,
+  youtube: DSP_CONFIGS.youtube_music.color,
+  tidal: DSP_CONFIGS.tidal.color,
 };
 // Calm DSP status dots — live is the default state and stays neutral.
 // Errors retain a clear rose so they read as needing attention.
@@ -873,7 +874,7 @@ function releaseDspItems(release: Release): DspAvatarItem[] {
     status: release.dsps[dsp],
     label: DSP_LABEL[dsp],
     glyph: DSP_GLYPH[dsp],
-    colorClass: DSP_COLOR[dsp],
+    color: DSP_COLOR[dsp],
   }));
 }
 

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/release-adapters.ts
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/release-adapters.ts
@@ -4,50 +4,50 @@ import type {
 } from '@/components/shell/DspAvatarStack';
 import type { ReleaseStatus } from '@/components/shell/StatusBadge';
 import type { ReleaseViewModel } from '@/lib/discography/types';
+import { DSP_CONFIGS } from '@/lib/dsp-registry';
 
 /**
  * Major DSPs surfaced in the shell-v1 release row's stacked avatars. Order
  * matches the visual sort: live providers come first regardless, but among
  * equal-status providers this is the tiebreaker.
  *
- * Glyph + colorClass per DSP — kept short (1 letter) so the 20px avatar
- * stays legible. Brand colors are ~70% saturation tokens shipped with
- * Tailwind so they harmonize with the dark surface.
+ * Glyph + brand color per DSP — kept short (1 letter) so the 20px avatar
+ * stays legible. Colors come from the canonical DSP registry.
  */
 const SHELL_DSP_META: ReadonlyArray<{
   readonly id: string;
   readonly providerKey: 'spotify' | 'apple_music' | 'youtube_music' | 'tidal';
   readonly label: string;
   readonly glyph: string;
-  readonly colorClass: string;
+  readonly color: string;
 }> = [
   {
     id: 'spotify',
     providerKey: 'spotify',
     label: 'Spotify',
     glyph: 'S',
-    colorClass: 'bg-emerald-500/90',
+    color: DSP_CONFIGS.spotify.color,
   },
   {
     id: 'apple_music',
     providerKey: 'apple_music',
     label: 'Apple Music',
     glyph: 'A',
-    colorClass: 'bg-rose-400/90',
+    color: DSP_CONFIGS.apple_music.color,
   },
   {
     id: 'youtube_music',
     providerKey: 'youtube_music',
     label: 'YouTube Music',
     glyph: 'Y',
-    colorClass: 'bg-red-500/90',
+    color: DSP_CONFIGS.youtube_music.color,
   },
   {
     id: 'tidal',
     providerKey: 'tidal',
     label: 'TIDAL',
     glyph: 'T',
-    colorClass: 'bg-sky-400/90',
+    color: DSP_CONFIGS.tidal.color,
   },
 ];
 
@@ -72,13 +72,13 @@ export function releaseToDspItems(release: ReleaseViewModel): DspAvatarItem[] {
         id: meta.id,
         label: meta.label,
         glyph: meta.glyph,
-        colorClass: meta.colorClass,
+        color: meta.color,
         status: providersByKey.has(meta.providerKey) ? 'live' : 'missing',
       }) satisfies {
         id: string;
         label: string;
         glyph: string;
-        colorClass: string;
+        color: string;
         status: DspStatus;
       }
   );

--- a/apps/web/components/jovie/components/EntityChip.test.tsx
+++ b/apps/web/components/jovie/components/EntityChip.test.tsx
@@ -98,8 +98,7 @@ describe('EntityChip', () => {
     );
     const chip = screen.getByTestId('entity-chip');
     expect(chip.getAttribute('data-entity-tone')).toBe('onLight');
-    // onLight uses #111216 (neutral) text — Option B from the plan gate.
-    expect(chip.className).toContain('#111216');
+    expect(chip).toHaveClass('system-b-entity-chip');
   });
 
   it('applies onDark tone classes by default', () => {

--- a/apps/web/components/jovie/components/EntityChip.tsx
+++ b/apps/web/components/jovie/components/EntityChip.tsx
@@ -4,7 +4,6 @@ import { X } from 'lucide-react';
 import Image from 'next/image';
 import { type CSSProperties } from 'react';
 import type { EntityKind } from '@/lib/chat/tokens';
-import { cn } from '@/lib/utils';
 
 export interface EntityChipData {
   readonly kind: EntityKind;
@@ -74,38 +73,9 @@ export function EntityChip({
     '--jovie-entity-accent': `var(${KIND_ACCENT_VAR[data.kind]})`,
   } as CSSProperties;
 
-  const transcriptOnDark =
-    'rounded-md border px-1.5 py-0.5 leading-5 border-[color:color-mix(in_srgb,var(--jovie-entity-accent)_22%,transparent)] bg-[color:color-mix(in_srgb,var(--jovie-entity-accent)_11%,transparent)] text-[color:color-mix(in_srgb,var(--jovie-entity-accent)_70%,white_30%)]';
-
-  // onLight: neutral text matching the user-bubble body color, with the
-  // saturated brand color living in the thumbnail/dot/border. Decided as
-  // Option B at plan gate so contrast stays consistent across all four
-  // kinds (purple/blue/pink/green) on white.
-  const transcriptOnLight =
-    'rounded-md border px-1.5 py-0.5 leading-5 border-[color:color-mix(in_srgb,var(--jovie-entity-accent)_30%,white)] bg-[color:color-mix(in_srgb,var(--jovie-entity-accent)_8%,white)] text-[#111216]';
-
-  const inputBase =
-    'h-7 max-w-[220px] shrink-0 cursor-default rounded-[9px] border border-[color:color-mix(in_srgb,var(--jovie-entity-accent)_30%,transparent)] bg-[color:color-mix(in_srgb,var(--jovie-entity-accent)_13%,transparent)] px-2 text-[13px] font-medium leading-none text-[color:color-mix(in_srgb,var(--jovie-entity-accent)_72%,white_28%)] shadow-[inset_0_1px_0_rgba(255,255,255,0.045)]';
-
-  const commonClassName = cn(
-    'inline-flex items-center gap-1.5 align-baseline select-none',
-    variant === 'input' && inputBase,
-    variant === 'transcript' &&
-      (tone === 'onLight' ? transcriptOnLight : transcriptOnDark)
-  );
+  const commonClassName = 'system-b-entity-chip';
 
   const thumbSize = variant === 'transcript' ? 16 : 14;
-  const thumbClassName =
-    variant === 'transcript'
-      ? 'h-4 w-4 rounded-sm object-cover shrink-0'
-      : 'h-3.5 w-3.5 rounded-sm object-cover shrink-0';
-
-  // Slightly larger dot for the transcript variant — 8px solid + soft halo so
-  // the chip still reads as a kind-tagged token even without artwork.
-  const dotClassName =
-    variant === 'transcript'
-      ? 'inline-block h-2 w-2 rounded-full shrink-0 bg-[var(--jovie-entity-accent)] shadow-[0_0_0_3px_color-mix(in_srgb,var(--jovie-entity-accent)_18%,transparent)]'
-      : 'inline-block h-1.5 w-1.5 rounded-full shrink-0 bg-[var(--jovie-entity-accent)] shadow-[0_0_0_3px_color-mix(in_srgb,var(--jovie-entity-accent)_12%,transparent)]';
 
   return (
     <span
@@ -124,11 +94,11 @@ export function EntityChip({
           alt=''
           width={thumbSize}
           height={thumbSize}
-          className={thumbClassName}
+          className='system-b-entity-chip-thumbnail'
           aria-hidden
         />
       ) : (
-        <span aria-hidden className={dotClassName} />
+        <span aria-hidden className='system-b-entity-chip-dot' />
       )}
       <span className='min-w-0 truncate'>{data.label}</span>
       {onRemove ? (
@@ -142,7 +112,7 @@ export function EntityChip({
             event.preventDefault();
             onRemove();
           }}
-          className='-mr-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm text-tertiary-token transition-colors duration-fast hover:bg-white/[0.07] hover:text-primary-token focus:outline-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30'
+          className='system-b-entity-chip-remove'
         >
           <X className='h-3 w-3' />
         </button>

--- a/apps/web/components/jovie/components/EntityChipPopover.tsx
+++ b/apps/web/components/jovie/components/EntityChipPopover.tsx
@@ -154,7 +154,7 @@ export function EntityChipPopover({
           onKeyDown={handleKeyDown}
           className={cn(
             'm-0 inline-flex cursor-pointer appearance-none items-baseline align-baseline border-0 bg-transparent p-0',
-            'rounded-md focus:outline-none focus-visible:outline-none focus-ring'
+            'rounded-full focus:outline-none focus-visible:outline-none focus-ring'
           )}
           data-testid='entity-chip-popover-trigger'
         >
@@ -219,13 +219,13 @@ function EntityChipPopoverBody({
             alt=''
             width={48}
             height={48}
-            className='h-12 w-12 rounded-md border border-subtle object-cover shadow-app-control'
+            className='h-12 w-12 rounded-xl border border-subtle object-cover shadow-app-control'
             aria-hidden
           />
         ) : (
           <div
             aria-hidden
-            className='flex h-12 w-12 items-center justify-center rounded-md border border-subtle bg-surface-1 text-app font-caption text-primary-token shadow-app-control'
+            className='flex h-12 w-12 items-center justify-center rounded-xl border border-subtle bg-surface-1 text-app font-caption text-primary-token shadow-app-control'
           >
             {getInitials(label) || '·'}
           </div>
@@ -250,7 +250,7 @@ function EntityChipPopoverBody({
           <button
             type='button'
             onClick={onOpenEntity}
-            className='mt-2 inline-flex items-center gap-1 rounded-md px-1 py-0.5 text-2xs font-caption text-secondary-token transition-colors duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token focus:outline-none focus-visible:outline-none focus-ring'
+            className='mt-2 inline-flex items-center gap-1 rounded-full px-1.5 py-0.5 text-2xs font-caption text-secondary-token transition-colors duration-fast ease-subtle hover:bg-surface-1 hover:text-primary-token focus:outline-none focus-visible:outline-none focus-ring'
           >
             Open {KIND_PREFIX[kind].toLowerCase()}
             <ArrowUpRight className='h-3 w-3' />

--- a/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx
@@ -92,39 +92,7 @@ const RELEASE_TYPE_LABELS: Record<string, string> = {
   other: 'Other',
 };
 
-const PROVIDER_COLOR_CLASS: Partial<Record<ProviderKey, string>> = {
-  spotify: 'bg-emerald-500/90',
-  apple_music: 'bg-rose-400/90',
-  youtube: 'bg-red-500/90',
-  youtube_music: 'bg-red-500/90',
-  soundcloud: 'bg-orange-400/90',
-  deezer: 'bg-violet-400/90',
-  tidal: 'bg-sky-400/90',
-  amazon_music: 'bg-blue-400/90',
-  bandcamp: 'bg-cyan-500/90',
-  beatport: 'bg-lime-400/90',
-  pandora: 'bg-blue-500/90',
-  napster: 'bg-indigo-400/90',
-  audiomack: 'bg-amber-400/90',
-  qobuz: 'bg-yellow-500/90',
-  anghami: 'bg-purple-400/90',
-  boomplay: 'bg-teal-500/90',
-  iheartradio: 'bg-red-600/90',
-  tiktok: 'bg-fuchsia-400/90',
-  amazon: 'bg-blue-400/90',
-  awa: 'bg-pink-400/90',
-  audius: 'bg-orange-500/90',
-  flo: 'bg-cyan-400/90',
-  gaana: 'bg-pink-500/90',
-  jio_saavn: 'bg-green-500/90',
-  joox: 'bg-emerald-400/90',
-  kkbox: 'bg-blue-600/90',
-  line_music: 'bg-green-400/90',
-  netease: 'bg-red-400/90',
-  qq_music: 'bg-green-600/90',
-  trebel: 'bg-amber-500/90',
-  yandex: 'bg-yellow-400/90',
-};
+const DEFAULT_DSP_COLOR = 'var(--color-text-quaternary-token)';
 
 function formatCooldown(remainingMs: number): string {
   if (remainingMs <= 0) return '';
@@ -277,7 +245,7 @@ function getDspAvatarItems(
       }),
       label,
       glyph: getProviderGlyph(label, provider.key),
-      colorClass: PROVIDER_COLOR_CLASS[provider.key] ?? 'bg-surface-2',
+      color: providerConfig[provider.key]?.accent ?? DEFAULT_DSP_COLOR,
     };
   });
 
@@ -290,7 +258,7 @@ function getDspAvatarItems(
         status: 'missing' as const,
         label,
         glyph: getProviderGlyph(label, key),
-        colorClass: PROVIDER_COLOR_CLASS[key] ?? 'bg-surface-2',
+        color: providerConfig[key]?.accent ?? DEFAULT_DSP_COLOR,
       };
     });
 

--- a/apps/web/components/shell/DspAvatarStack.test.tsx
+++ b/apps/web/components/shell/DspAvatarStack.test.tsx
@@ -8,21 +8,21 @@ const ITEMS: DspAvatarItem[] = [
     status: 'pending',
     label: 'Apple Music',
     glyph: 'A',
-    colorClass: 'bg-rose-500',
+    color: '#FA243C',
   },
   {
     id: 'spotify',
     status: 'live',
     label: 'Spotify',
     glyph: 'S',
-    colorClass: 'bg-emerald-500',
+    color: '#1DB954',
   },
   {
     id: 'youtube',
     status: 'missing',
     label: 'YouTube',
     glyph: 'Y',
-    colorClass: 'bg-red-500',
+    color: '#FF0000',
   },
 ];
 
@@ -56,6 +56,22 @@ describe('DspAvatarStack', () => {
 
   it('keeps the popover above shell chrome', () => {
     render(<DspAvatarStack dsps={ITEMS} />);
-    expect(screen.getByRole('tooltip').className).toContain('z-[150]');
+    expect(screen.getByRole('tooltip')).toHaveClass(
+      'system-b-dsp-avatar-stack-popover'
+    );
+  });
+
+  it('uses canonical DSP brand colors instead of Tailwind color classes', () => {
+    render(<DspAvatarStack dsps={ITEMS} />);
+
+    const primary = screen.getAllByText('S')[0];
+    const missing = screen.getAllByText('Y')[0];
+    const liveDot = document.querySelector('.system-b-dsp-status-dot-live');
+
+    expect(primary).toHaveStyle({ '--system-b-dsp-avatar-color': '#1DB954' });
+    expect(primary.className).not.toContain('bg-emerald');
+    expect(missing).toHaveStyle({ '--system-b-dsp-avatar-color': '#FF0000' });
+    expect(missing.className).toContain('opacity-45');
+    expect(liveDot?.className).not.toContain('bg-emerald');
   });
 });

--- a/apps/web/components/shell/DspAvatarStack.test.tsx
+++ b/apps/web/components/shell/DspAvatarStack.test.tsx
@@ -61,6 +61,20 @@ describe('DspAvatarStack', () => {
     );
   });
 
+  it('exposes the popover to keyboard focus without changing layout', () => {
+    render(<DspAvatarStack dsps={ITEMS} />);
+
+    const trigger = screen.getByLabelText('View DSP distribution details');
+    const popover = screen.getByRole('tooltip');
+
+    expect(trigger.tagName).toBe('BUTTON');
+    expect(trigger).toHaveAttribute('aria-describedby', popover.id);
+    expect(popover).toHaveClass('absolute');
+    expect(popover).toHaveClass('opacity-0');
+    expect(popover).toHaveClass('group-focus-within/dsps:opacity-100');
+    expect(popover).toHaveClass('group-focus-within/dsps:pointer-events-auto');
+  });
+
   it('uses canonical DSP brand colors instead of Tailwind color classes', () => {
     render(<DspAvatarStack dsps={ITEMS} />);
 

--- a/apps/web/components/shell/DspAvatarStack.tsx
+++ b/apps/web/components/shell/DspAvatarStack.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { CSSProperties } from 'react';
+import { type CSSProperties, useId } from 'react';
 import { cn } from '@/lib/utils';
 
 /**
@@ -78,6 +78,8 @@ export function DspAvatarStack({
   readonly dsps: readonly DspAvatarItem[];
   readonly className?: string;
 }) {
+  const popoverId = useId();
+
   if (dsps.length === 0) return null;
 
   const ordered = [...dsps].sort(
@@ -97,42 +99,50 @@ export function DspAvatarStack({
         className
       )}
     >
-      <span
-        className={cn(
-          'relative grid h-5 w-5 shrink-0 place-items-center rounded-full bg-(--system-b-dsp-avatar-color) text-3xs font-semibold text-white',
-          'ring-2 ring-(--system-b-bg-page)',
-          primary.status === 'missing'
-            ? 'opacity-40'
-            : 'opacity-75 transition-opacity duration-fast ease-subtle group-hover/dsps:opacity-95'
-        )}
-        style={primaryAvatarStyle}
+      <button
+        aria-describedby={popoverId}
+        aria-label='View DSP distribution details'
+        className='inline-flex items-center gap-1.5 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-(--system-b-bg-page)'
+        type='button'
       >
-        {primary.glyph}
-        {primary.status === 'pending' && (
-          <span
-            aria-hidden='true'
-            className='system-b-dsp-status-dot system-b-dsp-status-dot-pending absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-(--system-b-bg-page)'
-          />
-        )}
-        {primary.status === 'error' && (
-          <span
-            aria-hidden='true'
-            className='system-b-dsp-status-dot system-b-dsp-status-dot-error absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-(--system-b-bg-page)'
-          />
-        )}
-      </span>
-      {others > 0 && (
-        <span className='inline-flex h-5 items-center rounded-full border border-(--system-b-app-shell-border) bg-surface-1 px-1.5 text-3xs font-caption tabular-nums text-tertiary-token'>
-          +{others}
+        <span
+          className={cn(
+            'relative grid h-5 w-5 shrink-0 place-items-center rounded-full bg-(--system-b-dsp-avatar-color) text-3xs font-semibold text-white',
+            'ring-2 ring-(--system-b-bg-page)',
+            primary.status === 'missing'
+              ? 'opacity-40'
+              : 'opacity-75 transition-opacity duration-fast ease-subtle group-hover/dsps:opacity-95 group-focus-within/dsps:opacity-95'
+          )}
+          style={primaryAvatarStyle}
+        >
+          {primary.glyph}
+          {primary.status === 'pending' && (
+            <span
+              aria-hidden='true'
+              className='system-b-dsp-status-dot system-b-dsp-status-dot-pending absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-(--system-b-bg-page)'
+            />
+          )}
+          {primary.status === 'error' && (
+            <span
+              aria-hidden='true'
+              className='system-b-dsp-status-dot system-b-dsp-status-dot-error absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-(--system-b-bg-page)'
+            />
+          )}
         </span>
-      )}
+        {others > 0 && (
+          <span className='inline-flex h-5 items-center rounded-full border border-(--system-b-app-shell-border) bg-surface-1 px-1.5 text-3xs font-caption tabular-nums text-tertiary-token'>
+            +{others}
+          </span>
+        )}
+      </button>
 
       <div
+        id={popoverId}
         role='tooltip'
         className={cn(
           'system-b-dsp-avatar-stack-popover pointer-events-none absolute right-0 top-full mt-1.5 w-56',
-          'opacity-0 group-hover/dsps:opacity-100 group-hover/dsps:pointer-events-auto',
-          'transition-[opacity] duration-fast ease-subtle delay-[400ms] group-hover/dsps:delay-[400ms]'
+          'opacity-0 group-hover/dsps:opacity-100 group-hover/dsps:pointer-events-auto group-focus-within/dsps:opacity-100 group-focus-within/dsps:pointer-events-auto',
+          'transition-[opacity] duration-fast ease-subtle delay-[400ms] group-hover/dsps:delay-[400ms] group-focus-within/dsps:delay-0'
         )}
       >
         <div className='overflow-hidden rounded-xl border border-(--system-b-app-shell-border) bg-(--system-b-app-content-surface) shadow-popover backdrop-blur-xl'>

--- a/apps/web/components/shell/DspAvatarStack.tsx
+++ b/apps/web/components/shell/DspAvatarStack.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { CSSProperties } from 'react';
 import { cn } from '@/lib/utils';
 
 /**
@@ -14,7 +15,7 @@ export type DspStatus = 'live' | 'pending' | 'error' | 'missing';
 
 /**
  * One DSP entry passed to `DspAvatarStack`. Caller owns the brand metadata
- * (color class, single-letter glyph, full label) so the component stays
+ * (brand color, single-letter glyph, full label) so the component stays
  * generic — it has no opinion about which DSPs exist or what their brand
  * tokens are.
  */
@@ -23,15 +24,15 @@ export interface DspAvatarItem {
   readonly status: DspStatus;
   readonly label: string;
   readonly glyph: string;
-  /** Tailwind `bg-*` class used for the avatar fill at non-`missing` states. */
-  readonly colorClass: string;
+  /** Canonical DSP brand color. Missing states render this muted. */
+  readonly color: string;
 }
 
 const STATUS_DOT: Record<DspStatus, string> = {
-  live: 'bg-emerald-400',
-  pending: 'bg-amber-400',
-  error: 'bg-rose-500',
-  missing: 'bg-quaternary-token/60',
+  live: 'system-b-dsp-status-dot-live',
+  pending: 'system-b-dsp-status-dot-pending',
+  error: 'system-b-dsp-status-dot-error',
+  missing: 'system-b-dsp-status-dot-missing',
 };
 
 const STATUS_RANK: Record<DspStatus, number> = {
@@ -57,15 +58,15 @@ const STATUS_LABEL: Record<DspStatus, string> = {
  * preserves the input order's stability across renders.
  *
  * Pure presentational. The caller is expected to pre-define brand metadata
- * (`colorClass`, `glyph`, `label`) per DSP so the component has no built-in
+ * (`color`, `glyph`, `label`) per DSP so the component has no built-in
  * knowledge of specific DSPs.
  *
  * @example
  * ```tsx
  * <DspAvatarStack
  *   dsps={[
- *     { id: 'spotify', status: 'live', label: 'Spotify', glyph: 'S', colorClass: 'bg-emerald-500' },
- *     { id: 'apple', status: 'pending', label: 'Apple Music', glyph: 'A', colorClass: 'bg-rose-500' },
+ *     { id: 'spotify', status: 'live', label: 'Spotify', glyph: 'S', color: DSP_CONFIGS.spotify.color },
+ *     { id: 'apple', status: 'pending', label: 'Apple Music', glyph: 'A', color: DSP_CONFIGS.apple_music.color },
  *   ]}
  * />
  * ```
@@ -85,6 +86,9 @@ export function DspAvatarStack({
   const primary = ordered[0];
   const liveCount = ordered.filter(d => d.status === 'live').length;
   const others = Math.max(0, ordered.length - 1);
+  const primaryAvatarStyle = {
+    '--system-b-dsp-avatar-color': primary.color,
+  } as CSSProperties;
 
   return (
     <div
@@ -95,29 +99,30 @@ export function DspAvatarStack({
     >
       <span
         className={cn(
-          'relative h-[20px] w-[20px] rounded-full grid place-items-center text-[9px] font-semibold text-white shrink-0',
-          'ring-2 ring-(--linear-bg-page)',
+          'relative grid h-5 w-5 shrink-0 place-items-center rounded-full bg-(--system-b-dsp-avatar-color) text-3xs font-semibold text-white',
+          'ring-2 ring-(--system-b-bg-page)',
           primary.status === 'missing'
-            ? 'bg-quaternary-token/40 opacity-50'
-            : primary.colorClass
+            ? 'opacity-40'
+            : 'opacity-75 transition-opacity duration-fast ease-subtle group-hover/dsps:opacity-95'
         )}
+        style={primaryAvatarStyle}
       >
         {primary.glyph}
         {primary.status === 'pending' && (
           <span
             aria-hidden='true'
-            className='absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-amber-400 ring-1 ring-(--linear-bg-page)'
+            className='system-b-dsp-status-dot system-b-dsp-status-dot-pending absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-(--system-b-bg-page)'
           />
         )}
         {primary.status === 'error' && (
           <span
             aria-hidden='true'
-            className='absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-rose-500 ring-1 ring-(--linear-bg-page)'
+            className='system-b-dsp-status-dot system-b-dsp-status-dot-error absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full ring-1 ring-(--system-b-bg-page)'
           />
         )}
       </span>
       {others > 0 && (
-        <span className='inline-flex items-center h-5 px-1.5 rounded text-[10.5px] font-caption tabular-nums text-tertiary-token bg-(--surface-1)/70 border border-(--linear-app-shell-border)'>
+        <span className='inline-flex h-5 items-center rounded-full border border-(--system-b-app-shell-border) bg-surface-1 px-1.5 text-3xs font-caption tabular-nums text-tertiary-token'>
           +{others}
         </span>
       )}
@@ -125,47 +130,50 @@ export function DspAvatarStack({
       <div
         role='tooltip'
         className={cn(
-          'pointer-events-none absolute right-0 top-full mt-1.5 z-[150] w-[220px]',
+          'system-b-dsp-avatar-stack-popover pointer-events-none absolute right-0 top-full mt-1.5 w-56',
           'opacity-0 group-hover/dsps:opacity-100 group-hover/dsps:pointer-events-auto',
-          'transition-[opacity] duration-subtle ease-subtle delay-[400ms] group-hover/dsps:delay-[400ms]'
+          'transition-[opacity] duration-fast ease-subtle delay-[400ms] group-hover/dsps:delay-[400ms]'
         )}
       >
-        <div className='rounded-md border border-(--linear-app-shell-border) bg-(--linear-app-content-surface)/95 backdrop-blur-xl shadow-[0_8px_28px_rgba(0,0,0,0.32)] overflow-hidden'>
-          <div className='flex items-center justify-between px-2.5 h-7 border-b border-(--linear-app-shell-border)/60'>
-            <span className='text-[10px] uppercase tracking-[0.08em] text-quaternary-token font-semibold'>
+        <div className='overflow-hidden rounded-xl border border-(--system-b-app-shell-border) bg-(--system-b-app-content-surface) shadow-popover backdrop-blur-xl'>
+          <div className='flex h-7 items-center justify-between border-b border-(--system-b-app-shell-border) px-2.5'>
+            <span className='text-3xs font-semibold text-quaternary-token'>
               Distribution
             </span>
-            <span className='text-[10.5px] tabular-nums text-tertiary-token'>
+            <span className='text-3xs tabular-nums text-tertiary-token'>
               {liveCount}/{ordered.length} Live
             </span>
           </div>
-          <div className='max-h-[180px] overflow-y-auto'>
+          <div className='max-h-44 overflow-y-auto'>
             {ordered.map(dsp => (
               <div
                 key={dsp.id}
-                className='flex items-center gap-2 h-7 px-2.5 hover:bg-surface-1/40'
+                className='flex h-7 items-center gap-2 px-2.5 hover:bg-surface-1'
               >
                 <span
                   className={cn(
-                    'h-[14px] w-[14px] rounded-full grid place-items-center text-[8px] font-semibold text-white shrink-0',
-                    dsp.status === 'missing'
-                      ? 'bg-quaternary-token/40 opacity-60'
-                      : dsp.colorClass
+                    'grid h-3.5 w-3.5 shrink-0 place-items-center rounded-full bg-(--system-b-dsp-avatar-color) text-3xs font-semibold text-white',
+                    dsp.status === 'missing' ? 'opacity-45' : 'opacity-90'
                   )}
+                  style={
+                    {
+                      '--system-b-dsp-avatar-color': dsp.color,
+                    } as CSSProperties
+                  }
                 >
                   {dsp.glyph}
                 </span>
-                <span className='flex-1 text-[12px] text-secondary-token truncate'>
+                <span className='min-w-0 flex-1 truncate text-xs text-secondary-token'>
                   {dsp.label}
                 </span>
                 <span className='inline-flex items-center gap-1.5'>
                   <span
                     className={cn(
-                      'h-1.5 w-1.5 rounded-full',
+                      'system-b-dsp-status-dot h-1.5 w-1.5 rounded-full',
                       STATUS_DOT[dsp.status]
                     )}
                   />
-                  <span className='text-[10.5px] uppercase tracking-[0.06em] text-quaternary-token'>
+                  <span className='text-3xs text-quaternary-token'>
                     {STATUS_LABEL[dsp.status]}
                   </span>
                 </span>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2137,6 +2137,110 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
    SYSTEM B CHAT ENTITY PREVIEW PRIMITIVES
    ============================================ */
 
+.system-b-entity-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  border-radius: var(--radius-full);
+  user-select: none;
+  vertical-align: baseline;
+}
+
+.system-b-entity-chip[data-entity-variant="input"] {
+  flex-shrink: 0;
+  max-width: 220px;
+  height: 1.75rem;
+  cursor: default;
+  border: 1px solid
+    color-mix(in srgb, var(--jovie-entity-accent) 30%, transparent);
+  background: color-mix(in srgb, var(--jovie-entity-accent) 13%, transparent);
+  padding-inline: var(--space-2);
+  color: color-mix(in srgb, var(--jovie-entity-accent) 72%, white 28%);
+  font-size: var(--text-app);
+  font-weight: var(--font-weight-medium);
+  line-height: 1;
+}
+
+.system-b-entity-chip[data-entity-variant="transcript"] {
+  border: 1px solid
+    color-mix(in srgb, var(--jovie-entity-accent) 22%, transparent);
+  background: color-mix(in srgb, var(--jovie-entity-accent) 11%, transparent);
+  padding: var(--space-0-5) var(--space-1-5);
+  color: color-mix(in srgb, var(--jovie-entity-accent) 70%, white 30%);
+  line-height: 1.25rem;
+}
+
+.system-b-entity-chip[data-entity-variant="transcript"][data-entity-tone="onLight"] {
+  border-color: color-mix(in srgb, var(--jovie-entity-accent) 30%, white);
+  background: color-mix(in srgb, var(--jovie-entity-accent) 8%, white);
+  color: var(--system-b-entity-chip-on-light-text, #111216);
+}
+
+.system-b-entity-chip-thumbnail {
+  flex-shrink: 0;
+  border-radius: var(--radius-full);
+  object-fit: cover;
+}
+
+.system-b-entity-chip[data-entity-variant="input"]
+  .system-b-entity-chip-thumbnail {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.system-b-entity-chip[data-entity-variant="transcript"]
+  .system-b-entity-chip-thumbnail {
+  width: var(--space-4);
+  height: var(--space-4);
+}
+
+.system-b-entity-chip-dot {
+  display: inline-block;
+  flex-shrink: 0;
+  border-radius: var(--radius-full);
+  background: var(--jovie-entity-accent);
+}
+
+.system-b-entity-chip[data-entity-variant="input"] .system-b-entity-chip-dot {
+  width: var(--space-1-5);
+  height: var(--space-1-5);
+}
+
+.system-b-entity-chip[data-entity-variant="transcript"]
+  .system-b-entity-chip-dot {
+  width: var(--space-2);
+  height: var(--space-2);
+}
+
+.system-b-entity-chip-remove {
+  display: inline-flex;
+  width: var(--space-4);
+  height: var(--space-4);
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  margin-right: calc(var(--space-0-5) * -1);
+  border-radius: var(--radius-full);
+  color: var(--color-text-tertiary-token);
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+.system-b-entity-chip-remove:hover {
+  background: color-mix(in oklab, white 7%, transparent);
+  color: var(--color-text-primary-token);
+}
+
+.system-b-entity-chip-remove:focus,
+.system-b-entity-chip-remove:focus-visible {
+  outline: none;
+}
+
+.system-b-entity-chip-remove:focus-visible {
+  box-shadow: 0 0 0 1px color-mix(in oklab, white 30%, transparent);
+}
+
 .system-b-entity-chip-popover-content {
   z-index: 150;
   width: min(272px, calc(100vw - var(--space-6)));
@@ -2315,6 +2419,30 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-normal);
   text-transform: uppercase;
+}
+
+.system-b-dsp-status-dot-live {
+  background: color-mix(in oklab, var(--color-success) 72%, transparent);
+}
+
+.system-b-dsp-status-dot-pending {
+  background: color-mix(in oklab, var(--color-warning) 78%, transparent);
+}
+
+.system-b-dsp-status-dot-error {
+  background: color-mix(in oklab, var(--color-error) 82%, transparent);
+}
+
+.system-b-dsp-status-dot-missing {
+  background: color-mix(
+    in oklab,
+    var(--color-text-quaternary-token) 36%,
+    transparent
+  );
+}
+
+.system-b-dsp-avatar-stack-popover {
+  z-index: 150;
 }
 
 :where(.system-b-chat-generation-artifact-surface) {

--- a/apps/web/tests/unit/chat/TokenizedText.test.tsx
+++ b/apps/web/tests/unit/chat/TokenizedText.test.tsx
@@ -42,6 +42,6 @@ describe('TokenizedText', () => {
     const chip = screen.getByTestId('entity-chip');
     expect(chip).toHaveAttribute('data-entity-kind', 'artist');
     expect(chip).toHaveAttribute('data-entity-tone', 'onLight');
-    expect(chip.className).toContain('#111216');
+    expect(chip).toHaveClass('system-b-entity-chip');
   });
 });

--- a/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
@@ -7,8 +7,10 @@ const webRoot = path.resolve(__dirname, '../../..');
 const guardedFiles = [
   'components/jovie/components/ChatGenerationArtifactSurface.tsx',
   'components/jovie/components/ChatPitchCard.tsx',
+  'components/jovie/components/EntityChip.tsx',
   'components/jovie/components/EntityChipPopover.tsx',
   'components/jovie/components/EntityPreviewPane.tsx',
+  'components/shell/DspAvatarStack.tsx',
 ];
 
 const rawVisualPatterns = [
@@ -22,7 +24,7 @@ const rawVisualPatterns = [
 ];
 
 describe('entity rich chip System B style guard', () => {
-  it('keeps touched chip, preview, and artifact visuals on named primitives', () => {
+  it('keeps touched chip, preview, DSP, and artifact visuals on named primitives', () => {
     for (const file of guardedFiles) {
       const source = readFileSync(path.join(webRoot, file), 'utf8');
       const offenders = rawVisualPatterns


### PR DESCRIPTION
## Summary

- Normalize `EntityChip` rendering behind System B CSS selectors instead of inline rich utility/color-mix strings.
- Tighten `EntityChipPopover` geometry to the System B chip/popover shape.
- Move `DspAvatarStack` from Tailwind brand classes to canonical DSP color values and System B status selectors.
- Update the three DSP stack call sites required by the prop contract change.

Linear: [JOV-2720](https://linear.app/jovie/issue/JOV-2720/package-web-rich-chips-and-dsp-stack-system-b-slice)

<!-- linear-issue-id: aa02af64-3923-4322-8c6c-34105b166c4c -->
<!-- linear-issue-identifier: JOV-2720 -->

## Verification

- `pnpm --filter web exec vitest run components/jovie/components/EntityChip.test.tsx components/jovie/components/EntityChipPopover.test.tsx components/shell/DspAvatarStack.test.tsx tests/unit/chat/entity-rich-chip-style-guard.test.ts`
  - 4 files passed, 28 tests passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
  - passed.
- `pnpm biome check --write apps/web/app/exp/shell-v1/page.tsx apps/web/components/features/dashboard/organisms/release-provider-matrix/shell-releases/release-adapters.ts apps/web/components/jovie/components/EntityChip.tsx apps/web/components/jovie/components/EntityChipPopover.tsx apps/web/components/jovie/components/EntityChip.test.tsx apps/web/components/jovie/components/EntityChipPopover.test.tsx apps/web/components/organisms/release-sidebar/ReleaseSidebar.tsx apps/web/components/shell/DspAvatarStack.tsx apps/web/components/shell/DspAvatarStack.test.tsx apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts apps/web/styles/design-system.css`
  - checked 11 files, no fixes applied.
- `git diff --check`
  - passed.
- Pre-commit hook
  - `next:proxy-guard`, lint-staged Biome, ESLint, a11y staged check, and local web typecheck passed.
- Pre-push hook
  - `biome check .`, `next:proxy-guard`, Tailwind guard, web typecheck, and web Biome lint passed.
- Browser proof
  - `PORT=3100 pnpm run dev:web:browse`
  - `/exp/shell-v1` Releases view rendered 12 DSP stacks and 12 DSP popovers after warm compile.
  - Captured local screenshot proof at `/tmp/jovie-system-b-proof/dsp-stack-popover-open.png`.

## Notes

- `/exp/shell-v1` currently mounts `DspAvatarStack` but does not mount `EntityChip` or `EntityChipPopover`, so browser proof covers the DSP stack/popover on that route. Chip/popover behavior is covered by focused component tests and the rich-chip style guard.
- `pnpm run dev:web:fast` failed before startup with `scripts/dev-web-fast.sh: line 71: ENV_UNSET_ARGS[@]: unbound variable`; tracked separately as [JOV-2721](https://linear.app/jovie/issue/JOV-2721/fix-devwebfast-empty-env-unset-args-startup-path). Screenshot proof used the working `dev:web:browse` wrapper.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated DSP avatars to display consistent brand colors for Spotify, Apple Music, YouTube, and Tidal
  * Refined entity chip styling with improved visual appearance
  * Adjusted component border radius for better visual consistency
  * Enhanced status indicator styling for release availability states (live, pending, error, missing)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JovieInc/Jovie/pull/9950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->