### PR TITLE
fix(billing): map legacy founding Stripe price IDs (JOV-1769)

### DIFF
--- a/apps/web/lib/env-server-schema.ts
+++ b/apps/web/lib/env-server-schema.ts
@@ -114,6 +114,9 @@ export const ServerEnvSchema = z.object({
   PRINTFUL_STORE_ID: z.string().optional(),
   PRINTFUL_WEBHOOK_SECRET: z.string().optional(),
 
+  // Retired founding tier — webhook lookup only (founding -> pro entitlements)
+  STRIPE_PRICE_FOUNDING_MONTHLY: z.string().startsWith('price_').optional(),
+
   // Stripe price IDs for Pro tier (amounts in lib/config/plan-prices.ts)
   STRIPE_PRICE_PRO_MONTHLY: z.string().startsWith('price_').optional(),
   STRIPE_PRICE_PRO_ANNUAL: z.string().startsWith('price_').optional(),
@@ -385,6 +388,7 @@ export const ENV_KEYS = [
   'PRINTFUL_API_BASE_URL',
   'PRINTFUL_STORE_ID',
   'PRINTFUL_WEBHOOK_SECRET',
+  'STRIPE_PRICE_FOUNDING_MONTHLY',
   'STRIPE_PRICE_PRO_MONTHLY',
   'STRIPE_PRICE_PRO_ANNUAL',
   'STRIPE_PRICE_PRO_YEARLY',

--- a/apps/web/lib/stripe/config.ts
+++ b/apps/web/lib/stripe/config.ts
@@ -6,6 +6,9 @@
  *
  * Pricing tiers and amounts are defined in lib/config/plan-prices.ts (single source of truth).
  * Free tier has no Stripe subscription.
+ *
+ * Active prices are offered at checkout. Legacy prices resolve webhooks for retired
+ * subscriptions but are excluded from checkout and plan-change options.
  */
 
 import 'server-only';
@@ -13,24 +16,36 @@ import 'server-only';
 import { PRICING } from '@/lib/config/pricing';
 import { publicEnv } from '@/lib/env-public';
 import { env } from '@/lib/env-server';
+import { HARDCODED_LEGACY_PRICES } from './legacy-prices';
 
 // Plan types supported by the application
 export type PlanType = 'free' | 'pro' | 'max';
 
 // Price mapping interface
-interface PriceMapping {
+export interface PriceMapping {
   priceId: string;
   plan: PlanType;
   amount: number;
   currency: string;
   interval: 'month' | 'year';
   description: string;
+  /** When true, excluded from checkout and plan-change option lists. */
+  legacy?: boolean;
 }
 
-// Current active price mappings
-const buildPriceMappings = (): Record<string, PriceMapping> => {
+const toMappingRecord = (
+  mappings: PriceMapping[]
+): Record<string, PriceMapping> =>
+  mappings
+    .filter(mapping => Boolean(mapping.priceId))
+    .reduce<Record<string, PriceMapping>>((acc, mapping) => {
+      acc[mapping.priceId] = mapping;
+      return acc;
+    }, {});
+
+// Current active price mappings (checkout-eligible)
+const buildActivePriceMappings = (): Record<string, PriceMapping> => {
   const mappings: PriceMapping[] = [
-    // All tiers from centralized PRICING config
     {
       priceId: PRICING.pro.monthly.priceId || '',
       plan: PRICING.pro.monthly.entitlementPlan,
@@ -65,16 +80,57 @@ const buildPriceMappings = (): Record<string, PriceMapping> => {
     },
   ];
 
-  return mappings
-    .filter(mapping => Boolean(mapping.priceId))
-    .reduce<Record<string, PriceMapping>>((acc, mapping) => {
-      acc[mapping.priceId] = mapping;
-      return acc;
-    }, {});
+  return toMappingRecord(mappings);
 };
 
-export const PRICE_MAPPINGS: Record<string, PriceMapping> =
-  buildPriceMappings();
+/**
+ * Retired Stripe prices still on active subscriptions.
+ * founding -> pro per ENTITLEMENT_REGISTRY.getEntitlements('founding').
+ */
+const buildLegacyPriceMappings = (): Record<string, PriceMapping> => {
+  const mappings: PriceMapping[] = [];
+
+  if (env.STRIPE_PRICE_FOUNDING_MONTHLY) {
+    mappings.push({
+      priceId: env.STRIPE_PRICE_FOUNDING_MONTHLY,
+      plan: 'pro',
+      amount: 1200,
+      currency: 'usd',
+      interval: 'month',
+      description: 'Founding Member (legacy)',
+      legacy: true,
+    });
+  }
+
+  for (const legacy of HARDCODED_LEGACY_PRICES) {
+    if (mappings.some(mapping => mapping.priceId === legacy.priceId)) {
+      continue;
+    }
+    mappings.push({
+      priceId: legacy.priceId,
+      plan: legacy.plan,
+      amount: legacy.amount,
+      currency: 'usd',
+      interval: legacy.interval,
+      description: legacy.description,
+      legacy: true,
+    });
+  }
+
+  return toMappingRecord(mappings);
+};
+
+export const ACTIVE_PRICE_MAPPINGS: Record<string, PriceMapping> =
+  buildActivePriceMappings();
+
+const LEGACY_PRICE_MAPPINGS: Record<string, PriceMapping> =
+  buildLegacyPriceMappings();
+
+/** All price IDs for webhook/plan lookup (active + legacy). */
+export const PRICE_MAPPINGS: Record<string, PriceMapping> = {
+  ...ACTIVE_PRICE_MAPPINGS,
+  ...LEGACY_PRICE_MAPPINGS,
+};
 
 /**
  * Get plan type from Stripe price ID
@@ -89,7 +145,7 @@ export function getPlanFromPriceId(priceId: string): PlanType | null {
  * Get all currently active price IDs for checkout
  */
 export function getActivePriceIds(): string[] {
-  return Object.values(PRICE_MAPPINGS).map(mapping => mapping.priceId);
+  return Object.values(ACTIVE_PRICE_MAPPINGS).map(mapping => mapping.priceId);
 }
 
 /**
@@ -104,7 +160,9 @@ export function getPriceMappingDetails(priceId: string): PriceMapping | null {
  * Filters based on what's currently active
  */
 export function getAvailablePricing() {
-  return Object.values(PRICE_MAPPINGS).sort((a, b) => a.amount - b.amount);
+  return Object.values(ACTIVE_PRICE_MAPPINGS).sort(
+    (a, b) => a.amount - b.amount
+  );
 }
 
 export function isMaxPlanEnabled(): boolean {

--- a/apps/web/lib/stripe/legacy-prices.ts
+++ b/apps/web/lib/stripe/legacy-prices.ts
@@ -1,0 +1,50 @@
+/**
+ * Retired Stripe price IDs still held by active subscriptions.
+ *
+ * These prices are NOT offered at checkout. They exist only so webhook
+ * handlers and plan-change lookups can resolve legacy subscriptions to the
+ * correct entitlement tier per ENTITLEMENT_REGISTRY (founding -> pro).
+ */
+
+/** Entitlement tier for legacy prices (founding maps to pro per ENTITLEMENT_REGISTRY). */
+export type LegacyEntitlementPlan = 'pro' | 'max';
+
+export interface LegacyPriceDefinition {
+  readonly priceId: string;
+  /** Entitlement plan — founding subscribers receive pro entitlements. */
+  readonly plan: LegacyEntitlementPlan;
+  readonly amount: number;
+  readonly interval: 'month' | 'year';
+  readonly description: string;
+}
+
+/**
+ * Known retired price IDs that may still appear on live subscriptions.
+ * Prefer STRIPE_PRICE_FOUNDING_MONTHLY env when set; these are fallbacks.
+ */
+export const HARDCODED_LEGACY_PRICES: readonly LegacyPriceDefinition[] = [
+  {
+    // JOV-1769: founding member monthly — removed from checkout Mar 2026
+    priceId: 'price_1T1DegAAI1NrDqJSTtjAwLBi',
+    plan: 'pro',
+    amount: 1200,
+    interval: 'month',
+    description: 'Founding Member (legacy)',
+  },
+  {
+    // Pre-rebrand Standard monthly (Dec 2025 .env.example)
+    priceId: 'price_1Sde6QRSmm9B6YB5F8V7suAG',
+    plan: 'pro',
+    amount: 2000,
+    interval: 'month',
+    description: 'Standard Monthly (legacy)',
+  },
+  {
+    // Pre-rebrand Standard yearly (Dec 2025 .env.example)
+    priceId: 'price_1Sde6iRSmm9B6YB5PSxXPVdy',
+    plan: 'pro',
+    amount: 19200,
+    interval: 'year',
+    description: 'Standard Yearly (legacy)',
+  },
+] as const;

--- a/apps/web/lib/stripe/plan-change.ts
+++ b/apps/web/lib/stripe/plan-change.ts
@@ -22,10 +22,10 @@ import { logger } from '@/lib/utils/logger';
 
 import { stripe } from './client';
 import {
+  ACTIVE_PRICE_MAPPINGS,
   getActivePriceIds,
   getPriceMappingDetails,
   type PlanType,
-  PRICE_MAPPINGS,
 } from './config';
 
 /**
@@ -599,7 +599,7 @@ export async function getAvailablePlanChanges(customerId: string): Promise<{
   try {
     // Handle empty customer ID (no Stripe customer yet)
     if (!customerId) {
-      const allOptions = Object.values(PRICE_MAPPINGS).map(mapping => ({
+      const allOptions = Object.values(ACTIVE_PRICE_MAPPINGS).map(mapping => ({
         priceId: mapping.priceId,
         plan: mapping.plan,
         interval: mapping.interval,
@@ -623,7 +623,7 @@ export async function getAvailablePlanChanges(customerId: string): Promise<{
 
     if (!subscription) {
       // No subscription - show all options as "upgrades" from free
-      const allOptions = Object.values(PRICE_MAPPINGS).map(mapping => ({
+      const allOptions = Object.values(ACTIVE_PRICE_MAPPINGS).map(mapping => ({
         priceId: mapping.priceId,
         plan: mapping.plan,
         interval: mapping.interval,
@@ -655,8 +655,8 @@ export async function getAvailablePlanChanges(customerId: string): Promise<{
       return null;
     }
 
-    // Get all available plans except current
-    const availableChanges = Object.values(PRICE_MAPPINGS)
+    // Get all available plans except current (legacy prices excluded)
+    const availableChanges = Object.values(ACTIVE_PRICE_MAPPINGS)
       .filter(mapping => mapping.priceId !== currentPriceId)
       .map(mapping => ({
         priceId: mapping.priceId,

--- a/apps/web/tests/unit/lib/stripe/config.legacy-prices.test.ts
+++ b/apps/web/tests/unit/lib/stripe/config.legacy-prices.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const FOUNDING_PRICE_ID = 'price_1T1DegAAI1NrDqJSTtjAwLBi';
+
+describe('stripe config legacy price mappings', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('resolves JOV-1769 founding price ID to pro entitlements', async () => {
+    vi.stubEnv('STRIPE_PRICE_PRO_MONTHLY', 'price_pro_monthly');
+    vi.stubEnv('STRIPE_PRICE_PRO_YEARLY', 'price_pro_yearly');
+
+    const { getPlanFromPriceId, getPriceMappingDetails } = await import(
+      '@/lib/stripe/config'
+    );
+
+    expect(getPlanFromPriceId(FOUNDING_PRICE_ID)).toBe('pro');
+    expect(getPriceMappingDetails(FOUNDING_PRICE_ID)?.legacy).toBe(true);
+    expect(getPriceMappingDetails(FOUNDING_PRICE_ID)?.description).toContain(
+      'Founding'
+    );
+  });
+
+  it('excludes legacy prices from active checkout price IDs', async () => {
+    vi.stubEnv('STRIPE_PRICE_PRO_MONTHLY', 'price_pro_monthly');
+    vi.stubEnv('STRIPE_PRICE_PRO_YEARLY', 'price_pro_yearly');
+
+    const { getActivePriceIds, getAvailablePricing } = await import(
+      '@/lib/stripe/config'
+    );
+
+    const activeIds = getActivePriceIds();
+    expect(activeIds).toContain('price_pro_monthly');
+    expect(activeIds).not.toContain(FOUNDING_PRICE_ID);
+
+    const pricingOptions = getAvailablePricing();
+    expect(pricingOptions.every(option => !option.legacy)).toBe(true);
+    expect(
+      pricingOptions.some(option => option.priceId === FOUNDING_PRICE_ID)
+    ).toBe(false);
+  });
+
+  it('prefers STRIPE_PRICE_FOUNDING_MONTHLY env over hardcoded fallback', async () => {
+    const envFoundingId = 'price_founding_from_env';
+    vi.stubEnv('STRIPE_PRICE_FOUNDING_MONTHLY', envFoundingId);
+    vi.stubEnv('STRIPE_PRICE_PRO_MONTHLY', 'price_pro_monthly');
+    vi.stubEnv('STRIPE_PRICE_PRO_YEARLY', 'price_pro_yearly');
+
+    const { getPlanFromPriceId, getPriceMappingDetails } = await import(
+      '@/lib/stripe/config'
+    );
+
+    expect(getPlanFromPriceId(envFoundingId)).toBe('pro');
+    expect(getPriceMappingDetails(envFoundingId)?.legacy).toBe(true);
+    // Hardcoded ID still resolves when env points elsewhere
+    expect(getPlanFromPriceId(FOUNDING_PRICE_ID)).toBe('pro');
+  });
+});

--- a/apps/web/tests/unit/lib/stripe/plan-change.critical.test.ts
+++ b/apps/web/tests/unit/lib/stripe/plan-change.critical.test.ts
@@ -66,7 +66,7 @@ vi.mock('@/lib/utils/logger', () => ({
 vi.mock('@/lib/stripe/config', () => ({
   getActivePriceIds: mockGetActivePriceIds,
   getPriceMappingDetails: mockGetPriceMappingDetails,
-  get PRICE_MAPPINGS() {
+  get ACTIVE_PRICE_MAPPINGS() {
     return mockPriceMappings;
   },
 }));
@@ -170,7 +170,7 @@ describe('@critical plan-change.ts', () => {
       (priceId: string) => priceMappingsData[priceId] || null
     );
 
-    // Populate PRICE_MAPPINGS object
+    // Populate ACTIVE_PRICE_MAPPINGS object
     Object.keys(mockPriceMappings).forEach(
       k => delete (mockPriceMappings as Record<string, unknown>)[k]
     );

--- a/apps/web/tests/unit/lib/stripe/plan-change.test.ts
+++ b/apps/web/tests/unit/lib/stripe/plan-change.test.ts
@@ -54,7 +54,7 @@ vi.mock('@/lib/stripe/config', () => ({
     };
     return mapping[priceId] ?? null;
   }),
-  PRICE_MAPPINGS: {
+  ACTIVE_PRICE_MAPPINGS: {
     price_pro_monthly: {
       priceId: 'price_pro_monthly',
       plan: 'pro',


### PR DESCRIPTION
## Summary

Fixes `Unknown price ID: price_1T1DegAAI1NrDqJSTtjAwLBi` in Stripe subscription webhooks.

## Root cause

The founding member tier was removed from `PRICE_MAPPINGS` in #6837 (Mar 2026), but at least one active subscription still bills against the retired founding Stripe price `price_1T1DegAAI1NrDqJSTtjAwLBi`. Webhook handlers call `getPlanFromPriceId()`, which only knew active checkout prices, so subscription events were skipped with a critical Sentry error.

## Fix

- Split **active** vs **legacy** Stripe price mappings in `lib/stripe/config.ts`
- Add `lib/stripe/legacy-prices.ts` with known retired price IDs (including JOV-1769 founding price)
- Re-introduce optional `STRIPE_PRICE_FOUNDING_MONTHLY` env var for webhook lookup only
- Legacy prices resolve to **pro** entitlements per `ENTITLEMENT_REGISTRY` (`founding` → `pro`)
- Legacy prices are excluded from checkout and plan-change option lists

## Human review needed

- [ ] Confirm `price_1T1DegAAI1NrDqJSTtjAwLBi` is the founding member monthly price in prod Stripe
- [ ] Set `STRIPE_PRICE_FOUNDING_MONTHLY=price_1T1DegAAI1NrDqJSTtjAwLBi` in Doppler prod/preview if desired (hardcoded fallback also works)
- [ ] Verify no other unknown price IDs are still erroring in Sentry after deploy

linear-issue-id: JOV-1769

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing legacy and retired pricing plans alongside active pricing options.
  * Plan change selections now display only current pricing tiers, excluding deprecated plans.

* **Tests**
  * Added test coverage for legacy pricing resolution and exclusion from active checkout options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->