### PR TITLE
test(app-shell): slice 0 contracts and measurement harness (JOV-2219)

### DIFF
--- a/apps/web/tests/scripts/performance-route-manifest.test.ts
+++ b/apps/web/tests/scripts/performance-route-manifest.test.ts
@@ -22,6 +22,29 @@ interface CreatorShellRouteExpectation {
 
 const CREATOR_SHELL_SLICE_ROUTES = [
   {
+    id: 'creator-chat',
+    path: APP_ROUTES.CHAT,
+    measureMode: 'page-load',
+    warmupStrategy: 'authenticated-route',
+    primaryMetric: 'skeleton-to-content',
+  },
+  {
+    id: 'creator-chat-thread',
+    path: '/app/chat/[id]',
+    measureMode: 'page-load',
+    warmupStrategy: 'authenticated-route',
+    primaryMetric: 'skeleton-to-content',
+    resolvesDynamicPath: true,
+  },
+  {
+    id: 'creator-releases',
+    path: APP_ROUTES.RELEASES,
+    measureMode: 'warm-navigation',
+    warmupStrategy: 'authenticated-shell',
+    primaryMetric: 'warm-shell-response',
+    navTrigger: `a[href="${APP_ROUTES.RELEASES}"]`,
+  },
+  {
     id: 'creator-library',
     path: APP_ROUTES.LIBRARY,
     measureMode: 'warm-navigation',
@@ -55,6 +78,7 @@ const CREATOR_SHELL_SLICE_ROUTES = [
 ] as const satisfies readonly CreatorShellRouteExpectation[];
 
 const RELEASE_BUDGET_CREATOR_SHELL_ROUTE_IDS = [
+  'creator-releases',
   'creator-library',
   'creator-tasks',
   'creator-lyrics',

--- a/apps/web/tests/unit/app/unified-app-shell-slice-0-contract.test.ts
+++ b/apps/web/tests/unit/app/unified-app-shell-slice-0-contract.test.ts
@@ -1,0 +1,103 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
+import { getEndUserPerfRouteById } from '@/scripts/performance-route-manifest';
+
+const REPO_ROOT = join(process.cwd(), '../..');
+const CONTRACT_DOC_PATH = join(
+  REPO_ROOT,
+  'docs/unified-app-shell-slice-0-contract.md'
+);
+const SHELL_PERSISTENCE_SPEC_PATH = join(
+  process.cwd(),
+  'tests/e2e/shell-route-persistence.spec.ts'
+);
+const EXP_IMPORT_BOUNDARY_TEST_PATH = join(
+  process.cwd(),
+  'tests/unit/app/exp-import-boundary.test.ts'
+);
+
+const REQUIRED_CONTRACT_SECTIONS = [
+  '## Hard Constraints',
+  '## HOT ZONE Ownership',
+  '## Route UX And Data Contracts',
+  '## Data Ownership And Request Budgets',
+  '## `/exp/*` Inventory Format',
+  '## Screenshot And Pixel Target Matrix',
+  '## Slice Exit Checklist For Implementers',
+] as const;
+
+const SLICE_0_PERF_MANIFEST_ROUTE_IDS = [
+  { id: 'creator-chat', group: 'creator-shell', path: APP_ROUTES.CHAT },
+  { id: 'creator-chat-thread', group: 'creator-shell', path: '/app/chat/[id]' },
+  { id: 'creator-releases', group: 'creator-shell', path: APP_ROUTES.RELEASES },
+  { id: 'creator-library', group: 'creator-shell', path: APP_ROUTES.LIBRARY },
+  { id: 'creator-tasks', group: 'creator-shell', path: APP_ROUTES.TASKS },
+  {
+    id: 'creator-lyrics',
+    group: 'creator-shell',
+    path: `${APP_ROUTES.LYRICS}/[trackId]`,
+  },
+  { id: 'onboarding', group: 'onboarding', path: '/start' },
+] as const;
+
+const SHELL_PERSISTENCE_ROUTE_MARKERS = [
+  'chat',
+  'releases',
+  'library',
+  'tasks',
+  'JOV-2219 baseline',
+  'data-app-shell-frame="true"',
+] as const;
+
+describe('unified app shell slice 0 contract harness', () => {
+  it('keeps the slice 0 contract doc present with required sections', () => {
+    expect(existsSync(CONTRACT_DOC_PATH)).toBe(true);
+
+    const contractDoc = readFileSync(CONTRACT_DOC_PATH, 'utf8');
+    expect(contractDoc).toContain('Issue: JOV-2219');
+    expect(contractDoc).toContain(
+      'No production import may reference `apps/web/app/exp/*`.'
+    );
+
+    for (const section of REQUIRED_CONTRACT_SECTIONS) {
+      expect(contractDoc, `missing ${section}`).toContain(section);
+    }
+  });
+
+  it('maps slice 0 screenshot-matrix routes to performance manifest entries', () => {
+    for (const expectation of SLICE_0_PERF_MANIFEST_ROUTE_IDS) {
+      const route = getEndUserPerfRouteById(expectation.id);
+      expect(
+        route,
+        `${expectation.id} missing from perf manifest`
+      ).toBeDefined();
+      expect(route?.group).toBe(expectation.group);
+      expect(route?.path).toBe(expectation.path);
+      expect(route?.readySelectors.content?.length ?? 0).toBeGreaterThan(0);
+    }
+  });
+
+  it('keeps the shell route persistence harness wired to core slice routes', () => {
+    expect(existsSync(SHELL_PERSISTENCE_SPEC_PATH)).toBe(true);
+
+    const harnessSource = readFileSync(SHELL_PERSISTENCE_SPEC_PATH, 'utf8');
+    for (const marker of SHELL_PERSISTENCE_ROUTE_MARKERS) {
+      expect(harnessSource, `missing ${marker}`).toContain(marker);
+    }
+  });
+
+  it('keeps the experimental import boundary guard in the slice 0 harness', () => {
+    expect(existsSync(EXP_IMPORT_BOUNDARY_TEST_PATH)).toBe(true);
+
+    const boundarySource = readFileSync(EXP_IMPORT_BOUNDARY_TEST_PATH, 'utf8');
+    expect(boundarySource).toContain('app/exp');
+    expect(boundarySource).toContain(
+      'production source from importing app/exp'
+    );
+    expect(relative(REPO_ROOT, EXP_IMPORT_BOUNDARY_TEST_PATH)).toBe(
+      'apps/web/tests/unit/app/exp-import-boundary.test.ts'
+    );
+  });
+});


### PR DESCRIPTION
## Goal

Complete Slice 0 of the Unified App Shell migration: contracts and measurement harness only. No production UI or route behavior changes.

## Scope (JOV-2219)

- **Contract doc:** `docs/unified-app-shell-slice-0-contract.md` (route UX/data contracts, request budgets, `/exp/*` inventory format, screenshot matrix)
- **Measurement harness:**
  - `apps/web/tests/unit/app/unified-app-shell-slice-0-contract.test.ts` — links contract doc → perf manifest routes → shell persistence harness → exp import boundary
  - `apps/web/tests/scripts/performance-route-manifest.test.ts` — foundation shell route coverage (chat, chat-thread, releases, library, tasks, lyrics)
  - `apps/web/tests/unit/app/exp-import-boundary.test.ts` — blocks production imports from `app/exp/*`
  - `apps/web/tests/e2e/shell-route-persistence.spec.ts` — shell frame persistence + request budget probe

## KPI (if applicable)

n/a — test/contract harness only

## Rollback plan

Revert PR.

## Verification

```bash
cd apps/web && pnpm test -- \
  tests/unit/app/unified-app-shell-slice-0-contract.test.ts \
  tests/scripts/performance-route-manifest.test.ts \
  tests/unit/app/exp-import-boundary.test.ts
```

All 13 tests pass locally.