### PR TITLE
fix: keep dev web fast startup stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,6 +275,8 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: node scripts/desktop-release-guard.mjs --base "origin/${BASE_REF}"
+      - name: Script unit tests
+        run: node --test scripts/desktop-release-guard.test.mjs scripts/dev-web-fast.test.mjs
       - name: Version consistency guard
         run: node scripts/version-check.mjs
       - name: Next.js proxy guard

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -3509,7 +3509,7 @@ body:has(.system-b-launch-page) .marketing-glass-header__cta:focus-visible {
 }
 
 :where(.system-b-launch-logo-strip li) {
-  color: color-mix(in oklab, var(--system-b-text-primary) 44%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-size: var(--text-sm);
   font-weight: var(--font-weight-medium);
 }
@@ -3582,7 +3582,7 @@ body:has(.system-b-launch-page) .marketing-glass-header__cta:focus-visible {
 :where(.system-b-launch-mini-feature span),
 :where(.system-b-launch-field span),
 :where(.system-b-launch-stat-grid span) {
-  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   text-transform: uppercase;
@@ -3675,7 +3675,7 @@ body:has(.system-b-launch-page) .marketing-glass-header__cta:focus-visible {
 :where(.system-b-launch-stat-callout span) {
   display: block;
   margin-top: var(--space-2);
-  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-size: var(--text-xs);
 }
 
@@ -3694,7 +3694,7 @@ body:has(.system-b-launch-page) .marketing-glass-header__cta:focus-visible {
   border-bottom: 1px solid
     color-mix(in oklab, var(--system-b-text-primary) 8%, transparent);
   padding: var(--space-3) var(--space-4);
-  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-size: var(--text-xs);
 }
 
@@ -3835,7 +3835,7 @@ body:has(.system-b-launch-page) .marketing-glass-header__cta:focus-visible {
   align-items: center;
   gap: var(--space-2);
   margin: var(--space-1) 0 0;
-  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-size: var(--text-xs);
 }
 
@@ -3881,7 +3881,7 @@ body:has(.system-b-launch-page) .marketing-glass-header__cta:focus-visible {
 :where(.system-b-launch-tabs span) {
   border-bottom: 2px solid transparent;
   padding: var(--space-2) var(--space-3);
-  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-size: var(--text-xs);
 }
 
@@ -3896,7 +3896,7 @@ body:has(.system-b-launch-page) .marketing-glass-header__cta:focus-visible {
 
 :where(.system-b-launch-release-detail > p) {
   margin: var(--space-1) 0 var(--space-4);
-  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-size: var(--text-xs);
 }
 
@@ -3946,7 +3946,7 @@ body:has(.system-b-launch-page) .marketing-glass-header__cta:focus-visible {
 
 :where(.system-b-launch-deeplink h3 span) {
   display: block;
-  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   font-weight: var(--font-weight-normal);
@@ -4016,7 +4016,7 @@ body:has(.system-b-launch-page) .marketing-glass-header__cta:focus-visible {
   align-items: center;
   gap: var(--space-2);
   padding: var(--space-2) var(--space-4);
-  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-size: var(--text-sm);
 }
 
@@ -4079,7 +4079,7 @@ body:has(.system-b-launch-page) .marketing-glass-header__cta:focus-visible {
 
 :where(.system-b-launch-metrics span),
 :where(.system-b-launch-table th) {
-  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-size: var(--text-xs);
   font-weight: var(--font-weight-medium);
   text-transform: uppercase;
@@ -4097,7 +4097,7 @@ body:has(.system-b-launch-page) .marketing-glass-header__cta:focus-visible {
 :where(.system-b-launch-metrics em) {
   display: block;
   margin-top: var(--space-1);
-  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-size: var(--text-xs);
   font-style: normal;
 }
@@ -4454,7 +4454,7 @@ body:has(.system-b-pricing-page) .marketing-glass-header__cta:focus-visible {
 :where(.system-b-pricing-story-label),
 :where(.system-b-pricing-category-cell) {
   margin: 0;
-  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   font-weight: var(--font-weight-medium);
@@ -4902,7 +4902,7 @@ body:has(.system-b-pricing-page) .marketing-glass-header__cta:focus-visible {
 
 :where(.system-b-pricing-footnote) {
   margin: var(--space-4) 0 0;
-  color: color-mix(in oklab, var(--system-b-text-primary) 42%, transparent);
+  color: color-mix(in oklab, var(--system-b-text-primary) 50%, transparent);
   font-size: var(--text-xs);
   text-align: center;
 }

--- a/scripts/dev-web-fast.sh
+++ b/scripts/dev-web-fast.sh
@@ -68,15 +68,24 @@ if [ "${JOVIE_DISABLE_MODEL_KEYS_FOR_EVALS:-0}" = "1" ]; then
   echo "Starting dev server with model provider env disabled for isolated evals" >&2
 fi
 
-doppler run --project jovie-web --config dev -- env \
-  "${ENV_UNSET_ARGS[@]}" \
-  E2E_USE_TEST_AUTH_BYPASS="${E2E_USE_TEST_AUTH_BYPASS:-1}" \
-  NEXT_PUBLIC_CLERK_MOCK="${NEXT_PUBLIC_CLERK_MOCK:-1}" \
-  NEXT_PUBLIC_CLERK_PROXY_DISABLED="${NEXT_PUBLIC_CLERK_PROXY_DISABLED:-1}" \
-  NEXT_DISABLE_TOOLBAR="${NEXT_DISABLE_TOOLBAR:-1}" \
-  JOVIE_ENABLE_LOCAL_SENTRY="${JOVIE_ENABLE_LOCAL_SENTRY:-0}" \
-  PORT="$PORT" \
-  pnpm --filter @jovie/web run dev:fast >"$LOG_FILE" 2>&1 &
+DEV_ENV_ARGS=(
+  E2E_USE_TEST_AUTH_BYPASS="${E2E_USE_TEST_AUTH_BYPASS:-1}"
+  NEXT_PUBLIC_CLERK_MOCK="${NEXT_PUBLIC_CLERK_MOCK:-1}"
+  NEXT_PUBLIC_CLERK_PROXY_DISABLED="${NEXT_PUBLIC_CLERK_PROXY_DISABLED:-1}"
+  NEXT_DISABLE_TOOLBAR="${NEXT_DISABLE_TOOLBAR:-1}"
+  JOVIE_ENABLE_LOCAL_SENTRY="${JOVIE_ENABLE_LOCAL_SENTRY:-0}"
+  PORT="$PORT"
+  pnpm --filter @jovie/web run dev:fast
+)
+
+if [ "${#ENV_UNSET_ARGS[@]}" -gt 0 ]; then
+  doppler run --project jovie-web --config dev -- env \
+    "${ENV_UNSET_ARGS[@]}" \
+    "${DEV_ENV_ARGS[@]}" >"$LOG_FILE" 2>&1 &
+else
+  doppler run --project jovie-web --config dev -- env \
+    "${DEV_ENV_ARGS[@]}" >"$LOG_FILE" 2>&1 &
+fi
 DEV_PID=$!
 
 tail -f "$LOG_FILE" &

--- a/scripts/dev-web-fast.test.mjs
+++ b/scripts/dev-web-fast.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import net from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptsDir, '..');
+const devWebFastScript = path.join(scriptsDir, 'dev-web-fast.sh');
+
+function getAvailablePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      server.close(() => {
+        if (address && typeof address === 'object') {
+          resolve(address.port);
+          return;
+        }
+
+        reject(new Error('Unable to allocate a local test port'));
+      });
+    });
+  });
+}
+
+function makeFakeDoppler(binDir) {
+  const dopplerPath = path.join(binDir, 'doppler');
+
+  writeFileSync(
+    dopplerPath,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$@" > "$JOVIE_FAKE_DOPPLER_CAPTURE"
+printf 'Ready in 1ms\\n'
+sleep 1
+`,
+    { mode: 0o755 }
+  );
+}
+
+test('dev-web-fast keeps optional unset args behind a non-empty guard', () => {
+  const scriptText = readFileSync(devWebFastScript, 'utf8');
+  const guardIndex = scriptText.indexOf(
+    'if [ "${#ENV_UNSET_ARGS[@]}" -gt 0 ]; then'
+  );
+  const elseIndex = scriptText.indexOf('\nelse\n', guardIndex);
+  const envUnsetExpansions = [
+    ...scriptText.matchAll(/"\$\{ENV_UNSET_ARGS\[@\]\}"/g),
+  ];
+
+  assert.notEqual(
+    guardIndex,
+    -1,
+    'ENV_UNSET_ARGS must be length-checked before expansion for macOS Bash 3.2'
+  );
+  assert.notEqual(
+    elseIndex,
+    -1,
+    'Guarded ENV_UNSET_ARGS branch must have else'
+  );
+  assert.equal(
+    envUnsetExpansions.length,
+    1,
+    'ENV_UNSET_ARGS must have exactly one command expansion'
+  );
+  assert.ok(
+    envUnsetExpansions[0].index > guardIndex &&
+      envUnsetExpansions[0].index < elseIndex,
+    'ENV_UNSET_ARGS must only expand inside the non-empty branch'
+  );
+});
+
+test('dev-web-fast starts when optional env unset args are empty', async () => {
+  const tmp = mkdtempSync(path.join(tmpdir(), 'jovie-dev-web-fast-test-'));
+  const binDir = path.join(tmp, 'bin');
+  const capturePath = path.join(tmp, 'doppler-args.txt');
+
+  try {
+    mkdirSync(binDir, { recursive: true });
+    makeFakeDoppler(binDir);
+
+    const port = await getAvailablePort();
+    const result = spawnSync('bash', [devWebFastScript], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        PORT: String(port),
+        TMPDIR: tmp,
+        JOVIE_DEV_WARM_ROUTES: '',
+        JOVIE_DEV_READY_TIMEOUT: '5',
+        JOVIE_DISABLE_MODEL_KEYS_FOR_EVALS: '0',
+        JOVIE_DISABLE_REDIS_FOR_EVALS: '0',
+        JOVIE_FAKE_DOPPLER_CAPTURE: capturePath,
+      },
+      timeout: 10_000,
+    });
+
+    const output = `${result.stdout}\n${result.stderr}`;
+    assert.equal(result.status, 0, output);
+    assert.doesNotMatch(output, /ENV_UNSET_ARGS/);
+
+    const dopplerArgs = readFileSync(capturePath, 'utf8').trim().split('\n');
+    assert.ok(dopplerArgs.includes('E2E_USE_TEST_AUTH_BYPASS=1'));
+    assert.ok(dopplerArgs.includes('NEXT_PUBLIC_CLERK_MOCK=1'));
+    assert.ok(dopplerArgs.includes('pnpm'));
+  } finally {
+    rmSync(tmp, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
Fixes JOV-2748

## Summary
- Guard optional env-unset arguments in scripts/dev-web-fast.sh so macOS Bash 3.2 does not expand an empty array under set -u.
- Add a Node built-in regression test for the empty optional env path and wire it into the CI guardrails job.
- Preserve the local auth defaults needed by the iOS browser-login smoke path.
- Restore System B muted text contrast on the launch and pricing public surfaces so the CI axe audit stays green when this regression test triggers public-surface checks.

## Checks
- Red first: JOVIE_AGENT_PROFILE=coder node --test scripts/dev-web-fast.test.mjs failed on the old wrapper with ENV_UNSET_ARGS[@]: unbound variable.
- JOVIE_AGENT_PROFILE=coder node --test scripts/desktop-release-guard.test.mjs scripts/dev-web-fast.test.mjs
- bash -n scripts/dev-web-fast.sh
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write scripts/dev-web-fast.test.mjs .github/workflows/ci.yml
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/styles/design-system.css
- git diff --check
- JOVIE_AGENT_PROFILE=coder doppler run --project jovie-web --config dev -- env PUBLIC_SURFACE_FILTER=marketing-launch,marketing-pricing SMOKE_ONLY=1 E2E_USE_TEST_AUTH_BYPASS=1 NEXT_PUBLIC_CLERK_MOCK=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 pnpm --filter @jovie/web exec playwright test tests/e2e/axe-audit.spec.ts --config=playwright.config.ts --project=chromium --reporter=line: 5 passed
- JOVIE_AGENT_PROFILE=coder JOVIE_DEV_WARM_ROUTES="" JOVIE_DEV_READY_TIMEOUT=90 PORT=3100 pnpm run dev:web:fast reached Next readiness on http://localhost:3100, then the temporary server was stopped.
- Post-rebase: JOVIE_AGENT_PROFILE=coder node --test scripts/desktop-release-guard.test.mjs scripts/dev-web-fast.test.mjs
- Pre-push gate passed: biome check ., next:proxy-guard, tailwind:check, typecheck, lint.
- iOS smoke: JOVIE_AGENT_PROFILE=coder JOVIE_IOS_LIVE_AUTH_UI=1 API_BASE_URL=http://localhost:3100 WEB_BASE_URL=http://localhost:3100 pnpm test:auth:ios passed and reached authenticated needs_onboarding.