### PR TITLE
feat(hermes): add codex issue shipper

### DIFF
--- a/docs/HERMES_AIR.md
+++ b/docs/HERMES_AIR.md
@@ -4,7 +4,7 @@ Day-to-day operations for the always-on Hermes gateway running on the dedicated 
 
 ## What This Machine Is
 
-A single-purpose orchestration node. It listens for brain dumps (Telegram + Voice Memos), persists them to gbrain, routes engineering work to Linear (the Pro's existing runner consumes it), and routes ops tasks to sub-agents. It does **zero coding**.
+A single-purpose orchestration node. It listens for brain dumps (Telegram + Voice Memos), persists them to gbrain, routes engineering work to Linear, and routes ops tasks to sub-agents. The Hermes scanner code does **zero coding** itself. The opt-in codex issue shipper can start a separate `JOVIE_AGENT_PROFILE=coder` child session for GitHub issues explicitly labeled `codex`.
 
 ## First-Time Setup
 
@@ -96,6 +96,7 @@ Once installed, you should never need to interact with the Air directly. All con
 |---|---|
 | Brain-dump an idea | Telegram the bot, or record a Voice Memo on iPhone |
 | File a bug | Voice-memo "Hermes, file a Linear issue for ..." or type it |
+| Queue local coding work | Add the GitHub issue label `codex` |
 | Ask a strategic question | Telegram the bot; the chief profile routes |
 | Get a daily summary | Wait for the 07:00 briefing, or Telegram "brief me" |
 | Push back rate-limited | Hermes will respond with which model it used |
@@ -119,6 +120,10 @@ ps -axm -o rss,command | awk '/hermes|gbrain|ollama|whisper/ { sum+=$1; print } 
 
 # Recent dispatch log
 tail -50 ~/.hermes/logs/dispatch.jsonl | jq .
+
+# Codex issue shipper logs
+tail -50 ~/.hermes/logs/launchd/cron-codex-issue-shipper.log
+tail -50 ~/.hermes/logs/codex-issue-shipper/*.log 2>/dev/null  # after a non-dry-run agent dispatch
 
 # Free-model rankings
 cat ~/.hermes/state/model-router-rankings.json | jq .
@@ -174,6 +179,41 @@ tail -f ~/.hermes/logs/voice-memo.jsonl
 hermes gateway restart --all
 launchctl kickstart -k gui/$(id -u)/co.jovie.hermes.gbrain-server
 ```
+
+### Run the codex issue shipper once
+
+```bash
+HERMES_CODEX_SHIPPER_DRY_RUN=1 tsx scripts/hermes/jobs/codex-issue-shipper.ts
+tsx scripts/hermes/jobs/codex-issue-shipper.ts
+```
+
+The job watches open GitHub issues labeled `codex`. Empty runs only call GitHub, write a JSONL event, and exit. No gbrain query, model call, subagent, or CodeRabbit review starts until an eligible issue exists.
+
+Config variables:
+
+| Variable | Default | Purpose | Update path |
+|---|---:|---|---|
+| `HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN` | `1` | Max Codex issues shipped per run; controls concurrency and spend | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
+| `HERMES_CODEX_SHIPPER_INTEGRATION_THRESHOLD` | `4` | Eligible queue depth that routes trainable issues through `integration/codex-queue` | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
+| `HERMES_CODEX_SHIPPER_AGENT` | `claude` | Local coding agent binary; `claude` keeps subagent support, `codex` is available as an explicit override | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
+
+Control labels:
+
+| Label | Meaning |
+|---|---|
+| `codex` | Eligible source queue |
+| `codex-in-progress` | Claimed by the local shipper |
+| `codex-blocked` | Real blocker; the shipper will not retry automatically |
+| `human-review-required` | Hard skip |
+| `integration-branch` | Batch trainable issues through the integration branch |
+
+Ship now / Re-evaluate when / Then:
+
+| Decision | Trigger | Action |
+|---|---|---|
+| Ship now | Default `HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN=1`, because one coder session can consume hours of agent time plus CI minutes | Keep one issue per run and let the 15-minute cron continue draining |
+| Re-evaluate when | Eligible `codex` queue stays above 4 issues for two consecutive runs and cost per shipped issue stays under the weekly unit target: CI minutes x runner cost plus agent minutes x model cost | Raise `HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN` or add an `integration-branch` label to queue trainable issues |
+| Then | CI minutes x runner cost plus agent minutes x model cost stay within the weekly agent budget | Keep the higher concurrency; otherwise return to one issue per run |
 
 ## Recovery Procedures
 
@@ -245,6 +285,7 @@ Removes all launchd plists, drops `~/.hermes/`, leaves Doppler and Tailscale alo
 | `~/.hermes/config.yaml` | Hermes gateway config (rendered from Doppler) | regenerable |
 | `~/.hermes/.env` | Secrets (chmod 600) | regenerable |
 | `~/.hermes/logs/` | All Hermes logs | rotate weekly via launchd |
+| `~/.hermes/logs/codex-issue-shipper/` | Coder prompts and run logs for `codex` issue dispatches | operator-managed; prune if large |
 | `~/.hermes/state/voice-memos-seen.json` | Dedupe ledger | rebuildable (worst case: re-ingest 1 day) |
 | `~/.hermes/state/heavy-job.lock` | Semaphore for Ollama vs whisper | ephemeral |
 | `~/.hermes/state/model-router-rankings.json` | Free-model rankings | regenerable nightly |

--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
     "version:check": "node scripts/version-check.mjs",
     "changelog:send": "doppler run -- node scripts/send-changelog-email.mjs",
     "video:footer:generate": "doppler run --project jovie-web --config dev -- tsx scripts/generate-footer-cta-video.ts",
-    "hermes:worker": "pnpm --filter @jovie/web run hermes:worker"
+    "hermes:worker": "pnpm --filter @jovie/web run hermes:worker",
+    "hermes:codex-shipper": "tsx scripts/hermes/jobs/codex-issue-shipper.ts"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.100.1",

--- a/scripts/hermes/bootstrap-air.sh
+++ b/scripts/hermes/bootstrap-air.sh
@@ -132,6 +132,18 @@ require_cmd gh
 require_cmd jq
 require_cmd sqlite3
 require_cmd curl
+require_cmd node
+
+NODE_VERSION="$(node --version)"
+if [[ ! "$NODE_VERSION" =~ ^v22\.([0-9]+)\.([0-9]+) ]]; then
+  die "Node 22.x required, found $NODE_VERSION. Run: nvm use 22 && corepack prepare pnpm@9.15.4 --activate"
+fi
+NODE_MINOR="${BASH_REMATCH[1]}"
+if (( 10#$NODE_MINOR < 13 )); then
+  die "Node >=22.13.0 required, found $NODE_VERSION. Run: nvm use 22 && corepack prepare pnpm@9.15.4 --activate"
+fi
+ok "Node $NODE_VERSION supported"
+NODE_BIN_DIR="$(dirname "$(command -v node)")"
 
 # 2. Doppler auth + scope
 doppler setup --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" --no-interactive >/dev/null
@@ -220,6 +232,7 @@ else
   HERMES_BIN="$(command -v hermes || echo /usr/local/bin/hermes)"
   GBRAIN_BIN="$(command -v gbrain || echo /usr/local/bin/gbrain)"
   TSX_BIN="$(command -v tsx || echo "${REPO_ROOT}/node_modules/.bin/tsx")"
+  NODE_BIN_DIR="$(dirname "$(command -v node)")"
   TAILSCALE_IP="$(tailscale ip -4 2>/dev/null | head -1 || echo 127.0.0.1)"
 fi
 
@@ -295,7 +308,7 @@ for tmpl in "${REPO_ROOT}/scripts/hermes/launchd/"*.plist.template; do
   out="${LAUNCH_AGENTS}/${label}.plist"
   # Python substitution is safer than sed for paths that may contain |, &, /, etc.
   HOME_V="$HOME" REPO_V="$REPO_ROOT" HERMES_V="$HERMES_BIN" \
-  GBRAIN_V="$GBRAIN_BIN" TSX_V="$TSX_BIN" TS_IP_V="$TAILSCALE_IP" \
+  GBRAIN_V="$GBRAIN_BIN" TSX_V="$TSX_BIN" NODE_BIN_V="$NODE_BIN_DIR" TS_IP_V="$TAILSCALE_IP" \
   python3 - "$tmpl" "$out" <<'PYEOF'
 import os, sys
 src, dst = sys.argv[1], sys.argv[2]
@@ -305,6 +318,7 @@ mapping = {
     "{{HERMES_BIN}}": os.environ["HERMES_V"],
     "{{GBRAIN_BIN}}": os.environ["GBRAIN_V"],
     "{{TSX_BIN}}": os.environ["TSX_V"],
+    "{{NODE_BIN_DIR}}": os.environ["NODE_BIN_V"],
     "{{TAILSCALE_IP}}": os.environ["TS_IP_V"],
 }
 with open(src, "r") as f:

--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -302,6 +302,52 @@ function markBlocked(
   }
 }
 
+function releaseClaimForRetry(
+  config: ShipperConfig,
+  plan: DispatchPlan,
+  reason: string
+): void {
+  try {
+    run(
+      [
+        'gh',
+        'issue',
+        'edit',
+        String(plan.issue.number),
+        '--repo',
+        config.repo,
+        '--remove-label',
+        CODEX_CLAIM_LABEL,
+      ],
+      config
+    );
+  } catch (err) {
+    logJobEvent({
+      job: JOB,
+      event: 'release_claim_label_failed',
+      issue: plan.issue.number,
+      error: shortError(err),
+    });
+  }
+
+  try {
+    commentIssue(
+      config,
+      plan.issue.number,
+      [`Codex issue shipper released this issue for retry.`, '', reason].join(
+        '\n'
+      )
+    );
+  } catch (err) {
+    logJobEvent({
+      job: JOB,
+      event: 'release_claim_comment_failed',
+      issue: plan.issue.number,
+      error: shortError(err),
+    });
+  }
+}
+
 function gbrainCaptureSlug(raw: string, fallback: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return fallback;
@@ -464,7 +510,7 @@ async function dispatchPlan(
     gbrain = collectGbrainContext(plan);
   } catch (err) {
     const reason = `GBrain capture failed, so no coding agent was started.\n\n\`\`\`text\n${shortError(err)}\n\`\`\``;
-    markBlocked(config, plan, reason);
+    releaseClaimForRetry(config, plan, reason);
     logJobEvent({
       job: JOB,
       event: 'gbrain_failed',

--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -1,0 +1,637 @@
+#!/usr/bin/env tsx
+/**
+ * Codex Issue Shipper — Hermes-Air
+ *
+ * Watches open GitHub issues labeled `codex`, claims one eligible issue, writes
+ * dispatch context to gbrain, then starts a coder-profile agent to ship it.
+ *
+ * The empty-queue path is intentionally cheap: GitHub scan, log, exit. No
+ * gbrain query, model call, subagent, or CodeRabbit work happens unless an
+ * issue is eligible and claimed.
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  buildAgentCommand,
+  buildAgentPrompt,
+  buildDispatchPlans,
+  buildGbrainCaptureText,
+  buildGbrainQuery,
+  CODEX_BLOCKED_LABEL,
+  CODEX_CLAIM_LABEL,
+  type DispatchPlan,
+  type GbrainContext,
+  type GithubIssue,
+  HUMAN_REVIEW_LABEL,
+  labelNames,
+  loadShipperConfig,
+  type ShipperConfig,
+} from '../lib/codex-issue-shipper';
+import { withHeavyJobLock } from '../lib/heavy-job-lock';
+import { HERMES_PATHS } from '../lib/hermes-paths';
+import { logJobEvent, withJobLogging } from '../lib/jobs-log';
+
+const JOB = 'codex-issue-shipper';
+
+interface AgentRunResult {
+  readonly ok: boolean;
+  readonly status: number | null;
+  readonly signal: NodeJS.Signals | null;
+  readonly error?: string;
+  readonly logPath: string;
+  readonly promptPath: string;
+}
+
+function shortError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function unquoteEnvValue(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function loadHermesEnv(): void {
+  if (!existsSync(HERMES_PATHS.env)) return;
+  const lines = readFileSync(HERMES_PATHS.env, 'utf8').split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const index = trimmed.indexOf('=');
+    if (index <= 0) continue;
+    const key = trimmed.slice(0, index).trim();
+    if (!/^[A-Z_][A-Z0-9_]*$/.test(key)) continue;
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = unquoteEnvValue(trimmed.slice(index + 1));
+  }
+}
+
+function run(args: ReadonlyArray<string>, config: ShipperConfig): string {
+  return execFileSync(args[0], args.slice(1), {
+    cwd: config.repoRoot,
+    encoding: 'utf8',
+    timeout: 30_000,
+    maxBuffer: 5 * 1024 * 1024,
+  });
+}
+
+function detectRepoRoot(): string {
+  if (process.env.HERMES_JOVIE_REPO) return process.env.HERMES_JOVIE_REPO;
+  return execFileSync('git', ['rev-parse', '--show-toplevel'], {
+    encoding: 'utf8',
+    timeout: 10_000,
+  }).trim();
+}
+
+function detectGithubRepo(repoRoot: string): string {
+  if (process.env.GH_REPO) return process.env.GH_REPO;
+  return execFileSync(
+    'gh',
+    ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: 30_000,
+    }
+  ).trim();
+}
+
+function listCodexIssues(config: ShipperConfig): ReadonlyArray<GithubIssue> {
+  const raw = run(
+    [
+      'gh',
+      'issue',
+      'list',
+      '--repo',
+      config.repo,
+      '--state',
+      'open',
+      '--label',
+      'codex',
+      '--limit',
+      String(config.issueFetchLimit),
+      '--json',
+      'number,title,body,url,updatedAt,labels',
+    ],
+    config
+  );
+  return JSON.parse(raw) as ReadonlyArray<GithubIssue>;
+}
+
+function ensureLabel(
+  config: ShipperConfig,
+  name: string,
+  color: string,
+  description: string
+): void {
+  try {
+    run(
+      [
+        'gh',
+        'label',
+        'create',
+        name,
+        '--repo',
+        config.repo,
+        '--color',
+        color,
+        '--description',
+        description,
+      ],
+      config
+    );
+    return;
+  } catch {
+    // Existing labels return a non-zero exit. Edit best-effort so the
+    // description stays useful, but do not block dispatch if this fails.
+  }
+
+  try {
+    run(
+      [
+        'gh',
+        'label',
+        'edit',
+        name,
+        '--repo',
+        config.repo,
+        '--color',
+        color,
+        '--description',
+        description,
+      ],
+      config
+    );
+  } catch (err) {
+    logJobEvent({
+      job: JOB,
+      event: 'label_ensure_failed',
+      label: name,
+      error: shortError(err),
+    });
+  }
+}
+
+function ensureControlLabels(config: ShipperConfig): void {
+  ensureLabel(
+    config,
+    CODEX_CLAIM_LABEL,
+    '0969da',
+    'Claimed by the local codex issue shipper'
+  );
+  ensureLabel(
+    config,
+    CODEX_BLOCKED_LABEL,
+    'd1242f',
+    'Codex issue shipper hit a real blocker and will not retry automatically'
+  );
+}
+
+function commentIssue(
+  config: ShipperConfig,
+  issueNumber: number,
+  body: string
+): void {
+  run(
+    [
+      'gh',
+      'issue',
+      'comment',
+      String(issueNumber),
+      '--repo',
+      config.repo,
+      '--body',
+      body,
+    ],
+    config
+  );
+}
+
+function claimIssue(config: ShipperConfig, plan: DispatchPlan): void {
+  run(
+    [
+      'gh',
+      'issue',
+      'edit',
+      String(plan.issue.number),
+      '--repo',
+      config.repo,
+      '--add-label',
+      CODEX_CLAIM_LABEL,
+    ],
+    config
+  );
+
+  commentIssue(
+    config,
+    plan.issue.number,
+    [
+      `Codex issue shipper claimed this issue.`,
+      '',
+      `Branch: \`${plan.branchName}\``,
+      `Risk: \`${plan.route.riskLevel}\``,
+      `Model route: \`${plan.route.modelProfile}\` using \`${plan.route.sessionModel}\``,
+      plan.integrationBranch
+        ? `Integration branch: \`${plan.integrationBranch}\``
+        : 'Integration branch: not used for this issue',
+    ].join('\n')
+  );
+}
+
+function markBlocked(
+  config: ShipperConfig,
+  plan: DispatchPlan,
+  reason: string
+): void {
+  try {
+    run(
+      [
+        'gh',
+        'issue',
+        'edit',
+        String(plan.issue.number),
+        '--repo',
+        config.repo,
+        '--remove-label',
+        CODEX_CLAIM_LABEL,
+        '--add-label',
+        CODEX_BLOCKED_LABEL,
+      ],
+      config
+    );
+  } catch (err) {
+    logJobEvent({
+      job: JOB,
+      event: 'mark_blocked_label_failed',
+      issue: plan.issue.number,
+      error: shortError(err),
+    });
+  }
+
+  try {
+    commentIssue(
+      config,
+      plan.issue.number,
+      [`Codex issue shipper stopped on a real blocker.`, '', reason].join('\n')
+    );
+  } catch (err) {
+    logJobEvent({
+      job: JOB,
+      event: 'mark_blocked_comment_failed',
+      issue: plan.issue.number,
+      error: shortError(err),
+    });
+  }
+}
+
+function gbrainCaptureSlug(raw: string, fallback: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return fallback;
+  try {
+    const parsed = JSON.parse(trimmed) as { slug?: string };
+    return parsed.slug ?? fallback;
+  } catch {
+    return trimmed.split('\n').at(-1)?.trim() || fallback;
+  }
+}
+
+function collectGbrainContext(plan: DispatchPlan): GbrainContext {
+  const bin = process.env.HERMES_GBRAIN_BIN ?? 'gbrain';
+  const queryText = buildGbrainQuery(plan.issue);
+  let queryResult = '';
+
+  try {
+    queryResult = execFileSync(
+      bin,
+      [
+        'query',
+        queryText,
+        '--limit',
+        '5',
+        '--adaptive-return',
+        '--detail',
+        'medium',
+      ],
+      {
+        encoding: 'utf8',
+        timeout: 45_000,
+        maxBuffer: 512 * 1024,
+      }
+    );
+  } catch (err) {
+    queryResult = `gbrain query failed: ${shortError(err)}`;
+  }
+
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[:.]/g, '-')
+    .replace(/Z$/, 'z');
+  const slug = `ops/codex-issue-shipper/github-${plan.issue.number}-${timestamp}`;
+  const captureText = buildGbrainCaptureText(plan.issue);
+  const captureOut = execFileSync(
+    bin,
+    ['capture', '--stdin', '--type', 'report', '--slug', slug, '--json'],
+    {
+      encoding: 'utf8',
+      input: captureText,
+      timeout: 30_000,
+      maxBuffer: 256 * 1024,
+    }
+  );
+
+  return {
+    captureSlug: gbrainCaptureSlug(captureOut, slug),
+    queryText,
+    queryResult,
+  };
+}
+
+function agentLogsDir(): string {
+  const dir = join(HERMES_PATHS.logsDir, JOB);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function runAgent(
+  config: ShipperConfig,
+  plan: DispatchPlan,
+  prompt: string
+): AgentRunResult {
+  const timestamp = new Date()
+    .toISOString()
+    .replace(/[:.]/g, '-')
+    .replace(/Z$/, 'z');
+  const dir = agentLogsDir();
+  const base = `github-${plan.issue.number}-${timestamp}`;
+  const logPath = join(dir, `${base}.log`);
+  const promptPath = join(dir, `${base}.prompt.md`);
+  writeFileSync(promptPath, prompt);
+  appendFileSync(
+    logPath,
+    [
+      `job=${JOB}`,
+      `issue=${plan.issue.number}`,
+      `branch=${plan.branchName}`,
+      `model=${plan.route.sessionModel}`,
+      `started=${new Date().toISOString()}`,
+      '',
+    ].join('\n')
+  );
+
+  const command = buildAgentCommand(config, plan.route);
+  const fd = openSync(logPath, 'a');
+  try {
+    const result = spawnSync(command.command, [...command.args], {
+      cwd: config.repoRoot,
+      env: {
+        ...process.env,
+        JOVIE_AGENT_PROFILE: 'coder',
+      },
+      input: prompt,
+      timeout: config.agentTimeoutMs,
+      stdio: ['pipe', fd, fd],
+    });
+    return {
+      ok: result.status === 0,
+      status: result.status,
+      signal: result.signal,
+      error: result.error ? shortError(result.error) : undefined,
+      logPath,
+      promptPath,
+    };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function findPrForBranch(
+  config: ShipperConfig,
+  branchName: string
+): { number: number; url: string } | null {
+  try {
+    const raw = run(
+      [
+        'gh',
+        'pr',
+        'list',
+        '--repo',
+        config.repo,
+        '--head',
+        branchName,
+        '--state',
+        'open',
+        '--json',
+        'number,url',
+      ],
+      config
+    );
+    const prs = JSON.parse(raw) as ReadonlyArray<{
+      number: number;
+      url: string;
+    }>;
+    return prs[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function dispatchPlan(
+  config: ShipperConfig,
+  plan: DispatchPlan
+): Promise<void> {
+  claimIssue(config, plan);
+
+  let gbrain: GbrainContext;
+  try {
+    gbrain = collectGbrainContext(plan);
+  } catch (err) {
+    const reason = `GBrain capture failed, so no coding agent was started.\n\n\`\`\`text\n${shortError(err)}\n\`\`\``;
+    markBlocked(config, plan, reason);
+    logJobEvent({
+      job: JOB,
+      event: 'gbrain_failed',
+      issue: plan.issue.number,
+      error: shortError(err),
+    });
+    return;
+  }
+
+  const prompt = buildAgentPrompt({
+    issue: plan.issue,
+    branchName: plan.branchName,
+    baseBranch: 'main',
+    integrationBranch: plan.integrationBranch,
+    route: plan.route,
+    gbrain,
+    repoRoot: config.repoRoot,
+  });
+
+  const agentResult = runAgent(config, plan, prompt);
+  logJobEvent({
+    job: JOB,
+    event: agentResult.ok ? 'agent_succeeded' : 'agent_failed',
+    issue: plan.issue.number,
+    status: agentResult.status,
+    signal: agentResult.signal,
+    error: agentResult.error,
+    logPath: agentResult.logPath,
+    promptPath: agentResult.promptPath,
+    gbrainSlug: gbrain.captureSlug,
+  });
+
+  if (!agentResult.ok) {
+    markBlocked(
+      config,
+      plan,
+      [
+        `Agent exited without successfully shipping.`,
+        '',
+        `Status: \`${agentResult.status ?? 'null'}\``,
+        `Signal: \`${agentResult.signal ?? 'null'}\``,
+        agentResult.error ? `Error: \`${agentResult.error}\`` : null,
+        `Log: \`${agentResult.logPath}\``,
+        `Prompt: \`${agentResult.promptPath}\``,
+      ]
+        .filter((line): line is string => line !== null)
+        .join('\n')
+    );
+    return;
+  }
+
+  const pr = findPrForBranch(config, plan.branchName);
+  if (!pr) {
+    markBlocked(
+      config,
+      plan,
+      [
+        `Agent exited 0 but no open PR exists for \`${plan.branchName}\`.`,
+        '',
+        `Log: \`${agentResult.logPath}\``,
+        `Prompt: \`${agentResult.promptPath}\``,
+      ].join('\n')
+    );
+    logJobEvent({
+      job: JOB,
+      event: 'missing_pr_after_success',
+      issue: plan.issue.number,
+      branch: plan.branchName,
+    });
+    return;
+  }
+
+  commentIssue(
+    config,
+    plan.issue.number,
+    [
+      `Codex issue shipper completed agent run and found PR #${pr.number}.`,
+      '',
+      `PR: ${pr.url}`,
+      `GBrain dispatch slug: \`${gbrain.captureSlug}\``,
+      `Log: \`${agentResult.logPath}\``,
+    ].join('\n')
+  );
+
+  logJobEvent({
+    job: JOB,
+    event: 'pr_found_after_success',
+    issue: plan.issue.number,
+    pr: pr.number,
+    url: pr.url,
+  });
+}
+
+async function main(): Promise<void> {
+  loadHermesEnv();
+  const repoRoot = detectRepoRoot();
+  const repo = detectGithubRepo(repoRoot);
+  const config = loadShipperConfig(process.env, repoRoot, repo);
+
+  await withJobLogging(JOB, async () => {
+    const issues = listCodexIssues(config);
+    const plans = buildDispatchPlans(issues, config);
+    const skippedHuman = issues.filter(issue =>
+      labelNames(issue).includes(HUMAN_REVIEW_LABEL)
+    ).length;
+
+    logJobEvent({
+      job: JOB,
+      event: 'scanned',
+      issueCount: issues.length,
+      dispatchableCount: plans.length,
+      skippedHuman,
+      maxIssuesPerRun: config.maxIssuesPerRun,
+      dryRun: config.dryRun,
+    });
+
+    if (plans.length === 0) {
+      logJobEvent({ job: JOB, event: 'empty_queue' });
+      return;
+    }
+
+    if (config.dryRun) {
+      logJobEvent({
+        job: JOB,
+        event: 'dry_run_planned',
+        plans: plans.map(plan => ({
+          issue: plan.issue.number,
+          branch: plan.branchName,
+          risk: plan.route.riskLevel,
+          model: plan.route.sessionModel,
+          integrationBranch: plan.integrationBranch,
+        })),
+      });
+      return;
+    }
+
+    ensureControlLabels(config);
+
+    await withHeavyJobLock(JOB, async () => {
+      for (const plan of plans) {
+        try {
+          await dispatchPlan(config, plan);
+        } catch (err) {
+          logJobEvent({
+            job: JOB,
+            event: 'dispatch_failed',
+            issue: plan.issue.number,
+            error: shortError(err),
+          });
+          markBlocked(
+            config,
+            plan,
+            `Dispatcher failed before a clean agent handoff.\n\n\`\`\`text\n${shortError(err)}\n\`\`\``
+          );
+        }
+      }
+    });
+  });
+}
+
+void main().catch(err => {
+  logJobEvent({
+    job: JOB,
+    event: 'fatal',
+    error: err instanceof Error ? err.message : String(err),
+    stack: err instanceof Error ? err.stack : undefined,
+  });
+  console.error(`[${JOB}] fatal:`, err);
+  process.exit(0); // never loop launchd on transient failures
+});

--- a/scripts/hermes/launchd/README.md
+++ b/scripts/hermes/launchd/README.md
@@ -2,7 +2,7 @@
 
 Templates for the Jovie-owned launchd unit files installed by `scripts/hermes/bootstrap-air.sh`.
 
-Each `.plist.template` uses `{{HOME}}`, `{{JOVIE_REPO}}`, `{{HERMES_BIN}}`, `{{GBRAIN_BIN}}`, `{{TSX_BIN}}`, and `{{TAILSCALE_IP}}` placeholders. The bootstrap script substitutes these at install time (via Python so values containing shell-special characters render safely) before copying to `~/Library/LaunchAgents/`.
+Each `.plist.template` uses `{{HOME}}`, `{{JOVIE_REPO}}`, `{{HERMES_BIN}}`, `{{GBRAIN_BIN}}`, `{{TSX_BIN}}`, `{{NODE_BIN_DIR}}`, and `{{TAILSCALE_IP}}` placeholders. The bootstrap script substitutes these at install time (via Python so values containing shell-special characters render safely) before copying to `~/Library/LaunchAgents/`.
 
 The Hermes gateway itself is managed by the installed Hermes CLI as `ai.hermes.gateway`; these templates manage the Air-specific watchdog, gbrain server, and cron jobs around it.
 
@@ -16,6 +16,7 @@ The Hermes gateway itself is managed by the installed Hermes CLI as `ai.hermes.g
 | `co.jovie.hermes.cron-hud.plist.template` | every 5 min | Refresh HUD snapshot |
 | `co.jovie.hermes.cron-pr-monitor.plist.template` | every 10 min | Detect stuck PRs |
 | `co.jovie.hermes.cron-ci-monitor.plist.template` | every 10 min | Detect CI failures on main |
+| `co.jovie.hermes.cron-codex-issue-shipper.plist.template` | every 15 min | Claim one open GitHub issue labeled `codex` and dispatch a coder-profile agent |
 | `co.jovie.hermes.cron-cost-monitor.plist.template` | every 60 min | Cost kill switch |
 | `co.jovie.hermes.cron-daily-briefing.plist.template` | 07:00 daily | Morning briefing to Telegram |
 | `co.jovie.hermes.cron-deterministic-tracker.plist.template` | 03:00 daily | Self-improvement clustering |

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-codex-issue-shipper.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-codex-issue-shipper.plist.template
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>co.jovie.hermes.cron-codex-issue-shipper</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{TSX_BIN}}</string>
+        <string>{{JOVIE_REPO}}/scripts/hermes/jobs/codex-issue-shipper.ts</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>{{JOVIE_REPO}}</string>
+    <key>StartInterval</key>
+    <integer>900</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERMES_HOME</key>
+        <string>{{HOME}}/.hermes</string>
+        <key>HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN</key>
+        <string>1</string>
+        <key>HERMES_CODEX_SHIPPER_INTEGRATION_THRESHOLD</key>
+        <string>4</string>
+        <key>HERMES_CODEX_SHIPPER_AGENT</key>
+        <string>claude</string>
+        <key>HERMES_CODEX_SHIPPER_SIMPLE_MODEL</key>
+        <string>sonnet</string>
+        <key>HERMES_CODEX_SHIPPER_STANDARD_MODEL</key>
+        <string>sonnet</string>
+        <key>HERMES_CODEX_SHIPPER_ESCALATION_MODEL</key>
+        <string>opus</string>
+        <key>HERMES_CODEX_SHIPPER_FALLBACK_MODEL</key>
+        <string>sonnet</string>
+        <key>PATH</key>
+        <string>{{NODE_BIN_DIR}}:{{HOME}}/.bun/bin:{{HOME}}/.hermes/bin:{{HOME}}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-codex-issue-shipper.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.hermes/logs/launchd/cron-codex-issue-shipper.err.log</string>
+</dict>
+</plist>

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -1,0 +1,447 @@
+export const CODEX_SOURCE_LABEL = 'codex';
+export const CODEX_CLAIM_LABEL = 'codex-in-progress';
+export const CODEX_BLOCKED_LABEL = 'codex-blocked';
+export const HUMAN_REVIEW_LABEL = 'human-review-required';
+
+export interface GithubIssueLabel {
+  readonly name: string;
+}
+
+export interface GithubIssue {
+  readonly number: number;
+  readonly title: string;
+  readonly body?: string | null;
+  readonly url: string;
+  readonly updatedAt?: string;
+  readonly labels: ReadonlyArray<GithubIssueLabel>;
+}
+
+export interface ShipperConfig {
+  readonly repo: string;
+  readonly repoRoot: string;
+  readonly maxIssuesPerRun: number;
+  readonly issueFetchLimit: number;
+  readonly integrationThreshold: number;
+  readonly agent: 'claude' | 'codex';
+  readonly simpleModel: string;
+  readonly standardModel: string;
+  readonly escalationModel: string;
+  readonly fallbackModel: string;
+  readonly claudePermissionMode: string;
+  readonly agentTimeoutMs: number;
+  readonly dryRun: boolean;
+}
+
+export type RiskLevel = 'low' | 'medium' | 'high';
+export type ModelProfile = 'simple' | 'standard' | 'escalation';
+
+export interface TaskRoute {
+  readonly riskLevel: RiskLevel;
+  readonly modelProfile: ModelProfile;
+  readonly sessionModel: string;
+  readonly fallbackModel: string;
+  readonly maxTurns: number;
+  readonly reasons: ReadonlyArray<string>;
+  readonly specialistSubagents: ReadonlyArray<{
+    readonly name: string;
+    readonly model: string;
+    readonly required: boolean;
+  }>;
+}
+
+export interface DispatchPlan {
+  readonly issue: GithubIssue;
+  readonly branchName: string;
+  readonly integrationBranch: string | null;
+  readonly route: TaskRoute;
+}
+
+export interface GbrainContext {
+  readonly captureSlug: string;
+  readonly queryText: string;
+  readonly queryResult: string;
+}
+
+export interface BuildPromptInput {
+  readonly issue: GithubIssue;
+  readonly branchName: string;
+  readonly baseBranch: string;
+  readonly integrationBranch: string | null;
+  readonly route: TaskRoute;
+  readonly gbrain: GbrainContext;
+  readonly repoRoot: string;
+}
+
+const HIGH_RISK_PATTERN =
+  /\b(auth|billing|stripe|payment|checkout|entitlement|clerk|security|secret|token|webhook|middleware|proxy|database|db|drizzle|migration|rls|csp|deploy|workflow|github actions|ci|merge queue|agent pipeline|release)\b/i;
+
+const HIGH_COMPLEXITY_PATTERN =
+  /\b(refactor|architecture|orchestrator|automation|agent|harness|cross-package|monorepo|system|integration|parallel|queue|migration)\b/i;
+
+const SIMPLE_PATTERN =
+  /\b(copy|typo|docs?|readme|comment|test-only|lint|format|chore|rename|dead code)\b/i;
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseBool(value: string | undefined): boolean {
+  return value === '1' || value?.toLowerCase() === 'true';
+}
+
+export function loadShipperConfig(
+  env: NodeJS.ProcessEnv,
+  repoRoot: string,
+  repo: string
+): ShipperConfig {
+  const agent = env.HERMES_CODEX_SHIPPER_AGENT === 'codex' ? 'codex' : 'claude';
+  return {
+    repo,
+    repoRoot,
+    maxIssuesPerRun: parsePositiveInt(
+      env.HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN,
+      1
+    ),
+    issueFetchLimit: parsePositiveInt(
+      env.HERMES_CODEX_SHIPPER_ISSUE_FETCH_LIMIT,
+      25
+    ),
+    integrationThreshold: parsePositiveInt(
+      env.HERMES_CODEX_SHIPPER_INTEGRATION_THRESHOLD,
+      4
+    ),
+    agent,
+    simpleModel: env.HERMES_CODEX_SHIPPER_SIMPLE_MODEL ?? 'sonnet',
+    standardModel: env.HERMES_CODEX_SHIPPER_STANDARD_MODEL ?? 'sonnet',
+    escalationModel: env.HERMES_CODEX_SHIPPER_ESCALATION_MODEL ?? 'opus',
+    fallbackModel: env.HERMES_CODEX_SHIPPER_FALLBACK_MODEL ?? 'sonnet',
+    claudePermissionMode:
+      env.HERMES_CODEX_SHIPPER_CLAUDE_PERMISSION_MODE ?? 'auto',
+    agentTimeoutMs: parsePositiveInt(
+      env.HERMES_CODEX_SHIPPER_AGENT_TIMEOUT_MS,
+      2 * 60 * 60 * 1000
+    ),
+    dryRun: parseBool(env.HERMES_CODEX_SHIPPER_DRY_RUN),
+  };
+}
+
+export function labelNames(issue: GithubIssue): ReadonlyArray<string> {
+  return issue.labels.map(label => label.name);
+}
+
+export function issueText(issue: GithubIssue): string {
+  return `${issue.title}\n${issue.body ?? ''}`;
+}
+
+export function isHumanReviewRequired(issue: GithubIssue): boolean {
+  const labels = new Set(labelNames(issue));
+  if (labels.has(HUMAN_REVIEW_LABEL)) return true;
+  return /requires human review|human-review-required/i.test(issue.body ?? '');
+}
+
+export function isAlreadyClaimedOrBlocked(issue: GithubIssue): boolean {
+  const labels = new Set(labelNames(issue));
+  return labels.has(CODEX_CLAIM_LABEL) || labels.has(CODEX_BLOCKED_LABEL);
+}
+
+export function eligibleCodexIssues(
+  issues: ReadonlyArray<GithubIssue>
+): ReadonlyArray<GithubIssue> {
+  return issues.filter(
+    issue => !isHumanReviewRequired(issue) && !isAlreadyClaimedOrBlocked(issue)
+  );
+}
+
+export function slugify(input: string, maxLength = 48): string {
+  const slug = input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, maxLength)
+    .replace(/-+$/g, '');
+  return slug || 'issue';
+}
+
+export function branchNameForIssue(issue: GithubIssue): string {
+  return `codex/gh-${issue.number}-${slugify(issue.title)}`;
+}
+
+export function selectTaskRoute(
+  issue: GithubIssue,
+  config: Pick<
+    ShipperConfig,
+    'simpleModel' | 'standardModel' | 'escalationModel' | 'fallbackModel'
+  >
+): TaskRoute {
+  const text = issueText(issue);
+  const labels = new Set(labelNames(issue));
+  const reasons: string[] = [];
+
+  const isHighRisk =
+    HIGH_RISK_PATTERN.test(text) ||
+    labels.has('risk:high') ||
+    labels.has('security') ||
+    labels.has('billing') ||
+    labels.has('ci');
+  const isComplex = HIGH_COMPLEXITY_PATTERN.test(text);
+  const isSimple = SIMPLE_PATTERN.test(text) && !isHighRisk && !isComplex;
+
+  let riskLevel: RiskLevel = 'medium';
+  let modelProfile: ModelProfile = 'standard';
+  let sessionModel = config.standardModel;
+  let maxTurns = 80;
+
+  if (isHighRisk) {
+    riskLevel = 'high';
+    modelProfile = 'escalation';
+    sessionModel = config.escalationModel;
+    maxTurns = 120;
+    reasons.push('Sensitive or control-plane terms require escalation model');
+  } else if (isSimple) {
+    riskLevel = 'low';
+    modelProfile = 'simple';
+    sessionModel = config.simpleModel;
+    maxTurns = 50;
+    reasons.push('Docs, copy, lint, or test-only work can use simple model');
+  } else if (isComplex) {
+    riskLevel = 'medium';
+    modelProfile = 'standard';
+    sessionModel = config.standardModel;
+    maxTurns = 100;
+    reasons.push(
+      'Cross-file or automation wording requires standard coder model'
+    );
+  } else {
+    reasons.push('Default implementation route');
+  }
+
+  const specialistSubagents = [
+    {
+      name: 'testing',
+      model: riskLevel === 'high' ? config.standardModel : sessionModel,
+      required: true,
+    },
+    {
+      name: 'review',
+      model: sessionModel,
+      required: true,
+    },
+    ...(riskLevel === 'high'
+      ? [
+          {
+            name: 'security',
+            model: config.escalationModel,
+            required: true,
+          },
+        ]
+      : []),
+    ...(isComplex
+      ? [
+          {
+            name: 'architecture',
+            model: config.standardModel,
+            required: false,
+          },
+        ]
+      : []),
+  ];
+
+  return {
+    riskLevel,
+    modelProfile,
+    sessionModel,
+    fallbackModel: config.fallbackModel,
+    maxTurns,
+    reasons,
+    specialistSubagents,
+  };
+}
+
+export function shouldUseIntegrationBranch(args: {
+  readonly issue: GithubIssue;
+  readonly eligibleQueueDepth: number;
+  readonly integrationThreshold: number;
+  readonly route: TaskRoute;
+}): boolean {
+  const labels = new Set(labelNames(args.issue));
+  if (labels.has('integration-branch') || labels.has('integration-train')) {
+    return true;
+  }
+  if (args.route.riskLevel === 'high') return false;
+  return args.eligibleQueueDepth >= args.integrationThreshold;
+}
+
+export function buildDispatchPlans(
+  issues: ReadonlyArray<GithubIssue>,
+  config: Pick<
+    ShipperConfig,
+    | 'maxIssuesPerRun'
+    | 'integrationThreshold'
+    | 'simpleModel'
+    | 'standardModel'
+    | 'escalationModel'
+    | 'fallbackModel'
+  >
+): ReadonlyArray<DispatchPlan> {
+  const eligible = eligibleCodexIssues(issues);
+  return eligible.slice(0, config.maxIssuesPerRun).map(issue => {
+    const route = selectTaskRoute(issue, config);
+    const integrationBranch = shouldUseIntegrationBranch({
+      issue,
+      eligibleQueueDepth: eligible.length,
+      integrationThreshold: config.integrationThreshold,
+      route,
+    })
+      ? 'integration/codex-queue'
+      : null;
+    return {
+      issue,
+      branchName: branchNameForIssue(issue),
+      integrationBranch,
+      route,
+    };
+  });
+}
+
+export function buildGbrainCaptureText(issue: GithubIssue): string {
+  return [
+    `# Codex Issue Shipper Dispatch: GitHub #${issue.number}`,
+    '',
+    `Issue: ${issue.title}`,
+    `URL: ${issue.url}`,
+    `Labels: ${labelNames(issue).join(', ') || 'none'}`,
+    issue.updatedAt ? `Updated: ${issue.updatedAt}` : null,
+    '',
+    '## Body',
+    issue.body?.trim() || '(empty)',
+  ]
+    .filter((line): line is string => line !== null)
+    .join('\n');
+}
+
+export function buildGbrainQuery(issue: GithubIssue): string {
+  return [
+    'Jovie implementation context for GitHub issue',
+    `#${issue.number}`,
+    issue.title,
+    labelNames(issue).join(' '),
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function shellQuote(value: string): string {
+  const normalized = value.replace(/\r?\n/g, ' ');
+  return `'${normalized.replace(/'/g, "'\\''")}'`;
+}
+
+export function buildAgentPrompt(input: BuildPromptInput): string {
+  const issueBody = input.issue.body?.trim() || '(empty)';
+  const route = input.route;
+  const subagents = route.specialistSubagents
+    .map(
+      agent =>
+        `- ${agent.name}: model=${agent.model}, required=${agent.required ? 'yes' : 'no'}`
+    )
+    .join('\n');
+  const routeReasons = route.reasons.map(reason => `- ${reason}`).join('\n');
+  const integrationBlock = input.integrationBranch
+    ? [
+        `Base this feature branch from \`${input.integrationBranch}\`.`,
+        `Use \`./scripts/loop-integration-ship.sh ${shellQuote(input.integrationBranch)} ${shellQuote(input.branchName)} ${shellQuote(input.issue.title)}\` after local verification, then make sure an integration train PR from \`${input.integrationBranch}\` to \`${input.baseBranch}\` exists and is linked.`,
+        'Do not use the integration branch for sensitive shortcuts. Full main-train CI still has to run before merge.',
+      ].join('\n')
+    : `Base this feature branch from \`${input.baseBranch}\` and create the PR against \`${input.baseBranch}\`.`;
+
+  return [
+    'Load gstack. You are a Jovie coder agent executing a GitHub issue labeled `codex` end to end.',
+    '',
+    `Working directory: ${input.repoRoot}`,
+    `GitHub issue: #${input.issue.number} ${input.issue.title}`,
+    `Issue URL: ${input.issue.url}`,
+    `Branch to use: ${input.branchName}`,
+    `Linear context: this work is part of the codex-label issue shipping automation.`,
+    '',
+    '## Hard Requirements',
+    '- Set `JOVIE_AGENT_PROFILE=coder` before editing files.',
+    '- Read `AGENTS.md` and the scoped rules for any files you touch.',
+    '- Use gbrain before planning. Start with the gbrain context below, then run a targeted `gbrain query` if the first results are not enough.',
+    '- Use gstack workflows. For complex work run `/autoplan`; for bugs run `/investigate`; before shipping run exhaustive `/qa`; for PR creation use `/ship`.',
+    '- Use subagents. At minimum dispatch testing and review subagents. Add security, performance, architecture, or design subagents when the risk profile calls for them.',
+    '- Run local CodeRabbit review before shipping: `coderabbit review --agent -c AGENTS.md -t uncommitted`. Fix actionable issues, then rerun if the diff changed.',
+    '- Exhaustively QA your own work. Run typecheck and focused tests. For UI edits, verify layout-shift states and capture screenshots. For backend/control-plane edits, test the failure path and the empty path.',
+    '- Create a PR, link this GitHub issue with `Closes #<issue-number>`, and include exact verification output in the PR body.',
+    '- If the issue needs human review, secrets, irreversible data changes, production credential changes, auth/payment changes, or destructive operations, stop and label/comment clearly instead of forcing it.',
+    '',
+    '## Model Route',
+    `Session model: ${route.sessionModel}`,
+    `Fallback model: ${route.fallbackModel}`,
+    `Risk: ${route.riskLevel}`,
+    `Profile: ${route.modelProfile}`,
+    '',
+    routeReasons || '- Default route',
+    '',
+    '## Required Subagents',
+    subagents,
+    '',
+    '## Branching',
+    integrationBlock,
+    '',
+    '## GBrain Context',
+    `Captured slug: ${input.gbrain.captureSlug}`,
+    `Query: ${input.gbrain.queryText}`,
+    'Query result:',
+    '```text',
+    input.gbrain.queryResult.trim() || '(no gbrain results returned)',
+    '```',
+    '',
+    '## Issue Body',
+    '```markdown',
+    issueBody,
+    '```',
+    '',
+    'Stop only when the issue is represented by a PR with verification evidence, or when you have labeled/commented a real blocker that the automation cannot resolve safely.',
+  ].join('\n');
+}
+
+export function buildAgentCommand(
+  config: ShipperConfig,
+  route: TaskRoute
+): { readonly command: string; readonly args: ReadonlyArray<string> } {
+  if (config.agent === 'codex') {
+    return {
+      command: 'codex',
+      args: [
+        'exec',
+        '-',
+        '-C',
+        config.repoRoot,
+        '--sandbox',
+        'danger-full-access',
+        '--ask-for-approval',
+        'never',
+        '-m',
+        route.sessionModel,
+        '--color',
+        'never',
+      ],
+    };
+  }
+
+  return {
+    command: 'claude',
+    args: [
+      '--print',
+      '--max-turns',
+      String(route.maxTurns),
+      '--model',
+      route.sessionModel,
+      '--fallback-model',
+      route.fallbackModel,
+      '--permission-mode',
+      config.claudePermissionMode,
+    ],
+  };
+}

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAgentPrompt,
+  buildDispatchPlans,
+  buildGbrainCaptureText,
+  CODEX_BLOCKED_LABEL,
+  CODEX_CLAIM_LABEL,
+  eligibleCodexIssues,
+  HUMAN_REVIEW_LABEL,
+  selectTaskRoute,
+  shellQuote,
+} from '../../hermes/lib/codex-issue-shipper.ts';
+
+const config = {
+  maxIssuesPerRun: 2,
+  integrationThreshold: 3,
+  simpleModel: 'cheap-model',
+  standardModel: 'standard-model',
+  escalationModel: 'escalation-model',
+  fallbackModel: 'fallback-model',
+};
+
+function issue(overrides = {}) {
+  return {
+    number: 123,
+    title: 'Fix dashboard copy',
+    body: 'Small copy update',
+    url: 'https://github.com/JovieInc/Jovie/issues/123',
+    updatedAt: '2026-06-11T00:00:00Z',
+    labels: [{ name: 'codex' }],
+    ...overrides,
+  };
+}
+
+describe('codex issue shipper planner', () => {
+  it('returns no dispatch plans for an empty queue', () => {
+    expect(buildDispatchPlans([], config)).toEqual([]);
+  });
+
+  it('filters human-gated, claimed, and blocked issues before dispatch', () => {
+    const ready = issue({ number: 1, title: 'Fix docs typo' });
+    const human = issue({
+      number: 2,
+      labels: [{ name: 'codex' }, { name: HUMAN_REVIEW_LABEL }],
+    });
+    const claimed = issue({
+      number: 3,
+      labels: [{ name: 'codex' }, { name: CODEX_CLAIM_LABEL }],
+    });
+    const blocked = issue({
+      number: 4,
+      labels: [{ name: 'codex' }, { name: CODEX_BLOCKED_LABEL }],
+    });
+
+    expect(eligibleCodexIssues([ready, human, claimed, blocked])).toEqual([
+      ready,
+    ]);
+    expect(
+      buildDispatchPlans([ready, human, claimed, blocked], config)
+    ).toHaveLength(1);
+  });
+
+  it('uses cheap models for simple work and escalation models for sensitive work', () => {
+    const simple = selectTaskRoute(
+      issue({ title: 'Docs typo in README' }),
+      config
+    );
+    expect(simple.modelProfile).toBe('simple');
+    expect(simple.sessionModel).toBe('cheap-model');
+
+    const sensitive = selectTaskRoute(
+      issue({
+        title: 'Fix Stripe webhook auth token handling',
+        body: 'Touches billing and secrets',
+      }),
+      config
+    );
+    expect(sensitive.modelProfile).toBe('escalation');
+    expect(sensitive.sessionModel).toBe('escalation-model');
+    expect(sensitive.specialistSubagents.map(agent => agent.name)).toContain(
+      'security'
+    );
+  });
+
+  it('uses integration branches for trainable queue pressure but not high-risk work', () => {
+    const issues = [
+      issue({ number: 1, title: 'Refactor dashboard filter copy' }),
+      issue({ number: 2, title: 'Fix docs typo' }),
+      issue({ number: 3, title: 'Update test fixture' }),
+    ];
+    const plans = buildDispatchPlans(issues, config);
+    expect(plans[0].integrationBranch).toBe('integration/codex-queue');
+
+    const highRiskPlans = buildDispatchPlans(
+      [
+        issue({ number: 1, title: 'Fix Clerk auth middleware' }),
+        issue({ number: 2, title: 'Fix docs typo' }),
+        issue({ number: 3, title: 'Update test fixture' }),
+      ],
+      config
+    );
+    expect(highRiskPlans[0].integrationBranch).toBeNull();
+  });
+
+  it('respects maxIssuesPerRun', () => {
+    const plans = buildDispatchPlans(
+      [
+        issue({ number: 1, title: 'Fix docs typo' }),
+        issue({ number: 2, title: 'Update README' }),
+        issue({ number: 3, title: 'Refactor util' }),
+      ],
+      config
+    );
+
+    expect(plans).toHaveLength(2);
+    expect(plans.map(plan => plan.issue.number)).toEqual([1, 2]);
+  });
+});
+
+describe('codex issue shipper prompt', () => {
+  it('requires gbrain, gstack, subagents, exhaustive QA, CodeRabbit, and PR evidence', () => {
+    const plan = buildDispatchPlans([issue()], config)[0];
+    const prompt = buildAgentPrompt({
+      issue: plan.issue,
+      branchName: plan.branchName,
+      baseBranch: 'main',
+      integrationBranch: plan.integrationBranch,
+      route: plan.route,
+      repoRoot: '/repo',
+      gbrain: {
+        captureSlug: 'ops/codex-issue-shipper/github-123',
+        queryText: 'Jovie implementation context',
+        queryResult: 'Relevant memory result',
+      },
+    });
+
+    expect(prompt).toContain('Load gstack');
+    expect(prompt).toContain('Use gbrain before planning');
+    expect(prompt).toContain('Use subagents');
+    expect(prompt).toContain('/qa');
+    expect(prompt).toContain('/ship');
+    expect(prompt).toContain(
+      'coderabbit review --agent -c AGENTS.md -t uncommitted'
+    );
+    expect(prompt).toContain('Closes #<issue-number>');
+    expect(prompt).toContain('Session model: cheap-model');
+    expect(prompt).toContain(
+      'Captured slug: ops/codex-issue-shipper/github-123'
+    );
+  });
+
+  it('captures issue body and labels for gbrain', () => {
+    const capture = buildGbrainCaptureText(
+      issue({
+        title: 'Build codex automation',
+        body: 'Use gbrain and subagents.',
+        labels: [{ name: 'codex' }, { name: 'automation' }],
+      })
+    );
+
+    expect(capture).toContain('# Codex Issue Shipper Dispatch: GitHub #123');
+    expect(capture).toContain('Build codex automation');
+    expect(capture).toContain('codex, automation');
+    expect(capture).toContain('Use gbrain and subagents.');
+  });
+
+  it('shell-quotes integration branch commands in prompts', () => {
+    const plan = buildDispatchPlans(
+      [
+        issue({
+          title: "Fix $HOME `backtick` and user's path",
+          labels: [{ name: 'codex' }, { name: 'integration-branch' }],
+        }),
+      ],
+      config
+    )[0];
+    const prompt = buildAgentPrompt({
+      issue: plan.issue,
+      branchName: plan.branchName,
+      baseBranch: 'main',
+      integrationBranch: plan.integrationBranch,
+      route: plan.route,
+      repoRoot: '/repo',
+      gbrain: {
+        captureSlug: 'ops/codex-issue-shipper/github-123',
+        queryText: 'Jovie implementation context',
+        queryResult: 'Relevant memory result',
+      },
+    });
+
+    expect(shellQuote("Fix $HOME `backtick` and user's path")).toBe(
+      "'Fix $HOME `backtick` and user'\\''s path'"
+    );
+    expect(prompt).toContain(
+      `./scripts/loop-integration-ship.sh 'integration/codex-queue' '${plan.branchName}' 'Fix $HOME \`backtick\` and user'\\''s path'`
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Hermes codex issue shipper that scans open GitHub issues labeled `codex`, exits cheaply on empty/no-dispatch runs, claims eligible issues, captures/query gbrain context, and dispatches a coder-profile agent.
- Build model-aware prompts requiring gstack workflows, subagents, exhaustive QA, local CodeRabbit review, integration-branch handling, and PR evidence.
- Wire launchd/bootstrap/runbook support and add focused planner/prompt tests.
- Release the issue claim for retry when required `gbrain capture` fails, instead of permanently blocking an issue on a transient local failure.

## Verification
- `pnpm biome check --write scripts/hermes/jobs/codex-issue-shipper.ts scripts/hermes/lib/codex-issue-shipper.ts scripts/lib/__tests__/codex-issue-shipper.test.mjs`
- `pnpm exec vitest --root scripts --config vitest.config.mts run lib/__tests__/codex-issue-shipper.test.mjs` (8 tests passed)
- `HERMES_CODEX_SHIPPER_DRY_RUN=1 HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN=1 pnpm hermes:codex-shipper` (live GitHub scan planned #10608 without gbrain/model/agent work)
- `bash -n scripts/hermes/bootstrap-air.sh`
- `plutil -lint scripts/hermes/launchd/co.jovie.hermes.cron-codex-issue-shipper.plist.template`
- Pre-push hook passed after rebase onto `integration/loop-ui`: `biome check .`, `next:proxy-guard`, `tailwind:check`, web `typecheck`, web `lint`
- CodeRabbit local review: installed/authenticated CLI, ran multiple `coderabbit review --agent -c AGENTS.md -t uncommitted` passes, fixed actionable findings, and reran after the gbrain retry fix with 0 findings.

Closes #10608
Linear: JOV-3028