### PR TITLE
feat(testing): add web signed-in auth verification harness (JOV-2761)

### DIFF
--- a/AUTH_AUDIT.md
+++ b/AUTH_AUDIT.md
@@ -21,14 +21,23 @@ across Web, iOS, Electron, and Chrome Extension.
 | TestFlight launch crash guard | Installed TestFlight build `1.0 (40)` crash reports showed `EXC_BREAKPOINT` with Swift `_assertionFailure` after the Release config rejected a `pk_test` Clerk key. PR #9918 replaced the launch-time fatal error with a fail-closed path, and PR #9920 restored mock UI-test auth behavior. Main TestFlight run `26841365624` distributed build `1.0 (42)`; local build 42 launched and remained running with no fresh `Jovie*.ips` crash report. | Passed for no-crash launch |
 | TestFlight live sign-in config | Local build `1.0 (42)` still embeds a `pk_test` Clerk publishable key and therefore shows `Sign-in Unavailable`. Production Clerk secret/config remediation is tracked by [JOV-2713](https://linear.app/jovie/issue/JOV-2713/provision-production-clerk-key-for-ios-testflight-sign-in). | Open |
 
+## Web Evidence (JOV-2761)
+
+| Flow | Evidence | Result |
+| --- | --- | --- |
+| Clerk key routing preflight | `pnpm --filter @jovie/web run check:signed-in-auth -- --target=local\|stg\|prd` validates required env keys, staging host routing, and `staging_inherits_prod` guardrails. | Harness shipped |
+| Deployment Clerk status probe | `pnpm --filter @jovie/web run verify:signed-in-auth -- --target=<env> --probe --base-url=<url>` records `x-clerk-key-status`, auth-unavailable copy, and loopback dev test-auth session proof. | Harness shipped |
+| Signed-in web session harness | `pnpm run test:auth:web` runs unit checks plus `tests/e2e/signed-in-auth-verify.spec.ts` for session bootstrap, authenticated app shell, API/session proof, and sign-out. | Harness shipped |
+| Native surfaces follow-up | Electron, iOS live TestFlight sign-in, and Chrome extension signed-in proof remain tracked under JOV-2761 follow-up / JOV-2712. | Open |
+
 ## Current Platform Status
 
 | Platform | Status |
 | --- | --- |
 | iOS | Local auth callback, real-browser auth callback, live-auth PR verification, TestFlight launch no-crash proof, and CI evidence are current through `8e333b2e97`; live TestFlight sign-in remains blocked by JOV-2713. |
-| Web | Evidence required under JOV-2712. |
-| Electron | Evidence required under JOV-2712. |
-| Chrome Extension | Evidence required under JOV-2712. |
+| Web | JOV-2761 web harness covers Clerk routing preflight, deployment probe, and signed-in Playwright verification; staging/production live proof uses Doppler-backed `verify:signed-in-auth --probe`. |
+| Electron | Evidence required under JOV-2712 / JOV-2761 follow-up. |
+| Chrome Extension | Evidence required under JOV-2712 / JOV-2761 follow-up. |
 
 ## Acceptance Checks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project uses [Calendar Versioning](https://calver.org/) (`YY.M.PATCH`).
 
 ### Added
 
+- [internal] **Signed-in auth verification harness (JOV-2761)**: adds `check:signed-in-auth`, `verify:signed-in-auth`, `test:auth:web`, Clerk key-routing preflight, deployment probe, and Playwright signed-in session proof for web (Electron/iOS/extension follow-up tracked separately).
 - [internal] **Bug-to-test rule enforcement (JOV-1873)**: adds `pnpm test:bug-to-test`, PR template checklist, Danger gate, and `/ship` Step 3.35 to require regression tests (or documented waivers) on bug-fix PRs.
 
 ## [26.6.50] - 2026-06-11

--- a/apps/web/lib/readiness/signed-in-auth.ts
+++ b/apps/web/lib/readiness/signed-in-auth.ts
@@ -112,25 +112,73 @@ function checkRequiredEnvKeys(
   ];
 }
 
+interface ClerkEnvSnapshot {
+  readonly publishableKey?: string;
+  readonly secretKey?: string;
+  readonly stagingPublishableKey?: string;
+  readonly stagingSecretKey?: string;
+}
+
+function snapshotClerkEnv(): ClerkEnvSnapshot {
+  return {
+    publishableKey: process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+    secretKey: process.env.CLERK_SECRET_KEY,
+    stagingPublishableKey: process.env.CLERK_PUBLISHABLE_KEY_STAGING,
+    stagingSecretKey: process.env.CLERK_SECRET_KEY_STAGING,
+  };
+}
+
+function restoreClerkEnv(snapshot: ClerkEnvSnapshot): void {
+  if (snapshot.publishableKey === undefined) {
+    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  } else {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = snapshot.publishableKey;
+  }
+
+  if (snapshot.secretKey === undefined) {
+    delete process.env.CLERK_SECRET_KEY;
+  } else {
+    process.env.CLERK_SECRET_KEY = snapshot.secretKey;
+  }
+
+  if (snapshot.stagingPublishableKey === undefined) {
+    delete process.env.CLERK_PUBLISHABLE_KEY_STAGING;
+  } else {
+    process.env.CLERK_PUBLISHABLE_KEY_STAGING = snapshot.stagingPublishableKey;
+  }
+
+  if (snapshot.stagingSecretKey === undefined) {
+    delete process.env.CLERK_SECRET_KEY_STAGING;
+  } else {
+    process.env.CLERK_SECRET_KEY_STAGING = snapshot.stagingSecretKey;
+  }
+}
+
+function withClerkEnv<T>(
+  env: Partial<Record<string, string | undefined>>,
+  run: () => T
+): T {
+  const snapshot = snapshotClerkEnv();
+
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
+    env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  process.env.CLERK_SECRET_KEY = env.CLERK_SECRET_KEY;
+  process.env.CLERK_PUBLISHABLE_KEY_STAGING = env.CLERK_PUBLISHABLE_KEY_STAGING;
+  process.env.CLERK_SECRET_KEY_STAGING = env.CLERK_SECRET_KEY_STAGING;
+
+  try {
+    return run();
+  } finally {
+    restoreClerkEnv(snapshot);
+  }
+}
+
 function checkClerkKeyRouting(
   env: Partial<Record<string, string | undefined>>,
   target: SignedInAuthTarget,
   hostname: string
 ): SignedInAuthCheck[] {
-  const previousPublishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
-  const previousSecretKey = process.env.CLERK_SECRET_KEY;
-  const previousStagingPublishableKey =
-    process.env.CLERK_PUBLISHABLE_KEY_STAGING;
-  const previousStagingSecretKey = process.env.CLERK_SECRET_KEY_STAGING;
-
-  try {
-    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
-      env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
-    process.env.CLERK_SECRET_KEY = env.CLERK_SECRET_KEY;
-    process.env.CLERK_PUBLISHABLE_KEY_STAGING =
-      env.CLERK_PUBLISHABLE_KEY_STAGING;
-    process.env.CLERK_SECRET_KEY_STAGING = env.CLERK_SECRET_KEY_STAGING;
-
+  return withClerkEnv(env, () => {
     const keys = resolveClerkKeys(hostname);
 
     if (target === 'stg' && keys.status === 'staging_inherits_prod') {
@@ -176,31 +224,7 @@ function checkClerkKeyRouting(
         evidence: `status=${keys.status} publishableKeyPrefix=${publishableKeyPrefix(keys.publishableKey) ?? 'missing'}`,
       },
     ];
-  } finally {
-    if (previousPublishableKey === undefined) {
-      delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
-    } else {
-      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = previousPublishableKey;
-    }
-
-    if (previousSecretKey === undefined) {
-      delete process.env.CLERK_SECRET_KEY;
-    } else {
-      process.env.CLERK_SECRET_KEY = previousSecretKey;
-    }
-
-    if (previousStagingPublishableKey === undefined) {
-      delete process.env.CLERK_PUBLISHABLE_KEY_STAGING;
-    } else {
-      process.env.CLERK_PUBLISHABLE_KEY_STAGING = previousStagingPublishableKey;
-    }
-
-    if (previousStagingSecretKey === undefined) {
-      delete process.env.CLERK_SECRET_KEY_STAGING;
-    } else {
-      process.env.CLERK_SECRET_KEY_STAGING = previousStagingSecretKey;
-    }
-  }
+  });
 }
 
 function checkPublishableKeyType(
@@ -240,45 +264,7 @@ function resolveClerkKeysForEnv(
   env: Partial<Record<string, string | undefined>>,
   hostname: string
 ) {
-  const previousPublishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
-  const previousSecretKey = process.env.CLERK_SECRET_KEY;
-  const previousStagingPublishableKey =
-    process.env.CLERK_PUBLISHABLE_KEY_STAGING;
-  const previousStagingSecretKey = process.env.CLERK_SECRET_KEY_STAGING;
-
-  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
-    env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
-  process.env.CLERK_SECRET_KEY = env.CLERK_SECRET_KEY;
-  process.env.CLERK_PUBLISHABLE_KEY_STAGING = env.CLERK_PUBLISHABLE_KEY_STAGING;
-  process.env.CLERK_SECRET_KEY_STAGING = env.CLERK_SECRET_KEY_STAGING;
-
-  const keys = resolveClerkKeys(hostname);
-
-  if (previousPublishableKey === undefined) {
-    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
-  } else {
-    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = previousPublishableKey;
-  }
-
-  if (previousSecretKey === undefined) {
-    delete process.env.CLERK_SECRET_KEY;
-  } else {
-    process.env.CLERK_SECRET_KEY = previousSecretKey;
-  }
-
-  if (previousStagingPublishableKey === undefined) {
-    delete process.env.CLERK_PUBLISHABLE_KEY_STAGING;
-  } else {
-    process.env.CLERK_PUBLISHABLE_KEY_STAGING = previousStagingPublishableKey;
-  }
-
-  if (previousStagingSecretKey === undefined) {
-    delete process.env.CLERK_SECRET_KEY_STAGING;
-  } else {
-    process.env.CLERK_SECRET_KEY_STAGING = previousStagingSecretKey;
-  }
-
-  return keys;
+  return withClerkEnv(env, () => resolveClerkKeys(hostname));
 }
 
 function checkStagingHostnames(): SignedInAuthCheck {

--- a/apps/web/lib/readiness/signed-in-auth.ts
+++ b/apps/web/lib/readiness/signed-in-auth.ts
@@ -283,7 +283,9 @@ function resolveClerkKeysForEnv(
 
 function checkStagingHostnames(): SignedInAuthCheck {
   const expected = [`staging.${HOSTNAME}`, `main.${HOSTNAME}`];
-  const actual = Array.from(STAGING_HOSTNAMES).sort();
+  const actual = Array.from(STAGING_HOSTNAMES).sort((a, b) =>
+    a.localeCompare(b)
+  );
   const matches =
     expected.every(hostname => STAGING_HOSTNAMES.has(hostname)) &&
     actual.length === expected.length;
@@ -366,15 +368,62 @@ interface ProbeSignedInAuthDeploymentOptions {
   readonly timeoutMs?: number;
 }
 
-export async function probeSignedInAuthDeployment(
-  baseUrl: string,
-  options: ProbeSignedInAuthDeploymentOptions = {}
-): Promise<SignedInAuthProbeResult> {
-  const timeoutMs = options.timeoutMs ?? 15_000;
-  const parsedBaseUrl = new URL(baseUrl);
-  const hostname = parsedBaseUrl.hostname;
-  const checks: SignedInAuthCheck[] = [];
+function resolveClerkKeyStatus(
+  headerValue: string | null
+): ClerkKeyStatus | 'missing' {
+  if (
+    headerValue === 'ok' ||
+    headerValue === 'no_publishable_key' ||
+    headerValue === 'staging_missing' ||
+    headerValue === 'staging_inherits_prod'
+  ) {
+    return headerValue;
+  }
 
+  return 'missing';
+}
+
+function buildSignInProbeChecks(
+  signInResponse: Response,
+  clerkKeyStatus: ClerkKeyStatus | 'missing',
+  authUnavailable: boolean
+): SignedInAuthCheck[] {
+  return [
+    {
+      id: 'signin-reachable',
+      status: signInResponse.ok ? 'pass' : 'fail',
+      message: signInResponse.ok
+        ? 'Sign-in page responded successfully'
+        : `Sign-in page returned HTTP ${signInResponse.status}`,
+      evidence: `status=${signInResponse.status}`,
+    },
+    {
+      id: 'clerk-key-status-header',
+      status: clerkKeyStatus === 'ok' ? 'pass' : 'fail',
+      message:
+        clerkKeyStatus === 'ok'
+          ? 'Middleware reported healthy Clerk key routing'
+          : `Middleware reported Clerk key status ${clerkKeyStatus}`,
+      evidence: `${CLERK_KEY_STATUS_HEADER}=${clerkKeyStatus}`,
+    },
+    {
+      id: 'auth-unavailable-copy',
+      status: authUnavailable ? 'fail' : 'pass',
+      message: authUnavailable
+        ? 'Sign-in page rendered auth-unavailable copy'
+        : 'Sign-in page did not render auth-unavailable copy',
+    },
+  ];
+}
+
+async function probeSignInPage(
+  baseUrl: string,
+  timeoutMs: number,
+  checks: SignedInAuthCheck[]
+): Promise<{
+  readonly clerkKeyStatus: ClerkKeyStatus | 'missing';
+  readonly authUnavailable: boolean;
+}> {
   const signInResponse = await fetch(new URL('/signin', baseUrl), {
     method: 'GET',
     redirect: 'follow',
@@ -389,94 +438,96 @@ export async function probeSignedInAuthDeployment(
     return null;
   });
 
-  let clerkKeyStatus: ClerkKeyStatus | 'missing' = 'missing';
-  let authUnavailable = false;
-
-  if (signInResponse) {
-    const headerValue = signInResponse.headers.get(CLERK_KEY_STATUS_HEADER);
-    clerkKeyStatus =
-      headerValue === 'ok' ||
-      headerValue === 'no_publishable_key' ||
-      headerValue === 'staging_missing' ||
-      headerValue === 'staging_inherits_prod'
-        ? headerValue
-        : 'missing';
-
-    const bodyText = await signInResponse.text().catch(() => '');
-    authUnavailable = hasAuthUnavailableCopy(bodyText);
-
-    checks.push({
-      id: 'signin-reachable',
-      status: signInResponse.ok ? 'pass' : 'fail',
-      message: signInResponse.ok
-        ? 'Sign-in page responded successfully'
-        : `Sign-in page returned HTTP ${signInResponse.status}`,
-      evidence: `status=${signInResponse.status}`,
-    });
-
-    checks.push({
-      id: 'clerk-key-status-header',
-      status: clerkKeyStatus === 'ok' ? 'pass' : 'fail',
-      message:
-        clerkKeyStatus === 'ok'
-          ? 'Middleware reported healthy Clerk key routing'
-          : `Middleware reported Clerk key status ${clerkKeyStatus}`,
-      evidence: `${CLERK_KEY_STATUS_HEADER}=${clerkKeyStatus}`,
-    });
-
-    checks.push({
-      id: 'auth-unavailable-copy',
-      status: authUnavailable ? 'fail' : 'pass',
-      message: authUnavailable
-        ? 'Sign-in page rendered auth-unavailable copy'
-        : 'Sign-in page did not render auth-unavailable copy',
-    });
+  if (!signInResponse) {
+    return { clerkKeyStatus: 'missing', authUnavailable: false };
   }
 
-  let testAuthSessionOk: boolean | null = null;
-  if (isLoopbackHost(hostname)) {
-    const sessionResponse = await fetch(
-      new URL('/api/dev/test-auth/session', baseUrl),
-      {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          [TEST_MODE_HEADER]: TEST_AUTH_BYPASS_MODE,
-        },
-        body: JSON.stringify({ persona: 'creator-ready' }),
-        signal: AbortSignal.timeout(timeoutMs),
-      }
-    ).catch(error => {
-      checks.push({
-        id: 'dev-test-auth-session',
-        status: 'fail',
-        message: 'Dev test-auth session bootstrap failed',
-        evidence: error instanceof Error ? error.message : String(error),
-      });
-      testAuthSessionOk = false;
-      return null;
-    });
+  const clerkKeyStatus = resolveClerkKeyStatus(
+    signInResponse.headers.get(CLERK_KEY_STATUS_HEADER)
+  );
+  const bodyText = await signInResponse.text().catch(() => '');
+  const authUnavailable = hasAuthUnavailableCopy(bodyText);
 
-    if (sessionResponse) {
-      testAuthSessionOk = sessionResponse.ok;
-      const responseText = await sessionResponse.text().catch(() => '');
-      checks.push({
-        id: 'dev-test-auth-session',
-        status: sessionResponse.ok ? 'pass' : 'fail',
-        message: sessionResponse.ok
-          ? 'Dev test-auth session bootstrap succeeded'
-          : 'Dev test-auth session bootstrap returned a non-OK response',
-        evidence: `status=${sessionResponse.status} body=${responseText.slice(0, 160)}`,
-      });
-    }
-  } else {
+  checks.push(
+    ...buildSignInProbeChecks(signInResponse, clerkKeyStatus, authUnavailable)
+  );
+
+  return { clerkKeyStatus, authUnavailable };
+}
+
+async function probeDevTestAuthSession(
+  baseUrl: string,
+  hostname: string,
+  timeoutMs: number,
+  checks: SignedInAuthCheck[]
+): Promise<boolean | null> {
+  if (!isLoopbackHost(hostname)) {
     checks.push({
       id: 'dev-test-auth-session',
       status: 'skip',
       message:
         'Remote deployment probe skips loopback-only dev test-auth session',
     });
+    return null;
   }
+
+  const sessionResponse = await fetch(
+    new URL('/api/dev/test-auth/session', baseUrl),
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        [TEST_MODE_HEADER]: TEST_AUTH_BYPASS_MODE,
+      },
+      body: JSON.stringify({ persona: 'creator-ready' }),
+      signal: AbortSignal.timeout(timeoutMs),
+    }
+  ).catch(error => {
+    checks.push({
+      id: 'dev-test-auth-session',
+      status: 'fail',
+      message: 'Dev test-auth session bootstrap failed',
+      evidence: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  });
+
+  if (!sessionResponse) {
+    return false;
+  }
+
+  const responseText = await sessionResponse.text().catch(() => '');
+  checks.push({
+    id: 'dev-test-auth-session',
+    status: sessionResponse.ok ? 'pass' : 'fail',
+    message: sessionResponse.ok
+      ? 'Dev test-auth session bootstrap succeeded'
+      : 'Dev test-auth session bootstrap returned a non-OK response',
+    evidence: `status=${sessionResponse.status} body=${responseText.slice(0, 160)}`,
+  });
+
+  return sessionResponse.ok;
+}
+
+export async function probeSignedInAuthDeployment(
+  baseUrl: string,
+  options: ProbeSignedInAuthDeploymentOptions = {}
+): Promise<SignedInAuthProbeResult> {
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const hostname = new URL(baseUrl).hostname;
+  const checks: SignedInAuthCheck[] = [];
+
+  const { clerkKeyStatus, authUnavailable } = await probeSignInPage(
+    baseUrl,
+    timeoutMs,
+    checks
+  );
+  const testAuthSessionOk = await probeDevTestAuthSession(
+    baseUrl,
+    hostname,
+    timeoutMs,
+    checks
+  );
 
   const ok = checks.every(
     check => check.status === 'pass' || check.status === 'skip'

--- a/apps/web/lib/readiness/signed-in-auth.ts
+++ b/apps/web/lib/readiness/signed-in-auth.ts
@@ -1,0 +1,516 @@
+import { HOSTNAME, STAGING_HOSTNAMES } from '@/constants/domains';
+import type { ClerkKeyStatus } from '@/lib/auth/clerk-key-status';
+import { CLERK_KEY_STATUS_HEADER } from '@/lib/auth/clerk-key-status';
+import { resolveClerkKeys } from '@/lib/auth/staging-clerk-keys';
+import {
+  TEST_AUTH_BYPASS_MODE,
+  TEST_MODE_HEADER,
+} from '@/lib/auth/test-mode-constants';
+
+export type SignedInAuthTarget = 'local' | 'stg' | 'prd';
+export type SignedInAuthSource = 'env' | 'vercel-file';
+
+export type SignedInAuthCheckStatus = 'pass' | 'fail' | 'skip';
+
+export interface SignedInAuthCheck {
+  readonly id: string;
+  readonly status: SignedInAuthCheckStatus;
+  readonly message: string;
+  readonly evidence?: string;
+}
+
+export interface SignedInAuthVerificationResult {
+  readonly ok: boolean;
+  readonly target: SignedInAuthTarget;
+  readonly source: SignedInAuthSource;
+  readonly hostname: string;
+  readonly checks: readonly SignedInAuthCheck[];
+}
+
+export interface SignedInAuthProbeResult {
+  readonly ok: boolean;
+  readonly baseUrl: string;
+  readonly hostname: string;
+  readonly clerkKeyStatus: ClerkKeyStatus | 'missing';
+  readonly authUnavailable: boolean;
+  readonly testAuthSessionOk: boolean | null;
+  readonly checks: readonly SignedInAuthCheck[];
+}
+
+export const REQUIRED_SIGNED_IN_AUTH_ENV_KEYS = [
+  'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
+  'CLERK_SECRET_KEY',
+  'SESSION_SECRET',
+  'DATABASE_URL',
+] as const;
+
+export type SignedInAuthEnvKey =
+  (typeof REQUIRED_SIGNED_IN_AUTH_ENV_KEYS)[number];
+
+const AUTH_UNAVAILABLE_PHRASES = [
+  'auth unavailable',
+  'authentication unavailable',
+  'temporarily unavailable',
+  'clerk is not configured',
+] as const;
+
+function hasValue(value: string | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function publishableKeyPrefix(value: string | undefined): string | null {
+  if (!hasValue(value)) return null;
+  if (value!.startsWith('pk_live_')) return 'pk_live';
+  if (value!.startsWith('pk_test_')) return 'pk_test';
+  return 'unknown';
+}
+
+export function resolveSignedInAuthHostname(
+  target: SignedInAuthTarget
+): string {
+  if (target === 'stg') return `staging.${HOSTNAME}`;
+  if (target === 'prd') return HOSTNAME;
+  return 'localhost';
+}
+
+function checkRequiredEnvKeys(
+  env: Partial<Record<string, string | undefined>>,
+  target: SignedInAuthTarget
+): SignedInAuthCheck[] {
+  if (target === 'local') {
+    return [
+      {
+        id: 'required-env-keys',
+        status: 'skip',
+        message:
+          'Local target uses dev test-auth bypass; production auth keys are optional',
+      },
+    ];
+  }
+
+  const missing = REQUIRED_SIGNED_IN_AUTH_ENV_KEYS.filter(
+    key => !hasValue(env[key])
+  );
+
+  if (missing.length === 0) {
+    return [
+      {
+        id: 'required-env-keys',
+        status: 'pass',
+        message: `All required signed-in auth env keys are set (${REQUIRED_SIGNED_IN_AUTH_ENV_KEYS.join(', ')})`,
+      },
+    ];
+  }
+
+  return [
+    {
+      id: 'required-env-keys',
+      status: 'fail',
+      message: `Missing required signed-in auth env keys: ${missing.join(', ')}`,
+      evidence: missing.join(', '),
+    },
+  ];
+}
+
+function checkClerkKeyRouting(
+  env: Partial<Record<string, string | undefined>>,
+  target: SignedInAuthTarget,
+  hostname: string
+): SignedInAuthCheck[] {
+  const previousPublishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  const previousSecretKey = process.env.CLERK_SECRET_KEY;
+  const previousStagingPublishableKey =
+    process.env.CLERK_PUBLISHABLE_KEY_STAGING;
+  const previousStagingSecretKey = process.env.CLERK_SECRET_KEY_STAGING;
+
+  try {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
+      env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    process.env.CLERK_SECRET_KEY = env.CLERK_SECRET_KEY;
+    process.env.CLERK_PUBLISHABLE_KEY_STAGING =
+      env.CLERK_PUBLISHABLE_KEY_STAGING;
+    process.env.CLERK_SECRET_KEY_STAGING = env.CLERK_SECRET_KEY_STAGING;
+
+    const keys = resolveClerkKeys(hostname);
+
+    if (target === 'stg' && keys.status === 'staging_inherits_prod') {
+      return [
+        {
+          id: 'clerk-key-routing',
+          status: 'fail',
+          message:
+            'Staging host would inherit production Clerk keys; staging must use its own Clerk instance',
+          evidence: `hostname=${hostname} status=${keys.status}`,
+        },
+      ];
+    }
+
+    if (target === 'stg' && keys.status === 'staging_missing') {
+      return [
+        {
+          id: 'clerk-key-routing',
+          status: 'fail',
+          message:
+            'Staging Clerk keys are missing or incomplete for the staging hostname',
+          evidence: `hostname=${hostname} status=${keys.status}`,
+        },
+      ];
+    }
+
+    if (keys.status !== 'ok') {
+      return [
+        {
+          id: 'clerk-key-routing',
+          status: 'fail',
+          message: `Clerk key routing failed for ${hostname}`,
+          evidence: `status=${keys.status}`,
+        },
+      ];
+    }
+
+    return [
+      {
+        id: 'clerk-key-routing',
+        status: 'pass',
+        message: `Clerk key routing resolved for ${hostname}`,
+        evidence: `status=${keys.status} publishableKeyPrefix=${publishableKeyPrefix(keys.publishableKey) ?? 'missing'}`,
+      },
+    ];
+  } finally {
+    if (previousPublishableKey === undefined) {
+      delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+    } else {
+      process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = previousPublishableKey;
+    }
+
+    if (previousSecretKey === undefined) {
+      delete process.env.CLERK_SECRET_KEY;
+    } else {
+      process.env.CLERK_SECRET_KEY = previousSecretKey;
+    }
+
+    if (previousStagingPublishableKey === undefined) {
+      delete process.env.CLERK_PUBLISHABLE_KEY_STAGING;
+    } else {
+      process.env.CLERK_PUBLISHABLE_KEY_STAGING = previousStagingPublishableKey;
+    }
+
+    if (previousStagingSecretKey === undefined) {
+      delete process.env.CLERK_SECRET_KEY_STAGING;
+    } else {
+      process.env.CLERK_SECRET_KEY_STAGING = previousStagingSecretKey;
+    }
+  }
+}
+
+function checkPublishableKeyType(
+  env: Partial<Record<string, string | undefined>>,
+  target: SignedInAuthTarget,
+  hostname: string
+): SignedInAuthCheck {
+  if (target === 'local') {
+    return {
+      id: 'publishable-key-type',
+      status: 'skip',
+      message: 'Local target does not enforce publishable key prefix',
+    };
+  }
+
+  const keys = resolveClerkKeysForEnv(env, hostname);
+  const prefix = publishableKeyPrefix(keys.publishableKey);
+
+  if (target === 'prd' && prefix !== 'pk_live') {
+    return {
+      id: 'publishable-key-type',
+      status: 'fail',
+      message: 'Production target must use a pk_live_ Clerk publishable key',
+      evidence: `prefix=${prefix ?? 'missing'}`,
+    };
+  }
+
+  return {
+    id: 'publishable-key-type',
+    status: 'pass',
+    message: `Publishable key prefix is acceptable for ${target}`,
+    evidence: `prefix=${prefix ?? 'missing'}`,
+  };
+}
+
+function resolveClerkKeysForEnv(
+  env: Partial<Record<string, string | undefined>>,
+  hostname: string
+) {
+  const previousPublishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  const previousSecretKey = process.env.CLERK_SECRET_KEY;
+  const previousStagingPublishableKey =
+    process.env.CLERK_PUBLISHABLE_KEY_STAGING;
+  const previousStagingSecretKey = process.env.CLERK_SECRET_KEY_STAGING;
+
+  process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
+    env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  process.env.CLERK_SECRET_KEY = env.CLERK_SECRET_KEY;
+  process.env.CLERK_PUBLISHABLE_KEY_STAGING = env.CLERK_PUBLISHABLE_KEY_STAGING;
+  process.env.CLERK_SECRET_KEY_STAGING = env.CLERK_SECRET_KEY_STAGING;
+
+  const keys = resolveClerkKeys(hostname);
+
+  if (previousPublishableKey === undefined) {
+    delete process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
+  } else {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY = previousPublishableKey;
+  }
+
+  if (previousSecretKey === undefined) {
+    delete process.env.CLERK_SECRET_KEY;
+  } else {
+    process.env.CLERK_SECRET_KEY = previousSecretKey;
+  }
+
+  if (previousStagingPublishableKey === undefined) {
+    delete process.env.CLERK_PUBLISHABLE_KEY_STAGING;
+  } else {
+    process.env.CLERK_PUBLISHABLE_KEY_STAGING = previousStagingPublishableKey;
+  }
+
+  if (previousStagingSecretKey === undefined) {
+    delete process.env.CLERK_SECRET_KEY_STAGING;
+  } else {
+    process.env.CLERK_SECRET_KEY_STAGING = previousStagingSecretKey;
+  }
+
+  return keys;
+}
+
+function checkStagingHostnames(): SignedInAuthCheck {
+  const expected = [`staging.${HOSTNAME}`, `main.${HOSTNAME}`];
+  const actual = Array.from(STAGING_HOSTNAMES).sort();
+  const matches =
+    expected.every(hostname => STAGING_HOSTNAMES.has(hostname)) &&
+    actual.length === expected.length;
+
+  return {
+    id: 'staging-hostnames',
+    status: matches ? 'pass' : 'fail',
+    message: matches
+      ? 'Staging hostnames are configured for Clerk key routing'
+      : 'Staging hostname set does not match expected Clerk routing hosts',
+    evidence: `expected=${expected.join(',')} actual=${actual.join(',')}`,
+  };
+}
+
+export function hasAuthUnavailableCopy(text: string): boolean {
+  const normalized = text.toLowerCase();
+  return AUTH_UNAVAILABLE_PHRASES.some(phrase => normalized.includes(phrase));
+}
+
+interface VerifySignedInAuthOptions {
+  readonly env: Partial<Record<string, string | undefined>>;
+  readonly target: SignedInAuthTarget;
+  readonly source: SignedInAuthSource;
+}
+
+export function verifySignedInAuthConfig({
+  env,
+  target,
+  source,
+}: VerifySignedInAuthOptions): SignedInAuthVerificationResult {
+  const hostname = resolveSignedInAuthHostname(target);
+  const checks: SignedInAuthCheck[] = [
+    ...checkRequiredEnvKeys(env, target),
+    ...checkClerkKeyRouting(env, target, hostname),
+    checkPublishableKeyType(env, target, hostname),
+    checkStagingHostnames(),
+  ];
+
+  const ok = checks.every(
+    check => check.status === 'pass' || check.status === 'skip'
+  );
+
+  return {
+    ok,
+    target,
+    source,
+    hostname,
+    checks,
+  };
+}
+
+export function formatSignedInAuthReport(
+  result: SignedInAuthVerificationResult
+): string {
+  const lines = [
+    `[signed-in-auth] target=${result.target} source=${result.source} hostname=${result.hostname}`,
+  ];
+
+  for (const check of result.checks) {
+    lines.push(
+      `[${check.status}] ${check.id}: ${check.message}${
+        check.evidence ? ` (${check.evidence})` : ''
+      }`
+    );
+  }
+
+  lines.push(`[signed-in-auth] status=${result.ok ? 'passed' : 'failed'}`);
+  return lines.join('\n');
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname.endsWith('.localhost')
+  );
+}
+
+interface ProbeSignedInAuthDeploymentOptions {
+  readonly timeoutMs?: number;
+}
+
+export async function probeSignedInAuthDeployment(
+  baseUrl: string,
+  options: ProbeSignedInAuthDeploymentOptions = {}
+): Promise<SignedInAuthProbeResult> {
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const parsedBaseUrl = new URL(baseUrl);
+  const hostname = parsedBaseUrl.hostname;
+  const checks: SignedInAuthCheck[] = [];
+
+  const signInResponse = await fetch(new URL('/signin', baseUrl), {
+    method: 'GET',
+    redirect: 'follow',
+    signal: AbortSignal.timeout(timeoutMs),
+  }).catch(error => {
+    checks.push({
+      id: 'signin-reachable',
+      status: 'fail',
+      message: 'Failed to reach /signin for Clerk key status probe',
+      evidence: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  });
+
+  let clerkKeyStatus: ClerkKeyStatus | 'missing' = 'missing';
+  let authUnavailable = false;
+
+  if (signInResponse) {
+    const headerValue = signInResponse.headers.get(CLERK_KEY_STATUS_HEADER);
+    clerkKeyStatus =
+      headerValue === 'ok' ||
+      headerValue === 'no_publishable_key' ||
+      headerValue === 'staging_missing' ||
+      headerValue === 'staging_inherits_prod'
+        ? headerValue
+        : 'missing';
+
+    const bodyText = await signInResponse.text().catch(() => '');
+    authUnavailable = hasAuthUnavailableCopy(bodyText);
+
+    checks.push({
+      id: 'signin-reachable',
+      status: signInResponse.ok ? 'pass' : 'fail',
+      message: signInResponse.ok
+        ? 'Sign-in page responded successfully'
+        : `Sign-in page returned HTTP ${signInResponse.status}`,
+      evidence: `status=${signInResponse.status}`,
+    });
+
+    checks.push({
+      id: 'clerk-key-status-header',
+      status: clerkKeyStatus === 'ok' ? 'pass' : 'fail',
+      message:
+        clerkKeyStatus === 'ok'
+          ? 'Middleware reported healthy Clerk key routing'
+          : `Middleware reported Clerk key status ${clerkKeyStatus}`,
+      evidence: `${CLERK_KEY_STATUS_HEADER}=${clerkKeyStatus}`,
+    });
+
+    checks.push({
+      id: 'auth-unavailable-copy',
+      status: authUnavailable ? 'fail' : 'pass',
+      message: authUnavailable
+        ? 'Sign-in page rendered auth-unavailable copy'
+        : 'Sign-in page did not render auth-unavailable copy',
+    });
+  }
+
+  let testAuthSessionOk: boolean | null = null;
+  if (isLoopbackHost(hostname)) {
+    const sessionResponse = await fetch(
+      new URL('/api/dev/test-auth/session', baseUrl),
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          [TEST_MODE_HEADER]: TEST_AUTH_BYPASS_MODE,
+        },
+        body: JSON.stringify({ persona: 'creator-ready' }),
+        signal: AbortSignal.timeout(timeoutMs),
+      }
+    ).catch(error => {
+      checks.push({
+        id: 'dev-test-auth-session',
+        status: 'fail',
+        message: 'Dev test-auth session bootstrap failed',
+        evidence: error instanceof Error ? error.message : String(error),
+      });
+      testAuthSessionOk = false;
+      return null;
+    });
+
+    if (sessionResponse) {
+      testAuthSessionOk = sessionResponse.ok;
+      const responseText = await sessionResponse.text().catch(() => '');
+      checks.push({
+        id: 'dev-test-auth-session',
+        status: sessionResponse.ok ? 'pass' : 'fail',
+        message: sessionResponse.ok
+          ? 'Dev test-auth session bootstrap succeeded'
+          : 'Dev test-auth session bootstrap returned a non-OK response',
+        evidence: `status=${sessionResponse.status} body=${responseText.slice(0, 160)}`,
+      });
+    }
+  } else {
+    checks.push({
+      id: 'dev-test-auth-session',
+      status: 'skip',
+      message:
+        'Remote deployment probe skips loopback-only dev test-auth session',
+    });
+  }
+
+  const ok = checks.every(
+    check => check.status === 'pass' || check.status === 'skip'
+  );
+
+  return {
+    ok,
+    baseUrl,
+    hostname,
+    clerkKeyStatus,
+    authUnavailable,
+    testAuthSessionOk,
+    checks,
+  };
+}
+
+export function formatSignedInAuthProbeReport(
+  result: SignedInAuthProbeResult
+): string {
+  const lines = [
+    `[signed-in-auth-probe] baseUrl=${result.baseUrl} hostname=${result.hostname}`,
+    `[signed-in-auth-probe] clerkKeyStatus=${result.clerkKeyStatus} authUnavailable=${result.authUnavailable} testAuthSessionOk=${result.testAuthSessionOk}`,
+  ];
+
+  for (const check of result.checks) {
+    lines.push(
+      `[${check.status}] ${check.id}: ${check.message}${
+        check.evidence ? ` (${check.evidence})` : ''
+      }`
+    );
+  }
+
+  lines.push(
+    `[signed-in-auth-probe] status=${result.ok ? 'passed' : 'failed'}`
+  );
+  return lines.join('\n');
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,8 @@
     "dev:local:playwright": "NEXT_PUBLIC_E2E_MODE=1 NEXT_DISABLE_TOOLBAR=1 next dev --webpack",
     "validate-env": "tsx scripts/validate-env.ts",
     "check:signup-readiness": "tsx scripts/check-signup-readiness.ts",
+    "check:signed-in-auth": "tsx scripts/verify-signed-in-auth.ts",
+    "verify:signed-in-auth": "tsx scripts/verify-signed-in-auth.ts",
     "build": "NODE_OPTIONS=--max-old-space-size=8192 NEXT_IGNORE_TYPECHECK=1 next build --turbopack",
     "build:strict": "pnpm run typecheck && NODE_OPTIONS=--max-old-space-size=8192 next build --turbopack",
     "analyze": "NODE_OPTIONS=--max-old-space-size=8192 ANALYZE=true NEXT_IGNORE_TYPECHECK=1 next build --webpack",

--- a/apps/web/scripts/verify-signed-in-auth.ts
+++ b/apps/web/scripts/verify-signed-in-auth.ts
@@ -1,0 +1,217 @@
+#!/usr/bin/env tsx
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parse } from 'dotenv';
+import {
+  formatSignedInAuthProbeReport,
+  formatSignedInAuthReport,
+  probeSignedInAuthDeployment,
+  type SignedInAuthSource,
+  type SignedInAuthTarget,
+  verifySignedInAuthConfig,
+} from '@/lib/readiness/signed-in-auth';
+
+interface CliOptions {
+  readonly target: SignedInAuthTarget;
+  readonly source: SignedInAuthSource;
+  readonly file?: string;
+  readonly probe: boolean;
+  readonly baseUrl?: string;
+  readonly outputDir?: string;
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const webRoot = resolve(scriptDir, '..');
+const repoRoot = resolve(webRoot, '..', '..');
+
+function parseArgValue(arg: string, name: string): string | null {
+  const prefix = `${name}=`;
+  if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+  return null;
+}
+
+function parseCliArgs(argv: readonly string[]): CliOptions {
+  let target: SignedInAuthTarget = 'local';
+  let source: SignedInAuthSource = 'env';
+  let file: string | undefined;
+  let probe = false;
+  let baseUrl: string | undefined;
+  let outputDir: string | undefined;
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index]!;
+    const targetValue =
+      parseArgValue(arg, '--target') ??
+      (arg === '--target' ? argv[++index] : null);
+    const sourceValue =
+      parseArgValue(arg, '--source') ??
+      (arg === '--source' ? argv[++index] : null);
+    const fileValue =
+      parseArgValue(arg, '--file') ?? (arg === '--file' ? argv[++index] : null);
+    const baseUrlValue =
+      parseArgValue(arg, '--base-url') ??
+      (arg === '--base-url' ? argv[++index] : null);
+    const outputDirValue =
+      parseArgValue(arg, '--output-dir') ??
+      (arg === '--output-dir' ? argv[++index] : null);
+
+    if (targetValue) {
+      if (!['local', 'stg', 'prd'].includes(targetValue)) {
+        throw new Error(`Invalid --target: ${targetValue}`);
+      }
+      target = targetValue as SignedInAuthTarget;
+      continue;
+    }
+
+    if (sourceValue) {
+      if (!['env', 'vercel-file'].includes(sourceValue)) {
+        throw new Error(`Invalid --source: ${sourceValue}`);
+      }
+      source = sourceValue as SignedInAuthSource;
+      continue;
+    }
+
+    if (fileValue) {
+      file = fileValue;
+      continue;
+    }
+
+    if (baseUrlValue) {
+      baseUrl = baseUrlValue;
+      continue;
+    }
+
+    if (outputDirValue) {
+      outputDir = outputDirValue;
+      continue;
+    }
+
+    if (arg === '--probe') {
+      probe = true;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      printUsage();
+      process.exit(0);
+    }
+  }
+
+  return { target, source, file, probe, baseUrl, outputDir };
+}
+
+function defaultVercelEnvFile(target: SignedInAuthTarget): string {
+  if (target === 'prd') return '.vercel/.env.production.local';
+  if (target === 'stg') return '.vercel/.env.preview.local';
+  return '.env.local';
+}
+
+function defaultBaseUrl(target: SignedInAuthTarget): string {
+  if (target === 'prd') return 'https://jov.ie';
+  if (target === 'stg') return 'https://staging.jov.ie';
+  return 'http://localhost:3000';
+}
+
+export function resolveEnvFilePath(path: string): string {
+  const candidates = isAbsolute(path)
+    ? [path]
+    : [
+        resolve(process.cwd(), path),
+        resolve(webRoot, path),
+        resolve(repoRoot, path),
+      ];
+  const resolvedPath = candidates.find(candidate => existsSync(candidate));
+
+  if (!resolvedPath) {
+    throw new Error(
+      `Env file not found: ${path} (checked ${candidates.join(', ')})`
+    );
+  }
+
+  return resolvedPath;
+}
+
+function readEnvFile(path: string): Record<string, string> {
+  const resolvedPath = resolveEnvFilePath(path);
+  return parse(readFileSync(resolvedPath));
+}
+
+function printUsage() {
+  console.log(`Usage: tsx scripts/verify-signed-in-auth.ts [options]
+
+Options:
+  --target=local|stg|prd       Environment target (default: local)
+  --source=env|vercel-file     Read current process env or a pulled Vercel env file
+  --file=<path>                Env file path when --source=vercel-file
+  --probe                      Probe a running deployment for Clerk key status
+  --base-url=<url>             Base URL for --probe (defaults by target)
+  --output-dir=<path>          Write JSON evidence report to this directory
+
+Examples:
+  doppler run --config dev -- tsx scripts/verify-signed-in-auth.ts --target=local --probe
+  doppler run --config stg -- tsx scripts/verify-signed-in-auth.ts --target=stg
+  doppler run --config prd -- tsx scripts/verify-signed-in-auth.ts --target=prd --probe --base-url=https://jov.ie
+`);
+}
+
+function writeEvidenceReport(
+  outputDir: string | undefined,
+  payload: Record<string, unknown>
+) {
+  if (!outputDir) return;
+
+  const resolvedDir = isAbsolute(outputDir)
+    ? outputDir
+    : resolve(webRoot, outputDir);
+  mkdirSync(resolvedDir, { recursive: true });
+  const reportPath = resolve(resolvedDir, 'signed-in-auth-report.json');
+  writeFileSync(reportPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  console.log(`[signed-in-auth] evidence=${reportPath}`);
+}
+
+async function main() {
+  const options = parseCliArgs(process.argv.slice(2));
+  const env =
+    options.source === 'env'
+      ? process.env
+      : readEnvFile(options.file ?? defaultVercelEnvFile(options.target));
+
+  const configResult = verifySignedInAuthConfig({
+    env,
+    target: options.target,
+    source: options.source,
+  });
+
+  console.log(formatSignedInAuthReport(configResult));
+
+  let probeResult = null;
+  if (options.probe) {
+    const baseUrl = options.baseUrl ?? defaultBaseUrl(options.target);
+    probeResult = await probeSignedInAuthDeployment(baseUrl);
+    console.log(formatSignedInAuthProbeReport(probeResult));
+  }
+
+  writeEvidenceReport(options.outputDir, {
+    generatedAt: new Date().toISOString(),
+    config: configResult,
+    probe: probeResult,
+  });
+
+  const ok = configResult.ok && (probeResult ? probeResult.ok : true);
+  process.exit(ok ? 0 : 1);
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch(error => {
+    console.error(
+      `[signed-in-auth] crashed: ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    process.exit(1);
+  });
+}

--- a/apps/web/tests/e2e/signed-in-auth-verify.spec.ts
+++ b/apps/web/tests/e2e/signed-in-auth-verify.spec.ts
@@ -97,10 +97,10 @@ test.describe('Signed-in auth verification @smoke', () => {
     page,
   }) => {
     test.setTimeout(180_000);
-    test.skip(
-      !canRunSignedInAuthVerification(),
-      'Requires Clerk test credentials or E2E_USE_TEST_AUTH_BYPASS=1'
-    );
+    // Intentional conditional skip when Clerk credentials or dev test-auth bypass are unavailable. NOSONAR S1607
+    if (!canRunSignedInAuthVerification()) {
+      test.skip(); // NOSONAR S1607 — requires Clerk test credentials or E2E_USE_TEST_AUTH_BYPASS=1
+    }
 
     const { getContext, cleanup } = setupPageMonitoring(page);
 

--- a/apps/web/tests/e2e/signed-in-auth-verify.spec.ts
+++ b/apps/web/tests/e2e/signed-in-auth-verify.spec.ts
@@ -97,10 +97,10 @@ test.describe('Signed-in auth verification @smoke', () => {
     page,
   }) => {
     test.setTimeout(180_000);
-
-    if (!canRunSignedInAuthVerification()) {
-      test.skip();
-    }
+    test.skip(
+      !canRunSignedInAuthVerification(),
+      'Requires Clerk test credentials or E2E_USE_TEST_AUTH_BYPASS=1'
+    );
 
     const { getContext, cleanup } = setupPageMonitoring(page);
 

--- a/apps/web/tests/e2e/signed-in-auth-verify.spec.ts
+++ b/apps/web/tests/e2e/signed-in-auth-verify.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from '@playwright/test';
+import { APP_ROUTES } from '@/constants/routes';
+import { ensureSignedInUser, signInUser } from '../helpers/clerk-auth';
+import {
+  SMOKE_TIMEOUTS,
+  setupPageMonitoring,
+  smokeNavigateWithRetry,
+} from './utils/smoke-test-utils';
+
+const TEST_AUTH_BYPASS_ENABLED = process.env.E2E_USE_TEST_AUTH_BYPASS === '1';
+
+function hasRealClerkConfig(): boolean {
+  if (TEST_AUTH_BYPASS_ENABLED) {
+    return true;
+  }
+
+  const pk = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY ?? '';
+  const sk = process.env.CLERK_SECRET_KEY ?? '';
+  return (
+    pk.length > 0 &&
+    sk.length > 0 &&
+    !pk.toLowerCase().includes('dummy') &&
+    !pk.toLowerCase().includes('mock') &&
+    !sk.toLowerCase().includes('dummy') &&
+    !sk.toLowerCase().includes('mock')
+  );
+}
+
+function canRunSignedInAuthVerification(): boolean {
+  if (TEST_AUTH_BYPASS_ENABLED) {
+    return true;
+  }
+
+  return (
+    hasRealClerkConfig() &&
+    Boolean(process.env.E2E_CLERK_USER_USERNAME) &&
+    process.env.CLERK_TESTING_SETUP_SUCCESS === 'true'
+  );
+}
+
+async function bootstrapSignedInSession(page: import('@playwright/test').Page) {
+  if (TEST_AUTH_BYPASS_ENABLED) {
+    await smokeNavigateWithRetry(
+      page,
+      '/api/dev/test-auth/enter?persona=creator-ready&redirect=/app/chat'
+    );
+    await expect(page).toHaveURL(/\/app\/chat/, {
+      timeout: SMOKE_TIMEOUTS.NAVIGATION,
+    });
+    return;
+  }
+
+  await signInUser(page);
+  await ensureSignedInUser(page);
+}
+
+async function assertAuthenticatedApiAccess(
+  page: import('@playwright/test').Page
+) {
+  if (TEST_AUTH_BYPASS_ENABLED) {
+    const sessionProbe = await page.request.post('/api/dev/test-auth/session', {
+      headers: {
+        'Content-Type': 'application/json',
+        'x-test-mode': 'bypass-auth',
+      },
+      data: { persona: 'creator-ready' },
+    });
+
+    expect(sessionProbe.ok()).toBeTruthy();
+    const payload = (await sessionProbe.json()) as { userId?: string };
+    expect(payload.userId?.trim().length).toBeGreaterThan(0);
+    return;
+  }
+
+  const userId = await page.evaluate(() => {
+    const clerkWindow = window as {
+      Clerk?: { user?: { id?: string | null } | null };
+    };
+    return clerkWindow.Clerk?.user?.id ?? null;
+  });
+
+  expect(userId?.trim().length).toBeGreaterThan(0);
+}
+
+/**
+ * Web signed-in auth verification harness (JOV-2761).
+ *
+ * Covers session bootstrap, authenticated app access, API/session proof, and sign-out.
+ * iOS, Electron, and Chrome extension surfaces are tracked as follow-up evidence.
+ *
+ * @smoke
+ */
+test.describe('Signed-in auth verification @smoke', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('web signed-in auth start, session, API access, and sign-out', async ({
+    page,
+  }) => {
+    test.setTimeout(180_000);
+
+    if (!canRunSignedInAuthVerification()) {
+      test.skip();
+    }
+
+    const { getContext, cleanup } = setupPageMonitoring(page);
+
+    try {
+      await bootstrapSignedInSession(page);
+
+      const main = page.locator('main').first();
+      await expect(main, 'Authenticated app shell did not render').toBeVisible({
+        timeout: SMOKE_TIMEOUTS.VISIBILITY,
+      });
+
+      await assertAuthenticatedApiAccess(page);
+
+      if (TEST_AUTH_BYPASS_ENABLED) {
+        await smokeNavigateWithRetry(page, APP_ROUTES.SIGNIN);
+        await expect(page).toHaveURL(/\/signin/, {
+          timeout: SMOKE_TIMEOUTS.NAVIGATION,
+        });
+      } else {
+        await page.evaluate(async () => {
+          const clerkWindow = window as {
+            Clerk?: { signOut?: () => Promise<void> };
+          };
+          await clerkWindow.Clerk?.signOut?.();
+        });
+
+        await smokeNavigateWithRetry(page, APP_ROUTES.DASHBOARD);
+        await expect(page).toHaveURL(/\/signin|\/signup|\/start/, {
+          timeout: SMOKE_TIMEOUTS.NAVIGATION,
+        });
+      }
+
+      const context = getContext();
+      expect(
+        context.pageErrors,
+        'Signed-in auth verification page errors'
+      ).toEqual([]);
+      expect(
+        context.consoleErrors,
+        'Signed-in auth verification console errors'
+      ).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/apps/web/tests/e2e/signed-in-auth-verify.spec.ts
+++ b/apps/web/tests/e2e/signed-in-auth-verify.spec.ts
@@ -91,16 +91,18 @@ async function assertAuthenticatedApiAccess(
  * @smoke
  */
 test.describe('Signed-in auth verification @smoke', () => {
+  // Intentional conditional skip when Clerk credentials or dev test-auth bypass are unavailable. NOSONAR S1607
+  test.skip(
+    !canRunSignedInAuthVerification(),
+    'Requires Clerk test credentials or E2E_USE_TEST_AUTH_BYPASS=1'
+  ); // NOSONAR
+
   test.use({ storageState: { cookies: [], origins: [] } });
 
   test('web signed-in auth start, session, API access, and sign-out', async ({
     page,
   }) => {
     test.setTimeout(180_000);
-    // Intentional conditional skip when Clerk credentials or dev test-auth bypass are unavailable. NOSONAR S1607
-    if (!canRunSignedInAuthVerification()) {
-      test.skip(); // NOSONAR S1607 — requires Clerk test credentials or E2E_USE_TEST_AUTH_BYPASS=1
-    }
 
     const { getContext, cleanup } = setupPageMonitoring(page);
 

--- a/apps/web/tests/unit/lib/readiness/signed-in-auth.test.ts
+++ b/apps/web/tests/unit/lib/readiness/signed-in-auth.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HOSTNAME } from '@/constants/domains';
+import {
+  formatSignedInAuthProbeReport,
+  formatSignedInAuthReport,
+  hasAuthUnavailableCopy,
+  probeSignedInAuthDeployment,
+  resolveSignedInAuthHostname,
+  verifySignedInAuthConfig,
+} from '@/lib/readiness/signed-in-auth';
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('signed-in auth readiness', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY =
+      'pk_live_production_example';
+    process.env.CLERK_SECRET_KEY = 'sk_live_production_example';
+    process.env.SESSION_SECRET = 'session-secret-example';
+    process.env.DATABASE_URL = 'postgres://example';
+    delete process.env.CLERK_PUBLISHABLE_KEY_STAGING;
+    delete process.env.CLERK_SECRET_KEY_STAGING;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('resolves hostnames by target', () => {
+    expect(resolveSignedInAuthHostname('local')).toBe('localhost');
+    expect(resolveSignedInAuthHostname('stg')).toBe(`staging.${HOSTNAME}`);
+    expect(resolveSignedInAuthHostname('prd')).toBe(HOSTNAME);
+  });
+
+  it('passes production config when required keys and routing are healthy', () => {
+    const result = verifySignedInAuthConfig({
+      env: process.env,
+      target: 'prd',
+      source: 'env',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.checks.some(check => check.id === 'clerk-key-routing')).toBe(
+      true
+    );
+    expect(formatSignedInAuthReport(result)).toContain('status=passed');
+  });
+
+  it('fails staging config when production keys would be inherited', () => {
+    const result = verifySignedInAuthConfig({
+      env: process.env,
+      target: 'stg',
+      source: 'env',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(
+      result.checks.find(check => check.id === 'clerk-key-routing')?.status
+    ).toBe('fail');
+  });
+
+  it('passes staging config when explicit staging Clerk keys are configured', () => {
+    const result = verifySignedInAuthConfig({
+      env: {
+        ...process.env,
+        CLERK_PUBLISHABLE_KEY_STAGING: 'pk_test_staging_example',
+        CLERK_SECRET_KEY_STAGING: 'sk_test_staging_example',
+      },
+      target: 'stg',
+      source: 'env',
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it('skips required env keys for local target', () => {
+    const result = verifySignedInAuthConfig({
+      env: {},
+      target: 'local',
+      source: 'env',
+    });
+
+    expect(
+      result.checks.find(check => check.id === 'required-env-keys')?.status
+    ).toBe('skip');
+  });
+
+  it('detects auth-unavailable copy', () => {
+    expect(hasAuthUnavailableCopy('Authentication unavailable right now')).toBe(
+      true
+    );
+    expect(hasAuthUnavailableCopy('Sign in to continue')).toBe(false);
+  });
+});
+
+describe('signed-in auth deployment probe', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('reports healthy Clerk key routing from deployment headers', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
+          const url = String(input);
+          if (url.includes('/api/dev/test-auth/session')) {
+            return Promise.resolve(
+              new Response(JSON.stringify({ userId: 'user_test_123' }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+              })
+            );
+          }
+
+          return Promise.resolve(
+            new Response('<html>Sign in</html>', {
+              status: 200,
+              headers: {
+                'x-clerk-key-status': 'ok',
+              },
+            })
+          );
+        })
+    );
+
+    const result = await probeSignedInAuthDeployment('http://localhost:3000');
+
+    expect(result.ok).toBe(true);
+    expect(result.clerkKeyStatus).toBe('ok');
+    expect(result.testAuthSessionOk).toBe(true);
+    expect(formatSignedInAuthProbeReport(result)).toContain('status=passed');
+  });
+
+  it('fails when sign-in page renders auth-unavailable copy', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response('<html>Authentication unavailable</html>', {
+          status: 200,
+          headers: {
+            'x-clerk-key-status': 'ok',
+          },
+        })
+      )
+    );
+
+    const result = await probeSignedInAuthDeployment('https://staging.jov.ie');
+
+    expect(result.ok).toBe(false);
+    expect(result.authUnavailable).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "ios:runtime-performance": "bash apps/ios/scripts/measure-runtime-performance.sh",
     "ios:memory": "bash apps/ios/scripts/capture-memory-baseline.sh",
     "test:auth:ios": "bash apps/ios/scripts/test-auth-callback.sh",
+    "test:auth:web": "pnpm --filter @jovie/web exec vitest run tests/unit/lib/readiness/signed-in-auth.test.ts && doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web exec playwright test tests/e2e/signed-in-auth-verify.spec.ts --project=chromium --reporter=line",
     "test:auth:native": "pnpm --filter @jovie/web exec vitest run tests/unit/desktop/native-complete.test.ts tests/unit/dashboard/session-device-name.test.ts tests/unit/auth/AuthUnavailableCard.compact.test.tsx tests/unit/customer-facing-vendor-copy.test.ts tests/unit/api/auth/native-exchange.test.ts tests/unit/api/dev/test-auth-routes.test.ts && pnpm --filter @jovie/desktop run test && pnpm run test:auth:ios",
     "ios:screenshots": "bash apps/ios/scripts/capture-screenshots.sh",
     "build": "node scripts/turbo-local.mjs build",


### PR DESCRIPTION
## Goal

JOV-2761 requires signed-in auth to be verified across Jovie surfaces. This PR ships the **web-first** verification harness: Clerk key-routing preflight, deployment probe CLI, and Playwright signed-in session proof. Electron, iOS, and Chrome extension evidence remain follow-up work.

## Changes

- Add `lib/readiness/signed-in-auth.ts` for Clerk key routing + env preflight and deployment probe helpers
- Add `scripts/verify-signed-in-auth.ts` CLI (`check:signed-in-auth`, `verify:signed-in-auth`)
- Add `tests/unit/lib/readiness/signed-in-auth.test.ts` unit coverage
- Add `tests/e2e/signed-in-auth-verify.spec.ts` for session bootstrap, authenticated app shell, API/session proof, and sign-out
- Wire `pnpm run test:auth:web` root script
- Update `AUTH_AUDIT.md` with web harness evidence table

## Testing

```bash
pnpm --filter @jovie/web exec vitest run tests/unit/lib/readiness/signed-in-auth.test.ts
pnpm --filter @jovie/web run check:signed-in-auth -- --target=local
# With local dev server + Doppler dev:
doppler run --project jovie-web --config dev -- pnpm run test:auth:web
```

Linear: JOV-2761