### PR TITLE
fix(ci): extend main unit and pr smoke timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2627,7 +2627,7 @@ jobs:
     needs: [ci-fast, ci-path-changes, ci-risk-classifier]
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && (contains(github.event.pull_request.labels.*.name, 'testing') || needs.ci-risk-classifier.outputs.requires_smoke == 'true') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     outputs:
       run_full_ci: ${{ steps.check_changes.outputs.run_full_ci }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2341,7 +2341,7 @@ jobs:
     # Path-gated: skips test execution when no test-relevant files changed.
     if: ${{ github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch' }}
     runs-on: ${{ vars.CI_FAST_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Raises `ci-unit-tests` from 30 to 40 minutes so main-push unit shards can finish their full-suite path plus retry/upload tail.
- Raises `ci-e2e-smoke` from 20 to 30 minutes for high-risk PRs after the required smoke lane was still making progress when the job cap canceled it.

## Evidence
- Main run `26964667343` for PR #10057 deployed successfully, then three unit shards were cancelled at the 30-minute cap.
- Cancelled shard logs show tests were still passing; shard 6 reported `1598 passed` test files / `13175 passed` tests before cancellation during the tail work.
- PR run `26967070413` classified this workflow-only PR as `ci-workflows`, requiring E2E smoke evidence. The smoke suite has 20 tests across seven files and was still retrying `/signup` after a Next dev-server memory restart when the 20-minute job cap canceled it.

## Decision
Ship now: 40 minutes for main unit shards and 30 minutes for PR smoke give the observed CI paths enough room to finish without reducing coverage.
Re-evaluate when: JOV-2762 has two weeks of telemetry showing p95 main unit shard runtime under 25 minutes and p95 PR smoke runtime under 20 minutes, or runner spend for these lanes exceeds the CI-minute budget.
Then: reduce the caps or split the slow main-only/full-smoke paths so each lane has a tighter bound.

## Verification
- `pnpm exec actionlint -shellcheck= .github/workflows/ci.yml`
- `git diff --check`
- `pnpm --filter @jovie/web exec playwright test --config=playwright.config.smoke.ts --project=chromium --list`
- pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`

Linear: JOV-2049
