### PR TITLE
fix(connectors): degrade gracefully when workflow tables are missing (JOV-3125)

### DIFF
--- a/apps/web/app/api/cron/process-workflow-runs/route.ts
+++ b/apps/web/app/api/cron/process-workflow-runs/route.ts
@@ -30,6 +30,7 @@
 
 import { and, eq, inArray, isNull, lt, lte, or } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
+import { isMissingConnectorWorkflowTablesError } from '@/lib/connectors/schema-errors';
 import {
   executeApprovedAction,
   markWorkflowFailed,
@@ -172,6 +173,13 @@ export async function GET(request: Request): Promise<Response> {
       failed,
     });
   } catch (err) {
+    if (isMissingConnectorWorkflowTablesError(err)) {
+      logger.info(
+        '[process-workflow-runs] connector workflow tables not migrated; skipping tick'
+      );
+      return NextResponse.json({ ok: true, processed: 0, skipped: true });
+    }
+
     // JOV-2326: a failed cron tick is self-healing — the next tick (6 min) will retry
     // any pending rows. Log at warn level to avoid Sentry noise from transient Neon
     // connection failures; escalate only if the error recurs persistently.

--- a/apps/web/app/app/(shell)/settings/connectors/connectors-data.ts
+++ b/apps/web/app/app/(shell)/settings/connectors/connectors-data.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { and, eq } from 'drizzle-orm';
 import type { ConnectorStatus } from '@/components/features/connectors/ConnectorCard';
 import { CONNECTOR_PROVIDERS } from '@/lib/connectors/registry';
+import { isMissingConnectorSchemaError } from '@/lib/connectors/schema-errors';
 import { db } from '@/lib/db';
 import { getUserByClerkId } from '@/lib/db/queries/shared';
 import {
@@ -69,6 +70,12 @@ function toConnectorState(row: ConnectorAccountRow | null) {
   };
 }
 
+const EMPTY_CONNECTORS_DATA: SettingsConnectorsData = {
+  gmail: { status: 'not_connected' },
+  calendar: { status: 'not_connected' },
+  suggestedActions: [],
+};
+
 export async function loadSettingsConnectorsData(
   clerkUserId: string
 ): Promise<SettingsConnectorsData | null> {
@@ -78,6 +85,19 @@ export async function loadSettingsConnectorsData(
     return null;
   }
 
+  try {
+    return await loadSettingsConnectorsDataForUser(dbUser.id);
+  } catch (error) {
+    if (isMissingConnectorSchemaError(error)) {
+      return EMPTY_CONNECTORS_DATA;
+    }
+    throw error;
+  }
+}
+
+async function loadSettingsConnectorsDataForUser(
+  userId: string
+): Promise<SettingsConnectorsData> {
   const [gmailRow, calendarRow] = await Promise.all([
     db
       .select({
@@ -88,7 +108,7 @@ export async function loadSettingsConnectorsData(
       .from(connectorAccounts)
       .where(
         and(
-          eq(connectorAccounts.userId, dbUser.id),
+          eq(connectorAccounts.userId, userId),
           eq(connectorAccounts.provider, CONNECTOR_PROVIDERS.gmail)
         )
       )
@@ -103,7 +123,7 @@ export async function loadSettingsConnectorsData(
       .from(connectorAccounts)
       .where(
         and(
-          eq(connectorAccounts.userId, dbUser.id),
+          eq(connectorAccounts.userId, userId),
           eq(connectorAccounts.provider, CONNECTOR_PROVIDERS.google_calendar)
         )
       )
@@ -122,7 +142,7 @@ export async function loadSettingsConnectorsData(
     .from(suggestedActions)
     .where(
       and(
-        eq(suggestedActions.userId, dbUser.id),
+        eq(suggestedActions.userId, userId),
         eq(suggestedActions.status, 'pending')
       )
     )

--- a/apps/web/lib/connectors/schema-errors.test.ts
+++ b/apps/web/lib/connectors/schema-errors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isMissingConnectorSchemaError,
+  isMissingConnectorWorkflowTablesError,
+} from './schema-errors';
+
+describe('isMissingConnectorWorkflowTablesError', () => {
+  it('returns true for Drizzle-wrapped missing suggested_actions relation', () => {
+    const error = new Error(
+      'Failed query: select "id", "user_id", "payload" from "suggested_actions" where "suggested_actions"."status" = $1 limit $2',
+      {
+        cause: {
+          code: '42P01',
+          message: 'relation "suggested_actions" does not exist',
+        },
+      }
+    );
+
+    expect(isMissingConnectorWorkflowTablesError(error)).toBe(true);
+  });
+
+  it('returns true for missing workflow_runs relation', () => {
+    const error = new Error('relation "workflow_runs" does not exist', {
+      cause: { code: '42P01' },
+    });
+
+    expect(isMissingConnectorWorkflowTablesError(error)).toBe(true);
+  });
+
+  it('returns false for unrelated missing relations', () => {
+    const error = new Error('relation "user_entitlements" does not exist', {
+      cause: { code: '42P01' },
+    });
+
+    expect(isMissingConnectorWorkflowTablesError(error)).toBe(false);
+  });
+});
+
+describe('isMissingConnectorSchemaError', () => {
+  it('returns true for missing connector_accounts relation', () => {
+    const error = new Error(
+      'Failed query: select "status" from "connector_accounts" where "connector_accounts"."user_id" = $1',
+      {
+        cause: {
+          code: '42P01',
+          message: 'relation "connector_accounts" does not exist',
+        },
+      }
+    );
+
+    expect(isMissingConnectorSchemaError(error)).toBe(true);
+  });
+});

--- a/apps/web/lib/connectors/schema-errors.ts
+++ b/apps/web/lib/connectors/schema-errors.ts
@@ -1,0 +1,52 @@
+import { getDeepErrorMessage, unwrapPgError } from '@/lib/db/errors';
+
+/** Connector v1 tables introduced in migration 0048 (JOV-2229). */
+export const CONNECTOR_SCHEMA_TABLES = [
+  'connector_accounts',
+  'suggested_actions',
+  'workflow_runs',
+] as const;
+
+function mentionsConnectorSchemaTable(message: string): boolean {
+  const normalized = message.toLowerCase();
+
+  return CONNECTOR_SCHEMA_TABLES.some(table => {
+    const quoted = `"${table}"`;
+    return (
+      normalized.includes(`relation ${quoted}`) ||
+      normalized.includes(`relation ${table}`) ||
+      normalized.includes(`from ${quoted}`) ||
+      normalized.includes(`from ${table}`)
+    );
+  });
+}
+
+/**
+ * True when Postgres reports a connector v1 table is missing (pre-migration).
+ * Drizzle surfaces these as "Failed query: select ... from suggested_actions".
+ */
+export function isMissingConnectorSchemaError(error: unknown): boolean {
+  const message = getDeepErrorMessage(error).toLowerCase();
+  if (
+    !message.includes('does not exist') &&
+    unwrapPgError(error).code !== '42P01'
+  ) {
+    return false;
+  }
+
+  return mentionsConnectorSchemaTable(message);
+}
+
+export function isMissingConnectorWorkflowTablesError(error: unknown): boolean {
+  const message = getDeepErrorMessage(error).toLowerCase();
+  if (
+    !message.includes('does not exist') &&
+    unwrapPgError(error).code !== '42P01'
+  ) {
+    return false;
+  }
+
+  return (
+    message.includes('suggested_actions') || message.includes('workflow_runs')
+  );
+}

--- a/apps/web/lib/connectors/workflows/reconcile-orphaned-approved-actions.test.ts
+++ b/apps/web/lib/connectors/workflows/reconcile-orphaned-approved-actions.test.ts
@@ -197,6 +197,26 @@ describe('reconcileOrphanedAcceptedActions', () => {
     vi.clearAllMocks();
   });
 
+  it('returns empty results when connector workflow tables are not migrated', async () => {
+    vi.mocked(db.select).mockImplementation(() => {
+      throw new Error(
+        'Failed query: select "id", "user_id", "payload" from "suggested_actions"',
+        {
+          cause: {
+            code: '42P01',
+            message: 'relation "suggested_actions" does not exist',
+          },
+        }
+      );
+    });
+
+    await expect(reconcileOrphanedAcceptedActions(20)).resolves.toEqual({
+      scanned: 0,
+      enqueued: 0,
+    });
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
   it('enqueues workflow runs for each orphaned accepted action', async () => {
     mockSelectChain([
       {

--- a/apps/web/lib/connectors/workflows/reconcile-orphaned-approved-actions.ts
+++ b/apps/web/lib/connectors/workflows/reconcile-orphaned-approved-actions.ts
@@ -7,6 +7,7 @@
  */
 
 import { and, sql as drizzleSql, eq, notExists } from 'drizzle-orm';
+import { isMissingConnectorWorkflowTablesError } from '@/lib/connectors/schema-errors';
 import { db } from '@/lib/db';
 import { suggestedActions, workflowRuns } from '@/lib/db/schema/connectors';
 import { logger } from '@/lib/utils/logger';
@@ -23,6 +24,8 @@ export type OrphanedApprovalRecoveryResult =
   | 'already-queued'
   | 'not-accepted'
   | 'not-found';
+
+const EMPTY_RECONCILE_RESULT = { scanned: 0, enqueued: 0 } as const;
 
 function workflowRunMissingForSuggestedAction() {
   return notExists(
@@ -66,97 +69,118 @@ export async function recoverOrphanedApprovedAction(input: {
   approvalId: string;
   userId: string;
 }): Promise<OrphanedApprovalRecoveryResult> {
-  const [action] = await db
-    .select({
-      id: suggestedActions.id,
-      status: suggestedActions.status,
-      userId: suggestedActions.userId,
-      payload: suggestedActions.payload,
-    })
-    .from(suggestedActions)
-    .where(eq(suggestedActions.id, input.approvalId))
-    .limit(1);
+  try {
+    const [action] = await db
+      .select({
+        id: suggestedActions.id,
+        status: suggestedActions.status,
+        userId: suggestedActions.userId,
+        payload: suggestedActions.payload,
+      })
+      .from(suggestedActions)
+      .where(eq(suggestedActions.id, input.approvalId))
+      .limit(1);
 
-  if (!action) {
-    return 'not-found';
-  }
+    if (!action) {
+      return 'not-found';
+    }
 
-  if (action.userId !== input.userId || action.status !== 'accepted') {
-    return 'not-accepted';
-  }
+    if (action.userId !== input.userId || action.status !== 'accepted') {
+      return 'not-accepted';
+    }
 
-  const [existingRun] = await db
-    .select({ id: workflowRuns.id })
-    .from(workflowRuns)
-    .where(
-      and(
-        eq(workflowRuns.kind, 'execute_approved_action'),
-        drizzleSql`${workflowRuns.stepOutputs} ->> 'approvalId' = ${input.approvalId}`
+    const [existingRun] = await db
+      .select({ id: workflowRuns.id })
+      .from(workflowRuns)
+      .where(
+        and(
+          eq(workflowRuns.kind, 'execute_approved_action'),
+          drizzleSql`${workflowRuns.stepOutputs} ->> 'approvalId' = ${input.approvalId}`
+        )
       )
-    )
-    .limit(1);
+      .limit(1);
 
-  if (existingRun) {
-    return 'already-queued';
-  }
+    if (existingRun) {
+      return 'already-queued';
+    }
 
-  const enqueueResult = await enqueueApprovedActionWorkflow({
-    userId: action.userId,
-    approvalId: action.id,
-    eventPayload: action.payload as BookingPayload | null,
-  });
-
-  if (enqueueResult === 'already-queued') {
-    return 'already-queued';
-  }
-
-  logger.info('[reconcile] recovered orphaned accepted suggested_action', {
-    approvalId: input.approvalId,
-    userId: input.userId,
-  });
-
-  return 'enqueued';
-}
-
-export async function reconcileOrphanedAcceptedActions(
-  limit = 20
-): Promise<{ scanned: number; enqueued: number }> {
-  const orphaned = await db
-    .select({
-      id: suggestedActions.id,
-      userId: suggestedActions.userId,
-      payload: suggestedActions.payload,
-    })
-    .from(suggestedActions)
-    .where(
-      and(
-        eq(suggestedActions.status, 'accepted'),
-        workflowRunMissingForSuggestedAction()
-      )
-    )
-    .limit(limit);
-
-  let enqueued = 0;
-  for (const action of orphaned) {
     const enqueueResult = await enqueueApprovedActionWorkflow({
       userId: action.userId,
       approvalId: action.id,
       eventPayload: action.payload as BookingPayload | null,
     });
-    if (enqueueResult === 'enqueued') {
-      enqueued++;
+
+    if (enqueueResult === 'already-queued') {
+      return 'already-queued';
     }
-  }
 
-  if (enqueued > 0) {
-    logger.info(
-      '[reconcile] cron enqueued orphaned accepted suggested_actions',
-      {
-        scanned: orphaned.length,
-        enqueued,
+    logger.info('[reconcile] recovered orphaned accepted suggested_action', {
+      approvalId: input.approvalId,
+      userId: input.userId,
+    });
+
+    return 'enqueued';
+  } catch (error) {
+    if (isMissingConnectorWorkflowTablesError(error)) {
+      logger.info(
+        '[reconcile] connector workflow tables not migrated; skipping recovery',
+        { approvalId: input.approvalId }
+      );
+      return 'not-found';
+    }
+    throw error;
+  }
+}
+
+export async function reconcileOrphanedAcceptedActions(
+  limit = 20
+): Promise<{ scanned: number; enqueued: number }> {
+  try {
+    const orphaned = await db
+      .select({
+        id: suggestedActions.id,
+        userId: suggestedActions.userId,
+        payload: suggestedActions.payload,
+      })
+      .from(suggestedActions)
+      .where(
+        and(
+          eq(suggestedActions.status, 'accepted'),
+          workflowRunMissingForSuggestedAction()
+        )
+      )
+      .limit(limit);
+
+    let enqueued = 0;
+    for (const action of orphaned) {
+      const enqueueResult = await enqueueApprovedActionWorkflow({
+        userId: action.userId,
+        approvalId: action.id,
+        eventPayload: action.payload as BookingPayload | null,
+      });
+      if (enqueueResult === 'enqueued') {
+        enqueued++;
       }
-    );
-  }
+    }
 
-  return { scanned: orphaned.length, enqueued };
+    if (enqueued > 0) {
+      logger.info(
+        '[reconcile] cron enqueued orphaned accepted suggested_actions',
+        {
+          scanned: orphaned.length,
+          enqueued,
+        }
+      );
+    }
+
+    return { scanned: orphaned.length, enqueued };
+  } catch (error) {
+    if (isMissingConnectorWorkflowTablesError(error)) {
+      logger.info(
+        '[reconcile] connector workflow tables not migrated; skipping cron recovery'
+      );
+      return EMPTY_RECONCILE_RESULT;
+    }
+    throw error;
+  }
 }

--- a/apps/web/tests/unit/api/cron/process-workflow-runs.test.ts
+++ b/apps/web/tests/unit/api/cron/process-workflow-runs.test.ts
@@ -178,6 +178,35 @@ describe('GET /api/cron/process-workflow-runs', () => {
     expect(mockDb.select).not.toHaveBeenCalled();
   });
 
+  it('skips the tick when connector workflow tables are not migrated', async () => {
+    mockDb.select.mockImplementation(() => {
+      throw new Error(
+        'Failed query: select "id", "kind" from "workflow_runs"',
+        {
+          cause: {
+            code: '42P01',
+            message: 'relation "workflow_runs" does not exist',
+          },
+        }
+      );
+    });
+
+    const { GET } = await import('@/app/api/cron/process-workflow-runs/route');
+    const response = await GET(
+      new Request('http://localhost/api/cron/process-workflow-runs', {
+        headers: {
+          Authorization: 'Bearer test-secret',
+          ...TRUSTED_CRON_HEADERS,
+        },
+      })
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ ok: true, processed: 0, skipped: true });
+    expect(mockCaptureWarning).not.toHaveBeenCalled();
+  });
+
   it('claims queued workflow runs before executing them', async () => {
     const { selectChain, updateChain } = setupDbChains();
     const { workflowRuns } = await import('@/lib/db/schema/connectors');


### PR DESCRIPTION
## Summary

Fixes Sentry noise from `Failed query: select "id", "user_id", "payload" from "suggested_actions"` when connector v1 tables (migration 0048) are not yet applied.

## Root cause

- `reconcileOrphanedAcceptedActions()` in the frequent cron queries `suggested_actions` for `id`, `user_id`, and `payload`.
- Tables live in `apps/web` (Drizzle schema + migration `0048_broken_blockbuster.sql`), not in HUD/ai-ops or agentos.
- HUD `ai-ops.ts` references GitHub `workflow_runs` API payloads only — unrelated to the Postgres tables.

## Fix

- Add `lib/connectors/schema-errors.ts` to detect missing connector schema tables from Drizzle-wrapped `42P01` errors.
- Skip gracefully (no Sentry) in:
  - `reconcile-orphaned-approved-actions.ts` (frequent cron sub-job)
  - `process-workflow-runs` cron route
  - `settings/connectors/connectors-data.ts` page loader

## Verification

```bash
pnpm exec vitest run \
  lib/connectors/schema-errors.test.ts \
  lib/connectors/workflows/reconcile-orphaned-approved-actions.test.ts \
  tests/unit/api/cron/process-workflow-runs.test.ts
```

<!-- linear-issue-id:JOV-3125 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system resilience by gracefully handling missing connector database tables. The system now returns empty/default states and skips processing when migrations are pending instead of failing.

* **Tests**
  * Added comprehensive unit tests for schema error detection and missing table handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->