### PR TITLE
fix(auth): hard-block test-auth bypass on VERCEL_ENV=production (JOV-2948)

### DIFF
--- a/apps/web/lib/auth/test-mode.ts
+++ b/apps/web/lib/auth/test-mode.ts
@@ -26,12 +26,15 @@ const PRIVATE_IPV4_BLOCKS = [
 ] as const;
 
 export function isTestAuthBypassEnabled(): boolean {
-  // Explicitly block the bypass on Vercel preview deployments even if
-  // E2E_USE_TEST_AUTH_BYPASS=1 is set in the preview environment.  Combined
+  // Explicitly block the bypass on Vercel preview and production deployments
+  // even if E2E_USE_TEST_AUTH_BYPASS=1 is set in those environments. Combined
   // with the removal of the *.vercel.app wildcard from isTrustedTestBypassHostname,
   // this gives defence-in-depth: an attacker who knows a preview URL cannot forge
   // a session even if the env-var is accidentally set to "1" in that env.
-  if (process.env.VERCEL_ENV === 'preview') {
+  if (
+    process.env.VERCEL_ENV === 'preview' ||
+    process.env.VERCEL_ENV === 'production'
+  ) {
     return false;
   }
   return process.env.E2E_USE_TEST_AUTH_BYPASS === '1';

--- a/apps/web/tests/unit/lib/auth/test-mode.test.ts
+++ b/apps/web/tests/unit/lib/auth/test-mode.test.ts
@@ -31,6 +31,12 @@ describe('test-mode auth bypass', () => {
     expect(isTestAuthBypassEnabled()).toBe(false);
   });
 
+  it('does not enable the bypass on Vercel production deployments even when the flag is set', () => {
+    vi.stubEnv('E2E_USE_TEST_AUTH_BYPASS', '1');
+    vi.stubEnv('VERCEL_ENV', 'production');
+    expect(isTestAuthBypassEnabled()).toBe(false);
+  });
+
   it('does not leak bypass access on Vercel preview even for preview.jov.ie', () => {
     vi.stubEnv('E2E_USE_TEST_AUTH_BYPASS', '1');
     vi.stubEnv('VERCEL_ENV', 'preview');


### PR DESCRIPTION
## Summary
Adds an explicit `VERCEL_ENV=production` guard to `isTestAuthBypassEnabled()` so the E2E test-auth bypass cannot activate in production even if `E2E_USE_TEST_AUTH_BYPASS=1` is accidentally set in Doppler.

## Linear
https://linear.app/jovie/issue/JOV-2948/sweep-plat-006-test-auth-bypass-missing-explicit-vercel-envproduction

<!-- linear-issue-id:JOV-2948 -->

## Validation
- Added unit test: bypass disabled when `VERCEL_ENV=production` even with bypass flag set

## Rollback
Remove the production env check from `isTestAuthBypassEnabled()`.