### PR TITLE
fix(web): tokenize release downloads dropzone

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/page.tsx
@@ -233,9 +233,8 @@ export default function PromoDownloadsPage() {
                 }}
                 onDrop={handleDrop}
                 className={cn(
-                  'flex min-h-[154px] flex-col items-center justify-center rounded-lg border border-dashed border-(--linear-app-frame-seam) bg-surface-0 px-4 py-6 text-center transition-[background-color,border-color]',
-                  isDragging &&
-                    'border-(--linear-border-focus) bg-[color-mix(in_oklab,var(--linear-border-focus)_8%,var(--linear-bg-surface-0))]'
+                  'flex min-h-[154px] flex-col items-center justify-center rounded-lg border border-dashed border-subtle bg-surface-0 px-4 py-6 text-center transition-[background-color,border-color,box-shadow]',
+                  isDragging && 'border-focus bg-surface-1 ring-2 ring-focus/20'
                 )}
                 data-testid='promo-download-dropzone'
               >

--- a/apps/web/tests/unit/app/release-downloads-shell.test.ts
+++ b/apps/web/tests/unit/app/release-downloads-shell.test.ts
@@ -84,6 +84,35 @@ describe('release downloads shell contract', () => {
     expect(source).not.toContain("style={{ position: 'relative' }}");
   });
 
+  it('keeps the upload target visual states on named System B primitives', () => {
+    const source = readReleaseDownloadsSource();
+
+    for (const forbiddenPattern of [
+      /--linear-/,
+      /color-mix\(/,
+      /\b(?:bg|border|shadow)-\[/,
+      /\b(?:bg|border)-\(--/,
+      /\btransition-all\b/,
+      /\b(?:translate|scale)-/,
+    ]) {
+      expect(
+        source,
+        `release downloads page matched ${forbiddenPattern}`
+      ).not.toMatch(forbiddenPattern);
+    }
+
+    for (const className of [
+      'border-subtle',
+      'bg-surface-0',
+      'border-focus',
+      'bg-surface-1',
+      'ring-focus/20',
+      'transition-[background-color,border-color,box-shadow]',
+    ]) {
+      expect(source).toContain(className);
+    }
+  });
+
   it('surfaces network failures instead of silently swallowing them', () => {
     const source = readReleaseDownloadsSource();
 


### PR DESCRIPTION
## Summary
- Replace release promo-download dropzone drag chrome with named System B primitives (`border-subtle`, `border-focus`, `bg-surface-*`, `ring-focus/20`).
- Add a release-downloads shell guard preventing raw Linear CSS vars, arbitrary color mixes, arbitrary bg/border/shadow utilities, `transition-all`, and transform motion on this surface.

## Linear
- JOV-2819

## Layout Shift Audit
- States checked by source inspection: idle dropzone, drag-over, uploading, upload error, list error, operation error, empty table, loaded table.
- The change only swaps paint classes on an existing fixed `min-h-[154px]` dropzone and adds ring/box-shadow transition. No DOM, spacing, dimensions, or conditional content wrappers changed.
- Existing output regions keep `min-h-9` / `min-h-10`, and the table region keeps `min-h-[220px]`.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/app/release-downloads-shell.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/app/'(shell)'/dashboard/releases/'[releaseId]'/downloads/page.tsx apps/web/tests/unit/app/release-downloads-shell.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder git diff --check`
- Pre-push: `biome check .`, web `next:proxy-guard`, `tailwind:check`, `typecheck`, `lint`

## Visual Proof
- Attempted branch-local Playwright capture on `http://localhost:3105` under Doppler with `E2E_USE_TEST_AUTH_BYPASS=1`, `NEXT_PUBLIC_E2E_MODE=1`, `NEXT_PUBLIC_CLERK_MOCK=1`, `NEXT_PUBLIC_CLERK_PROXY_DISABLED=1`.
- Auth entered successfully with `303`, then route discovery redirected through `/app/library?view=releases` and timed out before writing screenshots. No screenshot evidence was produced for this protected route in this slice.