### PR TITLE
fix(web): remove provider copy icon scale motion

### DIFF
--- a/apps/web/components/features/dashboard/organisms/releases/cells/ProviderCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/cells/ProviderCell.tsx
@@ -65,15 +65,15 @@ function ProviderActionButtons({
         <span className='relative flex h-3.5 w-3.5 items-center justify-center'>
           <Icon
             name='Copy'
-            className={`absolute h-3.5 w-3.5 transition-all duration-150 ${
-              isCopied ? 'scale-50 opacity-0' : 'scale-100 opacity-100'
+            className={`absolute h-3.5 w-3.5 transition-opacity duration-subtle ${
+              isCopied ? 'opacity-0' : 'opacity-100'
             }`}
             aria-hidden='true'
           />
           <Icon
             name='Check'
-            className={`absolute h-3.5 w-3.5 transition-all duration-150 ${
-              isCopied ? 'scale-100 opacity-100' : 'scale-50 opacity-0'
+            className={`absolute h-3.5 w-3.5 transition-opacity duration-subtle ${
+              isCopied ? 'opacity-100' : 'opacity-0'
             }`}
             aria-hidden='true'
           />

--- a/apps/web/components/features/dashboard/organisms/releases/components/ProviderCopyButton.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/components/ProviderCopyButton.tsx
@@ -60,18 +60,18 @@ export function ProviderCopyButton({
         <Icon
           name='Copy'
           className={cn(
-            'absolute h-3 w-3 transition-all duration-150',
+            'absolute h-3 w-3 transition-opacity duration-subtle',
             isCopied
-              ? 'scale-50 opacity-0'
-              : 'scale-100 opacity-0 group-hover/btn:opacity-100 group-focus-visible/btn:opacity-100'
+              ? 'opacity-0'
+              : 'opacity-0 group-hover/btn:opacity-100 group-focus-visible/btn:opacity-100'
           )}
           aria-hidden='true'
         />
         <Icon
           name='Check'
           className={cn(
-            'absolute h-3 w-3 transition-all duration-150',
-            isCopied ? 'scale-100 opacity-100' : 'scale-50 opacity-0'
+            'absolute h-3 w-3 transition-opacity duration-subtle',
+            isCopied ? 'opacity-100' : 'opacity-0'
           )}
           aria-hidden='true'
         />

--- a/apps/web/tests/components/dashboard/organisms/releases/cells/ProviderCell.interaction.test.tsx
+++ b/apps/web/tests/components/dashboard/organisms/releases/cells/ProviderCell.interaction.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { TooltipProvider } from '@jovie/ui';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -70,5 +72,20 @@ describe('ProviderCell actions', () => {
     expect(onCopy).toHaveBeenCalledTimes(1);
 
     openSpy.mockRestore();
+  });
+
+  it('keeps provider copy icon swaps opacity-only', () => {
+    const sourceFiles = [
+      'components/features/dashboard/organisms/releases/cells/ProviderCell.tsx',
+      'components/features/dashboard/organisms/releases/components/ProviderCopyButton.tsx',
+    ];
+
+    for (const sourceFile of sourceFiles) {
+      const source = readFileSync(resolve(process.cwd(), sourceFile), 'utf8');
+
+      expect(source).not.toMatch(/\btransition-all\b/);
+      expect(source).not.toMatch(/\bscale-(?:50|95|100|105|110|125)\b/);
+      expect(source).toContain('transition-opacity');
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Remove scale-based icon swapping from release provider copy/check controls.
- Replace `transition-all` with opacity-only System B transitions while preserving fixed icon slots.
- Add a focused provider-cell source guard covering `ProviderCell` and `ProviderCopyButton`.

## Verification
- `pnpm --filter web exec vitest run tests/components/dashboard/organisms/releases/cells/ProviderCell.interaction.test.tsx`
- `pnpm biome check --write apps/web/components/features/dashboard/organisms/releases/cells/ProviderCell.tsx apps/web/components/features/dashboard/organisms/releases/components/ProviderCopyButton.tsx apps/web/tests/components/dashboard/organisms/releases/cells/ProviderCell.interaction.test.tsx`
- `rg -n "transition-all|scale-50|scale-100|duration-150" apps/web/components/features/dashboard/organisms/releases/cells/ProviderCell.tsx apps/web/components/features/dashboard/organisms/releases/components/ProviderCopyButton.tsx` returned no matches
- `pnpm --filter web run typecheck -- --pretty false`
- `git diff --check`
- pre-push: root Biome, web proxy guard, Tailwind guard, web typecheck, web lint

## Layout Shift Audit
States checked: idle, hover/focus copy affordance, copied, copied timeout reset, missing URL/no-op, and row click isolation. The icon wrappers remain fixed at `h-3.5 w-3.5` / `h-3 w-3`; the state change is opacity-only, so no row or button geometry changes.

Linear: JOV-2747
