### PR TITLE
fix(onboarding): hide Turnstile chrome until verification is required (JOV-2925)

### DIFF
--- a/apps/web/components/features/onboarding/OnboardingChat.tsx
+++ b/apps/web/components/features/onboarding/OnboardingChat.tsx
@@ -75,6 +75,8 @@ interface OnboardingChatProps {
   readonly turnstileStatus?: OnboardingTurnstileStatus;
   /** Visible Turnstile challenge panel rendered near the composer. */
   readonly turnstilePanel?: ReactNode;
+  /** Whether the Turnstile security chrome should appear in the composer. */
+  readonly turnstilePanelVisible?: boolean;
   /** Requests the visible Turnstile panel when a send needs verification. */
   readonly onTurnstileRequired?: (message?: string) => void;
   /** Clears stale verification after the server rejects a token. */
@@ -736,6 +738,7 @@ export function OnboardingChat({
   onTurnstileRequired,
   starterPrompt,
   turnstilePanel,
+  turnstilePanelVisible = false,
   turnstileStatus,
   turnstileToken,
 }: OnboardingChatProps) {
@@ -979,7 +982,7 @@ export function OnboardingChat({
   }, [messages, onConversationActivity, status]);
 
   const shouldShowTurnstileBanner =
-    Boolean(turnstilePanel) && isAwaitingFirstToken;
+    Boolean(turnstilePanel) && turnstilePanelVisible && isAwaitingFirstToken;
   const hasComposerStatusBanner =
     shouldShowTurnstileBanner || chatError !== null;
   const composerStatusBanner = hasComposerStatusBanner ? (

--- a/apps/web/components/features/onboarding/OnboardingShell.tsx
+++ b/apps/web/components/features/onboarding/OnboardingShell.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { AppShellFrame } from '@/components/organisms/AppShellFrame';
 import { SidebarProvider } from '@/components/organisms/Sidebar';
 import { track } from '@/lib/analytics';
+import { publicEnv } from '@/lib/env-public';
 import { ONBOARDING_FUNNEL_EVENTS } from '@/lib/onboarding/funnel-events';
 import { cn } from '@/lib/utils';
 import { OnboardingChat } from './OnboardingChat';
@@ -14,6 +15,7 @@ import {
   OnboardingProfileRail,
 } from './OnboardingProfileRail';
 import {
+  isOnboardingTurnstilePanelVisible,
   OnboardingTurnstile,
   type OnboardingTurnstileState,
 } from './OnboardingTurnstile';
@@ -110,6 +112,11 @@ export function OnboardingShell({
       resetSignal={turnstileResetSignal}
     />
   );
+  const turnstilePanelVisible = isOnboardingTurnstilePanelVisible(
+    turnstileState,
+    turnstileInstruction,
+    publicEnv.NEXT_PUBLIC_TURNSTILE_SITE_KEY
+  );
 
   const isTurnstileUnavailable =
     turnstileState.status === 'error' ||
@@ -159,6 +166,7 @@ export function OnboardingShell({
               turnstileToken={turnstileToken}
               turnstileStatus={turnstileState.status}
               turnstilePanel={turnstilePanel}
+              turnstilePanelVisible={turnstilePanelVisible}
               onTurnstileRequired={handleTurnstileRequired}
               onTurnstileRejected={handleTurnstileRejected}
             />

--- a/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
+++ b/apps/web/components/features/onboarding/OnboardingTurnstile.tsx
@@ -114,6 +114,22 @@ function getHeading(status: OnboardingTurnstileStatus) {
   return 'Security Check';
 }
 
+export function isOnboardingTurnstilePanelVisible(
+  state: OnboardingTurnstileState,
+  instruction?: string | null,
+  siteKey?: string | null
+): boolean {
+  if (instruction) return true;
+  if (!siteKey) return true;
+  return (
+    state.status === 'interactive' ||
+    state.status === 'error' ||
+    state.status === 'expired' ||
+    state.status === 'timeout' ||
+    state.status === 'unsupported'
+  );
+}
+
 export function OnboardingTurnstile({
   onToken,
   onStateChange,
@@ -273,15 +289,19 @@ export function OnboardingTurnstile({
     state.status === 'error' ||
     state.status === 'expired' ||
     state.status === 'timeout';
-  const shouldShowPanel =
-    !siteKey ||
-    state.status === 'loading' ||
-    state.status === 'interactive' ||
-    state.status === 'error' ||
-    state.status === 'expired' ||
-    state.status === 'timeout' ||
-    state.status === 'unsupported' ||
-    Boolean(instruction);
+  const shouldShowPanel = isOnboardingTurnstilePanelVisible(
+    state,
+    instruction,
+    siteKey
+  );
+  const shouldShowWidgetFrame =
+    shouldShowPanel &&
+    siteKey &&
+    (state.status === 'interactive' ||
+      state.status === 'error' ||
+      state.status === 'expired' ||
+      state.status === 'timeout' ||
+      Boolean(instruction));
 
   return (
     <>
@@ -292,53 +312,60 @@ export function OnboardingTurnstile({
           onLoad={() => render()}
         />
       ) : null}
-      <section
-        ref={panelRef}
-        aria-labelledby={headingId}
-        tabIndex={-1}
-        hidden={!shouldShowPanel}
-        data-testid='onboarding-turnstile-panel'
-        data-turnstile-status={state.status}
-        className={cn(
-          'px-3 py-2.5 text-primary-token outline-none sm:px-3.5 sm:py-3',
-          'focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20'
-        )}
-      >
-        <div className='flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between'>
-          <div className='min-w-0'>
-            <p
-              id={headingId}
-              className='text-app font-medium leading-5 text-primary-token'
-            >
-              {getHeading(state.status)}
-            </p>
-            <p className='mt-0.5 max-w-[34rem] text-2xs leading-5 text-secondary-token sm:text-[12px]'>
-              {panelCopy}
-            </p>
+      {shouldShowPanel ? (
+        <section
+          ref={panelRef}
+          aria-labelledby={headingId}
+          tabIndex={-1}
+          data-testid='onboarding-turnstile-panel'
+          data-turnstile-status={state.status}
+          className={cn(
+            'px-3 py-2.5 text-primary-token outline-none sm:px-3.5 sm:py-3',
+            'focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20'
+          )}
+        >
+          <div className='flex flex-col gap-2.5 sm:flex-row sm:items-start sm:justify-between'>
+            <div className='min-w-0'>
+              <p
+                id={headingId}
+                className='text-app font-medium leading-5 text-primary-token'
+              >
+                {getHeading(state.status)}
+              </p>
+              <p className='mt-0.5 max-w-[34rem] text-2xs leading-5 text-secondary-token sm:text-[12px]'>
+                {panelCopy}
+              </p>
+            </div>
+            {isActionable ? (
+              <button
+                type='button'
+                onClick={() => resetWidget()}
+                className='h-7 shrink-0 rounded-full border border-subtle px-2.5 text-2xs font-medium text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20'
+              >
+                Retry Verification
+              </button>
+            ) : null}
           </div>
-          {isActionable ? (
-            <button
-              type='button'
-              onClick={() => resetWidget()}
-              className='h-7 shrink-0 rounded-full border border-subtle px-2.5 text-2xs font-medium text-secondary-token transition-[background-color,border-color,color] duration-subtle hover:bg-surface-0 hover:text-primary-token focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/20'
-            >
-              Retry Verification
-            </button>
-          ) : null}
-        </div>
-        {siteKey ? (
+        </section>
+      ) : null}
+      {siteKey ? (
+        <div
+          className={cn(
+            shouldShowWidgetFrame
+              ? 'mt-2.5 overflow-hidden rounded-[10px] border border-subtle bg-surface-0'
+              : 'sr-only h-0 overflow-hidden',
+            !shouldShowPanel && 'sr-only h-0 overflow-hidden'
+          )}
+          data-testid='onboarding-turnstile-widget-frame'
+          aria-hidden={!shouldShowWidgetFrame ? 'true' : undefined}
+        >
           <div
-            className='mt-2.5 overflow-hidden rounded-[10px] border border-subtle bg-surface-0'
-            data-testid='onboarding-turnstile-widget-frame'
-          >
-            <div
-              ref={containerRef}
-              id={`cf-turnstile-${widgetDomId}`}
-              className='min-h-[64px]'
-            />
-          </div>
-        ) : null}
-      </section>
+            ref={containerRef}
+            id={`cf-turnstile-${widgetDomId}`}
+            className='min-h-[64px]'
+          />
+        </div>
+      ) : null}
     </>
   );
 }

--- a/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingChat.turnstile.test.tsx
@@ -174,6 +174,7 @@ function TurnstileHarness({
           <div data-testid='test-turnstile-panel'>{instruction}</div>
         ) : null
       }
+      turnstilePanelVisible={Boolean(instruction)}
       onTurnstileRequired={message => {
         onTurnstileRequired(message);
         setInstruction(message ?? null);

--- a/apps/web/tests/unit/onboarding/OnboardingTurnstile.test.tsx
+++ b/apps/web/tests/unit/onboarding/OnboardingTurnstile.test.tsx
@@ -83,7 +83,37 @@ describe('OnboardingTurnstile', () => {
     expect(onStateChange).toHaveBeenCalledWith(
       expect.objectContaining({ status: 'verified' })
     );
-    expect(screen.getByTestId('onboarding-turnstile-panel')).not.toBeVisible();
+    expect(
+      screen.queryByTestId('onboarding-turnstile-panel')
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the security chrome hidden while Turnstile is still loading', async () => {
+    vi.stubEnv('NODE_ENV', 'test');
+    vi.stubEnv('NEXT_PUBLIC_TURNSTILE_SITE_KEY', 'site-key');
+    const onToken = vi.fn();
+    const onStateChange = vi.fn();
+    const renderMock = vi.fn(
+      (_target: HTMLElement, _options: TurnstileOptions) => 'widget-1'
+    );
+    window.turnstile = {
+      render: renderMock,
+      reset: vi.fn(),
+      remove: vi.fn(),
+    };
+
+    render(
+      <OnboardingTurnstile onToken={onToken} onStateChange={onStateChange} />
+    );
+
+    await waitFor(() => expect(renderMock).toHaveBeenCalled());
+    expect(
+      screen.queryByTestId('onboarding-turnstile-panel')
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('onboarding-turnstile-widget-frame')).toHaveClass(
+      'sr-only'
+    );
+    expect(screen.queryByText('Security Check')).not.toBeInTheDocument();
   });
 
   it('bypasses verification in runtime E2E mode', async () => {

--- a/docs/marcdoc/engineering-backlog.md
+++ b/docs/marcdoc/engineering-backlog.md
@@ -343,3 +343,14 @@ description: Engineering backlog (MarcDoc-style)
   - Electric spark intro plays once per mount.
 - **PR**: https://github.com/JovieInc/Jovie/pull/10373
 - **Date**: 2026-06-09
+
+## ENG-034 — /start onboarding: hide Turnstile chrome until verification is required (JOV-2925)
+- **Status**: `P1-Doing`
+- **Why it matters**: The first-message composer showed redundant "Security Check" chrome while Turnstile was still loading silently, cluttering top-of-funnel onboarding.
+- **Where**: `apps/web/components/features/onboarding/OnboardingTurnstile.tsx`, `OnboardingShell.tsx`, `OnboardingChat.tsx`
+- **Acceptance criteria**:
+  - Turnstile widget can load silently without showing heading/copy/frame.
+  - Security panel appears only for interactive, error, or explicit verification states.
+  - Composer status banner omits Turnstile slot until the panel is actually visible.
+- **PR**: https://github.com/JovieInc/Jovie/pull/10376
+- **Date**: 2026-06-08


### PR DESCRIPTION
## Summary
- Hide the /start Turnstile "Security Check" panel while Cloudflare is still loading silently (`interaction-only` path).
- Show security chrome only when verification is interactive, failed, or explicitly requested by the composer.
- Keep the widget mounted off-screen so silent verification can still complete without cluttering first-message onboarding.

## Linear
JOV-2925

## Backlog
- ENG-033 → P1-Doing

## Test plan
- [x] `pnpm run typecheck:web:fast`
- [x] `vitest run tests/unit/onboarding/OnboardingTurnstile.test.tsx`
- [x] `vitest run tests/unit/onboarding/OnboardingChat.turnstile.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Turnstile security panel and widget now remain hidden until verification is required, reducing visual clutter during onboarding.
  * Onboarding chat negotiates whether the Turnstile banner is shown so the composer omits the slot unless active.

* **Tests**
  * Updated unit tests to reflect visible/removal behavior of the Turnstile panel and hidden widget frame while loading.

* **Documentation**
  * Added backlog entry describing acceptance criteria for Turnstile visibility during /start onboarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->