### PR TITLE
fix(web): remove dashboard link action press transforms

### DIFF
--- a/apps/web/components/features/dashboard/atoms/LinkPill.tsx
+++ b/apps/web/components/features/dashboard/atoms/LinkPill.tsx
@@ -157,7 +157,7 @@ export function LinkPill({
                   }}
                   className={cn(
                     MENU_ITEM_BASE,
-                    'w-full text-left active:scale-[0.98]',
+                    'w-full text-left',
                     item.variant === 'destructive' && MENU_ITEM_DESTRUCTIVE
                   )}
                   {...getItemProps()}

--- a/apps/web/components/features/dashboard/atoms/link-actions/LinkActions.tsx
+++ b/apps/web/components/features/dashboard/atoms/link-actions/LinkActions.tsx
@@ -79,7 +79,7 @@ export const LinkActions = memo(function LinkActions({
           <button
             type='button'
             onPointerDown={onDragHandlePointerDown}
-            className='opacity-0 group-hover:opacity-70 group-focus-within:opacity-100 transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] hover:opacity-100 active:scale-[0.97]'
+            className='opacity-0 transition-opacity duration-subtle ease-out hover:opacity-100 group-hover:opacity-70 group-focus-within:opacity-100'
             aria-label='Drag to reorder'
           >
             <span className='inline-flex h-7 w-7 items-center justify-center rounded-md border border-default bg-surface-2 text-secondary-token shadow-xs'>
@@ -98,7 +98,7 @@ export const LinkActions = memo(function LinkActions({
             aria-haspopup='menu'
             onClick={() => setOpen(!open)}
             onKeyDown={handleKeyDown}
-            className='inline-flex h-8 w-8 items-center justify-center rounded-md transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] hover:bg-surface-2 active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-0'
+            className='inline-flex h-8 w-8 items-center justify-center rounded-md transition-colors duration-subtle ease-out hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-0'
           >
             <Icon name='MoreVertical' className='h-5 w-5 text-primary-token' />
           </button>
@@ -137,7 +137,7 @@ export const LinkActions = memo(function LinkActions({
                     }
                   }}
                   className={cn(
-                    'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-secondary-token transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] hover:bg-surface-2 hover:text-primary-token active:scale-[0.97] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-0',
+                    'flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-secondary-token transition-colors duration-subtle ease-out hover:bg-surface-2 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-0',
                     item.id === 'remove' &&
                       'text-destructive hover:text-destructive/80',
                     focusedIndex === index && 'bg-surface-2'

--- a/apps/web/tests/components/dashboard/link-action-system-b-style-guard.test.ts
+++ b/apps/web/tests/components/dashboard/link-action-system-b-style-guard.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const forbiddenMotionClasses =
+  /\b(?:transition-all|duration-\d+|active:scale|active:translate|hover:-translate|group-hover:scale)\b/;
+
+describe('dashboard link action System B style guard', () => {
+  it.each([
+    [
+      'LinkActions',
+      'components/features/dashboard/atoms/link-actions/LinkActions.tsx',
+    ],
+    ['LinkPill', 'components/features/dashboard/atoms/LinkPill.tsx'],
+  ])('%s does not use decorative press motion', (_name, filePath) => {
+    const source = readFileSync(filePath, 'utf8');
+
+    expect(source).not.toMatch(forbiddenMotionClasses);
+  });
+});


### PR DESCRIPTION
## Summary

- Remove decorative pressed-state scale from dashboard link action controls.
- Replace broad transition classes with explicit opacity/color transitions on LinkActions and LinkPill menu actions.
- Add a dashboard System B style guard that blocks the removed motion classes from returning to these controls.

Linear: [JOV-2743](https://linear.app/jovie/issue/JOV-2743/remove-dashboard-link-action-press-transforms)

## Layout Shift Audit

States reviewed: hidden/default drag handle, drag handle hover/focus-visible, actions menu closed/open, keyboard-focused menu items, destructive remove item, LinkPill menu open, LinkPill destructive item.

No geometry-affecting class was added. Stable dimensions remain in place (`h-7`, `h-8`, existing menu item padding, existing LinkPill sizing). The change removes transform-only pressed movement and keeps feedback to opacity, color, background, and existing focus ring states.

## Verification

- `pnpm biome check --write apps/web/components/features/dashboard/atoms/link-actions/LinkActions.tsx apps/web/components/features/dashboard/atoms/LinkPill.tsx apps/web/tests/components/dashboard/link-action-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/components/dashboard/LinkActions.click.test.tsx tests/components/dashboard/LinkActions.keyboard.test.tsx tests/components/dashboard/LinkActions.negative.critical.test.tsx tests/components/dashboard/link-action-system-b-style-guard.test.ts` (21 tests passed)
- `rg` source guard for `transition-all`, numeric duration classes, and transform/scale press motion in the touched source files
- `git diff --check`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Commit hook: staged Biome, a11y, ESLint, and web typecheck
- Pre-push hook: root Biome, web proxy guard, Tailwind guard, web typecheck, and web lint
