### PR TITLE
fix(auth): resolve Clerk JS from runtime key

### DIFF
--- a/apps/web/components/providers/AuthClientProviders.tsx
+++ b/apps/web/components/providers/AuthClientProviders.tsx
@@ -12,6 +12,7 @@ import {
 import { publicEnv } from '@/lib/env-public';
 import { authClerkAppearance } from './clerkAppearance';
 import {
+  getClerkJSUrl,
   getClerkProxyUrl,
   isPublicAuthHost,
   shouldBypassClerk,
@@ -64,10 +65,16 @@ export function AuthClientProviders({
     );
   }
 
+  const clerkJSUrl = getClerkJSUrl(publishableKey);
+  const clerkScriptProps = clerkJSUrl
+    ? { __internal_clerkJSUrl: clerkJSUrl }
+    : {};
+
   // @clerk/ui bundled locally to avoid CDN loading issues with frontendApiProxy.
   // Added to transpilePackages in next.config.js to resolve Turbopack + pnpm symlink issues.
   return (
     <ClerkProvider
+      {...clerkScriptProps}
       publishableKey={publishableKey}
       proxyUrl={getClerkProxyUrl(globalThis.location)}
       appearance={authClerkAppearance}

--- a/apps/web/components/providers/ClientProviders.tsx
+++ b/apps/web/components/providers/ClientProviders.tsx
@@ -15,7 +15,11 @@ import { publicEnv } from '@/lib/env-public';
 import type { ThemeMode } from '@/types';
 import { CoreProviders } from './CoreProviders';
 import { clerkAppearanceBase } from './clerkAppearance';
-import { getClerkProxyUrl, shouldBypassClerk } from './clerkAvailability';
+import {
+  getClerkJSUrl,
+  getClerkProxyUrl,
+  shouldBypassClerk,
+} from './clerkAvailability';
 import { QueryProvider } from './QueryProvider';
 
 interface ClientProvidersProps {
@@ -88,8 +92,14 @@ export function ClientProviders({
     );
   }
 
+  const clerkJSUrl = getClerkJSUrl(publishableKey);
+  const clerkScriptProps = clerkJSUrl
+    ? { __internal_clerkJSUrl: clerkJSUrl }
+    : {};
+
   return (
     <ClerkProvider
+      {...clerkScriptProps}
       publishableKey={publishableKey}
       proxyUrl={getClerkProxyUrl(globalThis.location)}
       appearance={clerkAppearanceBase}

--- a/apps/web/components/providers/clerkAvailability.ts
+++ b/apps/web/components/providers/clerkAvailability.ts
@@ -176,10 +176,12 @@ export function getClerkProxyUrl(
  *
  * Returns undefined in dev (pk_test_) so Clerk loads JS from its default CDN.
  */
-export function getClerkJSUrl(): string | undefined {
+export function getClerkJSUrl(
+  publishableKey = publicEnv.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+): string | undefined {
   if (publicEnv.NEXT_PUBLIC_CLERK_PROXY_DISABLED === '1') return undefined;
 
-  const pk = publicEnv.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? '';
+  const pk = publishableKey?.trim() ?? '';
   if (!pk.startsWith('pk_live_')) return undefined;
 
   try {

--- a/apps/web/tests/components/providers/ClientProviders.interaction.test.tsx
+++ b/apps/web/tests/components/providers/ClientProviders.interaction.test.tsx
@@ -45,6 +45,7 @@ vi.mock('@/lib/env-public', () => ({
 }));
 vi.mock('@/components/providers/clerkAvailability', () => ({
   shouldBypassClerk: () => availabilityState.shouldBypass,
+  getClerkJSUrl: () => undefined,
   getClerkProxyUrl: () => '/__clerk',
 }));
 

--- a/apps/web/tests/unit/providers/clerk-availability.test.ts
+++ b/apps/web/tests/unit/providers/clerk-availability.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  getClerkJSUrl,
   getClerkProxyUrl,
   getRequestLocationFromHeaders,
   isMockPublishableKey,
@@ -166,6 +167,44 @@ describe('clerkAvailability', () => {
       expect(getClerkProxyUrl(new URL('https://localhost:3000'))).toBe(
         '/__clerk'
       );
+    });
+  });
+
+  describe('getClerkJSUrl', () => {
+    it('derives the Clerk JS bundle URL from the runtime publishable key', () => {
+      vi.stubEnv('NEXT_PUBLIC_CLERK_PROXY_DISABLED', '');
+
+      expect(getClerkJSUrl('pk_live_Y2xlcmsuc3RhZ2luZy5qb3YuaWUk')).toBe(
+        'https://clerk.staging.jov.ie/npm/@clerk/clerk-js@6/dist/clerk.browser.js'
+      );
+    });
+
+    it('does not pin staging to the build-time production publishable key', () => {
+      vi.stubEnv('NEXT_PUBLIC_CLERK_PROXY_DISABLED', '');
+      vi.stubEnv(
+        'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
+        'pk_live_Y2xlcmsuam92LmllJA'
+      );
+
+      expect(getClerkJSUrl('pk_live_Y2xlcmsuc3RhZ2luZy5qb3YuaWUk')).toContain(
+        'clerk.staging.jov.ie'
+      );
+    });
+
+    it('lets Clerk use its default script loader for test keys', () => {
+      vi.stubEnv('NEXT_PUBLIC_CLERK_PROXY_DISABLED', '');
+
+      expect(
+        getClerkJSUrl('pk_test_ZGV2LmNsZXJrLmFjY291bnRzLmRldiQ')
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when the Clerk proxy is disabled', () => {
+      vi.stubEnv('NEXT_PUBLIC_CLERK_PROXY_DISABLED', '1');
+
+      expect(
+        getClerkJSUrl('pk_live_Y2xlcmsuc3RhZ2luZy5qb3YuaWUk')
+      ).toBeUndefined();
     });
   });
 


### PR DESCRIPTION
## Summary
- Derive the Clerk JS bundle URL from the runtime publishable key passed into the provider, so staging renders `clerk.staging.jov.ie` instead of the promoted production build's `clerk.jov.ie` script URL.
- Pass Clerk's internal script URL override through a spread prop, preserving the typed public ClerkProvider surface while overriding the stale build-time env value.
- Add a regression test for staging publishable-key decoding.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/providers/clerk-availability.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/providers/AuthClientProviders.tsx apps/web/components/providers/ClientProviders.tsx apps/web/components/providers/clerkAvailability.ts apps/web/tests/components/providers/ClientProviders.interaction.test.tsx apps/web/tests/unit/providers/clerk-availability.test.ts`
- Pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push` passed, including proxy guard, Tailwind guard, web typecheck, and web lint.

## Issue
- JOV-2761


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for authentication provider configuration to ensure Clerk JS URL computation works correctly across different environments.

* **Chores**
  * Updated internal authentication provider configuration to dynamically compute Clerk JS URLs at runtime based on deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->