### PR TITLE
fix(onboarding): remove legacy route overhead (#10557)

### DIFF
--- a/apps/web/app/onboarding/actions/profile-setup.ts
+++ b/apps/web/app/onboarding/actions/profile-setup.ts
@@ -24,8 +24,6 @@ export async function createUserAndProfile(
   trimmedDisplayName: string
 ): Promise<CompletionResult> {
   try {
-    const createUserAndProfileTimer = 'db:onboarding:createUserAndProfile';
-    console.time(createUserAndProfileTimer);
     const result = await tx.execute(
       drizzleSql<{ profile_id: string }>`
         SELECT create_profile_with_user(
@@ -36,7 +34,6 @@ export async function createUserAndProfile(
         ) AS profile_id
       `
     );
-    console.timeEnd(createUserAndProfileTimer);
 
     const profileId = result.rows?.[0]?.profile_id
       ? String(result.rows[0].profile_id)
@@ -65,8 +62,6 @@ export async function createProfileForExistingUser(
   trimmedDisplayName: string
 ): Promise<CompletionResult> {
   try {
-    const createProfileTimer = 'db:onboarding:createProfileForExistingUser';
-    console.time(createProfileTimer);
     const [profile] = await tx
       .insert(creatorProfiles)
       .values({
@@ -87,7 +82,6 @@ export async function createProfileForExistingUser(
         id: creatorProfiles.id,
         usernameNormalized: creatorProfiles.usernameNormalized,
       });
-    console.timeEnd(createProfileTimer);
 
     // Set active_profile_id on the user so auth/session joins resolve correctly
     if (profile?.id) {
@@ -134,8 +128,6 @@ export async function updateExistingProfile(
     const nextDisplayName =
       trimmedDisplayName || profile.displayName || username;
 
-    const updateProfileTimer = 'db:onboarding:updateExistingProfile';
-    console.time(updateProfileTimer);
     const [updated] = await tx
       .update(creatorProfiles)
       .set({
@@ -152,7 +144,6 @@ export async function updateExistingProfile(
       .returning({
         usernameNormalized: creatorProfiles.usernameNormalized,
       });
-    console.timeEnd(updateProfileTimer);
 
     // Set active_profile_id on the user so auth/session joins resolve correctly
     if (profile.userId) {
@@ -183,14 +174,11 @@ export async function fetchExistingUser(
   clerkUserId: string
 ): Promise<{ id: string } | null> {
   try {
-    const fetchUserTimer = 'db:onboarding:fetchExistingUser';
-    console.time(fetchUserTimer);
     const [existingUser] = await tx
       .select({ id: users.id })
       .from(users)
       .where(eq(users.clerkId, clerkUserId))
       .limit(1);
-    console.timeEnd(fetchUserTimer);
 
     return existingUser ?? null;
   } catch (error) {
@@ -211,8 +199,6 @@ export async function fetchExistingProfile(
   userId: string
 ): Promise<CreatorProfile | null> {
   try {
-    const fetchProfileTimer = 'db:onboarding:fetchExistingProfile';
-    console.time(fetchProfileTimer);
     const [existingProfile] = await tx
       .select()
       .from(creatorProfiles)
@@ -222,7 +208,6 @@ export async function fetchExistingProfile(
         desc(creatorProfiles.onboardingCompletedAt)
       )
       .limit(1);
-    console.timeEnd(fetchProfileTimer);
 
     return existingProfile ?? null;
   } catch (error) {

--- a/apps/web/app/onboarding/layout.tsx
+++ b/apps/web/app/onboarding/layout.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from 'next';
-import { ResolvedClientProviders } from '@/components/providers/ResolvedClientProviders';
-import { AppFlagProvider } from '@/lib/flags/client';
-import { getAppFlagsSnapshot } from '@/lib/flags/server';
+import type { ReactNode } from 'react';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,16 +9,10 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default async function OnboardingLayout({
+export default function OnboardingLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
-  const initialFlags = await getAppFlagsSnapshot();
-
-  return (
-    <ResolvedClientProviders>
-      <AppFlagProvider initialFlags={initialFlags}>{children}</AppFlagProvider>
-    </ResolvedClientProviders>
-  );
+  return children;
 }


### PR DESCRIPTION
## Issue
Closes #10557

## Plan Source
- GitHub issue #10557 acceptance criteria
- gbrain task records:
  - `automation/jovie/hourly-2026-06-12-selection`
  - `automation/jovie/hourly-2026-06-12-issue-10557-plan`
  - `automation/jovie/hourly-2026-06-12-issue-10557-implementation`
  - `automation/jovie/hourly-2026-06-12-issue-10557-qa`
  - `automation/jovie/hourly-2026-06-12-issue-10557-shipping`

## Summary
- Made the legacy `/onboarding` layout pass children through without fetching app flags or mounting the app flag/provider stack.
- Removed `console.time` / `console.timeEnd` instrumentation from the onboarding `profile-setup` server action helpers.

## Files / Components Changed
- `apps/web/app/onboarding/layout.tsx`
- `apps/web/app/onboarding/actions/profile-setup.ts`

## QA Matrix
- `rg "console\\.|getAppFlagsSnapshot|AppFlagProvider|ResolvedClientProviders" apps/web/app/onboarding/layout.tsx apps/web/app/onboarding/actions/profile-setup.ts || true` — no matches
- `JOVIE_AGENT_PROFILE=coder pnpm exec biome check --write apps/web/app/onboarding/layout.tsx apps/web/app/onboarding/actions/profile-setup.ts` — passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/actions/onboarding/profile-setup.test.ts` — passed, 13 tests
- `JOVIE_AGENT_PROFILE=coder pnpm run typecheck:web:fast` — passed
- `JOVIE_AGENT_PROFILE=coder pnpm run biome:check` — passed, 6401 files
- `JOVIE_AGENT_PROFILE=coder pnpm ci:harness:check` — passed
- `JOVIE_AGENT_PROFILE=coder pnpm next:proxy-guard` — passed
- `JOVIE_AGENT_PROFILE=coder pnpm tailwind:check` — passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter=@jovie/web run lint:no-native-dialogs` — passed
- `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run test:fast` — passed, 1736 files / 13717 tests
- `JOVIE_AGENT_PROFILE=coder pnpm run build:web` — passed
- Commit hook — passed staged Biome/ESLint and web typecheck
- Pre-push hook — passed Biome, proxy guard, Tailwind, web typecheck, and web lint

## CodeRabbit
- `coderabbit review --agent --type uncommitted --base main -c AGENTS.md` — 0 findings
- `coderabbit review --agent --type committed --base main -c AGENTS.md` — 0 findings

## Risks / Rollback
- Risk is low: removal-only cleanup in a legacy redirect route layout and debug timing calls.
- Rollback: revert commit `64e3fdeb9`.

## Notes
- Linear MCP connection required reauthentication, so JOV-3002 could not be moved from this run. GitHub issue and gbrain were updated instead.
- Auto-merge intentionally not enabled until remote CI and branch protections are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal performance monitoring timers from profile setup operations.

* **Refactor**
  * Streamlined onboarding layout structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->