### PR TITLE
fix(web): tokenize entity popover spotify icon

### DIFF
--- a/apps/web/components/shell/EntityPopover.test.tsx
+++ b/apps/web/components/shell/EntityPopover.test.tsx
@@ -21,6 +21,13 @@ const release = {
   releaseType: 'Single',
 } satisfies EntityPopoverData;
 
+const spotifyUrlArtist = {
+  kind: 'artist',
+  id: 'artist_1',
+  label: 'https://open.spotify.com/artist/123',
+  handle: 'https://open.spotify.com/artist/123',
+} satisfies EntityPopoverData;
+
 afterEach(() => {
   vi.useRealTimers();
 });
@@ -80,6 +87,26 @@ describe('EntityHoverLink', () => {
 
     expect(screen.queryByRole('tooltip')).toBeNull();
   });
+
+  it('renders Spotify URL fallbacks with the named provider icon token', () => {
+    vi.useFakeTimers();
+    fastRender(
+      <EntityHoverLink entity={spotifyUrlArtist}>
+        Spotify artist
+      </EntityHoverLink>
+    );
+    const trigger = screen.getByRole('button', { name: 'Spotify artist' });
+
+    fireEvent.focus(trigger);
+    advanceTimers(200);
+
+    expect(screen.getByRole('tooltip').textContent).toContain('Spotify artist');
+    expect(
+      screen
+        .getByRole('tooltip')
+        .querySelector('.system-b-entity-popover-spotify-icon')
+    ).not.toBeNull();
+  });
 });
 
 describe('EntityPopover source contract', () => {
@@ -97,6 +124,8 @@ describe('EntityPopover source contract', () => {
       "import { LINEAR_SURFACE } from '@/components/tokens/linear-surface';"
     );
     expect(source).toContain('LINEAR_SURFACE.popover');
+    expect(source).toContain('system-b-entity-popover-spotify-icon');
+    expect(source).not.toContain('#1DB954');
     expect(source).not.toContain("'rounded-lg border border-default'");
     expect(source).not.toContain("'bg-surface-0 text-primary-token");
   });

--- a/apps/web/components/shell/EntityPopover.tsx
+++ b/apps/web/components/shell/EntityPopover.tsx
@@ -532,8 +532,7 @@ function EntityCard({ entity, onActivate }: EntityCardProps) {
           {artistDisp.useSpotifyIcon ? (
             <span className='inline-flex items-center gap-1.5'>
               <Music
-                className='h-3.5 w-3.5 shrink-0'
-                style={{ color: '#1DB954' }}
+                className='system-b-entity-popover-spotify-icon h-3.5 w-3.5 shrink-0'
                 aria-hidden='true'
               />
               {artistDisp.displayLabel}

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2561,6 +2561,10 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   text-transform: uppercase;
 }
 
+.system-b-entity-popover-spotify-icon {
+  color: var(--color-brand-spotify);
+}
+
 .system-b-dsp-status-dot-live {
   background: color-mix(in oklab, var(--color-success) 72%, transparent);
 }

--- a/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
@@ -11,6 +11,7 @@ const guardedFiles = [
   'components/jovie/components/EntityChipPopover.tsx',
   'components/jovie/components/EntityPreviewPane.tsx',
   'components/shell/DspAvatarStack.tsx',
+  'components/shell/EntityPopover.tsx',
 ];
 
 const rawVisualPatterns = [


### PR DESCRIPTION
## Summary
- Move the shell EntityPopover Spotify fallback icon off hardcoded #1DB954 and onto a named System B class backed by `--color-brand-spotify`.
- Add `EntityPopover.tsx` to the rich-chip System B source guard.
- Add regression coverage for Spotify URL fallback rendering so the provider icon token cannot drift back to an inline color.

## Verification
- `pnpm biome check --write apps/web/components/shell/EntityPopover.tsx apps/web/components/shell/EntityPopover.test.tsx apps/web/styles/design-system.css apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/chat/entity-rich-chip-style-guard.test.ts components/shell/EntityPopover.test.tsx components/jovie/components/EntityChip.test.tsx components/jovie/components/EntityChipPopover.test.tsx components/jovie/components/EntityPreviewPane.test.tsx components/shell/DspAvatarStack.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Focused source scan over EntityChip, EntityChipPopover, EntityPreviewPane, DspAvatarStack, and EntityPopover returned zero raw visual-token findings.
- Pre-commit hook passed: next proxy guard, Biome, ESLint, staged a11y, Turbo web typecheck.
- Pre-push hook passed: full Biome, web proxy guard, Tailwind guard, web typecheck, web lint.

## Visual Proof
- Captured local shell screenshots from `/exp/shell-v1` after opening Releases and the release detail drawer:
  - `.gstack/design-reports/screenshots/jov-2732-releases-before-detail-20260604.png`
  - `.gstack/design-reports/screenshots/jov-2732-entity-link-click-after-20260604.png`

Linear: JOV-2732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for Spotify URL fallback rendering in entity popovers.
  * Enhanced style guard testing for entity popover components.

* **Refactor**
  * Improved Spotify icon styling by transitioning from inline styles to design system tokens for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->