### PR TITLE
fix(chat): normalize attachment affordance styling

### DIFF
--- a/apps/web/components/jovie/components/ChatAvatarUploadCard.tsx
+++ b/apps/web/components/jovie/components/ChatAvatarUploadCard.tsx
@@ -94,7 +94,7 @@ export function ChatAvatarUploadCard() {
 
   if (state === 'success') {
     return (
-      <ContentSurfaceCard className='border-success/20 bg-[color-mix(in_oklab,var(--color-success)_8%,var(--linear-app-content-surface))] p-4'>
+      <ContentSurfaceCard className='system-b-chat-avatar-upload-state-card system-b-chat-avatar-upload-state-card-success'>
         <div className='flex items-center gap-2 text-success'>
           <Check className='h-4 w-4' />
           <span className='text-sm font-medium'>Profile photo updated</span>
@@ -105,7 +105,7 @@ export function ChatAvatarUploadCard() {
 
   if (state === 'error') {
     return (
-      <ContentSurfaceCard className='border-error/20 bg-[color-mix(in_oklab,var(--color-error)_8%,var(--linear-app-content-surface))] p-4'>
+      <ContentSurfaceCard className='system-b-chat-avatar-upload-state-card system-b-chat-avatar-upload-state-card-error'>
         <div className='flex items-center justify-between'>
           <div className='flex items-center gap-2 text-error'>
             <X className='h-4 w-4' />
@@ -134,7 +134,7 @@ export function ChatAvatarUploadCard() {
         className='hidden'
         tabIndex={-1}
       />
-      <ContentSurfaceCard className='border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-3'>
+      <ContentSurfaceCard className='system-b-chat-avatar-upload-card'>
         <button
           type='button'
           onClick={handleClick}
@@ -143,10 +143,8 @@ export function ChatAvatarUploadCard() {
           onDrop={handleDrop}
           disabled={state === 'uploading'}
           className={cn(
-            'w-full rounded-[8px] border border-dashed p-8 text-center transition-colors',
-            isDragOver
-              ? 'border-accent bg-accent/10'
-              : 'border-(--linear-app-frame-seam) bg-surface-0 hover:border-accent/50 hover:bg-surface-1',
+            'system-b-chat-avatar-upload-dropzone',
+            isDragOver && 'system-b-chat-avatar-upload-dropzone-active',
             state === 'uploading' && 'pointer-events-none opacity-60'
           )}
         >
@@ -160,7 +158,7 @@ export function ChatAvatarUploadCard() {
               </>
             ) : (
               <>
-                <span className='flex h-10 w-10 items-center justify-center rounded-[8px] border border-subtle bg-surface-1'>
+                <span className='system-b-chat-avatar-upload-icon-shell'>
                   <ImagePlus
                     className={cn(
                       'h-5 w-5',

--- a/apps/web/components/jovie/components/ChatLinkConfirmationCard.tsx
+++ b/apps/web/components/jovie/components/ChatLinkConfirmationCard.tsx
@@ -130,7 +130,7 @@ export function ChatLinkConfirmationCard({
 
   if (state === 'dismissed') {
     return (
-      <ContentSurfaceCard className='border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-4 opacity-60'>
+      <ContentSurfaceCard className='border-(--system-b-app-frame-seam) bg-(--system-b-app-content-surface) p-4 opacity-60'>
         <div className='flex items-center gap-2 text-secondary-token'>
           <X className='h-4 w-4' />
           <span className='text-sm'>Link dismissed</span>
@@ -140,9 +140,9 @@ export function ChatLinkConfirmationCard({
   }
 
   return (
-    <ContentSurfaceCard className='border-accent/20 bg-[color-mix(in_oklab,var(--linear-accent)_8%,var(--linear-app-content-surface))] p-4'>
+    <ContentSurfaceCard className='system-b-chat-link-card system-b-chat-link-card-add'>
       <div className='flex items-center gap-3'>
-        <span className='flex h-9 w-9 shrink-0 items-center justify-center rounded-[8px] border border-accent/20 bg-[color-mix(in_oklab,var(--linear-accent)_10%,var(--linear-app-content-surface))]'>
+        <span className='system-b-chat-link-card-icon system-b-chat-link-card-icon-add'>
           <SocialIcon
             platform={normalizeSocialPlatform(platform.icon)}
             className='h-5 w-5 shrink-0'
@@ -168,7 +168,7 @@ export function ChatLinkConfirmationCard({
             onClick={handleAdd}
             disabled={state === 'adding'}
             className={cn(
-              'inline-flex items-center gap-1 rounded-[8px] px-2.5 py-1.5 text-xs font-medium',
+              'system-b-chat-link-primary-action',
               'bg-accent text-accent-foreground hover:bg-accent/90',
               'disabled:opacity-50 transition-colors'
             )}
@@ -185,7 +185,7 @@ export function ChatLinkConfirmationCard({
             onClick={handleDismiss}
             disabled={state === 'adding'}
             className={cn(
-              'inline-flex items-center gap-1 rounded-[8px] border border-transparent p-1.5 text-xs',
+              'system-b-chat-link-dismiss-action',
               'text-secondary-token hover:bg-surface-0 hover:text-primary-token',
               'disabled:opacity-50 transition-colors'
             )}

--- a/apps/web/components/jovie/components/ChatLinkRemovalCard.tsx
+++ b/apps/web/components/jovie/components/ChatLinkRemovalCard.tsx
@@ -103,7 +103,7 @@ export function ChatLinkRemovalCard({
 
   if (state === 'dismissed') {
     return (
-      <ContentSurfaceCard className='border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) p-4 opacity-60'>
+      <ContentSurfaceCard className='border-(--system-b-app-frame-seam) bg-(--system-b-app-content-surface) p-4 opacity-60'>
         <div className='flex items-center gap-2 text-secondary-token'>
           <X className='h-4 w-4' />
           <span className='text-sm'>Removal cancelled</span>
@@ -113,9 +113,9 @@ export function ChatLinkRemovalCard({
   }
 
   return (
-    <ContentSurfaceCard className='border-error/20 bg-[color-mix(in_oklab,var(--color-error)_8%,var(--linear-app-content-surface))] p-4'>
+    <ContentSurfaceCard className='system-b-chat-link-card system-b-chat-link-card-remove'>
       <div className='flex items-center gap-3'>
-        <span className='flex h-9 w-9 shrink-0 items-center justify-center rounded-[8px] border border-error/20 bg-[color-mix(in_oklab,var(--color-error)_8%,var(--linear-app-content-surface))]'>
+        <span className='system-b-chat-link-card-icon system-b-chat-link-card-icon-remove'>
           <SocialIcon
             platform={normalizeSocialPlatform(platform)}
             className='h-5 w-5 shrink-0'
@@ -139,7 +139,7 @@ export function ChatLinkRemovalCard({
             onClick={handleRemove}
             disabled={state === 'removing'}
             className={cn(
-              'inline-flex items-center gap-1 rounded-[8px] px-2.5 py-1.5 text-xs font-medium',
+              'system-b-chat-link-primary-action',
               'bg-error text-error-foreground hover:bg-error/90',
               'disabled:opacity-50 transition-colors'
             )}
@@ -156,7 +156,7 @@ export function ChatLinkRemovalCard({
             onClick={handleDismiss}
             disabled={state === 'removing'}
             className={cn(
-              'inline-flex items-center gap-1 rounded-[8px] border border-transparent p-1.5 text-xs',
+              'system-b-chat-link-dismiss-action',
               'text-secondary-token hover:bg-surface-0 hover:text-primary-token',
               'disabled:opacity-50 transition-colors'
             )}

--- a/apps/web/components/jovie/components/ImageAttachmentChip.test.tsx
+++ b/apps/web/components/jovie/components/ImageAttachmentChip.test.tsx
@@ -56,7 +56,7 @@ describe('ImageAttachmentChip', () => {
     expect(screen.getByTestId('image-attachment-popover-content')).toBeTruthy();
   });
 
-  it('uses the chat overlay tier with an opaque viewport-bounded surface', async () => {
+  it('uses the chat overlay tier with a System B popover surface', async () => {
     const user = userEvent.setup();
     renderChip();
 
@@ -66,13 +66,7 @@ describe('ImageAttachmentChip', () => {
       'image-attachment-popover-content'
     );
 
-    expect(content.className).toContain('z-[150]');
-    expect(content.className).toContain('bg-surface-1');
-    expect(content.className).toContain('shadow-popover');
-    expect(content.className).toContain('calc(100vw-24px)');
-    expect(content.className).toContain(
-      '--radix-popover-content-available-height'
-    );
+    expect(content.className).toContain('system-b-image-attachment-popover');
   });
 
   it('opens on keyboard Enter and closes on Escape', async () => {

--- a/apps/web/components/jovie/components/ImageAttachmentChip.tsx
+++ b/apps/web/components/jovie/components/ImageAttachmentChip.tsx
@@ -87,10 +87,10 @@ export function ImageAttachmentChip({
   const label = name && name.trim().length > 0 ? name : 'Image';
 
   const chipClass = cn(
-    'inline-flex items-center gap-1.5 align-baseline rounded-md border px-1.5 py-0.5 leading-5 select-none',
+    'system-b-image-attachment-chip',
     tone === 'onLight'
-      ? 'border-black/10 bg-black/[0.04] text-[#111216]'
-      : 'border-white/10 bg-white/[0.04] text-primary-token'
+      ? 'system-b-image-attachment-chip-light'
+      : 'system-b-image-attachment-chip-dark'
   );
 
   return (
@@ -103,10 +103,7 @@ export function ImageAttachmentChip({
           aria-label={`Image attachment: ${label}`}
           onPointerEnter={handlePointerEnter}
           onPointerLeave={handlePointerLeave}
-          className={cn(
-            'inline-flex items-baseline align-baseline appearance-none p-0 m-0 bg-transparent border-0 cursor-pointer',
-            'focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_oklab,var(--linear-border-focus)_72%,transparent)] focus-visible:rounded-md'
-          )}
+          className='system-b-image-attachment-trigger'
           data-testid='image-attachment-chip-trigger'
         >
           <span className={chipClass} data-testid='image-attachment-chip'>
@@ -115,18 +112,16 @@ export function ImageAttachmentChip({
               alt=''
               width={16}
               height={16}
-              className='h-4 w-4 rounded-sm object-cover shrink-0'
+              className='system-b-image-attachment-thumb'
               unoptimized
               aria-hidden
             />
-            <span className='min-w-0 max-w-[180px] truncate text-[13px] leading-5'>
-              {label}
-            </span>
+            <span className='system-b-image-attachment-label'>{label}</span>
           </span>
         </button>
       </PopoverTrigger>
       <PopoverContent
-        className='z-[150] max-h-[var(--radix-popover-content-available-height)] w-auto max-w-[min(520px,calc(100vw-24px))] overflow-hidden rounded-xl border border-(--linear-app-frame-seam) bg-surface-1 p-0 shadow-popover'
+        className='system-b-image-attachment-popover'
         sideOffset={6}
         align='start'
         testId='image-attachment-popover-content'
@@ -146,7 +141,7 @@ export function ImageAttachmentChip({
               alt={label}
               width={480}
               height={480}
-              className='h-auto max-h-[min(480px,calc(var(--radix-popover-content-available-height,520px)-44px),calc(100vh-12rem))] w-auto max-w-[min(480px,calc(100vw-24px))] object-contain'
+              className='system-b-image-attachment-preview'
               unoptimized
             />
           </div>

--- a/apps/web/components/jovie/components/ImagePreviewStrip.tsx
+++ b/apps/web/components/jovie/components/ImagePreviewStrip.tsx
@@ -4,8 +4,6 @@ import { X } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import Image from 'next/image';
 
-import { cn } from '@/lib/utils';
-
 import type { PendingImage } from '../hooks/useChatImageAttachments';
 
 interface ImagePreviewStripProps {
@@ -20,12 +18,10 @@ export function ImagePreviewStrip({
   if (images.length === 0) return null;
 
   return (
-    <div className='rounded-[10px] border border-(--linear-app-frame-seam) bg-surface-0 p-3'>
+    <div className='system-b-image-preview-strip'>
       <div className='mb-3 flex items-center justify-between gap-3'>
         <div>
-          <p className='text-2xs font-medium tracking-[-0.01em] text-secondary-token'>
-            Attachments
-          </p>
+          <p className='system-b-image-preview-strip-title'>Attachments</p>
           <p className='text-xs text-tertiary-token'>
             {images.length} image{images.length === 1 ? '' : 's'} ready to send
           </p>
@@ -37,10 +33,10 @@ export function ImagePreviewStrip({
           {images.map(image => (
             <motion.div
               key={image.id}
-              className='group relative h-20 w-20 shrink-0 overflow-hidden rounded-[10px] border border-(--linear-app-frame-seam) bg-surface-1'
-              initial={{ opacity: 0, scale: 0.8 }}
-              animate={{ opacity: 1, scale: 1 }}
-              exit={{ opacity: 0, scale: 0.8 }}
+              className='system-b-image-preview-item'
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
               transition={{ duration: 0.15 }}
             >
               <Image
@@ -50,7 +46,7 @@ export function ImagePreviewStrip({
                 className='object-cover'
                 unoptimized
               />
-              <div className='absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 via-black/25 to-transparent px-2 pb-2 pt-5'>
+              <div className='system-b-image-preview-caption'>
                 <p className='truncate text-2xs font-medium text-white'>
                   {image.name}
                 </p>
@@ -58,11 +54,7 @@ export function ImagePreviewStrip({
               <button
                 type='button'
                 onClick={() => onRemove(image.id)}
-                className={cn(
-                  'absolute right-1.5 top-1.5 flex h-6 w-6 items-center justify-center',
-                  'rounded-[8px] border border-white/15 bg-black/55 text-white transition-opacity',
-                  'opacity-100 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 focus-visible:opacity-100'
-                )}
+                className='system-b-image-preview-remove-button'
                 aria-label={`Remove ${image.name}`}
               >
                 <X className='h-3.5 w-3.5' />

--- a/apps/web/components/jovie/components/ScrollToBottom.tsx
+++ b/apps/web/components/jovie/components/ScrollToBottom.tsx
@@ -3,8 +3,6 @@
 import { ArrowDown } from 'lucide-react';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 
-import { cn } from '@/lib/utils';
-
 interface ScrollToBottomProps {
   readonly visible: boolean;
   readonly onClick: () => void;
@@ -27,18 +25,10 @@ export function ScrollToBottom({ visible, onClick }: ScrollToBottomProps) {
           animate={shouldReduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
           exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 8 }}
           transition={{ duration: 0.15 }}
-          className={cn(
-            'absolute bottom-3 left-1/2 z-10 -translate-x-1/2',
-            'inline-flex items-center gap-2 rounded-full',
-            'border border-subtle bg-surface-1/95 px-3.5 py-2 backdrop-blur',
-            'text-2xs font-medium uppercase tracking-[0.16em] text-secondary-token',
-            'shadow-[0_10px_32px_-20px_rgba(15,23,42,0.7)] transition-[background-color,color,opacity,box-shadow]',
-            'hover:bg-surface-2 hover:text-primary-token',
-            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/20'
-          )}
+          className='system-b-scroll-to-bottom'
           aria-label='Scroll to latest messages'
         >
-          <span className='flex h-5 w-5 items-center justify-center rounded-full bg-surface-2 text-primary-token'>
+          <span className='system-b-scroll-to-bottom-icon'>
             <ArrowDown className='h-3 w-3' />
           </span>{' '}
           Latest

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2604,6 +2604,358 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   color: var(--color-error);
 }
 
+:where(.system-b-image-attachment-trigger) {
+  display: inline-flex;
+  align-items: baseline;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  appearance: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+:where(.system-b-image-attachment-trigger:focus) {
+  outline: none;
+}
+
+:where(.system-b-image-attachment-trigger:focus-visible) {
+  border-radius: var(--radius-md);
+  outline: none;
+  box-shadow: 0 0 0 2px
+    color-mix(in oklab, var(--color-border-focus) 72%, transparent);
+}
+
+:where(.system-b-image-attachment-chip) {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  padding: var(--space-0-5) var(--space-1-5);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  line-height: var(--space-5);
+  user-select: none;
+  vertical-align: baseline;
+}
+
+:where(.system-b-image-attachment-chip-light) {
+  border-color: color-mix(in oklab, black 10%, transparent);
+  background: color-mix(in oklab, black 4%, transparent);
+  color: var(
+    --system-b-entity-chip-on-light-text,
+    var(--color-text-primary-token)
+  );
+}
+
+:where(.system-b-image-attachment-chip-dark) {
+  border-color: color-mix(in oklab, white 10%, transparent);
+  background: color-mix(in oklab, white 4%, transparent);
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-image-attachment-thumb) {
+  width: var(--space-4);
+  height: var(--space-4);
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  object-fit: cover;
+}
+
+:where(.system-b-image-attachment-label) {
+  min-width: 0;
+  max-width: 180px;
+  overflow: hidden;
+  font-size: var(--text-app);
+  line-height: var(--space-5);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:where(.system-b-image-attachment-popover) {
+  z-index: 150;
+  width: auto;
+  max-width: min(520px, calc(100vw - var(--space-6)));
+  max-height: var(--radix-popover-content-available-height);
+  overflow: hidden;
+  border: 1px solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-xl);
+  background: var(--surface-1);
+  padding: 0;
+  box-shadow: var(--shadow-popover);
+}
+
+:where(.system-b-image-attachment-preview) {
+  width: auto;
+  max-width: min(480px, calc(100vw - var(--space-6)));
+  height: auto;
+  max-height: min(
+    480px,
+    calc(var(--radix-popover-content-available-height, 520px) - 44px),
+    calc(100vh - 12rem)
+  );
+  object-fit: contain;
+}
+
+:where(.system-b-image-preview-strip) {
+  border: 1px solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-xl);
+  background: var(--surface-0);
+  padding: var(--space-3);
+}
+
+:where(.system-b-image-preview-strip-title) {
+  color: var(--color-text-secondary-token);
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-medium);
+}
+
+:where(.system-b-image-preview-item) {
+  position: relative;
+  width: var(--space-20);
+  height: var(--space-20);
+  flex-shrink: 0;
+  overflow: hidden;
+  border: 1px solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-xl);
+  background: var(--surface-1);
+}
+
+:where(.system-b-image-preview-caption) {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  padding: var(--space-5) var(--space-2) var(--space-2);
+  background: linear-gradient(
+    to top,
+    color-mix(in oklab, black 70%, transparent),
+    color-mix(in oklab, black 25%, transparent),
+    transparent
+  );
+}
+
+:where(.system-b-image-preview-remove-button) {
+  position: absolute;
+  top: var(--space-1-5);
+  right: var(--space-1-5);
+  display: flex;
+  width: var(--space-6);
+  height: var(--space-6);
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in oklab, white 15%, transparent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklab, black 55%, transparent);
+  color: white;
+  opacity: 1;
+  transition: opacity var(--duration-fast) var(--ease-subtle);
+}
+
+@media (hover: hover) {
+  :where(.system-b-image-preview-remove-button) {
+    opacity: 0;
+  }
+
+  :where(
+      .system-b-image-preview-item:hover .system-b-image-preview-remove-button
+    ) {
+    opacity: 1;
+  }
+}
+
+:where(.system-b-image-preview-remove-button:focus-visible) {
+  opacity: 1;
+}
+
+:where(.system-b-chat-avatar-upload-state-card) {
+  padding: var(--space-4);
+}
+
+:where(.system-b-chat-avatar-upload-state-card-success) {
+  border-color: color-mix(in oklab, var(--color-success) 20%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--color-success) 8%,
+    var(--system-b-app-content-surface)
+  );
+}
+
+:where(.system-b-chat-avatar-upload-state-card-error) {
+  border-color: color-mix(in oklab, var(--color-error) 20%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--color-error) 8%,
+    var(--system-b-app-content-surface)
+  );
+}
+
+:where(.system-b-chat-avatar-upload-card) {
+  border-color: var(--system-b-app-frame-seam);
+  background: var(--system-b-app-content-surface);
+  padding: var(--space-3);
+}
+
+:where(.system-b-chat-avatar-upload-dropzone) {
+  width: 100%;
+  border: 1px dashed var(--system-b-app-frame-seam);
+  border-radius: var(--radius-lg);
+  background: var(--surface-0);
+  padding: var(--space-8);
+  text-align: center;
+  transition: var(--transition-colors);
+}
+
+:where(.system-b-chat-avatar-upload-dropzone:hover) {
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-accent-cyan) 50%,
+    transparent
+  );
+  background: var(--surface-1);
+}
+
+:where(.system-b-chat-avatar-upload-dropzone-active) {
+  border-color: var(--system-b-accent-cyan);
+  background: color-mix(in oklab, var(--system-b-accent-cyan) 10%, transparent);
+}
+
+:where(.system-b-chat-avatar-upload-icon-shell) {
+  display: flex;
+  width: var(--space-10);
+  height: var(--space-10);
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-1);
+}
+
+:where(.system-b-chat-link-card) {
+  padding: var(--space-4);
+}
+
+:where(.system-b-chat-link-card-add) {
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-accent-cyan) 20%,
+    transparent
+  );
+  background: color-mix(
+    in oklab,
+    var(--system-b-accent-cyan) 8%,
+    var(--system-b-app-content-surface)
+  );
+}
+
+:where(.system-b-chat-link-card-remove) {
+  border-color: color-mix(in oklab, var(--color-error) 20%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--color-error) 8%,
+    var(--system-b-app-content-surface)
+  );
+}
+
+:where(.system-b-chat-link-card-icon) {
+  display: flex;
+  width: var(--space-9);
+  height: var(--space-9);
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-lg);
+}
+
+:where(.system-b-chat-link-card-icon-add) {
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-accent-cyan) 20%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--system-b-accent-cyan) 10%,
+    var(--system-b-app-content-surface)
+  );
+}
+
+:where(.system-b-chat-link-card-icon-remove) {
+  border: 1px solid color-mix(in oklab, var(--color-error) 20%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--color-error) 8%,
+    var(--system-b-app-content-surface)
+  );
+}
+
+:where(.system-b-chat-link-primary-action) {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  border-radius: var(--radius-lg);
+  padding: var(--space-1-5) var(--space-2-5);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+}
+
+:where(.system-b-chat-link-dismiss-action) {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  border: 1px solid transparent;
+  border-radius: var(--radius-lg);
+  padding: var(--space-1-5);
+  font-size: var(--text-xs);
+}
+
+:where(.system-b-scroll-to-bottom) {
+  position: absolute;
+  z-index: 10;
+  bottom: var(--space-3);
+  left: 50%;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  border: 1px solid var(--color-border-subtle);
+  border-radius: var(--radius-full);
+  background: color-mix(in oklab, var(--surface-1) 95%, transparent);
+  color: var(--color-text-secondary-token);
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0.16em;
+  padding: var(--space-2) var(--space-3-5);
+  text-transform: uppercase;
+  transform: translateX(-50%);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 10px 32px -20px
+    color-mix(in oklab, var(--system-b-accent-cyan) 35%, black 65%);
+  transition:
+    background-color var(--duration-fast) var(--ease-subtle),
+    color var(--duration-fast) var(--ease-subtle),
+    opacity var(--duration-fast) var(--ease-subtle),
+    box-shadow var(--duration-fast) var(--ease-subtle);
+}
+
+:where(.system-b-scroll-to-bottom:hover) {
+  background: var(--surface-2);
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-scroll-to-bottom:focus-visible) {
+  outline: none;
+  box-shadow:
+    0 10px 32px -20px
+    color-mix(in oklab, var(--system-b-accent-cyan) 35%, black 65%),
+    0 0 0 2px color-mix(in oklab, var(--system-b-accent-cyan) 20%, transparent);
+}
+
+:where(.system-b-scroll-to-bottom-icon) {
+  display: flex;
+  width: var(--space-5);
+  height: var(--space-5);
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-full);
+  background: var(--surface-2);
+  color: var(--color-text-primary-token);
+}
+
 /* ============================================
    SYSTEM B LAUNCH PAGE
    ============================================ */

--- a/apps/web/tests/unit/chat/chat-attachments-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/chat-attachments-style-guard.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const guardedSources = [
+  'components/jovie/components/ImageAttachmentChip.tsx',
+  'components/jovie/components/ImagePreviewStrip.tsx',
+  'components/jovie/components/ChatAvatarUploadCard.tsx',
+  'components/jovie/components/ChatLinkConfirmationCard.tsx',
+  'components/jovie/components/ChatLinkRemovalCard.tsx',
+  'components/jovie/components/ScrollToBottom.tsx',
+] as const;
+
+const forbiddenVisualPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient|bg-gradient/,
+  /\b(?:bg|border|text|hover:bg|hover:text|focus-visible:ring)-\[/,
+  /\b(?:z|max-h|max-w|min-h|min-w|h|w|rounded|shadow|drop-shadow|tracking|transition)-\[/,
+] as const;
+
+describe('chat attachment and action System B source contract', () => {
+  it('keeps image/link/avatar/scroll affordances on named System B primitives', () => {
+    for (const sourcePath of guardedSources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+
+      for (const pattern of forbiddenVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Move chat image attachment, image preview, avatar upload, link add/remove, and scroll-to-latest affordance visuals into named System B primitives.
- Add `chat-attachments-style-guard.test.ts` so these affordances do not regain raw colors, raw gradients, arbitrary visual Tailwind classes, or one-off shadow/transition recipes in component source.
- Preserve behavior while changing image preview entry/exit to opacity-only motion and keeping fixed preview tile dimensions.

Linear: JOV-2733

## Layout Shift Audit

- Enumerated changed states: image chip light/dark, chip popover open, preview strip add/remove, avatar upload idle/drag/success/error/uploading, link add/remove pending/loading/dismissed/done, scroll-to-latest visible/hidden.
- Stable wrappers remain in place: preview tiles are fixed `var(--space-20)` squares, popover bounds are centralized in CSS, link/avatar card padding remains state-stable, and preview add/remove no longer scales the tile.

## Verification

- `pnpm biome check --write apps/web/components/jovie/components/ImageAttachmentChip.tsx apps/web/components/jovie/components/ImageAttachmentChip.test.tsx apps/web/components/jovie/components/ImagePreviewStrip.tsx apps/web/components/jovie/components/ChatAvatarUploadCard.tsx apps/web/components/jovie/components/ChatLinkConfirmationCard.tsx apps/web/components/jovie/components/ChatLinkRemovalCard.tsx apps/web/components/jovie/components/ScrollToBottom.tsx apps/web/tests/unit/chat/chat-attachments-style-guard.test.ts apps/web/styles/design-system.css`
- `pnpm --filter @jovie/web exec vitest run components/jovie/components/ImageAttachmentChip.test.tsx tests/unit/chat/chat-attachments-style-guard.test.ts tests/unit/chat/InlineChatArea.tool-rendering.test.tsx tests/unit/chat/ChatMessage.test.tsx` passed: 4 files, 22 tests. The run emitted the known mocked Next image `unoptimized` warning; assertions passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Commit hook passed: `next:proxy-guard`, lint-staged Biome, ESLint, staged a11y check, and web typecheck.
- Pre-push passed: `biome check .`, `next:proxy-guard`, `tailwind:check`, web typecheck, and web lint.
- `/ship` pre-landing review: clean. Design-lite review: clean.
