### PR TITLE
fix(auth): render owned SSO start surface

### DIFF
--- a/apps/web/app/(auth)/README.md
+++ b/apps/web/app/(auth)/README.md
@@ -1,11 +1,11 @@
 # Auth & Onboarding (App Router)
 
-This directory contains the App Router auth pages for Jovie. The primary auth UI now uses Clerk's prebuilt components for reliability instead of the older custom multi-step forms.
+This directory contains the App Router auth pages for Jovie. The primary auth UI is SSO-only: Jovie renders first-party Google and Apple buttons, then starts Clerk OAuth through `useSignIn()` / `useSignUp()`.
 
 ## Runtime Model
 
-- `/signin` renders Clerk `<SignIn />` inside the existing `AuthLayout`.
-- `/signup` renders Clerk `<SignUp />` inside the existing `AuthLayout`.
+- `/signin` renders `AuthShell` inside the existing `AuthLayout` and starts Clerk sign-in redirects from app-owned provider buttons.
+- `/signup` renders `AuthShell` inside the existing `AuthLayout` and starts Clerk sign-up redirects from app-owned provider buttons.
 - Auth pages use the bundled Core 3 Clerk UI via `AuthClientProviders`, rather than relying on the CDN-loaded default auth styling path.
 - Auth pages use an auth-only Clerk appearance config with the Core 3 `simple` theme baseline, while non-auth Clerk surfaces keep the shared base appearance.
 - Host-to-instance mapping is strict:
@@ -14,19 +14,17 @@ This directory contains the App Router auth pages for Jovie. The primary auth UI
   - `jov.ie` uses the account A production instance via `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` + `CLERK_SECRET_KEY`
 - Staging auth must never fall back to production Clerk keys. If the staging pair is unavailable at runtime, auth pages must render the auth-unavailable state instead of a `500`.
 - Clerk traffic stays on the current origin and proxies through `/__clerk`; do not switch auth pages to direct `clerk.*` URLs.
-- Both pages use:
-  - `routing="hash"`
-  - `oauthFlow="redirect"`
-- Clerk Dashboard configuration is the source of truth for enabled auth methods and social providers. The app no longer forces an OTP-only UI.
+- Both pages use Clerk redirect OAuth and return through `/signin/sso-callback` or `/signup/sso-callback`.
+- The app is the rendering source of truth for allowed providers. Clerk Dashboard configuration must stay SSO-only, but credential inputs must not mount even if the dashboard regresses.
 
 ## Route Behavior
 
 - `GET /signin`
   - Falls back to [`APP_ROUTES.DASHBOARD`](../../constants/routes.ts) after successful sign-in.
-  - Accepts `?email=` and prefills Clerk `initialValues.emailAddress` when the value is a valid email.
-  - Preserves a valid `redirect_url` when linking onward to `/signup`.
+  - Accepts `?email=` for compatibility, but does not render or prefill a credential field.
+  - Links returnees who need help to `/support`, preserving safe query params.
 - `GET /signup`
-  - Falls back to [`APP_ROUTES.ONBOARDING`](../../constants/routes.ts) after successful sign-up.
+  - Falls back to [`APP_ROUTES.WAITLIST`](../../constants/routes.ts) after successful sign-up unless a central return route is supplied.
   - Preserves signup claim and pricing-plan intent data in session storage before the Clerk flow starts.
   - Shows a compatibility banner for `?oauth_error=` and removes only that query param after render.
   - Preserves a valid `redirect_url` when linking onward to `/signin`.
@@ -43,7 +41,7 @@ This directory contains the App Router auth pages for Jovie. The primary auth UI
 
 - [`tests/e2e/auth.setup.ts`](../../tests/e2e/auth.setup.ts) uses `@clerk/testing/playwright` to create the shared authenticated Playwright session for protected-route specs.
 - [`tests/e2e/auth.spec.ts`](../../tests/e2e/auth.spec.ts) intentionally creates a fresh signed-out browser context so `/signin` and `/signup` are tested as public auth pages, not as redirects for an already signed-in user.
-- [`tests/e2e/smoke-prod-auth.spec.ts`](../../tests/e2e/smoke-prod-auth.spec.ts) exercises the rendered Clerk flow with real credentials and branches on the next step Clerk presents, including password, email-code, or redirect.
+- [`tests/e2e/synthetic-auth-ui.spec.ts`](../../tests/e2e/synthetic-auth-ui.spec.ts) verifies the production auth surface renders SSO buttons without credential inputs.
 
 ## Manual QA
 

--- a/apps/web/app/(auth)/signin/SignInPageClient.tsx
+++ b/apps/web/app/(auth)/signin/SignInPageClient.tsx
@@ -8,6 +8,7 @@ import { APP_ROUTES } from '@/constants/routes';
 import { AuthLayout, AuthRoutePrefetch, AuthShell } from '@/features/auth';
 import { buildAuthRouteUrl } from '@/lib/auth/build-auth-route-url';
 import { getCentralAuthCallbackPath } from '@/lib/auth/central-auth-routing';
+import { sanitizeRedirectUrl } from '@/lib/auth/constants';
 import {
   buildAuthRouteUrlWithDesktopReturn,
   buildDesktopAuthReturnPath,
@@ -139,7 +140,11 @@ function getFallbackRedirectUrl(
     return buildDesktopAuthReturnPath(options.desktopReturnRoute);
   }
 
-  return getCentralAuthCallbackPath(params) ?? undefined;
+  return (
+    getCentralAuthCallbackPath(params) ??
+    sanitizeRedirectUrl(params.get('redirect_url')) ??
+    undefined
+  );
 }
 
 export function SignInPageClient() {

--- a/apps/web/app/(auth)/signup/SignUpPageClient.tsx
+++ b/apps/web/app/(auth)/signup/SignUpPageClient.tsx
@@ -9,6 +9,7 @@ import { AuthLayout, AuthRoutePrefetch, AuthShell } from '@/features/auth';
 import { track } from '@/lib/analytics';
 import { buildAuthRouteUrl } from '@/lib/auth/build-auth-route-url';
 import { getCentralAuthCallbackPath } from '@/lib/auth/central-auth-routing';
+import { sanitizeRedirectUrl } from '@/lib/auth/constants';
 import { setPlanIntent, validatePlan } from '@/lib/auth/plan-intent';
 import {
   clearSignupClaimValue,
@@ -236,7 +237,11 @@ function getFallbackRedirectUrl(
     return buildDesktopAuthReturnPath(options.desktopReturnRoute);
   }
 
-  return getCentralAuthCallbackPath(params) ?? undefined;
+  return (
+    getCentralAuthCallbackPath(params) ??
+    sanitizeRedirectUrl(params.get('redirect_url')) ??
+    undefined
+  );
 }
 
 /**

--- a/apps/web/app/@auth/(.)signup/SignupModalClient.tsx
+++ b/apps/web/app/@auth/(.)signup/SignupModalClient.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/homepage/intent-store';
 import { APP_ROUTES } from '@/constants/routes';
 import { buildAuthRouteUrl } from '@/lib/auth/build-auth-route-url';
+import { sanitizeRedirectUrl } from '@/lib/auth/constants';
 
 /**
  * Intercepted signup modal.
@@ -50,7 +51,9 @@ export function SignupModalClient() {
   }, [searchParams]);
 
   const signInUrl = buildAuthRouteUrl(APP_ROUTES.SIGNIN, searchParams);
-  const redirectUrl = searchParams.get('redirect_url') ?? APP_ROUTES.WAITLIST;
+  const redirectUrl =
+    sanitizeRedirectUrl(searchParams.get('redirect_url')) ??
+    APP_ROUTES.WAITLIST;
 
   const statusRow = promptHint ? (
     <p aria-live='polite' className='truncate' title={promptHint}>

--- a/apps/web/components/features/auth/AuthProviderButtons.tsx
+++ b/apps/web/components/features/auth/AuthProviderButtons.tsx
@@ -6,6 +6,8 @@ import { AuthAppleIcon, AuthGoogleIcon } from './atoms';
 interface AuthProviderButtonSlotProps {
   readonly provider: PrimaryAuthOAuthProvider;
   readonly disabled?: boolean;
+  readonly onClick?: () => void;
+  readonly pending?: boolean;
 }
 
 function AuthProviderIcon({
@@ -23,23 +25,28 @@ function AuthProviderIcon({
 export function AuthProviderButtonSlot({
   provider,
   disabled = true,
+  onClick,
+  pending = false,
 }: Readonly<AuthProviderButtonSlotProps>) {
   const label = getAuthOAuthProviderLabel(provider);
+  const isDisabled = disabled || pending;
 
   return (
     <button
       type='button'
-      disabled={disabled}
-      aria-label={disabled ? `${label} loading` : undefined}
+      disabled={isDisabled}
+      aria-label={isDisabled ? `${label} loading` : undefined}
       data-auth-provider-slot={provider}
+      data-auth-provider-pending={pending ? 'true' : undefined}
+      onClick={onClick}
       className={cn(
-        'flex h-10 min-h-10 w-full items-center justify-center gap-2 rounded-full border px-4 text-[0.875rem] font-semibold tracking-[-0.011em]',
+        'flex h-(--linear-button-height-md) min-h-(--linear-button-height-md) w-full items-center justify-center gap-(--linear-gap-buttons) rounded-full border px-(--linear-space-4) text-caption font-caption tracking-normal',
         'transition-[background-color,border-color,color,box-shadow,opacity] duration-subtle ease-out',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/20',
-        disabled && 'cursor-wait',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/40',
+        isDisabled && 'cursor-wait opacity-75',
         provider === 'google'
-          ? 'border-white/15 bg-white text-[#06070a]'
-          : 'border-white/[0.08] bg-white/[0.045] text-white'
+          ? 'border-(--linear-btn-primary-border) bg-(--linear-btn-primary-bg) text-(--linear-btn-primary-fg) shadow-(--linear-shadow-button) hover:bg-(--linear-btn-primary-hover)'
+          : 'border-subtle bg-surface-1 text-primary-token hover:border-default hover:bg-surface-0'
       )}
     >
       <AuthProviderIcon provider={provider} />

--- a/apps/web/components/features/auth/AuthShell.tsx
+++ b/apps/web/components/features/auth/AuthShell.tsx
@@ -1,154 +1,52 @@
 'use client';
 
-import { SignIn, SignUp } from '@clerk/nextjs';
+import { useClerk, useSignIn, useSignUp } from '@clerk/nextjs';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
-import { AuthProviderButtonSlots } from '@/features/auth/AuthProviderButtons';
-import { useNormalizeClerkHomeLink } from '@/features/auth/useNormalizeClerkHomeLink';
+import {
+  AuthProviderButtonSlot,
+  AuthProviderButtonSlots,
+} from '@/features/auth/AuthProviderButtons';
 import { buildAuthRouteUrl } from '@/lib/auth/build-auth-route-url';
 import { CLERK_COMPONENT_OPTIONS } from '@/lib/auth/clerk-options';
 import {
-  buildDisabledOAuthProviderElements,
-  getAuthOAuthProviderLabel,
   getEnabledAuthOAuthProviders,
   type PrimaryAuthOAuthProvider,
 } from '@/lib/auth/oauth-providers';
-import { cn } from '@/lib/utils';
 
 export type AuthShellMode = 'sign-in' | 'sign-up';
-
-type ClerkAppearanceElements = Record<string, unknown>;
-
-const REQUIRED_CLERK_AUTH_ELEMENTS = {
-  socialButtonsBlockButton: {
-    alignItems: 'center',
-    display: 'flex',
-    justifyContent: 'center',
-    overflow: 'visible',
-    position: 'relative',
-  },
-  lastAuthenticationStrategyBadge: {
-    alignSelf: 'center',
-    justifySelf: 'end',
-    pointerEvents: 'none',
-    position: 'static',
-    transform: 'none',
-    whiteSpace: 'nowrap',
-  },
-} as const satisfies ClerkAppearanceElements;
-
-const HIDE_ELEMENT_STYLE = { display: 'none !important' } as const;
-
-// Jovie is SSO-only (JOV-2446). Even if the Clerk dashboard regresses and
-// re-enables email/password or email-OTP strategies, every credential surface
-// must stay invisible at the rendering layer. The cron at
-// `/api/cron/clerk-config-audit` is the primary regression alarm; this map is
-// defense in depth so a regression doesn't render a usable credential form
-// between the time the dashboard flips and the next cron tick.
-const CREDENTIAL_HIDE_ELEMENTS: Record<string, typeof HIDE_ELEMENT_STYLE> = {
-  // Row containers (signIn-start and signUp-start)
-  formFieldRow__identifier: HIDE_ELEMENT_STYLE,
-  formFieldRow__emailAddress: HIDE_ELEMENT_STYLE,
-  formFieldRow__password: HIDE_ELEMENT_STYLE,
-  // Field wrappers
-  formField__identifier: HIDE_ELEMENT_STYLE,
-  formField__emailAddress: HIDE_ELEMENT_STYLE,
-  formField__password: HIDE_ELEMENT_STYLE,
-  // Inputs themselves
-  formFieldInput__identifier: HIDE_ELEMENT_STYLE,
-  formFieldInput__emailAddress: HIDE_ELEMENT_STYLE,
-  formFieldInput__password: HIDE_ELEMENT_STYLE,
-  // Labels
-  formFieldLabel__identifier: HIDE_ELEMENT_STYLE,
-  formFieldLabel__emailAddress: HIDE_ELEMENT_STYLE,
-  formFieldLabel__password: HIDE_ELEMENT_STYLE,
-  // Username/phone (forbidden in clerk-config-audit; complete defense-in-depth)
-  formFieldRow__username: HIDE_ELEMENT_STYLE,
-  formField__username: HIDE_ELEMENT_STYLE,
-  formFieldInput__username: HIDE_ELEMENT_STYLE,
-  formFieldLabel__username: HIDE_ELEMENT_STYLE,
-  formFieldRow__phoneNumber: HIDE_ELEMENT_STYLE,
-  formField__phoneNumber: HIDE_ELEMENT_STYLE,
-  formFieldInput__phoneNumber: HIDE_ELEMENT_STYLE,
-  formFieldLabel__phoneNumber: HIDE_ELEMENT_STYLE,
-  formattedPhoneNumberInput: HIDE_ELEMENT_STYLE,
-  // Verification-step fields (factor-one / verifications routes — only render
-  // if Clerk advances past start with email re-enabled; hide pre-emptively).
-  formFieldInput__code: HIDE_ELEMENT_STYLE,
-  otpCodeFieldInput: HIDE_ELEMENT_STYLE,
-  formResendCodeLink: HIDE_ELEMENT_STYLE,
-  // Form chrome that only makes sense around a credential form.
-  formButtonPrimary: HIDE_ELEMENT_STYLE,
-  dividerRow: HIDE_ELEMENT_STYLE,
-  alternativeMethods: HIDE_ELEMENT_STYLE,
-  alternativeMethodsBlockButton: HIDE_ELEMENT_STYLE,
-};
 
 const AUTH_LEGAL_FALLBACK_HREFS = {
   privacy: '/legal/privacy',
   terms: '/legal/terms',
 } as const;
 
+type PrimaryAuthOAuthStrategy = `oauth_${PrimaryAuthOAuthProvider}`;
+
 function resolveLegalHref(value: string | undefined, fallback: string) {
   return value?.trim() ? value : fallback;
 }
 
-function mergeRequiredClerkElement(
-  baseElement: unknown,
-  requiredElement: Readonly<Record<string, unknown>>
-) {
-  if (
-    typeof baseElement === 'object' &&
-    baseElement !== null &&
-    !Array.isArray(baseElement)
-  ) {
-    return {
-      ...baseElement,
-      ...requiredElement,
-    };
-  }
-
-  return requiredElement;
+function getOAuthStrategy(
+  provider: PrimaryAuthOAuthProvider
+): PrimaryAuthOAuthStrategy {
+  return `oauth_${provider}`;
 }
 
-function hasEnabledButtonMatching(
-  root: HTMLDivElement | null,
-  predicate: (text: string) => boolean
-) {
-  if (!root) return false;
-
-  return Array.from(root.querySelectorAll('button')).some(button => {
-    if (button.disabled) return false;
-
-    const text = button.textContent?.replace(/\s+/g, ' ').trim() ?? '';
-    return predicate(text);
-  });
+function getSsoCallbackPath(mode: AuthShellMode): string {
+  return mode === 'sign-up' ? '/signup/sso-callback' : '/signin/sso-callback';
 }
 
-// Provider-only readiness check (JOV-2446). Jovie is SSO-only, so Clerk's
-// credential surface should never render. We do NOT fall back to detecting
-// `input[type="email"]` like the pre-2446 code did — a regression that
-// re-enables credentials must be visible (placeholder stays up), not silently
-// accepted.
-function hasReadyClerkAuthStart(
-  root: HTMLDivElement | null,
-  expectedProviderLabels: readonly string[]
-) {
-  if (!root) return false;
-
-  if (expectedProviderLabels.length > 0) {
-    return expectedProviderLabels.some(label =>
-      hasEnabledButtonMatching(root, text => text.includes(label))
-    );
-  }
-
-  return hasEnabledButtonMatching(root, text => /^continue with /i.test(text));
+function getAuthStartErrorMessage(mode: AuthShellMode): string {
+  return mode === 'sign-up'
+    ? 'Could not start sign-up. Please try again.'
+    : 'Could not start sign-in. Please try again.';
 }
 
 interface AuthShellProps {
-  /** Which Clerk flow to render. */
+  /** Which Clerk flow to start. */
   readonly mode: AuthShellMode;
   /**
    * Where to send Clerk after a successful sign-in or sign-up. Defaults match
@@ -158,7 +56,7 @@ interface AuthShellProps {
   readonly fallbackRedirectUrl?: string;
   /**
    * Override the link target for the opposite auth mode. Defaults to the
-   * canonical `/signin` / `/signup` route with the current search params
+   * canonical `/signin` / `/support` route with the current search params
    * preserved so deep links survive the cross-link.
    */
   readonly oppositeModeUrl?: string;
@@ -171,21 +69,18 @@ interface AuthShellProps {
   readonly forceOppositeModeHardNavigation?: boolean;
   /**
    * Marks the intercepted modal surface. AuthShell always renders only the
-   * Clerk form plus required sign-up legal terms; modal chrome lives in
-   * AuthModalShell.
+   * SSO start controls plus required sign-up legal terms; modal chrome lives
+   * in AuthModalShell.
    */
   readonly compact?: boolean;
   /**
-   * Clerk appearance override. Merged with the canonical
-   * `buildDisabledOAuthProviderElements()` map and required auth layout guards
-   * so disabled providers stay hidden and Clerk's "Last used" badge cannot
-   * overlap the provider button row when callers pass their own appearance.
+   * Legacy Clerk prebuilt component escape hatch. Kept so older callers remain
+   * source-compatible; the SSO-only shell no longer mounts Clerk form fields.
    */
   readonly appearance?: Record<string, unknown>;
   /**
-   * Forwarded to Clerk's `initialValues` prop. Used by the sign-in page to
-   * prefill the email address from the `?email=` query param. Sign-up flows
-   * generally leave this unset.
+   * Legacy email prefill prop. Kept so callers can pass it without rendering
+   * a credential input on the SSO-only auth surface.
    */
   readonly initialValues?: { readonly emailAddress?: string };
 }
@@ -193,136 +88,107 @@ interface AuthShellProps {
 /**
  * Canonical auth surface for Jovie.
  *
- * Renders the Clerk `<SignIn />` or `<SignUp />` flow inside a consistent
- * content frame so the full-page route and the intercepted modal route share
- * the exact same content model, typography, links, and provider list.
+ * Jovie is SSO-only (Google + Apple via Clerk) — see JOV-2446 and JOV-2778.
+ * The shell owns the visible OAuth buttons and calls Clerk's redirect APIs
+ * directly, so Clerk credential fields never mount even if the dashboard
+ * configuration regresses.
  *
- * Jovie is SSO-only (Google + Apple via Clerk) — see JOV-2446. Email/password
- * is disabled in the Clerk dashboard and additionally hidden via
- * `CREDENTIAL_HIDE_ELEMENTS` as defense in depth. Provider buttons are gated
- * by `lib/auth/oauth-providers.ts` (JOV-2062 prevention).
- *
- * See JOV-2064, JOV-2437, JOV-2446.
+ * See JOV-2064, JOV-2437, JOV-2446, JOV-2778.
  */
-export function AuthShell({
-  mode,
-  fallbackRedirectUrl,
-  oppositeModeUrl,
-  forceOppositeModeHardNavigation = false,
-  compact = false,
-  appearance,
-  initialValues,
-}: Readonly<AuthShellProps>) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const clerkSurfaceRef = useRef<HTMLDivElement>(null);
+export function AuthShell(props: Readonly<AuthShellProps>) {
+  const {
+    mode,
+    fallbackRedirectUrl,
+    oppositeModeUrl,
+    forceOppositeModeHardNavigation = false,
+    compact = false,
+  } = props;
   const searchParams = useSearchParams();
+  const clerk = useClerk();
+  const signInState = useSignIn();
+  const signUpState = useSignUp();
   const [isMounted, setIsMounted] = useState(false);
-  const [isClerkStartReady, setIsClerkStartReady] = useState(false);
-
-  useNormalizeClerkHomeLink(containerRef);
+  const [pendingProvider, setPendingProvider] =
+    useState<PrimaryAuthOAuthProvider | null>(null);
+  const [oauthError, setOauthError] = useState<string | null>(null);
 
   useEffect(() => {
     setIsMounted(true);
   }, []);
 
   const isSignUp = mode === 'sign-up';
-
   const crossLinkUrl =
     oppositeModeUrl ??
     buildAuthRouteUrl(
       isSignUp ? APP_ROUTES.SIGNIN : APP_ROUTES.SUPPORT,
       searchParams
     );
-  const clerkCrossLinkUrl =
-    forceOppositeModeHardNavigation &&
-    typeof globalThis.location !== 'undefined'
-      ? new URL(crossLinkUrl, globalThis.location.origin).toString()
-      : crossLinkUrl;
-
   const defaultRedirect = isSignUp ? APP_ROUTES.WAITLIST : APP_ROUTES.DASHBOARD;
   const resolvedRedirect = fallbackRedirectUrl ?? defaultRedirect;
   const enabledOAuthProviders = useMemo(
     () => getEnabledAuthOAuthProviders(),
     []
   );
-  const expectedProviderLabels = useMemo(
-    () => enabledOAuthProviders.map(getAuthOAuthProviderLabel),
-    [enabledOAuthProviders]
+  const activeAuthResource = isSignUp ? signUpState.signUp : signInState.signIn;
+  const isAuthStartReady =
+    isMounted && clerk.loaded && Boolean(activeAuthResource);
+
+  const handleProviderSelect = useCallback(
+    async (provider: PrimaryAuthOAuthProvider) => {
+      if (!isAuthStartReady || pendingProvider) return;
+
+      const strategy = getOAuthStrategy(provider);
+      const redirectParams = {
+        oidcPrompt: CLERK_COMPONENT_OPTIONS.oidcPrompt,
+        redirectCallbackUrl: getSsoCallbackPath(mode),
+        redirectUrl: resolvedRedirect,
+        strategy,
+      };
+
+      setPendingProvider(provider);
+      setOauthError(null);
+
+      try {
+        const result = isSignUp
+          ? await signUpState.signUp?.sso({
+              ...redirectParams,
+              legalAccepted: true,
+            })
+          : await signInState.signIn?.sso(redirectParams);
+
+        if (!result || result.error) {
+          throw result?.error ?? new Error('Missing Clerk auth resource');
+        }
+      } catch {
+        setOauthError(getAuthStartErrorMessage(mode));
+        setPendingProvider(null);
+      }
+    },
+    [
+      isAuthStartReady,
+      isSignUp,
+      mode,
+      pendingProvider,
+      resolvedRedirect,
+      signInState.signIn,
+      signUpState.signUp,
+    ]
   );
 
-  // Combine caller-supplied Clerk appearance with the provider guard, the
-  // credential-hiding map (JOV-2446 defense in depth), and the required
-  // layout guards so disabled providers stay hidden, credential rows can
-  // never render, and Clerk's "Last used" badge cannot overlap the provider
-  // button row when callers pass their own appearance.
-  const mergedAppearance = useMemo(() => {
-    const providerGuard = buildDisabledOAuthProviderElements();
-    const baseElements =
-      (appearance?.elements as ClerkAppearanceElements | undefined) ?? {};
-    return {
-      ...appearance,
-      elements: {
-        ...baseElements,
-        socialButtonsBlockButton: mergeRequiredClerkElement(
-          baseElements.socialButtonsBlockButton,
-          REQUIRED_CLERK_AUTH_ELEMENTS.socialButtonsBlockButton
-        ),
-        lastAuthenticationStrategyBadge: mergeRequiredClerkElement(
-          baseElements.lastAuthenticationStrategyBadge,
-          REQUIRED_CLERK_AUTH_ELEMENTS.lastAuthenticationStrategyBadge
-        ),
-        footer: HIDE_ELEMENT_STYLE,
-        footerAction: HIDE_ELEMENT_STYLE,
-        ...CREDENTIAL_HIDE_ELEMENTS,
-        ...providerGuard,
-      },
-    } as Record<string, unknown>;
-  }, [appearance]);
-
-  useEffect(() => {
-    if (!isMounted) return;
-
-    const root = clerkSurfaceRef.current;
-    if (!root) return;
-
-    const syncReadyState = () => {
-      if (hasReadyClerkAuthStart(root, expectedProviderLabels)) {
-        setIsClerkStartReady(true);
-      }
-    };
-
-    syncReadyState();
-
-    if (hasReadyClerkAuthStart(root, expectedProviderLabels)) {
-      return;
-    }
-
-    const observer = new MutationObserver(syncReadyState);
-    observer.observe(root, {
-      attributes: true,
-      childList: true,
-      subtree: true,
-    });
-
-    return () => observer.disconnect();
-  }, [expectedProviderLabels, isMounted]);
-
   const hasNoEnabledProviders = enabledOAuthProviders.length === 0;
-  const showStablePlaceholder = !isMounted || !isClerkStartReady;
+  const showStablePlaceholder = !isAuthStartReady;
 
   // If absolutely no providers are gated on, render the unavailable card
   // instead of an indefinite placeholder. This prevents the auth surface
-  // from looking broken during a provider-wide incident (e.g., both Apple
-  // and Google credentials disabled simultaneously).
+  // from looking broken during a provider-wide incident.
   if (hasNoEnabledProviders) {
     return (
       <div
-        ref={containerRef}
         data-auth-shell-mode={mode}
         data-auth-shell-compact={compact ? 'true' : undefined}
         data-auth-shell-ready='false'
         data-auth-shell-providers='0'
-        className='relative min-h-[280px]'
+        className='relative min-h-72'
       >
         <AuthProvidersUnavailable mode={mode} />
         <AuthLegalText mode={mode} />
@@ -332,11 +198,10 @@ export function AuthShell({
 
   return (
     <div
-      ref={containerRef}
       data-auth-shell-mode={mode}
       data-auth-shell-compact={compact ? 'true' : undefined}
-      data-auth-shell-ready={isClerkStartReady ? 'true' : 'false'}
-      className='relative min-h-[360px]'
+      data-auth-shell-ready={isAuthStartReady ? 'true' : 'false'}
+      className='relative min-h-96'
     >
       {showStablePlaceholder ? (
         <AuthStableStartPlaceholder
@@ -345,53 +210,29 @@ export function AuthShell({
           forceHardNavigation={forceOppositeModeHardNavigation}
           providers={enabledOAuthProviders}
         />
-      ) : null}
-
-      <div
-        ref={clerkSurfaceRef}
-        data-auth-clerk-surface
-        aria-hidden={showStablePlaceholder ? 'true' : undefined}
-        className={cn(
-          showStablePlaceholder &&
-            'pointer-events-none absolute inset-x-0 top-0 opacity-0'
-        )}
-      >
-        {isMounted ? (
-          isSignUp ? (
-            <SignUp
-              routing='path'
-              path='/signup'
-              oauthFlow='redirect'
-              signInUrl={clerkCrossLinkUrl}
-              fallbackRedirectUrl={resolvedRedirect}
-              appearance={mergedAppearance}
-              oidcPrompt={CLERK_COMPONENT_OPTIONS.oidcPrompt}
-            />
-          ) : (
-            <SignIn
-              routing='path'
-              path='/signin'
-              oauthFlow='redirect'
-              signUpUrl={clerkCrossLinkUrl}
-              fallbackRedirectUrl={resolvedRedirect}
-              appearance={mergedAppearance}
-              initialValues={initialValues}
-              oidcPrompt={CLERK_COMPONENT_OPTIONS.oidcPrompt}
-            />
-          )
-        ) : null}
-      </div>
-
-      {showStablePlaceholder ? null : (
-        <>
-          <AuthModeSwitchLink
-            mode={mode}
-            oppositeModeUrl={crossLinkUrl}
-            forceHardNavigation={forceOppositeModeHardNavigation}
-          />
-          <AuthLegalText mode={mode} />
-        </>
+      ) : (
+        <AuthOAuthStartSurface
+          mode={mode}
+          oppositeModeUrl={crossLinkUrl}
+          forceHardNavigation={forceOppositeModeHardNavigation}
+          providers={enabledOAuthProviders}
+          pendingProvider={pendingProvider}
+          errorMessage={oauthError}
+          onProviderSelect={handleProviderSelect}
+        />
       )}
+    </div>
+  );
+}
+
+function AuthShellTitle({ mode }: Readonly<{ mode: AuthShellMode }>) {
+  const isSignUp = mode === 'sign-up';
+
+  return (
+    <div className='mb-4 text-center'>
+      <p className='text-2xl font-semibold leading-tight tracking-normal text-primary-token'>
+        {isSignUp ? 'Request access' : 'Welcome back'}
+      </p>
     </div>
   );
 }
@@ -419,13 +260,15 @@ function AuthStableStartPlaceholder({
       }
       aria-busy='true'
     >
-      <div className='mb-4 text-center'>
-        <p className='text-[clamp(1.5rem,2.6vw,2rem)] font-[680] leading-[1.1] tracking-[-0.025em] text-white'>
-          {isSignUp ? 'Request access' : 'Welcome back'}
-        </p>
-      </div>
+      <AuthShellTitle mode={mode} />
 
       <AuthProviderButtonSlots providers={providers} />
+
+      <div
+        data-auth-oauth-error-slot
+        className='mt-3 min-h-5 text-center'
+        aria-hidden='true'
+      />
 
       <AuthModeSwitchLink
         mode={mode}
@@ -438,24 +281,88 @@ function AuthStableStartPlaceholder({
   );
 }
 
+function AuthOAuthStartSurface({
+  mode,
+  oppositeModeUrl,
+  forceHardNavigation,
+  providers,
+  pendingProvider,
+  errorMessage,
+  onProviderSelect,
+}: Readonly<{
+  mode: AuthShellMode;
+  oppositeModeUrl: string;
+  forceHardNavigation: boolean;
+  providers: readonly PrimaryAuthOAuthProvider[];
+  pendingProvider: PrimaryAuthOAuthProvider | null;
+  errorMessage: string | null;
+  onProviderSelect: (provider: PrimaryAuthOAuthProvider) => void;
+}>) {
+  return (
+    <div data-auth-sso-surface>
+      <AuthShellTitle mode={mode} />
+
+      <fieldset
+        data-auth-provider-slots
+        className='grid grid-cols-1 gap-1.5'
+        aria-busy={pendingProvider ? 'true' : undefined}
+      >
+        <legend className='sr-only'>Social sign-in options</legend>
+        {providers.map(provider => (
+          <AuthProviderButtonSlot
+            key={provider}
+            provider={provider}
+            disabled={Boolean(pendingProvider)}
+            pending={pendingProvider === provider}
+            onClick={() => onProviderSelect(provider)}
+          />
+        ))}
+      </fieldset>
+
+      <div
+        data-auth-oauth-error-slot
+        className='mt-3 min-h-5 text-center'
+        aria-live='polite'
+      >
+        {errorMessage ? (
+          <p
+            className='text-caption font-caption text-destructive'
+            role='alert'
+          >
+            {errorMessage}
+          </p>
+        ) : null}
+      </div>
+
+      <AuthModeSwitchLink
+        mode={mode}
+        oppositeModeUrl={oppositeModeUrl}
+        forceHardNavigation={forceHardNavigation}
+      />
+
+      <AuthLegalText mode={mode} />
+    </div>
+  );
+}
+
 function AuthProvidersUnavailable({ mode }: Readonly<{ mode: AuthShellMode }>) {
   const isSignUp = mode === 'sign-up';
   return (
     <div
       data-auth-providers-unavailable
-      className='mx-auto max-w-[22rem] text-center'
+      className='mx-auto max-w-sm text-center'
       role='status'
     >
-      <p className='text-[clamp(1.25rem,2.2vw,1.625rem)] font-[680] leading-[1.15] tracking-[-0.02em] text-white'>
+      <p className='text-xl font-semibold leading-tight tracking-normal text-primary-token'>
         {isSignUp
           ? 'Sign-up is temporarily unavailable'
           : 'Sign-in is temporarily unavailable'}
       </p>
-      <p className='mt-3 text-[0.9rem] leading-[1.5] text-white/72'>
+      <p className='mt-3 text-app leading-5 text-secondary-token'>
         Our sign-in providers are offline. Please try again in a few minutes, or{' '}
         <a
           href='mailto:support@jov.ie'
-          className='focus-ring-themed rounded-md text-white underline underline-offset-2'
+          className='focus-ring-themed rounded-md text-primary-token underline underline-offset-2'
         >
           contact support
         </a>
@@ -480,10 +387,10 @@ function AuthModeSwitchLink({
   const prompt = isSignUp ? 'Have an account?' : 'Need help?';
   const label = isSignUp ? 'Sign in' : 'Get help';
   const className =
-    'focus-ring-themed rounded-md text-white underline underline-offset-2';
+    'focus-ring-themed rounded-md text-primary-token underline underline-offset-2';
 
   return (
-    <span className='mt-5 block text-center text-[0.9rem] text-white/58'>
+    <span className='mt-5 block text-center text-app text-secondary-token'>
       {prompt}{' '}
       {forceHardNavigation ? (
         <a href={oppositeModeUrl} className={className}>
@@ -511,7 +418,7 @@ function AuthLegalText({ mode }: Readonly<{ mode: AuthShellMode }>) {
   return (
     <p
       data-auth-legal-copy
-      className='mx-auto mt-4 max-w-[22rem] text-center text-2xs leading-[1.55] text-white/78'
+      className='mx-auto mt-4 max-w-sm text-center text-2xs leading-5 text-secondary-token'
     >
       <span data-auth-legal-prefix className='block'>
         By {mode === 'sign-up' ? 'signing up' : 'continuing'}, you agree to our
@@ -519,14 +426,14 @@ function AuthLegalText({ mode }: Readonly<{ mode: AuthShellMode }>) {
       <span data-auth-legal-links className='block whitespace-nowrap'>
         <Link
           href={termsHref}
-          className='focus-ring-themed whitespace-nowrap rounded-md py-0.5 text-white underline underline-offset-2 transition-colors hover:text-white'
+          className='focus-ring-themed whitespace-nowrap rounded-md py-0.5 text-primary-token underline underline-offset-2 transition-colors hover:text-primary-token'
         >
           Terms of Service
         </Link>{' '}
         and{' '}
         <Link
           href={privacyHref}
-          className='focus-ring-themed whitespace-nowrap rounded-md py-0.5 text-white underline underline-offset-2 transition-colors hover:text-white'
+          className='focus-ring-themed whitespace-nowrap rounded-md py-0.5 text-primary-token underline underline-offset-2 transition-colors hover:text-primary-token'
         >
           Privacy Policy
         </Link>

--- a/apps/web/tests/e2e/auth-pages.spec.ts
+++ b/apps/web/tests/e2e/auth-pages.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Auth pages E2E tests — JOV-2037
  *
- * Covers /signin, /signup, redirect normalization, email prefill,
+ * Covers /signin, /signup, redirect normalization, SSO-only auth,
  * plan intent capture, and authenticated-user redirect behaviour.
  *
  * Tests use an anonymous context unless noted.
@@ -156,7 +156,7 @@ test.describe('/signin page', () => {
     }
   });
 
-  test('email prefill: ?email=test@example.com populates the email field', async ({
+  test('email query does not render credential fields on the SSO-only surface', async ({
     browser,
   }) => {
     const { page, context } = await createAnonPage(browser);
@@ -176,25 +176,17 @@ test.describe('/signin page', () => {
         return;
       }
 
-      // Look for the email field with the pre-filled value
-      const emailInput = page
-        .locator('input[type="email"], input[name="identifier"]')
-        .first();
-
-      // Clerk renders the field asynchronously; wait for it if needed
-      const inputVisible = await emailInput
-        .isVisible({ timeout: VISIBILITY_TIMEOUT })
-        .catch(() => false);
-
-      if (inputVisible) {
-        const value = await emailInput.inputValue();
-        expect(value).toBe(testEmail);
-      } else {
-        // In environments where Clerk is unavailable (no real instance),
-        // just verify the page loaded without error
-        const bodyText = await page.locator('body').textContent();
-        expect(bodyText).not.toContain('Unhandled Runtime Error');
-      }
+      await expect(
+        page.getByRole('button', { name: /continue with google/i })
+      ).toBeVisible({ timeout: VISIBILITY_TIMEOUT });
+      await expect(
+        page.getByRole('button', { name: /continue with apple/i })
+      ).toBeVisible({ timeout: VISIBILITY_TIMEOUT });
+      await expect(
+        page.locator(
+          'input[type="email"], input[name="identifier"], input[name="emailAddress"], input[type="password"]'
+        )
+      ).toHaveCount(0);
     } finally {
       await context.close();
     }

--- a/apps/web/tests/unit/app/signin-page.test.tsx
+++ b/apps/web/tests/unit/app/signin-page.test.tsx
@@ -2,24 +2,13 @@ import { render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const {
-  authLayoutMock,
-  clerkSignInMock,
-  routerPrefetchMock,
-  searchParamsState,
-} = vi.hoisted(() => ({
-  authLayoutMock: vi.fn(),
-  clerkSignInMock: vi.fn(),
-  routerPrefetchMock: vi.fn(),
-  searchParamsState: { value: '' },
-}));
-
-vi.mock('@clerk/nextjs', () => ({
-  SignIn: (props: unknown) => {
-    clerkSignInMock(props);
-    return <div data-testid='clerk-sign-in' />;
-  },
-}));
+const { authShellMock, authLayoutMock, routerPrefetchMock, searchParamsState } =
+  vi.hoisted(() => ({
+    authShellMock: vi.fn(),
+    authLayoutMock: vi.fn(),
+    routerPrefetchMock: vi.fn(),
+    searchParamsState: { value: '' },
+  }));
 
 vi.mock('next/navigation', () => ({
   useSearchParams: () => new URLSearchParams(searchParamsState.value),
@@ -40,8 +29,10 @@ vi.mock('@/features/auth', async () => {
       routerPrefetchMock(href);
       return null;
     },
-    // Import the real AuthShell so the Clerk wiring stays exercised end to end.
-    AuthShell: (await import('@/components/features/auth/AuthShell')).AuthShell,
+    AuthShell: (props: Record<string, unknown>) => {
+      authShellMock(props);
+      return reactModule.createElement('div', { 'data-testid': 'auth-shell' });
+    },
   };
 });
 
@@ -49,25 +40,17 @@ import { APP_ROUTES } from '@/constants/routes';
 import SignInPage from '../../../app/(auth)/signin/page';
 
 describe('signin page', () => {
-  function fullAuthUrl(path: string) {
-    return new URL(path, globalThis.location.origin).toString();
-  }
-
   beforeEach(() => {
+    authShellMock.mockReset();
     authLayoutMock.mockReset();
-    clerkSignInMock.mockReset();
     routerPrefetchMock.mockReset();
     searchParamsState.value = '';
   });
 
-  it('renders Clerk SignIn with the expected auth props', async () => {
+  it('renders AuthShell with the expected auth props', () => {
     render(<SignInPage />);
 
-    await waitFor(() => {
-      expect(clerkSignInMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(screen.getByTestId('clerk-sign-in')).toBeInTheDocument();
+    expect(screen.getByTestId('auth-shell')).toBeInTheDocument();
     expect(authLayoutMock).toHaveBeenCalledWith(
       expect.objectContaining({
         formTitle: 'Sign in',
@@ -80,16 +63,13 @@ describe('signin page', () => {
       screen.queryByText('Welcome back to Jovie.')
     ).not.toBeInTheDocument();
     expect(routerPrefetchMock).toHaveBeenCalledWith(APP_ROUTES.SIGNUP);
-    expect(clerkSignInMock).toHaveBeenCalledWith(
+    expect(authShellMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        routing: 'path',
-        path: '/signin',
-        oauthFlow: 'redirect',
-        // Cross-link for sign-in → /support (Need help?). SSO-only — waitlist
-        // is a dead end for returnees who lost their SSO session (JOV-2446).
-        signUpUrl: fullAuthUrl(APP_ROUTES.SUPPORT),
-        fallbackRedirectUrl: APP_ROUTES.DASHBOARD,
+        forceOppositeModeHardNavigation: true,
+        fallbackRedirectUrl: undefined,
         initialValues: undefined,
+        mode: 'sign-in',
+        oppositeModeUrl: undefined,
       })
     );
   });
@@ -99,11 +79,7 @@ describe('signin page', () => {
 
     render(<SignInPage />);
 
-    await waitFor(() => {
-      expect(clerkSignInMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(clerkSignInMock).toHaveBeenCalledWith(
+    expect(authShellMock).toHaveBeenCalledWith(
       expect.objectContaining({
         initialValues: { emailAddress: 'test@example.com' },
       })
@@ -115,27 +91,9 @@ describe('signin page', () => {
 
     render(<SignInPage />);
 
-    await waitFor(() => {
-      expect(clerkSignInMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(clerkSignInMock).toHaveBeenCalledWith(
+    expect(authShellMock).toHaveBeenCalledWith(
       expect.objectContaining({
         initialValues: undefined,
-      })
-    );
-  });
-
-  it('passes oidcPrompt=select_account to Clerk SignIn so account chooser always appears', async () => {
-    render(<SignInPage />);
-
-    await waitFor(() => {
-      expect(clerkSignInMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(clerkSignInMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        oidcPrompt: 'select_account',
       })
     );
   });
@@ -179,14 +137,10 @@ describe('signin page', () => {
 
     render(<SignInPage />);
 
-    await waitFor(() => {
-      expect(clerkSignInMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(clerkSignInMock).toHaveBeenCalledWith(
+    expect(authShellMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        // Cross-link for sign-in preserves redirect params toward /support (JOV-2446).
-        signUpUrl: fullAuthUrl('/support?redirect_url=%2Fonboarding'),
+        fallbackRedirectUrl: '/onboarding',
+        oppositeModeUrl: undefined,
       })
     );
   });
@@ -197,15 +151,10 @@ describe('signin page', () => {
 
     render(<SignInPage />);
 
-    await waitFor(() => {
-      expect(clerkSignInMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(clerkSignInMock).toHaveBeenCalledWith(
+    expect(authShellMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        signUpUrl: fullAuthUrl(
-          '/signup?desktop_return=%2Fapp%2Fsettings%3Ftab%3Dbilling'
-        ),
+        oppositeModeUrl:
+          '/signup?desktop_return=%2Fapp%2Fsettings%3Ftab%3Dbilling',
         fallbackRedirectUrl:
           '/auth-return?route=%2Fapp%2Fsettings%3Ftab%3Dbilling',
       })
@@ -220,13 +169,9 @@ describe('signin page', () => {
 
     render(<SignInPage />);
 
-    await waitFor(() => {
-      expect(clerkSignInMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(clerkSignInMock).toHaveBeenCalledWith(
+    expect(authShellMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        signUpUrl: fullAuthUrl('/signup?mobile_return=%2Fapp%2Fsettings'),
+        oppositeModeUrl: '/signup?mobile_return=%2Fapp%2Fsettings',
         fallbackRedirectUrl: '/mobile-auth-return?route=%2Fapp%2Fsettings',
       })
     );

--- a/apps/web/tests/unit/app/signup-page.test.tsx
+++ b/apps/web/tests/unit/app/signup-page.test.tsx
@@ -3,9 +3,9 @@ import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
+  authShellMock,
   clearSignupClaimValueMock,
   authLayoutMock,
-  clerkSignUpMock,
   fetchMock,
   persistSignupClaimValueMock,
   routerPrefetchMock,
@@ -14,9 +14,9 @@ const {
   trackMock,
   validatePlanMock,
 } = vi.hoisted(() => ({
+  authShellMock: vi.fn(),
   clearSignupClaimValueMock: vi.fn(),
   authLayoutMock: vi.fn(),
-  clerkSignUpMock: vi.fn(),
   fetchMock: vi.fn(),
   persistSignupClaimValueMock: vi.fn(),
   routerPrefetchMock: vi.fn(),
@@ -24,13 +24,6 @@ const {
   setPlanIntentMock: vi.fn(),
   trackMock: vi.fn(),
   validatePlanMock: vi.fn(),
-}));
-
-vi.mock('@clerk/nextjs', () => ({
-  SignUp: (props: unknown) => {
-    clerkSignUpMock(props);
-    return <div data-testid='clerk-sign-up' />;
-  },
 }));
 
 vi.mock('next/navigation', () => ({
@@ -52,9 +45,10 @@ vi.mock('@/features/auth', async () => {
       routerPrefetchMock(href);
       return null;
     },
-    // Import the real AuthShell so its Clerk wiring is exercised in this
-    // test. Provider gating is verified separately in oauth-providers.test.ts.
-    AuthShell: (await import('@/components/features/auth/AuthShell')).AuthShell,
+    AuthShell: (props: Record<string, unknown>) => {
+      authShellMock(props);
+      return reactModule.createElement('div', { 'data-testid': 'auth-shell' });
+    },
   };
 });
 
@@ -81,14 +75,10 @@ import { APP_ROUTES } from '@/constants/routes';
 import SignUpPage from '../../../app/(auth)/signup/page';
 
 describe('signup page', () => {
-  function fullAuthUrl(path: string) {
-    return new URL(path, globalThis.location.origin).toString();
-  }
-
   beforeEach(() => {
+    authShellMock.mockReset();
     clearSignupClaimValueMock.mockReset();
     authLayoutMock.mockReset();
-    clerkSignUpMock.mockReset();
     fetchMock.mockReset();
     fetchMock.mockResolvedValue({
       json: async () => ({ available: true }),
@@ -104,14 +94,10 @@ describe('signup page', () => {
     globalThis.history.replaceState(null, '', '/signup');
   });
 
-  it('renders Clerk SignUp with the expected auth props and legal links', async () => {
+  it('renders AuthShell with the expected auth props', () => {
     render(<SignUpPage />);
 
-    await waitFor(() => {
-      expect(clerkSignUpMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(screen.getByTestId('clerk-sign-up')).toBeInTheDocument();
+    expect(screen.getByTestId('auth-shell')).toBeInTheDocument();
     expect(authLayoutMock).toHaveBeenCalledWith(
       expect.objectContaining({
         formTitle: 'Request access',
@@ -125,21 +111,14 @@ describe('signup page', () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText("Don't have access?")).not.toBeInTheDocument();
     expect(routerPrefetchMock).toHaveBeenCalledWith(APP_ROUTES.SIGNIN);
-    expect(clerkSignUpMock).toHaveBeenCalledWith(
+    expect(authShellMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        routing: 'path',
-        path: '/signup',
-        oauthFlow: 'redirect',
-        signInUrl: fullAuthUrl(APP_ROUTES.SIGNIN),
-        fallbackRedirectUrl: APP_ROUTES.WAITLIST,
+        forceOppositeModeHardNavigation: true,
+        fallbackRedirectUrl: undefined,
+        mode: 'sign-up',
+        oppositeModeUrl: APP_ROUTES.SIGNIN,
       })
     );
-    expect(
-      screen.getByRole('link', { name: /terms of service/i })
-    ).toHaveAttribute('href', APP_ROUTES.LEGAL_TERMS);
-    expect(
-      screen.getByRole('link', { name: /privacy policy/i })
-    ).toHaveAttribute('href', APP_ROUTES.LEGAL_PRIVACY);
   });
 
   it('shows handle availability without writing pending claim session state', async () => {
@@ -217,13 +196,10 @@ describe('signup page', () => {
 
     render(<SignUpPage />);
 
-    await waitFor(() => {
-      expect(clerkSignUpMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(clerkSignUpMock).toHaveBeenCalledWith(
+    expect(authShellMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        signInUrl: fullAuthUrl('/signin?redirect_url=%2Fonboarding'),
+        fallbackRedirectUrl: '/onboarding',
+        oppositeModeUrl: '/signin?redirect_url=%2Fonboarding',
       })
     );
   });
@@ -233,15 +209,9 @@ describe('signup page', () => {
 
     render(<SignUpPage />);
 
-    await waitFor(() => {
-      expect(clerkSignUpMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(clerkSignUpMock).toHaveBeenCalledWith(
+    expect(authShellMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        signInUrl: fullAuthUrl(
-          '/signin?desktop_return=%2Fstart%3Fintent_id%3Dabc'
-        ),
+        oppositeModeUrl: '/signin?desktop_return=%2Fstart%3Fintent_id%3Dabc',
         fallbackRedirectUrl: '/auth-return?route=%2Fstart%3Fintent_id%3Dabc',
       })
     );
@@ -252,13 +222,9 @@ describe('signup page', () => {
 
     render(<SignUpPage />);
 
-    await waitFor(() => {
-      expect(clerkSignUpMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(clerkSignUpMock).toHaveBeenCalledWith(
+    expect(authShellMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        signInUrl: fullAuthUrl('/signin?mobile_return=%2Fapp'),
+        oppositeModeUrl: '/signin?mobile_return=%2Fapp',
         fallbackRedirectUrl: '/mobile-auth-return?route=%2Fapp',
       })
     );
@@ -269,10 +235,6 @@ describe('signup page', () => {
     validatePlanMock.mockReturnValue(null);
 
     render(<SignUpPage />);
-
-    await waitFor(() => {
-      expect(clerkSignUpMock).toHaveBeenCalledTimes(1);
-    });
 
     expect(validatePlanMock).toHaveBeenCalledWith('not-a-plan');
     expect(setPlanIntentMock).not.toHaveBeenCalled();
@@ -290,10 +252,6 @@ describe('signup page', () => {
     render(<SignUpPage />);
 
     await waitFor(() => {
-      expect(clerkSignUpMock).toHaveBeenCalledTimes(1);
-    });
-
-    await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
         '/api/handle/check?handle=quotacase',
         expect.objectContaining({
@@ -302,7 +260,7 @@ describe('signup page', () => {
       );
     });
 
-    expect(screen.getByTestId('clerk-sign-up')).toBeInTheDocument();
+    expect(screen.getByTestId('auth-shell')).toBeInTheDocument();
     setItemSpy.mockRestore();
   });
 
@@ -355,11 +313,9 @@ describe('signup page', () => {
       );
     });
 
-    expect(clerkSignUpMock).toHaveBeenCalledWith(
+    expect(authShellMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        signInUrl: fullAuthUrl(
-          '/signin?redirect_url=%2Fonboarding%3Fhandle%3Dartist'
-        ),
+        oppositeModeUrl: '/signin?redirect_url=%2Fonboarding%3Fhandle%3Dartist',
       })
     );
   });
@@ -378,19 +334,5 @@ describe('signup page', () => {
     const alert = screen.getByRole('alert');
     expect(alert).toHaveTextContent('artist@example.com');
     expect(alert).toHaveTextContent('already exists');
-  });
-
-  it('passes oidcPrompt=select_account to Clerk SignUp so account chooser always appears', async () => {
-    render(<SignUpPage />);
-
-    await waitFor(() => {
-      expect(clerkSignUpMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(clerkSignUpMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        oidcPrompt: 'select_account',
-      })
-    );
   });
 });

--- a/apps/web/tests/unit/auth/AuthShell.test.tsx
+++ b/apps/web/tests/unit/auth/AuthShell.test.tsx
@@ -1,53 +1,52 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
-  clerkRenderState,
-  clerkSignInMock,
-  clerkSignUpMock,
+  authResourceState,
   providerEnabledState,
   searchParamsState,
+  signInSsoMock,
+  signUpSsoMock,
 } = vi.hoisted(() => ({
-  clerkRenderState: {
-    signIn: 'empty' as 'empty' | 'credential' | 'social',
+  authResourceState: {
+    clerkLoaded: true,
+    signInLoaded: true,
+    signUpLoaded: true,
   },
-  clerkSignInMock: vi.fn(),
-  clerkSignUpMock: vi.fn(),
   providerEnabledState: {
     google: true,
     apple: true,
   },
   searchParamsState: { value: '' },
+  signInSsoMock: vi.fn(),
+  signUpSsoMock: vi.fn(),
 }));
 
 vi.mock('@clerk/nextjs', () => ({
-  SignIn: (props: unknown) => {
-    clerkSignInMock(props);
-
-    if (clerkRenderState.signIn === 'credential') {
-      return (
-        <form data-testid='clerk-sign-in'>
-          <input name='identifier' type='text' />
-          <input name='password' type='password' />
-          <button type='submit'>Continue</button>
-        </form>
-      );
-    }
-
-    if (clerkRenderState.signIn === 'social') {
-      return (
-        <div data-testid='clerk-sign-in'>
-          <button type='button'>Continue with Google</button>
-        </div>
-      );
-    }
-
-    return <div data-testid='clerk-sign-in' />;
-  },
-  SignUp: (props: unknown) => {
-    clerkSignUpMock(props);
-    return <div data-testid='clerk-sign-up' />;
-  },
+  useClerk: () => ({
+    loaded: authResourceState.clerkLoaded,
+  }),
+  useSignIn: () =>
+    authResourceState.signInLoaded
+      ? {
+          signIn: {
+            sso: signInSsoMock,
+          },
+        }
+      : {
+          signIn: null,
+        },
+  useSignUp: () =>
+    authResourceState.signUpLoaded
+      ? {
+          signUp: {
+            sso: signUpSsoMock,
+          },
+        }
+      : {
+          signUp: null,
+        },
 }));
 
 vi.mock('next/navigation', () => ({
@@ -74,121 +73,34 @@ vi.mock('@/lib/auth/oauth-providers', async () => {
 });
 
 import { authClerkLocalization } from '@/components/providers/clerkLocalization';
+import { APP_ROUTES } from '@/constants/routes';
 import { AuthShell } from '@/features/auth';
 
-describe('AuthShell — JOV-2446 SSO-only contract', () => {
+function expectNoCredentialInputs(container: HTMLElement) {
+  expect(
+    container.querySelector(
+      'input[name="identifier"], input[name="emailAddress"], input[type="email"], input[type="password"]'
+    )
+  ).toBeNull();
+}
+
+describe('AuthShell — JOV-2778 app-owned SSO-only contract', () => {
   beforeEach(() => {
-    clerkRenderState.signIn = 'empty';
-    clerkSignInMock.mockReset();
-    clerkSignUpMock.mockReset();
+    authResourceState.clerkLoaded = true;
+    authResourceState.signInLoaded = true;
+    authResourceState.signUpLoaded = true;
     providerEnabledState.google = true;
     providerEnabledState.apple = true;
     searchParamsState.value = '';
-  });
-
-  it('keeps required provider and last-used badge layout guards after caller overrides', async () => {
-    render(
-      <AuthShell
-        mode='sign-in'
-        appearance={{
-          elements: {
-            lastAuthenticationStrategyBadge: {
-              position: 'absolute',
-              transform: 'translate(10px, -50%)',
-            },
-            socialButtonsBlockButton: {
-              backgroundColor: 'rgb(1, 2, 3)',
-              display: 'grid',
-              overflow: 'hidden',
-            },
-            socialButtonsBlockButton__facebook: 'block',
-          },
-        }}
-      />
-    );
-
-    await waitFor(() => {
-      expect(clerkSignInMock).toHaveBeenCalledTimes(1);
-    });
-
-    const signInProps = clerkSignInMock.mock.calls[0]?.[0] as {
-      readonly appearance?: {
-        readonly elements?: Record<string, unknown>;
-      };
-    };
-    const elements = signInProps.appearance?.elements;
-
-    expect(elements?.socialButtonsBlockButton).toEqual(
-      expect.objectContaining({
-        backgroundColor: 'rgb(1, 2, 3)',
-        display: 'flex',
-        justifyContent: 'center',
-        overflow: 'visible',
-        position: 'relative',
-      })
-    );
-    expect(elements?.lastAuthenticationStrategyBadge).toEqual(
-      expect.objectContaining({
-        position: 'static',
-        transform: 'none',
-        whiteSpace: 'nowrap',
-      })
-    );
-    expect(elements?.socialButtonsBlockButton__facebook).toBe('hidden');
-  });
-
-  it('hides every credential element via appearance.elements (E1 defense in depth)', async () => {
-    render(<AuthShell mode='sign-in' />);
-
-    await waitFor(() => {
-      expect(clerkSignInMock).toHaveBeenCalledTimes(1);
-    });
-
-    const elements = (
-      clerkSignInMock.mock.calls[0]?.[0] as {
-        readonly appearance?: { readonly elements?: Record<string, unknown> };
-      }
-    ).appearance?.elements;
-
-    const HIDE_ELEMENT_STYLE = { display: 'none !important' };
-    // Row containers
-    expect(elements?.formFieldRow__identifier).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formFieldRow__emailAddress).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formFieldRow__password).toEqual(HIDE_ELEMENT_STYLE);
-    // Field wrappers
-    expect(elements?.formField__identifier).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formField__emailAddress).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formField__password).toEqual(HIDE_ELEMENT_STYLE);
-    // Inputs themselves
-    expect(elements?.formFieldInput__identifier).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formFieldInput__emailAddress).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formFieldInput__password).toEqual(HIDE_ELEMENT_STYLE);
-    // Labels
-    expect(elements?.formFieldLabel__identifier).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formFieldLabel__emailAddress).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formFieldLabel__password).toEqual(HIDE_ELEMENT_STYLE);
-    // Username/phone (forbidden by audit; assert defense-in-depth hides)
-    expect(elements?.formFieldRow__username).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formField__username).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formFieldInput__username).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formFieldLabel__username).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formFieldRow__phoneNumber).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formField__phoneNumber).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formFieldInput__phoneNumber).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formFieldLabel__phoneNumber).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formattedPhoneNumberInput).toEqual(HIDE_ELEMENT_STYLE);
-    // Verification-step fields
-    expect(elements?.formFieldInput__code).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.otpCodeFieldInput).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.formResendCodeLink).toEqual(HIDE_ELEMENT_STYLE);
-    // Form chrome
-    expect(elements?.formButtonPrimary).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.dividerRow).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.alternativeMethods).toEqual(HIDE_ELEMENT_STYLE);
-    expect(elements?.alternativeMethodsBlockButton).toEqual(HIDE_ELEMENT_STYLE);
+    signInSsoMock.mockReset();
+    signInSsoMock.mockResolvedValue({ error: null });
+    signUpSsoMock.mockReset();
+    signUpSsoMock.mockResolvedValue({ error: null });
   });
 
   it('renders stable full-label provider slots before Clerk is ready', () => {
+    authResourceState.signInLoaded = false;
+
     const { container } = render(<AuthShell mode='sign-in' />);
 
     expect(
@@ -197,9 +109,12 @@ describe('AuthShell — JOV-2446 SSO-only contract', () => {
     expect(
       container.querySelector('[data-auth-provider-slot="apple"]')
     ).toHaveTextContent('Continue with Apple');
+    expectNoCredentialInputs(container);
   });
 
   it('placeholder skeleton renders no input, no "or" divider, has animate-pulse + data-loading', () => {
+    authResourceState.signInLoaded = false;
+
     const { container } = render(<AuthShell mode='sign-in' />);
 
     const placeholder = container.querySelector(
@@ -214,13 +129,14 @@ describe('AuthShell — JOV-2446 SSO-only contract', () => {
     );
     expect(placeholder).toHaveAttribute('aria-busy', 'true');
     expect(placeholder?.classList.contains('animate-pulse')).toBe(true);
-    expect(placeholder?.querySelector('input')).toBeNull();
+    expect(
+      placeholder?.querySelector('[data-auth-oauth-error-slot]')
+    ).toHaveAttribute('aria-hidden', 'true');
+    expectNoCredentialInputs(container);
     expect(placeholder?.textContent ?? '').not.toMatch(/\bor\b/);
   });
 
-  it('releases the placeholder when Clerk renders a social-only start state', async () => {
-    clerkRenderState.signIn = 'social';
-
+  it('renders a ready sign-in SSO surface without mounting credential inputs', async () => {
     const { container } = render(<AuthShell mode='sign-in' />);
 
     await waitFor(() => {
@@ -229,57 +145,124 @@ describe('AuthShell — JOV-2446 SSO-only contract', () => {
         'true'
       );
     });
+
+    expect(container.querySelector('[data-auth-sso-surface]')).not.toBeNull();
     expect(
       container.querySelector('[data-auth-stable-placeholder]')
     ).toBeNull();
+    expectNoCredentialInputs(container);
+    expect(container.textContent ?? '').not.toMatch(/\bor\b/);
   });
 
-  it('keeps placeholder up when Clerk regresses to a credential-only start (prevention test for dashboard regression)', async () => {
-    // JOV-2446 contract: if Clerk's dashboard regresses and only credential
-    // inputs render, the readiness signal must NOT fire. The placeholder
-    // stays up, regression is visible to the Layer A canary, and the
-    // config-audit cron alerts within 30 min.
-    clerkRenderState.signIn = 'credential';
+  it('starts Google sign-in through Clerk redirect with the canonical callback and account chooser', async () => {
+    const user = userEvent.setup();
 
+    render(
+      <AuthShell mode='sign-in' fallbackRedirectUrl='/app?source=auth-test' />
+    );
+
+    const googleButton = await screen.findByRole('button', {
+      name: /continue with google/i,
+    });
+    await user.click(googleButton);
+
+    expect(signInSsoMock).toHaveBeenCalledWith({
+      oidcPrompt: 'select_account',
+      redirectCallbackUrl: '/signin/sso-callback',
+      redirectUrl: '/app?source=auth-test',
+      strategy: 'oauth_google',
+    });
+    expect(signUpSsoMock).not.toHaveBeenCalled();
+  });
+
+  it('starts Apple sign-up through Clerk redirect with the sign-up callback and legal acceptance', async () => {
+    const user = userEvent.setup();
+
+    render(<AuthShell mode='sign-up' />);
+
+    const appleButton = await screen.findByRole('button', {
+      name: /continue with apple/i,
+    });
+    await user.click(appleButton);
+
+    expect(signUpSsoMock).toHaveBeenCalledWith({
+      legalAccepted: true,
+      oidcPrompt: 'select_account',
+      redirectCallbackUrl: '/signup/sso-callback',
+      redirectUrl: APP_ROUTES.WAITLIST,
+      strategy: 'oauth_apple',
+    });
+    expect(signInSsoMock).not.toHaveBeenCalled();
+  });
+
+  it('renders a stable inline error when the OAuth redirect cannot start', async () => {
+    const user = userEvent.setup();
+    signInSsoMock.mockRejectedValueOnce(new Error('oauth down'));
+
+    render(<AuthShell mode='sign-in' />);
+
+    const googleButton = await screen.findByRole('button', {
+      name: /continue with google/i,
+    });
+    await user.click(googleButton);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not start sign-in. Please try again.'
+    );
+    expect(googleButton).toBeEnabled();
+  });
+
+  it('renders a stable inline error when Clerk returns an SSO error object', async () => {
+    const user = userEvent.setup();
+    signInSsoMock.mockResolvedValueOnce({
+      error: new Error('oauth unavailable'),
+    });
+
+    render(<AuthShell mode='sign-in' />);
+
+    const googleButton = await screen.findByRole('button', {
+      name: /continue with google/i,
+    });
+    await user.click(googleButton);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not start sign-in. Please try again.'
+    );
+    expect(googleButton).toBeEnabled();
+  });
+
+  it('/signin cross-link points to /support (Need help), not /waitlist', async () => {
     const { container } = render(<AuthShell mode='sign-in' />);
 
-    // Wait deterministically for MutationObserver-driven ready state to settle false (JOV-2446 Clerk regression guard).
-    await waitFor(() =>
+    await waitFor(() => {
       expect(container.firstElementChild).toHaveAttribute(
         'data-auth-shell-ready',
-        'false'
-      )
-    );
+        'true'
+      );
+    });
 
-    expect(
-      container.querySelector('[data-auth-stable-placeholder]')
-    ).not.toBeNull();
-  });
-
-  it('/signin cross-link points to /support (Need help), not /waitlist', () => {
-    const { container } = render(<AuthShell mode='sign-in' />);
-
-    const link = container.querySelector(
-      '[data-auth-stable-placeholder] a[href]'
-    );
-    expect(link).not.toBeNull();
-    expect(link?.getAttribute('href')).toContain('/support');
-    expect(link?.textContent ?? '').toMatch(/get help/i);
-    const prompt = link?.parentElement?.textContent ?? '';
-    expect(prompt).toMatch(/need help/i);
+    const link = screen.getByRole('link', { name: /get help/i });
+    expect(link).toHaveAttribute('href', '/support');
+    expect(link.parentElement?.textContent ?? '').toMatch(/need help/i);
     // Anti-regression: must not point at /waitlist
-    expect(link?.getAttribute('href')).not.toContain('/waitlist');
+    expect(link).not.toHaveAttribute(
+      'href',
+      expect.stringContaining('/waitlist')
+    );
   });
 
-  it('/signup cross-link still points to /signin (Have an account)', () => {
+  it('/signup cross-link still points to /signin (Have an account)', async () => {
     const { container } = render(<AuthShell mode='sign-up' />);
 
-    const link = container.querySelector(
-      '[data-auth-stable-placeholder] a[href]'
-    );
-    expect(link).not.toBeNull();
-    expect(link?.getAttribute('href')).toContain('/signin');
-    expect(link?.textContent ?? '').toMatch(/sign in/i);
+    await waitFor(() => {
+      expect(container.firstElementChild).toHaveAttribute(
+        'data-auth-shell-ready',
+        'true'
+      );
+    });
+
+    const link = screen.getByRole('link', { name: /sign in/i });
+    expect(link).toHaveAttribute('href', '/signin');
   });
 
   it('renders AuthProvidersUnavailable when zero OAuth providers are enabled', () => {
@@ -304,8 +287,7 @@ describe('AuthShell — JOV-2446 SSO-only contract', () => {
       'href',
       'mailto:support@jov.ie'
     );
-    // Clerk is NOT mounted on the unavailable surface.
-    expect(clerkSignInMock).not.toHaveBeenCalled();
+    expect(signInSsoMock).not.toHaveBeenCalled();
   });
 
   it('keeps legal copy in stable line groups with valid fallback hrefs', () => {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2778 -->

## Summary
- Replace Clerk prebuilt auth forms in `AuthShell` with app-owned Google and Apple SSO buttons backed by Clerk future-resource `sso(...)`.
- Keep the stable loading, unavailable, cross-link, and legal-copy states while preventing credential inputs from mounting.
- Update auth unit, page, E2E, and README coverage for the SSO-only contract.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/auth/AuthShell.test.tsx tests/unit/auth/AuthProviderButtons.test.tsx tests/unit/app/signin-page.test.tsx tests/unit/app/signup-page.test.tsx`
- `pnpm biome check --write apps/web/components/features/auth/AuthShell.tsx apps/web/components/features/auth/AuthProviderButtons.tsx apps/web/tests/unit/auth/AuthShell.test.tsx apps/web/tests/unit/auth/AuthProviderButtons.test.tsx apps/web/tests/unit/app/signin-page.test.tsx apps/web/tests/unit/app/signup-page.test.tsx apps/web/tests/e2e/auth-pages.spec.ts apps/web/app/(auth)/README.md`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web exec playwright test tests/e2e/auth-pages.spec.ts --project=chromium`
- Pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`
- Local browser check: `http://localhost:3100/signin` renders the auth-unavailable fallback in the mock-key environment; DOM/screenshot inspection confirmed the fallback path and the E2E spec covers that fail-closed state.

## Risk
- Auth UI start path changed from Clerk prebuilt components to Clerk future-resource APIs. Typecheck and focused `AuthShell` tests cover the exact `sso(...)` params for sign-in and sign-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication documentation to reflect SSO-only sign-in and sign-up flows with OAuth provider buttons.

* **Feature Changes**
  * Removed email credential input from authentication pages; system now uses OAuth-only sign-in and sign-up surfaces.

* **Improvements**
  * Enhanced redirect URL sanitization and authentication unavailable state handling for improved error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->