### PR TITLE
fix(web): tokenize toolbar menu primitives

### DIFF
--- a/apps/web/components/molecules/menus/ToolbarMenuPrimitives.test.tsx
+++ b/apps/web/components/molecules/menus/ToolbarMenuPrimitives.test.tsx
@@ -1,10 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { DropdownMenu, DropdownMenuContent } from '@jovie/ui';
 import { render, screen } from '@testing-library/react';
 import { Circle } from 'lucide-react';
 import { describe, expect, it, vi } from 'vitest';
 import { ToolbarMenuChoiceItem, ToolbarMenuRow } from './ToolbarMenuPrimitives';
 
+const toolbarMenuPrimitivesPath = resolve(
+  __dirname,
+  './ToolbarMenuPrimitives.tsx'
+);
+const designSystemPath = resolve(
+  __dirname,
+  '../../../styles/design-system.css'
+);
+
+const toolbarMenuSystemBClasses = [
+  'system-b-toolbar-menu-content',
+  'system-b-toolbar-menu-separator',
+  'system-b-toolbar-menu-header',
+  'system-b-toolbar-menu-header-badge',
+  'system-b-toolbar-menu-row-selected',
+  'system-b-toolbar-menu-item',
+  'system-b-toolbar-menu-sub-trigger',
+  'system-b-toolbar-menu-leading-visual',
+  'system-b-toolbar-menu-trailing-visual',
+  'system-b-toolbar-menu-check-icon',
+] as const;
+
+const rawVisualRecipes = [
+  /color-mix\(/,
+  /shadow-\[/,
+  /backdrop-blur/,
+  /rounded-\[[^\]]+\]/,
+  /border-\[[^\]]+\]/,
+  /bg-\[[^\]]+\]/,
+  /text-\[[^\]]+\]/,
+  /font-\[[^\]]+\]/,
+  /duration-\d+/,
+  /leading-\d+/,
+  /\b(?:min-h|min-w|h|w|px|py|p)-\[[^\]]+\]/,
+] as const;
+
 describe('ToolbarMenuPrimitives', () => {
+  it('keeps toolbar menu chrome on named System B classes', () => {
+    const source = readFileSync(toolbarMenuPrimitivesPath, 'utf8');
+    const designSystem = readFileSync(designSystemPath, 'utf8');
+    const offenders = rawVisualRecipes
+      .filter(pattern => pattern.test(source))
+      .map(pattern => pattern.toString());
+
+    expect(
+      offenders,
+      `ToolbarMenuPrimitives leaked raw visual recipes: ${offenders.join(', ')}`
+    ).toEqual([]);
+
+    for (const className of toolbarMenuSystemBClasses) {
+      expect(source).toContain(className);
+      expect(designSystem).toContain(className);
+    }
+  });
+
   it('renders leading, label, and trailing slots with stable data hooks', () => {
     render(
       <div data-testid='row'>
@@ -42,5 +98,30 @@ describe('ToolbarMenuPrimitives', () => {
     expect(row).toHaveAttribute('data-selected', 'true');
     expect(row?.querySelector('[data-menu-trailing]')).toHaveTextContent('3');
     expect(row?.querySelector('[data-menu-trailing] svg')).toBeTruthy();
+  });
+
+  it('keeps disabled long-label rows on the same stable row contract', () => {
+    render(
+      <DropdownMenu open>
+        <DropdownMenuContent>
+          <ToolbarMenuChoiceItem
+            active={false}
+            disabled
+            label='A very long toolbar menu label that should truncate without changing row geometry'
+            onSelect={vi.fn()}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+
+    const row = screen
+      .getByText(/A very long toolbar menu label/)
+      .closest('[data-menu-row]');
+
+    expect(row).toHaveAttribute('data-disabled');
+    expect(row).toHaveClass('system-b-toolbar-menu-item');
+    expect(row?.querySelector('.truncate')).toHaveTextContent(
+      /A very long toolbar menu label/
+    );
   });
 });

--- a/apps/web/components/molecules/menus/ToolbarMenuPrimitives.tsx
+++ b/apps/web/components/molecules/menus/ToolbarMenuPrimitives.tsx
@@ -1,37 +1,32 @@
 import { DropdownMenuItem } from '@jovie/ui';
 import { Check } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { LINEAR_SURFACE } from '@/components/tokens/linear-surface';
 import { cn } from '@/lib/utils';
 
-export const TOOLBAR_MENU_CONTENT_CLASS = cn(
-  LINEAR_SURFACE.popover,
-  'min-w-[13rem] overflow-hidden rounded-[11px] border-[color-mix(in_oklab,var(--linear-app-frame-seam)_68%,transparent)] bg-[color-mix(in_oklab,var(--linear-app-content-surface)_16%,var(--linear-bg-surface-0))] p-1 shadow-[0_10px_24px_-18px_rgba(15,23,42,0.24),0_10px_18px_-16px_rgba(15,23,42,0.18)] backdrop-blur-[8px]'
-);
+export const TOOLBAR_MENU_CONTENT_CLASS = 'system-b-toolbar-menu-content';
 
-export const TOOLBAR_MENU_SEPARATOR_CLASS =
-  'mx-1 my-1 h-px bg-[color-mix(in_oklab,var(--linear-app-frame-seam)_44%,transparent)]';
+export const TOOLBAR_MENU_SEPARATOR_CLASS = 'system-b-toolbar-menu-separator';
 
-export const TOOLBAR_MENU_HEADER_CLASS =
-  'flex items-center justify-between gap-2 border-b border-[color-mix(in_oklab,var(--linear-app-frame-seam)_44%,transparent)] px-2.5 py-[7px]';
+export const TOOLBAR_MENU_HEADER_CLASS = 'system-b-toolbar-menu-header';
 
 export const TOOLBAR_MENU_HEADER_BADGE_CLASS =
-  'inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-[6px] border border-[color-mix(in_oklab,var(--linear-app-frame-seam)_52%,transparent)] bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_36%,transparent)] px-[5px] text-[10px] font-[600] tabular-nums text-tertiary-token';
+  'system-b-toolbar-menu-header-badge';
 
 export const TOOLBAR_MENU_ROW_SELECTED_CLASS =
-  'bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_72%,transparent)] text-primary-token';
+  'system-b-toolbar-menu-row-selected';
 
-export const TOOLBAR_MENU_ITEM_CLASS =
-  'flex min-h-8 min-w-[13rem] items-center rounded-lg px-2.5 py-1.25 text-[12.5px] font-[500] leading-4 text-secondary-token outline-none transition-[background-color,color] duration-150 hover:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_60%,transparent)] hover:text-primary-token focus:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_60%,transparent)] focus:text-primary-token data-[highlighted]:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_60%,transparent)] data-[highlighted]:text-primary-token data-[disabled]:pointer-events-none data-[disabled]:opacity-45';
+export const TOOLBAR_MENU_ITEM_CLASS = 'system-b-toolbar-menu-item';
 
 export const TOOLBAR_MENU_SUB_TRIGGER_CLASS =
-  'justify-between gap-2 rounded-lg px-2.5 py-1.25 text-[12.5px] font-[500] leading-4 text-secondary-token hover:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_60%,transparent)] hover:text-primary-token focus:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_60%,transparent)] focus:text-primary-token data-[state=open]:bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_64%,transparent)] data-[state=open]:text-primary-token';
+  'system-b-toolbar-menu-sub-trigger';
 
 export const TOOLBAR_MENU_LEADING_VISUAL_CLASS =
-  'flex h-4 w-[18px] shrink-0 items-center justify-center text-tertiary-token';
+  'system-b-toolbar-menu-leading-visual';
 
 export const TOOLBAR_MENU_TRAILING_VISUAL_CLASS =
-  'inline-flex min-w-4 shrink-0 items-center justify-end gap-1 text-tertiary-token';
+  'system-b-toolbar-menu-trailing-visual';
+
+export const TOOLBAR_MENU_CHECK_ICON_CLASS = 'system-b-toolbar-menu-check-icon';
 
 export function ToolbarMenuRow({
   leadingVisual,
@@ -84,7 +79,7 @@ export function ToolbarMenuChoiceItem({
     active || trailingVisual ? (
       <>
         {trailingVisual ?? null}
-        {active ? <Check className='h-4 w-4 text-primary-token' /> : null}
+        {active ? <Check className={TOOLBAR_MENU_CHECK_ICON_CLASS} /> : null}
       </>
     ) : null;
 

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -5374,6 +5374,154 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   border-bottom: 2px solid var(--color-border-subtle);
 }
 
+/* System B toolbar menu primitives */
+:where(.system-b-toolbar-menu-content) {
+  min-width: 13rem;
+  overflow: hidden;
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 68%, transparent);
+  border-radius: var(--radius-xl);
+  background: color-mix(
+    in oklab,
+    var(--system-b-app-content-surface) 16%,
+    var(--system-b-bg-surface-0)
+  );
+  padding: var(--space-1);
+  box-shadow: var(--shadow-popover);
+  backdrop-filter: blur(var(--space-2));
+}
+
+:where(.system-b-toolbar-menu-separator) {
+  height: var(--space-px);
+  margin: var(--space-1);
+  background: color-mix(
+    in oklab,
+    var(--system-b-app-frame-seam) 44%,
+    transparent
+  );
+}
+
+:where(.system-b-toolbar-menu-header) {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  border-bottom: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 44%, transparent);
+  padding: calc(var(--space-2) - var(--space-px)) var(--space-2-5);
+}
+
+:where(.system-b-toolbar-menu-header-badge) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: calc(var(--space-4) + var(--space-0-5));
+  height: calc(var(--space-4) + var(--space-0-5));
+  border: 1px solid
+    color-mix(in oklab, var(--system-b-app-frame-seam) 52%, transparent);
+  border-radius: var(--radius-md);
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-1) 36%,
+    transparent
+  );
+  padding-inline: calc(var(--space-1) + var(--space-px));
+  color: var(--color-text-tertiary-token);
+  font-size: var(--text-3xs);
+  font-weight: var(--font-weight-semibold);
+  font-variant-numeric: tabular-nums;
+}
+
+:where(.system-b-toolbar-menu-item),
+:where(.system-b-toolbar-menu-sub-trigger) {
+  display: flex;
+  align-items: center;
+  min-width: 13rem;
+  min-height: var(--space-8);
+  border-radius: var(--radius-lg);
+  color: var(--color-text-secondary-token);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
+  line-height: var(--space-4);
+  outline: none;
+  transition-duration: var(--duration-subtle);
+  transition-property: background-color, color;
+  transition-timing-function: var(--ease-subtle);
+}
+
+:where(.system-b-toolbar-menu-item) {
+  padding: var(--space-1) var(--space-2-5);
+}
+
+:where(.system-b-toolbar-menu-sub-trigger) {
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2-5);
+}
+
+:where(.system-b-toolbar-menu-item:hover),
+:where(.system-b-toolbar-menu-item:focus),
+:where(.system-b-toolbar-menu-item[data-highlighted]),
+:where(.system-b-toolbar-menu-sub-trigger:hover),
+:where(.system-b-toolbar-menu-sub-trigger:focus),
+:where(.system-b-toolbar-menu-sub-trigger[data-highlighted]) {
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-1) 60%,
+    transparent
+  );
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-toolbar-menu-sub-trigger[data-state="open"]) {
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-1) 64%,
+    transparent
+  );
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-toolbar-menu-row-selected) {
+  background: color-mix(
+    in oklab,
+    var(--system-b-bg-surface-1) 72%,
+    transparent
+  );
+  color: var(--color-text-primary-token);
+}
+
+:where(.system-b-toolbar-menu-item[data-disabled]) {
+  pointer-events: none;
+  opacity: 0.45;
+}
+
+:where(.system-b-toolbar-menu-leading-visual) {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(var(--space-4) + var(--space-0-5));
+  height: var(--space-4);
+  flex-shrink: 0;
+  color: var(--color-text-tertiary-token);
+}
+
+:where(.system-b-toolbar-menu-trailing-visual) {
+  display: inline-flex;
+  min-width: var(--space-4);
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-1);
+  color: var(--color-text-tertiary-token);
+}
+
+:where(.system-b-toolbar-menu-check-icon) {
+  width: var(--space-4);
+  height: var(--space-4);
+  color: var(--color-text-primary-token);
+}
+
 :where(.group\/task-row:hover, .group\/task-row:focus-visible)
   :where(.system-b-shell-list-task-row-hover) {
   background: var(--linear-row-hover);


### PR DESCRIPTION
## Summary
- Moves `ToolbarMenuPrimitives` exported chrome constants from local arbitrary Tailwind recipes to named `.system-b-toolbar-menu-*` classes in `design-system.css`.
- Adds source guards for raw visual recipes plus disabled long-label row contract coverage.
- Verifies the shared task filter menu live in `/app/tasks` with admin test auth at desktop and narrow widths.

Closes #10211

## Verification
- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/molecules/menus/ToolbarMenuPrimitives.tsx apps/web/components/molecules/menus/ToolbarMenuPrimitives.test.tsx apps/web/styles/design-system.css`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run components/molecules/menus/ToolbarMenuPrimitives.test.tsx components/molecules/filters/FilterCheckboxItem.test.tsx components/molecules/filters/TableFilterDropdown.test.tsx tests/components/release-provider-matrix/ReleaseFilterDropdown.test.tsx tests/unit/dashboard/TasksPageClient.test.tsx`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- Pre-push hook: `biome check . && pnpm --filter=@jovie/web run pre-push`

Additional broad check:
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck:tests -- --pretty false` currently fails in existing unrelated script/profile/release test fixtures, including `scripts/drizzle-migrate.ts`, `scripts/drizzle-seed.ts`, and `tests/unit/profile/ProfileUnifiedDrawerReleases.test.tsx`. No touched file was listed.

## Browser Proof
- Admin test auth on `http://localhost:3101/app/tasks`.
- Desktop screenshot: `.gstack/design-reports/screenshots/system-b-toolbar-menu-tasks-desktop-after.png`.
- Narrow screenshot: `.gstack/design-reports/screenshots/system-b-toolbar-menu-tasks-narrow-after.png`.
- Closed/open filter trigger stayed `28x28` at 1440px and 1024px widths.
- Open menus had `.system-b-toolbar-menu-content`; rows had `.system-b-toolbar-menu-sub-trigger`, `.system-b-toolbar-menu-item`, and `.system-b-toolbar-menu-row-selected` where applicable.
- `scrollWidth` matched viewport width at 1440px and 1024px.
