### PR TITLE
fix(web): tokenize homepage command center rail

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -4896,3 +4896,57 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 /* SYSTEM B MOUNTED HOME HERO SHELL PRIMITIVES END */
+
+/* ============================================
+   SYSTEM B MOUNTED HOME COMMAND CENTER PRIMITIVES
+   ============================================ */
+
+.system-b-mounted-home-command-center {
+  color: var(--color-text-primary-token);
+}
+
+.system-b-mounted-home-command-center::before {
+  display: none;
+}
+
+.system-b-mounted-home-command-control {
+  width: calc(var(--space-10) + var(--space-1));
+  height: calc(var(--space-10) + var(--space-1));
+  border: var(--space-px) solid var(--system-b-app-frame-seam);
+  border-radius: var(--system-b-radius-pill);
+  background: var(--system-b-app-content-surface);
+  color: var(--color-text-secondary-token);
+  box-shadow: var(--shadow-button-inset);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    border-color var(--system-b-duration-fast) var(--system-b-ease),
+    color var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+.system-b-mounted-home-command-control:hover,
+.system-b-mounted-home-command-control:focus-visible {
+  border-color: var(--color-border-strong);
+  background: var(--system-b-bg-surface-1);
+  color: var(--color-text-primary-token);
+}
+
+.system-b-mounted-home-command-rail {
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
+.system-b-mounted-home-command-pane {
+  border: var(--space-px) solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-2xl);
+  background: var(--system-b-bg-page);
+  box-shadow: none;
+}
+
+.system-b-mounted-home-command-pane.homepage-product-pane--phone {
+  border-radius: var(--radius-3xl);
+  box-shadow: none;
+}
+
+/* SYSTEM B MOUNTED HOME COMMAND CENTER PRIMITIVES END */

--- a/apps/web/components/homepage/HomepageHeroCommandCenter.tsx
+++ b/apps/web/components/homepage/HomepageHeroCommandCenter.tsx
@@ -66,7 +66,10 @@ function ProductPane({
   sizes: string;
 }>) {
   return (
-    <figure className={`homepage-product-pane ${className}`} data-product-pane>
+    <figure
+      className={`homepage-product-pane system-b-mounted-home-command-pane ${className}`}
+      data-product-pane
+    >
       <Image
         src={image.publicUrl}
         alt={alt}
@@ -123,13 +126,13 @@ export function HomepageHeroCommandCenter({
   return (
     <section
       aria-label='Jovie release operating system preview'
-      className='homepage-hero-command-center'
+      className='homepage-hero-command-center system-b-mounted-home-command-center'
       data-testid='homepage-hero-command-center'
     >
-      <div className='homepage-product-controls'>
+      <div className='homepage-product-controls system-b-mounted-home-command-controls'>
         <button
           type='button'
-          className='homepage-product-control homepage-product-control--prev focus-ring-themed'
+          className='homepage-product-control system-b-mounted-home-command-control homepage-product-control--prev focus-ring-themed'
           aria-label='Previous product preview'
           onClick={() => scrollProductRail(-1)}
         >
@@ -137,14 +140,17 @@ export function HomepageHeroCommandCenter({
         </button>
         <button
           type='button'
-          className='homepage-product-control homepage-product-control--next focus-ring-themed'
+          className='homepage-product-control system-b-mounted-home-command-control homepage-product-control--next focus-ring-themed'
           aria-label='Next product preview'
           onClick={() => scrollProductRail(1)}
         >
           <ChevronRight aria-hidden='true' size={18} strokeWidth={1.8} />
         </button>
       </div>
-      <div ref={railRef} className='homepage-product-rail'>
+      <div
+        ref={railRef}
+        className='homepage-product-rail system-b-mounted-home-command-rail'
+      >
         <a
           href='#homepage-product-previews-end'
           className='sr-only focus:not-sr-only focus:absolute focus:left-6 focus:top-6 focus:z-10 focus:rounded-md focus:bg-surface-0 focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-primary-token focus-ring-themed'

--- a/apps/web/tests/unit/home/mounted-home-command-center-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-command-center-system-b-style-guard.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+const commandCenterPath = 'components/homepage/HomepageHeroCommandCenter.tsx';
+const cssPath = 'app/(home)/home.css';
+
+const forbiddenCommandCenterSourcePatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /\b(?:bg|border|text|ring|shadow|rounded|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\btext-white(?:\/|\b)/,
+  /\b(?:white|black|blue|violet|sky|cyan|pink|fuchsia|emerald|amber|orange|rose|red)-(?:[0-9]|\[|\/)/,
+  /\bshadow-(?:sm|md|lg|xl|2xl|inner|\[)/,
+  /\b(?:transition-all|transition-transform|hover:brightness|active:scale|hover:-translate|group-hover:scale)\b/,
+] as const;
+
+const forbiddenCommandCenterCssPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /box-shadow:(?!\s*(?:none|var\())/,
+  /letter-spacing:\s*-[^;]+/,
+  /(?:background|color|border(?:-[^:]+)?|text-decoration-color):[^;]*(?<!-)\b(?:white|black)\b/,
+] as const;
+
+function extractCommandCenterCss(source: string): string {
+  const start = source.indexOf(
+    'SYSTEM B MOUNTED HOME COMMAND CENTER PRIMITIVES'
+  );
+  const end = source.indexOf(
+    'SYSTEM B MOUNTED HOME COMMAND CENTER PRIMITIVES END',
+    start
+  );
+
+  expect(start, 'command center CSS block exists').toBeGreaterThanOrEqual(0);
+  expect(end, 'command center CSS block is bounded').toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
+function extractCommandCenterSource(source: string): string {
+  const start = source.indexOf('function ProductPane');
+  const end = source.indexOf("<span id='homepage-product-previews-end'", start);
+
+  expect(start, 'command center source exists').toBeGreaterThanOrEqual(0);
+  expect(end, 'command center source is bounded').toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
+describe('mounted homepage command center System B source contract', () => {
+  it('keeps mounted command center markup on named System B primitives', () => {
+    const source = extractCommandCenterSource(
+      readFileSync(path.join(webRoot, commandCenterPath), 'utf8')
+    );
+
+    for (const pattern of forbiddenCommandCenterSourcePatterns) {
+      expect(source, `${commandCenterPath} leaked ${pattern}`).not.toMatch(
+        pattern
+      );
+    }
+
+    for (const className of [
+      'system-b-mounted-home-command-center',
+      'system-b-mounted-home-command-controls',
+      'system-b-mounted-home-command-control',
+      'system-b-mounted-home-command-rail',
+      'system-b-mounted-home-command-pane',
+    ]) {
+      expect(source).toContain(className);
+    }
+  });
+
+  it('keeps mounted command center CSS tokenized and stable', () => {
+    const css = extractCommandCenterCss(
+      readFileSync(path.join(webRoot, cssPath), 'utf8')
+    );
+
+    for (const pattern of forbiddenCommandCenterCssPatterns) {
+      expect(css, `${cssPath} leaked ${pattern}`).not.toMatch(pattern);
+    }
+
+    expect(css).toContain('var(--system-b-app-frame-seam)');
+    expect(css).toContain('var(--system-b-app-content-surface)');
+    expect(css).toContain('var(--system-b-bg-page)');
+    expect(css).toContain('var(--system-b-bg-surface-1)');
+    expect(css).toContain('var(--color-text-primary-token)');
+    expect(css).toContain('var(--color-text-secondary-token)');
+    expect(css).toContain('var(--shadow-button-inset)');
+    expect(css).toContain('var(--system-b-radius-pill)');
+    expect(css).toContain('var(--radius-2xl)');
+    expect(css).toContain('mask-image: none;');
+    expect(css).toContain('display: none;');
+  });
+});


### PR DESCRIPTION
## Summary

- Moves the mounted homepage command-center rail, arrow controls, and product panes onto named `system-b-mounted-home-command-*` primitives.
- Removes the active rail glow/mask decoration from the mounted first-viewport slice and replaces local control/pane chrome with System B tokens.
- Adds a focused source/CSS guard so the mounted command-center rail cannot drift back to local visual literals.

## Verification Results

- `pnpm --filter @jovie/web exec vitest run tests/unit/home/mounted-home-command-center-system-b-style-guard.test.ts tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts` — passed.
- `pnpm biome check --write 'apps/web/components/homepage/HomepageHeroCommandCenter.tsx' 'apps/web/app/(home)/home.css' apps/web/tests/unit/home/mounted-home-command-center-system-b-style-guard.test.ts` — passed.
- `pnpm --filter @jovie/web run typecheck -- --pretty false` — passed.
- `git diff --check` — passed.
- Commit hook — proxy guard, lint-staged Biome/ESLint, staged a11y check, web typecheck passed.
- Pre-push hook — full Biome, proxy guard, Tailwind guard, web typecheck, web lint passed.

## Screenshot Evidence

Before:

- Desktop: `/Users/timwhite/.codex/worktrees/7060/jovie-system-b-next-scan/.gstack/design-reports/screenshots/jov-2810-home-command-center-desktop-before.png`
- Mobile: `/Users/timwhite/.codex/worktrees/7060/jovie-system-b-next-scan/.gstack/design-reports/screenshots/jov-2810-home-command-center-mobile-before.png`

After:

- Desktop: `/Users/timwhite/.codex/worktrees/7060/jovie-system-b-next-scan/.gstack/design-reports/screenshots/jov-2810-home-command-center-desktop-after.png`
- Mobile: `/Users/timwhite/.codex/worktrees/7060/jovie-system-b-next-scan/.gstack/design-reports/screenshots/jov-2810-home-command-center-mobile-after.png`

Browser metrics after: desktop `scrollWidth=1440`, `bodyWidth=1440`; mobile `scrollWidth=390`, `bodyWidth=390`; command-center pseudo glow `display=none`; rail `maskImage=none`; pane `boxShadow=none`; controls resolve to tokenized surface and border colors.

## Layout Stability

States checked: desktop first viewport, mobile first viewport, mounted command rail with previous/next controls, scroll-snap product panes, skip link present. The rail dimensions and product pane positions remain stable while decorative glow/mask chrome is removed.

Linear: JOV-2810
