### PR TITLE
fix(web): remove link suggestion press transform

### DIFF
--- a/apps/web/components/features/dashboard/molecules/universal-link-input/UniversalLinkInput.tsx
+++ b/apps/web/components/features/dashboard/molecules/universal-link-input/UniversalLinkInput.tsx
@@ -110,9 +110,8 @@ function PlatformSuggestionItem({
       data-option-id={optionId}
       type='button'
       className={cn(
-        'flex min-h-[44px] w-full items-center justify-between gap-2.5 px-3 py-2.5 text-left text-app text-primary-token transition',
-        active ? 'bg-surface-2' : 'hover:bg-surface-2',
-        'active:scale-[0.99]'
+        'flex min-h-[44px] w-full items-center justify-between gap-2.5 px-3 py-2.5 text-left text-app text-primary-token transition-[background-color,color] duration-subtle ease-subtle active:bg-surface-2',
+        active ? 'bg-surface-2' : 'hover:bg-surface-2'
       )}
       onMouseEnter={onMouseEnter}
       onClick={onClick}

--- a/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SidebarLinkInput.tsx
+++ b/apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SidebarLinkInput.tsx
@@ -56,9 +56,8 @@ function SidebarSuggestionItem({
     <button
       type='button'
       className={cn(
-        'flex w-full min-h-[44px] items-center gap-2.5 px-3 py-2.5 text-left text-app text-primary-token transition',
-        active ? 'bg-surface-2' : 'hover:bg-surface-2',
-        'active:scale-[0.99]'
+        'flex w-full min-h-[44px] items-center gap-2.5 px-3 py-2.5 text-left text-app text-primary-token transition-[background-color,color] duration-subtle ease-subtle active:bg-surface-2',
+        active ? 'bg-surface-2' : 'hover:bg-surface-2'
       )}
       onMouseEnter={onMouseEnter}
       onClick={onClick}

--- a/apps/web/tests/unit/dashboard/universal-link-suggestions-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/universal-link-suggestions-system-b-style-guard.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+
+const suggestionSources = [
+  'components/features/dashboard/molecules/universal-link-input/UniversalLinkInput.tsx',
+  'components/features/dashboard/organisms/profile-contact-sidebar/SidebarLinkInput.tsx',
+];
+
+const transformPressPatterns = [
+  /\bactive:scale(?:-\[[^\]]+\]|-\d+)?\b/,
+  /\btransition-all\b/,
+  /\btransition-transform\b/,
+  /\btransition-\[[^\]]*transform[^\]]*\]/,
+];
+
+describe('dashboard universal link suggestion System B guard', () => {
+  it('keeps suggestion row feedback color-only and dimensionally stable', () => {
+    for (const sourcePath of suggestionSources) {
+      const source = readFileSync(path.join(webRoot, sourcePath), 'utf8');
+      const offenders = transformPressPatterns
+        .filter(pattern => pattern.test(source))
+        .map(pattern => pattern.toString());
+
+      expect(offenders, `${sourcePath} leaked ${offenders.join(', ')}`).toEqual(
+        []
+      );
+      expect(source).toContain('min-h-[44px]');
+      expect(source).toContain('transition-[background-color,color]');
+      expect(source).toContain('active:bg-surface-2');
+    }
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2752 -->

## Summary
- Remove `active:scale-[0.99]` from universal link suggestion rows in the dashboard link input and profile contact sidebar.
- Narrow row transitions to background/color only while preserving the active row surface state.
- Add a System B source guard for these shared suggestion rows so transform/all-transition press feedback does not return.

## Layout Shift Audit
States covered: suggestions closed, suggestions open with no active row, active row highlighted, row pressed/clicked, keyboard commit, and the mobile hidden Enter hint state. Row `min-h-[44px]`, padding, gap, and width remain unchanged; the press state now changes background color only, so there is no geometry change between states.

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/molecules/universal-link-input/UniversalLinkInput.tsx apps/web/components/features/dashboard/organisms/profile-contact-sidebar/SidebarLinkInput.tsx apps/web/tests/unit/dashboard/universal-link-suggestions-system-b-style-guard.test.ts`
- `pnpm --filter web exec vitest run tests/unit/dashboard/universal-link-suggestions-system-b-style-guard.test.ts`
- `git diff --check`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Commit hook: `next:proxy-guard`, lint-staged Biome, ESLint, staged a11y, and web typecheck passed.
- Push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, web typecheck, and web lint passed.

## Risk
Low. This is a source-only visual feedback cleanup for two suggestion row primitives; selection behavior and row dimensions are unchanged.
