### PR TITLE
fix(ui): remove checkbox radio press transforms

### DIFF
--- a/packages/ui/atoms/checkbox.test.tsx
+++ b/packages/ui/atoms/checkbox.test.tsx
@@ -216,6 +216,14 @@ describe('Checkbox', () => {
       );
     });
 
+    it('keeps press feedback free of transform motion', () => {
+      render(<Checkbox aria-label='Test' data-testid='checkbox' />);
+      const checkbox = screen.getByTestId('checkbox');
+      expect(checkbox.className).not.toMatch(
+        /\b(?:transition-all|transition-transform|active:scale|active:translate|hover:-translate)\b/
+      );
+    });
+
     it('merges custom className', () => {
       render(
         <Checkbox

--- a/packages/ui/atoms/checkbox.tsx
+++ b/packages/ui/atoms/checkbox.tsx
@@ -39,7 +39,6 @@ const Checkbox = React.forwardRef<
       className={cn(
         'peer h-4 w-4 shrink-0 rounded-(--linear-app-radius-item) border border-(--linear-border-strong) bg-transparent cursor-pointer transition-colors duration-fast ease-interactive',
         'hover:border-(--color-accent) hover:bg-(--linear-bg-surface-1)',
-        'active:scale-95 active:transition-transform',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent) focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page)',
         'disabled:cursor-not-allowed disabled:opacity-50',
         'data-[state=checked]:bg-(--linear-btn-primary-bg) data-[state=checked]:border-(--linear-btn-primary-bg) data-[state=checked]:text-(--linear-btn-primary-fg) data-[state=checked]:hover:bg-(--linear-btn-primary-bg) data-[state=checked]:hover:border-(--linear-btn-primary-bg)',

--- a/packages/ui/atoms/radio-group.test.tsx
+++ b/packages/ui/atoms/radio-group.test.tsx
@@ -231,6 +231,18 @@ describe('RadioGroup', () => {
       expect(radio.className).toContain('disabled:opacity-50');
     });
 
+    it('keeps press feedback free of transform motion', () => {
+      render(
+        <RadioGroup>
+          <RadioGroupItem value='test' data-testid='radio' />
+        </RadioGroup>
+      );
+      const radio = screen.getByTestId('radio');
+      expect(radio.className).not.toMatch(
+        /\b(?:transition-all|transition-transform|active:scale|active:translate|hover:-translate)\b/
+      );
+    });
+
     it('merges custom className on group', () => {
       render(
         <RadioGroup className='custom-class' data-testid='group'>

--- a/packages/ui/atoms/radio-group.tsx
+++ b/packages/ui/atoms/radio-group.tsx
@@ -38,7 +38,6 @@ const RadioGroupItem = React.forwardRef<
         'aspect-square h-4 w-4 rounded-full border border-primary text-primary',
         'ring-offset-background',
         'hover:border-(--color-accent) hover:bg-(--linear-bg-surface-1)',
-        'active:scale-95 active:transition-transform',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
         'disabled:cursor-not-allowed disabled:opacity-50',
         className


### PR DESCRIPTION
## Summary
- Removes transform-based active press feedback from shared `@jovie/ui` checkbox and radio atoms.
- Keeps hover, focus, checked, indeterminate, and disabled styling stable with color/border feedback only.
- Adds focused atom assertions so `transition-all`, `transition-transform`, and active translate/scale classes stay out of these controls.

## Linear
- JOV-2745

## Verification
- `pnpm --filter @jovie/ui exec vitest run atoms/checkbox.test.tsx atoms/radio-group.test.tsx` — 2 files passed, 58 tests passed.
- `pnpm --filter @jovie/ui run test -- atoms/checkbox.test.tsx atoms/radio-group.test.tsx` — package runner passed, 32 files, 789 passed, 4 skipped.
- `pnpm biome check --write packages/ui/atoms/checkbox.tsx packages/ui/atoms/radio-group.tsx packages/ui/atoms/checkbox.test.tsx packages/ui/atoms/radio-group.test.tsx` — passed.
- `pnpm --filter @jovie/ui run typecheck` — passed.
- `git diff --check` — passed.
- Source guard for `transition-all|transition-transform|active:scale|active:translate|hover:-translate` in touched atoms — no matches.
- Push hook passed: root Biome, web proxy guard, Tailwind guard, web typecheck, web lint.
