### PR TITLE
fix(web): neutralize smart link gate banner accent

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/SmartLinkGateBanner.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/SmartLinkGateBanner.tsx
@@ -102,7 +102,7 @@ export function SmartLinkGateBanner(props: SmartLinkGateBannerProps) {
       <div className='flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/8'>
         <Icon
           name='Sparkles'
-          className='h-4 w-4 text-(--linear-accent)'
+          className='h-4 w-4 text-tertiary-token'
           aria-hidden='true'
         />
       </div>

--- a/apps/web/tests/components/release-provider-matrix/SmartLinkGateBanner.test.tsx
+++ b/apps/web/tests/components/release-provider-matrix/SmartLinkGateBanner.test.tsx
@@ -18,7 +18,23 @@ vi.mock('@/components/molecules/drawer', () => ({
 }));
 
 vi.mock('@/components/atoms/Icon', () => ({
-  Icon: ({ name }: { name: string }) => <span>{name}</span>,
+  Icon: ({
+    name,
+    className,
+    'aria-hidden': ariaHidden,
+  }: {
+    readonly name: string;
+    readonly className?: string;
+    readonly 'aria-hidden'?: boolean | 'false' | 'true';
+  }) => (
+    <span
+      aria-hidden={ariaHidden}
+      className={className}
+      data-testid='gate-icon'
+    >
+      {name}
+    </span>
+  ),
 }));
 
 const mockNudgeState = vi.hoisted(() => ({
@@ -86,5 +102,17 @@ describe('SmartLinkGateBanner', () => {
 
     expect(screen.getByText('3 upcoming releases')).toBeInTheDocument();
     expect(screen.getByText('Get Pro')).toBeInTheDocument();
+  });
+
+  it('uses a quiet System B text token for the gate icon', () => {
+    setNudgeState('never_trialed');
+    render(
+      <SmartLinkGateBanner mode='soft-cap' releasedCount={124} softCap={100} />
+    );
+
+    const icon = screen.getByTestId('gate-icon');
+
+    expect(icon).toHaveClass('h-4', 'w-4', 'text-tertiary-token');
+    expect(icon.className).not.toContain('--linear-accent');
   });
 });


### PR DESCRIPTION
## Summary
- replaces the SmartLinkGateBanner Sparkles icon legacy Linear accent with a quiet System B text token
- extends the focused banner test to preserve the icon dimensions and block the legacy accent token

## Layout Audit
- States enumerated: soft-cap banner and unreleased banner.
- The rendered element structure and sizing classes remain unchanged: icon wrapper keeps h-7 w-7, icon keeps h-4 w-4, copy and CTA markup are untouched.
- Change is color-only, verified by source inspection plus focused test coverage for the icon class.

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm exec biome check --write apps/web/components/features/dashboard/organisms/release-provider-matrix/SmartLinkGateBanner.tsx apps/web/tests/components/release-provider-matrix/SmartLinkGateBanner.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/components/release-provider-matrix/SmartLinkGateBanner.test.tsx
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- JOVIE_AGENT_PROFILE=coder rg guard confirmed SmartLinkGateBanner.tsx has no --linear-accent references
- Commit hook: staged Biome, ESLint, a11y check, web typecheck
- Pre-push hook: repo Biome, web proxy guard, Tailwind guard, typecheck, lint

<!-- linear-issue-id:JOV-2796 -->

<!-- agent-run-artifact
{
  "id": "jov-2796-smartlink-banner-gates-575595fdfcb8",
  "source": "github",
  "sourceRunId": "575595fdfcb80d19c3cfa0523526cb439f3ecee5",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2796 SmartLinkGateBanner System B gates",
  "summary": "Recorded QA, review, and ship evidence for neutralizing the SmartLinkGateBanner legacy accent.",
  "modelRoute": "deterministic",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr",
    "ready_pr"
  ],
  "forbiddenActions": [
    "deploy",
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2796",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2796/neutralize-smartlinkgatebanner-legacy-system-b-accent",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/10102",
  "adminSurface": "/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Soft-cap and unreleased banner states enumerated; source inspection confirms structure and sizing classes are unchanged and the edit is color-only.",
      "checkedAt": "2026-06-05T08:17:56.399Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Sparkles icon no longer uses the legacy Linear accent token; focused test asserts the quiet System B token and guards against drift.",
      "checkedAt": "2026-06-05T08:17:56.399Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Biome, SmartLinkGateBanner Vitest coverage, web typecheck, rg legacy-token guard, git diff check, commit hooks, and pre-push hooks passed after rebasing onto latest main.",
      "checkedAt": "2026-06-05T08:17:56.399Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic checks only."
  },
  "blockedReason": null,
  "createdAt": "2026-06-05T08:17:56.399Z",
  "updatedAt": "2026-06-05T08:17:56.399Z",
  "metadata": {
    "layoutStates": [
      "soft-cap banner",
      "unreleased banner"
    ],
    "changedPaths": [
      "apps/web/components/features/dashboard/organisms/release-provider-matrix/SmartLinkGateBanner.tsx",
      "apps/web/tests/components/release-provider-matrix/SmartLinkGateBanner.test.tsx"
    ],
    "rebasedOnto": "9d020426392592c4b151ef00a87a0b1b9e8cba5b"
  }
}
-->
