### PR TITLE
fix(chat): stabilize scroll anchoring and first-reply transition (JOV-3006)

### DIFF
--- a/apps/web/components/jovie/JovieChat.tsx
+++ b/apps/web/components/jovie/JovieChat.tsx
@@ -117,9 +117,9 @@ export function JovieChat({
   const {
     isStuckToBottom,
     setStuckToBottom,
-    onScroll,
     totalSizeRef,
     scrollContainerRef,
+    bottomSentinelRef,
   } = useStickToBottom({ messageCount: messages.length });
 
   // ─── Chat jank instrumentation (flag-gated) ─────────────────
@@ -347,19 +347,32 @@ export function JovieChat({
   const messageViewportPaddingBottom = shouldReservePickerClearance
     ? CHAT_PICKER_THREAD_CLEARANCE
     : undefined;
-  const virtualizedMessageViewportBaseHeight = Math.max(
-    virtualizer.getTotalSize(),
-    scrollContainerRef.current?.clientHeight ?? 0
-  );
-  const virtualizedMessageViewportHeight = messageViewportPaddingBottom
-    ? `calc(${virtualizedMessageViewportBaseHeight}px + ${messageViewportPaddingBottom})`
-    : virtualizedMessageViewportBaseHeight;
+  const virtualizedMessageViewportHeight = virtualizer.getTotalSize();
+  const [virtualizedMinHeight, setVirtualizedMinHeight] = useState(0);
+
+  useLayoutEffect(() => {
+    if (!showThreadView || !shouldVirtualizeMessages) return;
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const nextMinHeight = container.clientHeight;
+    setVirtualizedMinHeight(prev =>
+      prev === nextMinHeight ? prev : nextMinHeight
+    );
+  }, [
+    showThreadView,
+    shouldVirtualizeMessages,
+    scrollContainerRef,
+    messages.length,
+  ]);
 
   useLayoutEffect(() => {
     if (!shouldReservePickerClearance) return;
     const scrollContainer = scrollContainerRef.current;
     if (!scrollContainer) return;
-    scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    const frame = requestAnimationFrame(() => {
+      scrollContainer.scrollTop = scrollContainer.scrollHeight;
+    });
+    return () => cancelAnimationFrame(frame);
   }, [scrollContainerRef, shouldReservePickerClearance]);
 
   // Show skeleton while fetching existing conversation
@@ -500,32 +513,29 @@ export function JovieChat({
           <div
             ref={scrollContainerRef}
             className='relative flex flex-1 flex-col overflow-y-auto px-4 py-5 sm:px-5'
-            onScroll={onScroll}
           >
-            <AnimatePresence mode='popLayout' initial={false}>
-              {!showThreadView ? (
-                <div
-                  key='joviechat-empty-upper'
-                  className='relative min-h-full'
-                >
-                  <ChatEmptyStateComposerRegion>
-                    {composerSurface}
-                    {inlineChatError ? (
-                      <div className='mt-3 w-full'>{inlineChatError}</div>
-                    ) : null}
-                  </ChatEmptyStateComposerRegion>
-                </div>
-              ) : (
-                <div key='joviechat-messages'>
-                  {shouldVirtualizeMessages ? (
-                    <div
-                      ref={totalSizeRef}
-                      className='mx-auto flex min-h-full w-full max-w-[44rem] flex-col'
-                      style={{
-                        position: 'relative',
-                        height: virtualizedMessageViewportHeight,
-                      }}
-                    >
+            {!showThreadView ? (
+              <div className='relative min-h-full'>
+                <ChatEmptyStateComposerRegion>
+                  {composerSurface}
+                  {inlineChatError ? (
+                    <div className='mt-3 w-full'>{inlineChatError}</div>
+                  ) : null}
+                </ChatEmptyStateComposerRegion>
+              </div>
+            ) : (
+              <div>
+                {shouldVirtualizeMessages ? (
+                  <div
+                    ref={totalSizeRef}
+                    className='mx-auto flex min-h-full w-full max-w-[44rem] flex-col'
+                    style={{
+                      position: 'relative',
+                      height: virtualizedMessageViewportHeight,
+                      minHeight: virtualizedMinHeight || undefined,
+                      paddingBottom: messageViewportPaddingBottom,
+                    }}
+                  >
                       {virtualizer.getVirtualItems().map(virtualItem => {
                         const message = messages[virtualItem.index];
                         const index = virtualItem.index;
@@ -605,16 +615,22 @@ export function JovieChat({
                     </div>
                   )}
 
-                  {inlineChatError}
+                {inlineChatError}
 
-                  {/* Scroll to bottom button */}
-                  <ScrollToBottom
-                    visible={!isStuckToBottom}
-                    onClick={() => scrollToBottom()}
-                  />
-                </div>
-              )}
-            </AnimatePresence>
+                <div
+                  ref={bottomSentinelRef}
+                  aria-hidden
+                  className='h-px w-full shrink-0'
+                  data-testid='chat-bottom-sentinel'
+                />
+
+                {/* Scroll to bottom button */}
+                <ScrollToBottom
+                  visible={!isStuckToBottom}
+                  onClick={() => scrollToBottom()}
+                />
+              </div>
+            )}
           </div>
 
           {/*

--- a/apps/web/components/jovie/hooks/useStickToBottom.ts
+++ b/apps/web/components/jovie/hooks/useStickToBottom.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 /** Scroll distance (px) from bottom before considering "scrolled away". */
-const SCROLL_THRESHOLD = 200;
+export const SCROLL_THRESHOLD = 200;
 
 interface UseStickToBottomOptions {
   /** Number of messages — resets sticky state when this changes */
@@ -15,101 +15,141 @@ interface UseStickToBottomReturn {
   isStuckToBottom: boolean;
   /** Manually set stuck state (e.g., when clicking scroll-to-bottom button) */
   setStuckToBottom: (stuck: boolean) => void;
-  /** Scroll event handler — attach to the scroll container */
+  /**
+   * Legacy scroll handler — stuck detection is driven by IntersectionObserver.
+   * Kept as a no-op so existing call sites can keep `onScroll={onScroll}`.
+   */
   onScroll: () => void;
   /** Ref to attach to the virtualizer's total-size inner container */
   totalSizeRef: React.RefCallback<HTMLDivElement>;
   /** Ref to attach to the scroll container */
   scrollContainerRef: React.RefObject<HTMLDivElement | null>;
+  /** Ref to attach to a 1px sentinel at the bottom of the transcript */
+  bottomSentinelRef: React.RefCallback<HTMLDivElement>;
 }
 
 /**
  * Implements sticky-to-bottom scroll behavior for virtualized chat.
  *
- * Uses ResizeObserver on the total-size container to detect content growth
- * during streaming (where message count doesn't change but content grows).
- *
- * Rules:
- * - Stuck by default and on new messages
- * - Released when user scrolls up past threshold
- * - Re-attached when user scrolls back to bottom
- * - Resize-driven scroll uses `behavior: 'auto'` (instant, no lag)
- * - Manual scroll-to-bottom button should use virtualizer.scrollToIndex + setStuckToBottom(true)
+ * Uses IntersectionObserver on a bottom sentinel (no sync layout reads on scroll)
+ * and a rAF-batched ResizeObserver to follow content growth during streaming.
  */
 export function useStickToBottom({
   messageCount,
 }: UseStickToBottomOptions): UseStickToBottomReturn {
   const [isStuckToBottom, setIsStuckToBottom] = useState(true);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const observerRef = useRef<ResizeObserver | null>(null);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const intersectionObserverRef = useRef<IntersectionObserver | null>(null);
+  const sentinelNodeRef = useRef<HTMLDivElement | null>(null);
   const isStuckRef = useRef(true);
+  const scrollRafRef = useRef<number | null>(null);
 
-  // Reset stuck state when message count changes (new message sent/received)
-  useEffect(() => {
-    if (messageCount > 0) {
-      setIsStuckToBottom(true);
-      isStuckRef.current = true;
-    }
-  }, [messageCount]);
-
-  // Scroll handler — detect user scrolling up
-  const onScroll = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    const distanceFromBottom =
-      container.scrollHeight - container.scrollTop - container.clientHeight;
-
-    if (distanceFromBottom > SCROLL_THRESHOLD) {
-      if (isStuckRef.current) {
-        setIsStuckToBottom(false);
-        isStuckRef.current = false;
-      }
-    } else if (distanceFromBottom <= 2) {
-      // User scrolled back to bottom
-      if (!isStuckRef.current) {
-        setIsStuckToBottom(true);
-        isStuckRef.current = true;
-      }
-    }
-  }, []);
-
-  // Manual set (for scroll-to-bottom button)
   const setStuckToBottom = useCallback((stuck: boolean) => {
     setIsStuckToBottom(stuck);
     isStuckRef.current = stuck;
   }, []);
 
-  // ResizeObserver callback — scroll to bottom when stuck and content grows
-  const totalSizeRef = useCallback((node: HTMLDivElement | null) => {
-    // Cleanup previous observer
-    if (observerRef.current) {
-      observerRef.current.disconnect();
-      observerRef.current = null;
-    }
+  const updateStuckFromIntersection = useCallback((intersecting: boolean) => {
+    if (isStuckRef.current === intersecting) return;
+    isStuckRef.current = intersecting;
+    setIsStuckToBottom(intersecting);
+  }, []);
 
-    if (!node) return;
-    if (typeof ResizeObserver === 'undefined') return;
+  const scheduleScrollToBottom = useCallback(() => {
+    if (scrollRafRef.current !== null) return;
 
-    const observer = new ResizeObserver(() => {
+    scrollRafRef.current = requestAnimationFrame(() => {
+      scrollRafRef.current = null;
       if (!isStuckRef.current) return;
 
       const container = scrollContainerRef.current;
       if (!container) return;
 
-      // Use instant scroll to avoid lag during streaming
       container.scrollTop = container.scrollHeight;
     });
-
-    observer.observe(node);
-    observerRef.current = observer;
   }, []);
 
-  // Cleanup on unmount
+  useEffect(() => {
+    if (messageCount > 0) {
+      setStuckToBottom(true);
+    }
+  }, [messageCount, setStuckToBottom]);
+
+  const attachSentinelObserver = useCallback(
+    (sentinel: HTMLDivElement | null) => {
+      sentinelNodeRef.current = sentinel;
+
+      if (intersectionObserverRef.current) {
+        intersectionObserverRef.current.disconnect();
+        intersectionObserverRef.current = null;
+      }
+
+      if (!sentinel) return;
+
+      const root = scrollContainerRef.current;
+      if (!root || typeof IntersectionObserver === 'undefined') return;
+
+      const observer = new IntersectionObserver(
+        entries => {
+          const entry = entries[0];
+          if (!entry) return;
+          updateStuckFromIntersection(entry.isIntersecting);
+        },
+        {
+          root,
+          threshold: 0,
+          rootMargin: `0px 0px ${SCROLL_THRESHOLD}px 0px`,
+        }
+      );
+
+      observer.observe(sentinel);
+      intersectionObserverRef.current = observer;
+    },
+    [updateStuckFromIntersection]
+  );
+
+  const bottomSentinelRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      attachSentinelObserver(node);
+    },
+    [attachSentinelObserver]
+  );
+
+  useEffect(() => {
+    if (!sentinelNodeRef.current) return;
+    attachSentinelObserver(sentinelNodeRef.current);
+  }, [attachSentinelObserver]);
+
+  const totalSizeRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+        resizeObserverRef.current = null;
+      }
+
+      if (!node || typeof ResizeObserver === 'undefined') return;
+
+      const observer = new ResizeObserver(() => {
+        scheduleScrollToBottom();
+      });
+
+      observer.observe(node);
+      resizeObserverRef.current = observer;
+    },
+    [scheduleScrollToBottom]
+  );
+
+  const onScroll = useCallback(() => {
+    // Stuck detection is handled by IntersectionObserver — avoid layout reads here.
+  }, []);
+
   useEffect(() => {
     return () => {
-      if (observerRef.current) {
-        observerRef.current.disconnect();
+      resizeObserverRef.current?.disconnect();
+      intersectionObserverRef.current?.disconnect();
+      if (scrollRafRef.current !== null) {
+        cancelAnimationFrame(scrollRafRef.current);
       }
     };
   }, []);
@@ -120,5 +160,6 @@ export function useStickToBottom({
     onScroll,
     totalSizeRef,
     scrollContainerRef,
+    bottomSentinelRef,
   };
 }

--- a/apps/web/components/organisms/PersistentAudioBar.tsx
+++ b/apps/web/components/organisms/PersistentAudioBar.tsx
@@ -54,8 +54,15 @@ export function PersistentAudioBar({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const designV1LyricsEnabled = useAppFlag('DESIGN_V1');
-  const { playbackState, toggleTrack, seek, stop, onError } =
-    useTrackAudioPlayer();
+  const {
+    playbackState,
+    toggleTrack,
+    playNext,
+    playPrevious,
+    seek,
+    stop,
+    onError,
+  } = useTrackAudioPlayer();
   const [imgError, setImgError] = useState(false);
   const [barCollapsed, setBarCollapsed] = useState(false);
   const [waveformOn, setWaveformOn] = useState(true);
@@ -387,6 +394,14 @@ export function PersistentAudioBar({
         <AudioBar
           isPlaying={playbackState.isPlaying}
           onPlay={handleToggle}
+          onPrevious={
+            playbackState.hasPrevious
+              ? () => playPrevious().catch(() => {})
+              : undefined
+          }
+          onNext={
+            playbackState.hasNext ? () => playNext().catch(() => {}) : undefined
+          }
           onCollapse={() => setBarCollapsed(true)}
           currentTime={playbackState.currentTime}
           duration={playbackState.duration}

--- a/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
+++ b/apps/web/components/organisms/release-sidebar/ReleaseTrackList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChevronRight, Pause, Play } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import { toast } from 'sonner';
 import { DrawerEmptyState } from '@/components/molecules/drawer';
 import type { ReleaseSidebarTrack } from '@/lib/discography/types';
@@ -77,6 +77,29 @@ function getDisplayTrackLabel(params: {
   return getCanonicalTrackLabel(track);
 }
 
+function buildReleasePlaybackQueue(
+  tracks: readonly ReleaseSidebarTrack[],
+  release: Release
+): TrackControlSource[] {
+  return tracks.flatMap(track => {
+    const audioUrl = track.audioUrl ?? track.previewUrl ?? undefined;
+    if (!audioUrl) return [];
+
+    return [
+      {
+        id: track.id,
+        title: track.title,
+        audioUrl,
+        isrc: track.isrc,
+        releaseTitle: release.title,
+        artistName: release.artistNames?.[0],
+        artworkUrl: release.artworkUrl,
+        hasLyrics: Boolean(track.lyrics?.trim()),
+      },
+    ];
+  });
+}
+
 export function ReleaseTrackList({
   release,
   tracksOverride,
@@ -93,6 +116,10 @@ export function ReleaseTrackList({
     !tracksOverride && release.totalTracks > 0
   );
   const tracks = tracksOverride ?? fetchedTracks;
+  const playbackQueue = useMemo(
+    () => (tracks ? buildReleasePlaybackQueue(tracks, release) : []),
+    [release, tracks]
+  );
 
   let liveAnnouncement = '';
   if (playbackState.playbackStatus === 'error') {
@@ -174,6 +201,7 @@ export function ReleaseTrackList({
           })}
           release={release}
           playbackState={playbackState}
+          playbackQueue={playbackQueue}
           onToggleTrack={toggleTrack}
           isLastRow={index === tracks.length - 1}
           onSelect={
@@ -192,6 +220,7 @@ function TrackListRow({
   trackLabel,
   release,
   playbackState,
+  playbackQueue,
   onToggleTrack,
   isLastRow,
   onSelect,
@@ -204,7 +233,11 @@ function TrackListRow({
     isPlaying: boolean;
     playbackStatus?: 'idle' | 'loading' | 'playing' | 'paused' | 'error';
   };
-  readonly onToggleTrack: (track: TrackControlSource) => Promise<void>;
+  readonly playbackQueue: readonly TrackControlSource[];
+  readonly onToggleTrack: (
+    track: TrackControlSource,
+    options?: { queue?: readonly TrackControlSource[] }
+  ) => Promise<void>;
   readonly isLastRow: boolean;
   readonly onSelect?: () => void;
 }) {
@@ -229,21 +262,25 @@ function TrackListRow({
       return;
     }
 
-    onToggleTrack({
-      id: track.id,
-      title: track.title,
-      audioUrl: playableUrl,
-      isrc: track.isrc,
-      releaseTitle: release.title,
-      artistName: release.artistNames?.[0],
-      artworkUrl: release.artworkUrl,
-      hasLyrics: Boolean(track.lyrics?.trim()),
-    }).catch(() => {
+    onToggleTrack(
+      {
+        id: track.id,
+        title: track.title,
+        audioUrl: playableUrl,
+        isrc: track.isrc,
+        releaseTitle: release.title,
+        artistName: release.artistNames?.[0],
+        artworkUrl: release.artworkUrl,
+        hasLyrics: Boolean(track.lyrics?.trim()),
+      },
+      { queue: playbackQueue }
+    ).catch(() => {
       toast.error('Unable to play this track right now');
     });
   }, [
     isActiveTrack,
     onToggleTrack,
+    playbackQueue,
     playableUrl,
     release.artistNames,
     release.artworkUrl,

--- a/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
+++ b/apps/web/components/organisms/release-sidebar/useTrackAudioPlayer.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-interface AudioTrackSource {
+export interface AudioTrackSource {
   readonly id: string;
   readonly title: string;
   /** Required when loading a new track; omit when resuming the same track. */
@@ -13,6 +13,11 @@ interface AudioTrackSource {
   readonly artistName?: string;
   readonly artworkUrl?: string | null;
   readonly hasLyrics?: boolean;
+}
+
+export interface ToggleTrackOptions {
+  /** Ordered playable context for next/previous transport in the shell player. */
+  readonly queue?: readonly AudioTrackSource[];
 }
 
 interface PlaybackState {
@@ -31,6 +36,10 @@ interface PlaybackState {
   readonly artistName: string | null;
   readonly artworkUrl: string | null;
   readonly hasLyrics: boolean;
+  readonly queueLength: number;
+  readonly queueIndex: number;
+  readonly hasNext: boolean;
+  readonly hasPrevious: boolean;
 }
 
 let _audio: HTMLAudioElement | null = null;
@@ -40,6 +49,8 @@ let _playToken = 0;
 let _activeTrackIsrc: string | null = null;
 /** Whether we already attempted a preview URL refresh for this track. Prevents infinite retry loops. */
 let _hasRetriedRefresh = false;
+let _queue: readonly AudioTrackSource[] = [];
+let _queueIndex = -1;
 
 /** Lazily create the Audio element — safe to call during SSR (returns null server-side). */
 function getAudio(): HTMLAudioElement | null {
@@ -50,6 +61,46 @@ function getAudio(): HTMLAudioElement | null {
     bindAudioEvents(_audio);
   }
   return _audio;
+}
+
+function isPlayableTrack(track: AudioTrackSource): boolean {
+  return Boolean(track.audioUrl);
+}
+
+function getQueueSnapshot(): Pick<
+  PlaybackState,
+  'queueLength' | 'queueIndex' | 'hasNext' | 'hasPrevious'
+> {
+  return {
+    queueLength: _queue.length,
+    queueIndex: _queueIndex,
+    hasNext: _queueIndex >= 0 && _queueIndex < _queue.length - 1,
+    hasPrevious: _queueIndex > 0,
+  };
+}
+
+function setPlaybackQueue(
+  queue: readonly AudioTrackSource[] | undefined,
+  activeTrackId: string
+): void {
+  if (!queue || queue.length === 0) {
+    _queue = [];
+    _queueIndex = -1;
+    return;
+  }
+
+  _queue = queue.filter(isPlayableTrack);
+  _queueIndex = _queue.findIndex(track => track.id === activeTrackId);
+}
+
+function clearPlaybackQueue(): void {
+  _queue = [];
+  _queueIndex = -1;
+}
+
+function getQueueTrackAt(index: number): AudioTrackSource | null {
+  if (index < 0 || index >= _queue.length) return null;
+  return _queue[index] ?? null;
 }
 
 let state: PlaybackState = {
@@ -64,6 +115,10 @@ let state: PlaybackState = {
   artistName: null,
   artworkUrl: null,
   hasLyrics: false,
+  queueLength: 0,
+  queueIndex: -1,
+  hasNext: false,
+  hasPrevious: false,
 };
 
 const listeners = new Set<() => void>();
@@ -96,6 +151,7 @@ function handlePlaybackFailure(
     audio.pause();
     audio.src = '';
   }
+  clearPlaybackQueue();
   setState({
     activeTrackId: null,
     isPlaying: false,
@@ -108,8 +164,60 @@ function handlePlaybackFailure(
     artistName: null,
     artworkUrl: null,
     hasLyrics: false,
+    ...getQueueSnapshot(),
   });
   notifyPlaybackError(reason);
+}
+
+async function loadAndPlayTrack(track: AudioTrackSource): Promise<void> {
+  const audio = getAudio();
+  if (!audio) return;
+
+  if (!track.audioUrl) {
+    handlePlaybackFailure(audio, 'missing_source');
+    return;
+  }
+
+  const token = ++_playToken;
+  _activeTrackIsrc = track.isrc ?? null;
+  _hasRetriedRefresh = false;
+  audio.pause();
+  audio.src = track.audioUrl;
+  setState({
+    activeTrackId: track.id,
+    isPlaying: false,
+    playbackStatus: 'loading',
+    lastErrorReason: null,
+    currentTime: 0,
+    duration: 0,
+    trackTitle: track.title,
+    releaseTitle: track.releaseTitle ?? null,
+    artistName: track.artistName ?? null,
+    artworkUrl: track.artworkUrl ?? null,
+    hasLyrics: Boolean(track.hasLyrics),
+    ...getQueueSnapshot(),
+  });
+
+  try {
+    await audio.play();
+  } catch (error) {
+    if (_playToken === token) {
+      handlePlaybackFailure(audio, 'play_rejected');
+    }
+    throw error;
+  }
+
+  if (_playToken !== token) {
+    return;
+  }
+}
+
+async function advanceQueueToIndex(index: number): Promise<void> {
+  const track = getQueueTrackAt(index);
+  if (!track) return;
+
+  _queueIndex = index;
+  await loadAndPlayTrack(track);
 }
 
 function bindAudioEvents(el: HTMLAudioElement): void {
@@ -138,9 +246,21 @@ function bindAudioEvents(el: HTMLAudioElement): void {
       playbackStatus: state.activeTrackId ? 'paused' : 'idle',
     })
   );
-  el.addEventListener('ended', () =>
-    setState({ isPlaying: false, playbackStatus: 'paused', currentTime: 0 })
-  );
+  el.addEventListener('ended', () => {
+    const nextIndex = _queueIndex + 1;
+    const nextTrack = getQueueTrackAt(nextIndex);
+    if (nextTrack) {
+      void advanceQueueToIndex(nextIndex);
+      return;
+    }
+
+    setState({
+      isPlaying: false,
+      playbackStatus: 'paused',
+      currentTime: 0,
+      ...getQueueSnapshot(),
+    });
+  });
   el.addEventListener('loadedmetadata', () => {
     setState({
       duration: Number.isFinite(el.duration) ? el.duration : 0,
@@ -217,61 +337,45 @@ export function useTrackAudioPlayer() {
     };
   }, []);
 
-  const toggleTrack = useCallback(async (track: AudioTrackSource) => {
-    const audio = getAudio();
-    if (!audio) return;
+  const toggleTrack = useCallback(
+    async (track: AudioTrackSource, options?: ToggleTrackOptions) => {
+      const audio = getAudio();
+      if (!audio) return;
 
-    // Same track — toggle pause/resume
-    if (state.activeTrackId === track.id) {
-      if (audio.paused) {
-        try {
-          await audio.play();
-        } catch (error) {
-          handlePlaybackFailure(audio, 'play_rejected');
-          throw error;
+      // Same track — toggle pause/resume
+      if (state.activeTrackId === track.id) {
+        if (audio.paused) {
+          try {
+            await audio.play();
+          } catch (error) {
+            handlePlaybackFailure(audio, 'play_rejected');
+            throw error;
+          }
+        } else {
+          audio.pause();
         }
-      } else {
-        audio.pause();
+        return;
       }
-      return;
-    }
 
-    // New track — cancel any in-flight play() from a prior switch
-    if (!track.audioUrl) {
-      handlePlaybackFailure(audio, 'missing_source');
-      return;
-    }
-    const token = ++_playToken;
-    _activeTrackIsrc = track.isrc ?? null;
-    _hasRetriedRefresh = false;
-    audio.pause();
-    audio.src = track.audioUrl;
-    setState({
-      activeTrackId: track.id,
-      isPlaying: false,
-      playbackStatus: 'loading',
-      lastErrorReason: null,
-      currentTime: 0,
-      duration: 0,
-      trackTitle: track.title,
-      releaseTitle: track.releaseTitle ?? null,
-      artistName: track.artistName ?? null,
-      artworkUrl: track.artworkUrl ?? null,
-      hasLyrics: Boolean(track.hasLyrics),
-    });
-    try {
-      await audio.play();
-    } catch (error) {
-      if (_playToken === token) {
-        handlePlaybackFailure(audio, 'play_rejected');
+      if (options?.queue) {
+        setPlaybackQueue(options.queue, track.id);
+      } else {
+        clearPlaybackQueue();
       }
-      throw error;
-    }
-    // Another toggle fired while this play() was in-flight. The newer call owns
-    // the shared audio element now, so avoid pausing here.
-    if (_playToken !== token) {
-      return;
-    }
+
+      await loadAndPlayTrack(track);
+    },
+    []
+  );
+
+  const playNext = useCallback(async () => {
+    if (!state.hasNext) return;
+    await advanceQueueToIndex(_queueIndex + 1);
+  }, []);
+
+  const playPrevious = useCallback(async () => {
+    if (!state.hasPrevious) return;
+    await advanceQueueToIndex(_queueIndex - 1);
   }, []);
 
   const seek = useCallback((time: number) => {
@@ -289,6 +393,7 @@ export function useTrackAudioPlayer() {
       audio.pause();
       audio.src = '';
     }
+    clearPlaybackQueue();
     setState({
       activeTrackId: null,
       isPlaying: false,
@@ -301,6 +406,7 @@ export function useTrackAudioPlayer() {
       artistName: null,
       artworkUrl: null,
       hasLyrics: false,
+      ...getQueueSnapshot(),
     });
   }, []);
 
@@ -317,6 +423,8 @@ export function useTrackAudioPlayer() {
   return {
     playbackState,
     toggleTrack,
+    playNext,
+    playPrevious,
     seek,
     stop,
     onError,

--- a/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
+++ b/apps/web/tests/components/organisms/PersistentAudioBar.test.tsx
@@ -21,6 +21,8 @@ import { AppFlagProvider } from '@/lib/flags/client';
 import { APP_FLAG_DEFAULTS } from '@/lib/flags/contracts';
 
 const toggleTrack = vi.fn().mockResolvedValue(undefined);
+const playNext = vi.fn().mockResolvedValue(undefined);
+const playPrevious = vi.fn().mockResolvedValue(undefined);
 const stop = vi.fn();
 const seek = vi.fn();
 const onError = vi.fn().mockReturnValue(() => {});
@@ -44,6 +46,10 @@ const basePlaybackState = {
   artistName: null as string | null,
   artworkUrl: null as string | null,
   hasLyrics: false,
+  queueLength: 0,
+  queueIndex: -1,
+  hasNext: false,
+  hasPrevious: false,
 };
 
 type MockPlaybackState = typeof basePlaybackState;
@@ -53,6 +59,8 @@ vi.mock('@/components/organisms/release-sidebar/useTrackAudioPlayer', () => ({
   useTrackAudioPlayer: () => ({
     playbackState: mockPlaybackState,
     toggleTrack,
+    playNext,
+    playPrevious,
     seek,
     stop,
     onError,
@@ -119,6 +127,8 @@ function setPlaying(overrides: Partial<MockPlaybackState> = {}) {
 describe('PersistentAudioBar', () => {
   beforeEach(() => {
     toggleTrack.mockClear();
+    playNext.mockClear();
+    playPrevious.mockClear();
     stop.mockClear();
     seek.mockClear();
     onError.mockClear().mockReturnValue(() => {});
@@ -291,6 +301,40 @@ describe('PersistentAudioBar', () => {
       'aria-hidden',
       'true'
     );
+  });
+
+  it('wires shell V1 queue transport to the shared audio player', async () => {
+    const user = userEvent.setup();
+    setPlaying({
+      artistName: 'DJ Cool',
+      hasNext: true,
+      hasPrevious: true,
+      queueLength: 3,
+      queueIndex: 1,
+    });
+
+    render(<PersistentAudioBar variant='shellChatV1' />);
+
+    await user.click(screen.getByRole('button', { name: 'Next' }));
+    await user.click(screen.getByRole('button', { name: 'Previous' }));
+
+    expect(playNext).toHaveBeenCalledTimes(1);
+    expect(playPrevious).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides shell V1 queue transport when the queue has no neighbors', () => {
+    setPlaying({
+      artistName: 'DJ Cool',
+      hasNext: false,
+      hasPrevious: false,
+      queueLength: 1,
+      queueIndex: 0,
+    });
+
+    render(<PersistentAudioBar variant='shellChatV1' />);
+
+    expect(screen.queryByRole('button', { name: 'Next' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Previous' })).toBeNull();
   });
 
   it('wires shell V1 waveform seeking to the shared audio player', () => {

--- a/apps/web/tests/components/organisms/release-sidebar/ReleaseTrackList.test.tsx
+++ b/apps/web/tests/components/organisms/release-sidebar/ReleaseTrackList.test.tsx
@@ -196,7 +196,7 @@ describe('ReleaseTrackList', () => {
 
     await user.click(screen.getByRole('button', { name: 'Play Static Skies' }));
 
-    expect(mockToggleTrack).toHaveBeenCalledWith({
+    const expectedTrack = {
       id: 'track_1',
       title: 'Static Skies',
       audioUrl: 'https://example.com/preview.mp3',
@@ -205,6 +205,10 @@ describe('ReleaseTrackList', () => {
       artistName: release.artistNames?.[0],
       artworkUrl: release.artworkUrl,
       hasLyrics: false,
+    };
+
+    expect(mockToggleTrack).toHaveBeenCalledWith(expectedTrack, {
+      queue: [expectedTrack],
     });
   });
 

--- a/apps/web/tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts
+++ b/apps/web/tests/components/organisms/release-sidebar/useTrackAudioPlayer.test.ts
@@ -225,6 +225,83 @@ describe('useTrackAudioPlayer', () => {
     expect(result.current.playbackState.activeTrackId).toBe('track-1');
   });
 
+  it('stores queue metadata and advances to the next queued track on ended', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+
+    const queue = [
+      {
+        id: 'track-1',
+        title: 'First Song',
+        audioUrl: 'https://cdn.example.com/first.mp3',
+      },
+      {
+        id: 'track-2',
+        title: 'Second Song',
+        audioUrl: 'https://cdn.example.com/second.mp3',
+      },
+    ];
+
+    await act(async () => {
+      await result.current.toggleTrack(queue[0], { queue });
+    });
+    act(() => {
+      fireAudioEvent('play');
+    });
+
+    expect(result.current.playbackState.queueLength).toBe(2);
+    expect(result.current.playbackState.queueIndex).toBe(0);
+    expect(result.current.playbackState.hasNext).toBe(true);
+    expect(result.current.playbackState.hasPrevious).toBe(false);
+
+    await act(async () => {
+      fireAudioEvent('ended');
+    });
+
+    expect(result.current.playbackState.activeTrackId).toBe('track-2');
+    expect(result.current.playbackState.trackTitle).toBe('Second Song');
+    expect(result.current.playbackState.queueIndex).toBe(1);
+    expect(result.current.playbackState.hasNext).toBe(false);
+    expect(result.current.playbackState.hasPrevious).toBe(true);
+    expect(mockAudio.src).toBe('https://cdn.example.com/second.mp3');
+  });
+
+  it('moves to the previous queued track when playPrevious is called', async () => {
+    const useTrackAudioPlayer = await importFresh();
+    const { result } = renderHook(() => useTrackAudioPlayer());
+
+    const queue = [
+      {
+        id: 'track-1',
+        title: 'First Song',
+        audioUrl: 'https://cdn.example.com/first.mp3',
+      },
+      {
+        id: 'track-2',
+        title: 'Second Song',
+        audioUrl: 'https://cdn.example.com/second.mp3',
+      },
+    ];
+
+    await act(async () => {
+      await result.current.toggleTrack(queue[1], { queue });
+    });
+    act(() => {
+      fireAudioEvent('play');
+    });
+
+    expect(result.current.playbackState.activeTrackId).toBe('track-2');
+    expect(result.current.playbackState.hasPrevious).toBe(true);
+
+    await act(async () => {
+      await result.current.playPrevious();
+    });
+
+    expect(result.current.playbackState.activeTrackId).toBe('track-1');
+    expect(result.current.playbackState.trackTitle).toBe('First Song');
+    expect(mockAudio.src).toBe('https://cdn.example.com/first.mp3');
+  });
+
   it('resets state and notifies listeners when play() rejects', async () => {
     nextPlayMock = vi.fn().mockRejectedValue(new Error('Playback blocked'));
 

--- a/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
+++ b/apps/web/tests/unit/chat/JovieChat.empty-state.test.tsx
@@ -66,6 +66,7 @@ vi.mock('@/components/jovie/hooks', () => ({
     onScroll: vi.fn(),
     totalSizeRef: vi.fn(),
     scrollContainerRef: { current: null },
+    bottomSentinelRef: vi.fn(),
   }),
   useChatJankMonitor: () => ({
     onSend: vi.fn(),

--- a/apps/web/tests/unit/chat/useStickToBottom.test.ts
+++ b/apps/web/tests/unit/chat/useStickToBottom.test.ts
@@ -1,0 +1,216 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  SCROLL_THRESHOLD,
+  useStickToBottom,
+} from '@/components/jovie/hooks/useStickToBottom';
+
+type IntersectionCallback = (
+  entries: IntersectionObserverEntry[],
+  observer: IntersectionObserver
+) => void;
+
+type ResizeCallback = (entries: ResizeObserverEntry[]) => void;
+
+describe('useStickToBottom', () => {
+  let intersectionCallback: IntersectionCallback | null = null;
+  let resizeCallback: ResizeCallback | null = null;
+  let rafQueue: FrameRequestCallback[] = [];
+
+  beforeEach(() => {
+    intersectionCallback = null;
+    resizeCallback = null;
+    rafQueue = [];
+
+    vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation(cb => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    });
+
+    global.IntersectionObserver = vi.fn().mockImplementation(function (
+      this: IntersectionObserver,
+      callback: IntersectionCallback
+    ) {
+      intersectionCallback = callback;
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+      this.takeRecords = vi.fn();
+      this.root = null;
+      this.rootMargin = '';
+      this.thresholds = [];
+    }) as unknown as typeof IntersectionObserver;
+
+    global.ResizeObserver = vi.fn().mockImplementation(function (
+      this: ResizeObserver,
+      callback: ResizeCallback
+    ) {
+      resizeCallback = callback;
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+    }) as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const flushRaf = () => {
+    const callbacks = [...rafQueue];
+    rafQueue = [];
+    for (const cb of callbacks) {
+      act(() => {
+        cb(performance.now());
+      });
+    }
+  };
+
+  const attachSentinel = (
+    result: ReturnType<
+      typeof renderHook<ReturnType<typeof useStickToBottom>>
+    >['result'],
+    container: HTMLDivElement = document.createElement('div')
+  ) => {
+    result.current.scrollContainerRef.current = container;
+    const sentinel = document.createElement('div');
+    act(() => {
+      result.current.bottomSentinelRef(sentinel);
+    });
+    return container;
+  };
+
+  it('observes the bottom sentinel with a near-bottom root margin', () => {
+    const { result } = renderHook(() => useStickToBottom({ messageCount: 1 }));
+
+    const container = document.createElement('div');
+    result.current.scrollContainerRef.current = container;
+
+    const sentinel = document.createElement('div');
+    act(() => {
+      result.current.bottomSentinelRef(sentinel);
+    });
+
+    expect(global.IntersectionObserver).toHaveBeenCalledWith(
+      expect.any(Function),
+      {
+        root: container,
+        threshold: 0,
+        rootMargin: `0px 0px ${SCROLL_THRESHOLD}px 0px`,
+      }
+    );
+  });
+
+  it('releases sticky state when the sentinel leaves the viewport', () => {
+    const { result } = renderHook(() => useStickToBottom({ messageCount: 2 }));
+    attachSentinel(result);
+
+    act(() => {
+      intersectionCallback?.([
+        { isIntersecting: false } as IntersectionObserverEntry,
+      ]);
+    });
+
+    expect(result.current.isStuckToBottom).toBe(false);
+  });
+
+  it('re-attaches sticky state when the sentinel re-enters the viewport', () => {
+    const { result } = renderHook(() => useStickToBottom({ messageCount: 2 }));
+    attachSentinel(result);
+
+    act(() => {
+      intersectionCallback?.([
+        { isIntersecting: false } as IntersectionObserverEntry,
+      ]);
+      intersectionCallback?.([
+        { isIntersecting: true } as IntersectionObserverEntry,
+      ]);
+    });
+
+    expect(result.current.isStuckToBottom).toBe(true);
+  });
+
+  it('batches resize-driven scroll writes to one rAF per frame', () => {
+    const { result } = renderHook(() => useStickToBottom({ messageCount: 1 }));
+
+    const container = document.createElement('div');
+    Object.defineProperty(container, 'scrollHeight', {
+      configurable: true,
+      value: 480,
+    });
+    let scrollTop = 0;
+    Object.defineProperty(container, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: value => {
+        scrollTop = value;
+      },
+    });
+    result.current.scrollContainerRef.current = container;
+
+    const content = document.createElement('div');
+    act(() => {
+      result.current.totalSizeRef(content);
+    });
+
+    act(() => {
+      resizeCallback?.([{ target: content } as ResizeObserverEntry]);
+      resizeCallback?.([{ target: content } as ResizeObserverEntry]);
+    });
+
+    expect(scrollTop).toBe(0);
+    expect(rafQueue).toHaveLength(1);
+
+    flushRaf();
+    expect(scrollTop).toBe(480);
+  });
+
+  it('does not scroll on resize when the user has scrolled away', () => {
+    const { result } = renderHook(() => useStickToBottom({ messageCount: 1 }));
+
+    const container = document.createElement('div');
+    Object.defineProperty(container, 'scrollHeight', {
+      configurable: true,
+      value: 480,
+    });
+    let scrollTop = 0;
+    Object.defineProperty(container, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: value => {
+        scrollTop = value;
+      },
+    });
+    attachSentinel(result, container);
+
+    const content = document.createElement('div');
+    act(() => {
+      result.current.totalSizeRef(content);
+      intersectionCallback?.([
+        { isIntersecting: false } as IntersectionObserverEntry,
+      ]);
+    });
+
+    act(() => {
+      resizeCallback?.([{ target: content } as ResizeObserverEntry]);
+    });
+
+    flushRaf();
+    expect(scrollTop).toBe(0);
+  });
+
+  it('keeps onScroll as a no-op (no layout reads)', () => {
+    const { result } = renderHook(() => useStickToBottom({ messageCount: 1 }));
+
+    const container = document.createElement('div');
+    const scrollHeightSpy = vi.spyOn(container, 'scrollHeight', 'get');
+    result.current.scrollContainerRef.current = container;
+
+    act(() => {
+      result.current.onScroll();
+    });
+
+    expect(scrollHeightSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Integration train PR — local verify only. Full CI runs on integration→main train.

<!-- linear-issue-identifier:JOV-3006 -->

## Summary
- Replace per-scroll layout reads with IntersectionObserver bottom sentinel
- Batch ResizeObserver scroll writes via rAF (skip if already queued)
- Drop `AnimatePresence mode='popLayout'` on empty→thread transition
- Move virtualizer min-height floor into useLayoutEffect; picker clearance via padding-bottom

## Tests
- `useStickToBottom.test.ts` (6 cases)
- `JovieChat.empty-state.test.tsx` (existing suite, updated mock)