### PR TITLE
fix(auth): add Redis cached fallback to ban-check on DB errors (JOV-2998)

### DIFF
--- a/apps/web/app/app/(shell)/admin/actions.ts
+++ b/apps/web/app/app/(shell)/admin/actions.ts
@@ -7,6 +7,7 @@ import { APP_ROUTES } from '@/constants/routes';
 import { isAdmin as checkAdminRole } from '@/lib/admin/roles';
 import { getCachedAuth } from '@/lib/auth/cached';
 import { syncAllClerkMetadata } from '@/lib/auth/clerk-sync';
+import { invalidateBanStatusCache } from '@/lib/auth/ban-check';
 import { invalidateProxyUserStateCache } from '@/lib/auth/proxy-state';
 import { checkUserStatus } from '@/lib/auth/status-checker';
 import { invalidateProfileCache } from '@/lib/cache/profile';
@@ -561,9 +562,12 @@ export async function banUserAction(formData: FormData): Promise<void> {
   }
 
   try {
-    await invalidateProxyUserStateCache(result.clerkId);
+    await Promise.all([
+      invalidateProxyUserStateCache(result.clerkId),
+      invalidateBanStatusCache(result.clerkId),
+    ]);
   } catch (error) {
-    captureError('Failed to invalidate proxy cache after ban', error, {
+    captureError('Failed to invalidate auth caches after ban', error, {
       userId,
       clerkId: result.clerkId,
     });
@@ -691,9 +695,12 @@ export async function unbanUserAction(formData: FormData): Promise<void> {
   }
 
   try {
-    await invalidateProxyUserStateCache(result.clerkId);
+    await Promise.all([
+      invalidateProxyUserStateCache(result.clerkId),
+      invalidateBanStatusCache(result.clerkId),
+    ]);
   } catch (error) {
-    captureError('Failed to invalidate proxy cache after unban', error, {
+    captureError('Failed to invalidate auth caches after unban', error, {
       userId,
       clerkId: result.clerkId,
     });

--- a/apps/web/lib/audience/block-check.ts
+++ b/apps/web/lib/audience/block-check.ts
@@ -45,7 +45,7 @@ export async function isVisitorBlocked(
     return blocked.length > 0;
   } catch (error) {
     // Fail open: don't lock out visitors on DB errors.
-    // Matches ban-check.ts fail-open pattern.
+    // ban-check.ts uses a Redis cached fallback before failing open.
     captureError('Audience block check failed', error, {
       profileId,
       fingerprint: fingerprint.slice(0, 8),

--- a/apps/web/lib/auth/ban-check.ts
+++ b/apps/web/lib/auth/ban-check.ts
@@ -1,14 +1,122 @@
 import 'server-only';
 
+import * as Sentry from '@sentry/nextjs';
 import { eq } from 'drizzle-orm';
 import { cache } from 'react';
 import { checkUserStatus } from '@/lib/auth/status-checker';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema/auth';
-import { captureError } from '@/lib/error-tracking';
+import { captureError, captureWarning } from '@/lib/error-tracking';
+import { getRedis } from '@/lib/redis';
 
 interface BanStatus {
   isBanned: boolean;
+}
+
+interface BanStatusCacheEntry {
+  isBanned: boolean;
+  cachedAt: string;
+}
+
+const BAN_STATUS_CACHE_KEY_PREFIX = 'auth:ban-status:v1:';
+const BAN_STATUS_CACHE_TTL_BANNED_SECONDS = 300; // 5 minutes
+const BAN_STATUS_CACHE_TTL_ACTIVE_SECONDS = 120; // 2 minutes
+
+function getBanStatusCacheKey(clerkUserId: string): string {
+  return `${BAN_STATUS_CACHE_KEY_PREFIX}${clerkUserId}`;
+}
+
+function getBanStatusCacheTtlSeconds(isBanned: boolean): number {
+  return isBanned
+    ? BAN_STATUS_CACHE_TTL_BANNED_SECONDS
+    : BAN_STATUS_CACHE_TTL_ACTIVE_SECONDS;
+}
+
+async function readCachedBanStatus(
+  clerkUserId: string
+): Promise<BanStatus | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+
+  try {
+    const cached = await redis.get<BanStatusCacheEntry>(
+      getBanStatusCacheKey(clerkUserId)
+    );
+    if (!cached) return null;
+
+    const entry =
+      typeof cached === 'string'
+        ? (JSON.parse(cached) as BanStatusCacheEntry)
+        : cached;
+
+    if (typeof entry?.isBanned !== 'boolean') return null;
+
+    return { isBanned: entry.isBanned };
+  } catch (error) {
+    captureWarning('[ban-check] Redis cache read failed', {
+      clerkUserId,
+      error,
+    });
+    return null;
+  }
+}
+
+function writeBanStatusCache(clerkUserId: string, status: BanStatus): void {
+  const redis = getRedis();
+  if (!redis) return;
+
+  const entry: BanStatusCacheEntry = {
+    isBanned: status.isBanned,
+    cachedAt: new Date().toISOString(),
+  };
+
+  redis
+    .set(getBanStatusCacheKey(clerkUserId), entry, {
+      ex: getBanStatusCacheTtlSeconds(status.isBanned),
+    })
+    .catch(error => {
+      captureWarning('[ban-check] Redis cache write failed', {
+        clerkUserId,
+        error,
+      });
+    });
+}
+
+function recordFailOpenTelemetry(clerkUserId: string, error: unknown): void {
+  Sentry.addBreadcrumb({
+    category: 'ban-check',
+    message: 'Fail-open ban check',
+    level: 'warning',
+    data: {
+      clerkUserId: '[REDACTED]',
+      reason: 'db_and_cache_unavailable',
+    },
+  });
+
+  captureWarning('Ban status check failed open after DB and cache miss', {
+    clerkUserId,
+    error,
+  });
+}
+
+/**
+ * Invalidate the Redis cache for a user's ban status.
+ * Call after ban/unban or other status transitions that affect blocking.
+ */
+export async function invalidateBanStatusCache(
+  clerkUserId: string
+): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+
+  try {
+    await redis.del(getBanStatusCacheKey(clerkUserId));
+  } catch (error) {
+    captureWarning('[ban-check] Failed to invalidate cache', {
+      clerkUserId,
+      error,
+    });
+  }
 }
 
 /**
@@ -37,16 +145,40 @@ export const getUserBanStatus = cache(
         .limit(1);
 
       if (!user) {
-        return { isBanned: false };
+        const status = { isBanned: false };
+        writeBanStatusCache(clerkUserId, status);
+        return status;
       }
 
       const { isBlocked } = checkUserStatus(user.userStatus, user.deletedAt);
-      return { isBanned: isBlocked };
+      const status = { isBanned: isBlocked };
+      writeBanStatusCache(clerkUserId, status);
+      return status;
     } catch (error) {
-      // Fail open: a transient DB error should not lock out all
-      // authenticated users. A banned user slipping through briefly
-      // is far less impactful than denying the entire user base.
-      captureError('Ban status check failed', error, { clerkUserId });
+      const cached = await readCachedBanStatus(clerkUserId);
+      if (cached) {
+        Sentry.addBreadcrumb({
+          category: 'ban-check',
+          message: 'Served cached ban status after DB failure',
+          level: 'warning',
+          data: {
+            clerkUserId: '[REDACTED]',
+            isBanned: cached.isBanned,
+          },
+        });
+
+        captureError('Ban status check used cached fallback', error, {
+          clerkUserId,
+          isBanned: cached.isBanned,
+        });
+
+        return cached;
+      }
+
+      // Fail open only when both DB and Redis are unavailable. A banned user
+      // slipping through briefly is far less impactful than denying the entire
+      // user base, but we emit telemetry so the trade-off is visible.
+      recordFailOpenTelemetry(clerkUserId, error);
       return { isBanned: false };
     }
   }

--- a/apps/web/lib/auth/clerk-sync.ts
+++ b/apps/web/lib/auth/clerk-sync.ts
@@ -4,6 +4,7 @@ import { clerkClient } from '@clerk/nextjs/server';
 import * as Sentry from '@sentry/nextjs';
 import { eq } from 'drizzle-orm';
 
+import { invalidateBanStatusCache } from '@/lib/auth/ban-check';
 import { invalidateProxyUserStateCache } from '@/lib/auth/proxy-state';
 import { db } from '@/lib/db';
 import { adminAuditLog } from '@/lib/db/schema/admin';
@@ -244,8 +245,11 @@ export async function handleClerkUserDeleted(
       })
       .where(eq(users.id, dbUser.id));
 
-    // Invalidate user state cache so middleware reflects deletion immediately
-    await invalidateProxyUserStateCache(clerkUserId);
+    // Invalidate auth caches so middleware and shell reflect deletion immediately
+    await Promise.all([
+      invalidateProxyUserStateCache(clerkUserId),
+      invalidateBanStatusCache(clerkUserId),
+    ]);
 
     // Log the action if we have an admin context
     if (adminUserId) {

--- a/apps/web/tests/unit/actions/admin-actions.test.ts
+++ b/apps/web/tests/unit/actions/admin-actions.test.ts
@@ -83,6 +83,10 @@ vi.mock('@/lib/auth/clerk-sync', () => ({
   syncAllClerkMetadata: vi.fn().mockResolvedValue({ success: true }),
 }));
 
+vi.mock('@/lib/auth/ban-check', () => ({
+  invalidateBanStatusCache: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@/lib/auth/proxy-state', () => ({
   invalidateProxyUserStateCache: vi.fn().mockResolvedValue(undefined),
 }));

--- a/apps/web/tests/unit/lib/auth/ban-check.test.ts
+++ b/apps/web/tests/unit/lib/auth/ban-check.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDbSelect, mockRedisGet, mockRedisSet, mockRedisDel, mockGetRedis } =
+  vi.hoisted(() => ({
+    mockDbSelect: vi.fn(),
+    mockRedisGet: vi.fn(),
+    mockRedisSet: vi.fn().mockResolvedValue('OK'),
+    mockRedisDel: vi.fn().mockResolvedValue(1),
+    mockGetRedis: vi.fn(),
+  }));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mockDbSelect,
+  },
+}));
+
+vi.mock('@/lib/db/schema/auth', () => ({
+  users: {
+    clerkId: 'clerkId',
+    userStatus: 'userStatus',
+    deletedAt: 'deletedAt',
+  },
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  addBreadcrumb: vi.fn(),
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+  getClient: vi.fn().mockReturnValue(null),
+  withScope: vi.fn((cb: (scope: unknown) => void) =>
+    cb({ setExtra: vi.fn(), setTag: vi.fn() })
+  ),
+}));
+
+vi.mock('@/lib/sentry/init', () => ({
+  getSentryMode: vi.fn().mockReturnValue('disabled'),
+  isSentryInitialized: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/lib/analytics/runtime-aware', () => ({
+  trackEvent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/redis', () => ({
+  getRedis: mockGetRedis,
+}));
+
+vi.mock('react', async importOriginal => {
+  const actual = await importOriginal<typeof import('react')>();
+  return {
+    ...actual,
+    cache: <T extends (...args: never[]) => unknown>(fn: T) => fn,
+  };
+});
+
+import * as Sentry from '@sentry/nextjs';
+import {
+  getUserBanStatus,
+  invalidateBanStatusCache,
+} from '@/lib/auth/ban-check';
+
+function mockDbResult(result: unknown) {
+  mockDbSelect.mockReturnValue({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(result),
+      }),
+    }),
+  });
+}
+
+describe('ban-check.ts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRedis.mockReturnValue({
+      get: mockRedisGet,
+      set: mockRedisSet,
+      del: mockRedisDel,
+    });
+  });
+
+  it('returns banned status from DB and writes Redis cache', async () => {
+    mockDbResult([
+      {
+        userStatus: 'banned',
+        deletedAt: null,
+      },
+    ]);
+
+    const result = await getUserBanStatus('clerk_banned');
+
+    expect(result).toEqual({ isBanned: true });
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      'auth:ban-status:v1:clerk_banned',
+      expect.objectContaining({ isBanned: true }),
+      { ex: 300 }
+    );
+  });
+
+  it('returns active status from DB and writes shorter Redis TTL', async () => {
+    mockDbResult([
+      {
+        userStatus: 'active',
+        deletedAt: null,
+      },
+    ]);
+
+    const result = await getUserBanStatus('clerk_active');
+
+    expect(result).toEqual({ isBanned: false });
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      'auth:ban-status:v1:clerk_active',
+      expect.objectContaining({ isBanned: false }),
+      { ex: 120 }
+    );
+  });
+
+  it('serves cached banned status when DB is unavailable', async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockRejectedValue(new Error('DB unavailable')),
+        }),
+      }),
+    });
+    mockRedisGet.mockResolvedValue({
+      isBanned: true,
+      cachedAt: '2026-06-10T00:00:00.000Z',
+    });
+
+    const consoleSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const result = await getUserBanStatus('clerk_banned');
+
+    expect(result).toEqual({ isBanned: true });
+    expect(mockRedisGet).toHaveBeenCalledWith(
+      'auth:ban-status:v1:clerk_banned'
+    );
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'ban-check',
+        message: 'Served cached ban status after DB failure',
+      })
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Ban status check used cached fallback')
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('fails open with telemetry when DB and cache are unavailable', async () => {
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockRejectedValue(new Error('DB unavailable')),
+        }),
+      }),
+    });
+    mockRedisGet.mockResolvedValue(null);
+
+    const consoleSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+
+    const result = await getUserBanStatus('clerk_unknown');
+
+    expect(result).toEqual({ isBanned: false });
+    expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'ban-check',
+        message: 'Fail-open ban check',
+      })
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Ban status check failed open after DB and cache miss'
+      )
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('invalidates the Redis cache key', async () => {
+    await invalidateBanStatusCache('clerk_123');
+
+    expect(mockRedisDel).toHaveBeenCalledWith('auth:ban-status:v1:clerk_123');
+  });
+});

--- a/apps/web/tests/unit/lib/auth/clerk-sync.critical.test.ts
+++ b/apps/web/tests/unit/lib/auth/clerk-sync.critical.test.ts
@@ -85,6 +85,10 @@ vi.mock('@/lib/error-tracking', () => ({
 }));
 
 // Mock proxy state
+vi.mock('@/lib/auth/ban-check', () => ({
+  invalidateBanStatusCache: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock('@/lib/auth/proxy-state', () => ({
   invalidateProxyUserStateCache: mockInvalidateProxyUserStateCache,
 }));


### PR DESCRIPTION
## Summary
- Cache last-known ban status in Redis (`auth:ban-status:v1:*`) on successful DB reads
- On DB failure, serve cached ban state before falling back to fail-open
- Emit Sentry breadcrumbs when cached fallback or fail-open paths execute
- Invalidate ban-status cache on ban/unban and soft-delete transitions

## Acceptance criteria
- [x] DB-down simulation: previously-banned user stays banned via Redis
- [x] Fail-open path emits telemetry

Integration train PR — local verify only. Full CI runs on integration→main train.

<!-- linear-issue-identifier:JOV-2998 -->