### PR TITLE
fix(web): tokenize root not-found surface

### DIFF
--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -6,38 +6,31 @@ import { MarketingHeader } from '@/components/site/MarketingHeader';
 export default function NotFound() {
   return (
     <div className='dark linear-marketing min-h-screen bg-base text-primary-token'>
-      <MarketingHeader logoSize='xs' />
+      <MarketingHeader logoSize='xs' variant='minimal' />
 
       <main
         id='main-content'
         data-testid='not-found'
-        style={{ paddingTop: 'var(--linear-header-height, 64px)' }}
+        className='system-b-root-not-found-main'
       >
-        <Container className='flex min-h-[calc(100vh-8rem)] items-center justify-center'>
-          <div className='w-full max-w-md mx-auto text-center px-4 py-16'>
-            {/* Error code — oversized, muted, architectural */}
-            <div className='mb-8 select-none'>
-              <span
-                className='block text-[120px] md:text-[160px] font-semibold leading-none tracking-tighter text-primary-token/[0.42]'
-                aria-hidden='true'
-              >
+        <Container className='system-b-root-not-found-container'>
+          <div className='system-b-root-not-found-content'>
+            <div className='system-b-root-not-found-code-wrap'>
+              <span className='system-b-root-not-found-code' aria-hidden='true'>
                 404
               </span>
             </div>
 
-            {/* Content — positioned to overlap the number visually */}
-            <div className='-mt-16 relative'>
-              <h1 className='text-xl font-semibold text-primary-token tracking-tight mb-2'>
-                Page not found
-              </h1>
-              <p className='text-[13px] text-tertiary-token leading-relaxed mb-8'>
+            <div className='system-b-root-not-found-copy'>
+              <h1 className='system-b-root-not-found-title'>Page not found</h1>
+              <p className='system-b-root-not-found-description'>
                 The link you followed may be broken, or the page may have been
                 removed.
               </p>
 
               <Link
                 href='/'
-                className='inline-flex items-center justify-center h-8 px-4 text-[13px] font-medium rounded-lg bg-[var(--color-btn-primary-bg)] text-[var(--color-btn-primary-fg)] hover:bg-[var(--color-btn-primary-hover)] transition-colors duration-subtle'
+                className='system-b-root-not-found-action focus-ring-transparent-offset'
               >
                 Return home
               </Link>

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2206,6 +2206,90 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
 }
 
 /* ============================================
+   SYSTEM B ROOT NOT FOUND PRIMITIVES
+   ============================================ */
+
+:where(.system-b-root-not-found-main) {
+  padding-top: var(--system-b-header-height);
+}
+
+:where(.system-b-root-not-found-container) {
+  display: flex;
+  min-height: calc(100svh - (var(--space-16) * 2));
+  align-items: center;
+  justify-content: center;
+}
+
+:where(.system-b-root-not-found-content) {
+  width: 100%;
+  max-width: calc(var(--space-24) * 4 + var(--space-4));
+  margin-inline: auto;
+  padding-block: var(--space-16);
+  padding-inline: var(--space-4);
+  text-align: center;
+}
+
+:where(.system-b-root-not-found-code-wrap) {
+  margin-bottom: var(--space-8);
+  user-select: none;
+}
+
+:where(.system-b-root-not-found-code) {
+  display: block;
+  color: var(--color-text-quaternary-token);
+  font-size: clamp(
+    calc(var(--space-24) + var(--space-6)),
+    16vw,
+    calc(var(--space-24) + var(--space-16))
+  );
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+  line-height: 1;
+  opacity: 0.72;
+}
+
+:where(.system-b-root-not-found-copy) {
+  position: relative;
+  margin-top: calc(var(--space-16) * -1);
+}
+
+:where(.system-b-root-not-found-title) {
+  margin: 0 0 var(--space-2);
+  color: var(--system-b-text-primary);
+  font-size: var(--text-xl);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight);
+}
+
+:where(.system-b-root-not-found-description) {
+  max-width: calc(var(--space-24) * 3 + var(--space-4));
+  margin: 0 auto var(--space-8);
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+}
+
+:where(.system-b-root-not-found-action) {
+  display: inline-flex;
+  height: var(--space-8);
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  background: var(--system-b-primary-bg);
+  color: var(--system-b-primary-fg);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+  padding-inline: var(--space-4);
+  text-decoration: none;
+  transition: background var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-root-not-found-action:hover) {
+  background: var(--color-btn-primary-hover);
+}
+
+/* ============================================
    SYSTEM B UNAVAILABLE PAGE PRIMITIVES
    ============================================ */
 

--- a/apps/web/tests/unit/app/not-found-system-b-source.test.ts
+++ b/apps/web/tests/unit/app/not-found-system-b-source.test.ts
@@ -1,0 +1,57 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const sourcePath = join(appRoot, 'app/not-found.tsx');
+const designSystemPath = join(appRoot, 'styles/design-system.css');
+
+const hashMark = String.fromCharCode(35);
+const colorFunctionName = ['r', 'g', 'b', 'a'].join('');
+const hardcodedHashColorPattern = new RegExp(`${hashMark}[\\da-fA-F]{3,8}\\b`);
+const rawAlphaColorPattern = new RegExp(`${colorFunctionName}\\s*\\(`, 'i');
+const rawColorMixPattern = /color-mix\(/i;
+const gradientPattern = ['linear', 'gradient|radial', 'gradient'].join('-');
+const rawGradientPattern = new RegExp(gradientPattern, 'i');
+const rawVisualUtilityPattern =
+  /\b(?:bg|border|text|ring|shadow|outline|rounded|h|w|max-w|min-h|min-w|tracking|leading|px|py|pt|pb)-\[/;
+const negativeTrackingPattern = /\btracking-(?:tight|tighter)\b/;
+
+describe('root not-found System B source tokens', () => {
+  it('keeps the route free of route-local visual token drift', async () => {
+    const source = await readFile(sourcePath, 'utf8');
+
+    expect(source).not.toMatch(hardcodedHashColorPattern);
+    expect(source).not.toMatch(rawAlphaColorPattern);
+    expect(source).not.toMatch(rawColorMixPattern);
+    expect(source).not.toMatch(rawGradientPattern);
+    expect(source).not.toMatch(rawVisualUtilityPattern);
+    expect(source).not.toMatch(negativeTrackingPattern);
+    expect(source).not.toContain('style={{');
+    expect(source).toContain("variant='minimal'");
+    expect(source).toContain('system-b-root-not-found-main');
+    expect(source).toContain('system-b-root-not-found-action');
+    expect(source.match(/system-b-root-not-found-action/g)).toHaveLength(1);
+  });
+
+  it('backs the root not-found primitives with System B tokens', async () => {
+    const css = await readFile(designSystemPath, 'utf8');
+    const block = css.match(
+      /SYSTEM B ROOT NOT FOUND PRIMITIVES[\s\S]*?\/\* ============================================\s+SYSTEM B UNAVAILABLE PAGE PRIMITIVES/
+    )?.[0];
+
+    expect(block).toBeTruthy();
+    expect(block).toContain('var(--system-b-header-height)');
+    expect(block).toContain('var(--system-b-text-primary)');
+    expect(block).toContain('var(--system-b-primary-bg)');
+    expect(block).toContain('var(--system-b-primary-fg)');
+    expect(block).toContain('var(--space-16)');
+    expect(block).not.toMatch(hardcodedHashColorPattern);
+    expect(block).not.toMatch(rawAlphaColorPattern);
+    expect(block).not.toMatch(rawColorMixPattern);
+    expect(block).not.toMatch(rawGradientPattern);
+    expect(block).not.toContain('--linear-');
+  });
+});


### PR DESCRIPTION
## Summary

- Moves the root `app/not-found.tsx` visual geometry/type/action styling onto named `system-b-root-not-found-*` primitives in `design-system.css`.
- Switches the root 404 header to the minimal marketing variant so `Return home` is the only filled primary action in the viewport.
- Adds a focused System B source guard for root 404 token drift.

## Linear

[JOV-2816](https://linear.app/jovie/issue/JOV-2816/normalize-root-not-found-page-to-system-b-primitives)

## Verification

- `pnpm --filter @jovie/web exec vitest run tests/unit/app/not-found-system-b-source.test.ts tests/unit/app/error-system-b-source.test.ts tests/unit/app/global-error-system-b-source.test.ts tests/unit/components/unavailable-page-system-b-style-guard.test.ts`
- `pnpm biome check --write apps/web/app/not-found.tsx apps/web/styles/design-system.css apps/web/tests/unit/app/not-found-system-b-source.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `BASE_URL=http://localhost:3102 PUBLIC_SURFACE_FILTER=root-not-found pnpm --filter @jovie/web exec playwright test tests/e2e/public-exhaustive.spec.ts --project=chromium -g "all public anonymous routes stay green"`
- Pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Screenshot Proof

- Desktop: `.gstack/design-reports/screenshots/2026-06-05-jov-2816-root-not-found-desktop-clean-proof.png`
- Mobile: `.gstack/design-reports/screenshots/2026-06-05-jov-2816-root-not-found-mobile-clean-proof.png`

Browser proof on `http://localhost:3102/dev/root-not-found-probe` returned 404 with heading `Page not found`, `rootPrimaryActionCount=1`, `filledHeaderCtaCount=0`, no horizontal overflow, and `clsBeforeScreenshot=0` on desktop 1440x900 and mobile 390x844.
