### PR TITLE
fix(dashboard): degrade gracefully when creator_distribution_events query fails (JOV-3127)

### DIFF
--- a/apps/web/app/api/audience/visit/route.ts
+++ b/apps/web/app/api/audience/visit/route.ts
@@ -32,6 +32,7 @@ import {
   getInstagramReferrerHost,
   INSTAGRAM_DISTRIBUTION_PLATFORM,
   isInstagramActivationSource,
+  isMissingCreatorDistributionEventsTableError,
 } from '@/lib/distribution/instagram-activation';
 import { captureError, captureWarning } from '@/lib/error-tracking';
 import { withSystemIngestionSession } from '@/lib/ingestion/session';
@@ -335,10 +336,6 @@ async function incrementDailyProfileViews(
 }
 
 function isMissingDailyProfileViewsTableError(error: unknown): boolean {
-  return unwrapPgError(error).code === '42P01';
-}
-
-function isMissingCreatorDistributionEventsTableError(error: unknown): boolean {
   return unwrapPgError(error).code === '42P01';
 }
 

--- a/apps/web/app/api/onboarding/distribution-event/route.ts
+++ b/apps/web/app/api/onboarding/distribution-event/route.ts
@@ -4,13 +4,13 @@ import {
   isUnauthorizedSessionError,
   withDbSessionTx,
 } from '@/lib/auth/session';
-import { unwrapPgError } from '@/lib/db/errors';
 import { getAuthenticatedProfile } from '@/lib/db/queries/shared';
 import { creatorDistributionEvents } from '@/lib/db/schema/profiles';
 import {
   buildDistributionDedupeKey,
   CREATOR_DISTRIBUTION_EVENT_TYPES,
   INSTAGRAM_DISTRIBUTION_PLATFORM,
+  isMissingCreatorDistributionEventsTableError,
 } from '@/lib/distribution/instagram-activation';
 import { captureError, captureWarning } from '@/lib/error-tracking';
 import { NO_STORE_HEADERS } from '@/lib/http/headers';
@@ -28,10 +28,6 @@ const distributionEventSchema = z.object({
 type DistributionEventResolution =
   | { kind: 'response'; response: Response }
   | { kind: 'success' };
-
-function isMissingCreatorDistributionEventsTableError(error: unknown): boolean {
-  return unwrapPgError(error).code === '42P01';
-}
 
 export async function POST(request: Request) {
   try {

--- a/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
+++ b/apps/web/app/app/(shell)/dashboard/actions/dashboard-data.ts
@@ -19,7 +19,12 @@ import { withDbSessionTx } from '@/lib/auth/session';
 import { CACHE_TAGS, CACHE_TTL } from '@/lib/cache/tags';
 import { type DbOrTransaction, doesTableExist } from '@/lib/db';
 import { getAvatarQualityForProfile } from '@/lib/db/queries/avatar-quality';
-import { dashboardQuery, QUERY_TIMEOUTS } from '@/lib/db/query-timeout';
+import {
+  dashboardQuery,
+  isPostgresTimeoutError,
+  isQueryTimeoutError,
+  QUERY_TIMEOUTS,
+} from '@/lib/db/query-timeout';
 import { clickEvents, tips } from '@/lib/db/schema/analytics';
 import { userSettings, users } from '@/lib/db/schema/auth';
 import { socialLinks } from '@/lib/db/schema/links';
@@ -39,6 +44,7 @@ import {
   type BioLinkActivation,
   getBioLinkActivationWindowEnd,
   INSTAGRAM_DISTRIBUTION_PLATFORM,
+  isMissingCreatorDistributionEventsTableError,
   resolveBioLinkActivationStatus,
 } from '@/lib/distribution/instagram-activation';
 import { isE2EFastOnboardingEnabled } from '@/lib/e2e/runtime';
@@ -237,14 +243,41 @@ async function buildBioLinkActivation(
             )
           )
           .orderBy(asc(creatorDistributionEvents.createdAt)),
-      'Creator distribution events query'
+      'Creator distribution events query',
+      { db: tx }
     ).catch((error: unknown) => {
+      if (isMissingCreatorDistributionEventsTableError(error)) {
+        Sentry.logger.warn(
+          '[Dashboard] creator_distribution_events table missing; skipping activation lookup',
+          { profileId: profile.id }
+        );
+        return [];
+      }
+
+      const migrationResult = handleMigrationErrors(error, {
+        userId: profile.id,
+        operation: 'creator_distribution_events',
+      });
+
+      if (!migrationResult.shouldRetry) {
+        return (migrationResult.fallbackData ?? []) as Array<{
+          createdAt: Date;
+          eventType: string;
+        }>;
+      }
+
+      const level =
+        isQueryTimeoutError(error) || isPostgresTimeoutError(error)
+          ? 'warning'
+          : 'error';
+
       Sentry.captureException(error, {
-        level: 'warning',
+        level,
         tags: {
           query: 'creator_distribution_events',
           context: 'dashboard_data_settled',
         },
+        extra: { profileId: profile.id },
       });
       return [];
     });

--- a/apps/web/lib/distribution/instagram-activation.ts
+++ b/apps/web/lib/distribution/instagram-activation.ts
@@ -1,4 +1,5 @@
 import { getProfileUrl } from '@/constants/domains';
+import { unwrapPgError } from '@/lib/db/errors';
 import { buildUTMUrlString, slugify } from '@/lib/utm';
 import { UTM_PRESET_MAP } from '@/lib/utm/presets';
 
@@ -28,6 +29,13 @@ export type CreatorDistributionEventType =
   (typeof CREATOR_DISTRIBUTION_EVENT_TYPES)[number];
 
 export type BioLinkActivationStatus = 'pending' | 'activated' | 'expired';
+
+/** True when Postgres reports the creator_distribution_events relation is missing. */
+export function isMissingCreatorDistributionEventsTableError(
+  error: unknown
+): boolean {
+  return unwrapPgError(error).code === '42P01';
+}
 
 export interface DistributionEventPayload {
   readonly eventType: CreatorDistributionEventType;

--- a/apps/web/lib/migrations/handleMigrationErrors.ts
+++ b/apps/web/lib/migrations/handleMigrationErrors.ts
@@ -58,6 +58,23 @@ function isSocialLinksColumnMissing(message: string): boolean {
   );
 }
 
+function isCreatorDistributionEventsSchemaIssue(message: string): boolean {
+  const normalizedMessage = message.toLowerCase();
+  const referencesDistributionEventsTable =
+    normalizedMessage.includes('from "creator_distribution_events"') ||
+    normalizedMessage.includes('from creator_distribution_events') ||
+    normalizedMessage.includes('relation "creator_distribution_events"') ||
+    normalizedMessage.includes('relation creator_distribution_events');
+
+  return (
+    normalizedMessage.includes(
+      'relation "creator_distribution_events" does not exist'
+    ) ||
+    (normalizedMessage.includes('failed query:') &&
+      referencesDistributionEventsTable)
+  );
+}
+
 function isUserSettingsSchemaIssue(message: string): boolean {
   const normalizedMessage = message.toLowerCase();
   const referencesUserSettingsTable =
@@ -117,6 +134,17 @@ function resolveOperationFallback(
         return {
           log: '[Dashboard] social_links migration in progress; treating as no links',
           fallbackData: { hasLinks: false, hasMusicLinks: false },
+        };
+      }
+      break;
+    case 'creator_distribution_events':
+      if (
+        hasMigrationErrorCode ||
+        isCreatorDistributionEventsSchemaIssue(message)
+      ) {
+        return {
+          log: '[Dashboard] creator_distribution_events migration in progress; treating as no activation events',
+          fallbackData: [],
         };
       }
       break;

--- a/apps/web/tests/unit/lib/distribution/instagram-activation.test.ts
+++ b/apps/web/tests/unit/lib/distribution/instagram-activation.test.ts
@@ -3,6 +3,7 @@ import {
   buildInstagramBioLink,
   getBioLinkActivationWindowEnd,
   isInstagramActivationSource,
+  isMissingCreatorDistributionEventsTableError,
   postDistributionEvent,
   resolveBioLinkActivationStatus,
 } from '@/lib/distribution/instagram-activation';
@@ -74,6 +75,22 @@ describe('instagram activation helpers', () => {
         windowEndsAt,
       })
     ).toBe('expired');
+  });
+
+  it('detects missing creator_distribution_events table errors', () => {
+    expect(
+      isMissingCreatorDistributionEventsTableError(
+        new Error('relation "creator_distribution_events" does not exist', {
+          cause: { code: '42P01' },
+        })
+      )
+    ).toBe(true);
+
+    expect(
+      isMissingCreatorDistributionEventsTableError(
+        new Error('Failed query: select from creator_distribution_events')
+      )
+    ).toBe(false);
   });
 
   it('no-ops if the distribution event helper is called on the server', async () => {

--- a/apps/web/tests/unit/lib/migrations/handleMigrationErrors.test.ts
+++ b/apps/web/tests/unit/lib/migrations/handleMigrationErrors.test.ts
@@ -86,6 +86,46 @@ describe('handleMigrationErrors', () => {
     );
   });
 
+  it('returns fallback for creator_distribution_events migration errors', async () => {
+    const { handleMigrationErrors } = await import(
+      '@/lib/migrations/handleMigrationErrors'
+    );
+
+    const result = handleMigrationErrors(
+      {
+        code: '42P01',
+        message: 'relation "creator_distribution_events" does not exist',
+      },
+      { userId: 'profile_123', operation: 'creator_distribution_events' }
+    );
+
+    expect(result).toEqual({ shouldRetry: false, fallbackData: [] });
+    expect(mockWarn).toHaveBeenCalledWith(
+      '[Dashboard] creator_distribution_events migration in progress; treating as no activation events',
+      { userId: 'profile_123', operation: 'creator_distribution_events' }
+    );
+  });
+
+  it('returns fallback for creator_distribution_events failed query errors without postgres code', async () => {
+    const { handleMigrationErrors } = await import(
+      '@/lib/migrations/handleMigrationErrors'
+    );
+
+    const result = handleMigrationErrors(
+      {
+        message:
+          'Failed query: select "created_at", "event_type" from "creator_distribution_events" where ("creator_distribution_events"."creator_profile_id" = $1',
+      },
+      { userId: 'profile_123', operation: 'creator_distribution_events' }
+    );
+
+    expect(result).toEqual({ shouldRetry: false, fallbackData: [] });
+    expect(mockWarn).toHaveBeenCalledWith(
+      '[Dashboard] creator_distribution_events migration in progress; treating as no activation events',
+      { userId: 'profile_123', operation: 'creator_distribution_events' }
+    );
+  });
+
   it('returns fallback for social_links migration errors', async () => {
     const { handleMigrationErrors } = await import(
       '@/lib/migrations/handleMigrationErrors'


### PR DESCRIPTION
## Summary

Fixes production `Failed query: select "created_at", "event_type" from "creator_distribution_events"` Sentry noise on dashboard loads when the table is missing or a schema rollout is in flight.

## Changes

- `buildBioLinkActivation`: treat missing-table / migration errors as graceful degradation (empty events) instead of Sentry warnings
- Downgrade query timeouts to warning-level Sentry events (matches tipping stats pattern)
- Add `creator_distribution_events` operation to `handleMigrationErrors`
- Consolidate `isMissingCreatorDistributionEventsTableError` into `lib/distribution/instagram-activation` and reuse in API routes

## Validation

- [x] `pnpm --filter web exec vitest run tests/unit/lib/distribution/instagram-activation.test.ts tests/unit/lib/migrations/handleMigrationErrors.test.ts` (19 passed)
- [x] pre-push: biome, typecheck, lint

## Rollback

Revert this commit; dashboard falls back to prior behavior (Sentry warnings + empty activation state on query failure).

Linear: https://linear.app/jovie/issue/JOV-3127

<!-- linear-issue-id:JOV-3127 -->