### PR TITLE
fix(auth): bound Clerk FAPI proxy fetch with timeout and retry (JOV-2990)

### DIFF
--- a/apps/web/lib/auth/clerk-fapi-proxy.ts
+++ b/apps/web/lib/auth/clerk-fapi-proxy.ts
@@ -7,6 +7,16 @@ import {
 import { decodeFapiHostFromPublishableKey } from '@/lib/auth/decode-fapi-host';
 import { resolveClerkKeys } from '@/lib/auth/staging-clerk-keys';
 import { captureError } from '@/lib/error-tracking';
+import {
+  BoundedFetchTimeoutError,
+  boundedFetch,
+  isRetryableTransportError,
+} from '@/lib/http/bounded-fetch';
+
+/** Clerk FAPI proxy must not hang edge middleware on slow upstream responses. */
+const CLERK_FAPI_PROXY_TIMEOUT_MS = 10_000;
+const CLERK_FAPI_PROXY_RETRY_BASE_DELAY_MS = 100;
+const CLERK_FAPI_PROXY_MAX_RETRIES = 1;
 
 function hasCookieNameAfterComma(header: string, commaIndex: number) {
   let index = commaIndex + 1;
@@ -137,12 +147,28 @@ export async function handleClerkFapiProxy(
     if (referer) headers.set('referer', referer);
   }
 
+  const isMutatingRequest =
+    req.method !== 'GET' && req.method !== 'HEAD' && req.method !== 'OPTIONS';
+
   try {
-    const proxyRes = await fetch(targetUrl, {
+    const proxyRes = await boundedFetch(targetUrl, {
       method: req.method,
       headers,
       body: body && body.byteLength > 0 ? body : undefined,
       redirect: 'manual',
+      timeoutMs: CLERK_FAPI_PROXY_TIMEOUT_MS,
+      context: 'clerk-fapi-proxy',
+      retry: isMutatingRequest
+        ? {
+            maxRetries: CLERK_FAPI_PROXY_MAX_RETRIES,
+            baseDelayMs: CLERK_FAPI_PROXY_RETRY_BASE_DELAY_MS,
+            retryOn: ({ response, error }) =>
+              !response && Boolean(error && isRetryableTransportError(error)),
+          }
+        : {
+            maxRetries: CLERK_FAPI_PROXY_MAX_RETRIES,
+            baseDelayMs: CLERK_FAPI_PROXY_RETRY_BASE_DELAY_MS,
+          },
     });
 
     // Streaming a raw 3xx Response with a non-null body through Next.js
@@ -201,7 +227,12 @@ export async function handleClerkFapiProxy(
       headers: resHeaders,
     });
   } catch (err) {
-    const errName = err instanceof Error ? err.name : 'UnknownError';
+    const errName =
+      err instanceof BoundedFetchTimeoutError
+        ? 'BoundedFetchTimeoutError'
+        : err instanceof Error
+          ? err.name
+          : 'UnknownError';
     const errMessage = err instanceof Error ? err.message : String(err);
     await captureError('[clerk-proxy] fetch failed', err, {
       pathname,

--- a/apps/web/lib/http/bounded-fetch.ts
+++ b/apps/web/lib/http/bounded-fetch.ts
@@ -1,0 +1,190 @@
+import {
+  executeWithRetry,
+  type RetryPolicy,
+} from '@/lib/resilience/primitives';
+
+export class BoundedFetchTimeoutError extends Error {
+  constructor(
+    message: string,
+    public readonly timeoutMs: number,
+    public readonly context: string
+  ) {
+    super(message);
+    this.name = 'BoundedFetchTimeoutError';
+  }
+}
+
+class BoundedFetchRetryableStatusError extends Error {
+  constructor(
+    public readonly response: Response,
+    public readonly context: string
+  ) {
+    super(`${context} returned retryable status ${response.status}`);
+    this.name = 'BoundedFetchRetryableStatusError';
+  }
+}
+
+export interface BoundedFetchRetryOptions {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs?: number;
+  backoffMultiplier?: number;
+  retryOn?: (params: { response?: Response; error?: Error }) => boolean;
+}
+
+export type BoundedFetchOptions = RequestInit & {
+  timeoutMs?: number;
+  context?: string;
+  retry?: BoundedFetchRetryOptions;
+};
+
+function isRetryableStatus(status: number): boolean {
+  return status === 408 || status === 429 || status >= 500;
+}
+
+function cancelResponseBody(response: Response): void {
+  const cancelPromise = response.body?.cancel();
+  if (cancelPromise) {
+    void cancelPromise.catch(() => {});
+  }
+}
+
+/**
+ * Limits retries on mutating requests to transport-layer failures only.
+ */
+export function isRetryableTransportError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return (
+    error instanceof BoundedFetchTimeoutError ||
+    error.name === 'TypeError' ||
+    error.name === 'FetchError' ||
+    /network|fetch failed|econn|socket|dns/i.test(error.message)
+  );
+}
+
+function isRetryableError(error: Error): boolean {
+  if (error instanceof BoundedFetchRetryableStatusError) {
+    return true;
+  }
+
+  return isRetryableTransportError(error);
+}
+
+/**
+ * Edge- and Node-compatible fetch with timeout and optional retry.
+ *
+ * Use this in middleware/proxy paths. Server route handlers should prefer
+ * `serverFetch` from `@/lib/http/server-fetch` (same behavior, server-only guard).
+ */
+export async function boundedFetch(
+  input: RequestInfo | URL,
+  options: BoundedFetchOptions = {}
+): Promise<Response> {
+  const {
+    timeoutMs = 5000,
+    context = 'External request',
+    retry,
+    signal: externalSignal,
+    ...fetchOptions
+  } = options;
+
+  const performFetch = async (): Promise<Response> => {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    const abortFromExternalSignal = () => controller.abort();
+
+    if (externalSignal) {
+      if (externalSignal.aborted) {
+        controller.abort();
+      } else {
+        externalSignal.addEventListener('abort', abortFromExternalSignal, {
+          once: true,
+        });
+      }
+    }
+
+    try {
+      const response = await fetch(input, {
+        ...fetchOptions,
+        signal: controller.signal,
+      });
+
+      const shouldRetry =
+        retry &&
+        isRetryableStatus(response.status) &&
+        (retry.retryOn?.({ response }) ?? true);
+
+      if (shouldRetry) {
+        throw new BoundedFetchRetryableStatusError(response, context);
+      }
+
+      return response;
+    } catch (error) {
+      if (error instanceof BoundedFetchRetryableStatusError) {
+        throw error;
+      }
+
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new BoundedFetchTimeoutError(
+          `${context} timed out after ${timeoutMs}ms`,
+          timeoutMs,
+          context
+        );
+      }
+
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+      if (externalSignal) {
+        externalSignal.removeEventListener('abort', abortFromExternalSignal);
+      }
+    }
+  };
+
+  if (!retry || retry.maxRetries <= 0) {
+    try {
+      return await performFetch();
+    } catch (error) {
+      if (error instanceof BoundedFetchRetryableStatusError) {
+        return error.response;
+      }
+
+      throw error;
+    }
+  }
+
+  const policy: RetryPolicy = {
+    maxRetries: retry.maxRetries,
+    baseDelayMs: retry.baseDelayMs,
+    maxDelayMs: retry.maxDelayMs,
+    backoffMultiplier: retry.backoffMultiplier,
+    isRetryable: error => {
+      if (!(error instanceof Error)) {
+        return false;
+      }
+
+      if (!isRetryableError(error)) {
+        return false;
+      }
+
+      return retry.retryOn?.({ error }) ?? true;
+    },
+    onRetry: ({ error }) => {
+      if (error instanceof BoundedFetchRetryableStatusError) {
+        cancelResponseBody(error.response);
+      }
+    },
+  };
+
+  try {
+    return await executeWithRetry(performFetch, policy);
+  } catch (error) {
+    if (error instanceof BoundedFetchRetryableStatusError) {
+      return error.response;
+    }
+
+    throw error;
+  }
+}

--- a/apps/web/lib/http/server-fetch.ts
+++ b/apps/web/lib/http/server-fetch.ts
@@ -1,184 +1,39 @@
 import 'server-only';
 
 import {
-  executeWithRetry,
-  type RetryPolicy,
-} from '@/lib/resilience/primitives';
+  type BoundedFetchOptions,
+  type BoundedFetchRetryOptions,
+  BoundedFetchTimeoutError,
+  boundedFetch,
+  isRetryableTransportError,
+} from '@/lib/http/bounded-fetch';
 
-export class ServerFetchTimeoutError extends Error {
-  constructor(
-    message: string,
-    public readonly timeoutMs: number,
-    public readonly context: string
-  ) {
-    super(message);
+export class ServerFetchTimeoutError extends BoundedFetchTimeoutError {
+  constructor(message: string, timeoutMs: number, context: string) {
+    super(message, timeoutMs, context);
     this.name = 'ServerFetchTimeoutError';
   }
 }
 
-class ServerFetchRetryableStatusError extends Error {
-  constructor(
-    public readonly response: Response,
-    public readonly context: string
-  ) {
-    super(`${context} returned retryable status ${response.status}`);
-    this.name = 'ServerFetchRetryableStatusError';
-  }
-}
+export type ServerFetchRetryOptions = BoundedFetchRetryOptions;
 
-export interface ServerFetchRetryOptions {
-  maxRetries: number;
-  baseDelayMs: number;
-  maxDelayMs?: number;
-  backoffMultiplier?: number;
-  retryOn?: (params: { response?: Response; error?: Error }) => boolean;
-}
+type ServerFetchOptions = BoundedFetchOptions;
 
-type ServerFetchOptions = RequestInit & {
-  timeoutMs?: number;
-  context?: string;
-  retry?: ServerFetchRetryOptions;
-};
-
-function isRetryableStatus(status: number): boolean {
-  return status === 408 || status === 429 || status >= 500;
-}
-
-function cancelResponseBody(response: Response): void {
-  const cancelPromise = response.body?.cancel();
-  if (cancelPromise) {
-    void cancelPromise.catch(() => {});
-  }
-}
-
-/**
- * Limits retries on mutating requests to transport-layer failures only.
- */
-export function isRetryableTransportError(error: unknown): boolean {
-  if (!(error instanceof Error)) {
-    return false;
-  }
-  return (
-    error instanceof ServerFetchTimeoutError ||
-    error.name === 'TypeError' ||
-    error.name === 'FetchError' ||
-    /network|fetch failed|econn|socket|dns/i.test(error.message)
-  );
-}
-
-function isRetryableError(error: Error): boolean {
-  if (error instanceof ServerFetchRetryableStatusError) {
-    return true;
-  }
-
-  return isRetryableTransportError(error);
-}
+export { isRetryableTransportError };
 
 export async function serverFetch(
   input: RequestInfo | URL,
   options: ServerFetchOptions = {}
 ): Promise<Response> {
-  const {
-    timeoutMs = 5000,
-    context = 'External request',
-    retry,
-    signal: externalSignal,
-    ...fetchOptions
-  } = options;
-
-  const performFetch = async (): Promise<Response> => {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
-    const abortFromExternalSignal = () => controller.abort();
-
-    if (externalSignal) {
-      if (externalSignal.aborted) {
-        controller.abort();
-      } else {
-        externalSignal.addEventListener('abort', abortFromExternalSignal, {
-          once: true,
-        });
-      }
-    }
-
-    try {
-      const response = await fetch(input, {
-        ...fetchOptions,
-        signal: controller.signal,
-      });
-
-      const shouldRetry =
-        retry &&
-        isRetryableStatus(response.status) &&
-        (retry.retryOn?.({ response }) ?? true);
-
-      if (shouldRetry) {
-        throw new ServerFetchRetryableStatusError(response, context);
-      }
-
-      return response;
-    } catch (error) {
-      if (error instanceof ServerFetchRetryableStatusError) {
-        throw error;
-      }
-
-      if (error instanceof Error && error.name === 'AbortError') {
-        throw new ServerFetchTimeoutError(
-          `${context} timed out after ${timeoutMs}ms`,
-          timeoutMs,
-          context
-        );
-      }
-
-      throw error;
-    } finally {
-      clearTimeout(timeoutId);
-      if (externalSignal) {
-        externalSignal.removeEventListener('abort', abortFromExternalSignal);
-      }
-    }
-  };
-
-  if (!retry || retry.maxRetries <= 0) {
-    try {
-      return await performFetch();
-    } catch (error) {
-      if (error instanceof ServerFetchRetryableStatusError) {
-        return error.response;
-      }
-
-      throw error;
-    }
-  }
-
-  const policy: RetryPolicy = {
-    maxRetries: retry.maxRetries,
-    baseDelayMs: retry.baseDelayMs,
-    maxDelayMs: retry.maxDelayMs,
-    backoffMultiplier: retry.backoffMultiplier,
-    isRetryable: error => {
-      if (!(error instanceof Error)) {
-        return false;
-      }
-
-      if (!isRetryableError(error)) {
-        return false;
-      }
-
-      return retry.retryOn?.({ error }) ?? true;
-    },
-    onRetry: ({ error }) => {
-      if (error instanceof ServerFetchRetryableStatusError) {
-        cancelResponseBody(error.response);
-      }
-    },
-  };
-
   try {
-    return await executeWithRetry(performFetch, policy);
+    return await boundedFetch(input, options);
   } catch (error) {
-    if (error instanceof ServerFetchRetryableStatusError) {
-      return error.response;
+    if (error instanceof BoundedFetchTimeoutError) {
+      throw new ServerFetchTimeoutError(
+        error.message,
+        error.timeoutMs,
+        error.context
+      );
     }
 
     throw error;

--- a/apps/web/tests/unit/lib/auth/clerk-fapi-proxy.test.ts
+++ b/apps/web/tests/unit/lib/auth/clerk-fapi-proxy.test.ts
@@ -130,7 +130,8 @@ describe('clerk-fapi-proxy', () => {
 
   it('captures fetch failures and returns a bounded 502 response', async () => {
     const fetchError = new TypeError('fetch failed');
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(fetchError));
+    const fetchMock = vi.fn().mockRejectedValue(fetchError);
+    vi.stubGlobal('fetch', fetchMock);
 
     const { handleClerkFapiProxy } = await import(
       '@/lib/auth/clerk-fapi-proxy'
@@ -144,6 +145,7 @@ describe('clerk-fapi-proxy', () => {
       code: 'TypeError',
       hint: 'fetch failed',
     });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(mockCaptureError).toHaveBeenCalledWith(
       '[clerk-proxy] fetch failed',
       fetchError,
@@ -154,5 +156,70 @@ describe('clerk-fapi-proxy', () => {
         method: 'GET',
       })
     );
+  });
+
+  it('retries GET upstream 503 responses before succeeding', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('unavailable', { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { handleClerkFapiProxy } = await import(
+      '@/lib/auth/clerk-fapi-proxy'
+    );
+
+    const response = await handleClerkFapiProxy(request('/__clerk/v1/client'));
+
+    expect(response?.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry POST upstream 503 responses', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('unavailable', { status: 503 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { handleClerkFapiProxy } = await import(
+      '@/lib/auth/clerk-fapi-proxy'
+    );
+
+    const response = await handleClerkFapiProxy(
+      request('/__clerk/v1/oauth_callback', {
+        method: 'POST',
+        body: 'code=oauth-code',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+        },
+      })
+    );
+
+    expect(response?.status).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes an abort signal for bounded upstream GET requests', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { handleClerkFapiProxy } = await import(
+      '@/lib/auth/clerk-fapi-proxy'
+    );
+
+    await handleClerkFapiProxy(request('/__clerk/v1/client'));
+
+    const fetchInit = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(fetchInit.redirect).toBe('manual');
+    expect(fetchInit.signal).toBeInstanceOf(AbortSignal);
   });
 });

--- a/apps/web/tests/unit/lib/http/bounded-fetch.test.ts
+++ b/apps/web/tests/unit/lib/http/bounded-fetch.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  BoundedFetchTimeoutError,
+  boundedFetch,
+  isRetryableTransportError,
+} from '@/lib/http/bounded-fetch';
+
+describe('boundedFetch', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('throws BoundedFetchTimeoutError when the request exceeds timeoutMs', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+        return new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+          });
+        });
+      })
+    );
+
+    await expect(
+      boundedFetch('https://example.com/timeout', {
+        timeoutMs: 10,
+        context: 'Timeout test',
+      })
+    ).rejects.toEqual(expect.any(BoundedFetchTimeoutError));
+  });
+
+  it('retries retryable HTTP responses and returns the eventual success response', async () => {
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: 503,
+        body: {
+          cancel,
+        },
+      } as Response)
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await boundedFetch('https://example.com/retry', {
+      context: 'Retryable status test',
+      retry: {
+        maxRetries: 1,
+        baseDelayMs: 0,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('identifies timeout and network failures as transport-retryable', () => {
+    expect(
+      isRetryableTransportError(
+        new BoundedFetchTimeoutError('timed out', 1000, 'Timeout test')
+      )
+    ).toBe(true);
+    expect(isRetryableTransportError(new TypeError('fetch failed'))).toBe(true);
+    expect(isRetryableTransportError(new Error('HTTP 503'))).toBe(false);
+  });
+});


### PR DESCRIPTION
Integration train PR — local verify only. Full CI runs on integration→main train.

<!-- linear-issue-identifier:JOV-2990 -->
