### PR TITLE
fix(ui): tokenize error fallback surfaces

### DIFF
--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -1,54 +1,17 @@
 'use client';
 
+import { SystemBErrorFallback } from '@/components/providers/SystemBErrorFallback';
 import type { ErrorProps } from '@/types/common';
-
-const ICON_PATH =
-  'm176.84,0l3.08.05c8.92,1.73,16.9,6.45,23.05,13.18,7.95,8.7,12.87,20.77,12.87,34.14s-4.92,25.44-12.87,34.14c-6.7,7.34-15.59,12.28-25.49,13.57h-.64s0,.01,0,.01h0c-22.2,0-42.3,8.84-56.83,23.13-14.5,14.27-23.49,33.99-23.49,55.77h0v.02c0,21.78,8.98,41.5,23.49,55.77,14.54,14.3,34.64,23.15,56.83,23.15v-.02h.01c22.2,0,42.3-8.84,56.83-23.13,14.51-14.27,23.49-33.99,23.49-55.77h0c0-17.55-5.81-33.75-15.63-46.82-10.08-13.43-24.42-23.61-41.05-28.62l-2.11-.64c4.36-2.65,8.34-5.96,11.84-9.78,9.57-10.47,15.5-24.89,15.5-40.77s-5.93-30.3-15.5-40.77c-1.44-1.57-2.95-3.06-4.55-4.44l7.67,1.58c40.44,8.35,75.81,30.3,100.91,60.75,24.66,29.91,39.44,68.02,39.44,109.5h0c0,48.05-19.81,91.55-51.83,123.05-31.99,31.46-76.19,50.92-125,50.92v.02h-.01c-48.79,0-93-19.47-125-50.94C19.81,265.54,0,222.04,0,173.99h0c0-48.05,19.81-91.56,51.83-123.05C83.84,19.47,128.04,0,176.84,0Z';
 
 export default function RootError({ error, reset }: ErrorProps) {
   return (
-    <div className='flex min-h-dvh items-center justify-center bg-base px-6 text-primary-token'>
-      <div className='flex w-full max-w-xs flex-col items-center text-center'>
-        <svg
-          viewBox='0 0 353.68 347.97'
-          fill='none'
-          xmlns='http://www.w3.org/2000/svg'
-          aria-hidden='true'
-          className='h-8 w-8'
-        >
-          <path fill='currentColor' d={ICON_PATH} />
-        </svg>
-
-        <h1 className='mt-5 text-lg font-semibold leading-snug tracking-normal'>
-          Something Went Wrong
-        </h1>
-        <p className='mt-2 text-sm leading-normal text-tertiary-token'>
-          An unexpected error occurred.
-        </p>
-
-        <div className='mt-6 flex flex-row items-center gap-3'>
-          <button
-            type='button'
-            onClick={reset}
-            className='focus-ring-transparent-offset h-9 cursor-pointer rounded-full bg-btn-primary px-4 text-sm font-medium text-btn-primary-foreground transition-opacity duration-subtle hover:opacity-95'
-          >
-            Try Again
-          </button>
-          {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Using <a> for resilience when Next.js routing may be broken */}
-          <a
-            href='/'
-            className='focus-ring-transparent-offset flex h-9 items-center rounded-full border border-subtle bg-transparent px-4 text-sm font-medium text-tertiary-token transition-colors duration-subtle hover:border-default hover:bg-surface-0'
-          >
-            Go Home
-          </a>
-        </div>
-
-        {error.digest ? (
-          <p className='mt-5 text-xs text-quaternary-token'>
-            Error ID: {error.digest}
-          </p>
-        ) : null}
-      </div>
-    </div>
+    <SystemBErrorFallback
+      description='An unexpected error occurred.'
+      digest={error.digest}
+      actions={[
+        { type: 'button', label: 'Try Again', onClick: reset },
+        { type: 'link', label: 'Go Home', href: '/', variant: 'secondary' },
+      ]}
+    />
   );
 }

--- a/apps/web/app/global-error.tsx
+++ b/apps/web/app/global-error.tsx
@@ -2,9 +2,7 @@
 
 import './globals.css';
 import { useEffect } from 'react';
-
-const JOVIE_MARK_PATH =
-  'm176.84,0l3.08.05c8.92,1.73,16.9,6.45,23.05,13.18,7.95,8.7,12.87,20.77,12.87,34.14s-4.92,25.44-12.87,34.14c-6.7,7.34-15.59,12.28-25.49,13.57h-.64s0,.01,0,.01h0c-22.2,0-42.3,8.84-56.83,23.13-14.5,14.27-23.49,33.99-23.49,55.77h0v.02c0,21.78,8.98,41.5,23.49,55.77,14.54,14.3,34.64,23.15,56.83,23.15v-.02h.01c22.2,0,42.3-8.84,56.83-23.13,14.51-14.27,23.49-33.99,23.49-55.77h0c0-17.55-5.81-33.75-15.63-46.82-10.08-13.43-24.42-23.61-41.05-28.62l-2.11-.64c4.36-2.65,8.34-5.96,11.84-9.78,9.57-10.47,15.5-24.89,15.5-40.77s-5.93-30.3-15.5-40.77c-1.44-1.57-2.95-3.06-4.55-4.44l7.67,1.58c40.44,8.35,75.81,30.3,100.91,60.75,24.66,29.91,39.44,68.02,39.44,109.5h0c0,48.05-19.81,91.55-51.83,123.05-31.99,31.46-76.19,50.92-125,50.92v.02h-.01c-48.79,0-93-19.47-125-50.94C19.81,265.54,0,222.04,0,173.99h0c0-48.05,19.81-91.56,51.83-123.05C83.84,19.47,128.04,0,176.84,0Z';
+import { SystemBErrorFallback } from '@/components/providers/SystemBErrorFallback';
 
 /**
  * Global error page for Next.js App Router.
@@ -41,49 +39,21 @@ export default function GlobalError({
           content='width=device-width, initial-scale=1, viewport-fit=cover'
         />
       </head>
-      <body className='min-h-dvh bg-base font-sans text-primary-token antialiased'>
-        <main className='flex min-h-dvh items-center justify-center px-6'>
-          <div className='flex w-full max-w-xs flex-col items-center text-center'>
-            <svg
-              viewBox='0 0 353.68 347.97'
-              fill='none'
-              xmlns='http://www.w3.org/2000/svg'
-              aria-hidden='true'
-              className='h-8 w-8'
-            >
-              <path fill='currentColor' d={JOVIE_MARK_PATH} />
-            </svg>
-
-            <h1 className='mt-5 text-lg font-semibold leading-snug tracking-normal'>
-              Something Went Wrong
-            </h1>
-            <p className='mt-2 text-sm leading-normal text-tertiary-token'>
-              An unexpected error occurred.
-            </p>
-
-            <div className='mt-6 flex flex-row items-center gap-3'>
-              <button
-                type='button'
-                onClick={reset}
-                className='focus-ring-transparent-offset h-9 cursor-pointer rounded-full bg-btn-primary px-4 text-sm font-medium text-btn-primary-foreground transition-opacity duration-subtle hover:opacity-95'
-              >
-                Try Again
-              </button>
-              {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- Using <a> for resilience when Next.js routing may be broken */}
-              <a
-                href='/'
-                className='focus-ring-transparent-offset flex h-9 items-center rounded-full border border-subtle bg-transparent px-4 text-sm font-medium text-tertiary-token transition-colors duration-subtle hover:border-default hover:bg-surface-0'
-              >
-                Go Home
-              </a>
-            </div>
-
-            {error.digest ? (
-              <p className='mt-5 text-xs text-quaternary-token'>
-                Error ID: {error.digest}
-              </p>
-            ) : null}
-          </div>
+      <body className='system-b-error-fallback-body'>
+        <main>
+          <SystemBErrorFallback
+            description='An unexpected error occurred.'
+            digest={error.digest}
+            actions={[
+              { type: 'button', label: 'Try Again', onClick: reset },
+              {
+                type: 'link',
+                label: 'Go Home',
+                href: '/',
+                variant: 'secondary',
+              },
+            ]}
+          />
         </main>
       </body>
     </html>

--- a/apps/web/components/providers/PublicPageErrorFallback.tsx
+++ b/apps/web/components/providers/PublicPageErrorFallback.tsx
@@ -1,11 +1,8 @@
 'use client';
 
 import { useEffect } from 'react';
-import {
-  JOVIE_ICON_PATH,
-  JOVIE_ICON_VIEW_BOX,
-} from '@/components/atoms/jovie-icon-path';
 import { captureErrorInSentry } from '@/lib/errors/capture';
+import { SystemBErrorFallback } from './SystemBErrorFallback';
 
 interface PublicPageErrorFallbackProps {
   readonly error: Error & { digest?: string };
@@ -24,40 +21,12 @@ export function PublicPageErrorFallback({
   }, [context, error]);
 
   return (
-    <div
-      className='dark flex min-h-dvh items-center justify-center bg-base px-6 text-primary-token'
+    <SystemBErrorFallback
+      description='Try refreshing the page.'
+      digest={error.digest}
+      actions={[{ type: 'button', label: 'Refresh', onClick: onRefresh }]}
       role='alert'
-      aria-live='assertive'
-    >
-      <div className='flex w-full max-w-xs flex-col items-center text-center'>
-        <svg
-          viewBox={JOVIE_ICON_VIEW_BOX}
-          fill='none'
-          xmlns='http://www.w3.org/2000/svg'
-          aria-hidden='true'
-          className='h-8 w-8'
-        >
-          <path fill='currentColor' d={JOVIE_ICON_PATH} />
-        </svg>
-        <h1 className='mt-5 text-lg font-semibold leading-snug tracking-normal'>
-          Something Went Wrong
-        </h1>
-        <p className='mt-2 text-sm leading-normal text-tertiary-token'>
-          Try refreshing the page.
-        </p>
-        <button
-          type='button'
-          className='focus-ring-transparent-offset mt-6 inline-flex h-9 cursor-pointer items-center justify-center rounded-full bg-btn-primary px-4 text-sm font-medium text-btn-primary-foreground transition-opacity duration-subtle hover:opacity-95'
-          onClick={onRefresh}
-        >
-          Refresh
-        </button>
-        {error.digest ? (
-          <p className='mt-5 text-xs text-quaternary-token'>
-            Error ID {error.digest}
-          </p>
-        ) : null}
-      </div>
-    </div>
+      ariaLive='assertive'
+    />
   );
 }

--- a/apps/web/components/providers/SystemBErrorFallback.tsx
+++ b/apps/web/components/providers/SystemBErrorFallback.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import {
+  JOVIE_ICON_PATH,
+  JOVIE_ICON_VIEW_BOX,
+} from '@/components/atoms/jovie-icon-path';
+
+type SystemBErrorFallbackAction =
+  | {
+      readonly type: 'button';
+      readonly label: string;
+      readonly onClick: () => void;
+      readonly variant?: 'primary' | 'secondary';
+    }
+  | {
+      readonly type: 'link';
+      readonly label: string;
+      readonly href: string;
+      readonly variant?: 'primary' | 'secondary';
+    };
+
+interface SystemBErrorFallbackProps {
+  readonly title?: string;
+  readonly description: string;
+  readonly digest?: string;
+  readonly actions: readonly SystemBErrorFallbackAction[];
+  readonly role?: 'alert';
+  readonly ariaLive?: 'assertive' | 'polite';
+  readonly className?: string;
+}
+
+function actionClassName(
+  variant: SystemBErrorFallbackAction['variant'] = 'primary'
+): string {
+  return [
+    'system-b-error-fallback__action',
+    `system-b-error-fallback__action--${variant}`,
+    'focus-ring-transparent-offset',
+  ].join(' ');
+}
+
+function rootClassName(className: string | undefined): string {
+  return ['dark', 'system-b-error-fallback', className]
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function SystemBErrorFallback({
+  title = 'Something Went Wrong',
+  description,
+  digest,
+  actions,
+  role,
+  ariaLive,
+  className,
+}: SystemBErrorFallbackProps) {
+  return (
+    <div className={rootClassName(className)} role={role} aria-live={ariaLive}>
+      <div className='system-b-error-fallback__content'>
+        <svg
+          viewBox={JOVIE_ICON_VIEW_BOX}
+          fill='none'
+          xmlns='http://www.w3.org/2000/svg'
+          aria-hidden='true'
+          className='system-b-error-fallback__mark'
+        >
+          <path fill='currentColor' d={JOVIE_ICON_PATH} />
+        </svg>
+
+        <h1 className='system-b-error-fallback__title'>{title}</h1>
+        <p className='system-b-error-fallback__description'>{description}</p>
+
+        <div className='system-b-error-fallback__actions'>
+          {actions.map(action => {
+            if (action.type === 'link') {
+              return (
+                <a
+                  key={`${action.type}-${action.label}`}
+                  href={action.href}
+                  className={actionClassName(action.variant)}
+                >
+                  {action.label}
+                </a>
+              );
+            }
+
+            return (
+              <button
+                key={`${action.type}-${action.label}`}
+                type='button'
+                onClick={action.onClick}
+                className={actionClassName(action.variant)}
+              >
+                {action.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {digest ? (
+          <p className='system-b-error-fallback__digest'>Error ID: {digest}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -2289,6 +2289,116 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
 }
 
 /* ============================================
+   SYSTEM B ERROR FALLBACK PRIMITIVES
+   ============================================ */
+
+:where(.system-b-error-fallback-body) {
+  min-height: 100dvh;
+  margin: 0;
+  background: var(--system-b-bg-page);
+  color: var(--system-b-text-primary);
+  font-family: var(--font-sans), system-ui, sans-serif;
+}
+
+:where(.system-b-error-fallback) {
+  display: flex;
+  min-height: 100dvh;
+  align-items: center;
+  justify-content: center;
+  background: var(--system-b-bg-page);
+  color: var(--system-b-text-primary);
+  color-scheme: dark;
+  padding-inline: var(--space-6);
+  text-align: center;
+}
+
+:where(.system-b-error-fallback__content) {
+  display: flex;
+  width: 100%;
+  max-width: calc(var(--space-24) * 3 + var(--space-4));
+  flex-direction: column;
+  align-items: center;
+}
+
+:where(.system-b-error-fallback__mark) {
+  width: var(--space-8);
+  height: var(--space-8);
+  color: var(--system-b-text-primary);
+}
+
+:where(.system-b-error-fallback__title) {
+  margin: var(--space-5) 0 0;
+  color: var(--system-b-text-primary);
+  font-size: var(--text-lg);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: var(--tracking-normal);
+  line-height: var(--leading-snug);
+}
+
+:where(.system-b-error-fallback__description) {
+  margin: var(--space-2) 0 0;
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+}
+
+:where(.system-b-error-fallback__actions) {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  margin-top: var(--space-6);
+}
+
+:where(.system-b-error-fallback__action) {
+  display: inline-flex;
+  min-height: calc(var(--space-8) + var(--space-1));
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--system-b-radius-pill);
+  font-size: var(--text-sm);
+  font-weight: var(--font-weight-medium);
+  padding-inline: var(--space-4);
+  text-decoration: none;
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    border-color var(--system-b-duration-fast) var(--system-b-ease),
+    color var(--system-b-duration-fast) var(--system-b-ease),
+    opacity var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-error-fallback__action--primary) {
+  border: var(--space-px) solid var(--color-btn-primary-bg);
+  background: var(--color-btn-primary-bg);
+  color: var(--color-btn-primary-fg);
+}
+
+:where(.system-b-error-fallback__action--primary:hover) {
+  opacity: 0.95;
+}
+
+:where(.system-b-error-fallback__action--secondary) {
+  border: var(--space-px) solid var(--color-border-subtle);
+  background: transparent;
+  color: var(--color-text-tertiary-token);
+}
+
+:where(.system-b-error-fallback__action--secondary:hover) {
+  border-color: var(--color-border-default);
+  background: var(--color-bg-surface-0);
+  color: var(--system-b-text-primary);
+}
+
+:where(.system-b-error-fallback__digest) {
+  margin: var(--space-5) 0 0;
+  color: var(--color-text-quaternary-token);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+
+/* ============================================
    SYSTEM B PUBLIC PROFILE NOT FOUND PRIMITIVES
    ============================================ */
 

--- a/apps/web/tests/unit/app/error-system-b-source.test.ts
+++ b/apps/web/tests/unit/app/error-system-b-source.test.ts
@@ -26,7 +26,8 @@ describe('App error System B source tokens', () => {
     expect(source).not.toMatch(rawGradientPattern);
     expect(source).not.toMatch(rawVisualUtilityPattern);
     expect(source).not.toMatch(negativeTrackingPattern);
-    expect(source).toContain("fill='currentColor'");
-    expect(source).toContain('focus-ring-transparent-offset');
+    expect(source).toContain('SystemBErrorFallback');
+    expect(source).not.toContain("fill='currentColor'");
+    expect(source).not.toContain('focus-ring-transparent-offset');
   });
 });

--- a/apps/web/tests/unit/app/global-error-system-b-source.test.ts
+++ b/apps/web/tests/unit/app/global-error-system-b-source.test.ts
@@ -38,8 +38,9 @@ describe('Global error System B source tokens', () => {
     expect(source).not.toContain('dangerouslySetInnerHTML');
     expect(source).not.toContain('biome-ignore');
     expect(source).toContain("import './globals.css';");
-    expect(source).toContain("fill='currentColor'");
     expect(source).toContain("className='dark'");
-    expect(source).toContain('focus-ring-transparent-offset');
+    expect(source).toContain('SystemBErrorFallback');
+    expect(source).toContain('system-b-error-fallback-body');
+    expect(source).not.toContain('focus-ring-transparent-offset');
   });
 });

--- a/apps/web/tests/unit/providers/system-b-error-fallback.test.tsx
+++ b/apps/web/tests/unit/providers/system-b-error-fallback.test.tsx
@@ -1,0 +1,93 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { SystemBErrorFallback } from '@/components/providers/SystemBErrorFallback';
+
+const appRoot = join(dirname(fileURLToPath(import.meta.url)), '../../..');
+const sourcePath = join(
+  appRoot,
+  'components/providers/SystemBErrorFallback.tsx'
+);
+const designSystemPath = join(appRoot, 'styles/design-system.css');
+
+const hashMark = String.fromCharCode(35);
+const colorFunctionName = ['r', 'g', 'b', 'a'].join('');
+const hardcodedHashColorPattern = new RegExp(`${hashMark}[\\da-fA-F]{3,8}\\b`);
+const rawAlphaColorPattern = new RegExp(`${colorFunctionName}\\s*\\(`, 'i');
+const rawColorMixPattern = /color-mix\(/i;
+const gradientPattern = ['linear', 'gradient|radial', 'gradient'].join('-');
+const rawGradientPattern = new RegExp(gradientPattern, 'i');
+const rawVisualUtilityPattern =
+  /\b(?:bg|border|text|ring|shadow|outline|rounded|h|w|max-w|min-h|min-w|tracking|leading|px|py|pt|pb)-\[/;
+const hardcodedSvgFillPattern = new RegExp(
+  `fill=(['"])${hashMark}[\\da-fA-F]{3,8}\\1`
+);
+
+describe('SystemBErrorFallback', () => {
+  it('renders one quiet error fallback with stable actions', () => {
+    const reset = vi.fn();
+
+    render(
+      <SystemBErrorFallback
+        description='An unexpected error occurred.'
+        digest='digest-1'
+        actions={[
+          { type: 'button', label: 'Try Again', onClick: reset },
+          { type: 'link', label: 'Go Home', href: '/', variant: 'secondary' },
+        ]}
+      />
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Something Went Wrong' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('An unexpected error occurred.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Error ID: digest-1')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Try Again' })).toHaveClass(
+      'system-b-error-fallback__action--primary'
+    );
+    expect(screen.getByRole('link', { name: 'Go Home' })).toHaveAttribute(
+      'href',
+      '/'
+    );
+  });
+
+  it('keeps the shared primitive free of local visual token drift', async () => {
+    const source = await readFile(sourcePath, 'utf8');
+
+    expect(source).not.toMatch(hardcodedHashColorPattern);
+    expect(source).not.toMatch(rawAlphaColorPattern);
+    expect(source).not.toMatch(rawColorMixPattern);
+    expect(source).not.toMatch(rawGradientPattern);
+    expect(source).not.toMatch(rawVisualUtilityPattern);
+    expect(source).not.toMatch(hardcodedSvgFillPattern);
+    expect(source).not.toContain('style={');
+    expect(source).not.toContain('CSSProperties');
+    expect(source).toContain('JOVIE_ICON_PATH');
+    expect(source).toContain("fill='currentColor'");
+    expect(source).toContain('system-b-error-fallback__action--');
+  });
+
+  it('backs the primitive with System B tokens in the source of truth', async () => {
+    const css = await readFile(designSystemPath, 'utf8');
+    const block = css.match(
+      /SYSTEM B ERROR FALLBACK PRIMITIVES[\s\S]*?\/\* ============================================\s+SYSTEM B PUBLIC PROFILE NOT FOUND PRIMITIVES/
+    )?.[0];
+
+    expect(block).toBeTruthy();
+    expect(block).toContain('var(--system-b-bg-page)');
+    expect(block).toContain('var(--system-b-text-primary)');
+    expect(block).toContain('var(--color-btn-primary-bg)');
+    expect(block).toContain('var(--color-btn-primary-fg)');
+    expect(block).toContain('var(--system-b-radius-pill)');
+    expect(block).toContain(':where(.system-b-error-fallback__actions)');
+    expect(block).not.toMatch(hardcodedHashColorPattern);
+    expect(block).not.toMatch(rawAlphaColorPattern);
+    expect(block).not.toMatch(rawColorMixPattern);
+    expect(block).not.toMatch(rawGradientPattern);
+  });
+});

--- a/apps/web/tests/unit/public-page-error-fallback.test.tsx
+++ b/apps/web/tests/unit/public-page-error-fallback.test.tsx
@@ -56,16 +56,15 @@ describe('PublicPageErrorFallback', () => {
       })
     ).toBeInTheDocument();
     expect(screen.getByText('Try refreshing the page.')).toBeInTheDocument();
-    expect(screen.getByText('Error ID abc123')).toBeInTheDocument();
+    expect(screen.getByText('Error ID: abc123')).toBeInTheDocument();
     expect(screen.getByRole('alert')).toHaveClass(
       'dark',
-      'bg-base',
-      'text-primary-token'
+      'system-b-error-fallback'
     );
     expect(screen.getAllByRole('button')).toHaveLength(1);
     expect(screen.getByRole('button', { name: 'Refresh' })).toHaveClass(
-      'bg-btn-primary',
-      'text-btn-primary-foreground',
+      'system-b-error-fallback__action',
+      'system-b-error-fallback__action--primary',
       'focus-ring-transparent-offset'
     );
 
@@ -99,10 +98,9 @@ describe('PublicPageErrorFallback', () => {
     expect(source).not.toContain('const styles');
     expect(source).not.toContain('style={');
     expect(source).not.toContain('JovieMarkElectric');
-    expect(source).toContain('JOVIE_ICON_PATH');
-    expect(source).toContain("fill='currentColor'");
-    expect(source).toContain('bg-base');
-    expect(source).toContain('bg-btn-primary');
-    expect(source).toContain('focus-ring-transparent-offset');
+    expect(source).not.toContain('JOVIE_ICON_PATH');
+    expect(source).not.toContain("fill='currentColor'");
+    expect(source).not.toContain('focus-ring-transparent-offset');
+    expect(source).toContain('SystemBErrorFallback');
   });
 });


### PR DESCRIPTION
## Summary
- Replace duplicated root/global/public page error fallback chrome with `SystemBErrorFallback`.
- Move layout, mark, copy, action, and digest styling into `design-system.css` System B primitives.
- Strengthen source guards so error fallback routes cannot reintroduce raw visual recipes.

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/public-page-error-fallback.test.tsx tests/unit/app/global-error-system-b-source.test.ts tests/unit/app/error-system-b-source.test.ts tests/unit/providers/system-b-error-fallback.test.tsx`
- `pnpm biome check apps/web/app/error.tsx apps/web/app/global-error.tsx apps/web/components/providers/PublicPageErrorFallback.tsx apps/web/components/providers/SystemBErrorFallback.tsx apps/web/styles/design-system.css apps/web/tests/unit/public-page-error-fallback.test.tsx apps/web/tests/unit/app/global-error-system-b-source.test.ts apps/web/tests/unit/app/error-system-b-source.test.ts apps/web/tests/unit/providers/system-b-error-fallback.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Pre-push: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`

## Visual proof
- Screenshot: `.gstack/design-reports/screenshots/jov-2838-system-b-error-fallback.png`
- Browser render used the `SystemBErrorFallback` DOM contract with app/System B CSS.
- Bounding box stable over 1s: `304x205.75`, unchanged before/after.
- Primary action computed style: `rgb(230, 230, 230)` background, `rgb(6, 7, 10)` text.

Linear: JOV-2838


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error display design and styling across all application error pages for a consistent user experience.
  * Consolidated error UI components to use a centralized, reusable error fallback component with standard actions.
  * Unified error styling to align with system design tokens and visual standards.

* **Tests**
  * Added comprehensive tests for the new error fallback component.
  * Updated error-related tests to validate styling and behavior consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->