### PR TITLE
fix(profile): neutralize alert capture actions

### DIFF
--- a/apps/web/components/features/alerts/AlertGrowthLanding.tsx
+++ b/apps/web/components/features/alerts/AlertGrowthLanding.tsx
@@ -313,7 +313,7 @@ export function AlertGrowthLanding({
             <button
               type='submit'
               disabled={isPending}
-              className='bg-accent text-on-accent h-12 w-full rounded-[var(--profile-action-radius)] px-4 text-[14px] font-semibold disabled:opacity-60'
+              className='h-12 w-full rounded-[var(--profile-action-radius)] border border-(--linear-btn-primary-border) bg-btn-primary px-4 text-[14px] font-semibold text-btn-primary-foreground shadow-button-inset transition-colors duration-subtle hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover disabled:opacity-60'
             >
               {isPending ? 'Sending…' : 'Get alerts'}
             </button>
@@ -389,7 +389,7 @@ function ChannelToggle({
       onClick={onSelect}
       className={
         pressed
-          ? 'border-accent bg-accent/10 text-primary-token flex-1 rounded-[var(--profile-action-radius)] border px-4 py-3 text-[13px] font-semibold disabled:opacity-60'
+          ? 'border-default bg-surface-1 text-primary-token flex-1 rounded-[var(--profile-action-radius)] border px-4 py-3 text-[13px] font-semibold disabled:opacity-60'
           : 'border-subtle bg-surface-0 text-secondary-token flex-1 rounded-[var(--profile-action-radius)] border px-4 py-3 text-[13px] font-semibold disabled:opacity-60'
       }
     >

--- a/apps/web/tests/unit/components/alerts/alert-growth-landing-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/components/alerts/alert-growth-landing-system-b-style-guard.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const appRoot = resolve(__dirname, '../../../..');
+const alertGrowthLandingSourcePath =
+  'components/features/alerts/AlertGrowthLanding.tsx';
+
+const forbiddenActionPatterns = [
+  /bg-accent/,
+  /text-on-accent/,
+  /text-accent-foreground/,
+  /border-accent/,
+  /--linear-accent/,
+  /\bbg-(?:blue|purple|violet|indigo)-\d/,
+] as const;
+
+describe('AlertGrowthLanding System B source contract', () => {
+  it('keeps public alerts capture actions neutral instead of accent-filled', () => {
+    const source = readFileSync(
+      resolve(appRoot, alertGrowthLandingSourcePath),
+      'utf8'
+    );
+
+    for (const pattern of forbiddenActionPatterns) {
+      expect(
+        source,
+        `${alertGrowthLandingSourcePath} leaked ${pattern}`
+      ).not.toMatch(pattern);
+    }
+
+    expect(source).toContain('bg-btn-primary');
+    expect(source).toContain('text-btn-primary-foreground');
+    expect(source).toContain('hover:bg-btn-primary-hover');
+  });
+
+  it('keeps channel selection on neutral surfaces', () => {
+    const source = readFileSync(
+      resolve(appRoot, alertGrowthLandingSourcePath),
+      'utf8'
+    );
+
+    expect(source).toContain('border-default bg-surface-1');
+    expect(source).toContain('border-subtle bg-surface-0');
+  });
+});


### PR DESCRIPTION
## Summary
- neutralize the public alerts submit CTA with shared primary button tokens
- remove accent-filled selected channel styling while keeping stable neutral surfaces
- add a System B style guard so alert capture actions cannot regress to accent-filled buttons

Linear: JOV-2854

## Verification
- JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/components/alerts/AlertGrowthLanding.test.tsx tests/unit/components/alerts/alert-growth-landing-system-b-style-guard.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/components/features/alerts/AlertGrowthLanding.tsx apps/web/tests/unit/components/alerts/alert-growth-landing-system-b-style-guard.test.ts
- git diff --check
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- git push pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint