### PR TITLE
fix(security): harden secret scanning for backup files (JOV-3215)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,6 +354,39 @@ jobs:
 
           echo "✅ .env.example looks safe (no obvious secrets)."
 
+  ci-secret-scan:
+    name: Secret Scan (gitleaks + trufflehog)
+    # Always run; fast, catches secrets in PR diffs including *.backup files (JOV-3215).
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - name: Run secret scan
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch origin "${{ github.base_ref }}"
+            ./scripts/security/scan-secrets.sh ci-pr "origin/${{ github.base_ref }}"
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            git fetch origin main --depth=1
+            ./scripts/security/scan-secrets.sh ci-pr "origin/main"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            if [[ "${{ github.event.before }}" == "0000000000000000000000000000000000000000" ]]; then
+              git fetch origin main --depth=1
+              ./scripts/security/scan-secrets.sh ci-pr "origin/main"
+            else
+              ./scripts/security/scan-secrets.sh ci-pr "${{ github.event.before }}"
+            fi
+          else
+            git fetch origin main --depth=1
+            ./scripts/security/scan-secrets.sh ci-pr "origin/main"
+          fi
+      - name: Verify backup-file fixture coverage
+        run: ./scripts/security/verify-gitleaks-coverage.sh
+
   ci-guardrails:
     name: Guardrails (proxy)
     # Draft PRs skip; ready PRs + pushes + merge queue enforce core repo guardrails
@@ -3340,6 +3373,7 @@ jobs:
       contents: read
     needs:
       - ci-env-example-guard
+      - ci-secret-scan
       - ci-guardrails
       - ci-risk-classifier
       - ci-structural-contract

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,6 +2,7 @@
 #
 # This workflow complements CodeQL by adding:
 # - Gitleaks: Secret detection in git history
+# - TruffleHog: Defense-in-depth secret scanning (JOV-3215)
 # - Trivy: Vulnerability scanning for dependencies and filesystem (added in subtask-1-4)
 # - OSSF Scorecard: Supply chain security scoring (added in subtask-1-5)
 #
@@ -10,8 +11,8 @@ name: Security Scanning
 on:
   push:
     branches: ['main']
-  # Removed pull_request trigger — security scanning on push-to-main catches
-  # everything that merges, weekly schedule covers drift. Saves ~300 runs/month.
+  pull_request:
+    branches: ['main']
   schedule:
     - cron: '0 6 * * 1' # Weekly on Monday at 6:00 AM UTC
   workflow_dispatch:
@@ -41,8 +42,25 @@ jobs:
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
           GITLEAKS_ENABLE_COMMENTS: false
 
-      - name: Verify gitleaks detects Neon/Clerk leak shapes (JOV-2940)
+      - name: Verify gitleaks detects Neon/Clerk leak shapes and backup files
         run: ./scripts/security/verify-gitleaks-coverage.sh
+
+  trufflehog:
+    name: TruffleHog Secret Scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+
+      - name: Run TruffleHog (full history on main/schedule, PR diff on pull_request)
+        uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51 # v3.95.5
+        with:
+          path: ./
+          extra_args: --no-verification --exclude-paths=.trufflehog-exclude.txt
 
   trivy:
     name: Trivy Vulnerability Scanning

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,8 +1,9 @@
 # Gitleaks Configuration for Jovie
 # https://github.com/gitleaks/gitleaks
 #
-# Scans the full git history on push-to-main and weekly schedule.
+# Scans staged changes (pre-commit), PR diffs (CI), and full git history (main + schedule).
 # Keep allowlists narrow — broad docs/*.md exclusions hid real secrets (JOV-2940).
+# Backup files (*.backup, *.bak) are intentionally NOT allowlisted (JOV-3215).
 
 [extend]
 # Use the default gitleaks config as a base
@@ -18,13 +19,13 @@ description = "Narrow allowlist for test fixtures, examples, and templates"
 
 # Regex patterns for paths to ignore
 paths = [
-    # Test directories and fixtures
-    '''(?i)tests?/''',
-    '''(?i)__tests__/''',
+    # Test directories and fixtures (anchored — avoid matching paths like contests/)
+    '''(?:^|/)tests?/''',
+    '''(?:^|/)__tests__/''',
     '''(?i)\.test\.(ts|tsx|js|jsx)$''',
     '''(?i)\.spec\.(ts|tsx|js|jsx)$''',
-    '''(?i)fixtures?/''',
-    '''(?i)mocks?/''',
+    '''(?:^|/)fixtures?/''',
+    '''(?:^|/)mocks?/''',
 
     # Example and template files
     '''\.env\.example$''',
@@ -57,8 +58,9 @@ paths = [
     # Log files from test runs
     '''\.log$''',
 
-    # Gitleaks self-test fixture (intentionally contains leak-shaped strings)
+    # Gitleaks self-test fixtures (intentionally contain leak-shaped strings)
     '''scripts/security/gitleaks-fixture\.txt$''',
+    '''scripts/security/gitleaks-backup-fixture\.txt$''',
 ]
 
 # Regex patterns for content to ignore (false positive patterns)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,6 +2,7 @@
 set -e  # Required: ensures check-conflict-markers.sh failure actually blocks commits
 
 bash scripts/check-conflict-markers.sh
+bash scripts/security/scan-secrets.sh pre-commit
 pnpm run next:proxy-guard
 node scripts/turbo-warm-precommit-cache.mjs
 pnpm exec lint-staged

--- a/.trufflehog-exclude.txt
+++ b/.trufflehog-exclude.txt
@@ -1,0 +1,2 @@
+scripts/security/gitleaks-fixture.txt
+scripts/security/gitleaks-backup-fixture.txt

--- a/package.json
+++ b/package.json
@@ -135,6 +135,8 @@
     "ci:harness:validate": "node scripts/ci-harness.mjs validate",
     "ci:harness:docs": "node scripts/ci-harness.mjs generate-docs --write",
     "ci:harness:check": "pnpm ci:harness:validate && node scripts/ci-harness.mjs generate-docs --check",
+    "security:scan-secrets": "bash scripts/security/scan-secrets.sh",
+    "security:verify-secret-scan": "bash scripts/security/verify-gitleaks-coverage.sh",
     "ci:branching-guard": "node scripts/ci-branching-guard.mjs",
     "ci:branching-guard:validate": "node scripts/ci-branching-guard.mjs validate",
     "ci:harness:test": "vitest --root scripts --config vitest.config.mts run lib/__tests__",

--- a/scripts/security/gitleaks-backup-fixture.txt
+++ b/scripts/security/gitleaks-backup-fixture.txt
@@ -1,0 +1,4 @@
+# Intentional leak-shaped strings for backup-file coverage verification (JOV-3215).
+# This file is allowlisted in .gitleaks.toml — verify script copies it to a temp *.backup path.
+CLERK_SECRET_KEY=sk_test_gitleaksJOV3215notrealABCDEFGH12 # trufflehog:ignore
+postgresql://neondb_owner:gitleaks-test-secret-JOV-3215-not-real@ep-example-pooler.c-2.us-east-1.aws.neon.tech/neondb?sslmode=require # trufflehog:ignore

--- a/scripts/security/gitleaks-fixture.txt
+++ b/scripts/security/gitleaks-fixture.txt
@@ -1,4 +1,4 @@
 # Intentional leak-shaped strings for gitleaks coverage verification (JOV-2940).
 # This file is allowlisted in .gitleaks.toml — the verify script copies it to a temp path.
-postgresql://neondb_owner:npg_FAKE_GITLEAKS_FIXTURE@ep-example-pooler.c-2.us-east-1.aws.neon.tech/neondb?sslmode=require
-CLERK_SECRET_KEY=sk_test_FAKEGITLEAKSFIXTURE1234567890ABCD
+postgresql://neondb_owner:npg_FAKE_GITLEAKS_FIXTURE@ep-example-pooler.c-2.us-east-1.aws.neon.tech/neondb?sslmode=require # trufflehog:ignore
+CLERK_SECRET_KEY=sk_test_FAKEGITLEAKSFIXTURE1234567890ABCD # trufflehog:ignore

--- a/scripts/security/scan-secrets.sh
+++ b/scripts/security/scan-secrets.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Run gitleaks + trufflehog for defense-in-depth secret scanning (JOV-3215).
+# Modes:
+#   pre-commit          Scan staged changes (fast, for git hooks)
+#   ci-pr [base-ref]    Scan commits since base ref (PR CI)
+#   full                Scan full git history
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+MODE="${1:-pre-commit}"
+BASE_REF="${2:-origin/main}"
+GITLEAKS_VERSION="${GITLEAKS_VERSION:-8.21.2}"
+TRUFFLEHOG_VERSION="${TRUFFLEHOG_VERSION:-3.95.5}"
+EXCLUDE_PATHS="$REPO_ROOT/.trufflehog-exclude.txt"
+
+ensure_gitleaks() {
+  if [[ -n "${GITLEAKS_BIN:-}" ]]; then
+    return
+  fi
+  if command -v gitleaks >/dev/null 2>&1; then
+    GITLEAKS_BIN="$(command -v gitleaks)"
+    return
+  fi
+
+  local os arch cache_dir tarball
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64) arch="x64" ;;
+    aarch64 | arm64) arch="arm64" ;;
+  esac
+  cache_dir="${TMPDIR:-/tmp}/gitleaks-${GITLEAKS_VERSION}"
+  mkdir -p "$cache_dir"
+  tarball="gitleaks_${GITLEAKS_VERSION}_${os}_${arch}.tar.gz"
+  if [[ ! -x "$cache_dir/gitleaks" ]]; then
+    curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${tarball}" \
+      | tar -xz -C "$cache_dir" gitleaks
+    chmod +x "$cache_dir/gitleaks"
+  fi
+  GITLEAKS_BIN="$cache_dir/gitleaks"
+}
+
+ensure_trufflehog() {
+  if [[ -n "${TRUFFLEHOG_BIN:-}" ]]; then
+    return
+  fi
+  if command -v trufflehog >/dev/null 2>&1; then
+    TRUFFLEHOG_BIN="$(command -v trufflehog)"
+    return
+  fi
+
+  local os arch cache_dir tarball
+  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64) arch="amd64" ;;
+    aarch64 | arm64) arch="arm64" ;;
+  esac
+  cache_dir="${TMPDIR:-/tmp}/trufflehog-${TRUFFLEHOG_VERSION}"
+  mkdir -p "$cache_dir"
+  tarball="trufflehog_${TRUFFLEHOG_VERSION}_${os}_${arch}.tar.gz"
+  if [[ ! -x "$cache_dir/trufflehog" ]]; then
+    curl -sSfL "https://github.com/trufflesecurity/trufflehog/releases/download/v${TRUFFLEHOG_VERSION}/${tarball}" \
+      | tar -xz -C "$cache_dir" trufflehog
+    chmod +x "$cache_dir/trufflehog"
+  fi
+  TRUFFLEHOG_BIN="$cache_dir/trufflehog"
+}
+
+trufflehog_exclude_args() {
+  if [[ -f "$EXCLUDE_PATHS" ]]; then
+    printf '%s' "--exclude-paths=$EXCLUDE_PATHS"
+  fi
+}
+
+run_gitleaks_pre_commit() {
+  echo "Running gitleaks protect on staged changes..."
+  "$GITLEAKS_BIN" protect \
+    --staged \
+    --config "$REPO_ROOT/.gitleaks.toml" \
+    --verbose
+}
+
+run_gitleaks_ci_pr() {
+  echo "Running gitleaks detect on ${BASE_REF}..HEAD..."
+  "$GITLEAKS_BIN" detect \
+    --source "$REPO_ROOT" \
+    --config "$REPO_ROOT/.gitleaks.toml" \
+    --log-opts="${BASE_REF}..HEAD" \
+    --verbose
+}
+
+run_gitleaks_full() {
+  echo "Running gitleaks detect on full git history..."
+  "$GITLEAKS_BIN" detect \
+    --source "$REPO_ROOT" \
+    --config "$REPO_ROOT/.gitleaks.toml" \
+    --verbose
+}
+
+is_trufflehog_excluded() {
+  local file="$1"
+  if [[ ! -f "$EXCLUDE_PATHS" ]]; then
+    return 1
+  fi
+  while IFS= read -r excluded || [[ -n "$excluded" ]]; do
+    [[ -z "$excluded" || "$excluded" == \#* ]] && continue
+    if [[ "$file" == "$excluded" || "${file#./}" == "$excluded" ]]; then
+      return 0
+    fi
+  done < "$EXCLUDE_PATHS"
+  return 1
+}
+
+run_trufflehog_pre_commit() {
+  local -a staged_files=()
+  local file
+
+  while IFS= read -r file; do
+    if [[ -n "$file" && -f "$file" ]] && ! is_trufflehog_excluded "$file"; then
+      staged_files+=("$file")
+    fi
+  done < <(git diff --cached --name-only --diff-filter=ACMR)
+
+  if [[ ${#staged_files[@]} -eq 0 ]]; then
+    echo "No staged files for trufflehog filesystem scan."
+    return
+  fi
+
+  echo "Running trufflehog filesystem on ${#staged_files[@]} staged file(s)..."
+  # shellcheck disable=SC2048,SC2086
+  "$TRUFFLEHOG_BIN" filesystem \
+    ${staged_files[@]} \
+    --no-verification \
+    --fail \
+    $(trufflehog_exclude_args)
+}
+
+run_trufflehog_ci_pr() {
+  local base_commit
+  base_commit="$(git rev-parse "$BASE_REF")"
+
+  echo "Running trufflehog git since ${BASE_REF} (${base_commit})..."
+  # shellcheck disable=SC2046
+  "$TRUFFLEHOG_BIN" git file://"$REPO_ROOT" \
+    --since-commit "$base_commit" \
+    --branch HEAD \
+    --no-verification \
+    --fail \
+    $(trufflehog_exclude_args)
+}
+
+run_trufflehog_full() {
+  echo "Running trufflehog git on full history..."
+  # shellcheck disable=SC2046
+  "$TRUFFLEHOG_BIN" git file://"$REPO_ROOT" \
+    --no-verification \
+    --fail \
+    $(trufflehog_exclude_args)
+}
+
+usage() {
+  echo "Usage: $0 {pre-commit|ci-pr|full} [base-ref]" >&2
+  exit 1
+}
+
+ensure_gitleaks
+ensure_trufflehog
+
+case "$MODE" in
+  pre-commit)
+    run_gitleaks_pre_commit
+    run_trufflehog_pre_commit
+    ;;
+  ci-pr)
+    run_gitleaks_ci_pr
+    run_trufflehog_ci_pr
+    ;;
+  full)
+    run_gitleaks_full
+    run_trufflehog_full
+    ;;
+  *)
+    usage
+    ;;
+esac
+
+echo "PASS: secret scan (${MODE}) completed with no findings"

--- a/scripts/security/verify-gitleaks-coverage.sh
+++ b/scripts/security/verify-gitleaks-coverage.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Verify gitleaks detects Neon + Clerk secret shapes (JOV-2940 acceptance criterion).
+# Verify gitleaks detects Neon + Clerk leak shapes and *.backup files (JOV-2940 / JOV-3215).
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -16,7 +16,7 @@ if [[ -z "$GITLEAKS_BIN" ]]; then
     ARCH="$(uname -m)"
     case "$ARCH" in
       x86_64) ARCH="x64" ;;
-      aarch64|arm64) ARCH="arm64" ;;
+      aarch64 | arm64) ARCH="arm64" ;;
     esac
     CACHE_DIR="${TMPDIR:-/tmp}/gitleaks-${VERSION}"
     mkdir -p "$CACHE_DIR"
@@ -30,31 +30,45 @@ if [[ -z "$GITLEAKS_BIN" ]]; then
   fi
 fi
 
+run_fixture_scan() {
+  local fixture_src="$1"
+  local fixture_name="$2"
+  local expected_rules="$3"
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  cp "$fixture_src" "$tmp_dir/$fixture_name"
+
+  echo "Running gitleaks on intentional fixture $fixture_name (expect leaks found)..."
+  set +e
+  local output
+  output="$("$GITLEAKS_BIN" detect \
+    --source "$tmp_dir" \
+    --config "$REPO_ROOT/.gitleaks.toml" \
+    --no-git \
+    --verbose 2>&1)"
+  local status=$?
+  set -e
+  rm -rf "$tmp_dir"
+
+  if [[ $status -eq 0 ]]; then
+    echo "FAIL: gitleaks did not detect leaks in fixture file ($fixture_name)" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+
+  if ! echo "$output" | grep -qE "$expected_rules"; then
+    echo "FAIL: gitleaks reported leaks but not via expected rules for $fixture_name" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+
+  echo "PASS: gitleaks detected expected leak shapes in $fixture_name"
+}
+
 FIXTURE_SRC="$REPO_ROOT/scripts/security/gitleaks-fixture.txt"
-TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
-cp "$FIXTURE_SRC" "$TMP_DIR/leak-fixture.txt"
+BACKUP_FIXTURE_SRC="$REPO_ROOT/scripts/security/gitleaks-backup-fixture.txt"
 
-echo "Running gitleaks on intentional fixture (expect leaks found)..."
-set +e
-OUTPUT="$("$GITLEAKS_BIN" detect \
-  --source "$TMP_DIR" \
-  --config "$REPO_ROOT/.gitleaks.toml" \
-  --no-git \
-  --verbose 2>&1)"
-STATUS=$?
-set -e
+run_fixture_scan "$FIXTURE_SRC" "leak-fixture.txt" "neon-postgres-connection-string|clerk-secret-key"
+run_fixture_scan "$BACKUP_FIXTURE_SRC" "settings.local.json.backup" "neon-postgres-connection-string|clerk-secret-key"
 
-if [[ $STATUS -eq 0 ]]; then
-  echo "FAIL: gitleaks did not detect leaks in fixture file" >&2
-  echo "$OUTPUT" >&2
-  exit 1
-fi
-
-if ! echo "$OUTPUT" | grep -q "neon-postgres-connection-string\|clerk-secret-key"; then
-  echo "FAIL: gitleaks reported leaks but not via JOV-2940 custom rules" >&2
-  echo "$OUTPUT" >&2
-  exit 1
-fi
-
-echo "PASS: gitleaks detected Neon and Clerk leak shapes in fixture"
+echo "PASS: gitleaks coverage verification complete"


### PR DESCRIPTION
## Summary

Hardens CI and pre-commit secret scanning after JOV-2940, where credentials in `.claude/settings.local.json.backup` were missed.

- **Audit/fix gitleaks gaps**: tightened allowlist path anchors (no broad `docs/*.md`); backup files (`*.backup`, `*.bak`) are explicitly not allowlisted
- **Defense-in-depth**: added TruffleHog alongside Gitleaks
- **Coverage**: secret scans now run at **pre-commit**, **PR CI**, **push-to-main**, and **weekly schedule** (full history via `security.yml`)

## Acceptance

- [x] Planted test secret in backup-file fixture is caught by gitleaks (verify script copies to `settings.local.json.backup`)
- [x] Pre-commit blocks force-added `*.backup` secrets (tested locally)
- [x] Full-history scan wired via `security.yml` (gitleaks-action + trufflehog on schedule/workflow_dispatch)
- [x] No credential rotation or history purge (human-only per issue scope)

## Linear

https://linear.app/jovie/issue/JOV-3215/ci-secret-scanning-hardening-post-jov-2940

<!-- linear-issue-id:JOV-3215 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened secret scanning verification by combining gitleaks and TruffleHog runs and expanding fixture/backup coverage checks to ensure expected detections occur.

* **Chores**
  * Added an automated secrets scan to the pre-commit workflow.
  * Expanded CI security coverage for pull requests (main), including an additional secret-scan lane that blocks downstream CI summaries until finished.
  * Added npm scripts to run secret scanning and validate scan coverage.
  * Refined secret-scan allowlists and path exclusion behavior to reduce false allowance masking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Gate Evidence

<!-- agent-run-artifact
{
  "id": "run-gstack-pr-10971",
  "source": "github",
  "sourceRunId": "28203205d31da097aa69d33d8c5b13059550847a",
  "kind": "qa",
  "status": "done",
  "title": "GStack gates",
  "summary": "Orchestrator-recorded GStack gate evidence for agent PR landing.",
  "modelRoute": "deterministic",
  "allowedActions": [
    "read"
  ],
  "forbiddenActions": [
    "merge",
    "deploy"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-3215",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-3215/ci-secret-scanning-hardening-post-jov-2940",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/10971",
  "adminSurface": "/app/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/qa --exhaustive passed (orchestrator wave 1)",
      "checkedAt": "2026-06-16T17:57:33.538Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/review passed (orchestrator wave 1)",
      "checkedAt": "2026-06-16T17:57:33.538Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/ship passed (orchestrator wave 1)",
      "checkedAt": "2026-06-16T17:57:33.538Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-06-16T17:57:33.538Z",
  "updatedAt": "2026-06-16T17:57:33.538Z",
  "metadata": {}
}
-->
