### PR TITLE
fix(web): normalize pay claim system b contract

### DIFF
--- a/apps/web/components/features/pay/PayLanding.tsx
+++ b/apps/web/components/features/pay/PayLanding.tsx
@@ -1,6 +1,4 @@
-import { Button } from '@jovie/ui';
 import {
-  ArrowRight,
   Mail,
   MapPin,
   Mic,
@@ -11,9 +9,11 @@ import {
   Store,
   Users,
 } from 'lucide-react';
-import Link from 'next/link';
-import { MarketingContainer, MarketingHero } from '@/components/marketing';
-import { APP_ROUTES } from '@/constants/routes';
+import {
+  MarketingContainer,
+  MarketingHero,
+  MarketingPageShell,
+} from '@/components/marketing';
 import { ClaimHandleForm } from '@/features/home/claim-handle';
 
 /* -------------------------------------------------------------------------- */
@@ -74,14 +74,7 @@ const STEPS = [
 
 function HowItWorksSection() {
   return (
-    <section
-      className='relative z-10'
-      style={{
-        paddingTop: 'var(--linear-section-pt-lg)',
-        paddingBottom: 'var(--linear-section-pb-md)',
-        backgroundColor: 'var(--linear-bg-page)',
-      }}
-    >
+    <section className='relative z-10 bg-surface-page pt-(--linear-section-pt-lg) pb-(--linear-section-pb-md)'>
       <MarketingContainer width='landing'>
         <div className='mx-auto max-w-[1200px]'>
           <div className='homepage-section-intro'>
@@ -154,14 +147,7 @@ const BENEFITS = [
 
 function BenefitsSection() {
   return (
-    <section
-      className='relative z-10'
-      style={{
-        paddingTop: 'var(--linear-section-pt-md)',
-        paddingBottom: 'var(--linear-section-pb-md)',
-        backgroundColor: 'var(--linear-bg-footer)',
-      }}
-    >
+    <section className='relative z-10 bg-base pt-(--linear-section-pt-md) pb-(--linear-section-pb-md)'>
       <MarketingContainer width='landing'>
         <div className='mx-auto max-w-[1200px]'>
           <div className='marketing-divider mb-14' />
@@ -218,14 +204,7 @@ const USE_CASES = [
 
 function SocialProofSection() {
   return (
-    <section
-      className='relative z-10'
-      style={{
-        paddingTop: 'var(--linear-section-pt-md)',
-        paddingBottom: 'var(--linear-section-pb-md)',
-        backgroundColor: 'var(--linear-bg-page)',
-      }}
-    >
+    <section className='relative z-10 bg-surface-page pt-(--linear-section-pt-md) pb-(--linear-section-pb-md)'>
       <MarketingContainer width='landing'>
         <div className='mx-auto max-w-[1200px]'>
           <div className='homepage-section-intro'>
@@ -270,14 +249,7 @@ function SocialProofSection() {
 
 function TipsFinalCTA() {
   return (
-    <section
-      className='relative z-10'
-      style={{
-        paddingTop: 'var(--linear-section-pt-lg)',
-        paddingBottom: '140px',
-        backgroundColor: 'var(--linear-bg-page)',
-      }}
-    >
+    <section className='relative z-10 bg-surface-page pt-(--linear-section-pt-lg) pb-(--linear-section-pb-lg)'>
       <MarketingContainer width='landing'>
         <div className='marketing-divider mb-12' />
 
@@ -291,14 +263,6 @@ function TipsFinalCTA() {
               Keep the QR code simple, the follow-up automatic, and the listener
               path clean.
             </p>
-            <div className='mt-6'>
-              <Button size='lg' className='public-action-primary' asChild>
-                <Link href={APP_ROUTES.SIGNUP}>
-                  Claim Your Handle
-                  <ArrowRight className='ml-2 h-4 w-4' />
-                </Link>
-              </Button>
-            </div>
           </div>
 
           <div className='homepage-surface-card rounded-[1rem] p-2'>
@@ -316,18 +280,12 @@ function TipsFinalCTA() {
 
 export function PayLanding() {
   return (
-    <div
-      className='relative min-h-screen'
-      style={{
-        backgroundColor: 'var(--linear-bg-footer)',
-        color: 'var(--linear-text-primary)',
-      }}
-    >
+    <MarketingPageShell className='bg-base text-primary-token'>
       <TipsHero />
       <HowItWorksSection />
       <BenefitsSection />
       <SocialProofSection />
       <TipsFinalCTA />
-    </div>
+    </MarketingPageShell>
   );
 }

--- a/apps/web/tests/unit/pay/pay-landing-system-b-source.test.tsx
+++ b/apps/web/tests/unit/pay/pay-landing-system-b-source.test.tsx
@@ -1,0 +1,65 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PayLanding } from '@/components/features/pay/PayLanding';
+
+vi.mock('@/features/home/claim-handle', () => ({
+  ClaimHandleForm: () => (
+    <form aria-label='Claim handle'>
+      <input aria-label='Choose your handle' type='text' />
+      <button type='submit'>Claim</button>
+    </form>
+  ),
+}));
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const sourcePath = join(appRoot, 'components/features/pay/PayLanding.tsx');
+
+const inlineStylePattern = /style=\{\{/;
+const rawAlphaColorPattern = /\brgba?\(/i;
+const rawGradientPattern = /(?:linear|radial)-gradient/i;
+const directPrimaryActionPattern = /public-action-primary|Claim Your Handle/;
+
+describe('pay landing System B source contract', () => {
+  it('keeps the claim handle surface on shared System B primitives', async () => {
+    const source = await readFile(sourcePath, 'utf8');
+
+    expect(source).not.toMatch(inlineStylePattern);
+    expect(source).not.toMatch(rawAlphaColorPattern);
+    expect(source).not.toMatch(rawGradientPattern);
+    expect(source).not.toMatch(directPrimaryActionPattern);
+    expect(source).not.toContain("from '@jovie/ui'");
+    expect(source).not.toContain('@/constants/routes');
+    expect(source).toContain('MarketingPageShell');
+    expect(source).toContain('bg-base text-primary-token');
+    expect(source.match(/<ClaimHandleForm/g) ?? []).toHaveLength(2);
+  });
+
+  it('keeps the final claim section to the handle form action path', () => {
+    render(<PayLanding />);
+
+    const finalHeading = screen.getByRole('heading', {
+      name: /start turning payments into fans/i,
+    });
+    const finalSection = finalHeading.closest('section');
+
+    expect(finalSection).not.toBeNull();
+
+    const finalScope = within(finalSection as HTMLElement);
+    expect(
+      finalScope.getByRole('textbox', { name: /choose your handle/i })
+    ).toBeInTheDocument();
+    expect(
+      finalScope.getByRole('button', { name: 'Claim' })
+    ).toBeInTheDocument();
+    expect(finalScope.queryByRole('link')).not.toBeInTheDocument();
+
+    const finalControls = finalSection?.querySelectorAll(
+      'a[href], button, input:not([type="hidden"]), select, textarea, [role="button"], [role="link"], [role="textbox"]'
+    );
+    expect(finalControls).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize `/pay` section/root backgrounds onto existing System B class primitives instead of local inline style objects.
- Remove the duplicate final-section `Claim Your Handle` button so the final claim surface has one action path: handle input plus submit.
- Add a focused source guard for the `/pay` claim surface contract.

## Verification
- `./scripts/setup.sh`
- `pnpm biome check --write apps/web/components/features/pay/PayLanding.tsx apps/web/tests/unit/pay/pay-landing-system-b-source.test.tsx`
- `pnpm --filter web exec vitest run tests/unit/pay/pay-landing-system-b-source.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Commit hook: `next:proxy-guard`, `biome check --write --no-errors-on-unmatched`, `eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content`, `pnpm --filter=@jovie/web run a11y:check:staged`, `node scripts/turbo-local.mjs typecheck --filter=@jovie/web`
- Pre-push hook: `biome check .`, `pnpm --filter=@jovie/web run pre-push`, including `next:proxy-guard`, `tailwind:check`, `typecheck`, and `lint`

## Agent-Run Artifact Gate
- Desktop screenshot: `.gstack/artifacts/pay-system-b/pay-desktop-clean.png`
- Mobile screenshot: `.gstack/artifacts/pay-system-b/pay-mobile-clean.png`
- Playwright assertion from local `http://localhost:3100/pay`: final claim section visible controls were exactly `input[aria-label="Choose your handle"]` and submit button `Claim`.

## Coordination
- Branched from current `origin/main` in a separate worktree.
- Did not touch PR #9960 files: `apps/web/app/brand/layout.tsx`, `apps/web/app/brand/page.tsx`, `apps/web/styles/design-system.css`, `apps/web/tests/e2e/brand-page.spec.ts`, `apps/web/tests/unit/app/brand/page.test.tsx`, `apps/web/tests/unit/app/brand/system-b-style-guard.test.ts`, or `apps/web/tests/unit/marketing/pricing-system-b-style-guard.test.ts`.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated pay landing page styling to use Tailwind utility classes for improved maintainability.
  * Consolidated marketing component imports for better code organization.
  * Simplified final CTA section by removing duplicate signup action.

* **Tests**
  * Added comprehensive test suite to validate pay landing page styling patterns and DOM structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes JOV-2727

<!-- agent-run-artifact
{
  "id": "jov-2727-pay-system-b-91af8c3e82b3",
  "source": "github",
  "sourceRunId": "91af8c3e82b3a5f1b1cd7671ad0a2964701c7793",
  "kind": "workflow",
  "status": "done",
  "title": "Pay claim surface System B source contract",
  "summary": "Normalized /pay claim-handle source onto shared System B marketing primitives, removed the duplicate final signup button, added focused source and render guards, and captured desktop/mobile screenshot evidence.",
  "modelRoute": "codex-cli",
  "allowedActions": ["read", "write_code", "open_pr", "ready_pr"],
  "forbiddenActions": ["merge", "deploy", "mutate_production_data", "change_auth", "change_billing", "change_security", "send_outbound"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2727",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2727/normalize-pay-claim-surface-to-system-b-source-contract",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/9961",
  "adminSurface": "/app/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused pay System B source and render guards passed; web typecheck passed; desktop and mobile screenshots captured; final claim section controls are exactly the handle textbox and Claim submit button.",
      "checkedAt": "2026-06-03T15:47:12Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Parallel worker review, main-agent diff review, and read-only reviewer Halley completed; Halley finding on final action coverage was fixed with a render-level guard.",
      "checkedAt": "2026-06-03T15:47:12Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Committed fix(web): normalize pay claim system b contract after commit hooks and pre-push hooks passed, then amended with the final render guard after Biome, focused Vitest, typecheck, and diff checks passed.",
      "checkedAt": "2026-06-03T15:47:12Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Parallel Codex worker and reviewer in local session; no precise token cost available."
  },
  "blockedReason": null,
  "createdAt": "2026-06-03T15:47:12Z",
  "updatedAt": "2026-06-03T15:47:12Z",
  "metadata": {
    "branchName": "codex/jov-2727-pay-system-b",
    "screenshots": [
      ".gstack/artifacts/pay-system-b/pay-desktop-clean.png",
      ".gstack/artifacts/pay-system-b/pay-mobile-clean.png"
    ],
    "finalClaimControls": ["input[aria-label=Choose your handle]", "button:Claim"]
  }
}
-->
