### PR TITLE
feat(library): saved filter views (JOV-2934)

### DIFF
--- a/apps/web/app/app/(shell)/library/LibrarySurface.tsx
+++ b/apps/web/app/app/(shell)/library/LibrarySurface.tsx
@@ -87,6 +87,14 @@ import {
   type LibraryView,
   libraryAssetMatchesView,
 } from './library-data';
+import {
+  countLibrarySavedViewMatches,
+  getLibrarySavedViewPredicate,
+  LIBRARY_SAVED_VIEWS,
+  type LibrarySavedViewId,
+  persistLibrarySavedView,
+  readPersistedLibrarySavedView,
+} from './library-saved-views';
 
 const LIBRARY_TABLE_ROW_HEIGHT = 56;
 const LIBRARY_TABLE_MIN_WIDTH = '0';
@@ -683,14 +691,45 @@ function LibraryViewFilterChips({
   );
 }
 
+function LibrarySavedViewRow({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  readonly label: string;
+  readonly count: number;
+  readonly active: boolean;
+  readonly onClick: () => void;
+}) {
+  return (
+    <button
+      type='button'
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        'system-b-library-rail-button flex h-7 w-full items-center gap-2 border px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--linear-border-focus)/55 focus-visible:ring-offset-2 focus-visible:ring-offset-(--linear-app-content-surface) outline-none',
+        active && 'system-b-library-rail-button--active'
+      )}
+    >
+      <span className='min-w-0 flex-1 truncate text-left'>{label}</span>
+      <span className='system-b-library-rail-count tabular-nums'>{count}</span>
+    </button>
+  );
+}
+
 function LibraryRail({
   assets,
+  savedView,
+  onSavedView,
   filters,
   onFilters,
   onClearFilters,
   className,
 }: {
   readonly assets: readonly LibraryReleaseAsset[];
+  readonly savedView: LibrarySavedViewId;
+  readonly onSavedView: (savedView: LibrarySavedViewId) => void;
   readonly filters: LibraryFilters;
   readonly onFilters: (filters: LibraryFilters) => void;
   readonly onClearFilters: () => void;
@@ -735,7 +774,22 @@ function LibraryRail({
       )}
     >
       <div className='min-h-0 flex-1 overflow-y-auto px-1.5 pb-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden'>
-        <div className='flex items-center justify-between gap-2 pb-1 pt-2'>
+        <div className='pb-2'>
+          <p className='system-b-library-rail-title pb-1 pt-2'>Smart Filters</p>
+          <div className='space-y-px' data-testid='library-saved-filter-views'>
+            {LIBRARY_SAVED_VIEWS.map(view => (
+              <LibrarySavedViewRow
+                key={view.id}
+                label={view.label}
+                count={countLibrarySavedViewMatches(assets, view.id)}
+                active={savedView === view.id}
+                onClick={() => onSavedView(view.id)}
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className='flex items-center justify-between gap-2 border-t border-subtle pb-1 pt-2'>
           <p className='system-b-library-rail-title'>Filters</p>
           {hasActiveFilters(filters) ? (
             <button
@@ -1938,6 +1992,9 @@ export function LibrarySurface({
   const [preset, setPreset] = useState<LibraryPresetId>(() =>
     parseLibraryViewParam(searchParams.get('view'))
   );
+  const [savedView, setSavedView] = useState<LibrarySavedViewId>(() =>
+    readPersistedLibrarySavedView()
+  );
   const [filters, setFilters] = useState<LibraryFilters>(() => emptyFilters());
   const [sort, setSort] = useState<LibrarySortKey>('releaseDate');
   const [view, setView] = useState<LibraryViewMode>('list');
@@ -1948,6 +2005,7 @@ export function LibrarySurface({
   const isDesktopLayout = useBreakpoint('lg');
   const deferredFilters = useDeferredValue(filters);
   const deferredPreset = useDeferredValue(preset);
+  const deferredSavedView = useDeferredValue(savedView);
   const deferredPills = useDeferredValue(pills);
   const deferredSort = useDeferredValue(sort);
 
@@ -1978,9 +2036,11 @@ export function LibrarySurface({
     const presetPredicate =
       PRESETS.find(item => item.id === deferredPreset)?.predicate ??
       (() => true);
+    const savedViewPredicate = getLibrarySavedViewPredicate(deferredSavedView);
 
     return effectiveAssets
       .filter(presetPredicate)
+      .filter(savedViewPredicate)
       .filter(asset => assetMatchesFilters(asset, deferredFilters))
       .filter(asset => assetMatchesPills(asset, deferredPills))
       .toSorted(compareAssets(deferredSort));
@@ -1988,6 +2048,7 @@ export function LibrarySurface({
     deferredFilters,
     deferredPills,
     deferredPreset,
+    deferredSavedView,
     deferredSort,
     effectiveAssets,
   ]);
@@ -2089,8 +2150,14 @@ export function LibrarySurface({
     [router, searchParams]
   );
 
+  const handleSavedViewChange = useCallback((next: LibrarySavedViewId) => {
+    setSavedView(next);
+    persistLibrarySavedView(next);
+  }, []);
+
   function resetView() {
     handlePresetChange('all');
+    handleSavedViewChange('all');
     setFilters(emptyFilters());
     setPills([]);
   }
@@ -2194,12 +2261,14 @@ export function LibrarySurface({
     () => (
       <LibraryRail
         assets={effectiveAssets}
+        savedView={savedView}
+        onSavedView={handleSavedViewChange}
         filters={filters}
         onFilters={setFilters}
         onClearFilters={() => setFilters(emptyFilters())}
       />
     ),
-    [effectiveAssets, filters]
+    [effectiveAssets, filters, handleSavedViewChange, savedView]
   );
 
   useRegisterShellSidebarOverride(

--- a/apps/web/app/app/(shell)/library/library-saved-views.ts
+++ b/apps/web/app/app/(shell)/library/library-saved-views.ts
@@ -1,0 +1,137 @@
+import { getLibraryItemKind, type LibraryReleaseAsset } from './library-data';
+
+export type LibrarySavedViewId =
+  | 'all'
+  | 'scheduled'
+  | 'drafts'
+  | 'missing-audio'
+  | 'missing-artwork'
+  | 'no-providers'
+  | 'recent'
+  | 'live-merch';
+
+export interface LibrarySavedView {
+  readonly id: LibrarySavedViewId;
+  readonly label: string;
+  readonly description: string;
+  readonly predicate: (asset: LibraryReleaseAsset) => boolean;
+}
+
+export const LIBRARY_SAVED_VIEW_STORAGE_KEY = 'jovie:library:saved-view';
+
+export const LIBRARY_SAVED_VIEWS: readonly LibrarySavedView[] = [
+  {
+    id: 'all',
+    label: 'All items',
+    description: 'Full catalog',
+    predicate: () => true,
+  },
+  {
+    id: 'scheduled',
+    label: 'Scheduled',
+    description: 'Items with a future release date',
+    predicate: asset => asset.status === 'scheduled',
+  },
+  {
+    id: 'drafts',
+    label: 'Drafts',
+    description: 'Unpublished releases and merch',
+    predicate: asset => asset.status === 'draft',
+  },
+  {
+    id: 'missing-audio',
+    label: 'Missing audio',
+    description: 'Releases without a preview',
+    predicate: asset =>
+      getLibraryItemKind(asset) === 'release' && !asset.previewUrl,
+  },
+  {
+    id: 'missing-artwork',
+    label: 'Missing artwork',
+    description: 'Items without cover art',
+    predicate: asset => !asset.hasArtwork,
+  },
+  {
+    id: 'no-providers',
+    label: 'No providers',
+    description: 'Releases without DSP links',
+    predicate: asset =>
+      getLibraryItemKind(asset) === 'release' && asset.providerCount === 0,
+  },
+  {
+    id: 'recent',
+    label: 'Updated this week',
+    description: 'Touched in the last 7 days',
+    predicate: asset => isWithinDays(asset.updatedAt ?? asset.releaseDate, 7),
+  },
+  {
+    id: 'live-merch',
+    label: 'Live merch',
+    description: 'Merch cards currently for sale',
+    predicate: asset =>
+      getLibraryItemKind(asset) === 'merch' && asset.status === 'released',
+  },
+];
+
+function parseTimestamp(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const time = new Date(value).getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+function isWithinDays(
+  value: string | null | undefined,
+  days: number,
+  nowMs = Date.now()
+): boolean {
+  const time = parseTimestamp(value);
+  if (time === null) return false;
+  return nowMs - time <= days * 86_400_000;
+}
+
+export function isLibrarySavedViewId(
+  value: string
+): value is LibrarySavedViewId {
+  return LIBRARY_SAVED_VIEWS.some(view => view.id === value);
+}
+
+export function getLibrarySavedViewPredicate(
+  id: LibrarySavedViewId
+): (asset: LibraryReleaseAsset) => boolean {
+  return (
+    LIBRARY_SAVED_VIEWS.find(view => view.id === id)?.predicate ?? (() => true)
+  );
+}
+
+export function readPersistedLibrarySavedView(): LibrarySavedViewId {
+  if (typeof globalThis.window === 'undefined') return 'all';
+  try {
+    const stored = globalThis.localStorage?.getItem(
+      LIBRARY_SAVED_VIEW_STORAGE_KEY
+    );
+    return stored && isLibrarySavedViewId(stored) ? stored : 'all';
+  } catch {
+    return 'all';
+  }
+}
+
+export function persistLibrarySavedView(id: LibrarySavedViewId): void {
+  if (typeof globalThis.window === 'undefined') return;
+  try {
+    if (id === 'all') {
+      globalThis.localStorage?.removeItem(LIBRARY_SAVED_VIEW_STORAGE_KEY);
+      return;
+    }
+    globalThis.localStorage?.setItem(LIBRARY_SAVED_VIEW_STORAGE_KEY, id);
+  } catch {
+    // localStorage may be unavailable in restricted contexts.
+  }
+}
+
+export function countLibrarySavedViewMatches(
+  assets: readonly LibraryReleaseAsset[],
+  id: LibrarySavedViewId
+): number {
+  const predicate = getLibrarySavedViewPredicate(id);
+  return assets.filter(predicate).length;
+}

--- a/apps/web/tests/unit/library/LibrarySurface.test.tsx
+++ b/apps/web/tests/unit/library/LibrarySurface.test.tsx
@@ -236,6 +236,7 @@ describe('LibrarySurface', () => {
     expect(source).toContain('border-success/20 bg-success/10 text-success');
     expect(source).toContain('border-info/20 bg-info/10 text-info');
     expect(source).toContain('system-b-library-filter-pill-active');
+    expect(source).toContain('system-b-library-rail-button--active');
     expect(source).toContain('system-b-library-card--selected');
     expect(source).toContain('system-b-library-table-row-selected');
     expect(source).toContain('system-b-library-dropzone--dragging');
@@ -603,6 +604,35 @@ describe('LibrarySurface', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('filters library assets from sidebar smart filter views', async () => {
+    renderLibraryWithSidebarOverride([
+      buildAsset(),
+      buildAsset({
+        id: 'release-2',
+        title: 'Never Say A Word',
+        artist: 'Other Artist',
+        previewUrl: null,
+        assetKinds: ['artwork', 'lyrics', 'providers'],
+      }),
+    ]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show filters' }));
+    expect(
+      screen.getByTestId('library-saved-filter-views')
+    ).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Missing audio/u }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Never Say A Word')).toBeInTheDocument();
+      expect(screen.queryByText('Take Me Over')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^All items/u }));
+
+    expect(screen.getByText('Take Me Over')).toBeInTheDocument();
+    expect(screen.getByText('Never Say A Word')).toBeInTheDocument();
+  });
+
   it('filters library assets from top-level view chips', async () => {
     renderLibrary([
       buildAsset(),
@@ -658,6 +688,9 @@ describe('LibrarySurface', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Show filters' }));
     expect(
       screen.getByRole('navigation', { name: 'Library filters' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('library-saved-filter-views')
     ).toBeInTheDocument();
     expect(
       screen.queryByRole('button', { name: /All Releases/u })

--- a/apps/web/tests/unit/library/library-saved-views.test.ts
+++ b/apps/web/tests/unit/library/library-saved-views.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { LibraryReleaseAsset } from '@/app/app/(shell)/library/library-data';
+import {
+  countLibrarySavedViewMatches,
+  getLibrarySavedViewPredicate,
+  isLibrarySavedViewId,
+  LIBRARY_SAVED_VIEW_STORAGE_KEY,
+  persistLibrarySavedView,
+  readPersistedLibrarySavedView,
+} from '@/app/app/(shell)/library/library-saved-views';
+
+function buildAsset(
+  overrides: Partial<LibraryReleaseAsset> = {}
+): LibraryReleaseAsset {
+  return {
+    id: 'release-1',
+    title: 'Take Me Over',
+    artist: 'Tim White',
+    artworkUrl: 'https://cdn.example.com/artwork.jpg',
+    previewUrl: 'https://cdn.example.com/preview.mp3',
+    smartLinkPath: '/tim/take-me-over',
+    releaseDate: '2026-04-28T00:00:00.000Z',
+    releaseType: 'single',
+    status: 'released',
+    trackCount: 1,
+    providerCount: 1,
+    providers: [
+      {
+        key: 'spotify',
+        label: 'Spotify',
+        url: 'https://open.spotify.com/album/take-me-over',
+      },
+    ],
+    hasLyrics: true,
+    hasArtwork: true,
+    hasVideoLinks: false,
+    assetKinds: ['artwork', 'preview', 'lyrics', 'providers'],
+    genres: [],
+    spotifyPopularity: null,
+    targetPlaylistCount: 0,
+    isExplicit: false,
+    label: null,
+    upc: null,
+    distributor: null,
+    totalDurationMs: null,
+    ...overrides,
+  };
+}
+
+describe('library saved views', () => {
+  it('recognizes canonical smart filter ids', () => {
+    expect(isLibrarySavedViewId('missing-audio')).toBe(true);
+    expect(isLibrarySavedViewId('unknown-view')).toBe(false);
+  });
+
+  it('matches missing audio and no-provider smart filters', () => {
+    const missingAudio = getLibrarySavedViewPredicate('missing-audio');
+    const noProviders = getLibrarySavedViewPredicate('no-providers');
+
+    expect(
+      missingAudio(
+        buildAsset({
+          previewUrl: null,
+          assetKinds: ['artwork', 'lyrics', 'providers'],
+        })
+      )
+    ).toBe(true);
+    expect(missingAudio(buildAsset())).toBe(false);
+    expect(noProviders(buildAsset({ providerCount: 0, providers: [] }))).toBe(
+      true
+    );
+    expect(noProviders(buildAsset())).toBe(false);
+  });
+
+  it('counts smart filter matches across the catalog', () => {
+    const assets = [
+      buildAsset(),
+      buildAsset({
+        id: 'release-2',
+        previewUrl: null,
+        assetKinds: ['artwork', 'lyrics', 'providers'],
+      }),
+      buildAsset({
+        id: 'merch-1',
+        itemKind: 'merch',
+        status: 'released',
+        providerCount: 0,
+        providers: [],
+      }),
+    ];
+
+    expect(countLibrarySavedViewMatches(assets, 'missing-audio')).toBe(1);
+    expect(countLibrarySavedViewMatches(assets, 'live-merch')).toBe(1);
+  });
+
+  it('persists the selected smart filter in localStorage', () => {
+    const storage = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+      removeItem: (key: string) => {
+        storage.delete(key);
+      },
+    });
+
+    persistLibrarySavedView('missing-audio');
+    expect(readPersistedLibrarySavedView()).toBe('missing-audio');
+    expect(storage.get(LIBRARY_SAVED_VIEW_STORAGE_KEY)).toBe('missing-audio');
+
+    persistLibrarySavedView('all');
+    expect(readPersistedLibrarySavedView()).toBe('all');
+    expect(storage.has(LIBRARY_SAVED_VIEW_STORAGE_KEY)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add production smart filter presets to the library sidebar rail
- Compose saved views with view chips, facet filters, and header search pills via AND
- Persist the selected smart filter in localStorage across visits

## Test plan
- [x] `pnpm --filter @jovie/web run typecheck -- --pretty false`
- [x] biome on edited files
- [x] focused vitest: `library-saved-views.test.ts`, `LibrarySurface.test.tsx`