### PR TITLE
fix(web): normalize global error system b fallback

### DIFF
--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -1,6 +1,10 @@
 'use client';
 
+import './globals.css';
 import { useEffect } from 'react';
+
+const JOVIE_MARK_PATH =
+  'm176.84,0l3.08.05c8.92,1.73,16.9,6.45,23.05,13.18,7.95,8.7,12.87,20.77,12.87,34.14s-4.92,25.44-12.87,34.14c-6.7,7.34-15.59,12.28-25.49,13.57h-.64s0,.01,0,.01h0c-22.2,0-42.3,8.84-56.83,23.13-14.5,14.27-23.49,33.99-23.49,55.77h0v.02c0,21.78,8.98,41.5,23.49,55.77,14.54,14.3,34.64,23.15,56.83,23.15v-.02h.01c22.2,0,42.3-8.84,56.83-23.13,14.51-14.27,23.49-33.99,23.49-55.77h0c0-17.55-5.81-33.75-15.63-46.82-10.08-13.43-24.42-23.61-41.05-28.62l-2.11-.64c4.36-2.65,8.34-5.96,11.84-9.78,9.57-10.47,15.5-24.89,15.5-40.77s-5.93-30.3-15.5-40.77c-1.44-1.57-2.95-3.06-4.55-4.44l7.67,1.58c40.44,8.35,75.81,30.3,100.91,60.75,24.66,29.91,39.44,68.02,39.44,109.5h0c0,48.05-19.81,91.55-51.83,123.05-31.99,31.46-76.19,50.92-125,50.92v.02h-.01c-48.79,0-93-19.47-125-50.94C19.81,265.54,0,222.04,0,173.99h0c0-48.05,19.81-91.56,51.83-123.05C83.84,19.47,128.04,0,176.84,0Z';
 
 /**
  * Global error page for Next.js App Router.
@@ -30,174 +34,57 @@ export default function GlobalError({
   }, [error]);
 
   return (
-    <html lang='en'>
+    <html lang='en' className='dark' suppressHydrationWarning>
       <head>
         <meta
           name='viewport'
           content='width=device-width, initial-scale=1, viewport-fit=cover'
         />
-        <style
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: Required for dynamic CSS injection
-          dangerouslySetInnerHTML={{
-            __html: `
-              :root {
-                --global-error-bg: black;
-                --global-error-fg: white;
-                --global-error-muted: color-mix(in oklab, currentColor 58%, transparent);
-                --global-error-subtle: color-mix(in oklab, currentColor 38%, transparent);
-                --global-error-border: color-mix(in oklab, currentColor 12%, transparent);
-                --global-error-border-hover: color-mix(in oklab, currentColor 18%, transparent);
-                --global-error-control-hover: color-mix(in oklab, currentColor 8%, transparent);
-              }
-
-              *, *::before, *::after {
-                box-sizing: border-box;
-                margin: 0;
-                padding: 0;
-              }
-
-              body {
-                font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-                font-feature-settings: "cv01", "ss03";
-                background-color: var(--global-error-bg);
-                color: var(--global-error-fg);
-                min-height: 100dvh;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                padding: 24px;
-                padding-bottom: max(24px, env(safe-area-inset-bottom));
-                padding-left: max(24px, env(safe-area-inset-left));
-                padding-right: max(24px, env(safe-area-inset-right));
-                -webkit-font-smoothing: antialiased;
-              }
-
-              .container {
-                width: 100%;
-                max-width: 320px;
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-                text-align: center;
-              }
-
-              .logo {
-                display: flex;
-                justify-content: center;
-              }
-
-              .logo svg {
-                width: 32px;
-                height: 32px;
-              }
-
-              h1 {
-                margin-top: 20px;
-                font-size: 18px;
-                font-weight: 590;
-                letter-spacing: -0.02em;
-                line-height: 1.3;
-              }
-
-              .description {
-                margin-top: 8px;
-                font-size: 14px;
-                line-height: 1.5;
-                color: var(--global-error-muted);
-              }
-
-              .actions {
-                margin-top: 24px;
-                display: flex;
-                flex-direction: row;
-                align-items: center;
-                justify-content: center;
-                gap: 12px;
-              }
-
-              .btn {
-                display: inline-flex;
-                align-items: center;
-                justify-content: center;
-                height: 36px;
-                padding: 0 16px;
-                font-size: 14px;
-                font-weight: 500;
-                border-radius: 9999px;
-                border: none;
-                cursor: pointer;
-                text-decoration: none;
-                transition: background 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94),
-                            border-color 150ms cubic-bezier(0.25, 0.46, 0.45, 0.94);
-                -webkit-tap-highlight-color: transparent;
-              }
-
-              .btn:focus-visible {
-                outline: 2px solid currentColor;
-                outline-offset: 2px;
-              }
-
-              .btn:active {
-                transform: scale(0.97);
-              }
-
-              .btn-primary {
-                background: var(--global-error-fg);
-                color: var(--global-error-bg);
-              }
-
-              .btn-primary:hover {
-                background: var(--global-error-fg);
-              }
-
-              .btn-secondary {
-                background: transparent;
-                color: var(--global-error-muted);
-                border: 1px solid var(--global-error-border);
-              }
-
-              .btn-secondary:hover {
-                background: var(--global-error-control-hover);
-                border-color: var(--global-error-border-hover);
-              }
-
-              .error-id {
-                margin-top: 20px;
-                font-size: 12px;
-                color: var(--global-error-subtle);
-              }
-            `,
-          }}
-        />
       </head>
-      <body>
-        <div className='container'>
-          <div className='logo'>
+      <body className='min-h-dvh bg-base font-sans text-primary-token antialiased'>
+        <main className='flex min-h-dvh items-center justify-center px-6'>
+          <div className='flex w-full max-w-xs flex-col items-center text-center'>
             <svg
               viewBox='0 0 353.68 347.97'
-              fill='currentColor'
+              fill='none'
               xmlns='http://www.w3.org/2000/svg'
               aria-hidden='true'
+              className='h-8 w-8'
             >
-              <path d='m176.84,0l3.08.05c8.92,1.73,16.9,6.45,23.05,13.18,7.95,8.7,12.87,20.77,12.87,34.14s-4.92,25.44-12.87,34.14c-6.7,7.34-15.59,12.28-25.49,13.57h-.64s0,.01,0,.01h0c-22.2,0-42.3,8.84-56.83,23.13-14.5,14.27-23.49,33.99-23.49,55.77h0v.02c0,21.78,8.98,41.5,23.49,55.77,14.54,14.3,34.64,23.15,56.83,23.15v-.02h.01c22.2,0,42.3-8.84,56.83-23.13,14.51-14.27,23.49-33.99,23.49-55.77h0c0-17.55-5.81-33.75-15.63-46.82-10.08-13.43-24.42-23.61-41.05-28.62l-2.11-.64c4.36-2.65,8.34-5.96,11.84-9.78,9.57-10.47,15.5-24.89,15.5-40.77s-5.93-30.3-15.5-40.77c-1.44-1.57-2.95-3.06-4.55-4.44l7.67,1.58c40.44,8.35,75.81,30.3,100.91,60.75,24.66,29.91,39.44,68.02,39.44,109.5h0c0,48.05-19.81,91.55-51.83,123.05-31.99,31.46-76.19,50.92-125,50.92v.02h-.01c-48.79,0-93-19.47-125-50.94C19.81,265.54,0,222.04,0,173.99h0c0-48.05,19.81-91.56,51.83-123.05C83.84,19.47,128.04,0,176.84,0Z' />
+              <path fill='currentColor' d={JOVIE_MARK_PATH} />
             </svg>
+
+            <h1 className='mt-5 text-lg font-semibold leading-snug tracking-normal'>
+              Something Went Wrong
+            </h1>
+            <p className='mt-2 text-sm leading-normal text-tertiary-token'>
+              An unexpected error occurred.
+            </p>
+
+            <div className='mt-6 flex flex-row items-center gap-3'>
+              <button
+                type='button'
+                onClick={reset}
+                className='focus-ring-transparent-offset h-9 cursor-pointer rounded-full bg-btn-primary px-4 text-sm font-medium text-btn-primary-foreground transition-opacity duration-subtle hover:opacity-95'
+              >
+                Try Again
+              </button>
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Using <a> for resilience when Next.js routing may be broken */}
+              <a
+                href='/'
+                className='focus-ring-transparent-offset flex h-9 items-center rounded-full border border-subtle bg-transparent px-4 text-sm font-medium text-tertiary-token transition-colors duration-subtle hover:border-default hover:bg-surface-0'
+              >
+                Go Home
+              </a>
+            </div>
+
+            {error.digest ? (
+              <p className='mt-5 text-xs text-quaternary-token'>
+                Error ID: {error.digest}
+              </p>
+            ) : null}
           </div>
-
-          <h1>Something Went Wrong</h1>
-          <p className='description'>An unexpected error occurred.</p>
-
-          <div className='actions'>
-            <button type='button' onClick={reset} className='btn btn-primary'>
-              Try Again
-            </button>
-            {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Using <a> intentionally in global error boundary for resilience when routing may be broken */}
-            <a href='/' className='btn btn-secondary'>
-              Go Home
-            </a>
-          </div>
-
-          {error.digest && <p className='error-id'>Error ID: {error.digest}</p>}
-        </div>
+        </main>
       </body>
     </html>
   );

--- a/apps/web/tests/unit/app/global-error-system-b-source.test.ts
+++ b/apps/web/tests/unit/app/global-error-system-b-source.test.ts
@@ -11,6 +11,13 @@ const hashMark = String.fromCharCode(35);
 const colorFunctionName = ['r', 'g', 'b', 'a'].join('');
 const hardcodedHashColorPattern = new RegExp(`${hashMark}[\\da-fA-F]{3,8}\\b`);
 const rawAlphaColorPattern = new RegExp(`${colorFunctionName}\\s*\\(`, 'i');
+const rawColorMixPattern = /color-mix\(/i;
+const gradientPattern = ['linear', 'gradient|radial', 'gradient'].join('-');
+const rawGradientPattern = new RegExp(gradientPattern, 'i');
+const rawVisualUtilityPattern =
+  /\b(?:bg|border|text|ring|shadow|outline|rounded|h|w|max-w|min-h|min-w|tracking|leading|px|py|pt|pb)-\[/;
+const negativeTrackingPattern = /\btracking-(?:tight|tighter)\b/;
+const positionalMotionPattern = /\b(?:active:)?scale-|transform:\s*scale/i;
 const hardcodedSvgFillPattern = new RegExp(
   `fill=(['"])${hashMark}[\\da-fA-F]{3,8}\\1`
 );
@@ -21,7 +28,18 @@ describe('Global error System B source tokens', () => {
 
     expect(source).not.toMatch(hardcodedHashColorPattern);
     expect(source).not.toMatch(rawAlphaColorPattern);
+    expect(source).not.toMatch(rawColorMixPattern);
+    expect(source).not.toMatch(rawGradientPattern);
+    expect(source).not.toMatch(rawVisualUtilityPattern);
+    expect(source).not.toMatch(negativeTrackingPattern);
+    expect(source).not.toMatch(positionalMotionPattern);
     expect(source).not.toMatch(hardcodedSvgFillPattern);
+    expect(source).not.toContain('--global-error');
+    expect(source).not.toContain('dangerouslySetInnerHTML');
+    expect(source).not.toContain('biome-ignore');
+    expect(source).toContain("import './globals.css';");
     expect(source).toContain("fill='currentColor'");
+    expect(source).toContain("className='dark'");
+    expect(source).toContain('focus-ring-transparent-offset');
   });
 });


### PR DESCRIPTION
## Summary
- Replace the root `global-error.tsx` inline CSS island with the same compact System B fallback structure used by `app/error.tsx`.
- Import `globals.css` in `global-error.tsx` so the boundary still has token classes when it replaces the root layout.
- Expand the source guard to block raw colors, `color-mix`, arbitrary visual utilities, negative tracking, local `--global-error` variables, `dangerouslySetInnerHTML`, `biome-ignore`, and scale motion.

Linear: JOV-2722

## Verification
- `pnpm biome check --write apps/web/app/global-error.tsx apps/web/tests/unit/app/global-error-system-b-source.test.ts`
- `pnpm --filter web exec vitest run tests/unit/app/global-error-system-b-source.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web run build`
- Push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`
- Source scan: no matches for `--global-error`, `dangerouslySetInnerHTML`, `biome-ignore`, hardcoded hex, `rgba`, `color-mix`, scale motion, negative tracking, or arbitrary visual color/spacing utilities in `apps/web/app/global-error.tsx`.

## Visual Proof
- Production fallback capture used a temporary local root-layout throw hook, then removed before commit.
- Desktop: `.gstack/design-reports/screenshots/global-error-jov-2722-production-header-desktop.png` — HTTP 500, overlayCount 0, `body` background `rgb(6, 7, 10)`, Jovie mark 32x32, H1 18px.
- Mobile: `.gstack/design-reports/screenshots/global-error-jov-2722-production-header-mobile.png` — HTTP 500, overlayCount 0, same compact centered hierarchy.
- Layout states audited: digest present and digest absent. The digest is the final line, so its presence does not push subsequent content; controls keep fixed height and spacing across desktop/mobile.