### PR TITLE
fix(profile): replace undefined bg-surface-raised token in loading skeleton (JOV-2945)

### DIFF
--- a/apps/web/app/[username]/loading.tsx
+++ b/apps/web/app/[username]/loading.tsx
@@ -10,24 +10,24 @@ export default function ProfileLoading() {
       <div className='mx-auto max-w-2xl px-4 pt-24 pb-16'>
         {/* Avatar placeholder */}
         <div className='flex flex-col items-center'>
-          <div className='h-24 w-24 rounded-full bg-surface-raised animate-pulse' />
+          <div className='h-24 w-24 rounded-full bg-surface-1 animate-pulse' />
           {/* Name placeholder */}
-          <div className='mt-4 h-6 w-40 rounded-lg bg-surface-raised animate-pulse' />
+          <div className='mt-4 h-6 w-40 rounded-lg bg-surface-1 animate-pulse' />
           {/* Handle placeholder */}
-          <div className='mt-2 h-4 w-24 rounded-md bg-surface-raised animate-pulse' />
+          <div className='mt-2 h-4 w-24 rounded-md bg-surface-1 animate-pulse' />
         </div>
 
         {/* Bio placeholder */}
         <div className='mt-8 space-y-2'>
-          <div className='mx-auto h-3 w-full max-w-xs rounded bg-surface-raised animate-pulse' />
-          <div className='mx-auto h-3 w-3/4 max-w-xs rounded bg-surface-raised animate-pulse' />
+          <div className='mx-auto h-3 w-full max-w-xs rounded bg-surface-1 animate-pulse' />
+          <div className='mx-auto h-3 w-3/4 max-w-xs rounded bg-surface-1 animate-pulse' />
         </div>
 
         {/* Link buttons placeholder */}
         <div className='mt-10 space-y-3'>
-          <div className='mx-auto h-12 w-full max-w-sm rounded-xl bg-surface-raised animate-pulse' />
-          <div className='mx-auto h-12 w-full max-w-sm rounded-xl bg-surface-raised animate-pulse' />
-          <div className='mx-auto h-12 w-full max-w-sm rounded-xl bg-surface-raised animate-pulse' />
+          <div className='mx-auto h-12 w-full max-w-sm rounded-xl bg-surface-1 animate-pulse' />
+          <div className='mx-auto h-12 w-full max-w-sm rounded-xl bg-surface-1 animate-pulse' />
+          <div className='mx-auto h-12 w-full max-w-sm rounded-xl bg-surface-1 animate-pulse' />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Replaces 7 occurrences of the undefined `bg-surface-raised` token with `bg-surface-1` in the public profile loading skeleton so skeleton placeholders are visible during client-side navigation.

## Linear
https://linear.app/jovie/issue/JOV-2945/sweep-jov-wx-002-bg-surface-raised-token-undefined-public-profile

<!-- linear-issue-id:JOV-2945 -->

## Validation
- Verified no remaining `bg-surface-raised` references in the worktree
- Token maps to defined `surface.1` in tailwind config

## Rollback
Revert the single loading.tsx class substitution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the profile page loading skeleton with improved visual styling and refined theme colors for enhanced consistency during page load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->