### PR TITLE
fix(web): tokenize library shell accents

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -271,10 +271,10 @@ function formatLibraryStatus(asset: LibraryReleaseAsset): string {
 
 function releaseStatusClasses(status: LibraryReleaseAsset['status']): string {
   if (status === 'released') {
-    return 'border-[color-mix(in_oklab,var(--geist-cyan-solid)_24%,transparent)] bg-[color-mix(in_oklab,var(--geist-cyan-solid)_12%,var(--linear-app-content-surface))] text-[color:var(--geist-cyan-solid)]';
+    return 'border-success/20 bg-success/10 text-success';
   }
   if (status === 'scheduled') {
-    return 'border-[color-mix(in_oklab,var(--geist-blue-solid)_24%,transparent)] bg-[color-mix(in_oklab,var(--geist-blue-solid)_10%,var(--linear-app-content-surface))] text-[color:var(--geist-blue-solid)]';
+    return 'border-info/20 bg-info/10 text-info';
   }
   return 'border-subtle bg-surface-1 text-tertiary-token';
 }
@@ -282,9 +282,9 @@ function releaseStatusClasses(status: LibraryReleaseAsset['status']): string {
 function releaseStatusDotClasses(
   status: LibraryReleaseAsset['status']
 ): string {
-  if (status === 'released') return 'bg-[color:var(--geist-cyan-solid)]';
-  if (status === 'scheduled') return 'bg-[color:var(--geist-blue-solid)]';
-  return 'bg-white/35';
+  if (status === 'released') return 'bg-success';
+  if (status === 'scheduled') return 'bg-info';
+  return 'bg-muted';
 }
 
 function assetMatchesFilters(
@@ -684,8 +684,8 @@ function LibraryRail({
                 className={cn(
                   'flex h-8 w-full items-center gap-2 rounded-md border px-2 text-left text-[12.5px] transition-[background-color,border-color,color,box-shadow] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface) outline-none',
                   active
-                    ? 'border-[color-mix(in_oklab,var(--geist-cyan-solid)_20%,transparent)] bg-[color-mix(in_oklab,var(--geist-cyan-solid)_8%,var(--linear-app-content-surface))] text-primary-token'
-                    : 'border-transparent text-secondary-token hover:border-[color-mix(in_oklab,var(--geist-cyan-solid)_12%,transparent)] hover:bg-[color-mix(in_oklab,var(--geist-cyan-solid)_4%,var(--linear-app-content-surface))] hover:text-primary-token'
+                    ? 'border-default bg-surface-1 text-primary-token'
+                    : 'border-transparent text-secondary-token hover:border-default hover:bg-surface-1 hover:text-primary-token'
                 )}
               >
                 <span className='min-w-0 flex-1 truncate'>{view.label}</span>
@@ -705,7 +705,7 @@ function LibraryRail({
             <button
               type='button'
               onClick={onClearFilters}
-              className='rounded px-1.5 py-0.5 text-2xs text-tertiary-token transition-[background-color,color] duration-subtle ease-subtle hover:bg-[color-mix(in_oklab,var(--geist-cyan-solid)_5%,var(--linear-app-content-surface))] hover:text-primary-token'
+              className='rounded px-1.5 py-0.5 text-2xs text-tertiary-token transition-[background-color,color] duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token'
             >
               Clear Filters ({activeFilterCount})
             </button>
@@ -810,7 +810,7 @@ function FilterSection({
         aria-controls={panelId}
         aria-expanded={open}
         onClick={() => setOpen(value => !value)}
-        className='flex h-6 w-full items-center justify-between rounded-md px-1 text-[11px] font-medium text-tertiary-token transition-[background-color,color] duration-subtle ease-subtle hover:bg-[color-mix(in_oklab,var(--geist-cyan-solid)_4%,var(--linear-app-content-surface))] hover:text-primary-token'
+        className='flex h-6 w-full items-center justify-between rounded-md px-1 text-[11px] font-medium text-tertiary-token transition-[background-color,color] duration-subtle ease-subtle hover:bg-surface-1 hover:text-primary-token'
       >
         <span>{label}</span>
         <ChevronDown
@@ -856,8 +856,8 @@ function FilterRow({
       className={cn(
         'flex h-7 w-full items-center gap-2 rounded-md border px-2 text-[12px] transition-[background-color,border-color,color,box-shadow] duration-subtle ease-subtle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface) outline-none',
         active
-          ? 'border-[color-mix(in_oklab,var(--geist-cyan-solid)_20%,transparent)] bg-[color-mix(in_oklab,var(--geist-cyan-solid)_8%,var(--linear-app-content-surface))] text-primary-token'
-          : 'border-transparent text-secondary-token hover:border-[color-mix(in_oklab,var(--geist-cyan-solid)_12%,transparent)] hover:bg-[color-mix(in_oklab,var(--geist-cyan-solid)_4%,var(--linear-app-content-surface))] hover:text-primary-token'
+          ? 'border-default bg-surface-1 text-primary-token'
+          : 'border-transparent text-secondary-token hover:border-default hover:bg-surface-1 hover:text-primary-token'
       )}
     >
       {Icon ? (
@@ -871,7 +871,7 @@ function FilterRow({
       <span className='min-w-0 flex-1 truncate text-left'>{label}</span>
       <span className='text-2xs tabular-nums text-tertiary-token'>{count}</span>
       {active ? (
-        <Check className='h-3 w-3 shrink-0 text-[color:var(--geist-cyan-solid)]' />
+        <Check className='h-3 w-3 shrink-0 text-primary-token' />
       ) : null}
     </button>
   );
@@ -1032,14 +1032,14 @@ const AssetCard = memo(function AssetCard({
       className={cn(
         'group relative min-w-0 overflow-hidden rounded-lg border bg-surface-0 transition-[border-color,background-color] duration-subtle ease-subtle',
         selected
-          ? 'border-cyan-400/50 bg-surface-1'
+          ? 'border-default bg-surface-1'
           : 'border-subtle hover:border-default'
       )}
     >
       {selected ? (
         <span
           aria-hidden='true'
-          className='pointer-events-none absolute inset-0 rounded-lg shadow-[inset_2px_0_0_0_rgb(103_232_249),inset_0_0_0_1px_rgb(103_232_249_/_0.08)]'
+          className='pointer-events-none absolute inset-0 rounded-lg shadow-[inset_2px_0_0_0_var(--color-border-default),inset_0_0_0_1px_var(--color-border-subtle)]'
         />
       ) : null}
       <button
@@ -1204,7 +1204,7 @@ function LibraryDataTable({
   const getRowClassName = useCallback(
     (asset: LibraryReleaseAsset) =>
       asset.id === selectedId
-        ? 'bg-cyan-400/[0.08]! text-primary-token shadow-[inset_2px_0_0_0_rgb(103_232_249)]!'
+        ? 'bg-surface-1! text-primary-token shadow-[inset_2px_0_0_0_var(--color-border-default)]!'
         : '',
     [selectedId]
   );

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { TooltipProvider } from '@jovie/ui';
 import {
   fireEvent,
@@ -19,6 +21,20 @@ import {
 } from '@/contexts/ShellSidebarOverrideContext';
 
 Element.prototype.scrollIntoView = vi.fn();
+
+const LIBRARY_SURFACE_SOURCE = 'app/app/(shell)/library/LibrarySurface.tsx';
+const legacyGeistAccentPattern = new RegExp(
+  ['--', 'ge', 'ist-(?:cyan|blue)-solid'].join(''),
+  'u'
+);
+const legacySelectionAccentPatterns = [
+  legacyGeistAccentPattern,
+  new RegExp(['border-', 'cy', 'an-400/50'].join(''), 'u'),
+  new RegExp(['bg-', 'cy', 'an-400/\\[0\\.08\\]!'].join(''), 'u'),
+  new RegExp(['rgb\\(103', '_232_249'].join(''), 'u'),
+  new RegExp(['color-mix\\(in_oklab,var\\(--', 'ge', 'ist-'].join(''), 'u'),
+  new RegExp(['bg-', 'white/35'].join(''), 'u'),
+] as const;
 
 const navigationMock = vi.hoisted(() => ({
   refresh: vi.fn(),
@@ -185,6 +201,22 @@ describe('LibrarySurface', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     window.matchMedia = baseMatchMedia;
+  });
+
+  it('keeps library selection accents on System B semantic tokens', () => {
+    const source = readFileSync(
+      resolve(process.cwd(), LIBRARY_SURFACE_SOURCE),
+      'utf8'
+    );
+
+    for (const legacyPattern of legacySelectionAccentPatterns) {
+      expect(source).not.toMatch(legacyPattern);
+    }
+
+    expect(source).toContain('border-success/20 bg-success/10 text-success');
+    expect(source).toContain('border-info/20 bg-info/10 text-info');
+    expect(source).toContain('border-default bg-surface-1 text-primary-token');
+    expect(source).toContain('bg-surface-1! text-primary-token');
   });
 
   it('renders an empty read-only library state with a releases escape hatch', () => {
@@ -476,9 +508,9 @@ describe('LibrarySurface', () => {
       'false'
     );
     expect(row).toHaveAttribute('aria-selected', 'true');
-    expect(row.className).toContain('bg-cyan-400/[0.08]!');
+    expect(row.className).toContain('bg-surface-1!');
     expect(row.className).toContain(
-      'shadow-[inset_2px_0_0_0_rgb(103_232_249)]!'
+      'shadow-[inset_2px_0_0_0_var(--color-border-default)]!'
     );
     expect(screen.getByRole('link', { name: /Open Release/u })).toHaveAttribute(
       'href',


### PR DESCRIPTION
## Summary
- Replace LibrarySurface legacy Geist/cyan selection accents with existing semantic success/info and neutral System B token classes.
- Move active library nav/filter/card/row selection off hard-coded cyan classes while preserving DOM structure and state behavior.
- Add a focused source guard in LibrarySurface tests for the removed legacy accent strings.

Linear: JOV-2788

## Visual states checked
- Empty catalog
- No-results filters
- Populated grid and list
- Selected and idle card
- Selected and idle row
- Active and idle library nav pills
- Active and idle filter rows
- Filter sections open and closed
- Mobile filters open and closed
- Drawer open and closed on desktop/mobile
- Preview idle and playing
- Audio ready/dropzone dragging/uploading/error
- Skeleton/loading table

## Verification
- `./scripts/setup.sh` passed
- `pnpm exec biome check --write "apps/web/app/app/(shell)/library/LibrarySurface.tsx" apps/web/tests/unit/library/LibrarySurface.test.tsx` passed
- `pnpm --filter @jovie/web exec vitest run tests/unit/library/LibrarySurface.test.tsx` passed: 14 tests
- `pnpm --filter @jovie/web run typecheck -- --pretty false` passed
- `git diff --check origin/main..HEAD` passed
- Legacy library accent source guard passed: no forbidden strings found
- Pre-push passed: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint