### PR TITLE
Gate bulk press-photo import behind activation evidence (JOV-2878)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - **Printful merch mockup pipeline (JOV-2621)**: adds a mockup catalog, Printful mockup task creation/polling, authenticated `/api/merch/mockups`, and async chat merch enrichment that merges photorealistic mockup URLs into design options.
 
+### Changed
+
+- **[internal] Bulk press-photo import gate (JOV-2878)**: adds `bulk_press_photo_import` Statsig gate (default off), platform activation-evidence evaluation for manual press-photo usage, and gated scheduling after profile enrichment. Manual single-photo upload remains the default path; bulk import stays deferred until evidence thresholds pass.
+
 ## [26.6.30] - 2026-06-08
 
 > Library grid cards and list rows now line up with the page toolbar instead of sitting on a tighter inset.

--- a/apps/web/lib/dsp-enrichment/jobs/profile-enrichment.ts
+++ b/apps/web/lib/dsp-enrichment/jobs/profile-enrichment.ts
@@ -23,6 +23,7 @@ import {
 } from '@/lib/db/schema/profiles';
 import { DSP_PROVIDER_AVATAR_CONFIDENCE } from '@/lib/dsp-provider-metadata';
 import { captureError } from '@/lib/error-tracking';
+import { scheduleBulkPressPhotoImportIfEligible } from '@/lib/press-photos/schedule-bulk-import';
 import { buildThemeWithProfileAccent } from '@/lib/profile/profile-theme.server';
 import { logger } from '@/lib/utils/logger';
 import { setEnrichmentJobStatus } from '../enrichment-status';
@@ -606,7 +607,24 @@ export async function processProfileEnrichmentJob(
 export async function processProfileEnrichmentJobStandalone(
   jobPayload: unknown
 ): Promise<ProfileEnrichmentResult> {
-  return processProfileEnrichmentJob(db, jobPayload);
+  const result = await processProfileEnrichmentJob(db, jobPayload);
+
+  if (result.avatarCandidatesAdded > 0 && result.errors.length === 0) {
+    void scheduleBulkPressPhotoImportIfEligible({
+      creatorProfileId: result.creatorProfileId,
+      trigger: 'profile_enrichment_standalone',
+    }).catch(error => {
+      void captureError(
+        'Bulk press photo import scheduling failed after profile enrichment',
+        error,
+        {
+          creatorProfileId: result.creatorProfileId,
+        }
+      );
+    });
+  }
+
+  return result;
 }
 
 /**

--- a/apps/web/lib/flags/contracts.ts
+++ b/apps/web/lib/flags/contracts.ts
@@ -21,6 +21,7 @@ export const LEGACY_STATSIG_GATE_KEYS = {
   AI_CONNECTORS_BETA: 'ai_connectors_beta',
   IOS_APP_ALPHA_ACCESS: 'ios_app_alpha_access',
   MERCH_MVP: 'merch_mvp',
+  BULK_PRESS_PHOTO_IMPORT: 'bulk_press_photo_import',
 } as const;
 
 export type StatsigGateKey =
@@ -45,6 +46,7 @@ export const APP_FLAG_DEFAULTS = {
   AI_CONNECTORS_BETA: false,
   IOS_APP_ALPHA_ACCESS: false,
   MERCH_MVP: false,
+  BULK_PRESS_PHOTO_IMPORT: false,
   // DESIGN_V1 and all its surface aliases are permanently enabled.
   // Statsig gate "design_v1" is also set to 100% rollout.
   // The true default here ensures the new design is on even if Statsig is
@@ -76,6 +78,7 @@ export const APP_FLAG_KEYS = {
   AI_CONNECTORS_BETA: 'ai_connectors_beta',
   IOS_APP_ALPHA_ACCESS: 'ios_app_alpha_access',
   MERCH_MVP: LEGACY_STATSIG_GATE_KEYS.MERCH_MVP,
+  BULK_PRESS_PHOTO_IMPORT: LEGACY_STATSIG_GATE_KEYS.BULK_PRESS_PHOTO_IMPORT,
   DESIGN_V1: 'design_v1',
   SHELL_CHAT_V1: LEGACY_STATSIG_GATE_KEYS.DESIGN_V1,
   DESIGN_V1_RELEASES: LEGACY_STATSIG_GATE_KEYS.DESIGN_V1,
@@ -100,6 +103,7 @@ export const APP_FLAG_OVERRIDE_KEYS = {
   AI_CONNECTORS_BETA: 'code:AI_CONNECTORS_BETA',
   IOS_APP_ALPHA_ACCESS: 'code:IOS_APP_ALPHA_ACCESS',
   MERCH_MVP: 'code:MERCH_MVP',
+  BULK_PRESS_PHOTO_IMPORT: 'code:BULK_PRESS_PHOTO_IMPORT',
   DESIGN_V1: 'code:DESIGN_V1',
   SHELL_CHAT_V1: 'code:DESIGN_V1',
   DESIGN_V1_RELEASES: 'code:DESIGN_V1',
@@ -121,6 +125,7 @@ export const APP_FLAG_TO_STATSIG_GATE = {
   AI_CONNECTORS_BETA: LEGACY_STATSIG_GATE_KEYS.AI_CONNECTORS_BETA,
   IOS_APP_ALPHA_ACCESS: LEGACY_STATSIG_GATE_KEYS.IOS_APP_ALPHA_ACCESS,
   MERCH_MVP: LEGACY_STATSIG_GATE_KEYS.MERCH_MVP,
+  BULK_PRESS_PHOTO_IMPORT: LEGACY_STATSIG_GATE_KEYS.BULK_PRESS_PHOTO_IMPORT,
 } as const satisfies Partial<Record<AppFlagName, StatsigGateKey>>;
 
 export type StatsigBackedAppFlagName = keyof typeof APP_FLAG_TO_STATSIG_GATE;
@@ -140,6 +145,8 @@ export const APP_FLAG_DESCRIPTIONS = {
     'AI Connectors v1 beta (Gmail booking extraction → calendar)',
   IOS_APP_ALPHA_ACCESS: 'Internal iOS TestFlight alpha install access',
   MERCH_MVP: 'Jovie-owned merch creation, checkout, and Printful fulfillment',
+  BULK_PRESS_PHOTO_IMPORT:
+    'DSP bulk press-photo import after platform activation evidence passes',
   DESIGN_V1: 'New production design',
   SHELL_CHAT_V1: 'New production design alias for shell and chat',
   DESIGN_V1_RELEASES: 'New production design alias for releases',

--- a/apps/web/lib/flags/registry.ts
+++ b/apps/web/lib/flags/registry.ts
@@ -95,6 +95,7 @@ export const APP_FLAG_REGISTRY = {
   DESIGN_V1_ONBOARDING: buildBooleanFlag('DESIGN_V1_ONBOARDING'),
   AI_CONNECTORS_BETA: buildBooleanFlag('AI_CONNECTORS_BETA'),
   MERCH_MVP: buildBooleanFlag('MERCH_MVP'),
+  BULK_PRESS_PHOTO_IMPORT: buildBooleanFlag('BULK_PRESS_PHOTO_IMPORT'),
 } as const satisfies Record<AppFlagName, Flag<boolean, FlagEntities>>;
 
 export const SUBSCRIBE_CTA_VARIANT_FLAG = flag<

--- a/apps/web/lib/press-photos/activation-evidence.ts
+++ b/apps/web/lib/press-photos/activation-evidence.ts
@@ -1,0 +1,206 @@
+import 'server-only';
+
+import {
+  and,
+  count,
+  countDistinct,
+  sql as drizzleSql,
+  eq,
+  gte,
+  inArray,
+} from 'drizzle-orm';
+
+import { db } from '@/lib/db';
+import {
+  creatorAvatarCandidates,
+  creatorProfiles,
+  profilePhotos,
+} from '@/lib/db/schema/profiles';
+
+/** Rolling window for manual press-photo usage signals. */
+export const ACTIVATION_EVIDENCE_LOOKBACK_DAYS = 30;
+
+export interface BulkPressPhotoActivationEvidence {
+  readonly lookbackDays: number;
+  readonly manualUploadCount: number;
+  readonly manualUploadProfiles: number;
+  readonly profilesWithMultipleManualPressPhotos: number;
+  readonly ingestedDraftCount: number;
+  readonly avatarCandidateProfiles: number;
+}
+
+export interface ActivationEvidenceThresholds {
+  readonly minManualUploadCount: number;
+  readonly minManualUploadProfiles: number;
+  readonly minProfilesWithMultipleManualPressPhotos: number;
+}
+
+export const DEFAULT_ACTIVATION_EVIDENCE_THRESHOLDS: ActivationEvidenceThresholds =
+  {
+    minManualUploadCount: 20,
+    minManualUploadProfiles: 8,
+    minProfilesWithMultipleManualPressPhotos: 5,
+  };
+
+export type ActivationEvidenceDecisionReason =
+  | 'override_passed'
+  | 'manual_upload_volume'
+  | 'multi_photo_migration_signal'
+  | 'insufficient_manual_upload_volume'
+  | 'insufficient_migration_signal';
+
+export interface ActivationEvidenceEvaluation {
+  readonly passed: boolean;
+  readonly reason: ActivationEvidenceDecisionReason;
+  readonly evidence: BulkPressPhotoActivationEvidence;
+  readonly thresholds: ActivationEvidenceThresholds;
+}
+
+function getLookbackStartDate(
+  lookbackDays = ACTIVATION_EVIDENCE_LOOKBACK_DAYS
+): Date {
+  const start = new Date();
+  start.setUTCDate(start.getUTCDate() - lookbackDays);
+  return start;
+}
+
+function isEvidenceOverrideEnabled(): boolean {
+  return process.env.BULK_PRESS_PHOTO_IMPORT_EVIDENCE_OVERRIDE === 'passed';
+}
+
+export async function collectBulkPressPhotoActivationEvidence(options?: {
+  readonly lookbackDays?: number;
+}): Promise<BulkPressPhotoActivationEvidence> {
+  const lookbackDays =
+    options?.lookbackDays ?? ACTIVATION_EVIDENCE_LOOKBACK_DAYS;
+  const lookbackStart = getLookbackStartDate(lookbackDays);
+  const manualPressPhotoFilter = and(
+    eq(profilePhotos.photoType, 'press'),
+    eq(profilePhotos.sourceType, 'manual'),
+    inArray(profilePhotos.status, ['ready', 'draft', 'processing']),
+    gte(profilePhotos.createdAt, lookbackStart)
+  );
+
+  const [manualUploadMetrics] = await db
+    .select({
+      manualUploadCount: count(),
+      manualUploadProfiles: countDistinct(profilePhotos.creatorProfileId),
+    })
+    .from(profilePhotos)
+    .where(manualPressPhotoFilter);
+
+  const multiPhotoProfiles = await db
+    .select({
+      creatorProfileId: profilePhotos.creatorProfileId,
+      photoCount: count(),
+    })
+    .from(profilePhotos)
+    .where(manualPressPhotoFilter)
+    .groupBy(profilePhotos.creatorProfileId)
+    .having(drizzleSql`count(*) >= 2`);
+
+  const [ingestedDraftMetrics] = await db
+    .select({
+      ingestedDraftCount: count(),
+    })
+    .from(profilePhotos)
+    .where(
+      and(
+        eq(profilePhotos.photoType, 'press'),
+        eq(profilePhotos.sourceType, 'ingested'),
+        eq(profilePhotos.status, 'draft')
+      )
+    );
+
+  const [avatarCandidateMetrics] = await db
+    .select({
+      avatarCandidateProfiles: countDistinct(
+        creatorAvatarCandidates.creatorProfileId
+      ),
+    })
+    .from(creatorAvatarCandidates)
+    .innerJoin(
+      creatorProfiles,
+      eq(creatorProfiles.id, creatorAvatarCandidates.creatorProfileId)
+    )
+    .where(eq(creatorProfiles.isClaimed, true));
+
+  return {
+    lookbackDays,
+    manualUploadCount: Number(manualUploadMetrics?.manualUploadCount ?? 0),
+    manualUploadProfiles: Number(
+      manualUploadMetrics?.manualUploadProfiles ?? 0
+    ),
+    profilesWithMultipleManualPressPhotos: multiPhotoProfiles.length,
+    ingestedDraftCount: Number(ingestedDraftMetrics?.ingestedDraftCount ?? 0),
+    avatarCandidateProfiles: Number(
+      avatarCandidateMetrics?.avatarCandidateProfiles ?? 0
+    ),
+  };
+}
+
+export function evaluateActivationEvidence(
+  evidence: BulkPressPhotoActivationEvidence,
+  thresholds: ActivationEvidenceThresholds = DEFAULT_ACTIVATION_EVIDENCE_THRESHOLDS
+): ActivationEvidenceEvaluation {
+  if (isEvidenceOverrideEnabled()) {
+    return {
+      passed: true,
+      reason: 'override_passed',
+      evidence,
+      thresholds,
+    };
+  }
+
+  const hasManualUploadVolume =
+    evidence.manualUploadCount >= thresholds.minManualUploadCount &&
+    evidence.manualUploadProfiles >= thresholds.minManualUploadProfiles;
+
+  if (hasManualUploadVolume) {
+    return {
+      passed: true,
+      reason: 'manual_upload_volume',
+      evidence,
+      thresholds,
+    };
+  }
+
+  const hasMigrationSignal =
+    evidence.profilesWithMultipleManualPressPhotos >=
+    thresholds.minProfilesWithMultipleManualPressPhotos;
+
+  if (hasMigrationSignal) {
+    return {
+      passed: true,
+      reason: 'multi_photo_migration_signal',
+      evidence,
+      thresholds,
+    };
+  }
+
+  const reason =
+    evidence.profilesWithMultipleManualPressPhotos > 0
+      ? 'insufficient_migration_signal'
+      : 'insufficient_manual_upload_volume';
+
+  return {
+    passed: false,
+    reason,
+    evidence,
+    thresholds,
+  };
+}
+
+export async function evaluateBulkPressPhotoActivationEvidence(options?: {
+  readonly lookbackDays?: number;
+  readonly thresholds?: ActivationEvidenceThresholds;
+}): Promise<ActivationEvidenceEvaluation> {
+  const evidence = await collectBulkPressPhotoActivationEvidence({
+    lookbackDays: options?.lookbackDays,
+  });
+
+  return evaluateActivationEvidence(
+    evidence,
+    options?.thresholds ?? DEFAULT_ACTIVATION_EVIDENCE_THRESHOLDS
+  );
+}

--- a/apps/web/lib/press-photos/bulk-import-gate.ts
+++ b/apps/web/lib/press-photos/bulk-import-gate.ts
@@ -1,0 +1,83 @@
+import 'server-only';
+
+import { getAppFlagValue } from '@/lib/flags/server';
+import { logger } from '@/lib/utils/logger';
+
+import {
+  type ActivationEvidenceEvaluation,
+  evaluateBulkPressPhotoActivationEvidence,
+} from './activation-evidence';
+
+export type BulkPressPhotoImportGateReason =
+  | 'allowed'
+  | 'feature_flag_disabled'
+  | 'activation_evidence_missing';
+
+export interface BulkPressPhotoImportGateEvaluation {
+  readonly allowed: boolean;
+  readonly reason: BulkPressPhotoImportGateReason;
+  readonly featureFlagEnabled: boolean;
+  readonly activationEvidence: ActivationEvidenceEvaluation;
+}
+
+export async function evaluateBulkPressPhotoImportGate(options?: {
+  readonly clerkUserId?: string | null;
+}): Promise<BulkPressPhotoImportGateEvaluation> {
+  const [featureFlagEnabled, activationEvidence] = await Promise.all([
+    getAppFlagValue('BULK_PRESS_PHOTO_IMPORT', {
+      userId: options?.clerkUserId ?? null,
+    }),
+    evaluateBulkPressPhotoActivationEvidence(),
+  ]);
+
+  if (!featureFlagEnabled) {
+    return {
+      allowed: false,
+      reason: 'feature_flag_disabled',
+      featureFlagEnabled,
+      activationEvidence,
+    };
+  }
+
+  if (!activationEvidence.passed) {
+    return {
+      allowed: false,
+      reason: 'activation_evidence_missing',
+      featureFlagEnabled,
+      activationEvidence,
+    };
+  }
+
+  return {
+    allowed: true,
+    reason: 'allowed',
+    featureFlagEnabled,
+    activationEvidence,
+  };
+}
+
+export function logBulkPressPhotoImportGateDecision(
+  evaluation: BulkPressPhotoImportGateEvaluation,
+  context: {
+    readonly creatorProfileId: string;
+    readonly trigger: string;
+  }
+): void {
+  if (evaluation.allowed) {
+    logger.info('[press-photo-import-gate] Bulk import allowed', {
+      creatorProfileId: context.creatorProfileId,
+      trigger: context.trigger,
+      activationReason: evaluation.activationEvidence.reason,
+      evidence: evaluation.activationEvidence.evidence,
+    });
+    return;
+  }
+
+  logger.info('[press-photo-import-gate] Bulk import blocked', {
+    creatorProfileId: context.creatorProfileId,
+    trigger: context.trigger,
+    gateReason: evaluation.reason,
+    activationReason: evaluation.activationEvidence.reason,
+    evidence: evaluation.activationEvidence.evidence,
+  });
+}

--- a/apps/web/lib/press-photos/schedule-bulk-import.ts
+++ b/apps/web/lib/press-photos/schedule-bulk-import.ts
@@ -1,0 +1,120 @@
+import 'server-only';
+
+import { eq } from 'drizzle-orm';
+
+import { db } from '@/lib/db';
+import { users } from '@/lib/db/schema/auth';
+import { creatorProfiles } from '@/lib/db/schema/profiles';
+import { ingestDspPressPhotos } from '@/lib/dsp-enrichment/jobs/press-photo-ingestion';
+import { captureError } from '@/lib/error-tracking';
+import { logger } from '@/lib/utils/logger';
+
+import {
+  evaluateBulkPressPhotoImportGate,
+  logBulkPressPhotoImportGateDecision,
+} from './bulk-import-gate';
+
+export interface ScheduleBulkPressPhotoImportParams {
+  readonly creatorProfileId: string;
+  readonly trigger: string;
+}
+
+export interface ScheduleBulkPressPhotoImportResult {
+  readonly scheduled: boolean;
+  readonly gateReason: string;
+  readonly photosIngested?: number;
+  readonly photosSkipped?: number;
+}
+
+async function resolveProfileOwners(creatorProfileId: string): Promise<{
+  userId: string;
+  clerkUserId: string;
+} | null> {
+  const [row] = await db
+    .select({
+      userId: creatorProfiles.userId,
+      clerkUserId: users.clerkId,
+    })
+    .from(creatorProfiles)
+    .innerJoin(users, eq(users.id, creatorProfiles.userId))
+    .where(eq(creatorProfiles.id, creatorProfileId))
+    .limit(1);
+
+  if (!row?.userId || !row.clerkUserId) {
+    return null;
+  }
+
+  return {
+    userId: row.userId,
+    clerkUserId: row.clerkUserId,
+  };
+}
+
+/**
+ * Attempt DSP bulk press-photo import only when the Statsig gate and
+ * platform activation evidence both pass. Single-photo manual upload remains
+ * the default path regardless of this gate.
+ */
+export async function scheduleBulkPressPhotoImportIfEligible(
+  params: ScheduleBulkPressPhotoImportParams
+): Promise<ScheduleBulkPressPhotoImportResult> {
+  const owners = await resolveProfileOwners(params.creatorProfileId);
+  if (!owners) {
+    logger.warn('[press-photo-import-gate] Profile owners missing for import', {
+      creatorProfileId: params.creatorProfileId,
+      trigger: params.trigger,
+    });
+    return {
+      scheduled: false,
+      gateReason: 'profile_not_found',
+    };
+  }
+
+  const gate = await evaluateBulkPressPhotoImportGate({
+    clerkUserId: owners.clerkUserId,
+  });
+  logBulkPressPhotoImportGateDecision(gate, {
+    creatorProfileId: params.creatorProfileId,
+    trigger: params.trigger,
+  });
+
+  if (!gate.allowed) {
+    return {
+      scheduled: false,
+      gateReason: gate.reason,
+    };
+  }
+
+  try {
+    const result = await ingestDspPressPhotos(
+      params.creatorProfileId,
+      owners.userId,
+      owners.clerkUserId
+    );
+
+    logger.info('[press-photo-import-gate] Bulk import completed', {
+      creatorProfileId: params.creatorProfileId,
+      trigger: params.trigger,
+      photosIngested: result.photosIngested,
+      photosSkipped: result.photosSkipped,
+      errors: result.errors,
+    });
+
+    return {
+      scheduled: true,
+      gateReason: gate.reason,
+      photosIngested: result.photosIngested,
+      photosSkipped: result.photosSkipped,
+    };
+  } catch (error) {
+    await captureError(
+      'Bulk press photo import failed after gate passed',
+      error,
+      {
+        creatorProfileId: params.creatorProfileId,
+        trigger: params.trigger,
+      }
+    );
+    throw error;
+  }
+}

--- a/apps/web/tests/unit/lib/press-photos/activation-evidence.test.ts
+++ b/apps/web/tests/unit/lib/press-photos/activation-evidence.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  type BulkPressPhotoActivationEvidence,
+  DEFAULT_ACTIVATION_EVIDENCE_THRESHOLDS,
+  evaluateActivationEvidence,
+} from '@/lib/press-photos/activation-evidence';
+
+const BASE_EVIDENCE: BulkPressPhotoActivationEvidence = {
+  lookbackDays: 30,
+  manualUploadCount: 0,
+  manualUploadProfiles: 0,
+  profilesWithMultipleManualPressPhotos: 0,
+  ingestedDraftCount: 0,
+  avatarCandidateProfiles: 0,
+};
+
+describe('bulk press-photo activation evidence', () => {
+  afterEach(() => {
+    delete process.env.BULK_PRESS_PHOTO_IMPORT_EVIDENCE_OVERRIDE;
+  });
+
+  it('fails when manual upload volume is below threshold', () => {
+    const evaluation = evaluateActivationEvidence({
+      ...BASE_EVIDENCE,
+      manualUploadCount: 4,
+      manualUploadProfiles: 2,
+    });
+
+    expect(evaluation.passed).toBe(false);
+    expect(evaluation.reason).toBe('insufficient_manual_upload_volume');
+  });
+
+  it('passes when manual upload volume crosses the threshold', () => {
+    const evaluation = evaluateActivationEvidence({
+      ...BASE_EVIDENCE,
+      manualUploadCount:
+        DEFAULT_ACTIVATION_EVIDENCE_THRESHOLDS.minManualUploadCount,
+      manualUploadProfiles:
+        DEFAULT_ACTIVATION_EVIDENCE_THRESHOLDS.minManualUploadProfiles,
+    });
+
+    expect(evaluation.passed).toBe(true);
+    expect(evaluation.reason).toBe('manual_upload_volume');
+  });
+
+  it('passes on multi-photo migration signal even with low total volume', () => {
+    const evaluation = evaluateActivationEvidence({
+      ...BASE_EVIDENCE,
+      profilesWithMultipleManualPressPhotos:
+        DEFAULT_ACTIVATION_EVIDENCE_THRESHOLDS.minProfilesWithMultipleManualPressPhotos,
+    });
+
+    expect(evaluation.passed).toBe(true);
+    expect(evaluation.reason).toBe('multi_photo_migration_signal');
+  });
+
+  it('reports insufficient migration signal when some multi-photo demand exists', () => {
+    const evaluation = evaluateActivationEvidence({
+      ...BASE_EVIDENCE,
+      profilesWithMultipleManualPressPhotos: 2,
+    });
+
+    expect(evaluation.passed).toBe(false);
+    expect(evaluation.reason).toBe('insufficient_migration_signal');
+  });
+
+  it('honors the non-prod evidence override', () => {
+    process.env.BULK_PRESS_PHOTO_IMPORT_EVIDENCE_OVERRIDE = 'passed';
+
+    const evaluation = evaluateActivationEvidence(BASE_EVIDENCE);
+
+    expect(evaluation.passed).toBe(true);
+    expect(evaluation.reason).toBe('override_passed');
+  });
+});

--- a/apps/web/tests/unit/lib/press-photos/bulk-import-gate.test.ts
+++ b/apps/web/tests/unit/lib/press-photos/bulk-import-gate.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getAppFlagValue: vi.fn(),
+  evaluateBulkPressPhotoActivationEvidence: vi.fn(),
+  ingestDspPressPhotos: vi.fn(),
+  dbSelect: vi.fn(),
+}));
+
+vi.mock('@/lib/flags/server', () => ({
+  getAppFlagValue: mocks.getAppFlagValue,
+}));
+
+vi.mock('@/lib/press-photos/activation-evidence', async importOriginal => {
+  const actual =
+    await importOriginal<
+      typeof import('@/lib/press-photos/activation-evidence')
+    >();
+  return {
+    ...actual,
+    evaluateBulkPressPhotoActivationEvidence:
+      mocks.evaluateBulkPressPhotoActivationEvidence,
+  };
+});
+
+vi.mock('@/lib/dsp-enrichment/jobs/press-photo-ingestion', () => ({
+  ingestDspPressPhotos: mocks.ingestDspPressPhotos,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mocks.dbSelect,
+  },
+}));
+
+function mockProfileOwners(): void {
+  mocks.dbSelect.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([
+            {
+              userId: 'user-123',
+              clerkUserId: 'clerk-123',
+            },
+          ]),
+        }),
+      }),
+    }),
+  });
+}
+
+function buildActivationEvaluation(passed: boolean) {
+  return {
+    passed,
+    reason: passed
+      ? 'manual_upload_volume'
+      : 'insufficient_manual_upload_volume',
+    evidence: {
+      lookbackDays: 30,
+      manualUploadCount: passed ? 25 : 0,
+      manualUploadProfiles: passed ? 10 : 0,
+      profilesWithMultipleManualPressPhotos: 0,
+      ingestedDraftCount: 0,
+      avatarCandidateProfiles: 12,
+    },
+    thresholds: {
+      minManualUploadCount: 20,
+      minManualUploadProfiles: 8,
+      minProfilesWithMultipleManualPressPhotos: 5,
+    },
+  };
+}
+
+describe('bulk press-photo import gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockProfileOwners();
+    mocks.ingestDspPressPhotos.mockResolvedValue({
+      creatorProfileId: 'profile-123',
+      photosIngested: 2,
+      photosSkipped: 0,
+      errors: [],
+    });
+  });
+
+  it('blocks when the feature flag is disabled', async () => {
+    mocks.getAppFlagValue.mockResolvedValue(false);
+    mocks.evaluateBulkPressPhotoActivationEvidence.mockResolvedValue(
+      buildActivationEvaluation(true)
+    );
+
+    const { evaluateBulkPressPhotoImportGate } = await import(
+      '@/lib/press-photos/bulk-import-gate'
+    );
+    const evaluation = await evaluateBulkPressPhotoImportGate({
+      clerkUserId: 'clerk-123',
+    });
+
+    expect(evaluation.allowed).toBe(false);
+    expect(evaluation.reason).toBe('feature_flag_disabled');
+  });
+
+  it('blocks when activation evidence is missing', async () => {
+    mocks.getAppFlagValue.mockResolvedValue(true);
+    mocks.evaluateBulkPressPhotoActivationEvidence.mockResolvedValue(
+      buildActivationEvaluation(false)
+    );
+
+    const { evaluateBulkPressPhotoImportGate } = await import(
+      '@/lib/press-photos/bulk-import-gate'
+    );
+    const evaluation = await evaluateBulkPressPhotoImportGate({
+      clerkUserId: 'clerk-123',
+    });
+
+    expect(evaluation.allowed).toBe(false);
+    expect(evaluation.reason).toBe('activation_evidence_missing');
+  });
+
+  it('schedules ingestion only when the gate passes', async () => {
+    mocks.getAppFlagValue.mockResolvedValue(true);
+    mocks.evaluateBulkPressPhotoActivationEvidence.mockResolvedValue(
+      buildActivationEvaluation(true)
+    );
+
+    const { scheduleBulkPressPhotoImportIfEligible } = await import(
+      '@/lib/press-photos/schedule-bulk-import'
+    );
+
+    const result = await scheduleBulkPressPhotoImportIfEligible({
+      creatorProfileId: 'profile-123',
+      trigger: 'test',
+    });
+
+    expect(result.scheduled).toBe(true);
+    expect(result.photosIngested).toBe(2);
+    expect(mocks.ingestDspPressPhotos).toHaveBeenCalledWith(
+      'profile-123',
+      'user-123',
+      'clerk-123'
+    );
+  });
+
+  it('skips ingestion when the gate blocks', async () => {
+    mocks.getAppFlagValue.mockResolvedValue(false);
+    mocks.evaluateBulkPressPhotoActivationEvidence.mockResolvedValue(
+      buildActivationEvaluation(true)
+    );
+
+    const { scheduleBulkPressPhotoImportIfEligible } = await import(
+      '@/lib/press-photos/schedule-bulk-import'
+    );
+
+    const result = await scheduleBulkPressPhotoImportIfEligible({
+      creatorProfileId: 'profile-123',
+      trigger: 'test',
+    });
+
+    expect(result.scheduled).toBe(false);
+    expect(result.gateReason).toBe('feature_flag_disabled');
+    expect(mocks.ingestDspPressPhotos).not.toHaveBeenCalled();
+  });
+});

--- a/docs/FEATURE_REGISTRY.md
+++ b/docs/FEATURE_REGISTRY.md
@@ -41,6 +41,7 @@ This document is the canonical feature list for Jovie. It is designed for onboar
 | Profile | Subscribe / follow page | Shipped | Free+ | None | /username/subscribe |
 | Profile | Contact page | Shipped | Free+ | None | /username/contact |
 | Profile | About page | Shipped | Free+ | None | /username/about |
+| Profile | DSP bulk press-photo import | Shipped (flagged) | Flag + evidence-gated | `bulk_press_photo_import` | Default off; requires platform activation evidence before auto-ingesting DSP images as draft press photos |
 | Profile | Tour dates (Bandsintown) | Shipped | Free+ | None | /username/tour |
 | Profile | Latest release card on profile | Shipped (flagged) | Free+ | `feature_latest_release_card` | Rollout-controlled UI module |
 | Profile | Verified badge | Shipped | Pro+ | None | Entitlement-backed (`canBeVerified`) |

--- a/docs/STATSIG_FEATURE_GATES.md
+++ b/docs/STATSIG_FEATURE_GATES.md
@@ -25,6 +25,7 @@ experiments used by the web app.
 | `ai_connectors_beta` | `LEGACY_STATSIG_GATE_KEYS.AI_CONNECTORS_BETA` | `false` | AI Connector v1 closed beta — Gmail booking email → Google Calendar event flow | Active |
 | `ios_app_alpha_access` | `LEGACY_STATSIG_GATE_KEYS.IOS_APP_ALPHA_ACCESS` | `false` | Internal iOS TestFlight install access | Active |
 | `merch_mvp` | `LEGACY_STATSIG_GATE_KEYS.MERCH_MVP` | `false` | Jovie-owned merch generation, public merch cards, checkout, and Printful fulfillment | Active |
+| `bulk_press_photo_import` | `LEGACY_STATSIG_GATE_KEYS.BULK_PRESS_PHOTO_IMPORT` | `false` | DSP bulk press-photo import after platform activation evidence passes | Active |
 | `ai_chat_disabled` | `CHAT_KILL_SWITCH_GATES.DISABLED` | `false` | Emergency kill switch for `/api/chat` | Active |
 | `ai_chat_force_light` | `CHAT_KILL_SWITCH_GATES.FORCE_LIGHT` | `false` | Runtime switch to route `/api/chat` to the lighter model | Active |
 

--- a/docs/plans/bulk-press-photo-import-gate.md
+++ b/docs/plans/bulk-press-photo-import-gate.md
@@ -1,0 +1,58 @@
+# Bulk Press-Photo Import Gate (JOV-2878)
+
+## Decision (2026-06-08)
+
+Bulk DSP press-photo import remains **deferred** in production. The ingestion
+implementation (`ingestDspPressPhotos`) is wired only behind a two-layer gate:
+
+1. Statsig gate `bulk_press_photo_import` (default off)
+2. Platform activation evidence evaluation (`lib/press-photos/activation-evidence.ts`)
+
+Manual single-photo upload in the profile drawer remains the default and only
+user-facing import path today.
+
+## Activation evidence definition
+
+Evidence is evaluated on a rolling 30-day window using `profile_photos` and
+`creator_avatar_candidates` signals:
+
+| Signal | Purpose |
+|---|---|
+| Manual press-photo upload count | Users are actively adding press photos |
+| Profiles with manual press photos | Breadth of adoption |
+| Profiles with 2+ manual press photos | Migration / bulk-import demand proxy |
+| Ingested draft count | Existing auto-ingest residue monitoring |
+| Avatar-candidate profile count | DSP enrichment prerequisite health |
+
+### Pass thresholds
+
+Bulk import is allowed only when **either**:
+
+- `manualUploadCount >= 20` **and** `manualUploadProfiles >= 8`, or
+- `profilesWithMultipleManualPressPhotos >= 5`
+
+### Current status
+
+No production rollout is planned until analytics/support review confirms the
+thresholds above. Operators can force evidence evaluation to pass in non-prod via
+`BULK_PRESS_PHOTO_IMPORT_EVIDENCE_OVERRIDE=passed`.
+
+## Runtime entry point
+
+`scheduleBulkPressPhotoImportIfEligible()` is called after successful profile
+enrichment when avatar candidates were added. It logs allow/block decisions and
+never replaces the manual upload flow.
+
+## Out of scope
+
+- AI body estimation
+- Broad media-library management
+- Social/sharing workflows
+- Onboarding auto-ingest wiring (blocked until evidence + gate pass review)
+
+## Revisit checklist
+
+1. Pull manual press-photo upload metrics from analytics + DB
+2. Confirm support/customer migration requests
+3. Enable `bulk_press_photo_import` for an internal allowlist in Statsig
+4. Re-run unit tests and add screenshots for draft approval UX


### PR DESCRIPTION
## Summary

Gates DSP bulk press-photo import behind a two-layer control:

1. Statsig gate `bulk_press_photo_import` (default off)
2. Platform activation evidence (manual press-photo usage thresholds)

Manual single-photo upload in the profile drawer remains the default path. Bulk import is deferred until both controls pass.

## Changes

- Add `lib/press-photos/activation-evidence.ts` with rolling 30-day usage signals
- Add `lib/press-photos/bulk-import-gate.ts` and `schedule-bulk-import.ts`
- Wire gated scheduling after successful profile enrichment when avatar candidates are added
- Register `BULK_PRESS_PHOTO_IMPORT` in flags contracts/registry + docs
- Document deferral decision in `docs/plans/bulk-press-photo-import-gate.md`

## Verification

- `pnpm --filter web exec vitest run tests/unit/lib/press-photos/activation-evidence.test.ts tests/unit/lib/press-photos/bulk-import-gate.test.ts tests/unit/lib/feature-flags-registry.test.ts`
- `pnpm --filter web run typecheck`
- Pre-push hook: biome, proxy guard, tailwind guard, typecheck, lint

## Decision

Bulk import stays **off** in production until manual press-photo usage crosses evidence thresholds. Operators can force evidence pass in non-prod via `BULK_PRESS_PHOTO_IMPORT_EVIDENCE_OVERRIDE=passed`.

<!-- linear-issue-id:JOV-2878 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk press-photo import capability for streamlined content management. Controlled by a feature flag (off by default) and platform activation evidence requirements. When activated, automatically ingests bulk images as draft press photos following profile enrichment. Manual single-photo uploads remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->