### PR TITLE
ci: move coverage off main unit shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2225,11 +2225,6 @@ jobs:
           TURBO_SCM_HEAD: ${{ github.sha }}
           TURBO_SCM_BASE: ${{ github.event_name == 'merge_group' && 'origin/main' || (github.base_ref && format('origin/{0}', github.base_ref)) || '' }}
         run: |
-          # Only collect coverage on main branch pushes — PRs diff against main baseline
-          COVERAGE_FLAG=""
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            COVERAGE_FLAG="--coverage"
-          fi
           # Use forked pool with limited workers to reduce CI flakiness from memory pressure
           export NODE_OPTIONS="--max-old-space-size=2048"
           VITEST_CI_FLAGS="--pool=forks --maxWorkers=2"
@@ -2243,8 +2238,8 @@ jobs:
           OUTPUT_FLAG="--outputFile=test-report.${SHARD_SLUG}.junit.xml"
 
           if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "🧪 main: Running web unit suite with coverage"
-            pnpm --filter=@jovie/web run test:fast -- $VITEST_CI_FLAGS --coverage $RETRY_FLAG --shard=${{ matrix.shard }} ${{ steps.quarantine.outputs.unit_excludes }} $OUTPUT_FLAG
+            echo "main: Running web unit suite without coverage; nightly coverage audit uploads Codecov coverage"
+            pnpm --filter=@jovie/web run test:fast -- $VITEST_CI_FLAGS $RETRY_FLAG --shard=${{ matrix.shard }} ${{ steps.quarantine.outputs.unit_excludes }} $OUTPUT_FLAG
           elif [ -n "${{ github.base_ref }}" ] || [ "${{ github.event_name }}" = "merge_group" ]; then
             echo "🔍 PR/merge queue: Running full test suite"
             # Run all tests on PRs and merge queue to catch regressions before merge
@@ -2270,28 +2265,6 @@ jobs:
       - name: Run packages/ui unit tests
         if: steps.check_changes.outputs.run_full_ci == 'true'
         run: pnpm turbo test --filter=@jovie/ui
-
-      - name: Detect coverage reports
-        if: steps.check_changes.outputs.run_full_ci == 'true' && github.ref == 'refs/heads/main'
-        id: coverage_reports
-        shell: bash
-        run: |
-          if find apps/web/coverage -type f \( -name '*.json' -o -name '*.xml' -o -name '*.info' -o -name '*.lcov' \) -print -quit 2>/dev/null | grep -q .; then
-            echo "has_coverage=true" >> "$GITHUB_OUTPUT"
-            echo "Coverage reports found for this shard."
-          else
-            echo "has_coverage=false" >> "$GITHUB_OUTPUT"
-            echo "No coverage reports produced for this shard; skipping Codecov coverage upload."
-          fi
-
-      - name: Upload coverage to Codecov
-        if: steps.check_changes.outputs.run_full_ci == 'true' && github.ref == 'refs/heads/main' && steps.coverage_reports.outputs.has_coverage == 'true'
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v5
-        with:
-          directory: apps/web/coverage
-          flags: unittests
-          fail_ci_if_error: false
-          verbose: true
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && steps.check_changes.outputs.run_full_ci == 'true' }}

--- a/.github/workflows/test-coverage-audit.yml
+++ b/.github/workflows/test-coverage-audit.yml
@@ -3,7 +3,8 @@
 # PURPOSE: Nightly regeneration of docs/TEST_COVERAGE_HEATMAP.md from the
 # hand-curated docs/TEST_RISK_REGISTER.md plus v8 coverage data.
 #
-# Output: commits an updated heatmap to main only when values change.
+# Output: commits an updated heatmap to main only when values change and uploads
+# daily unit coverage to Codecov.
 # Also commits apps/web/reports/test-coverage-snapshot.json (machine-readable
 # baseline) so any PR can run `pnpm run test:coverage:diff` and compare to
 # the canonical baseline from main.
@@ -59,6 +60,15 @@ jobs:
 
       - name: Generate heatmap
         run: pnpm exec tsx scripts/audit-test-coverage.ts
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: apps/web/coverage/lcov.info
+          flags: nightly-unittests
+          fail_ci_if_error: false
+          verbose: true
 
       - name: Commit if changed
         if: ${{ github.event_name == 'schedule' || inputs.commit }}


### PR DESCRIPTION
## Summary
- Fixes JOV-1837 by taking v8 coverage off deploy-critical main unit shards.
- Keeps PR and merge-queue unit gating unchanged; main still runs the full sharded unit suite and uploads test-result XML.
- Moves Codecov coverage upload to the existing daily Test Coverage Audit workflow.

## Verification
- `pnpm exec actionlint -shellcheck= .github/workflows/ci.yml .github/workflows/test-coverage-audit.yml`
- `git diff --check`
- pre-commit hook: proxy guard; lint-staged found no matching staged workflow tasks
- pre-push hook: repo Biome, web proxy guard, Tailwind guard, typecheck, lint

## Decision
Ship now: remove coverage instrumentation from the per-merge main unit shards so deploy-critical CI is not tied to v8 coverage cost, while daily coverage still uploads to Codecov.

Re-evaluate when: nightly Codecov coverage misses 2 consecutive scheduled uploads or three main pushes with coverage removed show `ci-unit-tests` p95 shard runtime under 15 minutes.

Then: reduce `ci-unit-tests` timeout back to 20 minutes or below and revisit shard count under JOV-2762.

## Current Main Evidence
- JOV-2760 merged at `ba00baa015d3acb9162ce46b9893c6dc82e85b64` and removed the Turnstile onboarding unit failure.
- Main CI run https://github.com/JovieInc/Jovie/actions/runs/26931409413 canceled only `Unit Tests (5/6)` and `Unit Tests (6/6)` near the 30-minute mark after production deploy, smoke, Lighthouse, and Sentry gates had already passed.

<!-- agent-run-artifact
{
  "id": "jov-1837-local-ship",
  "source": "ci",
  "sourceRunId": "8217bee885089cc0e6d5994edec1d98e01de5c63",
  "kind": "workflow",
  "status": "done",
  "title": "JOV-1837 main CI coverage runtime repair",
  "summary": "Recorded local QA, review, and ship gates for the workflow-only coverage runtime fix.",
  "modelRoute": "deterministic",
  "allowedActions": ["read", "write_code", "open_pr"],
  "forbiddenActions": ["deploy"],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-1837",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-1837/ci-structurally-fix-main-branch-unit-test-runtime-move-coverage-off",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/10031",
  "adminSurface": "/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Workflow syntax passed with actionlint shellcheck disabled; git diff whitespace check passed.",
      "checkedAt": "2026-06-04T05:31:00.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed workflow-only diff; PR/merge-queue unit gating remains unchanged and daily coverage upload remains available.",
      "checkedAt": "2026-06-04T05:31:00.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Pre-commit and pre-push hooks passed, including repo Biome, proxy guard, Tailwind guard, web typecheck, and lint.",
      "checkedAt": "2026-06-04T05:31:00.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-06-04T05:31:00.000Z",
  "updatedAt": "2026-06-04T05:31:00.000Z",
  "metadata": {
    "mainRunUrl": "https://github.com/JovieInc/Jovie/actions/runs/26931409413"
  }
}
-->
