### PR TITLE
fix(web): replace library fallback dot token

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -284,7 +284,7 @@ function releaseStatusDotClasses(
 ): string {
   if (status === 'released') return 'bg-success';
   if (status === 'scheduled') return 'bg-info';
-  return 'bg-muted';
+  return 'bg-tertiary-token';
 }
 
 function assetMatchesFilters(

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -34,6 +34,7 @@ const legacySelectionAccentPatterns = [
   new RegExp(['rgb\\(103', '_232_249'].join(''), 'u'),
   new RegExp(['color-mix\\(in_oklab,var\\(--', 'ge', 'ist-'].join(''), 'u'),
   new RegExp(['bg-', 'white/35'].join(''), 'u'),
+  new RegExp(['bg-', 'muted'].join(''), 'u'),
 ] as const;
 
 const navigationMock = vi.hoisted(() => ({


### PR DESCRIPTION
## Summary
- Replaces the library fallback release-status dot from invalid `bg-muted` to `bg-tertiary-token`.
- Extends the LibrarySurface source guard so `bg-muted` cannot return on this surface.

## Linear
- JOV-2789

## Layout states checked
- Released, scheduled, and fallback release-status dots use stable `h-1.5 w-1.5 shrink-0 rounded-full` geometry.
- This patch changes only the fallback color token; it does not alter DOM structure, spacing, sizing, or conditional rendering.

## Verification
- `./scripts/setup.sh`
- `pnpm exec biome check --write "apps/web/app/app/(shell)/library/LibrarySurface.tsx" apps/web/tests/unit/library/LibrarySurface.test.tsx`
- `pnpm --filter @jovie/web exec vitest run tests/unit/library/LibrarySurface.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- explicit source guard: no forbidden legacy library accent strings found
- commit hook: proxy guard, Biome, ESLint, web typecheck
- pre-push hook: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint