### PR TITLE
fix(web): tokenize dashboard copy link chrome

### DIFF
--- a/apps/web/components/features/dashboard/atoms/CopyLinkInput.tsx
+++ b/apps/web/components/features/dashboard/atoms/CopyLinkInput.tsx
@@ -7,7 +7,7 @@
  * - Displays URL in input-style container
  * - Copy icon button on the right
  * - Click to select all text
- * - Visual feedback on copy (green highlight)
+ * - Visual feedback on copy
  */
 
 import {
@@ -112,15 +112,13 @@ export function CopyLinkInput({
         value={displayValue ?? url}
         onClick={handleInputClick}
         aria-label='URL to copy'
+        data-copied={isCopied ? 'true' : undefined}
         className={cn(
-          'w-full rounded-full border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-1.5 pr-9',
-          'truncate font-mono text-app text-secondary-token',
-          'cursor-text focus-visible:border-(--linear-border-focus) focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)',
-          'transition-colors',
+          'system-b-copy-link-input w-full rounded-full border px-2.5 py-1.5 pr-9',
+          'truncate font-mono text-app',
+          'cursor-text focus-visible:outline-none',
           size === 'sm' && 'h-7',
           size === 'md' && 'h-9',
-          isCopied &&
-            'bg-green-50 border-green-300 dark:bg-green-900/20 dark:border-green-700',
           inputClassName
         )}
       />
@@ -129,29 +127,23 @@ export function CopyLinkInput({
         onClick={handleCopy}
         aria-label={isCopied ? 'Copied to clipboard' : 'Copy to clipboard'}
         title={isCopied ? 'Copied!' : 'Copy to clipboard'}
+        data-copied={isCopied ? 'true' : undefined}
         className={cn(
-          'absolute right-1.5 top-1/2 -translate-y-1/2 rounded-full border border-transparent p-1',
-          'text-tertiary-token hover:border-(--linear-app-frame-seam) hover:bg-surface-1 hover:text-primary-token',
-          'transition-colors',
-          isCopied && 'text-success',
+          'system-b-copy-link-button absolute right-1.5 rounded-full border p-1',
           buttonClassName
         )}
       >
         <span className='relative flex h-3.5 w-3.5 items-center justify-center'>
           <Icon
             name='Copy'
-            className={cn(
-              'absolute h-3.5 w-3.5 transition-all duration-150',
-              isCopied ? 'scale-50 opacity-0' : 'scale-100 opacity-100'
-            )}
+            className='system-b-copy-link-icon absolute h-3.5 w-3.5'
+            data-visible={isCopied ? 'false' : 'true'}
             aria-hidden='true'
           />
           <Icon
             name='Check'
-            className={cn(
-              'absolute h-3.5 w-3.5 transition-all duration-150',
-              isCopied ? 'scale-100 opacity-100' : 'scale-50 opacity-0'
-            )}
+            className='system-b-copy-link-icon absolute h-3.5 w-3.5'
+            data-visible={isCopied ? 'true' : 'false'}
             aria-hidden='true'
           />
         </span>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -4348,6 +4348,76 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   }
 }
 
+.system-b-copy-link-input {
+  border-color: var(--system-b-app-frame-seam);
+  background: var(--system-b-bg-surface-0);
+  color: var(--color-text-secondary-token);
+  transition:
+    background-color var(--duration-fast) var(--ease-subtle),
+    border-color var(--duration-fast) var(--ease-subtle),
+    color var(--duration-fast) var(--ease-subtle),
+    box-shadow var(--duration-fast) var(--ease-subtle);
+}
+
+.system-b-copy-link-input:focus-visible {
+  border-color: var(--color-border-focus);
+  box-shadow: 0 0 0 1px var(--color-border-focus);
+}
+
+.system-b-copy-link-input[data-copied="true"] {
+  border-color: color-mix(
+    in oklab,
+    var(--color-success) 34%,
+    var(--system-b-app-frame-seam)
+  );
+  background: color-mix(
+    in oklab,
+    var(--color-success) 8%,
+    var(--system-b-bg-surface-0)
+  );
+  color: var(--color-text-primary-token);
+}
+
+.system-b-copy-link-button {
+  top: 50%;
+  transform: translateY(-50%);
+  border-color: transparent;
+  color: var(--color-text-tertiary-token);
+  transition:
+    background-color var(--duration-fast) var(--ease-subtle),
+    border-color var(--duration-fast) var(--ease-subtle),
+    color var(--duration-fast) var(--ease-subtle);
+}
+
+.system-b-copy-link-button:hover {
+  border-color: var(--system-b-app-frame-seam);
+  background: var(--system-b-bg-surface-1);
+  color: var(--color-text-primary-token);
+}
+
+.system-b-copy-link-button[data-copied="true"] {
+  border-color: color-mix(
+    in oklab,
+    var(--color-success) 32%,
+    var(--system-b-app-frame-seam)
+  );
+  background: color-mix(
+    in oklab,
+    var(--color-success) 10%,
+    var(--system-b-bg-surface-1)
+  );
+  color: var(--color-success);
+}
+
+.system-b-copy-link-icon {
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--ease-subtle);
+}
+
+.system-b-copy-link-icon[data-visible="true"] {
+  opacity: 1;
+}
+
 :where(.system-b-chat-composer-surface) {
   border: 1px solid
     color-mix(in oklab, var(--system-b-app-frame-seam) 84%, transparent);

--- a/apps/web/tests/unit/dashboard/copy-link-input-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/copy-link-input-system-b-style-guard.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+const copyLinkSourcePath =
+  'components/features/dashboard/atoms/CopyLinkInput.tsx';
+
+const forbiddenLocalChromePatterns = [
+  /\bgreen-/,
+  /\bscale-(?:50|100)\b/,
+  /\btransition-all\b/,
+  /-translate-y-1\/2/,
+  /rgba?\(/,
+  /\b(?:bg|border|shadow)-\[/,
+] as const;
+
+describe('CopyLinkInput System B source contract', () => {
+  it('keeps copied-state chrome on named System B primitives', () => {
+    const source = readFileSync(resolve(appRoot, copyLinkSourcePath), 'utf8');
+
+    for (const pattern of forbiddenLocalChromePatterns) {
+      expect(source, `${copyLinkSourcePath} matched ${pattern}`).not.toMatch(
+        pattern
+      );
+    }
+
+    for (const className of [
+      'system-b-copy-link-input',
+      'system-b-copy-link-button',
+      'system-b-copy-link-icon',
+    ]) {
+      expect(source).toContain(className);
+    }
+
+    expect(source).toContain('data-copied');
+    expect(source).toContain('data-visible');
+
+    for (const stableGeometryClass of [
+      'pr-9',
+      'h-7',
+      'h-9',
+      'right-1.5',
+      'p-1',
+      'h-3.5 w-3.5',
+    ]) {
+      expect(source).toContain(stableGeometryClass);
+    }
+  });
+
+  it('defines the copy-link visual states in the design system source of truth', () => {
+    const styles = readFileSync(
+      resolve(appRoot, 'styles/design-system.css'),
+      'utf8'
+    );
+
+    for (const selector of [
+      '.system-b-copy-link-input',
+      '.system-b-copy-link-input[data-copied="true"]',
+      '.system-b-copy-link-button',
+      '.system-b-copy-link-button[data-copied="true"]',
+      '.system-b-copy-link-icon',
+      '.system-b-copy-link-icon[data-visible="true"]',
+    ]) {
+      expect(styles).toContain(selector);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Move `CopyLinkInput` default/copied/hover/focus chrome onto named System B primitives.
- Replace copied-state scale swapping with opacity-only icon visibility inside the existing fixed icon box.
- Add a dashboard source guard for copied-state drift and stable geometry classes.

Linear: JOV-2805

## Layout Shift Audit
States inspected: default, copied, hover, focus-visible, `sm`, `md`, and parent-supplied input/button classes. The DOM shape, input heights (`h-7`/`h-9`), `pr-9`, right button anchor, `p-1`, and `h-3.5 w-3.5` icon box stay constant. Copy/check state changes use `data-visible` opacity only.

## Verification
- `pnpm biome check --write apps/web/components/features/dashboard/atoms/CopyLinkInput.tsx apps/web/styles/design-system.css apps/web/tests/unit/dashboard/copy-link-input-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/copy-link-input-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `rg -n "green-|scale-50|scale-100|transition-all|-translate-y-1/2|rgba?\(|bg-\[|border-\[|shadow-\[" apps/web/components/features/dashboard/atoms/CopyLinkInput.tsx` returned no matches
- Commit hook: proxy guard, staged Biome/format, ESLint, staged a11y, web typecheck
- Pre-push hook: full Biome, proxy guard, Tailwind guard, web typecheck, web lint
