### PR TITLE
feat(merch): ship same-design product variants

### DIFF
--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -79,6 +79,7 @@ import {
 } from '@/lib/chat/tool-events';
 import { proposeMerchAction } from '@/lib/chat/tools/merch-propose';
 import {
+  createMerchAlternativeTool,
   createMerchGenerateTool,
   createMerchPreviewTool,
   createMerchSelectTool,
@@ -2043,6 +2044,12 @@ function buildChatTools(
           selectMerchDesign: createMerchSelectTool({
             profileId: resolvedProfileId,
             clerkUserId,
+          }),
+          createMerchAlternativeItem: createMerchAlternativeTool({
+            profileId: resolvedProfileId,
+            clerkUserId,
+            conversationId: reservedTurn?.conversationId ?? null,
+            turnId: reservedTurn?.turnId ?? null,
           }),
           updateMerchCard: createMerchUpdateTool({
             profileId: resolvedProfileId,

--- a/apps/web/components/features/profile/ProfileMerchCard.tsx
+++ b/apps/web/components/features/profile/ProfileMerchCard.tsx
@@ -47,7 +47,7 @@ export function ProfileMerchCard({
         </div>
         <div className='flex min-w-0 flex-1 flex-col justify-between py-0.5'>
           <div className='min-w-0'>
-            <div className='mb-1 flex items-center gap-1.5 text-[10px] font-semibold uppercase leading-none text-white/58 [letter-spacing:0]'>
+            <div className='mb-1 flex items-center gap-1.5 text-[10px] font-semibold leading-none text-white/58 [letter-spacing:0]'>
               <ShoppingBag className='h-3 w-3 shrink-0' />
               <span>Merch</span>
             </div>

--- a/apps/web/components/jovie/components/ChatMerchCard.test.tsx
+++ b/apps/web/components/jovie/components/ChatMerchCard.test.tsx
@@ -188,4 +188,35 @@ describe('ChatMerchCard', () => {
       '/app/library?view=merch'
     );
   });
+
+  it('submits same-design alternative item prompts from the saved card', () => {
+    const dispatch = vi.spyOn(globalThis, 'dispatchEvent');
+
+    render(
+      <ChatMerchSelectionCard
+        result={{
+          success: true,
+          merchCardId: '00000000-0000-4000-8000-000000000201',
+          status: 'draft',
+          selectedOptionId: '00000000-0000-4000-8000-000000000101',
+          title: 'Signal Tee',
+          publicUrl: null,
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hoodie' }));
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'jovie-chat-submit-prompt',
+        detail: {
+          prompt:
+            'Create a hoodie version of merch card 00000000-0000-4000-8000-000000000201 with the same design.',
+        },
+      })
+    );
+
+    dispatch.mockRestore();
+  });
 });

--- a/apps/web/components/jovie/components/ChatMerchCard.tsx
+++ b/apps/web/components/jovie/components/ChatMerchCard.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2,
   ExternalLink,
   Loader2,
+  Shirt,
 } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -125,6 +126,10 @@ function optionPrompt(
   return `${action} merch option ${option.option_number} from generation ${generationId}.`;
 }
 
+function alternativeItemPrompt(merchCardId: string, itemType: string): string {
+  return `Create a ${itemType} version of merch card ${merchCardId} with the same design.`;
+}
+
 function MerchOptionPricing({
   recommendation,
 }: {
@@ -204,6 +209,8 @@ export function ChatMerchOptionsCard({
         {result.options.map(option => {
           const mockupUrls = option.mockup_urls ?? [];
           const imageUrl = selectPreferredMockupUrl(mockupUrls);
+          const productLabel =
+            option.printful_product_name ?? option.product_type;
           const mockupPending =
             hasRenderableMockup(mockupUrls) &&
             mockupUrls.every(url => isInternalMerchMockupUrl(url)) &&
@@ -258,7 +265,7 @@ export function ChatMerchOptionsCard({
                     {option.design_name}
                   </h3>
                   <p className='mt-0.5 truncate text-[11px] text-tertiary-token'>
-                    {option.product_type}
+                    {productLabel}
                     {option.colorway ? ` - ${option.colorway}` : ''}
                   </p>
                 </div>
@@ -313,6 +320,12 @@ export function ChatMerchSelectionCard({
   const statusLabel =
     result.status.slice(0, 1).toUpperCase() + result.status.slice(1);
   const blockedReasons = result.publishBlockedReasons ?? [];
+  const handleAlternativeItem = useCallback(
+    (itemType: string) => {
+      submitMerchPrompt(alternativeItemPrompt(result.merchCardId, itemType));
+    },
+    [result.merchCardId]
+  );
 
   return (
     <ChatGenerationArtifactSurface
@@ -364,6 +377,26 @@ export function ChatMerchSelectionCard({
                 <ExternalLink className='h-3 w-3' />
               </a>
             ) : null}
+            <Button
+              type='button'
+              size='sm'
+              variant='secondary'
+              className='h-8 gap-1.5'
+              onClick={() => handleAlternativeItem('hoodie')}
+            >
+              <Shirt className='h-3 w-3' />
+              Hoodie
+            </Button>
+            <Button
+              type='button'
+              size='sm'
+              variant='secondary'
+              className='h-8 gap-1.5'
+              onClick={() => handleAlternativeItem('hat')}
+            >
+              <Shirt className='h-3 w-3' />
+              Hat
+            </Button>
           </div>
         </div>
       </div>

--- a/apps/web/components/jovie/tool-ui.tsx
+++ b/apps/web/components/jovie/tool-ui.tsx
@@ -515,6 +515,8 @@ const ARTIFACT_RENDERERS: Partial<Record<string, ArtifactRenderer>> = {
   previewMerchOptions: event => renderMerchGenerationArtifact(event),
   selectMerchDesign: (event, profileId) =>
     renderMerchSelectionArtifact(event, profileId),
+  createMerchAlternativeItem: (event, profileId) =>
+    renderMerchSelectionArtifact(event, profileId),
   publishMerchCard: (event, profileId) =>
     renderMerchActionArtifact(event, profileId),
   unpauseMerchCard: (event, profileId) =>

--- a/apps/web/lib/chat/system-prompt.ts
+++ b/apps/web/lib/chat/system-prompt.ts
@@ -183,6 +183,7 @@ Use the voicePromo tool when the artist says "clone my voice", "voice promo", "r
 
 ## Merch Creation
 Use merch tools immediately when the artist asks to make, preview, publish, pause, kill, bring back, rank, optimize, or inspect merch. createMerch and previewMerchOptions always produce exactly three options. After showing options, ask the artist to pick 1, 2, or 3, or describe a change.
+Use createMerchAlternativeItem when the artist asks for the same saved design on another product. Do not regenerate the design unless they ask for a different concept.
 
 Merch confirmation fence:
 - publishMerchCard, unpauseMerchCard, and deleteOrArchiveMerchCard propose changes only. They return a confirmation card and never write live/archived status without the artist confirming.

--- a/apps/web/lib/chat/tool-schemas.ts
+++ b/apps/web/lib/chat/tool-schemas.ts
@@ -90,6 +90,21 @@ export const TOOL_SCHEMAS = {
     }),
   },
 
+  createMerchAlternativeItem: {
+    description:
+      'Create a new merch card that keeps an existing card design but moves it onto a different Printful product. Use when the artist asks for the same design on another item, like a hoodie, hat, tank, or a specific Printful catalog product ID.',
+    inputSchema: chatToolSchema({
+      merchCardId: z.string().uuid(),
+      itemType: z
+        .string()
+        .min(2)
+        .max(120)
+        .describe(
+          'Target product type or Printful catalog product ID, for example "hoodie", "hat", or "catalog product 71".'
+        ),
+    }),
+  },
+
   publishMerchCard: {
     description:
       'Propose publishing an existing merch card to the public artist profile. Returns a confirmation card; does not publish until the artist confirms.',

--- a/apps/web/lib/chat/tool-ui-registry.ts
+++ b/apps/web/lib/chat/tool-ui-registry.ts
@@ -131,6 +131,14 @@ export const TOOL_UI_REGISTRY = {
     successTitle: 'Merch pick saved',
     errorTitle: "Couldn't save that merch pick",
   },
+  createMerchAlternativeItem: {
+    label: 'Merch item',
+    uiHint: 'artifact',
+    renderer: 'artifact',
+    loadingTitle: 'Creating alternate item…',
+    successTitle: 'Alternate item saved',
+    errorTitle: "Couldn't create that item",
+  },
   publishMerchCard: {
     label: 'Merch publish',
     uiHint: 'artifact',

--- a/apps/web/lib/chat/tools/merch-tools.test.ts
+++ b/apps/web/lib/chat/tools/merch-tools.test.ts
@@ -64,6 +64,17 @@ describe('merch tool schemas', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('createMerchAlternativeItem requires a merch card and target item', () => {
+    const schema = TOOL_SCHEMAS.createMerchAlternativeItem.inputSchema;
+    expect(schema.safeParse({}).success).toBe(false);
+
+    const valid = schema.safeParse({
+      merchCardId: '00000000-0000-0000-0000-000000000000',
+      itemType: 'catalog product 71',
+    });
+    expect(valid.success).toBe(true);
+  });
 });
 
 describe('TOOL_SCHEMAS descriptions', () => {
@@ -84,5 +95,11 @@ describe('TOOL_SCHEMAS descriptions', () => {
       10
     );
     expect(TOOL_SCHEMAS.selectMerchDesign.description).toContain('option');
+  });
+
+  it('createMerchAlternativeItem describes same-design product changes', () => {
+    expect(TOOL_SCHEMAS.createMerchAlternativeItem.description).toContain(
+      'same design'
+    );
   });
 });

--- a/apps/web/lib/chat/tools/merch-tools.ts
+++ b/apps/web/lib/chat/tools/merch-tools.ts
@@ -22,6 +22,7 @@ import { tool } from 'ai';
 import { TOOL_SCHEMAS } from '@/lib/chat/tool-schemas';
 import { proposeMerchAction } from '@/lib/chat/tools/merch-propose';
 import {
+  createAlternativeMerchFromCard,
   generateMerchFromConcept,
   previewMerchFromConcept,
   selectAndCreateMerchCard,
@@ -137,6 +138,32 @@ export function createMerchSelectTool(params: {
       }
 
       return result;
+    },
+  });
+}
+
+export function createMerchAlternativeTool(params: {
+  readonly profileId: string | null;
+  readonly clerkUserId: string;
+  readonly conversationId?: string | null;
+  readonly turnId?: string | null;
+}) {
+  return tool({
+    description: TOOL_SCHEMAS.createMerchAlternativeItem.description,
+    inputSchema: TOOL_SCHEMAS.createMerchAlternativeItem.inputSchema,
+    execute: async ({ merchCardId, itemType }) => {
+      if (!params.profileId) {
+        return { success: false as const, error: 'Profile ID required' };
+      }
+
+      return createAlternativeMerchFromCard({
+        merchCardId,
+        profileId: params.profileId,
+        clerkUserId: params.clerkUserId,
+        itemType,
+        conversationId: params.conversationId ?? null,
+        turnId: params.turnId ?? null,
+      });
     },
   });
 }

--- a/apps/web/lib/commands/registry.ts
+++ b/apps/web/lib/commands/registry.ts
@@ -31,6 +31,8 @@ export const HIDDEN_TOOLS: Readonly<Record<string, string>> = {
     'Onboarding-only continuation from the Spotify picker; requires a selected candidate.',
   createMerch:
     'Conversational merch creation is gated by plan and rollout flags before broader slash exposure.',
+  createMerchAlternativeItem:
+    'Follow-up from a saved merch card; shown as card/menu actions once a source design exists.',
   createPromoStrategy: 'Pro-only; surfaced via the release detail surface.',
   createRelease: 'Surfaced in the releases dashboard; chat tool is a fallback.',
   deleteOrArchiveMerchCard:

--- a/apps/web/lib/merch/artwork.test.ts
+++ b/apps/web/lib/merch/artwork.test.ts
@@ -2,67 +2,40 @@ import sharp from 'sharp';
 import { describe, expect, it } from 'vitest';
 import { renderMockup } from './artwork';
 
-async function buildTransparentPrintFile(): Promise<Buffer> {
-  return sharp({
-    create: {
-      width: 4500,
-      height: 5400,
-      channels: 4,
-      background: { r: 0, g: 0, b: 0, alpha: 0 },
-    },
-  })
-    .png()
-    .toBuffer();
-}
-
-async function buildDesignedPrintFile(): Promise<Buffer> {
-  const chestArt = await sharp({
-    create: {
-      width: 3600,
-      height: 4300,
-      channels: 4,
-      background: { r: 243, g: 243, b: 240, alpha: 255 },
-    },
-  })
-    .png()
-    .toBuffer();
-
-  return sharp({
-    create: {
-      width: 4500,
-      height: 5400,
-      channels: 4,
-      background: { r: 0, g: 0, b: 0, alpha: 0 },
-    },
-  })
-    .composite([{ input: chestArt, left: 450, top: 420, blend: 'over' }])
+async function buildPrintFile(): Promise<Buffer> {
+  return sharp(
+    Buffer.from(`<svg width="4500" height="5400" viewBox="0 0 4500 5400" xmlns="http://www.w3.org/2000/svg">
+      <rect width="4500" height="5400" fill="none"/>
+      <rect x="720" y="920" width="3060" height="3560" rx="80" fill="none" stroke="#f3f3f0" stroke-width="48"/>
+      <text x="2250" y="1700" text-anchor="middle" font-family="Arial, sans-serif" font-size="320" font-weight="900" fill="#f3f3f0">LUNA</text>
+      <text x="2250" y="2280" text-anchor="middle" font-family="Arial, sans-serif" font-size="560" font-weight="900" fill="#f3f3f0">WAVES</text>
+      <text x="2250" y="2920" text-anchor="middle" font-family="Arial, sans-serif" font-size="190" font-weight="800" fill="#f3f3f0">SIGNAL OBJECT</text>
+    </svg>`)
+  )
     .png()
     .toBuffer();
 }
 
 describe('renderMockup', () => {
-  it('composites the chest print onto the blank garment instead of leaving it empty', async () => {
-    const blankGarmentOnly = await renderMockup(
-      await buildTransparentPrintFile()
-    );
-    const composited = await renderMockup(await buildDesignedPrintFile());
+  it('renders distinct product-aware fallback mockups', async () => {
+    const printFile = await buildPrintFile();
 
-    const blankChest = await sharp(blankGarmentOnly)
-      .extract({ left: 620, top: 860, width: 560, height: 620 })
-      .raw()
-      .toBuffer();
-    const designedChest = await sharp(composited)
-      .extract({ left: 620, top: 860, width: 560, height: 620 })
-      .raw()
-      .toBuffer();
+    const [tee, hoodie, hat] = await Promise.all([
+      renderMockup(printFile, 'premium tee'),
+      renderMockup(printFile, 'premium hoodie'),
+      renderMockup(printFile, 'structured dad hat'),
+    ]);
 
-    let differentPixels = 0;
-    for (let index = 0; index < blankChest.length; index += 1) {
-      if (blankChest[index] !== designedChest[index]) {
-        differentPixels += 1;
-      }
+    for (const mockup of [tee, hoodie, hat]) {
+      const metadata = await sharp(mockup).metadata();
+      expect(metadata.format).toBe('jpeg');
+      expect(metadata.width).toBe(1800);
+      expect(metadata.height).toBe(2200);
+      expect(mockup.length).toBeGreaterThan(10_000);
     }
 
-    expect(differentPixels).toBeGreaterThan(1_000);
+    expect(tee.equals(hoodie)).toBe(false);
+    expect(tee.equals(hat)).toBe(false);
+    expect(hoodie.equals(hat)).toBe(false);
   });
 });

--- a/apps/web/lib/merch/artwork.ts
+++ b/apps/web/lib/merch/artwork.ts
@@ -30,6 +30,20 @@ const SHIRT_CHEST = {
   height: 980,
 } as const;
 
+const HOODIE_CHEST = {
+  left: 500,
+  top: 710,
+  width: 800,
+  height: 900,
+} as const;
+
+const HAT_FRONT = {
+  left: 680,
+  top: 720,
+  width: 440,
+  height: 300,
+} as const;
+
 let embeddedInterFontFace: string | null = null;
 
 function escapeXml(value: string): string {
@@ -192,20 +206,67 @@ function buildPrintSvg(params: {
   return Buffer.from(svg);
 }
 
-function buildBlankGarmentSvg(): Buffer {
+function productFamily(
+  productType: string | null | undefined
+): 'tee' | 'hoodie' | 'hat' {
+  const normalized = productType?.toLowerCase() ?? '';
+  if (normalized.includes('hoodie') || normalized.includes('sweatshirt')) {
+    return 'hoodie';
+  }
+  if (
+    normalized.includes('hat') ||
+    normalized.includes('cap') ||
+    normalized.includes('beanie')
+  ) {
+    return 'hat';
+  }
+  return 'tee';
+}
+
+function printRegionForProduct(productType: string | null | undefined) {
+  switch (productFamily(productType)) {
+    case 'hoodie':
+      return HOODIE_CHEST;
+    case 'hat':
+      return HAT_FRONT;
+    case 'tee':
+      return SHIRT_CHEST;
+  }
+}
+
+function garmentSvgForProduct(productType: string | null | undefined): string {
+  switch (productFamily(productType)) {
+    case 'hoodie':
+      return '<path d="M560 260 L720 420 H1080 L1240 260 L1560 420 L1390 760 L1260 690 V1880 H540 V690 L410 760 L240 420 Z" fill="#111" stroke="#050505" stroke-width="8"/><path d="M720 420 C780 560 1020 560 1080 420" fill="none" stroke="#242424" stroke-width="16"/><path d="M742 422 C710 580 640 690 570 790" fill="none" stroke="#2f2f2f" stroke-width="12"/><path d="M1058 422 C1090 580 1160 690 1230 790" fill="none" stroke="#2f2f2f" stroke-width="12"/>';
+    case 'hat':
+      return '<path d="M420 770 C480 480 1320 480 1380 770 L1380 920 H420 Z" fill="#111" stroke="#050505" stroke-width="8"/><path d="M660 775 C760 915 1040 915 1140 775" fill="none" stroke="#242424" stroke-width="16"/><path d="M610 930 C820 1030 1210 1010 1510 910 C1390 1120 650 1130 300 950 Z" fill="#0b0b0c" stroke="#050505" stroke-width="8"/>';
+    case 'tee':
+      return '<path d="M560 260 L720 420 H1080 L1240 260 L1560 420 L1390 760 L1260 690 V1880 H540 V690 L410 760 L240 420 Z" fill="#111" stroke="#050505" stroke-width="8"/><path d="M720 420 C780 560 1020 560 1080 420" fill="none" stroke="#242424" stroke-width="16"/>';
+  }
+}
+
+function buildBlankGarmentSvg(productType: string | null | undefined): Buffer {
+  const garment = garmentSvgForProduct(productType);
+
   return Buffer.from(`<svg width="${MOCKUP_WIDTH}" height="${MOCKUP_HEIGHT}" viewBox="0 0 ${MOCKUP_WIDTH} ${MOCKUP_HEIGHT}" xmlns="http://www.w3.org/2000/svg">
     <rect width="${MOCKUP_WIDTH}" height="${MOCKUP_HEIGHT}" fill="#f4f2ed"/>
-    <path d="M560 260 L720 420 H1080 L1240 260 L1560 420 L1390 760 L1260 690 V1880 H540 V690 L410 760 L240 420 Z" fill="#111" stroke="#050505" stroke-width="8"/>
-    <path d="M720 420 C780 560 1020 560 1080 420" fill="none" stroke="#242424" stroke-width="16"/>
+    <rect x="120" y="120" width="1560" height="1960" rx="48" fill="#fbfaf7" stroke="#dedbd1" stroke-width="4"/>
+    ${garment}
   </svg>`);
 }
 
-export async function renderMockup(printFile: Buffer): Promise<Buffer> {
-  const garmentBuffer = await sharp(buildBlankGarmentSvg()).png().toBuffer();
+export async function renderMockup(
+  printFile: Buffer,
+  productType?: string | null
+): Promise<Buffer> {
+  const productPrintRegion = printRegionForProduct(productType);
+  const garmentBuffer = await sharp(buildBlankGarmentSvg(productType))
+    .png()
+    .toBuffer();
 
   const croppedPrint = await sharp(printFile)
     .extract(PRINT_CHEST_REGION)
-    .resize(SHIRT_CHEST.width, SHIRT_CHEST.height, {
+    .resize(productPrintRegion.width, productPrintRegion.height, {
       fit: 'inside',
       withoutEnlargement: false,
     })
@@ -213,12 +274,14 @@ export async function renderMockup(printFile: Buffer): Promise<Buffer> {
     .toBuffer();
 
   const printMeta = await sharp(croppedPrint).metadata();
-  const printWidth = printMeta.width ?? SHIRT_CHEST.width;
-  const printHeight = printMeta.height ?? SHIRT_CHEST.height;
+  const printWidth = printMeta.width ?? productPrintRegion.width;
+  const printHeight = printMeta.height ?? productPrintRegion.height;
   const left =
-    SHIRT_CHEST.left + Math.round((SHIRT_CHEST.width - printWidth) / 2);
+    productPrintRegion.left +
+    Math.round((productPrintRegion.width - printWidth) / 2);
   const top =
-    SHIRT_CHEST.top + Math.round((SHIRT_CHEST.height - printHeight) / 2);
+    productPrintRegion.top +
+    Math.round((productPrintRegion.height - printHeight) / 2);
 
   return sharp(garmentBuffer)
     .composite([{ input: croppedPrint, top, left, blend: 'over' }])
@@ -234,9 +297,10 @@ export async function createMerchArtwork(params: {
   readonly designName: string;
   readonly lane: MerchDesignLane;
   readonly concept: string;
+  readonly productType?: string | null;
 }): Promise<{ readonly printFileUrl: string; readonly mockupUrl: string }> {
   const printFile = await sharp(buildPrintSvg(params)).png().toBuffer();
-  const mockup = await renderMockup(printFile);
+  const mockup = await renderMockup(printFile, params.productType);
   const basePath = `merch/generated/${params.profileId}/${params.generationId}/${params.optionId}`;
   const [printFileUrl, mockupUrl] = await Promise.all([
     uploadPublicBuffer({

--- a/apps/web/lib/merch/catalog.test.ts
+++ b/apps/web/lib/merch/catalog.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const printful = vi.hoisted(() => ({
   getCatalogProductAvailability: vi.fn(),
+  getCatalogProduct: vi.fn(),
   getCatalogVariantPrices: vi.fn(),
   isPrintfulConfigured: vi.fn(),
   listCatalogProducts: vi.fn(),
@@ -15,6 +16,7 @@ import { resolveMerchCatalogSelection } from './catalog';
 describe('resolveMerchCatalogSelection', () => {
   beforeEach(() => {
     printful.getCatalogProductAvailability.mockReset();
+    printful.getCatalogProduct.mockReset();
     printful.getCatalogVariantPrices.mockReset();
     printful.isPrintfulConfigured.mockReset();
     printful.listCatalogProducts.mockReset();
@@ -117,8 +119,94 @@ describe('resolveMerchCatalogSelection', () => {
     expect(printful.listCatalogProducts).toHaveBeenCalledWith({
       sellingRegionName: 'north_america',
       placements: ['front'],
-      limit: 50,
+      limit: 100,
+      offset: 0,
     });
+  });
+
+  it('searches additional catalog pages before falling back to defaults', async () => {
+    printful.isPrintfulConfigured.mockReturnValue(true);
+    printful.listCatalogProducts
+      .mockResolvedValueOnce(
+        Array.from({ length: 100 }, (_, index) => ({
+          id: 1000 + index,
+          name: `Catalog Product ${index}`,
+          type: 'poster',
+          is_discontinued: false,
+        }))
+      )
+      .mockResolvedValueOnce([
+        {
+          id: 222,
+          name: 'Structured Dad Hat',
+          type: 'hat',
+          model: 'cap',
+          is_discontinued: false,
+        },
+      ]);
+    printful.listCatalogVariants.mockResolvedValue([
+      {
+        id: 2201,
+        catalog_product_id: 222,
+        name: 'Black',
+        size: 'One Size',
+        color: 'Black',
+      },
+    ]);
+    printful.getCatalogVariantPrices.mockResolvedValue({
+      currency: 'USD',
+      product: {
+        id: 222,
+        placements: [{ id: 'front', price: '13.00' }],
+      },
+      variant: {
+        id: 2201,
+        techniques: [{ technique_key: 'dtg', price: '1.25' }],
+      },
+    });
+    printful.getCatalogProductAvailability.mockResolvedValue([]);
+
+    const selection = await resolveMerchCatalogSelection('make a hat');
+
+    expect(selection.catalogProductId).toBe(222);
+    expect(printful.listCatalogProducts).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses explicit Printful catalog product IDs when provided', async () => {
+    printful.isPrintfulConfigured.mockReturnValue(true);
+    printful.getCatalogProduct.mockResolvedValue({
+      id: 333,
+      name: 'Heavyweight Tank',
+      type: 'tank',
+      is_discontinued: false,
+    });
+    printful.listCatalogVariants.mockResolvedValue([
+      {
+        id: 3301,
+        catalog_product_id: 333,
+        name: 'M / Black',
+        size: 'M',
+        color: 'Black',
+      },
+    ]);
+    printful.getCatalogVariantPrices.mockResolvedValue({
+      currency: 'USD',
+      product: {
+        id: 333,
+        placements: [{ id: 'front', price: '15.00' }],
+      },
+      variant: {
+        id: 3301,
+        techniques: [{ technique_key: 'dtg', price: '1.25' }],
+      },
+    });
+    printful.getCatalogProductAvailability.mockResolvedValue([]);
+
+    const selection = await resolveMerchCatalogSelection('catalog product 333');
+
+    expect(selection.catalogProductId).toBe(333);
+    expect(printful.getCatalogProduct).toHaveBeenCalledWith(333);
+    expect(printful.listCatalogProducts).not.toHaveBeenCalled();
   });
 
   it('falls back to draft-only defaults when provider data is unsafe', async () => {

--- a/apps/web/lib/merch/catalog.ts
+++ b/apps/web/lib/merch/catalog.ts
@@ -5,6 +5,7 @@ import type {
   MerchVariantMap,
 } from '@/lib/db/schema/merch';
 import {
+  getCatalogProduct,
   getCatalogProductAvailability,
   getCatalogVariantPrices,
   isPrintfulConfigured,
@@ -24,6 +25,9 @@ import {
   MERCH_DEFAULT_MARGIN_PRESET,
   MERCH_DEFAULT_PRINTFUL_PRODUCT_COST_CENTS,
 } from './pricing';
+
+const CATALOG_PAGE_SIZE = 100;
+const MAX_CATALOG_PRODUCTS = 500;
 
 export interface MerchCatalogSelection {
   readonly catalogProductId: number;
@@ -93,15 +97,93 @@ function productMatchesRequest(
 ): boolean {
   if (!request)
     return product.id === MERCH_DEFAULT_PRINTFUL_PRODUCT.catalogProductId;
+  const requestTokens = request
+    .split(' ')
+    .filter(Boolean)
+    .filter(token => token.length > 1)
+    .filter(
+      token =>
+        ![
+          'create',
+          'make',
+          'merch',
+          'product',
+          'catalog',
+          'printful',
+          'version',
+        ].includes(token)
+    );
+  if (requestTokens.length === 0) {
+    return product.id === MERCH_DEFAULT_PRINTFUL_PRODUCT.catalogProductId;
+  }
   const haystack = normalize(
     [product.name, product.type, product.brand, product.model]
       .filter(Boolean)
       .join(' ')
   );
-  return request
-    .split(' ')
-    .filter(Boolean)
-    .some(token => haystack.includes(token));
+  return requestTokens.some(token => haystack.includes(token));
+}
+
+function extractCatalogProductId(request: string): number | null {
+  const tokens = request.split(' ').filter(Boolean);
+  for (const [index, token] of tokens.entries()) {
+    const id = Number.parseInt(token, 10);
+    const isCatalogSizedNumber =
+      String(id) === token && token.length >= 2 && token.length <= 6;
+    if (!isCatalogSizedNumber || id <= 0) continue;
+
+    const context = tokens.slice(Math.max(0, index - 4), index);
+    const hasProductWord = context.some(item =>
+      ['product', 'item', 'sku'].includes(item)
+    );
+    const hasCatalogWord = context.some(item =>
+      ['catalog', 'printful'].includes(item)
+    );
+    if (hasProductWord || hasCatalogWord) {
+      return id;
+    }
+  }
+
+  return null;
+}
+
+async function listCatalogProductsForSelection(): Promise<
+  PrintfulCatalogProduct[]
+> {
+  const products: PrintfulCatalogProduct[] = [];
+
+  for (
+    let offset = 0;
+    offset < MAX_CATALOG_PRODUCTS;
+    offset += CATALOG_PAGE_SIZE
+  ) {
+    const page = await listCatalogProducts({
+      sellingRegionName: 'north_america',
+      placements: MERCH_DEFAULT_PRINTFUL_PRODUCT.placements,
+      limit: CATALOG_PAGE_SIZE,
+      offset,
+    });
+    products.push(...page);
+
+    if (page.length < CATALOG_PAGE_SIZE) break;
+  }
+
+  return products;
+}
+
+async function resolveRequestedCatalogProduct(
+  request: string
+): Promise<PrintfulCatalogProduct | null> {
+  const requestedProductId = extractCatalogProductId(request);
+  if (!requestedProductId) return null;
+
+  const product = await getCatalogProduct(requestedProductId);
+  if (product.is_discontinued) {
+    throw new Error(
+      `Printful catalog product ${requestedProductId} is discontinued`
+    );
+  }
+  return product;
 }
 
 function variantKey(variant: PrintfulCatalogVariant, index: number): string {
@@ -160,11 +242,10 @@ export async function resolveMerchCatalogSelection(
 
   try {
     const request = normalize(itemRequest);
-    const products = await listCatalogProducts({
-      sellingRegionName: 'north_america',
-      placements: MERCH_DEFAULT_PRINTFUL_PRODUCT.placements,
-      limit: 50,
-    });
+    const requestedProduct = await resolveRequestedCatalogProduct(request);
+    const products = requestedProduct
+      ? [requestedProduct]
+      : await listCatalogProductsForSelection();
     const product =
       products.find(
         item => !item.is_discontinued && productMatchesRequest(item, request)

--- a/apps/web/lib/merch/mockups.test.ts
+++ b/apps/web/lib/merch/mockups.test.ts
@@ -10,6 +10,7 @@ const dbMocks = vi.hoisted(() => ({
   selectLimit: vi.fn(),
   updateWhere: vi.fn(),
   lastUpdatedValues: null as Record<string, unknown> | null,
+  updatedValues: [] as Record<string, unknown>[],
 }));
 
 vi.mock('@/lib/printful/client', () => printful);
@@ -25,6 +26,7 @@ vi.mock('@/lib/db', () => ({
     update: () => ({
       set: (values: Record<string, unknown>) => {
         dbMocks.lastUpdatedValues = values;
+        dbMocks.updatedValues.push(values);
         return {
           where: dbMocks.updateWhere,
         };
@@ -194,6 +196,7 @@ describe('generateProductMockups', () => {
 describe('attachMockupsToDesignOption', () => {
   beforeEach(() => {
     dbMocks.lastUpdatedValues = null;
+    dbMocks.updatedValues = [];
     dbMocks.selectLimit.mockReset();
     dbMocks.updateWhere.mockReset();
     dbMocks.updateWhere.mockResolvedValue(undefined);
@@ -210,11 +213,29 @@ describe('attachMockupsToDesignOption', () => {
       'https://printful.test/mockup-tee.jpg',
     ]);
 
+    expect(dbMocks.updatedValues).toEqual([
+      {
+        mockupUrls: [
+          'https://printful.test/mockup-tee.jpg',
+          'https://cdn.test/internal-mockup.jpg',
+        ],
+        updatedAt: expect.any(Date),
+      },
+      {
+        mockupUrls: [
+          'https://printful.test/mockup-tee.jpg',
+          'https://cdn.test/internal-mockup.jpg',
+        ],
+        primaryImageUrl: 'https://printful.test/mockup-tee.jpg',
+        updatedAt: expect.any(Date),
+      },
+    ]);
     expect(dbMocks.lastUpdatedValues).toEqual({
       mockupUrls: [
         'https://printful.test/mockup-tee.jpg',
         'https://cdn.test/internal-mockup.jpg',
       ],
+      primaryImageUrl: 'https://printful.test/mockup-tee.jpg',
       updatedAt: expect.any(Date),
     });
   });

--- a/apps/web/lib/merch/mockups.ts
+++ b/apps/web/lib/merch/mockups.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import { eq } from 'drizzle-orm';
 import { db } from '@/lib/db';
-import { merchDesignOptions } from '@/lib/db/schema/merch';
+import { merchCards, merchDesignOptions } from '@/lib/db/schema/merch';
 import {
   createMockupTask,
   isPrintfulConfigured,
@@ -319,6 +319,15 @@ export async function attachMockupsToDesignOption(
     .update(merchDesignOptions)
     .set({ mockupUrls: merged, updatedAt: new Date() })
     .where(eq(merchDesignOptions.id, optionId));
+
+  await db
+    .update(merchCards)
+    .set({
+      mockupUrls: merged,
+      primaryImageUrl: merged[0] ?? '',
+      updatedAt: new Date(),
+    })
+    .where(eq(merchCards.selectedDesignOptionId, optionId));
 
   logger.info('[merch mockups] Attached Printful mockups to design option', {
     optionId,

--- a/apps/web/lib/merch/service.ts
+++ b/apps/web/lib/merch/service.ts
@@ -272,6 +272,40 @@ function buildOptionSpecs(
   ];
 }
 
+function isMerchDesignLane(value: string): value is MerchDesignLane {
+  return (
+    value === 'band_tour_uniform' ||
+    value === 'fashion_graphic_item' ||
+    value === 'artist_world_artifact'
+  );
+}
+
+function buildAlternativeDesignName(
+  sourceTitle: string,
+  productType: string
+): string {
+  const title = sourceTitle.trim();
+  const lowerTitle = title.toLowerCase();
+  const removableSuffixes = [
+    'tank top',
+    'sweatshirt',
+    't-shirt',
+    'hoodie',
+    'beanie',
+    'shirt',
+    'tee',
+    'cap',
+    'hat',
+  ];
+  const matchedSuffix = removableSuffixes.find(
+    suffix => lowerTitle === suffix || lowerTitle.endsWith(` ${suffix}`)
+  );
+  const baseTitle = matchedSuffix
+    ? title.slice(0, title.length - matchedSuffix.length).trim()
+    : title;
+  return `${baseTitle || title} ${productSuffixFromProductType(productType)}`;
+}
+
 function buildLearningSnapshot(
   spec: MerchOptionSpec,
   garmentColor: string,
@@ -493,6 +527,54 @@ function calculateRankScore(
   );
 }
 
+function attachPrintfulMockupsAsync(
+  options: readonly MerchDesignOption[]
+): void {
+  void Promise.allSettled(
+    options.map(async option => {
+      const printFileUrl = option.printFileUrls[0];
+      if (!printFileUrl) {
+        logger.warn('[merch-pipeline] skipping mockups without print file', {
+          optionId: option.id,
+        });
+        return;
+      }
+
+      try {
+        const { results, errors } = await generateProductMockups({
+          printFileUrl,
+          catalogProductId: option.printfulCatalogProductId,
+          catalogVariantIds: option.printfulCatalogVariantIds,
+          placements: option.placements,
+          technique: option.technique,
+          productTypes: [option.productType],
+        });
+        const mockupUrls = results.flatMap(result => result.mockupUrls);
+        if (mockupUrls.length > 0) {
+          await attachMockupsToDesignOption(option.id, mockupUrls);
+          logger.info('[merch-pipeline] Printful mockups attached', {
+            optionId: option.id,
+            mockupCount: mockupUrls.length,
+          });
+        } else if (errors.length > 0) {
+          logger.warn('[merch-pipeline] Printful mockup generation failed', {
+            optionId: option.id,
+            errors,
+          });
+        }
+      } catch (error) {
+        logger.warn(
+          '[merch-pipeline] mockup step failed (non-fatal for batch)',
+          {
+            optionId: option.id,
+            err: error instanceof Error ? error.message : String(error),
+          }
+        );
+      }
+    })
+  );
+}
+
 export async function createMerchGeneration(params: {
   readonly profileId: string;
   readonly clerkUserId: string;
@@ -535,6 +617,7 @@ export async function createMerchGeneration(params: {
         designName: spec.designName,
         lane: spec.lane,
         concept: spec.concept,
+        productType: catalog.productType,
       });
       const grossMargin =
         pricing.retailPriceCents -
@@ -587,49 +670,7 @@ export async function createMerchGeneration(params: {
 
     // Async Printful photorealistic mockups (non-blocking). Internal artwork mockups
     // are already persisted; Printful URLs are merged when tasks complete.
-    void Promise.allSettled(
-      insertedOptions.map(async option => {
-        const printFileUrl = option.printFileUrls[0];
-        if (!printFileUrl) {
-          logger.warn('[merch-pipeline] skipping mockups without print file', {
-            optionId: option.id,
-          });
-          return;
-        }
-
-        try {
-          const { results, errors } = await generateProductMockups({
-            printFileUrl,
-            catalogProductId: option.printfulCatalogProductId,
-            catalogVariantIds: option.printfulCatalogVariantIds,
-            placements: option.placements,
-            technique: option.technique,
-            productTypes: [option.productType],
-          });
-          const mockupUrls = results.flatMap(result => result.mockupUrls);
-          if (mockupUrls.length > 0) {
-            await attachMockupsToDesignOption(option.id, mockupUrls);
-            logger.info('[merch-pipeline] Printful mockups attached', {
-              optionId: option.id,
-              mockupCount: mockupUrls.length,
-            });
-          } else if (errors.length > 0) {
-            logger.warn('[merch-pipeline] Printful mockup generation failed', {
-              optionId: option.id,
-              errors,
-            });
-          }
-        } catch (error) {
-          logger.warn(
-            '[merch-pipeline] mockup step failed (non-fatal for batch)',
-            {
-              optionId: option.id,
-              err: error instanceof Error ? error.message : String(error),
-            }
-          );
-        }
-      })
-    );
+    attachPrintfulMockupsAsync(insertedOptions);
 
     await db
       .update(merchGenerationBatches)
@@ -816,6 +857,213 @@ export async function selectMerchDesign(params: {
         ? publishSellability.reasons
         : undefined,
   };
+}
+
+export async function createAlternativeMerchItem(params: {
+  readonly merchCardId: string;
+  readonly profileId: string;
+  readonly clerkUserId: string;
+  readonly itemType: string;
+  readonly conversationId?: string | null;
+  readonly turnId?: string | null;
+}): Promise<
+  MerchSelectionResult & {
+    readonly sourceMerchCardId: string;
+    readonly productType: string;
+    readonly printfulProductName: string;
+  }
+> {
+  await assertCanManageMerchProfile(params.profileId, params.clerkUserId);
+
+  const [sourceCard] = await db
+    .select()
+    .from(merchCards)
+    .where(
+      and(
+        eq(merchCards.id, params.merchCardId),
+        eq(merchCards.creatorProfileId, params.profileId)
+      )
+    )
+    .limit(1);
+
+  if (!sourceCard) {
+    throw new Error('Merch card not found');
+  }
+
+  const [sourceOption] = sourceCard.selectedDesignOptionId
+    ? await db
+        .select()
+        .from(merchDesignOptions)
+        .where(eq(merchDesignOptions.id, sourceCard.selectedDesignOptionId))
+        .limit(1)
+    : [];
+  const printFileUrl =
+    sourceOption?.printFileUrls[0] ?? sourceCard.printful.printFileUrls[0];
+  if (!printFileUrl) {
+    throw new Error('Original merch design has no reusable print file');
+  }
+
+  const profile = await getCreatorProfileForMerch(params.profileId);
+  const releaseContext = await getReleaseContext(params.profileId);
+  const prompt = `Create a ${params.itemType} version of ${sourceCard.title} with the same design.`;
+  const artistBrief = buildArtistBrief(profile, releaseContext, prompt);
+  const generationId = randomUUID();
+
+  await db.insert(merchGenerationBatches).values({
+    id: generationId,
+    creatorProfileId: params.profileId,
+    createdByClerkUserId: params.clerkUserId,
+    chatConversationId: params.conversationId ?? null,
+    chatTurnId: params.turnId ?? null,
+    prompt,
+    command: 'create_merch_alternative_item',
+    artistBrief,
+    status: 'generating',
+  });
+
+  try {
+    const catalog = await resolveMerchCatalogSelection(params.itemType);
+    const { pricing, providerWarnings } = catalog;
+    const grossMargin =
+      pricing.retailPriceCents -
+      pricing.estimatedPrintfulProductCostCents -
+      pricing.stripeFeeEstimateCents -
+      pricing.refundReserveCents;
+    const optionId = randomUUID();
+    const designLane =
+      sourceOption?.designLane ??
+      (isMerchDesignLane(sourceCard.learning.styleLane)
+        ? sourceCard.learning.styleLane
+        : 'fashion_graphic_item');
+    const title = buildAlternativeDesignName(
+      sourceCard.title,
+      catalog.productType
+    );
+    const learning = {
+      ...(sourceOption?.learning ?? sourceCard.learning),
+      garmentColor: catalog.colorway,
+      selectedOverOptionIds: [],
+    };
+
+    const [option] = await db
+      .insert(merchDesignOptions)
+      .values({
+        id: optionId,
+        generationBatchId: generationId,
+        creatorProfileId: params.profileId,
+        optionNumber: 1,
+        status: 'selected',
+        designLane,
+        designName: title,
+        productType: catalog.productType,
+        printfulProductName: catalog.productName,
+        printfulCatalogProductId: catalog.catalogProductId,
+        printfulCatalogVariantIds: catalog.catalogVariantIds,
+        variantMap: catalog.variantMap,
+        colorway: catalog.colorway,
+        availableSizes: catalog.sizes,
+        placements: catalog.placements,
+        technique: catalog.technique,
+        retailPriceCents: pricing.retailPriceCents,
+        estimatedPrintfulProductCostCents:
+          pricing.estimatedPrintfulProductCostCents,
+        estimatedShippingCostCents: pricing.estimatedShippingCostCents,
+        estimatedGrossMarginCents: grossMargin,
+        artistShareCents: pricing.artistPayoutPerUnitEstimateCents,
+        jovieShareCents: pricing.jovieMarginPerUnitEstimateCents,
+        pricing,
+        concept: sourceCard.description,
+        whyItFits:
+          sourceOption?.whyItFits ??
+          'It keeps the approved design and moves it onto a different Printful product.',
+        mockupUrls: [],
+        printFileUrls: [printFileUrl],
+        productionWarnings: providerWarnings,
+        qualityReview: sourceOption?.qualityReview ?? {
+          copyrightRisk: 'low',
+          typography: 'deterministic',
+          printFeasible: true,
+        },
+        learning,
+      })
+      .returning();
+
+    const printful = buildPrintfulSnapshot({
+      catalogProductId: option.printfulCatalogProductId,
+      catalogVariantIds: option.printfulCatalogVariantIds,
+      variantMap: option.variantMap,
+      placements: option.placements,
+      technique: option.technique,
+      printFileUrl,
+      availabilityRegion: catalog.availabilityRegion,
+      shippingProfile: catalog.shippingProfile,
+      productName: option.printfulProductName,
+      pricing: option.pricing,
+      providerWarnings,
+    });
+
+    const [card] = await db
+      .insert(merchCards)
+      .values({
+        creatorProfileId: params.profileId,
+        createdByClerkUserId: params.clerkUserId,
+        selectedDesignOptionId: option.id,
+        status: 'draft',
+        title,
+        description: sourceCard.description,
+        productType: option.productType,
+        primaryImageUrl: printFileUrl,
+        mockupUrls: [],
+        printful,
+        currency: 'USD',
+        retailPriceCents: option.retailPriceCents,
+        estimatedPrintfulProductCostCents:
+          option.estimatedPrintfulProductCostCents,
+        estimatedShippingCostCents: option.estimatedShippingCostCents,
+        platformFeeCents: 0,
+        artistRoyaltyRateBps: option.pricing.artistRoyaltyRateBps,
+        artistPayoutPerUnitEstimateCents: option.artistShareCents,
+        jovieMarginPerUnitEstimateCents: option.jovieShareCents,
+        pricing: option.pricing,
+        rankScore: 50,
+        learning,
+      })
+      .returning();
+
+    await db
+      .update(merchGenerationBatches)
+      .set({
+        selectedOptionId: option.id,
+        selectedMerchCardId: card.id,
+        completedAt: new Date(),
+        status: 'ready',
+      })
+      .where(eq(merchGenerationBatches.id, generationId));
+
+    attachPrintfulMockupsAsync([option]);
+
+    return {
+      success: true,
+      merchCardId: card.id,
+      status: card.status,
+      selectedOptionId: option.id,
+      title: card.title,
+      publicUrl: null,
+      sourceMerchCardId: sourceCard.id,
+      productType: option.productType,
+      printfulProductName: option.printfulProductName,
+    };
+  } catch (error) {
+    await db
+      .update(merchGenerationBatches)
+      .set({
+        status: 'failed',
+        error: error instanceof Error ? error.message : 'Unknown merch error',
+        completedAt: new Date(),
+      })
+      .where(eq(merchGenerationBatches.id, generationId));
+    throw error;
+  }
 }
 
 export async function publishMerchCard(params: {

--- a/apps/web/lib/services/merch/merch-generator.test.ts
+++ b/apps/web/lib/services/merch/merch-generator.test.ts
@@ -1,17 +1,24 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { createMerchGeneration, selectMerchDesign } from '@/lib/merch/service';
+import {
+  createAlternativeMerchItem,
+  createMerchGeneration,
+  selectMerchDesign,
+} from '@/lib/merch/service';
 import {
   canFulfillMerch,
+  createAlternativeMerchFromCard,
   generateMerchFromConcept,
   previewMerchFromConcept,
   selectAndCreateMerchCard,
 } from './merch-generator';
 
 vi.mock('@/lib/merch/service', () => ({
+  createAlternativeMerchItem: vi.fn(),
   createMerchGeneration: vi.fn(),
   selectMerchDesign: vi.fn(),
 }));
 
+const mockCreateAlternativeMerchItem = vi.mocked(createAlternativeMerchItem);
 const mockCreateMerchGeneration = vi.mocked(createMerchGeneration);
 const mockSelectMerchDesign = vi.mocked(selectMerchDesign);
 
@@ -99,6 +106,28 @@ describe('merch-generator wrappers', () => {
       optionId: null,
       optionNumber: 2,
       publish: true,
+    });
+  });
+
+  it('maps createAlternativeMerchFromCard arguments', async () => {
+    mockCreateAlternativeMerchItem.mockResolvedValueOnce({} as never);
+
+    await createAlternativeMerchFromCard({
+      merchCardId: 'merch_1',
+      profileId: 'profile_5',
+      clerkUserId: 'clerk_5',
+      itemType: 'hoodie',
+      conversationId: 'conversation_5',
+      turnId: 'turn_5',
+    });
+
+    expect(mockCreateAlternativeMerchItem).toHaveBeenCalledWith({
+      merchCardId: 'merch_1',
+      profileId: 'profile_5',
+      clerkUserId: 'clerk_5',
+      itemType: 'hoodie',
+      conversationId: 'conversation_5',
+      turnId: 'turn_5',
     });
   });
 });

--- a/apps/web/lib/services/merch/merch-generator.ts
+++ b/apps/web/lib/services/merch/merch-generator.ts
@@ -7,7 +7,11 @@ import 'server-only';
  * to the canonical merch service.
  */
 
-import { createMerchGeneration, selectMerchDesign } from '@/lib/merch/service';
+import {
+  createAlternativeMerchItem,
+  createMerchGeneration,
+  selectMerchDesign,
+} from '@/lib/merch/service';
 import type {
   MerchGenerationOptionView,
   MerchGenerationResult,
@@ -142,6 +146,24 @@ export async function selectAndCreateMerchCard(params: {
     optionId: params.optionId ?? null,
     optionNumber: params.optionNumber ?? null,
     publish: params.publish === true,
+  });
+}
+
+export async function createAlternativeMerchFromCard(params: {
+  readonly merchCardId: string;
+  readonly profileId: string;
+  readonly clerkUserId: string;
+  readonly itemType: string;
+  readonly conversationId?: string | null;
+  readonly turnId?: string | null;
+}): Promise<MerchSelectionResult> {
+  return createAlternativeMerchItem({
+    merchCardId: params.merchCardId,
+    profileId: params.profileId,
+    clerkUserId: params.clerkUserId,
+    itemType: params.itemType,
+    conversationId: params.conversationId ?? null,
+    turnId: params.turnId ?? null,
   });
 }
 

--- a/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
+++ b/apps/web/tests/eval/promptfoo/jovie-chat-provider.ts
@@ -464,6 +464,7 @@ const MERCH_TOOL_NAMES = [
   'createMerch',
   'previewMerchOptions',
   'selectMerchDesign',
+  'createMerchAlternativeItem',
   'publishMerchCard',
   'pauseMerchCard',
   'unpauseMerchCard',
@@ -649,6 +650,7 @@ const TOOL_RESULT_REQUIRED_KEYS: Record<string, readonly string[]> = {
   checkHandle: ['action', 'handle', 'available', 'summary'],
   confirmSpotifyArtist: ['action', 'spotifyArtistId', 'artist', 'summary'],
   createMerch: ['success', 'action', 'generationId', 'options'],
+  createMerchAlternativeItem: ['success', 'action', 'merchCardId'],
   createPromoStrategy: [
     'success',
     'action',
@@ -4156,6 +4158,16 @@ function defaultToolResult(toolName: string, input: unknown): unknown {
         optionNumber: args.optionNumber ?? null,
         optionId: args.optionId ?? null,
       };
+    case 'createMerchAlternativeItem':
+      return {
+        success: true,
+        action: 'create_merch_alternative_item',
+        merchCardId: '00000000-0000-4000-8000-000000000c03',
+        sourceMerchCardId: args.merchCardId,
+        itemType: args.itemType,
+        status: 'draft',
+        title: 'Tour Hoodie',
+      };
     case 'publishMerchCard':
       return {
         success: true,
@@ -4789,6 +4801,11 @@ function sampleToolInput(toolName: string): Record<string, unknown> {
       return {
         generationId: '00000000-0000-4000-8000-000000000b01',
         optionNumber: 1,
+      };
+    case 'createMerchAlternativeItem':
+      return {
+        merchCardId: '00000000-0000-4000-8000-000000000c01',
+        itemType: 'hoodie',
       };
     case 'publishMerchCard':
     case 'pauseMerchCard':

--- a/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
+++ b/apps/web/tests/eval/promptfoo/promptfooconfig.yaml
@@ -1522,6 +1522,7 @@ tests:
           - checkHandle
           - confirmSpotifyArtist
           - createMerch
+          - createMerchAlternativeItem
           - createPromoStrategy
           - createRelease
           - deleteOrArchiveMerchCard
@@ -2954,6 +2955,28 @@ tests:
         generationId: "00000000-0000-4000-8000-000000000b01"
         optionNumber: 2
         makeLive: false
+    assert:
+      - type: javascript
+        value: file://assertions.cjs:assertDeterministicNoSpend
+      - type: javascript
+        value: file://assertions.cjs:assertToolAvailable
+      - type: javascript
+        value: file://assertions.cjs:assertToolSchemaValid
+      - type: javascript
+        value: file://assertions.cjs:assertToolExecuted
+
+  - description: Tool contract accepts paid merch alternative item creation
+    metadata:
+      cost: deterministic
+    vars:
+      input: "Put this same design on a hoodie."
+      target: tool-contract
+      toolName: createMerchAlternativeItem
+      mode: app
+      plan: pro
+      toolInput:
+        merchCardId: "00000000-0000-4000-8000-000000000c01"
+        itemType: hoodie
     assert:
       - type: javascript
         value: file://assertions.cjs:assertDeterministicNoSpend

--- a/apps/web/tests/unit/chat/tool-schemas-strict.test.ts
+++ b/apps/web/tests/unit/chat/tool-schemas-strict.test.ts
@@ -16,6 +16,11 @@ function minimalValidInput(toolName: keyof typeof TOOL_SCHEMAS): unknown {
         generationId: '550e8400-e29b-41d4-a716-446655440000',
         optionNumber: 1,
       };
+    case 'createMerchAlternativeItem':
+      return {
+        merchCardId: '550e8400-e29b-41d4-a716-446655440000',
+        itemType: 'hoodie',
+      };
     case 'publishMerchCard':
     case 'pauseMerchCard':
     case 'unpauseMerchCard':


### PR DESCRIPTION
## Summary
- add a same-design merch alternative tool so artists can create a hoodie, hat, tank, or Printful catalog product from an existing merch card
- expand Printful catalog selection beyond the first page and support explicit catalog product IDs
- make fallback mockups product-aware for tees, hoodies, and hats, then propagate async Printful mockups onto saved library cards
- polish chat merch cards with clearer product labels and quick hoodie/hat actions

## Linear
- JOV-3176

## Verification
- pnpm biome check --write apps/web/app/api/chat/route.ts apps/web/components/features/profile/ProfileMerchCard.tsx apps/web/components/jovie/components/ChatMerchCard.test.tsx apps/web/components/jovie/components/ChatMerchCard.tsx apps/web/components/jovie/tool-ui.tsx apps/web/lib/chat/system-prompt.ts apps/web/lib/chat/tool-schemas.ts apps/web/lib/chat/tool-ui-registry.ts apps/web/lib/chat/tools/merch-tools.test.ts apps/web/lib/chat/tools/merch-tools.ts apps/web/lib/commands/registry.ts apps/web/lib/merch/artwork.test.ts apps/web/lib/merch/artwork.ts apps/web/lib/merch/catalog.test.ts apps/web/lib/merch/catalog.ts apps/web/lib/merch/mockups.test.ts apps/web/lib/merch/mockups.ts apps/web/lib/merch/service.ts apps/web/lib/services/merch/merch-generator.test.ts apps/web/lib/services/merch/merch-generator.ts apps/web/tests/eval/promptfoo/jovie-chat-provider.ts apps/web/tests/eval/promptfoo/promptfooconfig.yaml apps/web/tests/unit/chat/tool-schemas-strict.test.ts
- pnpm --filter @jovie/web exec vitest run lib/merch/artwork.test.ts lib/merch/catalog.test.ts lib/merch/mockups.test.ts lib/chat/tools/merch-tools.test.ts lib/services/merch/merch-generator.test.ts components/jovie/components/ChatMerchCard.test.tsx tests/unit/chat/tool-schemas-strict.test.ts tests/unit/chat/command-registry.test.ts
- pnpm --filter @jovie/web run evals:validate
- pnpm run evals (196/196 deterministic cases passed)
- pnpm --filter @jovie/web run typecheck -- --pretty false
- git diff --check
- commit hook: next:proxy-guard, Biome, ESLint, staged a11y, Turbo typecheck
- pre-push hook: repo Biome, next:proxy-guard, tailwind:check, typecheck, lint
- GitHub CI run 27506835260: all required PR checks green, including Promptfoo, Typecheck, Build (public routes), Unit Tests 1/6 through 6/6, CodeQL, SonarCloud, CodeRabbit, Preview Deploy, and Lighthouse (admin PR)

## Notes
- Local Storybook proof was unavailable before rendering because this checkout hits an existing Storybook/addon export mismatch and Vite dependency transform errors.
- Local Next browser proof was unavailable because the dev server accepted connections but returned zero bytes during instrumentation/proxy prewarm on both plain and fast wrappers. The changed route and component paths are covered by typecheck, focused tests, commit hooks, pre-push hooks, and green PR CI above.
