### PR TITLE
fix(extension): normalize signed-out system b shell

### DIFF
--- a/apps/extension/src/sidepanel.ts
+++ b/apps/extension/src/sidepanel.ts
@@ -392,11 +392,22 @@ function createCardImage(imageUrl: string | null, title: string) {
   return image;
 }
 
-function renderShell(children: HTMLElement[]) {
+function renderShell(
+  children: HTMLElement[],
+  options: {
+    readonly showPromptDock?: boolean;
+    readonly showTopRail?: boolean;
+  } = {}
+) {
   root.innerHTML = '';
 
   const shell = document.createElement('div');
   shell.className = 'shell';
+  const showPromptDock = options.showPromptDock ?? true;
+  const showTopRail = options.showTopRail ?? true;
+  if (!showTopRail) {
+    shell.dataset.hasTopRail = 'false';
+  }
   const isDockChild = (child: HTMLElement) =>
     child.classList.contains('action-tray') ||
     child.classList.contains('signed-out-actions');
@@ -404,26 +415,26 @@ function renderShell(children: HTMLElement[]) {
   const dockChildren = children.filter(isDockChild);
   const hasActionDock = dockChildren.length > 0;
 
-  const header = document.createElement('header');
-  header.className = 'top-rail';
-  header.appendChild(createLogoMark());
+  if (showTopRail) {
+    const header = document.createElement('header');
+    header.className = 'top-rail';
+    header.appendChild(createLogoMark());
 
-  const railCopy = document.createElement('div');
-  railCopy.className = 'top-rail-copy';
+    const railCopy = document.createElement('div');
+    railCopy.className = 'top-rail-copy';
 
-  const heading = document.createElement('p');
-  heading.className = 'eyebrow';
-  heading.textContent = 'Jovie';
+    const heading = document.createElement('p');
+    heading.className = 'eyebrow';
+    heading.textContent = 'Jovie';
 
-  const status = document.createElement('h1');
-  status.className = 'rail-title';
-  status.textContent =
-    state.summary?.context.statusLabel ??
-    (state.flags?.signedIn ? 'Extension' : 'Sign In Required');
+    const status = document.createElement('h1');
+    status.className = 'rail-title';
+    status.textContent = state.summary?.context.statusLabel ?? 'Jovie';
 
-  railCopy.append(heading, status);
-  header.appendChild(railCopy);
-  shell.appendChild(header);
+    railCopy.append(heading, status);
+    header.appendChild(railCopy);
+    shell.appendChild(header);
+  }
 
   const main = document.createElement('main');
   main.className = 'panel-scroll';
@@ -432,7 +443,7 @@ function renderShell(children: HTMLElement[]) {
   }
 
   shell.appendChild(main);
-  const promptDock = renderPromptDock({ hasActionDock });
+  const promptDock = showPromptDock ? renderPromptDock({ hasActionDock }) : null;
   if (promptDock) {
     if (hasActionDock) {
       promptDock.classList.add('prompt-dock-stacked');
@@ -468,12 +479,12 @@ function renderSignedOut() {
 
   const title = document.createElement('h2');
   title.className = 'empty-title';
-  title.textContent = 'Bring Jovie Into This Page';
+  title.textContent = 'Sign In To Continue';
 
   const body = document.createElement('p');
   body.className = 'empty-body';
   body.textContent =
-    'Sign in to load your artist context, releases, and one-click insert actions.';
+    'Load artist context and fill supported fields from the active page.';
 
   center.append(title, body);
   section.appendChild(center);
@@ -481,15 +492,12 @@ function renderSignedOut() {
   const footer = document.createElement('div');
   footer.className = 'signed-out-actions';
   footer.append(
-    createButton('Sign Up', 'secondary', () => {
-      window.open('https://app.jov.ie/sign-up', '_blank');
-    }),
-    createButton('Log In', 'primary', () => {
+    createButton('Sign In', 'primary', () => {
       window.open('https://app.jov.ie/sign-in', '_blank');
     })
   );
 
-  renderShell([section, footer]);
+  renderShell([section, footer], { showPromptDock: false, showTopRail: false });
 }
 
 function renderEmptyState(titleText: string, bodyText: string) {
@@ -1185,7 +1193,9 @@ function renderReady(
       );
     }
 
-    children.push(actionTray);
+    if (actionTray.childElementCount > 0) {
+      children.push(actionTray);
+    }
   }
 
   renderShell(children);

--- a/apps/extension/src/styles.css
+++ b/apps/extension/src/styles.css
@@ -1,24 +1,24 @@
 :root {
-  color-scheme: light;
+  color-scheme: dark;
   font-family:
     Inter, "SF Pro Text", "SF Pro Display", -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;
 
   /* Local System B bridge tokens for the Chrome extension runtime. */
-  --extension-system-b-bg-base: #f5f5f5;
-  --extension-system-b-bg-surface-0: #f2f3f5;
-  --extension-system-b-bg-surface-1: #ffffff;
-  --extension-system-b-bg-surface-2: #ebecef;
-  --extension-system-b-text-primary: #0c0c0c;
-  --extension-system-b-text-secondary: #2e2f31;
-  --extension-system-b-text-tertiary: #5a5b5d;
-  --extension-system-b-text-quaternary: #8b8d92;
-  --extension-system-b-border-subtle: rgb(12 12 12 / 0.08);
-  --extension-system-b-border-default: rgb(12 12 12 / 0.12);
-  --extension-system-b-border-strong: rgb(12 12 12 / 0.18);
-  --extension-system-b-focus: #7170ff;
-  --extension-system-b-shadow-card: 0 1px 2px rgb(12 12 12 / 0.04);
-  --extension-system-b-shadow-dock: 0 8px 24px rgb(12 12 12 / 0.08);
+  --extension-system-b-bg-base: #06070a;
+  --extension-system-b-bg-surface-0: #0a0b0e;
+  --extension-system-b-bg-surface-1: #101216;
+  --extension-system-b-bg-surface-2: #171a20;
+  --extension-system-b-text-primary: #f7f8f8;
+  --extension-system-b-text-secondary: #d8dadd;
+  --extension-system-b-text-tertiary: #969799;
+  --extension-system-b-text-quaternary: #6f7277;
+  --extension-system-b-border-subtle: rgb(255 255 255 / 0.07);
+  --extension-system-b-border-default: rgb(255 255 255 / 0.12);
+  --extension-system-b-border-strong: rgb(255 255 255 / 0.18);
+  --extension-system-b-focus: #0070f3;
+  --extension-system-b-shadow-card: 0 1px 2px rgb(0 0 0 / 0.24);
+  --extension-system-b-shadow-dock: 0 12px 28px rgb(0 0 0 / 0.36);
   --extension-system-b-radius-xs: 6px;
   --extension-system-b-radius-sm: 8px;
   --extension-system-b-radius-md: 10px;
@@ -83,6 +83,10 @@ button {
   background: var(--extension-system-b-bg-base);
 }
 
+.shell[data-has-top-rail="false"] {
+  justify-content: space-between;
+}
+
 .top-rail {
   display: flex;
   min-height: var(--extension-system-b-header-height);
@@ -95,7 +99,7 @@ button {
 
 .logo-mark {
   display: inline-flex;
-  color: var(--extension-system-b-text-secondary);
+  color: var(--extension-system-b-text-primary);
 }
 
 .top-rail-copy {
@@ -354,7 +358,7 @@ button {
 
 .button-primary {
   background: var(--extension-system-b-text-primary);
-  color: var(--extension-system-b-bg-surface-1);
+  color: var(--extension-system-b-bg-base);
 }
 
 .button-primary:hover {
@@ -459,7 +463,7 @@ button {
 }
 
 .empty-hero .logo-mark {
-  color: var(--extension-system-b-text-quaternary);
+  color: var(--extension-system-b-text-primary);
 }
 
 .discovery-card {

--- a/apps/extension/src/styles.test.ts
+++ b/apps/extension/src/styles.test.ts
@@ -7,7 +7,12 @@ const stylesPath = resolve(
   dirname(fileURLToPath(import.meta.url)),
   'styles.css'
 );
+const sidepanelPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  'sidepanel.ts'
+);
 const styles = readFileSync(stylesPath, 'utf8');
+const sidepanel = readFileSync(sidepanelPath, 'utf8');
 const stylesWithoutComments = styles.replace(/\/\*[\s\S]*?\*\//g, '');
 const rootBlockMatch = stylesWithoutComments.match(/:root\s*{[\s\S]*?\n}/);
 const stylesOutsideRoot = stylesWithoutComments.replace(
@@ -17,12 +22,16 @@ const stylesOutsideRoot = stylesWithoutComments.replace(
 
 describe('extension sidepanel System B styles', () => {
   it('declares a local System B bridge token block', () => {
+    expect(rootBlockMatch?.[0]).toContain('color-scheme: dark');
     expect(rootBlockMatch?.[0]).toContain('--extension-system-b-bg-base');
     expect(rootBlockMatch?.[0]).toContain('--extension-system-b-bg-surface-1');
     expect(rootBlockMatch?.[0]).toContain('--extension-system-b-text-primary');
     expect(rootBlockMatch?.[0]).toContain('--extension-system-b-border-subtle');
     expect(rootBlockMatch?.[0]).toContain('--extension-system-b-radius-lg');
     expect(rootBlockMatch?.[0]).toContain('--extension-system-b-dock-min-height');
+    expect(rootBlockMatch?.[0]).toContain(
+      '--extension-system-b-text-primary: #f7f8f8'
+    );
   });
 
   it('keeps raw color literals inside the token bridge only', () => {
@@ -34,6 +43,7 @@ describe('extension sidepanel System B styles', () => {
     expect(stylesOutsideRoot).not.toMatch(/\b(?:linear|radial)-gradient\(/);
     expect(stylesOutsideRoot).not.toMatch(/text-transform:\s*uppercase/);
     expect(stylesOutsideRoot).not.toMatch(/letter-spacing:(?!\s*0\b)/);
+    expect(stylesOutsideRoot).not.toMatch(/[{;]\s*transform:/);
   });
 
   it('uses tokens for radius and shadow recipes outside the token bridge', () => {
@@ -48,5 +58,16 @@ describe('extension sidepanel System B styles', () => {
     );
     expect(styles).toContain('.prompt-dock-stacked');
     expect(stylesOutsideRoot).not.toMatch(/position:\s*fixed/);
+  });
+
+  it('keeps the signed-out sidepanel to one System B sign-in action', () => {
+    expect(sidepanel).toContain("title.textContent = 'Sign In To Continue'");
+    expect(sidepanel).toContain("createButton('Sign In', 'primary'");
+    expect(sidepanel).toContain("window.open('https://app.jov.ie/sign-in'");
+    expect(sidepanel).toContain('showTopRail: false');
+    expect(sidepanel).toContain('showPromptDock: false');
+    expect(sidepanel).not.toContain('https://app.jov.ie/sign-up');
+    expect(sidepanel).not.toContain("'Log In'");
+    expect(sidepanel).not.toContain('Bring Jovie Into This Page');
   });
 });


### PR DESCRIPTION
## Summary

- Normalize the Chrome extension signed-out sidepanel to a dark System B shell.
- Collapse the signed-out state to one `Sign In` CTA, remove the redundant top rail/prompt dock there, and avoid empty action trays.
- Add extension guard coverage for the dark token bridge, no fixed/transformed docks, and the signed-out CTA/header contract.

## Verification

- `node --version && pnpm --version` -> `v22.22.1`, `9.15.4`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/extension run test`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/extension run typecheck`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/extension run build`
- `JOVIE_AGENT_PROFILE=no_agent git diff --check`
- Playwright screenshot against built `apps/extension/dist/sidepanel.html`: `.gstack/design-reports/screenshots/jov-2735-extension-signed-out-hover.png`
- Pre-push: `biome check .`, `next:proxy-guard`, `tailwind:check`, web `typecheck`, web `lint`

Note: `pnpm biome check apps/extension/src/...` processes 0 files because repo Biome config ignores `apps/extension`; the broader pre-push `biome check .` passed.

Linear: JOV-2735


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Implemented dark color scheme for the extension interface
  * Refined layout spacing and text color styling

* **New Features**
  * Simplified authentication UI to display single "Sign In To Continue" action
  * Made top rail and prompt dock visibility configurable

* **Tests**
  * Added assertions for color scheme tokens and styling configuration
  * Added test coverage for simplified sign-in UI behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->