### PR TITLE
fix(web): tokenize release provider sync banners

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/AppleMusicSyncBanner.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/AppleMusicSyncBanner.tsx
@@ -130,7 +130,7 @@ export function AppleMusicSyncBanner({
       return (
         <div
           className={cn(
-            'inline-flex h-7.5 items-center gap-2 rounded-md border border-[#FA243C]/18 bg-[#FA243C]/6 px-2.5 text-xs text-secondary-token',
+            'system-b-release-provider-banner--apple system-b-release-provider-banner-compact inline-flex h-7.5 items-center gap-2 rounded-md border px-2.5 text-xs text-secondary-token',
             className
           )}
         >
@@ -145,7 +145,7 @@ export function AppleMusicSyncBanner({
     return (
       <div
         className={cn(
-          'inline-flex h-7.5 items-center gap-2 rounded-md border border-[#FA243C]/18 bg-[#FA243C]/6 px-2 text-xs text-primary-token',
+          'system-b-release-provider-banner--apple system-b-release-provider-banner-compact inline-flex h-7.5 items-center gap-2 rounded-md border px-2 text-xs text-primary-token',
           className
         )}
       >
@@ -169,7 +169,7 @@ export function AppleMusicSyncBanner({
             confirmMutation.mutate({ matchId: match.id, profileId })
           }
           disabled={confirmMutation.isPending || rejectMutation.isPending}
-          className='h-7 rounded-md border-[#FA243C] bg-[#FA243C] px-2 text-2xs hover:border-[#FA243C] hover:bg-[#FA243C]/90'
+          className='system-b-release-provider-action h-7 rounded-md px-2 text-2xs'
         >
           Confirm
         </DrawerButton>
@@ -187,7 +187,7 @@ export function AppleMusicSyncBanner({
           className
         )}
       >
-        <div className='flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#FA243C]/8'>
+        <div className='system-b-release-provider-banner--apple system-b-release-provider-icon flex h-7 w-7 shrink-0 items-center justify-center rounded-full'>
           <DspProviderIcon provider='apple_music' size='md' />
         </div>
         <div className='min-w-0 flex-1'>
@@ -210,11 +210,11 @@ export function AppleMusicSyncBanner({
     <DrawerSurfaceCard
       variant='card'
       className={cn(
-        'flex items-center gap-3 rounded-[10px] border border-[#FA243C]/16 bg-[color-mix(in_oklab,#FA243C_4%,var(--linear-app-content-surface))] px-4 py-3',
+        'system-b-release-provider-banner system-b-release-provider-banner--apple flex items-center gap-3 border px-4 py-3',
         className
       )}
     >
-      <div className='flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#FA243C]/8'>
+      <div className='system-b-release-provider-icon flex h-7 w-7 shrink-0 items-center justify-center rounded-full'>
         <DspProviderIcon provider='apple_music' size='md' />
       </div>
 
@@ -265,7 +265,7 @@ export function AppleMusicSyncBanner({
             confirmMutation.mutate({ matchId: match.id, profileId })
           }
           disabled={confirmMutation.isPending || rejectMutation.isPending}
-          className='h-7 rounded-lg border-[#FA243C] bg-[#FA243C] px-2.5 text-xs hover:border-[#FA243C] hover:bg-[#FA243C]/90'
+          className='system-b-release-provider-action h-7 rounded-lg px-2.5 text-xs'
         >
           {confirmMutation.isPending &&
           confirmMutation.variables?.matchId === match.id ? (

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ImportProgressBanner.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ImportProgressBanner.tsx
@@ -39,7 +39,7 @@ export const ImportProgressBanner = memo(function ImportProgressBanner({
   if (compact) {
     return (
       <div
-        className='inline-flex h-7.5 items-center gap-2 rounded-md border border-[#1DB954]/16 bg-[#1DB954]/6 px-2.5 text-xs text-primary-token'
+        className='system-b-release-provider-banner--spotify system-b-release-provider-banner-compact inline-flex h-7.5 items-center gap-2 rounded-md border px-2.5 text-xs text-primary-token'
         aria-live='polite'
       >
         <ProviderIcon provider='spotify' className='h-3.5 w-3.5 shrink-0' />
@@ -66,7 +66,7 @@ export const ImportProgressBanner = memo(function ImportProgressBanner({
     >
       <DrawerSurfaceCard
         variant='card'
-        className='flex items-center gap-3 rounded-[10px] border border-[#1DB954]/14 bg-[color-mix(in_oklab,#1DB954_4.5%,var(--linear-app-content-surface))] px-4 py-3 transition-opacity duration-subtle'
+        className='system-b-release-provider-banner system-b-release-provider-banner--spotify flex items-center gap-3 border px-4 py-3 transition-opacity duration-subtle'
       >
         <ProviderIcon provider='spotify' className='h-4.5 w-4.5' />
         <div className='flex min-w-0 flex-1 flex-col gap-1'>
@@ -83,7 +83,7 @@ export const ImportProgressBanner = memo(function ImportProgressBanner({
             </span>
           </div>
           <div
-            className='h-1 w-full overflow-hidden rounded-full bg-[#1DB954]/12'
+            className='system-b-release-provider-progress-track h-1 w-full overflow-hidden rounded-full'
             role='progressbar'
             aria-valuenow={
               totalCount > 0
@@ -95,7 +95,7 @@ export const ImportProgressBanner = memo(function ImportProgressBanner({
             aria-label={progressLabel}
           >
             <motion.div
-              className='h-full rounded-full bg-[#1DB954]'
+              className='system-b-release-provider-progress-fill h-full rounded-full'
               initial={{ width: 0 }}
               animate={{
                 width:
@@ -112,17 +112,17 @@ export const ImportProgressBanner = memo(function ImportProgressBanner({
         <DrawerSurfaceCard
           variant='card'
           data-testid='release-enrichment-progress-banner'
-          className='mt-2 flex items-center gap-3 rounded-[10px] border border-accent/14 bg-[color-mix(in_oklab,var(--linear-accent)_4.5%,var(--linear-app-content-surface))] px-4 py-3 transition-opacity duration-subtle'
+          className='system-b-release-provider-banner system-b-release-provider-banner--accent mt-2 flex items-center gap-3 border px-4 py-3 transition-opacity duration-subtle'
         >
           <div className='flex h-5 w-5 items-center justify-center'>
-            <div className='h-4 w-4 animate-spin rounded-full border-2 border-accent/30 border-t-accent' />
+            <div className='system-b-release-provider-spinner h-4 w-4 animate-spin rounded-full border-2' />
           </div>
           <div className='flex min-w-0 flex-1 flex-col gap-1'>
             <span className='text-app text-primary-token'>
               Finding your music across streaming platforms...
             </span>
-            <div className='h-1 overflow-hidden rounded-full bg-accent/12'>
-              <div className='h-full w-1/3 animate-[progress-indeterminate_1.5s_ease-in-out_infinite] rounded-full bg-accent' />
+            <div className='system-b-release-provider-progress-track h-1 overflow-hidden rounded-full'>
+              <div className='system-b-release-provider-progress-fill h-full w-1/3 animate-[progress-indeterminate_1.5s_ease-in-out_infinite] rounded-full' />
             </div>
           </div>
         </DrawerSurfaceCard>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2565,6 +2565,99 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   color: var(--color-brand-spotify);
 }
 
+.system-b-release-provider-banner--spotify {
+  --system-b-release-provider-accent: var(--color-brand-spotify);
+  --system-b-release-provider-accent-hover: var(--color-brand-spotify-hover);
+}
+
+.system-b-release-provider-banner--apple {
+  --system-b-release-provider-accent: var(--color-brand-apple);
+  --system-b-release-provider-accent-hover: var(--color-brand-apple-hover);
+}
+
+.system-b-release-provider-banner--accent {
+  --system-b-release-provider-accent: var(--color-accent);
+  --system-b-release-provider-accent-hover: var(--color-accent-hover);
+}
+
+.system-b-release-provider-banner {
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-release-provider-accent, var(--color-accent)) 15%,
+    transparent
+  );
+  border-radius: var(--linear-app-radius-item);
+  background: color-mix(
+    in oklab,
+    var(--system-b-release-provider-accent, var(--color-accent)) 4.5%,
+    var(--linear-app-content-surface)
+  );
+}
+
+.system-b-release-provider-banner-compact {
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-release-provider-accent, var(--color-accent)) 17%,
+    transparent
+  );
+  background: color-mix(
+    in oklab,
+    var(--system-b-release-provider-accent, var(--color-accent)) 6%,
+    transparent
+  );
+}
+
+.system-b-release-provider-icon {
+  background: color-mix(
+    in oklab,
+    var(--system-b-release-provider-accent, var(--color-accent)) 8%,
+    transparent
+  );
+}
+
+.system-b-release-provider-action {
+  border-color: var(--system-b-release-provider-accent, var(--color-accent));
+  background: var(--system-b-release-provider-accent, var(--color-accent));
+  color: var(--color-accent-foreground);
+}
+
+.system-b-release-provider-action:hover,
+.system-b-release-provider-action:active {
+  border-color: var(
+    --system-b-release-provider-accent-hover,
+    var(--color-accent-hover)
+  );
+  background: var(
+    --system-b-release-provider-accent-hover,
+    var(--color-accent-hover)
+  );
+  color: var(--color-accent-foreground);
+}
+
+.system-b-release-provider-progress-track {
+  background: color-mix(
+    in oklab,
+    var(--system-b-release-provider-accent, var(--color-accent)) 12%,
+    transparent
+  );
+}
+
+.system-b-release-provider-progress-fill {
+  background: var(--system-b-release-provider-accent, var(--color-accent));
+}
+
+.system-b-release-provider-spinner {
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-release-provider-accent, var(--color-accent)) 30%,
+    transparent
+  );
+  border-top-color: var(
+    --system-b-release-provider-accent,
+    var(--color-accent)
+  );
+}
+
 .system-b-dsp-status-dot-live {
   background: color-mix(in oklab, var(--color-success) 72%, transparent);
 }

--- a/apps/web/tests/unit/dashboard/release-provider-sync-banners-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/release-provider-sync-banners-system-b-style-guard.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const guardedSources = [
+  'components/features/dashboard/organisms/release-provider-matrix/AppleMusicSyncBanner.tsx',
+  'components/features/dashboard/organisms/release-provider-matrix/ImportProgressBanner.tsx',
+] as const;
+
+const forbiddenVisualPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /\bcolor-mix\(/,
+  /\b(?:rounded|shadow)-\[/,
+] as const;
+
+describe('release provider sync banner System B source contract', () => {
+  it('keeps provider banner styling on named System B primitives', () => {
+    for (const sourcePath of guardedSources) {
+      const source = readFileSync(resolve(process.cwd(), sourcePath), 'utf8');
+
+      for (const pattern of forbiddenVisualPatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+
+      expect(source).toContain('system-b-release-provider-banner');
+      expect(source).toContain('system-b-release-provider-banner--');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Moves Apple Music sync and Spotify import banner styling off raw provider hex / inline color recipes and onto named System B provider primitives.
- Adds shared release-provider banner/action/progress/spinner classes in `design-system.css` backed by existing provider brand tokens.
- Adds a focused source guard for the two banner components.

Linear: JOV-2770

## Decision
Ship now: remove current raw `#FA243C`, `#1DB954`, component-local `color-mix(...)`, and bracketed radius/shadow utility drift from the release-provider sync banners while keeping the behavioral surface unchanged.

Re-evaluate when: the focused guard reports more than 0 findings or visual QA finds banner row overflow/layout shift on the releases surface.

Then: expand the same provider-token contract to adjacent release-provider matrix rows/mobile release states under a new Linear issue.

## Verification
- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh` passed.
- `JOVIE_AGENT_PROFILE=coder pnpm exec biome check --write apps/web/components/features/dashboard/organisms/release-provider-matrix/AppleMusicSyncBanner.tsx apps/web/components/features/dashboard/organisms/release-provider-matrix/ImportProgressBanner.tsx apps/web/styles/design-system.css apps/web/tests/unit/dashboard/release-provider-sync-banners-system-b-style-guard.test.ts` passed, no fixes applied.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/release-provider-sync-banners-system-b-style-guard.test.ts tests/unit/dashboard/ImportProgressBanner.test.tsx` passed: 2 files, 3 tests.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- `git diff --check` passed.
- Source scan returned no matches in the two banner components for `#FA243C|#1DB954|color-mix\(|rounded-\[|shadow-\[`.
- Pre-push passed: `biome check .`, `next:proxy-guard`, `tailwind:check`, web `typecheck`, web `lint`.

## Visual QA
- Desktop Playwright harness loaded `http://localhost:3100/exp/shell-v1?view=releases&capture=marketing` with real global CSS, then rendered all touched banner states. Local screenshot: `.gstack/design-reports/screenshots/jov-2770-release-provider-sync-banners.png`.
- Desktop layout measurements: compact Apple/Spotify states stayed 30px high; import banner visible vs hidden stayed at y=404, height=54.
- Mobile Playwright harness at 390x844 found no horizontal overflow for compact Apple, full Apple, full Spotify import, or enrichment states. Local screenshot: `.gstack/design-reports/screenshots/jov-2770-release-provider-sync-banners-mobile.png`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refreshed visual styling for Apple Music sync banners and Spotify import progress displays to match updated design system standards.
  * Enhanced presentation consistency across release provider UI elements.

* **Tests**
  * Added automated compliance verification for sync banner design system adherence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->