### PR TITLE
fix(chat): harden /api/chat input validation and release writes (JOV-3011)

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -56,7 +56,16 @@ import {
   detectAlbumArtGenerationIntent,
   resolveAlbumArtCapability,
 } from '@/lib/chat/album-art-capability';
+import {
+  updateOwnedReleaseGeneratedPitches,
+  updateOwnedReleaseMetadata,
+} from '@/lib/chat/release-writes';
+import {
+  extractUIMessageText,
+  parseChatRequestBody,
+} from '@/lib/chat/request-validation';
 import { executeChatTurn, isClientDisconnect } from '@/lib/chat/run';
+import { chatToolSchema } from '@/lib/chat/strict-schema';
 import {
   canUsePaidChatTools,
   resolveChatTurnPlanLimits,
@@ -161,12 +170,6 @@ import { detectPlatform } from '@/lib/utils/platform-detection/detector';
 export const dynamic = 'force-dynamic';
 
 export const maxDuration = 60;
-
-/** Maximum allowed message length (characters) */
-const MAX_MESSAGE_LENGTH = 4000;
-
-/** Maximum allowed messages per request */
-const MAX_MESSAGES_PER_REQUEST = 50;
 
 /**
  * Statsig gate keys for the chat kill switch. Declared as const so typos fail
@@ -434,80 +437,6 @@ async function resolveArtistContext(
   return { context: parseResult.data };
 }
 
-/**
- * Extracts text content from a UIMessage's parts array.
- */
-function extractUIMessageText(
-  parts: Array<{ type: string; text?: string }>
-): string {
-  return parts
-    .filter(
-      (p): p is { type: 'text'; text: string } =>
-        p.type === 'text' && typeof p.text === 'string'
-    )
-    .map(p => p.text)
-    .join('');
-}
-
-/**
- * Validates a single UIMessage object.
- * AI SDK v6 UIMessages have { id, role, parts } instead of { role, content }.
- * Returns an error message string if invalid, null if valid.
- */
-function validateMessage(message: unknown): string | null {
-  if (typeof message !== 'object' || message === null || !('role' in message)) {
-    return 'Invalid message format';
-  }
-
-  const msg = message as Record<string, unknown>;
-
-  if (msg.role !== 'user' && msg.role !== 'assistant') {
-    return 'Invalid message role';
-  }
-
-  // UIMessages must have a parts array
-  if (!('parts' in msg) || !Array.isArray(msg.parts)) {
-    return 'Invalid message format';
-  }
-
-  // Validate content length for user messages
-  if (msg.role === 'user') {
-    const contentStr = extractUIMessageText(
-      msg.parts as Array<{ type: string; text?: string }>
-    );
-    if (contentStr.length > MAX_MESSAGE_LENGTH) {
-      return `Message too long. Maximum is ${MAX_MESSAGE_LENGTH} characters`;
-    }
-  }
-
-  return null;
-}
-
-/**
- * Validates the messages array (UIMessage format).
- * Returns an error message string if invalid, null if valid.
- */
-function validateMessagesArray(messages: unknown): string | null {
-  if (!Array.isArray(messages)) {
-    return 'Messages must be an array';
-  }
-  if (messages.length === 0) {
-    return 'Messages array cannot be empty';
-  }
-  if (messages.length > MAX_MESSAGES_PER_REQUEST) {
-    return `Too many messages. Maximum is ${MAX_MESSAGES_PER_REQUEST}`;
-  }
-
-  for (const message of messages) {
-    const error = validateMessage(message);
-    if (error) {
-      return error;
-    }
-  }
-
-  return null;
-}
-
 function extractRequestId(req: Request): string {
   const incomingRequestId = req.headers.get('x-request-id')?.trim();
   if (incomingRequestId) return incomingRequestId.slice(0, 120);
@@ -715,7 +644,7 @@ function createAvatarUploadTool() {
   return tool({
     description:
       'Show a profile photo upload widget in the chat. Use this when the artist wants to change, update, or set their profile photo. Do not describe how to upload — just call this tool.',
-    inputSchema: z.object({}),
+    inputSchema: chatToolSchema({}),
     execute: async () => {
       return { success: true, action: 'avatar_upload' as const };
     },
@@ -730,7 +659,7 @@ function createSocialLinkTool() {
   return tool({
     description:
       'Propose adding a social link to the artist profile. Pass the full URL. The client will show a confirmation card with the detected platform. Use this when the artist asks to add a link or social profile URL.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       url: z
         .string()
         .describe(
@@ -771,7 +700,7 @@ function createSocialLinkRemovalTool(profileId: string | null) {
   return tool({
     description:
       'Propose removing a social link from the artist profile. Use this when the artist asks to remove or delete a link. Returns a confirmation card with link details. You must specify the platform name (e.g. "instagram", "spotify", "twitter") to identify which link to remove.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       platform: z
         .string()
         .describe(
@@ -841,7 +770,7 @@ function createCheckCanvasStatusTool(profileId: string | null) {
   return tool({
     description:
       "Check which of the artist's releases have Spotify Canvas videos set and which are missing them. Use this when the artist asks about canvas videos or wants to generate them.",
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       includeAll: z
         .boolean()
         .optional()
@@ -913,7 +842,7 @@ function createSuggestRelatedArtistsTool(context: ArtistContext) {
   return tool({
     description:
       "Suggest related artists for playlist pitching, ad targeting, and collaboration based on the artist's genre, style, and popularity level. Returns advice on which artists to target.",
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       purpose: z
         .enum(['playlist_pitching', 'ad_targeting', 'collaboration', 'all'])
         .describe('What the related artists will be used for'),
@@ -952,7 +881,7 @@ function createGenerateCanvasPlanTool(profileId: string | null) {
   return tool({
     description:
       'Generate a detailed plan for creating a Spotify Canvas video from album artwork. Includes artwork processing steps, animation style recommendations, and technical specs. Use this when an artist wants to create a canvas for a specific release.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       releaseTitle: z
         .string()
         .describe('The title of the release to generate canvas for'),
@@ -992,7 +921,7 @@ function createGenerateAlbumArtTool(params: {
   return tool({
     description:
       'Generate three album art options for a release. Use this when the artist asks to generate, create, or design album artwork or cover art. If no matching release exists, return a target-selection result so the client can ask whether to create a release or attach the art to an existing release.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       releaseTitle: z
         .string()
         .max(200)
@@ -1229,7 +1158,7 @@ function _createMerchGenerationTool(params: {
   return tool({
     description:
       'Generate exactly three premium merch design options for the current artist. Use for make merch, create a tee, create a hoodie, or make something that would sell.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       prompt: z.string().max(500).optional(),
       itemType: z.string().max(80).optional(),
       makeLive: z.boolean().optional(),
@@ -1317,7 +1246,7 @@ function createMerchStatusTool(params: {
   return tool({
     description:
       'Change a merch card status. Use publish for live, pause for kill temporarily, unpause to bring back, and archive for delete/remove.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       merchCardId: z.string().uuid(),
     }),
     execute: async ({ merchCardId }) => {
@@ -1363,7 +1292,7 @@ function createMerchUpdateTool(params: {
   return tool({
     description:
       'Update a merch card name, description, image URL, or retail price. If asked to make it live, run the merch safety guard before publishing.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       merchCardId: z.string().uuid(),
       title: z.string().min(1).max(120).optional(),
       description: z.string().min(1).max(500).optional(),
@@ -1400,7 +1329,7 @@ function createMerchUpdateTool(params: {
 function createMerchSalesTool(profileId: string | null) {
   return tool({
     description: 'Show merch revenue and purchase counts for this artist.',
-    inputSchema: z.object({}),
+    inputSchema: chatToolSchema({}),
     execute: async () => {
       if (!profileId) {
         return { success: false as const, error: 'Profile ID required' };
@@ -1420,7 +1349,7 @@ function createMerchPayoutsTool(profileId: string | null) {
   return tool({
     description:
       'Show manual merch payout liability for this artist. MVP payouts are not automatic.',
-    inputSchema: z.object({}),
+    inputSchema: chatToolSchema({}),
     execute: async () => {
       if (!profileId) {
         return { success: false as const, error: 'Profile ID required' };
@@ -1507,7 +1436,7 @@ function createPromoStrategyTool(
   return tool({
     description:
       'Create a comprehensive promotion strategy for a release, including social media video ads, TikTok strategy, Spotify Canvas, and ad targeting recommendations. Use this when an artist asks for help promoting their music.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       releaseTitle: z
         .string()
         .optional()
@@ -1569,7 +1498,7 @@ function createShowTopInsightsTool(profileId: string | null) {
   return tool({
     description:
       'Show the artist their top audience, release, track, and monetization signals as structured insight cards. Use this when they ask what is working, what to focus on, or how their audience and releases are performing.',
-    inputSchema: z.object({}),
+    inputSchema: chatToolSchema({}),
     execute: async () => {
       if (!profileId) {
         return {
@@ -1600,7 +1529,7 @@ function createMarkCanvasUploadedTool(profileId: string | null) {
   return tool({
     description:
       "Mark a release as having a Spotify Canvas video uploaded. Use this when the artist confirms they've already set a canvas for a track/release in Spotify for Artists, or when they tell you a canvas is already uploaded.",
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       releaseTitle: z
         .string()
         .describe('The title of the release that has a canvas uploaded'),
@@ -1620,17 +1549,21 @@ function createMarkCanvasUploadedTool(profileId: string | null) {
         };
       }
 
-      // Update the release metadata with canvas status
-      await db
-        .update(discogReleases)
-        .set({
-          metadata: {
-            ...release.metadata,
-            ...buildCanvasMetadata('uploaded'),
-          },
-          updatedAt: new Date(),
-        })
-        .where(eq(discogReleases.id, release.id));
+      const updated = await updateOwnedReleaseMetadata({
+        releaseId: release.id,
+        creatorProfileId: profileId,
+        metadata: {
+          ...release.metadata,
+          ...buildCanvasMetadata('uploaded'),
+        },
+      });
+
+      if (!updated) {
+        return {
+          success: false,
+          error: 'Release not found or unauthorized',
+        };
+      }
 
       return {
         success: true,
@@ -1650,7 +1583,7 @@ function createMarkCanvasUploadedTool(profileId: string | null) {
  * This tool directly creates the release in the database and returns the result.
  */
 function createReleaseTool(resolvedProfileId: string) {
-  const createReleaseSchema = z.object({
+  const createReleaseSchema = chatToolSchema({
     title: z.string().min(1).max(200).describe('The title of the release'),
     releaseType: z
       .enum([
@@ -1744,7 +1677,7 @@ function createWorldClassBioTool(
   return tool({
     description:
       'Write a world-class artist bio in an editorial style suitable for Spotify, Apple Music, and press use. Uses real artist context from profile + DSP metadata.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       goal: z
         .enum(['spotify', 'apple_music', 'press_kit', 'general'])
         .optional()
@@ -1814,7 +1747,7 @@ function createLyricsFormatTool() {
   return tool({
     description:
       'Format lyrics to Apple Music guidelines. Applies deterministic rules: removes section labels like [Verse]/[Chorus], straightens curly quotes, normalizes punctuation, collapses blank lines, and trims whitespace. Use when an artist asks to clean up or format lyrics.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       lyrics: z
         .string()
         .min(1)
@@ -1863,7 +1796,7 @@ function createSubmitFeedbackTool(clerkUserId: string) {
   return tool({
     description:
       'Submit product feedback from the artist. Use this when the artist wants to share feedback, report a bug, or request a feature. Collect their feedback message first, then call this tool with the full text.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       message: z
         .string()
         .min(5)
@@ -1891,7 +1824,7 @@ function createGenerateReleasePitchTool(
 ) {
   return tool({
     description: `Generate one copy-paste-ready release pitch for a specific destination. Use for playlist, radio, Sirius XM, install, playback/music supervisor, editorial post, record label, or collaborator pitching. Ask the artist where they want to pitch it before calling this tool unless a task or user message clearly maps to one of these destinations: ${PITCH_TARGET_OPTIONS_TEXT}. Ask which release they want to pitch if unclear. If the artist provides custom guidance, pass it via instructions.`,
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       releaseTitle: z
         .string()
         .max(200)
@@ -1994,10 +1927,18 @@ function createGenerateReleasePitchTool(
           },
         });
 
-        await db
-          .update(discogReleases)
-          .set({ generatedPitches: result.pitch })
-          .where(eq(discogReleases.id, release.id));
+        const updated = await updateOwnedReleaseGeneratedPitches({
+          releaseId: release.id,
+          creatorProfileId: resolvedProfileId,
+          generatedPitches: result.pitch,
+        });
+
+        if (!updated) {
+          return {
+            success: false as const,
+            error: 'Release not found or unauthorized',
+          };
+        }
 
         return {
           success: true as const,
@@ -2150,7 +2091,7 @@ function buildChatTools(
           reorderMerchCards: tool({
             description:
               'Record the desired order for merch cards. Use only when the artist gives explicit card IDs.',
-            inputSchema: z.object({
+            inputSchema: chatToolSchema({
               merchCardIds: z.array(z.string().uuid()).min(1).max(12),
             }),
             execute: async ({ merchCardIds }) => {
@@ -2175,7 +2116,7 @@ function buildChatTools(
           optimizeMerchCards: tool({
             description:
               'Optimize merch card ranking using current conversion, revenue, margin, and recency signals.',
-            inputSchema: z.object({}),
+            inputSchema: chatToolSchema({}),
             execute: async () => {
               if (!resolvedProfileId) {
                 return {
@@ -2434,27 +2375,16 @@ export async function POST(req: Request) {
     CHAT_KILL_SWITCH_GATES.FORCE_LIGHT,
     false
   );
-  // Parse and validate request body
-  let body: {
-    messages?: unknown;
-    profileId?: unknown;
-    conversationId?: unknown;
-    artistContext?: unknown;
-    clientTurnId?: unknown;
-    clientMessageId?: unknown;
-    source?: unknown;
-    toolIntent?: unknown;
-  };
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json(
-      { error: 'Invalid JSON body', requestId },
-      { status: 400, headers: { ...corsHeaders, 'x-request-id': requestId } }
-    );
+  const parsedRequest = await parseChatRequestBody(req, {
+    corsHeaders,
+    requestId,
+  });
+  if (!parsedRequest.ok) {
+    return parsedRequest.response;
   }
 
-  const { messages, profileId, conversationId } = body;
+  const { body, uiMessages } = parsedRequest;
+  const { profileId, conversationId } = body;
 
   // Validate that either profileId or artistContext is provided
   if (
@@ -2466,18 +2396,6 @@ export async function POST(req: Request) {
       { status: 400, headers: { ...corsHeaders, 'x-request-id': requestId } }
     );
   }
-
-  // Validate messages array and individual messages
-  const messagesError = validateMessagesArray(messages);
-  if (messagesError) {
-    return NextResponse.json(
-      { error: messagesError, requestId },
-      { status: 400, headers: { ...corsHeaders, 'x-request-id': requestId } }
-    );
-  }
-
-  // After validation, we know messages is a valid UIMessage array
-  const uiMessages = messages as UIMessage[];
   const userText = extractLastUserText(uiMessages);
   const clientTurnId = normalizeClientId(body.clientTurnId);
   const clientMessageId = normalizeClientId(body.clientMessageId);

--- a/apps/web/eslint-rules/chat-tool-schema-strict.js
+++ b/apps/web/eslint-rules/chat-tool-schema-strict.js
@@ -1,0 +1,70 @@
+/**
+ * Require chat tool input schemas to use chatToolSchema() instead of bare z.object().
+ */
+
+const CHAT_TOOL_SCHEMA_FILES = ['/lib/chat/', '/app/api/chat/'];
+
+function isChatToolSchemaFile(filename) {
+  return CHAT_TOOL_SCHEMA_FILES.some(segment => filename.includes(segment));
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require chat tool input schemas to use chatToolSchema() for strict validation',
+    },
+    schema: [],
+    messages: {
+      useChatToolSchema:
+        'Chat tool input schemas must use chatToolSchema() instead of z.object() so unknown keys are rejected.',
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.getFilename?.() ?? '';
+    if (!isChatToolSchemaFile(filename)) {
+      return {};
+    }
+
+    return {
+      Property(node) {
+        if (
+          node.key?.type !== 'Identifier' ||
+          node.key.name !== 'inputSchema' ||
+          node.value?.type !== 'CallExpression'
+        ) {
+          return;
+        }
+
+        const callee = node.value.callee;
+        if (
+          callee?.type === 'MemberExpression' &&
+          callee.object?.name === 'z' &&
+          callee.property?.name === 'object'
+        ) {
+          context.report({ node: node.value, messageId: 'useChatToolSchema' });
+        }
+      },
+      VariableDeclarator(node) {
+        if (
+          node.id?.type !== 'Identifier' ||
+          !node.id.name.endsWith('Schema') ||
+          node.init?.type !== 'CallExpression'
+        ) {
+          return;
+        }
+
+        const callee = node.init.callee;
+        if (
+          callee?.type === 'MemberExpression' &&
+          callee.object?.name === 'z' &&
+          callee.property?.name === 'object'
+        ) {
+          context.report({ node: node.init, messageId: 'useChatToolSchema' });
+        }
+      },
+    };
+  },
+};

--- a/apps/web/eslint-rules/chat-tool-schema-strict.test.js
+++ b/apps/web/eslint-rules/chat-tool-schema-strict.test.js
@@ -1,0 +1,41 @@
+import { createRequire } from 'node:module';
+import { RuleTester } from 'eslint';
+import { describe, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const rule = require('./chat-tool-schema-strict.js');
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('chat-tool-schema-strict', rule, {
+  valid: [
+    {
+      filename: '/repo/apps/web/lib/chat/tool-schemas.ts',
+      code: `const schema = chatToolSchema({ foo: z.string() });`,
+    },
+    {
+      filename: '/repo/apps/web/lib/other/file.ts',
+      code: `const schema = z.object({ foo: z.string() });`,
+    },
+  ],
+  invalid: [
+    {
+      filename: '/repo/apps/web/lib/chat/account-tools.ts',
+      code: `tool({ inputSchema: z.object({}), execute: async () => ({}) });`,
+      errors: [{ messageId: 'useChatToolSchema' }],
+    },
+    {
+      filename: '/repo/apps/web/app/api/chat/route.ts',
+      code: `const createReleaseSchema = z.object({ title: z.string() });`,
+      errors: [{ messageId: 'useChatToolSchema' }],
+    },
+  ],
+});

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -19,6 +19,7 @@ const noBannedMarketingCopyRule = require('./eslint-rules/no-banned-marketing-co
 const noRawFocusRingRule = require('./eslint-rules/no-raw-focus-ring');
 const noAdHocCurrencyRule = require('./eslint-rules/no-ad-hoc-currency');
 const clerkOauthOptionsMustIncludePromptRule = require('./eslint-rules/clerk-oauth-options-must-include-prompt');
+const chatToolSchemaStrictRule = require('./eslint-rules/chat-tool-schema-strict');
 const canonicalUiLabelCasingRule = require('./eslint-rules/canonical-ui-label-casing');
 
 const [nextBase, nextTypescript, nextIgnores] = nextConfig;
@@ -47,6 +48,7 @@ const baseConfig = {
         'no-ad-hoc-currency': noAdHocCurrencyRule,
         'clerk-oauth-options-must-include-prompt':
           clerkOauthOptionsMustIncludePromptRule,
+        'chat-tool-schema-strict': chatToolSchemaStrictRule,
         'canonical-ui-label-casing': canonicalUiLabelCasingRule,
       },
     },
@@ -205,6 +207,7 @@ const baseConfig = {
     // its internal file-path check, so setting 'error' globally is safe — it
     // will only fire on files under app/(auth)/.
     '@jovie/clerk-oauth-options-must-include-prompt': 'error',
+    '@jovie/chat-tool-schema-strict': 'error',
     // DESIGN.md text casing — Title Case labels, sentence case body/toasts/tooltips
     '@jovie/canonical-ui-label-casing': 'error',
   },

--- a/apps/web/lib/chat/account-tools.ts
+++ b/apps/web/lib/chat/account-tools.ts
@@ -1,8 +1,8 @@
 import 'server-only';
 
 import { tool } from 'ai';
-import { z } from 'zod';
 import { APP_ROUTES } from '@/constants/routes';
+import { chatToolSchema } from '@/lib/chat/strict-schema';
 import { publicEnv } from '@/lib/env-public';
 import { createBillingPortalSession } from '@/lib/stripe/client';
 import { getUserBillingInfo } from '@/lib/stripe/customer-sync';
@@ -46,13 +46,13 @@ export function createAccountChatTools(accountContext: ChatAccountContext) {
     showAccountStatus: tool({
       description:
         'Show the authenticated account plan, billing verification state, feature access, merch access, and safe next action.',
-      inputSchema: z.object({}),
+      inputSchema: chatToolSchema({}),
       execute: async () => buildAccountStatusPayload(accountContext),
     }),
     showUsage: tool({
       description:
         'Show AI chat usage, limits, remaining messages, and reset times for the authenticated account.',
-      inputSchema: z.object({}),
+      inputSchema: chatToolSchema({}),
       execute: async () => {
         if (!accountContext.usage) {
           return {
@@ -74,7 +74,7 @@ export function createAccountChatTools(accountContext: ChatAccountContext) {
     openBillingPortal: tool({
       description:
         'Open Stripe billing portal when available, or return the billing/settings route when no Stripe customer exists. Does not mutate subscriptions.',
-      inputSchema: z.object({}),
+      inputSchema: chatToolSchema({}),
       execute: async () => {
         const billing = await getUserBillingInfo();
         if (!billing.success) {

--- a/apps/web/lib/chat/release-writes.ts
+++ b/apps/web/lib/chat/release-writes.ts
@@ -1,0 +1,42 @@
+import 'server-only';
+
+import { and, eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { discogReleases } from '@/lib/db/schema/content';
+
+/** WHERE clause that re-asserts profile ownership on release writes. */
+export function ownedReleaseWhere(releaseId: string, creatorProfileId: string) {
+  return and(
+    eq(discogReleases.id, releaseId),
+    eq(discogReleases.creatorProfileId, creatorProfileId)
+  );
+}
+
+export async function updateOwnedReleaseMetadata(input: {
+  releaseId: string;
+  creatorProfileId: string;
+  metadata: Record<string, unknown>;
+}): Promise<boolean> {
+  const result = await db
+    .update(discogReleases)
+    .set({
+      metadata: input.metadata,
+      updatedAt: new Date(),
+    })
+    .where(ownedReleaseWhere(input.releaseId, input.creatorProfileId));
+
+  return (result.rowCount ?? 0) > 0;
+}
+
+export async function updateOwnedReleaseGeneratedPitches(input: {
+  releaseId: string;
+  creatorProfileId: string;
+  generatedPitches: unknown;
+}): Promise<boolean> {
+  const result = await db
+    .update(discogReleases)
+    .set({ generatedPitches: input.generatedPitches })
+    .where(ownedReleaseWhere(input.releaseId, input.creatorProfileId));
+
+  return (result.rowCount ?? 0) > 0;
+}

--- a/apps/web/lib/chat/release-writes.ts
+++ b/apps/web/lib/chat/release-writes.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { and, eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { discogReleases } from '@/lib/db/schema/content';
+import type { GeneratedPitchDraft } from '@/lib/services/pitch/types';
 
 /** WHERE clause that re-asserts profile ownership on release writes. */
 export function ownedReleaseWhere(releaseId: string, creatorProfileId: string) {
@@ -31,7 +32,7 @@ export async function updateOwnedReleaseMetadata(input: {
 export async function updateOwnedReleaseGeneratedPitches(input: {
   releaseId: string;
   creatorProfileId: string;
-  generatedPitches: unknown;
+  generatedPitches: GeneratedPitchDraft;
 }): Promise<boolean> {
   const result = await db
     .update(discogReleases)

--- a/apps/web/lib/chat/request-validation.ts
+++ b/apps/web/lib/chat/request-validation.ts
@@ -1,0 +1,168 @@
+import type { UIMessage } from 'ai';
+import { NextResponse } from 'next/server';
+import { parseJsonBody } from '@/lib/http/parse-json';
+
+/** Maximum allowed chat POST body size (bytes). */
+export const MAX_CHAT_BODY_SIZE = 256 * 1024;
+
+/** Maximum allowed message length (characters). */
+export const MAX_MESSAGE_LENGTH = 4000;
+
+/** Maximum allowed messages per request. */
+export const MAX_MESSAGES_PER_REQUEST = 50;
+
+/** Maximum parts per UIMessage. */
+export const MAX_PARTS_PER_MESSAGE = 50;
+
+/** Maximum serialized size of all message parts combined (bytes). */
+export const MAX_TOTAL_PARTS_SERIALIZED_BYTES = 128 * 1024;
+
+export type ChatRequestBody = {
+  messages?: unknown;
+  profileId?: unknown;
+  conversationId?: unknown;
+  artistContext?: unknown;
+  clientTurnId?: unknown;
+  clientMessageId?: unknown;
+  source?: unknown;
+  toolIntent?: unknown;
+};
+
+type MessagePart = { type: string; text?: string };
+
+export function extractUIMessageText(parts: MessagePart[]): string {
+  return parts
+    .filter(
+      (p): p is { type: 'text'; text: string } =>
+        p.type === 'text' && typeof p.text === 'string'
+    )
+    .map(p => p.text)
+    .join('');
+}
+
+function measurePartsSerializedBytes(parts: unknown[]): number {
+  try {
+    return new TextEncoder().encode(JSON.stringify(parts)).byteLength;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+export function validateMessage(message: unknown): string | null {
+  if (typeof message !== 'object' || message === null || !('role' in message)) {
+    return 'Invalid message format';
+  }
+
+  const msg = message as Record<string, unknown>;
+
+  if (msg.role !== 'user' && msg.role !== 'assistant') {
+    return 'Invalid message role';
+  }
+
+  if (!('parts' in msg) || !Array.isArray(msg.parts)) {
+    return 'Invalid message format';
+  }
+
+  if (msg.parts.length > MAX_PARTS_PER_MESSAGE) {
+    return `Too many message parts. Maximum is ${MAX_PARTS_PER_MESSAGE}`;
+  }
+
+  const partsBytes = measurePartsSerializedBytes(msg.parts);
+  if (partsBytes > MAX_TOTAL_PARTS_SERIALIZED_BYTES) {
+    return 'Message parts payload too large';
+  }
+
+  if (msg.role === 'user') {
+    const contentStr = extractUIMessageText(msg.parts as MessagePart[]);
+    if (contentStr.length > MAX_MESSAGE_LENGTH) {
+      return `Message too long. Maximum is ${MAX_MESSAGE_LENGTH} characters`;
+    }
+  }
+
+  return null;
+}
+
+export function validateMessagesArray(messages: unknown): string | null {
+  if (!Array.isArray(messages)) {
+    return 'Messages must be an array';
+  }
+  if (messages.length === 0) {
+    return 'Messages array cannot be empty';
+  }
+  if (messages.length > MAX_MESSAGES_PER_REQUEST) {
+    return `Too many messages. Maximum is ${MAX_MESSAGES_PER_REQUEST}`;
+  }
+
+  let totalPartsBytes = 0;
+  for (const message of messages) {
+    const error = validateMessage(message);
+    if (error) {
+      return error;
+    }
+
+    if (
+      typeof message === 'object' &&
+      message !== null &&
+      Array.isArray((message as { parts?: unknown }).parts)
+    ) {
+      totalPartsBytes += measurePartsSerializedBytes(
+        (message as { parts: unknown[] }).parts
+      );
+      if (totalPartsBytes > MAX_TOTAL_PARTS_SERIALIZED_BYTES) {
+        return 'Total message parts payload too large';
+      }
+    }
+  }
+
+  return null;
+}
+
+export type ParsedChatRequest =
+  | { ok: true; body: ChatRequestBody; uiMessages: UIMessage[] }
+  | { ok: false; response: NextResponse };
+
+export async function parseChatRequestBody(
+  request: Request,
+  options: {
+    corsHeaders: HeadersInit;
+    requestId: string;
+  }
+): Promise<ParsedChatRequest> {
+  const parsedBody = await parseJsonBody<ChatRequestBody>(request, {
+    route: '/api/chat',
+    headers: {
+      ...options.corsHeaders,
+      'x-request-id': options.requestId,
+    },
+    maxBodySize: MAX_CHAT_BODY_SIZE,
+    logContext: { requestId: options.requestId },
+  });
+
+  if (!parsedBody.ok) {
+    return { ok: false, response: parsedBody.response };
+  }
+
+  const body = parsedBody.data;
+  const messagesError = validateMessagesArray(body.messages);
+  if (messagesError) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: messagesError, requestId: options.requestId },
+        {
+          status: 400,
+          headers: {
+            ...options.corsHeaders,
+            'x-request-id': options.requestId,
+          },
+        }
+      ),
+    };
+  }
+
+  return {
+    ok: true,
+    body,
+    uiMessages: body.messages as UIMessage[],
+  };
+}

--- a/apps/web/lib/chat/strict-schema.ts
+++ b/apps/web/lib/chat/strict-schema.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+
+/**
+ * Chat tool inputs reject unknown keys (defense-in-depth against prompt injection
+ * and schema drift). Use this instead of bare `z.object()` for every chat
+ * tool `inputSchema`.
+ */
+export function chatToolSchema<T extends z.ZodRawShape>(shape: T) {
+  return z.object(shape).strict();
+}
+
+function unwrapZodObject(
+  schema: z.ZodTypeAny
+): z.ZodObject<z.ZodRawShape> | null {
+  if (schema instanceof z.ZodObject) {
+    return schema;
+  }
+  if (schema instanceof z.ZodEffects) {
+    return unwrapZodObject(schema._def.schema);
+  }
+  return null;
+}
+
+/** Returns true when the schema rejects unknown object keys. */
+export function isStrictZodObject(schema: z.ZodTypeAny): boolean {
+  const objectSchema = unwrapZodObject(schema);
+  if (!objectSchema) {
+    return false;
+  }
+
+  const result = objectSchema.safeParse({ __unexpectedKey: 'x' });
+  if (!result.success) {
+    return result.error.issues.some(
+      issue => issue.code === 'unrecognized_keys'
+    );
+  }
+  return false;
+}

--- a/apps/web/lib/chat/strict-schema.ts
+++ b/apps/web/lib/chat/strict-schema.ts
@@ -9,26 +9,9 @@ export function chatToolSchema<T extends z.ZodRawShape>(shape: T) {
   return z.object(shape).strict();
 }
 
-function unwrapZodObject(
-  schema: z.ZodTypeAny
-): z.ZodObject<z.ZodRawShape> | null {
-  if (schema instanceof z.ZodObject) {
-    return schema;
-  }
-  if (schema instanceof z.ZodEffects) {
-    return unwrapZodObject(schema._def.schema);
-  }
-  return null;
-}
-
 /** Returns true when the schema rejects unknown object keys. */
 export function isStrictZodObject(schema: z.ZodTypeAny): boolean {
-  const objectSchema = unwrapZodObject(schema);
-  if (!objectSchema) {
-    return false;
-  }
-
-  const result = objectSchema.safeParse({ __unexpectedKey: 'x' });
+  const result = schema.safeParse({ __unexpectedKey: 'x' });
   if (!result.success) {
     return result.error.issues.some(
       issue => issue.code === 'unrecognized_keys'

--- a/apps/web/lib/chat/tool-schemas.ts
+++ b/apps/web/lib/chat/tool-schemas.ts
@@ -12,6 +12,7 @@ import {
   PITCH_TARGET_OPTIONS_TEXT,
   PITCH_TARGETS,
 } from '@/lib/services/pitch/targets';
+import { chatToolSchema } from './strict-schema';
 import { interviewSignalSchema } from './tools/onboarding-signals';
 
 // ---------------------------------------------------------------------------
@@ -22,12 +23,12 @@ export const TOOL_SCHEMAS = {
   proposeAvatarUpload: {
     description:
       'Show a profile photo upload widget in the chat. Use this when the artist wants to change, update, or set their profile photo. Do not describe how to upload — just call this tool.',
-    inputSchema: z.object({}),
+    inputSchema: chatToolSchema({}),
   },
   generateAlbumArt: {
     description:
       'Generate three album art options for a release. Use when the artist asks to generate album artwork or cover art.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       releaseTitle: z.string().max(200).optional(),
       releaseId: z.string().uuid().optional(),
       styleId: z
@@ -45,7 +46,7 @@ export const TOOL_SCHEMAS = {
 
   generateReleasePitch: {
     description: `Generate one copy-paste-ready release pitch for a destination. Ask where they want to pitch it before using this tool unless the task or user message clearly maps to: ${PITCH_TARGET_OPTIONS_TEXT}.`,
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       releaseTitle: z.string().max(200).optional(),
       releaseId: z.string().uuid().optional(),
       target: z.enum(PITCH_TARGETS).optional(),
@@ -59,7 +60,7 @@ export const TOOL_SCHEMAS = {
   createMerch: {
     description:
       'Generate exactly three premium merch options for the artist. Use when the artist asks to make merch, create a tee/hoodie/item, or make something that would sell.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       prompt: z.string().max(500).optional(),
       itemType: z.string().max(80).optional(),
       makeLive: z.boolean().optional(),
@@ -69,7 +70,7 @@ export const TOOL_SCHEMAS = {
   previewMerchOptions: {
     description:
       'Preview three merch design options without publishing them. Use when the artist asks for concepts or wants to see merch ideas first.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       prompt: z.string().max(500).optional(),
       itemType: z.string().max(80).optional(),
     }),
@@ -78,36 +79,34 @@ export const TOOL_SCHEMAS = {
   selectMerchDesign: {
     description:
       'Select one of the three merch options from a previous merch generation. Use after the artist picks option 1, 2, or 3.',
-    inputSchema: z
-      .object({
-        generationId: z.string().uuid(),
-        optionNumber: z.number().int().min(1).max(3).optional(),
-        optionId: z.string().uuid().optional(),
-        makeLive: z.boolean().optional(),
-      })
-      .refine(data => data.optionNumber !== undefined || data.optionId, {
-        message: 'Provide either optionNumber or optionId.',
-        path: ['optionNumber'],
-      }),
+    inputSchema: chatToolSchema({
+      generationId: z.string().uuid(),
+      optionNumber: z.number().int().min(1).max(3).optional(),
+      optionId: z.string().uuid().optional(),
+      makeLive: z.boolean().optional(),
+    }).refine(data => data.optionNumber !== undefined || data.optionId, {
+      message: 'Provide either optionNumber or optionId.',
+      path: ['optionNumber'],
+    }),
   },
 
   publishMerchCard: {
     description: 'Publish an existing merch card to the public artist profile.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       merchCardId: z.string().uuid(),
     }),
   },
 
   pauseMerchCard: {
     description: 'Pause a live merch card so fans can no longer buy it.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       merchCardId: z.string().uuid(),
     }),
   },
 
   unpauseMerchCard: {
     description: 'Make a paused merch card live again after validating it.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       merchCardId: z.string().uuid(),
     }),
   },
@@ -115,7 +114,7 @@ export const TOOL_SCHEMAS = {
   deleteOrArchiveMerchCard: {
     description:
       'Archive a merch card. Use for kill/delete/remove merch requests.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       merchCardId: z.string().uuid(),
     }),
   },
@@ -123,7 +122,7 @@ export const TOOL_SCHEMAS = {
   reorderMerchCards: {
     description:
       'Reorder merch cards on the artist profile. Use when the artist asks to rank, pin, or move merch cards.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       merchCardIds: z.array(z.string().uuid()).min(1).max(12),
     }),
   },
@@ -131,42 +130,42 @@ export const TOOL_SCHEMAS = {
   optimizeMerchCards: {
     description:
       'Optimize merch card ranking using sales, margin, clicks, recency, and availability.',
-    inputSchema: z.object({}),
+    inputSchema: chatToolSchema({}),
   },
 
   showMerchSales: {
     description: 'Show merch revenue and purchase counts for this artist.',
-    inputSchema: z.object({}),
+    inputSchema: chatToolSchema({}),
   },
 
   showArtistPayouts: {
     description:
       'Show internal artist payout liability for merch. Do not imply automatic payout in MVP.',
-    inputSchema: z.object({}),
+    inputSchema: chatToolSchema({}),
   },
 
   showAccountStatus: {
     description:
       'Show authenticated account plan, billing verification, feature access, merch access, and safe next action.',
-    inputSchema: z.object({}),
+    inputSchema: chatToolSchema({}),
   },
 
   showUsage: {
     description:
       'Show AI chat usage, daily/monthly limits, remaining messages, and reset time for the authenticated account.',
-    inputSchema: z.object({}),
+    inputSchema: chatToolSchema({}),
   },
 
   openBillingPortal: {
     description:
       'Open the Stripe billing portal when available, or return billing settings when no billing account exists. Does not change the subscription.',
-    inputSchema: z.object({}),
+    inputSchema: chatToolSchema({}),
   },
 
   proposeSocialLink: {
     description:
       'Propose adding a social link to the artist profile. Pass the full URL. The client will show a confirmation card with the detected platform. Use this when the artist asks to add a link or social profile URL.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       url: z
         .string()
         .describe(
@@ -178,7 +177,7 @@ export const TOOL_SCHEMAS = {
   proposeSocialLinkRemoval: {
     description:
       'Propose removing a social link from the artist profile. Use this when the artist asks to remove or delete a link. Returns a confirmation card with link details. You must specify the platform name (e.g. "instagram", "spotify", "twitter") to identify which link to remove.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       platform: z
         .string()
         .describe(
@@ -190,7 +189,7 @@ export const TOOL_SCHEMAS = {
   submitFeedback: {
     description:
       'Submit product feedback from the artist. Use this when the artist wants to share feedback, report a bug, or request a feature. Collect their feedback message first, then call this tool with the full text.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       message: z
         .string()
         .min(5)
@@ -206,7 +205,7 @@ export const TOOL_SCHEMAS = {
   searchSpotifyArtist: {
     description:
       'Open the Spotify artist picker popout in the chat. Use this on the FIRST turn the visitor mentions being a musician/artist, or whenever you need to identify which artist they are. The widget calls /api/spotify/search and renders suggestion cards; pass the query if the visitor has already named themselves, otherwise leave it empty to let them type.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       query: z
         .string()
         .max(200)
@@ -218,7 +217,7 @@ export const TOOL_SCHEMAS = {
   confirmSpotifyArtist: {
     description:
       'Lock in the Spotify artist the visitor picked. This pulls Spotify enrichment (avatar, name, followers, popularity, genres) and is the trigger for the profile-preview reveal stage. Call this ONLY after the user has explicitly selected a candidate from searchSpotifyArtist results.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       spotifyArtistId: z
         .string()
         .min(1)
@@ -232,7 +231,7 @@ export const TOOL_SCHEMAS = {
   checkHandle: {
     description:
       'Check whether a Jovie handle (username) is available. Use after the visitor has been identified (Spotify pick or self-named) to claim their handle. The widget shows green-check / red-x with suggestions if taken. Pass the proposed handle without the @ prefix.',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       handle: z
         .string()
         .min(1)
@@ -254,13 +253,13 @@ export const TOOL_SCHEMAS = {
   proposeNextStep: {
     description:
       'Decide whether to render the checkout card, the waitlist confirmation card, or continue the interview. Call this once you believe you have enough signal (typically after confirmSpotifyArtist + checkHandle, OR after 2+ interview turns). The server runs the deterministic evaluator — you do NOT score the decision, you trigger the evaluation.',
-    inputSchema: z.object({}),
+    inputSchema: chatToolSchema({}),
   },
 
   proposeCheckout: {
     description:
       'Render the checkout card. Only call this AFTER proposeNextStep returned instant_access. The card defaults to a route-handoff to /onboarding/checkout (Stripe Embedded Checkout iframe is behind a separate flag pending CSP verification).',
-    inputSchema: z.object({
+    inputSchema: chatToolSchema({
       plan: z
         .enum(['free', 'pro', 'max'])
         .optional()

--- a/apps/web/lib/chat/tools/onboarding-signals.ts
+++ b/apps/web/lib/chat/tools/onboarding-signals.ts
@@ -13,6 +13,7 @@
  */
 
 import { z } from 'zod';
+import { chatToolSchema } from '@/lib/chat/strict-schema';
 
 /** Release stage the artist self-reports. */
 export const releaseStageSchema = z.enum([
@@ -36,7 +37,7 @@ export const audienceBandSchema = z.enum([
 export type AudienceBand = z.infer<typeof audienceBandSchema>;
 
 /** What the artist is currently using (the status quo Jovie is replacing). */
-export const currentToolSchema = z.object({
+export const currentToolSchema = chatToolSchema({
   /** Free-text identifier: "linktree", "bio.fm", "my own site", "nothing", etc. */
   name: z.string().min(1).max(120),
   /** What about it does/doesn't work — short free text. Optional. */
@@ -44,7 +45,7 @@ export const currentToolSchema = z.object({
 });
 
 /** A single objection or hesitation the user raised. */
-export const objectionSchema = z.object({
+export const objectionSchema = chatToolSchema({
   /** Categorized objection kind, free-text fallback allowed via `other`. */
   category: z.enum([
     'price',
@@ -65,26 +66,24 @@ export const objectionSchema = z.object({
  * The tool can pass only the fields it has signal on — every field is
  * optional, but at least one MUST be present (enforced via refine).
  */
-export const interviewSignalSchema = z
-  .object({
-    releaseStage: releaseStageSchema.optional(),
-    audienceBand: audienceBandSchema.optional(),
-    currentTool: currentToolSchema.optional(),
-    objection: objectionSchema.optional(),
-    /** Free-form note for anything that doesn't fit the typed schema yet. */
-    freeNote: z.string().max(2000).optional(),
-  })
-  .refine(
-    v =>
-      Boolean(
-        v.releaseStage ||
-          v.audienceBand ||
-          v.currentTool ||
-          v.objection ||
-          v.freeNote
-      ),
-    { message: 'At least one signal field must be present' }
-  );
+export const interviewSignalSchema = chatToolSchema({
+  releaseStage: releaseStageSchema.optional(),
+  audienceBand: audienceBandSchema.optional(),
+  currentTool: currentToolSchema.optional(),
+  objection: objectionSchema.optional(),
+  /** Free-form note for anything that doesn't fit the typed schema yet. */
+  freeNote: z.string().max(2000).optional(),
+}).refine(
+  v =>
+    Boolean(
+      v.releaseStage ||
+        v.audienceBand ||
+        v.currentTool ||
+        v.objection ||
+        v.freeNote
+    ),
+  { message: 'At least one signal field must be present' }
+);
 export type InterviewSignal = z.infer<typeof interviewSignalSchema>;
 
 /**

--- a/apps/web/tests/unit/chat/release-writes.test.ts
+++ b/apps/web/tests/unit/chat/release-writes.test.ts
@@ -55,7 +55,16 @@ describe('owned release writes', () => {
     const updated = await updateOwnedReleaseGeneratedPitches({
       releaseId: 'release-1',
       creatorProfileId: 'profile-a',
-      generatedPitches: { body: 'pitch' },
+      generatedPitches: {
+        target: 'playlist',
+        platform: 'spotify',
+        destinationLabel: 'Spotify Editorial',
+        audience: 'indie listeners',
+        subjectLine: null,
+        body: 'pitch',
+        generatedAt: '2026-06-11T00:00:00.000Z',
+        modelUsed: 'test-model',
+      },
     });
 
     expect(updated).toBe(false);
@@ -71,7 +80,16 @@ describe('owned release writes', () => {
     const updated = await updateOwnedReleaseGeneratedPitches({
       releaseId: 'release-1',
       creatorProfileId: 'profile-a',
-      generatedPitches: { body: 'pitch' },
+      generatedPitches: {
+        target: 'playlist',
+        platform: 'spotify',
+        destinationLabel: 'Spotify Editorial',
+        audience: 'indie listeners',
+        subjectLine: null,
+        body: 'pitch',
+        generatedAt: '2026-06-11T00:00:00.000Z',
+        modelUsed: 'test-model',
+      },
     });
 
     expect(updated).toBe(true);

--- a/apps/web/tests/unit/chat/release-writes.test.ts
+++ b/apps/web/tests/unit/chat/release-writes.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  whereMock: vi.fn().mockResolvedValue({ rowCount: 0 }),
+  setMock: vi.fn().mockReturnValue({ where: vi.fn() }),
+  updateMock: vi.fn(),
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    update: hoisted.updateMock,
+  },
+}));
+
+vi.mock('@/lib/db/schema/content', () => ({
+  discogReleases: {
+    id: 'id',
+    creatorProfileId: 'creatorProfileId',
+    metadata: 'metadata',
+    generatedPitches: 'generatedPitches',
+    updatedAt: 'updatedAt',
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...args: unknown[]) => ({ type: 'and', args })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ type: 'eq', left, right })),
+}));
+
+describe('owned release writes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.setMock.mockReturnValue({ where: hoisted.whereMock });
+    hoisted.updateMock.mockReturnValue({ set: hoisted.setMock });
+  });
+
+  it('ownedReleaseWhere requires both release id and creator profile id', async () => {
+    const { ownedReleaseWhere } = await import('@/lib/chat/release-writes');
+    const { and, eq } = await import('drizzle-orm');
+    const { discogReleases } = await import('@/lib/db/schema/content');
+
+    ownedReleaseWhere('release-1', 'profile-1');
+
+    expect(and).toHaveBeenCalledWith(
+      eq(discogReleases.id, 'release-1'),
+      eq(discogReleases.creatorProfileId, 'profile-1')
+    );
+  });
+
+  it('updateOwnedReleaseGeneratedPitches fails when profile ownership does not match', async () => {
+    const { updateOwnedReleaseGeneratedPitches } = await import(
+      '@/lib/chat/release-writes'
+    );
+
+    const updated = await updateOwnedReleaseGeneratedPitches({
+      releaseId: 'release-1',
+      creatorProfileId: 'profile-a',
+      generatedPitches: { body: 'pitch' },
+    });
+
+    expect(updated).toBe(false);
+    expect(hoisted.whereMock).toHaveBeenCalled();
+  });
+
+  it('updateOwnedReleaseGeneratedPitches succeeds when ownership matches', async () => {
+    hoisted.whereMock.mockResolvedValueOnce({ rowCount: 1 });
+    const { updateOwnedReleaseGeneratedPitches } = await import(
+      '@/lib/chat/release-writes'
+    );
+
+    const updated = await updateOwnedReleaseGeneratedPitches({
+      releaseId: 'release-1',
+      creatorProfileId: 'profile-a',
+      generatedPitches: { body: 'pitch' },
+    });
+
+    expect(updated).toBe(true);
+  });
+});

--- a/apps/web/tests/unit/chat/request-validation.test.ts
+++ b/apps/web/tests/unit/chat/request-validation.test.ts
@@ -1,0 +1,83 @@
+import { NextRequest } from 'next/server';
+import { describe, expect, it } from 'vitest';
+import {
+  MAX_CHAT_BODY_SIZE,
+  MAX_PARTS_PER_MESSAGE,
+  parseChatRequestBody,
+  validateMessagesArray,
+} from '@/lib/chat/request-validation';
+
+function chatRequest(body: unknown, headers?: Record<string, string>) {
+  return new NextRequest('http://localhost/api/chat', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('parseChatRequestBody', () => {
+  it('rejects oversized bodies before JSON parse with 413', async () => {
+    const request = chatRequest(
+      {
+        messages: [
+          {
+            id: 'm1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'hello' }],
+          },
+        ],
+        profileId: '550e8400-e29b-41d4-a716-446655440000',
+      },
+      {
+        'content-length': String(MAX_CHAT_BODY_SIZE + 1),
+      }
+    );
+
+    const result = await parseChatRequestBody(request, {
+      corsHeaders: {},
+      requestId: 'req-413',
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.response.status).toBe(413);
+  });
+
+  it('rejects messages with too many parts', async () => {
+    const parts = Array.from({ length: MAX_PARTS_PER_MESSAGE + 1 }, (_, i) => ({
+      type: 'text',
+      text: `part-${i}`,
+    }));
+
+    const result = await parseChatRequestBody(
+      chatRequest({
+        messages: [{ id: 'm1', role: 'user', parts }],
+        profileId: '550e8400-e29b-41d4-a716-446655440000',
+      }),
+      { corsHeaders: {}, requestId: 'req-parts' }
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.response.status).toBe(400);
+    const payload = await result.response.json();
+    expect(payload.error).toContain('Too many message parts');
+  });
+});
+
+describe('validateMessagesArray', () => {
+  it('accepts a valid UIMessage array', () => {
+    expect(
+      validateMessagesArray([
+        {
+          id: 'm1',
+          role: 'user',
+          parts: [{ type: 'text', text: 'hello' }],
+        },
+      ])
+    ).toBeNull();
+  });
+});

--- a/apps/web/tests/unit/chat/tool-schemas-strict.test.ts
+++ b/apps/web/tests/unit/chat/tool-schemas-strict.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { isStrictZodObject } from '@/lib/chat/strict-schema';
+import { TOOL_SCHEMAS } from '@/lib/chat/tool-schemas';
+
+function minimalValidInput(toolName: keyof typeof TOOL_SCHEMAS): unknown {
+  switch (toolName) {
+    case 'generateAlbumArt':
+    case 'generateReleasePitch':
+    case 'createMerch':
+    case 'previewMerchOptions':
+    case 'searchSpotifyArtist':
+    case 'proposeCheckout':
+      return {};
+    case 'selectMerchDesign':
+      return {
+        generationId: '550e8400-e29b-41d4-a716-446655440000',
+        optionNumber: 1,
+      };
+    case 'publishMerchCard':
+    case 'pauseMerchCard':
+    case 'unpauseMerchCard':
+    case 'deleteOrArchiveMerchCard':
+      return { merchCardId: '550e8400-e29b-41d4-a716-446655440000' };
+    case 'reorderMerchCards':
+      return { merchCardIds: ['550e8400-e29b-41d4-a716-446655440000'] };
+    case 'proposeSocialLink':
+      return { url: 'https://instagram.com/jovie' };
+    case 'proposeSocialLinkRemoval':
+      return { platform: 'instagram' };
+    case 'submitFeedback':
+      return { message: 'Love the chat experience' };
+    case 'confirmSpotifyArtist':
+      return { spotifyArtistId: '4uA0L8H4DcXmKkJtGTQGzz' };
+    case 'checkHandle':
+      return { handle: 'jovie' };
+    case 'recordInterviewSignal':
+      return { releaseStage: 'just_released' };
+    default:
+      return {};
+  }
+}
+
+describe('chat tool schemas strict mode', () => {
+  for (const [toolName, schema] of Object.entries(TOOL_SCHEMAS)) {
+    it(`${toolName} rejects unknown keys`, () => {
+      expect(isStrictZodObject(schema.inputSchema)).toBe(true);
+
+      const base = schema.inputSchema.safeParse(
+        minimalValidInput(toolName as keyof typeof TOOL_SCHEMAS)
+      );
+      expect(base.success).toBe(true);
+      if (!base.success) return;
+
+      const withExtra = schema.inputSchema.safeParse({
+        ...base.data,
+        __unexpectedKey: 'injected',
+      });
+      expect(withExtra.success).toBe(false);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Adds `chatToolSchema()` (`.strict()`) across the chat tool registry, account tools, onboarding signals, and inline `/api/chat` route tool schemas
- Replaces `req.json()` with `parseChatRequestBody()` using shared `parseJsonBody` (256KB cap, 413 on oversized `Content-Length`)
- Enforces per-message parts count (50) and serialized parts size limits before LLM work
- Re-asserts `creatorProfileId` on release metadata + generated pitch DB writes via `ownedReleaseWhere`
- Adds `@jovie/chat-tool-schema-strict` ESLint rule

## Acceptance criteria
- [x] Schema test asserting strict mode across registry (26 tools)
- [x] Write-path test proving cross-profile id update fails (`release-writes.test.ts`)
- [x] Oversized request rejected pre-parse with 413 (`request-validation.test.ts`)

## Test plan
- [x] `vitest run tests/unit/chat/tool-schemas-strict.test.ts`
- [x] `vitest run tests/unit/chat/release-writes.test.ts`
- [x] `vitest run tests/unit/chat/request-validation.test.ts`
- [x] `vitest run eslint-rules/chat-tool-schema-strict.test.js`

Closes JOV-3011