### PR TITLE
Fix(web): remove shared button press transforms

### DIFF
--- a/apps/web/components/atoms/CircleIconButton.tsx
+++ b/apps/web/components/atoms/CircleIconButton.tsx
@@ -149,9 +149,7 @@ const baseStyles = cn(
   // Shape and layout
   'inline-flex items-center justify-center rounded-full',
   // Transitions
-  'transition-all duration-150 ease-out',
-  // Active state
-  'active:scale-95',
+  'transition-colors duration-subtle ease-out',
   // Required for soft material treatments on profile chrome
   'relative isolate overflow-hidden',
   // Touch optimizations

--- a/apps/web/components/atoms/FrostedButton.tsx
+++ b/apps/web/components/atoms/FrostedButton.tsx
@@ -31,8 +31,8 @@ export const FrostedButton = React.forwardRef<
   ) => {
     const variant = toneToVariant[tone];
     const frostedClasses = cn(
-      'backdrop-blur-md transition-all duration-200 ease-out',
-      'active:translate-y-[1px] motion-reduce:transition-none motion-reduce:transform-none',
+      'backdrop-blur-md transition-colors duration-subtle ease-out',
+      'motion-reduce:transition-none',
       'focus-visible:ring-offset-2 focus-visible:ring-ring focus-visible:ring-offset-background',
       className
     );

--- a/apps/web/tests/unit/atoms/CircleIconButton.test.tsx
+++ b/apps/web/tests/unit/atoms/CircleIconButton.test.tsx
@@ -119,6 +119,33 @@ describe('CircleIconButton', () => {
     expect(button).toHaveClass('my-custom-class');
   });
 
+  it('keeps shared press feedback free of decorative transforms', () => {
+    const variants = [
+      'surface',
+      'frosted',
+      'ghost',
+      'secondary',
+      'outline',
+      'pearl',
+      'pearlQuiet',
+    ] as const;
+
+    for (const variant of variants) {
+      const { unmount } = render(
+        <CircleIconButton ariaLabel={`${variant} action`} variant={variant}>
+          <svg aria-hidden='true' />
+        </CircleIconButton>
+      );
+      const button = screen.getByRole('button', {
+        name: `${variant} action`,
+      });
+      expect(button.className).not.toMatch(
+        /\b(?:transition-all|duration-\d+|active:scale|active:translate|transform|motion-reduce:transform-none)\b/
+      );
+      unmount();
+    }
+  });
+
   it('has type="button" by default', () => {
     render(
       <CircleIconButton ariaLabel='Action'>

--- a/apps/web/tests/unit/atoms/FrostedButton.test.tsx
+++ b/apps/web/tests/unit/atoms/FrostedButton.test.tsx
@@ -72,6 +72,14 @@ describe('FrostedButton', () => {
     expect(button).toBeDisabled();
   });
 
+  it('keeps shared press feedback free of decorative transforms', () => {
+    render(<FrostedButton>Motion safe</FrostedButton>);
+    const button = screen.getByRole('button', { name: 'Motion safe' });
+    expect(button.className).not.toMatch(
+      /\b(?:transition-all|duration-\d+|active:scale|active:translate|transform|motion-reduce:transform-none)\b/
+    );
+  });
+
   it('has no accessibility violations', async () => {
     const { container } = render(<FrostedButton>Accessible</FrostedButton>);
     await expectNoA11yViolations(container);


### PR DESCRIPTION
## Summary

- removes decorative press transforms from `CircleIconButton` and `FrostedButton`
- narrows both wrappers from broad `transition-all` to canonical color-only transitions with `duration-subtle`
- adds focused atom tests that reject reintroduced transform/scale/translate/transition-all/raw duration classes

## Linear

JOV-2742

## Layout Shift Audit

Visual states reviewed:
- `CircleIconButton` sizes `xs`, `sm`, `md`, `lg`
- `CircleIconButton` variants `surface`, `frosted`, `ghost`, `secondary`, `outline`, `pearl`, `pearlQuiet`
- `CircleIconButton` `asChild`, click handler, forwarded ref, aria label, and custom class states
- `FrostedButton` `solid`, `ghost`, and `outline` tones
- `FrostedButton` button, link, external-link, disabled, and accessible states

The removed classes were transform-only press effects. Button dimensions, content, focus rings, variants, and routing behavior are unchanged; press feedback now stays color/opacity/border/shadow based.

## Verification

- `./scripts/setup.sh`
- `rg -n "transition-all|duration-[0-9]+|active:scale|active:translate|motion-reduce:transform-none|\\btransform\\b" apps/web/components/atoms/CircleIconButton.tsx apps/web/components/atoms/FrostedButton.tsx; test $? -eq 1`
- `pnpm biome check --write apps/web/components/atoms/CircleIconButton.tsx apps/web/components/atoms/FrostedButton.tsx apps/web/tests/unit/atoms/CircleIconButton.test.tsx apps/web/tests/unit/atoms/FrostedButton.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/atoms/CircleIconButton.test.tsx tests/unit/atoms/FrostedButton.test.tsx` — 24 passed
- `pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/components/atoms/CircleIconButton.tsx apps/web/components/atoms/FrostedButton.tsx apps/web/tests/unit/atoms/CircleIconButton.test.tsx apps/web/tests/unit/atoms/FrostedButton.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hook: `next:proxy-guard`, staged Biome, staged ESLint, staged a11y check, scoped web typecheck
- pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, web typecheck, web lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated CircleIconButton and FrostedButton to use color-only transitions with optimized animation timing instead of full-property transitions
  * Removed active-state scaling effect from CircleIconButton

* **Tests**
  * Added unit tests for CircleIconButton and FrostedButton to verify transition and transform class behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->