### PR TITLE
fix(chat): persist terminal tool-event states on client disconnect (JOV-3010)

### DIFF
--- a/apps/web/app/api/chat/conversations/[id]/route.ts
+++ b/apps/web/app/api/chat/conversations/[id]/route.ts
@@ -5,9 +5,16 @@ import {
   sanitizeConversationTitle,
   withSanitizedConversationTitle,
 } from '@/lib/chat/title';
-import { decodeToolEvents } from '@/lib/chat/tool-events';
+import {
+  decodeToolEvents,
+  resolvePersistedToolEventsForDisplay,
+} from '@/lib/chat/tool-events';
 import { db } from '@/lib/db';
-import { chatConversations, chatMessages } from '@/lib/db/schema/chat';
+import {
+  chatConversations,
+  chatMessages,
+  chatTurns,
+} from '@/lib/db/schema/chat';
 import { captureError } from '@/lib/error-tracking';
 import { logger } from '@/lib/utils/logger';
 import { getSessionErrorResponse } from '../../session-error-response';
@@ -89,9 +96,11 @@ export async function GET(req: Request, { params }: RouteParams) {
         toolCalls: chatMessages.toolCalls,
         clientMessageId: chatMessages.clientMessageId,
         turnId: chatMessages.turnId,
+        turnStatus: chatTurns.status,
         createdAt: chatMessages.createdAt,
       })
       .from(chatMessages)
+      .leftJoin(chatTurns, eq(chatMessages.turnId, chatTurns.id))
       .where(and(...conditions))
       .orderBy(desc(chatMessages.createdAt))
       .limit(limit + 1);
@@ -111,10 +120,22 @@ export async function GET(req: Request, { params }: RouteParams) {
         );
       }
 
+      const resolvedToolCalls = resolvePersistedToolEventsForDisplay(
+        decodedToolCalls.events,
+        {
+          messageCreatedAt: row.createdAt,
+          turnStatus: row.turnStatus,
+        }
+      );
+
       return {
-        ...row,
-        toolCalls:
-          decodedToolCalls.events.length > 0 ? decodedToolCalls.events : null,
+        id: row.id,
+        role: row.role,
+        content: row.content,
+        clientMessageId: row.clientMessageId,
+        turnId: row.turnId,
+        createdAt: row.createdAt,
+        toolCalls: resolvedToolCalls.length > 0 ? resolvedToolCalls : null,
       };
     });
 

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -63,8 +63,9 @@ import {
 } from '@/lib/chat/tool-access';
 import {
   decodeToolEvents,
-  encodeToolEvents,
   type PersistedToolEvent,
+  preparePersistedToolEventsForTurnFinish,
+  resolvePersistedToolEventsForDisplay,
 } from '@/lib/chat/tool-events';
 import {
   createMerchGenerateTool,
@@ -2560,8 +2561,14 @@ export async function POST(req: Request) {
         .reverse()
         .find(message => message.role === 'assistant');
       const assistantToolCalls = assistantMessage?.toolCalls;
-      const hasPersistedToolState =
-        decodeToolEvents(assistantToolCalls).events.length > 0;
+      const resolvedToolCalls = resolvePersistedToolEventsForDisplay(
+        decodeToolEvents(assistantToolCalls).events,
+        {
+          messageCreatedAt: assistantMessage?.createdAt,
+          turnStatus: reservation.turn.status,
+        }
+      );
+      const hasPersistedToolState = resolvedToolCalls.length > 0;
       const replayText =
         assistantMessage?.content ||
         (hasPersistedToolState
@@ -2569,7 +2576,8 @@ export async function POST(req: Request) {
           : 'This chat action already finished. Please send a new message if you need anything else.');
       return createAssistantReplayStreamResponse({
         text: replayText,
-        toolCalls: assistantToolCalls,
+        toolCalls:
+          resolvedToolCalls.length > 0 ? resolvedToolCalls : assistantToolCalls,
         requestId,
         corsHeaders,
         headers: {
@@ -2834,23 +2842,33 @@ export async function POST(req: Request) {
               requestId,
             })
           : undefined,
-      onFinish: async ({ responseMessage }) => {
+      onFinish: async ({ responseMessage, isAborted }) => {
         if (!reservedTurn || streamFailurePersisted) return;
 
         const assistantText = extractUIMessageText(
           responseMessage.parts as Array<{ type: string; text?: string }>
         );
-        const toolCalls = encodeToolEvents(responseMessage.parts);
+        const toolCalls = preparePersistedToolEventsForTurnFinish({
+          parts: responseMessage.parts,
+          isAborted,
+        });
         await persistTerminalAssistantMessage({
           conversationId: reservedTurn.conversationId,
           turnId: reservedTurn.turnId,
-          status: 'completed',
-          content:
-            assistantText ||
-            (toolCalls && toolCalls.length > 0
-              ? ''
-              : 'Done. What would you like to do next?'),
+          status: isAborted ? 'canceled' : 'completed',
+          content: isAborted
+            ? 'This response was canceled before Jovie could finish. Retry when you are ready.'
+            : assistantText ||
+              (toolCalls && toolCalls.length > 0
+                ? ''
+                : 'Done. What would you like to do next?'),
           toolCalls,
+          ...(isAborted
+            ? {
+                errorCode: 'CLIENT_DISCONNECTED',
+                errorMessage: 'Client disconnected',
+              }
+            : {}),
         });
       },
       onError: () => {

--- a/apps/web/lib/chat/tool-events.ts
+++ b/apps/web/lib/chat/tool-events.ts
@@ -353,6 +353,110 @@ function dedupeEvents(events: PersistedToolEvent[]): PersistedToolEvent[] {
   return Array.from(byId.values());
 }
 
+export const STALE_RUNNING_TOOL_EVENT_MS = 5 * 60 * 1000;
+
+const CLIENT_DISCONNECT_TOOL_ERROR =
+  'This tool was interrupted when the chat disconnected. Retry when you are ready.';
+
+const STALE_RUNNING_TOOL_ERROR =
+  'This tool call timed out before it could finish. Retry when you are ready.';
+
+export function terminalizeRunningToolEvents(
+  events: readonly PersistedToolEvent[] | undefined,
+  input?: { readonly errorMessage?: string }
+): PersistedToolEvent[] | undefined {
+  if (!events || events.length === 0) {
+    return undefined;
+  }
+
+  const errorMessage =
+    input?.errorMessage ??
+    'Tool execution was interrupted before it could finish.';
+  let changed = false;
+
+  const terminalized = events.map(event => {
+    if (event.state !== 'running') {
+      return event;
+    }
+
+    changed = true;
+    return {
+      ...event,
+      state: 'failed' as const,
+      errorMessage,
+      summary: errorMessage,
+    };
+  });
+
+  return changed ? terminalized : [...events];
+}
+
+export function preparePersistedToolEventsForTurnFinish(input: {
+  readonly parts: ReadonlyArray<UIMessage['parts'][number]>;
+  readonly isAborted: boolean;
+}): PersistedToolEvent[] | undefined {
+  const encoded = encodeToolEvents(input.parts);
+  if (!encoded) {
+    return undefined;
+  }
+
+  if (!input.isAborted) {
+    return encoded;
+  }
+
+  return terminalizeRunningToolEvents(encoded, {
+    errorMessage: CLIENT_DISCONNECT_TOOL_ERROR,
+  });
+}
+
+export function resolvePersistedToolEventsForDisplay(
+  events: readonly PersistedToolEvent[],
+  input?: {
+    readonly messageCreatedAt?: Date | string | null;
+    readonly observedAt?: Date;
+    readonly turnStatus?: string | null;
+  }
+): PersistedToolEvent[] {
+  if (events.length === 0) {
+    return [];
+  }
+
+  const hasRunning = events.some(event => event.state === 'running');
+  if (!hasRunning) {
+    return [...events];
+  }
+
+  if (input?.turnStatus === 'canceled') {
+    return (
+      terminalizeRunningToolEvents(events, {
+        errorMessage: CLIENT_DISCONNECT_TOOL_ERROR,
+      }) ?? [...events]
+    );
+  }
+
+  const observedAt = input?.observedAt ?? new Date();
+  const createdAt =
+    input?.messageCreatedAt instanceof Date
+      ? input.messageCreatedAt
+      : typeof input?.messageCreatedAt === 'string'
+        ? new Date(input.messageCreatedAt)
+        : null;
+  const ageMs =
+    createdAt && !Number.isNaN(createdAt.getTime())
+      ? observedAt.getTime() - createdAt.getTime()
+      : 0;
+
+  if (ageMs >= STALE_RUNNING_TOOL_EVENT_MS) {
+    return (
+      terminalizeRunningToolEvents(events, {
+        errorMessage: STALE_RUNNING_TOOL_ERROR,
+      }) ?? [...events]
+    );
+  }
+
+  return [...events];
+}
+
 export function encodeToolEvents(
   parts: ReadonlyArray<UIMessage['parts'][number]>
 ): PersistedToolEvent[] | undefined {

--- a/apps/web/tests/unit/chat/tool-events.test.ts
+++ b/apps/web/tests/unit/chat/tool-events.test.ts
@@ -3,6 +3,10 @@ import {
   decodeToolEvents,
   encodeToolEvents,
   persistedToolEventsSchema,
+  preparePersistedToolEventsForTurnFinish,
+  resolvePersistedToolEventsForDisplay,
+  STALE_RUNNING_TOOL_EVENT_MS,
+  terminalizeRunningToolEvents,
   toolEventToMessagePart,
 } from '@/lib/chat/tool-events';
 import { ONBOARDING_TOOLS } from '@/lib/chat/tool-schemas';
@@ -84,6 +88,139 @@ describe('tool event contract', () => {
     for (const toolName of [...CHAT_ROUTE_TOOL_NAMES, ...ONBOARDING_TOOLS]) {
       expect(TOOL_UI_REGISTRY[toolName]).toBeDefined();
     }
+  });
+
+  it('terminalizes running tool events for aborted turn persistence', () => {
+    const toolCalls = preparePersistedToolEventsForTurnFinish({
+      isAborted: true,
+      parts: [
+        {
+          type: 'dynamic-tool',
+          toolName: 'showTopInsights',
+          toolCallId: 'tool-running',
+          state: 'input-available',
+          input: { profileId: 'profile-1' },
+        },
+        {
+          type: 'dynamic-tool',
+          toolName: 'submitFeedback',
+          toolCallId: 'tool-done',
+          state: 'output-available',
+          input: { feedback: 'Ship it' },
+          output: { success: true },
+        },
+      ],
+    });
+
+    expect(toolCalls).toEqual([
+      expect.objectContaining({
+        toolCallId: 'tool-running',
+        state: 'failed',
+        errorMessage:
+          'This tool was interrupted when the chat disconnected. Retry when you are ready.',
+      }),
+      expect.objectContaining({
+        toolCallId: 'tool-done',
+        state: 'succeeded',
+      }),
+    ]);
+  });
+
+  it('resolves canceled-turn running tools for replay and reload', () => {
+    const runningEvent = {
+      schemaVersion: 2 as const,
+      toolCallId: 'tool-running',
+      toolName: 'showTopInsights',
+      state: 'running' as const,
+      uiHint: 'artifact' as const,
+    };
+
+    expect(
+      resolvePersistedToolEventsForDisplay([runningEvent], {
+        turnStatus: 'canceled',
+        messageCreatedAt: new Date('2026-06-10T12:00:00Z'),
+        observedAt: new Date('2026-06-10T12:00:10Z'),
+      })
+    ).toEqual([
+      expect.objectContaining({
+        toolCallId: 'tool-running',
+        state: 'failed',
+      }),
+    ]);
+  });
+
+  it('terminalizes stale running tools after the hydration grace window', () => {
+    const runningEvent = {
+      schemaVersion: 2 as const,
+      toolCallId: 'tool-stale',
+      toolName: 'showTopInsights',
+      state: 'running' as const,
+      uiHint: 'artifact' as const,
+    };
+    const createdAt = new Date('2026-06-10T12:00:00Z');
+
+    expect(
+      resolvePersistedToolEventsForDisplay([runningEvent], {
+        messageCreatedAt: createdAt,
+        observedAt: new Date(
+          createdAt.getTime() + STALE_RUNNING_TOOL_EVENT_MS + 1_000
+        ),
+      })
+    ).toEqual([
+      expect.objectContaining({
+        toolCallId: 'tool-stale',
+        state: 'failed',
+        errorMessage:
+          'This tool call timed out before it could finish. Retry when you are ready.',
+      }),
+    ]);
+  });
+
+  it('terminalizeRunningToolEvents only rewrites running entries', () => {
+    const runningEvent = {
+      schemaVersion: 2 as const,
+      toolCallId: 'tool-active',
+      toolName: 'showTopInsights',
+      state: 'running' as const,
+      uiHint: 'artifact' as const,
+    };
+    const succeededEvent = {
+      ...runningEvent,
+      toolCallId: 'tool-done',
+      state: 'succeeded' as const,
+      output: { success: true },
+    };
+
+    expect(
+      terminalizeRunningToolEvents([runningEvent, succeededEvent], {
+        errorMessage: 'Interrupted',
+      })
+    ).toEqual([
+      expect.objectContaining({
+        toolCallId: 'tool-active',
+        state: 'failed',
+        errorMessage: 'Interrupted',
+      }),
+      succeededEvent,
+    ]);
+  });
+
+  it('leaves in-flight running tools untouched while the turn is still active', () => {
+    const runningEvent = {
+      schemaVersion: 2 as const,
+      toolCallId: 'tool-active',
+      toolName: 'showTopInsights',
+      state: 'running' as const,
+      uiHint: 'artifact' as const,
+    };
+
+    expect(
+      resolvePersistedToolEventsForDisplay([runningEvent], {
+        turnStatus: 'streaming',
+        messageCreatedAt: new Date('2026-06-10T12:00:00Z'),
+        observedAt: new Date('2026-06-10T12:00:10Z'),
+      })
+    ).toEqual([runningEvent]);
   });
 
   it('preserves approval responses through persistence and hydration', () => {


### PR DESCRIPTION
## Summary
- Terminalize in-flight tool events when a chat stream aborts (`onFinish` with `isAborted`) so disconnects no longer persist `running` tool cards
- Resolve canceled-turn and stale (>5 min) running tool events on replay and conversation hydrate
- Add regression tests for the disconnect persistence contract

## Problem
If the client disconnects while a tool is executing, the turn can persist with tool events stuck in `running`. On reload/replay, the UI re-emits `tool-input-available` without a terminal chunk and shows a perpetual spinner.

## Test plan
- [x] `pnpm test -- tests/unit/chat/tool-events.test.ts`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`

Closes JOV-3010