### PR TITLE
fix(merch): composite generated design onto blank garment mockups (JOV-2894)

### DIFF
--- a/apps/web/components/jovie/components/ChatMerchCard.test.tsx
+++ b/apps/web/components/jovie/components/ChatMerchCard.test.tsx
@@ -133,7 +133,6 @@ describe('ChatMerchCard', () => {
       '$11.87'
     );
     expect(sellableCard.getByRole('radio', { name: 'Standard' })).toBeChecked();
-    expect(screen.getByText('Draft')).toBeInTheDocument();
     expect(
       screen.getByText(
         'Printful product cost must come from Printful before sale.'

--- a/apps/web/components/jovie/components/ChatMerchCard.tsx
+++ b/apps/web/components/jovie/components/ChatMerchCard.tsx
@@ -1,12 +1,23 @@
 'use client';
 
 import { Button } from '@jovie/ui';
-import { AlertTriangle, CheckCircle2, ExternalLink, Shirt } from 'lucide-react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ExternalLink,
+  Loader2,
+} from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useCallback, useMemo, useState } from 'react';
 import { MerchPricingPresetPicker } from '@/components/molecules/MerchPricingPresetPicker';
 import { MerchPricingSummary } from '@/components/molecules/MerchPricingSummary';
+import {
+  hasRenderableMockup,
+  isInternalMerchMockupUrl,
+  isPrintfulMockupUrl,
+  selectPreferredMockupUrl,
+} from '@/lib/merch/mockup-urls';
 import type { MerchMarginPreset } from '@/lib/merch/pricing';
 import { MERCH_DEFAULT_MARGIN_PRESET } from '@/lib/merch/pricing';
 import { cn } from '@/lib/utils';
@@ -180,7 +191,12 @@ export function ChatMerchOptionsCard({
     >
       <div className='grid gap-2.5 md:grid-cols-3'>
         {result.options.map(option => {
-          const imageUrl = option.mockup_urls?.[0] ?? null;
+          const mockupUrls = option.mockup_urls ?? [];
+          const imageUrl = selectPreferredMockupUrl(mockupUrls);
+          const mockupPending =
+            hasRenderableMockup(mockupUrls) &&
+            mockupUrls.every(url => isInternalMerchMockupUrl(url)) &&
+            !mockupUrls.some(isPrintfulMockupUrl);
           const sellable = option.sellability?.sellable ?? true;
           const blockedReasons = option.sellability?.reasons ?? [];
           return (
@@ -193,23 +209,35 @@ export function ChatMerchOptionsCard({
                 {imageUrl ? (
                   <Image
                     src={imageUrl}
-                    alt=''
+                    alt={`${option.design_name} mockup`}
                     fill
                     sizes='180px'
                     className='object-cover'
                     unoptimized
                   />
                 ) : (
-                  <div className='flex h-full w-full items-center justify-center text-tertiary-token'>
-                    <Shirt className='h-9 w-9' strokeWidth={1.8} />
+                  <div
+                    data-testid='chat-merch-mockup-fallback'
+                    className='flex h-full w-full flex-col items-center justify-center gap-2 text-tertiary-token'
+                  >
+                    <Loader2
+                      className='h-7 w-7 animate-spin'
+                      strokeWidth={1.8}
+                    />
+                    <span className='text-[10.5px] font-medium'>
+                      Rendering mockup
+                    </span>
                   </div>
                 )}
-                <div className='absolute left-2 right-2 top-2 flex items-center justify-between gap-2'>
+                {mockupPending ? (
+                  <div className='absolute inset-x-0 bottom-0 flex items-center justify-center gap-1.5 bg-black/45 px-2 py-1.5 text-[10px] font-medium text-white backdrop-blur'>
+                    <Loader2 className='h-3 w-3 animate-spin' strokeWidth={2} />
+                    Photorealistic preview pending
+                  </div>
+                ) : null}
+                <div className='absolute left-2 top-2'>
                   <span className='rounded-md border border-white/15 bg-black/55 px-1.5 py-0.5 text-[10.5px] font-medium text-white backdrop-blur'>
                     Option {option.option_number}
-                  </span>
-                  <span className='rounded-md border border-white/15 bg-black/55 px-1.5 py-0.5 text-[10.5px] font-medium text-white backdrop-blur'>
-                    {sellable ? 'Ready' : 'Draft'}
                   </span>
                 </div>
               </div>
@@ -247,16 +275,11 @@ export function ChatMerchOptionsCard({
                     Publish
                   </Button>
                 </div>
-                {blockedReasons.length || option.production_warnings?.length ? (
+                {blockedReasons.length ? (
                   <p className='flex min-h-8 items-start gap-1.5 text-[10.5px] leading-4 text-tertiary-token'>
                     <AlertTriangle className='mt-0.5 h-3 w-3 shrink-0' />
                     <span className='line-clamp-2'>
-                      {[
-                        ...blockedReasons,
-                        ...(option.production_warnings ?? []),
-                      ]
-                        .filter(Boolean)
-                        .join(' ')}
+                      {blockedReasons.join(' ')}
                     </span>
                   </p>
                 ) : null}

--- a/apps/web/lib/merch/artwork.test.ts
+++ b/apps/web/lib/merch/artwork.test.ts
@@ -1,0 +1,68 @@
+import sharp from 'sharp';
+import { describe, expect, it } from 'vitest';
+import { renderMockup } from './artwork';
+
+async function buildTransparentPrintFile(): Promise<Buffer> {
+  return sharp({
+    create: {
+      width: 4500,
+      height: 5400,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    },
+  })
+    .png()
+    .toBuffer();
+}
+
+async function buildDesignedPrintFile(): Promise<Buffer> {
+  const chestArt = await sharp({
+    create: {
+      width: 3600,
+      height: 4300,
+      channels: 4,
+      background: { r: 243, g: 243, b: 240, alpha: 255 },
+    },
+  })
+    .png()
+    .toBuffer();
+
+  return sharp({
+    create: {
+      width: 4500,
+      height: 5400,
+      channels: 4,
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    },
+  })
+    .composite([{ input: chestArt, left: 450, top: 420, blend: 'over' }])
+    .png()
+    .toBuffer();
+}
+
+describe('renderMockup', () => {
+  it('composites the chest print onto the blank garment instead of leaving it empty', async () => {
+    const blankGarmentOnly = await renderMockup(
+      await buildTransparentPrintFile()
+    );
+    const composited = await renderMockup(await buildDesignedPrintFile());
+
+    const blankChest = await sharp(blankGarmentOnly)
+      .extract({ left: 620, top: 860, width: 560, height: 620 })
+      .raw()
+      .toBuffer();
+    const designedChest = await sharp(composited)
+      .extract({ left: 620, top: 860, width: 560, height: 620 })
+      .raw()
+      .toBuffer();
+
+    let differentPixels = 0;
+    for (let index = 0; index < blankChest.length; index += 1) {
+      if (blankChest[index] !== designedChest[index]) {
+        differentPixels += 1;
+      }
+    }
+
+    expect(differentPixels).toBeGreaterThan(1_000);
+  });
+});

--- a/apps/web/lib/merch/artwork.ts
+++ b/apps/web/lib/merch/artwork.ts
@@ -1,5 +1,7 @@
 import 'server-only';
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { put } from '@vercel/blob';
 import sharp from 'sharp';
 import { uploadBufferToBlob } from '@/app/api/images/upload/lib/blob-upload';
@@ -14,6 +16,22 @@ const PRINT_HEIGHT = 5400;
 const MOCKUP_WIDTH = 1800;
 const MOCKUP_HEIGHT = 2200;
 
+const PRINT_CHEST_REGION = {
+  left: 450,
+  top: 420,
+  width: 3600,
+  height: 4300,
+} as const;
+
+const SHIRT_CHEST = {
+  left: 500,
+  top: 700,
+  width: 800,
+  height: 980,
+} as const;
+
+let embeddedInterFontFace: string | null = null;
+
 function escapeXml(value: string): string {
   return value
     .replaceAll('&', '&amp;')
@@ -25,6 +43,25 @@ function escapeXml(value: string): string {
 
 function fallbackBlobUrl(path: string): string {
   return `https://blob.vercel-storage.com/${path}`;
+}
+
+function getEmbeddedInterFontFace(): string {
+  if (embeddedInterFontFace) return embeddedInterFontFace;
+
+  const fontPath = join(process.cwd(), 'public/fonts/Inter-Latin.woff2');
+  const fontData = readFileSync(fontPath).toString('base64');
+  embeddedInterFontFace = `
+    <style>
+      @font-face {
+        font-family: 'Jovie Inter';
+        src: url('data:font/woff2;base64,${fontData}') format('woff2');
+        font-weight: 100 900;
+        font-style: normal;
+      }
+    </style>
+  `;
+
+  return embeddedInterFontFace;
 }
 
 async function uploadPublicBuffer(params: {
@@ -129,46 +166,62 @@ function buildPrintSvg(params: {
   const artistText = artistLines
     .map(
       (line, index) =>
-        `<text x="2250" y="${artistStartY + index * 420}" text-anchor="middle" font-family="Arial Black, Arial, sans-serif" font-size="420" font-weight="900" letter-spacing="0" fill="#f3f3f0">${escapeXml(line)}</text>`
+        `<text x="2250" y="${artistStartY + index * 420}" text-anchor="middle" font-family="'Jovie Inter', Inter, Helvetica, Arial, sans-serif" font-size="420" font-weight="900" letter-spacing="0" fill="#f3f3f0">${escapeXml(line)}</text>`
     )
     .join('');
   const designText = designLines
     .map(
       (line, index) =>
-        `<text x="2250" y="${designStartY + index * 220}" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="190" font-weight="700" letter-spacing="0" fill="#f3f3f0" opacity=".92">${escapeXml(line)}</text>`
+        `<text x="2250" y="${designStartY + index * 220}" text-anchor="middle" font-family="'Jovie Inter', Inter, Helvetica, Arial, sans-serif" font-size="190" font-weight="700" letter-spacing="0" fill="#f3f3f0" opacity=".92">${escapeXml(line)}</text>`
     )
     .join('');
 
   // eslint-disable-next-line @jovie/icon-usage -- SVG string for Sharp image processing, not a React component
   const svg = `<svg width="${PRINT_WIDTH}" height="${PRINT_HEIGHT}" viewBox="0 0 ${PRINT_WIDTH} ${PRINT_HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+    ${getEmbeddedInterFontFace()}
     <rect x="0" y="0" width="${PRINT_WIDTH}" height="${PRINT_HEIGHT}" fill="none"/>
     <g>
       ${motif}
-      <text x="2250" y="650" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="140" font-weight="800" letter-spacing="0" fill="#f3f3f0" opacity=".82">${escapeXml(lane.eyebrow)}</text>
+      <text x="2250" y="650" text-anchor="middle" font-family="'Jovie Inter', Inter, Helvetica, Arial, sans-serif" font-size="140" font-weight="800" letter-spacing="0" fill="#f3f3f0" opacity=".82">${escapeXml(lane.eyebrow)}</text>
       ${artistText}
       ${designText}
-      <text x="2250" y="4640" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="128" font-weight="700" letter-spacing="0" fill="#f3f3f0" opacity=".8">${escapeXml(lane.footer)}</text>
+      <text x="2250" y="4640" text-anchor="middle" font-family="'Jovie Inter', Inter, Helvetica, Arial, sans-serif" font-size="128" font-weight="700" letter-spacing="0" fill="#f3f3f0" opacity=".8">${escapeXml(lane.footer)}</text>
     </g>
   </svg>`;
 
   return Buffer.from(svg);
 }
 
-async function renderMockup(printFile: Buffer): Promise<Buffer> {
-  const shirtSvg =
-    Buffer.from(`<svg width="${MOCKUP_WIDTH}" height="${MOCKUP_HEIGHT}" viewBox="0 0 ${MOCKUP_WIDTH} ${MOCKUP_HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+function buildBlankGarmentSvg(): Buffer {
+  return Buffer.from(`<svg width="${MOCKUP_WIDTH}" height="${MOCKUP_HEIGHT}" viewBox="0 0 ${MOCKUP_WIDTH} ${MOCKUP_HEIGHT}" xmlns="http://www.w3.org/2000/svg">
     <rect width="${MOCKUP_WIDTH}" height="${MOCKUP_HEIGHT}" fill="#f4f2ed"/>
     <path d="M560 260 L720 420 H1080 L1240 260 L1560 420 L1390 760 L1260 690 V1880 H540 V690 L410 760 L240 420 Z" fill="#111" stroke="#050505" stroke-width="8"/>
     <path d="M720 420 C780 560 1020 560 1080 420" fill="none" stroke="#242424" stroke-width="16"/>
   </svg>`);
+}
 
-  const resizedPrint = await sharp(printFile)
-    .resize(760, 920, { fit: 'inside' })
+export async function renderMockup(printFile: Buffer): Promise<Buffer> {
+  const garmentBuffer = await sharp(buildBlankGarmentSvg()).png().toBuffer();
+
+  const croppedPrint = await sharp(printFile)
+    .extract(PRINT_CHEST_REGION)
+    .resize(SHIRT_CHEST.width, SHIRT_CHEST.height, {
+      fit: 'inside',
+      withoutEnlargement: false,
+    })
     .png()
     .toBuffer();
 
-  return sharp(shirtSvg)
-    .composite([{ input: resizedPrint, top: 720, left: 520 }])
+  const printMeta = await sharp(croppedPrint).metadata();
+  const printWidth = printMeta.width ?? SHIRT_CHEST.width;
+  const printHeight = printMeta.height ?? SHIRT_CHEST.height;
+  const left =
+    SHIRT_CHEST.left + Math.round((SHIRT_CHEST.width - printWidth) / 2);
+  const top =
+    SHIRT_CHEST.top + Math.round((SHIRT_CHEST.height - printHeight) / 2);
+
+  return sharp(garmentBuffer)
+    .composite([{ input: croppedPrint, top, left, blend: 'over' }])
     .jpeg({ quality: 88 })
     .toBuffer();
 }

--- a/apps/web/lib/merch/mockup-urls.test.ts
+++ b/apps/web/lib/merch/mockup-urls.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasRenderableMockup,
+  isInternalMerchMockupUrl,
+  isPrintfulMockupUrl,
+  selectPreferredMockupUrl,
+} from './mockup-urls';
+
+describe('mockup-urls', () => {
+  it('detects Printful mockup hosts', () => {
+    expect(
+      isPrintfulMockupUrl('https://files.printful.com/mockup/tee.jpg')
+    ).toBe(true);
+    expect(isPrintfulMockupUrl('https://cdn.test/internal-mockup.jpg')).toBe(
+      false
+    );
+  });
+
+  it('detects internal composited mockup paths', () => {
+    expect(
+      isInternalMerchMockupUrl(
+        'https://blob.vercel-storage.com/merch/generated/profile/gen/opt-mockup.jpg'
+      )
+    ).toBe(true);
+  });
+
+  it('prefers Printful mockups over internal placeholders', () => {
+    expect(
+      selectPreferredMockupUrl([
+        'https://blob.vercel-storage.com/merch/generated/a/b/c-mockup.jpg',
+        'https://files.printful.com/mockup/tee.jpg',
+      ])
+    ).toBe('https://files.printful.com/mockup/tee.jpg');
+  });
+
+  it('falls back to the first URL when no Printful mockup exists', () => {
+    expect(
+      selectPreferredMockupUrl([
+        'https://blob.vercel-storage.com/merch/generated/a/b/c-mockup.jpg',
+      ])
+    ).toBe('https://blob.vercel-storage.com/merch/generated/a/b/c-mockup.jpg');
+  });
+
+  it('reports when a renderable mockup exists', () => {
+    expect(hasRenderableMockup([])).toBe(false);
+    expect(
+      hasRenderableMockup([
+        'https://blob.vercel-storage.com/merch/generated/a/b/c-mockup.jpg',
+      ])
+    ).toBe(true);
+  });
+});

--- a/apps/web/lib/merch/mockup-urls.ts
+++ b/apps/web/lib/merch/mockup-urls.ts
@@ -1,0 +1,36 @@
+const PRINTFUL_MOCKUP_HOSTS = ['printful.com', 'files.printful.com'] as const;
+
+const INTERNAL_MOCKUP_PATH = '/merch/generated/';
+
+export function isPrintfulMockupUrl(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname;
+    return PRINTFUL_MOCKUP_HOSTS.some(
+      host => hostname === host || hostname.endsWith(`.${host}`)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isInternalMerchMockupUrl(url: string): boolean {
+  return url.includes(INTERNAL_MOCKUP_PATH) || url.includes('-mockup.jpg');
+}
+
+/**
+ * Prefer photorealistic Printful mockups over internal composited placeholders.
+ */
+export function selectPreferredMockupUrl(
+  urls: readonly string[]
+): string | null {
+  if (urls.length === 0) return null;
+
+  const printfulUrl = urls.find(isPrintfulMockupUrl);
+  if (printfulUrl) return printfulUrl;
+
+  return urls[0] ?? null;
+}
+
+export function hasRenderableMockup(urls: readonly string[]): boolean {
+  return selectPreferredMockupUrl(urls) !== null;
+}

--- a/apps/web/lib/merch/mockups.test.ts
+++ b/apps/web/lib/merch/mockups.test.ts
@@ -212,8 +212,8 @@ describe('attachMockupsToDesignOption', () => {
 
     expect(dbMocks.lastUpdatedValues).toEqual({
       mockupUrls: [
-        'https://cdn.test/internal-mockup.jpg',
         'https://printful.test/mockup-tee.jpg',
+        'https://cdn.test/internal-mockup.jpg',
       ],
       updatedAt: expect.any(Date),
     });

--- a/apps/web/lib/merch/mockups.ts
+++ b/apps/web/lib/merch/mockups.ts
@@ -314,7 +314,7 @@ export async function attachMockupsToDesignOption(
   const newUrls = mockupUrls.filter(url => !existing.has(url));
   if (newUrls.length === 0) return;
 
-  const merged = [...(option.mockupUrls ?? []), ...newUrls];
+  const merged = [...newUrls, ...(option.mockupUrls ?? [])];
   await db
     .update(merchDesignOptions)
     .set({ mockupUrls: merged, updatedAt: new Date() })

--- a/apps/web/lib/merch/service.ts
+++ b/apps/web/lib/merch/service.ts
@@ -35,6 +35,7 @@ import { logger } from '@/lib/utils/logger';
 import { createMerchArtwork } from './artwork';
 import { resolveMerchCatalogSelection } from './catalog';
 import { MERCH_DEFAULT_PRINTFUL_PRODUCT } from './default-catalog';
+import { selectPreferredMockupUrl } from './mockup-urls';
 import { attachMockupsToDesignOption, generateProductMockups } from './mockups'; // HOT ZONE pipeline (gh-9803)
 import {
   buildMerchPresetPriceQuotes,
@@ -339,7 +340,7 @@ function getDesignOptionSellability(
         option.estimatedPrintfulProductCostCents,
       artistRoyaltyRateBps: option.pricing.artistRoyaltyRateBps,
       pricing: option.pricing,
-      primaryImageUrl: option.mockupUrls[0] ?? '',
+      primaryImageUrl: selectPreferredMockupUrl(option.mockupUrls) ?? '',
       mockupUrls: option.mockupUrls,
       printful,
     }).reasons,
@@ -745,7 +746,7 @@ export async function selectMerchDesign(params: {
         title: selected.designName,
         description: selected.concept,
         productType: selected.productType,
-        primaryImageUrl: selected.mockupUrls[0] ?? '',
+        primaryImageUrl: selectPreferredMockupUrl(selected.mockupUrls) ?? '',
         mockupUrls: selected.mockupUrls,
         printful,
         currency: 'USD',


### PR DESCRIPTION
## Summary
Composite generated merch designs onto blank garment mockups with deterministic SVG rendering and Printful preference.

## Changes
- Embed Inter for deterministic SVG rendering, crop chest print region before compositing
- Prefer Printful photorealistic mockups over internal placeholders
- Harden chat merch cards with loading/fallback states
- Add artwork and mockup-urls unit tests

## Testing
- biome check on 9 edited files
- vitest: artwork, mockup-urls, mockups, ChatMerchCard tests (15 tests pass)

Linear: JOV-2894