### PR TITLE
fix(ios): tokenize venue qr plate

### DIFF
--- a/apps/ios/Jovie/DesignSystem/JovieTheme.swift
+++ b/apps/ios/Jovie/DesignSystem/JovieTheme.swift
@@ -61,6 +61,12 @@ enum JovieRadius {
   static let pill: CGFloat = 999
 }
 
+enum JovieQRCodePlate {
+  static let padding = JovieSpacing.xLarge
+  static let radius = JovieRadius.large
+  static let background = JovieColor.qrSurface
+}
+
 private struct JovieSurfaceModifier: ViewModifier {
   let radius: CGFloat
   let interactive: Bool
@@ -92,9 +98,24 @@ private struct JovieSurfaceModifier: ViewModifier {
   }
 }
 
+private struct JovieQRCodePlateModifier: ViewModifier {
+  func body(content: Content) -> some View {
+    content
+      .padding(JovieQRCodePlate.padding)
+      .background(
+        JovieQRCodePlate.background,
+        in: RoundedRectangle(cornerRadius: JovieQRCodePlate.radius, style: .continuous)
+      )
+  }
+}
+
 extension View {
   func jovieSurface(radius: CGFloat = JovieRadius.large, interactive: Bool = false) -> some View {
     modifier(JovieSurfaceModifier(radius: radius, interactive: interactive))
+  }
+
+  func jovieQRCodePlate() -> some View {
+    modifier(JovieQRCodePlateModifier())
   }
 }
 

--- a/apps/ios/Jovie/Features/Dashboard/DashboardView.swift
+++ b/apps/ios/Jovie/Features/Dashboard/DashboardView.swift
@@ -185,11 +185,7 @@ struct DashboardView: View {
             .interpolation(.none)
             .resizable()
             .scaledToFit()
-            .padding(24)
-            .background(
-              JovieColor.qrSurface,
-              in: RoundedRectangle(cornerRadius: JovieRadius.large, style: .continuous)
-            )
+            .jovieQRCodePlate()
             .accessibilityLabel("Profile QR Code")
         } else {
           Text("QR unavailable")

--- a/apps/ios/Jovie/Features/Dashboard/VenueModeView.swift
+++ b/apps/ios/Jovie/Features/Dashboard/VenueModeView.swift
@@ -16,8 +16,7 @@ struct VenueModeView: View {
             .interpolation(.none)
             .resizable()
             .scaledToFit()
-            .padding(24)
-            .background(Color.white, in: RoundedRectangle(cornerRadius: 28, style: .continuous))
+            .jovieQRCodePlate()
             .accessibilityLabel("Fullscreen Profile QR Code")
         }
 

--- a/apps/ios/JovieTests/QRCodeRendererTests.swift
+++ b/apps/ios/JovieTests/QRCodeRendererTests.swift
@@ -19,4 +19,9 @@ struct QRCodeRendererTests {
   @Test func skipsEmptyPayloads() {
     #expect(QRCodeRenderer.image(for: "") == nil)
   }
+
+  @Test func qrPlateStyleUsesSystemBTokens() {
+    #expect(JovieQRCodePlate.padding == JovieSpacing.xLarge)
+    #expect(JovieQRCodePlate.radius == JovieRadius.large)
+  }
 }


### PR DESCRIPTION
## Summary
- Promotes the native iOS QR plate recipe into `JovieQRCodePlate` System B tokens and a shared `jovieQRCodePlate()` modifier.
- Reuses the same QR plate in Dashboard and fullscreen Venue Mode.
- Adds a focused QR style regression assertion in the existing iOS QR test target.

## Verification
- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh`
- `pnpm run ios:setup-env`
- XcodeBuildMCP `build_sim` with `CODE_SIGNING_ALLOWED=NO`: passed
- XcodeBuildMCP `test_sim -only-testing:JovieTests/QRCodeRendererTests CODE_SIGNING_ALLOWED=NO`: 4 passed, 0 failed
- XcodeBuildMCP `build_run_sim` with `-ui-testing-venue-mode -ui-testing-allow-exit`: passed
- XcodeBuildMCP screenshot: `.gstack/design-reports/screenshots/jov-2822-ios-venue-mode-qr-after.jpg`
- XcodeBuildMCP `test_sim -only-testing:JovieUITests/JovieUITests/testVenueModeLaunchShowsFullscreenQR CODE_SIGNING_ALLOWED=NO`: 1 passed, 0 failed
- `rg "padding\\(24\\)|cornerRadius: 28|Color\\.white, in: RoundedRectangle" apps/ios/Jovie/Features/Dashboard apps/ios/Jovie/DesignSystem/JovieTheme.swift apps/ios/JovieTests/QRCodeRendererTests.swift`: no matches
- `git diff --check`
- Push pre-push hook: Biome, web proxy guard, Tailwind guard, web typecheck, web lint passed

## Linear
[JOV-2822](https://linear.app/jovie/issue/JOV-2822/fixios-tokenize-venue-mode-qr-plate)
