### PR TITLE
feat(visual-qa): build screenshot capture pipeline (JOV-1943)

### DIFF
--- a/agentos/runs/README.md
+++ b/agentos/runs/README.md
@@ -7,5 +7,6 @@ Run directories follow the naming convention: `<run-type>/<YYYY-MM-DD>/<run-id>/
 Examples:
 - `design-review/2026-05-08/abc123/`
 - `qa/2026-05-08/def456/`
+- `visual-qa/<run_id>/<surface>/{baseline,after}.png` (proposal-validation captures; see `apps/web/lib/visual-qa/registry.ts`)
 
 Binary artifact files (images, zips, built assets) are gitignored via `agentos/runs/**/artifacts/`. Only run metadata files (JSON summaries, markdown reports) are committed.

--- a/apps/web/lib/agent-os/visual-qa/manifest.ts
+++ b/apps/web/lib/agent-os/visual-qa/manifest.ts
@@ -1,0 +1,137 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import {
+  resolveVisualQaManifestPath,
+  resolveVisualQaRunDirectory,
+  toVisualQaRelativePath,
+} from '@/lib/agent-os/visual-qa/paths';
+import { getVisualQaSurface } from '@/lib/visual-qa/registry';
+import {
+  isVisualQaRunManifest,
+  type VisualQaPhase,
+  type VisualQaRunManifest,
+  type VisualQaSurfaceCaptureRecord,
+} from '@/lib/visual-qa/types';
+import { VISUAL_QA_VIEWPORTS } from '@/lib/visual-qa/viewports';
+
+interface RecordVisualQaCaptureInput {
+  readonly runId: string;
+  readonly surfaceId: string;
+  readonly phase: VisualQaPhase;
+  readonly screenshotPath: string;
+  readonly gitSha?: string | null;
+}
+
+async function readManifest(
+  runId: string
+): Promise<VisualQaRunManifest | null> {
+  const manifestPath = resolveVisualQaManifestPath(runId);
+
+  try {
+    const raw = await readFile(manifestPath, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!isVisualQaRunManifest(parsed) || parsed.runId !== runId) {
+      return null;
+    }
+
+    return parsed;
+  } catch (error) {
+    if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+function createSurfaceRecord(surfaceId: string): VisualQaSurfaceCaptureRecord {
+  const surface = getVisualQaSurface(surfaceId);
+  if (!surface) {
+    throw new Error(`Unknown Visual QA surface: ${surfaceId}`);
+  }
+
+  const viewport = VISUAL_QA_VIEWPORTS[surface.baseline.viewport];
+
+  return {
+    surfaceId: surface.id,
+    title: surface.title,
+    baselinePath: `${surface.id}/baseline.png`,
+    afterPath: `${surface.id}/after.png`,
+    baselineCapturedAt: null,
+    afterCapturedAt: null,
+    viewport,
+  };
+}
+
+function upsertSurfaceRecord(
+  manifest: VisualQaRunManifest,
+  surfaceId: string
+): VisualQaSurfaceCaptureRecord {
+  const existing = manifest.surfaces.find(
+    surface => surface.surfaceId === surfaceId
+  );
+  return existing ?? createSurfaceRecord(surfaceId);
+}
+
+export async function recordVisualQaCapture(
+  input: RecordVisualQaCaptureInput
+): Promise<VisualQaRunManifest> {
+  const capturedAt = new Date().toISOString();
+  const runDirectory = resolveVisualQaRunDirectory(input.runId);
+  await mkdir(runDirectory, { recursive: true });
+
+  const relativeScreenshotPath = toVisualQaRelativePath(input.screenshotPath);
+  const existingManifest = await readManifest(input.runId);
+  const gitSha = input.gitSha ?? existingManifest?.gitSha ?? null;
+
+  const nextSurfaceRecord = upsertSurfaceRecord(
+    existingManifest ?? {
+      runId: input.runId,
+      createdAt: capturedAt,
+      updatedAt: capturedAt,
+      gitSha,
+      surfaces: [],
+    },
+    input.surfaceId
+  );
+
+  const updatedSurfaceRecord: VisualQaSurfaceCaptureRecord = {
+    ...nextSurfaceRecord,
+    baselineCapturedAt:
+      input.phase === 'baseline'
+        ? capturedAt
+        : nextSurfaceRecord.baselineCapturedAt,
+    afterCapturedAt:
+      input.phase === 'after' ? capturedAt : nextSurfaceRecord.afterCapturedAt,
+    baselinePath:
+      input.phase === 'baseline'
+        ? relativeScreenshotPath
+        : nextSurfaceRecord.baselinePath,
+    afterPath:
+      input.phase === 'after'
+        ? relativeScreenshotPath
+        : nextSurfaceRecord.afterPath,
+  };
+
+  const remainingSurfaces =
+    existingManifest?.surfaces.filter(
+      surface => surface.surfaceId !== input.surfaceId
+    ) ?? [];
+
+  const nextManifest: VisualQaRunManifest = {
+    runId: input.runId,
+    createdAt: existingManifest?.createdAt ?? capturedAt,
+    updatedAt: capturedAt,
+    gitSha,
+    surfaces: [...remainingSurfaces, updatedSurfaceRecord].sort((left, right) =>
+      left.surfaceId.localeCompare(right.surfaceId)
+    ),
+  };
+
+  await writeFile(
+    resolveVisualQaManifestPath(input.runId),
+    `${JSON.stringify(nextManifest, null, 2)}\n`,
+    'utf8'
+  );
+
+  return nextManifest;
+}

--- a/apps/web/lib/agent-os/visual-qa/paths.ts
+++ b/apps/web/lib/agent-os/visual-qa/paths.ts
@@ -1,0 +1,85 @@
+import path from 'node:path';
+import { resolveMonorepoPath } from '@/lib/filesystem-paths';
+import { validatePathTraversal } from '@/lib/security/path-traversal';
+import type { VisualQaPhase } from '@/lib/visual-qa/types';
+
+export const VISUAL_QA_ROOT_SEGMENTS = [
+  'agentos',
+  'runs',
+  'visual-qa',
+] as const;
+
+const RUN_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,79}$/i;
+const SURFACE_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,79}$/i;
+
+export function getVisualQaRootDirectory(): string {
+  return resolveMonorepoPath(...VISUAL_QA_ROOT_SEGMENTS);
+}
+
+export function assertValidVisualQaRunId(runId: string): string {
+  const safeRunId = runId.trim();
+  if (!RUN_ID_PATTERN.test(safeRunId)) {
+    throw new Error(`Invalid Visual QA run id: ${runId}`);
+  }
+
+  return safeRunId;
+}
+
+export function assertValidVisualQaSurfaceId(surfaceId: string): string {
+  const safeSurfaceId = surfaceId.trim();
+  if (!SURFACE_ID_PATTERN.test(safeSurfaceId)) {
+    throw new Error(`Invalid Visual QA surface id: ${surfaceId}`);
+  }
+
+  return safeSurfaceId;
+}
+
+export function resolveVisualQaRunDirectory(runId: string): string {
+  const safeRunId = assertValidVisualQaRunId(runId);
+  return validatePathTraversal(safeRunId, getVisualQaRootDirectory());
+}
+
+export function resolveVisualQaSurfaceDirectory(
+  runId: string,
+  surfaceId: string
+): string {
+  const safeRunId = assertValidVisualQaRunId(runId);
+  const safeSurfaceId = assertValidVisualQaSurfaceId(surfaceId);
+  return validatePathTraversal(
+    path.join(safeRunId, safeSurfaceId),
+    getVisualQaRootDirectory()
+  );
+}
+
+export function resolveVisualQaPhaseScreenshotPath(
+  runId: string,
+  surfaceId: string,
+  phase: VisualQaPhase
+): string {
+  const safeRunId = assertValidVisualQaRunId(runId);
+  const safeSurfaceId = assertValidVisualQaSurfaceId(surfaceId);
+  return validatePathTraversal(
+    path.join(safeRunId, safeSurfaceId, `${phase}.png`),
+    getVisualQaRootDirectory()
+  );
+}
+
+export function resolveVisualQaManifestPath(runId: string): string {
+  const safeRunId = assertValidVisualQaRunId(runId);
+  return validatePathTraversal(
+    path.join(safeRunId, 'manifest.json'),
+    getVisualQaRootDirectory()
+  );
+}
+
+export function toVisualQaRelativePath(absolutePath: string): string {
+  const root = getVisualQaRootDirectory();
+  const resolvedRoot = path.resolve(root);
+  const resolvedPath = path.resolve(absolutePath);
+
+  if (!resolvedPath.startsWith(resolvedRoot + path.sep)) {
+    throw new Error(`Visual QA path is outside run root: ${absolutePath}`);
+  }
+
+  return path.relative(resolvedRoot, resolvedPath);
+}

--- a/apps/web/lib/visual-qa/capture-request.ts
+++ b/apps/web/lib/visual-qa/capture-request.ts
@@ -1,0 +1,57 @@
+import { VISUAL_QA_PHASES, type VisualQaPhase } from '@/lib/visual-qa/types';
+
+export type VisualQaCapturePhaseRequest = VisualQaPhase | 'both';
+
+export interface VisualQaCaptureRequest {
+  readonly runId: string;
+  readonly phases: readonly VisualQaPhase[];
+  readonly surfaceIds: readonly string[];
+}
+
+const RUN_ID_PATTERN = /^[a-z0-9][a-z0-9._-]{0,79}$/i;
+
+function parsePhaseToken(value: string): VisualQaCapturePhaseRequest {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'both') {
+    return 'both';
+  }
+
+  if ((VISUAL_QA_PHASES as readonly string[]).includes(normalized)) {
+    return normalized as VisualQaPhase;
+  }
+
+  throw new Error(
+    `Invalid Visual QA phase "${value}". Expected baseline, after, or both.`
+  );
+}
+
+export function resolveVisualQaCapturePhases(
+  phase: VisualQaCapturePhaseRequest
+): readonly VisualQaPhase[] {
+  return phase === 'both' ? [...VISUAL_QA_PHASES] : [phase];
+}
+
+export function parseVisualQaCaptureRequest(input: {
+  readonly runId?: string | null;
+  readonly phase?: string | null;
+  readonly surfaces?: string | null;
+}): VisualQaCaptureRequest {
+  const runId = input.runId?.trim() ?? '';
+  if (!RUN_ID_PATTERN.test(runId)) {
+    throw new Error(
+      'Visual QA capture requires a run id matching /^[a-z0-9][a-z0-9._-]{0,79}$/i.'
+    );
+  }
+
+  const phase = parsePhaseToken(input.phase ?? 'both');
+  const surfaceIds = (input.surfaces ?? '')
+    .split(',')
+    .map(surfaceId => surfaceId.trim())
+    .filter(surfaceId => surfaceId.length > 0);
+
+  return {
+    runId,
+    phases: resolveVisualQaCapturePhases(phase),
+    surfaceIds,
+  };
+}

--- a/apps/web/lib/visual-qa/registry.ts
+++ b/apps/web/lib/visual-qa/registry.ts
@@ -1,0 +1,144 @@
+import { APP_FLAG_OVERRIDE_KEYS } from '@/lib/flags/contracts';
+import type {
+  VisualQaCaptureConfig,
+  VisualQaSurface,
+} from '@/lib/visual-qa/types';
+
+const DESIGN_V1_OVERRIDES = {
+  [APP_FLAG_OVERRIDE_KEYS.DESIGN_V1]: true,
+} as const satisfies Readonly<Record<string, boolean>>;
+
+interface VisualQaSurfaceSeed
+  extends Omit<VisualQaSurface, 'baseline' | 'after'> {
+  readonly baseline: Omit<VisualQaCaptureConfig, 'flagOverrides'> & {
+    readonly flagOverrides?: Readonly<Record<string, boolean>>;
+  };
+  readonly after?: Partial<VisualQaCaptureConfig>;
+}
+
+function defineSurface(seed: VisualQaSurfaceSeed): VisualQaSurface {
+  const baseline: VisualQaCaptureConfig = {
+    ...seed.baseline,
+    flagOverrides: seed.baseline.flagOverrides ?? DESIGN_V1_OVERRIDES,
+  };
+
+  return {
+    id: seed.id,
+    title: seed.title,
+    description: seed.description,
+    parityLedgerGroup: seed.parityLedgerGroup,
+    canonicalSurfaceId: seed.canonicalSurfaceId,
+    baseline,
+    after: seed.after,
+  };
+}
+
+/**
+ * Declared design surfaces for the Visual QA proposal-validation pipeline.
+ *
+ * Distinct from:
+ * - apps/web/lib/screenshots/registry.ts (marketing/admin catalog)
+ * - docs/JOV-1605-screenshot-parity-ledger.md (manual parity drain)
+ */
+export const VISUAL_QA_SURFACES = [
+  defineSurface({
+    id: 'shell-desktop-idle',
+    title: 'Shell — desktop idle',
+    description:
+      'Global shell chrome at desktop idle for proposal validation against JOV-1605 shell parity rows.',
+    parityLedgerGroup: 'Shell',
+    canonicalSurfaceId: 'dashboard-releases',
+    baseline: {
+      route: '/exp/shell-v1?capture=marketing',
+      waitFor: '.shell-v1',
+      viewport: 'desktop',
+      captureTarget: 'page',
+      fullPage: false,
+      reducedMotion: true,
+    },
+  }),
+  defineSurface({
+    id: 'list-releases-default',
+    title: 'List — releases default density',
+    description:
+      'Authenticated releases list at default density for proposal validation against JOV-1605 list parity rows.',
+    parityLedgerGroup: 'List',
+    canonicalSurfaceId: 'dashboard-releases',
+    baseline: {
+      route: '/exp/shell-v1?view=releases&capture=marketing',
+      waitFor: '[data-testid="releases-matrix"]',
+      viewport: 'desktop',
+      captureTarget: 'page',
+      fullPage: false,
+      reducedMotion: true,
+    },
+  }),
+  defineSurface({
+    id: 'drawer-release-open',
+    title: 'Drawer — release detail open',
+    description:
+      'Right drawer with an open release detail state for proposal validation against JOV-1605 drawer parity rows.',
+    parityLedgerGroup: 'Drawer',
+    canonicalSurfaceId: 'dashboard-releases',
+    baseline: {
+      route:
+        '/exp/shell-v1?view=releases&release=the-deep-end&capture=marketing',
+      waitFor: '[data-testid="shell-v1-release-drawer"]',
+      viewport: 'desktop',
+      captureTarget: 'page',
+      fullPage: false,
+      reducedMotion: true,
+    },
+  }),
+  defineSurface({
+    id: 'settings-root-hierarchy',
+    title: 'Settings — root hierarchy',
+    description:
+      'Settings root hierarchy and control rhythm for proposal validation against JOV-1605 settings parity rows.',
+    parityLedgerGroup: 'Settings',
+    canonicalSurfaceId: 'settings-artist-profile',
+    baseline: {
+      route: '/demo/showcase/settings?capture=quality',
+      waitFor: '[data-testid="demo-settings-audience-quality-capture"]',
+      viewport: 'desktop',
+      captureTarget: 'page',
+      fullPage: false,
+      reducedMotion: true,
+    },
+  }),
+] as const satisfies readonly VisualQaSurface[];
+
+export type VisualQaSurfaceId = (typeof VISUAL_QA_SURFACES)[number]['id'];
+
+export function getVisualQaSurface(id: string): VisualQaSurface | undefined {
+  return VISUAL_QA_SURFACES.find(surface => surface.id === id);
+}
+
+export function listVisualQaSurfaces(
+  surfaceIds?: readonly string[]
+): readonly VisualQaSurface[] {
+  if (!surfaceIds || surfaceIds.length === 0) {
+    return VISUAL_QA_SURFACES;
+  }
+
+  const allowed = new Set(surfaceIds);
+  return VISUAL_QA_SURFACES.filter(surface => allowed.has(surface.id));
+}
+
+export function resolveVisualQaCaptureConfig(
+  surface: VisualQaSurface,
+  phase: 'baseline' | 'after'
+): VisualQaCaptureConfig {
+  if (phase === 'baseline') {
+    return surface.baseline;
+  }
+
+  return {
+    ...surface.baseline,
+    ...surface.after,
+    flagOverrides: {
+      ...surface.baseline.flagOverrides,
+      ...surface.after?.flagOverrides,
+    },
+  };
+}

--- a/apps/web/lib/visual-qa/types.ts
+++ b/apps/web/lib/visual-qa/types.ts
@@ -1,0 +1,89 @@
+import type { CanonicalSurfaceId } from '@/lib/canonical-surfaces';
+
+export const VISUAL_QA_PHASES = ['baseline', 'after'] as const;
+
+export type VisualQaPhase = (typeof VISUAL_QA_PHASES)[number];
+
+export type VisualQaViewport = 'desktop' | 'mobile';
+
+export type VisualQaCaptureTarget = 'page' | 'locator';
+
+export interface VisualQaCaptureConfig {
+  readonly route: string;
+  readonly waitFor: string;
+  readonly viewport: VisualQaViewport;
+  readonly captureTarget?: VisualQaCaptureTarget;
+  readonly captureSelector?: string;
+  readonly fullPage?: boolean;
+  readonly flagOverrides?: Readonly<Record<string, boolean>>;
+  readonly fixedNow?: string;
+  readonly reducedMotion?: boolean;
+}
+
+export interface VisualQaSurface {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string;
+  readonly parityLedgerGroup?: string;
+  readonly canonicalSurfaceId?: CanonicalSurfaceId;
+  readonly baseline: VisualQaCaptureConfig;
+  readonly after?: Partial<VisualQaCaptureConfig>;
+}
+
+export interface VisualQaViewportSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface VisualQaSurfaceCaptureRecord {
+  readonly surfaceId: string;
+  readonly title: string;
+  readonly baselinePath: string;
+  readonly afterPath: string;
+  readonly baselineCapturedAt: string | null;
+  readonly afterCapturedAt: string | null;
+  readonly viewport: VisualQaViewportSize;
+}
+
+export interface VisualQaRunManifest {
+  readonly runId: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly gitSha: string | null;
+  readonly surfaces: readonly VisualQaSurfaceCaptureRecord[];
+}
+
+export function isVisualQaRunManifest(
+  value: unknown
+): value is VisualQaRunManifest {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const manifest = value as Partial<VisualQaRunManifest>;
+  return (
+    typeof manifest.runId === 'string' &&
+    typeof manifest.createdAt === 'string' &&
+    typeof manifest.updatedAt === 'string' &&
+    (typeof manifest.gitSha === 'string' || manifest.gitSha === null) &&
+    Array.isArray(manifest.surfaces) &&
+    manifest.surfaces.every(surface => {
+      if (!surface || typeof surface !== 'object') {
+        return false;
+      }
+
+      return (
+        typeof surface.surfaceId === 'string' &&
+        typeof surface.title === 'string' &&
+        typeof surface.baselinePath === 'string' &&
+        typeof surface.afterPath === 'string' &&
+        (typeof surface.baselineCapturedAt === 'string' ||
+          surface.baselineCapturedAt === null) &&
+        (typeof surface.afterCapturedAt === 'string' ||
+          surface.afterCapturedAt === null) &&
+        typeof surface.viewport?.width === 'number' &&
+        typeof surface.viewport?.height === 'number'
+      );
+    })
+  );
+}

--- a/apps/web/lib/visual-qa/viewports.ts
+++ b/apps/web/lib/visual-qa/viewports.ts
@@ -1,0 +1,12 @@
+import type {
+  VisualQaViewport,
+  VisualQaViewportSize,
+} from '@/lib/visual-qa/types';
+
+export const VISUAL_QA_VIEWPORTS: Record<
+  VisualQaViewport,
+  VisualQaViewportSize
+> = {
+  desktop: { width: 1440, height: 900 },
+  mobile: { width: 390, height: 844 },
+} as const;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -94,6 +94,8 @@
     "screenshots": "pnpm run screenshots:seed && pnpm run screenshots:capture",
     "screenshots:capture": "playwright test --config=playwright.config.screenshots.ts",
     "screenshots:seed": "tsx tests/product-screenshots/seed.ts",
+    "visual-qa:capture": "playwright test --config=playwright.config.visual-qa.ts",
+    "visual-qa": "pnpm run visual-qa:capture",
     "e2e:full:noauth": "playwright test --config=playwright.config.noauth.ts",
     "e2e:chaos": "playwright test --config=playwright.config.nightly.ts tests/e2e/nightly/chaos-click-testing.spec.ts",
     "e2e:chaos:extended": "CHAOS_EXTENDED=1 playwright test --config=playwright.config.nightly.ts -g 'extended'",

--- a/apps/web/playwright.config.visual-qa.ts
+++ b/apps/web/playwright.config.visual-qa.ts
@@ -1,0 +1,81 @@
+/**
+ * Playwright configuration for the Visual QA capture pipeline.
+ *
+ * Usage:
+ *   VISUAL_QA_RUN_ID=demo-run pnpm --filter web visual-qa:capture
+ *   VISUAL_QA_RUN_ID=demo-run VISUAL_QA_PHASE=baseline pnpm --filter web visual-qa:capture
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+const extraHTTPHeaders: Record<string, string> = {};
+if (process.env.VERCEL_AUTOMATION_BYPASS_SECRET) {
+  extraHTTPHeaders['x-vercel-protection-bypass'] =
+    process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+  extraHTTPHeaders['x-vercel-set-bypass-cookie'] = 'samesitenone';
+}
+
+const webServerCommand = process.env.DATABASE_URL
+  ? 'pnpm run dev:local'
+  : 'doppler run --project jovie-web --config dev -- pnpm run dev:local';
+const baseURL = process.env.BASE_URL || 'http://localhost:3100';
+const managedWebServerUrl = new URL(baseURL);
+if (!managedWebServerUrl.port) {
+  managedWebServerUrl.port = '3100';
+}
+const managedWebServerPort = managedWebServerUrl.port;
+
+export default defineConfig({
+  testDir: './tests/visual-qa',
+  testMatch: '**/capture.spec.ts',
+  fullyParallel: false,
+  forbidOnly: true,
+  retries: 1,
+  workers: 1,
+  reporter: [['line']],
+
+  timeout: 120_000,
+  expect: { timeout: 20_000 },
+
+  use: {
+    baseURL,
+    trace: 'off',
+    video: 'off',
+    navigationTimeout: 90_000,
+    actionTimeout: 30_000,
+    ...(Object.keys(extraHTTPHeaders).length > 0 && { extraHTTPHeaders }),
+  },
+
+  projects: [
+    {
+      name: 'visual-qa',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 900 },
+        deviceScaleFactor: 2,
+        colorScheme: 'dark',
+      },
+    },
+  ],
+
+  ...(process.env.BASE_URL
+    ? {}
+    : {
+        webServer: {
+          command: webServerCommand,
+          env: {
+            ...process.env,
+            NODE_ENV: 'test',
+            PORT: managedWebServerPort,
+            NEXT_DISABLE_TOOLBAR: '1',
+            NEXT_PUBLIC_E2E_MODE: '1',
+            NEXT_PUBLIC_CLERK_PROXY_DISABLED: '1',
+          },
+          url: managedWebServerUrl.origin,
+          reuseExistingServer: process.env.REUSE_EXISTING_SERVER === '1',
+          timeout: 300_000,
+          stdout: 'pipe',
+          stderr: 'pipe',
+        },
+      }),
+});

--- a/apps/web/tests/unit/visual-qa/capture-request.test.ts
+++ b/apps/web/tests/unit/visual-qa/capture-request.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseVisualQaCaptureRequest,
+  resolveVisualQaCapturePhases,
+} from '@/lib/visual-qa/capture-request';
+
+describe('visual-qa capture request', () => {
+  it('defaults to both phases when phase is omitted', () => {
+    const request = parseVisualQaCaptureRequest({
+      runId: 'proposal-001',
+    });
+
+    expect(request.phases).toEqual(['baseline', 'after']);
+    expect(request.surfaceIds).toEqual([]);
+  });
+
+  it('parses explicit phase and surface filters', () => {
+    const request = parseVisualQaCaptureRequest({
+      runId: 'proposal-001',
+      phase: 'baseline',
+      surfaces: 'shell-desktop-idle, drawer-release-open',
+    });
+
+    expect(request.phases).toEqual(['baseline']);
+    expect(request.surfaceIds).toEqual([
+      'shell-desktop-idle',
+      'drawer-release-open',
+    ]);
+  });
+
+  it('rejects invalid run ids and phases', () => {
+    expect(() =>
+      parseVisualQaCaptureRequest({
+        runId: '../bad',
+      })
+    ).toThrow(/run id/i);
+
+    expect(() =>
+      parseVisualQaCaptureRequest({
+        runId: 'valid-run',
+        phase: 'middle',
+      })
+    ).toThrow(/phase/i);
+  });
+
+  it('expands both to baseline and after', () => {
+    expect(resolveVisualQaCapturePhases('both')).toEqual(['baseline', 'after']);
+  });
+});

--- a/apps/web/tests/unit/visual-qa/manifest.test.ts
+++ b/apps/web/tests/unit/visual-qa/manifest.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { isVisualQaRunManifest } from '@/lib/visual-qa/types';
+
+describe('visual-qa manifest', () => {
+  it('accepts a valid run manifest shape', () => {
+    expect(
+      isVisualQaRunManifest({
+        runId: 'proposal-001',
+        createdAt: '2026-06-08T12:00:00.000Z',
+        updatedAt: '2026-06-08T12:05:00.000Z',
+        gitSha: 'abc123',
+        surfaces: [
+          {
+            surfaceId: 'shell-desktop-idle',
+            title: 'Shell — desktop idle',
+            baselinePath: 'proposal-001/shell-desktop-idle/baseline.png',
+            afterPath: 'proposal-001/shell-desktop-idle/after.png',
+            baselineCapturedAt: '2026-06-08T12:00:00.000Z',
+            afterCapturedAt: '2026-06-08T12:05:00.000Z',
+            viewport: { width: 1440, height: 900 },
+          },
+        ],
+      })
+    ).toBe(true);
+  });
+
+  it('rejects malformed manifests', () => {
+    expect(isVisualQaRunManifest(null)).toBe(false);
+    expect(
+      isVisualQaRunManifest({
+        runId: 'proposal-001',
+        createdAt: '2026-06-08T12:00:00.000Z',
+        updatedAt: '2026-06-08T12:05:00.000Z',
+        gitSha: null,
+        surfaces: [],
+      })
+    ).toBe(true);
+    expect(
+      isVisualQaRunManifest({
+        runId: 'proposal-001',
+        surfaces: [{ surfaceId: 'shell-desktop-idle' }],
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/tests/unit/visual-qa/paths.test.ts
+++ b/apps/web/tests/unit/visual-qa/paths.test.ts
@@ -1,0 +1,50 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  getVisualQaRootDirectory,
+  resolveVisualQaManifestPath,
+  resolveVisualQaPhaseScreenshotPath,
+  resolveVisualQaRunDirectory,
+  toVisualQaRelativePath,
+} from '@/lib/agent-os/visual-qa/paths';
+
+describe('visual-qa paths', () => {
+  it('resolves run and phase screenshot paths under agentos/runs/visual-qa', () => {
+    const runDirectory = resolveVisualQaRunDirectory('demo-run');
+    const screenshotPath = resolveVisualQaPhaseScreenshotPath(
+      'demo-run',
+      'shell-desktop-idle',
+      'baseline'
+    );
+    const manifestPath = resolveVisualQaManifestPath('demo-run');
+
+    expect(runDirectory).toContain(
+      path.join('agentos', 'runs', 'visual-qa', 'demo-run')
+    );
+    expect(screenshotPath).toBe(
+      path.join(runDirectory, 'shell-desktop-idle', 'baseline.png')
+    );
+    expect(manifestPath).toBe(path.join(runDirectory, 'manifest.json'));
+  });
+
+  it('rejects traversal attempts in run ids', () => {
+    expect(() => resolveVisualQaRunDirectory('../escape')).toThrow(
+      /Invalid Visual QA run id/
+    );
+  });
+
+  it('converts absolute artifact paths to run-relative paths', () => {
+    const absolutePath = resolveVisualQaPhaseScreenshotPath(
+      'demo-run',
+      'list-releases-default',
+      'after'
+    );
+
+    expect(toVisualQaRelativePath(absolutePath)).toBe(
+      'demo-run/list-releases-default/after.png'
+    );
+    expect(getVisualQaRootDirectory()).toContain(
+      path.join('agentos', 'runs', 'visual-qa')
+    );
+  });
+});

--- a/apps/web/tests/unit/visual-qa/registry.test.ts
+++ b/apps/web/tests/unit/visual-qa/registry.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { APP_FLAG_OVERRIDE_KEYS } from '@/lib/flags/contracts';
+import {
+  getVisualQaSurface,
+  listVisualQaSurfaces,
+  resolveVisualQaCaptureConfig,
+  VISUAL_QA_SURFACES,
+} from '@/lib/visual-qa/registry';
+
+describe('visual-qa registry', () => {
+  it('declares unique surface ids', () => {
+    const ids = VISUAL_QA_SURFACES.map(surface => surface.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('pins design-v1 overrides on every surface baseline', () => {
+    for (const surface of VISUAL_QA_SURFACES) {
+      expect(
+        surface.baseline.flagOverrides?.[APP_FLAG_OVERRIDE_KEYS.DESIGN_V1]
+      ).toBe(true);
+      expect(surface.baseline.route.startsWith('/')).toBe(true);
+      expect(surface.baseline.waitFor.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('filters surfaces by id when requested', () => {
+    const surfaces = listVisualQaSurfaces(['shell-desktop-idle']);
+    expect(surfaces).toHaveLength(1);
+    expect(surfaces[0]?.id).toBe('shell-desktop-idle');
+  });
+
+  it('merges after overrides onto baseline config', () => {
+    const surface = getVisualQaSurface('shell-desktop-idle');
+    expect(surface).toBeDefined();
+
+    const afterConfig = resolveVisualQaCaptureConfig(surface!, 'after');
+    expect(afterConfig.route).toBe(surface!.baseline.route);
+    expect(afterConfig.flagOverrides?.[APP_FLAG_OVERRIDE_KEYS.DESIGN_V1]).toBe(
+      true
+    );
+  });
+});

--- a/apps/web/tests/visual-qa/capture.spec.ts
+++ b/apps/web/tests/visual-qa/capture.spec.ts
@@ -1,0 +1,61 @@
+import { mkdir } from 'node:fs/promises';
+import { test } from '@playwright/test';
+import { recordVisualQaCapture } from '@/lib/agent-os/visual-qa/manifest';
+import {
+  resolveVisualQaPhaseScreenshotPath,
+  resolveVisualQaSurfaceDirectory,
+} from '@/lib/agent-os/visual-qa/paths';
+import { parseVisualQaCaptureRequest } from '@/lib/visual-qa/capture-request';
+import {
+  listVisualQaSurfaces,
+  resolveVisualQaCaptureConfig,
+} from '@/lib/visual-qa/registry';
+import type { VisualQaPhase } from '@/lib/visual-qa/types';
+import { prepareVisualQaCapture, writeVisualQaScreenshot } from './helpers';
+
+const captureRequest = parseVisualQaCaptureRequest({
+  runId: process.env.VISUAL_QA_RUN_ID,
+  phase: process.env.VISUAL_QA_PHASE,
+  surfaces: process.env.VISUAL_QA_SURFACES,
+});
+
+const surfaces = listVisualQaSurfaces(captureRequest.surfaceIds);
+const gitSha = process.env.GITHUB_SHA ?? null;
+
+if (surfaces.length === 0) {
+  throw new Error('No Visual QA surfaces matched the requested capture run.');
+}
+
+test.describe('Visual QA capture pipeline', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  for (const surface of surfaces) {
+    for (const phase of captureRequest.phases) {
+      test(`captures ${surface.id} (${phase})`, async ({ page }) => {
+        test.setTimeout(120_000);
+
+        const config = resolveVisualQaCaptureConfig(surface, phase);
+        const surfaceDirectory = resolveVisualQaSurfaceDirectory(
+          captureRequest.runId,
+          surface.id
+        );
+        const screenshotPath = resolveVisualQaPhaseScreenshotPath(
+          captureRequest.runId,
+          surface.id,
+          phase
+        );
+
+        await mkdir(surfaceDirectory, { recursive: true });
+        await prepareVisualQaCapture(page, config);
+        await writeVisualQaScreenshot(page, config, screenshotPath);
+        await recordVisualQaCapture({
+          runId: captureRequest.runId,
+          surfaceId: surface.id,
+          phase: phase as VisualQaPhase,
+          screenshotPath,
+          gitSha,
+        });
+      });
+    }
+  }
+});

--- a/apps/web/tests/visual-qa/capture.spec.ts
+++ b/apps/web/tests/visual-qa/capture.spec.ts
@@ -13,21 +13,44 @@ import {
 import type { VisualQaPhase } from '@/lib/visual-qa/types';
 import { prepareVisualQaCapture, writeVisualQaScreenshot } from './helpers';
 
-const captureRequest = parseVisualQaCaptureRequest({
-  runId: process.env.VISUAL_QA_RUN_ID,
-  phase: process.env.VISUAL_QA_PHASE,
-  surfaces: process.env.VISUAL_QA_SURFACES,
-});
+function resolveCaptureRun() {
+  if (!process.env.VISUAL_QA_RUN_ID?.trim()) {
+    return null;
+  }
 
-const surfaces = listVisualQaSurfaces(captureRequest.surfaceIds);
-const gitSha = process.env.GITHUB_SHA ?? null;
+  const captureRequest = parseVisualQaCaptureRequest({
+    runId: process.env.VISUAL_QA_RUN_ID,
+    phase: process.env.VISUAL_QA_PHASE,
+    surfaces: process.env.VISUAL_QA_SURFACES,
+  });
+  const surfaces = listVisualQaSurfaces(captureRequest.surfaceIds);
 
-if (surfaces.length === 0) {
-  throw new Error('No Visual QA surfaces matched the requested capture run.');
+  if (surfaces.length === 0) {
+    throw new Error('No Visual QA surfaces matched the requested capture run.');
+  }
+
+  return { captureRequest, surfaces };
 }
 
+const captureRun = resolveCaptureRun();
+const gitSha = process.env.GITHUB_SHA ?? null;
+
 test.describe('Visual QA capture pipeline', () => {
+  test.skip(
+    captureRun === null,
+    'Set VISUAL_QA_RUN_ID to run the Visual QA capture lane.'
+  );
+
   test.describe.configure({ mode: 'serial' });
+
+  const { captureRequest, surfaces } = captureRun ?? {
+    captureRequest: {
+      runId: 'skipped',
+      phases: [],
+      surfaceIds: [],
+    },
+    surfaces: [],
+  };
 
   for (const surface of surfaces) {
     for (const phase of captureRequest.phases) {

--- a/apps/web/tests/visual-qa/helpers.ts
+++ b/apps/web/tests/visual-qa/helpers.ts
@@ -1,0 +1,80 @@
+import { expect, type Page } from '@playwright/test';
+import {
+  APP_FLAG_OVERRIDES_COOKIE,
+  FF_OVERRIDES_KEY,
+} from '@/lib/flags/overrides';
+import type { VisualQaCaptureConfig } from '@/lib/visual-qa/types';
+import { VISUAL_QA_VIEWPORTS } from '@/lib/visual-qa/viewports';
+import {
+  assertNoDevOverlays,
+  hideTransientUI,
+  SCREENSHOT_CLOCK_ISO,
+  TIMEOUTS,
+  waitForImages,
+  waitForSettle,
+} from '../product-screenshots/helpers';
+
+export async function prepareVisualQaCapture(
+  page: Page,
+  config: VisualQaCaptureConfig
+) {
+  const viewport = VISUAL_QA_VIEWPORTS[config.viewport];
+
+  if (!config.route.startsWith('/exp/shell-v1')) {
+    await page.clock.setFixedTime(
+      new Date(config.fixedNow ?? SCREENSHOT_CLOCK_ISO)
+    );
+  }
+
+  await page.emulateMedia({
+    reducedMotion: config.reducedMotion ? 'reduce' : 'no-preference',
+  });
+  await page.setViewportSize(viewport);
+
+  if (config.flagOverrides && Object.keys(config.flagOverrides).length > 0) {
+    const serializedOverrides = JSON.stringify(config.flagOverrides);
+    await page.addInitScript(
+      ({ cookieName, key, value }) => {
+        localStorage.setItem(key, value);
+        document.cookie = `${cookieName}=${encodeURIComponent(value)}; path=/; SameSite=Lax`;
+      },
+      {
+        cookieName: APP_FLAG_OVERRIDES_COOKIE,
+        key: FF_OVERRIDES_KEY,
+        value: serializedOverrides,
+      }
+    );
+  }
+
+  await page.goto(config.route, {
+    waitUntil: 'domcontentloaded',
+    timeout: TIMEOUTS.NAVIGATION,
+  });
+
+  await expect(page.locator(config.waitFor).first()).toBeVisible({
+    timeout: TIMEOUTS.CONTENT_VISIBLE,
+  });
+
+  await waitForImages(page).catch(() => {});
+  await waitForSettle(page);
+  await hideTransientUI(page);
+  await assertNoDevOverlays(page);
+}
+
+export async function writeVisualQaScreenshot(
+  page: Page,
+  config: VisualQaCaptureConfig,
+  outputPath: string
+) {
+  if (config.captureTarget === 'locator' && config.captureSelector) {
+    await page.locator(config.captureSelector).first().screenshot({
+      path: outputPath,
+    });
+    return;
+  }
+
+  await page.screenshot({
+    path: outputPath,
+    fullPage: config.fullPage ?? false,
+  });
+}

--- a/apps/web/vitest.config.ci.mts
+++ b/apps/web/vitest.config.ci.mts
@@ -21,6 +21,7 @@ export default defineConfig({
       'tests/eval/**',
       'tests/performance/**',
       'tests/product-screenshots/**',
+      'tests/visual-qa/**',
       'node_modules/**',
       '.next/**',
     ],

--- a/apps/web/vitest.config.fast.mts
+++ b/apps/web/vitest.config.fast.mts
@@ -82,6 +82,7 @@ export default defineConfig({
       'tests/integration/**',
       'tests/**/*.nightly.test.ts',
       'tests/product-screenshots/**',
+      'tests/visual-qa/**',
       'node_modules/**',
       '.next/**',
       '.stryker-tmp/**',


### PR DESCRIPTION
## Description

Implements the Visual QA screenshot capture pipeline for proposal validation (JOV-1943).

- Adds a declared Visual QA surface registry at `apps/web/lib/visual-qa/registry.ts`
- Adds Playwright capture lane (`pnpm --filter web visual-qa:capture`)
- Writes `baseline` and `after` PNGs per surface under `agentos/runs/visual-qa/<run_id>/<surface>/`
- Records run metadata in `agentos/runs/visual-qa/<run_id>/manifest.json`

This is intentionally separate from the marketing screenshot catalog and the JOV-1605 parity ledger.

## Usage

```bash
VISUAL_QA_RUN_ID=proposal-001 pnpm --filter web visual-qa:capture
VISUAL_QA_RUN_ID=proposal-001 VISUAL_QA_PHASE=baseline pnpm --filter web visual-qa:capture
VISUAL_QA_RUN_ID=proposal-001 VISUAL_QA_SURFACES=shell-desktop-idle,drawer-release-open pnpm --filter web visual-qa:capture
```

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] Unit tests pass (`tests/unit/visual-qa/*`)
- [ ] E2E capture lane not run in CI yet (requires local dev server + Doppler)

## Linear

Closes JOV-1943

<!-- linear-issue-id:6e7aabf4-cb5e-47a3-8a08-29b10a9432c5 -->
<!-- linear-issue-identifier:JOV-1943 -->