### PR TITLE
fix(web): remove auth oauth press transform

### DIFF
--- a/apps/web/lib/auth/constants.ts
+++ b/apps/web/lib/auth/constants.ts
@@ -69,7 +69,7 @@ export const AUTH_CLASSES = {
     'animate-in fade-in-0 slide-in-from-bottom-2 duration-300 ease-out',
   /** OAuth button touch optimization for mobile */
   oauthButtonMobile:
-    'touch-manipulation select-none [-webkit-tap-highlight-color:transparent] active:scale-[0.98] transition-transform duration-subtle',
+    'touch-manipulation select-none [-webkit-tap-highlight-color:transparent] transition-[opacity] duration-subtle active:opacity-[0.92]',
 } as const;
 
 /**

--- a/apps/web/tests/unit/lib/auth/constants.test.ts
+++ b/apps/web/tests/unit/lib/auth/constants.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-import { sanitizeRedirectUrl } from '@/lib/auth/constants';
+import { AUTH_CLASSES, sanitizeRedirectUrl } from '@/lib/auth/constants';
+
+describe('AUTH_CLASSES', () => {
+  it('keeps OAuth mobile feedback free of transform motion', () => {
+    expect(AUTH_CLASSES.oauthButtonMobile).toContain('touch-manipulation');
+    expect(AUTH_CLASSES.oauthButtonMobile).toContain('transition-[opacity]');
+    expect(AUTH_CLASSES.oauthButtonMobile).toContain('active:opacity-[0.92]');
+    expect(AUTH_CLASSES.oauthButtonMobile).not.toMatch(
+      /\b(?:transition-all|transition-transform|active:scale|active:translate|hover:-translate)\b/
+    );
+  });
+});
 
 describe('sanitizeRedirectUrl', () => {
   describe('valid redirect URLs', () => {


### PR DESCRIPTION
## Summary
- Replaced shared OAuth mobile button transform press feedback with opacity-only feedback.
- Added a focused auth constants contract preventing transition-all, transition-transform, and active scale/translate motion from returning.

## Verification
- pnpm biome check --write apps/web/lib/auth/constants.ts apps/web/tests/unit/lib/auth/constants.test.ts
- pnpm --filter web exec vitest run tests/unit/lib/auth/constants.test.ts
- rg -n "active:scale|transition-transform|transition-all" apps/web/lib/auth/constants.ts (no matches)
- git diff --check
- pnpm --filter web run typecheck -- --pretty false
- pre-push hook: biome check . && pnpm --filter=@jovie/web run pre-push

Linear: JOV-2751