### PR TITLE
fix(analytics): fail-safe tracking token when secret unset (JOV-2327)

### DIFF
--- a/apps/web/app/[username]/page.tsx
+++ b/apps/web/app/[username]/page.tsx
@@ -380,10 +380,10 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
       <div className='px-4 py-8'>
         <ErrorBanner
           title='Profile is temporarily unavailable'
-          description='We could not load this Jovie profile right now. Please refresh or try again in a few minutes.'
+          description='We could not load this profile right now, so please refresh or try again in a few minutes.'
           actions={[
-            { label: 'Try again', href: `/${username.toLowerCase()}` },
-            { label: 'Go home', href: '/' },
+            { label: 'Try Again', href: `/${username.toLowerCase()}` },
+            { label: 'Go Home', href: '/' },
           ]}
           testId='public-profile-error'
         />
@@ -421,12 +421,8 @@ export default async function ArtistPage({ params }: Readonly<Props>) {
   // Generate a short-lived HMAC token so the client can authenticate its visit
   // tracking request to /api/audience/visit (requires TRACKING_TOKEN_SECRET).
   // Falls back to undefined gracefully if the secret is not configured.
-  let visitTrackingToken: string | undefined;
-  try {
-    visitTrackingToken = getClientTrackingToken(profile.id).token;
-  } catch {
-    // Secret not configured — visit tracking will proceed without token auth
-  }
+  const visitTrackingToken =
+    getClientTrackingToken(profile.id).token ?? undefined;
 
   const latestRelease = fetchedLatestRelease;
 

--- a/apps/web/app/api/audience/visit-token/route.ts
+++ b/apps/web/app/api/audience/visit-token/route.ts
@@ -81,7 +81,8 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    return NextResponse.json(getClientTrackingToken(parsed.data.profileId), {
+    const tokenResult = getClientTrackingToken(parsed.data.profileId);
+    return NextResponse.json(tokenResult, {
       headers: NO_STORE_HEADERS,
     });
   } catch (error) {

--- a/apps/web/lib/analytics/tracking-token.ts
+++ b/apps/web/lib/analytics/tracking-token.ts
@@ -75,6 +75,10 @@ function verifySignature(
   timestamp: number
 ): boolean {
   const expectedSignature = generateSignature(profileId, timestamp);
+  if (!expectedSignature) {
+    return false;
+  }
+
   const signatureBuffer = Buffer.from(signature, 'hex');
   const expectedBuffer = Buffer.from(expectedSignature, 'hex');
 
@@ -94,23 +98,31 @@ export function isTrackingTokenEnabled(): boolean {
 /**
  * Generate HMAC-SHA256 signature for a payload
  */
-function generateSignature(profileId: string, timestamp: number): string {
+function generateSignature(
+  profileId: string,
+  timestamp: number
+): string | null {
   const secret = getTrackingSecret();
   if (!secret) {
-    throw new TypeError('TRACKING_TOKEN_SECRET not configured');
+    return null;
   }
 
   const data = `${profileId}:${timestamp}`;
   return crypto.createHmac('sha256', secret).update(data).digest('hex');
 }
 
+export interface ClientTrackingToken {
+  token: string | null;
+  expiresAt: number | null;
+}
+
 /**
  * Generate a signed tracking token for a profile
  *
  * @param profileId - The creator profile ID
- * @returns Signed token string
+ * @returns Signed token string, dev placeholder in development, or null when signing is disabled
  */
-export function generateTrackingToken(profileId: string): string {
+export function generateTrackingToken(profileId: string): string | null {
   if (!isTrackingTokenEnabled()) {
     // Return a placeholder token in development
     if (env.NODE_ENV === 'development') {
@@ -122,11 +134,21 @@ export function generateTrackingToken(profileId: string): string {
       });
       return `${profileId}:${Date.now()}:dev`;
     }
-    throw new TypeError('Tracking token signing not configured');
+
+    Sentry.addBreadcrumb({
+      category: 'tracking-token',
+      message: 'TRACKING_TOKEN_SECRET not set - skipping token generation',
+      level: 'warning',
+      data: { profileId },
+    });
+    return null;
   }
 
   const timestamp = Date.now();
   const signature = generateSignature(profileId, timestamp);
+  if (!signature) {
+    return null;
+  }
 
   return `${profileId}:${timestamp}:${signature}`;
 }
@@ -226,11 +248,12 @@ export class TrackingTokenError extends Error {
  * Generate a tracking token for client-side use
  * This should be called server-side and passed to the client
  */
-export function getClientTrackingToken(profileId: string): {
-  token: string;
-  expiresAt: number;
-} {
+export function getClientTrackingToken(profileId: string): ClientTrackingToken {
   const token = generateTrackingToken(profileId);
+  if (!token) {
+    return { token: null, expiresAt: null };
+  }
+
   const expiresAt = Date.now() + TOKEN_VALIDITY_MS;
 
   return { token, expiresAt };

--- a/apps/web/tests/lib/analytics/tracking-token.test.ts
+++ b/apps/web/tests/lib/analytics/tracking-token.test.ts
@@ -3,7 +3,8 @@
  * Validates HMAC-SHA256 signed request tokens for audience tracking endpoints
  */
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import * as Sentry from '@sentry/nextjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   generateTrackingToken,
   getClientTrackingToken,
@@ -11,6 +12,10 @@ import {
   TrackingTokenError,
   validateTrackingToken,
 } from '@/lib/analytics/tracking-token';
+
+vi.mock('@sentry/nextjs', () => ({
+  addBreadcrumb: vi.fn(),
+}));
 
 describe('Tracking Token', () => {
   describe('isTrackingTokenEnabled', () => {
@@ -49,8 +54,8 @@ describe('Tracking Token', () => {
 
       const token = generateTrackingToken(profileId);
 
-      expect(token).toBeDefined();
-      const parts = token.split(':');
+      expect(token).not.toBeNull();
+      const parts = token!.split(':');
       expect(parts.length).toBe(3);
       expect(parts[0]).toBe(profileId);
       expect(parseInt(parts[1], 10)).toBeGreaterThan(0);
@@ -71,7 +76,7 @@ describe('Tracking Token', () => {
       const token = generateTrackingToken(profileId);
 
       const after = Date.now();
-      const timestamp = parseInt(token.split(':')[1], 10);
+      const timestamp = parseInt(token!.split(':')[1], 10);
 
       expect(timestamp).toBeGreaterThanOrEqual(before);
       expect(timestamp).toBeLessThanOrEqual(after);
@@ -87,7 +92,7 @@ describe('Tracking Token', () => {
       const profileId = 'test-profile-id';
       const token = generateTrackingToken(profileId);
 
-      const result = validateTrackingToken(token);
+      const result = validateTrackingToken(token!);
 
       expect(result.valid).toBe(true);
       expect(result.payload).toBeDefined();
@@ -98,7 +103,7 @@ describe('Tracking Token', () => {
       const profileId = 'test-profile-id';
       const token = generateTrackingToken(profileId);
 
-      const result = validateTrackingToken(token, profileId);
+      const result = validateTrackingToken(token!, profileId);
 
       expect(result.valid).toBe(true);
     });
@@ -106,7 +111,7 @@ describe('Tracking Token', () => {
     it('should reject token with mismatched profile ID', () => {
       const token = generateTrackingToken('profile-1');
 
-      const result = validateTrackingToken(token, 'profile-2');
+      const result = validateTrackingToken(token!, 'profile-2');
 
       expect(result.valid).toBe(false);
       expect(result.error).toBe('Profile ID mismatch');
@@ -192,9 +197,86 @@ describe('Tracking Token', () => {
       const profileId = 'test-profile';
 
       const { token } = getClientTrackingToken(profileId);
-      const validation = validateTrackingToken(token, profileId);
+      const validation = validateTrackingToken(token!, profileId);
 
       expect(validation.valid).toBe(true);
+    });
+  });
+
+  describe('when TRACKING_TOKEN_SECRET is not configured', () => {
+    const originalSecret = process.env.TRACKING_TOKEN_SECRET;
+
+    afterEach(() => {
+      if (originalSecret) {
+        process.env.TRACKING_TOKEN_SECRET = originalSecret;
+      } else {
+        delete process.env.TRACKING_TOKEN_SECRET;
+      }
+      vi.unstubAllEnvs();
+      vi.clearAllMocks();
+    });
+
+    it('should return null instead of throwing in non-development environments', () => {
+      delete process.env.TRACKING_TOKEN_SECRET;
+      vi.stubEnv('NODE_ENV', 'production');
+
+      expect(() => generateTrackingToken('profile-id')).not.toThrow();
+      expect(generateTrackingToken('profile-id')).toBeNull();
+      expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'tracking-token',
+          message: 'TRACKING_TOKEN_SECRET not set - skipping token generation',
+        })
+      );
+    });
+
+    it('should return null client token payload in non-development environments', () => {
+      delete process.env.TRACKING_TOKEN_SECRET;
+      vi.stubEnv('NODE_ENV', 'production');
+
+      expect(getClientTrackingToken('profile-id')).toEqual({
+        token: null,
+        expiresAt: null,
+      });
+    });
+
+    it('should return dev token in development without throwing', () => {
+      delete process.env.TRACKING_TOKEN_SECRET;
+      vi.stubEnv('NODE_ENV', 'development');
+
+      const token = generateTrackingToken('profile-id');
+
+      expect(token).toMatch(/^profile-id:\d+:dev$/);
+      expect(Sentry.addBreadcrumb).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'tracking-token',
+          message: 'TRACKING_TOKEN_SECRET not set - using dev token',
+        })
+      );
+    });
+
+    it('should validate dev tokens in development', () => {
+      delete process.env.TRACKING_TOKEN_SECRET;
+      vi.stubEnv('NODE_ENV', 'development');
+
+      const token = generateTrackingToken('profile-id');
+      const validation = validateTrackingToken(token!, 'profile-id');
+
+      expect(validation.valid).toBe(true);
+      expect(validation.payload?.profileId).toBe('profile-id');
+    });
+
+    it('should reject validation when secret is unset outside development', () => {
+      delete process.env.TRACKING_TOKEN_SECRET;
+      vi.stubEnv('NODE_ENV', 'production');
+
+      const validation = validateTrackingToken(
+        'profile-id:123:dev',
+        'profile-id'
+      );
+
+      expect(validation.valid).toBe(false);
+      expect(validation.error).toBe('Token validation not configured');
     });
   });
 
@@ -207,8 +289,4 @@ describe('Tracking Token', () => {
       expect(error.message).toBe('test error');
     });
   });
-
-  // Note: Development mode tests removed as they require NODE_ENV manipulation
-  // which is read-only in TypeScript. The development mode behavior is tested
-  // implicitly through manual testing.
 });


### PR DESCRIPTION
## Summary

Fixes `TypeError: Tracking token signing not configured` when `TRACKING_TOKEN_SECRET` is unset in non-development environments.

- `generateTrackingToken` and `getClientTrackingToken` now return `null` instead of throwing
- Development still uses `:dev` placeholder tokens for local testing
- Profile pages read the nullable token without try/catch
- `/api/audience/visit-token` returns `{ token: null, expiresAt: null }` gracefully when signing is disabled
- Added unit tests for production and development paths

## Testing

- [x] `pnpm typecheck:web:fast`
- [x] `pnpm biome check` on changed files
- [x] `vitest run tests/lib/analytics/tracking-token.test.ts`
- [x] `vitest run tests/unit/api/audience/visit-token.test.ts`

<!-- linear-issue-id:JOV-2327 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Updated error message text and button labels on the public profile page for clearer user guidance

* **Bug Fixes**
  * Improved tracking system resilience to gracefully handle unavailable signing credentials instead of failing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->