### PR TITLE
fix(chat): normalize suggestion affordance styling

### DIFF
--- a/apps/web/components/jovie/components/SlashCommandMenu.tsx
+++ b/apps/web/components/jovie/components/SlashCommandMenu.tsx
@@ -296,8 +296,8 @@ function SlashHeader({ state }: SlashHeaderProps) {
   if (state.status === 'entity') {
     const Icon = KIND_ICON_MAP[state.kind];
     return (
-      <div className='flex items-center gap-[10px] border-b border-white/[0.055] px-[18px] pb-3 pt-4 text-[13px]'>
-        <span className='inline-flex items-center gap-1.5 rounded-[5px] border border-white/10 bg-white/[0.05] px-2 py-[2px] text-[11px] font-semibold uppercase tracking-[0.04em] text-primary-token shadow-[inset_0_0.5px_0_rgba(255,255,255,0.04)]'>
+      <div className='system-b-slash-header'>
+        <span className='system-b-slash-header-token system-b-slash-header-token-entity'>
           <Icon className='h-3 w-3' strokeWidth={1.6} />
           {entityKindLabel(state.kind)}
         </span>
@@ -310,8 +310,8 @@ function SlashHeader({ state }: SlashHeaderProps) {
     );
   }
   return (
-    <div className='flex items-center gap-[10px] border-b border-white/[0.055] px-[18px] pb-3 pt-4 text-[13px]'>
-      <span className='inline-flex h-[21px] items-center rounded-[4px] bg-white/[0.06] px-1.5 text-[12.5px] font-semibold leading-none text-primary-token shadow-[inset_0_0.5px_0_rgba(255,255,255,0.06),inset_0_0_0_0.5px_rgba(255,255,255,0.04)]'>
+    <div className='system-b-slash-header'>
+      <span className='system-b-slash-header-token system-b-slash-header-token-root'>
         /
       </span>
       {state.query ? (

--- a/apps/web/components/jovie/components/SuggestedProfilesCarousel.tsx
+++ b/apps/web/components/jovie/components/SuggestedProfilesCarousel.tsx
@@ -82,12 +82,8 @@ function CarouselDots({
           <div
             key={index}
             aria-hidden
-            className={cn(
-              'h-1.5 rounded-full transition-[width,background-color] duration-subtle',
-              index === current
-                ? 'w-4 bg-primary-token'
-                : 'w-1.5 bg-tertiary-token/30'
-            )}
+            className='system-b-suggested-profile-dot'
+            data-active={index === current ? 'true' : undefined}
           />
         );
       })}
@@ -111,7 +107,7 @@ function CarouselCardHeader({
   readonly isActioning: boolean;
 }) {
   return (
-    <div className='flex items-center justify-between border-b border-(--linear-app-frame-seam) px-3.5 py-2.5'>
+    <div className='flex items-center justify-between border-b border-(--system-b-app-frame-seam) px-3.5 py-2.5'>
       <div>
         <p className='text-2xs font-semibold tracking-normal text-tertiary-token'>
           Suggested identity
@@ -191,9 +187,7 @@ function ProfileReadyCard({
   return (
     <div
       className={cn(
-        'chat-card overflow-hidden rounded-[14px] border border-(--linear-app-frame-seam)',
-        'bg-(--linear-app-content-surface)',
-        'transition-[opacity,transform] duration-cinematic ease-out',
+        'system-b-suggested-profile-card',
         direction === 'left' && 'animate-slide-out-left',
         direction === 'right' && 'animate-slide-out-right'
       )}
@@ -263,12 +257,7 @@ function ProfileReadyCard({
           href={username ? `/${username}` : '/'}
           target='_blank'
           rel='noopener noreferrer'
-          className={cn(
-            'flex w-full items-center justify-center gap-1.5 rounded-[12px]',
-            'bg-btn-primary px-3 py-2.5 text-app font-medium text-btn-primary-foreground',
-            'transition-colors hover:bg-btn-primary/90',
-            'focus:outline-none'
-          )}
+          className='system-b-suggested-profile-primary-link'
         >
           View your profile
           <ExternalLink className='h-3.5 w-3.5' />
@@ -309,9 +298,7 @@ function SuggestionCard({
   return (
     <div
       className={cn(
-        'chat-card overflow-hidden rounded-[14px] border border-(--linear-app-frame-seam)',
-        'bg-(--linear-app-content-surface)',
-        'transition-[opacity,transform] duration-cinematic ease-out',
+        'system-b-suggested-profile-card',
         direction === 'left' && 'animate-slide-out-left',
         direction === 'right' && 'animate-slide-out-right'
       )}
@@ -327,7 +314,7 @@ function SuggestionCard({
       <div className='p-4'>
         {/* Header with platform icon */}
         <div className='flex items-center gap-2.5 mb-3'>
-          <div className='flex h-8 w-8 items-center justify-center rounded-[10px] border border-(--linear-app-frame-seam) bg-surface-0'>
+          <div className='system-b-suggested-profile-icon-shell'>
             {isAvatar ? (
               <Camera className='h-4 w-4 text-secondary-token' />
             ) : (
@@ -363,10 +350,10 @@ function SuggestionCard({
         {suggestion.imageUrl && (
           <div
             className={cn(
-              'relative mb-3 overflow-hidden rounded-lg bg-surface-2',
+              'system-b-suggested-profile-image',
               isAvatar
-                ? 'mx-auto h-24 w-24 rounded-full'
-                : 'aspect-[3/1] w-full'
+                ? 'system-b-suggested-profile-image-avatar'
+                : 'system-b-suggested-profile-image-wide'
             )}
           >
             <Image
@@ -401,11 +388,7 @@ function SuggestionCard({
             onClick={onReject}
             disabled={isActioning}
             className={cn(
-              'flex flex-1 items-center justify-center gap-1.5 rounded-[12px]',
-              'border border-subtle px-3 py-3 text-app font-medium sm:py-2',
-              'text-secondary-token transition-colors',
-              'hover:bg-surface-2 hover:text-primary-token',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-btn-primary/20',
+              'system-b-suggested-profile-action system-b-suggested-profile-action-secondary',
               'disabled:opacity-50 disabled:cursor-not-allowed'
             )}
           >
@@ -421,10 +404,7 @@ function SuggestionCard({
             onClick={onConfirm}
             disabled={isActioning}
             className={cn(
-              'flex flex-1 items-center justify-center gap-1.5 rounded-[12px]',
-              'bg-btn-primary px-3 py-3 text-app font-medium text-btn-primary-foreground sm:py-2',
-              'transition-colors hover:bg-btn-primary/90',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-btn-primary/20',
+              'system-b-suggested-profile-action system-b-suggested-profile-action-primary',
               'disabled:opacity-50 disabled:cursor-not-allowed'
             )}
           >

--- a/apps/web/components/jovie/components/SuggestedPrompts.tsx
+++ b/apps/web/components/jovie/components/SuggestedPrompts.tsx
@@ -285,7 +285,7 @@ export function SuggestedPrompts({
               disabled={
                 suggestion.label === 'Generate album art' && albumArtDisabled
               }
-              className='system-b-chat-suggested-prompts-flat-button'
+              className='group system-b-chat-suggested-prompts-flat-button'
               aria-label={suggestion.label}
               title={
                 suggestion.label === 'Generate album art'

--- a/apps/web/components/jovie/components/SuggestedPrompts.tsx
+++ b/apps/web/components/jovie/components/SuggestedPrompts.tsx
@@ -21,7 +21,6 @@ import {
 } from '../types';
 import {
   CHAT_PROMPT_RAIL_CLASS,
-  CHAT_PROMPT_RAIL_MASK_STYLE,
   CHAT_PROMPT_RAIL_SCROLL_CLASS,
   getChatPromptPillClass,
 } from './chat-prompt-styles';
@@ -91,7 +90,7 @@ function SuggestionPill({
       aria-disabled={disabled}
       title={disabledReason ?? undefined}
     >
-      <span className='flex h-4 w-4 shrink-0 items-center justify-center text-tertiary-token transition-colors duration-subtle group-hover:text-primary-token'>
+      <span className='flex h-4 w-4 shrink-0 items-center justify-center text-tertiary-token transition-colors duration-fast group-hover:text-primary-token'>
         {IconComponent && <IconComponent className='h-3.5 w-3.5 shrink-0' />}
       </span>
       <span className='min-w-0 flex-1 truncate leading-none'>
@@ -205,8 +204,8 @@ export function SuggestedPrompts({
   // so dimmed chips can't be reached by Tab/Shift+Tab while the slash picker
   // is open. `aria-hidden` on the wrapper hides them from SR.
   const dimClass = dimmed
-    ? 'opacity-0 transition-opacity duration-subtle ease-out'
-    : 'opacity-100 transition-opacity duration-subtle ease-out';
+    ? 'opacity-0 transition-opacity duration-fast ease-out'
+    : 'opacity-100 transition-opacity duration-fast ease-out';
 
   if (layout === 'grid') {
     const primarySuggestions = promptSuggestionsWithCapabilities.slice(0, 3);
@@ -217,12 +216,12 @@ export function SuggestedPrompts({
 
     return (
       <div
-        className={cn('mx-auto w-full max-w-[35rem]', dimClass)}
+        className={cn('system-b-chat-suggested-prompts-grid', dimClass)}
         aria-hidden={dimmed}
         inert={dimmed}
         data-testid='suggested-prompts-grid'
       >
-        <div className='grid grid-cols-[repeat(auto-fit,minmax(10.75rem,1fr))] gap-2'>
+        <div className='system-b-chat-suggested-prompts-primary-grid'>
           {primarySuggestions.map(suggestion => (
             <SuggestionPill
               key={suggestion.label}
@@ -261,10 +260,7 @@ export function SuggestedPrompts({
   if (layout === 'flat') {
     return (
       <div
-        className={cn(
-          'mx-auto flex w-full max-w-[35rem] flex-col gap-1.5',
-          dimClass
-        )}
+        className={cn('system-b-chat-suggested-prompts-flat', dimClass)}
         aria-hidden={dimmed}
         inert={dimmed}
         data-testid='suggested-prompts-flat'
@@ -289,7 +285,7 @@ export function SuggestedPrompts({
               disabled={
                 suggestion.label === 'Generate album art' && albumArtDisabled
               }
-              className='group flex w-full items-center gap-2 rounded-full bg-transparent px-3 py-2 text-left text-[12.5px] text-secondary-token transition-[background-color,color] duration-subtle enabled:hover:bg-surface-0 enabled:hover:text-primary-token disabled:cursor-not-allowed disabled:opacity-55 focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/12'
+              className='system-b-chat-suggested-prompts-flat-button'
               aria-label={suggestion.label}
               title={
                 suggestion.label === 'Generate album art'
@@ -297,7 +293,7 @@ export function SuggestedPrompts({
                   : undefined
               }
             >
-              <span className='flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-tertiary-token transition-colors duration-subtle group-hover:text-primary-token'>
+              <span className='flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-tertiary-token transition-colors duration-fast group-hover:text-primary-token'>
                 {IconComponent ? (
                   <IconComponent className='h-3.5 w-3.5 shrink-0' />
                 ) : null}
@@ -312,7 +308,7 @@ export function SuggestedPrompts({
 
   return (
     <div
-      className={cn('w-full max-w-[46rem]', dimClass)}
+      className={cn('system-b-chat-suggested-prompts-rail-wrapper', dimClass)}
       aria-hidden={dimmed}
       inert={dimmed}
     >
@@ -321,7 +317,6 @@ export function SuggestedPrompts({
           CHAT_PROMPT_RAIL_SCROLL_CLASS,
           'overscroll-x-contain px-1 sm:px-0'
         )}
-        style={CHAT_PROMPT_RAIL_MASK_STYLE}
         data-testid='suggested-prompts-rail'
       >
         <div

--- a/apps/web/components/jovie/components/TokenizedText.tsx
+++ b/apps/web/components/jovie/components/TokenizedText.tsx
@@ -92,10 +92,10 @@ function TranscriptSkillChip({ id, tone }: TranscriptSkillChipProps) {
   return (
     <span
       className={cn(
-        'mx-0.5 inline-flex h-6 max-w-[220px] items-center gap-1.5 rounded-[8px] border px-2 align-[-0.2em] text-[12px] font-medium leading-none shadow-none',
+        'system-b-transcript-skill-chip',
         tone === 'onLight'
-          ? 'border-black/10 bg-black/[0.055] text-[#111216]'
-          : 'border-white/[0.085] bg-white/[0.035] text-primary-token'
+          ? 'system-b-transcript-skill-chip-light'
+          : 'system-b-transcript-skill-chip-dark'
       )}
       title={label}
       data-testid='transcript-skill-chip'
@@ -103,8 +103,10 @@ function TranscriptSkillChip({ id, tone }: TranscriptSkillChipProps) {
       <span
         aria-hidden
         className={cn(
-          'h-1.5 w-1.5 shrink-0 rounded-full',
-          tone === 'onLight' ? 'bg-black/45' : 'bg-tertiary-token'
+          'system-b-transcript-skill-chip-dot',
+          tone === 'onLight'
+            ? 'system-b-transcript-skill-chip-dot-light'
+            : 'system-b-transcript-skill-chip-dot-dark'
         )}
       />
       <span className='min-w-0 truncate'>{label}</span>

--- a/apps/web/components/jovie/components/chat-prompt-styles.ts
+++ b/apps/web/components/jovie/components/chat-prompt-styles.ts
@@ -1,24 +1,12 @@
-export const CHAT_PROMPT_RAIL_SCROLL_CLASS =
-  'w-full overflow-x-auto overflow-y-hidden [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
+export const CHAT_PROMPT_RAIL_SCROLL_CLASS = 'system-b-chat-prompt-rail-scroll';
 
-export const CHAT_PROMPT_RAIL_CLASS =
-  'flex min-w-full flex-nowrap items-stretch gap-1.5';
+export const CHAT_PROMPT_RAIL_CLASS = 'system-b-chat-prompt-rail';
 
-export const CHAT_PROMPT_RAIL_MASK_STYLE = {
-  WebkitMaskImage:
-    'linear-gradient(to right, transparent 0, black 18px, black calc(100% - 18px), transparent 100%)',
-  maskImage:
-    'linear-gradient(to right, transparent 0, black 18px, black calc(100% - 18px), transparent 100%)',
-} as const;
+const CHAT_PROMPT_PILL_BASE_CLASS = 'group system-b-chat-prompt-pill';
 
-const CHAT_PROMPT_PILL_BASE_CLASS =
-  'group inline-flex items-center gap-2 rounded-full border border-black/6 bg-[color-mix(in_oklab,var(--linear-app-content-surface)_99%,var(--linear-bg-surface-0))] text-left text-secondary-token shadow-[0_1px_2px_rgba(15,23,42,0.04)] transition-[background-color,border-color,color] duration-150 hover:border-black/10 hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:bg-surface-0 focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/12 active:bg-surface-1 dark:border-white/[0.07] dark:shadow-[0_1px_2px_rgba(0,0,0,0.14)] dark:hover:border-white/[0.10]';
+const CHAT_PROMPT_PILL_DEFAULT_CLASS = 'system-b-chat-prompt-pill-default';
 
-const CHAT_PROMPT_PILL_DEFAULT_CLASS =
-  'min-w-[168px] max-w-[228px] px-3 py-1.5 text-xs';
-
-const CHAT_PROMPT_PILL_COMPACT_CLASS =
-  'min-w-[136px] max-w-[188px] px-2.5 py-1 text-2xs';
+const CHAT_PROMPT_PILL_COMPACT_CLASS = 'system-b-chat-prompt-pill-compact';
 
 export function getChatPromptPillClass(
   density: 'default' | 'compact' = 'default'

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2651,7 +2651,7 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   color: var(--color-text-secondary-token);
   text-align: left;
   box-shadow: 0 1px 2px
-    color-mix(in oklab, var(--system-b-accent-blue) 4%, transparent);
+    color-mix(in oklab, var(--system-b-accent-cyan) 4%, transparent);
   transition:
     background-color var(--duration-fast) var(--ease-subtle),
     border-color var(--duration-fast) var(--ease-subtle),

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2604,6 +2604,375 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   color: var(--color-error);
 }
 
+:where(.system-b-chat-prompt-rail-scroll) {
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black 18px,
+    black calc(100% - 18px),
+    transparent 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    black 18px,
+    black calc(100% - 18px),
+    transparent 100%
+  );
+}
+
+:where(.system-b-chat-prompt-rail-scroll::-webkit-scrollbar) {
+  display: none;
+}
+
+:where(.system-b-chat-prompt-rail) {
+  display: flex;
+  min-width: 100%;
+  flex-wrap: nowrap;
+  align-items: stretch;
+  gap: var(--space-1-5);
+}
+
+:where(.system-b-chat-prompt-pill) {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  border: 1px solid color-mix(in oklab, black 6%, transparent);
+  border-radius: var(--radius-full);
+  background: color-mix(
+    in oklab,
+    var(--system-b-app-content-surface) 99%,
+    var(--system-b-bg-surface-0)
+  );
+  color: var(--color-text-secondary-token);
+  text-align: left;
+  box-shadow: 0 1px 2px
+    color-mix(in oklab, var(--system-b-accent-blue) 4%, transparent);
+  transition:
+    background-color var(--duration-fast) var(--ease-subtle),
+    border-color var(--duration-fast) var(--ease-subtle),
+    color var(--duration-fast) var(--ease-subtle);
+}
+
+:where(.dark .system-b-chat-prompt-pill) {
+  border-color: color-mix(in oklab, white 7%, transparent);
+  box-shadow: 0 1px 2px color-mix(in oklab, black 14%, transparent);
+}
+
+:where(.system-b-chat-prompt-pill:hover) {
+  border-color: color-mix(in oklab, black 10%, transparent);
+  background: var(--surface-0);
+  color: var(--color-text-primary-token);
+}
+
+:where(.dark .system-b-chat-prompt-pill:hover) {
+  border-color: color-mix(in oklab, white 10%, transparent);
+}
+
+:where(.system-b-chat-prompt-pill:active) {
+  background: var(--surface-1);
+}
+
+:where(.system-b-chat-prompt-pill:focus-visible) {
+  border-color: var(--color-border-focus);
+  background: var(--surface-0);
+  outline: none;
+  box-shadow: 0 0 0 2px
+    color-mix(in oklab, var(--color-border-focus) 12%, transparent);
+}
+
+:where(.system-b-chat-prompt-pill-default) {
+  min-width: 168px;
+  max-width: 228px;
+  padding: var(--space-1-5) var(--space-3);
+  font-size: var(--text-xs);
+}
+
+:where(.system-b-chat-prompt-pill-compact) {
+  min-width: 136px;
+  max-width: 188px;
+  padding: var(--space-1) var(--space-2-5);
+  font-size: var(--text-2xs);
+}
+
+:where(.system-b-chat-suggested-prompts-grid) {
+  width: 100%;
+  max-width: 35rem;
+  margin-inline: auto;
+}
+
+:where(.system-b-chat-suggested-prompts-primary-grid) {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10.75rem, 1fr));
+  gap: var(--space-2);
+}
+
+:where(.system-b-chat-suggested-prompts-flat) {
+  display: flex;
+  width: 100%;
+  max-width: 35rem;
+  margin-inline: auto;
+  flex-direction: column;
+  gap: var(--space-1-5);
+}
+
+:where(.system-b-chat-suggested-prompts-flat-button) {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: var(--space-2);
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--color-text-secondary-token);
+  font-size: 12.5px;
+  padding: var(--space-2) var(--space-3);
+  text-align: left;
+  transition:
+    background-color var(--duration-fast) var(--ease-subtle),
+    color var(--duration-fast) var(--ease-subtle);
+}
+
+:where(.system-b-chat-suggested-prompts-flat-button:enabled:hover) {
+  background: var(--surface-0);
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-chat-suggested-prompts-flat-button:disabled) {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+:where(.system-b-chat-suggested-prompts-flat-button:focus-visible) {
+  border-color: var(--color-border-focus);
+  background: var(--surface-0);
+  outline: none;
+  box-shadow: 0 0 0 2px
+    color-mix(in oklab, var(--color-border-focus) 12%, transparent);
+}
+
+:where(.system-b-chat-suggested-prompts-rail-wrapper) {
+  width: 100%;
+  max-width: 46rem;
+}
+
+:where(.system-b-slash-header) {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid color-mix(in oklab, white 5.5%, transparent);
+  color: var(--color-text-primary-token);
+  font-size: var(--text-app);
+  padding: var(--space-4) 18px var(--space-3);
+}
+
+:where(.system-b-slash-header-token) {
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-text-primary-token);
+  font-weight: var(--font-weight-semibold);
+}
+
+:where(.system-b-slash-header-token-entity) {
+  gap: var(--space-1-5);
+  border: 1px solid color-mix(in oklab, white 10%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklab, white 5%, transparent);
+  font-size: var(--text-2xs);
+  letter-spacing: 0.04em;
+  padding: 2px var(--space-2);
+  text-transform: uppercase;
+  box-shadow: inset 0 0.5px 0 color-mix(in oklab, white 4%, transparent);
+}
+
+:where(.system-b-slash-header-token-root) {
+  height: 21px;
+  border-radius: var(--radius-xs);
+  background: color-mix(in oklab, white 6%, transparent);
+  font-size: 12.5px;
+  line-height: 1;
+  padding-inline: var(--space-1-5);
+  box-shadow:
+    inset 0 0.5px 0 color-mix(in oklab, white 6%, transparent),
+    inset 0 0 0 0.5px color-mix(in oklab, white 4%, transparent);
+}
+
+:where(.system-b-suggested-profile-card) {
+  overflow: hidden;
+  border: 1px solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-2xl);
+  background: var(--system-b-app-content-surface);
+  transition:
+    opacity var(--duration-cinematic) var(--ease-out),
+    transform var(--duration-cinematic) var(--ease-out);
+}
+
+:where(.system-b-suggested-profile-primary-link) {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1-5);
+  border-radius: var(--radius-xl);
+  background: var(--system-b-primary-bg);
+  color: var(--system-b-primary-fg);
+  font-size: var(--text-app);
+  font-weight: var(--font-weight-medium);
+  padding: var(--space-2-5) var(--space-3);
+  transition: background-color var(--duration-fast) var(--ease-subtle);
+}
+
+:where(.system-b-suggested-profile-primary-link:hover) {
+  background: var(--color-btn-primary-hover);
+}
+
+:where(.system-b-suggested-profile-primary-link:focus) {
+  outline: none;
+}
+
+:where(.system-b-suggested-profile-icon-shell) {
+  display: flex;
+  width: var(--space-8);
+  height: var(--space-8);
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-xl);
+  background: var(--surface-0);
+}
+
+:where(.system-b-suggested-profile-action) {
+  display: flex;
+  flex: 1 1 0;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1-5);
+  border-radius: var(--radius-xl);
+  font-size: var(--text-app);
+  font-weight: var(--font-weight-medium);
+  padding: var(--space-3);
+  transition:
+    background-color var(--duration-fast) var(--ease-subtle),
+    color var(--duration-fast) var(--ease-subtle);
+}
+
+@media (min-width: 640px) {
+  :where(.system-b-suggested-profile-action) {
+    padding-block: var(--space-2);
+  }
+}
+
+:where(.system-b-suggested-profile-action:focus-visible) {
+  outline: none;
+  box-shadow: 0 0 0 2px
+    color-mix(in oklab, var(--system-b-primary-bg) 20%, transparent);
+}
+
+:where(.system-b-suggested-profile-action-secondary) {
+  border: 1px solid var(--color-border-subtle);
+  color: var(--color-text-secondary-token);
+}
+
+:where(.system-b-suggested-profile-action-secondary:hover) {
+  background: var(--surface-2);
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-suggested-profile-action-primary) {
+  background: var(--system-b-primary-bg);
+  color: var(--system-b-primary-fg);
+}
+
+:where(.system-b-suggested-profile-action-primary:hover) {
+  background: var(--color-btn-primary-hover);
+}
+
+:where(.system-b-suggested-profile-dot) {
+  width: var(--space-1-5);
+  height: var(--space-1-5);
+  border-radius: var(--radius-full);
+  background: color-mix(
+    in oklab,
+    var(--color-text-tertiary-token) 30%,
+    transparent
+  );
+  transition:
+    width var(--duration-fast) var(--ease-subtle),
+    background-color var(--duration-fast) var(--ease-subtle);
+}
+
+:where(.system-b-suggested-profile-dot[data-active="true"]) {
+  width: var(--space-4);
+  background: var(--color-text-primary-token);
+}
+
+:where(.system-b-suggested-profile-image) {
+  position: relative;
+  overflow: hidden;
+  margin-bottom: var(--space-3);
+  border-radius: var(--radius-lg);
+  background: var(--surface-2);
+}
+
+:where(.system-b-suggested-profile-image-avatar) {
+  width: var(--space-24);
+  height: var(--space-24);
+  margin-inline: auto;
+  border-radius: var(--radius-full);
+}
+
+:where(.system-b-suggested-profile-image-wide) {
+  width: 100%;
+  aspect-ratio: 3 / 1;
+}
+
+:where(.system-b-transcript-skill-chip) {
+  display: inline-flex;
+  height: var(--space-6);
+  max-width: 220px;
+  align-items: center;
+  gap: var(--space-1-5);
+  margin-inline: var(--space-0-5);
+  border: 1px solid transparent;
+  border-radius: var(--radius-lg);
+  box-shadow: none;
+  font-size: 12px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1;
+  padding-inline: var(--space-2);
+  vertical-align: -0.2em;
+}
+
+:where(.system-b-transcript-skill-chip-light) {
+  border-color: color-mix(in oklab, black 10%, transparent);
+  background: color-mix(in oklab, black 5.5%, transparent);
+  color: var(--system-b-chat-user-bubble-text, #111216);
+}
+
+:where(.system-b-transcript-skill-chip-dark) {
+  border-color: color-mix(in oklab, white 8.5%, transparent);
+  background: color-mix(in oklab, white 3.5%, transparent);
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-transcript-skill-chip-dot) {
+  width: var(--space-1-5);
+  height: var(--space-1-5);
+  flex-shrink: 0;
+  border-radius: var(--radius-full);
+}
+
+:where(.system-b-transcript-skill-chip-dot-light) {
+  background: color-mix(in oklab, black 45%, transparent);
+}
+
+:where(.system-b-transcript-skill-chip-dot-dark) {
+  background: var(--color-text-tertiary-token);
+}
+
 :where(.system-b-image-attachment-trigger) {
   display: inline-flex;
   align-items: baseline;

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2805,6 +2805,7 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   border: 1px solid var(--system-b-app-frame-seam);
   border-radius: var(--radius-2xl);
   background: var(--system-b-app-content-surface);
+  box-shadow: var(--shadow-card-elevated);
   transition:
     opacity var(--duration-cinematic) var(--ease-out),
     transform var(--duration-cinematic) var(--ease-out);

--- a/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
+++ b/apps/web/tests/unit/chat/SuggestedPrompts.test.tsx
@@ -32,12 +32,12 @@ describe('SuggestedPrompts', () => {
     );
 
     const rail = getByTestId('suggested-prompts-rail');
-    expect(rail.className).toContain('overflow-x-auto');
+    expect(rail.className).toContain('system-b-chat-prompt-rail-scroll');
     expect(rail.className).not.toContain('scroll-smooth');
     expect(rail.className).not.toContain('md:overflow-visible');
     const row = rail.firstElementChild;
+    expect(row?.className).toContain('system-b-chat-prompt-rail');
     expect(row?.className).toContain('snap-x');
-    expect(row?.className).toContain('flex-nowrap');
     expect(row?.className).not.toContain('flex-wrap');
     expect(row?.className).toContain('whitespace-nowrap');
   });

--- a/apps/web/tests/unit/chat/chat-suggestions-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/chat-suggestions-style-guard.test.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
 const guardedSources = [
   'components/jovie/components/SuggestedProfilesCarousel.tsx',
@@ -22,7 +25,7 @@ const forbiddenVisualPatterns = [
 describe('chat suggestions and slash picker System B source contract', () => {
   it('keeps prompts, slash headers, suggestion cards, and transcript chips on named primitives', () => {
     for (const sourcePath of guardedSources) {
-      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+      const source = readFileSync(resolve(appRoot, sourcePath), 'utf8');
 
       for (const pattern of forbiddenVisualPatterns) {
         expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
@@ -32,7 +35,7 @@ describe('chat suggestions and slash picker System B source contract', () => {
 
   it('keeps suggested profile cards on the System B card depth token', () => {
     const styles = readFileSync(
-      resolve(process.cwd(), 'styles/design-system.css'),
+      resolve(appRoot, 'styles/design-system.css'),
       'utf8'
     );
 

--- a/apps/web/tests/unit/chat/chat-suggestions-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/chat-suggestions-style-guard.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const guardedSources = [
+  'components/jovie/components/SuggestedProfilesCarousel.tsx',
+  'components/jovie/components/chat-prompt-styles.ts',
+  'components/jovie/components/SlashCommandMenu.tsx',
+  'components/jovie/components/SuggestedPrompts.tsx',
+  'components/jovie/components/TokenizedText.tsx',
+] as const;
+
+const forbiddenVisualPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient|bg-gradient/,
+  /\b(?:bg|border|text|hover:bg|hover:text|focus-visible:ring)-\[/,
+  /\b(?:h|w|max-w|min-w|min-h|grid-cols|gap|px|py|rounded|shadow|tracking|transition|align)-\[/,
+] as const;
+
+describe('chat suggestions and slash picker System B source contract', () => {
+  it('keeps prompts, slash headers, suggestion cards, and transcript chips on named primitives', () => {
+    for (const sourcePath of guardedSources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+
+      for (const pattern of forbiddenVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+    }
+  });
+});

--- a/apps/web/tests/unit/chat/chat-suggestions-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/chat-suggestions-style-guard.test.ts
@@ -29,4 +29,15 @@ describe('chat suggestions and slash picker System B source contract', () => {
       }
     }
   });
+
+  it('keeps suggested profile cards on the System B card depth token', () => {
+    const styles = readFileSync(
+      resolve(process.cwd(), 'styles/design-system.css'),
+      'utf8'
+    );
+
+    expect(styles).toMatch(
+      /:where\(\.system-b-suggested-profile-card\)\s*{[^}]*box-shadow:\s*var\(--shadow-card-elevated\);/
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Move chat suggestion prompts, slash picker headers, suggested profile cards, and transcript skill chips onto named System B primitives.
- Add a focused source-contract guard so raw visual Tailwind, gradients, raw colors, and one-off shadows/transitions do not return in this slice.
- Preserve keyboard behavior and existing prompt/token rendering while keeping rail/flat/grid layouts stable.

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/jovie/components/SuggestedProfilesCarousel.tsx apps/web/components/jovie/components/chat-prompt-styles.ts apps/web/components/jovie/components/SlashCommandMenu.tsx apps/web/components/jovie/components/SuggestedPrompts.tsx apps/web/components/jovie/components/TokenizedText.tsx apps/web/tests/unit/chat/SuggestedPrompts.test.tsx apps/web/tests/unit/chat/chat-suggestions-style-guard.test.ts apps/web/styles/design-system.css`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/chat/SuggestedPrompts.test.tsx tests/unit/chat/SlashCommandMenu.keyboard.test.tsx tests/unit/chat/TokenizedText.test.tsx tests/unit/chat/chat-suggestions-style-guard.test.ts tests/unit/chat/ChatInput.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=no_agent git diff --check`
- Pre-push: `biome check .`, `next:proxy-guard`, `tailwind:check`, web `typecheck`, web `lint`

Linear: JOV-2734


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refreshed visual styling for chat prompts, suggested profiles carousel, slash command menu, and transcript skill chips using a comprehensive design system update.
  * Optimized animation transitions for improved responsiveness and user experience.
  * Enhanced visual consistency and refined interactions across UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->