### PR TITLE
fix(ci): stop workflow retries from inflating unit-test flake scores (JOV-3029)

### DIFF
--- a/.github/scripts/analyze-test-flakiness.js
+++ b/.github/scripts/analyze-test-flakiness.js
@@ -112,58 +112,117 @@ function _parseTestName(stepName) {
 }
 
 /**
+ * Filter workflow jobs down to test-relevant lanes.
+ */
+function filterTestJobs(jobs) {
+  return jobs.filter(
+    job =>
+      job.name.includes('E2E') ||
+      job.name.includes('Smoke') ||
+      job.name.includes('Unit')
+  );
+}
+
+/**
+ * Collect normalized test-step executions from a workflow run's jobs.
+ */
+function collectRunExecutions(jobs) {
+  const executions = [];
+
+  for (const job of filterTestJobs(jobs)) {
+    executions.push(...extractTestExecutions(job));
+  }
+
+  return executions;
+}
+
+/**
+ * Record attempt-1 outcomes per commit so later workflow retries only count
+ * when the same step failed on the first attempt.
+ */
+function buildAttemptOneOutcomes(runsWithJobs) {
+  const outcomesBySha = new Map();
+
+  for (const { run, jobs } of runsWithJobs) {
+    if (run.run_attempt !== 1) continue;
+
+    const stepOutcomes = new Map();
+    for (const execution of collectRunExecutions(jobs)) {
+      stepOutcomes.set(execution.name, execution.conclusion);
+    }
+
+    outcomesBySha.set(run.head_sha, stepOutcomes);
+  }
+
+  return outcomesBySha;
+}
+
+/**
+ * Count a retry only when a workflow re-run recovered a step that failed on
+ * attempt 1. Unrelated workflow retries should not inflate stable steps.
+ */
+function shouldCountAsRetry({ attemptOneConclusion, runAttempt, conclusion }) {
+  return (
+    runAttempt > 1 &&
+    conclusion === 'success' &&
+    attemptOneConclusion === 'failure'
+  );
+}
+
+/**
  * Analyze workflow runs for test flakiness
  */
 async function analyzeFlakiness(token, owner, repo) {
   const runs = await fetchWorkflowRuns(token, owner, repo);
   console.log(`Analyzing ${runs.length} workflow runs...`);
 
+  const runsWithJobs = [];
+  for (const run of runs) {
+    const jobs = await fetchRunJobs(token, owner, repo, run.id);
+    runsWithJobs.push({ run, jobs });
+  }
+
+  const attemptOneOutcomes = buildAttemptOneOutcomes(runsWithJobs);
   const testStats = new Map(); // testName -> { failures, successes, retries, runs }
   let totalRuns = 0;
   let runsWithRetries = 0;
   let runsWithFailures = 0;
 
-  for (const run of runs) {
+  for (const { run, jobs } of runsWithJobs) {
     totalRuns++;
-    const jobs = await fetchRunJobs(token, owner, repo, run.id);
-
-    // Look for E2E and Smoke test jobs
-    const testJobs = jobs.filter(
-      j =>
-        j.name.includes('E2E') ||
-        j.name.includes('Smoke') ||
-        j.name.includes('Unit')
-    );
-
     const runHadRetry = run.run_attempt > 1;
     let runHadFailure = false;
+    const firstAttemptOutcomes =
+      attemptOneOutcomes.get(run.head_sha) ?? new Map();
 
-    for (const job of testJobs) {
-      const executions = extractTestExecutions(job);
+    for (const execution of collectRunExecutions(jobs)) {
+      if (!testStats.has(execution.name)) {
+        testStats.set(execution.name, {
+          failures: 0,
+          successes: 0,
+          retries: 0,
+          runs: 0,
+          lastFailure: null,
+        });
+      }
 
-      for (const execution of executions) {
-        if (!testStats.has(execution.name)) {
-          testStats.set(execution.name, {
-            failures: 0,
-            successes: 0,
-            retries: 0,
-            runs: 0,
-            lastFailure: null,
-          });
-        }
+      const stats = testStats.get(execution.name);
+      stats.runs++;
 
-        const stats = testStats.get(execution.name);
-        stats.runs++;
-
-        if (execution.conclusion === 'failure') {
-          stats.failures++;
-          stats.lastFailure = run.created_at;
-          runHadFailure = true;
-        } else if (execution.conclusion === 'success') {
-          stats.successes++;
-          if (run.run_attempt > 1) {
-            stats.retries++;
-          }
+      if (execution.conclusion === 'failure') {
+        stats.failures++;
+        stats.lastFailure = run.created_at;
+        runHadFailure = true;
+      } else if (execution.conclusion === 'success') {
+        stats.successes++;
+        if (
+          shouldCountAsRetry({
+            attemptOneConclusion: firstAttemptOutcomes.get(execution.name),
+            runAttempt: run.run_attempt,
+            conclusion: execution.conclusion,
+          })
+        ) {
+          stats.retries++;
         }
       }
     }
@@ -463,8 +522,11 @@ if (require.main === module) {
 
 module.exports = {
   analyzeFlakiness,
+  buildAttemptOneOutcomes,
   calculateMetrics,
+  collectRunExecutions,
   extractTestExecutions,
   normalizeJobName,
   generateReport,
+  shouldCountAsRetry,
 };

--- a/.github/scripts/analyze-test-flakiness.test.js
+++ b/.github/scripts/analyze-test-flakiness.test.js
@@ -2,9 +2,11 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 
 const {
+  buildAttemptOneOutcomes,
   calculateMetrics,
   extractTestExecutions,
   normalizeJobName,
+  shouldCountAsRetry,
 } = require('./analyze-test-flakiness');
 
 test('normalizeJobName strips matrix shard suffixes', () => {
@@ -71,6 +73,84 @@ test('extractTestExecutions returns empty when test steps exist but are skipped/
 
   // Test steps exist but were skipped — should NOT fall back to job-level failure
   assert.deepEqual(extractTestExecutions(job), []);
+});
+
+test('shouldCountAsRetry only attributes workflow retries to failed attempt-1 steps', () => {
+  assert.equal(
+    shouldCountAsRetry({
+      attemptOneConclusion: 'failure',
+      runAttempt: 2,
+      conclusion: 'success',
+    }),
+    true
+  );
+  assert.equal(
+    shouldCountAsRetry({
+      attemptOneConclusion: 'success',
+      runAttempt: 2,
+      conclusion: 'success',
+    }),
+    false
+  );
+  assert.equal(
+    shouldCountAsRetry({
+      attemptOneConclusion: undefined,
+      runAttempt: 2,
+      conclusion: 'success',
+    }),
+    false
+  );
+});
+
+test('buildAttemptOneOutcomes records only first workflow attempts', () => {
+  const unitJob = {
+    name: 'Unit Tests (1/6)',
+    conclusion: 'success',
+    steps: [
+      { name: 'Run unit tests', conclusion: 'failure' },
+      { name: 'Run packages/ui unit tests', conclusion: 'success' },
+    ],
+  };
+
+  const outcomes = buildAttemptOneOutcomes([
+    {
+      run: { head_sha: 'sha-a', run_attempt: 1 },
+      jobs: [unitJob],
+    },
+    {
+      run: { head_sha: 'sha-a', run_attempt: 2 },
+      jobs: [unitJob],
+    },
+  ]);
+
+  assert.deepEqual(
+    [...outcomes.get('sha-a').entries()],
+    [
+      ['Unit Tests › Run unit tests', 'failure'],
+      ['Unit Tests › Run packages/ui unit tests', 'success'],
+    ]
+  );
+});
+
+test('calculateMetrics does not flag stable steps with workflow-only retries', () => {
+  const testStats = new Map([
+    [
+      'Unit Tests › Run unit tests',
+      { failures: 1, successes: 68, retries: 0, runs: 69, lastFailure: null },
+    ],
+    [
+      'Unit Tests › Run quarantined unit tests (retries)',
+      { failures: 0, successes: 68, retries: 0, runs: 68, lastFailure: null },
+    ],
+    [
+      'Unit Tests › Run packages/ui unit tests',
+      { failures: 0, successes: 68, retries: 0, runs: 68, lastFailure: null },
+    ],
+  ]);
+
+  const flaky = calculateMetrics(testStats);
+
+  assert.equal(flaky.length, 0);
 });
 
 test('calculateMetrics flags only tests above thresholds', () => {


### PR DESCRIPTION
## Summary

Fixes the 3 false-positive flaky tests reported in JOV-3029 / GH #10610.

The test flakiness analyzer counted **every successful CI step on a re-run workflow** as a test retry. When an unrelated job failed and the workflow was retried, stable unit-test steps (`Run unit tests`, `Run quarantined unit tests (retries)`, `Run packages/ui unit tests`) all inherited a ~13% retry rate even though they never failed.

## Fix

- Record attempt-1 outcomes per `head_sha`
- Only count a retry when the **same step failed on attempt 1** and succeeded on a later workflow attempt
- Add regression tests for the JOV-3029 signature (3 stable unit-test steps no longer flagged)

## Verification

```bash
node --test .github/scripts/analyze-test-flakiness.test.js
```

Closes JOV-3029

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved test flakiness analysis to more accurately track retries and identify flaky tests through refined detection logic.

* **Tests**
  * Added test coverage for retry attribution rules and flakiness detection mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->