### PR TITLE
fix(web): remove popularity cell transition drift

### DIFF
--- a/apps/web/components/features/dashboard/organisms/releases/cells/PopularityCell.tsx
+++ b/apps/web/components/features/dashboard/organisms/releases/cells/PopularityCell.tsx
@@ -36,7 +36,7 @@ export const PopularityCell = memo(function PopularityCell({
           >
             <div className='h-2 w-12 overflow-hidden rounded-full bg-(--linear-border-subtle)'>
               <div
-                className='h-full rounded-full bg-brand-spotify transition-all'
+                className='h-full rounded-full bg-brand-spotify transition-[background-color,width] duration-subtle ease-subtle'
                 style={{ width: `${clampedPopularity}%` }}
               />
             </div>

--- a/apps/web/tests/unit/dashboard/popularity-cell-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/popularity-cell-system-b-style-guard.test.ts
@@ -1,0 +1,24 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const sourcePath = join(
+  appRoot,
+  'components/features/dashboard/organisms/releases/cells/PopularityCell.tsx'
+);
+
+const forbiddenMotionClasses =
+  /\b(?:transition-all|transition-transform|duration-\d+|active:scale|active:translate|hover:-translate|group-hover:scale)\b|\btransition-\[[^\]]*transform[^\]]*\]/;
+
+describe('PopularityCell System B style guard', () => {
+  it('keeps popularity bar changes bounded to color and width', async () => {
+    const source = await readFile(sourcePath, 'utf8');
+
+    expect(source).not.toMatch(forbiddenMotionClasses);
+    expect(source).toContain('transition-[background-color,width]');
+    expect(source).toContain('duration-subtle');
+    expect(source).toContain('ease-subtle');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the release popularity bar's broad transition-all with an explicit background-color/width transition using System B motion tokens.
- Add a focused source guard so the popularity cell does not regress to broad transform/transition motion.

## Verification
- pnpm biome check --write apps/web/components/features/dashboard/organisms/releases/cells/PopularityCell.tsx apps/web/tests/unit/dashboard/popularity-cell-system-b-style-guard.test.ts
- pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/popularity-cell-system-b-style-guard.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-commit hook: next:proxy-guard, Biome, ESLint, staged a11y check, Turbo web typecheck
- pre-push hook: biome check ., web pre-push, Tailwind guard, web typecheck, web lint

## Layout Shift Audit
No geometry changes. The outer bar remains h-2 w-12, the fill remains h-full rounded-full, and the width still comes from the existing inline percentage style. The change only narrows which CSS properties can animate.

Linear: JOV-2765

<!-- agent-run-artifact
{
  "id": "codex-jov-2765-58febaa50895",
  "source": "github",
  "sourceRunId": "58febaa508957f40a5119b4cc085d441ff3fd0d2",
  "kind": "workflow",
  "status": "done",
  "title": "JOV-2765 popularity cell System B ship",
  "summary": "Removed broad transition-all drift from the release popularity bar and added a focused System B style guard. Layout geometry is unchanged: outer bar remains h-2 w-12, fill remains h-full rounded-full, and width stays the inline percentage value.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "write_code",
    "open_pr"
  ],
  "forbiddenActions": [
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2765",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2765/remove-release-popularity-bar-transition-all-drift",
  "pullRequestUrl": null,
  "adminSurface": null,
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Ran Biome on touched files, focused Vitest guard, web typecheck, git diff --check, and layout-shift audit by source inspection. No geometry or conditional state changed.",
      "checkedAt": "2026-06-04T06:43:18.425Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed diff scope: one class string change plus one source guard. No data, routing, auth, payment, migration, or production state changes.",
      "checkedAt": "2026-06-04T06:43:18.425Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Ran fresh-worktree setup, committed conventional commit fix(web): remove popularity cell transition drift, and prepared PR from codex/jov-2765-popularity-cell-motion-system-b.",
      "checkedAt": "2026-06-04T06:43:18.425Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local Codex desktop workflow; no metered external agent route recorded."
  },
  "blockedReason": null,
  "createdAt": "2026-06-04T06:43:18.425Z",
  "updatedAt": "2026-06-04T06:43:18.425Z",
  "metadata": {
    "branch": "codex/jov-2765-popularity-cell-motion-system-b",
    "checks": [
      "pnpm biome check --write apps/web/components/features/dashboard/organisms/releases/cells/PopularityCell.tsx apps/web/tests/unit/dashboard/popularity-cell-system-b-style-guard.test.ts",
      "pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/popularity-cell-system-b-style-guard.test.ts",
      "pnpm --filter @jovie/web run typecheck -- --pretty false",
      "git diff --check"
    ]
  }
}
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized animation performance for the dashboard popularity indicator with refined transition effects.

* **Tests**
  * Added test coverage to verify component styling consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->