### PR TITLE
fix(ci): retain opentelemetry trace peer for knip

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -44,6 +44,7 @@
         "@radix-ui/react-toggle",
         "@radix-ui/react-toggle-group",
         "@radix-ui/react-tooltip",
+        "@opentelemetry/sdk-trace-base",
         "@sentry/node",
         "promptfoo"
       ],


### PR DESCRIPTION
## Summary
- Keep `@opentelemetry/sdk-trace-base` declared for the web app while marking it as an intentional Knip ignored dependency.
- Restores the `Knip (dead code)` check that failed on `main` after #10756.

## Test plan
- `pnpm knip`
- `pnpm biome check knip.json`
- `git diff --check`
- pre-push gate: `biome check . && pnpm --filter=@jovie/web run pre-push`

## Risk
- Config-only CI fix; no runtime code or dependency graph change.
