### PR TITLE
fix(chat): soften empty-state logo edges and play spark once (JOV-2892)

### DIFF
--- a/apps/web/components/atoms/JovieMarkElectric.test.tsx
+++ b/apps/web/components/atoms/JovieMarkElectric.test.tsx
@@ -44,4 +44,14 @@ describe('JovieMarkElectric', () => {
     const paths = container.querySelectorAll('path[stroke-dasharray]');
     expect(paths.length).toBe(0);
   });
+
+  it('plays the electric spark intro animation exactly once', () => {
+    const { container } = render(<JovieMarkElectric />);
+    const sparkPaths = container.querySelectorAll('path[stroke-dasharray]');
+    for (const path of sparkPaths) {
+      expect(path.getAttribute('style')).toContain(
+        'animation-iteration-count: 1'
+      );
+    }
+  });
 });

--- a/apps/web/components/atoms/JovieMarkElectric.tsx
+++ b/apps/web/components/atoms/JovieMarkElectric.tsx
@@ -95,7 +95,7 @@ export function JovieMarkElectric({
                 animationName: sparkAnimationName,
                 animationDuration: sparkDuration,
                 animationTimingFunction: 'var(--ds-motion-subtle-easing)',
-                animationIterationCount: 2,
+                animationIterationCount: 1,
                 animationFillMode: 'both',
                 animationDelay: sparkDelay,
               }}
@@ -112,7 +112,7 @@ export function JovieMarkElectric({
                 animationName: sparkAnimationName,
                 animationDuration: sparkDuration,
                 animationTimingFunction: 'var(--ds-motion-subtle-easing)',
-                animationIterationCount: 2,
+                animationIterationCount: 1,
                 animationFillMode: 'both',
                 animationDelay: sparkDelay,
               }}

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.test.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ChatEmptyStateComposerRegion } from './ChatEmptyStateComposerRegion';
+
+describe('ChatEmptyStateComposerRegion', () => {
+  it('softens the background logo with a radial edge fade', () => {
+    render(
+      <ChatEmptyStateComposerRegion>
+        <div data-testid='composer-child' />
+      </ChatEmptyStateComposerRegion>
+    );
+
+    const logo = screen.getByTestId('chat-empty-state-logo');
+    const mask = logo.style.maskImage;
+
+    expect(mask).toContain('radial-gradient');
+    expect(mask).toContain('transparent 86%');
+    expect(logo.className).toContain('opacity-70');
+  });
+});

--- a/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
+++ b/apps/web/components/jovie/components/ChatEmptyStateComposerRegion.tsx
@@ -16,12 +16,12 @@ export function ChatEmptyStateComposerRegion({
       data-testid='chat-empty-state-composer-region'
     >
       <div
-        className='pointer-events-none absolute left-1/2 top-1/2 h-[min(46vw,28rem)] w-[min(46vw,28rem)] -translate-x-1/2 -translate-y-[60%] opacity-85 drop-shadow-[0_0_34px_rgba(68,188,255,0.18)] max-sm:h-[min(72vw,18rem)] max-sm:w-[min(72vw,18rem)]'
+        className='pointer-events-none absolute left-1/2 top-1/2 h-[min(46vw,28rem)] w-[min(46vw,28rem)] -translate-x-1/2 -translate-y-[60%] opacity-70 drop-shadow-[0_0_34px_rgba(68,188,255,0.14)] max-sm:h-[min(72vw,18rem)] max-sm:w-[min(72vw,18rem)]'
         style={{
           maskImage:
-            'radial-gradient(ellipse at center, black 54%, rgba(0,0,0,0.72) 68%, transparent 88%)',
+            'radial-gradient(ellipse at center, black 38%, rgba(0,0,0,0.55) 56%, rgba(0,0,0,0.2) 72%, transparent 86%)',
           WebkitMaskImage:
-            'radial-gradient(ellipse at center, black 54%, rgba(0,0,0,0.72) 68%, transparent 88%)',
+            'radial-gradient(ellipse at center, black 38%, rgba(0,0,0,0.55) 56%, rgba(0,0,0,0.2) 72%, transparent 86%)',
         }}
         data-testid='chat-empty-state-logo'
       >

--- a/docs/marcdoc/engineering-backlog.md
+++ b/docs/marcdoc/engineering-backlog.md
@@ -341,5 +341,5 @@ description: Engineering backlog (MarcDoc-style)
 - **Acceptance criteria**:
   - Logo edges fade softly behind the focus ring.
   - Electric spark intro plays once per mount.
-- **PR**: (opening)
+- **PR**: https://github.com/JovieInc/Jovie/pull/10373
 - **Date**: 2026-06-09

--- a/docs/marcdoc/engineering-backlog.md
+++ b/docs/marcdoc/engineering-backlog.md
@@ -333,3 +333,13 @@ description: Engineering backlog (MarcDoc-style)
 - **Acceptance criteria**:
   - Request ID propagated.
   - Errors include key context without PII.
+
+## ENG-033 — New chat empty-state logo polish (edge fade + single spark intro)
+- **Status**: `P1-Doing`
+- **Why it matters**: Most-seen chat surface; hard logo edges and double animation felt unfinished.
+- **Where**: `ChatEmptyStateComposerRegion.tsx`, `JovieMarkElectric.tsx`.
+- **Acceptance criteria**:
+  - Logo edges fade softly behind the focus ring.
+  - Electric spark intro plays once per mount.
+- **PR**: (opening)
+- **Date**: 2026-06-09


### PR DESCRIPTION
Closes JOV-2892

linear-issue-id: JOV-2892

## Summary
- Strengthen the radial mask on the new-chat empty-state logo so edges fade softly behind the focus ring
- Reduce `JovieMarkElectric` spark `animationIterationCount` from 2 → 1 so the electric intro plays once per mount

## Validation
- [x] `pnpm vitest --run` on `JovieMarkElectric.test.tsx` + `ChatEmptyStateComposerRegion.test.tsx`
- [x] Typecheck + lint via pre-commit hooks

## Backlog
- Updated `docs/marcdoc/engineering-backlog.md` → ENG-033 `P1-Doing`