### PR TITLE
fix(auth): prevent redirect loop between app and onboarding (JOV-2454)

### DIFF
--- a/apps/web/app/onboarding/checkout/page.tsx
+++ b/apps/web/app/onboarding/checkout/page.tsx
@@ -3,7 +3,11 @@ import { redirect } from 'next/navigation';
 import { getDashboardData } from '@/app/app/(shell)/dashboard/actions';
 import { APP_ROUTES } from '@/constants/routes';
 
-import { CanonicalUserState, resolveUserState } from '@/lib/auth/gate';
+import {
+  CanonicalUserState,
+  getRedirectForState,
+  resolveUserState,
+} from '@/lib/auth/gate';
 import type { PlanIntentTier } from '@/lib/auth/plan-intent';
 import {
   DEFAULT_UPSELL_PLAN,
@@ -141,8 +145,11 @@ export default async function OnboardingCheckoutPage({
   const pricing = resolvePriceIds(planIntent);
 
   if (!pricing.monthlyPriceId) {
-    // Price not configured — skip to dashboard
-    redirect(APP_ROUTES.DASHBOARD);
+    // Price not configured — skip checkout. Incomplete profiles must return
+    // to onboarding, not /app (the shell immediately redirects them back to
+    // /start and can loop with /onboarding/checkout — JOV-2454 / ENG-002).
+    const stateRedirect = getRedirectForState(authResult.state);
+    redirect(stateRedirect ?? APP_ROUTES.DASHBOARD);
   }
 
   return (

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -155,25 +155,27 @@ function readRedirectCount(req: NextRequest): number {
 }
 
 /**
- * Apply a state-based rewrite with a shared redirect-loop circuit breaker.
- * Returns the rewritten NextResponse, or null when the breaker fires (caller
+ * Apply a state-based redirect with a shared redirect-loop circuit breaker.
+ * Returns the redirect NextResponse, or null when the breaker fires (caller
  * falls through with NextResponse.next() and a Sentry event).
  *
- * The counter is shared across all state-based rewrites (waitlist + onboarding)
+ * Uses redirect (not rewrite) so the URL bar moves to the canonical target.
+ * Rewrites left the original pathname in the address bar, which caused
+ * repeated middleware hits (RSC prefetches) on non-exempt paths and tripped
+ * the breaker even when the user was already viewing onboarding content.
+ *
+ * The counter is shared across all state-based redirects (waitlist + onboarding)
  * so any loop class trips the same breaker.
  */
-function applyStateRewrite(
+function applyStateRedirect(
   req: NextRequest,
-  requestHeaders: Headers,
   target: string
 ): NextResponse | null {
   const redirectCount = readRedirectCount(req);
   if (redirectCount >= PROXY_REWRITE_CIRCUIT_BREAKER_THRESHOLD) {
     return null;
   }
-  const res = NextResponse.rewrite(new URL(target, req.url), {
-    request: { headers: requestHeaders },
-  });
+  const res = NextResponse.redirect(new URL(target, req.url));
   res.cookies.set(PROXY_REWRITE_COUNT_COOKIE, String(redirectCount + 1), {
     maxAge: PROXY_REWRITE_COUNT_TTL_SECONDS,
     path: '/',
@@ -459,17 +461,10 @@ async function handleRequest(req: NextRequest, userId: string | null) {
       req.headers.get('Next-Router-Prefetch') === '1' ||
       req.nextUrl.searchParams.has('_rsc');
 
-    // Authenticated users on homepage → redirect to dashboard at the edge.
-    // Skips the client-side AuthRedirectHandler overlay (black flash) entirely.
-    // No getUserState needed — /app handles waitlist/onboarding gating in its layout.
-    if (pathname === '/' && isNavigationMethod && !isRSCPrefetch) {
-      return NextResponse.redirect(new URL(DASHBOARD_URL, req.url));
-    }
-
     // Fetch user state ONCE for all authenticated routing decisions
     let userState: ProxyUserState | null = null;
 
-    // Only non-/app page routes need user state for middleware rewrites.
+    // Only non-/app page routes need user state for middleware redirects.
     // /app and /app/* perform auth and onboarding/waitlist gating deeper in
     // route handlers/layouts, so proxy-level state lookups are unnecessary.
     const needsUserState =
@@ -480,13 +475,27 @@ async function handleRequest(req: NextRequest, userId: string | null) {
 
     // Skip the getUserState call for RSC prefetch requests when the user is
     // already known-active from the in-memory cache. Active users don't need
-    // routing intervention (no waitlist/onboarding rewrite), so the prefetch
+    // routing intervention (no waitlist/onboarding redirect), so the prefetch
     // can pass through immediately. The subsequent full navigation will still
     // call getUserState normally.
     const canSkipForPrefetch = isRSCPrefetch && isKnownActiveUser(userId);
 
     if (needsUserState && !canSkipForPrefetch) {
       userState = await getUserState(userId);
+    }
+
+    // Authenticated users on homepage → route based on user state at the edge.
+    // needsOnboarding users go directly to /start so we never bounce through
+    // /app (which immediately redirects back to /start and can loop with
+    // /onboarding/checkout — JOV-2454 / ENG-002).
+    if (pathname === '/' && isNavigationMethod && !isRSCPrefetch) {
+      if (userState?.needsOnboarding) {
+        return NextResponse.redirect(new URL(APP_ROUTES.START, req.url));
+      }
+      if (userState?.needsWaitlist) {
+        return NextResponse.redirect(new URL('/waitlist', req.url));
+      }
+      return NextResponse.redirect(new URL(DASHBOARD_URL, req.url));
     }
 
     let res: NextResponse;
@@ -548,12 +557,8 @@ async function handleRequest(req: NextRequest, userId: string | null) {
         !isInviteRedemptionPath &&
         !isProxyRewriteExempt(pathname)
       ) {
-        const waitlistRewrite = applyStateRewrite(
-          req,
-          requestHeaders,
-          '/waitlist'
-        );
-        if (waitlistRewrite === null) {
+        const waitlistRedirect = applyStateRedirect(req, '/waitlist');
+        if (waitlistRedirect === null) {
           await captureWarning(
             '[proxy] Redirect loop circuit breaker triggered',
             new Error('Redirect loop detected'),
@@ -567,7 +572,7 @@ async function handleRequest(req: NextRequest, userId: string | null) {
           res = NextResponse.next({ request: { headers: requestHeaders } });
           res.cookies.delete(PROXY_REWRITE_COUNT_COOKIE);
         } else {
-          res = waitlistRewrite;
+          res = waitlistRedirect;
         }
       } else if (
         userState.needsOnboarding &&
@@ -582,12 +587,8 @@ async function handleRequest(req: NextRequest, userId: string | null) {
           res = NextResponse.next({ request: { headers: requestHeaders } });
           res.cookies.delete('jovie_onboarding_complete');
         } else {
-          const rewriteRes = applyStateRewrite(
-            req,
-            requestHeaders,
-            APP_ROUTES.START
-          );
-          if (rewriteRes === null) {
+          const onboardingRedirect = applyStateRedirect(req, APP_ROUTES.START);
+          if (onboardingRedirect === null) {
             await captureWarning(
               '[proxy] Redirect loop circuit breaker triggered',
               new Error('Redirect loop detected'),
@@ -601,7 +602,7 @@ async function handleRequest(req: NextRequest, userId: string | null) {
             res = NextResponse.next({ request: { headers: requestHeaders } });
             res.cookies.delete(PROXY_REWRITE_COUNT_COOKIE);
           } else {
-            res = rewriteRes;
+            res = onboardingRedirect;
           }
         }
       } else if (

--- a/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
+++ b/apps/web/tests/unit/middleware/proxy-behavioral.test.ts
@@ -981,6 +981,20 @@ describe('proxy.ts middleware', () => {
       expect(res.headers.get('location')).toContain('handle=artist');
     });
 
+    it('redirects authenticated needsOnboarding users from / to /start without bouncing through /app (JOV-2454)', async () => {
+      mocks.getUserState.mockResolvedValue(USER_STATES.needsOnboarding);
+
+      const req = createAuthenticatedRequest('clerk_user_1', {
+        pathname: '/',
+      });
+      const res = await callMiddleware(req);
+
+      expect(res.status).toBeGreaterThanOrEqual(300);
+      expect(res.status).toBeLessThan(400);
+      expect(isRedirectTo(res, '/start')).toBe(true);
+      expect(isRedirectTo(res, '/app')).toBe(false);
+    });
+
     it('redirects authenticated legacy earnings deep links to artist profile pay', async () => {
       mocks.getUserState.mockResolvedValue(USER_STATES.active);
 
@@ -1024,7 +1038,7 @@ describe('proxy.ts middleware', () => {
   // Circuit Breaker
   // ==========================================================================
   describe('circuit breaker (redirect loop prevention)', () => {
-    it('rewrites to /start and increments redirect count', async () => {
+    it('redirects to /start and increments redirect count', async () => {
       mocks.getUserState.mockResolvedValue(USER_STATES.needsOnboarding);
 
       const req = createAuthenticatedRequest('clerk_user_1', {
@@ -1032,16 +1046,15 @@ describe('proxy.ts middleware', () => {
       });
       const res = await callMiddleware(req);
 
-      // Verify the rewrite destination is /start
-      const rewriteUrl = res.headers.get('x-middleware-rewrite');
-      expect(rewriteUrl).toBeTruthy();
-      expect(new URL(rewriteUrl!).pathname).toBe('/start');
+      expect(res.status).toBeGreaterThanOrEqual(300);
+      expect(res.status).toBeLessThan(400);
+      expect(isRedirectTo(res, '/start')).toBe(true);
 
       const cookies = getResponseCookies(res);
       expect(cookies.jovie_redirect_count).toBe('1');
     });
 
-    it('increments redirect count on subsequent rewrites', async () => {
+    it('increments redirect count on subsequent redirects', async () => {
       mocks.getUserState.mockResolvedValue(USER_STATES.needsOnboarding);
 
       const req = createAuthenticatedRequest('clerk_user_1', {
@@ -1083,7 +1096,7 @@ describe('proxy.ts middleware', () => {
       expect(res.status).toBeLessThan(300);
     });
 
-    it('rewrites needsWaitlist user from /pricing to /waitlist and increments count', async () => {
+    it('redirects needsWaitlist user from /pricing to /waitlist and increments count', async () => {
       mocks.getUserState.mockResolvedValue(USER_STATES.needsWaitlist);
 
       const req = createAuthenticatedRequest('clerk_user_1', {
@@ -1091,9 +1104,9 @@ describe('proxy.ts middleware', () => {
       });
       const res = await callMiddleware(req);
 
-      const rewriteUrl = res.headers.get('x-middleware-rewrite');
-      expect(rewriteUrl).toBeTruthy();
-      expect(new URL(rewriteUrl!).pathname).toBe('/waitlist');
+      expect(res.status).toBeGreaterThanOrEqual(300);
+      expect(res.status).toBeLessThan(400);
+      expect(isRedirectTo(res, '/waitlist')).toBe(true);
 
       const cookies = getResponseCookies(res);
       expect(cookies.jovie_redirect_count).toBe('1');
@@ -1109,9 +1122,7 @@ describe('proxy.ts middleware', () => {
       const res = await callMiddleware(req);
 
       // Cookie was unparseable → treat as 0 and increment to 1, NOT NaN+1.
-      const rewriteUrl = res.headers.get('x-middleware-rewrite');
-      expect(rewriteUrl).toBeTruthy();
-      expect(new URL(rewriteUrl!).pathname).toBe('/start');
+      expect(isRedirectTo(res, '/start')).toBe(true);
       const cookies = getResponseCookies(res);
       expect(cookies.jovie_redirect_count).toBe('1');
     });


### PR DESCRIPTION
## Linear
https://linear.app/jovie/issue/JOV-2454/error-redirect-loop-detected

<!-- linear-issue-id:JOV-2454 -->

## Root cause

Two related redirect-loop classes were still occurring after the proxy circuit breaker landed:

1. **Checkout ↔ app ↔ start loop (ENG-002 / TD-09):** `/onboarding/checkout` skipped checkout when Stripe prices were unconfigured by redirecting every user to `/app`. The app shell immediately redirects incomplete profiles back to `/start`, and `useOnboardingClaim` sends claimed users back to `/onboarding/checkout` — producing an infinite server/client redirect cycle.

2. **Proxy rewrite counter false positives:** Proxy used `NextResponse.rewrite()` for onboarding/waitlist gating on marketing paths. The URL bar stayed on the original pathname (e.g. `/pricing`), so repeated RSC/middleware hits on that non-exempt path incremented `jovie_redirect_count` and eventually fired the Sentry `"Redirect loop detected"` circuit breaker even though the user was already being served onboarding content.

3. **Homepage bounce:** Authenticated homepage visits always redirected to `/app` before user-state lookup, forcing needs-onboarding users through an unnecessary `/app → /start` hop that amplified the checkout loop.

## Fix

- Route authenticated homepage visitors based on proxy user state (`/start`, `/waitlist`, or `/app`).
- Switch onboarding/waitlist gating from rewrite → redirect so the canonical URL is used and middleware stops re-counting the same navigation.
- When checkout prices are missing, use `getRedirectForState()` so incomplete profiles return to `/start` instead of `/app`.

## Tests

- Updated proxy behavioral circuit-breaker expectations for redirect-based gating.
- Added regression: authenticated `needsOnboarding` user on `/` goes directly to `/start`.

```
pnpm --filter web exec vitest run tests/unit/middleware/proxy-behavioral.test.ts
✓ 83 tests passed
```

## Files changed

- `apps/web/proxy.ts`
- `apps/web/app/onboarding/checkout/page.tsx`
- `apps/web/tests/unit/middleware/proxy-behavioral.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved onboarding checkout routing when pricing details are missing by using account state to choose the next destination (with a safe fallback).
  * Updated homepage routing for authenticated users to send them to onboarding, waitlist, or the dashboard based on their current status.
  * Enhanced redirect-loop protection by switching to redirect-based handling while preserving circuit-breaker behavior.

* **Tests**
  * Added a regression test for onboarding redirects.
  * Updated middleware tests to validate redirect destinations and redirect-count behavior across consecutive requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Gate Evidence

<!-- agent-run-artifact
{
  "id": "run-gstack-pr-10970",
  "source": "github",
  "sourceRunId": "e3807f2d9a3892b6475e9816b418e667019592ae",
  "kind": "qa",
  "status": "done",
  "title": "GStack gates",
  "summary": "Orchestrator-recorded GStack gate evidence for agent PR landing.",
  "modelRoute": "deterministic",
  "allowedActions": [
    "read"
  ],
  "forbiddenActions": [
    "merge",
    "deploy"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-2454",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-2454/error-redirect-loop-detected",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/10970",
  "adminSurface": "/app/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/qa --exhaustive passed (orchestrator wave 1)",
      "checkedAt": "2026-06-16T17:57:31.027Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/review passed (orchestrator wave 1)",
      "checkedAt": "2026-06-16T17:57:31.027Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/ship passed (orchestrator wave 1)",
      "checkedAt": "2026-06-16T17:57:31.027Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-06-16T17:57:31.027Z",
  "updatedAt": "2026-06-16T17:57:31.027Z",
  "metadata": {}
}
-->
