### PR TITLE
perf(auth): cache resolveUserState and parallelize gate lookups (JOV-2993)

### DIFF
--- a/apps/web/lib/auth/README.md
+++ b/apps/web/lib/auth/README.md
@@ -6,7 +6,7 @@ Clerk-based authentication, user state resolution, and route gating for the Jovi
 
 - **`cached.ts`** — `getCachedAuth()` and `getOptionalAuth()` are request-scoped (`React.cache`) wrappers around Clerk's `auth()`. Use `getOptionalAuth()` for routes that may be unauthenticated; both also honor the dev test-auth bypass.
 - **`require-auth.ts`** — `requireAuth()` returns `userId` or a 401 response. The standard guard for API routes.
-- **`gate.ts`** — `resolveUserState()` is the single source of truth for full user state: queries Clerk + DB, lazy-creates the DB user, returns `{ state, redirectTo, context }` where `context` carries `isAdmin`, `isPro`, etc.
+- **`gate.ts`** — `resolveUserState()` is the single source of truth for full user state: queries Clerk + DB, lazy-creates the DB user, returns `{ state, redirectTo, context }` where `context` carries `isAdmin`, `isPro`, etc. Wrapped in `React.cache()` per request; prefetches waitlist gate status in parallel with the auth-gate DB JOIN (JOV-2993).
 - **`canonical-user-state.ts`** — `resolveCanonicalState()` is the pure state machine. Maps `(authState, dbUser, profile, waitlist, deletion)` → one of 8 `CanonicalUserState` values.
 - **`proxy-state.ts`** — Lightweight middleware-friendly snapshot (`isActive`, `needsOnboarding`, `needsWaitlist`, `isBanned`) with Redis caching for edge runtime.
 

--- a/apps/web/lib/auth/gate.ts
+++ b/apps/web/lib/auth/gate.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import * as Sentry from '@sentry/nextjs';
 import { sql as drizzleSql, eq } from 'drizzle-orm';
+import { cache } from 'react';
 import { db } from '@/lib/db';
 import {
   getDeepErrorMessage,
@@ -708,6 +709,29 @@ async function syncVerifiedEmailIfNeeded(
   });
 }
 
+export interface ResolveUserStateOptions {
+  createDbUserIfMissing?: boolean;
+  /**
+   * Pre-resolved Clerk user ID. When provided, skips calling auth() and
+   * currentUser() — both of which read request headers and must NOT be
+   * called inside unstable_cache or "use cache" boundaries.
+   *
+   * Pass this when the Clerk user ID is already known (e.g. from a cached
+   * function that received it as a parameter). In this case the verified
+   * email is resolved from Clerk's backend API if a DB user must be created.
+   */
+  knownClerkUserId?: string;
+}
+
+function serializeResolveUserStateOptions(
+  options: ResolveUserStateOptions
+): string {
+  return JSON.stringify({
+    createDbUserIfMissing: options.createDbUserIfMissing ?? true,
+    knownClerkUserId: options.knownClerkUserId ?? null,
+  });
+}
+
 /**
  * Centralized auth gate function that resolves the current user's state.
  *
@@ -720,39 +744,34 @@ async function syncVerifiedEmailIfNeeded(
  * 3. Check user status → BANNED
  * 4. Check waitlist/profile state → WAITLIST_*, NEEDS_ONBOARDING, ACTIVE
  *
+ * Wrapped in React.cache() so repeated calls within the same server request
+ * reuse one DB/auth resolution pass (JOV-2993).
+ *
  * @param options.createDbUserIfMissing - If true, creates a DB user row when missing (default: true)
  */
-export async function resolveUserState(
-  options: {
-    createDbUserIfMissing?: boolean;
-    /**
-     * Pre-resolved Clerk user ID. When provided, skips calling auth() and
-     * currentUser() — both of which read request headers and must NOT be
-     * called inside unstable_cache or "use cache" boundaries.
-     *
-     * Pass this when the Clerk user ID is already known (e.g. from a cached
-     * function that received it as a parameter). In this case the verified
-     * email is resolved from Clerk's backend API if a DB user must be created.
-     */
-    knownClerkUserId?: string;
-  } = {}
+async function resolveUserStateInternal(
+  options: ResolveUserStateOptions = {}
 ): Promise<AuthGateResult> {
   const { createDbUserIfMissing = true, knownClerkUserId } = options;
 
-  // 1. Resolve the Clerk user ID.
-  //
-  // When knownClerkUserId is provided (e.g. from a cached function), skip
-  // getCachedAuth() and getCachedCurrentUser() — both access headers()
-  // internally and will throw ClerkUseCacheError inside unstable_cache scopes.
-  const { clerkUserId, email } = await resolveClerkIdentity(knownClerkUserId);
+  // 1. Resolve Clerk identity and prefetch waitlist gate in parallel.
+  // Gate status is needed for every authenticated path; starting it early
+  // overlaps with identity resolution and the DB JOIN below (JOV-2993).
+  const identityPromise = resolveClerkIdentity(knownClerkUserId);
+  const waitlistGatePromise = isWaitlistGateEnabled();
+  const { clerkUserId, email } = await identityPromise;
 
   if (!clerkUserId) {
     return createUnauthenticatedAuthGateResult();
   }
 
   // 2. Query DB user AND profile in a single JOIN query (performance optimization)
-  // This reduces database round trips from 2 to 1
-  const lookupResult = await loadAuthGateRecord(clerkUserId, email);
+  // This reduces database round trips from 2 to 1. Run in parallel with the
+  // waitlist gate lookup started above (matches proxy-state.ts hot-path pattern).
+  const [lookupResult, waitlistGateEnabled] = await Promise.all([
+    loadAuthGateRecord(clerkUserId, email),
+    waitlistGatePromise,
+  ]);
   if (lookupResult && 'state' in lookupResult) {
     return lookupResult;
   }
@@ -812,7 +831,6 @@ export async function resolveUserState(
   let profile = toAuthGateProfile(dbResult);
 
   if (!dbUserId) {
-    const waitlistGateEnabled = await isWaitlistGateEnabled();
     const creationResult = await handleMissingDbUser(
       {
         createDbUserIfMissing,
@@ -844,7 +862,6 @@ export async function resolveUserState(
     profile = null;
   }
 
-  const waitlistGateEnabled = await isWaitlistGateEnabled();
   const state = resolveCanonicalState({
     isAuthenticated: true,
     hasDbUser: Boolean(dbUserId),
@@ -866,6 +883,26 @@ export async function resolveUserState(
       email: resolvedEmail,
     },
   };
+}
+
+const resolveUserStateCached = cache(
+  async (optionsKey: string): Promise<AuthGateResult> => {
+    const parsed = JSON.parse(optionsKey) as {
+      createDbUserIfMissing: boolean;
+      knownClerkUserId: string | null;
+    };
+
+    return resolveUserStateInternal({
+      createDbUserIfMissing: parsed.createDbUserIfMissing,
+      knownClerkUserId: parsed.knownClerkUserId ?? undefined,
+    });
+  }
+);
+
+export async function resolveUserState(
+  options: ResolveUserStateOptions = {}
+): Promise<AuthGateResult> {
+  return resolveUserStateCached(serializeResolveUserStateOptions(options));
 }
 
 // =============================================================================

--- a/apps/web/tests/unit/lib/auth/gate-cache.test.ts
+++ b/apps/web/tests/unit/lib/auth/gate-cache.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockCachedAuth,
+  mockCachedCurrentUser,
+  mockDbSelect,
+  mockCheckUserStatus,
+  mockIsWaitlistGateEnabled,
+  mockCache,
+} = vi.hoisted(() => ({
+  mockCachedAuth: vi.fn(),
+  mockCachedCurrentUser: vi.fn(),
+  mockDbSelect: vi.fn(),
+  mockCheckUserStatus: vi.fn(),
+  mockIsWaitlistGateEnabled: vi.fn().mockResolvedValue(false),
+  mockCache: vi.fn(<T extends (...args: never[]) => unknown>(fn: T) => {
+    const cacheByKey = new Map<string, ReturnType<T>>();
+
+    return ((...args: never[]) => {
+      const key = JSON.stringify(args);
+      if (!cacheByKey.has(key)) {
+        cacheByKey.set(key, fn(...args) as ReturnType<T>);
+      }
+      return cacheByKey.get(key)!;
+    }) as T;
+  }),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('react', async importOriginal => {
+  const actual = await importOriginal<typeof import('react')>();
+  return {
+    ...actual,
+    cache: mockCache,
+  };
+});
+
+vi.mock('@/lib/auth/cached', () => ({
+  getCachedAuth: mockCachedAuth,
+  getCachedCurrentUser: mockCachedCurrentUser,
+}));
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: mockDbSelect,
+    insert: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/db/schema/auth', () => ({
+  users: {
+    id: 'users.id',
+    clerkId: 'users.clerkId',
+    email: 'users.email',
+    userStatus: 'users.userStatus',
+    isAdmin: 'users.isAdmin',
+    isPro: 'users.isPro',
+    deletedAt: 'users.deletedAt',
+  },
+}));
+
+vi.mock('@/lib/db/schema/profiles', () => ({
+  creatorProfiles: {
+    id: 'creatorProfiles.id',
+    username: 'creatorProfiles.username',
+    usernameNormalized: 'creatorProfiles.usernameNormalized',
+    displayName: 'creatorProfiles.displayName',
+    isPublic: 'creatorProfiles.isPublic',
+    avatarUrl: 'creatorProfiles.avatarUrl',
+    onboardingCompletedAt: 'creatorProfiles.onboardingCompletedAt',
+  },
+}));
+
+vi.mock('@/lib/db/schema/waitlist', () => ({
+  waitlistEntries: {
+    id: 'waitlistEntries.id',
+    email: 'waitlistEntries.email',
+    emailNormalized: 'waitlistEntries.emailNormalized',
+    status: 'waitlistEntries.status',
+    canonical: 'waitlistEntries.canonical',
+    createdAt: 'waitlistEntries.createdAt',
+  },
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: vi.fn().mockResolvedValue(undefined),
+  captureCriticalError: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/utils/email', () => ({
+  normalizeEmail: vi.fn((email: string) => email.toLowerCase().trim()),
+}));
+
+vi.mock('@/lib/auth/clerk-sync', () => ({
+  syncEmailFromClerk: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/auth/status-checker', () => ({
+  checkUserStatus: mockCheckUserStatus,
+}));
+
+vi.mock('@/lib/waitlist/settings', () => ({
+  isWaitlistGateEnabled: mockIsWaitlistGateEnabled,
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((_col, val) => ({ eq: val })),
+  sql: vi.fn((strings, ...values) => ({ sql: strings, values })),
+  desc: vi.fn(col => ({ desc: col })),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  addBreadcrumb: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/request-clerk-client', () => ({
+  getServerClerkClient: vi.fn().mockResolvedValue(null),
+}));
+
+function createJoinSelectChain(result: unknown[]) {
+  const mockLimit = vi.fn().mockResolvedValue(result);
+  const mockWhere = vi.fn().mockReturnValue({ limit: mockLimit });
+  const mockLeftJoin = vi.fn().mockReturnValue({ where: mockWhere });
+  const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin });
+  return { from: mockFrom };
+}
+
+describe('resolveUserState request cache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockCachedAuth.mockResolvedValue({ userId: 'clerk_cached' });
+    mockCachedCurrentUser.mockResolvedValue({
+      emailAddresses: [
+        {
+          emailAddress: 'cached@example.com',
+          verification: { status: 'verified' },
+        },
+      ],
+    });
+    mockCheckUserStatus.mockReturnValue({
+      isBlocked: false,
+      blockedState: null,
+      redirectTo: null,
+    });
+    mockDbSelect.mockReturnValue(
+      createJoinSelectChain([
+        {
+          id: 'db-user-1',
+          email: 'cached@example.com',
+          userStatus: 'active',
+          isAdmin: false,
+          isPro: false,
+          deletedAt: null,
+          profileId: 'profile-1',
+          profileUsername: 'cached',
+          profileUsernameNormalized: 'cached',
+          profileDisplayName: 'Cached User',
+          profileIsPublic: true,
+          profileAvatarUrl: null,
+          profileOnboardingCompletedAt: new Date(),
+        },
+      ])
+    );
+  });
+
+  it('deduplicates repeated resolveUserState calls within one request', async () => {
+    const { resolveUserState } = await import('@/lib/auth/gate');
+
+    const [first, second, third] = await Promise.all([
+      resolveUserState(),
+      resolveUserState(),
+      resolveUserState(),
+    ]);
+
+    expect(first).toEqual(second);
+    expect(second).toEqual(third);
+    expect(mockCachedAuth).toHaveBeenCalledTimes(1);
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
+    expect(mockIsWaitlistGateEnabled).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps separate cache entries for different option shapes', async () => {
+    const { resolveUserState } = await import('@/lib/auth/gate');
+
+    await resolveUserState();
+    expect(mockCachedAuth).toHaveBeenCalledTimes(1);
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
+
+    mockCachedAuth.mockClear();
+
+    await resolveUserState({ knownClerkUserId: 'clerk_cached' });
+
+    expect(mockCachedAuth).not.toHaveBeenCalled();
+    expect(mockDbSelect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/tests/unit/lib/auth/gate.critical.test.ts
+++ b/apps/web/tests/unit/lib/auth/gate.critical.test.ts
@@ -309,6 +309,58 @@ describe('@critical gate.ts', () => {
       expect(result.context.isAdmin).toBe(false);
     });
 
+    it('prefetches waitlist gate status before the auth gate DB query finishes', async () => {
+      mockCachedAuth.mockResolvedValue({ userId: 'clerk_parallel_gate' });
+      mockCachedCurrentUser.mockResolvedValue(mockClerkUser());
+
+      const callOrder: string[] = [];
+
+      mockIsWaitlistGateEnabled.mockImplementation(async () => {
+        callOrder.push('gate');
+        return true;
+      });
+
+      mockDbSelect.mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockImplementation(async () => {
+                callOrder.push('db');
+                return [
+                  mockDbUserResult({
+                    profileId: 'profile-123',
+                    profileOnboardingCompletedAt: new Date(),
+                  }),
+                ];
+              }),
+            }),
+          }),
+        }),
+      });
+
+      await resolveUserState();
+
+      expect(callOrder).toEqual(['gate', 'db']);
+      expect(mockIsWaitlistGateEnabled).toHaveBeenCalledTimes(1);
+    });
+
+    it('fetches waitlist gate status only once for existing users', async () => {
+      mockCachedAuth.mockResolvedValue({ userId: 'clerk_123' });
+      mockCachedCurrentUser.mockResolvedValue(mockClerkUser());
+      mockDbSelect.mockReturnValue(
+        createJoinSelectChain([
+          mockDbUserResult({
+            profileId: 'profile-123',
+            profileOnboardingCompletedAt: new Date(),
+          }),
+        ])
+      );
+
+      await resolveUserState();
+
+      expect(mockIsWaitlistGateEnabled).toHaveBeenCalledTimes(1);
+    });
+
     it('returns ACTIVE for a fully set up user with complete profile', async () => {
       mockCachedAuth.mockResolvedValue({ userId: 'clerk_123' });
       mockCachedCurrentUser.mockResolvedValue(mockClerkUser());


### PR DESCRIPTION
<!-- linear-issue-id:JOV-2993 -->

## Goal

Reduce auth hot-path latency by eliminating redundant per-request `resolveUserState()` work and serial waitlist gate lookups on the server auth gate.

## Changes

- Wrap `resolveUserState()` in `React.cache()` so repeated calls within one server request reuse a single DB/auth resolution pass
- Prefetch `isWaitlistGateEnabled()` alongside Clerk identity resolution (overlaps with auth header reads)
- Run the auth-gate DB JOIN and waitlist gate lookup in `Promise.all` (matches `proxy-state.ts` pattern)
- Remove duplicate `isWaitlistGateEnabled()` call on the missing-user creation path
- Add unit coverage for request-cache deduplication, single gate fetch, and prefetch ordering

## Testing

```bash
pnpm --filter @jovie/web test -- tests/unit/lib/auth/gate.critical.test.ts tests/unit/lib/auth/gate-cache.test.ts tests/unit/lib/auth/gate.test.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)