### PR TITLE
fix(dashboard): render loading skeleton instead of null during sub-route nav (JOV-2946)

### DIFF
--- a/apps/web/app/app/(shell)/dashboard/loading.tsx
+++ b/apps/web/app/app/(shell)/dashboard/loading.tsx
@@ -1,3 +1,36 @@
+/**
+ * Dashboard segment loading state shown during client navigation between
+ * dashboard sub-routes (e.g. audience -> contacts).
+ */
 export default function DashboardLoading() {
-  return null;
+  return (
+    <div className='space-y-3 p-4 sm:p-5' aria-busy='true' aria-live='polite'>
+      <div className='flex items-center justify-between gap-3'>
+        <div className='space-y-2'>
+          <div className='skeleton h-6 w-52 rounded-md' />
+          <div className='skeleton h-4 w-72 rounded' />
+        </div>
+        <div className='skeleton h-8 w-24 rounded-md' />
+      </div>
+
+      <div className='space-y-3 rounded-xl border border-subtle/70 bg-surface-0 p-3'>
+        <div className='grid grid-cols-[minmax(0,1.5fr)_120px_72px] gap-3 border-b border-subtle/60 pb-2'>
+          <div className='skeleton h-3 w-24 rounded' />
+          <div className='skeleton h-3 w-16 rounded' />
+          <div className='skeleton h-3 w-12 rounded' />
+        </div>
+
+        {[1, 2, 3, 4].map(row => (
+          <div
+            key={`dashboard-loading-row-${row}`}
+            className='grid grid-cols-[minmax(0,1.5fr)_120px_72px] items-center gap-3 py-1'
+          >
+            <div className='skeleton h-4 w-full rounded' />
+            <div className='skeleton h-4 w-20 rounded' />
+            <div className='skeleton h-4 w-12 rounded' />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }

--- a/apps/web/tests/unit/app/dashboard-loading.test.tsx
+++ b/apps/web/tests/unit/app/dashboard-loading.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import DashboardLoading from '@/app/app/(shell)/dashboard/loading';
+
+describe('DashboardLoading', () => {
+  it('renders a non-null dashboard skeleton while routes resolve', () => {
+    const { container } = render(<DashboardLoading />);
+
+    expect(container.firstChild).not.toBeNull();
+    expect(container.querySelector('[aria-busy="true"]')).not.toBeNull();
+    expect(container.querySelectorAll('.skeleton').length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
Replaces the dashboard segment `loading.tsx` null return with a shell-shaped skeleton so dashboard sub-route navigation shows immediate loading feedback instead of a frozen previous page.

## Linear
https://linear.app/jovie/issue/JOV-2946/sweep-jov-wx-003-dashboardloading-returns-null-dashboard-navigation

<!-- linear-issue-id:JOV-2946 -->

## Validation
- Added `tests/unit/app/dashboard-loading.test.tsx` asserting non-null skeleton output with `aria-busy`

## Rollback
Restore the previous `return null` dashboard loading component.