### PR TITLE
fix(onboarding): neutralize conversion actions

### DIFF
--- a/apps/web/app/onboarding/checkout/OnboardingCheckoutClient.tsx
+++ b/apps/web/app/onboarding/checkout/OnboardingCheckoutClient.tsx
@@ -343,7 +343,7 @@ export function OnboardingCheckoutClient({
         <Button
           onClick={handleCheckout}
           disabled={isLoading}
-          variant='accent'
+          variant='primary'
           size='xl'
           className='w-full'
           aria-busy={isLoading}

--- a/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
+++ b/apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx
@@ -141,7 +141,7 @@ export function OnboardingHandleStep({
               }
               className={cn(
                 'inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full transition-[background-color,opacity] duration-subtle',
-                'bg-accent text-white hover:bg-accent-hover',
+                'border border-(--linear-btn-primary-border) bg-btn-primary text-btn-primary-foreground shadow-button-inset hover:border-(--linear-btn-primary-hover) hover:bg-btn-primary-hover',
                 'disabled:cursor-not-allowed disabled:opacity-40'
               )}
             >

--- a/apps/web/tests/unit/onboarding/onboarding-conversion-actions-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/onboarding/onboarding-conversion-actions-system-b-style-guard.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = process.cwd();
+
+function readSource(path: string) {
+  return readFileSync(join(repoRoot, path), 'utf8');
+}
+
+describe('onboarding conversion action System B styling', () => {
+  const checkoutSource = readSource(
+    'app/onboarding/checkout/OnboardingCheckoutClient.tsx'
+  );
+  const handleSource = readSource(
+    'components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx'
+  );
+
+  it('keeps the checkout upgrade CTA on neutral primary button tokens', () => {
+    expect(checkoutSource).not.toContain("variant='accent'");
+    expect(checkoutSource).not.toContain('variant="accent"');
+    expect(checkoutSource).not.toContain('bg-accent text-accent-foreground');
+    expect(checkoutSource).not.toContain('text-on-accent');
+
+    expect(checkoutSource).toContain("variant='primary'");
+  });
+
+  it('keeps the handle claim submit button neutral and fixed-size', () => {
+    expect(handleSource).not.toContain('bg-accent text-white');
+    expect(handleSource).not.toContain('hover:bg-accent-hover');
+    expect(handleSource).not.toContain('text-accent-foreground');
+
+    expect(handleSource).toContain('h-10 w-10');
+    expect(handleSource).toContain('bg-btn-primary');
+    expect(handleSource).toContain('text-btn-primary-foreground');
+    expect(handleSource).toContain('hover:bg-btn-primary-hover');
+  });
+});


### PR DESCRIPTION
## Summary
- move the onboarding checkout upgrade CTA from the accent variant to neutral primary button styling
- move the handle claim submit button from accent fill to neutral primary button tokens while keeping its fixed circular geometry
- add a focused System B style guard for onboarding conversion actions

Linear: JOV-2877

## Verification
- JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/onboarding/onboarding-checkout.test.tsx tests/components/dashboard/organisms/onboarding-handle-step.test.tsx tests/unit/onboarding/onboarding-conversion-actions-system-b-style-guard.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/onboarding/checkout/OnboardingCheckoutClient.tsx apps/web/components/features/dashboard/organisms/onboarding/OnboardingHandleStep.tsx apps/web/tests/unit/onboarding/onboarding-conversion-actions-system-b-style-guard.test.ts
- git diff --check
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- git push pre-push hook: biome check ., next:proxy-guard, tailwind:check, typecheck, lint