### PR TITLE
JOV-3047: [Audit] Most dashboard route segments lack error.tsx — crashes blow out whole shell

### DIFF
--- a/apps/web/app/app/(shell)/audience/error.tsx
+++ b/apps/web/app/app/(shell)/audience/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import ErrorBoundary from '@/components/organisms/ErrorBoundary';
+import type { ErrorProps } from '@/types/common';
+
+export default function AudienceError({ error, reset }: ErrorProps) {
+  return <ErrorBoundary error={error} reset={reset} context='Audience' />;
+}

--- a/apps/web/app/app/(shell)/calendar/error.tsx
+++ b/apps/web/app/app/(shell)/calendar/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import ErrorBoundary from '@/components/organisms/ErrorBoundary';
+import type { ErrorProps } from '@/types/common';
+
+export default function CalendarError({ error, reset }: ErrorProps) {
+  return <ErrorBoundary error={error} reset={reset} context='Calendar' />;
+}

--- a/apps/web/app/app/(shell)/chat/[id]/error.tsx
+++ b/apps/web/app/app/(shell)/chat/[id]/error.tsx
@@ -1,0 +1,3 @@
+'use client';
+
+export { default } from '../error';

--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/error.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/downloads/error.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import ErrorBoundary from '@/components/organisms/ErrorBoundary';
+import type { ErrorProps } from '@/types/common';
+
+export default function PromoDownloadsError({ error, reset }: ErrorProps) {
+  return (
+    <ErrorBoundary error={error} reset={reset} context='Promo Downloads' />
+  );
+}

--- a/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/tasks/error.tsx
+++ b/apps/web/app/app/(shell)/dashboard/releases/[releaseId]/tasks/error.tsx
@@ -1,0 +1,3 @@
+'use client';
+
+export { default } from '../../../../releases/[releaseId]/tasks/error';

--- a/apps/web/app/app/(shell)/insights/error.tsx
+++ b/apps/web/app/app/(shell)/insights/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import ErrorBoundary from '@/components/organisms/ErrorBoundary';
+import type { ErrorProps } from '@/types/common';
+
+export default function InsightsError({ error, reset }: ErrorProps) {
+  return <ErrorBoundary error={error} reset={reset} context='Insights' />;
+}

--- a/apps/web/app/app/(shell)/releases/[releaseId]/tasks/error.tsx
+++ b/apps/web/app/app/(shell)/releases/[releaseId]/tasks/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import ErrorBoundary from '@/components/organisms/ErrorBoundary';
+import type { ErrorProps } from '@/types/common';
+
+export default function ReleaseTasksError({ error, reset }: ErrorProps) {
+  return <ErrorBoundary error={error} reset={reset} context='Release Tasks' />;
+}

--- a/apps/web/app/app/(shell)/tasks/error.tsx
+++ b/apps/web/app/app/(shell)/tasks/error.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import ErrorBoundary from '@/components/organisms/ErrorBoundary';
+import type { ErrorProps } from '@/types/common';
+
+export default function TasksError({ error, reset }: ErrorProps) {
+  return <ErrorBoundary error={error} reset={reset} context='Tasks' />;
+}


### PR DESCRIPTION
Main-target queue drain (btw Phase 0). Reopened against the recommended integration branch — full CI runs on the domain train PR only. Policy: `.claude/rules/ci-branching.md`, state: `.context/loop-state.json`.

Integration fast lane only. Merge via `scripts/loop-integration-ship.sh integration/loop-ui tim/jov-3047-dashboard-error-boundaries` after local verify.

<!-- linear-issue-id: -->