### PR TITLE
fix(web): remove chat link item press transforms

### DIFF
--- a/apps/web/components/features/dashboard/organisms/links/ChatStyleLinkItem.tsx
+++ b/apps/web/components/features/dashboard/organisms/links/ChatStyleLinkItem.tsx
@@ -196,7 +196,7 @@ export const ChatStyleLinkItem = React.memo(function ChatStyleLinkItem<
               className={cn(
                 'flex h-11 w-11 cursor-grab items-center justify-center rounded-md sm:h-8 sm:w-8',
                 'text-tertiary-token transition-colors',
-                'hover:text-secondary-token active:cursor-grabbing active:scale-95',
+                'hover:text-secondary-token active:cursor-grabbing active:text-primary-token',
                 'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
               )}
               aria-label='Drag to reorder'
@@ -240,9 +240,8 @@ export const ChatStyleLinkItem = React.memo(function ChatStyleLinkItem<
             className={cn(
               'inline-flex h-11 w-11 items-center justify-center rounded-md sm:h-9 sm:w-9 sm:rounded-lg',
               'text-secondary-token transition-colors',
-              'hover:bg-surface-1 hover:text-primary-token',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent',
-              'active:scale-95'
+              'hover:bg-surface-1 hover:text-primary-token active:bg-surface-2 active:text-primary-token',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent'
             )}
             {...getReferenceProps()}
           >
@@ -279,7 +278,7 @@ export const ChatStyleLinkItem = React.memo(function ChatStyleLinkItem<
                       }}
                       className={cn(
                         MENU_ITEM_BASE,
-                        'min-h-[44px] w-full text-left active:scale-[0.98]',
+                        'min-h-[44px] w-full text-left active:bg-surface-2',
                         item.variant === 'destructive' && MENU_ITEM_DESTRUCTIVE
                       )}
                       {...getItemProps()}

--- a/apps/web/tests/components/dashboard/link-action-system-b-style-guard.test.ts
+++ b/apps/web/tests/components/dashboard/link-action-system-b-style-guard.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const forbiddenMotionClasses =
-  /\b(?:transition-all|duration-\d+|active:scale|active:translate|hover:-translate|group-hover:scale)\b/;
+  /\b(?:transition-all|transition-transform|duration-\d+|active:scale|active:translate|hover:-translate|group-hover:scale)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
 
 describe('dashboard link action System B style guard', () => {
   it.each([
@@ -11,6 +11,10 @@ describe('dashboard link action System B style guard', () => {
       'components/features/dashboard/atoms/link-actions/LinkActions.tsx',
     ],
     ['LinkPill', 'components/features/dashboard/atoms/LinkPill.tsx'],
+    [
+      'ChatStyleLinkItem',
+      'components/features/dashboard/organisms/links/ChatStyleLinkItem.tsx',
+    ],
   ])('%s does not use decorative press motion', (_name, filePath) => {
     const source = readFileSync(filePath, 'utf8');
 


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2755 -->

## Summary
- Removed transform-based press feedback from `ChatStyleLinkItem` drag handle, menu trigger, and dropdown rows.
- Replaced press state with stable color/background feedback while preserving 44px mobile tap targets and focus rings.
- Expanded the dashboard link System B guard to cover `ChatStyleLinkItem` and transform transition classes.

## Layout Shift Audit
- Visual states enumerated: visible row, hidden row opacity, last-added ring, drag handle press/grab, menu trigger hover/press, dropdown open, default/destructive menu rows, mobile 44px tap targets, and focus-visible states.
- Press states now use text/background color only. No press state changes transform, width, height, padding, or row geometry.

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/organisms/links/ChatStyleLinkItem.tsx apps/web/tests/components/dashboard/link-action-system-b-style-guard.test.ts`
- `rg -n "active:scale|transition-all|transition-transform|transition-\[[^]]*transform|active:translate|hover:-translate|group-hover:scale|duration-[0-9]+" apps/web/components/features/dashboard/organisms/links/ChatStyleLinkItem.tsx` returned no matches
- `pnpm --filter web exec vitest run tests/components/dashboard/link-action-system-b-style-guard.test.ts`
- `git diff --check`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Commit hook: proxy guard, Biome, ESLint, staged a11y, local web typecheck
- Pre-push hook: repo-wide Biome, proxy guard, Tailwind guard, web typecheck, web lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined interactive element styling by replacing scale animations with color transitions for drag handles, menu triggers, and dropdown items.

* **Tests**
  * Expanded test coverage to enforce restrictions on motion and transform styles across additional components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->