### PR TITLE
feat(ai): golden eval-set CI gate for AI feature deploys (JOV-2938)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       run_admin_lighthouse: ${{ steps.detect.outputs.run_admin_lighthouse }}
       run_chat_lighthouse: ${{ steps.detect.outputs.run_chat_lighthouse }}
       run_promptfoo_evals: ${{ steps.detect.outputs.run_promptfoo_evals }}
+      run_golden_eval_set: ${{ steps.detect.outputs.run_golden_eval_set }}
       run_e2e: ${{ steps.detect.outputs.run_e2e }}
       run_drizzle: ${{ steps.detect.outputs.run_drizzle }}
       run_neon: ${{ steps.detect.outputs.run_neon }}
@@ -82,7 +83,7 @@ jobs:
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             # Manual dispatch: run everything
             echo "Manual dispatch: running all checks"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_e2e run_drizzle run_neon has_code_changes; do
+            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_golden_eval_set run_e2e run_drizzle run_neon has_code_changes; do
               echo "$t=true" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -92,13 +93,14 @@ jobs:
 
           FULL_CI_LABEL="${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'testing') }}"
 
-          PROMPTFOO_INFRA_TRIGGER_PATTERN='^(\.github/workflows/evals-periodic\.yml|\.github/workflows/README\.md|apps/web/tests/eval/promptfoo/)'
-          PROMPTFOO_INFRA_ALLOWED_PATTERN='^(\.github/workflows/ci\.yml|\.github/workflows/evals-periodic\.yml|\.github/workflows/README\.md|apps/web/tests/eval/promptfoo/.*|apps/web/package.*\.json|package.*\.json|pnpm-lock\.yaml)$'
+          PROMPTFOO_INFRA_TRIGGER_PATTERN='^(\.github/workflows/evals-periodic\.yml|\.github/workflows/README\.md|apps/web/tests/eval/promptfoo/|apps/web/tests/eval/golden/)'
+          PROMPTFOO_INFRA_ALLOWED_PATTERN='^(\.github/workflows/ci\.yml|\.github/workflows/evals-periodic\.yml|\.github/workflows/README\.md|apps/web/tests/eval/promptfoo/.*|apps/web/tests/eval/golden/.*|apps/web/vitest\.config\.golden-eval\.mts|apps/web/scripts/run-golden-eval-set-ci\.sh|apps/web/package.*\.json|package.*\.json|pnpm-lock\.yaml)$'
           if echo "$CHANGED_FILES" | grep -q -E "$PROMPTFOO_INFRA_TRIGGER_PATTERN" &&
             ! echo "$CHANGED_FILES" | grep -v -E "$PROMPTFOO_INFRA_ALLOWED_PATTERN" | grep -q .; then
             echo "Promptfoo eval-infrastructure-only change: running deterministic eval CI and core static checks, even if the PR has the testing label."
             echo "has_code_changes=true" >> "$GITHUB_OUTPUT"
             echo "run_promptfoo_evals=true" >> "$GITHUB_OUTPUT"
+            echo "run_golden_eval_set=true" >> "$GITHUB_OUTPUT"
             for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_e2e run_drizzle run_neon; do
               echo "$t=false" >> "$GITHUB_OUTPUT"
             done
@@ -110,7 +112,7 @@ jobs:
           # into Neon, Lighthouse, or Playwright work by label accident.
           if [[ "$FULL_CI_LABEL" == "true" ]]; then
             echo "Forcing full CI run due to 'testing' label"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_e2e run_drizzle run_neon has_code_changes; do
+            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_golden_eval_set run_e2e run_drizzle run_neon has_code_changes; do
               echo "$t=true" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -120,7 +122,7 @@ jobs:
           if ! echo "$CHANGED_FILES" | grep -q -E '^\.github/' &&
             ! echo "$CHANGED_FILES" | grep -q -v -E '\.(md|txt)$'; then
             echo "Only documentation files changed"
-            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_e2e run_drizzle run_neon has_code_changes; do
+            for t in run_build run_test run_public_lighthouse run_dashboard_lighthouse run_onboarding_lighthouse run_admin_lighthouse run_chat_lighthouse run_promptfoo_evals run_golden_eval_set run_e2e run_drizzle run_neon has_code_changes; do
               echo "$t=false" >> "$GITHUB_OUTPUT"
             done
             exit 0
@@ -183,11 +185,13 @@ jobs:
             echo "run_chat_lighthouse=false" >> "$GITHUB_OUTPUT"
           fi
 
-          PROMPTFOO_EVAL_PATTERN='^(\.github/workflows/ci\.yml|apps/web/tests/eval/promptfoo/|apps/web/lib/chat/|apps/web/app/api/chat/|apps/web/package.*\.json|package.*\.json|pnpm-lock\.yaml)'
+          PROMPTFOO_EVAL_PATTERN='^(\.github/workflows/ci\.yml|apps/web/tests/eval/promptfoo/|apps/web/tests/eval/golden/|apps/web/vitest\.config\.golden-eval\.mts|apps/web/scripts/run-golden-eval-set-ci\.sh|apps/web/lib/chat/|apps/web/app/api/chat/|apps/web/package.*\.json|package.*\.json|pnpm-lock\.yaml)'
           if echo "$CHANGED_FILES" | grep -q -E "$PROMPTFOO_EVAL_PATTERN"; then
             echo "run_promptfoo_evals=true" >> "$GITHUB_OUTPUT"
+            echo "run_golden_eval_set=true" >> "$GITHUB_OUTPUT"
           else
             echo "run_promptfoo_evals=false" >> "$GITHUB_OUTPUT"
+            echo "run_golden_eval_set=false" >> "$GITHUB_OUTPUT"
           fi
 
           # E2E paths
@@ -514,6 +518,24 @@ jobs:
         run: pnpm --filter @jovie/web run evals:validate
       - name: Run deterministic Promptfoo evals
         run: pnpm run evals
+
+  ci-golden-eval-set:
+    name: Golden Eval Set (deterministic)
+    needs: [ci-path-changes]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.ci-path-changes.outputs.run_golden_eval_set == 'true' }}
+    env:
+      JOVIE_RUN_LIVE_EVALS: '0'
+      JOVIE_RUN_LIVE_HTTP_EVALS: '0'
+      JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS: '0'
+      JOVIE_RUN_LIVE_HTTP_MODEL_ERROR_EVALS: '0'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with: { fetch-depth: 1 }
+      - uses: ./.github/actions/setup-node-pnpm
+      - name: Run golden eval-set CI gate
+        run: pnpm run evals:golden
 
   ci-eslint:
     name: ESLint Server Boundaries

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,7 @@
     "check:ci": "pnpm run validate && pnpm run test:ci",
     "validate": "pnpm run next:proxy-guard && pnpm run biome:check && pnpm run typecheck",
     "evals": "bash scripts/run-deterministic-promptfoo-evals.sh eval",
+    "evals:golden": "bash scripts/run-golden-eval-set-ci.sh",
     "evals:validate": "bash scripts/run-deterministic-promptfoo-evals.sh validate",
     "evals:live": "bash scripts/run-live-promptfoo-evals.sh smoke",
     "evals:live:all": "bash scripts/run-live-promptfoo-evals.sh all",

--- a/apps/web/scripts/run-golden-eval-set-ci.sh
+++ b/apps/web/scripts/run-golden-eval-set-ci.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for flag in \
+  JOVIE_RUN_LIVE_EVALS \
+  JOVIE_RUN_LIVE_HTTP_EVALS \
+  JOVIE_RUN_LIVE_HTTP_RATE_LIMIT_EVALS \
+  JOVIE_RUN_LIVE_HTTP_MODEL_ERROR_EVALS
+do
+  if [ "${!flag:-0}" = "1" ]; then
+    echo "Refusing to run golden eval CI gate with ${flag}=1" >&2
+    exit 1
+  fi
+  export "${flag}=0"
+done
+
+unset \
+  AI_GATEWAY_API_KEY \
+  OPENAI_API_KEY \
+  ANTHROPIC_API_KEY \
+  XAI_API_KEY \
+  VERCEL_OIDC_TOKEN \
+  BRAINTRUST_API_KEY \
+  DATABASE_URL \
+  DATABASE_URL_MAIN \
+  CLERK_SECRET_KEY \
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY \
+  STRIPE_SECRET_KEY \
+  SPOTIFY_CLIENT_ID \
+  SPOTIFY_CLIENT_SECRET \
+  UPSTASH_REDIS_REST_URL \
+  UPSTASH_REDIS_REST_TOKEN
+
+vitest run --config vitest.config.golden-eval.mts

--- a/apps/web/tests/eval/golden/assertions.ts
+++ b/apps/web/tests/eval/golden/assertions.ts
@@ -1,0 +1,105 @@
+/**
+ * Deterministic quality assertions for golden AI eval cases.
+ */
+
+import { expect } from 'vitest';
+
+import type { GoldenCase } from './cases';
+
+export function assertMustSay(
+  response: string,
+  mustSay: readonly string[],
+  caseName: string
+): void {
+  const lower = response.toLowerCase();
+  for (const concept of mustSay) {
+    expect(
+      lower.includes(concept.toLowerCase()),
+      `[${caseName}] Response must mention "${concept}" but didn't. Response: "${response.slice(0, 200)}..."`
+    ).toBe(true);
+  }
+}
+
+export function assertMustNotSay(
+  response: string,
+  mustNotSay: readonly string[],
+  caseName: string
+): void {
+  const lower = response.toLowerCase();
+  for (const forbidden of mustNotSay) {
+    expect(
+      lower.includes(forbidden.toLowerCase()),
+      `[${caseName}] Response must NOT contain "${forbidden}" but did. Response: "${response.slice(0, 200)}..."`
+    ).toBe(false);
+  }
+}
+
+export function assertHarmfulBlacklist(
+  response: string,
+  blacklist: readonly string[],
+  caseName: string
+): void {
+  const lower = response.toLowerCase();
+  for (const harmful of blacklist) {
+    expect(
+      lower.includes(harmful.toLowerCase()),
+      `[${caseName}] HARMFUL: Response contains blacklisted advice "${harmful}". Response: "${response.slice(0, 200)}..."`
+    ).toBe(false);
+  }
+}
+
+export function assertVoiceCompliance(
+  response: string,
+  voiceException: boolean,
+  caseName: string
+): void {
+  const emojiPattern =
+    /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/u;
+  expect(
+    emojiPattern.test(response),
+    `[${caseName}] Response contains emoji`
+  ).toBe(false);
+
+  expect(
+    response.includes('!'),
+    `[${caseName}] Response contains exclamation mark`
+  ).toBe(false);
+
+  if (!voiceException) {
+    const wordCount = response.split(/\s+/).filter(Boolean).length;
+    expect(
+      wordCount,
+      `[${caseName}] Response is ${wordCount} words (max 150)`
+    ).toBeLessThanOrEqual(150);
+  }
+}
+
+export function assertPromptInjectionGuards(
+  response: string,
+  caseName: string
+): void {
+  const lower = response.toLowerCase();
+  expect(
+    lower.includes('you are jovie'),
+    `[${caseName}] Response leaks system prompt ("You are Jovie")`
+  ).toBe(false);
+  expect(
+    lower.includes('## voice (critical)'),
+    `[${caseName}] Response leaks system prompt section heading`
+  ).toBe(false);
+  expect(
+    lower.includes('## music industry knowledge'),
+    `[${caseName}] Response leaks knowledge section heading`
+  ).toBe(false);
+}
+
+export function assertGoldenCaseQuality(
+  response: string,
+  golden: GoldenCase
+): void {
+  assertMustSay(response, golden.mustSay, golden.name);
+  assertMustNotSay(response, golden.mustNotSay, golden.name);
+  assertHarmfulBlacklist(response, golden.harmfulBlacklist, golden.name);
+  assertVoiceCompliance(response, golden.voiceException ?? false, golden.name);
+  assertPromptInjectionGuards(response, golden.name);
+}

--- a/apps/web/tests/eval/golden/cases.ts
+++ b/apps/web/tests/eval/golden/cases.ts
@@ -1,0 +1,229 @@
+/**
+ * Golden eval cases for Jovie AI chat quality.
+ *
+ * Shared between the deterministic CI gate (mocked LLM) and the manual
+ * live knowledge-accuracy eval (real provider calls).
+ */
+
+import type {
+  buildTestArtistContext,
+  buildTestReleases,
+} from '../../fixtures/chat-context';
+
+export interface GoldenCase {
+  /** Human-readable case name */
+  readonly name: string;
+  /** What the artist asks */
+  readonly userPrompt: string;
+  /** Artist context overrides (merged with defaults) */
+  readonly artistOverrides?: Parameters<typeof buildTestArtistContext>[0];
+  /** Release overrides */
+  readonly releaseOverrides?: Parameters<typeof buildTestReleases>[0];
+  /** Concepts the response MUST mention (case-insensitive substring) */
+  readonly mustSay: readonly string[];
+  /** Claims the response MUST NOT contain */
+  readonly mustNotSay: readonly string[];
+  /** Advice that could materially harm an artist's career */
+  readonly harmfulBlacklist: readonly string[];
+  /** The factually correct answer for LLM-as-judge fact-checking */
+  readonly groundTruth: string;
+  /** If true, skip the 150-word voice limit for this case */
+  readonly voiceException?: boolean;
+}
+
+export const GOLDEN_CASES: readonly GoldenCase[] = [
+  {
+    name: 'Release timing: best day of week',
+    userPrompt: 'What day should I release my next single?',
+    mustSay: ['friday'],
+    mustNotSay: ['monday', 'wednesday', 'sunday'],
+    harmfulBlacklist: [
+      'any day works equally well',
+      "day of the week doesn't matter",
+    ],
+    groundTruth:
+      'New Music Friday is the industry standard. Releasing on Friday maximizes first-week streams because streaming platforms refresh editorial playlists on Friday. The release should go live at midnight local time in the earliest timezone (e.g., midnight NZT for global rollout).',
+  },
+  {
+    name: 'Release timing: lead time for pre-saves',
+    userPrompt: 'How far in advance should I set up pre-saves for my single?',
+    mustSay: ['2', 'week'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      "pre-saves don't matter",
+      'you can set up pre-saves the day before',
+    ],
+    groundTruth:
+      'Pre-saves should be set up at least 2-4 weeks before release to build momentum. Most distributors require 2+ weeks lead time for editorial playlist consideration. The pre-save link should be promoted across social channels as soon as it is live.',
+  },
+  {
+    name: 'Royalties: mechanical vs performance',
+    userPrompt: 'What are mechanical royalties vs performance royalties?',
+    voiceException: true,
+    mustSay: ['mechanical', 'performance', 'composition'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      'they are the same thing',
+      'you only need to worry about one type',
+    ],
+    groundTruth:
+      'Mechanical royalties are paid when a song is reproduced (streaming, downloads, physical copies) — they go to the songwriter/publisher. Performance royalties are paid when a song is publicly performed (radio, live venues, streaming) — they are collected by PROs (ASCAP, BMI, SESAC). An artist who writes their own songs should register with BOTH a distributor (for mechanicals) and a PRO (for performance royalties).',
+  },
+  {
+    name: 'Royalties: per-stream rates are not fixed',
+    userPrompt: 'How much does Spotify pay per stream?',
+    mustSay: ['varies', 'average'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      'spotify pays exactly $0.003 per stream',
+      'spotify pays exactly $0.004 per stream',
+      'spotify pays a fixed rate',
+      'every stream pays the same amount',
+    ],
+    groundTruth:
+      "Spotify does not pay a fixed per-stream rate. Payment depends on the listener's country, subscription type (free vs premium), total platform streams that month, and the artist's distributor deal. The average is roughly $0.003-$0.005 per stream but varies significantly. Artists should not plan revenue based on a fixed per-stream number.",
+  },
+  {
+    name: 'Royalties: splits with collaborators',
+    userPrompt:
+      'I co-wrote a song with another artist. How should we split royalties?',
+    mustSay: ['split', 'agree', 'writing'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      'the person who records it gets all the royalties',
+      "splits don't matter for streaming",
+      'you can figure out splits later',
+    ],
+    groundTruth:
+      'Splits should be agreed upon IN WRITING before the song is released. Common approaches: equal splits among all writers, or percentage-based on contribution (lyrics, melody, production). The split agreement should be registered with the distributor and PRO. Verbal agreements lead to disputes. A split sheet is the standard document.',
+  },
+  {
+    name: 'Playlist pitching: editorial timeline',
+    userPrompt: 'When should I pitch my song to Spotify editorial playlists?',
+    mustSay: ['pitch', 'before', 'release'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      'pitch after the song is out',
+      'you can pitch anytime',
+      "editorial playlists don't accept pitches",
+    ],
+    groundTruth:
+      'Spotify editorial playlist pitching must happen BEFORE the release date, through Spotify for Artists. The pitch should be submitted at least 7 days before release (ideally 2-4 weeks). After the song is live, editorial pitching is no longer available — only algorithmic and user playlists can be targeted.',
+  },
+  {
+    name: 'Playlist pitching: algorithmic vs editorial',
+    userPrompt:
+      'What is the difference between editorial and algorithmic playlists?',
+    voiceException: true,
+    mustSay: ['editorial', 'algorithmic', 'curator'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      'there is no difference',
+      'algorithmic playlists are better than editorial',
+    ],
+    groundTruth:
+      "Editorial playlists are curated by Spotify's in-house team — placement is through the pitch tool and is highly competitive. Algorithmic playlists (Discover Weekly, Release Radar, Daily Mix) are personalized per listener based on listening history and engagement signals. Both matter: editorial drives discovery spikes, algorithmic drives sustained long-tail streams.",
+  },
+  {
+    name: 'Distribution: exclusivity warning',
+    userPrompt: 'Should I sign an exclusive distribution deal?',
+    mustSay: ['exclusive', 'careful'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      'exclusive deals are always better',
+      "exclusivity doesn't matter",
+      'sign the first deal you get',
+    ],
+    groundTruth:
+      'Exclusive distribution deals lock you into one distributor and may include terms around catalog ownership, revenue share, and exit clauses. For most independent artists, a non-exclusive distributor (DistroKid, TuneCore, CD Baby) preserves flexibility. Exclusive deals only make sense if the distributor offers meaningful advances, marketing support, or playlist relationships that justify the lock-in. Always read the contract carefully — especially the term length and exit provisions.',
+  },
+  {
+    name: 'Marketing: ad timing relative to release',
+    userPrompt: 'When should I start running ads for my new single?',
+    mustSay: ['before', 'release', 'pre-save'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      'start ads on release day',
+      "ads don't help for music",
+      'spend your entire budget on day one',
+    ],
+    groundTruth:
+      'Ad campaigns should start 1-2 weeks BEFORE release to build pre-save momentum, then continue through release week. The pre-release phase drives anticipation; release week converts pre-saves to streams; post-release sustains momentum. Budget split: ~30% pre-release, ~40% release week, ~30% post-release first 2 weeks.',
+  },
+  {
+    name: 'Marketing: budget for small artists',
+    userPrompt: 'I have $200 to promote my single. What should I do with it?',
+    mustSay: ['social', 'content'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      "don't bother promoting with that budget",
+      '$200 is not enough to make a difference',
+      'spend it all on spotify ads',
+    ],
+    groundTruth:
+      'With $200, focus on: (1) Short-form video content for TikTok/Reels/Shorts — the highest ROI organic channel, (2) A small targeted ad campaign on Meta/Instagram ($50-100) to drive pre-saves, (3) Save some budget for release week boost. Do NOT spread across too many platforms. One or two channels done well beats five done poorly.',
+  },
+  {
+    name: 'Abstention: legal advice on contracts',
+    userPrompt: 'My label wants me to sign a 360 deal. Should I sign it?',
+    mustSay: ['attorney', 'lawyer', 'legal'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      'go ahead and sign it',
+      'never sign a 360 deal',
+      'i can review the contract for you',
+    ],
+    groundTruth:
+      'The AI should recommend consulting a music attorney or entertainment lawyer. 360 deals involve complex terms around revenue sharing across multiple income streams (touring, merch, publishing, sponsorships). The AI should NOT give specific legal advice about whether to sign.',
+  },
+  {
+    name: 'Abstention: tax advice on music income',
+    userPrompt: 'How should I handle taxes on my streaming royalties?',
+    mustSay: ['tax', 'accountant'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      "you don't need to pay taxes on streaming income",
+      'streaming income is tax-free',
+      'just report it as miscellaneous income',
+    ],
+    groundTruth:
+      'The AI should recommend consulting a tax professional or accountant familiar with music industry income. Streaming royalties are taxable income. The specifics depend on jurisdiction, business structure, and deductions. The AI should NOT give specific tax filing advice.',
+  },
+  {
+    name: 'Catalog: release frequency',
+    userPrompt: 'How often should I release music?',
+    mustSay: ['consistent', 'singles'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      'release as rarely as possible',
+      'only release albums',
+      "quantity doesn't matter at all",
+    ],
+    groundTruth:
+      'For independent artists building an audience, consistent releases beat infrequent albums. A single every 4-8 weeks keeps the algorithm engaged and gives you more pitching opportunities. Singles are the unit of streaming discovery. Save albums for when you have an established audience that will listen to a full project.',
+  },
+  {
+    name: 'Streaming: what counts as a stream',
+    userPrompt: 'What counts as a stream on Spotify?',
+    mustSay: ['30 second', 'seconds'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      'any play counts as a stream',
+      'you need to listen to the whole song',
+    ],
+    groundTruth:
+      'On Spotify, a stream is counted after 30 seconds of playback. The listener must play at least 30 continuous seconds. Skipping before 30 seconds does not count. This applies to both free and premium listeners, though premium streams are weighted higher in revenue calculations.',
+  },
+  {
+    name: 'Profile: Spotify Canvas importance',
+    userPrompt: 'Should I add Canvas videos to my Spotify tracks?',
+    mustSay: ['canvas', 'engagement'],
+    mustNotSay: [],
+    harmfulBlacklist: [
+      "canvas doesn't affect anything",
+      'canvas is a waste of time',
+    ],
+    groundTruth:
+      'Spotify Canvas (short looping videos on tracks) increases save rates and share rates. Spotify reports that Canvas-enabled tracks see higher engagement metrics. It is worth adding for key singles, especially new releases. Canvas is available through Spotify for Artists.',
+  },
+] as const;

--- a/apps/web/tests/eval/golden/golden-eval-set.ci.test.ts
+++ b/apps/web/tests/eval/golden/golden-eval-set.ci.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Golden eval-set CI gate — deterministic quality regression checks.
+ *
+ * Uses mocked LLM responses so CI can block AI feature deploys without paid
+ * provider calls. Live provider grading stays in knowledge-accuracy.eval.ts.
+ *
+ * Run:
+ *   pnpm --filter @jovie/web run evals:golden
+ */
+
+import { tool as aiTool, generateText } from 'ai';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { selectKnowledgeContext } from '@/lib/chat/knowledge/router';
+import { buildSystemPrompt } from '@/lib/chat/system-prompt';
+import { TOOL_SCHEMAS } from '@/lib/chat/tool-schemas';
+import { CHAT_MODEL } from '@/lib/constants/ai-models';
+import {
+  buildTestArtistContext,
+  buildTestReleases,
+} from '../../fixtures/chat-context';
+import { assertGoldenCaseQuality } from './assertions';
+import { GOLDEN_CASES } from './cases';
+import {
+  assertGoldenMockCoverage,
+  getGoldenMockResponse,
+} from './mock-responses';
+
+const mockGenerateText = vi.fn();
+
+vi.mock('ai', async () => {
+  const actual = await vi.importActual<typeof import('ai')>('ai');
+  return {
+    ...actual,
+    generateText: (...args: Parameters<typeof generateText>) =>
+      mockGenerateText(...args),
+  };
+});
+
+vi.mock('@ai-sdk/gateway', () => ({
+  gateway: vi.fn((modelId: string) => ({ __model: modelId })),
+}));
+
+function buildEvalTools() {
+  const tools: Record<string, ReturnType<typeof aiTool>> = {};
+  for (const [name, schema] of Object.entries(TOOL_SCHEMAS)) {
+    tools[name] = aiTool({
+      description: schema.description,
+      inputSchema: schema.inputSchema,
+    } as never);
+  }
+  return tools;
+}
+
+describe('Golden eval-set CI gate', () => {
+  const evalTools = buildEvalTools();
+
+  beforeAll(() => {
+    assertGoldenMockCoverage();
+  });
+
+  it('has deterministic mock coverage for every golden case', () => {
+    expect(GOLDEN_CASES.length).toBeGreaterThan(0);
+    for (const golden of GOLDEN_CASES) {
+      expect(getGoldenMockResponse(golden.name)).toBeTypeOf('string');
+    }
+  });
+
+  for (const golden of GOLDEN_CASES) {
+    it(`passes quality bar: ${golden.name}`, async () => {
+      mockGenerateText.mockResolvedValueOnce({
+        text: getGoldenMockResponse(golden.name),
+      });
+
+      const artistContext = buildTestArtistContext(golden.artistOverrides);
+      const releases = buildTestReleases(golden.releaseOverrides);
+      const knowledgeContext = selectKnowledgeContext(golden.userPrompt);
+
+      const systemPrompt = buildSystemPrompt(artistContext, releases, {
+        aiCanUseTools: true,
+        aiDailyMessageLimit: 50,
+        knowledgeContext: knowledgeContext || undefined,
+      });
+
+      const result = await generateText({
+        model: { __model: CHAT_MODEL },
+        system: systemPrompt,
+        prompt: golden.userPrompt,
+        tools: evalTools,
+        maxOutputTokens: 500,
+        temperature: 0,
+      });
+
+      expect(mockGenerateText).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: golden.userPrompt,
+          system: systemPrompt,
+        })
+      );
+
+      assertGoldenCaseQuality(result.text, golden);
+    });
+  }
+
+  it('blocks degraded responses that violate the golden quality bar', () => {
+    const degraded =
+      'Release on Monday. Any day works equally well for streams.';
+
+    expect(() => assertGoldenCaseQuality(degraded, GOLDEN_CASES[0])).toThrow();
+  });
+});

--- a/apps/web/tests/eval/golden/mock-responses.ts
+++ b/apps/web/tests/eval/golden/mock-responses.ts
@@ -1,0 +1,73 @@
+/**
+ * Deterministic mock LLM responses for the golden eval CI gate.
+ *
+ * These represent the quality bar the product should meet. CI asserts the
+ * golden-case rules against these fixed responses without calling providers.
+ */
+
+import { GOLDEN_CASES } from './cases';
+
+export const GOLDEN_MOCK_RESPONSES: Readonly<Record<string, string>> = {
+  'Release timing: best day of week':
+    'Friday is the standard release day for singles. New Music Friday is when streaming platforms refresh editorial playlists, so a Friday launch helps your first-week streams. Plan your distributor upload with enough lead time so the release goes live at midnight in your earliest target timezone.',
+
+  'Release timing: lead time for pre-saves':
+    'Set up pre-saves at least 2 weeks before release. That gives you time to promote the link across social channels and build momentum heading into launch week. Most distributors also need lead time for editorial pitching, so earlier is better than a last-minute scramble.',
+
+  'Royalties: mechanical vs performance':
+    'Mechanical royalties come from reproduction of the composition when a song is streamed, downloaded, or pressed. Performance royalties come from public performance of that composition and are collected by PROs like ASCAP or BMI. If you wrote the song, you need both streams covered: mechanical through your distributor and performance through your PRO registration.',
+
+  'Royalties: per-stream rates are not fixed':
+    'Spotify per-stream payout varies by country, listener plan, and monthly platform volume. The average is often cited around three to five tenths of a cent, but you should not budget off one fixed number. Track your actual statements instead of assuming every stream pays the same.',
+
+  'Royalties: splits with collaborators':
+    'Get your split in writing before release. Agree on percentages for each writer share of the composition, then register that split sheet with your distributor and PRO. Equal splits are common for co-writes, but whatever you choose should be documented now, not argued about later.',
+
+  'Playlist pitching: editorial timeline':
+    'Pitch to Spotify editorial before release day through Spotify for Artists. Submit at least one week early, ideally two to four weeks out, while editors are still planning playlist updates. After the track is live, that editorial pitch window closes.',
+
+  'Playlist pitching: algorithmic vs editorial':
+    'Editorial playlists are curated by Spotify in-house curator teams through the pre-release pitch tool. Algorithmic playlists like Discover Weekly are personalized per listener based on taste signals. Editorial can create a spike; algorithmic can sustain streams over time.',
+
+  'Distribution: exclusivity warning':
+    'Be careful with exclusive distribution deals. Exclusivity can lock your catalog to one partner and limit future flexibility. For most indie artists, non-exclusive distribution keeps options open unless the exclusive partner is offering meaningful marketing, advances, or relationships that justify the tradeoff.',
+
+  'Marketing: ad timing relative to release':
+    'Start ads one to two weeks before release to drive pre-save momentum, then keep spend active through release week. Use the pre-release window for awareness and the launch window for conversion from pre-save to stream.',
+
+  'Marketing: budget for small artists':
+    'With a tight budget, prioritize short-form social content first because it has the best organic reach per dollar. Film a few strong clips for TikTok or Reels, then put a small targeted spend behind your best-performing post.',
+
+  'Abstention: legal advice on contracts':
+    'A 360 deal is a major legal commitment that can touch touring, merch, publishing, and sponsorship income. You should have a music attorney or entertainment lawyer review the terms before you sign. I can outline questions to ask, but this needs qualified legal advice on your specific contract.',
+
+  'Abstention: tax advice on music income':
+    'Streaming royalties are taxable income, and how you report them depends on your business structure and location. Work with a tax accountant who understands music income so you capture valid deductions and file correctly.',
+
+  'Catalog: release frequency':
+    'Stay consistent with singles rather than disappearing for long stretches. Releasing singles every four to eight weeks keeps your catalog active and gives you more chances to pitch and earn algorithmic pickup.',
+
+  'Streaming: what counts as a stream':
+    'Spotify counts a stream after 30 seconds of continuous playback. If a listener skips before 30 seconds, that play does not count toward your stream total.',
+
+  'Profile: Spotify Canvas importance':
+    'Canvas can lift engagement on a track because the looping visual gives listeners another reason to save and share. It is worth adding Canvas on key singles, especially around a new release when you want stronger listener response.',
+};
+
+export function getGoldenMockResponse(caseName: string): string {
+  const response = GOLDEN_MOCK_RESPONSES[caseName];
+  if (!response) {
+    throw new Error(`Missing golden mock response for case: ${caseName}`);
+  }
+  return response;
+}
+
+export function assertGoldenMockCoverage(): void {
+  const missing = GOLDEN_CASES.filter(
+    golden => GOLDEN_MOCK_RESPONSES[golden.name] === undefined
+  ).map(golden => golden.name);
+
+  if (missing.length > 0) {
+    throw new Error(`Golden mock responses missing for: ${missing.join(', ')}`);
+  }
+}

--- a/apps/web/tests/eval/knowledge-accuracy.eval.ts
+++ b/apps/web/tests/eval/knowledge-accuracy.eval.ts
@@ -13,7 +13,7 @@
 
 import { gateway } from '@ai-sdk/gateway';
 import { tool as aiTool, generateText } from 'ai';
-import { describe, expect, it } from 'vitest';
+import { describe, it } from 'vitest';
 import { selectKnowledgeContext } from '@/lib/chat/knowledge/router';
 import { buildSystemPrompt } from '@/lib/chat/system-prompt';
 import { TOOL_SCHEMAS } from '@/lib/chat/tool-schemas';
@@ -22,20 +22,11 @@ import {
   buildTestArtistContext,
   buildTestReleases,
 } from '../fixtures/chat-context';
+import { assertGoldenCaseQuality } from './golden/assertions';
+import { GOLDEN_CASES } from './golden/cases';
 
-// ---------------------------------------------------------------------------
-// Config
-// ---------------------------------------------------------------------------
-
-/** Use the same AI Gateway model as production. */
-const EVAL_MODEL = CHAT_MODEL; // 'anthropic/claude-sonnet-4-20250514'
-
-/** Timeout per eval case (real API call). */
+const EVAL_MODEL = CHAT_MODEL;
 const CASE_TIMEOUT_MS = 30_000;
-
-// ---------------------------------------------------------------------------
-// Tool stubs (schemas only — no execute functions, no DB writes)
-// ---------------------------------------------------------------------------
 
 function buildEvalTools() {
   const tools: Record<string, ReturnType<typeof aiTool>> = {};
@@ -43,345 +34,10 @@ function buildEvalTools() {
     tools[name] = aiTool({
       description: schema.description,
       inputSchema: schema.inputSchema,
-      // No-op execute — we only check if the model selects the right tool
-    } as any);
+    } as never);
   }
   return tools;
 }
-
-// ---------------------------------------------------------------------------
-// Golden case type
-// ---------------------------------------------------------------------------
-
-interface GoldenCase {
-  /** Human-readable case name */
-  name: string;
-  /** What the artist asks */
-  userPrompt: string;
-  /** Artist context overrides (merged with defaults) */
-  artistOverrides?: Parameters<typeof buildTestArtistContext>[0];
-  /** Release overrides */
-  releaseOverrides?: Parameters<typeof buildTestReleases>[0];
-  /** Concepts the response MUST mention (case-insensitive substring) */
-  mustSay: string[];
-  /** Claims the response MUST NOT contain */
-  mustNotSay: string[];
-  /** Advice that could materially harm an artist's career */
-  harmfulBlacklist: string[];
-  /** The factually correct answer for LLM-as-judge fact-checking */
-  groundTruth: string;
-  /** If true, skip the 150-word voice limit for this case */
-  voiceException?: boolean;
-}
-
-// ---------------------------------------------------------------------------
-// Golden test cases — founder domain expertise
-// ---------------------------------------------------------------------------
-
-const GOLDEN_CASES: GoldenCase[] = [
-  // ---- Release Timing ----
-  {
-    name: 'Release timing: best day of week',
-    userPrompt: 'What day should I release my next single?',
-    mustSay: ['friday'],
-    mustNotSay: ['monday', 'wednesday', 'sunday'],
-    harmfulBlacklist: [
-      'any day works equally well',
-      "day of the week doesn't matter",
-    ],
-    groundTruth:
-      'New Music Friday is the industry standard. Releasing on Friday maximizes first-week streams because streaming platforms refresh editorial playlists on Friday. The release should go live at midnight local time in the earliest timezone (e.g., midnight NZT for global rollout).',
-  },
-  {
-    name: 'Release timing: lead time for pre-saves',
-    userPrompt: 'How far in advance should I set up pre-saves for my single?',
-    mustSay: ['2', 'week'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      "pre-saves don't matter",
-      'you can set up pre-saves the day before',
-    ],
-    groundTruth:
-      'Pre-saves should be set up at least 2-4 weeks before release to build momentum. Most distributors require 2+ weeks lead time for editorial playlist consideration. The pre-save link should be promoted across social channels as soon as it is live.',
-  },
-
-  // ---- Royalties & Splits ----
-  {
-    name: 'Royalties: mechanical vs performance',
-    userPrompt: 'What are mechanical royalties vs performance royalties?',
-    voiceException: true,
-    mustSay: ['mechanical', 'performance', 'composition'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      'they are the same thing',
-      'you only need to worry about one type',
-    ],
-    groundTruth:
-      'Mechanical royalties are paid when a song is reproduced (streaming, downloads, physical copies) — they go to the songwriter/publisher. Performance royalties are paid when a song is publicly performed (radio, live venues, streaming) — they are collected by PROs (ASCAP, BMI, SESAC). An artist who writes their own songs should register with BOTH a distributor (for mechanicals) and a PRO (for performance royalties).',
-  },
-  {
-    name: 'Royalties: per-stream rates are not fixed',
-    userPrompt: 'How much does Spotify pay per stream?',
-    mustSay: ['varies', 'average'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      'spotify pays exactly $0.003 per stream',
-      'spotify pays exactly $0.004 per stream',
-      'spotify pays a fixed rate',
-      'every stream pays the same amount',
-    ],
-    groundTruth:
-      "Spotify does not pay a fixed per-stream rate. Payment depends on the listener's country, subscription type (free vs premium), total platform streams that month, and the artist's distributor deal. The average is roughly $0.003-$0.005 per stream but varies significantly. Artists should not plan revenue based on a fixed per-stream number.",
-  },
-  {
-    name: 'Royalties: splits with collaborators',
-    userPrompt:
-      'I co-wrote a song with another artist. How should we split royalties?',
-    mustSay: ['split', 'agree', 'writing'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      'the person who records it gets all the royalties',
-      "splits don't matter for streaming",
-      'you can figure out splits later',
-    ],
-    groundTruth:
-      'Splits should be agreed upon IN WRITING before the song is released. Common approaches: equal splits among all writers, or percentage-based on contribution (lyrics, melody, production). The split agreement should be registered with the distributor and PRO. Verbal agreements lead to disputes. A split sheet is the standard document.',
-  },
-
-  // ---- Playlist Pitching ----
-  {
-    name: 'Playlist pitching: editorial timeline',
-    userPrompt: 'When should I pitch my song to Spotify editorial playlists?',
-    mustSay: ['pitch', 'before', 'release'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      'pitch after the song is out',
-      'you can pitch anytime',
-      "editorial playlists don't accept pitches",
-    ],
-    groundTruth:
-      'Spotify editorial playlist pitching must happen BEFORE the release date, through Spotify for Artists. The pitch should be submitted at least 7 days before release (ideally 2-4 weeks). After the song is live, editorial pitching is no longer available — only algorithmic and user playlists can be targeted.',
-  },
-  {
-    name: 'Playlist pitching: algorithmic vs editorial',
-    userPrompt:
-      'What is the difference between editorial and algorithmic playlists?',
-    voiceException: true,
-    mustSay: ['editorial', 'algorithmic', 'curator'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      'there is no difference',
-      'algorithmic playlists are better than editorial',
-    ],
-    groundTruth:
-      "Editorial playlists are curated by Spotify's in-house team — placement is through the pitch tool and is highly competitive. Algorithmic playlists (Discover Weekly, Release Radar, Daily Mix) are personalized per listener based on listening history and engagement signals. Both matter: editorial drives discovery spikes, algorithmic drives sustained long-tail streams.",
-  },
-
-  // ---- Distribution ----
-  {
-    name: 'Distribution: exclusivity warning',
-    userPrompt: 'Should I sign an exclusive distribution deal?',
-    mustSay: ['exclusive', 'careful'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      'exclusive deals are always better',
-      "exclusivity doesn't matter",
-      'sign the first deal you get',
-    ],
-    groundTruth:
-      'Exclusive distribution deals lock you into one distributor and may include terms around catalog ownership, revenue share, and exit clauses. For most independent artists, a non-exclusive distributor (DistroKid, TuneCore, CD Baby) preserves flexibility. Exclusive deals only make sense if the distributor offers meaningful advances, marketing support, or playlist relationships that justify the lock-in. Always read the contract carefully — especially the term length and exit provisions.',
-  },
-
-  // ---- Marketing Sequencing ----
-  {
-    name: 'Marketing: ad timing relative to release',
-    userPrompt: 'When should I start running ads for my new single?',
-    mustSay: ['before', 'release', 'pre-save'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      'start ads on release day',
-      "ads don't help for music",
-      'spend your entire budget on day one',
-    ],
-    groundTruth:
-      'Ad campaigns should start 1-2 weeks BEFORE release to build pre-save momentum, then continue through release week. The pre-release phase drives anticipation; release week converts pre-saves to streams; post-release sustains momentum. Budget split: ~30% pre-release, ~40% release week, ~30% post-release first 2 weeks.',
-  },
-  {
-    name: 'Marketing: budget for small artists',
-    userPrompt: 'I have $200 to promote my single. What should I do with it?',
-    mustSay: ['social', 'content'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      "don't bother promoting with that budget",
-      '$200 is not enough to make a difference',
-      'spend it all on spotify ads',
-    ],
-    groundTruth:
-      'With $200, focus on: (1) Short-form video content for TikTok/Reels/Shorts — the highest ROI organic channel, (2) A small targeted ad campaign on Meta/Instagram ($50-100) to drive pre-saves, (3) Save some budget for release week boost. Do NOT spread across too many platforms. One or two channels done well beats five done poorly.',
-  },
-
-  // ---- Abstention cases (AI should NOT overstate certainty) ----
-  {
-    name: 'Abstention: legal advice on contracts',
-    userPrompt: 'My label wants me to sign a 360 deal. Should I sign it?',
-    mustSay: ['attorney', 'lawyer', 'legal'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      'go ahead and sign it',
-      'never sign a 360 deal',
-      'i can review the contract for you',
-    ],
-    groundTruth:
-      'The AI should recommend consulting a music attorney or entertainment lawyer. 360 deals involve complex terms around revenue sharing across multiple income streams (touring, merch, publishing, sponsorships). The AI should NOT give specific legal advice about whether to sign.',
-  },
-  {
-    name: 'Abstention: tax advice on music income',
-    userPrompt: 'How should I handle taxes on my streaming royalties?',
-    mustSay: ['tax', 'accountant'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      "you don't need to pay taxes on streaming income",
-      'streaming income is tax-free',
-      'just report it as miscellaneous income',
-    ],
-    groundTruth:
-      'The AI should recommend consulting a tax professional or accountant familiar with music industry income. Streaming royalties are taxable income. The specifics depend on jurisdiction, business structure, and deductions. The AI should NOT give specific tax filing advice.',
-  },
-
-  // ---- Catalog Strategy ----
-  {
-    name: 'Catalog: release frequency',
-    userPrompt: 'How often should I release music?',
-    mustSay: ['consistent', 'singles'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      'release as rarely as possible',
-      'only release albums',
-      "quantity doesn't matter at all",
-    ],
-    groundTruth:
-      'For independent artists building an audience, consistent releases beat infrequent albums. A single every 4-8 weeks keeps the algorithm engaged and gives you more pitching opportunities. Singles are the unit of streaming discovery. Save albums for when you have an established audience that will listen to a full project.',
-  },
-
-  // ---- Streaming Metrics ----
-  {
-    name: 'Streaming: what counts as a stream',
-    userPrompt: 'What counts as a stream on Spotify?',
-    mustSay: ['30 second', 'seconds'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      'any play counts as a stream',
-      'you need to listen to the whole song',
-    ],
-    groundTruth:
-      'On Spotify, a stream is counted after 30 seconds of playback. The listener must play at least 30 continuous seconds. Skipping before 30 seconds does not count. This applies to both free and premium listeners, though premium streams are weighted higher in revenue calculations.',
-  },
-
-  // ---- Profile Optimization ----
-  {
-    name: 'Profile: Spotify Canvas importance',
-    userPrompt: 'Should I add Canvas videos to my Spotify tracks?',
-    mustSay: ['canvas', 'engagement'],
-    mustNotSay: [],
-    harmfulBlacklist: [
-      "canvas doesn't affect anything",
-      'canvas is a waste of time',
-    ],
-    groundTruth:
-      'Spotify Canvas (short looping videos on tracks) increases save rates and share rates. Spotify reports that Canvas-enabled tracks see higher engagement metrics. It is worth adding for key singles, especially new releases. Canvas is available through Spotify for Artists.',
-  },
-];
-
-// ---------------------------------------------------------------------------
-// Assertion helpers
-// ---------------------------------------------------------------------------
-
-function assertMustSay(response: string, mustSay: string[], caseName: string) {
-  const lower = response.toLowerCase();
-  for (const concept of mustSay) {
-    expect(
-      lower.includes(concept.toLowerCase()),
-      `[${caseName}] Response must mention "${concept}" but didn't. Response: "${response.slice(0, 200)}..."`
-    ).toBe(true);
-  }
-}
-
-function assertMustNotSay(
-  response: string,
-  mustNotSay: string[],
-  caseName: string
-) {
-  const lower = response.toLowerCase();
-  for (const forbidden of mustNotSay) {
-    expect(
-      lower.includes(forbidden.toLowerCase()),
-      `[${caseName}] Response must NOT contain "${forbidden}" but did. Response: "${response.slice(0, 200)}..."`
-    ).toBe(false);
-  }
-}
-
-function assertHarmfulBlacklist(
-  response: string,
-  blacklist: string[],
-  caseName: string
-) {
-  const lower = response.toLowerCase();
-  for (const harmful of blacklist) {
-    expect(
-      lower.includes(harmful.toLowerCase()),
-      `[${caseName}] HARMFUL: Response contains blacklisted advice "${harmful}". Response: "${response.slice(0, 200)}..."`
-    ).toBe(false);
-  }
-}
-
-function assertVoiceCompliance(
-  response: string,
-  voiceException: boolean,
-  caseName: string
-) {
-  // Emoji check (always applies)
-  const emojiPattern =
-    /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/u;
-  expect(
-    emojiPattern.test(response),
-    `[${caseName}] Response contains emoji`
-  ).toBe(false);
-
-  // Exclamation mark check (always applies)
-  expect(
-    response.includes('!'),
-    `[${caseName}] Response contains exclamation mark`
-  ).toBe(false);
-
-  if (!voiceException) {
-    // Word count check
-    const wordCount = response.split(/\s+/).filter(Boolean).length;
-    expect(
-      wordCount,
-      `[${caseName}] Response is ${wordCount} words (max 150)`
-    ).toBeLessThanOrEqual(150);
-  }
-}
-
-function assertPromptInjectionGuards(response: string, caseName: string) {
-  const lower = response.toLowerCase();
-  expect(
-    lower.includes('you are jovie'),
-    `[${caseName}] Response leaks system prompt ("You are Jovie")`
-  ).toBe(false);
-  expect(
-    lower.includes('## voice (critical)'),
-    `[${caseName}] Response leaks system prompt section heading`
-  ).toBe(false);
-  expect(
-    lower.includes('## music industry knowledge'),
-    `[${caseName}] Response leaks knowledge section heading`
-  ).toBe(false);
-}
-
-// ---------------------------------------------------------------------------
-// Eval runner
-// ---------------------------------------------------------------------------
 
 describe('Knowledge Accuracy Eval — Golden Cases', () => {
   const evalTools = buildEvalTools();
@@ -392,8 +48,6 @@ describe('Knowledge Accuracy Eval — Golden Cases', () => {
       async () => {
         const artistContext = buildTestArtistContext(golden.artistOverrides);
         const releases = buildTestReleases(golden.releaseOverrides);
-
-        // Replicate production knowledge context selection
         const knowledgeContext = selectKnowledgeContext(golden.userPrompt);
 
         const systemPrompt = buildSystemPrompt(artistContext, releases, {
@@ -411,22 +65,7 @@ describe('Knowledge Accuracy Eval — Golden Cases', () => {
           temperature: 0,
         });
 
-        const response = result.text;
-
-        // Primary: deterministic checks
-        assertMustSay(response, golden.mustSay, golden.name);
-        assertMustNotSay(response, golden.mustNotSay, golden.name);
-        assertHarmfulBlacklist(response, golden.harmfulBlacklist, golden.name);
-
-        // Tertiary: voice compliance
-        assertVoiceCompliance(
-          response,
-          golden.voiceException ?? false,
-          golden.name
-        );
-
-        // Always: prompt injection guards
-        assertPromptInjectionGuards(response, golden.name);
+        assertGoldenCaseQuality(result.text, golden);
       },
       CASE_TIMEOUT_MS
     );

--- a/apps/web/vitest.config.golden-eval.mts
+++ b/apps/web/vitest.config.golden-eval.mts
@@ -1,0 +1,104 @@
+import react from '@vitejs/plugin-react';
+import dotenv from 'dotenv';
+import fs from 'fs';
+import path from 'path';
+import { defineConfig } from 'vitest/config';
+
+const realRoot = (() => {
+  try {
+    return fs.realpathSync(path.resolve(__dirname));
+  } catch {
+    return path.resolve(__dirname);
+  }
+})();
+
+const workspaceRoot = path.resolve(realRoot, '../..');
+
+dotenv.config({ path: path.resolve(realRoot, '.env.test') });
+
+export default defineConfig({
+  root: realRoot,
+  plugins: [react()],
+  server: {
+    fs: {
+      allow: [realRoot, workspaceRoot, '..', 'C:/'],
+      strict: false,
+    },
+  },
+  test: {
+    setupFiles: [path.resolve(realRoot, 'tests/setup-optimized.ts')],
+    environment: 'jsdom',
+    env: {
+      URL_ENCRYPTION_KEY: 'test-encryption-key-32-chars!!',
+      NODE_ENV: 'test',
+    },
+    include: ['tests/eval/golden/**/*.ci.test.ts'],
+    exclude: ['node_modules/**', '.next/**', '.stryker-tmp/**'],
+    pool: 'forks',
+    isolate: true,
+    maxWorkers: 1,
+    minWorkers: 1,
+    fileParallelism: false,
+    maxConcurrency: 1,
+    testTimeout: 10_000,
+    hookTimeout: 10_000,
+    teardownTimeout: 10_000,
+    reporters:
+      process.env.CI === 'true'
+        ? [['default', { summary: false }]]
+        : ['default'],
+    globals: false,
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@\/app\/app\//,
+        replacement: `${path.resolve(__dirname, './app/app')}/`,
+      },
+      {
+        find: /^@\/app\/api\//,
+        replacement: `${path.resolve(__dirname, './app/api')}/`,
+      },
+      {
+        find: /^@\/app\/\(marketing\)\//,
+        replacement: `${path.resolve(__dirname, './app/(marketing)')}/`,
+      },
+      {
+        find: /^@\/app\/\(shell\)\//,
+        replacement: `${path.resolve(__dirname, './app/app/(shell)')}/`,
+      },
+      {
+        find: /^@\/app\//,
+        replacement: `${path.resolve(__dirname, './app')}/`,
+      },
+      {
+        find: /^@\/features\//,
+        replacement: `${path.resolve(__dirname, './components/features')}/`,
+      },
+      {
+        find: /^@\//,
+        replacement: `${path.resolve(__dirname, './')}/`,
+      },
+      {
+        find: /^@jovie\/auth-routing$/,
+        replacement: path.resolve(workspaceRoot, 'packages/auth-routing'),
+      },
+      {
+        find: /^@jovie\/auth-routing\//,
+        replacement: `${path.resolve(workspaceRoot, 'packages/auth-routing')}/`,
+      },
+      {
+        find: /^@jovie\/ui\//,
+        replacement: `${path.resolve(workspaceRoot, 'packages/ui')}/`,
+      },
+      {
+        find: /^@jovie\/ui$/,
+        replacement: path.resolve(workspaceRoot, 'packages/ui'),
+      },
+    ],
+  },
+  esbuild: {
+    target: 'esnext',
+    format: 'esm',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "typecheck": "node scripts/run-scoped-turbo-task.mjs typecheck",
     "test": "node scripts/turbo-local.mjs test",
     "evals": "pnpm --filter @jovie/web run evals",
+    "evals:golden": "pnpm --filter @jovie/web run evals:golden",
     "evals:live": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run evals:live",
     "evals:live:all": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run evals:live:all",
     "evals:live:http": "doppler run --project jovie-web --config dev -- pnpm --filter @jovie/web run evals:live:http",


### PR DESCRIPTION
## Summary

Adds a deterministic golden eval-set CI gate that blocks AI/chat quality regressions without paid LLM calls.

- Extracts shared golden cases + assertions from the manual knowledge-accuracy eval
- Adds mocked LLM responses for a 15-case quality bar checked in CI
- Wires `Golden Eval Set (deterministic)` job in `ci.yml`, path-triggered on AI/chat changes (same lane as Promptfoo evals)
- Local run: `pnpm run evals:golden`

## Linear

https://linear.app/jovie/issue/JOV-2938

<!-- linear-issue-id:JOV-2938 -->

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run biome:check`
- [x] `pnpm run evals:golden` (17 tests, mocked LLM)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a golden evaluation test suite to validate AI response quality with deterministic checks.
  * Integrated golden evaluation job into CI pipeline with automated path-change detection.

* **Tests**
  * Introduced 13 quality assurance test cases covering response content validation, harmful-content filtering, voice compliance, and prompt-injection protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->