### PR TITLE
fix(web): stabilize sidebar hydration on mobile

### DIFF
--- a/apps/web/components/organisms/sidebar/sidebar.tsx
+++ b/apps/web/components/organisms/sidebar/sidebar.tsx
@@ -68,50 +68,48 @@ export const Sidebar = React.forwardRef<
           </SheetContent>
         </Sheet>
 
-        {/* Desktop Sidebar - hidden on mobile via CSS class */}
-        {!isMobile && (
+        {/* Desktop Sidebar - always in tree so SSR and first client render match. */}
+        <div
+          ref={ref}
+          className='group peer max-lg:hidden shrink-0 overflow-visible text-sidebar-foreground lg:sticky lg:top-0 lg:z-10'
+          data-state={state}
+          data-collapsible={state === 'closed' ? collapsible : ''}
+          data-variant={variant}
+          data-side={side}
+        >
           <div
-            ref={ref}
-            className='group peer max-lg:hidden shrink-0 overflow-visible text-sidebar-foreground lg:sticky lg:top-0 lg:z-10'
-            data-state={state}
-            data-collapsible={state === 'closed' ? collapsible : ''}
-            data-variant={variant}
-            data-side={side}
+            className={cn(
+              'duration-cinematic relative h-full w-(--sidebar-width) overflow-hidden transition-[width,transform,opacity] ease-cinematic motion-reduce:transition-none',
+              'group-data-[collapsible=offcanvas]:w-0',
+              state === 'closed' &&
+                collapsible === 'offcanvas' &&
+                side === 'left' &&
+                '-translate-x-[calc(100%+0.5rem)] opacity-0',
+              state === 'closed' &&
+                collapsible === 'offcanvas' &&
+                side === 'right' &&
+                'translate-x-[calc(100%+0.5rem)] opacity-0',
+              'group-data-[side=right]:rotate-180',
+              // Prevent pointer events from leaking into content area during width transition
+              'group-data-[collapsible=icon]:pointer-events-none',
+              variant === 'floating' &&
+                'px-2 py-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+1rem+2px)]',
+              variant === 'inset' &&
+                'px-2 py-0 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+1rem+2px)]',
+              variant === 'sidebar' &&
+                'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
+              className
+            )}
+            {...props}
           >
             <div
-              className={cn(
-                'duration-cinematic relative h-full w-(--sidebar-width) overflow-hidden transition-[width,transform,opacity] ease-cinematic motion-reduce:transition-none',
-                'group-data-[collapsible=offcanvas]:w-0',
-                state === 'closed' &&
-                  collapsible === 'offcanvas' &&
-                  side === 'left' &&
-                  '-translate-x-[calc(100%+0.5rem)] opacity-0',
-                state === 'closed' &&
-                  collapsible === 'offcanvas' &&
-                  side === 'right' &&
-                  'translate-x-[calc(100%+0.5rem)] opacity-0',
-                'group-data-[side=right]:rotate-180',
-                // Prevent pointer events from leaking into content area during width transition
-                'group-data-[collapsible=icon]:pointer-events-none',
-                variant === 'floating' &&
-                  'px-2 py-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+1rem+2px)]',
-                variant === 'inset' &&
-                  'px-2 py-0 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+1rem+2px)]',
-                variant === 'sidebar' &&
-                  'group-data-[collapsible=icon]:w-(--sidebar-width-icon)',
-                className
-              )}
-              {...props}
+              data-sidebar='sidebar'
+              className='pointer-events-auto flex h-full w-full flex-col overflow-clip bg-sidebar transition-[background-color] duration-normal ease-interactive lg:rounded-[var(--linear-app-shell-radius)] lg:shadow-[var(--linear-app-sidebar-shadow)] group-data-[variant=floating]:rounded-[14px] group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow group-data-[variant=inset]:border-r group-data-[variant=inset]:border-sidebar-border'
             >
-              <div
-                data-sidebar='sidebar'
-                className='pointer-events-auto flex h-full w-full flex-col overflow-clip bg-sidebar transition-[background-color] duration-normal ease-interactive lg:rounded-[var(--linear-app-shell-radius)] lg:shadow-[var(--linear-app-sidebar-shadow)] group-data-[variant=floating]:rounded-[14px] group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow group-data-[variant=inset]:border-r group-data-[variant=inset]:border-sidebar-border'
-              >
-                {children}
-              </div>
+              {children}
             </div>
           </div>
-        )}
+        </div>
       </>
     );
   }

--- a/apps/web/tests/unit/components/organisms/Sidebar.hydration.test.tsx
+++ b/apps/web/tests/unit/components/organisms/Sidebar.hydration.test.tsx
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Sidebar, SidebarProvider } from '@/components/organisms/Sidebar';
+
+const originalMatchMedia = globalThis.matchMedia;
+
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(globalThis, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+});
+
+describe('Sidebar hydration stability', () => {
+  it('keeps the desktop sidebar subtree in the first mobile render', () => {
+    mockMatchMedia(true);
+
+    const { container } = render(
+      <SidebarProvider>
+        <Sidebar>
+          <div data-testid='sidebar-child'>Navigation</div>
+        </Sidebar>
+        <main id='main-content'>Main content</main>
+      </SidebarProvider>
+    );
+
+    const desktopSidebar = container.querySelector('[data-variant="sidebar"]');
+
+    expect(desktopSidebar).not.toBeNull();
+    expect(desktopSidebar).toHaveClass('max-lg:hidden');
+    expect(
+      desktopSidebar?.querySelector('[data-testid="sidebar-child"]')
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes JOV-2730.

- Keeps the desktop sidebar subtree mounted during the first mobile client render so SSR and hydration preserve the same DOM order.
- Leaves mobile behavior CSS-driven through the existing `max-lg:hidden` sidebar class instead of branching the DOM on `matchMedia`.
- Adds a focused unit regression for the mobile first-render sidebar tree.

## Evidence

Before the fix, `/demo/showcase/releases?state=connected-empty` at `390x844` produced a React hydration error where the server-rendered desktop sidebar wrapper conflicted with client `main#main-content`.

After the fix, the same route at `390x844` reports:

- Hydration messages: `[]`
- Dev overlay issue count: `0`
- `main#main-content` bounds: `x=0`, `width=390`, `height=844`
- Timed samples at 100ms, 1000ms, and 3000ms all held the shell and main region at `390x844` with document scroll `390x844`.

Local screenshot proof:

- `.gstack/design-reports/screenshots/jov-2730-before-mobile-hydration.png`
- `.gstack/design-reports/screenshots/jov-2730-after-mobile-hydration.png`

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/components/organisms/Sidebar.hydration.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check apps/web/components/organisms/sidebar/sidebar.tsx apps/web/tests/unit/components/organisms/Sidebar.hydration.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=no_agent git diff --check`
- Direct Playwright mobile browser check against `http://localhost:3103/demo/showcase/releases?state=connected-empty`
- Pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced sidebar component rendering for improved stability during app initialization

* **Tests**
  * Added hydration stability tests for the sidebar component

<!-- end of auto-generated comment: release notes by coderabbit.ai -->