### PR TITLE
fix(hud): return degraded metrics on upstream timeout (JOV-3058)

### DIFF
--- a/apps/web/app/api/hud/metrics/route.ts
+++ b/apps/web/app/api/hud/metrics/route.ts
@@ -2,14 +2,18 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { authorizeHud } from '@/lib/auth/hud';
 import { captureError } from '@/lib/error-tracking';
-import { getHudMetrics } from '@/lib/hud/metrics';
+import { ServerFetchTimeoutError } from '@/lib/http/server-fetch';
+import { buildDegradedHudMetrics, getHudMetrics } from '@/lib/hud/metrics';
 import { logger } from '@/lib/utils/logger';
+import type { HudAccessMode } from '@/types/hud';
 
 export const runtime = 'nodejs';
 
 const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
 
 export async function GET(request: NextRequest) {
+  let accessMode: HudAccessMode = 'admin';
+
   try {
     const kioskToken = request.nextUrl.searchParams.get('kiosk');
     const auth = await authorizeHud(kioskToken);
@@ -21,9 +25,23 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    accessMode = auth.mode;
     const metrics = await getHudMetrics(auth.mode);
     return NextResponse.json(metrics, { headers: NO_STORE_HEADERS });
   } catch (error) {
+    if (error instanceof ServerFetchTimeoutError) {
+      logger.warn('HUD metrics route timed out; returning degraded payload', {
+        route: '/api/hud/metrics',
+        context: error.context,
+        timeoutMs: error.timeoutMs,
+      });
+      const metrics = buildDegradedHudMetrics(accessMode, {
+        context: error.context,
+        timeoutMs: error.timeoutMs,
+      });
+      return NextResponse.json(metrics, { headers: NO_STORE_HEADERS });
+    }
+
     await captureError('HUD metrics route failed', error, {
       route: '/api/hud/metrics',
     });

--- a/apps/web/lib/hud/metrics.ts
+++ b/apps/web/lib/hud/metrics.ts
@@ -7,9 +7,17 @@ import { getAdminStripeOverviewMetrics } from '@/lib/admin/stripe-metrics';
 import { checkDbHealth } from '@/lib/db';
 import { getHudDeployments } from '@/lib/deployments/github';
 import { env } from '@/lib/env-server';
+import { getHermesDispatchAvailability } from '@/lib/hermes/dispatch';
+import { ServerFetchTimeoutError } from '@/lib/http/server-fetch';
 import { getHudAiOpsSummary } from '@/lib/hud/ai-ops';
 import { buildHudMetricSources } from '@/lib/hud/source-trust';
+import { logger } from '@/lib/utils/logger';
 import type { HudAccessMode, HudMetrics } from '@/types/hud';
+
+export interface BuildDegradedHudMetricsOptions {
+  context?: string;
+  timeoutMs?: number;
+}
 
 function normalizeIso(value: unknown): string {
   if (value instanceof Date) return value.toISOString();
@@ -128,7 +136,166 @@ function calculateFinancialStatus(
   };
 }
 
-export async function getHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
+export function buildDegradedHudMetrics(
+  mode: HudAccessMode,
+  options: BuildDegradedHudMetricsOptions = {}
+): HudMetrics {
+  const generatedAt = new Date();
+  const fetchedAtIso = generatedAt.toISOString();
+  const timeoutDetail =
+    options.context != null
+      ? `${options.context} timed out after ${options.timeoutMs ?? 'unknown'}ms`
+      : 'HUD metrics request timed out';
+
+  const branding = {
+    startupName: env.HUD_STARTUP_NAME ?? 'Jovie',
+    logoUrl: env.HUD_STARTUP_LOGO_URL ?? null,
+  };
+
+  const stripeMetrics = {
+    mrrUsd: 0,
+    activeSubscribers: 0,
+    mrrUsd30dAgo: 0,
+    mrrGrowth30dUsd: 0,
+    isConfigured: true,
+    isAvailable: false,
+    errorMessage: timeoutDetail,
+  };
+
+  const mercuryMetrics = {
+    balanceUsd: 0,
+    burnRateUsd: 0,
+    burnWindowDays: 30,
+    isConfigured: true,
+    isAvailable: false,
+    defaultStatus: 'unknown' as const,
+    errorMessage: timeoutDetail,
+  };
+
+  const sentryMetrics = {
+    unresolvedIssues24h: 0,
+    totalEvents24h: 0,
+    impactedUsers24h: 0,
+    criticalIssues24h: 0,
+    topIssueTitle: null,
+    topIssueShortId: null,
+    isConfigured: true,
+    isAvailable: false,
+    errorMessage: timeoutDetail,
+  };
+
+  const operationsStatus: HudMetrics['operations'] = {
+    status: 'degraded',
+    dbLatencyMs: null,
+    checkedAtIso: fetchedAtIso,
+  };
+
+  const deployments: HudMetrics['deployments'] = {
+    availability: 'error',
+    current: null,
+    recent: [],
+    errorMessage: timeoutDetail,
+  };
+
+  const dispatch = getHermesDispatchAvailability();
+
+  return {
+    accessMode: mode,
+    branding,
+    overview: {
+      mrrUsd: 0,
+      activeSubscribers: 0,
+      balanceUsd: 0,
+      burnRateUsd: 0,
+      runwayMonths: null,
+      defaultStatus: 'unknown',
+      defaultStatusDetail:
+        'Metrics temporarily unavailable due to upstream timeout.',
+      financialDataAvailable: false,
+    },
+    operations: operationsStatus,
+    reliability: {
+      errorRatePercent: 0,
+      reliabilityScorePercent: 0,
+      p95LatencyMs: null,
+      incidents24h: 0,
+      lastIncidentAtIso: null,
+      unresolvedSentryIssues24h: 0,
+    },
+    deployments,
+    aiOps: {
+      availability: 'error',
+      generatedAtIso: fetchedAtIso,
+      counts: {
+        queued: 0,
+        running: 0,
+        blocked: 0,
+        review: 0,
+        done: 0,
+        failed: 0,
+        stale: 0,
+      },
+      dispatch,
+      mergeQueue: {
+        openAgentPrs: 0,
+        openAgentPrThreshold: 10,
+        pressure: 'normal',
+      },
+      runs: [],
+      blockers: [],
+      recommendations: [],
+      sources: {
+        github: {
+          availability: 'error',
+          configured: true,
+          itemCount: 0,
+          errorMessage: timeoutDetail,
+        },
+        linear: {
+          availability: 'not_configured',
+          configured: false,
+          itemCount: 0,
+        },
+        sentry: {
+          availability: 'not_configured',
+          configured: false,
+          itemCount: 0,
+        },
+        hermes: {
+          availability: 'available',
+          configured: true,
+          itemCount: 0,
+        },
+        'hermes-air': {
+          availability: 'not_configured',
+          configured: false,
+          itemCount: 0,
+        },
+        ci: {
+          availability: 'error',
+          configured: true,
+          itemCount: 0,
+          errorMessage: timeoutDetail,
+        },
+      },
+      errorMessage: timeoutDetail,
+    },
+    sources: buildHudMetricSources({
+      stripe: stripeMetrics,
+      mercury: mercuryMetrics,
+      sentry: sentryMetrics,
+      operations: operationsStatus,
+      deployments,
+      fetchedAtIso,
+      sentryOrgSlug: env.SENTRY_ORG_SLUG,
+      githubOwner: env.HUD_GITHUB_OWNER,
+      githubRepo: env.HUD_GITHUB_REPO,
+    }),
+    generatedAtIso: fetchedAtIso,
+  };
+}
+
+async function fetchHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
   const generatedAt = new Date();
 
   const branding = {
@@ -227,4 +394,23 @@ export async function getHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
     sources,
     generatedAtIso: fetchedAtIso,
   };
+}
+
+export async function getHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
+  try {
+    return await fetchHudMetrics(mode);
+  } catch (error) {
+    if (error instanceof ServerFetchTimeoutError) {
+      logger.warn('HUD metrics fetch timed out; returning degraded payload', {
+        context: error.context,
+        timeoutMs: error.timeoutMs,
+      });
+      return buildDegradedHudMetrics(mode, {
+        context: error.context,
+        timeoutMs: error.timeoutMs,
+      });
+    }
+
+    throw error;
+  }
 }

--- a/apps/web/tests/lib/hud/metrics.test.ts
+++ b/apps/web/tests/lib/hud/metrics.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getAdminMercuryMetrics } from '@/lib/admin/mercury-metrics';
 import { getAdminStripeOverviewMetrics } from '@/lib/admin/stripe-metrics';
-import { getHudMetrics } from '@/lib/hud/metrics';
+import { ServerFetchTimeoutError } from '@/lib/http/server-fetch';
+import { buildDegradedHudMetrics, getHudMetrics } from '@/lib/hud/metrics';
 
 const mockGetHudDeployments = vi.hoisted(() => vi.fn());
 const mockGetHudAiOpsSummary = vi.hoisted(() => vi.fn());
@@ -217,6 +219,47 @@ describe('getHudMetrics', () => {
     expect(metrics.sources.sentry.state).toBe('ok');
     expect(metrics.sources.github.state).toBe('not_configured');
     expect(metrics.sources.stripe.fetchedAtIso).toBe(metrics.generatedAtIso);
+  });
+
+  it('returns degraded metrics when an upstream fetch times out', async () => {
+    mockGetHudDeployments.mockResolvedValueOnce({
+      availability: 'not_configured',
+      current: null,
+      recent: [],
+    });
+    vi.mocked(getAdminMercuryMetrics).mockRejectedValueOnce(
+      new ServerFetchTimeoutError(
+        'External request timed out after 8000ms',
+        8000,
+        'Mercury checking balance'
+      )
+    );
+
+    const metrics = await getHudMetrics('kiosk');
+
+    expect(metrics.accessMode).toBe('kiosk');
+    expect(metrics.operations.status).toBe('degraded');
+    expect(metrics.overview.financialDataAvailable).toBe(false);
+    expect(metrics.overview.defaultStatusDetail).toContain(
+      'Metrics temporarily unavailable due to upstream timeout'
+    );
+    expect(metrics.sources.mercury.state).toBe('unavailable');
+    expect(metrics.sources.mercury.errorMessage).toContain(
+      'Mercury checking balance timed out after 8000ms'
+    );
+  });
+
+  it('buildDegradedHudMetrics exposes timeout context in source trust metadata', () => {
+    const metrics = buildDegradedHudMetrics('admin', {
+      context: 'GitHub workflow runs',
+      timeoutMs: 5000,
+    });
+
+    expect(metrics.operations.status).toBe('degraded');
+    expect(metrics.deployments.errorMessage).toContain(
+      'GitHub workflow runs timed out after 5000ms'
+    );
+    expect(metrics.sources.github.state).toBe('unavailable');
   });
 
   it('marks financial data unavailable when Stripe is down', async () => {

--- a/apps/web/tests/unit/api/hud-metrics-route.test.ts
+++ b/apps/web/tests/unit/api/hud-metrics-route.test.ts
@@ -1,17 +1,21 @@
 import { NextRequest } from 'next/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GET } from '@/app/api/hud/metrics/route';
+import { ServerFetchTimeoutError } from '@/lib/http/server-fetch';
 
 const mockAuthorizeHud = vi.hoisted(() => vi.fn());
 const mockGetHudMetrics = vi.hoisted(() => vi.fn());
+const mockBuildDegradedHudMetrics = vi.hoisted(() => vi.fn());
 const mockCaptureError = vi.hoisted(() => vi.fn());
 const mockLoggerError = vi.hoisted(() => vi.fn());
+const mockLoggerWarn = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/auth/hud', () => ({
   authorizeHud: mockAuthorizeHud,
 }));
 
 vi.mock('@/lib/hud/metrics', () => ({
+  buildDegradedHudMetrics: mockBuildDegradedHudMetrics,
   getHudMetrics: mockGetHudMetrics,
 }));
 
@@ -22,12 +26,49 @@ vi.mock('@/lib/error-tracking', () => ({
 vi.mock('@/lib/utils/logger', () => ({
   logger: {
     error: mockLoggerError,
+    warn: mockLoggerWarn,
   },
 }));
 
 describe('GET /api/hud/metrics', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('returns degraded metrics without reporting timeout errors to Sentry', async () => {
+    const request = new NextRequest('http://localhost:3000/api/hud/metrics');
+    const timeoutError = new ServerFetchTimeoutError(
+      'External request timed out after 8000ms',
+      8000,
+      'Mercury checking balance'
+    );
+    const degradedMetrics = {
+      accessMode: 'admin',
+      operations: { status: 'degraded' },
+    };
+
+    mockAuthorizeHud.mockResolvedValueOnce({ ok: true, mode: 'admin' });
+    mockGetHudMetrics.mockRejectedValueOnce(timeoutError);
+    mockBuildDegradedHudMetrics.mockReturnValueOnce(degradedMetrics);
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(degradedMetrics);
+    expect(mockBuildDegradedHudMetrics).toHaveBeenCalledWith('admin', {
+      context: 'Mercury checking balance',
+      timeoutMs: 8000,
+    });
+    expect(mockCaptureError).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'HUD metrics route timed out; returning degraded payload',
+      expect.objectContaining({
+        route: '/api/hud/metrics',
+        context: 'Mercury checking balance',
+        timeoutMs: 8000,
+      })
+    );
+    expect(mockLoggerError).not.toHaveBeenCalled();
   });
 
   it('captures and logs failures with route context', async () => {


### PR DESCRIPTION
Integration train PR — local verify only. Full CI runs on integration→main train.

When HUD metric fetches hit \`ServerFetchTimeoutError\`, return a degraded \`HudMetrics\` payload (HTTP 200) instead of a 500 and Sentry report. Covers \`getHudMetrics\` and \`/api/hud/metrics\` so kiosk/admin surfaces keep rendering during slow upstreams.

<!-- linear-issue-identifier:JOV-3058 -->