### PR TITLE
fix(web): tokenize start loading skeleton

### DIFF
--- a/apps/web/app/(dynamic)/start/loading.tsx
+++ b/apps/web/app/(dynamic)/start/loading.tsx
@@ -1,41 +1,42 @@
 import { Skeleton } from '@jovie/ui';
-import { JovieMarkElectric } from '@/components/atoms/JovieMarkElectric';
+import { Logo } from '@/components/atoms/Logo';
 
 export default function StartLoading() {
   return (
     <div
-      className='relative flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-(--linear-app-content-surface)'
+      className='system-b-start-loading-page'
       aria-busy='true'
       aria-live='polite'
       data-testid='start-loading-skeleton'
     >
-      <div className='relative flex-1 overflow-y-auto px-4 py-5 sm:px-6 lg:px-8'>
-        <div className='mx-auto flex min-h-full w-full max-w-[52rem] flex-col items-center justify-center px-1 py-8'>
+      <div className='system-b-start-loading-scroll'>
+        <div className='system-b-start-loading-content'>
           <div
-            className='pointer-events-none absolute left-1/2 top-1/2 h-[min(46vw,28rem)] w-[min(46vw,28rem)] -translate-x-1/2 -translate-y-[60%] opacity-85 drop-shadow-[0_0_34px_rgba(68,188,255,0.18)] max-sm:h-[min(72vw,18rem)] max-sm:w-[min(72vw,18rem)]'
-            style={{
-              maskImage:
-                'radial-gradient(ellipse at center, black 54%, rgba(0,0,0,0.72) 68%, transparent 88%)',
-              WebkitMaskImage:
-                'radial-gradient(ellipse at center, black 54%, rgba(0,0,0,0.72) 68%, transparent 88%)',
-            }}
+            className='system-b-start-loading-mark'
+            aria-hidden='true'
             data-testid='chat-empty-state-logo'
           >
-            <JovieMarkElectric className='h-full w-full' />
+            <Logo aria-hidden size='lg' tone='white' variant='icon' />
           </div>
 
-          <div className='relative z-10 mx-auto w-full max-w-[45rem]'>
-            <div
-              className='overflow-hidden rounded-[36px] border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_84%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_88%,black_12%)] shadow-[0_18px_68px_-34px_rgba(0,0,0,0.96),inset_0_1px_0_rgba(255,255,255,0.08)]'
-              aria-hidden='true'
-            >
-              <div className='flex min-h-[56px] items-center gap-1.5 px-3 py-1.5 sm:min-h-[56px] sm:px-3'>
-                <div className='min-w-0 flex-1 px-3'>
-                  <Skeleton className='h-5 w-[58%]' rounded='full' />
+          <div className='system-b-start-loading-composer-wrap'>
+            <div className='system-b-start-loading-composer' aria-hidden='true'>
+              <div className='system-b-start-loading-composer-row'>
+                <div className='system-b-start-loading-copy-slot'>
+                  <Skeleton
+                    className='system-b-start-loading-title-skeleton'
+                    rounded='full'
+                  />
                 </div>
-                <div className='flex shrink-0 items-center gap-2'>
-                  <Skeleton className='h-9 w-9' rounded='full' />
-                  <Skeleton className='h-9 w-9' rounded='full' />
+                <div className='system-b-start-loading-actions'>
+                  <Skeleton
+                    className='system-b-start-loading-action-skeleton'
+                    rounded='full'
+                  />
+                  <Skeleton
+                    className='system-b-start-loading-action-skeleton'
+                    rounded='full'
+                  />
                 </div>
               </div>
             </div>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2257,6 +2257,101 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
 }
 
 /* ============================================
+   SYSTEM B START LOADING PRIMITIVES
+   ============================================ */
+
+:where(.system-b-start-loading-page) {
+  position: relative;
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--system-b-app-content-surface);
+  color: var(--system-b-text-primary);
+  color-scheme: dark;
+}
+
+:where(.system-b-start-loading-scroll) {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding-block: clamp(var(--space-5), 4svh, var(--space-8));
+  padding-inline: clamp(var(--space-4), 4vw, var(--space-8));
+}
+
+:where(.system-b-start-loading-content) {
+  display: flex;
+  width: 100%;
+  min-height: 100%;
+  max-width: var(--app-shell-content-max-reading);
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-6);
+  margin-inline: auto;
+}
+
+:where(.system-b-start-loading-mark) {
+  display: flex;
+  width: var(--space-8);
+  height: var(--space-8);
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.92;
+}
+
+:where(.system-b-start-loading-composer-wrap) {
+  width: 100%;
+  max-width: var(--app-shell-content-max-form);
+}
+
+:where(.system-b-start-loading-composer) {
+  overflow: hidden;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 84%, transparent);
+  border-radius: var(--system-b-radius-pill);
+  background: color-mix(
+    in oklab,
+    var(--system-b-app-content-surface) 88%,
+    var(--system-b-bg-page) 12%
+  );
+}
+
+:where(.system-b-start-loading-composer-row) {
+  display: flex;
+  min-height: calc(var(--space-10) + var(--space-4));
+  align-items: center;
+  gap: var(--space-2);
+  padding-block: var(--space-2);
+  padding-inline: var(--space-3);
+}
+
+:where(.system-b-start-loading-copy-slot) {
+  min-width: 0;
+  flex: 1 1 auto;
+  padding-inline: var(--space-3);
+}
+
+:where(.system-b-start-loading-title-skeleton) {
+  width: min(58%, calc(var(--space-24) * 2));
+  height: var(--space-5);
+}
+
+:where(.system-b-start-loading-actions) {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+:where(.system-b-start-loading-action-skeleton) {
+  width: calc(var(--space-8) + var(--space-1));
+  height: calc(var(--space-8) + var(--space-1));
+}
+
+/* ============================================
    SYSTEM B ONBOARDING V2 PRIMITIVES
    ============================================ */
 

--- a/apps/web/tests/unit/app/start-loading-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/app/start-loading-system-b-style-guard.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+
+const rawComponentVisualPatterns = [
+  /\b(?:text|rounded|shadow|border|bg|px|py|pt|pb|min-w|min-h|max-w|max-h|w|h|tracking|blur|duration|z)-\[[^\]]+\]/,
+  /\bfont-\[[^\]]+\]/,
+  /\brgba?\(/,
+  /#[0-9A-Fa-f]{3,8}\b/,
+  /(?:radial|linear)-gradient/,
+  /\bdrop-shadow-/,
+  /\bshadow-/,
+  /\bblur-/,
+  /--linear-/,
+  /--surface-[0-9]/,
+];
+
+describe('/start loading System B style guard', () => {
+  it('keeps the loading route on named System B primitives', () => {
+    const source = readFileSync(
+      path.join(webRoot, 'app/(dynamic)/start/loading.tsx'),
+      'utf8'
+    );
+    const offenders = rawComponentVisualPatterns
+      .filter(pattern => pattern.test(source))
+      .map(pattern => pattern.toString());
+
+    expect(offenders, `/start loading leaked ${offenders.join(', ')}`).toEqual(
+      []
+    );
+    expect(source).toContain('system-b-start-loading-page');
+    expect(source).toContain('system-b-start-loading-composer');
+    expect(source).not.toContain('JovieMarkElectric');
+    expect(source).not.toContain('style={{');
+  });
+
+  it('keeps the loading CSS quiet and token-backed', () => {
+    const source = readFileSync(
+      path.join(webRoot, 'styles/design-system.css'),
+      'utf8'
+    );
+    const loadingCss = source.match(
+      /:where\(\.system-b-start-loading-page\)[\s\S]*?\/\* ============================================\s+SYSTEM B ONBOARDING V2 PRIMITIVES/
+    )?.[0];
+
+    expect(loadingCss).toBeDefined();
+    expect(loadingCss).toContain('var(--system-b-app-content-surface)');
+    expect(loadingCss).toContain('var(--system-b-text-primary)');
+    expect(loadingCss).toContain('var(--system-b-app-frame-seam)');
+    expect(loadingCss).toContain('var(--system-b-radius-pill)');
+    expect(loadingCss).toContain('width: var(--space-8)');
+    expect(loadingCss).toContain('height: var(--space-8)');
+    expect(loadingCss).toContain('var(--space-10)');
+    expect(loadingCss).not.toMatch(/--linear-/);
+    expect(loadingCss).not.toMatch(/--surface-[0-9]/);
+    expect(loadingCss).not.toMatch(/\brgba?\(/);
+    expect(loadingCss).not.toMatch(/#[0-9A-Fa-f]{3,8}\b/);
+    expect(loadingCss).not.toMatch(/(?:radial|linear)-gradient/);
+    expect(loadingCss).not.toMatch(/\b(?:box-)?shadow\b/);
+    expect(loadingCss).not.toMatch(/\bblur\b/);
+  });
+});


### PR DESCRIPTION
## Summary
- tokenizes /start loading onto named system-b-start-loading-* primitives
- removes the electric loader mark, raw radial mask, hardcoded shadow/glow recipe, and route-local arbitrary visual Tailwind
- keeps the existing onboarding selectors while reserving stable composer/logo geometry
- gives the mark wrapper explicit token-backed dimensions so the icon frame is stable
- adds a focused System B style guard for the /start loading route and CSS block

## Proof
- Desktop: .gstack/design-reports/screenshots/jov-2794-start-loading-after-desktop.png
- Mobile: .gstack/design-reports/screenshots/jov-2794-start-loading-after-mobile.png
- Before/after sheet: .gstack/design-reports/screenshots/jov-2794-start-loading-before-after.png
- Report: .gstack/design-reports/reports/jov-2794-start-loading-system-b.md

Note: the live route fallback resolves too quickly to catch reliably, so the proof harness renders the exact post-change DOM/classes against app CSS after confirming the real route ends at /start without exposing the loading fallback long enough for screenshot capture.

## Verification
- pnpm exec biome check --write apps/web/styles/design-system.css apps/web/tests/unit/app/start-loading-system-b-style-guard.test.ts
- pnpm --filter @jovie/web exec vitest run tests/unit/app/start-loading-system-b-style-guard.test.ts
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- commit hook: proxy guard, Biome, ESLint, web typecheck
- pre-push hook: repo Biome, proxy guard, Tailwind guard, web typecheck, web lint

<!-- linear-issue-id:JOV-2794 -->

<!-- agent-run-artifact
{
  "id": "jov-2794-start-loading-gates-a7277ed3c96f",
  "source": "github",
  "sourceRunId": "a7277ed3c96fe4192696dcff063795ab38c50163",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2794 Start loading System B gates",
  "summary": "Recorded QA, review, and ship evidence for /start loading System B tokenization.",
  "modelRoute": "deterministic",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr",
    "ready_pr"
  ],
  "forbiddenActions": [
    "deploy",
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2794",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2794/tokenize-start-loading-skeleton-system-b-styling",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/10098",
  "adminSurface": "/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Desktop, mobile, and before/after harness screenshots captured for the /start loading skeleton; composer remains 58px tall with no horizontal overflow at 1440x900 or 390x844, and the mark wrapper now has explicit token-backed dimensions.",
      "checkedAt": "2026-06-05T07:28:21.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed the route and CSS for System B drift: static white Logo, named primitives, explicit mark wrapper dimensions, no JovieMarkElectric, no inline radial mask, no raw rgba/hex gradient/shadow recipe in the route or guarded CSS block.",
      "checkedAt": "2026-06-05T07:28:21.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, focused Vitest guard, web typecheck, git diff --check, commit hook, and pre-push hook passed on head a7277ed3c96fe4192696dcff063795ab38c50163.",
      "checkedAt": "2026-06-05T07:28:21.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic verification and screenshot capture only."
  },
  "blockedReason": null,
  "createdAt": "2026-06-05T07:28:21.000Z",
  "updatedAt": "2026-06-05T07:28:21.000Z",
  "metadata": {
    "screenshots": [
      ".gstack/design-reports/screenshots/jov-2794-start-loading-after-desktop.png",
      ".gstack/design-reports/screenshots/jov-2794-start-loading-after-mobile.png",
      ".gstack/design-reports/screenshots/jov-2794-start-loading-before-after.png"
    ],
    "report": ".gstack/design-reports/reports/jov-2794-start-loading-system-b.md",
    "routeFallbackCapture": "Live /start loading fallback resolved too quickly for a direct screenshot; harness rendered exact post-change DOM/classes against app CSS."
  }
}
-->
