### PR TITLE
fix(auth): add stale-cache fallback for proxy-state DB timeouts (JOV-2985)

### DIFF
--- a/apps/web/lib/auth/proxy-state.ts
+++ b/apps/web/lib/auth/proxy-state.ts
@@ -23,8 +23,14 @@ export interface ProxyUserState {
 // Safe to use longer TTLs because all state transitions (waitlist approval,
 // onboarding completion, user deletion) explicitly call invalidateProxyUserStateCache().
 const USER_STATE_CACHE_KEY_PREFIX = 'proxy:user-state:';
+const USER_STATE_STALE_CACHE_KEY_PREFIX = 'proxy:user-state:stale:';
 const USER_STATE_CACHE_TTL_SECONDS = 120; // 2 minutes - transitional users (invalidation is explicit)
 const USER_STATE_CACHE_TTL_ACTIVE_SECONDS = 300; // 5 minutes - stable active users
+// Longer-lived stale snapshot used when the primary cache expires but Neon is
+// still waking up. State transitions call invalidateProxyUserStateCache() so
+// stale entries cannot outlive an explicit status change.
+const USER_STATE_STALE_CACHE_TTL_SECONDS = 1800; // 30 minutes
+const USER_STATE_STALE_CACHE_TTL_ACTIVE_SECONDS = 3600; // 1 hour - stable active users
 
 // Timeout for DB query to prevent proxy hanging on Neon cold starts.
 // Kept below the Neon p99 cold-start budget (~3 s) so that a single cache-miss
@@ -94,6 +100,18 @@ function getTtlForUserState(state: ProxyUserState): number {
   return USER_STATE_CACHE_TTL_SECONDS;
 }
 
+function getStaleTtlForUserState(state: ProxyUserState): number {
+  if (state.isActive) return USER_STATE_STALE_CACHE_TTL_ACTIVE_SECONDS;
+  return USER_STATE_STALE_CACHE_TTL_SECONDS;
+}
+
+function getStaleCacheKey(cacheKey: string): string {
+  return cacheKey.replace(
+    USER_STATE_CACHE_KEY_PREFIX,
+    USER_STATE_STALE_CACHE_KEY_PREFIX
+  );
+}
+
 /**
  * Try to get user state from Redis cache
  */
@@ -147,6 +165,52 @@ async function tryGetCachedState(
   return null;
 }
 
+/**
+ * Try to get user state from the longer-lived stale Redis snapshot.
+ * Used when the primary cache has expired and the DB is slow or timing out.
+ */
+async function tryGetStaleCachedState(
+  cacheKey: string,
+  clerkUserId: string
+): Promise<ProxyUserState | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+
+  const staleCacheKey = getStaleCacheKey(cacheKey);
+
+  try {
+    const cacheStart = Date.now();
+    const redisTimeoutPromise = new Promise<null>(resolve => {
+      setTimeout(() => resolve(null), REDIS_CACHE_TIMEOUT_MS);
+    });
+    const cached = await Promise.race([
+      redis.get<ProxyUserState>(staleCacheKey),
+      redisTimeoutPromise,
+    ]);
+    const cacheDuration = Date.now() - cacheStart;
+
+    if (cached) {
+      Sentry.addBreadcrumb({
+        category: 'proxy-state',
+        message: 'Stale cache hit',
+        level: 'info',
+        data: {
+          cacheKey: staleCacheKey.replace(clerkUserId, '[REDACTED]'),
+          durationMs: cacheDuration,
+          userState: getUserStateLabel(cached),
+        },
+      });
+      return cached;
+    }
+  } catch (cacheError) {
+    captureWarning('[proxy-state] Redis stale cache read failed', {
+      error: cacheError,
+    });
+  }
+
+  return null;
+}
+
 /** Statuses that indicate waitlist approval */
 const APPROVED_STATUSES = [
   'waitlist_approved',
@@ -170,7 +234,6 @@ function hasCompleteProfile(result: {
   profileUsername: string | null;
   profileUsernameNormalized: string | null;
   profileDisplayName: string | null;
-  profileAvatarUrl: string | null;
   profileIsPublic: boolean | null;
 }): boolean {
   if (!result.profileId) return false;
@@ -197,7 +260,6 @@ function determineUserState(
         profileUsername: string | null;
         profileUsernameNormalized: string | null;
         profileDisplayName: string | null;
-        profileAvatarUrl: string | null;
         profileIsPublic: boolean | null;
       }
     | undefined,
@@ -247,12 +309,18 @@ function determineUserState(
 function cacheUserState(
   cacheKey: string,
   userState: ProxyUserState,
-  ttlSeconds: number
+  ttlSeconds: number,
+  staleTtlSeconds: number
 ): void {
   const redis = getRedis();
   if (!redis) return;
 
-  redis.set(cacheKey, userState, { ex: ttlSeconds }).catch(cacheError => {
+  const staleCacheKey = getStaleCacheKey(cacheKey);
+
+  Promise.all([
+    redis.set(cacheKey, userState, { ex: ttlSeconds }),
+    redis.set(staleCacheKey, userState, { ex: staleTtlSeconds }),
+  ]).catch(cacheError => {
     captureWarning('[proxy-state] Redis cache write failed', {
       error: cacheError,
     });
@@ -313,7 +381,6 @@ async function executeUserStateQuery(clerkUserId: string) {
           profileUsername: creatorProfiles.username,
           profileUsernameNormalized: creatorProfiles.usernameNormalized,
           profileDisplayName: creatorProfiles.displayName,
-          profileAvatarUrl: creatorProfiles.avatarUrl,
           profileIsPublic: creatorProfiles.isPublic,
         })
         .from(users)
@@ -416,18 +483,49 @@ export async function getUserState(
     // Populate both cache layers
     setMemoryCachedState(cacheKey, userState);
     const ttl = getTtlForUserState(userState);
-    cacheUserState(cacheKey, userState, ttl);
+    const staleTtl = getStaleTtlForUserState(userState);
+    cacheUserState(cacheKey, userState, ttl, staleTtl);
 
     return userState;
   } catch (error) {
-    const isTransient =
-      error instanceof QueryTimeoutError || isRetryableError(error);
+    const isTimeout = error instanceof QueryTimeoutError;
+    const isTransient = isTimeout || isRetryableError(error);
 
-    await captureError('Database query failed in proxy state check', error, {
-      clerkUserId,
-      operation: 'getProxyUserState',
-      errorType: isTransient ? 'transient' : 'persistent',
-    });
+    const staleCached = await tryGetStaleCachedState(cacheKey, clerkUserId);
+    if (staleCached) {
+      await captureWarning(
+        '[proxy-state] Serving stale cache after DB failure',
+        error,
+        {
+          clerkUserId,
+          operation: 'getProxyUserState',
+          errorType: isTransient ? 'transient' : 'persistent',
+          fallback: 'stale-cache',
+        }
+      );
+      setMemoryCachedState(cacheKey, staleCached);
+      return staleCached;
+    }
+
+    if (isTimeout) {
+      await captureWarning(
+        '[proxy-state] DB query timed out without stale cache fallback',
+        error,
+        {
+          clerkUserId,
+          operation: 'getProxyUserState',
+          errorType: 'transient',
+          fallback: 'needs-onboarding',
+        }
+      );
+    } else {
+      await captureError('Database query failed in proxy state check', error, {
+        clerkUserId,
+        operation: 'getProxyUserState',
+        errorType: isTransient ? 'transient' : 'persistent',
+        fallback: 'needs-onboarding',
+      });
+    }
 
     return { ...NEEDS_ONBOARDING_STATE };
   }
@@ -462,7 +560,10 @@ export async function invalidateProxyUserStateCache(
   if (!redis) return;
 
   try {
-    await redis.del(cacheKey);
+    await Promise.all([
+      redis.del(cacheKey),
+      redis.del(getStaleCacheKey(cacheKey)),
+    ]);
   } catch (error) {
     captureWarning('[proxy-state] Failed to invalidate cache', { error });
   }

--- a/apps/web/tests/unit/lib/auth/proxy-state.test.ts
+++ b/apps/web/tests/unit/lib/auth/proxy-state.test.ts
@@ -1,10 +1,28 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Hoist mocks before module resolution
-const { mockDbSelect, mockIsWaitlistGateEnabled } = vi.hoisted(() => ({
-  mockDbSelect: vi.fn(),
-  mockIsWaitlistGateEnabled: vi.fn().mockResolvedValue(true),
-}));
+const {
+  mockDbSelect,
+  mockIsWaitlistGateEnabled,
+  mockRedisGet,
+  mockRedisSet,
+  mockRedisDel,
+  mockGetRedis,
+} = vi.hoisted(() => {
+  const mockRedisGet = vi.fn();
+  const mockRedisSet = vi.fn().mockResolvedValue('OK');
+  const mockRedisDel = vi.fn().mockResolvedValue(1);
+  const mockGetRedis = vi.fn().mockReturnValue(null);
+
+  return {
+    mockDbSelect: vi.fn(),
+    mockIsWaitlistGateEnabled: vi.fn().mockResolvedValue(true),
+    mockRedisGet,
+    mockRedisSet,
+    mockRedisDel,
+    mockGetRedis,
+  };
+});
 
 // Mock database
 vi.mock('@/lib/db', () => ({
@@ -54,7 +72,7 @@ vi.mock('@/lib/sentry/init', () => ({
 }));
 
 vi.mock('@/lib/redis', () => ({
-  getRedis: vi.fn().mockReturnValue(null),
+  getRedis: mockGetRedis,
 }));
 
 // Mock retry to skip exponential backoff delays — just execute the operation once
@@ -68,21 +86,28 @@ vi.mock('@/lib/waitlist/settings', () => ({
   isWaitlistGateEnabled: mockIsWaitlistGateEnabled,
 }));
 
-// Import once — clear in-memory cache between tests via invalidateProxyUserStateCache
 import {
   getUserState,
   invalidateProxyUserStateCache,
 } from '@/lib/auth/proxy-state';
+// Import once — clear in-memory cache between tests via invalidateProxyUserStateCache
+import { QueryTimeoutError } from '@/lib/db/query-timeout';
 
 describe('proxy-state.ts', () => {
   beforeEach(async () => {
     mockDbSelect.mockClear();
     mockIsWaitlistGateEnabled.mockClear();
+    mockRedisGet.mockClear();
+    mockRedisSet.mockClear();
+    mockRedisDel.mockClear();
+    mockGetRedis.mockReset();
+    mockGetRedis.mockReturnValue(null);
     mockIsWaitlistGateEnabled.mockResolvedValue(true);
     // Clear the module's in-memory cache to prevent cross-test contamination
     await invalidateProxyUserStateCache('clerk_123');
     await invalidateProxyUserStateCache('clerk_test_user');
     await invalidateProxyUserStateCache('clerk_parallel_gate');
+    await invalidateProxyUserStateCache('clerk_stale_timeout');
   });
 
   describe('getUserState', () => {
@@ -454,6 +479,118 @@ describe('proxy-state.ts', () => {
       );
 
       consoleSpy.mockRestore();
+    });
+
+    it('serves stale Redis cache when DB query times out', async () => {
+      const staleState = {
+        needsWaitlist: false,
+        needsOnboarding: false,
+        isActive: true,
+        isBanned: false,
+      };
+
+      mockGetRedis.mockReturnValue({
+        get: mockRedisGet,
+        set: mockRedisSet,
+        del: mockRedisDel,
+      });
+      mockRedisGet.mockImplementation(async (key: string) => {
+        if (key === 'proxy:user-state:clerk_stale_timeout') return null;
+        if (key === 'proxy:user-state:stale:clerk_stale_timeout') {
+          return staleState;
+        }
+        return null;
+      });
+
+      mockDbSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi
+                .fn()
+                .mockRejectedValue(
+                  new QueryTimeoutError(
+                    '[proxy-state] DB query timed out after 3000ms'
+                  )
+                ),
+            }),
+          }),
+        }),
+      });
+
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const result = await getUserState('clerk_stale_timeout');
+
+      expect(result).toEqual(staleState);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[WARNING] [proxy-state] Serving stale cache after DB failure'
+        )
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('downgrades timeout without stale cache to warning fallback', async () => {
+      mockGetRedis.mockReturnValue({
+        get: mockRedisGet,
+        set: mockRedisSet,
+        del: mockRedisDel,
+      });
+      mockRedisGet.mockResolvedValue(null);
+
+      mockDbSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi
+                .fn()
+                .mockRejectedValue(
+                  new QueryTimeoutError(
+                    '[proxy-state] DB query timed out after 3000ms'
+                  )
+                ),
+            }),
+          }),
+        }),
+      });
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const result = await getUserState('clerk_123');
+
+      expect(result).toEqual({
+        needsWaitlist: false,
+        needsOnboarding: true,
+        isActive: false,
+        isBanned: false,
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          '[WARNING] [proxy-state] DB query timed out without stale cache fallback'
+        )
+      );
+      expect(errorSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+      errorSpy.mockRestore();
+    });
+
+    it('invalidates both primary and stale Redis cache keys', async () => {
+      mockGetRedis.mockReturnValue({
+        get: mockRedisGet,
+        set: mockRedisSet,
+        del: mockRedisDel,
+      });
+
+      await invalidateProxyUserStateCache('clerk_123');
+
+      expect(mockRedisDel).toHaveBeenCalledWith('proxy:user-state:clerk_123');
+      expect(mockRedisDel).toHaveBeenCalledWith(
+        'proxy:user-state:stale:clerk_123'
+      );
     });
 
     it('handles non-Error objects in catch block', async () => {


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2985 -->

## Goal

Fix `QueryTimeoutError: [proxy-state] DB query timed out after 3000ms` on authenticated middleware cache misses during Neon cold starts, without relaxing the 3s latency budget introduced in JOV-1257.

## Root cause

JOV-1257 reduced `DB_QUERY_TIMEOUT_MS` from 8s → 3s to cap middleware latency. When the primary Redis cache (2–5 min TTL) expires during a Neon wake-up, the proxy-state query can exceed 3s and throw `QueryTimeoutError`, misrouting users to onboarding and flooding Sentry.

## Changes

- Add a longer-lived **stale Redis snapshot** (`proxy:user-state:stale:*`, 30 min / 1 hr TTL) written alongside the primary cache
- On DB timeout or transient failure, serve the stale snapshot before falling back to `NEEDS_ONBOARDING_STATE`
- Invalidate both primary and stale keys in `invalidateProxyUserStateCache()`
- Downgrade bare timeouts (no stale fallback) from `captureError` → `captureWarning` (matches dashboard-data pattern)
- Trim unused `profileAvatarUrl` from the proxy-state SELECT (not used by `isProfileComplete`)

## Testing

- `pnpm exec vitest run tests/unit/lib/auth/proxy-state.test.ts` — 18/18 pass
- New tests: stale-cache fallback on timeout, warning downgrade without stale cache, dual-key invalidation
- Pre-push: biome, tailwind guard, typecheck, lint all green

## Risk

First-time users with no prior cache still fall back to onboarding on cold-start timeout (expected). Returning users with expired primary cache but warm stale snapshot are now correctly routed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced authentication resilience with improved fallback mechanisms that maintain reliable sign-in experiences during database performance issues or service disruptions, ensuring users can consistently access their accounts regardless of temporary backend challenges.
  * Strengthened data consistency across caching infrastructure to provide more accurate user state information throughout the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->