### PR TITLE
fix(automation): keep codex shipper singleton draining

### DIFF
--- a/docs/HERMES_AIR.md
+++ b/docs/HERMES_AIR.md
@@ -189,11 +189,17 @@ tsx scripts/hermes/jobs/codex-issue-shipper.ts
 
 The job watches open GitHub issues labeled `codex`. Empty runs only call GitHub, write a JSONL event, and exit. No gbrain query, model call, subagent, or CodeRabbit review starts until an eligible issue exists.
 
+Only one shipper run may own the queue at a time. A new cron invocation takes a non-blocking singleton lock check; if another shipper is still active, the new invocation logs `singleton_active_skip` and exits. The active run keeps draining the queue in batches until no eligible issues remain, the machine is under too much pressure to launch another agent, or all remaining issues are blocked or human-gated.
+
 Config variables:
 
 | Variable | Default | Purpose | Update path |
 |---|---:|---|---|
-| `HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN` | `1` | Max Codex issues shipped per run; controls concurrency and spend | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
+| `HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN` | `3` | Max Codex issues selected per drain batch; also caps parallel agent fan-out | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
+| `HERMES_CODEX_SHIPPER_MAX_PARALLEL_AGENTS` | `3` | Absolute cap for concurrent coder agents inside the singleton shipper run | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
+| `HERMES_CODEX_SHIPPER_MIN_FREE_MEMORY_MB` | `4096` | Below this free-memory floor, launch at most one new coder; below half this floor, launch none | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
+| `HERMES_CODEX_SHIPPER_MAX_LOAD_PER_CPU` | `1.5` | Above this one-minute load-per-CPU threshold, launch at most one new coder; above 1.5x this threshold, launch none | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
+| `HERMES_CODEX_SHIPPER_SINGLETON_LOCK_STALE_MS` | `28800000` | Long-running shipper lock TTL; new crons skip while the owning process is alive | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
 | `HERMES_CODEX_SHIPPER_INTEGRATION_THRESHOLD` | `4` | Eligible queue depth that routes trainable issues through `integration/codex-queue` | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
 | `HERMES_CODEX_SHIPPER_AGENT` | `claude` | Local coding agent binary; `claude` keeps subagent support, `codex` is available as an explicit override | Doppler or plist env, then `./scripts/hermes/bootstrap-air.sh --reconfigure` |
 
@@ -211,9 +217,9 @@ Ship now / Re-evaluate when / Then:
 
 | Decision | Trigger | Action |
 |---|---|---|
-| Ship now | Default `HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN=1`, because one coder session can consume hours of agent time plus CI minutes | Keep one issue per run and let the 15-minute cron continue draining |
-| Re-evaluate when | Eligible `codex` queue stays above 4 issues for two consecutive runs and cost per shipped issue stays under the weekly unit target: CI minutes x runner cost plus agent minutes x model cost | Raise `HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN` or add an `integration-branch` label to queue trainable issues |
-| Then | CI minutes x runner cost plus agent minutes x model cost stay within the weekly agent budget | Keep the higher concurrency; otherwise return to one issue per run |
+| Ship now | Default `HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN=3` and `HERMES_CODEX_SHIPPER_MAX_PARALLEL_AGENTS=3`, because one singleton run can keep the queue hot without duplicate cron owners | Keep up to three coder lanes active while free memory stays above 4096MB and load stays below 1.5 per CPU |
+| Re-evaluate when | Cost per shipped issue rises above the weekly unit target: CI minutes x runner cost plus agent minutes x model cost, or local pressure repeatedly logs `capacity_throttled` | Lower `HERMES_CODEX_SHIPPER_MAX_PARALLEL_AGENTS`, raise machine capacity, or route more trainable issues through `integration-branch` labels |
+| Then | CI minutes x runner cost plus agent minutes x model cost stay within the weekly agent budget | Keep three lanes; otherwise reduce the cap until the queue drain cost is back inside target |
 
 ## Recovery Procedures
 

--- a/scripts/hermes/jobs/codex-issue-shipper.ts
+++ b/scripts/hermes/jobs/codex-issue-shipper.ts
@@ -11,7 +11,7 @@
  * issue is eligible and claimed.
  */
 
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import {
   appendFileSync,
   closeSync,
@@ -19,8 +19,10 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  rmSync,
   writeFileSync,
 } from 'node:fs';
+import { availableParallelism, freemem, loadavg, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
@@ -40,7 +42,7 @@ import {
   loadShipperConfig,
   type ShipperConfig,
 } from '../lib/codex-issue-shipper';
-import { withHeavyJobLock } from '../lib/heavy-job-lock';
+import { tryWithHeavyJobLock } from '../lib/heavy-job-lock';
 import { HERMES_PATHS } from '../lib/hermes-paths';
 import { logJobEvent, withJobLogging } from '../lib/jobs-log';
 
@@ -53,6 +55,15 @@ interface AgentRunResult {
   readonly error?: string;
   readonly logPath: string;
   readonly promptPath: string;
+}
+
+interface CapacitySnapshot {
+  readonly allowedAgents: number;
+  readonly cpuCount: number;
+  readonly freeMemoryMb: number;
+  readonly loadAverage1m: number;
+  readonly loadPerCpu: number;
+  readonly reasons: ReadonlyArray<string>;
 }
 
 function shortError(err: unknown): string {
@@ -93,6 +104,143 @@ function run(args: ReadonlyArray<string>, config: ShipperConfig): string {
     timeout: 30_000,
     maxBuffer: 5 * 1024 * 1024,
   });
+}
+
+function systemCapacity(config: ShipperConfig): CapacitySnapshot {
+  const cpuCount = Math.max(1, availableParallelism());
+  const freeMemoryMb = Math.round(freemem() / 1024 / 1024);
+  const loadAverage1m = loadavg()[0] ?? 0;
+  const loadPerCpu = loadAverage1m / cpuCount;
+  const reasons: string[] = [];
+  let allowedAgents = Math.min(
+    config.maxIssuesPerRun,
+    config.maxParallelAgents
+  );
+
+  if (freeMemoryMb < config.minFreeMemoryMb) {
+    allowedAgents = Math.min(allowedAgents, 1);
+    reasons.push(
+      `free memory ${freeMemoryMb}MB below ${config.minFreeMemoryMb}MB`
+    );
+  }
+
+  if (loadPerCpu > config.maxLoadPerCpu) {
+    allowedAgents = Math.min(allowedAgents, 1);
+    reasons.push(
+      `load ${loadPerCpu.toFixed(2)}/cpu above ${config.maxLoadPerCpu}`
+    );
+  }
+
+  if (
+    freeMemoryMb < config.minFreeMemoryMb / 2 ||
+    loadPerCpu > config.maxLoadPerCpu * 1.5
+  ) {
+    allowedAgents = 0;
+    reasons.push('system pressure too high to launch another coding agent');
+  }
+
+  return {
+    allowedAgents,
+    cpuCount,
+    freeMemoryMb,
+    loadAverage1m,
+    loadPerCpu,
+    reasons,
+  };
+}
+
+function timestampSlug(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-').replace(/Z$/, 'z');
+}
+
+function branchExists(config: ShipperConfig, branchName: string): boolean {
+  const local = spawnSyncSafe(
+    'git',
+    ['rev-parse', '--verify', `refs/heads/${branchName}`],
+    config.repoRoot
+  );
+  if (local.status === 0) return true;
+
+  const remote = spawnSyncSafe(
+    'git',
+    ['ls-remote', '--exit-code', '--heads', 'origin', branchName],
+    config.repoRoot
+  );
+  return remote.status === 0;
+}
+
+function spawnSyncSafe(
+  command: string,
+  args: ReadonlyArray<string>,
+  cwd: string
+): { readonly status: number | null } {
+  try {
+    const result = execFileSync(command, args, {
+      cwd,
+      encoding: 'utf8',
+      timeout: 30_000,
+      stdio: 'ignore',
+    });
+    void result;
+    return { status: 0 };
+  } catch (err) {
+    const status =
+      typeof (err as { status?: unknown }).status === 'number'
+        ? ((err as { status: number }).status ?? 1)
+        : 1;
+    return { status };
+  }
+}
+
+function prepareWorktree(
+  config: ShipperConfig,
+  plan: DispatchPlan
+): { readonly plan: DispatchPlan; readonly repoRoot: string } {
+  const base = timestampSlug();
+  const branchName = branchExists(config, plan.branchName)
+    ? `${plan.branchName}-${base}`
+    : plan.branchName;
+  const root =
+    process.env.HERMES_CODEX_SHIPPER_WORKTREE_ROOT ??
+    join(tmpdir(), 'jovie-worktrees');
+  const repoRoot = join(root, `gh-${plan.issue.number}-${base}`);
+
+  mkdirSync(root, { recursive: true });
+  run(['git', 'fetch', 'origin', 'main'], config);
+  run(
+    ['git', 'worktree', 'add', '-b', branchName, repoRoot, 'origin/main'],
+    config
+  );
+
+  return {
+    plan: { ...plan, branchName },
+    repoRoot,
+  };
+}
+
+function cleanupWorktree(config: ShipperConfig, repoRoot: string): void {
+  try {
+    run(['git', 'worktree', 'remove', '--force', repoRoot], config);
+    return;
+  } catch (err) {
+    logJobEvent({
+      job: JOB,
+      event: 'worktree_remove_failed',
+      repoRoot,
+      error: shortError(err),
+    });
+  }
+
+  try {
+    rmSync(repoRoot, { recursive: true, force: true });
+  } catch (err) {
+    logJobEvent({
+      job: JOB,
+      event: 'worktree_cleanup_failed',
+      repoRoot,
+      error: shortError(err),
+    });
+  }
 }
 
 function detectRepoRoot(): string {
@@ -445,8 +593,9 @@ function agentLogsDir(): string {
 function runAgent(
   config: ShipperConfig,
   plan: DispatchPlan,
-  prompt: string
-): AgentRunResult {
+  prompt: string,
+  repoRoot: string
+): Promise<AgentRunResult> {
   const timestamp = new Date()
     .toISOString()
     .replace(/[:.]/g, '-')
@@ -468,30 +617,59 @@ function runAgent(
     ].join('\n')
   );
 
-  const command = buildAgentCommand(config, plan.route);
+  const agentConfig = { ...config, repoRoot };
+  const command = buildAgentCommand(agentConfig, plan.route);
   const fd = openSync(logPath, 'a');
-  try {
-    const result = spawnSync(command.command, [...command.args], {
-      cwd: config.repoRoot,
+  return new Promise(resolve => {
+    let settled = false;
+    let timedOut = false;
+    let timeout: NodeJS.Timeout;
+    const child = spawn(command.command, [...command.args], {
+      cwd: repoRoot,
       env: {
         ...process.env,
         JOVIE_AGENT_PROFILE: 'coder',
       },
-      input: prompt,
-      timeout: config.agentTimeoutMs,
       stdio: ['pipe', fd, fd],
     });
-    return {
-      ok: result.status === 0,
-      status: result.status,
-      signal: result.signal,
-      error: result.error ? shortError(result.error) : undefined,
-      logPath,
-      promptPath,
+
+    const finish = (
+      result: Omit<AgentRunResult, 'logPath' | 'promptPath'>
+    ): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      closeSync(fd);
+      resolve({ ...result, logPath, promptPath });
     };
-  } finally {
-    closeSync(fd);
-  }
+
+    timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+    }, config.agentTimeoutMs);
+
+    child.on('error', err => {
+      finish({
+        ok: false,
+        status: null,
+        signal: null,
+        error: shortError(err),
+      });
+    });
+
+    child.on('close', (status, signal) => {
+      finish({
+        ok: status === 0,
+        status,
+        signal,
+        error: timedOut
+          ? `Agent timeout after ${config.agentTimeoutMs}ms`
+          : undefined,
+      });
+    });
+
+    child.stdin.end(prompt);
+  });
 }
 
 function findPrForBranch(
@@ -529,120 +707,156 @@ async function dispatchPlan(
   config: ShipperConfig,
   plan: DispatchPlan
 ): Promise<void> {
-  claimIssue(config, plan);
-
-  let gbrain: GbrainContext;
+  const prepared = prepareWorktree(config, plan);
+  const dispatch = prepared.plan;
   try {
-    gbrain = collectGbrainContext(plan);
-  } catch (err) {
-    const reason = `GBrain capture failed, so no coding agent was started.\n\n\`\`\`text\n${shortError(err)}\n\`\`\``;
-    releaseClaimForRetry(config, plan, reason);
-    logJobEvent({
-      job: JOB,
-      event: 'gbrain_failed',
-      issue: plan.issue.number,
-      error: shortError(err),
+    claimIssue(config, dispatch);
+
+    let gbrain: GbrainContext;
+    try {
+      gbrain = collectGbrainContext(dispatch);
+    } catch (err) {
+      const reason = `GBrain capture failed, so no coding agent was started.\n\n\`\`\`text\n${shortError(err)}\n\`\`\``;
+      releaseClaimForRetry(config, dispatch, reason);
+      logJobEvent({
+        job: JOB,
+        event: 'gbrain_failed',
+        issue: dispatch.issue.number,
+        error: shortError(err),
+      });
+      return;
+    }
+
+    const prompt = buildAgentPrompt({
+      issue: dispatch.issue,
+      branchName: dispatch.branchName,
+      baseBranch: 'main',
+      integrationBranch: dispatch.integrationBranch,
+      route: dispatch.route,
+      gbrain,
+      repoRoot: prepared.repoRoot,
     });
-    return;
-  }
 
-  const prompt = buildAgentPrompt({
-    issue: plan.issue,
-    branchName: plan.branchName,
-    baseBranch: 'main',
-    integrationBranch: plan.integrationBranch,
-    route: plan.route,
-    gbrain,
-    repoRoot: config.repoRoot,
-  });
-
-  const agentResult = runAgent(config, plan, prompt);
-  logJobEvent({
-    job: JOB,
-    event: agentResult.ok ? 'agent_succeeded' : 'agent_failed',
-    issue: plan.issue.number,
-    status: agentResult.status,
-    signal: agentResult.signal,
-    error: agentResult.error,
-    logPath: agentResult.logPath,
-    promptPath: agentResult.promptPath,
-    gbrainSlug: gbrain.captureSlug,
-  });
-
-  if (!agentResult.ok) {
-    markBlocked(
+    const agentResult = await runAgent(
       config,
-      plan,
-      [
-        `Agent exited without successfully shipping.`,
-        '',
-        `Status: \`${agentResult.status ?? 'null'}\``,
-        `Signal: \`${agentResult.signal ?? 'null'}\``,
-        agentResult.error ? `Error: \`${agentResult.error}\`` : null,
-        `Log: \`${agentResult.logPath}\``,
-        `Prompt: \`${agentResult.promptPath}\``,
-      ]
-        .filter((line): line is string => line !== null)
-        .join('\n')
-    );
-    return;
-  }
-
-  const pr = findPrForBranch(config, plan.branchName);
-  if (!pr) {
-    markBlocked(
-      config,
-      plan,
-      [
-        `Agent exited 0 but no open PR exists for \`${plan.branchName}\`.`,
-        '',
-        `Log: \`${agentResult.logPath}\``,
-        `Prompt: \`${agentResult.promptPath}\``,
-      ].join('\n')
+      dispatch,
+      prompt,
+      prepared.repoRoot
     );
     logJobEvent({
       job: JOB,
-      event: 'missing_pr_after_success',
-      issue: plan.issue.number,
-      branch: plan.branchName,
+      event: agentResult.ok ? 'agent_succeeded' : 'agent_failed',
+      issue: dispatch.issue.number,
+      status: agentResult.status,
+      signal: agentResult.signal,
+      error: agentResult.error,
+      logPath: agentResult.logPath,
+      promptPath: agentResult.promptPath,
+      gbrainSlug: gbrain.captureSlug,
     });
-    return;
-  }
 
-  let successCommentPosted = true;
-  try {
-    commentIssue(
-      config,
-      plan.issue.number,
-      [
-        `Codex issue shipper completed agent run and found PR #${pr.number}.`,
-        '',
-        `PR: ${pr.url}`,
-        `GBrain dispatch slug: \`${gbrain.captureSlug}\``,
-        `Log: \`${agentResult.logPath}\``,
-      ].join('\n')
-    );
-  } catch (err) {
-    successCommentPosted = false;
+    if (!agentResult.ok) {
+      markBlocked(
+        config,
+        dispatch,
+        [
+          `Agent exited without successfully shipping.`,
+          '',
+          `Status: \`${agentResult.status ?? 'null'}\``,
+          `Signal: \`${agentResult.signal ?? 'null'}\``,
+          agentResult.error ? `Error: \`${agentResult.error}\`` : null,
+          `Log: \`${agentResult.logPath}\``,
+          `Prompt: \`${agentResult.promptPath}\``,
+        ]
+          .filter((line): line is string => line !== null)
+          .join('\n')
+      );
+      return;
+    }
+
+    const pr = findPrForBranch(config, dispatch.branchName);
+    if (!pr) {
+      markBlocked(
+        config,
+        dispatch,
+        [
+          `Agent exited 0 but no open PR exists for \`${dispatch.branchName}\`.`,
+          '',
+          `Log: \`${agentResult.logPath}\``,
+          `Prompt: \`${agentResult.promptPath}\``,
+        ].join('\n')
+      );
+      logJobEvent({
+        job: JOB,
+        event: 'missing_pr_after_success',
+        issue: plan.issue.number,
+        branch: dispatch.branchName,
+      });
+      return;
+    }
+
+    let successCommentPosted = true;
+    try {
+      commentIssue(
+        config,
+        dispatch.issue.number,
+        [
+          `Codex issue shipper completed agent run and found PR #${pr.number}.`,
+          '',
+          `PR: ${pr.url}`,
+          `GBrain dispatch slug: \`${gbrain.captureSlug}\``,
+          `Log: \`${agentResult.logPath}\``,
+        ].join('\n')
+      );
+    } catch (err) {
+      successCommentPosted = false;
+      logJobEvent({
+        job: JOB,
+        event: 'success_comment_failed',
+        issue: plan.issue.number,
+        pr: pr.number,
+        error: shortError(err),
+      });
+    }
+
+    removeClaimLabel(config, dispatch, 'success_claim_remove_failed');
+
     logJobEvent({
       job: JOB,
-      event: 'success_comment_failed',
-      issue: plan.issue.number,
+      event: 'pr_found_after_success',
+      issue: dispatch.issue.number,
       pr: pr.number,
-      error: shortError(err),
+      url: pr.url,
+      successCommentPosted,
     });
+  } finally {
+    cleanupWorktree(config, prepared.repoRoot);
   }
+}
 
-  removeClaimLabel(config, plan, 'success_claim_remove_failed');
-
-  logJobEvent({
-    job: JOB,
-    event: 'pr_found_after_success',
-    issue: plan.issue.number,
-    pr: pr.number,
-    url: pr.url,
-    successCommentPosted,
-  });
+async function dispatchBatch(
+  config: ShipperConfig,
+  plans: ReadonlyArray<DispatchPlan>
+): Promise<void> {
+  await Promise.all(
+    plans.map(async plan => {
+      try {
+        await dispatchPlan(config, plan);
+      } catch (err) {
+        logJobEvent({
+          job: JOB,
+          event: 'dispatch_failed',
+          issue: plan.issue.number,
+          error: shortError(err),
+        });
+        markBlocked(
+          config,
+          plan,
+          `Dispatcher failed before a clean agent handoff.\n\n\`\`\`text\n${shortError(err)}\n\`\`\``
+        );
+      }
+    })
+  );
 }
 
 async function main(): Promise<void> {
@@ -652,63 +866,81 @@ async function main(): Promise<void> {
   const config = loadShipperConfig(process.env, repoRoot, repo);
 
   await withJobLogging(JOB, async () => {
-    const issues = listCodexIssues(config);
-    const plans = buildDispatchPlans(issues, config);
-    const skippedHuman = issues.filter(issue =>
-      labelNames(issue).includes(HUMAN_REVIEW_LABEL)
-    ).length;
+    const lockResult = await tryWithHeavyJobLock(
+      JOB,
+      async () => {
+        let controlLabelsEnsured = false;
 
-    logJobEvent({
-      job: JOB,
-      event: 'scanned',
-      issueCount: issues.length,
-      dispatchableCount: plans.length,
-      skippedHuman,
-      maxIssuesPerRun: config.maxIssuesPerRun,
-      dryRun: config.dryRun,
-    });
+        for (;;) {
+          const issues = listCodexIssues(config);
+          const plans = buildDispatchPlans(issues, config);
+          const skippedHuman = issues.filter(issue =>
+            labelNames(issue).includes(HUMAN_REVIEW_LABEL)
+          ).length;
+          const capacity = systemCapacity(config);
+          const batch = plans.slice(0, capacity.allowedAgents);
 
-    if (plans.length === 0) {
-      logJobEvent({ job: JOB, event: 'empty_queue' });
-      return;
-    }
+          logJobEvent({
+            job: JOB,
+            event: 'scanned',
+            issueCount: issues.length,
+            dispatchableCount: plans.length,
+            skippedHuman,
+            batchCount: batch.length,
+            maxIssuesPerRun: config.maxIssuesPerRun,
+            maxParallelAgents: config.maxParallelAgents,
+            capacity,
+            dryRun: config.dryRun,
+          });
 
-    if (config.dryRun) {
+          if (plans.length === 0) {
+            logJobEvent({ job: JOB, event: 'empty_queue' });
+            return;
+          }
+
+          if (batch.length === 0) {
+            logJobEvent({
+              job: JOB,
+              event: 'capacity_throttled',
+              capacity,
+            });
+            return;
+          }
+
+          if (config.dryRun) {
+            logJobEvent({
+              job: JOB,
+              event: 'dry_run_planned',
+              plans: batch.map(plan => ({
+                issue: plan.issue.number,
+                branch: plan.branchName,
+                risk: plan.route.riskLevel,
+                model: plan.route.sessionModel,
+                integrationBranch: plan.integrationBranch,
+              })),
+            });
+            return;
+          }
+
+          if (!controlLabelsEnsured) {
+            ensureControlLabels(config);
+            controlLabelsEnsured = true;
+          }
+
+          await dispatchBatch(config, batch);
+        }
+      },
+      { staleMs: config.singletonLockStaleMs }
+    );
+
+    if (!lockResult.acquired) {
       logJobEvent({
         job: JOB,
-        event: 'dry_run_planned',
-        plans: plans.map(plan => ({
-          issue: plan.issue.number,
-          branch: plan.branchName,
-          risk: plan.route.riskLevel,
-          model: plan.route.sessionModel,
-          integrationBranch: plan.integrationBranch,
-        })),
+        event: 'singleton_active_skip',
+        owner: lockResult.owner,
       });
       return;
     }
-
-    ensureControlLabels(config);
-
-    await withHeavyJobLock(JOB, async () => {
-      for (const plan of plans) {
-        try {
-          await dispatchPlan(config, plan);
-        } catch (err) {
-          logJobEvent({
-            job: JOB,
-            event: 'dispatch_failed',
-            issue: plan.issue.number,
-            error: shortError(err),
-          });
-          markBlocked(
-            config,
-            plan,
-            `Dispatcher failed before a clean agent handoff.\n\n\`\`\`text\n${shortError(err)}\n\`\`\``
-          );
-        }
-      }
-    });
   });
 }
 

--- a/scripts/hermes/launchd/co.jovie.hermes.cron-codex-issue-shipper.plist.template
+++ b/scripts/hermes/launchd/co.jovie.hermes.cron-codex-issue-shipper.plist.template
@@ -20,7 +20,15 @@
         <key>HERMES_HOME</key>
         <string>{{HOME}}/.hermes</string>
         <key>HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN</key>
-        <string>1</string>
+        <string>3</string>
+        <key>HERMES_CODEX_SHIPPER_MAX_PARALLEL_AGENTS</key>
+        <string>3</string>
+        <key>HERMES_CODEX_SHIPPER_MIN_FREE_MEMORY_MB</key>
+        <string>4096</string>
+        <key>HERMES_CODEX_SHIPPER_MAX_LOAD_PER_CPU</key>
+        <string>1.5</string>
+        <key>HERMES_CODEX_SHIPPER_SINGLETON_LOCK_STALE_MS</key>
+        <string>28800000</string>
         <key>HERMES_CODEX_SHIPPER_INTEGRATION_THRESHOLD</key>
         <string>4</string>
         <key>HERMES_CODEX_SHIPPER_AGENT</key>

--- a/scripts/hermes/lib/codex-issue-shipper.ts
+++ b/scripts/hermes/lib/codex-issue-shipper.ts
@@ -21,6 +21,10 @@ export interface ShipperConfig {
   readonly repo: string;
   readonly repoRoot: string;
   readonly maxIssuesPerRun: number;
+  readonly maxParallelAgents: number;
+  readonly minFreeMemoryMb: number;
+  readonly maxLoadPerCpu: number;
+  readonly singletonLockStaleMs: number;
   readonly issueFetchLimit: number;
   readonly integrationThreshold: number;
   readonly agent: 'claude' | 'codex';
@@ -99,6 +103,15 @@ function parsePositiveInt(value: string | undefined, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+function parsePositiveFloat(
+  value: string | undefined,
+  fallback: number
+): number {
+  if (!value) return fallback;
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 function parseBool(value: string | undefined): boolean {
   return value === '1' || value?.toLowerCase() === 'true';
 }
@@ -123,7 +136,23 @@ export function loadShipperConfig(
     repoRoot,
     maxIssuesPerRun: parsePositiveInt(
       env.HERMES_CODEX_SHIPPER_MAX_ISSUES_PER_RUN,
-      1
+      3
+    ),
+    maxParallelAgents: parsePositiveInt(
+      env.HERMES_CODEX_SHIPPER_MAX_PARALLEL_AGENTS,
+      3
+    ),
+    minFreeMemoryMb: parsePositiveInt(
+      env.HERMES_CODEX_SHIPPER_MIN_FREE_MEMORY_MB,
+      4096
+    ),
+    maxLoadPerCpu: parsePositiveFloat(
+      env.HERMES_CODEX_SHIPPER_MAX_LOAD_PER_CPU,
+      1.5
+    ),
+    singletonLockStaleMs: parsePositiveInt(
+      env.HERMES_CODEX_SHIPPER_SINGLETON_LOCK_STALE_MS,
+      8 * 60 * 60 * 1000
     ),
     issueFetchLimit: parsePositiveInt(
       env.HERMES_CODEX_SHIPPER_ISSUE_FETCH_LIMIT,

--- a/scripts/hermes/lib/heavy-job-lock.ts
+++ b/scripts/hermes/lib/heavy-job-lock.ts
@@ -21,6 +21,16 @@ import { HERMES_PATHS } from './hermes-paths';
 const LOCK = HERMES_PATHS.heavyJobLock;
 const STALE_MS = 5 * 60 * 1000;
 
+export interface HeavyJobLockOwner {
+  readonly caller?: string;
+  readonly pid?: number;
+  readonly ts?: number;
+}
+
+export type HeavyJobLockResult<T> =
+  | { readonly acquired: true; readonly value: T }
+  | { readonly acquired: false; readonly owner: HeavyJobLockOwner | null };
+
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -55,19 +65,22 @@ function tryClaim(caller: string): boolean {
   return true;
 }
 
+function readLockOwner(): HeavyJobLockOwner | null {
+  try {
+    return JSON.parse(readFileSync(LOCK, 'utf8')) as HeavyJobLockOwner;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * If the lock is genuinely stale (process gone or older than STALE_MS),
  * remove it so the next claim attempt can succeed. Returns true if we
  * removed it.
  */
-function reapIfStale(): boolean {
-  let data: { pid?: number; ts?: number };
-  try {
-    data = JSON.parse(readFileSync(LOCK, 'utf8')) as {
-      pid?: number;
-      ts?: number;
-    };
-  } catch {
+function reapIfStale(staleMs = STALE_MS): boolean {
+  const data = readLockOwner();
+  if (!data) {
     // Unreadable lock — assume corrupt, try to remove.
     try {
       unlinkSync(LOCK);
@@ -81,7 +94,7 @@ function reapIfStale(): boolean {
       ? Date.now() - data.ts
       : Number.POSITIVE_INFINITY;
   const dead = typeof data.pid === 'number' ? !isProcessAlive(data.pid) : true;
-  if (age > STALE_MS || dead) {
+  if (dead || age > staleMs) {
     try {
       unlinkSync(LOCK);
       return true;
@@ -92,10 +105,33 @@ function reapIfStale(): boolean {
   return false;
 }
 
+export async function tryWithHeavyJobLock<T>(
+  caller: string,
+  fn: () => Promise<T>,
+  options: { readonly staleMs?: number } = {}
+): Promise<HeavyJobLockResult<T>> {
+  if (
+    !tryClaim(caller) &&
+    (!reapIfStale(options.staleMs) || !tryClaim(caller))
+  ) {
+    return { acquired: false, owner: readLockOwner() };
+  }
+
+  try {
+    return { acquired: true, value: await fn() };
+  } finally {
+    try {
+      unlinkSync(LOCK);
+    } catch {
+      // best effort
+    }
+  }
+}
+
 export async function withHeavyJobLock<T>(
   caller: string,
   fn: () => Promise<T>,
-  options: { readonly timeoutMs?: number } = {}
+  options: { readonly timeoutMs?: number; readonly staleMs?: number } = {}
 ): Promise<T> {
   const timeoutMs = options.timeoutMs ?? 5 * 60 * 1000;
   const deadline = Date.now() + timeoutMs;
@@ -113,7 +149,7 @@ export async function withHeavyJobLock<T>(
       }
     }
     // Couldn't claim; check for stale and retry.
-    if (!reapIfStale()) {
+    if (!reapIfStale(options.staleMs)) {
       await new Promise(resolve => setTimeout(resolve, 2000));
     }
   }

--- a/scripts/lib/__tests__/codex-issue-shipper.test.mjs
+++ b/scripts/lib/__tests__/codex-issue-shipper.test.mjs
@@ -9,6 +9,7 @@ import {
   CODEX_TRUSTED_LABEL,
   eligibleCodexIssues,
   HUMAN_REVIEW_LABEL,
+  loadShipperConfig,
   selectTaskRoute,
   shellQuote,
 } from '../../hermes/lib/codex-issue-shipper.ts';
@@ -135,6 +136,16 @@ describe('codex issue shipper planner', () => {
     expect(plans).toHaveLength(2);
     expect(plans.map(plan => plan.issue.number)).toEqual([1, 2]);
   });
+
+  it('defaults to three parallel shipper lanes with resource guardrails', () => {
+    const loaded = loadShipperConfig({}, '/repo', 'JovieInc/Jovie');
+
+    expect(loaded.maxIssuesPerRun).toBe(3);
+    expect(loaded.maxParallelAgents).toBe(3);
+    expect(loaded.minFreeMemoryMb).toBe(4096);
+    expect(loaded.maxLoadPerCpu).toBe(1.5);
+    expect(loaded.singletonLockStaleMs).toBe(8 * 60 * 60 * 1000);
+  });
 });
 
 describe('codex issue shipper prompt', () => {
@@ -255,6 +266,10 @@ describe('codex issue shipper prompt', () => {
         repo: 'JovieInc/Jovie',
         repoRoot: '/repo',
         maxIssuesPerRun: 1,
+        maxParallelAgents: 3,
+        minFreeMemoryMb: 4096,
+        maxLoadPerCpu: 1.5,
+        singletonLockStaleMs: 1000,
         issueFetchLimit: 25,
         integrationThreshold: 3,
         agent: 'codex',


### PR DESCRIPTION
## Summary
- changes the Hermes Codex issue shipper from one sequential issue per run to a singleton drain loop with up to 3 safe parallel coder lanes
- adds load/free-memory capacity gating, non-blocking duplicate-cron skip behavior, per-issue isolated worktrees, and worktree cleanup
- updates the launchd template, Hermes Air docs, and local desktop automation prompt for the same singleton always-shipping policy

## Validation
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm exec biome check --write scripts/hermes/jobs/codex-issue-shipper.ts scripts/hermes/lib/codex-issue-shipper.ts scripts/hermes/lib/heavy-job-lock.ts scripts/lib/__tests__/codex-issue-shipper.test.mjs docs/HERMES_AIR.md`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm ci:harness:test` (5 files, 45 tests passed)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm typecheck` (8 packages successful)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH HERMES_CODEX_SHIPPER_DRY_RUN=1 pnpm exec tsx scripts/hermes/jobs/codex-issue-shipper.ts` (scan path completed; 0 dispatchable trusted issues; capacity gate refused launches under low free memory)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH coderabbit review --agent -c AGENTS.md -t uncommitted` (first pass found 2 valid minor issues; fixed both)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH coderabbit review --agent -c AGENTS.md -t uncommitted` (second pass: 0 findings)
- push pre-push hook: `biome check .`, `next:proxy-guard`, `tailwind:check`, `@jovie/web typecheck`, `@jovie/web lint` passed

## Rollout / Cost Impact
- Existing cron retained; no new scheduled job added.
- Default fan-out increases to at most 3 coder lanes per singleton owner, bounded by free memory and load.
- The active run logs `singleton_active_skip` for overlapping cron invocations instead of starting duplicate queue owners.
- Unit cost remains measurable as CI minutes x runner cost plus agent minutes x model cost; reduce `HERMES_CODEX_SHIPPER_MAX_PARALLEL_AGENTS` if `capacity_throttled` or CI congestion becomes frequent.

## Notes
- Local shell default is Node v20.20.2, so git hooks printed engine warnings. Validation above ran with Node v22.22.1 via `/opt/homebrew/opt/node@22/bin`.
- The `codex-automation` label is not present in this repository, so this PR is labeled `codex` only.