### PR TITLE
fix(ios): bound ci screenshot capture

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -56,6 +56,8 @@ jobs:
         timeout-minutes: 15
         env:
           IOS_SCREENSHOT_DERIVED_DATA: .build/ios-ci
+          IOS_SCREENSHOT_REUSE_BUILD: "1"
+          IOS_SCREENSHOT_CAPTURE_IPAD: "0"
           IOS_SCREENSHOT_REQUIRE_IPAD: "0"
         run: bash apps/ios/scripts/capture-screenshots.sh
 

--- a/apps/ios/scripts/capture-screenshots.sh
+++ b/apps/ios/scripts/capture-screenshots.sh
@@ -70,7 +70,7 @@ list_devices() {
     return 1
   fi
 
-  RUBYOPT= ruby -rjson -e '
+  RUBYOPT='' ruby -rjson -e '
     pattern = Regexp.new(ARGV.fetch(0))
     input = STDIN.read
     devices_by_runtime = JSON.parse(input).fetch("devices", {})
@@ -126,10 +126,10 @@ prepare_device() {
 
   echo "Preparing simulator $udid"
   run_with_timeout "${IOS_SCREENSHOT_BOOT_COMMAND_TIMEOUT:-120}" xcrun simctl boot "$udid" >/dev/null 2>&1 || true
-  wait_for_boot "$udid"
+  wait_for_boot "$udid" || return 1
   run_with_timeout "${IOS_SCREENSHOT_UI_TIMEOUT:-10}" xcrun simctl ui "$udid" appearance dark >/dev/null 2>&1 || true
   run_with_timeout "${IOS_SCREENSHOT_UNINSTALL_TIMEOUT:-30}" xcrun simctl uninstall "$udid" "$BUNDLE_ID" >/dev/null 2>&1 || true
-  run_with_timeout "${IOS_SCREENSHOT_INSTALL_TIMEOUT:-60}" xcrun simctl install "$udid" "$APP_PATH"
+  run_with_timeout "${IOS_SCREENSHOT_INSTALL_TIMEOUT:-60}" xcrun simctl install "$udid" "$APP_PATH" || return 1
 }
 
 wait_for_boot() {
@@ -174,13 +174,26 @@ capture() {
   shift 2
 
   run_with_timeout "${IOS_SCREENSHOT_TERMINATE_TIMEOUT:-15}" xcrun simctl terminate "$udid" "$BUNDLE_ID" >/dev/null 2>&1 || true
-  run_with_timeout "${IOS_SCREENSHOT_LAUNCH_TIMEOUT:-20}" xcrun simctl launch "$udid" "$BUNDLE_ID" "$@"
+  if ! run_with_timeout "${IOS_SCREENSHOT_LAUNCH_TIMEOUT:-20}" xcrun simctl launch "$udid" "$BUNDLE_ID" "$@"; then
+    echo "Unable to launch $BUNDLE_ID on $udid for $name."
+    return 1
+  fi
+
   sleep 2
   if ! run_with_timeout "${IOS_SCREENSHOT_CAPTURE_TIMEOUT:-45}" xcrun simctl io "$udid" screenshot "$OUTPUT_DIR/$name.png"; then
     echo "Retrying screenshot capture for $name after simulator settle."
     sleep 5
-    run_with_timeout "${IOS_SCREENSHOT_CAPTURE_TIMEOUT:-45}" xcrun simctl io "$udid" screenshot "$OUTPUT_DIR/$name.png"
+    if ! run_with_timeout "${IOS_SCREENSHOT_CAPTURE_TIMEOUT:-45}" xcrun simctl io "$udid" screenshot "$OUTPUT_DIR/$name.png"; then
+      echo "Unable to capture screenshot $name from simulator $udid."
+      return 1
+    fi
   fi
+
+  if [[ ! -s "$OUTPUT_DIR/$name.png" ]]; then
+    echo "Screenshot $OUTPUT_DIR/$name.png was not created."
+    return 1
+  fi
+
   echo "Captured $OUTPUT_DIR/$name.png"
 }
 
@@ -200,8 +213,9 @@ capture "$IPHONE_UDID" "04-settings" "-ui-testing-settings"
 capture "$IPHONE_UDID" "05-needs-onboarding" "-ui-testing-needs-onboarding"
 capture "$IPHONE_UDID" "06-chat" "-ui-testing-chat"
 
-IPAD_UDID="$(pick_device "^iPad")"
-if [[ -n "$IPAD_UDID" ]]; then
+if [[ "${IOS_SCREENSHOT_CAPTURE_IPAD:-1}" != "1" ]]; then
+  echo "Skipped iPad shell screenshot because IOS_SCREENSHOT_CAPTURE_IPAD=${IOS_SCREENSHOT_CAPTURE_IPAD:-0}."
+elif IPAD_UDID="$(pick_device "^iPad")" && [[ -n "$IPAD_UDID" ]]; then
   captured_ipad=false
   while IFS= read -r candidate_udid; do
     [[ -z "$candidate_udid" ]] && continue


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2739 -->

## Summary
- Reuse the `.build/ios-ci` app produced by the prior iOS build/test step during simulator screenshots.
- Skip optional iPad screenshot capture in iOS CI so the required iPhone artifact set reaches upload deterministically.
- Make screenshot launch/capture failures return nonzero instead of being masked inside the optional iPad branch.

## Verification
- `./scripts/setup.sh`
- `git diff --check`
- `bash -n apps/ios/scripts/capture-screenshots.sh`
- `ruby -e 'require "psych"; Psych.load_file(".github/workflows/ios-ci.yml"); puts "workflow yaml ok"'`
- `shellcheck apps/ios/scripts/capture-screenshots.sh`
- `actionlint .github/workflows/ios-ci.yml`
- Stubbed dry run with fake `xcrun`, `IOS_SCREENSHOT_REUSE_BUILD=1`, and `IOS_SCREENSHOT_CAPTURE_IPAD=0`: produced 7 PNG files and printed `Skipped iPad shell screenshot because IOS_SCREENSHOT_CAPTURE_IPAD=0.`
- Pre-push hook: `biome check .`, `next:proxy-guard`, Tailwind guard, web typecheck, and `biome lint .` passed.

## Notes
- Evidence from run `26911099568`: the unpatched screenshot step rebuilt the app, then optional iPad launch timed out before the step still reported an iPad capture.
- This PR keeps build/test as the gate for producing `.build/ios-ci`; if that app is missing, screenshot capture still fails closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized iOS build efficiency by enabling derived build reuse in CI workflows.
  * Enhanced screenshot capture reliability with improved error handling and file validation checks.
  * Disabled iPad screenshot capture in automated build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->