### PR TITLE
fix(web): tokenize spotify connect dialog

### DIFF
--- a/apps/web/components/features/dashboard/organisms/release-provider-matrix/SpotifyConnectDialog.tsx
+++ b/apps/web/components/features/dashboard/organisms/release-provider-matrix/SpotifyConnectDialog.tsx
@@ -43,11 +43,11 @@ function SearchDropdownState({
     >
       <DrawerSurfaceCard
         variant='card'
-        className='flex min-h-[56px] items-center bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_88%,var(--linear-bg-surface-0))] px-2.5'
+        className='system-b-spotify-connect-status-card px-2.5'
       >
         <p
           className={cn(
-            'text-xs leading-[17px]',
+            'system-b-spotify-connect-status-copy text-xs',
             tone === 'error' ? 'text-error' : 'text-secondary-token'
           )}
         >
@@ -61,7 +61,7 @@ function SearchDropdownState({
 function SearchResultsLoadingSkeleton() {
   return (
     <output
-      className='block p-2.5 space-y-1'
+      className='block space-y-1 p-2.5'
       aria-live='polite'
       aria-label='Loading Spotify artist results'
       aria-busy='true'
@@ -70,7 +70,7 @@ function SearchResultsLoadingSkeleton() {
         <DrawerSurfaceCard
           key={key}
           variant='card'
-          className='flex min-h-[56px] items-center gap-2.5 bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_88%,var(--linear-bg-surface-0))] px-2.5'
+          className='system-b-spotify-connect-status-card gap-2.5 px-2.5'
           aria-hidden='true'
         >
           <div className='h-10 w-10 shrink-0 rounded-full skeleton' />
@@ -130,33 +130,42 @@ function SearchInputTrailing({
 }) {
   if (showClaimButton) {
     return (
-      <DrawerButton
-        type='button'
-        tone='primary'
-        disabled={claimButtonDisabled}
-        onClick={onClaimArtist}
-        className={cn(
-          'h-8 shrink-0 px-3 text-app',
-          claimButtonDisabled && 'text-white/60'
-        )}
-      >
-        {(isLoading || isPending) && (
-          <LoadingSpinner size='sm' tone='inverse' label='Connecting' />
-        )}
-        Connect Spotify
-      </DrawerButton>
+      <div className='system-b-spotify-connect-trailing'>
+        <DrawerButton
+          type='button'
+          tone='primary'
+          disabled={claimButtonDisabled}
+          onClick={onClaimArtist}
+          className={cn(
+            'system-b-spotify-connect-claim-button h-8 shrink-0 px-3 text-app',
+            claimButtonDisabled &&
+              'system-b-spotify-connect-claim-button--disabled'
+          )}
+        >
+          {(isLoading || isPending) && (
+            <LoadingSpinner size='sm' tone='inverse' label='Connecting' />
+          )}
+          Connect Spotify
+        </DrawerButton>
+      </div>
     );
   }
 
   if (isPending) {
-    return <LoadingSpinner size='sm' tone='muted' label='Loading' />;
+    return (
+      <div className='system-b-spotify-connect-trailing'>
+        <LoadingSpinner size='sm' tone='muted' label='Loading' />
+      </div>
+    );
   }
 
   return (
-    <Search
-      className='h-4 w-4 shrink-0 text-tertiary-token'
-      aria-hidden='true'
-    />
+    <div className='system-b-spotify-connect-trailing'>
+      <Search
+        className='h-4 w-4 shrink-0 text-tertiary-token'
+        aria-hidden='true'
+      />
+    </div>
   );
 }
 
@@ -425,13 +434,13 @@ export function SpotifyConnectDialog({
       <DialogBody className='space-y-3'>
         <DrawerSurfaceCard
           variant='card'
-          className='overflow-visible bg-(--linear-app-content-surface) p-3.5'
+          className='system-b-spotify-connect-card p-3.5'
         >
           <div className='mb-2.5'>
             <p className='text-2xs font-caption leading-none text-tertiary-token'>
               Artist search
             </p>
-            <p className='mt-1 text-xs leading-[17px] text-secondary-token'>
+            <p className='system-b-spotify-connect-helper-copy mt-1 text-xs text-secondary-token'>
               Search by artist name or paste your Spotify artist URL to connect
               instantly.
             </p>
@@ -442,15 +451,14 @@ export function SpotifyConnectDialog({
             </label>
             <div
               className={cn(
-                'flex min-h-11 w-full items-center gap-2.5 rounded-[11px] border border-(--linear-app-frame-seam) bg-surface-0 px-2.5 py-2',
-                'transition-[border-color,box-shadow] duration-150',
+                'system-b-spotify-connect-input-shell',
                 shouldShowDropdown
-                  ? 'border-(--linear-border-focus) ring-2 ring-(--linear-border-focus)/20'
-                  : 'hover:border-(--linear-border-focus)',
+                  ? 'system-b-spotify-connect-input-shell--active'
+                  : 'system-b-spotify-connect-input-shell--idle',
                 isPending && 'opacity-60'
               )}
             >
-              <div className='flex items-center justify-center w-6 h-6 rounded-full shrink-0 bg-brand-spotify-subtle'>
+              <div className='flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-brand-spotify-subtle'>
                 <ProviderIcon provider='spotify' className='h-3.5 w-3.5' />
               </div>
               <input
@@ -505,7 +513,7 @@ export function SpotifyConnectDialog({
             )}
 
             {shouldShowDropdown && (
-              <div className='absolute z-50 mt-1.5 w-full overflow-hidden rounded-xl border border-(--linear-app-frame-seam) bg-(--linear-app-content-surface) shadow-popover'>
+              <div className='system-b-spotify-connect-dropdown absolute z-50 mt-1.5 w-full overflow-hidden'>
                 <select
                   id='spotify-connect-results'
                   className='sr-only'
@@ -580,13 +588,13 @@ export function SpotifyConnectDialog({
                         tabIndex={artist.isClaimed ? -1 : 0}
                         disabled={artist.isClaimed}
                         className={cn(
-                          'mb-1 flex w-full items-center gap-2.5 rounded-[10px] border border-transparent bg-[color-mix(in_oklab,var(--linear-bg-surface-1)_72%,var(--linear-bg-surface-0))] px-2.5 py-2 text-left transition-colors last:mb-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20 focus-visible:ring-inset',
+                          'system-b-spotify-connect-result-row mb-1 flex w-full items-center gap-2.5 px-2.5 py-2 text-left last:mb-0 focus-visible:outline-none',
                           index === formState.activeResultIndex &&
                             !artist.isClaimed &&
-                            'border-(--linear-app-frame-seam) bg-surface-1',
+                            'system-b-spotify-connect-result-row--active',
                           artist.isClaimed
                             ? 'opacity-50 cursor-not-allowed'
-                            : 'cursor-pointer hover:border-(--linear-app-frame-seam) hover:bg-surface-1'
+                            : 'system-b-spotify-connect-result-row--interactive cursor-pointer'
                         )}
                         onClick={() =>
                           !artist.isClaimed && handleArtistSelect(artist)
@@ -604,7 +612,7 @@ export function SpotifyConnectDialog({
                           })
                         }
                       >
-                        <div className='relative h-10 w-10 shrink-0 overflow-hidden rounded-[10px] border border-(--linear-app-frame-seam) bg-surface-1'>
+                        <div className='system-b-spotify-connect-result-artwork relative h-10 w-10 shrink-0 overflow-hidden'>
                           {artist.imageUrl ? (
                             <Image
                               src={artist.imageUrl}
@@ -615,7 +623,7 @@ export function SpotifyConnectDialog({
                               unoptimized
                             />
                           ) : (
-                            <div className='w-full h-full flex items-center justify-center'>
+                            <div className='flex h-full w-full items-center justify-center'>
                               <ProviderIcon
                                 provider='spotify'
                                 className='h-5 w-5'
@@ -623,7 +631,7 @@ export function SpotifyConnectDialog({
                             </div>
                           )}
                         </div>
-                        <div className='flex-1 min-w-0'>
+                        <div className='min-w-0 flex-1'>
                           <div className='truncate text-app font-caption text-primary-token'>
                             {artist.name}
                           </div>
@@ -658,9 +666,9 @@ export function SpotifyConnectDialog({
                   type='button'
                   tabIndex={0}
                   className={cn(
-                    'm-2 mt-0 flex w-[calc(100%-1rem)] cursor-pointer items-center gap-2.5 rounded-[10px] border border-(--linear-app-frame-seam) bg-surface-0 px-3 py-2 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20 focus-visible:ring-inset hover:bg-surface-1',
+                    'system-b-spotify-connect-paste-row m-2 mt-0 flex cursor-pointer items-center gap-2.5 px-3 py-2 text-left focus-visible:outline-none',
                     formState.activeResultIndex === pasteUrlIndex &&
-                      'bg-surface-1'
+                      'system-b-spotify-connect-paste-row--active'
                   )}
                   onClick={handlePasteUrlClick}
                   onKeyDown={event =>
@@ -673,7 +681,7 @@ export function SpotifyConnectDialog({
                     })
                   }
                 >
-                  <div className='flex h-10 w-10 items-center justify-center rounded-[10px] border border-(--linear-app-frame-seam) bg-surface-1'>
+                  <div className='system-b-spotify-connect-paste-icon flex h-10 w-10 items-center justify-center'>
                     <Link2
                       className='h-5 w-5 text-tertiary-token'
                       aria-hidden='true'

--- a/apps/web/components/molecules/drawer/DrawerButton.tsx
+++ b/apps/web/components/molecules/drawer/DrawerButton.tsx
@@ -9,7 +9,7 @@ type DrawerButtonSize = 'sm' | 'icon';
 
 const TONE_CLASSNAMES: Record<DrawerButtonTone, string> = {
   primary:
-    'border-(--linear-accent) bg-(--linear-accent) text-white hover:border-(--linear-accent) hover:bg-(--linear-accent-hover,rgba(91,111,255,0.92)) hover:text-white active:border-(--linear-accent) active:bg-(--linear-accent-hover,rgba(91,111,255,0.88))',
+    'border-(--color-btn-primary-bg) bg-btn-primary text-btn-primary-foreground hover:border-(--color-btn-primary-hover) hover:bg-btn-primary-hover hover:text-btn-primary-foreground active:border-(--color-btn-primary-hover) active:bg-btn-primary-hover active:text-btn-primary-foreground',
   secondary:
     'border-subtle bg-surface-0 text-secondary-token hover:border-default hover:bg-surface-1 hover:text-primary-token active:border-default active:bg-surface-2',
   ghost:
@@ -28,7 +28,7 @@ export interface DrawerButtonProps
 }
 
 export const DRAWER_BUTTON_CLASSNAME =
-  'border font-caption tracking-[-0.01em] shadow-none transition-[background-color,border-color,color] duration-150 focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20';
+  'border font-caption tracking-[-0.01em] shadow-none transition-[background-color,border-color,color] duration-subtle focus-visible:outline-none focus-visible:border-(--linear-border-focus) focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20';
 
 export const DrawerButton = React.forwardRef<
   HTMLButtonElement,

--- a/apps/web/styles/design-system.css
+++ b/apps/web/styles/design-system.css
@@ -4908,6 +4908,142 @@ body:has(.system-b-download-page) .marketing-glass-header__cta:focus-visible {
   --system-b-release-provider-accent-hover: var(--color-accent-hover);
 }
 
+:where(.system-b-spotify-connect-card) {
+  overflow: visible;
+  background: var(--system-b-app-content-surface);
+}
+
+:where(.system-b-spotify-connect-status-card) {
+  display: flex;
+  min-height: calc(var(--space-10) + var(--space-4));
+  align-items: center;
+  background: color-mix(
+    in oklab,
+    var(--system-b-app-content-surface) 88%,
+    var(--system-b-bg-page)
+  );
+}
+
+:where(
+    .system-b-spotify-connect-status-copy,
+    .system-b-spotify-connect-helper-copy
+  ) {
+  line-height: calc(var(--space-4) + var(--space-px));
+}
+
+:where(.system-b-spotify-connect-claim-button--disabled) {
+  color: color-mix(in oklab, var(--color-btn-primary-fg) 60%, transparent);
+}
+
+:where(.system-b-spotify-connect-trailing) {
+  display: flex;
+  min-height: var(--space-8);
+  width: calc(var(--space-24) + var(--space-8));
+  flex: 0 0 calc(var(--space-24) + var(--space-8));
+  align-items: center;
+  justify-content: center;
+}
+
+:where(.system-b-spotify-connect-claim-button) {
+  width: 100%;
+  justify-content: center;
+}
+
+:where(.system-b-spotify-connect-input-shell) {
+  display: flex;
+  min-height: calc(var(--space-10) + var(--space-1));
+  width: 100%;
+  align-items: center;
+  gap: var(--space-2-5);
+  border: var(--space-px) solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-xl);
+  background: var(--color-bg-surface-0);
+  padding: var(--space-2) var(--space-2-5);
+  transition:
+    border-color var(--system-b-duration-fast) var(--system-b-ease),
+    box-shadow var(--system-b-duration-fast) var(--system-b-ease),
+    opacity var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-spotify-connect-input-shell--idle):hover {
+  border-color: var(--color-border-focus);
+}
+
+:where(.system-b-spotify-connect-input-shell--active) {
+  border-color: var(--color-border-focus);
+  box-shadow: 0 0 0 calc(var(--space-px) * 2)
+    color-mix(in oklab, var(--color-border-focus) 20%, transparent);
+}
+
+:where(.system-b-spotify-connect-dropdown) {
+  border: var(--space-px) solid var(--system-b-app-frame-seam);
+  border-radius: var(--radius-xl);
+  background: var(--system-b-app-content-surface);
+  box-shadow: var(--shadow-popover);
+}
+
+:where(.system-b-spotify-connect-result-row) {
+  border: var(--space-px) solid transparent;
+  border-radius: calc(var(--radius-lg) + var(--space-0-5));
+  background: color-mix(
+    in oklab,
+    var(--system-b-app-content-surface) 72%,
+    var(--system-b-bg-page)
+  );
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    border-color var(--system-b-duration-fast) var(--system-b-ease),
+    box-shadow var(--system-b-duration-fast) var(--system-b-ease),
+    opacity var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(.system-b-spotify-connect-result-row):focus-visible {
+  box-shadow: inset 0 0 0 calc(var(--space-px) * 2)
+    color-mix(in oklab, var(--color-border-focus) 20%, transparent);
+}
+
+:where(
+    .system-b-spotify-connect-result-row--active,
+    .system-b-spotify-connect-result-row--interactive:hover
+  ) {
+  border-color: var(--system-b-app-frame-seam);
+  background: var(--color-bg-surface-1);
+}
+
+:where(.system-b-spotify-connect-result-artwork) {
+  border: var(--space-px) solid var(--system-b-app-frame-seam);
+  border-radius: calc(var(--radius-lg) + var(--space-0-5));
+  background: var(--color-bg-surface-1);
+}
+
+:where(.system-b-spotify-connect-paste-row) {
+  width: calc(100% - var(--space-4));
+  border: var(--space-px) solid var(--system-b-app-frame-seam);
+  border-radius: calc(var(--radius-lg) + var(--space-0-5));
+  background: var(--color-bg-surface-0);
+  transition:
+    background-color var(--system-b-duration-fast) var(--system-b-ease),
+    box-shadow var(--system-b-duration-fast) var(--system-b-ease);
+}
+
+:where(
+    .system-b-spotify-connect-paste-row:hover,
+    .system-b-spotify-connect-paste-row--active
+  ) {
+  background: var(--color-bg-surface-1);
+}
+
+:where(.system-b-spotify-connect-paste-row):focus-visible {
+  box-shadow: inset 0 0 0 calc(var(--space-px) * 2)
+    color-mix(in oklab, var(--color-border-focus) 20%, transparent);
+}
+
+:where(.system-b-spotify-connect-paste-icon) {
+  border: var(--space-px) solid var(--system-b-app-frame-seam);
+  border-radius: calc(var(--radius-lg) + var(--space-0-5));
+  background: var(--color-bg-surface-1);
+}
+
 .system-b-release-provider-banner {
   border-color: color-mix(
     in oklab,

--- a/apps/web/tests/unit/dashboard/spotify-connect-dialog-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/spotify-connect-dialog-system-b-style-guard.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+
+const rawComponentVisualPatterns = [
+  /\b(?:bg|border|text|ring|shadow|outline|rounded|h|w|max-w|min-h|min-w|tracking|leading|px|py|pt|pb)-\[[^\]]+\]/,
+  /\b(?:bg|border|ring|text)-\(--[^)]+\)/,
+  /color-mix\(/i,
+  /--linear-/,
+  /\brgba?\(/i,
+  /#[0-9A-Fa-f]{3,8}\b/,
+  /duration-150/,
+  /\bshadow-\[/,
+  /text-white\/60/,
+];
+
+function readWebFile(relativePath: string) {
+  return readFileSync(path.join(webRoot, relativePath), 'utf8');
+}
+
+describe('SpotifyConnectDialog System B style guard', () => {
+  it('keeps dialog source on named System B primitives', () => {
+    const source = readWebFile(
+      'components/features/dashboard/organisms/release-provider-matrix/SpotifyConnectDialog.tsx'
+    );
+    const offenders = rawComponentVisualPatterns
+      .filter(pattern => pattern.test(source))
+      .map(pattern => pattern.toString());
+
+    expect(
+      offenders,
+      `SpotifyConnectDialog leaked ${offenders.join(', ')}`
+    ).toEqual([]);
+    expect(source).toContain('system-b-spotify-connect-card');
+    expect(source).toContain('system-b-spotify-connect-input-shell');
+    expect(source).toContain('system-b-spotify-connect-trailing');
+    expect(source).toContain('system-b-spotify-connect-dropdown');
+    expect(source).toContain('system-b-spotify-connect-result-row');
+    expect(source).toContain('system-b-spotify-connect-paste-row');
+  });
+
+  it('keeps dialog primitives token-backed', () => {
+    const source = readWebFile('styles/design-system.css');
+    const spotifyConnectCss = source.match(
+      /:where\(\.system-b-spotify-connect-card\)[\s\S]*?(?=\.system-b-release-provider-banner)/
+    )?.[0];
+
+    expect(spotifyConnectCss).toBeDefined();
+    expect(spotifyConnectCss).toContain('var(--system-b-app-content-surface)');
+    expect(spotifyConnectCss).toContain('var(--system-b-app-frame-seam)');
+    expect(spotifyConnectCss).toContain('var(--system-b-bg-page)');
+    expect(spotifyConnectCss).toContain('var(--color-border-focus)');
+    expect(spotifyConnectCss).toContain('var(--shadow-popover)');
+    expect(spotifyConnectCss).toContain(
+      '.system-b-spotify-connect-input-shell--active'
+    );
+    expect(spotifyConnectCss).toContain('.system-b-spotify-connect-trailing');
+    expect(spotifyConnectCss).toContain(
+      '.system-b-spotify-connect-result-row--interactive:hover'
+    );
+    expect(spotifyConnectCss).not.toMatch(/--linear-/);
+    expect(spotifyConnectCss).not.toMatch(/\brgba?\(/i);
+    expect(spotifyConnectCss).not.toMatch(/#[0-9A-Fa-f]{3,8}\b/);
+    expect(spotifyConnectCss).not.toMatch(/(?:radial|linear)-gradient/i);
+  });
+});

--- a/apps/web/tests/unit/molecules/drawer-button-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/molecules/drawer-button-system-b-style-guard.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const webRoot = path.resolve(__dirname, '../../..');
+
+function readWebFile(relativePath: string) {
+  return readFileSync(path.join(webRoot, relativePath), 'utf8');
+}
+
+describe('DrawerButton System B style guard', () => {
+  it('keeps primary drawer actions neutral instead of accent-colored', () => {
+    const source = readWebFile('components/molecules/drawer/DrawerButton.tsx');
+
+    expect(source).toContain('bg-btn-primary');
+    expect(source).toContain('text-btn-primary-foreground');
+    expect(source).toContain('hover:bg-btn-primary-hover');
+    expect(source).not.toContain('--linear-accent');
+    expect(source).not.toContain('text-white');
+    expect(source).not.toContain('duration-150');
+    expect(source).not.toMatch(/\brgba?\(/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaced SpotifyConnectDialog raw Linear/arbitrary visual recipes with named System B primitives.
- Moved DrawerButton primary actions off accent tokens onto neutral primary button tokens, so central drawer CTAs render white/dark instead of purple.
- Added source guards for the Spotify connect dialog and neutral DrawerButton primary treatment.

EVENT: Central actions use neutral primary tokens; accent/provider colors stay reserved for provider marks, progress, and status.

## Verification
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/molecules/drawer/DrawerButton.tsx apps/web/tests/unit/molecules/drawer-button-system-b-style-guard.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/molecules/drawer-button-system-b-style-guard.test.ts tests/unit/dashboard/spotify-connect-dialog-system-b-style-guard.test.ts tests/unit/dashboard/ReleaseProviderMatrix.test.tsx tests/unit/dashboard/release-provider-sync-banners-system-b-style-guard.test.ts tests/components/release-provider-matrix/release-table-system-b-style-guard.test.ts tests/components/release-provider-matrix/release-filter-system-b-style-guard.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- Browser proof against http://localhost:3102/demo/showcase/releases?state=disconnected: desktop/mobile screenshots saved under .gstack/design-reports/screenshots/jov-2852-spotify-connect-*.png; CTA computed background rgb(230, 230, 230), zero measured input-shell shift, no horizontal overflow, no page/console errors.
- Pre-push hook: biome check . && pnpm --filter=@jovie/web run pre-push

Linear: JOV-2852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined Spotify connect dialog with updated visual styling and improved component layout organization
  * Enhanced drawer button styling with new color scheme application and transition handling

* **Tests**
  * Introduced style consistency tests for Spotify connect dialog and drawer button components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->