### PR TITLE
fix(web): remove pay selector transform drift

### DIFF
--- a/apps/web/components/molecules/PaySelector.tsx
+++ b/apps/web/components/molecules/PaySelector.tsx
@@ -184,7 +184,7 @@ export function PaySelector({
                         aria-label={`Select ${formatAmountForScreenReader(amount)} payment amount`}
                         onClick={() => handleAmountSelect(idx)}
                         className={cn(
-                          'flex h-[92px] items-center justify-center rounded-[22px] border text-center transition-[border-color,background-color,color,transform] duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
+                          'flex h-[92px] items-center justify-center rounded-[22px] border text-center transition-[border-color,background-color,box-shadow,color,opacity] duration-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--focus-ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-transparent',
                           isSelected
                             ? 'border-white bg-white text-[#121216] shadow-[0_20px_40px_rgba(255,255,255,0.08)]'
                             : 'border-white/10 bg-white/[0.02] text-white hover:border-white/18 hover:bg-white/[0.04]'

--- a/apps/web/tests/unit/molecules/pay-selector-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/molecules/pay-selector-system-b-style-guard.test.ts
@@ -1,0 +1,26 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const sourcePath = join(appRoot, 'components/molecules/PaySelector.tsx');
+
+const forbiddenPresetMotionClasses =
+  /\b(?:transition-all|transition-transform|duration-\d+|active:scale|active:translate|hover:-translate|group-hover:scale)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
+
+describe('PaySelector System B style guard', () => {
+  it('keeps amount preset state changes visually stable', async () => {
+    const source = await readFile(sourcePath, 'utf8');
+    const presetButtonClass = source.match(
+      /'flex h-\[92px\] items-center justify-center[^']+'/
+    )?.[0];
+
+    expect(presetButtonClass).toBeDefined();
+    expect(presetButtonClass).not.toMatch(forbiddenPresetMotionClasses);
+    expect(presetButtonClass).toContain(
+      'transition-[border-color,background-color,box-shadow,color,opacity]'
+    );
+    expect(presetButtonClass).toContain('duration-subtle');
+  });
+});


### PR DESCRIPTION
## Summary
- Removed `transform` from PaySelector amount preset state transitions.
- Added a focused source guard for the preset button class so transform/press drift cannot regress while preserving the existing chevron rotation.

## Layout Shift Audit
- States reviewed: unselected preset, selected preset, custom amount mode, other payment options collapsed/expanded.
- The amount slot keeps its fixed `min-h-[160px]` / `h-[92px]` footprint; this PR limits preset state changes to paint, shadow, color, and opacity.
- Existing PaySelector coverage confirms selected amounts still continue correctly and custom amount mode keeps the reserved slot.

## Verification
- `pnpm biome check --write apps/web/components/molecules/PaySelector.tsx apps/web/tests/unit/molecules/pay-selector-system-b-style-guard.test.ts`
- `node preset amount class forbidden-motion check`
- `pnpm --filter web exec vitest run tests/unit/molecules/pay-selector-system-b-style-guard.test.ts tests/unit/molecules/TipSelector.test.tsx`
- `git diff --check`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook: `next:proxy-guard`, Biome, ESLint, staged a11y check, web typecheck
- Pre-push hook: repo Biome, web proxy guard, Tailwind guard, web typecheck, web lint

Linear: JOV-2757

<!-- agent-run-artifact
{
  "id": "jov-2757-gstack-gates-6c183c253692",
  "source": "github",
  "sourceRunId": "6c183c2536920c663e3246613119b2645f72c5af",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2757 GStack gate evidence",
  "summary": "Recorded /qa, /review, and /ship evidence for PaySelector System B drift remediation.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2757",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2757/remove-payselector-amount-preset-transform-transition-drift",
  "pullRequestUrl": null,
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Scoped QA passed: preset amount class grep clean; PaySelector System B guard passed; existing PaySelector behavior/custom-slot tests passed; git diff whitespace check clean; web typecheck passed; pre-push Biome/proxy/Tailwind/typecheck/lint passed.",
      "checkedAt": "2026-06-04T02:28:31.902Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Review passed for a two-file UI molecule diff: amount preset buttons no longer transition transform, fixed h-[92px] slot preserved, and unrelated chevron rotation left untouched.",
      "checkedAt": "2026-06-04T02:28:31.902Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/ship path recorded: clean worktree from origin/main, Linear JOV-2757 moved In Progress before edit, committed, pushed, and draft PR opened with local verification evidence.",
      "checkedAt": "2026-06-04T02:28:31.902Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": "No metered project cost recorded for local deterministic gate evidence."
  },
  "blockedReason": null,
  "createdAt": "2026-06-04T02:28:31.902Z",
  "updatedAt": "2026-06-04T02:28:31.902Z",
  "metadata": {
    "branch": "codex/jov-2757-pay-selector-motion-system-b",
    "commit": "6c183c2536920c663e3246613119b2645f72c5af",
    "localChecks": [
      "pnpm biome check --write apps/web/components/molecules/PaySelector.tsx apps/web/tests/unit/molecules/pay-selector-system-b-style-guard.test.ts",
      "node preset amount class forbidden-motion check",
      "pnpm --filter web exec vitest run tests/unit/molecules/pay-selector-system-b-style-guard.test.ts tests/unit/molecules/TipSelector.test.tsx",
      "git diff --check",
      "pnpm --filter @jovie/web run typecheck -- --pretty false",
      "pre-push hook: biome check . && pnpm --filter=@jovie/web run pre-push"
    ]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined CSS transition properties on the payment selector component for improved animation performance.

* **Tests**
  * Added unit tests to maintain styling consistency for the payment selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->