### PR TITLE
fix(demo): neutralize onboarding step controls

### DIFF
--- a/apps/web/components/features/demo/OnboardingDemoContent.tsx
+++ b/apps/web/components/features/demo/OnboardingDemoContent.tsx
@@ -59,10 +59,10 @@ function StepSwitcher({
           type='button'
           onClick={() => onStepChange(step)}
           className={cn(
-            'shrink-0 rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
+            'min-h-7 shrink-0 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors duration-subtle',
             currentStep === step
-              ? 'bg-accent-token text-white'
-              : 'text-secondary-token hover:bg-surface-1 hover:text-primary-token'
+              ? 'border-(--linear-btn-primary-border) bg-btn-primary text-btn-primary-foreground shadow-button-inset hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover'
+              : 'border-transparent text-secondary-token hover:border-subtle hover:bg-surface-1 hover:text-primary-token'
           )}
         >
           {STEP_LABELS[step]}

--- a/apps/web/tests/unit/demo/onboarding-demo-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/demo/onboarding-demo-system-b-style-guard.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const appRoot = resolve(__dirname, '../../..');
+const demoOnboardingSourcePath =
+  'components/features/demo/OnboardingDemoContent.tsx';
+
+const forbiddenCentralActionPatterns = [
+  /bg-accent-token\s+text-white/,
+  /\bbg-(?:blue|purple|violet|indigo)-\d/,
+  /\b(?:from|via|to)-(?:blue|purple|violet|indigo)-\d/,
+  /\btext-white\b/,
+  /--linear-accent/,
+] as const;
+
+describe('Onboarding demo System B source contract', () => {
+  it('keeps demo step switcher actions neutral instead of accent-filled', () => {
+    const source = readFileSync(
+      resolve(appRoot, demoOnboardingSourcePath),
+      'utf8'
+    );
+
+    for (const pattern of forbiddenCentralActionPatterns) {
+      expect(
+        source,
+        `${demoOnboardingSourcePath} leaked ${pattern}`
+      ).not.toMatch(pattern);
+    }
+
+    expect(source).toContain('bg-btn-primary');
+    expect(source).toContain('text-btn-primary-foreground');
+    expect(source).toContain('hover:bg-btn-primary-hover');
+  });
+
+  it('reserves stable step switcher geometry across selected and idle states', () => {
+    const source = readFileSync(
+      resolve(appRoot, demoOnboardingSourcePath),
+      'utf8'
+    );
+
+    expect(source).toContain('min-h-7');
+    expect(source).toContain('border-transparent');
+    expect(source).toContain('border-(--linear-btn-primary-border)');
+  });
+});


### PR DESCRIPTION
## Summary
- Neutralize the demo onboarding step switcher selected state by moving it from accent-filled styling to the neutral primary button tokens.
- Add a source guard so blue/purple/accent-filled central action styling cannot return to this demo control.

## Linear
- JOV-2728

## Verification
- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/demo/onboarding-demo-system-b-style-guard.test.ts tests/unit/app/surface-elevation-guardrails.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/demo/OnboardingDemoContent.tsx apps/web/tests/unit/demo/onboarding-demo-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-commit hook: proxy guard, Biome, ESLint, staged a11y, typecheck
- pre-push hook: repo Biome, proxy guard, Tailwind guard, typecheck, Biome lint

## Integration Branch Note
This PR targets `codex/system-b-integration` so System B slices can batch before the next full main deploy.