### PR TITLE
fix(ui): tokenize switch system b states

### DIFF
--- a/packages/ui/atoms/switch.test.tsx
+++ b/packages/ui/atoms/switch.test.tsx
@@ -106,7 +106,7 @@ describe('Switch', () => {
       render(<Switch aria-label='Toggle' data-testid='switch' />);
       const switchElement = screen.getByTestId('switch');
       expect(switchElement.className).toContain(
-        'data-[state=unchecked]:bg-white/[0.08]'
+        'data-[state=unchecked]:bg-surface-2'
       );
     });
 
@@ -114,7 +114,7 @@ describe('Switch', () => {
       render(<Switch aria-label='Toggle' data-testid='switch' />);
       const switchElement = screen.getByTestId('switch');
       expect(switchElement.className).toContain(
-        'data-[state=unchecked]:hover:bg-white/[0.12]'
+        'data-[state=unchecked]:hover:bg-surface-3'
       );
     });
 
@@ -122,7 +122,7 @@ describe('Switch', () => {
       render(<Switch aria-label='Toggle' data-testid='switch' />);
       const switchElement = screen.getByTestId('switch');
       expect(switchElement.className).toContain(
-        'data-[state=checked]:hover:bg-[var(--color-accent-hover)]'
+        'data-[state=checked]:hover:bg-btn-primary-hover'
       );
     });
 
@@ -132,7 +132,7 @@ describe('Switch', () => {
       );
       const switchElement = screen.getByTestId('switch');
       expect(switchElement.className).toContain(
-        'data-[state=checked]:bg-[var(--color-accent)]'
+        'data-[state=checked]:bg-btn-primary'
       );
     });
 
@@ -140,9 +140,7 @@ describe('Switch', () => {
       render(<Switch aria-label='Toggle' data-testid='switch' />);
       const switchElement = screen.getByTestId('switch');
       expect(switchElement.className).toContain('focus-visible:ring-2');
-      expect(switchElement.className).toContain(
-        'focus-visible:ring-(--color-accent)'
-      );
+      expect(switchElement.className).toContain('focus-visible:ring-focus');
     });
 
     it('applies disabled styling', () => {
@@ -174,12 +172,34 @@ describe('Switch', () => {
       expect(thumb).toBeInTheDocument();
     });
 
-    it('thumb translates when checked', () => {
+    it('thumb uses tokenized margin state when checked', () => {
       render(<Switch defaultChecked aria-label='Toggle' />);
       const switchElement = screen.getByRole('switch');
-      // The thumb child has translate classes
       const thumb = switchElement.firstChild;
-      expect(thumb?.className || '').toContain('translate');
+      expect(thumb?.className || '').toContain('data-[state=checked]:ml-3');
+      expect(thumb?.className || '').not.toContain('translate');
+    });
+
+    it('keeps fixed track and thumb dimensions across state changes', () => {
+      const { rerender } = render(
+        <Switch aria-label='Toggle' data-testid='switch' />
+      );
+      const switchElement = screen.getByTestId('switch');
+      const thumb = switchElement.firstChild;
+
+      expect(switchElement.className).toContain('h-4');
+      expect(switchElement.className).toContain('w-7');
+      expect(thumb?.className || '').toContain('h-3');
+      expect(thumb?.className || '').toContain('w-3');
+
+      rerender(
+        <Switch defaultChecked aria-label='Toggle' data-testid='switch' />
+      );
+
+      expect(switchElement.className).toContain('h-4');
+      expect(switchElement.className).toContain('w-7');
+      expect(thumb?.className || '').toContain('h-3');
+      expect(thumb?.className || '').toContain('w-3');
     });
   });
 
@@ -274,13 +294,11 @@ describe('Switch', () => {
       const switchElement = screen.getByTestId('switch');
       const classes = switchElement.className;
 
-      // Unchecked track must use a visible background
-      expect(classes).toContain('data-[state=unchecked]:bg-white/[0.08]');
+      // Unchecked track must use a visible tokenized background
+      expect(classes).toContain('data-[state=unchecked]:bg-surface-2');
 
-      // Checked track must use the System B accent token
-      expect(classes).toContain(
-        'data-[state=checked]:bg-[var(--color-accent)]'
-      );
+      // Checked track must use the primary button token
+      expect(classes).toContain('data-[state=checked]:bg-btn-primary');
     });
 
     it('checked and unchecked use different background colors', () => {
@@ -288,10 +306,13 @@ describe('Switch', () => {
       const classes = screen.getByTestId('switch').className;
 
       // Extract the unchecked and checked bg classes to verify they differ
-      const uncheckedBg = classes.match(
-        /data-\[state=unchecked\]:bg-[^\s]+/
-      )?.[0];
-      const checkedBg = classes.match(/data-\[state=checked\]:bg-[^\s]+/)?.[0];
+      const classList = classes.split(/\s+/);
+      const uncheckedBg = classList.find(token =>
+        token.startsWith('data-[state=unchecked]:bg-')
+      );
+      const checkedBg = classList.find(token =>
+        token.startsWith('data-[state=checked]:bg-')
+      );
 
       expect(uncheckedBg).toBeDefined();
       expect(checkedBg).toBeDefined();

--- a/packages/ui/atoms/switch.tsx
+++ b/packages/ui/atoms/switch.tsx
@@ -6,8 +6,8 @@ import * as React from 'react';
 import { cn } from '../lib/utils';
 
 /**
- * Switch component matching Linear.app toggle design.
- * 28×16px track, 12×12px thumb, System B motion and accent tokens.
+ * System B switch component.
+ * 28×16px track, 12×12px thumb, tokenized 150ms state transition.
  * Supports keyboard navigation, disabled state, and focus ring.
  */
 const Switch = React.forwardRef<
@@ -17,11 +17,11 @@ const Switch = React.forwardRef<
   <SwitchPrimitives.Root
     className={cn(
       'peer inline-flex h-4 w-7 shrink-0 cursor-pointer items-center rounded-full px-0.5',
-      'transition-colors duration-subtle ease-[var(--ds-motion-subtle-easing)]',
-      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2',
+      'transition-colors duration-fast ease-interactive',
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus focus-visible:ring-offset-2 focus-visible:ring-offset-surface-page',
       'disabled:cursor-not-allowed disabled:opacity-50',
-      'data-[state=unchecked]:bg-white/[0.08] data-[state=unchecked]:hover:bg-white/[0.12] disabled:data-[state=unchecked]:hover:bg-white/[0.08]',
-      'data-[state=checked]:bg-[var(--color-accent)] data-[state=checked]:hover:bg-[var(--color-accent-hover)] disabled:data-[state=checked]:hover:bg-[var(--color-accent)]',
+      'data-[state=unchecked]:bg-surface-2 data-[state=unchecked]:hover:bg-surface-3 disabled:data-[state=unchecked]:hover:bg-surface-2',
+      'data-[state=checked]:bg-btn-primary data-[state=checked]:hover:bg-btn-primary-hover disabled:data-[state=checked]:hover:bg-btn-primary',
       className
     )}
     {...props}
@@ -29,10 +29,9 @@ const Switch = React.forwardRef<
   >
     <SwitchPrimitives.Thumb
       className={cn(
-        'pointer-events-none block h-3 w-3 rounded-full bg-white shadow-sm ring-0',
-        'transition-transform duration-subtle ease-[var(--ds-motion-subtle-easing)]',
-        'data-[state=unchecked]:translate-x-0',
-        'data-[state=checked]:translate-x-3'
+        'pointer-events-none block h-3 w-3 rounded-full bg-btn-primary-foreground shadow-sm ring-0',
+        'transition-[margin] duration-fast ease-interactive',
+        'data-[state=checked]:ml-3'
       )}
     />
   </SwitchPrimitives.Root>


### PR DESCRIPTION
## Summary

- JOV-2548 slice: move the shared UI `Switch` atom off raw white/accent classes and onto System B surface, button, foreground, focus, and timing tokens.
- Replace thumb translate motion with tokenized margin state so the switch keeps fixed track/thumb dimensions without transform-based decorative motion.
- Strengthen the focused switch tests to cover tokenized state colors, focus ring, no-translate motion, and fixed dimensions across checked/unchecked states.

## Layout Shift Audit

Enumerated visual states: unchecked, checked, disabled, focus-visible, and checked/unchecked state transition. The switch root keeps fixed `h-4 w-7` dimensions and the thumb keeps fixed `h-3 w-3` dimensions across state changes. The focused test now asserts those fixed dimensions and asserts the thumb no longer uses translate classes.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write packages/ui/atoms/switch.tsx packages/ui/atoms/switch.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/ui exec vitest run atoms/switch.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/ui run typecheck`
- `JOVIE_AGENT_PROFILE=no_agent git diff --check`
- pre-commit hook passed: proxy guard + lint-staged Biome
- pre-push hook passed: repo Biome + proxy guard + Tailwind guard + web typecheck + web lint

## Pre-Landing Review

Pre-landing review on the two-file diff found no SQL/data, auth, shell, enum, CI/distribution, or concurrency risks. The user-visible change is scoped to tokenized switch visual states and non-transform thumb motion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Switch component styling to align with new design tokens, including revised background colors for checked/unchecked states, updated focus ring styling, and improved thumb positioning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->