### PR TITLE
train(ui): loop-ui review blockers

### DIFF
--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -130,6 +130,7 @@ module.exports = {
         // Button colors
         'btn-primary': 'var(--color-btn-primary-bg)',
         'btn-primary-foreground': 'var(--color-btn-primary-fg)',
+        'btn-primary-hover': 'var(--color-btn-primary-hover)',
         'btn-secondary': 'var(--color-btn-secondary-bg)',
         'btn-secondary-foreground': 'var(--color-btn-secondary-fg)',
 
@@ -229,6 +230,7 @@ module.exports = {
 
       // Ring colors (for focus rings)
       ringColor: {
+        ring: 'var(--linear-border-focus)',
         accent: 'var(--color-accent)',
         focus: 'var(--color-border-focus)',
         success: 'var(--color-success)',

--- a/apps/web/tests/e2e/tasks-layout.spec.ts
+++ b/apps/web/tests/e2e/tasks-layout.spec.ts
@@ -342,7 +342,7 @@ async function ensureBoardViewMode(page: Page): Promise<void> {
   const displayOptions = page.getByRole('button', { name: 'Display options' });
   await expect(displayOptions).toBeVisible({ timeout: 90_000 });
   await displayOptions.click();
-  await page.getByRole('button', { name: 'Board view' }).click();
+  await page.getByRole('button', { name: 'Board View' }).click();
   await expect(board).toBeVisible({ timeout: 90_000 });
 }
 
@@ -564,7 +564,7 @@ test.describe('Tasks layout', () => {
       });
 
       await page.getByRole('button', { name: 'Display options' }).click();
-      await page.getByRole('button', { name: 'Board view' }).click();
+      await page.getByRole('button', { name: 'Board View' }).click();
 
       await expect(page.getByTestId('tasks-board')).toBeVisible({
         timeout: 60_000,

--- a/apps/web/tests/unit/calendar/calendar-inner-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/calendar/calendar-inner-system-b-style-guard.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 const ROOT = join(__dirname, '../../..');
 const CALENDAR_INNER = join(ROOT, 'components/atoms/CalendarInner.tsx');
+const TAILWIND_CONFIG = join(ROOT, 'tailwind.config.js');
 
 describe('CalendarInner System B style guard', () => {
   it('keeps calendar selection and focus states neutral', () => {
@@ -20,11 +21,32 @@ describe('CalendarInner System B style guard', () => {
     expect(source).toContain('focus-visible:ring-ring');
   });
 
+  it('maps calendar neutral utilities to concrete Tailwind tokens', () => {
+    const tailwindConfig = readFileSync(TAILWIND_CONFIG, 'utf8');
+
+    expect(tailwindConfig).toContain(
+      "'btn-primary-hover': 'var(--color-btn-primary-hover)'"
+    );
+    expect(tailwindConfig).toContain("ring: 'var(--linear-border-focus)'");
+  });
+
   it('preserves stable calendar control dimensions across visual states', () => {
     const source = readFileSync(CALENDAR_INNER, 'utf8');
 
     expect(source).toContain('inline-flex h-6 w-6');
     expect(source).toContain("day: 'h-8 w-8 p-0 text-center'");
     expect(source).toContain('inline-flex h-8 w-8');
+    expect(source).toContain(
+      'hover:bg-interactive-hover hover:text-primary-token transition-colors'
+    );
+    expect(source).toContain('hover:bg-interactive-hover transition-colors');
+    expect(source).toContain(
+      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+    );
+    expect(source).toContain('[&>button]:font-medium');
+    expect(source).toContain('[&>button]:text-primary-token');
+    expect(source).toContain('[&>button]:text-tertiary-token');
+    expect(source).toContain('[&>button]:opacity-50');
+    expect(source).toContain('[&>button]:opacity-40');
   });
 });

--- a/apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
+++ b/apps/web/tests/unit/dashboard/TaskWorkspaceHeaderBar.test.tsx
@@ -91,7 +91,7 @@ vi.mock('@/components/organisms/table/molecules/DisplayMenuDropdown', () => ({
     <div>
       {trigger}
       <button type='button' onClick={() => onViewModeChange?.('list')}>
-        List view
+        List View
       </button>
     </div>
   ),
@@ -165,7 +165,7 @@ describe('TaskWorkspaceHeaderBar', () => {
 
     render(<TaskWorkspaceHeaderBar {...props} mode='default' />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'List view' }));
+    fireEvent.click(screen.getByRole('button', { name: 'List View' }));
 
     expect(props.onViewModeChange).toHaveBeenCalledWith('list');
   });

--- a/apps/web/tests/unit/dashboard/display-menu-dropdown-system-b-style-guard.test.ts
+++ b/apps/web/tests/unit/dashboard/display-menu-dropdown-system-b-style-guard.test.ts
@@ -23,6 +23,13 @@ describe('DisplayMenuDropdown System B style guard', () => {
   it('keeps switch state transitions layout-stable', () => {
     const source = readFileSync(sourcePath, 'utf8');
 
+    expect(source).toContain('transition-[background-color]');
+    expect(source).toContain('hover:bg-surface-1');
+    expect(source).toContain('focus-visible:bg-surface-1');
+    expect(source).toContain('focus-visible:outline-none');
+    expect(source).toContain(
+      'focus-visible:ring-1 focus-visible:ring-(--linear-border-focus)'
+    );
     expect(source).toContain('h-4 w-7 shrink-0');
     expect(source).toContain('h-3 w-3 rounded-full');
     expect(source).toContain('translate-x-3');


### PR DESCRIPTION
## Summary
- trains the loop-ui integration branch containing #10755 into main
- adds missing neutral Tailwind mappings for calendar focus/hover utilities
- preserves DisplayMenu and calendar layout-stability guard coverage

## Verification
- #10755 merged into integration/loop-ui
- local focused Vitest, Biome, Tailwind guard, typecheck, and pre-push gate passed on the feature branch
- integration/loop-ui is one commit ahead of main