### PR TITLE
fix(web): stabilize demo release source guard

### DIFF
--- a/apps/web/tests/unit/demo/demo-release-system-b-source.test.ts
+++ b/apps/web/tests/unit/demo/demo-release-system-b-source.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const demoReleaseSources = [
@@ -15,10 +16,12 @@ const duplicatedProviderAccentPatterns = [
   /#[0-9a-fA-F]{3,8}/,
 ] as const;
 
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
 describe('demo release System B source contract', () => {
   it('keeps demo release provider accents on the canonical provider config', () => {
     for (const sourcePath of demoReleaseSources) {
-      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      const source = readFileSync(resolve(webRoot, sourcePath), 'utf8');
 
       for (const pattern of duplicatedProviderAccentPatterns) {
         expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);


### PR DESCRIPTION
## Summary
- Anchor the demo release System B source guard to the test file directory instead of process.cwd()
- Preserve the guard added in #9965 while making it stable from different Vitest launch directories

## Linear
- JOV-2731
- Related to JOV-2728 / PR #9965 CodeRabbit finding

## Test Plan
- JOVIE_AGENT_PROFILE=coder pnpm --filter web exec vitest run tests/unit/demo/demo-release-system-b-source.test.ts tests/unit/demo/demo-release-landing-surface.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm biome check apps/web/tests/unit/demo/demo-release-system-b-source.test.ts apps/web/tests/unit/demo/demo-release-landing-surface.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check origin/main..HEAD
- pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by making test execution independent of the working directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->