### PR TITLE
fix(web): tokenize homepage release mock card

### DIFF
--- a/apps/web/components/features/home/ReleaseModeMockCard.tsx
+++ b/apps/web/components/features/home/ReleaseModeMockCard.tsx
@@ -3,12 +3,6 @@ import { HomepageLabelLogoMark } from './HomepageLabelLogoMark';
 import type { HomepageReleaseMock } from './home-surface-seed';
 import { MarketingSurfaceCard } from './MarketingSurfaceCard';
 
-const ARTWORK_TONE_CLASS_NAMES = {
-  violet:
-    'bg-[linear-gradient(160deg,rgba(121,80,242,0.96),rgba(46,18,94,0.98))]',
-  blue: 'bg-[linear-gradient(160deg,rgba(59,130,246,0.96),rgba(14,25,68,0.98))]',
-} as const;
-
 interface ReleaseModeMockCardProps {
   readonly release: HomepageReleaseMock;
   readonly variant: 'compact' | 'feature' | 'comparison';
@@ -29,31 +23,22 @@ function ReleaseArtwork({
 }>) {
   return (
     <div
-      className={cn(
-        'relative overflow-hidden rounded-[1.1rem] border border-white/10 shadow-[0_16px_36px_rgba(0,0,0,0.28)]',
-        ARTWORK_TONE_CLASS_NAMES[tone]
-      )}
+      className='system-b-release-mode-artwork'
+      data-compact={compact ? 'true' : 'false'}
+      data-tone={tone}
     >
-      <div
-        aria-hidden='true'
-        className='pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.24),transparent_38%),linear-gradient(180deg,transparent_30%,rgba(5,7,13,0.42))]'
-      />
-      <div
-        aria-hidden='true'
-        className='pointer-events-none absolute -left-5 top-8 h-20 w-20 rounded-full border border-white/16'
-      />
-      <div
-        aria-hidden='true'
-        className='pointer-events-none absolute -right-4 bottom-5 h-16 w-16 rounded-full bg-white/10 blur-sm'
-      />
-      <div className='relative flex h-full min-h-[7rem] flex-col justify-between p-3'>
-        <span className='text-[10px] font-medium text-white/72'>Single</span>
-        <div className={cn(compact && 'max-w-[9rem]')}>
-          <p className='text-[14px] font-semibold tracking-[-0.02em] text-white'>
-            {title}
-          </p>
+      <div aria-hidden='true' className='system-b-release-mode-artwork-field' />
+      <div aria-hidden='true' className='system-b-release-mode-artwork-orbit' />
+      <div aria-hidden='true' className='system-b-release-mode-artwork-node' />
+      <div className='system-b-release-mode-artwork-content'>
+        <span className='system-b-release-mode-artwork-kicker'>Single</span>
+        <div
+          className='system-b-release-mode-artwork-copy'
+          data-compact={compact ? 'true' : 'false'}
+        >
+          <p className='system-b-release-mode-artwork-title'>{title}</p>
           {compact ? null : (
-            <p className='mt-1 text-[10px] leading-4 text-white/72'>{artist}</p>
+            <p className='system-b-release-mode-artwork-artist'>{artist}</p>
           )}
         </div>
       </div>
@@ -75,14 +60,11 @@ export function ReleaseModeMockCard({
 }: Readonly<ReleaseModeMockCardProps>) {
   const isCompact = variant === 'compact';
   const isComparison = variant === 'comparison';
-  const statePillClassName =
-    release.state === 'presave'
-      ? 'border-violet-400/20 bg-violet-400/10 text-violet-100/88'
-      : 'border-emerald-400/20 bg-emerald-400/10 text-emerald-100/88';
   const stateLabel = release.state === 'presave' ? 'Presave' : 'Live';
   const visibleLabels = isCompact ? release.labels.slice(0, 3) : release.labels;
   const stateMetaLabel = release.state === 'presave' ? 'Countdown' : 'Status';
   const aspectRatio = getAspectRatio(variant);
+  const bodyLayout = isCompact || isComparison ? 'stack' : 'split';
 
   return (
     <MarketingSurfaceCard
@@ -92,38 +74,26 @@ export function ReleaseModeMockCard({
       glowTone={release.artworkTone}
       className={cn('h-full', className)}
     >
-      <div className='relative flex h-full flex-col p-4'>
-        <div className='flex items-center justify-between gap-3'>
-          <div>
-            <p className='text-[10px] font-medium tracking-[0.02em] text-white/42'>
-              Smart Link
-            </p>
-            <p className='mt-1 text-[11px] text-white/34'>
+      <div className='system-b-release-mode-card'>
+        <div className='system-b-release-mode-header'>
+          <div className='system-b-release-mode-header-copy'>
+            <p className='system-b-release-mode-kicker'>Smart Link</p>
+            <p className='system-b-release-mode-subtitle'>
               {release.modeLabel}
             </p>
           </div>
           <span
-            className={cn(
-              'rounded-full border px-2.5 py-1 text-[10px] font-medium',
-              statePillClassName
-            )}
+            className='system-b-release-mode-state-pill'
+            data-state={release.state}
           >
             {stateLabel}
           </span>
         </div>
 
-        <div
-          className={cn(
-            'mt-4',
-            isCompact || isComparison
-              ? 'space-y-3'
-              : 'grid flex-1 gap-4 md:grid-cols-[12rem_minmax(0,1fr)]'
-          )}
-        >
+        <div className='system-b-release-mode-body' data-layout={bodyLayout}>
           <div
-            className={cn(
-              isCompact || isComparison ? '' : 'flex h-full flex-col'
-            )}
+            className='system-b-release-mode-artwork-column'
+            data-layout={bodyLayout}
           >
             <ReleaseArtwork
               title={release.title}
@@ -131,41 +101,35 @@ export function ReleaseModeMockCard({
               tone={release.artworkTone}
               compact={isCompact || isComparison}
             />
-            <div className='mt-3 flex items-center justify-between gap-3 text-[11px] leading-5 text-white/44'>
+            <div className='system-b-release-mode-release-meta'>
               <p>{release.artist}</p>
-              <p className='text-right'>{release.releaseLabel}</p>
+              <p>{release.releaseLabel}</p>
             </div>
           </div>
 
-          <div className='flex min-h-0 flex-1 flex-col'>
+          <div className='system-b-release-mode-details'>
             <div
-              className={cn(
-                'grid grid-cols-2 gap-2 border-y border-white/6 py-3',
-                (isCompact || isComparison) && 'py-2.5'
-              )}
+              className='system-b-release-mode-metric-grid'
+              data-layout={bodyLayout}
             >
-              <div className='rounded-[0.95rem] border border-white/7 bg-white/[0.03] px-3 py-2.5'>
-                <p className='text-[10px] text-white/36'>
+              <div className='system-b-release-mode-metric'>
+                <p className='system-b-release-mode-metric-label'>
                   {release.primaryMetricLabel}
                 </p>
                 <p
-                  className={cn(
-                    'mt-1 font-[580] tracking-[-0.03em] text-white',
-                    isComparison ? 'text-[20px]' : 'text-[22px]'
-                  )}
+                  className='system-b-release-mode-metric-value'
+                  data-layout={bodyLayout}
                 >
                   {release.primaryMetricValue}
                 </p>
               </div>
-              <div className='rounded-[0.95rem] border border-white/7 bg-white/[0.03] px-3 py-2.5'>
-                <p className='text-[10px] text-white/36'>
+              <div className='system-b-release-mode-metric'>
+                <p className='system-b-release-mode-metric-label'>
                   {release.secondaryMetricLabel}
                 </p>
                 <p
-                  className={cn(
-                    'mt-1 font-[580] tracking-[-0.03em] text-white',
-                    isComparison ? 'text-[20px]' : 'text-[22px]'
-                  )}
+                  className='system-b-release-mode-metric-value'
+                  data-layout={bodyLayout}
                 >
                   {release.secondaryMetricValue}
                 </p>
@@ -173,56 +137,48 @@ export function ReleaseModeMockCard({
             </div>
 
             <div
-              className={cn(
-                'mt-3 flex items-center justify-between gap-3 rounded-[0.95rem] px-3 py-2.5',
-                isComparison
-                  ? 'border border-white/6 bg-white/[0.02]'
-                  : 'border border-white/8 bg-white/[0.03]'
-              )}
+              className='system-b-release-mode-state-row'
+              data-layout={bodyLayout}
             >
               <div>
-                <p className='text-[10px] font-medium tracking-[0.02em] text-white/40'>
+                <p className='system-b-release-mode-state-label'>
                   {stateMetaLabel}
                 </p>
-                <p className='mt-1 text-[12px] text-white/82'>
+                <p className='system-b-release-mode-state-copy'>
                   {release.stateDetail}
                 </p>
               </div>
-              <div className='h-1.5 w-16 overflow-hidden rounded-full bg-white/10'>
+              <div className='system-b-release-mode-progress-track'>
                 <div
-                  className={cn(
-                    'h-full rounded-full',
-                    release.state === 'presave'
-                      ? 'w-[58%] bg-violet-300'
-                      : 'w-full bg-emerald-300'
-                  )}
+                  className='system-b-release-mode-progress-fill'
+                  data-state={release.state}
                 />
               </div>
             </div>
 
             {isComparison ? (
-              <div className='mt-4 border-t border-white/6 pt-3'>
-                <div className='flex flex-wrap items-center gap-x-4 gap-y-2'>
+              <div className='system-b-release-mode-labels' data-layout='flat'>
+                <div className='system-b-release-mode-label-list'>
                   {visibleLabels.map(label => (
                     <HomepageLabelLogoMark
                       key={`${release.id}-${label}`}
                       partner={label}
-                      className='text-white/68'
+                      className='system-b-release-mode-label-logo'
                     />
                   ))}
                 </div>
               </div>
             ) : (
-              <div className='mt-3 rounded-[0.95rem] border border-white/8 bg-white/[0.03] px-3 py-3'>
-                <p className='text-[10px] font-medium tracking-[0.02em] text-white/40'>
+              <div className='system-b-release-mode-labels' data-layout='panel'>
+                <p className='system-b-release-mode-label-heading'>
                   Label Partners
                 </p>
-                <div className='mt-3 flex flex-wrap items-center gap-x-4 gap-y-3'>
+                <div className='system-b-release-mode-label-list'>
                   {visibleLabels.map(label => (
                     <HomepageLabelLogoMark
                       key={`${release.id}-${label}`}
                       partner={label}
-                      className='text-white/72'
+                      className='system-b-release-mode-label-logo'
                     />
                   ))}
                 </div>
@@ -230,7 +186,7 @@ export function ReleaseModeMockCard({
             )}
 
             {isCompact && release.labels.length > visibleLabels.length ? (
-              <p className='mt-3 text-[10px] text-white/34'>
+              <p className='system-b-release-mode-overflow-copy'>
                 {release.labels.length - visibleLabels.length} more partners in
                 the release stack.
               </p>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2561,6 +2561,359 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
 }
 
 /* ============================================
+   SYSTEM B HOME RELEASE MODE MOCK CARD PRIMITIVES
+   ============================================ */
+
+:where(.system-b-release-mode-card) {
+  --system-b-release-mode-tone: var(--color-info);
+  --system-b-release-mode-state: var(--color-success);
+  --system-b-release-mode-progress: 100%;
+
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  flex-direction: column;
+  padding: var(--space-4);
+}
+
+:where(.system-b-release-mode-artwork[data-tone="violet"]) {
+  --system-b-release-mode-tone: var(--color-accent);
+}
+
+:where(.system-b-release-mode-artwork[data-tone="blue"]) {
+  --system-b-release-mode-tone: var(--color-info);
+}
+
+:where(.system-b-release-mode-header) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+:where(.system-b-release-mode-header-copy) {
+  min-width: 0;
+}
+
+:where(.system-b-release-mode-kicker),
+:where(.system-b-release-mode-artwork-kicker),
+:where(.system-b-release-mode-state-label),
+:where(.system-b-release-mode-label-heading) {
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0;
+  line-height: var(--line-height-tight);
+}
+
+:where(.system-b-release-mode-subtitle),
+:where(.system-b-release-mode-metric-label),
+:where(.system-b-release-mode-overflow-copy) {
+  color: var(--color-text-quaternary-token);
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-normal);
+  letter-spacing: 0;
+  line-height: var(--line-height-normal);
+}
+
+:where(.system-b-release-mode-subtitle),
+:where(.system-b-release-mode-artwork-artist),
+:where(.system-b-release-mode-state-copy) {
+  margin-top: var(--space-1);
+}
+
+:where(.system-b-release-mode-state-pill) {
+  display: inline-flex;
+  min-height: var(--space-6);
+  flex-shrink: 0;
+  align-items: center;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-release-mode-state) 26%, transparent);
+  border-radius: var(--system-b-radius-pill);
+  background: color-mix(
+    in oklab,
+    var(--system-b-release-mode-state) 10%,
+    transparent
+  );
+  color: var(--color-text-primary-token);
+  padding-inline: var(--space-2);
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: 0;
+  line-height: var(--line-height-tight);
+}
+
+:where(.system-b-release-mode-state-pill[data-state="presave"]) {
+  --system-b-release-mode-state: var(--color-accent);
+}
+
+:where(.system-b-release-mode-state-pill[data-state="live"]) {
+  --system-b-release-mode-state: var(--color-success);
+}
+
+:where(.system-b-release-mode-body) {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+}
+
+:where(.system-b-release-mode-body[data-layout="split"]) {
+  display: grid;
+  gap: var(--space-4);
+}
+
+:where(.system-b-release-mode-artwork-column) {
+  min-height: 0;
+}
+
+:where(.system-b-release-mode-artwork-column[data-layout="split"]) {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+}
+
+:where(.system-b-release-mode-artwork) {
+  position: relative;
+  min-height: calc(var(--space-24) + var(--space-4));
+  overflow: hidden;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-release-mode-tone) 20%, transparent);
+  border-radius: var(--radius-2xl);
+  background: color-mix(
+    in oklab,
+    var(--system-b-release-mode-tone) 20%,
+    var(--system-b-bg-surface-0) 80%
+  );
+}
+
+:where(.system-b-release-mode-artwork-field),
+:where(.system-b-release-mode-artwork-orbit),
+:where(.system-b-release-mode-artwork-node) {
+  pointer-events: none;
+  position: absolute;
+}
+
+:where(.system-b-release-mode-artwork-field) {
+  inset: var(--space-2);
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-release-mode-tone) 18%, transparent);
+  border-radius: calc(var(--radius-2xl) - var(--space-1));
+  background: color-mix(
+    in oklab,
+    var(--system-b-release-mode-tone) 12%,
+    transparent
+  );
+}
+
+:where(.system-b-release-mode-artwork-orbit) {
+  inset-block-start: var(--space-8);
+  inset-inline-start: calc(var(--space-5) * -1);
+  width: var(--space-20);
+  height: var(--space-20);
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-release-mode-tone) 28%, transparent);
+  border-radius: var(--system-b-radius-pill);
+}
+
+:where(.system-b-release-mode-artwork-node) {
+  right: var(--space-4);
+  bottom: var(--space-5);
+  width: var(--space-12);
+  height: var(--space-12);
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-release-mode-tone) 28%, transparent);
+  border-radius: var(--system-b-radius-pill);
+  background: color-mix(
+    in oklab,
+    var(--system-b-release-mode-tone) 18%,
+    transparent
+  );
+}
+
+:where(.system-b-release-mode-artwork-content) {
+  position: relative;
+  display: flex;
+  height: 100%;
+  min-height: calc(var(--space-24) + var(--space-4));
+  flex-direction: column;
+  justify-content: space-between;
+  padding: var(--space-3);
+}
+
+:where(.system-b-release-mode-artwork-copy[data-compact="true"]) {
+  max-width: calc(var(--space-24) + var(--space-12));
+}
+
+:where(.system-b-release-mode-artwork-title) {
+  color: var(--color-text-primary-token);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0;
+  line-height: var(--line-height-tight);
+}
+
+:where(.system-b-release-mode-artwork-artist) {
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-normal);
+  line-height: var(--line-height-normal);
+}
+
+:where(.system-b-release-mode-release-meta) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-2xs);
+  line-height: var(--line-height-normal);
+}
+
+:where(.system-b-release-mode-release-meta > :last-child) {
+  text-align: right;
+}
+
+:where(.system-b-release-mode-details) {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+}
+
+:where(.system-b-release-mode-metric-grid) {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-2);
+  border-block: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 70%, transparent);
+  padding-block: var(--space-3);
+}
+
+:where(.system-b-release-mode-metric-grid[data-layout="stack"]) {
+  padding-block: var(--space-2);
+}
+
+:where(.system-b-release-mode-metric),
+:where(.system-b-release-mode-state-row),
+:where(.system-b-release-mode-labels[data-layout="panel"]) {
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 68%, transparent);
+  border-radius: var(--radius-xl);
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-1) 76%,
+    transparent
+  );
+}
+
+:where(.system-b-release-mode-metric) {
+  padding: var(--space-2) var(--space-3);
+}
+
+:where(.system-b-release-mode-metric-value) {
+  margin-top: var(--space-1);
+  color: var(--color-text-primary-token);
+  font-size: var(--text-xl);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0;
+  line-height: var(--line-height-tight);
+}
+
+:where(.system-b-release-mode-metric-value[data-layout="stack"]) {
+  font-size: var(--text-lg);
+}
+
+:where(.system-b-release-mode-state-row) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  min-height: calc(var(--space-12) + var(--space-2));
+  margin-top: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+}
+
+:where(.system-b-release-mode-state-copy) {
+  color: var(--color-text-secondary-token);
+  font-size: var(--text-xs);
+  line-height: var(--line-height-normal);
+}
+
+:where(.system-b-release-mode-progress-track) {
+  width: var(--space-16);
+  height: calc(var(--space-1) + var(--space-0-5));
+  flex-shrink: 0;
+  overflow: hidden;
+  border-radius: var(--system-b-radius-pill);
+  background: color-mix(
+    in oklab,
+    var(--system-b-app-frame-seam) 54%,
+    transparent
+  );
+}
+
+:where(.system-b-release-mode-progress-fill) {
+  --system-b-release-mode-state: var(--color-success);
+  --system-b-release-mode-progress: 100%;
+
+  height: 100%;
+  width: var(--system-b-release-mode-progress);
+  border-radius: inherit;
+  background: var(--system-b-release-mode-state);
+}
+
+:where(.system-b-release-mode-progress-fill[data-state="presave"]) {
+  --system-b-release-mode-state: var(--color-accent);
+  --system-b-release-mode-progress: 58%;
+}
+
+:where(.system-b-release-mode-labels) {
+  margin-top: var(--space-3);
+}
+
+:where(.system-b-release-mode-labels[data-layout="flat"]) {
+  border-top: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 70%, transparent);
+  padding-top: var(--space-3);
+}
+
+:where(.system-b-release-mode-labels[data-layout="panel"]) {
+  padding: var(--space-3);
+}
+
+:where(.system-b-release-mode-label-list) {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: var(--space-4);
+  row-gap: var(--space-3);
+}
+
+:where(
+    .system-b-release-mode-label-heading + .system-b-release-mode-label-list
+  ) {
+  margin-top: var(--space-3);
+}
+
+:where(.system-b-release-mode-label-logo) {
+  color: var(--color-text-secondary-token);
+}
+
+:where(.system-b-release-mode-overflow-copy) {
+  margin-top: var(--space-3);
+}
+
+@media (min-width: 768px) {
+  :where(.system-b-release-mode-body[data-layout="split"]) {
+    grid-template-columns: calc(var(--space-24) * 2) minmax(0, 1fr);
+  }
+}
+
+/* ============================================
    SYSTEM B ONBOARDING V2 PRIMITIVES
    ============================================ */
 

--- a/apps/web/tests/unit/home/release-mode-mock-card-system-b-style-guard.test.tsx
+++ b/apps/web/tests/unit/home/release-mode-mock-card-system-b-style-guard.test.tsx
@@ -1,0 +1,148 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  HOME_HERO_RELEASE_MOCK,
+  HOME_RELEASE_DESTINATION_LIVE_MOCK,
+} from '@/features/home/home-surface-seed';
+import { ReleaseModeMockCard } from '@/features/home/ReleaseModeMockCard';
+
+vi.mock('@/features/home/HomepageLabelLogoMark', () => ({
+  HomepageLabelLogoMark: ({
+    partner,
+    className,
+  }: {
+    partner: string;
+    className?: string;
+  }) => (
+    <div className={className} data-testid={`label-logo-${partner}`}>
+      {partner}
+    </div>
+  ),
+}));
+
+const webRoot = path.resolve(__dirname, '../../..');
+const sourcePath = 'components/features/home/ReleaseModeMockCard.tsx';
+const cssPath = 'styles/design-system.css';
+
+const forbiddenSourceVisualPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /\b(?:bg|border|text|ring|shadow|rounded|h|w|max-w|min-h|tracking|leading|px|py|pt|pb)-\[/,
+  /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white|blue)-(?:[0-9]|\[|\/)/,
+  /\bshadow-(?:sm|md|lg|xl|2xl|inner|none|\[)/,
+  /\b(?:transition-all|transition-transform|hover:brightness|active:scale|hover:-translate|group-hover:scale)\b/,
+] as const;
+
+const forbiddenReleaseModeCssPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /box-shadow:/,
+  /letter-spacing:\s*-[^;]+/,
+  /(?:background|color|border(?:-[^:]+)?|box-shadow|text-decoration-color):[^;]*(?<!-)\b(?:white|black)\b/,
+] as const;
+
+function extractReleaseModeCss(source: string): string {
+  const start = source.indexOf(
+    'SYSTEM B HOME RELEASE MODE MOCK CARD PRIMITIVES'
+  );
+  const end = source.indexOf('SYSTEM B ONBOARDING V2 PRIMITIVES', start);
+
+  expect(start, 'release-mode CSS block exists').toBeGreaterThanOrEqual(0);
+  expect(end, 'release-mode CSS block is bounded').toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
+describe('release mode mock card System B source contract', () => {
+  it('keeps release mock visuals on named System B primitives', () => {
+    const source = readFileSync(path.join(webRoot, sourcePath), 'utf8');
+
+    for (const pattern of forbiddenSourceVisualPatterns) {
+      expect(source, `${sourcePath} leaked ${pattern}`).not.toMatch(pattern);
+    }
+
+    expect(source).toContain('system-b-release-mode-card');
+    expect(source).toContain('system-b-release-mode-artwork');
+    expect(source).toContain('system-b-release-mode-state-pill');
+    expect(source).toContain('system-b-release-mode-progress-fill');
+    expect(source).toContain('data-state={release.state}');
+    expect(source).toContain('data-tone={tone}');
+    expect(source).toContain('data-layout={bodyLayout}');
+  });
+
+  it('keeps release mock CSS tokenized and flat', () => {
+    const css = extractReleaseModeCss(
+      readFileSync(path.join(webRoot, cssPath), 'utf8')
+    );
+
+    for (const pattern of forbiddenReleaseModeCssPatterns) {
+      expect(css, `${cssPath} leaked ${pattern}`).not.toMatch(pattern);
+    }
+
+    expect(css).toContain('--system-b-release-mode-tone');
+    expect(css).toContain('var(--color-info)');
+    expect(css).toContain('var(--color-accent)');
+    expect(css).toContain('var(--color-success)');
+    expect(css).toContain('var(--system-b-app-frame-seam)');
+    expect(css).toContain('var(--system-b-bg-surface-1)');
+    expect(css).toContain('var(--space-');
+    expect(css).toContain('var(--radius-');
+  });
+
+  it('renders stable state and tone data attributes for both release states', () => {
+    const { container, rerender } = render(
+      <ReleaseModeMockCard
+        release={HOME_HERO_RELEASE_MOCK}
+        testId='release-mode-card'
+        variant='compact'
+      />
+    );
+
+    expect(screen.getByTestId('release-mode-card')).toBeInTheDocument();
+    expect(
+      container.querySelector(
+        '.system-b-release-mode-artwork[data-tone="violet"]'
+      )
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(
+        '.system-b-release-mode-state-pill[data-state="presave"]'
+      )
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(
+        '.system-b-release-mode-progress-fill[data-state="presave"]'
+      )
+    ).toBeInTheDocument();
+
+    rerender(
+      <ReleaseModeMockCard
+        release={HOME_RELEASE_DESTINATION_LIVE_MOCK}
+        testId='release-mode-card'
+        variant='comparison'
+      />
+    );
+
+    expect(
+      container.querySelector(
+        '.system-b-release-mode-artwork[data-tone="blue"]'
+      )
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(
+        '.system-b-release-mode-state-pill[data-state="live"]'
+      )
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(
+        '.system-b-release-mode-progress-fill[data-state="live"]'
+      )
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- moves ReleaseModeMockCard artwork, metrics, status, progress, and label chrome onto named System B primitives
- removes local gradient/RGBA, raw color utilities, arbitrary visual Tailwind, shadows, radii, and type recipes from the card
- adds a focused source/render guard for both presave and live states

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/home/ReleaseModeMockCard.test.tsx tests/unit/home/release-mode-mock-card-system-b-style-guard.test.tsx`
- `pnpm biome check --write apps/web/components/features/home/ReleaseModeMockCard.tsx apps/web/styles/design-system.css apps/web/tests/unit/home/release-mode-mock-card-system-b-style-guard.test.tsx apps/web/tests/unit/home/ReleaseModeMockCard.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- pre-commit hook: next proxy guard, lint-staged Biome, ESLint, staged a11y, web typecheck
- pre-push hook: full Biome, next proxy guard, Tailwind guard, web typecheck, web lint

## Visual Proof
- `rg "ReleaseModeMockCard" apps/web/components/features/home apps/web/app -g "*.tsx"` shows the card is not mounted by a current route on `main`; this slice is covered by render-contract proof rather than route screenshot proof.

Linear: JOV-2807