### PR TITLE
fix(web): normalize demo release provider colors

### DIFF
--- a/apps/web/components/features/demo/DemoReleaseDetail.tsx
+++ b/apps/web/components/features/demo/DemoReleaseDetail.tsx
@@ -20,14 +20,6 @@ interface DemoReleaseDetailProps {
   readonly onClose: () => void;
 }
 
-const PROVIDER_COLORS: Record<string, string> = {
-  Spotify: '#1DB954',
-  'Apple Music': '#FA2D48',
-  'YouTube Music': '#FF0000',
-  'Amazon Music': '#00A8E1',
-  SoundCloud: '#FF5500',
-};
-
 const STATUS_DOT: Record<string, string> = {
   connected: 'var(--color-success)',
   missing: 'var(--linear-text-tertiary)',
@@ -117,14 +109,7 @@ export function DemoReleaseDetail({
                     className='size-1.5 shrink-0 rounded-full'
                     style={{ backgroundColor: STATUS_DOT[link.status] }}
                   />
-                  <span
-                    className='flex-1 font-medium'
-                    style={{
-                      color:
-                        PROVIDER_COLORS[link.provider] ??
-                        'var(--linear-text-primary)',
-                    }}
-                  >
+                  <span className='flex-1 font-medium text-primary-token'>
                     {link.provider}
                   </span>
                   <span className='capitalize text-tertiary-token'>

--- a/apps/web/components/features/demo/DemoReleaseLandingSurface.tsx
+++ b/apps/web/components/features/demo/DemoReleaseLandingSurface.tsx
@@ -2,6 +2,7 @@
 
 import { useSearchParams } from 'next/navigation';
 import type { SmartLinkCreditGroup } from '@/app/[username]/[slug]/_lib/data';
+import { providerConfig } from '@/app/app/(shell)/dashboard/releases/config';
 import { ReleaseLandingPage } from '@/app/r/[slug]/ReleaseLandingPage';
 import { INTERNAL_DJ_DEMO_PERSONA } from '@/lib/demo-personas';
 import { DemoClientProviders } from './DemoClientProviders';
@@ -9,13 +10,6 @@ import { DEMO_RELEASE_VIEW_MODELS } from './mock-release-data';
 
 const RELEASE = DEMO_RELEASE_VIEW_MODELS[0];
 const ARTIST = INTERNAL_DJ_DEMO_PERSONA.profile;
-const PROVIDER_ACCENTS: Record<string, string> = {
-  spotify: '#1DB954',
-  apple_music: '#FA2D48',
-  youtube: '#FF0000',
-  amazon_music: '#00A8E1',
-};
-const DEFAULT_PROVIDER_ACCENT = '#5E6AD2';
 const DEMO_CREDITS: readonly SmartLinkCreditGroup[] = [
   {
     role: 'producer',
@@ -91,7 +85,7 @@ export function DemoReleaseLandingSurface() {
           providers={RELEASE.providers.map(provider => ({
             key: provider.key,
             label: provider.label,
-            accent: PROVIDER_ACCENTS[provider.key] ?? DEFAULT_PROVIDER_ACCENT,
+            accent: providerConfig[provider.key]?.accent,
             url: provider.url,
           }))}
           credits={[...DEMO_CREDITS]}

--- a/apps/web/components/features/demo/mock-release-data.ts
+++ b/apps/web/components/features/demo/mock-release-data.ts
@@ -16,6 +16,7 @@ import {
   FOUNDER_DEMO_PERSONA,
   INTERNAL_DJ_DEMO_PERSONA,
 } from '@/lib/demo-personas';
+import { PROVIDER_CONFIG } from '@/lib/discography/config';
 import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
 import type { AudienceMember } from '@/types';
 
@@ -24,26 +25,7 @@ import type { AudienceMember } from '@/types';
 export const DEMO_PROVIDER_CONFIG: Record<
   string,
   { label: string; accent: string }
-> = {
-  spotify: { label: 'Spotify', accent: '#1DB954' },
-  apple_music: { label: 'Apple Music', accent: '#FA2D48' },
-  youtube: { label: 'YouTube', accent: '#FF0000' },
-  youtube_music: { label: 'YouTube Music', accent: '#FF0000' },
-  soundcloud: { label: 'SoundCloud', accent: '#FF5500' },
-  deezer: { label: 'Deezer', accent: '#A238FF' },
-  tidal: { label: 'Tidal', accent: '#000000' },
-  amazon_music: { label: 'Amazon Music', accent: '#00A8E1' },
-  bandcamp: { label: 'Bandcamp', accent: '#1DA0C3' },
-  beatport: { label: 'Beatport', accent: '#94D500' },
-  pandora: { label: 'Pandora', accent: '#224099' },
-  napster: { label: 'Napster', accent: '#000000' },
-  audiomack: { label: 'Audiomack', accent: '#FFA200' },
-  qobuz: { label: 'Qobuz', accent: '#2C8CBA' },
-  anghami: { label: 'Anghami', accent: '#D60062' },
-  boomplay: { label: 'Boomplay', accent: '#FF6600' },
-  iheartradio: { label: 'iHeartRadio', accent: '#C6002B' },
-  tiktok: { label: 'TikTok', accent: '#010101' },
-};
+> = PROVIDER_CONFIG;
 
 // Helper to create provider links
 function makeProviders(

--- a/apps/web/tests/unit/demo/demo-release-landing-surface.test.tsx
+++ b/apps/web/tests/unit/demo/demo-release-landing-surface.test.tsx
@@ -17,6 +17,12 @@ interface CapturedReleaseLandingProps {
     readonly avatarUrl: string | null;
   };
   readonly credits?: readonly CapturedCreditGroup[];
+  readonly providers?: readonly {
+    readonly key: string;
+    readonly label: string;
+    readonly accent: string;
+    readonly url: string | null;
+  }[];
   readonly release: {
     readonly title: string;
   };
@@ -51,6 +57,9 @@ vi.mock('@/app/r/[slug]/ReleaseLandingPage', () => ({
 const { DemoReleaseLandingSurface } = await import(
   '@/features/demo/DemoReleaseLandingSurface'
 );
+const { providerConfig } = await import(
+  '@/app/app/(shell)/dashboard/releases/config'
+);
 
 describe('DemoReleaseLandingSurface', () => {
   beforeEach(() => {
@@ -75,5 +84,18 @@ describe('DemoReleaseLandingSurface', () => {
     expect(renderedPayload).not.toContain('Tim White');
     expect(renderedPayload).not.toContain('Blessings');
     expect(renderedPayload).not.toContain('Clementine Douglas');
+  });
+
+  it('uses the canonical release provider color config', () => {
+    render(<DemoReleaseLandingSurface />);
+
+    const provider = capturedProps?.providers?.find(
+      item => item.key === 'spotify'
+    );
+
+    expect(provider).toMatchObject({
+      label: providerConfig.spotify.label,
+      accent: providerConfig.spotify.accent,
+    });
   });
 });

--- a/apps/web/tests/unit/demo/demo-release-system-b-source.test.ts
+++ b/apps/web/tests/unit/demo/demo-release-system-b-source.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const demoReleaseSources = [
+  'components/features/demo/DemoReleaseLandingSurface.tsx',
+  'components/features/demo/DemoReleaseDetail.tsx',
+  'components/features/demo/mock-release-data.ts',
+] as const;
+
+const duplicatedProviderAccentPatterns = [
+  /PROVIDER_ACCENTS/,
+  /PROVIDER_COLORS/,
+  /DEFAULT_PROVIDER_ACCENT/,
+  /#[0-9a-fA-F]{3,8}/,
+] as const;
+
+describe('demo release System B source contract', () => {
+  it('keeps demo release provider accents on the canonical provider config', () => {
+    for (const sourcePath of demoReleaseSources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+
+      for (const pattern of duplicatedProviderAccentPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Removes local DSP provider hex maps from the demo release landing and legacy release detail surfaces.
- Routes demo release fixture/provider payloads through the canonical release provider config.
- Adds a focused System B source guard plus a render assertion so local provider color maps do not come back.

Fixes JOV-2728.

## Test plan

- `JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/demo/demo-release-system-b-source.test.ts tests/unit/demo/demo-release-landing-surface.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check apps/web/components/features/demo/DemoReleaseDetail.tsx apps/web/components/features/demo/DemoReleaseLandingSurface.tsx apps/web/components/features/demo/mock-release-data.ts apps/web/tests/unit/demo/demo-release-landing-surface.test.tsx apps/web/tests/unit/demo/demo-release-system-b-source.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook: `next:proxy-guard`, `biome check --write`, ESLint, staged a11y, web typecheck
- Pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, web typecheck, web Biome lint

## Visual proof

- `http://localhost:3100/demo/showcase/release-landing` returned 200 and captured `.gstack/design-reports/screenshots/jov-2728-release-landing-390x844.png`.
- `http://localhost:3100/demo/showcase/release-landing?capture=creator-menu` returned 200 and captured `.gstack/design-reports/screenshots/jov-2728-release-landing-creator-menu-390x844.png`.
- Layout-shift audit: `demo-showcase-release-landing` bounding box stayed `390x844` before/after 600ms settle on both states; text-overlap detector returned no issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated provider styling to use a centralized provider configuration system, ensuring consistent appearance across all UI components.

* **Tests**
  * Added validation tests to verify proper provider configuration usage and system integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->