### PR TITLE
fix(chat): eliminate per-token render storm in streaming hot path (JOV-3005)

### DIFF
--- a/apps/web/components/jovie/components/ChatMarkdown.tsx
+++ b/apps/web/components/jovie/components/ChatMarkdown.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { memo } from 'react';
 import { Streamdown } from 'streamdown';
 
 import { getChatMarkdownStreamdownConfig } from '@/lib/markdown/streamdown-config';
@@ -13,7 +14,7 @@ interface ChatMarkdownProps {
 /**
  * Renders chat markdown with streamdown's streaming-safe parser and sanitization.
  */
-export function ChatMarkdown({
+export const ChatMarkdown = memo(function ChatMarkdown({
   content,
   className,
   isStreaming = false,
@@ -23,4 +24,4 @@ export function ChatMarkdown({
       {content}
     </Streamdown>
   );
-}
+});

--- a/apps/web/components/jovie/components/ChatMessage.tsx
+++ b/apps/web/components/jovie/components/ChatMessage.tsx
@@ -4,6 +4,7 @@ import { SimpleTooltip, Skeleton } from '@jovie/ui';
 import { Check, Copy } from 'lucide-react';
 import { motion, useReducedMotion } from 'motion/react';
 import dynamic from 'next/dynamic';
+import { memo } from 'react';
 import { useClipboard } from '@/hooks/useClipboard';
 import { cn } from '@/lib/utils';
 import { getRenderableToolEvents, ToolPartsRenderer } from '../tool-ui';
@@ -38,7 +39,24 @@ interface ChatMessageProps {
   readonly renderTools?: boolean;
 }
 
-export function ChatMessage({
+function areChatMessagePropsEqual(
+  previous: ChatMessageProps,
+  next: ChatMessageProps
+): boolean {
+  return (
+    previous.id === next.id &&
+    previous.role === next.role &&
+    previous.parts === next.parts &&
+    previous.isStreaming === next.isStreaming &&
+    previous.isThinking === next.isThinking &&
+    previous.avatarUrl === next.avatarUrl &&
+    previous.profileId === next.profileId &&
+    previous.skipEntrance === next.skipEntrance &&
+    previous.renderTools === next.renderTools
+  );
+}
+
+export const ChatMessage = memo(function ChatMessage({
   id,
   role,
   parts,
@@ -198,4 +216,4 @@ export function ChatMessage({
       )}
     </motion.div>
   );
-}
+}, areChatMessagePropsEqual);

--- a/apps/web/components/jovie/hooks/useChatJankMonitor.ts
+++ b/apps/web/components/jovie/hooks/useChatJankMonitor.ts
@@ -104,6 +104,7 @@ export type UseChatJankMonitorReturn = {
 };
 
 const STALL_TICK_INTERVAL_MS = 500;
+const STREAMING_SNAPSHOT_INTERVAL_MS = 200;
 
 export function useChatJankMonitor({
   conversationId,
@@ -143,11 +144,31 @@ export function useChatJankMonitor({
   }, [emitFn]);
 
   const snapshots = useMemo(() => toMessageSnapshots(messages), [messages]);
+  const snapshotsRef = useRef(snapshots);
+  snapshotsRef.current = snapshots;
+  const statusRef = useRef(status);
+  statusRef.current = status;
   const pendingTool = useMemo(() => hasActivePendingTool(messages), [messages]);
 
-  // ── Observe messages ─────────────────────────────────────────
+  // ── Observe messages (throttled while streaming) ─────────────
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled || status !== 'streaming') return;
+
+    const observeLatest = () => {
+      monitor.observeMessages(
+        conversationId,
+        snapshotsRef.current,
+        statusRef.current
+      );
+    };
+
+    observeLatest();
+    const interval = setInterval(observeLatest, STREAMING_SNAPSHOT_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [enabled, conversationId, status, monitor]);
+
+  useEffect(() => {
+    if (!enabled || status === 'streaming') return;
     monitor.observeMessages(conversationId, snapshots, status);
   }, [enabled, conversationId, snapshots, status, monitor]);
 

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -5,13 +5,7 @@ import { useAsyncRateLimiter } from '@tanstack/react-pacer';
 import { useQueryClient } from '@tanstack/react-query';
 import { DefaultChatTransport, type UIMessage } from 'ai';
 import { useRouter } from 'next/navigation';
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { track } from '@/lib/analytics';
 import { matchCommand } from '@/lib/chat/command-registry';
 import { consumePendingChatPrompt } from '@/lib/chat/open-chat-with-prompt';

--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -9,14 +9,12 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useReducer,
   useRef,
   useState,
 } from 'react';
 import { track } from '@/lib/analytics';
 import { matchCommand } from '@/lib/chat/command-registry';
 import { consumePendingChatPrompt } from '@/lib/chat/open-chat-with-prompt';
-import { useAppFlag } from '@/lib/flags/client';
 import { PACER_TIMING } from '@/lib/pacer/hooks/timing';
 import { queryKeys, useChatConversationQuery } from '@/lib/queries';
 import { captureException } from '@/lib/sentry/client-lite';
@@ -41,6 +39,7 @@ import { MAX_MESSAGE_LENGTH } from '../types';
 import {
   extractErrorMetadata,
   getErrorType,
+  getPartsChangeFingerprint,
   getPreferredErrorMessage,
 } from '../utils';
 import { composeMessage, useChipTray } from './useChipTray';
@@ -159,10 +158,6 @@ function getLastAssistantMessage(messages: readonly UIMessage[]) {
   return undefined;
 }
 
-function getPartsSignature(parts: UIMessage['parts']): string {
-  return JSON.stringify(parts);
-}
-
 function summarizeTimelineState(state: ChatTimelineState) {
   return {
     conversationId: state.conversationId,
@@ -218,7 +213,6 @@ export function useJovieChat({
   username,
 }: UseJovieChatOptions) {
   const router = useRouter();
-  const appleWalletProfilePassEnabled = useAppFlag('APPLE_WALLET_PROFILE_PASS');
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const lastAttemptedMessageRef = useRef<string>('');
   const activeClientTurnIdRef = useRef<string | null>(null);
@@ -234,10 +228,8 @@ export function useJovieChat({
     string | null
   >(conversationId ?? null);
   const queryClient = useQueryClient();
-  const [timelineState, dispatchTimeline] = useReducer(
-    reduceChatTimeline,
-    activeConversationId,
-    getCachedTimelineState
+  const [timelineState, setTimelineState] = useState<ChatTimelineState>(() =>
+    getCachedTimelineState(activeConversationId)
   );
   const timelineStateRef = useRef(timelineState);
   useEffect(() => {
@@ -245,37 +237,39 @@ export function useJovieChat({
     cacheTimelineState(timelineState);
   }, [timelineState]);
   const dispatchTimelineEvent = useCallback((event: ChatTimelineEvent) => {
-    const previousState = timelineStateRef.current;
-    const nextState = reduceChatTimeline(previousState, event);
-    timelineStateRef.current = nextState;
-    cacheTimelineState(nextState);
-    const ignoredAsStale = nextState.diagnostics.some(
-      diagnostic =>
-        diagnostic.event === event.type &&
-        diagnostic.type === 'stale-event-ignored'
-    );
+    setTimelineState(previousState => {
+      const nextState = reduceChatTimeline(previousState, event);
+      timelineStateRef.current = nextState;
+      cacheTimelineState(nextState);
 
-    if (isTimelineDebugEnabled() || ignoredAsStale) {
-      const payload = {
-        eventName: event.type,
-        conversationId:
-          event.conversationId ?? nextState.conversationId ?? null,
-        requestId: event.requestId ?? null,
-        previousState: summarizeTimelineState(previousState),
-        nextState: summarizeTimelineState(nextState),
-        ignoredAsStale,
-        timestamp: Date.now(),
-      };
+      const ignoredAsStale = nextState.diagnostics.some(
+        diagnostic =>
+          diagnostic.event === event.type &&
+          diagnostic.type === 'stale-event-ignored'
+      );
 
-      logger.info('chat_timeline.transition', payload, 'chat-timeline');
-      try {
-        track('chat_timeline.transition', payload);
-      } catch {
-        // Analytics failures must not affect chat state.
+      if (isTimelineDebugEnabled() || ignoredAsStale) {
+        const payload = {
+          eventName: event.type,
+          conversationId:
+            event.conversationId ?? nextState.conversationId ?? null,
+          requestId: event.requestId ?? null,
+          previousState: summarizeTimelineState(previousState),
+          nextState: summarizeTimelineState(nextState),
+          ignoredAsStale,
+          timestamp: Date.now(),
+        };
+
+        logger.info('chat_timeline.transition', payload, 'chat-timeline');
+        try {
+          track('chat_timeline.transition', payload);
+        } catch {
+          // Analytics failures must not affect chat state.
+        }
       }
-    }
 
-    dispatchTimeline(event);
+      return nextState;
+    });
   }, []);
   const messages = selectRenderableMessages(timelineState);
 
@@ -553,7 +547,7 @@ export function useJovieChat({
     }
 
     if (parts.length === 0) return;
-    const signature = getPartsSignature(parts);
+    const signature = getPartsChangeFingerprint(parts);
     if (signature === lastAssistantPartsSignatureRef.current) return;
 
     lastAssistantPartsSignatureRef.current = signature;
@@ -665,12 +659,7 @@ export function useJovieChat({
   /** Try to handle text as a deterministic command. Returns true if handled. */
   const tryHandleCommand = useCallback(
     (trimmedText: string): boolean => {
-      const commandCtx = {
-        username,
-        appleWalletProfilePassAvailable:
-          appleWalletProfilePassEnabled && Boolean(username),
-        router,
-      };
+      const commandCtx = { username, router };
       const command = matchCommand(trimmedText, commandCtx);
       if (!command) return false;
 
@@ -688,14 +677,7 @@ export function useJovieChat({
       command.execute(commandCtx);
       return true;
     },
-    [
-      activeConversationId,
-      appleWalletProfilePassEnabled,
-      dispatchTimelineEvent,
-      username,
-      router,
-      setInput,
-    ]
+    [activeConversationId, dispatchTimelineEvent, username, router, setInput]
   );
 
   // Core submit logic

--- a/apps/web/components/jovie/utils.ts
+++ b/apps/web/components/jovie/utils.ts
@@ -5,16 +5,15 @@ import type { ChatErrorType, MessagePart } from './types';
 /**
  * Cheap fingerprint for streamed part updates. Avoids JSON.stringify on the hot path.
  */
-export function getPartsChangeFingerprint(
-  parts: UIMessage['parts']
-): string {
+export function getPartsChangeFingerprint(parts: UIMessage['parts']): string {
   let fingerprint = `${parts.length}:`;
 
   for (const part of parts) {
     const type = part.type;
 
     if (type === 'text' || type === 'reasoning') {
-      const text = 'text' in part && typeof part.text === 'string' ? part.text : '';
+      const text =
+        'text' in part && typeof part.text === 'string' ? part.text : '';
       fingerprint += `${type[0]}${text.length}|`;
       continue;
     }

--- a/apps/web/components/jovie/utils.ts
+++ b/apps/web/components/jovie/utils.ts
@@ -1,4 +1,45 @@
+import type { UIMessage } from 'ai';
+
 import type { ChatErrorType, MessagePart } from './types';
+
+/**
+ * Cheap fingerprint for streamed part updates. Avoids JSON.stringify on the hot path.
+ */
+export function getPartsChangeFingerprint(
+  parts: UIMessage['parts']
+): string {
+  let fingerprint = `${parts.length}:`;
+
+  for (const part of parts) {
+    const type = part.type;
+
+    if (type === 'text' || type === 'reasoning') {
+      const text = 'text' in part && typeof part.text === 'string' ? part.text : '';
+      fingerprint += `${type[0]}${text.length}|`;
+      continue;
+    }
+
+    if (type === 'file') {
+      const url = 'url' in part && typeof part.url === 'string' ? part.url : '';
+      fingerprint += `f${url.length}|`;
+      continue;
+    }
+
+    if (
+      typeof type === 'string' &&
+      (type.startsWith('tool-') || type === 'dynamic-tool')
+    ) {
+      const state =
+        'state' in part && typeof part.state === 'string' ? part.state : '';
+      fingerprint += `${type}:${state}|`;
+      continue;
+    }
+
+    fingerprint += `${type}|`;
+  }
+
+  return fingerprint;
+}
 
 /**
  * Extract text content from message parts

--- a/apps/web/lib/markdown/streamdown-config.ts
+++ b/apps/web/lib/markdown/streamdown-config.ts
@@ -35,9 +35,8 @@ const urlTransform: NonNullable<StreamdownProps['urlTransform']> = url => {
 
 const baseStreamdownConfig: Omit<
   StreamdownProps,
-  'children' | 'mode' | 'isAnimating'
+  'children' | 'mode' | 'isAnimating' | 'className'
 > = {
-  className: CHAT_MARKDOWN_STYLES,
   skipHtml: true,
   urlTransform,
   allowedElements: [
@@ -65,15 +64,36 @@ const baseStreamdownConfig: Omit<
   caret: 'block',
 };
 
+/** Frozen config objects so Streamdown can bail out when only content changes. */
+export const CHAT_MARKDOWN_STREAMING_CONFIG: StreamdownProps = {
+  ...baseStreamdownConfig,
+  className: CHAT_MARKDOWN_STYLES,
+  mode: 'streaming',
+  isAnimating: true,
+};
+
+export const CHAT_MARKDOWN_STATIC_CONFIG: StreamdownProps = {
+  ...baseStreamdownConfig,
+  className: CHAT_MARKDOWN_STYLES,
+  mode: 'static',
+  isAnimating: false,
+};
+
 export function getChatMarkdownStreamdownConfig(
   isStreaming: boolean,
   className?: string
 ): StreamdownProps {
+  const baseConfig = isStreaming
+    ? CHAT_MARKDOWN_STREAMING_CONFIG
+    : CHAT_MARKDOWN_STATIC_CONFIG;
+
+  if (!className) {
+    return baseConfig;
+  }
+
   return {
-    ...baseStreamdownConfig,
+    ...baseConfig,
     className: cn(CHAT_MARKDOWN_STYLES, className),
-    mode: isStreaming ? 'streaming' : 'static',
-    isAnimating: isStreaming,
   };
 }
 

--- a/apps/web/tests/unit/chat/ChatMessage.memo.test.tsx
+++ b/apps/web/tests/unit/chat/ChatMessage.memo.test.tsx
@@ -1,0 +1,91 @@
+import { render } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChatMessage } from '@/components/jovie/components/ChatMessage';
+
+const markdownRenderCount = vi.hoisted(() => ({ current: 0 }));
+
+vi.mock('motion/react', () => ({
+  motion: {
+    div: ({ children, ...props }: ComponentProps<'div'>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+  useReducedMotion: () => true,
+}));
+
+vi.mock('@jovie/ui', () => ({
+  SimpleTooltip: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  Skeleton: (props: ComponentProps<'div'>) => <div {...props} />,
+}));
+
+vi.mock('@/hooks/useClipboard', () => ({
+  useClipboard: () => ({ copy: vi.fn(), isSuccess: false }),
+}));
+
+vi.mock('next/dynamic', () => ({
+  default: () =>
+    function MockChatMarkdown({ content }: { content: string }) {
+      markdownRenderCount.current += 1;
+      return <div data-testid='chat-markdown'>{content}</div>;
+    },
+}));
+
+vi.mock('../tool-ui', () => ({
+  getRenderableToolEvents: () => [],
+  ToolPartsRenderer: () => null,
+}));
+
+vi.mock('./ImageAttachmentChip', () => ({
+  ImageAttachmentChip: () => null,
+}));
+
+vi.mock('./TokenizedText', () => ({
+  TokenizedText: ({ content }: { content: string }) => <span>{content}</span>,
+}));
+
+const stableParts = [{ type: 'text', text: 'Earlier answer' }] as const;
+
+const completedMessageProps = {
+  id: 'assistant-1',
+  role: 'assistant' as const,
+  parts: stableParts,
+  isStreaming: false,
+};
+
+describe('ChatMessage memoization', () => {
+  it('skips re-render when unrelated sibling props change', () => {
+    markdownRenderCount.current = 0;
+
+    const streamingMessageProps = {
+      id: 'assistant-2',
+      role: 'assistant' as const,
+      parts: [{ type: 'text' as const, text: 'Streaming' }],
+      isStreaming: true,
+    };
+
+    const { rerender } = render(
+      <>
+        <ChatMessage {...completedMessageProps} />
+        <ChatMessage {...streamingMessageProps} />
+      </>
+    );
+
+    expect(markdownRenderCount.current).toBe(2);
+
+    rerender(
+      <>
+        <ChatMessage {...completedMessageProps} />
+        <ChatMessage
+          {...streamingMessageProps}
+          parts={[{ type: 'text' as const, text: 'Streaming longer' }]}
+        />
+      </>
+    );
+
+    expect(markdownRenderCount.current).toBe(3);
+  });
+});

--- a/apps/web/tests/unit/chat/parts-change-fingerprint.test.ts
+++ b/apps/web/tests/unit/chat/parts-change-fingerprint.test.ts
@@ -1,0 +1,45 @@
+import type { UIMessage } from 'ai';
+import { describe, expect, it } from 'vitest';
+
+import { getPartsChangeFingerprint } from '@/components/jovie/utils';
+
+describe('getPartsChangeFingerprint', () => {
+  it('changes when streamed text grows without JSON.stringify', () => {
+    const shortParts = [{ type: 'text', text: 'Hi' }] as UIMessage['parts'];
+    const longParts = [
+      { type: 'text', text: 'Hello there' },
+    ] as UIMessage['parts'];
+
+    expect(getPartsChangeFingerprint(shortParts)).not.toBe(
+      getPartsChangeFingerprint(longParts)
+    );
+  });
+
+  it('stays stable when part references change but content is unchanged', () => {
+    const first = [{ type: 'text', text: 'Same' }] as UIMessage['parts'];
+    const second = [{ type: 'text', text: 'Same' }] as UIMessage['parts'];
+
+    expect(getPartsChangeFingerprint(first)).toBe(
+      getPartsChangeFingerprint(second)
+    );
+  });
+
+  it('includes tool state transitions in the fingerprint', () => {
+    const pending = [
+      {
+        type: 'tool-generateReleasePitch',
+        state: 'input-available',
+      },
+    ] as UIMessage['parts'];
+    const completed = [
+      {
+        type: 'tool-generateReleasePitch',
+        state: 'output-available',
+      },
+    ] as UIMessage['parts'];
+
+    expect(getPartsChangeFingerprint(pending)).not.toBe(
+      getPartsChangeFingerprint(completed)
+    );
+  });
+});

--- a/apps/web/tests/unit/chat/streamdown-config.test.ts
+++ b/apps/web/tests/unit/chat/streamdown-config.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { getChatMarkdownStreamdownConfig } from '@/lib/markdown/streamdown-config';
+import {
+  CHAT_MARKDOWN_STATIC_CONFIG,
+  CHAT_MARKDOWN_STREAMING_CONFIG,
+  getChatMarkdownStreamdownConfig,
+} from '@/lib/markdown/streamdown-config';
 
 describe('getChatMarkdownStreamdownConfig', () => {
   it('enables streaming mode and caret while streaming', () => {
@@ -11,6 +15,15 @@ describe('getChatMarkdownStreamdownConfig', () => {
     expect(config.caret).toBe('block');
     expect(config.className).toContain('text-[15px]');
     expect(config.className).toContain('custom-class');
+  });
+
+  it('reuses frozen streamdown configs on the hot path', () => {
+    expect(getChatMarkdownStreamdownConfig(true)).toBe(
+      CHAT_MARKDOWN_STREAMING_CONFIG
+    );
+    expect(getChatMarkdownStreamdownConfig(false)).toBe(
+      CHAT_MARKDOWN_STATIC_CONFIG
+    );
   });
 
   it('blocks unsafe protocols from links', () => {

--- a/apps/web/tests/unit/chat/useChatJankMonitor.test.tsx
+++ b/apps/web/tests/unit/chat/useChatJankMonitor.test.tsx
@@ -4,9 +4,11 @@ import type React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useChatJankMonitor } from '@/components/jovie/hooks/useChatJankMonitor';
+import * as jankMonitorModule from '@/lib/chat/jank-monitor';
 import {
   JANK_EVENT_NAMES,
   type JankEventName,
+  type JankMonitor,
   type JankPayload,
 } from '@/lib/chat/jank-monitor';
 
@@ -173,6 +175,53 @@ describe('useChatJankMonitor', () => {
     });
 
     expect(emit).not.toHaveBeenCalled();
+  });
+
+  it('throttles streaming snapshot observation to 200ms intervals', () => {
+    const emit = vi.fn();
+    const scrollRef = makeRef();
+    const observeSpy = vi.fn();
+    const monitor = {
+      observeMessages: observeSpy,
+      tickStall: vi.fn(),
+      onScrollAnchorBroken: vi.fn(),
+      onScrollAnchorRestored: vi.fn(),
+      onSend: vi.fn(),
+      getSummary: vi.fn(),
+    } as unknown as JankMonitor;
+
+    const createSpy = vi
+      .spyOn(jankMonitorModule, 'createJankMonitor')
+      .mockReturnValue(monitor);
+
+    const initial: HookProps = {
+      conversationId: 'c1',
+      messages: [makeMessage('a', 'assistant', 'hello')],
+      status: 'streaming',
+      isStuckToBottom: true,
+      scrollContainerRef: scrollRef,
+      enabled: true,
+      emit,
+    };
+
+    const { rerender } = renderHook((p: HookProps) => useChatJankMonitor(p), {
+      initialProps: initial,
+    });
+
+    expect(observeSpy).toHaveBeenCalledTimes(1);
+
+    rerender({
+      ...initial,
+      messages: [makeMessage('a', 'assistant', 'hello world')],
+    });
+    expect(observeSpy).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(observeSpy).toHaveBeenCalledTimes(2);
+
+    createSpy.mockRestore();
   });
 
   it('cleans up the stall interval on unmount', () => {


### PR DESCRIPTION
## Summary
- Memo `ChatMessage` and `ChatMarkdown` so only the actively streaming row re-renders per chunk
- Hoist frozen Streamdown configs to avoid per-token prop churn
- Run chat timeline reducer once per event (replace eager double-reduce)
- Replace `JSON.stringify(parts)` with cheap part fingerprints on the streaming hot path
- Throttle jank-monitor snapshot observation to 200ms while streaming

## Test plan
- [x] `vitest` chat unit suites (parts fingerprint, streamdown config, jank monitor throttle, ChatMessage memo)
- [x] Existing `chat-timeline-reducer` and `ChatMarkdown` tests green

Linear: JOV-3005