### PR TITLE
fix(dashboard): neutralize release task actions

### DIFF
--- a/apps/web/components/features/dashboard/release-tasks/MetadataAgentPanel.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/MetadataAgentPanel.tsx
@@ -403,7 +403,7 @@ export function MetadataAgentPanel({
               void handlePrepare();
             }}
             disabled={actionState === 'loading' || isPending}
-            className='rounded-md bg-accent px-3 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60'
+            className='rounded-md border border-(--linear-btn-primary-border) bg-btn-primary px-3 py-2 text-sm font-medium text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover disabled:cursor-not-allowed disabled:opacity-60'
           >
             {latestRequest ? 'Rebuild Package' : 'Prepare Package'}
           </button>

--- a/apps/web/components/features/dashboard/release-tasks/ReleaseTaskEmptyState.tsx
+++ b/apps/web/components/features/dashboard/release-tasks/ReleaseTaskEmptyState.tsx
@@ -28,7 +28,7 @@ export function ReleaseTaskEmptyState({
         type='button'
         onClick={onSetUp}
         disabled={isLoading}
-        className='rounded-md bg-accent px-4 py-2 text-xs font-medium text-white hover:opacity-90 transition-opacity disabled:opacity-50'
+        className='rounded-md border border-(--linear-btn-primary-border) bg-btn-primary px-4 py-2 text-xs font-medium text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover disabled:cursor-not-allowed disabled:opacity-50'
       >
         {isLoading ? 'Generating...' : 'Generate Release Plan'}
       </button>

--- a/apps/web/tests/unit/dashboard/release-task-actions-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/release-task-actions-system-b-style-guard.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const appRoot = resolve(__dirname, '../../..');
+
+const actionSourcePaths = [
+  'components/features/dashboard/release-tasks/ReleaseTaskEmptyState.tsx',
+  'components/features/dashboard/release-tasks/MetadataAgentPanel.tsx',
+] as const;
+
+const forbiddenActionPatterns = [
+  /bg-accent/,
+  /text-white/,
+  /text-accent-foreground/,
+  /--linear-accent/,
+  /\bbg-(?:blue|purple|violet|indigo)-\d/,
+] as const;
+
+describe('Release task action System B source contract', () => {
+  it('keeps release workspace primary actions neutral', () => {
+    for (const sourcePath of actionSourcePaths) {
+      const source = readFileSync(resolve(appRoot, sourcePath), 'utf8');
+
+      for (const pattern of forbiddenActionPatterns) {
+        expect(source, `${sourcePath} leaked ${pattern}`).not.toMatch(pattern);
+      }
+
+      expect(source).toContain('bg-btn-primary');
+      expect(source).toContain('text-btn-primary-foreground');
+      expect(source).toContain('hover:bg-btn-primary-hover');
+    }
+  });
+
+  it('keeps release task progress as the semantic accent exception', () => {
+    const progressSource = readFileSync(
+      resolve(
+        appRoot,
+        'components/features/dashboard/release-tasks/ReleaseTaskProgressBar.tsx'
+      ),
+      'utf8'
+    );
+
+    expect(progressSource).toContain('bg-accent');
+  });
+});


### PR DESCRIPTION
## Summary
- Move release task workspace central action buttons from accent-filled styling to neutral primary button tokens.
- Preserve semantic accent usage for the release task progress bar and add a source guard for that exception.

## Linear
- JOV-2853

## Verification
- `JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/release-task-actions-system-b-style-guard.test.ts tests/unit/dashboard/ReleaseProviderMatrix.test.tsx tests/unit/app/surface-elevation-guardrails.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/dashboard/release-tasks/ReleaseTaskEmptyState.tsx apps/web/components/features/dashboard/release-tasks/MetadataAgentPanel.tsx apps/web/tests/unit/dashboard/release-task-actions-system-b-style-guard.test.ts`
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check origin/codex/system-b-integration...HEAD`
- pre-commit hook: proxy guard, Biome, ESLint, staged a11y, typecheck
- pre-push hook: repo Biome, proxy guard, Tailwind guard, typecheck, Biome lint

## Integration Branch Note
This PR targets `codex/system-b-integration`; the eventual batch PR back to `main` will carry VERSION/CHANGELOG and full deploy verification.