### PR TITLE
fix(web): tokenize chat entity right panel chrome

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx
@@ -71,7 +71,7 @@ export interface ChatProfileContextSummary {
 }
 
 const CHAT_ENTITY_RIGHT_PANEL_SHELL_CLASSNAME =
-  'hidden h-full min-h-0 w-[320px] shrink-0 overflow-hidden bg-(--linear-app-content-surface) lg:flex xl:w-[340px]';
+  'system-b-chat-entity-right-panel-shell hidden h-full min-h-0 w-[320px] shrink-0 overflow-hidden lg:flex xl:w-[340px]';
 
 function formatReleaseDate(value: string | undefined): string | null {
   if (!value) return null;
@@ -203,7 +203,7 @@ function ChatEntityContextCard({
       data-context-kind={target.kind}
       className='group relative flex min-w-0 items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-surface-1'
     >
-      <div className='flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-cyan-400/[0.08] text-cyan-300'>
+      <div className='system-b-chat-entity-context-icon'>
         <ChatRailContextIcon kind={target.kind} />
       </div>
       <div className='min-w-0 flex-1'>
@@ -410,7 +410,7 @@ function ChatEntityPanelSection({
   children: ReactNode;
 }>) {
   return (
-    <section className='border-t border-[color-mix(in_oklab,var(--linear-app-shell-border)_58%,transparent)] px-4 py-4'>
+    <section className='system-b-chat-entity-panel-section px-4 py-4'>
       <div className='mb-3 flex items-center gap-2 text-[12px] font-semibold text-secondary-token'>
         {icon}
         <h3>{title}</h3>
@@ -464,10 +464,10 @@ function ChatReleaseEntityPanel({
   return (
     <TableContextMenu items={contextMenuItems}>
       <aside
-        className='flex h-full min-h-0 w-full flex-col overflow-hidden bg-(--linear-app-content-surface)'
+        className='system-b-chat-entity-panel-surface flex h-full min-h-0 w-full flex-col overflow-hidden'
         data-testid='chat-release-entity-panel'
       >
-        <div className='flex shrink-0 items-center justify-between border-b border-[color-mix(in_oklab,var(--linear-app-shell-border)_64%,transparent)] px-4 py-3'>
+        <div className='system-b-chat-entity-panel-header flex shrink-0 items-center justify-between px-4 py-3'>
           <div className='min-w-0'>
             <p className='text-[11px] text-tertiary-token'>Release</p>
             <h2 className='truncate text-[13px] font-semibold text-primary-token'>
@@ -729,10 +729,10 @@ function ChatSimpleEntityPanel({
   const hasContent = !loading && children !== null;
   return (
     <aside
-      className='flex h-full min-h-0 w-full flex-col overflow-hidden bg-(--linear-app-content-surface)'
+      className='system-b-chat-entity-panel-surface flex h-full min-h-0 w-full flex-col overflow-hidden'
       data-testid={testId}
     >
-      <div className='flex shrink-0 items-center justify-between border-b border-[color-mix(in_oklab,var(--linear-app-shell-border)_64%,transparent)] px-4 py-3'>
+      <div className='system-b-chat-entity-panel-header flex shrink-0 items-center justify-between px-4 py-3'>
         <div className='min-w-0'>
           <p className='text-[11px] text-tertiary-token'>{eyebrow}</p>
           <h2 className='truncate text-[13px] font-semibold text-primary-token'>
@@ -910,10 +910,10 @@ function ChatProfileBentoPanel({
   return (
     <TableContextMenu items={contextMenuItems}>
       <aside
-        className='flex h-full min-h-0 w-full flex-col overflow-hidden bg-(--linear-app-content-surface)'
+        className='system-b-chat-entity-panel-surface flex h-full min-h-0 w-full flex-col overflow-hidden'
         data-testid='chat-profile-bento-panel'
       >
-        <div className='flex shrink-0 items-center justify-between border-b border-[color-mix(in_oklab,var(--linear-app-shell-border)_64%,transparent)] px-4 py-3'>
+        <div className='system-b-chat-entity-panel-header flex shrink-0 items-center justify-between px-4 py-3'>
           <div className='min-w-0'>
             <p className='text-[11px] text-tertiary-token'>Profile</p>
             <h2 className='truncate text-[13px] font-semibold text-primary-token'>
@@ -1101,7 +1101,7 @@ export function ChatEntityRightPanelHost({
           className={cn(CHAT_ENTITY_RIGHT_PANEL_SHELL_CLASSNAME, 'flex-col')}
           data-testid='chat-rail-context-and-entity-panel'
         >
-          <div className='shrink-0 border-b border-[color-mix(in_oklab,var(--linear-app-shell-border)_64%,transparent)]'>
+          <div className='system-b-chat-entity-panel-context-divider shrink-0'>
             {contextCards}
           </div>
           <div className='min-h-0 flex-1'>{entityPanel}</div>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2444,6 +2444,36 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
    SYSTEM B CHAT ENTITY PREVIEW PRIMITIVES
    ============================================ */
 
+:where(.system-b-chat-entity-right-panel-shell),
+:where(.system-b-chat-entity-panel-surface) {
+  background: var(--system-b-app-content-surface);
+}
+
+:where(.system-b-chat-entity-panel-header),
+:where(.system-b-chat-entity-panel-context-divider) {
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 72%, transparent);
+}
+
+:where(.system-b-chat-entity-panel-section) {
+  border-top: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 58%, transparent);
+}
+
+:where(.system-b-chat-entity-context-icon) {
+  display: flex;
+  width: var(--space-8);
+  height: var(--space-8);
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 64%, transparent);
+  border-radius: var(--radius-lg);
+  background: var(--system-b-bg-surface-1);
+  color: var(--color-text-tertiary-token);
+}
+
 .system-b-entity-chip {
   display: inline-flex;
   align-items: center;

--- a/apps/web/tests/unit/chat/chat-entity-right-panel-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/chat-entity-right-panel-system-b-style-guard.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+const sourcePath = 'app/app/(shell)/chat/ChatEntityRightPanelHost.tsx';
+const designSystemPath = 'styles/design-system.css';
+
+const legacyRightPanelPatterns = [
+  /bg-\(--linear-app-content-surface\)/,
+  /--linear-app-shell-border/,
+  /bg-cyan-/,
+  /text-cyan-/,
+  /border-\[color-mix\(in_oklab,var\(--linear-/,
+];
+
+describe('chat entity right panel System B style guard', () => {
+  it('keeps right-panel host chrome off legacy Linear utilities', () => {
+    const source = readFileSync(path.join(webRoot, sourcePath), 'utf8');
+    const offenders = legacyRightPanelPatterns
+      .filter(pattern => pattern.test(source))
+      .map(pattern => pattern.toString());
+
+    expect(offenders, `${sourcePath} leaked ${offenders.join(', ')}`).toEqual(
+      []
+    );
+    expect(source).toContain('system-b-chat-entity-right-panel-shell');
+    expect(source).toContain('system-b-chat-entity-panel-surface');
+    expect(source).toContain('system-b-chat-entity-panel-header');
+    expect(source).toContain('system-b-chat-entity-panel-section');
+    expect(source).toContain('system-b-chat-entity-context-icon');
+  });
+
+  it('defines right-panel chrome from System B aliases', () => {
+    const source = readFileSync(path.join(webRoot, designSystemPath), 'utf8');
+    const panelCss = source.match(
+      /:where\(\.system-b-chat-entity-right-panel-shell\)[\s\S]*?\.system-b-entity-chip\s*{/
+    )?.[0];
+
+    expect(panelCss).toBeDefined();
+    expect(panelCss).toContain('var(--system-b-app-content-surface)');
+    expect(panelCss).toContain('var(--system-b-app-frame-seam)');
+    expect(panelCss).toContain('var(--system-b-bg-surface-1)');
+    expect(panelCss).not.toMatch(/--linear-/);
+    expect(panelCss).not.toMatch(/\b(?:bg|text|border)-cyan-/);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces chat entity right-panel legacy Linear surface/header/section chrome with named System B primitives.
- Neutralizes the generic entity-context icon away from cyan utility styling while preserving the existing rail dimensions.
- Adds a focused source guard for the right-panel host and its System B CSS definitions.

## Linear
- JOV-2801

## Layout Shift Audit
- States checked: context-only rail, entity-only rail, context+entity rail, release loading/empty/content, simple contact/tour-date loading/empty/content, profile preview panel.
- The patch only moves background, border, and icon chrome into CSS classes. Existing width, height, min-height, flex, padding, overflow, and skeleton sizing remain unchanged.

## Verification
- `pnpm biome check --write "apps/web/app/app/(shell)/chat/ChatEntityRightPanelHost.tsx" apps/web/styles/design-system.css apps/web/tests/unit/chat/chat-entity-right-panel-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/chat/chat-entity-right-panel-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`
