### PR TITLE
fix(auth): default post-signup redirect to /start instead of /waitlist (JOV-2956)

### DIFF
--- a/apps/web/app/@auth/(.)signup/SignupModalClient.tsx
+++ b/apps/web/app/@auth/(.)signup/SignupModalClient.tsx
@@ -9,7 +9,10 @@ import {
   readHomepageIntent,
 } from '@/components/homepage/intent-store';
 import { APP_ROUTES } from '@/constants/routes';
-import { buildAuthRouteUrl } from '@/lib/auth/build-auth-route-url';
+import {
+  buildAuthRouteUrl,
+  getDefaultSignUpFallbackRedirectUrl,
+} from '@/lib/auth/build-auth-route-url';
 import { sanitizeRedirectUrl } from '@/lib/auth/constants';
 
 /**
@@ -53,7 +56,7 @@ export function SignupModalClient() {
   const signInUrl = buildAuthRouteUrl(APP_ROUTES.SIGNIN, searchParams);
   const redirectUrl =
     sanitizeRedirectUrl(searchParams.get('redirect_url')) ??
-    APP_ROUTES.WAITLIST;
+    getDefaultSignUpFallbackRedirectUrl();
 
   const statusRow = promptHint ? (
     <p aria-live='polite' className='truncate' title={promptHint}>

--- a/apps/web/components/features/auth/AuthShell.tsx
+++ b/apps/web/components/features/auth/AuthShell.tsx
@@ -9,7 +9,10 @@ import {
   AuthProviderButtonSlot,
   AuthProviderButtonSlots,
 } from '@/features/auth/AuthProviderButtons';
-import { buildAuthRouteUrl } from '@/lib/auth/build-auth-route-url';
+import {
+  buildAuthRouteUrl,
+  getDefaultSignUpFallbackRedirectUrl,
+} from '@/lib/auth/build-auth-route-url';
 import { CLERK_COMPONENT_OPTIONS } from '@/lib/auth/clerk-options';
 import {
   getEnabledAuthOAuthProviders,
@@ -53,7 +56,7 @@ interface AuthShellProps {
   /**
    * Where to send Clerk after a successful sign-in or sign-up. Defaults match
    * the post-auth routing used elsewhere in the app (dashboard for sign-in,
-   * waitlist for sign-up).
+   * /start for sign-up).
    */
   readonly fallbackRedirectUrl?: string;
   /**
@@ -125,7 +128,9 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
       isSignUp ? APP_ROUTES.SIGNIN : APP_ROUTES.SUPPORT,
       searchParams
     );
-  const defaultRedirect = isSignUp ? APP_ROUTES.WAITLIST : APP_ROUTES.DASHBOARD;
+  const defaultRedirect = isSignUp
+    ? getDefaultSignUpFallbackRedirectUrl()
+    : APP_ROUTES.DASHBOARD;
   const resolvedRedirect = fallbackRedirectUrl ?? defaultRedirect;
   const enabledOAuthProviders = useMemo(
     () => getEnabledAuthOAuthProviders(),

--- a/apps/web/lib/auth/build-auth-route-url.ts
+++ b/apps/web/lib/auth/build-auth-route-url.ts
@@ -1,4 +1,13 @@
+import { APP_ROUTES } from '@/constants/routes';
+
 import { sanitizeRedirectUrl } from './constants';
+
+/**
+ * Default post-auth destination for sign-up flows when no redirect_url is set.
+ */
+export function getDefaultSignUpFallbackRedirectUrl(): string {
+  return APP_ROUTES.START;
+}
 
 interface SearchParamReader {
   get(key: string): string | null;

--- a/apps/web/tests/unit/lib/auth/build-auth-route-url.test.ts
+++ b/apps/web/tests/unit/lib/auth/build-auth-route-url.test.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest';
+import { APP_ROUTES } from '@/constants/routes';
 import {
   buildAuthRouteUrl,
   buildProtectedAuthRedirectUrl,
+  getDefaultSignUpFallbackRedirectUrl,
 } from '@/lib/auth/build-auth-route-url';
+
+describe('getDefaultSignUpFallbackRedirectUrl', () => {
+  it('routes new sign-ups to onboarding start by default', () => {
+    expect(getDefaultSignUpFallbackRedirectUrl()).toBe(APP_ROUTES.START);
+  });
+});
 
 describe('buildAuthRouteUrl', () => {
   it('forwards only a valid redirect_url', () => {


### PR DESCRIPTION
## Summary
Centralizes the default post-signup redirect in `getDefaultSignUpFallbackRedirectUrl()` and routes new sign-ups to `/start` instead of `/waitlist` in both the intercepted modal and `AuthShell` default.

## Linear
https://linear.app/jovie/issue/JOV-2956/sweep-jov-wx-020-post-signup-redirect-defaults-to-waitlist-on-both

<!-- linear-issue-id:JOV-2956 -->

## Validation
- Added unit test for `getDefaultSignUpFallbackRedirectUrl()` returning `APP_ROUTES.START`

## Rollback
Revert the centralized helper and restore `APP_ROUTES.WAITLIST` defaults.