### PR TITLE
fix(web): remove drawer header icon scale motion

### DIFF
--- a/apps/web/components/molecules/drawer-header/DrawerHeaderActions.tsx
+++ b/apps/web/components/molecules/drawer-header/DrawerHeaderActions.tsx
@@ -120,20 +120,16 @@ export function DrawerHeaderActions({
             <span className='relative flex h-3.5 w-3.5 items-center justify-center'>
               <DefaultIcon
                 className={cn(
-                  'absolute h-3.5 w-3.5 transition-all duration-150',
-                  action.isActive
-                    ? 'scale-50 opacity-0'
-                    : 'scale-100 opacity-100'
+                  'absolute h-3.5 w-3.5 transition-opacity duration-subtle',
+                  action.isActive ? 'opacity-0' : 'opacity-100'
                 )}
                 aria-hidden='true'
               />
               {ActiveIcon && (
                 <ActiveIcon
                   className={cn(
-                    'absolute h-3.5 w-3.5 transition-all duration-150',
-                    action.isActive
-                      ? 'scale-100 opacity-100'
-                      : 'scale-50 opacity-0'
+                    'absolute h-3.5 w-3.5 transition-opacity duration-subtle',
+                    action.isActive ? 'opacity-100' : 'opacity-0'
                   )}
                   aria-hidden='true'
                 />

--- a/apps/web/tests/unit/DrawerHeaderActions.test.tsx
+++ b/apps/web/tests/unit/DrawerHeaderActions.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { render, screen } from '@testing-library/react';
 import { Copy } from 'lucide-react';
 import type { ComponentProps, ReactNode } from 'react';
@@ -101,6 +103,19 @@ describe('DrawerHeaderActions', () => {
     expect(trigger.className).toContain('border-transparent');
     expect(trigger.className).not.toContain('border-(--linear-app-frame-seam)');
     expect(trigger.className).not.toContain('border-subtle');
+  });
+
+  it('keeps copy-state icon swaps free of scale motion', () => {
+    const source = readFileSync(
+      resolve(
+        process.cwd(),
+        'components/molecules/drawer-header/DrawerHeaderActions.tsx'
+      ),
+      'utf8'
+    );
+
+    expect(source).not.toMatch(/\b(?:transition-all|scale-50|scale-100)\b/);
+    expect(source).toContain('transition-opacity');
   });
 
   it('reuses shared dropdown menu items when menuItems is provided', () => {


### PR DESCRIPTION
## Summary
- Replace DrawerHeaderActions copy/check icon scale swaps with opacity-only swaps inside the existing fixed-size icon wrapper.
- Add a focused source guard so transition-all, scale-50, and scale-100 cannot return to this component.

Linear: JOV-2746

## Visual states checked
- Primary action inactive
- Primary action active with activeIcon
- Primary action active without activeIcon
- Disabled primary action
- Link primary action
- Overflow menu present and absent

The icon wrapper remains `h-3.5 w-3.5`, so the active/inactive icon state does not resize the button or shift neighboring drawer header actions.

## Verification
- `pnpm --filter web exec vitest run tests/unit/DrawerHeaderActions.test.tsx`
- `pnpm biome check --write apps/web/components/molecules/drawer-header/DrawerHeaderActions.tsx apps/web/tests/unit/DrawerHeaderActions.test.tsx`
- `pnpm --filter web run typecheck -- --pretty false`
- `git diff --check`
- `rg -n "transition-all|scale-50|scale-100|duration-150" apps/web/components/molecules/drawer-header/DrawerHeaderActions.tsx` (no matches)
- Pre-commit hook: proxy guard, Biome, ESLint, staged a11y, web typecheck
- Pre-push hook: root Biome, web proxy guard, Tailwind guard, web typecheck, web lint