### PR TITLE
fix(auth): fall back for iOS production ticket exchange

### DIFF
--- a/apps/web/app/api/auth/native/exchange/route.ts
+++ b/apps/web/app/api/auth/native/exchange/route.ts
@@ -84,6 +84,47 @@ function isNotFoundError(error: unknown): boolean {
   return record.status === 404 || record.statusCode === 404;
 }
 
+function hasClerkErrorCode(error: unknown, code: string): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const record = error as { errors?: unknown };
+  if (!Array.isArray(record.errors)) {
+    return false;
+  }
+
+  return record.errors.some(
+    entry =>
+      Boolean(entry) &&
+      typeof entry === 'object' &&
+      (entry as { code?: unknown }).code === code
+  );
+}
+
+function isIosSessionTokenUnavailableError(error: unknown): boolean {
+  return (
+    isNotFoundError(error) ||
+    hasClerkErrorCode(error, 'request_invalid_for_environment')
+  );
+}
+
+async function createNativeSignInTicketPayload(
+  clerk: Awaited<ReturnType<typeof clerkClient>>,
+  userId: string
+): Promise<NativeExchangePayload> {
+  const signInToken = await clerk.signInTokens.createSignInToken({
+    userId,
+    expiresInSeconds: SIGN_IN_TOKEN_TTL_SECONDS,
+  });
+
+  return {
+    ticket: signInToken.token,
+    userId,
+    expiresInSeconds: SIGN_IN_TOKEN_TTL_SECONDS,
+  };
+}
+
 export async function POST(request: Request) {
   try {
     const payload = (await request
@@ -214,16 +255,7 @@ async function createDesktopNativeExchangePayload(
   clerk: Awaited<ReturnType<typeof clerkClient>>,
   userId: string
 ): Promise<NativeExchangePayload> {
-  const signInToken = await clerk.signInTokens.createSignInToken({
-    userId,
-    expiresInSeconds: SIGN_IN_TOKEN_TTL_SECONDS,
-  });
-
-  return {
-    ticket: signInToken.token,
-    userId,
-    expiresInSeconds: SIGN_IN_TOKEN_TTL_SECONDS,
-  };
+  return createNativeSignInTicketPayload(clerk, userId);
 }
 
 async function createIosNativeExchangePayload(
@@ -245,29 +277,16 @@ async function createIosNativeExchangePayload(
       expiresInSeconds: SESSION_TOKEN_TTL_SECONDS,
     };
   } catch (error) {
-    if (!isNotFoundError(error)) {
+    if (!isIosSessionTokenUnavailableError(error)) {
       throw error;
     }
 
     /*
-     * If a preview environment has not been granted Sessions API access yet,
-     * keep the iOS test harness usable by falling back to Clerk's ticket flow.
-     * Production iOS prefers the session-token path so the app can persist the
-     * native session before calling /api/mobile/v1/me.
+     * Clerk only allows server-created sessions in development instances.
+     * Staging/production still complete native auth through the same one-time,
+     * PKCE-bound ticket flow that Electron uses; the iOS client then mints and
+     * persists its Clerk session token before calling /api/mobile/v1/me.
      */
-    if (!isProductionRuntimeEnvironment()) {
-      const signInToken = await clerk.signInTokens.createSignInToken({
-        userId,
-        expiresInSeconds: SIGN_IN_TOKEN_TTL_SECONDS,
-      });
-
-      return {
-        ticket: signInToken.token,
-        userId,
-        expiresInSeconds: SIGN_IN_TOKEN_TTL_SECONDS,
-      };
-    }
-
-    throw error;
+    return createNativeSignInTicketPayload(clerk, userId);
   }
 }

--- a/apps/web/tests/unit/api/auth/native-exchange.test.ts
+++ b/apps/web/tests/unit/api/auth/native-exchange.test.ts
@@ -217,6 +217,41 @@ describe('POST /api/auth/native/exchange', () => {
     expect(mockSessionsGetToken).not.toHaveBeenCalled();
   });
 
+  it('falls back to a sign-in ticket for iOS production exchange when Clerk rejects server-created sessions', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('VERCEL_ENV', 'production');
+    const unavailableError = new Error('Bad Request');
+    Object.assign(unavailableError, {
+      status: 400,
+      errors: [
+        {
+          code: 'request_invalid_for_environment',
+          message: 'Invalid request for environment',
+          longMessage: 'Request only valid for development instances.',
+        },
+      ],
+    });
+    mockSessionsCreateSession.mockRejectedValue(unavailableError);
+
+    const { POST } = await import('@/app/api/auth/native/exchange/route');
+    const response = await POST(createExchangeRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toMatchObject({
+      returnTo: '/app',
+      ticket: 'sign_in_ticket',
+      userId: 'user_native',
+      expiresInSeconds: 60,
+    });
+    expect(mockSignInTokensCreateSignInToken).toHaveBeenCalledWith({
+      userId: 'user_native',
+      expiresInSeconds: 60,
+    });
+    expect(mockSessionsGetToken).not.toHaveBeenCalled();
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+
   it('accepts the Mac OS native exchange client and passes through its PKCE verifier', async () => {
     const { POST } = await import('@/app/api/auth/native/exchange/route');
     const response = await POST(createElectronExchangeRequest());


### PR DESCRIPTION
## Summary
- Fall back to the existing PKCE-bound sign-in ticket path when Clerk rejects server-created sessions for iOS production runtimes.
- Cover the staging/prod Clerk `request_invalid_for_environment` response with a focused native exchange unit test.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/api/auth/native-exchange.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write apps/web/app/api/auth/native/exchange/route.ts apps/web/tests/unit/api/auth/native-exchange.test.ts`
- pre-push: Biome, proxy guard, Tailwind guard, web typecheck, web lint

<!-- agent-run-artifact
{
  "id": "jov-2761-ios-ticket-fallback-e5c1e4d2",
  "source": "github",
  "sourceRunId": "e5c1e4d289064d9ea3bb1e88f027ce0aba698826",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2761 iOS ticket fallback gates",
  "summary": "Recorded GStack QA, review, and ship evidence for the iOS native exchange fallback follow-up. Live staging and production QA continue under JOV-2761 after this fix deploys.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr",
    "change_auth"
  ],
  "forbiddenActions": [
    "change_billing",
    "mutate_production_data"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2761",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2761/p0-verify-signed-in-auth-across-web-electron-ios-and-chrome-extension",
  "pullRequestUrl": null,
  "adminSurface": "/app/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Root cause reproduced against live staging: Clerk Sessions API returns request_invalid_for_environment. Focused native exchange tests pass, web typecheck passes, and pre-push Biome/proxy/Tailwind/typecheck/lint passed.",
      "checkedAt": "2026-06-04T08:13:47.045Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Review gate passed locally: diff is limited to iOS native exchange fallback handling and one focused production-mode regression test.",
      "checkedAt": "2026-06-04T08:13:47.045Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Ship gate ready for branch e5c1e4d289064d9ea3bb1e88f027ce0aba698826: committed and pushed after local tests and pre-push guards passed.",
      "checkedAt": "2026-06-04T08:13:47.045Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local checks plus GitHub CI; no new paid services provisioned."
  },
  "blockedReason": null,
  "createdAt": "2026-06-04T08:13:47.045Z",
  "updatedAt": "2026-06-04T08:13:47.045Z",
  "metadata": {
    "headSha": "e5c1e4d289064d9ea3bb1e88f027ce0aba698826",
    "parentPr": 10033,
    "failingQa": "staging-ios-native-exchange-500"
  }
}
-->