### PR TITLE
fix(web): unify demo release action adapter

### DIFF
--- a/apps/web/components/features/demo/DemoReleasesExperience.tsx
+++ b/apps/web/components/features/demo/DemoReleasesExperience.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { toast } from 'sonner';
 import type { DashboardData } from '@/app/app/(shell)/dashboard/actions/dashboard-data';
 import {
   primaryProviderKeys,
@@ -11,9 +10,8 @@ import {
   FOUNDER_DEMO_PERSONA,
   INTERNAL_DJ_DEMO_PERSONA,
 } from '@/lib/demo-personas';
-import type { ReleaseViewModel } from '@/lib/discography/types';
-import type { CanvasStatus } from '@/lib/services/canvas/types';
 import { DemoAuthShell } from './DemoAuthShell';
+import { createDemoReleaseExperienceAdapter } from './demo-release-experience-adapter';
 import {
   DEMO_RELEASE_SIDEBAR_FIXTURES,
   DEMO_RELEASE_VIEW_MODELS,
@@ -22,59 +20,6 @@ import {
 } from './mock-release-data';
 
 type DemoReleasesExperienceVariant = 'internal-dj' | 'founder';
-
-async function copyDemoLink(path: string, label: string, _testId: string) {
-  const origin = globalThis.location?.origin ?? 'https://jov.ie';
-  const absoluteUrl = new URL(path, `${origin}/`).toString();
-  try {
-    await navigator.clipboard.writeText(absoluteUrl);
-    toast.success(`${label} copied (demo)`);
-  } catch {
-    toast.error('Unable to copy link in demo mode');
-  }
-  return absoluteUrl;
-}
-
-function notifyDemoAction(message: string) {
-  toast.info(message);
-}
-
-async function noopDemoAction(message: string) {
-  notifyDemoAction(message);
-}
-
-async function uploadDemoArtwork(
-  _file: File,
-  release: ReleaseViewModel
-): Promise<string> {
-  notifyDemoAction(
-    `Artwork editing for ${release.title} is disabled in demo mode`
-  );
-  return release.artworkUrl ?? '';
-}
-
-async function revertDemoArtwork(
-  releaseId: string,
-  release: ReleaseViewModel | null
-): Promise<string> {
-  notifyDemoAction('Artwork revert is disabled in demo mode');
-  return release?.artworkUrl ?? '';
-}
-
-async function formatDemoLyrics(
-  _releaseId: string,
-  lyrics: string
-): Promise<string[]> {
-  notifyDemoAction('Lyrics formatting is disabled in demo mode');
-  return [lyrics];
-}
-
-async function updateDemoCanvasStatus(
-  _releaseId: string,
-  _status: CanvasStatus
-): Promise<void> {
-  notifyDemoAction('Canvas updates are disabled in demo mode');
-}
 
 /**
  * DemoReleasesExperience — the full demo page content wrapped in the real
@@ -112,44 +57,10 @@ export function DemoReleasesExperience({
         appleMusicConnected
         appleMusicArtistName={persona.profile.displayName}
         allowArtworkDownloads
-        experienceAdapter={{
-          mode: 'demo',
-          entitlements: {
-            isPro: true,
-            canCreateManualReleases: true,
-            canEditSmartLinks: true,
-            canAccessFutureReleases: true,
-            smartLinksLimit: null,
-          },
-          onCopy: copyDemoLink,
-          onCreateRelease: () =>
-            notifyDemoAction('Creating releases is disabled in demo mode'),
-          onSync: () =>
-            notifyDemoAction('Spotify sync is disabled in demo mode'),
-          onRefreshRelease: releaseId => {
-            const release = releases.find(item => item.id === releaseId);
-            notifyDemoAction(
-              `Refresh is disabled for ${release?.title ?? 'this release'} in demo mode`
-            );
-          },
-          onArtworkUpload: uploadDemoArtwork,
-          onArtworkRevert: revertDemoArtwork,
-          onAddDspLink: async (_releaseId, _provider, _url) =>
-            noopDemoAction('Link editing is disabled in demo mode'),
-          onRescanIsrc: () =>
-            notifyDemoAction('ISRC rescans are disabled in demo mode'),
-          onSaveLyrics: async () =>
-            noopDemoAction('Lyrics editing is disabled in demo mode'),
-          onFormatLyrics: formatDemoLyrics,
-          onCanvasStatusUpdate: updateDemoCanvasStatus,
-          onToggleArtworkDownloads: async enabled =>
-            noopDemoAction(
-              enabled
-                ? 'Artwork downloads enabled (demo only)'
-                : 'Artwork downloads disabled (demo only)'
-            ),
+        experienceAdapter={createDemoReleaseExperienceAdapter({
+          releases,
           sidebarDataByReleaseId,
-        }}
+        })}
       />
     </DemoAuthShell>
   );

--- a/apps/web/components/features/demo/DemoShowcaseSurface.tsx
+++ b/apps/web/components/features/demo/DemoShowcaseSurface.tsx
@@ -29,6 +29,7 @@ import { DemoReleaseTasksSurface } from './DemoReleaseTasksSurface';
 import { DemoReleaseTrackedLinksSurface } from './DemoReleaseTrackedLinksSurface';
 import { DemoSettingsPanel } from './DemoSettingsPanel';
 import { DemoTimWhiteProfileSurface } from './DemoTimWhiteProfileSurface';
+import { createDemoReleaseExperienceAdapter } from './demo-release-experience-adapter';
 import {
   DEMO_EARNINGS_RESPONSE,
   DEMO_ENRICHED_PROFILE,
@@ -60,32 +61,6 @@ type ReleaseShowcaseState = (typeof RELEASE_SHOWCASE_STATES)[number];
 interface DemoShowcaseSurfaceProps {
   readonly surface: DemoRenderableSurfaceId;
 }
-
-const DEMO_RELEASE_EXPERIENCE_ADAPTER = {
-  mode: 'demo',
-  entitlements: {
-    isPro: true,
-    canCreateManualReleases: true,
-    canEditSmartLinks: true,
-    canAccessFutureReleases: true,
-    smartLinksLimit: null,
-  },
-  onCopy: async (path: string) => path,
-  onCreateRelease: () => {},
-  onSync: () => {},
-  onRefreshRelease: () => {},
-  onArtworkUpload: async () => '',
-  onArtworkRevert: async () => '',
-  onAddDspLink: async () => {},
-  onRescanIsrc: () => {},
-  onSaveLyrics: async () => {},
-  onSaveMetadata: async () => {},
-  onSavePrimaryIsrc: async () => {},
-  onFormatLyrics: async (_releaseId: string, lyrics: string) => [lyrics],
-  onCanvasStatusUpdate: async () => {},
-  onToggleArtworkDownloads: async () => {},
-  sidebarDataByReleaseId: DEMO_RELEASE_SIDEBAR_FIXTURES,
-} as const;
 
 function DemoShowcasePanel({
   testId,
@@ -175,7 +150,10 @@ function DemoReleasesShowcaseState({
         allowArtworkDownloads
         initialImporting={state === 'importing'}
         initialTotalCount={state === 'importing' ? 12 : 0}
-        experienceAdapter={DEMO_RELEASE_EXPERIENCE_ADAPTER}
+        experienceAdapter={createDemoReleaseExperienceAdapter({
+          releases: DEMO_RELEASE_VIEW_MODELS,
+          sidebarDataByReleaseId: DEMO_RELEASE_SIDEBAR_FIXTURES,
+        })}
       />
     </DemoAuthShell>
   );

--- a/apps/web/components/features/demo/demo-release-experience-adapter.ts
+++ b/apps/web/components/features/demo/demo-release-experience-adapter.ts
@@ -1,0 +1,114 @@
+'use client';
+
+import { toast } from 'sonner';
+import type {
+  ReleaseExperienceAdapter,
+  ReleaseSidebarFixtureData,
+} from '@/features/dashboard/organisms/release-provider-matrix/types';
+import type { ReleaseViewModel } from '@/lib/discography/types';
+import type { CanvasStatus } from '@/lib/services/canvas/types';
+
+interface DemoReleaseExperienceAdapterOptions {
+  readonly releases: readonly ReleaseViewModel[];
+  readonly sidebarDataByReleaseId: Record<string, ReleaseSidebarFixtureData>;
+}
+
+async function copyDemoLink(path: string, label: string, _testId: string) {
+  const origin = globalThis.location?.origin ?? 'https://jov.ie';
+  const absoluteUrl = new URL(path, `${origin}/`).toString();
+  try {
+    await navigator.clipboard.writeText(absoluteUrl);
+    toast.success(`${label} copied (demo)`);
+  } catch {
+    toast.error('Unable to copy link in demo mode');
+  }
+  return absoluteUrl;
+}
+
+function notifyDemoAction(message: string) {
+  toast.info(message);
+}
+
+async function noopDemoAction(message: string) {
+  notifyDemoAction(message);
+}
+
+async function uploadDemoArtwork(
+  _file: File,
+  release: ReleaseViewModel
+): Promise<string> {
+  notifyDemoAction(
+    `Artwork editing for ${release.title} is disabled in demo mode`
+  );
+  return release.artworkUrl ?? '';
+}
+
+async function revertDemoArtwork(
+  _releaseId: string,
+  release: ReleaseViewModel | null
+): Promise<string> {
+  notifyDemoAction('Artwork revert is disabled in demo mode');
+  return release?.artworkUrl ?? '';
+}
+
+async function formatDemoLyrics(
+  _releaseId: string,
+  lyrics: string
+): Promise<string[]> {
+  notifyDemoAction('Lyrics formatting is disabled in demo mode');
+  return [lyrics];
+}
+
+async function updateDemoCanvasStatus(
+  _releaseId: string,
+  _status: CanvasStatus
+): Promise<void> {
+  notifyDemoAction('Canvas updates are disabled in demo mode');
+}
+
+export function createDemoReleaseExperienceAdapter({
+  releases,
+  sidebarDataByReleaseId,
+}: DemoReleaseExperienceAdapterOptions): ReleaseExperienceAdapter {
+  return {
+    mode: 'demo',
+    entitlements: {
+      isPro: true,
+      canCreateManualReleases: true,
+      canEditSmartLinks: true,
+      canAccessFutureReleases: true,
+      smartLinksLimit: null,
+    },
+    onCopy: copyDemoLink,
+    onCreateRelease: () =>
+      notifyDemoAction('Creating releases is disabled in demo mode'),
+    onSync: () => notifyDemoAction('Spotify sync is disabled in demo mode'),
+    onRefreshRelease: releaseId => {
+      const release = releases.find(item => item.id === releaseId);
+      notifyDemoAction(
+        `Refresh is disabled for ${release?.title ?? 'this release'} in demo mode`
+      );
+    },
+    onArtworkUpload: uploadDemoArtwork,
+    onArtworkRevert: revertDemoArtwork,
+    onAddDspLink: async (_releaseId, _provider, _url) =>
+      noopDemoAction('Link editing is disabled in demo mode'),
+    onRescanIsrc: () =>
+      notifyDemoAction('ISRC rescans are disabled in demo mode'),
+    onSaveLyrics: async () =>
+      noopDemoAction('Lyrics editing is disabled in demo mode'),
+    onSaveMetadata: async () =>
+      noopDemoAction('Metadata editing is disabled in demo mode'),
+    onSavePrimaryIsrc: async () =>
+      noopDemoAction('Primary ISRC editing is disabled in demo mode'),
+    onFormatLyrics: formatDemoLyrics,
+    onCanvasStatusUpdate: updateDemoCanvasStatus,
+    onToggleArtworkDownloads: async enabled =>
+      noopDemoAction(
+        enabled
+          ? 'Artwork downloads enabled (demo only)'
+          : 'Artwork downloads disabled (demo only)'
+      ),
+    sidebarDataByReleaseId,
+  };
+}

--- a/apps/web/tests/unit/demo/demo-showcase-releases-actions.test.tsx
+++ b/apps/web/tests/unit/demo/demo-showcase-releases-actions.test.tsx
@@ -1,0 +1,160 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReleaseExperienceAdapter } from '@/features/dashboard/organisms/release-provider-matrix/types';
+
+const mocks = vi.hoisted(() => ({
+  clipboardWriteText: vi.fn(() => Promise.resolve()),
+  searchParams: {
+    current: new URLSearchParams('state=connected-empty'),
+  },
+  toastError: vi.fn(),
+  toastInfo: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/demo/showcase/releases',
+  useRouter: () => ({
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+    push: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+  }),
+  useSearchParams: () => mocks.searchParams.current,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    info: mocks.toastInfo,
+    success: mocks.toastSuccess,
+  },
+}));
+
+vi.mock('@/features/demo/DemoAuthShell', () => ({
+  DemoAuthShell: ({ children }: { readonly children: ReactNode }) => (
+    <div data-testid='demo-auth-shell'>{children}</div>
+  ),
+}));
+
+vi.mock('@/features/demo/DemoReleasesExperience', () => ({
+  DemoReleasesExperience: () => <div data-testid='demo-releases-experience' />,
+}));
+
+vi.mock(
+  '@/features/dashboard/organisms/release-provider-matrix/ReleasesExperience',
+  () => ({
+    ReleasesExperience: ({
+      experienceAdapter,
+    }: {
+      readonly experienceAdapter?: ReleaseExperienceAdapter;
+    }) => (
+      <div data-testid='stub-releases-experience'>
+        <button type='button' onClick={() => experienceAdapter?.onSync?.()}>
+          Sync adapter
+        </button>
+        <button
+          type='button'
+          onClick={() => experienceAdapter?.onCreateRelease?.()}
+        >
+          Create adapter
+        </button>
+        <button
+          type='button'
+          onClick={() =>
+            void experienceAdapter?.onCopy?.(
+              '/demo-copy',
+              'Smart link',
+              'copy-smart-link'
+            )
+          }
+        >
+          Copy adapter
+        </button>
+        <button
+          type='button'
+          onClick={() =>
+            void experienceAdapter?.onSaveMetadata?.('release-1', {
+              label: 'Demo Label',
+              upc: '123456789012',
+            })
+          }
+        >
+          Save metadata adapter
+        </button>
+        <button
+          type='button'
+          onClick={() =>
+            void experienceAdapter?.onSavePrimaryIsrc?.(
+              'release-1',
+              'USJV12600001'
+            )
+          }
+        >
+          Save ISRC adapter
+        </button>
+      </div>
+    ),
+  })
+);
+
+const { DemoShowcaseSurface } = await import(
+  '@/features/demo/DemoShowcaseSurface'
+);
+
+describe('DemoShowcaseSurface release actions', () => {
+  beforeEach(() => {
+    mocks.searchParams.current = new URLSearchParams('state=connected-empty');
+    mocks.clipboardWriteText.mockClear();
+    mocks.toastError.mockClear();
+    mocks.toastInfo.mockClear();
+    mocks.toastSuccess.mockClear();
+
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: mocks.clipboardWriteText,
+      },
+    });
+  });
+
+  it('wires showcase release actions to demo feedback instead of no-op callbacks', async () => {
+    render(<DemoShowcaseSurface surface='releases' />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sync adapter' }));
+    expect(mocks.toastInfo).toHaveBeenCalledWith(
+      'Spotify sync is disabled in demo mode'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create adapter' }));
+    expect(mocks.toastInfo).toHaveBeenCalledWith(
+      'Creating releases is disabled in demo mode'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy adapter' }));
+
+    await waitFor(() => {
+      expect(mocks.clipboardWriteText).toHaveBeenCalledWith(
+        expect.stringContaining('/demo-copy')
+      );
+      expect(mocks.toastSuccess).toHaveBeenCalledWith(
+        'Smart link copied (demo)'
+      );
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Save metadata adapter' })
+    );
+    expect(mocks.toastInfo).toHaveBeenCalledWith(
+      'Metadata editing is disabled in demo mode'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save ISRC adapter' }));
+    expect(mocks.toastInfo).toHaveBeenCalledWith(
+      'Primary ISRC editing is disabled in demo mode'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Extract the demo release experience adapter into a shared helper used by the full demo and showcase release states
- Wire showcase release sync/create/copy/edit actions to demo feedback instead of silent no-op callbacks
- Keep demo metadata and primary-ISRC saves inside the demo adapter so editable demo drawers do not fall back to live save handlers

## Linear
- JOV-2729
- Verification-discovered shell hydration issue tracked separately in JOV-2730

## Test Plan
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/demo/demo-showcase-releases-actions.test.tsx tests/unit/demo/demo-releases-experience.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm biome check apps/web/components/features/demo/demo-release-experience-adapter.ts apps/web/components/features/demo/DemoReleasesExperience.tsx apps/web/components/features/demo/DemoShowcaseSurface.tsx apps/web/tests/unit/demo/demo-showcase-releases-actions.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint

## Visual / Layout Evidence
- Local route: http://localhost:3102/demo/showcase/releases?state=connected-empty
- Mobile viewport: 390x844
- Release matrix bounds stayed 390x716 before click, after Sync from Spotify, and after Create Release
- Document scroll stayed 390x844 for the same states
- Screenshot: .gstack/design-reports/screenshots/jov-2729-showcase-releases-actions-390x844.png

## Notes
- The layout audit surfaced an existing app-shell hydration mismatch unrelated to this adapter change. It is tracked as JOV-2730 with the exact route and error text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved demo mode action feedback with consistent user notifications when attempting restricted operations.

* **Tests**
  * Added comprehensive test coverage for demo showcase release interactions and clipboard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->