### PR TITLE
fix(web): tokenize presence loading skeleton

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/presence/loading.tsx
+++ b/apps/web/app/app/(shell)/dashboard/presence/loading.tsx
@@ -5,12 +5,12 @@ const CARD_KEYS = ['a', 'b', 'c'] as const;
 export default function PresenceLoading() {
   return (
     <div
-      className='flex h-full min-h-0 flex-col bg-[color-mix(in_oklab,var(--linear-bg-page)_72%,var(--linear-bg-surface-1))]'
+      className='flex h-full min-h-0 flex-col bg-base'
       aria-busy='true'
       data-testid='presence-loading-skeleton'
     >
       {/* Summary bar skeleton */}
-      <div className='shrink-0 border-b border-(--linear-app-frame-seam) px-3 py-2.5 lg:px-4'>
+      <div className='shrink-0 border-b border-subtle px-3 py-2.5 lg:px-4'>
         <div className='flex items-center gap-3'>
           <LoadingSkeleton height='h-4' width='w-28' rounded='md' />
           <LoadingSkeleton height='h-3' width='w-40' rounded='sm' />

--- a/apps/web/tests/unit/dashboard/presence-loading-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/presence-loading-system-b-style-guard.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+const sourcePath = 'app/app/(shell)/dashboard/presence/loading.tsx';
+
+const forbiddenLocalChromePatterns = [
+  /--linear-/,
+  /color-mix\(/,
+  /\b(?:bg|border|shadow)-\[/,
+  /\b(?:bg|border)-\(--/,
+  /\btransition-all\b/,
+  /\b(?:translate|scale)-/,
+] as const;
+
+describe('presence loading skeleton System B source contract', () => {
+  it('keeps skeleton chrome on named System B primitives', () => {
+    const source = readFileSync(resolve(appRoot, sourcePath), 'utf8');
+
+    for (const pattern of forbiddenLocalChromePatterns) {
+      expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
+    }
+
+    for (const className of [
+      'bg-base',
+      'border-subtle',
+      'bg-surface-0',
+      'animate-pulse',
+      'h-full',
+      'min-h-0',
+      'overflow-hidden',
+    ]) {
+      expect(source).toContain(className);
+    }
+
+    expect(source).toContain("data-testid='presence-loading-skeleton'");
+    expect(source).toContain("const CARD_KEYS = ['a', 'b', 'c'] as const");
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the presence loading skeleton's Linear-era arbitrary background/divider classes with named System B utilities.
- Add a focused source guard so this route-level skeleton cannot regress to `--linear-*`, `color-mix`, or arbitrary bg/border/shadow chrome.

## Linear
- JOV-2818

## Layout Shift Audit
Visual states enumerated before edit:
- Loading skeleton while presence data is undefined.
- Mounted presence view once data is defined.
- Error state after data exists and `isError` is true.

This PR keeps the skeleton DOM, count, spacing, dimensions, and overflow behavior unchanged. Only static color/border utility names changed, so no state transition can gain or lose layout space.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/PresencePageClient-skeleton.test.tsx tests/unit/dashboard/presence-loading-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/app/'(shell)'/dashboard/presence/loading.tsx apps/web/tests/unit/dashboard/presence-loading-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Pre-commit hook: `next:proxy-guard`, staged Biome/ESLint, affected web typecheck
- Pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated presence loading skeleton styling with refined design tokens for consistency.

* **Tests**
  * Added test coverage to enforce styling standards for the presence loading component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->