### PR TITLE
fix(web): tokenize mounted homepage hero chrome

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -4791,7 +4791,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
 .system-b-mounted-home-hero-shell {
   position: relative;
   display: flex;
-  min-height: 100svh;
+  min-height: 100vh;
   flex-direction: column;
   overflow-x: clip;
   isolation: isolate;
@@ -4800,7 +4800,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 .system-b-mounted-home-hero-shell::before {
-  background: color-mix(in oklab, var(--system-b-bg-page) 92%, transparent);
+  background: var(--system-b-bg-page);
   opacity: 1;
 }
 
@@ -4859,12 +4859,7 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 .system-b-mounted-home-hero-primary {
-  border: 1px solid
-    color-mix(
-      in oklab,
-      var(--system-b-primary-bg) 72%,
-      var(--system-b-app-frame-seam) 28%
-    );
+  border: 1px solid var(--system-b-app-frame-seam);
   background: var(--system-b-primary-bg);
   color: var(--system-b-primary-fg);
 }
@@ -4876,6 +4871,28 @@ body:has(.home-viewport)::-webkit-scrollbar {
 .system-b-mounted-home-hero-secondary:hover,
 .system-b-mounted-home-hero-secondary:focus-visible {
   color: var(--color-text-primary-token);
+}
+
+@supports (height: 100svh) {
+  .system-b-mounted-home-hero-shell {
+    min-height: 100svh;
+  }
+}
+
+@supports (
+    background: color-mix(in oklab, var(--system-b-bg-page) 50%, transparent)
+  ) {
+  .system-b-mounted-home-hero-shell::before {
+    background: color-mix(in oklab, var(--system-b-bg-page) 92%, transparent);
+  }
+
+  .system-b-mounted-home-hero-primary {
+    border-color: color-mix(
+      in oklab,
+      var(--system-b-primary-bg) 72%,
+      var(--system-b-app-frame-seam) 28%
+    );
+  }
 }
 
 /* SYSTEM B MOUNTED HOME HERO SHELL PRIMITIVES END */

--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -4779,3 +4779,103 @@ body:has(.home-viewport)::-webkit-scrollbar {
     mask-image: linear-gradient(90deg, #000 0%, #000 88%, transparent 100%);
   }
 }
+
+/* ============================================
+   SYSTEM B MOUNTED HOME HERO SHELL PRIMITIVES
+   ============================================ */
+
+.system-b-mounted-home-hero-stage {
+  background: var(--system-b-bg-page);
+}
+
+.system-b-mounted-home-hero-shell {
+  position: relative;
+  display: flex;
+  min-height: 100svh;
+  flex-direction: column;
+  overflow-x: clip;
+  isolation: isolate;
+  background: var(--system-b-bg-page);
+  color: var(--color-text-primary-token);
+}
+
+.system-b-mounted-home-hero-shell::before {
+  background: color-mix(in oklab, var(--system-b-bg-page) 92%, transparent);
+  opacity: 1;
+}
+
+.system-b-mounted-home-hero-shell::after {
+  background: transparent;
+}
+
+.system-b-mounted-home-hero-shell .homepage-hero-shell__beam,
+.system-b-mounted-home-hero-shell .homepage-hero-shell__grid-wrap {
+  display: none;
+}
+
+.system-b-mounted-home-hero-inner {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  max-width: none;
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  margin-inline: auto;
+}
+
+.system-b-mounted-home-hero-copy {
+  width: 100%;
+  min-width: 0;
+}
+
+.system-b-mounted-home-hero-headline,
+.system-b-mounted-home-hero-subhead {
+  align-self: center;
+  text-align: center;
+  text-wrap: balance;
+}
+
+.system-b-mounted-home-hero-headline {
+  color: var(--color-text-primary-token);
+  letter-spacing: 0;
+}
+
+.system-b-mounted-home-hero-subhead {
+  color: var(--color-text-tertiary-token);
+}
+
+.system-b-mounted-home-hero-actions {
+  gap: var(--space-4);
+}
+
+.system-b-mounted-home-hero-primary,
+.system-b-mounted-home-hero-secondary {
+  min-height: calc(var(--space-10) + var(--space-0-5));
+  letter-spacing: 0;
+}
+
+.system-b-mounted-home-hero-primary {
+  border: 1px solid
+    color-mix(
+      in oklab,
+      var(--system-b-primary-bg) 72%,
+      var(--system-b-app-frame-seam) 28%
+    );
+  background: var(--system-b-primary-bg);
+  color: var(--system-b-primary-fg);
+}
+
+.system-b-mounted-home-hero-secondary {
+  color: var(--color-text-secondary-token);
+}
+
+.system-b-mounted-home-hero-secondary:hover,
+.system-b-mounted-home-hero-secondary:focus-visible {
+  color: var(--color-text-primary-token);
+}
+
+/* SYSTEM B MOUNTED HOME HERO SHELL PRIMITIVES END */

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -226,12 +226,12 @@ function HomepageHeroActions() {
   ).secondary;
 
   return (
-    <div className='homepage-hero-actions'>
+    <div className='homepage-hero-actions system-b-mounted-home-hero-actions'>
       <HomepageTrackedLink
         href={HERO_COPY.primaryCta.href}
         data-testid='homepage-primary-cta'
         data-cta-sign-up='true'
-        className='public-action-primary focus-ring-themed'
+        className='public-action-primary system-b-mounted-home-hero-primary focus-ring-themed'
         eventName='homepage_hero_cta_clicked'
         eventProperties={{ cta: 'primary', label: HERO_COPY.primaryCta.label }}
       >
@@ -240,7 +240,7 @@ function HomepageHeroActions() {
       {secondaryCta ? (
         <HomepageTrackedLink
           href={secondaryCta.href}
-          className='homepage-hero-secondary-link focus-ring-themed'
+          className='homepage-hero-secondary-link system-b-mounted-home-hero-secondary focus-ring-themed'
           eventName='homepage_hero_cta_clicked'
           eventProperties={{
             cta: 'secondary',
@@ -406,12 +406,12 @@ export default async function HomePage() {
   return (
     <HomePageShell>
       <section
-        className='homepage-hero-stage relative'
+        className='homepage-hero-stage system-b-mounted-home-hero-stage'
         aria-labelledby='home-hero-heading'
       >
         <div
           data-testid='homepage-hero-shell'
-          className='homepage-hero-shell relative flex min-h-[100svh] flex-col overflow-x-clip text-primary-token'
+          className='homepage-hero-shell system-b-mounted-home-hero-shell'
         >
           <div
             aria-hidden='true'
@@ -429,15 +429,15 @@ export default async function HomePage() {
             <div className='homepage-hero-shell__grid' />
           </div>
 
-          <div className='homepage-hero-inner relative z-[3] mx-auto flex w-full max-w-none min-w-0 flex-1 flex-col items-center justify-start'>
-            <div className='homepage-hero-copy w-full min-w-0'>
+          <div className='homepage-hero-inner system-b-mounted-home-hero-inner'>
+            <div className='homepage-hero-copy system-b-mounted-home-hero-copy'>
               <h1
                 id='home-hero-heading'
-                className='homepage-hero-headline self-center text-center text-white text-balance'
+                className='homepage-hero-headline system-b-mounted-home-hero-headline'
               >
                 {HERO_COPY.headline}
               </h1>
-              <p className='homepage-hero-subhead self-center text-center text-white/68'>
+              <p className='homepage-hero-subhead system-b-mounted-home-hero-subhead'>
                 {HERO_COPY.subhead}
               </p>
               <HomepageHeroActions />

--- a/apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+const pagePath = 'app/(home)/page.tsx';
+const cssPath = 'app/(home)/home.css';
+
+const forbiddenPageChromePatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /\b(?:bg|border|text|ring|shadow|rounded|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\btext-white(?:\/|\b)/,
+  /\b(?:white|black|blue|violet|sky|cyan|pink|fuchsia|emerald|amber|orange|rose|red)-(?:[0-9]|\[|\/)/,
+  /\bshadow-(?:sm|md|lg|xl|2xl|inner|\[)/,
+  /\b(?:transition-all|transition-transform|hover:brightness|active:scale|hover:-translate|group-hover:scale)\b/,
+] as const;
+
+const forbiddenHeroCssPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /box-shadow:/,
+  /letter-spacing:\s*-[^;]+/,
+  /(?:background|color|border(?:-[^:]+)?|text-decoration-color):[^;]*(?<!-)\b(?:white|black)\b/,
+] as const;
+
+function extractMountedHeroCss(source: string): string {
+  const start = source.indexOf('SYSTEM B MOUNTED HOME HERO SHELL PRIMITIVES');
+  const end = source.indexOf(
+    'SYSTEM B MOUNTED HOME HERO SHELL PRIMITIVES END',
+    start
+  );
+
+  expect(start, 'mounted hero CSS block exists').toBeGreaterThanOrEqual(0);
+  expect(end, 'mounted hero CSS block is bounded').toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
+function extractMountedHeroPageSource(source: string): string {
+  const actionsStart = source.indexOf('function HomepageHeroActions');
+  const actionsEnd = source.indexOf('function HomepageProductStatement');
+  const heroStart = source.indexOf(
+    "className='homepage-hero-stage system-b-mounted-home-hero-stage'"
+  );
+  const heroEnd = source.indexOf(
+    "<div className='homepage-trust-section'>",
+    heroStart
+  );
+
+  expect(actionsStart, 'hero actions source exists').toBeGreaterThanOrEqual(0);
+  expect(actionsEnd, 'hero actions source is bounded').toBeGreaterThan(
+    actionsStart
+  );
+  expect(heroStart, 'mounted hero source exists').toBeGreaterThanOrEqual(0);
+  expect(heroEnd, 'mounted hero source is bounded').toBeGreaterThan(heroStart);
+
+  return `${source.slice(actionsStart, actionsEnd)}\n${source.slice(
+    heroStart,
+    heroEnd
+  )}`;
+}
+
+describe('mounted homepage hero System B source contract', () => {
+  it('keeps mounted hero markup on named System B primitives', () => {
+    const source = extractMountedHeroPageSource(
+      readFileSync(path.join(webRoot, pagePath), 'utf8')
+    );
+
+    for (const pattern of forbiddenPageChromePatterns) {
+      expect(source, `${pagePath} leaked ${pattern}`).not.toMatch(pattern);
+    }
+
+    for (const className of [
+      'system-b-mounted-home-hero-stage',
+      'system-b-mounted-home-hero-shell',
+      'system-b-mounted-home-hero-inner',
+      'system-b-mounted-home-hero-copy',
+      'system-b-mounted-home-hero-headline',
+      'system-b-mounted-home-hero-subhead',
+      'system-b-mounted-home-hero-actions',
+      'system-b-mounted-home-hero-primary',
+      'system-b-mounted-home-hero-secondary',
+    ]) {
+      expect(source).toContain(className);
+    }
+  });
+
+  it('keeps mounted hero shell CSS tokenized and stable', () => {
+    const css = extractMountedHeroCss(
+      readFileSync(path.join(webRoot, cssPath), 'utf8')
+    );
+
+    for (const pattern of forbiddenHeroCssPatterns) {
+      expect(css, `${cssPath} leaked ${pattern}`).not.toMatch(pattern);
+    }
+
+    expect(css).toContain('var(--system-b-bg-page)');
+    expect(css).toContain('var(--system-b-app-frame-seam)');
+    expect(css).toContain('var(--system-b-primary-bg)');
+    expect(css).toContain('var(--color-text-primary-token)');
+    expect(css).toContain('var(--color-text-tertiary-token)');
+    expect(css).toContain('var(--space-');
+    expect(css).toContain('min-height: 100svh;');
+    expect(css).toContain(
+      'min-height: calc(var(--space-10) + var(--space-0-5));'
+    );
+  });
+});

--- a/apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts
@@ -105,7 +105,10 @@ describe('mounted homepage hero System B source contract', () => {
     expect(css).toContain('var(--color-text-primary-token)');
     expect(css).toContain('var(--color-text-tertiary-token)');
     expect(css).toContain('var(--space-');
+    expect(css).toContain('min-height: 100vh;');
     expect(css).toContain('min-height: 100svh;');
+    expect(css).toContain('@supports (height: 100svh)');
+    expect(css).toMatch(/@supports\s*\(\s*background:\s*color-mix\(/);
     expect(css).toContain(
       'min-height: calc(var(--space-10) + var(--space-0-5));'
     );


### PR DESCRIPTION
## Summary

- Moves the mounted homepage hero shell and hero actions onto `system-b-mounted-home-hero-*` primitives.
- Adds a final tokenized `home.css` System B contract for the active hero shell, copy, CTA, and first-viewport chrome.
- Adds `100vh` and token fallbacks behind `@supports` guards for `100svh` and `color-mix(...)` refinements.
- Adds a focused source guard for the mounted hero slice and fallback contract.

## Verification Results

- `pnpm --filter @jovie/web exec vitest run tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts` — passed.
- `pnpm biome check --write 'apps/web/app/(home)/page.tsx' 'apps/web/app/(home)/home.css' apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts` — passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `git diff --check` — passed.
- Commit hook — proxy guard, lint-staged Biome/ESLint, web typecheck passed.
- Pre-push hook — full Biome, proxy guard, Tailwind guard, web typecheck, web lint passed.

## Screenshot Evidence

- Desktop: `/Users/timwhite/.codex/worktrees/7060/jov-2808-home-hero-surface-cluster-system-b/.gstack/design-reports/screenshots/jov-2808-homepage-hero-desktop-reviewfix.png`
- Mobile: `/Users/timwhite/.codex/worktrees/7060/jov-2808-home-hero-surface-cluster-system-b/.gstack/design-reports/screenshots/jov-2808-homepage-hero-mobile-reviewfix.png`

Browser metrics: desktop `scrollWidth=1440`, `bodyWidth=1440`, shell `min-height=1100px`; mobile `scrollWidth=390`, `bodyWidth=390`, shell `min-height=844px`; headline letter spacing resolves to `normal`; beam and grid display resolve to `none`.

## Layout Stability

States checked: desktop hero, mobile hero, optional secondary CTA present, product rail present. The shell uses a `100vh` fallback with `100svh` guarded by `@supports`, CTA controls keep a fixed tokenized min-height, and the product rail remains in its existing reserved command-center slot.

Linear: JOV-2808
