### PR TITLE
fix(web): tokenize homepage trust strip

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -5116,3 +5116,191 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 /* SYSTEM B MOUNTED HOME WORKSPACE SHELL PRIMITIVES END */
+
+/* ============================================
+   SYSTEM B MOUNTED HOME TRUST STRIP PRIMITIVES
+   ============================================ */
+
+.system-b-mounted-home-trust-strip-shell {
+  background: var(--system-b-bg-page);
+  color: var(--color-text-primary-token);
+}
+
+.system-b-mounted-home-trust-strip-shell
+  > .system-b-mounted-home-trust-strip[data-presentation="inline-strip"] {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  margin-inline: auto;
+  overflow: hidden;
+  padding-block: clamp(var(--space-12), 5vw, var(--space-16))
+    clamp(var(--space-16), 7vw, var(--space-20));
+  padding-inline: var(--homepage-page-gutter);
+  background: var(--system-b-bg-page);
+  color: var(--color-text-primary-token);
+}
+
+.system-b-mounted-home-trust-strip-shell
+  > .system-b-mounted-home-trust-strip[data-presentation="inline-strip"]
+  > .system-b-mounted-home-trust-strip-inner {
+  width: 100%;
+  max-width: var(--homepage-section-max);
+  margin-inline: auto;
+  padding-inline: 0;
+  text-align: center;
+}
+
+.system-b-mounted-home-trust-strip .system-b-mounted-home-trust-strip-label {
+  margin: 0 0 clamp(var(--space-6), 3vw, var(--space-10));
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--leading-normal);
+  letter-spacing: 0;
+}
+
+.system-b-mounted-home-trust-strip
+  .system-b-mounted-home-trust-strip-logo-grid {
+  display: grid;
+  grid-template-columns:
+    minmax(var(--space-24), 0.95fr) minmax(var(--space-24), 1fr)
+    minmax(calc(var(--space-24) + var(--space-20)), 1.38fr)
+    minmax(var(--space-24), 1fr) minmax(var(--space-24), 0.9fr);
+  align-items: center;
+  gap: clamp(var(--space-4), 2.4vw, var(--space-12));
+  transform-origin: center top;
+  will-change: transform, opacity;
+}
+
+.system-b-mounted-home-trust-strip
+  .system-b-mounted-home-trust-strip-logo-slot {
+  display: flex;
+  min-width: 0;
+  height: clamp(var(--space-10), 4vw, calc(var(--space-12) + var(--space-2)));
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-tertiary-token);
+  filter: grayscale(1);
+  opacity: 1;
+}
+
+.system-b-mounted-home-trust-strip .system-b-mounted-home-trust-strip-logo {
+  display: block;
+  max-width: 100%;
+  color: var(--color-text-tertiary-token);
+  opacity: 1;
+  user-select: none;
+}
+
+.system-b-mounted-home-trust-strip
+  .system-b-mounted-home-trust-strip-logo--awal {
+  height: clamp(calc(var(--space-6) + var(--space-1)), 2.2vw, var(--space-8));
+  width: auto;
+}
+
+.system-b-mounted-home-trust-strip
+  .system-b-mounted-home-trust-strip-logo--orchard {
+  height: clamp(var(--space-12), 4.8vw, var(--space-16));
+  width: auto;
+}
+
+.system-b-mounted-home-trust-strip
+  .system-b-mounted-home-trust-strip-logo--umg {
+  width: clamp(
+    calc(var(--space-24) + var(--space-24)),
+    17vw,
+    calc(var(--space-24) * 2 + var(--space-10))
+  );
+  height: auto;
+}
+
+.system-b-mounted-home-trust-strip
+  .system-b-mounted-home-trust-strip-logo--armada {
+  height: clamp(
+    calc(var(--space-6) + var(--space-1)),
+    2.55vw,
+    calc(var(--space-8) + var(--space-1))
+  );
+  width: auto;
+}
+
+.system-b-mounted-home-trust-strip
+  .system-b-mounted-home-trust-strip-logo--black-hole {
+  width: clamp(
+    calc(var(--space-20) + var(--space-16)),
+    12.4vw,
+    calc(var(--space-24) + var(--space-20))
+  );
+  height: auto;
+}
+
+@media (max-width: 767px) {
+  .system-b-mounted-home-trust-strip-shell
+    > .system-b-mounted-home-trust-strip[data-presentation="inline-strip"] {
+    padding-block: clamp(
+        var(--space-12),
+        12vw,
+        calc(var(--space-12) + var(--space-2))
+      )
+      clamp(var(--space-16), 14vw, var(--space-20));
+  }
+
+  .system-b-mounted-home-trust-strip-shell
+    > .system-b-mounted-home-trust-strip[data-presentation="inline-strip"]
+    > .system-b-mounted-home-trust-strip-inner {
+    max-width: min(100%, calc(var(--space-24) * 4));
+  }
+
+  .system-b-mounted-home-trust-strip
+    .system-b-mounted-home-trust-strip-logo-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--space-4) var(--space-6);
+  }
+
+  .system-b-mounted-home-trust-strip
+    .system-b-mounted-home-trust-strip-logo-slot {
+    height: calc(var(--space-10) + var(--space-1));
+    justify-content: flex-start;
+  }
+
+  .system-b-mounted-home-trust-strip
+    .system-b-mounted-home-trust-strip-logo-slot--orchard,
+  .system-b-mounted-home-trust-strip
+    .system-b-mounted-home-trust-strip-logo-slot--black-hole {
+    justify-content: flex-end;
+  }
+
+  .system-b-mounted-home-trust-strip
+    .system-b-mounted-home-trust-strip-logo-slot--umg {
+    grid-column: 1 / -1;
+    height: calc(var(--space-8) + var(--space-1));
+    justify-content: center;
+  }
+
+  .system-b-mounted-home-trust-strip
+    .system-b-mounted-home-trust-strip-logo--awal {
+    height: calc(var(--space-6) + var(--space-1));
+  }
+
+  .system-b-mounted-home-trust-strip
+    .system-b-mounted-home-trust-strip-logo--orchard {
+    height: var(--space-12);
+  }
+
+  .system-b-mounted-home-trust-strip
+    .system-b-mounted-home-trust-strip-logo--umg {
+    width: min(calc(var(--space-24) * 2 + var(--space-4)), 100%);
+  }
+
+  .system-b-mounted-home-trust-strip
+    .system-b-mounted-home-trust-strip-logo--armada {
+    height: calc(var(--space-6) + var(--space-1));
+  }
+
+  .system-b-mounted-home-trust-strip
+    .system-b-mounted-home-trust-strip-logo--black-hole {
+    width: min(calc(var(--space-20) + var(--space-16)), 100%);
+  }
+}
+
+/* SYSTEM B MOUNTED HOME TRUST STRIP PRIMITIVES END */

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -455,7 +455,7 @@ export default async function HomePage() {
           </div>
         </div>
       </section>
-      <div className='homepage-trust-section'>
+      <div className='homepage-trust-section system-b-mounted-home-trust-strip-shell'>
         <HomeTrustSection
           label='Used by artists and teams with releases distributed through'
           presentation='inline-strip'

--- a/apps/web/components/features/home/HomeTrustSection.tsx
+++ b/apps/web/components/features/home/HomeTrustSection.tsx
@@ -21,7 +21,7 @@ function getInnerBoxClass(
   isInlineStrip: boolean,
   variant: 'default' | 'compact'
 ): string {
-  if (isInlineStrip) return 'px-0';
+  if (isInlineStrip) return 'system-b-mounted-home-trust-strip-inner';
   return cn(
     'rounded-[28px] border border-white/[0.08] bg-[linear-gradient(180deg,rgba(10,11,15,0.96)_0%,rgba(7,8,11,1)_100%)] shadow-[0_26px_72px_rgba(0,0,0,0.3),inset_0_1px_0_rgba(255,255,255,0.04)]',
     variant === 'compact'
@@ -42,7 +42,7 @@ function getSlotClass(isInlineStrip: boolean, slotName: string): string {
   return cn(
     'flex min-w-0 items-center justify-center',
     isInlineStrip &&
-      `homepage-trust-logo-slot homepage-trust-logo-slot--${slotName}`
+      `homepage-trust-logo-slot homepage-trust-logo-slot--${slotName} system-b-mounted-home-trust-strip-logo-slot system-b-mounted-home-trust-strip-logo-slot--${slotName}`
   );
 }
 
@@ -62,11 +62,9 @@ export function HomeTrustSection({
   label = 'Trusted by artists and teams releasing on',
 }: Readonly<HomeTrustSectionProps>) {
   const isInlineStrip = presentation === 'inline-strip';
-  const logoTone = isInlineStrip ? 'text-white/62' : 'text-white/55';
+  const logoTone = isInlineStrip ? '' : 'text-white/55';
   const innerBoxClass = getInnerBoxClass(isInlineStrip, variant);
-  const labelMarginClass = isInlineStrip
-    ? 'mb-8 sm:mb-10'
-    : getLabelMarginClass(isInlineStrip, variant);
+  const labelMarginClass = getLabelMarginClass(isInlineStrip, variant);
 
   return (
     <section
@@ -74,7 +72,7 @@ export function HomeTrustSection({
       data-presentation={presentation}
       className={cn(
         isInlineStrip
-          ? 'relative z-[1] mx-auto w-full overflow-hidden px-5 py-12 sm:px-6 sm:py-14 lg:px-0'
+          ? 'system-b-mounted-home-trust-strip'
           : 'relative z-[1] mx-auto w-full px-5 sm:px-6 lg:px-0',
         className
       )}
@@ -83,18 +81,17 @@ export function HomeTrustSection({
       <div
         className={cn(
           isInlineStrip
-            ? 'mx-auto max-w-[1320px] text-center'
+            ? 'homepage-trust-strip-inner'
             : 'mx-auto max-w-[var(--linear-content-max)]',
           innerBoxClass
         )}
       >
         <p
           className={cn(
-            'text-center font-medium tracking-[0.01em]',
             isInlineStrip
-              ? 'text-[12px] text-white/36'
-              : 'text-[12px] text-white/56',
-            labelMarginClass
+              ? 'system-b-mounted-home-trust-strip-label'
+              : 'text-center font-medium tracking-[0.01em] text-[12px] text-white/56',
+            !isInlineStrip && labelMarginClass
           )}
         >
           {label}
@@ -102,7 +99,7 @@ export function HomeTrustSection({
         <div
           className={cn(
             isInlineStrip
-              ? 'homepage-trust-logo-grid'
+              ? 'homepage-trust-logo-grid system-b-mounted-home-trust-strip-logo-grid'
               : 'grid grid-cols-1 items-center justify-items-center gap-x-6 gap-y-6 sm:flex sm:flex-wrap sm:items-center sm:justify-center sm:gap-x-10 sm:gap-y-5 lg:flex-nowrap lg:justify-between',
             variant === 'compact' &&
               !isInlineStrip &&
@@ -113,7 +110,7 @@ export function HomeTrustSection({
             <AwalLogo
               className={getLogoClass(
                 isInlineStrip,
-                'homepage-trust-logo homepage-trust-logo--awal w-auto max-w-[38vw] select-none',
+                'homepage-trust-logo homepage-trust-logo--awal system-b-mounted-home-trust-strip-logo system-b-mounted-home-trust-strip-logo--awal',
                 'h-[20px] w-auto max-w-[36vw] select-none sm:h-[22px]',
                 logoTone
               )}
@@ -123,7 +120,7 @@ export function HomeTrustSection({
             <TheOrchardLogo
               className={getLogoClass(
                 isInlineStrip,
-                'homepage-trust-logo homepage-trust-logo--orchard w-auto max-w-[44vw] select-none',
+                'homepage-trust-logo homepage-trust-logo--orchard system-b-mounted-home-trust-strip-logo system-b-mounted-home-trust-strip-logo--orchard',
                 'h-[28px] w-auto max-w-[34vw] select-none sm:h-[31px]',
                 logoTone
               )}
@@ -133,7 +130,7 @@ export function HomeTrustSection({
             <UniversalMusicGroupLogo
               className={getLogoClass(
                 isInlineStrip,
-                'homepage-trust-logo homepage-trust-logo--umg h-auto max-w-[52vw] select-none',
+                'homepage-trust-logo homepage-trust-logo--umg system-b-mounted-home-trust-strip-logo system-b-mounted-home-trust-strip-logo--umg',
                 'h-[14px] w-auto max-w-[72vw] select-none sm:h-[16px]',
                 logoTone
               )}
@@ -143,7 +140,7 @@ export function HomeTrustSection({
             <ArmadaMusicLogo
               className={getLogoClass(
                 isInlineStrip,
-                'homepage-trust-logo homepage-trust-logo--armada w-auto max-w-[44vw] select-none',
+                'homepage-trust-logo homepage-trust-logo--armada system-b-mounted-home-trust-strip-logo system-b-mounted-home-trust-strip-logo--armada',
                 'h-[22px] w-auto max-w-[38vw] select-none sm:h-[24px]',
                 logoTone
               )}
@@ -156,7 +153,7 @@ export function HomeTrustSection({
             <BlackHoleRecordingsLogo
               className={getLogoClass(
                 isInlineStrip,
-                'homepage-trust-logo homepage-trust-logo--black-hole h-auto',
+                'homepage-trust-logo homepage-trust-logo--black-hole system-b-mounted-home-trust-strip-logo system-b-mounted-home-trust-strip-logo--black-hole',
                 'h-[16px] w-auto sm:h-[18px]',
                 ''
               )}

--- a/apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts
@@ -47,10 +47,7 @@ function extractMountedHeroPageSource(source: string): string {
   const heroStart = source.indexOf(
     "className='homepage-hero-stage system-b-mounted-home-hero-stage'"
   );
-  const heroEnd = source.indexOf(
-    "<div className='homepage-trust-section'>",
-    heroStart
-  );
+  const heroEnd = source.indexOf('homepage-trust-section', heroStart);
 
   expect(actionsStart, 'hero actions source exists').toBeGreaterThanOrEqual(0);
   expect(actionsEnd, 'hero actions source is bounded').toBeGreaterThan(

--- a/apps/web/tests/unit/home/mounted-home-trust-strip-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-trust-strip-system-b-style-guard.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+const pagePath = 'app/(home)/page.tsx';
+const trustPath = 'components/features/home/HomeTrustSection.tsx';
+const cssPath = 'app/(home)/home.css';
+
+const forbiddenTrustStripCssPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /box-shadow:/,
+  /letter-spacing:\s*-[^;]+/,
+  /font-size:[^;]*vw/,
+  /(?:background|color|border(?:-[^:]+)?|text-decoration-color):[^;]*(?<!-)\b(?:white|black)\b/,
+] as const;
+
+function extractTrustStripCss(source: string): string {
+  const start = source.indexOf('SYSTEM B MOUNTED HOME TRUST STRIP PRIMITIVES');
+  const end = source.indexOf(
+    'SYSTEM B MOUNTED HOME TRUST STRIP PRIMITIVES END',
+    start
+  );
+
+  expect(start, 'trust strip CSS block exists').toBeGreaterThanOrEqual(0);
+  expect(end, 'trust strip CSS block is bounded').toBeGreaterThan(start);
+
+  return source.slice(start, end);
+}
+
+describe('mounted homepage trust strip System B source contract', () => {
+  it('keeps mounted trust strip markup on named System B primitives', () => {
+    const pageSource = readFileSync(path.join(webRoot, pagePath), 'utf8');
+    const trustSource = readFileSync(path.join(webRoot, trustPath), 'utf8');
+
+    expect(pageSource).toContain('system-b-mounted-home-trust-strip-shell');
+
+    for (const className of [
+      'system-b-mounted-home-trust-strip',
+      'system-b-mounted-home-trust-strip-inner',
+      'system-b-mounted-home-trust-strip-label',
+      'system-b-mounted-home-trust-strip-logo-grid',
+      'system-b-mounted-home-trust-strip-logo-slot',
+      'system-b-mounted-home-trust-strip-logo',
+      'system-b-mounted-home-trust-strip-logo--awal',
+      'system-b-mounted-home-trust-strip-logo--orchard',
+      'system-b-mounted-home-trust-strip-logo--umg',
+      'system-b-mounted-home-trust-strip-logo--armada',
+      'system-b-mounted-home-trust-strip-logo--black-hole',
+    ]) {
+      expect(trustSource).toContain(className);
+    }
+  });
+
+  it('keeps mounted trust strip CSS tokenized and stable', () => {
+    const css = extractTrustStripCss(
+      readFileSync(path.join(webRoot, cssPath), 'utf8')
+    );
+
+    for (const pattern of forbiddenTrustStripCssPatterns) {
+      expect(css, `${cssPath} leaked ${pattern}`).not.toMatch(pattern);
+    }
+
+    expect(css).toContain('var(--system-b-bg-page)');
+    expect(css).toContain('var(--color-text-primary-token)');
+    expect(css).toContain('var(--color-text-tertiary-token)');
+    expect(css).toContain('var(--homepage-page-gutter)');
+    expect(css).toContain('var(--homepage-section-max)');
+    expect(css).toContain('var(--text-xs)');
+    expect(css).toContain('var(--space-');
+    expect(css).toContain('filter: grayscale(1);');
+    expect(css).toContain(
+      '.system-b-mounted-home-trust-strip-shell\n' +
+        '  > .system-b-mounted-home-trust-strip[data-presentation="inline-strip"]\n' +
+        '  > .system-b-mounted-home-trust-strip-inner'
+    );
+    expect(css).toContain('padding-inline: 0;');
+    expect(css).toContain('@media (max-width: 767px)');
+    expect(css).toContain('letter-spacing: 0;');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds System B primitive classes to the mounted homepage trust-strip shell and inline HomeTrustSection path.
- Adds a bounded token-only CSS override block for the trust strip, label, logo grid, slots, and logos.
- Adds a focused System B guard and updates the hero guard sentinel so adjacent homepage contracts remain stable.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/home/mounted-home-trust-strip-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/home/HomeTrustSection.test.tsx tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts tests/unit/home/mounted-home-command-center-system-b-style-guard.test.ts tests/unit/home/mounted-home-product-statement-system-b-style-guard.test.ts tests/unit/home/mounted-home-workspace-system-b-style-guard.test.ts tests/unit/home/mounted-home-trust-strip-system-b-style-guard.test.ts`
- `pnpm biome check --write apps/web/components/features/home/HomeTrustSection.tsx apps/web/app/(home)/page.tsx apps/web/app/(home)/home.css apps/web/tests/unit/home/mounted-home-trust-strip-system-b-style-guard.test.ts apps/web/tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm --filter @jovie/web exec playwright test tests/e2e/homepage.spec.ts -g "trust, product statement, workspace, artist profiles, and footer CTA render"`
- `git diff --check`
- pre-push: `biome check .`, proxy guard, Tailwind guard, typecheck, Biome lint

## Screenshot Proof
- Desktop viewport: `.gstack/design-reports/screenshots/jov-2813-trust-strip-desktop-after.png`
- Desktop element: `.gstack/design-reports/screenshots/jov-2813-trust-strip-desktop-element-after.png`
- Mobile viewport: `.gstack/design-reports/screenshots/jov-2813-trust-strip-mobile-after.png`
- Mobile element: `.gstack/design-reports/screenshots/jov-2813-trust-strip-mobile-element-after.png`

## Linear
- JOV-2813


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced trust strip layout with improved mobile responsiveness and refined visual styling on the homepage.

* **Tests**
  * Added test coverage to verify trust strip styling implementation integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->