### PR TITLE
fix(ui): tokenize dropdown menu primitives

### DIFF
--- a/packages/ui/atoms/common-dropdown-renderer.tsx
+++ b/packages/ui/atoms/common-dropdown-renderer.tsx
@@ -11,7 +11,9 @@ import {
   MENU_EMPTY_STATE_BASE,
   MENU_LEADING_SLOT_BASE,
   MENU_LOADING_STATE_BASE,
+  MENU_SEARCH_CLEAR_BUTTON_BASE,
   MENU_SEARCH_HEADER_BASE,
+  MENU_SEARCH_ICON_BASE,
   MENU_SEARCH_INPUT_BASE,
   subMenuContentClasses,
 } from '../lib/dropdown-styles';
@@ -136,7 +138,7 @@ export function SearchableContent({
   return (
     <div data-menu-header className={MENU_SEARCH_HEADER_BASE}>
       <div className='relative'>
-        <Search className='pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-(--linear-text-tertiary)' />
+        <Search className={MENU_SEARCH_ICON_BASE} />
         <input
           ref={setInputRef}
           type='text'
@@ -178,7 +180,7 @@ export function SearchableContent({
               onClear();
               localInputRef.current?.focus();
             }}
-            className='absolute right-1.5 top-1/2 inline-flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded-(--linear-app-radius-item) text-(--linear-text-tertiary) hover:bg-(--linear-bg-surface-2) hover:text-(--linear-text-primary) focus-visible:outline-none focus-visible:bg-(--linear-bg-surface-2)'
+            className={MENU_SEARCH_CLEAR_BUTTON_BASE}
             aria-label='Clear search'
           >
             <X className='h-3 w-3' />

--- a/packages/ui/atoms/common-dropdown.tsx
+++ b/packages/ui/atoms/common-dropdown.tsx
@@ -10,8 +10,10 @@ import {
   contextMenuContentCompactClasses,
   dropdownMenuContentClasses,
   dropdownMenuContentCompactClasses,
+  MENU_ICON_TRIGGER_BASE,
   MENU_ITEM_BASE,
   MENU_ITEM_COMPACT,
+  SELECT_TRIGGER_BASE,
 } from '../lib/dropdown-styles';
 import { cn } from '../lib/utils';
 import {
@@ -166,14 +168,7 @@ export function CommonDropdown(props: CommonDropdownProps) {
       return (
         <button
           type='button'
-          className={cn(
-            'flex h-10 w-full items-center justify-between rounded-xl border border-subtle bg-surface-1 px-3 py-2',
-            'text-sm',
-            'placeholder:text-tertiary-token',
-            'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/24',
-            'disabled:cursor-not-allowed disabled:opacity-50',
-            triggerClassName
-          )}
+          className={cn(SELECT_TRIGGER_BASE, triggerClassName)}
           aria-label={ariaLabel || 'Open dropdown'}
         >
           <span>Select...</span>
@@ -185,10 +180,7 @@ export function CommonDropdown(props: CommonDropdownProps) {
     return (
       <button
         type='button'
-        className={cn(
-          'inline-flex h-8 w-8 items-center justify-center rounded-full border border-transparent bg-transparent text-tertiary-token transition-[background-color,color,box-shadow] duration-150 hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/50',
-          triggerClassName
-        )}
+        className={cn(MENU_ICON_TRIGGER_BASE, triggerClassName)}
         aria-label={ariaLabel || 'More actions'}
         onClick={event => event.stopPropagation()}
       >

--- a/packages/ui/atoms/overflow-menu-trigger.tsx
+++ b/packages/ui/atoms/overflow-menu-trigger.tsx
@@ -4,29 +4,24 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { MoreHorizontal } from 'lucide-react';
 import * as React from 'react';
 
+import {
+  MENU_OVERFLOW_TRIGGER_BASE,
+  MENU_OVERFLOW_TRIGGER_DRAWER,
+  MENU_OVERFLOW_TRIGGER_SEGMENT,
+} from '../lib/dropdown-styles';
 import { cn } from '../lib/utils';
 
-const overflowTriggerVariants = cva(
-  [
-    'relative inline-flex shrink-0 items-center justify-center rounded-full border bg-transparent transition-[background-color,color,border-color] duration-150',
-    'hover:border-default hover:bg-surface-0 hover:text-primary-token',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/35 focus-visible:ring-offset-1 focus-visible:ring-offset-(--linear-bg-page)',
-    'text-tertiary-token',
-  ],
-  {
-    variants: {
-      variant: {
-        drawer:
-          'min-h-7 border-subtle px-2 text-[11.5px] font-[510] tracking-[-0.01em]',
-        segment:
-          'h-7 border-subtle px-2 text-[12px] font-[510] tracking-[-0.01em]',
-      },
+const overflowTriggerVariants = cva(MENU_OVERFLOW_TRIGGER_BASE, {
+  variants: {
+    variant: {
+      drawer: MENU_OVERFLOW_TRIGGER_DRAWER,
+      segment: MENU_OVERFLOW_TRIGGER_SEGMENT,
     },
-    defaultVariants: {
-      variant: 'drawer',
-    },
-  }
-);
+  },
+  defaultVariants: {
+    variant: 'drawer',
+  },
+});
 
 export interface OverflowMenuTriggerProps
   extends VariantProps<typeof overflowTriggerVariants> {

--- a/packages/ui/atoms/searchable-submenu.tsx
+++ b/packages/ui/atoms/searchable-submenu.tsx
@@ -28,13 +28,20 @@ import {
 } from 'react';
 
 import {
-  DROPDOWN_CONTENT_BASE,
-  DROPDOWN_SHADOW,
-  DROPDOWN_SLIDE_ANIMATIONS,
-  DROPDOWN_TRANSITIONS,
+  MENU_BADGE_BASE,
+  MENU_EMPTY_STATE_BASE,
   MENU_ITEM_BASE,
+  MENU_ITEM_DESCRIPTION_BASE,
   MENU_LABEL_BASE,
+  MENU_LEADING_SLOT_BASE,
+  MENU_LOADING_STATE_BASE,
+  MENU_SEARCH_CLEAR_BUTTON_BASE,
+  MENU_SEARCH_HEADER_BASE,
+  MENU_SEARCH_ICON_BASE,
+  MENU_SEARCH_INPUT_BASE,
   MENU_SEPARATOR_BASE,
+  MENU_SHORTCUT_BASE,
+  searchableSubMenuContentClasses,
 } from '../lib/dropdown-styles';
 import { cn } from '../lib/utils';
 
@@ -180,7 +187,7 @@ export function SearchableSubmenu({
   useEffect(() => {
     const itemRef = itemRefs.current.get(highlightedIndex);
     if (itemRef) {
-      itemRef.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      itemRef.scrollIntoView({ block: 'nearest', behavior: 'auto' });
     }
   }, [highlightedIndex]);
 
@@ -284,15 +291,7 @@ export function SearchableSubmenu({
   );
 
   // Build content classes
-  const contentClasses = cn(
-    DROPDOWN_CONTENT_BASE,
-    DROPDOWN_SHADOW,
-    DROPDOWN_TRANSITIONS,
-    DROPDOWN_SLIDE_ANIMATIONS,
-    'min-w-[280px] max-w-[320px]',
-    'max-h-[400px] overflow-hidden flex flex-col',
-    contentClassName
-  );
+  const contentClasses = cn(searchableSubMenuContentClasses, contentClassName);
 
   let globalIndex = 0;
 
@@ -337,9 +336,9 @@ export function SearchableSubmenu({
           }}
         >
           {/* Search Input */}
-          <div className='sticky top-0 z-10 bg-surface-3 p-2 pb-1'>
+          <div className={MENU_SEARCH_HEADER_BASE}>
             <div className='relative'>
-              <Search className='absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary-token' />
+              <Search className={MENU_SEARCH_ICON_BASE} />
               <input
                 ref={searchInputRef}
                 id={searchId}
@@ -347,11 +346,7 @@ export function SearchableSubmenu({
                 placeholder={searchPlaceholder}
                 value={searchQuery}
                 onChange={handleSearchChange}
-                className={cn(
-                  'w-full rounded-lg border border-subtle bg-surface-2 py-2 pl-9 pr-8 text-sm',
-                  'text-primary-token placeholder:text-tertiary-token',
-                  'focus-visible:outline-none focus-visible:border-interactive'
-                )}
+                className={MENU_SEARCH_INPUT_BASE}
                 aria-label={searchPlaceholder}
                 aria-controls={listId}
                 aria-autocomplete='list'
@@ -367,7 +362,7 @@ export function SearchableSubmenu({
                 <button
                   type='button'
                   onClick={handleClearSearch}
-                  className='absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-tertiary-token hover:bg-interactive-hover hover:text-primary-token'
+                  className={MENU_SEARCH_CLEAR_BUTTON_BASE}
                   aria-label='Clear search'
                 >
                   <X className='h-3.5 w-3.5' />
@@ -412,14 +407,12 @@ export function SearchableSubmenu({
             aria-hidden='true'
           >
             {isLoading && (
-              <div className='flex items-center justify-center py-8'>
+              <div className={MENU_LOADING_STATE_BASE}>
                 <Loader2 className='h-5 w-5 animate-spin text-tertiary-token' />
               </div>
             )}
             {!isLoading && !hasResults && (
-              <div className='py-8 text-center text-sm text-tertiary-token'>
-                {emptyMessage}
-              </div>
+              <div className={MENU_EMPTY_STATE_BASE}>{emptyMessage}</div>
             )}
             {!isLoading &&
               hasResults &&
@@ -455,25 +448,23 @@ export function SearchableSubmenu({
                         )}
                       >
                         {item.icon && (
-                          <span className='flex h-4 w-4 items-center justify-center text-tertiary-token'>
+                          <span className={MENU_LEADING_SLOT_BASE}>
                             {item.icon}
                           </span>
                         )}
                         <div className='flex flex-1 flex-col gap-0.5'>
                           <span className='truncate'>{item.label}</span>
                           {item.description && (
-                            <span className='truncate text-xs text-tertiary-token'>
+                            <span className={MENU_ITEM_DESCRIPTION_BASE}>
                               {item.description}
                             </span>
                           )}
                         </div>
                         {item.badge && (
-                          <span className='text-[10px] text-tertiary-token'>
-                            {item.badge}
-                          </span>
+                          <span className={MENU_BADGE_BASE}>{item.badge}</span>
                         )}
                         {item.shortcut && (
-                          <span className='ml-auto text-[10px] tracking-wider text-tertiary-token/70'>
+                          <span className={MENU_SHORTCUT_BASE}>
                             {item.shortcut}
                           </span>
                         )}
@@ -553,7 +544,7 @@ export function SearchableList({
   useEffect(() => {
     const itemRef = itemRefs.current.get(highlightedIndex);
     if (itemRef) {
-      itemRef.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      itemRef.scrollIntoView({ block: 'nearest', behavior: 'auto' });
     }
   }, [highlightedIndex]);
 
@@ -601,21 +592,19 @@ export function SearchableList({
       {header}
 
       {/* Search Input */}
-      <div className='relative p-2'>
-        <Search className='absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-tertiary-token' />
-        <input
-          ref={searchInputRef}
-          type='text'
-          placeholder={searchPlaceholder}
-          value={searchQuery}
-          onChange={e => setSearchQuery(e.target.value)}
-          onKeyDown={handleKeyDown}
-          className={cn(
-            'w-full rounded-lg border border-subtle bg-surface-2 py-2 pl-9 pr-3 text-sm',
-            'text-primary-token placeholder:text-tertiary-token',
-            'focus-visible:outline-none focus-visible:border-interactive'
-          )}
-        />
+      <div className={MENU_SEARCH_HEADER_BASE}>
+        <div className='relative'>
+          <Search className={MENU_SEARCH_ICON_BASE} />
+          <input
+            ref={searchInputRef}
+            type='text'
+            placeholder={searchPlaceholder}
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className={MENU_SEARCH_INPUT_BASE}
+          />
+        </div>
       </div>
 
       <select
@@ -647,9 +636,7 @@ export function SearchableList({
       {/* Items */}
       <div className='flex-1 overflow-y-auto p-1.5 pt-0' aria-hidden='true'>
         {filteredItems.length === 0 ? (
-          <div className='py-8 text-center text-sm text-tertiary-token'>
-            {emptyMessage}
-          </div>
+          <div className={MENU_EMPTY_STATE_BASE}>{emptyMessage}</div>
         ) : (
           filteredItems.map((item, index) => (
             <button
@@ -669,22 +656,18 @@ export function SearchableList({
               )}
             >
               {item.icon && (
-                <span className='flex h-4 w-4 items-center justify-center text-tertiary-token'>
-                  {item.icon}
-                </span>
+                <span className={MENU_LEADING_SLOT_BASE}>{item.icon}</span>
               )}
               <div className='flex flex-1 flex-col gap-0.5'>
                 <span className='truncate'>{item.label}</span>
                 {item.description && (
-                  <span className='truncate text-xs text-tertiary-token'>
+                  <span className={MENU_ITEM_DESCRIPTION_BASE}>
                     {item.description}
                   </span>
                 )}
               </div>
               {item.badge && (
-                <span className='text-[10px] text-tertiary-token'>
-                  {item.badge}
-                </span>
+                <span className={MENU_BADGE_BASE}>{item.badge}</span>
               )}
             </button>
           ))

--- a/packages/ui/lib/dropdown-styles.test.ts
+++ b/packages/ui/lib/dropdown-styles.test.ts
@@ -15,11 +15,18 @@ import {
   DROPDOWN_TRANSITIONS,
   dropdownMenuContentClasses,
   dropdownMenuContentCompactClasses,
+  MENU_ICON_TRIGGER_BASE,
   MENU_ITEM_BASE,
   MENU_ITEM_COMPACT,
   MENU_ITEM_COMPACT_DESTRUCTIVE,
   MENU_ITEM_DESTRUCTIVE,
   MENU_LABEL_BASE,
+  MENU_OVERFLOW_TRIGGER_BASE,
+  MENU_OVERFLOW_TRIGGER_DRAWER,
+  MENU_OVERFLOW_TRIGGER_SEGMENT,
+  MENU_SEARCH_CLEAR_BUTTON_BASE,
+  MENU_SEARCH_ICON_BASE,
+  MENU_SEARCH_INPUT_BASE,
   MENU_SEPARATOR_BASE,
   MENU_SHORTCUT_BASE,
   POPOVER_TRANSFORM_ORIGIN,
@@ -29,6 +36,7 @@ import {
   SELECT_TRANSFORM_ORIGIN,
   SELECT_TRIGGER_BASE,
   SELECT_VIEWPORT_BASE,
+  searchableSubMenuContentClasses,
   selectContentClasses,
   subMenuContentClasses,
 } from './dropdown-styles';
@@ -38,28 +46,26 @@ describe('dropdown-styles', () => {
     it('DROPDOWN_TRANSITIONS contains open/close animations', () => {
       expect(DROPDOWN_TRANSITIONS).toContain('data-[state=open]:animate-in');
       expect(DROPDOWN_TRANSITIONS).toContain('data-[state=closed]:animate-out');
+      expect(DROPDOWN_TRANSITIONS).toContain('fade-in-0');
+      expect(DROPDOWN_TRANSITIONS).not.toContain('zoom');
+      expect(DROPDOWN_TRANSITIONS).not.toContain('slide');
     });
 
-    it('DROPDOWN_SLIDE_ANIMATIONS contains all four sides', () => {
-      expect(DROPDOWN_SLIDE_ANIMATIONS).toContain('data-[side=bottom]');
-      expect(DROPDOWN_SLIDE_ANIMATIONS).toContain('data-[side=left]');
-      expect(DROPDOWN_SLIDE_ANIMATIONS).toContain('data-[side=right]');
-      expect(DROPDOWN_SLIDE_ANIMATIONS).toContain('data-[side=top]');
+    it('DROPDOWN_SLIDE_ANIMATIONS remains disabled for opacity-only motion', () => {
+      expect(DROPDOWN_SLIDE_ANIMATIONS).toBe('');
     });
   });
 
   describe('content base styles', () => {
     it('DROPDOWN_CONTENT_BASE includes z-index, border, and background', () => {
-      expect(DROPDOWN_CONTENT_BASE).toContain('z-[90]');
+      expect(DROPDOWN_CONTENT_BASE).toContain('z-50');
       expect(DROPDOWN_CONTENT_BASE).toContain('border');
-      expect(DROPDOWN_CONTENT_BASE).toContain('bg-');
-      expect(DROPDOWN_CONTENT_BASE).toContain('rounded-');
+      expect(DROPDOWN_CONTENT_BASE).toContain('bg-surface-0');
+      expect(DROPDOWN_CONTENT_BASE).toContain('rounded-xl');
     });
 
     it('default base uses default border token and p-1 padding', () => {
-      expect(DROPDOWN_CONTENT_BASE).toContain(
-        'border-(--linear-border-default)'
-      );
+      expect(DROPDOWN_CONTENT_BASE).toContain('border-default');
       expect(DROPDOWN_CONTENT_BASE.split(/\s+/)).toContain('p-1');
     });
 
@@ -87,9 +93,10 @@ describe('dropdown-styles', () => {
       );
     });
 
-    it('popoverContentClasses uses popover transform origin and motion-reduce', () => {
+    it('popoverContentClasses uses popover transform origin without transform motion', () => {
       expect(popoverContentClasses).toContain(POPOVER_TRANSFORM_ORIGIN);
-      expect(popoverContentClasses).toContain('motion-reduce');
+      expect(popoverContentClasses).not.toContain('zoom');
+      expect(popoverContentClasses).not.toContain('slide-in');
     });
 
     it('selectContentClasses uses select-specific transform origin', () => {
@@ -103,6 +110,13 @@ describe('dropdown-styles', () => {
       expect(subMenuContentClasses).toContain('overflow-y-auto');
       expect(subMenuContentClasses).toContain(DROPDOWN_CONTENT_BASE);
       expect(subMenuContentClasses).toContain(DROPDOWN_SHADOW);
+    });
+
+    it('searchableSubMenuContentClasses uses fixed content sizing without local arbitrary values', () => {
+      expect(searchableSubMenuContentClasses).toContain('min-w-72');
+      expect(searchableSubMenuContentClasses).toContain('max-w-xs');
+      expect(searchableSubMenuContentClasses).toContain('max-h-96');
+      expect(searchableSubMenuContentClasses).toContain(DROPDOWN_CONTENT_BASE);
     });
   });
 
@@ -126,34 +140,29 @@ describe('dropdown-styles', () => {
 
   describe('menu item styles', () => {
     it('MENU_ITEM_BASE includes default sizing', () => {
-      expect(MENU_ITEM_BASE).toContain('text-[13px]');
+      expect(MENU_ITEM_BASE).toContain('text-app');
       expect(MENU_ITEM_BASE).toContain('leading-5');
-      expect(MENU_ITEM_BASE).toContain('font-[400]');
+      expect(MENU_ITEM_BASE).toContain('font-normal');
       expect(MENU_ITEM_BASE).toContain('py-1.5');
       expect(MENU_ITEM_BASE).toContain('gap-2');
     });
 
     it('menu rows use tokenized focus-visible rings', () => {
-      expect(MENU_ITEM_BASE).toContain(
-        'focus-visible:ring-(--linear-border-focus)'
-      );
-      expect(MENU_ITEM_COMPACT).toContain(
-        'focus-visible:ring-(--linear-border-focus)'
-      );
-      expect(CHECKBOX_RADIO_ITEM_BASE).toContain(
-        'focus-visible:ring-(--linear-border-focus)'
-      );
+      expect(MENU_ITEM_BASE).toContain('focus-visible:ring-focus');
+      expect(MENU_ITEM_COMPACT).toContain('focus-visible:ring-focus');
+      expect(CHECKBOX_RADIO_ITEM_BASE).toContain('focus-visible:ring-focus');
     });
 
     it('MENU_ITEM_COMPACT uses smaller sizing', () => {
-      expect(MENU_ITEM_COMPACT).toContain('text-[12.5px]');
+      expect(MENU_ITEM_COMPACT).toContain('text-xs');
       expect(MENU_ITEM_COMPACT).toContain('leading-4');
-      expect(MENU_ITEM_COMPACT).toContain('font-[400]');
+      expect(MENU_ITEM_COMPACT).toContain('font-normal');
       expect(MENU_ITEM_COMPACT).toContain('py-1');
     });
 
     it('MENU_ITEM_DESTRUCTIVE includes destructive color tokens', () => {
-      expect(MENU_ITEM_DESTRUCTIVE).toContain('linear-error');
+      expect(MENU_ITEM_DESTRUCTIVE).toContain('text-error');
+      expect(MENU_ITEM_DESTRUCTIVE).toContain('bg-error-subtle');
     });
 
     it('MENU_ITEM_COMPACT_DESTRUCTIVE is identical to MENU_ITEM_DESTRUCTIVE', () => {
@@ -173,7 +182,7 @@ describe('dropdown-styles', () => {
 
   describe('label, separator, and shortcut styles', () => {
     it('MENU_LABEL_BASE uses label typography tokens', () => {
-      expect(MENU_LABEL_BASE).toContain('text-[11px]');
+      expect(MENU_LABEL_BASE).toContain('text-2xs');
       expect(MENU_LABEL_BASE).toContain('font-medium');
     });
 
@@ -190,13 +199,35 @@ describe('dropdown-styles', () => {
   describe('trigger styles', () => {
     it('SELECT_TRIGGER_BASE includes border and focus styles', () => {
       expect(SELECT_TRIGGER_BASE).toContain('border');
-      expect(SELECT_TRIGGER_BASE).toContain(
-        'focus-visible:border-(--linear-border-focus)'
-      );
-      expect(SELECT_TRIGGER_BASE).toContain(
-        'focus-visible:ring-(--linear-border-focus)'
-      );
+      expect(SELECT_TRIGGER_BASE).toContain('focus-visible:border-focus');
+      expect(SELECT_TRIGGER_BASE).toContain('focus-visible:ring-focus');
       expect(SELECT_TRIGGER_BASE).toContain('disabled:opacity-50');
+    });
+
+    it('MENU_ICON_TRIGGER_BASE uses tokenized focus and hover styles', () => {
+      expect(MENU_ICON_TRIGGER_BASE).toContain('hover:bg-surface-1');
+      expect(MENU_ICON_TRIGGER_BASE).toContain('focus-visible:ring-focus');
+    });
+
+    it('overflow trigger variants use tokenized focus and density classes', () => {
+      expect(MENU_OVERFLOW_TRIGGER_BASE).toContain('focus-visible:ring-focus');
+      expect(MENU_OVERFLOW_TRIGGER_BASE).toContain('ring-offset-surface-page');
+      expect(MENU_OVERFLOW_TRIGGER_DRAWER).toContain('min-h-7');
+      expect(MENU_OVERFLOW_TRIGGER_SEGMENT).toContain('h-7');
+    });
+  });
+
+  describe('search styles', () => {
+    it('MENU_SEARCH_INPUT_BASE includes shared search field sizing', () => {
+      expect(MENU_SEARCH_INPUT_BASE).toContain('h-7');
+      expect(MENU_SEARCH_INPUT_BASE).toContain('focus-visible:border-focus');
+    });
+
+    it('search icon and clear button avoid transform-based centering', () => {
+      expect(MENU_SEARCH_ICON_BASE).toContain('inset-y-0');
+      expect(MENU_SEARCH_ICON_BASE).not.toContain('translate');
+      expect(MENU_SEARCH_CLEAR_BUTTON_BASE).toContain('inset-y-0');
+      expect(MENU_SEARCH_CLEAR_BUTTON_BASE).not.toContain('translate');
     });
   });
 
@@ -226,6 +257,13 @@ describe('dropdown-styles', () => {
       MENU_ITEM_COMPACT_DESTRUCTIVE,
       CHECKBOX_RADIO_ITEM_BASE,
       SELECT_ITEM_BASE,
+      MENU_SEARCH_ICON_BASE,
+      MENU_SEARCH_INPUT_BASE,
+      MENU_SEARCH_CLEAR_BUTTON_BASE,
+      MENU_ICON_TRIGGER_BASE,
+      MENU_OVERFLOW_TRIGGER_BASE,
+      MENU_OVERFLOW_TRIGGER_DRAWER,
+      MENU_OVERFLOW_TRIGGER_SEGMENT,
       MENU_LABEL_BASE,
       MENU_SEPARATOR_BASE,
       MENU_SHORTCUT_BASE,
@@ -236,6 +274,7 @@ describe('dropdown-styles', () => {
       popoverContentClasses,
       selectContentClasses,
       subMenuContentClasses,
+      searchableSubMenuContentClasses,
       dropdownMenuContentCompactClasses,
       contextMenuContentCompactClasses,
     };
@@ -243,8 +282,11 @@ describe('dropdown-styles', () => {
     for (const [name, value] of Object.entries(exports)) {
       it(`${name} is a non-empty string`, () => {
         expect(typeof value).toBe('string');
-        // DROPDOWN_SHADOW is intentionally empty (shadow is now in DROPDOWN_CONTENT_BASE)
-        if (name !== 'DROPDOWN_SHADOW') {
+        // These exports are intentionally empty compatibility hooks.
+        if (
+          name !== 'DROPDOWN_SHADOW' &&
+          name !== 'DROPDOWN_SLIDE_ANIMATIONS'
+        ) {
           expect(value.length).toBeGreaterThan(0);
         }
       });

--- a/packages/ui/lib/dropdown-styles.ts
+++ b/packages/ui/lib/dropdown-styles.ts
@@ -10,16 +10,16 @@
  *
  * Size variants:
  * - default: Standard menus (user menu, bulk actions, notifications)
- *   Content padding: p-1, Item: px-2 py-1.5 text-[13px] leading-[20px]
+ *   Content padding: p-1, Item: px-2.5 py-1.5 text-app leading-5
  * - compact: Dense menus (table actions, context menus, sidebars)
- *   Content padding: p-0.5, Item: px-2 py-1 text-[12.5px] leading-[16px]
+ *   Content padding: p-0.5, Item: px-2.5 py-1 text-xs leading-4
  *
  * Design tokens used:
- * - Border radius: rounded-(--linear-app-radius-menu) / rounded-(--linear-app-radius-item)
- * - Background: bg-(--linear-bg-surface-0) (elevated)
- * - Border: border-(--linear-border-default) (uses design token for both modes)
+ * - Border radius: rounded-xl surfaces, rounded-lg rows, rounded-full triggers
+ * - Background: bg-surface-0 (elevated)
+ * - Border: border-default (uses design token for both modes)
  * - Shadow: consistent across all variants
- * - Transition: duration-normal ease-interactive
+ * - Transition: duration-fast ease-interactive
  */
 
 // ============================================================================
@@ -27,19 +27,16 @@
 // ============================================================================
 
 /**
- * Base fade + subtle scale animations for open/close states (ease-interactive)
+ * Base opacity-only animations for open/close states.
  */
 export const DROPDOWN_TRANSITIONS =
   'data-[state=open]:animate-in data-[state=closed]:animate-out ' +
-  'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 ' +
-  'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95';
+  'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0';
 
 /**
- * Slide-in animations based on dropdown position
+ * @deprecated Positional slide/zoom motion is intentionally disabled.
  */
-export const DROPDOWN_SLIDE_ANIMATIONS =
-  'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 ' +
-  'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2';
+export const DROPDOWN_SLIDE_ANIMATIONS = '';
 
 // ============================================================================
 // CONTENT (CONTAINER) STYLES
@@ -49,10 +46,10 @@ export const DROPDOWN_SLIDE_ANIMATIONS =
  * Base styles for dropdown/popover content containers
  * Used by: DropdownMenuContent, ContextMenuContent, PopoverContent, SelectContent
  *
- * Border uses --linear-border-default (slightly more opaque than --linear-border-subtle used by separators)
+ * Border uses --color-border-default (slightly more opaque than --color-border-subtle used by separators)
  */
 export const DROPDOWN_CONTENT_BASE =
-  'z-[90] min-w-[184px] overflow-hidden rounded-(--linear-app-radius-menu) border border-(--linear-border-default) bg-(--linear-bg-surface-0) p-1 text-(--linear-text-primary) shadow-(--linear-shadow-card-elevated)';
+  'z-50 min-w-48 overflow-hidden rounded-xl border border-default bg-surface-0 p-1 text-primary-token shadow-popover';
 
 /**
  * Shadow effect for elevated appearance
@@ -86,14 +83,12 @@ export const POPOVER_TRANSFORM_ORIGIN =
 /**
  * Max height constraint for dropdown menu content (scrollable)
  */
-export const DROPDOWN_MAX_HEIGHT =
-  'max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto overflow-x-hidden';
+export const DROPDOWN_MAX_HEIGHT = 'max-h-96 overflow-y-auto overflow-x-hidden';
 
 /**
  * Max height constraint for context menu content (scrollable)
  */
-export const CONTEXT_MAX_HEIGHT =
-  'max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto overflow-x-hidden';
+export const CONTEXT_MAX_HEIGHT = 'max-h-96 overflow-y-auto overflow-x-hidden';
 
 /**
  * Max height constraint for select content (scrollable)
@@ -137,8 +132,6 @@ export const popoverContentClasses = [
   DROPDOWN_TRANSITIONS,
   DROPDOWN_SLIDE_ANIMATIONS,
   POPOVER_TRANSFORM_ORIGIN,
-  // Motion reduce support
-  'motion-reduce:transition-opacity motion-reduce:transform-none',
 ].join(' ');
 
 /**
@@ -163,51 +156,51 @@ export const selectContentClasses = [
  * Used by: DropdownMenuItem, ContextMenuItem, SelectItem
  */
 export const MENU_ITEM_BASE =
-  'relative flex min-h-8 cursor-default select-none items-center gap-2 rounded-(--linear-app-radius-item) px-2.5 py-1.5 text-[13px] font-[400] leading-5 outline-none ' +
-  'transition-colors duration-normal ease-interactive ' +
-  'text-(--linear-text-secondary) hover:bg-(--linear-bg-surface-1) hover:text-(--linear-text-primary) ' +
-  'data-[highlighted]:bg-(--linear-bg-surface-1) data-[highlighted]:text-(--linear-text-primary) ' +
-  'data-[disabled]:pointer-events-none data-[disabled]:opacity-[0.46] ' +
-  'focus-visible:outline-none focus-visible:bg-(--linear-bg-surface-1) focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35 ' +
-  '[&_svg]:pointer-events-none [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0 [&_svg]:[stroke-width:1.5] [&_svg]:text-(--linear-text-tertiary) ' +
-  'hover:[&_svg]:text-(--linear-text-primary) data-[highlighted]:[&_svg]:text-(--linear-text-primary)';
+  'relative flex min-h-8 cursor-default select-none items-center gap-2 rounded-lg px-2.5 py-1.5 text-app font-normal leading-5 outline-none ' +
+  'transition-colors duration-fast ease-interactive ' +
+  'text-secondary-token hover:bg-surface-1 hover:text-primary-token ' +
+  'data-[highlighted]:bg-surface-1 data-[highlighted]:text-primary-token ' +
+  'data-[disabled]:pointer-events-none data-[disabled]:opacity-50 ' +
+  'focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-focus/35 ' +
+  '[&_svg]:pointer-events-none [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0 [&_svg]:text-tertiary-token ' +
+  'hover:[&_svg]:text-primary-token data-[highlighted]:[&_svg]:text-primary-token';
 
 /**
  * Destructive variant for menu items (delete, remove actions)
  */
 export const MENU_ITEM_DESTRUCTIVE =
-  'text-(--linear-error) hover:text-(--linear-error) hover:bg-(--linear-error)/10 ' +
-  'data-[highlighted]:text-(--linear-error) data-[highlighted]:bg-(--linear-error)/10 ' +
-  'focus-visible:ring-(--linear-error) ' +
-  '[&_svg]:text-(--linear-error) hover:[&_svg]:text-(--linear-error) data-[highlighted]:[&_svg]:text-(--linear-error)';
+  'text-error hover:text-error hover:bg-error-subtle ' +
+  'data-[highlighted]:text-error data-[highlighted]:bg-error-subtle ' +
+  'focus-visible:ring-error ' +
+  '[&_svg]:text-error hover:[&_svg]:text-error data-[highlighted]:[&_svg]:text-error';
 
 /**
  * Selected/active item state for menus with current choices
  */
 export const MENU_ITEM_SELECTED =
-  'bg-(--linear-bg-surface-1) text-(--linear-text-primary) [&_svg]:text-(--linear-text-primary)';
+  'bg-surface-1 text-primary-token [&_svg]:text-primary-token';
 
 /**
  * Checkbox and radio item styles (with left indicator space)
  */
 export const CHECKBOX_RADIO_ITEM_BASE =
-  'relative flex cursor-default select-none items-center rounded-(--linear-app-radius-item) py-1 pl-7 pr-2 text-[12.5px] font-[400] leading-4 outline-none ' +
-  'transition-colors duration-normal ease-interactive ' +
-  'text-(--linear-text-secondary) hover:bg-(--linear-bg-surface-1) hover:text-(--linear-text-primary) ' +
-  'data-[highlighted]:bg-(--linear-bg-surface-1) data-[highlighted]:text-(--linear-text-primary) ' +
-  'data-[disabled]:pointer-events-none data-[disabled]:opacity-[0.46] ' +
-  'focus-visible:outline-none focus-visible:bg-(--linear-bg-surface-1) focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35';
+  'relative flex cursor-default select-none items-center rounded-lg py-1 pl-7 pr-2 text-xs font-normal leading-4 outline-none ' +
+  'transition-colors duration-fast ease-interactive ' +
+  'text-secondary-token hover:bg-surface-1 hover:text-primary-token ' +
+  'data-[highlighted]:bg-surface-1 data-[highlighted]:text-primary-token ' +
+  'data-[disabled]:pointer-events-none data-[disabled]:opacity-50 ' +
+  'focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-focus/35';
 
 /**
  * Select item base — unified with MENU_ITEM_BASE hover/focus behavior
  */
 export const SELECT_ITEM_BASE =
-  'relative flex w-full cursor-default select-none items-center rounded-(--linear-app-radius-item) py-1.5 pl-8 pr-2 text-[13px] font-[400] leading-5 outline-none ' +
-  'transition-colors duration-normal ease-interactive ' +
-  'text-(--linear-text-secondary) ' +
-  'focus-visible:outline-none focus-visible:bg-(--linear-bg-surface-1) focus-visible:text-(--linear-text-primary) focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35 ' +
-  'data-[highlighted]:bg-(--linear-bg-surface-1) data-[highlighted]:text-(--linear-text-primary) ' +
-  'data-[disabled]:pointer-events-none data-[disabled]:opacity-[0.46]';
+  'relative flex w-full cursor-default select-none items-center rounded-lg py-1.5 pl-8 pr-2 text-app font-normal leading-5 outline-none ' +
+  'transition-colors duration-fast ease-interactive ' +
+  'text-secondary-token ' +
+  'focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:text-primary-token focus-visible:ring-1 focus-visible:ring-focus/35 ' +
+  'data-[highlighted]:bg-surface-1 data-[highlighted]:text-primary-token ' +
+  'data-[disabled]:pointer-events-none data-[disabled]:opacity-50';
 
 // ============================================================================
 // COMPACT SIZE VARIANT (table actions, context menus, sidebar menus)
@@ -217,14 +210,14 @@ export const SELECT_ITEM_BASE =
  * Compact menu item — smaller padding & font for dense UIs (tables, sidebars)
  */
 export const MENU_ITEM_COMPACT =
-  'relative flex min-h-8 cursor-default select-none items-center gap-2 rounded-(--linear-app-radius-item) px-2.5 py-1 text-[12.5px] font-[400] leading-4 outline-none ' +
-  'transition-colors duration-normal ease-interactive ' +
-  'text-(--linear-text-secondary) hover:bg-(--linear-bg-surface-1) hover:text-(--linear-text-primary) ' +
-  'data-[highlighted]:bg-(--linear-bg-surface-1) data-[highlighted]:text-(--linear-text-primary) ' +
-  'data-[disabled]:pointer-events-none data-[disabled]:opacity-[0.46] ' +
-  'focus-visible:outline-none focus-visible:bg-(--linear-bg-surface-1) focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)/35 ' +
-  '[&_svg]:pointer-events-none [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0 [&_svg]:[stroke-width:1.5] [&_svg]:text-(--linear-text-tertiary) ' +
-  'hover:[&_svg]:text-(--linear-text-primary) data-[highlighted]:[&_svg]:text-(--linear-text-primary)';
+  'relative flex min-h-8 cursor-default select-none items-center gap-2 rounded-lg px-2.5 py-1 text-xs font-normal leading-4 outline-none ' +
+  'transition-colors duration-fast ease-interactive ' +
+  'text-secondary-token hover:bg-surface-1 hover:text-primary-token ' +
+  'data-[highlighted]:bg-surface-1 data-[highlighted]:text-primary-token ' +
+  'data-[disabled]:pointer-events-none data-[disabled]:opacity-50 ' +
+  'focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-focus/35 ' +
+  '[&_svg]:pointer-events-none [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0 [&_svg]:text-tertiary-token ' +
+  'hover:[&_svg]:text-primary-token data-[highlighted]:[&_svg]:text-primary-token';
 
 /**
  * @deprecated Use MENU_ITEM_DESTRUCTIVE instead — identical styles.
@@ -239,59 +232,63 @@ export const MENU_ITEM_COMPACT_DESTRUCTIVE = MENU_ITEM_DESTRUCTIVE;
  * Menu label styles (group headers)
  */
 export const MENU_LABEL_BASE =
-  'px-2.5 pb-1 pt-1.5 text-[11px] font-medium text-(--linear-text-tertiary)';
+  'px-2.5 pb-1 pt-1.5 text-2xs font-medium text-tertiary-token';
 
 /**
  * Menu separator styles
  * Uses design token for border consistency
  */
-export const MENU_SEPARATOR_BASE =
-  '-mx-1 my-1 h-px bg-(--linear-border-subtle)';
+export const MENU_SEPARATOR_BASE = '-mx-1 my-1 h-px border-t border-subtle';
 
 /**
  * Keyboard shortcut indicator styles
  */
 export const MENU_SHORTCUT_BASE =
-  'ml-auto text-[10.5px] font-medium text-(--linear-text-tertiary)';
+  'ml-auto text-3xs font-medium text-tertiary-token';
 
 /**
  * Shared leading/trailing slots for structured menu rows
  */
 export const MENU_LEADING_SLOT_BASE =
-  'flex h-4 w-4 shrink-0 items-center justify-center text-(--linear-text-tertiary)';
+  'flex h-4 w-4 shrink-0 items-center justify-center text-tertiary-token';
 
 export const MENU_TRAILING_SLOT_BASE =
-  'ml-auto inline-flex min-w-4 shrink-0 items-center justify-end gap-1 text-(--linear-text-tertiary)';
+  'ml-auto inline-flex min-w-4 shrink-0 items-center justify-end gap-1 text-tertiary-token';
 
 /**
  * Secondary line inside a structured menu row
  */
 export const MENU_ITEM_DESCRIPTION_BASE =
-  'truncate text-[11px] leading-3 text-(--linear-text-tertiary)';
+  'truncate text-2xs leading-3 text-tertiary-token';
 
 /**
  * Small count/status badge used in menu rows
  */
 export const MENU_BADGE_BASE =
-  'inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-(--linear-app-radius-item) border border-(--linear-border-subtle) bg-(--linear-bg-surface-1) px-1.5 text-[10.5px] font-medium tabular-nums text-(--linear-text-tertiary)';
+  'inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-subtle bg-surface-1 px-1.5 text-3xs font-medium tabular-nums text-tertiary-token';
 
 /**
  * Search header and input styles shared by root menus and searchable submenus
  */
-export const MENU_SEARCH_HEADER_BASE =
-  'border-b border-(--linear-border-subtle) px-2 py-2';
+export const MENU_SEARCH_HEADER_BASE = 'border-b border-subtle px-2 py-2';
+
+export const MENU_SEARCH_ICON_BASE =
+  'pointer-events-none absolute inset-y-0 left-2.5 my-auto h-3.5 w-3.5 text-tertiary-token';
 
 export const MENU_SEARCH_INPUT_BASE =
-  'h-7 w-full rounded-(--linear-app-radius-item) border border-(--linear-border-subtle) bg-(--linear-bg-surface-1) py-1 pl-7 pr-7 text-[12px] text-(--linear-text-primary) placeholder:text-(--linear-text-tertiary) focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/24';
+  'h-7 w-full rounded-full border border-subtle bg-surface-1 py-1 pl-7 pr-7 text-xs text-primary-token placeholder:text-tertiary-token focus-visible:outline-none focus-visible:border-focus focus-visible:ring-2 focus-visible:ring-focus/25';
+
+export const MENU_SEARCH_CLEAR_BUTTON_BASE =
+  'absolute inset-y-0 right-1.5 my-auto inline-flex h-4 w-4 items-center justify-center rounded-full text-tertiary-token transition-colors duration-fast ease-interactive hover:bg-surface-2 hover:text-primary-token focus-visible:outline-none focus-visible:bg-surface-2 focus-visible:ring-1 focus-visible:ring-focus/35';
 
 /**
  * Empty and loading states inside menu surfaces
  */
 export const MENU_EMPTY_STATE_BASE =
-  'px-3 py-6 text-center text-[12px] text-(--linear-text-tertiary)';
+  'px-3 py-6 text-center text-xs text-tertiary-token';
 
 export const MENU_LOADING_STATE_BASE =
-  'flex items-center justify-center px-3 py-6 text-(--linear-text-tertiary)';
+  'flex items-center justify-center px-3 py-6 text-tertiary-token';
 
 // ============================================================================
 // TRIGGER STYLES
@@ -301,14 +298,30 @@ export const MENU_LOADING_STATE_BASE =
  * Select trigger button styles
  */
 export const SELECT_TRIGGER_BASE =
-  'flex h-8 w-full items-center justify-between rounded-full border border-(--linear-border-subtle) bg-(--linear-bg-surface-1) px-3 py-1.5 ' +
-  'text-[13px] font-[400] tracking-[-0.011em] text-(--linear-text-primary) ' +
-  'placeholder:text-(--linear-text-tertiary) ' +
-  'transition-colors duration-normal ' +
-  'hover:border-(--linear-border-default) ' +
-  'focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/24 ' +
+  'flex h-8 w-full items-center justify-between rounded-full border border-subtle bg-surface-1 px-3 py-1.5 ' +
+  'text-app font-normal tracking-normal text-primary-token ' +
+  'placeholder:text-tertiary-token ' +
+  'transition-colors duration-fast ' +
+  'hover:border-default ' +
+  'focus-visible:outline-none focus-visible:border-focus focus-visible:ring-2 focus-visible:ring-focus/25 ' +
   'disabled:cursor-not-allowed disabled:opacity-50 ' +
   '[&>span]:line-clamp-1';
+
+/**
+ * Icon-only action trigger for menu controls.
+ */
+export const MENU_ICON_TRIGGER_BASE =
+  'inline-flex h-7 w-7 items-center justify-center rounded-full border border-transparent bg-transparent text-tertiary-token transition-colors duration-fast ease-interactive hover:bg-surface-1 hover:text-primary-token focus-visible:outline-none focus-visible:bg-surface-1 focus-visible:ring-1 focus-visible:ring-focus/50';
+
+/**
+ * Overflow trigger variants for tab and drawer menus.
+ */
+export const MENU_OVERFLOW_TRIGGER_BASE =
+  'relative inline-flex shrink-0 items-center justify-center rounded-full border bg-transparent text-xs font-medium tracking-normal text-tertiary-token transition-colors duration-fast ease-interactive hover:border-default hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/35 focus-visible:ring-offset-1 focus-visible:ring-offset-surface-page';
+
+export const MENU_OVERFLOW_TRIGGER_DRAWER = 'min-h-7 border-subtle px-2';
+
+export const MENU_OVERFLOW_TRIGGER_SEGMENT = 'h-7 border-subtle px-2';
 
 // ============================================================================
 // SUB-CONTENT STYLES
@@ -320,7 +333,19 @@ export const SELECT_TRIGGER_BASE =
  */
 export const subMenuContentClasses = [
   DROPDOWN_CONTENT_BASE,
-  'max-h-[min(var(--radix-dropdown-menu-content-available-height,var(--radix-context-menu-content-available-height,320px)),320px)] overflow-y-auto overflow-x-hidden',
+  'max-h-96 overflow-y-auto overflow-x-hidden',
+  DROPDOWN_SHADOW,
+  DROPDOWN_TRANSITIONS,
+  DROPDOWN_SLIDE_ANIMATIONS,
+].join(' ');
+
+/**
+ * Searchable submenu content classes.
+ * Keeps the search header fixed while the result body scrolls.
+ */
+export const searchableSubMenuContentClasses = [
+  DROPDOWN_CONTENT_BASE,
+  'flex max-h-96 min-w-72 max-w-xs flex-col overflow-hidden',
   DROPDOWN_SHADOW,
   DROPDOWN_TRANSITIONS,
   DROPDOWN_SLIDE_ANIMATIONS,
@@ -334,7 +359,7 @@ export const subMenuContentClasses = [
  * Compact base — currently equivalent to DROPDOWN_CONTENT_BASE; retained for future divergence
  */
 export const DROPDOWN_CONTENT_COMPACT_BASE =
-  'z-[70] min-w-[184px] overflow-hidden rounded-(--linear-app-radius-menu) border border-(--linear-border-default) bg-(--linear-bg-surface-0) p-0.5 text-(--linear-text-primary) shadow-(--linear-shadow-card-elevated)';
+  'z-50 min-w-48 overflow-hidden rounded-xl border border-default bg-surface-0 p-0.5 text-primary-token shadow-popover';
 
 /**
  * Complete compact DropdownMenu content classes


### PR DESCRIPTION
## Summary
- Replaces shared dropdown/menu/search/overflow trigger legacy visual utilities with named System B tokens.
- Disables dropdown slide/zoom motion while preserving opacity open/close animation.
- Centralizes search icon, clear button, select trigger, and overflow trigger classes in `packages/ui/lib/dropdown-styles.ts`.

Part of JOV-2775.

## Layout Shift Audit
- Menu rows keep `min-h-8` and stable content sizing for default and compact density.
- Search icon and clear button use `inset-y-0` centering instead of translate transforms.
- Searchable submenu content uses fixed `min-w-72 max-w-xs max-h-96` bounds with a stable scroll body.
- Playwright hover audit on `/demo/dropdowns`: desktop and mobile both reported `layoutShiftTotal: 0`, unchanged normal-menu bounding boxes, and no horizontal overflow.

## Verification Results
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/ui exec vitest run lib/dropdown-styles.test.ts atoms/common-dropdown.test.tsx atoms/searchable-submenu.test.tsx` — 3 files, 166 tests passed.
- `JOVIE_AGENT_PROFILE=coder pnpm biome check packages/ui/lib/dropdown-styles.ts packages/ui/lib/dropdown-styles.test.ts packages/ui/atoms/common-dropdown.tsx packages/ui/atoms/common-dropdown-renderer.tsx packages/ui/atoms/searchable-submenu.tsx packages/ui/atoms/overflow-menu-trigger.tsx` — checked 6 files, no fixes applied.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/ui run typecheck` — passed.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run tailwind:check` — passed.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `JOVIE_AGENT_PROFILE=coder node <touched-source-token-scan>` — `{ "total": 0, "byFile": {} }` for `--linear-*`, arbitrary colors/sizes, translate, slide/zoom motion, `duration-150`, `font-[`, `tracking-[`.
- `git diff --check` — passed.
- Pre-push passed: root `biome check .`, web `next:proxy-guard`, `tailwind:check`, `typecheck`, and `lint`.

## Visual Evidence
- Desktop screenshot: `/Users/timwhite/.codex/worktrees/7060/jovie-v1-ship-2775-next/apps/web/.gstack/design-reports/screenshots/system-b-dropdown-primitives-demo-desktop-20260604.png`
- Mobile screenshot: `/Users/timwhite/.codex/worktrees/7060/jovie-v1-ship-2775-next/apps/web/.gstack/design-reports/screenshots/system-b-dropdown-primitives-demo-mobile-20260604.png`
- Playwright report: `/Users/timwhite/.codex/worktrees/7060/jovie-v1-ship-2775-next/apps/web/.gstack/design-reports/screenshots/system-b-dropdown-primitives-demo-20260604-report.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated dropdown and menu styling with refined design tokens for improved visual consistency.
  * Refined dropdown animations to use opacity-based transitions.
  * Simplified dropdown content sizing constraints.

* **Tests**
  * Updated style constant tests to align with new tokenization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->