### PR TITLE
fix(releases): add track expansion fallback (JOV-2833)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx
@@ -962,6 +962,20 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
   const isTrackSidebarOpen = Boolean(editingTrack);
   const isSidebarOpen =
     isReleaseSidebarOpen || isTrackSidebarOpen || addReleaseOpen;
+  const tableTracksByReleaseId = useMemo(() => {
+    if (experienceAdapter?.tracksByReleaseId) {
+      return experienceAdapter.tracksByReleaseId;
+    }
+    if (!experienceAdapter?.sidebarDataByReleaseId) {
+      return undefined;
+    }
+
+    return Object.fromEntries(
+      Object.entries(experienceAdapter.sidebarDataByReleaseId)
+        .filter(([, data]) => data.tracks)
+        .map(([releaseId, data]) => [releaseId, data.tracks ?? []])
+    );
+  }, [experienceAdapter]);
 
   // Connect to tableMeta for drawer toggle button
   const { setTableMeta } = useTableMeta();
@@ -1290,6 +1304,7 @@ export const ReleaseProviderMatrix = memo(function ReleaseProviderMatrix({
                 groupByYear={groupByYear}
                 selectedReleaseId={editingRelease?.id}
                 selectedTrackId={editingTrack?.id}
+                tracksByReleaseId={tableTracksByReleaseId}
                 designV1={designV1ReleasesEnabled}
                 refreshingReleaseId={refreshingReleaseId}
                 flashedReleaseId={flashedReleaseId}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx
@@ -56,6 +56,7 @@ export function ReleaseTable({
   groupByYear = false,
   selectedReleaseId,
   selectedTrackId,
+  tracksByReleaseId,
   designV1 = false,
   refreshingReleaseId,
   flashedReleaseId,
@@ -218,6 +219,7 @@ export function ReleaseTable({
           flashedReleaseId={flashedReleaseId}
           selectedReleaseId={selectedReleaseId}
           selectedTrackId={selectedTrackId}
+          tracksByReleaseId={tracksByReleaseId}
           designV1={designV1}
           isSmartLinkLocked={isSmartLinkLocked}
           getSmartLinkLockReason={getSmartLinkLockReason}

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.types.ts
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.types.ts
@@ -1,5 +1,9 @@
 import type { TrackSidebarData } from '@/components/organisms/release-sidebar';
-import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
+import type {
+  ProviderKey,
+  ReleaseViewModel,
+  TrackViewModel,
+} from '@/lib/discography/types';
 
 export interface ProviderConfig {
   readonly label: string;
@@ -34,6 +38,7 @@ export interface ReleaseTableProps {
   readonly flashedReleaseId?: string | null;
   readonly selectedReleaseId?: string | null;
   readonly selectedTrackId?: string | null;
+  readonly tracksByReleaseId?: Record<string, TrackViewModel[]>;
   readonly designV1?: boolean;
   readonly isSmartLinkLocked?: (releaseId: string) => boolean;
   readonly getSmartLinkLockReason?: (

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx
@@ -55,6 +55,7 @@ export function ReleaseTableWithTracks({
   groupByYear = false,
   selectedReleaseId,
   selectedTrackId,
+  tracksByReleaseId,
   designV1 = false,
   refreshingReleaseId,
   flashedReleaseId,
@@ -69,7 +70,7 @@ export function ReleaseTableWithTracks({
     isLoading: isLoadingTracks,
     toggleExpansion,
     getTracksForRelease,
-  } = useExpandedTracks();
+  } = useExpandedTracks(tracksByReleaseId);
   const { sorting, onSortingChange, isSorting, isLargeDataset } =
     useSortingManager({ rowCount: releases.length });
 

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/hooks/useExpandedTracks.ts
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/hooks/useExpandedTracks.ts
@@ -34,7 +34,9 @@ export interface UseExpandedTracksResult {
  * - Loading state: shows spinner while fetching
  * - Session-only state: expanded state is not persisted
  */
-export function useExpandedTracks(): UseExpandedTracksResult {
+export function useExpandedTracks(
+  seededTracksByReleaseId?: Record<string, TrackViewModel[]>
+): UseExpandedTracksResult {
   const [expandedReleaseIds, setExpandedReleaseIds] = useState<Set<string>>(
     new Set()
   );
@@ -104,6 +106,17 @@ export function useExpandedTracks(): UseExpandedTracksResult {
         return;
       }
 
+      const seededTracks = seededTracksByReleaseId?.[releaseId];
+      if (seededTracks) {
+        setTracksByReleaseId(prev => {
+          const next = new Map(prev);
+          next.set(releaseId, seededTracks);
+          return next;
+        });
+        setExpandedReleaseIds(prev => new Set(prev).add(releaseId));
+        return;
+      }
+
       // Mark as loading (both state and ref)
       loadingReleaseIdsRef.current.add(releaseId);
       setLoadingReleaseIds(prev => new Set(prev).add(releaseId));
@@ -132,7 +145,16 @@ export function useExpandedTracks(): UseExpandedTracksResult {
           releaseSlug: release.slug,
           route: APP_ROUTES.RELEASES,
         });
-        // Could show a toast here
+        if (loadingReleaseIdsRef.current.has(releaseId)) {
+          startTransition(() => {
+            setTracksByReleaseId(prev => {
+              const next = new Map(prev);
+              next.set(releaseId, seededTracksByReleaseId?.[releaseId] ?? []);
+              return next;
+            });
+            setExpandedReleaseIds(prev => new Set(prev).add(releaseId));
+          });
+        }
       } finally {
         // Clear loading state (both state and ref)
         loadingReleaseIdsRef.current.delete(releaseId);
@@ -143,7 +165,12 @@ export function useExpandedTracks(): UseExpandedTracksResult {
         });
       }
     },
-    [expandedReleaseIds, fetchReleaseTracks, tracksByReleaseId]
+    [
+      expandedReleaseIds,
+      fetchReleaseTracks,
+      seededTracksByReleaseId,
+      tracksByReleaseId,
+    ]
   );
 
   const collapseAll = useCallback(() => {

--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/types.ts
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/types.ts
@@ -2,7 +2,11 @@ import type {
   ReleaseSidebarAnalytics,
   ReleaseSidebarTrack,
 } from '@/components/organisms/release-sidebar/types';
-import type { ProviderKey, ReleaseViewModel } from '@/lib/discography/types';
+import type {
+  ProviderKey,
+  ReleaseViewModel,
+  TrackViewModel,
+} from '@/lib/discography/types';
 import type { PlanGateEntitlements } from '@/lib/queries';
 import type { CanvasStatus } from '@/lib/services/canvas/types';
 
@@ -76,6 +80,7 @@ export interface ReleaseExperienceAdapter {
   ) => Promise<void>;
   readonly onToggleArtworkDownloads?: (enabled: boolean) => Promise<void>;
   readonly sidebarDataByReleaseId?: Record<string, ReleaseSidebarFixtureData>;
+  readonly tracksByReleaseId?: Record<string, TrackViewModel[]>;
 }
 
 export type DraftState = Partial<Record<ProviderKey, string>>;

--- a/apps/web/tests/components/release-provider-matrix/useExpandedTracks.test.ts
+++ b/apps/web/tests/components/release-provider-matrix/useExpandedTracks.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useExpandedTracks } from '@/features/dashboard/organisms/release-provider-matrix/hooks/useExpandedTracks';
+import type { ReleaseViewModel, TrackViewModel } from '@/lib/discography/types';
+import { createMockRelease } from '@/tests/test-utils/factories';
+
+const { captureErrorMock, fetchWithTimeoutMock } = vi.hoisted(() => ({
+  captureErrorMock: vi.fn(),
+  fetchWithTimeoutMock: vi.fn(),
+}));
+
+vi.mock('@/lib/queries', () => ({
+  fetchWithTimeout: fetchWithTimeoutMock,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: captureErrorMock,
+}));
+
+function makeRelease(): ReleaseViewModel {
+  return createMockRelease({
+    id: 'release_1',
+    title: 'Expanded Release',
+  });
+}
+
+function makeTrack(): TrackViewModel {
+  return {
+    id: 'track_1',
+    releaseId: 'release_1',
+    releaseSlug: 'expanded-release',
+    title: 'Seeded Track',
+    slug: 'seeded-track',
+    smartLinkPath: '/demo/expanded-release/tracks/1',
+    trackNumber: 1,
+    discNumber: 1,
+    durationMs: 180_000,
+    isrc: 'USRC10000001',
+    isExplicit: false,
+    previewUrl: null,
+    audioUrl: null,
+    audioFormat: null,
+    providers: [],
+  };
+}
+
+describe('useExpandedTracks', () => {
+  beforeEach(() => {
+    captureErrorMock.mockReset();
+    fetchWithTimeoutMock.mockReset();
+  });
+
+  it('expands seeded demo tracks without calling the live tracks API', async () => {
+    const release = makeRelease();
+    const track = makeTrack();
+    const { result } = renderHook(() =>
+      useExpandedTracks({ [release.id]: [track] })
+    );
+
+    await act(async () => {
+      await result.current.toggleExpansion(release);
+    });
+
+    expect(result.current.isExpanded(release.id)).toBe(true);
+    expect(result.current.getTracksForRelease(release.id)).toEqual([track]);
+    expect(fetchWithTimeoutMock).not.toHaveBeenCalled();
+  });
+
+  it('renders a visible empty track fallback when the live tracks API fails', async () => {
+    fetchWithTimeoutMock.mockRejectedValueOnce(new Error('offline'));
+    const release = makeRelease();
+    const { result } = renderHook(() => useExpandedTracks());
+
+    await act(async () => {
+      await result.current.toggleExpansion(release);
+    });
+
+    expect(result.current.isExpanded(release.id)).toBe(true);
+    expect(result.current.getTracksForRelease(release.id)).toEqual([]);
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      'Failed to load tracks for release',
+      expect.any(Error),
+      expect.objectContaining({ releaseId: release.id })
+    );
+  });
+});


### PR DESCRIPTION
Linear: JOV-2833

## Summary
- Thread seeded release tracks through the release provider matrix table path.
- Allow expanded release rows to use seeded/demo tracks without a live API call.
- Keep rows expandable with an empty fallback when the live tracks API fails, with focused hook coverage.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/components/release-provider-matrix/useExpandedTracks.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check apps/web/components/features/dashboard/organisms/release-provider-matrix/hooks/useExpandedTracks.ts apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseProviderMatrix.tsx apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.tsx apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTable.types.ts apps/web/components/features/dashboard/organisms/release-provider-matrix/ReleaseTableWithTracks.tsx apps/web/components/features/dashboard/organisms/release-provider-matrix/types.ts apps/web/tests/components/release-provider-matrix/useExpandedTracks.test.ts`
- Pre-push: `biome check . && pnpm --filter=@jovie/web run pre-push`