### PR TITLE
fix(auth): align canary with owned sso surface

### DIFF
--- a/apps/web/tests/e2e/auth-public-ready.spec.ts
+++ b/apps/web/tests/e2e/auth-public-ready.spec.ts
@@ -42,13 +42,13 @@ function expectPublicAuthReady(pathname: string) {
     });
     await expect(page.locator('[data-auth-stable-placeholder]')).toHaveCount(0);
 
-    const clerkSurface = page.locator('[data-auth-clerk-surface]').first();
-    await expect(clerkSurface).toBeVisible({
+    const ssoSurface = page.locator('[data-auth-sso-surface]').first();
+    await expect(ssoSurface).toBeVisible({
       timeout: SMOKE_TIMEOUTS.VISIBILITY,
     });
-    await expect(clerkSurface).not.toHaveAttribute('aria-hidden', 'true');
+    await expect(ssoSurface).not.toHaveAttribute('aria-hidden', 'true');
 
-    const surfaceState = await clerkSurface.evaluate(element => {
+    const surfaceState = await ssoSurface.evaluate(element => {
       const style = window.getComputedStyle(element);
       return {
         opacity: style.opacity,
@@ -64,8 +64,8 @@ function expectPublicAuthReady(pathname: string) {
 
     const liveAuthControls = page.locator(
       [
-        '[data-auth-clerk-surface] button:not([disabled])',
-        '[data-auth-clerk-surface] input:not([disabled])',
+        '[data-auth-sso-surface] button[data-auth-provider-slot]:not([disabled])',
+        '[data-auth-sso-surface] input:not([disabled])',
       ].join(', ')
     );
     await expect(liveAuthControls.first()).toBeVisible({
@@ -76,12 +76,12 @@ function expectPublicAuthReady(pathname: string) {
 
 test.describe('public auth readiness @production-smoke', () => {
   test(
-    'signin replaces the disabled placeholder with live Clerk controls',
+    'signin replaces the disabled placeholder with owned SSO controls',
     expectPublicAuthReady(APP_ROUTES.SIGNIN)
   );
 
   test(
-    'signup replaces the disabled placeholder with live Clerk controls',
+    'signup replaces the disabled placeholder with owned SSO controls',
     expectPublicAuthReady(APP_ROUTES.SIGNUP)
   );
 });


### PR DESCRIPTION
## Summary

- Updates the public auth readiness canary to assert the app-owned SSO surface shipped in JOV-2778 / PR #10069.
- Replaces stale `[data-auth-clerk-surface]` expectations with `[data-auth-sso-surface]` and enabled `[data-auth-provider-slot]` controls.

## Verification

- `./scripts/setup.sh` completed for this fresh worktree.
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/tests/e2e/auth-public-ready.spec.ts` passed.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/ci/deploy-workflow.test.ts` passed: 10 tests.
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` passed.
- `JOVIE_AGENT_PROFILE=coder NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 BASE_URL=http://127.0.0.1:3100 pnpm --filter @jovie/web exec playwright test tests/e2e/auth-public-ready.spec.ts --project=chromium --reporter=line` passed in local skip mode: auth setup passed, two public auth tests skipped because local mock/proxy-disabled mode is not a real Clerk runtime.
- Commit hook passed staged Biome, ESLint, and local web typecheck.
- Pre-push passed repo Biome, proxy guard, Tailwind guard, web typecheck, and web lint.

## Notes

The non-skipped version of `auth-public-ready.spec.ts` requires the staging deployment URL plus Vercel bypass and real Clerk runtime, so the next staging canary is the integration proof for JOV-2780.

Fixes JOV-2780.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authentication verification tests for SSO surface readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->