### PR TITLE
feat(admin/ops): add yes/no/yes-with-notes design proposal review flow (JOV-1936)

### DIFF
--- a/apps/web/app/api/admin/design-lab/proposals/[proposalId]/review/route.ts
+++ b/apps/web/app/api/admin/design-lab/proposals/[proposalId]/review/route.ts
@@ -1,0 +1,111 @@
+import 'server-only';
+
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+import { reviewDesignProposal } from '@/lib/agent-os/design-lab/review';
+import { DesignProposalReviewRequestSchema } from '@/lib/agent-os/design-lab/types';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import { captureError } from '@/lib/error-tracking';
+import { logger } from '@/lib/utils/logger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+const ProposalParamsSchema = z.object({
+  proposalId: z.string().trim().min(1).max(120),
+});
+
+export async function POST(
+  request: NextRequest,
+  context: { params: Promise<{ proposalId: string }> }
+): Promise<Response> {
+  try {
+    const entitlements = await getCurrentUserEntitlements();
+    if (!entitlements.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401, headers: NO_STORE_HEADERS }
+      );
+    }
+    if (!entitlements.isAdmin) {
+      return NextResponse.json(
+        { error: 'Forbidden' },
+        { status: 403, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const params = ProposalParamsSchema.parse(await context.params);
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid JSON payload' },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const parsedBody = DesignProposalReviewRequestSchema.parse(body);
+    const reviewer =
+      entitlements.email ?? entitlements.userId ?? 'admin@jovie.local';
+
+    const result = await reviewDesignProposal({
+      dayBucket: parsedBody.dayBucket,
+      proposalId: params.proposalId,
+      decision: parsedBody.decision,
+      notes: parsedBody.notes ?? null,
+      reviewer,
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        result,
+      },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        {
+          error: 'Invalid design proposal review request',
+          issues: error.issues,
+        },
+        { status: 400, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    if (error instanceof Error) {
+      if (error.message === 'Design proposal not found.') {
+        return NextResponse.json(
+          { error: error.message },
+          { status: 404, headers: NO_STORE_HEADERS }
+        );
+      }
+
+      if (error.message === 'Design proposal has already been reviewed.') {
+        return NextResponse.json(
+          { error: error.message },
+          { status: 409, headers: NO_STORE_HEADERS }
+        );
+      }
+    }
+
+    logger.error(
+      '[api/admin/design-lab/proposals/[proposalId]/review] Review failed',
+      error
+    );
+    await captureError('Design Lab proposal review failed', error, {
+      route: '/api/admin/design-lab/proposals/[proposalId]/review',
+      method: 'POST',
+    });
+    return NextResponse.json(
+      { error: 'Failed to review design proposal' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/api/admin/design-lab/proposals/route.ts
+++ b/apps/web/app/api/admin/design-lab/proposals/route.ts
@@ -1,0 +1,53 @@
+import 'server-only';
+
+import { NextResponse } from 'next/server';
+import { listPendingDesignProposals } from '@/lib/agent-os/design-lab/proposals';
+import { getCurrentUserEntitlements } from '@/lib/entitlements/server';
+import { captureError } from '@/lib/error-tracking';
+import { logger } from '@/lib/utils/logger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+export async function GET(): Promise<Response> {
+  try {
+    const entitlements = await getCurrentUserEntitlements();
+    if (!entitlements.isAuthenticated) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401, headers: NO_STORE_HEADERS }
+      );
+    }
+    if (!entitlements.isAdmin) {
+      return NextResponse.json(
+        { error: 'Forbidden' },
+        { status: 403, headers: NO_STORE_HEADERS }
+      );
+    }
+
+    const proposals = await listPendingDesignProposals();
+
+    return NextResponse.json(
+      {
+        proposals,
+        fetchedAt: new Date().toISOString(),
+      },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  } catch (error) {
+    logger.error(
+      '[api/admin/design-lab/proposals] Failed to list proposals',
+      error
+    );
+    await captureError('Design Lab proposals fetch failed', error, {
+      route: '/api/admin/design-lab/proposals',
+      method: 'GET',
+    });
+    return NextResponse.json(
+      { error: 'Failed to fetch design proposals' },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -21,6 +21,7 @@ import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { AgentOsRunsPanel } from '@/components/features/admin/agent-os';
+import { DesignProposalReviewPanel } from '@/components/features/admin/design-lab';
 import type { DailyBucket } from '@/components/features/admin/ShippingVelocityChart';
 import { ShippingVelocityChart } from '@/components/features/admin/ShippingVelocityChart';
 import { TimActionRequiredSection } from '@/components/features/admin/TimActionRequiredSection';
@@ -620,6 +621,7 @@ export function HudDashboardClient({
     return (
       <div className={outerClass}>
         <TimActionRequiredSection />
+        <DesignProposalReviewPanel />
 
         <div className='grid gap-3 md:grid-cols-2 xl:grid-cols-4'>
           <ContentMetricCard

--- a/apps/web/components/features/admin/design-lab/DesignProposalReviewPanel.tsx
+++ b/apps/web/components/features/admin/design-lab/DesignProposalReviewPanel.tsx
@@ -1,0 +1,378 @@
+'use client';
+
+import { ExternalLink, Loader2 } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { ContentSurfaceCard } from '@/components/molecules/ContentSurfaceCard';
+import { DrawerButton } from '@/components/molecules/drawer';
+import type { DesignProposal } from '@/lib/agent-os/design-lab/types';
+import { cn } from '@/lib/utils';
+
+const FETCH_URL = '/api/admin/design-lab/proposals';
+
+interface DesignProposalsResponse {
+  readonly proposals: readonly DesignProposal[];
+  readonly fetchedAt: string;
+}
+
+interface PendingNotesState {
+  readonly proposal: DesignProposal;
+  readonly decision: 'no' | 'yes-with-notes';
+}
+
+function formatCreatedAt(value: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'UTC',
+    timeZoneName: 'short',
+  }).format(new Date(value));
+}
+
+function ProposalCard({
+  proposal,
+  isSubmitting,
+  onApprove,
+  onReject,
+  onApproveWithNotes,
+}: Readonly<{
+  readonly proposal: DesignProposal;
+  readonly isSubmitting: boolean;
+  readonly onApprove: (proposal: DesignProposal) => void;
+  readonly onReject: (proposal: DesignProposal) => void;
+  readonly onApproveWithNotes: (proposal: DesignProposal) => void;
+}>) {
+  return (
+    <ContentSurfaceCard
+      className='space-y-3 p-3'
+      data-testid={`design-proposal-card-${proposal.id}`}
+    >
+      <div className='flex items-start justify-between gap-3'>
+        <div className='min-w-0 space-y-1'>
+          <p className='text-[13px] font-[560] text-primary-token'>
+            {proposal.surfaceName}
+          </p>
+          <p className='text-[11px] text-tertiary-token'>
+            {proposal.surfaceId}
+            {proposal.scoring
+              ? ` · score ${proposal.scoring.score.toFixed(2)}`
+              : null}
+          </p>
+        </div>
+        {proposal.linearIssueUrl ? (
+          <a
+            href={proposal.linearIssueUrl}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='inline-flex shrink-0 items-center gap-1 text-[11px] text-secondary-token hover:text-primary-token'
+          >
+            {proposal.linearIssueId}
+            <ExternalLink className='h-3 w-3' aria-hidden='true' />
+          </a>
+        ) : (
+          <span className='text-[11px] text-tertiary-token'>
+            {proposal.linearIssueId}
+          </span>
+        )}
+      </div>
+
+      <p className='text-[13px] leading-6 text-secondary-token'>
+        {proposal.proposalText}
+      </p>
+
+      <p className='text-[11px] text-tertiary-token'>
+        Queued {formatCreatedAt(proposal.createdAt)}
+      </p>
+
+      <div className='flex flex-wrap gap-2 border-t border-subtle pt-3'>
+        <DrawerButton
+          type='button'
+          tone='primary'
+          disabled={isSubmitting}
+          className='justify-center'
+          onClick={() => onApprove(proposal)}
+        >
+          Yes
+        </DrawerButton>
+        <DrawerButton
+          type='button'
+          tone='secondary'
+          disabled={isSubmitting}
+          className='justify-center'
+          onClick={() => onApproveWithNotes(proposal)}
+        >
+          Yes with notes
+        </DrawerButton>
+        <DrawerButton
+          type='button'
+          tone='secondary'
+          disabled={isSubmitting}
+          className='justify-center text-destructive'
+          onClick={() => onReject(proposal)}
+        >
+          No
+        </DrawerButton>
+      </div>
+    </ContentSurfaceCard>
+  );
+}
+
+export function DesignProposalReviewPanel() {
+  const [proposals, setProposals] = useState<readonly DesignProposal[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [submittingId, setSubmittingId] = useState<string | null>(null);
+  const [pendingNotes, setPendingNotes] = useState<PendingNotesState | null>(
+    null
+  );
+  const [notesDraft, setNotesDraft] = useState('');
+
+  const loadProposals = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(FETCH_URL, { cache: 'no-store' });
+      if (!response.ok) {
+        throw new Error(`Failed to load proposals (${response.status})`);
+      }
+      const payload = (await response.json()) as DesignProposalsResponse;
+      setProposals(payload.proposals);
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Failed to load design proposals'
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadProposals();
+  }, [loadProposals]);
+
+  const submitReview = useCallback(
+    async (
+      proposal: DesignProposal,
+      decision: 'yes' | 'no' | 'yes-with-notes',
+      notes: string | null
+    ) => {
+      if (!proposal.dayBucket) {
+        toast.error('Proposal day bucket is missing.');
+        return;
+      }
+
+      setSubmittingId(proposal.id);
+      try {
+        const response = await fetch(
+          `/api/admin/design-lab/proposals/${encodeURIComponent(proposal.id)}/review`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              dayBucket: proposal.dayBucket,
+              decision,
+              notes,
+            }),
+          }
+        );
+
+        const payload = (await response.json()) as {
+          error?: string;
+          result?: {
+            dispatchTriggered: boolean;
+            linearUpdated: boolean;
+          };
+        };
+
+        if (!response.ok) {
+          throw new Error(
+            payload.error ?? `Review failed (${response.status})`
+          );
+        }
+
+        setProposals(current =>
+          current.filter(item => item.id !== proposal.id)
+        );
+
+        if (decision === 'yes' || decision === 'yes-with-notes') {
+          toast.success(
+            payload.result?.dispatchTriggered
+              ? 'Proposal approved and D5 dispatch triggered.'
+              : 'Proposal approved.'
+          );
+        } else {
+          toast.success('Proposal rejected and taste memory updated.');
+        }
+
+        if (payload.result?.linearUpdated === false) {
+          toast.error('Linear issue status could not be updated.');
+        }
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : 'Failed to review proposal'
+        );
+      } finally {
+        setSubmittingId(null);
+        setPendingNotes(null);
+        setNotesDraft('');
+      }
+    },
+    []
+  );
+
+  if (isLoading) {
+    return (
+      <ContentSurfaceCard
+        surface='details'
+        className='flex items-center gap-2 p-3 text-[13px] text-secondary-token'
+        data-testid='design-proposal-review-panel'
+      >
+        <Loader2 className='h-4 w-4 animate-spin' aria-hidden='true' />
+        Loading design proposals...
+      </ContentSurfaceCard>
+    );
+  }
+
+  return (
+    <>
+      <ContentSurfaceCard
+        surface='details'
+        className='space-y-3 p-3'
+        data-testid='design-proposal-review-panel'
+      >
+        <div className='flex items-center justify-between gap-3'>
+          <div>
+            <p className='text-[12.5px] font-[560] text-primary-token'>
+              Design proposals
+            </p>
+            <p className='text-[12px] text-secondary-token'>
+              Review pending Design Lab proposals before dispatch.
+            </p>
+          </div>
+          <span className='text-[11px] tabular-nums text-tertiary-token'>
+            {proposals.length}
+          </span>
+        </div>
+
+        {proposals.length > 0 ? (
+          <div className='grid gap-3'>
+            {proposals.map(proposal => (
+              <ProposalCard
+                key={`${proposal.dayBucket ?? 'unknown'}:${proposal.id}`}
+                proposal={proposal}
+                isSubmitting={submittingId === proposal.id}
+                onApprove={next => {
+                  void submitReview(next, 'yes', null);
+                }}
+                onReject={next => {
+                  setPendingNotes({ proposal: next, decision: 'no' });
+                  setNotesDraft('');
+                }}
+                onApproveWithNotes={next => {
+                  setPendingNotes({
+                    proposal: next,
+                    decision: 'yes-with-notes',
+                  });
+                  setNotesDraft('');
+                }}
+              />
+            ))}
+          </div>
+        ) : (
+          <p className='text-[13px] text-secondary-token'>
+            No pending design proposals.
+          </p>
+        )}
+      </ContentSurfaceCard>
+
+      {pendingNotes ? (
+        <div
+          className='fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-4 sm:items-center'
+          role='dialog'
+          aria-modal='true'
+          aria-label={
+            pendingNotes.decision === 'no'
+              ? 'Reject design proposal'
+              : 'Approve design proposal with notes'
+          }
+        >
+          <button
+            type='button'
+            aria-label='Close review notes dialog'
+            className='absolute inset-0 cursor-default'
+            onClick={() => {
+              if (submittingId) return;
+              setPendingNotes(null);
+              setNotesDraft('');
+            }}
+          />
+          <ContentSurfaceCard
+            className={cn(
+              'relative z-10 w-full max-w-lg space-y-3 p-4',
+              submittingId && 'pointer-events-none opacity-70'
+            )}
+            data-testid='design-proposal-notes-dialog'
+          >
+            <div className='space-y-1'>
+              <p className='text-[14px] font-[560] text-primary-token'>
+                {pendingNotes.decision === 'no'
+                  ? 'Rejection notes'
+                  : 'Approval notes'}
+              </p>
+              <p className='text-[12px] text-secondary-token'>
+                {pendingNotes.decision === 'no'
+                  ? 'Capture the direction to reject so Design Lab does not regenerate it.'
+                  : 'Amendments are injected into the D5 dispatch payload.'}
+              </p>
+            </div>
+
+            <textarea
+              value={notesDraft}
+              onChange={event => setNotesDraft(event.target.value)}
+              rows={5}
+              className='w-full rounded-lg border border-subtle bg-surface-0 px-3 py-2 text-[13px] text-primary-token outline-none'
+              placeholder='Add notes for this decision'
+            />
+
+            <div className='flex justify-end gap-2'>
+              <DrawerButton
+                type='button'
+                tone='secondary'
+                disabled={submittingId !== null}
+                onClick={() => {
+                  setPendingNotes(null);
+                  setNotesDraft('');
+                }}
+              >
+                Cancel
+              </DrawerButton>
+              <DrawerButton
+                type='button'
+                tone='primary'
+                disabled={submittingId !== null}
+                onClick={() => {
+                  const notes = notesDraft.trim();
+                  if (!notes) {
+                    toast.error('Notes are required.');
+                    return;
+                  }
+                  void submitReview(
+                    pendingNotes.proposal,
+                    pendingNotes.decision,
+                    notes
+                  );
+                }}
+              >
+                {pendingNotes.decision === 'no'
+                  ? 'Reject'
+                  : 'Approve with notes'}
+              </DrawerButton>
+            </div>
+          </ContentSurfaceCard>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/components/features/admin/design-lab/index.ts
+++ b/apps/web/components/features/admin/design-lab/index.ts
@@ -1,0 +1,1 @@
+export { DesignProposalReviewPanel } from './DesignProposalReviewPanel';

--- a/apps/web/lib/agent-os/design-lab/dispatch.ts
+++ b/apps/web/lib/agent-os/design-lab/dispatch.ts
@@ -1,0 +1,121 @@
+import 'server-only';
+
+import { promises as fs } from 'node:fs';
+import {
+  dispatchHermesWorker,
+  getHermesDispatchAvailability,
+  HermesDispatchConfigurationError,
+} from '@/lib/hermes/dispatch';
+import { logger } from '@/lib/utils/logger';
+import {
+  getDesignLabDispatchDirectory,
+  resolveDesignDispatchFilePath,
+} from './paths';
+import { readDesignTasteMemoryExcerpt } from './taste-memory';
+import type { DesignLabDispatchPayload, DesignProposal } from './types';
+
+function buildDispatchPrompt(payload: DesignLabDispatchPayload): string {
+  const notesBlock = payload.amendmentNotes
+    ? `\nAmendment notes:\n${payload.amendmentNotes.trim()}`
+    : '';
+
+  const tasteBlock = payload.tasteMemoryExcerpt
+    ? `\nTaste memory excerpt:\n${payload.tasteMemoryExcerpt.trim()}`
+    : '';
+
+  return [
+    'Design Lab D5 dispatch: build an HTML artifact for the approved proposal.',
+    `Surface: ${payload.surfaceName} (${payload.surfaceId})`,
+    `Linear issue: ${payload.linearIssueId}`,
+    `Proposal:\n${payload.proposalText.trim()}`,
+    notesBlock,
+    tasteBlock,
+    'Store the resulting HTML artifact under agentos/runs/design-lab/ and link it back to the Linear issue.',
+  ]
+    .filter(part => part.length > 0)
+    .join('\n\n');
+}
+
+export async function triggerDesignLabDispatch(params: {
+  readonly proposal: DesignProposal;
+  readonly amendmentNotes: string | null;
+  readonly requestedBy: string;
+}): Promise<{ triggered: boolean; dispatchId: string | null }> {
+  const dispatchId = `design-lab-${crypto.randomUUID()}`;
+  const tasteMemoryExcerpt = await readDesignTasteMemoryExcerpt();
+
+  const payload: DesignLabDispatchPayload = {
+    dispatchId,
+    proposalId: params.proposal.id,
+    surfaceId: params.proposal.surfaceId,
+    surfaceName: params.proposal.surfaceName,
+    proposalText: params.proposal.proposalText,
+    amendmentNotes: params.amendmentNotes,
+    linearIssueId: params.proposal.linearIssueId,
+    linearIssueUrl: params.proposal.linearIssueUrl,
+    tasteMemoryExcerpt,
+    requestedAt: new Date().toISOString(),
+    requestedBy: params.requestedBy,
+  };
+
+  const dispatchDirectory = getDesignLabDispatchDirectory();
+  await fs.mkdir(dispatchDirectory, { recursive: true });
+  await fs.writeFile(
+    resolveDesignDispatchFilePath(dispatchId),
+    `${JSON.stringify(payload, null, 2)}\n`,
+    'utf8'
+  );
+
+  const availability = getHermesDispatchAvailability();
+  if (!availability.available) {
+    logger.info(
+      '[design-lab/dispatch] Hermes unavailable; persisted dispatch manifest only',
+      {
+        dispatchId,
+        reason: availability.unavailableReason,
+      }
+    );
+    return { triggered: true, dispatchId };
+  }
+
+  try {
+    await dispatchHermesWorker({
+      source: 'linear',
+      sourceId: params.proposal.linearIssueId,
+      sourceUrl: params.proposal.linearIssueUrl,
+      kind: 'investigation',
+      runtime: 'codex-cli',
+      priority: 70,
+      skills: ['design-html', 'autoplan'],
+      allowedPaths: ['agentos', 'apps/web/components', 'apps/web/styles'],
+      verification: [
+        'pnpm --filter @jovie/web run typecheck -- --pretty false',
+      ],
+      dryRun: false,
+      prompt: buildDispatchPrompt(payload),
+      owner: params.requestedBy,
+    });
+  } catch (error) {
+    if (error instanceof HermesDispatchConfigurationError) {
+      logger.warn(
+        '[design-lab/dispatch] Hermes dispatch skipped after manifest write',
+        {
+          dispatchId,
+          error: error.message,
+        }
+      );
+      return { triggered: true, dispatchId };
+    }
+
+    logger.error(
+      '[design-lab/dispatch] Hermes dispatch failed after manifest write',
+      {
+        dispatchId,
+        error,
+      }
+    );
+    return { triggered: true, dispatchId };
+  }
+
+  return { triggered: true, dispatchId };
+}

--- a/apps/web/lib/agent-os/design-lab/fixtures.ts
+++ b/apps/web/lib/agent-os/design-lab/fixtures.ts
@@ -1,0 +1,46 @@
+import type { DesignProposal } from './types';
+
+const FIXTURE_CREATED_AT = '2026-06-08T12:00:00.000Z';
+
+export const DESIGN_LAB_DEV_FIXTURE_PROPOSALS: readonly DesignProposal[] = [
+  {
+    id: 'profile-page-quiet-hero',
+    surfaceId: 'profile-page',
+    surfaceName: 'Public profile page',
+    proposalText:
+      'Replace the full-bleed hero gradient with a restrained surface-1 header band, left-aligned artist name, and a single accent underline on the active tab.',
+    assetRefs: ['agentos/runs/design-lab/assets/profile-page-quiet-hero.png'],
+    scoring: { weight: 0.9, score: 0.82 },
+    linearIssueId: 'JOV-1951',
+    linearIssueUrl:
+      'https://linear.app/jovie/issue/JOV-1951/profile-redesign-proposal-loop',
+    status: 'pending',
+    createdAt: FIXTURE_CREATED_AT,
+    reviewedAt: null,
+    reviewer: null,
+    reviewNotes: null,
+    reviewDecision: null,
+    dispatchId: null,
+    dayBucket: '2026-06-08',
+  },
+  {
+    id: 'sidebar-density-pass',
+    surfaceId: 'dashboard-sidebar',
+    surfaceName: 'Dashboard sidebar',
+    proposalText:
+      'Tighten sidebar row height by 2px, reduce icon stroke to 2.0, and move section labels to 11px tertiary copy with no uppercase tracking.',
+    assetRefs: [],
+    scoring: { weight: 0.7, score: 0.74 },
+    linearIssueId: 'JOV-2098',
+    linearIssueUrl:
+      'https://linear.app/jovie/issue/JOV-2098/designadmin-consolidate-overlapping-ia-across-overview-ops-growth',
+    status: 'pending',
+    createdAt: FIXTURE_CREATED_AT,
+    reviewedAt: null,
+    reviewer: null,
+    reviewNotes: null,
+    reviewDecision: null,
+    dispatchId: null,
+    dayBucket: '2026-06-08',
+  },
+];

--- a/apps/web/lib/agent-os/design-lab/linear.ts
+++ b/apps/web/lib/agent-os/design-lab/linear.ts
@@ -1,0 +1,202 @@
+import 'server-only';
+
+import { env } from '@/lib/env-server';
+import { logger } from '@/lib/utils/logger';
+
+const LINEAR_GRAPHQL_URL = 'https://api.linear.app/graphql';
+
+export type DesignLabLinearTargetState = 'completed' | 'canceled';
+
+interface LinearIssueLookup {
+  readonly id: string;
+  readonly identifier: string;
+}
+
+interface LinearTeamState {
+  readonly id: string;
+  readonly type: string;
+  readonly name: string;
+}
+
+async function linearGraphql<T>(
+  query: string,
+  variables: Record<string, unknown>
+): Promise<T> {
+  const apiKey = env.LINEAR_API_KEY;
+  if (!apiKey) {
+    throw new Error('LINEAR_API_KEY is not configured');
+  }
+
+  const response = await fetch(LINEAR_GRAPHQL_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: apiKey,
+      'Content-Type': 'application/json',
+      'User-Agent': 'Jovie-DesignLab/1.0',
+    },
+    body: JSON.stringify({ query, variables }),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Linear API error (${response.status})`);
+  }
+
+  const payload = (await response.json()) as {
+    data?: T;
+    errors?: Array<{ message: string }>;
+  };
+
+  if (payload.errors && payload.errors.length > 0) {
+    throw new Error(payload.errors[0]?.message ?? 'Linear GraphQL error');
+  }
+
+  if (!payload.data) {
+    throw new Error('Linear GraphQL returned empty data');
+  }
+
+  return payload.data;
+}
+
+async function lookupLinearIssue(
+  issueIdentifier: string
+): Promise<LinearIssueLookup | null> {
+  const query = `
+    query LookupIssue($identifier: String!) {
+      issue(id: $identifier) {
+        id
+        identifier
+      }
+    }
+  `;
+
+  try {
+    const data = await linearGraphql<{
+      issue: LinearIssueLookup | null;
+    }>(query, { identifier: issueIdentifier });
+
+    return data.issue;
+  } catch (error) {
+    logger.warn('[design-lab/linear] Failed direct issue lookup', {
+      issueIdentifier,
+      error,
+    });
+    return null;
+  }
+}
+
+async function lookupLinearIssueBySearch(
+  issueIdentifier: string
+): Promise<LinearIssueLookup | null> {
+  const query = `
+    query SearchIssue($query: String!) {
+      issues(filter: { title: { containsIgnoreCase: $query } }, first: 1) {
+        nodes {
+          id
+          identifier
+        }
+      }
+    }
+  `;
+
+  const data = await linearGraphql<{
+    issues: { nodes: LinearIssueLookup[] };
+  }>(query, { query: issueIdentifier });
+
+  return (
+    data.issues.nodes.find(node => node.identifier === issueIdentifier) ?? null
+  );
+}
+
+async function resolveLinearIssue(
+  issueIdentifier: string
+): Promise<LinearIssueLookup | null> {
+  const direct = await lookupLinearIssue(issueIdentifier);
+  if (direct) {
+    return direct;
+  }
+
+  return lookupLinearIssueBySearch(issueIdentifier);
+}
+
+async function findTeamState(
+  issueId: string,
+  target: DesignLabLinearTargetState
+): Promise<LinearTeamState | null> {
+  const query = `
+    query IssueTeamStates($issueId: String!) {
+      issue(id: $issueId) {
+        team {
+          states {
+            nodes {
+              id
+              type
+              name
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const data = await linearGraphql<{
+    issue: {
+      team: {
+        states: {
+          nodes: LinearTeamState[];
+        };
+      };
+    } | null;
+  }>(query, { issueId });
+
+  const states = data.issue?.team.states.nodes ?? [];
+  return states.find(state => state.type === target) ?? null;
+}
+
+export async function updateDesignLabLinearIssueStatus(
+  issueIdentifier: string,
+  target: DesignLabLinearTargetState
+): Promise<boolean> {
+  if (!env.LINEAR_API_KEY) {
+    logger.warn('[design-lab/linear] LINEAR_API_KEY not configured');
+    return false;
+  }
+
+  try {
+    const issue = await resolveLinearIssue(issueIdentifier);
+    if (!issue) {
+      logger.warn('[design-lab/linear] Issue not found', { issueIdentifier });
+      return false;
+    }
+
+    const state = await findTeamState(issue.id, target);
+    if (!state) {
+      logger.warn('[design-lab/linear] Target state not found', {
+        issueIdentifier,
+        target,
+      });
+      return false;
+    }
+
+    const mutation = `
+      mutation UpdateIssueState($issueId: String!, $stateId: String!) {
+        issueUpdate(id: $issueId, input: { stateId: $stateId }) {
+          success
+        }
+      }
+    `;
+
+    const result = await linearGraphql<{
+      issueUpdate: { success: boolean };
+    }>(mutation, { issueId: issue.id, stateId: state.id });
+
+    return result.issueUpdate.success;
+  } catch (error) {
+    logger.error('[design-lab/linear] Failed to update issue status', {
+      issueIdentifier,
+      target,
+      error,
+    });
+    return false;
+  }
+}

--- a/apps/web/lib/agent-os/design-lab/paths.ts
+++ b/apps/web/lib/agent-os/design-lab/paths.ts
@@ -1,0 +1,75 @@
+import 'server-only';
+
+import path from 'node:path';
+import { resolveMonorepoPath } from '@/lib/filesystem-paths';
+import { validatePathTraversal } from '@/lib/security/path-traversal';
+
+export const DESIGN_LAB_ROOT_SEGMENTS = [
+  'agentos',
+  'runs',
+  'design-lab',
+] as const;
+export const DESIGN_TASTE_MEMORY_SEGMENTS = [
+  'agentos',
+  'memory',
+  'design-taste.md',
+] as const;
+export const DESIGN_LAB_DISPATCH_SEGMENTS = [
+  'agentos',
+  'runs',
+  'design-lab',
+  'dispatches',
+] as const;
+
+export function getDesignLabRootDirectory(): string {
+  return resolveMonorepoPath(...DESIGN_LAB_ROOT_SEGMENTS);
+}
+
+export function getDesignTasteMemoryPath(): string {
+  return resolveMonorepoPath(...DESIGN_TASTE_MEMORY_SEGMENTS);
+}
+
+export function getDesignLabDispatchDirectory(): string {
+  return resolveMonorepoPath(...DESIGN_LAB_DISPATCH_SEGMENTS);
+}
+
+export function resolveDesignProposalDayDirectory(dayBucket: string): string {
+  const safeDayBucket = dayBucket.trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(safeDayBucket)) {
+    throw new Error(`Invalid design proposal day bucket: ${dayBucket}`);
+  }
+
+  return validatePathTraversal(safeDayBucket, getDesignLabRootDirectory());
+}
+
+export function resolveDesignProposalFilePath(
+  dayBucket: string,
+  proposalId: string
+): string {
+  const safeDayBucket = dayBucket.trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(safeDayBucket)) {
+    throw new Error(`Invalid design proposal day bucket: ${dayBucket}`);
+  }
+
+  const safeProposalId = proposalId.trim();
+  if (!/^[a-z0-9][a-z0-9._-]{0,119}$/i.test(safeProposalId)) {
+    throw new Error(`Invalid design proposal id: ${proposalId}`);
+  }
+
+  return validatePathTraversal(
+    path.join(safeDayBucket, `${safeProposalId}.json`),
+    getDesignLabRootDirectory()
+  );
+}
+
+export function resolveDesignDispatchFilePath(dispatchId: string): string {
+  const safeDispatchId = dispatchId.trim();
+  if (!/^[a-z0-9][a-z0-9._-]{0,79}$/i.test(safeDispatchId)) {
+    throw new Error(`Invalid design dispatch id: ${dispatchId}`);
+  }
+
+  return validatePathTraversal(
+    `${safeDispatchId}.json`,
+    getDesignLabDispatchDirectory()
+  );
+}

--- a/apps/web/lib/agent-os/design-lab/proposals.ts
+++ b/apps/web/lib/agent-os/design-lab/proposals.ts
@@ -1,0 +1,170 @@
+import 'server-only';
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { DESIGN_LAB_DEV_FIXTURE_PROPOSALS } from './fixtures';
+import {
+  getDesignLabRootDirectory,
+  resolveDesignProposalDayDirectory,
+  resolveDesignProposalFilePath,
+} from './paths';
+import {
+  type DesignProposal,
+  DesignProposalSchema,
+  type DesignProposalStatus,
+} from './types';
+
+function isMissingFileError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
+function parseProposalRecord(
+  raw: unknown,
+  dayBucket: string
+): DesignProposal | null {
+  const parsed = DesignProposalSchema.safeParse({
+    ...(typeof raw === 'object' && raw !== null ? raw : {}),
+    dayBucket,
+  });
+
+  return parsed.success ? parsed.data : null;
+}
+
+async function readProposalFile(
+  filePath: string,
+  dayBucket: string
+): Promise<DesignProposal | null> {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return parseProposalRecord(JSON.parse(raw), dayBucket);
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function listDayBuckets(): Promise<string[]> {
+  const rootDirectory = getDesignLabRootDirectory();
+
+  try {
+    const entries = await fs.readdir(rootDirectory, { withFileTypes: true });
+    return entries
+      .filter(
+        entry => entry.isDirectory() && /^\d{4}-\d{2}-\d{2}$/.test(entry.name)
+      )
+      .map(entry => entry.name)
+      .sort((left, right) => right.localeCompare(left));
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function listProposalsForDay(
+  dayBucket: string
+): Promise<readonly DesignProposal[]> {
+  const dayDirectory = resolveDesignProposalDayDirectory(dayBucket);
+
+  try {
+    const entries = await fs.readdir(dayDirectory, { withFileTypes: true });
+    const proposals = await Promise.all(
+      entries
+        .filter(entry => entry.isFile() && entry.name.endsWith('.json'))
+        .map(async entry => {
+          const filePath = path.join(dayDirectory, entry.name);
+          return readProposalFile(filePath, dayBucket);
+        })
+    );
+
+    return proposals
+      .filter((proposal): proposal is DesignProposal => proposal !== null)
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+export async function ensureDesignLabDevFixtures(): Promise<void> {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  const existingBuckets = await listDayBuckets();
+  if (existingBuckets.length > 0) {
+    return;
+  }
+
+  for (const proposal of DESIGN_LAB_DEV_FIXTURE_PROPOSALS) {
+    const dayBucket = proposal.dayBucket ?? '2026-06-08';
+    const filePath = resolveDesignProposalFilePath(dayBucket, proposal.id);
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.writeFile(
+      filePath,
+      `${JSON.stringify(proposal, null, 2)}\n`,
+      'utf8'
+    );
+  }
+}
+
+export async function listPendingDesignProposals(): Promise<
+  readonly DesignProposal[]
+> {
+  await ensureDesignLabDevFixtures();
+
+  const dayBuckets = await listDayBuckets();
+  const proposals = await Promise.all(
+    dayBuckets.map(day => listProposalsForDay(day))
+  );
+
+  return proposals
+    .flat()
+    .filter(proposal => proposal.status === 'pending')
+    .sort((left, right) => right.createdAt.localeCompare(left.createdAt));
+}
+
+export async function getDesignProposal(
+  dayBucket: string,
+  proposalId: string
+): Promise<DesignProposal | null> {
+  const filePath = resolveDesignProposalFilePath(dayBucket, proposalId);
+  return readProposalFile(filePath, dayBucket);
+}
+
+export async function saveDesignProposal(
+  proposal: DesignProposal
+): Promise<void> {
+  const dayBucket = proposal.dayBucket;
+  if (!dayBucket) {
+    throw new Error('Design proposal dayBucket is required before save.');
+  }
+
+  const parsed = DesignProposalSchema.parse(proposal);
+  const filePath = resolveDesignProposalFilePath(dayBucket, parsed.id);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(parsed, null, 2)}\n`, 'utf8');
+}
+
+export function deriveProposalStatus(
+  decision: DesignProposal['reviewDecision']
+): DesignProposalStatus {
+  if (decision === 'no') {
+    return 'rejected';
+  }
+
+  if (decision === 'yes' || decision === 'yes-with-notes') {
+    return 'approved';
+  }
+
+  return 'pending';
+}

--- a/apps/web/lib/agent-os/design-lab/review.ts
+++ b/apps/web/lib/agent-os/design-lab/review.ts
@@ -1,0 +1,97 @@
+import 'server-only';
+
+import { triggerDesignLabDispatch } from './dispatch';
+import { updateDesignLabLinearIssueStatus } from './linear';
+import {
+  deriveProposalStatus,
+  getDesignProposal,
+  saveDesignProposal,
+} from './proposals';
+import { appendDesignTasteMemoryEntry } from './taste-memory';
+import type {
+  DesignProposalReviewDecision,
+  ReviewDesignProposalResult,
+} from './types';
+
+function mapDecisionToTaste(
+  decision: DesignProposalReviewDecision
+): 'accepted' | 'rejected' {
+  return decision === 'no' ? 'rejected' : 'accepted';
+}
+
+function shouldTriggerDispatch(
+  decision: DesignProposalReviewDecision
+): boolean {
+  return decision === 'yes' || decision === 'yes-with-notes';
+}
+
+export async function reviewDesignProposal(params: {
+  readonly dayBucket: string;
+  readonly proposalId: string;
+  readonly decision: DesignProposalReviewDecision;
+  readonly notes: string | null;
+  readonly reviewer: string;
+}): Promise<ReviewDesignProposalResult> {
+  const existing = await getDesignProposal(params.dayBucket, params.proposalId);
+  if (!existing) {
+    throw new Error('Design proposal not found.');
+  }
+
+  if (existing.status !== 'pending') {
+    throw new Error('Design proposal has already been reviewed.');
+  }
+
+  const reviewedAt = new Date().toISOString();
+  const normalizedNotes = params.notes?.trim() ? params.notes.trim() : null;
+
+  let dispatchId: string | null = null;
+  let dispatchTriggered = false;
+
+  if (shouldTriggerDispatch(params.decision)) {
+    const dispatch = await triggerDesignLabDispatch({
+      proposal: existing,
+      amendmentNotes:
+        params.decision === 'yes-with-notes' ? normalizedNotes : null,
+      requestedBy: params.reviewer,
+    });
+    dispatchTriggered = dispatch.triggered;
+    dispatchId = dispatch.dispatchId;
+  }
+
+  const updatedProposal = {
+    ...existing,
+    status: deriveProposalStatus(params.decision),
+    reviewedAt,
+    reviewer: params.reviewer,
+    reviewNotes: normalizedNotes,
+    reviewDecision: params.decision,
+    dispatchId,
+    dayBucket: params.dayBucket,
+  };
+
+  await saveDesignProposal(updatedProposal);
+
+  await appendDesignTasteMemoryEntry({
+    timestamp: reviewedAt,
+    surfaceId: existing.surfaceId,
+    surfaceName: existing.surfaceName,
+    direction: existing.proposalText,
+    decision: mapDecisionToTaste(params.decision),
+    notes: normalizedNotes,
+    reviewer: params.reviewer,
+    linearIssueId: existing.linearIssueId,
+  });
+
+  const linearUpdated = await updateDesignLabLinearIssueStatus(
+    existing.linearIssueId,
+    params.decision === 'no' ? 'canceled' : 'completed'
+  );
+
+  return {
+    proposal: updatedProposal,
+    tasteMemoryWritten: true,
+    linearUpdated,
+    dispatchTriggered,
+    dispatchId,
+  };
+}

--- a/apps/web/lib/agent-os/design-lab/taste-memory.ts
+++ b/apps/web/lib/agent-os/design-lab/taste-memory.ts
@@ -1,0 +1,77 @@
+import 'server-only';
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { getDesignTasteMemoryPath } from './paths';
+import type { TasteMemoryEntry } from './types';
+
+const TASTE_MEMORY_HEADER = `# Design taste memory
+
+Persistent accepted/rejected design directions for Design Lab runs.
+Each entry records surface, direction, decision, notes, reviewer, and timestamp.
+`;
+
+function formatTasteMemoryEntry(entry: TasteMemoryEntry): string {
+  const notesBlock = entry.notes
+    ? `\nNotes: ${entry.notes.trim()}`
+    : '\nNotes: —';
+
+  return [
+    `## ${entry.timestamp} — ${entry.surfaceId} — ${entry.decision}`,
+    `Surface: ${entry.surfaceName}`,
+    `Direction: ${entry.direction.trim()}`,
+    `Decision: ${entry.decision}`,
+    `Linear: ${entry.linearIssueId}`,
+    `Reviewer: ${entry.reviewer}`,
+    notesBlock,
+    '',
+  ].join('\n');
+}
+
+export async function appendDesignTasteMemoryEntry(
+  entry: TasteMemoryEntry
+): Promise<void> {
+  const tasteMemoryPath = getDesignTasteMemoryPath();
+  await fs.mkdir(path.dirname(tasteMemoryPath), { recursive: true });
+
+  let existing = '';
+  try {
+    existing = await fs.readFile(tasteMemoryPath, 'utf8');
+  } catch (error) {
+    if (!(error instanceof Error) || !('code' in error)) {
+      throw error;
+    }
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  const nextContent =
+    existing.trim().length > 0
+      ? `${existing.trimEnd()}\n\n${formatTasteMemoryEntry(entry)}`
+      : `${TASTE_MEMORY_HEADER.trim()}\n\n${formatTasteMemoryEntry(entry)}`;
+
+  await fs.writeFile(tasteMemoryPath, nextContent, 'utf8');
+}
+
+export async function readDesignTasteMemoryExcerpt(
+  maxChars = 1200
+): Promise<string> {
+  const tasteMemoryPath = getDesignTasteMemoryPath();
+
+  try {
+    const content = await fs.readFile(tasteMemoryPath, 'utf8');
+    const trimmed = content.trim();
+    if (trimmed.length <= maxChars) {
+      return trimmed;
+    }
+    return `${trimmed.slice(trimmed.length - maxChars).trimStart()}`;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return '';
+      }
+    }
+    throw error;
+  }
+}

--- a/apps/web/lib/agent-os/design-lab/types.ts
+++ b/apps/web/lib/agent-os/design-lab/types.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod';
+
+export const DESIGN_PROPOSAL_STATUSES = [
+  'pending',
+  'approved',
+  'rejected',
+] as const;
+
+export const DESIGN_PROPOSAL_REVIEW_DECISIONS = [
+  'yes',
+  'no',
+  'yes-with-notes',
+] as const;
+
+export type DesignProposalStatus = (typeof DESIGN_PROPOSAL_STATUSES)[number];
+
+export type DesignProposalReviewDecision =
+  (typeof DESIGN_PROPOSAL_REVIEW_DECISIONS)[number];
+
+export const DesignProposalScoringSchema = z
+  .object({
+    weight: z.number().min(0),
+    score: z.number().min(0),
+  })
+  .strict();
+
+export const DesignProposalSchema = z
+  .object({
+    id: z.string().trim().min(1).max(120),
+    surfaceId: z.string().trim().min(1).max(80),
+    surfaceName: z.string().trim().min(1).max(120),
+    proposalText: z.string().trim().min(1).max(8000),
+    assetRefs: z.array(z.string().trim().min(1).max(500)).max(20),
+    scoring: DesignProposalScoringSchema.nullable(),
+    linearIssueId: z.string().trim().min(1).max(40),
+    linearIssueUrl: z.union([z.string().url(), z.null()]),
+    status: z.enum(DESIGN_PROPOSAL_STATUSES),
+    createdAt: z.string().datetime(),
+    reviewedAt: z.union([z.string().datetime(), z.null()]),
+    reviewer: z.union([z.string().trim().min(1).max(160), z.null()]),
+    reviewNotes: z.union([z.string().trim().max(4000), z.null()]),
+    reviewDecision: z
+      .union([z.enum(DESIGN_PROPOSAL_REVIEW_DECISIONS), z.null()])
+      .optional()
+      .transform(value => value ?? null),
+    dispatchId: z
+      .union([z.string().trim().min(1).max(80), z.null()])
+      .optional()
+      .transform(value => value ?? null),
+    dayBucket: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional()
+      .transform(value => value ?? null),
+  })
+  .strict();
+
+export type DesignProposal = z.infer<typeof DesignProposalSchema>;
+
+export const DesignProposalReviewRequestSchema = z
+  .object({
+    dayBucket: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    decision: z.enum(DESIGN_PROPOSAL_REVIEW_DECISIONS),
+    notes: z.union([z.string().trim().max(4000), z.null()]).optional(),
+  })
+  .strict()
+  .superRefine((input, context) => {
+    if (input.decision === 'yes-with-notes') {
+      const notes = input.notes?.trim() ?? '';
+      if (notes.length === 0) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Notes are required for yes-with-notes decisions.',
+          path: ['notes'],
+        });
+      }
+    }
+
+    if (input.decision === 'no' && (input.notes?.trim().length ?? 0) === 0) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Rejection direction notes are required for no decisions.',
+        path: ['notes'],
+      });
+    }
+  });
+
+export type DesignProposalReviewRequest = z.infer<
+  typeof DesignProposalReviewRequestSchema
+>;
+
+export interface TasteMemoryEntry {
+  readonly timestamp: string;
+  readonly surfaceId: string;
+  readonly surfaceName: string;
+  readonly direction: string;
+  readonly decision: 'accepted' | 'rejected';
+  readonly notes: string | null;
+  readonly reviewer: string;
+  readonly linearIssueId: string;
+}
+
+export interface DesignLabDispatchPayload {
+  readonly dispatchId: string;
+  readonly proposalId: string;
+  readonly surfaceId: string;
+  readonly surfaceName: string;
+  readonly proposalText: string;
+  readonly amendmentNotes: string | null;
+  readonly linearIssueId: string;
+  readonly linearIssueUrl: string | null;
+  readonly tasteMemoryExcerpt: string;
+  readonly requestedAt: string;
+  readonly requestedBy: string;
+}
+
+export interface ReviewDesignProposalResult {
+  readonly proposal: DesignProposal;
+  readonly tasteMemoryWritten: boolean;
+  readonly linearUpdated: boolean;
+  readonly dispatchTriggered: boolean;
+  readonly dispatchId: string | null;
+}

--- a/apps/web/tests/unit/agent-os/design-lab/review.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab/review.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { DesignProposal } from '@/lib/agent-os/design-lab/types';
+
+vi.mock('server-only', () => ({}));
+
+const getDesignProposal = vi.fn();
+const saveDesignProposal = vi.fn();
+const appendDesignTasteMemoryEntry = vi.fn();
+const updateDesignLabLinearIssueStatus = vi.fn();
+const triggerDesignLabDispatch = vi.fn();
+
+vi.mock('@/lib/agent-os/design-lab/proposals', () => ({
+  getDesignProposal,
+  saveDesignProposal,
+  deriveProposalStatus: (decision: string | null) => {
+    if (decision === 'no') return 'rejected';
+    if (decision === 'yes' || decision === 'yes-with-notes') return 'approved';
+    return 'pending';
+  },
+}));
+
+vi.mock('@/lib/agent-os/design-lab/taste-memory', () => ({
+  appendDesignTasteMemoryEntry,
+}));
+
+vi.mock('@/lib/agent-os/design-lab/linear', () => ({
+  updateDesignLabLinearIssueStatus,
+}));
+
+vi.mock('@/lib/agent-os/design-lab/dispatch', () => ({
+  triggerDesignLabDispatch,
+}));
+
+const baseProposal: DesignProposal = {
+  id: 'profile-page-quiet-hero',
+  surfaceId: 'profile-page',
+  surfaceName: 'Public profile page',
+  proposalText: 'Use a restrained surface-1 header band.',
+  assetRefs: [],
+  scoring: { weight: 0.9, score: 0.82 },
+  linearIssueId: 'JOV-1951',
+  linearIssueUrl: 'https://linear.app/jovie/issue/JOV-1951',
+  status: 'pending',
+  createdAt: '2026-06-08T12:00:00.000Z',
+  reviewedAt: null,
+  reviewer: null,
+  reviewNotes: null,
+  reviewDecision: null,
+  dispatchId: null,
+  dayBucket: '2026-06-08',
+};
+
+describe('reviewDesignProposal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getDesignProposal.mockResolvedValue(baseProposal);
+    saveDesignProposal.mockResolvedValue(undefined);
+    appendDesignTasteMemoryEntry.mockResolvedValue(undefined);
+    updateDesignLabLinearIssueStatus.mockResolvedValue(true);
+    triggerDesignLabDispatch.mockResolvedValue({
+      triggered: true,
+      dispatchId: 'design-lab-test',
+    });
+  });
+
+  it('approves with yes, dispatches D5, and completes Linear issue', async () => {
+    const { reviewDesignProposal } = await import(
+      '@/lib/agent-os/design-lab/review'
+    );
+
+    const result = await reviewDesignProposal({
+      dayBucket: '2026-06-08',
+      proposalId: baseProposal.id,
+      decision: 'yes',
+      notes: null,
+      reviewer: 'tim@jovie.com',
+    });
+
+    expect(triggerDesignLabDispatch).toHaveBeenCalledWith({
+      proposal: baseProposal,
+      amendmentNotes: null,
+      requestedBy: 'tim@jovie.com',
+    });
+    expect(appendDesignTasteMemoryEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: 'accepted',
+        reviewer: 'tim@jovie.com',
+      })
+    );
+    expect(updateDesignLabLinearIssueStatus).toHaveBeenCalledWith(
+      'JOV-1951',
+      'completed'
+    );
+    expect(saveDesignProposal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'approved',
+        reviewDecision: 'yes',
+        dispatchId: 'design-lab-test',
+      })
+    );
+    expect(result.dispatchTriggered).toBe(true);
+  });
+
+  it('rejects with no, skips dispatch, and cancels Linear issue', async () => {
+    const { reviewDesignProposal } = await import(
+      '@/lib/agent-os/design-lab/review'
+    );
+
+    const result = await reviewDesignProposal({
+      dayBucket: '2026-06-08',
+      proposalId: baseProposal.id,
+      decision: 'no',
+      notes: 'Too loud for our restrained aesthetic.',
+      reviewer: 'tim@jovie.com',
+    });
+
+    expect(triggerDesignLabDispatch).not.toHaveBeenCalled();
+    expect(appendDesignTasteMemoryEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        decision: 'rejected',
+        notes: 'Too loud for our restrained aesthetic.',
+      })
+    );
+    expect(updateDesignLabLinearIssueStatus).toHaveBeenCalledWith(
+      'JOV-1951',
+      'canceled'
+    );
+    expect(saveDesignProposal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'rejected',
+        reviewDecision: 'no',
+        dispatchId: null,
+      })
+    );
+    expect(result.dispatchTriggered).toBe(false);
+  });
+
+  it('approves with notes and injects amendments into dispatch', async () => {
+    const { reviewDesignProposal } = await import(
+      '@/lib/agent-os/design-lab/review'
+    );
+
+    await reviewDesignProposal({
+      dayBucket: '2026-06-08',
+      proposalId: baseProposal.id,
+      decision: 'yes-with-notes',
+      notes: 'Keep the underline but reduce accent saturation.',
+      reviewer: 'tim@jovie.com',
+    });
+
+    expect(triggerDesignLabDispatch).toHaveBeenCalledWith({
+      proposal: baseProposal,
+      amendmentNotes: 'Keep the underline but reduce accent saturation.',
+      requestedBy: 'tim@jovie.com',
+    });
+    expect(saveDesignProposal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'approved',
+        reviewDecision: 'yes-with-notes',
+        reviewNotes: 'Keep the underline but reduce accent saturation.',
+      })
+    );
+  });
+
+  it('throws when proposal was already reviewed', async () => {
+    getDesignProposal.mockResolvedValue({
+      ...baseProposal,
+      status: 'approved',
+    });
+
+    const { reviewDesignProposal } = await import(
+      '@/lib/agent-os/design-lab/review'
+    );
+
+    await expect(
+      reviewDesignProposal({
+        dayBucket: '2026-06-08',
+        proposalId: baseProposal.id,
+        decision: 'yes',
+        notes: null,
+        reviewer: 'tim@jovie.com',
+      })
+    ).rejects.toThrow('Design proposal has already been reviewed.');
+  });
+});

--- a/apps/web/tests/unit/agent-os/design-lab/taste-memory.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab/taste-memory.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+let tempRoot = '';
+
+vi.mock('@/lib/agent-os/design-lab/paths', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/lib/agent-os/design-lab/paths')
+  >('@/lib/agent-os/design-lab/paths');
+
+  return {
+    ...actual,
+    getDesignTasteMemoryPath: () =>
+      path.join(tempRoot, 'agentos', 'memory', 'design-taste.md'),
+  };
+});
+
+describe('appendDesignTasteMemoryEntry', () => {
+  beforeEach(async () => {
+    tempRoot = await mkdtemp(path.join(os.tmpdir(), 'design-taste-'));
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('creates taste memory file with formatted entry', async () => {
+    const { appendDesignTasteMemoryEntry } = await import(
+      '@/lib/agent-os/design-lab/taste-memory'
+    );
+
+    await appendDesignTasteMemoryEntry({
+      timestamp: '2026-06-08T12:00:00.000Z',
+      surfaceId: 'profile-page',
+      surfaceName: 'Public profile page',
+      direction: 'Use a restrained surface-1 header band.',
+      decision: 'rejected',
+      notes: 'Too loud for our restrained aesthetic.',
+      reviewer: 'tim@jovie.com',
+      linearIssueId: 'JOV-1951',
+    });
+
+    const content = await readFile(
+      path.join(tempRoot, 'agentos', 'memory', 'design-taste.md'),
+      'utf8'
+    );
+
+    expect(content).toContain('profile-page');
+    expect(content).toContain('rejected');
+    expect(content).toContain('Too loud for our restrained aesthetic.');
+  });
+});

--- a/apps/web/tests/unit/agent-os/design-lab/types.test.ts
+++ b/apps/web/tests/unit/agent-os/design-lab/types.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { DesignProposalReviewRequestSchema } from '@/lib/agent-os/design-lab/types';
+
+describe('DesignProposalReviewRequestSchema', () => {
+  it('accepts yes without notes', () => {
+    const parsed = DesignProposalReviewRequestSchema.safeParse({
+      dayBucket: '2026-06-08',
+      decision: 'yes',
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+
+  it('requires notes for yes-with-notes', () => {
+    const parsed = DesignProposalReviewRequestSchema.safeParse({
+      dayBucket: '2026-06-08',
+      decision: 'yes-with-notes',
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('requires notes for no', () => {
+    const parsed = DesignProposalReviewRequestSchema.safeParse({
+      dayBucket: '2026-06-08',
+      decision: 'no',
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it('accepts no with rejection direction notes', () => {
+    const parsed = DesignProposalReviewRequestSchema.safeParse({
+      dayBucket: '2026-06-08',
+      decision: 'no',
+      notes: 'Avoid gradient hero treatments.',
+    });
+
+    expect(parsed.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Design Lab review panel to `/app/admin/ops` for pending design proposals.
- Implements three review actions: **Yes**, **No**, and **Yes with notes**.
- On decision, persists outcomes to `agentos/memory/design-taste.md`, updates the linked Linear issue status, and triggers D5 dispatch for approved proposals.

## Review paths
- **Yes**: approve proposal, write accepted taste memory, complete Linear issue, trigger D5 dispatch.
- **No**: reject proposal, write rejected taste memory with required direction notes, cancel Linear issue, no dispatch.
- **Yes with notes**: approve with amendment notes injected into D5 dispatch payload.

## Verification
- `pnpm exec biome check --write` on edited files
- `pnpm exec tsc --noEmit` in `apps/web`
- `pnpm exec vitest run tests/unit/agent-os/design-lab` (9 tests passing)

## Notes
- Dev fixtures seed two pending proposals when no `agentos/runs/design-lab/*` data exists.
- Dispatch always writes a manifest under `agentos/runs/design-lab/dispatches/` and best-effort triggers Hermes when configured.

<!-- linear-issue-id:JOV-1936 -->