### PR TITLE
fix(web): allow screenshot fixtures in local automation

### DIFF
--- a/apps/web/app/exp/layout.tsx
+++ b/apps/web/app/exp/layout.tsx
@@ -1,7 +1,9 @@
 import { TooltipProvider } from '@jovie/ui';
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import type { ReactNode } from 'react';
 import { QueryProvider } from '@/components/providers/QueryProvider';
+import { isLocalDevelopmentAutomationRequest } from '@/lib/security/development-only';
 import { requireDevelopmentOnlyPage } from '@/lib/security/require-development-only';
 import { NOINDEX_ROBOTS } from '@/lib/seo/noindex-metadata';
 
@@ -12,12 +14,16 @@ export const metadata: Metadata = {
 // /exp/* routes share the production QueryClient + Tooltip context so
 // shipped components (Variant F ChatInput, etc.) work as-is when we
 // drop them into the design pass.
-export default function ExpLayout({
+export default async function ExpLayout({
   children,
 }: {
   readonly children: ReactNode;
 }) {
-  requireDevelopmentOnlyPage();
+  const headerStore = await headers();
+  requireDevelopmentOnlyPage({
+    allowLocalDevelopmentAutomation:
+      isLocalDevelopmentAutomationRequest(headerStore),
+  });
 
   return (
     <QueryProvider>

--- a/apps/web/lib/security/development-only.ts
+++ b/apps/web/lib/security/development-only.ts
@@ -6,6 +6,10 @@ export const DEVELOPMENT_ONLY_ERROR = 'Not available outside development';
 
 const NO_STORE_HEADERS = { 'Cache-Control': 'no-store' } as const;
 
+interface HeaderReader {
+  get(name: string): string | null;
+}
+
 /**
  * ALLOW gate for dev/test/debug routes.
  *
@@ -26,6 +30,52 @@ export function isExplicitDevelopmentEnvironment(): boolean {
 /** Hard production deploy check used for defence-in-depth proxy blocks. */
 export function isVercelProductionDeployment(): boolean {
   return process.env.VERCEL_ENV === 'production';
+}
+
+function extractHostname(value: string | null): string | null {
+  const normalized = value?.split(',')[0]?.trim();
+  if (!normalized) return null;
+
+  if (normalized.startsWith('http://') || normalized.startsWith('https://')) {
+    try {
+      return new URL(normalized).hostname.toLowerCase();
+    } catch {
+      return null;
+    }
+  }
+
+  return normalized.replace(/:\d+$/, '').toLowerCase();
+}
+
+export function isLocalDevelopmentAutomationHostname(
+  hostname: string | null
+): boolean {
+  const normalized = hostname?.trim().toLowerCase() ?? null;
+  return (
+    normalized === 'localhost' ||
+    normalized === '127.0.0.1' ||
+    normalized === '::1' ||
+    normalized === '[::1]' ||
+    Boolean(normalized?.endsWith('.localhost'))
+  );
+}
+
+/**
+ * Local-only automation escape hatch for production-built test servers.
+ * This intentionally requires an existing E2E opt-in and a loopback host.
+ */
+export function isLocalDevelopmentAutomationRequest(
+  headerReader: HeaderReader
+): boolean {
+  if (process.env.E2E_USE_TEST_AUTH_BYPASS !== '1') return false;
+
+  const hostname =
+    extractHostname(headerReader.get('x-forwarded-host')) ??
+    extractHostname(headerReader.get('host')) ??
+    extractHostname(headerReader.get('origin')) ??
+    extractHostname(headerReader.get('referer'));
+
+  return isLocalDevelopmentAutomationHostname(hostname);
 }
 
 export function developmentOnlyForbiddenResponse(

--- a/apps/web/lib/security/production-blocked-routes.ts
+++ b/apps/web/lib/security/production-blocked-routes.ts
@@ -28,6 +28,13 @@ export const PRODUCTION_BLOCKED_PAGE_EXACT = [
 ] as const;
 
 /**
+ * Production builds used by the Product Screenshots workflow still capture a
+ * few legacy experiment fixtures. Keep the inventory exact so the proxy can
+ * allow only screenshot automation without reopening all /exp routes.
+ */
+export const PRODUCT_SCREENSHOT_CAPTURE_PAGE_PATHS = ['/exp/shell-v1'] as const;
+
+/**
  * Routes that intentionally stay reachable outside development.
  * Keep this list tiny and justify every entry in code review.
  */
@@ -47,6 +54,12 @@ export function isProxyAllowlistedDevelopmentRoute(pathname: string): boolean {
   );
 }
 
+export function isProductScreenshotCapturePath(pathname: string): boolean {
+  return PRODUCT_SCREENSHOT_CAPTURE_PAGE_PATHS.some(
+    allowed => pathname === allowed
+  );
+}
+
 function matchesRoutePrefix(pathname: string, prefix: string): boolean {
   if (pathname === prefix) {
     return true;
@@ -59,8 +72,22 @@ function matchesRoutePrefix(pathname: string, prefix: string): boolean {
   return pathname.startsWith(`${prefix}/`);
 }
 
-export function isProductionBlockedDebugPath(pathname: string): boolean {
+interface ProductionBlockedDebugPathOptions {
+  readonly allowProductScreenshotCaptureRoutes?: boolean;
+}
+
+export function isProductionBlockedDebugPath(
+  pathname: string,
+  options: ProductionBlockedDebugPathOptions = {}
+): boolean {
   if (isProxyAllowlistedDevelopmentRoute(pathname)) {
+    return false;
+  }
+
+  if (
+    options.allowProductScreenshotCaptureRoutes === true &&
+    isProductScreenshotCapturePath(pathname)
+  ) {
     return false;
   }
 

--- a/apps/web/lib/security/require-development-only.ts
+++ b/apps/web/lib/security/require-development-only.ts
@@ -3,9 +3,18 @@ import 'server-only';
 import { notFound } from 'next/navigation';
 import { isExplicitDevelopmentEnvironment } from '@/lib/security/development-only';
 
+interface RequireDevelopmentOnlyPageOptions {
+  readonly allowLocalDevelopmentAutomation?: boolean;
+}
+
 /** Server component/layout guard for dev-only pages. */
-export function requireDevelopmentOnlyPage(): void {
-  if (!isExplicitDevelopmentEnvironment()) {
+export function requireDevelopmentOnlyPage(
+  options: RequireDevelopmentOnlyPageOptions = {}
+): void {
+  if (
+    !isExplicitDevelopmentEnvironment() &&
+    options.allowLocalDevelopmentAutomation !== true
+  ) {
     notFound();
   }
 }

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -49,7 +49,11 @@ import {
   isProxyRewriteExempt,
 } from '@/lib/routing/proxy-routing';
 import { SCRIPT_NONCE_HEADER } from '@/lib/security/content-security-policy';
-import { isExplicitDevelopmentEnvironment } from '@/lib/security/development-only';
+import {
+  isExplicitDevelopmentEnvironment,
+  isLocalDevelopmentAutomationHostname,
+  isLocalDevelopmentAutomationRequest,
+} from '@/lib/security/development-only';
 import {
   createFastNotFoundResponse,
   createProbeDropResponse,
@@ -106,6 +110,17 @@ function isElectronAppShellNavigation(
     (req.nextUrl.pathname === APP_ROUTES.DASHBOARD ||
       req.nextUrl.pathname.startsWith('/app/')) &&
     req.nextUrl.searchParams.get('runtime') === 'electron'
+  );
+}
+
+function shouldAllowProductScreenshotCaptureRoutes(req: NextRequest): boolean {
+  if (isLocalDevelopmentAutomationRequest(req.headers)) {
+    return true;
+  }
+
+  return (
+    process.env.E2E_USE_TEST_AUTH_BYPASS === '1' &&
+    isLocalDevelopmentAutomationHostname(req.nextUrl.hostname)
   );
 }
 
@@ -256,7 +271,10 @@ async function handleRequest(req: NextRequest, userId: string | null) {
     // Block debug/test/dev surfaces outside explicit development environments.
     if (
       !isExplicitDevelopmentEnvironment() &&
-      isProductionBlockedDebugPath(pathname)
+      isProductionBlockedDebugPath(pathname, {
+        allowProductScreenshotCaptureRoutes:
+          shouldAllowProductScreenshotCaptureRoutes(req),
+      })
     ) {
       return NextResponse.rewrite(new URL('/404', req.url));
     }

--- a/apps/web/tests/unit/lib/security/development-only.test.ts
+++ b/apps/web/tests/unit/lib/security/development-only.test.ts
@@ -68,4 +68,55 @@ describe('development-only security helpers', () => {
       });
     });
   });
+
+  describe('isLocalDevelopmentAutomationRequest', () => {
+    it('classifies loopback hostnames for local automation', async () => {
+      const { isLocalDevelopmentAutomationHostname } = await import(
+        '@/lib/security/development-only'
+      );
+
+      expect(isLocalDevelopmentAutomationHostname('localhost')).toBe(true);
+      expect(isLocalDevelopmentAutomationHostname('preview.localhost')).toBe(
+        true
+      );
+      expect(isLocalDevelopmentAutomationHostname('jov.ie')).toBe(false);
+      expect(isLocalDevelopmentAutomationHostname(null)).toBe(false);
+    });
+
+    it('allows E2E automation on localhost', async () => {
+      vi.stubEnv('E2E_USE_TEST_AUTH_BYPASS', '1');
+      const { isLocalDevelopmentAutomationRequest } = await import(
+        '@/lib/security/development-only'
+      );
+
+      expect(
+        isLocalDevelopmentAutomationRequest(
+          new Headers({ host: 'localhost:3000' })
+        )
+      ).toBe(true);
+    });
+
+    it('rejects localhost without explicit E2E opt-in', async () => {
+      const { isLocalDevelopmentAutomationRequest } = await import(
+        '@/lib/security/development-only'
+      );
+
+      expect(
+        isLocalDevelopmentAutomationRequest(
+          new Headers({ host: 'localhost:3000' })
+        )
+      ).toBe(false);
+    });
+
+    it('rejects public hosts even with explicit E2E opt-in', async () => {
+      vi.stubEnv('E2E_USE_TEST_AUTH_BYPASS', '1');
+      const { isLocalDevelopmentAutomationRequest } = await import(
+        '@/lib/security/development-only'
+      );
+
+      expect(
+        isLocalDevelopmentAutomationRequest(new Headers({ host: 'jov.ie' }))
+      ).toBe(false);
+    });
+  });
 });

--- a/apps/web/tests/unit/lib/security/production-blocked-routes.test.ts
+++ b/apps/web/tests/unit/lib/security/production-blocked-routes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   isProductionBlockedDebugPath,
+  PRODUCT_SCREENSHOT_CAPTURE_PAGE_PATHS,
   PRODUCTION_BLOCKED_API_PREFIXES,
   PRODUCTION_BLOCKED_PAGE_PREFIXES,
 } from '@/lib/security/production-blocked-routes';
@@ -22,6 +23,10 @@ describe('production-blocked debug routes', () => {
     );
   });
 
+  it('keeps the product screenshot capture inventory exact', () => {
+    expect(PRODUCT_SCREENSHOT_CAPTURE_PAGE_PATHS).toEqual(['/exp/shell-v1']);
+  });
+
   it.each([
     '/api/dev/test-auth/session',
     '/api/dev/clear-session',
@@ -35,6 +40,24 @@ describe('production-blocked debug routes', () => {
     '/sentry-example-page',
   ])('blocks %s outside development', route => {
     expect(isProductionBlockedDebugPath(route)).toBe(true);
+  });
+
+  it('allows only explicit product screenshot fixture routes when requested', () => {
+    expect(
+      isProductionBlockedDebugPath('/exp/shell-v1', {
+        allowProductScreenshotCaptureRoutes: true,
+      })
+    ).toBe(false);
+    expect(
+      isProductionBlockedDebugPath('/exp/shell-v1/other', {
+        allowProductScreenshotCaptureRoutes: true,
+      })
+    ).toBe(true);
+    expect(
+      isProductionBlockedDebugPath('/exp/library-v1', {
+        allowProductScreenshotCaptureRoutes: true,
+      })
+    ).toBe(true);
   });
 
   it.each([

--- a/apps/web/tests/unit/middleware/proxy-debug-route-lockdown.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-debug-route-lockdown.test.ts
@@ -194,6 +194,52 @@ describe('proxy debug/test route lockdown', () => {
     expect(new URL(rewriteUrl!).pathname).toBe('/404');
   });
 
+  it('allows shell-v1 product screenshots on loopback automation', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('VERCEL_ENV', 'production');
+    vi.stubEnv('E2E_USE_TEST_AUTH_BYPASS', '1');
+
+    const req = createTestRequest({
+      pathname: '/exp/shell-v1',
+      hostname: 'localhost',
+    });
+    const response = await callMiddleware(req);
+
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+  });
+
+  it('blocks shell-v1 product screenshots on public hosts even with test env', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('VERCEL_ENV', 'production');
+    vi.stubEnv('E2E_USE_TEST_AUTH_BYPASS', '1');
+
+    const req = createTestRequest({
+      pathname: '/exp/shell-v1',
+      hostname: 'jov.ie',
+    });
+    const response = await callMiddleware(req);
+    const rewriteUrl = response.headers.get('x-middleware-rewrite');
+
+    expect(rewriteUrl).toBeTruthy();
+    expect(new URL(rewriteUrl!).pathname).toBe('/404');
+  });
+
+  it('keeps other experiment routes blocked on loopback automation', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('VERCEL_ENV', 'production');
+    vi.stubEnv('E2E_USE_TEST_AUTH_BYPASS', '1');
+
+    const req = createTestRequest({
+      pathname: '/exp/library-v1',
+      hostname: 'localhost',
+    });
+    const response = await callMiddleware(req);
+    const rewriteUrl = response.headers.get('x-middleware-rewrite');
+
+    expect(rewriteUrl).toBeTruthy();
+    expect(new URL(rewriteUrl!).pathname).toBe('/404');
+  });
+
   it('allows debug routes during explicit local development', async () => {
     vi.stubEnv('NODE_ENV', 'development');
     vi.stubEnv('VERCEL_ENV', '');


### PR DESCRIPTION
## Summary
- Allows the exact `/exp/shell-v1` Product Screenshots fixture path during loopback E2E automation only.
- Keeps public production `/exp/*` debug/test routes blocked, including `/exp/library-v1` and public-host requests with test env enabled.
- Lets the `/exp` layout honor the same local automation gate so production-built screenshot servers can render the fixture instead of a 404.

## Bug-to-Test
bug-to-test: satisfied — regression tests added in:
- `apps/web/tests/unit/lib/security/development-only.test.ts`
- `apps/web/tests/unit/lib/security/production-blocked-routes.test.ts`
- `apps/web/tests/unit/middleware/proxy-debug-route-lockdown.test.ts`

## Test Coverage
New code paths covered:
- E2E opt-in + loopback host allows local screenshot automation.
- Missing E2E opt-in denies localhost automation.
- Public host denies screenshot fixture even with E2E env enabled.
- Only `/exp/shell-v1` is allowlisted for product screenshot capture.
- Proxy keeps other `/exp` routes blocked on local automation.

## Pre-Landing Review
Pre-Landing Review: No issues found.

## Design Review
No visual UI changes. Layout guard only.

## Eval Results
No prompt-related files changed — evals skipped.

## Linear follow-ups
Linear follow-ups: none.

## Test plan
- [x] `JOVIE_AGENT_PROFILE=coder pnpm biome check --write apps/web/app/exp/layout.tsx apps/web/lib/security/development-only.ts apps/web/lib/security/production-blocked-routes.ts apps/web/lib/security/require-development-only.ts apps/web/proxy.ts apps/web/tests/unit/lib/security/development-only.test.ts apps/web/tests/unit/lib/security/production-blocked-routes.test.ts apps/web/tests/unit/middleware/proxy-debug-route-lockdown.test.ts` — checked 8 files, fixed 1
- [x] `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web exec vitest run tests/unit/lib/security/development-only.test.ts tests/unit/lib/security/production-blocked-routes.test.ts tests/unit/middleware/proxy-debug-route-lockdown.test.ts` — 3 files, 38 tests passed
- [x] `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run typecheck -- --pretty false` — passed
- [x] `JOVIE_AGENT_PROFILE=coder pnpm --filter @jovie/web run test:bug-to-test` — not applicable by branch metadata; regression tests are included above
- [x] Guard repro: `node scripts/version-check.mjs && node scripts/desktop-release-guard.mjs --base origin/main && node --test scripts/desktop-release-guard.test.mjs scripts/dev-web-fast.test.mjs && node apps/web/scripts/next-proxy-guard.mjs` — passed after removing the unnecessary version bump
- [x] `JOVIE_AGENT_PROFILE=coder DATABASE_URL=postgresql://localhost/noop NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_mock CLERK_SECRET_KEY=sk_test_mock NEXT_DISABLE_TOOLBAR=1 NEXT_PUBLIC_CLERK_PROXY_DISABLED=1 E2E_USE_TEST_AUTH_BYPASS=1 E2E_CLERK_USER_ID=user_test pnpm --filter @jovie/web run build` — passed on final source diff before version-bump removal
- [x] Production server + targeted screenshot: `BASE_URL=http://localhost:3000 pnpm --filter @jovie/web exec playwright test --config=playwright.config.screenshots.ts --project=screenshots -g "captures shell-v1-dashboard-desktop$"` — 1 passed in 24.5s
- [x] Production server + full screenshot catalog: `BASE_URL=http://localhost:3000 pnpm --filter @jovie/web exec playwright test --config=playwright.config.screenshots.ts --project=screenshots` — 58 passed in 16.7m
- [x] Pre-push hook — `biome check .`, `next:proxy-guard`, `tailwind:check`, `typecheck`, and `biome lint .` passed