### PR TITLE
fix(auth): resolve staging Clerk email fallback for user provisioning (JOV-2776)

### DIFF
--- a/apps/web/lib/auth/gate.ts
+++ b/apps/web/lib/auth/gate.ts
@@ -1,6 +1,5 @@
 import 'server-only';
 
-import { createClerkClient } from '@clerk/backend';
 import * as Sentry from '@sentry/nextjs';
 import { sql as drizzleSql, eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
@@ -27,6 +26,7 @@ import {
   resolveCanonicalState,
 } from './canonical-user-state';
 import { syncEmailFromClerk } from './clerk-sync';
+import { getServerClerkClient } from './request-clerk-client';
 import { checkUserStatus } from './status-checker';
 
 export type { UserStateInput } from './canonical-user-state';
@@ -423,14 +423,27 @@ async function handleMissingDbUser(
     };
   }
 
-  // Need email to proceed
+  // Need email to proceed — return a terminal state instead of throwing so
+  // cached dashboard reconciliation can fail closed without duplicate Sentry noise.
   if (!email) {
     await captureError(
       'Cannot create user without email',
       new TypeError('Email is required for user creation'),
       { clerkUserId, operation: 'resolveUserState' }
     );
-    throw new TypeError('Email is required for user creation');
+
+    return {
+      state: CanonicalUserState.USER_CREATION_FAILED,
+      clerkUserId,
+      dbUserId: null,
+      profileId: null,
+      redirectTo: '/error/user-creation-failed',
+      context: {
+        ...baseContext,
+        email,
+        errorCode: 'EMAIL_REQUIRED_FOR_USER_CREATION',
+      },
+    };
   }
 
   // Check waitlist status before creating user. Gate OFF opens daily intake
@@ -547,8 +560,8 @@ function sleep(ms: number): Promise<void> {
 async function resolveVerifiedEmailFromClerkBackend(
   clerkUserId: string
 ): Promise<string | null> {
-  const secretKey = process.env.CLERK_SECRET_KEY;
-  if (!secretKey) {
+  const clerk = await getServerClerkClient();
+  if (!clerk) {
     Sentry.addBreadcrumb({
       category: 'auth-gate',
       level: 'warning',
@@ -558,7 +571,6 @@ async function resolveVerifiedEmailFromClerkBackend(
     return null;
   }
 
-  const clerk = createClerkClient({ secretKey });
   let lastError: unknown = null;
 
   for (

--- a/apps/web/lib/auth/request-clerk-client.ts
+++ b/apps/web/lib/auth/request-clerk-client.ts
@@ -1,5 +1,7 @@
 import { createClerkClient } from '@clerk/backend';
 import { clerkClient } from '@clerk/nextjs/server';
+import { headers } from 'next/headers';
+import { getRequestLocationFromHeaders } from '@/components/providers/clerkAvailability';
 import { isStagingHost, resolveClerkKeys } from '@/lib/auth/staging-clerk-keys';
 
 type ClerkClient = Awaited<ReturnType<typeof clerkClient>>;
@@ -18,6 +20,18 @@ export function getRequestHostname(request: Request): string {
   );
 }
 
+function createStagingClerkClient(hostname: string): ClerkClient {
+  const keys = resolveClerkKeys(hostname);
+  if (!keys.secretKey) {
+    throw new Error(`Staging Clerk secret unavailable: ${keys.status}`);
+  }
+
+  return createClerkClient({
+    publishableKey: keys.publishableKey,
+    secretKey: keys.secretKey,
+  }) as ClerkClient;
+}
+
 export async function getRequestClerkClient(
   request: Request
 ): Promise<ClerkClient> {
@@ -26,9 +40,39 @@ export async function getRequestClerkClient(
     return clerkClient();
   }
 
+  return createStagingClerkClient(hostname);
+}
+
+/**
+ * Resolve a Clerk backend client for server actions/components.
+ *
+ * Uses the request host to pick the staging Clerk instance when needed.
+ * Dashboard auth reconciliation calls resolveUserState() with only a Clerk
+ * user id; without host-aware key selection, staging sessions can be looked up
+ * against the production Clerk API and email resolution fails.
+ */
+export async function getServerClerkClient(): Promise<ClerkClient | null> {
+  let hostname = '';
+  try {
+    const hdrs = await headers();
+    hostname = getRequestLocationFromHeaders(hdrs)?.hostname ?? '';
+  } catch {
+    // headers() is unavailable outside a request context (tests, scripts).
+  }
+
+  if (!hostname) {
+    const secretKey = process.env.CLERK_SECRET_KEY;
+    if (!secretKey) return null;
+    return createClerkClient({ secretKey }) as ClerkClient;
+  }
+
+  if (!isStagingHost(hostname)) {
+    return clerkClient();
+  }
+
   const keys = resolveClerkKeys(hostname);
   if (!keys.secretKey) {
-    throw new Error(`Staging Clerk secret unavailable: ${keys.status}`);
+    return null;
   }
 
   return createClerkClient({

--- a/apps/web/tests/unit/lib/auth/gate.critical.test.ts
+++ b/apps/web/tests/unit/lib/auth/gate.critical.test.ts
@@ -19,6 +19,7 @@ const {
   mockSentryAddBreadcrumb,
   mockCreateClerkClient,
   mockClerkGetUser,
+  mockGetServerClerkClient,
 } = vi.hoisted(() => ({
   mockCachedAuth: vi.fn(),
   mockCachedCurrentUser: vi.fn(),
@@ -35,6 +36,7 @@ const {
   mockSentryAddBreadcrumb: vi.fn(),
   mockCreateClerkClient: vi.fn(),
   mockClerkGetUser: vi.fn(),
+  mockGetServerClerkClient: vi.fn(),
 }));
 
 // =============================================================================
@@ -133,6 +135,10 @@ vi.mock('@sentry/nextjs', () => ({
 
 vi.mock('@clerk/backend', () => ({
   createClerkClient: mockCreateClerkClient,
+}));
+
+vi.mock('@/lib/auth/request-clerk-client', () => ({
+  getServerClerkClient: mockGetServerClerkClient,
 }));
 
 // =============================================================================
@@ -265,9 +271,11 @@ describe('@critical gate.ts', () => {
     // Default: no fake timers needed since we mock setTimeout in retry tests
     mockIsWaitlistGateEnabled.mockResolvedValue(false);
     mockClerkGetUser.mockResolvedValue({ emailAddresses: [] });
-    mockCreateClerkClient.mockReturnValue({
+    const clerkBackendClient = {
       users: { getUser: mockClerkGetUser },
-    });
+    };
+    mockCreateClerkClient.mockReturnValue(clerkBackendClient);
+    mockGetServerClerkClient.mockResolvedValue(clerkBackendClient);
     setupNonBlockedStatus();
     mockResolveProfileState.mockReturnValue({
       state: CanonicalUserState.NEEDS_ONBOARDING,
@@ -727,8 +735,8 @@ describe('@critical gate.ts', () => {
       expect(result.state).toBe(CanonicalUserState.NEEDS_ONBOARDING);
     });
 
-    it('throws TypeError when createDbUserIfMissing is true but no email', async () => {
-      delete process.env.CLERK_SECRET_KEY;
+    it('returns USER_CREATION_FAILED when createDbUserIfMissing is true but no email', async () => {
+      mockGetServerClerkClient.mockResolvedValue(null);
       mockCachedAuth.mockResolvedValue({ userId: 'clerk_123' });
       mockCachedCurrentUser.mockResolvedValue({
         emailAddresses: [],
@@ -737,14 +745,17 @@ describe('@critical gate.ts', () => {
       // No DB user found
       mockDbSelect.mockReturnValue(createJoinSelectChain([]));
 
-      await expect(resolveUserState()).rejects.toThrow(
-        'Email is required for user creation'
-      );
+      const result = await resolveUserState();
+
+      expect(result.state).toBe(CanonicalUserState.USER_CREATION_FAILED);
+      expect(result.redirectTo).toBe('/error/user-creation-failed');
+      expect(result.context.errorCode).toBe('EMAIL_REQUIRED_FOR_USER_CREATION');
       expect(mockCaptureError).toHaveBeenCalled();
+      expect(mockDbInsert).not.toHaveBeenCalled();
     });
 
     it('does not create a DB user from an unverified primary email', async () => {
-      delete process.env.CLERK_SECRET_KEY;
+      mockGetServerClerkClient.mockResolvedValue(null);
       mockCachedAuth.mockResolvedValue({ userId: 'clerk_123' });
       mockCachedCurrentUser.mockResolvedValue({
         emailAddresses: [
@@ -760,11 +771,57 @@ describe('@critical gate.ts', () => {
 
       mockDbSelect.mockReturnValue(createJoinSelectChain([]));
 
-      await expect(resolveUserState()).rejects.toThrow(
-        'Email is required for user creation'
-      );
+      const result = await resolveUserState();
+
+      expect(result.state).toBe(CanonicalUserState.USER_CREATION_FAILED);
+      expect(result.context.errorCode).toBe('EMAIL_REQUIRED_FOR_USER_CREATION');
       expect(mockDbInsert).not.toHaveBeenCalled();
       expect(mockCaptureError).toHaveBeenCalled();
+    });
+
+    it('resolves verified email via host-aware Clerk backend on staging hosts (JOV-2776)', async () => {
+      mockGetServerClerkClient.mockResolvedValue({
+        users: {
+          getUser: mockClerkGetUser.mockResolvedValueOnce({
+            emailAddresses: [
+              {
+                emailAddress: 'staging-native@example.com',
+                verification: { status: 'verified' },
+              },
+            ],
+          }),
+        },
+      });
+      mockIsWaitlistGateEnabled.mockResolvedValue(true);
+
+      let selectCallCount = 0;
+      mockDbSelect.mockImplementation(() => {
+        selectCallCount++;
+        if (selectCallCount === 1) {
+          return createJoinSelectChain([]);
+        }
+        if (selectCallCount === 2) {
+          return createSimpleSelectChain([
+            { id: 'waitlist-entry-123', status: 'claimed' },
+          ]);
+        }
+        if (selectCallCount === 3) {
+          return createJoinSelectChain([]);
+        }
+        return createSimpleSelectChain([
+          { userStatus: 'waitlist_approved', deletedAt: null },
+        ]);
+      });
+      mockDbInsert.mockReturnValue(createInsertChain([{ id: 'new-user-id' }]));
+
+      const result = await resolveUserState({ knownClerkUserId: 'clerk_123' });
+
+      expect(mockGetServerClerkClient).toHaveBeenCalled();
+      expect(mockCachedAuth).not.toHaveBeenCalled();
+      expect(mockCachedCurrentUser).not.toHaveBeenCalled();
+      expect(result.dbUserId).toBe('new-user-id');
+      expect(result.context.email).toBe('staging-native@example.com');
+      expect(result.state).toBe(CanonicalUserState.NEEDS_ONBOARDING);
     });
 
     it('uses joined profile data when resolving canonical state', async () => {

--- a/apps/web/tests/unit/lib/auth/request-clerk-client.test.ts
+++ b/apps/web/tests/unit/lib/auth/request-clerk-client.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockClerkClient, mockCreateClerkClient } = vi.hoisted(() => ({
-  mockClerkClient: vi.fn(),
-  mockCreateClerkClient: vi.fn(),
-}));
+const { mockClerkClient, mockCreateClerkClient, headersMock } = vi.hoisted(
+  () => ({
+    mockClerkClient: vi.fn(),
+    mockCreateClerkClient: vi.fn(),
+    headersMock: vi.fn(),
+  })
+);
 
 vi.mock('@clerk/nextjs/server', () => ({
   clerkClient: mockClerkClient,
@@ -11,6 +14,10 @@ vi.mock('@clerk/nextjs/server', () => ({
 
 vi.mock('@clerk/backend', () => ({
   createClerkClient: mockCreateClerkClient,
+}));
+
+vi.mock('next/headers', () => ({
+  headers: headersMock,
 }));
 
 const ORIGINAL_ENV = {
@@ -39,6 +46,7 @@ describe('request Clerk client resolution', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    headersMock.mockReset();
     process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = 'pk_live_production';
     process.env.CLERK_SECRET_KEY = 'sk_live_production';
     delete process.env.CLERK_PUBLISHABLE_KEY_STAGING;
@@ -84,6 +92,46 @@ describe('request Clerk client resolution', () => {
       publishableKey: 'pk_live_staging',
       secretKey: 'sk_live_staging',
     });
+    expect(mockClerkClient).not.toHaveBeenCalled();
+  });
+
+  it('uses explicit staging Clerk keys for server actions on staging hosts', async () => {
+    process.env.CLERK_PUBLISHABLE_KEY_STAGING = 'pk_live_staging';
+    process.env.CLERK_SECRET_KEY_STAGING = 'sk_live_staging';
+    headersMock.mockResolvedValue(
+      new Headers({
+        host: 'staging.jov.ie',
+      })
+    );
+
+    const { getServerClerkClient } = await import(
+      '@/lib/auth/request-clerk-client'
+    );
+
+    await expect(getServerClerkClient()).resolves.toEqual({
+      source: 'backend',
+    });
+    expect(mockCreateClerkClient).toHaveBeenCalledWith({
+      publishableKey: 'pk_live_staging',
+      secretKey: 'sk_live_staging',
+    });
+    expect(mockClerkClient).not.toHaveBeenCalled();
+  });
+
+  it('returns null for staging hosts when the staging secret is unavailable', async () => {
+    process.env.CLERK_PUBLISHABLE_KEY_STAGING = 'pk_live_staging';
+    headersMock.mockResolvedValue(
+      new Headers({
+        host: 'staging.jov.ie',
+      })
+    );
+
+    const { getServerClerkClient } = await import(
+      '@/lib/auth/request-clerk-client'
+    );
+
+    await expect(getServerClerkClient()).resolves.toBeNull();
+    expect(mockCreateClerkClient).not.toHaveBeenCalled();
     expect(mockClerkClient).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Goal

Fix `TypeError: Email is required for user creation` (JOVIE-WEB-MB) when Electron users on `staging.jov.ie` hit `/app/chat` before a DB user exists. Dashboard auth reconciliation was calling Clerk's backend API with production keys while the session belonged to the staging Clerk instance, so verified email resolution failed.

## Changes

- Add `getServerClerkClient()` to resolve staging vs production Clerk secrets from request host headers
- Use host-aware Clerk client in `resolveVerifiedEmailFromClerkBackend()`
- Return `USER_CREATION_FAILED` instead of throwing when email is still unavailable after fallback (prevents duplicate Sentry noise in dashboard reconciliation)

## KPI (if applicable)

- JOVIE-WEB-MB should stop reproducing for staging Electron signups

## Rollback plan

Revert PR.

Fixes JOVIE-WEB-MB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added staging environment support with environment-specific authentication configuration

* **Bug Fixes**
  * Improved user creation failure handling with dedicated error page and error codes
  * Enhanced error reporting during authentication with specific error codes
  * Better handling of missing email data during user verification process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- agent-run-artifact
{
  "id": "run-jov-2776",
  "source": "github",
  "sourceRunId": "b2e742491ac00bea2f8426b66ed5ecdff94d51c8",
  "kind": "qa",
  "status": "done",
  "title": "JOV-2776 GStack gates",
  "summary": "Recorded GStack gate evidence for staging Clerk email fallback in user provisioning.",
  "modelRoute": "deterministic",
  "allowedActions": [
    "read"
  ],
  "forbiddenActions": [
    "merge",
    "deploy"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2776",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2776",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/10410",
  "adminSurface": "/app/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "typecheck, biome, vitest (44 tests) passed locally",
      "checkedAt": "2026-06-09T20:02:05.000Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "Self-review: getServerClerkClient + gate email fallback + auth tests only",
      "checkedAt": "2026-06-09T20:03:05.000Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "PR #10410 verified; typecheck/biome/vitest passed",
      "checkedAt": "2026-06-09T20:04:05.000Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-06-09T20:02:05.000Z",
  "updatedAt": "2026-06-09T20:04:05.000Z",
  "metadata": {}
}
-->
