### PR TITLE
fix(ios): remove splash scale motion

### DIFF
--- a/apps/ios/Jovie/App/JovieApp.swift
+++ b/apps/ios/Jovie/App/JovieApp.swift
@@ -267,7 +267,7 @@ func makeJovieClerkOptions(
     // These MUST be registered as allowed redirect URLs in the Clerk dashboard
     // for the matching publishable key (native/iOS app section). Explicit config
     // per 6 gstack principles (explicit over clever, pragmatic, completeness for
-    // end-to-end iOS Clerk auth with prior #8635/#9573 patterns).
+    // end-to-end iOS Clerk auth with prior PR 8635/9573 patterns).
     redirectConfig: .init(
       redirectUrl: redirectUrl,
       callbackUrlScheme: callbackUrlScheme

--- a/apps/ios/Jovie/Features/Splash/SplashView.swift
+++ b/apps/ios/Jovie/Features/Splash/SplashView.swift
@@ -4,7 +4,6 @@ struct SplashView: View {
   @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
   @State private var logoOpacity = 0.0
-  @State private var logoScale: CGFloat = 0.94
 
   var body: some View {
     ZStack {
@@ -12,7 +11,6 @@ struct SplashView: View {
 
       JovieLogoMark(size: 29)
         .opacity(logoOpacity)
-        .scaleEffect(logoScale)
         .accessibilityHidden(true)
         .accessibilityIdentifier("cinematic-loading-logo")
     }
@@ -28,27 +26,23 @@ struct SplashView: View {
   private func runLogoAnimation(reduceMotion: Bool) async {
     if reduceMotion {
       logoOpacity = 0.92
-      logoScale = 1
       return
     }
 
     logoOpacity = 0
-    logoScale = 0.94
 
     try? await Task.sleep(for: .milliseconds(180))
     guard !Task.isCancelled else { return }
 
     withAnimation(.easeOut(duration: 0.26)) {
       logoOpacity = 0.72
-      logoScale = 1.015
     }
 
     try? await Task.sleep(for: .milliseconds(180))
     guard !Task.isCancelled else { return }
 
-    withAnimation(.spring(response: 0.48, dampingFraction: 0.86, blendDuration: 0.08)) {
+    withAnimation(.easeOut(duration: 0.22)) {
       logoOpacity = 0.92
-      logoScale = 1
     }
   }
 }


### PR DESCRIPTION
## Summary
- Remove the splash logo scale animation so the iOS loading mark keeps a stable footprint.
- Reword comment-only PR references in `JovieApp.swift` so source scans do not read them as raw hex colors.

## Linear
- JOV-2738

## Verification
- `./scripts/setup.sh`
- `pnpm ios:setup-env`
- XcodeBuildMCP `build_run_sim` on iPhone 17, Debug, `-ui-testing-splash`, `CODE_SIGNING_ALLOWED=NO`
- XcodeBuildMCP `test_sim`, `-only-testing:JovieUITests/JovieUITests/testCinematicSplashLaunchShowsLoadingState`, `CODE_SIGNING_ALLOWED=NO`: 1 passed, 0 failed
- Focused source guard: no `scaleEffect`, `logoScale`, scale calls, or raw hex comment false positives in the touched files
- `git diff --check`
- pre-push hook: `biome check .`, web proxy guard, Tailwind guard, typecheck, and Biome lint

## Proof
- Simulator screenshot saved locally: `.gstack/design-reports/screenshots/jov-2738-ios-splash-static.jpg`
- Build log: `/Users/timwhite/Library/Developer/XcodeBuildMCP/workspaces/jovie-v1-e05cc6ea175e/logs/build_run_sim_2026-06-03T20-25-57-698Z_pid13120_ec1ef8a3.log`
- Test result bundle: `/Users/timwhite/Library/Developer/XcodeBuildMCP/workspaces/jovie-v1-e05cc6ea175e/result-bundles/test_sim_2026-06-03T20-26-50-378Z_pid13120_bd621487.xcresult`

## Notes
- Test diagnostics included two existing `AppStateTests.swift` async warnings; no errors or test failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved splash screen logo animation with optimized opacity-based effects and enhanced support for reduced motion settings

* **Chores**
  * Updated code documentation reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->