### PR TITLE
fix(auth): make /api/health/auth dev-fast aware

### DIFF
--- a/apps/web/app/api/health/auth/route.ts
+++ b/apps/web/app/api/health/auth/route.ts
@@ -1,9 +1,12 @@
 import { eq } from 'drizzle-orm';
 import { cookies, headers } from 'next/headers';
 import { NextResponse } from 'next/server';
-import { getCachedAuth } from '@/lib/auth/cached';
+import { getOptionalAuth } from '@/lib/auth/cached';
 import { getDbUser } from '@/lib/auth/session';
-import { resolveTestBypassUserId } from '@/lib/auth/test-mode';
+import {
+  isTestAuthBypassEnabled,
+  resolveTestBypassUserId,
+} from '@/lib/auth/test-mode';
 import { db } from '@/lib/db';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { captureWarning } from '@/lib/error-tracking';
@@ -12,6 +15,23 @@ import { logger } from '@/lib/utils/logger';
 export const dynamic = 'force-dynamic';
 
 const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+function resolveDevFastAuthHealthContext() {
+  const clerkMockEnabled = process.env.NEXT_PUBLIC_CLERK_MOCK === '1';
+  const clerkProxyDisabled =
+    process.env.NEXT_PUBLIC_CLERK_PROXY_DISABLED === '1';
+  const testAuthBypassEnabled = isTestAuthBypassEnabled();
+  const active =
+    clerkMockEnabled || clerkProxyDisabled || testAuthBypassEnabled;
+
+  return {
+    active,
+    clerkMockEnabled,
+    clerkProxyDisabled,
+    testAuthBypassEnabled,
+    clerkMiddleware: active ? ('bypassed' as const) : ('active' as const),
+  };
+}
 
 // Internal health check that validates auth.jwt()->>'sub' path
 // Only accessible in development unless a trusted test-bypass request is probing
@@ -38,14 +58,18 @@ export async function GET() {
       );
     }
 
-    const { userId } = await getCachedAuth();
+    const devFast = resolveDevFastAuthHealthContext();
+    const { userId } = await getOptionalAuth();
 
     if (!userId) {
       return NextResponse.json(
         {
           ok: true,
           authenticated: false,
-          message: 'No session - this is expected for anonymous requests',
+          devFast,
+          message: devFast.active
+            ? 'No session - dev-fast auth bypass active; use /api/dev/test-auth/session to probe authenticated state'
+            : 'No session - this is expected for anonymous requests',
         },
         { headers: NO_STORE_HEADERS }
       );
@@ -61,6 +85,7 @@ export async function GET() {
           authenticated: true,
           userId,
           hasProfile: false,
+          devFast,
           message:
             'User authenticated but not found in database ' +
             '(expected for new users)',
@@ -85,7 +110,10 @@ export async function GET() {
         profile: profile
           ? { id: profile.id, username: profile.username }
           : null,
-        message: 'Clerk + Drizzle auth validation successful',
+        devFast,
+        message: devFast.active
+          ? 'Dev-fast auth bypass + Drizzle auth validation successful'
+          : 'Clerk + Drizzle auth validation successful',
       },
       { headers: NO_STORE_HEADERS }
     );

--- a/apps/web/tests/unit/api/health/auth.critical.test.ts
+++ b/apps/web/tests/unit/api/health/auth.critical.test.ts
@@ -2,7 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockCookies = vi.hoisted(() => vi.fn());
 const mockHeaders = vi.hoisted(() => vi.fn());
-const mockGetCachedAuth = vi.hoisted(() => vi.fn());
+const mockGetOptionalAuth = vi.hoisted(() => vi.fn());
+const mockIsTestAuthBypassEnabled = vi.hoisted(() => vi.fn());
 const mockGetDbUser = vi.hoisted(() => vi.fn());
 const mockDbSelect = vi.hoisted(() => vi.fn());
 const mockCaptureWarning = vi.hoisted(() => vi.fn());
@@ -12,12 +13,15 @@ vi.mock('next/headers', () => ({
   cookies: mockCookies,
   headers: mockHeaders,
 }));
-vi.mock('@/lib/auth/cached', () => ({ getCachedAuth: mockGetCachedAuth }));
+vi.mock('@/lib/auth/cached', () => ({
+  getOptionalAuth: mockGetOptionalAuth,
+}));
 vi.mock('@/lib/auth/session', () => ({ getDbUser: mockGetDbUser }));
 vi.mock('@/lib/db', () => ({ db: { select: mockDbSelect } }));
 vi.mock('@/lib/db/schema/profiles', () => ({ creatorProfiles: {} }));
 vi.mock('@/lib/error-tracking', () => ({ captureWarning: mockCaptureWarning }));
 vi.mock('@/lib/auth/test-mode', () => ({
+  isTestAuthBypassEnabled: mockIsTestAuthBypassEnabled,
   resolveTestBypassUserId: mockResolveTestBypassUserId,
 }));
 
@@ -29,7 +33,8 @@ describe('@critical GET /api/health/auth', () => {
     mockHeaders.mockResolvedValue({ get: vi.fn().mockReturnValue(null) });
     mockCookies.mockResolvedValue({ get: vi.fn().mockReturnValue(undefined) });
     mockResolveTestBypassUserId.mockReturnValue(null);
-    mockGetCachedAuth.mockResolvedValue({ userId: null });
+    mockIsTestAuthBypassEnabled.mockReturnValue(false);
+    mockGetOptionalAuth.mockResolvedValue({ userId: null });
   });
 
   afterEach(() => {
@@ -48,7 +53,7 @@ describe('@critical GET /api/health/auth', () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('VERCEL_ENV', 'preview');
     mockResolveTestBypassUserId.mockReturnValue('user_bypass');
-    mockGetCachedAuth.mockResolvedValue({ userId: 'user_bypass' });
+    mockGetOptionalAuth.mockResolvedValue({ userId: 'user_bypass' });
     mockGetDbUser.mockResolvedValue(null);
 
     const { GET } = await import('@/app/api/health/auth/route');
@@ -76,8 +81,39 @@ describe('@critical GET /api/health/auth', () => {
     expect(response.status).toBe(403);
   });
 
+  it('returns dev-fast health response when Clerk middleware is bypassed', async () => {
+    vi.stubEnv('NEXT_PUBLIC_CLERK_MOCK', '1');
+    vi.stubEnv('NEXT_PUBLIC_CLERK_PROXY_DISABLED', '1');
+    vi.stubEnv('E2E_USE_TEST_AUTH_BYPASS', '1');
+    mockIsTestAuthBypassEnabled.mockReturnValue(true);
+    mockGetOptionalAuth.mockResolvedValue({
+      userId: null,
+      sessionId: null,
+      orgId: null,
+    });
+
+    const { GET } = await import('@/app/api/health/auth/route');
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        ok: true,
+        authenticated: false,
+        devFast: expect.objectContaining({
+          active: true,
+          clerkMockEnabled: true,
+          clerkProxyDisabled: true,
+          testAuthBypassEnabled: true,
+          clerkMiddleware: 'bypassed',
+        }),
+        message: expect.stringContaining('dev-fast auth bypass active'),
+      })
+    );
+  });
+
   it('captures warning when auth check throws', async () => {
-    mockGetCachedAuth.mockRejectedValue(new Error('Auth unavailable'));
+    mockGetOptionalAuth.mockRejectedValue(new Error('Auth unavailable'));
 
     const { GET } = await import('@/app/api/health/auth/route');
     const response = await GET();


### PR DESCRIPTION
## Summary

Fixes JOV-2750: `/api/health/auth` returned 500 under dev-fast defaults because it called `getCachedAuth()` → Clerk `auth()` on a route where `clerkMiddleware()` is intentionally bypassed.

- Switch probe to `getOptionalAuth()` so missing Clerk middleware context returns a signed-out health response instead of throwing
- Add `devFast` metadata (`clerkMockEnabled`, `clerkProxyDisabled`, `testAuthBypassEnabled`, `clerkMiddleware`) for local diagnostics
- Point anonymous dev-fast probes at `/api/dev/test-auth/session` for authenticated checks

## Test plan

- [x] `pnpm exec vitest run tests/unit/api/health/auth.critical.test.ts`
- [x] `pnpm run typecheck` (apps/web)
- [x] `pnpm exec biome check --write` on edited files
- [x] New unit test: dev-fast bypass returns 200 with `devFast.active: true`

## Linear

<!-- linear-issue-id:JOV-2750 -->

Closes JOV-2750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health check endpoint now detects and reports active authentication bypass mechanisms, including Clerk-related configurations and test authentication status, with detailed diagnostic information in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->