### PR TITLE
fix(web): normalize pricing system b contract

### DIFF
--- a/apps/web/app/(marketing)/pricing/page.tsx
+++ b/apps/web/app/(marketing)/pricing/page.tsx
@@ -124,64 +124,54 @@ function PricingStoryCard({
   body: string;
 }>) {
   return (
-    <article className='rounded-[1.25rem] border border-white/10 bg-white/[0.03] p-5 sm:p-6'>
-      <p className='text-[12px] font-semibold tracking-[0.08em] text-tertiary-token'>
-        {label}
-      </p>
-      <h2 className='mt-3 text-[1.35rem] font-semibold tracking-[-0.035em] text-primary-token'>
-        {headline}
-      </h2>
-      <p className='mt-3 text-[14px] leading-[1.65] text-secondary-token'>
-        {body}
-      </p>
+    <article className='system-b-pricing-story-card'>
+      <p className='system-b-pricing-story-label'>{label}</p>
+      <h2 className='system-b-pricing-story-title'>{headline}</h2>
+      <p className='system-b-pricing-story-body'>{body}</p>
     </article>
   );
 }
 
 export default function PricingPage() {
   return (
-    <MarketingPageShell>
+    <MarketingPageShell className='system-b-pricing-page'>
       <script type='application/ld+json'>
         {safeJsonLdStringify(PRICING_SCHEMA)}
       </script>
 
       <section
         aria-labelledby='pricing-hero-heading'
-        className='pb-16 pt-[5.9rem] sm:pb-20 sm:pt-[6.4rem] lg:pb-24'
+        className='system-b-pricing-hero'
       >
         <MarketingContainer width='page'>
-          <div className='grid gap-10 lg:grid-cols-[minmax(0,0.82fr)_minmax(0,1.18fr)] lg:items-start'>
-            <div className='max-w-[33rem]'>
-              <h1
-                id='pricing-hero-heading'
-                className='marketing-h1-linear text-primary-token'
-              >
+          <div className='system-b-pricing-hero-grid'>
+            <div className='system-b-pricing-hero-copy'>
+              <h1 id='pricing-hero-heading' className='system-b-pricing-title'>
                 Pricing
               </h1>
-              <p className='marketing-lead-linear mt-5 max-w-[30rem] text-secondary-token'>
+              <p className='system-b-pricing-lead'>
                 Artist profiles are free forever. Pro adds the release tools
                 when you need them.
               </p>
-              <p className='mt-6 text-[13px] font-medium tracking-[-0.01em] text-tertiary-token'>
-                {accessCopy}
-              </p>
-              <div className='mt-7 flex flex-wrap items-center gap-3'>
+              <p className='system-b-pricing-note'>{accessCopy}</p>
+              <div className='system-b-pricing-actions'>
                 <Link
                   href={`${APP_ROUTES.SIGNUP}?plan=free`}
-                  className='public-action-primary'
+                  className='system-b-pricing-primary-link'
+                  data-primary-action='true'
                 >
                   Claim your profile
                 </Link>
                 <Link
                   href={APP_ROUTES.ARTIST_PROFILES}
-                  className='public-action-secondary'
+                  className='system-b-pricing-secondary-link'
                 >
                   Explore Artist Profiles
                 </Link>
               </div>
             </div>
 
-            <div className='grid gap-4 md:grid-cols-2'>
+            <div className='system-b-pricing-story-grid'>
               {STORY_CARDS.map(card => (
                 <PricingStoryCard
                   key={card.label}
@@ -193,31 +183,31 @@ export default function PricingPage() {
             </div>
           </div>
 
-          <div className='mt-12'>
-            <MarketingPricingPlans mode='expanded' />
+          <div className='system-b-pricing-plans'>
+            <MarketingPricingPlans ctaVariant='secondary' mode='expanded' />
           </div>
         </MarketingContainer>
       </section>
 
       <section
         aria-labelledby='pricing-compare-heading'
-        className='border-t border-subtle py-20 md:py-24'
+        className='system-b-pricing-section'
       >
         <MarketingContainer width='page'>
-          <div className='mx-auto max-w-[58rem]'>
-            <div className='max-w-[30rem]'>
+          <div className='system-b-pricing-section-inner'>
+            <div className='system-b-pricing-section-copy'>
               <h2
                 id='pricing-compare-heading'
-                className='text-[clamp(2.15rem,3.6vw,3.25rem)] font-semibold tracking-[-0.04em] text-primary-token'
+                className='system-b-pricing-section-title'
               >
                 Compare all features
               </h2>
-              <p className='mt-4 text-[15px] leading-[1.7] text-secondary-token'>
+              <p className='system-b-pricing-section-body'>
                 See the plan matrix for notifications, analytics, contacts,
                 smart links, and release workspace capabilities.
               </p>
             </div>
-            <div className='mt-10'>
+            <div className='system-b-pricing-chart-wrap'>
               <PricingComparisonChart />
             </div>
           </div>
@@ -226,31 +216,29 @@ export default function PricingPage() {
 
       <section
         aria-labelledby='pricing-get-started-heading'
-        className='border-t border-subtle py-20 md:py-28'
+        className='system-b-pricing-final'
       >
         <MarketingContainer width='page'>
-          <div className='text-center'>
+          <div>
             <h2
               id='pricing-get-started-heading'
-              className='text-[clamp(2.1rem,3.6vw,3.25rem)] font-semibold tracking-[-0.04em] text-primary-token'
+              className='system-b-pricing-section-title'
             >
               Get Started
             </h2>
-            <p className='mx-auto mt-4 max-w-[30rem] text-[15px] leading-[1.7] text-secondary-token'>
-              {requestAccessCopy}
-            </p>
-            <div className='mt-8 flex flex-wrap items-center justify-center gap-3'>
+            <p className='system-b-pricing-final-copy'>{requestAccessCopy}</p>
+            <div className='system-b-pricing-actions system-b-pricing-actions--center'>
               <Link
                 href={`${APP_ROUTES.SIGNUP}?plan=free`}
                 prefetch={false}
-                className='public-action-primary'
+                className='system-b-pricing-secondary-link'
               >
                 Claim your profile
               </Link>
               <Link
                 href={`${APP_ROUTES.SIGNUP}?plan=pro`}
                 prefetch={false}
-                className='public-action-secondary'
+                className='system-b-pricing-secondary-link'
               >
                 Start Pro trial
               </Link>

--- a/apps/web/components/features/pricing/MarketingPricingPlans.tsx
+++ b/apps/web/components/features/pricing/MarketingPricingPlans.tsx
@@ -10,11 +10,14 @@ import {
 import { cn } from '@/lib/utils';
 
 type MarketingPricingMode = 'compact' | 'expanded';
+type MarketingPricingCtaVariant = 'primary' | 'secondary';
 
 function MarketingPricingPlanCard({
+  ctaVariant,
   mode,
   plan,
 }: Readonly<{
+  ctaVariant: MarketingPricingCtaVariant;
   mode: MarketingPricingMode;
   plan: MarketingPricingPlan;
 }>) {
@@ -50,7 +53,12 @@ function MarketingPricingPlanCard({
       <Link
         href={getMarketingPlanHref(plan.id)}
         prefetch={false}
-        className='marketing-pricing-plan-card__cta public-action-primary focus-ring-themed'
+        className={cn(
+          'marketing-pricing-plan-card__cta focus-ring-themed',
+          ctaVariant === 'primary'
+            ? 'public-action-primary'
+            : 'public-action-secondary'
+        )}
       >
         {getMarketingPlanCtaLabel(plan)}
       </Link>
@@ -68,9 +76,11 @@ function MarketingPricingPlanCard({
 }
 
 export function MarketingPricingPlans({
+  ctaVariant = 'primary',
   mode = 'compact',
   className,
 }: Readonly<{
+  ctaVariant?: MarketingPricingCtaVariant;
   mode?: MarketingPricingMode;
   className?: string;
 }>) {
@@ -85,7 +95,12 @@ export function MarketingPricingPlans({
       )}
     >
       {visiblePlans.map(plan => (
-        <MarketingPricingPlanCard key={plan.id} mode={mode} plan={plan} />
+        <MarketingPricingPlanCard
+          ctaVariant={ctaVariant}
+          key={plan.id}
+          mode={mode}
+          plan={plan}
+        />
       ))}
     </div>
   );

--- a/apps/web/components/features/pricing/PricingComparisonChart.tsx
+++ b/apps/web/components/features/pricing/PricingComparisonChart.tsx
@@ -22,65 +22,30 @@ function CellValue({
 }) {
   if (typeof value === 'string') {
     return (
-      <span
-        className='text-[13px]'
-        style={{ color: 'var(--linear-text-secondary)' }}
-      >
+      <span className='system-b-pricing-chart-value'>
         {value}
-        {comingSoon && (
-          <span
-            role='img'
-            aria-label='Coming soon'
-            className='ml-1.5 inline-block rounded-full px-1.5 py-px text-[10px] font-medium'
-            style={{
-              backgroundColor: 'var(--linear-warning-subtle)',
-              color: 'var(--linear-warning)',
-            }}
-          >
-            Soon
-          </span>
-        )}
+        {comingSoon ? (
+          <span className='system-b-pricing-chart-badge'>Soon</span>
+        ) : null}
       </span>
     );
   }
+
   if (value === true) {
     return (
       <Check
         aria-label='Included'
-        className='mx-auto'
-        style={{
-          width: '16px',
-          height: '16px',
-          color: 'var(--linear-text-secondary)',
-        }}
+        className='system-b-pricing-inclusion-icon'
       />
     );
   }
+
   if (comingSoon) {
-    return (
-      <span
-        role='img'
-        aria-label='Coming soon'
-        className='inline-block rounded-full px-1.5 py-px text-[10px] font-medium'
-        style={{
-          backgroundColor: 'var(--linear-warning-subtle)',
-          color: 'var(--linear-warning)',
-        }}
-      >
-        Soon
-      </span>
-    );
+    return <span className='system-b-pricing-chart-badge'>Soon</span>;
   }
+
   return (
-    <Minus
-      aria-label='Not included'
-      className='mx-auto'
-      style={{
-        width: '14px',
-        height: '14px',
-        color: 'var(--linear-text-quaternary)',
-      }}
-    />
+    <Minus aria-label='Not included' className='system-b-pricing-minus-icon' />
   );
 }
 
@@ -92,24 +57,16 @@ function MobileFeatureRow({
   readonly selectedPlan: PlanColumn;
 }) {
   return (
-    <tr
-      className='border-b'
-      style={{ borderColor: 'var(--linear-border-subtle)' }}
-    >
+    <tr className='system-b-pricing-chart-row'>
       <th
         scope='row'
-        className='px-5 py-3.5 pr-4 text-[13px]'
-        style={{ color: 'var(--linear-text-secondary)' }}
+        className='system-b-pricing-chart-cell system-b-pricing-chart-cell--feature'
       >
         {feature.name}
       </th>
       <td
-        className='px-5 py-3.5 text-center'
-        style={
-          selectedPlan === 'pro'
-            ? { backgroundColor: 'var(--linear-bg-surface-1)' }
-            : undefined
-        }
+        className='system-b-pricing-chart-cell system-b-pricing-chart-cell--value'
+        data-selected={selectedPlan === 'pro' ? 'true' : undefined}
       >
         <CellValue
           value={feature[selectedPlan]}
@@ -126,37 +83,33 @@ function DesktopFeatureRow({
   readonly feature: ComparisonFeature;
 }) {
   return (
-    <tr
-      className='border-b'
-      style={{ borderColor: 'var(--linear-border-subtle)' }}
-    >
+    <tr className='system-b-pricing-chart-row'>
       <th
         scope='row'
-        className='px-5 py-3.5 pr-4 text-[13px]'
-        style={{ color: 'var(--linear-text-secondary)' }}
+        className='system-b-pricing-chart-cell system-b-pricing-chart-cell--feature'
       >
         {feature.name}
       </th>
-      <td className='px-5 py-3.5 text-center'>
+      <td className='system-b-pricing-chart-cell system-b-pricing-chart-cell--value'>
         <CellValue
           value={feature.free}
           comingSoon={feature.comingSoon && feature.free !== false}
         />
       </td>
       <td
-        className='px-5 py-3.5 text-center'
-        style={{ backgroundColor: 'var(--linear-bg-surface-1)' }}
+        className='system-b-pricing-chart-cell system-b-pricing-chart-cell--value'
+        data-selected='true'
       >
         <CellValue
           value={feature.pro}
           comingSoon={feature.comingSoon && feature.pro !== false}
         />
       </td>
-      {maxPlanEnabled && (
-        <td className='px-5 py-3.5 text-center'>
+      {maxPlanEnabled ? (
+        <td className='system-b-pricing-chart-cell system-b-pricing-chart-cell--value'>
           <CellValue value={feature.max} comingSoon={feature.comingSoon} />
         </td>
-      )}
+      ) : null}
     </tr>
   );
 }
@@ -192,18 +145,15 @@ export function PricingComparisonChart() {
         ]
       : []),
   ];
+  const selectedPlanOption =
+    planOptions.find(option => option.id === selectedPlan) ?? planOptions[0];
 
   return (
-    <div className='mx-auto max-w-5xl'>
-      {/* Billing toggle */}
-      <div className='flex items-center justify-center gap-3 mb-8'>
+    <div className='system-b-pricing-chart'>
+      <div className='system-b-pricing-billing'>
         <span
-          className='text-[13px] font-medium'
-          style={{
-            color: isAnnual
-              ? 'var(--linear-text-tertiary)'
-              : 'var(--linear-text-primary)',
-          }}
+          className='system-b-pricing-billing-label'
+          data-active={isAnnual ? undefined : 'true'}
         >
           Monthly
         </span>
@@ -212,186 +162,110 @@ export function PricingComparisonChart() {
           role='switch'
           aria-checked={isAnnual}
           aria-label='Toggle annual billing'
-          onClick={() => setIsAnnual(v => !v)}
-          className='relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full transition-colors duration-200'
-          style={{
-            backgroundColor: isAnnual
-              ? 'var(--linear-btn-primary-bg)'
-              : 'var(--linear-bg-surface-2)',
-          }}
+          onClick={() => setIsAnnual(value => !value)}
+          className='system-b-pricing-switch'
+          data-state={isAnnual ? 'annual' : 'monthly'}
         >
-          <span
-            className='pointer-events-none inline-block h-5 w-5 transform rounded-full shadow-sm transition-transform duration-200'
-            style={{
-              backgroundColor: 'var(--linear-text-primary)',
-              transform: isAnnual
-                ? 'translate(22px, 2px)'
-                : 'translate(2px, 2px)',
-            }}
-          />
+          <span className='system-b-pricing-switch-thumb' />
         </button>
         <span
-          className='text-[13px] font-medium'
-          style={{
-            color: isAnnual
-              ? 'var(--linear-text-primary)'
-              : 'var(--linear-text-tertiary)',
-          }}
+          className='system-b-pricing-billing-label'
+          data-active={isAnnual ? 'true' : undefined}
         >
-          {'Annual'}
-          <span
-            className='ml-1.5 inline-block rounded-full px-1.5 py-px text-[10px] font-medium'
-            style={{
-              backgroundColor: 'var(--linear-success-subtle)',
-              color: 'var(--linear-success)',
-            }}
-          >
+          Annual
+          <span className='system-b-pricing-chart-badge' data-tone='success'>
             Save ~20%
           </span>
         </span>
       </div>
 
-      {/* Mobile plan selector */}
-      <div className='mb-4 md:hidden'>
+      <div className='system-b-pricing-mobile-selector'>
         <select
           aria-label='Select plan to compare'
           value={selectedPlan}
-          onChange={e => {
-            const val = e.target.value;
-            if (planOptions.some(o => o.id === val)) {
-              setSelectedPlan(val as PlanColumn);
+          onChange={event => {
+            const value = event.target.value;
+            if (planOptions.some(option => option.id === value)) {
+              setSelectedPlan(value as PlanColumn);
             }
           }}
-          className='w-full rounded-lg px-4 py-2.5 text-[14px] font-medium appearance-none cursor-pointer'
-          style={{
-            backgroundColor: 'var(--linear-bg-surface-1)',
-            border: '1px solid var(--linear-border-default)',
-            color: 'var(--linear-text-primary)',
-          }}
+          className='system-b-pricing-select'
         >
-          {planOptions.map(opt => (
-            <option key={opt.id} value={opt.id}>
-              {opt.name} — {opt.price}
+          {planOptions.map(option => (
+            <option key={option.id} value={option.id}>
+              {option.name} - {option.price}
             </option>
           ))}
         </select>
       </div>
 
-      {/* Desktop comparison table */}
-      <div
-        className='hidden overflow-x-auto rounded-[1.5rem] border p-3 md:block'
-        style={{
-          backgroundColor: 'var(--linear-bg-surface-0)',
-          borderColor: 'var(--linear-border-default)',
-        }}
-      >
-        <table className='w-full border-separate border-spacing-0'>
+      <div className='system-b-pricing-table-shell' data-variant='desktop'>
+        <table className='system-b-pricing-table'>
           <thead>
-            <tr
-              className='border-b'
-              style={{ borderColor: 'var(--linear-border-default)' }}
-            >
-              <th className='w-[40%] px-5 py-5 text-left' />
-              {/* Free */}
-              <th className='min-w-[120px] px-5 py-5 text-center'>
-                <div
-                  className='text-[13px] font-medium'
-                  style={{ color: 'var(--linear-text-tertiary)' }}
-                >
+            <tr className='system-b-pricing-chart-row'>
+              <th className='system-b-pricing-chart-cell system-b-pricing-chart-cell--feature-heading' />
+              <th className='system-b-pricing-chart-cell system-b-pricing-chart-cell--plan'>
+                <div className='system-b-pricing-plan-name'>
                   {free.marketing.displayName}
                 </div>
-                <div
-                  className='mt-1 text-2xl font-semibold'
-                  style={{ color: 'var(--linear-text-primary)' }}
-                >
-                  $0
-                </div>
+                <div className='system-b-pricing-plan-price'>$0</div>
               </th>
-              {/* Pro */}
               <th
-                className='min-w-[160px] px-5 py-5 text-center'
-                style={{ backgroundColor: 'var(--linear-bg-surface-1)' }}
+                className='system-b-pricing-chart-cell system-b-pricing-chart-cell--plan'
+                data-selected='true'
               >
-                <div
-                  className='text-[13px] font-medium'
-                  style={{ color: 'var(--linear-text-tertiary)' }}
-                >
+                <div className='system-b-pricing-plan-name'>
                   {pro.marketing.displayName}
                 </div>
-                <div
-                  className='mt-1 text-2xl font-semibold'
-                  style={{ color: 'var(--linear-text-primary)' }}
-                >
+                <div className='system-b-pricing-plan-price'>
                   ${proPrice}
-                  <span
-                    className='text-[13px] font-normal'
-                    style={{ color: 'var(--linear-text-tertiary)' }}
-                  >
-                    /mo
-                  </span>
+                  <span>/mo</span>
                 </div>
-                {isAnnual && pro.marketing.price?.yearly && (
-                  <div
-                    className='mt-0.5 text-[11px]'
-                    style={{ color: 'var(--linear-text-tertiary)' }}
-                  >
-                    ${pro.marketing.price.yearly}/yr
-                  </div>
-                )}
+                <div
+                  aria-hidden={isAnnual ? undefined : true}
+                  className='system-b-pricing-plan-annual'
+                  data-visible={isAnnual ? 'true' : undefined}
+                >
+                  {pro.marketing.price?.yearly
+                    ? `$${pro.marketing.price.yearly}/yr`
+                    : null}
+                </div>
               </th>
-              {/* Max */}
-              {maxPlanEnabled && (
-                <th className='min-w-[140px] px-5 py-5 text-center'>
-                  <div className='flex items-center justify-center gap-1.5'>
-                    <span
-                      className='text-[13px] font-medium'
-                      style={{ color: 'var(--linear-text-tertiary)' }}
-                    >
+              {maxPlanEnabled ? (
+                <th className='system-b-pricing-chart-cell system-b-pricing-chart-cell--plan'>
+                  <div className='system-b-pricing-plan-label'>
+                    <span className='system-b-pricing-plan-name'>
                       {max.marketing.displayName}
                     </span>
-                    <span
-                      className='rounded-full px-1.5 py-px text-[10px] font-medium'
-                      style={{
-                        backgroundColor: 'var(--linear-warning-subtle)',
-                        color: 'var(--linear-warning)',
-                      }}
-                    >
+                    <span className='system-b-pricing-chart-badge'>
                       Early Access
                     </span>
                   </div>
-                  <div
-                    className='mt-1 text-2xl font-semibold'
-                    style={{ color: 'var(--linear-text-primary)' }}
-                  >
+                  <div className='system-b-pricing-plan-price'>
                     ${maxPrice}
-                    <span
-                      className='text-[13px] font-normal'
-                      style={{ color: 'var(--linear-text-tertiary)' }}
-                    >
-                      /mo
-                    </span>
+                    <span>/mo</span>
                   </div>
-                  {isAnnual && max.marketing.price?.yearly && (
-                    <div
-                      className='mt-0.5 text-[11px]'
-                      style={{ color: 'var(--linear-text-tertiary)' }}
-                    >
-                      ${max.marketing.price.yearly}/yr
-                    </div>
-                  )}
+                  <div
+                    aria-hidden={isAnnual ? undefined : true}
+                    className='system-b-pricing-plan-annual'
+                    data-visible={isAnnual ? 'true' : undefined}
+                  >
+                    {max.marketing.price?.yearly
+                      ? `$${max.marketing.price.yearly}/yr`
+                      : null}
+                  </div>
                 </th>
-              )}
+              ) : null}
             </tr>
           </thead>
 
           <tbody>
             {PRICING_COMPARISON.map(category => (
               <Fragment key={`cat-${category.category}`}>
-                <tr style={{ backgroundColor: 'var(--linear-bg-page)' }}>
+                <tr className='system-b-pricing-category-row'>
                   <td
                     colSpan={maxPlanEnabled ? 4 : 3}
-                    className='px-5 py-3 text-[12px] font-semibold tracking-[0.04em]'
-                    style={{ color: 'var(--linear-text-tertiary)' }}
+                    className='system-b-pricing-category-cell'
                   >
                     {category.category}
                   </td>
@@ -408,40 +282,20 @@ export function PricingComparisonChart() {
         </table>
       </div>
 
-      {/* Mobile comparison table */}
-      <div
-        className='overflow-x-auto rounded-[1.5rem] border p-3 md:hidden'
-        style={{
-          backgroundColor: 'var(--linear-bg-surface-0)',
-          borderColor: 'var(--linear-border-default)',
-        }}
-      >
-        <table className='w-full border-separate border-spacing-0'>
+      <div className='system-b-pricing-table-shell' data-variant='mobile'>
+        <table className='system-b-pricing-table'>
           <thead>
-            <tr
-              className='border-b'
-              style={{ borderColor: 'var(--linear-border-default)' }}
-            >
-              <th className='w-[60%] px-5 py-5 text-left' />
+            <tr className='system-b-pricing-chart-row'>
+              <th className='system-b-pricing-chart-cell system-b-pricing-chart-cell--feature-heading' />
               <th
-                className='px-5 py-5 text-center'
-                style={
-                  selectedPlan === 'pro'
-                    ? { backgroundColor: 'var(--linear-bg-surface-1)' }
-                    : undefined
-                }
+                className='system-b-pricing-chart-cell system-b-pricing-chart-cell--plan'
+                data-selected={selectedPlan === 'pro' ? 'true' : undefined}
               >
-                <div
-                  className='text-[13px] font-medium'
-                  style={{ color: 'var(--linear-text-tertiary)' }}
-                >
-                  {planOptions.find(o => o.id === selectedPlan)?.name}
+                <div className='system-b-pricing-plan-name'>
+                  {selectedPlanOption.name}
                 </div>
-                <div
-                  className='mt-1 text-xl font-semibold'
-                  style={{ color: 'var(--linear-text-primary)' }}
-                >
-                  {planOptions.find(o => o.id === selectedPlan)?.price}
+                <div className='system-b-pricing-plan-price'>
+                  {selectedPlanOption.price}
                 </div>
               </th>
             </tr>
@@ -450,12 +304,8 @@ export function PricingComparisonChart() {
           <tbody>
             {PRICING_COMPARISON.map(category => (
               <Fragment key={`mcat-${category.category}`}>
-                <tr style={{ backgroundColor: 'var(--linear-bg-page)' }}>
-                  <td
-                    colSpan={2}
-                    className='px-5 py-3 text-[12px] font-semibold tracking-[0.04em]'
-                    style={{ color: 'var(--linear-text-tertiary)' }}
-                  >
+                <tr className='system-b-pricing-category-row'>
+                  <td colSpan={2} className='system-b-pricing-category-cell'>
                     {category.category}
                   </td>
                 </tr>
@@ -472,13 +322,7 @@ export function PricingComparisonChart() {
         </table>
       </div>
 
-      <p
-        className='mt-4 text-center'
-        style={{
-          fontSize: 'var(--linear-label-size)',
-          color: 'var(--linear-text-tertiary)',
-        }}
-      >
+      <p className='system-b-pricing-footnote'>
         All limits subject to fair-use guardrails.
       </p>
     </div>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -3457,6 +3457,682 @@ body:has(.system-b-launch-page) .marketing-glass-header__cta:focus-visible {
 }
 
 /* ============================================
+   SYSTEM B PRICING PAGE
+   ============================================ */
+:where(.system-b-pricing-page) {
+  background: var(--system-b-cinematic-black);
+  color: var(--system-b-text-primary);
+}
+
+:where(.system-b-pricing-page main) {
+  overflow: clip;
+}
+
+body:has(.system-b-pricing-page) .marketing-glass-header__cta {
+  min-height: var(--space-8);
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 16%, transparent);
+  border-radius: var(--system-b-radius-pill);
+  background: color-mix(in oklab, var(--system-b-text-primary) 6%, transparent);
+  color: var(--system-b-text-primary);
+  box-shadow: none;
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    border-color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+body:has(.system-b-pricing-page) .marketing-glass-header__cta:hover,
+body:has(.system-b-pricing-page) .marketing-glass-header__cta:focus-visible {
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-text-primary) 24%,
+    transparent
+  );
+  background: color-mix(
+    in oklab,
+    var(--system-b-text-primary) 10%,
+    transparent
+  );
+}
+
+:where(.system-b-pricing-hero) {
+  display: flex;
+  min-height: calc(92svh - var(--system-b-header-height));
+  align-items: center;
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
+  padding-block: calc(var(--system-b-header-height) + var(--space-8))
+    var(--space-12);
+}
+
+:where(.system-b-pricing-hero-grid) {
+  display: grid;
+  align-items: start;
+  gap: var(--space-10);
+}
+
+@media (min-width: 1024px) {
+  :where(.system-b-pricing-hero-grid) {
+    grid-template-columns: minmax(0, 0.82fr) minmax(0, 1.18fr);
+  }
+}
+
+:where(.system-b-pricing-hero-copy) {
+  max-width: 34rem;
+}
+
+:where(.system-b-pricing-title) {
+  margin: 0;
+  color: var(--system-b-text-primary);
+  font-size: calc(var(--text-5xl) + var(--space-2));
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0;
+  line-height: 0.96;
+}
+
+:where(.system-b-pricing-lead) {
+  max-width: 30rem;
+  margin: var(--space-5) 0 0;
+  color: color-mix(in oklab, var(--system-b-text-primary) 66%, transparent);
+  font-size: var(--text-lg);
+  line-height: 1.55;
+}
+
+:where(.system-b-pricing-note) {
+  max-width: 31rem;
+  margin: var(--space-5) 0 0;
+  color: color-mix(in oklab, var(--system-b-text-primary) 46%, transparent);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0;
+  line-height: 1.5;
+}
+
+:where(.system-b-pricing-actions) {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin-top: var(--space-5);
+}
+
+:where(.system-b-pricing-actions--center) {
+  justify-content: center;
+}
+
+:where(.system-b-pricing-primary-link),
+:where(.system-b-pricing-secondary-link),
+:where(.system-b-pricing-page .public-action-secondary) {
+  display: inline-flex;
+  min-height: calc(var(--space-10) + var(--space-1));
+  align-items: center;
+  justify-content: center;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 16%, transparent);
+  border-radius: var(--system-b-radius-pill);
+  padding-inline: var(--space-6);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0;
+  text-decoration: none;
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    border-color var(--system-b-duration-fast) var(--system-b-ease),
+    opacity var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-pricing-primary-link) {
+  background: var(--system-b-primary-bg);
+  color: var(--system-b-primary-fg);
+}
+
+:where(.system-b-pricing-secondary-link),
+:where(.system-b-pricing-page .public-action-secondary) {
+  background: color-mix(in oklab, var(--system-b-text-primary) 6%, transparent);
+  color: var(--system-b-text-primary);
+  box-shadow: none;
+}
+
+:where(.system-b-pricing-primary-link:hover),
+:where(.system-b-pricing-secondary-link:hover),
+:where(.system-b-pricing-page .public-action-secondary:hover) {
+  opacity: 0.92;
+}
+
+:where(.system-b-pricing-secondary-link:hover),
+:where(.system-b-pricing-page .public-action-secondary:hover) {
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-text-primary) 24%,
+    transparent
+  );
+}
+
+:where(.system-b-pricing-primary-link:focus-visible),
+:where(.system-b-pricing-secondary-link:focus-visible),
+:where(.system-b-pricing-page .public-action-secondary:focus-visible) {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--system-b-cinematic-black),
+    0 0 0 4px color-mix(in oklab, var(--system-b-text-primary) 35%, transparent);
+}
+
+:where(.system-b-pricing-story-grid) {
+  display: grid;
+  gap: var(--space-4);
+}
+
+@media (min-width: 768px) {
+  :where(.system-b-pricing-story-grid) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+:where(.system-b-pricing-story-card) {
+  display: grid;
+  min-height: calc(var(--space-20) + var(--space-10));
+  align-content: start;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 9%, transparent);
+  border-radius: var(--radius-lg);
+  background: var(--system-b-bg-surface-0);
+  padding: var(--space-6);
+}
+
+:where(.system-b-pricing-story-label),
+:where(.system-b-pricing-category-cell) {
+  margin: 0;
+  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+:where(.system-b-pricing-story-title) {
+  margin: var(--space-3) 0 0;
+  color: var(--system-b-text-primary);
+  font-size: var(--text-xl);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0;
+  line-height: 1.2;
+}
+
+:where(.system-b-pricing-story-body) {
+  margin: var(--space-3) 0 0;
+  color: color-mix(in oklab, var(--system-b-text-primary) 56%, transparent);
+  font-size: var(--text-sm);
+  line-height: 1.55;
+}
+
+:where(.system-b-pricing-plans) {
+  margin-top: var(--space-12);
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plans) {
+  gap: var(--space-px);
+  overflow: hidden;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plans--compact),
+:where(.system-b-pricing-page .marketing-pricing-plans--expanded) {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card),
+:where(.system-b-pricing-page .marketing-pricing-plan-card--blue),
+:where(.system-b-pricing-page .marketing-pricing-plan-card--pink),
+:where(.system-b-pricing-page .marketing-pricing-plan-card--violet) {
+  --marketing-plan-accent: var(--system-b-text-primary);
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card) {
+  min-height: calc(var(--space-20) + var(--space-16));
+  border: 0;
+  border-radius: 0;
+  background: var(--system-b-bg-surface-0);
+  box-shadow: none;
+  padding: var(--space-6);
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card__topline) {
+  display: none;
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card__header) {
+  min-height: var(--space-24);
+  gap: var(--space-3);
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card__name) {
+  color: var(--system-b-text-primary);
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0;
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card__body) {
+  max-width: 20rem;
+  color: color-mix(in oklab, var(--system-b-text-primary) 56%, transparent);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card__badge) {
+  min-height: var(--space-6);
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 10%, transparent);
+  border-radius: var(--system-b-radius-pill);
+  background: color-mix(in oklab, var(--system-b-text-primary) 5%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 56%, transparent);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0;
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card__price) {
+  margin: var(--space-5) 0 0;
+  color: var(--system-b-text-primary);
+  font-size: var(--text-4xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0;
+  line-height: 1;
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card__price span) {
+  color: color-mix(in oklab, var(--system-b-text-primary) 48%, transparent);
+  font-size: var(--text-base);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0;
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card__cta) {
+  width: 100%;
+  margin-top: var(--space-5);
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card__features) {
+  gap: var(--space-3);
+  margin: var(--space-5) 0 0;
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card__features li) {
+  grid-template-columns: var(--space-4) minmax(0, 1fr);
+  gap: var(--space-2);
+  color: color-mix(in oklab, var(--system-b-text-primary) 58%, transparent);
+  font-size: var(--text-sm);
+  line-height: 1.42;
+}
+
+:where(.system-b-pricing-page .marketing-pricing-plan-card__features svg) {
+  width: var(--space-4);
+  height: var(--space-4);
+  color: color-mix(
+    in oklab,
+    var(--system-b-accent-cyan) 66%,
+    var(--system-b-text-primary)
+  );
+}
+
+:where(.system-b-pricing-section),
+:where(.system-b-pricing-final) {
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
+  padding-block: var(--space-20);
+}
+
+:where(.system-b-pricing-section-inner) {
+  max-width: 64rem;
+  margin-inline: auto;
+}
+
+:where(.system-b-pricing-section-copy) {
+  max-width: 32rem;
+}
+
+:where(.system-b-pricing-section-title) {
+  margin: 0;
+  color: var(--system-b-text-primary);
+  font-size: calc(var(--text-4xl) + var(--space-1));
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0;
+  line-height: 1.04;
+}
+
+:where(.system-b-pricing-section-body),
+:where(.system-b-pricing-final-copy) {
+  margin: var(--space-4) 0 0;
+  color: color-mix(in oklab, var(--system-b-text-primary) 58%, transparent);
+  font-size: var(--text-base);
+  line-height: 1.65;
+}
+
+:where(.system-b-pricing-final) {
+  border-bottom: 0;
+  text-align: center;
+}
+
+:where(.system-b-pricing-final-copy) {
+  max-width: 30rem;
+  margin-inline: auto;
+}
+
+:where(.system-b-pricing-chart-wrap) {
+  margin-top: var(--space-10);
+}
+
+:where(.system-b-pricing-chart) {
+  max-width: 64rem;
+  margin-inline: auto;
+}
+
+:where(.system-b-pricing-billing) {
+  display: flex;
+  min-height: var(--space-8);
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-8);
+}
+
+:where(.system-b-pricing-billing-label) {
+  display: inline-flex;
+  min-height: var(--space-6);
+  align-items: center;
+  gap: var(--space-2);
+  color: color-mix(in oklab, var(--system-b-text-primary) 46%, transparent);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0;
+}
+
+:where(.system-b-pricing-billing-label[data-active="true"]) {
+  color: var(--system-b-text-primary);
+}
+
+:where(.system-b-pricing-switch) {
+  position: relative;
+  width: calc(var(--space-10) + var(--space-1));
+  height: var(--space-6);
+  flex: none;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 14%, transparent);
+  border-radius: var(--system-b-radius-pill);
+  background: var(--system-b-bg-surface-2);
+  cursor: pointer;
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    border-color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-pricing-switch[data-state="annual"]) {
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-accent-cyan) 38%,
+    transparent
+  );
+  background: color-mix(
+    in oklab,
+    var(--system-b-accent-cyan) 16%,
+    var(--system-b-bg-surface-2)
+  );
+}
+
+:where(.system-b-pricing-switch-thumb) {
+  position: absolute;
+  top: var(--space-0-5);
+  left: var(--space-0-5);
+  width: var(--space-5);
+  height: var(--space-5);
+  border-radius: var(--radius-full);
+  background: var(--system-b-text-primary);
+  transition: transform var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(
+    .system-b-pricing-switch[data-state="annual"] .system-b-pricing-switch-thumb
+  ) {
+  transform: translateX(calc(var(--space-5) - var(--space-0-5)));
+}
+
+:where(.system-b-pricing-chart-badge) {
+  display: inline-flex;
+  min-height: var(--space-5);
+  align-items: center;
+  border-radius: var(--system-b-radius-pill);
+  background: color-mix(in oklab, var(--system-b-text-primary) 6%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 58%, transparent);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0;
+  margin-left: var(--space-2);
+  padding-inline: var(--space-2);
+}
+
+:where(.system-b-pricing-chart-badge[data-tone="success"]) {
+  color: color-mix(
+    in oklab,
+    var(--geist-green-solid) 70%,
+    var(--system-b-text-primary)
+  );
+}
+
+:where(.system-b-pricing-mobile-selector) {
+  display: block;
+  margin-bottom: var(--space-4);
+}
+
+@media (min-width: 768px) {
+  :where(.system-b-pricing-mobile-selector) {
+    display: none;
+  }
+}
+
+:where(.system-b-pricing-select) {
+  width: 100%;
+  min-height: calc(var(--space-10) + var(--space-1));
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 12%, transparent);
+  border-radius: var(--radius-lg);
+  background: var(--system-b-bg-surface-0);
+  color: var(--system-b-text-primary);
+  cursor: pointer;
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+  padding-inline: var(--space-4);
+}
+
+:where(.system-b-pricing-table-shell) {
+  overflow-x: auto;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
+  border-radius: var(--radius-lg);
+  background: var(--system-b-bg-surface-0);
+  padding: var(--space-3);
+}
+
+:where(.system-b-pricing-table-shell[data-variant="desktop"]) {
+  display: none;
+}
+
+:where(.system-b-pricing-table-shell[data-variant="mobile"]) {
+  display: block;
+}
+
+@media (min-width: 768px) {
+  :where(.system-b-pricing-table-shell[data-variant="desktop"]) {
+    display: block;
+  }
+
+  :where(.system-b-pricing-table-shell[data-variant="mobile"]) {
+    display: none;
+  }
+}
+
+:where(.system-b-pricing-table) {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+}
+
+:where(.system-b-pricing-chart-row) {
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 7%, transparent);
+}
+
+:where(.system-b-pricing-chart-cell) {
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--system-b-text-primary) 7%, transparent);
+  padding: var(--space-3) var(--space-5);
+}
+
+:where(.system-b-pricing-chart-cell--feature),
+:where(.system-b-pricing-chart-cell--feature-heading) {
+  width: 40%;
+  color: color-mix(in oklab, var(--system-b-text-primary) 58%, transparent);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+  text-align: left;
+}
+
+:where(.system-b-pricing-chart-cell--value),
+:where(.system-b-pricing-chart-cell--plan) {
+  text-align: center;
+}
+
+:where(.system-b-pricing-chart-cell[data-selected="true"]) {
+  background: color-mix(in oklab, var(--system-b-text-primary) 4%, transparent);
+}
+
+:where(.system-b-pricing-plan-label) {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+}
+
+:where(.system-b-pricing-plan-name) {
+  color: color-mix(in oklab, var(--system-b-text-primary) 54%, transparent);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0;
+}
+
+:where(.system-b-pricing-plan-price) {
+  margin-top: var(--space-1);
+  color: var(--system-b-text-primary);
+  font-size: var(--text-2xl);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0;
+  line-height: 1.1;
+}
+
+:where(.system-b-pricing-plan-price span),
+:where(.system-b-pricing-plan-annual) {
+  color: color-mix(in oklab, var(--system-b-text-primary) 46%, transparent);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-normal);
+}
+
+:where(.system-b-pricing-plan-annual) {
+  margin-top: var(--space-1);
+  min-height: var(--space-4);
+  visibility: hidden;
+}
+
+:where(.system-b-pricing-plan-annual[data-visible="true"]) {
+  visibility: visible;
+}
+
+:where(.system-b-pricing-category-row) {
+  background: var(--system-b-bg-page);
+}
+
+:where(.system-b-pricing-category-cell) {
+  padding: var(--space-3) var(--space-5);
+}
+
+:where(.system-b-pricing-chart-value) {
+  display: inline-flex;
+  min-height: var(--space-5);
+  align-items: center;
+  justify-content: center;
+  color: color-mix(in oklab, var(--system-b-text-primary) 58%, transparent);
+  font-size: var(--text-sm);
+  line-height: 1.4;
+}
+
+:where(.system-b-pricing-inclusion-icon),
+:where(.system-b-pricing-minus-icon) {
+  display: block;
+  margin-inline: auto;
+}
+
+:where(.system-b-pricing-inclusion-icon) {
+  width: var(--space-4);
+  height: var(--space-4);
+  color: color-mix(in oklab, var(--system-b-text-primary) 68%, transparent);
+}
+
+:where(.system-b-pricing-minus-icon) {
+  width: var(--space-4);
+  height: var(--space-4);
+  color: color-mix(in oklab, var(--system-b-text-primary) 30%, transparent);
+}
+
+:where(.system-b-pricing-footnote) {
+  margin: var(--space-4) 0 0;
+  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  font-size: var(--text-xs);
+  text-align: center;
+}
+
+@media (max-width: 767px) {
+  :where(.system-b-pricing-hero) {
+    min-height: auto;
+    padding-block: calc(var(--system-b-header-height) + var(--space-8))
+      var(--space-12);
+  }
+
+  :where(.system-b-pricing-title) {
+    font-size: var(--text-5xl);
+  }
+
+  :where(.system-b-pricing-story-card) {
+    min-height: auto;
+  }
+
+  :where(.system-b-pricing-page .marketing-pricing-plan-card) {
+    min-height: auto;
+  }
+
+  :where(.system-b-pricing-section),
+  :where(.system-b-pricing-final) {
+    padding-block: var(--space-16);
+  }
+
+  :where(.system-b-pricing-section-title) {
+    font-size: var(--text-4xl);
+  }
+
+  :where(.system-b-pricing-chart-cell) {
+    padding: var(--space-3) var(--space-4);
+  }
+
+  :where(.system-b-pricing-chart-cell--feature),
+  :where(.system-b-pricing-chart-cell--feature-heading) {
+    width: 60%;
+  }
+}
+
+/* ============================================
    GEIST ACCENT PALETTE — feature-surface accents
    ============================================
 

--- a/apps/web/tests/unit/marketing/launch-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/launch-system-b-style-guard.test.ts
@@ -33,6 +33,7 @@ const forbiddenLaunchCssPatterns = [
 function extractLaunchCss(source: string): string {
   const start = source.indexOf(':where(.system-b-launch-page)');
   const nextSectionMarkers = [
+    '/* ============================================\n   SYSTEM B PRICING PAGE',
     '/* ============================================\n   SYSTEM B CHAT ENTITY PREVIEW PRIMITIVES',
     '/* ============================================\n   GEIST ACCENT PALETTE',
   ];

--- a/apps/web/tests/unit/marketing/pricing-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/pricing-system-b-style-guard.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const pageSourcePath = 'app/(marketing)/pricing/page.tsx';
+const comparisonChartPath =
+  'components/features/pricing/PricingComparisonChart.tsx';
+const marketingPlansPath =
+  'components/features/pricing/MarketingPricingPlans.tsx';
+const designSystemPath = 'styles/design-system.css';
+
+const forbiddenRouteVisualPatterns = [
+  /style=\{/,
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /\b(?:bg|border|text|ring|shadow|decoration)-\[/,
+  /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
+  /[☰☷✉■☆✓×▶□]/,
+  /&#(?:10024|9634|9654|9654|9679);/,
+] as const;
+
+const forbiddenPricingCssPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /--linear-/,
+  /color-mix\(in oklab,\s*(?:white|black)\b/,
+  /(?:background|color|border(?:-[^:]+)?|box-shadow|text-decoration-color):[^;]*(?<!-)\b(?:white|black)\b/,
+] as const;
+
+function extractPricingCss(source: string): string {
+  const start = source.indexOf(':where(.system-b-pricing-page)');
+  const nextSectionMarkers = [
+    '/* ============================================\n   SYSTEM B CHAT ENTITY PREVIEW PRIMITIVES',
+    '/* ============================================\n   GEIST ACCENT PALETTE',
+  ];
+  const end = nextSectionMarkers
+    .map(marker => source.indexOf(marker, start))
+    .filter(index => index > start)
+    .sort((a, b) => a - b)[0];
+
+  expect(start, 'pricing CSS block exists').toBeGreaterThanOrEqual(0);
+  expect(
+    end,
+    'pricing CSS block is bounded before the next section'
+  ).toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
+describe('pricing page System B source contract', () => {
+  it('keeps pricing page visuals on named System B primitives', () => {
+    const sources = [
+      [
+        pageSourcePath,
+        readFileSync(resolve(process.cwd(), pageSourcePath), 'utf8'),
+      ],
+      [
+        comparisonChartPath,
+        readFileSync(resolve(process.cwd(), comparisonChartPath), 'utf8'),
+      ],
+      [
+        marketingPlansPath,
+        readFileSync(resolve(process.cwd(), marketingPlansPath), 'utf8'),
+      ],
+    ] as const;
+
+    for (const [sourcePath, source] of sources) {
+      for (const pattern of forbiddenRouteVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it('keeps exactly one page-level primary action on pricing', () => {
+    const source = readFileSync(resolve(process.cwd(), pageSourcePath), 'utf8');
+
+    expect(source.match(/data-primary-action='true'/g) ?? []).toHaveLength(1);
+    expect(
+      source,
+      `${pageSourcePath} should not use global primary CTAs`
+    ).not.toMatch(/public-action-primary/);
+  });
+
+  it('keeps pricing System B CSS within stable tokenized bounds', () => {
+    const source = extractPricingCss(
+      readFileSync(resolve(process.cwd(), designSystemPath), 'utf8')
+    );
+
+    for (const pattern of forbiddenPricingCssPatterns) {
+      expect(source, `${designSystemPath} matched ${pattern}`).not.toMatch(
+        pattern
+      );
+    }
+
+    for (const declaration of source.match(/letter-spacing:\s*[^;]+;/g) ?? []) {
+      expect(declaration).toMatch(/letter-spacing:\s*0\s*;/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize `/pricing` onto named System B route classes instead of route-local visual Tailwind literals.
- Move the pricing comparison chart off inline `style={{ ... }}` and legacy `--linear-*` variables.
- Keep the hero claim CTA as the only page-level primary action; pricing plan and final CTAs render as secondary actions on this route.
- Add `pricing-system-b-style-guard.test.ts` and bound the launch CSS guard so route contracts stay independent.

Linear: JOV-2725

## Verification
- `pnpm biome check --write 'apps/web/app/(marketing)/pricing/page.tsx' apps/web/components/features/pricing/MarketingPricingPlans.tsx apps/web/components/features/pricing/PricingComparisonChart.tsx apps/web/styles/design-system.css apps/web/tests/unit/marketing/launch-system-b-style-guard.test.ts apps/web/tests/unit/marketing/pricing-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/marketing/pricing-system-b-style-guard.test.ts tests/unit/marketing/launch-system-b-style-guard.test.ts tests/unit/pricing/pricing-source-of-truth.test.ts` - 23 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git push` pre-push gate: `biome check .`, `next:proxy-guard`, `tailwind:check`, web typecheck, web lint all passed

## Screenshot Proof
Local dev URL: `http://localhost:4307/pricing`

Before metrics:
- Desktop primary visible count: 5, primary in first viewport: 4
- Mobile primary visible count: 5, primary in first viewport: 1

After metrics:
- Desktop: `primaryVisibleCount=1`, `primaryInViewportCount=1`, `horizontalOverflow=false`, annual toggle `chartHeightDelta=0`, `tableHeightDelta=0`
- Mobile: `primaryVisibleCount=1`, `primaryInViewportCount=1`, `horizontalOverflow=false`, annual toggle `chartHeightDelta=0`, `tableHeightDelta=0`

Screenshots captured locally:
- `.gstack/design-reports/screenshots/jov-2725-pricing-before-desktop.png`
- `.gstack/design-reports/screenshots/jov-2725-pricing-before-mobile.png`
- `.gstack/design-reports/screenshots/jov-2725-pricing-after-desktop.png`
- `.gstack/design-reports/screenshots/jov-2725-pricing-after-mobile.png`
