### PR TITLE
fix(home): tokenize footer CTA System B

### DIFF
--- a/apps/web/app/(home)/home.css
+++ b/apps/web/app/(home)/home.css
@@ -66,8 +66,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
     rgba(12, 16, 24, 0.98) 0%,
     rgba(4, 5, 7, 0.98) 100%
   );
-  --homepage-footer-cta-top: clamp(4rem, 6.5vw, 5.6rem);
-  --homepage-footer-cta-bottom: clamp(9.5rem, 14vw, 13rem);
 }
 
 .home-viewport
@@ -1217,39 +1215,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
     linear-gradient(180deg, rgba(10, 12, 18, 0.96) 0%, rgba(5, 6, 8, 0.98) 100%);
 }
 
-.homepage-story-final-cta {
-  min-height: clamp(28rem, 40vw, 36rem);
-  border-top: 1px solid rgba(255, 255, 255, 0.055);
-  padding-top: 0;
-  padding-bottom: 0;
-}
-
-.homepage-final-cta-glow {
-  background: radial-gradient(
-    56% 48% at 50% 96%,
-    rgba(0, 112, 243, 0.18) 0%,
-    rgba(45, 55, 132, 0.11) 34%,
-    rgba(0, 0, 0, 0) 73%
-  );
-}
-
-.homepage-final-cta-rays {
-  height: clamp(14rem, 28vw, 21rem);
-  opacity: 0.38;
-}
-
-.homepage-final-cta-copy {
-  max-width: 42.5rem;
-  padding: calc(var(--homepage-footer-cta-top) + clamp(1.4rem, 3vw, 3rem))
-    var(--homepage-page-gutter)
-    calc(var(--homepage-footer-cta-bottom) + clamp(1.25rem, 3vw, 3rem));
-  text-align: center;
-}
-
-.homepage-final-cta-action {
-  margin-top: 1.35rem;
-}
-
 @media (max-width: 767px) {
   .home-viewport {
     --linear-header-height: 52px;
@@ -1263,8 +1228,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
     --homepage-carousel-step: min(88vw, 28rem);
     --homepage-carousel-control-inset: 1.5rem;
     --homepage-section-space: 4rem;
-    --homepage-footer-cta-top: 4rem;
-    --homepage-footer-cta-bottom: 11rem;
   }
 
   .homepage-hero-shell__grid-wrap {
@@ -1482,15 +1445,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
   .homepage-split-column,
   .homepage-pricing-card {
     padding: 1.35rem;
-  }
-
-  .homepage-story-final-cta {
-    min-height: 30rem;
-  }
-
-  .homepage-final-cta-rays {
-    height: 18rem;
-    opacity: 0.42;
   }
 }
 
@@ -1964,26 +1918,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.42);
   vertical-align: 0.1em;
-}
-
-.homepage-final-cta-copy {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.homepage-final-cta-secondary {
-  margin-top: 0.9rem;
-  color: rgba(255, 255, 255, 0.62);
-  font-size: 13px;
-  font-weight: 560;
-  text-decoration: none;
-  transition: color 140ms ease;
-}
-
-.homepage-final-cta-secondary:hover,
-.homepage-final-cta-secondary:focus-visible {
-  color: rgba(255, 255, 255, 0.94);
 }
 
 @media (min-width: 900px) {
@@ -4249,40 +4183,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
   line-height: 1.04;
 }
 
-.homepage-story-final-cta {
-  min-height: clamp(38rem, 58vw, 48rem);
-  display: grid;
-  align-items: center;
-  padding-block: 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.055);
-  background: #000;
-}
-
-.homepage-final-cta-rays {
-  display: block;
-  height: clamp(21rem, 43vw, 34rem);
-  opacity: 0.72;
-  bottom: -1px;
-}
-
-.homepage-final-cta-glow {
-  opacity: 1;
-  background:
-    radial-gradient(
-      44% 42% at 50% 96%,
-      rgba(0, 112, 243, 0.24) 0%,
-      rgba(45, 55, 132, 0.11) 42%,
-      rgba(0, 0, 0, 0) 78%
-    ),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.025), transparent 28%);
-}
-
-.homepage-final-cta-action {
-  box-shadow:
-    0 18px 52px rgba(0, 0, 0, 0.34),
-    inset 0 1px 0 rgba(255, 255, 255, 0.26);
-}
-
 @media (min-width: 900px) {
   .homepage-intent-band__inner {
     grid-template-columns: minmax(0, 0.76fr) minmax(0, 1fr);
@@ -4680,32 +4580,6 @@ body:has(.home-viewport)::-webkit-scrollbar {
   background: var(--frame-hairline);
   border: 0;
   width: 100%;
-}
-
-.home-viewport .marketing-footer-premium > div {
-  padding-top: clamp(2.6rem, 4.5vw, 3.6rem) !important;
-  padding-bottom: clamp(1.7rem, 3vw, 2.25rem) !important;
-}
-
-.home-viewport .marketing-footer-premium .grid {
-  gap: clamp(2rem, 3.4vw, 3rem);
-}
-
-.home-viewport .marketing-footer-premium .mf-mark-tagline {
-  margin-top: 1rem;
-}
-
-.home-viewport .marketing-footer-premium .mf-eyebrow {
-  margin-bottom: 0.85rem;
-}
-
-.home-viewport .marketing-footer-premium ul {
-  gap: 0.55rem;
-}
-
-.home-viewport .marketing-footer-premium .mf-baseband {
-  margin-top: clamp(2rem, 3.6vw, 2.8rem);
-  padding-top: clamp(1.15rem, 2vw, 1.45rem);
 }
 
 @media (max-width: 1023px) {
@@ -5304,3 +5178,120 @@ body:has(.home-viewport)::-webkit-scrollbar {
 }
 
 /* SYSTEM B MOUNTED HOME TRUST STRIP PRIMITIVES END */
+
+/* ============================================
+   SYSTEM B MOUNTED HOME FOOTER CTA PRIMITIVES
+   ============================================ */
+
+.system-b-mounted-home-footer-cta {
+  display: grid;
+  min-height: clamp(calc(var(--space-24) * 4), 58vw, calc(var(--space-24) * 5));
+  align-items: center;
+  border-top: var(--space-px) solid var(--system-b-app-frame-seam);
+  padding-block: 0;
+  background: var(--system-b-bg-page);
+  color: var(--color-text-primary-token);
+}
+
+.system-b-mounted-home-footer-cta-container {
+  position: relative;
+  z-index: 1;
+}
+
+.system-b-mounted-home-footer-cta-copy {
+  display: flex;
+  max-width: calc(var(--space-24) * 6);
+  flex-direction: column;
+  align-items: center;
+  padding-block: clamp(var(--space-20), 12vw, calc(var(--space-24) * 2))
+    clamp(var(--space-24), 15vw, calc(var(--space-24) * 2 + var(--space-16)));
+  padding-inline: var(--homepage-page-gutter);
+  text-align: center;
+}
+
+.system-b-mounted-home-footer-cta-heading {
+  margin: 0;
+  color: var(--color-text-primary-token);
+  font-size: calc(var(--text-5xl) + var(--space-2));
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--leading-none);
+  letter-spacing: 0;
+}
+
+.system-b-mounted-home-footer-cta-action {
+  min-height: calc(var(--space-10) + var(--space-0-5));
+  margin-top: var(--space-8);
+  letter-spacing: 0;
+}
+
+.home-viewport .system-b-mounted-home-footer {
+  --mf-text: var(--color-text-primary-token);
+  --mf-text-secondary: var(--color-text-secondary-token);
+  --mf-text-tertiary: var(--color-text-tertiary-token);
+  --mf-text-muted: var(--color-text-quaternary-token);
+  --mf-hairline: var(--system-b-app-frame-seam);
+
+  border-top: var(--space-px) solid var(--system-b-app-frame-seam);
+  background: var(--system-b-bg-page);
+  color: var(--color-text-primary-token);
+}
+
+.home-viewport .system-b-mounted-home-footer > div {
+  max-width: var(--homepage-section-max);
+  padding-block: clamp(var(--space-12), 4.5vw, var(--space-16))
+    clamp(var(--space-8), 3vw, var(--space-12));
+  padding-inline: var(--homepage-page-gutter);
+}
+
+.home-viewport .system-b-mounted-home-footer .grid {
+  gap: clamp(var(--space-8), 3.4vw, var(--space-12));
+}
+
+.home-viewport .system-b-mounted-home-footer .mf-mark-tagline {
+  margin-top: var(--space-4);
+  color: var(--color-text-tertiary-token);
+}
+
+.home-viewport .system-b-mounted-home-footer .mf-eyebrow {
+  margin-bottom: var(--space-3);
+  color: var(--color-text-tertiary-token);
+  letter-spacing: 0;
+}
+
+.home-viewport .system-b-mounted-home-footer ul {
+  gap: var(--space-2);
+}
+
+.home-viewport .system-b-mounted-home-footer .mf-baseband {
+  margin-top: clamp(var(--space-8), 3.6vw, var(--space-12));
+  border-top-color: var(--system-b-app-frame-seam);
+  padding-top: clamp(var(--space-5), 2vw, var(--space-6));
+}
+
+.home-viewport .system-b-mounted-home-footer .mf-baseband > span {
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  letter-spacing: 0;
+}
+
+@media (max-width: 767px) {
+  .system-b-mounted-home-footer-cta {
+    min-height: calc(var(--space-24) * 3);
+  }
+
+  .system-b-mounted-home-footer-cta-copy {
+    padding-block: clamp(var(--space-16), 18vw, var(--space-20))
+      clamp(var(--space-20), 24vw, calc(var(--space-24) + var(--space-12)));
+  }
+
+  .system-b-mounted-home-footer-cta-heading {
+    font-size: var(--text-4xl);
+  }
+
+  .home-viewport .system-b-mounted-home-footer > div {
+    padding-block: var(--space-10) var(--space-8);
+  }
+}
+
+/* SYSTEM B MOUNTED HOME FOOTER CTA PRIMITIVES END */

--- a/apps/web/app/(home)/layout.tsx
+++ b/apps/web/app/(home)/layout.tsx
@@ -29,7 +29,7 @@ export default function HomeLayout({
       <main id='main-content' className='flex min-h-[100svh] flex-1 flex-col'>
         {children}
       </main>
-      <HomeLegalFooter />
+      <HomeLegalFooter className='system-b-mounted-home-footer' />
     </div>
   );
 }

--- a/apps/web/components/homepage/HomeLegalFooter.tsx
+++ b/apps/web/components/homepage/HomeLegalFooter.tsx
@@ -1,5 +1,9 @@
 import { MarketingFooter } from '@/components/site/MarketingFooter';
 
-export function HomeLegalFooter() {
-  return <MarketingFooter variant='expanded' />;
+interface HomeLegalFooterProps {
+  readonly className?: string;
+}
+
+export function HomeLegalFooter({ className }: HomeLegalFooterProps) {
+  return <MarketingFooter variant='expanded' className={className} />;
 }

--- a/apps/web/components/marketing/homepage-v2/HomepageV2Ctas.tsx
+++ b/apps/web/components/marketing/homepage-v2/HomepageV2Ctas.tsx
@@ -74,96 +74,26 @@ export function HomepageV2Pricing() {
   );
 }
 
-const HOMEPAGE_FINAL_CTA_ARCS = [
-  { radiusX: 70, radiusY: 245 },
-  { radiusX: 130, radiusY: 235 },
-  { radiusX: 195, radiusY: 225 },
-  { radiusX: 265, radiusY: 215 },
-  { radiusX: 340, radiusY: 205 },
-  { radiusX: 420, radiusY: 198 },
-  { radiusX: 505, radiusY: 192 },
-  { radiusX: 590, radiusY: 188 },
-] as const;
-
 export function HomepageV2FinalCta() {
   return (
     <section
       data-testid='homepage-v2-final-cta'
-      className='homepage-story-final-cta relative isolate overflow-hidden bg-black'
+      className='homepage-story-final-cta system-b-mounted-home-footer-cta relative isolate overflow-hidden'
     >
-      <div
-        aria-hidden='true'
-        className='homepage-final-cta-glow pointer-events-none absolute inset-0 z-[1]'
-      />
-      <svg
-        className='homepage-final-cta-rays pointer-events-none absolute inset-x-0 bottom-0 z-[2] w-full'
-        viewBox='0 0 1200 540'
-        preserveAspectRatio='xMidYMax slice'
-        aria-hidden='true'
+      <MarketingContainer
+        width='page'
+        className='system-b-mounted-home-footer-cta-container'
       >
-        <defs>
-          <linearGradient
-            id='homepage-final-cta-ray-primary'
-            x1='0'
-            x2='0'
-            y1='0'
-            y2='1'
-          >
-            <stop offset='0%' stopColor='#0070f3' stopOpacity='0' />
-            <stop offset='55%' stopColor='#0070f3' stopOpacity='0.35' />
-            <stop offset='92%' stopColor='#ffffff' stopOpacity='0.95' />
-            <stop offset='100%' stopColor='#ffffff' stopOpacity='0.6' />
-          </linearGradient>
-          <linearGradient
-            id='homepage-final-cta-ray-secondary'
-            x1='0'
-            x2='0'
-            y1='0'
-            y2='1'
-          >
-            <stop offset='0%' stopColor='#0070f3' stopOpacity='0' />
-            <stop offset='70%' stopColor='#0070f3' stopOpacity='0.55' />
-            <stop offset='100%' stopColor='#dbeaff' stopOpacity='0.85' />
-          </linearGradient>
-        </defs>
-        <ellipse
-          cx='600'
-          cy='600'
-          rx='22'
-          ry='260'
-          stroke='url(#homepage-final-cta-ray-secondary)'
-          strokeWidth='2.2'
-          fill='none'
-        />
-        {HOMEPAGE_FINAL_CTA_ARCS.map((arc, index) => (
-          <ellipse
-            key={`${arc.radiusX}-${arc.radiusY}`}
-            cx='600'
-            cy='600'
-            rx={arc.radiusX}
-            ry={arc.radiusY}
-            stroke={
-              index % 2 === 0
-                ? 'url(#homepage-final-cta-ray-primary)'
-                : 'url(#homepage-final-cta-ray-secondary)'
-            }
-            strokeWidth={index < 4 ? 1.5 : 1.2}
-            fill='none'
-            opacity={1 - index * 0.05}
-          />
-        ))}
-      </svg>
-      <MarketingContainer width='page' className='relative z-10'>
-        <div className='homepage-final-cta-copy mx-auto'>
+        <div className='homepage-final-cta-copy system-b-mounted-home-footer-cta-copy mx-auto'>
           <h2
             data-testid='homepage-v2-final-cta-heading'
-            className='text-balance text-[clamp(2.15rem,3.7vw,3.65rem)] font-semibold leading-[1.03] tracking-[-0.035em] text-white'
+            className='homepage-final-cta-heading system-b-mounted-home-footer-cta-heading text-balance'
           >
             {HOMEPAGE_V2_COPY.finalCta.headline}
           </h2>
           <Link
             href={HOMEPAGE_FRONT_DOOR_CTA.primary.href}
-            className='homepage-final-cta-action public-action-primary focus-ring-themed'
+            className='homepage-final-cta-action system-b-mounted-home-footer-cta-action public-action-primary focus-ring-themed'
             data-testid='homepage-v2-final-cta-primary'
             data-cta-sign-up='true'
           >

--- a/apps/web/tests/unit/home/mounted-home-footer-cta-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/mounted-home-footer-cta-system-b-style-guard.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+const cssPath = 'app/(home)/home.css';
+const readSource = (relativePath: string) =>
+  readFileSync(path.join(webRoot, relativePath), 'utf8');
+const footerCtaCssBlock = (source: string) => {
+  const start = source.indexOf('SYSTEM B MOUNTED HOME FOOTER CTA PRIMITIVES');
+  const end = source.indexOf(
+    'SYSTEM B MOUNTED HOME FOOTER CTA PRIMITIVES END',
+    start
+  );
+  expect(start, 'footer CTA CSS block exists').toBeGreaterThanOrEqual(0);
+  expect(end, 'footer CTA CSS block is bounded').toBeGreaterThan(start);
+  return source.slice(start, end);
+};
+
+describe('mounted homepage footer CTA System B source contract', () => {
+  it('keeps mounted footer CTA markup on named System B primitives', () => {
+    const layoutSource = readSource('app/(home)/layout.tsx');
+    const finalCtaSource = readSource(
+      'components/marketing/homepage-v2/HomepageV2Ctas.tsx'
+    );
+
+    expect(layoutSource).toContain(
+      "<HomeLegalFooter className='system-b-mounted-home-footer' />"
+    );
+    expect(finalCtaSource).toMatch(
+      /(?=.*system-b-mounted-home-footer-cta(?!-))(?=.*system-b-mounted-home-footer-cta-container)(?=.*system-b-mounted-home-footer-cta-copy)(?=.*system-b-mounted-home-footer-cta-heading)(?=.*system-b-mounted-home-footer-cta-action)/s
+    );
+    expect(finalCtaSource).not.toMatch(
+      /HOMEPAGE_FINAL_CTA_ARCS|homepage-final-cta-ray|stopColor=|linearGradient|bg-black|text-white|tracking-\[-|text-\[clamp/
+    );
+  });
+
+  it('keeps mounted footer CTA CSS tokenized and stable', () => {
+    const homeCss = readSource(cssPath);
+    const css = footerCtaCssBlock(homeCss);
+
+    expect(css).not.toMatch(
+      /#[0-9a-fA-F]{3,8}|rgba?\(|hsla?\(|linear-gradient|radial-gradient|box-shadow:|letter-spacing:\s*-[^;]+|font-size:[^;]*vw|(?:background|color|border(?:-[^:]+)?|text-decoration-color):[^;]*(?<!-)\b(?:white|black)\b/
+    );
+    expect(homeCss).not.toMatch(
+      /--homepage-footer-cta-(top|bottom)|\\.home-viewport \\.marketing-footer-premium > div|homepage-final-cta-rays/
+    );
+    expect(css).toMatch(
+      /(?=.*var\(--system-b-bg-page\))(?=.*var\(--color-text-primary-token\))(?=.*var\(--color-text-tertiary-token\))(?=.*var\(--system-b-app-frame-seam\))(?=.*var\(--homepage-page-gutter\))(?=.*var\(--homepage-section-max\))(?=.*var\(--text-4xl\))(?=.*var\(--text-xs\))(?=.*var\(--space-)(?=.*\.home-viewport \.system-b-mounted-home-footer)(?=.*@media \(max-width: 767px\))(?=.*letter-spacing: 0;)/s
+    );
+  });
+});

--- a/apps/web/tests/unit/marketing/homepage-v2-final-cta.test.tsx
+++ b/apps/web/tests/unit/marketing/homepage-v2-final-cta.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { HomepageV2FinalCta } from '@/components/marketing/homepage-v2/HomepageV2Route';
 
 describe('HomepageV2FinalCta', () => {
-  it('renders the static CTA contract without a media background', () => {
+  it('renders the static CTA contract without decorative media', () => {
     const { container } = render(<HomepageV2FinalCta />);
 
     expect(screen.getByTestId('homepage-v2-final-cta')).toBeInTheDocument();
@@ -22,6 +22,6 @@ describe('HomepageV2FinalCta', () => {
     expect(
       screen.queryByTestId('homepage-v2-final-cta-video')
     ).not.toBeInTheDocument();
-    expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- removes the active homepage final CTA blue ray/glow layer and moves it to named System B footer CTA primitives
- scopes the homepage legal/footer skin through `system-b-mounted-home-footer` instead of generic `.marketing-footer-premium` overrides
- adds a mounted-home footer CTA guard for token-only CSS and source drift prevention

Linear: JOV-2814

## Verification
- `pnpm biome check --write apps/web/tests/unit/home/mounted-home-footer-cta-system-b-style-guard.test.ts`
- `pnpm biome check --write apps/web/app/(home)/home.css apps/web/tests/unit/home/mounted-home-footer-cta-system-b-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/home/HomeTrustSection.test.tsx tests/unit/home/mounted-home-hero-system-b-style-guard.test.ts tests/unit/home/mounted-home-command-center-system-b-style-guard.test.ts tests/unit/home/mounted-home-product-statement-system-b-style-guard.test.ts tests/unit/home/mounted-home-workspace-system-b-style-guard.test.ts tests/unit/home/mounted-home-trust-strip-system-b-style-guard.test.ts tests/unit/home/mounted-home-footer-cta-system-b-style-guard.test.ts tests/unit/marketing/homepage-v2-final-cta.test.tsx tests/unit/components/site/MarketingFooter.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- `pnpm --filter @jovie/web exec playwright test tests/e2e/homepage.spec.ts -g "trust, product statement, workspace, artist profiles, and footer CTA render"`
- pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Visual proof
- Desktop CTA: `.gstack/design-reports/screenshots/2026-06-05-jov-2814-footer-cta-desktop.png`
- Desktop footer: `.gstack/design-reports/screenshots/2026-06-05-jov-2814-footer-desktop.png`
- Mobile CTA: `.gstack/design-reports/screenshots/2026-06-05-jov-2814-footer-cta-mobile.png`
- Mobile footer: `.gstack/design-reports/screenshots/2026-06-05-jov-2814-footer-mobile.png`

Layout proof: desktop 1440x1100 and mobile 390x844 both have no decorative SVG/glow, heading/action fit horizontally, heading/action remain inside the CTA, and the footer remains separated from the CTA by 7px.