### PR TITLE
fix(web): tokenize thread media card styling

### DIFF
--- a/apps/web/components/shell/ThreadAudioCard.tsx
+++ b/apps/web/components/shell/ThreadAudioCard.tsx
@@ -25,15 +25,13 @@ export function ThreadAudioCard({
   onPlay,
 }: ThreadAudioCardProps) {
   return (
-    <div className='flex items-center gap-3 rounded-xl border border-(--linear-app-shell-border) bg-(--surface-0)/40 px-3 py-2.5'>
-      <div className='shrink-0 h-10 w-10 rounded bg-(--surface-2) grid place-items-center'>
+    <div className='system-b-thread-media-card system-b-thread-audio-card'>
+      <div className='system-b-thread-audio-artwork'>
         <Disc3 className='h-4 w-4 text-tertiary-token' strokeWidth={2.25} />
       </div>
-      <div className='flex-1 min-w-0'>
-        <p className='text-[12.5px] font-medium text-primary-token truncate'>
-          {title}
-        </p>
-        <p className='text-[11px] text-tertiary-token truncate'>
+      <div className='system-b-thread-audio-copy'>
+        <p className='system-b-thread-audio-title'>{title}</p>
+        <p className='system-b-thread-audio-meta'>
           {artist} · {duration}
         </p>
       </div>
@@ -41,7 +39,7 @@ export function ThreadAudioCard({
         type='button'
         onClick={onPlay}
         disabled={!onPlay}
-        className='h-8 w-8 rounded-full grid place-items-center bg-white text-black hover:bg-white/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-colors duration-subtle ease-subtle'
+        className='system-b-thread-audio-play'
         aria-label='Play in global player'
       >
         <Play

--- a/apps/web/components/shell/ThreadImageCard.tsx
+++ b/apps/web/components/shell/ThreadImageCard.tsx
@@ -28,9 +28,6 @@ export type ThreadImageCardProps =
       readonly onRegenerate?: () => void;
     };
 
-const SHIMMER_BG =
-  'linear-gradient(110deg, transparent 0%, rgba(255,255,255,0.04) 35%, rgba(103,232,249,0.06) 50%, rgba(255,255,255,0.04) 65%, transparent 100%)';
-
 /**
  * Image generation card — clean attachment block. Shimmer + visible
  * prompt while generating; aspect-correct preview + tap-to-lightbox once
@@ -44,20 +41,12 @@ const SHIMMER_BG =
 export function ThreadImageCard(props: ThreadImageCardProps) {
   const { prompt, status } = props;
   return (
-    <div className='rounded-xl border border-(--linear-app-shell-border) bg-(--surface-0)/40 overflow-hidden'>
-      <div className='aspect-[16/10] relative bg-(--surface-2)'>
+    <div className='system-b-thread-media-card'>
+      <div className='system-b-thread-media-preview system-b-thread-image-preview'>
         {status === 'generating' ? (
-          <div className='absolute inset-0 grid place-items-center'>
-            <div
-              aria-hidden='true'
-              className='absolute inset-0'
-              style={{
-                backgroundImage: SHIMMER_BG,
-                backgroundSize: '200% 100%',
-                animation: 'shimmer 2.4s ease-in-out infinite',
-              }}
-            />
-            <p className='relative text-[12px] text-tertiary-token text-center px-6'>
+          <div className='system-b-thread-media-generating'>
+            <div aria-hidden='true' className='system-b-thread-image-shimmer' />
+            <p className='system-b-thread-generating-copy'>
               Generating &ldquo;{prompt}&rdquo;
             </p>
           </div>
@@ -72,11 +61,9 @@ export function ThreadImageCard(props: ThreadImageCardProps) {
           />
         )}
       </div>
-      <div className='flex items-center gap-2 px-3 h-9 border-t border-(--linear-app-shell-border)/60'>
-        <Sparkles className='h-3 w-3 text-cyan-300/80' strokeWidth={2.25} />
-        <span className='flex-1 text-[11.5px] text-tertiary-token truncate'>
-          {prompt}
-        </span>
+      <div className='system-b-thread-media-footer'>
+        <Sparkles className='system-b-thread-media-icon' strokeWidth={2.25} />
+        <span className='system-b-thread-media-label'>{prompt}</span>
         {status === 'ready' &&
           (props.onDownload || props.onCopy || props.onRegenerate) && (
             <span className='inline-flex items-center gap-0.5'>

--- a/apps/web/components/shell/ThreadVideoCard.tsx
+++ b/apps/web/components/shell/ThreadVideoCard.tsx
@@ -34,7 +34,7 @@ export function ThreadVideoCard({
 }: ThreadVideoCardProps) {
   const Thumb = onPlay ? 'button' : 'div';
   return (
-    <div className='rounded-xl border border-(--linear-app-shell-border) bg-(--surface-0)/40 overflow-hidden'>
+    <div className='system-b-thread-media-card'>
       <Thumb
         {...(onPlay
           ? {
@@ -43,23 +43,13 @@ export function ThreadVideoCard({
               'aria-label': `Play ${title}`,
             }
           : {})}
-        className='group/vid relative w-full aspect-[16/9] block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-token'
+        className='system-b-thread-media-preview system-b-thread-video-preview'
       >
-        <span
-          aria-hidden='true'
-          className='absolute inset-0'
-          style={{
-            background:
-              'radial-gradient(ellipse at 60% 40%, rgba(255,255,255,0.06) 0%, rgba(0,0,0,0) 60%), linear-gradient(135deg, hsl(220, 30%, 12%), hsl(220, 30%, 4%))',
-          }}
-        />
-        <span className='absolute inset-0 grid place-items-center'>
+        <span aria-hidden='true' className='system-b-thread-video-backdrop' />
+        <span className='system-b-thread-play-shell'>
           <span
-            className={
-              onPlay
-                ? 'h-12 w-12 rounded-full bg-white/95 text-black grid place-items-center transition-colors duration-subtle ease-subtle group-hover/vid:bg-white'
-                : 'h-12 w-12 rounded-full bg-white/40 text-black grid place-items-center'
-            }
+            className='system-b-thread-play-button'
+            data-interactive={onPlay ? 'true' : 'false'}
           >
             <Play
               className='h-4 w-4 translate-x-px'
@@ -68,15 +58,13 @@ export function ThreadVideoCard({
             />
           </span>
         </span>
-        <span className='absolute bottom-2 right-2 inline-flex items-center h-5 px-1.5 rounded text-[10px] font-caption tabular-nums text-primary-token bg-black/60 backdrop-blur'>
+        <span className='system-b-thread-duration-badge'>
           {formatDuration(durationSec)}
         </span>
       </Thumb>
-      <div className='flex items-center gap-2 px-3 h-9 border-t border-(--linear-app-shell-border)/60'>
-        <Mic2 className='h-3 w-3 text-cyan-300/80' strokeWidth={2.25} />
-        <span className='flex-1 text-[11.5px] text-tertiary-token truncate'>
-          {title}
-        </span>
+      <div className='system-b-thread-media-footer'>
+        <Mic2 className='system-b-thread-media-icon' strokeWidth={2.25} />
+        <span className='system-b-thread-media-label'>{title}</span>
         {onFullscreen && (
           <ThreadCardIconBtn label='Full-screen' onClick={onFullscreen}>
             <Maximize2 className='h-3 w-3' strokeWidth={2.25} />

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2445,6 +2445,244 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
     color-mix(in oklab, var(--color-border-focus) 36%, transparent);
 }
 
+:where(.system-b-thread-media-card) {
+  overflow: hidden;
+  border: 1px solid var(--system-b-app-shell-border);
+  border-radius: var(--radius-xl);
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-0) 72%,
+    transparent
+  );
+}
+
+:where(.system-b-thread-media-preview) {
+  position: relative;
+  display: block;
+  width: 100%;
+  background: var(--system-b-bg-surface-2);
+}
+
+:where(.system-b-thread-image-preview) {
+  aspect-ratio: 16 / 10;
+}
+
+:where(.system-b-thread-video-preview) {
+  aspect-ratio: 16 / 9;
+}
+
+:where(.system-b-thread-video-preview:focus-visible) {
+  outline: none;
+  box-shadow: 0 0 0 2px
+    color-mix(in oklab, var(--color-border-focus) 55%, transparent);
+}
+
+:where(.system-b-thread-media-generating) {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+}
+
+:where(.system-b-thread-image-shimmer) {
+  position: absolute;
+  inset: 0;
+  animation: shimmer 2.4s ease-in-out infinite;
+  background-image: linear-gradient(
+    110deg,
+    transparent,
+    color-mix(in oklab, var(--color-text-primary-token) 4%, transparent) 35%,
+    color-mix(in oklab, var(--system-b-accent-cyan) 8%, transparent) 50%,
+    color-mix(in oklab, var(--color-text-primary-token) 4%, transparent) 65%,
+    transparent
+  );
+  background-size: 200% 100%;
+}
+
+:where(.system-b-thread-generating-copy) {
+  position: relative;
+  max-width: calc(var(--space-24) * 4);
+  padding-inline: var(--space-6);
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  text-align: center;
+}
+
+:where(.system-b-thread-video-backdrop) {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(
+      ellipse at 60% 40%,
+      color-mix(in oklab, var(--color-text-primary-token) 6%, transparent),
+      transparent 60%
+    ),
+    linear-gradient(
+      135deg,
+      var(--system-b-bg-surface-2),
+      var(--system-b-bg-page)
+    );
+}
+
+:where(.system-b-thread-play-shell) {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+}
+
+:where(.system-b-thread-play-button) {
+  display: grid;
+  width: var(--space-12);
+  height: var(--space-12);
+  place-items: center;
+  border-radius: var(--radius-full);
+  background: var(--system-b-primary-bg);
+  color: var(--system-b-primary-fg);
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    opacity var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(
+    .system-b-thread-video-preview:hover
+      .system-b-thread-play-button[data-interactive="true"]
+  ) {
+  background: color-mix(
+    in oklab,
+    var(--system-b-primary-bg) 94%,
+    var(--system-b-bg-surface-2)
+  );
+}
+
+:where(.system-b-thread-play-button[data-interactive="false"]) {
+  background: color-mix(in oklab, var(--system-b-primary-bg) 42%, transparent);
+}
+
+:where(.system-b-thread-duration-badge) {
+  position: absolute;
+  right: var(--space-2);
+  bottom: var(--space-2);
+  display: inline-flex;
+  height: var(--space-5);
+  align-items: center;
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklab, var(--system-b-bg-page) 64%, transparent);
+  color: var(--color-text-primary-token);
+  font-family: var(--font-caption);
+  font-size: var(--text-3xs);
+  font-variant-numeric: tabular-nums;
+  line-height: var(--leading-none);
+  padding-inline: var(--space-1-5);
+}
+
+:where(.system-b-thread-media-footer) {
+  display: flex;
+  height: calc(var(--space-8) + var(--space-1));
+  align-items: center;
+  gap: var(--space-2);
+  border-top: 1px solid
+    color-mix(in oklab, var(--system-b-app-shell-border) 60%, transparent);
+  padding-inline: var(--space-3);
+}
+
+:where(.system-b-thread-media-icon) {
+  width: var(--space-3);
+  height: var(--space-3);
+  flex-shrink: 0;
+  color: color-mix(in oklab, var(--system-b-accent-cyan) 80%, transparent);
+}
+
+:where(.system-b-thread-media-label) {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-2xs);
+  line-height: var(--leading-none);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:where(.system-b-thread-audio-card) {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2-5) var(--space-3);
+}
+
+:where(.system-b-thread-audio-artwork) {
+  display: grid;
+  width: var(--space-10);
+  height: var(--space-10);
+  flex-shrink: 0;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  background: var(--system-b-bg-surface-2);
+  box-shadow: var(--shadow-button-inset);
+}
+
+:where(.system-b-thread-audio-copy) {
+  min-width: 0;
+  flex: 1;
+}
+
+:where(.system-b-thread-audio-title) {
+  margin: 0;
+  overflow: hidden;
+  color: var(--color-text-primary-token);
+  font-size: var(--text-app);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--leading-tight);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:where(.system-b-thread-audio-meta) {
+  margin: 0;
+  overflow: hidden;
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-2xs);
+  line-height: var(--leading-normal);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:where(.system-b-thread-audio-play) {
+  display: grid;
+  width: var(--space-8);
+  height: var(--space-8);
+  flex-shrink: 0;
+  place-items: center;
+  border-radius: var(--radius-full);
+  background: var(--system-b-primary-bg);
+  color: var(--system-b-primary-fg);
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    opacity var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-thread-audio-play:hover:not(:disabled)) {
+  background: color-mix(
+    in oklab,
+    var(--system-b-primary-bg) 92%,
+    var(--system-b-bg-surface-2)
+  );
+}
+
+:where(.system-b-thread-audio-play:disabled) {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+:where(.system-b-thread-audio-play:focus-visible) {
+  outline: none;
+  box-shadow:
+    0 0 0 2px var(--system-b-bg-page),
+    0 0 0 4px color-mix(in oklab, var(--color-border-focus) 55%, transparent);
+}
+
 .system-b-entity-chip-popover-content {
   z-index: 150;
   width: min(272px, calc(100vw - var(--space-6)));

--- a/apps/web/tests/unit/components/shell/thread-media-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/components/shell/thread-media-system-b-style-guard.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../../..');
+
+const guardedFiles = [
+  'components/shell/ThreadAudioCard.tsx',
+  'components/shell/ThreadImageCard.tsx',
+  'components/shell/ThreadVideoCard.tsx',
+];
+
+const rawVisualPatterns = [
+  /\b(?:text|rounded|shadow|border|bg|px|py|min-w|min-h|max-w|max-h|w|h|tracking|duration|z)-\[[^\]]+\]/,
+  /\bfont-\[[^\]]+\]/,
+  /tracking-\[-/,
+  /color-mix\s*\(\s*in\s+srgb/i,
+  /\brgba?\(/,
+  /#[0-9A-Fa-f]{3,8}\b/,
+  /--surface-[0-9]/,
+];
+
+describe('thread media System B style guard', () => {
+  it('keeps thread media card component visuals on named primitives', () => {
+    for (const file of guardedFiles) {
+      const source = readFileSync(path.join(webRoot, file), 'utf8');
+      const offenders = rawVisualPatterns
+        .filter(pattern => pattern.test(source))
+        .map(pattern => pattern.toString());
+
+      expect(offenders, `${file} leaked ${offenders.join(', ')}`).toEqual([]);
+    }
+  });
+
+  it('keeps thread media card CSS on globally defined System B tokens', () => {
+    const source = readFileSync(
+      path.join(webRoot, 'styles/design-system.css'),
+      'utf8'
+    );
+    const threadMediaCss = source.match(
+      /:where\(\.system-b-thread-media-card\)[\s\S]*?\.system-b-entity-chip-popover-content/
+    )?.[0];
+
+    expect(threadMediaCss).toContain('var(--system-b-bg-surface-0)');
+    expect(threadMediaCss).toContain('var(--system-b-bg-surface-2)');
+    expect(threadMediaCss).toContain('var(--system-b-primary-bg)');
+    expect(threadMediaCss).toContain('var(--system-b-primary-fg)');
+    expect(threadMediaCss).not.toMatch(/--linear-/);
+    expect(threadMediaCss).not.toMatch(/--surface-[0-9]/);
+    expect(threadMediaCss).not.toMatch(/\brgba?\(/);
+    expect(threadMediaCss).not.toMatch(/#[0-9A-Fa-f]{3,8}\b/);
+  });
+});


### PR DESCRIPTION
## Summary
- JOV-2791: move thread image, video, and audio card visuals onto named System B primitives
- remove raw local gradients, rgba/white/black button recipes, and --surface-* aliases from these reusable thread media cards
- add a dedicated shell style guard for thread media card token compliance

## Verification
- pnpm exec biome check --write apps/web/components/shell/ThreadImageCard.tsx apps/web/components/shell/ThreadVideoCard.tsx apps/web/components/shell/ThreadAudioCard.tsx apps/web/styles/design-system.css apps/web/tests/unit/components/shell/thread-media-system-b-style-guard.test.ts
- pnpm --filter @jovie/web exec vitest run components/shell/ThreadImageCard.test.tsx components/shell/ThreadVideoCard.test.tsx components/shell/ThreadAudioCard.test.tsx tests/unit/components/shell/thread-media-system-b-style-guard.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- pre-push: repo Biome, next proxy guard, Tailwind guard, web typecheck, web lint

## Screenshot proof
- .gstack/design-reports/screenshots/jov-2791-thread-media-system-b-before-after.png
- .gstack/design-reports/screenshots/jov-2791-thread-media-system-b-desktop.png
- .gstack/design-reports/screenshots/jov-2791-thread-media-system-b-desktop-region.png

## Common-sense review
The after state is quieter and more consistent. Image, video, and audio cards now share the same shell border, radius, surface, footer density, caption sizing, and primary play treatment. Cyan remains a small media accent instead of a competing primary color.