### PR TITLE
fix(ui): reuse shared pill close button styles in Dialog (JOV-2821)

### DIFF
--- a/packages/ui/atoms/close-button.test.tsx
+++ b/packages/ui/atoms/close-button.test.tsx
@@ -100,4 +100,11 @@ describe('closeButtonClassName', () => {
     expect(closeButtonClassName).toContain('disabled:pointer-events-none');
     expect(closeButtonClassName).toContain('ring-offset-(--linear-bg-page)');
   });
+
+  it('uses the shared pill close button shape', () => {
+    expect(closeButtonClassName).toContain('rounded-full');
+    expect(closeButtonClassName).not.toContain(
+      'rounded-(--linear-app-radius-item)'
+    );
+  });
 });


### PR DESCRIPTION
## Summary
Lock shared pill close button contract at helper level with test assertions for rounded-full styling.

## Changes
- Add closeButtonClassName assertions in close-button.test.tsx
- Dialog already reuses shared helper; this enforces contract at source

## Testing
- biome check packages/ui/atoms/close-button.test.tsx
- vitest: close-button.test.tsx, dialog.test.tsx (38 tests pass)

Linear: JOV-2821