### PR TITLE
fix(profile): use allowed Next.js image quality for photo downloads (JOV-2163)

### DIFF
--- a/apps/web/lib/utils/avatar-sizes.ts
+++ b/apps/web/lib/utils/avatar-sizes.ts
@@ -11,6 +11,12 @@ export interface AvatarSize {
   readonly url: string;
 }
 
+/** Must stay in sync with `images.qualities` in apps/web/next.config.js */
+export const ALLOWED_NEXT_IMAGE_QUALITIES = [25, 50, 75, 85, 100] as const;
+
+/** Highest allowed quality for profile photo download variants */
+export const PROFILE_PHOTO_DOWNLOAD_QUALITY = 100;
+
 /** Standard download size presets aligned to profile photo export UX */
 const SIZE_PRESETS = [
   { key: 'medium', label: 'Medium (512 x 512)', dimension: 512 },
@@ -26,7 +32,7 @@ function buildNextImageUrl(url: string, width: number): string {
   const params = new URLSearchParams({
     url,
     w: String(width),
-    q: '90',
+    q: String(PROFILE_PHOTO_DOWNLOAD_QUALITY),
   });
   return `/_next/image?${params.toString()}`;
 }

--- a/apps/web/tests/unit/lib/utils/avatar-sizes.test.ts
+++ b/apps/web/tests/unit/lib/utils/avatar-sizes.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { buildAvatarSizes } from '@/lib/utils/avatar-sizes';
+import {
+  ALLOWED_NEXT_IMAGE_QUALITIES,
+  buildAvatarSizes,
+  PROFILE_PHOTO_DOWNLOAD_QUALITY,
+} from '@/lib/utils/avatar-sizes';
 
 describe('buildAvatarSizes', () => {
   it('returns empty array when no sizesMap or avatarUrl', () => {
@@ -88,6 +92,30 @@ describe('buildAvatarSizes', () => {
     expect(sizes[0].key).toBe('medium');
     expect(sizes[0].url).toContain('/_next/image');
     expect(sizes[2].key).toBe('original');
+  });
+
+  it('uses only allowed Next.js image optimization quality values', () => {
+    const sizes = buildAvatarSizes(
+      null,
+      'https://example.blob.vercel-storage.com/avatars/photo.avif'
+    );
+
+    for (const size of sizes) {
+      if (!size.url.includes('/_next/image?')) continue;
+      const quality = new URL(size.url, 'https://jov.ie').searchParams.get('q');
+      expect(quality).not.toBeNull();
+      expect(
+        ALLOWED_NEXT_IMAGE_QUALITIES.includes(
+          Number(quality) as (typeof ALLOWED_NEXT_IMAGE_QUALITIES)[number]
+        )
+      ).toBe(true);
+    }
+
+    const mediumQuality = new URL(
+      sizes[0].url,
+      'https://jov.ie'
+    ).searchParams.get('q');
+    expect(mediumQuality).toBe(String(PROFILE_PHOTO_DOWNLOAD_QUALITY));
   });
 
   it('encodes Supabase avatar URLs correctly for Next.js image optimizer variants', () => {

--- a/apps/web/tests/unit/profile/profile-photo-context-menu.test.tsx
+++ b/apps/web/tests/unit/profile/profile-photo-context-menu.test.tsx
@@ -27,12 +27,12 @@ const multipleSizes: AvatarSize[] = [
   {
     key: 'medium',
     label: 'Medium (512 x 512)',
-    url: '/_next/image?url=https%3A%2F%2Fcdn.jov.ie%2Favatar-original.png&w=512&q=90',
+    url: '/_next/image?url=https%3A%2F%2Fcdn.jov.ie%2Favatar-original.png&w=512&q=100',
   },
   {
     key: 'large',
     label: 'Large (1024 x 1024)',
-    url: '/_next/image?url=https%3A%2F%2Fcdn.jov.ie%2Favatar-original.png&w=1024&q=90',
+    url: '/_next/image?url=https%3A%2F%2Fcdn.jov.ie%2Favatar-original.png&w=1024&q=100',
   },
   {
     key: 'original',


### PR DESCRIPTION
## Goal

Resolve JOV-2163 scope investigation for closed PR #8512 and ship the profile photo download fix that was never implemented.

## Investigation findings (PR #8512)

| Question | Result |
|---|---|
| Does PR diff match profile-image q=90→100 intent? | **No** — only `ChatInput.tsx` styling changed |
| Does PR diff match CodeRabbit ChatInput summary? | **Yes** — light/dark surface + shadow tweaks |
| Was profile download fix ever done? | **No** — `avatar-sizes.ts` still used `q=90` (invalid vs `next.config.js` qualities `[25,50,75,85,100]`) |
| Should ChatInput polish be ported? | **No** — superseded by `system-b-chat-composer-surface` tokens in `design-system.css` |

PR #8512 remains **closed**. This PR implements the missing profile download fix.

## Changes

- Change profile photo download optimizer URLs from `q=90` → `q=100`
- Export `ALLOWED_NEXT_IMAGE_QUALITIES` + `PROFILE_PHOTO_DOWNLOAD_QUALITY` constants
- Add unit test asserting generated `/_next/image` URLs use allowed quality values
- Update profile photo context menu test fixtures

## Testing

```bash
pnpm --filter @jovie/web exec vitest run \
  tests/unit/lib/utils/avatar-sizes.test.ts \
  tests/unit/profile/profile-photo-context-menu.test.tsx
```

All 9 tests pass locally.

Closes JOV-2163