### PR TITLE
train(chat): JOV-2930 persistent shell audio player

### DIFF
--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -54,8 +54,15 @@ export function PersistentAudioBar({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const designV1LyricsEnabled = useAppFlag('DESIGN_V1');
-  const { playbackState, toggleTrack, seek, stop, onError } =
-    useTrackAudioPlayer();
+  const {
+    playbackState,
+    toggleTrack,
+    playNext,
+    playPrevious,
+    seek,
+    stop,
+    onError,
+  } = useTrackAudioPlayer();
   const [imgError, setImgError] = useState(false);
   const [barCollapsed, setBarCollapsed] = useState(false);
   const [waveformOn, setWaveformOn] = useState(true);
@@ -387,6 +394,14 @@ export function PersistentAudioBar({
         <AudioBar
           isPlaying={playbackState.isPlaying}
           onPlay={handleToggle}
+          onPrevious={
+            playbackState.hasPrevious
+              ? () => playPrevious().catch(() => {})
+              : undefined
+          }
+          onNext={
+            playbackState.hasNext ? () => playNext().catch(() => {}) : undefined
+          }
           onCollapse={() => setBarCollapsed(true)}
           currentTime={playbackState.currentTime}
           duration={playbackState.duration}

--- a/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChevronRight, Pause, Play } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 import { DrawerEmptyState } from '@/components/molecules/drawer';
 import type { ReleaseSidebarTrack } from '@/lib/discography/types';
@@ -77,6 +77,29 @@ function getDisplayTrackLabel(params: {
   return getCanonicalTrackLabel(track);
 }
 
+function buildReleasePlaybackQueue(
+  tracks: readonly ReleaseSidebarTrack[],
+  release: Release
+): TrackControlSource[] {
+  return tracks.flatMap(track => {
+    const audioUrl = track.audioUrl ?? track.previewUrl ?? undefined;
+    if (!audioUrl) return [];
+
+    return [
+      {
+        id: track.id,
+        title: track.title,
+        audioUrl,
+        isrc: track.isrc,
+        releaseTitle: release.title,
+        artistName: release.artistNames?.[0],
+        artworkUrl: release.artworkUrl,
+        hasLyrics: Boolean(track.lyrics?.trim()),
+      },
+    ];
+  });
+}
+
 export function ReleaseTrackList({
   release,
   tracksOverride,
@@ -93,6 +116,10 @@ export function ReleaseTrackList({
     !tracksOverride && release.totalTracks > 0
   );
   const tracks = tracksOverride ?? fetchedTracks;
+  const playbackQueue = useMemo(
+    () => (tracks ? buildReleasePlaybackQueue(tracks, release) : []),
+    [release, tracks]
+  );
 
   let liveAnnouncement = '';
   if (playbackState.playbackStatus === 'error') {
@@ -174,6 +201,7 @@ export function ReleaseTrackList({
           })}
           release={release}
           playbackState={playbackState}
+          playbackQueue={playbackQueue}
           onToggleTrack={toggleTrack}
           isLastRow={index === tracks.length - 1}
           onSelect={
@@ -192,6 +220,7 @@ function TrackListRow({
   trackLabel,
   release,
   playbackState,
+  playbackQueue,
   onToggleTrack,
   isLastRow,
   onSelect,
@@ -204,7 +233,11 @@ function TrackListRow({
     isPlaying: boolean;
     playbackStatus?: 'idle' | 'loading' | 'playing' | 'paused' | 'error';
   };
-  readonly onToggleTrack: (track: TrackControlSource) => Promise<void>;
+  readonly playbackQueue: readonly TrackControlSource[];
+  readonly onToggleTrack: (
+    track: TrackControlSource,
+    options?: { queue?: readonly TrackControlSource[] }
+  ) => Promise<void>;
   readonly isLastRow: boolean;
   readonly onSelect?: () => void;
 }) {
@@ -229,21 +262,25 @@ function TrackListRow({
       return;
     }
 
-    onToggleTrack({
-      id: track.id,
-      title: track.title,
-      audioUrl: playableUrl,
-      isrc: track.isrc,
-      releaseTitle: release.title,
-      artistName: release.artistNames?.[0],
-      artworkUrl: release.artworkUrl,
-      hasLyrics: Boolean(track.lyrics?.trim()),
-    }).catch(() => {
+    onToggleTrack(
+      {
+        id: track.id,
+        title: track.title,
+        audioUrl: playableUrl,
+        isrc: track.isrc,
+        releaseTitle: release.title,
+        artistName: release.artistNames?.[0],
+        artworkUrl: release.artworkUrl,
+        hasLyrics: Boolean(track.lyrics?.trim()),
+      },
+      { queue: playbackQueue }
+    ).catch(() => {
       toast.error('Unable to play this track right now');
     });
   }, [
     isActiveTrack,
     onToggleTrack,
+    playbackQueue,
     playableUrl,
     release.artistNames,
     release.artworkUrl,

--- a/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
+++ b/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-interface AudioTrackSource {
+export interface AudioTrackSource {
   readonly id: string;
   readonly title: string;
   /** Required when loading a new track; omit when resuming the same track. */
@@ -13,6 +13,11 @@ interface AudioTrackSource {
   readonly artistName?: string;
   readonly artworkUrl?: string | null;
   readonly hasLyrics?: boolean;
+}
+
+export interface ToggleTrackOptions {
+  /** Ordered playable context for next/previous transport in the shell player. */
+  readonly queue?: readonly AudioTrackSource[];
 }
 
 interface PlaybackState {
@@ -31,6 +36,10 @@ interface PlaybackState {
   readonly artistName: string | null;
   readonly artworkUrl: string | null;
   readonly hasLyrics: boolean;
+  readonly queueLength: number;
+  readonly queueIndex: number;
+  readonly hasNext: boolean;
+  readonly hasPrevious: boolean;
 }
 
 let _audio: HTMLAudioElement | null = null;
@@ -40,6 +49,8 @@ let _playToken = 0;
 let _activeTrackIsrc: string | null = null;
 /** Whether we already attempted a preview URL refresh for this track. Prevents infinite retry loops. */
 let _hasRetriedRefresh = false;
+let _queue: readonly AudioTrackSource[] = [];
+let _queueIndex = -1;
 
 /** Lazily create the Audio element — safe to call during SSR (returns null server-side). */
 function getAudio(): HTMLAudioElement | null {
@@ -50,6 +61,46 @@ function getAudio(): HTMLAudioElement | null {
     bindAudioEvents(_audio);
   }
   return _audio;
+}
+
+function isPlayableTrack(track: AudioTrackSource): boolean {
+  return Boolean(track.audioUrl);
+}
+
+function getQueueSnapshot(): Pick<
+  PlaybackState,
+  'queueLength' | 'queueIndex' | 'hasNext' | 'hasPrevious'
+> {
+  return {
+    queueLength: _queue.length,
+    queueIndex: _queueIndex,
+    hasNext: _queueIndex >= 0 && _queueIndex < _queue.length - 1,
+    hasPrevious: _queueIndex > 0,
+  };
+}
+
+function setPlaybackQueue(
+  queue: readonly AudioTrackSource[] | undefined,
+  activeTrackId: string
+): void {
+  if (!queue || queue.length === 0) {
+    _queue = [];
+    _queueIndex = -1;
+    return;
+  }
+
+  _queue = queue.filter(isPlayableTrack);
+  _queueIndex = _queue.findIndex(track => track.id === activeTrackId);
+}
+
+function clearPlaybackQueue(): void {
+  _queue = [];
+  _queueIndex = -1;
+}
+
+function getQueueTrackAt(index: number): AudioTrackSource | null {
+  if (index < 0 || index >= _queue.length) return null;
+  return _queue[index] ?? null;
 }
 
 let state: PlaybackState = {
@@ -64,6 +115,10 @@ let state: PlaybackState = {
   artistName: null,
   artworkUrl: null,
   hasLyrics: false,
+  queueLength: 0,
+  queueIndex: -1,
+  hasNext: false,
+  hasPrevious: false,
 };
 
 const listeners = new Set<() => void>();
@@ -96,6 +151,7 @@ function handlePlaybackFailure(
     audio.pause();
     audio.src = '';
   }
+  clearPlaybackQueue();
   setState({
     activeTrackId: null,
     isPlaying: false,
@@ -108,8 +164,60 @@ function handlePlaybackFailure(
     artistName: null,
     artworkUrl: null,
     hasLyrics: false,
+    ...getQueueSnapshot(),
   });
   notifyPlaybackError(reason);
+}
+
+async function loadAndPlayTrack(track: AudioTrackSource): Promise<void> {
+  const audio = getAudio();
+  if (!audio) return;
+
+  if (!track.audioUrl) {
+    handlePlaybackFailure(audio, 'missing_source');
+    return;
+  }
+
+  const token = ++_playToken;
+  _activeTrackIsrc = track.isrc ?? null;
+  _hasRetriedRefresh = false;
+  audio.pause();
+  audio.src = track.audioUrl;
+  setState({
+    activeTrackId: track.id,
+    isPlaying: false,
+    playbackStatus: 'loading',
+    lastErrorReason: null,
+    currentTime: 0,
+    duration: 0,
+    trackTitle: track.title,
+    releaseTitle: track.releaseTitle ?? null,
+    artistName: track.artistName ?? null,
+    artworkUrl: track.artworkUrl ?? null,
+    hasLyrics: Boolean(track.hasLyrics),
+    ...getQueueSnapshot(),
+  });
+
+  try {
+    await audio.play();
+  } catch (error) {
+    if (_playToken === token) {
+      handlePlaybackFailure(audio, 'play_rejected');
+    }
+    throw error;
+  }
+
+  if (_playToken !== token) {
+    return;
+  }
+}
+
+async function advanceQueueToIndex(index: number): Promise<void> {
+  const track = getQueueTrackAt(index);
+  if (!track) return;
+
+  _queueIndex = index;
+  await loadAndPlayTrack(track);
 }
 
 function bindAudioEvents(el: HTMLAudioElement): void {
@@ -138,9 +246,21 @@ function bindAudioEvents(el: HTMLAudioElement): void {
       playbackStatus: state.activeTrackId ? 'paused' : 'idle',
     })
   );
-  el.addEventListener('ended', () =>
-    setState({ isPlaying: false, playbackStatus: 'paused', currentTime: 0 })
-  );
+  el.addEventListener('ended', () => {
+    const nextIndex = _queueIndex + 1;
+    const nextTrack = getQueueTrackAt(nextIndex);
+    if (nextTrack) {
+      void advanceQueueToIndex(nextIndex);
+      return;
+    }
+
+    setState({
+      isPlaying: false,
+      playbackStatus: 'paused',
+      currentTime: 0,
+      ...getQueueSnapshot(),
+    });
+  });
   el.addEventListener('loadedmetadata', () => {
     setState({
       duration: Number.isFinite(el.duration) ? el.duration : 0,
@@ -217,61 +337,45 @@ export function useTrackAudioPlayer() {
     };
   }, []);
 
-  const toggleTrack = useCallback(async (track: AudioTrackSource) => {
-    const audio = getAudio();
-    if (!audio) return;
+  const toggleTrack = useCallback(
+    async (track: AudioTrackSource, options?: ToggleTrackOptions) => {
+      const audio = getAudio();
+      if (!audio) return;
 
-    // Same track — toggle pause/resume
-    if (state.activeTrackId === track.id) {
-      if (audio.paused) {
-        try {
-          await audio.play();
-        } catch (error) {
-          handlePlaybackFailure(audio, 'play_rejected');
-          throw error;
+      // Same track — toggle pause/resume
+      if (state.activeTrackId === track.id) {
+        if (audio.paused) {
+          try {
+            await audio.play();
+          } catch (error) {
+            handlePlaybackFailure(audio, 'play_rejected');
+            throw error;
+          }
+        } else {
+          audio.pause();
         }
-      } else {
-        audio.pause();
+        return;
       }
-      return;
-    }
 
-    // New track — cancel any in-flight play() from a prior switch
-    if (!track.audioUrl) {
-      handlePlaybackFailure(audio, 'missing_source');
-      return;
-    }
-    const token = ++_playToken;
-    _activeTrackIsrc = track.isrc ?? null;
-    _hasRetriedRefresh = false;
-    audio.pause();
-    audio.src = track.audioUrl;
-    setState({
-      activeTrackId: track.id,
-      isPlaying: false,
-      playbackStatus: 'loading',
-      lastErrorReason: null,
-      currentTime: 0,
-      duration: 0,
-      trackTitle: track.title,
-      releaseTitle: track.releaseTitle ?? null,
-      artistName: track.artistName ?? null,
-      artworkUrl: track.artworkUrl ?? null,
-      hasLyrics: Boolean(track.hasLyrics),
-    });
-    try {
-      await audio.play();
-    } catch (error) {
-      if (_playToken === token) {
-        handlePlaybackFailure(audio, 'play_rejected');
+      if (options?.queue) {
+        setPlaybackQueue(options.queue, track.id);
+      } else {
+        clearPlaybackQueue();
       }
-      throw error;
-    }
-    // Another toggle fired while this play() was in-flight. The newer call owns
-    // the shared audio element now, so avoid pausing here.
-    if (_playToken !== token) {
-      return;
-    }
+
+      await loadAndPlayTrack(track);
+    },
+    []
+  );
+
+  const playNext = useCallback(async () => {
+    if (!state.hasNext) return;
+    await advanceQueueToIndex(_queueIndex + 1);
+  }, []);
+
+  const playPrevious = useCallback(async () => {
+    if (!state.hasPrevious) return;
+    await advanceQueueToIndex(_queueIndex - 1);
   }, []);
 
   const seek = useCallback((time: number) => {
@@ -289,6 +393,7 @@ export function useTrackAudioPlayer() {
       audio.pause();
       audio.src = '';
     }
+    clearPlaybackQueue();
     setState({
       activeTrackId: null,
       isPlaying: false,
@@ -301,6 +406,7 @@ export function useTrackAudioPlayer() {
       artistName: null,
       artworkUrl: null,
       hasLyrics: false,
+      ...getQueueSnapshot(),
     });
   }, []);
 
@@ -317,6 +423,8 @@ export function useTrackAudioPlayer() {
   return {
     playbackState,
     toggleTrack,
+    playNext,
+    playPrevious,
     seek,
     stop,
     onError,

--- a/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
+++ b/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
@@ -21,6 +21,8 @@ import { AppFlagProvider } from '@/lib/flags/client';
 import { APP_FLAG_DEFAULTS } from '@/lib/flags/contracts';
 
 const toggleTrack = vi.fn().mockResolvedValue(undefined);
+const playNext = vi.fn().mockResolvedValue(undefined);
+const playPrevious = vi.fn().mockResolvedValue(undefined);
 const stop = vi.fn();
 const seek = vi.fn();
 const onError = vi.fn().mockReturnValue(() => {});
@@ -44,6 +46,10 @@ const basePlaybackState = {
   artistName: null as string | null,
   artworkUrl: null as string | null,
   hasLyrics: false,
+  queueLength: 0,
+  queueIndex: -1,
+  hasNext: false,
+  hasPrevious: false,
 };
 
 type MockPlaybackState = typeof basePlaybackState;
@@ -53,6 +59,8 @@ vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
   useTrackAudioPlayer: () => ({
     playbackState: mockPlaybackState,
     toggleTrack,
+    playNext,
+    playPrevious,
     seek,
     stop,
     onError,
@@ -119,6 +127,8 @@ function setPlaying(overrides: Partial<MockPlaybackState> = {}) {
 describe('PersistentAudioBar', () => {
   beforeEach(() => {
     toggleTrack.mockClear();
+    playNext.mockClear();
+    playPrevious.mockClear();
     stop.mockClear();
     seek.mockClear();
     onError.mockClear().mockReturnValue(() => {});
@@ -291,6 +301,40 @@ describe('PersistentAudioBar', () => {
       'aria-hidden',
       'true'
     );
+  });
+
+  it('wires shell V1 queue transport to the shared audio player', async () => {
+    const user = userEvent.setup();
+    setPlaying({
+      artistName: 'DJ Cool',
+      hasNext: true,
+      hasPrevious: true,
+      queueLength: 3,
+      queueIndex: 1,
+    });
+
+    render(<PersistentAudioBar variant='shellChatV1' />);
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await user.click(screen.getByRole('button', { name: 'Previous' }));
+
+    expect(playNext).toHaveBeenCalledTimes(1);
+    expect(playPrevious).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides shell V1 queue transport when the queue has no neighbors', () => {
+    setPlaying({
+      artistName: 'DJ Cool',
+      hasNext: false,
+      hasPrevious: false,
+      queueLength: 1,
+      queueIndex: 0,
+    });
+
+    render(<PersistentAudioBar variant='shellChatV1' />);
+
+    expect(screen.queryByRole('button', { name: 'Next' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Previous' })).toBeNull();
   });
 
   it('wires shell V1 waveform seeking to the shared audio player', () => {

--- a/apps/web/tests/components/organisms/release-sidebar/ReleaseTrackList.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/ReleaseTrackList.test.tsx
@@ -196,7 +196,7 @@ describe('ReleaseTrackList', () => {
 
     await user.click(screen.getByRole('button', { name: 'Play Static Skies' }));
 
-    expect(mockToggleTrack).toHaveBeenCalledWith({
+    const expectedTrack = {
       id: 'track_1',
       title: 'Static Skies',
       audioUrl: 'https://example.com/preview.mp3',
@@ -205,6 +205,10 @@ describe('ReleaseTrackList', () => {
       artistName: release.artistNames?.[0],
       artworkUrl: release.artworkUrl,
       hasLyrics: false,
+    };
+
+    expect(mockToggleTrack).toHaveBeenCalledWith(expectedTrack, {
+      queue: [expectedTrack],
     });
   });
 

--- a/apps/web/tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts
+++ b/apps/web/tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts
@@ -225,6 +225,83 @@ describe('useTrackAudioPlayer', () => {
     expect(result.current.playbackState.activeTrackId).toBe('track-1');
   });
 
+  it('stores queue metadata and advances to the next queued track on ended', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+
+    const queue = [
+      {
+        id: 'track-1',
+        title: 'First Song',
+        audioUrl: 'https://cdn.example.com/first.mp3',
+      },
+      {
+        id: 'track-2',
+        title: 'Second Song',
+        audioUrl: 'https://cdn.example.com/second.mp3',
+      },
+    ];
+
+    await act(async () => {
+      await result.current.toggleTrack(queue[0], { queue });
+    });
+    act(() => {
+      fireAudioEvent('play');
+    });
+
+    expect(result.current.playbackState.queueLength).toBe(2);
+    expect(result.current.playbackState.queueIndex).toBe(0);
+    expect(result.current.playbackState.hasNext).toBe(true);
+    expect(result.current.playbackState.hasPrevious).toBe(false);
+
+    await act(async () => {
+      fireAudioEvent('ended');
+    });
+
+    expect(result.current.playbackState.activeTrackId).toBe('track-2');
+    expect(result.current.playbackState.trackTitle).toBe('Second Song');
+    expect(result.current.playbackState.queueIndex).toBe(1);
+    expect(result.current.playbackState.hasNext).toBe(false);
+    expect(result.current.playbackState.hasPrevious).toBe(true);
+    expect(mockAudio.src).toBe('https://cdn.example.com/second.mp3');
+  });
+
+  it('moves to the previous queued track when playPrevious is called', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+
+    const queue = [
+      {
+        id: 'track-1',
+        title: 'First Song',
+        audioUrl: 'https://cdn.example.com/first.mp3',
+      },
+      {
+        id: 'track-2',
+        title: 'Second Song',
+        audioUrl: 'https://cdn.example.com/second.mp3',
+      },
+    ];
+
+    await act(async () => {
+      await result.current.toggleTrack(queue[1], { queue });
+    });
+    act(() => {
+      fireAudioEvent('play');
+    });
+
+    expect(result.current.playbackState.activeTrackId).toBe('track-2');
+    expect(result.current.playbackState.hasPrevious).toBe(true);
+
+    await act(async () => {
+      await result.current.playPrevious();
+    });
+
+    expect(result.current.playbackState.activeTrackId).toBe('track-1');
+    expect(result.current.playbackState.trackTitle).toBe('First Song');
+    expect(mockAudio.src).toBe('https://cdn.example.com/first.mp3');
+  });
+
   it('resets state and notifies listeners when play() rejects', async () => {
     nextPlayMock = vi.fn().mockRejectedValue(new Error('Playback blocked'));
 


### PR DESCRIPTION
Integration train PR — batches agent work landed on `integration/loop-chat`. Full CI runs once for the batch.

<!-- linear-issue-id:loop-train -->
<!-- linear-issue-identifier:LOOP-TRAIN -->

## Included work
See commits on integration/loop-chat since main.

## Ship validation
- [ ] CI fast gate + unit tests
- [ ] Add `testing` label if auth/billing/migrations touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio player now includes Previous and Next buttons to navigate between tracks in releases and albums. Buttons appear only when adjacent tracks are available.
  * Tracks automatically advance to the next song in the queue when playback finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->