### PR TITLE
fix(web): remove carousel artwork hover zoom

### DIFF
--- a/apps/web/components/features/home/SeeItInActionCarousel.tsx
+++ b/apps/web/components/features/home/SeeItInActionCarousel.tsx
@@ -219,7 +219,7 @@ function ReleaseCard({
                 alt={`${release.title} artwork`}
                 fill
                 sizes='(min-width: 768px) 240px, 100vw'
-                className='object-cover transition-transform duration-[var(--linear-duration-normal)] group-hover:scale-[1.02]'
+                className='object-cover'
               />
             </div>
             <div className='mt-4'>

--- a/apps/web/tests/unit/components/home/SeeItInActionCarousel.test.tsx
+++ b/apps/web/tests/unit/components/home/SeeItInActionCarousel.test.tsx
@@ -64,6 +64,13 @@ describe('SeeItInActionCarousel', () => {
     expect(
       screen.getByRole('img', { name: /Take Me Over artwork/i })
     ).toBeInTheDocument();
+
+    for (const artwork of screen.getAllByRole('img', { name: /artwork/i })) {
+      expect(artwork).toHaveClass('object-cover');
+      expect(artwork.className).not.toMatch(
+        /group-hover:scale|transition-transform/
+      );
+    }
   });
 
   it('opens the popover and links DSP buttons to the smart link page', async () => {


### PR DESCRIPTION
## Summary
- Removes decorative hover zoom/transform motion from SeeItInActionCarousel release artwork.
- Adds a focused unit guard that release artwork remains `object-cover` without hover scale or transform transition classes.

## Linear
- JOV-2768: https://linear.app/jovie/issue/JOV-2768/remove-decorative-hover-zoom-from-seeitinactioncarousel-artwork

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/home/SeeItInActionCarousel.tsx apps/web/tests/unit/components/home/SeeItInActionCarousel.test.tsx` passed: Checked 2 files. No fixes applied.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/components/home/SeeItInActionCarousel.test.tsx` passed: 1 test file, 3 tests.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- Pre-commit hook passed: next proxy guard, Biome, ESLint, staged a11y, local typecheck.
- Pre-push hook passed: `biome check .`, web proxy guard, Tailwind guard, web typecheck, web lint.

## Risk
- Low. This only removes decorative artwork transform classes and preserves markup, artwork image rendering, links, popover behavior, and DSP button semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed hover animation effects from release artwork images in the carousel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->