### PR TITLE
fix(chat): stabilize transport cache during conversation adoption (JOV-3007)

### DIFF
--- a/apps/web/components/jovie/hooks/useJovieChat.ts
+++ b/apps/web/components/jovie/hooks/useJovieChat.ts
@@ -178,8 +178,22 @@ function getCachedTimelineState(conversationId: string | null) {
   );
 }
 
+function shouldCacheTimelineState(state: ChatTimelineState) {
+  return !state.messages.some(
+    message =>
+      message.status === 'sending' ||
+      message.status === 'pending' ||
+      message.status === 'sent' ||
+      message.status === 'streaming'
+  );
+}
+
 function cacheTimelineState(state: ChatTimelineState) {
   if (!state.conversationId) return;
+  if (!shouldCacheTimelineState(state)) {
+    timelineStateCache.delete(state.conversationId);
+    return;
+  }
   timelineStateCache.set(state.conversationId, state);
   while (timelineStateCache.size > TIMELINE_CACHE_LIMIT) {
     const oldestKey = timelineStateCache.keys().next().value;
@@ -296,6 +310,10 @@ export function useJovieChat({
     },
     [activeConversationId, onConversationCreate]
   );
+  const adoptServerConversationIdRef = useRef(adoptServerConversationId);
+  useEffect(() => {
+    adoptServerConversationIdRef.current = adoptServerConversationId;
+  }, [adoptServerConversationId]);
 
   // Determine whether to poll: only while we're actively waiting for a title
   // and haven't exceeded the max poll duration.
@@ -334,7 +352,10 @@ export function useJovieChat({
           const serverTurnId = response.headers.get('x-chat-turn-id');
           const clientTurnId = activeClientTurnIdRef.current;
           if (serverConversationId) {
-            adoptServerConversationId(serverConversationId, 'reserved');
+            adoptServerConversationIdRef.current(
+              serverConversationId,
+              'reserved'
+            );
           }
           if (serverConversationId && clientTurnId) {
             dispatchTimelineEvent({
@@ -349,13 +370,7 @@ export function useJovieChat({
           return response;
         },
       }),
-    [
-      profileId,
-      artistContext,
-      activeConversationId,
-      adoptServerConversationId,
-      dispatchTimelineEvent,
-    ]
+    [profileId, artistContext, activeConversationId, dispatchTimelineEvent]
   );
 
   // Convert loaded messages to canonical timeline input. Query data feeds the

--- a/apps/web/tests/unit/chat/useJovieChat.rate-limit.test.tsx
+++ b/apps/web/tests/unit/chat/useJovieChat.rate-limit.test.tsx
@@ -230,6 +230,35 @@ describe('useJovieChat', () => {
     expect(setMessagesMock).not.toHaveBeenCalled();
   });
 
+  it('does not restore in-progress timeline rows from cache after remount', async () => {
+    const { result, unmount } = renderHook(() =>
+      useJovieChat({ profileId: 'profile_1', conversationId: 'conv_cache' })
+    );
+
+    await act(async () => {
+      await result.current.submitMessage('Keep streaming');
+    });
+
+    expect(result.current.messages).toMatchObject([
+      {
+        role: 'user',
+        status: 'sending',
+      },
+      {
+        role: 'assistant',
+        status: 'pending',
+      },
+    ]);
+
+    unmount();
+
+    const remounted = renderHook(() =>
+      useJovieChat({ profileId: 'profile_1', conversationId: 'conv_cache' })
+    );
+
+    expect(remounted.result.current.messages).toHaveLength(0);
+  });
+
   it('merges loaded conversation messages into the canonical timeline without SDK replacement', () => {
     mockConversationData = {
       conversation: { id: 'conv_merge', title: null },


### PR DESCRIPTION
<!-- linear-issue-id:9adfa1fb-ecdc-4844-a8f1-5d932f6f9b40 -->
## Summary
- stabilize `useJovieChat` transport adoption by routing reserved conversation-id updates through a ref-backed callback instead of a memo dependency
- avoid restoring in-progress timeline rows from the cache after remounts or thread switches
- add a hook regression test that proves stale in-flight timeline rows are not resurrected

## Validation
- `pnpm --filter web exec vitest run tests/unit/chat/useJovieChat.rate-limit.test.tsx`
- `pnpm biome check --write apps/web/components/jovie/hooks/useJovieChat.ts apps/web/tests/unit/chat/useJovieChat.rate-limit.test.tsx`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- commit hook guardrails passed: `next:proxy-guard`, staged Biome, staged ESLint, staged a11y check, staged `@jovie/web` typecheck
- `git diff --check`

## CodeRabbit
- `coderabbit review --plain --type uncommitted --base origin/main` connected and completed analysis phases, but the CLI hung while emitting final comments
- `coderabbit review --agent --type uncommitted --base origin/main` also reached `reviewing` and then stalled without returning findings
- no local CodeRabbit findings were emitted to address in this run

## Risks
- transport identity is still expected to change on an actual conversation boundary change; this diff only removes stale callback churn during reserved-id adoption
- the new cache guard intentionally drops in-progress local timeline rows on remount so we do not leak stale streaming state across conversations
