### PR TITLE
fix(tasks): send single order anchor on board drag

### DIFF
--- a/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
+++ b/apps/web/components/features/dashboard/tasks/TaskBoard.tsx
@@ -24,7 +24,10 @@ import { Disc3, Plus } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
 import { ReleaseDueBadge } from '@/components/molecules/ReleaseDueBadge';
 import { type ContextMenuItemType } from '@/components/organisms/table';
-import { TASK_BOARD_STATUSES } from '@/lib/tasks/task-board';
+import {
+  getTaskBoardColumnDroppableId,
+  resolveTaskBoardMoveInput,
+} from '@/lib/tasks/task-board';
 import type {
   MoveTaskInput,
   TaskBoardColumnResult,
@@ -65,17 +68,6 @@ const TASK_AGENT_STATUS_LABELS: Partial<
   failed: 'Failed',
 };
 
-function getColumnDroppableId(status: TaskStatus): string {
-  return `task-board-column:${status}`;
-}
-
-function getStatusFromColumnDroppableId(id: string): TaskStatus | null {
-  const status = id.replace('task-board-column:', '');
-  return TASK_BOARD_STATUSES.includes(status as TaskStatus)
-    ? (status as TaskStatus)
-    : null;
-}
-
 function findBoardTask(
   columns: ReadonlyArray<TaskBoardColumnResult>,
   taskId: string
@@ -86,116 +78,6 @@ function findBoardTask(
   }
 
   return null;
-}
-
-function findTaskStatus(
-  columns: ReadonlyArray<TaskBoardColumnResult>,
-  taskId: string
-): TaskStatus | null {
-  return (
-    columns.find(column => column.tasks.some(task => task.id === taskId))
-      ?.status ?? null
-  );
-}
-
-function resolveDropInsertIndex({
-  overTaskIndex,
-  destinationLength,
-  isSameColumn,
-  sourceIndex,
-  overIndex,
-}: Readonly<{
-  overTaskIndex: number;
-  destinationLength: number;
-  isSameColumn: boolean;
-  sourceIndex: number;
-  overIndex: number;
-}>): number {
-  if (overTaskIndex === -1) {
-    return destinationLength;
-  }
-
-  if (isSameColumn && sourceIndex < overIndex) {
-    return overTaskIndex + 1;
-  }
-
-  return overTaskIndex;
-}
-
-function resolveTaskBoardMoveInput({
-  activeTaskId,
-  overId,
-  columns,
-}: Readonly<{
-  activeTaskId: string;
-  overId: string;
-  columns: ReadonlyArray<TaskBoardColumnResult>;
-}>): MoveTaskInput | null {
-  const activeTask = findBoardTask(columns, activeTaskId);
-  if (!activeTask || activeTask.id === overId) {
-    return null;
-  }
-
-  const overColumnStatus =
-    getStatusFromColumnDroppableId(overId) ?? findTaskStatus(columns, overId);
-  if (!overColumnStatus) {
-    return null;
-  }
-
-  const destinationColumn = columns.find(
-    column => column.status === overColumnStatus
-  );
-  if (!destinationColumn) {
-    return null;
-  }
-
-  const destinationTasksWithoutActive = destinationColumn.tasks.filter(
-    task => task.id !== activeTaskId
-  );
-  const overTaskIndex = destinationTasksWithoutActive.findIndex(
-    task => task.id === overId
-  );
-  const sourceColumn = columns.find(
-    column => column.status === activeTask.status
-  );
-  const sourceIndex =
-    sourceColumn?.tasks.findIndex(task => task.id === activeTaskId) ?? -1;
-  const overIndex =
-    destinationColumn.tasks.findIndex(task => task.id === overId) ?? -1;
-  const insertIndex = resolveDropInsertIndex({
-    overTaskIndex,
-    destinationLength: destinationTasksWithoutActive.length,
-    isSameColumn: activeTask.status === overColumnStatus,
-    sourceIndex,
-    overIndex,
-  });
-  const beforeTaskId = destinationTasksWithoutActive[insertIndex]?.id ?? null;
-  const afterTaskId =
-    destinationTasksWithoutActive[insertIndex - 1]?.id ?? null;
-
-  if (activeTask.status === overColumnStatus && sourceColumn) {
-    const sourceTasksWithoutActive = sourceColumn.tasks.filter(
-      task => task.id !== activeTaskId
-    );
-    const currentBeforeTaskId =
-      sourceTasksWithoutActive[sourceIndex]?.id ?? null;
-    const currentAfterTaskId =
-      sourceTasksWithoutActive[sourceIndex - 1]?.id ?? null;
-
-    if (
-      currentBeforeTaskId === beforeTaskId &&
-      currentAfterTaskId === afterTaskId
-    ) {
-      return null;
-    }
-  }
-
-  return {
-    taskId: activeTaskId,
-    toStatus: overColumnStatus,
-    beforeTaskId,
-    afterTaskId,
-  };
 }
 
 function useVisibleTaskBoardColumns({
@@ -338,7 +220,7 @@ function TaskBoardColumn({
   const accent = getAccentCssVars(visual.accent);
   const StatusIcon = visual.icon;
   const { setNodeRef, isOver } = useDroppable({
-    id: getColumnDroppableId(column.status),
+    id: getTaskBoardColumnDroppableId(column.status),
     data: { type: 'column', status: column.status },
   });
 

--- a/apps/web/lib/tasks/task-board.test.ts
+++ b/apps/web/lib/tasks/task-board.test.ts
@@ -4,8 +4,14 @@ import {
   applyTaskListMove,
   compareTasksByBoardOrder,
   getVisibleTaskBoardStatuses,
+  resolveTaskBoardMoveInput,
 } from './task-board';
-import type { TaskBoardResult, TaskStatus, TaskView } from './types';
+import type {
+  TaskBoardColumnResult,
+  TaskBoardResult,
+  TaskStatus,
+  TaskView,
+} from './types';
 
 function createTask(
   id: string,
@@ -45,7 +51,7 @@ function createTask(
   };
 }
 
-function createBoard(tasks: TaskView[]): TaskBoardResult {
+function createColumns(tasks: TaskView[]): TaskBoardColumnResult[] {
   const statuses: TaskStatus[] = [
     'backlog',
     'todo',
@@ -54,18 +60,34 @@ function createBoard(tasks: TaskView[]): TaskBoardResult {
     'cancelled',
   ];
 
+  return statuses.map(status => {
+    const columnTasks = tasks.filter(task => task.status === status);
+    return {
+      status,
+      tasks: columnTasks,
+      totalCount: columnTasks.length,
+      nextCursor: null,
+    };
+  });
+}
+
+function createBoard(tasks: TaskView[]): TaskBoardResult {
   return {
-    columns: statuses.map(status => {
-      const columnTasks = tasks.filter(task => task.status === status);
-      return {
-        status,
-        tasks: columnTasks,
-        totalCount: columnTasks.length,
-        nextCursor: null,
-      };
-    }),
+    columns: createColumns(tasks),
     totalCount: tasks.length,
   };
+}
+
+function expectSingleAnchor(
+  input: ReturnType<typeof resolveTaskBoardMoveInput>
+): void {
+  expect(input).not.toBeNull();
+  if (!input) return;
+
+  const anchorCount = [input.beforeTaskId, input.afterTaskId].filter(
+    Boolean
+  ).length;
+  expect(anchorCount).toBeLessThanOrEqual(1);
 }
 
 describe('task board helpers', () => {
@@ -138,6 +160,72 @@ describe('task board helpers', () => {
     expect(
       moved?.columns.find(column => column.status === 'done')?.totalCount
     ).toBe(2);
+  });
+
+  it('resolves same-column middle moves with only a before anchor', () => {
+    const columns = createColumns([
+      createTask('todo-1', 'todo', 1),
+      createTask('todo-2', 'todo', 2),
+      createTask('todo-3', 'todo', 3),
+      createTask('todo-4', 'todo', 4),
+    ]);
+
+    const input = resolveTaskBoardMoveInput({
+      activeTaskId: 'todo-1',
+      overId: 'todo-3',
+      columns,
+    });
+
+    expectSingleAnchor(input);
+    expect(input).toEqual({
+      taskId: 'todo-1',
+      toStatus: 'todo',
+      beforeTaskId: 'todo-4',
+    });
+    expect(input?.afterTaskId).toBeUndefined();
+  });
+
+  it('resolves end-of-column moves with only an after anchor', () => {
+    const columns = createColumns([
+      createTask('todo-1', 'todo', 1),
+      createTask('todo-2', 'todo', 2),
+    ]);
+
+    const input = resolveTaskBoardMoveInput({
+      activeTaskId: 'todo-1',
+      overId: 'task-board-column:todo',
+      columns,
+    });
+
+    expectSingleAnchor(input);
+    expect(input).toEqual({
+      taskId: 'todo-1',
+      toStatus: 'todo',
+      afterTaskId: 'todo-2',
+    });
+  });
+
+  it('returns null when a drag would leave the task in the same position', () => {
+    const columns = createColumns([
+      createTask('todo-1', 'todo', 1),
+      createTask('todo-2', 'todo', 2),
+    ]);
+
+    expect(
+      resolveTaskBoardMoveInput({
+        activeTaskId: 'todo-1',
+        overId: 'todo-1',
+        columns,
+      })
+    ).toBeNull();
+
+    expect(
+      resolveTaskBoardMoveInput({
+        activeTaskId: 'todo-2',
+        overId: 'todo-2',
+        columns,
+      })
+    ).toBeNull();
   });
 
   it('applies optimistic list status updates with canonical ordering', () => {

--- a/apps/web/lib/tasks/task-board.ts
+++ b/apps/web/lib/tasks/task-board.ts
@@ -1,5 +1,6 @@
 import type {
   MoveTaskInput,
+  TaskBoardColumnResult,
   TaskBoardResult,
   TaskListResult,
   TaskStatus,
@@ -82,6 +83,164 @@ function findTaskInBoard(
   }
 
   return null;
+}
+
+export function getTaskBoardColumnDroppableId(status: TaskStatus): string {
+  return `task-board-column:${status}`;
+}
+
+export function getTaskStatusFromBoardColumnDroppableId(
+  id: string
+): TaskStatus | null {
+  const status = id.replace('task-board-column:', '');
+  return TASK_BOARD_STATUSES.includes(status as TaskStatus)
+    ? (status as TaskStatus)
+    : null;
+}
+
+function findTaskInBoardColumns(
+  columns: ReadonlyArray<TaskBoardColumnResult>,
+  taskId: string
+): TaskView | null {
+  for (const column of columns) {
+    const task = column.tasks.find(candidate => candidate.id === taskId);
+    if (task) return task;
+  }
+
+  return null;
+}
+
+function findTaskStatusInBoardColumns(
+  columns: ReadonlyArray<TaskBoardColumnResult>,
+  taskId: string
+): TaskStatus | null {
+  return (
+    columns.find(column => column.tasks.some(task => task.id === taskId))
+      ?.status ?? null
+  );
+}
+
+export function resolveTaskBoardDropInsertIndex({
+  overTaskIndex,
+  destinationLength,
+  isSameColumn,
+  sourceIndex,
+  overIndex,
+}: Readonly<{
+  overTaskIndex: number;
+  destinationLength: number;
+  isSameColumn: boolean;
+  sourceIndex: number;
+  overIndex: number;
+}>): number {
+  if (overTaskIndex === -1) {
+    return destinationLength;
+  }
+
+  if (isSameColumn && sourceIndex < overIndex) {
+    return overTaskIndex + 1;
+  }
+
+  return overTaskIndex;
+}
+
+function toSingleAnchorMoveInput({
+  taskId,
+  toStatus,
+  beforeTaskId,
+  afterTaskId,
+}: Readonly<{
+  taskId: string;
+  toStatus: TaskStatus;
+  beforeTaskId: string | null;
+  afterTaskId: string | null;
+}>): MoveTaskInput {
+  if (beforeTaskId) {
+    return { taskId, toStatus, beforeTaskId };
+  }
+
+  if (afterTaskId) {
+    return { taskId, toStatus, afterTaskId };
+  }
+
+  return { taskId, toStatus };
+}
+
+export function resolveTaskBoardMoveInput({
+  activeTaskId,
+  overId,
+  columns,
+}: Readonly<{
+  activeTaskId: string;
+  overId: string;
+  columns: ReadonlyArray<TaskBoardColumnResult>;
+}>): MoveTaskInput | null {
+  const activeTask = findTaskInBoardColumns(columns, activeTaskId);
+  if (!activeTask || activeTask.id === overId) {
+    return null;
+  }
+
+  const overColumnStatus =
+    getTaskStatusFromBoardColumnDroppableId(overId) ??
+    findTaskStatusInBoardColumns(columns, overId);
+  if (!overColumnStatus) {
+    return null;
+  }
+
+  const destinationColumn = columns.find(
+    column => column.status === overColumnStatus
+  );
+  if (!destinationColumn) {
+    return null;
+  }
+
+  const destinationTasksWithoutActive = destinationColumn.tasks.filter(
+    task => task.id !== activeTaskId
+  );
+  const overTaskIndex = destinationTasksWithoutActive.findIndex(
+    task => task.id === overId
+  );
+  const sourceColumn = columns.find(
+    column => column.status === activeTask.status
+  );
+  const sourceIndex =
+    sourceColumn?.tasks.findIndex(task => task.id === activeTaskId) ?? -1;
+  const overIndex =
+    destinationColumn.tasks.findIndex(task => task.id === overId) ?? -1;
+  const insertIndex = resolveTaskBoardDropInsertIndex({
+    overTaskIndex,
+    destinationLength: destinationTasksWithoutActive.length,
+    isSameColumn: activeTask.status === overColumnStatus,
+    sourceIndex,
+    overIndex,
+  });
+  const beforeTaskId = destinationTasksWithoutActive[insertIndex]?.id ?? null;
+  const afterTaskId =
+    destinationTasksWithoutActive[insertIndex - 1]?.id ?? null;
+
+  if (activeTask.status === overColumnStatus && sourceColumn) {
+    const sourceTasksWithoutActive = sourceColumn.tasks.filter(
+      task => task.id !== activeTaskId
+    );
+    const currentBeforeTaskId =
+      sourceTasksWithoutActive[sourceIndex]?.id ?? null;
+    const currentAfterTaskId =
+      sourceTasksWithoutActive[sourceIndex - 1]?.id ?? null;
+
+    if (
+      currentBeforeTaskId === beforeTaskId &&
+      currentAfterTaskId === afterTaskId
+    ) {
+      return null;
+    }
+  }
+
+  return toSingleAnchorMoveInput({
+    taskId: activeTaskId,
+    toStatus: overColumnStatus,
+    beforeTaskId,
+    afterTaskId,
+  });
 }
 
 function resolveInsertIndex(


### PR DESCRIPTION
## Goal

Fix JOV-2968: dragging tasks on the task board was failing with "Provide only one task order anchor" because the client sent both `beforeTaskId` and `afterTaskId` for middle-column moves.

## Changes

- Extract task board drag move-input resolution into `task-board.ts`
- Prefer `beforeTaskId` when available; otherwise send `afterTaskId`
- Add regression tests covering middle, end, and no-op drag scenarios

## Testing

- `pnpm --filter @jovie/web test lib/tasks/task-board.test.ts`
- `pnpm turbo typecheck --filter=@jovie/web`
- Manual: drag a task between two others on the board and confirm reorder succeeds without error

<!-- linear-issue-id:JOV-2968 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized task board drag-and-drop logic into centralized reusable utilities, enhancing code maintainability and consistency.

* **Tests**
  * Expanded test coverage for task board drag-and-drop functionality with scenarios covering same-column repositioning, end-of-column moves, and edge cases where drops don't alter task ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->