### PR TITLE
fix(web): remove amount selector transform drift

### DIFF
--- a/apps/web/components/atoms/AmountSelector.tsx
+++ b/apps/web/components/atoms/AmountSelector.tsx
@@ -33,7 +33,7 @@ export const AmountSelector = memo(function AmountSelector({
       disabled={disabled}
       aria-disabled={disabled}
       className={cn(
-        'group relative flex aspect-square w-full flex-col items-center justify-center gap-0.5 rounded-[16px] border text-center transition-[background-color,border-color,color,transform] duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-base',
+        'group relative flex aspect-square w-full flex-col items-center justify-center gap-0.5 rounded-[16px] border text-center transition-[background-color,border-color,box-shadow,color,opacity] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-base',
         disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
         isSelected
           ? 'border-[color:var(--profile-pearl-primary-bg)] bg-[var(--profile-pearl-primary-bg)] text-[var(--profile-pearl-primary-fg)] ring-1 ring-white/10'

--- a/apps/web/tests/unit/atoms/amount-selector-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/atoms/amount-selector-system-b-style-guard.test.ts
@@ -1,0 +1,24 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const sourcePath = join(appRoot, 'components/atoms/AmountSelector.tsx');
+
+const forbiddenMotionClasses =
+  /\b(?:transition-all|transition-transform|duration-\d+|active:scale|active:translate|hover:-translate|group-hover:scale)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
+
+describe('AmountSelector System B style guard', () => {
+  it('keeps amount state changes visually stable', async () => {
+    const source = await readFile(sourcePath, 'utf8');
+
+    expect(source).not.toMatch(forbiddenMotionClasses);
+    expect(source).toContain(
+      'transition-[background-color,border-color,box-shadow,color,opacity]'
+    );
+    expect(source).toContain('duration-subtle');
+    expect(source).toContain('ease-subtle');
+    expect(source).toContain('aspect-square');
+  });
+});


### PR DESCRIPTION
## Summary
- Removed `transform` from `AmountSelector` state transitions and moved the timing to System B `duration-subtle` / `ease-subtle` tokens.
- Added a focused source guard for AmountSelector so transform/press drift and raw duration utilities cannot regress.

## Layout Shift Audit
- States reviewed: unselected preset, selected preset, disabled preset, and PaySelector custom-amount swap.
- The selector already reserves its square footprint with `aspect-square`; this PR keeps state changes to paint, shadow, color, and opacity only.
- Existing PaySelector coverage confirms the amount slot stays reserved when switching between preset buttons and custom input.

## Verification
- `pnpm biome check --write apps/web/components/atoms/AmountSelector.tsx apps/web/tests/unit/atoms/amount-selector-system-b-style-guard.test.ts`
- `rg -n "transition-all|transition-transform|transition-\[[^]]*transform|active:scale|active:translate|hover:-translate|group-hover:scale|duration-[0-9]+" apps/web/components/atoms/AmountSelector.tsx || true`
- `pnpm --filter web exec vitest run tests/unit/atoms/amount-selector-system-b-style-guard.test.ts tests/unit/molecules/TipSelector.test.tsx`
- `git diff --check`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook: `next:proxy-guard`, Biome, ESLint, staged a11y check, web typecheck
- Pre-push hook: repo Biome, web proxy guard, Tailwind guard, web typecheck, web lint

Linear: JOV-2756


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button transition effects in the amount selector component to enhance visual feedback during user interactions.

* **Tests**
  * Added test coverage to ensure button styling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->