### PR TITLE
fix(web): neutralize release filter badge accents

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/FilterSubmenu.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/FilterSubmenu.tsx
@@ -111,7 +111,7 @@ export function FilterSubmenu<T extends string = string>({
           />
           <span>{label}</span>
           {selectedCount > 0 && (
-            <span className='rounded-md border border-(--linear-app-frame-seam) bg-surface-1 px-1.5 py-0.5 text-3xs font-caption text-secondary-token'>
+            <span className='rounded-md border border-subtle bg-surface-1 px-1.5 py-0.5 text-3xs font-caption text-tertiary-token'>
               {selectedCount}
             </span>
           )}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseFilterDropdown.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseFilterDropdown.tsx
@@ -172,6 +172,8 @@ interface ReleaseFilterDropdownProps {
 
 const FILTER_TRIGGER_ACTIVE_CLASS =
   'border-transparent bg-surface-1 text-primary-token';
+const FILTER_COUNT_BADGE_CLASS =
+  'rounded-md bg-surface-1 px-1.5 py-0.5 text-3xs font-caption text-tertiary-token';
 
 export function ReleaseFilterDropdown({
   filters,
@@ -389,7 +391,7 @@ export function ReleaseFilterDropdown({
                         />
                         <span>Label</span>
                         {labelFilterCount > 0 && (
-                          <span className='rounded-md bg-(--linear-accent-subtle) px-1.5 py-0.5 text-3xs font-caption text-(--linear-accent)'>
+                          <span className={FILTER_COUNT_BADGE_CLASS}>
                             {labelFilterCount}
                           </span>
                         )}

--- a/apps/web/tests/components/release-provider-matrix/release-filter-system-b-style-guard.test.ts
+++ b/apps/web/tests/components/release-provider-matrix/release-filter-system-b-style-guard.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readSource(relativePath: string) {
+  return readFileSync(
+    join(
+      process.cwd(),
+      'components/features/dashboard/organisms/release-provider-matrix',
+      relativePath
+    ),
+    'utf8'
+  );
+}
+
+describe('release filter System B style guard', () => {
+  it('keeps ReleaseFilterDropdown count badges off legacy accent variables', () => {
+    const source = readSource('ReleaseFilterDropdown.tsx');
+
+    expect(source).not.toContain('--linear-accent');
+    expect(source).toContain('bg-surface-1');
+    expect(source).toContain('text-tertiary-token');
+  });
+
+  it('keeps FilterSubmenu count badges on named System B seam utilities', () => {
+    const source = readSource('FilterSubmenu.tsx');
+
+    expect(source).not.toContain('border-(--linear-app-frame-seam)');
+    expect(source).toContain('border-subtle');
+    expect(source).toContain('bg-surface-1');
+    expect(source).toContain('text-tertiary-token');
+  });
+});


### PR DESCRIPTION
## Summary
- Replaced the release filter label-count badge legacy accent styling with neutral System B surface/text utilities.
- Replaced the filter submenu selected-count badge seam var with named `border-subtle` and quieter tertiary text.
- Added a focused guard so these filter badges stay off `--linear-accent` and `--linear-app-frame-seam` recipes.

## Layout Audit
States covered: filter count badge, submenu count badge, zero-count omitted state by existing conditional rendering.

The badge size recipe is unchanged: `rounded-md`, `px-1.5`, `py-0.5`, `text-3xs`, and `font-caption` remain stable. This PR changes color/seam utilities only, so no layout shift is introduced.

## Verification
- Worker verification passed: Biome on edited files, focused Vitest guard, web typecheck, `git diff --check`, and raw source guard.
- Parent verification passed: `pnpm --filter @jovie/web exec vitest run tests/components/release-provider-matrix/release-filter-system-b-style-guard.test.ts` passed, 1 file, 2 tests.
- Parent verification passed: `pnpm --filter @jovie/web run typecheck -- --pretty false`.
- Parent verification passed: `pnpm exec biome check --write apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseFilterDropdown.tsx apps/web/components/features/dashboard/organisms/release-provider-matrix/FilterSubmenu.tsx apps/web/tests/components/release-provider-matrix/release-filter-system-b-style-guard.test.ts`.
- Parent source scan for `--linear-accent`, `--linear-app-frame-seam`, `bg-(--linear-accent-subtle)`, `text-(--linear-accent)`, and `border-(--linear-app-frame-seam)` passed with no matches in the edited components.
- Pre-push passed: repo Biome, web proxy guard, Tailwind guard, typecheck, and lint.

<!-- linear-issue-id:JOV-2798 -->

<!-- agent-run-artifact
{
  "id": "jov-2798-release-filter-gates-2c4dd5a0e5fd",
  "source": "github",
  "sourceRunId": "2c4dd5a0e5fdb89ec7a528ab28bf422c8af07aed",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2798 Release filter System B gates",
  "summary": "Neutral release-filter badge styling verified with focused guard tests, source scans, typecheck, Biome, git diff check, and pre-push checks.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr",
    "ready_pr"
  ],
  "forbiddenActions": [
    "deploy",
    "mutate_production_data",
    "change_auth",
    "change_billing",
    "change_security"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2798",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2798/neutralize-release-filter-legacy-accent-badges",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/10106",
  "adminSurface": "/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused release-filter System B guard passed; edited components scan clean for legacy accent and seam vars.",
      "checkedAt": "2026-06-05T09:06:01.111Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Diff review found only color/seam utility changes with stable badge dimensions and no layout-shift risk.",
      "checkedAt": "2026-06-05T09:06:01.111Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Ship gate passed: Biome, focused Vitest, typecheck, git diff check, raw-style scan, and pre-push checks passed.",
      "checkedAt": "2026-06-05T09:06:01.111Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": null,
    "outputTokens": null,
    "notes": "Local deterministic checks plus parent review; no production mutation."
  },
  "blockedReason": null,
  "createdAt": "2026-06-05T09:06:01.111Z",
  "updatedAt": "2026-06-05T09:06:01.111Z",
  "metadata": {
    "changedFiles": [
      "apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseFilterDropdown.tsx",
      "apps/web/components/features/dashboard/organisms/release-provider-matrix/FilterSubmenu.tsx",
      "apps/web/tests/components/release-provider-matrix/release-filter-system-b-style-guard.test.ts"
    ],
    "parentVerification": [
      "focused vitest passed",
      "typecheck passed",
      "source scan passed",
      "pre-push passed"
    ]
  }
}
-->
