### PR TITLE
fix(web): tokenize homepage product statement

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -4950,3 +4950,99 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 /* SYSTEM B MOUNTED HOME COMMAND CENTER PRIMITIVES END */
+
+/* ============================================
+   SYSTEM B MOUNTED HOME PRODUCT STATEMENT PRIMITIVES
+   ============================================ */
+
+.system-b-mounted-home-product-statement {
+  padding-block: clamp(
+      var(--space-24),
+      8vw,
+      calc(var(--space-24) + var(--space-8))
+    )
+    clamp(calc(var(--space-16) + var(--space-3)), 6.4vw, var(--space-24));
+  background: var(--system-b-bg-page);
+  color: var(--color-text-primary-token);
+}
+
+.homepage-story-stack--proof-transition
+  .system-b-mounted-home-product-statement {
+  padding-top: clamp(
+    calc(var(--space-24) + var(--space-3)),
+    9.4vw,
+    calc(var(--space-24) + var(--space-12))
+  );
+}
+
+.system-b-mounted-home-product-statement::before {
+  display: none;
+}
+
+.system-b-mounted-home-product-statement-inner {
+  gap: clamp(var(--space-8), 4.2vw, var(--space-16));
+}
+
+.system-b-mounted-home-product-statement
+  .system-b-mounted-home-product-statement-eyebrow {
+  color: var(--color-text-tertiary-token);
+}
+
+.system-b-mounted-home-product-statement
+  .system-b-mounted-home-product-statement-headline {
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-5xl);
+  letter-spacing: 0;
+}
+
+.system-b-mounted-home-product-statement-lead {
+  color: var(--color-text-primary-token);
+}
+
+.system-b-mounted-home-product-statement-body {
+  color: var(--color-text-tertiary-token);
+}
+
+.system-b-mounted-home-product-statement-ai {
+  color: var(--color-text-secondary-token);
+}
+
+.system-b-mounted-home-product-statement
+  .system-b-mounted-home-product-statement-ai-copy
+  h3 {
+  color: var(--color-text-primary-token);
+  letter-spacing: 0;
+}
+
+.system-b-mounted-home-product-statement
+  .system-b-mounted-home-product-statement-ai-copy
+  p {
+  color: var(--color-text-tertiary-token);
+}
+
+@media (max-width: 767px) {
+  .system-b-mounted-home-product-statement {
+    padding-block: clamp(
+        var(--space-20),
+        14vw,
+        calc(var(--space-24) + var(--space-1))
+      )
+      clamp(calc(var(--space-16) + var(--space-1)), 11vw, var(--space-20));
+  }
+
+  .homepage-story-stack--proof-transition
+    .system-b-mounted-home-product-statement {
+    padding-top: clamp(
+      calc(var(--space-20) + var(--space-0-5)),
+      14vw,
+      calc(var(--space-24) + var(--space-2))
+    );
+  }
+
+  .system-b-mounted-home-product-statement
+    .system-b-mounted-home-product-statement-headline {
+    font-size: var(--text-4xl);
+  }
+}
+
+/* SYSTEM B MOUNTED HOME PRODUCT STATEMENT PRIMITIVES END */

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -261,25 +261,34 @@ function HomepageProductStatement() {
 
   return (
     <section
-      className='homepage-product-statement'
+      className='homepage-product-statement system-b-mounted-home-product-statement'
       aria-labelledby='homepage-product-statement-heading'
       data-testid='homepage-product-statement'
     >
-      <div className='homepage-product-statement__inner'>
+      <div className='homepage-product-statement__inner system-b-mounted-home-product-statement-inner'>
         {copy.eyebrow ? (
-          <p className='homepage-section-eyebrow'>{copy.eyebrow}</p>
+          <p className='homepage-section-eyebrow system-b-mounted-home-product-statement-eyebrow'>
+            {copy.eyebrow}
+          </p>
         ) : null}
-        <h2 id='homepage-product-statement-heading'>
-          <span className='homepage-product-statement__lead'>{copy.lead}</span>{' '}
-          <span className='homepage-product-statement__body'>{copy.body}</span>
+        <h2
+          id='homepage-product-statement-heading'
+          className='system-b-mounted-home-product-statement-headline'
+        >
+          <span className='homepage-product-statement__lead system-b-mounted-home-product-statement-lead'>
+            {copy.lead}
+          </span>{' '}
+          <span className='homepage-product-statement__body system-b-mounted-home-product-statement-body'>
+            {copy.body}
+          </span>
         </h2>
         {FEATURE_FLAGS.SHOW_HOMEPAGE_AI_COMPOSER_SECTION ? (
           <div
-            className='homepage-product-statement__ai'
+            className='homepage-product-statement__ai system-b-mounted-home-product-statement-ai'
             data-testid='homepage-ai-composer-demo'
           >
             <HomeComposerHero />
-            <div className='homepage-product-statement__ai-copy'>
+            <div className='homepage-product-statement__ai-copy system-b-mounted-home-product-statement-ai-copy'>
               <h3>{aiCopy.headline}</h3>
               <p>{aiCopy.body}</p>
             </div>

--- a/apps/web/tests/unit/home/mounted-home-product-statement-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-product-statement-system-b-style-guard.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+const pagePath = 'app/(home)/page.tsx';
+const cssPath = 'app/(home)/home.css';
+
+const forbiddenProductStatementSourcePatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /\b(?:bg|border|text|ring|shadow|rounded|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\btext-white(?:\/|\b)/,
+  /\b(?:white|black|blue|violet|sky|cyan|pink|fuchsia|emerald|amber|orange|rose|red)-(?:[0-9]|\[|\/)/,
+  /\bshadow-(?:sm|md|lg|xl|2xl|inner|\[)/,
+  /\b(?:transition-all|transition-transform|hover:brightness|active:scale|hover:-translate|group-hover:scale)\b/,
+] as const;
+
+const forbiddenProductStatementCssPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /box-shadow:/,
+  /letter-spacing:\s*-[^;]+/,
+  /font-size:[^;]*vw/,
+  /(?:background|color|border(?:-[^:]+)?|text-decoration-color):[^;]*(?<!-)\b(?:white|black)\b/,
+] as const;
+
+function extractProductStatementCss(source: string): string {
+  const start = source.indexOf(
+    'SYSTEM B MOUNTED HOME PRODUCT STATEMENT PRIMITIVES'
+  );
+  const end = source.indexOf(
+    'SYSTEM B MOUNTED HOME PRODUCT STATEMENT PRIMITIVES END',
+    start
+  );
+
+  expect(start, 'product statement CSS block exists').toBeGreaterThanOrEqual(0);
+  expect(end, 'product statement CSS block is bounded').toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
+function extractProductStatementSource(source: string): string {
+  const start = source.indexOf('function HomepageProductStatement');
+  const end = source.indexOf('function HomepageGoLiveStepsSection', start);
+
+  expect(start, 'product statement source exists').toBeGreaterThanOrEqual(0);
+  expect(end, 'product statement source is bounded').toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
+describe('mounted homepage product statement System B source contract', () => {
+  it('keeps mounted product statement markup on named System B primitives', () => {
+    const source = extractProductStatementSource(
+      readFileSync(path.join(webRoot, pagePath), 'utf8')
+    );
+
+    for (const pattern of forbiddenProductStatementSourcePatterns) {
+      expect(source, `${pagePath} leaked ${pattern}`).not.toMatch(pattern);
+    }
+
+    for (const className of [
+      'system-b-mounted-home-product-statement',
+      'system-b-mounted-home-product-statement-inner',
+      'system-b-mounted-home-product-statement-eyebrow',
+      'system-b-mounted-home-product-statement-headline',
+      'system-b-mounted-home-product-statement-lead',
+      'system-b-mounted-home-product-statement-body',
+      'system-b-mounted-home-product-statement-ai',
+      'system-b-mounted-home-product-statement-ai-copy',
+    ]) {
+      expect(source).toContain(className);
+    }
+  });
+
+  it('keeps mounted product statement CSS tokenized and stable', () => {
+    const css = extractProductStatementCss(
+      readFileSync(path.join(webRoot, cssPath), 'utf8')
+    );
+
+    for (const pattern of forbiddenProductStatementCssPatterns) {
+      expect(css, `${cssPath} leaked ${pattern}`).not.toMatch(pattern);
+    }
+
+    expect(css).toContain('var(--system-b-bg-page)');
+    expect(css).toContain('var(--color-text-primary-token)');
+    expect(css).toContain('var(--color-text-secondary-token)');
+    expect(css).toContain('var(--color-text-tertiary-token)');
+    expect(css).toContain('var(--text-5xl)');
+    expect(css).toContain('var(--text-4xl)');
+    expect(css).toContain('var(--space-');
+    expect(css).toContain('display: none;');
+    expect(css).toContain('@media (max-width: 767px)');
+    expect(css).toContain('letter-spacing: 0;');
+  });
+});


### PR DESCRIPTION
## Summary
- Add named System B primitives to the mounted homepage product statement markup.
- Add a bounded token-only product-statement CSS block that removes raw glow/gradient chrome and fixes headline type to System B text tokens.
- Add a focused source/CSS guard for the product-statement surface.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts tests/unit/home/mounted-home-command-center-system-b-style-guard.test.ts tests/unit/home/mounted-home-product-statement-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check 'apps/web/app/(home)/page.tsx' 'apps/web/app/(home)/home.css' apps/web/tests/unit/home/mounted-home-product-statement-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web exec playwright test tests/e2e/homepage.spec.ts -g 'trust, product statement'`
- Pre-push: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`

## Visual proof
- Desktop: `.gstack/design-reports/screenshots/jov-2811-product-statement-desktop-after.png`
- Mobile: `.gstack/design-reports/screenshots/jov-2811-product-statement-mobile-after.png`
- Metrics: no horizontal overflow at 1440 or 390; product statement background image computes to `none`; pseudo-element display computes to `none`; AI composer count remains 0.

Linear: JOV-2811