### PR TITLE
feat(shell): create shared AppShellRightRail component (JOV-2638)

### DIFF
--- a/apps/web/components/organisms/AppShellFrame.tsx
+++ b/apps/web/components/organisms/AppShellFrame.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { memo } from 'react';
 import { CanvasGrain } from '@/components/atoms/CanvasGrain';
 import { DesktopTitlebar } from '@/components/atoms/DesktopTitlebar';
+import { AppShellRightRail } from '@/components/shell/AppShellRightRail';
 import { isEnabled } from '@/lib/feature-flags';
 import { cn } from '@/lib/utils';
 
@@ -98,7 +99,11 @@ export const AppShellFrame = memo(function AppShellFrame({
             >
               {main}
             </div>
-            {rightPanel}
+            {rightPanel ? (
+              <AppShellRightRail variant={variant}>
+                {rightPanel}
+              </AppShellRightRail>
+            ) : null}
           </div>
           {audioPlayer}
         </main>

--- a/apps/web/components/shell/AppShellRightRail.tsx
+++ b/apps/web/components/shell/AppShellRightRail.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export type AppShellRightRailVariant = 'legacy' | 'shellChatV1';
+
+export interface AppShellRightRailProps {
+  /** Right-rail content — typically a RightDrawer or EntitySidebarShell tree. */
+  readonly children: ReactNode;
+  /** Shell design variant — mirrors AppShellFrame so rail chrome stays in sync. */
+  readonly variant?: AppShellRightRailVariant;
+  readonly className?: string;
+}
+
+/**
+ * Shared AppShell right-rail frame slot.
+ *
+ * Owns the sticky structural container that sits beside the main scroll clip in
+ * AppShellFrame. Card elevation, borders, and drawer width animation live in
+ * RightDrawer / EntitySidebarShell / DrawerSurfaceCard — this primitive only
+ * pins the rail outside route-owned scroll so list and grid surfaces do not
+ * drag the context panel along with them.
+ *
+ * Usage (normally composed by AppShellFrame):
+ *   <AppShellRightRail variant="shellChatV1">
+ *     <EntitySidebarShell ...>{content}</EntitySidebarShell>
+ *   </AppShellRightRail>
+ */
+export function AppShellRightRail({
+  children,
+  variant = 'legacy',
+  className,
+}: AppShellRightRailProps) {
+  const isShellChatV1 = variant === 'shellChatV1';
+
+  return (
+    <aside
+      data-testid='app-shell-right-rail'
+      data-shell-design={variant}
+      aria-label='Context panel'
+      className={cn(
+        'sticky top-0 z-10 flex h-full min-h-0 shrink-0 flex-col self-start overflow-hidden',
+        isShellChatV1 && 'lg:rounded-[var(--linear-app-shell-radius)]',
+        className
+      )}
+    >
+      {children}
+    </aside>
+  );
+}

--- a/apps/web/components/shell/README.md
+++ b/apps/web/components/shell/README.md
@@ -44,6 +44,12 @@ ledger and delete-later inventory.
 If another caller needs a differently shaped source, add a small adapter at
 that caller boundary instead of widening the component contract.
 
+## App shell frame
+
+| Component | Purpose | Wired in production |
+|-----------|---------|---------------------|
+| `AppShellRightRail` | Sticky frame slot for the app-shell context panel. Rendered by `AppShellFrame` beside the main scroll clip so route-owned lists/grids do not drag the rail. Card elevation stays in `RightDrawer` / `EntitySidebarShell` / `DrawerSurfaceCard`. | Yes — `AppShellFrame` |
+
 ## Drawer
 
 | Component | Purpose |

--- a/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
+++ b/apps/web/components/shell/__tests__/AppShellRightRail.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AppShellRightRail } from '../AppShellRightRail';
+
+describe('AppShellRightRail', () => {
+  it('renders children inside the sticky context panel landmark', () => {
+    render(
+      <AppShellRightRail>
+        <div data-testid='fixture-panel'>Panel body</div>
+      </AppShellRightRail>
+    );
+
+    const rail = screen.getByTestId('app-shell-right-rail');
+
+    expect(rail).toHaveAttribute('aria-label', 'Context panel');
+    expect(rail).toHaveClass('sticky', 'top-0', 'overflow-hidden');
+    expect(rail).toContainElement(screen.getByTestId('fixture-panel'));
+  });
+
+  it('applies shellChatV1 radius treatment when opted in', () => {
+    render(
+      <AppShellRightRail variant='shellChatV1'>
+        <div>Panel</div>
+      </AppShellRightRail>
+    );
+
+    const rail = screen.getByTestId('app-shell-right-rail');
+
+    expect(rail).toHaveAttribute('data-shell-design', 'shellChatV1');
+    expect(rail).toHaveClass('lg:rounded-[var(--linear-app-shell-radius)]');
+  });
+
+  it('defaults to legacy variant without shell radius chrome', () => {
+    render(
+      <AppShellRightRail>
+        <div>Panel</div>
+      </AppShellRightRail>
+    );
+
+    const rail = screen.getByTestId('app-shell-right-rail');
+
+    expect(rail).toHaveAttribute('data-shell-design', 'legacy');
+    expect(rail).not.toHaveClass('lg:rounded-[var(--linear-app-shell-radius)]');
+  });
+
+  it('merges custom className without replacing base sticky layout', () => {
+    render(
+      <AppShellRightRail className='fixture-rail'>
+        <div>Panel</div>
+      </AppShellRightRail>
+    );
+
+    const rail = screen.getByTestId('app-shell-right-rail');
+
+    expect(rail).toHaveClass('fixture-rail', 'sticky', 'top-0');
+  });
+});

--- a/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
+++ b/apps/web/tests/unit/components/organisms/AppShellFrame.test.tsx
@@ -79,6 +79,27 @@ describe('AppShellFrame', () => {
     );
   });
 
+  it('wraps the right panel in the shared AppShellRightRail slot', () => {
+    render(
+      <AppShellFrame
+        sidebar={<aside>Sidebar</aside>}
+        header={<header>Header</header>}
+        main={<div>Main Content</div>}
+        rightPanel={<div data-testid='fixture-right-rail'>Right rail</div>}
+      />
+    );
+
+    const scrollPane = screen.getByTestId('app-shell-scroll');
+    const rightRail = screen.getByTestId('app-shell-right-rail');
+
+    expect(scrollPane).toContainElement(screen.getByText('Main Content'));
+    expect(scrollPane).not.toContainElement(rightRail);
+    expect(rightRail).toContainElement(
+      screen.getByTestId('fixture-right-rail')
+    );
+    expect(rightRail).toHaveClass('sticky', 'top-0');
+  });
+
   it('renders the shared audio player slot inside the shell frame', () => {
     render(
       <AppShellFrame


### PR DESCRIPTION
## Summary

- Adds `AppShellRightRail`, a shared sticky frame slot for the app-shell context panel
- Wires `AppShellFrame` to render `rightPanel` through the new primitive
- Documents the component in `components/shell/README.md`

## Design

`AppShellRightRail` owns the **structural** right-rail slot beside the main scroll clip. Card elevation, borders, and drawer animation remain in `RightDrawer` / `EntitySidebarShell` / `DrawerSurfaceCard` so existing entity drawers keep their current visuals.

This coordinates with JOV-2639 (scroll clipping) without changing scroll ownership here — JOV-2639 can import this component instead of an inline sticky wrapper when it lands.

## Test plan

- [x] `AppShellRightRail` unit tests (sticky landmark, variant chrome, className merge)
- [x] `AppShellFrame` unit test (right rail sits outside main scroll pane)
- [x] Typecheck + lint clean

Closes JOV-2638