### PR TITLE
fix(web): tokenize homepage claim handle chrome

### DIFF
--- a/apps/web/components/features/home/HeroClaimHandle.tsx
+++ b/apps/web/components/features/home/HeroClaimHandle.tsx
@@ -4,28 +4,6 @@ interface HeroClaimHandleProps {
   readonly submitButtonTestId?: string;
 }
 
-const FALLBACK_ROW_STYLE = {
-  minHeight: 56,
-  background:
-    'linear-gradient(180deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0.018) 100%)',
-  border: '1px solid rgba(255,255,255,0.08)',
-  boxShadow:
-    '0 10px 24px rgba(0,0,0,0.14), inset 0 1px 0 rgba(255,255,255,0.04)',
-} as const;
-
-const FALLBACK_BUTTON_STYLE = {
-  height: 38,
-  fontSize: '12px',
-  fontWeight: 510,
-  letterSpacing: '-0.005em',
-  background:
-    'linear-gradient(180deg, rgba(244,245,246,0.96) 0%, rgba(228,230,232,0.92) 100%)',
-  color: 'rgb(8,9,10)',
-  boxShadow:
-    '0 6px 18px rgba(0,0,0,0.14), inset 0 1px 0 rgba(255,255,255,0.34)',
-  border: '1px solid rgba(255,255,255,0.12)',
-} as const;
-
 export function HeroClaimHandle({
   submitButtonTestId,
 }: Readonly<HeroClaimHandleProps>) {
@@ -33,27 +11,14 @@ export function HeroClaimHandle({
     <form action={APP_ROUTES.SIGNUP} className='w-full' method='get'>
       <input name='redirect_url' type='hidden' value={APP_ROUTES.START} />
       <div
-        className='relative flex w-full items-center gap-2 rounded-[1rem] p-[0.35rem]'
-        style={FALLBACK_ROW_STYLE}
+        className='system-b-claim-handle-row relative flex w-full items-center gap-2'
+        data-size='hero'
+        data-available='false'
       >
-        <div
-          aria-hidden='true'
-          className='pointer-events-none absolute inset-x-2 top-0 h-px rounded-full'
-          style={{
-            background:
-              'linear-gradient(90deg, transparent, rgba(255,255,255,0.2) 20%, rgba(255,255,255,0.24) 50%, rgba(255,255,255,0.18) 80%, transparent)',
-          }}
-        />
         <div className='flex min-w-0 flex-1 items-center gap-0 pl-3.5 pr-1.5'>
           <span
-            className='shrink-0 select-none'
-            style={{
-              fontSize: '15px',
-              fontWeight: 450,
-              letterSpacing: '-0.016em',
-              color: 'var(--linear-text-tertiary)',
-              fontFamily: 'inherit',
-            }}
+            className='system-b-claim-handle-domain shrink-0 select-none'
+            data-size='hero'
           >
             jov.ie/
           </span>
@@ -62,23 +27,20 @@ export function HeroClaimHandle({
             autoCapitalize='none'
             autoComplete='off'
             autoCorrect='off'
-            className='min-w-0 flex-1 bg-transparent placeholder:text-quaternary-token focus-visible:outline-none'
+            className='system-b-claim-handle-input min-w-0 flex-1 bg-transparent placeholder:text-quaternary-token focus-visible:outline-none'
+            data-size='hero'
+            data-available='false'
             name='handle'
             placeholder='you'
-            style={{
-              fontSize: '16px',
-              fontWeight: 510,
-              letterSpacing: '-0.022em',
-              color: 'var(--linear-text-primary)',
-            }}
             type='text'
           />
         </div>
 
         <button
-          className='group inline-flex shrink-0 items-center justify-center gap-1.5 rounded-[0.8rem] px-4 transition-[background-color,color,box-shadow,filter,opacity] duration-slow hover:brightness-110 focus-ring-themed'
+          className='system-b-claim-handle-button group inline-flex shrink-0 items-center justify-center gap-1.5 focus-ring-themed'
           data-testid={submitButtonTestId}
-          style={FALLBACK_BUTTON_STYLE}
+          data-size='hero'
+          data-disabled='false'
           type='submit'
         >
           <span className='whitespace-nowrap'>Claim</span>

--- a/apps/web/components/features/home/claim-handle/ClaimHandleForm.tsx
+++ b/apps/web/components/features/home/claim-handle/ClaimHandleForm.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-type ClaimHandleSize = 'default' | 'hero' | 'display';
-
 import { ChevronRight } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import {
@@ -23,147 +21,6 @@ import type { ClaimHandleFormProps } from './types';
 import { useHandleValidation } from './useHandleValidation';
 import { HELPER_TONE_CLASSES, useHelperState } from './useHelperState';
 
-function getInputRowStyleHero(isAvailable: boolean) {
-  return {
-    minHeight: 56,
-    background:
-      'linear-gradient(180deg, rgba(255,255,255,0.03) 0%, rgba(255,255,255,0.018) 100%)',
-    border: `1px solid ${isAvailable ? 'rgba(74,222,128,0.22)' : 'rgba(255,255,255,0.08)'}`,
-    boxShadow: isAvailable
-      ? '0 12px 30px rgba(0,0,0,0.14), inset 0 1px 0 rgba(255,255,255,0.04), 0 0 16px rgba(74,222,128,0.05)'
-      : '0 12px 30px rgba(0,0,0,0.14), inset 0 1px 0 rgba(255,255,255,0.04)',
-    backdropFilter: 'blur(14px)',
-    WebkitBackdropFilter: 'blur(14px)',
-  };
-}
-
-function getInputRowStyle(size: ClaimHandleSize, isAvailable: boolean) {
-  if (size === 'hero') return getInputRowStyleHero(isAvailable);
-
-  const isDisplay = size === 'display';
-  const isHeroLike = size !== 'default';
-  let borderColor = 'rgba(255,255,255,0.06)';
-  if (isAvailable) borderColor = 'rgba(74,222,128,0.25)';
-  else if (isHeroLike) borderColor = 'rgba(255,255,255,0.1)';
-
-  const heroShadow = [
-    '0 14px 38px rgba(0,0,0,0.18)',
-    'inset 0 1px 0 rgba(255,255,255,0.04)',
-    isAvailable
-      ? '0 0 18px rgba(74,222,128,0.06)'
-      : '0 1px 4px rgba(0,0,0,0.18)',
-  ].join(', ');
-
-  const defaultShadow = [
-    'inset 0 1px 2px rgba(0,0,0,0.2)',
-    isAvailable
-      ? '0 0 20px rgba(74,222,128,0.06)'
-      : '0 1px 2px rgba(0,0,0,0.1)',
-  ].join(', ');
-
-  let minHeight = 52;
-  if (isDisplay) minHeight = 88;
-  else if (isHeroLike) minHeight = 58;
-
-  return {
-    minHeight,
-    background: isHeroLike
-      ? 'linear-gradient(180deg, rgba(255,255,255,0.04) 0%, rgba(255,255,255,0.024) 100%)'
-      : 'rgba(255,255,255,0.03)',
-    border: `${isDisplay ? 1.5 : 1}px solid ${borderColor}`,
-    boxShadow: isHeroLike ? heroShadow : defaultShadow,
-  };
-}
-
-function getDomainPrefixStyle(size: ClaimHandleSize) {
-  if (size === 'display') {
-    return {
-      fontSize: '28px',
-      fontWeight: 510,
-      letterSpacing: '-0.04em',
-      color: 'var(--linear-text-quaternary)',
-      fontFamily: 'inherit',
-    } as const;
-  }
-  if (size === 'hero') {
-    return {
-      fontSize: '15px',
-      fontWeight: 450,
-      letterSpacing: '-0.016em',
-      color: 'var(--linear-text-tertiary)',
-      fontFamily: 'inherit',
-    } as const;
-  }
-  return {
-    fontSize: '13px',
-    fontWeight: 400,
-    color: 'var(--linear-text-tertiary)',
-    letterSpacing: '-0.02em',
-    fontFamily: 'monospace',
-  } as const;
-}
-
-function getInputStyle(size: ClaimHandleSize, isAvailable: boolean) {
-  const isHero = size === 'hero';
-  const isDisplay = size === 'display';
-  const color = isAvailable ? 'rgb(74,222,128)' : 'var(--linear-text-primary)';
-  if (isDisplay) {
-    return {
-      fontSize: '28px',
-      fontWeight: 510,
-      letterSpacing: '-0.04em',
-      color,
-    };
-  }
-  if (isHero) {
-    return {
-      fontSize: '16px',
-      fontWeight: 510,
-      letterSpacing: '-0.022em',
-      color,
-    };
-  }
-  return { fontSize: '13px', fontWeight: 450, letterSpacing: '-0.01em', color };
-}
-
-function getButtonStyle(size: ClaimHandleSize, isDisabled: boolean) {
-  const isHero = size === 'hero';
-  const isDisplay = size === 'display';
-  if (isHero) {
-    return {
-      height: 38,
-      fontSize: '12px',
-      fontWeight: 510,
-      letterSpacing: '-0.005em',
-      background:
-        'linear-gradient(180deg, rgba(244,245,246,0.96) 0%, rgba(228,230,232,0.92) 100%)',
-      color: isDisabled ? 'var(--linear-text-quaternary)' : 'rgb(8,9,10)',
-      boxShadow: isDisabled
-        ? 'none'
-        : '0 6px 18px rgba(0,0,0,0.14), inset 0 1px 0 rgba(255,255,255,0.34)',
-      border: isDisabled
-        ? '1px solid transparent'
-        : '1px solid rgba(255,255,255,0.12)',
-    };
-  }
-  return {
-    height: isDisplay ? 64 : 36,
-    fontSize: isDisplay ? '16px' : '13px',
-    fontWeight: 510,
-    letterSpacing: '-0.01em',
-    background: isDisabled
-      ? 'rgba(255,255,255,0.06)'
-      : 'linear-gradient(180deg, rgb(244,245,246) 0%, rgb(228,230,232) 100%)',
-    color: isDisabled ? 'var(--linear-text-quaternary)' : 'rgb(8,9,10)',
-    boxShadow: isDisabled
-      ? 'none'
-      : '0 10px 24px rgba(0,0,0,0.2), 0 1px 3px rgba(0,0,0,0.32), inset 0 1px 0 rgba(255,255,255,0.4)',
-    border: isDisabled
-      ? '1px solid transparent'
-      : '1px solid rgba(255,255,255,0.18)',
-  };
-}
-
 export function ClaimHandleForm({
   onHandleChange,
   size = 'default',
@@ -172,7 +29,6 @@ export function ClaimHandleForm({
   submitTracking,
 }: Readonly<ClaimHandleFormProps>) {
   const isHero = size === 'hero';
-  const isDisplay = size === 'display';
   const isHeroLike = size !== 'default';
   const router = useRouter();
   const { isSignedIn } = useAuthSafe();
@@ -281,18 +137,6 @@ export function ClaimHandleForm({
   const hasClientError = !!handleError;
   const isDisabled = navigating || hasClientError;
 
-  const inputRowStyle = getInputRowStyle(size, isAvailable);
-  const inputStyle = getInputStyle(size, isAvailable);
-  const buttonStyle = getButtonStyle(size, isDisabled);
-
-  let sizeRoundingClass = 'rounded-xl p-1';
-  if (isDisplay) sizeRoundingClass = 'rounded-[1.4rem] p-1.5 sm:p-2';
-  else if (isHero) sizeRoundingClass = 'rounded-[1rem] p-[0.35rem]';
-
-  let buttonRoundingClass = 'rounded-lg px-3.5 sm:px-4';
-  if (isDisplay) buttonRoundingClass = 'rounded-[1rem] px-6 sm:px-7';
-  else if (isHero) buttonRoundingClass = 'rounded-[0.8rem] px-4';
-
   return (
     <form
       onSubmit={onSubmit}
@@ -304,23 +148,13 @@ export function ClaimHandleForm({
       <div
         className={cn(
           'claim-input-row',
-          'relative flex w-full items-center gap-2 transition-[background,border-color,box-shadow] duration-cinematic ease-cinematic',
-          sizeRoundingClass,
+          'system-b-claim-handle-row',
+          'relative flex w-full items-center gap-2',
           isAvailable && 'claim-input-row--available'
         )}
-        style={inputRowStyle}
+        data-size={size}
+        data-available={isAvailable ? 'true' : 'false'}
       >
-        {isHeroLike && (
-          <div
-            aria-hidden='true'
-            className='pointer-events-none absolute inset-x-2 top-0 h-px rounded-full'
-            style={{
-              background:
-                'linear-gradient(90deg, transparent, rgba(255,255,255,0.2) 20%, rgba(255,255,255,0.24) 50%, rgba(255,255,255,0.18) 80%, transparent)',
-            }}
-          />
-        )}
-
         <div
           className={cn(
             'flex min-w-0 flex-1 items-center gap-0',
@@ -329,8 +163,8 @@ export function ClaimHandleForm({
         >
           {/* Domain prefix — etched, permanent feel */}
           <span
-            className='shrink-0 select-none'
-            style={getDomainPrefixStyle(size)}
+            className='system-b-claim-handle-domain shrink-0 select-none'
+            data-size={size}
           >
             {displayDomain}/
           </span>
@@ -349,8 +183,15 @@ export function ClaimHandleForm({
             aria-label='Choose your handle'
             aria-invalid={unavailable ? 'true' : undefined}
             aria-describedby={helperState.text ? 'handle-hint' : undefined}
-            className={`min-w-0 flex-1 bg-transparent focus-visible:outline-none ${isHeroLike ? 'placeholder:text-quaternary-token' : 'placeholder:text-tertiary-token'}`}
-            style={inputStyle}
+            className={cn(
+              'system-b-claim-handle-input',
+              'min-w-0 flex-1 bg-transparent focus-visible:outline-none',
+              isHeroLike
+                ? 'placeholder:text-quaternary-token'
+                : 'placeholder:text-tertiary-token'
+            )}
+            data-size={size}
+            data-available={isAvailable ? 'true' : 'false'}
           />
 
           <HandleStatusIcon
@@ -367,14 +208,12 @@ export function ClaimHandleForm({
           disabled={isDisabled}
           data-testid={submitButtonTestId}
           aria-busy={checkingAvail || navigating}
+          data-size={size}
+          data-disabled={isDisabled ? 'true' : 'false'}
           className={cn(
-            'group shrink-0 inline-flex items-center justify-center gap-1.5 transition-[background,opacity,filter] duration-slow focus-ring-themed',
-            buttonRoundingClass,
-            isDisabled
-              ? 'cursor-not-allowed opacity-40'
-              : 'hover:brightness-110'
+            'system-b-claim-handle-button',
+            'group shrink-0 inline-flex items-center justify-center gap-1.5 focus-ring-themed'
           )}
-          style={buttonStyle}
         >
           <span className='inline-flex items-center gap-1.5 whitespace-nowrap'>
             {buttonContent}
@@ -383,38 +222,21 @@ export function ClaimHandleForm({
       </div>
 
       {/* Helper text — minimal, surgical */}
-      {!hideHelperText && helperState.text && (
+      {!hideHelperText && (
         <p
           id='handle-hint'
           data-testid='claim-handle-status'
           className={cn(
+            'system-b-claim-handle-helper',
             'mt-2 pl-1 transition-colors duration-slow',
             helperToneClass
           )}
+          data-visible={helperState.text ? 'true' : 'false'}
+          aria-hidden={helperState.text ? undefined : 'true'}
           aria-live={helperState.tone === 'error' ? 'assertive' : 'polite'}
-          style={{
-            fontSize: '11px',
-            lineHeight: '16px',
-            letterSpacing: '0.01em',
-            fontWeight: 400,
-          }}
+          role={formSubmitted && handleError ? 'alert' : undefined}
         >
-          {helperState.text}
-        </p>
-      )}
-
-      {/* Error summary for form validation */}
-      {!hideHelperText && formSubmitted && handleError && (
-        <p
-          className='mt-1.5 pl-1'
-          style={{
-            fontSize: '11px',
-            color: 'var(--linear-warning)',
-            fontWeight: 400,
-          }}
-          role='alert'
-        >
-          {handleError}
+          {helperState.text || ' '}
         </p>
       )}
     </form>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2368,6 +2368,199 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
 }
 
 /* ============================================
+   SYSTEM B HOME CLAIM HANDLE PRIMITIVES
+   ============================================ */
+
+.system-b-claim-handle-row {
+  min-height: 52px;
+  overflow: hidden;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 70%, transparent);
+  border-radius: var(--radius-xl);
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-1) 90%,
+    transparent
+  );
+  padding: var(--space-1);
+  transition:
+    background var(--ds-motion-cinematic-duration)
+    var(--ds-motion-cinematic-easing),
+    border-color var(--ds-motion-cinematic-duration)
+    var(--ds-motion-cinematic-easing);
+}
+
+.system-b-claim-handle-row[data-size="hero"] {
+  min-height: 56px;
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-app-frame-seam) 78%,
+    transparent
+  );
+  border-radius: 1rem;
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-1) 84%,
+    var(--system-b-app-content-surface) 16%
+  );
+  padding: 0.35rem;
+}
+
+.system-b-claim-handle-row[data-size="display"] {
+  min-height: 88px;
+  border-width: 1.5px;
+  border-radius: 1.4rem;
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-1) 88%,
+    var(--system-b-bg-surface-0) 12%
+  );
+  padding: 0.375rem;
+}
+
+.system-b-claim-handle-row[data-available="true"] {
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-app-frame-seam) 76%,
+    var(--color-success) 24%
+  );
+}
+
+.system-b-claim-handle-domain {
+  color: var(--color-text-tertiary-token);
+  font-family: var(
+    --font-geist-mono,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace
+  );
+  font-size: var(--text-app);
+  font-weight: var(--font-weight-normal);
+  letter-spacing: 0;
+}
+
+.system-b-claim-handle-domain[data-size="hero"] {
+  color: var(--color-text-tertiary-token);
+  font-family: inherit;
+  font-size: 15px;
+  font-weight: 450;
+}
+
+.system-b-claim-handle-domain[data-size="display"] {
+  color: var(--color-text-quaternary-token);
+  font-family: inherit;
+  font-size: 28px;
+  font-weight: 510;
+}
+
+.system-b-claim-handle-input {
+  color: var(--color-text-primary-token);
+  caret-color: var(--color-text-primary-token);
+  font-size: var(--text-app);
+  font-weight: 450;
+  letter-spacing: 0;
+}
+
+.system-b-claim-handle-input[data-size="hero"] {
+  font-size: 16px;
+  font-weight: 510;
+}
+
+.system-b-claim-handle-input[data-size="display"] {
+  font-size: 28px;
+  font-weight: 510;
+}
+
+.system-b-claim-handle-input[data-available="true"] {
+  color: var(--color-text-primary-token);
+}
+
+.system-b-claim-handle-button {
+  height: 36px;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-primary-bg) 22%, transparent);
+  border-radius: var(--radius-lg);
+  background: var(--system-b-primary-bg);
+  color: var(--system-b-primary-fg);
+  padding-inline: 0.875rem;
+  font-size: var(--text-app);
+  font-weight: 510;
+  letter-spacing: 0;
+  transition:
+    background var(--system-b-duration-fast) var(--system-b-ease),
+    border-color var(--system-b-duration-fast) var(--system-b-ease),
+    color var(--system-b-duration-fast) var(--system-b-ease),
+    opacity var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+.system-b-claim-handle-button[data-size="hero"] {
+  height: 38px;
+  border-radius: 0.8rem;
+  padding-inline: var(--space-4);
+  font-size: var(--text-xs);
+}
+
+.system-b-claim-handle-button[data-size="display"] {
+  height: 64px;
+  border-radius: 1rem;
+  padding-inline: var(--space-6);
+  font-size: var(--text-base);
+}
+
+.system-b-claim-handle-button:not(:disabled):hover,
+.system-b-claim-handle-button:not(:disabled):focus-visible {
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-primary-bg) 34%,
+    transparent
+  );
+  background: color-mix(
+    in oklab,
+    var(--system-b-primary-bg) 92%,
+    var(--system-b-primary-fg) 8%
+  );
+}
+
+.system-b-claim-handle-button[data-disabled="true"] {
+  cursor: not-allowed;
+  border-color: transparent;
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-2) 82%,
+    transparent
+  );
+  color: var(--color-text-quaternary-token);
+  opacity: 0.42;
+}
+
+.system-b-claim-handle-helper {
+  min-height: 16px;
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-normal);
+  letter-spacing: 0;
+  line-height: 16px;
+}
+
+.system-b-claim-handle-helper[data-visible="false"] {
+  visibility: hidden;
+}
+
+@media (min-width: 640px) {
+  .system-b-claim-handle-row[data-size="display"] {
+    padding: var(--space-2);
+  }
+
+  .system-b-claim-handle-button {
+    padding-inline: var(--space-4);
+  }
+
+  .system-b-claim-handle-button[data-size="display"] {
+    padding-inline: var(--space-7);
+  }
+}
+
+/* ============================================
    SYSTEM B ONBOARDING V2 PRIMITIVES
    ============================================ */
 

--- a/apps/web/tests/unit/home/claim-handle-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/claim-handle-system-b-style-guard.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { render, screen } from '@testing-library/react';
+import { createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+import { HeroClaimHandle } from '@/features/home/HeroClaimHandle';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+const claimHandleSourcePaths = [
+  'components/features/home/claim-handle/ClaimHandleForm.tsx',
+  'components/features/home/HeroClaimHandle.tsx',
+] as const;
+
+const forbiddenLocalChromePatterns = [
+  /rgba?\(/,
+  /linear-gradient/,
+  /boxShadow/,
+  /backdropFilter/,
+  /WebkitBackdropFilter/,
+  /style=/,
+  /\bgreen-/,
+  /\b(?:bg|border|shadow)-\[/,
+  /\btransition-all\b/,
+  /hover:brightness/,
+  /\b(?:scale|translate)-/,
+] as const;
+
+describe('ClaimHandleForm System B source contract', () => {
+  it('renders the static hero claim form on System B primitives', () => {
+    render(
+      createElement(HeroClaimHandle, {
+        submitButtonTestId: 'homepage-primary-cta',
+      })
+    );
+
+    const button = screen.getByTestId('homepage-primary-cta');
+    const form = button.closest('form');
+    const row = form?.querySelector('.system-b-claim-handle-row');
+    const input = screen.getByRole('textbox', { name: /choose your handle/i });
+
+    expect(form).toHaveAttribute('action', '/signup');
+    expect(row).toHaveAttribute('data-size', 'hero');
+    expect(row).toHaveAttribute('data-available', 'false');
+    expect(input).toHaveClass('system-b-claim-handle-input');
+    expect(button).toHaveClass('system-b-claim-handle-button');
+    expect(button).toHaveAttribute('data-disabled', 'false');
+  });
+
+  it('keeps claim-handle chrome on named System B primitives', () => {
+    for (const sourcePath of claimHandleSourcePaths) {
+      const source = readFileSync(resolve(appRoot, sourcePath), 'utf8');
+
+      for (const pattern of forbiddenLocalChromePatterns) {
+        expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+      }
+
+      for (const className of [
+        'system-b-claim-handle-row',
+        'system-b-claim-handle-domain',
+        'system-b-claim-handle-input',
+        'system-b-claim-handle-button',
+      ]) {
+        expect(source).toContain(className);
+      }
+
+      for (const stateAttribute of [
+        'data-size',
+        'data-available',
+        'data-disabled',
+      ]) {
+        expect(source).toContain(stateAttribute);
+      }
+    }
+
+    const interactiveSource = readFileSync(
+      resolve(
+        appRoot,
+        'components/features/home/claim-handle/ClaimHandleForm.tsx'
+      ),
+      'utf8'
+    );
+    expect(interactiveSource).toContain('system-b-claim-handle-helper');
+    expect(interactiveSource).toContain('data-visible');
+  });
+
+  it('defines stable claim-handle visual states in the design system source of truth', () => {
+    const styles = readFileSync(
+      resolve(appRoot, 'styles/design-system.css'),
+      'utf8'
+    );
+
+    for (const selector of [
+      '.system-b-claim-handle-row',
+      '.system-b-claim-handle-row[data-size="hero"]',
+      '.system-b-claim-handle-row[data-size="display"]',
+      '.system-b-claim-handle-row[data-available="true"]',
+      '.system-b-claim-handle-domain',
+      '.system-b-claim-handle-input',
+      '.system-b-claim-handle-input[data-available="true"]',
+      '.system-b-claim-handle-button',
+      '.system-b-claim-handle-button[data-size="hero"]',
+      '.system-b-claim-handle-button[data-size="display"]',
+      '.system-b-claim-handle-button[data-disabled="true"]',
+      '.system-b-claim-handle-helper',
+      '.system-b-claim-handle-helper[data-visible="false"]',
+    ]) {
+      expect(styles).toContain(selector);
+    }
+
+    for (const stableDimension of [
+      'min-height: 52px;',
+      'min-height: 56px;',
+      'min-height: 88px;',
+      'height: 36px;',
+      'height: 38px;',
+      'height: 64px;',
+      'min-height: 16px;',
+    ]) {
+      expect(styles).toContain(stableDimension);
+    }
+  });
+});


### PR DESCRIPTION
Linear: JOV-2806

## Summary
- Move homepage claim-handle row/input/button chrome from inline gradients, raw color recipes, and hover brightness onto named System B primitives.
- Apply the shared primitives to both the static hero claim form and the interactive claim-handle form.
- Reserve the helper slot in the interactive form so empty/checking/available/error text does not shift the form.
- Add a focused source/render guard for the claim-handle System B contract.

## Verification
- `pnpm biome check --write apps/web/components/features/home/claim-handle/ClaimHandleForm.tsx apps/web/components/features/home/HeroClaimHandle.tsx apps/web/styles/design-system.css apps/web/tests/unit/home/claim-handle-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/ClaimHandleForm.test.tsx tests/unit/home/claim-handle-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Direct grep for raw local chrome patterns in claim-handle sources: no matches.
- Local homepage smoke at `http://localhost:3056/`: CTA present, no console/page errors, no error-boundary text.
- Commit hook: proxy guard, staged Biome, ESLint, staged a11y, web typecheck.
- Pre-push: full Biome, proxy guard, Tailwind guard, web typecheck, web lint.