### PR TITLE
fix(auth): avoid iOS native exchange fallback for missing users (JOV-3001)

### DIFF
--- a/apps/web/app/api/auth/native/exchange/route.ts
+++ b/apps/web/app/api/auth/native/exchange/route.ts
@@ -116,7 +116,8 @@ function hasClerkErrorCode(error: unknown, code: string): boolean {
 
 function isIosSessionTokenUnavailableError(error: unknown): boolean {
   return (
-    isNotFoundError(error) ||
+    (isNotFoundError(error) &&
+      !hasClerkErrorCode(error, 'resource_not_found')) ||
     hasClerkErrorCode(error, 'request_invalid_for_environment')
   );
 }

--- a/apps/web/tests/unit/api/auth/native-exchange.test.ts
+++ b/apps/web/tests/unit/api/auth/native-exchange.test.ts
@@ -328,6 +328,37 @@ describe('POST /api/auth/native/exchange', () => {
     expect(mockCaptureError).not.toHaveBeenCalled();
   });
 
+  it('does not fall back to a sign-in ticket when Clerk reports the iOS user resource is missing', async () => {
+    const missingUserError = new Error('Resource not found');
+    Object.assign(missingUserError, {
+      status: 404,
+      errors: [
+        {
+          code: 'resource_not_found',
+          longMessage: 'User not found',
+        },
+      ],
+    });
+    mockSessionsCreateSession.mockRejectedValue(missingUserError);
+
+    const { POST } = await import('@/app/api/auth/native/exchange/route');
+    const response = await POST(createExchangeRequest());
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data).toEqual({
+      error: 'Native auth exchange failed',
+    });
+    expect(mockSignInTokensCreateSignInToken).not.toHaveBeenCalled();
+    expect(mockCaptureError).toHaveBeenCalledWith(
+      'Native auth exchange route failed',
+      missingUserError,
+      {
+        route: '/api/auth/native/exchange',
+      }
+    );
+  });
+
   it('uses staging Clerk keys for iOS native exchange on staging hosts', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     vi.stubEnv('VERCEL_ENV', 'production');


### PR DESCRIPTION
<!-- linear-issue-id:e96cd4a7-7f52-43b9-a58e-6266724817f8 -->
## Summary
- stop the iOS native exchange fallback from minting a sign-in ticket when Clerk reports the user resource is genuinely missing
- preserve the environment-only Clerk fallback path for preview/production iOS exchanges
- add a regression test that asserts the missing-user path returns a hard auth failure instead of a doomed ticket

## Validation
- `pnpm --filter web exec vitest run tests/unit/api/auth/native-exchange.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`

## CodeRabbit
- `coderabbit review --plain --type committed --base origin/main` reached analysis and stalled during comment emission
- `coderabbit review findings` reported no stored findings for this scope

## Risks
- uncoded 404 Clerk environment failures still fall through to the existing ticket fallback path by design
