### PR TITLE
fix(web): tokenize homepage workspace shell

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -5046,3 +5046,73 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 /* SYSTEM B MOUNTED HOME PRODUCT STATEMENT PRIMITIVES END */
+
+/* ============================================
+   SYSTEM B MOUNTED HOME WORKSPACE SHELL PRIMITIVES
+   ============================================ */
+
+.system-b-mounted-home-workspace {
+  background: var(--system-b-bg-page);
+  color: var(--color-text-primary-token);
+}
+
+.system-b-mounted-home-workspace-inner {
+  gap: clamp(var(--space-10), 4.3vw, var(--space-16));
+}
+
+.system-b-mounted-home-workspace .system-b-mounted-home-workspace-headline {
+  color: var(--color-text-primary-token);
+  font-size: var(--text-5xl);
+  letter-spacing: 0;
+}
+
+.system-b-mounted-home-workspace-placeholder-heading {
+  visibility: hidden;
+}
+
+.system-b-mounted-home-workspace-media {
+  border: var(--space-px) solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-3xl);
+  background: var(--system-b-bg-page);
+  box-shadow: none;
+}
+
+.system-b-mounted-home-workspace-callout {
+  border: var(--space-px) solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-xl);
+  background: var(--system-b-app-content-surface);
+  color: var(--color-text-primary-token);
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+.system-b-mounted-home-workspace-callout::before {
+  background: var(--system-b-app-frame-seam);
+}
+
+.system-b-mounted-home-workspace-callout
+  .system-b-mounted-home-workspace-callout-label {
+  color: var(--color-text-tertiary-token);
+}
+
+.system-b-mounted-home-workspace-callout
+  .system-b-mounted-home-workspace-callout-title {
+  color: var(--color-text-primary-token);
+  font-size: var(--text-lg);
+  letter-spacing: 0;
+}
+
+.system-b-mounted-home-workspace-callout
+  .system-b-mounted-home-workspace-callout-body {
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-sm);
+}
+
+@media (max-width: 767px) {
+  .system-b-mounted-home-workspace .system-b-mounted-home-workspace-headline {
+    font-size: var(--text-4xl);
+  }
+}
+
+/* SYSTEM B MOUNTED HOME WORKSPACE SHELL PRIMITIVES END */

--- a/apps/web/components/homepage/HomepageWorkspaceSection.tsx
+++ b/apps/web/components/homepage/HomepageWorkspaceSection.tsx
@@ -76,14 +76,17 @@ export function HomepageWorkspaceSection({
     <section
       ref={sectionRef}
       id='release-workspace'
-      className='homepage-workspace-section'
+      className='homepage-workspace-section system-b-mounted-home-workspace'
       style={{ position: 'relative' }}
       aria-labelledby='homepage-workspace-heading'
       data-testid='homepage-workspace-section'
     >
-      <div className='homepage-workspace-section__inner'>
-        <div className='homepage-workspace-section__copy'>
-          <h2 id='homepage-workspace-heading'>
+      <div className='homepage-workspace-section__inner system-b-mounted-home-workspace-inner'>
+        <div className='homepage-workspace-section__copy system-b-mounted-home-workspace-copy'>
+          <h2
+            id='homepage-workspace-heading'
+            className='system-b-mounted-home-workspace-headline'
+          >
             {headlineLines.map(line => (
               <span key={line}>{line}</span>
             ))}
@@ -91,7 +94,7 @@ export function HomepageWorkspaceSection({
         </div>
 
         <motion.div
-          className='homepage-workspace-visual'
+          className='homepage-workspace-visual system-b-mounted-home-workspace-visual'
           style={
             // Only apply MotionValues after client mount to prevent hydration
             // mismatch between SSR-serialised styles and client initial render.
@@ -106,7 +109,7 @@ export function HomepageWorkspaceSection({
           }
         >
           <div
-            className='homepage-workspace-media'
+            className='homepage-workspace-media system-b-mounted-home-workspace-media'
             data-testid='homepage-workspace-screenshot'
           >
             <Image
@@ -121,12 +124,12 @@ export function HomepageWorkspaceSection({
           </div>
 
           <ol
-            className='homepage-workspace-callouts'
+            className='homepage-workspace-callouts system-b-mounted-home-workspace-callouts'
             aria-label='Release workspace flow'
           >
             {HOMEPAGE_LAUNCH_COPY.workspace.callouts.map((callout, index) => (
               <motion.li
-                className={`homepage-workspace-callout homepage-workspace-callout--${callout.key}`}
+                className={`homepage-workspace-callout system-b-mounted-home-workspace-callout homepage-workspace-callout--${callout.key}`}
                 key={callout.title}
                 style={
                   // Same guard: only bind MotionValues after mount.
@@ -135,9 +138,15 @@ export function HomepageWorkspaceSection({
                     : undefined
                 }
               >
-                <span>{callout.number}</span>
-                <h3>{callout.title}</h3>
-                <p>{callout.body}</p>
+                <span className='system-b-mounted-home-workspace-callout-label'>
+                  {callout.number}
+                </span>
+                <h3 className='system-b-mounted-home-workspace-callout-title'>
+                  {callout.title}
+                </h3>
+                <p className='system-b-mounted-home-workspace-callout-body'>
+                  {callout.body}
+                </p>
               </motion.li>
             ))}
           </ol>

--- a/apps/web/components/homepage/HomepageWorkspaceSectionLazy.tsx
+++ b/apps/web/components/homepage/HomepageWorkspaceSectionLazy.tsx
@@ -37,17 +37,17 @@ const HomepageWorkspaceSectionImpl = dynamic(
       <section
         aria-hidden='true'
         data-testid='homepage-workspace-section-placeholder'
-        className='homepage-workspace-section'
+        className='homepage-workspace-section system-b-mounted-home-workspace'
       >
-        <div className='homepage-workspace-section__inner'>
-          <div className='homepage-workspace-section__copy'>
-            <h2 style={{ visibility: 'hidden' }}>
+        <div className='homepage-workspace-section__inner system-b-mounted-home-workspace-inner'>
+          <div className='homepage-workspace-section__copy system-b-mounted-home-workspace-copy'>
+            <h2 className='system-b-mounted-home-workspace-headline system-b-mounted-home-workspace-placeholder-heading'>
               {HOMEPAGE_LAUNCH_COPY.workspace.headline.split('\n').map(line => (
                 <span key={line}>{line}</span>
               ))}
             </h2>
           </div>
-          <div className='homepage-workspace-visual' />
+          <div className='homepage-workspace-visual system-b-mounted-home-workspace-visual' />
         </div>
       </section>
     ),

--- a/apps/web/tests/unit/home/mounted-home-workspace-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-workspace-system-b-style-guard.test.ts
@@ -1,0 +1,122 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+const workspacePath = 'components/homepage/HomepageWorkspaceSection.tsx';
+const workspaceLazyPath =
+  'components/homepage/HomepageWorkspaceSectionLazy.tsx';
+const cssPath = 'app/(home)/home.css';
+
+const forbiddenWorkspaceSourcePatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /\b(?:bg|border|text|ring|shadow|rounded|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
+  /\btext-white(?:\/|\b)/,
+  /\b(?:white|black|blue|violet|sky|cyan|pink|fuchsia|emerald|amber|orange|rose|red)-(?:[0-9]|\[|\/)/,
+  /\bshadow-(?:sm|md|lg|xl|2xl|inner|\[)/,
+  /\b(?:transition-all|transition-transform|hover:brightness|active:scale|hover:-translate|group-hover:scale)\b/,
+] as const;
+
+const forbiddenWorkspaceCssPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /box-shadow:(?!\s*(?:none|var\())/,
+  /letter-spacing:\s*-[^;]+/,
+  /font-size:[^;]*vw/,
+  /(?:background|color|border(?:-[^:]+)?|text-decoration-color):[^;]*(?<!-)\b(?:white|black)\b/,
+] as const;
+
+function extractWorkspaceCss(source: string): string {
+  const start = source.indexOf(
+    'SYSTEM B MOUNTED HOME WORKSPACE SHELL PRIMITIVES'
+  );
+  const end = source.indexOf(
+    'SYSTEM B MOUNTED HOME WORKSPACE SHELL PRIMITIVES END',
+    start
+  );
+
+  expect(start, 'workspace CSS block exists').toBeGreaterThanOrEqual(0);
+  expect(end, 'workspace CSS block is bounded').toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
+describe('mounted homepage workspace System B source contract', () => {
+  it('keeps loaded workspace markup on named System B primitives', () => {
+    const source = readFileSync(path.join(webRoot, workspacePath), 'utf8');
+
+    for (const pattern of forbiddenWorkspaceSourcePatterns) {
+      expect(source, `${workspacePath} leaked ${pattern}`).not.toMatch(pattern);
+    }
+
+    for (const className of [
+      'system-b-mounted-home-workspace',
+      'system-b-mounted-home-workspace-inner',
+      'system-b-mounted-home-workspace-copy',
+      'system-b-mounted-home-workspace-headline',
+      'system-b-mounted-home-workspace-visual',
+      'system-b-mounted-home-workspace-media',
+      'system-b-mounted-home-workspace-callouts',
+      'system-b-mounted-home-workspace-callout',
+      'system-b-mounted-home-workspace-callout-label',
+      'system-b-mounted-home-workspace-callout-title',
+      'system-b-mounted-home-workspace-callout-body',
+    ]) {
+      expect(source).toContain(className);
+    }
+  });
+
+  it('keeps workspace placeholder markup on matching System B primitives', () => {
+    const source = readFileSync(path.join(webRoot, workspaceLazyPath), 'utf8');
+
+    for (const pattern of forbiddenWorkspaceSourcePatterns) {
+      expect(source, `${workspaceLazyPath} leaked ${pattern}`).not.toMatch(
+        pattern
+      );
+    }
+
+    for (const className of [
+      'system-b-mounted-home-workspace',
+      'system-b-mounted-home-workspace-inner',
+      'system-b-mounted-home-workspace-copy',
+      'system-b-mounted-home-workspace-headline',
+      'system-b-mounted-home-workspace-placeholder-heading',
+      'system-b-mounted-home-workspace-visual',
+    ]) {
+      expect(source).toContain(className);
+    }
+  });
+
+  it('keeps mounted workspace CSS tokenized and stable', () => {
+    const css = extractWorkspaceCss(
+      readFileSync(path.join(webRoot, cssPath), 'utf8')
+    );
+
+    for (const pattern of forbiddenWorkspaceCssPatterns) {
+      expect(css, `${cssPath} leaked ${pattern}`).not.toMatch(pattern);
+    }
+
+    expect(css).toContain('var(--system-b-bg-page)');
+    expect(css).toContain('var(--system-b-app-frame-seam)');
+    expect(css).toContain('var(--system-b-app-content-surface)');
+    expect(css).toContain('var(--color-text-primary-token)');
+    expect(css).toContain('var(--color-text-tertiary-token)');
+    expect(css).toContain('var(--radius-3xl)');
+    expect(css).toContain('var(--radius-xl)');
+    expect(css).toContain('var(--text-5xl)');
+    expect(css).toContain('var(--text-4xl)');
+    expect(css).toContain('var(--text-lg)');
+    expect(css).toContain('var(--text-sm)');
+    expect(css).toContain('var(--space-');
+    expect(css).toContain('box-shadow: none;');
+    expect(css).toContain('backdrop-filter: none;');
+    expect(css).toContain('visibility: hidden;');
+    expect(css).toContain('@media (max-width: 767px)');
+    expect(css).toContain('letter-spacing: 0;');
+  });
+});


### PR DESCRIPTION
## Summary

- Add System B mounted-home workspace primitives to the loaded workspace section and matching lazy placeholder.
- Add a bounded token-only workspace shell CSS block for section background, headline, media frame, and callout card chrome/text.
- Add a source/CSS guard to prevent the workspace shell from drifting back to local visual literals.

Linear: JOV-2812

## Verification

- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/home/mounted-home-workspace-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts tests/unit/home/mounted-home-command-center-system-b-style-guard.test.ts tests/unit/home/mounted-home-product-statement-system-b-style-guard.test.ts tests/unit/home/mounted-home-workspace-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check apps/web/components/homepage/HomepageWorkspaceSection.tsx apps/web/components/homepage/HomepageWorkspaceSectionLazy.tsx 'apps/web/app/(home)/home.css' apps/web/tests/unit/home/mounted-home-workspace-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec playwright test tests/e2e/homepage.spec.ts -g 'trust, product statement, workspace, artist profiles, and footer CTA render'`
- `git diff --check`
- Commit hook: `next:proxy-guard`, lint-staged Biome, ESLint, staged a11y check, web typecheck
- Pre-push hook: full Biome, `next:proxy-guard`, `tailwind:check`, web typecheck, web lint

## Screenshot Evidence

- Desktop viewport: `/Users/timwhite/.codex/worktrees/7060/jovie-system-b-next-scan/.gstack/design-reports/screenshots/jov-2812-workspace-desktop-after.png`
- Mobile viewport: `/Users/timwhite/.codex/worktrees/7060/jovie-system-b-next-scan/.gstack/design-reports/screenshots/jov-2812-workspace-mobile-after.png`
- Desktop element: `/Users/timwhite/.codex/worktrees/7060/jovie-system-b-next-scan/.gstack/design-reports/screenshots/jov-2812-workspace-desktop-element-after.png`
- Mobile element: `/Users/timwhite/.codex/worktrees/7060/jovie-system-b-next-scan/.gstack/design-reports/screenshots/jov-2812-workspace-mobile-element-after.png`

Browser metrics: desktop/mobile `scrollWidth` matched `bodyWidth`; workspace background image and media background image were `none`; media/callout box shadows were `none`; callout backdrop filter was `none`; headline computed to `48px` desktop and `36px` mobile; the workspace heading cleared the fixed header in both viewport captures.
