### PR TITLE
feat(auth): complete Clerk config automation (JOV-2653)

### DIFF
--- a/.claude/rules/auth.md
+++ b/.claude/rules/auth.md
@@ -180,3 +180,23 @@ clerk users delete <user_id>            # delete a user (irreversible — confir
 - Staging application (Account B): staging (`pk_live_...`) → staging.jov.ie
 
 Always confirm `clerk whoami` shows the correct instance before running write operations. For bulk E2E test-user cleanup, prefer `apps/web/scripts/cleanup-e2e-users.ts` over direct CLI deletion.
+
+### Clerk config automation (agents)
+
+For inspecting or safely mutating Clerk instance settings (redirect URLs, OAuth/native apps, allowed origins, webhooks, JWT templates), use the Doppler-wrapped automation script — not manual dashboard edits:
+
+```bash
+# Pull + auth-key preview
+doppler run --project jovie-web --config dev -- \
+  pnpm tsx scripts/clerk-config.ts pull --instance dev
+
+# Diagnose iOS/native redirect gaps
+doppler run --project jovie-web --config dev -- \
+  pnpm tsx scripts/clerk-config.ts check-redirects --pattern "myapp://|jov.ie"
+
+# Preview a patch (mutations require --dry-run first)
+doppler run --project jovie-web --config dev -- \
+  pnpm tsx scripts/clerk-config.ts patch --dry-run --json '{"auth":{"redirect_urls":["..."]}}'
+```
+
+Safety: `whoami` + audit logging always; `sk_live_` / prod patches refused without `--allow-prod`; staging/prod patches need explicit human review. Invoke the `/clerk-cli` skill for full workflows. See `docs/CLERK_CLI.md` and `scripts/clerk-config.ts --help`.

--- a/.claude/skills/clerk-cli/SKILL.md
+++ b/.claude/skills/clerk-cli/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: clerk-cli
+description: |
+  Clerk CLI and config automation for Jovie auth debugging. Use when inspecting
+  or updating Clerk users, sessions, instance config, redirect URLs, OAuth/native
+  app settings, or diagnosing iOS/auth redirect failures. Invoke for any Clerk-side
+  auth configuration work.
+version: 2026-06-08
+scope: JovieInc/Jovie
+---
+
+# clerk-cli
+
+Agent workflow for Clerk user management, instance inspection, and auth configuration changes.
+
+## Before any write operation
+
+1. Confirm the target environment (`dev`, `staging`, `prod`).
+2. Run `clerk whoami` (or the wrapper below) and verify the active Clerk app/instance.
+3. Prefer `dev` (`sk_test_`) for automation; never bulk-experiment on production.
+
+## Jovie instance map
+
+| Wrapper `--instance` | Doppler config | Clerk app | Clerk instance |
+|---|---|---|---|
+| `dev` | `jovie-web/dev` | Jovie | `dev` |
+| `staging` | `jovie-web/stg` | Jovie Preview | `prod` |
+| `prod` | `jovie-web/prd` | Jovie | `prod` |
+
+Detached worktrees are not `clerk link`ed — always use `scripts/clerk-config.ts` with explicit `--instance` so the correct app ID is passed.
+
+## Preferred automation wrapper
+
+Use `scripts/clerk-config.ts` for config inspection and safe mutations. It adds Doppler env injection, instance targeting, dry-run defaults, prod guards, and audit logging.
+
+```bash
+# Confirm context
+doppler run --project jovie-web --config dev -- \
+  pnpm tsx scripts/clerk-config.ts whoami --instance dev
+
+# Pull current config + auth-key preview
+doppler run --project jovie-web --config dev -- \
+  pnpm tsx scripts/clerk-config.ts pull --instance dev --output /tmp/clerk-dev.json
+
+# Diagnose missing redirect/native scheme (iOS auth failures)
+doppler run --project jovie-web --config dev -- \
+  pnpm tsx scripts/clerk-config.ts check-redirects --pattern "myapp://|jov.ie"
+
+# Preview a config patch (always dry-run first)
+doppler run --project jovie-web --config dev -- \
+  pnpm tsx scripts/clerk-config.ts patch --dry-run --json '{"auth":{"redirect_urls":["..."]}}'
+```
+
+Subcommands: `whoami`, `pull`, `schema`, `patch`, `check-redirects`, `--self-test`.
+
+## Direct Clerk CLI (users/sessions)
+
+When the wrapper is not needed (user lookup, session revoke):
+
+```bash
+clerk auth login          # one-time browser OAuth
+clerk whoami              # confirm active session
+clerk users list --query email@example
+clerk users get <user_id>
+clerk users delete <user_id>   # irreversible — confirm first
+clerk api /sessions
+clerk api /sessions/<id> -X DELETE
+```
+
+For E2E test-user cleanup, prefer the repo script (metadata + email pattern aware):
+
+```bash
+doppler run --project jovie-web --config dev -- \
+  pnpm tsx apps/web/scripts/cleanup-e2e-users.ts --force
+```
+
+## Common auth-fix flows
+
+### iOS / native redirect missing
+
+1. `check-redirects --pattern "custom-scheme://"` on the target instance.
+2. `pull` or `schema` to see the current redirect/native app shape.
+3. `patch --dry-run` with the corrected redirect list.
+4. Re-run `check-redirects` against a pulled file (`--file`) to verify offline.
+5. Apply with `--yes` on `dev` only; staging/prod require `--allow-prod` and human review.
+
+### OAuth provider / allowed origins
+
+1. `pull --instance <env>` and inspect `extractAuthRelevantConfigKeys` output (printed on pull).
+2. `schema --instance <env>` for valid patch keys.
+3. `patch --dry-run` before any apply.
+
+### User-specific auth debug
+
+1. `clerk users list --query <email>` to find the user ID.
+2. `clerk users get <id>` for metadata and identities.
+3. Use `cleanup-e2e-users.ts` for `+clerk_test` / `role: e2e` users — not arbitrary deletes.
+
+## Safety rules (non-negotiable)
+
+- Always `whoami` before writes.
+- Mutations default to `--dry-run`; real apply needs `--yes` (dev) or `--yes --allow-prod` (staging/prod).
+- `sk_live_` keys refused unless `--allow-prod`.
+- `clerk users delete` is irreversible.
+- Do not use production for bulk or experimental operations.
+- All wrapper operations log `[clerk-config-audit ...]` lines to stderr.
+
+## References
+
+- Full manual: `docs/CLERK_CLI.md`
+- Auth architecture + proxy rules: `.claude/rules/auth.md`
+- Wrapper source + exported helpers: `scripts/clerk-config.ts`
+- Unit tests: `apps/web/tests/unit/scripts/clerk-config-script.test.ts`

--- a/apps/web/tests/unit/scripts/clerk-config-script.test.ts
+++ b/apps/web/tests/unit/scripts/clerk-config-script.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertPatchTargetAllowed,
+  assertTestOrAllowedInstance,
+  extractAuthRelevantConfigKeys,
+  getDopplerForInstance,
+  hasMatchingRedirect,
+} from '../../../../../scripts/clerk-config';
+
+describe('scripts/clerk-config.ts', () => {
+  const sampleConfig = JSON.stringify({
+    auth: {
+      redirect_urls: ['https://jov.ie/*', 'myapp://callback'],
+      oauth_providers: { google: { enabled: true } },
+    },
+    allowed_origins: ['https://staging.jov.ie'],
+    native_applications: [{ scheme: 'jovie' }],
+    connection_oauth_custom: { enabled: false },
+    auth_sign_in_url: '/signin',
+    unrelated_key: 'ignored',
+  });
+
+  it('maps wrapper instances to Doppler + Clerk app targets', () => {
+    expect(getDopplerForInstance('dev')).toEqual({
+      project: 'jovie-web',
+      config: 'dev',
+      appId: 'app_30k0dWZPrUoCQ51f2ix99TWosSg',
+      clerkInstance: 'dev',
+    });
+    expect(getDopplerForInstance('staging')).toEqual({
+      project: 'jovie-web',
+      config: 'stg',
+      appId: 'app_31OUB1NkwJoCRW4w0ka65SRZCGz',
+      clerkInstance: 'prod',
+    });
+    expect(getDopplerForInstance('prod')).toEqual({
+      project: 'jovie-web',
+      config: 'prd',
+      appId: 'app_30k0dWZPrUoCQ51f2ix99TWosSg',
+      clerkInstance: 'prod',
+    });
+  });
+
+  it('rejects unknown wrapper instances', () => {
+    expect(() => getDopplerForInstance('qa')).toThrow(
+      'Unknown instance "qa". Use dev|staging|prod.'
+    );
+  });
+
+  it('extracts auth-relevant keys from Clerk config JSON', () => {
+    const extracted = extractAuthRelevantConfigKeys(sampleConfig);
+
+    expect(extracted.auth).toEqual({
+      redirect_urls: ['https://jov.ie/*', 'myapp://callback'],
+      oauth_providers: { google: { enabled: true } },
+    });
+    expect(extracted.allowed_origins).toEqual(['https://staging.jov.ie']);
+    expect(extracted.native_applications).toEqual([{ scheme: 'jovie' }]);
+    expect(extracted.connection_oauth_custom).toEqual({ enabled: false });
+    expect(extracted['auth.redirect_urls']).toEqual([
+      'https://jov.ie/*',
+      'myapp://callback',
+    ]);
+    expect(extracted).not.toHaveProperty('unrelated_key');
+  });
+
+  it('returns parse diagnostics for invalid JSON', () => {
+    const extracted = extractAuthRelevantConfigKeys('not-json');
+
+    expect(extracted).toHaveProperty('parse_error');
+    expect(extracted).toHaveProperty('raw_preview', 'not-json');
+  });
+
+  it('matches redirect patterns case-insensitively', () => {
+    expect(hasMatchingRedirect(sampleConfig, 'MYAPP://')).toBe(true);
+    expect(hasMatchingRedirect(sampleConfig, 'jov.ie')).toBe(true);
+    expect(hasMatchingRedirect(sampleConfig, 'missing-scheme://')).toBe(false);
+  });
+
+  it('refuses production secret keys without --allow-prod', () => {
+    expect(() => assertTestOrAllowedInstance('sk_live_secret', false)).toThrow(
+      'SAFETY: Refusing to target production'
+    );
+    expect(() =>
+      assertTestOrAllowedInstance('sk_test_secret', false)
+    ).not.toThrow();
+    expect(() =>
+      assertTestOrAllowedInstance('sk_live_secret', true)
+    ).not.toThrow();
+  });
+
+  it('refuses prod/staging patch targets without --allow-prod', () => {
+    expect(() =>
+      assertPatchTargetAllowed(getDopplerForInstance('staging'), false)
+    ).toThrow('SAFETY: Refusing to patch the production Clerk app');
+    expect(() =>
+      assertPatchTargetAllowed(getDopplerForInstance('prod'), false)
+    ).toThrow('SAFETY: Refusing to patch the production Clerk app');
+    expect(() =>
+      assertPatchTargetAllowed(getDopplerForInstance('dev'), false)
+    ).not.toThrow();
+    expect(() =>
+      assertPatchTargetAllowed(getDopplerForInstance('staging'), true)
+    ).not.toThrow();
+  });
+});

--- a/scripts/clerk-config.ts
+++ b/scripts/clerk-config.ts
@@ -49,6 +49,7 @@
 import { execSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 // --- Types (explicit, no clever golf) ---
 interface ClerkConfigOptions {
@@ -92,7 +93,7 @@ const INSTANCE_TO_DOPPLER: Record<string, DopplerRun> = {
   },
 };
 
-function getDopplerForInstance(instance: string = 'dev'): DopplerRun {
+export function getDopplerForInstance(instance: string = 'dev'): DopplerRun {
   const key = (
     instance || 'dev'
   ).toLowerCase() as keyof typeof INSTANCE_TO_DOPPLER;
@@ -116,7 +117,7 @@ function getClerkCommandPrefix(doppler: DopplerRun): string[] {
 }
 
 // --- Safety guards (explicit, reused patterns) ---
-function assertTestOrAllowedInstance(
+export function assertTestOrAllowedInstance(
   secretKey: string | undefined,
   allowProd: boolean
 ): void {
@@ -134,7 +135,10 @@ function assertTestOrAllowedInstance(
   // staging keys are often pk_live_ but scoped; allow if flag or known
 }
 
-function assertPatchTargetAllowed(doppler: DopplerRun, allowProd: boolean) {
+export function assertPatchTargetAllowed(
+  doppler: DopplerRun,
+  allowProd: boolean
+) {
   if (doppler.clerkInstance === 'prod' && !allowProd) {
     throw new Error(
       'SAFETY: Refusing to patch the production Clerk app without --allow-prod.'
@@ -558,8 +562,13 @@ gh-9805 principles: explicit, complete, small, DRY, action-oriented.
   }
 }
 
-main().catch(err => {
-  console.error('clerk-config error:', err?.message || err);
-  logAudit('error', { message: String(err?.message || err) });
-  process.exit(1);
-});
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch(err => {
+    console.error('clerk-config error:', err?.message || err);
+    logAudit('error', { message: String(err?.message || err) });
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

Completes **JOV-2653** — self-serve Clerk configuration access for auth fixes.

The core `scripts/clerk-config.ts` wrapper landed in #9885; this PR finishes the remaining agent workflow pieces:

- **Unit tests** for `extractAuthRelevantConfigKeys`, `hasMatchingRedirect`, instance mapping, and safety guards
- **Import-safe entry point** so Vitest can import helpers without running CLI `main()`
- **`/clerk-cli` agent skill** (`.claude/skills/clerk-cli/SKILL.md`) — referenced by `auth.md`, `gstack.md`, and `docs/CLERK_CLI.md` but previously missing
- **`auth.md` cross-reference** with quick clerk-config automation examples

## Test plan

- [x] `pnpm exec vitest run tests/unit/scripts/clerk-config-script.test.ts` (7 tests pass)
- [x] `pnpm exec tsx scripts/clerk-config.ts --self-test` (helpers + guards pass)
- [x] Pre-commit + pre-push hooks (biome, eslint, typecheck, lint)

## Usage

```bash
doppler run --project jovie-web --config dev -- \
  pnpm tsx scripts/clerk-config.ts check-redirects --pattern "myapp://|jov.ie"
```

See `docs/CLERK_CLI.md` and invoke `/clerk-cli` for full workflows.

Closes JOV-2653 / gh-9805.