### PR TITLE
fix(web): remove mobile menu transform drift

### DIFF
--- a/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx
@@ -182,8 +182,7 @@ function MenuItemLink({
     <Link
       href={item.href}
       className={cn(
-        'flex items-center gap-3 rounded-lg px-3 py-2.5 text-app font-caption transition-[background-color,color,transform] duration-subtle',
-        'active:scale-[0.98]',
+        'flex items-center gap-3 rounded-lg px-3 py-2.5 text-app font-caption transition-[background-color,color] duration-subtle ease-subtle active:bg-surface-2',
         active
           ? 'bg-bg-surface-2 text-primary-token'
           : 'text-secondary-token hover:text-primary-token hover:bg-surface-1'
@@ -261,8 +260,8 @@ export function LiquidGlassMenu({
         {/* Expanded menu */}
         <div
           className={cn(
-            'relative z-50 mx-3 mb-2 overflow-hidden rounded-xl transition-[transform,opacity] duration-cinematic ease-out',
-            isExpanded ? 'translate-y-0 scale-100' : 'translate-y-4 scale-95'
+            'relative z-50 mx-3 mb-2 overflow-hidden rounded-xl transition-opacity duration-cinematic ease-cinematic',
+            isExpanded ? 'opacity-100' : 'opacity-0'
           )}
           style={{
             background: 'var(--liquid-glass-bg-solid)',
@@ -311,7 +310,7 @@ export function LiquidGlassMenu({
                   <button
                     type='button'
                     onClick={onSignOut}
-                    className='flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-app font-caption text-secondary-token transition-[background-color,color,transform] duration-subtle hover:bg-surface-1 hover:text-primary-token active:scale-[0.98]'
+                    className='flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-app font-caption text-secondary-token transition-[background-color,color] duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token active:bg-surface-2'
                   >
                     <LogOut
                       className='size-5 shrink-0 text-tertiary-token'
@@ -351,8 +350,7 @@ export function LiquidGlassMenu({
                 href={item.href}
                 aria-current={active ? 'page' : undefined}
                 className={cn(
-                  'relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-[color,transform] duration-subtle',
-                  'active:scale-95',
+                  'relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-colors duration-subtle ease-subtle active:text-primary-token',
                   active
                     ? 'text-primary-token'
                     : 'text-tertiary-token hover:text-secondary-token'
@@ -389,8 +387,7 @@ export function LiquidGlassMenu({
             aria-label={isExpanded ? 'Close menu' : 'More options'}
             aria-expanded={isExpanded}
             className={cn(
-              'relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-[color,transform] duration-subtle',
-              'active:scale-95',
+              'relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 transition-colors duration-subtle ease-subtle active:text-primary-token',
               isExpanded
                 ? 'text-primary-token'
                 : 'text-tertiary-token hover:text-secondary-token'
@@ -413,7 +410,7 @@ export function LiquidGlassMenu({
               type='button'
               onClick={onSearchClick}
               aria-label='Search'
-              className='relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 text-tertiary-token transition-[color,transform] duration-subtle hover:text-secondary-token active:scale-95'
+              className='relative flex min-w-[64px] flex-col items-center justify-center gap-0.5 rounded-lg py-1.5 text-tertiary-token transition-colors duration-subtle ease-subtle hover:text-secondary-token active:text-primary-token'
             >
               <Search className='h-5 w-5' aria-hidden='true' />
               <span className='sr-only'>Search</span>

--- a/apps/web/tests/unit/dashboard/liquid-glass-menu-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/liquid-glass-menu-system-b-style-guard.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+const sourcePath =
+  'components/features/dashboard/organisms/LiquidGlassMenu.tsx';
+
+const transformMotionPatterns = [
+  /\bactive:scale(?:-\[[^\]]+\]|-\d+)?\b/,
+  /\btransition-all\b/,
+  /\btransition-transform\b/,
+  /\btransition-\[[^\]]*transform[^\]]*\]/,
+  /\btranslate-y-/,
+  /\bscale(?:-\[[^\]]+\]|-\d{1,3})/,
+];
+
+describe('dashboard LiquidGlassMenu System B guard', () => {
+  it('keeps mobile menu feedback color or opacity only', () => {
+    const source = readFileSync(path.join(webRoot, sourcePath), 'utf8');
+    const offenders = transformMotionPatterns
+      .filter(pattern => pattern.test(source))
+      .map(pattern => pattern.toString());
+
+    expect(offenders, `${sourcePath} leaked ${offenders.join(', ')}`).toEqual(
+      []
+    );
+    expect(source).toContain('transition-[background-color,color]');
+    expect(source).toContain('transition-colors');
+    expect(source).toContain('transition-opacity');
+    expect(source).toContain('active:bg-surface-2');
+    expect(source).toContain('active:text-primary-token');
+    expect(source).toContain('min-w-[64px]');
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2753 -->

## Summary
- Removed transform-based press feedback from the mobile dashboard `LiquidGlassMenu` rows, bottom tabs, More, Search, and Sign out controls.
- Replaced expanded-sheet translate/scale entrance motion with opacity-only state changes.
- Added a focused System B guard for `LiquidGlassMenu` transform drift.

## Layout Shift Audit
- Visual states enumerated: collapsed tab bar, expanded menu, active route tab, inactive tab press, More expanded state, Search press, Sign out press, active expanded-menu row, inactive expanded-menu row, and badge rendering.
- State transitions now use fixed tab widths plus color/background/opacity only. No press or open state applies translate or scale transforms.

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx apps/web/tests/unit/dashboard/liquid-glass-menu-system-b-style-guard.test.ts`
- `rg -n "active:scale|transition-all|transition-transform|transition-\[[^]]*transform|translate-y-|scale-" apps/web/components/features/dashboard/organisms/LiquidGlassMenu.tsx` returned no matches
- `pnpm --filter web exec vitest run tests/unit/dashboard/liquid-glass-menu-system-b-style-guard.test.ts`
- `git diff --check`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Commit hook: proxy guard, Biome, ESLint, staged a11y, local web typecheck
- Pre-push hook: `biome check .`, proxy guard, Tailwind guard, web typecheck, web lint
