### PR TITLE
fix(chat): hide album-art suggestions when provider unconfigured (JOV-2524)

### DIFF
--- a/apps/web/components/jovie/components/SlashCommandMenu.tsx
+++ b/apps/web/components/jovie/components/SlashCommandMenu.tsx
@@ -29,10 +29,15 @@ import {
   flattenSections,
   InlinePalette,
 } from '@/components/organisms/SharedCommandPalette';
+import {
+  filterSkillsHidingBrokenAlbumArt,
+  shouldHideAlbumArtChatSuggestion,
+} from '@/lib/chat/album-art-capability';
 import type { EntityKind } from '@/lib/chat/tokens';
 import type { EntityRef } from '@/lib/commands/entities';
 import { commandsForSurface, type SkillCommand } from '@/lib/commands/registry';
 import { useArtistSearchQuery } from '@/lib/queries/useArtistSearchQuery';
+import { useChatCapabilitiesQuery } from '@/lib/queries/useChatCapabilitiesQuery';
 import { useEventsQuery } from '@/lib/queries/useEventsQuery';
 import { useReleasesQuery } from '@/lib/queries/useReleasesQuery';
 import {
@@ -154,6 +159,11 @@ export function useSlashItems(
     artistSearchSearch(artistQueryString);
   }, [artistQueryString, artistSearchSearch]);
 
+  const { data: chatCapabilities } = useChatCapabilitiesQuery({
+    profileId,
+    enabled: Boolean(profileId) && isRoot,
+  });
+
   return useMemo<UseSlashItemsResult>(() => {
     if (state.status === 'closed') {
       return { items: [], sections: [], isLoading: false };
@@ -206,9 +216,12 @@ export function useSlashItems(
     }
 
     // root: skills + entity suggestions per kind
-    const skills = commandsForSurface('chat-slash')
-      .filter((c): c is SkillCommand => c.kind === 'skill')
-      .filter(s => fuzzyMatch(`${s.label} ${s.description}`, query));
+    const skills = filterSkillsHidingBrokenAlbumArt(
+      commandsForSurface('chat-slash').filter(
+        (c): c is SkillCommand => c.kind === 'skill'
+      ),
+      chatCapabilities?.tools.albumArt
+    ).filter(s => fuzzyMatch(`${s.label} ${s.description}`, query));
 
     const sections: ListSection[] = [];
     const items: SlashMenuItem[] = [];
@@ -261,6 +274,7 @@ export function useSlashItems(
     eventLoading,
     artistSearch.results,
     artistSearch.state,
+    chatCapabilities?.tools,
   ]);
 }
 
@@ -346,9 +360,20 @@ export function SlashCommandMenu({
 }: SlashCommandMenuProps) {
   const { sections, isLoading } = useSlashItems(state, profileId);
   const query = state.status === 'closed' ? '' : state.query;
+  const { data: chatCapabilities } = useChatCapabilitiesQuery({
+    profileId,
+    enabled: Boolean(profileId) && state.status === 'root',
+  });
+  const hideAlbumArtSuggestions = chatCapabilities?.tools.albumArt
+    ? shouldHideAlbumArtChatSuggestion(chatCapabilities.tools.albumArt)
+    : false;
   const promptItems = useMemo<PickerItem[]>(() => {
     if (state.status !== 'root' || !promptActions?.length) return [];
     return promptActions
+      .filter(
+        action =>
+          !(hideAlbumArtSuggestions && action.label === 'Generate album art')
+      )
       .filter(action => fuzzyMatch(`${action.label} ${action.prompt}`, query))
       .map(action => ({
         kind: 'prompt' as const,
@@ -359,7 +384,7 @@ export function SlashCommandMenu({
           prompt: action.prompt,
         },
       }));
-  }, [promptActions, query, state.status]);
+  }, [hideAlbumArtSuggestions, promptActions, query, state.status]);
 
   // Map legacy SlashMenuItem sections → PickerItem sections for the shared
   // shell. The shape is structurally equivalent; the indirection just gates

--- a/apps/web/components/jovie/components/SuggestedPrompts.tsx
+++ b/apps/web/components/jovie/components/SuggestedPrompts.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import type { ComponentType, SVGProps } from 'react';
 
+import { shouldHideAlbumArtChatSuggestion } from '@/lib/chat/album-art-capability';
 import { cn } from '@/lib/utils';
 import {
   type ChatSuggestion,
@@ -141,10 +142,9 @@ export function SuggestedPrompts({
   // point. Plan-gated ('PLAN_UNAVAILABLE') and profile-pending
   // ('PROFILE_REQUIRED') reasons remain visible-but-disabled because the user
   // has an action to take (upgrade, finish onboarding).
-  const isAlbumArtProviderBroken =
-    resolvedAlbumArtCapability.availability === 'unavailable' &&
-    (resolvedAlbumArtCapability.reasonCode === 'PROVIDER_UNAVAILABLE' ||
-      resolvedAlbumArtCapability.reasonCode === 'FEATURE_DISABLED');
+  const isAlbumArtProviderBroken = shouldHideAlbumArtChatSuggestion(
+    resolvedAlbumArtCapability
+  );
   const draftAlbumArtBriefSuggestion: ChatSuggestion | null =
     resolvedAlbumArtCapability.availability === 'unavailable'
       ? {

--- a/apps/web/components/organisms/CmdKPalette.tsx
+++ b/apps/web/components/organisms/CmdKPalette.tsx
@@ -19,6 +19,7 @@ import { Search } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { APP_ROUTES } from '@/constants/routes';
+import { filterSkillsHidingBrokenAlbumArt } from '@/lib/chat/album-art-capability';
 import { type EntityRef } from '@/lib/commands/entities';
 import { resolveEntityHref } from '@/lib/commands/entity-routing';
 import {
@@ -28,6 +29,7 @@ import {
   type SkillCommand,
 } from '@/lib/commands/registry';
 import { useArtistSearchQuery } from '@/lib/queries/useArtistSearchQuery';
+import { useChatCapabilitiesQuery } from '@/lib/queries/useChatCapabilitiesQuery';
 import { useReleasesQuery } from '@/lib/queries/useReleasesQuery';
 import {
   artistResultToEntityRef,
@@ -63,9 +65,17 @@ function useCmdkData(profileId: string, query: string, open: boolean) {
     () => commandsForSurface('cmdk'),
     []
   );
+  const { data: chatCapabilities } = useChatCapabilitiesQuery({
+    profileId,
+    enabled: open,
+  });
   const skills = useMemo(
-    () => commands.filter((c): c is SkillCommand => c.kind === 'skill'),
-    [commands]
+    () =>
+      filterSkillsHidingBrokenAlbumArt(
+        commands.filter((c): c is SkillCommand => c.kind === 'skill'),
+        chatCapabilities?.tools.albumArt
+      ),
+    [chatCapabilities?.tools.albumArt, commands]
   );
   const navs = useMemo(
     () => commands.filter((c): c is NavCommand => c.kind === 'nav'),

--- a/apps/web/lib/chat/album-art-capability.ts
+++ b/apps/web/lib/chat/album-art-capability.ts
@@ -1,3 +1,4 @@
+import type { SkillCommand } from '@/lib/commands/registry';
 import type { getCurrentUserEntitlements } from '@/lib/entitlements/server';
 
 export type ToolAvailability = 'available' | 'unavailable' | 'unknown';
@@ -70,6 +71,27 @@ export function detectAlbumArtGenerationIntent(input: {
     /\bbrief\b/.test(normalized) || /\bdraft\b/.test(normalized);
 
   return mentionsAlbumArt && asksForGeneration && !asksForBrief;
+}
+
+/** Provider-down and feature-flag kills are broken states — hide entry points. */
+export function shouldHideAlbumArtChatSuggestion(
+  capability: AlbumArtCapability
+): boolean {
+  return (
+    capability.availability === 'unavailable' &&
+    (capability.reasonCode === 'PROVIDER_UNAVAILABLE' ||
+      capability.reasonCode === 'FEATURE_DISABLED')
+  );
+}
+
+export function filterSkillsHidingBrokenAlbumArt(
+  skills: readonly SkillCommand[],
+  capability: AlbumArtCapability | undefined
+): readonly SkillCommand[] {
+  if (!capability || !shouldHideAlbumArtChatSuggestion(capability)) {
+    return skills;
+  }
+  return skills.filter(skill => skill.id !== 'generateAlbumArt');
 }
 
 export function buildAlbumArtUnavailableAssistantMessage(

--- a/apps/web/tests/e2e/chat-first-turn-regression.spec.ts
+++ b/apps/web/tests/e2e/chat-first-turn-regression.spec.ts
@@ -3,7 +3,7 @@
  *
  * Covers the user-visible regression contract:
  * - chat opens as a chat-specific empty state, not the dashboard welcome state
- * - unavailable album-art action is disabled before invocation
+ * - empty chat does not advertise album-art generation when provider is down
  * - typed album-art generation produces a durable assistant transcript item
  * - refresh restores the same user + assistant messages
  */
@@ -134,10 +134,7 @@ test('new thread album-art unavailable state survives refresh', async ({
   await expect(page.getByText(/Welcome back/i)).toHaveCount(0);
   await expect(
     page.getByRole('button', { name: 'Generate album art' })
-  ).toBeDisabled();
-  await expect(
-    page.getByRole('button', { name: 'Draft album-art brief' })
-  ).toBeEnabled();
+  ).toHaveCount(0);
 
   const composer = page
     .getByPlaceholder(/ask jovie|ask a follow-up|chat message/i)

--- a/apps/web/tests/unit/chat/SlashCommandMenu.keyboard.test.tsx
+++ b/apps/web/tests/unit/chat/SlashCommandMenu.keyboard.test.tsx
@@ -36,6 +36,22 @@ vi.mock('@/lib/queries/useEventsQuery', () => ({
   useEventsQuery: mockUseEventsQuery,
 }));
 
+vi.mock('@/lib/queries/useChatCapabilitiesQuery', () => ({
+  useChatCapabilitiesQuery: () => ({
+    data: {
+      tools: {
+        albumArt: {
+          availability: 'available',
+          reason: null,
+          reasonCode: null,
+        },
+      },
+    },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
 function withProviders(ui: ReactNode) {
   const client = new QueryClient({
     defaultOptions: {

--- a/apps/web/tests/unit/chat/album-art-capability.test.ts
+++ b/apps/web/tests/unit/chat/album-art-capability.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   buildAlbumArtUnavailableAssistantMessage,
   detectAlbumArtGenerationIntent,
+  filterSkillsHidingBrokenAlbumArt,
   resolveAlbumArtCapability,
+  shouldHideAlbumArtChatSuggestion,
 } from '@/lib/chat/album-art-capability';
+import { commandsForSurface } from '@/lib/commands/registry';
 
 describe('album art capability resolution', () => {
   it('marks album art unavailable when the provider is not configured', () => {
@@ -37,6 +40,44 @@ describe('album art capability resolution', () => {
         text: 'Draft an album-art brief for my latest release.',
       })
     ).toBe(false);
+  });
+
+  it('hides chat suggestions when provider is unavailable or feature is disabled', () => {
+    expect(
+      shouldHideAlbumArtChatSuggestion({
+        availability: 'unavailable',
+        reason: 'Album art generation is temporarily unavailable.',
+        reasonCode: 'PROVIDER_UNAVAILABLE',
+      })
+    ).toBe(true);
+    expect(
+      shouldHideAlbumArtChatSuggestion({
+        availability: 'unavailable',
+        reason: 'Album art generation is not enabled for this workspace.',
+        reasonCode: 'FEATURE_DISABLED',
+      })
+    ).toBe(true);
+    expect(
+      shouldHideAlbumArtChatSuggestion({
+        availability: 'unavailable',
+        reason: 'Album art generation requires a Pro plan.',
+        reasonCode: 'PLAN_UNAVAILABLE',
+      })
+    ).toBe(false);
+  });
+
+  it('filters generateAlbumArt from slash/cmdk skills when provider is broken', () => {
+    const skills = commandsForSurface('chat-slash').filter(
+      command => command.kind === 'skill'
+    );
+    const filtered = filterSkillsHidingBrokenAlbumArt(skills, {
+      availability: 'unavailable',
+      reason: 'Album art generation is temporarily unavailable.',
+      reasonCode: 'PROVIDER_UNAVAILABLE',
+    });
+
+    expect(filtered.some(skill => skill.id === 'generateAlbumArt')).toBe(false);
+    expect(filtered.length).toBe(skills.length - 1);
   });
 
   it('builds a durable assistant recovery message', () => {

--- a/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
+++ b/apps/web/tests/unit/commands/SharedCommandPalette.test.tsx
@@ -79,6 +79,22 @@ vi.mock('@/lib/queries/useArtistSearchQuery', () => ({
   }),
 }));
 
+vi.mock('@/lib/queries/useChatCapabilitiesQuery', () => ({
+  useChatCapabilitiesQuery: () => ({
+    data: {
+      tools: {
+        albumArt: {
+          availability: 'available',
+          reason: null,
+          reasonCode: null,
+        },
+      },
+    },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
 describe('SharedCommandPalette (cmd+k surface)', () => {
   it('exposes both skills and navs from the registry on the cmdk surface', () => {
     const cmds = commandsForSurface('cmdk');

--- a/apps/web/tests/unit/organisms/CommandPalette.test.tsx
+++ b/apps/web/tests/unit/organisms/CommandPalette.test.tsx
@@ -51,6 +51,22 @@ vi.mock('@/lib/queries/useArtistSearchQuery', () => ({
   }),
 }));
 
+vi.mock('@/lib/queries/useChatCapabilitiesQuery', () => ({
+  useChatCapabilitiesQuery: () => ({
+    data: {
+      tools: {
+        albumArt: {
+          availability: 'available',
+          reason: null,
+          reasonCode: null,
+        },
+      },
+    },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
 vi.mock('@/lib/queries', async () => {
   const actual =
     await vi.importActual<typeof import('@/lib/queries')>('@/lib/queries');


### PR DESCRIPTION
Closes JOV-2524

linear-issue-id: JOV-2524

## Summary
- Centralized `shouldHideAlbumArtChatSuggestion` / `filterSkillsHidingBrokenAlbumArt` in `album-art-capability.ts` and reused it in `SuggestedPrompts`
- Slash picker and cmd+k now omit `generateAlbumArt` when `reasonCode` is `PROVIDER_UNAVAILABLE` or `FEATURE_DISABLED`
- Updated the first-turn e2e regression to match the simplified empty chat (no album-art pill when provider is down)

## Validation
- [x] TypeScript typecheck passed
- [x] Biome lint/format passed
- [x] Unit tests passed (`album-art-capability`, `SuggestedPrompts`, `SlashCommandMenu`, `SharedCommandPalette`, `CommandPalette`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Album art generation suggestions are now hidden when the feature or provider is unavailable, preventing users from accessing broken functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->