### PR TITLE
fix(web): normalize threads System B surface chrome

### DIFF
--- a/apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx
+++ b/apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx
@@ -105,7 +105,7 @@ export function ChatsPageClient() {
       surfaceMode='default'
     >
       <div className='flex h-full min-h-0 flex-col'>
-        <div className='shrink-0 border-b border-[color-mix(in_oklab,var(--linear-app-frame-seam)_44%,transparent)] px-4 py-3 sm:px-6'>
+        <div className='shrink-0 border-b border-subtle px-4 py-3 sm:px-6'>
           <div className='flex items-center gap-2'>
             <AppSearchField
               value={query}
@@ -147,7 +147,7 @@ export function ChatsPageClient() {
               }}
             />
           ) : filteredThreads.length === 0 ? (
-            <div className='grid min-h-[18rem] place-items-center rounded-2xl border border-dashed border-[color-mix(in_oklab,var(--linear-app-frame-seam)_48%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_92%,transparent)] px-6 py-10 text-center'>
+            <div className='grid min-h-[18rem] place-items-center rounded-2xl border border-dashed border-subtle bg-surface-0 px-6 py-10 text-center'>
               <div className='max-w-sm space-y-3'>
                 <p className='text-[14px] font-semibold text-primary-token'>
                   {normalizedQuery

--- a/apps/web/tests/unit/app/threads-page-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/app/threads-page-system-b-style-guard.test.ts
@@ -1,0 +1,49 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const sourcePath = join(
+  appRoot,
+  'app/app/(shell)/threads/ThreadsPageClient.tsx'
+);
+
+const colorMixPattern = /color-mix\(/i;
+const inlineLinearSurfacePattern =
+  /\b(?:bg|border)-\[[^\]\n]*--linear-[^\]\n]*\]/;
+const legacyFrameSeamPattern =
+  /border-\[color-mix\(in_oklab,var\(--linear-app-frame-seam\)[^\]]+\)\]/;
+const legacyContentSurfacePattern =
+  /bg-\[color-mix\(in_oklab,var\(--linear-app-content-surface\)[^\]]+\)\]/;
+
+describe('threads page System B source contract', () => {
+  it('keeps threads chrome on named System B primitives', async () => {
+    const source = await readFile(sourcePath, 'utf8');
+
+    expect(source).not.toMatch(colorMixPattern);
+    expect(source).not.toMatch(inlineLinearSurfacePattern);
+    expect(source).not.toMatch(legacyFrameSeamPattern);
+    expect(source).not.toMatch(legacyContentSurfacePattern);
+    expect(source).toContain(
+      "className='shrink-0 border-b border-subtle px-4 py-3 sm:px-6'"
+    );
+    expect(source).toContain(
+      "className='grid min-h-[18rem] place-items-center rounded-2xl border border-dashed border-subtle bg-surface-0 px-6 py-10 text-center'"
+    );
+  });
+
+  it('keeps layout-state wrappers stable across thread states', async () => {
+    const source = await readFile(sourcePath, 'utf8');
+
+    expect(source).toContain("className='flex h-full min-h-0 flex-col'");
+    expect(source).toContain(
+      "className='min-h-0 flex-1 overflow-y-auto px-4 py-4 sm:px-6'"
+    );
+    expect(source).toContain('<ChatListSkeleton />');
+    expect(source).toContain('<PageErrorState');
+    expect(source).toContain('filteredThreads.length === 0');
+    expect(source).toContain('filteredThreads.map(thread => (');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the app threads toolbar seam and empty-state chrome with named System B primitives (`border-subtle`, `bg-surface-0`).
- Add a focused source guard for legacy inline `color-mix()` / `--linear-*` right-surface chrome and stable layout wrappers.

## Layout Shift Audit
States checked by source structure: loading skeleton, error/retry, empty/no-match, populated list, local search metadata, unread metadata, mobile and desktop. This PR changes color classes only; `h-full`, `min-h-0`, toolbar padding, scroll region, and empty-state `min-h-[18rem]` stay fixed.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/app/threads-page-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write 'apps/web/app/app/(shell)/threads/ThreadsPageClient.tsx' apps/web/tests/unit/app/threads-page-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: `next:proxy-guard`, Biome, ESLint, staged web typecheck
- pre-push hook: root `biome check .`, web `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`

Linear: JOV-2803

Blockers: none.
