### PR TITLE
test(onboarding): add chat-first golden path handoff e2e coverage (JOV-2551)

### DIFF
--- a/apps/web/tests/e2e/chat-first-golden-path-handoff.spec.ts
+++ b/apps/web/tests/e2e/chat-first-golden-path-handoff.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from '@playwright/test';
+import { setTestAuthBypassSession } from '../helpers/clerk-auth';
+import { waitForHydration } from './utils/smoke-test-utils';
+
+const USE_TEST_AUTH_BYPASS = process.env.E2E_USE_TEST_AUTH_BYPASS === '1';
+const CHAT_PANEL = '[data-testid="onboarding-chat"]';
+const COMPOSER_TEXTAREA = '[aria-label="Chat message input"]';
+
+const IGNORABLE_CONSOLE_ERRORS = [
+  /favicon/i,
+  /ResizeObserver loop/i,
+  /eval\(\) is not supported.*React requires eval/i,
+] as const;
+
+function collectConsoleFailures(page: import('@playwright/test').Page) {
+  const failures: string[] = [];
+  page.on('console', msg => {
+    if (msg.type() === 'error') {
+      const location = msg.location().url;
+      failures.push(location ? `${msg.text()} (${location})` : msg.text());
+    }
+  });
+  page.on('pageerror', error => {
+    failures.push(error.message);
+  });
+  return failures;
+}
+
+function relevantConsoleFailures(failures: readonly string[]) {
+  return failures.filter(
+    failure => !IGNORABLE_CONSOLE_ERRORS.some(pattern => pattern.test(failure))
+  );
+}
+
+test.describe('Chat-first golden path handoff @golden-path', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('authenticated welcome-chat bootstrap returns onboarding route with zero console errors', async ({
+    page,
+  }) => {
+    test.skip(!USE_TEST_AUTH_BYPASS, 'Run with E2E_USE_TEST_AUTH_BYPASS=1');
+
+    const consoleFailures = collectConsoleFailures(page);
+    await setTestAuthBypassSession(
+      page,
+      'creator-ready',
+      'e2e-chat-first-golden-path'
+    );
+
+    const bootstrapResponse = await page.request.post(
+      '/api/onboarding/welcome-chat',
+      {
+        data: { initialReply: 'Ready to build my profile' },
+        timeout: 60_000,
+      }
+    );
+
+    expect([200, 201]).toContain(bootstrapResponse.status());
+    const payload = (await bootstrapResponse.json()) as {
+      route?: string;
+      conversationId?: string;
+      success?: boolean;
+    };
+
+    expect(payload.success).toBe(true);
+    expect(payload.conversationId).toBeTruthy();
+    expect(payload.route ?? '').toMatch(
+      /^\/app\/chat\/.+\?panel=profile&from=onboarding$/
+    );
+
+    await page.goto(payload.route ?? '/app/chat', {
+      waitUntil: 'domcontentloaded',
+    });
+    await waitForHydration(page);
+
+    await expect(page).toHaveURL(
+      /\/app\/chat\/.+\?panel=profile&from=onboarding/
+    );
+    await expect(page.locator('body')).not.toContainText(
+      /application error|internal server error|something went wrong/i
+    );
+    await expect(page.getByLabel('Chat message input')).toBeVisible();
+
+    expect(
+      relevantConsoleFailures(consoleFailures),
+      `Unexpected console failures: ${consoleFailures.join('\n')}`
+    ).toEqual([]);
+  });
+
+  test('/start exposes accessible onboarding chat landmarks without console errors', async ({
+    page,
+  }) => {
+    const consoleFailures = collectConsoleFailures(page);
+
+    await page.goto('/start', { waitUntil: 'domcontentloaded' });
+    await waitForHydration(page);
+
+    await expect(page.locator(CHAT_PANEL)).toBeVisible();
+    await expect(page.getByLabel('Jovie onboarding chat')).toBeVisible();
+    await expect(page.locator(COMPOSER_TEXTAREA)).toBeVisible();
+    await expect(page.locator(COMPOSER_TEXTAREA)).toHaveAttribute(
+      'aria-label',
+      'Chat message input'
+    );
+
+    expect(
+      relevantConsoleFailures(consoleFailures),
+      `Unexpected /start console failures: ${consoleFailures.join('\n')}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `chat-first-golden-path-handoff.spec.ts` covering authenticated welcome-chat bootstrap → `/app/chat?from=onboarding` with zero console errors
- Assert `/start` exposes accessible onboarding chat landmarks without runtime errors

## Linear
Closes JOV-2551

## Verification
- `pnpm --filter @jovie/web exec vitest run tests/unit/api/chat/onboarding-handler.test.ts tests/unit/api/onboarding/welcome-chat.test.ts tests/unit/api/onboarding/claim.test.ts`
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- E2E (auth bypass): `E2E_USE_TEST_AUTH_BYPASS=1 NEXT_PUBLIC_CLERK_MOCK=1 pnpm --filter @jovie/web exec playwright test tests/e2e/chat-first-golden-path-handoff.spec.ts --project=chromium`