### PR TITLE
perf(chat): reduce turn latency N+1 and gate fan-out (JOV-3012)

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -36,10 +36,9 @@ import {
   createUIMessageStream,
   createUIMessageStreamResponse,
   tool,
-  type UIMessage,
   type UIMessageChunk,
 } from 'ai';
-import { and, count, desc, sql as drizzleSql, eq } from 'drizzle-orm';
+import { and, count, sql as drizzleSql, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { tryHandleAnonymousOnboardingChat } from '@/app/api/chat/onboarding-handler';
@@ -56,10 +55,12 @@ import {
   detectAlbumArtGenerationIntent,
   resolveAlbumArtCapability,
 } from '@/lib/chat/album-art-capability';
+import { extractLastUserText } from '@/lib/chat/message-text';
 import {
   updateOwnedReleaseGeneratedPitches,
   updateOwnedReleaseMetadata,
 } from '@/lib/chat/release-writes';
+import { fetchReleasesForChat } from '@/lib/chat/releases';
 import {
   extractUIMessageText,
   parseChatRequestBody,
@@ -98,14 +99,14 @@ import {
 import { db } from '@/lib/db';
 import { clickEvents, tips } from '@/lib/db/schema/analytics';
 import { users } from '@/lib/db/schema/auth';
-import { discogReleases } from '@/lib/db/schema/content';
+
 import { socialLinks } from '@/lib/db/schema/links';
 import { creatorProfiles } from '@/lib/db/schema/profiles';
 import { sqlAny } from '@/lib/db/sql-helpers';
 import { upsertRelease } from '@/lib/discography/queries';
 import { generateUniqueSlug } from '@/lib/discography/slug';
 import { FEATURE_FLAGS } from '@/lib/feature-flags/shared';
-import { checkGateForUser } from '@/lib/flags/server';
+import { checkGatesForUser } from '@/lib/flags/server';
 import { createAuthenticatedCorsHeaders } from '@/lib/http/headers';
 import {
   classifyIntent,
@@ -152,7 +153,6 @@ import type {
 } from '@/lib/services/album-art/types';
 import {
   buildCanvasMetadata,
-  getCanvasStatusFromMetadata,
   summarizeCanvasStatus,
 } from '@/lib/services/canvas/service';
 import { getInsightsSummary } from '@/lib/services/insights/lifecycle';
@@ -165,7 +165,6 @@ import {
   resolvePitchDestination,
 } from '@/lib/services/pitch';
 import { DSP_PLATFORMS } from '@/lib/services/social-links/types';
-import { toISOStringOrNull } from '@/lib/utils/date';
 import { detectPlatform } from '@/lib/utils/platform-detection/detector';
 
 export const dynamic = 'force-dynamic';
@@ -367,36 +366,6 @@ function formatAvailableReleases(releases: ReleaseContext[]): string {
 }
 
 /**
- * Fetches release data for the chat context.
- * Used by creative tools (canvas, social ads, related artists).
- */
-async function fetchReleasesForChat(
-  profileId: string
-): Promise<ReleaseContext[]> {
-  const releases = await db
-    .select({
-      id: discogReleases.id,
-      title: discogReleases.title,
-      releaseType: discogReleases.releaseType,
-      releaseDate: discogReleases.releaseDate,
-      artworkUrl: discogReleases.artworkUrl,
-      spotifyPopularity: discogReleases.spotifyPopularity,
-      totalTracks: discogReleases.totalTracks,
-      metadata: discogReleases.metadata,
-    })
-    .from(discogReleases)
-    .where(eq(discogReleases.creatorProfileId, profileId))
-    .orderBy(desc(discogReleases.releaseDate))
-    .limit(50);
-
-  return releases.map(r => ({
-    ...r,
-    releaseDate: toISOStringOrNull(r.releaseDate),
-    canvasStatus: getCanvasStatusFromMetadata(r.metadata),
-  }));
-}
-
-/**
  * Resolves artist context from profileId (server-side) or client-provided data.
  * Returns { context } on success or { error } with a NextResponse on failure.
  */
@@ -462,14 +431,6 @@ function safeSetSentryContext(callback: () => void): void {
   } catch {
     // Observability must never break the chat request path.
   }
-}
-
-function extractLastUserText(uiMessages: UIMessage[]): string {
-  const lastUserMsg = [...uiMessages].reverse().find(m => m.role === 'user');
-  if (!lastUserMsg) return '';
-  return extractUIMessageText(
-    lastUserMsg.parts as Array<{ type: string; text?: string }>
-  ).trim();
 }
 
 function normalizeChatTurnSource(value: unknown): ChatTurnSource {
@@ -767,7 +728,10 @@ function createSocialLinkRemovalTool(profileId: string | null) {
  * Creates the checkCanvasStatus tool for querying release canvas status.
  * Fetches release data and reports which releases need canvas videos.
  */
-function createCheckCanvasStatusTool(profileId: string | null) {
+function createCheckCanvasStatusTool(
+  profileId: string | null,
+  releases: ReleaseContext[]
+) {
   return tool({
     description:
       "Check which of the artist's releases have Spotify Canvas videos set and which are missing them. Use this when the artist asks about canvas videos or wants to generate them.",
@@ -786,8 +750,6 @@ function createCheckCanvasStatusTool(profileId: string | null) {
           error: 'Profile ID required for release data',
         };
       }
-
-      const releases = await fetchReleasesForChat(profileId);
 
       if (releases.length === 0) {
         return {
@@ -878,7 +840,10 @@ function createSuggestRelatedArtistsTool(context: ArtistContext) {
  * Creates the generateCanvasPlan tool.
  * Helps the artist plan a canvas video generation from their album artwork.
  */
-function createGenerateCanvasPlanTool(profileId: string | null) {
+function createGenerateCanvasPlanTool(
+  profileId: string | null,
+  releases: ReleaseContext[]
+) {
   return tool({
     description:
       'Generate a detailed plan for creating a Spotify Canvas video from album artwork. Includes artwork processing steps, animation style recommendations, and technical specs. Use this when an artist wants to create a canvas for a specific release.',
@@ -898,7 +863,6 @@ function createGenerateCanvasPlanTool(profileId: string | null) {
         return { success: false, error: 'Profile ID required' };
       }
 
-      const releases = await fetchReleasesForChat(profileId);
       const release = findReleaseByTitle(releases, releaseTitle);
 
       if (!release) {
@@ -918,6 +882,7 @@ function createGenerateAlbumArtTool(params: {
   readonly clerkUserId: string;
   readonly artistName: string;
   readonly canGenerateAlbumArt: boolean;
+  readonly releases: ReleaseContext[];
 }) {
   return tool({
     description:
@@ -986,8 +951,7 @@ function createGenerateAlbumArtTool(params: {
         };
       }
 
-      const releases = await fetchReleasesForChat(params.profileId);
-      const target = resolveAlbumArtReleaseTarget(releases, {
+      const target = resolveAlbumArtReleaseTarget(params.releases, {
         releaseId,
         releaseTitle,
       });
@@ -1442,7 +1406,8 @@ function buildCanvasPlan(
  */
 function createPromoStrategyTool(
   context: ArtistContext,
-  profileId: string | null
+  profileId: string | null,
+  releases: ReleaseContext[]
 ) {
   return tool({
     description:
@@ -1468,14 +1433,11 @@ function createPromoStrategyTool(
         .describe('Target platforms for the promotion'),
     }),
     execute: async ({ releaseTitle, budget, platforms }) => {
-      let targetRelease: ReleaseContext | null = null;
-
-      if (profileId) {
-        const releases = await fetchReleasesForChat(profileId);
-        targetRelease = releaseTitle
+      const targetRelease = profileId
+        ? releaseTitle
           ? findReleaseByTitle(releases, releaseTitle)
-          : (releases[0] ?? null);
-      }
+          : (releases[0] ?? null)
+        : null;
 
       return {
         success: true,
@@ -1536,7 +1498,10 @@ function createShowTopInsightsTool(profileId: string | null) {
  * Lets artists self-report that they've uploaded a canvas to Spotify for Artists.
  * Since Spotify has no public API for canvas status, this is the only reliable way to track it.
  */
-function createMarkCanvasUploadedTool(profileId: string | null) {
+function createMarkCanvasUploadedTool(
+  profileId: string | null,
+  releases: ReleaseContext[]
+) {
   return tool({
     description:
       "Mark a release as having a Spotify Canvas video uploaded. Use this when the artist confirms they've already set a canvas for a track/release in Spotify for Artists, or when they tell you a canvas is already uploaded.",
@@ -1550,7 +1515,6 @@ function createMarkCanvasUploadedTool(profileId: string | null) {
         return { success: false, error: 'Profile ID required' };
       }
 
-      const releases = await fetchReleasesForChat(profileId);
       const release = findReleaseByTitle(releases, releaseTitle);
 
       if (!release) {
@@ -1683,7 +1647,8 @@ function createReleaseTool(resolvedProfileId: string) {
  */
 function createWorldClassBioTool(
   context: ArtistContext,
-  profileId: string | null
+  profileId: string | null,
+  releases: ReleaseContext[]
 ) {
   return tool({
     description:
@@ -1706,12 +1671,6 @@ function createWorldClassBioTool(
         .describe('Maximum words for the returned draft (default 180)'),
     }),
     execute: async ({ goal, tone, maxWords }) => {
-      let releases: Awaited<ReturnType<typeof fetchReleasesForChat>> = [];
-      try {
-        releases = profileId ? await fetchReleasesForChat(profileId) : [];
-      } catch {
-        // Non-fatal: proceed with empty releases rather than failing the tool
-      }
       const wordLimit = maxWords ?? 180;
       const draftPackage = buildArtistBioDraft({
         artistName: context.displayName,
@@ -1831,7 +1790,8 @@ function createSubmitFeedbackTool(clerkUserId: string) {
  */
 function createGenerateReleasePitchTool(
   resolvedProfileId: string,
-  identity: { clerkUserId: string; conversationId: string | null }
+  identity: { clerkUserId: string; conversationId: string | null },
+  releases: ReleaseContext[]
 ) {
   return tool({
     description: `Generate one copy-paste-ready release pitch for a specific destination. Use for playlist, radio, Sirius XM, install, playback/music supervisor, editorial post, record label, or collaborator pitching. Ask the artist where they want to pitch it before calling this tool unless a task or user message clearly maps to one of these destinations: ${PITCH_TARGET_OPTIONS_TEXT}. Ask which release they want to pitch if unclear. If the artist provides custom guidance, pass it via instructions.`,
@@ -1884,8 +1844,6 @@ function createGenerateReleasePitchTool(
       instructions,
     }) => {
       try {
-        const releases = await fetchReleasesForChat(resolvedProfileId);
-
         if (releases.length === 0) {
           return {
             success: false as const,
@@ -2000,6 +1958,7 @@ function buildFreeChatTools(
 function buildChatTools(
   artistContext: ArtistContext,
   resolvedProfileId: string | null,
+  releases: ReleaseContext[],
   insightsEnabled: boolean,
   clerkUserId: string,
   canGenerateAlbumArt: boolean,
@@ -2016,13 +1975,17 @@ function buildChatTools(
       : {}),
     proposeProfileEdit: createProfileEditTool(artistContext),
     importBioFromUrl: createImportBioFromUrlTool({ userId: clerkUserId }),
-    checkCanvasStatus: createCheckCanvasStatusTool(resolvedProfileId),
+    checkCanvasStatus: createCheckCanvasStatusTool(resolvedProfileId, releases),
     suggestRelatedArtists: createSuggestRelatedArtistsTool(artistContext),
     writeWorldClassBio: createWorldClassBioTool(
       artistContext,
-      resolvedProfileId
+      resolvedProfileId,
+      releases
     ),
-    generateCanvasPlan: createGenerateCanvasPlanTool(resolvedProfileId),
+    generateCanvasPlan: createGenerateCanvasPlanTool(
+      resolvedProfileId,
+      releases
+    ),
     ...(albumArtEnabled && canGenerateAlbumArt
       ? {
           generateAlbumArt: createGenerateAlbumArtTool({
@@ -2030,12 +1993,14 @@ function buildChatTools(
             clerkUserId,
             artistName: artistContext.displayName,
             canGenerateAlbumArt,
+            releases,
           }),
         }
       : {}),
     createPromoStrategy: createPromoStrategyTool(
       artistContext,
-      resolvedProfileId
+      resolvedProfileId,
+      releases
     ),
     // gh-9808 HOT ZONE: voice promo audio generation from cloned voice (premium, 11Labs)
     // "clone my voice" / "voice promo" / "radio drop" intent loads via system prompt
@@ -2043,7 +2008,10 @@ function buildChatTools(
       profileId: resolvedProfileId ?? '',
       artistName: artistContext.displayName,
     }),
-    markCanvasUploaded: createMarkCanvasUploadedTool(resolvedProfileId),
+    markCanvasUploaded: createMarkCanvasUploadedTool(
+      resolvedProfileId,
+      releases
+    ),
     formatLyrics: createLyricsFormatTool(),
     ...(resolvedProfileId
       ? {
@@ -2053,7 +2021,8 @@ function buildChatTools(
             {
               clerkUserId,
               conversationId: reservedTurn?.conversationId ?? null,
-            }
+            },
+            releases
           ),
         }
       : {}),
@@ -2205,24 +2174,14 @@ function buildChatErrorResponse(
 }
 
 async function tryRouteViaIntent(
-  uiMessages: UIMessage[],
+  userText: string,
   profileId: unknown,
   userId: string,
   corsHeaders: Record<string, string>,
   requestId: string,
   reservedTurn?: { conversationId: string; turnId: string } | null
 ): Promise<Response | null> {
-  const lastUserMsg = [...uiMessages].reverse().find(m => m.role === 'user');
-  if (!lastUserMsg) return null;
-
-  const userText = lastUserMsg.parts
-    .filter(
-      (p): p is { type: 'text'; text: string } =>
-        p.type === 'text' && typeof p.text === 'string'
-    )
-    .map(p => p.text)
-    .join('')
-    .trim();
+  if (!userText) return null;
 
   const intent = classifyIntent(userText);
   if (!isDeterministicIntent(intent)) return null;
@@ -2364,11 +2323,10 @@ export async function POST(req: Request) {
   // light model without a code change. Defaults (both false) = normal behavior.
   // Keys are const-declared so a typo fails at compile time rather than
   // silently falling back to the default.
-  const chatDisabled = await checkGateForUser(
-    userId,
-    CHAT_KILL_SWITCH_GATES.DISABLED,
-    false
-  );
+  const [chatDisabled, forceLightModel] = await checkGatesForUser(userId, [
+    { key: CHAT_KILL_SWITCH_GATES.DISABLED, defaultValue: false },
+    { key: CHAT_KILL_SWITCH_GATES.FORCE_LIGHT, defaultValue: false },
+  ]);
   if (chatDisabled) {
     return NextResponse.json(
       {
@@ -2381,11 +2339,6 @@ export async function POST(req: Request) {
       { status: 503, headers: { ...corsHeaders, 'x-request-id': requestId } }
     );
   }
-  const forceLightModel = await checkGateForUser(
-    userId,
-    CHAT_KILL_SWITCH_GATES.FORCE_LIGHT,
-    false
-  );
   const parsedRequest = await parseChatRequestBody(req, {
     corsHeaders,
     requestId,
@@ -2620,7 +2573,7 @@ export async function POST(req: Request) {
 
   // --- Deterministic intent routing (skip AI for simple CRUD) ---
   const intentResponse = await tryRouteViaIntent(
-    uiMessages,
+    userText,
     profileId,
     userId,
     corsHeaders,
@@ -2689,6 +2642,7 @@ export async function POST(req: Request) {
           ...buildChatTools(
             artistContext,
             resolvedProfileId,
+            releases,
             insightsEnabled,
             userId,
             albumArtCapability.availability === 'available',
@@ -2753,6 +2707,7 @@ export async function POST(req: Request) {
       accountContext,
       insightsEnabled,
       forceLightModel,
+      lastUserText: userText,
       tools,
       signal: req.signal,
       requestId,

--- a/apps/web/lib/chat/message-text.ts
+++ b/apps/web/lib/chat/message-text.ts
@@ -1,0 +1,19 @@
+import type { UIMessage } from 'ai';
+import { extractUIMessageText } from '@/lib/chat/request-validation';
+
+type MessagePart = { type: string; text?: string };
+
+/**
+ * Returns trimmed text from the most recent user message in a UIMessage thread.
+ * Compute once per chat turn and pass through intent routing + model heuristics.
+ */
+export function extractLastUserText(uiMessages: UIMessage[]): string {
+  const lastUserMsg = [...uiMessages]
+    .reverse()
+    .find(message => message.role === 'user');
+  if (!lastUserMsg) {
+    return '';
+  }
+
+  return extractUIMessageText(lastUserMsg.parts as MessagePart[]).trim();
+}

--- a/apps/web/lib/chat/releases.ts
+++ b/apps/web/lib/chat/releases.ts
@@ -1,0 +1,38 @@
+import 'server-only';
+
+import { desc, eq } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { discogReleases } from '@/lib/db/schema/content';
+import { getCanvasStatusFromMetadata } from '@/lib/services/canvas/service';
+import { toISOStringOrNull } from '@/lib/utils/date';
+import type { ReleaseContext } from './types';
+
+/**
+ * Fetches release data for chat context (creative tools, canvas, pitches, etc.).
+ * Call once per chat turn and pass the result into tool factories.
+ */
+export async function fetchReleasesForChat(
+  profileId: string
+): Promise<ReleaseContext[]> {
+  const releases = await db
+    .select({
+      id: discogReleases.id,
+      title: discogReleases.title,
+      releaseType: discogReleases.releaseType,
+      releaseDate: discogReleases.releaseDate,
+      artworkUrl: discogReleases.artworkUrl,
+      spotifyPopularity: discogReleases.spotifyPopularity,
+      totalTracks: discogReleases.totalTracks,
+      metadata: discogReleases.metadata,
+    })
+    .from(discogReleases)
+    .where(eq(discogReleases.creatorProfileId, profileId))
+    .orderBy(desc(discogReleases.releaseDate))
+    .limit(50);
+
+  return releases.map(release => ({
+    ...release,
+    releaseDate: toISOStringOrNull(release.releaseDate),
+    canvasStatus: getCanvasStatusFromMetadata(release.metadata),
+  }));
+}

--- a/apps/web/lib/chat/run.ts
+++ b/apps/web/lib/chat/run.ts
@@ -11,6 +11,7 @@ import { buildAiTelemetry } from '@/lib/ai/telemetry';
 import type { ChatAccountContext } from '@/lib/chat/account-context';
 import { resolveImportBioRestrictedTools } from '@/lib/chat/import-bio-turn-guard';
 import { selectKnowledgeContext } from '@/lib/chat/knowledge/router';
+import { extractLastUserText } from '@/lib/chat/message-text';
 import { ONBOARDING_SYSTEM_PROMPT } from '@/lib/chat/prompts/onboarding';
 import { buildSystemPrompt } from '@/lib/chat/system-prompt';
 import {
@@ -51,7 +52,8 @@ const SIMPLE_INTENT_PATTERNS = [
  */
 export function canUseLightModel(
   messages: UIMessage[],
-  aiCanUseTools: boolean
+  aiCanUseTools: boolean,
+  lastUserText?: string
 ): boolean {
   // Free-plan users don't have advanced tools — always use the light model
   if (!aiCanUseTools) return true;
@@ -59,17 +61,8 @@ export function canUseLightModel(
   // Only consider light model for short conversations
   if (messages.length > 6) return false;
 
-  const lastUserMsg = [...messages].reverse().find(m => m.role === 'user');
-  if (!lastUserMsg) return false;
-
-  const text = lastUserMsg.parts
-    .filter(
-      (p): p is { type: 'text'; text: string } =>
-        p.type === 'text' && typeof p.text === 'string'
-    )
-    .map(p => p.text)
-    .join('')
-    .trim();
+  const text = lastUserText ?? extractLastUserText(messages);
+  if (!text) return false;
 
   // Short, clearly tool-oriented requests
   return text.length < 200 && SIMPLE_INTENT_PATTERNS.some(p => p.test(text));
@@ -123,6 +116,8 @@ export interface ExecuteChatTurnInput {
   insightsEnabled: boolean;
   accountContext?: ChatAccountContext;
   forceLightModel: boolean;
+  /** Precomputed once per turn to avoid repeated message scans. */
+  lastUserText?: string;
   /**
    * Pre-built tools for the turn. The caller composes free + paid tool sets
    * based on plan and feature flags before invoking. For `mode='onboarding'`,
@@ -187,6 +182,7 @@ export async function executeChatTurn(
     insightsEnabled,
     accountContext,
     forceLightModel,
+    lastUserText,
     tools,
     signal,
     requestId,
@@ -227,7 +223,11 @@ export async function executeChatTurn(
   // variable keeps the precedence explicit (|| binds tighter than ?:).
   const shouldUseLightModel =
     forceLightModel ||
-    canUseLightModel(uiMessages, planLimits.booleans.aiCanUseTools);
+    canUseLightModel(
+      uiMessages,
+      planLimits.booleans.aiCanUseTools,
+      lastUserText
+    );
   const selectedModel = shouldUseLightModel ? CHAT_MODEL_LIGHT : CHAT_MODEL;
 
   // Tag the request scope with chat-specific dimensions so all telemetry

--- a/apps/web/lib/chat/tool-events.ts
+++ b/apps/web/lib/chat/tool-events.ts
@@ -40,6 +40,8 @@ export interface PendingToolPersistenceEnvelope {
 }
 
 const recordSchema = z.record(z.string(), z.unknown());
+
+/* eslint-disable @jovie/chat-tool-schema-strict -- persistence DTOs, not LLM tool inputs */
 const approvalSchema = z.object({
   id: z.string().min(1),
   approved: z.boolean().optional(),
@@ -94,6 +96,7 @@ export const chatPersistenceMessageSchema = z
 export const chatPersistenceBatchSchema = z.object({
   messages: z.array(chatPersistenceMessageSchema).min(1).max(100),
 });
+/* eslint-enable @jovie/chat-tool-schema-strict */
 
 export type ChatPersistenceMessage = z.infer<
   typeof chatPersistenceMessageSchema
@@ -262,15 +265,23 @@ function normalizeToolPart(part: ToolPart): PersistedToolEvent | null {
     errorMessage = outputError ?? approvalReason;
   }
 
+  const persistedOutput =
+    state === 'succeeded' ? capPersistedToolOutput(output) : output;
+
   return {
     schemaVersion: 2,
     toolCallId: part.toolCallId,
     toolName,
     state,
     input,
-    output,
+    output: persistedOutput,
     errorMessage,
-    summary: getSummaryForState(state, output, outputError, approvalReason),
+    summary: getSummaryForState(
+      state,
+      persistedOutput,
+      outputError,
+      approvalReason
+    ),
     uiHint: config.uiHint,
     approval,
   };
@@ -354,6 +365,62 @@ function dedupeEvents(events: PersistedToolEvent[]): PersistedToolEvent[] {
 }
 
 export const STALE_RUNNING_TOOL_EVENT_MS = 5 * 60 * 1000;
+
+/** Max serialized bytes for a persisted tool output payload. */
+export const PERSISTED_TOOL_OUTPUT_MAX_BYTES = 16 * 1024;
+
+function measureSerializedBytes(value: unknown): number {
+  try {
+    return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function pickRefetchableId(
+  output: Record<string, unknown>
+): string | undefined {
+  for (const key of [
+    'releaseId',
+    'generationId',
+    'id',
+    'merchCardId',
+    'conversationId',
+  ]) {
+    const value = output[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+export function capPersistedToolOutput(
+  output: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!output) {
+    return output;
+  }
+
+  if (measureSerializedBytes(output) <= PERSISTED_TOOL_OUTPUT_MAX_BYTES) {
+    return output;
+  }
+
+  const refetchableId = pickRefetchableId(output);
+  const summary =
+    extractSummary(output) ??
+    (typeof output.message === 'string' ? output.message : undefined) ??
+    'Tool output truncated for storage.';
+
+  return {
+    success: output.success,
+    truncated: true,
+    summary,
+    ...(refetchableId ? { refetchableId } : {}),
+    originalBytes: measureSerializedBytes(output),
+  };
+}
 
 const CLIENT_DISCONNECT_TOOL_ERROR =
   'This tool was interrupted when the chat disconnected. Retry when you are ready.';

--- a/apps/web/lib/flags/server.ts
+++ b/apps/web/lib/flags/server.ts
@@ -131,4 +131,9 @@ export async function getProfileAlertOptInVariant(
   });
 }
 
-export { checkGateForUser, getExperiment, shutdownStatsig } from './statsig';
+export {
+  checkGateForUser,
+  checkGatesForUser,
+  getExperiment,
+  shutdownStatsig,
+} from './statsig';

--- a/apps/web/lib/flags/statsig.ts
+++ b/apps/web/lib/flags/statsig.ts
@@ -21,6 +21,38 @@ let statsigWarnedNoSecret = false;
 const isE2ERuntime = publicEnv.NEXT_PUBLIC_E2E_MODE === '1';
 const STATSIG_INIT_TIMEOUT_MS = 10_000;
 const STATSIG_SHUTDOWN_TIMEOUT_MS = 1500;
+const GATE_CACHE_TTL_MS = 10_000;
+const gateCache = new Map<string, { value: boolean; expiresAt: number }>();
+
+function gateCacheKey(userId: string | null, gateKey: string): string {
+  return `${userId ?? 'anonymous'}:${gateKey}`;
+}
+
+function readCachedGateValue(
+  userId: string | null,
+  gateKey: string
+): boolean | undefined {
+  const cached = gateCache.get(gateCacheKey(userId, gateKey));
+  if (!cached || cached.expiresAt <= Date.now()) {
+    if (cached) {
+      gateCache.delete(gateCacheKey(userId, gateKey));
+    }
+    return undefined;
+  }
+
+  return cached.value;
+}
+
+function writeCachedGateValue(
+  userId: string | null,
+  gateKey: string,
+  value: boolean
+): void {
+  gateCache.set(gateCacheKey(userId, gateKey), {
+    value,
+    expiresAt: Date.now() + GATE_CACHE_TTL_MS,
+  });
+}
 
 function getStatsigUser(userId: string | null): StatsigUser {
   return StatsigUser.withUserID(userId ?? 'anonymous');
@@ -113,6 +145,11 @@ export async function checkGateForUser(
     return defaultValue;
   }
 
+  const cachedValue = readCachedGateValue(userId, gateKey);
+  if (cachedValue !== undefined) {
+    return cachedValue;
+  }
+
   await initializeStatsig();
 
   if (!statsigInitialized) {
@@ -126,14 +163,27 @@ export async function checkGateForUser(
     }
 
     const gate = statsig.getFeatureGate(getStatsigUser(userId), gateKey);
-    if (gate.getEvaluationDetails().reason === 'Unrecognized') {
-      return defaultValue;
-    }
-    return gate.value;
+    const value =
+      gate.getEvaluationDetails().reason === 'Unrecognized'
+        ? defaultValue
+        : gate.value;
+    writeCachedGateValue(userId, gateKey, value);
+    return value;
   } catch (error) {
     logger.error(`[Statsig] Error checking gate ${gateKey}`, error, 'Statsig');
     return defaultValue;
   }
+}
+
+export async function checkGatesForUser(
+  userId: string | null,
+  gates: ReadonlyArray<{ key: string; defaultValue?: boolean }>
+): Promise<boolean[]> {
+  return Promise.all(
+    gates.map(({ key, defaultValue = false }) =>
+      checkGateForUser(userId, key, defaultValue)
+    )
+  );
 }
 
 export async function getStatsigGateValue(

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -6044,7 +6044,7 @@ function evaluateAlbumArtProviderContract(vars: EvalVars) {
       chatRouteSource,
       [
         'if (!isXaiConfigured())',
-        'const releases = await fetchReleasesForChat(params.profileId)',
+        'const target = resolveAlbumArtReleaseTarget(params.releases, {',
         'const burstLimit = await albumArtGenerationBurstLimiter.limit',
         'const generated = await generateAlbumArtBackgrounds',
       ]

--- a/apps/web/tests/unit/chat/chat-latency.test.ts
+++ b/apps/web/tests/unit/chat/chat-latency.test.ts
@@ -1,0 +1,54 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { UIMessage } from 'ai';
+import { describe, expect, it } from 'vitest';
+import { extractLastUserText } from '@/lib/chat/message-text';
+import { canUseLightModel } from '@/lib/chat/run';
+
+function userMessage(text: string): UIMessage {
+  return {
+    id: 'user-1',
+    role: 'user',
+    parts: [{ type: 'text', text }],
+  } as UIMessage;
+}
+
+describe('chat turn latency helpers', () => {
+  it('extracts the latest user text once for downstream consumers', () => {
+    const messages = [
+      userMessage('older request'),
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'done' }],
+      } as UIMessage,
+      userMessage('change my display name to Aurora'),
+    ];
+
+    expect(extractLastUserText(messages)).toBe(
+      'change my display name to Aurora'
+    );
+  });
+
+  it('reuses precomputed last user text for light-model heuristics', () => {
+    const messages = [userMessage('change my display name to Aurora')];
+
+    expect(
+      canUseLightModel(messages, true, 'change my display name to Aurora')
+    ).toBe(true);
+  });
+});
+
+describe('chat route gate fan-out', () => {
+  it('checks kill-switch gates in parallel', async () => {
+    const routePath = path.join(process.cwd(), 'app/api/chat/route.ts');
+    const source = await readFile(routePath, 'utf8');
+
+    expect(source).toContain('checkGatesForUser(userId, [');
+    expect(source).toContain('CHAT_KILL_SWITCH_GATES.DISABLED');
+    expect(source).toContain('CHAT_KILL_SWITCH_GATES.FORCE_LIGHT');
+    expect(source).not.toMatch(
+      /await checkGateForUser\([\s\S]*?await checkGateForUser\(/
+    );
+  });
+});

--- a/apps/web/tests/unit/chat/releases.test.ts
+++ b/apps/web/tests/unit/chat/releases.test.ts
@@ -1,0 +1,74 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const selectMock = vi.fn();
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+  },
+}));
+
+vi.mock('@/lib/services/canvas/service', () => ({
+  getCanvasStatusFromMetadata: () => 'missing',
+}));
+
+describe('fetchReleasesForChat', () => {
+  beforeEach(() => {
+    selectMock.mockReset();
+    const chain = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue([
+        {
+          id: 'release-1',
+          title: 'Midnight',
+          releaseType: 'single',
+          releaseDate: new Date('2026-01-01T00:00:00.000Z'),
+          artworkUrl: null,
+          spotifyPopularity: 12,
+          totalTracks: 1,
+          metadata: {},
+        },
+      ]),
+    };
+    selectMock.mockReturnValue(chain);
+  });
+
+  it('issues one release query per fetch call', async () => {
+    const { fetchReleasesForChat } = await import('@/lib/chat/releases');
+
+    const releases = await fetchReleasesForChat('profile-1');
+
+    expect(selectMock).toHaveBeenCalledTimes(1);
+    expect(releases).toEqual([
+      expect.objectContaining({
+        id: 'release-1',
+        title: 'Midnight',
+        canvasStatus: 'missing',
+      }),
+    ]);
+  });
+});
+
+describe('chat route release-query wiring', () => {
+  it('does not call fetchReleasesForChat inside tool executors', async () => {
+    const routePath = path.join(process.cwd(), 'app/api/chat/route.ts');
+    const source = await readFile(routePath, 'utf8');
+    const matches = source.match(/fetchReleasesForChat/g) ?? [];
+
+    expect(matches).toHaveLength(2);
+    expect(source).toContain(
+      "import { fetchReleasesForChat } from '@/lib/chat/releases'"
+    );
+    expect(source).toContain('return await fetchReleasesForChat(profileId);');
+    expect(source).not.toContain(
+      'await fetchReleasesForChat(params.profileId)'
+    );
+    expect(source).not.toContain(
+      'await fetchReleasesForChat(resolvedProfileId)'
+    );
+  });
+});

--- a/apps/web/tests/unit/chat/tool-events.test.ts
+++ b/apps/web/tests/unit/chat/tool-events.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  capPersistedToolOutput,
   decodeToolEvents,
   encodeToolEvents,
+  PERSISTED_TOOL_OUTPUT_MAX_BYTES,
   persistedToolEventsSchema,
   preparePersistedToolEventsForTurnFinish,
   resolvePersistedToolEventsForDisplay,
@@ -221,6 +223,68 @@ describe('tool event contract', () => {
         observedAt: new Date('2026-06-10T12:00:10Z'),
       })
     ).toEqual([runningEvent]);
+  });
+
+  it('caps oversized persisted tool outputs with summary and refetchable id', () => {
+    const oversizedOutput = {
+      success: true,
+      releaseId: 'release-123',
+      summary: 'Generated album art',
+      candidates: Array.from({ length: 200 }, (_, index) => ({
+        id: `candidate-${index}`,
+        previewUrl: `https://example.com/preview-${index}.jpg`,
+        fullResUrl: `https://example.com/full-${index}.jpg`,
+        prompt: 'x'.repeat(500),
+      })),
+    };
+
+    const capped = capPersistedToolOutput(oversizedOutput);
+
+    expect(capped).toEqual(
+      expect.objectContaining({
+        success: true,
+        truncated: true,
+        summary: 'Generated album art',
+        refetchableId: 'release-123',
+      })
+    );
+    expect(
+      new TextEncoder().encode(JSON.stringify(capped)).byteLength
+    ).toBeLessThanOrEqual(PERSISTED_TOOL_OUTPUT_MAX_BYTES);
+  });
+
+  it('encodes oversized tool outputs within the persisted byte budget', () => {
+    const [event] =
+      encodeToolEvents([
+        {
+          type: 'dynamic-tool',
+          toolName: 'generateAlbumArt',
+          toolCallId: 'album-art-1',
+          state: 'output-available',
+          input: { releaseTitle: 'Midnight' },
+          output: {
+            success: true,
+            generationId: 'gen-1',
+            summary: 'Generated album art',
+            candidates: Array.from({ length: 200 }, (_, index) => ({
+              id: `candidate-${index}`,
+              previewUrl: `https://example.com/preview-${index}.jpg`,
+              fullResUrl: `https://example.com/full-${index}.jpg`,
+              prompt: 'x'.repeat(500),
+            })),
+          },
+        },
+      ]) ?? [];
+
+    expect(event?.output).toEqual(
+      expect.objectContaining({
+        truncated: true,
+        refetchableId: 'gen-1',
+      })
+    );
+    expect(
+      new TextEncoder().encode(JSON.stringify(event?.output)).byteLength
+    ).toBeLessThanOrEqual(PERSISTED_TOOL_OUTPUT_MAX_BYTES);
   });
 
   it('preserves approval responses through persistence and hydration', () => {


### PR DESCRIPTION
Main-target queue drain (btw Phase 0). Reopened against the recommended integration branch — full CI runs on the domain train PR only. Policy: `.claude/rules/ci-branching.md`, state: `.context/loop-state.json`.

Integration fast lane only. Merge via `scripts/loop-integration-ship.sh integration/loop-chat tim/jov-3012-chat-latency` after local verify.

<!-- linear-issue-id: -->