### PR TITLE
fix(web): tokenize skill chip styling

### DIFF
--- a/apps/web/components/jovie/components/SkillChip.tsx
+++ b/apps/web/components/jovie/components/SkillChip.tsx
@@ -20,14 +20,11 @@ interface SkillChipProps {
 export function SkillChip({ label, onRemove, removeLabel }: SkillChipProps) {
   return (
     <span
-      className='inline-flex h-7 max-w-[220px] shrink-0 items-center gap-1.5 rounded-[9px] border border-white/[0.085] bg-white/[0.035] px-2 text-[13px] font-medium leading-none text-primary-token shadow-[inset_0_1px_0_rgba(255,255,255,0.045)] select-none'
+      className='system-b-skill-chip'
       title={label}
       data-testid='skill-chip'
     >
-      <span
-        aria-hidden
-        className='h-1.5 w-1.5 shrink-0 rounded-full bg-tertiary-token'
-      />
+      <span aria-hidden className='system-b-skill-chip-dot' />
       <span className='min-w-0 truncate'>{label}</span>
       {onRemove ? (
         <button
@@ -39,7 +36,7 @@ export function SkillChip({ label, onRemove, removeLabel }: SkillChipProps) {
           onClick={() => {
             onRemove();
           }}
-          className='-mr-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm text-tertiary-token transition-colors duration-fast hover:bg-white/[0.07] hover:text-primary-token focus:outline-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/30'
+          className='system-b-skill-chip-remove'
         >
           <X className='h-3 w-3' />
         </button>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2389,6 +2389,62 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   box-shadow: 0 0 0 1px color-mix(in oklab, white 30%, transparent);
 }
 
+.system-b-skill-chip {
+  display: inline-flex;
+  height: 1.75rem;
+  max-width: 220px;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--space-1-5);
+  border: 1px solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-full);
+  background: var(--system-b-bg-surface-1);
+  color: var(--color-text-primary-token);
+  font-size: var(--text-app);
+  font-weight: var(--font-weight-medium);
+  line-height: 1;
+  padding-inline: var(--space-2);
+  user-select: none;
+}
+
+.system-b-skill-chip-dot {
+  width: var(--space-1-5);
+  height: var(--space-1-5);
+  flex-shrink: 0;
+  border-radius: var(--radius-full);
+  background: var(--color-text-tertiary-token);
+}
+
+.system-b-skill-chip-remove {
+  display: inline-flex;
+  width: var(--space-4);
+  height: var(--space-4);
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  margin-right: calc(var(--space-0-5) * -1);
+  border-radius: var(--radius-full);
+  color: var(--color-text-tertiary-token);
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+.system-b-skill-chip-remove:hover {
+  background: var(--system-b-bg-surface-2);
+  color: var(--color-text-primary-token);
+}
+
+.system-b-skill-chip-remove:focus,
+.system-b-skill-chip-remove:focus-visible {
+  outline: none;
+}
+
+.system-b-skill-chip-remove:focus-visible {
+  box-shadow: 0 0 0 1px
+    color-mix(in oklab, var(--color-border-focus) 36%, transparent);
+}
+
 .system-b-entity-chip-popover-content {
   z-index: 150;
   width: min(272px, calc(100vw - var(--space-6)));

--- a/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts
@@ -10,6 +10,7 @@ const guardedFiles = [
   'components/jovie/components/EntityChip.tsx',
   'components/jovie/components/EntityChipPopover.tsx',
   'components/jovie/components/EntityPreviewPane.tsx',
+  'components/jovie/components/SkillChip.tsx',
   'components/shell/DspAvatarStack.tsx',
   'components/shell/EntityPopover.tsx',
 ];
@@ -35,5 +36,19 @@ describe('entity rich chip System B style guard', () => {
 
       expect(offenders, `${file} leaked ${offenders.join(', ')}`).toEqual([]);
     }
+  });
+
+  it('keeps input skill chip CSS on globally defined System B surface tokens', () => {
+    const source = readFileSync(
+      path.join(webRoot, 'styles/design-system.css'),
+      'utf8'
+    );
+    const skillChipCss = source.match(
+      /\.system-b-skill-chip[\s\S]*?\.system-b-entity-chip-popover-content/
+    )?.[0];
+
+    expect(skillChipCss).toContain('var(--system-b-bg-surface-1)');
+    expect(skillChipCss).toContain('var(--system-b-bg-surface-2)');
+    expect(skillChipCss).not.toMatch(/--surface-[0-9]/);
   });
 });


### PR DESCRIPTION
## Summary
- Move `SkillChip` off local Tailwind visual recipes and onto named System B primitives.
- Add `.system-b-skill-chip`, `.system-b-skill-chip-dot`, and `.system-b-skill-chip-remove` in the System B CSS source of truth.
- Extend the entity-rich chat chip style guard to include `SkillChip.tsx`.

## Layout States
- Removable skill chip.
- Long-label truncation.
- Remove affordance hover/focus geometry.
- Multiple chips wrapping inside the composer row.

## Verification
- `./scripts/setup.sh`
- `pnpm exec biome check --write apps/web/components/jovie/components/SkillChip.tsx apps/web/styles/design-system.css apps/web/tests/unit/chat/entity-rich-chip-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/chat/ChatInput.test.tsx tests/unit/chat/ChatInput.aria.test.tsx tests/unit/chat/entity-rich-chip-style-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- `git push` pre-push gate: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint

## Proof
- Local screenshot: `.gstack/design-reports/screenshots/jov-2790-skillchip-system-b-before-after.png`
- Local ledger: `.gstack/design-reports/reports/jov-2790-skillchip-system-b.md`

Linear: JOV-2790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Consolidated skill chip styling for improved design consistency across components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->