### PR TITLE
fix(web): tokenize chat entity chip tones

### DIFF
--- a/apps/web/components/jovie/components/EntityChip.test.tsx
+++ b/apps/web/components/jovie/components/EntityChip.test.tsx
@@ -22,15 +22,15 @@ describe('EntityChip', () => {
     expect(chip.textContent).toContain('Sober');
     expect(chip.getAttribute('data-entity-kind')).toBe('release');
     expect(chip.style.getPropertyValue('--jovie-entity-accent')).toBe(
-      'var(--geist-purple-solid)'
+      'var(--system-b-entity-chip-release-accent)'
     );
   });
 
   it.each([
-    ['release', 'var(--geist-purple-solid)'],
-    ['artist', 'var(--geist-blue-solid)'],
-    ['track', 'var(--geist-pink-solid)'],
-    ['event', 'var(--geist-green-solid)'],
+    ['release', 'var(--system-b-entity-chip-release-accent)'],
+    ['artist', 'var(--system-b-entity-chip-artist-accent)'],
+    ['track', 'var(--system-b-entity-chip-track-accent)'],
+    ['event', 'var(--system-b-entity-chip-event-accent)'],
   ] as const)('maps kind=%s to the correct accent variable', (kind, accent) => {
     fastRender(
       <EntityChip
@@ -43,6 +43,21 @@ describe('EntityChip', () => {
         .getByTestId('entity-chip')
         .style.getPropertyValue('--jovie-entity-accent')
     ).toBe(accent);
+  });
+
+  it('keeps entity chip tones on System B aliases instead of legacy Geist tokens', () => {
+    fastRender(
+      <EntityChip
+        data={{ kind: 'artist', id: 'artist_1', label: 'Tim White' }}
+        variant='transcript'
+      />
+    );
+
+    const accent = screen
+      .getByTestId('entity-chip')
+      .style.getPropertyValue('--jovie-entity-accent');
+    expect(accent).toContain('--system-b-entity-chip-artist-accent');
+    expect(accent).not.toContain('geist');
   });
 
   it('renders thumbnail when provided', () => {

--- a/apps/web/components/jovie/components/EntityChip.tsx
+++ b/apps/web/components/jovie/components/EntityChip.tsx
@@ -38,10 +38,10 @@ const KIND_PREFIX: Record<EntityKind, string> = {
 };
 
 const KIND_ACCENT_VAR: Record<EntityKind, string> = {
-  release: '--geist-purple-solid',
-  artist: '--geist-blue-solid',
-  track: '--geist-pink-solid',
-  event: '--geist-green-solid',
+  release: '--system-b-entity-chip-release-accent',
+  artist: '--system-b-entity-chip-artist-accent',
+  track: '--system-b-entity-chip-track-accent',
+  event: '--system-b-entity-chip-event-accent',
 };
 
 /**

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -88,6 +88,11 @@
   --system-b-app-frame-seam: var(--app-shell-frame-seam);
   --system-b-app-content-surface: var(--app-shell-content-surface);
   --system-b-accent-cyan: var(--geist-cyan-solid);
+  --system-b-entity-chip-release-accent: var(--color-accent);
+  --system-b-entity-chip-artist-accent: var(--color-info);
+  --system-b-entity-chip-track-accent: var(--color-accent-pink);
+  --system-b-entity-chip-event-accent: var(--color-success);
+  --system-b-entity-chip-on-light-text: var(--color-text-primary-token);
   --system-b-duration-fast: var(--ds-motion-subtle-duration);
   --system-b-ease: var(--ds-motion-subtle-easing);
   --system-b-radius-pill: var(--radius-full);
@@ -2313,7 +2318,10 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
 .system-b-entity-chip[data-entity-variant="transcript"][data-entity-tone="onLight"] {
   border-color: color-mix(in srgb, var(--jovie-entity-accent) 30%, white);
   background: color-mix(in srgb, var(--jovie-entity-accent) 8%, white);
-  color: var(--system-b-entity-chip-on-light-text, #111216);
+  color: var(
+    --system-b-entity-chip-on-light-text,
+    var(--color-text-primary-token)
+  );
 }
 
 .system-b-entity-chip-thumbnail {

--- a/apps/web/tests/unit/chat/ChatInput.test.tsx
+++ b/apps/web/tests/unit/chat/ChatInput.test.tsx
@@ -525,7 +525,7 @@ describe('ChatInput', () => {
       within(inlineField).getByText('Performance Budget')
     ).toBeInTheDocument();
     expect(screen.getByTitle('Release: Performance Budget')).toHaveStyle({
-      '--jovie-entity-accent': 'var(--geist-purple-solid)',
+      '--jovie-entity-accent': 'var(--system-b-entity-chip-release-accent)',
     });
     expect(inlineField).toContainElement(
       screen.getByRole('textbox', { name: /chat message input/i })

--- a/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
@@ -18,6 +18,7 @@ const rawVisualPatterns = [
   /\b(?:text|rounded|shadow|border|bg|px|py|min-w|min-h|max-w|max-h|w|h|tracking|duration|z)-\[[^\]]+\]/,
   /\bfont-\[[^\]]+\]/,
   /tracking-\[-/,
+  new RegExp(['--', 'geist-'].join('')),
   /color-mix\s*\(\s*in\s+srgb/i,
   /\brgba?\(/,
   /#[0-9A-Fa-f]{3,8}\b/,


### PR DESCRIPTION
## Summary

- Replaces chat `EntityChip` legacy Geist tone variables with named System B entity-chip accent aliases.
- Adds System B entity-chip tone aliases to `design-system.css`, including a tokenized light-surface text fallback.
- Updates focused chip/chat tests and strengthens the rich-chip style guard so guarded rich-chip source cannot point back at legacy Geist tokens.

## Verification

- `pnpm exec biome check --write apps/web/components/jovie/components/EntityChip.tsx apps/web/components/jovie/components/EntityChip.test.tsx apps/web/tests/unit/chat/ChatInput.test.tsx apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts apps/web/styles/design-system.css`
- `pnpm --filter @jovie/web exec vitest run components/jovie/components/EntityChip.test.tsx tests/unit/chat/ChatInput.test.tsx tests/unit/chat/TokenizedText.test.tsx tests/unit/chat/entity-rich-chip-style-guard.test.ts` — 4 files, 36 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Token compliance script for `EntityChip` source + new `--system-b-entity-chip-*` aliases: pass
- Playwright proof: `.gstack/design-reports/screenshots/jov-2786-entitychip-system-b-proof.png`; chip boxes stayed at 30px input / 26px transcript across input, transcript dark, transcript light, and thumbnail states.

Linear: JOV-2786


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated entity chip styling to use System B design tokens, ensuring consistency across release, artist, track, and event entities.
  * Enhanced style validation to prevent legacy token usage in entity components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->