### PR TITLE
fix(ui): reuse shared dialog close button styles

### DIFF
--- a/packages/ui/atoms/dialog.test.tsx
+++ b/packages/ui/atoms/dialog.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { closeButtonClassName } from './close-button';
 import {
   Dialog,
   DialogClose,
@@ -182,6 +183,17 @@ describe('Dialog', () => {
     it('shows close button by default', () => {
       render(<TestDialog open={true} />);
       expect(screen.getByTestId('dialog-close-button')).toBeInTheDocument();
+    });
+
+    it('uses the shared pill close button styles', () => {
+      render(<TestDialog open={true} />);
+      const closeButton = screen.getByTestId('dialog-close-button');
+
+      expect(closeButton.className).toBe(closeButtonClassName);
+      expect(closeButton.className).toContain('rounded-full');
+      expect(closeButton.className).not.toContain(
+        'rounded-(--linear-app-radius-item)'
+      );
     });
 
     it('hides close button when hideClose is true', () => {

--- a/packages/ui/atoms/dialog.tsx
+++ b/packages/ui/atoms/dialog.tsx
@@ -12,13 +12,7 @@ import {
   titleStyles,
 } from '../lib/overlay-styles';
 import { cn } from '../lib/utils';
-import { CloseButtonIcon } from './close-button';
-
-const dialogCloseButtonClassName =
-  'absolute right-3 top-3 rounded-(--linear-app-radius-item) p-1 text-(--linear-text-tertiary) opacity-70 transition-colors duration-normal ease-interactive ' +
-  'hover:bg-(--linear-bg-surface-1) hover:text-(--linear-text-primary) hover:opacity-100 ' +
-  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-bg-page) ' +
-  'disabled:pointer-events-none';
+import { CloseButtonIcon, closeButtonClassName } from './close-button';
 
 const Dialog = DialogPrimitive.Root;
 
@@ -97,7 +91,7 @@ const DialogContent = React.forwardRef<
         {children}
         {!hideClose && (
           <DialogPrimitive.Close
-            className={dialogCloseButtonClassName}
+            className={closeButtonClassName}
             data-testid='dialog-close-button'
           >
             <CloseButtonIcon />


### PR DESCRIPTION
## Summary
- Reuses the shared `closeButtonClassName` for `DialogContent` instead of a local item-radius class.
- Adds a focused regression test proving Dialog uses the shared pill close-button contract and does not drift back to `--linear-app-radius-item`.

## Verification
- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write packages/ui/atoms/dialog.tsx packages/ui/atoms/dialog.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/ui exec vitest run atoms/dialog.test.tsx atoms/close-button.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/ui run typecheck`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/ui run lint`
- `git diff --check`
- pre-push: repo Biome, web next:proxy-guard, tailwind:check, typecheck, lint

## Visual proof
- Captured `/ui/dialogs` at `1440x960` and opened the standard dialog.
- Rendered close button class includes `rounded-full`, omits `rounded-(--linear-app-radius-item)`, and remains `absolute`.
- Local screenshots: `.gstack/design-reports/screenshots/jov-2821-dialog-showcase-page.png`, `.gstack/design-reports/screenshots/jov-2821-dialog-open-pill-close.png`.

Linear: JOV-2821