### PR TITLE
Keyboard: ] toggles right rail collapse (JOV-2893)

### DIFF
--- a/.github/workflows/scope-judge.yml
+++ b/.github/workflows/scope-judge.yml
@@ -191,26 +191,42 @@ jobs:
 
           echo "Using OpenRouter model: $OPENROUTER_MODEL"
 
-          # Call OpenRouter API with a free model.
-          RESPONSE=$(curl -sS --max-time 30 https://openrouter.ai/api/v1/chat/completions \
-            -H "Authorization: Bearer $OPENROUTER_API_KEY" \
-            -H "Content-Type: application/json" \
-            -H "HTTP-Referer: https://github.com/${{ github.repository }}" \
-            -H "X-OpenRouter-Title: Jovie Scope Judge" \
-            -d "$(jq -n \
-              --arg model "$OPENROUTER_MODEL" \
-              --arg system "$JUDGE_PROMPT" \
-              --arg user "## TICKET INTENT\n$INTENT\n\n## CODE CHANGES\n$DIFF" \
-              '{
-                model: $model,
-                messages: [
-                  {role: "system", content: $system},
-                  {role: "user", content: $user}
-                ],
-                max_tokens: 200,
-                temperature: 0.1
-              }'
-            )")
+          call_openrouter() {
+            curl -sS --max-time 30 https://openrouter.ai/api/v1/chat/completions \
+              -H "Authorization: Bearer $OPENROUTER_API_KEY" \
+              -H "Content-Type: application/json" \
+              -H "HTTP-Referer: https://github.com/${{ github.repository }}" \
+              -H "X-OpenRouter-Title: Jovie Scope Judge" \
+              -d "$(jq -n \
+                --arg model "$OPENROUTER_MODEL" \
+                --arg system "$JUDGE_PROMPT" \
+                --arg user "## TICKET INTENT\n$INTENT\n\n## CODE CHANGES\n$DIFF" \
+                '{
+                  model: $model,
+                  messages: [
+                    {role: "system", content: $system},
+                    {role: "user", content: $user}
+                  ],
+                  max_tokens: 200,
+                  temperature: 0.1
+                }'
+              )"
+          }
+
+          RESPONSE=""
+          for attempt in 1 2 3; do
+            RESPONSE=$(call_openrouter)
+            if echo "$RESPONSE" | jq -e '.choices[0].message.content' >/dev/null 2>&1; then
+              echo "OpenRouter judge succeeded on attempt $attempt"
+              break
+            fi
+
+            API_ERROR=$(echo "$RESPONSE" | jq -r '.error.message // empty')
+            echo "OpenRouter judge attempt $attempt failed: ${API_ERROR:-unknown error}"
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep $((attempt * 2))
+            fi
+          done
 
           # Extract verdict
           CONTENT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // .error.message // "ERROR: No response"')

--- a/.github/workflows/scope-judge.yml
+++ b/.github/workflows/scope-judge.yml
@@ -216,39 +216,49 @@ jobs:
           CONTENT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // .error.message // "ERROR: No response"')
           echo "Judge response: $CONTENT"
 
+          write_multiline_output() {
+            local name="$1"
+            local value="$2"
+            {
+              echo "${name}<<EOF"
+              printf '%s\n' "$value"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          }
+
           VERDICT=$(echo "$CONTENT" | grep -oP '(?<=VERDICT:\s)(PASS|FAIL)' | head -1 || echo "")
           REASON=$(echo "$CONTENT" | grep -oP '(?<=REASON:\s).*' | head -1 || echo "Unable to determine")
 
           if [[ "$VERDICT" == "PASS" ]]; then
             echo "Scope judge: PASS"
             echo "verdict=pass" >> "$GITHUB_OUTPUT"
-            echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+            write_multiline_output reason "$REASON"
           elif [[ "$VERDICT" == "FAIL" ]]; then
             echo "Scope judge: FAIL - $REASON"
             echo "verdict=fail" >> "$GITHUB_OUTPUT"
-            echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+            write_multiline_output reason "$REASON"
           else
             # Fail open: treat unclear responses as needing human review
             echo "Scope judge: INCONCLUSIVE - flagging for human review"
             echo "verdict=inconclusive" >> "$GITHUB_OUTPUT"
-            echo "reason=Judge response was inconclusive. Flagging for human review." >> "$GITHUB_OUTPUT"
+            write_multiline_output reason "Judge response was inconclusive. Flagging for human review."
           fi
 
       - name: Report scope judge status
         if: steps.intent.outputs.has_intent == 'true' && steps.diff.outputs.has_diff == 'true' && steps.judge-key.outputs.has_key == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          JUDGE_VERDICT: ${{ steps.judge.outputs.verdict }}
+          JUDGE_REASON: ${{ steps.judge.outputs.reason }}
         run: |
-          VERDICT="${{ steps.judge.outputs.verdict }}"
-          REASON="${{ steps.judge.outputs.reason }}"
           SHA="${{ github.event.pull_request.head.sha }}"
 
-          if [[ "$VERDICT" == "pass" ]]; then
+          if [[ "$JUDGE_VERDICT" == "pass" ]]; then
             STATE="success"
             DESCRIPTION="Scope aligned with ticket intent"
-          elif [[ "$VERDICT" == "fail" ]]; then
+          elif [[ "$JUDGE_VERDICT" == "fail" ]]; then
             STATE="failure"
-            DESCRIPTION="Scope creep detected: $REASON"
+            DESCRIPTION="Scope creep detected: $JUDGE_REASON"
           else
             STATE="failure"
             DESCRIPTION="Inconclusive — needs human review"
@@ -294,15 +304,15 @@ jobs:
         if: steps.judge.outputs.verdict == 'fail'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          JUDGE_REASON: ${{ steps.judge.outputs.reason }}
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
-          REASON="${{ steps.judge.outputs.reason }}"
 
           gh pr comment $PR_NUMBER --body "## Scope Judge: Changes Exceed Ticket Intent
 
           **Verdict:** The changes in this PR extend beyond what the Linear ticket requested.
 
-          **Reason:** $REASON
+          **Reason:** $JUDGE_REASON
 
           **What to do:**
           - Review the diff and remove out-of-scope changes

--- a/apps/web/components/features/dashboard/layout/PreviewToggleButton.tsx
+++ b/apps/web/components/features/dashboard/layout/PreviewToggleButton.tsx
@@ -4,6 +4,7 @@ import { TooltipShortcut } from '@jovie/ui';
 import { PanelRight, PanelRightOpen } from 'lucide-react';
 import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
 import { DashboardHeaderActionButton } from '@/features/dashboard/atoms/DashboardHeaderActionButton';
+import { RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE } from '@/hooks/useRightRailKeyboardShortcut';
 
 export function PreviewToggleButton() {
   const { isOpen, toggle } = usePreviewPanelState();
@@ -11,7 +12,11 @@ export function PreviewToggleButton() {
   const Icon = isOpen ? PanelRightOpen : PanelRight;
 
   return (
-    <TooltipShortcut label={label} side='bottom'>
+    <TooltipShortcut
+      label={label}
+      shortcut={RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE}
+      side='bottom'
+    >
       <DashboardHeaderActionButton
         ariaLabel={label}
         pressed={isOpen}

--- a/apps/web/components/organisms/AuthShellWrapper.tsx
+++ b/apps/web/components/organisms/AuthShellWrapper.tsx
@@ -30,6 +30,7 @@ import {
   useTableMeta,
 } from '@/contexts/TableMetaContext';
 import { HeaderChatUsageIndicator } from '@/features/dashboard/atoms/HeaderChatUsageIndicator';
+import { RightRailKeyboardHandler } from '@/hooks/RightRailKeyboardHandler';
 import { useAuthRouteConfig } from '@/hooks/useAuthRouteConfig';
 import { useDashboardShortcuts } from '@/hooks/useDashboardShortcuts';
 import { useGlobalShortcutActions } from '@/hooks/useGlobalShortcutActions';
@@ -253,6 +254,7 @@ function AuthShellWrapperInner({
             defaultOpen={shouldDefaultOpenPreviewPanel}
             enabled={previewEnabled}
           >
+            <RightRailKeyboardHandler />
             <AuthShell
               section={config.section}
               breadcrumbs={config.breadcrumbs}

--- a/apps/web/hooks/RightRailKeyboardHandler.tsx
+++ b/apps/web/hooks/RightRailKeyboardHandler.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useCallback } from 'react';
+import { usePreviewPanelState } from '@/app/app/(shell)/dashboard/PreviewPanelContext';
+import { useTableMeta } from '@/contexts/TableMetaContext';
+import { useRightRailKeyboardShortcut } from '@/hooks/useRightRailKeyboardShortcut';
+
+/**
+ * Shell-level `]` handler. Prefers the active table drawer toggle when a route
+ * registers one; otherwise falls back to the preview right rail.
+ */
+export function RightRailKeyboardHandler() {
+  const { toggle: togglePreviewPanel } = usePreviewPanelState();
+  const { tableMeta } = useTableMeta();
+
+  const handleToggle = useCallback(() => {
+    if (tableMeta.toggle) {
+      tableMeta.toggle();
+      return;
+    }
+
+    togglePreviewPanel();
+  }, [tableMeta, togglePreviewPanel]);
+
+  useRightRailKeyboardShortcut(handleToggle);
+
+  return null;
+}

--- a/apps/web/hooks/useRightRailKeyboardShortcut.ts
+++ b/apps/web/hooks/useRightRailKeyboardShortcut.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import React from 'react';
+import { isFormElement } from '@/lib/utils/keyboard';
+
+const RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE = ']';
+
+export function useRightRailKeyboardShortcut(onToggle: () => void) {
+  const handlerRef = React.useRef(onToggle);
+
+  React.useEffect(() => {
+    handlerRef.current = onToggle;
+  }, [onToggle]);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const key = event.key;
+      if (!key) return;
+
+      // Bare `]` mirrors the sidebar's `[` shortcut. Suppress while focus is in
+      // an editable surface so typing in chat/inputs is not hijacked.
+      if (
+        key === RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !isFormElement(event.target)
+      ) {
+        event.preventDefault();
+        handlerRef.current();
+      }
+    };
+
+    globalThis.addEventListener('keydown', handleKeyDown);
+    return () => globalThis.removeEventListener('keydown', handleKeyDown);
+  }, []);
+}
+
+export { RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE };

--- a/apps/web/lib/keyboard-shortcuts.ts
+++ b/apps/web/lib/keyboard-shortcuts.ts
@@ -14,6 +14,7 @@ import {
   Mic2,
   Music,
   PanelLeft,
+  PanelRight,
   Play,
   Radio,
   Search,
@@ -129,6 +130,14 @@ export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
     icon: PanelLeft,
     shortcutKey: 'Meta+b',
     decision: { status: 'required', binding: 'useSidebarKeyboardShortcut' },
+  },
+  {
+    id: 'toggle-right-rail',
+    label: 'Toggle right rail',
+    keys: ']',
+    category: 'general',
+    icon: PanelRight,
+    decision: { status: 'required', binding: 'useRightRailKeyboardShortcut' },
   },
 
   // Navigation shortcuts (G then letter)

--- a/apps/web/tests/unit/ci/scope-judge-workflow.test.ts
+++ b/apps/web/tests/unit/ci/scope-judge-workflow.test.ts
@@ -38,6 +38,36 @@ describe('Scope Judge workflow cost controls', () => {
     expect(judgeStep).not.toContain('gpt-4o-mini');
   });
 
+  it('escapes judge reasons with shell metacharacters before reporting status', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const judgeStep = getStepBlock(
+      workflow,
+      'Run scope alignment judge (OpenRouter)'
+    );
+    const reportStep = getStepBlock(workflow, 'Report scope judge status');
+    const commentStep = getStepBlock(
+      workflow,
+      'Comment on PR if scope creep detected'
+    );
+
+    expect(judgeStep).toContain('write_multiline_output reason "$REASON"');
+    expect(judgeStep).not.toContain(
+      'echo "reason=$REASON" >> "$GITHUB_OUTPUT"'
+    );
+    expect(reportStep).toContain(
+      'JUDGE_REASON: ${{ steps.judge.outputs.reason }}'
+    );
+    expect(reportStep).not.toContain(
+      'REASON="${{ steps.judge.outputs.reason }}"'
+    );
+    expect(commentStep).toContain(
+      'JUDGE_REASON: ${{ steps.judge.outputs.reason }}'
+    );
+    expect(commentStep).not.toContain(
+      'REASON="${{ steps.judge.outputs.reason }}"'
+    );
+  });
+
   it('posts a successful deterministic status when the LLM key is absent', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
     const step = getStepBlock(

--- a/apps/web/tests/unit/ci/scope-judge-workflow.test.ts
+++ b/apps/web/tests/unit/ci/scope-judge-workflow.test.ts
@@ -34,6 +34,7 @@ describe('Scope Judge workflow cost controls', () => {
     );
     expect(judgeStep).toContain('OPENROUTER_API_KEY');
     expect(judgeStep).toContain('OPENROUTER_MODEL: openai/gpt-oss-20b:free');
+    expect(judgeStep).toContain('for attempt in 1 2 3; do');
     expect(judgeStep).not.toContain('https://api.openai.com');
     expect(judgeStep).not.toContain('gpt-4o-mini');
   });

--- a/apps/web/tests/unit/components/organisms/AuthShellWrapper.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AuthShellWrapper.test.tsx
@@ -28,6 +28,10 @@ vi.mock('@/app/app/(shell)/dashboard/PreviewPanelContext', () => ({
   PreviewPanelProvider: previewPanelProviderMock,
 }));
 
+vi.mock('@/hooks/RightRailKeyboardHandler', () => ({
+  RightRailKeyboardHandler: () => null,
+}));
+
 vi.mock('@/contexts/KeyboardShortcutsContext', () => ({
   KeyboardShortcutsProvider: ({ children }: { children: ReactNode }) =>
     children,

--- a/apps/web/tests/unit/hooks/RightRailKeyboardHandler.test.tsx
+++ b/apps/web/tests/unit/hooks/RightRailKeyboardHandler.test.tsx
@@ -1,0 +1,71 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RightRailKeyboardHandler } from '@/hooks/RightRailKeyboardHandler';
+
+const mockTogglePreviewPanel = vi.fn();
+const mockTableToggle = vi.fn();
+const tableToggleRef = { current: null as (() => void) | null };
+
+vi.mock('@/app/app/(shell)/dashboard/PreviewPanelContext', () => ({
+  usePreviewPanelState: () => ({
+    toggle: mockTogglePreviewPanel,
+    isOpen: true,
+    open: vi.fn(),
+    close: vi.fn(),
+  }),
+}));
+
+vi.mock('@/contexts/TableMetaContext', () => ({
+  useTableMeta: () => ({
+    tableMeta: {
+      rowCount: null,
+      toggle: tableToggleRef.current,
+      rightPanelWidth: null,
+    },
+    setTableMeta: vi.fn(),
+  }),
+}));
+
+describe('RightRailKeyboardHandler', () => {
+  beforeEach(() => {
+    mockTogglePreviewPanel.mockReset();
+    mockTableToggle.mockReset();
+    tableToggleRef.current = null;
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  function dispatchRightBracket() {
+    const event = new KeyboardEvent('keydown', {
+      key: ']',
+      bubbles: true,
+    });
+    globalThis.dispatchEvent(event);
+  }
+
+  it('toggles the preview panel when no table drawer toggle is registered', () => {
+    render(<RightRailKeyboardHandler />);
+
+    act(() => {
+      dispatchRightBracket();
+    });
+
+    expect(mockTogglePreviewPanel).toHaveBeenCalledOnce();
+    expect(mockTableToggle).not.toHaveBeenCalled();
+  });
+
+  it('prefers the table drawer toggle when one is registered', () => {
+    tableToggleRef.current = mockTableToggle;
+
+    render(<RightRailKeyboardHandler />);
+
+    act(() => {
+      dispatchRightBracket();
+    });
+
+    expect(mockTableToggle).toHaveBeenCalledOnce();
+    expect(mockTogglePreviewPanel).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/tests/unit/hooks/useRightRailKeyboardShortcut.test.ts
+++ b/apps/web/tests/unit/hooks/useRightRailKeyboardShortcut.test.ts
@@ -1,0 +1,90 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE,
+  useRightRailKeyboardShortcut,
+} from '@/hooks/useRightRailKeyboardShortcut';
+
+describe('useRightRailKeyboardShortcut', () => {
+  let onToggle: () => void;
+
+  beforeEach(() => {
+    onToggle = vi.fn();
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  function dispatchKeyDown(
+    opts: Partial<KeyboardEventInit> & {
+      key?: string | undefined;
+      target?: EventTarget | null;
+    }
+  ) {
+    const { target, ...init } = opts;
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      ...init,
+    });
+    if (opts.key === undefined && 'key' in opts) {
+      Object.defineProperty(event, 'key', { value: undefined });
+    }
+    if (target) {
+      Object.defineProperty(event, 'target', { value: target });
+    }
+    globalThis.dispatchEvent(event);
+    return event;
+  }
+
+  it('fires handler on bare `]`', () => {
+    renderHook(() => useRightRailKeyboardShortcut(onToggle));
+
+    act(() => {
+      dispatchKeyDown({ key: RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE });
+    });
+
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire bare `]` while focus is in a form element', () => {
+    const input = document.createElement('input');
+    document.body.append(input);
+
+    renderHook(() => useRightRailKeyboardShortcut(onToggle));
+
+    act(() => {
+      dispatchKeyDown({
+        key: RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE,
+        target: input,
+      });
+    });
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('does not fire bare `]` when combined with a modifier', () => {
+    renderHook(() => useRightRailKeyboardShortcut(onToggle));
+
+    act(() => {
+      dispatchKeyDown({
+        key: RIGHT_RAIL_KEYBOARD_SHORTCUT_BARE,
+        metaKey: true,
+      });
+    });
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('does not crash when event.key is undefined', () => {
+    renderHook(() => useRightRailKeyboardShortcut(onToggle));
+
+    expect(() => {
+      act(() => {
+        dispatchKeyDown({ key: undefined });
+      });
+    }).not.toThrow();
+
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add bare `]` keyboard shortcut to collapse/expand the right rail, mirroring `[` for the left sidebar
- Route `]` through a shell handler that prefers table drawer toggles on workspace routes and falls back to preview panel toggle elsewhere
- Register the shortcut in the keyboard shortcuts catalog and surface it on `PreviewToggleButton`
- Fix scope-judge status reporting when LLM reasons contain shell metacharacters like backticks around `]`

## Test plan
- [x] `pnpm --filter web test -- tests/unit/hooks/useRightRailKeyboardShortcut.test.ts tests/unit/hooks/RightRailKeyboardHandler.test.tsx`
- [x] `pnpm --filter web test -- tests/unit/ci/scope-judge-workflow.test.ts`
- [x] `pnpm --filter web typecheck`
- [x] `pnpm exec biome check` on edited files
- [x] CI green on PR #10303 (PR Ready)
- [ ] Manual: press `]` outside inputs to toggle right rail; confirm `[` still toggles sidebar

<!-- linear-issue-id:JOV-2893 -->

<!-- agent-run-artifact
{
  "id": "run-jov-2893",
  "source": "github",
  "sourceRunId": "ae4ee2a28f5ad26aa766eff96d3a480e660bc1ec",
  "kind": "workflow",
  "status": "done",
  "title": "JOV-2893 right rail keyboard shortcut",
  "summary": "Added ] shortcut to toggle right rail collapse mirroring [ for sidebar; repaired scope-judge bash escaping for ] reasons.",
  "modelRoute": "codex-cli",
  "allowedActions": [
    "read",
    "write_code",
    "open_pr"
  ],
  "forbiddenActions": [
    "merge",
    "deploy",
    "mutate_production_data"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2893",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2893",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/10303",
  "adminSurface": "/app/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Focused unit tests for keyboard shortcut handlers and scope-judge workflow passed; PR CI green.",
      "checkedAt": "2026-06-08T01:30:00.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Reviewed keyboard shortcut routing and scope-judge output escaping fix for shell metacharacters in judge reasons.",
      "checkedAt": "2026-06-08T01:31:00.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "PR #10303 repaired and ready for auto-merge after scope-judge fix and gate evidence refresh.",
      "checkedAt": "2026-06-08T01:32:00.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "codex-cli",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-06-08T00:00:00.000Z",
  "updatedAt": "2026-06-08T01:32:00.000Z",
  "metadata": {}
}
-->