### PR TITLE
fix(ci): retain opentelemetry trace peer for knip

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -44,6 +44,7 @@
         "@radix-ui/react-toggle",
         "@radix-ui/react-toggle-group",
         "@radix-ui/react-tooltip",
+        "@opentelemetry/sdk-trace-base",
         "@sentry/node",
         "promptfoo"
       ],


### PR DESCRIPTION
Integration train PR — local verify only. Full CI runs on integration→main train.

<!-- linear-issue-identifier: -->
