### PR TITLE
fix(web): clean calendar system b chrome

### DIFF
--- a/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
+++ b/apps/web/app/app/(shell)/calendar/CalendarPageClient.tsx
@@ -847,16 +847,16 @@ function EventRow(props: EventRowProps) {
             </span>
           )}
         </div>
-        <div className='system-b-calendar-row-description mt-1 text-tertiary-token'>
+        <div className='system-b-calendar-row-description mt-1'>
           {event.subtitle}
         </div>
         {props.variant === 'pending' && event.lastSyncedAt && (
-          <div className='system-b-calendar-row-secondary mt-1 text-quaternary-token'>
+          <div className='system-b-calendar-row-secondary mt-1'>
             Last synced {formatReviewedAt(event.lastSyncedAt)}
           </div>
         )}
         {props.variant === 'confirmed' && reviewedLabel && (
-          <div className='system-b-calendar-row-secondary mt-1 text-quaternary-token'>
+          <div className='system-b-calendar-row-secondary mt-1'>
             Reviewed {reviewedLabel}
           </div>
         )}
@@ -923,7 +923,7 @@ type ProviderChipProps = Readonly<{
 
 function ProviderChip({ provider }: ProviderChipProps) {
   return (
-    <span className='system-b-calendar-provider-chip rounded bg-surface-0 px-1.5 py-0.5 text-tertiary-token'>
+    <span className='system-b-calendar-provider-chip rounded bg-surface-0 px-1.5 py-0.5'>
       {provider}
     </span>
   );

--- a/apps/web/tests/unit/calendar/calendar-shell-style-guard.test.ts
+++ b/apps/web/tests/unit/calendar/calendar-shell-style-guard.test.ts
@@ -12,7 +12,9 @@ const CHROME_CLASS_PATTERN = /(?:^|\s)(?:uppercase|tracking-[^\s'"]+)/;
 const LABEL_ELEMENT_PATTERN =
   /<(?:h3|h4|span)\b[\s\S]*?className=(?:'[^']*'|"[^"]*"|\{[^}]*\})[\s\S]*?>/g;
 const ROUTE_LOCAL_VISUAL_PATTERN =
-  /(?:text-\[[^\]]+\]|(?:min-[hw]|max-[hw]|w|h)-\[[^\]]+\]|border-\(--linear-[^)]+\)(?:\/\d+)?|(?:bg|text|border|accent)-(?:emerald|red|amber|violet|cyan)-[^\s'"]+|(?:bg|text)-quaternary-token\/\d+)/;
+  /(?:--linear-|color-mix\(|(?:bg|text|border|accent|ring|from|via|to|decoration)-(?:blue|sky|indigo|purple|violet|cyan|emerald|green|red|rose|pink|amber|yellow|orange|teal)-[^\s'"]+|(?:bg|text|border)-\[[^\]]+\]|(?:min-[hw]|max-[hw]|w|h)-\[[^\]]+\]|(?:bg|text)-quaternary-token\/\d+)/;
+const NAMED_COLOR_OWNER_PATTERN =
+  /className=(?:'[^']*\bsystem-b-calendar-(?:provider-chip|row-description|row-secondary)\b[^']*\btext-(?:tertiary-token|quaternary-token)\b[^']*'|"[^"]*\bsystem-b-calendar-(?:provider-chip|row-description|row-secondary)\b[^"]*\btext-(?:tertiary-token|quaternary-token)\b[^"]*")/g;
 
 function lineNumberFor(source: string, index: number): number {
   return source.slice(0, index).split('\n').length;
@@ -56,7 +58,20 @@ describe('calendar shell style guard', () => {
     expect(source).toContain('system-b-calendar-day-cell');
     expect(
       offenders,
-      `Calendar visual chrome should use named system-b-calendar-* classes backed by design-system.css.\n${offenders.join('\n')}`
+      `Calendar visual chrome should use named system-b-calendar-* classes instead of legacy Linear variables, color-mix(), arbitrary color utilities, or hardcoded accent utilities.\n${offenders.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('lets named detail metadata classes own their text color', () => {
+    const source = readFileSync(CALENDAR_CLIENT, 'utf8');
+    const offenders = [...source.matchAll(NAMED_COLOR_OWNER_PATTERN)].map(
+      match =>
+        `CalendarPageClient.tsx:${lineNumberFor(source, match.index ?? 0)} ${match[0].replace(/\s+/g, ' ').trim()}`
+    );
+
+    expect(
+      offenders,
+      `Calendar detail metadata classes should not carry duplicate route-local text color utilities.\n${offenders.join('\n')}`
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Removed duplicate route-local text color utilities from calendar detail metadata where named `system-b-calendar-*` classes already own text color.
- Expanded the calendar shell style guard to reject legacy `--linear-*`, `color-mix()`, arbitrary color utilities, and hardcoded accent palette utilities in `CalendarPageClient`.

## Layout Shift Audit
States inspected: loading, populated month grid, selected day with releases, selected day with confirmed events, selected day with pending events and bulk actions, rejected events collapsed/expanded, empty selected day, and each filter chip state. This change only moves text color ownership onto existing named classes; no DOM nodes, grid sizing, spacing utilities, or conditional rendering branches changed.

## Verification
- `pnpm --filter web exec vitest run tests/unit/calendar/calendar-shell-style-guard.test.ts tests/unit/calendar/CalendarPageClient.test.tsx` — 7 tests passed
- `pnpm biome check --write apps/web` — 5920 files checked, no fixes applied
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push` — passed

Linear: [JOV-2802](https://linear.app/jovie/issue/JOV-2802/clean-up-system-b-drift-on-app-calendar-page)