### PR TITLE
fix(web): tokenize unavailable page styling

### DIFF
--- a/apps/web/components/UnavailablePage.tsx
+++ b/apps/web/components/UnavailablePage.tsx
@@ -1,4 +1,4 @@
-import { JovieMarkElectric } from '@/components/atoms/JovieMarkElectric';
+import { Logo } from '@/components/atoms/Logo';
 
 /**
  * Generic "service unavailable" page shown to blocked users.
@@ -13,28 +13,17 @@ import { JovieMarkElectric } from '@/components/atoms/JovieMarkElectric';
  */
 export function UnavailablePage() {
   return (
-    <div className='fixed inset-0 isolate flex flex-col items-center bg-page text-primary-token overflow-y-auto overflow-x-clip [color-scheme:dark] px-4 sm:px-6 pt-10 pb-10 sm:pt-14 sm:pb-12'>
-      <div
-        aria-hidden='true'
-        className='pointer-events-none absolute inset-0 overflow-hidden'
-      >
-        <div className='absolute left-1/2 top-[8%] h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-accent/12 blur-[120px] sm:top-[10%] sm:h-[34rem] sm:w-[34rem]' />
-        <div className='absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.045),transparent_42%)]' />
-        <div className='absolute inset-0 bg-[linear-gradient(180deg,rgba(15,16,17,0.72)_0%,rgba(8,9,10,0.96)_68%)]' />
-      </div>
-
-      <div className='w-full max-w-[420px] relative z-10 flex flex-col items-center'>
-        <div className='mb-6 sm:mb-8' aria-hidden='true'>
-          <JovieMarkElectric size={32} />
+    <div className='system-b-unavailable-page'>
+      <div className='system-b-unavailable-content'>
+        <div className='system-b-unavailable-mark' aria-hidden='true'>
+          <Logo aria-hidden size='lg' tone='white' variant='icon' />
         </div>
 
-        <h1 className='text-[18px] leading-[22px] font-medium text-primary-token text-center mb-4'>
+        <h1 className='system-b-unavailable-title'>
           Jovie is unavailable right now
         </h1>
 
-        <p className='text-[13px] leading-5 text-secondary-token text-center'>
-          Please try again later.
-        </p>
+        <p className='system-b-unavailable-copy'>Please try again later.</p>
       </div>
     </div>
   );

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2206,6 +2206,57 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
 }
 
 /* ============================================
+   SYSTEM B UNAVAILABLE PAGE PRIMITIVES
+   ============================================ */
+
+:where(.system-b-unavailable-page) {
+  position: fixed;
+  inset: 0;
+  isolation: isolate;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow-x: clip;
+  overflow-y: auto;
+  background: var(--system-b-bg-page);
+  color: var(--system-b-text-primary);
+  color-scheme: dark;
+  padding-block: clamp(var(--space-10), 7svh, var(--space-16));
+  padding-inline: var(--space-4);
+}
+
+:where(.system-b-unavailable-content) {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  width: 100%;
+  max-width: calc(var(--space-24) * 4 + var(--space-6));
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+:where(.system-b-unavailable-mark) {
+  margin-bottom: var(--space-6);
+}
+
+:where(.system-b-unavailable-title) {
+  margin: 0 0 var(--space-4);
+  color: var(--system-b-text-primary);
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--leading-tight);
+  text-wrap: balance;
+}
+
+:where(.system-b-unavailable-copy) {
+  margin: 0;
+  color: var(--color-text-secondary-token);
+  font-size: var(--text-app);
+  line-height: var(--leading-normal);
+}
+
+/* ============================================
    SYSTEM B ONBOARDING V2 PRIMITIVES
    ============================================ */
 

--- a/apps/web/tests/unit/components/unavailable-page-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/components/unavailable-page-system-b-style-guard.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+
+const rawComponentVisualPatterns = [
+  /\b(?:text|rounded|shadow|border|bg|px|py|pt|pb|min-w|min-h|max-w|max-h|w|h|tracking|blur|duration|z)-\[[^\]]+\]/,
+  /\bfont-\[[^\]]+\]/,
+  /\brgba?\(/,
+  /#[0-9A-Fa-f]{3,8}\b/,
+  /(?:radial|linear)-gradient/,
+  /\bbg-accent\/\d+/,
+  /--surface-[0-9]/,
+];
+
+describe('UnavailablePage System B style guard', () => {
+  it('keeps the unavailable page component on named System B primitives', () => {
+    const source = readFileSync(
+      path.join(webRoot, 'components/UnavailablePage.tsx'),
+      'utf8'
+    );
+    const offenders = rawComponentVisualPatterns
+      .filter(pattern => pattern.test(source))
+      .map(pattern => pattern.toString());
+
+    expect(offenders, `UnavailablePage leaked ${offenders.join(', ')}`).toEqual(
+      []
+    );
+  });
+
+  it('keeps unavailable page CSS quiet and token-backed', () => {
+    const source = readFileSync(
+      path.join(webRoot, 'styles/design-system.css'),
+      'utf8'
+    );
+    const unavailableCss = source.match(
+      /:where\(\.system-b-unavailable-page\)[\s\S]*?\/\* ============================================\s+SYSTEM B ONBOARDING V2 PRIMITIVES/
+    )?.[0];
+
+    expect(unavailableCss).toContain('var(--system-b-bg-page)');
+    expect(unavailableCss).toContain('var(--system-b-text-primary)');
+    expect(unavailableCss).toContain('var(--color-text-secondary-token)');
+    expect(unavailableCss).toContain('var(--space-10)');
+    expect(unavailableCss).not.toMatch(/--linear-/);
+    expect(unavailableCss).not.toMatch(/--surface-[0-9]/);
+    expect(unavailableCss).not.toMatch(/\brgba?\(/);
+    expect(unavailableCss).not.toMatch(/#[0-9A-Fa-f]{3,8}\b/);
+    expect(unavailableCss).not.toMatch(/(?:radial|linear)-gradient/);
+    expect(unavailableCss).not.toMatch(/\bblur\b/);
+  });
+});


### PR DESCRIPTION
## Summary
- tokenizes `UnavailablePage` onto named `system-b-unavailable-*` primitives
- removes the local glow/gradient backdrop and raw visual sizing from the component
- uses the existing static white `Logo` icon instead of the animated electric loader mark
- adds a focused System B style guard for the unavailable surface

## Proof
- Desktop: `.gstack/design-reports/screenshots/jov-2793-unavailable-system-b-desktop.png`
- Mobile: `.gstack/design-reports/screenshots/jov-2793-unavailable-system-b-mobile.png`
- Before/after sheet: `.gstack/design-reports/screenshots/jov-2793-unavailable-system-b-before-after.png`

## Verification
- `pnpm exec biome check --write apps/web/components/UnavailablePage.tsx apps/web/styles/design-system.css apps/web/tests/unit/components/unavailable-page-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/components/unavailable-page-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- commit hook: proxy guard, Biome, ESLint, a11y staged check, web typecheck
- pre-push hook: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint

<!-- linear-issue-id:JOV-2793 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the unavailable page with refreshed visual design, new logo, and improved styling.

* **Tests**
  * Added styling consistency tests for the unavailable page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->