### PR TITLE
feat(testing): flaky quarantine ledger + HUD retry budget panel (JOV-1874)

### DIFF
--- a/.github/scripts/quarantine-ledger.mjs
+++ b/.github/scripts/quarantine-ledger.mjs
@@ -7,13 +7,10 @@
  *   node .github/scripts/quarantine-ledger.mjs emit-github-output
  */
 
-import { readFileSync, appendFileSync } from 'node:fs';
+import { appendFileSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-const LEDGER_PATH = resolve(
-  process.cwd(),
-  'apps/web/tests/quarantine.json'
-);
+const LEDGER_PATH = resolve(process.cwd(), 'apps/web/tests/quarantine.json');
 
 const DEFAULT_RETRY_BUDGET = {
   unitDefaultRetries: 1,

--- a/.github/scripts/quarantine-ledger.mjs
+++ b/.github/scripts/quarantine-ledger.mjs
@@ -7,197 +7,23 @@
  *   node .github/scripts/quarantine-ledger.mjs emit-github-output
  */
 
-import { appendFileSync, readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-
-const LEDGER_PATH = resolve(process.cwd(), 'apps/web/tests/quarantine.json');
-
-const DEFAULT_RETRY_BUDGET = {
-  unitDefaultRetries: 1,
-  quarantineUnitRetries: 2,
-  e2eDefaultRetries: 0,
-  quarantineE2eRetries: 2,
-  maxRetryAttemptsPerCiRun: 120,
-  unitShardCount: 6,
-};
-
-function parseLedger(raw) {
-  const issues = [];
-  if (!raw || typeof raw !== 'object') {
-    return {
-      issues: [{ path: 'root', message: 'Expected JSON object' }],
-      unitPaths: [],
-      e2ePaths: [],
-      retryBudget: DEFAULT_RETRY_BUDGET,
-      summary: null,
-    };
-  }
-
-  const retryBudget = { ...DEFAULT_RETRY_BUDGET, ...(raw.retryBudget ?? {}) };
-  const entries = Array.isArray(raw.entries)
-    ? raw.entries
-    : [
-        ...(raw.unit ?? []).map((path, index) => ({
-          id: `legacy-unit-${index}`,
-          kind: 'unit',
-          path,
-          owner: 'platform',
-          firstSeenAt: '2026-01-01',
-          reproductionCommand: `pnpm --filter @jovie/web exec vitest run ${path}`,
-          fixIssueUrl: 'https://linear.app/jovie/issue/JOV-782',
-          expiresAt: '2026-12-31',
-        })),
-        ...(raw.e2e ?? []).map((path, index) => ({
-          id: `legacy-e2e-${index}`,
-          kind: 'e2e',
-          path,
-          owner: 'platform',
-          firstSeenAt: '2026-01-01',
-          reproductionCommand: `cd apps/web && pnpm playwright test ${path.replace(/^apps\/web\//, '')}`,
-          fixIssueUrl: 'https://linear.app/jovie/issue/JOV-782',
-          expiresAt: '2026-12-31',
-        })),
-      ];
-
-  const required = [
-    'id',
-    'kind',
-    'path',
-    'owner',
-    'firstSeenAt',
-    'reproductionCommand',
-    'fixIssueUrl',
-    'expiresAt',
-  ];
-
-  const unitPaths = [];
-  const e2ePaths = [];
-
-  for (const [index, entry] of entries.entries()) {
-    for (const field of required) {
-      if (typeof entry?.[field] !== 'string' || entry[field].trim() === '') {
-        issues.push({
-          path: `entries[${index}].${field}`,
-          message: 'Required non-empty string',
-        });
-      }
-    }
-
-    if (entry?.kind === 'unit') {
-      unitPaths.push(entry.path);
-      if (entry.path?.startsWith('apps/web/')) {
-        issues.push({
-          path: `entries[${index}].path`,
-          message: 'Unit paths must be relative to apps/web',
-        });
-      }
-    } else if (entry?.kind === 'e2e') {
-      e2ePaths.push(entry.path);
-      if (!entry.path?.startsWith('apps/web/')) {
-        issues.push({
-          path: `entries[${index}].path`,
-          message: 'E2E paths must be repo-root relative',
-        });
-      }
-    } else {
-      issues.push({
-        path: `entries[${index}].kind`,
-        message: 'Expected unit or e2e',
-      });
-    }
-  }
-
-  const estimatedRetryAttemptsPerRun =
-    retryBudget.unitShardCount * retryBudget.unitDefaultRetries +
-    unitPaths.length * retryBudget.quarantineUnitRetries +
-    e2ePaths.length * retryBudget.quarantineE2eRetries;
-
-  if (estimatedRetryAttemptsPerRun > retryBudget.maxRetryAttemptsPerCiRun) {
-    issues.push({
-      path: 'retryBudget.maxRetryAttemptsPerCiRun',
-      message: `Estimated retry attempts (${estimatedRetryAttemptsPerRun}) exceed cap (${retryBudget.maxRetryAttemptsPerCiRun})`,
-    });
-  }
-
-  return {
-    issues,
-    unitPaths,
-    e2ePaths,
-    retryBudget,
-    summary: {
-      activeCount: entries.length,
-      estimatedRetryAttemptsPerRun,
-      retryBudgetCap: retryBudget.maxRetryAttemptsPerCiRun,
-      withinRetryBudget:
-        estimatedRetryAttemptsPerRun <= retryBudget.maxRetryAttemptsPerCiRun,
-    },
-  };
-}
-
-function validate() {
-  const raw = JSON.parse(readFileSync(LEDGER_PATH, 'utf8'));
-  const parsed = parseLedger(raw);
-
-  if (parsed.issues.length > 0) {
-    console.error('Quarantine ledger validation failed:\n');
-    for (const issue of parsed.issues) {
-      console.error(`- ${issue.path}: ${issue.message}`);
-    }
-    process.exit(1);
-  }
-
-  console.log('Quarantine ledger is valid.');
-  console.log(
-    `Retry budget: ${parsed.summary.estimatedRetryAttemptsPerRun}/${parsed.summary.retryBudgetCap}`
-  );
-}
-
-function emitGithubOutput() {
-  const raw = JSON.parse(readFileSync(LEDGER_PATH, 'utf8'));
-  const parsed = parseLedger(raw);
-
-  if (parsed.issues.length > 0) {
-    console.error('Quarantine ledger validation failed:\n');
-    for (const issue of parsed.issues) {
-      console.error(`- ${issue.path}: ${issue.message}`);
-    }
-    process.exit(1);
-  }
-
-  const unitFiles = parsed.unitPaths.join(' ');
-  const unitExcludes = parsed.unitPaths
-    .map(path => `--exclude=${path}`)
-    .join(' ');
-  const e2eFiles = parsed.e2ePaths.join(' ');
-
-  const lines = [
-    `unit_files=${unitFiles}`,
-    `unit_excludes=${unitExcludes}`,
-    `e2e_files=${e2eFiles}`,
-    `has_unit=${parsed.unitPaths.length > 0 ? 'true' : 'false'}`,
-    `has_quarantine=${parsed.e2ePaths.length > 0 ? 'true' : 'false'}`,
-    `quarantined_specs=${e2eFiles}`,
-    `unit_default_retries=${parsed.retryBudget.unitDefaultRetries}`,
-    `quarantine_unit_retries=${parsed.retryBudget.quarantineUnitRetries}`,
-    `quarantine_e2e_retries=${parsed.retryBudget.quarantineE2eRetries}`,
-    `retry_budget_usage=${parsed.summary.estimatedRetryAttemptsPerRun}`,
-    `retry_budget_cap=${parsed.summary.retryBudgetCap}`,
-  ];
-
-  const output = process.env.GITHUB_OUTPUT;
-  if (output) {
-    appendFileSync(output, `${lines.join('\n')}\n`);
-  } else {
-    console.log(lines.join('\n'));
-  }
-}
+import { execSync } from 'node:child_process';
 
 const command = process.argv[2] ?? 'validate';
+const root = process.cwd();
+
+const run = script => {
+  execSync(`pnpm --filter @jovie/web exec tsx ${script}`, {
+    cwd: root,
+    stdio: 'inherit',
+    env: process.env,
+  });
+};
 
 if (command === 'validate') {
-  validate();
+  run('scripts/check-quarantine-ledger.ts');
 } else if (command === 'emit-github-output') {
-  emitGithubOutput();
+  run('scripts/emit-quarantine-github-output.ts');
 } else {
   console.error(`Unknown command: ${command}`);
   process.exit(1);

--- a/.github/scripts/quarantine-ledger.mjs
+++ b/.github/scripts/quarantine-ledger.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+/**
+ * CI helper for apps/web/tests/quarantine.json ledger.
+ *
+ * Usage:
+ *   node .github/scripts/quarantine-ledger.mjs validate
+ *   node .github/scripts/quarantine-ledger.mjs emit-github-output
+ */
+
+import { readFileSync, appendFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const LEDGER_PATH = resolve(
+  process.cwd(),
+  'apps/web/tests/quarantine.json'
+);
+
+const DEFAULT_RETRY_BUDGET = {
+  unitDefaultRetries: 1,
+  quarantineUnitRetries: 2,
+  e2eDefaultRetries: 0,
+  quarantineE2eRetries: 2,
+  maxRetryAttemptsPerCiRun: 120,
+  unitShardCount: 6,
+};
+
+function parseLedger(raw) {
+  const issues = [];
+  if (!raw || typeof raw !== 'object') {
+    return {
+      issues: [{ path: 'root', message: 'Expected JSON object' }],
+      unitPaths: [],
+      e2ePaths: [],
+      retryBudget: DEFAULT_RETRY_BUDGET,
+      summary: null,
+    };
+  }
+
+  const retryBudget = { ...DEFAULT_RETRY_BUDGET, ...(raw.retryBudget ?? {}) };
+  const entries = Array.isArray(raw.entries)
+    ? raw.entries
+    : [
+        ...(raw.unit ?? []).map((path, index) => ({
+          id: `legacy-unit-${index}`,
+          kind: 'unit',
+          path,
+          owner: 'platform',
+          firstSeenAt: '2026-01-01',
+          reproductionCommand: `pnpm --filter @jovie/web exec vitest run ${path}`,
+          fixIssueUrl: 'https://linear.app/jovie/issue/JOV-782',
+          expiresAt: '2026-12-31',
+        })),
+        ...(raw.e2e ?? []).map((path, index) => ({
+          id: `legacy-e2e-${index}`,
+          kind: 'e2e',
+          path,
+          owner: 'platform',
+          firstSeenAt: '2026-01-01',
+          reproductionCommand: `cd apps/web && pnpm playwright test ${path.replace(/^apps\/web\//, '')}`,
+          fixIssueUrl: 'https://linear.app/jovie/issue/JOV-782',
+          expiresAt: '2026-12-31',
+        })),
+      ];
+
+  const required = [
+    'id',
+    'kind',
+    'path',
+    'owner',
+    'firstSeenAt',
+    'reproductionCommand',
+    'fixIssueUrl',
+    'expiresAt',
+  ];
+
+  const unitPaths = [];
+  const e2ePaths = [];
+
+  for (const [index, entry] of entries.entries()) {
+    for (const field of required) {
+      if (typeof entry?.[field] !== 'string' || entry[field].trim() === '') {
+        issues.push({
+          path: `entries[${index}].${field}`,
+          message: 'Required non-empty string',
+        });
+      }
+    }
+
+    if (entry?.kind === 'unit') {
+      unitPaths.push(entry.path);
+      if (entry.path?.startsWith('apps/web/')) {
+        issues.push({
+          path: `entries[${index}].path`,
+          message: 'Unit paths must be relative to apps/web',
+        });
+      }
+    } else if (entry?.kind === 'e2e') {
+      e2ePaths.push(entry.path);
+      if (!entry.path?.startsWith('apps/web/')) {
+        issues.push({
+          path: `entries[${index}].path`,
+          message: 'E2E paths must be repo-root relative',
+        });
+      }
+    } else {
+      issues.push({
+        path: `entries[${index}].kind`,
+        message: 'Expected unit or e2e',
+      });
+    }
+  }
+
+  const estimatedRetryAttemptsPerRun =
+    retryBudget.unitShardCount * retryBudget.unitDefaultRetries +
+    unitPaths.length * retryBudget.quarantineUnitRetries +
+    e2ePaths.length * retryBudget.quarantineE2eRetries;
+
+  if (estimatedRetryAttemptsPerRun > retryBudget.maxRetryAttemptsPerCiRun) {
+    issues.push({
+      path: 'retryBudget.maxRetryAttemptsPerCiRun',
+      message: `Estimated retry attempts (${estimatedRetryAttemptsPerRun}) exceed cap (${retryBudget.maxRetryAttemptsPerCiRun})`,
+    });
+  }
+
+  return {
+    issues,
+    unitPaths,
+    e2ePaths,
+    retryBudget,
+    summary: {
+      activeCount: entries.length,
+      estimatedRetryAttemptsPerRun,
+      retryBudgetCap: retryBudget.maxRetryAttemptsPerCiRun,
+      withinRetryBudget:
+        estimatedRetryAttemptsPerRun <= retryBudget.maxRetryAttemptsPerCiRun,
+    },
+  };
+}
+
+function validate() {
+  const raw = JSON.parse(readFileSync(LEDGER_PATH, 'utf8'));
+  const parsed = parseLedger(raw);
+
+  if (parsed.issues.length > 0) {
+    console.error('Quarantine ledger validation failed:\n');
+    for (const issue of parsed.issues) {
+      console.error(`- ${issue.path}: ${issue.message}`);
+    }
+    process.exit(1);
+  }
+
+  console.log('Quarantine ledger is valid.');
+  console.log(
+    `Retry budget: ${parsed.summary.estimatedRetryAttemptsPerRun}/${parsed.summary.retryBudgetCap}`
+  );
+}
+
+function emitGithubOutput() {
+  const raw = JSON.parse(readFileSync(LEDGER_PATH, 'utf8'));
+  const parsed = parseLedger(raw);
+
+  if (parsed.issues.length > 0) {
+    console.error('Quarantine ledger validation failed:\n');
+    for (const issue of parsed.issues) {
+      console.error(`- ${issue.path}: ${issue.message}`);
+    }
+    process.exit(1);
+  }
+
+  const unitFiles = parsed.unitPaths.join(' ');
+  const unitExcludes = parsed.unitPaths
+    .map(path => `--exclude=${path}`)
+    .join(' ');
+  const e2eFiles = parsed.e2ePaths.join(' ');
+
+  const lines = [
+    `unit_files=${unitFiles}`,
+    `unit_excludes=${unitExcludes}`,
+    `e2e_files=${e2eFiles}`,
+    `has_unit=${parsed.unitPaths.length > 0 ? 'true' : 'false'}`,
+    `has_quarantine=${parsed.e2ePaths.length > 0 ? 'true' : 'false'}`,
+    `quarantined_specs=${e2eFiles}`,
+    `unit_default_retries=${parsed.retryBudget.unitDefaultRetries}`,
+    `quarantine_unit_retries=${parsed.retryBudget.quarantineUnitRetries}`,
+    `quarantine_e2e_retries=${parsed.retryBudget.quarantineE2eRetries}`,
+    `retry_budget_usage=${parsed.summary.estimatedRetryAttemptsPerRun}`,
+    `retry_budget_cap=${parsed.summary.retryBudgetCap}`,
+  ];
+
+  const output = process.env.GITHUB_OUTPUT;
+  if (output) {
+    appendFileSync(output, `${lines.join('\n')}\n`);
+  } else {
+    console.log(lines.join('\n'));
+  }
+}
+
+const command = process.argv[2] ?? 'validate';
+
+if (command === 'validate') {
+  validate();
+} else if (command === 'emit-github-output') {
+  emitGithubOutput();
+} else {
+  console.error(`Unknown command: ${command}`);
+  process.exit(1);
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,8 @@ jobs:
           pnpm next:proxy-guard
           pnpm tailwind:check
           pnpm --filter=@jovie/web run lint:no-native-dialogs
+      - name: Validate flaky quarantine ledger
+        run: node .github/scripts/quarantine-ledger.mjs validate
       - name: Write remediation summary
         if: always()
         run: |
@@ -2418,24 +2420,7 @@ jobs:
       - name: Load quarantined unit tests
         if: steps.check_changes.outputs.run_full_ci == 'true'
         id: quarantine
-        run: |
-          FILE="apps/web/tests/quarantine.json"
-          UNIT_FILES=""
-          UNIT_EXCLUDES=""
-
-          if [ -f "$FILE" ]; then
-            UNIT_FILES=$(jq -r '.unit // [] | join(" ")' "$FILE")
-            UNIT_EXCLUDES=$(jq -r '.unit // [] | map("--exclude=" + .) | join(" ")' "$FILE")
-          fi
-
-          echo "unit_files=$UNIT_FILES" >> "$GITHUB_OUTPUT"
-          echo "unit_excludes=$UNIT_EXCLUDES" >> "$GITHUB_OUTPUT"
-
-          if [ -n "$UNIT_FILES" ]; then
-            echo "has_unit=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_unit=false" >> "$GITHUB_OUTPUT"
-          fi
+        run: node .github/scripts/quarantine-ledger.mjs emit-github-output
 
       - name: Run unit tests
         if: steps.check_changes.outputs.run_full_ci == 'true'
@@ -2446,8 +2431,8 @@ jobs:
           # Use forked pool with limited workers to reduce CI flakiness from memory pressure
           export NODE_OPTIONS="--max-old-space-size=2048"
           VITEST_CI_FLAGS="--pool=forks --maxWorkers=2"
-          # Mitigate low-frequency flakes by retrying failed tests once in CI
-          RETRY_FLAG="--retry=1"
+          # Retry budget comes from apps/web/tests/quarantine.json
+          RETRY_FLAG="--retry=${{ steps.quarantine.outputs.unit_default_retries }}"
           # Use shard-specific output file so Codecov Test Analytics receives all 6 shards
           # (a shared filename causes only the last upload to be recorded)
           # Note: vitest runs from apps/web/, so path is relative to that directory
@@ -2476,7 +2461,7 @@ jobs:
         env:
           TURBO_SCM_HEAD: ${{ github.sha }}
           TURBO_SCM_BASE: ${{ github.event_name == 'merge_group' && 'origin/main' || (github.base_ref && format('origin/{0}', github.base_ref)) || '' }}
-        run: pnpm turbo test:fast --affected -- --pool=forks --maxWorkers=2 --retry=2 ${{ steps.quarantine.outputs.unit_files }}
+        run: pnpm turbo test:fast --affected -- --pool=forks --maxWorkers=2 --retry=${{ steps.quarantine.outputs.quarantine_unit_retries }} ${{ steps.quarantine.outputs.unit_files }}
 
       - name: Run packages/ui unit tests
         if: steps.check_changes.outputs.run_full_ci == 'true'
@@ -2859,11 +2844,12 @@ jobs:
         id: quarantine
         if: steps.check_changes.outputs.run_full_ci == 'true'
         run: |
+          node .github/scripts/quarantine-ledger.mjs validate
           FILE="apps/web/tests/quarantine.json"
           QUARANTINED=()
 
           if [ -f "$FILE" ]; then
-            mapfile -t QUARANTINED < <(jq -r '.e2e // [] | .[]' "$FILE")
+            mapfile -t QUARANTINED < <(jq -r '.entries[]? | select(.kind == "e2e") | .path' "$FILE")
           fi
 
           ADMIN_SPEC="apps/web/tests/e2e/dashboard-pages-health.spec.ts"
@@ -3070,11 +3056,12 @@ jobs:
         if: ${{ (hashFiles('apps/web/tests/e2e/**') != '' || hashFiles('apps/web/tests/smoke/**') != '') }}
         id: quarantine
         run: |
+          node .github/scripts/quarantine-ledger.mjs validate
           FILE="apps/web/tests/quarantine.json"
           QUARANTINED=()
 
           if [ -f "$FILE" ]; then
-            mapfile -t QUARANTINED < <(jq -r '.e2e // [] | .[]' "$FILE")
+            mapfile -t QUARANTINED < <(jq -r '.entries[]? | select(.kind == "e2e") | .path' "$FILE")
           fi
 
           mapfile -t ALL_SPECS < <(git ls-files "apps/web/tests/e2e/**/*.spec.ts" "apps/web/tests/smoke/**/*.spec.ts")
@@ -3199,7 +3186,9 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_ENVIRONMENT: ci-main-e2e-quarantine
           SENTRY_RELEASE: ${{ github.sha }}
-        run: cd apps/web && pnpm playwright test --retries=2 ${{ steps.quarantine.outputs.quarantined_specs }}
+        run: |
+          RETRIES=$(jq -r '.retryBudget.quarantineE2eRetries // 2' apps/web/tests/quarantine.json)
+          cd apps/web && pnpm playwright test --retries="$RETRIES" ${{ steps.quarantine.outputs.quarantined_specs }}
 
       - name: Upload Playwright Report on Failure
         if: ${{ failure() && (hashFiles('apps/web/tests/e2e/**') != '' || hashFiles('apps/web/tests/smoke/**') != '') }}

--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -115,6 +115,23 @@ function formatReliabilitySubtitle(
   return `${reliability.unresolvedSentryIssues24h.toLocaleString('en-US')} unresolved | p95 ${p95}`;
 }
 
+function formatTestingQuarantineSubtitle(
+  quarantine: HudMetrics['testing']['quarantine']
+): string {
+  const budget = `${quarantine.estimatedRetryAttemptsPerRun}/${quarantine.retryBudgetCap} retries`;
+  const mix = `${quarantine.unitCount} unit | ${quarantine.e2eCount} e2e`;
+  if (!quarantine.isValid) {
+    return `Ledger invalid | ${budget}`;
+  }
+  if (!quarantine.withinRetryBudget) {
+    return `Over budget | ${mix}`;
+  }
+  if (quarantine.expiredCount > 0) {
+    return `${quarantine.expiredCount} expired | ${budget}`;
+  }
+  return `${mix} | ${budget}`;
+}
+
 function formatDefaultStatusLabel(
   status: HudMetrics['overview']['defaultStatus']
 ): string {
@@ -744,6 +761,18 @@ export function HudDashboardClient({
             className='p-3'
             valueClassName={secondaryValueClass}
           />
+          <ContentMetricCard
+            label='Flaky Quarantine'
+            value={metrics.testing.quarantine.activeCount.toLocaleString(
+              'en-US'
+            )}
+            subtitle={formatTestingQuarantineSubtitle(
+              metrics.testing.quarantine
+            )}
+            className='p-3'
+            valueClassName={secondaryValueClass}
+            data-testid='hud-flaky-quarantine-card'
+          />
         </div>
 
         {metrics.accessMode === 'admin' ? (
@@ -925,8 +954,20 @@ export function HudDashboardClient({
                 sentrySource,
                 handleSourceRetry
               )}
-              className='p-3 col-span-2'
+              className='p-3'
               valueClassName={secondaryValueClass}
+            />
+            <ContentMetricCard
+              label='Flaky Quarantine'
+              value={metrics.testing.quarantine.activeCount.toLocaleString(
+                'en-US'
+              )}
+              subtitle={formatTestingQuarantineSubtitle(
+                metrics.testing.quarantine
+              )}
+              className='p-3'
+              valueClassName={secondaryValueClass}
+              data-testid='hud-flaky-quarantine-card'
             />
           </div>
         </div>

--- a/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
+++ b/apps/web/app/app/(shell)/admin/ops/HudDashboardClient.tsx
@@ -132,6 +132,88 @@ function formatTestingQuarantineSubtitle(
   return `${mix} | ${budget}`;
 }
 
+function HudHealthMetricCards({
+  metrics,
+  secondaryValueClass,
+  databaseSource,
+  sentrySource,
+  handleSourceRetry,
+}: Readonly<{
+  readonly metrics: HudMetrics;
+  readonly secondaryValueClass: string;
+  readonly databaseSource: HudMetrics['sources']['database'];
+  readonly sentrySource: HudMetrics['sources']['sentry'];
+  readonly handleSourceRetry: () => void;
+}>) {
+  return (
+    <>
+      <ContentMetricCard
+        label='Operations'
+        value={metrics.operations.status === 'ok' ? 'Healthy' : 'Degraded'}
+        subtitle={metricSubtitleWithTrust(
+          metrics.operations.dbLatencyMs === null
+            ? 'DB latency —'
+            : `DB latency ${metrics.operations.dbLatencyMs.toFixed(0)}ms`,
+          databaseSource,
+          handleSourceRetry
+        )}
+        className='p-3'
+        valueClassName={secondaryValueClass}
+      />
+      <ContentMetricCard
+        label='Reliability'
+        value={`${metrics.reliability.reliabilityScorePercent.toFixed(1)}%`}
+        subtitle={metricSubtitleWithTrust(
+          formatReliabilitySubtitle(metrics.reliability),
+          sentrySource,
+          handleSourceRetry
+        )}
+        className='p-3'
+        valueClassName={secondaryValueClass}
+      />
+      <ContentMetricCard
+        label='Flaky Quarantine'
+        value={metrics.testing.quarantine.activeCount.toLocaleString('en-US')}
+        subtitle={formatTestingQuarantineSubtitle(metrics.testing.quarantine)}
+        className='p-3'
+        valueClassName={secondaryValueClass}
+        data-testid='hud-flaky-quarantine-card'
+      />
+    </>
+  );
+}
+
+function HudDeploymentsSurfaceCard({
+  metrics,
+  deploymentDetail,
+  githubSource,
+  handleSourceRetry,
+}: Readonly<{
+  readonly metrics: HudMetrics;
+  readonly deploymentDetail: string;
+  readonly githubSource: HudMetrics['sources']['github'];
+  readonly handleSourceRetry: () => void;
+}>) {
+  return (
+    <ContentSurfaceCard surface='details' className='space-y-3 p-3'>
+      <div className='flex items-center justify-between gap-3'>
+        <SectionLabel>Deployments</SectionLabel>
+        <p className='text-[12px] text-secondary-token'>{deploymentDetail}</p>
+      </div>
+      {metrics.deployments.recent.length > 0 ? (
+        <div className='grid gap-2'>
+          {metrics.deployments.recent.slice(0, 5).map(run => (
+            <DeploymentRow key={run.id} run={run} />
+          ))}
+        </div>
+      ) : (
+        <p className='text-[13px] text-secondary-token'>No recent runs.</p>
+      )}
+      <HudMetricSourceTrust source={githubSource} onRetry={handleSourceRetry} />
+    </ContentSurfaceCard>
+  );
+}
+
 function formatDefaultStatusLabel(
   status: HudMetrics['overview']['defaultStatus']
 ): string {
@@ -737,41 +819,12 @@ export function HudDashboardClient({
             className='p-3'
             valueClassName={secondaryValueClass}
           />
-          <ContentMetricCard
-            label='Operations'
-            value={metrics.operations.status === 'ok' ? 'Healthy' : 'Degraded'}
-            subtitle={metricSubtitleWithTrust(
-              metrics.operations.dbLatencyMs === null
-                ? 'DB latency —'
-                : `DB latency ${metrics.operations.dbLatencyMs.toFixed(0)}ms`,
-              databaseSource,
-              handleSourceRetry
-            )}
-            className='p-3'
-            valueClassName={secondaryValueClass}
-          />
-          <ContentMetricCard
-            label='Reliability'
-            value={`${metrics.reliability.reliabilityScorePercent.toFixed(1)}%`}
-            subtitle={metricSubtitleWithTrust(
-              formatReliabilitySubtitle(metrics.reliability),
-              sentrySource,
-              handleSourceRetry
-            )}
-            className='p-3'
-            valueClassName={secondaryValueClass}
-          />
-          <ContentMetricCard
-            label='Flaky Quarantine'
-            value={metrics.testing.quarantine.activeCount.toLocaleString(
-              'en-US'
-            )}
-            subtitle={formatTestingQuarantineSubtitle(
-              metrics.testing.quarantine
-            )}
-            className='p-3'
-            valueClassName={secondaryValueClass}
-            data-testid='hud-flaky-quarantine-card'
+          <HudHealthMetricCards
+            metrics={metrics}
+            secondaryValueClass={secondaryValueClass}
+            databaseSource={databaseSource}
+            sentrySource={sentrySource}
+            handleSourceRetry={handleSourceRetry}
           />
         </div>
 
@@ -931,43 +984,12 @@ export function HudDashboardClient({
               className='p-3'
               valueClassName={secondaryValueClass}
             />
-            <ContentMetricCard
-              label='Operations'
-              value={
-                metrics.operations.status === 'ok' ? 'Healthy' : 'Degraded'
-              }
-              subtitle={metricSubtitleWithTrust(
-                metrics.operations.dbLatencyMs === null
-                  ? 'DB latency —'
-                  : `DB latency ${metrics.operations.dbLatencyMs.toFixed(0)}ms`,
-                databaseSource,
-                handleSourceRetry
-              )}
-              className='p-3'
-              valueClassName={secondaryValueClass}
-            />
-            <ContentMetricCard
-              label='Reliability'
-              value={`${metrics.reliability.reliabilityScorePercent.toFixed(1)}%`}
-              subtitle={metricSubtitleWithTrust(
-                formatReliabilitySubtitle(metrics.reliability),
-                sentrySource,
-                handleSourceRetry
-              )}
-              className='p-3'
-              valueClassName={secondaryValueClass}
-            />
-            <ContentMetricCard
-              label='Flaky Quarantine'
-              value={metrics.testing.quarantine.activeCount.toLocaleString(
-                'en-US'
-              )}
-              subtitle={formatTestingQuarantineSubtitle(
-                metrics.testing.quarantine
-              )}
-              className='p-3'
-              valueClassName={secondaryValueClass}
-              data-testid='hud-flaky-quarantine-card'
+            <HudHealthMetricCards
+              metrics={metrics}
+              secondaryValueClass={secondaryValueClass}
+              databaseSource={databaseSource}
+              sentrySource={sentrySource}
+              handleSourceRetry={handleSourceRetry}
             />
           </div>
         </div>
@@ -976,29 +998,12 @@ export function HudDashboardClient({
       {/* Deployments + optional QR panel */}
       {showQrPanel ? (
         <div className='grid gap-3 xl:grid-cols-[minmax(0,1.6fr)_minmax(320px,0.9fr)]'>
-          <ContentSurfaceCard surface='details' className='space-y-3 p-3'>
-            <div className='flex items-center justify-between gap-3'>
-              <SectionLabel>Deployments</SectionLabel>
-              <p className='text-[12px] text-secondary-token'>
-                {deploymentDetail}
-              </p>
-            </div>
-            {metrics.deployments.recent.length > 0 ? (
-              <div className='grid gap-2'>
-                {metrics.deployments.recent.slice(0, 5).map(run => (
-                  <DeploymentRow key={run.id} run={run} />
-                ))}
-              </div>
-            ) : (
-              <p className='text-[13px] text-secondary-token'>
-                No recent runs.
-              </p>
-            )}
-            <HudMetricSourceTrust
-              source={githubSource}
-              onRetry={handleSourceRetry}
-            />
-          </ContentSurfaceCard>
+          <HudDeploymentsSurfaceCard
+            metrics={metrics}
+            deploymentDetail={deploymentDetail}
+            githubSource={githubSource}
+            handleSourceRetry={handleSourceRetry}
+          />
 
           <ContentSurfaceCard surface='details' className='space-y-4 p-3'>
             <div className='flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between'>
@@ -1023,27 +1028,12 @@ export function HudDashboardClient({
           </ContentSurfaceCard>
         </div>
       ) : (
-        <ContentSurfaceCard surface='details' className='space-y-3 p-3'>
-          <div className='flex items-center justify-between gap-3'>
-            <SectionLabel>Deployments</SectionLabel>
-            <p className='text-[12px] text-secondary-token'>
-              {deploymentDetail}
-            </p>
-          </div>
-          {metrics.deployments.recent.length > 0 ? (
-            <div className='grid gap-2'>
-              {metrics.deployments.recent.slice(0, 5).map(run => (
-                <DeploymentRow key={run.id} run={run} />
-              ))}
-            </div>
-          ) : (
-            <p className='text-[13px] text-secondary-token'>No recent runs.</p>
-          )}
-          <HudMetricSourceTrust
-            source={githubSource}
-            onRetry={handleSourceRetry}
-          />
-        </ContentSurfaceCard>
+        <HudDeploymentsSurfaceCard
+          metrics={metrics}
+          deploymentDetail={deploymentDetail}
+          githubSource={githubSource}
+          handleSourceRetry={handleSourceRetry}
+        />
       )}
 
       {/* AI Ops / Hermes control plane */}

--- a/apps/web/lib/hud/metrics.ts
+++ b/apps/web/lib/hud/metrics.ts
@@ -11,8 +11,33 @@ import { getHermesDispatchAvailability } from '@/lib/hermes/dispatch';
 import { ServerFetchTimeoutError } from '@/lib/http/server-fetch';
 import { getHudAiOpsSummary } from '@/lib/hud/ai-ops';
 import { buildHudMetricSources } from '@/lib/hud/source-trust';
+import { getHudQuarantineMetrics } from '@/lib/testing/quarantine-ledger.server';
 import { logger } from '@/lib/utils/logger';
 import type { HudAccessMode, HudMetrics } from '@/types/hud';
+
+function buildHudTestingMetrics(): HudMetrics['testing'] {
+  const quarantine = getHudQuarantineMetrics();
+
+  return {
+    quarantine: {
+      activeCount: quarantine.summary.activeCount,
+      expiredCount: quarantine.summary.expiredCount,
+      expiringSoonCount: quarantine.summary.expiringSoonCount,
+      unitCount: quarantine.summary.unitCount,
+      e2eCount: quarantine.summary.e2eCount,
+      estimatedRetryAttemptsPerRun:
+        quarantine.summary.estimatedRetryAttemptsPerRun,
+      retryBudgetCap: quarantine.summary.retryBudgetCap,
+      retryBudgetUsagePercent: quarantine.summary.retryBudgetUsagePercent,
+      withinRetryBudget: quarantine.summary.withinRetryBudget,
+      unitDefaultRetries: quarantine.retryBudget.unitDefaultRetries,
+      quarantineUnitRetries: quarantine.retryBudget.quarantineUnitRetries,
+      quarantineE2eRetries: quarantine.retryBudget.quarantineE2eRetries,
+      isValid: quarantine.isValid,
+      ledgerPath: quarantine.ledgerPath,
+    },
+  };
+}
 
 export interface BuildDegradedHudMetricsOptions {
   context?: string;
@@ -222,6 +247,7 @@ export function buildDegradedHudMetrics(
       lastIncidentAtIso: null,
       unresolvedSentryIssues24h: 0,
     },
+    testing: buildHudTestingMetrics(),
     deployments,
     aiOps: {
       availability: 'error',
@@ -389,6 +415,7 @@ async function fetchHudMetrics(mode: HudAccessMode): Promise<HudMetrics> {
       lastIncidentAtIso,
       unresolvedSentryIssues24h: reliabilitySummary.unresolvedSentryIssues24h,
     },
+    testing: buildHudTestingMetrics(),
     deployments,
     aiOps,
     sources,

--- a/apps/web/lib/testing/quarantine-ledger.server.ts
+++ b/apps/web/lib/testing/quarantine-ledger.server.ts
@@ -1,0 +1,79 @@
+import 'server-only';
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  buildQuarantineLedgerSummary,
+  type ParsedQuarantineLedger,
+  parseQuarantineLedger,
+  type QuarantineLedgerSummary,
+} from '@/lib/testing/quarantine-ledger';
+
+const QUARANTINE_LEDGER_PATH = resolve(process.cwd(), 'tests/quarantine.json');
+
+export interface HudQuarantineMetrics {
+  readonly ledgerPath: string;
+  readonly summary: QuarantineLedgerSummary;
+  readonly entries: ParsedQuarantineLedger['ledger']['entries'];
+  readonly retryBudget: ParsedQuarantineLedger['ledger']['retryBudget'];
+  readonly isValid: boolean;
+  readonly validationIssues: ParsedQuarantineLedger['issues'];
+}
+
+export function getQuarantineLedgerPath(): string {
+  return QUARANTINE_LEDGER_PATH;
+}
+
+export function loadQuarantineLedgerFromFile(
+  filePath = QUARANTINE_LEDGER_PATH
+): ParsedQuarantineLedger {
+  const raw = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+  return parseQuarantineLedger(raw);
+}
+
+export function getHudQuarantineMetrics(
+  filePath = QUARANTINE_LEDGER_PATH
+): HudQuarantineMetrics {
+  try {
+    const parsed = loadQuarantineLedgerFromFile(filePath);
+    return {
+      ledgerPath: filePath,
+      summary: parsed.summary,
+      entries: parsed.ledger.entries,
+      retryBudget: parsed.ledger.retryBudget,
+      isValid: parsed.issues.length === 0,
+      validationIssues: parsed.issues,
+    };
+  } catch {
+    return {
+      ledgerPath: filePath,
+      summary: buildQuarantineLedgerSummary({
+        entries: [],
+        retryBudget: {
+          unitDefaultRetries: 1,
+          quarantineUnitRetries: 2,
+          e2eDefaultRetries: 0,
+          quarantineE2eRetries: 2,
+          maxRetryAttemptsPerCiRun: 120,
+          unitShardCount: 6,
+        },
+      }),
+      entries: [],
+      retryBudget: {
+        unitDefaultRetries: 1,
+        quarantineUnitRetries: 2,
+        e2eDefaultRetries: 0,
+        quarantineE2eRetries: 2,
+        maxRetryAttemptsPerCiRun: 120,
+        unitShardCount: 6,
+      },
+      isValid: false,
+      validationIssues: [
+        {
+          path: filePath,
+          message: 'Failed to read or parse quarantine ledger',
+        },
+      ],
+    };
+  }
+}

--- a/apps/web/lib/testing/quarantine-ledger.ts
+++ b/apps/web/lib/testing/quarantine-ledger.ts
@@ -146,7 +146,8 @@ function legacyEntry(
   const slug = path
     .replace(/^apps\/web\//, '')
     .replace(/[^a-zA-Z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '')
     .toLowerCase();
 
   return {

--- a/apps/web/lib/testing/quarantine-ledger.ts
+++ b/apps/web/lib/testing/quarantine-ledger.ts
@@ -138,17 +138,44 @@ function normalizeRetryBudget(
   };
 }
 
+function slugifyLedgerPath(path: string): string {
+  const trimmed = path.startsWith('apps/web/')
+    ? path.slice('apps/web/'.length)
+    : path;
+  const parts: string[] = [];
+  let current = '';
+
+  for (const char of trimmed) {
+    const code = char.charCodeAt(0);
+    const isAlphaNumeric =
+      (code >= 48 && code <= 57) ||
+      (code >= 65 && code <= 90) ||
+      (code >= 97 && code <= 122);
+
+    if (isAlphaNumeric) {
+      current += char.toLowerCase();
+      continue;
+    }
+
+    if (current.length > 0) {
+      parts.push(current);
+      current = '';
+    }
+  }
+
+  if (current.length > 0) {
+    parts.push(current);
+  }
+
+  return parts.join('-');
+}
+
 function legacyEntry(
   kind: QuarantineEntryKind,
   path: string,
   index: number
 ): QuarantineLedgerEntry {
-  const slug = path
-    .replace(/^apps\/web\//, '')
-    .replace(/[^a-zA-Z0-9]+/g, '-')
-    .replace(/^-+/, '')
-    .replace(/-+$/, '')
-    .toLowerCase();
+  const slug = slugifyLedgerPath(path);
 
   return {
     id: `legacy-${kind}-${index}-${slug || 'entry'}`,

--- a/apps/web/lib/testing/quarantine-ledger.ts
+++ b/apps/web/lib/testing/quarantine-ledger.ts
@@ -1,0 +1,449 @@
+export type QuarantineEntryKind = 'unit' | 'e2e';
+
+export interface QuarantineRetryBudget {
+  /** Retries for the default (non-quarantine) unit lane. */
+  readonly unitDefaultRetries: number;
+  /** Retries for quarantined unit specs. */
+  readonly quarantineUnitRetries: number;
+  /** Retries for the default (non-quarantine) E2E lane. */
+  readonly e2eDefaultRetries: number;
+  /** Retries for quarantined E2E specs. */
+  readonly quarantineE2eRetries: number;
+  /**
+   * Upper bound on total retry attempts budgeted per CI run.
+   * Computed as: unit shard count * unitDefaultRetries + sum(quarantine retries).
+   */
+  readonly maxRetryAttemptsPerCiRun: number;
+  /** Number of unit-test shards in CI (used for budget estimation). */
+  readonly unitShardCount: number;
+}
+
+export interface QuarantineLedgerEntry {
+  readonly id: string;
+  readonly kind: QuarantineEntryKind;
+  /** Unit paths are relative to apps/web; E2E paths are repo-root relative. */
+  readonly path: string;
+  readonly owner: string;
+  readonly firstSeenAt: string;
+  readonly reproductionCommand: string;
+  readonly fixIssueUrl: string;
+  readonly expiresAt: string;
+  readonly consecutiveSuccesses?: number;
+}
+
+export interface QuarantineLedger {
+  readonly schemaVersion: 1;
+  readonly retryBudget: QuarantineRetryBudget;
+  readonly entries: readonly QuarantineLedgerEntry[];
+}
+
+export interface LegacyQuarantineFile {
+  readonly unit?: readonly string[];
+  readonly e2e?: readonly string[];
+}
+
+export interface QuarantineLedgerValidationIssue {
+  readonly path: string;
+  readonly message: string;
+}
+
+export interface QuarantineLedgerSummary {
+  readonly activeCount: number;
+  readonly expiredCount: number;
+  readonly unitCount: number;
+  readonly e2eCount: number;
+  readonly estimatedRetryAttemptsPerRun: number;
+  readonly retryBudgetCap: number;
+  readonly retryBudgetUsagePercent: number;
+  readonly withinRetryBudget: boolean;
+  readonly expiringSoonCount: number;
+}
+
+export interface ParsedQuarantineLedger {
+  readonly ledger: QuarantineLedger;
+  readonly unitPaths: readonly string[];
+  readonly e2ePaths: readonly string[];
+  readonly summary: QuarantineLedgerSummary;
+  readonly issues: readonly QuarantineLedgerValidationIssue[];
+}
+
+const REQUIRED_ENTRY_FIELDS: readonly (keyof QuarantineLedgerEntry)[] = [
+  'id',
+  'kind',
+  'path',
+  'owner',
+  'firstSeenAt',
+  'reproductionCommand',
+  'fixIssueUrl',
+  'expiresAt',
+];
+
+const DEFAULT_RETRY_BUDGET: QuarantineRetryBudget = {
+  unitDefaultRetries: 1,
+  quarantineUnitRetries: 2,
+  e2eDefaultRetries: 0,
+  quarantineE2eRetries: 2,
+  maxRetryAttemptsPerCiRun: 120,
+  unitShardCount: 6,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isIsoDate(value: string): boolean {
+  return !Number.isNaN(Date.parse(value));
+}
+
+function isQuarantineKind(value: unknown): value is QuarantineEntryKind {
+  return value === 'unit' || value === 'e2e';
+}
+
+function normalizeRetryBudget(
+  value: unknown
+): QuarantineRetryBudget & { issues: QuarantineLedgerValidationIssue[] } {
+  const issues: QuarantineLedgerValidationIssue[] = [];
+  if (!isRecord(value)) {
+    return { ...DEFAULT_RETRY_BUDGET, issues };
+  }
+
+  const readNumber = (
+    key: keyof QuarantineRetryBudget,
+    fallback: number,
+    min = 0
+  ): number => {
+    const raw = value[key];
+    if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < min) {
+      issues.push({
+        path: `retryBudget.${key}`,
+        message: `Expected number >= ${min}`,
+      });
+      return fallback;
+    }
+    return raw;
+  };
+
+  return {
+    unitDefaultRetries: readNumber('unitDefaultRetries', 1),
+    quarantineUnitRetries: readNumber('quarantineUnitRetries', 2),
+    e2eDefaultRetries: readNumber('e2eDefaultRetries', 0),
+    quarantineE2eRetries: readNumber('quarantineE2eRetries', 2),
+    maxRetryAttemptsPerCiRun: readNumber('maxRetryAttemptsPerCiRun', 120, 1),
+    unitShardCount: readNumber('unitShardCount', 6, 1),
+    issues,
+  };
+}
+
+function legacyEntry(
+  kind: QuarantineEntryKind,
+  path: string,
+  index: number
+): QuarantineLedgerEntry {
+  const slug = path
+    .replace(/^apps\/web\//, '')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase();
+
+  return {
+    id: `legacy-${kind}-${index}-${slug || 'entry'}`,
+    kind,
+    path,
+    owner: 'platform',
+    firstSeenAt: '2026-01-01',
+    reproductionCommand:
+      kind === 'unit'
+        ? `pnpm --filter @jovie/web exec vitest run ${path}`
+        : `cd apps/web && pnpm playwright test ${path.replace(/^apps\/web\//, '')}`,
+    fixIssueUrl: 'https://linear.app/jovie/issue/JOV-782',
+    expiresAt: '2026-12-31',
+  };
+}
+
+export function parseQuarantineLedger(raw: unknown): ParsedQuarantineLedger {
+  const issues: QuarantineLedgerValidationIssue[] = [];
+
+  if (!isRecord(raw)) {
+    return {
+      ledger: {
+        schemaVersion: 1,
+        retryBudget: DEFAULT_RETRY_BUDGET,
+        entries: [],
+      },
+      unitPaths: [],
+      e2ePaths: [],
+      summary: buildQuarantineLedgerSummary({
+        entries: [],
+        retryBudget: DEFAULT_RETRY_BUDGET,
+      }),
+      issues: [{ path: 'root', message: 'Expected JSON object' }],
+    };
+  }
+
+  const retryBudgetResult = normalizeRetryBudget(raw.retryBudget);
+  issues.push(...retryBudgetResult.issues);
+
+  const entries: QuarantineLedgerEntry[] = [];
+
+  if (Array.isArray(raw.entries)) {
+    raw.entries.forEach((entry, index) => {
+      if (!isRecord(entry)) {
+        issues.push({
+          path: `entries[${index}]`,
+          message: 'Expected object',
+        });
+        return;
+      }
+
+      for (const field of REQUIRED_ENTRY_FIELDS) {
+        if (!isNonEmptyString(entry[field])) {
+          issues.push({
+            path: `entries[${index}].${field}`,
+            message: 'Required non-empty string',
+          });
+        }
+      }
+
+      if (!isQuarantineKind(entry.kind)) {
+        issues.push({
+          path: `entries[${index}].kind`,
+          message: 'Expected "unit" or "e2e"',
+        });
+      }
+
+      if (
+        isNonEmptyString(entry.firstSeenAt) &&
+        !isIsoDate(entry.firstSeenAt)
+      ) {
+        issues.push({
+          path: `entries[${index}].firstSeenAt`,
+          message: 'Expected ISO date',
+        });
+      }
+
+      if (isNonEmptyString(entry.expiresAt) && !isIsoDate(entry.expiresAt)) {
+        issues.push({
+          path: `entries[${index}].expiresAt`,
+          message: 'Expected ISO date',
+        });
+      }
+
+      if (
+        isQuarantineKind(entry.kind) &&
+        isNonEmptyString(entry.path) &&
+        entry.kind === 'unit' &&
+        entry.path.startsWith('apps/web/')
+      ) {
+        issues.push({
+          path: `entries[${index}].path`,
+          message: 'Unit paths must be relative to apps/web',
+        });
+      }
+
+      if (
+        isQuarantineKind(entry.kind) &&
+        isNonEmptyString(entry.path) &&
+        entry.kind === 'e2e' &&
+        !entry.path.startsWith('apps/web/')
+      ) {
+        issues.push({
+          path: `entries[${index}].path`,
+          message: 'E2E paths must be repo-root relative (apps/web/...)',
+        });
+      }
+
+      const id = entry.id;
+      const kind = entry.kind;
+      const path = entry.path;
+      const owner = entry.owner;
+      const firstSeenAt = entry.firstSeenAt;
+      const reproductionCommand = entry.reproductionCommand;
+      const fixIssueUrl = entry.fixIssueUrl;
+      const expiresAt = entry.expiresAt;
+
+      if (
+        isQuarantineKind(kind) &&
+        isNonEmptyString(id) &&
+        isNonEmptyString(path) &&
+        isNonEmptyString(owner) &&
+        isNonEmptyString(firstSeenAt) &&
+        isNonEmptyString(reproductionCommand) &&
+        isNonEmptyString(fixIssueUrl) &&
+        isNonEmptyString(expiresAt)
+      ) {
+        entries.push({
+          id: id.trim(),
+          kind,
+          path: path.trim(),
+          owner: owner.trim(),
+          firstSeenAt: firstSeenAt.trim(),
+          reproductionCommand: reproductionCommand.trim(),
+          fixIssueUrl: fixIssueUrl.trim(),
+          expiresAt: expiresAt.trim(),
+          consecutiveSuccesses:
+            typeof entry.consecutiveSuccesses === 'number'
+              ? entry.consecutiveSuccesses
+              : 0,
+        });
+      }
+    });
+  } else if (Array.isArray(raw.unit) || Array.isArray(raw.e2e)) {
+    const legacy = raw as LegacyQuarantineFile;
+    (legacy.unit ?? []).forEach((path, index) => {
+      entries.push(legacyEntry('unit', path, index));
+    });
+    (legacy.e2e ?? []).forEach((path, index) => {
+      entries.push(legacyEntry('e2e', path, index));
+    });
+    issues.push({
+      path: 'entries',
+      message:
+        'Legacy unit/e2e arrays detected — migrate to schemaVersion 1 entries with owner metadata',
+    });
+  } else {
+    issues.push({
+      path: 'entries',
+      message: 'Expected entries array',
+    });
+  }
+
+  const ids = new Set<string>();
+  for (const entry of entries) {
+    if (ids.has(entry.id)) {
+      issues.push({
+        path: `entries.${entry.id}`,
+        message: 'Duplicate entry id',
+      });
+    }
+    ids.add(entry.id);
+  }
+
+  const retryBudget: QuarantineRetryBudget = {
+    unitDefaultRetries: retryBudgetResult.unitDefaultRetries,
+    quarantineUnitRetries: retryBudgetResult.quarantineUnitRetries,
+    e2eDefaultRetries: retryBudgetResult.e2eDefaultRetries,
+    quarantineE2eRetries: retryBudgetResult.quarantineE2eRetries,
+    maxRetryAttemptsPerCiRun: retryBudgetResult.maxRetryAttemptsPerCiRun,
+    unitShardCount: retryBudgetResult.unitShardCount,
+  };
+
+  const ledger: QuarantineLedger = {
+    schemaVersion: 1,
+    retryBudget,
+    entries,
+  };
+
+  const summary = buildQuarantineLedgerSummary({
+    entries,
+    retryBudget,
+  });
+
+  if (!summary.withinRetryBudget) {
+    issues.push({
+      path: 'retryBudget.maxRetryAttemptsPerCiRun',
+      message: `Estimated retry attempts (${summary.estimatedRetryAttemptsPerRun}) exceed cap (${summary.retryBudgetCap})`,
+    });
+  }
+
+  const unitPaths = entries
+    .filter(entry => entry.kind === 'unit')
+    .map(entry => entry.path);
+  const e2ePaths = entries
+    .filter(entry => entry.kind === 'e2e')
+    .map(entry => entry.path);
+
+  return {
+    ledger,
+    unitPaths,
+    e2ePaths,
+    summary,
+    issues,
+  };
+}
+
+export function buildQuarantineLedgerSummary(input: {
+  readonly entries: readonly QuarantineLedgerEntry[];
+  readonly retryBudget: QuarantineRetryBudget;
+  readonly now?: Date;
+}): QuarantineLedgerSummary {
+  const now = input.now ?? new Date();
+  const nowMs = now.getTime();
+  const soonThresholdMs = 14 * 24 * 60 * 60 * 1000;
+
+  let activeCount = 0;
+  let expiredCount = 0;
+  let expiringSoonCount = 0;
+  let unitCount = 0;
+  let e2eCount = 0;
+
+  for (const entry of input.entries) {
+    const expiresMs = Date.parse(entry.expiresAt);
+    const isExpired = !Number.isNaN(expiresMs) && expiresMs < nowMs;
+
+    if (entry.kind === 'unit') unitCount += 1;
+    if (entry.kind === 'e2e') e2eCount += 1;
+
+    if (isExpired) {
+      expiredCount += 1;
+      continue;
+    }
+
+    activeCount += 1;
+    if (!Number.isNaN(expiresMs) && expiresMs - nowMs <= soonThresholdMs) {
+      expiringSoonCount += 1;
+    }
+  }
+
+  const quarantineUnitRetries =
+    unitCount * input.retryBudget.quarantineUnitRetries;
+  const quarantineE2eRetries =
+    e2eCount * input.retryBudget.quarantineE2eRetries;
+  const defaultUnitRetries =
+    input.retryBudget.unitShardCount * input.retryBudget.unitDefaultRetries;
+
+  const estimatedRetryAttemptsPerRun =
+    defaultUnitRetries + quarantineUnitRetries + quarantineE2eRetries;
+  const retryBudgetCap = input.retryBudget.maxRetryAttemptsPerCiRun;
+  const retryBudgetUsagePercent =
+    retryBudgetCap > 0
+      ? Math.min(100, (estimatedRetryAttemptsPerRun / retryBudgetCap) * 100)
+      : 0;
+
+  return {
+    activeCount,
+    expiredCount,
+    unitCount,
+    e2eCount,
+    estimatedRetryAttemptsPerRun,
+    retryBudgetCap,
+    retryBudgetUsagePercent,
+    withinRetryBudget: estimatedRetryAttemptsPerRun <= retryBudgetCap,
+    expiringSoonCount,
+  };
+}
+
+export function isQuarantineLedgerValid(
+  parsed: ParsedQuarantineLedger
+): boolean {
+  return parsed.issues.length === 0;
+}
+
+export function formatQuarantineValidationReport(
+  parsed: ParsedQuarantineLedger
+): string {
+  if (parsed.issues.length === 0) {
+    return [
+      'Quarantine ledger is valid.',
+      `Active entries: ${parsed.summary.activeCount}`,
+      `Retry budget: ${parsed.summary.estimatedRetryAttemptsPerRun}/${parsed.summary.retryBudgetCap} (${parsed.summary.retryBudgetUsagePercent.toFixed(1)}%)`,
+    ].join('\n');
+  }
+
+  return parsed.issues
+    .map(issue => `${issue.path}: ${issue.message}`)
+    .join('\n');
+}

--- a/apps/web/lib/testing/quarantine-ledger.ts
+++ b/apps/web/lib/testing/quarantine-ledger.ts
@@ -384,15 +384,15 @@ export function buildQuarantineLedgerSummary(input: {
     const expiresMs = Date.parse(entry.expiresAt);
     const isExpired = !Number.isNaN(expiresMs) && expiresMs < nowMs;
 
-    if (entry.kind === 'unit') unitCount += 1;
-    if (entry.kind === 'e2e') e2eCount += 1;
-
     if (isExpired) {
       expiredCount += 1;
       continue;
     }
 
     activeCount += 1;
+    if (entry.kind === 'unit') unitCount += 1;
+    if (entry.kind === 'e2e') e2eCount += 1;
+
     if (!Number.isNaN(expiresMs) && expiresMs - nowMs <= soonThresholdMs) {
       expiringSoonCount += 1;
     }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,6 +47,7 @@
     "test:coverage": "vitest run --coverage",
     "test:truth": "node scripts/test-truth-guard.mjs",
     "test:bug-to-test": "tsx scripts/check-bug-to-test-rule.ts",
+    "test:quarantine-ledger": "tsx scripts/check-quarantine-ledger.ts",
     "test:watch": "vitest --config=vitest.config.mts",
     "test:fast": "vitest run --config=vitest.config.mts",
     "test:profile": "tsx scripts/test-performance-profiler.ts",

--- a/apps/web/scripts/check-quarantine-ledger.ts
+++ b/apps/web/scripts/check-quarantine-ledger.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env tsx
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  formatQuarantineValidationReport,
+  isQuarantineLedgerValid,
+  parseQuarantineLedger,
+} from '@/lib/testing/quarantine-ledger';
+
+const ledgerPath = resolve(process.cwd(), 'tests/quarantine.json');
+
+function main() {
+  const raw = JSON.parse(readFileSync(ledgerPath, 'utf8')) as unknown;
+  const parsed = parseQuarantineLedger(raw);
+
+  console.log(formatQuarantineValidationReport(parsed));
+
+  if (!isQuarantineLedgerValid(parsed)) {
+    process.exit(1);
+  }
+}
+
+main();

--- a/apps/web/scripts/emit-quarantine-github-output.ts
+++ b/apps/web/scripts/emit-quarantine-github-output.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env tsx
+
+import { appendFileSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  isQuarantineLedgerValid,
+  parseQuarantineLedger,
+} from '@/lib/testing/quarantine-ledger';
+
+const ledgerPath = resolve(process.cwd(), 'tests/quarantine.json');
+
+function main() {
+  const raw = JSON.parse(readFileSync(ledgerPath, 'utf8')) as unknown;
+  const parsed = parseQuarantineLedger(raw);
+
+  if (!isQuarantineLedgerValid(parsed)) {
+    console.error('Quarantine ledger validation failed:\n');
+    for (const issue of parsed.issues) {
+      console.error(`- ${issue.path}: ${issue.message}`);
+    }
+    process.exit(1);
+  }
+
+  const unitFiles = parsed.unitPaths.join(' ');
+  const unitExcludes = parsed.unitPaths
+    .map(path => `--exclude=${path}`)
+    .join(' ');
+  const e2eFiles = parsed.e2ePaths.join(' ');
+
+  const lines = [
+    `unit_files=${unitFiles}`,
+    `unit_excludes=${unitExcludes}`,
+    `e2e_files=${e2eFiles}`,
+    `has_unit=${parsed.unitPaths.length > 0 ? 'true' : 'false'}`,
+    `has_quarantine=${parsed.e2ePaths.length > 0 ? 'true' : 'false'}`,
+    `quarantined_specs=${e2eFiles}`,
+    `unit_default_retries=${parsed.ledger.retryBudget.unitDefaultRetries}`,
+    `quarantine_unit_retries=${parsed.ledger.retryBudget.quarantineUnitRetries}`,
+    `quarantine_e2e_retries=${parsed.ledger.retryBudget.quarantineE2eRetries}`,
+    `retry_budget_usage=${parsed.summary.estimatedRetryAttemptsPerRun}`,
+    `retry_budget_cap=${parsed.summary.retryBudgetCap}`,
+  ];
+
+  const output = process.env.GITHUB_OUTPUT;
+  if (output) {
+    appendFileSync(output, `${lines.join('\n')}\n`);
+  } else {
+    console.log(lines.join('\n'));
+  }
+}
+
+main();

--- a/apps/web/tests/TESTING.md
+++ b/apps/web/tests/TESTING.md
@@ -327,9 +327,12 @@ The helper now prefers the local dev auth route on loopback/private hosts and on
 
 ### Flaky tests
 
-- Add to `tests/quarantine.json` with owner and exit criteria
+- Add to `tests/quarantine.json` ledger entries with owner, first-seen date, reproduction command, fix issue link, and expiration date
+- Retry budget caps live in `retryBudget` and are enforced by CI via `.github/scripts/quarantine-ledger.mjs`
+- HUD `/app/admin/ops` shows active quarantine count and retry budget usage
 - Auto-unquarantined after 5 consecutive passes
 - Run `pnpm test:flaky` to detect flaky tests
+- Validate ledger locally with `pnpm --filter @jovie/web run test:quarantine-ledger`
 
 ### Smoke suite too slow
 

--- a/apps/web/tests/lib/hud/metrics.test.ts
+++ b/apps/web/tests/lib/hud/metrics.test.ts
@@ -213,6 +213,8 @@ describe('getHudMetrics', () => {
 
     const metrics = await getHudMetrics('admin');
 
+    expect(metrics.testing.quarantine.activeCount).toBeGreaterThanOrEqual(0);
+    expect(metrics.testing.quarantine.retryBudgetCap).toBeGreaterThan(0);
     expect(metrics.sources.stripe.state).toBe('ok');
     expect(metrics.sources.mercury.state).toBe('ok');
     expect(metrics.sources.database.state).toBe('ok');

--- a/apps/web/tests/quarantine.json
+++ b/apps/web/tests/quarantine.json
@@ -1,7 +1,46 @@
 {
-  "unit": [
-    "tests/contracts/dashboard-apis.spec.ts",
-    "tests/unit/dashboard/SettingsAdPixelsSection.test.tsx"
-  ],
-  "e2e": ["apps/web/tests/e2e/dashboard-pages-health.spec.ts"]
+  "schemaVersion": 1,
+  "retryBudget": {
+    "unitDefaultRetries": 1,
+    "quarantineUnitRetries": 2,
+    "e2eDefaultRetries": 0,
+    "quarantineE2eRetries": 2,
+    "maxRetryAttemptsPerCiRun": 120,
+    "unitShardCount": 6
+  },
+  "entries": [
+    {
+      "id": "unit-dashboard-apis-contract",
+      "kind": "unit",
+      "path": "tests/contracts/dashboard-apis.spec.ts",
+      "owner": "platform",
+      "firstSeenAt": "2026-02-10",
+      "reproductionCommand": "pnpm --filter @jovie/web exec vitest run tests/contracts/dashboard-apis.spec.ts",
+      "fixIssueUrl": "https://linear.app/jovie/issue/JOV-782",
+      "expiresAt": "2026-09-30",
+      "consecutiveSuccesses": 0
+    },
+    {
+      "id": "unit-settings-ad-pixels",
+      "kind": "unit",
+      "path": "tests/unit/dashboard/SettingsAdPixelsSection.test.tsx",
+      "owner": "platform",
+      "firstSeenAt": "2026-02-10",
+      "reproductionCommand": "pnpm --filter @jovie/web exec vitest run tests/unit/dashboard/SettingsAdPixelsSection.test.tsx",
+      "fixIssueUrl": "https://linear.app/jovie/issue/JOV-782",
+      "expiresAt": "2026-09-30",
+      "consecutiveSuccesses": 0
+    },
+    {
+      "id": "e2e-dashboard-pages-health",
+      "kind": "e2e",
+      "path": "apps/web/tests/e2e/dashboard-pages-health.spec.ts",
+      "owner": "platform",
+      "firstSeenAt": "2026-02-10",
+      "reproductionCommand": "cd apps/web && pnpm playwright test tests/e2e/dashboard-pages-health.spec.ts --project=chromium",
+      "fixIssueUrl": "https://linear.app/jovie/issue/JOV-782",
+      "expiresAt": "2026-09-30",
+      "consecutiveSuccesses": 0
+    }
+  ]
 }

--- a/apps/web/tests/unit/lib/testing/quarantine-ledger.test.ts
+++ b/apps/web/tests/unit/lib/testing/quarantine-ledger.test.ts
@@ -122,7 +122,7 @@ describe('quarantine ledger', () => {
     expect(summary.activeCount).toBe(1);
     expect(summary.expiredCount).toBe(1);
     expect(summary.unitCount).toBe(1);
-    expect(summary.e2eCount).toBe(1);
+    expect(summary.e2eCount).toBe(0);
   });
 
   it('formats a validation report', () => {

--- a/apps/web/tests/unit/lib/testing/quarantine-ledger.test.ts
+++ b/apps/web/tests/unit/lib/testing/quarantine-ledger.test.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  buildQuarantineLedgerSummary,
+  formatQuarantineValidationReport,
+  isQuarantineLedgerValid,
+  parseQuarantineLedger,
+} from '@/lib/testing/quarantine-ledger';
+
+describe('quarantine ledger', () => {
+  it('parses the committed ledger file with required metadata', () => {
+    const ledgerPath = resolve(process.cwd(), 'tests/quarantine.json');
+    const parsed = parseQuarantineLedger(
+      JSON.parse(readFileSync(ledgerPath, 'utf8'))
+    );
+
+    expect(isQuarantineLedgerValid(parsed)).toBe(true);
+    expect(parsed.ledger.entries).toHaveLength(3);
+    expect(parsed.unitPaths).toHaveLength(2);
+    expect(parsed.e2ePaths).toHaveLength(1);
+    expect(parsed.summary.withinRetryBudget).toBe(true);
+  });
+
+  it('flags missing required entry metadata', () => {
+    const parsed = parseQuarantineLedger({
+      schemaVersion: 1,
+      retryBudget: {
+        unitDefaultRetries: 1,
+        quarantineUnitRetries: 2,
+        e2eDefaultRetries: 0,
+        quarantineE2eRetries: 2,
+        maxRetryAttemptsPerCiRun: 10,
+        unitShardCount: 6,
+      },
+      entries: [
+        {
+          id: 'broken-entry',
+          kind: 'unit',
+          path: 'tests/foo.test.ts',
+          owner: '',
+          firstSeenAt: '2026-02-01',
+          reproductionCommand: 'pnpm test',
+          fixIssueUrl: 'https://linear.app/jovie/issue/JOV-1',
+          expiresAt: '2026-12-31',
+        },
+      ],
+    });
+
+    expect(isQuarantineLedgerValid(parsed)).toBe(false);
+    expect(parsed.issues.some(issue => issue.path.includes('owner'))).toBe(
+      true
+    );
+  });
+
+  it('enforces retry budget caps', () => {
+    const parsed = parseQuarantineLedger({
+      schemaVersion: 1,
+      retryBudget: {
+        unitDefaultRetries: 1,
+        quarantineUnitRetries: 5,
+        e2eDefaultRetries: 0,
+        quarantineE2eRetries: 5,
+        maxRetryAttemptsPerCiRun: 10,
+        unitShardCount: 6,
+      },
+      entries: Array.from({ length: 4 }, (_, index) => ({
+        id: `unit-${index}`,
+        kind: 'unit',
+        path: `tests/foo-${index}.test.ts`,
+        owner: 'platform',
+        firstSeenAt: '2026-02-01',
+        reproductionCommand: 'pnpm test',
+        fixIssueUrl: 'https://linear.app/jovie/issue/JOV-1',
+        expiresAt: '2026-12-31',
+      })),
+    });
+
+    expect(parsed.summary.withinRetryBudget).toBe(false);
+    expect(
+      parsed.issues.some(issue =>
+        issue.path.includes('maxRetryAttemptsPerCiRun')
+      )
+    ).toBe(true);
+  });
+
+  it('summarizes active vs expired entries', () => {
+    const summary = buildQuarantineLedgerSummary({
+      entries: [
+        {
+          id: 'active',
+          kind: 'unit',
+          path: 'tests/active.test.ts',
+          owner: 'platform',
+          firstSeenAt: '2026-02-01',
+          reproductionCommand: 'pnpm test',
+          fixIssueUrl: 'https://linear.app/jovie/issue/JOV-1',
+          expiresAt: '2099-01-01',
+        },
+        {
+          id: 'expired',
+          kind: 'e2e',
+          path: 'apps/web/tests/e2e/expired.spec.ts',
+          owner: 'platform',
+          firstSeenAt: '2026-02-01',
+          reproductionCommand: 'pnpm playwright test',
+          fixIssueUrl: 'https://linear.app/jovie/issue/JOV-2',
+          expiresAt: '2020-01-01',
+        },
+      ],
+      retryBudget: {
+        unitDefaultRetries: 1,
+        quarantineUnitRetries: 2,
+        e2eDefaultRetries: 0,
+        quarantineE2eRetries: 2,
+        maxRetryAttemptsPerCiRun: 120,
+        unitShardCount: 6,
+      },
+      now: new Date('2026-06-13T00:00:00.000Z'),
+    });
+
+    expect(summary.activeCount).toBe(1);
+    expect(summary.expiredCount).toBe(1);
+    expect(summary.unitCount).toBe(1);
+    expect(summary.e2eCount).toBe(1);
+  });
+
+  it('formats a validation report', () => {
+    const parsed = parseQuarantineLedger({ entries: [] });
+    expect(formatQuarantineValidationReport(parsed)).toContain(
+      'Quarantine ledger is valid'
+    );
+  });
+});

--- a/apps/web/types/hud.ts
+++ b/apps/web/types/hud.ts
@@ -72,6 +72,23 @@ export interface HudMetricSourceTrust {
   readonly nextStep: string | null;
 }
 
+export interface HudTestingQuarantineMetrics {
+  readonly activeCount: number;
+  readonly expiredCount: number;
+  readonly expiringSoonCount: number;
+  readonly unitCount: number;
+  readonly e2eCount: number;
+  readonly estimatedRetryAttemptsPerRun: number;
+  readonly retryBudgetCap: number;
+  readonly retryBudgetUsagePercent: number;
+  readonly withinRetryBudget: boolean;
+  readonly unitDefaultRetries: number;
+  readonly quarantineUnitRetries: number;
+  readonly quarantineE2eRetries: number;
+  readonly isValid: boolean;
+  readonly ledgerPath: string;
+}
+
 export interface HudMetrics {
   accessMode: HudAccessMode;
   branding: HudBranding;
@@ -85,6 +102,9 @@ export interface HudMetrics {
     incidents24h: number;
     lastIncidentAtIso: string | null;
     unresolvedSentryIssues24h: number;
+  };
+  testing: {
+    quarantine: HudTestingQuarantineMetrics;
   };
   deployments: HudDeployments;
   aiOps: HermesAiOpsSummary;

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "test:coverage:report": "tsx scripts/audit-test-coverage.ts",
     "test:coverage:diff": "tsx scripts/audit-test-coverage.ts --check-pr",
     "test:bug-to-test": "pnpm --filter @jovie/web run test:bug-to-test",
+    "test:quarantine-ledger": "pnpm --filter @jovie/web run test:quarantine-ledger",
     "admin:green": "doppler run --project jovie-web --config dev -- pnpm --filter=@jovie/web run admin:green",
     "admin:green:record": "doppler run --project jovie-web --config dev -- pnpm --filter=@jovie/web run admin:green:record",
     "admin:green:watch": "doppler run --project jovie-web --config dev -- pnpm --filter=@jovie/web run admin:green:watch",


### PR DESCRIPTION
## Summary

Implements **JOV-1874** — flaky quarantine ledger with retry budget enforcement and HUD visibility.

- Upgrades `apps/web/tests/quarantine.json` to **schemaVersion 1** with per-entry metadata: owner, first-seen date, reproduction command, fix issue link, expiration date
- Adds shared ledger parser/validator (`apps/web/lib/testing/quarantine-ledger.ts`) and CI helper (`.github/scripts/quarantine-ledger.mjs`)
- CI structural contract now validates the ledger; unit/E2E lanes read retry caps from `retryBudget` instead of hardcoded `--retry=1/2`
- `/app/admin/ops` HUD shows **Flaky Quarantine** count and retry budget usage (`12/120` today)

## Verification

- [x] `pnpm test:quarantine-ledger`
- [x] `node .github/scripts/quarantine-ledger.mjs validate`
- [x] `vitest run tests/unit/lib/testing/quarantine-ledger.test.ts tests/lib/hud/metrics.test.ts`
- [x] Pre-push: biome, typecheck, lint

## Linear

Closes JOV-1874

bug-to-test: satisfied — regression tests in `tests/unit/lib/testing/quarantine-ledger.test.ts`