### PR TITLE
fix(home): tokenize profile showcase chrome

### DIFF
--- a/apps/web/components/features/home/HomeProfileShowcase.tsx
+++ b/apps/web/components/features/home/HomeProfileShowcase.tsx
@@ -90,18 +90,20 @@ function HomeProfileOverlayCard({
           'homepage-showcase-overlay-card-apple-pay'
         )}
       >
-        <div className='flex items-center justify-between gap-3'>
-          <p className='text-[13px] font-[620] tracking-[-0.02em] text-slate-950'>
-            {overlay.title}
-          </p>
-          <span className='rounded-full bg-slate-950 px-2.5 py-1 text-[10px] font-[620] tracking-[0.08em] text-white'>
+        <div className='homepage-showcase-overlay-row'>
+          <p className='homepage-showcase-overlay-title'>{overlay.title}</p>
+          <span
+            className='homepage-showcase-overlay-badge'
+            data-tone='on-light'
+          >
             Pay
           </span>
         </div>
-        <p className='mt-3 text-[20px] font-[650] tracking-[-0.04em] text-slate-950'>
-          {overlay.body}
-        </p>
-        <div className='mt-4 flex items-center justify-between rounded-[1rem] bg-white/80 px-3 py-2.5 text-[11px] font-semibold text-slate-600'>
+        <p className='homepage-showcase-overlay-headline'>{overlay.body}</p>
+        <div
+          className='homepage-showcase-overlay-meta-row'
+          data-tone='on-light'
+        >
           <span>{overlay.accentLabel}</span>
           <span>Face ID</span>
         </div>
@@ -119,16 +121,12 @@ function HomeProfileOverlayCard({
           'homepage-showcase-overlay-card-thank-you'
         )}
       >
-        <span className='inline-flex rounded-full bg-emerald-400/16 px-2.5 py-1 text-[10px] font-[620] tracking-[0.08em] text-emerald-300'>
+        <span className='homepage-showcase-overlay-badge' data-tone='success'>
           {overlay.accentLabel}
         </span>
-        <p className='mt-3 text-[19px] font-[650] tracking-[-0.04em] text-white'>
-          {overlay.title}
-        </p>
-        <p className='mt-2 text-[12px] leading-[1.6] text-white/68'>
-          {overlay.body}
-        </p>
-        <div className='mt-4 rounded-[1rem] border border-white/8 bg-white/[0.04] px-3 py-2.5 text-[11px] font-semibold text-white/76'>
+        <p className='homepage-showcase-overlay-headline'>{overlay.title}</p>
+        <p className='homepage-showcase-overlay-body'>{overlay.body}</p>
+        <div className='homepage-showcase-overlay-meta-row'>
           Take Me Over · Listen
         </div>
       </div>
@@ -141,22 +139,18 @@ function HomeProfileOverlayCard({
       data-testid='homepage-overlay-email-preview'
       className={cn(shellClassName, 'homepage-showcase-overlay-card-email')}
     >
-      <div className='flex items-start justify-between gap-3'>
-        <div>
-          <p className='text-[10px] font-[620] tracking-[0.08em] text-sky-300/88'>
+      <div className='homepage-showcase-overlay-row' data-align='start'>
+        <div className='homepage-showcase-overlay-copy'>
+          <p className='homepage-showcase-overlay-label' data-tone='info'>
             {overlay.accentLabel}
           </p>
-          <p className='mt-1 text-[13px] font-[620] tracking-[-0.02em] text-white'>
-            {overlay.title}
-          </p>
+          <p className='homepage-showcase-overlay-title'>{overlay.title}</p>
         </div>
-        <div className='rounded-full bg-white/10 px-2 py-1 text-[10px] font-semibold text-white/72'>
+        <div className='homepage-showcase-overlay-badge' data-tone='muted'>
           Email
         </div>
       </div>
-      <p className='mt-2 text-[12px] leading-[1.55] text-white/68'>
-        {overlay.body}
-      </p>
+      <p className='homepage-showcase-overlay-body'>{overlay.body}</p>
     </div>
   );
 }
@@ -258,10 +252,7 @@ function ShowcaseSurface({
   );
 
   return (
-    <div
-      className='homepage-showcase-surface relative h-full w-full bg-black/96'
-      style={profileAccentStyle}
-    >
+    <div className='homepage-showcase-surface' style={profileAccentStyle}>
       <ProfileCompactSurface
         dataTestId='homepage-profile-preview'
         renderMode='preview'
@@ -346,7 +337,7 @@ export function HomeProfileShowcase({
   if (referenceImageSrc) {
     content = (
       <div
-        className={cn('mx-auto w-full max-w-[853px]')}
+        className='homepage-showcase-reference'
         data-testid='homepage-mock-home-reference'
       >
         <Image
@@ -354,7 +345,7 @@ export function HomeProfileShowcase({
           alt='Tim White mock home review'
           width={853}
           height={1844}
-          className='h-auto w-full'
+          className='homepage-showcase-reference-image'
         />
       </div>
     );

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2833,7 +2833,6 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   );
   color: var(--color-text-primary-token);
   padding: var(--space-4);
-  backdrop-filter: blur(var(--space-5));
 }
 
 :where(.homepage-showcase-overlay-card-absolute) {

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2736,6 +2736,288 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
 }
 
 /* ============================================
+   SYSTEM B HOME PROFILE SHOWCASE PRIMITIVES
+   ============================================ */
+
+:where(.homepage-showcase) {
+  isolation: isolate;
+}
+
+:where(.homepage-showcase-surface) {
+  position: relative;
+  height: 100%;
+  width: 100%;
+  background: color-mix(
+    in oklab,
+    var(--system-b-cinematic-black) 96%,
+    var(--system-b-bg-surface-0) 4%
+  );
+}
+
+:where(.homepage-showcase-reference) {
+  width: 100%;
+  max-width: 53.3125rem;
+  margin-inline: auto;
+}
+
+:where(.homepage-showcase-reference-image) {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+:where(.homepage-showcase-crop-viewport) {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 430 / 540;
+  overflow: hidden;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 70%, transparent);
+  border-radius: var(--profile-card-radius);
+  background: var(--system-b-cinematic-black);
+}
+
+:where(.homepage-showcase[data-presentation="drawer-crop"])
+  :where(.homepage-showcase-crop-viewport) {
+  aspect-ratio: 430 / 500;
+}
+
+:where(.homepage-showcase[data-presentation="featured-card-crop"])
+  :where(.homepage-showcase-crop-viewport) {
+  aspect-ratio: 430 / 470;
+}
+
+:where(.homepage-showcase[data-presentation="surface-card"])
+  :where(.homepage-showcase-crop-viewport) {
+  aspect-ratio: 430 / 950;
+}
+
+:where(.homepage-showcase-crop-surface) {
+  position: absolute;
+  inset-inline: 0;
+  top: 50%;
+  width: 100%;
+  aspect-ratio: 430 / 950;
+  transform: translateY(-50%);
+}
+
+:where(.homepage-showcase[data-crop-anchor="bottom"])
+  :where(.homepage-showcase-crop-surface) {
+  top: auto;
+  bottom: 0;
+  transform: none;
+}
+
+:where(.homepage-showcase[data-crop-anchor="left"])
+  :where(.homepage-showcase-crop-surface) {
+  inset-inline-start: 0;
+  inset-inline-end: auto;
+}
+
+:where(.homepage-showcase[data-crop-anchor="right"])
+  :where(.homepage-showcase-crop-surface) {
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+}
+
+:where(.homepage-showcase-overlay-card) {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 78%, transparent);
+  border-radius: var(--profile-inner-radius);
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-1) 86%,
+    transparent
+  );
+  color: var(--color-text-primary-token);
+  padding: var(--space-4);
+  backdrop-filter: blur(var(--space-5));
+}
+
+:where(.homepage-showcase-overlay-card-absolute) {
+  position: absolute;
+  right: var(--space-4);
+  bottom: var(--space-5);
+  left: var(--space-4);
+  z-index: 30;
+}
+
+:where(.homepage-showcase-overlay-card-standalone) {
+  width: min(100%, calc(var(--space-24) * 3));
+  margin-inline: auto;
+}
+
+:where(.homepage-showcase-overlay-card-apple-pay) {
+  border-color: color-mix(
+    in oklab,
+    var(--system-b-app-frame-seam) 24%,
+    transparent
+  );
+  background: color-mix(
+    in oklab,
+    var(--color-success-foreground) 90%,
+    var(--system-b-bg-surface-2) 10%
+  );
+  color: var(--system-b-cinematic-black);
+}
+
+:where(.homepage-showcase-overlay-card-thank-you) {
+  border-color: color-mix(in oklab, var(--color-success) 24%, transparent);
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-1) 88%,
+    var(--color-success) 12%
+  );
+}
+
+:where(.homepage-showcase-overlay-card-email) {
+  border-color: color-mix(in oklab, var(--color-info) 22%, transparent);
+}
+
+:where(.homepage-showcase-overlay-row) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+:where(.homepage-showcase-overlay-row[data-align="start"]) {
+  align-items: flex-start;
+}
+
+:where(.homepage-showcase-overlay-copy) {
+  min-width: 0;
+}
+
+:where(.homepage-showcase-overlay-label) {
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-3xs);
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight);
+}
+
+:where(.homepage-showcase-overlay-label[data-tone="info"]) {
+  color: color-mix(
+    in oklab,
+    var(--color-info) 84%,
+    var(--color-success-foreground) 16%
+  );
+}
+
+:where(.homepage-showcase-overlay-title) {
+  color: currentColor;
+  font-size: var(--text-app);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight);
+}
+
+:where(.homepage-showcase-overlay-label + .homepage-showcase-overlay-title) {
+  margin-top: var(--space-1);
+}
+
+:where(.homepage-showcase-overlay-headline) {
+  margin-top: var(--space-3);
+  color: currentColor;
+  font-size: var(--text-xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight);
+}
+
+:where(.homepage-showcase-overlay-card-thank-you)
+  :where(.homepage-showcase-overlay-headline) {
+  font-size: var(--text-lg);
+}
+
+:where(.homepage-showcase-overlay-body) {
+  margin-top: var(--space-2);
+  color: color-mix(
+    in oklab,
+    currentColor 68%,
+    var(--system-b-bg-surface-1) 32%
+  );
+  font-size: var(--text-xs);
+  line-height: var(--leading-relaxed);
+}
+
+:where(.homepage-showcase-overlay-badge) {
+  display: inline-flex;
+  min-height: var(--space-6);
+  flex-shrink: 0;
+  align-items: center;
+  border: 1px solid color-mix(in oklab, currentColor 14%, transparent);
+  border-radius: var(--system-b-radius-pill);
+  background: color-mix(in oklab, currentColor 9%, transparent);
+  color: currentColor;
+  padding-inline: var(--space-2);
+  font-size: var(--text-3xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight);
+}
+
+:where(.homepage-showcase-overlay-badge[data-tone="on-light"]) {
+  background: var(--system-b-cinematic-black);
+  color: var(--color-success-foreground);
+}
+
+:where(.homepage-showcase-overlay-badge[data-tone="success"]) {
+  border-color: color-mix(in oklab, var(--color-success) 24%, transparent);
+  background: color-mix(in oklab, var(--color-success) 14%, transparent);
+  color: color-mix(
+    in oklab,
+    var(--color-success) 78%,
+    var(--color-success-foreground) 22%
+  );
+}
+
+:where(.homepage-showcase-overlay-badge[data-tone="muted"]) {
+  color: color-mix(in oklab, var(--color-text-primary-token) 72%, transparent);
+}
+
+:where(.homepage-showcase-overlay-meta-row) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-top: var(--space-4);
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 64%, transparent);
+  border-radius: var(--profile-action-radius);
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-2) 38%,
+    transparent
+  );
+  color: color-mix(
+    in oklab,
+    currentColor 76%,
+    var(--system-b-bg-surface-1) 24%
+  );
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--text-2xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-tight);
+}
+
+:where(.homepage-showcase-overlay-meta-row[data-tone="on-light"]) {
+  border-color: transparent;
+  background: color-mix(
+    in oklab,
+    var(--color-success-foreground) 72%,
+    var(--system-b-bg-surface-2) 28%
+  );
+  color: color-mix(in oklab, var(--system-b-cinematic-black) 62%, transparent);
+}
+
+/* SYSTEM B HOME PROFILE SHOWCASE PRIMITIVES END */
+
+/* ============================================
    SYSTEM B HOME RELEASE MODE MOCK CARD PRIMITIVES
    ============================================ */
 

--- a/apps/web/tests/unit/home/home-profile-showcase-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/home/home-profile-showcase-system-b-style-guard.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+const sourcePath = 'components/features/home/HomeProfileShowcase.tsx';
+const cssPath = 'styles/design-system.css';
+
+const forbiddenShowcaseSourcePatterns = [
+  /\btext-\[[^\]]+\]/,
+  /\bfont-\[[^\]]+\]/,
+  /\btracking-\[[^\]]+\]/,
+  /\brounded-\[[^\]]+\]/,
+  /\bbg-white\//,
+  /\bbg-black\/96\b/,
+  /\btext-(?:sky|emerald|slate)-/,
+  /\bmax-w-\[853px\]/,
+] as const;
+
+const forbiddenShowcaseCssPatterns = [
+  /#[0-9a-fA-F]{3,8}/,
+  /rgba?\(/,
+  /hsla?\(/,
+  /linear-gradient|radial-gradient/,
+  /letter-spacing:\s*-[^;]+/,
+  /(?:background|color|border(?:-[^:]+)?|text-decoration-color):[^;]*(?<!-)\b(?:white|black)\b/,
+] as const;
+
+function extractHomeProfileShowcaseCss(source: string): string {
+  const start = source.indexOf('SYSTEM B HOME PROFILE SHOWCASE PRIMITIVES');
+  const end = source.indexOf(
+    'SYSTEM B HOME PROFILE SHOWCASE PRIMITIVES END',
+    start
+  );
+
+  expect(start, 'HomeProfileShowcase CSS block exists').toBeGreaterThanOrEqual(
+    0
+  );
+  expect(end, 'HomeProfileShowcase CSS block is bounded').toBeGreaterThan(
+    start
+  );
+
+  return source.slice(start, end);
+}
+
+describe('HomeProfileShowcase System B source contract', () => {
+  it('keeps overlay and reference chrome on named System B primitives', () => {
+    const source = readFileSync(path.join(webRoot, sourcePath), 'utf8');
+
+    for (const pattern of forbiddenShowcaseSourcePatterns) {
+      expect(source, `${sourcePath} leaked ${pattern}`).not.toMatch(pattern);
+    }
+
+    for (const className of [
+      'homepage-showcase-reference',
+      'homepage-showcase-reference-image',
+      'homepage-showcase-crop-viewport',
+      'homepage-showcase-crop-surface',
+      'homepage-showcase-overlay-row',
+      'homepage-showcase-overlay-title',
+      'homepage-showcase-overlay-headline',
+      'homepage-showcase-overlay-body',
+      'homepage-showcase-overlay-badge',
+      'homepage-showcase-overlay-meta-row',
+    ]) {
+      expect(source).toContain(className);
+    }
+
+    expect(source).toContain('data-presentation={presentation}');
+    expect(source).toContain('data-overlay-mode={overlayMode}');
+    expect(source).toContain('data-crop-anchor={cropAnchor}');
+    expect(source).toContain("aria-hidden='true'");
+    expect(source).toContain('inert');
+  });
+
+  it('keeps HomeProfileShowcase CSS tokenized and grayscale-first', () => {
+    const css = extractHomeProfileShowcaseCss(
+      readFileSync(path.join(webRoot, cssPath), 'utf8')
+    );
+
+    for (const pattern of forbiddenShowcaseCssPatterns) {
+      expect(css, `${cssPath} leaked ${pattern}`).not.toMatch(pattern);
+    }
+
+    expect(css).toContain('var(--system-b-cinematic-black)');
+    expect(css).toContain('var(--system-b-bg-surface-1)');
+    expect(css).toContain('var(--system-b-app-frame-seam)');
+    expect(css).toContain('var(--color-text-primary-token)');
+    expect(css).toContain('var(--color-success)');
+    expect(css).toContain('var(--color-info)');
+    expect(css).toContain('var(--space-');
+    expect(css).toContain('var(--profile-card-radius)');
+    expect(css).toContain('letter-spacing: var(--tracking-normal);');
+    expect(css).toContain('aspect-ratio: 430 / 950;');
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2835 -->

## Summary
- Moved HomeProfileShowcase overlay, crop, surface, and reference-image chrome onto named System B CSS primitives.
- Replaced raw overlay Tailwind text, tracking, color, rounded, surface, and reference width recipes in the component source.
- Added a focused System B source guard for HomeProfileShowcase.

## Verification
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/home/HomeProfileShowcase.tsx apps/web/styles/design-system.css apps/web/tests/unit/home/home-profile-showcase-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/home/home-profile-showcase-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- Push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`

## Screenshot Proof
- `/renders/surfaces/profile?width=390`: `/tmp/jov-2835-homeprofile-screenshots/renders-profile-390.png`
- `/renders/surfaces/tips?width=390`: `/tmp/jov-2835-homeprofile-screenshots/renders-tips-390.png`

## Notes
- The current `/` route in this worktree does not mount `data-testid="homepage-spec-section"`; render-route screenshots cover the HomeProfileShowcase surfaces that are mounted here.
- System B audit command path `.gstack/design-reports/scripts/system-b-audit.mjs` is absent in this worktree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the home profile showcase component styling system with improved semantic organization and enhanced class structure for better maintainability and consistency across the design system.

* **Tests**
  * Added new unit test coverage to validate the home profile showcase component implementation, ensuring adherence to styling standards and required accessibility attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->