### PR TITLE
fix(db): use set_config for statement_timeout in query wrappers (JOV-3128)

### DIFF
--- a/apps/web/lib/db/query-timeout.ts
+++ b/apps/web/lib/db/query-timeout.ts
@@ -77,17 +77,31 @@ export class QueryTimeoutError extends Error {
   }
 }
 
+function assertPositiveTimeoutMs(timeoutMs: number): number {
+  const safeMs = Math.floor(timeoutMs);
+  if (!Number.isFinite(safeMs) || safeMs <= 0) {
+    throw new Error(`Invalid statement_timeout ms: ${timeoutMs}`);
+  }
+
+  return safeMs;
+}
+
 /**
  * Sets the PostgreSQL statement timeout for the current session.
- * Uses SET (session-scoped) instead of SET LOCAL, because SET LOCAL is a
- * no-op outside a transaction block and the Neon HTTP driver does not
- * support transactions.
+ *
+ * Uses parameterized `set_config` instead of `SET statement_timeout = $1`.
+ * PostgreSQL rejects bind parameters on SET, which surfaced in production as
+ * "Failed query: SET statement_timeout = $1".
  */
 export async function setStatementTimeout(
   db: DbOrTransaction,
   timeoutMs: number
 ): Promise<void> {
-  await db.execute(drizzleSql`SET statement_timeout = ${timeoutMs}`);
+  const safeMs = assertPositiveTimeoutMs(timeoutMs);
+
+  await db.execute(
+    drizzleSql`SELECT set_config('statement_timeout', ${String(safeMs)}, false)`
+  );
 }
 
 /**

--- a/apps/web/tests/lib/analytics/query-timeout.test.ts
+++ b/apps/web/tests/lib/analytics/query-timeout.test.ts
@@ -12,6 +12,7 @@ import {
   isQueryTimeoutError,
   QUERY_TIMEOUTS,
   QueryTimeoutError,
+  setStatementTimeout,
   withTimeout,
 } from '@/lib/db/query-timeout';
 
@@ -126,6 +127,11 @@ describe('Query Timeout', () => {
       });
 
       expect(execute).toHaveBeenCalledTimes(1);
+      const [statement] = execute.mock.calls[0] as [
+        { queryChunks?: unknown[] },
+      ];
+      expect(JSON.stringify(statement)).toContain('set_config');
+      expect(JSON.stringify(statement)).not.toContain('SET statement_timeout');
     });
 
     it('skips PostgreSQL statement_timeout when db client is omitted', async () => {
@@ -133,6 +139,18 @@ describe('Query Timeout', () => {
 
       await executeWithTimeout(async () => 'ok', 'api', 'Test query');
 
+      expect(execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setStatementTimeout', () => {
+    it('rejects invalid timeout values before hitting the database', async () => {
+      const execute = vi.fn().mockResolvedValue(undefined);
+      const db = { execute } as const;
+
+      await expect(setStatementTimeout(db, 0)).rejects.toThrow(
+        'Invalid statement_timeout ms: 0'
+      );
       expect(execute).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary

Fixes production `Failed query: SET statement_timeout = $1` errors triggered when `dashboardQuery`/`apiQuery` pass a transaction handle with `{ db: tx }`.

PostgreSQL rejects bind parameters on `SET statement_timeout`. This switches to parameterized `set_config('statement_timeout', …, false)` — the same pattern already used for RLS session setup.

## Changes

- `setStatementTimeout`: use `set_config` instead of `SET statement_timeout = $1`
- Validate timeout ms is a positive integer before executing
- Tests: assert `set_config` path and reject invalid values

## Validation

- [x] `pnpm --filter web exec vitest run tests/lib/analytics/query-timeout.test.ts` (16 passed)
- [x] pre-push: biome, typecheck, lint

## Rollback

Revert this commit; query wrappers fall back to JS-only `withTimeout` if `setStatementTimeout` is removed (no schema changes).

Linear: https://linear.app/jovie/issue/JOV-3128

<!-- linear-issue-id:JOV-3128 -->