### PR TITLE
fix(infra): stop reporting transient Sentry API 503s to Sentry (JOV-2981)

### DIFF
--- a/apps/web/lib/admin/sentry-metrics.ts
+++ b/apps/web/lib/admin/sentry-metrics.ts
@@ -64,8 +64,19 @@ function buildErrorResponse(message: string): AdminSentryMetrics {
   };
 }
 
-function isExpectedSentryAuthError(message: string): boolean {
-  return message.startsWith('401 ') || message.startsWith('403 ');
+const NON_REPORTABLE_SENTRY_API_STATUS_PREFIXES = [
+  '401 ',
+  '403 ',
+  '429 ',
+  '502 ',
+  '503 ',
+  '504 ',
+] as const;
+
+function isNonReportableSentryApiError(message: string): boolean {
+  return NON_REPORTABLE_SENTRY_API_STATUS_PREFIXES.some(prefix =>
+    message.startsWith(prefix)
+  );
 }
 
 function getCacheKey(orgSlug: string): string {
@@ -174,7 +185,7 @@ export async function getAdminSentryMetrics(): Promise<AdminSentryMetrics> {
     return metrics;
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
-    if (!isExpectedSentryAuthError(message)) {
+    if (!isNonReportableSentryApiError(message)) {
       captureError('Error loading Sentry metrics', error, { message });
     }
     return buildErrorResponse(message);

--- a/apps/web/tests/lib/admin/sentry-metrics.test.ts
+++ b/apps/web/tests/lib/admin/sentry-metrics.test.ts
@@ -75,4 +75,20 @@ describe('getAdminSentryMetrics', () => {
     expect(metrics.errorMessage).toContain('401 Unauthorized');
     expect(mockCaptureError).not.toHaveBeenCalled();
   });
+
+  it('gracefully degrades when sentry api is temporarily unavailable', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+    } as Response);
+
+    const metrics = await getAdminSentryMetrics();
+
+    expect(metrics.unresolvedIssues24h).toBe(0);
+    expect(metrics.isConfigured).toBe(true);
+    expect(metrics.isAvailable).toBe(false);
+    expect(metrics.errorMessage).toContain('503 Service Unavailable');
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Integration train PR — local verify only. Full CI runs on integration→main train.

<!-- linear-issue-identifier:JOV-2981 -->
