### PR TITLE
fix(ui): remove textarea transition drift

### DIFF
--- a/packages/ui/atoms/textarea.test.tsx
+++ b/packages/ui/atoms/textarea.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 import { fireEvent, render, screen } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it } from 'vitest';
@@ -5,6 +7,27 @@ import { describe, expect, it } from 'vitest';
 import { Textarea } from './textarea';
 
 describe('Textarea', () => {
+  describe('System B motion contract', () => {
+    it('uses explicit non-transform transitions only', () => {
+      const source = readFileSync(
+        path.join(process.cwd(), 'atoms/textarea.tsx'),
+        {
+          encoding: 'utf8',
+        }
+      );
+
+      expect(source).not.toMatch(
+        /\b(?:transition-all|transition-transform|active:scale|active:translate|hover:-translate)\b/
+      );
+      expect(source).not.toMatch(/\bduration-\d+\b/);
+      expect(source).toContain(
+        'transition-[background-color,border-color,box-shadow,color,opacity]'
+      );
+      expect(source).toContain('duration-normal');
+      expect(source).toContain('ease-interactive');
+    });
+  });
+
   describe('Basic Rendering', () => {
     it('renders with default props', () => {
       render(<Textarea placeholder='Enter text' />);

--- a/packages/ui/atoms/textarea.tsx
+++ b/packages/ui/atoms/textarea.tsx
@@ -13,7 +13,7 @@ const textareaVariants = cva(
     'hover:border-(--linear-border-default)',
     'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/24',
     'disabled:cursor-not-allowed disabled:opacity-50',
-    'transition-all duration-normal ease-interactive',
+    'transition-[background-color,border-color,box-shadow,color,opacity] duration-normal ease-interactive',
     'min-h-[80px]',
   ],
   {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2754 -->

## Summary
- Replaced shared `Textarea` broad `transition-all` styling with explicit background, border, shadow, color, and opacity transitions.
- Added a focused System B motion contract guard to the existing textarea atom test.

## Layout Shift Audit
- Visual states enumerated: default textarea, hover border, focus-visible ring, disabled opacity, error validation border, success validation border, resize-y default, resize-none opt-out, labeled/help/error wrapper states.
- The shared atom now avoids broad property animation and has no transform press/hover classes, so validation/focus states cannot accidentally animate geometry through `transition-all`.

## Verification
- `pnpm biome check --write packages/ui/atoms/textarea.tsx packages/ui/atoms/textarea.test.tsx`
- `rg -n "transition-all|transition-transform|active:scale|active:translate|hover:-translate|duration-[0-9]+" packages/ui/atoms/textarea.tsx` returned no matches
- `pnpm --filter @jovie/ui exec vitest run atoms/textarea.test.tsx`
- `pnpm --filter @jovie/ui run typecheck`
- `pnpm --filter @jovie/ui run lint`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Commit hook: proxy guard and staged Biome
- Pre-push hook: repo-wide Biome, proxy guard, Tailwind guard, web typecheck, web lint
