### PR TITLE
fix(ci): keep product screenshots from timing out (JOV-2834)

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -40,7 +40,7 @@ jobs:
   generate:
     name: Generate Screenshots
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 35
     permissions:
       contents: read
     defaults:
@@ -77,8 +77,12 @@ jobs:
 
       - name: Start production server
         run: |
-          pnpm run start &
-          for attempt in $(seq 1 30); do
+          if [ -f .next/standalone/apps/web/server.js ]; then
+            node .next/standalone/apps/web/server.js &
+          else
+            pnpm run start &
+          fi
+          for _attempt in $(seq 1 30); do
             if curl -fsS http://localhost:3000 >/dev/null 2>&1; then
               exit 0
             fi
@@ -88,6 +92,7 @@ jobs:
           exit 1
 
       - name: Capture screenshot catalog
+        timeout-minutes: 30
         run: |
           pnpm exec playwright test \
             --config=playwright.config.screenshots.ts \


### PR DESCRIPTION
## Summary
- Increase Product Screenshots job headroom from 15 to 35 minutes so the catalog can finish retries instead of being cancelled by the job timeout.
- Add a 30-minute timeout to the capture step so failures remain actionable at the Playwright step.
- Start the standalone Next.js server artifact when it exists, matching the production build output.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm exec actionlint .github/workflows/screenshots.yml`
- `git diff --check`
- `JOVIE_AGENT_PROFILE=coder git push -u origin codex/jov-2834-screenshots-timeout` pre-push hook:
  - `biome check .`
  - `pnpm --filter=@jovie/web run next:proxy-guard`
  - `pnpm --filter=@jovie/web run tailwind:check`
  - `pnpm --filter=@jovie/web run typecheck`
  - `pnpm --filter=@jovie/web run lint`

Linear: JOV-2834

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline reliability by extending screenshot generation timeout and optimizing production server startup handling with conditional fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->