### PR TITLE
Fix(web): remove playlist hover scale motion

### DIFF
--- a/apps/web/app/(dynamic)/playlists/_components/PlaylistGrid.tsx
+++ b/apps/web/app/(dynamic)/playlists/_components/PlaylistGrid.tsx
@@ -10,7 +10,7 @@ export interface PlaylistCardData {
 
 /**
  * Shared playlist grid used by the index, genre hub, and mood hub pages.
- * Cover-art-dominant cards: 80% art, small title, hover scale-up, no chrome.
+ * Cover-art-dominant cards: 80% art, small title, static cover, no chrome.
  */
 export function PlaylistGrid({
   playlists,
@@ -40,7 +40,7 @@ export function PlaylistGrid({
               <Image
                 src={playlist.coverImageUrl}
                 alt={playlist.title}
-                className='h-full w-full object-cover transition-transform duration-200 group-hover:scale-105'
+                className='h-full w-full object-cover'
                 width={400}
                 height={400}
                 unoptimized


### PR DESCRIPTION
## Summary

- removes the decorative `group-hover:scale-105` cover-art motion from the shared playlist grid
- updates the component comment so it no longer documents hover scale as the intended behavior

## Linear

JOV-2740

## Layout Shift Audit

Visual states reviewed:
- empty playlist list
- playlist cards with cover images
- playlist cards without cover images
- hover/focus on desktop
- responsive 2/3/4-column grid layouts

The square cover wrapper remains `aspect-square`; image sizing remains `h-full w-full object-cover`; removing transform-only scale cannot change card dimensions or neighboring layout.

## Visual Proof

Local DB rendered the empty playlist state, so cover-card motion was verified by source guard while route layout was verified in browser:

- Desktop screenshot: `.gstack/design-reports/screenshots/jov-2740-playlists-desktop.png`
- Mobile screenshot: `.gstack/design-reports/screenshots/jov-2740-playlists-mobile.png`
- Browser check: `/playlists` returned HTTP 200 at 1440x1000 and 390x844, no console/page errors, no horizontal overflow.

`pnpm run dev:web:fast` failed before startup with `scripts/dev-web-fast.sh: line 71: ENV_UNSET_ARGS[@]: unbound variable`; JOV-2741 tracks that infra fix. Visual proof used `PORT=3174 pnpm --filter @jovie/web run dev:local`.

## Verification

- `./scripts/setup.sh`
- `rg -n "hover scale|transition-transform|group-hover:scale|scale-[0-9]" 'apps/web/app/(dynamic)/playlists/_components/PlaylistGrid.tsx'; test $? -eq 1`
- `pnpm biome check --write 'apps/web/app/(dynamic)/playlists/_components/PlaylistGrid.tsx'`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hook: `next:proxy-guard`, staged Biome, staged ESLint, scoped web typecheck
- pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, web typecheck, web lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed hover scale animation from playlist cover images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->