### PR TITLE
fix(web): tokenize settings usage tones

### DIFF
--- a/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
+++ b/apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx
@@ -53,14 +53,26 @@ function formatResetAt(value: string | null | undefined): string {
 
 function getStatusToneClasses(state: ChatUsageState): string {
   if (state === 'healthy') {
-    return 'border-[color-mix(in_oklab,var(--geist-cyan-solid)_24%,transparent)] bg-[color-mix(in_oklab,var(--geist-cyan-solid)_10%,var(--linear-app-content-surface))] text-[color:var(--geist-cyan-solid)]';
+    return 'border-success/25 bg-success/10 text-success';
   }
 
   if (state === 'near_limit') {
-    return 'border-[color-mix(in_oklab,var(--geist-blue-solid)_24%,transparent)] bg-[color-mix(in_oklab,var(--geist-blue-solid)_10%,var(--linear-app-content-surface))] text-[color:var(--geist-blue-solid)]';
+    return 'border-warning/25 bg-warning/10 text-warning';
   }
 
-  return 'border-[color-mix(in_oklab,var(--geist-red-solid)_24%,transparent)] bg-[color-mix(in_oklab,var(--geist-red-solid)_10%,var(--linear-app-content-surface))] text-[color:var(--geist-red-solid)]';
+  return 'border-error/25 bg-error/10 text-error';
+}
+
+function getProgressToneClasses(state: ChatUsageState): string {
+  if (state === 'healthy') {
+    return 'bg-success/10 [&::-moz-progress-bar]:bg-success [&::-webkit-progress-bar]:bg-success/10 [&::-webkit-progress-value]:bg-success';
+  }
+
+  if (state === 'near_limit') {
+    return 'bg-warning/10 [&::-moz-progress-bar]:bg-warning [&::-webkit-progress-bar]:bg-warning/10 [&::-webkit-progress-value]:bg-warning';
+  }
+
+  return 'bg-error/10 [&::-moz-progress-bar]:bg-error [&::-webkit-progress-bar]:bg-error/10 [&::-webkit-progress-value]:bg-error';
 }
 
 function getMonthlyUsage(data: ChatUsageData): {
@@ -83,6 +95,7 @@ function getMonthlyUsage(data: ChatUsageData): {
 interface UsageMeterRowProps {
   readonly title: string;
   readonly description: string;
+  readonly state: ChatUsageState;
   readonly used: number;
   readonly limit: number;
   readonly remaining: number;
@@ -92,6 +105,7 @@ interface UsageMeterRowProps {
 function UsageMeterRow({
   title,
   description,
+  state,
   used,
   limit,
   remaining,
@@ -121,7 +135,10 @@ function UsageMeterRow({
           aria-label={`${title} usage`}
           value={clampedUsed}
           max={progressMax}
-          className='block h-2 w-full appearance-none overflow-hidden rounded-full bg-[color-mix(in_oklab,var(--geist-cyan-solid)_8%,var(--linear-app-content-surface))] [&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-[color:var(--geist-cyan-solid)] [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-bar]:bg-[color-mix(in_oklab,var(--geist-cyan-solid)_8%,var(--linear-app-content-surface))] [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-[color:var(--geist-cyan-solid)]'
+          className={cn(
+            'block h-2 w-full appearance-none overflow-hidden rounded-full [&::-moz-progress-bar]:rounded-full [&::-webkit-progress-bar]:rounded-full [&::-webkit-progress-value]:rounded-full',
+            getProgressToneClasses(state)
+          )}
         />
       </div>
       <p className='mt-2 text-2xs text-tertiary-token'>
@@ -281,6 +298,7 @@ export function SettingsUsageStatsSection() {
         <UsageMeterRow
           title='Daily Messages'
           description='Quota for the current 24-hour window.'
+          state={copy.state}
           used={data.used}
           limit={data.dailyLimit}
           remaining={data.remaining}
@@ -289,6 +307,7 @@ export function SettingsUsageStatsSection() {
         <UsageMeterRow
           title='Monthly Capacity'
           description='Plan capacity across the current calendar month.'
+          state={copy.state}
           used={monthly.used}
           limit={monthly.limit}
           remaining={monthly.remaining}

--- a/apps/web/tests/unit/dashboard/SettingsUsageStatsSection.test.tsx
+++ b/apps/web/tests/unit/dashboard/SettingsUsageStatsSection.test.tsx
@@ -1,9 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { SettingsUsageStatsSection } from '@/features/dashboard/organisms/SettingsUsageStatsSection';
 import type { ChatUsageData } from '@/lib/queries/useChatUsageQuery';
 
 const mockUseChatUsageQuery = vi.fn();
+const APP_ROOT = resolve(import.meta.dirname, '../../..');
+const COMPONENT_PATH =
+  'components/features/dashboard/organisms/SettingsUsageStatsSection.tsx';
+const LEGACY_GEIST_VAR_PATTERN = new RegExp(['--', 'geist-'].join(''));
+
+function readComponentSource() {
+  return readFileSync(resolve(APP_ROOT, COMPONENT_PATH), 'utf8');
+}
 
 vi.mock('@/lib/queries', () => ({
   useCheckoutMutation: () => ({
@@ -93,12 +103,14 @@ describe('SettingsUsageStatsSection', () => {
     expect(
       screen.getByRole('progressbar', { name: 'Daily Messages usage' })
         .className
-    ).toContain('bg-[color:var(--geist-cyan-solid)]');
+    ).toContain('[&::-webkit-progress-value]:bg-success');
     expect(
       screen.getByRole('progressbar', { name: 'Monthly Capacity usage' })
     ).toHaveAttribute('value', '24');
     expect(screen.getByText('Within Daily Limit')).toHaveClass(
-      'border-[color-mix(in_oklab,var(--geist-cyan-solid)_24%,transparent)]'
+      'border-success/25',
+      'bg-success/10',
+      'text-success'
     );
     expect(screen.getByText('6 left')).toBeInTheDocument();
     expect(screen.getByText('286 left')).toBeInTheDocument();
@@ -129,11 +141,62 @@ describe('SettingsUsageStatsSection', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Pro')).toBeInTheDocument();
     expect(screen.getByText('Near Daily Limit')).toHaveClass(
-      'border-[color-mix(in_oklab,var(--geist-blue-solid)_24%,transparent)]'
+      'border-warning/25',
+      'bg-warning/10',
+      'text-warning'
     );
+    expect(
+      screen.getByRole('progressbar', { name: 'Daily Messages usage' })
+        .className
+    ).toContain('[&::-webkit-progress-value]:bg-warning');
     expect(screen.getByRole('link', { name: /view plans/i })).toHaveAttribute(
       'href',
       '/pricing'
     );
+  });
+
+  it('renders exhausted state on semantic error tokens', () => {
+    mockUseChatUsageQuery.mockReturnValue({
+      data: {
+        ...baseUsage,
+        used: 10,
+        remaining: 0,
+        monthlyUsed: 310,
+        monthlyRemaining: 0,
+        isExhausted: true,
+      },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<SettingsUsageStatsSection />);
+
+    expect(
+      screen.getByText("You've reached today's chat limit")
+    ).toBeInTheDocument();
+    expect(screen.getByText('Daily Limit Reached')).toHaveClass(
+      'border-error/25',
+      'bg-error/10',
+      'text-error'
+    );
+    expect(
+      screen.getByRole('progressbar', { name: 'Daily Messages usage' })
+    ).toHaveAttribute('value', '10');
+    expect(
+      screen.getByRole('progressbar', { name: 'Daily Messages usage' })
+        .className
+    ).toContain('[&::-webkit-progress-value]:bg-error');
+  });
+
+  it('keeps usage tones on semantic tokens instead of legacy Geist variables', () => {
+    const source = readComponentSource();
+
+    expect(source).not.toMatch(LEGACY_GEIST_VAR_PATTERN);
+    expect(source).toContain('border-success/25');
+    expect(source).toContain('border-warning/25');
+    expect(source).toContain('border-error/25');
+    expect(source).toContain('[&::-webkit-progress-value]:bg-success');
+    expect(source).toContain('[&::-webkit-progress-value]:bg-warning');
+    expect(source).toContain('[&::-webkit-progress-value]:bg-error');
   });
 });


### PR DESCRIPTION
## Summary
- Replace settings usage badge and progress tones with semantic System B status utilities.
- Add near-limit and exhausted progress assertions plus a source guard against legacy Geist status vars.
- Preserve the existing usage panel structure and min-height-backed loading/empty/error geometry.

## Layout states audited
- Loading panel
- Empty state
- Error state
- Healthy usage
- Near-limit usage
- Exhausted usage
- Daily and monthly progress rows

## Verification
- `pnpm exec biome check --write apps/web/components/features/dashboard/organisms/SettingsUsageStatsSection.tsx apps/web/tests/unit/dashboard/SettingsUsageStatsSection.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/SettingsUsageStatsSection.test.tsx` (7 tests)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Source guard: no legacy Geist usage in the settings usage component/test slice
- Commit hook: proxy guard, Biome, ESLint, staged a11y, web typecheck
- Pre-push: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint

Linear: JOV-2787