### PR TITLE
fix(auth): correct RLS session ordering in account delete (JOV-3048)

### DIFF
--- a/apps/web/app/api/account/delete/route.ts
+++ b/apps/web/app/api/account/delete/route.ts
@@ -2,7 +2,7 @@ import { clerkClient } from '@clerk/nextjs/server';
 import { eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 import { getCachedAuth } from '@/lib/auth/cached';
-import { setupDbSession } from '@/lib/auth/session';
+import { withDbSession, withDbSessionTx } from '@/lib/auth/session';
 import { invalidateProfileCache } from '@/lib/cache/profile';
 import { db } from '@/lib/db';
 import { users } from '@/lib/db/schema/auth';
@@ -37,8 +37,10 @@ interface DeleteAccountBody {
  * Dependent rows are removed first; `users.deletedAt` is written last as a
  * success-fence so a mid-chain error never leaves a banned limbo account.
  *
- * `setupDbSession` scopes RLS to the authenticated Clerk user — all deletes
- * below must filter by the resolved `user.id` from that session.
+ * RLS contract: existence checks run in `withDbSession` (read-only). The
+ * destructive delete chain runs inside `withDbSessionTx` so `app.clerk_user_id`
+ * is set on the same connection as every DELETE/UPDATE. All cross-table deletes
+ * must filter by the resolved `user.id` — never rely on RLS alone.
  */
 export async function POST(request: Request) {
   const { userId: clerkUserId } = await getCachedAuth();
@@ -81,13 +83,15 @@ export async function POST(request: Request) {
   }
 
   try {
-    await setupDbSession(clerkUserId);
+    const user = await withDbSession(async sessionClerkUserId => {
+      const [row] = await db
+        .select({ id: users.id, deletedAt: users.deletedAt })
+        .from(users)
+        .where(eq(users.clerkId, sessionClerkUserId))
+        .limit(1);
 
-    const [user] = await db
-      .select({ id: users.id, deletedAt: users.deletedAt })
-      .from(users)
-      .where(eq(users.clerkId, clerkUserId))
-      .limit(1);
+      return row;
+    }, { clerkUserId });
 
     if (!user) {
       return NextResponse.json(
@@ -98,37 +102,42 @@ export async function POST(request: Request) {
 
     const now = new Date();
 
-    // Fetch usernames before deletion so we can invalidate handle availability cache
-    const profiles = await db
-      .select({ usernameNormalized: creatorProfiles.usernameNormalized })
-      .from(creatorProfiles)
-      .where(eq(creatorProfiles.userId, user.id));
+    const profiles = await withDbSessionTx(async tx => {
+      const profileRows = await tx
+        .select({ usernameNormalized: creatorProfiles.usernameNormalized })
+        .from(creatorProfiles)
+        .where(eq(creatorProfiles.userId, user.id));
 
-    // Delete dependent data first — users.deletedAt is the success-fence below
-    await db.delete(creatorProfiles).where(eq(creatorProfiles.userId, user.id));
-    await db.delete(preSaveTokens).where(eq(preSaveTokens.userId, user.id));
-    await db.delete(feedbackItems).where(eq(feedbackItems.userId, user.id));
-    await db
-      .delete(emailSuppressions)
-      .where(eq(emailSuppressions.createdBy, user.id));
+      // Delete dependent data first — users.deletedAt is the success-fence below
+      await tx
+        .delete(creatorProfiles)
+        .where(eq(creatorProfiles.userId, user.id));
+      await tx.delete(preSaveTokens).where(eq(preSaveTokens.userId, user.id));
+      await tx.delete(feedbackItems).where(eq(feedbackItems.userId, user.id));
+      await tx
+        .delete(emailSuppressions)
+        .where(eq(emailSuppressions.createdBy, user.id));
 
-    if (!user.deletedAt) {
-      // Soft-delete: anonymize all personal data and mark as deleted
-      // GDPR requires removal of all PII - we retain only structural fields
-      await db
-        .update(users)
-        .set({
-          name: null,
-          email: null,
-          stripeCustomerId: null,
-          stripeSubscriptionId: null,
-          waitlistEntryId: null,
-          deletedAt: now,
-          userStatus: 'banned',
-          updatedAt: now,
-        })
-        .where(eq(users.id, user.id));
-    }
+      if (!user.deletedAt) {
+        // Soft-delete: anonymize all personal data and mark as deleted
+        // GDPR requires removal of all PII - we retain only structural fields
+        await tx
+          .update(users)
+          .set({
+            name: null,
+            email: null,
+            stripeCustomerId: null,
+            stripeSubscriptionId: null,
+            waitlistEntryId: null,
+            deletedAt: now,
+            userStatus: 'banned',
+            updatedAt: now,
+          })
+          .where(eq(users.id, user.id));
+      }
+
+      return profileRows;
+    }, { clerkUserId });
 
     // Invalidate handle availability cache so deleted usernames become available
     for (const profile of profiles) {

--- a/apps/web/tests/unit/api/account/delete-route.test.ts
+++ b/apps/web/tests/unit/api/account/delete-route.test.ts
@@ -1,21 +1,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ---- hoisted mocks ----
-const mockAuth = vi.hoisted(() => vi.fn());
+const mockGetCachedAuth = vi.hoisted(() => vi.fn());
 const mockClerkClient = vi.hoisted(() => vi.fn());
-const mockSetupDbSession = vi.hoisted(() => vi.fn());
+const mockWithDbSession = vi.hoisted(() => vi.fn());
+const mockWithDbSessionTx = vi.hoisted(() => vi.fn());
 const mockCaptureError = vi.hoisted(() => vi.fn());
 const mockCheckAccountDeleteRateLimit = vi.hoisted(() => vi.fn());
 const mockInvalidateHandleCache = vi.hoisted(() => vi.fn());
 const mockInvalidateProfileCache = vi.hoisted(() => vi.fn());
 
+vi.mock('@/lib/auth/cached', () => ({
+  getCachedAuth: mockGetCachedAuth,
+}));
+
 vi.mock('@clerk/nextjs/server', () => ({
-  auth: mockAuth,
   clerkClient: mockClerkClient,
 }));
 
 vi.mock('@/lib/auth/session', () => ({
-  setupDbSession: mockSetupDbSession,
+  withDbSession: mockWithDbSession,
+  withDbSessionTx: mockWithDbSessionTx,
 }));
 
 vi.mock('@/lib/error-tracking', () => ({
@@ -67,8 +72,8 @@ function makeChain(resolveValue: unknown = undefined) {
 const mockDbUpdate = vi.hoisted(() => vi.fn());
 const mockDbDelete = vi.hoisted(() => vi.fn());
 
-vi.mock('@/lib/db', () => ({
-  db: {
+function makeTx() {
+  return {
     select: vi.fn().mockImplementation(() => {
       const result =
         selectResults.queue.length > 0 ? selectResults.queue.shift() : [];
@@ -76,6 +81,16 @@ vi.mock('@/lib/db', () => ({
     }),
     update: mockDbUpdate.mockImplementation(() => makeChain()),
     delete: mockDbDelete.mockImplementation(() => makeChain()),
+  };
+}
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn().mockImplementation(() => {
+      const result =
+        selectResults.queue.length > 0 ? selectResults.queue.shift() : [];
+      return makeChain(result);
+    }),
   },
 }));
 
@@ -121,16 +136,21 @@ describe('POST /api/account/delete', () => {
     vi.clearAllMocks();
     selectResults.queue = [];
 
-    mockAuth.mockResolvedValue({ userId: 'clerk_user_1' });
+    mockGetCachedAuth.mockResolvedValue({ userId: 'clerk_user_1' });
     mockCheckAccountDeleteRateLimit.mockResolvedValue({ success: true });
-    mockSetupDbSession.mockResolvedValue(undefined);
+    mockWithDbSession.mockImplementation(async (operation, options) =>
+      operation(options?.clerkUserId ?? 'clerk_user_1')
+    );
+    mockWithDbSessionTx.mockImplementation(async (operation, options) =>
+      operation(makeTx(), options?.clerkUserId ?? 'clerk_user_1')
+    );
     mockClerkClient.mockResolvedValue({
       users: { deleteUser: vi.fn().mockResolvedValue(undefined) },
     });
   });
 
   it('returns 401 when unauthenticated', async () => {
-    mockAuth.mockResolvedValue({ userId: null });
+    mockGetCachedAuth.mockResolvedValue({ userId: null });
 
     const { POST } = await import('@/app/api/account/delete/route');
     const response = await POST(makeRequest({ confirmation: 'DELETE' }));
@@ -168,6 +188,30 @@ describe('POST /api/account/delete', () => {
     const response = await POST(makeRequest({ confirmation: 'DELETE' }));
 
     expect(response.status).toBe(404);
+    expect(mockWithDbSession).toHaveBeenCalledTimes(1);
+    expect(mockWithDbSessionTx).not.toHaveBeenCalled();
+  });
+
+  it('scopes RLS to existence check then delete transaction (JOV-3048)', async () => {
+    selectResults.queue.push([{ id: 'user_1', deletedAt: null }]);
+    selectResults.queue.push([{ usernameNormalized: 'testartist' }]);
+
+    const { POST } = await import('@/app/api/account/delete/route');
+    await POST(makeRequest({ confirmation: 'DELETE' }));
+
+    expect(mockWithDbSession).toHaveBeenCalledTimes(1);
+    expect(mockWithDbSessionTx).toHaveBeenCalledTimes(1);
+    expect(mockWithDbSession.mock.invocationCallOrder[0]).toBeLessThan(
+      mockWithDbSessionTx.mock.invocationCallOrder[0]
+    );
+    expect(mockWithDbSession).toHaveBeenCalledWith(
+      expect.any(Function),
+      { clerkUserId: 'clerk_user_1' }
+    );
+    expect(mockWithDbSessionTx).toHaveBeenCalledWith(
+      expect.any(Function),
+      { clerkUserId: 'clerk_user_1' }
+    );
   });
 
   it('retries idempotently when account was partially deleted', async () => {


### PR DESCRIPTION
Integration train PR — local verify only. Full CI runs on integration→main train.

<!-- linear-issue-identifier:JOV-3048 -->
