### PR TITLE
feat(library): add expiry presets to share drop creator (JOV-2936)

### DIFF
--- a/apps/web/components/features/library-share/LibraryShareDropCreator.tsx
+++ b/apps/web/components/features/library-share/LibraryShareDropCreator.tsx
@@ -3,6 +3,10 @@
 import { Share2 } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import {
+  type LibraryShareExpiryPreset,
+  resolveLibraryShareExpiryIso,
+} from '@/lib/library-share/expiry';
 
 interface LibraryShareDropCreatorProps {
   readonly releaseIds: readonly string[];
@@ -20,6 +24,8 @@ export function LibraryShareDropCreator({
   const [message, setMessage] = useState('');
   const [layout, setLayout] = useState<'grid' | 'list' | 'reel'>('grid');
   const [downloadsEnabled, setDownloadsEnabled] = useState(true);
+  const [expiryPreset, setExpiryPreset] =
+    useState<LibraryShareExpiryPreset>('never');
   const [passphrase, setPassphrase] = useState('');
   const [loading, setLoading] = useState(false);
 
@@ -34,6 +40,7 @@ export function LibraryShareDropCreator({
           message: message.trim() || null,
           layout,
           downloadsEnabled,
+          expiresAt: resolveLibraryShareExpiryIso(expiryPreset),
           passphrase: passphrase.trim() || null,
           releaseIds,
         }),
@@ -126,6 +133,22 @@ export function LibraryShareDropCreator({
             onChange={event => setDownloadsEnabled(event.target.checked)}
           />
           Allow downloads
+        </label>
+        <label className='block text-xs font-medium text-secondary-token'>
+          Expires
+          <select
+            value={expiryPreset}
+            onChange={event =>
+              setExpiryPreset(event.target.value as LibraryShareExpiryPreset)
+            }
+            className='mt-1 w-full rounded-xl border border-subtle bg-surface-1 px-3 py-2 text-sm text-primary-token'
+            data-testid='library-share-expiry-select'
+          >
+            <option value='never'>Never</option>
+            <option value='7d'>7 days</option>
+            <option value='30d'>30 days</option>
+            <option value='90d'>90 days</option>
+          </select>
         </label>
         <label className='block text-xs font-medium text-secondary-token'>
           Passphrase (optional)

--- a/apps/web/lib/library-share/expiry.ts
+++ b/apps/web/lib/library-share/expiry.ts
@@ -1,0 +1,10 @@
+export type LibraryShareExpiryPreset = 'never' | '7d' | '30d' | '90d';
+
+export function resolveLibraryShareExpiryIso(
+  preset: LibraryShareExpiryPreset,
+  now = Date.now()
+): string | null {
+  if (preset === 'never') return null;
+  const days = preset === '7d' ? 7 : preset === '30d' ? 30 : 90;
+  return new Date(now + days * 24 * 60 * 60 * 1000).toISOString();
+}

--- a/apps/web/tests/unit/library-share/expiry.test.ts
+++ b/apps/web/tests/unit/library-share/expiry.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { resolveLibraryShareExpiryIso } from '@/lib/library-share/expiry';
+
+describe('resolveLibraryShareExpiryIso', () => {
+  const now = Date.parse('2026-06-10T12:00:00.000Z');
+
+  it('returns null when the drop never expires', () => {
+    expect(resolveLibraryShareExpiryIso('never', now)).toBeNull();
+  });
+
+  it('returns an ISO timestamp for preset windows', () => {
+    expect(resolveLibraryShareExpiryIso('7d', now)).toBe(
+      '2026-06-17T12:00:00.000Z'
+    );
+    expect(resolveLibraryShareExpiryIso('30d', now)).toBe(
+      '2026-07-10T12:00:00.000Z'
+    );
+    expect(resolveLibraryShareExpiryIso('90d', now)).toBe(
+      '2026-09-08T12:00:00.000Z'
+    );
+  });
+});


### PR DESCRIPTION
Integration train PR — local verify only. Full CI runs on integration→main train.

<!-- linear-issue-identifier:JOV-2936 -->

Completes MVP expiry control for branded press-kit share drops. Core share surface already shipped via #10455.