### PR TITLE
feat(ops): freshness indicators and per-source failure states (JOV-2123)

### DIFF
--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -30,6 +30,7 @@ import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
 import { QRCode } from '@/components/molecules/QRCode';
 import { ShellListRowFrame } from '@/components/organisms/table';
 import { AGENT_OS_ADMIN_FIXTURE_ARTIFACTS } from '@/lib/agent-os/fixtures';
+import { isHudMetricValueAvailable } from '@/lib/hud/source-trust';
 import {
   getDefaultStatusTone,
   getDeploymentLabel,
@@ -43,6 +44,7 @@ import type {
   HudMetrics,
 } from '@/types/hud';
 import { HudClockClient } from './HudClockClient';
+import { HudMetricSourceTrust } from './HudMetricSourceTrust';
 import { HudStatusPill } from './HudStatusPill';
 import { useHudMetricsQuery } from './useHudMetricsQuery';
 
@@ -334,6 +336,25 @@ function DeploymentsPanel({
   );
 }
 
+function DeploymentsPanelWithTrust({
+  deployments,
+  detail,
+  githubSource,
+  onRetry,
+}: Readonly<{
+  readonly deployments: HudMetrics['deployments'];
+  readonly detail: string;
+  readonly githubSource: HudMetrics['sources']['github'];
+  readonly onRetry?: () => void;
+}>) {
+  return (
+    <div className='space-y-2'>
+      <DeploymentsPanel deployments={deployments} detail={detail} />
+      <HudMetricSourceTrust source={githubSource} onRetry={onRetry} />
+    </div>
+  );
+}
+
 function AiOpsItemRow({
   item,
   onDismiss,
@@ -545,6 +566,19 @@ function makeItemKey(item: HudMetrics['aiOps']['blockers'][number]): string {
   return `${item.source}|${item.summary}|${item.updatedAt}`;
 }
 
+function metricSubtitleWithTrust(
+  body: ReactNode,
+  source: HudMetrics['sources'][keyof HudMetrics['sources']],
+  onRetry?: () => void
+): ReactNode {
+  return (
+    <>
+      {body}
+      <HudMetricSourceTrust source={source} onRetry={onRetry} />
+    </>
+  );
+}
+
 export function HudDashboardClient({
   initialMetrics,
   density = 'kiosk',
@@ -579,6 +613,14 @@ export function HudDashboardClient({
   const deploymentDetail = getDeploymentDetail(metrics.deployments);
   const aiOpsTone = getAiOpsTone(metrics.aiOps);
   const aiOpsLabel = getAiOpsLabel(metrics.aiOps);
+  const stripeSource = metrics.sources.stripe;
+  const mercurySource = metrics.sources.mercury;
+  const databaseSource = metrics.sources.database;
+  const sentrySource = metrics.sources.sentry;
+  const githubSource = metrics.sources.github;
+  const handleSourceRetry = () => {
+    refetch().catch(() => {});
+  };
 
   const isShell = density === 'shell';
   const showDispatch = presentationMode !== 'token';
@@ -624,13 +666,20 @@ export function HudDashboardClient({
         <div className='grid gap-3 md:grid-cols-2 xl:grid-cols-4'>
           <ContentMetricCard
             label='MRR'
-            value={formatUsd(metrics.overview.mrrUsd)}
-            subtitle={
-              <span>
-                {metrics.overview.activeSubscribers.toLocaleString('en-US')}{' '}
-                subscribers
-              </span>
+            value={
+              isHudMetricValueAvailable(stripeSource)
+                ? formatUsd(metrics.overview.mrrUsd)
+                : '\u2014'
             }
+            subtitle={metricSubtitleWithTrust(
+              <span>
+                {isHudMetricValueAvailable(stripeSource)
+                  ? `${metrics.overview.activeSubscribers.toLocaleString('en-US')} subscribers`
+                  : 'Stripe data unavailable'}
+              </span>,
+              stripeSource,
+              handleSourceRetry
+            )}
             headerRight={
               <HudStatusPill label={deploymentLabel} tone={deploymentsTone} />
             }
@@ -640,13 +689,13 @@ export function HudDashboardClient({
           <ContentMetricCard
             label='Runway'
             value={
-              metrics.overview.financialDataAvailable
+              isHudMetricValueAvailable(mercurySource)
                 ? formatRunway(metrics.overview.runwayMonths)
                 : '\u2014'
             }
-            subtitle={
-              metrics.overview.financialDataAvailable ? (
-                <div className='mt-2 grid gap-1.5'>
+            subtitle={metricSubtitleWithTrust(
+              isHudMetricValueAvailable(mercurySource) ? (
+                <div className='grid gap-1.5'>
                   <ContentMetricRow
                     label='Cash'
                     value={formatUsd(metrics.overview.balanceUsd)}
@@ -657,27 +706,35 @@ export function HudDashboardClient({
                   />
                 </div>
               ) : (
-                'Unavailable'
-              )
-            }
+                <span>Mercury data unavailable</span>
+              ),
+              mercurySource,
+              handleSourceRetry
+            )}
             className='p-3'
             valueClassName={secondaryValueClass}
           />
           <ContentMetricCard
             label='Operations'
             value={metrics.operations.status === 'ok' ? 'Healthy' : 'Degraded'}
-            subtitle={
+            subtitle={metricSubtitleWithTrust(
               metrics.operations.dbLatencyMs === null
-                ? 'DB latency -'
-                : `DB latency ${metrics.operations.dbLatencyMs.toFixed(0)}ms`
-            }
+                ? 'DB latency —'
+                : `DB latency ${metrics.operations.dbLatencyMs.toFixed(0)}ms`,
+              databaseSource,
+              handleSourceRetry
+            )}
             className='p-3'
             valueClassName={secondaryValueClass}
           />
           <ContentMetricCard
             label='Reliability'
             value={`${metrics.reliability.reliabilityScorePercent.toFixed(1)}%`}
-            subtitle={formatReliabilitySubtitle(metrics.reliability)}
+            subtitle={metricSubtitleWithTrust(
+              formatReliabilitySubtitle(metrics.reliability),
+              sentrySource,
+              handleSourceRetry
+            )}
             className='p-3'
             valueClassName={secondaryValueClass}
           />
@@ -689,9 +746,11 @@ export function HudDashboardClient({
             summary={aiOpsSummary}
             status={<HudStatusPill label={aiOpsLabel} tone={aiOpsTone} />}
             deploymentsPanel={
-              <DeploymentsPanel
+              <DeploymentsPanelWithTrust
                 deployments={metrics.deployments}
                 detail={deploymentDetail}
+                githubSource={githubSource}
+                onRetry={handleSourceRetry}
               />
             }
           />
@@ -787,13 +846,20 @@ export function HudDashboardClient({
         <div className='grid gap-3 content-start'>
           <ContentMetricCard
             label='Monthly recurring revenue'
-            value={formatUsd(metrics.overview.mrrUsd)}
-            subtitle={
-              <span className='text-[14px] text-secondary-token'>
-                {metrics.overview.activeSubscribers.toLocaleString('en-US')}{' '}
-                subscribers
-              </span>
+            value={
+              isHudMetricValueAvailable(stripeSource)
+                ? formatUsd(metrics.overview.mrrUsd)
+                : '\u2014'
             }
+            subtitle={metricSubtitleWithTrust(
+              <span className='text-[14px] text-secondary-token'>
+                {isHudMetricValueAvailable(stripeSource)
+                  ? `${metrics.overview.activeSubscribers.toLocaleString('en-US')} subscribers`
+                  : 'Stripe data unavailable'}
+              </span>,
+              stripeSource,
+              handleSourceRetry
+            )}
             headerRight={
               <HudStatusPill label={deploymentLabel} tone={deploymentsTone} />
             }
@@ -805,13 +871,13 @@ export function HudDashboardClient({
             <ContentMetricCard
               label='Runway'
               value={
-                metrics.overview.financialDataAvailable
+                isHudMetricValueAvailable(mercurySource)
                   ? formatRunway(metrics.overview.runwayMonths)
-                  : '—'
+                  : '\u2014'
               }
-              subtitle={
-                metrics.overview.financialDataAvailable ? (
-                  <div className='mt-2 grid gap-1.5'>
+              subtitle={metricSubtitleWithTrust(
+                isHudMetricValueAvailable(mercurySource) ? (
+                  <div className='grid gap-1.5'>
                     <ContentMetricRow
                       label='Cash'
                       value={formatUsd(metrics.overview.balanceUsd)}
@@ -822,9 +888,11 @@ export function HudDashboardClient({
                     />
                   </div>
                 ) : (
-                  'Unavailable'
-                )
-              }
+                  <span>Mercury data unavailable</span>
+                ),
+                mercurySource,
+                handleSourceRetry
+              )}
               className='p-3'
               valueClassName={secondaryValueClass}
             />
@@ -833,18 +901,24 @@ export function HudDashboardClient({
               value={
                 metrics.operations.status === 'ok' ? 'Healthy' : 'Degraded'
               }
-              subtitle={
+              subtitle={metricSubtitleWithTrust(
                 metrics.operations.dbLatencyMs === null
                   ? 'DB latency —'
-                  : `DB latency ${metrics.operations.dbLatencyMs.toFixed(0)}ms`
-              }
+                  : `DB latency ${metrics.operations.dbLatencyMs.toFixed(0)}ms`,
+                databaseSource,
+                handleSourceRetry
+              )}
               className='p-3'
               valueClassName={secondaryValueClass}
             />
             <ContentMetricCard
               label='Reliability'
               value={`${metrics.reliability.reliabilityScorePercent.toFixed(1)}%`}
-              subtitle={formatReliabilitySubtitle(metrics.reliability)}
+              subtitle={metricSubtitleWithTrust(
+                formatReliabilitySubtitle(metrics.reliability),
+                sentrySource,
+                handleSourceRetry
+              )}
               className='p-3 col-span-2'
               valueClassName={secondaryValueClass}
             />
@@ -873,6 +947,10 @@ export function HudDashboardClient({
                 No recent runs.
               </p>
             )}
+            <HudMetricSourceTrust
+              source={githubSource}
+              onRetry={handleSourceRetry}
+            />
           </ContentSurfaceCard>
 
           <ContentSurfaceCard surface='details' className='space-y-4 p-3'>
@@ -914,6 +992,10 @@ export function HudDashboardClient({
           ) : (
             <p className='text-[13px] text-secondary-token'>No recent runs.</p>
           )}
+          <HudMetricSourceTrust
+            source={githubSource}
+            onRetry={handleSourceRetry}
+          />
         </ContentSurfaceCard>
       )}
 

--- a/apps/web/app/app/(shell)/admin/ops/HudMetricSourceTrust.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudMetricSourceTrust.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { ExternalLink, RefreshCw } from 'lucide-react';
+import { formatSourceFreshness, isSourceStale } from '@/lib/hud/source-trust';
+import type { HudMetricSourceTrust as HudMetricSourceTrustType } from '@/types/hud';
+
+const STATE_LABELS = {
+  ok: null,
+  no_data: 'No data',
+  unavailable: 'Fetch failed',
+  not_configured: 'Not configured',
+} as const;
+
+function getStatusTone(
+  source: HudMetricSourceTrustType,
+  stale: boolean
+): string {
+  if (source.state === 'unavailable') return 'text-error';
+  if (source.state === 'not_configured') return 'text-warning';
+  if (source.state === 'no_data') return 'text-tertiary-token';
+  if (stale) return 'text-warning';
+  return 'text-tertiary-token';
+}
+
+export interface HudMetricSourceTrustProps {
+  readonly source: HudMetricSourceTrustType;
+  readonly onRetry?: () => void;
+}
+
+export function HudMetricSourceTrust({
+  source,
+  onRetry,
+}: Readonly<HudMetricSourceTrustProps>) {
+  const stale = isSourceStale(source.fetchedAtIso);
+  const statusTone = getStatusTone(source, stale);
+  const stateLabel = STATE_LABELS[source.state];
+  const showFreshness = source.state === 'ok' || source.state === 'no_data';
+  const showReason =
+    source.state === 'unavailable' || source.state === 'not_configured';
+  const linkLabel = `Open ${source.label}`;
+
+  return (
+    <div
+      className='mt-2 min-h-[36px] space-y-1'
+      data-testid={`hud-source-trust-${source.key}`}
+    >
+      <div className='flex items-center justify-between gap-2'>
+        <p className={`text-[11px] leading-4 ${statusTone}`}>
+          {showFreshness ? (
+            <>
+              {stale ? <span className='font-medium'>Stale · </span> : null}
+              Updated {formatSourceFreshness(source.fetchedAtIso)}
+            </>
+          ) : (
+            <span className='font-medium'>{stateLabel}</span>
+          )}
+        </p>
+        <div className='flex shrink-0 items-center gap-2'>
+          {onRetry && source.state === 'unavailable' ? (
+            <button
+              type='button'
+              onClick={onRetry}
+              className='inline-flex items-center gap-1 text-[11px] font-medium text-secondary-token transition-colors hover:text-primary-token'
+              data-testid={`hud-source-retry-${source.key}`}
+            >
+              <RefreshCw className='h-3 w-3' aria-hidden='true' />
+              Retry
+            </button>
+          ) : null}
+          {source.dashboardUrl ? (
+            <a
+              href={source.dashboardUrl}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='inline-flex items-center gap-1 text-[11px] font-medium text-secondary-token transition-colors hover:text-primary-token'
+              data-testid={`hud-source-link-${source.key}`}
+            >
+              {linkLabel}
+              <ExternalLink className='h-3 w-3' aria-hidden='true' />
+            </a>
+          ) : null}
+        </div>
+      </div>
+      {showReason && source.errorMessage ? (
+        <p className='text-[11px] leading-4 text-secondary-token'>
+          {source.errorMessage}
+        </p>
+      ) : null}
+      {source.nextStep ? (
+        <p className='text-[11px] leading-4 text-secondary-token'>
+          {source.nextStep}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/hud/metrics.ts
+++ b/apps/web/lib/hud/metrics.ts
@@ -2,11 +2,13 @@ import 'server-only';
 
 import { getAdminMercuryMetrics } from '@/lib/admin/mercury-metrics';
 import { getAdminReliabilitySummary } from '@/lib/admin/overview';
+import { getAdminSentryMetrics } from '@/lib/admin/sentry-metrics';
 import { getAdminStripeOverviewMetrics } from '@/lib/admin/stripe-metrics';
 import { checkDbHealth } from '@/lib/db';
 import { getHudDeployments } from '@/lib/deployments/github';
 import { env } from '@/lib/env-server';
 import { getHudAiOpsSummary } from '@/lib/hud/ai-ops';
+import { buildHudMetricSources } from '@/lib/hud/source-trust';
 import type { HudAccessMode, HudMetrics } from '@/types/hud';
 
 function normalizeIso(value: unknown): string {
@@ -138,6 +140,7 @@ export async function getHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
     stripeMetrics,
     mercuryMetrics,
     reliabilitySummary,
+    sentryMetrics,
     dbHealth,
     deployments,
     aiOps,
@@ -145,6 +148,7 @@ export async function getHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
     getAdminStripeOverviewMetrics(),
     getAdminMercuryMetrics(),
     getAdminReliabilitySummary(),
+    getAdminSentryMetrics(),
     checkDbHealth(),
     getHudDeployments(),
     getHudAiOpsSummary(generatedAt),
@@ -172,6 +176,23 @@ export async function getHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
     }
     return null;
   })();
+
+  const fetchedAtIso = generatedAt.toISOString();
+  const sources = buildHudMetricSources({
+    stripe: stripeMetrics,
+    mercury: mercuryMetrics,
+    sentry: sentryMetrics,
+    operations: {
+      status: dbHealth.healthy ? 'ok' : 'degraded',
+      dbLatencyMs: dbHealth.latency ?? null,
+      checkedAtIso: fetchedAtIso,
+    },
+    deployments,
+    fetchedAtIso,
+    sentryOrgSlug: env.SENTRY_ORG_SLUG,
+    githubOwner: env.HUD_GITHUB_OWNER,
+    githubRepo: env.HUD_GITHUB_REPO,
+  });
 
   return {
     accessMode: mode,
@@ -203,6 +224,7 @@ export async function getHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
     },
     deployments,
     aiOps,
-    generatedAtIso: generatedAt.toISOString(),
+    sources,
+    generatedAtIso: fetchedAtIso,
   };
 }

--- a/apps/web/lib/hud/source-trust.ts
+++ b/apps/web/lib/hud/source-trust.ts
@@ -1,0 +1,223 @@
+import { APP_ROUTES } from '@/constants/routes';
+import type { AdminMercuryMetrics } from '@/lib/admin/mercury-metrics';
+import type { AdminSentryMetrics } from '@/lib/admin/sentry-metrics';
+import type { AdminStripeOverviewMetrics } from '@/lib/admin/stripe-metrics';
+import type {
+  HudDeployments,
+  HudMetricSourceKey,
+  HudMetricSourceState,
+  HudMetricSourceTrust,
+  HudOperationsStatus,
+} from '@/types/hud';
+
+/** Client-side staleness threshold aligned with HUD poll cadence and Sentry cache TTL. */
+export const HUD_SOURCE_STALE_AFTER_MS = 5 * 60 * 1000;
+
+export function formatSourceFreshness(
+  fetchedAtIso: string,
+  now = Date.now()
+): string {
+  const diff = now - new Date(fetchedAtIso).getTime();
+  if (!Number.isFinite(diff) || diff < 0) return 'just now';
+
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes === 1) return '1 min ago';
+  if (minutes < 60) return `${minutes} min ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours === 1) return '1 hr ago';
+  return `${hours} hrs ago`;
+}
+
+export function isSourceStale(fetchedAtIso: string, now = Date.now()): boolean {
+  const diff = now - new Date(fetchedAtIso).getTime();
+  return Number.isFinite(diff) && diff > HUD_SOURCE_STALE_AFTER_MS;
+}
+
+function resolveExternalState(
+  isConfigured: boolean,
+  isAvailable: boolean
+): HudMetricSourceState {
+  if (!isConfigured) return 'not_configured';
+  if (!isAvailable) return 'unavailable';
+  return 'ok';
+}
+
+function buildStripeSourceTrust(
+  stripe: AdminStripeOverviewMetrics,
+  fetchedAtIso: string
+): HudMetricSourceTrust {
+  const state = resolveExternalState(stripe.isConfigured, stripe.isAvailable);
+
+  return {
+    key: 'stripe',
+    label: 'Stripe',
+    state,
+    fetchedAtIso,
+    errorMessage: stripe.errorMessage ?? null,
+    dashboardUrl: 'https://dashboard.stripe.com/',
+    configureUrl: null,
+    nextStep:
+      state === 'not_configured'
+        ? 'Add STRIPE_SECRET_KEY to load MRR from Stripe.'
+        : state === 'unavailable'
+          ? 'Check Stripe API credentials and retry.'
+          : null,
+  };
+}
+
+function buildMercurySourceTrust(
+  mercury: AdminMercuryMetrics,
+  fetchedAtIso: string
+): HudMetricSourceTrust {
+  const state = resolveExternalState(mercury.isConfigured, mercury.isAvailable);
+
+  return {
+    key: 'mercury',
+    label: 'Mercury',
+    state,
+    fetchedAtIso,
+    errorMessage: mercury.errorMessage ?? null,
+    dashboardUrl: 'https://app.mercury.com/',
+    configureUrl: null,
+    nextStep:
+      state === 'not_configured'
+        ? 'Add MERCURY_API_TOKEN and MERCURY_CHECKING_ACCOUNT_ID to load runway.'
+        : state === 'unavailable'
+          ? 'Check Mercury API credentials and retry.'
+          : null,
+  };
+}
+
+function buildDatabaseSourceTrust(
+  operations: HudOperationsStatus
+): HudMetricSourceTrust {
+  const state: HudMetricSourceState =
+    operations.status === 'ok' ? 'ok' : 'unavailable';
+
+  return {
+    key: 'database',
+    label: 'PostgreSQL',
+    state,
+    fetchedAtIso: operations.checkedAtIso,
+    errorMessage:
+      state === 'unavailable'
+        ? 'Database health check reported degraded status.'
+        : null,
+    dashboardUrl: APP_ROUTES.ADMIN_OPS,
+    configureUrl: null,
+    nextStep:
+      state === 'unavailable'
+        ? 'Inspect database latency and connection pool health.'
+        : null,
+  };
+}
+
+function buildSentrySourceTrust(
+  sentry: AdminSentryMetrics,
+  fetchedAtIso: string,
+  orgSlug: string | undefined
+): HudMetricSourceTrust {
+  const state = resolveExternalState(sentry.isConfigured, sentry.isAvailable);
+  const dashboardUrl =
+    orgSlug && state !== 'not_configured'
+      ? `https://${orgSlug}.sentry.io/issues/?query=is%3Aunresolved`
+      : null;
+
+  return {
+    key: 'sentry',
+    label: 'Sentry',
+    state,
+    fetchedAtIso,
+    errorMessage: sentry.errorMessage ?? null,
+    dashboardUrl,
+    configureUrl: null,
+    nextStep:
+      state === 'not_configured'
+        ? 'Add SENTRY_AUTH_TOKEN and SENTRY_ORG_SLUG to load incident metrics.'
+        : state === 'unavailable'
+          ? 'Check Sentry API credentials and retry.'
+          : null,
+  };
+}
+
+function buildGithubSourceTrust(
+  deployments: HudDeployments,
+  fetchedAtIso: string,
+  owner: string | undefined,
+  repo: string | undefined
+): HudMetricSourceTrust {
+  let state: HudMetricSourceState;
+  if (deployments.availability === 'not_configured') {
+    state = 'not_configured';
+  } else if (deployments.availability === 'error') {
+    state = 'unavailable';
+  } else if (deployments.recent.length === 0) {
+    state = 'no_data';
+  } else {
+    state = 'ok';
+  }
+
+  const dashboardUrl =
+    owner && repo
+      ? `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions`
+      : null;
+
+  return {
+    key: 'github',
+    label: 'GitHub',
+    state,
+    fetchedAtIso,
+    errorMessage: deployments.errorMessage ?? null,
+    dashboardUrl,
+    configureUrl: null,
+    nextStep:
+      state === 'not_configured'
+        ? 'Add HUD_GITHUB_TOKEN, HUD_GITHUB_OWNER, and HUD_GITHUB_REPO to load deploys.'
+        : state === 'unavailable'
+          ? 'Check GitHub API credentials and retry.'
+          : state === 'no_data'
+            ? 'No workflow runs yet — open GitHub Actions to inspect the pipeline.'
+            : null,
+  };
+}
+
+export interface BuildHudMetricSourcesInput {
+  readonly stripe: AdminStripeOverviewMetrics;
+  readonly mercury: AdminMercuryMetrics;
+  readonly sentry: AdminSentryMetrics;
+  readonly operations: HudOperationsStatus;
+  readonly deployments: HudDeployments;
+  readonly fetchedAtIso: string;
+  readonly sentryOrgSlug?: string;
+  readonly githubOwner?: string;
+  readonly githubRepo?: string;
+}
+
+export function buildHudMetricSources(
+  input: BuildHudMetricSourcesInput
+): Record<HudMetricSourceKey, HudMetricSourceTrust> {
+  return {
+    stripe: buildStripeSourceTrust(input.stripe, input.fetchedAtIso),
+    mercury: buildMercurySourceTrust(input.mercury, input.fetchedAtIso),
+    database: buildDatabaseSourceTrust(input.operations),
+    sentry: buildSentrySourceTrust(
+      input.sentry,
+      input.fetchedAtIso,
+      input.sentryOrgSlug
+    ),
+    github: buildGithubSourceTrust(
+      input.deployments,
+      input.fetchedAtIso,
+      input.githubOwner,
+      input.githubRepo
+    ),
+  };
+}
+
+export function isHudMetricValueAvailable(
+  source: HudMetricSourceTrust
+): boolean {
+  return source.state === 'ok' || source.state === 'no_data';
+}

--- a/apps/web/tests/lib/hud/metrics.test.ts
+++ b/apps/web/tests/lib/hud/metrics.test.ts
@@ -39,9 +39,24 @@ vi.mock('@/lib/admin/mercury-metrics', () => ({
 vi.mock('@/lib/admin/overview', () => ({
   getAdminReliabilitySummary: vi.fn(async () => ({
     errorRatePercent: 0.1,
+    reliabilityScorePercent: 99.9,
     p95LatencyMs: 250,
     incidents24h: 0,
     lastIncidentAt: null,
+    unresolvedSentryIssues24h: 0,
+  })),
+}));
+
+vi.mock('@/lib/admin/sentry-metrics', () => ({
+  getAdminSentryMetrics: vi.fn(async () => ({
+    unresolvedIssues24h: 0,
+    totalEvents24h: 0,
+    impactedUsers24h: 0,
+    criticalIssues24h: 0,
+    topIssueTitle: null,
+    topIssueShortId: null,
+    isConfigured: true,
+    isAvailable: true,
   })),
 }));
 
@@ -187,6 +202,23 @@ describe('getHudMetrics', () => {
     expect(metrics.aiOps.counts.blocked).toBe(1);
   });
 
+  it('includes per-source trust metadata in the HUD payload', async () => {
+    mockGetHudDeployments.mockResolvedValueOnce({
+      availability: 'not_configured',
+      current: null,
+      recent: [],
+    });
+
+    const metrics = await getHudMetrics('admin');
+
+    expect(metrics.sources.stripe.state).toBe('ok');
+    expect(metrics.sources.mercury.state).toBe('ok');
+    expect(metrics.sources.database.state).toBe('ok');
+    expect(metrics.sources.sentry.state).toBe('ok');
+    expect(metrics.sources.github.state).toBe('not_configured');
+    expect(metrics.sources.stripe.fetchedAtIso).toBe(metrics.generatedAtIso);
+  });
+
   it('marks financial data unavailable when Stripe is down', async () => {
     mockGetHudDeployments.mockResolvedValueOnce({
       availability: 'not_configured',
@@ -209,5 +241,7 @@ describe('getHudMetrics', () => {
     expect(metrics.overview.defaultStatusDetail).toContain(
       'Stripe (unavailable)'
     );
+    expect(metrics.sources.stripe.state).toBe('unavailable');
+    expect(metrics.sources.stripe.nextStep).toContain('retry');
   });
 });

--- a/apps/web/tests/lib/hud/source-trust.test.ts
+++ b/apps/web/tests/lib/hud/source-trust.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildHudMetricSources,
+  formatSourceFreshness,
+  HUD_SOURCE_STALE_AFTER_MS,
+  isHudMetricValueAvailable,
+  isSourceStale,
+} from '@/lib/hud/source-trust';
+
+const fetchedAtIso = '2026-06-08T12:00:00.000Z';
+
+function buildInput(
+  overrides: Partial<Parameters<typeof buildHudMetricSources>[0]> = {}
+) {
+  return {
+    stripe: {
+      mrrUsd: 1000,
+      activeSubscribers: 10,
+      mrrUsd30dAgo: 900,
+      mrrGrowth30dUsd: 100,
+      isConfigured: true,
+      isAvailable: true,
+    },
+    mercury: {
+      balanceUsd: 5000,
+      burnRateUsd: 2000,
+      burnWindowDays: 30,
+      isConfigured: true,
+      isAvailable: true,
+      defaultStatus: 'alive' as const,
+    },
+    sentry: {
+      unresolvedIssues24h: 2,
+      totalEvents24h: 10,
+      impactedUsers24h: 1,
+      criticalIssues24h: 0,
+      topIssueTitle: null,
+      topIssueShortId: null,
+      isConfigured: true,
+      isAvailable: true,
+    },
+    operations: {
+      status: 'ok' as const,
+      dbLatencyMs: 12,
+      checkedAtIso: fetchedAtIso,
+    },
+    deployments: {
+      availability: 'available' as const,
+      current: null,
+      recent: [
+        {
+          id: 1,
+          runNumber: 42,
+          status: 'success' as const,
+          createdAtIso: fetchedAtIso,
+          branch: 'main',
+          url: 'https://github.com/JovieInc/Jovie/actions/runs/1',
+        },
+      ],
+    },
+    fetchedAtIso,
+    sentryOrgSlug: 'jovie',
+    githubOwner: 'JovieInc',
+    githubRepo: 'Jovie',
+    ...overrides,
+  };
+}
+
+describe('source-trust freshness helpers', () => {
+  it('formats sub-minute freshness as just now', () => {
+    const now = Date.parse(fetchedAtIso) + 30_000;
+    expect(formatSourceFreshness(fetchedAtIso, now)).toBe('just now');
+  });
+
+  it('marks sources stale after the configured threshold', () => {
+    const now = Date.parse(fetchedAtIso) + HUD_SOURCE_STALE_AFTER_MS + 1;
+    expect(isSourceStale(fetchedAtIso, now)).toBe(true);
+  });
+});
+
+describe('buildHudMetricSources', () => {
+  it('builds ok states with outbound dashboard links', () => {
+    const sources = buildHudMetricSources(buildInput());
+
+    expect(sources.stripe.state).toBe('ok');
+    expect(sources.stripe.dashboardUrl).toBe('https://dashboard.stripe.com/');
+    expect(sources.mercury.dashboardUrl).toBe('https://app.mercury.com/');
+    expect(sources.sentry.dashboardUrl).toBe(
+      'https://jovie.sentry.io/issues/?query=is%3Aunresolved'
+    );
+    expect(sources.github.dashboardUrl).toBe(
+      'https://github.com/JovieInc/Jovie/actions'
+    );
+  });
+
+  it('distinguishes unavailable Stripe from not configured Mercury', () => {
+    const sources = buildHudMetricSources(
+      buildInput({
+        stripe: {
+          mrrUsd: 0,
+          activeSubscribers: 0,
+          mrrUsd30dAgo: 0,
+          mrrGrowth30dUsd: 0,
+          isConfigured: true,
+          isAvailable: false,
+          errorMessage: 'Stripe API error: timeout',
+        },
+        mercury: {
+          balanceUsd: 0,
+          burnRateUsd: 0,
+          burnWindowDays: 30,
+          isConfigured: false,
+          isAvailable: false,
+          defaultStatus: 'unknown',
+          errorMessage:
+            'Mercury credentials not configured (MERCURY_API_TOKEN required)',
+        },
+      })
+    );
+
+    expect(sources.stripe.state).toBe('unavailable');
+    expect(sources.stripe.errorMessage).toContain('Stripe API error');
+    expect(sources.mercury.state).toBe('not_configured');
+    expect(sources.mercury.nextStep).toContain('MERCURY_API_TOKEN');
+  });
+
+  it('marks GitHub as no_data when configured but empty', () => {
+    const sources = buildHudMetricSources(
+      buildInput({
+        deployments: {
+          availability: 'available',
+          current: null,
+          recent: [],
+        },
+      })
+    );
+
+    expect(sources.github.state).toBe('no_data');
+    expect(sources.github.nextStep).toContain('No workflow runs yet');
+  });
+});
+
+describe('isHudMetricValueAvailable', () => {
+  it('treats ok and no_data as displayable values', () => {
+    expect(
+      isHudMetricValueAvailable({
+        key: 'github',
+        label: 'GitHub',
+        state: 'no_data',
+        fetchedAtIso,
+        errorMessage: null,
+        dashboardUrl: null,
+        configureUrl: null,
+        nextStep: null,
+      })
+    ).toBe(true);
+
+    expect(
+      isHudMetricValueAvailable({
+        key: 'stripe',
+        label: 'Stripe',
+        state: 'unavailable',
+        fetchedAtIso,
+        errorMessage: 'failed',
+        dashboardUrl: null,
+        configureUrl: null,
+        nextStep: null,
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/app/HudMetricSourceTrust.test.tsx
+++ b/apps/web/tests/unit/app/HudMetricSourceTrust.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { HudMetricSourceTrust } from '@/app/app/(shell)/admin/ops/HudMetricSourceTrust';
+import type { HudMetricSourceTrust as HudMetricSourceTrustType } from '@/types/hud';
+
+const freshSource: HudMetricSourceTrustType = {
+  key: 'stripe',
+  label: 'Stripe',
+  state: 'ok',
+  fetchedAtIso: new Date().toISOString(),
+  errorMessage: null,
+  dashboardUrl: 'https://dashboard.stripe.com/',
+  configureUrl: null,
+  nextStep: null,
+};
+
+const failedSource: HudMetricSourceTrustType = {
+  key: 'mercury',
+  label: 'Mercury',
+  state: 'unavailable',
+  fetchedAtIso: new Date().toISOString(),
+  errorMessage: 'Mercury API error: timeout',
+  dashboardUrl: 'https://app.mercury.com/',
+  configureUrl: null,
+  nextStep: 'Check Mercury API credentials and retry.',
+};
+
+describe('HudMetricSourceTrust', () => {
+  it('renders freshness and outbound link for healthy sources', () => {
+    render(<HudMetricSourceTrust source={freshSource} />);
+
+    expect(screen.getByText(/Updated just now/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open Stripe/i })).toHaveAttribute(
+      'href',
+      'https://dashboard.stripe.com/'
+    );
+  });
+
+  it('renders scoped failure state with retry and next step', () => {
+    const onRetry = vi.fn();
+    render(<HudMetricSourceTrust source={failedSource} onRetry={onRetry} />);
+
+    expect(screen.getByText('Fetch failed')).toBeInTheDocument();
+    expect(screen.getByText('Mercury API error: timeout')).toBeInTheDocument();
+    expect(
+      screen.getByText('Check Mercury API credentials and retry.')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Retry/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('reserves footer height to avoid layout shift', () => {
+    const { container } = render(<HudMetricSourceTrust source={freshSource} />);
+
+    expect(
+      container.querySelector('[data-testid="hud-source-trust-stripe"]')
+    ).toHaveClass('min-h-[36px]');
+  });
+});

--- a/apps/web/types/hud.ts
+++ b/apps/web/types/hud.ts
@@ -48,6 +48,30 @@ export interface HudBranding {
   logoUrl: string | null;
 }
 
+export type HudMetricSourceKey =
+  | 'stripe'
+  | 'mercury'
+  | 'database'
+  | 'sentry'
+  | 'github';
+
+export type HudMetricSourceState =
+  | 'ok'
+  | 'unavailable'
+  | 'not_configured'
+  | 'no_data';
+
+export interface HudMetricSourceTrust {
+  readonly key: HudMetricSourceKey;
+  readonly label: string;
+  readonly state: HudMetricSourceState;
+  readonly fetchedAtIso: string;
+  readonly errorMessage: string | null;
+  readonly dashboardUrl: string | null;
+  readonly configureUrl: string | null;
+  readonly nextStep: string | null;
+}
+
 export interface HudMetrics {
   accessMode: HudAccessMode;
   branding: HudBranding;
@@ -64,5 +88,7 @@ export interface HudMetrics {
   };
   deployments: HudDeployments;
   aiOps: HermesAiOpsSummary;
+  /** Per-source fetch metadata for ops metric cards (freshness + failure states). */
+  sources: Record<HudMetricSourceKey, HudMetricSourceTrust>;
   generatedAtIso: string;
 }


### PR DESCRIPTION
## Summary

Adds ops metrics data trust to the admin HUD (`/app/admin/ops`):

- **Per-source trust metadata** on the HUD payload (`stripe`, `mercury`, `database`, `sentry`, `github`) with fetch state, timestamps, error messages, and next-step guidance
- **`HudMetricSourceTrust` UI** on each KPI card: last-updated/stale indicator, scoped failure vs no-data states, outbound links (Stripe, Mercury, Sentry, GitHub Actions), and retry
- **Layout-shift prevention**: reserved `min-h-[36px]` footer on conditional status UI
- **Value gating**: MRR and runway show `—` when Stripe/Mercury are unavailable (not misleading `$0`)

Closes JOV-2123 / #8491

## Acceptance criteria

- [x] MRR (Stripe) and runway (Mercury) show last-updated timestamps or staleness indicators
- [x] Per-source failures handled gracefully without full-page error boundary
- [x] Loading / partial / error / stale states implemented per source
- [x] Each KPI card has at least one outbound link to the owning system
- [x] Unavailable states show a reason and next step, not just a label

## Test plan

- [x] `pnpm exec vitest run tests/lib/hud/source-trust.test.ts tests/lib/hud/metrics.test.ts tests/unit/app/HudMetricSourceTrust.test.tsx`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec biome check` on changed files
- [ ] Manual: open `/app/admin/ops` and verify MRR/Runway/Operations/Reliability footers + GitHub deployments trust row

## Blockers

None — ready for review.