### PR TITLE
fix(web): polish entity popover System B chrome

### DIFF
--- a/apps/web/components/shell/EntityPopover.test.tsx
+++ b/apps/web/components/shell/EntityPopover.test.tsx
@@ -8,9 +8,16 @@ import { fastRender } from '@/tests/utils/fast-render';
 import { EntityHoverLink, type EntityPopoverData } from './EntityPopover';
 
 vi.mock('next/image', () => ({
-  default: ({ src, alt, ...rest }: ComponentProps<'img'>) => (
-    <img src={src as string} alt={alt ?? ''} {...rest} />
-  ),
+  default: ({
+    src,
+    alt,
+    fill: _fill,
+    unoptimized: _unoptimized,
+    ...rest
+  }: ComponentProps<'img'> & {
+    fill?: boolean;
+    unoptimized?: boolean;
+  }) => <img src={src as string} alt={alt ?? ''} {...rest} />,
 }));
 
 const release = {
@@ -102,9 +109,7 @@ describe('EntityHoverLink', () => {
 
     expect(screen.getByRole('tooltip').textContent).toContain('Spotify artist');
     expect(
-      screen
-        .getByRole('tooltip')
-        .querySelector('.system-b-entity-popover-spotify-icon')
+      screen.getByRole('tooltip').querySelector('.system-b-brand-spotify-glyph')
     ).not.toBeNull();
   });
 });
@@ -124,7 +129,7 @@ describe('EntityPopover source contract', () => {
       "import { LINEAR_SURFACE } from '@/components/tokens/linear-surface';"
     );
     expect(source).toContain('LINEAR_SURFACE.popover');
-    expect(source).toContain('system-b-entity-popover-spotify-icon');
+    expect(source).toContain('system-b-brand-spotify-glyph');
     expect(source).not.toContain('#1DB954');
     expect(source).not.toContain("'rounded-lg border border-default'");
     expect(source).not.toContain("'bg-surface-0 text-primary-token");

--- a/apps/web/components/shell/EntityPopover.tsx
+++ b/apps/web/components/shell/EntityPopover.tsx
@@ -212,7 +212,7 @@ export function EntityRowArt({
     const stamp = stampParts(entity.eventDate);
     if (stamp) {
       return (
-        <span className='flex h-7 w-7 shrink-0 flex-col items-center justify-center rounded-md border border-subtle bg-surface-1 shadow-app-control'>
+        <span className='flex h-7 w-7 shrink-0 flex-col items-center justify-center rounded-xl border border-subtle bg-surface-1 shadow-app-control'>
           <span className='text-3xs font-caption leading-none text-tertiary-token'>
             {stamp.month}
           </span>
@@ -229,7 +229,7 @@ export function EntityRowArt({
       entity.kind === 'contact' ||
       entity.kind === 'teammate'
         ? 'rounded-full'
-        : 'rounded-md';
+        : 'rounded-xl';
     return (
       <span
         className={cn(
@@ -256,7 +256,7 @@ export function EntityRowArt({
     <span
       className={cn(
         'flex h-7 w-7 shrink-0 items-center justify-center border border-subtle bg-surface-1 text-3xs font-caption text-primary-token shadow-app-control',
-        isCircular ? 'rounded-full' : 'rounded-md'
+        isCircular ? 'rounded-full' : 'rounded-xl'
       )}
     >
       {getInitials(entity.label) || '·'}
@@ -457,7 +457,7 @@ function CardArtwork({ entity }: { readonly entity: EntityPopoverData }) {
     const stamp = stampParts(entity.eventDate);
     if (stamp) {
       return (
-        <div className='flex h-12 w-12 shrink-0 flex-col items-center justify-center rounded-md bg-surface-1'>
+        <div className='flex h-12 w-12 shrink-0 flex-col items-center justify-center rounded-xl bg-surface-1'>
           <span className='text-3xs font-caption text-tertiary-token'>
             {stamp.month}
           </span>
@@ -477,7 +477,7 @@ function CardArtwork({ entity }: { readonly entity: EntityPopoverData }) {
       <div
         className={cn(
           'relative h-12 w-12 shrink-0 overflow-hidden',
-          isCircular ? 'rounded-full' : 'rounded-md'
+          isCircular ? 'rounded-full' : 'rounded-xl'
         )}
       >
         <Image
@@ -495,7 +495,7 @@ function CardArtwork({ entity }: { readonly entity: EntityPopoverData }) {
     <div
       className={cn(
         'flex h-12 w-12 shrink-0 items-center justify-center bg-surface-1 text-app font-caption text-primary-token',
-        isCircular ? 'rounded-full' : 'rounded-md'
+        isCircular ? 'rounded-full' : 'rounded-xl'
       )}
     >
       {getInitials(entity.label) || '·'}
@@ -532,7 +532,7 @@ function EntityCard({ entity, onActivate }: EntityCardProps) {
           {artistDisp.useSpotifyIcon ? (
             <span className='inline-flex items-center gap-1.5'>
               <Music
-                className='system-b-entity-popover-spotify-icon h-3.5 w-3.5 shrink-0'
+                className='system-b-brand-spotify-glyph h-3.5 w-3.5 shrink-0'
                 aria-hidden='true'
               />
               {artistDisp.displayLabel}
@@ -552,7 +552,7 @@ function EntityCard({ entity, onActivate }: EntityCardProps) {
                 label: artistLink,
               });
             }}
-            className='mb-2 inline-flex items-center text-2xs font-caption text-secondary-token underline decoration-subtle underline-offset-2 transition-colors duration-subtle ease-subtle hover:text-primary-token hover:decoration-default'
+            className='mb-2 inline-flex items-center text-2xs font-caption text-secondary-token underline decoration-subtle underline-offset-2 transition-colors duration-fast ease-subtle hover:text-primary-token hover:decoration-default'
           >
             {artistLink}
           </button>
@@ -679,7 +679,7 @@ export function EntityPopover({
       className={cn(
         LINEAR_SURFACE.popover,
         'text-primary-token',
-        'animate-in fade-in-0 zoom-in-95 duration-subtle ease-subtle',
+        'animate-in fade-in-0 zoom-in-95 duration-fast ease-subtle',
         pos?.side === 'left' ? 'slide-in-from-right-1' : 'slide-in-from-left-1',
         'motion-reduce:transition-opacity motion-reduce:transform-none'
       )}
@@ -797,7 +797,7 @@ export function EntityHoverLink({
         // decoration — keeps entity-rich copy from reading as a wall of
         // dotted lines while still surfacing the affordance on intent.
         className={cn(
-          'inline-flex items-center rounded-md transition-colors duration-subtle ease-subtle hover:text-primary-token',
+          'inline-flex items-center rounded-full transition-colors duration-fast ease-subtle hover:text-primary-token',
           'no-underline hover:underline focus-visible:underline underline-offset-2',
           'focus-ring-themed',
           className


### PR DESCRIPTION
## Summary
- Polishes entity popover visual chrome for System B: release/event/track artwork now uses the larger System B corner radius while people remain circular.
- Uses the shared Spotify brand glyph class for Spotify artist URL fallback display.
- Tightens transient popover/trigger animation timing to `duration-fast`.

Part of JOV-2775.

## Test Coverage
All changed behavior is covered by the existing focused popover test and the rich-chip source guard.

## Pre-Landing Review
Pre-Landing Review: No issues found.

## Design Review
Lite design review: clean. Layout shift audit by inspection and test coverage: changed states are closed, hover open, focus open, Escape close, Spotify URL fallback, release/event/contact variants, thumbnail/no-thumbnail. The popover renders through a portal, and this PR changes only border-radius, transition duration, and a glyph class; fixed art dimensions are unchanged.

## Verification Results
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run components/shell/EntityPopover.test.tsx tests/unit/chat/entity-rich-chip-style-guard.test.ts` — 2 files, 6 tests passed
- `JOVIE_AGENT_PROFILE=coder pnpm biome check apps/web/components/shell/EntityPopover.tsx apps/web/components/shell/EntityPopover.test.tsx apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts` — passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- Pre-commit hook — proxy guard, Biome write, ESLint, staged a11y check, web typecheck passed
- Pre-push hook — root Biome, web proxy guard, Tailwind guard, web typecheck, web Biome lint passed

## Test plan
- [x] Focused EntityPopover and rich-chip guard tests pass
- [x] Web typecheck passes
- [x] Biome passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined border-radius styling across Entity Popover elements, including event stamps, artwork thumbnails, and buttons.
  * Updated Spotify icon branding appearance.
  * Improved animation transition timing for popover interactions.

* **Tests**
  * Updated test fixtures and assertions for Entity Popover styling changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->