### PR TITLE
fix(analytics): align audience visit tracking with schema (JOV-3178)

### DIFF
--- a/apps/web/app/api/audience/visit/route.ts
+++ b/apps/web/app/api/audience/visit/route.ts
@@ -15,8 +15,9 @@ import {
   db,
   doesColumnExist,
   doesTableExist,
+  invalidateColumnExistenceCache,
 } from '@/lib/db';
-import { unwrapPgError } from '@/lib/db/errors';
+import { isMissingColumnError, unwrapPgError } from '@/lib/db/errors';
 import {
   audienceMembers,
   audienceReferrers,
@@ -61,6 +62,74 @@ interface AudienceVisitSchemaCompatibility {
   hasAudienceReferrersTable: boolean;
   hasCreatorDistributionEventsTable: boolean;
   hasDailyProfileViewsTable: boolean;
+}
+
+const AUDIENCE_MEMBER_SUMMARY_COLUMNS = [
+  'latest_referrer_url',
+  'latest_action_label',
+] as const;
+
+type AudienceMemberSummaryColumn =
+  (typeof AUDIENCE_MEMBER_SUMMARY_COLUMNS)[number];
+
+function getMissingAudienceMemberSummaryColumn(
+  error: unknown
+): AudienceMemberSummaryColumn | null {
+  for (const columnName of AUDIENCE_MEMBER_SUMMARY_COLUMNS) {
+    if (isMissingColumnError(error, columnName)) {
+      return columnName;
+    }
+  }
+
+  return null;
+}
+
+function downgradeAudienceVisitSchemaCompatibility(
+  compatibility: AudienceVisitSchemaCompatibility,
+  missingColumn: AudienceMemberSummaryColumn
+): AudienceVisitSchemaCompatibility {
+  if (missingColumn === 'latest_referrer_url') {
+    return {
+      ...compatibility,
+      hasAudienceMemberLatestReferrerUrlColumn: false,
+    };
+  }
+
+  return {
+    ...compatibility,
+    hasAudienceMemberLatestActionLabelColumn: false,
+  };
+}
+
+async function persistAudienceVisitWithSchemaFallback(
+  initialCompatibility: AudienceVisitSchemaCompatibility,
+  persist: (compatibility: AudienceVisitSchemaCompatibility) => Promise<void>
+): Promise<void> {
+  let compatibility = initialCompatibility;
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      await persist(compatibility);
+      return;
+    } catch (error) {
+      const missingColumn = getMissingAudienceMemberSummaryColumn(error);
+      if (attempt > 0 || !missingColumn) {
+        throw error;
+      }
+
+      invalidateColumnExistenceCache('audience_members', missingColumn);
+      compatibility = downgradeAudienceVisitSchemaCompatibility(
+        compatibility,
+        missingColumn
+      );
+
+      await captureWarning(
+        '[audience/visit] audience_members summary column missing; retrying without optional column writes',
+        error,
+        { column: missingColumn }
+      );
+    }
+  }
 }
 
 async function resolveAudienceVisitSchemaCompatibility(): Promise<AudienceVisitSchemaCompatibility> {
@@ -514,192 +583,198 @@ export async function POST(request: NextRequest) {
 
     const schemaCompatibility = await resolveAudienceVisitSchemaCompatibility();
 
-    await withSystemIngestionSession(async tx => {
-      const viewDate = now.toISOString().slice(0, 10);
+    await persistAudienceVisitWithSchemaFallback(
+      schemaCompatibility,
+      async compatibility => {
+        await withSystemIngestionSession(async tx => {
+          const viewDate = now.toISOString().slice(0, 10);
 
-      const [existing] = await tx
-        .select({
-          id: audienceMembers.id,
-          visits: audienceMembers.visits,
-          latestActions: audienceMembers.latestActions,
-          referrerHistory: audienceMembers.referrerHistory,
-          engagementScore: audienceMembers.engagementScore,
-          geoCity: audienceMembers.geoCity,
-          geoCountry: audienceMembers.geoCountry,
-          deviceType: audienceMembers.deviceType,
-          utmParams: audienceMembers.utmParams,
-          tags: audienceMembers.tags,
-        })
-        .from(audienceMembers)
-        .where(
-          and(
-            eq(audienceMembers.creatorProfileId, profileId),
-            eq(audienceMembers.fingerprint, fingerprint)
-          )
-        )
-        .limit(1);
+          const [existing] = await tx
+            .select({
+              id: audienceMembers.id,
+              visits: audienceMembers.visits,
+              latestActions: audienceMembers.latestActions,
+              referrerHistory: audienceMembers.referrerHistory,
+              engagementScore: audienceMembers.engagementScore,
+              geoCity: audienceMembers.geoCity,
+              geoCountry: audienceMembers.geoCountry,
+              deviceType: audienceMembers.deviceType,
+              utmParams: audienceMembers.utmParams,
+              tags: audienceMembers.tags,
+            })
+            .from(audienceMembers)
+            .where(
+              and(
+                eq(audienceMembers.creatorProfileId, profileId),
+                eq(audienceMembers.fingerprint, fingerprint)
+              )
+            )
+            .limit(1);
 
-      const mergedTags = mergeAudienceTags(existing?.tags, audienceTags);
-      const isBotAudienceMember = mergedTags.includes('bot');
-      const updatedVisits = isBotAudienceMember
-        ? (existing?.visits ?? 0)
-        : (existing?.visits ?? 0) + 1;
-      const actionCount = Array.isArray(existing?.latestActions)
-        ? existing.latestActions.length
-        : 0;
-      const updatedIntent = isBotAudienceMember
-        ? 'low'
-        : deriveIntentLevel(updatedVisits, actionCount);
-      const updatedScore = isBotAudienceMember
-        ? (existing?.engagementScore ?? 0)
-        : (existing?.engagementScore ?? 0) + 1;
-      const previousReferrers = Array.isArray(existing?.referrerHistory)
-        ? existing.referrerHistory
-        : [];
-      const referrerHistory = trimHistory(
-        [...referrerEntry, ...previousReferrers],
-        3
-      );
-      const geoCityValue = resolvedGeoCity ?? existing?.geoCity ?? null;
-      const geoCountryValue =
-        resolvedGeoCountry ?? existing?.geoCountry ?? null;
+          const mergedTags = mergeAudienceTags(existing?.tags, audienceTags);
+          const isBotAudienceMember = mergedTags.includes('bot');
+          const updatedVisits = isBotAudienceMember
+            ? (existing?.visits ?? 0)
+            : (existing?.visits ?? 0) + 1;
+          const actionCount = Array.isArray(existing?.latestActions)
+            ? existing.latestActions.length
+            : 0;
+          const updatedIntent = isBotAudienceMember
+            ? 'low'
+            : deriveIntentLevel(updatedVisits, actionCount);
+          const updatedScore = isBotAudienceMember
+            ? (existing?.engagementScore ?? 0)
+            : (existing?.engagementScore ?? 0) + 1;
+          const previousReferrers = Array.isArray(existing?.referrerHistory)
+            ? existing.referrerHistory
+            : [];
+          const referrerHistory = trimHistory(
+            [...referrerEntry, ...previousReferrers],
+            3
+          );
+          const geoCityValue = resolvedGeoCity ?? existing?.geoCity ?? null;
+          const geoCountryValue =
+            resolvedGeoCountry ?? existing?.geoCountry ?? null;
 
-      // Merge UTM params: new visit's UTM overwrites if present, else keep existing
-      const hasUtmParams =
-        !!utmParams &&
-        Object.values(utmParams).some(
-          value => typeof value === 'string' && value.length > 0
-        );
-      const resolvedUtmParams = hasUtmParams
-        ? utmParams
-        : (existing?.utmParams ?? {});
-      const instagramReferrerHost = getInstagramReferrerHost(resolvedReferrer);
+          // Merge UTM params: new visit's UTM overwrites if present, else keep existing
+          const hasUtmParams =
+            !!utmParams &&
+            Object.values(utmParams).some(
+              value => typeof value === 'string' && value.length > 0
+            );
+          const resolvedUtmParams = hasUtmParams
+            ? utmParams
+            : (existing?.utmParams ?? {});
+          const instagramReferrerHost =
+            getInstagramReferrerHost(resolvedReferrer);
 
-      if (
-        schemaCompatibility.hasDailyProfileViewsTable &&
-        !isBotAudienceMember
-      ) {
-        await writeDailyProfileViews(tx, profileId, viewDate, now);
-      }
-
-      if (
-        schemaCompatibility.hasCreatorDistributionEventsTable &&
-        shouldTrackInstagramActivation &&
-        !isBotAudienceMember
-      ) {
-        await writeInstagramActivation(
-          tx,
-          profileId,
-          instagramReferrerHost,
-          utmParams,
-          now
-        );
-      }
-
-      // Summary column value for fast list views
-      const latestReferrerUrl = resolvedReferrer?.trim() ?? null;
-      const recordProfileVisitEvent = async (audienceMemberId: string) => {
-        if (!schemaCompatibility.canWriteAudienceActions) return;
-
-        await recordAudienceEvent(
-          tx,
-          {
-            creatorProfileId: profileId,
-            audienceMemberId,
-            eventType: 'profile_visited',
-            verb: 'visited',
-            confidence: 'observed',
-            sourceKind: resolveVisitSourceKind(utmParams, latestReferrerUrl),
-            sourceLabel: resolveVisitSourceLabel(utmParams, latestReferrerUrl),
-            objectType: 'profile',
-            objectId: profileId,
-            objectLabel: 'Profile',
-            properties: {
-              referrer: latestReferrerUrl,
-              utmParams: resolvedUtmParams,
-            },
-            timestamp: now,
-          },
-          {
-            includeLatestActionLabel:
-              schemaCompatibility.hasAudienceMemberLatestActionLabelColumn,
+          if (compatibility.hasDailyProfileViewsTable && !isBotAudienceMember) {
+            await writeDailyProfileViews(tx, profileId, viewDate, now);
           }
-        );
-      };
 
-      if (existing) {
-        await tx
-          .update(audienceMembers)
-          .set({
-            visits: updatedVisits,
-            lastSeenAt: now,
-            updatedAt: now,
-            engagementScore: updatedScore,
-            intentLevel: updatedIntent,
-            geoCity: geoCityValue,
-            geoCountry: geoCountryValue,
-            deviceType: normalizedDevice,
-            referrerHistory,
-            tags: mergedTags,
-            ...(schemaCompatibility.hasAudienceMemberLatestReferrerUrlColumn &&
-              latestReferrerUrl && { latestReferrerUrl }),
-            ...(utmParams && { utmParams: resolvedUtmParams }),
-          })
-          .where(eq(audienceMembers.id, existing.id));
+          if (
+            compatibility.hasCreatorDistributionEventsTable &&
+            shouldTrackInstagramActivation &&
+            !isBotAudienceMember
+          ) {
+            await writeInstagramActivation(
+              tx,
+              profileId,
+              instagramReferrerHost,
+              utmParams,
+              now
+            );
+          }
 
-        if (
-          schemaCompatibility.hasAudienceReferrersTable &&
-          latestReferrerUrl
-        ) {
-          await writeReferrer(tx, existing.id, latestReferrerUrl, now);
-        }
-        await recordProfileVisitEvent(existing.id);
-        return;
+          // Summary column value for fast list views
+          const latestReferrerUrl = resolvedReferrer?.trim() ?? null;
+          const recordProfileVisitEvent = async (audienceMemberId: string) => {
+            if (!compatibility.canWriteAudienceActions) return;
+
+            await recordAudienceEvent(
+              tx,
+              {
+                creatorProfileId: profileId,
+                audienceMemberId,
+                eventType: 'profile_visited',
+                verb: 'visited',
+                confidence: 'observed',
+                sourceKind: resolveVisitSourceKind(
+                  utmParams,
+                  latestReferrerUrl
+                ),
+                sourceLabel: resolveVisitSourceLabel(
+                  utmParams,
+                  latestReferrerUrl
+                ),
+                objectType: 'profile',
+                objectId: profileId,
+                objectLabel: 'Profile',
+                properties: {
+                  referrer: latestReferrerUrl,
+                  utmParams: resolvedUtmParams,
+                },
+                timestamp: now,
+              },
+              {
+                includeLatestActionLabel:
+                  compatibility.hasAudienceMemberLatestActionLabelColumn,
+              }
+            );
+          };
+
+          if (existing) {
+            await tx
+              .update(audienceMembers)
+              .set({
+                visits: updatedVisits,
+                lastSeenAt: now,
+                updatedAt: now,
+                engagementScore: updatedScore,
+                intentLevel: updatedIntent,
+                geoCity: geoCityValue,
+                geoCountry: geoCountryValue,
+                deviceType: normalizedDevice,
+                referrerHistory,
+                tags: mergedTags,
+                ...(compatibility.hasAudienceMemberLatestReferrerUrlColumn &&
+                  latestReferrerUrl && { latestReferrerUrl }),
+                ...(utmParams && { utmParams: resolvedUtmParams }),
+              })
+              .where(eq(audienceMembers.id, existing.id));
+
+            if (compatibility.hasAudienceReferrersTable && latestReferrerUrl) {
+              await writeReferrer(tx, existing.id, latestReferrerUrl, now);
+            }
+            await recordProfileVisitEvent(existing.id);
+            return;
+          }
+
+          const [inserted] = await tx
+            .insert(audienceMembers)
+            .values({
+              creatorProfileId: profileId,
+              fingerprint,
+              type: 'anonymous',
+              displayName: 'Visitor',
+              firstSeenAt: now,
+              lastSeenAt: now,
+              visits: updatedVisits,
+              engagementScore: updatedScore,
+              intentLevel: updatedIntent,
+              geoCity: geoCityValue,
+              geoCountry: geoCountryValue,
+              deviceType: normalizedDevice,
+              referrerHistory,
+              utmParams: resolvedUtmParams,
+              tags: mergedTags,
+              latestActions: [],
+              ...(compatibility.hasAudienceMemberLatestReferrerUrlColumn &&
+                latestReferrerUrl && { latestReferrerUrl }),
+              updatedAt: now,
+              createdAt: now,
+            })
+            .onConflictDoNothing({
+              target: [
+                audienceMembers.creatorProfileId,
+                audienceMembers.fingerprint,
+              ],
+            })
+            .returning({ id: audienceMembers.id });
+
+          if (
+            inserted &&
+            compatibility.hasAudienceReferrersTable &&
+            latestReferrerUrl
+          ) {
+            await writeReferrer(tx, inserted.id, latestReferrerUrl, now);
+          }
+          if (inserted) {
+            await recordProfileVisitEvent(inserted.id);
+          }
+        });
       }
-
-      const [inserted] = await tx
-        .insert(audienceMembers)
-        .values({
-          creatorProfileId: profileId,
-          fingerprint,
-          type: 'anonymous',
-          displayName: 'Visitor',
-          firstSeenAt: now,
-          lastSeenAt: now,
-          visits: updatedVisits,
-          engagementScore: updatedScore,
-          intentLevel: updatedIntent,
-          geoCity: geoCityValue,
-          geoCountry: geoCountryValue,
-          deviceType: normalizedDevice,
-          referrerHistory,
-          utmParams: resolvedUtmParams,
-          tags: mergedTags,
-          latestActions: [],
-          ...(schemaCompatibility.hasAudienceMemberLatestReferrerUrlColumn &&
-            latestReferrerUrl && { latestReferrerUrl }),
-          updatedAt: now,
-          createdAt: now,
-        })
-        .onConflictDoNothing({
-          target: [
-            audienceMembers.creatorProfileId,
-            audienceMembers.fingerprint,
-          ],
-        })
-        .returning({ id: audienceMembers.id });
-
-      if (
-        inserted &&
-        schemaCompatibility.hasAudienceReferrersTable &&
-        latestReferrerUrl
-      ) {
-        await writeReferrer(tx, inserted.id, latestReferrerUrl, now);
-      }
-      if (inserted) {
-        await recordProfileVisitEvent(inserted.id);
-      }
-    });
+    );
 
     return NextResponse.json(
       { success: true, fingerprint },

--- a/apps/web/lib/db/client/health.ts
+++ b/apps/web/lib/db/client/health.ts
@@ -134,6 +134,17 @@ export async function doesTableExist(tableName: string): Promise<boolean> {
 }
 
 /**
+ * Drop a cached column-existence result so the next lookup re-queries
+ * information_schema. Used when a write fails with undefined_column (42703).
+ */
+export function invalidateColumnExistenceCache(
+  tableName: string,
+  columnName: string
+): void {
+  columnExistenceCache.delete(`${tableName}.${columnName}`);
+}
+
+/**
  * Check if a column exists in a public table.
  * Uses the same TTL cache, retry, and timeout policy as doesTableExist so
  * public routes can avoid issuing schema-incompatible writes during rollout.
@@ -188,7 +199,14 @@ export async function doesColumnExist(
     const firstRow = result.rows[0];
     const exists = isColumnExistsRow(firstRow) ? firstRow.column_exists : false;
 
-    columnExistenceCache.set(cacheKey, { exists, timestamp: Date.now() });
+    // Only cache negative results. A stale positive cache can survive schema
+    // rollbacks/restores that share the same DATABASE_URL and cause public
+    // routes to write columns that no longer exist (JOV-3178).
+    if (!exists) {
+      columnExistenceCache.set(cacheKey, { exists, timestamp: Date.now() });
+    } else {
+      columnExistenceCache.delete(cacheKey);
+    }
 
     return exists;
   } catch (error) {

--- a/apps/web/lib/db/client/index.ts
+++ b/apps/web/lib/db/client/index.ts
@@ -25,6 +25,7 @@ export {
   doesColumnExist,
   doesTableExist,
   getDbConfig,
+  invalidateColumnExistenceCache,
   validateDbConnection,
 } from './health';
 // Logging

--- a/apps/web/lib/db/errors.ts
+++ b/apps/web/lib/db/errors.ts
@@ -109,3 +109,34 @@ export function isUniqueViolation(
     (pg.detail ?? '').includes(constraint)
   );
 }
+
+/**
+ * Check whether an error (possibly Drizzle-wrapped) is a PostgreSQL
+ * undefined_column error (42703).
+ */
+export function isUndefinedColumnError(error: unknown): boolean {
+  return unwrapPgError(error).code === '42703';
+}
+
+/**
+ * Check whether an error references a specific missing column name.
+ * Matches both quoted (`"column_name"`) and unquoted forms in PG messages.
+ */
+export function isMissingColumnError(
+  error: unknown,
+  columnName: string
+): boolean {
+  const message = getDeepErrorMessage(error).toLowerCase();
+  const normalizedColumn = columnName.toLowerCase();
+
+  const mentionsColumn =
+    message.includes(`"${normalizedColumn}"`) ||
+    message.includes(`column ${normalizedColumn}`) ||
+    message.includes(`column "${normalizedColumn}"`);
+
+  if (!mentionsColumn) {
+    return false;
+  }
+
+  return isUndefinedColumnError(error) || message.includes('does not exist');
+}

--- a/apps/web/lib/db/index.ts
+++ b/apps/web/lib/db/index.ts
@@ -40,6 +40,7 @@ export {
   getRlsSessionResetSql,
   getRlsSessionSetSql,
   initializeDb,
+  invalidateColumnExistenceCache,
   isRetryableError,
   resetRlsSession,
   setSessionUser,

--- a/apps/web/tests/unit/api/audience/visit.test.ts
+++ b/apps/web/tests/unit/api/audience/visit.test.ts
@@ -8,6 +8,7 @@ const mockDetectBot = vi.hoisted(() => vi.fn());
 const mockDbSelect = vi.hoisted(() => vi.fn());
 const mockDoesColumnExist = vi.hoisted(() => vi.fn());
 const mockDoesTableExist = vi.hoisted(() => vi.fn());
+const mockInvalidateColumnExistenceCache = vi.hoisted(() => vi.fn());
 const mockWithSystemIngestionSession = vi.hoisted(() => vi.fn());
 const mockCheckVisitRateLimit = vi.hoisted(() => vi.fn());
 const mockIsTrackingTokenEnabled = vi.hoisted(() => vi.fn());
@@ -34,6 +35,7 @@ vi.mock('@/lib/db', () => ({
   },
   doesColumnExist: mockDoesColumnExist,
   doesTableExist: mockDoesTableExist,
+  invalidateColumnExistenceCache: mockInvalidateColumnExistenceCache,
 }));
 
 vi.mock('@/lib/db/schema', () => ({
@@ -626,6 +628,90 @@ describe('POST /api/audience/visit', () => {
         includeLatestActionLabel: false,
       })
     );
+    expect(mockCaptureError).not.toHaveBeenCalled();
+  });
+
+  it('retries visit persistence when stale column cache causes summary column writes', async () => {
+    mockDoesColumnExist.mockResolvedValue(true);
+    mockDoesTableExist.mockResolvedValue(true);
+    mockDbSelect.mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi
+            .fn()
+            .mockResolvedValue([{ id: 'profile_123', isPublic: true }]),
+        }),
+      }),
+    });
+
+    const insertedValues: Record<string, unknown>[] = [];
+    let sessionAttempt = 0;
+    mockWithSystemIngestionSession.mockImplementation(async callback => {
+      sessionAttempt += 1;
+
+      if (sessionAttempt === 1) {
+        throw new Error('column "latest_referrer_url" does not exist');
+      }
+
+      const mockInsert = vi.fn().mockReturnValue({
+        values: vi
+          .fn()
+          .mockReturnValueOnce({
+            onConflictDoUpdate: vi.fn().mockResolvedValue(undefined),
+          })
+          .mockImplementation((value: Record<string, unknown>) => {
+            insertedValues.push(value);
+            return {
+              onConflictDoNothing: vi.fn().mockReturnValue({
+                returning: vi
+                  .fn()
+                  .mockResolvedValue([{ id: 'inserted_member' }]),
+              }),
+            };
+          }),
+      });
+
+      await callback({
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue({
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+        insert: mockInsert,
+      });
+    });
+
+    const request = new NextRequest('http://localhost/api/audience/visit', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        profileId: '123e4567-e89b-12d3-a456-426614174000',
+        referrer: 'https://example.com/profile',
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+    const audienceMemberInsert = insertedValues.find(
+      value => value.type === 'anonymous'
+    );
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(sessionAttempt).toBe(2);
+    expect(mockInvalidateColumnExistenceCache).toHaveBeenCalledWith(
+      'audience_members',
+      'latest_referrer_url'
+    );
+    expect(mockCaptureWarning).toHaveBeenCalledWith(
+      '[audience/visit] audience_members summary column missing; retrying without optional column writes',
+      expect.any(Error),
+      { column: 'latest_referrer_url' }
+    );
+    expect(audienceMemberInsert).toBeDefined();
+    expect(audienceMemberInsert).not.toHaveProperty('latestReferrerUrl');
     expect(mockCaptureError).not.toHaveBeenCalled();
   });
 

--- a/apps/web/tests/unit/lib/db/errors.test.ts
+++ b/apps/web/tests/unit/lib/db/errors.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   getDeepErrorMessage,
+  isMissingColumnError,
+  isUndefinedColumnError,
   isUniqueViolation,
   unwrapPgError,
 } from '@/lib/db/errors';
@@ -120,6 +122,54 @@ describe('getDeepErrorMessage', () => {
   it('returns plain message for unwrapped errors', () => {
     const error = new Error('something broke');
     expect(getDeepErrorMessage(error)).toBe('something broke');
+  });
+});
+
+describe('isUndefinedColumnError', () => {
+  it('detects raw PG undefined_column errors', () => {
+    const error = Object.assign(
+      new Error('column "latest_referrer_url" does not exist'),
+      {
+        code: '42703',
+      }
+    );
+
+    expect(isUndefinedColumnError(error)).toBe(true);
+  });
+
+  it('detects Drizzle-wrapped undefined_column errors', () => {
+    const pgError = Object.assign(
+      new Error('column "latest_action_label" does not exist'),
+      { code: '42703' }
+    );
+    const drizzleError = new Error(
+      'Failed query: update "audience_members"...'
+    );
+    drizzleError.cause = pgError;
+
+    expect(isUndefinedColumnError(drizzleError)).toBe(true);
+  });
+});
+
+describe('isMissingColumnError', () => {
+  it('matches a specific missing column in wrapped errors', () => {
+    const pgError = Object.assign(
+      new Error(
+        'column "latest_referrer_url" of relation "audience_members" does not exist'
+      ),
+      { code: '42703' }
+    );
+    const drizzleError = new Error(
+      'Failed query: update "audience_members"...'
+    );
+    drizzleError.cause = pgError;
+
+    expect(isMissingColumnError(drizzleError, 'latest_referrer_url')).toBe(
+      true
+    );
+    expect(isMissingColumnError(drizzleError, 'latest_action_label')).toBe(
+      false
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes `POST /api/audience/visit` returning 500 in dev when `audience_members.latest_referrer_url` (and related summary columns) are missing from the database schema.

## Root cause
Migration `0030_normalize_audience_jsonb.sql` adds `latest_referrer_url` and `latest_action_label`, but dev databases can lag behind. A prior guard (#8705) skipped optional columns via `doesColumnExist`, but a **stale positive column-existence cache** (60s TTL, only cleared on `DATABASE_URL` change) could still allow writes to columns that no longer exist after schema rollback/restore.

## Fix
- Only cache **negative** `doesColumnExist` results to avoid stale positives
- Add `invalidateColumnExistenceCache()` and call it when a 42703 missing-column error is detected
- Retry visit persistence once with optional `audience_members` summary columns disabled
- Add `isMissingColumnError` / `isUndefinedColumnError` helpers for robust PG error detection

## Migration note
`apps/web/drizzle/migrations/0030_normalize_audience_jsonb.sql` already defines the missing columns. Applying migrations to dev will restore full functionality; this change keeps visit tracking working until then.

## Verification
- `pnpm --filter @jovie/web run typecheck -- --pretty false`
- `pnpm biome check --write <edited files>`
- `pnpm --filter web exec vitest run tests/unit/api/audience/visit.test.ts tests/unit/lib/db/errors.test.ts` (38 passed)

Linear: https://linear.app/jovie/issue/JOV-3178/public-profile-visit-tracking-still-writes-missing-audience-members

<!-- linear-issue-id:JOV-3178 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audience-visit persistence reliability by adding schema-compatibility fallback when optional database columns are missing, including targeted cache invalidation and a one-time retry that safely omits unavailable fields.
  * Updated database column-existence caching to prevent stale “missing column” results after schema changes.
* **Tests**
  * Added unit coverage for the retry flow and for missing/undefined-column database error detection (including wrapped errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Agent Gate Evidence

<!-- agent-run-artifact
{
  "id": "run-gstack-pr-10972",
  "source": "github",
  "sourceRunId": "02bc21b8ca8bed8059094f0f0e9ec983be45732e",
  "kind": "qa",
  "status": "done",
  "title": "GStack gates",
  "summary": "Orchestrator-recorded GStack gate evidence for agent PR landing.",
  "modelRoute": "deterministic",
  "allowedActions": [
    "read"
  ],
  "forbiddenActions": [
    "merge",
    "deploy"
  ],
  "humanApprovalRequired": false,
  "humanGate": {
    "required": false,
    "status": "not_required",
    "reason": null,
    "reviewer": null,
    "reviewedAt": null
  },
  "linearIssueId": "JOV-3178",
  "linearIssueUrl": "https://linear.app/jovie/issue/JOV-3178/public-profile-visit-tracking-still-writes-missing-audience-members",
  "pullRequestUrl": "https://github.com/JovieInc/Jovie/pull/10972",
  "adminSurface": "/app/admin/ops",
  "verificationGates": [
    {
      "name": "gstack.qa.exhaustive",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/qa --exhaustive passed (orchestrator wave 1)",
      "checkedAt": "2026-06-16T17:57:35.944Z"
    },
    {
      "name": "gstack.review",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/review passed (orchestrator wave 1)",
      "checkedAt": "2026-06-16T17:57:35.944Z"
    },
    {
      "name": "gstack.ship",
      "required": true,
      "status": "passed",
      "evidenceUrl": null,
      "summary": "/ship passed (orchestrator wave 1)",
      "checkedAt": "2026-06-16T17:57:35.944Z"
    }
  ],
  "costEstimate": {
    "usd": 0,
    "route": "deterministic",
    "inputTokens": 0,
    "outputTokens": 0,
    "notes": null
  },
  "blockedReason": null,
  "createdAt": "2026-06-16T17:57:35.944Z",
  "updatedAt": "2026-06-16T17:57:35.944Z",
  "metadata": {}
}
-->
