### PR TITLE
fix(marketing): keep download page static

### DIFF
--- a/apps/web/app/(marketing)/download/page.tsx
+++ b/apps/web/app/(marketing)/download/page.tsx
@@ -16,15 +16,12 @@ import { MarketingFooterCta } from '@/components/site/MarketingFooterCta';
 import { APP_NAME, BASE_URL } from '@/constants/app';
 import { APP_ROUTES } from '@/constants/routes';
 import { buildBreadcrumbSchema, buildFaqSchema } from '@/lib/constants/schemas';
-import {
-  DESKTOP_RELEASES_HTML_URL,
-  fetchLatestDesktopRelease,
-} from '@/lib/desktop/github-releases';
 import { getMarketingExportImage } from '@/lib/screenshots/registry';
 
 export const revalidate = false;
 
 const DOWNLOAD_URL = '/api/desktop/download';
+const DESKTOP_RELEASES_HTML_URL = 'https://github.com/JovieInc/Jovie/releases';
 const DESKTOP_IMAGE = getMarketingExportImage('shell-v1-releases-desktop');
 const PROFILE_IMAGE = getMarketingExportImage('tim-white-profile-live-mobile');
 
@@ -131,41 +128,15 @@ const BREADCRUMB_SCHEMA = buildBreadcrumbSchema([
   { name: 'Download', url: `${BASE_URL}/download` },
 ]);
 
-function formatBytes(bytes: number): string {
-  if (bytes <= 0) return '';
-  const mb = bytes / (1024 * 1024);
-  return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${Math.round(mb)} MB`;
-}
-
-export default async function DownloadPage() {
-  const release = await fetchLatestDesktopRelease();
-  const versionLabel = release?.version ? `v${release.version}` : null;
-  const sizeLabel = release?.mac?.sizeBytes
-    ? formatBytes(release.mac.sizeBytes)
-    : null;
-  const meta = [versionLabel, sizeLabel, 'Apple Silicon + Intel']
-    .filter((value): value is string => Boolean(value))
-    .join(' / ');
-
+export default function DownloadPage() {
   return (
     <>
       <script type='application/ld+json'>{FAQ_SCHEMA}</script>
       <script type='application/ld+json'>{BREADCRUMB_SCHEMA}</script>
 
       <main className='system-b-download-page'>
-        <section
-          className='homepage-hero-stage relative'
-          aria-labelledby='download-hero-heading'
-        >
-          <div className='homepage-hero-shell system-b-download-hero-shell'>
-            <div
-              aria-hidden='true'
-              className='homepage-hero-shell__layer homepage-hero-shell__beam'
-            />
-            <div aria-hidden='true' className='homepage-hero-shell__grid-wrap'>
-              <div className='homepage-hero-shell__grid' />
-            </div>
-
+        <section aria-labelledby='download-hero-heading'>
+          <div className='system-b-download-hero-shell'>
             <MarketingContainer
               width='page'
               className='system-b-download-hero-container'
@@ -213,7 +184,7 @@ export default async function DownloadPage() {
                   <div className='system-b-download-meta'>
                     <span>Developer ID signed</span>
                     <span>Apple notarized</span>
-                    {meta ? <span>{meta}</span> : null}
+                    <span>Apple Silicon + Intel</span>
                   </div>
                 </div>
 

--- a/apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts
@@ -14,6 +14,14 @@ const forbiddenRouteVisualPatterns = [
   /\b(?:rounded|text|h|w|max-w|min-h|tracking|leading|px|py|pt|pb|z)-\[/,
   /\b(?:emerald|fuchsia|amber|sky|indigo|orange|rose|cyan|violet|red|black|white)-(?:[0-9]|\[|\/)/,
 ] as const;
+const forbiddenImportedDecorationPatterns = [
+  /\bhomepage-hero(?:-[\w-]+|__[\w-]+)?\b/,
+] as const;
+const forbiddenStaticBypassPatterns = [
+  /fetchLatestDesktopRelease/,
+  /@\/lib\/desktop\/github-releases/,
+  /async\s+function\s+DownloadPage/,
+] as const;
 
 const forbiddenDownloadCssPatterns = [
   /#[0-9a-fA-F]{3,8}/,
@@ -51,6 +59,26 @@ describe('download page System B source contract', () => {
     const source = readFileSync(resolve(process.cwd(), pageSourcePath), 'utf8');
 
     for (const pattern of forbiddenRouteVisualPatterns) {
+      expect(source, `${pageSourcePath} matched ${pattern}`).not.toMatch(
+        pattern
+      );
+    }
+  });
+
+  it('does not import homepage hero decoration into download', () => {
+    const source = readFileSync(resolve(process.cwd(), pageSourcePath), 'utf8');
+
+    for (const pattern of forbiddenImportedDecorationPatterns) {
+      expect(source, `${pageSourcePath} matched ${pattern}`).not.toMatch(
+        pattern
+      );
+    }
+  });
+
+  it('keeps live desktop release lookup out of the static render path', () => {
+    const source = readFileSync(resolve(process.cwd(), pageSourcePath), 'utf8');
+
+    for (const pattern of forbiddenStaticBypassPatterns) {
       expect(source, `${pageSourcePath} matched ${pattern}`).not.toMatch(
         pattern
       );

--- a/apps/web/tests/unit/marketing/static-revalidate-policy.test.ts
+++ b/apps/web/tests/unit/marketing/static-revalidate-policy.test.ts
@@ -1,5 +1,5 @@
-import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, extname, join, relative, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const STATIC_ROUTE_ROOTS = [
@@ -23,6 +23,9 @@ const STATIC_ENTRYPOINT_FILENAMES = new Set([
   'twitter-image.ts',
   'twitter-image.tsx',
 ]);
+const STATIC_SERVER_GRAPH_ENTRYPOINTS = new Set([
+  'app/(marketing)/download/page.tsx',
+]);
 const FORBIDDEN_REQUEST_TIME_PATTERNS: readonly RegExp[] = [
   /\bheaders\s*\(/,
   /\bcookies\s*\(/,
@@ -31,6 +34,13 @@ const FORBIDDEN_REQUEST_TIME_PATTERNS: readonly RegExp[] = [
   /from\s+['"]@\/lib\/config\/pricing['"]/,
   /from\s+['"]server-only['"]/,
 ];
+const FORBIDDEN_SERVER_GRAPH_PATTERNS: readonly RegExp[] = [
+  ...FORBIDDEN_REQUEST_TIME_PATTERNS,
+  /\bfetch\s*\(/,
+  /next\s*:\s*{\s*revalidate\s*:/,
+];
+const IMPORT_STATEMENT_PATTERN =
+  /\b(?:import|export)\s+(?:type\s+)?(?:[\s\S]*?\s+from\s+)?['"]([^'"]+)['"]/g;
 
 function listRouteFiles(directory: string): string[] {
   return readdirSync(directory).flatMap(entry => {
@@ -51,6 +61,89 @@ function listRouteFiles(directory: string): string[] {
   });
 }
 
+function isStaticEntrypoint(path: string): boolean {
+  return STATIC_ENTRYPOINT_FILENAMES.has(path.split(/[\\/]/).at(-1) ?? '');
+}
+
+function isClientBoundary(source: string): boolean {
+  return /^['"]use client['"];?/.test(source.trimStart());
+}
+
+function resolveLocalImport(
+  repoRoot: string,
+  importerPath: string,
+  specifier: string
+): string | null {
+  const basePath = specifier.startsWith('@/')
+    ? resolve(repoRoot, specifier.slice(2))
+    : specifier.startsWith('.')
+      ? resolve(dirname(importerPath), specifier)
+      : null;
+
+  if (!basePath) return null;
+
+  const candidates = extname(basePath)
+    ? [basePath]
+    : [
+        `${basePath}.ts`,
+        `${basePath}.tsx`,
+        `${basePath}.js`,
+        `${basePath}.jsx`,
+        join(basePath, 'index.ts'),
+        join(basePath, 'index.tsx'),
+        join(basePath, 'index.js'),
+        join(basePath, 'index.jsx'),
+      ];
+
+  return (
+    candidates.find(
+      candidate => existsSync(candidate) && statSync(candidate).isFile()
+    ) ?? null
+  );
+}
+
+function listServerLocalImports(
+  repoRoot: string,
+  importerPath: string,
+  source: string
+): string[] {
+  return [...source.matchAll(IMPORT_STATEMENT_PATTERN)].flatMap(match => {
+    const statement = match[0];
+    const specifier = match[1];
+
+    if (!specifier || /\b(?:import|export)\s+type\b/.test(statement)) {
+      return [];
+    }
+
+    const resolved = resolveLocalImport(repoRoot, importerPath, specifier);
+    return resolved ? [resolved] : [];
+  });
+}
+
+function listServerGraphViolations(
+  repoRoot: string,
+  entrypointPath: string,
+  visited = new Set<string>()
+): string[] {
+  if (visited.has(entrypointPath)) return [];
+  visited.add(entrypointPath);
+
+  const source = readFileSync(entrypointPath, 'utf8');
+  if (isClientBoundary(source)) return [];
+
+  const relativePath = relative(repoRoot, entrypointPath);
+  const currentViolations = FORBIDDEN_SERVER_GRAPH_PATTERNS.filter(pattern =>
+    pattern.test(source)
+  ).map(pattern => `${relativePath}: server graph forbidden ${pattern.source}`);
+  const nestedViolations = listServerLocalImports(
+    repoRoot,
+    entrypointPath,
+    source
+  ).flatMap(path => listServerGraphViolations(repoRoot, path, visited));
+
+  return [...currentViolations, ...nestedViolations];
+}
+
 describe('static marketing route policy', () => {
   it('keeps marketing and legal route entrypoints fully static', () => {
     const repoRoot = process.cwd();
@@ -63,9 +156,7 @@ describe('static marketing route policy', () => {
       source: readFileSync(path, 'utf8'),
     }));
     const staticEntrypointViolations = routeSources
-      .filter(({ path }) =>
-        STATIC_ENTRYPOINT_FILENAMES.has(path.split(/[\\/]/).at(-1) ?? '')
-      )
+      .filter(({ path }) => isStaticEntrypoint(path))
       .filter(
         ({ source }) =>
           !/export\s+const\s+revalidate\s*=\s*false\b/.test(source)
@@ -86,11 +177,17 @@ describe('static marketing route policy', () => {
       .map(
         ({ relativePath }) => `${relativePath}: non-static revalidate export`
       );
+    const serverGraphViolations = routeSources
+      .filter(({ relativePath }) =>
+        STATIC_SERVER_GRAPH_ENTRYPOINTS.has(relativePath)
+      )
+      .flatMap(({ path }) => listServerGraphViolations(repoRoot, path));
 
     expect([
       ...staticEntrypointViolations,
       ...dynamicRevalidateExports,
       ...requestTimeApiViolations,
+      ...serverGraphViolations,
     ]).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Removed the /download render-time desktop release fetch and async release metadata.
- Removed homepage hero shell, beam, and grid decoration classes from the /download hero while keeping the local System B shell dimensions.
- Expanded guards for /download decorative class imports and nested server-side fetch helpers.

## Linear
- https://linear.app/jovie/issue/JOV-2846/remove-download-marketing-static-and-palette-drift
<!-- linear-issue-id:JOV-2846 -->

## Gate Evidence
- PASS: `pnpm --filter @jovie/web exec vitest run tests/unit/marketing/download-system-b-style-guard.test.ts tests/unit/marketing/static-revalidate-policy.test.ts`
- PASS: `pnpm biome check --write 'apps/web/app/(marketing)/download/page.tsx' apps/web/tests/unit/marketing/download-system-b-style-guard.test.ts apps/web/tests/unit/marketing/static-revalidate-policy.test.ts`
- PASS: `pnpm --filter @jovie/web run typecheck -- --pretty false`
- PASS: `git diff --check`
- PASS: pre-push hook, including `biome check .`, `next:proxy-guard`, `tailwind:check`, web typecheck, and `biome lint .`

## Browser Proof
- PASS: `http://127.0.0.1:3100/download` returned 200 in gstack browse.
- PASS: gstack browse reported no console errors.
- PASS: DOM check returned `homepageHeroClasses: 0` and preserved hero min-height at `844px` on mobile.
- Screenshots: `/tmp/jov-2846-download-desktop.png`, `/tmp/jov-2846-download-mobile.png`

## Layout Shift Audit
- Visual states checked: public anonymous /download, desktop and mobile responsive hero, Mac active CTA, iPhone inactive alpha CTA, existing FAQ collapsed/expanded surface.
- The release lookup loading/empty/error states were removed from page render, so metadata now reserves stable static content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Download page now displays static system compatibility information for Apple Silicon and Intel architectures.
  * Optimized page rendering behavior for improved performance and reliability.
  * All existing SEO features and structured data capabilities retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->