### PR TITLE
fix(onboarding): import artist profile details on claim

### DIFF
--- a/apps/web/lib/onboarding/claim-profile.ts
+++ b/apps/web/lib/onboarding/claim-profile.ts
@@ -9,6 +9,11 @@ import {
   chatMessages,
 } from '@/lib/db/schema/chat';
 import { creatorProfiles, userProfileClaims } from '@/lib/db/schema/profiles';
+import {
+  fetchArtistBySpotifyUrl,
+  type MusicFetchArtistResult,
+} from '@/lib/dsp-enrichment/providers/musicfetch';
+import { captureError } from '@/lib/error-tracking';
 import { isHandleUniqueViolation } from '@/lib/errors/onboarding';
 import {
   type ClaimedOnboardingState,
@@ -20,6 +25,7 @@ import { normalizeUsername, validateUsername } from '@/lib/validation/username';
 type CreatorProfile = typeof creatorProfiles.$inferSelect;
 
 const HANDLE_CLAIM_MAX_ATTEMPTS = 5;
+const MAX_IMPORTED_BIO_LENGTH = 2_000;
 
 export interface MaterializeClaimedOnboardingProfileInput {
   readonly userId: string;
@@ -101,6 +107,83 @@ function buildOnboardingSettings(
 
 function hasMaterializableState(state: ClaimedOnboardingState): boolean {
   return Boolean(state.artist || state.handle);
+}
+
+function cleanImportedBio(bio: string | null | undefined): string | null {
+  const cleaned = bio?.trim().replaceAll(/\s+/g, ' ') ?? '';
+  if (!cleaned) return null;
+  return cleaned.slice(0, MAX_IMPORTED_BIO_LENGTH);
+}
+
+function cleanSpotifyAvatarUrl(
+  imageUrl: string | null | undefined
+): string | null {
+  const cleaned = imageUrl?.trim();
+  if (!cleaned) return null;
+
+  try {
+    const parsed = new URL(cleaned);
+    if (parsed.protocol !== 'https:') return null;
+    if (
+      parsed.hostname === 'i.scdn.co' ||
+      parsed.hostname.endsWith('.scdn.co')
+    ) {
+      return parsed.toString();
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+async function fetchMusicFetchProfile(
+  state: ClaimedOnboardingState
+): Promise<MusicFetchArtistResult | null> {
+  if (!state.artist?.url) return null;
+
+  try {
+    return await fetchArtistBySpotifyUrl(state.artist.url);
+  } catch (error) {
+    await captureError(
+      'MusicFetch profile import failed during chat claim',
+      error,
+      {
+        route: 'onboarding_claim_profile',
+        spotifyArtistId: state.artist.id,
+      }
+    );
+    return null;
+  }
+}
+
+async function buildImportedProfileFields({
+  existingProfile,
+  state,
+}: {
+  readonly existingProfile: CreatorProfile | null;
+  readonly state: ClaimedOnboardingState;
+}): Promise<Record<string, unknown>> {
+  if (!state.artist) return {};
+
+  const musicFetch = await fetchMusicFetchProfile(state);
+  const importedBio = cleanImportedBio(musicFetch?.bio);
+  const importedAvatarUrl =
+    cleanSpotifyAvatarUrl(state.artist.imageUrl) ??
+    cleanSpotifyAvatarUrl(musicFetch?.image?.url);
+
+  return {
+    avatarUrl:
+      existingProfile?.avatarLockedByUser && existingProfile.avatarUrl
+        ? existingProfile.avatarUrl
+        : (importedAvatarUrl ?? existingProfile?.avatarUrl ?? null),
+    ...(importedBio && !existingProfile?.bio ? { bio: importedBio } : {}),
+    spotifyId: state.artist.id,
+    spotifyUrl: state.artist.url,
+    spotifyFollowers: state.artist.followers,
+    spotifyPopularity: state.artist.popularity,
+    genres: [...state.artist.genres],
+  };
 }
 
 interface PersistClaimedProfileInput {
@@ -260,19 +343,10 @@ export async function materializeClaimedOnboardingProfile({
     conversationId,
     now
   );
-  const spotifyFields = state.artist
-    ? {
-        avatarUrl:
-          existingProfile?.avatarLockedByUser && existingProfile.avatarUrl
-            ? existingProfile.avatarUrl
-            : (state.artist.imageUrl ?? existingProfile?.avatarUrl ?? null),
-        spotifyId: state.artist.id,
-        spotifyUrl: state.artist.url,
-        spotifyFollowers: state.artist.followers,
-        spotifyPopularity: state.artist.popularity,
-        genres: [...state.artist.genres],
-      }
-    : {};
+  const spotifyFields = await buildImportedProfileFields({
+    existingProfile,
+    state,
+  });
 
   const { profileId, handle, status } =
     await persistClaimedProfileWithHandleRetry({

--- a/apps/web/tests/unit/lib/onboarding/claim-profile.test.ts
+++ b/apps/web/tests/unit/lib/onboarding/claim-profile.test.ts
@@ -4,12 +4,14 @@ const {
   mockDbSelect,
   mockDbUpdate,
   mockDbInsert,
+  mockFetchArtistBySpotifyUrl,
   mockReserveOnboardingHandle,
   mockDeriveClaimedOnboardingStateFromMessageRows,
 } = vi.hoisted(() => ({
   mockDbSelect: vi.fn(),
   mockDbUpdate: vi.fn(),
   mockDbInsert: vi.fn(),
+  mockFetchArtistBySpotifyUrl: vi.fn(),
   mockReserveOnboardingHandle: vi.fn(),
   mockDeriveClaimedOnboardingStateFromMessageRows: vi.fn(),
 }));
@@ -58,6 +60,7 @@ vi.mock('@/lib/db/schema/chat', () => ({
 
 vi.mock('@/lib/db/schema/profiles', () => ({
   creatorProfiles: {
+    bio: 'creator_profiles.bio',
     id: 'creator_profiles.id',
     userId: 'creator_profiles.user_id',
     username: 'creator_profiles.username',
@@ -73,6 +76,11 @@ vi.mock('@/lib/db/schema/profiles', () => ({
     avatarLockedByUser: 'creator_profiles.avatar_locked_by_user',
     avatarUrl: 'creator_profiles.avatar_url',
     creatorType: 'creator_profiles.creator_type',
+    genres: 'creator_profiles.genres',
+    spotifyFollowers: 'creator_profiles.spotify_followers',
+    spotifyId: 'creator_profiles.spotify_id',
+    spotifyPopularity: 'creator_profiles.spotify_popularity',
+    spotifyUrl: 'creator_profiles.spotify_url',
     theme: 'creator_profiles.theme',
     ingestionStatus: 'creator_profiles.ingestion_status',
   },
@@ -87,6 +95,14 @@ vi.mock('drizzle-orm', () => ({
   and: vi.fn((...args: unknown[]) => ({ and: args })),
   desc: vi.fn((col: unknown) => ({ desc: col })),
   eq: vi.fn((col: unknown, val: unknown) => ({ eq: [col, val] })),
+}));
+
+vi.mock('@/lib/dsp-enrichment/providers/musicfetch', () => ({
+  fetchArtistBySpotifyUrl: mockFetchArtistBySpotifyUrl,
+}));
+
+vi.mock('@/lib/error-tracking', () => ({
+  captureError: vi.fn(),
 }));
 
 vi.mock('@/lib/onboarding/claimed-state', () => ({
@@ -124,8 +140,9 @@ function queueProfileInsert(
     | { id: string }
     | { error: Error }
     | Array<{ id: string } | { error: Error }>
-) {
+): ReturnType<typeof vi.fn>[] {
   const outcomes = Array.isArray(outcome) ? outcome : [outcome];
+  const valueSpies: ReturnType<typeof vi.fn>[] = [];
 
   for (const current of outcomes) {
     const returning =
@@ -133,8 +150,11 @@ function queueProfileInsert(
         ? vi.fn().mockRejectedValue(current.error)
         : vi.fn().mockResolvedValue([current]);
     const values = vi.fn().mockReturnValue({ returning });
+    valueSpies.push(values);
     mockDbInsert.mockReturnValueOnce({ values });
   }
+
+  return valueSpies;
 }
 
 function queueProfileUpdate(
@@ -142,8 +162,9 @@ function queueProfileUpdate(
     | { id: string }
     | { error: Error }
     | Array<{ id: string } | { error: Error }>
-) {
+): ReturnType<typeof vi.fn>[] {
   const outcomes = Array.isArray(outcome) ? outcome : [outcome];
+  const valueSpies: ReturnType<typeof vi.fn>[] = [];
 
   for (const current of outcomes) {
     const returning =
@@ -152,8 +173,11 @@ function queueProfileUpdate(
         : vi.fn().mockResolvedValue([current]);
     const where = vi.fn().mockReturnValue({ returning });
     const set = vi.fn().mockReturnValue({ where });
+    valueSpies.push(set);
     mockDbUpdate.mockReturnValueOnce({ set });
   }
+
+  return valueSpies;
 }
 
 function queuePostPersistWrites() {
@@ -182,6 +206,7 @@ describe('materializeClaimedOnboardingProfile', () => {
       interviewSignals: [],
     });
     mockReserveOnboardingHandle.mockResolvedValue('coolartist1');
+    mockFetchArtistBySpotifyUrl.mockResolvedValue(null);
   });
 
   it('skips when chat state has no materializable profile data', async () => {
@@ -230,6 +255,66 @@ describe('materializeClaimedOnboardingProfile', () => {
     });
 
     expect(mockReserveOnboardingHandle).not.toHaveBeenCalled();
+  });
+
+  it('imports Spotify image and MusicFetch bio while creating the live profile', async () => {
+    mockDeriveClaimedOnboardingStateFromMessageRows.mockReturnValue({
+      artist: {
+        id: 'spotify_1',
+        name: 'Luna Waves',
+        url: 'https://open.spotify.com/artist/spotify_1',
+        imageUrl: 'https://i.scdn.co/image/luna.jpg',
+        followers: 42_000,
+        popularity: 61,
+        genres: ['indie pop', 'dream pop'],
+      },
+      handle: 'lunawaves',
+      socialLinks: [],
+      interviewSignals: [],
+    });
+    mockFetchArtistBySpotifyUrl.mockResolvedValue({
+      type: 'artist',
+      name: 'Luna Waves',
+      image: { url: 'https://i.scdn.co/image/luna-musicfetch.jpg' },
+      bio: '  Luna Waves makes late-night pop from Los Angeles.  ',
+      services: {},
+    });
+
+    setupMessageSelect();
+    setupExistingProfileSelect(null);
+    const [profileInsertValues] = queueProfileInsert({ id: 'profile_new' });
+    queuePostPersistWrites();
+
+    await expect(
+      materializeClaimedOnboardingProfile({
+        userId: 'user_1',
+        conversationId: 'conv_1',
+        ipAddress: null,
+        userAgent: null,
+      })
+    ).resolves.toEqual({
+      profileId: 'profile_new',
+      handle: 'lunawaves',
+      status: 'created',
+    });
+
+    expect(mockFetchArtistBySpotifyUrl).toHaveBeenCalledWith(
+      'https://open.spotify.com/artist/spotify_1'
+    );
+    expect(profileInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        avatarUrl: 'https://i.scdn.co/image/luna.jpg',
+        bio: 'Luna Waves makes late-night pop from Los Angeles.',
+        displayName: 'Luna Waves',
+        genres: ['indie pop', 'dream pop'],
+        isClaimed: true,
+        isPublic: true,
+        spotifyFollowers: 42_000,
+        spotifyId: 'spotify_1',
+        spotifyPopularity: 61,
+        spotifyUrl: 'https://open.spotify.com/artist/spotify_1',
+      })
+    );
   });
 
   it('retries with a reserved handle when INSERT hits a username unique violation', async () => {


### PR DESCRIPTION
## Summary

Fixes JOV-3177.

- Import MusicFetch artist bio during chat onboarding claim materialization.
- Persist safe Spotify-backed avatar, Spotify URL/ID, followers, popularity, and genres when the claimed profile is created or updated.
- Keep optional MusicFetch enrichment fail-open with error capture so profile publishing is not blocked by the provider.
- Preserve user-locked avatars and existing bios.

## Verification

- JOVIE_AGENT_PROFILE=coder ./scripts/setup.sh
- JOVIE_AGENT_PROFILE=coder pnpm biome check apps/web/lib/onboarding/claim-profile.ts apps/web/tests/unit/lib/onboarding/claim-profile.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/lib/onboarding/claim-profile.test.ts lib/onboarding/claimed-state.test.ts lib/chat/tools/onboarding-tool-impls.test.ts
- JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false
- Local browser QA on http://localhost:3217/start: desktop 1280px and mobile 390px, Spotify entry text present, no horizontal overflow, no browser console errors.
- Local browser QA on http://localhost:3217/arkells: public URL resolved, Spotify image loaded through Next image optimizer, Spotify text present, no horizontal overflow, no browser console errors.
- Local browser QA on http://localhost:3217/e2e-admin-one: bio and profile name rendered; dev tracking schema regression logged separately as JOV-3178.
- Pre-push hook passed: biome check ., next:proxy-guard, tailwind:check, typecheck, biome lint .

## Notes

- The public profile visit tracking 500 observed in local dev is unrelated to this claim path and is captured in JOV-3178.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile onboarding now imports artist bios and avatars from external sources during Spotify profile claiming.

* **Improvements**
  * Enhanced validation and sanitization of imported artist profile data for better security and data quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->