### PR TITLE
fix(ui): tokenize linear pill segment control

### DIFF
--- a/apps/web/styles/linear-tokens.css
+++ b/apps/web/styles/linear-tokens.css
@@ -214,6 +214,13 @@
   --linear-hero-height: 392px;
   --linear-button-height-sm: 32px;
   --linear-button-height-md: 40px;
+  --linear-pill-track-padding: 3px;
+  --linear-pill-height-md: 36px;
+  --linear-pill-surface-shadow: var(--linear-shadow-button);
+  --linear-pill-indicator-shadow: var(
+    --shadow-button-inset,
+    var(--linear-shadow-button)
+  );
   --linear-radius-sm: 8px;
   --linear-radius-md: 8px;
   --linear-radius-lg: 12px;

--- a/packages/ui/atoms/segment-control.test.tsx
+++ b/packages/ui/atoms/segment-control.test.tsx
@@ -232,6 +232,22 @@ describe('SegmentControl', () => {
       expect((root as HTMLElement).className).toContain('bg-transparent');
     });
 
+    it('keeps default variants on existing surface padding', () => {
+      const { container } = render(
+        <SegmentControl
+          value='links'
+          onValueChange={vi.fn()}
+          options={defaultOptions}
+          variant='default'
+          size='sm'
+        />
+      );
+
+      expect((container.firstChild as HTMLElement).className).toContain(
+        'p-0.5'
+      );
+    });
+
     it('renders the linear pill indicator', () => {
       const { container } = render(
         <SegmentControl
@@ -256,6 +272,20 @@ describe('SegmentControl', () => {
       expect((container.firstChild as HTMLElement).className).toContain(
         'bg-(--linear-bg-button)'
       );
+      expect((container.firstChild as HTMLElement).className).toContain(
+        'p-(--linear-pill-track-padding)'
+      );
+      expect((container.firstChild as HTMLElement).className).not.toContain(
+        'p-0.5'
+      );
+      expect(activeTab.className).toContain('font-caption');
+      expect(activeTab.className).toContain(
+        'tracking-(--linear-caption-tracking)'
+      );
+      expect(activeTab.className).toContain('text-caption');
+      expect(activeTab.className).not.toContain('font-[510]');
+      expect(activeTab.className).not.toContain('tracking-[-0.01em]');
+      expect(activeTab.className).not.toContain('text-[12px]');
     });
   });
 

--- a/packages/ui/atoms/segment-control.tsx
+++ b/packages/ui/atoms/segment-control.tsx
@@ -20,21 +20,21 @@ const segmentControlVariants = cva('inline-flex items-center rounded-full', {
       ghost: 'border-transparent bg-transparent shadow-none',
       'linear-pill': linearPillSurfaceClassName,
     },
-    size: {
-      sm: 'p-0.5',
-      md: 'p-1',
-      lg: 'p-1',
-    },
   },
   defaultVariants: {
     variant: 'default',
-    size: 'sm',
   },
 });
 
+const segmentControlSurfaceSizeClassNames = {
+  sm: 'p-0.5',
+  md: 'p-1',
+  lg: 'p-1',
+} as const;
+
 const segmentTriggerVariants = cva(
   [
-    'relative rounded-full border border-transparent bg-transparent font-[510] tracking-[-0.01em] transition-[background-color,color,box-shadow,border-color] duration-fast ease-interactive',
+    'relative rounded-full border border-transparent bg-transparent transition-[background-color,color,box-shadow,border-color]',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--color-accent)/30 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-app-content-surface)',
     'disabled:pointer-events-none disabled:opacity-45',
     // Inactive state
@@ -45,18 +45,13 @@ const segmentTriggerVariants = cva(
   {
     variants: {
       variant: {
-        default: '',
-        ghost: '',
+        default: 'font-[510] tracking-[-0.01em] duration-fast ease-interactive',
+        ghost: 'font-[510] tracking-[-0.01em] duration-fast ease-interactive',
         'linear-pill': cn(
           linearPillLabelClassName,
           linearPillFocusClassName,
           'text-(--linear-text-tertiary) hover:text-(--linear-text-primary) data-[state=active]:text-(--linear-btn-primary-fg)'
         ),
-      },
-      size: {
-        sm: 'h-7 px-2.5 text-[12px]',
-        md: 'h-[28px] px-2.5 text-[13px]',
-        lg: 'h-9 px-4 text-sm',
       },
       layout: {
         fill: 'flex-1',
@@ -65,11 +60,16 @@ const segmentTriggerVariants = cva(
     },
     defaultVariants: {
       variant: 'default',
-      size: 'sm',
       layout: 'fill',
     },
   }
 );
+
+const segmentTriggerSizeClassNames = {
+  sm: 'h-7 px-2.5 text-[12px]',
+  md: 'h-[28px] px-2.5 text-[13px]',
+  lg: 'h-9 px-4 text-sm',
+} as const;
 
 interface IndicatorLayout {
   readonly width: number;
@@ -244,7 +244,10 @@ export function SegmentControl<T extends string = string>({
       value={value}
       onValueChange={onValueChange as (value: string) => void}
       className={cn(
-        segmentControlVariants({ variant, size }),
+        segmentControlVariants({ variant }),
+        variant === 'linear-pill'
+          ? null
+          : segmentControlSurfaceSizeClassNames[size],
         layout === 'fill' ? 'w-full' : 'max-w-full',
         className
       )}
@@ -276,8 +279,9 @@ export function SegmentControl<T extends string = string>({
               triggerRefs.current[option.value] = node;
             }}
             className={cn(
-              segmentTriggerVariants({ layout, size, variant }),
-              linearPillTriggerSizeClassName,
+              segmentTriggerVariants({ layout, variant }),
+              linearPillTriggerSizeClassName ??
+                segmentTriggerSizeClassNames[size],
               variant !== 'linear-pill' &&
                 'motion-safe:transition-[background-color,color,box-shadow] motion-safe:duration-150 motion-safe:ease-out',
               triggerClassName

--- a/packages/ui/lib/linear-pill.test.ts
+++ b/packages/ui/lib/linear-pill.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const sourcePath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'linear-pill.ts'
+);
+
+const forbiddenPatterns = [
+  /\brgba?\(/,
+  /#[0-9A-Fa-f]{3,8}\b/,
+  /\b(?:p|inset-y|left|shadow|text|font|tracking|duration|ease)-\[[^\]]+\]/,
+  /\bduration-\d+\b/,
+  /\bfont-\[[^\]]+\]/,
+  /tracking-\[-/,
+  /cubic-bezier\(/,
+];
+
+describe('linear pill System B token contract', () => {
+  it('keeps the shared pill primitive on named System B tokens', () => {
+    const source = readFileSync(sourcePath, 'utf8');
+    const offenders = forbiddenPatterns
+      .filter(pattern => pattern.test(source))
+      .map(pattern => pattern.toString());
+
+    expect(offenders, offenders.join(', ')).toEqual([]);
+    expect(source).toContain('p-(--linear-pill-track-padding)');
+    expect(source).toContain('shadow-(--linear-pill-surface-shadow)');
+    expect(source).toContain('shadow-(--linear-pill-indicator-shadow)');
+    expect(source).toContain('duration-normal');
+    expect(source).toContain('ease-interactive');
+    expect(source).toContain('font-caption');
+    expect(source).toContain('tracking-(--linear-caption-tracking)');
+  });
+});

--- a/packages/ui/lib/linear-pill.ts
+++ b/packages/ui/lib/linear-pill.ts
@@ -4,26 +4,26 @@ export type LinearPillSize = 'sm' | 'md' | 'lg';
 export type LinearPillTone = 'accent' | 'neutral';
 
 export const linearPillSurfaceClassName =
-  'relative inline-flex items-center rounded-full border border-(--linear-border-subtle) bg-(--linear-bg-button) p-[3px] shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_1px_1px_rgba(0,0,0,0.08)]';
+  'relative inline-flex items-center rounded-full border border-(--linear-border-subtle) bg-(--linear-bg-button) p-(--linear-pill-track-padding) shadow-(--linear-pill-surface-shadow)';
 
 export const linearPillIndicatorClassName =
-  'pointer-events-none absolute inset-y-[3px] left-[3px] rounded-full border border-(--linear-btn-primary-border) bg-(--linear-btn-primary-bg) text-(--linear-btn-primary-fg) shadow-[var(--shadow-button-inset),0_1px_1px_rgba(0,0,0,0.14)] motion-safe:transition-[transform,width,opacity] motion-safe:duration-200 motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:duration-75';
+  'pointer-events-none absolute inset-y-(--linear-pill-track-padding) left-(--linear-pill-track-padding) rounded-full border border-(--linear-btn-primary-border) bg-(--linear-btn-primary-bg) text-(--linear-btn-primary-fg) shadow-(--linear-pill-indicator-shadow) motion-safe:transition-[transform,width,opacity] motion-safe:duration-normal motion-safe:ease-interactive motion-reduce:duration-instant';
 
 export const linearPillSizeClassNames: Record<LinearPillSize, string> = {
-  sm: 'h-[var(--linear-button-height-sm)] min-h-[var(--linear-button-height-sm)] px-4 text-[var(--linear-caption-size)]',
-  md: 'h-9 min-h-9 px-4 text-[13px]',
-  lg: 'h-10 min-h-10 px-5 text-sm',
+  sm: 'h-(--linear-button-height-sm) min-h-(--linear-button-height-sm) px-4 text-caption',
+  md: 'h-(--linear-pill-height-md) min-h-(--linear-pill-height-md) px-4 text-caption',
+  lg: 'h-(--linear-button-height-md) min-h-(--linear-button-height-md) px-5 text-sm',
 };
 
 const linearPillToneClassNames: Record<LinearPillTone, string> = {
   accent:
-    'border border-(--linear-btn-primary-border) bg-(--linear-btn-primary-bg) text-(--linear-btn-primary-fg) shadow-[var(--shadow-button-inset),0_1px_1px_rgba(0,0,0,0.14)] hover:bg-(--linear-btn-primary-hover) hover:border-(--linear-btn-primary-hover)',
+    'border border-(--linear-btn-primary-border) bg-(--linear-btn-primary-bg) text-(--linear-btn-primary-fg) shadow-(--linear-pill-indicator-shadow) hover:bg-(--linear-btn-primary-hover) hover:border-(--linear-btn-primary-hover)',
   neutral:
-    'border border-(--linear-border-subtle) bg-(--linear-bg-button) text-(--linear-text-tertiary) shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_1px_1px_rgba(0,0,0,0.08)] hover:border-(--linear-border-default) hover:text-(--linear-text-primary)',
+    'border border-(--linear-border-subtle) bg-(--linear-bg-button) text-(--linear-text-tertiary) shadow-(--linear-pill-surface-shadow) hover:border-(--linear-border-default) hover:text-(--linear-text-primary)',
 };
 
 export const linearPillLabelClassName =
-  'relative z-10 inline-flex shrink-0 items-center justify-center rounded-full border border-transparent bg-transparent font-[510] leading-none tracking-[-0.011em] transition-[color,opacity] duration-normal ease-interactive';
+  'relative z-10 inline-flex shrink-0 items-center justify-center rounded-full border border-transparent bg-transparent font-caption leading-none tracking-(--linear-caption-tracking) transition-[color,opacity] duration-normal ease-interactive';
 
 export const linearPillFocusClassName =
   'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent';
@@ -38,7 +38,7 @@ export function getLinearPillClassName({
   tone?: LinearPillTone;
 }>) {
   return cn(
-    'inline-flex items-center justify-center rounded-full font-[510] leading-none tracking-[-0.011em] transition-[background-color,border-color,color,box-shadow,opacity] duration-normal ease-interactive disabled:pointer-events-none disabled:opacity-50',
+    'inline-flex items-center justify-center rounded-full font-caption leading-none tracking-(--linear-caption-tracking) transition-[background-color,border-color,color,box-shadow,opacity] duration-normal ease-interactive disabled:pointer-events-none disabled:opacity-50',
     linearPillFocusClassName,
     linearPillSizeClassNames[size],
     linearPillToneClassNames[tone],


### PR DESCRIPTION
## Summary

- Tokenizes the shared linear-pill surface, indicator, typography, timing, and sizing through named System B variables.
- Splits `SegmentControl` sizing so default/ghost variants keep existing padding while `linear-pill` no longer gets `p-0.5`, raw font weight, raw tracking, or raw text sizing merged into its runtime classes.
- Adds focused package tests for the linear-pill source contract and the `SegmentControl` runtime class contract.

## Verification

- `pnpm exec biome check --write packages/ui/lib/linear-pill.ts packages/ui/lib/linear-pill.test.ts packages/ui/atoms/segment-control.tsx packages/ui/atoms/segment-control.test.tsx apps/web/styles/linear-tokens.css`
- `pnpm --filter @jovie/ui exec vitest run lib/linear-pill.test.ts atoms/segment-control.test.tsx` → 2 files, 28 tests passed
- `pnpm --filter @jovie/ui run typecheck`
- `pnpm --filter @jovie/web run tailwind:check`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Visual Proof

- Local route: `/new` on `http://localhost:3101`
- Desktop screenshot: `.gstack/design-reports/screenshots/jov-2773-linear-pill-desktop-final.png`
- Mobile-width screenshot: `.gstack/design-reports/screenshots/jov-2773-linear-pill-mobile-final.png`
- Browser runtime check: token padding true, legacy `p-0.5` false, active trigger `font-caption` true, raw `font-[510]` false, raw `text-[12px]` false.
- Layout-shift check: desktop tablist delta `{ x: 0, y: 0, width: 0, height: 0 }`; mobile-width tablist delta `{ x: 0, y: 0, width: 0, height: 0 }` after selecting the second tab.

Linear: JOV-2773


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Introduced new design tokens for pill UI component sizing and shadow styling.
  * Refactored segment control component styling logic to improve size variant handling.
  * Updated linear pill component styling to align with design token standards.

* **Tests**
  * Added validation tests for linear pill token usage and variant application.
  * Enhanced segment control test coverage for padding and typography variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->