### PR TITLE
fix(web): remove shell player press transforms

### DIFF
--- a/apps/web/components/shell/MobilePlayerCard.tsx
+++ b/apps/web/components/shell/MobilePlayerCard.tsx
@@ -91,7 +91,7 @@ export const MobilePlayerCard = React.memo(function MobilePlayerCard({
         <button
           type='button'
           onClick={onPlay}
-          className='h-9 w-9 rounded-full grid place-items-center bg-primary text-on-primary shrink-0 transition-transform duration-subtle ease-subtle active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
+          className='h-9 w-9 rounded-full grid place-items-center bg-primary text-on-primary shrink-0 transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
           aria-label={isPlaying ? 'Pause' : 'Play'}
         >
           {isPlaying ? (

--- a/apps/web/components/shell/PlayerCard.system-b-style-guard.test.ts
+++ b/apps/web/components/shell/PlayerCard.system-b-style-guard.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const forbiddenMotionClasses =
+  /\b(?:transition-all|transition-transform|active:scale|active:translate|hover:-translate)\b/;
+
+describe('shell player card System B style guard', () => {
+  it.each([
+    ['MobilePlayerCard', 'components/shell/MobilePlayerCard.tsx'],
+    ['TabletPlayerCard', 'components/shell/TabletPlayerCard.tsx'],
+  ])('%s does not use transform-based press motion', (_name, filePath) => {
+    const source = readFileSync(filePath, 'utf8');
+
+    expect(source).not.toMatch(forbiddenMotionClasses);
+  });
+});

--- a/apps/web/components/shell/TabletPlayerCard.tsx
+++ b/apps/web/components/shell/TabletPlayerCard.tsx
@@ -118,7 +118,7 @@ export const TabletPlayerCard = React.memo(function TabletPlayerCard({
             <button
               type='button'
               onClick={onPlay}
-              className='h-9 w-9 rounded-full grid place-items-center bg-primary text-on-primary transition-transform duration-subtle ease-subtle active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
+              className='h-9 w-9 rounded-full grid place-items-center bg-primary text-on-primary transition-colors duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) outline-none'
               aria-label={isPlaying ? 'Pause' : 'Play'}
             >
               {isPlaying ? (


### PR DESCRIPTION
## Summary

- Remove transform-based pressed-state motion from mobile and tablet shell player play buttons.
- Keep fixed button dimensions, labels, icons, color transition timing, and focus rings intact.
- Add a System B source guard covering the two player-card files.

Linear: [JOV-2744](https://linear.app/jovie/issue/JOV-2744/remove-shell-player-transport-press-transforms)

## Layout Shift Audit

States reviewed: mobile player hidden/null vs visible, mobile play and pause icon swap, tablet previous/play/next cluster, tablet play and pause icon swap, focus ring states, and progress bar width updates.

No geometry class was changed. Stable dimensions remain (`h-9 w-9`, `h-8 w-8`, fixed artwork sizes, existing grid columns). Press feedback no longer scales the transport button, so interaction does not move the shell card content.

## Verification

- `pnpm biome check --write apps/web/components/shell/MobilePlayerCard.tsx apps/web/components/shell/TabletPlayerCard.tsx apps/web/components/shell/PlayerCard.system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run components/shell/MobilePlayerCard.test.tsx components/shell/TabletPlayerCard.test.tsx components/shell/PlayerCard.system-b-style-guard.test.ts` (11 tests passed)
- `rg` source guard for `transition-all`, `transition-transform`, `active:scale`, `active:translate`, and `hover:-translate` in the touched source files
- `git diff --check`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Commit hook: staged Biome, a11y, ESLint, and web typecheck
- Pre-push hook: root Biome, web proxy guard, Tailwind guard, web typecheck, and web lint
