### PR TITLE
fix(ci): route scope judge through OpenRouter

### DIFF
--- a/.github/workflows/scope-judge.yml
+++ b/.github/workflows/scope-judge.yml
@@ -9,8 +9,8 @@
 # HOW IT WORKS:
 # 1. Extracts Linear ticket intent from PR body (populated by linear-ai-orchestrator)
 # 2. Gets the full diff of the PR
-# 3. If an API key is configured, sends diff + intent to OpenAI GPT-4o for
-#    scope alignment judgment
+# 3. If an API key is configured, sends diff + intent to an OpenRouter free
+#    model for scope alignment judgment
 # 4. If no API key is configured, skips the LLM call and reports a deterministic
 #    no-cost success status so CI does not burn tokens or fail inconclusively
 # 5. Reports pass/fail/skip as a commit status (used as required check for auto-approve)
@@ -136,21 +136,22 @@ jobs:
         id: judge-key
         if: steps.intent.outputs.has_intent == 'true' && steps.diff.outputs.has_diff == 'true'
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
-          if [[ -n "$OPENAI_API_KEY" ]]; then
-            echo "Scope judge API key is configured."
+          if [[ -n "$OPENROUTER_API_KEY" ]]; then
+            echo "Scope judge OpenRouter API key is configured."
             echo "has_key=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Scope judge API key is not configured. Skipping LLM-backed scope judgment."
+            echo "Scope judge OpenRouter API key is not configured. Skipping LLM-backed scope judgment."
             echo "has_key=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Run scope alignment judge (OpenAI)
+      - name: Run scope alignment judge (OpenRouter)
         id: judge
         if: steps.intent.outputs.has_intent == 'true' && steps.diff.outputs.has_diff == 'true' && steps.judge-key.outputs.has_key == 'true'
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_MODEL: openai/gpt-oss-20b:free
         run: |
           INTENT=$(echo "${{ steps.intent.outputs.intent }}" | base64 -d)
           DIFF=$(echo "${{ steps.diff.outputs.diff }}" | base64 -d)
@@ -188,15 +189,20 @@ jobs:
           PROMPTEOF
           )
 
-          # Call OpenAI API
-          RESPONSE=$(curl -sS --max-time 30 https://api.openai.com/v1/chat/completions \
-            -H "Authorization: Bearer $OPENAI_API_KEY" \
+          echo "Using OpenRouter model: $OPENROUTER_MODEL"
+
+          # Call OpenRouter API with a free model.
+          RESPONSE=$(curl -sS --max-time 30 https://openrouter.ai/api/v1/chat/completions \
+            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
             -H "Content-Type: application/json" \
+            -H "HTTP-Referer: https://github.com/${{ github.repository }}" \
+            -H "X-OpenRouter-Title: Jovie Scope Judge" \
             -d "$(jq -n \
+              --arg model "$OPENROUTER_MODEL" \
               --arg system "$JUDGE_PROMPT" \
               --arg user "## TICKET INTENT\n$INTENT\n\n## CODE CHANGES\n$DIFF" \
               '{
-                model: "gpt-4o-mini",
+                model: $model,
                 messages: [
                   {role: "system", content: $system},
                   {role: "user", content: $user}
@@ -207,7 +213,7 @@ jobs:
             )")
 
           # Extract verdict
-          CONTENT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // "ERROR: No response"')
+          CONTENT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // .error.message // "ERROR: No response"')
           echo "Judge response: $CONTENT"
 
           VERDICT=$(echo "$CONTENT" | grep -oP '(?<=VERDICT:\s)(PASS|FAIL)' | head -1 || echo "")
@@ -267,7 +273,7 @@ jobs:
           gh api repos/${{ github.repository }}/statuses/$SHA \
             -f state="success" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-            -f description="Scope judge skipped - API key missing; no model call" \
+            -f description="Scope judge skipped - OpenRouter API key missing; no model call" \
             -f context="scope-judge"
 
       - name: Skip status (no Linear intent found)

--- a/apps/web/tests/unit/ci/scope-judge-workflow.test.ts
+++ b/apps/web/tests/unit/ci/scope-judge-workflow.test.ts
@@ -19,6 +19,25 @@ function getStepBlock(workflow: string, stepName: string): string {
 }
 
 describe('Scope Judge workflow cost controls', () => {
+  it('runs the LLM-backed judge through OpenRouter free models', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const keyStep = getStepBlock(workflow, 'Check scope judge API key');
+    const judgeStep = getStepBlock(
+      workflow,
+      'Run scope alignment judge (OpenRouter)'
+    );
+
+    expect(keyStep).toContain('OPENROUTER_API_KEY');
+    expect(keyStep).not.toContain('OPENAI_API_KEY');
+    expect(judgeStep).toContain(
+      'https://openrouter.ai/api/v1/chat/completions'
+    );
+    expect(judgeStep).toContain('OPENROUTER_API_KEY');
+    expect(judgeStep).toContain('OPENROUTER_MODEL: openai/gpt-oss-20b:free');
+    expect(judgeStep).not.toContain('https://api.openai.com');
+    expect(judgeStep).not.toContain('gpt-4o-mini');
+  });
+
   it('posts a successful deterministic status when the LLM key is absent', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const step = getStepBlock(
@@ -29,7 +48,7 @@ describe('Scope Judge workflow cost controls', () => {
     expect(step).toContain("steps.judge-key.outputs.has_key != 'true'");
     expect(step).toContain('-f state="success"');
     expect(step).toContain('context="scope-judge"');
-    expect(step).toContain('API key missing; no model call');
+    expect(step).toContain('OpenRouter API key missing; no model call');
     expect(step).not.toContain('-f state="failure"');
     expect(step).not.toContain('OPENAI_API_KEY');
   });

--- a/docs/AUTOMATION_AUDIT.md
+++ b/docs/AUTOMATION_AUDIT.md
@@ -134,20 +134,20 @@ There is no workflow that reports the weekly health of the agent pipeline itself
 
 ---
 
-## 4. OpenRouter Free-Model Substitution Candidates
+## 4. OpenRouter Free-Model Routing
 
 | Cron / Agent | Current Model | Substitution Candidate | Acceptable? | Notes |
 |---|---|---|---|---|
 | `generate-insights` | Unknown (check `lib/services/insights/insight-generator.ts`) | `google/gemini-flash-1.5:free` or `meta-llama/llama-3.1-8b-instruct:free` | Maybe — flag for review | Insights are a Pro feature; output quality matters. Free models are worth A/B testing against current output before switching. |
 | `summarize-interviews` | Claude Haiku (`summarize-interviews` comment) | `google/gemini-flash-1.5:free` | Likely yes for internal interviews | Summarization is a structured extract task; free Gemini Flash handles it well. Use for internal/admin interviews; keep Haiku for user-facing summaries if quality bar is high. |
 | `generate-playlist` | Unknown (check `lib/playlists/pipeline.ts`) | `meta-llama/llama-3.1-8b-instruct:free` | Maybe | Playlist concept generation is creative; output quality is visible to admins. Test before switching. |
-| `scope-judge` (`scope-judge.yml`) | `gpt-4o-mini` (OpenAI) | `google/gemini-flash-1.5:free` via OpenRouter | Yes — low stakes | Scope alignment is a pass/fail classification task; free Gemini Flash is more than capable. Switching would eliminate the OpenAI API dependency for this workflow. Per-PR cost is ~1 small API call; at current throughput, switching saves a modest but real amount. |
+| `scope-judge` (`scope-judge.yml`) | `openai/gpt-oss-20b:free` via OpenRouter | Already routed | Yes — low stakes | Scope alignment is a pass/fail classification task; the workflow reads `OPENROUTER_API_KEY` and calls OpenRouter's chat completions endpoint. Per-PR cost stays on a free-model route while preserving the existing `scope-judge` status context. |
 | `linear-ai-orchestrator` (Claude Code action) | Claude Sonnet (Anthropic) | Not substitutable | No | Full code implementation requires strong reasoning. Claude Code OAuth token is a different billing vector (Anthropic usage, not OpenAI). Do not substitute. |
 | `main-autofix` (Claude Code action) | Claude Sonnet (Anthropic) | Not substitutable | No | Red-main fix requires strong code reasoning; wrong fixes compound the problem. Do not substitute. |
 | `sentry-autofix` (Claude Code action) | Claude Sonnet (Anthropic) | Not substitutable | No | Same as above. |
 | `agent-pipeline` fix job (Claude Code action) | Claude Sonnet (Anthropic) | Not substitutable | No | Same as above. |
 
-**Summary:** The only clear OpenRouter free-model win right now is the `scope-judge` workflow (swap `gpt-4o-mini` for `google/gemini-flash-1.5:free` via OpenRouter). The LLM-using cron routes are worth testing with free models on a staging branch before committing.
+**Summary:** The clear OpenRouter free-model win has been landed in the `scope-judge` workflow. The LLM-using cron routes are worth testing with free models on a staging branch before committing.
 
 ---
 
@@ -162,7 +162,7 @@ There is no workflow that reports the weekly health of the agent pipeline itself
 | `frequent` → `pixelRetry` / `pixel-forwarding` | FB/Google/TikTok pixel endpoints | Up to 500 events | 48 (minute ≥30 runs) | Up to 24,000 pixel forwards | O(pixel events) | Low — batch forwarding, not per-user API calls |
 | `generate-insights` | LLM API | Per eligible profile | 1 | O(Pro+ users with clicks) | O(users) | **Monitor as Pro user count grows** |
 | `summarize-interviews` | Claude Haiku | Per pending interview | 0 (not scheduled!) | 0 | O(interviews) | Currently zero cost (not running) |
-| `scope-judge` | OpenAI GPT-4o-mini | 1 per agent PR | ~10-20/day (estimate) | 10-20 calls | O(agent PRs) | Low; ~$0.01-0.02/day |
+| `scope-judge` | OpenRouter free model | 1 per agent PR | ~10-20/day (estimate) | 10-20 calls | O(agent PRs) | Low; free-model route, blocks only on the `OPENROUTER_API_KEY` secret |
 | `synthetic-monitoring` | Playwright against `jov.ie` | Read-only GET requests | ~80/day (mixed schedule) | ~80 runs × N requests | O(1) | Low; read-only production traffic |
 
 ### Quiet cost concern


### PR DESCRIPTION
## Summary
- Routes Scope Judge LLM calls through OpenRouter using `OPENROUTER_API_KEY`.
- Pins the default judge model to `openai/gpt-oss-20b:free` and keeps the existing `scope-judge` status context.
- Updates the workflow unit test and automation audit docs so the OpenRouter contract stays explicit.

## Validation
- `actionlint .github/workflows/scope-judge.yml`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run test -- tests/unit/ci/scope-judge-workflow.test.ts`
- `git diff --check`
- Commit hook: `next:proxy-guard`, Biome, ESLint, `node scripts/turbo-local.mjs typecheck --filter=@jovie/web`
- Pre-push hook: `biome check .`, web `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`

## Secret/runtime proof
- GitHub Actions secret `OPENROUTER_API_KEY` exists for `JovieInc/Jovie`.
- Doppler `jovie-web/dev` has a non-empty `OPENROUTER_API_KEY`.
- Live OpenRouter smoke call against `openai/gpt-oss-20b:free` returned a parseable `VERDICT: PASS` response.