### PR TITLE
fix(auth): resolve native exchange Not Found via backend Clerk client (JOV-2771)

### DIFF
--- a/apps/web/app/api/auth/native/exchange/route.ts
+++ b/apps/web/app/api/auth/native/exchange/route.ts
@@ -80,8 +80,19 @@ function isNotFoundError(error: unknown): boolean {
     return false;
   }
 
-  const record = error as { status?: unknown; statusCode?: unknown };
-  return record.status === 404 || record.statusCode === 404;
+  const record = error as {
+    status?: unknown;
+    statusCode?: unknown;
+    message?: unknown;
+  };
+  if (record.status === 404 || record.statusCode === 404) {
+    return true;
+  }
+
+  return (
+    typeof record.message === 'string' &&
+    record.message.toLowerCase().includes('not found')
+  );
 }
 
 function hasClerkErrorCode(error: unknown, code: string): boolean {

--- a/apps/web/lib/auth/clerk-middleware-bypass.ts
+++ b/apps/web/lib/auth/clerk-middleware-bypass.ts
@@ -46,6 +46,7 @@ const AUTHENTICATED_API_PREFIXES = [
 ] as const;
 
 const PUBLIC_API_EXACT_PATHS = [
+  '/api/auth/native/exchange',
   '/api/profile/view',
   '/api/stripe/pricing-options',
 ] as const;

--- a/apps/web/lib/auth/request-clerk-client.ts
+++ b/apps/web/lib/auth/request-clerk-client.ts
@@ -20,27 +20,22 @@ export function getRequestHostname(request: Request): string {
   );
 }
 
-function createStagingClerkClient(hostname: string): ClerkClient {
-  const keys = resolveClerkKeys(hostname);
-  if (!keys.secretKey) {
-    throw new Error(`Staging Clerk secret unavailable: ${keys.status}`);
-  }
-
-  return createClerkClient({
-    publishableKey: keys.publishableKey,
-    secretKey: keys.secretKey,
-  }) as ClerkClient;
-}
-
 export async function getRequestClerkClient(
   request: Request
 ): Promise<ClerkClient> {
   const hostname = getRequestHostname(request);
-  if (!isStagingHost(hostname)) {
-    return clerkClient();
+  const keys = resolveClerkKeys(hostname);
+  if (!keys.secretKey) {
+    const prefix = isStagingHost(hostname) ? 'Staging Clerk' : 'Clerk';
+    throw new Error(`${prefix} secret unavailable: ${keys.status}`);
   }
 
-  return createStagingClerkClient(hostname);
+  // Native exchange and other server routes that bypass Clerk middleware must
+  // not depend on clerkClient() from @clerk/nextjs/server.
+  return createClerkClient({
+    publishableKey: keys.publishableKey,
+    secretKey: keys.secretKey,
+  }) as ClerkClient;
 }
 
 /**

--- a/apps/web/tests/unit/api/auth/native-exchange.test.ts
+++ b/apps/web/tests/unit/api/auth/native-exchange.test.ts
@@ -110,6 +110,8 @@ describe('POST /api/auth/native/exchange', () => {
     vi.clearAllMocks();
     vi.resetModules();
     vi.unstubAllEnvs();
+    vi.stubEnv('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY', 'pk_live_production');
+    vi.stubEnv('CLERK_SECRET_KEY', 'sk_live_production');
 
     mockCaptureError.mockResolvedValue(undefined);
     mockCreateAuthAnalyticsEvent.mockReturnValue({});
@@ -274,6 +276,55 @@ describe('POST /api/auth/native/exchange', () => {
       expiresInSeconds: 60,
     });
     expect(mockSessionsGetToken).not.toHaveBeenCalled();
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+
+  it('uses production Clerk keys for iOS native exchange on production hosts', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('VERCEL_ENV', 'production');
+    vi.stubEnv('NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY', 'pk_live_production');
+    vi.stubEnv('CLERK_SECRET_KEY', 'sk_live_production');
+
+    const { POST } = await import('@/app/api/auth/native/exchange/route');
+    const response = await POST(createExchangeRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toMatchObject({
+      returnTo: '/app',
+      sessionToken: 'ios_session_token',
+      sessionId: 'sess_ios',
+      userId: 'user_native',
+    });
+    expect(mockCreateClerkClient).toHaveBeenCalledWith({
+      publishableKey: 'pk_live_production',
+      secretKey: 'sk_live_production',
+    });
+    expect(mockClerkClient).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a sign-in ticket when Clerk session token minting returns Not Found', async () => {
+    const unavailableError = new Error('Not Found');
+    mockSessionsGetToken.mockRejectedValue(unavailableError);
+
+    const { POST } = await import('@/app/api/auth/native/exchange/route');
+    const response = await POST(createExchangeRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toMatchObject({
+      returnTo: '/app',
+      ticket: 'sign_in_ticket',
+      userId: 'user_native',
+      expiresInSeconds: 60,
+    });
+    expect(mockSessionsCreateSession).toHaveBeenCalledWith({
+      userId: 'user_native',
+    });
+    expect(mockSignInTokensCreateSignInToken).toHaveBeenCalledWith({
+      userId: 'user_native',
+      expiresInSeconds: 60,
+    });
     expect(mockCaptureError).not.toHaveBeenCalled();
   });
 

--- a/apps/web/tests/unit/lib/auth/clerk-middleware-bypass.test.ts
+++ b/apps/web/tests/unit/lib/auth/clerk-middleware-bypass.test.ts
@@ -38,6 +38,14 @@ describe('shouldBypassClerkForRequest', () => {
         pathname: '/api/profile/view',
       })
     ).toBe(true);
+
+    expect(
+      shouldBypassClerkForRequest({
+        cookies: [],
+        pathInfo: PUBLIC_PATH_INFO,
+        pathname: '/api/auth/native/exchange',
+      })
+    ).toBe(true);
   });
 
   it('keeps Clerk enabled for authenticated API families', () => {

--- a/apps/web/tests/unit/lib/auth/request-clerk-client.test.ts
+++ b/apps/web/tests/unit/lib/auth/request-clerk-client.test.ts
@@ -59,17 +59,20 @@ describe('request Clerk client resolution', () => {
     restoreEnv();
   });
 
-  it('uses the default Next Clerk client for production hosts', async () => {
+  it('uses backend Clerk client with production keys for production hosts', async () => {
     const { getRequestClerkClient } = await import(
       '@/lib/auth/request-clerk-client'
     );
     const request = new Request('https://jov.ie/api/mobile/v1/me');
 
     await expect(getRequestClerkClient(request)).resolves.toEqual({
-      source: 'next',
+      source: 'backend',
     });
-    expect(mockClerkClient).toHaveBeenCalledOnce();
-    expect(mockCreateClerkClient).not.toHaveBeenCalled();
+    expect(mockCreateClerkClient).toHaveBeenCalledWith({
+      publishableKey: 'pk_live_production',
+      secretKey: 'sk_live_production',
+    });
+    expect(mockClerkClient).not.toHaveBeenCalled();
   });
 
   it('uses explicit staging Clerk keys for staging hosts', async () => {


### PR DESCRIPTION
Integration train PR — local verify only. Full CI runs on integration→main train.

Rebased on integration/loop-auth; merged getRequestClerkClient backend-client fix with getServerClerkClient from wave 15.

<!-- linear-issue-identifier:JOV-2771 -->