### PR TITLE
JOV-2785: Fix production synthetic monitor skipped onboarding robot classification

### DIFF
--- a/.github/scripts/parse-synthetic-test-results.js
+++ b/.github/scripts/parse-synthetic-test-results.js
@@ -1,0 +1,192 @@
+const fs = require('node:fs');
+
+const DEFAULT_RESULT_FILES = legacyCanaryEnabled => [
+  {
+    name: 'synthetic-auth-ui',
+    path: 'apps/web/test-results/synthetic-auth-ui-results.json',
+    required: true,
+  },
+  {
+    name: 'synthetic-golden-path',
+    path: 'apps/web/test-results/synthetic-golden-path-results.json',
+    required: true,
+  },
+  {
+    name: 'onboarding-robot-full',
+    path: 'apps/web/test-results/onboarding-robot-full-results.json',
+    required: true,
+  },
+  {
+    name: 'public-profile-smoke',
+    path: 'apps/web/test-results/public-profile-smoke-results.json',
+    required: true,
+  },
+  {
+    name: 'synthetic-legacy-otp',
+    path: 'apps/web/test-results/synthetic-legacy-otp-results.json',
+    required: legacyCanaryEnabled,
+  },
+];
+
+function collectSpecs(suites = [], source) {
+  const specs = [];
+
+  for (const suite of suites) {
+    specs.push(...(suite.specs ?? []).map(spec => ({ source, spec })));
+    specs.push(...collectSpecs(suite.suites ?? [], source));
+  }
+
+  return specs;
+}
+
+function classifySyntheticTests(tests) {
+  const skipped = tests.filter(
+    ({ testCase }) =>
+      testCase.status === 'skipped' ||
+      (testCase.results ?? []).some(result => result.status === 'skipped')
+  );
+  const warnings = tests.flatMap(({ source, spec, testCase }) =>
+    (testCase.results ?? []).flatMap(result =>
+      [...(result.stdout ?? []), ...(result.stderr ?? [])]
+        .map(entry => entry.text ?? '')
+        .filter(text => text.includes('[Synthetic][warning]'))
+        .map(text => `${source}: ${spec.title}: ${text.trim()}`)
+    )
+  );
+  const flaky = tests.filter(({ testCase }) => testCase.status === 'flaky');
+  const failed = tests.filter(
+    ({ testCase }) => testCase.status === 'unexpected'
+  );
+  const passed = tests.filter(
+    ({ testCase }) =>
+      ['expected', 'flaky'].includes(testCase.status) &&
+      !(testCase.results ?? []).some(result => result.status === 'skipped')
+  );
+
+  return { skipped, warnings, flaky, failed, passed };
+}
+
+function resolveSyntheticTestStatus({
+  tests,
+  missingResults,
+  passed,
+  skipped,
+  failed,
+}) {
+  if (missingResults.length > 0 || tests.length === 0) {
+    return 'error';
+  }
+
+  if (failed.length > 0) {
+    return 'failed';
+  }
+
+  if (passed.length + skipped.length === tests.length) {
+    return 'passed';
+  }
+
+  return 'error';
+}
+
+function loadSyntheticResultSpecs(resultFiles, fileSystem = fs) {
+  const specs = [];
+  const missingResults = [];
+
+  for (const resultFile of resultFiles) {
+    if (!fileSystem.existsSync(resultFile.path)) {
+      if (resultFile.required !== false) {
+        missingResults.push(
+          `${resultFile.name}: Test results file not found (${resultFile.path})`
+        );
+      }
+      continue;
+    }
+
+    try {
+      const results = JSON.parse(
+        fileSystem.readFileSync(resultFile.path, 'utf8')
+      );
+      specs.push(...collectSpecs(results.suites ?? [], resultFile.name));
+    } catch (error) {
+      missingResults.push(
+        `${resultFile.name}: Failed to parse ${resultFile.path}: ${error.message}`
+      );
+    }
+  }
+
+  return { specs, missingResults };
+}
+
+function parseSyntheticTestResults({ resultFiles, fileSystem = fs } = {}) {
+  const resolvedResultFiles =
+    resultFiles ??
+    DEFAULT_RESULT_FILES(process.env.LEGACY_CANARY_ENABLED === '1');
+
+  const { specs, missingResults } = loadSyntheticResultSpecs(
+    resolvedResultFiles,
+    fileSystem
+  );
+  const tests = specs.flatMap(({ source, spec }) =>
+    (spec.tests ?? []).map(testCase => ({ source, spec, testCase }))
+  );
+  const { skipped, warnings, flaky, failed, passed } =
+    classifySyntheticTests(tests);
+  const testStatus = resolveSyntheticTestStatus({
+    tests,
+    missingResults,
+    passed,
+    skipped,
+    failed,
+  });
+
+  const failedTests = [
+    ...missingResults,
+    ...failed.map(({ source, spec }) => `${source}: ${spec.title}`),
+    ...(skipped.length > 0
+      ? [
+          'Skipped tests:',
+          ...skipped.map(({ source, spec }) => `${source}: ${spec.title}`),
+        ]
+      : []),
+  ];
+
+  return {
+    totalTests: tests.length,
+    passedTests: passed.length,
+    flakyTests: flaky.length,
+    skippedTests: skipped.length,
+    warningCount: warnings.length,
+    testStatus,
+    failedTests,
+    testWarnings: warnings,
+  };
+}
+
+function formatGithubOutput(result) {
+  const lines = [
+    `total_tests=${result.totalTests}`,
+    `passed_tests=${result.passedTests}`,
+    `flaky_tests=${result.flakyTests}`,
+    `skipped_tests=${result.skippedTests}`,
+    `warning_count=${result.warningCount}`,
+    'failed_tests<<EOF',
+    ...result.failedTests,
+    'EOF',
+    'test_warnings<<EOF',
+    ...result.testWarnings,
+    'EOF',
+    `test_status=${result.testStatus}`,
+  ];
+
+  return `${lines.join('\n')}\n`;
+}
+
+module.exports = {
+  DEFAULT_RESULT_FILES,
+  classifySyntheticTests,
+  collectSpecs,
+  formatGithubOutput,
+  loadSyntheticResultSpecs,
+  parseSyntheticTestResults,
+  resolveSyntheticTestStatus,
+};

--- a/.github/scripts/parse-synthetic-test-results.test.js
+++ b/.github/scripts/parse-synthetic-test-results.test.js
@@ -1,0 +1,286 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  classifySyntheticTests,
+  parseSyntheticTestResults,
+  resolveSyntheticTestStatus,
+} = require('./parse-synthetic-test-results');
+
+function buildPlaywrightReport(specs) {
+  return {
+    suites: [
+      {
+        specs: specs.map(spec => ({
+          title: spec.title,
+          tests: [
+            {
+              status: spec.status,
+              results: spec.results ?? [{ status: spec.status }],
+            },
+          ],
+        })),
+      },
+    ],
+  };
+}
+
+function createMemoryFileSystem(files) {
+  return {
+    existsSync(path) {
+      return Object.hasOwn(files, path);
+    },
+    readFileSync(path) {
+      return files[path];
+    },
+  };
+}
+
+test('resolveSyntheticTestStatus treats intentional skips without unexpected failures as passed', () => {
+  const tests = [{}, {}];
+  const passed = [{}];
+  const skipped = [{}];
+
+  assert.equal(
+    resolveSyntheticTestStatus({
+      tests,
+      missingResults: [],
+      passed,
+      skipped,
+      failed: [],
+    }),
+    'passed'
+  );
+});
+
+test('resolveSyntheticTestStatus fails only on unexpected failures', () => {
+  const tests = [{}, {}, {}];
+  const passed = [{}];
+  const skipped = [{}];
+  const failed = [{}];
+
+  assert.equal(
+    resolveSyntheticTestStatus({
+      tests,
+      missingResults: [],
+      passed,
+      skipped,
+      failed,
+    }),
+    'failed'
+  );
+});
+
+test('classifySyntheticTests distinguishes skipped results from unexpected failures', () => {
+  const tests = [
+    {
+      source: 'onboarding-robot-full',
+      spec: { title: 'creates a profile' },
+      testCase: { status: 'skipped', results: [{ status: 'skipped' }] },
+    },
+    {
+      source: 'synthetic-golden-path',
+      spec: { title: 'loads homepage' },
+      testCase: { status: 'expected', results: [{ status: 'passed' }] },
+    },
+    {
+      source: 'synthetic-auth-ui',
+      spec: { title: 'shows SSO buttons' },
+      testCase: { status: 'unexpected', results: [{ status: 'failed' }] },
+    },
+  ];
+
+  const classification = classifySyntheticTests(tests);
+
+  assert.equal(classification.skipped.length, 1);
+  assert.equal(classification.failed.length, 1);
+  assert.equal(classification.passed.length, 1);
+});
+
+test('parseSyntheticTestResults passes when onboarding robot is skipped and other suites pass', () => {
+  const fileSystem = createMemoryFileSystem({
+    'apps/web/test-results/synthetic-auth-ui-results.json': JSON.stringify(
+      buildPlaywrightReport([
+        { title: 'shows SSO buttons', status: 'expected' },
+      ])
+    ),
+    'apps/web/test-results/synthetic-golden-path-results.json': JSON.stringify(
+      buildPlaywrightReport([{ title: 'loads homepage', status: 'expected' }])
+    ),
+    'apps/web/test-results/onboarding-robot-full-results.json': JSON.stringify(
+      buildPlaywrightReport([
+        {
+          title:
+            'creates a profile, verifies dashboard/public profile, and cleans up',
+          status: 'skipped',
+        },
+      ])
+    ),
+    'apps/web/test-results/public-profile-smoke-results.json': JSON.stringify(
+      buildPlaywrightReport([
+        { title: 'renders public profile', status: 'expected' },
+      ])
+    ),
+  });
+
+  const result = parseSyntheticTestResults({
+    resultFiles: [
+      {
+        name: 'synthetic-auth-ui',
+        path: 'apps/web/test-results/synthetic-auth-ui-results.json',
+        required: true,
+      },
+      {
+        name: 'synthetic-golden-path',
+        path: 'apps/web/test-results/synthetic-golden-path-results.json',
+        required: true,
+      },
+      {
+        name: 'onboarding-robot-full',
+        path: 'apps/web/test-results/onboarding-robot-full-results.json',
+        required: true,
+      },
+      {
+        name: 'public-profile-smoke',
+        path: 'apps/web/test-results/public-profile-smoke-results.json',
+        required: true,
+      },
+      {
+        name: 'synthetic-legacy-otp',
+        path: 'apps/web/test-results/synthetic-legacy-otp-results.json',
+        required: false,
+      },
+    ],
+    fileSystem,
+  });
+
+  assert.equal(result.testStatus, 'passed');
+  assert.equal(result.totalTests, 4);
+  assert.equal(result.passedTests, 3);
+  assert.equal(result.skippedTests, 1);
+  assert.deepEqual(result.failedTests, [
+    'Skipped tests:',
+    'onboarding-robot-full: creates a profile, verifies dashboard/public profile, and cleans up',
+  ]);
+});
+
+test('parseSyntheticTestResults fails when any suite reports unexpected failures', () => {
+  const fileSystem = createMemoryFileSystem({
+    'apps/web/test-results/synthetic-auth-ui-results.json': JSON.stringify(
+      buildPlaywrightReport([
+        { title: 'shows SSO buttons', status: 'unexpected' },
+      ])
+    ),
+    'apps/web/test-results/synthetic-golden-path-results.json': JSON.stringify(
+      buildPlaywrightReport([{ title: 'loads homepage', status: 'expected' }])
+    ),
+    'apps/web/test-results/onboarding-robot-full-results.json': JSON.stringify(
+      buildPlaywrightReport([
+        {
+          title:
+            'creates a profile, verifies dashboard/public profile, and cleans up',
+          status: 'skipped',
+        },
+      ])
+    ),
+    'apps/web/test-results/public-profile-smoke-results.json': JSON.stringify(
+      buildPlaywrightReport([
+        { title: 'renders public profile', status: 'expected' },
+      ])
+    ),
+  });
+
+  const result = parseSyntheticTestResults({
+    resultFiles: [
+      {
+        name: 'synthetic-auth-ui',
+        path: 'apps/web/test-results/synthetic-auth-ui-results.json',
+        required: true,
+      },
+      {
+        name: 'synthetic-golden-path',
+        path: 'apps/web/test-results/synthetic-golden-path-results.json',
+        required: true,
+      },
+      {
+        name: 'onboarding-robot-full',
+        path: 'apps/web/test-results/onboarding-robot-full-results.json',
+        required: true,
+      },
+      {
+        name: 'public-profile-smoke',
+        path: 'apps/web/test-results/public-profile-smoke-results.json',
+        required: true,
+      },
+    ],
+    fileSystem,
+  });
+
+  assert.equal(result.testStatus, 'failed');
+  assert.deepEqual(result.failedTests, [
+    'synthetic-auth-ui: shows SSO buttons',
+    'Skipped tests:',
+    'onboarding-robot-full: creates a profile, verifies dashboard/public profile, and cleans up',
+  ]);
+});
+
+test('parseSyntheticTestResults ignores optional legacy OTP results when absent', () => {
+  const fileSystem = createMemoryFileSystem({
+    'apps/web/test-results/synthetic-auth-ui-results.json': JSON.stringify(
+      buildPlaywrightReport([
+        { title: 'shows SSO buttons', status: 'expected' },
+      ])
+    ),
+    'apps/web/test-results/synthetic-golden-path-results.json': JSON.stringify(
+      buildPlaywrightReport([{ title: 'loads homepage', status: 'expected' }])
+    ),
+    'apps/web/test-results/onboarding-robot-full-results.json': JSON.stringify(
+      buildPlaywrightReport([
+        {
+          title:
+            'creates a profile, verifies dashboard/public profile, and cleans up',
+          status: 'expected',
+        },
+      ])
+    ),
+    'apps/web/test-results/public-profile-smoke-results.json': JSON.stringify(
+      buildPlaywrightReport([
+        { title: 'renders public profile', status: 'expected' },
+      ])
+    ),
+  });
+
+  const result = parseSyntheticTestResults({
+    resultFiles: [
+      {
+        name: 'synthetic-auth-ui',
+        path: 'apps/web/test-results/synthetic-auth-ui-results.json',
+        required: true,
+      },
+      {
+        name: 'synthetic-golden-path',
+        path: 'apps/web/test-results/synthetic-golden-path-results.json',
+        required: true,
+      },
+      {
+        name: 'onboarding-robot-full',
+        path: 'apps/web/test-results/onboarding-robot-full-results.json',
+        required: true,
+      },
+      {
+        name: 'public-profile-smoke',
+        path: 'apps/web/test-results/public-profile-smoke-results.json',
+        required: true,
+      },
+      {
+        name: 'synthetic-legacy-otp',
+        path: 'apps/web/test-results/synthetic-legacy-otp-results.json',
+        required: false,
+      },
+    ],
+    fileSystem,
+  });
+
+  assert.equal(result.testStatus, 'passed');
+  assert.equal(result.totalTests, 4);
+});

--- a/.github/workflows/synthetic-monitoring.yml
+++ b/.github/workflows/synthetic-monitoring.yml
@@ -151,148 +151,26 @@ jobs:
         run: |
           node <<'NODE'
           const fs = require('node:fs');
+          const {
+            DEFAULT_RESULT_FILES,
+            formatGithubOutput,
+            parseSyntheticTestResults,
+          } = require('./.github/scripts/parse-synthetic-test-results.js');
+
           const legacyCanaryEnabled = process.env.LEGACY_CANARY_ENABLED === '1';
+          const result = parseSyntheticTestResults({
+            resultFiles: DEFAULT_RESULT_FILES(legacyCanaryEnabled),
+          });
 
-          const resultFiles = [
-            {
-              name: 'synthetic-auth-ui',
-              path: 'apps/web/test-results/synthetic-auth-ui-results.json',
-              required: true,
-            },
-            {
-              name: 'synthetic-golden-path',
-              path: 'apps/web/test-results/synthetic-golden-path-results.json',
-              required: true,
-            },
-            {
-              name: 'onboarding-robot-full',
-              path: 'apps/web/test-results/onboarding-robot-full-results.json',
-              required: true,
-            },
-            {
-              name: 'public-profile-smoke',
-              path: 'apps/web/test-results/public-profile-smoke-results.json',
-              required: true,
-            },
-            {
-              // Optional — legacy OTP canary is gated at the workflow level on
-              // `E2E_PROD_LEGACY_CANARY` (JOV-2446). When the step is skipped,
-              // no results file is produced and we must NOT treat that as an
-              // error.
-              name: 'synthetic-legacy-otp',
-              path: 'apps/web/test-results/synthetic-legacy-otp-results.json',
-              required: legacyCanaryEnabled,
-            },
-          ];
-          const outputFile = process.env.GITHUB_OUTPUT;
-
-          function emit(line) {
-            if (outputFile) {
-              fs.appendFileSync(outputFile, `${line}\n`);
-            } else {
-              console.log(line);
-            }
-          }
-
-          function emitMultiline(name, lines) {
-            emit(`${name}<<EOF`);
-            for (const line of lines) emit(line);
-            emit('EOF');
-          }
-
-          const specs = [];
-          const missingResults = [];
-
-          function collectSpecs(suites = [], source) {
-            for (const suite of suites) {
-              specs.push(
-                ...(suite.specs ?? []).map(spec => ({ source, spec }))
-              );
-              collectSpecs(suite.suites ?? [], source);
-            }
-          }
-
-          for (const resultFile of resultFiles) {
-            if (!fs.existsSync(resultFile.path)) {
-              if (resultFile.required !== false) {
-                missingResults.push(
-                  `${resultFile.name}: Test results file not found (${resultFile.path})`
-                );
-              } else {
-                console.log(
-                  `${resultFile.name}: optional results not produced (step likely skipped); ignoring.`
-                );
-              }
-              continue;
-            }
-
-            try {
-              const results = JSON.parse(
-                fs.readFileSync(resultFile.path, 'utf8')
-              );
-              collectSpecs(results.suites ?? [], resultFile.name);
-            } catch (error) {
-              missingResults.push(
-                `${resultFile.name}: Failed to parse ${resultFile.path}: ${error.message}`
-              );
-            }
-          }
-
-          const tests = specs.flatMap(({ source, spec }) =>
-            (spec.tests ?? []).map(testCase => ({ source, spec, testCase }))
-          );
-          const skipped = tests.filter(({ testCase }) =>
-            testCase.status === 'skipped' ||
-            (testCase.results ?? []).some(result => result.status === 'skipped')
-          );
-          const warnings = tests.flatMap(({ source, spec, testCase }) =>
-            (testCase.results ?? []).flatMap(result =>
-              [...(result.stdout ?? []), ...(result.stderr ?? [])]
-                .map(entry => entry.text ?? '')
-                .filter(text => text.includes('[Synthetic][warning]'))
-                .map(text => `${source}: ${spec.title}: ${text.trim()}`)
-            )
-          );
-          const flaky = tests.filter(({ testCase }) => testCase.status === 'flaky');
-          const failed = tests.filter(
-            ({ testCase }) => testCase.status === 'unexpected'
-          );
-          const passed = tests.filter(
-            ({ testCase }) =>
-              ['expected', 'flaky'].includes(testCase.status) &&
-              !(testCase.results ?? []).some(result => result.status === 'skipped')
-          );
-
-          emit(`total_tests=${tests.length}`);
-          emit(`passed_tests=${passed.length}`);
-          emit(`flaky_tests=${flaky.length}`);
-          emit(`skipped_tests=${skipped.length}`);
-          emit(`warning_count=${warnings.length}`);
-
-          const details = [
-            ...missingResults,
-            ...failed.map(({ source, spec }) => `${source}: ${spec.title}`),
-            ...(skipped.length > 0
-              ? [
-                  'Skipped tests:',
-                  ...skipped.map(({ source, spec }) => `${source}: ${spec.title}`),
-                ]
-              : []),
-          ];
-          emitMultiline('failed_tests', details);
-          emitMultiline('test_warnings', warnings);
-          for (const warning of warnings) {
+          for (const warning of result.testWarnings) {
             console.log(`::warning::${warning}`);
           }
 
-          if (missingResults.length > 0 || tests.length === 0) {
-            emit('test_status=error');
-          } else if (failed.length > 0 || skipped.length > 0) {
-            emit('test_status=failed');
-          } else if (passed.length === tests.length) {
-            emit('test_status=passed');
+          const outputFile = process.env.GITHUB_OUTPUT;
+          if (outputFile) {
+            fs.appendFileSync(outputFile, formatGithubOutput(result));
           } else {
-            emit('test_status=error');
+            process.stdout.write(formatGithubOutput(result));
           }
           NODE
 

--- a/apps/web/tests/unit/ci/synthetic-monitoring-workflow.test.ts
+++ b/apps/web/tests/unit/ci/synthetic-monitoring-workflow.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(testDir, '..', '..', '..', '..', '..');
+const workflowPath = resolve(
+  repoRoot,
+  '.github/workflows/synthetic-monitoring.yml'
+);
+
+function getStepBlock(workflow: string, stepName: string): string {
+  const lines = workflow.split('\n');
+  const start = lines.findIndex(line => line.trim() === `- name: ${stepName}`);
+
+  expect(start, `Missing workflow step: ${stepName}`).toBeGreaterThanOrEqual(0);
+
+  const block: string[] = [];
+
+  for (let index = start; index < lines.length; index++) {
+    const line = lines[index]!;
+
+    if (index > start && line.startsWith('      - name: ')) break;
+    if (index > start && /^[a-zA-Z0-9_-]+:/.test(line)) break;
+
+    block.push(line);
+  }
+
+  return block.join('\n');
+}
+
+describe('synthetic monitoring workflow parser', () => {
+  it('uses the shared parser module instead of inline skip-as-failure logic', () => {
+    const workflow = readFileSync(workflowPath, 'utf8');
+    const parseStep = getStepBlock(workflow, 'Parse test results');
+
+    expect(parseStep).toContain(
+      "require('./.github/scripts/parse-synthetic-test-results.js')"
+    );
+    expect(parseStep).toContain('parseSyntheticTestResults');
+    expect(parseStep).toContain('formatGithubOutput');
+    expect(parseStep).not.toContain('failed.length > 0 || skipped.length > 0');
+  });
+});


### PR DESCRIPTION
## Summary

Production Synthetic Monitoring was failing when the onboarding robot suite intentionally skipped (expected: 0, skipped: 1, unexpected: 0) even though no real test failures occurred.

This change extracts Playwright JSON parsing into `.github/scripts/parse-synthetic-test-results.js` and only marks the workflow as failed when Playwright reports `unexpected` failures. Intentional skips are still surfaced in output for visibility, but no longer trigger Slack paging or job failure when other suites pass.

## Linear

- Issue: JOV-2785
- URL: https://linear.app/jovie/issue/JOV-2785/fix-production-synthetic-monitor-skipped-onboarding-robot

<!-- linear-issue-identifier:JOV-2785 -->

## Test plan

- [x] `node --test .github/scripts/parse-synthetic-test-results.test.js`
- [x] `pnpm --filter @jovie/web exec vitest run tests/unit/ci/synthetic-monitoring-workflow.test.ts`
- [x] Biome on edited files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored synthetic test result parsing in GitHub Actions workflows to use a centralized, reusable module for improved maintainability and consistency of test result reporting.

* **Tests**
  * Added comprehensive unit tests for synthetic test result parsing to ensure accurate classification of test outcomes and proper warning extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->