### PR TITLE
fix(ui): tokenize calendar accent primitives

### DIFF
--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -5904,7 +5904,7 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
 }
 
 :where(.system-b-calendar-event-dot-confirmed) {
-  background: var(--color-accent-purple);
+  background: var(--color-text-secondary-token);
 }
 
 :where(.system-b-calendar-filter-pill-active) {
@@ -5919,8 +5919,9 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
 }
 
 :where(.system-b-calendar-type-chip) {
-  background: color-mix(in oklab, var(--color-accent-purple) 14%, transparent);
-  color: color-mix(in oklab, var(--color-accent-purple) 78%, white 22%);
+  background: var(--system-b-bg-surface-0);
+  color: var(--color-text-tertiary-token);
+  box-shadow: inset 0 0 0 1px var(--color-border-subtle);
 }
 
 :where(.system-b-calendar-pending-checkbox) {

--- a/apps/web/tests/unit/calendar/calendar-shell-style-guard.test.ts
+++ b/apps/web/tests/unit/calendar/calendar-shell-style-guard.test.ts
@@ -7,6 +7,7 @@ const CALENDAR_CLIENT = join(
   ROOT,
   'app/app/(shell)/calendar/CalendarPageClient.tsx'
 );
+const DESIGN_SYSTEM = join(ROOT, 'styles/design-system.css');
 
 const CHROME_CLASS_PATTERN = /(?:^|\s)(?:uppercase|tracking-[^\s'"]+)/;
 const LABEL_ELEMENT_PATTERN =
@@ -15,6 +16,10 @@ const ROUTE_LOCAL_VISUAL_PATTERN =
   /(?:--linear-|color-mix\(|(?:bg|text|border|accent|ring|from|via|to|decoration)-(?:blue|sky|indigo|purple|violet|cyan|emerald|green|red|rose|pink|amber|yellow|orange|teal)-[^\s'"]+|(?:bg|text|border)-\[[^\]]+\]|(?:min-[hw]|max-[hw]|w|h)-\[[^\]]+\]|(?:bg|text)-quaternary-token\/\d+)/;
 const NAMED_COLOR_OWNER_PATTERN =
   /className=(?:'[^']*\bsystem-b-calendar-(?:provider-chip|row-description|row-secondary)\b[^']*\btext-(?:tertiary-token|quaternary-token)\b[^']*'|"[^"]*\bsystem-b-calendar-(?:provider-chip|row-description|row-secondary)\b[^"]*\btext-(?:tertiary-token|quaternary-token)\b[^"]*")/g;
+const CALENDAR_PRIMITIVES_PATTERN =
+  /\/\* System B calendar route primitives \*\/([\s\S]*?)\/\* System B shell pill search primitives \*\//;
+const CALENDAR_ACCENT_DRIFT_PATTERN =
+  /(?:--color-accent-(?:purple|pink)|var\(--color-accent(?:-(?:purple|pink))?\))/;
 
 function lineNumberFor(source: string, index: number): number {
   return source.slice(0, index).split('\n').length;
@@ -72,6 +77,28 @@ describe('calendar shell style guard', () => {
     expect(
       offenders,
       `Calendar detail metadata classes should not carry duplicate route-local text color utilities.\n${offenders.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('keeps calendar CSS primitives off decorative accent tokens', () => {
+    const source = readFileSync(DESIGN_SYSTEM, 'utf8');
+    const match = source.match(CALENDAR_PRIMITIVES_PATTERN);
+    const primitiveBlock = match?.[1] ?? '';
+    const blockStartLine =
+      typeof match?.index === 'number' ? lineNumberFor(source, match.index) : 1;
+    const offenders = primitiveBlock
+      .split('\n')
+      .map((line, index) => ({ line, lineNumber: index + 1 }))
+      .filter(({ line }) => CALENDAR_ACCENT_DRIFT_PATTERN.test(line))
+      .map(
+        ({ line, lineNumber }) =>
+          `design-system.css:${blockStartLine + lineNumber} ${line.trim()}`
+      );
+
+    expect(primitiveBlock).toContain('system-b-calendar-type-chip');
+    expect(
+      offenders,
+      `Calendar CSS primitives should use neutral System B tokens instead of purple or pink decorative accent ownership.\n${offenders.join('\n')}`
     ).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes JOV-2843

## Summary

- Neutralizes the calendar confirmed-event dot away from the decorative purple accent.
- Moves calendar type chips onto neutral System B surface/text tokens with an inset border.
- Extends the calendar shell style guard to scan the calendar CSS primitive block for purple/pink accent ownership.

## Verification

- `./scripts/setup.sh`
- `pnpm biome check --write apps/web/styles/design-system.css apps/web/tests/unit/calendar/calendar-shell-style-guard.test.ts`
- `pnpm --filter @jovie/web exec vitest run tests/unit/calendar/CalendarPageClient.test.tsx tests/unit/calendar/calendar-shell-style-guard.test.ts --reporter verbose` — 2 files, 8 tests passed
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git fetch origin main && git merge origin/main --no-edit` — already up to date
- `git diff --check`
- Commit hook: `next:proxy-guard`, Biome, ESLint, web typecheck
- Push hook: repo Biome, web `next:proxy-guard`, `tailwind:check`, web typecheck, web Biome lint

## Visual Proof

- `/app/calendar` rendered with dev auth bypass: HTTP 200, final URL `http://localhost:3000/app/calendar`, screenshot at `/tmp/jov-2843-calendar-css-accent-primitives/jov-2843-calendar-desktop.png`
- Calendar primitive probe screenshot at `/tmp/jov-2843-calendar-css-accent-primitives/jov-2843-calendar-style-probe.png`
- Probe computed styles: type chip background `rgb(10, 11, 14)`, type chip inset border `rgba(255, 255, 255, 0.07)`, confirmed dot background `lab(90.65 0.280681 -1.3205)`

## Related Slices Recorded

- JOV-2844: remaining calendar semantic and surface drift
- JOV-2845: home feature-card System B drift
- JOV-2846: download marketing static and palette drift
- JOV-2847: launch imported-demo guard coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated System B calendar event dot colors for improved visual consistency
  * Refined type chip appearance with enhanced visual hierarchy, contrast, and border treatment
  * Improved overall calendar interface styling and color token application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->