### PR TITLE
JOV-3057: [Audit] Full feature-flag map exposed in RSC payload on every page — roadmap leak

### DIFF
--- a/apps/web/app/(auth)/layout.tsx
+++ b/apps/web/app/(auth)/layout.tsx
@@ -15,6 +15,7 @@ import { CLERK_KEY_STATUS_HEADER } from '@/lib/auth/clerk-key-status';
 import { resolvePublishableKeyFromHeaders } from '@/lib/auth/staging-clerk-keys';
 import { publicEnv } from '@/lib/env-public';
 import { AppFlagProvider } from '@/lib/flags/client';
+import { resolveAuthRouteFlagNames } from '@/lib/flags/route-snapshots';
 import { getAppFlagsSnapshot } from '@/lib/flags/server';
 
 export const dynamic = 'force-dynamic';
@@ -30,7 +31,9 @@ export default async function AuthLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const initialFlags = await getAppFlagsSnapshot();
+  const initialFlags = await getAppFlagsSnapshot({
+    flagNames: resolveAuthRouteFlagNames(),
+  });
   const publishableKey = await resolvePublishableKeyFromHeaders();
   const hdrs = await headers();
   const isClerkUnavailable =

--- a/apps/web/app/(dynamic)/start/layout.tsx
+++ b/apps/web/app/(dynamic)/start/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { ResolvedClientProviders } from '@/components/providers/ResolvedClientProviders';
 import { AppFlagProvider } from '@/lib/flags/client';
+import { resolveStartRouteFlagNames } from '@/lib/flags/route-snapshots';
 import { getAppFlagsSnapshot } from '@/lib/flags/server';
 
 export const dynamic = 'force-dynamic';
@@ -14,7 +15,9 @@ export default async function StartLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const initialFlags = await getAppFlagsSnapshot();
+  const initialFlags = await getAppFlagsSnapshot({
+    flagNames: resolveStartRouteFlagNames(),
+  });
 
   return (
     <ResolvedClientProviders skipCoreProviders>

--- a/apps/web/app/app/(shell)/DashboardShellContent.tsx
+++ b/apps/web/app/app/(shell)/DashboardShellContent.tsx
@@ -7,8 +7,8 @@ import { ImpersonationBannerWrapper } from '@/features/admin/ImpersonationBanner
 import { OperatorBanner } from '@/features/admin/OperatorBanner';
 import { getUserBanStatus } from '@/lib/auth/ban-check';
 import { AppFlagProvider } from '@/lib/flags/client';
-import { APP_FLAG_DEFAULTS, type AppFlagSnapshot } from '@/lib/flags/contracts';
-import { getAppFlagsSnapshot, getAppFlagValue } from '@/lib/flags/server';
+import { resolveAppShellRouteFlagNames } from '@/lib/flags/route-snapshots';
+import { getAppFlagsSnapshot } from '@/lib/flags/server';
 import { HydrateClient } from '@/lib/queries';
 import { getDehydratedState } from '@/lib/queries/server';
 import { DashboardLoadTracker } from './DashboardLoadTracker';
@@ -23,25 +23,6 @@ import {
   shouldRedirectToOnboarding,
   shouldUseEssentialShellData,
 } from './shell-route-matches';
-
-async function getEssentialShellFlagsSnapshot(
-  userId: string
-): Promise<AppFlagSnapshot> {
-  const designV1 = await getAppFlagValue('DESIGN_V1', { userId });
-
-  return {
-    ...APP_FLAG_DEFAULTS,
-    DESIGN_V1: designV1,
-    SHELL_CHAT_V1: designV1,
-    DESIGN_V1_RELEASES: designV1,
-    DESIGN_V1_TASKS: designV1,
-    DESIGN_V1_CHAT_ENTITIES: designV1,
-    DESIGN_V1_LYRICS: designV1,
-    DESIGN_V1_LIBRARY: designV1,
-    DESIGN_V1_AUTH: designV1,
-    DESIGN_V1_ONBOARDING: designV1,
-  };
-}
 
 /**
  * Async server component that fetches dashboard data,
@@ -70,9 +51,10 @@ export async function DashboardShellContent({
   // page data should not force the shared shell through the full dashboard path.
   const useEssentialShell = shouldUseEssentialShellData(pathname);
   const cookieStorePromise = cookies();
-  const initialFlagsPromise = useEssentialShell
-    ? getEssentialShellFlagsSnapshot(userId)
-    : getAppFlagsSnapshot({ userId });
+  const initialFlagsPromise = getAppFlagsSnapshot({
+    userId,
+    flagNames: resolveAppShellRouteFlagNames(pathname),
+  });
 
   // Run ban check in parallel with dashboard data fetch
   const [dashboardData, banStatus, cookieStore, initialFlags] =

--- a/apps/web/app/onboarding/layout.tsx
+++ b/apps/web/app/onboarding/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { ResolvedClientProviders } from '@/components/providers/ResolvedClientProviders';
 import { AppFlagProvider } from '@/lib/flags/client';
+import { resolveOnboardingRouteFlagNames } from '@/lib/flags/route-snapshots';
 import { getAppFlagsSnapshot } from '@/lib/flags/server';
 
 export const dynamic = 'force-dynamic';
@@ -16,7 +17,9 @@ export default async function OnboardingLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const initialFlags = await getAppFlagsSnapshot();
+  const initialFlags = await getAppFlagsSnapshot({
+    flagNames: resolveOnboardingRouteFlagNames(),
+  });
 
   return (
     <ResolvedClientProviders>

--- a/apps/web/lib/flags/client.tsx
+++ b/apps/web/lib/flags/client.tsx
@@ -12,7 +12,8 @@ import {
   APP_FLAG_DEFAULTS,
   APP_FLAG_OVERRIDE_KEYS,
   type AppFlagName,
-  type AppFlagSnapshot,
+  DESIGN_V1_ALIAS_FLAGS,
+  type PartialAppFlagSnapshot,
 } from './contracts';
 import {
   APP_FLAG_OVERRIDES_CHANGED_EVENT,
@@ -53,7 +54,9 @@ function partitionOverrides(record: AppFlagOverrideRecord): {
   return { valid, orphans };
 }
 
-const AppFlagsContext = createContext<AppFlagSnapshot | null>(null);
+const DESIGN_V1_ALIAS_FLAG_NAMES = new Set<AppFlagName>(DESIGN_V1_ALIAS_FLAGS);
+
+const AppFlagsContext = createContext<PartialAppFlagSnapshot | null>(null);
 const OverridesContext = createContext<AppFlagOverridesContextValue | null>(
   null
 );
@@ -140,12 +143,12 @@ export function AppFlagProvider({
   initialFlags,
 }: {
   readonly children: React.ReactNode;
-  readonly initialFlags?: AppFlagSnapshot;
+  readonly initialFlags?: PartialAppFlagSnapshot;
 }) {
   const overridesValue = useStoredAppFlagOverrides();
 
   return (
-    <AppFlagsContext.Provider value={initialFlags ?? APP_FLAG_DEFAULTS}>
+    <AppFlagsContext.Provider value={initialFlags ?? null}>
       <OverridesContext.Provider value={overridesValue}>
         {children}
       </OverridesContext.Provider>
@@ -167,7 +170,19 @@ export function useAppFlag(flagName: AppFlagName): boolean {
     return overrideValue;
   }
 
-  return appFlags?.[flagName] ?? APP_FLAG_DEFAULTS[flagName];
+  if (appFlags && flagName in appFlags) {
+    return appFlags[flagName] ?? APP_FLAG_DEFAULTS[flagName];
+  }
+
+  if (
+    DESIGN_V1_ALIAS_FLAG_NAMES.has(flagName) &&
+    appFlags &&
+    'DESIGN_V1' in appFlags
+  ) {
+    return appFlags.DESIGN_V1 ?? APP_FLAG_DEFAULTS[flagName];
+  }
+
+  return APP_FLAG_DEFAULTS[flagName];
 }
 
 export function useAppFlagWithLoading(flagName: AppFlagName): {

--- a/apps/web/lib/flags/contracts.ts
+++ b/apps/web/lib/flags/contracts.ts
@@ -66,6 +66,8 @@ export const APP_FLAG_DEFAULTS = {
 
 export type AppFlagName = keyof typeof APP_FLAG_DEFAULTS;
 export type AppFlagSnapshot = Record<AppFlagName, boolean>;
+/** Trimmed server-to-client payload — only flags resolved for the active route. */
+export type PartialAppFlagSnapshot = Partial<Record<AppFlagName, boolean>>;
 
 export const APP_FLAG_KEYS = {
   BILLING_UPGRADE_DIRECT: LEGACY_STATSIG_GATE_KEYS.BILLING_UPGRADE_DIRECT,

--- a/apps/web/lib/flags/route-snapshots.ts
+++ b/apps/web/lib/flags/route-snapshots.ts
@@ -1,0 +1,124 @@
+import 'server-only';
+
+import { APP_ROUTES } from '@/constants/routes';
+import type { AppFlagName } from './contracts';
+
+const SHELL_CHROME_FLAG_NAMES = [
+  'DESIGN_V1',
+  'STRIPE_CONNECT_ENABLED',
+] as const satisfies readonly AppFlagName[];
+
+const AUTH_ROUTE_FLAG_NAMES = [
+  'DESIGN_V1',
+] as const satisfies readonly AppFlagName[];
+
+const ONBOARDING_ROUTE_FLAG_NAMES = [
+  'CHAT_JANK_MONITOR',
+] as const satisfies readonly AppFlagName[];
+
+function matchesExactRoute(
+  pathname: string | null,
+  ...routes: readonly string[]
+): boolean {
+  if (!pathname) return false;
+  return routes.some(route => pathname === route);
+}
+
+function matchesRoutePrefix(
+  pathname: string | null,
+  ...routes: readonly string[]
+): boolean {
+  if (!pathname) return false;
+  return routes.some(
+    route => pathname === route || pathname.startsWith(`${route}/`)
+  );
+}
+
+function isChatShellRoute(pathname: string | null): boolean {
+  return (
+    matchesExactRoute(pathname, APP_ROUTES.DASHBOARD) ||
+    matchesRoutePrefix(
+      pathname,
+      APP_ROUTES.CHAT,
+      APP_ROUTES.CHATS,
+      APP_ROUTES.THREADS
+    )
+  );
+}
+
+function isReleasesShellRoute(pathname: string | null): boolean {
+  return matchesRoutePrefix(
+    pathname,
+    APP_ROUTES.RELEASES,
+    APP_ROUTES.DASHBOARD_RELEASES
+  );
+}
+
+function isReleasePlanRoute(pathname: string | null): boolean {
+  return matchesRoutePrefix(pathname, APP_ROUTES.DASHBOARD_RELEASE_PLAN);
+}
+
+function isDashboardProfileRoute(pathname: string | null): boolean {
+  return matchesRoutePrefix(pathname, APP_ROUTES.DASHBOARD_PROFILE);
+}
+
+function isArtistProfileSettingsRoute(pathname: string | null): boolean {
+  return matchesRoutePrefix(pathname, APP_ROUTES.SETTINGS_ARTIST_PROFILE);
+}
+
+function isDashboardSectionRoute(pathname: string | null): boolean {
+  return matchesRoutePrefix(pathname, APP_ROUTES.LEGACY_DASHBOARD);
+}
+
+function needsAppleWalletProfilePassFlag(pathname: string | null): boolean {
+  return (
+    isChatShellRoute(pathname) ||
+    (isDashboardSectionRoute(pathname) && !isChatShellRoute(pathname)) ||
+    isArtistProfileSettingsRoute(pathname)
+  );
+}
+
+function needsChatJankMonitorFlag(pathname: string | null): boolean {
+  return isChatShellRoute(pathname) || isDashboardProfileRoute(pathname);
+}
+
+/**
+ * Resolve the minimal runtime flag set for an authenticated app-shell route.
+ * Shell chrome flags are always included; route-specific flags are added only
+ * when client components on that route read them via `useAppFlag`.
+ */
+export function resolveAppShellRouteFlagNames(
+  pathname: string | null
+): readonly AppFlagName[] {
+  const flagNames = new Set<AppFlagName>(SHELL_CHROME_FLAG_NAMES);
+
+  if (needsChatJankMonitorFlag(pathname)) {
+    flagNames.add('CHAT_JANK_MONITOR');
+  }
+
+  if (isReleasesShellRoute(pathname)) {
+    flagNames.add('ALBUM_ART_GENERATION');
+  }
+
+  if (isReleasePlanRoute(pathname)) {
+    flagNames.add('RELEASE_PLAN_DEMO');
+  }
+
+  if (needsAppleWalletProfilePassFlag(pathname)) {
+    flagNames.add('APPLE_WALLET_PROFILE_PASS');
+  }
+
+  return [...flagNames];
+}
+
+export function resolveAuthRouteFlagNames(): readonly AppFlagName[] {
+  return AUTH_ROUTE_FLAG_NAMES;
+}
+
+export function resolveOnboardingRouteFlagNames(): readonly AppFlagName[] {
+  return ONBOARDING_ROUTE_FLAG_NAMES;
+}
+
+export function resolveStartRouteFlagNames(): readonly AppFlagName[] {
+  return ONBOARDING_ROUTE_FLAG_NAMES;
+}

--- a/apps/web/lib/flags/server.ts
+++ b/apps/web/lib/flags/server.ts
@@ -6,8 +6,8 @@ import {
   APP_FLAG_DEFAULTS,
   APP_FLAG_OVERRIDE_KEYS,
   type AppFlagName,
-  type AppFlagSnapshot,
   LEGACY_STATSIG_GATE_KEYS,
+  type PartialAppFlagSnapshot,
   type ProfileAlertOptInVariant,
   type StatsigFeatureFlagsBootstrap,
   type SubscribeCTAVariant,
@@ -75,17 +75,20 @@ export async function getAppFlagValue(
 
 export async function getAppFlagsSnapshot(options?: {
   readonly userId?: string | null;
-}): Promise<AppFlagSnapshot> {
+  readonly flagNames?: readonly AppFlagName[];
+}): Promise<PartialAppFlagSnapshot> {
   const userId = options?.userId ?? null;
+  const flagNames =
+    options?.flagNames ?? (Object.keys(APP_FLAG_REGISTRY) as AppFlagName[]);
 
   const resolvedEntries = await Promise.all(
-    (Object.keys(APP_FLAG_REGISTRY) as AppFlagName[]).map(async flagName => [
+    flagNames.map(async flagName => [
       flagName,
       await getAppFlagValue(flagName, { userId }),
     ])
   );
 
-  return Object.fromEntries(resolvedEntries) as AppFlagSnapshot;
+  return Object.fromEntries(resolvedEntries) as PartialAppFlagSnapshot;
 }
 
 export async function getFeatureFlagsBootstrap(

--- a/apps/web/tests/unit/lib/flags/client-partial-snapshot.test.tsx
+++ b/apps/web/tests/unit/lib/flags/client-partial-snapshot.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { AppFlagProvider, useAppFlag } from '@/lib/flags/client';
+import { APP_FLAG_DEFAULTS } from '@/lib/flags/contracts';
+
+function FlagProbe({
+  flagName,
+}: {
+  readonly flagName: keyof typeof APP_FLAG_DEFAULTS;
+}) {
+  const enabled = useAppFlag(flagName);
+  return <div data-testid={`flag-${flagName}`}>{String(enabled)}</div>;
+}
+
+describe('AppFlagProvider partial snapshots', () => {
+  it('mirrors DESIGN_V1 aliases from a trimmed payload', () => {
+    render(
+      <AppFlagProvider initialFlags={{ DESIGN_V1: false }}>
+        <FlagProbe flagName='DESIGN_V1_RELEASES' />
+      </AppFlagProvider>
+    );
+
+    expect(screen.getByTestId('flag-DESIGN_V1_RELEASES')).toHaveTextContent(
+      'false'
+    );
+  });
+
+  it('falls back to local defaults for flags omitted from the payload', () => {
+    render(
+      <AppFlagProvider initialFlags={{ DESIGN_V1: true }}>
+        <FlagProbe flagName='ALBUM_ART_GENERATION' />
+      </AppFlagProvider>
+    );
+
+    expect(screen.getByTestId('flag-ALBUM_ART_GENERATION')).toHaveTextContent(
+      String(APP_FLAG_DEFAULTS.ALBUM_ART_GENERATION)
+    );
+  });
+});

--- a/apps/web/tests/unit/lib/flags/route-snapshots.test.ts
+++ b/apps/web/tests/unit/lib/flags/route-snapshots.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { APP_ROUTES } from '@/constants/routes';
+import {
+  resolveAppShellRouteFlagNames,
+  resolveAuthRouteFlagNames,
+  resolveOnboardingRouteFlagNames,
+  resolveStartRouteFlagNames,
+} from '@/lib/flags/route-snapshots';
+
+describe('route flag snapshots', () => {
+  it('keeps auth routes to the design shell flag only', () => {
+    expect(resolveAuthRouteFlagNames()).toEqual(['DESIGN_V1']);
+  });
+
+  it('keeps onboarding and start routes to chat instrumentation only', () => {
+    expect(resolveOnboardingRouteFlagNames()).toEqual(['CHAT_JANK_MONITOR']);
+    expect(resolveStartRouteFlagNames()).toEqual(['CHAT_JANK_MONITOR']);
+  });
+
+  it('includes shell chrome flags for every app-shell route', () => {
+    for (const pathname of [
+      APP_ROUTES.CHAT,
+      APP_ROUTES.RELEASES,
+      APP_ROUTES.SETTINGS,
+      APP_ROUTES.ADMIN,
+      APP_ROUTES.FEATURE_FLAGS,
+    ]) {
+      expect(resolveAppShellRouteFlagNames(pathname)).toEqual(
+        expect.arrayContaining(['DESIGN_V1', 'STRIPE_CONNECT_ENABLED'])
+      );
+    }
+  });
+
+  it('adds route-specific flags only where client consumers need them', () => {
+    expect(resolveAppShellRouteFlagNames(APP_ROUTES.CHAT)).toEqual(
+      expect.arrayContaining(['CHAT_JANK_MONITOR', 'APPLE_WALLET_PROFILE_PASS'])
+    );
+    expect(resolveAppShellRouteFlagNames(APP_ROUTES.CHAT)).not.toContain(
+      'ALBUM_ART_GENERATION'
+    );
+
+    expect(resolveAppShellRouteFlagNames(APP_ROUTES.RELEASES)).toEqual(
+      expect.arrayContaining(['ALBUM_ART_GENERATION'])
+    );
+    expect(resolveAppShellRouteFlagNames(APP_ROUTES.RELEASES)).not.toContain(
+      'CHAT_JANK_MONITOR'
+    );
+
+    expect(
+      resolveAppShellRouteFlagNames(APP_ROUTES.DASHBOARD_RELEASE_PLAN)
+    ).toEqual(expect.arrayContaining(['RELEASE_PLAN_DEMO']));
+
+    expect(resolveAppShellRouteFlagNames(APP_ROUTES.DASHBOARD_PROFILE)).toEqual(
+      expect.arrayContaining(['CHAT_JANK_MONITOR'])
+    );
+
+    expect(
+      resolveAppShellRouteFlagNames(APP_ROUTES.SETTINGS_ARTIST_PROFILE)
+    ).toEqual(expect.arrayContaining(['APPLE_WALLET_PROFILE_PASS']));
+  });
+
+  it('does not include unrelated runtime flags in trimmed shell payloads', () => {
+    const chatFlags = resolveAppShellRouteFlagNames(APP_ROUTES.CHAT);
+
+    expect(chatFlags).not.toContain('MERCH_MVP');
+    expect(chatFlags).not.toContain('AI_CONNECTORS_BETA');
+    expect(chatFlags).not.toContain('PLAYLIST_ENGINE');
+    expect(chatFlags).not.toContain('BULK_PRESS_PHOTO_IMPORT');
+  });
+});

--- a/apps/web/tests/unit/lib/flags/server-snapshot.test.ts
+++ b/apps/web/tests/unit/lib/flags/server-snapshot.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const registryRunMock = vi.fn();
+
+vi.mock('flags/next', () => ({
+  dedupe: (fn: () => Promise<unknown>) => fn,
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({
+    get: () => undefined,
+  }),
+}));
+
+vi.mock('@/lib/admin/roles', () => ({
+  isAdmin: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('@/lib/flags/registry', () => ({
+  APP_FLAG_REGISTRY: {
+    DESIGN_V1: {
+      run: (...args: unknown[]) => registryRunMock('DESIGN_V1', ...args),
+    },
+    STRIPE_CONNECT_ENABLED: {
+      run: (...args: unknown[]) =>
+        registryRunMock('STRIPE_CONNECT_ENABLED', ...args),
+    },
+    MERCH_MVP: {
+      run: (...args: unknown[]) => registryRunMock('MERCH_MVP', ...args),
+    },
+  },
+  PROFILE_ALERT_OPTIN_VARIANT_FLAG: { run: vi.fn() },
+  SUBSCRIBE_CTA_VARIANT_FLAG: { run: vi.fn() },
+}));
+
+describe('getAppFlagsSnapshot flagNames option', () => {
+  beforeEach(() => {
+    registryRunMock.mockReset();
+    registryRunMock.mockImplementation(async (flagName: string) => {
+      if (flagName === 'DESIGN_V1') return true;
+      if (flagName === 'STRIPE_CONNECT_ENABLED') return false;
+      return true;
+    });
+  });
+
+  it('resolves only the requested flags', async () => {
+    const { getAppFlagsSnapshot } = await import('@/lib/flags/server');
+
+    const snapshot = await getAppFlagsSnapshot({
+      userId: 'user_123',
+      flagNames: ['DESIGN_V1', 'STRIPE_CONNECT_ENABLED'],
+    });
+
+    const resolvedFlagNames = registryRunMock.mock.calls.map(call => call[0]);
+    expect(resolvedFlagNames).toEqual(
+      expect.arrayContaining(['DESIGN_V1', 'STRIPE_CONNECT_ENABLED'])
+    );
+    expect(resolvedFlagNames).not.toContain('MERCH_MVP');
+    expect(snapshot).toEqual({
+      DESIGN_V1: true,
+      STRIPE_CONNECT_ENABLED: false,
+    });
+    expect(Object.keys(snapshot)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Main-target queue drain (btw Phase 0). Reopened against the recommended integration branch — full CI runs on the domain train PR only. Policy: `.claude/rules/ci-branching.md`, state: `.context/loop-state.json`.

Integration fast lane only. Merge via `scripts/loop-integration-ship.sh integration/loop-ui tim/jov-3057-flag-payload-trim` after local verify.

<!-- linear-issue-id: -->