### PR TITLE
test(auth): daily auth/signup/onboarding golden-path canary (JOV-1871)

### DIFF
--- a/apps/web/app/api/cron/auth-signup-onboarding-canary/route.ts
+++ b/apps/web/app/api/cron/auth-signup-onboarding-canary/route.ts
@@ -1,0 +1,179 @@
+/**
+ * Auth / signup / onboarding golden-path canary cron (JOV-1871)
+ *
+ * Runs daily at 06:23 UTC (off-peak — 10 minutes after public-profile canary).
+ *
+ * PURPOSE: Lightweight HTTP-level check that the anonymous auth + onboarding
+ * golden-path entrypoints are healthy in production:
+ *  - GET /signup, /signin — auth shell renders without config errors
+ *  - GET /start — onboarding chat surface renders
+ *  - POST /api/chat (onboarding mode) — reaches Turnstile gate, not disabled
+ *
+ * This is the production-monitoring half of the Reliability Every-Bug-Becomes-a-Detector
+ * loop (JOV-1855). The full Playwright canary spec runs in nightly CI.
+ *
+ * OUTPUT: Structured Sentry breadcrumb with tag `canary.auth_signup_onboarding=pass|fail`.
+ * The admin ops panel reads the canary status from a short-lived Redis key
+ * written by this route (TTL: 26h).
+ *
+ * Cost impact: 4 HTTP calls/day to production. ~$0/month.
+ *
+ * Schedule: `23 6 * * *` (configured in vercel.json per JOV-1871 approval)
+ *
+ * @see .claude/rules/infra.md — explicit approval from JOV-1871 acceptance criteria
+ */
+
+import * as Sentry from '@sentry/nextjs';
+import { type NextRequest, NextResponse } from 'next/server';
+import {
+  AUTH_SIGNUP_ONBOARDING_CANARY_REDIS_KEY,
+  AUTH_SIGNUP_ONBOARDING_ROUTES,
+  bodyContainsAuthShellReady,
+  bodyContainsOnboardingChat,
+  buildReport,
+  type CanaryReport,
+  checkAuthSurfaceGet,
+  checkOnboardingChatProbe,
+  formatAuthSignupOnboardingReportSummary,
+} from '@/lib/canaries/auth-signup-onboarding';
+import { verifyCronRequest } from '@/lib/cron/auth';
+import { captureError } from '@/lib/error-tracking';
+import { getRedis } from '@/lib/redis';
+import { logger } from '@/lib/utils/logger';
+
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
+/** 26 hours so the key persists through a brief cron delay. */
+const CANARY_REDIS_TTL_SECONDS = 26 * 60 * 60;
+
+const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
+
+function resolveProductionBaseUrl(): string {
+  return 'https://jov.ie';
+}
+
+async function persistCanaryResult(report: CanaryReport): Promise<void> {
+  const redis = getRedis();
+  if (!redis) {
+    logger.warn(
+      '[canary/auth-signup-onboarding] Redis unavailable — skipping persistence'
+    );
+    return;
+  }
+
+  try {
+    await redis.set(
+      AUTH_SIGNUP_ONBOARDING_CANARY_REDIS_KEY,
+      JSON.stringify(report),
+      {
+        ex: CANARY_REDIS_TTL_SECONDS,
+      }
+    );
+  } catch (err) {
+    logger.warn(
+      '[canary/auth-signup-onboarding] Failed to write Redis canary key',
+      err
+    );
+  }
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const authError = verifyCronRequest(request, {
+    route: '/api/cron/auth-signup-onboarding-canary',
+    allowDevelopmentBypass: true,
+  });
+  if (authError) return authError;
+
+  const runAt = new Date().toISOString();
+  const wallStart = Date.now();
+  const base = resolveProductionBaseUrl();
+
+  try {
+    const [signupCheck, signinCheck, startCheck, chatCheck] =
+      await Promise.allSettled([
+        checkAuthSurfaceGet(
+          'signup-200',
+          `${base}${AUTH_SIGNUP_ONBOARDING_ROUTES.signup}`,
+          bodyContainsAuthShellReady
+        ),
+        checkAuthSurfaceGet(
+          'signin-200',
+          `${base}${AUTH_SIGNUP_ONBOARDING_ROUTES.signin}`,
+          bodyContainsAuthShellReady
+        ),
+        checkAuthSurfaceGet(
+          'start-200',
+          `${base}${AUTH_SIGNUP_ONBOARDING_ROUTES.start}`,
+          bodyContainsOnboardingChat
+        ),
+        checkOnboardingChatProbe(
+          'onboarding-chat-gate',
+          `${base}${AUTH_SIGNUP_ONBOARDING_ROUTES.onboardingChat}`
+        ),
+      ]);
+
+    const checks = [signupCheck, signinCheck, startCheck, chatCheck].map(
+      (result, idx) => {
+        if (result.status === 'fulfilled') return result.value;
+        const names = [
+          'signup-200',
+          'signin-200',
+          'start-200',
+          'onboarding-chat-gate',
+        ];
+        return {
+          name: names[idx] ?? 'unknown',
+          ok: false,
+          detail:
+            result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason),
+          durationMs: 0,
+        };
+      }
+    );
+
+    const totalDurationMs = Date.now() - wallStart;
+    const report = buildReport(runAt, checks, totalDurationMs);
+    const summary = formatAuthSignupOnboardingReportSummary(report);
+
+    logger.info(summary, { report });
+
+    Sentry.addBreadcrumb({
+      category: 'canary',
+      message: summary,
+      level: report.pass ? 'info' : 'error',
+      data: {
+        'canary.auth_signup_onboarding': report.pass ? 'pass' : 'fail',
+        runAt,
+        checks: report.checks,
+      },
+    });
+
+    if (!report.pass) {
+      const failedChecks = report.checks.filter(c => !c.ok);
+      Sentry.captureMessage(
+        `[canary/auth-signup-onboarding] FAIL — ${failedChecks.map(c => c.name).join(', ')}`,
+        'error'
+      );
+    }
+
+    await persistCanaryResult(report);
+
+    return NextResponse.json(report, {
+      status: report.pass ? 200 : 207,
+      headers: NO_STORE_HEADERS,
+    });
+  } catch (error) {
+    logger.error('[canary/auth-signup-onboarding] Canary run failed', error);
+    await captureError('Auth signup onboarding canary run failed', error, {
+      route: '/api/cron/auth-signup-onboarding-canary',
+    });
+
+    return NextResponse.json(
+      { error: 'Canary run failed', runAt },
+      { status: 500, headers: NO_STORE_HEADERS }
+    );
+  }
+}

--- a/apps/web/app/app/(shell)/admin/ops/page.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/page.tsx
@@ -9,7 +9,11 @@ import type {
 import { AdminPage } from '@/components/features/admin/layout/AdminPage';
 import { OperationalControlPanel } from '@/components/features/admin/OperationalControlPanel';
 import { APP_ROUTES } from '@/constants/routes';
-import { getPublicProfileCanaryStatus } from '@/lib/admin/ops-queries';
+import {
+  getAuthSignupOnboardingCanaryStatus,
+  getPublicProfileCanaryStatus,
+} from '@/lib/admin/ops-queries';
+import type { CanaryReport } from '@/lib/canaries/public-profile';
 import { env } from '@/lib/env-server';
 import { getHudMetrics } from '@/lib/hud/metrics';
 import { NOINDEX_ROBOTS } from '@/lib/seo/noindex-metadata';
@@ -31,6 +35,69 @@ const PRESENTATION_VIEW_HREF = `${APP_ROUTES.ADMIN_OPS}?mode=kiosk`;
 
 function resolvePresentationMode(value: unknown): PresentationMode {
   return value === 'kiosk' ? 'admin-kiosk' : 'shell';
+}
+
+function formatCanaryRunAt(runAt: string | undefined): string | null {
+  if (!runAt) return null;
+  return new Date(runAt).toLocaleString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'UTC',
+    timeZoneName: 'short',
+  });
+}
+
+function CanaryStatusRow({
+  label,
+  status,
+  testId,
+}: Readonly<{
+  label: string;
+  status: CanaryReport | null;
+  testId: string;
+}>) {
+  const pass = status?.pass ?? null;
+  const runAt = formatCanaryRunAt(status?.runAt);
+
+  return (
+    <div
+      className='flex items-center gap-2 rounded-md border border-subtle bg-surface-1 px-3 py-2 text-[13px]'
+      data-testid={testId}
+    >
+      {pass === null ? (
+        <span
+          className='h-2 w-2 rounded-full bg-tertiary-token'
+          aria-hidden='true'
+        />
+      ) : pass ? (
+        <CheckCircle2
+          className='h-3.5 w-3.5 shrink-0 text-success'
+          aria-label='Pass'
+        />
+      ) : (
+        <XCircle
+          className='h-3.5 w-3.5 shrink-0 text-destructive'
+          aria-label='Fail'
+        />
+      )}
+      <span className='font-medium text-secondary-token'>{label}</span>
+      <span className='text-tertiary-token'>
+        {pass === null
+          ? 'No data yet'
+          : pass
+            ? 'Pass'
+            : `Fail — ${status?.checks
+                .filter(check => !check.ok)
+                .map(check => check.name)
+                .join(', ')}`}
+      </span>
+      {runAt ? (
+        <span className='ml-auto text-[12px] text-tertiary-token'>{runAt}</span>
+      ) : null}
+    </div>
+  );
 }
 
 /**
@@ -83,10 +150,16 @@ export default async function AdminOpsPage({
   // The admin layout has already verified admin entitlement; getHudMetrics
   // accepts the access mode for downstream auth-aware features (e.g. AI ops
   // dispatch UI). Admin sees full dispatch; kiosk-token would not.
-  const [metrics, shippingPrefetch, canaryStatus] = await Promise.all([
+  const [
+    metrics,
+    shippingPrefetch,
+    publicProfileCanaryStatus,
+    authCanaryStatus,
+  ] = await Promise.all([
     getHudMetrics('admin'),
     getInitialShippingData(),
     getPublicProfileCanaryStatus(),
+    getAuthSignupOnboardingCanaryStatus(),
   ]);
 
   // In admin-kiosk presentation, render the kiosk-density body inside the
@@ -106,19 +179,6 @@ export default async function AdminOpsPage({
     );
   }
 
-  // Derive canary display state
-  const canaryPass = canaryStatus?.pass ?? null;
-  const canaryRunAt = canaryStatus?.runAt
-    ? new Date(canaryStatus.runAt).toLocaleString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        timeZone: 'UTC',
-        timeZoneName: 'short',
-      })
-    : null;
-
   return (
     <AdminPage
       title='Ops'
@@ -130,7 +190,7 @@ export default async function AdminOpsPage({
             href={PRESENTATION_VIEW_HREF}
             target='_blank'
             rel='noopener'
-            aria-label='Open TV view in a new tab'
+            aria-label='Open TV View In A New Tab'
           >
             <Maximize2 className='h-3.5 w-3.5' aria-hidden='true' />
             TV view
@@ -138,45 +198,17 @@ export default async function AdminOpsPage({
         </Button>
       }
     >
-      {/* Public-profile canary status (JOV-1872) — one line + status dot */}
-      <div
-        className='flex items-center gap-2 rounded-md border border-subtle bg-surface-1 px-3 py-2 text-[13px]'
-        data-testid='public-profile-canary-status'
-      >
-        {canaryPass === null ? (
-          <span
-            className='h-2 w-2 rounded-full bg-tertiary-token'
-            aria-hidden='true'
-          />
-        ) : canaryPass ? (
-          <CheckCircle2
-            className='h-3.5 w-3.5 shrink-0 text-success'
-            aria-label='Pass'
-          />
-        ) : (
-          <XCircle
-            className='h-3.5 w-3.5 shrink-0 text-destructive'
-            aria-label='Fail'
-          />
-        )}
-        <span className='font-medium text-secondary-token'>
-          Public profile canary
-        </span>
-        <span className='text-tertiary-token'>
-          {canaryPass === null
-            ? 'No data yet'
-            : canaryPass
-              ? 'Pass'
-              : `Fail — ${canaryStatus?.checks
-                  .filter(c => !c.ok)
-                  .map(c => c.name)
-                  .join(', ')}`}
-        </span>
-        {canaryRunAt ? (
-          <span className='ml-auto text-[12px] text-tertiary-token'>
-            {canaryRunAt}
-          </span>
-        ) : null}
+      <div className='flex flex-col gap-2'>
+        <CanaryStatusRow
+          label='Public Profile Canary'
+          status={publicProfileCanaryStatus}
+          testId='public-profile-canary-status'
+        />
+        <CanaryStatusRow
+          label='Auth Signup Onboarding Canary'
+          status={authCanaryStatus}
+          testId='auth-signup-onboarding-canary-status'
+        />
       </div>
 
       <OperationalControlPanel />

--- a/apps/web/lib/admin/ops-queries.ts
+++ b/apps/web/lib/admin/ops-queries.ts
@@ -1,6 +1,10 @@
 import 'server-only';
 
 import {
+  AUTH_SIGNUP_ONBOARDING_CANARY_REDIS_KEY,
+  type CanaryReport as AuthSignupOnboardingCanaryReport,
+} from '@/lib/canaries/auth-signup-onboarding';
+import {
   CANARY_REDIS_KEY,
   type CanaryCheckResult,
   type CanaryReport,
@@ -44,25 +48,41 @@ function parseCanaryReport(raw: unknown): CanaryReport | null {
  * Fetch the latest public-profile canary run result from Redis.
  * Returns null if Redis is unavailable or the key has expired (> 26h since last run).
  */
-export async function getPublicProfileCanaryStatus(): Promise<CanaryReport | null> {
+async function loadCanaryReportFromRedis(
+  key: string,
+  context: string
+): Promise<CanaryReport | null> {
   const redis = getRedis();
   if (!redis) return null;
 
   try {
-    const raw = await redis.get<unknown>(CANARY_REDIS_KEY);
+    const raw = await redis.get<unknown>(key);
     if (!raw) return null;
 
     const report = parseCanaryReport(raw);
     if (!report) {
-      logger.warn('[admin/ops] Ignoring malformed canary status from Redis');
+      logger.warn(
+        `[admin/ops] Ignoring malformed canary status for ${context}`
+      );
     }
 
     return report;
   } catch (err) {
-    logger.warn('[admin/ops] Failed to load canary status from Redis', err);
-    await captureError('Admin ops: canary status load failed', err, {
+    logger.warn(`[admin/ops] Failed to load canary status for ${context}`, err);
+    await captureError(`Admin ops: ${context} canary status load failed`, err, {
       context: 'ops-queries',
     });
     return null;
   }
+}
+
+export async function getPublicProfileCanaryStatus(): Promise<CanaryReport | null> {
+  return loadCanaryReportFromRedis(CANARY_REDIS_KEY, 'public-profile');
+}
+
+export async function getAuthSignupOnboardingCanaryStatus(): Promise<AuthSignupOnboardingCanaryReport | null> {
+  return loadCanaryReportFromRedis(
+    AUTH_SIGNUP_ONBOARDING_CANARY_REDIS_KEY,
+    'auth-signup-onboarding'
+  );
 }

--- a/apps/web/lib/canaries/auth-signup-onboarding.test.ts
+++ b/apps/web/lib/canaries/auth-signup-onboarding.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  AUTH_SIGNUP_ONBOARDING_ROUTES,
+  AUTH_SURFACE_MIN_BODY_CHARS,
+  bodyContainsAuthShellReady,
+  bodyContainsOnboardingChat,
+  buildOnboardingChatProbePayload,
+  buildReport,
+  evaluateOnboardingChatProbe,
+  formatAuthSignupOnboardingReportSummary,
+  hasAuthSurfaceError,
+  hasGoldenPathSurfaceError,
+} from './auth-signup-onboarding';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('hasAuthSurfaceError', () => {
+  it('detects auth unavailable', () => {
+    expect(hasAuthSurfaceError('Auth unavailable right now')).toBe(true);
+  });
+
+  it('detects turnstile misconfiguration', () => {
+    expect(hasAuthSurfaceError('turnstile is not configured')).toBe(true);
+  });
+
+  it('returns false for healthy auth HTML', () => {
+    expect(
+      hasAuthSurfaceError(
+        '<div data-auth-shell-ready="true" data-auth-shell-mode="sign-up"></div>'
+      )
+    ).toBe(false);
+  });
+});
+
+describe('hasGoldenPathSurfaceError', () => {
+  it('includes generic server errors', () => {
+    expect(hasGoldenPathSurfaceError('Internal Server Error')).toBe(true);
+  });
+
+  it('includes auth config errors', () => {
+    expect(hasGoldenPathSurfaceError('clerk is not configured')).toBe(true);
+  });
+});
+
+describe('bodyContainsAuthShellReady', () => {
+  it('matches the ready marker', () => {
+    expect(
+      bodyContainsAuthShellReady('<div data-auth-shell-ready="true"></div>')
+    ).toBe(true);
+  });
+
+  it('rejects the loading marker', () => {
+    expect(
+      bodyContainsAuthShellReady('<div data-auth-shell-ready="false"></div>')
+    ).toBe(false);
+  });
+});
+
+describe('bodyContainsOnboardingChat', () => {
+  it('matches onboarding chat test id', () => {
+    expect(
+      bodyContainsOnboardingChat('<div data-testid="onboarding-chat"></div>')
+    ).toBe(true);
+  });
+});
+
+describe('buildOnboardingChatProbePayload', () => {
+  it('uses onboarding mode with a canary message', () => {
+    const payload = buildOnboardingChatProbePayload();
+    expect(payload.mode).toBe('onboarding');
+    expect(Array.isArray(payload.messages)).toBe(true);
+    expect((payload.messages as { id: string }[])[0]?.id).toBe(
+      'canary-onboarding'
+    );
+  });
+});
+
+describe('evaluateOnboardingChatProbe', () => {
+  it('accepts 403 TURNSTILE_REQUIRED', () => {
+    expect(
+      evaluateOnboardingChatProbe(
+        403,
+        JSON.stringify({ errorCode: 'TURNSTILE_REQUIRED' })
+      )
+    ).toEqual({ ok: true });
+  });
+
+  it('rejects ONBOARDING_CHAT_DISABLED', () => {
+    const result = evaluateOnboardingChatProbe(
+      503,
+      JSON.stringify({ errorCode: 'ONBOARDING_CHAT_DISABLED' })
+    );
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('disabled');
+  });
+
+  it('rejects unexpected status codes', () => {
+    const result = evaluateOnboardingChatProbe(200, '{}');
+    expect(result.ok).toBe(false);
+    expect(result.detail).toContain('403');
+  });
+});
+
+describe('formatAuthSignupOnboardingReportSummary', () => {
+  it('uses the auth-signup-onboarding prefix', () => {
+    const report = buildReport(
+      '2026-06-12T06:23:00Z',
+      [{ name: 'signup-200', ok: true, durationMs: 10 }],
+      10
+    );
+    expect(formatAuthSignupOnboardingReportSummary(report)).toContain(
+      '[canary/auth-signup-onboarding] PASS'
+    );
+  });
+});
+
+describe('auth-signup-onboarding constants', () => {
+  it('covers the golden-path entrypoints', () => {
+    expect(AUTH_SIGNUP_ONBOARDING_ROUTES.signup).toBe('/signup');
+    expect(AUTH_SIGNUP_ONBOARDING_ROUTES.signin).toBe('/signin');
+    expect(AUTH_SIGNUP_ONBOARDING_ROUTES.start).toBe('/start');
+    expect(AUTH_SIGNUP_ONBOARDING_ROUTES.onboardingChat).toBe('/api/chat');
+  });
+
+  it('uses a conservative minimum body length', () => {
+    expect(AUTH_SURFACE_MIN_BODY_CHARS).toBeGreaterThanOrEqual(500);
+  });
+});

--- a/apps/web/lib/canaries/auth-signup-onboarding.ts
+++ b/apps/web/lib/canaries/auth-signup-onboarding.ts
@@ -1,0 +1,239 @@
+/**
+ * Auth / signup / onboarding golden-path canary assertion helpers.
+ *
+ * Shared between:
+ *  - The Playwright E2E spec (`tests/e2e/canary-auth-signup-onboarding.spec.ts`)
+ *  - The daily production cron (`app/api/cron/auth-signup-onboarding-canary/route.ts`)
+ *
+ * Design rules (JOV-1871):
+ *  - Pure functions that operate on typed primitives — no Playwright imports here.
+ *  - Cron variant is lightweight HTTP only; E2E variant exercises browser rendering.
+ *  - Mirrors the deploy canary auth/onboarding probes in canary-health-gate.yml.
+ */
+
+import {
+  buildReport,
+  type CanaryCheckResult,
+  type CanaryReport,
+  checkHttpGet,
+  formatReportSummary,
+  hasServerError,
+} from './public-profile';
+
+export {
+  buildReport,
+  type CanaryCheckResult,
+  type CanaryReport,
+  formatReportSummary,
+};
+
+export const AUTH_SIGNUP_ONBOARDING_CANARY_REDIS_KEY =
+  'canary:auth_signup_onboarding:last_run';
+
+/** Minimum HTML body length for auth/onboarding page renders. */
+export const AUTH_SURFACE_MIN_BODY_CHARS = 500;
+
+/** Routes exercised by the golden-path canary. */
+export const AUTH_SIGNUP_ONBOARDING_ROUTES = {
+  signup: '/signup',
+  signin: '/signin',
+  start: '/start',
+  onboardingChat: '/api/chat',
+} as const;
+
+export type AuthSignupOnboardingRouteName =
+  keyof typeof AUTH_SIGNUP_ONBOARDING_ROUTES;
+
+const AUTH_SURFACE_CONFIG_ERRORS = [
+  'auth unavailable',
+  'authentication unavailable',
+  'clerk is not configured',
+  'turnstile is not configured',
+] as const;
+
+/**
+ * Check whether `body` text contains an obvious auth/onboarding config error.
+ */
+export function hasAuthSurfaceError(body: string): boolean {
+  const lower = body.toLowerCase();
+  return AUTH_SURFACE_CONFIG_ERRORS.some(phrase => lower.includes(phrase));
+}
+
+/**
+ * Combined server + auth-surface error detector for golden-path pages.
+ */
+export function hasGoldenPathSurfaceError(body: string): boolean {
+  return hasServerError(body) || hasAuthSurfaceError(body);
+}
+
+export function bodyContainsAuthShellReady(body: string): boolean {
+  return body.includes('data-auth-shell-ready="true"');
+}
+
+export function bodyContainsOnboardingChat(body: string): boolean {
+  return (
+    body.includes('data-testid="onboarding-chat"') ||
+    body.includes("data-testid='onboarding-chat'")
+  );
+}
+
+/**
+ * Build the anonymous onboarding chat probe payload used by deploy + prod crons.
+ * Intentionally omits a Turnstile token: a healthy build should reach the bot
+ * gate and return 403 TURNSTILE_REQUIRED, not 503 ONBOARDING_CHAT_DISABLED.
+ */
+export function buildOnboardingChatProbePayload(): Record<string, unknown> {
+  return {
+    mode: 'onboarding',
+    messages: [
+      {
+        id: 'canary-onboarding',
+        role: 'user',
+        parts: [{ type: 'text', text: 'canary' }],
+      },
+    ],
+  };
+}
+
+export interface OnboardingChatProbeEvaluation {
+  readonly ok: boolean;
+  readonly detail?: string;
+}
+
+/**
+ * Evaluate the onboarding chat probe response from POST /api/chat.
+ */
+export function evaluateOnboardingChatProbe(
+  statusCode: number,
+  body: string
+): OnboardingChatProbeEvaluation {
+  if (body.includes('"errorCode":"ONBOARDING_CHAT_DISABLED"')) {
+    return {
+      ok: false,
+      detail: 'Onboarding chat disabled by runtime gate',
+    };
+  }
+
+  if (statusCode === 403 && body.includes('"errorCode":"TURNSTILE_REQUIRED"')) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    detail: `Expected 403 TURNSTILE_REQUIRED, got HTTP ${statusCode}`,
+  };
+}
+
+function expectBodyMinLength(
+  body: string,
+  minChars: number
+): string | undefined {
+  if (body.length < minChars) {
+    return `Response body too short (${body.length} chars)`;
+  }
+  return undefined;
+}
+
+/**
+ * Perform a timed HTTP GET for an auth/onboarding page and return a check result.
+ */
+export async function checkAuthSurfaceGet(
+  name: string,
+  url: string,
+  expectBodyFn: (body: string) => boolean
+): Promise<CanaryCheckResult> {
+  const result = await checkHttpGet(name, url, body => {
+    if (hasGoldenPathSurfaceError(body)) return false;
+    const lengthError = expectBodyMinLength(body, AUTH_SURFACE_MIN_BODY_CHARS);
+    if (lengthError) return false;
+    return expectBodyFn(body);
+  });
+
+  if (result.ok) return result;
+
+  // Enrich failure detail when the generic HTTP helper hid the root cause.
+  if (result.detail === 'Response body assertion failed') {
+    try {
+      const res = await fetch(url, { redirect: 'follow' });
+      const body = await res.text();
+      if (hasGoldenPathSurfaceError(body)) {
+        return {
+          ...result,
+          detail: 'Response body contains auth/onboarding error indicator',
+        };
+      }
+      const lengthError = expectBodyMinLength(
+        body,
+        AUTH_SURFACE_MIN_BODY_CHARS
+      );
+      if (lengthError) {
+        return { ...result, detail: lengthError };
+      }
+      if (!expectBodyFn(body)) {
+        return { ...result, detail: 'Golden-path surface marker missing' };
+      }
+    } catch {
+      // Keep the original detail from checkHttpGet.
+    }
+  }
+
+  return result;
+}
+
+/**
+ * POST /api/chat onboarding probe — validates the anonymous chat gate is healthy.
+ */
+export async function checkOnboardingChatProbe(
+  name: string,
+  url: string
+): Promise<CanaryCheckResult> {
+  const start = Date.now();
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(buildOnboardingChatProbePayload()),
+      signal: AbortSignal.timeout(10_000),
+    });
+    const durationMs = Date.now() - start;
+    const body = await res.text();
+    const evaluation = evaluateOnboardingChatProbe(res.status, body);
+
+    if (!evaluation.ok) {
+      return {
+        name,
+        ok: false,
+        statusCode: res.status,
+        detail: evaluation.detail,
+        durationMs,
+      };
+    }
+
+    return {
+      name,
+      ok: true,
+      statusCode: res.status,
+      durationMs,
+    };
+  } catch (err) {
+    return {
+      name,
+      ok: false,
+      detail: err instanceof Error ? err.message : String(err),
+      durationMs: Date.now() - start,
+    };
+  }
+}
+
+/**
+ * Format an auth/signup/onboarding canary report summary line.
+ */
+export function formatAuthSignupOnboardingReportSummary(
+  report: CanaryReport
+): string {
+  const base = formatReportSummary(report);
+  return base.replace(
+    '[canary/public-profile]',
+    '[canary/auth-signup-onboarding]'
+  );
+}

--- a/apps/web/tests/e2e/canary-auth-signup-onboarding.spec.ts
+++ b/apps/web/tests/e2e/canary-auth-signup-onboarding.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * Auth / signup / onboarding golden-path canary (JOV-1871)
+ *
+ * Deterministic regression net for the anonymous auth + onboarding entrypoints.
+ * Runs nightly in CI. Every check corresponds to a real production regression
+ * risk on the signup → onboarding funnel.
+ *
+ * Bug → Detector mapping:
+ *  Deploy canary auth/onboarding probes     → signup/signin/start render checks
+ *  ONBOARDING_CHAT_DISABLED runtime gate    → onboarding chat gate probe
+ *  Clerk / Turnstile config regressions     → auth shell ready + config error scan
+ *
+ * Anonymous visitor — no auth required.
+ *
+ * @canary @nightly @auth-signup-onboarding
+ */
+
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+import {
+  buildOnboardingChatProbePayload,
+  evaluateOnboardingChatProbe,
+} from '@/lib/canaries/auth-signup-onboarding';
+import { AUTH_SIGNUP_ONBOARDING_SPEC_ROUTES } from './fixtures/canary-auth-signup-onboarding';
+import {
+  SMOKE_TIMEOUTS,
+  smokeNavigate,
+  waitForHydration,
+} from './utils/smoke-test-utils';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+test.describe.configure({ mode: 'serial' });
+
+const AUTH_UNAVAILABLE_PATTERN =
+  /auth unavailable|authentication unavailable|temporarily unavailable|clerk is not configured|turnstile is not configured/i;
+
+async function allowAnalyticsPassthrough(page: Page) {
+  await page.route('**/api/profile/view', route =>
+    route.fulfill({ status: 200, body: '{}' })
+  );
+  await page.route('**/api/audience/visit', route =>
+    route.fulfill({ status: 200, body: '{}' })
+  );
+  await page.route('**/api/track', route =>
+    route.fulfill({ status: 200, body: '{}' })
+  );
+}
+
+function collectHydrationErrors(page: Page): {
+  messages: string[];
+  cleanup: () => void;
+} {
+  const messages: string[] = [];
+
+  const handler = (msg: import('@playwright/test').ConsoleMessage) => {
+    const text = msg.text();
+    if (
+      text.includes('Hydration failed') ||
+      text.includes('hydration mismatch') ||
+      text.includes('Text content does not match') ||
+      text.includes('did not match') ||
+      (text.includes('Warning: ') && text.includes('server rendered HTML'))
+    ) {
+      messages.push(text);
+    }
+  };
+
+  page.on('console', handler);
+  return {
+    messages,
+    cleanup: () => page.off('console', handler),
+  };
+}
+
+async function goAndWait(
+  page: Page,
+  path: string
+): Promise<{ status: number; ok: boolean }> {
+  const response = await smokeNavigate(page, path, {
+    timeout: SMOKE_TIMEOUTS.NAVIGATION,
+  });
+  const status = response?.status() ?? 0;
+  if (status < 200 || status >= 400) {
+    return { status, ok: false };
+  }
+  await waitForHydration(page);
+  return { status, ok: true };
+}
+
+async function assertAuthShellReady(page: Page, mode: 'sign-in' | 'sign-up') {
+  const bodyText = await page.locator('body').innerText();
+  expect(bodyText).not.toMatch(AUTH_UNAVAILABLE_PATTERN);
+
+  const shell = page.locator(
+    `[data-auth-shell-mode="${mode}"][data-auth-shell-ready="true"]`
+  );
+  await expect(
+    shell,
+    `AuthShell did not signal ready for mode=${mode}`
+  ).toBeVisible({ timeout: 30_000 });
+
+  await expect(page.locator('input[type="password"]')).toHaveCount(0);
+}
+
+test.describe('Auth signup onboarding canary', () => {
+  test('signup /signup renders the owned auth shell', async ({ page }) => {
+    test.setTimeout(90_000);
+    await allowAnalyticsPassthrough(page);
+
+    const hydrationErrors = collectHydrationErrors(page);
+    const { status, ok } = await goAndWait(
+      page,
+      AUTH_SIGNUP_ONBOARDING_SPEC_ROUTES.signup
+    );
+
+    expect(ok, `/signup returned ${status}`).toBe(true);
+    await assertAuthShellReady(page, 'sign-up');
+
+    hydrationErrors.cleanup();
+    expect(hydrationErrors.messages).toHaveLength(0);
+  });
+
+  test('signin /signin renders the owned auth shell', async ({ page }) => {
+    test.setTimeout(90_000);
+    await allowAnalyticsPassthrough(page);
+
+    const { status, ok } = await goAndWait(
+      page,
+      AUTH_SIGNUP_ONBOARDING_SPEC_ROUTES.signin
+    );
+
+    expect(ok, `/signin returned ${status}`).toBe(true);
+    await assertAuthShellReady(page, 'sign-in');
+  });
+
+  test('start /start renders onboarding chat', async ({ page }) => {
+    test.setTimeout(90_000);
+    await allowAnalyticsPassthrough(page);
+
+    const { status, ok } = await goAndWait(
+      page,
+      AUTH_SIGNUP_ONBOARDING_SPEC_ROUTES.start
+    );
+
+    expect(ok, `/start returned ${status}`).toBe(true);
+    await expect(page.getByTestId('onboarding-chat')).toBeVisible({
+      timeout: SMOKE_TIMEOUTS.VISIBILITY,
+    });
+  });
+
+  test('onboarding chat POST reaches Turnstile gate', async ({ page }) => {
+    test.setTimeout(60_000);
+    await allowAnalyticsPassthrough(page);
+
+    const { ok } = await goAndWait(
+      page,
+      AUTH_SIGNUP_ONBOARDING_SPEC_ROUTES.start
+    );
+    expect(ok).toBe(true);
+
+    const result = await page.evaluate(async payload => {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      return { status: res.status, body: await res.text() };
+    }, buildOnboardingChatProbePayload());
+
+    const evaluation = evaluateOnboardingChatProbe(result.status, result.body);
+    expect(
+      evaluation.ok,
+      evaluation.detail ??
+        `onboarding chat probe failed with HTTP ${result.status}`
+    ).toBe(true);
+  });
+});

--- a/apps/web/tests/e2e/fixtures/canary-auth-signup-onboarding.ts
+++ b/apps/web/tests/e2e/fixtures/canary-auth-signup-onboarding.ts
@@ -1,0 +1,14 @@
+/**
+ * Auth / signup / onboarding canary fixtures (JOV-1871)
+ *
+ * Stable route constants for the golden-path canary spec. These paths are
+ * intentionally anonymous — no seeded profile or Clerk account is required.
+ */
+
+import { AUTH_SIGNUP_ONBOARDING_ROUTES } from '@/lib/canaries/auth-signup-onboarding';
+
+export const AUTH_SIGNUP_ONBOARDING_SPEC_ROUTES = {
+  signup: AUTH_SIGNUP_ONBOARDING_ROUTES.signup,
+  signin: AUTH_SIGNUP_ONBOARDING_ROUTES.signin,
+  start: AUTH_SIGNUP_ONBOARDING_ROUTES.start,
+} as const;

--- a/docs/CRON_REGISTRY.md
+++ b/docs/CRON_REGISTRY.md
@@ -42,9 +42,10 @@ Source of truth: `apps/web/vercel.json`. The Vercel project's Root Directory is 
 | `/api/cron/monitor-metadata-submissions` | `0 * * * *` | Hourly |
 | `/api/cron/process-metadata-submissions` | `0 4 * * *` | Daily at 04:00 UTC |
 | `/api/cron/public-profile-canary` | `13 6 * * *` | Daily at 06:13 UTC |
+| `/api/cron/auth-signup-onboarding-canary` | `23 6 * * *` | Daily at 06:23 UTC (JOV-1871) |
 | `/api/cron/clerk-config-audit` | `*/30 * * * *` | Every 30 minutes (JOV-2446) |
 
-13 paths are currently scheduled in production. `cleanup-sms-intents` was folded into `daily-maintenance` as a sub-job per JOV-1901 (see AUTOMATION_AUDIT.md). Other cron route files exist as standalone endpoints whose logic is called as sub-jobs of `frequent` or `daily-maintenance`.
+14 paths are currently scheduled in production. `cleanup-sms-intents` was folded into `daily-maintenance` as a sub-job per JOV-1901 (see AUTOMATION_AUDIT.md). Other cron route files exist as standalone endpoints whose logic is called as sub-jobs of `frequent` or `daily-maintenance`.
 
 **Auth:** All crons use `Authorization: Bearer ${CRON_SECRET}`. The `data-retention` route additionally uses timing-safe comparison + origin verification.
 
@@ -109,6 +110,7 @@ These have their own Vercel schedule OR exist as callable endpoints (also invoke
 | `/api/cron/schedule-release-notifications` | 60s | Schedules release-day notifications | `daily-maintenance` |
 | `/api/cron/send-release-notifications` | 120s | Sends notifications; recovers stuck rows >10min; max 100/run | `frequent` |
 | `/api/cron/public-profile-canary` | 30s | Lightweight HTTP health check: GET /tim, /tim/alerts, /tim/pay, POST /api/audience/visit; emits Sentry breadcrumb + writes Redis key for admin ops panel (JOV-1872) | — |
+| `/api/cron/auth-signup-onboarding-canary` | 30s | Lightweight HTTP golden-path check: GET /signup, /signin, /start, POST /api/chat onboarding probe; emits Sentry breadcrumb + writes Redis key for admin ops panel (JOV-1871) | — |
 
 ## LLM Model Usage in Web App Crons
 

--- a/vercel.json
+++ b/vercel.json
@@ -57,6 +57,10 @@
       "schedule": "13 6 * * *"
     },
     {
+      "path": "/api/cron/auth-signup-onboarding-canary",
+      "schedule": "23 6 * * *"
+    },
+    {
       "path": "/api/cron/clerk-config-audit",
       "schedule": "*/30 * * * *"
     }


### PR DESCRIPTION
## Goal

Add production monitoring for the anonymous auth → onboarding golden path, mirroring the JOV-1872 public-profile canary pattern.

## Changes

- **`lib/canaries/auth-signup-onboarding.ts`** — shared HTTP assertion helpers for `/signup`, `/signin`, `/start`, and onboarding chat gate probe
- **`app/api/cron/auth-signup-onboarding-canary/route.ts`** — daily prod cron (`23 6 * * *`) with Sentry breadcrumb + Redis persistence
- **`tests/e2e/canary-auth-signup-onboarding.spec.ts`** — nightly Playwright regression net
- **Admin ops panel** — surfaces pass/fail + last run for both public-profile and auth-signup-onboarding canaries
- **`vercel.json` + `docs/CRON_REGISTRY.md`** — schedule registration

## Bug → Detector mapping

| Risk | Detector |
|------|----------|
| Clerk/Turnstile config regressions | signup/signin auth-shell-ready + config error scan |
| Onboarding chat disabled by flag | POST /api/chat expects 403 `TURNSTILE_REQUIRED`, not `ONBOARDING_CHAT_DISABLED` |
| Broken /start render | onboarding-chat test id visibility |

## Cost Impact

- **External API calls**: 4 HTTP calls/day to production (1× signup, 1× signin, 1× start, 1× chat probe)
- **Monthly projection**: ~120 calls/month
- **Scaling factor**: O(1) per run
- **Monthly cost estimate**: ~$0

## Testing

```bash
pnpm --filter=@jovie/web run test -- lib/canaries/auth-signup-onboarding.test.ts
```

<!-- linear-issue-id:JOV-1871 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated health monitoring for authentication and onboarding flows to the Admin operations dashboard.
  * Enabled real-time visibility into critical user funnel readiness through enhanced status reporting.

* **Chores**
  * Configured production monitoring checks for core authentication and signup flows.
  * Updated operational documentation for system health tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->