### PR TITLE
fix(web): remove claim handle chevron hover motion

### DIFF
--- a/apps/web/components/features/home/claim-handle/ClaimHandleForm.tsx
+++ b/apps/web/components/features/home/claim-handle/ClaimHandleForm.tsx
@@ -268,10 +268,7 @@ export function ClaimHandleForm({
       return (
         <>
           <span>Claim @{handle}</span>
-          <ChevronRight
-            className='h-3.5 w-3.5 transition-transform duration-slow group-hover:translate-x-0.5'
-            aria-hidden='true'
-          />
+          <ChevronRight className='h-3.5 w-3.5' aria-hidden='true' />
         </>
       );
     }

--- a/apps/web/tests/unit/ClaimHandleForm.test.tsx
+++ b/apps/web/tests/unit/ClaimHandleForm.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 // Use hoisted mocks for shared state
@@ -122,6 +122,28 @@ describe('ClaimHandleForm', () => {
     // Only check for component-specific animation keyframes (not third-party CSS like Sonner)
     expect(styleContents).not.toContain('jv-shake');
     expect(styleContents).not.toContain('jv-available');
+  });
+
+  test('does not animate the available-state chevron with positional hover motion', async () => {
+    render(<ClaimHandleForm />);
+
+    fireEvent.change(
+      screen.getByRole('textbox', { name: /choose your handle/i }),
+      {
+        target: { value: 'motionguard' },
+      }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Claim @motionguard')).toBeInTheDocument();
+    });
+
+    const button = screen.getByRole('button', { name: /claim @motionguard/i });
+    const chevron = button.querySelector('svg');
+
+    expect(chevron).toBeInTheDocument();
+    expect(chevron).not.toHaveClass('transition-transform');
+    expect(chevron).not.toHaveClass('group-hover:translate-x-0.5');
   });
 
   test('tracks landing claim submits when tracking is configured', () => {


### PR DESCRIPTION
## Summary
- Remove the decorative hover translate/transform from the available-state ClaimHandleForm chevron.
- Add a focused unit guard so the available-state chevron stays non-positional.

## Linear
- JOV-2767: https://linear.app/jovie/issue/JOV-2767/remove-claimhandleform-decorative-chevron-motion

## Layout Shift Audit
States reviewed: empty input, invalid input, availability checking, available, unavailable, navigating, anonymous redirect path, and signed-in start route path. The change only removes transform-related classes from an always-rendered available-state SVG with fixed dimensions, so no content is inserted, removed, or resized.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/home/claim-handle/ClaimHandleForm.tsx apps/web/tests/unit/ClaimHandleForm.test.tsx` — passed; fixed 1 file
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/ClaimHandleForm.test.tsx` — passed, 1 file / 10 tests
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- Commit hook: next proxy guard, lint-staged Biome, ESLint, staged a11y check, local web typecheck — passed
- Pre-push hook: `biome check .`, web proxy guard, Tailwind guard, web typecheck, web Biome lint — passed

## Notes
- Draft PR only; not merged.
- Did not touch PR #10038.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary animation behavior on the chevron icon within the claim handle button. The icon no longer animates when hovering over the available state, resulting in a more static and predictable user interface interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->