### PR TITLE
feat(merch): simplify pricing UI around sale price and profit

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -1078,7 +1078,7 @@ const AssetCard = memo(function AssetCard({
             </div>
             <span className='system-b-library-card-count shrink-0 tabular-nums'>
               {getLibraryItemKind(asset) === 'merch'
-                ? (asset.retailPriceLabel ?? 'Merch')
+                ? (asset.salePriceLabel ?? 'Merch')
                 : formatCompactCount(asset.providerCount)}
             </span>
           </div>
@@ -1753,16 +1753,12 @@ function AssetDrawer({
                 {isMerch ? (
                   <>
                     <MetadataRow
-                      label='Price'
-                      value={current.retailPriceLabel ?? 'No Price'}
+                      label='Sale Price'
+                      value={current.salePriceLabel ?? 'No Price'}
                     />
                     <MetadataRow
-                      label='Artist Share'
-                      value={current.artistPayoutLabel ?? 'No Estimate'}
-                    />
-                    <MetadataRow
-                      label='Jovie Margin'
-                      value={current.jovieMarginLabel ?? 'No Estimate'}
+                      label='Profit'
+                      value={current.profitLabel ?? 'No Estimate'}
                     />
                     <MetadataRow
                       label='Sellability'

--- a/apps/web/app/app/(shell)/library/library-data.ts
+++ b/apps/web/app/app/(shell)/library/library-data.ts
@@ -54,9 +54,8 @@ export interface LibraryReleaseAsset {
   readonly primaryActionLabel?: string;
   readonly primaryActionHref?: string | null;
   readonly productType?: string;
-  readonly retailPriceLabel?: string;
-  readonly artistPayoutLabel?: string;
-  readonly jovieMarginLabel?: string;
+  readonly salePriceLabel?: string;
+  readonly profitLabel?: string;
   readonly sellabilityLabel?: string;
   readonly description?: string;
   readonly createdAt?: string;
@@ -188,11 +187,8 @@ export function buildLibraryMerchAssets(
       primaryActionLabel: 'Open Merch',
       primaryActionHref: '/app/library?view=merch',
       productType: card.productType,
-      retailPriceLabel: formatMerchCents(card.retailPriceCents),
-      artistPayoutLabel: formatMerchCents(
-        card.artistPayoutPerUnitEstimateCents
-      ),
-      jovieMarginLabel: formatMerchCents(card.jovieMarginPerUnitEstimateCents),
+      salePriceLabel: formatMerchCents(card.retailPriceCents),
+      profitLabel: formatMerchCents(card.artistPayoutPerUnitEstimateCents),
       sellabilityLabel: card.sellable
         ? 'Ready To Sell'
         : (card.sellabilityReasons?.[0] ?? 'Blocked'),

--- a/apps/web/components/features/profile/ProfileMerchCard.test.tsx
+++ b/apps/web/components/features/profile/ProfileMerchCard.test.tsx
@@ -88,6 +88,7 @@ describe('ProfileMerchCard', () => {
       screen.getByRole('heading', { name: 'Static Bloom Tee' })
     ).toBeInTheDocument();
     expect(screen.getByText('$45.00')).toBeInTheDocument();
+    expect(screen.getByText('Profit $11.87')).toBeInTheDocument();
     expect(screen.getByAltText('Static Bloom Tee')).toHaveAttribute(
       'src',
       'https://cdn.test/mockup.jpg'

--- a/apps/web/components/features/profile/ProfileMerchCard.tsx
+++ b/apps/web/components/features/profile/ProfileMerchCard.tsx
@@ -60,21 +60,32 @@ export function ProfileMerchCard({
           </div>
           <div className='mt-2 flex items-center justify-between gap-2'>
             {(() => {
-              const p = getMerchPriceDisplay(card.retailPriceCents); // gh-9802 simplify: sale/profit hero via shared helper (explicit, ready for salePriceCents + creatorProfit)
+              const p = getMerchPriceDisplay(
+                card.retailPriceCents,
+                null,
+                card.pricing.artistPayoutPerUnitEstimateCents
+              );
               return (
-                <span className='text-[13px] font-semibold text-white'>
-                  {p.isOnSale ? (
-                    <>
-                      <span className='text-emerald-400'>Sale </span>
-                      {p.displayPrice}
-                      <span className='ml-1 text-[10px] line-through text-white/50'>
-                        {p.originalPrice}
-                      </span>
-                    </>
-                  ) : (
-                    p.displayPrice
-                  )}
-                </span>
+                <div className='min-w-0'>
+                  <span className='text-[13px] font-semibold text-white'>
+                    {p.isOnSale ? (
+                      <>
+                        <span className='text-emerald-400'>Sale </span>
+                        {p.displayPrice}
+                        <span className='ml-1 text-[10px] line-through text-white/50'>
+                          {p.originalPrice}
+                        </span>
+                      </>
+                    ) : (
+                      p.displayPrice
+                    )}
+                  </span>
+                  {p.creatorProfit ? (
+                    <p className='mt-0.5 text-[11px] text-white/58'>
+                      Profit {p.creatorProfit}
+                    </p>
+                  ) : null}
+                </div>
               );
             })()}
             <span className='rounded-full border border-white/12 px-2 py-1 text-[11px] font-medium text-white/78'>

--- a/apps/web/components/jovie/components/ChatMerchCard.test.tsx
+++ b/apps/web/components/jovie/components/ChatMerchCard.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -51,10 +51,29 @@ const generationResult: ChatMerchGenerationResult = {
       concept: 'A premium shirt with restrained artist typography.',
       mockup_urls: ['https://cdn.test/signal.jpg'],
       price_recommendation: {
-        retail_price: '$45.00',
-        artist_share: '$11.87',
-        jovie_share: '$11.87',
-        minimum_jovie_margin: '$5.00',
+        sale_price: '$45.00',
+        profit: '$11.87',
+        margin_preset: 'standard',
+        presets: [
+          {
+            preset: 'safe',
+            label: 'Safe',
+            sale_price: '$42.00',
+            profit: '$10.50',
+          },
+          {
+            preset: 'standard',
+            label: 'Standard',
+            sale_price: '$45.00',
+            profit: '$11.87',
+          },
+          {
+            preset: 'aggressive',
+            label: 'Aggressive',
+            sale_price: '$49.00',
+            profit: '$13.25',
+          },
+        ],
       },
       sellability: { sellable: true, reasons: [] },
       production_warnings: [],
@@ -68,10 +87,29 @@ const generationResult: ChatMerchGenerationResult = {
       concept: 'A heavier item waiting on provider pricing.',
       mockup_urls: ['https://cdn.test/hoodie.jpg'],
       price_recommendation: {
-        retail_price: '$58.00',
-        artist_share: '$0.00',
-        jovie_share: '$0.00',
-        minimum_jovie_margin: '$5.80',
+        sale_price: '$58.00',
+        profit: '$0.00',
+        margin_preset: 'standard',
+        presets: [
+          {
+            preset: 'safe',
+            label: 'Safe',
+            sale_price: '$55.00',
+            profit: '$0.00',
+          },
+          {
+            preset: 'standard',
+            label: 'Standard',
+            sale_price: '$58.00',
+            profit: '$0.00',
+          },
+          {
+            preset: 'aggressive',
+            label: 'Aggressive',
+            sale_price: '$62.00',
+            profit: '$0.00',
+          },
+        ],
       },
       sellability: {
         sellable: false,
@@ -86,9 +124,15 @@ describe('ChatMerchCard', () => {
   it('shows merch option economics and disables publish when blocked', () => {
     render(<ChatMerchOptionsCard result={generationResult} />);
 
-    expect(screen.getByText('Price $45.00')).toBeInTheDocument();
-    expect(screen.getByText('Jovie $11.87')).toBeInTheDocument();
-    expect(screen.getByText('Floor $5.80')).toBeInTheDocument();
+    const optionCards = screen.getAllByTestId('chat-merch-option-card');
+    const sellableCard = within(optionCards[0]);
+    expect(sellableCard.getByTestId('merch-pricing-summary')).toHaveTextContent(
+      '$45.00'
+    );
+    expect(sellableCard.getByTestId('merch-pricing-summary')).toHaveTextContent(
+      '$11.87'
+    );
+    expect(sellableCard.getByRole('radio', { name: 'Standard' })).toBeChecked();
     expect(screen.getByText('Draft')).toBeInTheDocument();
     expect(
       screen.getByText(

--- a/apps/web/components/jovie/components/ChatMerchCard.tsx
+++ b/apps/web/components/jovie/components/ChatMerchCard.tsx
@@ -4,7 +4,11 @@ import { Button } from '@jovie/ui';
 import { AlertTriangle, CheckCircle2, ExternalLink, Shirt } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useCallback } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import { MerchPricingPresetPicker } from '@/components/molecules/MerchPricingPresetPicker';
+import { MerchPricingSummary } from '@/components/molecules/MerchPricingSummary';
+import type { MerchMarginPreset } from '@/lib/merch/pricing';
+import { MERCH_DEFAULT_MARGIN_PRESET } from '@/lib/merch/pricing';
 import { cn } from '@/lib/utils';
 import { ChatGenerationArtifactSurface } from './ChatGenerationArtifactSurface';
 
@@ -17,12 +21,16 @@ interface MerchGenerationOption {
   readonly colorway?: string;
   readonly available_sizes?: readonly string[];
   readonly price_recommendation?: {
-    readonly retail_price?: string;
-    readonly estimated_gross_margin?: string;
-    readonly artist_share?: string;
-    readonly jovie_share?: string;
-    readonly minimum_jovie_margin?: string;
-    readonly target_jovie_margin?: string;
+    readonly sale_price?: string;
+    readonly profit?: string;
+    readonly margin_preset?: MerchMarginPreset;
+    readonly presets?: readonly {
+      readonly preset: MerchMarginPreset;
+      readonly label: string;
+      readonly sale_price: string;
+      readonly profit: string;
+    }[];
+    readonly estimated_printful_cost?: string;
   };
   readonly sellability?: {
     readonly sellable: boolean;
@@ -95,6 +103,63 @@ function optionPrompt(
   return `${action} merch option ${option.option_number} from generation ${generationId}.`;
 }
 
+function MerchOptionPricing({
+  recommendation,
+}: {
+  readonly recommendation: MerchGenerationOption['price_recommendation'];
+}) {
+  const presetOptions = useMemo(
+    () =>
+      (recommendation?.presets ?? []).map(preset => ({
+        preset: preset.preset,
+        label: preset.label,
+        salePrice: preset.sale_price,
+        profit: preset.profit,
+      })),
+    [recommendation?.presets]
+  );
+  const [selectedPreset, setSelectedPreset] = useState<MerchMarginPreset>(
+    recommendation?.margin_preset ?? MERCH_DEFAULT_MARGIN_PRESET
+  );
+  const activeQuote = useMemo(() => {
+    const selected = presetOptions.find(
+      option => option.preset === selectedPreset
+    );
+    if (selected) return selected;
+    return {
+      preset: MERCH_DEFAULT_MARGIN_PRESET,
+      label: 'Standard',
+      salePrice: recommendation?.sale_price ?? '$0.00',
+      profit: recommendation?.profit ?? '$0.00',
+    };
+  }, [
+    presetOptions,
+    recommendation?.profit,
+    recommendation?.sale_price,
+    selectedPreset,
+  ]);
+
+  if (!recommendation?.sale_price && !recommendation?.profit) {
+    return null;
+  }
+
+  return (
+    <div className='space-y-1.5'>
+      {presetOptions.length > 1 ? (
+        <MerchPricingPresetPicker
+          options={presetOptions}
+          value={selectedPreset}
+          onChange={setSelectedPreset}
+        />
+      ) : null}
+      <MerchPricingSummary
+        salePrice={activeQuote.salePrice}
+        profit={activeQuote.profit}
+      />
+    </div>
+  );
+}
+
 export function ChatMerchOptionsCard({
   result,
 }: {
@@ -161,28 +226,9 @@ export function ChatMerchOptionsCard({
                 <p className='line-clamp-3 min-h-[54px] text-[11.5px] leading-[18px] text-secondary-token'>
                   {option.concept}
                 </p>
-                <div className='grid min-h-[58px] grid-cols-2 gap-1'>
-                  {option.price_recommendation?.retail_price ? (
-                    <span className='rounded-md bg-surface-1 px-1.5 py-1 text-[10.5px] text-secondary-token'>
-                      Price {option.price_recommendation.retail_price}
-                    </span>
-                  ) : null}
-                  {option.price_recommendation?.artist_share ? (
-                    <span className='rounded-md bg-surface-1 px-1.5 py-1 text-[10.5px] text-secondary-token'>
-                      Artist {option.price_recommendation.artist_share}
-                    </span>
-                  ) : null}
-                  {option.price_recommendation?.jovie_share ? (
-                    <span className='rounded-md bg-surface-1 px-1.5 py-1 text-[10.5px] text-secondary-token'>
-                      Jovie {option.price_recommendation.jovie_share}
-                    </span>
-                  ) : null}
-                  {option.price_recommendation?.minimum_jovie_margin ? (
-                    <span className='rounded-md bg-surface-1 px-1.5 py-1 text-[10.5px] text-secondary-token'>
-                      Floor {option.price_recommendation.minimum_jovie_margin}
-                    </span>
-                  ) : null}
-                </div>
+                <MerchOptionPricing
+                  recommendation={option.price_recommendation}
+                />
                 <div className='flex flex-wrap gap-1.5 pt-0.5'>
                   <Button
                     type='button'

--- a/apps/web/components/molecules/MerchPricingPresetPicker.tsx
+++ b/apps/web/components/molecules/MerchPricingPresetPicker.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import type { MerchMarginPreset } from '@/lib/merch/pricing';
+import { cn } from '@/lib/utils';
+
+export interface MerchPricingPresetOption {
+  readonly preset: MerchMarginPreset;
+  readonly label: string;
+  readonly salePrice: string;
+  readonly profit: string;
+}
+
+export function MerchPricingPresetPicker({
+  options,
+  value,
+  onChange,
+  className,
+}: {
+  readonly options: readonly MerchPricingPresetOption[];
+  readonly value: MerchMarginPreset;
+  readonly onChange: (preset: MerchMarginPreset) => void;
+  readonly className?: string;
+}) {
+  const groupName = `merch-pricing-preset-${options.map(option => option.preset).join('-')}`;
+
+  return (
+    <fieldset
+      className={cn('flex flex-wrap gap-1 border-0 p-0', className)}
+      data-testid='merch-pricing-preset-picker'
+    >
+      <legend className='sr-only'>Pricing preset</legend>
+      {options.map(option => {
+        const active = option.preset === value;
+        return (
+          <label
+            key={option.preset}
+            className={cn(
+              'inline-flex h-7 cursor-pointer items-center rounded-md border px-2 text-[10.5px] font-medium transition-[background-color,border-color,color] duration-subtle has-[:focus-visible]:outline-none has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-(--linear-border-focus)/55',
+              active
+                ? 'border-default bg-surface-1 text-primary-token'
+                : 'border-subtle bg-surface-0 text-tertiary-token hover:border-default hover:text-secondary-token'
+            )}
+          >
+            <input
+              type='radio'
+              name={groupName}
+              value={option.preset}
+              checked={active}
+              onChange={() => onChange(option.preset)}
+              className='sr-only'
+            />
+            {option.label}
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/apps/web/components/molecules/MerchPricingSummary.tsx
+++ b/apps/web/components/molecules/MerchPricingSummary.tsx
@@ -1,0 +1,43 @@
+import { cn } from '@/lib/utils';
+
+export function MerchPricingSummary({
+  salePrice,
+  profit,
+  className,
+  compact = false,
+}: {
+  readonly salePrice: string;
+  readonly profit: string;
+  readonly className?: string;
+  readonly compact?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        'grid min-h-[58px] grid-cols-2 gap-1',
+        compact && 'min-h-[48px]',
+        className
+      )}
+      data-testid='merch-pricing-summary'
+    >
+      <span
+        className={cn(
+          'rounded-md bg-surface-1 px-1.5 py-1 text-secondary-token',
+          compact ? 'text-[10px]' : 'text-[10.5px]'
+        )}
+      >
+        <span className='text-tertiary-token'>Sale </span>
+        <span className='font-medium text-primary-token'>{salePrice}</span>
+      </span>
+      <span
+        className={cn(
+          'rounded-md bg-surface-1 px-1.5 py-1 text-secondary-token',
+          compact ? 'text-[10px]' : 'text-[10.5px]'
+        )}
+      >
+        <span className='text-tertiary-token'>Profit </span>
+        <span className='font-medium text-primary-token'>{profit}</span>
+      </span>
+    </div>
+  );
+}

--- a/apps/web/lib/merch/catalog.ts
+++ b/apps/web/lib/merch/catalog.ts
@@ -18,7 +18,12 @@ import {
   getDefaultVariantIds,
   MERCH_DEFAULT_PRINTFUL_PRODUCT,
 } from './default-catalog';
-import { buildMerchPricingSnapshot } from './pricing';
+import {
+  buildMerchPricingSnapshot,
+  calculateRecommendedSalePriceCents,
+  MERCH_DEFAULT_MARGIN_PRESET,
+  MERCH_DEFAULT_PRINTFUL_PRODUCT_COST_CENTS,
+} from './pricing';
 
 export interface MerchCatalogSelection {
   readonly catalogProductId: number;
@@ -57,6 +62,15 @@ function defaultSelection(
     availabilityRegion: MERCH_DEFAULT_PRINTFUL_PRODUCT.availabilityRegion,
     shippingProfile: MERCH_DEFAULT_PRINTFUL_PRODUCT.shippingProfile,
     pricing: buildMerchPricingSnapshot({
+      retailPriceCents: calculateRecommendedSalePriceCents(
+        MERCH_DEFAULT_PRINTFUL_PRODUCT_COST_CENTS,
+        MERCH_DEFAULT_MARGIN_PRESET,
+        {
+          printfulCostSource: 'jovie_default',
+          printfulCostUpdatedAt: null,
+        }
+      ),
+      printfulProductCostCents: MERCH_DEFAULT_PRINTFUL_PRODUCT_COST_CENTS,
       printfulCostSource: 'jovie_default',
       printfulCostUpdatedAt: null,
     }),
@@ -224,6 +238,14 @@ export async function resolveMerchCatalogSelection(
       availabilityRegion: MERCH_DEFAULT_PRINTFUL_PRODUCT.availabilityRegion,
       shippingProfile: MERCH_DEFAULT_PRINTFUL_PRODUCT.shippingProfile,
       pricing: buildMerchPricingSnapshot({
+        retailPriceCents: calculateRecommendedSalePriceCents(
+          productCostCents,
+          MERCH_DEFAULT_MARGIN_PRESET,
+          {
+            printfulCostSource: 'printful',
+            printfulCostUpdatedAt: new Date().toISOString(),
+          }
+        ),
         printfulProductCostCents: productCostCents,
         printfulCostSource: 'printful',
         printfulCostUpdatedAt: new Date().toISOString(),

--- a/apps/web/lib/merch/pricing.test.ts
+++ b/apps/web/lib/merch/pricing.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   assertSellableMerchEconomics,
+  buildMerchPresetPriceQuotes,
   buildMerchPricingSnapshot,
+  calculateRecommendedSalePriceCents,
   estimateStripeFeeCents,
   formatMerchMoney,
   getMerchSellability,
@@ -14,18 +16,35 @@ describe('merch pricing', () => {
     expect(estimateStripeFeeCents(5025)).toBe(176);
   });
 
-  it('defaults artist payout to 50% of estimated net profit', () => {
+  it('auto-sets sale price from the standard margin preset', () => {
     const pricing = buildMerchPricingSnapshot();
 
     expect(pricing.currency).toBe('USD');
-    expect(pricing.retailPriceCents).toBe(4500);
+    expect(pricing.retailPriceCents).toBe(4100);
     expect(pricing.estimatedPrintfulProductCostCents).toBe(1750);
     expect(pricing.estimatedShippingCostCents).toBe(525);
     expect(pricing.refundReserveCents).toBe(200);
-    expect(pricing.stripeFeeEstimateCents).toBe(176);
+    expect(pricing.stripeFeeEstimateCents).toBe(164);
     expect(pricing.artistRoyaltyRateBps).toBe(5000);
-    expect(pricing.artistPayoutPerUnitEstimateCents).toBe(1187);
-    expect(pricing.jovieMarginPerUnitEstimateCents).toBe(1187);
+    expect(pricing.artistPayoutPerUnitEstimateCents).toBe(993);
+    expect(pricing.jovieMarginPerUnitEstimateCents).toBe(993);
+  });
+
+  it('builds safe, standard, and aggressive preset quotes from wholesale cost', () => {
+    const quotes = buildMerchPresetPriceQuotes({
+      printfulProductCostCents: 1750,
+    });
+
+    expect(quotes.map(quote => quote.preset)).toEqual([
+      'safe',
+      'standard',
+      'aggressive',
+    ]);
+    expect(quotes[0].salePriceCents).toBeLessThan(quotes[1].salePriceCents);
+    expect(quotes[1].salePriceCents).toBeLessThan(quotes[2].salePriceCents);
+    expect(quotes[1].salePriceCents).toBe(
+      calculateRecommendedSalePriceCents(1750, 'standard')
+    );
   });
 
   it('marks below-cost pricing as unsellable instead of trusting zeroed payouts', () => {

--- a/apps/web/lib/merch/pricing.ts
+++ b/apps/web/lib/merch/pricing.ts
@@ -12,6 +12,29 @@ export const MERCH_TARGET_JOVIE_MARGIN_CENTS = 800;
 export const MERCH_TARGET_JOVIE_MARGIN_RATE_BPS = 1500;
 export const MERCH_PRINTFUL_COST_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
+export type MerchMarginPreset = 'safe' | 'standard' | 'aggressive';
+
+export const MERCH_DEFAULT_MARGIN_PRESET: MerchMarginPreset = 'standard';
+
+export const MERCH_MARGIN_PRESET_OPTIONS: readonly {
+  readonly id: MerchMarginPreset;
+  readonly label: string;
+  readonly markupBps: number;
+}[] = [
+  { id: 'safe', label: 'Safe', markupBps: 4_500 },
+  { id: 'standard', label: 'Standard', markupBps: 6_500 },
+  { id: 'aggressive', label: 'Aggressive', markupBps: 9_000 },
+] as const;
+
+export interface MerchPresetPriceQuote {
+  readonly preset: MerchMarginPreset;
+  readonly label: string;
+  readonly salePriceCents: number;
+  readonly profitCents: number;
+  readonly salePrice: string;
+  readonly profit: string;
+}
+
 export interface MerchEconomicsInput {
   readonly currency?: string;
   readonly retailPriceCents: number;
@@ -104,6 +127,107 @@ export function getJovieTargetMarginCents(retailPriceCents: number): number {
   return Math.max(MERCH_TARGET_JOVIE_MARGIN_CENTS, rateTarget);
 }
 
+export function getArtistProfitCents(pricing: MerchPricingSnapshot): number {
+  return pricing.artistPayoutPerUnitEstimateCents;
+}
+
+function roundSalePriceToWholeDollar(cents: number): number {
+  return Math.max(100, Math.ceil(cents / 100) * 100);
+}
+
+function getPresetMarkupBps(preset: MerchMarginPreset): number {
+  const option = MERCH_MARGIN_PRESET_OPTIONS.find(item => item.id === preset);
+  return option?.markupBps ?? MERCH_MARGIN_PRESET_OPTIONS[1].markupBps;
+}
+
+export function calculateRecommendedSalePriceCents(
+  printfulProductCostCents: number,
+  preset: MerchMarginPreset = MERCH_DEFAULT_MARGIN_PRESET,
+  overrides?: {
+    readonly shippingCostCents?: number;
+    readonly refundReserveCents?: number;
+    readonly artistRoyaltyRateBps?: number;
+    readonly printfulCostSource?: MerchPricingSnapshot['printfulCostSource'];
+    readonly printfulCostUpdatedAt?: string | null;
+  }
+): number {
+  assertNonNegativeInteger(
+    printfulProductCostCents,
+    'printfulProductCostCents'
+  );
+
+  const shippingCostCents =
+    overrides?.shippingCostCents ?? MERCH_DEFAULT_SHIPPING_CENTS;
+  const refundReserveCents =
+    overrides?.refundReserveCents ?? MERCH_DEFAULT_REFUND_RESERVE_CENTS;
+  const markupBps = getPresetMarkupBps(preset);
+  const loadedBaseCents =
+    printfulProductCostCents + shippingCostCents + refundReserveCents;
+  let candidate = roundSalePriceToWholeDollar(
+    loadedBaseCents + Math.ceil((loadedBaseCents * markupBps) / 10_000)
+  );
+
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    const snapshot = buildMerchPricingSnapshot({
+      retailPriceCents: candidate,
+      printfulProductCostCents,
+      shippingCostCents,
+      refundReserveCents,
+      artistRoyaltyRateBps: overrides?.artistRoyaltyRateBps,
+      printfulCostSource: overrides?.printfulCostSource,
+      printfulCostUpdatedAt: overrides?.printfulCostUpdatedAt,
+    });
+    const marginFloor = getJovieMarginFloorCents(candidate);
+    const clearsFloor =
+      snapshot.jovieMarginPerUnitEstimateCents >= marginFloor &&
+      snapshot.artistPayoutPerUnitEstimateCents > 0 &&
+      candidate > printfulProductCostCents;
+
+    if (clearsFloor) {
+      return candidate;
+    }
+
+    candidate += 100;
+  }
+
+  return candidate;
+}
+
+export function buildMerchPresetPriceQuotes(params: {
+  readonly printfulProductCostCents: number;
+  readonly shippingCostCents?: number;
+  readonly refundReserveCents?: number;
+  readonly artistRoyaltyRateBps?: number;
+  readonly printfulCostSource?: MerchPricingSnapshot['printfulCostSource'];
+  readonly printfulCostUpdatedAt?: string | null;
+}): readonly MerchPresetPriceQuote[] {
+  return MERCH_MARGIN_PRESET_OPTIONS.map(option => {
+    const salePriceCents = calculateRecommendedSalePriceCents(
+      params.printfulProductCostCents,
+      option.id,
+      params
+    );
+    const snapshot = buildMerchPricingSnapshot({
+      retailPriceCents: salePriceCents,
+      printfulProductCostCents: params.printfulProductCostCents,
+      shippingCostCents: params.shippingCostCents,
+      refundReserveCents: params.refundReserveCents,
+      artistRoyaltyRateBps: params.artistRoyaltyRateBps,
+      printfulCostSource: params.printfulCostSource,
+      printfulCostUpdatedAt: params.printfulCostUpdatedAt,
+    });
+
+    return {
+      preset: option.id,
+      label: option.label,
+      salePriceCents,
+      profitCents: getArtistProfitCents(snapshot),
+      salePrice: formatMerchMoney(salePriceCents),
+      profit: formatMerchMoney(getArtistProfitCents(snapshot)),
+    };
+  });
+}
+
 function parseFreshnessDate(value: Date | string | null | undefined): number {
   if (!value) return Number.NaN;
   const date = value instanceof Date ? value : new Date(value);
@@ -191,11 +315,22 @@ export function buildMerchPricingSnapshot(params?: {
   readonly printfulCostSource?: MerchPricingSnapshot['printfulCostSource'];
   readonly printfulCostUpdatedAt?: string | null;
 }): MerchPricingSnapshot {
-  const retailPriceCents =
-    params?.retailPriceCents ?? MERCH_DEFAULT_RETAIL_PRICE_CENTS;
   const estimatedPrintfulProductCostCents =
     params?.printfulProductCostCents ??
     MERCH_DEFAULT_PRINTFUL_PRODUCT_COST_CENTS;
+  const retailPriceCents =
+    params?.retailPriceCents ??
+    calculateRecommendedSalePriceCents(
+      estimatedPrintfulProductCostCents,
+      MERCH_DEFAULT_MARGIN_PRESET,
+      {
+        shippingCostCents: params?.shippingCostCents,
+        refundReserveCents: params?.refundReserveCents,
+        artistRoyaltyRateBps: params?.artistRoyaltyRateBps,
+        printfulCostSource: params?.printfulCostSource,
+        printfulCostUpdatedAt: params?.printfulCostUpdatedAt,
+      }
+    );
   const estimatedShippingCostCents =
     params?.shippingCostCents ?? MERCH_DEFAULT_SHIPPING_CENTS;
   const refundReserveCents =

--- a/apps/web/lib/merch/service.ts
+++ b/apps/web/lib/merch/service.ts
@@ -37,8 +37,10 @@ import { resolveMerchCatalogSelection } from './catalog';
 import { MERCH_DEFAULT_PRINTFUL_PRODUCT } from './default-catalog';
 import { attachMockupsToDesignOption, generateProductMockups } from './mockups'; // HOT ZONE pipeline (gh-9803)
 import {
+  buildMerchPresetPriceQuotes,
   buildMerchPricingSnapshot,
   formatMerchMoney,
+  MERCH_DEFAULT_MARGIN_PRESET,
   type MerchSellabilityResult,
 } from './pricing';
 import { getMerchCardSellability } from './safety';
@@ -357,6 +359,36 @@ function validateMerchCardForPublishing(card: MerchCard): void {
   }
 }
 
+function buildOptionPriceRecommendation(option: MerchDesignOption) {
+  const presetQuotes = buildMerchPresetPriceQuotes({
+    printfulProductCostCents: option.estimatedPrintfulProductCostCents,
+    shippingCostCents: option.estimatedShippingCostCents,
+    refundReserveCents: option.pricing.refundReserveCents,
+    artistRoyaltyRateBps: option.pricing.artistRoyaltyRateBps,
+    printfulCostSource: option.pricing.printfulCostSource,
+    printfulCostUpdatedAt: option.pricing.printfulCostUpdatedAt,
+  });
+  const activePreset =
+    presetQuotes.find(quote => quote.preset === MERCH_DEFAULT_MARGIN_PRESET) ??
+    presetQuotes[1];
+
+  return {
+    sale_price: activePreset.salePrice,
+    profit: activePreset.profit,
+    margin_preset: activePreset.preset,
+    presets: presetQuotes.map(quote => ({
+      preset: quote.preset,
+      label: quote.label,
+      sale_price: quote.salePrice,
+      profit: quote.profit,
+    })),
+    estimated_printful_cost:
+      option.estimatedPrintfulProductCostCents > 0
+        ? formatMerchMoney(option.estimatedPrintfulProductCostCents)
+        : undefined,
+  };
+}
+
 function optionToView(option: MerchDesignOption): MerchGenerationOptionView {
   const sellability = getDesignOptionSellability(option);
   return {
@@ -371,24 +403,7 @@ function optionToView(option: MerchDesignOption): MerchGenerationOptionView {
     available_sizes: option.availableSizes,
     placements: option.placements,
     technique: option.technique,
-    price_recommendation: {
-      retail_price: formatMerchMoney(option.retailPriceCents),
-      estimated_printful_cost: formatMerchMoney(
-        option.estimatedPrintfulProductCostCents
-      ),
-      estimated_shipping: formatMerchMoney(option.estimatedShippingCostCents),
-      estimated_gross_margin: formatMerchMoney(
-        option.estimatedGrossMarginCents
-      ),
-      artist_share: formatMerchMoney(option.artistShareCents),
-      jovie_share: formatMerchMoney(option.jovieShareCents),
-      minimum_jovie_margin: option.pricing.minimumJovieMarginCents
-        ? formatMerchMoney(option.pricing.minimumJovieMarginCents)
-        : undefined,
-      target_jovie_margin: option.pricing.targetJovieMarginCents
-        ? formatMerchMoney(option.pricing.targetJovieMarginCents)
-        : undefined,
-    },
+    price_recommendation: buildOptionPriceRecommendation(option),
     sellability,
     concept: option.concept,
     why_it_fits: option.whyItFits,

--- a/apps/web/lib/merch/types.ts
+++ b/apps/web/lib/merch/types.ts
@@ -44,14 +44,16 @@ export interface MerchGenerationOptionView {
     | 'sublimation'
     | 'other';
   readonly price_recommendation: {
-    readonly retail_price: string;
-    readonly estimated_printful_cost: string;
-    readonly estimated_shipping: string;
-    readonly estimated_gross_margin: string;
-    readonly artist_share: string;
-    readonly jovie_share: string;
-    readonly minimum_jovie_margin?: string;
-    readonly target_jovie_margin?: string;
+    readonly sale_price: string;
+    readonly profit: string;
+    readonly margin_preset: 'safe' | 'standard' | 'aggressive';
+    readonly presets: readonly {
+      readonly preset: 'safe' | 'standard' | 'aggressive';
+      readonly label: string;
+      readonly sale_price: string;
+      readonly profit: string;
+    }[];
+    readonly estimated_printful_cost?: string;
   };
   readonly sellability?: {
     readonly sellable: boolean;

--- a/apps/web/tests/unit/chat/ChatMessage.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.test.tsx
@@ -275,8 +275,17 @@ describe('ChatMessage', () => {
                 concept: 'Cover art on heavyweight black fleece.',
                 mockup_urls: ['https://cdn.example.com/hoodie.png'],
                 price_recommendation: {
-                  retail_price: '$68.00',
-                  artist_share: '$22.00',
+                  sale_price: '$68.00',
+                  profit: '$22.00',
+                  margin_preset: 'standard',
+                  presets: [
+                    {
+                      preset: 'standard',
+                      label: 'Standard',
+                      sale_price: '$68.00',
+                      profit: '$22.00',
+                    },
+                  ],
                 },
               },
             ],

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -308,9 +308,8 @@ describe('LibrarySurface', () => {
         primaryActionLabel: 'Open Merch',
         primaryActionHref: '/app/library?view=merch',
         productType: 'hoodie',
-        retailPriceLabel: '$68.00',
-        artistPayoutLabel: '$22.00',
-        jovieMarginLabel: '$9.00',
+        salePriceLabel: '$68.00',
+        profitLabel: '$22.00',
         description: 'Black hoodie with Never Say A Word cover art.',
         previewUrl: null,
         providerCount: 0,
@@ -337,7 +336,7 @@ describe('LibrarySurface', () => {
       drawer.getByText('Black hoodie with Never Say A Word cover art.')
     ).toBeInTheDocument();
     expect(drawer.getByText('$22.00')).toBeInTheDocument();
-    expect(drawer.getByText('$9.00')).toBeInTheDocument();
+    expect(drawer.queryByText('$9.00')).toBeNull();
     expect(drawer.getByRole('link', { name: /Open Merch/u })).toHaveAttribute(
       'href',
       '/app/library?view=merch'

--- a/apps/web/tests/unit/library/library-data.test.ts
+++ b/apps/web/tests/unit/library/library-data.test.ts
@@ -146,9 +146,8 @@ describe('library data', () => {
         productType: 'hoodie',
         primaryActionLabel: 'Open Merch',
         smartLinkPath: '/app/library?view=merch',
-        retailPriceLabel: '$68.00',
-        artistPayoutLabel: '$22.00',
-        jovieMarginLabel: '$9.00',
+        salePriceLabel: '$68.00',
+        profitLabel: '$22.00',
       }),
     ]);
   });


### PR DESCRIPTION
## Summary

Simplifies merch pricing surfaces to foreground **sale price** and **artist profit**, removing the separate Jovie share / wholesale breakdown from creator-facing UI.

- Chat merch option cards now show Sale + Profit with Safe/Standard/Aggressive preset picker (no free-form margin editing)
- Library merch drawer collapses Price/Artist Share/Jovie Margin into Sale Price + Profit
- Profile merch cards show profit under the sale price
- Backend auto-sets sale price from the Standard margin preset when Printful cost is known

## Linear

<!-- linear-issue-id:JOV-2649 -->

Closes JOV-2649

## UI QA (/qa exhaustive)

- [x] Chat merch options: preset picker + sale/profit summary (unit tests)
- [x] Library merch drawer: sale price + profit metadata only (unit tests)
- [x] Profile merch card: sale price + profit line (unit tests)
- [x] Wholesale/base cost hidden from primary UI (optional server field retained, not rendered)
- [x] Layout shift guard: fixed min-heights preserved on pricing summary grid

## Validation

```bash
pnpm --filter web typecheck
pnpm exec vitest run lib/merch/pricing.test.ts components/jovie/components/ChatMerchCard.test.tsx components/features/profile/ProfileMerchCard.test.tsx tests/unit/library/library-data.test.ts tests/unit/library/LibrarySurface.test.tsx
pnpm exec biome check <edited files>
```

All checks green locally; pre-push hook passed (biome, typecheck, lint).

## Screenshots (described)

1. **Chat merch option card** — three compact preset chips (Safe / Standard / Aggressive) above a two-cell summary: "Sale $45.00" and "Profit $11.87"; Jovie share and floor chips removed.
2. **Library merch drawer** — metadata shows Sale Price, Profit, Sellability; Artist Share and Jovie Margin rows removed.
3. **Profile merch card** — price row shows "$45.00" with a secondary "Profit $11.87" line beneath.

## GStack Gate Evidence

<!-- agent-run-artifact
{
  "id": "run-jov-2649-merch-pricing",
  "source": "github",
  "sourceRunId": "75f345ad4698ad3a9bfaa899c7a949eb73e924d4",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2649 merch pricing UI gates",
  "summary": "Recorded exhaustive QA, review, and ship evidence for merch pricing UI simplification.",
  "modelRoute": "deterministic",
  "allowedActions": [
    "read",
    "open_pr"
  ],
  "forbiddenActions": [
    "merge",
    "deploy",
    "mutate_production_data"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2649",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2649/simplify-merch-pricing-ui-around-sale-price-and-profit",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/10305",
  "adminSurface": "/app/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/qa exhaustive: chat merch preset picker, library drawer sale/profit, profile profit line; 33 unit tests green; layout min-heights preserved.",
      "checkedAt": "2026-06-08T00:11:14.236Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/review: removed Jovie share + wholesale from creator UI; preset-only margin control; backend auto-prices via Standard preset.",
      "checkedAt": "2026-06-08T00:11:14.236Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/ship: typecheck, lint, biome, vitest merch suite, pre-push hook all green; PR #10305 opened.",
      "checkedAt": "2026-06-08T00:11:14.236Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-06-08T00:11:14.236Z",
  "updatedAt": "2026-06-08T00:11:14.236Z",
  "metadata": {}
}
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added margin preset options (safe, standard, aggressive) for merch pricing
  * Added preset selector UI for choosing different price tiers on merch items

* **Refactor**
  * Updated merch pricing displays across the library and chat to show sale price and profit instead of retail price and margin information
  * Restructured merch price recommendation data model to support preset-based pricing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->