### PR TITLE
fix(insights): dedupe same-fact insight spam (JOV-3084)

### DIFF
--- a/apps/web/app/api/cron/generate-insights/route.ts
+++ b/apps/web/app/api/cron/generate-insights/route.ts
@@ -17,6 +17,7 @@ import {
   expireStaleInsights,
   getExistingInsightTypes,
   persistInsights,
+  prepareInsightsForPersistence,
 } from '@/lib/services/insights/lifecycle';
 import {
   INSIGHTS_CRON_CONCURRENCY,
@@ -58,11 +59,12 @@ async function processProfile(
   const result = await generateInsights(metrics, existingTypes, {
     sessionId: profileId,
   });
+  const dedupedInsights = prepareInsightsForPersistence(result.insights);
 
   const persisted = await persistInsights(
     profileId,
     run.id,
-    result.insights,
+    dedupedInsights,
     metrics.period,
     metrics.comparisonPeriod
   );

--- a/apps/web/lib/services/insights/lifecycle.ts
+++ b/apps/web/lib/services/insights/lifecycle.ts
@@ -22,6 +22,7 @@ import { GENERATION_COOLDOWN_HOURS } from './thresholds';
 
 const INSIGHT_PRIORITY_ORDER = drizzleSql`case ${aiInsights.priority} when 'high' then 0 when 'medium' then 1 when 'low' then 2 end`;
 
+// Keep in sync with INSIGHT_PRIORITY_ORDER so DB and JS ordering match.
 const INSIGHT_PRIORITY_RANK: Record<InsightPriority, number> = {
   high: 0,
   medium: 1,
@@ -458,43 +459,71 @@ function getInsightSourceKey(dataSnapshot: unknown): string | null {
   }
 
   const snapshot = dataSnapshot as Record<string, unknown>;
-  const city = normalizeSnapshotToken(snapshot.city);
-  const country = normalizeSnapshotToken(snapshot.country);
+  const city = getSnapshotToken(snapshot, 'city', ['location', 'city']);
+  const country = getSnapshotToken(snapshot, 'country', [
+    'location',
+    'country',
+  ]);
   if (city) {
     return country ? `city:${city}|${country}` : `city:${city}`;
   }
 
-  const market = normalizeSnapshotToken(snapshot.market);
+  const market = getSnapshotToken(snapshot, 'market');
   if (market) {
     return `market:${market}`;
   }
 
-  const release = normalizeSnapshotToken(snapshot.release);
+  const release = getSnapshotToken(snapshot, 'release');
   if (release) {
     return `release:${release}`;
   }
 
-  const referrer = normalizeSnapshotToken(snapshot.referrer);
+  const referrer = getSnapshotToken(snapshot, 'referrer');
   if (referrer) {
     return `referrer:${referrer}`;
   }
 
-  const spikeDate = normalizeSnapshotToken(snapshot.spikeDate);
+  const spikeDate = getSnapshotToken(snapshot, 'spikeDate');
   if (spikeDate) {
     return `spikeDate:${spikeDate}`;
   }
 
-  const deviceType = normalizeSnapshotToken(snapshot.deviceType);
+  const deviceType = getSnapshotToken(snapshot, 'deviceType');
   if (deviceType) {
     return `deviceType:${deviceType}`;
   }
 
-  const linkType = normalizeSnapshotToken(snapshot.linkType);
+  const linkType = getSnapshotToken(snapshot, 'linkType');
   if (linkType) {
     return `linkType:${linkType}`;
   }
 
   return null;
+}
+
+function getSnapshotToken(
+  snapshot: Record<string, unknown>,
+  key: string,
+  nestedPath?: readonly string[]
+): string | null {
+  const topLevelValue = normalizeSnapshotToken(snapshot[key]);
+  if (topLevelValue) {
+    return topLevelValue;
+  }
+
+  if (!nestedPath) {
+    return null;
+  }
+
+  let value: unknown = snapshot;
+  for (const segment of nestedPath) {
+    if (!value || typeof value !== 'object') {
+      return null;
+    }
+    value = (value as Record<string, unknown>)[segment];
+  }
+
+  return normalizeSnapshotToken(value);
 }
 
 function normalizeSnapshotToken(value: unknown): string | null {

--- a/apps/web/lib/services/insights/lifecycle.ts
+++ b/apps/web/lib/services/insights/lifecycle.ts
@@ -20,6 +20,21 @@ import type {
 } from '@/types/insights';
 import { GENERATION_COOLDOWN_HOURS } from './thresholds';
 
+const INSIGHT_PRIORITY_ORDER = drizzleSql`case ${aiInsights.priority} when 'high' then 0 when 'medium' then 1 when 'low' then 2 end`;
+
+const INSIGHT_PRIORITY_RANK: Record<InsightPriority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
+type InsightDedupCandidate = {
+  category: InsightCategory;
+  title: string;
+  description: string;
+  dataSnapshot: unknown;
+};
+
 // ---------------------------------------------------------------------------
 // Insight Generation Runs
 // ---------------------------------------------------------------------------
@@ -110,13 +125,14 @@ export async function persistInsights(
   period: { start: Date; end: Date },
   comparisonPeriod: { start: Date; end: Date }
 ): Promise<number> {
-  if (insights.length === 0) return 0;
+  const dedupedInsights = prepareInsightsForPersistence(insights);
+  if (dedupedInsights.length === 0) return 0;
 
   const now = new Date();
   let persisted = 0;
 
   // Insert each insight individually to handle dedup gracefully
-  for (const insight of insights) {
+  for (const insight of dedupedInsights) {
     const expiresAt = new Date(now);
     expiresAt.setDate(expiresAt.getDate() + insight.expiresInDays);
 
@@ -208,28 +224,17 @@ export async function getActiveInsights(
 
   const whereClause = and(...conditions);
 
-  const [rows, countResult] = await Promise.all([
-    db
-      .select()
-      .from(aiInsights)
-      .where(whereClause)
-      .orderBy(
-        drizzleSql`case ${aiInsights.priority} when 'high' then 0 when 'medium' then 1 when 'low' then 2 end`,
-        desc(aiInsights.createdAt)
-      )
-      .limit(limit)
-      .offset(offset),
-    db
-      .select({ count: drizzleSql<number>`count(*)::int` })
-      .from(aiInsights)
-      .where(whereClause),
-  ]);
-
-  const total = countResult[0]?.count ?? 0;
+  const rows = await db
+    .select()
+    .from(aiInsights)
+    .where(whereClause)
+    .orderBy(INSIGHT_PRIORITY_ORDER, desc(aiInsights.createdAt));
+  const dedupedRows = dedupeVisibleInsights(rows);
+  const pagedRows = dedupedRows.slice(offset, offset + limit);
 
   return {
-    insights: rows.map(formatInsightResponse),
-    total,
+    insights: pagedRows.map(formatInsightResponse),
+    total: dedupedRows.length,
   };
 }
 
@@ -241,20 +246,11 @@ export async function getInsightsSummary(
 ): Promise<InsightsSummaryResponse> {
   const now = new Date();
 
-  const [insights, countResult, lastRun] = await Promise.all([
+  const [insights, lastRun] = await Promise.all([
     db
       .select()
       .from(aiInsights)
-      .where(
-        and(
-          eq(aiInsights.creatorProfileId, creatorProfileId),
-          eq(aiInsights.status, 'active'),
-          gte(aiInsights.expiresAt, now)
-        )
-      ),
-    db
-      .select({ count: drizzleSql<number>`count(*)::int` })
-      .from(aiInsights)
+      .orderBy(INSIGHT_PRIORITY_ORDER, desc(aiInsights.createdAt))
       .where(
         and(
           eq(aiInsights.creatorProfileId, creatorProfileId),
@@ -275,13 +271,14 @@ export async function getInsightsSummary(
       .limit(1),
   ]);
 
+  const dedupedInsights = dedupeVisibleInsights(insights);
   const sortedInsights = sortInsightsForChat(
-    insights.map(formatInsightResponse)
+    dedupedInsights.map(formatInsightResponse)
   );
 
   return {
     insights: sortedInsights.slice(0, 3),
-    totalActive: countResult[0]?.count ?? 0,
+    totalActive: dedupedInsights.length,
     lastGeneratedAt: lastRun[0]?.createdAt
       ? toISOStringSafe(lastRun[0].createdAt)
       : null,
@@ -358,9 +355,40 @@ export async function getExistingInsightTypes(
   return rows.map(r => r.insightType);
 }
 
+export function prepareInsightsForPersistence(
+  insights: readonly GeneratedInsight[]
+): GeneratedInsight[] {
+  return dedupeVisibleInsights(
+    [...insights].sort(
+      (left, right) =>
+        INSIGHT_PRIORITY_RANK[left.priority] -
+          INSIGHT_PRIORITY_RANK[right.priority] ||
+        right.confidence - left.confidence
+    )
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+export function dedupeVisibleInsights<T extends InsightDedupCandidate>(
+  insights: readonly T[]
+): T[] {
+  const seen = new Set<string>();
+  const deduped: T[] = [];
+
+  for (const insight of insights) {
+    const key = buildInsightDedupKey(insight);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(insight);
+  }
+
+  return deduped;
+}
 
 function formatInsightResponse(
   row: typeof aiInsights.$inferSelect
@@ -380,4 +408,71 @@ function formatInsightResponse(
     createdAt: toISOStringSafe(row.createdAt),
     expiresAt: toISOStringSafe(row.expiresAt),
   };
+}
+
+function buildInsightDedupKey(insight: InsightDedupCandidate): string {
+  const sourceKey = getInsightSourceKey(insight.dataSnapshot);
+  if (sourceKey) {
+    return `${insight.category}|${sourceKey}`;
+  }
+
+  return `${insight.category}|${normalizeInsightCopy(insight.title)}|${normalizeInsightCopy(insight.description)}`;
+}
+
+function getInsightSourceKey(dataSnapshot: unknown): string | null {
+  if (!dataSnapshot || typeof dataSnapshot !== 'object') {
+    return null;
+  }
+
+  const snapshot = dataSnapshot as Record<string, unknown>;
+  const city = normalizeSnapshotToken(snapshot.city);
+  const country = normalizeSnapshotToken(snapshot.country);
+  if (city) {
+    return country ? `city:${city}|${country}` : `city:${city}`;
+  }
+
+  const market = normalizeSnapshotToken(snapshot.market);
+  if (market) {
+    return `market:${market}`;
+  }
+
+  const release = normalizeSnapshotToken(snapshot.release);
+  if (release) {
+    return `release:${release}`;
+  }
+
+  const referrer = normalizeSnapshotToken(snapshot.referrer);
+  if (referrer) {
+    return `referrer:${referrer}`;
+  }
+
+  const spikeDate = normalizeSnapshotToken(snapshot.spikeDate);
+  if (spikeDate) {
+    return `spikeDate:${spikeDate}`;
+  }
+
+  const deviceType = normalizeSnapshotToken(snapshot.deviceType);
+  if (deviceType) {
+    return `deviceType:${deviceType}`;
+  }
+
+  const linkType = normalizeSnapshotToken(snapshot.linkType);
+  if (linkType) {
+    return `linkType:${linkType}`;
+  }
+
+  return null;
+}
+
+function normalizeSnapshotToken(value: unknown): string | null {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  return normalized ? normalized : null;
+}
+
+function normalizeInsightCopy(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, ' ');
 }

--- a/apps/web/lib/services/insights/lifecycle.ts
+++ b/apps/web/lib/services/insights/lifecycle.ts
@@ -28,7 +28,12 @@ const INSIGHT_PRIORITY_RANK: Record<InsightPriority, number> = {
   low: 2,
 };
 
+const INSIGHT_DEDUP_READ_LIMIT = 150;
+const INSIGHT_SUMMARY_CANDIDATE_LIMIT = 50;
+const FALLBACK_PRIORITY_RANK = 99;
+
 type InsightDedupCandidate = {
+  insightType: string;
   category: InsightCategory;
   title: string;
   description: string;
@@ -224,17 +229,27 @@ export async function getActiveInsights(
 
   const whereClause = and(...conditions);
 
-  const rows = await db
-    .select()
-    .from(aiInsights)
-    .where(whereClause)
-    .orderBy(INSIGHT_PRIORITY_ORDER, desc(aiInsights.createdAt));
+  const candidateLimit = Math.min(limit * 3, INSIGHT_DEDUP_READ_LIMIT);
+
+  const [rows, totalRows] = await Promise.all([
+    db
+      .select()
+      .from(aiInsights)
+      .where(whereClause)
+      .orderBy(INSIGHT_PRIORITY_ORDER, desc(aiInsights.createdAt))
+      .limit(candidateLimit)
+      .offset(offset),
+    db
+      .select({ total: drizzleSql<number>`count(*)::int` })
+      .from(aiInsights)
+      .where(whereClause),
+  ]);
   const dedupedRows = dedupeVisibleInsights(rows);
-  const pagedRows = dedupedRows.slice(offset, offset + limit);
+  const pagedRows = dedupedRows.slice(0, limit);
 
   return {
     insights: pagedRows.map(formatInsightResponse),
-    total: dedupedRows.length,
+    total: totalRows[0]?.total ?? 0,
   };
 }
 
@@ -246,18 +261,19 @@ export async function getInsightsSummary(
 ): Promise<InsightsSummaryResponse> {
   const now = new Date();
 
-  const [insights, lastRun] = await Promise.all([
+  const activeWhereClause = and(
+    eq(aiInsights.creatorProfileId, creatorProfileId),
+    eq(aiInsights.status, 'active'),
+    gte(aiInsights.expiresAt, now)
+  );
+
+  const [insights, lastRun, totalRows] = await Promise.all([
     db
       .select()
       .from(aiInsights)
       .orderBy(INSIGHT_PRIORITY_ORDER, desc(aiInsights.createdAt))
-      .where(
-        and(
-          eq(aiInsights.creatorProfileId, creatorProfileId),
-          eq(aiInsights.status, 'active'),
-          gte(aiInsights.expiresAt, now)
-        )
-      ),
+      .where(activeWhereClause)
+      .limit(INSIGHT_SUMMARY_CANDIDATE_LIMIT),
     db
       .select({ createdAt: insightGenerationRuns.createdAt })
       .from(insightGenerationRuns)
@@ -269,6 +285,10 @@ export async function getInsightsSummary(
       )
       .orderBy(desc(insightGenerationRuns.createdAt))
       .limit(1),
+    db
+      .select({ total: drizzleSql<number>`count(*)::int` })
+      .from(aiInsights)
+      .where(activeWhereClause),
   ]);
 
   const dedupedInsights = dedupeVisibleInsights(insights);
@@ -278,7 +298,7 @@ export async function getInsightsSummary(
 
   return {
     insights: sortedInsights.slice(0, 3),
-    totalActive: dedupedInsights.length,
+    totalActive: totalRows[0]?.total ?? 0,
     lastGeneratedAt: lastRun[0]?.createdAt
       ? toISOStringSafe(lastRun[0].createdAt)
       : null,
@@ -361,8 +381,7 @@ export function prepareInsightsForPersistence(
   return dedupeVisibleInsights(
     [...insights].sort(
       (left, right) =>
-        INSIGHT_PRIORITY_RANK[left.priority] -
-          INSIGHT_PRIORITY_RANK[right.priority] ||
+        getPriorityRank(left.priority) - getPriorityRank(right.priority) ||
         right.confidence - left.confidence
     )
   );
@@ -413,10 +432,24 @@ function formatInsightResponse(
 function buildInsightDedupKey(insight: InsightDedupCandidate): string {
   const sourceKey = getInsightSourceKey(insight.dataSnapshot);
   if (sourceKey) {
-    return `${insight.category}|${sourceKey}`;
+    return `${insight.category}|${getInsightDedupFamily(insight.insightType)}|${sourceKey}`;
   }
 
-  return `${insight.category}|${normalizeInsightCopy(insight.title)}|${normalizeInsightCopy(insight.description)}`;
+  return `${insight.category}|${insight.insightType}|${normalizeInsightCopy(insight.title)}|${normalizeInsightCopy(insight.description)}`;
+}
+
+function getPriorityRank(priority: InsightPriority): number {
+  return INSIGHT_PRIORITY_RANK[priority] ?? FALLBACK_PRIORITY_RANK;
+}
+
+function getInsightDedupFamily(insightType: string): string {
+  switch (insightType) {
+    case 'city_growth':
+    case 'new_market':
+      return 'city_growth';
+    default:
+      return insightType;
+  }
 }
 
 function getInsightSourceKey(dataSnapshot: unknown): string | null {

--- a/apps/web/tests/unit/api/cron/generate-insights.test.ts
+++ b/apps/web/tests/unit/api/cron/generate-insights.test.ts
@@ -38,13 +38,20 @@ vi.mock('@/lib/utils/logger', () => ({
   },
 }));
 
-vi.mock('@/lib/services/insights/lifecycle', () => ({
-  expireStaleInsights: expireStaleInsightsMock,
-  createGenerationRun: createGenerationRunMock,
-  getExistingInsightTypes: getExistingInsightTypesMock,
-  persistInsights: persistInsightsMock,
-  completeGenerationRun: completeGenerationRunMock,
-}));
+vi.mock('@/lib/services/insights/lifecycle', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/lib/services/insights/lifecycle')
+  >('@/lib/services/insights/lifecycle');
+
+  return {
+    ...actual,
+    expireStaleInsights: expireStaleInsightsMock,
+    createGenerationRun: createGenerationRunMock,
+    getExistingInsightTypes: getExistingInsightTypesMock,
+    persistInsights: persistInsightsMock,
+    completeGenerationRun: completeGenerationRunMock,
+  };
+});
 
 vi.mock('@/lib/services/insights/data-aggregator', () => ({
   aggregateMetrics: aggregateMetricsMock,
@@ -116,5 +123,91 @@ describe('GET /api/cron/generate-insights', () => {
     expect(maxInFlight).toBeGreaterThan(1);
     expect(data.stats.processed).toBe(6);
     expect(data.stats.insightsGenerated).toBe(6);
+  });
+
+  it('deduplicates obvious same-fact insights before persistence', async () => {
+    executeMock.mockResolvedValue({
+      rows: [{ profile_id: 'profile-1' }],
+    });
+
+    createGenerationRunMock.mockResolvedValue({ id: 'run-profile-1' });
+    generateInsightsMock.mockResolvedValue({
+      insights: [
+        {
+          insightType: 'city_growth',
+          category: 'geographic',
+          priority: 'medium',
+          title: 'Austin listeners grew 34% this month',
+          description: 'Austin traffic is accelerating compared to last month.',
+          actionSuggestion: 'Consider a new Austin push.',
+          confidence: 0.81,
+          dataSnapshot: { city: 'Austin', country: 'US', growthRate: 0.34 },
+          expiresInDays: 7,
+        },
+        {
+          insightType: 'new_market',
+          category: 'geographic',
+          priority: 'high',
+          title: 'Austin is becoming a breakout market',
+          description:
+            'Austin traffic is accelerating compared to last month with repeat growth.',
+          actionSuggestion: 'Consider a new Austin push.',
+          confidence: 0.93,
+          dataSnapshot: { city: 'Austin', country: 'US', currentViews: 44 },
+          expiresInDays: 7,
+        },
+        {
+          insightType: 'tip_hotspot',
+          category: 'revenue',
+          priority: 'medium',
+          title: 'Austin fans tip above your average',
+          description:
+            'Austin supporters tip more than the rest of your audience.',
+          actionSuggestion: 'Test a VIP offer in Austin.',
+          confidence: 0.72,
+          dataSnapshot: { city: 'Austin', avgTip: 2100, overallAvg: 1200 },
+          expiresInDays: 7,
+        },
+      ],
+      modelUsed: 'gpt',
+      promptTokens: 10,
+      completionTokens: 10,
+    });
+    persistInsightsMock.mockResolvedValue(2);
+
+    const { GET } = await import('@/app/api/cron/generate-insights/route');
+
+    const response = await GET(
+      new Request('http://localhost/api/cron/generate-insights', {
+        headers: { authorization: 'Bearer test-secret' },
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(persistInsightsMock).toHaveBeenCalledTimes(1);
+
+    const dedupedInsights = persistInsightsMock.mock.calls[0]?.[2];
+    expect(dedupedInsights).toHaveLength(2);
+    expect(dedupedInsights).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          insightType: 'new_market',
+          category: 'geographic',
+        }),
+        expect.objectContaining({
+          insightType: 'tip_hotspot',
+          category: 'revenue',
+        }),
+      ])
+    );
+    expect(data.stats.insightsGenerated).toBe(2);
+    expect(completeGenerationRunMock).toHaveBeenCalledWith(
+      'run-profile-1',
+      expect.objectContaining({
+        status: 'completed',
+        insightsGenerated: 2,
+      })
+    );
   });
 });

--- a/apps/web/tests/unit/lib/services/insights/lifecycle.test.ts
+++ b/apps/web/tests/unit/lib/services/insights/lifecycle.test.ts
@@ -54,6 +54,19 @@ describe('insight lifecycle deduplication', () => {
     ]);
   });
 
+  it('deduplicates top-level and nested location snapshots consistently', () => {
+    const result = dedupeVisibleInsights([
+      baseInsight,
+      {
+        ...baseInsight,
+        dataSnapshot: { location: { city: 'Austin', country: 'US' } },
+        title: 'Austin is breaking out',
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+  });
+
   it('uses normalized copy fallback when there is no structured source key', () => {
     const result = dedupeVisibleInsights([
       {

--- a/apps/web/tests/unit/lib/services/insights/lifecycle.test.ts
+++ b/apps/web/tests/unit/lib/services/insights/lifecycle.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  dedupeVisibleInsights,
+  prepareInsightsForPersistence,
+} from '@/lib/services/insights/lifecycle';
+import type { GeneratedInsight } from '@/types/insights';
+
+const baseInsight: GeneratedInsight = {
+  insightType: 'city_growth',
+  category: 'geographic',
+  priority: 'medium',
+  title: 'Austin listeners grew this month',
+  description: 'Austin traffic is accelerating.',
+  actionSuggestion: 'Plan an Austin push.',
+  confidence: 0.8,
+  dataSnapshot: { city: 'Austin', country: 'US' },
+  expiresInDays: 7,
+};
+
+describe('insight lifecycle deduplication', () => {
+  it('keeps the highest priority same-fact city insight before persistence', () => {
+    const result = prepareInsightsForPersistence([
+      baseInsight,
+      {
+        ...baseInsight,
+        insightType: 'new_market',
+        priority: 'high',
+        title: 'Austin is becoming a breakout market',
+        confidence: 0.93,
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      insightType: 'new_market',
+      priority: 'high',
+    });
+  });
+
+  it('does not collapse different insight types for the same source', () => {
+    const result = dedupeVisibleInsights([
+      baseInsight,
+      {
+        ...baseInsight,
+        insightType: 'declining_market',
+        title: 'Austin listeners fell this month',
+        description: 'Austin traffic is slowing.',
+      },
+    ]);
+
+    expect(result.map(insight => insight.insightType)).toEqual([
+      'city_growth',
+      'declining_market',
+    ]);
+  });
+
+  it('uses normalized copy fallback when there is no structured source key', () => {
+    const result = dedupeVisibleInsights([
+      {
+        ...baseInsight,
+        dataSnapshot: {},
+        title: '  Repeat listeners jumped   ',
+        description: 'Fans came back twice as often.',
+      },
+      {
+        ...baseInsight,
+        dataSnapshot: null,
+        title: 'repeat listeners jumped',
+        description: 'Fans came back twice as often.',
+      },
+    ]);
+
+    expect(result).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
<!-- linear-issue-id:69be0d7d-dfa8-4562-9a86-4b9052bc4127 -->
## Summary
- dedupe same-fact insight spam before persistence using existing `dataSnapshot` source keys with normalized-copy fallback
- bound read-side dedup candidate windows for active and summary APIs so visible dedup no longer requires loading every active insight row
- keep total counts backed by database counts, preserve distinct same-source insight types except the intended city-growth/new-market duplicate family, and handle nested location snapshots consistently
- add focused cron and lifecycle regression tests for dedup behavior

## Validation
- `./scripts/setup.sh` (previous run)
- `pnpm --filter web exec vitest run tests/unit/api/cron/generate-insights.test.ts`
- `pnpm --filter web exec vitest run tests/unit/api/cron/generate-insights.test.ts tests/unit/lib/services/insights/lifecycle.test.ts`
- `pnpm biome check --write apps/web/lib/services/insights/lifecycle.ts apps/web/app/api/cron/generate-insights/route.ts apps/web/tests/unit/api/cron/generate-insights.test.ts apps/web/tests/unit/lib/services/insights/lifecycle.test.ts`
- `pnpm --filter @jovie/web run test:bug-to-test`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `git diff --check`
- pre-commit hook: `next:proxy-guard`, Biome, ESLint, staged-file typecheck
- pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, `biome lint .`

## CodeRabbit
- `coderabbit review --plain --type uncommitted --base origin/main` completed analysis but repeatedly stalled during comment emission
- first local run emitted one nitpick; simplification applied
- final `coderabbit review findings` reported no stored findings for this scope

## Review response
- addressed Hermes review findings for unbounded reads, count semantics, priority fallback, source-key collisions, nested location snapshots, and priority-order drift note
- left duplicate preparation in `persistInsights` intentionally as a defensive boundary for non-cron callers

## Risks
- read APIs now dedupe within bounded candidate windows instead of scanning all active rows; totals remain database-backed active-row counts
- no schema, route contract, or UI changes
