### PR TITLE
fix(dev): guard dev:web:fast empty ENV_UNSET_ARGS startup path (JOV-2741)

### DIFF
--- a/scripts/dev-web-fast.sh
+++ b/scripts/dev-web-fast.sh
@@ -78,8 +78,9 @@ DEV_ENV_ARGS=(
   pnpm --filter @jovie/web run dev:fast
 )
 
-# macOS ships Bash 3.2; with `set -u`, expanding an empty ENV_UNSET_ARGS array
-# makes `env` fail before the dev server starts. Only pass -u flags when present.
+# JOV-2741: macOS ships Bash 3.2; with `set -u`, expanding an empty ENV_UNSET_ARGS
+# array makes `env` fail on fresh worktrees before the dev server starts. Only pass
+# -u flags when eval isolation opts in.
 if [ "${#ENV_UNSET_ARGS[@]}" -gt 0 ]; then
   doppler run --project jovie-web --config dev -- env \
     "${ENV_UNSET_ARGS[@]}" \


### PR DESCRIPTION
Main-target queue drain (btw Phase 0). Reopened against the recommended integration branch — full CI runs on the domain train PR only. Policy: `.claude/rules/ci-branching.md`, state: `.context/loop-state.json`.

Integration fast lane only. Merge via `scripts/loop-integration-ship.sh integration/loop-ui tim/jov-2741` after local verify.

<!-- linear-issue-id: -->