### PR TITLE
fix(web): tokenize table system b chrome

### DIFF
--- a/apps/web/components/organisms/table/atoms/ShellListRowFrame.test.tsx
+++ b/apps/web/components/organisms/table/atoms/ShellListRowFrame.test.tsx
@@ -20,7 +20,7 @@ describe('ShellListRowFrame', () => {
     const row = getByTestId('row');
     expect(row).toHaveAttribute('data-shell-list-row', 'true');
     expect(row).toHaveAttribute('data-selected', 'true');
-    expect(row.className).toContain('bg-(--linear-row-selected)');
+    expect(row.className).toContain('system-b-table-row-selected');
     expect(row.className).toContain('cursor-pointer');
     expect(row.className).toContain('h-14');
   });
@@ -31,8 +31,7 @@ describe('ShellListRowFrame', () => {
       isSelected: false,
     });
 
-    expect(className).toContain('group-hover/task-row:bg-(--linear-row-hover)');
-    expect(className).toContain('group-focus-visible/task-row:bg-');
+    expect(className).toContain('system-b-shell-list-task-row-hover');
     expect(className).not.toContain('cursor-pointer');
   });
 
@@ -48,7 +47,7 @@ describe('ShellListRowFrame', () => {
     expect(row).toHaveAttribute('type', 'button');
     expect(row).toHaveAttribute('data-shell-list-row', 'true');
     expect(row).toHaveAttribute('data-selected', 'true');
-    expect(row.className).toContain('bg-(--linear-row-selected)');
+    expect(row.className).toContain('system-b-table-row-selected');
     expect(row.className).toContain('cursor-pointer');
     expect(row.className).toContain('px-3');
   });

--- a/apps/web/components/organisms/table/atoms/ShellListRowFrame.tsx
+++ b/apps/web/components/organisms/table/atoms/ShellListRowFrame.tsx
@@ -19,13 +19,10 @@ export interface ShellListRowButtonProps
 
 function getTaskRowGroupState(isSelected: boolean): string {
   if (isSelected) {
-    return cn(
-      rowState.selected,
-      'group-hover/task-row:bg-(--linear-row-selected) group-focus-visible/task-row:bg-(--linear-row-selected) group-focus-visible/task-row:shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_24%,transparent)]'
-    );
+    return cn(rowState.selected, 'system-b-shell-list-task-row-selected');
   }
 
-  return 'group-hover/task-row:bg-(--linear-row-hover) group-focus-visible/task-row:bg-(--linear-row-hover) group-focus-visible/task-row:shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_45%,transparent)]';
+  return 'system-b-shell-list-task-row-hover';
 }
 
 export function getShellListRowFrameClassName({

--- a/apps/web/components/organisms/table/atoms/SkeletonCell.tsx
+++ b/apps/web/components/organisms/table/atoms/SkeletonCell.tsx
@@ -43,8 +43,8 @@ export function SkeletonCell({
       >
         <div className='mt-0.5 h-4 w-4 shrink-0 rounded skeleton' />
         <div className='min-w-0 flex-1 space-y-0.5'>
-          <div className='h-3 w-[56%] rounded-sm skeleton' />
-          <div className='h-2.5 w-[38%] rounded-sm skeleton' />
+          <div className='system-b-table-skeleton-release-title rounded-sm skeleton' />
+          <div className='system-b-table-skeleton-release-meta rounded-sm skeleton' />
         </div>
       </div>
     );
@@ -54,7 +54,7 @@ export function SkeletonCell({
     return (
       <div
         className={cn(
-          'ml-auto grid min-w-[154px] grid-cols-[minmax(0,1fr)_12px_28px] items-center gap-x-1',
+          'system-b-table-skeleton-meta-grid ml-auto grid items-center gap-x-1',
           className
         )}
         style={{ width }}

--- a/apps/web/components/organisms/table/table.styles.test.ts
+++ b/apps/web/components/organisms/table/table.styles.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  alignment,
+  columnWidths,
+  presets,
+  rowState,
+  selection,
+} from './table.styles';
+
+const TABLE_STYLE_SOURCE = readFileSync(
+  join(process.cwd(), 'components/organisms/table/table.styles.ts'),
+  'utf8'
+);
+const SHELL_LIST_ROW_SOURCE = readFileSync(
+  join(process.cwd(), 'components/organisms/table/atoms/ShellListRowFrame.tsx'),
+  'utf8'
+);
+const SKELETON_CELL_SOURCE = readFileSync(
+  join(process.cwd(), 'components/organisms/table/atoms/SkeletonCell.tsx'),
+  'utf8'
+);
+
+describe('table System B style exports', () => {
+  it('routes table row states, sticky headers, and fixed sizing through named System B classes', () => {
+    expect(alignment.rowHeight).toBe('system-b-table-row-height');
+    expect(rowState.selected).toBe('system-b-table-row-selected');
+    expect(rowState.focusVisible).toBe('system-b-table-row-focus-visible');
+    expect(selection.checked).toBe('system-b-table-selection-checked');
+    expect(columnWidths.small).toBe('system-b-table-column-small');
+    expect(columnWidths.actions).toBe('system-b-table-column-actions');
+    expect(presets.stickyHeader).toContain('system-b-table-sticky-header');
+    expect(presets.tableRow).toContain('system-b-table-row-shell');
+  });
+
+  it('keeps shared table primitives free of local visual literals', () => {
+    const source = [
+      TABLE_STYLE_SOURCE,
+      SHELL_LIST_ROW_SOURCE,
+      SKELETON_CELL_SOURCE,
+    ].join('\n');
+
+    expect(source).not.toMatch(/\b(?:bg|shadow|ring|border|w|min-w|h)-\[/);
+    expect(source).not.toMatch(/color-mix\(|rgba?\(|#[0-9a-fA-F]{3,8}\b/);
+    expect(source).not.toMatch(/group-(?:hover|focus-visible)\/task-row:bg-/);
+  });
+});

--- a/apps/web/components/organisms/table/table.styles.ts
+++ b/apps/web/components/organisms/table/table.styles.ts
@@ -18,7 +18,7 @@ export const typography = {
 export const alignment = {
   checkboxCell: 'flex items-center justify-center', // Center checkbox
   numberCell: 'flex items-center justify-end tabular-nums', // Right-align numbers
-  rowHeight: 'h-[40px]', // Comfortable density with room for two-line cells
+  rowHeight: 'system-b-table-row-height', // Comfortable density with room for two-line cells
   cellPadding: 'px-3 py-1', // Balanced padding for cells
   headerPadding: 'px-3 py-1.5', // Slightly more header breathing room
   checkboxSize: 'h-3.5 w-3.5', // 14px checkbox
@@ -26,28 +26,20 @@ export const alignment = {
 
 // Row Selection Colors — aligned with Linear design tokens
 export const selection = {
-  unchecked:
-    'hover:bg-(--linear-row-hover) focus-within:bg-(--linear-row-hover) transition-[background-color,box-shadow] duration-subtle',
-  checked:
-    'bg-(--linear-row-selected) hover:bg-(--linear-row-selected) focus-within:bg-(--linear-row-selected) shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_28%,transparent)]',
-  selected:
-    'bg-(--linear-row-selected) shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_24%,transparent)]',
-  hover: 'hover:bg-(--linear-row-hover)',
+  unchecked: 'system-b-table-selection-unchecked',
+  checked: 'system-b-table-selection-checked',
+  selected: 'system-b-table-selection-selected',
+  hover: 'system-b-table-selection-hover',
 } as const;
 
 export const rowState = {
-  base: 'transition-[background-color,box-shadow] duration-subtle ease-out',
-  hover: 'hover:bg-(--linear-row-hover)',
-  focusVisible:
-    'focus-visible:outline-none focus-visible:bg-(--linear-row-hover) focus-visible:shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_45%,transparent)]',
-  focusWithin:
-    'focus-within:bg-(--linear-row-hover) focus-within:shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_45%,transparent)]',
-  focused:
-    'bg-(--linear-row-hover) shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_35%,transparent)]',
-  selected:
-    'bg-(--linear-row-selected) hover:bg-(--linear-row-selected) shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_24%,transparent)]',
-  checked:
-    'bg-(--linear-row-selected) hover:bg-(--linear-row-selected) shadow-[inset_0_0_0_1px_color-mix(in_oklab,var(--linear-border-focus)_28%,transparent)]',
+  base: 'system-b-table-row-base',
+  hover: 'system-b-table-row-hover',
+  focusVisible: 'system-b-table-row-focus-visible',
+  focusWithin: 'system-b-table-row-focus-within',
+  focused: 'system-b-table-row-focused',
+  selected: 'system-b-table-row-selected',
+  checked: 'system-b-table-row-checked',
 } as const;
 
 // Icon Colors (use CSS variables where possible)
@@ -67,19 +59,19 @@ export const zIndex = {
 // Transition Timings — Linear uses 160ms cubic-bezier for bg
 export const transitions = {
   fast: 'transition-colors duration-fast ease-out',
-  standard: 'transition-colors duration-subtle ease-out',
-  slow: 'transition-colors duration-slow ease-out',
+  standard: 'transition-colors duration-fast ease-out',
+  slow: 'transition-colors duration-cinematic ease-out',
 } as const;
 
 // Column Widths (Standard)
 export const columnWidths = {
   checkbox: 'w-14', // 56px
   avatar: 'w-12', // 48px
-  small: 'w-[120px]',
-  medium: 'w-[160px]',
-  large: 'w-[200px]',
-  xlarge: 'w-[320px]',
-  actions: 'w-[140px]',
+  small: 'system-b-table-column-small',
+  medium: 'system-b-table-column-medium',
+  large: 'system-b-table-column-large',
+  xlarge: 'system-b-table-column-xlarge',
+  actions: 'system-b-table-column-actions',
 } as const;
 
 // Layout Stability - Fixed Heights to Prevent Layout Shift
@@ -137,19 +129,17 @@ export const presets = {
   stickyHeader: cn(
     'sticky top-0',
     zIndex.tableHeader,
-    'bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,transparent)] backdrop-blur-[14px]',
-    'shadow-[inset_0_-1px_0_color-mix(in_oklab,var(--linear-app-shell-border)_74%,transparent)]',
+    'system-b-table-sticky-header',
     'align-middle'
   ),
   stickyGroupHeader: cn(
     'sticky top-0',
     zIndex.groupHeader,
-    'bg-(--linear-app-content-surface)',
-    borders.groupHeader
+    'system-b-table-sticky-group-header'
   ),
   tableRow: cn(
     alignment.rowHeight,
-    'border-b border-[color-mix(in_oklab,var(--linear-app-frame-seam)_60%,transparent)]',
+    'system-b-table-row-shell',
     rowState.base,
     rowState.hover,
     rowState.focusWithin,

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2713,6 +2713,145 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   z-index: 150;
 }
 
+:where(.system-b-table-row-height) {
+  height: 40px;
+}
+
+:where(.system-b-table-column-small) {
+  width: 120px;
+}
+
+:where(.system-b-table-column-medium) {
+  width: 160px;
+}
+
+:where(.system-b-table-column-large) {
+  width: 200px;
+}
+
+:where(.system-b-table-column-xlarge) {
+  width: 320px;
+}
+
+:where(.system-b-table-column-actions) {
+  width: 140px;
+}
+
+:where(.system-b-table-row-shell) {
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 60%, transparent);
+}
+
+:where(.system-b-table-row-base),
+:where(.system-b-table-selection-unchecked) {
+  transition-duration: var(--system-b-duration-fast);
+  transition-property: background-color, box-shadow;
+  transition-timing-function: var(--system-b-ease);
+}
+
+:where(.system-b-table-row-hover):hover,
+:where(.system-b-table-row-focus-within):focus-within,
+:where(.system-b-table-row-focus-visible):focus-visible,
+:where(.system-b-table-row-focused),
+:where(.system-b-table-selection-hover):hover,
+:where(.system-b-table-selection-unchecked):hover,
+:where(.system-b-table-selection-unchecked):focus-within {
+  background: var(--linear-row-hover);
+}
+
+:where(.system-b-table-row-focus-visible):focus-visible {
+  outline: none;
+}
+
+:where(.system-b-table-row-focus-visible):focus-visible,
+:where(.system-b-table-row-focus-within):focus-within {
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklab, var(--linear-border-focus) 45%, transparent);
+}
+
+:where(.system-b-table-row-focused) {
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklab, var(--linear-border-focus) 35%, transparent);
+}
+
+:where(.system-b-table-row-selected),
+:where(.system-b-table-selection-selected) {
+  background: var(--linear-row-selected);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklab, var(--linear-border-focus) 24%, transparent);
+}
+
+:where(.system-b-table-row-selected):hover,
+:where(.system-b-table-row-checked):hover,
+:where(.system-b-table-selection-selected):hover,
+:where(.system-b-table-selection-checked):hover,
+:where(.system-b-table-selection-checked):focus-within {
+  background: var(--linear-row-selected);
+}
+
+:where(.system-b-table-row-checked),
+:where(.system-b-table-selection-checked) {
+  background: var(--linear-row-selected);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklab, var(--linear-border-focus) 28%, transparent);
+}
+
+:where(.system-b-table-sticky-header) {
+  background: color-mix(
+    in oklab,
+    var(--system-b-app-content-surface) 92%,
+    transparent
+  );
+  box-shadow: inset 0 -1px 0
+    color-mix(in oklab, var(--system-b-app-shell-border) 74%, transparent);
+}
+
+@supports (backdrop-filter: blur(1px)) {
+  :where(.system-b-table-sticky-header) {
+    backdrop-filter: blur(14px);
+  }
+}
+
+@supports (-webkit-backdrop-filter: blur(1px)) {
+  :where(.system-b-table-sticky-header) {
+    -webkit-backdrop-filter: blur(14px);
+  }
+}
+
+:where(.system-b-table-sticky-group-header) {
+  background: var(--system-b-app-content-surface);
+  border-bottom: 2px solid var(--color-border-subtle);
+}
+
+:where(.group\/task-row:hover, .group\/task-row:focus-visible)
+  :where(.system-b-shell-list-task-row-hover) {
+  background: var(--linear-row-hover);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklab, var(--linear-border-focus) 45%, transparent);
+}
+
+:where(.group\/task-row:hover, .group\/task-row:focus-visible)
+  :where(.system-b-shell-list-task-row-selected) {
+  background: var(--linear-row-selected);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in oklab, var(--linear-border-focus) 24%, transparent);
+}
+
+:where(.system-b-table-skeleton-release-title) {
+  height: 0.75rem;
+  width: 56%;
+}
+
+:where(.system-b-table-skeleton-release-meta) {
+  height: 0.625rem;
+  width: 38%;
+}
+
+:where(.system-b-table-skeleton-meta-grid) {
+  grid-template-columns: minmax(0, 1fr) 12px 28px;
+  min-width: 154px;
+}
+
 /* System B calendar route primitives */
 :where(.system-b-calendar-month-label) {
   min-width: calc(var(--space-24) + var(--space-10) + var(--space-4));

--- a/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.test.tsx
+++ b/apps/web/tests/components/features/dashboard/organisms/release-provider-matrix/shell-releases/ShellReleaseRow.test.tsx
@@ -72,8 +72,8 @@ describe('ShellReleaseRow audio affordance', () => {
     const row = container.querySelector('[data-shell-release-row]');
     expect(row).toHaveAttribute('aria-selected', 'true');
     expect(row).toHaveAttribute('data-selected', 'true');
-    expect(row?.className).toContain('bg-(--linear-row-selected)');
-    expect(row?.className).toContain('--linear-border-focus');
+    expect(row?.className).toContain('system-b-table-row-selected');
+    expect(row?.className).toContain('system-b-table-row-focus-visible');
   });
 
   it('uses the shell typography tokens for the release title and subtitle', () => {

--- a/apps/web/tests/components/release-provider-matrix/MobileReleaseList.test.tsx
+++ b/apps/web/tests/components/release-provider-matrix/MobileReleaseList.test.tsx
@@ -100,8 +100,8 @@ describe('MobileReleaseList', () => {
 
     const row = screen.getByTestId('mobile-release-row-release-1');
     expect(row).toHaveAttribute('data-shell-list-row', 'true');
-    expect(row.className).toContain('hover:bg-(--linear-row-hover)');
-    expect(row.className).toContain('focus-visible:bg-(--linear-row-hover)');
+    expect(row.className).toContain('system-b-table-row-hover');
+    expect(row.className).toContain('system-b-table-row-focus-visible');
 
     await user.click(row);
 

--- a/apps/web/tests/unit/admin/LeadTable.test.tsx
+++ b/apps/web/tests/unit/admin/LeadTable.test.tsx
@@ -164,7 +164,7 @@ describe('LeadTable', () => {
 
     const row = document.querySelector('tbody tr');
     // Canonical shell row via presets.tableRow / rowState (no explicit 'group' needed for this table)
-    expect(row).toHaveClass('hover:bg-(--linear-row-hover)');
+    expect(row).toHaveClass('system-b-table-row-hover');
   });
 
   it('renders status filter tabs', async () => {

--- a/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskListRow.test.tsx
@@ -74,7 +74,7 @@ describe('TaskListRow', () => {
       'true'
     );
     expect(getByTestId('task-list-row-task-1').className).toContain(
-      'bg-(--linear-row-selected)'
+      'system-b-table-row-selected'
     );
   });
 

--- a/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
+++ b/apps/web/tests/unit/dashboard/TasksPageClient.test.tsx
@@ -826,17 +826,17 @@ describe('TasksPageClient', () => {
 
     expect(
       getLatestTableProps()?.getRowClassName?.(mockTaskTwo, 0)
-    ).not.toContain('bg-(--linear-row-selected)');
+    ).not.toContain('system-b-table-row-selected');
 
     act(() => {
       getLatestTableProps()?.onRowClick?.(mockTaskTwo);
     });
 
     expect(getLatestTableProps()?.getRowClassName?.(mockTaskTwo, 0)).toContain(
-      'bg-(--linear-row-selected)'
+      'system-b-table-row-selected'
     );
     expect(getLatestTableProps()?.getRowClassName?.(mockTask, 1)).not.toContain(
-      'bg-(--linear-row-selected)'
+      'system-b-table-row-selected'
     );
   });
 

--- a/apps/web/tests/unit/organisms/table/VirtualizedTableRow.test.tsx
+++ b/apps/web/tests/unit/organisms/table/VirtualizedTableRow.test.tsx
@@ -112,7 +112,7 @@ describe('VirtualizedTableRow', () => {
 
     const row = screen.getByRole('row');
     expect(row).toHaveAttribute('aria-selected', 'true');
-    expect(row.className).toContain('bg-(--linear-row-selected)');
-    expect(row.className).toContain('--linear-border-focus');
+    expect(row.className).toContain('system-b-table-row-selected');
+    expect(row.className).toContain('system-b-table-row-focus-within');
   });
 });


### PR DESCRIPTION
## Summary

- Move shared table row, selection, sticky header, task-row hover, and skeleton geometry styles onto named System B primitives.
- Add a focused table style guard covering `table.styles`, `ShellListRowFrame`, and `SkeletonCell`.
- Keep the CSS change scoped to `system-b-table-*` / shell-list task row primitives.

Linear: JOV-2784

## Verification

- `pnpm biome check --write apps/web/components/organisms/table/table.styles.ts apps/web/components/organisms/table/table.styles.test.ts apps/web/components/organisms/table/atoms/ShellListRowFrame.tsx apps/web/components/organisms/table/atoms/ShellListRowFrame.test.tsx apps/web/components/organisms/table/atoms/SkeletonCell.tsx apps/web/styles/design-system.css`
- `pnpm --filter @jovie/web exec vitest run components/organisms/table/table.styles.test.ts components/organisms/table/atoms/ShellListRowFrame.test.tsx` (2 files, 5 tests)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Pre-push: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`

## Layout Audit

States checked by source and test inspection: default row, hover row, focus-visible row, focus-within row, selected row, checked row, sticky header, sticky group header, release skeleton, meta skeleton, task-row group hover/focus.

Dimensions are preserved from the previous literals: row height remains 40px, standard columns remain 120/160/200/320/140px, release skeleton lines remain 56% and 38%, and meta skeleton keeps the 154px minimum plus `minmax(0,1fr)_12px_28px` grid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated table row styling with enhanced visual indicators for selection, hover, and keyboard focus states, improving user feedback during interactions.
  * Refined skeleton placeholder styling for improved visual consistency and smoother appearance during content loading.

* **Tests**
  * Added comprehensive test coverage for table styling to ensure design consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->