### PR TITLE
fix(chat): tokenize action card chrome

### DIFF
--- a/apps/web/components/jovie/components/ChatActionCard.test.tsx
+++ b/apps/web/components/jovie/components/ChatActionCard.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ChatActionCard } from './ChatActionCard';
+
+describe('ChatActionCard', () => {
+  it('renders the tool-call card on named System B primitives', () => {
+    render(
+      <ChatActionCard
+        title='Review imported links'
+        body='Jovie found three profile links that need confirmation before they appear publicly.'
+        actionLabel='Review links'
+        onAct={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('chat-action-card')).toHaveClass(
+      'system-b-chat-action-card'
+    );
+    expect(screen.getByText('Review imported links')).toHaveClass(
+      'system-b-chat-action-card-title'
+    );
+    expect(
+      screen.getByText(
+        'Jovie found three profile links that need confirmation before they appear publicly.'
+      )
+    ).toHaveClass('system-b-chat-action-card-body');
+    expect(screen.getByRole('button', { name: 'Review links' })).toHaveClass(
+      'system-b-chat-action-card-primary'
+    );
+    expect(
+      screen.getByRole('button', { name: 'Dismiss Review imported links' })
+    ).toHaveClass('system-b-chat-action-card-dismiss');
+  });
+
+  it('keeps exactly one primary action and one dismiss action wired', () => {
+    const onAct = vi.fn();
+    const onDismiss = vi.fn();
+
+    render(
+      <ChatActionCard
+        title='Confirm venue data'
+        body='The imported venue profile has conflicting capacity metadata.'
+        actionLabel='Confirm'
+        onAct={onAct}
+        onDismiss={onDismiss}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dismiss Confirm venue data' })
+    );
+
+    expect(onAct).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+});

--- a/apps/web/components/jovie/components/ChatActionCard.tsx
+++ b/apps/web/components/jovie/components/ChatActionCard.tsx
@@ -22,43 +22,42 @@ export function ChatActionCard({
 }: ChatActionCardProps) {
   return (
     <article
-      className={cn(
-        'relative grid min-h-[148px] w-full grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3 rounded-[16px] border border-[color-mix(in_oklab,var(--linear-border-focus)_22%,var(--linear-app-frame-seam))] bg-[linear-gradient(180deg,rgba(255,255,255,0.052)_0%,rgba(255,255,255,0.016)_100%),var(--linear-app-content-surface)] px-4 py-4 text-left shadow-none sm:min-h-[132px] sm:items-center sm:px-5',
-        className
-      )}
+      className={cn('system-b-chat-action-card', className)}
       data-testid='chat-action-card'
     >
-      <span
-        className='mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-white/[0.08] bg-white/[0.035] text-secondary-token sm:mt-0'
-        aria-hidden='true'
-      >
-        <AlertCircle className='h-4 w-4' strokeWidth={2.2} />
+      <span className='system-b-chat-action-card-icon-shell' aria-hidden='true'>
+        <AlertCircle
+          className='system-b-chat-action-card-icon'
+          strokeWidth={2.2}
+        />
       </span>
 
-      <div className='min-w-0 pr-1'>
-        <h2 className='text-pretty text-[15px] font-semibold leading-5 text-primary-token sm:text-[15.5px]'>
-          {title}
-        </h2>
-        <p className='mt-1.5 max-w-[48ch] text-pretty text-[12.5px] leading-5 text-tertiary-token'>
-          {body}
-        </p>
+      <div className='system-b-chat-action-card-copy'>
+        <h2 className='system-b-chat-action-card-title'>{title}</h2>
+        <p className='system-b-chat-action-card-body'>{body}</p>
         <button
           type='button'
           onClick={onAct}
-          className='mt-3 inline-flex h-8 items-center gap-1.5 rounded-full bg-white px-3.5 text-[12px] font-medium text-black shadow-[0_6px_18px_rgba(0,0,0,0.22),inset_0_1px_0_rgba(255,255,255,0.45)] transition-[filter,box-shadow] duration-subtle ease-out hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface)'
+          className='system-b-chat-action-card-primary'
         >
           {actionLabel}
-          <ArrowRight className='h-3.5 w-3.5' strokeWidth={2.5} />
+          <ArrowRight
+            className='system-b-chat-action-card-primary-icon'
+            strokeWidth={2.5}
+          />
         </button>
       </div>
 
       <button
         type='button'
         onClick={onDismiss}
-        className='inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-tertiary-token transition-colors duration-subtle hover:bg-white/[0.06] hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/45'
+        className='system-b-chat-action-card-dismiss focus-ring'
         aria-label={`Dismiss ${title}`}
       >
-        <X className='h-3.5 w-3.5' strokeWidth={2.25} />
+        <X
+          className='system-b-chat-action-card-dismiss-icon'
+          strokeWidth={2.25}
+        />
       </button>
     </article>
   );

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -106,6 +106,10 @@
     color-mix(in oklab, var(--system-b-cinematic-black) 85%, transparent),
     inset 0 var(--space-px) 0
     color-mix(in oklab, var(--color-text-primary-token) 90%, transparent);
+  --system-b-chat-action-card-min-height: 148px;
+  --system-b-chat-action-card-min-height-compact: 132px;
+  --system-b-chat-action-card-icon-size: 28px;
+  --system-b-chat-action-card-primary-height: 32px;
   --system-b-duration-fast: var(--ds-motion-subtle-duration);
   --system-b-ease: var(--ds-motion-subtle-easing);
   --system-b-radius-pill: var(--radius-full);
@@ -6611,6 +6615,163 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
       .system-b-shell-dropdown-link-icon
   ) {
   color: var(--color-text-tertiary-token);
+}
+
+:where(.system-b-chat-action-card) {
+  position: relative;
+  display: grid;
+  width: 100%;
+  min-height: var(--system-b-chat-action-card-min-height);
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: flex-start;
+  gap: var(--space-3);
+  border: 1px solid
+    color-mix(
+      in oklab,
+      var(--linear-border-focus) 22%,
+      var(--system-b-app-frame-seam)
+    );
+  border-radius: var(--radius-2xl);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in oklab, var(--color-text-primary-token) 5%, transparent),
+      color-mix(in oklab, var(--color-text-primary-token) 1.6%, transparent)
+    ),
+    var(--system-b-app-content-surface);
+  padding: var(--space-4);
+  text-align: left;
+  box-shadow: none;
+}
+
+@media (min-width: 640px) {
+  :where(.system-b-chat-action-card) {
+    min-height: var(--system-b-chat-action-card-min-height-compact);
+    align-items: center;
+    padding-inline: var(--space-5);
+  }
+}
+
+:where(.system-b-chat-action-card-icon-shell) {
+  display: inline-flex;
+  width: var(--system-b-chat-action-card-icon-size);
+  height: var(--system-b-chat-action-card-icon-size);
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  margin-top: var(--space-0-5);
+  border: 1px solid
+    color-mix(in oklab, var(--color-text-primary-token) 8%, transparent);
+  border-radius: var(--radius-full);
+  background: color-mix(
+    in oklab,
+    var(--color-text-primary-token) 3.5%,
+    transparent
+  );
+  color: var(--color-text-secondary-token);
+}
+
+@media (min-width: 640px) {
+  :where(.system-b-chat-action-card-icon-shell) {
+    margin-top: 0;
+  }
+}
+
+:where(.system-b-chat-action-card-icon) {
+  width: var(--space-4);
+  height: var(--space-4);
+}
+
+:where(.system-b-chat-action-card-copy) {
+  min-width: 0;
+  padding-right: var(--space-1);
+}
+
+:where(.system-b-chat-action-card-title) {
+  color: var(--color-text-primary-token);
+  font-size: var(--text-mid);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--space-5);
+  text-wrap: pretty;
+}
+
+:where(.system-b-chat-action-card-body) {
+  max-width: 48ch;
+  margin-top: var(--space-1-5);
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-xs);
+  line-height: var(--space-5);
+  text-wrap: pretty;
+}
+
+:where(.system-b-chat-action-card-primary) {
+  display: inline-flex;
+  min-height: var(--system-b-chat-action-card-primary-height);
+  align-items: center;
+  gap: var(--space-1-5);
+  margin-top: var(--space-3);
+  border: 1px solid var(--color-btn-primary-bg);
+  border-radius: var(--radius-full);
+  background: var(--color-btn-primary-bg);
+  color: var(--color-btn-primary-fg);
+  padding-inline: calc(var(--space-3) + var(--space-0-5));
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  box-shadow: var(--shadow-button-inset);
+  transition:
+    background-color var(--duration-fast) var(--ease-subtle),
+    border-color var(--duration-fast) var(--ease-subtle),
+    color var(--duration-fast) var(--ease-subtle),
+    box-shadow var(--duration-fast) var(--ease-subtle);
+}
+
+:where(.system-b-chat-action-card-primary:hover) {
+  border-color: var(--color-btn-primary-hover);
+  background: var(--color-btn-primary-hover);
+}
+
+.system-b-chat-action-card-primary:focus-visible {
+  outline: calc(var(--space-px) * 2) solid
+    color-mix(in oklab, var(--linear-border-focus) 70%, transparent);
+  outline-offset: var(--space-0-5);
+  box-shadow: var(--shadow-button-inset);
+}
+
+:where(.system-b-chat-action-card-primary-icon),
+:where(.system-b-chat-action-card-dismiss-icon) {
+  width: calc(var(--space-3) + var(--space-0-5));
+  height: calc(var(--space-3) + var(--space-0-5));
+  flex-shrink: 0;
+}
+
+:where(.system-b-chat-action-card-dismiss) {
+  display: inline-flex;
+  width: var(--system-b-chat-action-card-icon-size);
+  height: var(--system-b-chat-action-card-icon-size);
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  color: var(--color-text-tertiary-token);
+  transition:
+    background-color var(--duration-fast) var(--ease-subtle),
+    border-color var(--duration-fast) var(--ease-subtle),
+    color var(--duration-fast) var(--ease-subtle);
+}
+
+:where(.system-b-chat-action-card-dismiss:hover) {
+  border-color: color-mix(
+    in oklab,
+    var(--color-text-primary-token) 8%,
+    transparent
+  );
+  background: color-mix(
+    in oklab,
+    var(--color-text-primary-token) 6%,
+    transparent
+  );
+  color: var(--color-text-primary-token);
 }
 
 :where(.system-b-chat-generation-artifact-surface) {

--- a/apps/web/tests/unit/chat/chat-attachments-style-guard.test.ts
+++ b/apps/web/tests/unit/chat/chat-attachments-style-guard.test.ts
@@ -6,6 +6,7 @@ const guardedSources = [
   'components/jovie/components/ImageAttachmentChip.tsx',
   'components/jovie/components/ImagePreviewStrip.tsx',
   'components/jovie/components/ChatAvatarUploadCard.tsx',
+  'components/jovie/components/ChatActionCard.tsx',
   'components/jovie/components/ChatLinkConfirmationCard.tsx',
   'components/jovie/components/ChatLinkRemovalCard.tsx',
   'components/jovie/components/ScrollToBottom.tsx',
@@ -28,6 +29,34 @@ describe('chat attachment and action System B source contract', () => {
       for (const pattern of forbiddenVisualPatterns) {
         expect(source, `${sourcePath} matched ${pattern}`).not.toMatch(pattern);
       }
+    }
+  });
+
+  it('defines chat action-card visual states in the design system source of truth', () => {
+    const actionCardSource = readFileSync(
+      resolve(process.cwd(), 'components/jovie/components/ChatActionCard.tsx'),
+      'utf8'
+    );
+    const designSystemSource = readFileSync(
+      resolve(process.cwd(), 'styles/design-system.css'),
+      'utf8'
+    );
+    const requiredClasses = [
+      'system-b-chat-action-card',
+      'system-b-chat-action-card-icon-shell',
+      'system-b-chat-action-card-icon',
+      'system-b-chat-action-card-copy',
+      'system-b-chat-action-card-title',
+      'system-b-chat-action-card-body',
+      'system-b-chat-action-card-primary',
+      'system-b-chat-action-card-primary-icon',
+      'system-b-chat-action-card-dismiss',
+      'system-b-chat-action-card-dismiss-icon',
+    ];
+
+    for (const className of requiredClasses) {
+      expect(actionCardSource).toContain(className);
+      expect(designSystemSource).toContain(`.${className}`);
     }
   });
 });


### PR DESCRIPTION
## Summary
- Move `ChatActionCard` off route-local hardcoded geometry, gradient, shadow, type, and focus utilities onto named System B primitives.
- Add stable System B action-card CSS tokens/classes for shell, icon, copy, primary action, dismiss action, hover, and focus states.
- Add focused component coverage and extend the chat attachment/action style guard to block raw visual recipes from returning.

## Verification
- `pnpm biome check --write apps/web/components/jovie/components/ChatActionCard.tsx apps/web/components/jovie/components/ChatActionCard.test.tsx apps/web/tests/unit/chat/chat-attachments-style-guard.test.ts apps/web/styles/design-system.css`
- `pnpm --filter @jovie/web exec vitest run components/jovie/components/ChatActionCard.test.tsx tests/unit/chat/chat-attachments-style-guard.test.ts --reporter verbose` (2 files, 4 tests)
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`

## Browser proof
- Desktop: `.gstack/design-reports/screenshots/jov-2849/chat-action-card-desktop.png`
- Mobile: `.gstack/design-reports/screenshots/jov-2849/chat-action-card-mobile.png`
- Metrics: `.gstack/design-reports/screenshots/jov-2849/chat-action-card-proof.json`
- Proof metrics: desktop/mobile focus height delta 0, horizontal overflow 0, console errors 0, primary focus outline solid 2px, dismiss focus visible.

Fixes JOV-2849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style/Refactor**
  * ChatActionCard component now uses updated design system tokens with improved visual consistency and restructured internal layout.

* **Tests**
  * Added comprehensive test coverage for ChatActionCard functionality, including button interactions and action callbacks.
  * Extended design system contract verification to ensure CSS class consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->