### PR TITLE
fix(ops): add Turnstile hostname automation for jov.ie production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,6 +173,9 @@ DEMO_VIDEO_URL=
 # Cloudflare Turnstile keys for onboarding chat bot protection.
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=
+# Cloudflare Turnstile widget management (scripts/turnstile-config.ts)
+CLOUDFLARE_API_TOKEN=
+CLOUDFLARE_ACCOUNT_ID=
 # Production synthetic signup canary. Configure only in Doppler prd.
 E2E_SYNTHETIC_MODE=
 E2E_PROD_SIGNUP_EMAIL_BASE=

--- a/AUTH_FIX_LOG.md
+++ b/AUTH_FIX_LOG.md
@@ -488,6 +488,41 @@ Final passing evidence:
 - No production Clerk settings changed.
 - No Clerk dashboard changes made for this auth-smoke stabilization.
 
+## JOV-2329 — Production Turnstile hostname allowlist for jov.ie - 2026-06-12
+
+Failing production evidence inspected:
+
+- Linear JOV-2329: `/start` on `https://jov.ie/start` rendered Turnstile client
+  error `110200` (domain not authorized) even though Doppler `prd` already had
+  `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY`.
+- Live Playwright probe on 2026-06-12: sending the first onboarding message surfaces
+  the Turnstile security panel and loads the Cloudflare challenge for site key
+  `0x4AAAAAADM7PX2W5Au4ZIkV`, but anonymous `/api/chat` still returns
+  `TURNSTILE_REQUIRED` until a client token is minted.
+
+Root cause:
+
+- The active Cloudflare Turnstile widget did not include `jov.ie` / `www.jov.ie`
+  in Hostname Management. Cloudflare returns client error `110200` when the page
+  hostname is outside the widget allowlist.
+
+Fix made in repo:
+
+- Added `scripts/turnstile-config.ts` to inspect/update widget hostnames via the
+  Cloudflare API (dry-run by default).
+- Documented operator flow in `docs/TURNSTILE_SETUP.md`.
+- Added synthetic regression coverage for `verification failed (110200)`.
+
+Post-merge operator action still required once per environment:
+
+1. Create/store `CLOUDFLARE_API_TOKEN` (Turnstile Sites Read + Write) in Doppler
+   `jovie-web/prd`.
+2. Preview:
+   `doppler run --project jovie-web --config prd -- pnpm tsx scripts/turnstile-config.ts ensure-hostnames --dry-run`
+3. Apply:
+   `doppler run --project jovie-web --config prd -- pnpm tsx scripts/turnstile-config.ts ensure-hostnames --yes --allow-prod`
+4. Re-check `https://jov.ie/start` and production synthetic `/start` health.
+
 ## Post-Merge Required Smoke and Mobile Guard Closeout - 2026-06-02
 
 Failing CI evidence inspected:

--- a/apps/web/tests/e2e/synthetic-auth-ui.spec.ts
+++ b/apps/web/tests/e2e/synthetic-auth-ui.spec.ts
@@ -34,6 +34,7 @@ const FRONT_DOOR_CONFIG_ERRORS = [
   'auth unavailable',
   'clerk is not configured',
   'turnstile is not configured',
+  'verification failed (110200)',
 ] as const;
 
 const EMAIL_IDENTIFIER_INPUT_SELECTOR =

--- a/apps/web/tests/e2e/synthetic-golden-path.spec.ts
+++ b/apps/web/tests/e2e/synthetic-golden-path.spec.ts
@@ -20,6 +20,7 @@ const HOMEPAGE_PRIMARY_CTA_TEST_ID = 'homepage-primary-cta';
 const SIGNUP_PATH = '/signup';
 const START_PATH = '/start';
 const TURNSTILE_CONFIG_ERROR = 'turnstile is not configured';
+const TURNSTILE_DOMAIN_ERROR = 'verification failed (110200)';
 
 test.describe('Synthetic Monitoring - Golden Path', () => {
   // Only run in synthetic monitoring mode
@@ -72,6 +73,7 @@ test.describe('Synthetic Monitoring - Golden Path', () => {
         'text="Internal Server Error"',
         'text="Something went wrong"',
         `text="${TURNSTILE_CONFIG_ERROR}"`,
+        `text="${TURNSTILE_DOMAIN_ERROR}"`,
         '[data-testid="error-boundary"]',
       ];
 

--- a/apps/web/tests/unit/scripts/turnstile-config-script.test.ts
+++ b/apps/web/tests/unit/scripts/turnstile-config-script.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergeHostnameAllowlist,
+  missingHostnames,
+  PRODUCTION_TURNSTILE_HOSTNAMES,
+  resolveHostnameTarget,
+  STAGING_TURNSTILE_HOSTNAMES,
+} from '../../../../../scripts/turnstile-config';
+
+describe('scripts/turnstile-config.ts', () => {
+  it('defines production hostnames required for jov.ie signup', () => {
+    expect(PRODUCTION_TURNSTILE_HOSTNAMES).toEqual(['jov.ie', 'www.jov.ie']);
+  });
+
+  it('defines staging hostnames for pre-prod verification', () => {
+    expect(STAGING_TURNSTILE_HOSTNAMES).toEqual([
+      'staging.jov.ie',
+      'main.jov.ie',
+    ]);
+  });
+
+  it('resolves hostname targets explicitly', () => {
+    expect(resolveHostnameTarget('prod')).toEqual(
+      PRODUCTION_TURNSTILE_HOSTNAMES
+    );
+    expect(resolveHostnameTarget('staging')).toEqual(
+      STAGING_TURNSTILE_HOSTNAMES
+    );
+    expect(resolveHostnameTarget('all')).toEqual([
+      ...PRODUCTION_TURNSTILE_HOSTNAMES,
+      ...STAGING_TURNSTILE_HOSTNAMES,
+    ]);
+  });
+
+  it('merges hostnames without duplicates and normalizes casing', () => {
+    expect(
+      mergeHostnameAllowlist(
+        ['meetjovie.com', 'JOV.IE'],
+        ['jov.ie', 'www.jov.ie']
+      )
+    ).toEqual(['jov.ie', 'meetjovie.com', 'www.jov.ie']);
+  });
+
+  it('reports missing required hostnames only', () => {
+    expect(
+      missingHostnames(
+        ['meetjovie.com', 'staging.jov.ie'],
+        ['jov.ie', 'www.jov.ie']
+      )
+    ).toEqual(['jov.ie', 'www.jov.ie']);
+
+    expect(
+      missingHostnames(
+        ['jov.ie', 'www.jov.ie', 'meetjovie.com'],
+        ['jov.ie', 'www.jov.ie']
+      )
+    ).toEqual([]);
+  });
+});

--- a/docs/DOPPLER_SETUP.md
+++ b/docs/DOPPLER_SETUP.md
@@ -195,7 +195,11 @@ SESSION_SECRET
 AI_GATEWAY_API_KEY
 NEXT_PUBLIC_TURNSTILE_SITE_KEY
 TURNSTILE_SECRET_KEY
+CLOUDFLARE_API_TOKEN
 ```
+
+`CLOUDFLARE_API_TOKEN` is optional for runtime but required for Turnstile widget
+hostname automation (`scripts/turnstile-config.ts`). See `docs/TURNSTILE_SETUP.md`.
 
 Run the redacted readiness check before promoting production:
 

--- a/docs/TURNSTILE_SETUP.md
+++ b/docs/TURNSTILE_SETUP.md
@@ -1,0 +1,110 @@
+# Cloudflare Turnstile Setup
+
+Jovie uses Cloudflare Turnstile to gate anonymous onboarding chat on `/start`
+and changelog email signup. Production signup is blocked when the active widget
+does not authorize the serving hostname (Cloudflare client error `110200`).
+
+## Required production hostnames
+
+The production widget referenced by `NEXT_PUBLIC_TURNSTILE_SITE_KEY` must allow:
+
+- `jov.ie`
+- `www.jov.ie`
+
+Staging shares the same widget today and should also allow:
+
+- `staging.jov.ie`
+- `main.jov.ie`
+
+Use `scripts/turnstile-config.ts` as the source of truth for these lists.
+
+## Secrets (Doppler `jovie-web/prd`)
+
+```bash
+NEXT_PUBLIC_TURNSTILE_SITE_KEY
+TURNSTILE_SECRET_KEY
+CLOUDFLARE_API_TOKEN      # Turnstile Sites Read + Write
+CLOUDFLARE_ACCOUNT_ID     # optional when R2_ACCOUNT_ID is already set
+```
+
+`CLOUDFLARE_ACCOUNT_ID` matches the Cloudflare account that owns R2
+(`R2_ACCOUNT_ID` in Doppler).
+
+## Inspect the active widget
+
+```bash
+doppler run --project jovie-web --config prd -- \
+  pnpm tsx scripts/turnstile-config.ts show
+```
+
+## Add missing hostnames (preferred automation)
+
+Preview:
+
+```bash
+doppler run --project jovie-web --config prd -- \
+  pnpm tsx scripts/turnstile-config.ts ensure-hostnames --dry-run
+```
+
+Apply after review:
+
+```bash
+doppler run --project jovie-web --config prd -- \
+  pnpm tsx scripts/turnstile-config.ts ensure-hostnames --yes --allow-prod
+```
+
+Include staging hostnames in the same widget:
+
+```bash
+doppler run --project jovie-web --config prd -- \
+  pnpm tsx scripts/turnstile-config.ts ensure-hostnames \
+    --target all --yes --allow-prod
+```
+
+## Manual dashboard fallback
+
+1. Open Cloudflare → Turnstile → select the widget used by
+   `NEXT_PUBLIC_TURNSTILE_SITE_KEY`.
+2. Settings → Hostname Management → Add Hostnames.
+3. Add `jov.ie` and `www.jov.ie` (and staging hostnames if needed).
+4. Re-test `https://jov.ie/start` — the widget must not show
+   `Verification failed (110200)` or `Turnstile is not configured`.
+
+## Verification
+
+Production smoke checks:
+
+```bash
+# Read-only synthetic golden path (CI)
+pnpm --filter=@jovie/web exec playwright test tests/e2e/synthetic-golden-path.spec.ts
+
+# Signup readiness (env only)
+doppler run --project jovie-web --config prd -- \
+  pnpm --filter=@jovie/web run check:signup-readiness -- --target=prd
+```
+
+Healthy `/start` behavior:
+
+- Page returns `200`
+- No `turnstile is not configured` copy
+- No `Verification failed (110200)` copy
+- First anonymous onboarding chat POST reaches the Turnstile gate instead of
+  failing client-side
+
+## Creating `CLOUDFLARE_API_TOKEN`
+
+Create a custom token in the Cloudflare dashboard with:
+
+- Permission: **Turnstile Sites Read**
+- Permission: **Turnstile Sites Write**
+- Account resource: the Jovie account (`fd8a6fcfa0ff0b708dbae942af18c49b`)
+
+Store the token in Doppler `jovie-web/prd` (and `stg` if operators run the
+script there). Do not commit token values to Git.
+
+## Related
+
+- `scripts/turnstile-config.ts` — hostname automation
+- `apps/web/lib/turnstile/verify.ts` — server-side siteverify helper
+- `docs/DOPPLER_SETUP.md` — production signup readiness keys
+- `docs/SYNTHETIC_MONITORING.md` — `/start` Turnstile smoke coverage

--- a/scripts/turnstile-config.ts
+++ b/scripts/turnstile-config.ts
@@ -1,0 +1,452 @@
+#!/usr/bin/env -S tsx
+
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Cloudflare Turnstile widget automation (JOV-2329).
+ *
+ * Manages Turnstile widget hostname allowlists via the Cloudflare API so
+ * production /start no longer fails with client error 110200 (domain not
+ * authorized).
+ *
+ * Usage (via Doppler for account + site key context):
+ *   doppler run --project jovie-web --config prd -- \
+ *     pnpm tsx scripts/turnstile-config.ts list
+ *
+ *   doppler run --project jovie-web --config prd -- \
+ *     pnpm tsx scripts/turnstile-config.ts show
+ *
+ *   # Preview hostname additions (default)
+ *   doppler run --project jovie-web --config prd -- \
+ *     pnpm tsx scripts/turnstile-config.ts ensure-hostnames --dry-run
+ *
+ *   # Apply after review
+ *   doppler run --project jovie-web --config prd -- \
+ *     pnpm tsx scripts/turnstile-config.ts ensure-hostnames --yes --allow-prod
+ *
+ * Required env:
+ *   CLOUDFLARE_API_TOKEN — API token with Turnstile Sites Read/Write
+ *   CLOUDFLARE_ACCOUNT_ID — defaults to R2_ACCOUNT_ID when present
+ *   NEXT_PUBLIC_TURNSTILE_SITE_KEY — widget sitekey to inspect/update
+ *
+ * See docs/TURNSTILE_SETUP.md for dashboard fallback and token creation.
+ */
+
+const CLOUDFLARE_API_BASE = 'https://api.cloudflare.com/client/v4';
+
+export const PRODUCTION_TURNSTILE_HOSTNAMES = ['jov.ie', 'www.jov.ie'] as const;
+
+export const STAGING_TURNSTILE_HOSTNAMES = [
+  'staging.jov.ie',
+  'main.jov.ie',
+] as const;
+
+export type TurnstileHostnameTarget = 'prod' | 'staging' | 'all';
+
+export interface TurnstileWidget {
+  readonly sitekey: string;
+  readonly name?: string;
+  readonly mode?: string;
+  readonly domains: readonly string[];
+  readonly clearance_level?: string;
+}
+
+export interface TurnstileConfigOptions {
+  readonly accountId?: string;
+  readonly siteKey?: string;
+  readonly apiToken?: string;
+  readonly dryRun?: boolean;
+  readonly yes?: boolean;
+  readonly allowProd?: boolean;
+  readonly target?: TurnstileHostnameTarget;
+  readonly verbose?: boolean;
+}
+
+interface CloudflareApiResponse<T> {
+  readonly success: boolean;
+  readonly errors?: readonly { code?: number; message?: string }[];
+  readonly result?: T;
+}
+
+function logAudit(action: string, details: Record<string, unknown>): void {
+  const ts = new Date().toISOString();
+  console.error(
+    `[turnstile-config-audit ${ts}] ${action} ${JSON.stringify(details)}`
+  );
+}
+
+export function resolveHostnameTarget(
+  target: TurnstileHostnameTarget = 'prod'
+): readonly string[] {
+  switch (target) {
+    case 'staging':
+      return STAGING_TURNSTILE_HOSTNAMES;
+    case 'all':
+      return [
+        ...PRODUCTION_TURNSTILE_HOSTNAMES,
+        ...STAGING_TURNSTILE_HOSTNAMES,
+      ];
+    case 'prod':
+    default:
+      return PRODUCTION_TURNSTILE_HOSTNAMES;
+  }
+}
+
+export function mergeHostnameAllowlist(
+  existingDomains: readonly string[],
+  requiredHostnames: readonly string[]
+): string[] {
+  const merged = new Set(
+    existingDomains.map(domain => domain.trim().toLowerCase())
+  );
+  for (const hostname of requiredHostnames) {
+    merged.add(hostname.trim().toLowerCase());
+  }
+  return [...merged].sort();
+}
+
+export function missingHostnames(
+  existingDomains: readonly string[],
+  requiredHostnames: readonly string[]
+): string[] {
+  const existing = new Set(
+    existingDomains.map(domain => domain.trim().toLowerCase())
+  );
+  return requiredHostnames.filter(
+    hostname => !existing.has(hostname.toLowerCase())
+  );
+}
+
+function getApiToken(options: TurnstileConfigOptions): string {
+  const token = options.apiToken ?? process.env.CLOUDFLARE_API_TOKEN;
+  if (!token?.trim()) {
+    throw new Error(
+      'CLOUDFLARE_API_TOKEN is required. Create a token with Turnstile Sites Read/Write ' +
+        'in the Cloudflare dashboard and store it in Doppler (jovie-web/prd). ' +
+        'See docs/TURNSTILE_SETUP.md.'
+    );
+  }
+  return token.trim();
+}
+
+function getAccountId(options: TurnstileConfigOptions): string {
+  const accountId =
+    options.accountId ??
+    process.env.CLOUDFLARE_ACCOUNT_ID ??
+    process.env.R2_ACCOUNT_ID;
+  if (!accountId?.trim()) {
+    throw new Error(
+      'CLOUDFLARE_ACCOUNT_ID (or R2_ACCOUNT_ID) is required to call the Turnstile API.'
+    );
+  }
+  return accountId.trim();
+}
+
+function getSiteKey(options: TurnstileConfigOptions): string {
+  const siteKey = options.siteKey ?? process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
+  if (!siteKey?.trim()) {
+    throw new Error(
+      'NEXT_PUBLIC_TURNSTILE_SITE_KEY is required. Load via Doppler for the target environment.'
+    );
+  }
+  return siteKey.trim();
+}
+
+async function cloudflareRequest<T>(
+  path: string,
+  options: TurnstileConfigOptions,
+  init?: RequestInit
+): Promise<T> {
+  const token = getApiToken(options);
+  const response = await fetch(`${CLOUDFLARE_API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      ...(init?.headers ?? {}),
+    },
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  const payload = (await response.json()) as CloudflareApiResponse<T>;
+  if (!response.ok || !payload.success) {
+    const message =
+      payload.errors?.map(error => error.message).join('; ') ||
+      `HTTP ${response.status}`;
+    throw new Error(`Cloudflare API error: ${message}`);
+  }
+
+  if (payload.result === undefined) {
+    throw new Error(
+      'Cloudflare API returned success without a result payload.'
+    );
+  }
+
+  return payload.result;
+}
+
+function normalizeWidget(raw: Record<string, unknown>): TurnstileWidget {
+  const domains = Array.isArray(raw.domains)
+    ? raw.domains.filter(
+        (domain): domain is string => typeof domain === 'string'
+      )
+    : [];
+
+  return {
+    sitekey:
+      typeof raw.sitekey === 'string'
+        ? raw.sitekey
+        : typeof raw.id === 'string'
+          ? raw.id
+          : '',
+    name: typeof raw.name === 'string' ? raw.name : undefined,
+    mode: typeof raw.mode === 'string' ? raw.mode : undefined,
+    domains,
+    clearance_level:
+      typeof raw.clearance_level === 'string' ? raw.clearance_level : undefined,
+  };
+}
+
+export async function listTurnstileWidgets(
+  options: TurnstileConfigOptions = {}
+): Promise<TurnstileWidget[]> {
+  const accountId = getAccountId(options);
+  const result = await cloudflareRequest<Record<string, unknown>[]>(
+    `/accounts/${accountId}/challenges/widgets`,
+    options,
+    { method: 'GET' }
+  );
+
+  return result.map(widget => normalizeWidget(widget));
+}
+
+export async function getTurnstileWidget(
+  options: TurnstileConfigOptions = {}
+): Promise<TurnstileWidget> {
+  const accountId = getAccountId(options);
+  const siteKey = getSiteKey(options);
+  const result = await cloudflareRequest<Record<string, unknown>>(
+    `/accounts/${accountId}/challenges/widgets/${siteKey}`,
+    options,
+    { method: 'GET' }
+  );
+  return normalizeWidget(result);
+}
+
+export async function updateTurnstileWidgetDomains(
+  widget: TurnstileWidget,
+  domains: readonly string[],
+  options: TurnstileConfigOptions = {}
+): Promise<TurnstileWidget> {
+  const accountId = getAccountId(options);
+  const body = {
+    domains: [...domains],
+    ...(widget.name ? { name: widget.name } : {}),
+    ...(widget.mode ? { mode: widget.mode } : {}),
+    ...(widget.clearance_level
+      ? { clearance_level: widget.clearance_level }
+      : {}),
+  };
+
+  const result = await cloudflareRequest<Record<string, unknown>>(
+    `/accounts/${accountId}/challenges/widgets/${widget.sitekey}`,
+    options,
+    {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    }
+  );
+
+  return normalizeWidget(result);
+}
+
+export async function ensureTurnstileHostnames(
+  options: TurnstileConfigOptions = {}
+): Promise<{
+  readonly changed: boolean;
+  readonly widget: TurnstileWidget;
+  readonly added: readonly string[];
+  readonly domains: readonly string[];
+}> {
+  const required = resolveHostnameTarget(options.target);
+  const widget = await getTurnstileWidget(options);
+  const added = missingHostnames(widget.domains, required);
+  const domains = mergeHostnameAllowlist(widget.domains, required);
+
+  if (added.length === 0) {
+    return { changed: false, widget, added, domains: widget.domains };
+  }
+
+  if (options.dryRun || !options.yes) {
+    return { changed: true, widget, added, domains };
+  }
+
+  const updated = await updateTurnstileWidgetDomains(widget, domains, options);
+  return { changed: true, widget: updated, added, domains: updated.domains };
+}
+
+async function cmdList(options: TurnstileConfigOptions): Promise<void> {
+  const widgets = await listTurnstileWidgets(options);
+  console.log(JSON.stringify(widgets, null, 2));
+}
+
+async function cmdShow(options: TurnstileConfigOptions): Promise<void> {
+  const widget = await getTurnstileWidget(options);
+  console.log(JSON.stringify(widget, null, 2));
+}
+
+async function cmdEnsureHostnames(
+  options: TurnstileConfigOptions
+): Promise<void> {
+  const required = resolveHostnameTarget(options.target);
+  const result = await ensureTurnstileHostnames(options);
+
+  const payload = {
+    sitekey: result.widget.sitekey,
+    target: options.target ?? 'prod',
+    required,
+    currentDomains: result.widget.domains,
+    added: result.added,
+    nextDomains: result.domains,
+    dryRun: Boolean(options.dryRun || !options.yes),
+    applied: result.changed && !options.dryRun && Boolean(options.yes),
+  };
+
+  console.log(JSON.stringify(payload, null, 2));
+
+  if (result.added.length === 0) {
+    console.error('✅ Required hostnames are already present on the widget.');
+    return;
+  }
+
+  if (options.dryRun || !options.yes) {
+    console.error(
+      `DRY RUN: would add hostnames: ${result.added.join(', ')}. ` +
+        'Re-run with --yes to apply.'
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  logAudit('ensure-hostnames', {
+    sitekey: result.widget.sitekey,
+    added: result.added,
+    domains: result.domains,
+  });
+  console.error(
+    `✅ Updated widget hostnames. Added: ${result.added.join(', ')}`
+  );
+}
+
+function assertProdMutationAllowed(options: TurnstileConfigOptions): void {
+  const target = options.target ?? 'prod';
+  const touchesProd = target === 'prod' || target === 'all';
+  if (touchesProd && !options.allowProd) {
+    throw new Error(
+      'SAFETY: production hostname changes require --allow-prod. ' +
+        'Preview with --dry-run first.'
+    );
+  }
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  if (argv.length === 0 || argv.includes('--help') || argv.includes('-h')) {
+    console.log(`
+Cloudflare Turnstile widget automation (JOV-2329)
+
+Subcommands:
+  list                         List all Turnstile widgets for the account
+  show                         Show the widget referenced by NEXT_PUBLIC_TURNSTILE_SITE_KEY
+  ensure-hostnames [options]   Add required Jovie hostnames to the active widget
+
+Options:
+  --target <prod|staging|all>  Hostname set to enforce (default: prod)
+  --dry-run                    Preview changes without applying (default for mutations)
+  --yes                        Apply hostname updates
+  --allow-prod                 Permit production hostname mutations
+  --account-id <id>            Override CLOUDFLARE_ACCOUNT_ID / R2_ACCOUNT_ID
+  --site-key <key>             Override NEXT_PUBLIC_TURNSTILE_SITE_KEY
+  --verbose                    Reserved for future verbose logging
+
+Examples:
+  doppler run --project jovie-web --config prd -- \\
+    pnpm tsx scripts/turnstile-config.ts show
+
+  doppler run --project jovie-web --config prd -- \\
+    pnpm tsx scripts/turnstile-config.ts ensure-hostnames --dry-run
+
+  doppler run --project jovie-web --config prd -- \\
+    pnpm tsx scripts/turnstile-config.ts ensure-hostnames --yes --allow-prod
+`);
+    return;
+  }
+
+  const sub = argv[0];
+  const options: TurnstileConfigOptions = {
+    dryRun: true,
+    target: 'prod',
+  };
+
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--target' && argv[i + 1]) {
+      options.target = argv[++i] as TurnstileHostnameTarget;
+      continue;
+    }
+    if (arg === '--dry-run') {
+      options.dryRun = true;
+      continue;
+    }
+    if (arg === '--yes') {
+      options.yes = true;
+      options.dryRun = false;
+      continue;
+    }
+    if (arg === '--allow-prod') {
+      options.allowProd = true;
+      continue;
+    }
+    if (arg === '--account-id' && argv[i + 1]) {
+      options.accountId = argv[++i];
+      continue;
+    }
+    if (arg === '--site-key' && argv[i + 1]) {
+      options.siteKey = argv[++i];
+      continue;
+    }
+    if (arg === '--verbose') {
+      options.verbose = true;
+      continue;
+    }
+  }
+
+  if (sub === 'ensure-hostnames') {
+    assertProdMutationAllowed(options);
+  }
+
+  switch (sub) {
+    case 'list':
+      await cmdList(options);
+      break;
+    case 'show':
+      await cmdShow(options);
+      break;
+    case 'ensure-hostnames':
+      await cmdEnsureHostnames(options);
+      break;
+    default:
+      throw new Error(`Unknown subcommand "${sub}". Run with --help.`);
+  }
+}
+
+const isMain =
+  import.meta.url === pathToFileURL(process.argv[1] ?? '').href ||
+  process.argv[1]?.endsWith('turnstile-config.ts');
+
+if (isMain) {
+  main().catch(error => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Goal

Fix production `/start` Turnstile failures (Cloudflare client error `110200` — domain not authorized) by adding repeatable hostname management for the active production widget.

<!-- linear-issue-id:JOV-2329 -->

## Context

- Doppler `prd` already has `NEXT_PUBLIC_TURNSTILE_SITE_KEY` + `TURNSTILE_SECRET_KEY`
- Production `/start` still fails when `jov.ie` / `www.jov.ie` are missing from the Cloudflare Turnstile widget Hostname Management allowlist
- Wrangler OAuth lacks Turnstile Sites scopes; automation requires a dedicated `CLOUDFLARE_API_TOKEN`

## Changes

- Add `scripts/turnstile-config.ts` (list/show/ensure-hostnames with dry-run + `--allow-prod` guard)
- Add `docs/TURNSTILE_SETUP.md` operator runbook
- Document `CLOUDFLARE_API_TOKEN` in `.env.example` + `docs/DOPPLER_SETUP.md`
- Add unit tests for hostname merge logic
- Extend synthetic monitoring to fail on `verification failed (110200)`
- Log operator follow-up in `AUTH_FIX_LOG.md`

## Post-merge operator action (required to complete JOV-2329)

1. Create `CLOUDFLARE_API_TOKEN` with **Turnstile Sites Read + Write** for account `fd8a6fcfa0ff0b708dbae942af18c49b`
2. Store in Doppler `jovie-web/prd`
3. Preview: `doppler run --project jovie-web --config prd -- pnpm tsx scripts/turnstile-config.ts ensure-hostnames --dry-run`
4. Apply: `doppler run --project jovie-web --config prd -- pnpm tsx scripts/turnstile-config.ts ensure-hostnames --yes --allow-prod`
5. Verify `https://jov.ie/start` no longer shows `110200`

## Testing

- `pnpm --filter=@jovie/web exec vitest run tests/unit/scripts/turnstile-config-script.test.ts`
- `pnpm biome check scripts/turnstile-config.ts docs/TURNSTILE_SETUP.md`
- Live Playwright probe confirmed Turnstile challenge loads on `/start` after first message; hostname allowlist update still required via Cloudflare API