### PR TITLE
feat(auth): enable email one-time-code sign-in/sign-up in AuthShell (JOV-3053)

### DIFF
--- a/apps/web/components/features/auth/AuthShell.tsx
+++ b/apps/web/components/features/auth/AuthShell.tsx
@@ -18,6 +18,7 @@ import {
   getEnabledAuthOAuthProviders,
   type PrimaryAuthOAuthProvider,
 } from '@/lib/auth/oauth-providers';
+import { EmailCodeAuthForm } from './EmailCodeAuthForm';
 
 export type AuthShellMode = 'sign-in' | 'sign-up';
 
@@ -84,8 +85,7 @@ interface AuthShellProps {
    */
   readonly appearance?: Record<string, unknown>;
   /**
-   * Legacy email prefill prop. Kept so callers can pass it without rendering
-   * a credential input on the SSO-only auth surface.
+   * Email prefill for the email-code form (e.g. `?email=` deep links).
    */
   readonly initialValues?: { readonly emailAddress?: string };
 }
@@ -93,10 +93,12 @@ interface AuthShellProps {
 /**
  * Canonical auth surface for Jovie.
  *
- * Jovie is SSO-only (Google + Apple via Clerk) — see JOV-2446 and JOV-2778.
- * The shell owns the visible OAuth buttons and calls Clerk's redirect APIs
- * directly, so Clerk credential fields never mount even if the dashboard
- * configuration regresses.
+ * Renders SSO (Google + Apple via Clerk) plus the email one-time-code flow.
+ * Email (`email_code`) auth is intentionally enabled (founder decision,
+ * 2026-06) — this supersedes the SSO-only contract from JOV-2446/JOV-2778.
+ * Password auth remains intentionally unsupported: the shell owns all
+ * visible auth controls and never mounts a password field, even if the
+ * Clerk dashboard configuration regresses.
  *
  * See JOV-2064, JOV-2437, JOV-2446, JOV-2778.
  */
@@ -185,10 +187,11 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
   const hasNoEnabledProviders = enabledOAuthProviders.length === 0;
   const showStablePlaceholder = !isAuthStartReady;
 
-  // If absolutely no providers are gated on, render the unavailable card
-  // instead of an indefinite placeholder. This prevents the auth surface
-  // from looking broken during a provider-wide incident.
-  if (hasNoEnabledProviders) {
+  // If absolutely no OAuth providers are gated on, the email-code form is
+  // still a valid auth path, so only render the unavailable card when Clerk
+  // itself never becomes ready. With zero providers we skip the OAuth grid
+  // and lead with the email form.
+  if (hasNoEnabledProviders && !isAuthStartReady) {
     return (
       <div
         data-auth-shell-mode={mode}
@@ -226,6 +229,8 @@ export function AuthShell(props: Readonly<AuthShellProps>) {
           pendingProvider={pendingProvider}
           errorMessage={oauthError}
           onProviderSelect={handleProviderSelect}
+          redirectUrl={resolvedRedirect}
+          initialEmailAddress={props.initialValues?.emailAddress}
         />
       )}
     </div>
@@ -271,6 +276,14 @@ function AuthStableStartPlaceholder({
 
       <AuthProviderButtonSlots providers={providers} />
 
+      {/* Reserved space for the email-code form (divider + input + button)
+          so the placeholder → ready transition does not shift layout. */}
+      <div data-auth-email-form-slot aria-hidden='true' className='mt-4'>
+        <div className='h-5' />
+        <div className='h-11 rounded-(--linear-radius-sm) bg-surface-0' />
+        <div className='mt-3 h-11 rounded-(--linear-radius-sm) bg-surface-0' />
+      </div>
+
       <div
         data-auth-oauth-error-slot
         className='mt-3 min-h-5 text-center'
@@ -296,6 +309,8 @@ function AuthOAuthStartSurface({
   pendingProvider,
   errorMessage,
   onProviderSelect,
+  redirectUrl,
+  initialEmailAddress,
 }: Readonly<{
   mode: AuthShellMode;
   oppositeModeUrl: string;
@@ -304,27 +319,42 @@ function AuthOAuthStartSurface({
   pendingProvider: PrimaryAuthOAuthProvider | null;
   errorMessage: string | null;
   onProviderSelect: (provider: PrimaryAuthOAuthProvider) => void;
+  redirectUrl: string;
+  initialEmailAddress?: string;
 }>) {
+  const hasProviders = providers.length > 0;
+
   return (
     <div data-auth-sso-surface>
       <AuthShellTitle mode={mode} />
 
-      <fieldset
-        data-auth-provider-slots
-        className='grid grid-cols-1 gap-1.5'
-        aria-busy={pendingProvider ? 'true' : undefined}
-      >
-        <legend className='sr-only'>Social sign-in options</legend>
-        {providers.map(provider => (
-          <AuthProviderButtonSlot
-            key={provider}
-            provider={provider}
-            disabled={Boolean(pendingProvider)}
-            pending={pendingProvider === provider}
-            onClick={() => onProviderSelect(provider)}
-          />
-        ))}
-      </fieldset>
+      {hasProviders ? (
+        <fieldset
+          data-auth-provider-slots
+          className='grid grid-cols-1 gap-1.5'
+          aria-busy={pendingProvider ? 'true' : undefined}
+        >
+          <legend className='sr-only'>Social sign-in options</legend>
+          {providers.map(provider => (
+            <AuthProviderButtonSlot
+              key={provider}
+              provider={provider}
+              disabled={Boolean(pendingProvider)}
+              pending={pendingProvider === provider}
+              onClick={() => onProviderSelect(provider)}
+            />
+          ))}
+        </fieldset>
+      ) : null}
+
+      <div data-auth-email-form-slot className='mt-4'>
+        {hasProviders ? <AuthMethodDivider /> : null}
+        <EmailCodeAuthForm
+          mode={mode}
+          redirectUrl={redirectUrl}
+          initialEmailAddress={initialEmailAddress}
+        />
+      </div>
 
       <div
         data-auth-oauth-error-slot
@@ -348,6 +378,22 @@ function AuthOAuthStartSurface({
       />
 
       <AuthLegalText mode={mode} />
+    </div>
+  );
+}
+
+function AuthMethodDivider() {
+  return (
+    <div
+      data-auth-method-divider
+      className='mb-4 flex items-center gap-3'
+      aria-hidden='true'
+    >
+      <span className='h-px flex-1 bg-(--linear-border-subtle)' />
+      <span className='text-2xs uppercase tracking-wide text-secondary-token'>
+        or
+      </span>
+      <span className='h-px flex-1 bg-(--linear-border-subtle)' />
     </div>
   );
 }

--- a/apps/web/components/features/auth/EmailCodeAuthForm.tsx
+++ b/apps/web/components/features/auth/EmailCodeAuthForm.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import { useSignIn, useSignUp } from '@clerk/nextjs';
+import type { FormEvent } from 'react';
+import { useCallback, useState } from 'react';
+import {
+  AuthButton,
+  AuthInput,
+  FormError,
+  OtpInput,
+} from '@/features/auth/atoms';
+import type { AuthShellMode } from './AuthShell';
+
+/**
+ * Email one-time-code auth flow for the canonical AuthShell.
+ *
+ * Email (`email_code`) auth is intentionally enabled on the Clerk instance
+ * (founder decision, 2026-06 — supersedes the SSO-only contract from
+ * JOV-2446/JOV-2778). This form is the app-owned UI for that strategy:
+ * email entry → six-digit code → session finalize. Password auth remains
+ * intentionally unsupported; no password field may ever mount here.
+ *
+ * Uses the same Clerk resource API style as the SSO buttons in AuthShell:
+ * methods return `{ error }` instead of throwing.
+ */
+
+type EmailCodeStep = 'email' | 'code';
+
+interface EmailCodeAuthFormProps {
+  /** Which Clerk flow to drive. */
+  readonly mode: AuthShellMode;
+  /** Where to navigate after the session is finalized. */
+  readonly redirectUrl: string;
+  /** Optional email prefill (e.g. from `?email=` deep links). */
+  readonly initialEmailAddress?: string;
+}
+
+interface ClerkErrorLike {
+  readonly code?: string;
+  readonly message?: string;
+}
+
+function readClerkError(error: unknown): ClerkErrorLike {
+  if (!error || typeof error !== 'object') return {};
+
+  const candidate = error as {
+    code?: unknown;
+    message?: unknown;
+    errors?: ReadonlyArray<{ code?: unknown; message?: unknown }>;
+  };
+  const first = Array.isArray(candidate.errors)
+    ? candidate.errors[0]
+    : undefined;
+  const code = first?.code ?? candidate.code;
+  const message = first?.message ?? candidate.message;
+
+  return {
+    code: typeof code === 'string' ? code : undefined,
+    message: typeof message === 'string' ? message : undefined,
+  };
+}
+
+function getSendErrorMessage(mode: AuthShellMode, error: unknown): string {
+  const { code } = readClerkError(error);
+
+  if (mode === 'sign-in' && code === 'form_identifier_not_found') {
+    return 'No account found for this email. Request access below to get started.';
+  }
+  if (mode === 'sign-up' && code === 'form_identifier_exists') {
+    return 'An account with this email already exists. Sign in instead.';
+  }
+  if (code === 'form_param_format_invalid') {
+    return 'That email address doesn’t look right. Check it and try again.';
+  }
+
+  return mode === 'sign-up'
+    ? 'Could not start sign-up. Please try again.'
+    : 'Could not send the code. Please try again.';
+}
+
+function getVerifyErrorMessage(error: unknown): string {
+  const { code } = readClerkError(error);
+
+  if (code === 'form_code_incorrect') {
+    return 'That code is incorrect. Check your email and try again.';
+  }
+  if (code === 'verification_expired') {
+    return 'That code has expired. Send a new one and try again.';
+  }
+
+  return 'Could not verify the code. Please try again.';
+}
+
+export function EmailCodeAuthForm({
+  mode,
+  redirectUrl,
+  initialEmailAddress,
+}: EmailCodeAuthFormProps) {
+  const signInState = useSignIn();
+  const signUpState = useSignUp();
+  const [step, setStep] = useState<EmailCodeStep>('email');
+  const [emailAddress, setEmailAddress] = useState(initialEmailAddress ?? '');
+  const [code, setCode] = useState('');
+  const [isPending, setIsPending] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const isSignUp = mode === 'sign-up';
+  const signIn = signInState.signIn;
+  const signUp = signUpState.signUp;
+  const isReady = isSignUp ? Boolean(signUp) : Boolean(signIn);
+
+  const sendCode = useCallback(async () => {
+    const trimmedEmail = emailAddress.trim();
+    if (!trimmedEmail || isPending || !isReady) return;
+
+    setIsPending(true);
+    setErrorMessage(null);
+
+    try {
+      if (isSignUp) {
+        if (!signUp) throw new Error('Missing Clerk sign-up resource');
+        const created = await signUp.create({
+          emailAddress: trimmedEmail,
+          legalAccepted: true,
+        });
+        if (created.error) throw created.error;
+        const sent = await signUp.verifications.sendEmailCode();
+        if (sent.error) throw sent.error;
+      } else {
+        if (!signIn) throw new Error('Missing Clerk sign-in resource');
+        const sent = await signIn.emailCode.sendCode({
+          emailAddress: trimmedEmail,
+        });
+        if (sent.error) throw sent.error;
+      }
+
+      setCode('');
+      setStep('code');
+    } catch (error) {
+      setErrorMessage(getSendErrorMessage(mode, error));
+    } finally {
+      setIsPending(false);
+    }
+  }, [emailAddress, isPending, isReady, isSignUp, mode, signIn, signUp]);
+
+  const verifyCode = useCallback(
+    async (submittedCode: string) => {
+      if (submittedCode.length < 6 || isPending) return;
+
+      setIsPending(true);
+      setErrorMessage(null);
+
+      try {
+        if (isSignUp) {
+          if (!signUp) throw new Error('Missing Clerk sign-up resource');
+          const verified = await signUp.verifications.verifyEmailCode({
+            code: submittedCode,
+          });
+          if (verified.error) throw verified.error;
+          const finalized = await signUp.finalize();
+          if (finalized.error) throw finalized.error;
+        } else {
+          if (!signIn) throw new Error('Missing Clerk sign-in resource');
+          const verified = await signIn.emailCode.verifyCode({
+            code: submittedCode,
+          });
+          if (verified.error) throw verified.error;
+          const finalized = await signIn.finalize();
+          if (finalized.error) throw finalized.error;
+        }
+
+        globalThis.location?.assign(redirectUrl);
+      } catch (error) {
+        setErrorMessage(getVerifyErrorMessage(error));
+        setIsPending(false);
+      }
+    },
+    [isPending, isSignUp, redirectUrl, signIn, signUp]
+  );
+
+  const handleEmailSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      void sendCode();
+    },
+    [sendCode]
+  );
+
+  const handleCodeSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      void verifyCode(code);
+    },
+    [code, verifyCode]
+  );
+
+  const handleBackToEmail = useCallback(() => {
+    setStep('email');
+    setCode('');
+    setErrorMessage(null);
+  }, []);
+
+  if (step === 'code') {
+    return (
+      <form
+        data-auth-email-code-step='code'
+        onSubmit={handleCodeSubmit}
+        className='flex flex-col gap-3'
+      >
+        <p className='text-center text-app text-secondary-token'>
+          Enter the code sent to{' '}
+          <span className='font-medium text-primary-token'>
+            {emailAddress.trim()}
+          </span>
+        </p>
+        <OtpInput
+          value={code}
+          onChange={setCode}
+          onComplete={verifyCode}
+          disabled={isPending}
+          error={Boolean(errorMessage)}
+          errorId='auth-email-code-error'
+        />
+        <FormError id='auth-email-code-error' message={errorMessage} />
+        <AuthButton type='submit' disabled={isPending || code.length < 6}>
+          {isPending ? 'Verifying…' : 'Verify Code'}
+        </AuthButton>
+        <button
+          type='button'
+          onClick={handleBackToEmail}
+          className='focus-ring-themed mx-auto rounded-md text-app text-secondary-token underline underline-offset-2'
+        >
+          Use a different email
+        </button>
+      </form>
+    );
+  }
+
+  return (
+    <form
+      data-auth-email-code-step='email'
+      onSubmit={handleEmailSubmit}
+      className='flex flex-col gap-3'
+    >
+      <AuthInput
+        type='email'
+        name='emailAddress'
+        autoComplete='email'
+        inputMode='email'
+        placeholder='Email address'
+        aria-label='Email address'
+        value={emailAddress}
+        error={Boolean(errorMessage)}
+        disabled={isPending}
+        onChange={event => setEmailAddress(event.target.value)}
+      />
+      <FormError message={errorMessage} />
+      <AuthButton
+        type='submit'
+        disabled={isPending || !isReady || emailAddress.trim().length === 0}
+      >
+        {isPending
+          ? 'Sending code…'
+          : isSignUp
+            ? 'Continue with Email'
+            : 'Email me a Code'}
+      </AuthButton>
+    </form>
+  );
+}

--- a/apps/web/tests/unit/auth/AuthShell.test.tsx
+++ b/apps/web/tests/unit/auth/AuthShell.test.tsx
@@ -8,6 +8,13 @@ const {
   searchParamsState,
   signInSsoMock,
   signUpSsoMock,
+  signInEmailCodeSendMock,
+  signInEmailCodeVerifyMock,
+  signInFinalizeMock,
+  signUpCreateMock,
+  signUpSendEmailCodeMock,
+  signUpVerifyEmailCodeMock,
+  signUpFinalizeMock,
 } = vi.hoisted(() => ({
   authResourceState: {
     clerkLoaded: true,
@@ -21,6 +28,13 @@ const {
   searchParamsState: { value: '' },
   signInSsoMock: vi.fn(),
   signUpSsoMock: vi.fn(),
+  signInEmailCodeSendMock: vi.fn(),
+  signInEmailCodeVerifyMock: vi.fn(),
+  signInFinalizeMock: vi.fn(),
+  signUpCreateMock: vi.fn(),
+  signUpSendEmailCodeMock: vi.fn(),
+  signUpVerifyEmailCodeMock: vi.fn(),
+  signUpFinalizeMock: vi.fn(),
 }));
 
 vi.mock('@clerk/nextjs', () => ({
@@ -32,6 +46,11 @@ vi.mock('@clerk/nextjs', () => ({
       ? {
           signIn: {
             sso: signInSsoMock,
+            emailCode: {
+              sendCode: signInEmailCodeSendMock,
+              verifyCode: signInEmailCodeVerifyMock,
+            },
+            finalize: signInFinalizeMock,
           },
         }
       : {
@@ -42,6 +61,12 @@ vi.mock('@clerk/nextjs', () => ({
       ? {
           signUp: {
             sso: signUpSsoMock,
+            create: signUpCreateMock,
+            verifications: {
+              sendEmailCode: signUpSendEmailCodeMock,
+              verifyEmailCode: signUpVerifyEmailCodeMock,
+            },
+            finalize: signUpFinalizeMock,
           },
         }
       : {
@@ -84,7 +109,11 @@ function expectNoCredentialInputs(container: HTMLElement) {
   ).toBeNull();
 }
 
-describe('AuthShell — JOV-2778 app-owned SSO-only contract', () => {
+function expectNoPasswordInputs(container: HTMLElement) {
+  expect(container.querySelector('input[type="password"]')).toBeNull();
+}
+
+describe('AuthShell — app-owned SSO + email-code contract', () => {
   beforeEach(() => {
     authResourceState.clerkLoaded = true;
     authResourceState.signInLoaded = true;
@@ -96,6 +125,18 @@ describe('AuthShell — JOV-2778 app-owned SSO-only contract', () => {
     signInSsoMock.mockResolvedValue({ error: null });
     signUpSsoMock.mockReset();
     signUpSsoMock.mockResolvedValue({ error: null });
+    for (const mock of [
+      signInEmailCodeSendMock,
+      signInEmailCodeVerifyMock,
+      signInFinalizeMock,
+      signUpCreateMock,
+      signUpSendEmailCodeMock,
+      signUpVerifyEmailCodeMock,
+      signUpFinalizeMock,
+    ]) {
+      mock.mockReset();
+      mock.mockResolvedValue({ error: null });
+    }
   });
 
   it('renders stable full-label provider slots before Clerk is ready', () => {
@@ -136,7 +177,7 @@ describe('AuthShell — JOV-2778 app-owned SSO-only contract', () => {
     expect(placeholder?.textContent ?? '').not.toMatch(/\bor\b/);
   });
 
-  it('renders a ready sign-in SSO surface without mounting credential inputs', async () => {
+  it('renders a ready sign-in surface with SSO buttons and the email-code form, never a password input', async () => {
     const { container } = render(<AuthShell mode='sign-in' />);
 
     await waitFor(() => {
@@ -150,8 +191,43 @@ describe('AuthShell — JOV-2778 app-owned SSO-only contract', () => {
     expect(
       container.querySelector('[data-auth-stable-placeholder]')
     ).toBeNull();
-    expectNoCredentialInputs(container);
-    expect(container.textContent ?? '').not.toMatch(/\bor\b/);
+    // Email OTP is the supported credential path (intentional, 2026-06).
+    expect(
+      container.querySelector('input[type="email"][name="emailAddress"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-auth-method-divider]')
+    ).not.toBeNull();
+    expectNoPasswordInputs(container);
+  });
+
+  it('sends an email code and advances to the code step on submit (sign-in)', async () => {
+    const user = userEvent.setup();
+
+    const { container } = render(<AuthShell mode='sign-in' />);
+
+    const emailInput = await waitFor(() => {
+      const input = container.querySelector<HTMLInputElement>(
+        'input[type="email"][name="emailAddress"]'
+      );
+      expect(input).not.toBeNull();
+      return input as HTMLInputElement;
+    });
+
+    await user.type(emailInput, 'artist@example.com');
+    await user.click(
+      screen.getByRole('button', { name: /email me a code/i })
+    );
+
+    await waitFor(() => {
+      expect(signInEmailCodeSendMock).toHaveBeenCalledWith({
+        emailAddress: 'artist@example.com',
+      });
+    });
+    expect(
+      container.querySelector('[data-auth-email-code-step="code"]')
+    ).not.toBeNull();
+    expectNoPasswordInputs(container);
   });
 
   it('starts Google sign-in through Clerk redirect with the canonical callback and account chooser', async () => {
@@ -265,9 +341,36 @@ describe('AuthShell — JOV-2778 app-owned SSO-only contract', () => {
     expect(link).toHaveAttribute('href', '/signin');
   });
 
-  it('renders AuthProvidersUnavailable when zero OAuth providers are enabled', () => {
+  it('falls back to the email-code form when zero OAuth providers are enabled but Clerk is ready', async () => {
     providerEnabledState.google = false;
     providerEnabledState.apple = false;
+
+    const { container } = render(<AuthShell mode='sign-in' />);
+
+    await waitFor(() => {
+      expect(container.firstElementChild).toHaveAttribute(
+        'data-auth-shell-ready',
+        'true'
+      );
+    });
+
+    // Email auth keeps the surface usable during an OAuth-provider incident.
+    expect(
+      container.querySelector('input[type="email"][name="emailAddress"]')
+    ).not.toBeNull();
+    expect(container.querySelector('[data-auth-provider-slots]')).toBeNull();
+    expect(container.querySelector('[data-auth-method-divider]')).toBeNull();
+    expect(
+      container.querySelector('[data-auth-providers-unavailable]')
+    ).toBeNull();
+    expect(signInSsoMock).not.toHaveBeenCalled();
+  });
+
+  it('renders AuthProvidersUnavailable when zero providers are enabled and Clerk never becomes ready', () => {
+    providerEnabledState.google = false;
+    providerEnabledState.apple = false;
+    authResourceState.clerkLoaded = false;
+    authResourceState.signInLoaded = false;
 
     const { container, getByRole } = render(<AuthShell mode='sign-in' />);
 


### PR DESCRIPTION
<!-- linear-issue-id:JOV-3053 -->

## Summary
- **Problem (JOV-3053, prod audit 2026-06-10):** email (`email_code`) auth is intentionally enabled on the Clerk instance, but the app-owned AuthShell still enforced the obsolete SSO-only contract — `/signin` and `/signup` render only Apple+Google, so users without those accounts cannot sign in or sign up at all. The Layer A prod synthetic (`synthetic-auth-ui.spec.ts`) already asserts an email input renders (JOV-2774 fix), so the canary is red against the live surface today.
- **Fix:** new `EmailCodeAuthForm` (email → 6-digit OTP → `finalize()`), rendered below the SSO buttons with an `or` divider, using the same Clerk resource API style as the SSO flow (`{ error }` returns; `signIn.emailCode.sendCode/verifyCode`, `signUp.create + verifications.sendEmailCode/verifyEmailCode`). Reuses existing auth atoms (`AuthInput`, `OtpInput`, `AuthButton`, `FormError`).
- **Password auth stays unmounted** — no password field can render; the shell still owns all visible controls.
- Zero-OAuth-provider incident now falls back to the email form when Clerk is ready (unavailable card only when Clerk never loads).
- Placeholder skeleton reserves matching space for the email form (no layout shift on ready transition).
- Unit-test contract updated to match the synthetic: email input + divider required, password forbidden; adds email-code send-flow coverage.

## Cost Impact
None — no new external calls beyond Clerk's existing email OTP delivery.

## Test plan
- [ ] `pnpm --filter web exec vitest run tests/unit/auth/AuthShell.test.tsx`
- [ ] `pnpm turbo typecheck` + `pnpm biome check --write apps/web` (authored without local toolchain — please run before merge)
- [ ] Manual: /signin → email → OTP from inbox → lands on /app; /signup with fresh email → OTP → onboarding; wrong code shows inline error; `synthetic-auth-ui.spec.ts` Layer A goes green after deploy

⚠️ Auth surface = high-risk path: labeled for human review; do not auto-merge.

🤖 Generated with Eve (PM agent) — audit epic JOV-3037
