### PR TITLE
fix(web): remove popover entrance motion

### DIFF
--- a/apps/web/components/shell/EntityPopover.test.tsx
+++ b/apps/web/components/shell/EntityPopover.test.tsx
@@ -133,5 +133,7 @@ describe('EntityPopover source contract', () => {
     expect(source).not.toContain('#1DB954');
     expect(source).not.toContain("'rounded-lg border border-default'");
     expect(source).not.toContain("'bg-surface-0 text-primary-token");
+    expect(source).not.toContain('zoom-in');
+    expect(source).not.toContain('slide-in');
   });
 });

--- a/apps/web/components/shell/EntityPopover.tsx
+++ b/apps/web/components/shell/EntityPopover.tsx
@@ -679,9 +679,7 @@ export function EntityPopover({
       className={cn(
         LINEAR_SURFACE.popover,
         'text-primary-token',
-        'animate-in fade-in-0 zoom-in-95 duration-fast ease-subtle',
-        pos?.side === 'left' ? 'slide-in-from-right-1' : 'slide-in-from-left-1',
-        'motion-reduce:transition-opacity motion-reduce:transform-none'
+        'animate-in fade-in-0 duration-fast ease-subtle'
       )}
     >
       <div className='px-3 py-2.5'>


### PR DESCRIPTION
## Summary

- Removes the EntityPopover `zoom-in` and side-dependent `slide-in-*` entrance classes so the popover uses opacity-only motion.
- Adds source-contract assertions preventing `zoom-in` / `slide-in` tokens from returning to this component.

Part of JOV-2775. Addresses the valid CodeRabbit finding posted on #10063.

## Verification

- `pnpm --filter @jovie/web exec vitest run components/shell/EntityPopover.test.tsx tests/unit/chat/entity-rich-chip-style-guard.test.ts` ✅ 2 files, 6 tests
- `pnpm biome check apps/web/components/shell/EntityPopover.tsx apps/web/components/shell/EntityPopover.test.tsx` ✅
- `pnpm --filter @jovie/web run typecheck -- --pretty false` ✅
- `git diff --check` ✅
- pre-commit hook ✅ proxy guard, Biome write, staged a11y check, web typecheck
- pre-push hook ✅ root Biome, web proxy guard, Tailwind guard, web typecheck, web lint

## Layout Shift Audit

States enumerated: closed, hover open, focus open, Escape close, pointer leave close, left/right side placement. The portal keeps the same fixed positioning, fixed width, and surface classes; this change only removes transform-based entrance tokens and keeps opacity-only animation, so geometry does not change across state transitions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified popover animations to improve visual consistency and performance.

* **Tests**
  * Updated test assertions to verify animation behavior matches new specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->