### PR TITLE
fix: neutralize InlineChatArea user bubble accent fill (JOV-2895)

### DIFF
--- a/apps/web/components/features/dashboard/organisms/InlineChatArea.tsx
+++ b/apps/web/components/features/dashboard/organisms/InlineChatArea.tsx
@@ -82,9 +82,7 @@ const InlineChatMessage = memo(function InlineChatMessage({
           <div
             className={cn(
               'max-w-[85%] rounded-xl px-3 py-2',
-              message.role === 'user'
-                ? 'border border-(--linear-app-frame-seam) bg-surface-1 text-primary-token'
-                : 'border border-(--linear-app-frame-seam) bg-surface-0 text-primary-token'
+              'border border-(--linear-app-frame-seam) bg-surface-0 text-primary-token'
             )}
           >
             <div className='whitespace-pre-wrap text-app leading-relaxed'>

--- a/apps/web/tests/unit/chat/InlineChatArea.tool-rendering.test.tsx
+++ b/apps/web/tests/unit/chat/InlineChatArea.tool-rendering.test.tsx
@@ -307,7 +307,7 @@ describe('InlineChatArea tool invocation rendering', () => {
     const textNode = screen.getByText('Keep this quiet and neutral');
     const bubble = textNode.parentElement;
 
-    expect(bubble?.className).toContain('bg-surface-1');
+    expect(bubble?.className).toContain('bg-surface-0');
     expect(bubble?.className).toContain('text-primary-token');
     expect(bubble?.className).not.toContain('bg-accent');
     expect(bubble?.className).not.toContain('text-accent-foreground');


### PR DESCRIPTION
## Summary\n- Remove accent background fill for user message bubbles in InlineChatArea\n- Apply consistent bordered surface-0 styling to both user and assistant messages\n- All unit tests pass (8/8)\n- Biome check, typecheck, lint all pass\n\n## Verification\n- vitest tests/unit/chat/InlineChatArea.tool-rendering.test.tsx — 8/8 passed\n- Pre-push hooks passed\n\nCloses JOV-2895

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated message bubble styling to provide consistent visual appearance across all message types in the chat interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->