### PR TITLE
fix(ui): tokenize avatar System B classes

### DIFF
--- a/packages/ui/atoms/avatar.test.tsx
+++ b/packages/ui/atoms/avatar.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Avatar, AvatarFallback, AvatarStatusDot, UserAvatar } from './avatar';
+
+describe('Avatar', () => {
+  it('uses System B ring tokens for stacked avatars', () => {
+    render(<Avatar data-testid='avatar' ring />);
+
+    const avatar = screen.getByTestId('avatar');
+    expect(avatar.className).toContain('ring-2');
+    expect(avatar.className).toContain('ring-surface-page');
+  });
+
+  it('uses named System B fallback surface and type scale', () => {
+    render(
+      <Avatar>
+        <AvatarFallback size='md'>TW</AvatarFallback>
+      </Avatar>
+    );
+
+    const fallback = screen.getByText('TW');
+    expect(fallback.className).toContain('bg-surface-2');
+    expect(fallback.className).toContain('text-secondary-token');
+    expect(fallback.className).toContain('text-2xs');
+  });
+
+  it('uses semantic status tokens', () => {
+    render(<AvatarStatusDot status='online' />);
+
+    const status = screen.getByText('online').parentElement;
+    expect(status?.className).toContain('bg-success');
+    expect(status?.className).toContain('ring-surface-page');
+  });
+
+  it('derives initials for user avatars', () => {
+    render(<UserAvatar name='Tim White' />);
+
+    expect(screen.getByText('TW')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/atoms/avatar.tsx
+++ b/packages/ui/atoms/avatar.tsx
@@ -8,31 +8,31 @@ import * as React from 'react';
 const SIZE_MAP = {
   xs: {
     px: 16,
-    text: 'text-[8px]',
+    text: 'text-3xs',
     dot: 'h-2 w-2',
     dotOffset: '-bottom-px -right-px',
   },
   sm: {
     px: 20,
-    text: 'text-[10px]',
+    text: 'text-3xs',
     dot: 'h-2.5 w-2.5',
     dotOffset: '-bottom-px -right-px',
   },
   md: {
     px: 24,
-    text: 'text-[11px]',
+    text: 'text-2xs',
     dot: 'h-3 w-3',
     dotOffset: '-bottom-0.5 -right-0.5',
   },
   lg: {
     px: 32,
-    text: 'text-[13px]',
+    text: 'text-app',
     dot: 'h-3.5 w-3.5',
     dotOffset: '-bottom-0.5 -right-0.5',
   },
   xl: {
     px: 40,
-    text: 'text-[15px]',
+    text: 'text-mid',
     dot: 'h-4 w-4',
     dotOffset: '-bottom-0.5 -right-0.5',
   },
@@ -109,7 +109,7 @@ const Avatar = React.forwardRef<HTMLSpanElement, AvatarProps>(
         ref={ref}
         className={cn(
           'relative inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full',
-          ring && 'ring-2 ring-(--linear-bg-page)',
+          ring && 'ring-2 ring-surface-page',
           className
         )}
         style={{ width: px, height: px, ...style }}
@@ -156,8 +156,8 @@ const AvatarFallback = React.forwardRef<HTMLSpanElement, AvatarFallbackProps>(
     <span
       ref={ref}
       className={cn(
-        'flex h-full w-full items-center justify-center rounded-full font-[510] select-none',
-        'bg-(--linear-bg-surface-2) text-(--linear-text-secondary)',
+        'flex h-full w-full items-center justify-center rounded-full font-medium select-none',
+        'bg-surface-2 text-secondary-token',
         SIZE_MAP[size].text,
         className
       )}
@@ -172,9 +172,9 @@ AvatarFallback.displayName = 'AvatarFallback';
 // ---------------------------------------------------------------------------
 
 const STATUS_COLOR: Record<AvatarStatus, string> = {
-  online: 'bg-(--linear-success)',
-  away: 'bg-(--linear-warning)',
-  offline: 'bg-(--linear-text-tertiary)',
+  online: 'bg-success',
+  away: 'bg-warning',
+  offline: 'bg-tertiary-token',
 };
 
 export interface AvatarStatusDotProps {
@@ -192,7 +192,7 @@ function AvatarStatusDot({
   return (
     <span
       className={cn(
-        'absolute rounded-full ring-[1.5px] ring-(--linear-bg-page)',
+        'absolute rounded-full ring-2 ring-surface-page',
         dot,
         dotOffset,
         STATUS_COLOR[status],

--- a/packages/ui/lib/utils.test.ts
+++ b/packages/ui/lib/utils.test.ts
@@ -45,4 +45,21 @@ describe('cn', () => {
   it('handles array inputs', () => {
     expect(cn(['foo', 'bar'])).toBe('foo bar');
   });
+
+  it('keeps System B text scale and text color tokens together', () => {
+    expect(cn('text-app', 'text-primary-token')).toContain('text-app');
+    expect(cn('text-app', 'text-primary-token')).toContain(
+      'text-primary-token'
+    );
+  });
+
+  it('still merges conflicting font sizes', () => {
+    expect(cn('text-lg', 'text-sm')).toBe('text-sm');
+  });
+
+  it('still merges conflicting text colors', () => {
+    expect(cn('text-primary-token', 'text-secondary-token')).toBe(
+      'text-secondary-token'
+    );
+  });
 });

--- a/packages/ui/lib/utils.ts
+++ b/packages/ui/lib/utils.ts
@@ -1,6 +1,27 @@
 import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import { extendTailwindMerge, validators } from 'tailwind-merge';
+
+const mergeTailwindClasses = extendTailwindMerge({
+  override: {
+    classGroups: {
+      'font-size': [
+        {
+          text: [
+            '3xs',
+            '2xs',
+            'app',
+            'mid',
+            'base',
+            validators.isTshirtSize,
+            validators.isArbitraryVariableLength,
+            validators.isArbitraryLength,
+          ],
+        },
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return mergeTailwindClasses(clsx(inputs));
 }


### PR DESCRIPTION
## Summary
- Moves shared Avatar fallback, ring, status, and small-size text classes onto named System B/Tailwind tokens.
- Extends `cn`/Tailwind merge so System B text scale classes like `text-app` can coexist with semantic text color classes.
- Adds Avatar unit coverage and preserves existing `cn` merge behavior coverage.

Part of JOV-2775.

## Test Coverage
Avatar token behavior and `cn` merge behavior are covered by focused UI package tests.

## Pre-Landing Review
Pre-Landing Review: No issues found.

## Design Review
Lite design review: clean. Layout shift audit by inspection and tests: avatar dimensions remain driven by the same fixed `px` size map and status dots stay absolutely positioned. This PR changes token names/ring thickness only, not avatar sizing or placement.

## Verification Results
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/ui exec vitest run atoms/avatar.test.tsx lib/utils.test.ts` — 2 files, 16 tests passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/ui run typecheck` — passed
- `JOVIE_AGENT_PROFILE=coder pnpm biome check packages/ui/atoms/avatar.tsx packages/ui/atoms/avatar.test.tsx packages/ui/lib/utils.ts packages/ui/lib/utils.test.ts` — passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run tailwind:check` — passed
- Pre-commit hook — proxy guard and Biome write passed
- Pre-push hook — root Biome, web proxy guard, Tailwind guard, web typecheck, web Biome lint passed

## Test plan
- [x] Avatar and `cn` focused tests pass
- [x] UI package typecheck passes
- [x] Tailwind guard passes
- [x] Biome passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Avatar components now use refined design tokens for improved visual consistency and better styling hierarchy.

* **Tests**
  * Added comprehensive test coverage for Avatar components, including fallback and status indicator variants, along with utility function tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->