### PR TITLE
fix(web): remove otp progress dot drift

### DIFF
--- a/apps/web/components/features/auth/atoms/otp-input/OtpInput.tsx
+++ b/apps/web/components/features/auth/atoms/otp-input/OtpInput.tsx
@@ -92,10 +92,10 @@ export function OtpInput({
             <div
               key={key}
               className={cn(
-                'h-1 w-1 rounded-full transition-all duration-200',
+                'h-1 w-1 rounded-full transition-[background-color,opacity] duration-subtle ease-subtle',
                 i < currentValue.length
-                  ? 'scale-125 bg-[var(--profile-pearl-primary-bg)]'
-                  : 'bg-[color:var(--profile-pearl-border)]'
+                  ? 'bg-primary-token opacity-100'
+                  : 'bg-tertiary-token opacity-35'
               )}
             />
           ))}

--- a/apps/web/tests/components/auth/OtpInput.test.tsx
+++ b/apps/web/tests/components/auth/OtpInput.test.tsx
@@ -1,7 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { OtpInput } from '@/features/auth/atoms/otp-input';
+
+const otpInputSourcePath = resolve(
+  process.cwd(),
+  'components/features/auth/atoms/otp-input/OtpInput.tsx'
+);
 
 // Mock haptic feedback hook
 vi.mock('@/hooks/useHapticFeedback', () => ({
@@ -162,6 +169,27 @@ describe('OtpInput', () => {
       '[class*="rounded-full"][class*="bg-"]'
     );
     expect(progressDots.length).toBe(6);
+    for (const dot of progressDots) {
+      expect(dot.className).toContain('h-1');
+      expect(dot.className).toContain('w-1');
+      expect(dot.className).not.toMatch(/\b(?:transition-all|scale-125)\b/);
+    }
+    expect(progressDots[0]?.className).toContain('bg-primary-token');
+    expect(progressDots[3]?.className).toContain('bg-tertiary-token');
+  });
+
+  it('keeps progress dots fixed-size with System B tokens', () => {
+    const source = readFileSync(otpInputSourcePath, 'utf8');
+
+    expect(source).not.toMatch(
+      /\b(?:transition-all|transition-transform|scale-(?:95|100|105|110|125))\b/
+    );
+    expect(source).not.toContain('profile-pearl');
+    expect(source).toContain(
+      'h-1 w-1 rounded-full transition-[background-color,opacity] duration-subtle ease-subtle'
+    );
+    expect(source).toContain('bg-primary-token opacity-100');
+    expect(source).toContain('bg-tertiary-token opacity-35');
   });
 
   it('supports controlled value', () => {


### PR DESCRIPTION
## Summary
- Replaced mobile OTP progress dot profile-pearl fill and scale motion with fixed-size System B token color/opacity states.
- Added regression coverage that keeps OTP dots free of transition-all, scale motion, and profile-pearl tokens.

## Verification
- pnpm biome check --write apps/web/components/features/auth/atoms/otp-input/OtpInput.tsx apps/web/tests/components/auth/OtpInput.test.tsx
- pnpm --filter web exec vitest run tests/components/auth/OtpInput.test.tsx tests/components/auth/OtpInput.hero.test.tsx
- rg -n "transition-all|scale-125|profile-pearl" apps/web/components/features/auth/atoms/otp-input/OtpInput.tsx (no matches)
- git diff --check
- pnpm --filter web run typecheck -- --pretty false
- pre-push hook: biome check . && pnpm --filter=@jovie/web run pre-push

Linear: JOV-2749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated the OTP input progress indicator dots with revised visual styling, including modified background color tokens and transition effects.

* **Tests**
  * Enhanced test suite for the OTP input component, adding validation of progress indicator dot styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->