### PR TITLE
fix(onboarding): silence welcome chat bootstrap failure toast (JOV-2955)

### DIFF
--- a/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
+++ b/apps/web/app/app/(shell)/chat/ChatPageClient.tsx
@@ -172,7 +172,7 @@ function getWelcomeChatBootstrapAnnouncement(
     case 'scheduled':
       return 'Still setting up your onboarding chat. Retrying now.';
     case 'failed':
-      return 'We could not start your onboarding chat. Refresh to try again.';
+      return '';
     default:
       return '';
   }
@@ -705,10 +705,9 @@ export function ChatPageClient({
         welcomeChatRetryCountRef.current >=
           WELCOME_CHAT_BOOTSTRAP_RETRY_DELAYS_MS.length
       ) {
-        setWelcomeChatBootstrapStatus('failed');
-        notifications.error(
-          'We could not start your onboarding chat. Refresh to try again.'
-        );
+        // Welcome chat bootstrap is a non-blocking enhancement. The chat shell
+        // remains usable even when auto-creating the welcome thread fails.
+        setWelcomeChatBootstrapStatus('done');
         return;
       }
 

--- a/apps/web/tests/unit/chat/ChatPageClient.test.tsx
+++ b/apps/web/tests/unit/chat/ChatPageClient.test.tsx
@@ -532,4 +532,27 @@ describe('ChatPageClient', () => {
       'Starting your onboarding chat.'
     );
   });
+
+  it('does not show a destructive toast after welcome chat bootstrap retries exhaust', async () => {
+    vi.useFakeTimers();
+    mockSearchParams = new URLSearchParams('from=onboarding');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(null, {
+            status: 503,
+            statusText: 'Service Unavailable',
+          })
+        )
+      )
+    );
+
+    renderChatPage();
+
+    await vi.runAllTimersAsync();
+
+    expect(mockErrorNotification).not.toHaveBeenCalled();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
Treats welcome chat bootstrap as a non-blocking enhancement. After retry exhaustion, the client now completes silently instead of firing a destructive error toast while the chat shell remains usable.

## Linear
https://linear.app/jovie/issue/JOV-2955/sweep-jov-wx-009-onboarding-bootstrap-retry-shows-destructive-error

<!-- linear-issue-id:JOV-2955 -->

## Validation
- Added regression test simulating 3 bootstrap failures and asserting no error toast/alert

## Rollback
Restore the previous `notifications.error(...)` failure path.