### PR TITLE
fix: stabilize onboarding turnstile unit test

### DIFF
--- a/apps/web/tests/unit/api/chat/onboarding-handler.test.ts
+++ b/apps/web/tests/unit/api/chat/onboarding-handler.test.ts
@@ -70,13 +70,6 @@ vi.mock('@sentry/nextjs', () => ({
   addBreadcrumb: hoisted.addBreadcrumbMock,
 }));
 
-// Default to development so the Turnstile fail-closed path doesn't fire in
-// the happy-path tests. The "non-dev" test overrides this with vi.doMock.
-vi.mock('@/lib/env-server', () => ({
-  env: { NODE_ENV: 'development' },
-  isSecureEnv: () => false,
-}));
-
 function makeRequest(body: unknown, cookieHeader = ''): Request {
   return new Request('http://localhost/api/chat', {
     method: 'POST',
@@ -120,15 +113,27 @@ function installDefaultDbMocks() {
   }));
 }
 
+function stubRuntimeEnv({
+  nodeEnv = 'development',
+  vercelEnv,
+}: {
+  readonly nodeEnv?: string;
+  readonly vercelEnv?: string;
+} = {}) {
+  vi.stubEnv('NODE_ENV', nodeEnv);
+  if (vercelEnv) {
+    vi.stubEnv('VERCEL_ENV', vercelEnv);
+  } else {
+    vi.stubEnv('VERCEL_ENV', '');
+  }
+}
+
 describe('tryHandleAnonymousOnboardingChat', () => {
   beforeEach(() => {
     vi.unstubAllEnvs();
     vi.resetModules();
-    vi.doMock('@/lib/env-server', () => ({
-      env: { NODE_ENV: 'development' },
-      isSecureEnv: () => false,
-    }));
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+    stubRuntimeEnv();
     hoisted.checkGateForUserMock.mockResolvedValue(true);
     hoisted.checkAnonymousChatRateLimitMock.mockResolvedValue({
       success: true,
@@ -152,10 +157,7 @@ describe('tryHandleAnonymousOnboardingChat', () => {
 
   it('does not let the removed onboarding rollout gate disable the live route', async () => {
     vi.resetModules();
-    vi.doMock('@/lib/env-server', () => ({
-      env: { NODE_ENV: 'production' },
-      isSecureEnv: () => true,
-    }));
+    stubRuntimeEnv({ nodeEnv: 'production' });
     hoisted.checkGateForUserMock.mockResolvedValue(false);
     hoisted.isTurnstileConfiguredMock.mockReturnValue(true);
     hoisted.verifyTurnstileTokenMock.mockResolvedValue({
@@ -188,10 +190,7 @@ describe('tryHandleAnonymousOnboardingChat', () => {
 
   it('returns 503 when the global chat kill-switch is enabled', async () => {
     vi.resetModules();
-    vi.doMock('@/lib/env-server', () => ({
-      env: { NODE_ENV: 'production' },
-      isSecureEnv: () => true,
-    }));
+    stubRuntimeEnv({ nodeEnv: 'production' });
     hoisted.checkGateForUserMock.mockResolvedValue(true);
     const { tryHandleAnonymousOnboardingChat } = await import(
       '@/app/api/chat/onboarding-handler'
@@ -246,12 +245,8 @@ describe('tryHandleAnonymousOnboardingChat', () => {
   });
 
   it('returns 503 when Turnstile is not configured outside dev (first turn)', async () => {
-    // Re-mock env to non-dev for this case.
     vi.resetModules();
-    vi.doMock('@/lib/env-server', () => ({
-      env: { NODE_ENV: 'production' },
-      isSecureEnv: () => true,
-    }));
+    stubRuntimeEnv({ nodeEnv: 'production' });
     hoisted.checkGateForUserMock.mockResolvedValue(false);
     hoisted.isTurnstileConfiguredMock.mockReturnValue(false);
     const { tryHandleAnonymousOnboardingChat } = await import(
@@ -269,10 +264,7 @@ describe('tryHandleAnonymousOnboardingChat', () => {
 
   it('skips Turnstile verification in explicit E2E mock runtime', async () => {
     vi.resetModules();
-    vi.doMock('@/lib/env-server', () => ({
-      env: { NODE_ENV: 'test' },
-      isSecureEnv: () => false,
-    }));
+    stubRuntimeEnv({ nodeEnv: 'test' });
     vi.stubEnv('NEXT_PUBLIC_E2E_MODE', '1');
     vi.stubEnv('NEXT_PUBLIC_CLERK_MOCK', '1');
     hoisted.checkGateForUserMock.mockResolvedValue(true);
@@ -309,10 +301,7 @@ describe('tryHandleAnonymousOnboardingChat', () => {
 
   it('keeps Turnstile fail-closed in secure env even when mock flags are set', async () => {
     vi.resetModules();
-    vi.doMock('@/lib/env-server', () => ({
-      env: { NODE_ENV: 'production', VERCEL_ENV: 'preview' },
-      isSecureEnv: () => true,
-    }));
+    stubRuntimeEnv({ nodeEnv: 'production', vercelEnv: 'preview' });
     vi.stubEnv('NEXT_PUBLIC_E2E_MODE', '1');
     vi.stubEnv('NEXT_PUBLIC_CLERK_MOCK', '1');
     hoisted.checkGateForUserMock.mockResolvedValue(false);
@@ -337,11 +326,7 @@ describe('tryHandleAnonymousOnboardingChat', () => {
 
   it('dispatches executeChatTurn with mode=onboarding and the 7 onboarding tools', async () => {
     vi.resetModules();
-    // Restore the dev env mock so Turnstile gate is skipped.
-    vi.doMock('@/lib/env-server', () => ({
-      env: { NODE_ENV: 'development' },
-      isSecureEnv: () => false,
-    }));
+    stubRuntimeEnv();
     // Make executeChatTurn return a fake stream response.
     hoisted.executeChatTurnMock.mockResolvedValue({
       streamResult: {
@@ -405,10 +390,7 @@ describe('tryHandleAnonymousOnboardingChat', () => {
 
   it('fails closed before streaming when anonymous persistence is unavailable', async () => {
     vi.resetModules();
-    vi.doMock('@/lib/env-server', () => ({
-      env: { NODE_ENV: 'development' },
-      isSecureEnv: () => false,
-    }));
+    stubRuntimeEnv();
     installDefaultDbMocks();
     hoisted.dbSelectRowsMock.mockRejectedValueOnce(new Error('db unavailable'));
 
@@ -429,10 +411,7 @@ describe('tryHandleAnonymousOnboardingChat', () => {
 
   it('reuses an existing valid session cookie (no fresh cookie minted)', async () => {
     vi.resetModules();
-    vi.doMock('@/lib/env-server', () => ({
-      env: { NODE_ENV: 'development' },
-      isSecureEnv: () => false,
-    }));
+    stubRuntimeEnv();
     hoisted.executeChatTurnMock.mockResolvedValue({
       streamResult: {
         toUIMessageStreamResponse: ({


### PR DESCRIPTION
## Summary
- Fixes JOV-2760 by stabilizing `tests/unit/api/chat/onboarding-handler.test.ts` env isolation.
- Replaces per-test `vi.doMock('@/lib/env-server')` swaps with `vi.stubEnv()` against the real dynamic env proxy.
- Resets mock implementations between cases so E2E bypass stream mocks cannot leak into secure Turnstile fail-closed tests.

## Verification
- `pnpm --filter web exec vitest run tests/unit/api/chat/onboarding-handler.test.ts --config=vitest.config.mts --pool=forks --maxWorkers=2 --retry=0 --reporter=verbose`
- `pnpm --filter web exec vitest run tests/unit/api/chat/onboarding-handler.test.ts --config=vitest.config.mts --pool=forks --maxWorkers=2 --coverage --retry=0 --outputFile=test-report.jov-2760.junit.xml`
- `pnpm biome check --write apps/web/tests/unit/api/chat/onboarding-handler.test.ts`
- `pnpm exec eslint --config apps/web/eslint.config.js --max-warnings=0 --no-warn-ignored --cache --cache-location apps/web/.cache/eslint --cache-strategy content apps/web/tests/unit/api/chat/onboarding-handler.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: proxy guard, Biome, ESLint, web typecheck
- pre-push hook: repo Biome, web proxy guard, Tailwind guard, typecheck, lint

## Main CI Failure Addressed
- Run: https://github.com/JovieInc/Jovie/actions/runs/26929626840
- Failed job: `Unit Tests (6/6)` / `79446634474`
- Failed assertion: `tests/unit/api/chat/onboarding-handler.test.ts` expected secure Turnstile fail-closed status `503`, received `500`.

<!-- agent-run-artifact
{
  "id": "jov-2760-local-ship",
  "source": "ci",
  "sourceRunId": "fa3e6b98ed258a82911f3e4dc5660a8f80acb81a",
  "kind": "workflow",
  "status": "done",
  "title": "JOV-2760 Turnstile onboarding unit repair",
  "summary": "Recorded local QA, review, and ship gates for the one-file test isolation fix.",
  "modelRoute": "deterministic",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["deploy"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2760",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2760/fix-main-ci-turnstile-onboarding-unit-failure",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/10029",
  "adminSurface": "/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused onboarding-handler Vitest passed with 12/12 tests; coverage-mode focused run also passed.",
      "checkedAt": "2026-06-04T04:40:20.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed one-file test isolation diff; production onboarding handler behavior unchanged.",
      "checkedAt": "2026-06-04T04:40:20.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, ESLint, typecheck, pre-commit, and pre-push hooks passed.",
      "checkedAt": "2026-06-04T04:40:20.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-06-04T04:40:20.000Z",
  "updatedAt": "2026-06-04T04:40:20.000Z",
  "metadata": {}
}
-->
