### PR TITLE
fix(workflows): recover orphaned accepted suggested_actions (JOV-3039)

### DIFF
--- a/apps/web/app/api/connectors/suggested-actions/[id]/approve/route.ts
+++ b/apps/web/app/api/connectors/suggested-actions/[id]/approve/route.ts
@@ -21,6 +21,7 @@
 import { and, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/auth/require-auth';
+import { recoverOrphanedApprovedAction } from '@/lib/connectors/workflows/reconcile-orphaned-approved-actions';
 import { db } from '@/lib/db';
 import { suggestedActions, workflowRuns } from '@/lib/db/schema/connectors';
 import { captureError } from '@/lib/error-tracking';
@@ -64,6 +65,32 @@ export async function POST(_request: Request, { params }: RouteParams) {
       });
 
     if (updated.length === 0) {
+      const recovery = await recoverOrphanedApprovedAction({
+        approvalId: id,
+        userId,
+      });
+
+      if (recovery === 'enqueued' || recovery === 'already-queued') {
+        return NextResponse.json(
+          {
+            ok: true,
+            approvalId: id,
+            status:
+              recovery === 'enqueued'
+                ? 'approved-recovered'
+                : 'approved-pending-enqueue',
+          },
+          { status: 200, headers: NO_STORE_HEADERS }
+        );
+      }
+
+      if (recovery === 'not-found') {
+        return NextResponse.json(
+          { error: 'not-found' },
+          { status: 404, headers: NO_STORE_HEADERS }
+        );
+      }
+
       // 0 rows returned = CAS missed (already decided or not found)
       return NextResponse.json(
         { error: 'already-decided' },

--- a/apps/web/app/api/cron/frequent/route.ts
+++ b/apps/web/app/api/cron/frequent/route.ts
@@ -18,6 +18,7 @@
 
 import { sql as drizzleSql, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
+import { reconcileOrphanedAcceptedActions } from '@/lib/connectors/workflows/reconcile-orphaned-approved-actions';
 import { verifyCronRequest } from '@/lib/cron/auth';
 import { db } from '@/lib/db';
 import {
@@ -265,7 +266,13 @@ export async function GET(request: Request) {
     results.alphabetCache = { success: true, skipped: true };
   }
 
-  // 8. Fallback ingestion job processing — drains up to 2 jobs if the
+  // 8. Recover accepted suggested_actions missing workflow_runs enqueue
+  results.workflowApprovalRecovery = await runSubJob(
+    'workflowApprovalRecovery',
+    async () => reconcileOrphanedAcceptedActions(20)
+  );
+
+  // 9. Fallback ingestion job processing — drains up to 2 jobs if the
   //    dedicated cron hasn't picked them up. Runs last to stay within budget.
   const elapsed = Date.now() - startTime;
   if (elapsed < 50_000) {

--- a/apps/web/lib/connectors/workflows/reconcile-orphaned-approved-actions.test.ts
+++ b/apps/web/lib/connectors/workflows/reconcile-orphaned-approved-actions.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/db', () => {
+  const mockDb = {
+    select: vi.fn(),
+    insert: vi.fn(),
+  };
+  return { db: mockDb };
+});
+
+vi.mock('@/lib/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { db } from '@/lib/db';
+import {
+  reconcileOrphanedAcceptedActions,
+  recoverOrphanedApprovedAction,
+} from './reconcile-orphaned-approved-actions';
+
+const USER_ID = 'user-uuid-0000-0000-0000-000000000001';
+const ACTION_ID = 'action-uuid-0000-0000-0000-000000000001';
+
+function mockSelectChain(rows: unknown[]) {
+  const chain = {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  };
+  vi.mocked(db.select).mockReturnValue(
+    chain as unknown as ReturnType<typeof db.select>
+  );
+  return chain;
+}
+
+function mockInsertChain() {
+  const chain = {
+    values: vi.fn().mockResolvedValue([{ id: 'workflow-run-id' }]),
+  };
+  vi.mocked(db.insert).mockReturnValue(
+    chain as unknown as ReturnType<typeof db.insert>
+  );
+  return chain;
+}
+
+describe('recoverOrphanedApprovedAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns not-found when the suggested action does not exist', async () => {
+    mockSelectChain([]);
+
+    await expect(
+      recoverOrphanedApprovedAction({
+        approvalId: ACTION_ID,
+        userId: USER_ID,
+      })
+    ).resolves.toBe('not-found');
+  });
+
+  it('returns not-accepted when the action is not accepted for the user', async () => {
+    mockSelectChain([
+      {
+        id: ACTION_ID,
+        status: 'dismissed',
+        userId: USER_ID,
+        payload: {},
+      },
+    ]);
+
+    await expect(
+      recoverOrphanedApprovedAction({
+        approvalId: ACTION_ID,
+        userId: USER_ID,
+      })
+    ).resolves.toBe('not-accepted');
+  });
+
+  it('returns already-queued when a workflow run already exists', async () => {
+    let selectCall = 0;
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCall++;
+      const rows =
+        selectCall === 1
+          ? [
+              {
+                id: ACTION_ID,
+                status: 'accepted',
+                userId: USER_ID,
+                payload: { title: 'Show' },
+              },
+            ]
+          : [{ id: 'existing-run' }];
+      return {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue(rows),
+      } as unknown as ReturnType<typeof db.select>;
+    });
+
+    await expect(
+      recoverOrphanedApprovedAction({
+        approvalId: ACTION_ID,
+        userId: USER_ID,
+      })
+    ).resolves.toBe('already-queued');
+
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('enqueues a workflow run for accepted actions missing a run', async () => {
+    let selectCall = 0;
+    vi.mocked(db.select).mockImplementation(() => {
+      selectCall++;
+      const rows =
+        selectCall === 1
+          ? [
+              {
+                id: ACTION_ID,
+                status: 'accepted',
+                userId: USER_ID,
+                payload: { title: 'Show' },
+              },
+            ]
+          : [];
+      return {
+        from: vi.fn().mockReturnThis(),
+        where: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue(rows),
+      } as unknown as ReturnType<typeof db.select>;
+    });
+    const insertChain = mockInsertChain();
+
+    await expect(
+      recoverOrphanedApprovedAction({
+        approvalId: ACTION_ID,
+        userId: USER_ID,
+      })
+    ).resolves.toBe('enqueued');
+
+    expect(insertChain.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'execute_approved_action',
+        userId: USER_ID,
+        stepOutputs: {
+          approvalId: ACTION_ID,
+          eventPayload: { title: 'Show' },
+        },
+      })
+    );
+  });
+});
+
+describe('reconcileOrphanedAcceptedActions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('enqueues workflow runs for each orphaned accepted action', async () => {
+    mockSelectChain([
+      {
+        id: ACTION_ID,
+        userId: USER_ID,
+        payload: { title: 'Show' },
+      },
+    ]);
+    const insertChain = mockInsertChain();
+
+    await expect(reconcileOrphanedAcceptedActions(20)).resolves.toEqual({
+      scanned: 1,
+      enqueued: 1,
+    });
+
+    expect(insertChain.values).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/lib/connectors/workflows/reconcile-orphaned-approved-actions.ts
+++ b/apps/web/lib/connectors/workflows/reconcile-orphaned-approved-actions.ts
@@ -1,0 +1,150 @@
+/**
+ * Recovery for accepted suggested_actions rows missing a workflow_runs enqueue.
+ *
+ * The approve endpoint performs two sequential writes (CAS update, then insert).
+ * If the insert fails after CAS succeeds, the action is stuck accepted with no
+ * run until recovered here or via the approve retry path.
+ */
+
+import { and, sql as drizzleSql, eq, notExists } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { suggestedActions, workflowRuns } from '@/lib/db/schema/connectors';
+import { logger } from '@/lib/utils/logger';
+
+type BookingPayload = {
+  title?: string;
+  startsAt?: string;
+  endsAt?: string;
+  timeZone?: string;
+};
+
+export type OrphanedApprovalRecoveryResult =
+  | 'enqueued'
+  | 'already-queued'
+  | 'not-accepted'
+  | 'not-found';
+
+function workflowRunMissingForSuggestedAction() {
+  return notExists(
+    db
+      .select({ id: workflowRuns.id })
+      .from(workflowRuns)
+      .where(
+        and(
+          eq(workflowRuns.kind, 'execute_approved_action'),
+          drizzleSql`${workflowRuns.stepOutputs} ->> 'approvalId' = ${suggestedActions.id}::text`
+        )
+      )
+  );
+}
+
+export async function enqueueApprovedActionWorkflow(input: {
+  userId: string;
+  approvalId: string;
+  eventPayload: BookingPayload | null;
+}): Promise<void> {
+  await db.insert(workflowRuns).values({
+    kind: 'execute_approved_action',
+    userId: input.userId,
+    status: 'queued',
+    currentStep: 'create_calendar_event',
+    stepOutputs: {
+      approvalId: input.approvalId,
+      eventPayload: input.eventPayload,
+    },
+    runAt: new Date(),
+  });
+}
+
+export async function recoverOrphanedApprovedAction(input: {
+  approvalId: string;
+  userId: string;
+}): Promise<OrphanedApprovalRecoveryResult> {
+  const [action] = await db
+    .select({
+      id: suggestedActions.id,
+      status: suggestedActions.status,
+      userId: suggestedActions.userId,
+      payload: suggestedActions.payload,
+    })
+    .from(suggestedActions)
+    .where(eq(suggestedActions.id, input.approvalId))
+    .limit(1);
+
+  if (!action) {
+    return 'not-found';
+  }
+
+  if (action.userId !== input.userId || action.status !== 'accepted') {
+    return 'not-accepted';
+  }
+
+  const [existingRun] = await db
+    .select({ id: workflowRuns.id })
+    .from(workflowRuns)
+    .where(
+      and(
+        eq(workflowRuns.kind, 'execute_approved_action'),
+        drizzleSql`${workflowRuns.stepOutputs} ->> 'approvalId' = ${input.approvalId}`
+      )
+    )
+    .limit(1);
+
+  if (existingRun) {
+    return 'already-queued';
+  }
+
+  await enqueueApprovedActionWorkflow({
+    userId: action.userId,
+    approvalId: action.id,
+    eventPayload: action.payload as BookingPayload | null,
+  });
+
+  logger.info('[reconcile] recovered orphaned accepted suggested_action', {
+    approvalId: input.approvalId,
+    userId: input.userId,
+  });
+
+  return 'enqueued';
+}
+
+export async function reconcileOrphanedAcceptedActions(
+  limit = 20
+): Promise<{ scanned: number; enqueued: number }> {
+  const orphaned = await db
+    .select({
+      id: suggestedActions.id,
+      userId: suggestedActions.userId,
+      payload: suggestedActions.payload,
+    })
+    .from(suggestedActions)
+    .where(
+      and(
+        eq(suggestedActions.status, 'accepted'),
+        workflowRunMissingForSuggestedAction()
+      )
+    )
+    .limit(limit);
+
+  let enqueued = 0;
+  for (const action of orphaned) {
+    await enqueueApprovedActionWorkflow({
+      userId: action.userId,
+      approvalId: action.id,
+      eventPayload: action.payload as BookingPayload | null,
+    });
+    enqueued++;
+  }
+
+  if (enqueued > 0) {
+    logger.info(
+      '[reconcile] cron enqueued orphaned accepted suggested_actions',
+      {
+        scanned: orphaned.length,
+        enqueued,
+      }
+    );
+  }
+
+  return { scanned: orphaned.length, enqueued };
+}

--- a/scripts/loop-train-drain.sh
+++ b/scripts/loop-train-drain.sh
@@ -6,7 +6,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 # Update this list when opening new integration→main train PRs.
-TRAIN_PRS=(10514 10515)
+TRAIN_PRS=(10631)
 
 for num in "${TRAIN_PRS[@]}"; do
   state="$(gh pr view "$num" --json mergeStateStatus -q .mergeStateStatus 2>/dev/null || echo MISSING)"


### PR DESCRIPTION
## Summary
- Approve retry path re-enqueues workflow_runs when CAS already accepted the action
- Frequent cron scans for accepted suggested_actions missing a workflow enqueue

Linear: https://linear.app/jovie/issue/JOV-3039

<!-- linear-issue-id:JOV-3039 -->

## Validation
- pnpm --filter web exec vitest run lib/connectors/workflows/reconcile-orphaned-approved-actions.test.ts
- typecheck + lint via pre-commit hooks